### PR TITLE
fix(wallet-lib): tx chaining mempool conflict errors 

### DIFF
--- a/packages/js-dash-sdk/package.json
+++ b/packages/js-dash-sdk/package.json
@@ -13,7 +13,7 @@
     "lint": "",
     "test": "npm run test:unit && npm run test:functional && npm run test:browsers",
     "test:browsers": "karma start ./karma.conf.js --single-run",
-    "test:unit": "TS_NODE_COMPILER_OPTIONS={\"target\":\"es6\"} mocha -r ts-node/register/transpile-only \"src/**/*.spec.ts\"",
+    "test:unit": "TS_NODE_COMPILER_OPTIONS='{\"target\":\"es6\"}' mocha -r ts-node/register/transpile-only \"src/**/*.spec.ts\"",
     "test:functional": "npm run build && mocha --recursive tests/functional/**/*.js",
     "prepublishOnly": "npm run build:web",
     "prepare": "npm run build"

--- a/packages/js-dash-sdk/package.json
+++ b/packages/js-dash-sdk/package.json
@@ -13,7 +13,7 @@
     "lint": "",
     "test": "npm run test:unit && npm run test:functional && npm run test:browsers",
     "test:browsers": "karma start ./karma.conf.js --single-run",
-    "test:unit": "TS_NODE_COMPILER_OPTIONS='{\"target\":\"es6\"}' mocha -r ts-node/register/transpile-only \"src/**/*.spec.ts\"",
+    "test:unit": "TS_NODE_COMPILER_OPTIONS={\"target\":\"es6\"} mocha -r ts-node/register/transpile-only \"src/**/*.spec.ts\"",
     "test:functional": "npm run build && mocha --recursive tests/functional/**/*.js",
     "prepublishOnly": "npm run build:web",
     "prepare": "npm run build"

--- a/packages/wallet-lib/src/types/Account/Account.js
+++ b/packages/wallet-lib/src/types/Account/Account.js
@@ -169,6 +169,12 @@ class Account extends EventEmitter {
       }
     }
     this.emit(EVENTS.CREATED, { type: EVENTS.CREATED, payload: null });
+
+    /**
+     * Stores promise that waits for the IS lock of the particular transaction
+     * @type {Promise<void>}
+     */
+    this.txISLockListener = null;
   }
 
   static getInstantLockTopicName(transactionHash) {

--- a/packages/wallet-lib/src/types/Account/methods/getUnusedAddress.js
+++ b/packages/wallet-lib/src/types/Account/methods/getUnusedAddress.js
@@ -40,6 +40,11 @@ function getUnusedAddress(type = 'external', skip = 0) {
   if (unused.address === '') {
     return this.getAddress(accountIndex, type);
   }
+
+  if (!this.storage.mappedAddress[unused.address]) {
+    this.storage.mappedAddress[unused.address] = { walletId, type, path: unused.path };
+  }
+
   return unused;
 }
 

--- a/packages/wallet-lib/src/types/Account/methods/getUnusedAddress.spec.js
+++ b/packages/wallet-lib/src/types/Account/methods/getUnusedAddress.spec.js
@@ -17,6 +17,7 @@ describe('Account - getUnusedAddress', function suite() {
       storage: {
         getStore: () => mockedStore,
         importAddresses: (_) => (_),
+        mappedAddress: {}
       },
       emit: (_) => (_),
       keyChain: new KeyChain({

--- a/packages/wallet-lib/src/types/Storage/methods/importTransaction.js
+++ b/packages/wallet-lib/src/types/Storage/methods/importTransaction.js
@@ -102,6 +102,10 @@ const importTransaction = function importTransaction(transaction, transactionMet
             addressObject.utxos[utxoKey] = vout;
             addressObject.balanceSat += vout.satoshis;
             hasUpdateStorage = true;
+          } else if (addressObject.unconfirmedBalanceSat >= vout.satoshis) {
+            addressObject.unconfirmedBalanceSat -= vout.satoshis;
+            addressObject.balanceSat += vout.satoshis;
+            hasUpdateStorage = true;
           }
         }
       }

--- a/packages/wallet-lib/tests/functional/wallet.js
+++ b/packages/wallet-lib/tests/functional/wallet.js
@@ -158,5 +158,23 @@ describe('Wallet-lib - functional', function suite() {
       expect(addresses).to.be.deep.equal(expectedAddresses);
       expect(Object.keys(transactions)).to.be.deep.equal(Object.keys(expectedTransactions));
     });
+
+    it('should broadcast a chain of transactions from a single UTXO', async () => {
+      const txAmount = 5;
+      const satoshis = 1000;
+      let balance = account.getTotalBalance();
+
+      for (let i = 0; i < txAmount; i++) {
+        const tx = account
+          .createTransaction({ satoshis, recipient: "ydvgJ2eVSmdKt78ZSVBJ7zarVVtdHGj3yR" });
+
+        await account.broadcastTransaction(tx);
+        const newBalance = account.getTotalBalance();
+
+        const fee = tx.getFee();
+        expect(newBalance).to.equal(balance - satoshis - fee);
+        balance = newBalance
+      }
+    })
   });
 });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The feature allows calling `broadcastTransaction` function in sequence one after another without the risk of hitting mempool conflict error or reusing the same output in case there's only one UTXO


## What was done?
<!--- Describe your changes in detail -->
In case of multiple invocations of `broadcastTransaction` call, the library puts a subsequent call to DAPI on hold until the previous TX acquires the instant lock.


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Wrote a relevant functional test
- Tested manually with 1 or multiple UTXOs

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
