### PR TITLE
fix(drive)!: masternode identities sync from begging after restart

### DIFF
--- a/packages/js-drive/lib/abci/handlers/initChainHandlerFactory.js
+++ b/packages/js-drive/lib/abci/handlers/initChainHandlerFactory.js
@@ -64,6 +64,13 @@ function initChainHandlerFactory(
 
     await rsAbci.initChain({ }, true);
 
+    // Create misc tree
+    await groveDBStore.createTree(
+      [],
+      Buffer.from([5]),
+      { useTransaction: true },
+    );
+
     await registerSystemDataContracts(consensusLogger, time);
 
     const synchronizeMasternodeIdentitiesResult = await synchronizeMasternodeIdentities(

--- a/packages/js-drive/lib/core/waitForCoreChainLockSyncFactory.js
+++ b/packages/js-drive/lib/core/waitForCoreChainLockSyncFactory.js
@@ -43,10 +43,13 @@ function waitForCoreChainLockSyncFactory(
       try {
         ({ chainLock } = new ChainLockSigMessage(rawChainLockMessage));
       } catch (e) {
-        logger.error({ err: e }, 'Error on creating ChainLockSigMessage');
-        logger.debug({
-          rawChainLockMessage: rawChainLockMessage.toString('hex'),
-        });
+        logger.error(
+          {
+            err: e,
+            rawChainLockMessage: rawChainLockMessage.toString('hex'),
+          },
+          'Error on creating ChainLockSigMessage',
+        );
 
         return;
       }
@@ -55,7 +58,7 @@ function waitForCoreChainLockSyncFactory(
 
       logger.trace(
         {
-          rawChainLockMessage: rawChainLockMessage.toString('hex'),
+          chainLock,
         },
         `Updated latestCoreChainLock for core height ${chainLock.height}`,
       );

--- a/packages/js-drive/lib/createDIContainer.js
+++ b/packages/js-drive/lib/createDIContainer.js
@@ -131,6 +131,7 @@ const DocumentRepository = require('./document/DocumentRepository');
 const ExecutionTimer = require('./util/ExecutionTimer');
 const noopLoggerInstance = require('./util/noopLogger');
 const fetchTransactionFactory = require('./core/fetchTransactionFactory');
+const LastSyncedCoreHeightRepository = require('./identity/masternode/LastSyncedCoreHeightRepository');
 
 /**
  *
@@ -472,6 +473,8 @@ function createDIContainer(options) {
     )).singleton(),
 
     synchronizeMasternodeIdentities: asFunction(synchronizeMasternodeIdentitiesFactory).singleton(),
+
+    lastSyncedCoreHeightRepository: asClass(LastSyncedCoreHeightRepository).singleton(),
 
     createMasternodeIdentity: asFunction(createMasternodeIdentityFactory).singleton(),
 

--- a/packages/js-drive/lib/identity/masternode/LastSyncedCoreHeightRepository.js
+++ b/packages/js-drive/lib/identity/masternode/LastSyncedCoreHeightRepository.js
@@ -1,0 +1,68 @@
+const StorageResult = require('../../storage/StorageResult');
+
+class LastSyncedCoreHeightRepository {
+  /**
+   *
+   * @param {GroveDBStore} groveDBStore
+   */
+  constructor(groveDBStore) {
+    this.storage = groveDBStore;
+  }
+
+  /**
+   * Store last synced core height
+   *
+   * @param {number} height
+   * @param {Object} [options]
+   * @param {boolean} [options.useTransaction=false]
+   * @param {boolean} [options.dryRun=false]
+   * @return {Promise<StorageResult<void>>}
+   */
+  async store(height, options = {}) {
+    const value = Buffer.alloc(4);
+
+    value.writeUInt32BE(height);
+
+    return this.storage.put(
+      LastSyncedCoreHeightRepository.TREE_PATH,
+      LastSyncedCoreHeightRepository.KEY,
+      value,
+      options,
+    );
+  }
+
+  /**
+   * Fetch last synced core height
+   *
+   * @param {Object} [options]
+   * @param {boolean} [options.useTransaction=false]
+   * @param {boolean} [options.dryRun=false]
+   * @return {Promise<StorageResult<number|null>>}
+   */
+  async fetch(options = {}) {
+    const encodedHeightResult = await this.storage.get(
+      LastSyncedCoreHeightRepository.TREE_PATH,
+      LastSyncedCoreHeightRepository.KEY,
+      {
+        ...options,
+        predictedValueSize: 4,
+      },
+    );
+
+    if (encodedHeightResult.isNull()) {
+      return encodedHeightResult;
+    }
+
+    const encodedHeight = encodedHeightResult.getValue();
+
+    return new StorageResult(
+      encodedHeight.readUInt32BE(),
+      encodedHeightResult.getOperations(),
+    );
+  }
+}
+
+LastSyncedCoreHeightRepository.TREE_PATH = [Buffer.from([5])];
+LastSyncedCoreHeightRepository.KEY = Buffer.from('lastSyncedCoreHeight');
+
+module.exports = LastSyncedCoreHeightRepository;

--- a/packages/js-drive/lib/identity/masternode/synchronizeMasternodeIdentitiesFactory.js
+++ b/packages/js-drive/lib/identity/masternode/synchronizeMasternodeIdentitiesFactory.js
@@ -15,6 +15,7 @@ const createOperatorIdentifier = require('./createOperatorIdentifier');
  * @param {handleUpdatedScriptPayout} handleUpdatedScriptPayout
  * @param {number} smlMaxListsLimit
  * @param {RpcClient} coreRpcClient
+ * @param {LastSyncedCoreHeightRepository} lastSyncedCoreHeightRepository
  * @return {synchronizeMasternodeIdentities}
  */
 function synchronizeMasternodeIdentitiesFactory(
@@ -27,6 +28,7 @@ function synchronizeMasternodeIdentitiesFactory(
   handleUpdatedScriptPayout,
   smlMaxListsLimit,
   coreRpcClient,
+  lastSyncedCoreHeightRepository,
 ) {
   let lastSyncedCoreHeight = 0;
 
@@ -42,6 +44,12 @@ function synchronizeMasternodeIdentitiesFactory(
    * }>}
    */
   async function synchronizeMasternodeIdentities(coreHeight) {
+    if (!lastSyncedCoreHeight) {
+      const lastSyncedHeightResult = await lastSyncedCoreHeightRepository.fetch();
+
+      lastSyncedCoreHeight = lastSyncedHeightResult.getValue() || 0;
+    }
+
     let newMasternodes = [];
 
     let previousMNList = [];
@@ -182,6 +190,8 @@ function synchronizeMasternodeIdentitiesFactory(
     const fromHeight = lastSyncedCoreHeight;
 
     lastSyncedCoreHeight = coreHeight;
+
+    await lastSyncedCoreHeightRepository.store(lastSyncedCoreHeight);
 
     return {
       fromHeight,

--- a/packages/js-drive/test/integration/identity/masternode/LastSyncedCoreHeightRepository.spec.js
+++ b/packages/js-drive/test/integration/identity/masternode/LastSyncedCoreHeightRepository.spec.js
@@ -1,0 +1,82 @@
+const Drive = require('@dashevo/rs-drive');
+const fs = require('fs');
+
+const LastSyncedSmlHeightRepository = require('../../../../lib/identity/masternode/LastSyncedCoreHeightRepository');
+const StorageResult = require('../../../../lib/storage/StorageResult');
+const GroveDBStore = require('../../../../lib/storage/GroveDBStore');
+const logger = require('../../../../lib/util/noopLogger');
+
+describe('LastSyncedSmlHeightRepository', () => {
+  let repository;
+  let store;
+  let rsDrive;
+
+  beforeEach(async () => {
+    rsDrive = new Drive('./db/grovedb_test');
+    store = new GroveDBStore(rsDrive, logger);
+
+    repository = new LastSyncedSmlHeightRepository(store);
+
+    // Create misc tree
+    await store.createTree(
+      [],
+      Buffer.from([5]),
+      { useTransaction: true },
+    );
+  });
+
+  afterEach(async () => {
+    await rsDrive.close();
+    fs.rmSync('./db/grovedb_test', { recursive: true });
+  });
+
+  describe('#store', () => {
+    it('should store last synced height', async () => {
+      const result = await repository.store(1, {
+        useTransaction: true,
+      });
+
+      expect(result).to.be.instanceOf(StorageResult);
+      expect(result.getOperations().length).to.be.greaterThan(0);
+
+      const placeholderResult = await store.get(
+        LastSyncedSmlHeightRepository.TREE_PATH,
+        LastSyncedSmlHeightRepository.KEY,
+      );
+
+      const encodedValue = placeholderResult.getValue();
+
+      expect(encodedValue.readUInt32BE()).to.deep.equal(1);
+    });
+  });
+
+  describe('#fetch', () => {
+    it('should return null if last synced height is not present', async () => {
+      const result = await repository.fetch();
+
+      expect(result).to.be.instanceOf(StorageResult);
+      expect(result.getOperations().length).to.be.greaterThan(0);
+
+      expect(result.getValue()).to.be.null();
+    });
+
+    it('should return last synced height', async () => {
+      const encodedValue = Buffer.alloc(4);
+
+      encodedValue.writeUInt32BE(1);
+
+      await store.put(
+        LastSyncedSmlHeightRepository.TREE_PATH,
+        LastSyncedSmlHeightRepository.KEY,
+        encodedValue,
+      );
+
+      const result = await repository.fetch();
+
+      expect(result).to.be.instanceOf(StorageResult);
+      expect(result.getOperations().length).to.be.greaterThan(0);
+
+      expect(result.getValue()).to.be.deep.equal(1);
+    });
+  });
+});

--- a/packages/js-drive/test/integration/identity/masternode/synchronizeMasternodeIdentitiesFactory.spec.js
+++ b/packages/js-drive/test/integration/identity/masternode/synchronizeMasternodeIdentitiesFactory.spec.js
@@ -296,7 +296,7 @@ describe('synchronizeMasternodeIdentitiesFactory', () => {
 
   beforeEach(async function beforeEach() {
     coreHeight = 3;
-    firstSyncAppHash = '4e1d18a332be99b4b11894e8c00efa40c0166ea593526852f26589ecbf9ed8f1';
+    firstSyncAppHash = '458731b06d86f200f174f4a3e22f54202f3838e456bc12ed67f81c9bfcc64e7c';
 
     container = await createTestDIContainer();
 
@@ -377,6 +377,14 @@ describe('synchronizeMasternodeIdentitiesFactory', () => {
      */
     const rsDrive = container.resolve('rsDrive');
     await rsDrive.createInitialStateStructure();
+
+    // Create misc tree
+    const groveDBStore = container.resolve('groveDBStore');
+    await groveDBStore.createTree(
+      [],
+      Buffer.from([5]),
+      { useTransaction: true },
+    );
 
     const registerSystemDataContract = container.resolve('registerSystemDataContract');
     const masternodeRewardSharesContractId = container.resolve('masternodeRewardSharesContractId');
@@ -564,7 +572,7 @@ describe('synchronizeMasternodeIdentitiesFactory', () => {
 
     // Nothing happened
 
-    await expectDeterministicAppHash(firstSyncAppHash);
+    await expectDeterministicAppHash('c1e14007355ba59b6255688125bd8be19b2cccf59646a9a8eaed8b0976c495ea');
 
     // Core RPC should be called
 
@@ -618,7 +626,7 @@ describe('synchronizeMasternodeIdentitiesFactory', () => {
     expect(result.updatedEntities).to.have.lengthOf(0);
     expect(result.removedEntities).to.have.lengthOf(0);
 
-    await expectDeterministicAppHash('336104fb366a2f474e0d5ee5162b3dbacf0018939e824f460972abd16353e677');
+    await expectDeterministicAppHash('f76584f44a9c4d052cbd30140a81a3022c0684356f70a0dd9b23f3aa1ba7c4f8');
 
     // New masternode identity should be created
 
@@ -694,7 +702,7 @@ describe('synchronizeMasternodeIdentitiesFactory', () => {
     expect(result.updatedEntities).to.have.lengthOf(0);
     expect(result.removedEntities).to.have.lengthOf(1);
 
-    await expectDeterministicAppHash('a32d5254e424f284a950029a42ebd62c6132cfa626d8cd5acc028ba5c97ef837');
+    await expectDeterministicAppHash('30ef43b0a3ae64acdf0bfecb9959f0c9fbdb2c1751ec8a8bac5e21c93981a5c3');
 
     // Masternode identity should stay
 
@@ -754,7 +762,7 @@ describe('synchronizeMasternodeIdentitiesFactory', () => {
     expect(result.updatedEntities).to.have.lengthOf(0);
     expect(result.removedEntities).to.have.lengthOf(1);
 
-    await expectDeterministicAppHash('a32d5254e424f284a950029a42ebd62c6132cfa626d8cd5acc028ba5c97ef837');
+    await expectDeterministicAppHash('30ef43b0a3ae64acdf0bfecb9959f0c9fbdb2c1751ec8a8bac5e21c93981a5c3');
 
     const invalidMasternodeIdentifier = Identifier.from(
       Buffer.from(invalidSmlEntry.proRegTxHash, 'hex'),
@@ -803,7 +811,7 @@ describe('synchronizeMasternodeIdentitiesFactory', () => {
     expect(result.updatedEntities).to.have.lengthOf(3);
     expect(result.removedEntities).to.have.lengthOf(0);
 
-    await expectDeterministicAppHash('07e1fa9e8485d21c94c46e5df357b15539a21e75fc5857f551e48f80daadbf26');
+    await expectDeterministicAppHash('0d36cfde4ca44f1b191c9f272148238e2ebc12be95fbdf9556f4fb31ea453dbb');
 
     // Masternode identity should stay
 
@@ -870,7 +878,7 @@ describe('synchronizeMasternodeIdentitiesFactory', () => {
 
     await synchronizeMasternodeIdentities(coreHeight + 1);
 
-    await expectDeterministicAppHash('92f909c4b4ee1bd2f8c0c030c74d44ad7102bbde03061122e1ab9772ead05c6c');
+    await expectDeterministicAppHash('08dd50b99139af601b1b29aaa5b0f9f1111c2d30e940c7353386aeb33664ed52');
 
     // Masternode identity should contain new public key
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Drive syncs masernode identities since the beginning after restart

## What was done?
<!--- Describe your changes in detail -->
- Store last synced core height

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
With integration tests

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
Previous chain data won't be valid

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
