### PR TITLE
feat(platform)!: clean up expired compacted address balances

### DIFF
--- a/packages/rs-dpp/Cargo.toml
+++ b/packages/rs-dpp/Cargo.toml
@@ -65,8 +65,8 @@ platform-serialization = { path = "../rs-platform-serialization" }
 platform-serialization-derive = { path = "../rs-platform-serialization-derive" }
 derive_more = { version = "1.0", features = ["from", "display", "try_into"] }
 nohash-hasher = "0.2.0"
-rust_decimal = { version = "1.29.1", optional = true }
-rust_decimal_macros = { version = "1.29.1", optional = true }
+rust_decimal = { version = "1.39.0", optional = true }
+rust_decimal_macros = { version = "1.39.0", optional = true }
 indexmap = { version = "2.7.0", features = ["serde"] }
 strum = { version = "0.26", features = ["derive"] }
 json-schema-compatibility-validator = { path = '../rs-json-schema-compatibility-validator', optional = true }

--- a/packages/rs-drive-abci/Cargo.toml
+++ b/packages/rs-drive-abci/Cargo.toml
@@ -30,8 +30,8 @@ hex = "0.4.3"
 indexmap = { version = "2.2.6", features = ["serde"] }
 dpp = { path = "../rs-dpp", default-features = false, features = ["abci"] }
 simple-signer = { path = "../simple-signer", features = ["state-transitions"] }
-rust_decimal = "1.2.5"
-rust_decimal_macros = "1.25.0"
+rust_decimal = "1.39.0"
+rust_decimal_macros = "1.39.0"
 mockall = { version = "0.13", optional = true }
 prost = { version = "0.14", default-features = false }
 tracing = { version = "0.1.41", default-features = false, features = [] }

--- a/packages/rs-drive-abci/src/execution/engine/run_block_proposal/v0/mod.rs
+++ b/packages/rs-drive-abci/src/execution/engine/run_block_proposal/v0/mod.rs
@@ -337,6 +337,13 @@ where
             platform_version,
         )?;
 
+        // Clean up expired compacted address balance entries
+        self.cleanup_recent_block_storage_address_balances(
+            &block_info,
+            transaction,
+            platform_version,
+        )?;
+
         // Pool withdrawals into transactions queue
 
         // Takes queued withdrawals, creates untiled withdrawal transaction payload, saves them to queue

--- a/packages/rs-drive-abci/src/execution/platform_events/protocol_upgrade/perform_events_on_first_block_of_protocol_change/v0/mod.rs
+++ b/packages/rs-drive-abci/src/execution/platform_events/protocol_upgrade/perform_events_on_first_block_of_protocol_change/v0/mod.rs
@@ -23,7 +23,10 @@ use drive::drive::identity::withdrawals::paths::{
     WITHDRAWAL_TRANSACTIONS_SUM_AMOUNT_TREE_KEY,
 };
 use drive::drive::prefunded_specialized_balances::prefunded_specialized_balances_for_voting_path_vec;
-use drive::drive::saved_block_transactions::ADDRESS_BALANCES_KEY_U8;
+use drive::drive::saved_block_transactions::{
+    ADDRESS_BALANCES_KEY_U8, COMPACTED_ADDRESSES_EXPIRATION_TIME_KEY_U8,
+    COMPACTED_ADDRESS_BALANCES_KEY_U8,
+};
 use drive::drive::system::misc_path;
 use drive::drive::tokens::paths::{
     token_distributions_root_path, token_timed_distributions_path, tokens_root_path,
@@ -569,6 +572,24 @@ impl<C> Platform<C> {
         self.drive.grove_insert_if_not_exists(
             saved_block_path.as_slice().into(),
             &[ADDRESS_BALANCES_KEY_U8],
+            Element::empty_count_sum_tree(),
+            Some(transaction),
+            None,
+            &platform_version.drive,
+        )?;
+
+        self.drive.grove_insert_if_not_exists(
+            saved_block_path.as_slice().into(),
+            &[COMPACTED_ADDRESS_BALANCES_KEY_U8],
+            Element::empty_tree(),
+            Some(transaction),
+            None,
+            &platform_version.drive,
+        )?;
+
+        self.drive.grove_insert_if_not_exists(
+            saved_block_path.as_slice().into(),
+            &[COMPACTED_ADDRESSES_EXPIRATION_TIME_KEY_U8],
             Element::empty_tree(),
             Some(transaction),
             None,

--- a/packages/rs-drive-abci/src/execution/platform_events/state_transition_processing/cleanup_recent_block_storage_address_balances/mod.rs
+++ b/packages/rs-drive-abci/src/execution/platform_events/state_transition_processing/cleanup_recent_block_storage_address_balances/mod.rs
@@ -1,0 +1,55 @@
+mod v0;
+
+use crate::error::execution::ExecutionError;
+use crate::error::Error;
+use crate::platform_types::platform::Platform;
+use crate::rpc::core::CoreRPCLike;
+use dpp::block::block_info::BlockInfo;
+use dpp::version::PlatformVersion;
+use drive::grovedb::Transaction;
+
+impl<C> Platform<C>
+where
+    C: CoreRPCLike,
+{
+    /// Cleans up expired compacted address balance entries from recent block storage.
+    ///
+    /// This function removes compacted address balance entries whose expiration
+    /// time has passed (older than 1 day from when they were compacted).
+    ///
+    /// # Arguments
+    ///
+    /// * `block_info` - Information about the current block (provides current time)
+    /// * `transaction` - The database transaction
+    /// * `platform_version` - The platform version
+    ///
+    /// # Returns
+    ///
+    /// * `Result<(), Error>` - Success or an error if the operation fails
+    ///
+    pub(in crate::execution) fn cleanup_recent_block_storage_address_balances(
+        &self,
+        block_info: &BlockInfo,
+        transaction: &Transaction,
+        platform_version: &PlatformVersion,
+    ) -> Result<(), Error> {
+        match platform_version
+            .drive_abci
+            .methods
+            .state_transition_processing
+            .cleanup_recent_block_storage_address_balances
+        {
+            None => Ok(()),
+            Some(0) => self.cleanup_recent_block_storage_address_balances_v0(
+                block_info,
+                transaction,
+                platform_version,
+            ),
+            Some(version) => Err(Error::Execution(ExecutionError::UnknownVersionMismatch {
+                method: "cleanup_recent_block_storage_address_balances".to_string(),
+                known_versions: vec![0],
+                received: version,
+            })),
+        }
+    }
+}

--- a/packages/rs-drive-abci/src/execution/platform_events/state_transition_processing/cleanup_recent_block_storage_address_balances/v0/mod.rs
+++ b/packages/rs-drive-abci/src/execution/platform_events/state_transition_processing/cleanup_recent_block_storage_address_balances/v0/mod.rs
@@ -1,0 +1,29 @@
+use crate::error::Error;
+use crate::platform_types::platform::Platform;
+use crate::rpc::core::CoreRPCLike;
+use dpp::block::block_info::BlockInfo;
+use dpp::version::PlatformVersion;
+use drive::grovedb::Transaction;
+
+impl<C> Platform<C>
+where
+    C: CoreRPCLike,
+{
+    /// Version 0 implementation of cleaning up expired compacted address balance entries.
+    ///
+    /// Calls the drive layer to remove compacted entries that have expired.
+    pub(super) fn cleanup_recent_block_storage_address_balances_v0(
+        &self,
+        block_info: &BlockInfo,
+        transaction: &Transaction,
+        platform_version: &PlatformVersion,
+    ) -> Result<(), Error> {
+        self.drive.cleanup_expired_address_balances(
+            block_info.time_ms,
+            Some(transaction),
+            platform_version,
+        )?;
+
+        Ok(())
+    }
+}

--- a/packages/rs-drive-abci/src/execution/platform_events/state_transition_processing/mod.rs
+++ b/packages/rs-drive-abci/src/execution/platform_events/state_transition_processing/mod.rs
@@ -1,3 +1,4 @@
+mod cleanup_recent_block_storage_address_balances;
 mod decode_raw_state_transitions;
 mod execute_event;
 mod process_raw_state_transitions;

--- a/packages/rs-drive-abci/src/execution/platform_events/state_transition_processing/store_address_balances_to_recent_block_storage/v0/mod.rs
+++ b/packages/rs-drive-abci/src/execution/platform_events/state_transition_processing/store_address_balances_to_recent_block_storage/v0/mod.rs
@@ -38,6 +38,7 @@ where
         self.drive.store_address_balances_for_block(
             address_balances,
             block_info.height,
+            block_info.time_ms,
             Some(transaction),
             platform_version,
         )?;

--- a/packages/rs-drive-abci/tests/strategy_tests/test_cases/address_tests.rs
+++ b/packages/rs-drive-abci/tests/strategy_tests/test_cases/address_tests.rs
@@ -13,9 +13,16 @@ mod tests {
     use dapi_grpc::platform::v0::get_recent_address_balance_changes_response::{
         get_recent_address_balance_changes_response_v0, Version as RecentChangesResponseVersion,
     };
+    use dapi_grpc::platform::v0::get_recent_compacted_address_balance_changes_request::{
+        GetRecentCompactedAddressBalanceChangesRequestV0, Version as CompactedChangesRequestVersion,
+    };
+    use dapi_grpc::platform::v0::get_recent_compacted_address_balance_changes_response::{
+        get_recent_compacted_address_balance_changes_response_v0,
+        Version as CompactedChangesResponseVersion,
+    };
     use dapi_grpc::platform::v0::{
         address_balance_change, GetAddressesTrunkStateRequest,
-        GetRecentAddressBalanceChangesRequest,
+        GetRecentAddressBalanceChangesRequest, GetRecentCompactedAddressBalanceChangesRequest,
     };
     use dpp::address_funds::PlatformAddress;
     use dpp::dash_to_credits;
@@ -2176,5 +2183,886 @@ mod tests {
             proof.quorum_type, quorum_type,
             "quorum type in proof should match config"
         );
+    }
+
+    /// Test for querying compacted address balance changes.
+    /// This test runs enough blocks with checkpoints enabled to trigger compaction,
+    /// then verifies the compacted data can be queried correctly.
+    #[test]
+    fn run_chain_query_compacted_address_balance_changes() {
+        drive_abci::logging::init_for_tests(LogLevel::Debug);
+
+        let strategy = NetworkStrategy {
+            strategy: Strategy {
+                start_contracts: vec![],
+                operations: vec![
+                    Operation {
+                        op_type: OperationType::AddressTransfer(
+                            dash_to_credits!(5)..=dash_to_credits!(5),
+                            1..=4,
+                            Some(0.2),
+                            None,
+                        ),
+                        frequency: Frequency {
+                            times_per_block_range: 1..3,
+                            chance_per_block: None,
+                        },
+                    },
+                    Operation {
+                        op_type: OperationType::AddressFundingFromCoreAssetLock(
+                            dash_to_credits!(20)..=dash_to_credits!(20),
+                        ),
+                        frequency: Frequency {
+                            times_per_block_range: 1..3,
+                            chance_per_block: None,
+                        },
+                    },
+                ],
+                start_identities: StartIdentities::default(),
+                start_addresses: StartAddresses::default(),
+                identity_inserts: IdentityInsertInfo {
+                    frequency: Frequency {
+                        times_per_block_range: 1..2,
+                        chance_per_block: None,
+                    },
+                    ..Default::default()
+                },
+                identity_contract_nonce_gaps: None,
+                signer: None,
+            },
+            total_hpmns: 100,
+            extra_normal_mns: 0,
+            validator_quorum_count: 24,
+            chain_lock_quorum_count: 24,
+            upgrading_info: None,
+
+            proposer_strategy: Default::default(),
+            rotate_quorums: false,
+            failure_testing: None,
+            query_testing: None,
+            verify_state_transition_results: true,
+            sign_instant_locks: true,
+            ..Default::default()
+        };
+
+        // Use 3 minute block spacing to trigger checkpoints and compaction
+        let config = PlatformConfig {
+            validator_set: ValidatorSetConfig::default_100_67(),
+            chain_lock: ChainLockConfig::default_100_67(),
+            instant_lock: InstantLockConfig::default_100_67(),
+            execution: ExecutionConfig {
+                verify_sum_trees: true,
+                ..Default::default()
+            },
+            block_spacing_ms: 180000, // 3 mins - triggers checkpoint every ~12 blocks
+            testing_configs: PlatformTestConfig {
+                disable_checkpoints: false,
+                ..PlatformTestConfig::default_minimal_verifications()
+            },
+            ..Default::default()
+        };
+
+        let mut platform = TestPlatformBuilder::new()
+            .with_config(config.clone())
+            .build_with_mock_rpc();
+
+        // Run enough blocks to trigger multiple checkpoints and compaction
+        // With 3 min block spacing, checkpoint happens around every 12 blocks
+        // We run 25 blocks to ensure at least one compaction cycle
+        let outcome = run_chain_for_strategy(
+            &mut platform,
+            25,
+            strategy,
+            config,
+            15,
+            &mut None,
+            &mut None,
+        );
+
+        // Verify we had some address activity
+        let executed = outcome
+            .state_transition_results_per_block
+            .values()
+            .flat_map(|results| results.iter())
+            .filter(|(state_transition, result)| {
+                result.code == 0
+                    && matches!(state_transition, StateTransition::AddressFundsTransfer(_))
+            })
+            .count();
+        assert!(executed > 0, "expected at least one address transfer");
+
+        // Drop outcome to release the mutable borrow of platform
+        drop(outcome);
+
+        let platform_version = PlatformVersion::latest();
+
+        // Get current platform state for the query
+        let platform_state = platform.platform.state.load();
+
+        // Query compacted address balance changes from block 0
+        let request = GetRecentCompactedAddressBalanceChangesRequest {
+            version: Some(CompactedChangesRequestVersion::V0(
+                GetRecentCompactedAddressBalanceChangesRequestV0 {
+                    start_block_height: 0,
+                    prove: false,
+                },
+            )),
+        };
+
+        let query_validation_result = platform
+            .platform
+            .query_recent_compacted_address_balance_changes(
+                request,
+                &platform_state,
+                platform_version,
+            )
+            .expect("expected to run query");
+
+        assert!(
+            query_validation_result.errors.is_empty(),
+            "query errors: {:?}",
+            query_validation_result.errors
+        );
+
+        let response = query_validation_result
+            .into_data()
+            .expect("expected data on query_validation_result");
+
+        let versioned_result = response.version.expect("expected a version");
+        match versioned_result {
+            CompactedChangesResponseVersion::V0(v0) => {
+                let result = v0.result.expect("expected a result");
+                match result {
+                    get_recent_compacted_address_balance_changes_response_v0::Result::CompactedAddressBalanceUpdateEntries(entries) => {
+                        // Verify we got compacted entries
+                        // Note: compaction may or may not have been triggered depending on thresholds
+                        // The key test is that the query works correctly
+
+                        // Log what we found
+                        eprintln!(
+                            "Found {} compacted block change entries",
+                            entries.compacted_block_changes.len()
+                        );
+
+                        for entry in &entries.compacted_block_changes {
+                            eprintln!(
+                                "  Compacted entry: start_block={}, end_block={}, changes={}",
+                                entry.start_block_height,
+                                entry.end_block_height,
+                                entry.changes.len()
+                            );
+
+                            // Verify the entry structure
+                            assert!(
+                                entry.end_block_height >= entry.start_block_height,
+                                "end_block_height should be >= start_block_height"
+                            );
+
+                            // Verify each change has valid data
+                            for change in &entry.changes {
+                                assert!(
+                                    !change.address.is_empty(),
+                                    "address should not be empty"
+                                );
+                                assert!(
+                                    change.operation.is_some(),
+                                    "operation should be present"
+                                );
+
+                                // Verify address can be parsed
+                                let _address = PlatformAddress::from_bytes(&change.address)
+                                    .expect("expected valid address bytes");
+
+                                // Verify operation type
+                                match &change.operation {
+                                    Some(address_balance_change::Operation::SetBalance(balance)) => {
+                                        eprintln!(
+                                            "    Address {:?}: SetBalance({})",
+                                            hex::encode(&change.address),
+                                            balance
+                                        );
+                                    }
+                                    Some(address_balance_change::Operation::AddToBalance(amount)) => {
+                                        eprintln!(
+                                            "    Address {:?}: AddToBalance({})",
+                                            hex::encode(&change.address),
+                                            amount
+                                        );
+                                    }
+                                    None => {
+                                        panic!("expected an operation on address balance change");
+                                    }
+                                }
+                            }
+                        }
+
+                        // If we have compacted entries, verify they span multiple blocks
+                        // (that's the point of compaction)
+                        if !entries.compacted_block_changes.is_empty() {
+                            for entry in &entries.compacted_block_changes {
+                                assert!(
+                                    entry.end_block_height > entry.start_block_height
+                                        || entry.changes.len() > 0,
+                                    "compacted entry should span multiple blocks or have changes"
+                                );
+                            }
+                        }
+                    }
+                    get_recent_compacted_address_balance_changes_response_v0::Result::Proof(_) => {
+                        panic!("expected entries, not proof");
+                    }
+                }
+            }
+        }
+
+        // Also query recent (non-compacted) changes to verify both queries work
+        let recent_request = GetRecentAddressBalanceChangesRequest {
+            version: Some(RecentChangesRequestVersion::V0(
+                GetRecentAddressBalanceChangesRequestV0 {
+                    start_height: 1,
+                    prove: false,
+                },
+            )),
+        };
+
+        let recent_query_result = platform
+            .platform
+            .query_recent_address_balance_changes(recent_request, &platform_state, platform_version)
+            .expect("expected to run recent changes query");
+
+        assert!(
+            recent_query_result.errors.is_empty(),
+            "recent query errors: {:?}",
+            recent_query_result.errors
+        );
+
+        let recent_response = recent_query_result
+            .into_data()
+            .expect("expected data on recent query");
+
+        match recent_response.version.expect("expected a version") {
+            RecentChangesResponseVersion::V0(v0) => {
+                let result = v0.result.expect("expected a result");
+                match result {
+                    get_recent_address_balance_changes_response_v0::Result::AddressBalanceUpdateEntries(entries) => {
+                        eprintln!(
+                            "Found {} recent block change entries (non-compacted)",
+                            entries.block_changes.len()
+                        );
+                    }
+                    get_recent_address_balance_changes_response_v0::Result::Proof(_) => {
+                        panic!("expected entries, not proof");
+                    }
+                }
+            }
+        }
+    }
+
+    /// Test that verifies there is no overlap between compacted and non-compacted
+    /// address balance changes. Compacted entries should cover older blocks that have
+    /// been merged, while non-compacted entries should cover newer blocks.
+    #[test]
+    fn run_chain_verify_no_overlap_between_compacted_and_recent_changes() {
+        drive_abci::logging::init_for_tests(LogLevel::Debug);
+
+        let strategy = NetworkStrategy {
+            strategy: Strategy {
+                start_contracts: vec![],
+                operations: vec![
+                    Operation {
+                        op_type: OperationType::AddressTransfer(
+                            dash_to_credits!(5)..=dash_to_credits!(5),
+                            1..=4,
+                            Some(0.2),
+                            None,
+                        ),
+                        frequency: Frequency {
+                            times_per_block_range: 2..4,
+                            chance_per_block: None,
+                        },
+                    },
+                    Operation {
+                        op_type: OperationType::AddressFundingFromCoreAssetLock(
+                            dash_to_credits!(20)..=dash_to_credits!(20),
+                        ),
+                        frequency: Frequency {
+                            times_per_block_range: 2..4,
+                            chance_per_block: None,
+                        },
+                    },
+                ],
+                start_identities: StartIdentities::default(),
+                start_addresses: StartAddresses::default(),
+                identity_inserts: IdentityInsertInfo {
+                    frequency: Frequency {
+                        times_per_block_range: 1..2,
+                        chance_per_block: None,
+                    },
+                    ..Default::default()
+                },
+                identity_contract_nonce_gaps: None,
+                signer: None,
+            },
+            total_hpmns: 100,
+            extra_normal_mns: 0,
+            validator_quorum_count: 24,
+            chain_lock_quorum_count: 24,
+            upgrading_info: None,
+
+            proposer_strategy: Default::default(),
+            rotate_quorums: false,
+            failure_testing: None,
+            query_testing: None,
+            verify_state_transition_results: true,
+            sign_instant_locks: true,
+            ..Default::default()
+        };
+
+        // Use 3 minute block spacing to trigger checkpoints and compaction
+        let config = PlatformConfig {
+            validator_set: ValidatorSetConfig::default_100_67(),
+            chain_lock: ChainLockConfig::default_100_67(),
+            instant_lock: InstantLockConfig::default_100_67(),
+            execution: ExecutionConfig {
+                verify_sum_trees: true,
+                ..Default::default()
+            },
+            block_spacing_ms: 180000, // 3 mins - triggers checkpoint every ~12 blocks
+            testing_configs: PlatformTestConfig {
+                disable_checkpoints: false,
+                ..PlatformTestConfig::default_minimal_verifications()
+            },
+            ..Default::default()
+        };
+
+        let mut platform = TestPlatformBuilder::new()
+            .with_config(config.clone())
+            .build_with_mock_rpc();
+
+        // Run enough blocks to trigger compaction and have some recent blocks after
+        // We need: some blocks -> compaction -> more blocks (not yet compacted)
+        let outcome = run_chain_for_strategy(
+            &mut platform,
+            30,
+            strategy,
+            config,
+            15,
+            &mut None,
+            &mut None,
+        );
+
+        // Verify we had address activity
+        let executed = outcome
+            .state_transition_results_per_block
+            .values()
+            .flat_map(|results| results.iter())
+            .filter(|(state_transition, result)| {
+                result.code == 0
+                    && (matches!(state_transition, StateTransition::AddressFundsTransfer(_))
+                        || matches!(
+                            state_transition,
+                            StateTransition::AddressFundingFromAssetLock(_)
+                        ))
+            })
+            .count();
+        assert!(
+            executed > 0,
+            "expected at least one address-related transition"
+        );
+
+        drop(outcome);
+
+        let platform_version = PlatformVersion::latest();
+        let platform_state = platform.platform.state.load();
+
+        // Query compacted address balance changes
+        let compacted_request = GetRecentCompactedAddressBalanceChangesRequest {
+            version: Some(CompactedChangesRequestVersion::V0(
+                GetRecentCompactedAddressBalanceChangesRequestV0 {
+                    start_block_height: 0,
+                    prove: false,
+                },
+            )),
+        };
+
+        let compacted_result = platform
+            .platform
+            .query_recent_compacted_address_balance_changes(
+                compacted_request,
+                &platform_state,
+                platform_version,
+            )
+            .expect("expected to run compacted query");
+
+        assert!(
+            compacted_result.errors.is_empty(),
+            "compacted query errors: {:?}",
+            compacted_result.errors
+        );
+
+        // Query recent (non-compacted) address balance changes
+        let recent_request = GetRecentAddressBalanceChangesRequest {
+            version: Some(RecentChangesRequestVersion::V0(
+                GetRecentAddressBalanceChangesRequestV0 {
+                    start_height: 1,
+                    prove: false,
+                },
+            )),
+        };
+
+        let recent_result = platform
+            .platform
+            .query_recent_address_balance_changes(recent_request, &platform_state, platform_version)
+            .expect("expected to run recent query");
+
+        assert!(
+            recent_result.errors.is_empty(),
+            "recent query errors: {:?}",
+            recent_result.errors
+        );
+
+        // Extract block heights from compacted entries
+        let compacted_response = compacted_result
+            .into_data()
+            .expect("expected compacted data");
+        let mut compacted_block_ranges: Vec<(u64, u64)> = Vec::new();
+
+        match compacted_response.version.expect("expected version") {
+            CompactedChangesResponseVersion::V0(v0) => {
+                let result = v0.result.expect("expected result");
+                match result {
+                    get_recent_compacted_address_balance_changes_response_v0::Result::CompactedAddressBalanceUpdateEntries(entries) => {
+                        for entry in entries.compacted_block_changes {
+                            compacted_block_ranges
+                                .push((entry.start_block_height, entry.end_block_height));
+                        }
+                    }
+                    get_recent_compacted_address_balance_changes_response_v0::Result::Proof(_) => {
+                        panic!("expected entries, not proof");
+                    }
+                }
+            }
+        }
+
+        // Extract block heights from recent entries
+        let recent_response = recent_result.into_data().expect("expected recent data");
+        let mut recent_block_heights: Vec<u64> = Vec::new();
+
+        match recent_response.version.expect("expected version") {
+            RecentChangesResponseVersion::V0(v0) => {
+                let result = v0.result.expect("expected result");
+                match result {
+                    get_recent_address_balance_changes_response_v0::Result::AddressBalanceUpdateEntries(entries) => {
+                        for entry in entries.block_changes {
+                            recent_block_heights.push(entry.block_height);
+                        }
+                    }
+                    get_recent_address_balance_changes_response_v0::Result::Proof(_) => {
+                        panic!("expected entries, not proof");
+                    }
+                }
+            }
+        }
+
+        // Log what we found
+        eprintln!("Compacted block ranges: {:?}", compacted_block_ranges);
+        eprintln!("Recent block heights: {:?}", recent_block_heights);
+
+        // Verify no overlap between compacted ranges and recent blocks
+        for (compacted_start, compacted_end) in &compacted_block_ranges {
+            for recent_height in &recent_block_heights {
+                assert!(
+                    *recent_height < *compacted_start || *recent_height > *compacted_end,
+                    "Overlap detected! Recent block {} falls within compacted range [{}, {}]",
+                    recent_height,
+                    compacted_start,
+                    compacted_end
+                );
+            }
+        }
+
+        // If we have both compacted and recent data, verify the ordering:
+        // All compacted ranges should be before all recent blocks
+        if !compacted_block_ranges.is_empty() && !recent_block_heights.is_empty() {
+            let max_compacted_end = compacted_block_ranges
+                .iter()
+                .map(|(_, end)| *end)
+                .max()
+                .unwrap();
+            let min_recent_height = recent_block_heights.iter().min().unwrap();
+
+            eprintln!(
+                "Max compacted end block: {}, Min recent block: {}",
+                max_compacted_end, min_recent_height
+            );
+
+            assert!(
+                *min_recent_height > max_compacted_end,
+                "Recent blocks should come after compacted blocks. \
+                Max compacted end: {}, Min recent: {}",
+                max_compacted_end,
+                min_recent_height
+            );
+        }
+
+        // Verify compacted ranges don't overlap with each other
+        for i in 0..compacted_block_ranges.len() {
+            for j in (i + 1)..compacted_block_ranges.len() {
+                let (start_i, end_i) = compacted_block_ranges[i];
+                let (start_j, end_j) = compacted_block_ranges[j];
+
+                // Two ranges overlap if: start_i <= end_j AND start_j <= end_i
+                let overlaps = start_i <= end_j && start_j <= end_i;
+                assert!(
+                    !overlaps,
+                    "Compacted ranges overlap! Range [{}, {}] overlaps with [{}, {}]",
+                    start_i, end_i, start_j, end_j
+                );
+            }
+        }
+
+        // Verify compacted ranges are in ascending order (sorted by start block)
+        for i in 1..compacted_block_ranges.len() {
+            let (prev_start, prev_end) = compacted_block_ranges[i - 1];
+            let (curr_start, _) = compacted_block_ranges[i];
+
+            assert!(
+                curr_start > prev_end,
+                "Compacted ranges should be in ascending order with no gaps. \
+                Previous end: {}, Current start: {}",
+                prev_end,
+                curr_start
+            );
+        }
+
+        // Verify recent blocks are in ascending order
+        for i in 1..recent_block_heights.len() {
+            assert!(
+                recent_block_heights[i] > recent_block_heights[i - 1],
+                "Recent block heights should be in ascending order. \
+                Found {} after {}",
+                recent_block_heights[i],
+                recent_block_heights[i - 1]
+            );
+        }
+
+        // Summary
+        eprintln!(
+            "\nSummary: {} compacted ranges, {} recent blocks, no overlap detected",
+            compacted_block_ranges.len(),
+            recent_block_heights.len()
+        );
+    }
+
+    /// Test that verifies the cleanup of expired compacted address balance entries works.
+    ///
+    /// This test:
+    /// 1. Runs blocks to trigger compaction (64+ blocks threshold)
+    /// 2. Verifies compacted entries exist after the run
+    /// 3. Verifies entries with expired timestamps are cleaned up
+    ///
+    /// Note: Since cleanup runs every block, entries are cleaned up as time passes.
+    /// With 6-hour block spacing and 24-hour expiration:
+    /// - First compaction at block 64 (hour 384)
+    /// - Those entries expire at hour 408 (block 68)
+    /// - By block 70, entries from block 64 should be cleaned up
+    #[test]
+    fn run_chain_cleanup_expired_compacted_address_balances() {
+        // drive_abci::logging::init_for_tests(LogLevel::Debug);
+
+        let strategy = NetworkStrategy {
+            strategy: Strategy {
+                start_contracts: vec![],
+                operations: vec![
+                    Operation {
+                        op_type: OperationType::AddressTransfer(
+                            dash_to_credits!(5)..=dash_to_credits!(5),
+                            1..=4,
+                            Some(0.2),
+                            None,
+                        ),
+                        frequency: Frequency {
+                            times_per_block_range: 2..4,
+                            chance_per_block: None,
+                        },
+                    },
+                    Operation {
+                        op_type: OperationType::AddressFundingFromCoreAssetLock(
+                            dash_to_credits!(20)..=dash_to_credits!(20),
+                        ),
+                        frequency: Frequency {
+                            times_per_block_range: 2..4,
+                            chance_per_block: None,
+                        },
+                    },
+                ],
+                start_identities: StartIdentities::default(),
+                start_addresses: StartAddresses::default(),
+                identity_inserts: IdentityInsertInfo {
+                    frequency: Frequency {
+                        times_per_block_range: 1..2,
+                        chance_per_block: None,
+                    },
+                    ..Default::default()
+                },
+                identity_contract_nonce_gaps: None,
+                signer: None,
+            },
+            total_hpmns: 100,
+            extra_normal_mns: 0,
+            validator_quorum_count: 24,
+            chain_lock_quorum_count: 24,
+            upgrading_info: None,
+
+            proposer_strategy: Default::default(),
+            rotate_quorums: false,
+            failure_testing: None,
+            query_testing: None,
+            verify_state_transition_results: true,
+            sign_instant_locks: true,
+            ..Default::default()
+        };
+
+        // Use 20-minute block spacing to allow some entries to expire while others remain
+        // Compaction happens every 64 blocks, entries expire after 24 hours (1440 mins)
+        // With 20-min spacing, entries expire after 72 blocks (1440/20 = 72)
+        //
+        // Timeline with 300 blocks:
+        // - Block 64: Compaction #1 → expires at block 136 → cleaned up
+        // - Block 128: Compaction #2 → expires at block 200 → cleaned up
+        // - Block 192: Compaction #3 → expires at block 264 → cleaned up
+        // - Block 256: Compaction #4 → expires at block 328 → still valid at 300!
+        //
+        // So at block 300, we should see 1 compacted entry (from block 256)
+        let config = PlatformConfig {
+            validator_set: ValidatorSetConfig::default_100_67(),
+            chain_lock: ChainLockConfig::default_100_67(),
+            instant_lock: InstantLockConfig::default_100_67(),
+            execution: ExecutionConfig {
+                verify_sum_trees: true,
+                ..Default::default()
+            },
+            block_spacing_ms: 1_200_000, // 20 minutes
+            testing_configs: PlatformTestConfig {
+                disable_checkpoints: false,
+                ..PlatformTestConfig::default_minimal_verifications()
+            },
+            ..Default::default()
+        };
+
+        let mut platform = TestPlatformBuilder::new()
+            .with_config(config.clone())
+            .build_with_mock_rpc();
+
+        // Run 300 blocks to:
+        // 1. Trigger multiple compactions (at blocks 64, 128, 192, 256)
+        // 2. Allow time for some entries to expire and be cleaned up
+        // 3. End with at least one valid compacted entry (from block 256)
+        let outcome = run_chain_for_strategy(
+            &mut platform,
+            300,
+            strategy,
+            config,
+            15,
+            &mut None,
+            &mut None,
+        );
+
+        // Verify we had address activity
+        let executed = outcome
+            .state_transition_results_per_block
+            .values()
+            .flat_map(|results| results.iter())
+            .filter(|(state_transition, result)| {
+                result.code == 0
+                    && (matches!(state_transition, StateTransition::AddressFundsTransfer(_))
+                        || matches!(
+                            state_transition,
+                            StateTransition::AddressFundingFromAssetLock(_)
+                        ))
+            })
+            .count();
+        assert!(
+            executed > 0,
+            "expected at least one address-related transition"
+        );
+
+        drop(outcome);
+
+        let platform_version = PlatformVersion::latest();
+        let platform_state = platform.platform.state.load();
+
+        // Query compacted address balance changes
+        let request = GetRecentCompactedAddressBalanceChangesRequest {
+            version: Some(CompactedChangesRequestVersion::V0(
+                GetRecentCompactedAddressBalanceChangesRequestV0 {
+                    start_block_height: 0,
+                    prove: false,
+                },
+            )),
+        };
+
+        let query_result = platform
+            .platform
+            .query_recent_compacted_address_balance_changes(
+                request,
+                &platform_state,
+                platform_version,
+            )
+            .expect("expected to run query");
+
+        assert!(
+            query_result.errors.is_empty(),
+            "query errors: {:?}",
+            query_result.errors
+        );
+
+        let response = query_result
+            .into_data()
+            .expect("expected data on query_validation_result");
+
+        let versioned_result = response.version.expect("expected a version");
+        match versioned_result {
+            CompactedChangesResponseVersion::V0(v0) => {
+                let result = v0.result.expect("expected a result");
+                match result {
+                    get_recent_compacted_address_balance_changes_response_v0::Result::CompactedAddressBalanceUpdateEntries(entries) => {
+                        // With 20-minute block spacing over 300 blocks:
+                        // - Compactions at blocks 64, 128, 192, 256
+                        // - Entries expire 72 blocks after creation (24hrs / 20mins = 72 blocks)
+                        // - Block 64 entry expires at 136 → cleaned up
+                        // - Block 128 entry expires at 200 → cleaned up
+                        // - Block 192 entry expires at 264 → cleaned up
+                        // - Block 256 entry expires at 328 → still valid at 300!
+                        //
+                        // We expect exactly 1 compacted entry to remain.
+                        // This proves both compaction AND cleanup are working correctly.
+
+                        // Assert exactly 1 compacted entry remains (earlier ones were cleaned up)
+                        assert_eq!(
+                            entries.compacted_block_changes.len(),
+                            1,
+                            "expected exactly 1 compacted entry (from ~block 256), but found {}. \
+                             Earlier compactions should have been cleaned up.",
+                            entries.compacted_block_changes.len()
+                        );
+
+                        let entry = &entries.compacted_block_changes[0];
+
+                        // The remaining entry should be from the most recent compaction (~block 256)
+                        // It should start after block 128 (earlier compactions were cleaned up)
+                        assert!(
+                            entry.start_block_height > 128,
+                            "compacted entry should start after block 128 (cleanup removed earlier entries), \
+                             but starts at {}",
+                            entry.start_block_height
+                        );
+
+                        // Compaction covers 64 blocks
+                        let block_span = entry.end_block_height - entry.start_block_height + 1;
+                        assert_eq!(
+                            block_span, 64,
+                            "compacted entry should span 64 blocks, but spans {}",
+                            block_span
+                        );
+
+                        // The entry should have address changes (our strategy generates address activity)
+                        assert!(
+                            !entry.changes.is_empty(),
+                            "compacted entry should contain address balance changes"
+                        );
+
+                        // Verify each change has valid data
+                        for change in &entry.changes {
+                            assert!(!change.address.is_empty(), "address should not be empty");
+                            assert!(change.operation.is_some(), "operation should be present");
+                        }
+                    }
+                    get_recent_compacted_address_balance_changes_response_v0::Result::Proof(_) => {
+                        panic!("expected entries, not proof");
+                    }
+                }
+            }
+        }
+
+        // Query non-compacted (recent) address balance changes
+        // These are blocks after the last compaction (~block 258 to 300)
+        let recent_request = GetRecentAddressBalanceChangesRequest {
+            version: Some(RecentChangesRequestVersion::V0(
+                GetRecentAddressBalanceChangesRequestV0 {
+                    start_height: 1,
+                    prove: false,
+                },
+            )),
+        };
+
+        let recent_query_result = platform
+            .platform
+            .query_recent_address_balance_changes(recent_request, &platform_state, platform_version)
+            .expect("expected to run recent query");
+
+        assert!(
+            recent_query_result.errors.is_empty(),
+            "recent query errors: {:?}",
+            recent_query_result.errors
+        );
+
+        let recent_response = recent_query_result
+            .into_data()
+            .expect("expected data on recent query result");
+
+        let recent_versioned_result = recent_response.version.expect("expected a version");
+        match recent_versioned_result {
+            RecentChangesResponseVersion::V0(v0) => {
+                let result = v0.result.expect("expected a result");
+                match result {
+                    get_recent_address_balance_changes_response_v0::Result::AddressBalanceUpdateEntries(entries) => {
+                        // After compaction at ~block 257, blocks 258-300 should be non-compacted
+                        // That's approximately 42 blocks of recent address changes
+                        assert!(
+                            !entries.block_changes.is_empty(),
+                            "expected non-compacted recent blocks after the last compaction"
+                        );
+
+                        // We should have roughly 300 - 257 = 43 blocks of recent data
+                        // (allowing some variance due to exact compaction timing)
+                        let recent_block_count = entries.block_changes.len();
+                        assert!(
+                            recent_block_count >= 40 && recent_block_count <= 50,
+                            "expected ~43 recent non-compacted blocks, but found {}",
+                            recent_block_count
+                        );
+
+                        // Verify blocks are in ascending order and have valid heights
+                        let mut prev_height = 0u64;
+                        for block in &entries.block_changes {
+                            assert!(
+                                block.block_height > prev_height,
+                                "blocks should be in ascending order"
+                            );
+                            prev_height = block.block_height;
+
+                            // Each block should have some address changes
+                            assert!(
+                                !block.changes.is_empty(),
+                                "block {} should have address balance changes",
+                                block.block_height
+                            );
+                        }
+
+                        // The first recent block should be after the compacted range
+                        let first_recent_block = entries.block_changes.first().unwrap();
+                        assert!(
+                            first_recent_block.block_height > 250,
+                            "first recent block should be after compaction (~block 257), but is {}",
+                            first_recent_block.block_height
+                        );
+                    }
+                    get_recent_address_balance_changes_response_v0::Result::Proof(_) => {
+                        panic!("expected recent entries, not proof");
+                    }
+                }
+            }
+        }
     }
 }

--- a/packages/rs-drive/src/drive/initialization/v2/mod.rs
+++ b/packages/rs-drive/src/drive/initialization/v2/mod.rs
@@ -2,7 +2,8 @@
 
 use crate::drive::address_funds::queries::CLEAR_ADDRESS_POOL;
 use crate::drive::saved_block_transactions::{
-    ADDRESS_BALANCES_KEY_U8, COMPACTED_ADDRESS_BALANCES_KEY_U8,
+    ADDRESS_BALANCES_KEY_U8, COMPACTED_ADDRESSES_EXPIRATION_TIME_KEY_U8,
+    COMPACTED_ADDRESS_BALANCES_KEY_U8,
 };
 use crate::drive::{Drive, RootTree};
 use crate::error::Error;
@@ -96,6 +97,16 @@ impl Drive {
         batch.add_insert(
             Self::saved_block_transactions_path(),
             vec![COMPACTED_ADDRESS_BALANCES_KEY_U8],
+            Element::empty_tree(),
+        );
+
+        // Compacted addresses expiration time subtree under SavedBlockTransactions for storing
+        // expiration timestamps (in milliseconds) for compacted address balance ranges.
+        // Each item uses the same (start_block, end_block) key as the compacted balances,
+        // with the value being the expiration time (block time + 1 day).
+        batch.add_insert(
+            Self::saved_block_transactions_path(),
+            vec![COMPACTED_ADDRESSES_EXPIRATION_TIME_KEY_U8],
             Element::empty_tree(),
         );
 

--- a/packages/rs-drive/src/drive/saved_block_transactions/cleanup_expired_address_balances/mod.rs
+++ b/packages/rs-drive/src/drive/saved_block_transactions/cleanup_expired_address_balances/mod.rs
@@ -1,0 +1,49 @@
+mod v0;
+
+use crate::drive::Drive;
+use crate::error::drive::DriveError;
+use crate::error::Error;
+use grovedb::TransactionArg;
+use platform_version::version::PlatformVersion;
+
+impl Drive {
+    /// Cleans up expired compacted address balance entries.
+    ///
+    /// This function queries the expiration time tree for entries with
+    /// expiration time <= current_block_time_ms, then deletes:
+    /// 1. The corresponding compacted address balance entries
+    /// 2. The expiration time entries themselves
+    ///
+    /// # Arguments
+    /// * `current_block_time_ms` - The current block time in milliseconds
+    /// * `transaction` - Optional database transaction
+    /// * `platform_version` - The platform version
+    ///
+    /// # Returns
+    /// * `Ok(usize)` - The number of compacted entries that were cleaned up
+    /// * `Err` - An error occurred
+    pub fn cleanup_expired_address_balances(
+        &self,
+        current_block_time_ms: u64,
+        transaction: TransactionArg,
+        platform_version: &PlatformVersion,
+    ) -> Result<usize, Error> {
+        match platform_version
+            .drive
+            .methods
+            .saved_block_transactions
+            .cleanup_expired_address_balances
+        {
+            0 => self.cleanup_expired_address_balances_v0(
+                current_block_time_ms,
+                transaction,
+                platform_version,
+            ),
+            version => Err(Error::Drive(DriveError::UnknownVersionMismatch {
+                method: "cleanup_expired_address_balances".to_string(),
+                known_versions: vec![0],
+                received: version,
+            })),
+        }
+    }
+}

--- a/packages/rs-drive/src/drive/saved_block_transactions/cleanup_expired_address_balances/v0/mod.rs
+++ b/packages/rs-drive/src/drive/saved_block_transactions/cleanup_expired_address_balances/v0/mod.rs
@@ -1,0 +1,95 @@
+use crate::drive::Drive;
+use crate::error::Error;
+use crate::util::batch::grovedb_op_batch::GroveDbOpBatchV0Methods;
+use crate::util::batch::GroveDbOpBatch;
+use dpp::ProtocolError;
+use grovedb::query_result_type::QueryResultType;
+use grovedb::{PathQuery, Query, QueryItem, SizedQuery, TransactionArg};
+use platform_version::version::PlatformVersion;
+
+impl Drive {
+    /// Version 0 implementation of cleaning up expired compacted address balance entries.
+    ///
+    /// Queries for all expiration entries with time <= current_block_time_ms,
+    /// then deletes the corresponding compacted entries and the expiration entries.
+    pub(super) fn cleanup_expired_address_balances_v0(
+        &self,
+        current_block_time_ms: u64,
+        transaction: TransactionArg,
+        platform_version: &PlatformVersion,
+    ) -> Result<usize, Error> {
+        let expiration_path = Self::saved_compacted_addresses_expiration_time_path_vec();
+
+        // Query all entries with expiration time <= current_block_time_ms
+        let mut query = Query::new();
+        // Range from 0 to current_block_time_ms (inclusive)
+        query.insert_item(QueryItem::RangeToInclusive(
+            ..=current_block_time_ms.to_be_bytes().to_vec(),
+        ));
+
+        let path_query =
+            PathQuery::new(expiration_path.clone(), SizedQuery::new(query, None, None));
+
+        let (results, _) = self.grove_get_path_query(
+            &path_query,
+            transaction,
+            QueryResultType::QueryKeyElementPairResultType,
+            &mut vec![],
+            &platform_version.drive,
+        )?;
+
+        let key_elements = results.to_key_elements();
+
+        if key_elements.is_empty() {
+            return Ok(0);
+        }
+
+        let config = bincode::config::standard()
+            .with_big_endian()
+            .with_no_limit();
+
+        let mut batch = GroveDbOpBatch::new();
+        let mut total_cleaned = 0usize;
+
+        let compacted_path = Self::saved_compacted_block_transactions_address_balances_path_vec();
+
+        for (expiration_key, element) in key_elements {
+            // Get the vec of block ranges from the element
+            let grovedb::Element::Item(serialized_ranges, _) = element else {
+                return Err(Error::Protocol(Box::new(
+                    ProtocolError::CorruptedSerialization(
+                        "expected item element for expiration block ranges".to_string(),
+                    ),
+                )));
+            };
+
+            // Deserialize the vec of block ranges
+            let (ranges, _): (Vec<(u64, u64)>, usize) =
+                bincode::decode_from_slice(&serialized_ranges, config).map_err(|e| {
+                    Error::Protocol(Box::new(ProtocolError::CorruptedSerialization(format!(
+                        "cannot decode expiration block ranges: {}",
+                        e
+                    ))))
+                })?;
+
+            // Delete each compacted address balance entry
+            for (start_block, end_block) in &ranges {
+                let mut compacted_key = Vec::with_capacity(16);
+                compacted_key.extend_from_slice(&start_block.to_be_bytes());
+                compacted_key.extend_from_slice(&end_block.to_be_bytes());
+
+                batch.add_delete(compacted_path.clone(), compacted_key);
+                total_cleaned += 1;
+            }
+
+            // Delete the expiration entry itself
+            batch.add_delete(expiration_path.clone(), expiration_key);
+        }
+
+        if !batch.is_empty() {
+            self.grove_apply_batch(batch, false, transaction, &platform_version.drive)?;
+        }
+
+        Ok(total_cleaned)
+    }
+}

--- a/packages/rs-drive/src/drive/saved_block_transactions/compact_address_balances/mod.rs
+++ b/packages/rs-drive/src/drive/saved_block_transactions/compact_address_balances/mod.rs
@@ -9,6 +9,9 @@ use grovedb::TransactionArg;
 use platform_version::version::PlatformVersion;
 use std::collections::BTreeMap;
 
+/// One day in milliseconds (used for compacted address expiration)
+pub const ONE_DAY_IN_MS: u64 = 24 * 60 * 60 * 1000;
+
 impl Drive {
     /// Compacts address balance changes from recent blocks, including the current block,
     /// into a single compacted entry.
@@ -17,9 +20,13 @@ impl Drive {
     /// with the provided current block's address balances, and stores the result in
     /// the compacted address balances tree with a (start_block, end_block) key.
     ///
+    /// Also stores the expiration time (current block time + 1 day) in the
+    /// compacted addresses expiration time tree.
+    ///
     /// # Arguments
     /// * `current_address_balances` - The current block's address balance changes to include
     /// * `current_block_height` - The height of the current block
+    /// * `current_block_time_ms` - The current block time in milliseconds
     /// * `transaction` - Optional database transaction
     /// * `platform_version` - The platform version
     ///
@@ -30,6 +37,7 @@ impl Drive {
         &self,
         current_address_balances: &BTreeMap<PlatformAddress, CreditOperation>,
         current_block_height: u64,
+        current_block_time_ms: u64,
         transaction: TransactionArg,
         platform_version: &PlatformVersion,
     ) -> Result<(u64, u64), Error> {
@@ -42,6 +50,7 @@ impl Drive {
             0 => self.compact_address_balances_with_current_block_v0(
                 current_address_balances,
                 current_block_height,
+                current_block_time_ms,
                 transaction,
                 platform_version,
             ),

--- a/packages/rs-drive/src/drive/saved_block_transactions/compact_address_balances/v0/mod.rs
+++ b/packages/rs-drive/src/drive/saved_block_transactions/compact_address_balances/v0/mod.rs
@@ -174,9 +174,13 @@ impl Drive {
 
         let expiration_value = if let Some(Element::Item(existing_data, _)) = existing_ranges {
             // Deserialize existing vec of block ranges and append the new one
-            let mut ranges: Vec<(u64, u64)> = bincode::decode_from_slice(&existing_data, config)
-                .map(|(v, _)| v)
-                .unwrap_or_default();
+            let (mut ranges, _): (Vec<(u64, u64)>, usize) =
+                bincode::decode_from_slice(&existing_data, config).map_err(|e| {
+                    Error::Protocol(Box::new(ProtocolError::CorruptedSerialization(format!(
+                        "cannot decode expiration block ranges: {}",
+                        e
+                    ))))
+                })?;
             ranges.push((start_block, end_block));
             bincode::encode_to_vec(&ranges, config).map_err(|e| {
                 Error::Protocol(Box::new(ProtocolError::CorruptedSerialization(format!(

--- a/packages/rs-drive/src/drive/saved_block_transactions/compact_address_balances/v0/mod.rs
+++ b/packages/rs-drive/src/drive/saved_block_transactions/compact_address_balances/v0/mod.rs
@@ -1,12 +1,15 @@
+use crate::drive::saved_block_transactions::compact_address_balances::ONE_DAY_IN_MS;
 use crate::drive::Drive;
 use crate::error::Error;
 use crate::util::batch::grovedb_op_batch::GroveDbOpBatchV0Methods;
 use crate::util::batch::GroveDbOpBatch;
+use crate::util::grove_operations::DirectQueryType;
 use dpp::address_funds::PlatformAddress;
 use dpp::balances::credits::CreditOperation;
 use dpp::ProtocolError;
 use grovedb::query_result_type::QueryResultType;
 use grovedb::{Element, PathQuery, Query, SizedQuery, TransactionArg};
+use grovedb_path::SubtreePath;
 use platform_version::version::PlatformVersion;
 use std::collections::BTreeMap;
 
@@ -18,11 +21,15 @@ impl Drive {
     /// and stores the result in the compacted address balances tree
     /// with a (start_block, end_block) key.
     ///
+    /// Also stores the expiration time (current block time + 1 day) in the
+    /// compacted addresses expiration time tree with the same (start_block, end_block) key.
+    ///
     /// Returns the range of blocks that were compacted (start_block, end_block).
     pub(super) fn compact_address_balances_with_current_block_v0(
         &self,
         current_address_balances: &BTreeMap<PlatformAddress, CreditOperation>,
         current_block_height: u64,
+        current_block_time_ms: u64,
         transaction: TransactionArg,
         platform_version: &PlatformVersion,
     ) -> Result<(u64, u64), Error> {
@@ -143,8 +150,57 @@ impl Drive {
         // Insert the compacted entry
         batch.add_insert(
             Self::saved_compacted_block_transactions_address_balances_path_vec(),
-            compacted_key,
+            compacted_key.clone(),
             Element::new_item(serialized),
+        );
+
+        // Calculate expiration time (current block time + 1 day)
+        let expiration_time_ms = current_block_time_ms.saturating_add(ONE_DAY_IN_MS);
+        let expiration_key = expiration_time_ms.to_be_bytes().to_vec();
+
+        // Check if an entry with this expiration time already exists
+        // If so, we need to append to the existing vec of block ranges
+        let expiration_path = Self::saved_compacted_addresses_expiration_time_path();
+
+        let mut drive_operations = vec![];
+        let existing_ranges = self.grove_get_raw_optional(
+            SubtreePath::from(expiration_path.as_ref()),
+            &expiration_key,
+            DirectQueryType::StatefulDirectQuery,
+            transaction,
+            &mut drive_operations,
+            &platform_version.drive,
+        )?;
+
+        let expiration_value = if let Some(Element::Item(existing_data, _)) = existing_ranges {
+            // Deserialize existing vec of block ranges and append the new one
+            let mut ranges: Vec<(u64, u64)> = bincode::decode_from_slice(&existing_data, config)
+                .map(|(v, _)| v)
+                .unwrap_or_default();
+            ranges.push((start_block, end_block));
+            bincode::encode_to_vec(&ranges, config).map_err(|e| {
+                Error::Protocol(Box::new(ProtocolError::CorruptedSerialization(format!(
+                    "cannot encode expiration block ranges: {}",
+                    e
+                ))))
+            })?
+        } else {
+            // No existing entry, create new vec with single range
+            let ranges: Vec<(u64, u64)> = vec![(start_block, end_block)];
+            bincode::encode_to_vec(&ranges, config).map_err(|e| {
+                Error::Protocol(Box::new(ProtocolError::CorruptedSerialization(format!(
+                    "cannot encode expiration block ranges: {}",
+                    e
+                ))))
+            })?
+        };
+
+        // Store in the expiration tree: key = expiration_time, value = vec of (start_block, end_block)
+        // This allows efficient querying for expired entries by time
+        batch.add_insert(
+            Self::saved_compacted_addresses_expiration_time_path_vec(),
+            expiration_key,
+            Element::new_item(expiration_value),
         );
 
         // Apply the batch

--- a/packages/rs-drive/src/drive/saved_block_transactions/mod.rs
+++ b/packages/rs-drive/src/drive/saved_block_transactions/mod.rs
@@ -1,3 +1,4 @@
+mod cleanup_expired_address_balances;
 mod compact_address_balances;
 mod fetch_address_balances;
 mod fetch_compacted_address_balances;

--- a/packages/rs-drive/src/drive/saved_block_transactions/queries.rs
+++ b/packages/rs-drive/src/drive/saved_block_transactions/queries.rs
@@ -13,6 +13,12 @@ pub const COMPACTED_ADDRESS_BALANCES_KEY: &[u8; 1] = b"c";
 /// The subtree key for compacted address balances storage as u8
 pub const COMPACTED_ADDRESS_BALANCES_KEY_U8: u8 = b'c';
 
+/// The subtree key for compacted addresses expiration time storage
+pub const COMPACTED_ADDRESSES_EXPIRATION_TIME_KEY: &[u8; 1] = b"e";
+
+/// The subtree key for compacted addresses expiration time storage as u8
+pub const COMPACTED_ADDRESSES_EXPIRATION_TIME_KEY_U8: u8 = b'e';
+
 impl Drive {
     /// Path to saved block transactions storage.
     pub fn saved_block_transactions_path() -> Vec<Vec<u8>> {
@@ -48,6 +54,22 @@ impl Drive {
         [
             Into::<&[u8; 1]>::into(RootTree::SavedBlockTransactions),
             &[COMPACTED_ADDRESS_BALANCES_KEY_U8],
+        ]
+    }
+
+    /// Path to compacted addresses expiration time under saved block transactions (Vec version).
+    pub fn saved_compacted_addresses_expiration_time_path_vec() -> Vec<Vec<u8>> {
+        vec![
+            vec![RootTree::SavedBlockTransactions as u8],
+            vec![COMPACTED_ADDRESSES_EXPIRATION_TIME_KEY_U8],
+        ]
+    }
+
+    /// Path to compacted addresses expiration time under saved block transactions.
+    pub fn saved_compacted_addresses_expiration_time_path() -> [&'static [u8]; 2] {
+        [
+            Into::<&[u8; 1]>::into(RootTree::SavedBlockTransactions),
+            &[COMPACTED_ADDRESSES_EXPIRATION_TIME_KEY_U8],
         ]
     }
 }

--- a/packages/rs-drive/src/drive/saved_block_transactions/store_address_balances/mod.rs
+++ b/packages/rs-drive/src/drive/saved_block_transactions/store_address_balances/mod.rs
@@ -13,11 +13,14 @@ impl Drive {
     /// Stores address balance changes for a block in the SavedBlockTransactions tree.
     ///
     /// This method serializes the address balance changes using bincode and stores
-    /// them keyed by block height.
+    /// them keyed by block height. If compaction thresholds are exceeded, it will
+    /// compact existing entries along with the current block's data and store
+    /// an expiration time for the compacted entry.
     ///
     /// # Parameters
     /// - `address_balances`: The map of address balance changes to store
     /// - `block_height`: The height of the block these changes belong to
+    /// - `block_time_ms`: The block time in milliseconds (used for expiration calculation)
     /// - `transaction`: The database transaction
     /// - `platform_version`: The platform version
     ///
@@ -28,6 +31,7 @@ impl Drive {
         &self,
         address_balances: &BTreeMap<PlatformAddress, CreditOperation>,
         block_height: u64,
+        block_time_ms: u64,
         transaction: TransactionArg,
         platform_version: &PlatformVersion,
     ) -> Result<(), Error> {
@@ -40,6 +44,7 @@ impl Drive {
             0 => self.store_address_balances_for_block_v0(
                 address_balances,
                 block_height,
+                block_time_ms,
                 transaction,
                 platform_version,
             ),

--- a/packages/rs-drive/src/drive/saved_block_transactions/store_address_balances/v0/mod.rs
+++ b/packages/rs-drive/src/drive/saved_block_transactions/store_address_balances/v0/mod.rs
@@ -27,6 +27,7 @@ impl Drive {
         &self,
         address_balances: &BTreeMap<PlatformAddress, CreditOperation>,
         block_height: u64,
+        block_time_ms: u64,
         transaction: TransactionArg,
         platform_version: &PlatformVersion,
     ) -> Result<(), Error> {
@@ -39,6 +40,7 @@ impl Drive {
         let compacted = self.check_and_compact_if_needed(
             address_balances,
             block_height,
+            block_time_ms,
             transaction,
             platform_version,
         )?;
@@ -103,6 +105,7 @@ impl Drive {
         &self,
         address_balances: &BTreeMap<PlatformAddress, CreditOperation>,
         block_height: u64,
+        block_time_ms: u64,
         transaction: TransactionArg,
         platform_version: &PlatformVersion,
     ) -> Result<bool, Error> {
@@ -141,6 +144,7 @@ impl Drive {
                 self.compact_address_balances_with_current_block(
                     address_balances,
                     block_height,
+                    block_time_ms,
                     transaction,
                     platform_version,
                 )?;
@@ -183,6 +187,9 @@ mod tests {
         version
     }
 
+    // Test block time constant (arbitrary value for testing)
+    const TEST_BLOCK_TIME_MS: u64 = 1700000000000; // Some timestamp in ms
+
     #[test]
     fn should_compact_when_max_blocks_threshold_exceeded() {
         let drive = setup_drive_with_initial_state_structure(None);
@@ -197,10 +204,22 @@ mod tests {
         balances_block_2.insert(ADDR_2, CreditOperation::AddToCredits(2000));
 
         drive
-            .store_address_balances_for_block_v0(&balances_block_1, 100, None, &platform_version)
+            .store_address_balances_for_block_v0(
+                &balances_block_1,
+                100,
+                TEST_BLOCK_TIME_MS,
+                None,
+                &platform_version,
+            )
             .expect("should store block 1");
         drive
-            .store_address_balances_for_block_v0(&balances_block_2, 101, None, &platform_version)
+            .store_address_balances_for_block_v0(
+                &balances_block_2,
+                101,
+                TEST_BLOCK_TIME_MS,
+                None,
+                &platform_version,
+            )
             .expect("should store block 2");
 
         // Verify blocks are stored (not compacted yet)
@@ -214,7 +233,13 @@ mod tests {
         balances_block_3.insert(ADDR_3, CreditOperation::AddToCredits(3000));
 
         drive
-            .store_address_balances_for_block_v0(&balances_block_3, 102, None, &platform_version)
+            .store_address_balances_for_block_v0(
+                &balances_block_3,
+                102,
+                TEST_BLOCK_TIME_MS,
+                None,
+                &platform_version,
+            )
             .expect("should store and compact block 3");
 
         // After compaction, recent address balances should be empty (all moved to compacted)
@@ -262,7 +287,13 @@ mod tests {
         balances_block_1.insert(ADDR_2, CreditOperation::AddToCredits(2000));
 
         drive
-            .store_address_balances_for_block_v0(&balances_block_1, 100, None, &platform_version)
+            .store_address_balances_for_block_v0(
+                &balances_block_1,
+                100,
+                TEST_BLOCK_TIME_MS,
+                None,
+                &platform_version,
+            )
             .expect("should store block 1");
 
         // Verify block is stored (not compacted yet - only 2 addresses)
@@ -277,7 +308,13 @@ mod tests {
         balances_block_2.insert(ADDR_4, CreditOperation::AddToCredits(4000));
 
         drive
-            .store_address_balances_for_block_v0(&balances_block_2, 101, None, &platform_version)
+            .store_address_balances_for_block_v0(
+                &balances_block_2,
+                101,
+                TEST_BLOCK_TIME_MS,
+                None,
+                &platform_version,
+            )
             .expect("should store and compact block 2");
 
         // After compaction, recent address balances should be empty
@@ -312,7 +349,13 @@ mod tests {
         balances_block_1.insert(ADDR_1, CreditOperation::AddToCredits(1000));
 
         drive
-            .store_address_balances_for_block_v0(&balances_block_1, 100, None, &platform_version)
+            .store_address_balances_for_block_v0(
+                &balances_block_1,
+                100,
+                TEST_BLOCK_TIME_MS,
+                None,
+                &platform_version,
+            )
             .expect("should store block 1");
 
         // Block 2: Add more credits to same address - should trigger compaction and merge
@@ -320,7 +363,13 @@ mod tests {
         balances_block_2.insert(ADDR_1, CreditOperation::AddToCredits(500));
 
         drive
-            .store_address_balances_for_block_v0(&balances_block_2, 101, None, &platform_version)
+            .store_address_balances_for_block_v0(
+                &balances_block_2,
+                101,
+                TEST_BLOCK_TIME_MS,
+                None,
+                &platform_version,
+            )
             .expect("should store and compact block 2");
 
         // Verify compacted data has merged credits
@@ -350,7 +399,13 @@ mod tests {
         balances_block_1.insert(ADDR_1, CreditOperation::SetCredits(1000));
 
         drive
-            .store_address_balances_for_block_v0(&balances_block_1, 100, None, &platform_version)
+            .store_address_balances_for_block_v0(
+                &balances_block_1,
+                100,
+                TEST_BLOCK_TIME_MS,
+                None,
+                &platform_version,
+            )
             .expect("should store block 1");
 
         // Block 2: Add credits to same address - should trigger compaction and merge
@@ -358,7 +413,13 @@ mod tests {
         balances_block_2.insert(ADDR_1, CreditOperation::AddToCredits(500));
 
         drive
-            .store_address_balances_for_block_v0(&balances_block_2, 101, None, &platform_version)
+            .store_address_balances_for_block_v0(
+                &balances_block_2,
+                101,
+                TEST_BLOCK_TIME_MS,
+                None,
+                &platform_version,
+            )
             .expect("should store and compact block 2");
 
         // Verify compacted data has merged: SetCredits(1000) + AddToCredits(500) = SetCredits(1500)
@@ -387,7 +448,13 @@ mod tests {
         balances_block_1.insert(ADDR_1, CreditOperation::AddToCredits(1000));
 
         drive
-            .store_address_balances_for_block_v0(&balances_block_1, 100, None, &platform_version)
+            .store_address_balances_for_block_v0(
+                &balances_block_1,
+                100,
+                TEST_BLOCK_TIME_MS,
+                None,
+                &platform_version,
+            )
             .expect("should store block 1");
 
         // Block 2: Set credits to same address - should override
@@ -395,7 +462,13 @@ mod tests {
         balances_block_2.insert(ADDR_1, CreditOperation::SetCredits(500));
 
         drive
-            .store_address_balances_for_block_v0(&balances_block_2, 101, None, &platform_version)
+            .store_address_balances_for_block_v0(
+                &balances_block_2,
+                101,
+                TEST_BLOCK_TIME_MS,
+                None,
+                &platform_version,
+            )
             .expect("should store and compact block 2");
 
         // Verify compacted data has the set value (overrides previous add)
@@ -421,7 +494,13 @@ mod tests {
         // Try to store empty balances
         let empty_balances: BTreeMap<PlatformAddress, CreditOperation> = BTreeMap::new();
         drive
-            .store_address_balances_for_block_v0(&empty_balances, 100, None, &platform_version)
+            .store_address_balances_for_block_v0(
+                &empty_balances,
+                100,
+                TEST_BLOCK_TIME_MS,
+                None,
+                &platform_version,
+            )
             .expect("should handle empty balances");
 
         // Verify nothing was stored
@@ -444,10 +523,22 @@ mod tests {
         balances_101.insert(ADDR_1, CreditOperation::AddToCredits(100));
 
         drive
-            .store_address_balances_for_block_v0(&balances_100, 100, None, &platform_version)
+            .store_address_balances_for_block_v0(
+                &balances_100,
+                100,
+                TEST_BLOCK_TIME_MS,
+                None,
+                &platform_version,
+            )
             .expect("should store block 100");
         drive
-            .store_address_balances_for_block_v0(&balances_101, 101, None, &platform_version)
+            .store_address_balances_for_block_v0(
+                &balances_101,
+                101,
+                TEST_BLOCK_TIME_MS,
+                None,
+                &platform_version,
+            )
             .expect("should store and compact block 101");
 
         // Second cycle: blocks 200, 201
@@ -457,10 +548,22 @@ mod tests {
         balances_201.insert(ADDR_2, CreditOperation::AddToCredits(200));
 
         drive
-            .store_address_balances_for_block_v0(&balances_200, 200, None, &platform_version)
+            .store_address_balances_for_block_v0(
+                &balances_200,
+                200,
+                TEST_BLOCK_TIME_MS,
+                None,
+                &platform_version,
+            )
             .expect("should store block 200");
         drive
-            .store_address_balances_for_block_v0(&balances_201, 201, None, &platform_version)
+            .store_address_balances_for_block_v0(
+                &balances_201,
+                201,
+                TEST_BLOCK_TIME_MS,
+                None,
+                &platform_version,
+            )
             .expect("should store and compact block 201");
 
         // Verify we have 2 compacted entries
@@ -505,6 +608,7 @@ mod tests {
                 .store_address_balances_for_block_v0(
                     &balances_1,
                     base_block,
+                    TEST_BLOCK_TIME_MS,
                     None,
                     &platform_version,
                 )
@@ -513,6 +617,7 @@ mod tests {
                 .store_address_balances_for_block_v0(
                     &balances_2,
                     base_block + 1,
+                    TEST_BLOCK_TIME_MS,
                     None,
                     &platform_version,
                 )
@@ -575,6 +680,7 @@ mod tests {
                 .store_address_balances_for_block_v0(
                     &balances_1,
                     base_block,
+                    TEST_BLOCK_TIME_MS,
                     None,
                     &platform_version,
                 )
@@ -583,6 +689,7 @@ mod tests {
                 .store_address_balances_for_block_v0(
                     &balances_2,
                     base_block + 1,
+                    TEST_BLOCK_TIME_MS,
                     None,
                     &platform_version,
                 )
@@ -623,7 +730,13 @@ mod tests {
             let mut balances = BTreeMap::new();
             balances.insert(ADDR_1, CreditOperation::AddToCredits(100));
             drive
-                .store_address_balances_for_block_v0(&balances, block, None, &platform_version)
+                .store_address_balances_for_block_v0(
+                    &balances,
+                    block,
+                    TEST_BLOCK_TIME_MS,
+                    None,
+                    &platform_version,
+                )
                 .expect("should store");
         }
 
@@ -639,7 +752,13 @@ mod tests {
         let mut balances_103 = BTreeMap::new();
         balances_103.insert(ADDR_2, CreditOperation::AddToCredits(500));
         drive
-            .store_address_balances_for_block_v0(&balances_103, 103, None, &platform_version)
+            .store_address_balances_for_block_v0(
+                &balances_103,
+                103,
+                TEST_BLOCK_TIME_MS,
+                None,
+                &platform_version,
+            )
             .expect("should store block 103");
 
         // Verify we have both compacted AND recent data
@@ -666,7 +785,13 @@ mod tests {
         let mut balances_104 = BTreeMap::new();
         balances_104.insert(ADDR_3, CreditOperation::AddToCredits(600));
         drive
-            .store_address_balances_for_block_v0(&balances_104, 104, None, &platform_version)
+            .store_address_balances_for_block_v0(
+                &balances_104,
+                104,
+                TEST_BLOCK_TIME_MS,
+                None,
+                &platform_version,
+            )
             .expect("should store block 104");
 
         let recent_2 = drive
@@ -678,7 +803,13 @@ mod tests {
         let mut balances_105 = BTreeMap::new();
         balances_105.insert(ADDR_4, CreditOperation::AddToCredits(700));
         drive
-            .store_address_balances_for_block_v0(&balances_105, 105, None, &platform_version)
+            .store_address_balances_for_block_v0(
+                &balances_105,
+                105,
+                TEST_BLOCK_TIME_MS,
+                None,
+                &platform_version,
+            )
             .expect("should store block 105 and trigger compaction");
 
         // Verify we now have 2 compacted entries and no recent
@@ -711,7 +842,13 @@ mod tests {
             let mut balances = BTreeMap::new();
             balances.insert(ADDR_1, CreditOperation::AddToCredits(block));
             drive
-                .store_address_balances_for_block_v0(&balances, block, None, &platform_version)
+                .store_address_balances_for_block_v0(
+                    &balances,
+                    block,
+                    TEST_BLOCK_TIME_MS,
+                    None,
+                    &platform_version,
+                )
                 .expect("should store");
         }
 
@@ -739,5 +876,218 @@ mod tests {
             .fetch_recent_address_balance_changes(200, None, None, &platform_version)
             .expect("should fetch");
         assert!(from_200.is_empty(), "should have no blocks from 200");
+    }
+
+    #[test]
+    fn should_store_expiration_time_when_compacting() {
+        use crate::drive::saved_block_transactions::compact_address_balances::ONE_DAY_IN_MS;
+        use crate::drive::saved_block_transactions::COMPACTED_ADDRESSES_EXPIRATION_TIME_KEY_U8;
+        use grovedb::query_result_type::QueryResultType;
+        use grovedb::{PathQuery, Query, SizedQuery};
+
+        let drive = setup_drive_with_initial_state_structure(None);
+        // Compact after 2 blocks
+        let platform_version = create_test_platform_version_for_compaction(2, 1000);
+
+        // Store 2 blocks to trigger compaction
+        let mut balances_1 = BTreeMap::new();
+        balances_1.insert(ADDR_1, CreditOperation::AddToCredits(1000));
+
+        let mut balances_2 = BTreeMap::new();
+        balances_2.insert(ADDR_2, CreditOperation::AddToCredits(2000));
+
+        let block_time_ms: u64 = 1700000000000; // Some timestamp
+
+        drive
+            .store_address_balances_for_block_v0(
+                &balances_1,
+                100,
+                block_time_ms,
+                None,
+                &platform_version,
+            )
+            .expect("should store block 1");
+        drive
+            .store_address_balances_for_block_v0(
+                &balances_2,
+                101,
+                block_time_ms,
+                None,
+                &platform_version,
+            )
+            .expect("should store and compact block 2");
+
+        // Query the expiration time tree directly to verify it was stored
+        let path = vec![
+            vec![crate::drive::RootTree::SavedBlockTransactions as u8],
+            vec![COMPACTED_ADDRESSES_EXPIRATION_TIME_KEY_U8],
+        ];
+
+        let mut query = Query::new();
+        query.insert_all();
+
+        let path_query = PathQuery::new(path, SizedQuery::new(query, None, None));
+
+        let (results, _) = drive
+            .grove_get_path_query(
+                &path_query,
+                None,
+                QueryResultType::QueryKeyElementPairResultType,
+                &mut vec![],
+                &platform_version.drive,
+            )
+            .expect("should query expiration tree");
+
+        let key_elements = results.to_key_elements();
+        assert_eq!(key_elements.len(), 1, "should have 1 expiration entry");
+
+        // Verify the key is the expiration time (block_time + 1 day)
+        let (key, element) = &key_elements[0];
+        assert_eq!(key.len(), 8, "key should be 8 bytes (u64 expiration time)");
+
+        let expiration_time = u64::from_be_bytes(key.as_slice().try_into().unwrap());
+        let expected_expiration = block_time_ms + ONE_DAY_IN_MS;
+        assert_eq!(
+            expiration_time, expected_expiration,
+            "key should be expiration time (block_time + 1 day)"
+        );
+
+        // Verify the value is a vec of block ranges
+        if let grovedb::Element::Item(serialized_ranges, _) = element {
+            let config = bincode::config::standard()
+                .with_big_endian()
+                .with_no_limit();
+            let (ranges, _): (Vec<(u64, u64)>, usize) =
+                bincode::decode_from_slice(serialized_ranges, config)
+                    .expect("should decode block ranges");
+
+            assert_eq!(ranges.len(), 1, "should have 1 block range");
+            assert_eq!(ranges[0], (100, 101), "block range should be (100, 101)");
+        } else {
+            panic!("expected Item element for block ranges");
+        }
+    }
+
+    #[test]
+    fn should_append_to_expiration_time_when_same_time() {
+        use crate::drive::saved_block_transactions::compact_address_balances::ONE_DAY_IN_MS;
+        use crate::drive::saved_block_transactions::COMPACTED_ADDRESSES_EXPIRATION_TIME_KEY_U8;
+        use grovedb::query_result_type::QueryResultType;
+        use grovedb::{PathQuery, Query, SizedQuery};
+
+        let drive = setup_drive_with_initial_state_structure(None);
+        // Compact after 2 blocks
+        let platform_version = create_test_platform_version_for_compaction(2, 1000);
+
+        let block_time_ms: u64 = 1700000000000; // Same timestamp for both compactions
+
+        // First compaction cycle: blocks 100-101
+        let mut balances_1 = BTreeMap::new();
+        balances_1.insert(ADDR_1, CreditOperation::AddToCredits(1000));
+        let mut balances_2 = BTreeMap::new();
+        balances_2.insert(ADDR_1, CreditOperation::AddToCredits(500));
+
+        drive
+            .store_address_balances_for_block_v0(
+                &balances_1,
+                100,
+                block_time_ms,
+                None,
+                &platform_version,
+            )
+            .expect("should store block 100");
+        drive
+            .store_address_balances_for_block_v0(
+                &balances_2,
+                101,
+                block_time_ms,
+                None,
+                &platform_version,
+            )
+            .expect("should store and compact block 101");
+
+        // Second compaction cycle: blocks 200-201 (same block time - unlikely but possible)
+        let mut balances_3 = BTreeMap::new();
+        balances_3.insert(ADDR_2, CreditOperation::AddToCredits(2000));
+        let mut balances_4 = BTreeMap::new();
+        balances_4.insert(ADDR_2, CreditOperation::AddToCredits(500));
+
+        drive
+            .store_address_balances_for_block_v0(
+                &balances_3,
+                200,
+                block_time_ms,
+                None,
+                &platform_version,
+            )
+            .expect("should store block 200");
+        drive
+            .store_address_balances_for_block_v0(
+                &balances_4,
+                201,
+                block_time_ms,
+                None,
+                &platform_version,
+            )
+            .expect("should store and compact block 201");
+
+        // Query the expiration time tree
+        let path = vec![
+            vec![crate::drive::RootTree::SavedBlockTransactions as u8],
+            vec![COMPACTED_ADDRESSES_EXPIRATION_TIME_KEY_U8],
+        ];
+
+        let mut query = Query::new();
+        query.insert_all();
+
+        let path_query = PathQuery::new(path, SizedQuery::new(query, None, None));
+
+        let (results, _) = drive
+            .grove_get_path_query(
+                &path_query,
+                None,
+                QueryResultType::QueryKeyElementPairResultType,
+                &mut vec![],
+                &platform_version.drive,
+            )
+            .expect("should query expiration tree");
+
+        let key_elements = results.to_key_elements();
+        // Should still have only 1 entry since both compactions have the same expiration time
+        assert_eq!(
+            key_elements.len(),
+            1,
+            "should have 1 expiration entry (same time)"
+        );
+
+        // Verify the key is the expiration time
+        let (key, element) = &key_elements[0];
+        let expiration_time = u64::from_be_bytes(key.as_slice().try_into().unwrap());
+        let expected_expiration = block_time_ms + ONE_DAY_IN_MS;
+        assert_eq!(expiration_time, expected_expiration);
+
+        // Verify the value contains BOTH block ranges
+        if let grovedb::Element::Item(serialized_ranges, _) = element {
+            let config = bincode::config::standard()
+                .with_big_endian()
+                .with_no_limit();
+            let (ranges, _): (Vec<(u64, u64)>, usize) =
+                bincode::decode_from_slice(serialized_ranges, config)
+                    .expect("should decode block ranges");
+
+            assert_eq!(ranges.len(), 2, "should have 2 block ranges");
+            assert_eq!(
+                ranges[0],
+                (100, 101),
+                "first block range should be (100, 101)"
+            );
+            assert_eq!(
+                ranges[1],
+                (200, 201),
+                "second block range should be (200, 201)"
+            );
+        } else {
+            panic!("expected Item element for block ranges");
+        }
     }
 }

--- a/packages/rs-platform-version/src/version/drive_abci_versions/drive_abci_method_versions/mod.rs
+++ b/packages/rs-platform-version/src/version/drive_abci_versions/drive_abci_method_versions/mod.rs
@@ -176,4 +176,5 @@ pub struct DriveAbciStateTransitionProcessingMethodVersions {
     pub decode_raw_state_transitions: FeatureVersion,
     pub validate_fees_of_event: FeatureVersion,
     pub store_address_balances_to_recent_block_storage: OptionalFeatureVersion,
+    pub cleanup_recent_block_storage_address_balances: OptionalFeatureVersion,
 }

--- a/packages/rs-platform-version/src/version/drive_abci_versions/drive_abci_method_versions/v1.rs
+++ b/packages/rs-platform-version/src/version/drive_abci_versions/drive_abci_method_versions/v1.rs
@@ -106,6 +106,7 @@ pub const DRIVE_ABCI_METHOD_VERSIONS_V1: DriveAbciMethodVersions = DriveAbciMeth
         decode_raw_state_transitions: 0,
         validate_fees_of_event: 0,
         store_address_balances_to_recent_block_storage: None,
+        cleanup_recent_block_storage_address_balances: None,
     },
     epoch: DriveAbciEpochMethodVersions {
         gather_epoch_info: 0,

--- a/packages/rs-platform-version/src/version/drive_abci_versions/drive_abci_method_versions/v2.rs
+++ b/packages/rs-platform-version/src/version/drive_abci_versions/drive_abci_method_versions/v2.rs
@@ -107,6 +107,7 @@ pub const DRIVE_ABCI_METHOD_VERSIONS_V2: DriveAbciMethodVersions = DriveAbciMeth
         decode_raw_state_transitions: 0,
         validate_fees_of_event: 0,
         store_address_balances_to_recent_block_storage: None,
+        cleanup_recent_block_storage_address_balances: None,
     },
     epoch: DriveAbciEpochMethodVersions {
         gather_epoch_info: 0,

--- a/packages/rs-platform-version/src/version/drive_abci_versions/drive_abci_method_versions/v3.rs
+++ b/packages/rs-platform-version/src/version/drive_abci_versions/drive_abci_method_versions/v3.rs
@@ -106,6 +106,7 @@ pub const DRIVE_ABCI_METHOD_VERSIONS_V3: DriveAbciMethodVersions = DriveAbciMeth
         decode_raw_state_transitions: 0,
         validate_fees_of_event: 0,
         store_address_balances_to_recent_block_storage: None,
+        cleanup_recent_block_storage_address_balances: None,
     },
     epoch: DriveAbciEpochMethodVersions {
         gather_epoch_info: 0,

--- a/packages/rs-platform-version/src/version/drive_abci_versions/drive_abci_method_versions/v4.rs
+++ b/packages/rs-platform-version/src/version/drive_abci_versions/drive_abci_method_versions/v4.rs
@@ -106,6 +106,7 @@ pub const DRIVE_ABCI_METHOD_VERSIONS_V4: DriveAbciMethodVersions = DriveAbciMeth
         decode_raw_state_transitions: 0,
         validate_fees_of_event: 0,
         store_address_balances_to_recent_block_storage: None,
+        cleanup_recent_block_storage_address_balances: None,
     },
     epoch: DriveAbciEpochMethodVersions {
         gather_epoch_info: 0,

--- a/packages/rs-platform-version/src/version/drive_abci_versions/drive_abci_method_versions/v5.rs
+++ b/packages/rs-platform-version/src/version/drive_abci_versions/drive_abci_method_versions/v5.rs
@@ -110,6 +110,7 @@ pub const DRIVE_ABCI_METHOD_VERSIONS_V5: DriveAbciMethodVersions = DriveAbciMeth
         decode_raw_state_transitions: 0,
         validate_fees_of_event: 0,
         store_address_balances_to_recent_block_storage: None,
+        cleanup_recent_block_storage_address_balances: None,
     },
     epoch: DriveAbciEpochMethodVersions {
         gather_epoch_info: 0,

--- a/packages/rs-platform-version/src/version/drive_abci_versions/drive_abci_method_versions/v6.rs
+++ b/packages/rs-platform-version/src/version/drive_abci_versions/drive_abci_method_versions/v6.rs
@@ -108,6 +108,7 @@ pub const DRIVE_ABCI_METHOD_VERSIONS_V6: DriveAbciMethodVersions = DriveAbciMeth
         decode_raw_state_transitions: 0,
         validate_fees_of_event: 0,
         store_address_balances_to_recent_block_storage: None,
+        cleanup_recent_block_storage_address_balances: None,
     },
     epoch: DriveAbciEpochMethodVersions {
         gather_epoch_info: 0,

--- a/packages/rs-platform-version/src/version/drive_abci_versions/drive_abci_method_versions/v7.rs
+++ b/packages/rs-platform-version/src/version/drive_abci_versions/drive_abci_method_versions/v7.rs
@@ -107,6 +107,7 @@ pub const DRIVE_ABCI_METHOD_VERSIONS_V7: DriveAbciMethodVersions = DriveAbciMeth
         decode_raw_state_transitions: 0,
         validate_fees_of_event: 0,
         store_address_balances_to_recent_block_storage: Some(0), // changed
+        cleanup_recent_block_storage_address_balances: Some(0), // cleanup enabled when store is enabled
     },
     epoch: DriveAbciEpochMethodVersions {
         gather_epoch_info: 0,

--- a/packages/rs-platform-version/src/version/drive_versions/mod.rs
+++ b/packages/rs-platform-version/src/version/drive_versions/mod.rs
@@ -79,6 +79,7 @@ pub struct DriveSavedBlockTransactionsMethodVersions {
     pub store_address_balances: FeatureVersion,
     pub fetch_address_balances: FeatureVersion,
     pub compact_address_balances: FeatureVersion,
+    pub cleanup_expired_address_balances: FeatureVersion,
     /// Maximum number of blocks to store before compaction is triggered
     pub max_blocks_before_compaction: u16,
     /// Maximum number of address balance entries before compaction is triggered

--- a/packages/rs-platform-version/src/version/drive_versions/v1.rs
+++ b/packages/rs-platform-version/src/version/drive_versions/v1.rs
@@ -107,6 +107,7 @@ pub const DRIVE_VERSION_V1: DriveVersion = DriveVersion {
             store_address_balances: 0,
             fetch_address_balances: 0,
             compact_address_balances: 0,
+            cleanup_expired_address_balances: 0,
             max_blocks_before_compaction: 64,
             max_addresses_before_compaction: 2048,
         },

--- a/packages/rs-platform-version/src/version/drive_versions/v2.rs
+++ b/packages/rs-platform-version/src/version/drive_versions/v2.rs
@@ -107,6 +107,7 @@ pub const DRIVE_VERSION_V2: DriveVersion = DriveVersion {
             store_address_balances: 0,
             fetch_address_balances: 0,
             compact_address_balances: 0,
+            cleanup_expired_address_balances: 0,
             max_blocks_before_compaction: 64,
             max_addresses_before_compaction: 2048,
         },

--- a/packages/rs-platform-version/src/version/drive_versions/v3.rs
+++ b/packages/rs-platform-version/src/version/drive_versions/v3.rs
@@ -107,6 +107,7 @@ pub const DRIVE_VERSION_V3: DriveVersion = DriveVersion {
             store_address_balances: 0,
             fetch_address_balances: 0,
             compact_address_balances: 0,
+            cleanup_expired_address_balances: 0,
             max_blocks_before_compaction: 64,
             max_addresses_before_compaction: 2048,
         },

--- a/packages/rs-platform-version/src/version/drive_versions/v4.rs
+++ b/packages/rs-platform-version/src/version/drive_versions/v4.rs
@@ -107,6 +107,7 @@ pub const DRIVE_VERSION_V4: DriveVersion = DriveVersion {
             store_address_balances: 0,
             fetch_address_balances: 0,
             compact_address_balances: 0,
+            cleanup_expired_address_balances: 0,
             max_blocks_before_compaction: 64,
             max_addresses_before_compaction: 2048,
         },

--- a/packages/rs-platform-version/src/version/drive_versions/v5.rs
+++ b/packages/rs-platform-version/src/version/drive_versions/v5.rs
@@ -109,6 +109,7 @@ pub const DRIVE_VERSION_V5: DriveVersion = DriveVersion {
             store_address_balances: 0,
             fetch_address_balances: 0,
             compact_address_balances: 0,
+            cleanup_expired_address_balances: 0,
             max_blocks_before_compaction: 64,
             max_addresses_before_compaction: 2048,
         },

--- a/packages/rs-platform-version/src/version/drive_versions/v6.rs
+++ b/packages/rs-platform-version/src/version/drive_versions/v6.rs
@@ -111,6 +111,7 @@ pub const DRIVE_VERSION_V6: DriveVersion = DriveVersion {
             store_address_balances: 0,
             fetch_address_balances: 0,
             compact_address_balances: 0,
+            cleanup_expired_address_balances: 0,
             max_blocks_before_compaction: 64,
             max_addresses_before_compaction: 2048,
         },

--- a/packages/rs-platform-version/src/version/mocks/v2_test.rs
+++ b/packages/rs-platform-version/src/version/mocks/v2_test.rs
@@ -141,7 +141,7 @@ pub const TEST_PLATFORM_V2: PlatformVersion = PlatformVersion {
             },
             group: DRIVE_GROUP_METHOD_VERSIONS_V1,
             address_funds: DRIVE_ADDRESS_FUNDS_METHOD_VERSIONS_V1,
-            saved_block_transactions: DriveSavedBlockTransactionsMethodVersions { store_address_balances: 0, fetch_address_balances: 0, compact_address_balances: 0, max_blocks_before_compaction: 64, max_addresses_before_compaction: 2048 },
+            saved_block_transactions: DriveSavedBlockTransactionsMethodVersions { store_address_balances: 0, fetch_address_balances: 0, compact_address_balances: 0, cleanup_expired_address_balances: 0, max_blocks_before_compaction: 64, max_addresses_before_compaction: 2048 },
         },
         grove_methods: DRIVE_GROVE_METHOD_VERSIONS_V1,
         grove_version: GROVE_V1,

--- a/packages/rs-platform-version/src/version/mocks/v3_test.rs
+++ b/packages/rs-platform-version/src/version/mocks/v3_test.rs
@@ -141,6 +141,7 @@ pub const TEST_PLATFORM_V3: PlatformVersion = PlatformVersion {
                 decode_raw_state_transitions: 0,
                 validate_fees_of_event: 0,
                 store_address_balances_to_recent_block_storage: None,
+                cleanup_recent_block_storage_address_balances: None,
             },
             epoch: DriveAbciEpochMethodVersions {
                 gather_epoch_info: 0,

--- a/packages/strategy-tests/src/transitions.rs
+++ b/packages/strategy-tests/src/transitions.rs
@@ -555,7 +555,6 @@ pub fn create_identity_update_transition_disable_keys(
         .collect::<Vec<_>>();
 
     if key_ids_we_could_disable.is_empty() {
-        identity.set_revision(identity.revision() - 1); //since we added 1 before
         return None;
     }
     let indices: Vec<_> = (0..key_ids_we_could_disable.len()).choose_multiple(rng, count as usize);

--- a/packages/strategy-tests/src/transitions.rs
+++ b/packages/strategy-tests/src/transitions.rs
@@ -445,8 +445,6 @@ pub fn create_identity_update_transition_add_keys(
     rng: &mut StdRng,
     platform_version: &PlatformVersion,
 ) -> (StateTransition, (Identifier, Vec<IdentityPublicKey>)) {
-    identity.bump_revision();
-
     let start_id = (identity
         .public_keys()
         .values()
@@ -487,6 +485,8 @@ pub fn create_identity_update_transition_add_keys(
         None,
     )
     .expect("expected to create an AddKeys transition");
+
+    identity.bump_revision();
 
     (state_transition, (identity.id(), add_public_keys))
 }
@@ -539,7 +539,6 @@ pub fn create_identity_update_transition_disable_keys(
     rng: &mut StdRng,
     platform_version: &PlatformVersion,
 ) -> Option<StateTransition> {
-    identity.bump_revision();
     // we want to find keys that are not disabled
     let key_ids_we_could_disable = identity
         .public_keys()
@@ -596,6 +595,8 @@ pub fn create_identity_update_transition_disable_keys(
         None,
     )
     .expect("expected to create a DisableKeys transition");
+
+    identity.bump_revision();
 
     Some(state_transition)
 }


### PR DESCRIPTION
## Issue being fixed or feature implemented

  Implements automatic cleanup of expired compacted address balance entries. This is part of the getRecentAddressBalanceChanges and getRecentCompactedAddressBalanceChanges query feature. Compacted address balance entries are stored with a 24-hour expiration time and need to be cleaned up to prevent unbounded storage growth.

## What was done?

  - Added expiration time storage for compacted address balance ranges (stored as milliseconds timestamp)
  - Created cleanup_expired_address_balances function in the drive layer to remove expired compacted entries from GroveDB
  - Created cleanup_recent_block_storage_address_balances platform event wrapper in drive-abci
  - Added version fields (cleanup_recent_block_storage_address_balances) to drive and drive_abci version structs
  - Integrated cleanup call into run_block_proposal to run on every block
  - Added strategy test run_chain_cleanup_expired_compacted_address_balances that validates the full compaction and cleanup lifecycle

## How Has This Been Tested?

  Strategy test with 300 blocks and 20-minute block spacing validates:
  - Compaction: Multiple compactions occur at blocks 64, 128, 192, 256
  - Cleanup: Earlier compactions (blocks 64, 128, 192) expire after 72 blocks (24hrs / 20min) and are cleaned up
  - Result: Only the most recent compaction (from ~block 256) remains at block 300
  - Recent blocks: ~43 non-compacted blocks (258-300) remain available for querying

## Breaking Changes
Yes, will be activated in version 11

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [x] I have made corresponding changes to the documentation if needed

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic cleanup of expired compacted address-balance entries during block processing.
  * Time-aware compaction and expiration tracking for compacted address-balance snapshots; block timestamps are now used when storing/compacting balances.
  * Saved-block storage initializes expiration metadata during upgrades.

* **Tests**
  * New end-to-end tests for compacted vs recent balance queries, non-overlap guarantees, compaction behavior, and cleanup/expiration over time.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->