### PR TITLE
ci(fix): docker images incorrectly tagged with v

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -147,7 +147,7 @@ jobs:
             type=match,pattern=v(\d+.\d+),group=1,enable=${{github.event_name == 'release'}}
             type=match,pattern=v(\d+.\d+.\d+),group=1,enable=${{github.event_name == 'release'}}
             type=match,pattern=v(.*),group=1,suffix=,enable=${{ contains(github.event.release.tag_name, '-dev') }}
-            type=match,pattern=v(.*),value=${{ github.event.inputs.tag }},enable=${{github.event_name == 'workflow_dispatch'}}
+            type=match,pattern=v(.*),group=1,value=${{ github.event.inputs.tag }},enable=${{github.event_name == 'workflow_dispatch'}}
           flavor: |
             suffix=${{ steps.suffix.outputs.result }},onlatest=true
             latest=${{ github.event_name == 'release' }}
@@ -245,7 +245,7 @@ jobs:
             type=match,pattern=v(\d+.\d+),group=1,enable=${{github.event_name == 'release'}}
             type=match,pattern=v(\d+.\d+.\d+),group=1,enable=${{github.event_name == 'release'}}
             type=match,pattern=v(.*),group=1,suffix=,enable=${{ contains(github.event.release.tag_name, '-dev') }}
-            type=match,pattern=v(.*),value=${{ github.event.inputs.tag }},enable=${{github.event_name == 'workflow_dispatch'}}
+            type=match,pattern=v(.*),group=1,value=${{ github.event.inputs.tag }},enable=${{github.event_name == 'workflow_dispatch'}}
           flavor: |
             suffix=${{ steps.suffix.outputs.result }},onlatest=true
             latest=${{ github.event_name == 'release' }}
@@ -343,7 +343,7 @@ jobs:
             type=match,pattern=v(\d+.\d+),group=1,enable=${{github.event_name == 'release'}}
             type=match,pattern=v(\d+.\d+.\d+),group=1,enable=${{github.event_name == 'release'}}
             type=match,pattern=v(.*),group=1,suffix=,enable=${{ contains(github.event.release.tag_name, '-dev') }}
-            type=match,pattern=v(.*),value=${{ github.event.inputs.tag }},enable=${{github.event_name == 'workflow_dispatch'}}
+            type=match,pattern=v(.*),group=1,value=${{ github.event.inputs.tag }},enable=${{github.event_name == 'workflow_dispatch'}}
           flavor: |
             suffix=${{ steps.suffix.outputs.result }},onlatest=true
             latest=${{ github.event_name == 'release' }}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Docker images built with the new workflow dispatch automation were incorrectly tagged with a `v` prefix

## What was done?
<!--- Describe your changes in detail -->
- Specify regex capturing group when parsing tag value

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Works with other tags ;)

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
