### PR TITLE
ci: Use self hosted mac runner

### DIFF
--- a/.github/workflows/swift-sdk-build.yml
+++ b/.github/workflows/swift-sdk-build.yml
@@ -16,7 +16,7 @@ on:
 jobs:
   swift-sdk-build:
     name: Swift SDK and Example build (warnings as errors)
-    runs-on: macos-15
+    runs-on: [self-hosted, macOS, ARM64]
     timeout-minutes: 60
 
     steps:

--- a/packages/swift-sdk/SwiftExampleApp/SwiftExampleApp/Core/Services/WalletService.swift
+++ b/packages/swift-sdk/SwiftExampleApp/SwiftExampleApp/Core/Services/WalletService.swift
@@ -494,14 +494,16 @@ extension WalletService: SPVClientDelegate {
         let targetHeight = progress.targetHeight
         let rate = progress.rate
         let stage = progress.stage
-        let mappedStage = WalletService.mapSyncStage(stage)
         let overall = progress.overallProgress
+        let stageRawValue = stage.rawValue
 
         Task { @MainActor in
             let base = Double(startHeight)
             let numer = max(0.0, Double(currentHeight) - base)
             let denom = max(1.0, Double(targetHeight) - base)
             let headerPct = min(1.0, max(0.0, numer / denom))
+            
+            let mappedStage = WalletService.mapSyncStage(stage)
 
             WalletService.shared.syncProgress = headerPct
             WalletService.shared.headerProgress = headerPct
@@ -515,7 +517,7 @@ extension WalletService: SPVClientDelegate {
             )
 
             if ProcessInfo.processInfo.environment["SPV_SWIFT_LOG"] == "1" {
-                print("📊 Sync progress: \(stage.rawValue) - \(Int(overall * 100))%")
+                print("📊 Sync progress: \(stageRawValue) - \(Int(overall * 100))%")
             }
         }
 

--- a/packages/swift-sdk/SwiftExampleApp/SwiftExampleApp/Core/Services/WalletService.swift
+++ b/packages/swift-sdk/SwiftExampleApp/SwiftExampleApp/Core/Services/WalletService.swift
@@ -496,14 +496,13 @@ extension WalletService: SPVClientDelegate {
         let stage = progress.stage
         let overall = progress.overallProgress
         let stageRawValue = stage.rawValue
+        let mappedStage = WalletService.mapSyncStage(stage)
 
         Task { @MainActor in
             let base = Double(startHeight)
             let numer = max(0.0, Double(currentHeight) - base)
             let denom = max(1.0, Double(targetHeight) - base)
             let headerPct = min(1.0, max(0.0, numer / denom))
-            
-            let mappedStage = WalletService.mapSyncStage(stage)
 
             WalletService.shared.syncProgress = headerPct
             WalletService.shared.headerProgress = headerPct


### PR DESCRIPTION
 ## Issue being fixed or feature implemented
  Swift SDK build workflow fails on GitHub-hosted runners

  ## What was done?
  - Updated swift-sdk-build.yml to use self-hosted macOS ARM64 runner instead of GitHub-hosted macos-15

  ## Breaking Changes
  None

  ## Checklist:
  - [x] I have performed a self-review of my own code
  - [ ] I have commented my code, particularly in hard-to-understand areas
  - [ ] I have added or updated relevant unit/integration/functional/e2e tests
  - [ ] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
  - [ ] I have made corresponding changes to the documentation if needed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved wallet sync progress reporting to keep stages and percentages consistent during updates, reducing transient UI mismatches and improving log clarity.
* **Chores**
  * Migrated Swift SDK CI to a self-hosted macOS ARM64 runner for more reliable and faster builds.
* **Notes**
  * No public APIs or user-facing configuration changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->