### PR TITLE
chore: removed unused dependency (node-merk)

### DIFF
--- a/packages/platform-test-suite/package.json
+++ b/packages/platform-test-suite/package.json
@@ -27,7 +27,6 @@
     "@dashevo/feature-flags-contract": "workspace:~",
     "@dashevo/grpc-common": "workspace:~",
     "@dashevo/masternode-reward-shares-contract": "workspace:~",
-    "@dashevo/merk": "github:dashevo/node-merk#eb37003300d22c6c04604463bcd7e861dd07000f",
     "@dashevo/wallet-lib": "workspace:~",
     "assert-browserify": "^2.0.0",
     "blake3": "^2.1.4",


### PR DESCRIPTION
Removed unused dependency in the `platform-test-suite` package

## Issue being fixed or feature implemented
The `@dashevo/node-merk` package is [no longer in use](https://discord.com/channels/@me/883274884078272522/951796796701687848) from v0.22, and has been replaced with the `@dashevo/rs-drive` package. However, it is still a dependency in `platform-test-suite`, causing issues when installing test suite.


## What was done?
Removed the `@dashevo/node-merk` package which is [no longer in use](https://discord.com/channels/@me/883274884078272522/951796796701687848), as requested [here](https://discord.com/channels/@me/883274884078272522/951852418042302464).


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
