### PR TITLE
fix(drive)!: cumulative fees are not reset between blocks

### DIFF
--- a/.pnp.cjs
+++ b/.pnp.cjs
@@ -2676,7 +2676,7 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["@dashevo/feature-flags-contract", "workspace:packages/feature-flags-contract"],
             ["@dashevo/grpc-common", "workspace:packages/js-grpc-common"],
             ["@dashevo/masternode-reward-shares-contract", "workspace:packages/masternode-reward-shares-contract"],
-            ["@dashevo/rs-drive", "npm:0.23.0-dev.7"],
+            ["@dashevo/rs-drive", "npm:0.23.0-dev.8"],
             ["@types/pino", "npm:6.3.12"],
             ["ajv", "npm:8.8.1"],
             ["ajv-keywords", "virtual:34fbe5a7dba3086dcbcce8a7faed986b10f7a208f11db70499feb2c1afd76e24089e5b95f9e3b937e89512de1cf4937177cc2000303a1e908baefc73362a7d48#npm:5.0.0"],
@@ -2919,10 +2919,10 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
         }]
       ]],
       ["@dashevo/rs-drive", [
-        ["npm:0.23.0-dev.7", {
-          "packageLocation": "./.yarn/unplugged/@dashevo-rs-drive-npm-0.23.0-dev.7-cda2443644/node_modules/@dashevo/rs-drive/",
+        ["npm:0.23.0-dev.8", {
+          "packageLocation": "./.yarn/unplugged/@dashevo-rs-drive-npm-0.23.0-dev.8-a11a98b062/node_modules/@dashevo/rs-drive/",
           "packageDependencies": [
-            ["@dashevo/rs-drive", "npm:0.23.0-dev.7"],
+            ["@dashevo/rs-drive", "npm:0.23.0-dev.8"],
             ["@dashevo/dpp", "npm:0.22.1"],
             ["cargo-cp-artifact", "npm:0.1.6"],
             ["cbor", "npm:8.1.0"],

--- a/packages/js-drive/lib/blockExecution/BlockExecutionContext.js
+++ b/packages/js-drive/lib/blockExecution/BlockExecutionContext.js
@@ -15,14 +15,7 @@ const Long = require('long');
 
 class BlockExecutionContext {
   constructor() {
-    this.dataContracts = [];
-    this.cumulativeProcessingFee = 0;
-    this.cumulativeStorageFee = 0;
-    this.header = null;
-    this.lastCommitInfo = null;
-    this.validTxs = 0;
-    this.invalidTxs = 0;
-    this.consensusLogger = null;
+    this.reset();
   }
 
   /**
@@ -199,7 +192,8 @@ class BlockExecutionContext {
    */
   reset() {
     this.dataContracts = [];
-    this.cumulativeFees = 0;
+    this.cumulativeProcessingFee = 0;
+    this.cumulativeStorageFee = 0;
     this.header = null;
     this.lastCommitInfo = null;
     this.validTxs = 0;
@@ -224,7 +218,8 @@ class BlockExecutionContext {
   populate(blockExecutionContext) {
     this.dataContracts = blockExecutionContext.dataContracts;
     this.lastCommitInfo = blockExecutionContext.lastCommitInfo;
-    this.cumulativeFees = blockExecutionContext.cumulativeFees;
+    this.cumulativeProcessingFee = blockExecutionContext.cumulativeProcessingFee;
+    this.cumulativeStorageFee = blockExecutionContext.cumulativeStorageFee;
     this.header = blockExecutionContext.header;
     this.validTxs = blockExecutionContext.validTxs;
     this.invalidTxs = blockExecutionContext.invalidTxs;
@@ -234,13 +229,16 @@ class BlockExecutionContext {
   /**
    * Populate the current instance with data
    *
-   * @param object
+   * @param {Object} object
    */
   fromObject(object) {
     this.dataContracts = object.dataContracts
       .map((rawDataContract) => new DataContract(rawDataContract));
     this.lastCommitInfo = LastCommitInfo.fromObject(object.lastCommitInfo);
-    this.cumulativeFees = object.cumulativeFees;
+
+    this.cumulativeProcessingFee = object.cumulativeProcessingFee;
+    this.cumulativeStorageFee = object.cumulativeStorageFee;
+
     this.header = Header.fromObject(object.header);
     this.validTxs = object.validTxs;
     this.invalidTxs = object.invalidTxs;
@@ -258,7 +256,8 @@ class BlockExecutionContext {
    *  invalidTxs: number,
    *  header: null,
    *  validTxs: number,
-   *  cumulativeFees: number
+   *  cumulativeProcessingFee: number,
+   *  cumulativeStorageFee: number
    * }}
    */
   toObject(options = {}) {
@@ -269,7 +268,8 @@ class BlockExecutionContext {
 
     const object = {
       dataContracts: this.dataContracts.map((dataContract) => dataContract.toObject()),
-      cumulativeFees: this.cumulativeFees,
+      cumulativeProcessingFee: this.cumulativeProcessingFee,
+      cumulativeStorageFee: this.cumulativeStorageFee,
       header,
       lastCommitInfo: LastCommitInfo.toObject(this.lastCommitInfo),
       validTxs: this.validTxs,

--- a/packages/js-drive/lib/document/DocumentRepository.js
+++ b/packages/js-drive/lib/document/DocumentRepository.js
@@ -113,39 +113,6 @@ class DocumentRepository {
   }
 
   /**
-   * @param {Document} document
-   * @param {Object} [options]
-   * @param {boolean} [options.useTransaction=false]
-   * @param {boolean} [options.dryRun=false]
-   *
-   * @return {Promise<StorageResult<boolean>>}
-   */
-  async isExist(document, options = { }) {
-    const documentTypeTreePath = createDocumentTypeTreePath(
-      document.getDataContract(),
-      document.getType(),
-    );
-
-    const documentTreePath = documentTypeTreePath.concat(
-      [Buffer.from([0])],
-    );
-
-    const result = await this.storage.get(
-      documentTreePath,
-      document.getId().toBuffer(),
-      {
-        useTransaction: Boolean(options.useTransaction),
-        dryRun: Boolean(options.dryRun),
-      },
-    );
-
-    return new StorageResult(
-      Boolean(result.getValue()),
-      result.getOperations(),
-    );
-  }
-
-  /**
    * Find documents with query
    *
    * @param {DataContract} dataContract

--- a/packages/js-drive/lib/document/DocumentRepository.js
+++ b/packages/js-drive/lib/document/DocumentRepository.js
@@ -3,7 +3,6 @@ const { createHash } = require('crypto');
 const lodashCloneDeep = require('lodash.clonedeep');
 
 const PreCalculatedOperation = require('@dashevo/dpp/lib/stateTransition/fee/operations/PreCalculatedOperation');
-const createDocumentTypeTreePath = require('./groveDB/createDocumentTreePath');
 const InvalidQueryError = require('./errors/InvalidQueryError');
 const StorageResult = require('../storage/StorageResult');
 const DataContractStoreRepository = require('../dataContract/DataContractStoreRepository');

--- a/packages/js-drive/lib/test/fixtures/getBlockExecutionContextObjectFixture.js
+++ b/packages/js-drive/lib/test/fixtures/getBlockExecutionContextObjectFixture.js
@@ -26,7 +26,8 @@ const getDataContractFixture = require('@dashevo/dpp/lib/test/fixtures/getDataCo
  *   invalidTxs: number,
  *   header: Object,
  *   validTxs: number,
- *   cumulativeFees: number,
+ *   cumulativeStorageFee: number,
+ *   cumulativeProcessingFee: number,
  *   consensusLogger: Logger,
  * }}
  */
@@ -45,21 +46,15 @@ function getBlockExecutionContextObjectFixture(dataContract = getDataContractFix
     }),
   });
 
-  const cumulativeFees = 10;
-
-  const logger = pino();
-
-  const validTxs = 2;
-  const invalidTxs = 1;
-
   return {
     dataContracts: [dataContract.toObject()],
     lastCommitInfo: LastCommitInfo.toObject(lastCommitInfo),
-    cumulativeFees,
+    cumulativeProcessingFee: 1000,
+    cumulativeStorageFee: 2000,
     header: Header.toObject(header),
-    validTxs,
-    invalidTxs,
-    consensusLogger: logger,
+    validTxs: 2,
+    invalidTxs: 1,
+    consensusLogger: pino(),
   };
 }
 

--- a/packages/js-drive/package.json
+++ b/packages/js-drive/package.json
@@ -76,7 +76,7 @@
     "@dashevo/feature-flags-contract": "workspace:~",
     "@dashevo/grpc-common": "workspace:~",
     "@dashevo/masternode-reward-shares-contract": "workspace:~",
-    "@dashevo/rs-drive": "0.23.0-dev.7",
+    "@dashevo/rs-drive": "0.23.0-dev.8",
     "ajv": "^8.6.0",
     "ajv-keywords": "^5.0.0",
     "awilix": "^4.2.6",

--- a/packages/js-drive/test/unit/abci/handlers/commitHandlerFactory.spec.js
+++ b/packages/js-drive/test/unit/abci/handlers/commitHandlerFactory.spec.js
@@ -26,7 +26,6 @@ describe('commitHandlerFactory', () => {
   let appHash;
   let blockExecutionContextMock;
   let dataContract;
-  let accumulativeFees;
   let rootTreeMock;
   let dppMock;
   let header;
@@ -45,7 +44,6 @@ describe('commitHandlerFactory', () => {
     blockExecutionContextMock = new BlockExecutionContextMock(this.sinon);
 
     blockExecutionContextMock.getDataContracts.returns([dataContract]);
-    blockExecutionContextMock.getCumulativeProcessingFee.returns(accumulativeFees);
 
     header = {
       height: Long.fromInt(1),

--- a/packages/js-drive/test/unit/blockExecution/BlockExecutionContext.spec.js
+++ b/packages/js-drive/test/unit/blockExecution/BlockExecutionContext.spec.js
@@ -19,7 +19,8 @@ describe('BlockExecutionContext', () => {
   let lastCommitInfo;
   let header;
   let logger;
-  let cumulativeFees;
+  let cumulativeProcessingFee;
+  let cumulativeStorageFee;
   let plainObject;
   let validTxs;
   let invalidTxs;
@@ -36,7 +37,8 @@ describe('BlockExecutionContext', () => {
     header = Header.fromObject(plainObject.header);
 
     logger = plainObject.consensusLogger;
-    cumulativeFees = plainObject.cumulativeFees;
+    cumulativeProcessingFee = plainObject.cumulativeProcessingFee;
+    cumulativeStorageFee = plainObject.cumulativeStorageFee;
     validTxs = plainObject.validTxs;
     invalidTxs = plainObject.invalidTxs;
   });
@@ -88,11 +90,11 @@ describe('BlockExecutionContext', () => {
 
       expect(result).to.equal(0);
 
-      blockExecutionContext.cumulativeProcessingFee = cumulativeFees;
+      blockExecutionContext.cumulativeProcessingFee = cumulativeProcessingFee;
 
       result = blockExecutionContext.getCumulativeProcessingFee();
 
-      expect(result).to.equal(cumulativeFees);
+      expect(result).to.equal(cumulativeProcessingFee);
     });
   });
 
@@ -102,11 +104,11 @@ describe('BlockExecutionContext', () => {
 
       expect(result).to.equal(0);
 
-      blockExecutionContext.cumulativeStorageFee = cumulativeFees;
+      blockExecutionContext.cumulativeStorageFee = cumulativeStorageFee;
 
       result = blockExecutionContext.getCumulativeStorageFee();
 
-      expect(result).to.equal(cumulativeFees);
+      expect(result).to.equal(cumulativeStorageFee);
     });
   });
 
@@ -194,7 +196,8 @@ describe('BlockExecutionContext', () => {
 
       anotherBlockExecutionContext.dataContracts = [dataContract];
       anotherBlockExecutionContext.lastCommitInfo = lastCommitInfo;
-      anotherBlockExecutionContext.cumulativeFees = cumulativeFees;
+      anotherBlockExecutionContext.cumulativeProcessingFee = cumulativeProcessingFee;
+      anotherBlockExecutionContext.cumulativeStorageFee = cumulativeStorageFee;
       anotherBlockExecutionContext.header = header;
       anotherBlockExecutionContext.validTxs = validTxs;
       anotherBlockExecutionContext.invalidTxs = invalidTxs;
@@ -208,8 +211,11 @@ describe('BlockExecutionContext', () => {
       expect(blockExecutionContext.lastCommitInfo).to.equal(
         anotherBlockExecutionContext.lastCommitInfo,
       );
-      expect(blockExecutionContext.cumulativeFees).to.equal(
-        anotherBlockExecutionContext.cumulativeFees,
+      expect(blockExecutionContext.cumulativeProcessingFee).to.equal(
+        anotherBlockExecutionContext.cumulativeProcessingFee,
+      );
+      expect(blockExecutionContext.cumulativeStorageFee).to.equal(
+        anotherBlockExecutionContext.cumulativeStorageFee,
       );
       expect(blockExecutionContext.header).to.equal(
         anotherBlockExecutionContext.header,
@@ -230,7 +236,8 @@ describe('BlockExecutionContext', () => {
     it('should return a plain object', () => {
       blockExecutionContext.dataContracts = [dataContract];
       blockExecutionContext.lastCommitInfo = lastCommitInfo;
-      blockExecutionContext.cumulativeFees = cumulativeFees;
+      blockExecutionContext.cumulativeProcessingFee = cumulativeProcessingFee;
+      blockExecutionContext.cumulativeStorageFee = cumulativeStorageFee;
       blockExecutionContext.header = header;
       blockExecutionContext.validTxs = validTxs;
       blockExecutionContext.invalidTxs = invalidTxs;
@@ -242,7 +249,8 @@ describe('BlockExecutionContext', () => {
     it('should skipConsensusLogger if the option passed', () => {
       blockExecutionContext.dataContracts = [dataContract];
       blockExecutionContext.lastCommitInfo = lastCommitInfo;
-      blockExecutionContext.cumulativeFees = cumulativeFees;
+      blockExecutionContext.cumulativeProcessingFee = cumulativeProcessingFee;
+      blockExecutionContext.cumulativeStorageFee = cumulativeStorageFee;
       blockExecutionContext.header = header;
       blockExecutionContext.validTxs = validTxs;
       blockExecutionContext.invalidTxs = invalidTxs;
@@ -268,7 +276,8 @@ describe('BlockExecutionContext', () => {
         [dataContract],
       );
       expect(blockExecutionContext.lastCommitInfo).to.deep.equal(lastCommitInfo);
-      expect(blockExecutionContext.cumulativeFees).to.equal(cumulativeFees);
+      expect(blockExecutionContext.cumulativeProcessingFee).to.equal(cumulativeProcessingFee);
+      expect(blockExecutionContext.cumulativeStorageFee).to.equal(cumulativeStorageFee);
       expect(blockExecutionContext.header).to.deep.equal(header);
       expect(blockExecutionContext.validTxs).to.equal(validTxs);
       expect(blockExecutionContext.invalidTxs).to.equal(invalidTxs);

--- a/yarn.lock
+++ b/yarn.lock
@@ -1665,7 +1665,7 @@ __metadata:
     "@dashevo/feature-flags-contract": "workspace:~"
     "@dashevo/grpc-common": "workspace:~"
     "@dashevo/masternode-reward-shares-contract": "workspace:~"
-    "@dashevo/rs-drive": 0.23.0-dev.7
+    "@dashevo/rs-drive": 0.23.0-dev.8
     "@types/pino": ^6.3.0
     ajv: ^8.6.0
     ajv-keywords: ^5.0.0
@@ -1889,16 +1889,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@dashevo/rs-drive@npm:0.23.0-dev.7":
-  version: 0.23.0-dev.7
-  resolution: "@dashevo/rs-drive@npm:0.23.0-dev.7"
+"@dashevo/rs-drive@npm:0.23.0-dev.8":
+  version: 0.23.0-dev.8
+  resolution: "@dashevo/rs-drive@npm:0.23.0-dev.8"
   dependencies:
     "@dashevo/dpp": ~0.22.0-dev.7
     cargo-cp-artifact: ^0.1.6
     cbor: ^8.1.0
     neon-load-or-build: ^2.2.2
     neon-tag-prebuild: "github:shumkov/neon-tag-prebuild#patch-1"
-  checksum: 386ca34fdde97a89a49dfac4032e88233354368079e90e19a861dee78da6939a96d5dbcb7fb56f4a5966b5c5012374cefec799f9432c8a9cbdafc6ddb31a47aa
+  checksum: ac7c17a4a191dc6a24078099c80f5d259a8c932ea2ba8abbee5f8cdfb4dc52a813d89e396468cebdaaa26ce34fb09128bf138ac6e3f7d667d8826e18dfeb7b3a
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Cumulative fees for block should be reset on the next begin block but it's not.

## What was done?
<!--- Describe your changes in detail -->
- Reset storage and processing cumulative fees in block execution context

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Unit tests

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
Correct cumulative fees invalidate previous blockchain data

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
