### PR TITLE
chore(dashmate): tenderdash requires 'mode' setting

### DIFF
--- a/packages/dashmate/templates/platform/drive/tenderdash/config.toml.dot
+++ b/packages/dashmate/templates/platform/drive/tenderdash/config.toml.dot
@@ -54,7 +54,7 @@ log-format = "{{=it.platform.drive.tenderdash.log.format}}"
 genesis-file = "config/genesis.json"
 
 # Set to whether we are a masternode or not
-is-masternode = {{?it.core.masternode.enable}}true{{??}}false{{?}}
+mode = {{?it.core.masternode.enable}}"validator"{{??}}"full"{{?}}
 
 # Path to the JSON file containing the private key to use for node authentication in the p2p protocol
 node-key-file = "config/node_key.json"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented

Tenderdash 0.8.0-dev.2 will remove `is-validator` setting in favor of `mode`. 
This PR does respective changes to `dashmate`.

## What was done?

Changed `is-masternode` to `mode` in tenderdash config template.

## How Has This Been Tested?

Started TD+Drive locally with `dashmate`.

## Breaking Changes

None

Note: it requires https://github.com/dashevo/tenderdash/pull/353 

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone
