### PR TITLE
fix: unable to build for web environment

### DIFF
--- a/packages/js-dash-sdk/webpack.base.config.js
+++ b/packages/js-dash-sdk/webpack.base.config.js
@@ -12,10 +12,15 @@ const baseConfig = {
       },
     ],
   },
+  externals: {
+    '@dashevo/wasm-re2' :'require("@dashevo/wasm-re2")'
+  },
   resolve: {
     extensions: ['.ts', '.js', '.json'],
     fallback: {
       fs: false,
+      // or require.resolve("console-browserify") } if wanted
+      console: false,
       util: require.resolve('util/'),
       crypto: require.resolve('crypto-browserify'),
       http: require.resolve('stream-http'),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented

Running `yarn workspace dash build:web` would fail with `Module not found: Error: Can't resolve 'ws' in 'node_modules/@dashevo/wasm-re2/bin'`. 
This PR fixes that issue.

## What was done?
- fix: build issue with wasm-re2

## How Has This Been Tested?
- Running a web build manually and import it in web env.


## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone
