### PR TITLE
refactor: make wasm-sdk contract version test config dynamic

### DIFF
--- a/packages/wasm-sdk/tests/unit/data-contract.spec.mjs
+++ b/packages/wasm-sdk/tests/unit/data-contract.spec.mjs
@@ -18,6 +18,17 @@ const CONTRACT_FORMAT_VERSIONS = {
   V1: { introduced: 9, fixture: contractFixtureV1 },
 };
 
+// Validate configuration
+if (PLATFORM_VERSIONS.MIN >= PLATFORM_VERSIONS.MAX) {
+  throw new Error(`Invalid PLATFORM_VERSIONS: MIN (${PLATFORM_VERSIONS.MIN}) must be less than MAX (${PLATFORM_VERSIONS.MAX})`);
+}
+
+Object.entries(CONTRACT_FORMAT_VERSIONS).forEach(([key, config]) => {
+  if (config.introduced < PLATFORM_VERSIONS.MIN || config.introduced > PLATFORM_VERSIONS.MAX) {
+    throw new Error(`Invalid ${key}.introduced (${config.introduced}): must be between ${PLATFORM_VERSIONS.MIN} and ${PLATFORM_VERSIONS.MAX}`);
+  }
+});
+
 // Auto-generate compatibility data for all formats
 const FORMATS = Object.entries(CONTRACT_FORMAT_VERSIONS).reduce((acc, [formatKey, config]) => {
   const compatibleVersions = Array.from(
@@ -25,12 +36,10 @@ const FORMATS = Object.entries(CONTRACT_FORMAT_VERSIONS).reduce((acc, [formatKey
     (_, i) => i + config.introduced
   );
 
-  const allVersions = Array.from(
-    { length: PLATFORM_VERSIONS.MAX - PLATFORM_VERSIONS.MIN + 1 },
+  const incompatibleVersions = Array.from(
+    { length: Math.max(0, config.introduced - PLATFORM_VERSIONS.MIN) },
     (_, i) => i + PLATFORM_VERSIONS.MIN
   );
-
-  const incompatibleVersions = allVersions.filter(v => v < config.introduced);
 
   acc[formatKey] = {
     ...config,

--- a/packages/wasm-sdk/tests/unit/data-contract.spec.mjs
+++ b/packages/wasm-sdk/tests/unit/data-contract.spec.mjs
@@ -310,23 +310,6 @@ describe('DataContract', () => {
           }).to.throw(/unknown version/);
         });
       });
-
-      it('should handle version boundary correctly at V9 transition', () => {
-        // V0 contract should work in V9 (backward compatibility)
-        const contract = sdk.DataContract.fromJSON(contractFixtureV0, 9);
-        expect(contract.id()).to.equal(contractFixtureV0.id);
-        contract.free();
-
-        // V1 contract should work in V9 (first supported version)
-        const contractV1 = sdk.DataContract.fromJSON(contractFixtureV1, 9);
-        expect(contractV1.id()).to.equal(contractFixtureV1.id);
-        contractV1.free();
-
-        // V1 contract should fail in V8 (last unsupported version)
-        expect(() => {
-          sdk.DataContract.fromJSON(contractFixtureV1, 8);
-        }).to.throw(/dpp unknown version/);
-      });
     });
   });
 });

--- a/packages/wasm-sdk/tests/unit/data-contract.spec.mjs
+++ b/packages/wasm-sdk/tests/unit/data-contract.spec.mjs
@@ -33,12 +33,12 @@ Object.entries(CONTRACT_FORMAT_VERSIONS).forEach(([key, config]) => {
 const FORMATS = Object.entries(CONTRACT_FORMAT_VERSIONS).reduce((acc, [formatKey, config]) => {
   const compatibleVersions = Array.from(
     { length: PLATFORM_VERSIONS.MAX - config.introduced + 1 },
-    (_, i) => i + config.introduced
+    (_, i) => i + config.introduced,
   );
 
   const incompatibleVersions = Array.from(
     { length: Math.max(0, config.introduced - PLATFORM_VERSIONS.MIN) },
-    (_, i) => i + PLATFORM_VERSIONS.MIN
+    (_, i) => i + PLATFORM_VERSIONS.MIN,
   );
 
   acc[formatKey] = {
@@ -290,7 +290,7 @@ describe('DataContract', () => {
           formatData.fixture,
           formatKey,
           formatData.compatibleVersions,
-          formatData.incompatibleVersions
+          formatData.incompatibleVersions,
         );
       });
     });

--- a/packages/wasm-sdk/tests/unit/data-contract.spec.mjs
+++ b/packages/wasm-sdk/tests/unit/data-contract.spec.mjs
@@ -42,13 +42,6 @@ const FORMATS = Object.entries(CONTRACT_FORMAT_VERSIONS).reduce((acc, [formatKey
   return acc;
 }, {});
 
-// Backward compatibility: Keep existing constant names as aliases
-const PLATFORM_VERSION_CONTRACT_V0 = FORMATS.V0.platformVersion;
-const PLATFORM_VERSION_CONTRACT_V1 = FORMATS.V1.platformVersion;
-const V0_COMPATIBLE_VERSIONS = FORMATS.V0.compatibleVersions;
-const V1_COMPATIBLE_VERSIONS = FORMATS.V1.compatibleVersions;
-const V0_ONLY_VERSIONS = FORMATS.V0.incompatibleVersions;
-
 const LATEST_KNOWN_VERSION = PLATFORM_VERSIONS.MAX;
 
 // Helper function for testing contract compatibility across versions
@@ -87,7 +80,7 @@ describe('DataContract', () => {
 
   describe('Contract Creation', () => {
     it('should create a V0 contract from JSON and expose all properties', async () => {
-      const contract = sdk.DataContract.fromJSON(contractFixtureV0, PLATFORM_VERSION_CONTRACT_V0);
+      const contract = sdk.DataContract.fromJSON(contractFixtureV0, FORMATS.V0.platformVersion);
 
       expect(contract).to.be.ok();
       expect(contract.id()).to.equal(contractFixtureV0.id);
@@ -113,7 +106,7 @@ describe('DataContract', () => {
 
     // TODO: enable test once an SDK fix to support this is merged
     it.skip('should create a V1 contract from JSON and expose all properties including tokens and groups', async () => {
-      const contract = sdk.DataContract.fromJSON(contractFixtureV1, PLATFORM_VERSION_CONTRACT_V1);
+      const contract = sdk.DataContract.fromJSON(contractFixtureV1, FORMATS.V1.platformVersion);
 
       expect(contract).to.be.ok();
       expect(contract.id()).to.equal(contractFixtureV1.id);
@@ -144,7 +137,7 @@ describe('DataContract', () => {
 
     it('should create a contract with only document schemas (no tokens)', () => {
       // V0 fixture already has only documents, no tokens - verify it works
-      const contract = sdk.DataContract.fromJSON(contractFixtureV0, PLATFORM_VERSION_CONTRACT_V0);
+      const contract = sdk.DataContract.fromJSON(contractFixtureV0, FORMATS.V0.platformVersion);
       const roundTripped = contract.toJSON();
 
       expect(roundTripped.documentSchemas.card).to.exist();
@@ -162,7 +155,7 @@ describe('DataContract', () => {
 
       const contract = sdk.DataContract.fromJSON(
         contractWithOnlyTokens,
-        PLATFORM_VERSION_CONTRACT_V1,
+        FORMATS.V1.platformVersion,
       );
       const roundTripped = contract.toJSON();
 
@@ -175,7 +168,7 @@ describe('DataContract', () => {
   describe('Version Compatibility', () => {
     it('should fail to create a V1 contract with V0 platform version', async () => {
       expect(() => {
-        sdk.DataContract.fromJSON(contractFixtureV1, PLATFORM_VERSION_CONTRACT_V0);
+        sdk.DataContract.fromJSON(contractFixtureV1, FORMATS.V0.platformVersion);
       }).to.throw(/dpp unknown version.*known versions.*\[0\].*received.*1/);
     });
   });
@@ -183,15 +176,15 @@ describe('DataContract', () => {
   describe('Validation', () => {
     it('should handle invalid JSON input gracefully', () => {
       expect(() => {
-        sdk.DataContract.fromJSON(null, PLATFORM_VERSION_CONTRACT_V0);
+        sdk.DataContract.fromJSON(null, FORMATS.V0.platformVersion);
       }).to.throw();
 
       expect(() => {
-        sdk.DataContract.fromJSON({}, PLATFORM_VERSION_CONTRACT_V0);
+        sdk.DataContract.fromJSON({}, FORMATS.V0.platformVersion);
       }).to.throw();
 
       expect(() => {
-        sdk.DataContract.fromJSON({ id: 'invalid' }, PLATFORM_VERSION_CONTRACT_V0);
+        sdk.DataContract.fromJSON({ id: 'invalid' }, FORMATS.V0.platformVersion);
       }).to.throw();
     });
 
@@ -201,7 +194,7 @@ describe('DataContract', () => {
         sdk.DataContract.fromJSON({
           ...contractFixtureV0,
           id: 'invalid-not-base58!',
-        }, PLATFORM_VERSION_CONTRACT_V0);
+        }, FORMATS.V0.platformVersion);
       }).to.throw();
 
       // Test negative version number
@@ -209,7 +202,7 @@ describe('DataContract', () => {
         sdk.DataContract.fromJSON({
           ...contractFixtureV0,
           version: -1,
-        }, PLATFORM_VERSION_CONTRACT_V0);
+        }, FORMATS.V0.platformVersion);
       }).to.throw();
 
       // Test invalid ownerId
@@ -217,7 +210,7 @@ describe('DataContract', () => {
         sdk.DataContract.fromJSON({
           ...contractFixtureV0,
           ownerId: 'not-a-valid-id',
-        }, PLATFORM_VERSION_CONTRACT_V0);
+        }, FORMATS.V0.platformVersion);
       }).to.throw();
     });
 
@@ -232,18 +225,18 @@ describe('DataContract', () => {
       };
 
       expect(() => {
-        sdk.DataContract.fromJSON(contractWithEmptySchemas, PLATFORM_VERSION_CONTRACT_V0);
+        sdk.DataContract.fromJSON(contractWithEmptySchemas, FORMATS.V0.platformVersion);
       }).to.throw(/must have at least one document type or token defined/);
     });
   });
 
   describe('Data Preservation', () => {
     it('should preserve all data through JSON round-trip for V0 contract', async () => {
-      const contract = sdk.DataContract.fromJSON(contractFixtureV0, PLATFORM_VERSION_CONTRACT_V0);
+      const contract = sdk.DataContract.fromJSON(contractFixtureV0, FORMATS.V0.platformVersion);
       const roundTripped = contract.toJSON();
 
       // Create a new contract from the round-tripped JSON
-      const contract2 = sdk.DataContract.fromJSON(roundTripped, PLATFORM_VERSION_CONTRACT_V0);
+      const contract2 = sdk.DataContract.fromJSON(roundTripped, FORMATS.V0.platformVersion);
       const roundTripped2 = contract2.toJSON();
 
       expect(roundTripped2).to.deep.equal(roundTripped);
@@ -253,11 +246,11 @@ describe('DataContract', () => {
     });
 
     it('should preserve all data through JSON round-trip for V1 contract', async () => {
-      const contract = sdk.DataContract.fromJSON(contractFixtureV1, PLATFORM_VERSION_CONTRACT_V1);
+      const contract = sdk.DataContract.fromJSON(contractFixtureV1, FORMATS.V1.platformVersion);
       const roundTripped = contract.toJSON();
 
       // Create a new contract from the round-tripped JSON
-      const contract2 = sdk.DataContract.fromJSON(roundTripped, PLATFORM_VERSION_CONTRACT_V1);
+      const contract2 = sdk.DataContract.fromJSON(roundTripped, FORMATS.V1.platformVersion);
       const roundTripped2 = contract2.toJSON();
 
       expect(roundTripped2).to.deep.equal(roundTripped);
@@ -269,8 +262,8 @@ describe('DataContract', () => {
 
   describe('Memory Management', () => {
     it('should handle memory management properly with multiple contracts', async () => {
-      const contract1 = sdk.DataContract.fromJSON(contractFixtureV0, PLATFORM_VERSION_CONTRACT_V0);
-      const contract2 = sdk.DataContract.fromJSON(contractFixtureV1, PLATFORM_VERSION_CONTRACT_V1);
+      const contract1 = sdk.DataContract.fromJSON(contractFixtureV0, FORMATS.V0.platformVersion);
+      const contract2 = sdk.DataContract.fromJSON(contractFixtureV1, FORMATS.V1.platformVersion);
 
       expect(contract1.id()).to.equal(contractFixtureV0.id);
       expect(contract2.id()).to.equal(contractFixtureV1.id);


### PR DESCRIPTION
## Issue being fixed or feature implemented

The WASM SDK data contract test suite used hard-coded version arrays that required manual updates across multiple locations when adding new contract format versions or platform versions. This made the codebase harder to maintain and error-prone.

Fixes #2803 [comment](https://github.com/dashpay/platform/pull/2803/files#r2461350795).

## What was done?

Refactored the data contract test configuration to be fully data-driven and self-expanding:
- Introduced `CONTRACT_FORMAT_VERSIONS` config object mapping format versions to their introduction platform version and fixtures
- Created `FORMATS` object that auto-generates compatibility arrays, incompatibility arrays, and platform version constants for all defined formats
- Updated test suite to dynamically iterate over all contract formats instead of hard-coded test blocks
- Removed redundant backward compatibility constants in favor of direct `FORMATS` references

Adding a new contract format (e.g., V2) now requires:
1. Updating `PLATFORM_VERSIONS.MAX` to the new version
2. Adding `V2: { introduced: X, fixture: contractFixtureV2 }` to `CONTRACT_FORMAT_VERSIONS`
3. Importing a V2 contract fixture

All compatibility arrays, test suites, and constants are automatically generated.

## How Has This Been Tested?

- Ran existing WASM SDK test suite: all 84 tests passing
- Verified V0 and V1 contract compatibility tests work correctly across all platform versions
- Confirmed dynamic test iteration generates proper test suites for both formats
- Validated that generated arrays match previous hard-coded values

## Breaking Changes

None. This is a pure refactoring with no API or behavior changes.

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [ ] I have made corresponding changes to the documentation if needed

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Replaced hard-coded version constants with dynamic configuration so tests derive per-format compatibility automatically.
  * Introduced an auto-generated compatibility matrix and per-format platform version values used across tests.
  * Test suite now iterates all defined contract formats, using a shared test helper and a generalized "latest known" version, covering creation, validation, round-trip, and memory checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->