### PR TITLE
chore(dashmate): backport rs-dapi not stopped when dashmate reset --platform -f is called 

### DIFF
--- a/packages/dashmate/src/config/getConfigProfilesFactory.js
+++ b/packages/dashmate/src/config/getConfigProfilesFactory.js
@@ -16,7 +16,10 @@ export default function getConfigProfilesFactory() {
     if (config.get('platform.enable')) {
       profiles.push('platform');
 
-      const deprecatedEnabled = config.get('platform.dapi.deprecated.enabled');
+      // Config option 'platform.dapi.deprecated.enabled' was removed
+      const deprecatedEnabled = config.has('platform.dapi.deprecated.enabled')
+        ? config.get('platform.dapi.deprecated.enabled')
+        : false;
 
       if (includeAll) {
         profiles.push('platform-dapi-deprecated');

--- a/packages/dashmate/src/config/getConfigProfilesFactory.js
+++ b/packages/dashmate/src/config/getConfigProfilesFactory.js
@@ -8,13 +8,24 @@ export default function getConfigProfilesFactory() {
    * @param {{ includeAll?: boolean }} [options]
    * @returns {string[]}
    */
-  function getConfigProfiles(config) {
+  function getConfigProfiles(config, { includeAll = false } = {}) {
     const profiles = [];
 
     profiles.push('core');
 
     if (config.get('platform.enable')) {
       profiles.push('platform');
+
+      const deprecatedEnabled = config.get('platform.dapi.deprecated.enabled');
+
+      if (includeAll) {
+        profiles.push('platform-dapi-deprecated');
+        profiles.push('platform-dapi-rs');
+      } else if (deprecatedEnabled) {
+        profiles.push('platform-dapi-deprecated');
+      } else {
+        profiles.push('platform-dapi-rs');
+      }
     }
 
     return Array.from(new Set(profiles));


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented

Backport of #2824 from v2.1 to v2.2 which was incorrectly applied during merge


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced platform DAPI profile selection with configurable options to include all available profiles or select them conditionally based on version status.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->