### PR TITLE
chore: update to rust dash core v0.40.0

### DIFF
--- a/.github/workflows/swift-sdk-build.yml
+++ b/.github/workflows/swift-sdk-build.yml
@@ -23,12 +23,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Select Xcode 16
-        uses: maxim-lobanov/setup-xcode@v1
-        with:
-          xcode-version: '16.*'
-
-      - name: Show Xcode and Swift versions
+      - name: Show Xcode and Swift versions (use default on self-hosted runner)
         run: |
           xcodebuild -version
           swift --version

--- a/.github/workflows/swift-sdk-build.yml
+++ b/.github/workflows/swift-sdk-build.yml
@@ -98,12 +98,19 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          # Use the same rust-dashcore revision as rs-dpp (parse single-line dep)
-          REV=$(grep -E '^[[:space:]]*dashcore[[:space:]]*=[[:space:]]*\{.*rev[[:space:]]*=' packages/rs-dpp/Cargo.toml \
-                | sed -E 's/.*rev[[:space:]]*=[[:space:]]*"([^"]+)".*/\1/' \
+          # Use the same rust-dashcore revision/tag as rs-dpp
+          # Try to find tag first (preferred format)
+          REV=$(grep -E '^[[:space:]]*dashcore[[:space:]]*=[[:space:]]*\{.*tag[[:space:]]*=' packages/rs-dpp/Cargo.toml \
+                | sed -E 's/.*tag[[:space:]]*=[[:space:]]*"([^"]+)".*/\1/' \
                 | head -n1 || true)
+          # If no tag found, try rev format
           if [ -z "${REV:-}" ]; then
-            echo "Failed to determine rust-dashcore revision from Cargo.toml" >&2
+            REV=$(grep -E '^[[:space:]]*dashcore[[:space:]]*=[[:space:]]*\{.*rev[[:space:]]*=' packages/rs-dpp/Cargo.toml \
+                  | sed -E 's/.*rev[[:space:]]*=[[:space:]]*"([^"]+)".*/\1/' \
+                  | head -n1 || true)
+          fi
+          if [ -z "${REV:-}" ]; then
+            echo "Failed to determine rust-dashcore revision or tag from Cargo.toml" >&2
             exit 1
           fi
           echo "rev=$REV" >> "$GITHUB_OUTPUT"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1390,7 +1390,7 @@ dependencies = [
 [[package]]
 name = "dash-network"
 version = "0.40.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=c877c1a74d145e2003d549619698511513db925c#c877c1a74d145e2003d549619698511513db925c"
+source = "git+https://github.com/dashpay/rust-dashcore?tag=v0.40.0#c877c1a74d145e2003d549619698511513db925c"
 dependencies = [
  "bincode 2.0.0-rc.3",
  "bincode_derive",
@@ -1461,7 +1461,7 @@ dependencies = [
 [[package]]
 name = "dash-spv"
 version = "0.40.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=c877c1a74d145e2003d549619698511513db925c#c877c1a74d145e2003d549619698511513db925c"
+source = "git+https://github.com/dashpay/rust-dashcore?tag=v0.40.0#c877c1a74d145e2003d549619698511513db925c"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1489,7 +1489,7 @@ dependencies = [
 [[package]]
 name = "dash-spv-ffi"
 version = "0.40.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=c877c1a74d145e2003d549619698511513db925c#c877c1a74d145e2003d549619698511513db925c"
+source = "git+https://github.com/dashpay/rust-dashcore?tag=v0.40.0#c877c1a74d145e2003d549619698511513db925c"
 dependencies = [
  "cbindgen 0.29.0",
  "clap",
@@ -1514,7 +1514,7 @@ dependencies = [
 [[package]]
 name = "dashcore"
 version = "0.40.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=c877c1a74d145e2003d549619698511513db925c#c877c1a74d145e2003d549619698511513db925c"
+source = "git+https://github.com/dashpay/rust-dashcore?tag=v0.40.0#c877c1a74d145e2003d549619698511513db925c"
 dependencies = [
  "anyhow",
  "base64-compat",
@@ -1540,12 +1540,12 @@ dependencies = [
 [[package]]
 name = "dashcore-private"
 version = "0.40.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=c877c1a74d145e2003d549619698511513db925c#c877c1a74d145e2003d549619698511513db925c"
+source = "git+https://github.com/dashpay/rust-dashcore?tag=v0.40.0#c877c1a74d145e2003d549619698511513db925c"
 
 [[package]]
 name = "dashcore-rpc"
 version = "0.40.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=c877c1a74d145e2003d549619698511513db925c#c877c1a74d145e2003d549619698511513db925c"
+source = "git+https://github.com/dashpay/rust-dashcore?tag=v0.40.0#c877c1a74d145e2003d549619698511513db925c"
 dependencies = [
  "dashcore-rpc-json",
  "hex",
@@ -1558,7 +1558,7 @@ dependencies = [
 [[package]]
 name = "dashcore-rpc-json"
 version = "0.40.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=c877c1a74d145e2003d549619698511513db925c#c877c1a74d145e2003d549619698511513db925c"
+source = "git+https://github.com/dashpay/rust-dashcore?tag=v0.40.0#c877c1a74d145e2003d549619698511513db925c"
 dependencies = [
  "bincode 2.0.0-rc.3",
  "dashcore",
@@ -1573,7 +1573,7 @@ dependencies = [
 [[package]]
 name = "dashcore_hashes"
 version = "0.40.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=c877c1a74d145e2003d549619698511513db925c#c877c1a74d145e2003d549619698511513db925c"
+source = "git+https://github.com/dashpay/rust-dashcore?tag=v0.40.0#c877c1a74d145e2003d549619698511513db925c"
 dependencies = [
  "bincode 2.0.0-rc.3",
  "dashcore-private",
@@ -3393,7 +3393,7 @@ dependencies = [
 [[package]]
 name = "key-wallet"
 version = "0.40.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=c877c1a74d145e2003d549619698511513db925c#c877c1a74d145e2003d549619698511513db925c"
+source = "git+https://github.com/dashpay/rust-dashcore?tag=v0.40.0#c877c1a74d145e2003d549619698511513db925c"
 dependencies = [
  "aes",
  "base58ck",
@@ -3422,7 +3422,7 @@ dependencies = [
 [[package]]
 name = "key-wallet-ffi"
 version = "0.40.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=c877c1a74d145e2003d549619698511513db925c#c877c1a74d145e2003d549619698511513db925c"
+source = "git+https://github.com/dashpay/rust-dashcore?tag=v0.40.0#c877c1a74d145e2003d549619698511513db925c"
 dependencies = [
  "cbindgen 0.29.0",
  "dash-network",
@@ -3438,7 +3438,7 @@ dependencies = [
 [[package]]
 name = "key-wallet-manager"
 version = "0.40.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=c877c1a74d145e2003d549619698511513db925c#c877c1a74d145e2003d549619698511513db925c"
+source = "git+https://github.com/dashpay/rust-dashcore?tag=v0.40.0#c877c1a74d145e2003d549619698511513db925c"
 dependencies = [
  "async-trait",
  "bincode 2.0.0-rc.3",

--- a/packages/rs-dpp/Cargo.toml
+++ b/packages/rs-dpp/Cargo.toml
@@ -23,17 +23,17 @@ chrono = { version = "0.4.35", default-features = false, features = [
 ] }
 chrono-tz = { version = "0.8", optional = true }
 ciborium = { version = "0.2.2", optional = true }
-dashcore = { git = "https://github.com/dashpay/rust-dashcore", rev = "c877c1a74d145e2003d549619698511513db925c", features = [
+dashcore = { git = "https://github.com/dashpay/rust-dashcore", tag = "v0.40.0", features = [
   "std",
   "secp-recovery",
   "rand",
   "signer",
   "serde",
 ], default-features = false }
-key-wallet = { git = "https://github.com/dashpay/rust-dashcore", rev = "c877c1a74d145e2003d549619698511513db925c", optional = true }
-key-wallet-manager = { git = "https://github.com/dashpay/rust-dashcore", rev = "c877c1a74d145e2003d549619698511513db925c", optional = true }
-dash-spv = { git = "https://github.com/dashpay/rust-dashcore", rev = "c877c1a74d145e2003d549619698511513db925c", optional = true }
-dashcore-rpc = { git = "https://github.com/dashpay/rust-dashcore", rev = "c877c1a74d145e2003d549619698511513db925c", optional = true }
+key-wallet = { git = "https://github.com/dashpay/rust-dashcore", tag = "v0.40.0", optional = true }
+key-wallet-manager = { git = "https://github.com/dashpay/rust-dashcore", tag = "v0.40.0", optional = true }
+dash-spv = { git = "https://github.com/dashpay/rust-dashcore", tag = "v0.40.0", optional = true }
+dashcore-rpc = { git = "https://github.com/dashpay/rust-dashcore", tag = "v0.40.0", optional = true }
 
 env_logger = { version = "0.11" }
 getrandom = { version = "0.2", features = ["js"] }

--- a/packages/rs-platform-wallet/Cargo.toml
+++ b/packages/rs-platform-wallet/Cargo.toml
@@ -11,11 +11,11 @@ description = "Platform wallet with identity management support"
 dpp = { path = "../rs-dpp" }
 
 # Key wallet dependencies (from rust-dashcore)
-key-wallet = { git = "https://github.com/dashpay/rust-dashcore", rev = "c877c1a74d145e2003d549619698511513db925c" }
-key-wallet-manager = { git = "https://github.com/dashpay/rust-dashcore", rev = "c877c1a74d145e2003d549619698511513db925c", optional = true }
+key-wallet = { git = "https://github.com/dashpay/rust-dashcore", tag = "v0.40.0" }
+key-wallet-manager = { git = "https://github.com/dashpay/rust-dashcore", tag = "v0.40.0", optional = true }
 
 # Core dependencies
-dashcore = { git = "https://github.com/dashpay/rust-dashcore", rev = "c877c1a74d145e2003d549619698511513db925c" }
+dashcore = { git = "https://github.com/dashpay/rust-dashcore", tag = "v0.40.0" }
 
 # Standard dependencies
 serde = { version = "1.0", features = ["derive"] }

--- a/packages/rs-sdk-ffi/Cargo.toml
+++ b/packages/rs-sdk-ffi/Cargo.toml
@@ -18,7 +18,7 @@ rs-sdk-trusted-context-provider = { path = "../rs-sdk-trusted-context-provider",
 simple-signer = { path = "../simple-signer" }
 
 # Core SDK integration (always included for unified SDK)
-dash-spv-ffi = { git = "https://github.com/dashpay/rust-dashcore", rev = "c877c1a74d145e2003d549619698511513db925c", optional = true }
+dash-spv-ffi = { git = "https://github.com/dashpay/rust-dashcore", tag = "v0.40.0", optional = true }
 
 # FFI and serialization
 serde = { version = "1.0", features = ["derive"] }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated dependency pins to the stable v0.40.0 release across multiple Rust packages for more consistent and reliable version resolution.
  * CI/workflow updated to prefer release tags (falling back to commit IDs) and now emits clearer messages when neither is available.
  * Removed explicit Xcode selection step from the Swift build workflow to rely on the runner's default environment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->