### PR TITLE
fix(drive-abci): update to version 11 should correctly use a provable count sum tree.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -871,7 +871,7 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "check-features"
-version = "3.0.0-dev.2"
+version = "3.0.0-dev.3"
 dependencies = [
  "toml",
 ]
@@ -1296,7 +1296,7 @@ dependencies = [
 
 [[package]]
 name = "dapi-grpc"
-version = "3.0.0-dev.2"
+version = "3.0.0-dev.3"
 dependencies = [
  "dash-platform-macros",
  "futures-core",
@@ -1349,7 +1349,7 @@ dependencies = [
 
 [[package]]
 name = "dash-context-provider"
-version = "3.0.0-dev.2"
+version = "3.0.0-dev.3"
 dependencies = [
  "dpp",
  "drive",
@@ -1371,7 +1371,7 @@ dependencies = [
 
 [[package]]
 name = "dash-platform-balance-checker"
-version = "3.0.0-dev.2"
+version = "3.0.0-dev.3"
 dependencies = [
  "anyhow",
  "clap",
@@ -1386,7 +1386,7 @@ dependencies = [
 
 [[package]]
 name = "dash-platform-macros"
-version = "3.0.0-dev.2"
+version = "3.0.0-dev.3"
 dependencies = [
  "heck 0.5.0",
  "quote",
@@ -1395,7 +1395,7 @@ dependencies = [
 
 [[package]]
 name = "dash-sdk"
-version = "3.0.0-dev.2"
+version = "3.0.0-dev.3"
 dependencies = [
  "arc-swap",
  "assert_matches",
@@ -1567,7 +1567,7 @@ dependencies = [
 
 [[package]]
 name = "dashpay-contract"
-version = "3.0.0-dev.2"
+version = "3.0.0-dev.3"
 dependencies = [
  "platform-value",
  "platform-version",
@@ -1577,7 +1577,7 @@ dependencies = [
 
 [[package]]
 name = "data-contracts"
-version = "3.0.0-dev.2"
+version = "3.0.0-dev.3"
 dependencies = [
  "dashpay-contract",
  "dpns-contract",
@@ -1724,7 +1724,7 @@ checksum = "1435fa1053d8b2fbbe9be7e97eca7f33d37b28409959813daefc1446a14247f1"
 
 [[package]]
 name = "dpns-contract"
-version = "3.0.0-dev.2"
+version = "3.0.0-dev.3"
 dependencies = [
  "platform-value",
  "platform-version",
@@ -1734,7 +1734,7 @@ dependencies = [
 
 [[package]]
 name = "dpp"
-version = "3.0.0-dev.2"
+version = "3.0.0-dev.3"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -1791,7 +1791,7 @@ dependencies = [
 
 [[package]]
 name = "drive"
-version = "3.0.0-dev.2"
+version = "3.0.0-dev.3"
 dependencies = [
  "arc-swap",
  "assert_matches",
@@ -1832,7 +1832,7 @@ dependencies = [
 
 [[package]]
 name = "drive-abci"
-version = "3.0.0-dev.2"
+version = "3.0.0-dev.3"
 dependencies = [
  "arc-swap",
  "assert_matches",
@@ -1886,7 +1886,7 @@ dependencies = [
 
 [[package]]
 name = "drive-proof-verifier"
-version = "3.0.0-dev.2"
+version = "3.0.0-dev.3"
 dependencies = [
  "bincode 2.0.0-rc.3",
  "dapi-grpc",
@@ -2139,7 +2139,7 @@ checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "feature-flags-contract"
-version = "3.0.0-dev.2"
+version = "3.0.0-dev.3"
 dependencies = [
  "platform-value",
  "platform-version",
@@ -3336,7 +3336,7 @@ dependencies = [
 
 [[package]]
 name = "json-schema-compatibility-validator"
-version = "3.0.0-dev.2"
+version = "3.0.0-dev.3"
 dependencies = [
  "assert_matches",
  "json-patch",
@@ -3455,7 +3455,7 @@ dependencies = [
 
 [[package]]
 name = "keyword-search-contract"
-version = "3.0.0-dev.2"
+version = "3.0.0-dev.3"
 dependencies = [
  "base58",
  "platform-value",
@@ -3616,7 +3616,7 @@ dependencies = [
 
 [[package]]
 name = "masternode-reward-shares-contract"
-version = "3.0.0-dev.2"
+version = "3.0.0-dev.3"
 dependencies = [
  "platform-value",
  "platform-version",
@@ -4278,7 +4278,7 @@ checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
 name = "platform-serialization"
-version = "3.0.0-dev.2"
+version = "3.0.0-dev.3"
 dependencies = [
  "bincode 2.0.0-rc.3",
  "platform-version",
@@ -4286,7 +4286,7 @@ dependencies = [
 
 [[package]]
 name = "platform-serialization-derive"
-version = "3.0.0-dev.2"
+version = "3.0.0-dev.3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4296,7 +4296,7 @@ dependencies = [
 
 [[package]]
 name = "platform-value"
-version = "3.0.0-dev.2"
+version = "3.0.0-dev.3"
 dependencies = [
  "base64 0.22.1",
  "bincode 2.0.0-rc.3",
@@ -4315,7 +4315,7 @@ dependencies = [
 
 [[package]]
 name = "platform-value-convertible"
-version = "3.0.0-dev.2"
+version = "3.0.0-dev.3"
 dependencies = [
  "quote",
  "syn 2.0.106",
@@ -4323,7 +4323,7 @@ dependencies = [
 
 [[package]]
 name = "platform-version"
-version = "3.0.0-dev.2"
+version = "3.0.0-dev.3"
 dependencies = [
  "bincode 2.0.0-rc.3",
  "grovedb-version",
@@ -4334,7 +4334,7 @@ dependencies = [
 
 [[package]]
 name = "platform-versioning"
-version = "3.0.0-dev.2"
+version = "3.0.0-dev.3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4343,7 +4343,7 @@ dependencies = [
 
 [[package]]
 name = "platform-wallet"
-version = "3.0.0-dev.2"
+version = "3.0.0-dev.3"
 dependencies = [
  "dashcore",
  "dpp",
@@ -5111,7 +5111,7 @@ dependencies = [
 
 [[package]]
 name = "rs-dapi"
-version = "3.0.0-dev.2"
+version = "3.0.0-dev.3"
 dependencies = [
  "async-trait",
  "axum 0.8.4",
@@ -5160,7 +5160,7 @@ dependencies = [
 
 [[package]]
 name = "rs-dapi-client"
-version = "3.0.0-dev.2"
+version = "3.0.0-dev.3"
 dependencies = [
  "backon",
  "chrono",
@@ -5185,7 +5185,7 @@ dependencies = [
 
 [[package]]
 name = "rs-dash-event-bus"
-version = "3.0.0-dev.2"
+version = "3.0.0-dev.3"
 dependencies = [
  "metrics",
  "tokio",
@@ -5194,7 +5194,7 @@ dependencies = [
 
 [[package]]
 name = "rs-sdk-ffi"
-version = "3.0.0-dev.2"
+version = "3.0.0-dev.3"
 dependencies = [
  "bincode 2.0.0-rc.3",
  "bs58",
@@ -5223,7 +5223,7 @@ dependencies = [
 
 [[package]]
 name = "rs-sdk-trusted-context-provider"
-version = "3.0.0-dev.2"
+version = "3.0.0-dev.3"
 dependencies = [
  "arc-swap",
  "dash-context-provider",
@@ -5885,7 +5885,7 @@ checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
 name = "simple-signer"
-version = "3.0.0-dev.2"
+version = "3.0.0-dev.3"
 dependencies = [
  "base64 0.22.1",
  "bincode 2.0.0-rc.3",
@@ -5982,7 +5982,7 @@ dependencies = [
 
 [[package]]
 name = "strategy-tests"
-version = "3.0.0-dev.2"
+version = "3.0.0-dev.3"
 dependencies = [
  "bincode 2.0.0-rc.3",
  "dpp",
@@ -6374,7 +6374,7 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "token-history-contract"
-version = "3.0.0-dev.2"
+version = "3.0.0-dev.3"
 dependencies = [
  "platform-value",
  "platform-version",
@@ -7091,7 +7091,7 @@ dependencies = [
 
 [[package]]
 name = "wallet-utils-contract"
-version = "3.0.0-dev.2"
+version = "3.0.0-dev.3"
 dependencies = [
  "platform-value",
  "platform-version",
@@ -7232,7 +7232,7 @@ dependencies = [
 
 [[package]]
 name = "wasm-dpp"
-version = "3.0.0-dev.2"
+version = "3.0.0-dev.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7273,7 +7273,7 @@ dependencies = [
 
 [[package]]
 name = "wasm-drive-verify"
-version = "3.0.0-dev.2"
+version = "3.0.0-dev.3"
 dependencies = [
  "base64 0.22.1",
  "bincode 2.0.0-rc.3",
@@ -7306,7 +7306,7 @@ dependencies = [
 
 [[package]]
 name = "wasm-sdk"
-version = "3.0.0-dev.2"
+version = "3.0.0-dev.3"
 dependencies = [
  "base64 0.22.1",
  "bip39",
@@ -7856,7 +7856,7 @@ checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"
 
 [[package]]
 name = "withdrawals-contract"
-version = "3.0.0-dev.2"
+version = "3.0.0-dev.3"
 dependencies = [
  "num_enum 0.5.11",
  "platform-value",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,5 +45,5 @@ members = [
 
 [workspace.package]
 
-version = "3.0.0-dev.2"
+version = "3.0.0-dev.3"
 rust-version = "1.92"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dashevo/platform",
-  "version": "3.0.0-dev.2",
+  "version": "3.0.0-dev.3",
   "private": true,
   "scripts": {
     "setup": "yarn install && yarn run build && yarn run configure",

--- a/packages/bench-suite/package.json
+++ b/packages/bench-suite/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@dashevo/bench-suite",
   "private": true,
-  "version": "3.0.0-dev.2",
+  "version": "3.0.0-dev.3",
   "description": "Dash Platform benchmark tool",
   "scripts": {
     "bench": "node ./bin/bench.js",

--- a/packages/dapi-grpc/package.json
+++ b/packages/dapi-grpc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dashevo/dapi-grpc",
-  "version": "3.0.0-dev.2",
+  "version": "3.0.0-dev.3",
   "description": "DAPI GRPC definition file and generated clients",
   "browser": "browser.js",
   "main": "node.js",

--- a/packages/dapi/package.json
+++ b/packages/dapi/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@dashevo/dapi",
   "private": true,
-  "version": "3.0.0-dev.2",
+  "version": "3.0.0-dev.3",
   "description": "A decentralized API for the Dash network",
   "scripts": {
     "api": "node scripts/api.js",

--- a/packages/dash-spv/package.json
+++ b/packages/dash-spv/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dashevo/dash-spv",
-  "version": "4.0.0-dev.2",
+  "version": "4.0.0-dev.3",
   "description": "Repository containing SPV functions used by @dashevo",
   "main": "index.js",
   "scripts": {

--- a/packages/dashmate/package.json
+++ b/packages/dashmate/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dashmate",
-  "version": "3.0.0-dev.2",
+  "version": "3.0.0-dev.3",
   "description": "Distribution package for Dash node installation",
   "scripts": {
     "lint": "eslint .",

--- a/packages/dashpay-contract/package.json
+++ b/packages/dashpay-contract/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dashevo/dashpay-contract",
-  "version": "3.0.0-dev.2",
+  "version": "3.0.0-dev.3",
   "description": "Reference contract of the DashPay DPA on Dash Evolution",
   "scripts": {
     "lint": "eslint .",

--- a/packages/dpns-contract/package.json
+++ b/packages/dpns-contract/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dashevo/dpns-contract",
-  "version": "3.0.0-dev.2",
+  "version": "3.0.0-dev.3",
   "description": "A contract and helper scripts for DPNS DApp",
   "scripts": {
     "lint": "eslint .",

--- a/packages/feature-flags-contract/package.json
+++ b/packages/feature-flags-contract/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dashevo/feature-flags-contract",
-  "version": "3.0.0-dev.2",
+  "version": "3.0.0-dev.3",
   "description": "Data Contract to store Dash Platform feature flags",
   "scripts": {
     "build": "",

--- a/packages/js-dapi-client/package.json
+++ b/packages/js-dapi-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dashevo/dapi-client",
-  "version": "3.0.0-dev.2",
+  "version": "3.0.0-dev.3",
   "description": "Client library used to access Dash DAPI endpoints",
   "main": "lib/index.js",
   "contributors": [

--- a/packages/js-dash-sdk/package.json
+++ b/packages/js-dash-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dash",
-  "version": "6.0.0-dev.2",
+  "version": "6.0.0-dev.3",
   "description": "Dash library for JavaScript/TypeScript ecosystem (Wallet, DAPI, Primitives, BLS, ...)",
   "main": "build/index.js",
   "unpkg": "dist/dash.min.js",

--- a/packages/js-evo-sdk/package.json
+++ b/packages/js-evo-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dashevo/evo-sdk",
-  "version": "3.0.0-dev.2",
+  "version": "3.0.0-dev.3",
   "type": "module",
   "main": "./dist/evo-sdk.module.js",
   "types": "./dist/sdk.d.ts",

--- a/packages/js-grpc-common/package.json
+++ b/packages/js-grpc-common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dashevo/grpc-common",
-  "version": "3.0.0-dev.2",
+  "version": "3.0.0-dev.3",
   "description": "Common GRPC library",
   "main": "index.js",
   "scripts": {

--- a/packages/keyword-search-contract/package.json
+++ b/packages/keyword-search-contract/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dashevo/keyword-search-contract",
-  "version": "3.0.0-dev.2",
+  "version": "3.0.0-dev.3",
   "description": "A contract that allows searching for contracts",
   "scripts": {
     "lint": "eslint .",

--- a/packages/masternode-reward-shares-contract/package.json
+++ b/packages/masternode-reward-shares-contract/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dashevo/masternode-reward-shares-contract",
-  "version": "3.0.0-dev.2",
+  "version": "3.0.0-dev.3",
   "description": "A contract and helper scripts for reward sharing",
   "scripts": {
     "lint": "eslint .",

--- a/packages/platform-test-suite/package.json
+++ b/packages/platform-test-suite/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@dashevo/platform-test-suite",
   "private": true,
-  "version": "3.0.0-dev.2",
+  "version": "3.0.0-dev.3",
   "description": "Dash Network end-to-end tests",
   "scripts": {
     "test": "yarn exec bin/test.sh",

--- a/packages/rs-drive-abci/src/execution/platform_events/protocol_upgrade/perform_events_on_first_block_of_protocol_change/v0/mod.rs
+++ b/packages/rs-drive-abci/src/execution/platform_events/protocol_upgrade/perform_events_on_first_block_of_protocol_change/v0/mod.rs
@@ -547,7 +547,7 @@ impl<C> Platform<C> {
         self.drive.grove_insert_if_not_exists(
             path.as_slice().into(),
             &[CLEAR_ADDRESS_POOL_U8],
-            Element::empty_sum_tree(),
+            Element::empty_provable_count_sum_tree(),
             Some(transaction),
             None,
             &platform_version.drive,

--- a/packages/rs-drive-abci/tests/strategy_tests/test_cases/address_tests.rs
+++ b/packages/rs-drive-abci/tests/strategy_tests/test_cases/address_tests.rs
@@ -6,6 +6,7 @@ mod tests {
     use dpp::dash_to_credits;
     use dpp::identity::{KeyType, Purpose, SecurityLevel};
     use dpp::state_transition::StateTransition;
+    use drive::drive::Drive;
     use drive_abci::config::{
         ChainLockConfig, ExecutionConfig, InstantLockConfig, PlatformConfig, PlatformTestConfig,
         ValidatorSetConfig,
@@ -437,5 +438,40 @@ mod tests {
             })
             .count();
         assert!(executed > 0, "expected at least one address transfer");
+
+        // Drop outcome to release the mutable borrow of platform
+        drop(outcome);
+
+        // Test prove_address_funds_trunk_query
+        let platform_version = PlatformVersion::latest();
+
+        let proof = platform
+            .drive
+            .prove_address_funds_trunk_query(platform_version)
+            .expect("should generate trunk query proof");
+
+        assert!(!proof.is_empty(), "proof should not be empty");
+
+        // Verify the proof
+        let (root_hash, trunk_result) =
+            Drive::verify_address_funds_trunk_query(&proof, platform_version)
+                .expect("should verify trunk query proof");
+
+        // The root hash should be valid (32 bytes)
+        assert_eq!(root_hash.len(), 32, "root hash should be 32 bytes");
+
+        // Check that we got some elements or leaf keys from the trunk query
+        let total_items = trunk_result.elements.len() + trunk_result.leaf_keys.len();
+        assert!(
+            total_items > 0,
+            "trunk query should return elements or leaf keys"
+        );
+
+        println!(
+            "Trunk query result: {} elements, {} leaf keys, chunk_depths: {:?}",
+            trunk_result.elements.len(),
+            trunk_result.leaf_keys.len(),
+            trunk_result.chunk_depths
+        );
     }
 }

--- a/packages/token-history-contract/package.json
+++ b/packages/token-history-contract/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dashevo/token-history-contract",
-  "version": "3.0.0-dev.2",
+  "version": "3.0.0-dev.3",
   "description": "The token history contract",
   "scripts": {
     "lint": "eslint .",

--- a/packages/wallet-lib/package.json
+++ b/packages/wallet-lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dashevo/wallet-lib",
-  "version": "10.0.0-dev.2",
+  "version": "10.0.0-dev.3",
   "description": "Light wallet library for Dash",
   "main": "src/index.js",
   "unpkg": "dist/wallet-lib.min.js",

--- a/packages/wallet-utils-contract/package.json
+++ b/packages/wallet-utils-contract/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dashevo/wallet-utils-contract",
-  "version": "3.0.0-dev.2",
+  "version": "3.0.0-dev.3",
   "description": "A contract and helper scripts for Wallet DApp",
   "scripts": {
     "lint": "eslint .",

--- a/packages/wasm-dpp/package.json
+++ b/packages/wasm-dpp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dashevo/wasm-dpp",
-  "version": "3.0.0-dev.2",
+  "version": "3.0.0-dev.3",
   "description": "The JavaScript implementation of the Dash Platform Protocol",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/wasm-dpp2/package.json
+++ b/packages/wasm-dpp2/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dashevo/wasm-dpp2",
-  "version": "3.0.0-dev.2",
+  "version": "3.0.0-dev.3",
   "type": "module",
   "main": "./dist/dpp.js",
   "types": "./dist/dpp.d.ts",

--- a/packages/wasm-drive-verify/package.json
+++ b/packages/wasm-drive-verify/package.json
@@ -3,7 +3,7 @@
   "collaborators": [
     "Dash Core Group <dev@dash.org>"
   ],
-  "version": "3.0.0-dev.2",
+  "version": "3.0.0-dev.3",
   "license": "MIT",
   "description": "WASM bindings for Drive verify functions",
   "repository": {

--- a/packages/wasm-sdk/package.json
+++ b/packages/wasm-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dashevo/wasm-sdk",
-  "version": "3.0.0-dev.2",
+  "version": "3.0.0-dev.3",
   "type": "module",
   "main": "./dist/sdk.js",
   "types": "./dist/sdk.d.ts",

--- a/packages/withdrawals-contract/package.json
+++ b/packages/withdrawals-contract/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dashevo/withdrawals-contract",
-  "version": "3.0.0-dev.2",
+  "version": "3.0.0-dev.3",
   "description": "Data Contract to manipulate and track withdrawals",
   "scripts": {
     "build": "",


### PR DESCRIPTION
In transition_to_version_11 we had forgotten to use a `empty_provable_count_sum_tree`. This fixes this.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Development version bumped to 3.0.0-dev.3 across all packages (3.0.0-dev.2 → 3.0.0-dev.3; dash-spv: 4.0.0-dev.2 → 4.0.0-dev.3).
  * Internal improvements to protocol upgrade handling and address fund verification testing.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->