### PR TITLE
feat(dpp)!: `$id` can't be used in secondary indices

### DIFF
--- a/packages/js-dpp/lib/dataContract/getPropertyDefinitionByPath.js
+++ b/packages/js-dpp/lib/dataContract/getPropertyDefinitionByPath.js
@@ -1,6 +1,7 @@
 /**
  * Get user property definition
  *
+ * @typeof getPropertyDefinitionByPath
  * @param {Object} documentDefinition
  * @param {string} path
  *

--- a/packages/js-dpp/lib/dataContract/validation/validateDataContractFactory.js
+++ b/packages/js-dpp/lib/dataContract/validation/validateDataContractFactory.js
@@ -16,8 +16,8 @@ const InvalidCompoundIndexError = require('../../errors/consensus/basic/dataCont
 const convertBuffersToArrays = require('../../util/convertBuffersToArrays');
 const DuplicateIndexNameError = require('../../errors/consensus/basic/dataContract/DuplicateIndexNameError');
 
-const allowedSystemProperties = ['$id', '$ownerId', '$createdAt', '$updatedAt'];
-const prebuiltIndices = ['$id'];
+const allowedIndexSystemProperties = ['$ownerId', '$createdAt', '$updatedAt'];
+const notAllowedIndexProperties = ['$id'];
 
 const MAX_INDEXED_STRING_PROPERTY_LENGTH = 1024;
 
@@ -147,12 +147,9 @@ module.exports = function validateDataContractFactory(
           }
 
           // Ensure there are no duplicate system indices
-          prebuiltIndices
+          notAllowedIndexProperties
             .forEach((propertyName) => {
-              const isSingleIndex = indexPropertyNames.length === 1
-                    && indexPropertyNames[0] === propertyName;
-
-              if (isSingleIndex) {
+              if (indexPropertyNames.includes(propertyName)) {
                 result.addError(new SystemPropertyIndexAlreadyPresentError(
                   documentType,
                   indexDefinition,
@@ -163,7 +160,7 @@ module.exports = function validateDataContractFactory(
 
           // Ensure index properties are defined in the document
           const userDefinedProperties = indexPropertyNames
-            .filter((name) => !allowedSystemProperties.includes(name));
+            .filter((name) => !allowedIndexSystemProperties.includes(name));
 
           const propertyDefinitionEntities = userDefinedProperties
             .map((propertyName) => (

--- a/packages/js-dpp/lib/errors/consensus/basic/dataContract/SystemPropertyIndexAlreadyPresentError.js
+++ b/packages/js-dpp/lib/errors/consensus/basic/dataContract/SystemPropertyIndexAlreadyPresentError.js
@@ -7,7 +7,7 @@ class SystemPropertyIndexAlreadyPresentError extends AbstractIndexError {
    * @param {string} propertyName
    */
   constructor(documentType, indexDefinition, propertyName) {
-    const message = `Single-property index on ${propertyName} system property is already indexed for ${documentType} document.`;
+    const message = `System property ${propertyName} is already indexed and can't be used in other indices for ${documentType} document.`;
 
     super(
       message,

--- a/packages/js-dpp/lib/test/fixtures/getDataContractFixture.js
+++ b/packages/js-dpp/lib/test/fixtures/getDataContractFixture.js
@@ -56,7 +56,6 @@ module.exports = function getDataContractFixture(ownerId = randomOwnerId) {
         {
           name: 'index3',
           properties: [
-            { $id: 'asc' },
             { lastName: 'asc' },
           ],
         },
@@ -208,7 +207,6 @@ module.exports = function getDataContractFixture(ownerId = randomOwnerId) {
         {
           name: 'index2',
           properties: [
-            { $id: 'asc' },
             { $ownerId: 'asc' },
             { firstName: 'asc' },
             { lastName: 'asc' },

--- a/packages/js-dpp/test/integration/dataContract/validation/validateDataContractFactory.spec.js
+++ b/packages/js-dpp/test/integration/dataContract/validation/validateDataContractFactory.spec.js
@@ -1471,11 +1471,12 @@ describe('validateDataContractFactory', function main() {
         expect(error.getDocumentType()).to.equal('indexedDocument');
       });
 
-      it('should return invalid result if index is prebuilt', async () => {
+      it('should return invalid result if $id is specified as an indexed property', async () => {
         const indexDefinition = {
           name: 'index_1',
           properties: [
             { $id: 'asc' },
+            { firstName: 'desc' },
           ],
         };
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
There is no practical benefits of using `$id` property as a part of secondary indices so we should do not allow do that and optimize GroveDB internal structure

## What was done?
<!--- Describe your changes in detail -->
- Do not allow to use `$id` as a secondary indices.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
With integration test

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
`$id` can't be used in secondary indices

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
