### PR TITLE
fix(github): use clang instead of gcc

### DIFF
--- a/.github/actions/rust/action.yaml
+++ b/.github/actions/rust/action.yaml
@@ -47,3 +47,11 @@ runs:
         cache-targets: false
         # We set a shared key, as our cache is reusable between jobs
         shared-key: rust-cargo
+
+    - name: Install clang
+      id: deps-clang
+      shell: bash
+      run: |
+        sudo apt update -qq
+        sudo apt install -qq --yes clang
+        sudo update-alternatives --set cc /usr/bin/clang


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented

Build fails with:

```
error: failed to run custom build command for `bls-dash-sys v1.2.5 (https://github.com/dashpay/bls-signatures?branch=feat/threshold_bindings#198e246f)`

[...]

cc: error: unrecognized command-line option ‘-fembed-bitcode’
```

## What was done?

Install and use clang

## How Has This Been Tested?

GH actions

## Breaking Changes

None


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone
