### PR TITLE
feat(dpp)!: lower indexed string properties constraints

### DIFF
--- a/packages/dpns-contract/schema/dpns-contract-documents.json
+++ b/packages/dpns-contract/schema/dpns-contract-documents.json
@@ -49,9 +49,9 @@
       },
       "normalizedParentDomainName": {
         "type": "string",
-        "pattern": "^$|^[[a-z0-9][a-z0-9-\\.]{0,62}[a-z0-9]$",
+        "pattern": "^$|^[[a-z0-9][a-z0-9-\\.]{0,61}[a-z0-9]$",
         "minLength": 0,
-        "maxLength": 64,
+        "maxLength": 63,
         "description": "A full parent domain name in lowercase for case-insensitive uniqueness validation. e.g. 'dash'",
         "$comment": "Must either be equal to an existing domain or empty to create a top level domain. Only the data contract owner can create top level domains."
       },

--- a/packages/dpns-contract/schema/dpns-contract-documents.json
+++ b/packages/dpns-contract/schema/dpns-contract-documents.json
@@ -49,9 +49,9 @@
       },
       "normalizedParentDomainName": {
         "type": "string",
-        "pattern": "^$|^[[a-z0-9][a-z0-9-\\.]{0,188}[a-z0-9]$",
+        "pattern": "^$|^[[a-z0-9][a-z0-9-\\.]{0,62}[a-z0-9]$",
         "minLength": 0,
-        "maxLength": 190,
+        "maxLength": 64,
         "description": "A full parent domain name in lowercase for case-insensitive uniqueness validation. e.g. 'dash'",
         "$comment": "Must either be equal to an existing domain or empty to create a top level domain. Only the data contract owner can create top level domains."
       },

--- a/packages/js-dpp/lib/dataContract/validation/validateDataContractFactory.js
+++ b/packages/js-dpp/lib/dataContract/validation/validateDataContractFactory.js
@@ -19,8 +19,8 @@ const DuplicateIndexNameError = require('../../errors/consensus/basic/dataContra
 const allowedIndexSystemProperties = ['$ownerId', '$createdAt', '$updatedAt'];
 const notAllowedIndexProperties = ['$id'];
 
-const MAX_INDEXED_STRING_PROPERTY_LENGTH = 1024;
-const MAX_INDEXED_BYTE_ARRAY_PROPERTY_LENGTH = 4096;
+const MAX_INDEXED_STRING_PROPERTY_LENGTH = 64;
+const MAX_INDEXED_BYTE_ARRAY_PROPERTY_LENGTH = 256;
 const MAX_INDEXED_ARRAY_ITEMS = 1024;
 
 /**

--- a/packages/js-dpp/lib/dataContract/validation/validateDataContractFactory.js
+++ b/packages/js-dpp/lib/dataContract/validation/validateDataContractFactory.js
@@ -19,8 +19,8 @@ const DuplicateIndexNameError = require('../../errors/consensus/basic/dataContra
 const allowedIndexSystemProperties = ['$ownerId', '$createdAt', '$updatedAt'];
 const notAllowedIndexProperties = ['$id'];
 
-const MAX_INDEXED_STRING_PROPERTY_LENGTH = 64;
-const MAX_INDEXED_BYTE_ARRAY_PROPERTY_LENGTH = 256;
+const MAX_INDEXED_STRING_PROPERTY_LENGTH = 63;
+const MAX_INDEXED_BYTE_ARRAY_PROPERTY_LENGTH = 255;
 const MAX_INDEXED_ARRAY_ITEMS = 1024;
 
 /**

--- a/packages/js-dpp/lib/test/fixtures/getDataContractFixture.js
+++ b/packages/js-dpp/lib/test/fixtures/getDataContractFixture.js
@@ -82,11 +82,11 @@ module.exports = function getDataContractFixture(ownerId = randomOwnerId) {
       properties: {
         firstName: {
           type: 'string',
-          maxLength: 256,
+          maxLength: 64,
         },
         lastName: {
           type: 'string',
-          maxLength: 256,
+          maxLength: 64,
         },
       },
       required: ['firstName', '$createdAt', '$updatedAt', 'lastName'],
@@ -188,19 +188,19 @@ module.exports = function getDataContractFixture(ownerId = randomOwnerId) {
       properties: {
         firstName: {
           type: 'string',
-          maxLength: 256,
+          maxLength: 64,
         },
         lastName: {
           type: 'string',
-          maxLength: 256,
+          maxLength: 64,
         },
         country: {
           type: 'string',
-          maxLength: 256,
+          maxLength: 64,
         },
         city: {
           type: 'string',
-          maxLength: 256,
+          maxLength: 64,
         },
       },
       indices: [

--- a/packages/js-dpp/lib/test/fixtures/getDataContractFixture.js
+++ b/packages/js-dpp/lib/test/fixtures/getDataContractFixture.js
@@ -82,11 +82,11 @@ module.exports = function getDataContractFixture(ownerId = randomOwnerId) {
       properties: {
         firstName: {
           type: 'string',
-          maxLength: 64,
+          maxLength: 63,
         },
         lastName: {
           type: 'string',
-          maxLength: 64,
+          maxLength: 63,
         },
       },
       required: ['firstName', '$createdAt', '$updatedAt', 'lastName'],
@@ -188,19 +188,19 @@ module.exports = function getDataContractFixture(ownerId = randomOwnerId) {
       properties: {
         firstName: {
           type: 'string',
-          maxLength: 64,
+          maxLength: 63,
         },
         lastName: {
           type: 'string',
-          maxLength: 64,
+          maxLength: 63,
         },
         country: {
           type: 'string',
-          maxLength: 64,
+          maxLength: 63,
         },
         city: {
           type: 'string',
-          maxLength: 64,
+          maxLength: 63,
         },
       },
       indices: [

--- a/packages/js-dpp/test/integration/dataContract/validation/validateDataContractFactory.spec.js
+++ b/packages/js-dpp/test/integration/dataContract/validation/validateDataContractFactory.spec.js
@@ -1451,7 +1451,7 @@ describe('validateDataContractFactory', function main() {
 
           rawDataContract.documents.indexedDocument.properties[propertyName] = {
             type: 'string',
-            maxLength: 256,
+            maxLength: 64,
           };
 
           rawDataContract.documents.indexedDocument.indices.push({
@@ -1986,7 +1986,7 @@ describe('validateDataContractFactory', function main() {
     expect(error.getCode()).to.equal(1012);
     expect(error.getPropertyName()).to.equal('firstName');
     expect(error.getConstraintName()).to.equal('maxLength');
-    expect(error.getReason()).to.equal('should be less or equal 1024');
+    expect(error.getReason()).to.equal('should be less or equal 64');
   });
 
   it('should return invalid result if indexed string property have to big maxLength', async () => {
@@ -2001,7 +2001,7 @@ describe('validateDataContractFactory', function main() {
     expect(error.getCode()).to.equal(1012);
     expect(error.getPropertyName()).to.equal('firstName');
     expect(error.getConstraintName()).to.equal('maxLength');
-    expect(error.getReason()).to.equal('should be less or equal 1024');
+    expect(error.getReason()).to.equal('should be less or equal 64');
   });
 
   // it('should return invalid result if indexed array property missing maxItems constraint',
@@ -2017,7 +2017,7 @@ describe('validateDataContractFactory', function main() {
   //   expect(error.getCode()).to.equal(1012);
   //   expect(error.getPropertyName()).to.equal('mentions');
   //   expect(error.getConstraintName()).to.equal('maxItems');
-  //   expect(error.getReason()).to.equal('should be less or equal 1024');
+  //   expect(error.getReason()).to.equal('should be less or equal 64');
   // });
   //
   // it('should return invalid result if indexed array property have to big maxItems', async () => {
@@ -2032,7 +2032,7 @@ describe('validateDataContractFactory', function main() {
   //   expect(error.getCode()).to.equal(1012);
   //   expect(error.getPropertyName()).to.equal('mentions');
   //   expect(error.getConstraintName()).to.equal('maxItems');
-  //   expect(error.getReason()).to.equal('should be less or equal 1024');
+  //   expect(error.getReason()).to.equal('should be less or equal 64');
   // });
   //
   // it('should return invalid result if indexed array property
@@ -2048,7 +2048,7 @@ describe('validateDataContractFactory', function main() {
   //   expect(error.getCode()).to.equal(1012);
   //   expect(error.getPropertyName()).to.equal('mentions');
   //   expect(error.getConstraintName()).to.equal('maxItems');
-  //   expect(error.getReason()).to.equal('should be less or equal 1024');
+  //   expect(error.getReason()).to.equal('should be less or equal 64');
   // });
   //
   // it('should return invalid result if indexed array property have
@@ -2064,7 +2064,7 @@ describe('validateDataContractFactory', function main() {
   //   expect(error.getCode()).to.equal(1012);
   //   expect(error.getPropertyName()).to.equal('mentions');
   //   expect(error.getConstraintName()).to.equal('maxItems');
-  //   expect(error.getReason()).to.equal('should be less or equal 1024');
+  //   expect(error.getReason()).to.equal('should be less or equal 64');
   // });
 
   it('should return invalid result if indexed byte array property missing maxItems constraint', async () => {
@@ -2079,7 +2079,7 @@ describe('validateDataContractFactory', function main() {
     expect(error.getCode()).to.equal(1012);
     expect(error.getPropertyName()).to.equal('byteArrayField');
     expect(error.getConstraintName()).to.equal('maxItems');
-    expect(error.getReason()).to.equal('should be less or equal 4096');
+    expect(error.getReason()).to.equal('should be less or equal 256');
   });
 
   it('should return invalid result if indexed byte array property have to big maxItems', async () => {
@@ -2094,7 +2094,7 @@ describe('validateDataContractFactory', function main() {
     expect(error.getCode()).to.equal(1012);
     expect(error.getPropertyName()).to.equal('byteArrayField');
     expect(error.getConstraintName()).to.equal('maxItems');
-    expect(error.getReason()).to.equal('should be less or equal 4096');
+    expect(error.getReason()).to.equal('should be less or equal 256');
   });
 
   it('should return valid result if Data Contract is valid', async () => {

--- a/packages/js-dpp/test/integration/dataContract/validation/validateDataContractFactory.spec.js
+++ b/packages/js-dpp/test/integration/dataContract/validation/validateDataContractFactory.spec.js
@@ -1451,7 +1451,7 @@ describe('validateDataContractFactory', function main() {
 
           rawDataContract.documents.indexedDocument.properties[propertyName] = {
             type: 'string',
-            maxLength: 64,
+            maxLength: 63,
           };
 
           rawDataContract.documents.indexedDocument.indices.push({
@@ -1986,7 +1986,7 @@ describe('validateDataContractFactory', function main() {
     expect(error.getCode()).to.equal(1012);
     expect(error.getPropertyName()).to.equal('firstName');
     expect(error.getConstraintName()).to.equal('maxLength');
-    expect(error.getReason()).to.equal('should be less or equal 64');
+    expect(error.getReason()).to.equal('should be less or equal 63');
   });
 
   it('should return invalid result if indexed string property have to big maxLength', async () => {
@@ -2001,7 +2001,7 @@ describe('validateDataContractFactory', function main() {
     expect(error.getCode()).to.equal(1012);
     expect(error.getPropertyName()).to.equal('firstName');
     expect(error.getConstraintName()).to.equal('maxLength');
-    expect(error.getReason()).to.equal('should be less or equal 64');
+    expect(error.getReason()).to.equal('should be less or equal 63');
   });
 
   // it('should return invalid result if indexed array property missing maxItems constraint',
@@ -2017,7 +2017,7 @@ describe('validateDataContractFactory', function main() {
   //   expect(error.getCode()).to.equal(1012);
   //   expect(error.getPropertyName()).to.equal('mentions');
   //   expect(error.getConstraintName()).to.equal('maxItems');
-  //   expect(error.getReason()).to.equal('should be less or equal 64');
+  //   expect(error.getReason()).to.equal('should be less or equal 63');
   // });
   //
   // it('should return invalid result if indexed array property have to big maxItems', async () => {
@@ -2032,7 +2032,7 @@ describe('validateDataContractFactory', function main() {
   //   expect(error.getCode()).to.equal(1012);
   //   expect(error.getPropertyName()).to.equal('mentions');
   //   expect(error.getConstraintName()).to.equal('maxItems');
-  //   expect(error.getReason()).to.equal('should be less or equal 64');
+  //   expect(error.getReason()).to.equal('should be less or equal 63');
   // });
   //
   // it('should return invalid result if indexed array property
@@ -2048,7 +2048,7 @@ describe('validateDataContractFactory', function main() {
   //   expect(error.getCode()).to.equal(1012);
   //   expect(error.getPropertyName()).to.equal('mentions');
   //   expect(error.getConstraintName()).to.equal('maxItems');
-  //   expect(error.getReason()).to.equal('should be less or equal 64');
+  //   expect(error.getReason()).to.equal('should be less or equal 63');
   // });
   //
   // it('should return invalid result if indexed array property have
@@ -2064,7 +2064,7 @@ describe('validateDataContractFactory', function main() {
   //   expect(error.getCode()).to.equal(1012);
   //   expect(error.getPropertyName()).to.equal('mentions');
   //   expect(error.getConstraintName()).to.equal('maxItems');
-  //   expect(error.getReason()).to.equal('should be less or equal 64');
+  //   expect(error.getReason()).to.equal('should be less or equal 63');
   // });
 
   it('should return invalid result if indexed byte array property missing maxItems constraint', async () => {
@@ -2079,7 +2079,7 @@ describe('validateDataContractFactory', function main() {
     expect(error.getCode()).to.equal(1012);
     expect(error.getPropertyName()).to.equal('byteArrayField');
     expect(error.getConstraintName()).to.equal('maxItems');
-    expect(error.getReason()).to.equal('should be less or equal 256');
+    expect(error.getReason()).to.equal('should be less or equal 255');
   });
 
   it('should return invalid result if indexed byte array property have to big maxItems', async () => {
@@ -2094,7 +2094,7 @@ describe('validateDataContractFactory', function main() {
     expect(error.getCode()).to.equal(1012);
     expect(error.getPropertyName()).to.equal('byteArrayField');
     expect(error.getConstraintName()).to.equal('maxItems');
-    expect(error.getReason()).to.equal('should be less or equal 256');
+    expect(error.getReason()).to.equal('should be less or equal 255');
   });
 
   it('should return valid result if Data Contract is valid', async () => {

--- a/packages/platform-test-suite/test/functional/platform/DataContract.spec.js
+++ b/packages/platform-test-suite/test/functional/platform/DataContract.spec.js
@@ -152,11 +152,11 @@ describe('Platform', () => {
         properties: {
           firstName: {
             type: 'string',
-            maxLength: 64,
+            maxLength: 63,
           },
           lastName: {
             type: 'string',
-            maxLength: 64,
+            maxLength: 63,
           },
         },
         required: ['firstName', '$createdAt', '$updatedAt', 'lastName'],

--- a/packages/platform-test-suite/test/functional/platform/DataContract.spec.js
+++ b/packages/platform-test-suite/test/functional/platform/DataContract.spec.js
@@ -152,11 +152,11 @@ describe('Platform', () => {
         properties: {
           firstName: {
             type: 'string',
-            maxLength: 256,
+            maxLength: 64,
           },
           lastName: {
             type: 'string',
-            maxLength: 256,
+            maxLength: 64,
           },
         },
         required: ['firstName', '$createdAt', '$updatedAt', 'lastName'],


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Temporarily lowering constraints of indexed string properties due to the way how grovedb works internally.

## What was done?
<!--- Describe your changes in detail -->
- lowered constraints to `64` characters or `256` bytes

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- unit tests

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
- old contract schemas that have indexed string properties of longer length are no longer valid
- DPNS now supports only cut versions of domain names due to lower constraints

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
