### PR TITLE
fix(dapi): getStatus errored if masternode is banned

### DIFF
--- a/packages/dapi/lib/config/index.js
+++ b/packages/dapi/lib/config/index.js
@@ -56,7 +56,7 @@ Object
 const config = { ...DEFAULT_CONFIG, ...envConfig };
 
 module.exports = {
-  livenet: Boolean(config[OPTIONS.LIVENET]),
+  livenet: config[OPTIONS.LIVENET] === 'true',
   rpcServer: {
     port: parseInt(config[OPTIONS.API_JSON_RPC_PORT], 10),
   },

--- a/packages/dapi/lib/grpcServer/handlers/core/getStatusHandlerFactory.js
+++ b/packages/dapi/lib/grpcServer/handlers/core/getStatusHandlerFactory.js
@@ -53,7 +53,11 @@ function getStatusHandlerFactory(coreRPCClient) {
     const masternodeStatus = GetStatusResponse.Masternode.Status[masternodeStatusResponse.state];
 
     masternode.setStatus(masternodeStatus);
-    masternode.setProTxHash(Buffer.from(masternodeStatusResponse.proTxHash, 'hex'));
+
+    if (masternodeStatusResponse.proTxHash) {
+      masternode.setProTxHash(Buffer.from(masternodeStatusResponse.proTxHash, 'hex'));
+    }
+
     masternode.setPosePenalty(masternodeStatusResponse.dmnState.PoSePenalty);
     masternode.setIsSynced(mnSyncStatusResponse.IsSynced);
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
```
TypeError [ERR_INVALID_ARG_TYPE]: The first argument must be of type string or an instance of Buffer, ArrayBuffer, or Array or an Array-like Object. Received undefined
    at new NodeError (node:internal/errors:372:5)
    at Function.from (node:buffer:323:9)
    at getStatusHandler (/platform/packages/dapi/lib/grpcServer/handlers/core/getStatusHandlerFactory.js:56:36)
    at runMicrotasks (<anonymous>)
    at processTicksAndRejections (node:internal/process/task_queues:96:5)
    at async rpcMethodErrorHandler (/platform/packages/js-grpc-common/lib/server/error/wrapInErrorHandlerFactory.js:25:24) {
  code: 'ERR_INVALID_ARG_TYPE'
}
```

In case a masternode is banned

## What was done?
<!--- Describe your changes in detail -->
- Do not respond with proTxHash if masternode is banned
- Propoerly parse livenet config option

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
None

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
