### PR TITLE
fix(sdk): wasm sdk is not initialized for static methods

### DIFF
--- a/packages/js-evo-sdk/src/sdk.ts
+++ b/packages/js-evo-sdk/src/sdk.ts
@@ -116,11 +116,13 @@ export class EvoSDK {
     return this.wasm.version();
   }
 
-  static setLogLevel(levelOrFilter: string): void {
+  static async setLogLevel(levelOrFilter: string): Promise<void> {
+    await initWasm();
     wasm.WasmSdk.setLogLevel(levelOrFilter);
   }
 
-  static getLatestVersionNumber(): number {
+  static async getLatestVersionNumber(): Promise<number> {
+    await initWasm();
     return wasm.WasmSdkBuilder.getLatestVersionNumber();
   }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Static version and logging methods aren't working.

## What was done?
<!--- Describe your changes in detail -->
This pull request updates the logging and version retrieval methods in the `EvoSDK` class to ensure proper initialization of the WebAssembly module before use. Both methods are now asynchronous, which helps prevent runtime errors if the WASM module hasn't finished loading.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
None

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [x] I have made corresponding changes to the documentation if needed

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Breaking Changes**
  * Logging configuration and latest version retrieval methods are now asynchronous and must be awaited. Return types have changed to Promises.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->