### PR TITLE
ci: unstable swift and rocksdb build workflows

### DIFF
--- a/.github/actions/librocksdb/action.yaml
+++ b/.github/actions/librocksdb/action.yaml
@@ -27,6 +27,8 @@ runs:
     - if: ${{ steps.librocksdb-cache.outputs.cache-hit != 'true' || inputs.force == 'true' }}
       shell: bash
       name: Build librocksdb
+      env:
+          PORTABLE: 1
       run: |
         set -ex
         WORKDIR=/tmp/rocksdb-build

--- a/.github/workflows/swift-sdk-build.yml
+++ b/.github/workflows/swift-sdk-build.yml
@@ -124,6 +124,7 @@ jobs:
             git clone --filter=blob:none https://github.com/dashpay/rust-dashcore.git rust-dashcore
             cd rust-dashcore
           fi
+          git reset --hard # clean any local changes from previous runs, possibly with another branch
           git checkout "${{ steps.dashcore_rev.outputs.rev }}"
 
       - name: Determine rust-dashcore toolchain channel


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented

Some workflows fail due to:

* overly aggressive optimizations of rocksdb builds inside drive-abci tests; I think the library is cached and then restored in another run on old CPU 
* caching issue when checking out rust-dashcore inside the swift task.

## What was done?

Fixed both issues by:
* `git reset` of rust-dashcore dir before fetch
* setting PORTABLE=1 on rocksdb build

## How Has This Been Tested?

GHA green

## Breaking Changes
None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [ ] I have made corresponding changes to the documentation if needed

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone
