### PR TITLE
feat(drive): update verification logic for compacted address balance changes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2482,8 +2482,8 @@ dependencies = [
 
 [[package]]
 name = "grovedb"
-version = "3.1.0"
-source = "git+https://github.com/dashpay/grovedb?rev=83a8fe5b64a92fe25cb550f9e448b16345d920e9#83a8fe5b64a92fe25cb550f9e448b16345d920e9"
+version = "4.0.0"
+source = "git+https://github.com/dashpay/grovedb?rev=a7bc60a6760c395e90489c655eee84ae75003af4#a7bc60a6760c395e90489c655eee84ae75003af4"
 dependencies = [
  "axum 0.8.8",
  "bincode 2.0.0-rc.3",
@@ -2515,8 +2515,8 @@ dependencies = [
 
 [[package]]
 name = "grovedb-costs"
-version = "3.1.0"
-source = "git+https://github.com/dashpay/grovedb?rev=83a8fe5b64a92fe25cb550f9e448b16345d920e9#83a8fe5b64a92fe25cb550f9e448b16345d920e9"
+version = "4.0.0"
+source = "git+https://github.com/dashpay/grovedb?rev=a7bc60a6760c395e90489c655eee84ae75003af4#a7bc60a6760c395e90489c655eee84ae75003af4"
 dependencies = [
  "integer-encoding",
  "intmap",
@@ -2525,8 +2525,8 @@ dependencies = [
 
 [[package]]
 name = "grovedb-element"
-version = "3.1.0"
-source = "git+https://github.com/dashpay/grovedb?rev=83a8fe5b64a92fe25cb550f9e448b16345d920e9#83a8fe5b64a92fe25cb550f9e448b16345d920e9"
+version = "4.0.0"
+source = "git+https://github.com/dashpay/grovedb?rev=a7bc60a6760c395e90489c655eee84ae75003af4#a7bc60a6760c395e90489c655eee84ae75003af4"
 dependencies = [
  "bincode 2.0.0-rc.3",
  "bincode_derive",
@@ -2540,8 +2540,8 @@ dependencies = [
 
 [[package]]
 name = "grovedb-epoch-based-storage-flags"
-version = "3.1.0"
-source = "git+https://github.com/dashpay/grovedb?rev=83a8fe5b64a92fe25cb550f9e448b16345d920e9#83a8fe5b64a92fe25cb550f9e448b16345d920e9"
+version = "4.0.0"
+source = "git+https://github.com/dashpay/grovedb?rev=a7bc60a6760c395e90489c655eee84ae75003af4#a7bc60a6760c395e90489c655eee84ae75003af4"
 dependencies = [
  "grovedb-costs",
  "hex",
@@ -2552,8 +2552,8 @@ dependencies = [
 
 [[package]]
 name = "grovedb-merk"
-version = "3.1.0"
-source = "git+https://github.com/dashpay/grovedb?rev=83a8fe5b64a92fe25cb550f9e448b16345d920e9#83a8fe5b64a92fe25cb550f9e448b16345d920e9"
+version = "4.0.0"
+source = "git+https://github.com/dashpay/grovedb?rev=a7bc60a6760c395e90489c655eee84ae75003af4#a7bc60a6760c395e90489c655eee84ae75003af4"
 dependencies = [
  "bincode 2.0.0-rc.3",
  "bincode_derive",
@@ -2577,16 +2577,16 @@ dependencies = [
 
 [[package]]
 name = "grovedb-path"
-version = "3.1.0"
-source = "git+https://github.com/dashpay/grovedb?rev=83a8fe5b64a92fe25cb550f9e448b16345d920e9#83a8fe5b64a92fe25cb550f9e448b16345d920e9"
+version = "4.0.0"
+source = "git+https://github.com/dashpay/grovedb?rev=a7bc60a6760c395e90489c655eee84ae75003af4#a7bc60a6760c395e90489c655eee84ae75003af4"
 dependencies = [
  "hex",
 ]
 
 [[package]]
 name = "grovedb-storage"
-version = "3.1.0"
-source = "git+https://github.com/dashpay/grovedb?rev=83a8fe5b64a92fe25cb550f9e448b16345d920e9#83a8fe5b64a92fe25cb550f9e448b16345d920e9"
+version = "4.0.0"
+source = "git+https://github.com/dashpay/grovedb?rev=a7bc60a6760c395e90489c655eee84ae75003af4#a7bc60a6760c395e90489c655eee84ae75003af4"
 dependencies = [
  "blake3",
  "grovedb-costs",
@@ -2604,8 +2604,8 @@ dependencies = [
 
 [[package]]
 name = "grovedb-version"
-version = "3.1.0"
-source = "git+https://github.com/dashpay/grovedb?rev=83a8fe5b64a92fe25cb550f9e448b16345d920e9#83a8fe5b64a92fe25cb550f9e448b16345d920e9"
+version = "4.0.0"
+source = "git+https://github.com/dashpay/grovedb?rev=a7bc60a6760c395e90489c655eee84ae75003af4#a7bc60a6760c395e90489c655eee84ae75003af4"
 dependencies = [
  "thiserror 2.0.17",
  "versioned-feature-core 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2613,8 +2613,8 @@ dependencies = [
 
 [[package]]
 name = "grovedb-visualize"
-version = "3.1.0"
-source = "git+https://github.com/dashpay/grovedb?rev=83a8fe5b64a92fe25cb550f9e448b16345d920e9#83a8fe5b64a92fe25cb550f9e448b16345d920e9"
+version = "4.0.0"
+source = "git+https://github.com/dashpay/grovedb?rev=a7bc60a6760c395e90489c655eee84ae75003af4#a7bc60a6760c395e90489c655eee84ae75003af4"
 dependencies = [
  "hex",
  "itertools 0.14.0",
@@ -2622,8 +2622,8 @@ dependencies = [
 
 [[package]]
 name = "grovedbg-types"
-version = "3.1.0"
-source = "git+https://github.com/dashpay/grovedb?rev=83a8fe5b64a92fe25cb550f9e448b16345d920e9#83a8fe5b64a92fe25cb550f9e448b16345d920e9"
+version = "4.0.0"
+source = "git+https://github.com/dashpay/grovedb?rev=a7bc60a6760c395e90489c655eee84ae75003af4#a7bc60a6760c395e90489c655eee84ae75003af4"
 dependencies = [
  "serde",
  "serde_with 3.16.1",

--- a/packages/rs-drive/Cargo.toml
+++ b/packages/rs-drive/Cargo.toml
@@ -52,12 +52,12 @@ enum-map = { version = "2.0.3", optional = true }
 intmap = { version = "3.0.1", features = ["serde"], optional = true }
 chrono = { version = "0.4.35", optional = true }
 itertools = { version = "0.13", optional = true }
-grovedb = { git = "https://github.com/dashpay/grovedb", rev = "83a8fe5b64a92fe25cb550f9e448b16345d920e9", optional = true, default-features = false }
-grovedb-costs = { git = "https://github.com/dashpay/grovedb", rev = "83a8fe5b64a92fe25cb550f9e448b16345d920e9", optional = true }
-grovedb-path = { git = "https://github.com/dashpay/grovedb", rev = "83a8fe5b64a92fe25cb550f9e448b16345d920e9" }
-grovedb-storage = { git = "https://github.com/dashpay/grovedb", rev = "83a8fe5b64a92fe25cb550f9e448b16345d920e9", optional = true }
-grovedb-version = { git = "https://github.com/dashpay/grovedb", rev = "83a8fe5b64a92fe25cb550f9e448b16345d920e9" }
-grovedb-epoch-based-storage-flags = { git = "https://github.com/dashpay/grovedb", rev = "83a8fe5b64a92fe25cb550f9e448b16345d920e9" }
+grovedb = { git = "https://github.com/dashpay/grovedb", rev = "a7bc60a6760c395e90489c655eee84ae75003af4", optional = true, default-features = false }
+grovedb-costs = { git = "https://github.com/dashpay/grovedb", rev = "a7bc60a6760c395e90489c655eee84ae75003af4", optional = true }
+grovedb-path = { git = "https://github.com/dashpay/grovedb", rev = "a7bc60a6760c395e90489c655eee84ae75003af4" }
+grovedb-storage = { git = "https://github.com/dashpay/grovedb", rev = "a7bc60a6760c395e90489c655eee84ae75003af4", optional = true }
+grovedb-version = { git = "https://github.com/dashpay/grovedb", rev = "a7bc60a6760c395e90489c655eee84ae75003af4" }
+grovedb-epoch-based-storage-flags = { git = "https://github.com/dashpay/grovedb", rev = "a7bc60a6760c395e90489c655eee84ae75003af4" }
 
 [dev-dependencies]
 criterion = "0.5"

--- a/packages/rs-drive/src/verify/address_funds/verify_compacted_address_balance_changes/v0/mod.rs
+++ b/packages/rs-drive/src/verify/address_funds/verify_compacted_address_balance_changes/v0/mod.rs
@@ -8,105 +8,127 @@ use dpp::address_funds::PlatformAddress;
 /// The subtree key for compacted address balances storage as u8
 const COMPACTED_ADDRESS_BALANCES_KEY_U8: u8 = b'c';
 use dpp::balances::credits::BlockAwareCreditOperation;
-use grovedb::{Element, GroveDb, PathQuery, Query, SizedQuery};
+use grovedb::operations::proof::GroveDBProof;
+use grovedb::{
+    GroveDb, MerkProofDecoder, MerkProofNode, MerkProofOp, PathQuery, Query, SizedQuery,
+};
 use platform_version::version::PlatformVersion;
 use std::collections::BTreeMap;
 
 use super::VerifiedCompactedAddressBalanceChanges;
 
+/// Extract KV entries from merk proof bytes using the proper decoder.
+fn extract_kv_entries_from_merk_proof(merk_proof: &[u8]) -> Vec<(Vec<u8>, Vec<u8>)> {
+    let mut entries = Vec::new();
+
+    for op_result in MerkProofDecoder::new(merk_proof) {
+        if let Ok(op) = op_result {
+            match op {
+                MerkProofOp::Push(MerkProofNode::KV(key, value))
+                | MerkProofOp::PushInverted(MerkProofNode::KV(key, value)) => {
+                    entries.push((key, value));
+                }
+                _ => {}
+            }
+        }
+    }
+
+    entries
+}
+
 impl Drive {
     /// Verifies compacted address balance changes proof.
     ///
-    /// Verification is done in two steps:
-    /// 1. First query in descending order to find a compacted range that might
-    ///    contain start_block_height (e.g., range 50-150 when querying from block 100).
-    /// 2. Then verify the main ascending query using the discovered start key,
-    ///    or fall back to (start_block_height, start_block_height) if no containing range.
+    /// This verification works by:
+    /// 1. Decoding the GroveDBProof structure
+    /// 2. Navigating to the compacted address balances layer ('c')
+    /// 3. Extracting KV entries from the merk proof
+    /// 4. Filtering entries where the key range contains start_block_height
+    /// 5. Verifying the root hash using a subset query
     pub(super) fn verify_compacted_address_balance_changes_v0(
         proof: &[u8],
         start_block_height: u64,
         limit: Option<u16>,
         platform_version: &PlatformVersion,
     ) -> Result<(RootHash, VerifiedCompactedAddressBalanceChanges), Error> {
-        let path = vec![
-            vec![RootTree::SavedBlockTransactions as u8],
-            vec![COMPACTED_ADDRESS_BALANCES_KEY_U8],
-        ];
-
-        let config = bincode::config::standard()
+        let bincode_config = bincode::config::standard()
             .with_big_endian()
             .with_no_limit();
 
-        // Step 1: Query in descending order to find the closest entry before start_block_height.
-        // This finds compacted ranges that might contain our start_block_height
-        // (e.g., range 50-150 when querying from block 100).
-        let mut subset_query = Query::new_with_direction(false);
+        // Decode the GroveDBProof to navigate its structure
+        let grovedb_proof: GroveDBProof = bincode::decode_from_slice(proof, bincode_config)
+            .map(|(p, _)| p)
+            .map_err(|e| {
+                Error::Proof(ProofError::CorruptedProof(format!(
+                    "cannot decode GroveDBProof: {}",
+                    e
+                )))
+            })?;
 
-        let mut key = Vec::with_capacity(16);
-        key.extend_from_slice(&start_block_height.to_be_bytes());
-        key.extend_from_slice(&start_block_height.to_be_bytes());
+        // Navigate to the compacted address balances layer
+        // Path: SavedBlockTransactions ('$' = 0x24) -> CompactedAddressBalances ('c' = 0x63)
+        let root_layer = match &grovedb_proof {
+            GroveDBProof::V0(v0) => &v0.root_layer,
+        };
 
-        subset_query.insert_range_to(..key);
+        let saved_block_key = vec![RootTree::SavedBlockTransactions as u8];
+        let compacted_key = vec![COMPACTED_ADDRESS_BALANCES_KEY_U8];
 
-        let subset_path_query =
-            PathQuery::new(path.clone(), SizedQuery::new(subset_query, Some(1), None));
+        let compacted_layer = root_layer
+            .lower_layers
+            .get(&saved_block_key)
+            .and_then(|layer| layer.lower_layers.get(&compacted_key));
 
-        // Use verify_subset_query to look at what's in the proof
-        let (root_hash, subset_results) = GroveDb::verify_subset_query(
-            proof,
-            &subset_path_query,
-            &platform_version.drive.grove_version,
-        )?;
+        // Extract KV entries from the compacted layer's merk proof to find
+        // if there's a containing range for start_block_height
+        let kv_entries = compacted_layer
+            .map(|layer| extract_kv_entries_from_merk_proof(&layer.merk_proof))
+            .unwrap_or_default();
 
-        // Collect results into a BTreeMap to ensure proper ordering by key
-        let results_map: BTreeMap<Vec<u8>, Element> = subset_results
-            .into_iter()
-            .filter_map(|(_, key, maybe_element)| maybe_element.map(|element| (key, element)))
-            .collect();
-
-        // Get the first entry and check if it's a containing range
-        // Only use the key from the proof if it contains start_block_height
-        // (start <= start_block_height <= end)
-        // Otherwise fall back to (start_block_height, start_block_height)
-        let start_key = results_map.first_key_value().and_then(|(key, _)| {
+        // Look for a KV entry where the range contains start_block_height
+        // Keys are 16 bytes: (start_block, end_block), both big-endian
+        let containing_key = kv_entries.iter().find_map(|(key, _)| {
             if key.len() != 16 {
                 return None;
             }
-            let start_block = u64::from_be_bytes(key[0..8].try_into().unwrap());
-            let end_block = u64::from_be_bytes(key[8..16].try_into().unwrap());
+            let range_start = u64::from_be_bytes(key[0..8].try_into().unwrap());
+            let range_end = u64::from_be_bytes(key[8..16].try_into().unwrap());
 
-            // Only return the key if it's a containing range
-            if start_block <= start_block_height && start_block_height <= end_block {
+            // Check if this range contains start_block_height
+            if range_start <= start_block_height && start_block_height <= range_end {
                 Some(key.clone())
             } else {
                 None
             }
         });
 
-        // Step 2: Verify the proof using the start_key discovered from the proof
-        // The smallest key in the proof is what the prove function used as its starting point
-        // If no entries exist, fall back to (start_block_height, start_block_height)
-        let start_key = start_key.unwrap_or_else(|| {
+        // Determine the start_key for the query
+        // Use the containing range's key if found, otherwise (start_block_height, start_block_height)
+        let start_key = containing_key.unwrap_or_else(|| {
             let mut key = Vec::with_capacity(16);
             key.extend_from_slice(&start_block_height.to_be_bytes());
             key.extend_from_slice(&start_block_height.to_be_bytes());
             key
         });
 
+        // Verify the proof and get results using subset query
+        let path = vec![
+            vec![RootTree::SavedBlockTransactions as u8],
+            vec![COMPACTED_ADDRESS_BALANCES_KEY_U8],
+        ];
+
         let mut query = Query::new();
         query.insert_range_from(start_key..);
 
         let path_query = PathQuery::new(path, SizedQuery::new(query, limit, None));
-        let (verified_root_hash, proved_key_values) =
-            GroveDb::verify_query(proof, &path_query, &platform_version.drive.grove_version)?;
 
-        // Both verifications must have the same root hash
-        if root_hash != verified_root_hash {
-            return Err(Error::Proof(ProofError::CorruptedProof(
-                "root hash mismatch between subset and main query verification".to_string(),
-            )));
-        }
+        let (root_hash, proved_key_values) = GroveDb::verify_subset_query(
+            proof,
+            &path_query,
+            &platform_version.drive.grove_version,
+        )?;
 
+        // Process the verified results
         let mut compacted_changes = Vec::new();
 
         for (_path, key, maybe_element) in proved_key_values {
@@ -114,18 +136,17 @@ impl Drive {
                 continue;
             };
 
-            // Parse start_block and end_block from key (16 bytes total, both big-endian)
             if key.len() != 16 {
                 return Err(Error::Proof(ProofError::CorruptedProof(
                     "invalid compacted block key length, expected 16 bytes".to_string(),
                 )));
             }
 
-            let start_block = u64::from_be_bytes(key[0..8].try_into().unwrap());
-            let end_block = u64::from_be_bytes(key[8..16].try_into().unwrap());
+            let range_start = u64::from_be_bytes(key[0..8].try_into().unwrap());
+            let range_end = u64::from_be_bytes(key[8..16].try_into().unwrap());
 
             // Get the serialized data from the Item element
-            let Element::Item(serialized_data, _) = element else {
+            let grovedb::Element::Item(serialized_data, _) = element else {
                 return Err(Error::Proof(ProofError::CorruptedProof(
                     "expected item element for compacted address balances".to_string(),
                 )));
@@ -135,16 +156,105 @@ impl Drive {
             let (address_balances, _): (
                 BTreeMap<PlatformAddress, BlockAwareCreditOperation>,
                 usize,
-            ) = bincode::decode_from_slice(&serialized_data, config).map_err(|e| {
+            ) = bincode::decode_from_slice(&serialized_data, bincode_config).map_err(|e| {
                 Error::Proof(ProofError::CorruptedProof(format!(
                     "cannot decode compacted address balances: {}",
                     e
                 )))
             })?;
 
-            compacted_changes.push((start_block, end_block, address_balances));
+            compacted_changes.push((range_start, range_end, address_balances));
         }
 
         Ok((root_hash, compacted_changes))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use platform_version::version::PlatformVersion;
+
+    #[test]
+    fn test_verify_compacted_address_balance_changes_proof() {
+        // This proof was generated with start_block_height = 329
+        // Path: [[36], [99]] = [['$'], ['c']] = SavedBlockTransactions -> CompactedAddressBalances
+        // Query: RangeTo(..[0, 0, 0, 0, 0, 0, 1, 73, 0, 0, 0, 0, 0, 0, 1, 73]) = RangeTo(..(329, 329))
+        let proof: Vec<u8> = vec![
+            0, 251, 1, 24, 1, 24, 215, 122, 183, 233, 12, 7, 14, 37, 119, 175, 74, 229, 6, 76, 88,
+            209, 79, 175, 135, 230, 45, 89, 116, 17, 76, 49, 87, 242, 4, 40, 35, 2, 33, 229, 84,
+            218, 198, 132, 136, 197, 212, 253, 180, 247, 125, 228, 176, 179, 248, 100, 19, 202,
+            143, 20, 196, 132, 112, 114, 44, 43, 11, 174, 49, 96, 16, 4, 1, 36, 0, 5, 2, 1, 1, 101,
+            0, 126, 152, 206, 30, 157, 147, 101, 232, 212, 68, 50, 242, 52, 170, 136, 72, 39, 136,
+            235, 41, 105, 28, 199, 93, 222, 168, 227, 241, 80, 234, 2, 185, 2, 120, 2, 233, 247,
+            175, 89, 203, 114, 37, 58, 187, 95, 169, 151, 247, 245, 82, 228, 73, 77, 131, 5, 100,
+            241, 7, 152, 139, 156, 94, 138, 33, 173, 16, 2, 124, 156, 122, 25, 79, 47, 39, 233, 96,
+            90, 9, 165, 232, 130, 103, 245, 113, 145, 31, 183, 102, 94, 40, 86, 140, 146, 128, 172,
+            85, 184, 13, 220, 16, 1, 48, 30, 57, 216, 246, 121, 172, 45, 163, 129, 189, 9, 238,
+            108, 64, 21, 231, 140, 164, 160, 37, 184, 182, 34, 151, 148, 194, 74, 83, 124, 199, 87,
+            17, 17, 2, 199, 32, 12, 6, 52, 58, 219, 92, 42, 60, 69, 132, 209, 186, 193, 248, 18,
+            33, 26, 78, 216, 110, 114, 103, 202, 56, 45, 175, 163, 68, 139, 6, 16, 1, 62, 159, 56,
+            33, 169, 193, 143, 7, 131, 179, 169, 31, 163, 163, 50, 117, 235, 211, 94, 247, 244, 60,
+            246, 149, 186, 142, 105, 187, 230, 247, 212, 141, 17, 1, 1, 36, 125, 4, 1, 99, 0, 20,
+            2, 1, 16, 0, 0, 0, 0, 0, 0, 1, 4, 0, 0, 0, 0, 0, 0, 1, 8, 0, 97, 206, 71, 247, 121, 93,
+            103, 7, 209, 119, 82, 59, 209, 145, 171, 254, 112, 14, 204, 81, 30, 98, 213, 203, 146,
+            141, 32, 167, 232, 34, 0, 37, 2, 170, 200, 228, 36, 229, 197, 116, 242, 100, 137, 25,
+            37, 45, 57, 56, 2, 38, 8, 75, 144, 250, 71, 108, 90, 106, 133, 2, 231, 236, 42, 149,
+            206, 16, 1, 77, 52, 100, 69, 203, 109, 100, 190, 84, 2, 6, 238, 168, 74, 208, 99, 16,
+            56, 200, 98, 181, 205, 24, 79, 120, 235, 223, 144, 61, 197, 8, 215, 17, 1, 1, 99, 220,
+            1, 28, 113, 173, 87, 207, 150, 171, 166, 221, 201, 207, 122, 14, 62, 119, 8, 5, 100,
+            182, 50, 112, 191, 244, 5, 125, 9, 161, 17, 66, 201, 126, 148, 2, 170, 62, 172, 42,
+            117, 12, 62, 165, 78, 141, 84, 194, 75, 135, 140, 198, 85, 219, 214, 218, 149, 56, 32,
+            251, 16, 134, 21, 44, 31, 22, 80, 69, 16, 1, 191, 139, 156, 120, 188, 0, 187, 111, 169,
+            41, 135, 146, 156, 103, 102, 125, 235, 0, 70, 180, 94, 103, 134, 250, 135, 56, 55, 144,
+            156, 185, 212, 67, 2, 223, 93, 226, 244, 94, 203, 160, 13, 145, 161, 22, 104, 133, 135,
+            132, 239, 27, 61, 12, 167, 134, 237, 120, 58, 229, 208, 50, 55, 70, 139, 211, 234, 16,
+            2, 58, 253, 249, 36, 12, 24, 122, 198, 7, 161, 13, 237, 229, 3, 224, 98, 176, 51, 237,
+            101, 105, 33, 10, 45, 111, 96, 89, 201, 212, 82, 1, 141, 5, 16, 0, 0, 0, 0, 0, 0, 1,
+            32, 0, 0, 0, 0, 0, 0, 1, 36, 77, 228, 149, 252, 55, 96, 22, 145, 235, 199, 188, 83, 13,
+            88, 13, 241, 48, 191, 78, 152, 20, 50, 252, 186, 199, 105, 134, 73, 62, 136, 228, 196,
+            17, 17, 17, 0, 1,
+        ];
+
+        let start_block_height = 329u64;
+        let platform_version = PlatformVersion::latest();
+
+        let result = Drive::verify_compacted_address_balance_changes_v0(
+            &proof,
+            start_block_height,
+            None,
+            platform_version,
+        );
+
+        assert!(
+            result.is_ok(),
+            "proof verification failed: {:?}",
+            result.err()
+        );
+
+        let (root_hash, compacted_changes) = result.unwrap();
+
+        // Verify we got a valid root hash
+        assert!(!root_hash.is_empty(), "root hash should not be empty");
+
+        // The proof shows entry (288, 292) is the rightmost in the tree.
+        // Since 292 < 329 (our start_block_height), there are no results.
+        // The KVDigest at the boundary proves nothing exists >= (329, 329).
+        assert!(
+            compacted_changes.is_empty(),
+            "expected empty results since start_block_height 329 > last entry end_block 292"
+        );
+
+        // Log what we found for debugging
+        eprintln!("Root hash: {:?}", root_hash);
+        eprintln!("Number of compacted entries: {}", compacted_changes.len());
+        for (start, end, changes) in &compacted_changes {
+            eprintln!(
+                "  Blocks {}-{}: {} address changes",
+                start,
+                end,
+                changes.len()
+            );
+        }
     }
 }

--- a/packages/rs-drive/src/verify/address_funds/verify_compacted_address_balance_changes/v0/mod.rs
+++ b/packages/rs-drive/src/verify/address_funds/verify_compacted_address_balance_changes/v0/mod.rs
@@ -18,10 +18,10 @@ impl Drive {
     /// Verifies compacted address balance changes proof.
     ///
     /// Verification is done in two steps:
-    /// 1. First verify as SUBSET to examine what's in the proof and determine
-    ///    what actual_start_block was used when generating the proof.
-    /// 2. Then verify the main ascending query (not as subset) using the exact
-    ///    same query that was used for proving.
+    /// 1. First query in descending order to find a compacted range that might
+    ///    contain start_block_height (e.g., range 50-150 when querying from block 100).
+    /// 2. Then verify the main ascending query using the discovered start key,
+    ///    or fall back to (start_block_height, start_block_height) if no containing range.
     pub(super) fn verify_compacted_address_balance_changes_v0(
         proof: &[u8],
         start_block_height: u64,
@@ -37,14 +37,19 @@ impl Drive {
             .with_big_endian()
             .with_no_limit();
 
-        // Step 1: Use subset query with insert_all() to examine everything in the proof
-        // This allows us to find entries that might start before start_block_height
-        // but contain it (e.g., range 100-200 when querying from block 150)
-        let mut subset_query = Query::new();
-        subset_query.insert_all();
+        // Step 1: Query in descending order to find the closest entry before start_block_height.
+        // This finds compacted ranges that might contain our start_block_height
+        // (e.g., range 50-150 when querying from block 100).
+        let mut subset_query = Query::new_with_direction(false);
+
+        let mut key = Vec::with_capacity(16);
+        key.extend_from_slice(&start_block_height.to_be_bytes());
+        key.extend_from_slice(&start_block_height.to_be_bytes());
+
+        subset_query.insert_range_to(..key);
 
         let subset_path_query =
-            PathQuery::new(path.clone(), SizedQuery::new(subset_query, None, None));
+            PathQuery::new(path.clone(), SizedQuery::new(subset_query, Some(1), None));
 
         // Use verify_subset_query to look at what's in the proof
         let (root_hash, subset_results) = GroveDb::verify_subset_query(

--- a/packages/rs-drive/src/verify/address_funds/verify_compacted_address_balance_changes/v0/mod.rs
+++ b/packages/rs-drive/src/verify/address_funds/verify_compacted_address_balance_changes/v0/mod.rs
@@ -21,15 +21,13 @@ use super::VerifiedCompactedAddressBalanceChanges;
 fn extract_kv_entries_from_merk_proof(merk_proof: &[u8]) -> Vec<(Vec<u8>, Vec<u8>)> {
     let mut entries = Vec::new();
 
-    for op_result in MerkProofDecoder::new(merk_proof) {
-        if let Ok(op) = op_result {
-            match op {
-                MerkProofOp::Push(MerkProofNode::KV(key, value))
-                | MerkProofOp::PushInverted(MerkProofNode::KV(key, value)) => {
-                    entries.push((key, value));
-                }
-                _ => {}
+    for op in MerkProofDecoder::new(merk_proof).flatten() {
+        match op {
+            MerkProofOp::Push(MerkProofNode::KV(key, value))
+            | MerkProofOp::PushInverted(MerkProofNode::KV(key, value)) => {
+                entries.push((key, value));
             }
+            _ => {}
         }
     }
 

--- a/packages/rs-platform-version/Cargo.toml
+++ b/packages/rs-platform-version/Cargo.toml
@@ -11,7 +11,7 @@ license = "MIT"
 thiserror = { version = "2.0.12" }
 bincode = { version = "=2.0.0-rc.3" }
 versioned-feature-core = { git = "https://github.com/dashpay/versioned-feature-core", version = "1.0.0" }
-grovedb-version = { git = "https://github.com/dashpay/grovedb", rev = "83a8fe5b64a92fe25cb550f9e448b16345d920e9" }
+grovedb-version = { git = "https://github.com/dashpay/grovedb", rev = "a7bc60a6760c395e90489c655eee84ae75003af4" }
 once_cell = "1.19.0"
 
 [features]


### PR DESCRIPTION
## Issue being fixed or feature implemented
Updates the verification logic for compacted address balance changes to improve accuracy in determining the starting block height during proof verification.

## What was done?
- Changed the verification process to first query in descending order to find a compacted range that might contain the `start_block_height`.
- Adjusted the logic to use the discovered start key for the main ascending query, with a fallback to `(start_block_height, start_block_height)` if no containing range is found.

## How Has This Been Tested?
The changes have been tested through existing unit tests that cover the verification logic and ensure that the new querying method functions correctly.

## Breaking Changes
None

## Checklist
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests

  **For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Simplified address-balance verification to use merk-proof KV extraction and a single subset verification flow for clearer, more reliable checks.

* **Bug Fixes**
  * Stronger proof decoding/error mapping and improved handling of 16-byte range keys and fallbacks to avoid incorrect boundary interpretation.

* **Tests**
  * Added unit tests covering verification behavior and edge cases.

* **Chores**
  * Updated underlying storage-related revisions for related components.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->