### PR TITLE
build: bump rust-dashcore to v0.41-dev  rev e7792c4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1239,31 +1239,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
-name = "crossterm"
-version = "0.27.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f476fe445d41c9e991fd07515a6f463074b782242ccf4a5b7b1d1012e70824df"
-dependencies = [
- "bitflags 2.9.4",
- "crossterm_winapi",
- "libc",
- "mio 0.8.11",
- "parking_lot",
- "signal-hook",
- "signal-hook-mio",
- "winapi",
-]
-
-[[package]]
-name = "crossterm_winapi"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
-dependencies = [
- "winapi",
-]
-
-[[package]]
 name = "crunchy"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1386,18 +1361,7 @@ dependencies = [
 [[package]]
 name = "dash-network"
 version = "0.40.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=8f97c4b7599849ba048cdd7ef98276966b71e1fd#8f97c4b7599849ba048cdd7ef98276966b71e1fd"
-dependencies = [
- "bincode 2.0.0-rc.3",
- "bincode_derive",
- "hex",
- "serde",
-]
-
-[[package]]
-name = "dash-network"
-version = "0.40.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=e44b1fb2086ad57c8884995f9f93f14de91bf964#e44b1fb2086ad57c8884995f9f93f14de91bf964"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=e7792c431c55c0d28efb0344b3a1948f576be5ce#e7792c431c55c0d28efb0344b3a1948f576be5ce"
 dependencies = [
  "bincode 2.0.0-rc.3",
  "bincode_derive",
@@ -1476,7 +1440,7 @@ dependencies = [
 [[package]]
 name = "dash-spv"
 version = "0.40.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=8f97c4b7599849ba048cdd7ef98276966b71e1fd#8f97c4b7599849ba048cdd7ef98276966b71e1fd"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=e7792c431c55c0d28efb0344b3a1948f576be5ce#e7792c431c55c0d28efb0344b3a1948f576be5ce"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1484,13 +1448,13 @@ dependencies = [
  "blsful",
  "chrono",
  "clap",
- "dashcore 0.40.0 (git+https://github.com/dashpay/rust-dashcore?rev=8f97c4b7599849ba048cdd7ef98276966b71e1fd)",
- "dashcore_hashes 0.40.0 (git+https://github.com/dashpay/rust-dashcore?rev=8f97c4b7599849ba048cdd7ef98276966b71e1fd)",
+ "dashcore",
+ "dashcore_hashes",
  "hex",
  "hickory-resolver",
  "indexmap 2.11.4",
- "key-wallet 0.40.0 (git+https://github.com/dashpay/rust-dashcore?rev=8f97c4b7599849ba048cdd7ef98276966b71e1fd)",
- "key-wallet-manager 0.40.0 (git+https://github.com/dashpay/rust-dashcore?rev=8f97c4b7599849ba048cdd7ef98276966b71e1fd)",
+ "key-wallet",
+ "key-wallet-manager",
  "log",
  "rand 0.8.5",
  "rayon",
@@ -1505,48 +1469,20 @@ dependencies = [
 ]
 
 [[package]]
-name = "dash-spv"
-version = "0.40.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=e44b1fb2086ad57c8884995f9f93f14de91bf964#e44b1fb2086ad57c8884995f9f93f14de91bf964"
-dependencies = [
- "anyhow",
- "async-trait",
- "bincode 1.3.3",
- "blsful",
- "clap",
- "crossterm",
- "dashcore 0.40.0 (git+https://github.com/dashpay/rust-dashcore?rev=e44b1fb2086ad57c8884995f9f93f14de91bf964)",
- "dashcore_hashes 0.40.0 (git+https://github.com/dashpay/rust-dashcore?rev=e44b1fb2086ad57c8884995f9f93f14de91bf964)",
- "hex",
- "hickory-resolver",
- "indexmap 2.11.4",
- "key-wallet 0.40.0 (git+https://github.com/dashpay/rust-dashcore?rev=e44b1fb2086ad57c8884995f9f93f14de91bf964)",
- "key-wallet-manager 0.40.0 (git+https://github.com/dashpay/rust-dashcore?rev=e44b1fb2086ad57c8884995f9f93f14de91bf964)",
- "log",
- "rand 0.8.5",
- "serde",
- "serde_json",
- "thiserror 1.0.69",
- "tokio",
- "tracing",
- "tracing-subscriber",
-]
-
-[[package]]
 name = "dash-spv-ffi"
 version = "0.40.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=8f97c4b7599849ba048cdd7ef98276966b71e1fd#8f97c4b7599849ba048cdd7ef98276966b71e1fd"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=e7792c431c55c0d28efb0344b3a1948f576be5ce#e7792c431c55c0d28efb0344b3a1948f576be5ce"
 dependencies = [
  "cbindgen 0.29.0",
  "clap",
- "dash-spv 0.40.0 (git+https://github.com/dashpay/rust-dashcore?rev=8f97c4b7599849ba048cdd7ef98276966b71e1fd)",
- "dashcore 0.40.0 (git+https://github.com/dashpay/rust-dashcore?rev=8f97c4b7599849ba048cdd7ef98276966b71e1fd)",
+ "dash-spv",
+ "dashcore",
  "env_logger 0.10.2",
  "futures",
  "hex",
- "key-wallet 0.40.0 (git+https://github.com/dashpay/rust-dashcore?rev=8f97c4b7599849ba048cdd7ef98276966b71e1fd)",
+ "key-wallet",
  "key-wallet-ffi",
- "key-wallet-manager 0.40.0 (git+https://github.com/dashpay/rust-dashcore?rev=8f97c4b7599849ba048cdd7ef98276966b71e1fd)",
+ "key-wallet-manager",
  "libc",
  "log",
  "once_cell",
@@ -1561,7 +1497,7 @@ dependencies = [
 [[package]]
 name = "dashcore"
 version = "0.40.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=8f97c4b7599849ba048cdd7ef98276966b71e1fd#8f97c4b7599849ba048cdd7ef98276966b71e1fd"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=e7792c431c55c0d28efb0344b3a1948f576be5ce#e7792c431c55c0d28efb0344b3a1948f576be5ce"
 dependencies = [
  "anyhow",
  "base64-compat",
@@ -1571,9 +1507,9 @@ dependencies = [
  "bitvec",
  "blake3",
  "blsful",
- "dash-network 0.40.0 (git+https://github.com/dashpay/rust-dashcore?rev=8f97c4b7599849ba048cdd7ef98276966b71e1fd)",
- "dashcore-private 0.40.0 (git+https://github.com/dashpay/rust-dashcore?rev=8f97c4b7599849ba048cdd7ef98276966b71e1fd)",
- "dashcore_hashes 0.40.0 (git+https://github.com/dashpay/rust-dashcore?rev=8f97c4b7599849ba048cdd7ef98276966b71e1fd)",
+ "dash-network",
+ "dashcore-private",
+ "dashcore_hashes",
  "ed25519-dalek",
  "hex",
  "hex_lit",
@@ -1585,59 +1521,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "dashcore"
-version = "0.40.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=e44b1fb2086ad57c8884995f9f93f14de91bf964#e44b1fb2086ad57c8884995f9f93f14de91bf964"
-dependencies = [
- "anyhow",
- "base64-compat",
- "bech32 0.9.1",
- "bincode 2.0.0-rc.3",
- "bincode_derive",
- "bitvec",
- "blake3",
- "blsful",
- "dash-network 0.40.0 (git+https://github.com/dashpay/rust-dashcore?rev=e44b1fb2086ad57c8884995f9f93f14de91bf964)",
- "dashcore-private 0.40.0 (git+https://github.com/dashpay/rust-dashcore?rev=e44b1fb2086ad57c8884995f9f93f14de91bf964)",
- "dashcore_hashes 0.40.0 (git+https://github.com/dashpay/rust-dashcore?rev=e44b1fb2086ad57c8884995f9f93f14de91bf964)",
- "hex",
- "hex_lit",
- "log",
- "rustversion",
- "secp256k1",
- "serde",
- "thiserror 2.0.17",
-]
-
-[[package]]
 name = "dashcore-private"
 version = "0.40.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=8f97c4b7599849ba048cdd7ef98276966b71e1fd#8f97c4b7599849ba048cdd7ef98276966b71e1fd"
-
-[[package]]
-name = "dashcore-private"
-version = "0.40.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=e44b1fb2086ad57c8884995f9f93f14de91bf964#e44b1fb2086ad57c8884995f9f93f14de91bf964"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=e7792c431c55c0d28efb0344b3a1948f576be5ce#e7792c431c55c0d28efb0344b3a1948f576be5ce"
 
 [[package]]
 name = "dashcore-rpc"
 version = "0.40.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=8f97c4b7599849ba048cdd7ef98276966b71e1fd#8f97c4b7599849ba048cdd7ef98276966b71e1fd"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=e7792c431c55c0d28efb0344b3a1948f576be5ce#e7792c431c55c0d28efb0344b3a1948f576be5ce"
 dependencies = [
- "dashcore-rpc-json 0.40.0 (git+https://github.com/dashpay/rust-dashcore?rev=8f97c4b7599849ba048cdd7ef98276966b71e1fd)",
- "hex",
- "jsonrpc",
- "log",
- "serde",
- "serde_json",
-]
-
-[[package]]
-name = "dashcore-rpc"
-version = "0.40.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=e44b1fb2086ad57c8884995f9f93f14de91bf964#e44b1fb2086ad57c8884995f9f93f14de91bf964"
-dependencies = [
- "dashcore-rpc-json 0.40.0 (git+https://github.com/dashpay/rust-dashcore?rev=e44b1fb2086ad57c8884995f9f93f14de91bf964)",
+ "dashcore-rpc-json",
  "hex",
  "jsonrpc",
  "log",
@@ -1648,27 +1541,12 @@ dependencies = [
 [[package]]
 name = "dashcore-rpc-json"
 version = "0.40.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=8f97c4b7599849ba048cdd7ef98276966b71e1fd#8f97c4b7599849ba048cdd7ef98276966b71e1fd"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=e7792c431c55c0d28efb0344b3a1948f576be5ce#e7792c431c55c0d28efb0344b3a1948f576be5ce"
 dependencies = [
  "bincode 2.0.0-rc.3",
- "dashcore 0.40.0 (git+https://github.com/dashpay/rust-dashcore?rev=8f97c4b7599849ba048cdd7ef98276966b71e1fd)",
+ "dashcore",
  "hex",
- "key-wallet 0.40.0 (git+https://github.com/dashpay/rust-dashcore?rev=8f97c4b7599849ba048cdd7ef98276966b71e1fd)",
- "serde",
- "serde_json",
- "serde_repr",
- "serde_with 2.3.3",
-]
-
-[[package]]
-name = "dashcore-rpc-json"
-version = "0.40.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=e44b1fb2086ad57c8884995f9f93f14de91bf964#e44b1fb2086ad57c8884995f9f93f14de91bf964"
-dependencies = [
- "bincode 2.0.0-rc.3",
- "dashcore 0.40.0 (git+https://github.com/dashpay/rust-dashcore?rev=e44b1fb2086ad57c8884995f9f93f14de91bf964)",
- "hex",
- "key-wallet 0.40.0 (git+https://github.com/dashpay/rust-dashcore?rev=e44b1fb2086ad57c8884995f9f93f14de91bf964)",
+ "key-wallet",
  "serde",
  "serde_json",
  "serde_repr",
@@ -1678,22 +1556,10 @@ dependencies = [
 [[package]]
 name = "dashcore_hashes"
 version = "0.40.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=8f97c4b7599849ba048cdd7ef98276966b71e1fd#8f97c4b7599849ba048cdd7ef98276966b71e1fd"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=e7792c431c55c0d28efb0344b3a1948f576be5ce#e7792c431c55c0d28efb0344b3a1948f576be5ce"
 dependencies = [
  "bincode 2.0.0-rc.3",
- "dashcore-private 0.40.0 (git+https://github.com/dashpay/rust-dashcore?rev=8f97c4b7599849ba048cdd7ef98276966b71e1fd)",
- "rs-x11-hash",
- "secp256k1",
- "serde",
-]
-
-[[package]]
-name = "dashcore_hashes"
-version = "0.40.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=e44b1fb2086ad57c8884995f9f93f14de91bf964#e44b1fb2086ad57c8884995f9f93f14de91bf964"
-dependencies = [
- "bincode 2.0.0-rc.3",
- "dashcore-private 0.40.0 (git+https://github.com/dashpay/rust-dashcore?rev=e44b1fb2086ad57c8884995f9f93f14de91bf964)",
+ "dashcore-private",
  "rs-x11-hash",
  "secp256k1",
  "serde",
@@ -1882,9 +1748,9 @@ dependencies = [
  "chrono",
  "chrono-tz",
  "ciborium",
- "dash-spv 0.40.0 (git+https://github.com/dashpay/rust-dashcore?rev=8f97c4b7599849ba048cdd7ef98276966b71e1fd)",
- "dashcore 0.40.0 (git+https://github.com/dashpay/rust-dashcore?rev=8f97c4b7599849ba048cdd7ef98276966b71e1fd)",
- "dashcore-rpc 0.40.0 (git+https://github.com/dashpay/rust-dashcore?rev=8f97c4b7599849ba048cdd7ef98276966b71e1fd)",
+ "dash-spv",
+ "dashcore",
+ "dashcore-rpc",
  "data-contracts",
  "derive_more 1.0.0",
  "dpp",
@@ -1896,8 +1762,8 @@ dependencies = [
  "itertools 0.13.0",
  "json-schema-compatibility-validator",
  "jsonschema",
- "key-wallet 0.40.0 (git+https://github.com/dashpay/rust-dashcore?rev=8f97c4b7599849ba048cdd7ef98276966b71e1fd)",
- "key-wallet-manager 0.40.0 (git+https://github.com/dashpay/rust-dashcore?rev=8f97c4b7599849ba048cdd7ef98276966b71e1fd)",
+ "key-wallet",
+ "key-wallet-manager",
  "lazy_static",
  "log",
  "nohash-hasher",
@@ -3530,7 +3396,7 @@ dependencies = [
 [[package]]
 name = "key-wallet"
 version = "0.40.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=8f97c4b7599849ba048cdd7ef98276966b71e1fd#8f97c4b7599849ba048cdd7ef98276966b71e1fd"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=e7792c431c55c0d28efb0344b3a1948f576be5ce#e7792c431c55c0d28efb0344b3a1948f576be5ce"
 dependencies = [
  "aes",
  "async-trait",
@@ -3540,10 +3406,10 @@ dependencies = [
  "bip39",
  "bitflags 2.9.4",
  "bs58",
- "dash-network 0.40.0 (git+https://github.com/dashpay/rust-dashcore?rev=8f97c4b7599849ba048cdd7ef98276966b71e1fd)",
- "dashcore 0.40.0 (git+https://github.com/dashpay/rust-dashcore?rev=8f97c4b7599849ba048cdd7ef98276966b71e1fd)",
- "dashcore-private 0.40.0 (git+https://github.com/dashpay/rust-dashcore?rev=8f97c4b7599849ba048cdd7ef98276966b71e1fd)",
- "dashcore_hashes 0.40.0 (git+https://github.com/dashpay/rust-dashcore?rev=8f97c4b7599849ba048cdd7ef98276966b71e1fd)",
+ "dash-network",
+ "dashcore",
+ "dashcore-private",
+ "dashcore_hashes",
  "getrandom 0.2.16",
  "hex",
  "hkdf",
@@ -3558,42 +3424,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "key-wallet"
-version = "0.40.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=e44b1fb2086ad57c8884995f9f93f14de91bf964#e44b1fb2086ad57c8884995f9f93f14de91bf964"
-dependencies = [
- "base58ck",
- "bincode 2.0.0-rc.3",
- "bincode_derive",
- "bip39",
- "bitflags 2.9.4",
- "dash-network 0.40.0 (git+https://github.com/dashpay/rust-dashcore?rev=e44b1fb2086ad57c8884995f9f93f14de91bf964)",
- "dashcore 0.40.0 (git+https://github.com/dashpay/rust-dashcore?rev=e44b1fb2086ad57c8884995f9f93f14de91bf964)",
- "dashcore-private 0.40.0 (git+https://github.com/dashpay/rust-dashcore?rev=e44b1fb2086ad57c8884995f9f93f14de91bf964)",
- "dashcore_hashes 0.40.0 (git+https://github.com/dashpay/rust-dashcore?rev=e44b1fb2086ad57c8884995f9f93f14de91bf964)",
- "getrandom 0.2.16",
- "hex",
- "hkdf",
- "rand 0.8.5",
- "secp256k1",
- "serde",
- "serde_json",
- "sha2",
- "tracing",
- "zeroize",
-]
-
-[[package]]
 name = "key-wallet-ffi"
 version = "0.40.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=8f97c4b7599849ba048cdd7ef98276966b71e1fd#8f97c4b7599849ba048cdd7ef98276966b71e1fd"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=e7792c431c55c0d28efb0344b3a1948f576be5ce#e7792c431c55c0d28efb0344b3a1948f576be5ce"
 dependencies = [
  "cbindgen 0.29.0",
- "dash-network 0.40.0 (git+https://github.com/dashpay/rust-dashcore?rev=8f97c4b7599849ba048cdd7ef98276966b71e1fd)",
- "dashcore 0.40.0 (git+https://github.com/dashpay/rust-dashcore?rev=8f97c4b7599849ba048cdd7ef98276966b71e1fd)",
+ "dash-network",
+ "dashcore",
  "hex",
- "key-wallet 0.40.0 (git+https://github.com/dashpay/rust-dashcore?rev=8f97c4b7599849ba048cdd7ef98276966b71e1fd)",
- "key-wallet-manager 0.40.0 (git+https://github.com/dashpay/rust-dashcore?rev=8f97c4b7599849ba048cdd7ef98276966b71e1fd)",
+ "key-wallet",
+ "key-wallet-manager",
  "libc",
  "secp256k1",
  "tokio",
@@ -3602,27 +3442,13 @@ dependencies = [
 [[package]]
 name = "key-wallet-manager"
 version = "0.40.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=8f97c4b7599849ba048cdd7ef98276966b71e1fd#8f97c4b7599849ba048cdd7ef98276966b71e1fd"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=e7792c431c55c0d28efb0344b3a1948f576be5ce#e7792c431c55c0d28efb0344b3a1948f576be5ce"
 dependencies = [
  "async-trait",
  "bincode 2.0.0-rc.3",
- "dashcore 0.40.0 (git+https://github.com/dashpay/rust-dashcore?rev=8f97c4b7599849ba048cdd7ef98276966b71e1fd)",
- "dashcore_hashes 0.40.0 (git+https://github.com/dashpay/rust-dashcore?rev=8f97c4b7599849ba048cdd7ef98276966b71e1fd)",
- "key-wallet 0.40.0 (git+https://github.com/dashpay/rust-dashcore?rev=8f97c4b7599849ba048cdd7ef98276966b71e1fd)",
- "secp256k1",
- "zeroize",
-]
-
-[[package]]
-name = "key-wallet-manager"
-version = "0.40.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=e44b1fb2086ad57c8884995f9f93f14de91bf964#e44b1fb2086ad57c8884995f9f93f14de91bf964"
-dependencies = [
- "async-trait",
- "bincode 2.0.0-rc.3",
- "dashcore 0.40.0 (git+https://github.com/dashpay/rust-dashcore?rev=e44b1fb2086ad57c8884995f9f93f14de91bf964)",
- "dashcore_hashes 0.40.0 (git+https://github.com/dashpay/rust-dashcore?rev=e44b1fb2086ad57c8884995f9f93f14de91bf964)",
- "key-wallet 0.40.0 (git+https://github.com/dashpay/rust-dashcore?rev=e44b1fb2086ad57c8884995f9f93f14de91bf964)",
+ "dashcore",
+ "dashcore_hashes",
+ "key-wallet",
  "secp256k1",
  "zeroize",
 ]
@@ -3923,18 +3749,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
 dependencies = [
  "adler2",
-]
-
-[[package]]
-name = "mio"
-version = "0.8.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4a650543ca06a924e8b371db273b2756685faae30f8487da1b56505a8f78b0c"
-dependencies = [
- "libc",
- "log",
- "wasi 0.11.1+wasi-snapshot-preview1",
- "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -4532,11 +4346,11 @@ dependencies = [
 name = "platform-wallet"
 version = "2.2.0-dev.2"
 dependencies = [
- "dashcore 0.40.0 (git+https://github.com/dashpay/rust-dashcore?rev=8f97c4b7599849ba048cdd7ef98276966b71e1fd)",
+ "dashcore",
  "dpp",
  "indexmap 2.11.4",
- "key-wallet 0.40.0 (git+https://github.com/dashpay/rust-dashcore?rev=8f97c4b7599849ba048cdd7ef98276966b71e1fd)",
- "key-wallet-manager 0.40.0 (git+https://github.com/dashpay/rust-dashcore?rev=8f97c4b7599849ba048cdd7ef98276966b71e1fd)",
+ "key-wallet",
+ "key-wallet-manager",
  "thiserror 1.0.69",
 ]
 
@@ -5318,8 +5132,8 @@ dependencies = [
  "ciborium",
  "clap",
  "dapi-grpc",
- "dash-spv 0.40.0 (git+https://github.com/dashpay/rust-dashcore?rev=e44b1fb2086ad57c8884995f9f93f14de91bf964)",
- "dashcore-rpc 0.40.0 (git+https://github.com/dashpay/rust-dashcore?rev=e44b1fb2086ad57c8884995f9f93f14de91bf964)",
+ "dash-spv",
+ "dashcore-rpc",
  "dotenvy",
  "dpp",
  "envy",
@@ -6052,27 +5866,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
-name = "signal-hook"
-version = "0.3.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d881a16cf4426aa584979d30bd82cb33429027e42122b169753d6ef1085ed6e2"
-dependencies = [
- "libc",
- "signal-hook-registry",
-]
-
-[[package]]
-name = "signal-hook-mio"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34db1a06d485c9142248b7a054f034b349b212551f3dfd19c94d45a754a217cd"
-dependencies = [
- "libc",
- "mio 0.8.11",
- "signal-hook",
-]
-
-[[package]]
 name = "signal-hook-registry"
 version = "1.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6609,7 +6402,7 @@ checksum = "ff360e02eab121e0bc37a2d3b4d4dc622e6eda3a8e5253d5435ecf5bd4c68408"
 dependencies = [
  "bytes",
  "libc",
- "mio 1.0.4",
+ "mio",
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",

--- a/packages/rs-dapi/Cargo.toml
+++ b/packages/rs-dapi/Cargo.toml
@@ -78,15 +78,17 @@ zeromq = { git = "https://github.com/gvz/zmq.rs", rev = "b0787de310befaedd1f762e
 
 xxhash-rust = { version = "0.8.15", features = ["xxh3"] }
 # Dash Platform dependencies (using workspace versions)
-dpp = { path = "../rs-dpp", default-features = false, features = ["state-transitions"] }
+dpp = { path = "../rs-dpp", default-features = false, features = [
+    "state-transitions",
+] }
 dapi-grpc = { path = "../dapi-grpc", features = ["server", "client", "serde"] }
 quick_cache = "0.6.16"
 prometheus = "0.14"
 once_cell = "1.19"
 
 # Dash Core RPC client
-dashcore-rpc = { git = "https://github.com/dashpay/rust-dashcore", rev = "e44b1fb2086ad57c8884995f9f93f14de91bf964" }
-dash-spv = { git = "https://github.com/dashpay/rust-dashcore", rev = "e44b1fb2086ad57c8884995f9f93f14de91bf964" }
+dashcore-rpc = { git = "https://github.com/dashpay/rust-dashcore", rev = "e7792c431c55c0d28efb0344b3a1948f576be5ce" }
+dash-spv = { git = "https://github.com/dashpay/rust-dashcore", rev = "e7792c431c55c0d28efb0344b3a1948f576be5ce" }
 
 rs-dash-event-bus = { path = "../rs-dash-event-bus" }
 

--- a/packages/rs-dpp/Cargo.toml
+++ b/packages/rs-dpp/Cargo.toml
@@ -24,7 +24,7 @@ chrono = { version = "0.4.35", default-features = false, features = [
 ] }
 chrono-tz = { version = "0.8", optional = true }
 ciborium = { version = "0.2.2", optional = true }
-dashcore = { git = "https://github.com/dashpay/rust-dashcore", rev = "8f97c4b7599849ba048cdd7ef98276966b71e1fd", features = [
+dashcore = { git = "https://github.com/dashpay/rust-dashcore", rev = "e7792c431c55c0d28efb0344b3a1948f576be5ce", features = [
   "std",
   "secp-recovery",
   "rand",
@@ -32,10 +32,10 @@ dashcore = { git = "https://github.com/dashpay/rust-dashcore", rev = "8f97c4b759
   "serde",
   "eddsa",
 ], default-features = false }
-key-wallet = { git = "https://github.com/dashpay/rust-dashcore", rev = "8f97c4b7599849ba048cdd7ef98276966b71e1fd", optional = true }
-key-wallet-manager = { git = "https://github.com/dashpay/rust-dashcore", rev = "8f97c4b7599849ba048cdd7ef98276966b71e1fd", optional = true }
-dash-spv = { git = "https://github.com/dashpay/rust-dashcore", rev = "8f97c4b7599849ba048cdd7ef98276966b71e1fd", optional = true }
-dashcore-rpc = { git = "https://github.com/dashpay/rust-dashcore", rev = "8f97c4b7599849ba048cdd7ef98276966b71e1fd", optional = true }
+key-wallet = { git = "https://github.com/dashpay/rust-dashcore", rev = "e7792c431c55c0d28efb0344b3a1948f576be5ce", optional = true }
+key-wallet-manager = { git = "https://github.com/dashpay/rust-dashcore", rev = "e7792c431c55c0d28efb0344b3a1948f576be5ce", optional = true }
+dash-spv = { git = "https://github.com/dashpay/rust-dashcore", rev = "e7792c431c55c0d28efb0344b3a1948f576be5ce", optional = true }
+dashcore-rpc = { git = "https://github.com/dashpay/rust-dashcore", rev = "e7792c431c55c0d28efb0344b3a1948f576be5ce", optional = true }
 
 env_logger = { version = "0.11" }
 getrandom = { version = "0.2", features = ["js"] }

--- a/packages/rs-platform-wallet/Cargo.toml
+++ b/packages/rs-platform-wallet/Cargo.toml
@@ -11,11 +11,11 @@ description = "Platform wallet with identity management support"
 dpp = { path = "../rs-dpp" }
 
 # Key wallet dependencies (from rust-dashcore)
-key-wallet = { git = "https://github.com/dashpay/rust-dashcore", rev = "8f97c4b7599849ba048cdd7ef98276966b71e1fd" }
-key-wallet-manager = { git = "https://github.com/dashpay/rust-dashcore", rev = "8f97c4b7599849ba048cdd7ef98276966b71e1fd", optional = true }
+key-wallet = { git = "https://github.com/dashpay/rust-dashcore", rev = "e7792c431c55c0d28efb0344b3a1948f576be5ce" }
+key-wallet-manager = { git = "https://github.com/dashpay/rust-dashcore", rev = "e7792c431c55c0d28efb0344b3a1948f576be5ce", optional = true }
 
 # Core dependencies
-dashcore = { git = "https://github.com/dashpay/rust-dashcore", rev = "8f97c4b7599849ba048cdd7ef98276966b71e1fd" }
+dashcore = { git = "https://github.com/dashpay/rust-dashcore", rev = "e7792c431c55c0d28efb0344b3a1948f576be5ce" }
 
 # Standard dependencies
 thiserror = "1.0"

--- a/packages/rs-platform-wallet/examples/basic_usage.rs
+++ b/packages/rs-platform-wallet/examples/basic_usage.rs
@@ -6,7 +6,9 @@ use platform_wallet::{PlatformWalletError, PlatformWalletInfo};
 fn main() -> Result<(), PlatformWalletError> {
     // Create a platform wallet
     let wallet_id = [1u8; 32];
-    let platform_wallet = PlatformWalletInfo::new(wallet_id, "My Platform Wallet".to_string());
+    let network = dashcore::Network::Testnet;
+    let platform_wallet =
+        PlatformWalletInfo::new(wallet_id, "My Platform Wallet".to_string(), network);
 
     println!("Created wallet: {:?}", platform_wallet.name());
 

--- a/packages/rs-platform-wallet/src/lib.rs
+++ b/packages/rs-platform-wallet/src/lib.rs
@@ -47,9 +47,9 @@ pub struct PlatformWalletInfo {
 
 impl PlatformWalletInfo {
     /// Create a new platform wallet info
-    pub fn new(wallet_id: [u8; 32], name: String) -> Self {
+    pub fn new(wallet_id: [u8; 32], name: String, network: Network) -> Self {
         Self {
-            wallet_info: ManagedWalletInfo::with_name(wallet_id, name),
+            wallet_info: ManagedWalletInfo::with_name(network, wallet_id, name),
             identity_manager: IdentityManager::new(),
         }
     }
@@ -102,20 +102,13 @@ impl WalletTransactionChecker for PlatformWalletInfo {
     async fn check_transaction(
         &mut self,
         tx: &Transaction,
-        network: Network,
         context: TransactionContext,
         wallet: &mut Wallet,
         update_state_with_wallet_if_found: bool,
     ) -> TransactionCheckResult {
         // Delegate to the underlying wallet info
         self.wallet_info
-            .check_transaction(
-                tx,
-                network,
-                context,
-                wallet,
-                update_state_with_wallet_if_found,
-            )
+            .check_transaction(tx, context, wallet, update_state_with_wallet_if_found)
             .await
     }
 }
@@ -126,35 +119,27 @@ impl ManagedAccountOperations for PlatformWalletInfo {
         &mut self,
         wallet: &Wallet,
         account_type: AccountType,
-        network: Network,
     ) -> key_wallet::Result<()> {
-        self.wallet_info
-            .add_managed_account(wallet, account_type, network)
+        self.wallet_info.add_managed_account(wallet, account_type)
     }
 
     fn add_managed_account_with_passphrase(
         &mut self,
         wallet: &Wallet,
         account_type: AccountType,
-        network: Network,
         passphrase: &str,
     ) -> key_wallet::Result<()> {
-        self.wallet_info.add_managed_account_with_passphrase(
-            wallet,
-            account_type,
-            network,
-            passphrase,
-        )
+        self.wallet_info
+            .add_managed_account_with_passphrase(wallet, account_type, passphrase)
     }
 
     fn add_managed_account_from_xpub(
         &mut self,
         account_type: AccountType,
-        network: Network,
         account_xpub: ExtendedPubKey,
     ) -> key_wallet::Result<()> {
         self.wallet_info
-            .add_managed_account_from_xpub(account_type, network, account_xpub)
+            .add_managed_account_from_xpub(account_type, account_xpub)
     }
 
     #[cfg(feature = "bls")]
@@ -162,10 +147,9 @@ impl ManagedAccountOperations for PlatformWalletInfo {
         &mut self,
         wallet: &Wallet,
         account_type: AccountType,
-        network: Network,
     ) -> key_wallet::Result<()> {
         self.wallet_info
-            .add_managed_bls_account(wallet, account_type, network)
+            .add_managed_bls_account(wallet, account_type)
     }
 
     #[cfg(feature = "bls")]
@@ -173,29 +157,20 @@ impl ManagedAccountOperations for PlatformWalletInfo {
         &mut self,
         wallet: &Wallet,
         account_type: AccountType,
-        network: Network,
         passphrase: &str,
     ) -> key_wallet::Result<()> {
-        self.wallet_info.add_managed_bls_account_with_passphrase(
-            wallet,
-            account_type,
-            network,
-            passphrase,
-        )
+        self.wallet_info
+            .add_managed_bls_account_with_passphrase(wallet, account_type, passphrase)
     }
 
     #[cfg(feature = "bls")]
     fn add_managed_bls_account_from_public_key(
         &mut self,
         account_type: AccountType,
-        network: Network,
         bls_public_key: [u8; 48],
     ) -> key_wallet::Result<()> {
-        self.wallet_info.add_managed_bls_account_from_public_key(
-            account_type,
-            network,
-            bls_public_key,
-        )
+        self.wallet_info
+            .add_managed_bls_account_from_public_key(account_type, bls_public_key)
     }
 
     #[cfg(feature = "eddsa")]
@@ -203,10 +178,9 @@ impl ManagedAccountOperations for PlatformWalletInfo {
         &mut self,
         wallet: &Wallet,
         account_type: AccountType,
-        network: Network,
     ) -> key_wallet::Result<()> {
         self.wallet_info
-            .add_managed_eddsa_account(wallet, account_type, network)
+            .add_managed_eddsa_account(wallet, account_type)
     }
 
     #[cfg(feature = "eddsa")]
@@ -214,29 +188,20 @@ impl ManagedAccountOperations for PlatformWalletInfo {
         &mut self,
         wallet: &Wallet,
         account_type: AccountType,
-        network: Network,
         passphrase: &str,
     ) -> key_wallet::Result<()> {
-        self.wallet_info.add_managed_eddsa_account_with_passphrase(
-            wallet,
-            account_type,
-            network,
-            passphrase,
-        )
+        self.wallet_info
+            .add_managed_eddsa_account_with_passphrase(wallet, account_type, passphrase)
     }
 
     #[cfg(feature = "eddsa")]
     fn add_managed_eddsa_account_from_public_key(
         &mut self,
         account_type: AccountType,
-        network: Network,
         ed25519_public_key: [u8; 32],
     ) -> key_wallet::Result<()> {
-        self.wallet_info.add_managed_eddsa_account_from_public_key(
-            account_type,
-            network,
-            ed25519_public_key,
-        )
+        self.wallet_info
+            .add_managed_eddsa_account_from_public_key(account_type, ed25519_public_key)
     }
 }
 
@@ -296,8 +261,8 @@ impl WalletInfoInterface for PlatformWalletInfo {
         self.wallet_info.update_last_synced(timestamp)
     }
 
-    fn monitored_addresses(&self, network: Network) -> Vec<DashAddress> {
-        self.wallet_info.monitored_addresses(network)
+    fn monitored_addresses(&self) -> Vec<DashAddress> {
+        self.wallet_info.monitored_addresses()
     }
 
     fn utxos(&self) -> BTreeSet<&Utxo> {
@@ -324,39 +289,34 @@ impl WalletInfoInterface for PlatformWalletInfo {
         self.wallet_info.transaction_history()
     }
 
-    fn accounts_mut(&mut self, network: Network) -> Option<&mut ManagedAccountCollection> {
-        self.wallet_info.accounts_mut(network)
+    fn accounts_mut(&mut self) -> &mut ManagedAccountCollection {
+        self.wallet_info.accounts_mut()
     }
 
-    fn accounts(&self, network: Network) -> Option<&ManagedAccountCollection> {
-        self.wallet_info.accounts(network)
+    fn accounts(&self) -> &ManagedAccountCollection {
+        self.wallet_info.accounts()
     }
 
-    fn process_matured_transactions(
-        &mut self,
-        network: Network,
-        current_height: u32,
-    ) -> Vec<ImmatureTransaction> {
+    fn process_matured_transactions(&mut self, current_height: u32) -> Vec<ImmatureTransaction> {
         self.wallet_info
-            .process_matured_transactions(network, current_height)
+            .process_matured_transactions(current_height)
     }
 
-    fn add_immature_transaction(&mut self, network: Network, tx: ImmatureTransaction) {
-        self.wallet_info.add_immature_transaction(network, tx)
+    fn add_immature_transaction(&mut self, tx: ImmatureTransaction) {
+        self.wallet_info.add_immature_transaction(tx)
     }
 
-    fn immature_transactions(&self, network: Network) -> Option<&ImmatureTransactionCollection> {
-        self.wallet_info.immature_transactions(network)
+    fn immature_transactions(&self) -> &ImmatureTransactionCollection {
+        self.wallet_info.immature_transactions()
     }
 
-    fn network_immature_balance(&self, network: Network) -> u64 {
-        self.wallet_info.network_immature_balance(network)
+    fn immature_balance(&self) -> u64 {
+        self.wallet_info.immature_balance()
     }
 
     fn create_unsigned_payment_transaction(
         &mut self,
         wallet: &Wallet,
-        network: Network,
         account_index: u32,
         account_type_pref: Option<AccountTypePreference>,
         recipients: Vec<(Address, u64)>,
@@ -365,7 +325,6 @@ impl WalletInfoInterface for PlatformWalletInfo {
     ) -> Result<Transaction, TransactionError> {
         self.wallet_info.create_unsigned_payment_transaction(
             wallet,
-            network,
             account_index,
             account_type_pref,
             recipients,
@@ -373,9 +332,12 @@ impl WalletInfoInterface for PlatformWalletInfo {
             current_block_height,
         )
     }
-    fn update_chain_height(&mut self, network: Network, current_height: u32) {
-        self.wallet_info
-            .update_chain_height(network, current_height)
+    fn update_chain_height(&mut self, current_height: u32) {
+        self.wallet_info.update_chain_height(current_height)
+    }
+
+    fn network(&self) -> Network {
+        self.wallet_info.network()
     }
 }
 
@@ -402,7 +364,9 @@ mod tests {
     #[test]
     fn test_platform_wallet_creation() {
         let wallet_id = [1u8; 32];
-        let wallet = PlatformWalletInfo::new(wallet_id, "Test Platform Wallet".to_string());
+        let network = Network::Testnet;
+        let wallet =
+            PlatformWalletInfo::new(wallet_id, "Test Platform Wallet".to_string(), network);
 
         assert_eq!(wallet.wallet_id(), wallet_id);
         assert_eq!(wallet.name(), Some("Test Platform Wallet"));

--- a/packages/rs-sdk-ffi/Cargo.toml
+++ b/packages/rs-sdk-ffi/Cargo.toml
@@ -22,7 +22,7 @@ rs-sdk-trusted-context-provider = { path = "../rs-sdk-trusted-context-provider",
 simple-signer = { path = "../simple-signer" }
 
 # Core SDK integration (always included for unified SDK)
-dash-spv-ffi = { git = "https://github.com/dashpay/rust-dashcore", rev = "8f97c4b7599849ba048cdd7ef98276966b71e1fd", optional = true }
+dash-spv-ffi = { git = "https://github.com/dashpay/rust-dashcore", rev = "e7792c431c55c0d28efb0344b3a1948f576be5ce", optional = true }
 
 # FFI and serialization
 serde = { version = "1.0", features = ["derive"] }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented

We need most recent rust-dashcore for iOS SDK.

## What was done?

Bumped rust-dashcore to rev e7792c4, fixed build issues caused by API changes.

## How Has This Been Tested?

GHA

## Breaking Changes

None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [ ] I have made corresponding changes to the documentation if needed

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone
