### PR TITLE
feat(wallet-lib): do not sync transactions if mnemonic is absent

### DIFF
--- a/packages/wallet-lib/src/plugins/Workers/TransactionSyncStreamWorker/TransactionSyncStreamWorker.js
+++ b/packages/wallet-lib/src/plugins/Workers/TransactionSyncStreamWorker/TransactionSyncStreamWorker.js
@@ -9,6 +9,8 @@ const sleep = require('../../../utils/sleep');
 const Worker = require('../../Worker');
 const isBrowser = require('../../../utils/isBrowser');
 
+const logger = require('../../../logger');
+
 class TransactionSyncStreamWorker extends Worker {
   constructor(options) {
     super({
@@ -132,7 +134,15 @@ class TransactionSyncStreamWorker extends Worker {
     // instead of usual injection process
     const {
       skipSynchronizationBeforeHeight,
+      skipSynchronization,
     } = (this.storage.store.syncOptions || {});
+
+    if (skipSynchronization) {
+      logger.debug('TransactionSyncStreamWorker - Wallet created from a new mnemonic. Sync from the best block height.');
+      const bestBlockHeight = this.storage.store.chains[this.network.toString()].blockHeight;
+      this.setLastSyncedBlockHeight(bestBlockHeight);
+      return;
+    }
 
     if (skipSynchronizationBeforeHeight) {
       this.setLastSyncedBlockHeight(


### PR DESCRIPTION
## Issue being fixed or feature implemented

This change eliminates unnecessary synchronization of transactions in case wallet has been generated from the new mnemonic


## What was done?
Check if the wallet has been generated from the new mnemonic and sync transactions from the best block (instead of block 1 or the one provided via `unsafeOptions: { skipSynchronizationBeforeHeight: <n> }`)


## How Has This Been Tested?
- Passed no mnemonic to the Wallet initialization arguments
- Ensured quick initialization time
- Hooked on account events and ensured that synchronization of the new blocks works properly


## Breaking Changes


## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
