### PR TITLE
chore: update to groveDB 3.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2472,8 +2472,9 @@ dependencies = [
 
 [[package]]
 name = "grovedb"
-version = "3.0.0"
-source = "git+https://github.com/dashpay/grovedb?rev=1ecedf530fbc5b5e12edf1bc607bd288c187ddde#1ecedf530fbc5b5e12edf1bc607bd288c187ddde"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f12b2378c5eda5b7cadceb34fc6e0a8fd87fe03fc04841a7d32a74ff73ccef71"
 dependencies = [
  "axum 0.8.4",
  "bincode 2.0.0-rc.3",
@@ -2504,8 +2505,9 @@ dependencies = [
 
 [[package]]
 name = "grovedb-costs"
-version = "3.0.0"
-source = "git+https://github.com/dashpay/grovedb?rev=1ecedf530fbc5b5e12edf1bc607bd288c187ddde#1ecedf530fbc5b5e12edf1bc607bd288c187ddde"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e74fafe53bf5ae27128799856e557ef5cb2d7109f1f7bc7f4440bbd0f97c7072"
 dependencies = [
  "integer-encoding",
  "intmap",
@@ -2514,8 +2516,9 @@ dependencies = [
 
 [[package]]
 name = "grovedb-epoch-based-storage-flags"
-version = "3.0.0"
-source = "git+https://github.com/dashpay/grovedb?rev=1ecedf530fbc5b5e12edf1bc607bd288c187ddde#1ecedf530fbc5b5e12edf1bc607bd288c187ddde"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc6bdc033cc229b17cd02ee9d5c5a5a344788ed0e69ad7468b0d34d94b021fc4"
 dependencies = [
  "grovedb-costs",
  "hex",
@@ -2526,8 +2529,9 @@ dependencies = [
 
 [[package]]
 name = "grovedb-merk"
-version = "3.0.0"
-source = "git+https://github.com/dashpay/grovedb?rev=1ecedf530fbc5b5e12edf1bc607bd288c187ddde#1ecedf530fbc5b5e12edf1bc607bd288c187ddde"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6dd6f733e9d5c15c98e05b68a2028e00b7f177baa51e8d8c1541102942a72b7"
 dependencies = [
  "bincode 2.0.0-rc.3",
  "bincode_derive",
@@ -2550,16 +2554,18 @@ dependencies = [
 
 [[package]]
 name = "grovedb-path"
-version = "3.0.0"
-source = "git+https://github.com/dashpay/grovedb?rev=1ecedf530fbc5b5e12edf1bc607bd288c187ddde#1ecedf530fbc5b5e12edf1bc607bd288c187ddde"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01f716520d6c6b0f25dc4a68bc7dded645826ed57d38a06a80716a487c09d23c"
 dependencies = [
  "hex",
 ]
 
 [[package]]
 name = "grovedb-storage"
-version = "3.0.0"
-source = "git+https://github.com/dashpay/grovedb?rev=1ecedf530fbc5b5e12edf1bc607bd288c187ddde#1ecedf530fbc5b5e12edf1bc607bd288c187ddde"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52d04f3831fe210543a7246f2a60ae068f23eac5f9d53200d5a82785750f68fd"
 dependencies = [
  "blake3",
  "grovedb-costs",
@@ -2577,8 +2583,9 @@ dependencies = [
 
 [[package]]
 name = "grovedb-version"
-version = "3.0.0"
-source = "git+https://github.com/dashpay/grovedb?rev=1ecedf530fbc5b5e12edf1bc607bd288c187ddde#1ecedf530fbc5b5e12edf1bc607bd288c187ddde"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdc855662f05f41b10dd022226cb78e345a33f35c390e25338d21dedd45966ae"
 dependencies = [
  "thiserror 2.0.16",
  "versioned-feature-core 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2586,8 +2593,9 @@ dependencies = [
 
 [[package]]
 name = "grovedb-visualize"
-version = "3.0.0"
-source = "git+https://github.com/dashpay/grovedb?rev=1ecedf530fbc5b5e12edf1bc607bd288c187ddde#1ecedf530fbc5b5e12edf1bc607bd288c187ddde"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34fa6f41c110d1d141bf912175f187ef51ac5d2a8f163dfd229be007461a548f"
 dependencies = [
  "hex",
  "itertools 0.14.0",
@@ -2595,8 +2603,9 @@ dependencies = [
 
 [[package]]
 name = "grovedbg-types"
-version = "3.0.0"
-source = "git+https://github.com/dashpay/grovedb?rev=1ecedf530fbc5b5e12edf1bc607bd288c187ddde#1ecedf530fbc5b5e12edf1bc607bd288c187ddde"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb3ce8a460d679ffa078aba5555e493f966c4f1acc75a10890666ae12bb417c2"
 dependencies = [
  "serde",
  "serde_with 3.14.0",

--- a/packages/rs-drive/Cargo.toml
+++ b/packages/rs-drive/Cargo.toml
@@ -52,12 +52,12 @@ enum-map = { version = "2.0.3", optional = true }
 intmap = { version = "3.0.1", features = ["serde"], optional = true }
 chrono = { version = "0.4.35", optional = true }
 itertools = { version = "0.13", optional = true }
-grovedb = { git = "https://github.com/dashpay/grovedb", rev = "1ecedf530fbc5b5e12edf1bc607bd288c187ddde", optional = true, default-features = false }
-grovedb-costs = { git = "https://github.com/dashpay/grovedb", rev = "1ecedf530fbc5b5e12edf1bc607bd288c187ddde", optional = true }
-grovedb-path = { git = "https://github.com/dashpay/grovedb", rev = "1ecedf530fbc5b5e12edf1bc607bd288c187ddde" }
-grovedb-storage = { git = "https://github.com/dashpay/grovedb", rev = "1ecedf530fbc5b5e12edf1bc607bd288c187ddde", optional = true }
-grovedb-version = { git = "https://github.com/dashpay/grovedb", rev = "1ecedf530fbc5b5e12edf1bc607bd288c187ddde" }
-grovedb-epoch-based-storage-flags = { git = "https://github.com/dashpay/grovedb", rev = "1ecedf530fbc5b5e12edf1bc607bd288c187ddde" }
+grovedb = { version = "3.1.0", optional = true, default-features = false }
+grovedb-costs = { version = "3.1.0", optional = true }
+grovedb-path = { version = "3.1.0" }
+grovedb-storage = { version = "3.1.0", optional = true }
+grovedb-version = { version = "3.1.0" }
+grovedb-epoch-based-storage-flags = { version = "3.1.0" }
 
 [dev-dependencies]
 criterion = "0.5"

--- a/packages/rs-platform-version/Cargo.toml
+++ b/packages/rs-platform-version/Cargo.toml
@@ -11,7 +11,7 @@ license = "MIT"
 thiserror = { version = "2.0.12" }
 bincode = { version = "=2.0.0-rc.3" }
 versioned-feature-core = { git = "https://github.com/dashpay/versioned-feature-core", version = "1.0.0" }
-grovedb-version = { git = "https://github.com/dashpay/grovedb", rev = "1ecedf530fbc5b5e12edf1bc607bd288c187ddde" }
+grovedb-version = { version = "3.1.0" }
 once_cell = "1.19.0"
 
 [features]


### PR DESCRIPTION
This doesn't actually change underlying grovedb. We just released the grovedb version that will be used.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated grovedb dependencies to version 3.1.0 across packages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->