### PR TITLE
feat(dashmate): update mainnet dashd version to v18

### DIFF
--- a/packages/dashmate/configs/system/mainnet.js
+++ b/packages/dashmate/configs/system/mainnet.js
@@ -15,7 +15,7 @@ const mainnetConfig = lodashMerge({}, baseConfig, {
   },
   core: {
     docker: {
-      image: 'dashpay/dashd:0.17.0.3',
+      image: 'dashpay/dashd:18.0.1',
     },
     p2p: {
       port: 9999,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Last release misses upgrading mainnet nodes. It works for local, but users cannot use run mainnet nodes, because it loads latest sentinel but with the v17 dashcore node.

## What was done?
<!--- Describe your changes in detail -->
Upgrade dashd version for mainnet

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Issue originally discovered by community member dashfriend, fixed and tested on my laptop (m1)

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
Nope

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
