### PR TITLE
fix(dapi): send tx id to tenderdash as hex, not base64

### DIFF
--- a/packages/dapi/lib/externalApis/tenderdash/waitForTransactionToBeProvable/getExistingTransactionResult.js
+++ b/packages/dapi/lib/externalApis/tenderdash/waitForTransactionToBeProvable/getExistingTransactionResult.js
@@ -15,7 +15,7 @@ function getExistingTransactionResultFactory(rpcClient) {
   async function getExistingTransactionResult(hashString) {
     const hash = Buffer.from(hashString, 'hex');
 
-    const params = { hash: hash.toString('base64') };
+    const params = { hash: hashString };
 
     const { result, error } = await rpcClient.request('tx', params);
 


### PR DESCRIPTION
## Issue being fixed or feature implemented

Tenderdash 0.8 requires transaction hash to be provided as a hex string.
Platform sends it as a base64.

## What was done?

Send transaction hash as hex string.

## How Has This Been Tested?

```bash
yarn test:suite
```

## Breaking Changes

none

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone
