### PR TITLE
fix(dapi): broadcast errors displayed as consensus error

### DIFF
--- a/packages/platform-test-suite/test/functional/platform/DataContract.spec.js
+++ b/packages/platform-test-suite/test/functional/platform/DataContract.spec.js
@@ -59,6 +59,31 @@ describe('Platform', () => {
       expect(broadcastError.getCause()).to.be.an.instanceOf(IdentityNotFoundError);
     });
 
+    it('should expose validation error when document property positions are not contiguous', async () => {
+      // Additional wait time to mitigate testnet latency
+      await waitForSTPropagated();
+
+      const identityNonce = await client.platform.nonceManager
+        .bumpIdentityNonce(identity.getId());
+      const invalidDataContract = await getDataContractFixture(identityNonce, identity.getId());
+
+      const documentSchema = invalidDataContract.getDocumentSchema('niceDocument');
+      documentSchema.properties.name.position = 5;
+      invalidDataContract.setDocumentSchema('niceDocument', documentSchema);
+
+      let broadcastError;
+
+      try {
+        await client.platform.contracts.publish(invalidDataContract, identity);
+      } catch (e) {
+        broadcastError = e;
+      }
+
+      expect(broadcastError).to.be.an.instanceOf(StateTransitionBroadcastError);
+      expect(broadcastError.getCode()).to.equal(10411);
+      expect(broadcastError.getMessage()).to.equal('position field is not present for document type "niceDocument"');
+    });
+
     it('should create new data contract with previously created identity as an owner', async () => {
       // Additional wait time to mitigate testnet latency
       await waitForSTPropagated();

--- a/packages/platform-test-suite/test/functional/platform/DataContract.spec.js
+++ b/packages/platform-test-suite/test/functional/platform/DataContract.spec.js
@@ -69,7 +69,7 @@ describe('Platform', () => {
 
       const documentSchema = invalidDataContract.getDocumentSchema('niceDocument');
       documentSchema.properties.name.position = 5;
-      invalidDataContract.setDocumentSchema('niceDocument', documentSchema);
+      invalidDataContract.setDocumentSchema('niceDocument', documentSchema, { skipValidation: true });
 
       let broadcastError;
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented

rs-dapi returns `Unknown error` when state transition fails

## What was done?

Extract error message from consensus error received from Tenderdash.

## How Has This Been Tested?

local devnet

## Breaking Changes

None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [ ] I have made corresponding changes to the documentation if needed

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error messages for state transition broadcast failures to provide more descriptive error details when consensus errors are available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->