### PR TITLE
feat(dashmate): bypass validation for total reset

### DIFF
--- a/packages/dashmate/src/config/Config.js
+++ b/packages/dashmate/src/config/Config.js
@@ -17,12 +17,13 @@ export default class Config {
   /**
    * @param {string} name
    * @param {Object} options
+   * @param {boolean} [skipValidation=false] - Skip schema validation (use with --force)
    */
-  constructor(name, options = {}) {
+  constructor(name, options = {}, skipValidation = false) {
     this.name = name;
     this.changed = false;
 
-    this.setOptions(options);
+    this.setOptions(options, skipValidation);
   }
 
   /**
@@ -122,22 +123,25 @@ export default class Config {
    * Set options
    *
    * @param {Object} options
+   * @param {boolean} [skipValidation=false] - Skip schema validation (use with --force)
    *
    * @return {Config}
    */
-  setOptions(options) {
+  setOptions(options, skipValidation = false) {
     const clonedOptions = lodashCloneDeep(options);
 
-    const isValid = Config.ajv.validate(configJsonSchema, clonedOptions);
+    if (!skipValidation) {
+      const isValid = Config.ajv.validate(configJsonSchema, clonedOptions);
 
-    if (!isValid) {
-      const message = Config.ajv.errorsText(undefined, { dataVar: 'config' });
+      if (!isValid) {
+        const message = Config.ajv.errorsText(undefined, { dataVar: 'config' });
 
-      throw new InvalidOptionsError(
-        clonedOptions,
-        Config.ajv.errors,
-        message,
-      );
+        throw new InvalidOptionsError(
+          clonedOptions,
+          Config.ajv.errors,
+          message,
+        );
+      }
     }
 
     this.options = clonedOptions;

--- a/packages/dashmate/src/config/configFile/ConfigFileJsonRepository.js
+++ b/packages/dashmate/src/config/configFile/ConfigFileJsonRepository.js
@@ -22,9 +22,12 @@ export default class ConfigFileJsonRepository {
   /**
    * Load configs from file
    *
+   * @param {Object} [options={}]
+   * @param {boolean} [options.skipValidation=false] - Skip per-config schema validation
    * @returns {ConfigFile}
    */
-  read() {
+  read(options = {}) {
+    const { skipValidation = false } = options;
     if (!fs.existsSync(this.configFilePath)) {
       throw new ConfigFileNotFoundError(this.configFilePath);
     }
@@ -59,7 +62,7 @@ export default class ConfigFileJsonRepository {
     let configs;
     try {
       configs = Object.entries(migratedConfigFileData.configs)
-        .map(([name, options]) => new Config(name, options));
+        .map(([name, opts]) => new Config(name, opts, skipValidation));
     } catch (e) {
       throw new InvalidConfigFileFormatError(this.configFilePath, e);
     }

--- a/packages/dashmate/src/oclif/command/BaseCommand.js
+++ b/packages/dashmate/src/oclif/command/BaseCommand.js
@@ -41,7 +41,10 @@ export default class BaseCommand extends Command {
     let configFile;
     try {
       // Load config collection from config file
-      configFile = configFileRepository.read();
+      // Skip per-config validation when --force flag is passed (e.g., for reset command)
+      configFile = configFileRepository.read({
+        skipValidation: Boolean(this.parsedFlags.force),
+      });
     } catch (e) {
       // Create default config collection if config file is not present
       // on the first start for example


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
When we attempt to reset in order to redeploy, dashmate will check the config despite us sending --force


## What was done?
Bypass config checks when sending a reset --hard --force


## How Has This Been Tested?
Tested on devnet-tadi


## Breaking Changes
None


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [ ] I have made corresponding changes to the documentation if needed

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a `--force` flag to skip configuration validation when necessary, providing flexibility for advanced users to bypass validation checks in specific scenarios.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->