### PR TITLE
ci: add workflow to auto-assign milestones based on target branch

### DIFF
--- a/.github/workflows/milestone.yml
+++ b/.github/workflows/milestone.yml
@@ -13,7 +13,7 @@ jobs:
       issues: write 
     steps:
       - name: Assign milestone based on target branch
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
         with:
           script: |
             const pr = context.payload.pull_request;

--- a/.github/workflows/milestone.yml
+++ b/.github/workflows/milestone.yml
@@ -52,7 +52,7 @@ jobs:
             const milestone = milestones.data.find(m => m.title === milestoneName);
 
             if (!milestone) {
-              console.log(`Milestone ${milestoneName} not found`);
+              core.warning(`Milestone ${milestoneName} not found. Create it to enable automatic assignment.`);
               return;
             }
 

--- a/.github/workflows/milestone.yml
+++ b/.github/workflows/milestone.yml
@@ -1,0 +1,67 @@
+name: Assign Milestone
+
+on:
+  pull_request:
+    types: [opened, reopened, edited]
+    branches:
+      - master
+      - "v*-dev"
+
+jobs:
+  assign-milestone:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Assign milestone based on target branch
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const pr = context.payload.pull_request;
+            const baseBranch = pr.base.ref;
+
+            // Skip if PR already has a milestone
+            if (pr.milestone) {
+              console.log(`PR already has milestone: ${pr.milestone.title}`);
+              return;
+            }
+
+            // Skip if targeting master
+            if (baseBranch === 'master') {
+              console.log('PR targets master, skipping milestone assignment');
+              return;
+            }
+
+            // Parse v*-dev branch pattern
+            const match = baseBranch.match(/^v(\d+\.\d+)-dev$/);
+            if (!match) {
+              console.log(`Branch ${baseBranch} does not match v*-dev pattern`);
+              return;
+            }
+
+            const milestoneName = `v${match[1]}.0`;
+            console.log(`Looking for milestone: ${milestoneName}`);
+
+            // Find the milestone
+            const milestones = await github.rest.issues.listMilestones({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open'
+            });
+
+            const milestone = milestones.data.find(m => m.title === milestoneName);
+
+            if (!milestone) {
+              console.log(`Milestone ${milestoneName} not found`);
+              return;
+            }
+
+            // Assign the milestone
+            await github.rest.issues.update({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: pr.number,
+              milestone: milestone.number
+            });
+
+            console.log(`Assigned milestone ${milestoneName} to PR #${pr.number}`);

--- a/.github/workflows/milestone.yml
+++ b/.github/workflows/milestone.yml
@@ -3,15 +3,14 @@ name: Assign Milestone
 on:
   pull_request:
     types: [opened, reopened, edited]
-    branches:
-      - master
-      - "v*-dev"
 
 jobs:
   assign-milestone:
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write
+      # Following needed because PRs are technically under issues
+      issues: write 
     steps:
       - name: Assign milestone based on target branch
         uses: actions/github-script@v7
@@ -19,12 +18,6 @@ jobs:
           script: |
             const pr = context.payload.pull_request;
             const baseBranch = pr.base.ref;
-
-            // Skip if PR already has a milestone
-            if (pr.milestone) {
-              console.log(`PR already has milestone: ${pr.milestone.title}`);
-              return;
-            }
 
             // Skip if targeting master
             if (baseBranch === 'master') {
@@ -40,6 +33,13 @@ jobs:
             }
 
             const milestoneName = `v${match[1]}.0`;
+
+            // Skip if PR already has the correct milestone
+            if (pr.milestone && pr.milestone.title === milestoneName) {
+              console.log(`PR already has correct milestone: ${pr.milestone.title}`);
+              return;
+            }
+
             console.log(`Looking for milestone: ${milestoneName}`);
 
             // Find the milestone
@@ -56,7 +56,10 @@ jobs:
               return;
             }
 
-            // Assign the milestone
+            // Assign or update the milestone
+            if (pr.milestone) {
+              console.log(`Updating milestone from ${pr.milestone.title} to ${milestoneName}`);
+            }
             await github.rest.issues.update({
               owner: context.repo.owner,
               repo: context.repo.repo,


### PR DESCRIPTION
## Issue being fixed or feature implemented

Pull requests in this repo frequently are not assigned to a milestone. This PR automates milestone assignment for PRs to reduce manual overhead and ensure consistent milestone tracking. PRs targeting `v*-dev` branches will automatically receive the corresponding `v*.0` milestone.

## What was done?

Added a new GitHub Actions workflow that automatically assigns milestones to PRs based on their target branch:

- Maps `v*-dev` branches to `v*.0` milestones (e.g., `v3.0-dev` → `v3.0.0`)
- Updates milestone when PR is retargeted to a different branch
- Skips PRs targeting `master` or non-matching branches
- Warns if the expected milestone doesn't exist (open milestones only)
- Respects existing correct milestone assignments

## How Has This Been Tested?

Manual testing on my fork of the repo

## Breaking Changes

None

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [ ] I have made corresponding changes to the documentation if needed

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added an automated workflow that assigns or updates pull request milestones for PRs targeting release dev branches (vX.Y-dev). It skips master, warns if the derived milestone doesn’t exist, and logs decisions and updates during processing.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->