### PR TITLE
fix(dpp): repeated disabling of already disabled identity key

### DIFF
--- a/packages/dashmate/configs/system/base.js
+++ b/packages/dashmate/configs/system/base.js
@@ -117,7 +117,7 @@ module.exports = {
       },
       tenderdash: {
         docker: {
-          image: 'dashpay/tenderdash:0.8.0-dev.4',
+          image: 'dashpay/tenderdash:0.8.0-dev.7',
         },
         p2p: {
           port: 26656,

--- a/packages/dashmate/configs/system/base.js
+++ b/packages/dashmate/configs/system/base.js
@@ -117,7 +117,7 @@ module.exports = {
       },
       tenderdash: {
         docker: {
-          image: 'dashpay/tenderdash:0.8.0-dev.7',
+          image: 'dashpay/tenderdash:0.8.0-dev.4',
         },
         p2p: {
           port: 26656,

--- a/packages/js-dpp/lib/errors/consensus/codes.js
+++ b/packages/js-dpp/lib/errors/consensus/codes.js
@@ -82,6 +82,7 @@ const InvalidSignaturePublicKeySecurityLevelError = require('./signature/Invalid
 const PublicKeyIsDisabledError = require('./signature/PublicKeyIsDisabledError');
 const PublicKeySecurityLevelNotMetError = require('./signature/PublicKeySecurityLevelNotMetError');
 const WrongPublicKeyPurposeError = require('./signature/WrongPublicKeyPurposeError');
+const IdentityPublicKeyIsDisabledError = require('./state/identity/IdentityPublicKeyIsDisabledError');
 
 const codes = {
   /**
@@ -203,6 +204,7 @@ const codes = {
   4020: StateMaxIdentityPublicKeyLimitReachedError,
   4021: DuplicatedIdentityPublicKeyStateError,
   4022: DuplicatedIdentityPublicKeyIdStateError,
+  4023: IdentityPublicKeyIsDisabledError,
 };
 
 module.exports = codes;

--- a/packages/js-dpp/lib/errors/consensus/state/identity/IdentityPublicKeyIsDisabledError.js
+++ b/packages/js-dpp/lib/errors/consensus/state/identity/IdentityPublicKeyIsDisabledError.js
@@ -1,0 +1,22 @@
+const AbstractStateError = require('../AbstractStateError');
+
+class IdentityPublicKeyIsDisabledError extends AbstractStateError {
+  /**
+   * @param {number} publicKeyIndex
+   */
+  constructor(publicKeyIndex) {
+    super(`Identity Public Key #${publicKeyIndex} is disabled`);
+
+    this.publicKeyIndex = publicKeyIndex;
+  }
+
+  /**
+   *
+   * @returns {number}
+   */
+  getPublicKeyIndex() {
+    return this.publicKeyIndex;
+  }
+}
+
+module.exports = IdentityPublicKeyIsDisabledError;

--- a/packages/js-dpp/lib/identity/IdentityPublicKey.js
+++ b/packages/js-dpp/lib/identity/IdentityPublicKey.js
@@ -189,6 +189,13 @@ class IdentityPublicKey {
   }
 
   /**
+   * Is public key disabled
+   */
+  isDisabled() {
+    return this.getDisabledAt() !== undefined;
+  }
+
+  /**
    * Set signature
    *
    * @param {Buffer} signature

--- a/packages/js-dpp/test/integration/identity/stateTransition/IdentityUpdateTransition/validation/state/validateIdentityUpdateTransitionStateFactory.spec.js
+++ b/packages/js-dpp/test/integration/identity/stateTransition/IdentityUpdateTransition/validation/state/validateIdentityUpdateTransitionStateFactory.spec.js
@@ -11,6 +11,7 @@ const IdentityPublicKeyDisabledAtWindowViolationError = require('../../../../../
 const InvalidIdentityPublicKeyIdError = require('../../../../../../../lib/errors/consensus/state/identity/InvalidIdentityPublicKeyIdError');
 const SomeConsensusError = require('../../../../../../../lib/test/mocks/SomeConsensusError');
 const StateTransitionExecutionContext = require('../../../../../../../lib/stateTransition/StateTransitionExecutionContext');
+const IdentityPublicKeyIsDisabledError = require('../../../../../../../lib/errors/consensus/state/identity/IdentityPublicKeyIsDisabledError');
 
 describe('validateIdentityUpdateTransitionStateFactory', () => {
   let validateIdentityUpdateTransitionState;
@@ -88,6 +89,18 @@ describe('validateIdentityUpdateTransitionStateFactory', () => {
     const result = await validateIdentityUpdateTransitionState(stateTransition);
 
     expectValidationError(result, IdentityPublicKeyIsReadOnlyError);
+
+    const [error] = result.getErrors();
+    expect(error.getPublicKeyIndex()).to.equal(0);
+  });
+
+  it('should return IdentityPublicKeyIsDisabledError if disabling public key is already disabled', async () => {
+    identity.getPublicKeyById(0).setDisabledAt(new Date().getTime());
+    stateTransition.setPublicKeyIdsToDisable([0]);
+
+    const result = await validateIdentityUpdateTransitionState(stateTransition);
+
+    expectValidationError(result, IdentityPublicKeyIsDisabledError);
 
     const [error] = result.getErrors();
     expect(error.getPublicKeyIndex()).to.equal(0);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
It is possible to disable the already disabled identity public key and update `disabledAt` timestamp.

## What was done?
<!--- Describe your changes in detail -->
- Return `IdentityPublicKeyIsDisabledError` if identity key is already disabled

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
WIth tests

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
