### PR TITLE
fix(wasm-sdk): support ECDSA_SECP256K1 keys in identity operations

### DIFF
--- a/packages/wasm-sdk/src/state_transitions/identity/mod.rs
+++ b/packages/wasm-sdk/src/state_transitions/identity/mod.rs
@@ -20,9 +20,10 @@ use tracing::{debug, error};
 use wasm_bindgen::prelude::*;
 use wasm_bindgen::JsValue;
 
-/// Match a private key against a public key, supporting multiple key types.
-/// Returns true if the private key corresponds to the given public key.
-fn private_key_matches_public_key(
+/// Check if an ECDSA-derived public key matches an identity's public key.
+/// Supports ECDSA_SECP256K1 (33-byte comparison) and ECDSA_HASH160 (20-byte comparison).
+/// Returns false for non-ECDSA key types (BLS, EdDSA, etc.) since they require different derivation.
+fn ecdsa_public_key_matches_identity_key(
     public_key_bytes: &[u8],   // 33-byte compressed secp256k1 public key
     public_key_hash160: &[u8], // 20-byte hash160 of the public key
     key: &IdentityPublicKey,
@@ -674,7 +675,7 @@ impl WasmSdk {
                 .get(&requested_key_id)
                 .filter(|key| {
                     key.purpose() == Purpose::TRANSFER
-                        && private_key_matches_public_key(
+                        && ecdsa_public_key_matches_identity_key(
                             &public_key_bytes,
                             &public_key_hash160,
                             key,
@@ -693,7 +694,7 @@ impl WasmSdk {
                 .iter()
                 .find(|(_, key)| {
                     key.purpose() == Purpose::TRANSFER
-                        && private_key_matches_public_key(
+                        && ecdsa_public_key_matches_identity_key(
                             &public_key_bytes,
                             &public_key_hash160,
                             key,
@@ -861,7 +862,7 @@ impl WasmSdk {
                 .get(&requested_key_id)
                 .filter(|key| {
                     (key.purpose() == Purpose::TRANSFER || key.purpose() == Purpose::OWNER)
-                        && private_key_matches_public_key(
+                        && ecdsa_public_key_matches_identity_key(
                             &public_key_bytes,
                             &public_key_hash160,
                             key,
@@ -880,7 +881,7 @@ impl WasmSdk {
                 .iter()
                 .find(|(_, key)| {
                     key.purpose() == Purpose::TRANSFER
-                        && private_key_matches_public_key(
+                        && ecdsa_public_key_matches_identity_key(
                             &public_key_bytes,
                             &public_key_hash160,
                             key,
@@ -889,7 +890,7 @@ impl WasmSdk {
                 .or_else(|| {
                     identity.public_keys().iter().find(|(_, key)| {
                         key.purpose() == Purpose::OWNER
-                            && private_key_matches_public_key(
+                            && ecdsa_public_key_matches_identity_key(
                                 &public_key_bytes,
                                 &public_key_hash160,
                                 key,
@@ -1033,7 +1034,7 @@ impl WasmSdk {
             .find(|(_, key)| {
                 key.purpose() == Purpose::AUTHENTICATION
                     && key.security_level() == SecurityLevel::MASTER
-                    && private_key_matches_public_key(&public_key_bytes, &public_key_hash160, key)
+                    && ecdsa_public_key_matches_identity_key(&public_key_bytes, &public_key_hash160, key)
             })
             .map(|(id, _)| *id)
             .ok_or_else(|| {
@@ -1541,14 +1542,14 @@ mod tests {
 
         // Should match when comparing full public key bytes
         assert!(
-            private_key_matches_public_key(&public_key_bytes, &public_key_hash160, &secp_key),
+            ecdsa_public_key_matches_identity_key(&public_key_bytes, &public_key_hash160, &secp_key),
             "ECDSA_SECP256K1 key should match with correct public key bytes"
         );
 
         // Should not match with wrong public key
         let wrong_bytes = [0u8; 33];
         assert!(
-            !private_key_matches_public_key(&wrong_bytes, &public_key_hash160, &secp_key),
+            !ecdsa_public_key_matches_identity_key(&wrong_bytes, &public_key_hash160, &secp_key),
             "ECDSA_SECP256K1 key should not match with wrong public key bytes"
         );
     }
@@ -1575,14 +1576,14 @@ mod tests {
 
         // Should match when comparing hash160
         assert!(
-            private_key_matches_public_key(&public_key_bytes, &public_key_hash160, &hash160_key),
+            ecdsa_public_key_matches_identity_key(&public_key_bytes, &public_key_hash160, &hash160_key),
             "ECDSA_HASH160 key should match with correct hash160"
         );
 
         // Should not match with wrong hash
         let wrong_hash = [0u8; 20].to_vec();
         assert!(
-            !private_key_matches_public_key(&public_key_bytes, &wrong_hash, &hash160_key),
+            !ecdsa_public_key_matches_identity_key(&public_key_bytes, &wrong_hash, &hash160_key),
             "ECDSA_HASH160 key should not match with wrong hash160"
         );
     }
@@ -1607,7 +1608,7 @@ mod tests {
         let bls_key = create_test_key(KeyType::BLS12_381, vec![0u8; 48]);
 
         assert!(
-            !private_key_matches_public_key(&public_key_bytes, &public_key_hash160, &bls_key),
+            !ecdsa_public_key_matches_identity_key(&public_key_bytes, &public_key_hash160, &bls_key),
             "BLS12_381 key should not match with ECDSA private key"
         );
     }
@@ -1620,7 +1621,7 @@ mod tests {
         // BIP13_SCRIPT_HASH should not match
         let script_hash_key = create_test_key(KeyType::BIP13_SCRIPT_HASH, vec![0u8; 20]);
         assert!(
-            !private_key_matches_public_key(
+            !ecdsa_public_key_matches_identity_key(
                 &public_key_bytes,
                 &public_key_hash160,
                 &script_hash_key
@@ -1631,7 +1632,7 @@ mod tests {
         // EDDSA_25519_HASH160 should not match
         let eddsa_key = create_test_key(KeyType::EDDSA_25519_HASH160, vec![0u8; 20]);
         assert!(
-            !private_key_matches_public_key(&public_key_bytes, &public_key_hash160, &eddsa_key),
+            !ecdsa_public_key_matches_identity_key(&public_key_bytes, &public_key_hash160, &eddsa_key),
             "EDDSA_25519_HASH160 key should not match with ECDSA private key"
         );
     }
@@ -1663,7 +1664,7 @@ mod tests {
         // Before fix: This would return false because the code only checked ECDSA_HASH160
         // After fix: This correctly returns true
         assert!(
-            private_key_matches_public_key(&public_key_bytes, &public_key_hash160, &master_key),
+            ecdsa_public_key_matches_identity_key(&public_key_bytes, &public_key_hash160, &master_key),
             "REGRESSION: ECDSA_SECP256K1 master key must be matchable with the correct private key"
         );
     }

--- a/packages/wasm-sdk/src/state_transitions/identity/mod.rs
+++ b/packages/wasm-sdk/src/state_transitions/identity/mod.rs
@@ -1034,7 +1034,11 @@ impl WasmSdk {
             .find(|(_, key)| {
                 key.purpose() == Purpose::AUTHENTICATION
                     && key.security_level() == SecurityLevel::MASTER
-                    && ecdsa_public_key_matches_identity_key(&public_key_bytes, &public_key_hash160, key)
+                    && ecdsa_public_key_matches_identity_key(
+                        &public_key_bytes,
+                        &public_key_hash160,
+                        key,
+                    )
             })
             .map(|(id, _)| *id)
             .ok_or_else(|| {
@@ -1542,7 +1546,11 @@ mod tests {
 
         // Should match when comparing full public key bytes
         assert!(
-            ecdsa_public_key_matches_identity_key(&public_key_bytes, &public_key_hash160, &secp_key),
+            ecdsa_public_key_matches_identity_key(
+                &public_key_bytes,
+                &public_key_hash160,
+                &secp_key
+            ),
             "ECDSA_SECP256K1 key should match with correct public key bytes"
         );
 
@@ -1576,7 +1584,11 @@ mod tests {
 
         // Should match when comparing hash160
         assert!(
-            ecdsa_public_key_matches_identity_key(&public_key_bytes, &public_key_hash160, &hash160_key),
+            ecdsa_public_key_matches_identity_key(
+                &public_key_bytes,
+                &public_key_hash160,
+                &hash160_key
+            ),
             "ECDSA_HASH160 key should match with correct hash160"
         );
 
@@ -1608,7 +1620,11 @@ mod tests {
         let bls_key = create_test_key(KeyType::BLS12_381, vec![0u8; 48]);
 
         assert!(
-            !ecdsa_public_key_matches_identity_key(&public_key_bytes, &public_key_hash160, &bls_key),
+            !ecdsa_public_key_matches_identity_key(
+                &public_key_bytes,
+                &public_key_hash160,
+                &bls_key
+            ),
             "BLS12_381 key should not match with ECDSA private key"
         );
     }
@@ -1632,7 +1648,11 @@ mod tests {
         // EDDSA_25519_HASH160 should not match
         let eddsa_key = create_test_key(KeyType::EDDSA_25519_HASH160, vec![0u8; 20]);
         assert!(
-            !ecdsa_public_key_matches_identity_key(&public_key_bytes, &public_key_hash160, &eddsa_key),
+            !ecdsa_public_key_matches_identity_key(
+                &public_key_bytes,
+                &public_key_hash160,
+                &eddsa_key
+            ),
             "EDDSA_25519_HASH160 key should not match with ECDSA private key"
         );
     }
@@ -1664,7 +1684,11 @@ mod tests {
         // Before fix: This would return false because the code only checked ECDSA_HASH160
         // After fix: This correctly returns true
         assert!(
-            ecdsa_public_key_matches_identity_key(&public_key_bytes, &public_key_hash160, &master_key),
+            ecdsa_public_key_matches_identity_key(
+                &public_key_bytes,
+                &public_key_hash160,
+                &master_key
+            ),
             "REGRESSION: ECDSA_SECP256K1 master key must be matchable with the correct private key"
         );
     }

--- a/packages/wasm-sdk/src/state_transitions/identity/mod.rs
+++ b/packages/wasm-sdk/src/state_transitions/identity/mod.rs
@@ -20,6 +20,28 @@ use tracing::{debug, error};
 use wasm_bindgen::prelude::*;
 use wasm_bindgen::JsValue;
 
+/// Match a private key against a public key, supporting multiple key types.
+/// Returns true if the private key corresponds to the given public key.
+fn private_key_matches_public_key(
+    public_key_bytes: &[u8],   // 33-byte compressed secp256k1 public key
+    public_key_hash160: &[u8], // 20-byte hash160 of the public key
+    key: &IdentityPublicKey,
+) -> bool {
+    match key.key_type() {
+        KeyType::ECDSA_SECP256K1 => {
+            // Compare full 33-byte compressed public key
+            key.data().as_slice() == public_key_bytes
+        }
+        KeyType::ECDSA_HASH160 => {
+            // Compare 20-byte hash160
+            key.data().as_slice() == public_key_hash160
+        }
+        // BLS12_381 keys require separate BLS key derivation - not supported via ECDSA private key
+        // BIP13_SCRIPT_HASH and EDDSA_25519_HASH160 are also not derivable from ECDSA private key
+        _ => false,
+    }
+}
+
 #[wasm_bindgen]
 impl WasmSdk {
     /// Create a new identity on Dash Platform.
@@ -644,6 +666,7 @@ impl WasmSdk {
         };
 
         // Find matching key - prioritize key_id if provided, otherwise find any matching key
+        // Supports ECDSA_SECP256K1 and ECDSA_HASH160 key types
         let matching_key = if let Some(requested_key_id) = key_id {
             // Find specific key by ID
             sender_identity
@@ -651,8 +674,11 @@ impl WasmSdk {
                 .get(&requested_key_id)
                 .filter(|key| {
                     key.purpose() == Purpose::TRANSFER
-                        && key.key_type() == KeyType::ECDSA_HASH160
-                        && key.data().as_slice() == public_key_hash160.as_slice()
+                        && private_key_matches_public_key(
+                            &public_key_bytes,
+                            &public_key_hash160,
+                            key,
+                        )
                 })
                 .ok_or_else(|| {
                     WasmSdkError::not_found(format!(
@@ -667,8 +693,11 @@ impl WasmSdk {
                 .iter()
                 .find(|(_, key)| {
                     key.purpose() == Purpose::TRANSFER
-                        && key.key_type() == KeyType::ECDSA_HASH160
-                        && key.data().as_slice() == public_key_hash160.as_slice()
+                        && private_key_matches_public_key(
+                            &public_key_bytes,
+                            &public_key_hash160,
+                            key,
+                        )
                 })
                 .map(|(_, key)| key)
                 .ok_or_else(|| {
@@ -824,6 +853,7 @@ impl WasmSdk {
 
         // Find matching key - prioritize key_id if provided, otherwise find any matching key
         // For withdrawals, we can use either TRANSFER or OWNER keys
+        // Supports ECDSA_SECP256K1 and ECDSA_HASH160 key types
         let matching_key = if let Some(requested_key_id) = key_id {
             // Find specific key by ID
             identity
@@ -831,8 +861,11 @@ impl WasmSdk {
                 .get(&requested_key_id)
                 .filter(|key| {
                     (key.purpose() == Purpose::TRANSFER || key.purpose() == Purpose::OWNER)
-                        && key.key_type() == KeyType::ECDSA_HASH160
-                        && key.data().as_slice() == public_key_hash160.as_slice()
+                        && private_key_matches_public_key(
+                            &public_key_bytes,
+                            &public_key_hash160,
+                            key,
+                        )
                 })
                 .ok_or_else(|| {
                     WasmSdkError::not_found(format!(
@@ -847,14 +880,20 @@ impl WasmSdk {
                 .iter()
                 .find(|(_, key)| {
                     key.purpose() == Purpose::TRANSFER
-                        && key.key_type() == KeyType::ECDSA_HASH160
-                        && key.data().as_slice() == public_key_hash160.as_slice()
+                        && private_key_matches_public_key(
+                            &public_key_bytes,
+                            &public_key_hash160,
+                            key,
+                        )
                 })
                 .or_else(|| {
                     identity.public_keys().iter().find(|(_, key)| {
                         key.purpose() == Purpose::OWNER
-                            && key.key_type() == KeyType::ECDSA_HASH160
-                            && key.data().as_slice() == public_key_hash160.as_slice()
+                            && private_key_matches_public_key(
+                                &public_key_bytes,
+                                &public_key_hash160,
+                                key,
+                            )
                     })
                 })
                 .map(|(_, key)| key)
@@ -987,15 +1026,14 @@ impl WasmSdk {
                 .to_vec()
         };
 
-        // Find matching master key
+        // Find matching master key (supports ECDSA_SECP256K1 and ECDSA_HASH160)
         let master_key = identity
             .public_keys()
             .iter()
             .find(|(_, key)| {
                 key.purpose() == Purpose::AUTHENTICATION
                     && key.security_level() == SecurityLevel::MASTER
-                    && key.key_type() == KeyType::ECDSA_HASH160
-                    && key.data().as_slice() == public_key_hash160.as_slice()
+                    && private_key_matches_public_key(&public_key_bytes, &public_key_hash160, key)
             })
             .map(|(id, _)| *id)
             .ok_or_else(|| {
@@ -1458,5 +1496,175 @@ impl WasmSdk {
         .map_err(|e| WasmSdkError::generic(format!("Failed to set message: {:?}", e)))?;
 
         Ok(result_obj.into())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use dash_sdk::dpp::identity::identity_public_key::v0::IdentityPublicKeyV0;
+
+    /// Creates a test public key with the given key type and data
+    fn create_test_key(key_type: KeyType, data: Vec<u8>) -> IdentityPublicKey {
+        IdentityPublicKeyV0 {
+            id: 0u32.into(),
+            key_type,
+            purpose: Purpose::AUTHENTICATION,
+            security_level: SecurityLevel::MASTER,
+            read_only: false,
+            disabled_at: None,
+            data: data.into(),
+            contract_bounds: None,
+        }
+        .into()
+    }
+
+    #[test]
+    fn test_private_key_matches_ecdsa_secp256k1() {
+        // 33-byte compressed public key (typical ECDSA_SECP256K1 key)
+        let public_key_bytes: [u8; 33] = [
+            0x02, 0x10, 0x85, 0x8c, 0xce, 0x1f, 0x12, 0xbe, 0x35, 0xd1, 0x3c, 0x65, 0xba, 0xec,
+            0x1d, 0xcd, 0x75, 0x64, 0xd7, 0x53, 0xf0, 0x31, 0x10, 0x8e, 0xb2, 0x7b, 0x53, 0x8e,
+            0xe2, 0xd0, 0x74, 0xdb, 0x6b,
+        ];
+
+        // Hash160 of the public key (20 bytes)
+        let public_key_hash160 = {
+            use dash_sdk::dpp::dashcore::hashes::{hash160, Hash};
+            hash160::Hash::hash(&public_key_bytes[..])
+                .to_byte_array()
+                .to_vec()
+        };
+
+        // Create ECDSA_SECP256K1 key with 33-byte data
+        let secp_key = create_test_key(KeyType::ECDSA_SECP256K1, public_key_bytes.to_vec());
+
+        // Should match when comparing full public key bytes
+        assert!(
+            private_key_matches_public_key(&public_key_bytes, &public_key_hash160, &secp_key),
+            "ECDSA_SECP256K1 key should match with correct public key bytes"
+        );
+
+        // Should not match with wrong public key
+        let wrong_bytes = [0u8; 33];
+        assert!(
+            !private_key_matches_public_key(&wrong_bytes, &public_key_hash160, &secp_key),
+            "ECDSA_SECP256K1 key should not match with wrong public key bytes"
+        );
+    }
+
+    #[test]
+    fn test_private_key_matches_ecdsa_hash160() {
+        // 33-byte compressed public key
+        let public_key_bytes: [u8; 33] = [
+            0x02, 0x10, 0x85, 0x8c, 0xce, 0x1f, 0x12, 0xbe, 0x35, 0xd1, 0x3c, 0x65, 0xba, 0xec,
+            0x1d, 0xcd, 0x75, 0x64, 0xd7, 0x53, 0xf0, 0x31, 0x10, 0x8e, 0xb2, 0x7b, 0x53, 0x8e,
+            0xe2, 0xd0, 0x74, 0xdb, 0x6b,
+        ];
+
+        // Hash160 of the public key (20 bytes)
+        let public_key_hash160 = {
+            use dash_sdk::dpp::dashcore::hashes::{hash160, Hash};
+            hash160::Hash::hash(&public_key_bytes[..])
+                .to_byte_array()
+                .to_vec()
+        };
+
+        // Create ECDSA_HASH160 key with 20-byte hash data
+        let hash160_key = create_test_key(KeyType::ECDSA_HASH160, public_key_hash160.clone());
+
+        // Should match when comparing hash160
+        assert!(
+            private_key_matches_public_key(&public_key_bytes, &public_key_hash160, &hash160_key),
+            "ECDSA_HASH160 key should match with correct hash160"
+        );
+
+        // Should not match with wrong hash
+        let wrong_hash = [0u8; 20].to_vec();
+        assert!(
+            !private_key_matches_public_key(&public_key_bytes, &wrong_hash, &hash160_key),
+            "ECDSA_HASH160 key should not match with wrong hash160"
+        );
+    }
+
+    #[test]
+    fn test_private_key_does_not_match_bls_keys() {
+        // 33-byte compressed public key
+        let public_key_bytes: [u8; 33] = [
+            0x02, 0x10, 0x85, 0x8c, 0xce, 0x1f, 0x12, 0xbe, 0x35, 0xd1, 0x3c, 0x65, 0xba, 0xec,
+            0x1d, 0xcd, 0x75, 0x64, 0xd7, 0x53, 0xf0, 0x31, 0x10, 0x8e, 0xb2, 0x7b, 0x53, 0x8e,
+            0xe2, 0xd0, 0x74, 0xdb, 0x6b,
+        ];
+
+        let public_key_hash160 = {
+            use dash_sdk::dpp::dashcore::hashes::{hash160, Hash};
+            hash160::Hash::hash(&public_key_bytes[..])
+                .to_byte_array()
+                .to_vec()
+        };
+
+        // BLS keys require separate BLS key derivation, so ECDSA private keys should never match
+        let bls_key = create_test_key(KeyType::BLS12_381, vec![0u8; 48]);
+
+        assert!(
+            !private_key_matches_public_key(&public_key_bytes, &public_key_hash160, &bls_key),
+            "BLS12_381 key should not match with ECDSA private key"
+        );
+    }
+
+    #[test]
+    fn test_private_key_does_not_match_other_key_types() {
+        let public_key_bytes: [u8; 33] = [0x02; 33];
+        let public_key_hash160 = vec![0u8; 20];
+
+        // BIP13_SCRIPT_HASH should not match
+        let script_hash_key = create_test_key(KeyType::BIP13_SCRIPT_HASH, vec![0u8; 20]);
+        assert!(
+            !private_key_matches_public_key(
+                &public_key_bytes,
+                &public_key_hash160,
+                &script_hash_key
+            ),
+            "BIP13_SCRIPT_HASH key should not match with ECDSA private key"
+        );
+
+        // EDDSA_25519_HASH160 should not match
+        let eddsa_key = create_test_key(KeyType::EDDSA_25519_HASH160, vec![0u8; 20]);
+        assert!(
+            !private_key_matches_public_key(&public_key_bytes, &public_key_hash160, &eddsa_key),
+            "EDDSA_25519_HASH160 key should not match with ECDSA private key"
+        );
+    }
+
+    #[test]
+    fn test_regression_secp256k1_key_not_mistaken_for_hash160() {
+        // This is the regression test for the original bug:
+        // identity_update was only checking for ECDSA_HASH160 keys,
+        // so ECDSA_SECP256K1 keys would never match even with the correct private key.
+
+        // Real public key bytes (33-byte compressed secp256k1)
+        let public_key_bytes: [u8; 33] = [
+            0x02, 0x10, 0x85, 0x8c, 0xce, 0x1f, 0x12, 0xbe, 0x35, 0xd1, 0x3c, 0x65, 0xba, 0xec,
+            0x1d, 0xcd, 0x75, 0x64, 0xd7, 0x53, 0xf0, 0x31, 0x10, 0x8e, 0xb2, 0x7b, 0x53, 0x8e,
+            0xe2, 0xd0, 0x74, 0xdb, 0x6b,
+        ];
+
+        let public_key_hash160 = {
+            use dash_sdk::dpp::dashcore::hashes::{hash160, Hash};
+            hash160::Hash::hash(&public_key_bytes[..])
+                .to_byte_array()
+                .to_vec()
+        };
+
+        // The bug: Code was only checking ECDSA_HASH160 keys
+        // But most identities (DashPay) use ECDSA_SECP256K1 with the full 33-byte key
+        let master_key = create_test_key(KeyType::ECDSA_SECP256K1, public_key_bytes.to_vec());
+
+        // Before fix: This would return false because the code only checked ECDSA_HASH160
+        // After fix: This correctly returns true
+        assert!(
+            private_key_matches_public_key(&public_key_bytes, &public_key_hash160, &master_key),
+            "REGRESSION: ECDSA_SECP256K1 master key must be matchable with the correct private key"
+        );
     }
 }


### PR DESCRIPTION
The identity_update, identity_credit_transfer, and identity_credit_withdrawal functions only supported ECDSA_HASH160 keys, but most identities (including all DashPay-created identities) use ECDSA_SECP256K1 keys. This caused these operations to fail with "Provided private key does not match any master key".

Changes:
- Add private_key_matches_public_key helper that handles both key types:
  - ECDSA_SECP256K1: compares full 33-byte compressed public key
  - ECDSA_HASH160: compares 20-byte hash160
- Update identity_update master key lookup to use the helper
- Update identity_credit_transfer key lookups to use the helper
- Update identity_credit_withdrawal key lookups to use the helper

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## How Has This Been Tested?
- Add 5 regression tests to verify the fix and prevent future regressions


## Breaking Changes
None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [ ] I have made corresponding changes to the documentation if needed

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded coverage for identity key validation, adding scenarios for ECDSA-derived key matching and ensuring non-ECDSA types do not match; includes regression checks.

* **Refactor**
  * Unified identity key matching logic across creation, transfer, withdrawal, and update flows to improve consistency and reliability without changing public APIs.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->