### PR TITLE
chore(drive): add more block execution timers

### DIFF
--- a/packages/js-drive/lib/abci/handlers/beginBlockHandlerFactory.js
+++ b/packages/js-drive/lib/abci/handlers/beginBlockHandlerFactory.js
@@ -55,10 +55,7 @@ function beginBlockHandlerFactory(
     } = header;
 
     // Start block execution timer
-
-    if (executionTimer.isStarted('blockExecution')) {
-      executionTimer.endTimer('blockExecution');
-    }
+    executionTimer.clearTimer('blockExecution');
 
     executionTimer.startTimer('blockExecution');
 

--- a/packages/js-drive/lib/abci/handlers/commitHandlerFactory.js
+++ b/packages/js-drive/lib/abci/handlers/commitHandlerFactory.js
@@ -95,7 +95,7 @@ function commitHandlerFactory(
       `Block commit #${blockHeight} with appHash ${appHash.toString('hex').toUpperCase()}`,
     );
 
-    const blockExecutionTimings = executionTimer.endTimer('blockExecution');
+    const blockExecutionTimings = executionTimer.stopTimer('blockExecution');
 
     consensusLogger.trace(
       {

--- a/packages/js-drive/lib/abci/handlers/deliverTxHandlerFactory.js
+++ b/packages/js-drive/lib/abci/handlers/deliverTxHandlerFactory.js
@@ -26,6 +26,8 @@ const DATA_CONTRACT_ACTION_DESCRIPTIONS = {
   [stateTransitionTypes.DATA_CONTRACT_UPDATE]: 'updated',
 };
 
+const TIMERS = require('./timers');
+
 /**
  * @param {unserializeStateTransition} transactionalUnserializeStateTransition
  * @param {DashPlatformProtocol} transactionalDpp
@@ -55,11 +57,14 @@ function deliverTxHandlerFactory(
 
     // Start execution timer
 
-    if (executionTimer.isStarted('deliverTx')) {
-      executionTimer.endTimer('deliverTx');
-    }
+    executionTimer.clearTimer(TIMERS.DELIVER_TX.OVERALL);
+    executionTimer.clearTimer(TIMERS.DELIVER_TX.VALIDATE_BASIC);
+    executionTimer.clearTimer(TIMERS.DELIVER_TX.VALIDATE_FEE);
+    executionTimer.clearTimer(TIMERS.DELIVER_TX.VALIDATE_SIGNATURE);
+    executionTimer.clearTimer(TIMERS.DELIVER_TX.VALIDATE_STATE);
+    executionTimer.clearTimer(TIMERS.DELIVER_TX.APPLY);
 
-    executionTimer.startTimer('deliverTx');
+    executionTimer.startTimer(TIMERS.DELIVER_TX.OVERALL);
 
     const stHash = crypto
       .createHash('sha256')
@@ -84,6 +89,7 @@ function deliverTxHandlerFactory(
         stateTransitionByteArray,
         {
           logger: consensusLogger,
+          executionTimer,
         },
       );
     } catch (e) {
@@ -91,6 +97,8 @@ function deliverTxHandlerFactory(
 
       throw e;
     }
+
+    executionTimer.startTimer(TIMERS.DELIVER_TX.VALIDATE_STATE);
 
     const result = await transactionalDpp.stateTransition.validateState(stateTransition);
 
@@ -108,8 +116,14 @@ function deliverTxHandlerFactory(
       throw new DPPValidationAbciError(message, result.getFirstError());
     }
 
+    executionTimer.stopTimer(TIMERS.DELIVER_TX.VALIDATE_STATE, true);
+
+    executionTimer.startTimer(TIMERS.DELIVER_TX.APPLY);
+
     // Apply state transition to the state
     await transactionalDpp.stateTransition.apply(stateTransition);
+
+    executionTimer.stopTimer(TIMERS.DELIVER_TX.APPLY, true);
 
     blockExecutionContext.incrementValidTxCount();
 
@@ -189,14 +203,21 @@ function deliverTxHandlerFactory(
         break;
     }
 
-    const deliverTxTimings = executionTimer.endTimer('deliverTx');
+    const deliverTxTiming = executionTimer.stopTimer(TIMERS.DELIVER_TX.OVERALL);
 
     logger.trace(
       {
-        timings: deliverTxTimings,
+        timings: {
+          overall: deliverTxTiming,
+          validateBasic: executionTimer.getTimer(TIMERS.DELIVER_TX.VALIDATE_BASIC, true),
+          validateFee: executionTimer.getTimer(TIMERS.DELIVER_TX.VALIDATE_FEE, true),
+          validateSignature: executionTimer.getTimer(TIMERS.DELIVER_TX.VALIDATE_SIGNATURE, true),
+          validateState: executionTimer.getTimer(TIMERS.DELIVER_TX.VALIDATE_STATE, true),
+          apply: executionTimer.getTimer(TIMERS.DELIVER_TX.APPLY, true),
+        },
         stateTransitionType: stateTransition.getType(),
       },
-      `${stateTransition.constructor.name} execution took ${deliverTxTimings} seconds`,
+      `${stateTransition.constructor.name} execution took ${deliverTxTiming} seconds`,
     );
 
     return new ResponseDeliverTx();

--- a/packages/js-drive/lib/abci/handlers/stateTransition/unserializeStateTransitionFactory.js
+++ b/packages/js-drive/lib/abci/handlers/stateTransition/unserializeStateTransitionFactory.js
@@ -3,6 +3,8 @@ const InvalidArgumentAbciError = require('../../errors/InvalidArgumentAbciError'
 
 const DPPValidationAbciError = require('../../errors/DPPValidationAbciError');
 
+const TIMERS = require('../timers');
+
 /**
  * @param {DashPlatformProtocol} dpp
  * @param {Object} noopLogger
@@ -14,11 +16,18 @@ function unserializeStateTransitionFactory(dpp, noopLogger) {
    * @param {Uint8Array} stateTransitionByteArray
    * @param {Object} [options]
    * @param {BaseLogger} [options.logger]
+   * @param {ExecutionTimer} [options.executionTimer]
    * @return {DocumentsBatchTransition|DataContractCreateTransition|IdentityCreateTransition}
    */
   async function unserializeStateTransition(stateTransitionByteArray, options = {}) {
     // either use a logger passed or use noop logger
     const logger = (options.logger || noopLogger);
+
+    // measure timing if timer is passed
+    const executionTimer = (options.executionTimer || {
+      startTimer: () => {},
+      stopTimer: () => {},
+    });
 
     if (!stateTransitionByteArray) {
       logger.info('State transition is not specified');
@@ -27,6 +36,8 @@ function unserializeStateTransitionFactory(dpp, noopLogger) {
     }
 
     const stateTransitionSerialized = Buffer.from(stateTransitionByteArray);
+
+    executionTimer.startTimer(TIMERS.DELIVER_TX.VALIDATE_BASIC);
 
     let stateTransition;
     try {
@@ -49,6 +60,10 @@ function unserializeStateTransitionFactory(dpp, noopLogger) {
       throw e;
     }
 
+    executionTimer.stopTimer(TIMERS.DELIVER_TX.VALIDATE_BASIC, true);
+
+    executionTimer.startTimer(TIMERS.DELIVER_TX.VALIDATE_SIGNATURE);
+
     let result = await dpp.stateTransition.validateSignature(stateTransition);
 
     if (!result.isValid()) {
@@ -64,6 +79,10 @@ function unserializeStateTransitionFactory(dpp, noopLogger) {
       throw new DPPValidationAbciError(message, consensusError);
     }
 
+    executionTimer.stopTimer(TIMERS.DELIVER_TX.VALIDATE_SIGNATURE, true);
+
+    executionTimer.startTimer(TIMERS.DELIVER_TX.VALIDATE_FEE);
+
     result = await dpp.stateTransition.validateFee(stateTransition);
 
     if (!result.isValid()) {
@@ -78,6 +97,8 @@ function unserializeStateTransitionFactory(dpp, noopLogger) {
 
       throw new DPPValidationAbciError(message, consensusError);
     }
+
+    executionTimer.stopTimer(TIMERS.DELIVER_TX.VALIDATE_FEE, true);
 
     return stateTransition;
   }

--- a/packages/js-drive/lib/abci/handlers/timers.js
+++ b/packages/js-drive/lib/abci/handlers/timers.js
@@ -1,0 +1,10 @@
+module.exports = {
+  DELIVER_TX: {
+    OVERALL: 'deliverTx:overall',
+    VALIDATE_BASIC: 'deliverTx:validate:basic',
+    VALIDATE_FEE: 'deliverTx:validate:fee',
+    VALIDATE_SIGNATURE: 'deliverTx:validate:signature',
+    VALIDATE_STATE: 'deliverTx:validate:state',
+    APPLY: 'deliverTx:apply',
+  },
+};

--- a/packages/js-drive/test/unit/abci/handlers/beginBlockHandlerFactory.spec.js
+++ b/packages/js-drive/test/unit/abci/handlers/beginBlockHandlerFactory.spec.js
@@ -62,9 +62,9 @@ describe('beginBlockHandlerFactory', () => {
     });
 
     executionTimerMock = {
+      clearTimer: this.sinon.stub(),
       startTimer: this.sinon.stub(),
-      endTimer: this.sinon.stub(),
-      isStarted: this.sinon.stub(),
+      stopTimer: this.sinon.stub(),
     };
 
     beginBlockHandler = beginBlockHandlerFactory(

--- a/packages/js-drive/test/unit/abci/handlers/commitHandlerFactory.spec.js
+++ b/packages/js-drive/test/unit/abci/handlers/commitHandlerFactory.spec.js
@@ -88,10 +88,7 @@ describe('commitHandlerFactory', () => {
 
     executionTimerMock = {
       startTimer: this.sinon.stub(),
-      endTimer: this.sinon.stub().returns({
-        seconds: 1,
-        nanoseconds: 1,
-      }),
+      stopTimer: this.sinon.stub(),
     };
 
     commitHandler = commitHandlerFactory(

--- a/packages/js-drive/test/unit/abci/handlers/deliverTxHandlerFactory.spec.js
+++ b/packages/js-drive/test/unit/abci/handlers/deliverTxHandlerFactory.spec.js
@@ -91,11 +91,10 @@ describe('deliverTxHandlerFactory', () => {
     const loggerMock = new LoggerMock(this.sinon);
 
     executionTimerMock = {
+      clearTimer: this.sinon.stub(),
+      getTimer: this.sinon.stub(),
       startTimer: this.sinon.stub(),
-      endTimer: this.sinon.stub().returns({
-        seconds: 1,
-        nanoseconds: 1,
-      }),
+      stopTimer: this.sinon.stub(),
       isStarted: this.sinon.stub(),
     };
 

--- a/packages/js-drive/test/unit/util/ExecutionTimer.spec.js
+++ b/packages/js-drive/test/unit/util/ExecutionTimer.spec.js
@@ -21,10 +21,10 @@ describe('ExecutionTimer', () => {
     });
   });
 
-  describe('#endTimer', () => {
+  describe('#stopTimer', () => {
     it('should throw an error if timer has not been started', () => {
       try {
-        timer.endTimer('some');
+        timer.stopTimer('some');
         expect.fail('An error was not thrown');
       } catch (e) {
         expect(e.message).to.equal('some timer is not started');
@@ -36,7 +36,7 @@ describe('ExecutionTimer', () => {
     // TODO: maybe there should be a better way to do it
     timer.startTimer('some');
     await wait(1500);
-    const timings = timer.endTimer('some');
+    const timings = timer.stopTimer('some');
 
     expect(parseInt(timings, 10)).to.equal(1);
   });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
We need a more precise picture of block execution performance to make the right decision on which operations we need to take into account for fee calculation.

## What was done?
<!--- Describe your changes in detail -->
- Add timers for all validation steps during `deliverTx`

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Unit tests
- Running test suite locally

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
