### PR TITLE
feat(dashmate): add an ability to configure node subnet mask

### DIFF
--- a/packages/dashmate/configs/migrations.js
+++ b/packages/dashmate/configs/migrations.js
@@ -305,6 +305,12 @@ module.exports = {
         }
       });
 
+    // Update docker subnet settings
+    configFile.base.docker = systemConfigs.base.docker;
+    configFile.local.docker = systemConfigs.local.docker;
+    configFile.testnet.docker = systemConfigs.testnet.docker;
+    configFile.mainnet.docker = systemConfigs.mainnet.docker;
+
     // Update contracts
     configFile.configs.testnet.platform.drive.tenderdash.genesis = systemConfigs.testnet.platform
       .drive.tenderdash.genesis;

--- a/packages/dashmate/configs/migrations.js
+++ b/packages/dashmate/configs/migrations.js
@@ -304,11 +304,7 @@ module.exports = {
             .masternodeRewardShares;
         }
 
-        if (config.group === 'local') {
-          config.docker = systemConfigs.local.docker;
-        } else {
-          config.docker = systemConfigs.base.docker;
-        }
+        config.docker = systemConfigs[config.group || 'base'].docker;
       });
 
     // Update docker subnet settings

--- a/packages/dashmate/configs/migrations.js
+++ b/packages/dashmate/configs/migrations.js
@@ -303,11 +303,16 @@ module.exports = {
           config.platform.masternodeRewardShares = systemConfigs.base.platform
             .masternodeRewardShares;
         }
+
+        if (config.group === 'local') {
+          config.docker = systemConfigs.local.docker;
+        } else {
+          config.docker = systemConfigs.base.docker;
+        }
       });
 
     // Update docker subnet settings
     configFile.base.docker = systemConfigs.base.docker;
-    configFile.local.docker = systemConfigs.local.docker;
     configFile.testnet.docker = systemConfigs.testnet.docker;
     configFile.mainnet.docker = systemConfigs.mainnet.docker;
 

--- a/packages/dashmate/configs/schema/configJsonSchema.js
+++ b/packages/dashmate/configs/schema/configJsonSchema.js
@@ -86,6 +86,23 @@ module.exports = {
     group: {
       type: ['string', 'null'],
     },
+    docker: {
+      type: 'object',
+      properties: {
+        network: {
+          type: 'object',
+          properties: {
+            subnet: {
+              type: 'string',
+            },
+          },
+          additionalProperties: false,
+          required: ['subnet'],
+        },
+      },
+      additionalProperties: false,
+      required: ['network'],
+    },
     core: {
       type: 'object',
       properties: {

--- a/packages/dashmate/configs/system/base.js
+++ b/packages/dashmate/configs/system/base.js
@@ -26,6 +26,11 @@ const {
 module.exports = {
   description: 'base config for use as template',
   group: null,
+  docker: {
+    network: {
+      subnet: '172.24.24.0/24',
+    },
+  },
   core: {
     docker: {
       image: 'dashpay/dashd:0.17',

--- a/packages/dashmate/configs/system/base.js
+++ b/packages/dashmate/configs/system/base.js
@@ -26,11 +26,6 @@ const {
 module.exports = {
   description: 'base config for use as template',
   group: null,
-  docker: {
-    network: {
-      subnet: '172.24.24.0/24',
-    },
-  },
   core: {
     docker: {
       image: 'dashpay/dashd:0.17',

--- a/packages/dashmate/configs/system/local.js
+++ b/packages/dashmate/configs/system/local.js
@@ -8,6 +8,11 @@ const baseConfig = require('./base');
 
 module.exports = lodashMerge({}, baseConfig, {
   description: 'template for local configs',
+  docker: {
+    network: {
+      subnet: '172.24.24.0/24',
+    },
+  },
   platform: {
     dapi: {
       envoy: {

--- a/packages/dashmate/configs/system/mainnet.js
+++ b/packages/dashmate/configs/system/mainnet.js
@@ -8,6 +8,11 @@ const baseConfig = require('./base');
 
 const mainnetConfig = lodashMerge({}, baseConfig, {
   description: 'node with mainnet configuration',
+  docker: {
+    network: {
+      subnet: '172.26.24.0/24',
+    },
+  },
   core: {
     p2p: {
       port: 9999,

--- a/packages/dashmate/configs/system/testnet.js
+++ b/packages/dashmate/configs/system/testnet.js
@@ -10,6 +10,11 @@ const baseConfig = require('./base');
 
 module.exports = lodashMerge({}, baseConfig, {
   description: 'node with testnet configuration',
+  docker: {
+    network: {
+      subnet: '172.25.24.0/24',
+    },
+  },
   core: {
     p2p: {
       port: 19999,

--- a/packages/dashmate/docker-compose.yml
+++ b/packages/dashmate/docker-compose.yml
@@ -19,5 +19,6 @@ volumes:
 
 networks:
   default:
-    external:
-      name: dash_test_network
+    ipam:
+      config:
+        - subnet: ${DOCKER_NETWORK_SUBNET:?err}

--- a/packages/dashmate/docker-compose.yml
+++ b/packages/dashmate/docker-compose.yml
@@ -16,3 +16,8 @@ services:
 
 volumes:
   core_data:
+
+networks:
+  default:
+    external:
+      name: dash_test_network

--- a/packages/dashmate/src/commands/setup.js
+++ b/packages/dashmate/src/commands/setup.js
@@ -76,16 +76,23 @@ class SetupCommand extends BaseCommand {
       },
       {
         task: async (ctx) => {
-          await docker.createNetwork({
-            Name: 'dash_test_network',
-            IPAM: {
-              Config: [
-                {
-                  Subnet: '172.24.24.0/24',
-                },
-              ],
-            },
-          });
+          const dashLocalNetworkName = 'dash_test_network';
+
+          const dashLocalNetwork = (await docker.listNetworks())
+            .find(({ Name }) => Name === dashLocalNetworkName);
+
+          if (!dashLocalNetwork) {
+            await docker.createNetwork({
+              Name: dashLocalNetworkName,
+              IPAM: {
+                Config: [
+                  {
+                    Subnet: '172.24.24.0/24',
+                  },
+                ],
+              },
+            });
+          }
 
           if (ctx.preset === PRESET_LOCAL) {
             return setupLocalPresetTask();

--- a/packages/dashmate/src/commands/setup.js
+++ b/packages/dashmate/src/commands/setup.js
@@ -73,7 +73,7 @@ class SetupCommand extends BaseCommand {
         },
       },
       {
-        task: async (ctx) => {
+        task: (ctx) => {
           if (ctx.preset === PRESET_LOCAL) {
             return setupLocalPresetTask();
           }

--- a/packages/dashmate/src/commands/setup.js
+++ b/packages/dashmate/src/commands/setup.js
@@ -21,6 +21,7 @@ class SetupCommand extends BaseCommand {
    * @param {generateBlsKeys} generateBlsKeys
    * @param {setupLocalPresetTask} setupLocalPresetTask
    * @param {setupRegularPresetTask} setupRegularPresetTask
+   * @param {Docker} docker
    * @return {Promise<void>}
    */
   async runWithDependencies(
@@ -40,6 +41,7 @@ class SetupCommand extends BaseCommand {
     generateBlsKeys,
     setupLocalPresetTask,
     setupRegularPresetTask,
+    docker,
   ) {
     if (preset === PRESET_LOCAL) {
       if (nodeType === undefined) {
@@ -73,7 +75,18 @@ class SetupCommand extends BaseCommand {
         },
       },
       {
-        task: (ctx) => {
+        task: async (ctx) => {
+          await docker.createNetwork({
+            Name: 'dash_test_network',
+            IPAM: {
+              Config: [
+                {
+                  Subnet: '172.24.24.0/24',
+                },
+              ],
+            },
+          });
+
           if (ctx.preset === PRESET_LOCAL) {
             return setupLocalPresetTask();
           }

--- a/packages/dashmate/src/commands/setup.js
+++ b/packages/dashmate/src/commands/setup.js
@@ -21,7 +21,6 @@ class SetupCommand extends BaseCommand {
    * @param {generateBlsKeys} generateBlsKeys
    * @param {setupLocalPresetTask} setupLocalPresetTask
    * @param {setupRegularPresetTask} setupRegularPresetTask
-   * @param {Docker} docker
    * @return {Promise<void>}
    */
   async runWithDependencies(
@@ -41,7 +40,6 @@ class SetupCommand extends BaseCommand {
     generateBlsKeys,
     setupLocalPresetTask,
     setupRegularPresetTask,
-    docker,
   ) {
     if (preset === PRESET_LOCAL) {
       if (nodeType === undefined) {
@@ -76,24 +74,6 @@ class SetupCommand extends BaseCommand {
       },
       {
         task: async (ctx) => {
-          const dashLocalNetworkName = 'dash_test_network';
-
-          const dashLocalNetwork = (await docker.listNetworks())
-            .find(({ Name }) => Name === dashLocalNetworkName);
-
-          if (!dashLocalNetwork) {
-            await docker.createNetwork({
-              Name: dashLocalNetworkName,
-              IPAM: {
-                Config: [
-                  {
-                    Subnet: '172.24.24.0/24',
-                  },
-                ],
-              },
-            });
-          }
-
           if (ctx.preset === PRESET_LOCAL) {
             return setupLocalPresetTask();
           }

--- a/packages/dashmate/src/listr/tasks/setup/setupLocalPresetTaskFactory.js
+++ b/packages/dashmate/src/listr/tasks/setup/setupLocalPresetTaskFactory.js
@@ -141,6 +141,8 @@ function setupLocalPresetTaskFactory(
                 config.set('core.rpc.port', 20002 + (i * 100));
                 config.set('externalIp', hostDockerInternalIp);
 
+                config.set('docker.network.subnet', `172.24.${nodeIndex}.0/24`);
+
                 // Setup Core debug logs
                 if (ctx.debugLogs) {
                   config.set('core.debug', 1);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Under linux running a VPN service network could not be created due to IPv4 address conflicts. This PR aims to add an ability to specify subnet mask for a default Docker network for each node.

## What was done?
<!--- Describe your changes in detail -->
- updated `docker-compose.yml` to use env variable for default network subnet
- updated config templates

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Local setup

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
