### PR TITLE
feat(platform)!: add block-aware credit operations to manage address balance changes

### DIFF
--- a/packages/dapi-grpc/protos/platform/v0/platform.proto
+++ b/packages/dapi-grpc/protos/platform/v0/platform.proto
@@ -2072,10 +2072,35 @@ message GetRecentAddressBalanceChangesResponse {
   oneof version { GetRecentAddressBalanceChangesResponseV0 v0 = 1; }
 }
 
+// Entry for block height to credits mapping in AddToCreditsOperations
+message BlockHeightCreditEntry {
+  uint64 block_height = 1 [ jstype = JS_STRING ];
+  uint64 credits = 2 [ jstype = JS_STRING ];
+}
+
+// Compacted address balance change supporting block-aware credit operations
+// For SetCredits: the final balance value
+// For AddToCreditsOperations: preserves individual adds with their block heights
+message CompactedAddressBalanceChange {
+  bytes address = 1;
+  oneof operation {
+    // The address balance was set to this value (overwrites previous)
+    uint64 set_credits = 2 [ jstype = JS_STRING ];
+    // Individual add-to-credits operations by block height (preserved for partial sync)
+    AddToCreditsOperations add_to_credits_operations = 3;
+  }
+}
+
+// A collection of add-to-credits operations, each tagged with block height
+// This allows clients to determine which adds to apply based on their sync height
+message AddToCreditsOperations {
+  repeated BlockHeightCreditEntry entries = 1;
+}
+
 message CompactedBlockAddressBalanceChanges {
   uint64 start_block_height = 1 [ jstype = JS_STRING ];
   uint64 end_block_height = 2 [ jstype = JS_STRING ];
-  repeated AddressBalanceChange changes = 3;
+  repeated CompactedAddressBalanceChange changes = 3;
 }
 
 message CompactedAddressBalanceUpdateEntries {

--- a/packages/rs-dpp/src/balances/credits.rs
+++ b/packages/rs-dpp/src/balances/credits.rs
@@ -8,8 +8,10 @@
 //! and unlocking dash on the payment chain.
 //!
 
+use crate::prelude::BlockHeight;
 use crate::ProtocolError;
 use integer_encoding::VarInt;
+use std::collections::BTreeMap;
 use std::convert::TryFrom;
 
 /// Duffs type
@@ -46,6 +48,71 @@ pub enum CreditOperation {
     SetCredits(Credits),
     /// We are adding to credits
     AddToCredits(Credits),
+}
+
+/// An enum for credit operations in compacted address blobs
+#[derive(Debug, Clone, PartialEq, Eq, bincode::Encode, bincode::Decode)]
+pub enum BlockAwareCreditOperation {
+    /// We are setting credit amounts - the final value after all operations
+    SetCredits(Credits),
+    /// We are adding to credits - individual additions by block height
+    AddToCreditsOperations(BTreeMap<BlockHeight, Credits>),
+}
+
+impl BlockAwareCreditOperation {
+    /// Merges a CreditOperation from a specific block height into this BlockAwareCreditOperation.
+    ///
+    /// The merge logic:
+    /// - Once a SetCredits is encountered, the result becomes SetCredits with the final computed value
+    /// - If only AddToCredits operations, they are preserved with their block heights
+    pub fn merge(&mut self, block_height: BlockHeight, operation: &CreditOperation) {
+        match (self, operation) {
+            // Current is SetCredits, new is SetCredits -> take new value
+            (
+                BlockAwareCreditOperation::SetCredits(current),
+                CreditOperation::SetCredits(new_val),
+            ) => {
+                *current = *new_val;
+            }
+            // Current is SetCredits, new is AddToCredits -> add to current value
+            (
+                BlockAwareCreditOperation::SetCredits(current),
+                CreditOperation::AddToCredits(add_val),
+            ) => {
+                *current = current.saturating_add(*add_val);
+            }
+            // Current is AddToCredits, new is SetCredits -> compute total of adds before this block + set value
+            (
+                this @ BlockAwareCreditOperation::AddToCreditsOperations(_),
+                CreditOperation::SetCredits(new_val),
+            ) => {
+                // When we see a SetCredits, all previous AddToCredits don't matter for the final value
+                // The SetCredits establishes the baseline
+                *this = BlockAwareCreditOperation::SetCredits(*new_val);
+            }
+            // Current is AddToCredits, new is AddToCredits -> add to map
+            (
+                BlockAwareCreditOperation::AddToCreditsOperations(map),
+                CreditOperation::AddToCredits(add_val),
+            ) => {
+                map.entry(block_height)
+                    .and_modify(|existing| *existing = existing.saturating_add(*add_val))
+                    .or_insert(*add_val);
+            }
+        }
+    }
+
+    /// Creates a new BlockAwareCreditOperation from a CreditOperation at a specific block height.
+    pub fn from_operation(block_height: BlockHeight, operation: &CreditOperation) -> Self {
+        match operation {
+            CreditOperation::SetCredits(value) => BlockAwareCreditOperation::SetCredits(*value),
+            CreditOperation::AddToCredits(value) => {
+                let mut map = BTreeMap::new();
+                map.insert(block_height, *value);
+                BlockAwareCreditOperation::AddToCreditsOperations(map)
+            }
+        }
+    }
 }
 
 impl CreditOperation {
@@ -131,5 +198,164 @@ impl Creditable for SignedCredits {
 
     fn to_vec_bytes(&self) -> Vec<u8> {
         self.encode_var_vec()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    mod block_aware_credit_operation {
+        use super::*;
+
+        #[test]
+        fn from_operation_set_credits() {
+            let op =
+                BlockAwareCreditOperation::from_operation(100, &CreditOperation::SetCredits(1000));
+            assert_eq!(op, BlockAwareCreditOperation::SetCredits(1000));
+        }
+
+        #[test]
+        fn from_operation_add_to_credits() {
+            let op =
+                BlockAwareCreditOperation::from_operation(100, &CreditOperation::AddToCredits(500));
+            let expected: BTreeMap<BlockHeight, Credits> = [(100, 500)].into_iter().collect();
+            assert_eq!(
+                op,
+                BlockAwareCreditOperation::AddToCreditsOperations(expected)
+            );
+        }
+
+        #[test]
+        fn merge_set_then_set_takes_latest() {
+            let mut op = BlockAwareCreditOperation::SetCredits(1000);
+            op.merge(101, &CreditOperation::SetCredits(2000));
+            assert_eq!(op, BlockAwareCreditOperation::SetCredits(2000));
+        }
+
+        #[test]
+        fn merge_set_then_add_adds_to_set() {
+            let mut op = BlockAwareCreditOperation::SetCredits(1000);
+            op.merge(101, &CreditOperation::AddToCredits(500));
+            assert_eq!(op, BlockAwareCreditOperation::SetCredits(1500));
+        }
+
+        #[test]
+        fn merge_set_then_multiple_adds() {
+            let mut op = BlockAwareCreditOperation::SetCredits(1000);
+            op.merge(101, &CreditOperation::AddToCredits(500));
+            op.merge(102, &CreditOperation::AddToCredits(300));
+            assert_eq!(op, BlockAwareCreditOperation::SetCredits(1800));
+        }
+
+        #[test]
+        fn merge_add_then_set_becomes_set() {
+            let mut op =
+                BlockAwareCreditOperation::from_operation(100, &CreditOperation::AddToCredits(500));
+            op.merge(101, &CreditOperation::SetCredits(2000));
+            assert_eq!(op, BlockAwareCreditOperation::SetCredits(2000));
+        }
+
+        #[test]
+        fn merge_add_then_add_preserves_block_heights() {
+            let mut op =
+                BlockAwareCreditOperation::from_operation(100, &CreditOperation::AddToCredits(500));
+            op.merge(101, &CreditOperation::AddToCredits(300));
+            op.merge(102, &CreditOperation::AddToCredits(200));
+
+            let expected: BTreeMap<BlockHeight, Credits> =
+                [(100, 500), (101, 300), (102, 200)].into_iter().collect();
+            assert_eq!(
+                op,
+                BlockAwareCreditOperation::AddToCreditsOperations(expected)
+            );
+        }
+
+        #[test]
+        fn merge_multiple_adds_at_same_block_combines() {
+            let mut op =
+                BlockAwareCreditOperation::from_operation(100, &CreditOperation::AddToCredits(500));
+            op.merge(100, &CreditOperation::AddToCredits(300)); // Same block
+
+            let expected: BTreeMap<BlockHeight, Credits> = [(100, 800)].into_iter().collect();
+            assert_eq!(
+                op,
+                BlockAwareCreditOperation::AddToCreditsOperations(expected)
+            );
+        }
+
+        #[test]
+        fn merge_add_then_set_then_add() {
+            // AddToCredits(500) at block 100
+            let mut op =
+                BlockAwareCreditOperation::from_operation(100, &CreditOperation::AddToCredits(500));
+            // SetCredits(1000) at block 101 - wipes out the add
+            op.merge(101, &CreditOperation::SetCredits(1000));
+            // AddToCredits(200) at block 102 - adds to the set
+            op.merge(102, &CreditOperation::AddToCredits(200));
+
+            // Result: SetCredits(1200) because Set wiped previous Add, then new Add was applied
+            assert_eq!(op, BlockAwareCreditOperation::SetCredits(1200));
+        }
+
+        #[test]
+        fn client_sync_scenario() {
+            // This tests the key use case: client synced at block 550,
+            // then receives a compacted range 400-600 with AddToCredits at various blocks.
+            // Client should be able to filter and only apply adds for blocks > 550.
+
+            let mut op =
+                BlockAwareCreditOperation::from_operation(400, &CreditOperation::AddToCredits(100));
+            op.merge(450, &CreditOperation::AddToCredits(200));
+            op.merge(500, &CreditOperation::AddToCredits(300));
+            op.merge(550, &CreditOperation::AddToCredits(400));
+            op.merge(600, &CreditOperation::AddToCredits(500));
+
+            // Verify we have all block heights preserved
+            if let BlockAwareCreditOperation::AddToCreditsOperations(map) = &op {
+                assert_eq!(map.len(), 5);
+
+                // Client synced at 550, so they need to apply blocks > 550
+                let to_apply: Credits = map
+                    .iter()
+                    .filter(|(block, _)| **block > 550)
+                    .map(|(_, credits)| *credits)
+                    .sum();
+
+                // Only block 600's AddToCredits(500) should be applied
+                assert_eq!(to_apply, 500);
+
+                // Client synced at 400, so they need to apply blocks > 400
+                let to_apply_from_400: Credits = map
+                    .iter()
+                    .filter(|(block, _)| **block > 400)
+                    .map(|(_, credits)| *credits)
+                    .sum();
+
+                // Blocks 450, 500, 550, 600: 200 + 300 + 400 + 500 = 1400
+                assert_eq!(to_apply_from_400, 1400);
+            } else {
+                panic!("Expected AddToCreditsOperations");
+            }
+        }
+
+        #[test]
+        fn set_credits_followed_by_adds_scenario() {
+            // SetCredits at block 400, then adds at 500, 600
+            // Client synced at 450, receives range 400-600
+            // Client knows balance was SET at 400, so they start from that value
+            // and only need to apply adds at blocks > 450
+
+            let mut op =
+                BlockAwareCreditOperation::from_operation(400, &CreditOperation::SetCredits(10000));
+            op.merge(500, &CreditOperation::AddToCredits(100));
+            op.merge(600, &CreditOperation::AddToCredits(200));
+
+            // Result is SetCredits(10300) - all operations merged into final value
+            assert_eq!(op, BlockAwareCreditOperation::SetCredits(10300));
+
+            // Note: Once SetCredits is encountered, we lose per-block granularity for adds
+            // This is by design - if the balance was SET, client must use the full compacted value
+        }
     }
 }

--- a/packages/rs-drive-abci/src/query/address_funds/recent_compacted_address_balance_changes/v0/mod.rs
+++ b/packages/rs-drive-abci/src/query/address_funds/recent_compacted_address_balance_changes/v0/mod.rs
@@ -9,10 +9,11 @@ use dapi_grpc::platform::v0::get_recent_compacted_address_balance_changes_respon
     GetRecentCompactedAddressBalanceChangesResponseV0,
 };
 use dapi_grpc::platform::v0::{
-    address_balance_change, AddressBalanceChange, CompactedAddressBalanceUpdateEntries,
+    compacted_address_balance_change, AddToCreditsOperations, BlockHeightCreditEntry,
+    CompactedAddressBalanceChange, CompactedAddressBalanceUpdateEntries,
     CompactedBlockAddressBalanceChanges,
 };
-use dpp::balances::credits::CreditOperation;
+use dpp::balances::credits::BlockAwareCreditOperation;
 use dpp::version::PlatformVersion;
 use drive::util::grove_operations::GroveDBToUse;
 
@@ -61,18 +62,34 @@ impl<C> Platform<C> {
                 compacted_address_balance_changes
                     .into_iter()
                     .map(|(start_block, end_block, changes)| {
-                        let address_changes: Vec<AddressBalanceChange> = changes
+                        let address_changes: Vec<CompactedAddressBalanceChange> = changes
                             .into_iter()
                             .map(|(address, operation)| {
                                 let op = match operation {
-                                    CreditOperation::SetCredits(credits) => {
-                                        address_balance_change::Operation::SetBalance(credits)
+                                    BlockAwareCreditOperation::SetCredits(credits) => {
+                                        compacted_address_balance_change::Operation::SetCredits(
+                                            credits,
+                                        )
                                     }
-                                    CreditOperation::AddToCredits(credits) => {
-                                        address_balance_change::Operation::AddToBalance(credits)
+                                    BlockAwareCreditOperation::AddToCreditsOperations(
+                                        block_credits_map,
+                                    ) => {
+                                        let entries: Vec<BlockHeightCreditEntry> =
+                                            block_credits_map
+                                                .into_iter()
+                                                .map(|(block_height, credits)| {
+                                                    BlockHeightCreditEntry {
+                                                        block_height,
+                                                        credits,
+                                                    }
+                                                })
+                                                .collect();
+                                        compacted_address_balance_change::Operation::AddToCreditsOperations(
+                                            AddToCreditsOperations { entries },
+                                        )
                                     }
                                 };
-                                AddressBalanceChange {
+                                CompactedAddressBalanceChange {
                                     address: address.to_bytes(),
                                     operation: Some(op),
                                 }

--- a/packages/rs-drive-abci/tests/strategy_tests/test_cases/address_tests.rs
+++ b/packages/rs-drive-abci/tests/strategy_tests/test_cases/address_tests.rs
@@ -21,7 +21,7 @@ mod tests {
         Version as CompactedChangesResponseVersion,
     };
     use dapi_grpc::platform::v0::{
-        address_balance_change, GetAddressesTrunkStateRequest,
+        address_balance_change, compacted_address_balance_change, GetAddressesTrunkStateRequest,
         GetRecentAddressBalanceChangesRequest, GetRecentCompactedAddressBalanceChangesRequest,
     };
     use dash_platform_macros::stack_size;
@@ -2391,19 +2391,26 @@ mod tests {
 
                                 // Verify operation type
                                 match &change.operation {
-                                    Some(address_balance_change::Operation::SetBalance(balance)) => {
+                                    Some(compacted_address_balance_change::Operation::SetCredits(credits)) => {
                                         eprintln!(
-                                            "    Address {:?}: SetBalance({})",
+                                            "    Address {:?}: SetCredits({})",
                                             hex::encode(&change.address),
-                                            balance
+                                            credits
                                         );
                                     }
-                                    Some(address_balance_change::Operation::AddToBalance(amount)) => {
+                                    Some(compacted_address_balance_change::Operation::AddToCreditsOperations(ops)) => {
                                         eprintln!(
-                                            "    Address {:?}: AddToBalance({})",
+                                            "    Address {:?}: AddToCreditsOperations({} entries)",
                                             hex::encode(&change.address),
-                                            amount
+                                            ops.entries.len()
                                         );
+                                        for entry in &ops.entries {
+                                            eprintln!(
+                                                "      block {}: {} credits",
+                                                entry.block_height,
+                                                entry.credits
+                                            );
+                                        }
                                     }
                                     None => {
                                         panic!("expected an operation on address balance change");
@@ -3077,6 +3084,290 @@ mod tests {
                     }
                     get_recent_address_balance_changes_response_v0::Result::Proof(_) => {
                         panic!("expected recent entries, not proof");
+                    }
+                }
+            }
+        }
+    }
+
+    /// Test that verifies AddToCreditsOperations preserves block heights for partial sync.
+    ///
+    /// This test:
+    /// 1. Only uses AddressFundingFromAssetLock (which creates AddToCredits, not SetCredits)
+    /// 2. Runs 70+ blocks to trigger compaction (threshold is 64 blocks)
+    /// 3. Verifies the compacted data has AddToCreditsOperations with preserved block heights
+    /// 4. Simulates a client sync scenario where we filter by block height
+    #[test]
+    #[stack_size(4 * 1024 * 1024)]
+    fn run_chain_verify_add_to_credits_operations_for_partial_sync() {
+        // drive_abci::logging::init_for_tests(LogLevel::Debug);
+
+        // Only use AddressFundingFromAssetLock - no transfers that spend from addresses
+        // This ensures we only get AddToCredits operations, not SetCredits
+        let strategy = NetworkStrategy {
+            strategy: Strategy {
+                start_contracts: vec![],
+                operations: vec![Operation {
+                    op_type: OperationType::AddressFundingFromCoreAssetLock(
+                        dash_to_credits!(10)..=dash_to_credits!(10),
+                    ),
+                    frequency: Frequency {
+                        times_per_block_range: 2..4,
+                        chance_per_block: None,
+                    },
+                }],
+                start_identities: StartIdentities::default(),
+                start_addresses: StartAddresses::default(),
+                identity_inserts: IdentityInsertInfo::default(),
+                identity_contract_nonce_gaps: None,
+                signer: None,
+            },
+            total_hpmns: 100,
+            extra_normal_mns: 0,
+            validator_quorum_count: 24,
+            chain_lock_quorum_count: 24,
+            upgrading_info: None,
+            proposer_strategy: Default::default(),
+            rotate_quorums: false,
+            failure_testing: None,
+            query_testing: None,
+            verify_state_transition_results: true,
+            sign_instant_locks: true,
+            ..Default::default()
+        };
+
+        // Use 3 minute block spacing
+        // Compaction happens every 64 blocks, so we need to run at least 70 blocks
+        let config = PlatformConfig {
+            validator_set: ValidatorSetConfig::default_100_67(),
+            chain_lock: ChainLockConfig::default_100_67(),
+            instant_lock: InstantLockConfig::default_100_67(),
+            execution: ExecutionConfig {
+                verify_sum_trees: true,
+                ..Default::default()
+            },
+            block_spacing_ms: 180000, // 3 mins
+            testing_configs: PlatformTestConfig {
+                disable_checkpoints: false,
+                ..PlatformTestConfig::default_minimal_verifications()
+            },
+            ..Default::default()
+        };
+
+        let mut platform = TestPlatformBuilder::new()
+            .with_config(config.clone())
+            .build_with_mock_rpc();
+
+        // Run 70 blocks to trigger compaction (threshold is 64 blocks)
+        let outcome = run_chain_for_strategy(
+            &mut platform,
+            70,
+            strategy,
+            config,
+            15,
+            &mut None,
+            &mut None,
+        );
+
+        // Verify we had some successful address fundings
+        let successful_fundings = outcome
+            .state_transition_results_per_block
+            .values()
+            .flat_map(|results| results.iter())
+            .filter(|(state_transition, result)| {
+                result.code == 0
+                    && matches!(
+                        state_transition,
+                        StateTransition::AddressFundingFromAssetLock(_)
+                    )
+            })
+            .count();
+        assert!(
+            successful_fundings > 0,
+            "expected at least one successful address funding"
+        );
+
+        drop(outcome);
+
+        let platform_version = PlatformVersion::latest();
+        let platform_state = platform.platform.state.load();
+
+        // Query compacted address balance changes
+        let request = GetRecentCompactedAddressBalanceChangesRequest {
+            version: Some(CompactedChangesRequestVersion::V0(
+                GetRecentCompactedAddressBalanceChangesRequestV0 {
+                    start_block_height: 0,
+                    prove: false,
+                },
+            )),
+        };
+
+        let query_result = platform
+            .platform
+            .query_recent_compacted_address_balance_changes(
+                request,
+                &platform_state,
+                platform_version,
+            )
+            .expect("expected to run query");
+
+        assert!(
+            query_result.errors.is_empty(),
+            "query errors: {:?}",
+            query_result.errors
+        );
+
+        let response = query_result.into_data().expect("expected data");
+        let versioned_result = response.version.expect("expected a version");
+
+        match versioned_result {
+            CompactedChangesResponseVersion::V0(v0) => {
+                let result = v0.result.expect("expected a result");
+                match result {
+                    get_recent_compacted_address_balance_changes_response_v0::Result::CompactedAddressBalanceUpdateEntries(entries) => {
+                        // Assert we have at least one compacted entry
+                        assert!(
+                            !entries.compacted_block_changes.is_empty(),
+                            "expected at least one compacted entry after 70 blocks"
+                        );
+
+                        let mut total_add_operations = 0usize;
+                        let mut total_set_operations = 0usize;
+
+                        for entry in &entries.compacted_block_changes {
+                            // Assert valid block range
+                            assert!(
+                                entry.end_block_height >= entry.start_block_height,
+                                "end_block should be >= start_block"
+                            );
+                            assert!(
+                                !entry.changes.is_empty(),
+                                "compacted entry should have changes"
+                            );
+
+                            let range_start = entry.start_block_height;
+                            let range_end = entry.end_block_height;
+
+                            for change in &entry.changes {
+                                // Assert valid address
+                                let _address = PlatformAddress::from_bytes(&change.address)
+                                    .expect("should be valid address bytes");
+
+                                match &change.operation {
+                                    Some(compacted_address_balance_change::Operation::SetCredits(_)) => {
+                                        total_set_operations += 1;
+                                    }
+                                    Some(compacted_address_balance_change::Operation::AddToCreditsOperations(ops)) => {
+                                        total_add_operations += 1;
+
+                                        // Assert entries are not empty
+                                        assert!(
+                                            !ops.entries.is_empty(),
+                                            "AddToCreditsOperations should have at least one entry"
+                                        );
+
+                                        // Assert all block heights are within the compacted range
+                                        for block_entry in &ops.entries {
+                                            assert!(
+                                                block_entry.block_height >= range_start
+                                                    && block_entry.block_height <= range_end,
+                                                "block height {} should be within range [{}, {}]",
+                                                block_entry.block_height,
+                                                range_start,
+                                                range_end
+                                            );
+                                            assert!(
+                                                block_entry.credits > 0,
+                                                "credits should be positive"
+                                            );
+                                        }
+
+                                        // Simulate partial sync: client synced at midpoint
+                                        let synced_at = (range_start + range_end) / 2;
+
+                                        let credits_before: u64 = ops
+                                            .entries
+                                            .iter()
+                                            .filter(|e| e.block_height <= synced_at)
+                                            .map(|e| e.credits)
+                                            .sum();
+
+                                        let credits_after: u64 = ops
+                                            .entries
+                                            .iter()
+                                            .filter(|e| e.block_height > synced_at)
+                                            .map(|e| e.credits)
+                                            .sum();
+
+                                        let total_credits: u64 =
+                                            ops.entries.iter().map(|e| e.credits).sum();
+
+                                        // Assert partition is correct
+                                        assert_eq!(
+                                            credits_before + credits_after,
+                                            total_credits,
+                                            "partitioned credits should sum to total"
+                                        );
+
+                                        // Assert we can filter by block height
+                                        let blocks_before: Vec<u64> = ops
+                                            .entries
+                                            .iter()
+                                            .filter(|e| e.block_height <= synced_at)
+                                            .map(|e| e.block_height)
+                                            .collect();
+
+                                        let blocks_after: Vec<u64> = ops
+                                            .entries
+                                            .iter()
+                                            .filter(|e| e.block_height > synced_at)
+                                            .map(|e| e.block_height)
+                                            .collect();
+
+                                        // Assert all "before" blocks are actually <= synced_at
+                                        for bh in &blocks_before {
+                                            assert!(
+                                                *bh <= synced_at,
+                                                "block {} should be <= synced_at {}",
+                                                bh,
+                                                synced_at
+                                            );
+                                        }
+
+                                        // Assert all "after" blocks are actually > synced_at
+                                        for bh in &blocks_after {
+                                            assert!(
+                                                *bh > synced_at,
+                                                "block {} should be > synced_at {}",
+                                                bh,
+                                                synced_at
+                                            );
+                                        }
+                                    }
+                                    None => {
+                                        panic!("expected operation to be present");
+                                    }
+                                }
+                            }
+                        }
+
+                        // Assert we have AddToCreditsOperations (our strategy only funds addresses)
+                        assert!(
+                            total_add_operations > 0,
+                            "expected AddToCreditsOperations since we only use AddressFundingFromAssetLock"
+                        );
+
+                        // Since we only fund addresses (no transfers that spend),
+                        // we should have mostly or all AddToCreditsOperations
+                        assert!(
+                            total_add_operations > total_set_operations,
+                            "expected more AddToCreditsOperations ({}) than SetCredits ({})",
+                            total_add_operations,
+                            total_set_operations
+                        );
+                    }
+                    get_recent_compacted_address_balance_changes_response_v0::Result::Proof(_) => {
+                        panic!("expected entries, not proof");
                     }
                 }
             }

--- a/packages/rs-drive-proof-verifier/src/types.rs
+++ b/packages/rs-drive-proof-verifier/src/types.rs
@@ -706,7 +706,7 @@ pub struct CompactedBlockAddressBalanceChanges {
     /// The end block height of the compacted range
     pub end_block_height: u64,
     /// The merged address balance changes for this range
-    pub changes: BTreeMap<PlatformAddress, dpp::balances::credits::CreditOperation>,
+    pub changes: BTreeMap<PlatformAddress, dpp::balances::credits::BlockAwareCreditOperation>,
 }
 
 /// Compacted address balance changes across multiple ranges.

--- a/packages/rs-drive/src/drive/saved_block_transactions/compact_address_balances/v0/mod.rs
+++ b/packages/rs-drive/src/drive/saved_block_transactions/compact_address_balances/v0/mod.rs
@@ -5,7 +5,7 @@ use crate::util::batch::grovedb_op_batch::GroveDbOpBatchV0Methods;
 use crate::util::batch::GroveDbOpBatch;
 use crate::util::grove_operations::DirectQueryType;
 use dpp::address_funds::PlatformAddress;
-use dpp::balances::credits::CreditOperation;
+use dpp::balances::credits::{BlockAwareCreditOperation, CreditOperation};
 use dpp::ProtocolError;
 use grovedb::query_result_type::QueryResultType;
 use grovedb::{Element, PathQuery, Query, SizedQuery, TransactionArg};
@@ -59,8 +59,10 @@ impl Drive {
         let mut start_block: u64 = current_block_height;
         let mut end_block: u64 = current_block_height;
 
-        // Start with empty map - we'll merge in chronological order
-        let mut merged_balances: BTreeMap<PlatformAddress, CreditOperation> = BTreeMap::new();
+        // Start with empty map - we'll merge in chronological order using BlockAwareCreditOperation
+        // This preserves block heights for AddToCredits operations while collapsing SetCredits
+        let mut merged_balances: BTreeMap<PlatformAddress, BlockAwareCreditOperation> =
+            BTreeMap::new();
         let mut keys_to_delete: Vec<Vec<u8>> = Vec::new();
 
         // First, process stored blocks in chronological order (ascending by block height)
@@ -100,16 +102,17 @@ impl Drive {
                     ))))
                 })?;
 
-            // Merge into the combined map - stored blocks come first chronologically
-            // existing.merge(operation) means: apply existing first, then operation (later)
+            // Merge into the combined map using BlockAwareCreditOperation
+            // This preserves block heights for AddToCredits, collapses when SetCredits is seen
             for (address, operation) in address_balances {
                 merged_balances
                     .entry(address)
                     .and_modify(|existing| {
-                        // existing is from earlier blocks, operation is from this (later) block
-                        *existing = existing.merge(&operation);
+                        existing.merge(block_height, &operation);
                     })
-                    .or_insert(operation);
+                    .or_insert_with(|| {
+                        BlockAwareCreditOperation::from_operation(block_height, &operation)
+                    });
             }
 
             keys_to_delete.push(key);
@@ -120,10 +123,11 @@ impl Drive {
             merged_balances
                 .entry(*address)
                 .and_modify(|existing| {
-                    // existing is from stored blocks (earlier), operation is from current (latest)
-                    *existing = existing.merge(operation);
+                    existing.merge(current_block_height, operation);
                 })
-                .or_insert(*operation);
+                .or_insert_with(|| {
+                    BlockAwareCreditOperation::from_operation(current_block_height, operation)
+                });
         }
 
         // Serialize the merged balances

--- a/packages/rs-drive/src/drive/saved_block_transactions/fetch_compacted_address_balances/v0/mod.rs
+++ b/packages/rs-drive/src/drive/saved_block_transactions/fetch_compacted_address_balances/v0/mod.rs
@@ -1,7 +1,7 @@
 use crate::drive::Drive;
 use crate::error::Error;
 use dpp::address_funds::PlatformAddress;
-use dpp::balances::credits::CreditOperation;
+use dpp::balances::credits::BlockAwareCreditOperation;
 use dpp::ProtocolError;
 use grovedb::query_result_type::QueryResultType;
 use grovedb::{Element, PathQuery, Query, SizedQuery, TransactionArg};
@@ -10,8 +10,11 @@ use std::collections::BTreeMap;
 
 /// Result type for fetched compacted address balance changes
 /// Each entry is (start_block, end_block, address_balance_map)
-pub type CompactedAddressBalanceChanges =
-    Vec<(u64, u64, BTreeMap<PlatformAddress, CreditOperation>)>;
+pub type CompactedAddressBalanceChanges = Vec<(
+    u64,
+    u64,
+    BTreeMap<PlatformAddress, BlockAwareCreditOperation>,
+)>;
 
 impl Drive {
     /// Version 0 implementation of fetching compacted address balance changes.
@@ -91,13 +94,15 @@ impl Drive {
                     )));
                 };
 
-                let (address_balances, _): (BTreeMap<PlatformAddress, CreditOperation>, usize) =
-                    bincode::decode_from_slice(&serialized_data, config).map_err(|e| {
-                        Error::Protocol(Box::new(ProtocolError::CorruptedSerialization(format!(
-                            "cannot decode compacted address balances: {}",
-                            e
-                        ))))
-                    })?;
+                let (address_balances, _): (
+                    BTreeMap<PlatformAddress, BlockAwareCreditOperation>,
+                    usize,
+                ) = bincode::decode_from_slice(&serialized_data, config).map_err(|e| {
+                    Error::Protocol(Box::new(ProtocolError::CorruptedSerialization(format!(
+                        "cannot decode compacted address balances: {}",
+                        e
+                    ))))
+                })?;
 
                 compacted_changes.push((start_block, end_block, address_balances));
             }
@@ -166,13 +171,15 @@ impl Drive {
                 )));
             };
 
-            let (address_balances, _): (BTreeMap<PlatformAddress, CreditOperation>, usize) =
-                bincode::decode_from_slice(&serialized_data, config).map_err(|e| {
-                    Error::Protocol(Box::new(ProtocolError::CorruptedSerialization(format!(
-                        "cannot decode compacted address balances: {}",
-                        e
-                    ))))
-                })?;
+            let (address_balances, _): (
+                BTreeMap<PlatformAddress, BlockAwareCreditOperation>,
+                usize,
+            ) = bincode::decode_from_slice(&serialized_data, config).map_err(|e| {
+                Error::Protocol(Box::new(ProtocolError::CorruptedSerialization(format!(
+                    "cannot decode compacted address balances: {}",
+                    e
+                ))))
+            })?;
 
             compacted_changes.push((start_block, end_block, address_balances));
         }

--- a/packages/rs-drive/src/drive/saved_block_transactions/store_address_balances/v0/mod.rs
+++ b/packages/rs-drive/src/drive/saved_block_transactions/store_address_balances/v0/mod.rs
@@ -160,6 +160,7 @@ impl Drive {
 mod tests {
     use super::*;
     use crate::util::test_helpers::setup::setup_drive_with_initial_state_structure;
+    use dpp::balances::credits::BlockAwareCreditOperation;
     use dpp::version::mocks::v2_test::TEST_PLATFORM_V2;
     use dpp::version::PlatformVersion;
 
@@ -261,17 +262,24 @@ mod tests {
         assert_eq!(*start_block, 100, "start block should be 100");
         assert_eq!(*end_block, 102, "end block should be 102");
         assert_eq!(merged.len(), 3, "should have 3 addresses in merged data");
+        // Each address has AddToCredits from its respective block
         assert_eq!(
             merged.get(&ADDR_1),
-            Some(&CreditOperation::AddToCredits(1000))
+            Some(&BlockAwareCreditOperation::AddToCreditsOperations(
+                [(100, 1000)].into_iter().collect()
+            ))
         );
         assert_eq!(
             merged.get(&ADDR_2),
-            Some(&CreditOperation::AddToCredits(2000))
+            Some(&BlockAwareCreditOperation::AddToCreditsOperations(
+                [(101, 2000)].into_iter().collect()
+            ))
         );
         assert_eq!(
             merged.get(&ADDR_3),
-            Some(&CreditOperation::AddToCredits(3000))
+            Some(&BlockAwareCreditOperation::AddToCreditsOperations(
+                [(102, 3000)].into_iter().collect()
+            ))
         );
     }
 
@@ -380,11 +388,14 @@ mod tests {
 
         let (_, _, merged) = &compacted[0];
         assert_eq!(merged.len(), 1, "should have 1 address");
-        // 1000 + 500 = 1500
+        // Block 100: AddToCredits(1000), Block 101: AddToCredits(500)
+        // Each block's add is preserved separately
         assert_eq!(
             merged.get(&ADDR_1),
-            Some(&CreditOperation::AddToCredits(1500)),
-            "should merge add operations"
+            Some(&BlockAwareCreditOperation::AddToCreditsOperations(
+                [(100, 1000), (101, 500)].into_iter().collect()
+            )),
+            "should preserve add operations by block"
         );
     }
 
@@ -432,7 +443,7 @@ mod tests {
         assert_eq!(merged.len(), 1, "should have 1 address");
         assert_eq!(
             merged.get(&ADDR_1),
-            Some(&CreditOperation::SetCredits(1500)),
+            Some(&BlockAwareCreditOperation::SetCredits(1500)),
             "should merge set + add to set"
         );
     }
@@ -481,7 +492,7 @@ mod tests {
         assert_eq!(merged.len(), 1, "should have 1 address");
         assert_eq!(
             merged.get(&ADDR_1),
-            Some(&CreditOperation::SetCredits(500)),
+            Some(&BlockAwareCreditOperation::SetCredits(500)),
             "later SetCredits should override"
         );
     }
@@ -572,22 +583,26 @@ mod tests {
             .expect("should fetch compacted changes");
         assert_eq!(compacted.len(), 2, "should have 2 compacted entries");
 
-        // First compaction: blocks 100-101 with ADDR_1 having 200 credits
+        // First compaction: blocks 100-101 with ADDR_1 having adds from both blocks
         let (start1, end1, merged1) = &compacted[0];
         assert_eq!(*start1, 100);
         assert_eq!(*end1, 101);
         assert_eq!(
             merged1.get(&ADDR_1),
-            Some(&CreditOperation::AddToCredits(200))
+            Some(&BlockAwareCreditOperation::AddToCreditsOperations(
+                [(100, 100), (101, 100)].into_iter().collect()
+            ))
         );
 
-        // Second compaction: blocks 200-201 with ADDR_2 having 400 credits
+        // Second compaction: blocks 200-201 with ADDR_2 having adds from both blocks
         let (start2, end2, merged2) = &compacted[1];
         assert_eq!(*start2, 200);
         assert_eq!(*end2, 201);
         assert_eq!(
             merged2.get(&ADDR_2),
-            Some(&CreditOperation::AddToCredits(400))
+            Some(&BlockAwareCreditOperation::AddToCreditsOperations(
+                [(200, 200), (201, 200)].into_iter().collect()
+            ))
         );
     }
 

--- a/packages/rs-drive/src/verify/address_funds/verify_compacted_address_balance_changes/mod.rs
+++ b/packages/rs-drive/src/verify/address_funds/verify_compacted_address_balance_changes/mod.rs
@@ -5,14 +5,17 @@ use crate::error::drive::DriveError;
 use crate::error::Error;
 use crate::verify::RootHash;
 use dpp::address_funds::PlatformAddress;
-use dpp::balances::credits::CreditOperation;
+use dpp::balances::credits::BlockAwareCreditOperation;
 use dpp::version::PlatformVersion;
 use std::collections::BTreeMap;
 
 /// Result type for verified compacted address balance changes
 /// Each entry is (start_block, end_block, address_balance_changes)
-pub type VerifiedCompactedAddressBalanceChanges =
-    Vec<(u64, u64, BTreeMap<PlatformAddress, CreditOperation>)>;
+pub type VerifiedCompactedAddressBalanceChanges = Vec<(
+    u64,
+    u64,
+    BTreeMap<PlatformAddress, BlockAwareCreditOperation>,
+)>;
 
 impl Drive {
     /// Verifies the proof of compacted address balance changes starting from a given block height.

--- a/packages/rs-drive/src/verify/address_funds/verify_compacted_address_balance_changes/v0/mod.rs
+++ b/packages/rs-drive/src/verify/address_funds/verify_compacted_address_balance_changes/v0/mod.rs
@@ -7,7 +7,7 @@ use dpp::address_funds::PlatformAddress;
 
 /// The subtree key for compacted address balances storage as u8
 const COMPACTED_ADDRESS_BALANCES_KEY_U8: u8 = b'c';
-use dpp::balances::credits::CreditOperation;
+use dpp::balances::credits::BlockAwareCreditOperation;
 use grovedb::{Element, GroveDb, PathQuery, Query, SizedQuery};
 use platform_version::version::PlatformVersion;
 use std::collections::BTreeMap;
@@ -127,13 +127,15 @@ impl Drive {
             };
 
             // Deserialize the address balance map
-            let (address_balances, _): (BTreeMap<PlatformAddress, CreditOperation>, usize) =
-                bincode::decode_from_slice(&serialized_data, config).map_err(|e| {
-                    Error::Proof(ProofError::CorruptedProof(format!(
-                        "cannot decode compacted address balances: {}",
-                        e
-                    )))
-                })?;
+            let (address_balances, _): (
+                BTreeMap<PlatformAddress, BlockAwareCreditOperation>,
+                usize,
+            ) = bincode::decode_from_slice(&serialized_data, config).map_err(|e| {
+                Error::Proof(ProofError::CorruptedProof(format!(
+                    "cannot decode compacted address balances: {}",
+                    e
+                )))
+            })?;
 
             compacted_changes.push((start_block, end_block, address_balances));
         }


### PR DESCRIPTION
## Issue being fixed or feature implemented
This update introduces block-aware credit operations to enhance the management of address balance changes. The new structure allows for better handling of individual credit additions based on block heights, enabling partial synchronization for clients.

## What was done?
- Added `BlockHeightCreditEntry`, `CompactedAddressBalanceChange`, and `AddToCreditsOperations` messages to the protocol buffer definitions.
- Introduced `BlockAwareCreditOperation` enum to encapsulate credit operations with block height awareness.
- Updated the merging logic in `BlockAwareCreditOperation` to handle both `SetCredits` and `AddToCredits` operations while preserving block heights.
- Modified existing code to utilize the new block-aware structures in various components, including serialization, deserialization, and testing.
- Updated tests to ensure correct behavior of the new block-aware credit operations.

## How Has This Been Tested?
All existing and new unit tests have been executed successfully, ensuring that the new block-aware credit operations function as intended and integrate seamlessly with the existing codebase.

## Breaking Changes
None

## Checklist
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have added ! to the title and described breaking changes in the corresponding section if my code contains any.

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone