### PR TITLE
build: new node alpine image breaks package builds

### DIFF
--- a/packages/dapi/Dockerfile
+++ b/packages/dapi/Dockerfile
@@ -1,5 +1,5 @@
 # syntax = docker/dockerfile:1.3
-FROM node:16-alpine as builder
+FROM node:16.16-alpine as builder
 
 ARG NODE_ENV=production
 ENV NODE_ENV ${NODE_ENV}
@@ -42,7 +42,7 @@ RUN --mount=type=cache,target=/tmp/unplugged \
     cp -R /platform/.yarn/unplugged /tmp/
 
 
-FROM node:16-alpine
+FROM node:16.16-alpine
 
 ARG NODE_ENV=production
 ENV NODE_ENV ${NODE_ENV}

--- a/packages/js-drive/Dockerfile
+++ b/packages/js-drive/Dockerfile
@@ -1,5 +1,5 @@
 # syntax = docker/dockerfile:1.3
-FROM node:16-alpine as builder
+FROM node:16.16-alpine as builder
 
 ARG NODE_ENV=production
 ENV NODE_ENV ${NODE_ENV}
@@ -43,7 +43,7 @@ RUN --mount=type=cache,target=/tmp/unplugged \
     yarn workspaces focus --production @dashevo/drive && \
     cp -R /platform/.yarn/unplugged /tmp/
 
-FROM node:16-alpine
+FROM node:16.16-alpine
 
 ARG NODE_ENV=production
 ENV NODE_ENV ${NODE_ENV}

--- a/packages/platform-test-suite/Dockerfile
+++ b/packages/platform-test-suite/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:16-alpine as builder
+FROM node:16.16-alpine as builder
 
 ARG NODE_ENV=production
 ENV NODE_ENV ${NODE_ENV}
@@ -40,7 +40,7 @@ RUN --mount=type=cache,target=/tmp/unplugged \
     yarn workspaces focus --production @dashevo/platform-test-suite && \
     cp -R /platform/.yarn/unplugged /tmp/
 
-FROM node:16-alpine
+FROM node:16.16-alpine
 
 ARG NODE_ENV=production
 ENV NODE_ENV ${NODE_ENV}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Node image was updated recently https://github.com/nodejs/docker-node/commit/9e9c0ecbd938e672add198b3cbbb2ab7704f6970 that was built with updated alpine image https://github.com/alpinelinux/docker-alpine/commit/adebcfd075c83ef788b5f071678dcfb8ea118bb3

It seems alpine 3.16.2 did something bad with dependencies so NPM package builds doesn't work anymore

## What was done?
<!--- Describe your changes in detail -->
- Downgrade base image to `node:16.16-alpine` 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Locally

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
