### PR TITLE
fix(wallet-lib): eventemitter memory leak

### DIFF
--- a/packages/js-dash-sdk/package.json
+++ b/packages/js-dash-sdk/package.json
@@ -1,7 +1,7 @@
 {
   "name": "dash",
   "version": "3.21.4",
-  "description": "Dash library for JavaScript/TypeScript ecosystem (Wallet, DAPI, Primitives, BLS, ...)",
+  "description": "Dash library for JavaScript/TypeScript ecosystem (Wallet, DAPI, Primitives, BLS, ....)",
   "main": "build/src/index.js",
   "unpkg": "dist/dash.min.js",
   "types": "dist/src/index.d.ts",

--- a/packages/js-dash-sdk/package.json
+++ b/packages/js-dash-sdk/package.json
@@ -1,7 +1,7 @@
 {
   "name": "dash",
   "version": "3.21.4",
-  "description": "Dash library for JavaScript/TypeScript ecosystem (Wallet, DAPI, Primitives, BLS, ....)",
+  "description": "Dash library for JavaScript/TypeScript ecosystem (Wallet, DAPI, Primitives, BLS, ...)",
   "main": "build/src/index.js",
   "unpkg": "dist/dash.min.js",
   "types": "dist/src/index.d.ts",

--- a/packages/wallet-lib/src/transport/AbstractTransport.js
+++ b/packages/wallet-lib/src/transport/AbstractTransport.js
@@ -10,10 +10,6 @@ class AbstractTransport extends EventEmitter {
   constructor() {
     super();
 
-    // we dynamically add blockheight_changed events, that cause MaxListenersExceededWarning
-    // to disable this warning, we set max listeners to 0
-    this.setMaxListeners(0);
-
     this.state = {
       block: null,
       blockHeaders: null,

--- a/packages/wallet-lib/src/types/Account/Account.js
+++ b/packages/wallet-lib/src/types/Account/Account.js
@@ -175,6 +175,10 @@ class Account extends EventEmitter {
      * @type {Promise<void>}
      */
     this.txISLockListener = null;
+
+    // Increases a limit of max listeners for transactions related events
+    // 25 - mempool limit
+    this.setMaxListeners(25);
   }
 
   static getInstantLockTopicName(transactionHash) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The wallet was hooking on lots of redundant event listeners during the processing raw transactions from the stream.


## What was done?
<!--- Describe your changes in detail -->
Remove event listeners right after they'd became not needed

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Manually broadcast 10 transactions one by one to ensure that the warning does not appear anymore
- Ensure that the warning is not present in the logs of the test suites

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
