### PR TITLE
fix: envoy is restarting if admin is not enabled

### DIFF
--- a/packages/dashmate/templates/platform/gateway/envoy.yaml.dot
+++ b/packages/dashmate/templates/platform/gateway/envoy.yaml.dot
@@ -411,7 +411,7 @@ static_resources:
                       address: gateway_rate_limiter
                       port_value: 8081
     {{?}}
-    {{? it.platform.gateway.metrics.enabled && it.platform.gateway.admin.enabled }}
+    {{? it.platform.gateway.metrics.enabled || it.platform.gateway.admin.enabled }}
     - name: admin
       connect_timeout: 0.25s
       type: STATIC


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
When metrics are enabled for gateway, the envoy container is restarting until admin is enabled.

## What was done?
<!--- Describe your changes in detail -->
- Fixed if condition to add admin cluster if admin or metrics are enabled

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
None

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [x] I have made corresponding changes to the documentation if needed

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
