### PR TITLE
feat(platform): update address expiration time from 1 day to 1 week

### DIFF
--- a/packages/rs-drive-abci/tests/strategy_tests/test_cases/address_tests.rs
+++ b/packages/rs-drive-abci/tests/strategy_tests/test_cases/address_tests.rs
@@ -2840,15 +2840,15 @@ mod tests {
             ..Default::default()
         };
 
-        // Use 20-minute block spacing to allow some entries to expire while others remain
-        // Compaction happens every 64 blocks, entries expire after 24 hours (1440 mins)
-        // With 20-min spacing, entries expire after 72 blocks (1440/20 = 72)
+        // Use 3-hour block spacing to allow some entries to expire while others remain
+        // Compaction happens every 64 blocks, entries expire after 1 week (168 hours)
+        // With 3-hour spacing, entries expire after 56 blocks (168/3 = 56)
         //
         // Timeline with 300 blocks:
-        // - Block 64: Compaction #1 → expires at block 136 → cleaned up
-        // - Block 128: Compaction #2 → expires at block 200 → cleaned up
-        // - Block 192: Compaction #3 → expires at block 264 → cleaned up
-        // - Block 256: Compaction #4 → expires at block 328 → still valid at 300!
+        // - Block 64: Compaction #1 → expires at block 120 → cleaned up
+        // - Block 128: Compaction #2 → expires at block 184 → cleaned up
+        // - Block 192: Compaction #3 → expires at block 248 → cleaned up
+        // - Block 256: Compaction #4 → expires at block 312 → still valid at 300!
         //
         // So at block 300, we should see 1 compacted entry (from block 256)
         let config = PlatformConfig {
@@ -2859,7 +2859,7 @@ mod tests {
                 verify_sum_trees: true,
                 ..Default::default()
             },
-            block_spacing_ms: 1_200_000, // 20 minutes
+            block_spacing_ms: 10_800_000, // 3 hours
             testing_configs: PlatformTestConfig {
                 disable_checkpoints: false,
                 ..PlatformTestConfig::default_minimal_verifications()
@@ -2944,13 +2944,13 @@ mod tests {
                 let result = v0.result.expect("expected a result");
                 match result {
                     get_recent_compacted_address_balance_changes_response_v0::Result::CompactedAddressBalanceUpdateEntries(entries) => {
-                        // With 20-minute block spacing over 300 blocks:
+                        // With 3-hour block spacing over 300 blocks:
                         // - Compactions at blocks 64, 128, 192, 256
-                        // - Entries expire 72 blocks after creation (24hrs / 20mins = 72 blocks)
-                        // - Block 64 entry expires at 136 → cleaned up
-                        // - Block 128 entry expires at 200 → cleaned up
-                        // - Block 192 entry expires at 264 → cleaned up
-                        // - Block 256 entry expires at 328 → still valid at 300!
+                        // - Entries expire 56 blocks after creation (1 week / 3hrs = 56 blocks)
+                        // - Block 64 entry expires at 120 → cleaned up
+                        // - Block 128 entry expires at 184 → cleaned up
+                        // - Block 192 entry expires at 248 → cleaned up
+                        // - Block 256 entry expires at 312 → still valid at 300!
                         //
                         // We expect exactly 1 compacted entry to remain.
                         // This proves both compaction AND cleanup are working correctly.

--- a/packages/rs-drive/src/drive/saved_block_transactions/compact_address_balances/mod.rs
+++ b/packages/rs-drive/src/drive/saved_block_transactions/compact_address_balances/mod.rs
@@ -9,8 +9,8 @@ use grovedb::TransactionArg;
 use platform_version::version::PlatformVersion;
 use std::collections::BTreeMap;
 
-/// One day in milliseconds (used for compacted address expiration)
-pub const ONE_DAY_IN_MS: u64 = 24 * 60 * 60 * 1000;
+/// One week in milliseconds (used for compacted address expiration)
+pub const ONE_WEEK_IN_MS: u64 = 7 * 24 * 60 * 60 * 1000;
 
 impl Drive {
     /// Compacts address balance changes from recent blocks, including the current block,
@@ -20,7 +20,7 @@ impl Drive {
     /// with the provided current block's address balances, and stores the result in
     /// the compacted address balances tree with a (start_block, end_block) key.
     ///
-    /// Also stores the expiration time (current block time + 1 day) in the
+    /// Also stores the expiration time (current block time + 1 week) in the
     /// compacted addresses expiration time tree.
     ///
     /// # Arguments

--- a/packages/rs-drive/src/drive/saved_block_transactions/compact_address_balances/v0/mod.rs
+++ b/packages/rs-drive/src/drive/saved_block_transactions/compact_address_balances/v0/mod.rs
@@ -1,4 +1,4 @@
-use crate::drive::saved_block_transactions::compact_address_balances::ONE_DAY_IN_MS;
+use crate::drive::saved_block_transactions::compact_address_balances::ONE_WEEK_IN_MS;
 use crate::drive::Drive;
 use crate::error::Error;
 use crate::util::batch::grovedb_op_batch::GroveDbOpBatchV0Methods;
@@ -21,7 +21,7 @@ impl Drive {
     /// and stores the result in the compacted address balances tree
     /// with a (start_block, end_block) key.
     ///
-    /// Also stores the expiration time (current block time + 1 day) in the
+    /// Also stores the expiration time (current block time + 1 week) in the
     /// compacted addresses expiration time tree with the same (start_block, end_block) key.
     ///
     /// Returns the range of blocks that were compacted (start_block, end_block).
@@ -154,8 +154,8 @@ impl Drive {
             Element::new_item(serialized),
         );
 
-        // Calculate expiration time (current block time + 1 day)
-        let expiration_time_ms = current_block_time_ms.saturating_add(ONE_DAY_IN_MS);
+        // Calculate expiration time (current block time + 1 week)
+        let expiration_time_ms = current_block_time_ms.saturating_add(ONE_WEEK_IN_MS);
         let expiration_key = expiration_time_ms.to_be_bytes().to_vec();
 
         // Check if an entry with this expiration time already exists

--- a/packages/rs-drive/src/drive/saved_block_transactions/store_address_balances/v0/mod.rs
+++ b/packages/rs-drive/src/drive/saved_block_transactions/store_address_balances/v0/mod.rs
@@ -880,7 +880,7 @@ mod tests {
 
     #[test]
     fn should_store_expiration_time_when_compacting() {
-        use crate::drive::saved_block_transactions::compact_address_balances::ONE_DAY_IN_MS;
+        use crate::drive::saved_block_transactions::compact_address_balances::ONE_WEEK_IN_MS;
         use crate::drive::saved_block_transactions::COMPACTED_ADDRESSES_EXPIRATION_TIME_KEY_U8;
         use grovedb::query_result_type::QueryResultType;
         use grovedb::{PathQuery, Query, SizedQuery};
@@ -941,15 +941,15 @@ mod tests {
         let key_elements = results.to_key_elements();
         assert_eq!(key_elements.len(), 1, "should have 1 expiration entry");
 
-        // Verify the key is the expiration time (block_time + 1 day)
+        // Verify the key is the expiration time (block_time + 1 week)
         let (key, element) = &key_elements[0];
         assert_eq!(key.len(), 8, "key should be 8 bytes (u64 expiration time)");
 
         let expiration_time = u64::from_be_bytes(key.as_slice().try_into().unwrap());
-        let expected_expiration = block_time_ms + ONE_DAY_IN_MS;
+        let expected_expiration = block_time_ms + ONE_WEEK_IN_MS;
         assert_eq!(
             expiration_time, expected_expiration,
-            "key should be expiration time (block_time + 1 day)"
+            "key should be expiration time (block_time + 1 week)"
         );
 
         // Verify the value is a vec of block ranges
@@ -970,7 +970,7 @@ mod tests {
 
     #[test]
     fn should_append_to_expiration_time_when_same_time() {
-        use crate::drive::saved_block_transactions::compact_address_balances::ONE_DAY_IN_MS;
+        use crate::drive::saved_block_transactions::compact_address_balances::ONE_WEEK_IN_MS;
         use crate::drive::saved_block_transactions::COMPACTED_ADDRESSES_EXPIRATION_TIME_KEY_U8;
         use grovedb::query_result_type::QueryResultType;
         use grovedb::{PathQuery, Query, SizedQuery};
@@ -1063,7 +1063,7 @@ mod tests {
         // Verify the key is the expiration time
         let (key, element) = &key_elements[0];
         let expiration_time = u64::from_be_bytes(key.as_slice().try_into().unwrap());
-        let expected_expiration = block_time_ms + ONE_DAY_IN_MS;
+        let expected_expiration = block_time_ms + ONE_WEEK_IN_MS;
         assert_eq!(expiration_time, expected_expiration);
 
         // Verify the value contains BOTH block ranges


### PR DESCRIPTION
## Issue being fixed or feature implemented
The expiration time for compacted address balances was previously set to 1 day. This change updates it to 1 week to allow for longer retention of address balance changes.

## What was done?
- Updated the expiration time constant from 1 day to 1 week across multiple files.
- Adjusted related comments and test cases to reflect the new expiration duration.
- Modified block spacing logic in tests to align with the new expiration timeframe.

## How Has This Been Tested?
All relevant tests have been updated and executed to ensure that the new expiration logic functions correctly and that the expected outcomes are met.

## Breaking Changes
None

## Checklist
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests

  **For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated system timing parameters and test assertions for address balance processing and block intervals.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->