### PR TITLE
fix(drive-abci): test updates based on increase asset lock costs

### DIFF
--- a/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/address_funding_from_asset_lock/tests.rs
+++ b/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/address_funding_from_asset_lock/tests.rs
@@ -8330,7 +8330,7 @@ mod tests {
                     )
                     .unwrap(),
                 ),
-                Some(200000), // 200,000 duffs = minimum for identity create
+                Some(2560000), // 200,000 duffs = minimum for identity create
             );
 
             let identifier = asset_lock_proof

--- a/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/address_funding_from_asset_lock/tests.rs
+++ b/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/address_funding_from_asset_lock/tests.rs
@@ -8246,7 +8246,7 @@ mod tests {
             // be used for address funding with an output that fits within the remaining balance.
             //
             // Key calculations (CREDITS_PER_DUFF = 1000):
-            // - Asset lock: 200,000 duffs = 200,000,000 credits (minimum for identity create)
+            // - Asset lock: 256,000 duffs = 256,000,000 credits (minimum for identity create)
             // - Penalty for unique_key_already_present: 10,000,000 credits = 10,000 duffs
             // - Processing fees: ~1-2M credits = ~1-2K duffs per attempt
             // - After 1 failure: ~188,000 duffs remain
@@ -8330,7 +8330,7 @@ mod tests {
                     )
                     .unwrap(),
                 ),
-                Some(2560000), // 200,000 duffs = minimum for identity create
+                Some(256000), // 200,000 + 56,000 duffs = minimum for identity create
             );
 
             let identifier = asset_lock_proof

--- a/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/identity_create/mod.rs
+++ b/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/identity_create/mod.rs
@@ -215,6 +215,7 @@ mod tests {
     use rand::SeedableRng;
     use simple_signer::signer::SimpleSigner;
     use std::collections::BTreeMap;
+    use std::ops::Div;
 
     #[test]
     fn test_identity_create_validation_first_protocol_version() {
@@ -1198,10 +1199,15 @@ mod tests {
         let (_, pk) = ECDSA_SECP256K1
             .random_public_and_private_key_data(&mut rng, platform_version)
             .unwrap();
+        let min_fees = &platform_version.fee_version.state_transition_min_fees;
+        let base_cost = min_fees.identity_create_base_cost;
+        let keys_extra_cost = base_cost
+            .saturating_add(min_fees.identity_key_in_creation_cost.saturating_mul(2))
+            .div(1000);
 
         let asset_lock_proof = instant_asset_lock_proof_fixture(
             Some(PrivateKey::from_byte_array(&pk, Network::Testnet).unwrap()),
-            Some(220000),
+            Some(220000 + keys_extra_cost),
         );
 
         let identifier = asset_lock_proof


### PR DESCRIPTION
Fixed two small tests.
