### PR TITLE
feat: adds balance and metadata information from registered identity

### DIFF
--- a/packages/js-dash-sdk/src/SDK/Client/Platform/methods/identities/register.ts
+++ b/packages/js-dash-sdk/src/SDK/Client/Platform/methods/identities/register.ts
@@ -43,5 +43,13 @@ export default async function register(
       identityIndex,
     );
 
+    // Current identity object will not have metadata or balance information
+    const registeredIdentity = await this.identities.get(identity.id.toString());
+
+    // We cannot just return registeredIdentity as we want to
+    // keep additional information (assetLockProof and transaction) instance
+    identity.balance = registeredIdentity.balance;
+    identity.metadata = registeredIdentity.metadata;
+
     return identity;
 }

--- a/packages/js-dash-sdk/src/SDK/Client/Platform/methods/identities/register.ts
+++ b/packages/js-dash-sdk/src/SDK/Client/Platform/methods/identities/register.ts
@@ -48,8 +48,8 @@ export default async function register(
 
     // We cannot just return registeredIdentity as we want to
     // keep additional information (assetLockProof and transaction) instance
-    identity.balance = registeredIdentity.balance;
-    identity.metadata = registeredIdentity.metadata;
+    identity.setMetadata(registeredIdentity.metadata);
+    identity.setBalance(registeredIdentity.balance);
 
     return identity;
 }


### PR DESCRIPTION
## Issue being fixed or feature implemented

When an identity is registered, the returned instance does not have any network information such as balance and metadata. 
This PR will fetch after a registration the identity by its ID from the network in order to extend such information to the returned object by updating the balance value and adding the metadata property.

## What was done?
- feat: correctly setBalance and setMetadata of newly registered identity.


## How Has This Been Tested?
- Relying on test-suite

## Breaking Changes
N/A

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added or updated relevant unit/integration/functional/e2e tests
- [X] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
