### PR TITLE
chore: undefined "-w" argument in restart script

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "setup": "yarn install && yarn run build && yarn run configure",
     "start": "yarn run dashmate group:start --verbose -w",
-    "restart": "yarn run dashmate group:restart --verbose -w",
+    "restart": "yarn run dashmate group:restart --verbose",
     "stop": "yarn run dashmate group:stop --verbose",
     "reset": "yarn run clean:data --force && yarn run setup",
     "test": "ultra -r $* test",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
`Error: Unexpected argument: -w` on `yarn restart`. `dashmate group:restart` doesn't accept `-w` flag

## What was done?
<!--- Describe your changes in detail -->
- Remove undefined flag

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Running this command manually

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
