### PR TITLE
fix(drive): `orderBy` for `where` clauses with `in` and `startsWith`

### DIFF
--- a/packages/js-drive/lib/document/query/validateQueryFactory.js
+++ b/packages/js-drive/lib/document/query/validateQueryFactory.js
@@ -99,7 +99,8 @@ function validateQueryFactory(
 
       const [property, operator] = lastCondition;
 
-      if (!operator.includes('<') && !operator.includes('>')) {
+      if (!operator.includes('<') && !operator.includes('>')
+          && !operator.includes('startsWith') && !operator.includes('in')) {
         result.addError(new InvalidPropertiesInOrderByError());
 
         return result;

--- a/packages/js-drive/test/unit/document/query/validateQueryFactory.spec.js
+++ b/packages/js-drive/test/unit/document/query/validateQueryFactory.spec.js
@@ -125,6 +125,21 @@ const invalidFieldNameTestCases = [
   'a.b.c.',
 ];
 
+const validOrderByOperators = {
+  '>': {
+    value: 42,
+  },
+  '<': {
+    value: 42,
+  },
+  startsWith: {
+    value: 'rt-',
+  },
+  in: {
+    value: ['a', 'b'],
+  },
+};
+
 describe('validateQueryFactory', () => {
   let findConflictingConditionsStub;
   let validateQuery;
@@ -1435,6 +1450,29 @@ describe('validateQueryFactory', () => {
       expect(result.errors[0].instancePath).to.be.equal('/orderBy/0');
       expect(result.errors[0].keyword).to.be.equal('maxItems');
       expect(result.errors[0].params.limit).to.be.equal(2);
+    });
+
+    Object.keys(validOrderByOperators).forEach((operator) => {
+      it(`should return true if "orderBy" has valid field with valid operator in "where" clause - "${operator}"`, () => {
+        documentSchema = {
+          indices: [
+            {
+              properties: [{ a: 'asc' }],
+            },
+          ],
+        };
+
+        const result = validateQuery({
+          where: [
+            ['a', operator, validOrderByOperators[operator].value],
+          ],
+          orderBy: [['a', 'asc']],
+        },
+        documentSchema);
+
+        expect(result).to.be.instanceOf(ValidationResult);
+        expect(result.isValid()).to.be.true();
+      });
     });
   });
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Allowing using `orderBy` for properties that have `in` and `startsWith` in their `where` clause. Since they are range queries as well.

## What was done?
<!--- Describe your changes in detail -->
- updated `validateQuery` function

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Unit tests

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
