### PR TITLE
fix: `verifyChainLock` was returning `false` instead of `ResponseQuery`

### DIFF
--- a/packages/js-drive/lib/abci/handlers/query/verifyChainLockQueryHandlerFactory.js
+++ b/packages/js-drive/lib/abci/handlers/query/verifyChainLockQueryHandlerFactory.js
@@ -64,7 +64,7 @@ function verifyChainLockQueryHandlerFactory(
           {
             err: e,
             chainLock: data.toString('hex'),
-          }, 
+          },
           `Chainlock verification failed using verifyChainLock method: ${e.message}`,
         );
 

--- a/packages/js-drive/lib/abci/handlers/query/verifyChainLockQueryHandlerFactory.js
+++ b/packages/js-drive/lib/abci/handlers/query/verifyChainLockQueryHandlerFactory.js
@@ -60,7 +60,18 @@ function verifyChainLockQueryHandlerFactory(
       // Invalid signature format
       // Parse error
       if ([-8, -32700].includes(e.code)) {
-        return false;
+        logger.debug(
+          {
+            err: e,
+            chainLock: data.toString('hex'),
+          }, 
+          `Chainlock verification failed using verifyChainLock method: ${e.message}`,
+        );
+
+        return new ResponseQuery({
+          code: e.code,
+          log: `Chainlock verification failed using verifyChainLock method: ${e.message}`,
+        });
       }
 
       throw e;

--- a/packages/js-drive/lib/core/waitForCoreChainLockSyncFactory.js
+++ b/packages/js-drive/lib/core/waitForCoreChainLockSyncFactory.js
@@ -53,7 +53,12 @@ function waitForCoreChainLockSyncFactory(
 
       latestCoreChainLock.update(chainLock);
 
-      logger.trace(`Updated latestCoreChainLock for core height ${chainLock.height}`);
+      logger.trace(
+        { 
+          rawChainLockMessage: rawChainLockMessage.toString('hex'), 
+        }, 
+        `Updated latestCoreChainLock for core height ${chainLock.height}`,
+      );
 
       if (resolveFirstChainLockFromZMQPromise) {
         resolveFirstChainLockFromZMQPromise();

--- a/packages/js-drive/lib/core/waitForCoreChainLockSyncFactory.js
+++ b/packages/js-drive/lib/core/waitForCoreChainLockSyncFactory.js
@@ -54,9 +54,9 @@ function waitForCoreChainLockSyncFactory(
       latestCoreChainLock.update(chainLock);
 
       logger.trace(
-        { 
-          rawChainLockMessage: rawChainLockMessage.toString('hex'), 
-        }, 
+        {
+          rawChainLockMessage: rawChainLockMessage.toString('hex'),
+        },
         `Updated latestCoreChainLock for core height ${chainLock.height}`,
       );
 

--- a/packages/js-drive/test/unit/abci/handlers/query/verifyChainLockQueryHandlerFactory.spec.js
+++ b/packages/js-drive/test/unit/abci/handlers/query/verifyChainLockQueryHandlerFactory.spec.js
@@ -121,7 +121,10 @@ describe('verifyChainLockQueryHandlerFactory', () => {
 
     const result = await verifyChainLockQueryHandler(params, encodedChainLock);
 
-    expect(result).to.be.equal(false);
+    expect(result).to.deep.equal(new ResponseQuery({
+      code: -32700,
+      log: 'Chainlock verification failed using verifyChainLock method: ',
+    }));
 
     expect(decodeChainLockMock).to.be.calledOnceWithExactly(encodedChainLock);
     expect(coreRpcClientMock.verifyChainLock).to.be.calledOnceWithExactly(
@@ -139,7 +142,10 @@ describe('verifyChainLockQueryHandlerFactory', () => {
 
     const result = await verifyChainLockQueryHandler(params, encodedChainLock);
 
-    expect(result).to.be.equal(false);
+    expect(result).to.deep.equal(new ResponseQuery({
+      code: -8,
+      log: 'Chainlock verification failed using verifyChainLock method: ',
+    }));
 
     expect(decodeChainLockMock).to.be.calledOnceWithExactly(encodedChainLock);
     expect(coreRpcClientMock.verifyChainLock).to.be.calledOnceWithExactly(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
`verifyChainLock` was returning `false` instead of `ResponseQuery` in case of Core not verifying `ChainLock`

## What was done?
<!--- Describe your changes in detail -->
- updated `verifyChainLock`
- added more debug and trace logs

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
`devnet-mekhong`

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
