### PR TITLE
fix(sdk): enable scroll-to-top

### DIFF
--- a/packages/wasm-sdk/docs.html
+++ b/packages/wasm-sdk/docs.html
@@ -2892,7 +2892,15 @@ const result = await sdk.identityTopUp(identityId, assetLockProof, assetLockProo
         document.querySelectorAll('a[href^="#"]').forEach(anchor => {
             anchor.addEventListener('click', function (e) {
                 e.preventDefault();
-                const target = document.querySelector(this.getAttribute('href'));
+                const href = this.getAttribute('href');
+                if (href === '#') {
+                    window.scrollTo({
+                        top: 0,
+                        behavior: 'smooth'
+                    });
+                    return;
+                }
+                const target = document.querySelector(href);
                 if (target) {
                     target.scrollIntoView({
                         behavior: 'smooth',


### PR DESCRIPTION
## Issue being fixed or feature implemented
The scroll-to-top button on the SDK docs page didn't work.

## What was done?
Ensure docs page scroll-to-top button works by handling empty hash links in smooth scroll script

## How Has This Been Tested?
Locally

## Breaking Changes
N/A

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [ ] I have made corresponding changes to the documentation if needed

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Documentation
  - Improved in-page navigation in the documentation: clicking links pointing to “#” now smoothly scrolls to the top.
  - Enhanced reliability of anchor links within the page, ensuring smooth scrolling to the correct section when an anchor target exists.
  - Maintains smooth scrolling behavior for all supported anchors, providing a more consistent and polished browsing experience across the docs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->