### PR TITLE
fix(dashmate): `rimraf` module could not remove config directory

### DIFF
--- a/.pnp.cjs
+++ b/.pnp.cjs
@@ -7526,7 +7526,6 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["pretty-bytes", "npm:5.6.0"],
             ["pretty-ms", "npm:7.0.1"],
             ["public-ip", "npm:4.0.4"],
-            ["rimraf", "npm:3.0.2"],
             ["rxjs", "npm:6.6.7"],
             ["semver", "npm:7.3.5"],
             ["strip-ansi", "npm:6.0.1"],

--- a/packages/dashmate/package.json
+++ b/packages/dashmate/package.json
@@ -82,7 +82,6 @@
     "pretty-bytes": "^5.3.0",
     "pretty-ms": "^7.0.0",
     "public-ip": "^4.0.1",
-    "rimraf": "^3.0.2",
     "rxjs": "^6.6.7",
     "semver": "^7.3.2",
     "strip-ansi": "^6.0.1",

--- a/packages/dashmate/src/templates/writeServiceConfigsFactory.js
+++ b/packages/dashmate/src/templates/writeServiceConfigsFactory.js
@@ -21,7 +21,7 @@ function writeServiceConfigsFactory() {
     const configDir = path.join(HOME_DIR_PATH, configName);
 
     if (fs.existsSync(configDir)) {
-      fs.rmdirSync(configDir, { recursive: true });
+      fs.rmSync(configDir, { recursive: true, force: true });
     }
 
     for (const filePath of Object.keys(configFiles)) {

--- a/packages/dashmate/src/templates/writeServiceConfigsFactory.js
+++ b/packages/dashmate/src/templates/writeServiceConfigsFactory.js
@@ -20,7 +20,9 @@ function writeServiceConfigsFactory() {
     // Drop all files from configs directory
     const configDir = path.join(HOME_DIR_PATH, configName);
 
-    fs.rmdirSync(configDir, { recursive: true });
+    if (fs.existsSync(configDir) && fs.lstatSync(configDir).isDirectory()) {
+      fs.rmdirSync(configDir, { recursive: true });
+    }
 
     for (const filePath of Object.keys(configFiles)) {
       const absoluteFilePath = path.join(configDir, filePath);

--- a/packages/dashmate/src/templates/writeServiceConfigsFactory.js
+++ b/packages/dashmate/src/templates/writeServiceConfigsFactory.js
@@ -20,7 +20,7 @@ function writeServiceConfigsFactory() {
     // Drop all files from configs directory
     const configDir = path.join(HOME_DIR_PATH, configName);
 
-    if (fs.existsSync(configDir) && fs.lstatSync(configDir).isDirectory()) {
+    if (fs.existsSync(configDir)) {
       fs.rmdirSync(configDir, { recursive: true });
     }
 

--- a/packages/dashmate/src/templates/writeServiceConfigsFactory.js
+++ b/packages/dashmate/src/templates/writeServiceConfigsFactory.js
@@ -1,6 +1,5 @@
 const fs = require('fs');
 const path = require('path');
-const rimraf = require('rimraf');
 
 const { HOME_DIR_PATH } = require('../constants');
 
@@ -20,7 +19,8 @@ function writeServiceConfigsFactory() {
   function writeServiceConfigs(configName, configFiles) {
     // Drop all files from configs directory
     const configDir = path.join(HOME_DIR_PATH, configName);
-    rimraf.sync(configDir);
+
+    fs.rmdirSync(configDir, { recursive: true });
 
     for (const filePath of Object.keys(configFiles)) {
       const absoluteFilePath = path.join(configDir, filePath);

--- a/packages/dashmate/src/templates/writeServiceConfigsFactory.js
+++ b/packages/dashmate/src/templates/writeServiceConfigsFactory.js
@@ -20,9 +20,7 @@ function writeServiceConfigsFactory() {
     // Drop all files from configs directory
     const configDir = path.join(HOME_DIR_PATH, configName);
 
-    if (fs.existsSync(configDir)) {
-      fs.rmSync(configDir, { recursive: true, force: true });
-    }
+    fs.rmSync(configDir, { recursive: true, force: true });
 
     for (const filePath of Object.keys(configFiles)) {
       const absoluteFilePath = path.join(configDir, filePath);

--- a/yarn.lock
+++ b/yarn.lock
@@ -5725,7 +5725,6 @@ __metadata:
     pretty-bytes: ^5.3.0
     pretty-ms: ^7.0.0
     public-ip: ^4.0.1
-    rimraf: ^3.0.2
     rxjs: ^6.6.7
     semver: ^7.3.2
     strip-ansi: ^6.0.1


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
`rimraf` module could not remove non-empty directory during `start`, leading to:
`Error: ENOTEMPTY: directory not empty, rmdir '<userdir>/.dashmate/local_1/logs'
    Code: ENOTEMPTY`

Partially fixes [this issue](https://github.com/dashevo/platform/issues/90)

## What was done?
<!--- Describe your changes in detail -->
- used `fs.rmSync` instead

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
local setup

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
