### PR TITLE
build: use workspace version in Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,4 +44,5 @@ members = [
 
 [workspace.package]
 
+version = "2.1.2"
 rust-version = "1.89"

--- a/packages/check-features/Cargo.toml
+++ b/packages/check-features/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "check-features"
-version = "2.1.2"
+version.workspace = true
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/packages/dapi-grpc/Cargo.toml
+++ b/packages/dapi-grpc/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "dapi-grpc"
 description = "GRPC client for Dash Platform"
-version = "2.1.2"
+version.workspace = true
 authors = [
   "Samuel Westrich <sam@dash.org>",
   "Igor Markin <igor.markin@dash.org>",

--- a/packages/dash-platform-balance-checker/Cargo.toml
+++ b/packages/dash-platform-balance-checker/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dash-platform-balance-checker"
-version = "2.1.2"
+version.workspace = true
 edition = "2021"
 
 [[bin]]

--- a/packages/dashpay-contract/Cargo.toml
+++ b/packages/dashpay-contract/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "dashpay-contract"
 description = "DashPay data contract schema and tools"
-version = "2.1.2"
+version.workspace = true
 edition = "2021"
 rust-version.workspace = true
 license = "MIT"

--- a/packages/data-contracts/Cargo.toml
+++ b/packages/data-contracts/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "data-contracts"
 description = "Dash Platform system data contracts"
-version = "2.1.2"
+version.workspace = true
 edition = "2021"
 rust-version.workspace = true
 license = "MIT"

--- a/packages/dpns-contract/Cargo.toml
+++ b/packages/dpns-contract/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "dpns-contract"
 description = "DPNS data contract schema and tools"
-version = "2.1.2"
+version.workspace = true
 edition = "2021"
 rust-version.workspace = true
 license = "MIT"

--- a/packages/feature-flags-contract/Cargo.toml
+++ b/packages/feature-flags-contract/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "feature-flags-contract"
 description = "Feature flags data contract schema and tools"
-version = "2.1.2"
+version.workspace = true
 edition = "2021"
 rust-version.workspace = true
 license = "MIT"

--- a/packages/keyword-search-contract/Cargo.toml
+++ b/packages/keyword-search-contract/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "keyword-search-contract"
 description = "Search data contract schema and tools. Keyword Search contract is used to find other contracts and tokens"
-version = "2.1.2"
+version.workspace = true
 edition = "2021"
 rust-version.workspace = true
 license = "MIT"

--- a/packages/masternode-reward-shares-contract/Cargo.toml
+++ b/packages/masternode-reward-shares-contract/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "masternode-reward-shares-contract"
 description = "Masternode reward shares data contract schema and tools"
-version = "2.1.2"
+version.workspace = true
 edition = "2021"
 rust-version.workspace = true
 license = "MIT"

--- a/packages/rs-context-provider/Cargo.toml
+++ b/packages/rs-context-provider/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dash-context-provider"
-version = "2.1.2"
+version.workspace = true
 edition = "2021"
 authors = ["sam@dash.org"]
 license = "MIT"

--- a/packages/rs-dapi-client/Cargo.toml
+++ b/packages/rs-dapi-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rs-dapi-client"
-version = "2.1.2"
+version.workspace = true
 edition = "2021"
 
 [features]

--- a/packages/rs-dapi-grpc-macros/Cargo.toml
+++ b/packages/rs-dapi-grpc-macros/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "dapi-grpc-macros"
-version = "2.1.2"
+version.workspace = true
 edition = "2021"
 description = "Macros used by dapi-grpc. Internal use only."
 

--- a/packages/rs-dapi/Cargo.toml
+++ b/packages/rs-dapi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rs-dapi"
-version = "2.1.2"
+version.workspace = true
 edition = "2024"
 
 [[bin]]

--- a/packages/rs-dash-event-bus/Cargo.toml
+++ b/packages/rs-dash-event-bus/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rs-dash-event-bus"
-version = "2.1.2"
+version.workspace = true
 edition = "2024"
 license = "MIT"
 description = "Shared event bus and Platform events multiplexer for Dash Platform (rs-dapi, rs-drive-abci, rs-sdk)"

--- a/packages/rs-dpp/Cargo.toml
+++ b/packages/rs-dpp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dpp"
-version = "2.1.2"
+version.workspace = true
 edition = "2021"
 rust-version.workspace = true
 authors = [

--- a/packages/rs-drive-abci/Cargo.toml
+++ b/packages/rs-drive-abci/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "drive-abci"
-version = "2.1.2"
+version.workspace = true
 authors = [
   "Samuel Westrich <sam@dash.org>",
   "Ivan Shumkov <ivan@shumkov.ru>",

--- a/packages/rs-drive-proof-verifier/Cargo.toml
+++ b/packages/rs-drive-proof-verifier/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "drive-proof-verifier"
-version = "2.1.2"
+version.workspace = true
 edition = "2021"
 rust-version.workspace = true
 

--- a/packages/rs-drive/Cargo.toml
+++ b/packages/rs-drive/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "drive"
 description = "Dash drive built on top of GroveDB"
-version = "2.1.2"
+version.workspace = true
 authors = [
   "Samuel Westrich <sam@dash.org>",
   "Ivan Shumkov <ivan@shumkov.ru>",

--- a/packages/rs-json-schema-compatibility-validator/Cargo.toml
+++ b/packages/rs-json-schema-compatibility-validator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "json-schema-compatibility-validator"
-version = "2.1.2"
+version.workspace = true
 edition = "2021"
 rust-version.workspace = true
 authors = ["Ivan Shumkov <ivan@shumkov.ru>"]

--- a/packages/rs-platform-serialization-derive/Cargo.toml
+++ b/packages/rs-platform-serialization-derive/Cargo.toml
@@ -2,7 +2,7 @@
 name = "platform-serialization-derive"
 authors = ["Samuel Westrich <sam@dash.org>"]
 description = "Bincode serialization and deserialization derivations"
-version = "2.1.2"
+version.workspace = true
 edition = "2021"
 rust-version.workspace = true
 license = "MIT"

--- a/packages/rs-platform-serialization/Cargo.toml
+++ b/packages/rs-platform-serialization/Cargo.toml
@@ -2,7 +2,7 @@
 name = "platform-serialization"
 authors = ["Samuel Westrich <sam@dash.org>"]
 description = "Bincode based serialization and deserialization"
-version = "2.1.2"
+version.workspace = true
 edition = "2021"
 rust-version.workspace = true
 license = "MIT"

--- a/packages/rs-platform-value-convertible/Cargo.toml
+++ b/packages/rs-platform-value-convertible/Cargo.toml
@@ -2,7 +2,7 @@
 name = "platform-value-convertible"
 authors = ["Samuel Westrich <sam@dash.org>"]
 description = "Convertion to and from platform values"
-version = "2.1.2"
+version.workspace = true
 edition = "2021"
 rust-version.workspace = true
 license = "MIT"

--- a/packages/rs-platform-value/Cargo.toml
+++ b/packages/rs-platform-value/Cargo.toml
@@ -2,7 +2,7 @@
 name = "platform-value"
 authors = ["Samuel Westrich <sam@dash.org>"]
 description = "A simple value module"
-version = "2.1.2"
+version.workspace = true
 edition = "2021"
 rust-version.workspace = true
 license = "MIT"

--- a/packages/rs-platform-version/Cargo.toml
+++ b/packages/rs-platform-version/Cargo.toml
@@ -2,7 +2,7 @@
 name = "platform-version"
 authors = ["Samuel Westrich <sam@dash.org>"]
 description = "Versioning library for Platform"
-version = "2.1.2"
+version.workspace = true
 edition = "2021"
 rust-version.workspace = true
 license = "MIT"

--- a/packages/rs-platform-versioning/Cargo.toml
+++ b/packages/rs-platform-versioning/Cargo.toml
@@ -2,7 +2,7 @@
 name = "platform-versioning"
 authors = ["Samuel Westrich <sam@dash.org>"]
 description = "Version derivation"
-version = "2.1.2"
+version.workspace = true
 edition = "2021"
 rust-version.workspace = true
 license = "MIT"

--- a/packages/rs-platform-wallet/Cargo.toml
+++ b/packages/rs-platform-wallet/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "platform-wallet"
-version = "2.1.2"
+version.workspace = true
 edition = "2021"
 authors = ["Dash Core Team"]
 license = "MIT"

--- a/packages/rs-sdk-ffi/Cargo.toml
+++ b/packages/rs-sdk-ffi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rs-sdk-ffi"
-version = "2.1.2"
+version.workspace = true
 authors = ["Dash Core Group <dev@dash.org>"]
 edition = "2021"
 license = "MIT"

--- a/packages/rs-sdk-trusted-context-provider/Cargo.toml
+++ b/packages/rs-sdk-trusted-context-provider/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rs-sdk-trusted-context-provider"
-version = "2.1.2"
+version.workspace = true
 edition = "2021"
 authors = ["sam@dash.org"]
 license = "MIT"

--- a/packages/rs-sdk/Cargo.toml
+++ b/packages/rs-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dash-sdk"
-version = "2.1.2"
+version.workspace = true
 edition = "2021"
 
 [dependencies]

--- a/packages/simple-signer/Cargo.toml
+++ b/packages/simple-signer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "simple-signer"
-version = "2.1.2"
+version.workspace = true
 edition = "2021"
 rust-version.workspace = true
 

--- a/packages/strategy-tests/Cargo.toml
+++ b/packages/strategy-tests/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "strategy-tests"
-version = "2.1.2"
+version.workspace = true
 authors = [
   "Samuel Westrich <sam@dash.org>",
   "Ivan Shumkov <ivan@shumkov.ru>",

--- a/packages/token-history-contract/Cargo.toml
+++ b/packages/token-history-contract/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "token-history-contract"
 description = "Token history data contract schema and tools"
-version = "2.1.2"
+version.workspace = true
 edition = "2021"
 rust-version.workspace = true
 license = "MIT"

--- a/packages/wallet-utils-contract/Cargo.toml
+++ b/packages/wallet-utils-contract/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "wallet-utils-contract"
 description = "Wallet data contract schema and tools"
-version = "2.1.2"
+version.workspace = true
 edition = "2021"
 rust-version.workspace = true
 license = "MIT"

--- a/packages/wasm-dpp/Cargo.toml
+++ b/packages/wasm-dpp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasm-dpp"
-version = "2.1.2"
+version.workspace = true
 edition = "2021"
 rust-version.workspace = true
 authors = ["Anton Suprunchuk <anton.suprunchuk@gmail.com>"]

--- a/packages/wasm-drive-verify/Cargo.toml
+++ b/packages/wasm-drive-verify/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasm-drive-verify"
-version = "2.1.2"
+version.workspace = true
 authors = ["Dash Core Group <dev@dash.org>"]
 edition = "2021"
 rust-version = "1.89"

--- a/packages/wasm-sdk/Cargo.toml
+++ b/packages/wasm-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasm-sdk"
-version = "2.1.2"
+version.workspace = true
 edition = "2021"
 publish = false
 rust-version.workspace = true

--- a/packages/withdrawals-contract/Cargo.toml
+++ b/packages/withdrawals-contract/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "withdrawals-contract"
 description = "Witdrawals data contract schema and tools"
-version = "2.1.2"
+version.workspace = true
 edition = "2021"
 rust-version.workspace = true
 license = "MIT"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented

A bit messy versioning - we repeat the same version in all Rust crates.


## What was done?

Define version in workspace Cargo.toml only, others refer to it.

Updated `bump_version.js`


## How Has This Been Tested?

GHA.

``` yarn node scripts/release/bump_version.js dv```


## Breaking Changes

None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [ ] I have made corresponding changes to the documentation if needed

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone
