### PR TITLE
fix(dashmate): reset command doesn't work if setup failed

### DIFF
--- a/packages/dashmate/src/commands/group/reset.js
+++ b/packages/dashmate/src/commands/group/reset.js
@@ -18,6 +18,7 @@ class GroupResetCommand extends GroupBaseCommand {
    * @param {configureTenderdashTask} configureTenderdashTask
    * @param {initializePlatformTask} initializePlatformTask
    * @param {generateToAddressTask} generateToAddressTask
+   * @param {ConfigFile} configFile
    * @return {Promise<void>}
    */
   async runWithDependencies(
@@ -34,6 +35,7 @@ class GroupResetCommand extends GroupBaseCommand {
     configureTenderdashTask,
     initializePlatformTask,
     generateToAddressTask,
+    configFile,
   ) {
     const groupName = configGroup[0].get('group');
 
@@ -72,6 +74,13 @@ class GroupResetCommand extends GroupBaseCommand {
           }))),
         },
         {
+          enabled: (ctx) => ctx.isHardReset,
+          title: 'Delete node configs',
+          task: () => (
+            configGroup.forEach((config) => configFile.removeConfig(config.getName()))
+          ),
+        },
+        {
           enabled: (ctx) => !ctx.isHardReset,
           title: 'Configure Tenderdash nodes',
           task: () => configureTenderdashTask(configGroup),
@@ -84,7 +93,7 @@ class GroupResetCommand extends GroupBaseCommand {
         {
           // in case we don't need to register masternodes
           title: `Generate ${amount} dash to local wallet`,
-          enabled: () => !isHardReset,
+          enabled: (ctx) => !ctx.isHardReset,
           skip: (ctx) => !!ctx.fundingPrivateKeyString,
           task: () => generateToAddressTask(configGroup[0], amount),
         },

--- a/packages/dashmate/src/listr/tasks/setup/setupLocalPresetTaskFactory.js
+++ b/packages/dashmate/src/listr/tasks/setup/setupLocalPresetTaskFactory.js
@@ -13,6 +13,7 @@ const {
  * @param {configureTenderdashTask} configureTenderdashTask
  * @param {initializePlatformTask} initializePlatformTask
  * @param {resolveDockerHostIp} resolveDockerHostIp
+ * @param {configFileRepository} configFileRepository
  */
 function setupLocalPresetTaskFactory(
   configFile,
@@ -20,6 +21,7 @@ function setupLocalPresetTaskFactory(
   configureTenderdashTask,
   initializePlatformTask,
   resolveDockerHostIp,
+  configFileRepository,
 ) {
   /**
    * @typedef {setupLocalPresetTask}
@@ -153,6 +155,16 @@ function setupLocalPresetTaskFactory(
             }
           ));
 
+          subTasks.push({
+            title: 'Save configs',
+            task: async () => {
+              configFile.setDefaultGroupName(PRESET_LOCAL);
+
+              // Persist configs
+              await configFileRepository.write(configFile);
+            },
+          });
+
           return new Listr(subTasks);
         },
       },
@@ -167,15 +179,6 @@ function setupLocalPresetTaskFactory(
       {
         title: 'Initialize Platform',
         task: (ctx) => initializePlatformTask(ctx.configGroup),
-      },
-      {
-        title: 'Set default config group',
-        task: (ctx, task) => {
-          configFile.setDefaultGroupName(PRESET_LOCAL);
-
-          // eslint-disable-next-line no-param-reassign
-          task.output = `${PRESET_LOCAL} set as default group`;
-        },
       },
     ]);
   }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Reset command doesn't work properly if setup command failed

## What was done?
<!--- Describe your changes in detail -->
- Store configs  and default config on very end of setup
- Remove generated configs on hard reset

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Running manually

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
