### PR TITLE
feat(drive): add performance timers to measure block execution

### DIFF
--- a/packages/js-drive/lib/abci/handlers/beginBlockHandlerFactory.js
+++ b/packages/js-drive/lib/abci/handlers/beginBlockHandlerFactory.js
@@ -22,6 +22,7 @@ const NetworkProtocolVersionIsNotSetError = require('./errors/NetworkProtocolVer
  * @param {waitForChainLockedHeight} waitForChainLockedHeight
  * @param {synchronizeMasternodeIdentities} synchronizeMasternodeIdentities
  * @param {BaseLogger} logger
+ * @param {ExecutionTimer} executionTimer
  *
  * @return {beginBlockHandler}
  */
@@ -36,6 +37,7 @@ function beginBlockHandlerFactory(
   waitForChainLockedHeight,
   synchronizeMasternodeIdentities,
   logger,
+  executionTimer,
 ) {
   /**
    * @typedef beginBlockHandler
@@ -56,6 +58,8 @@ function beginBlockHandlerFactory(
       height: height.toString(),
       abciMethod: 'beginBlock',
     });
+
+    executionTimer.startTimer('blockExecution');
 
     consensusLogger.debug('BeginBlock ABCI method requested');
     consensusLogger.trace({ abciRequest: request });

--- a/packages/js-drive/lib/abci/handlers/beginBlockHandlerFactory.js
+++ b/packages/js-drive/lib/abci/handlers/beginBlockHandlerFactory.js
@@ -54,14 +54,6 @@ function beginBlockHandlerFactory(
       version,
     } = header;
 
-    const consensusLogger = logger.child({
-      height: height.toString(),
-      abciMethod: 'beginBlock',
-    });
-
-    consensusLogger.debug('BeginBlock ABCI method requested');
-    consensusLogger.trace({ abciRequest: request });
-
     // Start block execution timer
 
     if (executionTimer.isStarted('blockExecution')) {
@@ -69,6 +61,14 @@ function beginBlockHandlerFactory(
     }
 
     executionTimer.startTimer('blockExecution');
+
+    const consensusLogger = logger.child({
+      height: height.toString(),
+      abciMethod: 'beginBlock',
+    });
+
+    consensusLogger.debug('BeginBlock ABCI method requested');
+    consensusLogger.trace({ abciRequest: request });
 
     // Validate protocol version
 

--- a/packages/js-drive/lib/abci/handlers/commitHandlerFactory.js
+++ b/packages/js-drive/lib/abci/handlers/commitHandlerFactory.js
@@ -101,7 +101,7 @@ function commitHandlerFactory(
       {
         timings: blockExecutionTimings,
       },
-      `Block #${blockHeight} execution took ${blockExecutionTimings.seconds} seconds and ${blockExecutionTimings.nanoseconds} nanoseconds`,
+      `Block #${blockHeight} execution took ${blockExecutionTimings.seconds} seconds`,
     );
 
     return new ResponseCommit({

--- a/packages/js-drive/lib/abci/handlers/commitHandlerFactory.js
+++ b/packages/js-drive/lib/abci/handlers/commitHandlerFactory.js
@@ -101,7 +101,7 @@ function commitHandlerFactory(
       {
         timings: blockExecutionTimings,
       },
-      `Block #${blockHeight} execution took ${blockExecutionTimings.seconds} seconds`,
+      `Block #${blockHeight} execution took ${blockExecutionTimings} seconds`,
     );
 
     return new ResponseCommit({

--- a/packages/js-drive/lib/abci/handlers/deliverTxHandlerFactory.js
+++ b/packages/js-drive/lib/abci/handlers/deliverTxHandlerFactory.js
@@ -53,6 +53,12 @@ function deliverTxHandlerFactory(
   async function deliverTxHandler({ tx: stateTransitionByteArray }) {
     const { height: blockHeight } = blockExecutionContext.getHeader();
 
+    // Start execution timer
+
+    if (executionTimer.isStarted('deliverTx')) {
+      executionTimer.endTimer('deliverTx');
+    }
+
     executionTimer.startTimer('deliverTx');
 
     const stHash = crypto

--- a/packages/js-drive/lib/abci/handlers/deliverTxHandlerFactory.js
+++ b/packages/js-drive/lib/abci/handlers/deliverTxHandlerFactory.js
@@ -190,7 +190,7 @@ function deliverTxHandlerFactory(
         timings: deliverTxTimings,
         stateTransitionType: stateTransition.getType(),
       },
-      `${stateTransition.constructor.name} execution took ${deliverTxTimings.seconds} seconds and ${deliverTxTimings.nanoseconds} nanoseconds`,
+      `${stateTransition.constructor.name} execution took ${deliverTxTimings} seconds`,
     );
 
     return new ResponseDeliverTx();

--- a/packages/js-drive/lib/createDIContainer.js
+++ b/packages/js-drive/lib/createDIContainer.js
@@ -132,6 +132,8 @@ const splitDocumentsIntoChunks = require('./identity/masternode/splitDocumentsIn
 const registerSystemDataContractsFactory = require('./abci/handlers/state/registerSystemDataContractsFactory');
 const DocumentRepository = require('./document/DocumentRepository');
 
+const ExecutionTimer = require('./util/ExecutionTimer');
+
 const noopLoggerInstance = require('./util/noopLogger');
 
 /**
@@ -382,6 +384,8 @@ function createDIContainer(options) {
     noopLogger: asValue(noopLoggerInstance),
 
     sanitizeUrl: asValue(sanitizeUrl),
+
+    executionTimer: asClass(ExecutionTimer).singleton(),
   });
 
   /**

--- a/packages/js-drive/lib/util/ExecutionTimer.js
+++ b/packages/js-drive/lib/util/ExecutionTimer.js
@@ -27,7 +27,7 @@ class ExecutionTimer {
    *
    * @param {string} name
    *
-   * @return {{ seconds: number, nanoseconds: number }}
+   * @return {number}
    */
   endTimer(name) {
     if (!this.#isStarted(name)) {
@@ -38,10 +38,7 @@ class ExecutionTimer {
 
     delete this.timers[name];
 
-    return {
-      seconds: timings[0],
-      nanoseconds: timings[1],
-    };
+    return (parseFloat(timings[0]) + timings[1] / 1000000000).toFixed(3);
   }
 
   #isStarted(name) {

--- a/packages/js-drive/lib/util/ExecutionTimer.js
+++ b/packages/js-drive/lib/util/ExecutionTimer.js
@@ -1,0 +1,52 @@
+const process = require('process');
+
+class ExecutionTimer {
+  constructor() {
+    this.timers = {};
+  }
+
+  /**
+   * Start named timer
+   *
+   * @param {string} name
+   *
+   * @return {void}
+   */
+  startTimer(name) {
+    if (this.#isStarted(name)) {
+      throw new Error(`${name} timer is already started`);
+    }
+
+    const timer = process.hrtime();
+
+    this.timers[name] = timer;
+  }
+
+  /**
+   * End named timer and get timings
+   *
+   * @param {string} name
+   *
+   * @return {{ seconds: number, nanoseconds: number }}
+   */
+  endTimer(name) {
+    if (!this.#isStarted(name)) {
+      throw new Error(`${name} timer is not started`);
+    }
+
+    const timings = process.hrtime(this.timers[name]);
+
+    delete this.timers[name];
+
+    return {
+      seconds: timings[0],
+      nanoseconds: timings[1],
+    };
+  }
+
+  #isStarted(name) {
+    return this.timers[name] !== undefined;
+  }
+}
+
+module.exports = ExecutionTimer;

--- a/packages/js-drive/test/integration/util/ExecutionTimer.spec.js
+++ b/packages/js-drive/test/integration/util/ExecutionTimer.spec.js
@@ -1,0 +1,49 @@
+const ExecutionTimer = require('../../../lib/util/ExecutionTimer');
+const wait = require('../../../lib/util/wait');
+
+describe('ExecutionTimer', () => {
+  let timer;
+
+  beforeEach(() => {
+    timer = new ExecutionTimer();
+  });
+
+  describe('#constructor', () => {
+    it('should create an instance with empty timers', () => {
+      expect(timer.timers).to.deep.equal({});
+    });
+  });
+
+  describe('#startTimer', () => {
+    it('should throw an error if timer already started', () => {
+      timer.startTimer('some');
+
+      try {
+        timer.startTimer('some');
+        expect.fail('An error was not thrown');
+      } catch (e) {
+        expect(e.message).to.equal('some timer is already started');
+      }
+    });
+  });
+
+  describe('#endTimer', () => {
+    it('should throw an error if timer has not been started', () => {
+      try {
+        timer.endTimer('some');
+        expect.fail('An error was not thrown');
+      } catch (e) {
+        expect(e.message).to.equal('some timer is not started');
+      }
+    });
+  });
+
+  it('should measure function execution time', async () => {
+    // TODO: maybe there should be a better way to do it
+    timer.startTimer('some');
+    await wait(500);
+    const timings = timer.endTimer('some');
+
+    expect(parseInt(timings.nanoseconds / 1000 / 1000 / 100, 10)).to.equal(5);
+  });
+});

--- a/packages/js-drive/test/integration/util/ExecutionTimer.spec.js
+++ b/packages/js-drive/test/integration/util/ExecutionTimer.spec.js
@@ -38,6 +38,6 @@ describe('ExecutionTimer', () => {
     await wait(1500);
     const timings = timer.endTimer('some');
 
-    expect(parseInt(timings)).to.equal(1);
+    expect(parseInt(timings, 10)).to.equal(1);
   });
 });

--- a/packages/js-drive/test/integration/util/ExecutionTimer.spec.js
+++ b/packages/js-drive/test/integration/util/ExecutionTimer.spec.js
@@ -41,9 +41,9 @@ describe('ExecutionTimer', () => {
   it('should measure function execution time', async () => {
     // TODO: maybe there should be a better way to do it
     timer.startTimer('some');
-    await wait(500);
+    await wait(1500);
     const timings = timer.endTimer('some');
 
-    expect(parseInt(timings.nanoseconds / 1000 / 1000 / 100, 10)).to.equal(5);
+    expect(parseInt(timings)).to.equal(1);
   });
 });

--- a/packages/js-drive/test/unit/abci/handlers/beginBlockHandlerFactory.spec.js
+++ b/packages/js-drive/test/unit/abci/handlers/beginBlockHandlerFactory.spec.js
@@ -34,6 +34,7 @@ describe('beginBlockHandlerFactory', () => {
   let synchronizeMasternodeIdentitiesMock;
   let groveDBStoreMock;
   let blockExecutionContextStackMock;
+  let executionTimerMock;
 
   beforeEach(function beforeEach() {
     protocolVersion = Long.fromInt(1);
@@ -60,6 +61,11 @@ describe('beginBlockHandlerFactory', () => {
       getHeader: this.sinon.stub(),
     });
 
+    executionTimerMock = {
+      startTimer: this.sinon.stub(),
+      endTimer: this.sinon.stub(),
+    };
+
     beginBlockHandler = beginBlockHandlerFactory(
       groveDBStoreMock,
       blockExecutionContextMock,
@@ -71,6 +77,7 @@ describe('beginBlockHandlerFactory', () => {
       waitForChainLockedHeightMock,
       synchronizeMasternodeIdentitiesMock,
       loggerMock,
+      executionTimerMock,
     );
 
     blockHeight = 2;

--- a/packages/js-drive/test/unit/abci/handlers/commitHandlerFactory.spec.js
+++ b/packages/js-drive/test/unit/abci/handlers/commitHandlerFactory.spec.js
@@ -37,6 +37,7 @@ describe('commitHandlerFactory', () => {
   let blockExecutionContextStackRepositoryMock;
   let groveDBStoreMock;
   let rotateSignedStoreMock;
+  let executionTimerMock;
 
   beforeEach(function beforeEach() {
     appHash = Buffer.alloc(0);
@@ -85,6 +86,14 @@ describe('commitHandlerFactory', () => {
     groveDBStoreMock = new GroveDBStoreMock(this.sinon);
     groveDBStoreMock.getRootHash.resolves(appHash);
 
+    executionTimerMock = {
+      startTimer: this.sinon.stub(),
+      endTimer: this.sinon.stub().returns({
+        seconds: 1,
+        nanoseconds: 1,
+      }),
+    };
+
     commitHandler = commitHandlerFactory(
       creditsDistributionPoolMock,
       creditsDistributionPoolRepositoryMock,
@@ -95,6 +104,7 @@ describe('commitHandlerFactory', () => {
       loggerMock,
       dataContractCacheMock,
       groveDBStoreMock,
+      executionTimerMock,
     );
   });
 

--- a/packages/js-drive/test/unit/abci/handlers/deliverTxHandlerFactory.spec.js
+++ b/packages/js-drive/test/unit/abci/handlers/deliverTxHandlerFactory.spec.js
@@ -96,6 +96,7 @@ describe('deliverTxHandlerFactory', () => {
         seconds: 1,
         nanoseconds: 1,
       }),
+      isStarted: this.sinon.stub(),
     };
 
     deliverTxHandler = deliverTxHandlerFactory(

--- a/packages/js-drive/test/unit/abci/handlers/deliverTxHandlerFactory.spec.js
+++ b/packages/js-drive/test/unit/abci/handlers/deliverTxHandlerFactory.spec.js
@@ -40,6 +40,7 @@ describe('deliverTxHandlerFactory', () => {
   let unserializeStateTransitionMock;
   let blockExecutionContextMock;
   let validationResult;
+  let executionTimerMock;
 
   beforeEach(async function beforeEach() {
     const dataContractFixture = getDataContractFixture();
@@ -89,11 +90,20 @@ describe('deliverTxHandlerFactory', () => {
 
     const loggerMock = new LoggerMock(this.sinon);
 
+    executionTimerMock = {
+      startTimer: this.sinon.stub(),
+      endTimer: this.sinon.stub().returns({
+        seconds: 1,
+        nanoseconds: 1,
+      }),
+    };
+
     deliverTxHandler = deliverTxHandlerFactory(
       unserializeStateTransitionMock,
       dppMock,
       blockExecutionContextMock,
       loggerMock,
+      executionTimerMock,
     );
   });
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Added timers for various block execution points, so we later can track bottlenecks in it.

## What was done?
<!--- Describe your changes in detail -->
- implemented basic execution timer using `process.hrtime`
- updated `beginBlock`, `deliverTx`, and `commit` handlers

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Integration tests
- local run

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
None.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
