### PR TITLE
fix(wallet-lib): hook tx chain broadcast on mempool response

### DIFF
--- a/packages/wallet-lib/docs/account/broadcastTransaction.md
+++ b/packages/wallet-lib/docs/account/broadcastTransaction.md
@@ -4,12 +4,12 @@
 
 Parameters: 
 
-| parameters                        | type               | required       | Description                                                                                      |  
-|-----------------------------------|--------------------|----------------| ------------------------------------------------------------------------------------------------ |
-| **transaction**                   | Transaction/String | yes            | A valid [created transaction](../account/createTransaction.md) or it's hexadecimal raw representation |
-| **options**                       | Object             | no             | |
-| **options.skipFeeValidation**     | Boolean            | no             | When set to true, and min relay fee is not met, will still try to broadcast a transaction        |
-
+| parameters                            | type               | required | Description                                                                                           |
+|---------------------------------------|--------------------|----------|-------------------------------------------------------------------------------------------------------|
+| **transaction**                       | Transaction/String | yes      | A valid [created transaction](../account/createTransaction.md) or it's hexadecimal raw representation |
+| **options**                           | Object             | no       |                                                                                                       |
+| **options.skipFeeValidation**         | Boolean            | no       | When set to true, and min relay fee is not met, will still try to broadcast a transaction             |
+| **options.mempoolPropagationTimeout** | Number             | no       | The amount of milliseconds to wait for transaction mempool propagation                                |
 Returns : transactionId (string).
 
 N.B : The TransactionID provided is subject to [transaction malleability](https://dashcore.readme.io/docs/core-guide-transactions-transaction-malleability), and is not a source of truth (the transaction might be included in a block with a different txid).

--- a/packages/wallet-lib/src/errors/MempoolPropagationTimeoutError.js
+++ b/packages/wallet-lib/src/errors/MempoolPropagationTimeoutError.js
@@ -1,0 +1,12 @@
+const WalletLibError = require('./WalletLibError');
+
+class MempoolPropagationTimeoutError extends WalletLibError {
+  /**
+   * @param {string} transactionHash
+   */
+  constructor(transactionHash) {
+    super(`Mempool propagation waiting period for transaction ${transactionHash} timed out`);
+  }
+}
+
+module.exports = MempoolPropagationTimeoutError;

--- a/packages/wallet-lib/src/test/bootstrap.js
+++ b/packages/wallet-lib/src/test/bootstrap.js
@@ -3,8 +3,10 @@ const path = require('path');
 const dotenvSafe = require('dotenv-safe');
 const sinon = require('sinon');
 const sinonChai = require('sinon-chai');
+const chaiAsPromised = require('chai-as-promised');
 
 use(sinonChai);
+use(chaiAsPromised);
 
 dotenvSafe.config({
   path: path.resolve(__dirname, '..', '..', '.env'),

--- a/packages/wallet-lib/src/test/karma/bootstrap.js
+++ b/packages/wallet-lib/src/test/karma/bootstrap.js
@@ -1,8 +1,10 @@
 const { expect, use } = require('chai');
 const sinon = require('sinon');
 const chaiAsPromised = require('chai-as-promised');
+const sinonChai = require('sinon-chai');
 
 use(chaiAsPromised);
+use(sinonChai);
 
 beforeEach(function beforeEach() {
   if (!this.sinonSandbox) {

--- a/packages/wallet-lib/src/types/Account/methods/broadcastTransaction.js
+++ b/packages/wallet-lib/src/types/Account/methods/broadcastTransaction.js
@@ -170,25 +170,6 @@ async function broadcastTransaction(transaction, options = {
   }
 
   return transaction.hash;
-
-  // if (!this.txFetchListener) {
-  //   this.txFetchListener = new Promise((resolve) => {
-  //     this.once(EVENTS.FETCHED_CONFIRMED_TRANSACTION, ({ payload }) => {
-  //       if (payload.transaction.hash === transaction.hash) {
-  //         this.txFetchListener = null;
-  //         resolve();
-  //       }
-  //     });
-  //   });
-  //
-  //   await _broadcastTransaction.call(this, transaction, options);
-  //
-  //   return transaction.hash;
-  // }
-
-  // await this.txFetchListener;
-
-  // return broadcastTransaction.call(this, transaction, options);
 }
 
 module.exports = broadcastTransaction;

--- a/packages/wallet-lib/src/types/Account/methods/broadcastTransaction.js
+++ b/packages/wallet-lib/src/types/Account/methods/broadcastTransaction.js
@@ -9,7 +9,7 @@ const EVENTS = require('../../../EVENTS');
 const MempoolPropagationTimeoutError = require('../../../errors/MempoolPropagationTimeoutError');
 const logger = require('../../../logger');
 
-const MEMPOOL_PROPAGATION_TIMEOUT = 60000;
+const MEMPOOL_PROPAGATION_TIMEOUT = 360000;
 
 function impactAffectedInputs({ transaction }) {
   const {

--- a/packages/wallet-lib/src/types/Account/methods/broadcastTransaction.js
+++ b/packages/wallet-lib/src/types/Account/methods/broadcastTransaction.js
@@ -129,12 +129,16 @@ async function broadcastTransaction(transaction, options = {
 
   const mempoolPropagationPromise = new Promise((resolve) => {
     const listener = ({ payload }) => {
+      // TODO: consider reworking to use inputs/outputs comparison
+      // to ensure that TX malleability is not a problem
+      // https://dashcore.readme.io/v18.0.0/docs/core-guide-transactions-transaction-malleability
       if (payload.transaction.hash === transaction.hash) {
         logger.debug(`broadcastTransaction - received from mempool TX "${transaction.hash}"`);
         clearTimeout(rejectTimeout);
         resolve();
       }
     };
+    // TODO: change to FETCHED_UNCONFIRMED_TRANSACTION once this event is restored
     this.once(EVENTS.FETCHED_CONFIRMED_TRANSACTION, listener);
     cancelMempoolSubscription = () => {
       logger.debug(`broadcastTransaction - canceled mempool subscription for TX "${transaction.hash}"`);

--- a/packages/wallet-lib/src/types/Account/methods/broadcastTransaction.spec.js
+++ b/packages/wallet-lib/src/types/Account/methods/broadcastTransaction.spec.js
@@ -1,11 +1,17 @@
-const { expect } = require('chai');
+const chai = require('chai');
+const EventEmitter = require('events');
 const Dashcore = require('@dashevo/dashcore-lib');
+const chaiAsPromised = require('chai-as-promised');
 const broadcastTransaction = require('./broadcastTransaction');
+const EVENTS = require('../../../EVENTS');
 const validRawTxs = require('../../../../fixtures/rawtx').valid;
 const invalidRawTxs = require('../../../../fixtures/rawtx').invalid;
-const expectThrowsAsync = require('../../../utils/expectThrowsAsync');
+const MempoolPropagationTimeoutError = require('../../../errors/MempoolPropagationTimeoutError');
 const ChainStore = require('../../ChainStore/ChainStore');
 const { PrivateKey } = Dashcore;
+
+chai.use(chaiAsPromised);
+const { expect } = chai;
 
 describe('Account - broadcastTransaction', function suite() {
   this.timeout(10000);
@@ -21,7 +27,11 @@ describe('Account - broadcastTransaction', function suite() {
   const storage = {
     getChainStore:()=> chainStore
   }
-  beforeEach(() => {
+
+  let self;
+  let sendCalled = 0;
+
+  beforeEach(function () {
     utxos = [
       {
         address: 'yj8sq7ogzz6JtaxpBQm5Hg9YaB5cKExn5T',
@@ -41,114 +51,89 @@ describe('Account - broadcastTransaction', function suite() {
       .to(address, 138)
       .fee(fee);
     oneToOneTx.sign(keysToSign);
-  });
 
-  it('should throw error on missing transport', async () => {
-    const expectedException1 = 'A transport layer is needed to perform a broadcast';
-    const self = {
-      transport: null,
-      storage,
-      network: 'testnet'
+    sendCalled = 0;
+    self = new EventEmitter();
+    self.removeListener = this.sinonSandbox.spy();
+    self.transport = {
+      sendTransaction: (txHex) => {
+        const transaction = new Dashcore.Transaction(txHex)
+        self.emit(EVENTS.FETCHED_CONFIRMED_TRANSACTION, {
+          payload: {
+            transaction
+          }
+        });
+
+        sendCalled += 1;
+        return transaction.hash
+      },
     };
-    expectThrowsAsync(async () => await broadcastTransaction.call(self, validRawTxs.tx2to2Testnet), expectedException1);
-
-    // return broadcastTransaction
-    //   .call(self, validRawTxs.tx2to2Testnet)
-    //   .then(
-    //     (e) => Promise.reject(new Error('Expected method to reject.'+e)),
-    //     err => expect(err).to.be.a('Error').with.property('message', expectedException1),
-    //   );
+    self.network = 'testnet';
+    self.storage = storage;
   });
+
+
+  it('should throw error on missing transport', async function () {
+    const expectedException1 = 'A transport layer is needed to perform a broadcast';
+    self.transport = null;
+
+    await expect(broadcastTransaction.call(self, validRawTxs.tx2to2Testnet))
+      .to.be.rejectedWith(expectedException1);
+
+    expect(self.removeListener).to.have.been.calledOnceWith(EVENTS.FETCHED_CONFIRMED_TRANSACTION);
+  });
+
   it('should throw error on invalid rawtx (string)', async () => {
     const expectedException1 = 'A valid transaction object or it\'s hex representation is required';
-    const self = {
-      transport: { },
-      storage,
-      network: 'testnet'
-    };
 
-    expectThrowsAsync(async () => await broadcastTransaction.call(self, invalidRawTxs.notRelatedString), expectedException1);
+    await expect(broadcastTransaction.call(self, invalidRawTxs.notRelatedString))
+      .to.be.rejectedWith(expectedException1);
+    expect(self.removeListener).to.have.been.calledOnceWith(EVENTS.FETCHED_CONFIRMED_TRANSACTION);
   });
+
   it('should throw error on invalid rawtx (hex)', async () => {
     const expectedException1 = 'A valid transaction object or it\'s hex representation is required';
-    const self = {
-      transport: { },
-      storage,
-      network: 'testnet'
-    };
 
-    expectThrowsAsync(async () => await broadcastTransaction.call(self, invalidRawTxs.truncatedRawTx), expectedException1);
+    await expect(broadcastTransaction.call(self, invalidRawTxs.truncatedRawTx))
+      .to.be.rejectedWith(expectedException1);
+    expect(self.removeListener).to.have.been.calledOnceWith(EVENTS.FETCHED_CONFIRMED_TRANSACTION);
   });
+
   it('should work on valid Transaction object', async () => {
-    let sendCalled = +1;
-    let searchCalled = +1;
-    const self = {
-      transport: {
-        sendTransaction: () => sendCalled = +1,
-      },
-      network: 'testnet',
-      storage
-    };
-
-    const tx = oneToOneTx;
-    return broadcastTransaction
-      .call(self, tx)
-      .then(
-        () => expect(sendCalled).to.equal(1) && expect(searchCalled).to.equal(1),
-      );
-  });
-  it('should update affected tx', () => {
-    let sendCalled = +1;
-    let searchCalled = +1;
-    const self = {
-      transport: {
-        sendTransaction: () => sendCalled = +1,
-      },
-      network: 'testnet',
-      storage
-    };
-
     return broadcastTransaction
       .call(self, oneToOneTx)
       .then(
-        () => expect(sendCalled).to.equal(1) && expect(searchCalled).to.equal(1),
+        () => expect(sendCalled).to.equal(1)
       );
   });
-  it('should throw error on fee not met', function () {
+
+  it('should throw error on fee not met', async function () {
     const expectedException1 = 'Expected minimum fee for transaction 149. Current: 0';
 
-    let sendCalled = +1;
-    let searchCalled = +1;
-    const self = {
-      transport: {
-        sendTransaction: () => sendCalled = +1,
-      },
-      network: 'testnet',
-      storage
-    };
+    oneToOneTx.fee(0);
 
-    const tx = oneToOneTx;
-    tx.fee(0);
-    expectThrowsAsync(async () => await broadcastTransaction.call(self, tx), expectedException1);
+    await expect(broadcastTransaction.call(self, oneToOneTx))
+      .to.be.rejectedWith(expectedException1);
+    expect(self.removeListener).to.have.been.calledOnceWith(EVENTS.FETCHED_CONFIRMED_TRANSACTION);
   });
-  it('should broadcast when force and fee not met', function () {
-    let sendCalled = +1;
-    let searchCalled = +1;
-    const self = {
-      transport: {
-        sendTransaction: () => sendCalled = +1,
-      },
-      network: 'testnet',
-      storage
-    };
 
-    const tx = oneToOneTx;
-    tx.fee(0);
+  it('should broadcast when force and fee not met', function () {
+    oneToOneTx.fee(0);
 
     return broadcastTransaction
-      .call(self, tx, {skipFeeValidation: true})
+      .call(self, oneToOneTx, { skipFeeValidation: true })
       .then(
-        () => expect(sendCalled).to.equal(1) && expect(searchCalled).to.equal(1),
+        () => expect(sendCalled).to.equal(1)
       );
+  });
+
+  it('should throw mempool propagation timeout error', async function () {
+    self.transport.sendTransaction = () => new Promise(() => {})
+
+    await expect(broadcastTransaction.call(self, oneToOneTx, {
+      mempoolPropagationTimeout: 1
+    })).to.be.rejectedWith(MempoolPropagationTimeoutError);
+
+    expect(self.removeListener).to.have.been.calledOnceWith(EVENTS.FETCHED_CONFIRMED_TRANSACTION);
   });
 });

--- a/packages/wallet-lib/src/types/Account/methods/broadcastTransaction.spec.js
+++ b/packages/wallet-lib/src/types/Account/methods/broadcastTransaction.spec.js
@@ -1,7 +1,7 @@
-const chai = require('chai');
+const { expect } = require('chai');
 const EventEmitter = require('events');
 const Dashcore = require('@dashevo/dashcore-lib');
-const chaiAsPromised = require('chai-as-promised');
+
 const broadcastTransaction = require('./broadcastTransaction');
 const EVENTS = require('../../../EVENTS');
 const validRawTxs = require('../../../../fixtures/rawtx').valid;
@@ -9,9 +9,6 @@ const invalidRawTxs = require('../../../../fixtures/rawtx').invalid;
 const MempoolPropagationTimeoutError = require('../../../errors/MempoolPropagationTimeoutError');
 const ChainStore = require('../../ChainStore/ChainStore');
 const { PrivateKey } = Dashcore;
-
-chai.use(chaiAsPromised);
-const { expect } = chai;
 
 describe('Account - broadcastTransaction', function suite() {
   this.timeout(10000);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The change improves reliability of the transaction chaining mechanism and eliminates divergence between `account.getTotalBalance()` and balance impact derived from transaction history

```
const wallet = new Wallet(...);
const account = await wallet.getAccount();

const txAmount = 5;
for (let i = 0; i < txAmount; i++) {
    const tx = account.createTransaction({
      recipient: '...'
      satoshis: 1000,
    });

    await account.broadcastTransaction(tx);

    const transactionHistory = await account.getTransactionHistory();
    const balanceImpact = transactionHistory
      .reduce((acc, item) => acc + item.satoshisBalanceImpact - item.feeImpact, 0);
    const balance = account.getTotalBalance();
    
    console.log(balance, balanceImpact); // equal
}
```


## What was done?
<!--- Describe your changes in detail -->
Rework `broadcastTransaction.js`:
- wait for transaction data response from mempool as a sign of `broadcastTransaction` completeness
- reject after a timeout (360 seconds by default)


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Added unit test
- CI (relevant functional test exists in the wallet-lib/test/functional/wallet.js)
- Tested tx chaining against the testnet 


## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
