### PR TITLE
feat(dpp)!: allow 1 char document type and 1 char property name

### DIFF
--- a/packages/js-dpp/schema/dataContract/dataContractMeta.json
+++ b/packages/js-dpp/schema/dataContract/dataContractMeta.json
@@ -6,7 +6,7 @@
     "documentProperties": {
       "type": "object",
       "patternProperties": {
-        "^[a-zA-Z][a-zA-Z0-9-_]{1,62}[a-zA-Z0-9]$": {
+        "^[a-zA-Z0-9-_]{1,64}$": {
           "type": "object",
           "allOf": [
             {
@@ -17,7 +17,7 @@
         }
       },
       "propertyNames": {
-        "pattern": "^[a-zA-Z][a-zA-Z0-9-_]{1,62}[a-zA-Z0-9]$"
+        "pattern": "^[a-zA-Z0-9-_]{1,64}$"
       },
       "minProperties": 1,
       "maxProperties": 100
@@ -359,7 +359,7 @@
     "documents": {
       "type": "object",
       "propertyNames": {
-        "pattern": "^[a-zA-Z][a-zA-Z0-9-_]{1,62}[a-zA-Z0-9]$"
+        "pattern": "^[a-zA-Z0-9-_]{1,64}$"
       },
       "additionalProperties": {
         "type": "object",
@@ -381,7 +381,7 @@
                       "items": {
                         "type": "object",
                         "propertyNames": {
-                          "pattern": "^[a-zA-Z$][a-zA-Z0-9-_.]{1,62}[a-zA-Z0-9]$"
+                          "pattern": "^[a-zA-Z0-9-_$]{0,1}[a-zA-Z0-9-_.]{1,63}$"
                         },
                         "additionalProperties": {
                           "type": "string",

--- a/packages/js-dpp/schema/dataContract/dataContractMeta.json
+++ b/packages/js-dpp/schema/dataContract/dataContractMeta.json
@@ -381,7 +381,7 @@
                       "items": {
                         "type": "object",
                         "propertyNames": {
-                          "pattern": "^[a-zA-Z0-9-_$]{0,1}[a-zA-Z0-9-_.]{1,63}$"
+                          "maxLength": 256
                         },
                         "additionalProperties": {
                           "type": "string",

--- a/packages/js-dpp/test/integration/dataContract/validation/validateDataContractFactory.spec.js
+++ b/packages/js-dpp/test/integration/dataContract/validation/validateDataContractFactory.spec.js
@@ -1,4 +1,5 @@
 const { getRE2Class } = require('@dashevo/wasm-re2');
+const lodashCloneDeep = require('lodash.clonedeep');
 
 const $RefParser = require('@apidevtools/json-schema-ref-parser');
 
@@ -355,16 +356,23 @@ describe('validateDataContractFactory', function main() {
 
     it('should have valid property names', async () => {
       const validNames = ['validName', 'valid_name', 'valid-name', 'abc', 'ab12c', 'abc123', 'ValidName',
-        'abcdefghigklmnopqrstuvwxyz01234567890abcdefghigklmnopqrstuvwxyz', 'abc_gbf_gdb', 'abc-gbf-gdb'];
+        'abcdefghigklmnopqrstuvwxyz01234567890abcdefghigklmnopqrstuvwxyz', 'abc_gbf_gdb', 'abc-gbf-gdb',
+        '-validname', '_validname', 'validname-', 'validname_', 'a', 'ab', '1', '123', '123_', '-123', '_123'];
 
-      rawDataContract.$defs = {};
       await Promise.all(
         validNames.map(async (name) => {
-          rawDataContract.$defs[name] = {
+          const clonedDataContract = lodashCloneDeep(rawDataContract);
+
+          clonedDataContract.$defs = {};
+          clonedDataContract.$defs[name] = {
             type: 'string',
           };
 
-          const result = await validateDataContract(rawDataContract);
+          clonedDataContract.$defs[name] = {
+            type: 'string',
+          };
+
+          const result = await validateDataContract(clonedDataContract);
 
           expectJsonSchemaError(result, 0);
         }),
@@ -372,16 +380,18 @@ describe('validateDataContractFactory', function main() {
     });
 
     it('should return an invalid result if a property has invalid format', async () => {
-      const invalidNames = ['-invalidname', '_invalidname', 'invalidname-', 'invalidname_', '*(*&^', '$test', '123abci', 'ab'];
+      const invalidNames = ['*(*&^', '$test', '.', '.a'];
 
-      rawDataContract.$defs = {};
       await Promise.all(
         invalidNames.map(async (name) => {
-          rawDataContract.$defs[name] = {
+          const clonedDataContract = lodashCloneDeep(rawDataContract);
+
+          clonedDataContract.$defs = {};
+          clonedDataContract.$defs[name] = {
             type: 'string',
           };
 
-          const result = await validateDataContract(rawDataContract);
+          const result = await validateDataContract(clonedDataContract);
 
           expectJsonSchemaError(result, 2);
 
@@ -441,9 +451,11 @@ describe('validateDataContractFactory', function main() {
 
       await Promise.all(
         validNames.map(async (name) => {
-          rawDataContract.documents[name] = rawDataContract.documents.niceDocument;
+          const clonedDataContract = lodashCloneDeep(rawDataContract);
 
-          const result = await validateDataContract(rawDataContract);
+          clonedDataContract.documents[name] = clonedDataContract.documents.niceDocument;
+
+          const result = await validateDataContract(clonedDataContract);
 
           expectJsonSchemaError(result, 0);
         }),
@@ -451,13 +463,15 @@ describe('validateDataContractFactory', function main() {
     });
 
     it('should return an invalid result if a property (document type) has invalid format', async () => {
-      const invalidNames = ['-invalidname', '_invalidname', 'invalidname-', 'invalidname_', '*(*&^', '$test', '123abc', 'ab'];
+      const invalidNames = ['*(*&^', '$test', '.', '.a'];
 
       await Promise.all(
         invalidNames.map(async (name) => {
-          rawDataContract.documents[name] = rawDataContract.documents.niceDocument;
+          const clonedDataContract = lodashCloneDeep(rawDataContract);
 
-          const result = await validateDataContract(rawDataContract);
+          clonedDataContract.documents[name] = clonedDataContract.documents.niceDocument;
+
+          const result = await validateDataContract(clonedDataContract);
 
           expectJsonSchemaError(result, 2);
 
@@ -563,11 +577,13 @@ describe('validateDataContractFactory', function main() {
 
         await Promise.all(
           validNames.map(async (name) => {
-            rawDataContract.documents.niceDocument.properties[name] = {
+            const clonedDataContract = lodashCloneDeep(rawDataContract);
+
+            clonedDataContract.documents.niceDocument.properties[name] = {
               type: 'string',
             };
 
-            const result = await validateDataContract(rawDataContract);
+            const result = await validateDataContract(clonedDataContract);
 
             expectJsonSchemaError(result, 0);
           }),
@@ -586,11 +602,13 @@ describe('validateDataContractFactory', function main() {
 
         await Promise.all(
           validNames.map(async (name) => {
-            rawDataContract.documents.niceDocument.properties.something.properties[name] = {
+            const clonedDataContract = lodashCloneDeep(rawDataContract);
+
+            clonedDataContract.documents.niceDocument.properties.something.properties[name] = {
               type: 'string',
             };
 
-            const result = await validateDataContract(rawDataContract);
+            const result = await validateDataContract(clonedDataContract);
 
             expectJsonSchemaError(result, 0);
           }),
@@ -598,13 +616,15 @@ describe('validateDataContractFactory', function main() {
       });
 
       it('should return an invalid result if a property has invalid format', async () => {
-        const invalidNames = ['-invalidname', '_invalidname', 'invalidname-', 'invalidname_', '*(*&^', '$test', '123abc', 'ab'];
+        const invalidNames = [ '*(*&^', '$test', '.', '.a'];
 
         await Promise.all(
           invalidNames.map(async (name) => {
-            rawDataContract.documents.niceDocument.properties[name] = {};
+            const clonedDataContract = lodashCloneDeep(rawDataContract);
 
-            const result = await validateDataContract(rawDataContract);
+            clonedDataContract.documents.niceDocument.properties[name] = {};
+
+            const result = await validateDataContract(clonedDataContract);
 
             expectJsonSchemaError(result, 3);
 
@@ -619,7 +639,7 @@ describe('validateDataContractFactory', function main() {
       });
 
       it('should return an invalid result if a nested property has invalid format', async () => {
-        const invalidNames = ['-invalidname', '_invalidname', 'invalidname-', 'invalidname_', '*(*&^', '$test'];
+        const invalidNames = ['*(*&^', '$test', '.', '.a'];
 
         rawDataContract.documents.niceDocument.properties.something = {
           properties: {},
@@ -628,9 +648,11 @@ describe('validateDataContractFactory', function main() {
 
         await Promise.all(
           invalidNames.map(async (name) => {
-            rawDataContract.documents.niceDocument.properties.something.properties[name] = {};
+            const clonedDataContract = lodashCloneDeep(rawDataContract);
 
-            const result = await validateDataContract(rawDataContract);
+            clonedDataContract.documents.niceDocument.properties.something.properties[name] = {};
+
+            const result = await validateDataContract(clonedDataContract);
 
             expectJsonSchemaError(result, 4);
 

--- a/packages/js-dpp/test/integration/dataContract/validation/validateDataContractFactory.spec.js
+++ b/packages/js-dpp/test/integration/dataContract/validation/validateDataContractFactory.spec.js
@@ -616,7 +616,7 @@ describe('validateDataContractFactory', function main() {
       });
 
       it('should return an invalid result if a property has invalid format', async () => {
-        const invalidNames = [ '*(*&^', '$test', '.', '.a'];
+        const invalidNames = ['*(*&^', '$test', '.', '.a'];
 
         await Promise.all(
           invalidNames.map(async (name) => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The old restrictions were dictated by mongoDB. Since we don't use it anymore - the limits have been updated. So we need to allow 1 char document type and 1 char property name. 

## What was done?
<!--- Describe your changes in detail -->
DataContract schema has been changed 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
With tests

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
Previous invalid data contracts in blockchain might be valid now

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
