### PR TITLE
fix(dpp): return UnsupportedFeatureError for legacy state transition structure validation

### DIFF
--- a/packages/rs-dpp/src/state_transition/mod.rs
+++ b/packages/rs-dpp/src/state_transition/mod.rs
@@ -44,6 +44,8 @@ mod traits;
 
 // pub mod state_transition_fee;
 
+#[cfg(feature = "state-transition-validation")]
+use crate::consensus::basic::UnsupportedFeatureError;
 #[cfg(feature = "state-transition-signing")]
 use crate::consensus::signature::InvalidSignaturePublicKeySecurityLevelError;
 #[cfg(feature = "state-transition-validation")]
@@ -1167,32 +1169,22 @@ impl StateTransitionStructureValidation for StateTransition {
         platform_version: &PlatformVersion,
     ) -> crate::validation::SimpleConsensusValidationResult {
         match self {
-            StateTransition::DataContractCreate(_) => {
-                crate::validation::SimpleConsensusValidationResult::default()
-            }
-            StateTransition::DataContractUpdate(_) => {
-                crate::validation::SimpleConsensusValidationResult::default()
-            }
-            StateTransition::Batch(_) => {
-                crate::validation::SimpleConsensusValidationResult::default()
-            }
-            StateTransition::IdentityCreate(_) => {
-                crate::validation::SimpleConsensusValidationResult::default()
-            }
-            StateTransition::IdentityTopUp(_) => {
-                crate::validation::SimpleConsensusValidationResult::default()
-            }
-            StateTransition::IdentityCreditWithdrawal(_) => {
-                crate::validation::SimpleConsensusValidationResult::default()
-            }
-            StateTransition::IdentityUpdate(_) => {
-                crate::validation::SimpleConsensusValidationResult::default()
-            }
-            StateTransition::IdentityCreditTransfer(_) => {
-                crate::validation::SimpleConsensusValidationResult::default()
-            }
-            StateTransition::MasternodeVote(_) => {
-                crate::validation::SimpleConsensusValidationResult::default()
+            StateTransition::DataContractCreate(_)
+            | StateTransition::DataContractUpdate(_)
+            | StateTransition::Batch(_)
+            | StateTransition::IdentityCreate(_)
+            | StateTransition::IdentityTopUp(_)
+            | StateTransition::IdentityCreditWithdrawal(_)
+            | StateTransition::IdentityUpdate(_)
+            | StateTransition::IdentityCreditTransfer(_)
+            | StateTransition::MasternodeVote(_) => {
+                crate::validation::SimpleConsensusValidationResult::new_with_error(
+                    UnsupportedFeatureError::new(
+                        "structure validation for identity-based state transitions".to_string(),
+                        platform_version.protocol_version,
+                    )
+                    .into(),
+                )
             }
             StateTransition::IdentityCreditTransferToAddresses(transition) => {
                 transition.validate_structure(platform_version)

--- a/packages/rs-sdk/src/platform/transition/validation.rs
+++ b/packages/rs-sdk/src/platform/transition/validation.rs
@@ -1,10 +1,24 @@
 use crate::Error;
 use dpp::{
+    consensus::{basic::BasicError, ConsensusError},
     state_transition::{StateTransition, StateTransitionStructureValidation},
     version::PlatformVersion,
 };
 
+/// Checks if an error is an UnsupportedFeatureError
+fn is_unsupported_feature_error(error: &ConsensusError) -> bool {
+    matches!(
+        error,
+        ConsensusError::BasicError(BasicError::UnsupportedFeatureError(_))
+    )
+}
+
 /// Ensures a state transition passes structure validation before broadcasting.
+///
+/// Note: UnsupportedFeatureError is allowed to pass through, as it indicates
+/// that structure validation is not implemented for that state transition type
+/// (e.g., identity-based state transitions). The platform will still perform
+/// validation during execution.
 pub(crate) fn ensure_valid_state_transition_structure(
     state_transition: &StateTransition,
     platform_version: &PlatformVersion,
@@ -13,6 +27,16 @@ pub(crate) fn ensure_valid_state_transition_structure(
     if validation_result.is_valid() {
         Ok(())
     } else {
-        Err(validation_result.into())
+        // Allow UnsupportedFeatureError to pass through - this means structure
+        // validation is not implemented for this state transition type
+        let all_unsupported_feature_errors = validation_result
+            .errors
+            .iter()
+            .all(is_unsupported_feature_error);
+        if all_unsupported_feature_errors {
+            Ok(())
+        } else {
+            Err(validation_result.into())
+        }
     }
 }


### PR DESCRIPTION
## Issue being fixed or feature implemented:

  Structure validation for legacy/identity-based state transitions was returning an empty success result, which obscured the fact that no actual validation was being performed. This made it unclear
  whether validation passed because the transition was valid or because validation wasn't implemented.

## What was done:

  1. rs-dpp/state_transition/mod.rs: Changed validate_structure for legacy state transitions (DataContractCreate, DataContractUpdate, Batch, IdentityCreate, IdentityTopUp, IdentityCreditWithdrawal,
  IdentityUpdate, IdentityCreditTransfer, MasternodeVote) to return UnsupportedFeatureError instead of an empty validation result. This explicitly signals that client-side structure validation is
  not implemented for these transition types.
  2. rs-sdk/transition/validation.rs: Updated ensure_valid_state_transition_structure to allow UnsupportedFeatureError to pass through without blocking broadcast. This allows legacy state
  transitions to still be broadcast while address-based transitions get proper structure validation with real error reporting.

  The platform still performs full validation during execution, so this change only affects client-side pre-broadcast checks.


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [ ] I have made corresponding changes to the documentation if needed

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone
