### PR TITLE
feat: allow using Document and Identifier for `startAt` and `startAfter` in document query

### DIFF
--- a/packages/js-dash-sdk/src/SDK/Client/Platform/methods/documents/get.spec.ts
+++ b/packages/js-dash-sdk/src/SDK/Client/Platform/methods/documents/get.spec.ts
@@ -103,6 +103,24 @@ describe('Client - Platform - Documents - .get()', () => {
     ]);
   });
 
+  it('should convert string to identifiers inside where condition for "startAt" and "startAfter"', async () => {
+    const [docA, docB] = getDocumentsFixture();
+
+    await get.call(platform, 'app.withByteArrays', {
+      startAt: docA.getId().toString('base58'),
+      startAfter: docB.getId().toString('base58'),
+    });
+
+    expect(getDocumentsMock.getCall(0).args).to.have.deep.members([
+      appDefinition.contractId,
+      'withByteArrays',
+      {
+        startAt: docA.getId(),
+        startAfter: docB.getId(),
+      },
+    ]);
+  });
+
   it('should convert nested identifier properties inside where condition if `elementMatch` is used', async () => {
     const id = generateRandomIdentifier();
 

--- a/packages/js-dash-sdk/src/SDK/Client/Platform/methods/documents/get.spec.ts
+++ b/packages/js-dash-sdk/src/SDK/Client/Platform/methods/documents/get.spec.ts
@@ -1,6 +1,7 @@
 import getDataContractFixture from '@dashevo/dpp/lib/test/fixtures/getDataContractFixture';
 import generateRandomIdentifier from '@dashevo/dpp/lib/test/utils/generateRandomIdentifier';
 import createDPPMock from '@dashevo/dpp/lib/test/mocks/createDPPMock';
+import getDocumentsFixture from '@dashevo/dpp/lib/test/fixtures/getDocumentsFixture';
 import getResponseMetadataFixture from '../../../../../test/fixtures/getResponseMetadataFixture';
 const GetDocumentsResponse = require("@dashevo/dapi-client/lib/methods/platform/getDocuments/GetDocumentsResponse");
 
@@ -80,6 +81,24 @@ describe('Client - Platform - Documents - .get()', () => {
           ['$id', '==', id],
           ['$ownerId', '==', ownerId],
         ],
+      },
+    ]);
+  });
+
+  it('should convert Document to identifiers inside where condition for "startAt" and "startAfter"', async () => {
+    const [docA, docB] = getDocumentsFixture();
+
+    await get.call(platform, 'app.withByteArrays', {
+      startAt: docA,
+      startAfter: docB,
+    });
+
+    expect(getDocumentsMock.getCall(0).args).to.have.deep.members([
+      appDefinition.contractId,
+      'withByteArrays',
+      {
+        startAt: docA.getId(),
+        startAfter: docB.getId(),
       },
     ]);
   });

--- a/packages/js-dash-sdk/src/SDK/Client/Platform/methods/documents/get.ts
+++ b/packages/js-dash-sdk/src/SDK/Client/Platform/methods/documents/get.ts
@@ -1,5 +1,6 @@
 import Identifier from '@dashevo/dpp/lib/Identifier';
 import Metadata from "@dashevo/dpp/lib/Metadata";
+import Document from '@dashevo/dpp/lib/document/Document';
 
 import {Platform} from "../../Platform";
 
@@ -14,8 +15,8 @@ declare interface fetchOpts {
     where?: WhereCondition[];
     orderBy?: OrderByCondition[];
     limit?: number;
-    startAt?: number;
-    startAfter?: number;
+    startAt?: number|Document|Identifier;
+    startAfter?: number|Document|Identifier;
 }
 
 type OrderByCondition = [
@@ -119,6 +120,14 @@ export async function get(this: Platform, typeLocator: string, opts: fetchOpts):
         const binaryProperties = appDefinition.contract.getBinaryProperties(fieldType);
 
         opts.where = opts.where.map((whereCondition) => convertIdentifierProperties(whereCondition, binaryProperties));
+    }
+
+    if (opts.startAt instanceof Document) {
+      opts.startAt = opts.startAt.getId();
+    }
+
+    if (opts.startAfter instanceof Document) {
+      opts.startAt = opts.startAfter.getId();
     }
 
     // @ts-ignore

--- a/packages/js-dash-sdk/src/SDK/Client/Platform/methods/documents/get.ts
+++ b/packages/js-dash-sdk/src/SDK/Client/Platform/methods/documents/get.ts
@@ -15,8 +15,8 @@ declare interface fetchOpts {
     where?: WhereCondition[];
     orderBy?: OrderByCondition[];
     limit?: number;
-    startAt?: number|Document|Identifier;
-    startAfter?: number|Document|Identifier;
+    startAt?: number|string|Buffer|Document|Identifier;
+    startAfter?: number|string|Buffer|Document|Identifier;
 }
 
 type OrderByCondition = [
@@ -124,10 +124,14 @@ export async function get(this: Platform, typeLocator: string, opts: fetchOpts):
 
     if (opts.startAt instanceof Document) {
       opts.startAt = opts.startAt.getId();
+    } else if (typeof opts.startAt === 'string') {
+      opts.startAt = Identifier.from(opts.startAt);
     }
 
     if (opts.startAfter instanceof Document) {
       opts.startAt = opts.startAfter.getId();
+    } else if (typeof opts.startAfter === 'string') {
+      opts.startAfter = Identifier.from(opts.startAfter);
     }
 
     // @ts-ignore

--- a/packages/js-drive/lib/document/query/jsonSchema.js
+++ b/packages/js-drive/lib/document/query/jsonSchema.js
@@ -149,16 +149,32 @@ module.exports = {
       maxItems: 2,
     },
     startAfter: {
-      type: 'number',
-      minimum: 1,
-      maximum: 20000,
-      multipleOf: 1.0,
+      oneOf: [
+        {
+          type: 'number',
+          minimum: 1,
+          maximum: 20000,
+          multipleOf: 1.0,
+        },
+        {
+          type: 'object',
+          instanceof: 'Buffer',
+        },
+      ],
     },
     startAt: {
-      type: 'number',
-      minimum: 1,
-      maximum: 20000,
-      multipleOf: 1.0,
+      oneOf: [
+        {
+          type: 'number',
+          minimum: 1,
+          maximum: 20000,
+          multipleOf: 1.0,
+        },
+        {
+          type: 'object',
+          instanceof: 'Buffer',
+        },
+      ],
     },
   },
   dependentSchemas: {

--- a/packages/js-drive/test/unit/document/query/validateQueryFactory.spec.js
+++ b/packages/js-drive/test/unit/document/query/validateQueryFactory.spec.js
@@ -1,3 +1,4 @@
+const generateRandomIdentifier = require('@dashevo/dpp/lib/test/utils/generateRandomIdentifier');
 const validateQueryFactory = require('../../../../lib/document/query/validateQueryFactory');
 const ValidationResult = require('../../../../lib/document/query/ValidationResult');
 
@@ -143,15 +144,21 @@ const validOrderByOperators = {
 
 describe('validateQueryFactory', () => {
   let findConflictingConditionsStub;
+  let findAppropriateIndexStub;
+  let sortWhereClausesAccordingToIndexStub;
   let validateQuery;
   let documentSchema;
 
   beforeEach(function beforeEach() {
     findConflictingConditionsStub = this.sinon.stub().returns([]);
+    findAppropriateIndexStub = this.sinon.stub().returns({});
+    sortWhereClausesAccordingToIndexStub = this.sinon.stub().returns([]);
     documentSchema = {};
 
     validateQuery = validateQueryFactory(
       findConflictingConditionsStub,
+      findAppropriateIndexStub,
+      sortWhereClausesAccordingToIndexStub,
     );
   });
 
@@ -273,6 +280,8 @@ describe('validateQueryFactory', () => {
         });
 
         it('should return invalid result if property is not specified in document indices', () => {
+          findAppropriateIndexStub.returns(null);
+
           const result = validateQuery({ where: [['a', '==', '1']] }, documentSchema);
 
           expect(result).to.be.instanceOf(ValidationResult);
@@ -1641,6 +1650,18 @@ describe('validateQueryFactory', () => {
       expect(result.errors[0].keyword).to.be.equal('multipleOf');
       expect(result.errors[0].params.multipleOf).to.be.equal(1);
     });
+
+    it('should return valid result if "startAt" is an Identifier', () => {
+      const result = validateQuery(
+        {
+          startAt: generateRandomIdentifier(),
+        },
+        documentSchema,
+      );
+
+      expect(result).to.be.instanceOf(ValidationResult);
+      expect(result.isValid()).to.be.true();
+    });
   });
 
   describe('startAfter', () => {
@@ -1735,6 +1756,18 @@ describe('validateQueryFactory', () => {
       expect(result.errors[0].instancePath).to.be.equal('/startAfter');
       expect(result.errors[0].keyword).to.be.equal('multipleOf');
       expect(result.errors[0].params.multipleOf).to.be.equal(1);
+    });
+
+    it('should return valid result if "startAfter" is an Identifier', () => {
+      const result = validateQuery(
+        {
+          startAfter: generateRandomIdentifier(),
+        },
+        documentSchema,
+      );
+
+      expect(result).to.be.instanceOf(ValidationResult);
+      expect(result.isValid()).to.be.true();
     });
   });
 });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Allowing to use `Document` and `Identifier` in document queries as a `startAt` and `startAfter` parameter. This is done to make queries easier to work with.

## What was done?
<!--- Describe your changes in detail -->
- updated `get` method in `SDK`
- updated query validation in `Drive`

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Unit tests.

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
None.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
