### PR TITLE
fix(dpp): Identity public key `readOnly` is `undefined`

### DIFF
--- a/packages/js-dpp/lib/identity/IdentityFactory.js
+++ b/packages/js-dpp/lib/identity/IdentityFactory.js
@@ -47,6 +47,7 @@ class IdentityFactory {
             ? IdentityPublicKey.SECURITY_LEVELS.CRITICAL : publicKey.securityLevel,
           // Copy data buffer
           data: publicKey.key.toBuffer(),
+          readOnly: Boolean(publicKey.readOnly),
         };
 
         if (publicKey.readOnly) {

--- a/packages/js-dpp/lib/test/fixtures/getIdentityFixture.js
+++ b/packages/js-dpp/lib/test/fixtures/getIdentityFixture.js
@@ -23,6 +23,7 @@ module.exports = function getIdentityFixture() {
         data: Buffer.from('AuryIuMtRrl/VviQuyLD1l4nmxi9ogPzC9LT7tdpo0di', 'base64'),
         purpose: IdentityPublicKey.PURPOSES.AUTHENTICATION,
         securityLevel: IdentityPublicKey.SECURITY_LEVELS.MASTER,
+        readOnly: false,
       },
       {
         id: 1,
@@ -30,6 +31,7 @@ module.exports = function getIdentityFixture() {
         data: Buffer.from('A8AK95PYMVX5VQKzOhcVQRCUbc9pyg3RiL7jttEMDU+L', 'base64'),
         purpose: IdentityPublicKey.PURPOSES.ENCRYPTION,
         securityLevel: IdentityPublicKey.SECURITY_LEVELS.MEDIUM,
+        readOnly: false,
       },
     ],
   };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Upon creation of `Identity` it's public keys `readOnly` flags was set to `undefined` instead of `false`

## What was done?
<!--- Describe your changes in detail -->
- updated `IdentityFactory`
- updated fixtures

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Unit tests

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
