### PR TITLE
fix(dashmate): dashmate home not set in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -275,6 +275,10 @@ COPY --from=build-dashmate-helper /platform/packages/data-contracts packages/dat
 COPY --from=build-dashmate-helper /platform/packages/wasm-dpp packages/wasm-dpp
 
 USER node
+
+ENV DASHMATE_HOME_DIR=/home/dashmate/.dashmate
+ENV DASHMATE_HELPER=1
+
 ENTRYPOINT ["/platform/packages/dashmate/docker/entrypoint.sh"]
 
 #


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Dashmate Docker image restarts with error: `ConfigFileNotFoundError(CONFIG_FILE_PATH);`

## What was done?

Set missing env variables in Dockerfile.


## How Has This Been Tested?

Started local network

## Breaking Changes

None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone
