### PR TITLE
fix(drive-abci): call update checkpoints

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -871,7 +871,7 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "check-features"
-version = "3.0.0-dev.1"
+version = "3.0.0-dev.2"
 dependencies = [
  "toml",
 ]
@@ -1296,7 +1296,7 @@ dependencies = [
 
 [[package]]
 name = "dapi-grpc"
-version = "3.0.0-dev.1"
+version = "3.0.0-dev.2"
 dependencies = [
  "dash-platform-macros",
  "futures-core",
@@ -1349,7 +1349,7 @@ dependencies = [
 
 [[package]]
 name = "dash-context-provider"
-version = "3.0.0-dev.1"
+version = "3.0.0-dev.2"
 dependencies = [
  "dpp",
  "drive",
@@ -1371,7 +1371,7 @@ dependencies = [
 
 [[package]]
 name = "dash-platform-balance-checker"
-version = "3.0.0-dev.1"
+version = "3.0.0-dev.2"
 dependencies = [
  "anyhow",
  "clap",
@@ -1386,7 +1386,7 @@ dependencies = [
 
 [[package]]
 name = "dash-platform-macros"
-version = "3.0.0-dev.1"
+version = "3.0.0-dev.2"
 dependencies = [
  "heck 0.5.0",
  "quote",
@@ -1395,7 +1395,7 @@ dependencies = [
 
 [[package]]
 name = "dash-sdk"
-version = "3.0.0-dev.1"
+version = "3.0.0-dev.2"
 dependencies = [
  "arc-swap",
  "assert_matches",
@@ -1567,7 +1567,7 @@ dependencies = [
 
 [[package]]
 name = "dashpay-contract"
-version = "3.0.0-dev.1"
+version = "3.0.0-dev.2"
 dependencies = [
  "platform-value",
  "platform-version",
@@ -1577,7 +1577,7 @@ dependencies = [
 
 [[package]]
 name = "data-contracts"
-version = "3.0.0-dev.1"
+version = "3.0.0-dev.2"
 dependencies = [
  "dashpay-contract",
  "dpns-contract",
@@ -1724,7 +1724,7 @@ checksum = "1435fa1053d8b2fbbe9be7e97eca7f33d37b28409959813daefc1446a14247f1"
 
 [[package]]
 name = "dpns-contract"
-version = "3.0.0-dev.1"
+version = "3.0.0-dev.2"
 dependencies = [
  "platform-value",
  "platform-version",
@@ -1734,7 +1734,7 @@ dependencies = [
 
 [[package]]
 name = "dpp"
-version = "3.0.0-dev.1"
+version = "3.0.0-dev.2"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -1791,7 +1791,7 @@ dependencies = [
 
 [[package]]
 name = "drive"
-version = "3.0.0-dev.1"
+version = "3.0.0-dev.2"
 dependencies = [
  "arc-swap",
  "assert_matches",
@@ -1832,7 +1832,7 @@ dependencies = [
 
 [[package]]
 name = "drive-abci"
-version = "3.0.0-dev.1"
+version = "3.0.0-dev.2"
 dependencies = [
  "arc-swap",
  "assert_matches",
@@ -1886,7 +1886,7 @@ dependencies = [
 
 [[package]]
 name = "drive-proof-verifier"
-version = "3.0.0-dev.1"
+version = "3.0.0-dev.2"
 dependencies = [
  "bincode 2.0.0-rc.3",
  "dapi-grpc",
@@ -2139,7 +2139,7 @@ checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "feature-flags-contract"
-version = "3.0.0-dev.1"
+version = "3.0.0-dev.2"
 dependencies = [
  "platform-value",
  "platform-version",
@@ -3336,7 +3336,7 @@ dependencies = [
 
 [[package]]
 name = "json-schema-compatibility-validator"
-version = "3.0.0-dev.1"
+version = "3.0.0-dev.2"
 dependencies = [
  "assert_matches",
  "json-patch",
@@ -3455,7 +3455,7 @@ dependencies = [
 
 [[package]]
 name = "keyword-search-contract"
-version = "3.0.0-dev.1"
+version = "3.0.0-dev.2"
 dependencies = [
  "base58",
  "platform-value",
@@ -3616,7 +3616,7 @@ dependencies = [
 
 [[package]]
 name = "masternode-reward-shares-contract"
-version = "3.0.0-dev.1"
+version = "3.0.0-dev.2"
 dependencies = [
  "platform-value",
  "platform-version",
@@ -4278,7 +4278,7 @@ checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
 name = "platform-serialization"
-version = "3.0.0-dev.1"
+version = "3.0.0-dev.2"
 dependencies = [
  "bincode 2.0.0-rc.3",
  "platform-version",
@@ -4286,7 +4286,7 @@ dependencies = [
 
 [[package]]
 name = "platform-serialization-derive"
-version = "3.0.0-dev.1"
+version = "3.0.0-dev.2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4296,7 +4296,7 @@ dependencies = [
 
 [[package]]
 name = "platform-value"
-version = "3.0.0-dev.1"
+version = "3.0.0-dev.2"
 dependencies = [
  "base64 0.22.1",
  "bincode 2.0.0-rc.3",
@@ -4315,7 +4315,7 @@ dependencies = [
 
 [[package]]
 name = "platform-value-convertible"
-version = "3.0.0-dev.1"
+version = "3.0.0-dev.2"
 dependencies = [
  "quote",
  "syn 2.0.106",
@@ -4323,7 +4323,7 @@ dependencies = [
 
 [[package]]
 name = "platform-version"
-version = "3.0.0-dev.1"
+version = "3.0.0-dev.2"
 dependencies = [
  "bincode 2.0.0-rc.3",
  "grovedb-version",
@@ -4334,7 +4334,7 @@ dependencies = [
 
 [[package]]
 name = "platform-versioning"
-version = "3.0.0-dev.1"
+version = "3.0.0-dev.2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4343,7 +4343,7 @@ dependencies = [
 
 [[package]]
 name = "platform-wallet"
-version = "3.0.0-dev.1"
+version = "3.0.0-dev.2"
 dependencies = [
  "dashcore",
  "dpp",
@@ -5111,7 +5111,7 @@ dependencies = [
 
 [[package]]
 name = "rs-dapi"
-version = "3.0.0-dev.1"
+version = "3.0.0-dev.2"
 dependencies = [
  "async-trait",
  "axum 0.8.4",
@@ -5160,7 +5160,7 @@ dependencies = [
 
 [[package]]
 name = "rs-dapi-client"
-version = "3.0.0-dev.1"
+version = "3.0.0-dev.2"
 dependencies = [
  "backon",
  "chrono",
@@ -5185,7 +5185,7 @@ dependencies = [
 
 [[package]]
 name = "rs-dash-event-bus"
-version = "3.0.0-dev.1"
+version = "3.0.0-dev.2"
 dependencies = [
  "metrics",
  "tokio",
@@ -5194,7 +5194,7 @@ dependencies = [
 
 [[package]]
 name = "rs-sdk-ffi"
-version = "3.0.0-dev.1"
+version = "3.0.0-dev.2"
 dependencies = [
  "bincode 2.0.0-rc.3",
  "bs58",
@@ -5223,7 +5223,7 @@ dependencies = [
 
 [[package]]
 name = "rs-sdk-trusted-context-provider"
-version = "3.0.0-dev.1"
+version = "3.0.0-dev.2"
 dependencies = [
  "arc-swap",
  "dash-context-provider",
@@ -5885,7 +5885,7 @@ checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
 name = "simple-signer"
-version = "3.0.0-dev.1"
+version = "3.0.0-dev.2"
 dependencies = [
  "base64 0.22.1",
  "bincode 2.0.0-rc.3",
@@ -5982,7 +5982,7 @@ dependencies = [
 
 [[package]]
 name = "strategy-tests"
-version = "3.0.0-dev.1"
+version = "3.0.0-dev.2"
 dependencies = [
  "bincode 2.0.0-rc.3",
  "dpp",
@@ -6374,7 +6374,7 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "token-history-contract"
-version = "3.0.0-dev.1"
+version = "3.0.0-dev.2"
 dependencies = [
  "platform-value",
  "platform-version",
@@ -7091,7 +7091,7 @@ dependencies = [
 
 [[package]]
 name = "wallet-utils-contract"
-version = "3.0.0-dev.1"
+version = "3.0.0-dev.2"
 dependencies = [
  "platform-value",
  "platform-version",
@@ -7232,7 +7232,7 @@ dependencies = [
 
 [[package]]
 name = "wasm-dpp"
-version = "3.0.0-dev.1"
+version = "3.0.0-dev.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7273,7 +7273,7 @@ dependencies = [
 
 [[package]]
 name = "wasm-drive-verify"
-version = "3.0.0-dev.1"
+version = "3.0.0-dev.2"
 dependencies = [
  "base64 0.22.1",
  "bincode 2.0.0-rc.3",
@@ -7306,7 +7306,7 @@ dependencies = [
 
 [[package]]
 name = "wasm-sdk"
-version = "3.0.0-dev.1"
+version = "3.0.0-dev.2"
 dependencies = [
  "base64 0.22.1",
  "bip39",
@@ -7856,7 +7856,7 @@ checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"
 
 [[package]]
 name = "withdrawals-contract"
-version = "3.0.0-dev.1"
+version = "3.0.0-dev.2"
 dependencies = [
  "num_enum 0.5.11",
  "platform-value",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,5 +45,5 @@ members = [
 
 [workspace.package]
 
-version = "3.0.0-dev.1"
+version = "3.0.0-dev.2"
 rust-version = "1.92"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dashevo/platform",
-  "version": "3.0.0-dev.1",
+  "version": "3.0.0-dev.2",
   "private": true,
   "scripts": {
     "setup": "yarn install && yarn run build && yarn run configure",

--- a/packages/bench-suite/package.json
+++ b/packages/bench-suite/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@dashevo/bench-suite",
   "private": true,
-  "version": "3.0.0-dev.1",
+  "version": "3.0.0-dev.2",
   "description": "Dash Platform benchmark tool",
   "scripts": {
     "bench": "node ./bin/bench.js",

--- a/packages/dapi-grpc/package.json
+++ b/packages/dapi-grpc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dashevo/dapi-grpc",
-  "version": "3.0.0-dev.1",
+  "version": "3.0.0-dev.2",
   "description": "DAPI GRPC definition file and generated clients",
   "browser": "browser.js",
   "main": "node.js",

--- a/packages/dapi/package.json
+++ b/packages/dapi/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@dashevo/dapi",
   "private": true,
-  "version": "3.0.0-dev.1",
+  "version": "3.0.0-dev.2",
   "description": "A decentralized API for the Dash network",
   "scripts": {
     "api": "node scripts/api.js",

--- a/packages/dash-spv/package.json
+++ b/packages/dash-spv/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dashevo/dash-spv",
-  "version": "4.0.0-dev.1",
+  "version": "4.0.0-dev.2",
   "description": "Repository containing SPV functions used by @dashevo",
   "main": "index.js",
   "scripts": {

--- a/packages/dashmate/package.json
+++ b/packages/dashmate/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dashmate",
-  "version": "3.0.0-dev.1",
+  "version": "3.0.0-dev.2",
   "description": "Distribution package for Dash node installation",
   "scripts": {
     "lint": "eslint .",

--- a/packages/dashpay-contract/package.json
+++ b/packages/dashpay-contract/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dashevo/dashpay-contract",
-  "version": "3.0.0-dev.1",
+  "version": "3.0.0-dev.2",
   "description": "Reference contract of the DashPay DPA on Dash Evolution",
   "scripts": {
     "lint": "eslint .",

--- a/packages/dpns-contract/package.json
+++ b/packages/dpns-contract/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dashevo/dpns-contract",
-  "version": "3.0.0-dev.1",
+  "version": "3.0.0-dev.2",
   "description": "A contract and helper scripts for DPNS DApp",
   "scripts": {
     "lint": "eslint .",

--- a/packages/feature-flags-contract/package.json
+++ b/packages/feature-flags-contract/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dashevo/feature-flags-contract",
-  "version": "3.0.0-dev.1",
+  "version": "3.0.0-dev.2",
   "description": "Data Contract to store Dash Platform feature flags",
   "scripts": {
     "build": "",

--- a/packages/js-dapi-client/package.json
+++ b/packages/js-dapi-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dashevo/dapi-client",
-  "version": "3.0.0-dev.1",
+  "version": "3.0.0-dev.2",
   "description": "Client library used to access Dash DAPI endpoints",
   "main": "lib/index.js",
   "contributors": [

--- a/packages/js-dash-sdk/package.json
+++ b/packages/js-dash-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dash",
-  "version": "6.0.0-dev.1",
+  "version": "6.0.0-dev.2",
   "description": "Dash library for JavaScript/TypeScript ecosystem (Wallet, DAPI, Primitives, BLS, ...)",
   "main": "build/index.js",
   "unpkg": "dist/dash.min.js",

--- a/packages/js-evo-sdk/package.json
+++ b/packages/js-evo-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dashevo/evo-sdk",
-  "version": "3.0.0-dev.1",
+  "version": "3.0.0-dev.2",
   "type": "module",
   "main": "./dist/evo-sdk.module.js",
   "types": "./dist/sdk.d.ts",

--- a/packages/js-grpc-common/package.json
+++ b/packages/js-grpc-common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dashevo/grpc-common",
-  "version": "3.0.0-dev.1",
+  "version": "3.0.0-dev.2",
   "description": "Common GRPC library",
   "main": "index.js",
   "scripts": {

--- a/packages/keyword-search-contract/package.json
+++ b/packages/keyword-search-contract/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dashevo/keyword-search-contract",
-  "version": "3.0.0-dev.1",
+  "version": "3.0.0-dev.2",
   "description": "A contract that allows searching for contracts",
   "scripts": {
     "lint": "eslint .",

--- a/packages/masternode-reward-shares-contract/package.json
+++ b/packages/masternode-reward-shares-contract/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dashevo/masternode-reward-shares-contract",
-  "version": "3.0.0-dev.1",
+  "version": "3.0.0-dev.2",
   "description": "A contract and helper scripts for reward sharing",
   "scripts": {
     "lint": "eslint .",

--- a/packages/platform-test-suite/package.json
+++ b/packages/platform-test-suite/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@dashevo/platform-test-suite",
   "private": true,
-  "version": "3.0.0-dev.1",
+  "version": "3.0.0-dev.2",
   "description": "Dash Network end-to-end tests",
   "scripts": {
     "test": "yarn exec bin/test.sh",

--- a/packages/rs-drive-abci/src/config.rs
+++ b/packages/rs-drive-abci/src/config.rs
@@ -879,6 +879,8 @@ pub struct PlatformTestConfig {
     pub disable_instant_lock_signature_verification: bool,
     /// Disable temporarily disabled contested documents validation
     pub disable_contested_documents_is_allowed_validation: bool,
+    /// Disable checkpoint creation during tests
+    pub disable_checkpoints: bool,
 }
 
 #[cfg(feature = "testing-config")]
@@ -891,6 +893,7 @@ impl PlatformTestConfig {
             block_commit_signature_verification: false,
             disable_instant_lock_signature_verification: true,
             disable_contested_documents_is_allowed_validation: true,
+            disable_checkpoints: true,
         }
     }
 }
@@ -904,6 +907,7 @@ impl Default for PlatformTestConfig {
             block_commit_signature_verification: true,
             disable_instant_lock_signature_verification: false,
             disable_contested_documents_is_allowed_validation: true,
+            disable_checkpoints: true,
         }
     }
 }

--- a/packages/rs-drive-abci/src/execution/engine/finalize_block_proposal/v0/mod.rs
+++ b/packages/rs-drive-abci/src/execution/engine/finalize_block_proposal/v0/mod.rs
@@ -224,6 +224,8 @@ where
 
         self.update_drive_cache(&block_execution_context, platform_version)?;
 
+        self.update_checkpoints(&block_execution_context, platform_version)?;
+
         let block_platform_state = block_execution_context.block_platform_state_owned();
 
         self.update_state_cache(

--- a/packages/rs-drive-abci/src/execution/platform_events/block_end/update_checkpoints/mod.rs
+++ b/packages/rs-drive-abci/src/execution/platform_events/block_end/update_checkpoints/mod.rs
@@ -41,8 +41,9 @@ where
             .block_end
             .update_checkpoints
         {
-            0 => self.update_checkpoints_v0(block_execution_context, platform_version),
-            version => Err(Error::Execution(ExecutionError::UnknownVersionMismatch {
+            None => Ok(()),
+            Some(0) => self.update_checkpoints_v0(block_execution_context, platform_version),
+            Some(version) => Err(Error::Execution(ExecutionError::UnknownVersionMismatch {
                 method: "update_checkpoints".to_string(),
                 known_versions: vec![0],
                 received: version,

--- a/packages/rs-drive-abci/src/execution/platform_events/block_end/update_checkpoints/v0/mod.rs
+++ b/packages/rs-drive-abci/src/execution/platform_events/block_end/update_checkpoints/v0/mod.rs
@@ -22,6 +22,12 @@ where
         block_execution_context: &BlockExecutionContext,
         platform_version: &PlatformVersion,
     ) -> Result<(), Error> {
+        // Check if checkpoints are disabled in testing config
+        #[cfg(feature = "testing-config")]
+        if self.config.testing_configs.disable_checkpoints {
+            return Ok(());
+        }
+
         // How often we want a checkpoint
         let checkpoint_interval_milliseconds =
             platform_version.drive_abci.checkpoints.frequency_seconds as u64 * 1000;

--- a/packages/rs-drive-abci/src/platform_types/platform/mod.rs
+++ b/packages/rs-drive-abci/src/platform_types/platform/mod.rs
@@ -125,10 +125,18 @@ impl<C> Platform<C> {
     where
         C: CoreRPCLike,
     {
-        let config = config.unwrap_or(PlatformConfig::default_testnet());
+        let config = match config {
+            Some(config) => config,
+            None => {
+                // When using default config, set db_path to the provided path
+                let mut config = PlatformConfig::default_testnet();
+                config.db_path = path.as_ref().to_path_buf();
+                config
+            }
+        };
 
         let (drive, current_platform_version) =
-            Drive::open(path, Some(config.drive.clone())).map_err(Error::Drive)?;
+            Drive::open(&config.db_path, Some(config.drive.clone())).map_err(Error::Drive)?;
 
         if let Some(initial_protocol_version) = initial_protocol_version {
             if initial_protocol_version > 1 {

--- a/packages/rs-drive-abci/src/test/helpers/setup.rs
+++ b/packages/rs-drive-abci/src/test/helpers/setup.rs
@@ -71,9 +71,14 @@ impl TestPlatformBuilder {
             } else {
                 Some(PlatformVersion::latest().protocol_version)
             };
+        // Ensure db_path matches the tempdir path
+        let config = self.config.map(|mut c| {
+            c.db_path = self.tempdir.path().to_path_buf();
+            c
+        });
         let platform = Platform::<MockCoreRPCLike>::open(
             self.tempdir.path(),
-            self.config,
+            config,
             use_initial_protocol_version,
         )
         .expect("should open Platform successfully");
@@ -86,7 +91,12 @@ impl TestPlatformBuilder {
 
     /// Create a new temp platform with a default core rpc
     pub fn build_with_default_rpc(self) -> TempPlatform<DefaultCoreRPC> {
-        let platform = Platform::<DefaultCoreRPC>::open(self.tempdir.path(), self.config)
+        // Ensure db_path matches the tempdir path
+        let config = self.config.map(|mut c| {
+            c.db_path = self.tempdir.path().to_path_buf();
+            c
+        });
+        let platform = Platform::<DefaultCoreRPC>::open(self.tempdir.path(), config)
             .expect("should open Platform successfully");
 
         TempPlatform {
@@ -229,7 +239,9 @@ impl TempPlatform<MockCoreRPCLike> {
     }
 
     /// Rebuilds Platform from the tempdir as if it was destroyed and restarted
-    pub fn open_with_tempdir(tempdir: TempDir, config: PlatformConfig) -> Self {
+    pub fn open_with_tempdir(tempdir: TempDir, mut config: PlatformConfig) -> Self {
+        // Ensure db_path matches the tempdir path
+        config.db_path = tempdir.path().to_path_buf();
         let platform = Platform::<MockCoreRPCLike>::open(tempdir.path(), Some(config), None)
             .expect("should open Platform successfully");
 

--- a/packages/rs-drive-abci/tests/strategy_tests/test_cases/address_tests.rs
+++ b/packages/rs-drive-abci/tests/strategy_tests/test_cases/address_tests.rs
@@ -340,4 +340,102 @@ mod tests {
             "expected at least one identity to be created"
         );
     }
+
+    #[test]
+    fn run_chain_address_transitions_with_checkpoints() {
+        drive_abci::logging::init_for_tests(LogLevel::Debug);
+
+        let strategy = NetworkStrategy {
+            strategy: Strategy {
+                start_contracts: vec![],
+                operations: vec![
+                    Operation {
+                        op_type: OperationType::AddressTransfer(
+                            dash_to_credits!(5)..=dash_to_credits!(5),
+                            1..=4,
+                            Some(0.2),
+                            None,
+                        ),
+                        frequency: Frequency {
+                            times_per_block_range: 1..3,
+                            chance_per_block: None,
+                        },
+                    },
+                    Operation {
+                        op_type: OperationType::AddressFundingFromCoreAssetLock(
+                            dash_to_credits!(20)..=dash_to_credits!(20),
+                        ),
+                        frequency: Frequency {
+                            times_per_block_range: 1..3,
+                            chance_per_block: None,
+                        },
+                    },
+                ],
+                start_identities: StartIdentities::default(),
+                start_addresses: StartAddresses::default(),
+                identity_inserts: IdentityInsertInfo {
+                    frequency: Frequency {
+                        times_per_block_range: 1..2,
+                        chance_per_block: None,
+                    },
+                    ..Default::default()
+                },
+                identity_contract_nonce_gaps: None,
+                signer: None,
+            },
+            total_hpmns: 100,
+            extra_normal_mns: 0,
+            validator_quorum_count: 24,
+            chain_lock_quorum_count: 24,
+            upgrading_info: None,
+
+            proposer_strategy: Default::default(),
+            rotate_quorums: false,
+            failure_testing: None,
+            query_testing: None,
+            verify_state_transition_results: true,
+            sign_instant_locks: true,
+            ..Default::default()
+        };
+        let config = PlatformConfig {
+            validator_set: ValidatorSetConfig::default_100_67(),
+            chain_lock: ChainLockConfig::default_100_67(),
+            instant_lock: InstantLockConfig::default_100_67(),
+            execution: ExecutionConfig {
+                verify_sum_trees: true,
+
+                ..Default::default()
+            },
+            block_spacing_ms: 180000, // 3 mins
+            testing_configs: PlatformTestConfig {
+                disable_checkpoints: false,
+                ..PlatformTestConfig::default_minimal_verifications()
+            },
+            ..Default::default()
+        };
+        let mut platform = TestPlatformBuilder::new()
+            .with_config(config.clone())
+            .build_with_mock_rpc();
+
+        let outcome = run_chain_for_strategy(
+            &mut platform,
+            12,
+            strategy,
+            config,
+            15,
+            &mut None,
+            &mut None,
+        );
+
+        let executed = outcome
+            .state_transition_results_per_block
+            .values()
+            .flat_map(|results| results.iter())
+            .filter(|(state_transition, result)| {
+                result.code == 0
+                    && matches!(state_transition, StateTransition::AddressFundsTransfer(_))
+            })
+            .count();
+        assert!(executed > 0, "expected at least one address transfer");
+    }
 }

--- a/packages/rs-drive-abci/tests/strategy_tests/test_cases/voting_tests.rs
+++ b/packages/rs-drive-abci/tests/strategy_tests/test_cases/voting_tests.rs
@@ -53,6 +53,7 @@ mod tests {
                 block_commit_signature_verification: false,
                 disable_instant_lock_signature_verification: true,
                 disable_contested_documents_is_allowed_validation: false,
+                disable_checkpoints: true,
             },
             chain_lock: ChainLockConfig::default_100_67(),
             instant_lock: InstantLockConfig::default_100_67(),

--- a/packages/rs-platform-version/src/version/drive_abci_versions/drive_abci_method_versions/mod.rs
+++ b/packages/rs-platform-version/src/version/drive_abci_versions/drive_abci_method_versions/mod.rs
@@ -6,6 +6,7 @@ pub mod v3;
 pub mod v4;
 pub mod v5;
 pub mod v6;
+pub mod v7;
 
 #[derive(Clone, Debug, Default)]
 pub struct DriveAbciMethodVersions {
@@ -131,7 +132,7 @@ pub struct DriveAbciBlockEndMethodVersions {
     pub update_state_cache: FeatureVersion,
     pub update_drive_cache: FeatureVersion,
     pub validator_set_update: FeatureVersion,
-    pub update_checkpoints: FeatureVersion,
+    pub update_checkpoints: OptionalFeatureVersion,
 }
 
 #[derive(Clone, Debug, Default)]

--- a/packages/rs-platform-version/src/version/drive_abci_versions/drive_abci_method_versions/v1.rs
+++ b/packages/rs-platform-version/src/version/drive_abci_versions/drive_abci_method_versions/v1.rs
@@ -117,7 +117,7 @@ pub const DRIVE_ABCI_METHOD_VERSIONS_V1: DriveAbciMethodVersions = DriveAbciMeth
         update_state_cache: 0,
         update_drive_cache: 0,
         validator_set_update: 0,
-        update_checkpoints: 0,
+        update_checkpoints: None,
     },
     platform_state_storage: DriveAbciPlatformStateStorageMethodVersions {
         fetch_platform_state: 0,

--- a/packages/rs-platform-version/src/version/drive_abci_versions/drive_abci_method_versions/v3.rs
+++ b/packages/rs-platform-version/src/version/drive_abci_versions/drive_abci_method_versions/v3.rs
@@ -117,7 +117,7 @@ pub const DRIVE_ABCI_METHOD_VERSIONS_V3: DriveAbciMethodVersions = DriveAbciMeth
         update_state_cache: 0,
         update_drive_cache: 0,
         validator_set_update: 1,
-        update_checkpoints: 0,
+        update_checkpoints: None,
     },
     platform_state_storage: DriveAbciPlatformStateStorageMethodVersions {
         fetch_platform_state: 0,

--- a/packages/rs-platform-version/src/version/drive_abci_versions/drive_abci_method_versions/v4.rs
+++ b/packages/rs-platform-version/src/version/drive_abci_versions/drive_abci_method_versions/v4.rs
@@ -117,7 +117,7 @@ pub const DRIVE_ABCI_METHOD_VERSIONS_V4: DriveAbciMethodVersions = DriveAbciMeth
         update_state_cache: 0,
         update_drive_cache: 0,
         validator_set_update: 2,
-        update_checkpoints: 0,
+        update_checkpoints: None,
     },
     platform_state_storage: DriveAbciPlatformStateStorageMethodVersions {
         fetch_platform_state: 0,

--- a/packages/rs-platform-version/src/version/drive_abci_versions/drive_abci_method_versions/v5.rs
+++ b/packages/rs-platform-version/src/version/drive_abci_versions/drive_abci_method_versions/v5.rs
@@ -121,7 +121,7 @@ pub const DRIVE_ABCI_METHOD_VERSIONS_V5: DriveAbciMethodVersions = DriveAbciMeth
         update_state_cache: 0,
         update_drive_cache: 0,
         validator_set_update: 2,
-        update_checkpoints: 0,
+        update_checkpoints: None,
     },
     platform_state_storage: DriveAbciPlatformStateStorageMethodVersions {
         fetch_platform_state: 0,

--- a/packages/rs-platform-version/src/version/drive_abci_versions/drive_abci_method_versions/v6.rs
+++ b/packages/rs-platform-version/src/version/drive_abci_versions/drive_abci_method_versions/v6.rs
@@ -119,7 +119,7 @@ pub const DRIVE_ABCI_METHOD_VERSIONS_V6: DriveAbciMethodVersions = DriveAbciMeth
         update_state_cache: 0,
         update_drive_cache: 0,
         validator_set_update: 2,
-        update_checkpoints: 0,
+        update_checkpoints: None,
     },
     platform_state_storage: DriveAbciPlatformStateStorageMethodVersions {
         fetch_platform_state: 0,

--- a/packages/rs-platform-version/src/version/drive_abci_versions/drive_abci_method_versions/v7.rs
+++ b/packages/rs-platform-version/src/version/drive_abci_versions/drive_abci_method_versions/v7.rs
@@ -12,18 +12,18 @@ use crate::version::drive_abci_versions::drive_abci_method_versions::{
     DriveAbciVotingMethodVersions,
 };
 
-pub const DRIVE_ABCI_METHOD_VERSIONS_V2: DriveAbciMethodVersions = DriveAbciMethodVersions {
+// Introduced in Protocol version 11 (3.0.0) for checkpoints
+pub const DRIVE_ABCI_METHOD_VERSIONS_V7: DriveAbciMethodVersions = DriveAbciMethodVersions {
     engine: DriveAbciEngineMethodVersions {
         init_chain: 0,
         check_tx: 0,
         run_block_proposal: 0,
         finalize_block_proposal: 0,
-        // Update app version if changed as well
         consensus_params_update: 1,
     },
     initialization: DriveAbciInitializationMethodVersions {
         initial_core_height_and_time: 0,
-        create_genesis_state: 0,
+        create_genesis_state: 1,
     },
     core_based_updates: DriveAbciCoreBasedUpdatesMethodVersions {
         update_core_info: 0,
@@ -37,24 +37,24 @@ pub const DRIVE_ABCI_METHOD_VERSIONS_V2: DriveAbciMethodVersions = DriveAbciMeth
             get_voter_identifier_from_masternode_list_item: 0,
             get_operator_identifier_from_masternode_list_item: 0,
             create_operator_identity: 0,
-            create_owner_identity: 0,
+            create_owner_identity: 1,
             create_voter_identity: 0,
             disable_identity_keys: 0,
             update_masternode_identities: 0,
             update_operator_identity: 0,
-            update_owner_withdrawal_address: 0,
+            update_owner_withdrawal_address: 1,
             update_voter_identity: 0,
         },
     },
     protocol_upgrade: DriveAbciProtocolUpgradeMethodVersions {
         check_for_desired_protocol_upgrade: 1,
         upgrade_protocol_version_on_epoch_change: 0,
-        perform_events_on_first_block_of_protocol_change: None,
+        perform_events_on_first_block_of_protocol_change: Some(0),
         protocol_version_upgrade_percentage_needed: 67,
     },
     block_fee_processing: DriveAbciBlockFeeProcessingMethodVersions {
         add_process_epoch_change_operations: 0,
-        process_block_fees_and_validate_sum_trees: 0,
+        process_block_fees_and_validate_sum_trees: 1,
     },
     tokens_processing: DriveAbciTokensProcessingMethodVersions {
         validate_token_aggregated_balance: 0,
@@ -75,7 +75,7 @@ pub const DRIVE_ABCI_METHOD_VERSIONS_V2: DriveAbciMethodVersions = DriveAbciMeth
         add_distribute_storage_fee_to_epochs_operations: 0,
     },
     fee_pool_outwards_distribution: DriveAbciFeePoolOutwardsDistributionMethodVersions {
-        add_distribute_fees_from_oldest_unpaid_epoch_pool_to_proposers_operations: 0,
+        add_distribute_fees_from_oldest_unpaid_epoch_pool_to_proposers_operations: 1,
         add_epoch_pool_to_proposers_payout_operations: 0,
         find_oldest_epoch_needing_payment: 0,
         fetch_reward_shares_list_for_masternode: 0,
@@ -84,16 +84,16 @@ pub const DRIVE_ABCI_METHOD_VERSIONS_V2: DriveAbciMethodVersions = DriveAbciMeth
         build_untied_withdrawal_transactions_from_documents: 0,
         dequeue_and_build_unsigned_withdrawal_transactions: 0,
         fetch_transactions_block_inclusion_status: 0,
-        pool_withdrawals_into_transactions_queue: 0,
+        pool_withdrawals_into_transactions_queue: 1,
         update_broadcasted_withdrawal_statuses: 0,
-        rebroadcast_expired_withdrawal_documents: 0,
+        rebroadcast_expired_withdrawal_documents: 1,
         append_signatures_and_broadcast_withdrawal_transactions: 0,
         cleanup_expired_locks_of_withdrawal_amounts: 0,
     },
     voting: DriveAbciVotingMethodVersions {
         keep_record_of_finished_contested_resource_vote_poll: 0,
         clean_up_after_vote_poll_end: 0,
-        clean_up_after_contested_resources_vote_poll_end: 0,
+        clean_up_after_contested_resources_vote_poll_end: 1,
         check_for_ended_vote_polls: 0,
         tally_votes_for_contested_document_resource_vote_poll: 0,
         award_document_to_winner: 0,
@@ -117,8 +117,8 @@ pub const DRIVE_ABCI_METHOD_VERSIONS_V2: DriveAbciMethodVersions = DriveAbciMeth
     block_end: DriveAbciBlockEndMethodVersions {
         update_state_cache: 0,
         update_drive_cache: 0,
-        validator_set_update: 0,
-        update_checkpoints: None,
+        validator_set_update: 2,
+        update_checkpoints: Some(1),
     },
     platform_state_storage: DriveAbciPlatformStateStorageMethodVersions {
         fetch_platform_state: 0,

--- a/packages/rs-platform-version/src/version/drive_abci_versions/drive_abci_method_versions/v7.rs
+++ b/packages/rs-platform-version/src/version/drive_abci_versions/drive_abci_method_versions/v7.rs
@@ -118,7 +118,7 @@ pub const DRIVE_ABCI_METHOD_VERSIONS_V7: DriveAbciMethodVersions = DriveAbciMeth
         update_state_cache: 0,
         update_drive_cache: 0,
         validator_set_update: 2,
-        update_checkpoints: Some(1),
+        update_checkpoints: Some(0),
     },
     platform_state_storage: DriveAbciPlatformStateStorageMethodVersions {
         fetch_platform_state: 0,

--- a/packages/rs-platform-version/src/version/mocks/v3_test.rs
+++ b/packages/rs-platform-version/src/version/mocks/v3_test.rs
@@ -152,7 +152,7 @@ pub const TEST_PLATFORM_V3: PlatformVersion = PlatformVersion {
                 update_state_cache: 0,
                 update_drive_cache: 0,
                 validator_set_update: 0,
-                update_checkpoints: 0,
+                update_checkpoints: None,
             },
             platform_state_storage: DriveAbciPlatformStateStorageMethodVersions {
                 fetch_platform_state: 0,

--- a/packages/rs-platform-version/src/version/v11.rs
+++ b/packages/rs-platform-version/src/version/v11.rs
@@ -15,7 +15,7 @@ use crate::version::dpp_versions::dpp_validation_versions::v2::DPP_VALIDATION_VE
 use crate::version::dpp_versions::dpp_voting_versions::v2::VOTING_VERSION_V2;
 use crate::version::dpp_versions::DPPVersion;
 use crate::version::drive_abci_versions::drive_abci_checkpoint_parameters::v1::DRIVE_ABCI_CHECKPOINT_PARAMETERS_V1;
-use crate::version::drive_abci_versions::drive_abci_method_versions::v6::DRIVE_ABCI_METHOD_VERSIONS_V6;
+use crate::version::drive_abci_versions::drive_abci_method_versions::v7::DRIVE_ABCI_METHOD_VERSIONS_V7;
 use crate::version::drive_abci_versions::drive_abci_query_versions::v1::DRIVE_ABCI_QUERY_VERSIONS_V1;
 use crate::version::drive_abci_versions::drive_abci_structure_versions::v1::DRIVE_ABCI_STRUCTURE_VERSIONS_V1;
 use crate::version::drive_abci_versions::drive_abci_validation_versions::v7::DRIVE_ABCI_VALIDATION_VERSIONS_V7;
@@ -30,13 +30,13 @@ use crate::version::ProtocolVersion;
 
 pub const PROTOCOL_VERSION_11: ProtocolVersion = 11;
 
-/// This version was for Platform release 2.2.0
+/// This version was for Platform release 3.0.0
 pub const PLATFORM_V11: PlatformVersion = PlatformVersion {
     protocol_version: PROTOCOL_VERSION_11,
     drive: DRIVE_VERSION_V6, // Changed to fix identity update issue
     drive_abci: DriveAbciVersion {
         structs: DRIVE_ABCI_STRUCTURE_VERSIONS_V1,
-        methods: DRIVE_ABCI_METHOD_VERSIONS_V6,
+        methods: DRIVE_ABCI_METHOD_VERSIONS_V7, //update checkpoints change
         validation_and_processing: DRIVE_ABCI_VALIDATION_VERSIONS_V7, // changed for validate_unique_identity_public_key_hashes_in_state
         withdrawal_constants: DRIVE_ABCI_WITHDRAWAL_CONSTANTS_V2,
         query: DRIVE_ABCI_QUERY_VERSIONS_V1,

--- a/packages/token-history-contract/package.json
+++ b/packages/token-history-contract/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dashevo/token-history-contract",
-  "version": "3.0.0-dev.1",
+  "version": "3.0.0-dev.2",
   "description": "The token history contract",
   "scripts": {
     "lint": "eslint .",

--- a/packages/wallet-lib/package.json
+++ b/packages/wallet-lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dashevo/wallet-lib",
-  "version": "10.0.0-dev.1",
+  "version": "10.0.0-dev.2",
   "description": "Light wallet library for Dash",
   "main": "src/index.js",
   "unpkg": "dist/wallet-lib.min.js",

--- a/packages/wallet-utils-contract/package.json
+++ b/packages/wallet-utils-contract/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dashevo/wallet-utils-contract",
-  "version": "3.0.0-dev.1",
+  "version": "3.0.0-dev.2",
   "description": "A contract and helper scripts for Wallet DApp",
   "scripts": {
     "lint": "eslint .",

--- a/packages/wasm-dpp/package.json
+++ b/packages/wasm-dpp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dashevo/wasm-dpp",
-  "version": "3.0.0-dev.1",
+  "version": "3.0.0-dev.2",
   "description": "The JavaScript implementation of the Dash Platform Protocol",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/wasm-dpp2/package.json
+++ b/packages/wasm-dpp2/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dashevo/wasm-dpp2",
-  "version": "3.0.0-dev.1",
+  "version": "3.0.0-dev.2",
   "type": "module",
   "main": "./dist/dpp.js",
   "types": "./dist/dpp.d.ts",

--- a/packages/wasm-drive-verify/package.json
+++ b/packages/wasm-drive-verify/package.json
@@ -3,7 +3,7 @@
   "collaborators": [
     "Dash Core Group <dev@dash.org>"
   ],
-  "version": "3.0.0-dev.1",
+  "version": "3.0.0-dev.2",
   "license": "MIT",
   "description": "WASM bindings for Drive verify functions",
   "repository": {

--- a/packages/wasm-sdk/package.json
+++ b/packages/wasm-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dashevo/wasm-sdk",
-  "version": "3.0.0-dev.1",
+  "version": "3.0.0-dev.2",
   "type": "module",
   "main": "./dist/sdk.js",
   "types": "./dist/sdk.d.ts",

--- a/packages/withdrawals-contract/package.json
+++ b/packages/withdrawals-contract/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dashevo/withdrawals-contract",
-  "version": "3.0.0-dev.1",
+  "version": "3.0.0-dev.2",
   "description": "Data Contract to manipulate and track withdrawals",
   "scripts": {
     "build": "",


### PR DESCRIPTION
We were not calling update checkpoints. This fixes that. Added a test. Also bumped versions to 3.0.0-dev.2.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Bumped workspace package versions from 3.0.0-dev.1 to 3.0.0-dev.2 across the project. Applied separate version updates to specific packages: dash-spv (4.0.0-dev.2), js-dash-sdk (6.0.0-dev.2), and wallet-lib (10.0.0-dev.2).
  * Updated Platform v11 release documentation to reflect Platform release 3.0.0.
  * Added testing configuration options and infrastructure improvements for checkpoint management.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->