### PR TITLE
test(drive-abci): revert stack size back to 4MB in drive-abci tests

### DIFF
--- a/.github/workflows/tests-rs-package.yml
+++ b/.github/workflows/tests-rs-package.yml
@@ -198,9 +198,8 @@ jobs:
       - name: Install librocksdb
         uses: ./.github/actions/librocksdb
 
-      - name: Run tests
-        # Note: we don't set RUST_MIN_STACK globally, annotate appropriate tests with #[stack_size(BYTES)] instead
-        run: cargo test --package=${{ inputs.package }} --all-features --locked
+      - name: Run tests        
+        run: RUST_MIN_STACK=4194304 cargo test --package=${{ inputs.package }} --all-features --locked
         env:
           SCCACHE_S3_KEY_PREFIX: ${{ runner.os }}/sccache/${{ runner.arch }}/linux-gnu
           ROCKSDB_STATIC: "/opt/rocksdb/usr/local/lib/librocksdb.a"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,6 +7,7 @@ on:
     branches:
       - master
       - "v*-dev"
+      - "feat/platformAddresses" # TODO: remove
   push:
     branches:
       - master

--- a/packages/rs-drive-abci/tests/strategy_tests/failures.rs
+++ b/packages/rs-drive-abci/tests/strategy_tests/failures.rs
@@ -1,6 +1,7 @@
 #[cfg(test)]
 mod tests {
     use crate::execution::run_chain_for_strategy;
+    use dash_platform_macros::stack_size;
     use std::collections::{BTreeMap, HashMap};
     use strategy_tests::frequency::Frequency;
 
@@ -21,6 +22,7 @@ mod tests {
     use drive_abci::test::helpers::setup::TestPlatformBuilder;
 
     #[test]
+    #[stack_size(4*1024*1024)]
     fn run_chain_insert_one_new_identity_and_a_contract_with_bad_update() {
         let platform_version = PlatformVersion::latest();
         let contract = json_document_to_created_contract(

--- a/packages/rs-drive-abci/tests/strategy_tests/test_cases/core_height_increase.rs
+++ b/packages/rs-drive-abci/tests/strategy_tests/test_cases/core_height_increase.rs
@@ -800,6 +800,7 @@ mod tests {
     }
 
     #[test]
+    #[stack_size(4*1024*1024)]
     fn run_chain_heavy_rotation_deterministic_before_payout() {
         let strategy = NetworkStrategy {
             strategy: Strategy {

--- a/packages/rs-drive-abci/tests/strategy_tests/test_cases/core_height_increase.rs
+++ b/packages/rs-drive-abci/tests/strategy_tests/test_cases/core_height_increase.rs
@@ -972,6 +972,7 @@ mod tests {
     }
 
     #[test]
+    #[stack_size(4*1024*1024)]
     fn run_chain_proposer_proposes_a_chainlock_that_would_remove_themselves_from_the_list_deterministic(
     ) {
         let strategy = NetworkStrategy {

--- a/packages/rs-drive-abci/tests/strategy_tests/test_cases/identity_and_document_tests.rs
+++ b/packages/rs-drive-abci/tests/strategy_tests/test_cases/identity_and_document_tests.rs
@@ -541,6 +541,7 @@ mod tests {
     }
 
     #[test]
+    #[stack_size(4 * 1024 * 1024)]
     fn run_chain_insert_one_new_identity_and_a_contract_with_updates() {
         let platform_version = PlatformVersion::latest();
         let contract = json_document_to_created_contract(


### PR DESCRIPTION
## Issue being fixed or feature implemented

Tests fail due to stack overflow


## What was done?

Reverted github action back to 4 MB default stack size for drive-abci tests.

Annotated some of the  failing tests with `#[stack_size(4*1024*1024)]`.

Enabled tests to be run when targeting feat/platformAddresses branch

## How Has This Been Tested?

github actions 

## Breaking Changes

none


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [ ] I have made corresponding changes to the documentation if needed

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
