### PR TITLE
build(rs-drive-abci): update Dockerfile to Alpine and build correctly on ARM64

### DIFF
--- a/packages/rs-drive-abci/Dockerfile
+++ b/packages/rs-drive-abci/Dockerfile
@@ -7,7 +7,15 @@
 # - build - actual build process
 # - release - final image
 #
-
+# The following build arguments can be provided using --build-arg:
+# - CARGO_BUILD_PROFILE - set to `release` to build final binary, without debugging information
+# - SCCACHE_GHA_ENABLED, ACTIONS_CACHE_URL, ACTIONS_RUNTIME_TOKEN - store sccache caches inside github actions
+#   cache instead of Docker cache mounts (not tested yet)
+# - PROTOC_ARCH - select architecture of protobuf compiler; one of: `x86_64` (default), `aarch_64`
+# - ALPINE_VERSION - use different version of Alpine base image; requires also rust:apline... 
+#   image to be available
+# - USERNAME, USER_UID, USER_GID - specification of user used to run the binary
+#
 ARG ALPINE_VERSION=3.17
 
 #


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented

As learned from https://github.com/dashpay/rs-tenderdash-abci/pull/14 , cargo build takes too many resources on ARM64 target in github actions. This causes Arm64 image build to fail.

## What was done?

Added `--config net.git-fetch-with-cli=true` to address ARM build issue. See https://github.com/rust-lang/cargo/issues/10781#issuecomment-1441071052

Replace Debian base image with Apline.

## How Has This Been Tested?

On rs-tenderdash-abci, similar solution fixed the arm64 build issue: https://github.com/dashpay/rs-tenderdash-abci/actions/runs/4512281223

Locally, it also passes:

```
docker buildx build --platform linux/arm64,linux/amd64 -f packages/rs-drive-abci/Dockerfile .
```

## Breaking Changes

None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone
