### PR TITLE
fix(dapi): Identifier expects Buffer

### DIFF
--- a/.github/workflows/all-packages.yml
+++ b/.github/workflows/all-packages.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   local-deps:
-    name: Check local package dependencies
+    name: Check local dependency references
     runs-on: ubuntu-20.04
     steps:
       - name: Check out repo
@@ -38,7 +38,7 @@ jobs:
         run: node_modules/.bin/packster check --all --error
 
   remote-deps:
-    name: Check mismatched package dependencies
+    name: Check mismatched dependencies
     runs-on: ubuntu-20.04
     steps:
       - name: Check out repo

--- a/packages/dapi/lib/externalApis/drive/DriveClient.js
+++ b/packages/dapi/lib/externalApis/drive/DriveClient.js
@@ -75,7 +75,7 @@ class DriveClient {
   /**
    * Fetch serialized data contract
    *
-   * @param {string} contractId
+   * @param {Buffer|Identifier} contractId
    * @param {boolean} prove - include proofs into the response
    *
    * @return {Promise<Buffer>}
@@ -93,7 +93,7 @@ class DriveClient {
   /**
    * Fetch serialized documents
    *
-   * @param {string} contractId
+   * @param {Buffer} contractId
    * @param {string} type - Documents type to fetch
    *
    * @param options
@@ -121,7 +121,7 @@ class DriveClient {
   /**
    * Fetch serialized identity
    *
-   * @param {string} id
+   * @param {Buffer} id
    * @param {boolean} prove - include proofs into the response
    *
    * @return {Promise<Buffer>}

--- a/packages/dapi/lib/externalApis/drive/fetchProofForStateTransitionFactory.js
+++ b/packages/dapi/lib/externalApis/drive/fetchProofForStateTransitionFactory.js
@@ -15,15 +15,21 @@ function fetchProofForStateTransitionFactory(driveClient) {
     let metadata;
     if (stateTransition.isDocumentStateTransition()) {
       ({ documentsProof: proof, metadata } = await driveClient.fetchProofs(
-        { documentIds: modifiedIds.map(Buffer.from) },
+        {
+          documentIds: modifiedIds.map((identifier) => identifier.toBuffer()),
+        },
       ));
     } else if (stateTransition.isIdentityStateTransition()) {
       ({ identitiesProof: proof, metadata } = await driveClient.fetchProofs(
-        { identityIds: modifiedIds.map(Buffer.from) },
+        {
+          identityIds: modifiedIds((identifier) => identifier.toBuffer()),
+        },
       ));
     } else if (stateTransition.isDataContractStateTransition()) {
       ({ dataContractsProof: proof, metadata } = await driveClient.fetchProofs(
-        { dataContractIds: modifiedIds.map(Buffer.from) },
+        {
+          dataContractIds: modifiedIds.map((identifier) => identifier.toBuffer()),
+        },
       ));
     }
 

--- a/packages/dapi/lib/externalApis/drive/fetchProofForStateTransitionFactory.js
+++ b/packages/dapi/lib/externalApis/drive/fetchProofForStateTransitionFactory.js
@@ -22,7 +22,7 @@ function fetchProofForStateTransitionFactory(driveClient) {
     } else if (stateTransition.isIdentityStateTransition()) {
       ({ identitiesProof: proof, metadata } = await driveClient.fetchProofs(
         {
-          identityIds: modifiedIds((identifier) => identifier.toBuffer()),
+          identityIds: modifiedIds.map((identifier) => identifier.toBuffer()),
         },
       ));
     } else if (stateTransition.isDataContractStateTransition()) {

--- a/packages/dapi/lib/externalApis/drive/fetchProofForStateTransitionFactory.js
+++ b/packages/dapi/lib/externalApis/drive/fetchProofForStateTransitionFactory.js
@@ -15,15 +15,15 @@ function fetchProofForStateTransitionFactory(driveClient) {
     let metadata;
     if (stateTransition.isDocumentStateTransition()) {
       ({ documentsProof: proof, metadata } = await driveClient.fetchProofs(
-        { documentIds: modifiedIds },
+        { documentIds: modifiedIds.map(Buffer.from) },
       ));
     } else if (stateTransition.isIdentityStateTransition()) {
       ({ identitiesProof: proof, metadata } = await driveClient.fetchProofs(
-        { identityIds: modifiedIds },
+        { identityIds: modifiedIds.map(Buffer.from) },
       ));
     } else if (stateTransition.isDataContractStateTransition()) {
       ({ dataContractsProof: proof, metadata } = await driveClient.fetchProofs(
-        { dataContractIds: modifiedIds },
+        { dataContractIds: modifiedIds.map(Buffer.from) },
       ));
     }
 

--- a/packages/dapi/lib/grpcServer/handlers/platform/getDataContractHandlerFactory.js
+++ b/packages/dapi/lib/grpcServer/handlers/platform/getDataContractHandlerFactory.js
@@ -34,7 +34,7 @@ function getDataContractHandlerFactory(driveClient) {
       throw new InvalidArgumentGrpcError('id is not specified');
     }
 
-    const dataContractResponseBuffer = await driveClient.fetchDataContract(id, prove);
+    const dataContractResponseBuffer = await driveClient.fetchDataContract(Buffer.from(id), prove);
 
     return GetDataContractResponse.deserializeBinary(dataContractResponseBuffer);
   }

--- a/packages/dapi/lib/grpcServer/handlers/platform/getDocumentsHandlerFactory.js
+++ b/packages/dapi/lib/grpcServer/handlers/platform/getDocumentsHandlerFactory.js
@@ -108,7 +108,7 @@ function getDocumentsHandlerFactory(driveClient) {
     const prove = request.getProve();
 
     const documentResponseBuffer = await driveClient.fetchDocuments(
-      dataContractId, documentType, options, prove,
+      Buffer.from(dataContractId), documentType, options, prove,
     );
 
     return GetDocumentsResponse.deserializeBinary(documentResponseBuffer);

--- a/packages/dapi/lib/grpcServer/handlers/platform/getIdentitiesByPublicKeyHashesHandlerFactory.js
+++ b/packages/dapi/lib/grpcServer/handlers/platform/getIdentitiesByPublicKeyHashesHandlerFactory.js
@@ -37,7 +37,7 @@ function getIdentitiesByPublicKeyHashesHandlerFactory(
     const prove = request.getProve();
 
     const identitiesResponseBuffer = await driveClient
-      .fetchIdentitiesByPublicKeyHashes(publicKeyHashes, prove);
+      .fetchIdentitiesByPublicKeyHashes(publicKeyHashes.map(Buffer.from), prove);
 
     return GetIdentitiesByPublicKeyHashesResponse.deserializeBinary(identitiesResponseBuffer);
   }

--- a/packages/dapi/lib/grpcServer/handlers/platform/getIdentityHandlerFactory.js
+++ b/packages/dapi/lib/grpcServer/handlers/platform/getIdentityHandlerFactory.js
@@ -37,7 +37,7 @@ function getIdentityHandlerFactory(driveClient) {
     const prove = request.getProve();
 
     const identityResponseBuffer = await driveClient
-      .fetchIdentity(id, prove);
+      .fetchIdentity(Buffer.from(id), prove);
 
     return GetIdentityResponse.deserializeBinary(identityResponseBuffer);
   }

--- a/packages/dapi/lib/grpcServer/handlers/platform/getIdentityIdsByPublicKeyHashesHandlerFactory.js
+++ b/packages/dapi/lib/grpcServer/handlers/platform/getIdentityIdsByPublicKeyHashesHandlerFactory.js
@@ -38,7 +38,7 @@ function getIdentityIdsByPublicKeyHashesHandlerFactory(
 
     const identityIdsResponseBuffer = await driveClient
       .fetchIdentityIdsByPublicKeyHashes(
-        publicKeyHashes,
+        publicKeyHashes.map(Buffer.from),
         prove,
       );
 

--- a/packages/dapi/test/integration/grpcServer/handlers/platform/waitForStateTransitionResultHandlerFactory.js
+++ b/packages/dapi/test/integration/grpcServer/handlers/platform/waitForStateTransitionResultHandlerFactory.js
@@ -241,7 +241,7 @@ describe('waitForStateTransitionResultHandlerFactory', () => {
     expect(resultStoreTreeProof).to.deep.equal(storeTreeProofs);
 
     expect(driveClientMock.fetchProofs).to.be.calledOnceWithExactly({
-      identityIds: stateTransitionFixture.getModifiedDataIds(),
+      identityIds: stateTransitionFixture.getModifiedDataIds().map(Buffer.from),
     });
   });
 

--- a/packages/dapi/test/integration/grpcServer/handlers/platform/waitForStateTransitionResultHandlerFactory.js
+++ b/packages/dapi/test/integration/grpcServer/handlers/platform/waitForStateTransitionResultHandlerFactory.js
@@ -241,7 +241,7 @@ describe('waitForStateTransitionResultHandlerFactory', () => {
     expect(resultStoreTreeProof).to.deep.equal(storeTreeProofs);
 
     expect(driveClientMock.fetchProofs).to.be.calledOnceWithExactly({
-      identityIds: stateTransitionFixture.getModifiedDataIds().map(Buffer.from),
+      identityIds: stateTransitionFixture.getModifiedDataIds().map((identifier) => identifier.toBuffer()),
     });
   });
 

--- a/packages/dapi/test/integration/grpcServer/handlers/platform/waitForStateTransitionResultHandlerFactory.js
+++ b/packages/dapi/test/integration/grpcServer/handlers/platform/waitForStateTransitionResultHandlerFactory.js
@@ -241,7 +241,8 @@ describe('waitForStateTransitionResultHandlerFactory', () => {
     expect(resultStoreTreeProof).to.deep.equal(storeTreeProofs);
 
     expect(driveClientMock.fetchProofs).to.be.calledOnceWithExactly({
-      identityIds: stateTransitionFixture.getModifiedDataIds().map((identifier) => identifier.toBuffer()),
+      identityIds: stateTransitionFixture.getModifiedDataIds()
+        .map((identifier) => identifier.toBuffer()),
     });
   });
 

--- a/packages/dapi/test/unit/grpcServer/handlers/platform/getDataContractHandlerFactory.js
+++ b/packages/dapi/test/unit/grpcServer/handlers/platform/getDataContractHandlerFactory.js
@@ -90,7 +90,7 @@ describe('getDataContractHandlerFactory', () => {
     expect(rootTreeProof).to.deep.equal(proofFixture.rootTreeProof);
     expect(resultStoreTreeProofs).to.deep.equal(storeTreeProofs);
 
-    expect(driveStateRepositoryMock.fetchDataContract).to.be.calledOnceWith(id, true);
+    expect(driveStateRepositoryMock.fetchDataContract).to.be.calledOnceWith(id.toBuffer(), true);
   });
 
   it('should not include proof', async () => {
@@ -105,7 +105,7 @@ describe('getDataContractHandlerFactory', () => {
 
     expect(proof).to.be.undefined();
 
-    expect(driveStateRepositoryMock.fetchDataContract).to.be.calledOnceWith(id, false);
+    expect(driveStateRepositoryMock.fetchDataContract).to.be.calledOnceWith(id.toBuffer(), false);
   });
 
   it('should throw InvalidArgumentGrpcError error if id is not specified', async () => {

--- a/packages/dapi/test/unit/grpcServer/handlers/platform/getDocumentsHandlerFactory.js
+++ b/packages/dapi/test/unit/grpcServer/handlers/platform/getDocumentsHandlerFactory.js
@@ -111,7 +111,7 @@ describe('getDocumentsHandlerFactory', () => {
     expect(documentsBinary).to.have.lengthOf(documentsFixture.length);
 
     expect(driveStateRepositoryMock.fetchDocuments).to.be.calledOnceWith(
-      dataContractId,
+      dataContractId.toBuffer(),
       documentType,
       {
         where,
@@ -138,7 +138,7 @@ describe('getDocumentsHandlerFactory', () => {
     expect(result).to.be.an.instanceOf(GetDocumentsResponse);
 
     expect(driveStateRepositoryMock.fetchDocuments).to.be.calledOnceWith(
-      dataContractId,
+      dataContractId.toBuffer(),
       documentType,
       {
         where,

--- a/packages/dapi/test/unit/grpcServer/handlers/platform/getIdentitiesByPublicKeyHashesHandlerFactory.js
+++ b/packages/dapi/test/unit/grpcServer/handlers/platform/getIdentitiesByPublicKeyHashesHandlerFactory.js
@@ -34,7 +34,7 @@ describe('getIdentitiesByPublicKeyHashesHandlerFactory', () => {
   let storeTreeProofs;
 
   beforeEach(function beforeEach() {
-    publicKeyHash = '556c2910d46fda2b327ef9d9bda850cc84d30db0';
+    publicKeyHash = Buffer.from('556c2910d46fda2b327ef9d9bda850cc84d30db0');
 
     call = new GrpcCallMock(this.sinon, {
       getPublicKeyHashesList: this.sinon.stub().returns(

--- a/packages/dapi/test/unit/grpcServer/handlers/platform/getIdentitiesByPublicKeyHashesHandlerFactory.js
+++ b/packages/dapi/test/unit/grpcServer/handlers/platform/getIdentitiesByPublicKeyHashesHandlerFactory.js
@@ -34,7 +34,7 @@ describe('getIdentitiesByPublicKeyHashesHandlerFactory', () => {
   let storeTreeProofs;
 
   beforeEach(function beforeEach() {
-    publicKeyHash = Buffer.from('556c2910d46fda2b327ef9d9bda850cc84d30db0');
+    publicKeyHash = Buffer.from('556c2910d46fda2b327ef9d9bda850cc84d30db0', 'hex');
 
     call = new GrpcCallMock(this.sinon, {
       getPublicKeyHashesList: this.sinon.stub().returns(

--- a/packages/dapi/test/unit/grpcServer/handlers/platform/getIdentityHandlerFactory.js
+++ b/packages/dapi/test/unit/grpcServer/handlers/platform/getIdentityHandlerFactory.js
@@ -75,7 +75,7 @@ describe('getIdentityHandlerFactory', () => {
 
     expect(result).to.be.an.instanceOf(GetIdentityResponse);
     expect(result.getIdentity()).to.deep.equal(identity.toBuffer());
-    expect(driveStateRepositoryMock.fetchIdentity).to.be.calledOnceWith(id, false);
+    expect(driveStateRepositoryMock.fetchIdentity).to.be.calledOnceWith(id.toBuffer(), false);
 
     const proof = result.getProof();
     expect(proof).to.be.undefined();
@@ -97,7 +97,7 @@ describe('getIdentityHandlerFactory', () => {
     expect(rootTreeProof).to.deep.equal(proofFixture.rootTreeProof);
     expect(resultStoreTreeProof).to.deep.equal(storeTreeProofs);
 
-    expect(driveStateRepositoryMock.fetchIdentity).to.be.calledOnceWith(id, true);
+    expect(driveStateRepositoryMock.fetchIdentity).to.be.calledOnceWith(id.toBuffer(), true);
   });
 
   it('should throw an InvalidArgumentGrpcError if id is not specified', async () => {
@@ -125,7 +125,7 @@ describe('getIdentityHandlerFactory', () => {
       expect.fail('should throw an error');
     } catch (e) {
       expect(e).to.equal(error);
-      expect(driveStateRepositoryMock.fetchIdentity).to.be.calledOnceWith(id);
+      expect(driveStateRepositoryMock.fetchIdentity).to.be.calledOnceWith(id.toBuffer());
     }
   });
 });

--- a/packages/dapi/test/unit/grpcServer/handlers/platform/getIdentityIdsByPublicKeyHashesHandlerFactory.js
+++ b/packages/dapi/test/unit/grpcServer/handlers/platform/getIdentityIdsByPublicKeyHashesHandlerFactory.js
@@ -34,7 +34,7 @@ describe('getIdentityIdsByPublicKeyHashesHandlerFactory', () => {
   let storeTreeProofs;
 
   beforeEach(function beforeEach() {
-    publicKeyHash = '556c2910d46fda2b327ef9d9bda850cc84d30db0';
+    publicKeyHash = Buffer.from('556c2910d46fda2b327ef9d9bda850cc84d30db0');
 
     call = new GrpcCallMock(this.sinon, {
       getPublicKeyHashesList: this.sinon.stub().returns(

--- a/packages/dapi/test/unit/grpcServer/handlers/platform/getIdentityIdsByPublicKeyHashesHandlerFactory.js
+++ b/packages/dapi/test/unit/grpcServer/handlers/platform/getIdentityIdsByPublicKeyHashesHandlerFactory.js
@@ -34,7 +34,7 @@ describe('getIdentityIdsByPublicKeyHashesHandlerFactory', () => {
   let storeTreeProofs;
 
   beforeEach(function beforeEach() {
-    publicKeyHash = Buffer.from('556c2910d46fda2b327ef9d9bda850cc84d30db0');
+    publicKeyHash = Buffer.from('556c2910d46fda2b327ef9d9bda850cc84d30db0', 'hex');
 
     call = new GrpcCallMock(this.sinon, {
       getPublicKeyHashesList: this.sinon.stub().returns(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
CBOR v.4 used to convert Uint8Array values to Buffer on encoding. Since we migrated to CBOR v.8, which doesnt convert them anymore, we need to convert them manually.

## What was done?
<!--- Describe your changes in detail -->
Convert Uint8Array to Buffer

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
With platform test suite

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
No

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
