### PR TITLE
feat(dashmate): force option for `group:stop` command

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "configure": "npm run configure:dashmate && npm run configure:network && npm run configure:tests && npm run configure:dotenv",
     "clean:data": "npm run dashmate group:reset -- --group=local --hard",
     "clean": "npm run clean:data && npm run build",
-    "reset": "npm run clean:data && npm run setup",
+    "reset": "npm run clean:data -- --force && npm run setup",
     "dashmate": "./packages/dashmate/bin/dashmate"
   },
   "devDependencies": {

--- a/packages/dashmate/src/commands/group/reset.js
+++ b/packages/dashmate/src/commands/group/reset.js
@@ -26,6 +26,7 @@ class GroupResetCommand extends GroupBaseCommand {
     {
       verbose: isVerbose,
       hard: isHardReset,
+      force: isForceReset,
       'platform-only': isPlatformOnlyReset,
     },
     isSystemConfig,
@@ -117,6 +118,7 @@ class GroupResetCommand extends GroupBaseCommand {
     try {
       await tasks.run({
         isHardReset,
+        isForceReset,
         isPlatformOnlyReset,
         isVerbose,
       });
@@ -130,8 +132,20 @@ GroupResetCommand.description = 'Reset group nodes';
 
 GroupResetCommand.flags = {
   ...GroupBaseCommand.flags,
-  hard: flagTypes.boolean({ char: 'h', description: 'reset config as well as data', default: false }),
-  'platform-only': flagTypes.boolean({ char: 'p', description: 'reset platform data only', default: false }),
+  hard: flagTypes.boolean({
+    description: 'reset config as well as data',
+    default: false,
+  }),
+  force: flagTypes.boolean({
+    char: 'f',
+    description: 'reset config as well as data',
+    default: false,
+  }),
+  'platform-only': flagTypes.boolean({
+    char: 'p',
+    description: 'reset platform data only',
+    default: false,
+  }),
 };
 
 module.exports = GroupResetCommand;

--- a/packages/dashmate/src/listr/tasks/resetNodeTaskFactory.js
+++ b/packages/dashmate/src/listr/tasks/resetNodeTaskFactory.js
@@ -27,6 +27,7 @@ function resetNodeTaskFactory(
     return new Listr([
       {
         title: 'Check services are not running',
+        skip: (ctx) => ctx.isForceReset,
         task: async () => {
           if (await dockerCompose.isServiceRunning(config.toEnvs())) {
             throw new Error('Running services detected. Please ensure all services are stopped for this config before starting');


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
When a node is running but some of the containers are stuck or restarting, there is not way to reset.

## What was done?
<!--- Describe your changes in detail -->
- Introduce `force` option to `group:reset` command to skip the "service running" check
- Added the `force` flag to `npm run reset`

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manually

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
