### PR TITLE
feat(sdk): query platform addresses in JS SDK

### DIFF
--- a/packages/js-evo-sdk/src/addresses/facade.ts
+++ b/packages/js-evo-sdk/src/addresses/facade.ts
@@ -1,0 +1,56 @@
+import * as wasm from '../wasm.js';
+import type { EvoSDK } from '../sdk.js';
+
+export class AddressesFacade {
+  private sdk: EvoSDK;
+
+  constructor(sdk: EvoSDK) {
+    this.sdk = sdk;
+  }
+
+  /**
+   * Fetches information about a Platform address including its nonce and balance.
+   *
+   * @param address - The platform address to query (PlatformAddress, Uint8Array, or bech32m string)
+   * @returns AddressInfo containing address, nonce, and balance, or undefined if not found
+   */
+  async get(address: wasm.PlatformAddressLike): Promise<wasm.AddressInfo | undefined> {
+    const w = await this.sdk.getWasmSdkConnected();
+    return w.getAddressInfo(address);
+  }
+
+  /**
+   * Fetches information about a Platform address with proof.
+   *
+   * @param address - The platform address to query (PlatformAddress, Uint8Array, or bech32m string)
+   * @returns ProofMetadataResponse containing AddressInfo with proof information
+   */
+  async getWithProof(address: wasm.PlatformAddressLike): Promise<wasm.ProofMetadataResponseTyped<wasm.AddressInfo>> {
+    const w = await this.sdk.getWasmSdkConnected();
+    return w.getAddressInfoWithProofInfo(address);
+  }
+
+  /**
+   * Fetches information about multiple Platform addresses.
+   *
+   * @param addresses - Array of platform addresses to query
+   * @returns Map of PlatformAddress to AddressInfo (or undefined for unfunded addresses)
+   */
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  async getMany(addresses: wasm.PlatformAddressLike[]): Promise<Map<any, any>> {
+    const w = await this.sdk.getWasmSdkConnected();
+    return w.getAddressesInfos(addresses);
+  }
+
+  /**
+   * Fetches information about multiple Platform addresses with proof.
+   *
+   * @param addresses - Array of platform addresses to query
+   * @returns ProofMetadataResponse containing Map of PlatformAddress to AddressInfo
+   */
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  async getManyWithProof(addresses: wasm.PlatformAddressLike[]): Promise<wasm.ProofMetadataResponseTyped<Map<any, any>>> {
+    const w = await this.sdk.getWasmSdkConnected();
+    return w.getAddressesInfosWithProofInfo(addresses);
+  }
+}

--- a/packages/js-evo-sdk/src/addresses/facade.ts
+++ b/packages/js-evo-sdk/src/addresses/facade.ts
@@ -12,9 +12,9 @@ export class AddressesFacade {
    * Fetches information about a Platform address including its nonce and balance.
    *
    * @param address - The platform address to query (PlatformAddress, Uint8Array, or bech32m string)
-   * @returns AddressInfo containing address, nonce, and balance, or undefined if not found
+   * @returns PlatformAddressInfo containing address, nonce, and balance, or undefined if not found
    */
-  async get(address: wasm.PlatformAddressLike): Promise<wasm.AddressInfo | undefined> {
+  async get(address: wasm.PlatformAddressLike): Promise<wasm.PlatformAddressInfo | undefined> {
     const w = await this.sdk.getWasmSdkConnected();
     return w.getAddressInfo(address);
   }
@@ -23,9 +23,9 @@ export class AddressesFacade {
    * Fetches information about a Platform address with proof.
    *
    * @param address - The platform address to query (PlatformAddress, Uint8Array, or bech32m string)
-   * @returns ProofMetadataResponse containing AddressInfo with proof information
+   * @returns ProofMetadataResponse containing PlatformAddressInfo with proof information
    */
-  async getWithProof(address: wasm.PlatformAddressLike): Promise<wasm.ProofMetadataResponseTyped<wasm.AddressInfo>> {
+  async getWithProof(address: wasm.PlatformAddressLike): Promise<wasm.ProofMetadataResponseTyped<wasm.PlatformAddressInfo>> {
     const w = await this.sdk.getWasmSdkConnected();
     return w.getAddressInfoWithProofInfo(address);
   }
@@ -34,10 +34,11 @@ export class AddressesFacade {
    * Fetches information about multiple Platform addresses.
    *
    * @param addresses - Array of platform addresses to query
-   * @returns Map of PlatformAddress to AddressInfo (or undefined for unfunded addresses)
+   * @returns Map of PlatformAddress to PlatformAddressInfo (or undefined for unfunded addresses)
    */
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  async getMany(addresses: wasm.PlatformAddressLike[]): Promise<Map<any, any>> {
+  async getMany(
+    addresses: wasm.PlatformAddressLike[],
+  ): Promise<Map<wasm.PlatformAddress, wasm.PlatformAddressInfo | undefined>> {
     const w = await this.sdk.getWasmSdkConnected();
     return w.getAddressesInfos(addresses);
   }
@@ -46,10 +47,11 @@ export class AddressesFacade {
    * Fetches information about multiple Platform addresses with proof.
    *
    * @param addresses - Array of platform addresses to query
-   * @returns ProofMetadataResponse containing Map of PlatformAddress to AddressInfo
+   * @returns ProofMetadataResponse containing Map of PlatformAddress to PlatformAddressInfo
    */
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  async getManyWithProof(addresses: wasm.PlatformAddressLike[]): Promise<wasm.ProofMetadataResponseTyped<Map<any, any>>> {
+  async getManyWithProof(
+    addresses: wasm.PlatformAddressLike[],
+  ): Promise<wasm.ProofMetadataResponseTyped<Map<wasm.PlatformAddress, wasm.PlatformAddressInfo | undefined>>> {
     const w = await this.sdk.getWasmSdkConnected();
     return w.getAddressesInfosWithProofInfo(addresses);
   }

--- a/packages/js-evo-sdk/src/sdk.ts
+++ b/packages/js-evo-sdk/src/sdk.ts
@@ -1,5 +1,6 @@
 import * as wasm from './wasm.js';
 import { ensureInitialized as initWasm } from './wasm.js';
+import { AddressesFacade } from './addresses/facade.js';
 import { DocumentsFacade } from './documents/facade.js';
 import { IdentitiesFacade } from './identities/facade.js';
 import { ContractsFacade } from './contracts/facade.js';
@@ -38,6 +39,7 @@ export class EvoSDK {
   private wasmSdk?: wasm.WasmSdk;
   private options: Required<Pick<EvoSDKOptions, 'network' | 'trusted'>> & ConnectionOptions & { addresses?: string[] };
 
+  public addresses!: AddressesFacade;
   public documents!: DocumentsFacade;
   public identities!: IdentitiesFacade;
   public contracts!: ContractsFacade;
@@ -53,6 +55,7 @@ export class EvoSDK {
     const { network = 'testnet', trusted = false, addresses, ...connection } = options;
     this.options = { network, trusted, addresses, ...connection };
 
+    this.addresses = new AddressesFacade(this);
     this.documents = new DocumentsFacade(this);
     this.identities = new IdentitiesFacade(this);
     this.contracts = new ContractsFacade(this);
@@ -164,6 +167,7 @@ export class EvoSDK {
   }
 }
 
+export { AddressesFacade } from './addresses/facade.js';
 export { DocumentsFacade } from './documents/facade.js';
 export { IdentitiesFacade } from './identities/facade.js';
 export { ContractsFacade } from './contracts/facade.js';

--- a/packages/js-evo-sdk/tests/fixtures/testnet.mjs
+++ b/packages/js-evo-sdk/tests/fixtures/testnet.mjs
@@ -17,6 +17,14 @@ export const TEST_IDS = {
   username: 'alice',
   existingUsername: 'therealslimshaddy5',
   epoch: 8635,
+  // Platform address fixtures (21 bytes: type byte + 20-byte hash)
+  // Type 0x00 = P2PKH, Type 0x01 = P2SH
+  // These are test addresses with zero hashes - queries will return undefined if not funded
+  platformAddressBytes: new Uint8Array([0x00, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]),
+  platformAddressesBytesArray: [
+    new Uint8Array([0x00, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]),
+    new Uint8Array([0x00, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]),
+  ],
 };
 
 // Optional environment-driven secrets for state-transition tests (skipped by default).

--- a/packages/js-evo-sdk/tests/fixtures/testnet.mjs
+++ b/packages/js-evo-sdk/tests/fixtures/testnet.mjs
@@ -20,7 +20,9 @@ export const TEST_IDS = {
   // Platform address fixtures (21 bytes: type byte + 20-byte hash)
   // Type 0x00 = P2PKH, Type 0x01 = P2SH
   // These are test addresses with zero hashes - queries will return undefined if not funded
-  platformAddressBytes: new Uint8Array([0x00, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]),
+  platformAddressBytes: new Uint8Array([
+    0x00, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+  ]),
   platformAddressesBytesArray: [
     new Uint8Array([0x00, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]),
     new Uint8Array([0x00, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]),

--- a/packages/js-evo-sdk/tests/functional/addresses.spec.mjs
+++ b/packages/js-evo-sdk/tests/functional/addresses.spec.mjs
@@ -1,0 +1,47 @@
+import { EvoSDK } from '../../dist/evo-sdk.module.js';
+import { TEST_IDS } from '../fixtures/testnet.mjs';
+
+describe('Addresses', function addressesSuite() {
+  this.timeout(60000);
+  let sdk;
+
+  before(async () => {
+    sdk = EvoSDK.testnetTrusted();
+    await sdk.connect();
+  });
+
+  // Note: Platform addresses need to be funded on testnet for these tests to return data.
+  // If no funded addresses exist, the tests will still pass but return undefined/empty results.
+
+  it('get() returns address info or undefined for unfunded address', async () => {
+    const testAddress = TEST_IDS.platformAddressBytes;
+    const res = await sdk.addresses.get(testAddress);
+    // Result is undefined for unfunded/non-existent addresses
+    expect(res === undefined || res !== null).to.be.true();
+  });
+
+  it('getWithProof() returns proof info for address query', async () => {
+    const testAddress = TEST_IDS.platformAddressBytes;
+    const res = await sdk.addresses.getWithProof(testAddress);
+    expect(res).to.exist();
+    expect(res.proof).to.exist();
+    expect(res.metadata).to.exist();
+    // data may be undefined for unfunded addresses
+  });
+
+  it('getMany() returns map of address infos', async () => {
+    const testAddresses = TEST_IDS.platformAddressesBytesArray;
+    const res = await sdk.addresses.getMany(testAddresses);
+    expect(res).to.be.instanceOf(Map);
+    expect(res.size).to.equal(testAddresses.length);
+  });
+
+  it('getManyWithProof() returns proof info for multiple addresses', async () => {
+    const testAddresses = TEST_IDS.platformAddressesBytesArray;
+    const res = await sdk.addresses.getManyWithProof(testAddresses);
+    expect(res).to.exist();
+    expect(res.proof).to.exist();
+    expect(res.metadata).to.exist();
+    expect(res.data).to.be.instanceOf(Map);
+  });
+});

--- a/packages/js-evo-sdk/tests/unit/facades/addresses.spec.mjs
+++ b/packages/js-evo-sdk/tests/unit/facades/addresses.spec.mjs
@@ -1,0 +1,109 @@
+import init, * as wasmSDKPackage from '@dashevo/wasm-sdk';
+import { EvoSDK } from '../../../dist/sdk.js';
+
+describe('AddressesFacade', () => {
+  let wasmSdk;
+  let client;
+
+  beforeEach(async function setup() {
+    await init();
+    const builder = wasmSDKPackage.WasmSdkBuilder.testnetTrusted();
+    wasmSdk = builder.build();
+    client = EvoSDK.fromWasm(wasmSdk);
+
+    this.sinon.stub(wasmSdk, 'getAddressInfo').resolves('ok');
+    this.sinon.stub(wasmSdk, 'getAddressInfoWithProofInfo').resolves('ok');
+    this.sinon.stub(wasmSdk, 'getAddressesInfos').resolves('ok');
+    this.sinon.stub(wasmSdk, 'getAddressesInfosWithProofInfo').resolves('ok');
+  });
+
+  it('get() forwards address to getAddressInfo', async () => {
+    const address = 'tdashevo1qr4nl2m5z7v7g7d2c4z6k8x9w3y2f5p6h0s1t4';
+    await client.addresses.get(address);
+    expect(wasmSdk.getAddressInfo).to.be.calledOnceWithExactly(address);
+  });
+
+  it('getWithProof() forwards address to getAddressInfoWithProofInfo', async () => {
+    const address = 'tdashevo1qr4nl2m5z7v7g7d2c4z6k8x9w3y2f5p6h0s1t4';
+    await client.addresses.getWithProof(address);
+    expect(wasmSdk.getAddressInfoWithProofInfo).to.be.calledOnceWithExactly(address);
+  });
+
+  it('getMany() forwards array of addresses to getAddressesInfos', async () => {
+    const addresses = [
+      'tdashevo1qr4nl2m5z7v7g7d2c4z6k8x9w3y2f5p6h0s1t4',
+      'tdashevo1abc123def456ghi789jkl012mno345pqr678st',
+    ];
+    await client.addresses.getMany(addresses);
+    expect(wasmSdk.getAddressesInfos).to.be.calledOnceWithExactly(addresses);
+  });
+
+  it('getManyWithProof() forwards array of addresses to getAddressesInfosWithProofInfo', async () => {
+    const addresses = [
+      'tdashevo1qr4nl2m5z7v7g7d2c4z6k8x9w3y2f5p6h0s1t4',
+    ];
+    await client.addresses.getManyWithProof(addresses);
+    expect(wasmSdk.getAddressesInfosWithProofInfo).to.be.calledOnceWithExactly(addresses);
+  });
+
+  it('get() accepts Uint8Array address', async () => {
+    const addressBytes = new Uint8Array(21);
+    await client.addresses.get(addressBytes);
+    expect(wasmSdk.getAddressInfo).to.be.calledOnceWithExactly(addressBytes);
+  });
+
+  it('getMany() accepts mixed address formats', async () => {
+    const bech32Address = 'tdashevo1qr4nl2m5z7v7g7d2c4z6k8x9w3y2f5p6h0s1t4';
+    const bytesAddress = new Uint8Array(21);
+    const mixedAddresses = [bech32Address, bytesAddress];
+    await client.addresses.getMany(mixedAddresses);
+    expect(wasmSdk.getAddressesInfos).to.be.calledOnceWithExactly(mixedAddresses);
+  });
+});
+
+describe('PlatformAddress', () => {
+  let PlatformAddress;
+
+  before(async () => {
+    await init();
+    PlatformAddress = wasmSDKPackage.PlatformAddress;
+  });
+
+  it('can be created from bytes', () => {
+    // Create P2PKH address from bytes (type 0x00)
+    const p2pkhBytes = new Uint8Array([0x00, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20]);
+    const p2pkhAddr = PlatformAddress.fromBytes(Array.from(p2pkhBytes));
+    expect(p2pkhAddr).to.exist();
+    expect(p2pkhAddr.addressType).to.equal('P2PKH');
+    expect(p2pkhAddr.isP2pkh).to.be.true();
+    expect(p2pkhAddr.isP2sh).to.be.false();
+
+    // Create P2SH address from bytes (type 0x01)
+    const p2shBytes = new Uint8Array([0x01, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20]);
+    const p2shAddr = PlatformAddress.fromBytes(Array.from(p2shBytes));
+    expect(p2shAddr).to.exist();
+    expect(p2shAddr.addressType).to.equal('P2SH');
+    expect(p2shAddr.isP2pkh).to.be.false();
+    expect(p2shAddr.isP2sh).to.be.true();
+  });
+
+  it('converts to bech32m and back', () => {
+    // Create address from bytes
+    const originalBytes = new Uint8Array([0x00, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20]);
+    const addr = PlatformAddress.fromBytes(Array.from(originalBytes));
+
+    // Convert to bech32m for testnet
+    const bech32m = addr.toBech32m('testnet');
+    expect(bech32m).to.be.a('string');
+    expect(bech32m.startsWith('tdashevo1')).to.be.true();
+
+    // Convert back from bech32m
+    const recoveredAddr = PlatformAddress.fromBech32m(bech32m);
+    expect(recoveredAddr).to.exist();
+    expect(recoveredAddr.addressType).to.equal(addr.addressType);
+
+    // Verify bytes match
+    const recoveredBytes = recoveredAddr.toBytes();
+    expect(Array.from(recoveredBytes)).to.deep.equal(Array.from(originalBytes));
+  });
+});

--- a/packages/js-evo-sdk/tests/unit/facades/addresses.spec.mjs
+++ b/packages/js-evo-sdk/tests/unit/facades/addresses.spec.mjs
@@ -71,6 +71,7 @@ describe('PlatformAddress', () => {
 
   it('can be created from bytes', () => {
     // Create P2PKH address from bytes (type 0x00)
+    // eslint-disable-next-line max-len
     const p2pkhBytes = new Uint8Array([0x00, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20]);
     const p2pkhAddr = PlatformAddress.fromBytes(Array.from(p2pkhBytes));
     expect(p2pkhAddr).to.exist();
@@ -79,6 +80,7 @@ describe('PlatformAddress', () => {
     expect(p2pkhAddr.isP2sh).to.be.false();
 
     // Create P2SH address from bytes (type 0x01)
+    // eslint-disable-next-line max-len
     const p2shBytes = new Uint8Array([0x01, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20]);
     const p2shAddr = PlatformAddress.fromBytes(Array.from(p2shBytes));
     expect(p2shAddr).to.exist();
@@ -89,6 +91,7 @@ describe('PlatformAddress', () => {
 
   it('converts to bech32m and back', () => {
     // Create address from bytes
+    // eslint-disable-next-line max-len
     const originalBytes = new Uint8Array([0x00, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20]);
     const addr = PlatformAddress.fromBytes(Array.from(originalBytes));
 

--- a/packages/rs-drive/src/drive/mod.rs
+++ b/packages/rs-drive/src/drive/mod.rs
@@ -1,12 +1,9 @@
-use std::collections::BTreeMap;
-use std::path::PathBuf;
 use std::sync::Arc;
 
 #[cfg(any(feature = "server", feature = "verify"))]
 use crate::config::DriveConfig;
 #[cfg(feature = "server")]
 use arc_swap::ArcSwap;
-use dpp::prelude::{BlockHeight, TimestampMillis};
 #[cfg(any(feature = "server", feature = "verify"))]
 use grovedb::GroveDb;
 use std::fmt;

--- a/packages/rs-drive/src/drive/mod.rs
+++ b/packages/rs-drive/src/drive/mod.rs
@@ -1,9 +1,12 @@
+use std::collections::BTreeMap;
+use std::path::PathBuf;
 use std::sync::Arc;
 
 #[cfg(any(feature = "server", feature = "verify"))]
 use crate::config::DriveConfig;
 #[cfg(feature = "server")]
 use arc_swap::ArcSwap;
+use dpp::prelude::{BlockHeight, TimestampMillis};
 #[cfg(any(feature = "server", feature = "verify"))]
 use grovedb::GroveDb;
 use std::fmt;

--- a/packages/wasm-dpp2/src/lib.rs
+++ b/packages/wasm-dpp2/src/lib.rs
@@ -41,9 +41,9 @@ pub use identity::{
     IdentityTopUpTransitionWasm, IdentityUpdateTransitionWasm, IdentityWasm,
     MasternodeVoteTransitionWasm, PartialIdentityWasm,
 };
+pub use platform_address::PlatformAddressWasm;
 pub use state_transitions::base::{GroupStateTransitionInfoWasm, StateTransitionWasm};
 pub use tokens::*;
-pub use platform_address::PlatformAddressWasm;
 pub use voting::{
     ContenderWithSerializedDocumentWasm, ContestedDocumentVotePollWinnerInfoWasm,
     ResourceVoteChoiceWasm, VotePollWasm, VoteWasm,

--- a/packages/wasm-dpp2/src/lib.rs
+++ b/packages/wasm-dpp2/src/lib.rs
@@ -21,6 +21,7 @@ pub mod group;
 pub mod identifier;
 pub mod identity;
 pub mod mock_bls;
+pub mod platform_address;
 pub mod private_key;
 pub mod public_key;
 pub mod state_transitions;
@@ -42,6 +43,7 @@ pub use identity::{
 };
 pub use state_transitions::base::{GroupStateTransitionInfoWasm, StateTransitionWasm};
 pub use tokens::*;
+pub use platform_address::PlatformAddressWasm;
 pub use voting::{
     ContenderWithSerializedDocumentWasm, ContestedDocumentVotePollWinnerInfoWasm,
     ResourceVoteChoiceWasm, VotePollWasm, VoteWasm,

--- a/packages/wasm-dpp2/src/platform_address.rs
+++ b/packages/wasm-dpp2/src/platform_address.rs
@@ -264,7 +264,7 @@ impl PlatformAddressWasm {
     pub fn from_bech32m(address: &str) -> WasmDppResult<PlatformAddressWasm> {
         PlatformAddress::from_bech32m_string(address)
             .map(|(addr, _)| PlatformAddressWasm(addr))
-            .map_err(|e| WasmDppError::invalid_argument(e.to_string()).into())
+            .map_err(|e| WasmDppError::invalid_argument(e.to_string()))
     }
 
     /// Creates a PlatformAddress from raw bytes (21 bytes: type byte + 20-byte hash).
@@ -272,7 +272,7 @@ impl PlatformAddressWasm {
     pub fn from_bytes(bytes: Vec<u8>) -> WasmDppResult<PlatformAddressWasm> {
         PlatformAddress::from_bytes(&bytes)
             .map(PlatformAddressWasm)
-            .map_err(|e| WasmDppError::invalid_argument(e.to_string()).into())
+            .map_err(|e| WasmDppError::invalid_argument(e.to_string()))
     }
 
     /// Creates a PlatformAddress from a hex-encoded string.
@@ -282,7 +282,7 @@ impl PlatformAddressWasm {
             .map_err(|e| WasmDppError::invalid_argument(format!("Invalid hex: {}", e)))?;
         PlatformAddress::from_bytes(&bytes)
             .map(PlatformAddressWasm)
-            .map_err(|e| WasmDppError::invalid_argument(e.to_string()).into())
+            .map_err(|e| WasmDppError::invalid_argument(e.to_string()))
     }
 
     /// Creates a P2PKH address from a 20-byte public key hash.
@@ -292,8 +292,7 @@ impl PlatformAddressWasm {
             return Err(WasmDppError::invalid_argument(format!(
                 "P2PKH hash must be 20 bytes, got {}",
                 hash.len()
-            ))
-            .into());
+            )));
         }
         let mut arr = [0u8; 20];
         arr.copy_from_slice(&hash);
@@ -307,8 +306,7 @@ impl PlatformAddressWasm {
             return Err(WasmDppError::invalid_argument(format!(
                 "P2SH hash must be 20 bytes, got {}",
                 hash.len()
-            ))
-            .into());
+            )));
         }
         let mut arr = [0u8; 20];
         arr.copy_from_slice(&hash);

--- a/packages/wasm-dpp2/src/platform_address.rs
+++ b/packages/wasm-dpp2/src/platform_address.rs
@@ -1,0 +1,329 @@
+use crate::error::{WasmDppError, WasmDppResult};
+use crate::utils::IntoWasm;
+use dpp::address_funds::PlatformAddress;
+use dpp::dashcore::Network;
+use js_sys::Uint8Array;
+use serde::de::{self, Error, Visitor};
+use serde::{Deserialize, Deserializer};
+use std::fmt;
+use wasm_bindgen::prelude::*;
+
+#[derive(Clone, Copy, PartialEq, Eq, Hash, Debug)]
+#[wasm_bindgen(js_name = "PlatformAddress")]
+pub struct PlatformAddressWasm(PlatformAddress);
+
+#[wasm_bindgen(typescript_custom_section)]
+const PLATFORM_ADDRESS_TS_HELPERS: &'static str = r#"
+/**
+ * A Platform address can be provided as:
+ * - A PlatformAddress object
+ * - A Uint8Array (21 bytes: type byte + 20-byte hash)
+ * - A bech32m string (e.g., "dashevo1..." or "tdashevo1...")
+ */
+export type PlatformAddressLike = PlatformAddress | Uint8Array | string;
+"#;
+
+impl From<PlatformAddressWasm> for PlatformAddress {
+    fn from(address: PlatformAddressWasm) -> Self {
+        address.0
+    }
+}
+
+impl From<PlatformAddress> for PlatformAddressWasm {
+    fn from(address: PlatformAddress) -> Self {
+        PlatformAddressWasm(address)
+    }
+}
+
+impl From<&PlatformAddressWasm> for PlatformAddress {
+    fn from(address: &PlatformAddressWasm) -> Self {
+        address.0
+    }
+}
+
+impl TryFrom<&[u8]> for PlatformAddressWasm {
+    type Error = WasmDppError;
+
+    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
+        PlatformAddress::from_bytes(value)
+            .map(PlatformAddressWasm)
+            .map_err(|e| WasmDppError::invalid_argument(e.to_string()))
+    }
+}
+
+impl TryFrom<JsValue> for PlatformAddressWasm {
+    type Error = WasmDppError;
+
+    fn try_from(value: JsValue) -> Result<Self, Self::Error> {
+        if value.is_undefined() || value.is_null() {
+            return Err(WasmDppError::invalid_argument(
+                "the platform address cannot be null or undefined",
+            ));
+        }
+
+        // Check if it's already a PlatformAddressWasm
+        if let Ok(existing) = value
+            .clone()
+            .to_wasm::<PlatformAddressWasm>("PlatformAddress")
+        {
+            return Ok(*existing);
+        }
+
+        // Try parsing as string (bech32m)
+        if let Some(string) = value.as_string() {
+            return PlatformAddressWasm::try_from(string.as_str());
+        }
+
+        // Try parsing as bytes
+        if value.is_instance_of::<js_sys::Uint8Array>() || value.is_array() || value.is_object() {
+            let uint8_array = Uint8Array::from(value.clone());
+            let bytes = uint8_array.to_vec();
+
+            return PlatformAddress::from_bytes(&bytes)
+                .map(PlatformAddressWasm)
+                .map_err(|e| WasmDppError::invalid_argument(e.to_string()));
+        }
+
+        Err(WasmDppError::invalid_argument(
+            "Invalid platform address. Expected PlatformAddress, Uint8Array, or bech32m string",
+        ))
+    }
+}
+
+impl TryFrom<&JsValue> for PlatformAddressWasm {
+    type Error = WasmDppError;
+
+    fn try_from(value: &JsValue) -> Result<Self, Self::Error> {
+        PlatformAddressWasm::try_from(value.clone())
+    }
+}
+
+impl TryFrom<&str> for PlatformAddressWasm {
+    type Error = WasmDppError;
+
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        // Try parsing as bech32m string
+        PlatformAddress::from_bech32m_string(value)
+            .map(|(addr, _network)| PlatformAddressWasm(addr))
+            .map_err(|e| WasmDppError::invalid_argument(e.to_string()))
+    }
+}
+
+struct PlatformAddressWasmVisitor;
+
+impl<'de> Visitor<'de> for PlatformAddressWasmVisitor {
+    type Value = PlatformAddressWasm;
+
+    fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        formatter.write_str("PlatformAddress or compatible representation")
+    }
+
+    fn visit_str<E>(self, value: &str) -> Result<Self::Value, E>
+    where
+        E: de::Error,
+    {
+        PlatformAddressWasm::try_from(value).map_err(|err| E::custom(err.to_string()))
+    }
+
+    fn visit_string<E>(self, value: String) -> Result<Self::Value, E>
+    where
+        E: de::Error,
+    {
+        self.visit_str(&value)
+    }
+
+    fn visit_bytes<E>(self, value: &[u8]) -> Result<Self::Value, E>
+    where
+        E: de::Error,
+    {
+        PlatformAddress::from_bytes(value)
+            .map(PlatformAddressWasm)
+            .map_err(|e| E::custom(e.to_string()))
+    }
+
+    fn visit_seq<A>(self, mut seq: A) -> Result<Self::Value, A::Error>
+    where
+        A: de::SeqAccess<'de>,
+    {
+        let mut bytes: Vec<u8> = Vec::new();
+        while let Some(byte) = seq.next_element::<u8>()? {
+            bytes.push(byte);
+        }
+        PlatformAddress::from_bytes(&bytes)
+            .map(PlatformAddressWasm)
+            .map_err(|e| A::Error::custom(e.to_string()))
+    }
+}
+
+impl<'de> Deserialize<'de> for PlatformAddressWasm {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        deserializer.deserialize_any(PlatformAddressWasmVisitor)
+    }
+}
+
+fn parse_network(network: &str) -> Result<Network, WasmDppError> {
+    match network.to_lowercase().as_str() {
+        "mainnet" | "dash" => Ok(Network::Dash),
+        "testnet" => Ok(Network::Testnet),
+        "devnet" => Ok(Network::Devnet),
+        "regtest" => Ok(Network::Regtest),
+        _ => Err(WasmDppError::invalid_argument(format!(
+            "Invalid network: {}. Expected 'mainnet', 'testnet', 'devnet', or 'regtest'",
+            network
+        ))),
+    }
+}
+
+#[wasm_bindgen(js_class = PlatformAddress)]
+impl PlatformAddressWasm {
+    #[wasm_bindgen(getter = __type)]
+    pub fn type_name(&self) -> String {
+        "PlatformAddress".to_string()
+    }
+
+    #[wasm_bindgen(getter = __struct)]
+    pub fn struct_name() -> String {
+        "PlatformAddress".to_string()
+    }
+
+    /// Creates a new PlatformAddress from various input types.
+    ///
+    /// Accepts:
+    /// - A bech32m string (e.g., "dashevo1..." or "tdashevo1...")
+    /// - A Uint8Array (21 bytes: type byte + 20-byte hash)
+    /// - An existing PlatformAddress object
+    #[wasm_bindgen(constructor)]
+    pub fn new(
+        #[wasm_bindgen(unchecked_param_type = "PlatformAddress | Uint8Array | string")]
+        js_address: &JsValue,
+    ) -> WasmDppResult<PlatformAddressWasm> {
+        PlatformAddressWasm::try_from(js_address)
+    }
+
+    /// Returns the bech32m-encoded address string for the specified network.
+    ///
+    /// @param network - "mainnet", "testnet", "devnet", or "regtest"
+    #[wasm_bindgen(js_name = "toBech32m")]
+    pub fn to_bech32m(&self, network: &str) -> WasmDppResult<String> {
+        let net = parse_network(network)?;
+        Ok(self.0.to_bech32m_string(net))
+    }
+
+    /// Returns the raw bytes of the address (21 bytes: type byte + 20-byte hash).
+    #[wasm_bindgen(js_name = "toBytes")]
+    pub fn to_bytes(&self) -> Vec<u8> {
+        self.0.to_bytes()
+    }
+
+    /// Returns the hex-encoded address bytes.
+    #[wasm_bindgen(js_name = "toHex")]
+    pub fn to_hex(&self) -> String {
+        hex::encode(self.0.to_bytes())
+    }
+
+    /// Returns the address type: "P2PKH" or "P2SH".
+    #[wasm_bindgen(js_name = "addressType", getter)]
+    pub fn address_type(&self) -> String {
+        match self.0 {
+            PlatformAddress::P2pkh(_) => "P2PKH".to_string(),
+            PlatformAddress::P2sh(_) => "P2SH".to_string(),
+        }
+    }
+
+    /// Returns true if this is a P2PKH address.
+    #[wasm_bindgen(js_name = "isP2pkh", getter)]
+    pub fn is_p2pkh(&self) -> bool {
+        self.0.is_p2pkh()
+    }
+
+    /// Returns true if this is a P2SH address.
+    #[wasm_bindgen(js_name = "isP2sh", getter)]
+    pub fn is_p2sh(&self) -> bool {
+        self.0.is_p2sh()
+    }
+
+    /// Returns the 20-byte hash portion of the address.
+    #[wasm_bindgen(js_name = "hash")]
+    pub fn hash(&self) -> Vec<u8> {
+        self.0.hash().to_vec()
+    }
+
+    /// Returns the hash as a hex string.
+    #[wasm_bindgen(js_name = "hashToHex")]
+    pub fn hash_to_hex(&self) -> String {
+        hex::encode(self.0.hash())
+    }
+
+    /// Creates a PlatformAddress from a bech32m-encoded string.
+    ///
+    /// Accepts addresses with either mainnet ("dashevo") or testnet ("tdashevo") HRP.
+    #[wasm_bindgen(js_name = "fromBech32m")]
+    pub fn from_bech32m(address: &str) -> WasmDppResult<PlatformAddressWasm> {
+        PlatformAddress::from_bech32m_string(address)
+            .map(|(addr, _)| PlatformAddressWasm(addr))
+            .map_err(|e| WasmDppError::invalid_argument(e.to_string()).into())
+    }
+
+    /// Creates a PlatformAddress from raw bytes (21 bytes: type byte + 20-byte hash).
+    #[wasm_bindgen(js_name = "fromBytes")]
+    pub fn from_bytes(bytes: Vec<u8>) -> WasmDppResult<PlatformAddressWasm> {
+        PlatformAddress::from_bytes(&bytes)
+            .map(PlatformAddressWasm)
+            .map_err(|e| WasmDppError::invalid_argument(e.to_string()).into())
+    }
+
+    /// Creates a PlatformAddress from a hex-encoded string.
+    #[wasm_bindgen(js_name = "fromHex")]
+    pub fn from_hex(hex_string: &str) -> WasmDppResult<PlatformAddressWasm> {
+        let bytes = hex::decode(hex_string)
+            .map_err(|e| WasmDppError::invalid_argument(format!("Invalid hex: {}", e)))?;
+        PlatformAddress::from_bytes(&bytes)
+            .map(PlatformAddressWasm)
+            .map_err(|e| WasmDppError::invalid_argument(e.to_string()).into())
+    }
+
+    /// Creates a P2PKH address from a 20-byte public key hash.
+    #[wasm_bindgen(js_name = "fromP2pkhHash")]
+    pub fn from_p2pkh_hash(hash: Vec<u8>) -> WasmDppResult<PlatformAddressWasm> {
+        if hash.len() != 20 {
+            return Err(WasmDppError::invalid_argument(format!(
+                "P2PKH hash must be 20 bytes, got {}",
+                hash.len()
+            ))
+            .into());
+        }
+        let mut arr = [0u8; 20];
+        arr.copy_from_slice(&hash);
+        Ok(PlatformAddressWasm(PlatformAddress::P2pkh(arr)))
+    }
+
+    /// Creates a P2SH address from a 20-byte script hash.
+    #[wasm_bindgen(js_name = "fromP2shHash")]
+    pub fn from_p2sh_hash(hash: Vec<u8>) -> WasmDppResult<PlatformAddressWasm> {
+        if hash.len() != 20 {
+            return Err(WasmDppError::invalid_argument(format!(
+                "P2SH hash must be 20 bytes, got {}",
+                hash.len()
+            ))
+            .into());
+        }
+        let mut arr = [0u8; 20];
+        arr.copy_from_slice(&hash);
+        Ok(PlatformAddressWasm(PlatformAddress::P2sh(arr)))
+    }
+}
+
+impl PlatformAddressWasm {
+    /// Returns the inner PlatformAddress.
+    pub fn inner(&self) -> &PlatformAddress {
+        &self.0
+    }
+
+    /// Consumes self and returns the inner PlatformAddress.
+    pub fn into_inner(self) -> PlatformAddress {
+        self.0
+    }
+}

--- a/packages/wasm-dpp2/src/platform_address.rs
+++ b/packages/wasm-dpp2/src/platform_address.rs
@@ -75,7 +75,7 @@ impl TryFrom<JsValue> for PlatformAddressWasm {
         }
 
         // Try parsing as bytes
-        if value.is_instance_of::<js_sys::Uint8Array>() || value.is_array() || value.is_object() {
+        if value.is_instance_of::<js_sys::Uint8Array>() || value.is_array() {
             let uint8_array = Uint8Array::from(value.clone());
             let bytes = uint8_array.to_vec();
 

--- a/packages/wasm-sdk/src/lib.rs
+++ b/packages/wasm-sdk/src/lib.rs
@@ -13,7 +13,9 @@ pub mod wallet;
 // Re-export commonly used items
 pub use dpns::*;
 pub use error::{WasmSdkError, WasmSdkErrorKind};
-pub use queries::{AddressInfoWasm, ProofInfoWasm, ProofMetadataResponseWasm, ResponseMetadataWasm};
+pub use queries::{
+    AddressInfoWasm, ProofInfoWasm, ProofMetadataResponseWasm, ResponseMetadataWasm,
+};
 pub use state_transitions::identity as state_transition_identity;
 pub use wallet::*;
 pub use wasm_dpp2::*;

--- a/packages/wasm-sdk/src/lib.rs
+++ b/packages/wasm-sdk/src/lib.rs
@@ -14,7 +14,7 @@ pub mod wallet;
 pub use dpns::*;
 pub use error::{WasmSdkError, WasmSdkErrorKind};
 pub use queries::{
-    AddressInfoWasm, ProofInfoWasm, ProofMetadataResponseWasm, ResponseMetadataWasm,
+    PlatformAddressInfoWasm, ProofInfoWasm, ProofMetadataResponseWasm, ResponseMetadataWasm,
 };
 pub use state_transitions::identity as state_transition_identity;
 pub use wallet::*;

--- a/packages/wasm-sdk/src/lib.rs
+++ b/packages/wasm-sdk/src/lib.rs
@@ -13,7 +13,7 @@ pub mod wallet;
 // Re-export commonly used items
 pub use dpns::*;
 pub use error::{WasmSdkError, WasmSdkErrorKind};
-pub use queries::{ProofInfoWasm, ProofMetadataResponseWasm, ResponseMetadataWasm};
+pub use queries::{AddressInfoWasm, ProofInfoWasm, ProofMetadataResponseWasm, ResponseMetadataWasm};
 pub use state_transitions::identity as state_transition_identity;
 pub use wallet::*;
 pub use wasm_dpp2::*;

--- a/packages/wasm-sdk/src/queries/address.rs
+++ b/packages/wasm-sdk/src/queries/address.rs
@@ -11,17 +11,17 @@ use wasm_bindgen::JsValue;
 use wasm_dpp2::platform_address::PlatformAddressWasm;
 
 /// Information about a Platform address including its nonce and balance.
-#[wasm_bindgen(js_name = "AddressInfo")]
+#[wasm_bindgen(js_name = "PlatformAddressInfo")]
 #[derive(Clone)]
-pub struct AddressInfoWasm {
+pub struct PlatformAddressInfoWasm {
     address: PlatformAddressWasm,
     nonce: u32,
     balance: u64,
 }
 
-impl AddressInfoWasm {
+impl PlatformAddressInfoWasm {
     fn from_address_info(info: AddressInfo) -> Self {
-        AddressInfoWasm {
+        PlatformAddressInfoWasm {
             address: info.address.into(),
             nonce: info.nonce,
             balance: info.balance,
@@ -29,8 +29,8 @@ impl AddressInfoWasm {
     }
 }
 
-#[wasm_bindgen(js_class = AddressInfo)]
-impl AddressInfoWasm {
+#[wasm_bindgen(js_class = PlatformAddressInfo)]
+impl PlatformAddressInfoWasm {
     /// Returns the platform address.
     #[wasm_bindgen(getter = "address")]
     pub fn address(&self) -> PlatformAddressWasm {
@@ -55,12 +55,12 @@ impl WasmSdk {
     /// Fetches information about a Platform address including its nonce and balance.
     ///
     /// @param address - The platform address to query (PlatformAddress, Uint8Array, or bech32m string)
-    /// @returns AddressInfo containing address, nonce, and balance
+    /// @returns PlatformAddressInfo containing address, nonce, and balance
     #[wasm_bindgen(js_name = "getAddressInfo")]
     pub async fn get_address_info(
         &self,
         #[wasm_bindgen(unchecked_param_type = "PlatformAddressLike")] address: JsValue,
-    ) -> Result<Option<AddressInfoWasm>, WasmSdkError> {
+    ) -> Result<Option<PlatformAddressInfoWasm>, WasmSdkError> {
         let platform_address: PlatformAddress = PlatformAddressWasm::try_from(&address)
             .map_err(|err| {
                 WasmSdkError::invalid_argument(format!("Invalid platform address: {}", err))
@@ -69,16 +69,16 @@ impl WasmSdk {
 
         let address_info = AddressInfo::fetch(self.as_ref(), platform_address).await?;
 
-        Ok(address_info.map(AddressInfoWasm::from_address_info))
+        Ok(address_info.map(PlatformAddressInfoWasm::from_address_info))
     }
 
     /// Fetches information about a Platform address including its nonce and balance, with proof.
     ///
     /// @param address - The platform address to query (PlatformAddress, Uint8Array, or bech32m string)
-    /// @returns ProofMetadataResponse containing AddressInfo with proof information
+    /// @returns ProofMetadataResponse containing PlatformAddressInfo with proof information
     #[wasm_bindgen(
         js_name = "getAddressInfoWithProofInfo",
-        unchecked_return_type = "ProofMetadataResponseTyped<AddressInfo>"
+        unchecked_return_type = "ProofMetadataResponseTyped<PlatformAddressInfo>"
     )]
     pub async fn get_address_info_with_proof_info(
         &self,
@@ -95,7 +95,7 @@ impl WasmSdk {
                 .await?;
 
         let data = address_info
-            .map(|info| JsValue::from(AddressInfoWasm::from_address_info(info)))
+            .map(|info| JsValue::from(PlatformAddressInfoWasm::from_address_info(info)))
             .unwrap_or(JsValue::UNDEFINED);
 
         Ok(ProofMetadataResponseWasm::from_sdk_parts(
@@ -106,10 +106,10 @@ impl WasmSdk {
     /// Fetches information about multiple Platform addresses.
     ///
     /// @param addresses - Array of platform addresses to query
-    /// @returns Map of PlatformAddress to AddressInfo (or undefined for unfunded addresses)
+    /// @returns Map of PlatformAddress to PlatformAddressInfo (or undefined for unfunded addresses)
     #[wasm_bindgen(
         js_name = "getAddressesInfos",
-        unchecked_return_type = "Map<PlatformAddress, AddressInfo | undefined>"
+        unchecked_return_type = "Map<PlatformAddress, PlatformAddressInfo | undefined>"
     )]
     pub async fn get_addresses_infos(
         &self,
@@ -138,7 +138,7 @@ impl WasmSdk {
             let value = address_infos
                 .get(&address)
                 .and_then(|opt| opt.as_ref())
-                .map(|info| JsValue::from(AddressInfoWasm::from_address_info(info.clone())))
+                .map(|info| JsValue::from(PlatformAddressInfoWasm::from_address_info(info.clone())))
                 .unwrap_or(JsValue::UNDEFINED);
             results_map.set(&key, &value);
         }
@@ -149,10 +149,10 @@ impl WasmSdk {
     /// Fetches information about multiple Platform addresses with proof.
     ///
     /// @param addresses - Array of platform addresses to query
-    /// @returns ProofMetadataResponse containing Map of PlatformAddress to AddressInfo
+    /// @returns ProofMetadataResponse containing Map of PlatformAddress to PlatformAddressInfo
     #[wasm_bindgen(
         js_name = "getAddressesInfosWithProofInfo",
-        unchecked_return_type = "ProofMetadataResponseTyped<Map<PlatformAddress, AddressInfo | undefined>>"
+        unchecked_return_type = "ProofMetadataResponseTyped<Map<PlatformAddress, PlatformAddressInfo | undefined>>"
     )]
     pub async fn get_addresses_infos_with_proof_info(
         &self,
@@ -186,7 +186,7 @@ impl WasmSdk {
             let value = address_infos
                 .get(&address)
                 .and_then(|opt| opt.as_ref())
-                .map(|info| JsValue::from(AddressInfoWasm::from_address_info(info.clone())))
+                .map(|info| JsValue::from(PlatformAddressInfoWasm::from_address_info(info.clone())))
                 .unwrap_or(JsValue::UNDEFINED);
             results_map.set(&key, &value);
         }

--- a/packages/wasm-sdk/src/queries/address.rs
+++ b/packages/wasm-sdk/src/queries/address.rs
@@ -94,15 +94,13 @@ impl WasmSdk {
             AddressInfo::fetch_with_metadata_and_proof(self.as_ref(), platform_address, None)
                 .await?;
 
-        address_info
-            .map(|info| {
-                ProofMetadataResponseWasm::from_sdk_parts(
-                    JsValue::from(AddressInfoWasm::from_address_info(info)),
-                    metadata,
-                    proof,
-                )
-            })
-            .ok_or_else(|| WasmSdkError::not_found("Address info not found"))
+        let data = address_info
+            .map(|info| JsValue::from(AddressInfoWasm::from_address_info(info)))
+            .unwrap_or(JsValue::UNDEFINED);
+
+        Ok(ProofMetadataResponseWasm::from_sdk_parts(
+            data, metadata, proof,
+        ))
     }
 
     /// Fetches information about multiple Platform addresses.

--- a/packages/wasm-sdk/src/queries/address.rs
+++ b/packages/wasm-sdk/src/queries/address.rs
@@ -1,0 +1,198 @@
+use crate::error::WasmSdkError;
+use crate::queries::ProofMetadataResponseWasm;
+use crate::sdk::WasmSdk;
+use dash_sdk::dpp::address_funds::PlatformAddress;
+use dash_sdk::platform::{Fetch, FetchMany};
+use drive_proof_verifier::types::{AddressInfo, AddressInfos};
+use js_sys::{BigInt, Map};
+use std::collections::BTreeSet;
+use wasm_bindgen::prelude::wasm_bindgen;
+use wasm_bindgen::JsValue;
+use wasm_dpp2::platform_address::PlatformAddressWasm;
+
+/// Information about a Platform address including its nonce and balance.
+#[wasm_bindgen(js_name = "AddressInfo")]
+#[derive(Clone)]
+pub struct AddressInfoWasm {
+    address: PlatformAddressWasm,
+    nonce: u32,
+    balance: u64,
+}
+
+impl AddressInfoWasm {
+    fn from_address_info(info: AddressInfo) -> Self {
+        AddressInfoWasm {
+            address: info.address.into(),
+            nonce: info.nonce,
+            balance: info.balance,
+        }
+    }
+}
+
+#[wasm_bindgen(js_class = AddressInfo)]
+impl AddressInfoWasm {
+    /// Returns the platform address.
+    #[wasm_bindgen(getter = "address")]
+    pub fn address(&self) -> PlatformAddressWasm {
+        self.address
+    }
+
+    /// Returns the nonce associated with the address.
+    #[wasm_bindgen(getter = "nonce")]
+    pub fn nonce(&self) -> BigInt {
+        BigInt::from(self.nonce)
+    }
+
+    /// Returns the balance stored for the address in credits.
+    #[wasm_bindgen(getter = "balance")]
+    pub fn balance(&self) -> BigInt {
+        BigInt::from(self.balance)
+    }
+}
+
+#[wasm_bindgen]
+impl WasmSdk {
+    /// Fetches information about a Platform address including its nonce and balance.
+    ///
+    /// @param address - The platform address to query (PlatformAddress, Uint8Array, or bech32m string)
+    /// @returns AddressInfo containing address, nonce, and balance
+    #[wasm_bindgen(js_name = "getAddressInfo")]
+    pub async fn get_address_info(
+        &self,
+        #[wasm_bindgen(unchecked_param_type = "PlatformAddressLike")] address: JsValue,
+    ) -> Result<Option<AddressInfoWasm>, WasmSdkError> {
+        let platform_address: PlatformAddress = PlatformAddressWasm::try_from(&address)
+            .map_err(|err| {
+                WasmSdkError::invalid_argument(format!("Invalid platform address: {}", err))
+            })?
+            .into();
+
+        let address_info = AddressInfo::fetch(self.as_ref(), platform_address).await?;
+
+        Ok(address_info.map(AddressInfoWasm::from_address_info))
+    }
+
+    /// Fetches information about a Platform address including its nonce and balance, with proof.
+    ///
+    /// @param address - The platform address to query (PlatformAddress, Uint8Array, or bech32m string)
+    /// @returns ProofMetadataResponse containing AddressInfo with proof information
+    #[wasm_bindgen(
+        js_name = "getAddressInfoWithProofInfo",
+        unchecked_return_type = "ProofMetadataResponseTyped<AddressInfo>"
+    )]
+    pub async fn get_address_info_with_proof_info(
+        &self,
+        #[wasm_bindgen(unchecked_param_type = "PlatformAddressLike")] address: JsValue,
+    ) -> Result<ProofMetadataResponseWasm, WasmSdkError> {
+        let platform_address: PlatformAddress = PlatformAddressWasm::try_from(&address)
+            .map_err(|err| {
+                WasmSdkError::invalid_argument(format!("Invalid platform address: {}", err))
+            })?
+            .into();
+
+        let (address_info, metadata, proof) =
+            AddressInfo::fetch_with_metadata_and_proof(self.as_ref(), platform_address, None)
+                .await?;
+
+        address_info
+            .map(|info| {
+                ProofMetadataResponseWasm::from_sdk_parts(
+                    JsValue::from(AddressInfoWasm::from_address_info(info)),
+                    metadata,
+                    proof,
+                )
+            })
+            .ok_or_else(|| WasmSdkError::not_found("Address info not found"))
+    }
+
+    /// Fetches information about multiple Platform addresses.
+    ///
+    /// @param addresses - Array of platform addresses to query
+    /// @returns Map of PlatformAddress to AddressInfo (or undefined for unfunded addresses)
+    #[wasm_bindgen(
+        js_name = "getAddressesInfos",
+        unchecked_return_type = "Map<PlatformAddress, AddressInfo | undefined>"
+    )]
+    pub async fn get_addresses_infos(
+        &self,
+        #[wasm_bindgen(unchecked_param_type = "Array<PlatformAddressLike>")] addresses: Vec<JsValue>,
+    ) -> Result<Map, WasmSdkError> {
+        let platform_addresses: BTreeSet<PlatformAddress> = addresses
+            .into_iter()
+            .map(|value| {
+                PlatformAddressWasm::try_from(&value)
+                    .map(PlatformAddress::from)
+                    .map_err(|err| {
+                        WasmSdkError::invalid_argument(format!("Invalid platform address: {}", err))
+                    })
+            })
+            .collect::<Result<BTreeSet<_>, _>>()?;
+
+        let address_infos: AddressInfos =
+            AddressInfo::fetch_many(self.as_ref(), platform_addresses.clone()).await?;
+
+        let results_map = Map::new();
+
+        for address in platform_addresses {
+            let key = JsValue::from(PlatformAddressWasm::from(address));
+            let value = address_infos
+                .get(&address)
+                .and_then(|opt| opt.as_ref())
+                .map(|info| JsValue::from(AddressInfoWasm::from_address_info(info.clone())))
+                .unwrap_or(JsValue::UNDEFINED);
+            results_map.set(&key, &value);
+        }
+
+        Ok(results_map)
+    }
+
+    /// Fetches information about multiple Platform addresses with proof.
+    ///
+    /// @param addresses - Array of platform addresses to query
+    /// @returns ProofMetadataResponse containing Map of PlatformAddress to AddressInfo
+    #[wasm_bindgen(
+        js_name = "getAddressesInfosWithProofInfo",
+        unchecked_return_type = "ProofMetadataResponseTyped<Map<PlatformAddress, AddressInfo | undefined>>"
+    )]
+    pub async fn get_addresses_infos_with_proof_info(
+        &self,
+        #[wasm_bindgen(unchecked_param_type = "Array<PlatformAddressLike>")] addresses: Vec<JsValue>,
+    ) -> Result<ProofMetadataResponseWasm, WasmSdkError> {
+        let platform_addresses: BTreeSet<PlatformAddress> = addresses
+            .into_iter()
+            .map(|value| {
+                PlatformAddressWasm::try_from(&value)
+                    .map(PlatformAddress::from)
+                    .map_err(|err| {
+                        WasmSdkError::invalid_argument(format!("Invalid platform address: {}", err))
+                    })
+            })
+            .collect::<Result<BTreeSet<_>, _>>()?;
+
+        let (address_infos, metadata, proof): (AddressInfos, _, _) =
+            AddressInfo::fetch_many_with_metadata_and_proof(
+                self.as_ref(),
+                platform_addresses.clone(),
+                None,
+            )
+            .await?;
+
+        let results_map = Map::new();
+
+        for address in platform_addresses {
+            let key = JsValue::from(PlatformAddressWasm::from(address));
+            let value = address_infos
+                .get(&address)
+                .and_then(|opt| opt.as_ref())
+                .map(|info| JsValue::from(AddressInfoWasm::from_address_info(info.clone())))
+                .unwrap_or(JsValue::UNDEFINED);
+            results_map.set(&key, &value);
+        }
+
+        Ok(ProofMetadataResponseWasm::from_sdk_parts(
+            results_map,
+            metadata,
+            proof,
+        ))
+    }
+}

--- a/packages/wasm-sdk/src/queries/address.rs
+++ b/packages/wasm-sdk/src/queries/address.rs
@@ -115,7 +115,9 @@ impl WasmSdk {
     )]
     pub async fn get_addresses_infos(
         &self,
-        #[wasm_bindgen(unchecked_param_type = "Array<PlatformAddressLike>")] addresses: Vec<JsValue>,
+        #[wasm_bindgen(unchecked_param_type = "Array<PlatformAddressLike>")] addresses: Vec<
+            JsValue,
+        >,
     ) -> Result<Map, WasmSdkError> {
         let platform_addresses: BTreeSet<PlatformAddress> = addresses
             .into_iter()
@@ -156,7 +158,9 @@ impl WasmSdk {
     )]
     pub async fn get_addresses_infos_with_proof_info(
         &self,
-        #[wasm_bindgen(unchecked_param_type = "Array<PlatformAddressLike>")] addresses: Vec<JsValue>,
+        #[wasm_bindgen(unchecked_param_type = "Array<PlatformAddressLike>")] addresses: Vec<
+            JsValue,
+        >,
     ) -> Result<ProofMetadataResponseWasm, WasmSdkError> {
         let platform_addresses: BTreeSet<PlatformAddress> = addresses
             .into_iter()

--- a/packages/wasm-sdk/src/queries/mod.rs
+++ b/packages/wasm-sdk/src/queries/mod.rs
@@ -1,3 +1,4 @@
+pub mod address;
 pub mod data_contract;
 pub mod document;
 pub mod epoch;
@@ -10,6 +11,7 @@ pub(crate) mod utils;
 pub mod voting;
 
 // Re-export all query functions for easy access
+pub use address::AddressInfoWasm;
 pub use group::*;
 
 use js_sys::Uint8Array;

--- a/packages/wasm-sdk/src/queries/mod.rs
+++ b/packages/wasm-sdk/src/queries/mod.rs
@@ -11,7 +11,7 @@ pub(crate) mod utils;
 pub mod voting;
 
 // Re-export all query functions for easy access
-pub use address::AddressInfoWasm;
+pub use address::PlatformAddressInfoWasm;
 pub use group::*;
 
 use js_sys::Uint8Array;


### PR DESCRIPTION
## Issue being fixed or feature implemented

Support Platform Address queries in JS Evo SDK

## What was done?


- Added `PlatformAddress` type to wasm-dpp2 (P2PKH/P2SH, bytes/hex/bech32m conversions)
- Added address query endpoints to wasm-sdk (`getAddressInfo`, `getAddressesInfos`, with proof variants)
- Added `AddressesFacade` to JS Evo SDK (`get`, `getMany`, `getWithProof`, `getManyWithProof`)
- Address queries return `undefined` for unfunded addresses instead of throwing errors

## How Has This Been Tested?

- Unit tests for `AddressesFacade` verifying correct method delegation to wasm-sdk
- Unit tests for `PlatformAddress` verifying bytes/bech32m conversions and address type detection
- Functional tests querying testnet addresses

## Breaking Changes

None

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [x] I have made corresponding changes to the documentation if needed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an addresses API to the SDK for fetching single or multiple platform address details, with optional cryptographic proof and metadata.
  * Introduced a PlatformAddress JS type with multi-format support (bech32m, bytes, hex) and helpers for encoding/decoding and inspection.
  * Address info is exposed to the wasm SDK as a typed PlatformAddressInfo object.

* **Tests**
  * Added unit and functional tests covering single/multi lookups, proof responses, and address format handling.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->