### PR TITLE
fix!: for wallet access on dashmate seed node (partial)

### DIFF
--- a/packages/dashmate/docker-compose.yml
+++ b/packages/dashmate/docker-compose.yml
@@ -10,9 +10,10 @@ services:
     volumes:
       - core_data:/dash
       - ${DASHMATE_HOME_DIR:?err}/${CONFIG_NAME:?err}/core/dash.conf:/dash/.dashcore/dash.conf
+    environment:
+      - CORE_MASTERNODE_OPERATOR_PRIVATE_KEY=${CORE_MASTERNODE_OPERATOR_PRIVATE_KEY}
     command:
       - dashd
-      - -masternodeblsprivkey=${CORE_MASTERNODE_OPERATOR_PRIVATE_KEY}
 
 volumes:
   core_data:


### PR DESCRIPTION
Wallet access on seed node (via rpcs) in local network was broken.
Changed the docker-compose file so it does not feed the `-masternodeblsprivkey` flag to `dashd` when a node is not a masternode. Instead, it sets an environment variable with `CORE_MASTERNODE_OPERATOR_PRIVATE_KEY`. 

This was discussed in PR on archived [dashmate repo](https://github.com/dashevo/dashmate/pull/466).

<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Partially fixes archived repo [issue 465](https://github.com/dashevo/dashmate/issues/465)

## What was done?
<!--- Describe your changes in detail -->
Change docker-compose command for core containers, remove the `-masternodeblsprivkeyflag` from the dashd command.
Instead, add an environment section and add `CORE_MASTERNODE_OPERATOR_PRIVATE_KEY` env var.

This env var should be read by the docker entrypoint (of dashcore image) ([docker-entrypoint.sh](https://github.com/dashpay/dash/blob/master/docker/docker-entrypoint.sh)), which processes it and adds it to dash.conf

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I did test this locally by setting up a dashmate network with local preset (`dashmate setup local`), and I checked wallet functionality via RPC. Starting and stopping of nodes works fine. (I also patched dashcore docker image entrypoint script to test this.)

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
This makes dashmate fail since the dashcore docker image does not yet have an entrypoint script that checks the masternode privkey and adds it to dash.conf. [This PR](https://github.com/dashpay/dash/pull/4624) on dashcore fixes this. When the two PRs are both applied, this will not break anything as far as I know/tested.
However, since if the entrypoint script does not process the environment variable holding the masternode privkey, then nodes will never be run as masternode. Therefore, dashmate will fail to setup a mn network.

Note that this will require rebuilding the dashcore docker image (and pushing it to docker hub?). If this is not done before merging then dashmate will break.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone
