### PR TITLE
test(wasm-sdk): enable contract token and group check

### DIFF
--- a/packages/wasm-sdk/tests/unit/data-contract.spec.mjs
+++ b/packages/wasm-sdk/tests/unit/data-contract.spec.mjs
@@ -76,8 +76,7 @@ describe('DataContract', () => {
       contract.free();
     });
 
-    // TODO: enable test once an SDK fix to support this is merged
-    it.skip('should create a V1 contract from JSON and expose all properties including tokens and groups', async () => {
+    it('should create a V1 contract from JSON and expose all properties including tokens and groups', async () => {
       const contract = sdk.DataContract.fromJSON(
         contractFixtureV1,
         true,


### PR DESCRIPTION
## Issue being fixed or feature implemented

Re-enables a previously skipped test for V1 data contracts with tokens and groups in the WASM SDK unit tests. The test was disabled due to a serialization issue that has since been fixed. Related to #2803 and #2794.

## What was done?

- Enabled the `should create a V1 contract from JSON and expose all properties including tokens and groups` test in `packages/wasm-sdk/tests/unit/data-contract.spec.mjs`
- Removed the `it.skip()` and associated TODO comment

## How Has This Been Tested?

- The test passes locally after the serialization fix was merged
- Run with: `yarn workspace @dashevo/wasm-sdk test`

## Breaking Changes

None

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [ ] I have made corresponding changes to the documentation if needed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Restored and enabled a previously skipped test for V1 contract validation to ensure proper verification of contract properties.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->