### PR TITLE
fix(dapi-client): node marked as banned on retriable JSON RPC error

### DIFF
--- a/packages/js-dapi-client/lib/transport/JsonRpcTransport/JsonRpcTransport.js
+++ b/packages/js-dapi-client/lib/transport/JsonRpcTransport/JsonRpcTransport.js
@@ -84,13 +84,13 @@ class JsonRpcTransport {
         throw error;
       }
 
-      address.markAsBanned();
-
       const responseError = this.createJsonTransportError(error, address);
 
       if (!(responseError instanceof RetriableResponseError)) {
         throw responseError;
       }
+
+      address.markAsBanned();
 
       if (options.retries === 0) {
         throw new MaxRetriesReachedError(responseError);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
DAPI client marks node as banned in case of invalid arguments for JSON RPC requests

## What was done?
<!--- Describe your changes in detail -->
- Mark as banned only on retriable error

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
With tests

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
No

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
