### PR TITLE
test: fixes of sdk and platform test suite

### DIFF
--- a/packages/platform-test-suite/karma.conf.js
+++ b/packages/platform-test-suite/karma.conf.js
@@ -17,6 +17,7 @@ module.exports = (config) => {
     client: {
       mocha: {
         timeout: 650000,
+        bail: true,
       },
     },
     browserNoActivityTimeout: 900000,
@@ -61,7 +62,7 @@ module.exports = (config) => {
           bufferutil: require.resolve('bufferutil/'),
           tls: require.resolve('tls/'),
           net: require.resolve('net/'),
-          ['utf-8-validate']: require.resolve('utf-8-validate/'),
+          'utf-8-validate': require.resolve('utf-8-validate/'),
           string_decoder: require.resolve('string_decoder/'),
         },
         extensions: ['.ts', '.js', '.json'],

--- a/packages/platform-test-suite/test/e2e/wallet.spec.js
+++ b/packages/platform-test-suite/test/e2e/wallet.spec.js
@@ -25,17 +25,18 @@ describe('e2e', () => {
 
     before(async () => {
       fundedWallet = await createClientWithFundedWallet();
+      const network = process.env.NETWORK;
       emptyWallet = new Dash.Client({
         seeds: getDAPISeeds(),
-        network: process.env.NETWORK,
+        network,
         wallet: {
           waitForInstantLockTimeout: 120000,
         },
       });
 
       mnemonic = emptyWallet.wallet.exportWallet();
-      emptyWalletHeight = fundedWallet
-        .wallet.storage.store.chains[fundedWallet.network].blockHeight;
+      const { storage } = fundedWallet.wallet;
+      emptyWalletHeight = storage.store.chains[storage.network].blockHeight;
     });
 
     // Skip test if any prior test in this describe failed

--- a/packages/platform-test-suite/test/e2e/wallet.spec.js
+++ b/packages/platform-test-suite/test/e2e/wallet.spec.js
@@ -148,11 +148,13 @@ describe('e2e', () => {
 
     describe('empty wallet', () => {
       it('should receive a transaction when as it has been sent to restored wallet', async () => {
-        const transactionIds = Object.keys(emptyAccount.getTransactions());
+        let transactionIds = Object.keys(emptyAccount.getTransactions());
 
         if (transactionIds.length < 2) {
           await waitForBalanceToChange(emptyAccount);
         }
+
+        transactionIds = Object.keys(emptyAccount.getTransactions());
 
         expect(transactionIds).to.have.lengthOf(2);
 

--- a/packages/platform-test-suite/test/e2e/wallet.spec.js
+++ b/packages/platform-test-suite/test/e2e/wallet.spec.js
@@ -1,7 +1,3 @@
-const {
-  Mnemonic,
-} = require('@dashevo/dashcore-lib');
-
 const Dash = require('dash');
 
 const getDAPISeeds = require('../../lib/test/getDAPISeeds');
@@ -19,6 +15,7 @@ describe('e2e', () => {
     let fundedWallet;
     let fundedAccount;
     let emptyWallet;
+    let emptyWalletHeight;
     let emptyAccount;
     let restoredWallet;
     let restoredAccount;
@@ -27,16 +24,18 @@ describe('e2e', () => {
     let secondTransaction;
 
     before(async () => {
-      mnemonic = new Mnemonic();
       fundedWallet = await createClientWithFundedWallet();
       emptyWallet = new Dash.Client({
         seeds: getDAPISeeds(),
         network: process.env.NETWORK,
         wallet: {
-          mnemonic,
           waitForInstantLockTimeout: 120000,
         },
       });
+
+      mnemonic = emptyWallet.wallet.exportWallet();
+      emptyWalletHeight = fundedWallet
+        .wallet.storage.store.chains[fundedWallet.network].blockHeight;
     });
 
     // Skip test if any prior test in this describe failed
@@ -98,6 +97,9 @@ describe('e2e', () => {
           wallet: {
             mnemonic,
             waitForInstantLockTimeout: 120000,
+            unsafeOptions: {
+              skipSynchronizationBeforeHeight: emptyWalletHeight,
+            },
           },
           seeds: getDAPISeeds(),
           network: process.env.NETWORK,
@@ -105,13 +107,17 @@ describe('e2e', () => {
 
         restoredAccount = await restoredWallet.getWalletAccount();
 
-        // Due to the limitations of DAPI, we need to wait for a block to be mined if we connected
-        // in the moment when transaction already entered the mempool, but haven't been mined yet
-        await new Promise((resolve) => restoredAccount.once(EVENTS.BLOCKHEADER, resolve));
+        let transactions = restoredAccount.getTransactions();
+
+        // Wait for new block if transaction has not been propagated yet
+        if (Object.keys(transactions).length === 0) {
+          await new Promise((resolve) => restoredAccount.once(EVENTS.BLOCKHEADER, resolve));
+          transactions = restoredAccount.getTransactions();
+        }
 
         await waitForBalanceToChange(restoredAccount);
 
-        const transactionIds = Object.keys(restoredAccount.getTransactions());
+        const transactionIds = Object.keys(transactions);
 
         expect(transactionIds).to.have.lengthOf(1);
 
@@ -141,8 +147,12 @@ describe('e2e', () => {
     });
 
     describe('empty wallet', () => {
-      it('should receive a transaction when as it has been sent to restored wallet', () => {
+      it('should receive a transaction when as it has been sent to restored wallet', async () => {
         const transactionIds = Object.keys(emptyAccount.getTransactions());
+
+        if (transactionIds.length < 2) {
+          await waitForBalanceToChange(emptyAccount);
+        }
 
         expect(transactionIds).to.have.lengthOf(2);
 

--- a/packages/platform-test-suite/test/functional/dapi/subscribeToBlockHeadersWithChainLocksHandlerFactory.spec.js
+++ b/packages/platform-test-suite/test/functional/dapi/subscribeToBlockHeadersWithChainLocksHandlerFactory.spec.js
@@ -18,7 +18,7 @@ const wait = (ms) => new Promise((resolve) => {
 const createRetryableStream = (dapiClient) => {
   const streamMediator = new EventEmitter();
 
-  const maxRetries = 5;
+  const maxRetries = 10;
   let currentRetries = 0;
 
   const createStream = async (fromBlockHeight, count = 0) => {

--- a/packages/platform-test-suite/test/functional/dapi/subscribeToBlockHeadersWithChainLocksHandlerFactory.spec.js
+++ b/packages/platform-test-suite/test/functional/dapi/subscribeToBlockHeadersWithChainLocksHandlerFactory.spec.js
@@ -6,6 +6,7 @@ const {
   ChainLock,
 } = require('@dashevo/dashcore-lib');
 
+const GrpcErrorCodes = require('@dashevo/grpc-common/lib/server/error/GrpcErrorCodes');
 const getDAPISeeds = require('../../../lib/test/getDAPISeeds');
 const createClientWithFundedWallet = require('../../../lib/test/createClientWithFundedWallet');
 
@@ -35,6 +36,11 @@ const createRetryableStream = (dapiClient) => {
     });
 
     stream.on('error', (e) => {
+      if (e.code === GrpcErrorCodes.CANCELLED) {
+        streamMediator.emit('end');
+        return;
+      }
+
       streamError = e;
       if (currentRetries === maxRetries) {
         streamMediator.emit('error', e);

--- a/packages/platform-test-suite/test/functional/dapi/subscribeToBlockHeadersWithChainLocksHandlerFactory.spec.js
+++ b/packages/platform-test-suite/test/functional/dapi/subscribeToBlockHeadersWithChainLocksHandlerFactory.spec.js
@@ -13,13 +13,12 @@ const wait = (ms) => new Promise((resolve) => {
   setTimeout(resolve, ms);
 });
 
+// TODO: disconnect funded wallet after test is complete
+
 const createRetryableStream = (dapiClient) => {
   const streamMediator = new EventEmitter();
 
-  // The stream interrupts every minutes, so 2 retries
-  // (3 minutes = 1 first subscription + 2 retries)
-  // ie enough to ensure that the block have been mined
-  const maxRetries = 2;
+  const maxRetries = 5;
   let currentRetries = 0;
 
   const createStream = async (fromBlockHeight, count = 0) => {

--- a/packages/platform-test-suite/test/functional/dapi/subscribeToBlockHeadersWithChainLocksHandlerFactory.spec.js
+++ b/packages/platform-test-suite/test/functional/dapi/subscribeToBlockHeadersWithChainLocksHandlerFactory.spec.js
@@ -28,7 +28,7 @@ const createRetryableStream = (dapiClient) => {
       },
     );
 
-    streamMediator.cancel = stream.cancel;
+    streamMediator.cancel = stream.cancel.bind(stream);
 
     stream.on('data', (data) => {
       streamMediator.emit('data', data);

--- a/packages/platform-test-suite/test/functional/dapi/subscribeToBlockHeadersWithChainLocksHandlerFactory.spec.js
+++ b/packages/platform-test-suite/test/functional/dapi/subscribeToBlockHeadersWithChainLocksHandlerFactory.spec.js
@@ -13,8 +13,6 @@ const wait = (ms) => new Promise((resolve) => {
   setTimeout(resolve, ms);
 });
 
-// TODO: disconnect funded wallet after test is complete
-
 const createRetryableStream = (dapiClient) => {
   const streamMediator = new EventEmitter();
 
@@ -65,6 +63,7 @@ const createRetryableStream = (dapiClient) => {
 
 describe('subscribeToBlockHeadersWithChainLocksHandlerFactory', () => {
   let dapiClient;
+  let sdkClient;
   const network = process.env.NETWORK;
 
   let bestBlock;
@@ -81,6 +80,10 @@ describe('subscribeToBlockHeadersWithChainLocksHandlerFactory', () => {
       await dapiClient.core.getBlockByHash(bestBlockHash),
     );
     bestBlockHeight = bestBlock.transactions[0].extraPayload.height;
+  });
+
+  after(async () => {
+    await sdkClient.disconnect();
   });
 
   it('should respond with only historical data', async () => {
@@ -150,9 +153,8 @@ describe('subscribeToBlockHeadersWithChainLocksHandlerFactory', () => {
 
     let obtainedFreshBlock = false;
 
-    const client = await createClientWithFundedWallet();
-    const account = await client.getWalletAccount();
-
+    sdkClient = await createClientWithFundedWallet();
+    const account = await sdkClient.getWalletAccount();
     // Connect to the stream
     const stream = createRetryableStream(dapiClient);
     await stream.init(bestBlockHeight - historicalBlocksToGet + 1);

--- a/packages/wallet-lib/src/types/Account/Account.js
+++ b/packages/wallet-lib/src/types/Account/Account.js
@@ -179,10 +179,10 @@ class Account extends EventEmitter {
     this.emit(EVENTS.CREATED, { type: EVENTS.CREATED, payload: null });
 
     /**
-     * Stores promise that waits for the IS lock of the particular transaction
+     * Stores promise that waits for the transaction FETCH event
      * @type {Promise<void>}
      */
-    this.txISLockListener = null;
+    this.txFetchListener = null;
 
     // Increases a limit of max listeners for transactions related events
     // 25 - mempool limit

--- a/packages/wallet-lib/src/types/Account/methods/broadcastTransaction.js
+++ b/packages/wallet-lib/src/types/Account/methods/broadcastTransaction.js
@@ -120,7 +120,6 @@ async function _broadcastTransaction(transaction, options = {}) {
  */
 async function broadcastTransaction(transaction, options = {}) {
   if (!this.txFetchListener) {
-    // TODO: change event to FETCHED_UNCONFIRMED_TRANSACTION
     this.txFetchListener = new Promise((resolve) => {
       this.once(EVENTS.FETCHED_CONFIRMED_TRANSACTION, ({ payload }) => {
         if (payload.transaction.hash === transaction.hash) {

--- a/packages/wallet-lib/src/types/Wallet/Wallet.js
+++ b/packages/wallet-lib/src/types/Wallet/Wallet.js
@@ -17,7 +17,7 @@ const defaultOptions = {
   allowSensitiveOperations: false,
   unsafeOptions: {},
   waitForInstantLockTimeout: 60000,
-  waitForTxMetadataTimeout: 180000,
+  waitForTxMetadataTimeout: 360000,
 };
 
 const fromMnemonic = require('./methods/fromMnemonic');

--- a/packages/wallet-lib/src/types/Wallet/Wallet.js
+++ b/packages/wallet-lib/src/types/Wallet/Wallet.js
@@ -17,7 +17,7 @@ const defaultOptions = {
   allowSensitiveOperations: false,
   unsafeOptions: {},
   waitForInstantLockTimeout: 60000,
-  waitForTxMetadataTimeout: 360000,
+  waitForTxMetadataTimeout: 540000,
 };
 
 const fromMnemonic = require('./methods/fromMnemonic');


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
A set of fixes and optimizations facilitating platform-test-suite execution on testnet

## What was done?
<!--- Describe your changes in detail -->
- [Bugfix] Reworks transactions queue broadcasting. Instead of the instant lock, wallet relies on transaction info coming from the node  (Fix for `Mocha timeout of 650000ms exceeded.`)

  _This fix allows subsequent broadcastTransaction calls to pass once wallet received the information about previously sent TX_

- [Bugfix] Implements retryable stream for `packages/platform-test-suite/test/functional/dapi/subscribeToBlockHeadersWithChainLocksHandlerFactory.spec.js` 
  
  _This fix does not let test suite fail in case stream have been closed by the backend_

- [Bugfix] Increases TX metadata waiting interval from 180 to 360 seconds. Metadata needs more time to be delivered on a large-scale network. 
(`Metadata waiting period for transaction ${transactionHash} timed out` error)

- [Optimization] Optimizes E2E `wallet.spec.js` for faster execution

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Executing `platform-test-suite` on testnet


## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
