### PR TITLE
fix(sdk): reset SDK nonce caches after failed transitions

### DIFF
--- a/packages/rs-dapi-client/src/mock.rs
+++ b/packages/rs-dapi-client/src/mock.rs
@@ -61,6 +61,28 @@ impl MockDapiClient {
         Ok(self)
     }
 
+    /// Remove an existing expectation for a request.
+    ///
+    /// Returns `true` if the expectation was present.
+    pub fn remove<R>(&mut self, request: &R) -> bool
+    where
+        R: TransportRequest + Mockable,
+        R::Response: Mockable,
+    {
+        let key = Key::new(request);
+        let removed = self.expectations.remove(&key);
+
+        if removed {
+            tracing::trace!(
+                %key,
+                request_type = std::any::type_name::<R>(),
+                "mock removed expectation"
+            );
+        }
+
+        removed
+    }
+
     /// Load expectation from file.
     ///
     /// The file must contain JSON structure.
@@ -252,6 +274,11 @@ impl Expectations {
         let response = self.expectations.get(&key).and_then(|v| v.deserialize());
 
         (key, response)
+    }
+
+    /// Remove expectation associated with the given key.
+    pub fn remove(&mut self, key: &Key) -> bool {
+        self.expectations.remove(key).is_some()
     }
 }
 

--- a/packages/rs-sdk/src/mock/sdk.rs
+++ b/packages/rs-sdk/src/mock/sdk.rs
@@ -315,6 +315,19 @@ impl MockDashPlatformSdk {
         Ok(self)
     }
 
+    /// Remove previously defined expectation for a [Fetch] request.
+    ///
+    /// Returns `true` if any expectation was removed.
+    pub async fn remove_fetch_expectation<O, Q>(&mut self, query: Q) -> bool
+    where
+        O: Fetch,
+        Q: Query<<O as Fetch>::Request>,
+        <O as Fetch>::Request: TransportRequest,
+    {
+        let grpc_request = query.query(self.prove()).expect("query must be correct");
+        self.remove(grpc_request).await
+    }
+
     /// Expect a [FetchMany] request and return provided object.
     ///
     /// This method is used to define mock expectations for [FetchMany] requests.
@@ -411,6 +424,17 @@ impl MockDashPlatformSdk {
         )?;
 
         Ok(())
+    }
+
+    /// Remove expectations for a request.
+    async fn remove<I: TransportRequest>(&mut self, grpc_request: I) -> bool {
+        let key = Key::new(&grpc_request);
+        let removed_from_proof = self.from_proof_expectations.remove(&key).is_some();
+
+        let mut dapi_guard = self.dapi.lock().await;
+        let removed_from_dapi = dapi_guard.remove(&grpc_request);
+
+        removed_from_proof || removed_from_dapi
     }
 
     /// Wrapper around [FromProof] that uses mock expectations instead of executing [FromProof] trait.

--- a/packages/rs-sdk/src/platform/transition/broadcast.rs
+++ b/packages/rs-sdk/src/platform/transition/broadcast.rs
@@ -82,7 +82,10 @@ impl BroadcastStateTransition for StateTransition {
 
         match &result {
             Ok(_) => trace!("broadcast: completed successfully"),
-            Err(e) => warn!(error = ?e, "broadcast: failed after retries"),
+            Err(e) => {
+                warn!(error = ?e, "broadcast: failed after retries");
+                sdk.refresh_identity_nonce(&self.owner_id()).await;
+            }
         }
         result
     }

--- a/packages/rs-sdk/src/platform/transition/broadcast.rs
+++ b/packages/rs-sdk/src/platform/transition/broadcast.rs
@@ -135,7 +135,7 @@ impl BroadcastStateTransition for StateTransition {
             };
 
             if let Some(e) = state_transition_broadcast_error {
-                warn!("wait: state transition broadcast error detected");
+                warn!(error=?e, "wait: state transition broadcast error detected");
                 let state_transition_broadcast_error: StateTransitionBroadcastError =
                     StateTransitionBroadcastError::try_from(e.clone())
                         .wrap_to_execution_result(&response)?

--- a/packages/rs-sdk/src/sdk.rs
+++ b/packages/rs-sdk/src/sdk.rs
@@ -399,7 +399,7 @@ impl Sdk {
             }
         };
 
-        if should_query_platform {
+        let nonce = if should_query_platform {
             let platform_nonce = IdentityNonceFetcher::fetch_with_settings(
                 self,
                 identity_id,
@@ -451,7 +451,16 @@ impl Sdk {
                     }
                 }
             }
-        }
+        };
+
+        tracing::trace!(
+            identity_id = %identity_id,
+            bump_first,
+            nonce = ?nonce,
+            "Fetched identity nonce"
+        );
+
+        nonce
     }
 
     // TODO: Move to a separate struct

--- a/packages/rs-sdk/src/sdk.rs
+++ b/packages/rs-sdk/src/sdk.rs
@@ -553,6 +553,24 @@ impl Sdk {
         }
     }
 
+    /// Forces reload of the identity nonce from Platform on the next call to `get_identity_nonce`.
+    pub async fn refresh_identity_nonce(&self, identity_id: &Identifier) {
+        {
+            let mut identity_nonce_counter =
+                self.internal_cache.identity_nonce_counter.lock().await;
+            identity_nonce_counter.remove(identity_id);
+        }
+        {
+            let mut identity_contract_nonce_counter = self
+                .internal_cache
+                .identity_contract_nonce_counter
+                .lock()
+                .await;
+            identity_contract_nonce_counter
+                .retain(|(cached_identity_id, _), _| cached_identity_id != identity_id);
+        }
+    }
+
     /// Return [Dash Platform version](PlatformVersion) information used by this SDK.
     ///
     ///


### PR DESCRIPTION
## Issue being fixed or feature implemented

Fixes #2737 

## What was done?

If an error is received from state transition, we remove cached identity nonce to force refreshing it.


## How Has This Been Tested?

Added some more logging and used dash-evo-tool to send invalid transactions.

* error happens => nonce still at 1
* no error => nonce increased to 2

## Breaking Changes

None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [ ] I have made corresponding changes to the documentation if needed

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added method to manually refresh identity nonce from Platform.
  * Added capability to remove mock expectations in test utilities.

* **Improvements**
  * Automatic identity nonce refresh triggered on failed state transition broadcasts.
  * Enhanced structured logging for broadcast errors and nonce operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->