### PR TITLE
fix(dashmate): dapi not removed after migration to rs-dapi

### DIFF
--- a/packages/dashmate/src/docker/DockerCompose.js
+++ b/packages/dashmate/src/docker/DockerCompose.js
@@ -451,13 +451,28 @@ export default class DockerCompose {
    * @param {string[]} [options.profiles]
    * @return {Promise<void>}
    */
-  async rm(config, { serviceNames = [], profiles = [] } = {}) {
+  async rm(config, {
+    serviceNames = [],
+    profiles = [],
+    removeVolumes = false,
+    force = false,
+  } = {}) {
     await this.throwErrorIfNotInstalled();
+
+    const commandOptions = ['--stop'];
+
+    if (removeVolumes) {
+      commandOptions.push('-v');
+    }
+
+    if (force) {
+      commandOptions.push('--force');
+    }
 
     try {
       await dockerCompose.rm({
         ...this.#createOptions(config, { profiles }),
-        commandOptions: ['--stop'],
+        commandOptions,
       }, ...serviceNames);
     } catch (e) {
       throw new DockerComposeError(e);

--- a/packages/dashmate/src/listr/tasks/startNodeTaskFactory.js
+++ b/packages/dashmate/src/listr/tasks/startNodeTaskFactory.js
@@ -4,6 +4,11 @@ import { Observable } from 'rxjs';
 import { NETWORK_LOCAL } from '../../constants.js';
 import isServiceBuildRequired from '../../util/isServiceBuildRequired.js';
 
+const DAPI_PROFILE_SERVICES = {
+  'platform-dapi-deprecated': ['dapi_api', 'dapi_core_streams'],
+  'platform-dapi-rs': ['rs_dapi'],
+};
+
 /**
  *
  * @param {DockerCompose} dockerCompose
@@ -107,6 +112,31 @@ export default function startNodeTaskFactory(
         enabled: (ctx) => !ctx.skipBuildServices
           && isServiceBuildRequired(config),
         task: () => buildServicesTask(config),
+      },
+      {
+        title: 'Remove inactive DAPI stack',
+        enabled: () => config.get('platform.enable'),
+        task: async () => {
+          const deprecatedEnabled = config.has('platform.dapi.deprecated.enabled')
+            ? config.get('platform.dapi.deprecated.enabled')
+            : false;
+
+          const inactiveProfile = deprecatedEnabled
+            ? 'platform-dapi-rs'
+            : 'platform-dapi-deprecated';
+
+          const serviceNames = DAPI_PROFILE_SERVICES[inactiveProfile] ?? [];
+
+          if (serviceNames.length === 0) {
+            return;
+          }
+
+          await dockerCompose.rm(config, {
+            serviceNames,
+            profiles: [inactiveProfile],
+            force: true,
+          });
+        },
       },
       {
         title: 'Start services',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented

After upgrade from v2.0.0 to v2.1.0-rc.1, there is both dapi and rs-dapi container running


## What was done?

Remove unused container.

## How Has This Been Tested?



## Breaking Changes

yarn dashmate config set --config local_2 platform.dapi.deprecated.enabled true
yarn dashmate restart --config local_2 --verbose
yarn dashmate config set --config local_2 platform.dapi.deprecated.enabled false
yarn dashmate restart --config local_2 --verbose

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [ ] I have made corresponding changes to the documentation if needed

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Node startup now automatically removes inactive DAPI stack components based on configured deprecation settings and platform requirements, optimizing resource allocation and cluster management
  * Docker container management capabilities have been significantly enhanced with expanded removal operations, now supporting selective volume deletion, forced container termination, and flexible configuration options for infrastructure optimization

<!-- end of auto-generated comment: release notes by coderabbit.ai -->