### PR TITLE
fix(sdk): clamp address sync branch query depth to platform limits

### DIFF
--- a/packages/rs-sdk/src/platform/address_sync/mod.rs
+++ b/packages/rs-sdk/src/platform/address_sync/mod.rs
@@ -281,8 +281,8 @@ fn process_trunk_result<P: AddressProvider>(
 /// Get privacy-adjusted leaves to query.
 ///
 /// For leaves with count below min_privacy_count, find an ancestor with sufficient count.
-/// The depth is clamped to [min_query_depth, max_query_depth] to stay within platform limits.
-/// Returns None for leaves where the subtree is too small to query (depth < min after clamping).
+/// Returns a `Vec` of `(LeafBoundaryKey, LeafInfo, u8)` tuples where the `u8` is the query depth
+/// clamped to [`min_query_depth`, `max_query_depth`] to stay within platform limits.
 fn get_privacy_adjusted_leaves(
     tracker: &KeyLeafTracker,
     trunk_result: &GroveTrunkQueryResult,

--- a/packages/rs-sdk/src/platform/address_sync/mod.rs
+++ b/packages/rs-sdk/src/platform/address_sync/mod.rs
@@ -127,14 +127,30 @@ pub async fn sync_address_balances<P: AddressProvider>(
     process_trunk_result(&trunk_result, provider, &mut result, &mut tracker);
 
     // Step 3: Iterative branch queries
+    let min_query_depth = platform_version
+        .drive
+        .methods
+        .address_funds
+        .address_funds_query_min_depth;
+    let max_query_depth = platform_version
+        .drive
+        .methods
+        .address_funds
+        .address_funds_query_max_depth;
+
     let mut iterations = 0;
     while !tracker.is_empty() && iterations < config.max_iterations {
         iterations += 1;
         result.metrics.iterations = iterations;
 
         // Get leaves that need querying (apply privacy adjustment)
-        let leaves_to_query =
-            get_privacy_adjusted_leaves(&tracker, &trunk_result, config.min_privacy_count);
+        let leaves_to_query = get_privacy_adjusted_leaves(
+            &tracker,
+            &trunk_result,
+            config.min_privacy_count,
+            min_query_depth,
+            max_query_depth,
+        );
 
         if leaves_to_query.is_empty() {
             break;
@@ -265,10 +281,14 @@ fn process_trunk_result<P: AddressProvider>(
 /// Get privacy-adjusted leaves to query.
 ///
 /// For leaves with count below min_privacy_count, find an ancestor with sufficient count.
+/// The depth is clamped to [min_query_depth, max_query_depth] to stay within platform limits.
+/// Returns None for leaves where the subtree is too small to query (depth < min after clamping).
 fn get_privacy_adjusted_leaves(
     tracker: &KeyLeafTracker,
     trunk_result: &GroveTrunkQueryResult,
     min_privacy_count: u64,
+    min_query_depth: u8,
+    max_query_depth: u8,
 ) -> Vec<(LeafBoundaryKey, LeafInfo, u8)> {
     let active_leaves = tracker.active_leaves();
     let mut result = Vec::new();
@@ -277,11 +297,13 @@ fn get_privacy_adjusted_leaves(
     for (leaf_key, info) in active_leaves {
         let count = info.count.unwrap_or(0);
         let tree_depth = calculate_max_tree_depth_from_count(count);
+        // Clamp to allowed depth range
+        let clamped_depth = tree_depth.clamp(min_query_depth, max_query_depth);
 
         if count >= min_privacy_count {
             // Leaf has sufficient privacy, use it directly
             if seen_ancestors.insert(leaf_key.clone()) {
-                result.push((leaf_key, info, tree_depth));
+                result.push((leaf_key, info, clamped_depth));
             }
         } else {
             // Need to find an ancestor with more elements
@@ -293,14 +315,16 @@ fn get_privacy_adjusted_leaves(
                         hash: ancestor_hash,
                         count: Some(_count),
                     };
-                    // Reduce depth based on how many levels up we went
-                    let depth = tree_depth.saturating_sub(levels_up);
-                    result.push((ancestor_key, ancestor_info, depth.max(1)));
+                    // Reduce depth based on how many levels up we went, then clamp
+                    let depth = tree_depth
+                        .saturating_sub(levels_up)
+                        .clamp(min_query_depth, max_query_depth);
+                    result.push((ancestor_key, ancestor_info, depth));
                 }
             } else {
                 // No suitable ancestor found, use the leaf anyway
                 if seen_ancestors.insert(leaf_key.clone()) {
-                    result.push((leaf_key, info, tree_depth));
+                    result.push((leaf_key, info, clamped_depth));
                 }
             }
         }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The `get_privacy_adjusted_leaves` function was calculating tree depth from element count using `calculate_max_tree_depth_from_count()` but not clamping the result to the platform's allowed range.

This caused two failure modes:
- Large subtrees (many elements) → depth > 9 (e.g., depth 11)
- Small subtrees (few elements) → depth < 6 (e.g., depth 2)

Both cases were rejected by Platform with: `query: storage: drive: invalid input: depth X is outside the allowed range [6, 9]`

## What was done?
<!--- Describe your changes in detail -->
Read `address_funds_query_min_depth` and `address_funds_query_max_depth` from `platform_version` and clamp the calculated depth to this range before making branch queries.

The iterative nature of the sync algorithm handles depths outside the natural tree range:
- Clamping up (small tree): queries more depth than exists, returns entire subtree
- Clamping down (large tree): returns leaf_keys for deeper subtrees, queried in subsequent iterations

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
DET

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [x] I have made corresponding changes to the documentation if needed

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Updates**
  * Address synchronization now respects platform-driven minimum and maximum depth limits when selecting leaves, ensuring depths are clamped within the configured range.
  * Ancestor selection and fallback behavior have been adjusted for more consistent depth outcomes.
  * Documentation and messages updated to reflect the new depth-clamping behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->