### PR TITLE
fix: `startAt` and `startAfter` invalid decoding

### DIFF
--- a/packages/dapi/lib/grpcServer/handlers/platform/getDocumentsHandlerFactory.js
+++ b/packages/dapi/lib/grpcServer/handlers/platform/getDocumentsHandlerFactory.js
@@ -48,10 +48,10 @@ function getDocumentsHandlerFactory(driveClient) {
 
     // Where
 
-    const whereBinary = request.getWhere();
+    const whereBinary = request.getWhere_asU8();
 
     let where;
-    if (whereBinary && whereBinary.length > 0) {
+    if (whereBinary.length > 0) {
       where = cbor.decode(
         Buffer.from(whereBinary),
       );
@@ -59,10 +59,10 @@ function getDocumentsHandlerFactory(driveClient) {
 
     // Order by
 
-    const orderByBinary = request.getOrderBy();
+    const orderByBinary = request.getOrderBy_asU8();
 
     let orderBy;
-    if (orderByBinary && orderByBinary.length > 0) {
+    if (orderByBinary.length > 0) {
       orderBy = cbor.decode(
         Buffer.from(orderByBinary),
       );
@@ -70,29 +70,29 @@ function getDocumentsHandlerFactory(driveClient) {
 
     // Limit
 
-    const limitDefault = request.getLimit();
+    const limitOrDefault = request.getLimit();
 
     let limit;
-    if (limitDefault !== 0) {
-      limit = limitDefault;
+    if (limitOrDefault !== 0) {
+      limit = limitOrDefault;
     }
 
     // Start after
 
-    const startAfterDefault = request.getStartAfter();
+    const startAfterBinary = request.getStartAfter_asU8();
 
     let startAfter;
-    if (startAfterDefault) {
-      startAfter = startAfterDefault;
+    if (startAfterBinary.length > 0) {
+      startAfter = Buffer.from(startAfterBinary);
     }
 
     // Start at
 
-    const startAtDefault = request.getStartAt();
+    const startAtBinary = request.getStartAt_asU8();
 
     let startAt;
-    if (startAtDefault) {
-      startAt = startAtDefault;
+    if (startAtBinary.length > 0) {
+      startAt = Buffer.from(startAtBinary);
     }
 
     const options = {

--- a/packages/dapi/test/unit/grpcServer/handlers/platform/getDocumentsHandlerFactory.js
+++ b/packages/dapi/test/unit/grpcServer/handlers/platform/getDocumentsHandlerFactory.js
@@ -49,17 +49,17 @@ describe('getDocumentsHandlerFactory', () => {
     where = [['name', '==', 'John']];
     orderBy = [{ order: 'asc' }];
     limit = 20;
-    startAfter = generateRandomIdentifier();
-    startAt = null;
+    startAfter = new Uint8Array(generateRandomIdentifier().toBuffer());
+    startAt = new Uint8Array([]);
 
     request = {
       getDataContractId: this.sinon.stub().returns(dataContractId),
       getDocumentType: this.sinon.stub().returns(documentType),
-      getWhere: this.sinon.stub().returns(new Uint8Array(cbor.encode(where))),
-      getOrderBy: this.sinon.stub().returns(new Uint8Array(cbor.encode(orderBy))),
+      getWhere_asU8: this.sinon.stub().returns(new Uint8Array(cbor.encode(where))),
+      getOrderBy_asU8: this.sinon.stub().returns(new Uint8Array(cbor.encode(orderBy))),
       getLimit: this.sinon.stub().returns(limit),
-      getStartAfter: this.sinon.stub().returns(startAfter),
-      getStartAt: this.sinon.stub().returns(startAt),
+      getStartAfter_asU8: this.sinon.stub().returns(startAfter),
+      getStartAt_asU8: this.sinon.stub().returns(startAt),
       getProve: this.sinon.stub().returns(false),
     };
 
@@ -110,7 +110,7 @@ describe('getDocumentsHandlerFactory', () => {
         where,
         orderBy,
         limit,
-        startAfter,
+        startAfter: Buffer.from(startAfter),
         startAt: undefined,
       },
       false,
@@ -137,7 +137,7 @@ describe('getDocumentsHandlerFactory', () => {
         where,
         orderBy,
         limit,
-        startAfter,
+        startAfter: Buffer.from(startAfter),
         startAt: undefined,
       },
       true,

--- a/packages/js-drive/lib/abci/handlers/query/documentQueryHandlerFactory.js
+++ b/packages/js-drive/lib/abci/handlers/query/documentQueryHandlerFactory.js
@@ -38,8 +38,8 @@ function documentQueryHandlerFactory(
    * @param {string} [data.where]
    * @param {string} [data.orderBy]
    * @param {string} [data.limit]
-   * @param {string} [data.startAfter]
-   * @param {string} [data.startAt]
+   * @param {Buffer} [data.startAfter]
+   * @param {Buffer} [data.startAt]
    * @param {RequestQuery} request
    * @return {Promise<ResponseQuery>}
    */
@@ -80,8 +80,8 @@ function documentQueryHandlerFactory(
         where,
         orderBy,
         limit,
-        startAfter,
-        startAt,
+        startAfter: startAfter ? Buffer.from(startAfter) : startAfter,
+        startAt: startAt ? Buffer.from(startAt) : startAt,
       });
     } catch (e) {
       if (e instanceof InvalidQueryError) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Getting validation error if `startAt` or `startAfter` encoded as a byte array
```
{"errors": [{"name": "JsonSchemaValidationError", "instancePath": "/startAfter", "schemaPath": "#/properties/startAfter/instanceof", "keyword": "instanceof", "params": {}}]}
```

## What was done?
<!--- Describe your changes in detail -->
- Convert Uint8Array to Buffer

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
With tests

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
