### PR TITLE
fix(dashmate): `cannot read properties` error on `group:reset`

### DIFF
--- a/packages/dashmate/configs/system/mainnet.js
+++ b/packages/dashmate/configs/system/mainnet.js
@@ -6,9 +6,7 @@ const {
 
 const baseConfig = require('./base');
 
-delete baseConfig.platform;
-
-module.exports = lodashMerge({}, baseConfig, {
+const mainnetConfig = lodashMerge({}, baseConfig, {
   description: 'node with mainnet configuration',
   core: {
     p2p: {
@@ -20,3 +18,7 @@ module.exports = lodashMerge({}, baseConfig, {
   },
   network: NETWORK_MAINNET,
 });
+
+delete mainnetConfig.platform;
+
+module.exports = mainnetConfig;

--- a/packages/dashmate/src/commands/group/reset.js
+++ b/packages/dashmate/src/commands/group/reset.js
@@ -2,8 +2,6 @@ const { Listr } = require('listr2');
 
 const { flags: flagTypes } = require('@oclif/command');
 
-const baseConfig = require('../../../configs/system/base');
-
 const GroupBaseCommand = require('../../oclif/command/GroupBaseCommand');
 const MuteOneLineError = require('../../oclif/errors/MuteOneLineError');
 
@@ -19,6 +17,7 @@ class GroupResetCommand extends GroupBaseCommand {
    * @param {initializePlatformTask} initializePlatformTask
    * @param {generateToAddressTask} generateToAddressTask
    * @param {ConfigFile} configFile
+   * @param {Object[]} systemConfigs
    * @return {Promise<void>}
    */
   async runWithDependencies(
@@ -37,12 +36,15 @@ class GroupResetCommand extends GroupBaseCommand {
     initializePlatformTask,
     generateToAddressTask,
     configFile,
+    systemConfigs,
   ) {
     const groupName = configGroup[0].get('group');
 
     if (isHardReset && !isSystemConfig(groupName)) {
       throw new Error(`Cannot hard reset non-system config group "${configGroup[0].get('group')}"`);
     }
+
+    const baseConfig = systemConfigs.base;
 
     const amount = 100;
 

--- a/packages/dashmate/src/config/Config.js
+++ b/packages/dashmate/src/config/Config.js
@@ -77,7 +77,7 @@ class Config {
   set(path, value) {
     const clonedOptions = lodashCloneDeep(this.options);
 
-    lodashSet(clonedOptions, path, value);
+    lodashSet(clonedOptions, path, lodashCloneDeep(value));
 
     const isValid = Config.ajv.validate(configJsonSchema, clonedOptions);
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
`Cannot read properties of undefined (reading 'dpns')` error is thrown on `group:reset` command

## What was done?
<!--- Describe your changes in detail -->
- Avoid modification of CommonJS module exported object
- Clone value on `Config#set` to avoid future problems
- Use `systemConfigs` from DI container

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Running command

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
