### PR TITLE
feat(platform): document count index

### DIFF
--- a/packages/rs-dpp/schema/meta_schemas/document/v0/document-meta.json
+++ b/packages/rs-dpp/schema/meta_schemas/document/v0/document-meta.json
@@ -426,6 +426,10 @@
               "resolution"
             ],
             "additionalProperties": false
+          },
+          "countable": {
+            "type": "boolean",
+            "description": "Enables countable operations on the index. Adds extra costs for documents storage"
           }
         },
         "required": [

--- a/packages/rs-dpp/src/data_contract/document_type/class_methods/try_from_schema/v1/mod.rs
+++ b/packages/rs-dpp/src/data_contract/document_type/class_methods/try_from_schema/v1/mod.rs
@@ -38,6 +38,8 @@ use crate::consensus::basic::document::MissingPositionsInDocumentTypePropertiesE
 use crate::consensus::basic::token::InvalidTokenPositionError;
 #[cfg(feature = "validation")]
 use crate::consensus::basic::BasicError;
+#[cfg(feature = "validation")]
+use crate::consensus::basic::UnsupportedFeatureError;
 use crate::data_contract::config::v0::DataContractConfigGettersV0;
 use crate::data_contract::config::DataContractConfig;
 use crate::data_contract::document_type::class_methods::try_from_schema::{
@@ -319,6 +321,17 @@ impl DocumentTypeV1 {
 
                         #[cfg(feature = "validation")]
                         if full_validation {
+                            // Countable indices are only supported starting from protocol version 12
+                            if index.countable && platform_version.protocol_version < 12 {
+                                return Err(ProtocolError::ConsensusError(Box::new(
+                                    UnsupportedFeatureError::new(
+                                        "count index".to_string(),
+                                        platform_version.protocol_version,
+                                    )
+                                    .into(),
+                                )));
+                            }
+
                             validation_operations.extend(std::iter::once(
                                 ProtocolValidationOperation::DocumentTypeSchemaIndexValidation(
                                     index.properties.len() as u64,

--- a/packages/rs-dpp/src/data_contract/document_type/index/mod.rs
+++ b/packages/rs-dpp/src/data_contract/document_type/index/mod.rs
@@ -295,6 +295,8 @@ pub struct Index {
     pub null_searchable: bool,
     /// Contested indexes are useful when a resource is considered valuable
     pub contested_index: Option<ContestedIndexInformation>,
+    /// Enables countable operations on the index
+    pub countable: bool,
 }
 
 impl Index {
@@ -469,6 +471,7 @@ impl TryFrom<&[(Value, Value)]> for Index {
         let mut name = None;
         let mut contested_index = None;
         let mut index_properties: Vec<IndexProperty> = Vec::new();
+        let mut countable = false;
 
         for (key_value, value_value) in index_type_value_map {
             let key = key_value.to_str()?;
@@ -585,6 +588,13 @@ impl TryFrom<&[(Value, Value)]> for Index {
                     }
                     contested_index = Some(contested_index_information);
                 }
+                "countable" => {
+                    countable = value_value
+                        .as_bool()
+                        .ok_or(DataContractError::ValueWrongType(
+                            "countable value must be a boolean".to_string(),
+                        ))?;
+                }
                 "properties" => {
                     let properties =
                         value_value
@@ -627,6 +637,7 @@ impl TryFrom<&[(Value, Value)]> for Index {
             unique,
             null_searchable,
             contested_index,
+            countable,
         })
     }
 }
@@ -680,6 +691,7 @@ mod tests {
             unique,
             null_searchable: true,
             contested_index: None,
+            countable: false,
         }
     }
 

--- a/packages/rs-dpp/src/data_contract/document_type/index/random_index.rs
+++ b/packages/rs-dpp/src/data_contract/document_type/index/random_index.rs
@@ -60,6 +60,7 @@ impl Index {
             unique,
             null_searchable: true,
             contested_index: None,
+            countable: false,
         })
     }
 }

--- a/packages/rs-dpp/src/data_contract/document_type/index_level/mod.rs
+++ b/packages/rs-dpp/src/data_contract/document_type/index_level/mod.rs
@@ -35,6 +35,8 @@ pub struct IndexLevelTypeInfo {
     pub should_insert_with_all_null: bool,
     /// The index type
     pub index_type: IndexType,
+    /// Is this index countable. Uses sum trees to enable count operations
+    pub countable: bool,
 }
 
 impl IndexType {
@@ -214,12 +216,38 @@ impl IndexLevel {
                     current_level.has_index_with_type = Some(IndexLevelTypeInfo {
                         should_insert_with_all_null: index.null_searchable,
                         index_type,
+                        countable: index.countable,
                     });
                 }
             }
         }
 
         Ok(index_level)
+    }
+
+    /// Recursively finds the first index path where the `countable` property differs
+    /// between two IndexLevel trees. Returns `None` if countable is the same everywhere.
+    #[cfg(feature = "validation")]
+    fn find_first_countable_change(&self, new: &IndexLevel) -> Option<String> {
+        // Compare countable at this level if both have an index termination
+        if let (Some(old_info), Some(new_info)) =
+            (&self.has_index_with_type, &new.has_index_with_type)
+        {
+            if old_info.countable != new_info.countable {
+                return Some("(countable changed)".to_string());
+            }
+        }
+
+        // Recurse into sub-levels that exist in both old and new
+        for (key, old_sub) in &self.sub_index_levels {
+            if let Some(new_sub) = new.sub_index_levels.get(key) {
+                if let Some(inner_path) = old_sub.find_first_countable_change(new_sub) {
+                    return Some(format!("{} -> {}", key, inner_path));
+                }
+            }
+        }
+
+        None
     }
 
     #[cfg(feature = "validation")]
@@ -258,6 +286,19 @@ impl IndexLevel {
             );
         }
 
+        // Check that the countable property has not changed on any existing index.
+        // Changing countable requires rebuilding the entire index tree structure
+        // (NormalTree vs CountTree), so it must be treated as immutable after creation.
+        if let Some(countable_change_path) = self.find_first_countable_change(new_indices) {
+            return SimpleConsensusValidationResult::new_with_error(
+                DataContractInvalidIndexDefinitionUpdateError::new(
+                    document_type_name.to_string(),
+                    countable_change_path,
+                )
+                .into(),
+            );
+        }
+
         SimpleConsensusValidationResult::new()
     }
 }
@@ -282,6 +323,7 @@ mod tests {
             unique: false,
             null_searchable: true,
             contested_index: None,
+            countable: false,
         }];
 
         let old_index_structure =
@@ -309,6 +351,7 @@ mod tests {
             unique: false,
             null_searchable: true,
             contested_index: None,
+            countable: false,
         }];
 
         let new_indices = vec![
@@ -321,6 +364,7 @@ mod tests {
                 unique: false,
                 null_searchable: true,
                 contested_index: None,
+                countable: false,
             },
             Index {
                 name: "test2".to_string(),
@@ -331,6 +375,7 @@ mod tests {
                 unique: false,
                 null_searchable: true,
                 contested_index: None,
+                countable: false,
             },
         ];
 
@@ -367,6 +412,7 @@ mod tests {
                 unique: false,
                 null_searchable: true,
                 contested_index: None,
+                countable: false,
             },
             Index {
                 name: "test2".to_string(),
@@ -377,6 +423,7 @@ mod tests {
                 unique: false,
                 null_searchable: true,
                 contested_index: None,
+                countable: false,
             },
         ];
 
@@ -389,6 +436,7 @@ mod tests {
             unique: false,
             null_searchable: true,
             contested_index: None,
+            countable: false,
         }];
 
         let old_index_structure =
@@ -423,6 +471,7 @@ mod tests {
             unique: false,
             null_searchable: true,
             contested_index: None,
+            countable: false,
         }];
 
         let new_indices = vec![Index {
@@ -440,6 +489,7 @@ mod tests {
             unique: false,
             null_searchable: true,
             contested_index: None,
+            countable: false,
         }];
 
         let old_index_structure =
@@ -480,6 +530,7 @@ mod tests {
             unique: false,
             null_searchable: true,
             contested_index: None,
+            countable: false,
         }];
 
         let new_indices = vec![Index {
@@ -491,6 +542,7 @@ mod tests {
             unique: false,
             null_searchable: true,
             contested_index: None,
+            countable: false,
         }];
 
         let old_index_structure =
@@ -508,6 +560,188 @@ mod tests {
             [ConsensusError::BasicError(
                 BasicError::DataContractInvalidIndexDefinitionUpdateError(e)
             )] if e.index_path() == "test -> test2"
+        );
+    }
+
+    #[test]
+    fn should_return_invalid_result_if_countable_changed_from_false_to_true() {
+        let platform_version = PlatformVersion::latest();
+        let document_type_name = "test";
+
+        let old_indices = vec![Index {
+            name: "test".to_string(),
+            properties: vec![IndexProperty {
+                name: "test".to_string(),
+                ascending: false,
+            }],
+            unique: false,
+            null_searchable: true,
+            contested_index: None,
+            countable: false,
+        }];
+
+        let new_indices = vec![Index {
+            name: "test".to_string(),
+            properties: vec![IndexProperty {
+                name: "test".to_string(),
+                ascending: false,
+            }],
+            unique: false,
+            null_searchable: true,
+            contested_index: None,
+            countable: true,
+        }];
+
+        let old_index_structure =
+            IndexLevel::try_from_indices(&old_indices, document_type_name, platform_version)
+                .expect("failed to create old index level");
+
+        let new_index_structure =
+            IndexLevel::try_from_indices(&new_indices, document_type_name, platform_version)
+                .expect("failed to create new index level");
+
+        let result = old_index_structure.validate_update(document_type_name, &new_index_structure);
+
+        assert_matches!(
+            result.errors.as_slice(),
+            [ConsensusError::BasicError(
+                BasicError::DataContractInvalidIndexDefinitionUpdateError(e)
+            )] if e.index_path() == "test -> (countable changed)"
+        );
+    }
+
+    #[test]
+    fn should_return_invalid_result_if_countable_changed_from_true_to_false() {
+        let platform_version = PlatformVersion::latest();
+        let document_type_name = "test";
+
+        let old_indices = vec![Index {
+            name: "test".to_string(),
+            properties: vec![IndexProperty {
+                name: "test".to_string(),
+                ascending: false,
+            }],
+            unique: false,
+            null_searchable: true,
+            contested_index: None,
+            countable: true,
+        }];
+
+        let new_indices = vec![Index {
+            name: "test".to_string(),
+            properties: vec![IndexProperty {
+                name: "test".to_string(),
+                ascending: false,
+            }],
+            unique: false,
+            null_searchable: true,
+            contested_index: None,
+            countable: false,
+        }];
+
+        let old_index_structure =
+            IndexLevel::try_from_indices(&old_indices, document_type_name, platform_version)
+                .expect("failed to create old index level");
+
+        let new_index_structure =
+            IndexLevel::try_from_indices(&new_indices, document_type_name, platform_version)
+                .expect("failed to create new index level");
+
+        let result = old_index_structure.validate_update(document_type_name, &new_index_structure);
+
+        assert_matches!(
+            result.errors.as_slice(),
+            [ConsensusError::BasicError(
+                BasicError::DataContractInvalidIndexDefinitionUpdateError(e)
+            )] if e.index_path() == "test -> (countable changed)"
+        );
+    }
+
+    #[test]
+    fn should_pass_if_countable_unchanged_on_update() {
+        let platform_version = PlatformVersion::latest();
+        let document_type_name = "test";
+
+        let old_indices = vec![Index {
+            name: "test".to_string(),
+            properties: vec![IndexProperty {
+                name: "test".to_string(),
+                ascending: false,
+            }],
+            unique: false,
+            null_searchable: true,
+            contested_index: None,
+            countable: true,
+        }];
+
+        let old_index_structure =
+            IndexLevel::try_from_indices(&old_indices, document_type_name, platform_version)
+                .expect("failed to create old index level");
+
+        // Clone so countable stays the same
+        let new_index_structure = old_index_structure.clone();
+
+        let result = old_index_structure.validate_update(document_type_name, &new_index_structure);
+
+        assert!(result.is_valid());
+    }
+
+    #[test]
+    fn should_return_invalid_result_if_countable_changed_on_compound_index() {
+        let platform_version = PlatformVersion::latest();
+        let document_type_name = "test";
+
+        let old_indices = vec![Index {
+            name: "compound".to_string(),
+            properties: vec![
+                IndexProperty {
+                    name: "first".to_string(),
+                    ascending: true,
+                },
+                IndexProperty {
+                    name: "second".to_string(),
+                    ascending: true,
+                },
+            ],
+            unique: false,
+            null_searchable: true,
+            contested_index: None,
+            countable: false,
+        }];
+
+        let new_indices = vec![Index {
+            name: "compound".to_string(),
+            properties: vec![
+                IndexProperty {
+                    name: "first".to_string(),
+                    ascending: true,
+                },
+                IndexProperty {
+                    name: "second".to_string(),
+                    ascending: true,
+                },
+            ],
+            unique: false,
+            null_searchable: true,
+            contested_index: None,
+            countable: true,
+        }];
+
+        let old_index_structure =
+            IndexLevel::try_from_indices(&old_indices, document_type_name, platform_version)
+                .expect("failed to create old index level");
+
+        let new_index_structure =
+            IndexLevel::try_from_indices(&new_indices, document_type_name, platform_version)
+                .expect("failed to create new index level");
+
+        let result = old_index_structure.validate_update(document_type_name, &new_index_structure);
+
+        assert_matches!(
+            result.errors.as_slice(),
+            [ConsensusError::BasicError(
+                BasicError::DataContractInvalidIndexDefinitionUpdateError(e)
+            )] if e.index_path() == "first -> second -> (countable changed)"
         );
     }
 }

--- a/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/data_contract_create/mod.rs
+++ b/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/data_contract_create/mod.rs
@@ -4779,4 +4779,64 @@ mod tests {
                 .expect("expected to commit transaction");
         }
     }
+
+    #[test]
+    fn test_data_contract_creation_with_countable_index() {
+        let platform_version = PlatformVersion::latest();
+        let mut platform = TestPlatformBuilder::new()
+            .build_with_mock_rpc()
+            .set_genesis_state();
+
+        let platform_state = platform.state.load();
+
+        let (identity, signer, key) = setup_identity(&mut platform, 958, dash_to_credits!(2.0));
+
+        let mut data_contract = json_document_to_contract_with_ids(
+            "tests/supporting_files/contract/family/family-contract-countable.json",
+            None,
+            None,
+            false,
+            platform_version,
+        )
+        .expect("expected to get json based contract");
+
+        data_contract.set_owner_id(identity.id());
+        data_contract
+            .set_config(DataContractConfig::default_for_version(platform_version).unwrap());
+
+        let data_contract_create_transition = DataContractCreateTransition::new_from_data_contract(
+            data_contract,
+            1,
+            &identity.into_partial_identity_info(),
+            key.id(),
+            &signer,
+            platform_version,
+            None,
+        )
+        .expect("expect to create data contract create transition");
+
+        let data_contract_create_serialized_transition = data_contract_create_transition
+            .serialize_to_bytes()
+            .expect("expected serialized state transition");
+
+        let transaction = platform.drive.grove.start_transaction();
+
+        let processing_result = platform
+            .platform
+            .process_raw_state_transitions(
+                &[data_contract_create_serialized_transition],
+                &platform_state,
+                &BlockInfo::default(),
+                &transaction,
+                platform_version,
+                false,
+                None,
+            )
+            .expect("expected to process state transition");
+
+        assert_matches!(
+            processing_result.execution_results().as_slice(),
+            [StateTransitionExecutionResult::SuccessfulExecution { .. }]
+        );
+    }
 }

--- a/packages/rs-drive-abci/tests/supporting_files/contract/family/family-contract-countable.json
+++ b/packages/rs-drive-abci/tests/supporting_files/contract/family/family-contract-countable.json
@@ -1,0 +1,29 @@
+{
+  "$formatVersion": "0",
+  "id": "GoVFhJnbHr7bPMBPNv7aJxuvPMRi41r85mpFE5FnVkgT",
+  "ownerId": "AcYUCSvAmUwryNsQqkqqD1o3BnFuzepGtR3Mhh2swLk6",
+  "version": 1,
+  "documentSchemas": {
+    "person": {
+      "type": "object",
+      "indices": [
+        {
+          "name": "byFirstName",
+          "properties": [
+            { "firstName": "asc" }
+          ],
+          "countable": true
+        }
+      ],
+      "properties": {
+        "firstName": {
+          "type": "string",
+          "maxLength": 50,
+          "position": 0
+        }
+      },
+      "required": ["firstName"],
+      "additionalProperties": false
+    }
+  }
+}

--- a/packages/rs-drive/src/drive/document/delete/remove_reference_for_index_level_for_contract_operations/v0/mod.rs
+++ b/packages/rs-drive/src/drive/document/delete/remove_reference_for_index_level_for_contract_operations/v0/mod.rs
@@ -59,13 +59,19 @@ impl Drive {
         {
             key_info_path.push(KnownKey(vec![0]));
 
+            let reference_tree_type = if index_type.countable {
+                TreeType::CountTree
+            } else {
+                TreeType::NormalTree
+            };
+
             if let Some(estimated_costs_only_with_layer_info) = estimated_costs_only_with_layer_info
             {
                 // On this level we will have a 0 and all the top index paths
                 estimated_costs_only_with_layer_info.insert(
                     key_info_path.clone(),
                     EstimatedLayerInformation {
-                        tree_type: TreeType::NormalTree,
+                        tree_type: reference_tree_type,
                         estimated_layer_count: PotentiallyAtMaxElements,
                         estimated_layer_sizes: AllSubtrees(
                             DEFAULT_HASH_SIZE_U8,

--- a/packages/rs-drive/src/drive/document/insert/add_reference_for_index_level_for_contract_operations/v0/mod.rs
+++ b/packages/rs-drive/src/drive/document/insert/add_reference_for_index_level_for_contract_operations/v0/mod.rs
@@ -49,6 +49,14 @@ impl Drive {
         if all_fields_null && !index_type.should_insert_with_all_null {
             return Ok(());
         }
+
+        // if index is countable, we should use count trees, so we can get the count of elements
+        let reference_tree_type = if index_type.countable {
+            TreeType::CountTree
+        } else {
+            TreeType::NormalTree
+        };
+
         // unique indexes will be stored under key "0"
         // non-unique indices should have a tree at key "0" that has all elements based off of primary key
         if !index_type.index_type.is_unique() || any_fields_null {
@@ -63,7 +71,7 @@ impl Drive {
             } else {
                 BatchInsertTreeApplyType::StatelessBatchInsertTree {
                     in_tree_type: TreeType::NormalTree,
-                    tree_type: TreeType::NormalTree,
+                    tree_type: reference_tree_type,
                     flags_len: storage_flags
                         .map(|s| s.serialized_size())
                         .unwrap_or_default(),
@@ -76,7 +84,7 @@ impl Drive {
             // a contested resource index
             self.batch_insert_empty_tree_if_not_exists(
                 path_key_info,
-                TreeType::NormalTree,
+                reference_tree_type,
                 *storage_flags,
                 apply_type,
                 transaction,
@@ -95,7 +103,7 @@ impl Drive {
                 estimated_costs_only_with_layer_info.insert(
                     index_path_info.clone().convert_to_key_info_path(),
                     EstimatedLayerInformation {
-                        tree_type: TreeType::NormalTree,
+                        tree_type: reference_tree_type,
                         estimated_layer_count: PotentiallyAtMaxElements,
                         estimated_layer_sizes: AllReference(
                             DEFAULT_HASH_SIZE_U8,
@@ -195,7 +203,7 @@ impl Drive {
                 BatchInsertApplyType::StatefulBatchInsert
             } else {
                 BatchInsertApplyType::StatelessBatchInsert {
-                    in_tree_type: TreeType::NormalTree,
+                    in_tree_type: reference_tree_type,
                     target: QueryTargetValue(
                         document_reference_size(document_and_contract_info.document_type)
                             + storage_flags

--- a/packages/rs-drive/tests/query_tests.rs
+++ b/packages/rs-drive/tests/query_tests.rs
@@ -270,6 +270,81 @@ pub fn setup_family_tests(
 }
 
 #[cfg(feature = "server")]
+/// Inserts the test "family" contract and adds `count` documents containing randomly named people to it.
+pub fn setup_countable_family_tests(
+    count: u32,
+    seed: u64,
+    platform_version: &PlatformVersion,
+) -> (Drive, DataContract) {
+    let drive_config = DriveConfig::default();
+
+    let drive = setup_drive(Some(drive_config));
+
+    let db_transaction = drive.grove.start_transaction();
+
+    // Create contracts tree
+    let mut batch = GroveDbOpBatch::new();
+
+    add_init_contracts_structure_operations(&mut batch);
+
+    drive
+        .grove_apply_batch(batch, false, Some(&db_transaction), &platform_version.drive)
+        .expect("expected to create contracts tree successfully");
+
+    // setup code
+    let contract = test_helpers::setup_contract(
+        &drive,
+        "tests/supporting_files/contract/family/family-contract-countable.json",
+        None,
+        None,
+        None::<fn(&mut DataContract)>,
+        Some(&db_transaction),
+        Some(platform_version),
+    );
+
+    let people = Person::random_people(count, seed);
+    for person in people {
+        let value = serde_json::to_value(person).expect("serialized person");
+        let document_cbor = cbor_serializer::serializable_value_to_cbor(&value, Some(0))
+            .expect("expected to serialize to cbor");
+        let document = Document::from_cbor(document_cbor.as_slice(), None, None, platform_version)
+            .expect("document should be properly deserialized");
+
+        let document_type = contract
+            .document_type_for_name("person")
+            .expect("expected to get document type");
+
+        let storage_flags = Some(Cow::Owned(StorageFlags::SingleEpoch(0)));
+
+        drive
+            .add_document_for_contract(
+                DocumentAndContractInfo {
+                    owned_document_info: OwnedDocumentInfo {
+                        document_info: DocumentRefInfo((&document, storage_flags)),
+                        owner_id: None,
+                    },
+                    contract: &contract,
+                    document_type,
+                },
+                true,
+                BlockInfo::genesis(),
+                true,
+                Some(&db_transaction),
+                platform_version,
+                None,
+            )
+            .expect("document should be inserted");
+    }
+    drive
+        .grove
+        .commit_transaction(db_transaction)
+        .unwrap()
+        .expect("transaction should be committed");
+
+    (drive, contract)
+}
+
+#[cfg(feature = "server")]
 /// Same as `setup_family_tests` but with null values in the documents.
 pub fn setup_family_tests_with_nulls(count: u32, seed: u64) -> (Drive, DataContract) {
     let drive_config = DriveConfig::default();
@@ -6997,5 +7072,50 @@ mod tests {
             .expect("should query documents");
 
         assert_eq!(query_result.documents().len(), 1);
+    }
+
+    #[cfg(feature = "server")]
+    #[test]
+    fn test_count_regular_index() {
+        let platform_version = PlatformVersion::latest();
+
+        let (drive, contract) = setup_countable_family_tests(6, 15, platform_version);
+
+        let db_transaction = drive.grove.start_transaction();
+
+        let _root_hash = drive
+            .grove
+            .root_hash(Some(&db_transaction), &platform_version.drive.grove_version)
+            .unwrap()
+            .expect("there is always a root hash");
+
+        // A query getting all elements by age
+
+        let query_value = platform_value!({
+            "where": [
+                ["age", ">=", 1]
+            ],
+            "orderBy": [
+                ["age", "asc"]
+            ]
+        });
+
+        let person_document_type = contract
+            .document_type_for_name("person")
+            .expect("contract should have a person document type");
+
+        let query = DriveDocumentQuery::from_value(
+            query_value,
+            &contract,
+            person_document_type,
+            &drive.config,
+        )
+        .expect("query should be built");
+
+        let (proof, _) = query
+            .execute_with_proof(&drive, None, None, platform_version)
+            .expect("we should be able to a proof");
+
+        assert!(!proof.is_empty(), "proof should not be empty");
     }
 }

--- a/packages/rs-drive/tests/supporting_files/contract/family/family-contract-countable.json
+++ b/packages/rs-drive/tests/supporting_files/contract/family/family-contract-countable.json
@@ -1,0 +1,74 @@
+{
+  "$formatVersion": "0",
+  "id": "94zNLp7A1ZcYG3Egqf2YmQk4DQr9P8D543GwXyCJRz4",
+  "ownerId": "AcYUCSvAmUwryNsQqkqqD1o3BnFuzepGtR3Mhh2swLk6",
+  "version": 1,
+  "documentSchemas": {
+    "person": {
+      "type": "object",
+      "indices": [
+        {
+          "properties": [
+            {
+              "firstName": "asc"
+            },
+            {
+              "lastName": "asc"
+            }
+          ],
+          "countable": true
+        },
+        {
+          "properties": [
+            {
+              "firstName": "asc"
+            },
+            {
+              "middleName": "asc"
+            },
+            {
+              "lastName": "asc"
+            }
+          ],
+          "unique": true,
+          "countable": true
+        },
+        {
+          "properties": [
+            {
+              "age": "asc"
+            }
+          ],
+          "countable": true
+        }
+      ],
+      "properties": {
+        "age": {
+          "type": "integer",
+          "position": 0
+        },
+        "firstName": {
+          "type": "string",
+          "maxLength": 50,
+           "position": 1
+        },
+        "middleName": {
+          "type": "string",
+          "maxLength": 50,
+          "position": 2
+        },
+        "lastName": {
+          "type": "string",
+          "maxLength": 50,
+          "position": 3
+        }
+      },
+      "required": [
+        "firstName",
+        "lastName",
+        "age"
+      ],
+      "additionalProperties": false
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Add support for a `countable` boolean property on document type indices. When an index has `"count": true` in the data contract schema, Drive uses `CountTree` instead of `NormalTree` for that index level, enabling efficient document counting queries.

### Changes

- Add `countable: bool` field to `Index` struct and `IndexLevelTypeInfo`
- Parse `"countable"` key from data contract index schema
- Use `CountTree` in Drive when `countable` is true
- **Version-gated to protocol version 12+** — contracts with countable indices are rejected on v11 and below via `UnsupportedFeatureError`
- Add test contract (`family-contract-countable.json`) and query test

### Schema example

```json
{
  "indices": [{
    "name": "byFirstName",
    "properties": [{"firstName": "asc"}],
    "countable": true
  }]
}
```

## Test plan

- [x] `cargo check -p dpp -p drive` passes
- [x] `cargo fmt --all` clean
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional per-index "countable" flag in document schemas; index defaults to non-countable.
  * Query/storage flows now use count-aware index handling where applicable.

* **Validation**
  * Countable indices require protocol v12+.
  * Schema update validation rejects changes that alter an index's countable setting.

* **Tests**
  * Added sample contract and tests exercising countable-index behavior and queries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->