### PR TITLE
chore: remove buildx bake workaround

### DIFF
--- a/packages/dashmate/src/docker/DockerCompose.js
+++ b/packages/dashmate/src/docker/DockerCompose.js
@@ -5,8 +5,6 @@ const dockerCompose = require('@dashevo/docker-compose');
 const hasbin = require('hasbin');
 const semver = require('semver');
 
-const { exec } = require('child_process');
-
 const DockerComposeError = require('./errors/DockerComposeError');
 const ServiceAlreadyRunningError = require('./errors/ServiceAlreadyRunningError');
 const ServiceIsNotRunningError = require('./errors/ServiceIsNotRunningError');

--- a/packages/dashmate/src/docker/DockerCompose.js
+++ b/packages/dashmate/src/docker/DockerCompose.js
@@ -123,28 +123,20 @@ class DockerCompose {
    * @return {Promise<ChildProcess>}
    */
   // eslint-disable-next-line no-unused-vars
-  async build(envs, serviceName = undefined) {
+  async build(envs, serviceName = undefined, options = []) {
     await this.throwErrorIfNotInstalled();
 
     try {
-      // Temporarily build with buildx bake until docker compose build selects correct builder
-      // https://github.com/docker/compose-cli/issues/1840
-      const childProcess = exec(
-        'docker buildx bake --progress plain --load -f docker-compose.platform.build.yml',
-        this.getOptions(envs),
-      );
-
-      childProcess.isReady = new Promise((resolve, reject) => {
-        childProcess.on('exit', (code) => {
-          if (code === 0) {
-            resolve(childProcess);
-          } else {
-            reject(childProcess);
-          }
+      if (serviceName) {
+        await dockerCompose.buildOne(serviceName, {
+          ...this.getOptions(envs),
+          commandOptions: options,
         });
-      });
-
-      return childProcess;
+      } else {
+        await dockerCompose.buildAll({
+          ...this.getOptions(envs),
+        });
+      }
     } catch (e) {
       throw new DockerComposeError(e);
     }

--- a/packages/dashmate/src/listr/tasks/buildServicesTaskFactory.js
+++ b/packages/dashmate/src/listr/tasks/buildServicesTaskFactory.js
@@ -16,7 +16,7 @@ function buildServicesTaskFactory(
   function buildServicesTask(config) {
     return new Listr({
       title: 'Build services',
-      task: async (ctx, task) => {
+      task: async () => {
         const envs = config.toEnvs();
         await dockerCompose.build(envs);
       },

--- a/packages/dashmate/src/listr/tasks/buildServicesTaskFactory.js
+++ b/packages/dashmate/src/listr/tasks/buildServicesTaskFactory.js
@@ -18,15 +18,7 @@ function buildServicesTaskFactory(
       title: 'Build services',
       task: async (ctx, task) => {
         const envs = config.toEnvs();
-
-        const buildProcess = await dockerCompose.build(envs);
-
-        if (ctx.isVerbose) {
-          buildProcess.stdout.pipe(task.stdout());
-          buildProcess.stderr.pipe(task.stdout());
-        }
-
-        await buildProcess.isReady;
+        await dockerCompose.build(envs);
       },
     });
   }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
A workaround was in place to fix a problem with the way the builder was invoked by Docker Compose v2. Now that the problem has been fixed, we can remove this workaround.

## What was done?
<!--- Describe your changes in detail -->
Remove use of child process and docker buildx bake and replace with the same `docker-compose` dependency used by all other docker commands.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
`yarn dashmate setup && yarn dashmate start` on local device, build works fine

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
Output is no longer piped through, @shumkov is this a necessary requirement for devs? @pshenmic you worked on the `docker-compose` dep, can we show build output when in verbose mode somehow?

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
