### PR TITLE
fix(drive-abci): use checkpoints properly in queries

### DIFF
--- a/packages/rs-drive-abci/src/execution/engine/finalize_block_proposal/v0/mod.rs
+++ b/packages/rs-drive-abci/src/execution/engine/finalize_block_proposal/v0/mod.rs
@@ -227,13 +227,14 @@ where
 
         self.update_drive_cache(&block_execution_context, platform_version)?;
 
-        self.update_checkpoints(&block_execution_context, platform_version)?;
+        let checkpointed = self.update_checkpoints(&block_execution_context, platform_version)?;
 
         let block_platform_state = block_execution_context.block_platform_state_owned();
 
         self.update_state_cache(
             extended_block_info,
             block_platform_state,
+            checkpointed,
             transaction,
             platform_version,
         )?;

--- a/packages/rs-drive-abci/src/execution/platform_events/block_end/update_checkpoints/mod.rs
+++ b/packages/rs-drive-abci/src/execution/platform_events/block_end/update_checkpoints/mod.rs
@@ -27,21 +27,21 @@ where
     ///
     /// # Returns
     ///
-    /// * `Result<(), Error>` - If the state cache and quorums are successfully updated, it returns `Ok(())`.
+    /// * `Result<bool, Error>` - Returns `Ok(true)` if a checkpoint was created, `Ok(false)` otherwise.
     ///   If there is a problem with the update, it returns an `Error`.
     ///
     pub fn update_checkpoints(
         &self,
         block_execution_context: &BlockExecutionContext,
         platform_version: &PlatformVersion,
-    ) -> Result<(), Error> {
+    ) -> Result<bool, Error> {
         match platform_version
             .drive_abci
             .methods
             .block_end
             .update_checkpoints
         {
-            None => Ok(()),
+            None => Ok(false),
             Some(0) => self.update_checkpoints_v0(block_execution_context, platform_version),
             Some(version) => Err(Error::Execution(ExecutionError::UnknownVersionMismatch {
                 method: "update_checkpoints".to_string(),

--- a/packages/rs-drive-abci/src/execution/platform_events/block_end/update_checkpoints/v0/mod.rs
+++ b/packages/rs-drive-abci/src/execution/platform_events/block_end/update_checkpoints/v0/mod.rs
@@ -5,7 +5,7 @@ use crate::execution::types::block_state_info::v0::BlockStateInfoV0Getters;
 use crate::platform_types::platform::Platform;
 use crate::rpc::core::CoreRPCLike;
 use dpp::version::PlatformVersion;
-use drive::drive::Checkpoint;
+use drive::drive::{Checkpoint, CheckpointInfo};
 use drive::error::Error::IOErrorWithInfoString;
 use drive::grovedb::GroveDb;
 use std::collections::BTreeMap;
@@ -16,16 +16,18 @@ where
     C: CoreRPCLike,
 {
     /// Updates checkpoints
+    ///
+    /// Returns `true` if a new checkpoint was created, `false` otherwise.
     #[inline(always)]
     pub(super) fn update_checkpoints_v0(
         &self,
         block_execution_context: &BlockExecutionContext,
         platform_version: &PlatformVersion,
-    ) -> Result<(), Error> {
+    ) -> Result<bool, Error> {
         // Check if checkpoints are disabled in testing config
         #[cfg(feature = "testing-config")]
         if self.config.testing_configs.disable_checkpoints {
-            return Ok(());
+            return Ok(false);
         }
 
         // How often we want a checkpoint
@@ -35,7 +37,7 @@ where
 
         // If disabled or misconfigured, do nothing.
         if checkpoint_interval_milliseconds == 0 || keep_n == 0 {
-            return Ok(());
+            return Ok(false);
         }
 
         let block_info = block_execution_context.block_state_info();
@@ -51,14 +53,14 @@ where
         // Determine whether we should checkpoint based on the last checkpoint timestamp
         let should_checkpoint = match current_checkpoints.last_key_value() {
             None => true,
-            Some((_height, (last_ts_ms, _db))) => {
-                *last_ts_ms < most_recent_checkpoint_interval_time
+            Some((_height, checkpoint_info)) => {
+                checkpoint_info.timestamp_ms < most_recent_checkpoint_interval_time
                     && block_time >= most_recent_checkpoint_interval_time
             }
         };
 
         if !should_checkpoint {
-            return Ok(());
+            return Ok(false);
         }
 
         // Build the checkpoint path: db_path/checkpoints/<block_height>
@@ -90,15 +92,18 @@ where
 
         // Mark old checkpoints that we're not keeping for deletion
         // They will be cleaned up when their Arc reference count drops to zero
-        for (_, (_, checkpoint)) in current_checkpoints.iter().take(to_skip) {
-            checkpoint.mark_for_deletion();
+        for (_, checkpoint_info) in current_checkpoints.iter().take(to_skip) {
+            checkpoint_info.checkpoint.mark_for_deletion();
         }
 
         // Build new map with only the checkpoints we want to keep
         let mut new_checkpoints = BTreeMap::new();
 
         // Add the new checkpoint
-        new_checkpoints.insert(block_height, (block_time, Arc::new(checkpoint)));
+        new_checkpoints.insert(
+            block_height,
+            CheckpointInfo::new(block_time, Arc::new(checkpoint)),
+        );
 
         // Copy only the most recent old checkpoints (skip the oldest ones)
         // BTreeMap iterates in ascending order, so skip the first `to_skip` entries
@@ -109,6 +114,6 @@ where
         // Atomically swap in the new checkpoints map
         self.drive.checkpoints.store(Arc::new(new_checkpoints));
 
-        Ok(())
+        Ok(true)
     }
 }

--- a/packages/rs-drive-abci/src/execution/platform_events/block_end/update_state_cache/mod.rs
+++ b/packages/rs-drive-abci/src/execution/platform_events/block_end/update_state_cache/mod.rs
@@ -24,6 +24,8 @@ where
     /// # Arguments
     ///
     /// * `extended_block_info` - Extended block information for the current block.
+    /// * `block_platform_state` - The platform state for this block.
+    /// * `checkpointed` - Whether a checkpoint was created for this block.
     /// * `transaction` - The transaction associated with the block.
     /// * `platform_version` - A `PlatformVersion` reference that dictates which version of
     ///   the method to call.
@@ -37,6 +39,7 @@ where
         &self,
         extended_block_info: ExtendedBlockInfo,
         block_platform_state: PlatformState,
+        checkpointed: bool,
         transaction: &Transaction,
         platform_version: &PlatformVersion,
     ) -> Result<(), Error> {
@@ -49,6 +52,7 @@ where
             0 => self.update_state_cache_v0(
                 extended_block_info,
                 block_platform_state,
+                checkpointed,
                 transaction,
                 platform_version,
             ),

--- a/packages/rs-drive-abci/src/execution/platform_events/block_end/update_state_cache/v0/mod.rs
+++ b/packages/rs-drive-abci/src/execution/platform_events/block_end/update_state_cache/v0/mod.rs
@@ -4,7 +4,9 @@ use crate::platform_types::platform_state::PlatformState;
 use crate::platform_types::platform_state::PlatformStateV0Methods;
 use crate::rpc::core::CoreRPCLike;
 use dpp::block::extended_block_info::ExtendedBlockInfo;
+use dpp::serialization::PlatformSerializable;
 use dpp::version::PlatformVersion;
+use drive::error::Error::IOErrorWithInfoString;
 use drive::grovedb::Transaction;
 use std::collections::BTreeMap;
 use std::sync::Arc;
@@ -71,6 +73,25 @@ where
             let keep_n = platform_version.drive_abci.checkpoints.num_checkpoints as usize;
             let max_old_to_keep = keep_n.saturating_sub(1);
             let to_skip = checkpoints.len().saturating_sub(max_old_to_keep);
+
+            // Save platform state to checkpoint directory on disk
+            let checkpoint_state_path = self
+                .config
+                .db_path
+                .join("checkpoints")
+                .join(block_height.to_string())
+                .join("platform_state.bin");
+
+            let state_bytes = block_platform_state.serialize_to_bytes()?;
+            std::fs::write(&checkpoint_state_path, &state_bytes).map_err(|err| {
+                Error::Drive(IOErrorWithInfoString(
+                    err.into(),
+                    format!(
+                        "trying to write checkpoint platform state to {:?}",
+                        checkpoint_state_path
+                    ),
+                ))
+            })?;
 
             let current_checkpoint_states = self.checkpoint_platform_states.load();
             let mut new_checkpoint_states = BTreeMap::new();

--- a/packages/rs-drive-abci/src/execution/platform_events/block_end/update_state_cache/v0/mod.rs
+++ b/packages/rs-drive-abci/src/execution/platform_events/block_end/update_state_cache/v0/mod.rs
@@ -6,6 +6,7 @@ use crate::rpc::core::CoreRPCLike;
 use dpp::block::extended_block_info::ExtendedBlockInfo;
 use dpp::version::PlatformVersion;
 use drive::grovedb::Transaction;
+use std::collections::BTreeMap;
 use std::sync::Arc;
 
 impl<C> Platform<C>
@@ -22,6 +23,7 @@ where
     /// # Arguments
     ///
     /// * `block_info` - Extended block information for the current block.
+    /// * `checkpointed` - Whether a checkpoint was created for this block.
     /// * `transaction` - The transaction associated with the block.
     ///
     /// # Returns
@@ -39,6 +41,7 @@ where
         &self,
         extended_block_info: ExtendedBlockInfo,
         mut block_platform_state: PlatformState,
+        checkpointed: bool,
         transaction: &Transaction,
         platform_version: &PlatformVersion,
     ) -> Result<(), Error> {
@@ -59,7 +62,33 @@ where
 
         self.store_platform_state(&block_platform_state, Some(transaction), platform_version)?;
 
-        self.state.store(Arc::new(block_platform_state));
+        let block_platform_state = Arc::new(block_platform_state);
+
+        // If a checkpoint was created, store the platform state for that checkpoint
+        if checkpointed {
+            let block_height = block_platform_state.last_committed_block_height();
+            let checkpoints = self.drive.checkpoints.load();
+            let keep_n = platform_version.drive_abci.checkpoints.num_checkpoints as usize;
+            let max_old_to_keep = keep_n.saturating_sub(1);
+            let to_skip = checkpoints.len().saturating_sub(max_old_to_keep);
+
+            let current_checkpoint_states = self.checkpoint_platform_states.load();
+            let mut new_checkpoint_states = BTreeMap::new();
+
+            // Add the current platform state for this new checkpoint
+            new_checkpoint_states.insert(block_height, block_platform_state.clone());
+
+            // Copy only the states for checkpoints we're keeping
+            for (height, state) in current_checkpoint_states.iter().skip(to_skip) {
+                new_checkpoint_states.insert(*height, state.clone());
+            }
+
+            // Atomically swap in the new checkpoint states map
+            self.checkpoint_platform_states
+                .store(Arc::new(new_checkpoint_states));
+        }
+
+        self.state.store(block_platform_state);
 
         Ok(())
     }

--- a/packages/rs-drive-abci/src/platform_types/platform/mock.rs
+++ b/packages/rs-drive-abci/src/platform_types/platform/mock.rs
@@ -1,12 +1,14 @@
 use crate::config::PlatformConfig;
 use crate::error::Error;
 use crate::platform_types::platform::Platform;
-use crate::platform_types::platform_state::PlatformStateV0Methods;
+use crate::platform_types::platform_state::{PlatformState, PlatformStateV0Methods};
 use crate::rpc::core::MockCoreRPCLike;
 use dpp::dashcore::BlockHash;
+use dpp::serialization::PlatformDeserializableFromVersionedStructure;
 use dpp::version::PlatformVersionCurrentVersion;
 use dpp::version::{PlatformVersion, ProtocolVersion};
 use serde_json::json;
+use std::collections::BTreeMap;
 use std::path::Path;
 use std::str::FromStr;
 use std::sync::Arc;
@@ -49,6 +51,30 @@ impl Platform<MockCoreRPCLike> {
         PlatformVersion::set_current(PlatformVersion::get(
             persisted_state.current_protocol_version_in_consensus(),
         )?);
+
+        // Reload checkpoint platform states from disk
+        let mut checkpoint_platform_states = BTreeMap::new();
+        let checkpoints = self.drive.checkpoints.load();
+        for (&block_height, _checkpoint_info) in checkpoints.iter() {
+            let checkpoint_state_path = self
+                .config
+                .db_path
+                .join("checkpoints")
+                .join(block_height.to_string())
+                .join("platform_state.bin");
+
+            if checkpoint_state_path.exists() {
+                if let Ok(state_bytes) = std::fs::read(&checkpoint_state_path) {
+                    if let Ok(state) =
+                        PlatformState::versioned_deserialize(&state_bytes, platform_version)
+                    {
+                        checkpoint_platform_states.insert(block_height, Arc::new(state));
+                    }
+                }
+            }
+        }
+        self.checkpoint_platform_states
+            .store(Arc::new(checkpoint_platform_states));
 
         self.state.store(Arc::new(persisted_state));
 

--- a/packages/rs-drive-abci/src/platform_types/platform/mod.rs
+++ b/packages/rs-drive-abci/src/platform_types/platform/mod.rs
@@ -10,9 +10,11 @@ use std::fmt::{Debug, Formatter};
 
 use crate::platform_types::platform_state::{PlatformState, PlatformStateV0Methods};
 use arc_swap::ArcSwap;
+use dpp::prelude::BlockHeight;
 use dpp::version::ProtocolVersion;
 use dpp::version::INITIAL_PROTOCOL_VERSION;
 use dpp::version::{PlatformVersion, PlatformVersionCurrentVersion};
+use std::collections::BTreeMap;
 use std::path::Path;
 use std::sync::atomic::AtomicU64;
 use std::sync::Arc;
@@ -29,6 +31,9 @@ pub struct Platform<C> {
     // for query and check tx and we don't want to block affect the
     // state update on finalize block, and vise versa.
     pub state: ArcSwap<PlatformState>,
+    /// Platform states corresponding to each checkpoint, keyed by block height.
+    /// This allows queries against checkpoints to return the correct platform state.
+    pub checkpoint_platform_states: ArcSwap<BTreeMap<BlockHeight, Arc<PlatformState>>>,
     /// block height guard
     pub committed_block_height_guard: AtomicU64,
     /// Configuration
@@ -207,6 +212,7 @@ impl<C> Platform<C> {
 
         let platform: Platform<C> = Platform {
             drive,
+            checkpoint_platform_states: ArcSwap::from_pointee(BTreeMap::new()),
             state: ArcSwap::new(Arc::new(platform_state)),
             committed_block_height_guard: AtomicU64::from(height),
             config,
@@ -239,6 +245,7 @@ impl<C> Platform<C> {
 
         Ok(Platform {
             drive,
+            checkpoint_platform_states: ArcSwap::from_pointee(BTreeMap::new()),
             state: ArcSwap::new(Arc::new(platform_state)),
             committed_block_height_guard: AtomicU64::from(height),
             config,

--- a/packages/rs-drive-abci/src/platform_types/platform/mod.rs
+++ b/packages/rs-drive-abci/src/platform_types/platform/mod.rs
@@ -11,6 +11,7 @@ use std::fmt::{Debug, Formatter};
 use crate::platform_types::platform_state::{PlatformState, PlatformStateV0Methods};
 use arc_swap::ArcSwap;
 use dpp::prelude::BlockHeight;
+use dpp::serialization::PlatformDeserializableFromVersionedStructure;
 use dpp::version::ProtocolVersion;
 use dpp::version::INITIAL_PROTOCOL_VERSION;
 use dpp::version::{PlatformVersion, PlatformVersionCurrentVersion};
@@ -167,11 +168,53 @@ impl<C> Platform<C> {
                     .reload_system_contracts(platform_version)?;
             }
 
+            // Load checkpoint platform states from disk
+            let mut checkpoint_platform_states = BTreeMap::new();
+            let checkpoints = drive.checkpoints.load();
+            for (&block_height, _checkpoint_info) in checkpoints.iter() {
+                let checkpoint_state_path = config
+                    .db_path
+                    .join("checkpoints")
+                    .join(block_height.to_string())
+                    .join("platform_state.bin");
+
+                if checkpoint_state_path.exists() {
+                    match std::fs::read(&checkpoint_state_path) {
+                        Ok(state_bytes) => {
+                            match PlatformState::versioned_deserialize(
+                                &state_bytes,
+                                platform_version,
+                            ) {
+                                Ok(state) => {
+                                    checkpoint_platform_states
+                                        .insert(block_height, Arc::new(state));
+                                }
+                                Err(e) => {
+                                    tracing::warn!(
+                                        "Failed to deserialize checkpoint platform state at height {}: {:?}",
+                                        block_height,
+                                        e
+                                    );
+                                }
+                            }
+                        }
+                        Err(e) => {
+                            tracing::warn!(
+                                "Failed to read checkpoint platform state file at {:?}: {:?}",
+                                checkpoint_state_path,
+                                e
+                            );
+                        }
+                    }
+                }
+            }
+
             return Platform::open_with_client_saved_state::<P>(
                 drive,
                 core_rpc,
                 config,
                 execution_state,
+                checkpoint_platform_states,
             );
         }
 
@@ -190,6 +233,7 @@ impl<C> Platform<C> {
         core_rpc: C,
         config: PlatformConfig,
         mut platform_state: PlatformState,
+        checkpoint_platform_states: BTreeMap<BlockHeight, Arc<PlatformState>>,
     ) -> Result<Platform<C>, Error>
     where
         C: CoreRPCLike,
@@ -212,7 +256,7 @@ impl<C> Platform<C> {
 
         let platform: Platform<C> = Platform {
             drive,
-            checkpoint_platform_states: ArcSwap::from_pointee(BTreeMap::new()),
+            checkpoint_platform_states: ArcSwap::from_pointee(checkpoint_platform_states),
             state: ArcSwap::new(Arc::new(platform_state)),
             committed_block_height_guard: AtomicU64::from(height),
             config,

--- a/packages/rs-drive-abci/src/query/address_funds/address_info/v0/mod.rs
+++ b/packages/rs-drive-abci/src/query/address_funds/address_info/v0/mod.rs
@@ -2,6 +2,7 @@ use crate::error::query::QueryError;
 use crate::error::Error;
 use crate::platform_types::platform::Platform;
 use crate::platform_types::platform_state::PlatformState;
+use crate::query::response_metadata::CheckpointUsed;
 use crate::query::QueryValidationResult;
 use dapi_grpc::platform::v0::get_address_info_request::GetAddressInfoRequestV0;
 use dapi_grpc::platform::v0::get_address_info_response::{
@@ -12,6 +13,7 @@ use dpp::address_funds::PlatformAddress;
 use dpp::check_validation_result_with_data;
 use dpp::validation::ValidationResult;
 use dpp::version::PlatformVersion;
+use drive::util::grove_operations::GroveDBToUse;
 
 impl<C> Platform<C> {
     pub(super) fn query_address_info_v0(
@@ -36,11 +38,12 @@ impl<C> Platform<C> {
                 platform_version,
             ));
 
+            let (grovedb_used, proof) =
+                self.response_proof_v0(platform_state, proof, GroveDBToUse::Current)?;
+
             GetAddressInfoResponseV0 {
-                result: Some(get_address_info_response_v0::Result::Proof(
-                    self.response_proof_v0(platform_state, proof),
-                )),
-                metadata: Some(self.response_metadata_v0(platform_state)),
+                result: Some(get_address_info_response_v0::Result::Proof(proof)),
+                metadata: Some(self.response_metadata_v0(platform_state, grovedb_used)),
             }
         } else {
             let balance_and_nonce = self
@@ -55,7 +58,7 @@ impl<C> Platform<C> {
                         balance_and_nonce,
                     },
                 )),
-                metadata: Some(self.response_metadata_v0(platform_state)),
+                metadata: Some(self.response_metadata_v0(platform_state, CheckpointUsed::Current)),
             }
         };
 

--- a/packages/rs-drive-abci/src/query/address_funds/addresses_infos/v0/mod.rs
+++ b/packages/rs-drive-abci/src/query/address_funds/addresses_infos/v0/mod.rs
@@ -2,6 +2,7 @@ use crate::error::query::QueryError;
 use crate::error::Error;
 use crate::platform_types::platform::Platform;
 use crate::platform_types::platform_state::PlatformState;
+use crate::query::response_metadata::CheckpointUsed;
 use crate::query::QueryValidationResult;
 use dapi_grpc::platform::v0::get_addresses_infos_request::GetAddressesInfosRequestV0;
 use dapi_grpc::platform::v0::get_addresses_infos_response::{
@@ -12,6 +13,7 @@ use dpp::address_funds::PlatformAddress;
 use dpp::check_validation_result_with_data;
 use dpp::validation::ValidationResult;
 use dpp::version::PlatformVersion;
+use drive::util::grove_operations::GroveDBToUse;
 use std::collections::BTreeMap;
 
 impl<C> Platform<C> {
@@ -37,11 +39,12 @@ impl<C> Platform<C> {
                 platform_version,
             ));
 
+            let (grovedb_used, proof) =
+                self.response_proof_v0(platform_state, proof, GroveDBToUse::Current)?;
+
             GetAddressesInfosResponseV0 {
-                result: Some(get_addresses_infos_response_v0::Result::Proof(
-                    self.response_proof_v0(platform_state, proof),
-                )),
-                metadata: Some(self.response_metadata_v0(platform_state)),
+                result: Some(get_addresses_infos_response_v0::Result::Proof(proof)),
+                metadata: Some(self.response_metadata_v0(platform_state, grovedb_used)),
             }
         } else {
             let addresses_infos: BTreeMap<_, _> =
@@ -63,7 +66,7 @@ impl<C> Platform<C> {
                         address_info_entries,
                     },
                 )),
-                metadata: Some(self.response_metadata_v0(platform_state)),
+                metadata: Some(self.response_metadata_v0(platform_state, CheckpointUsed::Current)),
             }
         };
 

--- a/packages/rs-drive-abci/src/query/address_funds/addresses_trunk_state/v0/mod.rs
+++ b/packages/rs-drive-abci/src/query/address_funds/addresses_trunk_state/v0/mod.rs
@@ -7,6 +7,7 @@ use dapi_grpc::platform::v0::get_addresses_trunk_state_response::GetAddressesTru
 use dpp::check_validation_result_with_data;
 use dpp::validation::ValidationResult;
 use dpp::version::PlatformVersion;
+use drive::util::grove_operations::GroveDBToUse;
 
 impl<C> Platform<C> {
     pub(super) fn query_addresses_trunk_state_v0(
@@ -19,9 +20,12 @@ impl<C> Platform<C> {
             .drive
             .prove_address_funds_trunk_query(platform_version));
 
+        let (grovedb_used, proof) =
+            self.response_proof_v0(platform_state, proof, GroveDBToUse::LatestCheckpoint)?;
+
         let response = GetAddressesTrunkStateResponseV0 {
-            proof: Some(self.response_proof_v0(platform_state, proof)),
-            metadata: Some(self.response_metadata_v0(platform_state)),
+            proof: Some(proof),
+            metadata: Some(self.response_metadata_v0(platform_state, grovedb_used)),
         };
 
         Ok(QueryValidationResult::new_with_data(response))

--- a/packages/rs-drive-abci/src/query/data_contract_based_queries/data_contract/v0/mod.rs
+++ b/packages/rs-drive-abci/src/query/data_contract_based_queries/data_contract/v0/mod.rs
@@ -2,6 +2,7 @@ use crate::error::query::QueryError;
 use crate::error::Error;
 use crate::platform_types::platform::Platform;
 use crate::platform_types::platform_state::PlatformState;
+use crate::query::response_metadata::CheckpointUsed;
 use crate::query::QueryValidationResult;
 use dapi_grpc::platform::v0::get_data_contract_request::GetDataContractRequestV0;
 use dapi_grpc::platform::v0::get_data_contract_response::{
@@ -12,6 +13,7 @@ use dpp::identifier::Identifier;
 use dpp::serialization::PlatformSerializableWithPlatformVersion;
 use dpp::validation::ValidationResult;
 use dpp::version::PlatformVersion;
+use drive::util::grove_operations::GroveDBToUse;
 
 impl<C> Platform<C> {
     pub(super) fn query_data_contract_v0(
@@ -34,9 +36,10 @@ impl<C> Platform<C> {
 
             GetDataContractResponseV0 {
                 result: Some(get_data_contract_response_v0::Result::Proof(
-                    self.response_proof_v0(platform_state, proof),
+                    self.response_proof_v0(platform_state, proof, GroveDBToUse::Current)
+                        .map(|(_, proof)| proof)?,
                 )),
-                metadata: Some(self.response_metadata_v0(platform_state)),
+                metadata: Some(self.response_metadata_v0(platform_state, CheckpointUsed::Current)),
             }
         } else {
             let maybe_data_contract_fetch_info = self
@@ -64,7 +67,7 @@ impl<C> Platform<C> {
                 result: Some(get_data_contract_response_v0::Result::DataContract(
                     serialized_data_contract,
                 )),
-                metadata: Some(self.response_metadata_v0(platform_state)),
+                metadata: Some(self.response_metadata_v0(platform_state, CheckpointUsed::Current)),
             }
         };
 

--- a/packages/rs-drive-abci/src/query/data_contract_based_queries/data_contract_history/v0/mod.rs
+++ b/packages/rs-drive-abci/src/query/data_contract_based_queries/data_contract_history/v0/mod.rs
@@ -10,6 +10,8 @@ use dpp::validation::ValidationResult;
 use dpp::version::PlatformVersion;
 use dpp::{check_validation_result_with_data, ProtocolError};
 use dapi_grpc::platform::v0::get_data_contract_history_response::get_data_contract_history_response_v0::DataContractHistoryEntry;
+use drive::util::grove_operations::GroveDBToUse;
+use crate::query::response_metadata::CheckpointUsed;
 use crate::platform_types::platform_state::PlatformState;
 
 impl<C> Platform<C> {
@@ -58,9 +60,10 @@ impl<C> Platform<C> {
 
             GetDataContractHistoryResponseV0 {
                 result: Some(get_data_contract_history_response_v0::Result::Proof(
-                    self.response_proof_v0(platform_state, proof),
+                    self.response_proof_v0(platform_state, proof, GroveDBToUse::Current)
+                        .map(|(_, proof)| proof)?,
                 )),
-                metadata: Some(self.response_metadata_v0(platform_state)),
+                metadata: Some(self.response_metadata_v0(platform_state, CheckpointUsed::Current)),
             }
         } else {
             let contracts = self.drive.fetch_contract_with_history(
@@ -97,7 +100,7 @@ impl<C> Platform<C> {
                         },
                     ),
                 ),
-                metadata: Some(self.response_metadata_v0(platform_state)),
+                metadata: Some(self.response_metadata_v0(platform_state, CheckpointUsed::Current)),
             }
         };
 

--- a/packages/rs-drive-abci/src/query/data_contract_based_queries/data_contracts/v0/mod.rs
+++ b/packages/rs-drive-abci/src/query/data_contract_based_queries/data_contracts/v0/mod.rs
@@ -2,6 +2,7 @@ use crate::error::query::QueryError;
 use crate::error::Error;
 use crate::platform_types::platform::Platform;
 use crate::platform_types::platform_state::PlatformState;
+use crate::query::response_metadata::CheckpointUsed;
 use crate::query::QueryValidationResult;
 use dapi_grpc::platform::v0::get_data_contracts_request::GetDataContractsRequestV0;
 use dapi_grpc::platform::v0::get_data_contracts_response;
@@ -14,6 +15,7 @@ use dpp::serialization::PlatformSerializableWithPlatformVersion;
 use dpp::validation::ValidationResult;
 use dpp::version::PlatformVersion;
 use dpp::{check_validation_result_with_data, ProtocolError};
+use drive::util::grove_operations::GroveDBToUse;
 
 impl<C> Platform<C> {
     pub(super) fn query_data_contracts_v0(
@@ -42,9 +44,10 @@ impl<C> Platform<C> {
 
             GetDataContractsResponseV0 {
                 result: Some(get_data_contracts_response_v0::Result::Proof(
-                    self.response_proof_v0(platform_state, proof),
+                    self.response_proof_v0(platform_state, proof, GroveDBToUse::Current)
+                        .map(|(_, proof)| proof)?,
                 )),
-                metadata: Some(self.response_metadata_v0(platform_state)),
+                metadata: Some(self.response_metadata_v0(platform_state, CheckpointUsed::Current)),
             }
         } else {
             let contracts = self.drive.get_contracts_with_fetch_info(
@@ -76,7 +79,7 @@ impl<C> Platform<C> {
                         data_contract_entries: contracts,
                     },
                 )),
-                metadata: Some(self.response_metadata_v0(platform_state)),
+                metadata: Some(self.response_metadata_v0(platform_state, CheckpointUsed::Current)),
             }
         };
 

--- a/packages/rs-drive-abci/src/query/document_query/v0/mod.rs
+++ b/packages/rs-drive-abci/src/query/document_query/v0/mod.rs
@@ -2,6 +2,7 @@ use crate::error::query::QueryError;
 use crate::error::Error;
 use crate::platform_types::platform::Platform;
 use crate::platform_types::platform_state::PlatformState;
+use crate::query::response_metadata::CheckpointUsed;
 use crate::query::QueryValidationResult;
 use dapi_grpc::platform::v0::get_documents_request::get_documents_request_v0::Start;
 use dapi_grpc::platform::v0::get_documents_request::GetDocumentsRequestV0;
@@ -16,6 +17,7 @@ use dpp::validation::ValidationResult;
 use dpp::version::PlatformVersion;
 use drive::error::query::QuerySyntaxError;
 use drive::query::DriveDocumentQuery;
+use drive::util::grove_operations::GroveDBToUse;
 
 impl<C> Platform<C> {
     pub(super) fn query_documents_v0(
@@ -143,11 +145,12 @@ impl<C> Platform<C> {
                     Err(e) => return Err(e.into()),
                 };
 
+            let (grovedb_used, proof) =
+                self.response_proof_v0(platform_state, proof, GroveDBToUse::Current)?;
+
             GetDocumentsResponseV0 {
-                result: Some(get_documents_response_v0::Result::Proof(
-                    self.response_proof_v0(platform_state, proof),
-                )),
-                metadata: Some(self.response_metadata_v0(platform_state)),
+                result: Some(get_documents_response_v0::Result::Proof(proof)),
+                metadata: Some(self.response_metadata_v0(platform_state, grovedb_used)),
             }
         } else {
             let results = match drive_query.execute_raw_results_no_proof(
@@ -169,7 +172,7 @@ impl<C> Platform<C> {
                 result: Some(get_documents_response_v0::Result::Documents(
                     get_documents_response_v0::Documents { documents: results },
                 )),
-                metadata: Some(self.response_metadata_v0(platform_state)),
+                metadata: Some(self.response_metadata_v0(platform_state, CheckpointUsed::Current)),
             }
         };
 

--- a/packages/rs-drive-abci/src/query/group_queries/group_action_signers/v0/mod.rs
+++ b/packages/rs-drive-abci/src/query/group_queries/group_action_signers/v0/mod.rs
@@ -15,6 +15,8 @@ use dpp::identifier::Identifier;
 use dpp::validation::ValidationResult;
 use dpp::version::PlatformVersion;
 use drive::error::query::QuerySyntaxError;
+use drive::util::grove_operations::GroveDBToUse;
+use crate::query::response_metadata::CheckpointUsed;
 
 impl<C> Platform<C> {
     pub(super) fn query_group_action_signers_v0(
@@ -69,11 +71,12 @@ impl<C> Platform<C> {
                 platform_version,
             ));
 
+            let (grovedb_used, proof) =
+                self.response_proof_v0(platform_state, proof, GroveDBToUse::Current)?;
+
             GetGroupActionSignersResponseV0 {
-                result: Some(get_group_action_signers_response_v0::Result::Proof(
-                    self.response_proof_v0(platform_state, proof),
-                )),
-                metadata: Some(self.response_metadata_v0(platform_state)),
+                result: Some(get_group_action_signers_response_v0::Result::Proof(proof)),
+                metadata: Some(self.response_metadata_v0(platform_state, grovedb_used)),
             }
         } else {
             let group_action_signers = self
@@ -100,7 +103,7 @@ impl<C> Platform<C> {
                         },
                     ),
                 ),
-                metadata: Some(self.response_metadata_v0(platform_state)),
+                metadata: Some(self.response_metadata_v0(platform_state, CheckpointUsed::Current)),
             }
         };
 

--- a/packages/rs-drive-abci/src/query/group_queries/group_actions/v0/mod.rs
+++ b/packages/rs-drive-abci/src/query/group_queries/group_actions/v0/mod.rs
@@ -22,6 +22,8 @@ use dpp::tokens::token_pricing_schedule::TokenPricingSchedule;
 use dpp::validation::ValidationResult;
 use dpp::version::PlatformVersion;
 use drive::error::query::QuerySyntaxError;
+use drive::util::grove_operations::GroveDBToUse;
+use crate::query::response_metadata::CheckpointUsed;
 
 impl<C> Platform<C> {
     pub(super) fn query_group_actions_v0(
@@ -107,11 +109,12 @@ impl<C> Platform<C> {
                 platform_version,
             ));
 
+            let (grovedb_used, proof) =
+                self.response_proof_v0(platform_state, proof, GroveDBToUse::Current)?;
+
             GetGroupActionsResponseV0 {
-                result: Some(get_group_actions_response_v0::Result::Proof(
-                    self.response_proof_v0(platform_state, proof),
-                )),
-                metadata: Some(self.response_metadata_v0(platform_state)),
+                result: Some(get_group_actions_response_v0::Result::Proof(proof)),
+                metadata: Some(self.response_metadata_v0(platform_state, grovedb_used)),
             }
         } else {
             let group_actions = self
@@ -235,7 +238,7 @@ impl<C> Platform<C> {
                 result: Some(get_group_actions_response_v0::Result::GroupActions(
                     GroupActions { group_actions },
                 )),
-                metadata: Some(self.response_metadata_v0(platform_state)),
+                metadata: Some(self.response_metadata_v0(platform_state, CheckpointUsed::Current)),
             }
         };
 

--- a/packages/rs-drive-abci/src/query/group_queries/group_info/v0/mod.rs
+++ b/packages/rs-drive-abci/src/query/group_queries/group_info/v0/mod.rs
@@ -2,6 +2,7 @@ use crate::error::query::QueryError;
 use crate::error::Error;
 use crate::platform_types::platform::Platform;
 use crate::platform_types::platform_state::PlatformState;
+use crate::query::response_metadata::CheckpointUsed;
 use crate::query::QueryValidationResult;
 use dapi_grpc::platform::v0::get_group_info_request::GetGroupInfoRequestV0;
 use dapi_grpc::platform::v0::get_group_info_response::get_group_info_response_v0::{
@@ -16,6 +17,7 @@ use dpp::identifier::Identifier;
 use dpp::validation::ValidationResult;
 use dpp::version::PlatformVersion;
 use drive::error::query::QuerySyntaxError;
+use drive::util::grove_operations::GroveDBToUse;
 
 impl<C> Platform<C> {
     pub(super) fn query_group_info_v0(
@@ -52,11 +54,12 @@ impl<C> Platform<C> {
                 platform_version,
             ));
 
+            let (grovedb_used, proof) =
+                self.response_proof_v0(platform_state, proof, GroveDBToUse::Current)?;
+
             GetGroupInfoResponseV0 {
-                result: Some(get_group_info_response_v0::Result::Proof(
-                    self.response_proof_v0(platform_state, proof),
-                )),
-                metadata: Some(self.response_metadata_v0(platform_state)),
+                result: Some(get_group_info_response_v0::Result::Proof(proof)),
+                metadata: Some(self.response_metadata_v0(platform_state, grovedb_used)),
             }
         } else {
             let group_info = self
@@ -86,7 +89,7 @@ impl<C> Platform<C> {
                 result: Some(get_group_info_response_v0::Result::GroupInfo(GroupInfo {
                     group_info,
                 })),
-                metadata: Some(self.response_metadata_v0(platform_state)),
+                metadata: Some(self.response_metadata_v0(platform_state, CheckpointUsed::Current)),
             }
         };
 

--- a/packages/rs-drive-abci/src/query/group_queries/group_infos/v0/mod.rs
+++ b/packages/rs-drive-abci/src/query/group_queries/group_infos/v0/mod.rs
@@ -2,6 +2,7 @@ use crate::error::query::QueryError;
 use crate::error::Error;
 use crate::platform_types::platform::Platform;
 use crate::platform_types::platform_state::PlatformState;
+use crate::query::response_metadata::CheckpointUsed;
 use crate::query::QueryValidationResult;
 use dapi_grpc::platform::v0::get_group_infos_request::GetGroupInfosRequestV0;
 use dapi_grpc::platform::v0::get_group_infos_response::get_group_infos_response_v0::{
@@ -16,6 +17,7 @@ use dpp::identifier::Identifier;
 use dpp::validation::ValidationResult;
 use dpp::version::PlatformVersion;
 use drive::error::query::QuerySyntaxError;
+use drive::util::grove_operations::GroveDBToUse;
 
 impl<C> Platform<C> {
     pub(super) fn query_group_infos_v0(
@@ -80,11 +82,12 @@ impl<C> Platform<C> {
                 platform_version,
             ));
 
+            let (grovedb_used, proof) =
+                self.response_proof_v0(platform_state, proof, GroveDBToUse::Current)?;
+
             GetGroupInfosResponseV0 {
-                result: Some(get_group_infos_response_v0::Result::Proof(
-                    self.response_proof_v0(platform_state, proof),
-                )),
-                metadata: Some(self.response_metadata_v0(platform_state)),
+                result: Some(get_group_infos_response_v0::Result::Proof(proof)),
+                metadata: Some(self.response_metadata_v0(platform_state, grovedb_used)),
             }
         } else {
             let group_infos = self
@@ -118,7 +121,7 @@ impl<C> Platform<C> {
                 result: Some(get_group_infos_response_v0::Result::GroupInfos(
                     GroupInfos { group_infos },
                 )),
-                metadata: Some(self.response_metadata_v0(platform_state)),
+                metadata: Some(self.response_metadata_v0(platform_state, CheckpointUsed::Current)),
             }
         };
 

--- a/packages/rs-drive-abci/src/query/identity_based_queries/balance/v0/mod.rs
+++ b/packages/rs-drive-abci/src/query/identity_based_queries/balance/v0/mod.rs
@@ -2,6 +2,7 @@ use crate::error::query::QueryError;
 use crate::error::Error;
 use crate::platform_types::platform::Platform;
 use crate::platform_types::platform_state::PlatformState;
+use crate::query::response_metadata::CheckpointUsed;
 use crate::query::QueryValidationResult;
 use dapi_grpc::platform::v0::get_identity_balance_request::GetIdentityBalanceRequestV0;
 use dapi_grpc::platform::v0::get_identity_balance_response::get_identity_balance_response_v0;
@@ -10,6 +11,7 @@ use dpp::check_validation_result_with_data;
 use dpp::identifier::Identifier;
 use dpp::validation::ValidationResult;
 use dpp::version::PlatformVersion;
+use drive::util::grove_operations::GroveDBToUse;
 
 impl<C> Platform<C> {
     pub(super) fn query_balance_v0(
@@ -34,9 +36,10 @@ impl<C> Platform<C> {
 
             GetIdentityBalanceResponseV0 {
                 result: Some(get_identity_balance_response_v0::Result::Proof(
-                    self.response_proof_v0(platform_state, proof),
+                    self.response_proof_v0(platform_state, proof, GroveDBToUse::Current)
+                        .map(|(_, proof)| proof)?,
                 )),
-                metadata: Some(self.response_metadata_v0(platform_state)),
+                metadata: Some(self.response_metadata_v0(platform_state, CheckpointUsed::Current)),
             }
         } else {
             let maybe_balance = self.drive.fetch_identity_balance(
@@ -53,7 +56,7 @@ impl<C> Platform<C> {
 
             GetIdentityBalanceResponseV0 {
                 result: Some(get_identity_balance_response_v0::Result::Balance(balance)),
-                metadata: Some(self.response_metadata_v0(platform_state)),
+                metadata: Some(self.response_metadata_v0(platform_state, CheckpointUsed::Current)),
             }
         };
 

--- a/packages/rs-drive-abci/src/query/identity_based_queries/balance_and_revision/v0/mod.rs
+++ b/packages/rs-drive-abci/src/query/identity_based_queries/balance_and_revision/v0/mod.rs
@@ -9,6 +9,8 @@ use dpp::validation::ValidationResult;
 use dpp::version::PlatformVersion;
 use dapi_grpc::platform::v0::get_identity_balance_and_revision_request::GetIdentityBalanceAndRevisionRequestV0;
 use dapi_grpc::platform::v0::get_identity_balance_and_revision_response::get_identity_balance_and_revision_response_v0::BalanceAndRevision;
+use drive::util::grove_operations::GroveDBToUse;
+use crate::query::response_metadata::CheckpointUsed;
 use crate::platform_types::platform_state::PlatformState;
 
 impl<C> Platform<C> {
@@ -35,10 +37,11 @@ impl<C> Platform<C> {
             GetIdentityBalanceAndRevisionResponseV0 {
                 result: Some(
                     get_identity_balance_and_revision_response_v0::Result::Proof(
-                        self.response_proof_v0(platform_state, proof),
+                        self.response_proof_v0(platform_state, proof, GroveDBToUse::Current)
+                            .map(|(_, proof)| proof)?,
                     ),
                 ),
-                metadata: Some(self.response_metadata_v0(platform_state)),
+                metadata: Some(self.response_metadata_v0(platform_state, CheckpointUsed::Current)),
             }
         } else {
             let maybe_balance = self.drive.fetch_identity_balance(
@@ -72,7 +75,7 @@ impl<C> Platform<C> {
                         BalanceAndRevision { balance, revision },
                     ),
                 ),
-                metadata: Some(self.response_metadata_v0(platform_state)),
+                metadata: Some(self.response_metadata_v0(platform_state, CheckpointUsed::Current)),
             }
         };
 

--- a/packages/rs-drive-abci/src/query/identity_based_queries/balances/v0/mod.rs
+++ b/packages/rs-drive-abci/src/query/identity_based_queries/balances/v0/mod.rs
@@ -2,6 +2,7 @@ use crate::error::query::QueryError;
 use crate::error::Error;
 use crate::platform_types::platform::Platform;
 use crate::platform_types::platform_state::PlatformState;
+use crate::query::response_metadata::CheckpointUsed;
 use crate::query::QueryValidationResult;
 use dapi_grpc::platform::v0::get_identities_balances_request::GetIdentitiesBalancesRequestV0;
 use dapi_grpc::platform::v0::get_identities_balances_response::{
@@ -11,6 +12,7 @@ use dpp::check_validation_result_with_data;
 use dpp::identifier::Identifier;
 use dpp::validation::ValidationResult;
 use dpp::version::PlatformVersion;
+use drive::util::grove_operations::GroveDBToUse;
 
 impl<C> Platform<C> {
     pub(super) fn query_identities_balances_v0(
@@ -40,9 +42,10 @@ impl<C> Platform<C> {
 
             GetIdentitiesBalancesResponseV0 {
                 result: Some(get_identities_balances_response_v0::Result::Proof(
-                    self.response_proof_v0(platform_state, proof),
+                    self.response_proof_v0(platform_state, proof, GroveDBToUse::Current)
+                        .map(|(_, proof)| proof)?,
                 )),
-                metadata: Some(self.response_metadata_v0(platform_state)),
+                metadata: Some(self.response_metadata_v0(platform_state, CheckpointUsed::Current)),
             }
         } else {
             let map = |(key, value): ([u8; 32], Option<u64>)| {
@@ -67,7 +70,7 @@ impl<C> Platform<C> {
                         },
                     ),
                 ),
-                metadata: Some(self.response_metadata_v0(platform_state)),
+                metadata: Some(self.response_metadata_v0(platform_state, CheckpointUsed::Current)),
             }
         };
 

--- a/packages/rs-drive-abci/src/query/identity_based_queries/identities_contract_keys/v0/mod.rs
+++ b/packages/rs-drive-abci/src/query/identity_based_queries/identities_contract_keys/v0/mod.rs
@@ -2,6 +2,7 @@ use crate::error::query::QueryError;
 use crate::error::Error;
 use crate::platform_types::platform::Platform;
 use crate::platform_types::platform_state::PlatformState;
+use crate::query::response_metadata::CheckpointUsed;
 use crate::query::QueryValidationResult;
 use dapi_grpc::platform::v0::get_identities_contract_keys_request::GetIdentitiesContractKeysRequestV0;
 use dapi_grpc::platform::v0::get_identities_contract_keys_response::{
@@ -13,6 +14,7 @@ use dpp::platform_value::Bytes32;
 use dpp::validation::ValidationResult;
 use dpp::version::PlatformVersion;
 use drive::error::query::QuerySyntaxError;
+use drive::util::grove_operations::GroveDBToUse;
 
 impl<C> Platform<C> {
     #[inline(always)]
@@ -75,9 +77,10 @@ impl<C> Platform<C> {
 
             GetIdentitiesContractKeysResponseV0 {
                 result: Some(get_identities_contract_keys_response_v0::Result::Proof(
-                    self.response_proof_v0(platform_state, proof),
+                    self.response_proof_v0(platform_state, proof, GroveDBToUse::Current)
+                        .map(|(_, proof)| proof)?,
                 )),
-                metadata: Some(self.response_metadata_v0(platform_state)),
+                metadata: Some(self.response_metadata_v0(platform_state, CheckpointUsed::Current)),
             }
         } else {
             use get_identities_contract_keys_response_v0::IdentitiesKeys;
@@ -116,7 +119,7 @@ impl<C> Platform<C> {
                 result: Some(Result::IdentitiesKeys(IdentitiesKeys {
                     entries: identities_keys,
                 })),
-                metadata: Some(self.response_metadata_v0(platform_state)),
+                metadata: Some(self.response_metadata_v0(platform_state, CheckpointUsed::Current)),
             }
         };
 

--- a/packages/rs-drive-abci/src/query/identity_based_queries/identity/v0/mod.rs
+++ b/packages/rs-drive-abci/src/query/identity_based_queries/identity/v0/mod.rs
@@ -2,6 +2,7 @@ use crate::error::query::QueryError;
 use crate::error::Error;
 use crate::platform_types::platform::Platform;
 use crate::platform_types::platform_state::PlatformState;
+use crate::query::response_metadata::CheckpointUsed;
 use crate::query::QueryValidationResult;
 use dapi_grpc::platform::v0::get_identity_request::GetIdentityRequestV0;
 use dapi_grpc::platform::v0::get_identity_response::{
@@ -12,6 +13,7 @@ use dpp::identifier::Identifier;
 use dpp::serialization::PlatformSerializable;
 use dpp::validation::ValidationResult;
 use dpp::version::PlatformVersion;
+use drive::util::grove_operations::GroveDBToUse;
 
 impl<C> Platform<C> {
     pub(super) fn query_identity_v0(
@@ -36,9 +38,10 @@ impl<C> Platform<C> {
 
             GetIdentityResponseV0 {
                 result: Some(get_identity_response_v0::Result::Proof(
-                    self.response_proof_v0(platform_state, proof),
+                    self.response_proof_v0(platform_state, proof, GroveDBToUse::Current)
+                        .map(|(_, proof)| proof)?,
                 )),
-                metadata: Some(self.response_metadata_v0(platform_state)),
+                metadata: Some(self.response_metadata_v0(platform_state, CheckpointUsed::Current)),
             }
         } else {
             let maybe_identity = self.drive.fetch_full_identity(
@@ -59,7 +62,7 @@ impl<C> Platform<C> {
                 result: Some(get_identity_response_v0::Result::Identity(
                     serialized_identity,
                 )),
-                metadata: Some(self.response_metadata_v0(platform_state)),
+                metadata: Some(self.response_metadata_v0(platform_state, CheckpointUsed::Current)),
             }
         };
 

--- a/packages/rs-drive-abci/src/query/identity_based_queries/identity_by_non_unique_public_key_hash/v0/mod.rs
+++ b/packages/rs-drive-abci/src/query/identity_based_queries/identity_by_non_unique_public_key_hash/v0/mod.rs
@@ -13,6 +13,8 @@ use dpp::platform_value::{Bytes20, Bytes32};
 use dpp::serialization::PlatformSerializable;
 use dpp::validation::ValidationResult;
 use dpp::version::PlatformVersion;
+use drive::util::grove_operations::GroveDBToUse;
+use crate::query::response_metadata::CheckpointUsed;
 
 impl<C> Platform<C> {
     pub(super) fn query_identity_by_non_unique_public_key_hash_v0(
@@ -58,15 +60,19 @@ impl<C> Platform<C> {
                 result: Some(
                     get_identity_by_non_unique_public_key_hash_response_v0::Result::Proof(
                         IdentityProvedResponse {
-                            grovedb_identity_public_key_hash_proof: Some(self.response_proof_v0(
-                                platform_state,
-                                proof.identity_id_public_key_hash_proof,
-                            )),
+                            grovedb_identity_public_key_hash_proof: Some(
+                                self.response_proof_v0(
+                                    platform_state,
+                                    proof.identity_id_public_key_hash_proof,
+                                    GroveDBToUse::Current,
+                                )
+                                .map(|(_, proof)| proof)?,
+                            ),
                             identity_proof_bytes: proof.identity_proof,
                         },
                     ),
                 ),
-                metadata: Some(self.response_metadata_v0(platform_state)),
+                metadata: Some(self.response_metadata_v0(platform_state, CheckpointUsed::Current)),
             }
         } else {
             let maybe_identity = self
@@ -87,7 +93,7 @@ impl<C> Platform<C> {
                 .transpose()?;
 
             GetIdentityByNonUniquePublicKeyHashResponseV0 {
-                metadata: Some(self.response_metadata_v0(platform_state)),
+                metadata: Some(self.response_metadata_v0(platform_state, CheckpointUsed::Current)),
                 result: Some(
                     get_identity_by_non_unique_public_key_hash_response_v0::Result::Identity(
                         IdentityResponse {

--- a/packages/rs-drive-abci/src/query/identity_based_queries/identity_by_unique_public_key_hash/v0/mod.rs
+++ b/packages/rs-drive-abci/src/query/identity_based_queries/identity_by_unique_public_key_hash/v0/mod.rs
@@ -2,6 +2,7 @@ use crate::error::query::QueryError;
 use crate::error::Error;
 use crate::platform_types::platform::Platform;
 use crate::platform_types::platform_state::PlatformState;
+use crate::query::response_metadata::CheckpointUsed;
 use crate::query::QueryValidationResult;
 use dapi_grpc::platform::v0::get_identity_by_public_key_hash_request::GetIdentityByPublicKeyHashRequestV0;
 use dapi_grpc::platform::v0::get_identity_by_public_key_hash_response::{
@@ -12,6 +13,7 @@ use dpp::platform_value::Bytes20;
 use dpp::serialization::PlatformSerializable;
 use dpp::validation::ValidationResult;
 use dpp::version::PlatformVersion;
+use drive::util::grove_operations::GroveDBToUse;
 
 impl<C> Platform<C> {
     pub(super) fn query_identity_by_unique_public_key_hash_v0(
@@ -39,9 +41,10 @@ impl<C> Platform<C> {
 
             GetIdentityByPublicKeyHashResponseV0 {
                 result: Some(get_identity_by_public_key_hash_response_v0::Result::Proof(
-                    self.response_proof_v0(platform_state, proof),
+                    self.response_proof_v0(platform_state, proof, GroveDBToUse::Current)
+                        .map(|(_, proof)| proof)?,
                 )),
-                metadata: Some(self.response_metadata_v0(platform_state)),
+                metadata: Some(self.response_metadata_v0(platform_state, CheckpointUsed::Current)),
             }
         } else {
             let maybe_identity = self.drive.fetch_full_identity_by_unique_public_key_hash(
@@ -62,7 +65,7 @@ impl<C> Platform<C> {
                 .map_err(Error::Protocol)?;
 
             GetIdentityByPublicKeyHashResponseV0 {
-                metadata: Some(self.response_metadata_v0(platform_state)),
+                metadata: Some(self.response_metadata_v0(platform_state, CheckpointUsed::Current)),
                 result: Some(
                     get_identity_by_public_key_hash_response_v0::Result::Identity(
                         serialized_identity,

--- a/packages/rs-drive-abci/src/query/identity_based_queries/identity_contract_nonce/v0/mod.rs
+++ b/packages/rs-drive-abci/src/query/identity_based_queries/identity_contract_nonce/v0/mod.rs
@@ -2,6 +2,7 @@ use crate::error::query::QueryError;
 use crate::error::Error;
 use crate::platform_types::platform::Platform;
 use crate::platform_types::platform_state::PlatformState;
+use crate::query::response_metadata::CheckpointUsed;
 use crate::query::QueryValidationResult;
 use dapi_grpc::platform::v0::get_identity_contract_nonce_request::GetIdentityContractNonceRequestV0;
 use dapi_grpc::platform::v0::get_identity_contract_nonce_response::{
@@ -11,6 +12,7 @@ use dpp::check_validation_result_with_data;
 use dpp::platform_value::Identifier;
 use dpp::validation::ValidationResult;
 use dpp::version::PlatformVersion;
+use drive::util::grove_operations::GroveDBToUse;
 
 impl<C> Platform<C> {
     pub(super) fn query_identity_contract_nonce_v0(
@@ -45,9 +47,10 @@ impl<C> Platform<C> {
 
             GetIdentityContractNonceResponseV0 {
                 result: Some(get_identity_contract_nonce_response_v0::Result::Proof(
-                    self.response_proof_v0(platform_state, proof),
+                    self.response_proof_v0(platform_state, proof, GroveDBToUse::Current)
+                        .map(|(_, proof)| proof)?,
                 )),
-                metadata: Some(self.response_metadata_v0(platform_state)),
+                metadata: Some(self.response_metadata_v0(platform_state, CheckpointUsed::Current)),
             }
         } else {
             let maybe_identity = self.drive.fetch_identity_contract_nonce(
@@ -62,7 +65,7 @@ impl<C> Platform<C> {
             let identity_contract_nonce = maybe_identity.unwrap_or_default();
 
             GetIdentityContractNonceResponseV0 {
-                metadata: Some(self.response_metadata_v0(platform_state)),
+                metadata: Some(self.response_metadata_v0(platform_state, CheckpointUsed::Current)),
                 result: Some(
                     get_identity_contract_nonce_response_v0::Result::IdentityContractNonce(
                         identity_contract_nonce,

--- a/packages/rs-drive-abci/src/query/identity_based_queries/identity_nonce/v0/mod.rs
+++ b/packages/rs-drive-abci/src/query/identity_based_queries/identity_nonce/v0/mod.rs
@@ -2,6 +2,7 @@ use crate::error::query::QueryError;
 use crate::error::Error;
 use crate::platform_types::platform::Platform;
 use crate::platform_types::platform_state::PlatformState;
+use crate::query::response_metadata::CheckpointUsed;
 use crate::query::QueryValidationResult;
 use dapi_grpc::platform::v0::get_identity_nonce_request::GetIdentityNonceRequestV0;
 use dapi_grpc::platform::v0::get_identity_nonce_response::{
@@ -11,6 +12,7 @@ use dpp::check_validation_result_with_data;
 use dpp::platform_value::Identifier;
 use dpp::validation::ValidationResult;
 use dpp::version::PlatformVersion;
+use drive::util::grove_operations::GroveDBToUse;
 
 impl<C> Platform<C> {
     pub(super) fn query_identity_nonce_v0(
@@ -32,9 +34,10 @@ impl<C> Platform<C> {
 
             GetIdentityNonceResponseV0 {
                 result: Some(get_identity_nonce_response_v0::Result::Proof(
-                    self.response_proof_v0(platform_state, proof),
+                    self.response_proof_v0(platform_state, proof, GroveDBToUse::Current)
+                        .map(|(_, proof)| proof)?,
                 )),
-                metadata: Some(self.response_metadata_v0(platform_state)),
+                metadata: Some(self.response_metadata_v0(platform_state, CheckpointUsed::Current)),
             }
         } else {
             let maybe_identity =
@@ -45,7 +48,7 @@ impl<C> Platform<C> {
             let identity_nonce = maybe_identity.unwrap_or_default();
 
             GetIdentityNonceResponseV0 {
-                metadata: Some(self.response_metadata_v0(platform_state)),
+                metadata: Some(self.response_metadata_v0(platform_state, CheckpointUsed::Current)),
                 result: Some(get_identity_nonce_response_v0::Result::IdentityNonce(
                     identity_nonce,
                 )),

--- a/packages/rs-drive-abci/src/query/identity_based_queries/keys/v0/mod.rs
+++ b/packages/rs-drive-abci/src/query/identity_based_queries/keys/v0/mod.rs
@@ -12,6 +12,7 @@ use drive::error::query::QuerySyntaxError;
 use std::collections::BTreeMap;
 
 use crate::platform_types::platform_state::PlatformState;
+use crate::query::response_metadata::CheckpointUsed;
 use dpp::identity::{KeyID, Purpose, SecurityLevel};
 use dpp::validation::ValidationResult;
 use dpp::version::PlatformVersion;
@@ -19,6 +20,7 @@ use drive::drive::identity::key::fetch::{
     IdentityKeysRequest, KeyKindRequestType, KeyRequestType, PurposeU8, SecurityLevelU8,
     SerializedKeyVec,
 };
+use drive::util::grove_operations::GroveDBToUse;
 
 fn from_i32_to_key_kind_request_type(value: i32) -> Option<KeyKindRequestType> {
     match value {
@@ -142,9 +144,10 @@ impl<C> Platform<C> {
 
             GetIdentityKeysResponseV0 {
                 result: Some(get_identity_keys_response_v0::Result::Proof(
-                    self.response_proof_v0(platform_state, proof),
+                    self.response_proof_v0(platform_state, proof, GroveDBToUse::Current)
+                        .map(|(_, proof)| proof)?,
                 )),
-                metadata: Some(self.response_metadata_v0(platform_state)),
+                metadata: Some(self.response_metadata_v0(platform_state, CheckpointUsed::Current)),
             }
         } else {
             let keys: SerializedKeyVec =
@@ -155,7 +158,7 @@ impl<C> Platform<C> {
                 result: Some(get_identity_keys_response_v0::Result::Keys(
                     get_identity_keys_response_v0::Keys { keys_bytes: keys },
                 )),
-                metadata: Some(self.response_metadata_v0(platform_state)),
+                metadata: Some(self.response_metadata_v0(platform_state, CheckpointUsed::Current)),
             }
         };
 

--- a/packages/rs-drive-abci/src/query/prefunded_specialized_balances/balance/v0/mod.rs
+++ b/packages/rs-drive-abci/src/query/prefunded_specialized_balances/balance/v0/mod.rs
@@ -2,6 +2,7 @@ use crate::error::query::QueryError;
 use crate::error::Error;
 use crate::platform_types::platform::Platform;
 use crate::platform_types::platform_state::PlatformState;
+use crate::query::response_metadata::CheckpointUsed;
 use crate::query::QueryValidationResult;
 use dapi_grpc::platform::v0::get_prefunded_specialized_balance_request::GetPrefundedSpecializedBalanceRequestV0;
 use dapi_grpc::platform::v0::get_prefunded_specialized_balance_response::get_prefunded_specialized_balance_response_v0;
@@ -10,6 +11,7 @@ use dpp::check_validation_result_with_data;
 use dpp::identifier::Identifier;
 use dpp::validation::ValidationResult;
 use dpp::version::PlatformVersion;
+use drive::util::grove_operations::GroveDBToUse;
 
 impl<C> Platform<C> {
     pub(super) fn query_prefunded_specialized_balance_v0(
@@ -36,10 +38,11 @@ impl<C> Platform<C> {
             GetPrefundedSpecializedBalanceResponseV0 {
                 result: Some(
                     get_prefunded_specialized_balance_response_v0::Result::Proof(
-                        self.response_proof_v0(platform_state, proof),
+                        self.response_proof_v0(platform_state, proof, GroveDBToUse::Current)
+                            .map(|(_, proof)| proof)?,
                     ),
                 ),
-                metadata: Some(self.response_metadata_v0(platform_state)),
+                metadata: Some(self.response_metadata_v0(platform_state, CheckpointUsed::Current)),
             }
         } else {
             let maybe_balance = self.drive.fetch_prefunded_specialized_balance(
@@ -58,7 +61,7 @@ impl<C> Platform<C> {
                 result: Some(
                     get_prefunded_specialized_balance_response_v0::Result::Balance(balance),
                 ),
-                metadata: Some(self.response_metadata_v0(platform_state)),
+                metadata: Some(self.response_metadata_v0(platform_state, CheckpointUsed::Current)),
             }
         };
 

--- a/packages/rs-drive-abci/src/query/proofs/v0/mod.rs
+++ b/packages/rs-drive-abci/src/query/proofs/v0/mod.rs
@@ -8,6 +8,7 @@ use dpp::serialization::PlatformDeserializable;
 
 use dpp::state_transition::StateTransition;
 use dpp::version::PlatformVersion;
+use drive::util::grove_operations::GroveDBToUse;
 
 impl<C> Platform<C> {
     pub(super) fn query_proofs_v0(
@@ -48,9 +49,12 @@ impl<C> Platform<C> {
 
         let proof = result.into_data()?;
 
+        let (grovedb_used, proof) =
+            self.response_proof_v0(platform_state, proof, GroveDBToUse::Current)?;
+
         let response = GetProofsResponse {
-            proof: Some(self.response_proof_v0(platform_state, proof)),
-            metadata: Some(self.response_metadata_v0(platform_state)),
+            proof: Some(proof),
+            metadata: Some(self.response_metadata_v0(platform_state, grovedb_used)),
         };
 
         Ok(QueryValidationResult::new_with_data(response))

--- a/packages/rs-drive-abci/src/query/response_metadata/mod.rs
+++ b/packages/rs-drive-abci/src/query/response_metadata/mod.rs
@@ -1,29 +1,13 @@
 mod v0;
 
-use crate::error::execution::ExecutionError;
-use crate::error::Error;
-use crate::platform_types::platform::Platform;
-
 use crate::platform_types::platform_state::PlatformState;
-use dapi_grpc::platform::v0::ResponseMetadata;
-use dpp::version::PlatformVersion;
+use std::sync::Arc;
 
-impl<C> Platform<C> {
-    #[allow(dead_code)]
-    #[deprecated(note = "This function is marked as unused.")]
-    #[allow(deprecated)]
-    pub(in crate::query) fn response_metadata(
-        &self,
-        platform_state: &PlatformState,
-        platform_version: &PlatformVersion,
-    ) -> Result<ResponseMetadata, Error> {
-        match platform_version.drive_abci.query.response_metadata {
-            0 => Ok(self.response_metadata_v0(platform_state)),
-            version => Err(Error::Execution(ExecutionError::UnknownVersionMismatch {
-                method: "response_metadata".to_string(),
-                known_versions: vec![0],
-                received: version,
-            })),
-        }
-    }
+/// Specifies which GroveDB instance was used for a query, along with the associated platform state
+#[derive(Debug, Clone)]
+pub enum CheckpointUsed {
+    /// The current (main) GroveDB was used
+    Current,
+    /// A checkpoint was used, with the platform state at that checkpoint
+    Checkpoint(Arc<PlatformState>),
 }

--- a/packages/rs-drive-abci/src/query/response_metadata/v0/mod.rs
+++ b/packages/rs-drive-abci/src/query/response_metadata/v0/mod.rs
@@ -1,37 +1,110 @@
+use crate::error::Error;
 use crate::platform_types::platform::Platform;
 use crate::platform_types::platform_state::PlatformState;
 use crate::platform_types::platform_state::PlatformStateV0Methods;
+use crate::query::response_metadata::CheckpointUsed;
 use dapi_grpc::platform::v0::{Proof, ResponseMetadata};
+use drive::error::drive::DriveError;
+use drive::util::grove_operations::GroveDBToUse;
 
 impl<C> Platform<C> {
+    /// Returns response metadata for the given GroveDB that was used.
+    ///
+    /// This function should be called with the `GroveDBUsed` returned from `response_proof_v0`
+    /// to ensure consistency between the proof and metadata.
     pub(in crate::query) fn response_metadata_v0(
         &self,
         platform_state: &PlatformState,
+        grovedb_used: CheckpointUsed,
     ) -> ResponseMetadata {
+        let state: &PlatformState = match &grovedb_used {
+            CheckpointUsed::Current => platform_state,
+            CheckpointUsed::Checkpoint(checkpoint_state) => checkpoint_state.as_ref(),
+        };
+
         ResponseMetadata {
-            height: platform_state.last_committed_block_height(),
-            core_chain_locked_height: platform_state.last_committed_core_height(),
-            epoch: platform_state.last_committed_block_epoch().index as u32,
-            time_ms: platform_state
-                .last_committed_block_time_ms()
-                .unwrap_or_default(),
+            height: state.last_committed_block_height(),
+            core_chain_locked_height: state.last_committed_core_height(),
+            epoch: state.last_committed_block_epoch().index as u32,
+            time_ms: state.last_committed_block_time_ms().unwrap_or_default(),
             chain_id: self.config.abci.chain_id.clone(),
-            protocol_version: platform_state.current_protocol_version_in_consensus(),
+            protocol_version: state.current_protocol_version_in_consensus(),
         }
     }
 
+    /// Returns response proof for the requested GroveDB along with which GroveDB was actually used.
+    ///
+    /// Returns a tuple of (GroveDBUsed, Proof) so the caller can pass the same GroveDBUsed
+    /// to `response_metadata_v0` for consistency.
+    ///
+    /// Returns an error if a checkpoint was requested but not found.
     pub(in crate::query) fn response_proof_v0(
         &self,
         platform_state: &PlatformState,
         proof: Vec<u8>,
-    ) -> Proof {
-        Proof {
-            grovedb_proof: proof,
-            quorum_hash: platform_state.last_committed_quorum_hash().to_vec(),
-            quorum_type: self.config.validator_set.quorum_type as u32,
-            block_id_hash: platform_state.last_committed_block_id_hash().to_vec(),
-            signature: platform_state.last_committed_block_signature().to_vec(),
-            round: platform_state.last_committed_block_round(),
+        grovedb_to_use: GroveDBToUse,
+    ) -> Result<(CheckpointUsed, Proof), Error> {
+        match grovedb_to_use {
+            GroveDBToUse::Current => {
+                let proof = Proof {
+                    grovedb_proof: proof,
+                    quorum_hash: platform_state.last_committed_quorum_hash().to_vec(),
+                    quorum_type: self.config.validator_set.quorum_type as u32,
+                    block_id_hash: platform_state.last_committed_block_id_hash().to_vec(),
+                    signature: platform_state.last_committed_block_signature().to_vec(),
+                    round: platform_state.last_committed_block_round(),
+                };
+                Ok((CheckpointUsed::Current, proof))
+            }
+            GroveDBToUse::LatestCheckpoint => {
+                let checkpoints = self.drive.checkpoints.load();
+                let (&height, _) = checkpoints.last_key_value().ok_or_else(|| {
+                    Error::Drive(drive::error::Error::Drive(
+                        DriveError::NoCheckpointsAvailable,
+                    ))
+                })?;
+
+                let checkpoint_states = self.checkpoint_platform_states.load();
+                let checkpoint_state = checkpoint_states
+                    .get(&height)
+                    .ok_or_else(|| {
+                        Error::Drive(drive::error::Error::Drive(DriveError::CheckpointNotFound(
+                            height,
+                        )))
+                    })?
+                    .clone();
+
+                let proof = Proof {
+                    grovedb_proof: proof,
+                    quorum_hash: checkpoint_state.last_committed_quorum_hash().to_vec(),
+                    quorum_type: self.config.validator_set.quorum_type as u32,
+                    block_id_hash: checkpoint_state.last_committed_block_id_hash().to_vec(),
+                    signature: checkpoint_state.last_committed_block_signature().to_vec(),
+                    round: checkpoint_state.last_committed_block_round(),
+                };
+                Ok((CheckpointUsed::Checkpoint(checkpoint_state), proof))
+            }
+            GroveDBToUse::Checkpoint(block_height) => {
+                let checkpoint_states = self.checkpoint_platform_states.load();
+                let checkpoint_state = checkpoint_states
+                    .get(&block_height)
+                    .ok_or_else(|| {
+                        Error::Drive(drive::error::Error::Drive(DriveError::CheckpointNotFound(
+                            block_height,
+                        )))
+                    })?
+                    .clone();
+
+                let proof = Proof {
+                    grovedb_proof: proof,
+                    quorum_hash: checkpoint_state.last_committed_quorum_hash().to_vec(),
+                    quorum_type: self.config.validator_set.quorum_type as u32,
+                    block_id_hash: checkpoint_state.last_committed_block_id_hash().to_vec(),
+                    signature: checkpoint_state.last_committed_block_signature().to_vec(),
+                    round: checkpoint_state.last_committed_block_round(),
+                };
+                Ok((CheckpointUsed::Checkpoint(checkpoint_state), proof))
+            }
         }
     }
 }

--- a/packages/rs-drive-abci/src/query/system/current_quorums_info/v0/mod.rs
+++ b/packages/rs-drive-abci/src/query/system/current_quorums_info/v0/mod.rs
@@ -3,6 +3,7 @@ use crate::platform_types::platform::Platform;
 use crate::platform_types::platform_state::PlatformState;
 use crate::platform_types::platform_state::PlatformStateV0Methods;
 use crate::platform_types::validator_set::v0::ValidatorSetV0Getters;
+use crate::query::response_metadata::CheckpointUsed;
 use crate::query::QueryValidationResult;
 use dapi_grpc::platform::v0::get_current_quorums_info_request::GetCurrentQuorumsInfoRequestV0;
 use dapi_grpc::platform::v0::get_current_quorums_info_response::{
@@ -63,7 +64,7 @@ impl<C> Platform<C> {
             validator_sets,
             last_block_proposer: last_committed_block_proposer_pro_tx_hash.to_vec(),
             current_quorum_hash: current_quorum_index.as_byte_array().to_vec(),
-            metadata: Some(self.response_metadata_v0(platform_state)),
+            metadata: Some(self.response_metadata_v0(platform_state, CheckpointUsed::Current)),
         };
 
         // Return the response wrapped in a QueryValidationResult

--- a/packages/rs-drive-abci/src/query/system/epoch_infos/v0/mod.rs
+++ b/packages/rs-drive-abci/src/query/system/epoch_infos/v0/mod.rs
@@ -12,8 +12,10 @@ use dpp::block::extended_epoch_info::v0::ExtendedEpochInfoV0Getters;
 use dpp::check_validation_result_with_data;
 
 use crate::platform_types::platform_state::PlatformState;
+use crate::query::response_metadata::CheckpointUsed;
 use dpp::validation::ValidationResult;
 use dpp::version::PlatformVersion;
+use drive::util::grove_operations::GroveDBToUse;
 
 impl<C> Platform<C> {
     pub(super) fn query_epoch_infos_v0(
@@ -61,9 +63,10 @@ impl<C> Platform<C> {
 
             GetEpochsInfoResponseV0 {
                 result: Some(get_epochs_info_response_v0::Result::Proof(
-                    self.response_proof_v0(platform_state, proof),
+                    self.response_proof_v0(platform_state, proof, GroveDBToUse::Current)
+                        .map(|(_, proof)| proof)?,
                 )),
-                metadata: Some(self.response_metadata_v0(platform_state)),
+                metadata: Some(self.response_metadata_v0(platform_state, CheckpointUsed::Current)),
             }
         } else {
             let result = check_validation_result_with_data!(self.drive.get_epochs_infos(
@@ -90,7 +93,7 @@ impl<C> Platform<C> {
                 result: Some(get_epochs_info_response_v0::Result::Epochs(EpochInfos {
                     epoch_infos,
                 })),
-                metadata: Some(self.response_metadata_v0(platform_state)),
+                metadata: Some(self.response_metadata_v0(platform_state, CheckpointUsed::Current)),
             }
         };
 

--- a/packages/rs-drive-abci/src/query/system/finalized_epoch_infos/v0/mod.rs
+++ b/packages/rs-drive-abci/src/query/system/finalized_epoch_infos/v0/mod.rs
@@ -13,6 +13,8 @@ use dpp::block::finalized_epoch_info::v0::getters::FinalizedEpochInfoGettersV0;
 use dpp::check_validation_result_with_data;
 use dpp::version::PlatformVersion;
 use dpp::validation::ValidationResult;
+use drive::util::grove_operations::GroveDBToUse;
+use crate::query::response_metadata::CheckpointUsed;
 
 impl<C> Platform<C> {
     pub(super) fn query_finalized_epoch_infos_v0(
@@ -74,9 +76,12 @@ impl<C> Platform<C> {
             Ok(QueryValidationResult::new_with_data(
                 GetFinalizedEpochInfosResponseV0 {
                     result: Some(get_finalized_epoch_infos_response_v0::Result::Proof(
-                        self.response_proof_v0(platform_state, proof),
+                        self.response_proof_v0(platform_state, proof, GroveDBToUse::Current)
+                            .map(|(_, proof)| proof)?,
                     )),
-                    metadata: Some(self.response_metadata_v0(platform_state)),
+                    metadata: Some(
+                        self.response_metadata_v0(platform_state, CheckpointUsed::Current),
+                    ),
                 },
             ))
         } else {
@@ -132,7 +137,9 @@ impl<C> Platform<C> {
                             finalized_epoch_infos,
                         },
                     )),
-                    metadata: Some(self.response_metadata_v0(platform_state)),
+                    metadata: Some(
+                        self.response_metadata_v0(platform_state, CheckpointUsed::Current),
+                    ),
                 },
             ))
         }

--- a/packages/rs-drive-abci/src/query/system/path_elements/v0/mod.rs
+++ b/packages/rs-drive-abci/src/query/system/path_elements/v0/mod.rs
@@ -10,9 +10,11 @@ use dpp::check_validation_result_with_data;
 
 use crate::error::query::QueryError;
 use crate::platform_types::platform_state::PlatformState;
+use crate::query::response_metadata::CheckpointUsed;
 use dpp::validation::ValidationResult;
 use dpp::version::PlatformVersion;
 use drive::error::query::QuerySyntaxError;
+use drive::util::grove_operations::GroveDBToUse;
 
 impl<C> Platform<C> {
     pub(super) fn query_path_elements_v0(
@@ -40,9 +42,10 @@ impl<C> Platform<C> {
 
             GetPathElementsResponseV0 {
                 result: Some(get_path_elements_response_v0::Result::Proof(
-                    self.response_proof_v0(platform_state, proof),
+                    self.response_proof_v0(platform_state, proof, GroveDBToUse::Current)
+                        .map(|(_, proof)| proof)?,
                 )),
-                metadata: Some(self.response_metadata_v0(platform_state)),
+                metadata: Some(self.response_metadata_v0(platform_state, CheckpointUsed::Current)),
             }
         } else {
             let result = check_validation_result_with_data!(self.drive.fetch_elements(
@@ -65,7 +68,7 @@ impl<C> Platform<C> {
                 result: Some(get_path_elements_response_v0::Result::Elements(Elements {
                     elements: serialized,
                 })),
-                metadata: Some(self.response_metadata_v0(platform_state)),
+                metadata: Some(self.response_metadata_v0(platform_state, CheckpointUsed::Current)),
             }
         };
 

--- a/packages/rs-drive-abci/src/query/system/total_credits_in_platform/v0/mod.rs
+++ b/packages/rs-drive-abci/src/query/system/total_credits_in_platform/v0/mod.rs
@@ -2,6 +2,7 @@ use crate::error::Error;
 use crate::platform_types::platform::Platform;
 use crate::platform_types::platform_state::PlatformState;
 use crate::platform_types::platform_state::PlatformStateV0Methods;
+use crate::query::response_metadata::CheckpointUsed;
 use crate::query::QueryValidationResult;
 use dapi_grpc::platform::v0::get_total_credits_in_platform_request::GetTotalCreditsInPlatformRequestV0;
 use dapi_grpc::platform::v0::get_total_credits_in_platform_response::{
@@ -23,7 +24,7 @@ use drive::drive::system::misc_path;
 use drive::drive::RootTree;
 use drive::error::proof::ProofError;
 use drive::grovedb::{PathQuery, Query, SizedQuery};
-use drive::util::grove_operations::DirectQueryType;
+use drive::util::grove_operations::{DirectQueryType, GroveDBToUse};
 
 impl<C> Platform<C> {
     pub(super) fn query_total_credits_in_platform_v0(
@@ -76,11 +77,14 @@ impl<C> Platform<C> {
                 &platform_version.drive,
             ));
 
+            let (grovedb_used, proof) =
+                self.response_proof_v0(platform_state, proof, GroveDBToUse::Current)?;
+
             GetTotalCreditsInPlatformResponseV0 {
                 result: Some(get_total_credits_in_platform_response_v0::Result::Proof(
-                    self.response_proof_v0(platform_state, proof),
+                    proof,
                 )),
-                metadata: Some(self.response_metadata_v0(platform_state)),
+                metadata: Some(self.response_metadata_v0(platform_state, grovedb_used)),
             }
         } else {
             let path_holding_total_credits = misc_path();
@@ -125,7 +129,7 @@ impl<C> Platform<C> {
                 result: Some(get_total_credits_in_platform_response_v0::Result::Credits(
                     total_credits_with_rewards,
                 )),
-                metadata: Some(self.response_metadata_v0(platform_state)),
+                metadata: Some(self.response_metadata_v0(platform_state, CheckpointUsed::Current)),
             }
         };
 

--- a/packages/rs-drive-abci/src/query/system/version_upgrade_state/v0/mod.rs
+++ b/packages/rs-drive-abci/src/query/system/version_upgrade_state/v0/mod.rs
@@ -8,6 +8,8 @@ use dpp::version::PlatformVersion;
 use dapi_grpc::platform::v0::get_protocol_version_upgrade_state_request::GetProtocolVersionUpgradeStateRequestV0;
 use dapi_grpc::platform::v0::get_protocol_version_upgrade_state_response::get_protocol_version_upgrade_state_response_v0::{VersionEntry, Versions};
 use dapi_grpc::platform::v0::get_protocol_version_upgrade_state_response::{get_protocol_version_upgrade_state_response_v0, GetProtocolVersionUpgradeStateResponseV0};
+use drive::util::grove_operations::GroveDBToUse;
+use crate::query::response_metadata::CheckpointUsed;
 use crate::platform_types::platform_state::PlatformState;
 
 impl<C> Platform<C> {
@@ -22,13 +24,12 @@ impl<C> Platform<C> {
                 .drive
                 .fetch_proved_versions_with_counter(None, &platform_version.drive));
 
+            let (grovedb_used, proof) =
+                self.response_proof_v0(platform_state, proof, GroveDBToUse::Current)?;
+
             GetProtocolVersionUpgradeStateResponseV0 {
-                result: Some(
-                    get_protocol_version_upgrade_state_response_v0::Result::Proof(
-                        self.response_proof_v0(platform_state, proof),
-                    ),
-                ),
-                metadata: Some(self.response_metadata_v0(platform_state)),
+                result: Some(get_protocol_version_upgrade_state_response_v0::Result::Proof(proof)),
+                metadata: Some(self.response_metadata_v0(platform_state, grovedb_used)),
             }
         } else {
             let protocol_versions_counter = self.drive.cache.protocol_versions_counter.read();
@@ -50,7 +51,7 @@ impl<C> Platform<C> {
                         versions,
                     }),
                 ),
-                metadata: Some(self.response_metadata_v0(platform_state)),
+                metadata: Some(self.response_metadata_v0(platform_state, CheckpointUsed::Current)),
             }
         };
 

--- a/packages/rs-drive-abci/src/query/system/version_upgrade_vote_status/v0/mod.rs
+++ b/packages/rs-drive-abci/src/query/system/version_upgrade_vote_status/v0/mod.rs
@@ -8,6 +8,8 @@ use dpp::version::PlatformVersion;
 use dapi_grpc::platform::v0::get_protocol_version_upgrade_vote_status_request::GetProtocolVersionUpgradeVoteStatusRequestV0;
 use dapi_grpc::platform::v0::get_protocol_version_upgrade_vote_status_response::get_protocol_version_upgrade_vote_status_response_v0::{VersionSignal, VersionSignals};
 use dapi_grpc::platform::v0::get_protocol_version_upgrade_vote_status_response::{get_protocol_version_upgrade_vote_status_response_v0, GetProtocolVersionUpgradeVoteStatusResponseV0};
+use drive::util::grove_operations::GroveDBToUse;
+use crate::query::response_metadata::CheckpointUsed;
 use crate::error::query::QueryError;
 use crate::platform_types::platform_state::PlatformState;
 
@@ -57,10 +59,11 @@ impl<C> Platform<C> {
             GetProtocolVersionUpgradeVoteStatusResponseV0 {
                 result: Some(
                     get_protocol_version_upgrade_vote_status_response_v0::Result::Proof(
-                        self.response_proof_v0(platform_state, proof),
+                        self.response_proof_v0(platform_state, proof, GroveDBToUse::Current)
+                            .map(|(_, proof)| proof)?,
                     ),
                 ),
-                metadata: Some(self.response_metadata_v0(platform_state)),
+                metadata: Some(self.response_metadata_v0(platform_state, CheckpointUsed::Current)),
             }
         } else {
             let result =
@@ -86,7 +89,7 @@ impl<C> Platform<C> {
                         },
                     ),
                 ),
-                metadata: Some(self.response_metadata_v0(platform_state)),
+                metadata: Some(self.response_metadata_v0(platform_state, CheckpointUsed::Current)),
             }
         };
 

--- a/packages/rs-drive-abci/src/query/token_queries/identities_token_balances/v0/mod.rs
+++ b/packages/rs-drive-abci/src/query/token_queries/identities_token_balances/v0/mod.rs
@@ -10,6 +10,8 @@ use dpp::check_validation_result_with_data;
 use dpp::identifier::Identifier;
 use dpp::validation::ValidationResult;
 use dpp::version::PlatformVersion;
+use drive::util::grove_operations::GroveDBToUse;
+use crate::query::response_metadata::CheckpointUsed;
 
 impl<C> Platform<C> {
     pub(super) fn query_identities_token_balances_v0(
@@ -51,9 +53,10 @@ impl<C> Platform<C> {
 
             GetIdentitiesTokenBalancesResponseV0 {
                 result: Some(get_identities_token_balances_response_v0::Result::Proof(
-                    self.response_proof_v0(platform_state, proof),
+                    self.response_proof_v0(platform_state, proof, GroveDBToUse::Current)
+                        .map(|(_, proof)| proof)?,
                 )),
-                metadata: Some(self.response_metadata_v0(platform_state)),
+                metadata: Some(self.response_metadata_v0(platform_state, CheckpointUsed::Current)),
             }
         } else {
             let identity_token_balances = self
@@ -79,7 +82,7 @@ impl<C> Platform<C> {
                         },
                     ),
                 ),
-                metadata: Some(self.response_metadata_v0(platform_state)),
+                metadata: Some(self.response_metadata_v0(platform_state, CheckpointUsed::Current)),
             }
         };
 

--- a/packages/rs-drive-abci/src/query/token_queries/identities_token_infos/v0/mod.rs
+++ b/packages/rs-drive-abci/src/query/token_queries/identities_token_infos/v0/mod.rs
@@ -11,6 +11,8 @@ use dpp::identifier::Identifier;
 use dpp::tokens::info::v0::IdentityTokenInfoV0Accessors;
 use dpp::validation::ValidationResult;
 use dpp::version::PlatformVersion;
+use drive::util::grove_operations::GroveDBToUse;
+use crate::query::response_metadata::CheckpointUsed;
 
 impl<C> Platform<C> {
     pub(super) fn query_identities_token_infos_v0(
@@ -52,9 +54,10 @@ impl<C> Platform<C> {
 
             GetIdentitiesTokenInfosResponseV0 {
                 result: Some(get_identities_token_infos_response_v0::Result::Proof(
-                    self.response_proof_v0(platform_state, proof),
+                    self.response_proof_v0(platform_state, proof, GroveDBToUse::Current)
+                        .map(|(_, proof)| proof)?,
                 )),
-                metadata: Some(self.response_metadata_v0(platform_state)),
+                metadata: Some(self.response_metadata_v0(platform_state, CheckpointUsed::Current)),
             }
         } else {
             let identity_token_infos = self
@@ -85,7 +88,7 @@ impl<C> Platform<C> {
                         },
                     ),
                 ),
-                metadata: Some(self.response_metadata_v0(platform_state)),
+                metadata: Some(self.response_metadata_v0(platform_state, CheckpointUsed::Current)),
             }
         };
 

--- a/packages/rs-drive-abci/src/query/token_queries/identity_token_balances/v0/mod.rs
+++ b/packages/rs-drive-abci/src/query/token_queries/identity_token_balances/v0/mod.rs
@@ -10,6 +10,8 @@ use dpp::check_validation_result_with_data;
 use dpp::identifier::Identifier;
 use dpp::validation::ValidationResult;
 use dpp::version::PlatformVersion;
+use drive::util::grove_operations::GroveDBToUse;
+use crate::query::response_metadata::CheckpointUsed;
 
 impl<C> Platform<C> {
     pub(super) fn query_identity_token_balances_v0(
@@ -51,9 +53,10 @@ impl<C> Platform<C> {
 
             GetIdentityTokenBalancesResponseV0 {
                 result: Some(get_identity_token_balances_response_v0::Result::Proof(
-                    self.response_proof_v0(platform_state, proof),
+                    self.response_proof_v0(platform_state, proof, GroveDBToUse::Current)
+                        .map(|(_, proof)| proof)?,
                 )),
-                metadata: Some(self.response_metadata_v0(platform_state)),
+                metadata: Some(self.response_metadata_v0(platform_state, CheckpointUsed::Current)),
             }
         } else {
             let token_balances = self
@@ -77,7 +80,7 @@ impl<C> Platform<C> {
                         token_balances,
                     }),
                 ),
-                metadata: Some(self.response_metadata_v0(platform_state)),
+                metadata: Some(self.response_metadata_v0(platform_state, CheckpointUsed::Current)),
             }
         };
 

--- a/packages/rs-drive-abci/src/query/token_queries/identity_token_infos/v0/mod.rs
+++ b/packages/rs-drive-abci/src/query/token_queries/identity_token_infos/v0/mod.rs
@@ -11,6 +11,8 @@ use dpp::identifier::Identifier;
 use dpp::tokens::info::v0::IdentityTokenInfoV0Accessors;
 use dpp::validation::ValidationResult;
 use dpp::version::PlatformVersion;
+use drive::util::grove_operations::GroveDBToUse;
+use crate::query::response_metadata::CheckpointUsed;
 
 impl<C> Platform<C> {
     pub(super) fn query_identity_token_infos_v0(
@@ -51,9 +53,10 @@ impl<C> Platform<C> {
 
             GetIdentityTokenInfosResponseV0 {
                 result: Some(get_identity_token_infos_response_v0::Result::Proof(
-                    self.response_proof_v0(platform_state, proof),
+                    self.response_proof_v0(platform_state, proof, GroveDBToUse::Current)
+                        .map(|(_, proof)| proof)?,
                 )),
-                metadata: Some(self.response_metadata_v0(platform_state)),
+                metadata: Some(self.response_metadata_v0(platform_state, CheckpointUsed::Current)),
             }
         } else {
             let token_infos = self
@@ -80,7 +83,7 @@ impl<C> Platform<C> {
                 result: Some(get_identity_token_infos_response_v0::Result::TokenInfos(
                     TokenInfos { token_infos },
                 )),
-                metadata: Some(self.response_metadata_v0(platform_state)),
+                metadata: Some(self.response_metadata_v0(platform_state, CheckpointUsed::Current)),
             }
         };
 

--- a/packages/rs-drive-abci/src/query/token_queries/token_contract_info/v0/mod.rs
+++ b/packages/rs-drive-abci/src/query/token_queries/token_contract_info/v0/mod.rs
@@ -2,6 +2,7 @@ use crate::error::query::QueryError;
 use crate::error::Error;
 use crate::platform_types::platform::Platform;
 use crate::platform_types::platform_state::PlatformState;
+use crate::query::response_metadata::CheckpointUsed;
 use crate::query::QueryValidationResult;
 use dapi_grpc::platform::v0::get_token_contract_info_request::GetTokenContractInfoRequestV0;
 use dapi_grpc::platform::v0::get_token_contract_info_response::{
@@ -11,6 +12,7 @@ use dpp::check_validation_result_with_data;
 use dpp::tokens::contract_info::v0::TokenContractInfoV0Accessors;
 use dpp::validation::ValidationResult;
 use dpp::version::PlatformVersion;
+use drive::util::grove_operations::GroveDBToUse;
 
 impl<C> Platform<C> {
     pub(super) fn query_token_contract_info_v0(
@@ -26,37 +28,41 @@ impl<C> Platform<C> {
                 )
             }));
 
-        let response =
-            if prove {
-                let proof = check_validation_result_with_data!(self
-                    .drive
-                    .prove_token_contract_info(token_id, None, platform_version));
+        let response = if prove {
+            let proof = check_validation_result_with_data!(self.drive.prove_token_contract_info(
+                token_id,
+                None,
+                platform_version
+            ));
 
-                GetTokenContractInfoResponseV0 {
-                    result: Some(get_token_contract_info_response_v0::Result::Proof(
-                        self.response_proof_v0(platform_state, proof),
-                    )),
-                    metadata: Some(self.response_metadata_v0(platform_state)),
-                }
-            } else {
-                let result = check_validation_result_with_data!(self
-                    .drive
-                    .fetch_token_contract_info(token_id, None, platform_version))
-                .map(|token_contract_info| {
-                    get_token_contract_info_response_v0::Result::Data(
-                        get_token_contract_info_response_v0::TokenContractInfoData {
-                            contract_id: token_contract_info.contract_id().to_vec(),
-                            token_contract_position: token_contract_info.token_contract_position()
-                                as u32,
-                        },
-                    )
-                });
+            GetTokenContractInfoResponseV0 {
+                result: Some(get_token_contract_info_response_v0::Result::Proof(
+                    self.response_proof_v0(platform_state, proof, GroveDBToUse::Current)
+                        .map(|(_, proof)| proof)?,
+                )),
+                metadata: Some(self.response_metadata_v0(platform_state, CheckpointUsed::Current)),
+            }
+        } else {
+            let result = check_validation_result_with_data!(self.drive.fetch_token_contract_info(
+                token_id,
+                None,
+                platform_version
+            ))
+            .map(|token_contract_info| {
+                get_token_contract_info_response_v0::Result::Data(
+                    get_token_contract_info_response_v0::TokenContractInfoData {
+                        contract_id: token_contract_info.contract_id().to_vec(),
+                        token_contract_position: token_contract_info.token_contract_position()
+                            as u32,
+                    },
+                )
+            });
 
-                GetTokenContractInfoResponseV0 {
-                    result,
-                    metadata: Some(self.response_metadata_v0(platform_state)),
-                }
-            };
+            GetTokenContractInfoResponseV0 {
+                result,
+                metadata: Some(self.response_metadata_v0(platform_state, CheckpointUsed::Current)),
+            }
+        };
 
         Ok(QueryValidationResult::new_with_data(response))
     }

--- a/packages/rs-drive-abci/src/query/token_queries/token_direct_purchase_prices/v0/mod.rs
+++ b/packages/rs-drive-abci/src/query/token_queries/token_direct_purchase_prices/v0/mod.rs
@@ -2,6 +2,7 @@ use crate::error::query::QueryError;
 use crate::error::Error;
 use crate::platform_types::platform::Platform;
 use crate::platform_types::platform_state::PlatformState;
+use crate::query::response_metadata::CheckpointUsed;
 use crate::query::QueryValidationResult;
 use dapi_grpc::platform::v0::get_token_direct_purchase_prices_request::GetTokenDirectPurchasePricesRequestV0;
 use dapi_grpc::platform::v0::get_token_direct_purchase_prices_response::{
@@ -15,6 +16,7 @@ use dpp::check_validation_result_with_data;
 use dpp::tokens::token_pricing_schedule::TokenPricingSchedule;
 use dpp::validation::ValidationResult;
 use dpp::version::PlatformVersion;
+use drive::util::grove_operations::GroveDBToUse;
 
 impl<C> Platform<C> {
     pub(super) fn query_token_direct_purchase_prices_v0(
@@ -49,9 +51,10 @@ impl<C> Platform<C> {
 
             GetTokenDirectPurchasePricesResponseV0 {
                 result: Some(get_token_direct_purchase_prices_response_v0::Result::Proof(
-                    self.response_proof_v0(platform_state, proof),
+                    self.response_proof_v0(platform_state, proof, GroveDBToUse::Current)
+                        .map(|(_, proof)| proof)?,
                 )),
-                metadata: Some(self.response_metadata_v0(platform_state)),
+                metadata: Some(self.response_metadata_v0(platform_state, CheckpointUsed::Current)),
             }
         } else {
             let token_prices: Vec<TokenDirectPurchasePriceEntry> = self
@@ -93,7 +96,7 @@ impl<C> Platform<C> {
                         },
                     ),
                 ),
-                metadata: Some(self.response_metadata_v0(platform_state)),
+                metadata: Some(self.response_metadata_v0(platform_state, CheckpointUsed::Current)),
             }
         };
 

--- a/packages/rs-drive-abci/src/query/token_queries/token_perpetual_distribution_last_claim/v0/mod.rs
+++ b/packages/rs-drive-abci/src/query/token_queries/token_perpetual_distribution_last_claim/v0/mod.rs
@@ -19,6 +19,8 @@ use dpp::data_contract::associated_token::token_perpetual_distribution::reward_d
 use dpp::identifier::Identifier;
 use dpp::validation::ValidationResult;
 use dpp::version::PlatformVersion;
+use drive::util::grove_operations::GroveDBToUse;
+use crate::query::response_metadata::CheckpointUsed;
 
 impl<C> Platform<C> {
     pub(super) fn query_token_perpetual_distribution_last_claim_v0(
@@ -61,10 +63,11 @@ impl<C> Platform<C> {
             GetTokenPerpetualDistributionLastClaimResponseV0 {
                 result: Some(
                     get_token_perpetual_distribution_last_claim_response_v0::Result::Proof(
-                        self.response_proof_v0(platform_state, proof),
+                        self.response_proof_v0(platform_state, proof, GroveDBToUse::Current)
+                            .map(|(_, proof)| proof)?,
                     ),
                 ),
-                metadata: Some(self.response_metadata_v0(platform_state)),
+                metadata: Some(self.response_metadata_v0(platform_state, CheckpointUsed::Current)),
             }
         } else if let Some(ContractTokenInfo {
             contract_id,
@@ -143,7 +146,7 @@ impl<C> Platform<C> {
                         LastClaimInfo { paid_at },
                     ),
                 ),
-                metadata: Some(self.response_metadata_v0(platform_state)),
+                metadata: Some(self.response_metadata_v0(platform_state, CheckpointUsed::Current)),
             }
         } else {
             let paid_at = self
@@ -162,7 +165,7 @@ impl<C> Platform<C> {
                         LastClaimInfo { paid_at },
                     ),
                 ),
-                metadata: Some(self.response_metadata_v0(platform_state)),
+                metadata: Some(self.response_metadata_v0(platform_state, CheckpointUsed::Current)),
             }
         };
 

--- a/packages/rs-drive-abci/src/query/token_queries/token_pre_programmed_distributions/v0/mod.rs
+++ b/packages/rs-drive-abci/src/query/token_queries/token_pre_programmed_distributions/v0/mod.rs
@@ -13,6 +13,8 @@ use dpp::validation::ValidationResult;
 use dpp::version::PlatformVersion;
 use drive::drive::tokens::distribution::queries::QueryPreProgrammedDistributionStartAt;
 use drive::error::query::QuerySyntaxError;
+use drive::util::grove_operations::GroveDBToUse;
+use crate::query::response_metadata::CheckpointUsed;
 
 impl<C> Platform<C> {
     pub(super) fn query_token_pre_programmed_distributions_v0(
@@ -92,10 +94,11 @@ impl<C> Platform<C> {
             GetTokenPreProgrammedDistributionsResponseV0 {
                 result: Some(
                     get_token_pre_programmed_distributions_response_v0::Result::Proof(
-                        self.response_proof_v0(platform_state, proof),
+                        self.response_proof_v0(platform_state, proof, GroveDBToUse::Current)
+                            .map(|(_, proof)| proof)?,
                     ),
                 ),
-                metadata: Some(self.response_metadata_v0(platform_state)),
+                metadata: Some(self.response_metadata_v0(platform_state, CheckpointUsed::Current)),
             }
         } else {
             let token_distributions = self
@@ -131,7 +134,7 @@ impl<C> Platform<C> {
                         },
                     ),
                 ),
-                metadata: Some(self.response_metadata_v0(platform_state)),
+                metadata: Some(self.response_metadata_v0(platform_state, CheckpointUsed::Current)),
             }
         };
 

--- a/packages/rs-drive-abci/src/query/token_queries/token_status/v0/mod.rs
+++ b/packages/rs-drive-abci/src/query/token_queries/token_status/v0/mod.rs
@@ -2,6 +2,7 @@ use crate::error::query::QueryError;
 use crate::error::Error;
 use crate::platform_types::platform::Platform;
 use crate::platform_types::platform_state::PlatformState;
+use crate::query::response_metadata::CheckpointUsed;
 use crate::query::QueryValidationResult;
 use dapi_grpc::platform::v0::get_token_statuses_request::GetTokenStatusesRequestV0;
 use dapi_grpc::platform::v0::get_token_statuses_response::get_token_statuses_response_v0::{
@@ -14,6 +15,7 @@ use dpp::check_validation_result_with_data;
 use dpp::tokens::status::v0::TokenStatusV0Accessors;
 use dpp::validation::ValidationResult;
 use dpp::version::PlatformVersion;
+use drive::util::grove_operations::GroveDBToUse;
 
 impl<C> Platform<C> {
     pub(super) fn query_token_statuses_v0(
@@ -42,9 +44,10 @@ impl<C> Platform<C> {
 
             GetTokenStatusesResponseV0 {
                 result: Some(get_token_statuses_response_v0::Result::Proof(
-                    self.response_proof_v0(platform_state, proof),
+                    self.response_proof_v0(platform_state, proof, GroveDBToUse::Current)
+                        .map(|(_, proof)| proof)?,
                 )),
-                metadata: Some(self.response_metadata_v0(platform_state)),
+                metadata: Some(self.response_metadata_v0(platform_state, CheckpointUsed::Current)),
             }
         } else {
             let token_statuses = self
@@ -64,7 +67,7 @@ impl<C> Platform<C> {
                 result: Some(get_token_statuses_response_v0::Result::TokenStatuses(
                     TokenStatuses { token_statuses },
                 )),
-                metadata: Some(self.response_metadata_v0(platform_state)),
+                metadata: Some(self.response_metadata_v0(platform_state, CheckpointUsed::Current)),
             }
         };
 

--- a/packages/rs-drive-abci/src/query/token_queries/token_total_supply/v0/mod.rs
+++ b/packages/rs-drive-abci/src/query/token_queries/token_total_supply/v0/mod.rs
@@ -2,6 +2,7 @@ use crate::error::query::QueryError;
 use crate::error::Error;
 use crate::platform_types::platform::Platform;
 use crate::platform_types::platform_state::PlatformState;
+use crate::query::response_metadata::CheckpointUsed;
 use crate::query::QueryValidationResult;
 use dapi_grpc::platform::v0::get_token_total_supply_request::GetTokenTotalSupplyRequestV0;
 use dapi_grpc::platform::v0::get_token_total_supply_response::get_token_total_supply_response_v0::TokenTotalSupplyEntry;
@@ -12,6 +13,7 @@ use dpp::check_validation_result_with_data;
 use dpp::identifier::Identifier;
 use dpp::validation::ValidationResult;
 use dpp::version::PlatformVersion;
+use drive::util::grove_operations::GroveDBToUse;
 
 impl<C> Platform<C> {
     pub(super) fn query_token_total_supply_v0(
@@ -38,9 +40,10 @@ impl<C> Platform<C> {
 
             GetTokenTotalSupplyResponseV0 {
                 result: Some(get_token_total_supply_response_v0::Result::Proof(
-                    self.response_proof_v0(platform_state, proof),
+                    self.response_proof_v0(platform_state, proof, GroveDBToUse::Current)
+                        .map(|(_, proof)| proof)?,
                 )),
-                metadata: Some(self.response_metadata_v0(platform_state)),
+                metadata: Some(self.response_metadata_v0(platform_state, CheckpointUsed::Current)),
             }
         } else {
             let Some(token_total_aggregated_identity_balances) = self
@@ -72,7 +75,7 @@ impl<C> Platform<C> {
                         },
                     ),
                 ),
-                metadata: Some(self.response_metadata_v0(platform_state)),
+                metadata: Some(self.response_metadata_v0(platform_state, CheckpointUsed::Current)),
             }
         };
 

--- a/packages/rs-drive-abci/src/query/validator_queries/proposed_block_counts_by_evonode_ids/v0/mod.rs
+++ b/packages/rs-drive-abci/src/query/validator_queries/proposed_block_counts_by_evonode_ids/v0/mod.rs
@@ -12,6 +12,8 @@ use dpp::check_validation_result_with_data;
 use dpp::validation::ValidationResult;
 use dpp::version::PlatformVersion;
 use drive::query::proposer_block_count_query::ProposerQueryType;
+use drive::util::grove_operations::GroveDBToUse;
+use crate::query::response_metadata::CheckpointUsed;
 use crate::platform_types::platform_state::PlatformStateV0Methods;
 
 impl<C> Platform<C> {
@@ -71,13 +73,12 @@ impl<C> Platform<C> {
                 platform_version
             ));
 
+            let (grovedb_used, proof) =
+                self.response_proof_v0(platform_state, proof, GroveDBToUse::Current)?;
+
             GetEvonodesProposedEpochBlocksResponseV0 {
-                result: Some(
-                    get_evonodes_proposed_epoch_blocks_response_v0::Result::Proof(
-                        self.response_proof_v0(platform_state, proof),
-                    ),
-                ),
-                metadata: Some(self.response_metadata_v0(platform_state)),
+                result: Some(get_evonodes_proposed_epoch_blocks_response_v0::Result::Proof(proof)),
+                metadata: Some(self.response_metadata_v0(platform_state, grovedb_used)),
             }
         } else {
             let evonodes_proposed_block_counts = self
@@ -101,7 +102,7 @@ impl<C> Platform<C> {
 
             GetEvonodesProposedEpochBlocksResponseV0 {
                 result: Some(get_evonodes_proposed_epoch_blocks_response_v0::Result::EvonodesProposedBlockCountsInfo(evonode_proposed_blocks)),
-                metadata: Some(self.response_metadata_v0(platform_state)),
+                metadata: Some(self.response_metadata_v0(platform_state, CheckpointUsed::Current)),
             }
         };
 

--- a/packages/rs-drive-abci/src/query/validator_queries/proposed_block_counts_by_range/v0/mod.rs
+++ b/packages/rs-drive-abci/src/query/validator_queries/proposed_block_counts_by_range/v0/mod.rs
@@ -14,6 +14,8 @@ use dpp::validation::ValidationResult;
 use dpp::version::PlatformVersion;
 use drive::query::proposer_block_count_query::ProposerQueryType;
 use drive::error::query::QuerySyntaxError;
+use drive::util::grove_operations::GroveDBToUse;
+use crate::query::response_metadata::CheckpointUsed;
 use crate::platform_types::platform_state::PlatformStateV0Methods;
 
 impl<C> Platform<C> {
@@ -103,13 +105,12 @@ impl<C> Platform<C> {
                 platform_version
             ));
 
+            let (grovedb_used, proof) =
+                self.response_proof_v0(platform_state, proof, GroveDBToUse::Current)?;
+
             GetEvonodesProposedEpochBlocksResponseV0 {
-                result: Some(
-                    get_evonodes_proposed_epoch_blocks_response_v0::Result::Proof(
-                        self.response_proof_v0(platform_state, proof),
-                    ),
-                ),
-                metadata: Some(self.response_metadata_v0(platform_state)),
+                result: Some(get_evonodes_proposed_epoch_blocks_response_v0::Result::Proof(proof)),
+                metadata: Some(self.response_metadata_v0(platform_state, grovedb_used)),
             }
         } else {
             let evonodes_proposed_block_counts = self
@@ -133,7 +134,7 @@ impl<C> Platform<C> {
 
             GetEvonodesProposedEpochBlocksResponseV0 {
                 result: Some(get_evonodes_proposed_epoch_blocks_response_v0::Result::EvonodesProposedBlockCountsInfo(evonode_proposed_blocks)),
-                metadata: Some(self.response_metadata_v0(platform_state)),
+                metadata: Some(self.response_metadata_v0(platform_state, CheckpointUsed::Current)),
             }
         };
 

--- a/packages/rs-drive-abci/src/query/voting/contested_resource_identity_votes/v0/mod.rs
+++ b/packages/rs-drive-abci/src/query/voting/contested_resource_identity_votes/v0/mod.rs
@@ -2,6 +2,7 @@ use crate::error::query::QueryError;
 use crate::error::Error;
 use crate::platform_types::platform::Platform;
 use crate::platform_types::platform_state::PlatformState;
+use crate::query::response_metadata::CheckpointUsed;
 use crate::query::QueryValidationResult;
 use dapi_grpc::platform::v0::get_contested_resource_identity_votes_request::GetContestedResourceIdentityVotesRequestV0;
 use dapi_grpc::platform::v0::get_contested_resource_identity_votes_response::{
@@ -15,6 +16,7 @@ use dpp::{check_validation_result_with_data, platform_value, ProtocolError};
 use drive::drive::votes::storage_form::contested_document_resource_storage_form::ContestedDocumentResourceVoteStorageForm;
 use drive::error::query::QuerySyntaxError;
 use drive::query::contested_resource_votes_given_by_identity_query::ContestedResourceVotesGivenByIdentityQuery;
+use drive::util::grove_operations::GroveDBToUse;
 
 impl<C> Platform<C> {
     pub(super) fn query_contested_resource_identity_votes_v0(
@@ -87,13 +89,14 @@ impl<C> Platform<C> {
                 Err(e) => return Err(e.into()),
             };
 
+            let (grovedb_used, proof) =
+                self.response_proof_v0(platform_state, proof, GroveDBToUse::Current)?;
+
             GetContestedResourceIdentityVotesResponseV0 {
                 result: Some(
-                    get_contested_resource_identity_votes_response_v0::Result::Proof(
-                        self.response_proof_v0(platform_state, proof),
-                    ),
+                    get_contested_resource_identity_votes_response_v0::Result::Proof(proof),
                 ),
-                metadata: Some(self.response_metadata_v0(platform_state)),
+                metadata: Some(self.response_metadata_v0(platform_state, grovedb_used)),
             }
         } else {
             let votes =
@@ -189,7 +192,7 @@ impl<C> Platform<C> {
                         },
                     ),
                 ),
-                metadata: Some(self.response_metadata_v0(platform_state)),
+                metadata: Some(self.response_metadata_v0(platform_state, CheckpointUsed::Current)),
             }
         };
 

--- a/packages/rs-drive-abci/src/query/voting/contested_resource_vote_state/v0/mod.rs
+++ b/packages/rs-drive-abci/src/query/voting/contested_resource_vote_state/v0/mod.rs
@@ -22,6 +22,8 @@ use drive::error::query::QuerySyntaxError;
 use drive::query::vote_poll_vote_state_query::{
     ContestedDocumentVotePollDriveQuery,
 };
+use drive::util::grove_operations::GroveDBToUse;
+use crate::query::response_metadata::CheckpointUsed;
 
 impl<C> Platform<C> {
     pub(super) fn query_contested_resource_vote_state_v0(
@@ -168,13 +170,12 @@ impl<C> Platform<C> {
                 Err(e) => return Err(e.into()),
             };
 
+            let (grovedb_used, proof) =
+                self.response_proof_v0(platform_state, proof, GroveDBToUse::Current)?;
+
             GetContestedResourceVoteStateResponseV0 {
-                result: Some(
-                    get_contested_resource_vote_state_response_v0::Result::Proof(
-                        self.response_proof_v0(platform_state, proof),
-                    ),
-                ),
-                metadata: Some(self.response_metadata_v0(platform_state)),
+                result: Some(get_contested_resource_vote_state_response_v0::Result::Proof(proof)),
+                metadata: Some(self.response_metadata_v0(platform_state, grovedb_used)),
             }
         } else {
             let results =
@@ -249,7 +250,7 @@ impl<C> Platform<C> {
                         },
                     ),
                 ),
-                metadata: Some(self.response_metadata_v0(platform_state)),
+                metadata: Some(self.response_metadata_v0(platform_state, CheckpointUsed::Current)),
             }
         };
 

--- a/packages/rs-drive-abci/src/query/voting/contested_resource_voters_for_identity/v0/mod.rs
+++ b/packages/rs-drive-abci/src/query/voting/contested_resource_voters_for_identity/v0/mod.rs
@@ -2,6 +2,7 @@ use crate::error::query::QueryError;
 use crate::error::Error;
 use crate::platform_types::platform::Platform;
 use crate::platform_types::platform_state::PlatformState;
+use crate::query::response_metadata::CheckpointUsed;
 use crate::query::QueryValidationResult;
 use dapi_grpc::platform::v0::get_contested_resource_voters_for_identity_request::GetContestedResourceVotersForIdentityRequestV0;
 use dapi_grpc::platform::v0::get_contested_resource_voters_for_identity_response::{
@@ -17,6 +18,7 @@ use dpp::voting::vote_polls::contested_document_resource_vote_poll::ContestedDoc
 use dpp::{check_validation_result_with_data, platform_value};
 use drive::error::query::QuerySyntaxError;
 use drive::query::vote_poll_contestant_votes_query::ContestedDocumentVotePollVotesDriveQuery;
+use drive::util::grove_operations::GroveDBToUse;
 
 impl<C> Platform<C> {
     pub(super) fn query_contested_resource_voters_for_identity_v0(
@@ -162,13 +164,14 @@ impl<C> Platform<C> {
                 Err(e) => return Err(e.into()),
             };
 
+            let (grovedb_used, proof) =
+                self.response_proof_v0(platform_state, proof, GroveDBToUse::Current)?;
+
             GetContestedResourceVotersForIdentityResponseV0 {
                 result: Some(
-                    get_contested_resource_voters_for_identity_response_v0::Result::Proof(
-                        self.response_proof_v0(platform_state, proof),
-                    ),
+                    get_contested_resource_voters_for_identity_response_v0::Result::Proof(proof),
                 ),
-                metadata: Some(self.response_metadata_v0(platform_state)),
+                metadata: Some(self.response_metadata_v0(platform_state, grovedb_used)),
             }
         } else {
             let query = ContestedDocumentVotePollVotesDriveQuery {
@@ -239,7 +242,7 @@ impl<C> Platform<C> {
                         },
                     ),
                 ),
-                metadata: Some(self.response_metadata_v0(platform_state)),
+                metadata: Some(self.response_metadata_v0(platform_state, CheckpointUsed::Current)),
             }
         };
 

--- a/packages/rs-drive-abci/src/query/voting/contested_resources/v0/mod.rs
+++ b/packages/rs-drive-abci/src/query/voting/contested_resources/v0/mod.rs
@@ -2,6 +2,7 @@ use crate::error::query::QueryError;
 use crate::error::Error;
 use crate::platform_types::platform::Platform;
 use crate::platform_types::platform_state::PlatformState;
+use crate::query::response_metadata::CheckpointUsed;
 use crate::query::QueryValidationResult;
 use bincode::error::EncodeError;
 use dapi_grpc::platform::v0::get_contested_resources_request::GetContestedResourcesRequestV0;
@@ -16,6 +17,7 @@ use dpp::version::PlatformVersion;
 use dpp::{check_validation_result_with_data, ProtocolError};
 use drive::error::query::QuerySyntaxError;
 use drive::query::vote_polls_by_document_type_query::VotePollsByDocumentTypeQuery;
+use drive::util::grove_operations::GroveDBToUse;
 
 impl<C> Platform<C> {
     pub(super) fn query_contested_resources_v0(
@@ -192,11 +194,12 @@ impl<C> Platform<C> {
                     Err(e) => return Err(e.into()),
                 };
 
+            let (grovedb_used, proof) =
+                self.response_proof_v0(platform_state, proof, GroveDBToUse::Current)?;
+
             GetContestedResourcesResponseV0 {
-                result: Some(get_contested_resources_response_v0::Result::Proof(
-                    self.response_proof_v0(platform_state, proof),
-                )),
-                metadata: Some(self.response_metadata_v0(platform_state)),
+                result: Some(get_contested_resources_response_v0::Result::Proof(proof)),
+                metadata: Some(self.response_metadata_v0(platform_state, grovedb_used)),
             }
         } else {
             let results =
@@ -226,7 +229,7 @@ impl<C> Platform<C> {
                         },
                     ),
                 ),
-                metadata: Some(self.response_metadata_v0(platform_state)),
+                metadata: Some(self.response_metadata_v0(platform_state, CheckpointUsed::Current)),
             }
         };
 

--- a/packages/rs-drive-abci/src/query/voting/vote_polls_by_end_date_query/v0/mod.rs
+++ b/packages/rs-drive-abci/src/query/voting/vote_polls_by_end_date_query/v0/mod.rs
@@ -10,8 +10,10 @@ use dpp::check_validation_result_with_data;
 use dpp::version::PlatformVersion;
 use dpp::validation::ValidationResult;
 
+use crate::query::response_metadata::CheckpointUsed;
 use drive::error::query::QuerySyntaxError;
 use drive::query::VotePollsByEndDateDriveQuery;
+use drive::util::grove_operations::GroveDBToUse;
 
 impl<C> Platform<C> {
     pub(super) fn query_vote_polls_by_end_date_query_v0(
@@ -109,11 +111,12 @@ impl<C> Platform<C> {
                 Err(e) => return Err(e.into()),
             };
 
+            let (grovedb_used, proof) =
+                self.response_proof_v0(platform_state, proof, GroveDBToUse::Current)?;
+
             GetVotePollsByEndDateResponseV0 {
-                result: Some(get_vote_polls_by_end_date_response_v0::Result::Proof(
-                    self.response_proof_v0(platform_state, proof),
-                )),
-                metadata: Some(self.response_metadata_v0(platform_state)),
+                result: Some(get_vote_polls_by_end_date_response_v0::Result::Proof(proof)),
+                metadata: Some(self.response_metadata_v0(platform_state, grovedb_used)),
             }
         } else {
             let results = match query.execute_no_proof_keep_serialized(
@@ -207,7 +210,7 @@ impl<C> Platform<C> {
                         },
                     ),
                 ),
-                metadata: Some(self.response_metadata_v0(platform_state)),
+                metadata: Some(self.response_metadata_v0(platform_state, CheckpointUsed::Current)),
             }
         };
 

--- a/packages/rs-drive-abci/tests/strategy_tests/test_cases/address_tests.rs
+++ b/packages/rs-drive-abci/tests/strategy_tests/test_cases/address_tests.rs
@@ -528,4 +528,201 @@ mod tests {
             "trunk query should have chunk_depths [6]"
         );
     }
+
+    #[test]
+    fn run_chain_address_transitions_with_checkpoints_stop_and_restart() {
+        drive_abci::logging::init_for_tests(LogLevel::Debug);
+
+        let strategy = NetworkStrategy {
+            strategy: Strategy {
+                start_contracts: vec![],
+                operations: vec![
+                    Operation {
+                        op_type: OperationType::AddressTransfer(
+                            dash_to_credits!(5)..=dash_to_credits!(5),
+                            1..=4,
+                            Some(0.2),
+                            None,
+                        ),
+                        frequency: Frequency {
+                            times_per_block_range: 1..3,
+                            chance_per_block: None,
+                        },
+                    },
+                    Operation {
+                        op_type: OperationType::AddressFundingFromCoreAssetLock(
+                            dash_to_credits!(20)..=dash_to_credits!(20),
+                        ),
+                        frequency: Frequency {
+                            times_per_block_range: 1..3,
+                            chance_per_block: None,
+                        },
+                    },
+                ],
+                start_identities: StartIdentities::default(),
+                start_addresses: StartAddresses::default(),
+                identity_inserts: IdentityInsertInfo {
+                    frequency: Frequency {
+                        times_per_block_range: 1..2,
+                        chance_per_block: None,
+                    },
+                    ..Default::default()
+                },
+                identity_contract_nonce_gaps: None,
+                signer: None,
+            },
+            total_hpmns: 100,
+            extra_normal_mns: 0,
+            validator_quorum_count: 24,
+            chain_lock_quorum_count: 24,
+            upgrading_info: None,
+
+            proposer_strategy: Default::default(),
+            rotate_quorums: false,
+            failure_testing: None,
+            query_testing: None,
+            verify_state_transition_results: true,
+            sign_instant_locks: true,
+            ..Default::default()
+        };
+        let config = PlatformConfig {
+            validator_set: ValidatorSetConfig::default_100_67(),
+            chain_lock: ChainLockConfig::default_100_67(),
+            instant_lock: InstantLockConfig::default_100_67(),
+            execution: ExecutionConfig {
+                verify_sum_trees: true,
+
+                ..Default::default()
+            },
+            block_spacing_ms: 180000, // 3 mins
+            testing_configs: PlatformTestConfig {
+                disable_checkpoints: false,
+                ..PlatformTestConfig::default_minimal_verifications()
+            },
+            ..Default::default()
+        };
+        let mut platform = TestPlatformBuilder::new()
+            .with_config(config.clone())
+            .build_with_mock_rpc();
+
+        let outcome = run_chain_for_strategy(
+            &mut platform,
+            13,
+            strategy,
+            config,
+            15,
+            &mut None,
+            &mut None,
+        );
+
+        let executed = outcome
+            .state_transition_results_per_block
+            .values()
+            .flat_map(|results| results.iter())
+            .filter(|(state_transition, result)| {
+                result.code == 0
+                    && matches!(state_transition, StateTransition::AddressFundsTransfer(_))
+            })
+            .count();
+        assert!(executed > 0, "expected at least one address transfer");
+
+        // Drop outcome to release the mutable borrow of platform
+        drop(outcome);
+
+        let platform_version = PlatformVersion::latest();
+
+        // Verify checkpoints exist before restart
+        let checkpoints = platform.platform.drive.checkpoints.load();
+        assert!(
+            !checkpoints.is_empty(),
+            "expected at least one checkpoint to be created"
+        );
+        let (&checkpoint_height, _) = checkpoints.last_key_value().unwrap();
+        assert_eq!(checkpoint_height, 12, "expected checkpoint height to be 12");
+
+        // Verify checkpoint platform states exist before restart
+        let checkpoint_states_before = platform.platform.checkpoint_platform_states.load();
+        assert!(
+            checkpoint_states_before.contains_key(&12),
+            "expected checkpoint platform state at height 12 before restart"
+        );
+
+        // Simulate restart by reloading state from storage
+        platform
+            .platform
+            .reload_state_from_storage(platform_version)
+            .expect("expected to reload state from storage");
+
+        // Verify checkpoint platform states were restored after restart
+        let checkpoint_states_after = platform.platform.checkpoint_platform_states.load();
+        assert!(
+            checkpoint_states_after.contains_key(&12),
+            "expected checkpoint platform state at height 12 after restart"
+        );
+
+        // Verify we can still query using checkpoints after restart
+        let platform_state = platform.platform.state.load();
+        let current_height = platform_state.last_committed_block_height();
+        assert_eq!(current_height, 13, "expected current height to be 13");
+
+        // Test the ABCI query layer for trunk state (uses LatestCheckpoint)
+        let request = GetAddressesTrunkStateRequest {
+            version: Some(RequestVersion::V0(GetAddressesTrunkStateRequestV0 {})),
+        };
+
+        let query_result = platform
+            .platform
+            .query_addresses_trunk_state(request, &platform_state, platform_version)
+            .expect("should execute trunk state query after restart");
+
+        assert!(
+            query_result.errors.is_empty(),
+            "query should succeed after restart: {:?}",
+            query_result.errors
+        );
+
+        let response = query_result.into_data().expect("expected data");
+        let response_v0 = match response.version.expect("expected version") {
+            ResponseVersion::V0(v0) => v0,
+        };
+
+        // Verify we got a proof
+        let proof = response_v0.proof.expect("expected proof");
+        assert!(
+            !proof.grovedb_proof.is_empty(),
+            "grovedb proof should not be empty after restart"
+        );
+
+        // Verify the metadata shows we used the checkpoint (height should match checkpoint)
+        let metadata = response_v0.metadata.expect("expected metadata");
+        assert_eq!(
+            metadata.height, 12,
+            "trunk query should use checkpoint at height 12 after restart"
+        );
+
+        // Verify the proof
+        let (root_hash, trunk_result) =
+            Drive::verify_address_funds_trunk_query(&proof.grovedb_proof, platform_version)
+                .expect("should verify trunk query proof after restart");
+
+        // The root hash should be valid (32 bytes)
+        assert_eq!(root_hash.len(), 32, "root hash should be 32 bytes");
+
+        // Verify trunk query results match expected values
+        assert_eq!(
+            trunk_result.elements.len(),
+            29,
+            "trunk query should return 29 elements after restart"
+        );
+        assert_eq!(
+            trunk_result.leaf_keys.len(),
+            0,
+            "trunk query should return 0 leaf keys after restart"
+        );
+        assert_eq!(
+            trunk_result.chunk_depths,
+            vec![6],
+            "trunk query should have chunk_depths [6] after restart"
+        );
+    }
 }

--- a/packages/rs-drive-abci/tests/strategy_tests/test_cases/address_tests.rs
+++ b/packages/rs-drive-abci/tests/strategy_tests/test_cases/address_tests.rs
@@ -3,6 +3,11 @@ mod tests {
 
     use crate::execution::run_chain_for_strategy;
     use crate::strategy::NetworkStrategy;
+    use dapi_grpc::platform::v0::get_addresses_trunk_state_request::{
+        GetAddressesTrunkStateRequestV0, Version as RequestVersion,
+    };
+    use dapi_grpc::platform::v0::get_addresses_trunk_state_response::Version as ResponseVersion;
+    use dapi_grpc::platform::v0::GetAddressesTrunkStateRequest;
     use dpp::dash_to_credits;
     use dpp::identity::{KeyType, Purpose, SecurityLevel};
     use dpp::state_transition::StateTransition;
@@ -12,6 +17,7 @@ mod tests {
         ValidatorSetConfig,
     };
     use drive_abci::logging::LogLevel;
+    use drive_abci::platform_types::platform_state::PlatformStateV0Methods;
     use drive_abci::test::helpers::setup::TestPlatformBuilder;
     use platform_version::version::PlatformVersion;
     use strategy_tests::frequency::Frequency;
@@ -420,7 +426,7 @@ mod tests {
 
         let outcome = run_chain_for_strategy(
             &mut platform,
-            12,
+            13,
             strategy,
             config,
             15,
@@ -442,36 +448,84 @@ mod tests {
         // Drop outcome to release the mutable borrow of platform
         drop(outcome);
 
-        // Test prove_address_funds_trunk_query
         let platform_version = PlatformVersion::latest();
 
-        let proof = platform
-            .drive
-            .prove_address_funds_trunk_query(platform_version)
-            .expect("should generate trunk query proof");
+        // Get current platform state for the query
+        let platform_state = platform.platform.state.load();
+        let current_height = platform_state.last_committed_block_height();
 
-        assert!(!proof.is_empty(), "proof should not be empty");
+        // Verify checkpoints exist
+        let checkpoints = platform.platform.drive.checkpoints.load();
+        assert!(
+            !checkpoints.is_empty(),
+            "expected at least one checkpoint to be created"
+        );
+
+        // Get the checkpoint height
+        let (&checkpoint_height, _) = checkpoints.last_key_value().unwrap();
+
+        // Verify expected heights
+        assert_eq!(current_height, 13, "expected current height to be 13");
+        assert_eq!(checkpoint_height, 12, "expected checkpoint height to be 12");
+
+        // Test the ABCI query layer for trunk state (uses LatestCheckpoint)
+        let request = GetAddressesTrunkStateRequest {
+            version: Some(RequestVersion::V0(GetAddressesTrunkStateRequestV0 {})),
+        };
+
+        let query_result = platform
+            .platform
+            .query_addresses_trunk_state(request, &platform_state, platform_version)
+            .expect("should execute trunk state query");
+
+        assert!(
+            query_result.errors.is_empty(),
+            "query should succeed: {:?}",
+            query_result.errors
+        );
+
+        let response = query_result.into_data().expect("expected data");
+        let response_v0 = match response.version.expect("expected version") {
+            ResponseVersion::V0(v0) => v0,
+        };
+
+        // Verify we got a proof
+        let proof = response_v0.proof.expect("expected proof");
+        assert!(
+            !proof.grovedb_proof.is_empty(),
+            "grovedb proof should not be empty"
+        );
+
+        // Verify the metadata shows we used the checkpoint (height should match checkpoint)
+        let metadata = response_v0.metadata.expect("expected metadata");
+        assert_eq!(
+            metadata.height, 12,
+            "trunk query should use checkpoint at height 12"
+        );
 
         // Verify the proof
         let (root_hash, trunk_result) =
-            Drive::verify_address_funds_trunk_query(&proof, platform_version)
+            Drive::verify_address_funds_trunk_query(&proof.grovedb_proof, platform_version)
                 .expect("should verify trunk query proof");
 
         // The root hash should be valid (32 bytes)
         assert_eq!(root_hash.len(), 32, "root hash should be 32 bytes");
 
-        // Check that we got some elements or leaf keys from the trunk query
-        let total_items = trunk_result.elements.len() + trunk_result.leaf_keys.len();
-        assert!(
-            total_items > 0,
-            "trunk query should return elements or leaf keys"
-        );
-
-        println!(
-            "Trunk query result: {} elements, {} leaf keys, chunk_depths: {:?}",
+        // Verify trunk query results
+        assert_eq!(
             trunk_result.elements.len(),
+            29,
+            "trunk query should return 29 elements"
+        );
+        assert_eq!(
             trunk_result.leaf_keys.len(),
-            trunk_result.chunk_depths
+            0,
+            "trunk query should return 0 leaf keys"
+        );
+        assert_eq!(
+            trunk_result.chunk_depths,
+            vec![6],
+            "trunk query should have chunk_depths [6]"
         );
     }
 }

--- a/packages/rs-drive/src/drive/mod.rs
+++ b/packages/rs-drive/src/drive/mod.rs
@@ -126,6 +126,7 @@ pub struct CheckpointInfo {
     pub checkpoint: Arc<Checkpoint>,
 }
 
+#[cfg(feature = "server")]
 impl CheckpointInfo {
     /// Creates a new CheckpointInfo with the given timestamp and checkpoint
     pub fn new(timestamp_ms: TimestampMillis, checkpoint: Arc<Checkpoint>) -> Self {

--- a/packages/rs-drive/src/drive/mod.rs
+++ b/packages/rs-drive/src/drive/mod.rs
@@ -116,9 +116,29 @@ impl Drop for Checkpoint {
     }
 }
 
+/// Information about a checkpoint including the database
+#[cfg(feature = "server")]
+#[derive(Clone)]
+pub struct CheckpointInfo {
+    /// The timestamp when this checkpoint was created
+    pub timestamp_ms: TimestampMillis,
+    /// The checkpoint database
+    pub checkpoint: Arc<Checkpoint>,
+}
+
+impl CheckpointInfo {
+    /// Creates a new CheckpointInfo with the given timestamp and checkpoint
+    pub fn new(timestamp_ms: TimestampMillis, checkpoint: Arc<Checkpoint>) -> Self {
+        Self {
+            timestamp_ms,
+            checkpoint,
+        }
+    }
+}
+
 /// Type alias for the checkpoints map wrapped in ArcSwap for atomic updates
 #[cfg(feature = "server")]
-pub type CheckpointsMap = ArcSwap<BTreeMap<BlockHeight, (TimestampMillis, Arc<Checkpoint>)>>;
+pub type CheckpointsMap = ArcSwap<BTreeMap<BlockHeight, CheckpointInfo>>;
 
 /// Drive struct
 #[cfg(any(feature = "server", feature = "verify"))]

--- a/packages/rs-drive/src/open/load_current_checkpoints.rs
+++ b/packages/rs-drive/src/open/load_current_checkpoints.rs
@@ -6,7 +6,7 @@ use arc_swap::ArcSwap;
 use dpp::prelude::{BlockHeight, TimestampMillis};
 use grovedb::GroveDb;
 
-use crate::drive::{Checkpoint, CheckpointsMap};
+use crate::drive::{Checkpoint, CheckpointInfo, CheckpointsMap};
 use crate::error::Error;
 
 /// Loads existing checkpoints from the checkpoints directory.
@@ -71,7 +71,10 @@ pub fn load_current_checkpoints<P: AsRef<Path>>(db_path: P) -> Result<Checkpoint
             .unwrap_or(0);
 
         let checkpoint = Checkpoint::new(grove_db, path);
-        checkpoints.insert(block_height, (timestamp_ms, Arc::new(checkpoint)));
+        checkpoints.insert(
+            block_height,
+            CheckpointInfo::new(timestamp_ms, Arc::new(checkpoint)),
+        );
     }
 
     Ok(ArcSwap::from_pointee(checkpoints))

--- a/packages/rs-drive/src/util/grove_operations/grove_get_proved_trunk_chunk_query/v0/mod.rs
+++ b/packages/rs-drive/src/util/grove_operations/grove_get_proved_trunk_chunk_query/v0/mod.rs
@@ -34,10 +34,11 @@ impl Drive {
             }
             GroveDBToUse::LatestCheckpoint => {
                 let checkpoints = self.checkpoints.load();
-                let (_, (_, checkpoint)) = checkpoints
+                let (_, checkpoint_info) = checkpoints
                     .last_key_value()
                     .ok_or(Error::Drive(DriveError::NoCheckpointsAvailable))?;
-                let CostContext { value, cost } = checkpoint
+                let CostContext { value, cost } = checkpoint_info
+                    .checkpoint
                     .grove_db
                     .prove_trunk_chunk(query, &drive_version.grove_version);
                 drive_operations.push(CalculatedCostOperation(cost));
@@ -45,10 +46,11 @@ impl Drive {
             }
             GroveDBToUse::Checkpoint(block_height) => {
                 let checkpoints = self.checkpoints.load();
-                let (_, checkpoint) = checkpoints
+                let checkpoint_info = checkpoints
                     .get(&block_height)
                     .ok_or(Error::Drive(DriveError::CheckpointNotFound(block_height)))?;
-                let CostContext { value, cost } = checkpoint
+                let CostContext { value, cost } = checkpoint_info
+                    .checkpoint
                     .grove_db
                     .prove_trunk_chunk(query, &drive_version.grove_version);
                 drive_operations.push(CalculatedCostOperation(cost));


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
Queries that needed checkpoints were returning metadata from the chain tip.


## What was done?
We now store checkpoint platform states. They are loaded and pushed to when creating checkpoints. We use these previous states to give metadata on the queries for previous time.


## How Has This Been Tested?
Added a strategy test. Altered another one to better capture the issue.


## Breaking Changes
None


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [x] I have made corresponding changes to the documentation if needed

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Block platform state checkpointing: periodic disk checkpoints of platform state with automatic restoration on startup
  * Query proof/metadata improvements: responses indicate whether data came from current state or a checkpoint and proofs now include which DB source was used
  * Checkpoint info surfaced: richer checkpoint metadata tracked for reliability

* **Tests**
  * Expanded checkpoint validation tests covering restart and recovery scenarios

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->