### PR TITLE
fix: ensure only one from_block field is set in subscribeToTransactionsWithProofs

### DIFF
--- a/packages/js-dapi-client/lib/methods/core/subscribeToTransactionsWithProofsFactory.js
+++ b/packages/js-dapi-client/lib/methods/core/subscribeToTransactionsWithProofsFactory.js
@@ -39,7 +39,7 @@ function subscribeToTransactionsWithProofsFactory(grpcTransport) {
       ...options,
     };
 
-    if (options.fromBlockHeight === 0) {
+    if ('fromBlockHeight' in options && options.fromBlockHeight === 0) {
       throw new DAPIClientError('Invalid argument: minimum value for `fromBlockHeight` is 1');
     }
 
@@ -59,14 +59,14 @@ function subscribeToTransactionsWithProofsFactory(grpcTransport) {
     const request = new TransactionsWithProofsRequest();
     request.setBloomFilter(bloomFilterMessage);
 
-    if (options.fromBlockHeight !== undefined) {
-      request.setFromBlockHeight(options.fromBlockHeight);
-    }
-
-    if (options.fromBlockHash) {
+    if ('fromBlockHash' in options) {
       request.setFromBlockHash(
-        Buffer.from(options.fromBlockHash, 'hex'),
+        Buffer.isBuffer(options.fromBlockHash)
+          ? options.fromBlockHash
+          : Buffer.from(options.fromBlockHash, 'hex'),
       );
+    } else if ('fromBlockHeight' in options) {
+      request.setFromBlockHeight(options.fromBlockHeight);
     }
 
     request.setCount(options.count);


### PR DESCRIPTION
## Issue being fixed or feature implemented
This PR resolves a bug in dapi-client where providing `fromBlockHash` to `subscribeToTransactionsWithProofs()` would still result in a gRPC error due to unintended Protobuf serialization of `fromBlockHeight = 0`.

## What was done?

- Updated validation logic to only throw if `fromBlockHeight` was explicitly passed and is zero.
- Ensured that `fromBlockHeight` is only used when `fromBlockHash` is not present.
- No functional change to other fields or logic.

## How Has This Been Tested?
CI

## Breaking Changes
N/A

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [ ] I have made corresponding changes to the documentation if needed

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved the transaction subscription process by refining how optional parameters are handled. This update enhances reliability by preventing errors when certain identifiers are absent, ensuring that the subscription service functions more predictably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->