### PR TITLE
fix(sdk)!: failed address sync on invalid proof 

### DIFF
--- a/packages/rs-drive-proof-verifier/src/proof.rs
+++ b/packages/rs-drive-proof-verifier/src/proof.rs
@@ -1083,6 +1083,32 @@ impl FromProof<platform::GetAddressesTrunkStateRequest> for GroveTrunkQueryResul
     }
 }
 
+impl FromProof<platform::GetAddressesTrunkStateRequest> for PlatformAddressTrunkState {
+    type Request = platform::GetAddressesTrunkStateRequest;
+    type Response = platform::GetAddressesTrunkStateResponse;
+
+    fn maybe_from_proof_with_metadata<'a, I: Into<Self::Request>, O: Into<Self::Response>>(
+        request: I,
+        response: O,
+        network: Network,
+        platform_version: &PlatformVersion,
+        provider: &'a dyn ContextProvider,
+    ) -> Result<(Option<Self>, ResponseMetadata, Proof), Error>
+    where
+        PlatformAddressTrunkState: 'a,
+    {
+        let (result, metadata, proof) = GroveTrunkQueryResult::maybe_from_proof_with_metadata(
+            request,
+            response,
+            network,
+            platform_version,
+            provider,
+        )?;
+
+        Ok((result.map(PlatformAddressTrunkState), metadata, proof))
+    }
+}
+
 impl FromProof<platform::GetDataContractRequest> for DataContract {
     type Request = platform::GetDataContractRequest;
     type Response = platform::GetDataContractResponse;

--- a/packages/rs-drive-proof-verifier/src/types.rs
+++ b/packages/rs-drive-proof-verifier/src/types.rs
@@ -724,3 +724,38 @@ impl RecentCompactedAddressBalanceChanges {
         self.0
     }
 }
+
+/// Platform address trunk state for address balance synchronization.
+///
+/// This is a newtype wrapper around [`GroveTrunkQueryResult`](drive::grovedb::GroveTrunkQueryResult)
+/// that represents the result of querying the trunk (top levels) of the address funds tree.
+///
+/// The trunk query returns:
+/// - Elements (addresses with balances) found at the queried depth
+/// - Leaf boundary keys that indicate subtrees requiring further branch queries
+///
+/// This type implements [`FromProof`](crate::FromProof) by delegating to the underlying
+/// `GroveTrunkQueryResult` implementation.
+#[derive(Debug)]
+pub struct PlatformAddressTrunkState(pub drive::grovedb::GroveTrunkQueryResult);
+
+impl PlatformAddressTrunkState {
+    /// Get the inner `GroveTrunkQueryResult`.
+    pub fn into_inner(self) -> drive::grovedb::GroveTrunkQueryResult {
+        self.0
+    }
+}
+
+impl std::ops::Deref for PlatformAddressTrunkState {
+    type Target = drive::grovedb::GroveTrunkQueryResult;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl std::ops::DerefMut for PlatformAddressTrunkState {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}

--- a/packages/rs-sdk-ffi/src/address_sync/mod.rs
+++ b/packages/rs-sdk-ffi/src/address_sync/mod.rs
@@ -14,7 +14,7 @@ use crate::sdk::SDKWrapper;
 use crate::types::SDKHandle;
 use crate::{DashSDKError, DashSDKErrorCode, DashSDKResult, FFIError};
 use dash_sdk::platform::address_sync::{AddressSyncConfig, AddressSyncResult};
-use rs_dapi_client::RequestSettings;
+use dash_sdk::RequestSettings;
 use tracing::{debug, error, info};
 
 /// Synchronize address balances using trunk/branch chunk queries.

--- a/packages/rs-sdk-ffi/src/address_sync/mod.rs
+++ b/packages/rs-sdk-ffi/src/address_sync/mod.rs
@@ -14,6 +14,7 @@ use crate::sdk::SDKWrapper;
 use crate::types::SDKHandle;
 use crate::{DashSDKError, DashSDKErrorCode, DashSDKResult, FFIError};
 use dash_sdk::platform::address_sync::{AddressSyncConfig, AddressSyncResult};
+use rs_dapi_client::RequestSettings;
 use tracing::{debug, error, info};
 
 /// Synchronize address balances using trunk/branch chunk queries.
@@ -56,6 +57,7 @@ pub unsafe extern "C" fn dash_sdk_sync_address_balances(
             min_privacy_count: (*config).min_privacy_count,
             max_concurrent_requests: (*config).max_concurrent_requests as usize,
             max_iterations: (*config).max_iterations as usize,
+            request_settings: RequestSettings::default(),
         })
     };
 
@@ -134,6 +136,7 @@ pub unsafe extern "C" fn dash_sdk_sync_address_balances_with_result(
             min_privacy_count: (*config).min_privacy_count,
             max_concurrent_requests: (*config).max_concurrent_requests as usize,
             max_iterations: (*config).max_iterations as usize,
+            request_settings: RequestSettings::default(),
         })
     };
 

--- a/packages/rs-sdk/src/mock/requests.rs
+++ b/packages/rs-sdk/src/mock/requests.rs
@@ -35,9 +35,10 @@ use drive_proof_verifier::types::token_status::TokenStatuses;
 use drive::grovedb::GroveTrunkQueryResult;
 use drive_proof_verifier::types::{
     AddressInfo, Contenders, ContestedResources, CurrentQuorumsInfo, ElementFetchRequestItem,
-    IdentityBalanceAndRevision, IndexMap, MasternodeProtocolVote, PrefundedSpecializedBalance,
-    ProposerBlockCounts, RecentAddressBalanceChanges, RecentCompactedAddressBalanceChanges,
-    RetrievedValues, TotalCreditsInPlatform, VotePollsGroupedByTimestamp, Voters,
+    IdentityBalanceAndRevision, IndexMap, MasternodeProtocolVote, PlatformAddressTrunkState,
+    PrefundedSpecializedBalance, ProposerBlockCounts, RecentAddressBalanceChanges,
+    RecentCompactedAddressBalanceChanges, RetrievedValues, TotalCreditsInPlatform,
+    VotePollsGroupedByTimestamp, Voters,
 };
 use std::{collections::BTreeMap, hash::Hash};
 
@@ -519,5 +520,20 @@ impl MockResponse for GroveTrunkQueryResult {
         Self: Sized,
     {
         unimplemented!("GroveTrunkQueryResult does not support mock deserialization - the Tree type is not serializable")
+    }
+}
+
+/// MockResponse for PlatformAddressTrunkState - panics when called because the underlying
+/// Tree type doesn't support serialization. Address sync operations should not be mocked.
+impl MockResponse for PlatformAddressTrunkState {
+    fn mock_serialize(&self, _sdk: &MockDashPlatformSdk) -> Vec<u8> {
+        unimplemented!("PlatformAddressTrunkState does not support mock serialization - the Tree type is not serializable")
+    }
+
+    fn mock_deserialize(_sdk: &MockDashPlatformSdk, _buf: &[u8]) -> Self
+    where
+        Self: Sized,
+    {
+        unimplemented!("PlatformAddressTrunkState does not support mock deserialization - the Tree type is not serializable")
     }
 }

--- a/packages/rs-sdk/src/platform/address_sync/mod.rs
+++ b/packages/rs-sdk/src/platform/address_sync/mod.rs
@@ -232,9 +232,7 @@ async fn execute_trunk_query(
     metrics.trunk_queries += 1;
 
     let trunk_state = trunk_state.ok_or_else(|| {
-        Error::Protocol(dpp::ProtocolError::CorruptedCodeExecution(
-            "Trunk query returned no state".to_string(),
-        ))
+        Error::InvalidProvedResponse("Trunk query returned no state".to_string())
     })?;
 
     metrics.total_elements_seen += trunk_state.elements.len();
@@ -432,9 +430,7 @@ async fn execute_single_branch_query(
                 Some(get_addresses_branch_state_response::Version::V0(v0)) => v0.merk_proof,
                 None => {
                     return Err(ExecutionError {
-                        inner: Error::Protocol(dpp::ProtocolError::CorruptedCodeExecution(
-                            "Missing version in branch response".to_string(),
-                        )),
+                        inner: Error::Proof(drive_proof_verifier::Error::EmptyVersion),
                         address: Some(address),
                         retries,
                     });

--- a/packages/rs-sdk/src/platform/address_sync/mod.rs
+++ b/packages/rs-sdk/src/platform/address_sync/mod.rs
@@ -47,11 +47,12 @@ pub use types::{
 };
 
 use crate::error::Error;
+use crate::platform::Fetch;
+use crate::sync::retry;
 use crate::Sdk;
 use dapi_grpc::platform::v0::{
     get_addresses_branch_state_request, get_addresses_branch_state_response,
-    get_addresses_trunk_state_request, GetAddressesBranchStateRequest,
-    GetAddressesTrunkStateRequest,
+    GetAddressesBranchStateRequest,
 };
 use dpp::version::PlatformVersion;
 use drive::drive::Drive;
@@ -59,8 +60,11 @@ use drive::grovedb::{
     calculate_max_tree_depth_from_count, Element, GroveBranchQueryResult, GroveTrunkQueryResult,
     LeafInfo,
 };
+use drive_proof_verifier::types::PlatformAddressTrunkState;
 use futures::stream::{FuturesUnordered, StreamExt};
-use rs_dapi_client::{DapiRequest, IntoInner, RequestSettings};
+use rs_dapi_client::{
+    DapiRequest, ExecutionError, ExecutionResponse, InnerInto, IntoInner, RequestSettings,
+};
 use std::collections::{BTreeSet, HashMap};
 use tracing::{debug, trace, warn};
 use tracker::KeyLeafTracker;
@@ -114,7 +118,8 @@ pub async fn sync_address_balances<P: AddressProvider>(
     }
 
     // Step 1: Execute trunk query
-    let (trunk_result, checkpoint_height) = execute_trunk_query(sdk, &mut result.metrics).await?;
+    let (trunk_result, checkpoint_height) =
+        execute_trunk_query(sdk, config.request_settings, &mut result.metrics).await?;
     result.checkpoint_height = checkpoint_height;
 
     trace!(
@@ -171,6 +176,7 @@ pub async fn sync_address_balances<P: AddressProvider>(
             checkpoint_height,
             &mut result.metrics,
             config.max_concurrent_requests,
+            config.request_settings,
             platform_version,
         )
         .await?;
@@ -217,27 +223,13 @@ pub async fn sync_address_balances<P: AddressProvider>(
 /// Execute the trunk query and return the verified result.
 async fn execute_trunk_query(
     sdk: &Sdk,
+    settings: RequestSettings,
     metrics: &mut AddressSyncMetrics,
 ) -> Result<(GroveTrunkQueryResult, u64), Error> {
-    let request = GetAddressesTrunkStateRequest {
-        version: Some(get_addresses_trunk_state_request::Version::V0(
-            get_addresses_trunk_state_request::GetAddressesTrunkStateRequestV0 {},
-        )),
-    };
-
-    let response: dapi_grpc::platform::v0::GetAddressesTrunkStateResponse = request
-        .execute(sdk, RequestSettings::default())
-        .await?
-        .into_inner();
+    let (trunk_state, metadata) =
+        PlatformAddressTrunkState::fetch_with_metadata(sdk, (), Some(settings)).await?;
 
     metrics.trunk_queries += 1;
-
-    // Parse and verify the proof using the standard SDK pattern
-    let (trunk_state, metadata) = sdk
-        .parse_proof_with_metadata::<GetAddressesTrunkStateRequest, GroveTrunkQueryResult>(
-            request, response,
-        )
-        .await?;
 
     let trunk_state = trunk_state.ok_or_else(|| {
         Error::Protocol(dpp::ProtocolError::CorruptedCodeExecution(
@@ -247,7 +239,7 @@ async fn execute_trunk_query(
 
     metrics.total_elements_seen += trunk_state.elements.len();
 
-    Ok((trunk_state, metadata.height))
+    Ok((trunk_state.into_inner(), metadata.height))
 }
 
 /// Process the trunk query result.
@@ -341,6 +333,7 @@ async fn execute_branch_queries(
     checkpoint_height: u64,
     metrics: &mut AddressSyncMetrics,
     max_concurrent: usize,
+    settings: RequestSettings,
     platform_version: &PlatformVersion,
 ) -> Result<Vec<(LeafBoundaryKey, GroveBranchQueryResult)>, Error> {
     let mut futures = FuturesUnordered::new();
@@ -358,6 +351,7 @@ async fn execute_branch_queries(
                 depth_u32,
                 expected_hash,
                 checkpoint_height,
+                settings,
                 platform_version,
             )
             .await
@@ -397,13 +391,17 @@ async fn execute_branch_queries(
     Ok(results)
 }
 
-/// Execute a single branch query.
+/// Execute a single branch query with retry logic.
+///
+/// If proof verification fails, the request will be retried with a different node
+/// according to the retry settings.
 async fn execute_single_branch_query(
     sdk: &Sdk,
     key: LeafBoundaryKey,
     depth: u32,
     expected_hash: [u8; 32],
     checkpoint_height: u64,
+    settings: RequestSettings,
     platform_version: &PlatformVersion,
 ) -> Result<GroveBranchQueryResult, Error> {
     let request = GetAddressesBranchStateRequest {
@@ -416,31 +414,58 @@ async fn execute_single_branch_query(
         )),
     };
 
-    let response: dapi_grpc::platform::v0::GetAddressesBranchStateResponse = request
-        .execute(sdk, RequestSettings::default())
-        .await?
-        .into_inner();
+    let fut = |settings: RequestSettings| {
+        let request = request.clone();
+        let key = key.clone();
+        async move {
+            let ExecutionResponse {
+                address,
+                retries,
+                inner: response,
+            } = request
+                .execute(sdk, settings)
+                .await
+                .map_err(|execution_error| execution_error.inner_into())?;
 
-    // Extract merk proof
-    let proof_bytes = match response.version {
-        Some(get_addresses_branch_state_response::Version::V0(v0)) => v0.merk_proof,
-        None => {
-            return Err(Error::Protocol(dpp::ProtocolError::CorruptedCodeExecution(
-                "Missing version in branch response".to_string(),
-            )));
+            // Extract merk proof
+            let proof_bytes = match response.version {
+                Some(get_addresses_branch_state_response::Version::V0(v0)) => v0.merk_proof,
+                None => {
+                    return Err(ExecutionError {
+                        inner: Error::Protocol(dpp::ProtocolError::CorruptedCodeExecution(
+                            "Missing version in branch response".to_string(),
+                        )),
+                        address: Some(address),
+                        retries,
+                    });
+                }
+            };
+
+            // Verify the proof
+            let branch_result = Drive::verify_address_funds_branch_query(
+                &proof_bytes,
+                key,
+                depth as u8,
+                expected_hash,
+                platform_version,
+            )
+            .map_err(|e| ExecutionError {
+                inner: e.into(),
+                address: Some(address.clone()),
+                retries,
+            })?;
+
+            Ok(ExecutionResponse {
+                inner: branch_result,
+                address,
+                retries,
+            })
         }
     };
 
-    // Verify the proof
-    let branch_result = Drive::verify_address_funds_branch_query(
-        &proof_bytes,
-        key,
-        depth as u8,
-        expected_hash,
-        platform_version,
-    )?;
+    let settings = sdk.dapi_client_settings.override_by(settings);
 
-    Ok(branch_result)
+    retry(sdk.address_list(), settings, fut).await.into_inner()
 }
 
 /// Process a branch query result.

--- a/packages/rs-sdk/src/platform/address_sync/mod.rs
+++ b/packages/rs-sdk/src/platform/address_sync/mod.rs
@@ -231,9 +231,8 @@ async fn execute_trunk_query(
 
     metrics.trunk_queries += 1;
 
-    let trunk_state = trunk_state.ok_or_else(|| {
-        Error::InvalidProvedResponse("Trunk query returned no state".to_string())
-    })?;
+    let trunk_state = trunk_state
+        .ok_or_else(|| Error::InvalidProvedResponse("Trunk query returned no state".to_string()))?;
 
     metrics.total_elements_seen += trunk_state.elements.len();
 

--- a/packages/rs-sdk/src/platform/address_sync/types.rs
+++ b/packages/rs-sdk/src/platform/address_sync/types.rs
@@ -1,6 +1,7 @@
 //! Types for address synchronization.
 
 use dpp::fee::Credits;
+use rs_dapi_client::RequestSettings;
 use std::collections::{BTreeMap, BTreeSet};
 
 /// A 32-byte address key that we're searching for in the address funds tree.
@@ -42,6 +43,9 @@ pub struct AddressSyncConfig {
     ///
     /// Default: 50
     pub max_iterations: usize,
+
+    /// Request settings for undergoing address sync queries.
+    pub request_settings: RequestSettings,
 }
 
 impl Default for AddressSyncConfig {
@@ -50,6 +54,7 @@ impl Default for AddressSyncConfig {
             min_privacy_count: 32,
             max_concurrent_requests: 10,
             max_iterations: 50,
+            request_settings: RequestSettings::default(),
         }
     }
 }

--- a/packages/rs-sdk/src/platform/fetch.rs
+++ b/packages/rs-sdk/src/platform/fetch.rs
@@ -324,3 +324,7 @@ impl Fetch for drive_proof_verifier::types::RecentAddressBalanceChanges {
 impl Fetch for drive_proof_verifier::types::RecentCompactedAddressBalanceChanges {
     type Request = platform_proto::GetRecentCompactedAddressBalanceChangesRequest;
 }
+
+impl Fetch for drive_proof_verifier::types::PlatformAddressTrunkState {
+    type Request = platform_proto::GetAddressesTrunkStateRequest;
+}

--- a/packages/rs-sdk/src/platform/query.rs
+++ b/packages/rs-sdk/src/platform/query.rs
@@ -17,10 +17,10 @@ use dapi_grpc::platform::v0::get_status_request::GetStatusRequestV0;
 use dapi_grpc::platform::v0::get_total_credits_in_platform_request::GetTotalCreditsInPlatformRequestV0;
 use dapi_grpc::platform::v0::{
     self as proto, get_address_info_request, get_addresses_infos_request,
-    get_current_quorums_info_request, get_identity_keys_request,
+    get_addresses_trunk_state_request, get_current_quorums_info_request, get_identity_keys_request,
     get_identity_keys_request::GetIdentityKeysRequestV0, get_path_elements_request,
     get_total_credits_in_platform_request, AllKeys, GetAddressInfoRequest,
-    GetAddressesInfosRequest, GetContestedResourceVoteStateRequest,
+    GetAddressesInfosRequest, GetAddressesTrunkStateRequest, GetContestedResourceVoteStateRequest,
     GetContestedResourceVotersForIdentityRequest, GetContestedResourcesRequest,
     GetCurrentQuorumsInfoRequest, GetEpochsInfoRequest, GetEvonodesProposedEpochBlocksByIdsRequest,
     GetEvonodesProposedEpochBlocksByRangeRequest, GetIdentityKeysRequest, GetPathElementsRequest,
@@ -295,6 +295,20 @@ impl Query<GetAddressesInfosRequest> for BTreeSet<PlatformAddress> {
         Ok(GetAddressesInfosRequest {
             version: Some(get_addresses_infos_request::Version::V0(
                 get_addresses_infos_request::GetAddressesInfosRequestV0 { addresses, prove },
+            )),
+        })
+    }
+}
+
+impl Query<GetAddressesTrunkStateRequest> for () {
+    fn query(self, prove: bool) -> Result<GetAddressesTrunkStateRequest, Error> {
+        if !prove {
+            unimplemented!("queries without proofs are not supported yet");
+        }
+
+        Ok(GetAddressesTrunkStateRequest {
+            version: Some(get_addresses_trunk_state_request::Version::V0(
+                get_addresses_trunk_state_request::GetAddressesTrunkStateRequestV0 {},
             )),
         })
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
During address syn, invalid proof will lead to sync failure

## What was done?
<!--- Describe your changes in detail -->
- Implemented `Fetch` for `PlatfromAddressTrunkState`
- Implemented retry logic in case if proof verification failed

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
With existing tests

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
`AddressSyncMetrics` struct is changed.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [x] I have made corresponding changes to the documentation if needed

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Adds a dedicated trunk-state response type for address trunk queries and exposes the corresponding public request type.
  * Fetch support added for the new trunk-state type.

* **Refactor**
  * Per-request settings now propagate through trunk and branch flows; execution uses a unified, retry-aware path for improved resilience.
  * Address sync config now includes request settings with a sensible default.

* **Tests/Mocks**
  * Mocks updated to include the new trunk-state type (marked non-serializable in mock flows).

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->