### PR TITLE
fix(dashmate): connect ENOENT /var/run/docker.sock

### DIFF
--- a/packages/dashmate/src/createDIContainer.js
+++ b/packages/dashmate/src/createDIContainer.js
@@ -93,7 +93,7 @@ const registerMasternodeGuideTaskFactory = require('./listr/tasks/setup/regular/
 const configureNodeTaskFactory = require('./listr/tasks/setup/regular/configureNodeTaskFactory');
 const configureSSLCertificateTaskFactory = require('./listr/tasks/setup/regular/configureSSLCertificateTaskFactory');
 const createHttpApiServerFactory = require('./helper/api/createHttpApiServerFactory');
-const resolveDockerSocket = require('./docker/resolveDockerSocketPath');
+const resolveDockerSocketPath = require('./docker/resolveDockerSocketPath');
 
 async function createDIContainer() {
   const container = createAwilixContainer({
@@ -150,9 +150,11 @@ async function createDIContainer() {
    */
 
   const dockerOptions = {};
-  const dockerSocketPath = await resolveDockerSocket();
-  if (dockerSocketPath) {
-    dockerOptions.socketPath = dockerSocketPath;
+  try {
+    dockerOptions.socketPath = await resolveDockerSocketPath();
+  } catch (e) {
+    // Here we skip possible error which is happening if docker is not installed or not running
+    // It will be handled in the logic below
   }
 
   container.register({

--- a/packages/dashmate/src/docker/resolveDockerSocketPath.js
+++ b/packages/dashmate/src/docker/resolveDockerSocketPath.js
@@ -4,18 +4,14 @@ const exec = promisify(require('child_process').exec);
 
 /**
  * Returns docker socket path
- * @returns {Promise<string|undefined>}
+ * @returns {Promise<string>}
  */
 async function resolveDockerSocketPath() {
-  try {
-    const { stdout } = await exec('docker context inspect');
+  const { stdout } = await exec('docker context inspect');
 
-    const output = JSON.parse(stdout);
+  const output = JSON.parse(stdout);
 
-    return path.normalize(output[0].Endpoints.docker.Host.split(':').pop());
-  } catch (e) {
-    return undefined;
-  }
+  return path.normalize(output[0].Endpoints.docker.Host.split(':').pop());
 }
 
 module.exports = resolveDockerSocketPath;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
If docker uses non-default context (e.g. in docker-desktop for linux), dashmate throws fatal error: `connect ENOENT /var/run/docker.sock`

## What was done?
<!--- Describe your changes in detail -->
Now at the start, we are trying to find out from the docker its current socket path and use it instead of the default one.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manual

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
No

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
