### PR TITLE
fix: non-deterministic fees due to data contract cache

### DIFF
--- a/packages/js-dpp/lib/StateRepositoryInterface.js
+++ b/packages/js-dpp/lib/StateRepositoryInterface.js
@@ -66,7 +66,7 @@
  * @async
  * @method
  * @name StateRepository#removeDocument
- * @param {Identifier} contractId
+ * @param {DataContract} dataContract
  * @param {string} type
  * @param {Identifier} id
  * @param {StateTransitionExecutionContext} [StateTransitionExecutionContext]

--- a/packages/js-dpp/lib/document/stateTransition/DocumentsBatchTransition/applyDocumentsBatchTransitionFactory.js
+++ b/packages/js-dpp/lib/document/stateTransition/DocumentsBatchTransition/applyDocumentsBatchTransitionFactory.js
@@ -115,7 +115,7 @@ function applyDocumentsBatchTransitionFactory(
           }
           case AbstractDocumentTransition.ACTIONS.DELETE: {
             return stateRepository.removeDocument(
-              documentTransition.getDataContractId(),
+              documentTransition.getDataContract(),
               documentTransition.getType(),
               documentTransition.getId(),
               executionContext,

--- a/packages/js-dpp/test/unit/document/stateTransition/DocumetsBatchTransition/applyDocumentsBatchTransitionFactory.spec.js
+++ b/packages/js-dpp/test/unit/document/stateTransition/DocumetsBatchTransition/applyDocumentsBatchTransitionFactory.spec.js
@@ -106,7 +106,7 @@ describe('applyDocumentsBatchTransitionFactory', () => {
     ]);
 
     expect(stateRepositoryMock.removeDocument).to.have.been.calledOnceWithExactly(
-      documentTransitions[2].getDataContractId(),
+      documentTransitions[2].getDataContract(),
       documentTransitions[2].getType(),
       documentTransitions[2].getId(),
       executionContext,

--- a/packages/js-drive/lib/abci/handlers/commitHandlerFactory.js
+++ b/packages/js-drive/lib/abci/handlers/commitHandlerFactory.js
@@ -5,6 +5,8 @@ const {
     },
   },
 } = require('@dashevo/abci/types');
+const ReadOperation = require('@dashevo/dpp/lib/stateTransition/fee/operations/ReadOperation');
+const DataContractCacheItem = require('../../dataContract/DataContractCacheItem');
 
 /**
  * @param {CreditsDistributionPool} creditsDistributionPool
@@ -76,12 +78,14 @@ function commitHandlerFactory(
     await groveDBStore.commitTransaction();
 
     // Update data contract cache with new version of
-    // commited data contract
+    // committed data contract
     for (const dataContract of blockExecutionContext.getDataContracts()) {
-      const idString = dataContract.getId().toString();
+      const operations = [new ReadOperation(dataContract.toBuffer().length)];
 
-      if (dataContractCache.has(idString)) {
-        dataContractCache.set(idString, dataContract);
+      const cacheItem = new DataContractCacheItem(dataContract, operations);
+
+      if (dataContractCache.has(cacheItem.getKey())) {
+        dataContractCache.set(cacheItem.getKey(), cacheItem);
       }
     }
 

--- a/packages/js-drive/lib/createDIContainer.js
+++ b/packages/js-drive/lib/createDIContainer.js
@@ -605,7 +605,6 @@ function createDIContainer(options) {
         coreRpcClient,
         blockExecutionContext,
         simplifiedMasternodeList,
-        dataContractCache,
       );
 
       return new CachedStateRepositoryDecorator(
@@ -637,7 +636,6 @@ function createDIContainer(options) {
         coreRpcClient,
         blockExecutionContext,
         simplifiedMasternodeList,
-        dataContractCache,
         {
           useTransaction: true,
         },

--- a/packages/js-drive/lib/dataContract/DataContractCacheItem.js
+++ b/packages/js-drive/lib/dataContract/DataContractCacheItem.js
@@ -1,0 +1,44 @@
+class DataContractCacheItem {
+  /**
+   * @type {DataContract}
+   */
+  #dataContract;
+
+  /**
+   * @type {AbstractOperation[]}
+   */
+  #operations;
+
+  /**
+   *
+   * @param {DataContract} dataContract
+   * @param {AbstractOperation[]} operations
+   */
+  constructor(dataContract, operations) {
+    this.#dataContract = dataContract;
+    this.#operations = operations;
+  }
+
+  /**
+   * @return {DataContract}
+   */
+  getDataContract() {
+    return this.#dataContract;
+  }
+
+  /**
+   * @return {AbstractOperation[]}
+   */
+  getOperations() {
+    return this.#operations;
+  }
+
+  /**
+   * @return {string}
+   */
+  getKey() {
+    return this.#dataContract.getId().toString();
+  }
+}
+
+module.exports = DataContractCacheItem;

--- a/packages/js-drive/lib/dpp/DriveStateRepository.js
+++ b/packages/js-drive/lib/dpp/DriveStateRepository.js
@@ -10,11 +10,6 @@ class DriveStateRepository {
   #options = {};
 
   /**
-   * @type {LRUCache}
-   */
-  #dataContractCache;
-
-  /**
    * @param {IdentityStoreRepository} identityRepository
    * @param {PublicKeyToIdentitiesStoreRepository} publicKeyToToIdentitiesRepository
    * @param {DataContractStoreRepository} dataContractRepository
@@ -24,7 +19,6 @@ class DriveStateRepository {
    * @param {RpcClient} coreRpcClient
    * @param {BlockExecutionContext} blockExecutionContext
    * @param {SimplifiedMasternodeList} simplifiedMasternodeList
-   * @param {LRUCache} dataContractCache
    * @param {Object} [options]
    * @param {Object} [options.useTransaction=false]
    */
@@ -38,7 +32,6 @@ class DriveStateRepository {
     coreRpcClient,
     blockExecutionContext,
     simplifiedMasternodeList,
-    dataContractCache,
     options = {},
   ) {
     this.identityRepository = identityRepository;
@@ -50,7 +43,6 @@ class DriveStateRepository {
     this.coreRpcClient = coreRpcClient;
     this.blockExecutionContext = blockExecutionContext;
     this.simplifiedMasternodeList = simplifiedMasternodeList;
-    this.#dataContractCache = dataContractCache;
     this.#options = options;
   }
 
@@ -318,26 +310,14 @@ class DriveStateRepository {
   /**
    * Remove document
    *
-   * @param {Identifier} contractId
+   * @param {DataContract} dataContract
    * @param {string} type
    * @param {Identifier} id
    * @param {StateTransitionExecutionContext} [executionContext]
    *
    * @returns {Promise<void>}
    */
-  async removeDocument(contractId, type, id, executionContext = undefined) {
-    const contractIdString = contractId.toString();
-
-    // TODO: This is not very clean approach since we have already cached decorator
-    //  to enable caching for the whole state repository
-    let dataContract = this.#dataContractCache.get(contractIdString);
-
-    if (!dataContract) {
-      dataContract = await this.fetchDataContract(contractId, executionContext);
-
-      this.#dataContractCache.set(contractIdString, dataContract);
-    }
-
+  async removeDocument(dataContract, type, id, executionContext = undefined) {
     const result = await this.documentRepository.delete(
       dataContract,
       type,

--- a/packages/js-drive/lib/dpp/LoggedStateRepositoryDecorator.js
+++ b/packages/js-drive/lib/dpp/LoggedStateRepositoryDecorator.js
@@ -363,23 +363,28 @@ class LoggedStateRepositoryDecorator {
   /**
    * Remove document
    *
-   * @param {Identifier} contractId
+   * @param {DataContract} dataContract
    * @param {string} type
    * @param {Identifier} id
    * @param {StateTransitionExecutionContext} [executionContext]
    *
    * @returns {Promise<void>}
    */
-  async removeDocument(contractId, type, id, executionContext = undefined) {
+  async removeDocument(dataContract, type, id, executionContext = undefined) {
     let response;
 
     try {
-      response = await this.stateRepository.removeDocument(contractId, type, id, executionContext);
+      response = await this.stateRepository.removeDocument(
+        dataContract,
+        type,
+        id,
+        executionContext,
+      );
     } finally {
       this.log(
         'removeDocument',
         {
-          contractId,
+          dataContract,
           type,
           id,
         },

--- a/packages/js-drive/lib/state/registerSystemDataContractFactory.js
+++ b/packages/js-drive/lib/state/registerSystemDataContractFactory.js
@@ -1,4 +1,6 @@
 const IdentityPublicKey = require('@dashevo/dpp/lib/identity/IdentityPublicKey');
+const ReadOperation = require('@dashevo/dpp/lib/stateTransition/fee/operations/ReadOperation');
+const DataContractCacheItem = require('../dataContract/DataContractCacheItem');
 
 /**
  * @param {DashPlatformProtocol} dpp
@@ -71,7 +73,11 @@ function registerSystemDataContractFactory(
     });
 
     // Store data contract in the cache
-    dataContractCache.set(dataContract.getId().toString(), dataContract);
+    const cacheItem = new DataContractCacheItem(dataContract, [
+      new ReadOperation(dataContract.toBuffer().length),
+    ]);
+
+    dataContractCache.set(cacheItem.getKey(), cacheItem);
 
     return dataContract;
   }

--- a/packages/js-drive/test/integration/fee/feesPrediction.spec.js
+++ b/packages/js-drive/test/integration/fee/feesPrediction.spec.js
@@ -340,13 +340,6 @@ describe('feesPrediction', () => {
       it('should have predicted fee more than actual fee', async () => {
         await stateRepository.storeDataContract(dataContract);
 
-        // store data contract in cache
-        const dataContractCache = container.resolve('dataContractCache');
-        dataContractCache.set(
-          dataContract.getId().toString(),
-          await dpp.dataContract.createFromObject(dataContract.toObject()),
-        );
-
         dataContract.setVersion(2);
 
         const documents = dataContract.getDocuments();
@@ -436,13 +429,6 @@ describe('feesPrediction', () => {
       dataContract = dpp.dataContract.create(identity.getId(), documentTypes);
 
       await stateRepository.storeDataContract(dataContract);
-
-      // store data contract in cache
-      const dataContractCache = container.resolve('dataContractCache');
-      dataContractCache.set(
-        dataContract.getId().toString(),
-        await dpp.dataContract.createFromObject(dataContract.toObject()),
-      );
 
       // Create documents
 

--- a/packages/js-drive/test/unit/dpp/CachedStateRepositoryDecorator.spec.js
+++ b/packages/js-drive/test/unit/dpp/CachedStateRepositoryDecorator.spec.js
@@ -4,6 +4,7 @@ const getDataContractFixture = require('@dashevo/dpp/lib/test/fixtures/getDataCo
 const createStateRepositoryMock = require('@dashevo/dpp/lib/test/mocks/createStateRepositoryMock');
 
 const CachedStateRepositoryDecorator = require('../../../lib/dpp/CachedStateRepositoryDecorator');
+const DataContractCacheItem = require('../../../lib/dataContract/DataContractCacheItem');
 
 describe('CachedStateRepositoryDecorator', () => {
   let stateRepositoryMock;
@@ -135,12 +136,11 @@ describe('CachedStateRepositoryDecorator', () => {
 
   describe('#removeDocument', () => {
     it('should delete document from repository', async () => {
-      const contractId = 'contractId';
       const type = 'documentType';
 
-      await cachedStateRepository.removeDocument(contractId, type, id);
+      await cachedStateRepository.removeDocument(dataContract, type, id);
 
-      expect(stateRepositoryMock.removeDocument).to.be.calledOnceWith(contractId, type, id);
+      expect(stateRepositoryMock.removeDocument).to.be.calledOnceWith(dataContract, type, id);
     });
   });
 
@@ -157,7 +157,9 @@ describe('CachedStateRepositoryDecorator', () => {
 
   describe('#fetchDataContract', () => {
     it('should fetch data contract from cache', async () => {
-      dataContractCacheMock.get.returns(dataContract);
+      const cacheItem = new DataContractCacheItem(dataContract, []);
+
+      dataContractCacheMock.get.returns(cacheItem);
 
       const result = await cachedStateRepository.fetchDataContract(id);
 
@@ -172,9 +174,11 @@ describe('CachedStateRepositoryDecorator', () => {
 
       const result = await cachedStateRepository.fetchDataContract(id);
 
+      const cacheItem = new DataContractCacheItem(dataContract, []);
+
       expect(result).to.equal(dataContract);
       expect(dataContractCacheMock.get).to.be.calledOnceWith(id);
-      expect(dataContractCacheMock.set).to.be.calledOnceWith(id, dataContract);
+      expect(dataContractCacheMock.set).to.be.calledOnceWith(id, cacheItem);
       expect(stateRepositoryMock.fetchDataContract).to.be.calledOnceWith(id);
     });
 

--- a/packages/js-drive/test/unit/dpp/DriveStateRepository.spec.js
+++ b/packages/js-drive/test/unit/dpp/DriveStateRepository.spec.js
@@ -25,7 +25,6 @@ describe('DriveStateRepository', () => {
   let blockExecutionContextMock;
   let simplifiedMasternodeListMock;
   let instantLockMock;
-  let dataContractCacheMock;
   let repositoryOptions;
   let executionContext;
   let operations;
@@ -80,11 +79,6 @@ describe('DriveStateRepository', () => {
       getStore: this.sinon.stub(),
     };
 
-    dataContractCacheMock = {
-      set: this.sinon.stub(),
-      get: this.sinon.stub(),
-    };
-
     repositoryOptions = { useTransaction: true };
 
     stateRepository = new DriveStateRepository(
@@ -97,7 +91,6 @@ describe('DriveStateRepository', () => {
       coreRpcClientMock,
       blockExecutionContextMock,
       simplifiedMasternodeListMock,
-      dataContractCacheMock,
       repositoryOptions,
     );
 
@@ -388,27 +381,13 @@ describe('DriveStateRepository', () => {
 
   describe('#removeDocument', () => {
     it('should delete document from repository', async () => {
-      dataContractCacheMock.get.returns(null);
-      dataContractRepositoryMock.fetch.resolves(
-        new StorageResult(dataContract, operations),
-      );
       documentsRepositoryMock.delete.resolves(
         new StorageResult(undefined, operations),
       );
 
-      const contractId = generateRandomIdentifier();
       const type = 'documentType';
 
-      await stateRepository.removeDocument(contractId, type, id, executionContext);
-
-      expect(dataContractRepositoryMock.fetch).to.be.calledOnceWithExactly(contractId, {
-        useTransaction: false,
-        dryRun: false,
-      });
-      expect(dataContractCacheMock.set).to.be.calledOnceWithExactly(
-        contractId.toString(),
-        dataContract,
-      );
+      await stateRepository.removeDocument(dataContract, type, id, executionContext);
 
       expect(documentsRepositoryMock.delete).to.be.calledOnceWith(
         dataContract,
@@ -420,7 +399,7 @@ describe('DriveStateRepository', () => {
         },
       );
 
-      expect(executionContext.getOperations()).to.deep.equals(operations.concat(operations));
+      expect(executionContext.getOperations()).to.deep.equals(operations);
     });
   });
 

--- a/packages/js-drive/test/unit/dpp/LoggedStateRepositoryDecorator.spec.js
+++ b/packages/js-drive/test/unit/dpp/LoggedStateRepositoryDecorator.spec.js
@@ -508,12 +508,12 @@ describe('LoggedStateRepositoryDecorator', () => {
   });
 
   describe('#removeDocument', () => {
-    let contractId;
+    let dataContract;
     let type;
     let id;
 
     beforeEach(() => {
-      contractId = generateRandomIdentifier();
+      dataContract = getDataContractFixture();
       type = 'type';
       id = generateRandomIdentifier();
     });
@@ -523,12 +523,12 @@ describe('LoggedStateRepositoryDecorator', () => {
 
       stateRepositoryMock.removeDocument.resolves(response);
 
-      await loggedStateRepositoryDecorator.removeDocument(contractId, type, id);
+      await loggedStateRepositoryDecorator.removeDocument(dataContract, type, id);
 
       expect(loggerMock.trace).to.be.calledOnceWithExactly({
         stateRepository: {
           method: 'removeDocument',
-          parameters: { contractId, type, id },
+          parameters: { dataContract, type, id },
           response,
         },
       }, 'StateRepository#removeDocument');
@@ -540,7 +540,7 @@ describe('LoggedStateRepositoryDecorator', () => {
       stateRepositoryMock.removeDocument.throws(error);
 
       try {
-        await loggedStateRepositoryDecorator.removeDocument(contractId, type, id);
+        await loggedStateRepositoryDecorator.removeDocument(dataContract, type, id);
 
         expect.fail('should throw an error');
       } catch (e) {
@@ -550,7 +550,7 @@ describe('LoggedStateRepositoryDecorator', () => {
       expect(loggerMock.trace).to.be.calledOnceWithExactly({
         stateRepository: {
           method: 'removeDocument',
-          parameters: { contractId, type, id },
+          parameters: { dataContract, type, id },
           response: undefined,
         },
       }, 'StateRepository#removeDocument');


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Drive calculates different fees for a state transition depending on the data contract cache state. If a data contract is cached, then the read operation will be skipped. Since the data contract cache is not deterministic this could lead to a chain halt.

## What was done?
<!--- Describe your changes in detail -->
- Calculate fees for a data contract read even if the contract is already cached.
- `StateRepository#removeDocument` now accepts Data Contract to remove additional read operation.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
With tests

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
