### PR TITLE
fix(dapi-client): A.metadata.get is not a function

### DIFF
--- a/packages/js-dapi-client/lib/transport/GrpcTransport/createGrpcTransportError.js
+++ b/packages/js-dapi-client/lib/transport/GrpcTransport/createGrpcTransportError.js
@@ -47,36 +47,34 @@ function createGrpcTransportError(grpcError, dapiAddress) {
   // Extract error code and data
   let data = {};
   let { code } = grpcError;
+
   const message = grpcError.details || grpcError.message;
 
   if (grpcError.metadata) {
-    let encodedData;
-
+    // In cases of gRPC-Web client we get plain map instead of Metadata instance
+    let metadataMap = grpcError.metadata;
     if (grpcError.metadata instanceof Metadata) {
-      const cboredMetaData = grpcError.metadata.get('drive-error-data-bin');
-      if (cboredMetaData && cboredMetaData.length > 0) {
-        [encodedData] = cboredMetaData;
-      }
-
-      // since gRPC doesn't allow to use custom error codes
-      // DAPI pass them as a part of metadata
-      const metaCode = grpcError.metadata.get('code');
-      if (metaCode && metaCode.length > 0) {
-        [code] = metaCode;
-      }
-    } else {
-      if (grpcError.metadata['drive-error-data-bin']) {
-        encodedData = Buffer.from(grpcError.metadata['drive-error-data-bin'], 'base64');
-      }
-
-      const metaCode = grpcError.metadata.code;
-      if (metaCode !== undefined) {
-        code = Number(metaCode);
-      }
+      metadataMap = grpcError.metadata.getMap();
     }
 
-    if (encodedData) {
+    // Error data
+    const driveErrorData = metadataMap['drive-error-data-bin'];
+    if (driveErrorData) {
+      const encodedData = Buffer.from(driveErrorData, 'base64');
       data = cbor.decode(encodedData);
+    }
+
+    // Error code
+    const driveErrorCode = metadataMap.code;
+    if (driveErrorCode) {
+      code = Number(driveErrorCode);
+    }
+
+    // Error stack
+    const driveErrorStack = metadataMap['stack-bin'];
+    if (driveErrorStack) {
+      const encodedStack = Buffer.from(driveErrorStack, 'base64');
+      data.stack = cbor.decode(encodedStack);
     }
   }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Floating error in test suite running in a browser
```
TypeError: A.metadata.get is not a function
[146](https://github.com/dashevo/platform/runs/7894472793?check_suite_focus=true#step:15:147)
            at A.exports [as createGrpcTransportError] (/tmp/_karma_webpack_750351/commons.js:147688:2164070)
[147](https://github.com/dashevo/platform/runs/7894472793?check_suite_focus=true#step:15:148)
            at GrpcTransport.request (/tmp/_karma_webpack_750351/commons.js:147688:2162587)
[148](https://github.com/dashevo/platform/runs/7894472793?check_suite_focus=true#step:15:149)
            at async PlatformMethodsFacade.getConsensusParams (/tmp/_karma_webpack_750351/commons.js:147688:2152071)
[149](https://github.com/dashevo/platform/runs/7894472793?check_suite_focus=true#step:15:150)
            at async Context.<anonymous> (/tmp/_karma_webpack_750351/commons.js:151559:30)
```

## What was done?
<!--- Describe your changes in detail -->
- Handle gRPC-Web metadata for `stack-bin` as well 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Running locally

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
