### PR TITLE
docs: ignore folder with empty docs during build

### DIFF
--- a/scripts/prepare_docs.sh
+++ b/scripts/prepare_docs.sh
@@ -5,5 +5,7 @@ cp -r ./packages/js-dpp/docs/ ./docs/Dash-Platform-Protocol
 mv ./docs/Dash-Platform-Protocol/_sidebar.md ./docs/Dash-Platform-Protocol/Overview.md
 cp -r ./packages/js-dash-sdk/docs/ ./docs/SDK
 mv ./docs/SDK/_sidebar.md ./docs/SDK/Overview.md
+# Exclude folder with empty documents
+rm -r ./docs/SDK/walkthroughs
 cp -r ./packages/wallet-lib/docs/ ./docs/Wallet-library
 mv ./docs/Wallet-library/_sidebar.md ./docs/Wallet-library/Overview.md


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This is an alternative to #189. 
There's a section on the docs site for walkthroughs (e.g. https://dashevo.github.io/platform/SDK/walkthroughs/automatically-consolidate-UTXO/automatically-consolidate-UTXO/), but they're empty files - confusing, not helpful.

## What was done?
<!--- Describe your changes in detail -->
Updated the doc build prep script so it ignores the folder containing the empty docs. This way the files remain in the repo as placeholders but don't appear on the built documentation.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested locally

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
N/A

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
