### PR TITLE
fix(sdk): fail on invalid proof

### DIFF
--- a/packages/rs-drive-proof-verifier/src/proof/token_info.rs
+++ b/packages/rs-drive-proof-verifier/src/proof/token_info.rs
@@ -56,8 +56,6 @@ impl FromProof<GetIdentityTokenInfosRequest> for IdentityTokenInfos {
 
         let proof = response.proof_owned().or(Err(Error::NoProofInResult))?;
 
-        println!("{:?}", hex::encode(&proof.grovedb_proof));
-
         let (root_hash, result) = Drive::verify_token_infos_for_identity_id(
             &proof.grovedb_proof,
             &token_ids,

--- a/packages/rs-sdk/src/error.rs
+++ b/packages/rs-sdk/src/error.rs
@@ -185,7 +185,10 @@ where
 
 impl CanRetry for Error {
     fn can_retry(&self) -> bool {
-        matches!(self, Error::StaleNode(..) | Error::TimeoutReached(_, _))
+        matches!(
+            self,
+            Error::StaleNode(..) | Error::TimeoutReached(_, _) | Error::Proof(_)
+        )
     }
 }
 

--- a/packages/rs-sdk/src/sdk.rs
+++ b/packages/rs-sdk/src/sdk.rs
@@ -334,7 +334,9 @@ impl Sdk {
             }
         }?;
 
+        // TODO: We should verify freshness (light check) before we validate proofs (heavy check)
         self.verify_response_metadata(&metadata)?;
+
         Ok((object, metadata, proof))
     }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
SDK fails without retries when it gets invalid proof from a malicious or outdated node

## What was done?
<!--- Describe your changes in detail -->
- Retry on proof error

Future improvement: validate response height and time (freshness) before we validate proofs (heavy check).

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
With existing tests.

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [x] I have made corresponding changes to the documentation if needed

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error resilience by enabling automatic retry for proof validation failures.

* **Chores**
  * Removed debug logging output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->