### PR TITLE
fix: downgrade dash-core image to v0.17

### DIFF
--- a/packages/dashmate/configs/system/base.js
+++ b/packages/dashmate/configs/system/base.js
@@ -10,7 +10,7 @@ module.exports = {
   group: null,
   core: {
     docker: {
-      image: 'dashpay/dashd:0.18.0.0-beta1',
+      image: 'dashpay/dashd:0.17',
     },
     p2p: {
       port: 20001,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Most recent dash core release (dashd:0.18.0.0-beta1 at the time) comes without arm64 support. This lead to segfault crashes on Apple Silicon devices. Solution is to downgrade to v0.17 until arm64 dash core images is provided.

## What was done?
<!--- Describe your changes in detail -->
Set up dashd v0.17 in the dashmate. After this fix you can successfully run `yarn setup` on Apple Silicon devices 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested locally on my laptop.

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
