### PR TITLE
fix(dpp): cannot read properties of null (reading 'getBalance')

### DIFF
--- a/packages/js-dpp/lib/stateTransition/StateTransitionFacade.js
+++ b/packages/js-dpp/lib/stateTransition/StateTransitionFacade.js
@@ -136,6 +136,7 @@ class StateTransitionFacade {
     this.validateStateTransitionKeySignature = validateStateTransitionKeySignatureFactory(
       verifyHashSignature,
       fetchAssetLockPublicKeyHash,
+      this.stateRepository,
     );
 
     // eslint-disable-next-line max-len

--- a/packages/js-dpp/lib/stateTransition/validation/validateStateTransitionKeySignatureFactory.js
+++ b/packages/js-dpp/lib/stateTransition/validation/validateStateTransitionKeySignatureFactory.js
@@ -32,9 +32,9 @@ function validateStateTransitionKeySignatureFactory(
     if (stateTransition.getType() === stateTransitionTypes.IDENTITY_TOP_UP) {
       const targetIdentityId = stateTransition.getIdentityId();
 
-      // // We use temporary execution context without dry run,
-      // // because despite the dryRun, we need to get the
-      // // identity to proceed with following logic
+      // We use temporary execution context without dry run,
+      // because despite the dryRun, we need to get the
+      // identity to proceed with following logic
       const tmpExecutionContext = new StateTransitionExecutionContext();
 
       // Target identity must exist

--- a/packages/js-dpp/lib/stateTransition/validation/validateStateTransitionKeySignatureFactory.js
+++ b/packages/js-dpp/lib/stateTransition/validation/validateStateTransitionKeySignatureFactory.js
@@ -3,15 +3,20 @@ const InvalidStateTransitionSignatureError = require('../../errors/consensus/sig
 const ValidationResult = require('../../validation/ValidationResult');
 const SignatureVerificationOperation = require('../fee/operations/SignatureVerificationOperation');
 const { TYPES } = require('../../identity/IdentityPublicKey');
+const StateTransitionExecutionContext = require('../StateTransitionExecutionContext');
+const IdentityNotFoundError = require('../../errors/consensus/signature/IdentityNotFoundError');
+const stateTransitionTypes = require('../stateTransitionTypes');
 
 /**
  * @param {Function} verifyHashSignature
  * @param {fetchAssetLockPublicKeyHash} fetchAssetLockPublicKeyHash
+ * @param {StateRepository} stateRepository
  * @returns {validateStateTransitionKeySignature}
  */
 function validateStateTransitionKeySignatureFactory(
   verifyHashSignature,
   fetchAssetLockPublicKeyHash,
+  stateRepository,
 ) {
   /**
    * @typedef {validateStateTransitionKeySignature}
@@ -22,6 +27,28 @@ function validateStateTransitionKeySignatureFactory(
     const result = new ValidationResult();
 
     const executionContext = stateTransition.getExecutionContext();
+
+    // Validate target identity existence for top up
+    if (stateTransition.getType() === stateTransitionTypes.IDENTITY_TOP_UP) {
+      const targetIdentityId = stateTransition.getIdentityId();
+
+      // // We use temporary execution context without dry run,
+      // // because despite the dryRun, we need to get the
+      // // identity to proceed with following logic
+      const tmpExecutionContext = new StateTransitionExecutionContext();
+
+      // Target identity must exist
+      const identity = await stateRepository.fetchIdentity(targetIdentityId, tmpExecutionContext);
+
+      // Collect operations back from temporary context
+      executionContext.addOperation(...tmpExecutionContext.getOperations());
+
+      if (!identity) {
+        result.addError(new IdentityNotFoundError(targetIdentityId.toBuffer()));
+
+        return result;
+      }
+    }
 
     const stateTransitionHash = stateTransition.hash({ skipSignature: true });
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
DPP throw `Cannot read properties of null (reading 'getBalance')` error

## What was done?
<!--- Describe your changes in detail -->
`validateStateTransitionKeySignature` method now checks identity existence on topUp transitions

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
With tests

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
No

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
