### PR TITLE
fix: Drive and DAPI expect data available on H+1 block

### DIFF
--- a/packages/dapi/lib/errors/TransactionWaitPeriodExceededError.js
+++ b/packages/dapi/lib/errors/TransactionWaitPeriodExceededError.js
@@ -1,14 +1,10 @@
 class TransactionWaitPeriodExceededError extends Error {
   /**
    * @param {string} transactionHash
-   * @param originalStack
    */
-  constructor(transactionHash, originalStack) {
+  constructor(transactionHash) {
     const message = `Transaction waiting period for ${transactionHash} exceeded`;
     super(message);
-    if (originalStack) {
-      this.stack = originalStack;
-    }
 
     this.transactionHash = transactionHash;
   }

--- a/packages/dapi/lib/externalApis/tenderdash/waitForTransactionToBeProvable/waitForTransactionToBeProvableFactory.js
+++ b/packages/dapi/lib/externalApis/tenderdash/waitForTransactionToBeProvable/waitForTransactionToBeProvableFactory.js
@@ -1,16 +1,13 @@
 const TransactionWaitPeriodExceededError = require('../../../errors/TransactionWaitPeriodExceededError');
-const TransactionOkResult = require('./transactionResult/TransactionOkResult');
 
 /**
  * @param {waitForTransactionResult} waitForTransactionResult
  * @param {getExistingTransactionResult} getExistingTransactionResult
- * @param {waitForHeight} waitForHeight
  * @return {waitForTransactionToBeProvable}
  */
 function waitForTransactionToBeProvableFactory(
   waitForTransactionResult,
   getExistingTransactionResult,
-  waitForHeight,
 ) {
   /**
    * Returns result for a transaction or rejects after a timeout
@@ -45,21 +42,15 @@ function waitForTransactionToBeProvableFactory(
         return Promise.reject(error);
       }),
 
-      // Wait for upcoming results if transaction result doesn't not exist yet
+      // Wait for upcoming results if transaction is not executed yet and result is not present
       waitForTransactionResultPromise,
     ]);
 
     return Promise.race([
-      // Wait for transaction results and commitment
-      transactionResultPromise.then(async (result) => {
-        if (result instanceof TransactionOkResult) {
-          await waitForHeight(result.getHeight() + 1);
-        }
+      // Get transaction result
+      transactionResultPromise,
 
-        return result;
-      }),
-
-      // Throw wait period exceeded error after timeout
+      // Throw an error when wait period exceeded
       new Promise((resolve, reject) => {
         setTimeout(() => {
           // Detaching handlers

--- a/packages/dapi/lib/grpcServer/handlers/platform/platformHandlersFactory.js
+++ b/packages/dapi/lib/grpcServer/handlers/platform/platformHandlersFactory.js
@@ -179,12 +179,9 @@ function platformHandlersFactory(
     rpcClient,
   );
 
-  const waitForHeight = waitForHeightFactory(blockchainListener);
-
   const waitForTransactionToBeProvable = waitForTransactionToBeProvableFactory(
     waitForTransactionResult,
     getExistingTransactionResult,
-    waitForHeight,
   );
 
   const waitForStateTransitionResultHandler = waitForStateTransitionResultHandlerFactory(

--- a/packages/dapi/lib/grpcServer/handlers/platform/platformHandlersFactory.js
+++ b/packages/dapi/lib/grpcServer/handlers/platform/platformHandlersFactory.js
@@ -70,7 +70,6 @@ const getConsensusParamsHandlerFactory = require(
 const fetchProofForStateTransitionFactory = require('../../../externalApis/drive/fetchProofForStateTransitionFactory');
 const waitForTransactionToBeProvableFactory = require('../../../externalApis/tenderdash/waitForTransactionToBeProvable/waitForTransactionToBeProvableFactory');
 const waitForTransactionResult = require('../../../externalApis/tenderdash/waitForTransactionToBeProvable/waitForTransactionResult');
-const waitForHeightFactory = require('../../../externalApis/tenderdash/waitForHeightFactory');
 const getExistingTransactionResultFactory = require('../../../externalApis/tenderdash/waitForTransactionToBeProvable/getExistingTransactionResult');
 const getConsensusParamsFactory = require('../../../externalApis/tenderdash/getConsensusParamsFactory');
 

--- a/packages/dapi/test/integration/grpcServer/handlers/platform/waitForStateTransitionResultHandlerFactory.js
+++ b/packages/dapi/test/integration/grpcServer/handlers/platform/waitForStateTransitionResultHandlerFactory.js
@@ -30,7 +30,6 @@ const waitForTransactionToBeProvableFactory = require('../../../../../lib/extern
 const waitForTransactionResult = require('../../../../../lib/externalApis/tenderdash/waitForTransactionToBeProvable/waitForTransactionResult');
 
 const waitForStateTransitionResultHandlerFactory = require('../../../../../lib/grpcServer/handlers/platform/waitForStateTransitionResultHandlerFactory');
-const waitForHeightFactory = require('../../../../../lib/externalApis/tenderdash/waitForHeightFactory');
 
 describe('waitForStateTransitionResultHandlerFactory', () => {
   let call;
@@ -190,10 +189,6 @@ describe('waitForStateTransitionResultHandlerFactory', () => {
 
     fetchProofForStateTransition = fetchProofForStateTransitionFactory(driveClientMock);
 
-    const waitForHeight = waitForHeightFactory(
-      blockchainListener,
-    );
-
     transactionNotFoundError = new Error();
 
     transactionNotFoundError.code = -32603;
@@ -204,7 +199,6 @@ describe('waitForStateTransitionResultHandlerFactory', () => {
     waitForTransactionToBeProvable = waitForTransactionToBeProvableFactory(
       waitForTransactionResult,
       getExistingTransactionResult,
-      waitForHeight,
     );
 
     createGrpcErrorFromDriveResponseMock = this.sinon.stub().returns(

--- a/packages/dapi/test/unit/externalApis/tenderdash/waitForTransactionToBeProvable/waitForTransactionToBeProvableFactory.spec.js
+++ b/packages/dapi/test/unit/externalApis/tenderdash/waitForTransactionToBeProvable/waitForTransactionToBeProvableFactory.spec.js
@@ -34,7 +34,6 @@ describe('waitForTransactionToBeProvableFactory', () => {
       waitForTransactionResultResponse,
     );
 
-
     waitForTransactionToBeProvable = waitForTransactionToBeProvableFactory(
       waitForTransactionResultMock,
       getExistingTransactionResultMock,

--- a/packages/dapi/test/unit/externalApis/tenderdash/waitForTransactionToBeProvable/waitForTransactionToBeProvableFactory.spec.js
+++ b/packages/dapi/test/unit/externalApis/tenderdash/waitForTransactionToBeProvable/waitForTransactionToBeProvableFactory.spec.js
@@ -10,7 +10,6 @@ describe('waitForTransactionToBeProvableFactory', () => {
   let waitForTransactionResultResponse;
   let getExistingTransactionResultMock;
   let blockchainListenerMock;
-  let waitForHeightMock;
   let hashString;
   let timeout;
   let height;
@@ -35,12 +34,10 @@ describe('waitForTransactionToBeProvableFactory', () => {
       waitForTransactionResultResponse,
     );
 
-    waitForHeightMock = this.sinon.stub().resolves();
 
     waitForTransactionToBeProvable = waitForTransactionToBeProvableFactory(
       waitForTransactionResultMock,
       getExistingTransactionResultMock,
-      waitForHeightMock,
     );
 
     okResult = new TransactionOkResult({}, height, Buffer.alloc(0));
@@ -56,8 +53,6 @@ describe('waitForTransactionToBeProvableFactory', () => {
     getExistingTransactionResultMock.resolves(okResult);
 
     waitForTransactionResultResponse.promise = new Promise(() => {});
-
-    waitForHeightMock.promise = Promise.resolve();
 
     const actualResult = await waitForTransactionToBeProvable(
       blockchainListenerMock,
@@ -76,14 +71,10 @@ describe('waitForTransactionToBeProvableFactory', () => {
       hashString,
     );
 
-    expect(waitForHeightMock).to.be.calledOnceWithExactly(
-      height + 1,
-    );
-
     expect(waitForTransactionResultResponse.detach).to.be.called();
   });
 
-  it('should return existing transaction error result and do not wait for next block', async () => {
+  it('should return existing transaction error result', async () => {
     getExistingTransactionResultMock.resolves(errorResult);
 
     waitForTransactionResultResponse.promise = new Promise(() => {});
@@ -105,12 +96,10 @@ describe('waitForTransactionToBeProvableFactory', () => {
       hashString,
     );
 
-    expect(waitForHeightMock).to.not.be.called();
-
     expect(waitForTransactionResultResponse.detach).to.be.called();
   });
 
-  it('should return upcoming transaction ok result when next block arrived', async () => {
+  it('should return upcoming transaction ok result', async () => {
     getExistingTransactionResultMock.rejects(transactionNotFoundError);
 
     waitForTransactionResultResponse.promise = Promise.resolve(okResult);
@@ -132,14 +121,10 @@ describe('waitForTransactionToBeProvableFactory', () => {
       hashString,
     );
 
-    expect(waitForHeightMock).to.be.calledOnceWithExactly(
-      height + 1,
-    );
-
     expect(waitForTransactionResultResponse.detach).to.not.be.called();
   });
 
-  it('should return upcoming transaction error result and do not wait for next block', async () => {
+  it('should return upcoming transaction error result', async () => {
     getExistingTransactionResultMock.rejects(transactionNotFoundError);
 
     waitForTransactionResultResponse.promise = Promise.resolve(errorResult);
@@ -160,8 +145,6 @@ describe('waitForTransactionToBeProvableFactory', () => {
       blockchainListenerMock,
       hashString,
     );
-
-    expect(waitForHeightMock).to.not.be.called();
 
     expect(waitForTransactionResultResponse.detach).to.not.be.called();
   });
@@ -194,8 +177,6 @@ describe('waitForTransactionToBeProvableFactory', () => {
         blockchainListenerMock,
         hashString,
       );
-
-      expect(waitForHeightMock).to.not.be.called();
 
       expect(waitForTransactionResultResponse.detach).to.be.calledOnce();
     }

--- a/packages/js-drive/lib/abci/handlers/deliverTxHandlerFactory.js
+++ b/packages/js-drive/lib/abci/handlers/deliverTxHandlerFactory.js
@@ -163,6 +163,7 @@ function deliverTxHandlerFactory(
     // await transactionalDpp.getStateRepository().updateIdentity(identity);
 
     // Logging
+    /* istanbul ignore next */
     switch (stateTransition.getType()) {
       case stateTransitionTypes.DATA_CONTRACT_UPDATE:
       case stateTransitionTypes.DATA_CONTRACT_CREATE: {

--- a/packages/js-drive/lib/abci/handlers/query/dataContractQueryHandlerFactory.js
+++ b/packages/js-drive/lib/abci/handlers/query/dataContractQueryHandlerFactory.js
@@ -22,13 +22,11 @@ const InvalidArgumentAbciError = require('../../errors/InvalidArgumentAbciError'
  *
  * @param {DataContractStoreRepository} signedDataContractRepository
  * @param {createQueryResponse} createQueryResponse
- * @param {BlockExecutionContextStack} blockExecutionContextStack
  * @return {dataContractQueryHandler}
  */
 function dataContractQueryHandlerFactory(
   signedDataContractRepository,
   createQueryResponse,
-  blockExecutionContextStack,
 ) {
   /**
    * @typedef dataContractQueryHandler
@@ -39,11 +37,6 @@ function dataContractQueryHandlerFactory(
    * @return {Promise<ResponseQuery>}
    */
   async function dataContractQueryHandler(params, { id }, request) {
-    // There is no signed state (current committed block height less than 3)
-    if (!blockExecutionContextStack.getLast()) {
-      throw new NotFoundAbciError('Data Contract not found');
-    }
-
     let contractIdIdentifier;
     try {
       contractIdIdentifier = new Identifier(id);

--- a/packages/js-drive/lib/abci/handlers/query/documentQueryHandlerFactory.js
+++ b/packages/js-drive/lib/abci/handlers/query/documentQueryHandlerFactory.js
@@ -9,7 +9,6 @@ const {
 const {
   v0: {
     GetDocumentsResponse,
-    ResponseMetadata,
   },
 } = require('@dashevo/dapi-grpc');
 
@@ -21,14 +20,12 @@ const InvalidQueryError = require('../../../document/errors/InvalidQueryError');
  * @param {fetchDocuments} fetchSignedDocuments
  * @param {proveDocuments} proveSignedDocuments
  * @param {createQueryResponse} createQueryResponse
- * @param {BlockExecutionContextStack} blockExecutionContextStack
  * @return {documentQueryHandler}
  */
 function documentQueryHandlerFactory(
   fetchSignedDocuments,
   proveSignedDocuments,
   createQueryResponse,
-  blockExecutionContextStack,
 ) {
   /**
    * @typedef {documentQueryHandler}
@@ -57,17 +54,6 @@ function documentQueryHandlerFactory(
     },
     request,
   ) {
-    // There is no signed state (current committed block height less than 3)
-    if (!blockExecutionContextStack.getLast()) {
-      const response = new GetDocumentsResponse();
-
-      response.setMetadata(new ResponseMetadata());
-
-      return new ResponseQuery({
-        value: response.serializeBinary(),
-      });
-    }
-
     const response = createQueryResponse(GetDocumentsResponse, request.prove);
 
     const options = {

--- a/packages/js-drive/lib/abci/handlers/query/getProofsQueryHandlerFactory.js
+++ b/packages/js-drive/lib/abci/handlers/query/getProofsQueryHandlerFactory.js
@@ -37,28 +37,12 @@ function getProofsQueryHandlerFactory(
     dataContractIds,
     documents,
   }) {
-    // There is no signed state (current committed block height less than 3)
-    if (!blockExecutionContextStack.getLast()) {
-      return new ResponseQuery({
-        value: await cbor.encodeAsync({
-          documentsProof: null,
-          identitiesProof: null,
-          dataContractsProof: null,
-          metadata: {
-            height: 0,
-            coreChainLockedHeight: 0,
-          },
-        }),
-      });
-    }
-
     const blockExecutionContext = blockExecutionContextStack.getFirst();
-    const signedBlockExecutionContext = blockExecutionContextStack.getLast();
 
     const {
       height: signedBlockHeight,
       coreChainLockedHeight: signedCoreChainLockedHeight,
-    } = signedBlockExecutionContext.getHeader();
+    } = blockExecutionContext.getHeader();
 
     const {
       quorumHash: signatureLlmqHash,

--- a/packages/js-drive/lib/abci/handlers/query/identitiesByPublicKeyHashesQueryHandlerFactory.js
+++ b/packages/js-drive/lib/abci/handlers/query/identitiesByPublicKeyHashesQueryHandlerFactory.js
@@ -9,7 +9,6 @@ const {
 const {
   v0: {
     GetIdentitiesByPublicKeyHashesResponse,
-    ResponseMetadata,
   },
 } = require('@dashevo/dapi-grpc');
 
@@ -20,14 +19,12 @@ const InvalidArgumentAbciError = require('../../errors/InvalidArgumentAbciError'
  * @param {PublicKeyToIdentitiesStoreRepository} signedPublicKeyToIdentitiesRepository
  * @param {number} maxIdentitiesPerRequest
  * @param {createQueryResponse} createQueryResponse
- * @param {BlockExecutionContextStack} blockExecutionContextStack
  * @return {identitiesByPublicKeyHashesQueryHandler}
  */
 function identitiesByPublicKeyHashesQueryHandlerFactory(
   signedPublicKeyToIdentitiesRepository,
   maxIdentitiesPerRequest,
   createQueryResponse,
-  blockExecutionContextStack,
 ) {
   /**
    * @typedef identitiesByPublicKeyHashesQueryHandler
@@ -44,18 +41,6 @@ function identitiesByPublicKeyHashesQueryHandlerFactory(
           maxIdentitiesPerRequest,
         },
       );
-    }
-
-    // There is no signed state (current committed block height less than 3)
-    if (!blockExecutionContextStack.getLast()) {
-      const response = new GetIdentitiesByPublicKeyHashesResponse();
-
-      response.setIdentitiesList([]);
-      response.setMetadata(new ResponseMetadata());
-
-      return new ResponseQuery({
-        value: response.serializeBinary(),
-      });
     }
 
     const response = createQueryResponse(GetIdentitiesByPublicKeyHashesResponse, request.prove);

--- a/packages/js-drive/lib/abci/handlers/query/identityQueryHandlerFactory.js
+++ b/packages/js-drive/lib/abci/handlers/query/identityQueryHandlerFactory.js
@@ -22,15 +22,11 @@ const InvalidArgumentAbciError = require('../../errors/InvalidArgumentAbciError'
  *
  * @param {IdentityStoreRepository} signedIdentityRepository
  * @param {createQueryResponse} createQueryResponse
- * @param {BlockExecutionContext} blockExecutionContext
- * @param {BlockExecutionContextStack} blockExecutionContextStack
  * @return {identityQueryHandler}
  */
 function identityQueryHandlerFactory(
   signedIdentityRepository,
   createQueryResponse,
-  blockExecutionContext,
-  blockExecutionContextStack,
 ) {
   /**
    * @typedef identityQueryHandler
@@ -41,11 +37,6 @@ function identityQueryHandlerFactory(
    * @return {Promise<ResponseQuery>}
    */
   async function identityQueryHandler(params, { id }, request) {
-    // There is no signed state (current committed block height less than 3)
-    if (!blockExecutionContextStack.getLast()) {
-      throw new NotFoundAbciError('Identity not found');
-    }
-
     let identifier;
     try {
       identifier = new Identifier(id);

--- a/packages/js-drive/lib/abci/handlers/query/response/createQueryResponseFactory.js
+++ b/packages/js-drive/lib/abci/handlers/query/response/createQueryResponseFactory.js
@@ -19,12 +19,11 @@ function createQueryResponseFactory(
    */
   function createQueryResponse(ResponseClass, prove = false) {
     const blockExecutionContext = blockExecutionContextStack.getFirst();
-    const signedBlockExecutionContext = blockExecutionContextStack.getLast();
 
     const {
       height: signedBlockHeight,
       coreChainLockedHeight: signedCoreChainLockedHeight,
-    } = signedBlockExecutionContext.getHeader();
+    } = blockExecutionContext.getHeader();
 
     const response = new ResponseClass();
 

--- a/packages/js-drive/test/unit/abci/handlers/query/dataContractQueryHandlerFactory.spec.js
+++ b/packages/js-drive/test/unit/abci/handlers/query/dataContractQueryHandlerFactory.spec.js
@@ -20,7 +20,6 @@ const dataContractQueryHandlerFactory = require('../../../../../lib/abci/handler
 
 const NotFoundAbciError = require('../../../../../lib/abci/errors/NotFoundAbciError');
 const StoreRepositoryMock = require('../../../../../lib/test/mock/StoreRepositoryMock');
-const BlockExecutionContextStackMock = require('../../../../../lib/test/mock/BlockExecutionContextStackMock');
 const InvalidArgumentAbciError = require('../../../../../lib/abci/errors/InvalidArgumentAbciError');
 const StorageResult = require('../../../../../lib/storage/StorageResult');
 
@@ -31,7 +30,6 @@ describe('dataContractQueryHandlerFactory', () => {
   let data;
   let createQueryResponseMock;
   let responseMock;
-  let blockExecutionContextStackMock;
   let signedDataContractRepositoryMock;
 
   beforeEach(function beforeEach() {
@@ -44,37 +42,17 @@ describe('dataContractQueryHandlerFactory', () => {
 
     createQueryResponseMock.returns(responseMock);
 
-    blockExecutionContextStackMock = new BlockExecutionContextStackMock(this.sinon);
-    blockExecutionContextStackMock.getLast.returns(true);
-
     signedDataContractRepositoryMock = new StoreRepositoryMock(this.sinon);
 
     dataContractQueryHandler = dataContractQueryHandlerFactory(
       signedDataContractRepositoryMock,
       createQueryResponseMock,
-      blockExecutionContextStackMock,
     );
-
-    blockExecutionContextStackMock.getLast.returns(true);
 
     params = { };
     data = {
       id: dataContract.getId(),
     };
-  });
-
-  it('should throw NotFoundAbciError if there is no signed state', async () => {
-    blockExecutionContextStackMock.getLast.returns(null);
-
-    try {
-      await dataContractQueryHandler(params, data, {});
-
-      expect.fail('should throw NotFoundAbciError');
-    } catch (e) {
-      expect(e).to.be.an.instanceOf(NotFoundAbciError);
-      expect(blockExecutionContextStackMock.getLast).to.be.calledOnce();
-      expect(signedDataContractRepositoryMock.fetch).to.be.not.called();
-    }
   });
 
   it('should throw NotFoundAbciError if Data Contract not found', async () => {
@@ -88,7 +66,6 @@ describe('dataContractQueryHandlerFactory', () => {
       expect.fail('should throw NotFoundAbciError');
     } catch (e) {
       expect(e).to.be.an.instanceOf(NotFoundAbciError);
-      expect(blockExecutionContextStackMock.getLast).to.be.calledOnce();
       expect(signedDataContractRepositoryMock.fetch).to.be.calledOnce();
     }
   });

--- a/packages/js-drive/test/unit/abci/handlers/query/getProofsQueryHandlerFactory.spec.js
+++ b/packages/js-drive/test/unit/abci/handlers/query/getProofsQueryHandlerFactory.spec.js
@@ -38,17 +38,16 @@ describe('getProofsQueryHandlerFactory', () => {
     identity = getIdentityFixture();
     documents = getDocumentsFixture();
 
-    signedBlockExecutionContextMock = new BlockExecutionContextMock(this.sinon);
-    signedBlockExecutionContextMock.getHeader.returns({
-      height: new Long(42),
-      coreChainLockedHeight: 41,
-    });
-
     blockExecutionContextMock = new BlockExecutionContextMock(this.sinon);
 
     blockExecutionContextMock.getLastCommitInfo.returns({
       quorumHash: Buffer.alloc(32, 1),
       stateSignature: Buffer.alloc(32, 1),
+    });
+
+    blockExecutionContextMock.getHeader.returns({
+      height: new Long(42),
+      coreChainLockedHeight: 41,
     });
 
     blockExecutionContextStackMock = new BlockExecutionContextStackMock(this.sinon);
@@ -86,29 +85,6 @@ describe('getProofsQueryHandlerFactory', () => {
       dataContractId: doc.getDataContractId(),
       type: doc.getType(),
     }));
-  });
-
-  it('should return empty response if there is no signed state', async () => {
-    blockExecutionContextStackMock.getLast.returns(null);
-
-    const result = await getProofsQueryHandler({}, {}, {});
-
-    expect(result).to.be.an.instanceof(ResponseQuery);
-    expect(result.code).to.equal(0);
-
-    const emptyValue = cbor.encode(
-      {
-        documentsProof: null,
-        identitiesProof: null,
-        dataContractsProof: null,
-        metadata: {
-          height: 0,
-          coreChainLockedHeight: 0,
-        },
-      },
-    );
-
-    expect(result.value).to.deep.equal(emptyValue);
   });
 
   it('should return proof for passed data contract ids', async () => {

--- a/packages/js-drive/test/unit/abci/handlers/query/identitiesByPublicKeyHashesQueryHandlerFactory.spec.js
+++ b/packages/js-drive/test/unit/abci/handlers/query/identitiesByPublicKeyHashesQueryHandlerFactory.spec.js
@@ -10,7 +10,6 @@ const {
   v0: {
     GetIdentitiesByPublicKeyHashesResponse,
     Proof,
-    ResponseMetadata,
   },
 } = require('@dashevo/dapi-grpc');
 
@@ -20,7 +19,6 @@ const identitiesByPublicKeyHashesQueryHandlerFactory = require(
   '../../../../../lib/abci/handlers/query/identitiesByPublicKeyHashesQueryHandlerFactory',
 );
 const InvalidArgumentAbciError = require('../../../../../lib/abci/errors/InvalidArgumentAbciError');
-const BlockExecutionContextStackMock = require('../../../../../lib/test/mock/BlockExecutionContextStackMock');
 const StorageResult = require('../../../../../lib/storage/StorageResult');
 
 describe('identitiesByPublicKeyHashesQueryHandlerFactory', () => {
@@ -31,7 +29,6 @@ describe('identitiesByPublicKeyHashesQueryHandlerFactory', () => {
   let maxIdentitiesPerRequest;
   let createQueryResponseMock;
   let responseMock;
-  let blockExecutionContextStackMock;
   let params;
   let data;
 
@@ -50,15 +47,10 @@ describe('identitiesByPublicKeyHashesQueryHandlerFactory', () => {
 
     createQueryResponseMock.returns(responseMock);
 
-    blockExecutionContextStackMock = new BlockExecutionContextStackMock(this.sinon);
-
-    blockExecutionContextStackMock.getLast.returns(true);
-
     identitiesByPublicKeyHashesQueryHandler = identitiesByPublicKeyHashesQueryHandlerFactory(
       signedPublicKeyToIdentitiesRepositoryMock,
       maxIdentitiesPerRequest,
       createQueryResponseMock,
-      blockExecutionContextStackMock,
     );
 
     publicKeyHashes = [
@@ -81,23 +73,6 @@ describe('identitiesByPublicKeyHashesQueryHandlerFactory', () => {
     data = { publicKeyHashes };
   });
 
-  it('should return empty response if there is no signed state', async () => {
-    blockExecutionContextStackMock.getLast.returns(null);
-
-    responseMock = new GetIdentitiesByPublicKeyHashesResponse();
-    responseMock.setIdentitiesList([]);
-    responseMock.setMetadata(new ResponseMetadata());
-
-    const result = await identitiesByPublicKeyHashesQueryHandler(params, data, {});
-
-    expect(result).to.be.an.instanceof(ResponseQuery);
-    expect(result.code).to.equal(0);
-
-    expect(result.value).to.deep.equal(responseMock.serializeBinary());
-
-    expect(signedPublicKeyToIdentitiesRepositoryMock.fetchManyBuffers).to.have.not.been.called();
-  });
-
   it('should throw an error if maximum requested items exceeded', async () => {
     maxIdentitiesPerRequest = 1;
 
@@ -105,7 +80,6 @@ describe('identitiesByPublicKeyHashesQueryHandlerFactory', () => {
       signedPublicKeyToIdentitiesRepositoryMock,
       maxIdentitiesPerRequest,
       createQueryResponseMock,
-      blockExecutionContextStackMock,
     );
 
     try {

--- a/packages/js-drive/test/unit/abci/handlers/query/identityQueryHandlerFactory.spec.js
+++ b/packages/js-drive/test/unit/abci/handlers/query/identityQueryHandlerFactory.spec.js
@@ -17,9 +17,7 @@ const getIdentityFixture = require('@dashevo/dpp/lib/test/fixtures/getIdentityFi
 
 const GrpcErrorCodes = require('@dashevo/grpc-common/lib/server/error/GrpcErrorCodes');
 const identityQueryHandlerFactory = require('../../../../../lib/abci/handlers/query/identityQueryHandlerFactory');
-const BlockExecutionContextMock = require('../../../../../lib/test/mock/BlockExecutionContextMock');
 const NotFoundAbciError = require('../../../../../lib/abci/errors/NotFoundAbciError');
-const BlockExecutionContextStackMock = require('../../../../../lib/test/mock/BlockExecutionContextStackMock');
 const StorageResult = require('../../../../../lib/storage/StorageResult');
 
 describe('identityQueryHandlerFactory', () => {
@@ -30,8 +28,6 @@ describe('identityQueryHandlerFactory', () => {
   let data;
   let createQueryResponseMock;
   let responseMock;
-  let blockExecutionContextMock;
-  let blockExecutionContextStackMock;
 
   beforeEach(function beforeEach() {
     signedIdentityRepositoryMock = {
@@ -46,15 +42,9 @@ describe('identityQueryHandlerFactory', () => {
 
     createQueryResponseMock.returns(responseMock);
 
-    blockExecutionContextMock = new BlockExecutionContextMock(this.sinon);
-    blockExecutionContextStackMock = new BlockExecutionContextStackMock(this.sinon);
-    blockExecutionContextStackMock.getLast.returns(true);
-
     identityQueryHandler = identityQueryHandlerFactory(
       signedIdentityRepositoryMock,
       createQueryResponseMock,
-      blockExecutionContextMock,
-      blockExecutionContextStackMock,
     );
 
     identity = getIdentityFixture();
@@ -63,18 +53,6 @@ describe('identityQueryHandlerFactory', () => {
     data = {
       id: identity.getId(),
     };
-  });
-
-  it('should throw NotFoundAbciError if there is no signed state', async () => {
-    blockExecutionContextStackMock.getLast.returns(null);
-
-    try {
-      await identityQueryHandler(params, data, {});
-
-      expect.fail('should throw NotFoundAbciError');
-    } catch (e) {
-      expect(e).to.be.an.instanceOf(NotFoundAbciError);
-    }
   });
 
   it('should return serialized identity', async () => {

--- a/packages/js-drive/test/unit/abci/handlers/query/response/createQueryResponseFactory.spec.js
+++ b/packages/js-drive/test/unit/abci/handlers/query/response/createQueryResponseFactory.spec.js
@@ -13,23 +13,20 @@ describe('createQueryResponseFactory', () => {
   let createQueryResponse;
   let metadata;
   let lastCommitInfo;
-  let signedBlockExecutionContext;
   let blockExecutionContextMock;
 
   beforeEach(function beforeEach() {
-    signedBlockExecutionContext = new BlockExecutionContextMock(this.sinon);
-    blockExecutionContextMock = new BlockExecutionContextMock(this.sinon);
-    blockExecutionContextStackMock = new BlockExecutionContextStackMock(this.sinon);
-
-    blockExecutionContextStackMock.getLast.returns(signedBlockExecutionContext);
-    blockExecutionContextStackMock.getFirst.returns(blockExecutionContextMock);
-
     metadata = {
       height: 1,
       coreChainLockedHeight: 1,
     };
 
-    signedBlockExecutionContext.getHeader.returns(metadata);
+    blockExecutionContextMock = new BlockExecutionContextMock(this.sinon);
+    blockExecutionContextMock.getHeader.returns(metadata);
+
+    blockExecutionContextStackMock = new BlockExecutionContextStackMock(this.sinon);
+
+    blockExecutionContextStackMock.getFirst.returns(blockExecutionContextMock);
 
     lastCommitInfo = {
       quorumHash: Buffer.alloc(12).fill(1),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
After #484, `waitForStateTransitionResult` do not need to wait for next block to obtain block signature anymore. Also, Drive should respond with current block data.

## What was done?
<!--- Describe your changes in detail -->
- Remove the waiting for next block logic
- Updated Drive's endpoint to respond with current block data

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tests

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
