### PR TITLE
feat(dpp)!: do not allow to index array properties

### DIFF
--- a/packages/js-dpp/lib/dataContract/validation/validateDataContractFactory.js
+++ b/packages/js-dpp/lib/dataContract/validation/validateDataContractFactory.js
@@ -204,21 +204,24 @@ module.exports = function validateDataContractFactory(
               invalidPropertyType = 'object';
             }
 
-            const { items, prefixItems } = propertyDefinition;
+            // const { items, prefixItems } = propertyDefinition;
 
             // Validate arrays contain scalar values or have the same types
             if (propertyType === 'array' && !isByteArray) {
-              const isInvalidPrefixItems = prefixItems
-                && (
-                  prefixItems.some((prefixItem) => prefixItem.type === 'object' || prefixItem.type === 'array')
-                  || !prefixItems.every((prefixItem) => prefixItem.type === prefixItems[0].type)
-                );
+              invalidPropertyType = 'array';
 
-              const isInvalidItemTypes = items.type === 'object' || items.type === 'array';
-
-              if (isInvalidPrefixItems || isInvalidItemTypes) {
-                invalidPropertyType = 'array';
-              }
+            // const isInvalidPrefixItems = prefixItems
+            //   && (
+            // prefixItems.some((prefixItem) =>
+              // prefixItem.type === 'object' || prefixItem.type === 'array')
+            //     || !prefixItems.every((prefixItem) => prefixItem.type === prefixItems[0].type)
+            //   );
+            //
+            // const isInvalidItemTypes = items.type === 'object' || items.type === 'array';
+            //
+            // if (isInvalidPrefixItems || isInvalidItemTypes) {
+            //   invalidPropertyType = 'array';
+            // }
             }
 
             if (invalidPropertyType) {
@@ -231,31 +234,31 @@ module.exports = function validateDataContractFactory(
             }
 
             // Validate sting length inside arrays
-            if (!invalidPropertyType && propertyType === 'array' && !isByteArray) {
-              const isInvalidPrefixItems = prefixItems && prefixItems.some((prefixItem) => (
-                prefixItem.type === 'string'
-                && (
-                  !prefixItem.maxLength || prefixItem.maxLength > MAX_INDEXED_STRING_PROPERTY_LENGTH
-                )
-              ));
-
-              const isInvalidItemTypes = items.type === 'string' && (
-                !items.maxLength || items.maxLength > MAX_INDEXED_STRING_PROPERTY_LENGTH
-              );
-
-              if (isInvalidPrefixItems || isInvalidItemTypes) {
-                result.addError(
-                  new InvalidIndexedPropertyConstraintError(
-                    documentType,
-                    indexDefinition,
-                    propertyName,
-                    'maxLength',
-                    `should be less or equal ${MAX_INDEXED_STRING_PROPERTY_LENGTH}`,
-                  ),
-                );
-              }
-            }
-
+            // if (!invalidPropertyType && propertyType === 'array' && !isByteArray) {
+            //   const isInvalidPrefixItems = prefixItems && prefixItems.some((prefixItem) => (
+            //     prefixItem.type === 'string'
+            //     && (
+            // !prefixItem.maxLength || prefixItem.maxLength > MAX_INDEXED_STRING_PROPERTY_LENGTH
+            //     )
+            //   ));
+            //
+            //   const isInvalidItemTypes = items.type === 'string' && (
+            //     !items.maxLength || items.maxLength > MAX_INDEXED_STRING_PROPERTY_LENGTH
+            //   );
+            //
+            //   if (isInvalidPrefixItems || isInvalidItemTypes) {
+            //     result.addError(
+            //       new InvalidIndexedPropertyConstraintError(
+            //         documentType,
+            //         indexDefinition,
+            //         propertyName,
+            //         'maxLength',
+            //         `should be less or equal ${MAX_INDEXED_STRING_PROPERTY_LENGTH}`,
+            //       ),
+            //     );
+            //   }
+            // }
+            //
             if (!invalidPropertyType && propertyType === 'array') {
               const { maxItems } = propertyDefinition;
 

--- a/packages/js-dpp/lib/test/fixtures/getDataContractFixture.js
+++ b/packages/js-dpp/lib/test/fixtures/getDataContractFixture.js
@@ -92,32 +92,32 @@ module.exports = function getDataContractFixture(ownerId = randomOwnerId) {
       required: ['firstName', '$createdAt', '$updatedAt', 'lastName'],
       additionalProperties: false,
     },
-    indexedArray: {
-      type: 'object',
-      indices: [
-        {
-          name: 'index1',
-          properties: [
-            { mentions: 'asc' },
-          ],
-        },
-      ],
-      properties: {
-        mentions: {
-          type: 'array',
-          prefixItems: [
-            {
-              type: 'string',
-              maxLength: 100,
-            },
-          ],
-          minItems: 1,
-          maxItems: 5,
-          items: false,
-        },
-      },
-      additionalProperties: false,
-    },
+    // indexedArray: {
+    //   type: 'object',
+    //   indices: [
+    //     {
+    //       name: 'index1',
+    //       properties: [
+    //         { mentions: 'asc' },
+    //       ],
+    //     },
+    //   ],
+    //   properties: {
+    //     mentions: {
+    //       type: 'array',
+    //       prefixItems: [
+    //         {
+    //           type: 'string',
+    //           maxLength: 100,
+    //         },
+    //       ],
+    //       minItems: 1,
+    //       maxItems: 5,
+    //       items: false,
+    //     },
+    //   },
+    //   additionalProperties: false,
+    // },
     noTimeDocument: {
       type: 'object',
       properties: {

--- a/packages/js-dpp/test/integration/dataContract/validation/validateDataContractFactory.spec.js
+++ b/packages/js-dpp/test/integration/dataContract/validation/validateDataContractFactory.spec.js
@@ -1549,29 +1549,35 @@ describe('validateDataContractFactory', function main() {
         expect(error.getIndexDefinition()).to.deep.equal(indexDefinition);
       });
 
-      it('should return invalid result if index property is array of objects', async () => {
-        const indexedDocumentDefinition = rawDataContract.documents.indexedDocument;
-
-        indexedDocumentDefinition.properties.arrayProperty = {
-          type: 'array',
-          items: {
-            type: 'object',
-            properties: {
-              something: {
-                type: 'string',
-              },
+      it('should return invalid result if index property is an array', async () => {
+        rawDataContract.documents.indexedArray = {
+          type: 'object',
+          indices: [
+            {
+              name: 'index1',
+              properties: [
+                { mentions: 'asc' },
+              ],
             },
-            additionalProperties: false,
+          ],
+          properties: {
+            mentions: {
+              type: 'array',
+              prefixItems: [
+                {
+                  type: 'string',
+                  maxLength: 100,
+                },
+              ],
+              minItems: 1,
+              maxItems: 5,
+              items: false,
+            },
           },
+          additionalProperties: false,
         };
 
-        indexedDocumentDefinition.required.push('arrayProperty');
-
-        const indexDefinition = indexedDocumentDefinition.indices[0];
-
-        indexDefinition.properties.push({
-          arrayProperty: 'asc',
-        });
+        const indexDefinition = rawDataContract.documents.indexedArray.indices[0];
 
         const result = await validateDataContract(rawDataContract);
 
@@ -1580,128 +1586,168 @@ describe('validateDataContractFactory', function main() {
         const [error] = result.getErrors();
 
         expect(error.getCode()).to.equal(1013);
-        expect(error.getPropertyName()).to.equal('arrayProperty');
-        expect(error.getPropertyType()).to.equal('array');
-        expect(error.getDocumentType()).to.deep.equal('indexedDocument');
-        expect(error.getIndexDefinition()).to.deep.equal(indexDefinition);
-      });
-
-      it('should return invalid result if index property is an array of different types', async () => {
-        const indexedDocumentDefinition = rawDataContract.documents.indexedArray;
-
-        const indexDefinition = indexedDocumentDefinition.indices[0];
-
-        rawDataContract.documents.indexedArray.properties.mentions.prefixItems = [
-          {
-            type: 'string',
-          },
-          {
-            type: 'number',
-          },
-        ];
-
-        rawDataContract.documents.indexedArray.properties.mentions.minItems = 2;
-
-        const result = await validateDataContract(rawDataContract);
-        expectValidationError(result, InvalidIndexPropertyTypeError);
-
-        const error = result.getFirstError();
-
-        expect(error.getCode()).to.equal(1013);
         expect(error.getPropertyName()).to.equal('mentions');
         expect(error.getPropertyType()).to.equal('array');
         expect(error.getDocumentType()).to.deep.equal('indexedArray');
         expect(error.getIndexDefinition()).to.deep.equal(indexDefinition);
       });
 
-      it('should return invalid result if index property contained prefixItems array of arrays', async () => {
-        const indexedDocumentDefinition = rawDataContract.documents.indexedArray;
+      // it('should return invalid result if index property is array of objects', async () => {
+      //   const indexedDocumentDefinition = rawDataContract.documents.indexedDocument;
+      //
+      //   indexedDocumentDefinition.properties.arrayProperty = {
+      //     type: 'array',
+      //     items: {
+      //       type: 'object',
+      //       properties: {
+      //         something: {
+      //           type: 'string',
+      //         },
+      //       },
+      //       additionalProperties: false,
+      //     },
+      //   };
+      //
+      //   indexedDocumentDefinition.required.push('arrayProperty');
+      //
+      //   const indexDefinition = indexedDocumentDefinition.indices[0];
+      //
+      //   indexDefinition.properties.push({
+      //     arrayProperty: 'asc',
+      //   });
+      //
+      //   const result = await validateDataContract(rawDataContract);
+      //
+      //   expectValidationError(result, InvalidIndexPropertyTypeError);
+      //
+      //   const [error] = result.getErrors();
+      //
+      //   expect(error.getCode()).to.equal(1013);
+      //   expect(error.getPropertyName()).to.equal('arrayProperty');
+      //   expect(error.getPropertyType()).to.equal('array');
+      //   expect(error.getDocumentType()).to.deep.equal('indexedDocument');
+      //   expect(error.getIndexDefinition()).to.deep.equal(indexDefinition);
+      // });
 
-        const indexDefinition = indexedDocumentDefinition.indices[0];
+      // it('should return invalid result if index property is an array of different types',
+      // async () => {
+      //   const indexedDocumentDefinition = rawDataContract.documents.indexedArray;
+      //
+      //   const indexDefinition = indexedDocumentDefinition.indices[0];
+      //
+      //   rawDataContract.documents.indexedArray.properties.mentions.prefixItems = [
+      //     {
+      //       type: 'string',
+      //     },
+      //     {
+      //       type: 'number',
+      //     },
+      //   ];
+      //
+      //   rawDataContract.documents.indexedArray.properties.mentions.minItems = 2;
+      //
+      //   const result = await validateDataContract(rawDataContract);
+      //   expectValidationError(result, InvalidIndexPropertyTypeError);
+      //
+      //   const error = result.getFirstError();
+      //
+      //   expect(error.getCode()).to.equal(1013);
+      //   expect(error.getPropertyName()).to.equal('mentions');
+      //   expect(error.getPropertyType()).to.equal('array');
+      //   expect(error.getDocumentType()).to.deep.equal('indexedArray');
+      //   expect(error.getIndexDefinition()).to.deep.equal(indexDefinition);
+      // });
+      //
+      // it('should return invalid result if index property contained prefixItems array of arrays',
+      // async () => {
+      //   const indexedDocumentDefinition = rawDataContract.documents.indexedArray;
+      //
+      //   const indexDefinition = indexedDocumentDefinition.indices[0];
+      //
+      //   rawDataContract.documents.indexedArray.properties.mentions.prefixItems = [
+      //     {
+      //       type: 'array',
+      //       items: {
+      //         type: 'string',
+      //       },
+      //     },
+      //   ];
+      //
+      //   const result = await validateDataContract(rawDataContract);
+      //   expectValidationError(result, InvalidIndexPropertyTypeError);
+      //
+      //   const error = result.getFirstError();
+      //
+      //   expect(error.getCode()).to.equal(1013);
+      //   expect(error.getPropertyName()).to.equal('mentions');
+      //   expect(error.getPropertyType()).to.equal('array');
+      //   expect(error.getDocumentType()).to.deep.equal('indexedArray');
+      //   expect(error.getIndexDefinition()).to.deep.equal(indexDefinition);
+      // });
 
-        rawDataContract.documents.indexedArray.properties.mentions.prefixItems = [
-          {
-            type: 'array',
-            items: {
-              type: 'string',
-            },
-          },
-        ];
-
-        const result = await validateDataContract(rawDataContract);
-        expectValidationError(result, InvalidIndexPropertyTypeError);
-
-        const error = result.getFirstError();
-
-        expect(error.getCode()).to.equal(1013);
-        expect(error.getPropertyName()).to.equal('mentions');
-        expect(error.getPropertyType()).to.equal('array');
-        expect(error.getDocumentType()).to.deep.equal('indexedArray');
-        expect(error.getIndexDefinition()).to.deep.equal(indexDefinition);
-      });
-
-      it('should return invalid result if index property contained prefixItems array of objects', async () => {
-        const indexedDocumentDefinition = rawDataContract.documents.indexedArray;
-
-        const indexDefinition = indexedDocumentDefinition.indices[0];
-
-        rawDataContract.documents.indexedArray.properties.mentions.prefixItems = [
-          {
-            type: 'object',
-            properties: {
-              something: {
-                type: 'string',
-              },
-            },
-            additionalProperties: false,
-          },
-        ];
-
-        const result = await validateDataContract(rawDataContract);
-        expectValidationError(result, InvalidIndexPropertyTypeError);
-
-        const error = result.getFirstError();
-
-        expect(error.getCode()).to.equal(1013);
-        expect(error.getPropertyName()).to.equal('mentions');
-        expect(error.getPropertyType()).to.equal('array');
-        expect(error.getDocumentType()).to.deep.equal('indexedArray');
-        expect(error.getIndexDefinition()).to.deep.equal(indexDefinition);
-      });
-
-      it('should return invalid result if index property is array of arrays', async () => {
-        const indexedDocumentDefinition = rawDataContract.documents.indexedDocument;
-
-        indexedDocumentDefinition.properties.arrayProperty = {
-          type: 'array',
-          items: {
-            type: 'array',
-            items: {
-              type: 'string',
-            },
-          },
-        };
-
-        indexedDocumentDefinition.required.push('arrayProperty');
-
-        const indexDefinition = indexedDocumentDefinition.indices[0];
-
-        indexDefinition.properties.push({
-          arrayProperty: 'asc',
-        });
-
-        const result = await validateDataContract(rawDataContract);
-
-        expectValidationError(result, InvalidIndexPropertyTypeError);
-
-        const [error] = result.getErrors();
-
-        expect(error.getCode()).to.equal(1013);
-        expect(error.getPropertyName()).to.equal('arrayProperty');
-        expect(error.getPropertyType()).to.equal('array');
-        expect(error.getDocumentType()).to.deep.equal('indexedDocument');
-        expect(error.getIndexDefinition()).to.deep.equal(indexDefinition);
-      });
+      // it('should return invalid result if index property contained prefixItems array of objects',
+      // async () => {
+      //   const indexedDocumentDefinition = rawDataContract.documents.indexedArray;
+      //
+      //   const indexDefinition = indexedDocumentDefinition.indices[0];
+      //
+      //   rawDataContract.documents.indexedArray.properties.mentions.prefixItems = [
+      //     {
+      //       type: 'object',
+      //       properties: {
+      //         something: {
+      //           type: 'string',
+      //         },
+      //       },
+      //       additionalProperties: false,
+      //     },
+      //   ];
+      //
+      //   const result = await validateDataContract(rawDataContract);
+      //   expectValidationError(result, InvalidIndexPropertyTypeError);
+      //
+      //   const error = result.getFirstError();
+      //
+      //   expect(error.getCode()).to.equal(1013);
+      //   expect(error.getPropertyName()).to.equal('mentions');
+      //   expect(error.getPropertyType()).to.equal('array');
+      //   expect(error.getDocumentType()).to.deep.equal('indexedArray');
+      //   expect(error.getIndexDefinition()).to.deep.equal(indexDefinition);
+      // });
+      //
+      // it('should return invalid result if index property is array of arrays', async () => {
+      //   const indexedDocumentDefinition = rawDataContract.documents.indexedDocument;
+      //
+      //   indexedDocumentDefinition.properties.arrayProperty = {
+      //     type: 'array',
+      //     items: {
+      //       type: 'array',
+      //       items: {
+      //         type: 'string',
+      //       },
+      //     },
+      //   };
+      //
+      //   indexedDocumentDefinition.required.push('arrayProperty');
+      //
+      //   const indexDefinition = indexedDocumentDefinition.indices[0];
+      //
+      //   indexDefinition.properties.push({
+      //     arrayProperty: 'asc',
+      //   });
+      //
+      //   const result = await validateDataContract(rawDataContract);
+      //
+      //   expectValidationError(result, InvalidIndexPropertyTypeError);
+      //
+      //   const [error] = result.getErrors();
+      //
+      //   expect(error.getCode()).to.equal(1013);
+      //   expect(error.getPropertyName()).to.equal('arrayProperty');
+      //   expect(error.getPropertyType()).to.equal('array');
+      //   expect(error.getDocumentType()).to.deep.equal('indexedDocument');
+      //   expect(error.getIndexDefinition()).to.deep.equal(indexDefinition);
+      // });
 
       it('should return invalid result if index property is array with different item definitions', async () => {
         const indexedDocumentDefinition = rawDataContract.documents.indexedDocument;
@@ -1958,65 +2004,68 @@ describe('validateDataContractFactory', function main() {
     expect(error.getReason()).to.equal('should be less or equal 1024');
   });
 
-  it('should return invalid result if indexed array property missing maxItems constraint', async () => {
-    delete rawDataContract.documents.indexedArray.properties.mentions.maxItems;
-
-    const result = await validateDataContract(rawDataContract);
-
-    expectValidationError(result, InvalidIndexedPropertyConstraintError);
-
-    const [error] = result.getErrors();
-
-    expect(error.getCode()).to.equal(1012);
-    expect(error.getPropertyName()).to.equal('mentions');
-    expect(error.getConstraintName()).to.equal('maxItems');
-    expect(error.getReason()).to.equal('should be less or equal 1024');
-  });
-
-  it('should return invalid result if indexed array property have to big maxItems', async () => {
-    rawDataContract.documents.indexedArray.properties.mentions.maxItems = 2048;
-
-    const result = await validateDataContract(rawDataContract);
-
-    expectValidationError(result, InvalidIndexedPropertyConstraintError);
-
-    const [error] = result.getErrors();
-
-    expect(error.getCode()).to.equal(1012);
-    expect(error.getPropertyName()).to.equal('mentions');
-    expect(error.getConstraintName()).to.equal('maxItems');
-    expect(error.getReason()).to.equal('should be less or equal 1024');
-  });
-
-  it('should return invalid result if indexed array property have string item without maxItems constraint', async () => {
-    delete rawDataContract.documents.indexedArray.properties.mentions.maxItems;
-
-    const result = await validateDataContract(rawDataContract);
-
-    expectValidationError(result, InvalidIndexedPropertyConstraintError);
-
-    const [error] = result.getErrors();
-
-    expect(error.getCode()).to.equal(1012);
-    expect(error.getPropertyName()).to.equal('mentions');
-    expect(error.getConstraintName()).to.equal('maxItems');
-    expect(error.getReason()).to.equal('should be less or equal 1024');
-  });
-
-  it('should return invalid result if indexed array property have string item with maxItems bigger than 1024', async () => {
-    rawDataContract.documents.indexedArray.properties.mentions.maxItems = 2048;
-
-    const result = await validateDataContract(rawDataContract);
-
-    expectValidationError(result, InvalidIndexedPropertyConstraintError);
-
-    const [error] = result.getErrors();
-
-    expect(error.getCode()).to.equal(1012);
-    expect(error.getPropertyName()).to.equal('mentions');
-    expect(error.getConstraintName()).to.equal('maxItems');
-    expect(error.getReason()).to.equal('should be less or equal 1024');
-  });
+  // it('should return invalid result if indexed array property missing maxItems constraint',
+  // async () => {
+  //   delete rawDataContract.documents.indexedArray.properties.mentions.maxItems;
+  //
+  //   const result = await validateDataContract(rawDataContract);
+  //
+  //   expectValidationError(result, InvalidIndexedPropertyConstraintError);
+  //
+  //   const [error] = result.getErrors();
+  //
+  //   expect(error.getCode()).to.equal(1012);
+  //   expect(error.getPropertyName()).to.equal('mentions');
+  //   expect(error.getConstraintName()).to.equal('maxItems');
+  //   expect(error.getReason()).to.equal('should be less or equal 1024');
+  // });
+  //
+  // it('should return invalid result if indexed array property have to big maxItems', async () => {
+  //   rawDataContract.documents.indexedArray.properties.mentions.maxItems = 2048;
+  //
+  //   const result = await validateDataContract(rawDataContract);
+  //
+  //   expectValidationError(result, InvalidIndexedPropertyConstraintError);
+  //
+  //   const [error] = result.getErrors();
+  //
+  //   expect(error.getCode()).to.equal(1012);
+  //   expect(error.getPropertyName()).to.equal('mentions');
+  //   expect(error.getConstraintName()).to.equal('maxItems');
+  //   expect(error.getReason()).to.equal('should be less or equal 1024');
+  // });
+  //
+  // it('should return invalid result if indexed array property
+  // have string item without maxItems constraint', async () => {
+  //   delete rawDataContract.documents.indexedArray.properties.mentions.maxItems;
+  //
+  //   const result = await validateDataContract(rawDataContract);
+  //
+  //   expectValidationError(result, InvalidIndexedPropertyConstraintError);
+  //
+  //   const [error] = result.getErrors();
+  //
+  //   expect(error.getCode()).to.equal(1012);
+  //   expect(error.getPropertyName()).to.equal('mentions');
+  //   expect(error.getConstraintName()).to.equal('maxItems');
+  //   expect(error.getReason()).to.equal('should be less or equal 1024');
+  // });
+  //
+  // it('should return invalid result if indexed array property have
+  // string item with maxItems bigger than 1024', async () => {
+  //   rawDataContract.documents.indexedArray.properties.mentions.maxItems = 2048;
+  //
+  //   const result = await validateDataContract(rawDataContract);
+  //
+  //   expectValidationError(result, InvalidIndexedPropertyConstraintError);
+  //
+  //   const [error] = result.getErrors();
+  //
+  //   expect(error.getCode()).to.equal(1012);
+  //   expect(error.getPropertyName()).to.equal('mentions');
+  //   expect(error.getConstraintName()).to.equal('maxItems');
+  //   expect(error.getReason()).to.equal('should be less or equal 1024');
+  // });
 
   it('should return invalid result if indexed byte array property missing maxItems constraint', async () => {
     delete rawDataContract.documents.withByteArrays.properties.byteArrayField.maxItems;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
In order to be consistent with current rs-drive implementation we need to forbid using indexes for array properties

## What was done?
<!--- Describe your changes in detail -->
Removed array index support from validateDataContract

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
With tests

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
Array properties cannot be indexed anymore

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
