### PR TITLE
fix(wasm-sdk): use identity contract nonce for data contract updates

### DIFF
--- a/packages/wasm-sdk/src/state_transitions/contracts/mod.rs
+++ b/packages/wasm-sdk/src/state_transitions/contracts/mod.rs
@@ -259,11 +259,11 @@ impl WasmSdk {
             )));
         }
         
-        // Get identity nonce
-        let identity_nonce = sdk
-            .get_identity_nonce(owner_identifier, true, None)
+        // Get identity contract nonce (contract updates use per-contract nonces)
+        let identity_contract_nonce = sdk
+            .get_identity_contract_nonce(owner_identifier, contract_identifier, true, None)
             .await
-            .map_err(|e| JsValue::from_str(&format!("Failed to get identity nonce: {}", e)))?;
+            .map_err(|e| JsValue::from_str(&format!("Failed to get identity contract nonce: {}", e)))?;
         
         // Create partial identity for signing
         let partial_identity = dash_sdk::dpp::identity::PartialIdentity {
@@ -283,7 +283,7 @@ impl WasmSdk {
             updated_contract.clone(),
             &partial_identity,
             matching_key.id(),
-            identity_nonce,
+            identity_contract_nonce,
             dash_sdk::dpp::prelude::UserFeeIncrease::default(),
             &signer,
             sdk.version(),


### PR DESCRIPTION
## Issue being fixed or feature implemented
Data contract update transitions require identity_contract_nonce instead of identity_nonce. This aligns with the DataContractUpdateTransition struct and matches how document/token operations work.

## What was done?
Switched to identity contract nonce for contract update

## How Has This Been Tested?
Locally

## Breaking Changes
:thinking: Technically maybe. But not really, because it was mostly non-functional before (it only worked when your identity nonce and identity contract nonce were the same)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [ ] I have made corresponding changes to the documentation if needed

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Contract updates now use per‑contract nonces, preventing collisions across multiple contracts owned by the same identity and reducing failed or rejected updates.

* **Improvements**
  * More reliable signing for contract updates by aligning nonce handling with per‑contract behavior.
  * Clearer error messaging when a contract-specific nonce cannot be retrieved.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->