### PR TITLE
build: fix configure test suite script for grep 2.5.1

### DIFF
--- a/scripts/configure_test_suite.sh
+++ b/scripts/configure_test_suite.sh
@@ -23,7 +23,7 @@ FEATURE_FLAGS_CONTRACT_ID=$(yarn dashmate config get --config="${CONFIG}_1" plat
 
 MASTERNODE_REWARD_SHARES_CONTRACT_ID=$(yarn dashmate config:get --config="${CONFIG}_1" platform.masternodeRewardShares.contract.id)
 MASTERNODE_REWARD_SHARES_OWNER_PRO_REG_TX_HASH=$(grep -m 1 "ProRegTx transaction ID:" "${SETUP_FILE_PATH}" | awk '{printf $5}')
-MASTERNODE_REWARD_SHARES_OWNER_PRIVATE_KEY=$(grep -m 1 -A 2 "Create a new owner addresses" "${SETUP_FILE_PATH}" | grep "Private key" | awk  '{printf $4}')
+MASTERNODE_REWARD_SHARES_OWNER_PRIVATE_KEY=$(grep -m 2 -A 2 "Create a new owner addresses" "${SETUP_FILE_PATH}" | grep "Private key" | awk  '{printf $4}')
 
 echo "Mint 100 Dash to faucet address"
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
`yarn configure:test` throws "Internal error. Some of the env variables are empty. Please check logs above."

With grep 2.5.1, command `grep -A 2 -m 1  "Create a new owner addresses" ./logs/setup.log` returns 
```
[STARTED] Create a new owner addresses
```
instead of
```
[STARTED] Create a new owner addresses
[DATA] Address: "..."
[DATA] Private key: "..."
```


## What was done?
<!--- Describe your changes in detail -->
Changed `-m` flag's value to 2

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
`yarn configure:test`

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
