### PR TITLE
feat(wallet-lib): dump wallet storage

### DIFF
--- a/packages/wallet-lib/docs/_sidebar.md
+++ b/packages/wallet-lib/docs/_sidebar.md
@@ -42,6 +42,7 @@
         - [`.fromSeed()`](wallet/fromSeed.md)
         - [`.generateNewWalletId()`](wallet/generateNewWalletId.md)
         - [`.getAccount()`](wallet/getAccount.md)
+        - [`.dumpStorage()`](wallet/dumpStorage.md)
     - Identities
         - [`new Identities()`](identities/Identities.md)
         - [`.getIdentityHDKeyByIndex()`](identities/getIdentityHDKeyByIndex.md)

--- a/packages/wallet-lib/docs/wallet/dumpStorage.md
+++ b/packages/wallet-lib/docs/wallet/dumpStorage.md
@@ -1,0 +1,15 @@
+**Usage**: `wallet.dumpStorage([opts])`    
+**Description**: Method dumps the state of the storage in JSON format
+
+**Warning**: Storage dump may contain sensitive data.
+Please, do not share the output of this function for `mainnet` wallets.
+
+Parameters:
+
+| parameters             | type      | required       | Description                                                                       |  
+|------------------------|-----------|----------------| ----------------------------------------------------------  |
+| **opts.log**         | Boolean    | no             | Indicates whether storage should be logged in the console             |
+
+Returns : {String}
+
+

--- a/packages/wallet-lib/src/types/Wallet/Wallet.d.ts
+++ b/packages/wallet-lib/src/types/Wallet/Wallet.d.ts
@@ -30,6 +30,15 @@ export declare class Wallet {
     generateNewWalletId():string;
     getAccount(accOptions?: Account.Options): Promise<Account>;
     sweepWallet(): Promise<Account>
+
+    /**
+     * <b>Warning:</b> Storage dump may contain sensitive data.
+     * Please, do not share the output of this function for mainnet wallets.
+     * @param options
+     */
+    dumpStorage(options?: {
+        log: boolean
+    }): string;
 }
 
 declare interface DAPIClientOptions {

--- a/packages/wallet-lib/src/types/Wallet/Wallet.js
+++ b/packages/wallet-lib/src/types/Wallet/Wallet.js
@@ -188,5 +188,6 @@ Wallet.prototype.getAccount = require('./methods/getAccount');
 Wallet.prototype.generateNewWalletId = generateNewWalletId;
 Wallet.prototype.exportWallet = require('./methods/exportWallet');
 Wallet.prototype.sweepWallet = require('./methods/sweepWallet');
+Wallet.prototype.dumpStorage = require('./methods/dumpStorage');
 
 module.exports = Wallet;

--- a/packages/wallet-lib/src/types/Wallet/methods/dumpStorage.js
+++ b/packages/wallet-lib/src/types/Wallet/methods/dumpStorage.js
@@ -1,0 +1,29 @@
+const logger = require('../../../logger');
+
+const defaultOptions = {
+  log: false,
+};
+
+/**
+ * Dumps storage on user's demand
+ *
+ * @param options - dumping options
+ * @return {string} - Returns JSON string of the wallet store
+ */
+function dumpStorage(options) {
+  const dumpOptions = options !== null && typeof options === 'object'
+    ? Object.assign(defaultOptions, options)
+    : defaultOptions;
+  const storageDump = JSON.stringify(this.storage.store);
+
+  if (dumpOptions.log) {
+    // Add a linebreak to the log message for the ease of copying of the
+    // truncated log from the browser consoles
+    // (the text from the buffer then can be directly pasted to the JSON parser)
+    logger.info('Dumping wallet storage\n', storageDump);
+  }
+
+  return storageDump;
+}
+
+module.exports = dumpStorage;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
The change allows wallet users to dump storage on demand for debugging purposes


## What was done?
<!--- Describe your changes in detail -->
Created a new function `dumpStorage` which returns storage JSON string and logs it to the console if not specified otherwise


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested function during different phases of the wallet lifecycle (initialized/disconnected/crashed)

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
