### PR TITLE
feat(dpp): temporarily disable $refs in data contract definitions

### DIFF
--- a/packages/js-dpp/lib/test/fixtures/getDataContractFixture.js
+++ b/packages/js-dpp/lib/test/fixtures/getDataContractFixture.js
@@ -28,7 +28,7 @@ module.exports = function getDataContractFixture(ownerId = randomOwnerId) {
       type: 'object',
       properties: {
         lastName: {
-          $ref: '#/$defs/lastName',
+          type: 'string',
         },
       },
       required: ['lastName', '$updatedAt'],
@@ -238,11 +238,11 @@ module.exports = function getDataContractFixture(ownerId = randomOwnerId) {
 
   const dataContract = factory.create(ownerId, documents);
 
-  dataContract.setDefinitions({
-    lastName: {
-      type: 'string',
-    },
-  });
+  // dataContract.setDefinitions({
+  //   lastName: {
+  //     type: 'string',
+  //   },
+  // });
 
   return dataContract;
 };

--- a/packages/js-dpp/schema/dataContract/dataContractMeta.json
+++ b/packages/js-dpp/schema/dataContract/dataContractMeta.json
@@ -43,11 +43,6 @@
           "pattern": "^#",
           "minLength": 1
         },
-        "$ref": {
-          "type": "string",
-          "pattern": "^#",
-          "minLength": 1
-        },
         "$comment": {
           "$ref": "https://json-schema.org/draft/2020-12/meta/core#/properties/$comment"
         },

--- a/packages/js-dpp/test/integration/dataContract/validation/validateDataContractFactory.spec.js
+++ b/packages/js-dpp/test/integration/dataContract/validation/validateDataContractFactory.spec.js
@@ -357,6 +357,7 @@ describe('validateDataContractFactory', function main() {
       const validNames = ['validName', 'valid_name', 'valid-name', 'abc', 'ab12c', 'abc123', 'ValidName',
         'abcdefghigklmnopqrstuvwxyz01234567890abcdefghigklmnopqrstuvwxyz', 'abc_gbf_gdb', 'abc-gbf-gdb'];
 
+      rawDataContract.$defs = {};
       await Promise.all(
         validNames.map(async (name) => {
           rawDataContract.$defs[name] = {
@@ -373,6 +374,7 @@ describe('validateDataContractFactory', function main() {
     it('should return an invalid result if a property has invalid format', async () => {
       const invalidNames = ['-invalidname', '_invalidname', 'invalidname-', 'invalidname_', '*(*&^', '$test', '123abci', 'ab'];
 
+      rawDataContract.$defs = {};
       await Promise.all(
         invalidNames.map(async (name) => {
           rawDataContract.$defs[name] = {
@@ -856,7 +858,7 @@ describe('validateDataContractFactory', function main() {
         expect(error.getKeyword()).to.equal('unevaluatedProperties');
       });
 
-      it('should return invalid result if remote `$ref` is used', async () => {
+      it.skip('should return invalid result if remote `$ref` is used', async () => {
         rawDataContract.documents.indexedDocument = {
           $ref: 'http://remote.com/schema#',
         };
@@ -1960,7 +1962,7 @@ describe('validateDataContractFactory', function main() {
     });
   });
 
-  it('should return invalid result with circular $ref pointer', async () => {
+  it.skip('should return invalid result with circular $ref pointer', async () => {
     rawDataContract.$defs.object = { $ref: '#/$defs/object' };
 
     const result = await validateDataContract(rawDataContract);

--- a/packages/js-dpp/test/unit/dataContract/DataContractFactory.spec.js
+++ b/packages/js-dpp/test/unit/dataContract/DataContractFactory.spec.js
@@ -62,7 +62,7 @@ describe('DataContractFactory', () => {
 
       const result = await factory.createFromObject(rawDataContract);
 
-      expect(result).excluding('entropy').to.deep.equal(dataContract);
+      expect(result.toObject()).excluding('entropy').to.deep.equal(rawDataContract);
 
       expect(validateDataContractMock).to.have.been.calledOnceWith(rawDataContract);
     });
@@ -70,7 +70,7 @@ describe('DataContractFactory', () => {
     it('should return new Data Contract without validation if "skipValidation" option is passed', async () => {
       const result = await factory.createFromObject(rawDataContract, { skipValidation: true });
 
-      expect(result).excluding('entropy').to.deep.equal(dataContract);
+      expect(result.toObject()).excluding('entropy').to.deep.equal(rawDataContract);
 
       expect(validateDataContractMock).to.have.not.been.called();
     });

--- a/packages/js-drive/test/unit/blockExecution/BlockExecutionContext.spec.js
+++ b/packages/js-drive/test/unit/blockExecution/BlockExecutionContext.spec.js
@@ -232,8 +232,12 @@ describe('BlockExecutionContext', () => {
     it('should populate instance from a plain object', () => {
       blockExecutionContext.fromObject(plainObject);
 
-      expect(blockExecutionContext.dataContracts.map((dc) => dc.toObject())).to.have.deep.members(
-        [dataContract.toObject()],
+      if (blockExecutionContext.dataContracts[0].$defs === undefined) {
+        blockExecutionContext.dataContracts[0].$defs = {};
+      }
+
+      expect(blockExecutionContext.dataContracts).to.have.deep.members(
+        [dataContract],
       );
       expect(blockExecutionContext.lastCommitInfo).to.deep.equal(lastCommitInfo);
       expect(blockExecutionContext.cumulativeFees).to.equal(cumulativeFees);

--- a/packages/js-drive/test/unit/blockExecution/BlockExecutionContext.spec.js
+++ b/packages/js-drive/test/unit/blockExecution/BlockExecutionContext.spec.js
@@ -232,7 +232,7 @@ describe('BlockExecutionContext', () => {
     it('should populate instance from a plain object', () => {
       blockExecutionContext.fromObject(plainObject);
 
-      expect(blockExecutionContext.dataContracts).to.deep.equal([dataContract]);
+      expect(blockExecutionContext.dataContracts.map((dc) => dc.toObject())).to.have.deep.members([dataContract.toObject()]);
       expect(blockExecutionContext.lastCommitInfo).to.deep.equal(lastCommitInfo);
       expect(blockExecutionContext.cumulativeFees).to.equal(cumulativeFees);
       expect(blockExecutionContext.header).to.deep.equal(header);

--- a/packages/js-drive/test/unit/blockExecution/BlockExecutionContext.spec.js
+++ b/packages/js-drive/test/unit/blockExecution/BlockExecutionContext.spec.js
@@ -232,7 +232,9 @@ describe('BlockExecutionContext', () => {
     it('should populate instance from a plain object', () => {
       blockExecutionContext.fromObject(plainObject);
 
-      expect(blockExecutionContext.dataContracts.map((dc) => dc.toObject())).to.have.deep.members([dataContract.toObject()]);
+      expect(blockExecutionContext.dataContracts.map((dc) => dc.toObject())).to.have.deep.members(
+        [dataContract.toObject()],
+      );
       expect(blockExecutionContext.lastCommitInfo).to.deep.equal(lastCommitInfo);
       expect(blockExecutionContext.cumulativeFees).to.equal(cumulativeFees);
       expect(blockExecutionContext.header).to.deep.equal(header);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
As `GroveDB` not supporting $refs at the moment, they are disabled in `dpp` for now.

## What was done?
<!--- Describe your changes in detail -->
- removed `$ref` definition in data contract meta schema

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Units and integration tests.

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
- `$ref` in data contract definitions are not supported for now

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
