### PR TITLE
fix(wasm-sdk): support ECDSA_SECP256K1 keys in contract create/update

### DIFF
--- a/packages/wasm-sdk/src/state_transitions/contracts/mod.rs
+++ b/packages/wasm-sdk/src/state_transitions/contracts/mod.rs
@@ -6,8 +6,32 @@ use dash_sdk::dpp::data_contract::conversion::json::DataContractJsonConversionMe
 use dash_sdk::dpp::data_contract::DataContract;
 use dash_sdk::dpp::identity::accessors::IdentityGettersV0;
 use dash_sdk::dpp::identity::identity_public_key::accessors::v0::IdentityPublicKeyGettersV0;
+use dash_sdk::dpp::identity::identity_public_key::IdentityPublicKey;
 use dash_sdk::dpp::identity::{KeyType, Purpose};
 use dash_sdk::dpp::platform_value::string_encoding::Encoding;
+
+/// Check if an ECDSA-derived public key matches an identity's public key.
+/// Supports ECDSA_SECP256K1 (33-byte comparison) and ECDSA_HASH160 (20-byte comparison).
+/// Returns false for non-ECDSA key types (BLS, EdDSA, etc.) since they require different derivation.
+fn ecdsa_public_key_matches_identity_key(
+    public_key_bytes: &[u8],   // 33-byte compressed secp256k1 public key
+    public_key_hash160: &[u8], // 20-byte hash160 of the public key
+    key: &IdentityPublicKey,
+) -> bool {
+    match key.key_type() {
+        KeyType::ECDSA_SECP256K1 => {
+            // Compare full 33-byte compressed public key
+            key.data().as_slice() == public_key_bytes
+        }
+        KeyType::ECDSA_HASH160 => {
+            // Compare 20-byte hash160
+            key.data().as_slice() == public_key_hash160
+        }
+        // BLS12_381 keys require separate BLS key derivation - not supported via ECDSA private key
+        // BIP13_SCRIPT_HASH and EDDSA_25519_HASH160 are also not derivable from ECDSA private key
+        _ => false,
+    }
+}
 use dash_sdk::dpp::state_transition::data_contract_update_transition::methods::DataContractUpdateTransitionMethodsV0;
 use dash_sdk::dpp::state_transition::data_contract_update_transition::DataContractUpdateTransition;
 use dash_sdk::platform::transition::broadcast::BroadcastStateTransition;
@@ -83,6 +107,7 @@ impl WasmSdk {
         };
 
         // Find matching key - prioritize key_id if provided, otherwise find any authentication key
+        // Supports ECDSA_SECP256K1 and ECDSA_HASH160 key types
         let matching_key = if let Some(requested_key_id) = key_id {
             // Find specific key by ID
             owner_identity
@@ -90,8 +115,11 @@ impl WasmSdk {
                 .get(&requested_key_id)
                 .filter(|key| {
                     key.purpose() == Purpose::AUTHENTICATION
-                        && key.key_type() == KeyType::ECDSA_HASH160
-                        && key.data().as_slice() == public_key_hash160.as_slice()
+                        && ecdsa_public_key_matches_identity_key(
+                            &public_key_bytes,
+                            &public_key_hash160,
+                            key,
+                        )
                 })
                 .ok_or_else(|| {
                     WasmSdkError::not_found(format!(
@@ -107,8 +135,11 @@ impl WasmSdk {
                 .iter()
                 .find(|(_, key)| {
                     key.purpose() == Purpose::AUTHENTICATION
-                        && key.key_type() == KeyType::ECDSA_HASH160
-                        && key.data().as_slice() == public_key_hash160.as_slice()
+                        && ecdsa_public_key_matches_identity_key(
+                            &public_key_bytes,
+                            &public_key_hash160,
+                            key,
+                        )
                 })
                 .map(|(_, key)| key.clone())
                 .ok_or_else(|| {
@@ -270,6 +301,7 @@ impl WasmSdk {
         };
 
         // Find matching key - prioritize key_id if provided, otherwise find any authentication key
+        // Supports ECDSA_SECP256K1 and ECDSA_HASH160 key types
         let matching_key = if let Some(requested_key_id) = key_id {
             // Find specific key by ID
             owner_identity
@@ -277,8 +309,11 @@ impl WasmSdk {
                 .get(&requested_key_id)
                 .filter(|key| {
                     key.purpose() == Purpose::AUTHENTICATION
-                        && key.key_type() == KeyType::ECDSA_HASH160
-                        && key.data().as_slice() == public_key_hash160.as_slice()
+                        && ecdsa_public_key_matches_identity_key(
+                            &public_key_bytes,
+                            &public_key_hash160,
+                            key,
+                        )
                 })
                 .ok_or_else(|| {
                     WasmSdkError::not_found(format!(
@@ -294,8 +329,11 @@ impl WasmSdk {
                 .iter()
                 .find(|(_, key)| {
                     key.purpose() == Purpose::AUTHENTICATION
-                        && key.key_type() == KeyType::ECDSA_HASH160
-                        && key.data().as_slice() == public_key_hash160.as_slice()
+                        && ecdsa_public_key_matches_identity_key(
+                            &public_key_bytes,
+                            &public_key_hash160,
+                            key,
+                        )
                 })
                 .map(|(_, key)| key.clone())
                 .ok_or_else(|| {

--- a/packages/wasm-sdk/src/state_transitions/contracts/mod.rs
+++ b/packages/wasm-sdk/src/state_transitions/contracts/mod.rs
@@ -6,33 +6,11 @@ use dash_sdk::dpp::data_contract::conversion::json::DataContractJsonConversionMe
 use dash_sdk::dpp::data_contract::DataContract;
 use dash_sdk::dpp::identity::accessors::IdentityGettersV0;
 use dash_sdk::dpp::identity::identity_public_key::accessors::v0::IdentityPublicKeyGettersV0;
-use dash_sdk::dpp::identity::identity_public_key::IdentityPublicKey;
-use dash_sdk::dpp::identity::{KeyType, Purpose};
+use dash_sdk::dpp::identity::Purpose;
 use dash_sdk::dpp::platform_value::string_encoding::Encoding;
-
-/// Check if an ECDSA-derived public key matches an identity's public key.
-/// Supports ECDSA_SECP256K1 (33-byte comparison) and ECDSA_HASH160 (20-byte comparison).
-/// Returns false for non-ECDSA key types (BLS, EdDSA, etc.) since they require different derivation.
-fn ecdsa_public_key_matches_identity_key(
-    public_key_bytes: &[u8],   // 33-byte compressed secp256k1 public key
-    public_key_hash160: &[u8], // 20-byte hash160 of the public key
-    key: &IdentityPublicKey,
-) -> bool {
-    match key.key_type() {
-        KeyType::ECDSA_SECP256K1 => {
-            // Compare full 33-byte compressed public key
-            key.data().as_slice() == public_key_bytes
-        }
-        KeyType::ECDSA_HASH160 => {
-            // Compare 20-byte hash160
-            key.data().as_slice() == public_key_hash160
-        }
-        // BLS12_381 keys require separate BLS key derivation - not supported via ECDSA private key
-        // BIP13_SCRIPT_HASH and EDDSA_25519_HASH160 are also not derivable from ECDSA private key
-        _ => false,
-    }
-}
 use dash_sdk::dpp::state_transition::data_contract_update_transition::methods::DataContractUpdateTransitionMethodsV0;
+
+use super::identity::ecdsa_public_key_matches_identity_key;
 use dash_sdk::dpp::state_transition::data_contract_update_transition::DataContractUpdateTransition;
 use dash_sdk::platform::transition::broadcast::BroadcastStateTransition;
 use dash_sdk::platform::transition::put_contract::PutContract;

--- a/packages/wasm-sdk/src/state_transitions/identity/mod.rs
+++ b/packages/wasm-sdk/src/state_transitions/identity/mod.rs
@@ -66,7 +66,7 @@ fn parse_security_level(s: Option<&str>) -> SecurityLevel {
 /// Check if an ECDSA-derived public key matches an identity's public key.
 /// Supports ECDSA_SECP256K1 (33-byte comparison) and ECDSA_HASH160 (20-byte comparison).
 /// Returns false for non-ECDSA key types (BLS, EdDSA, etc.) since they require different derivation.
-fn ecdsa_public_key_matches_identity_key(
+pub(crate) fn ecdsa_public_key_matches_identity_key(
     public_key_bytes: &[u8],   // 33-byte compressed secp256k1 public key
     public_key_hash160: &[u8], // 20-byte hash160 of the public key
     key: &IdentityPublicKey,


### PR DESCRIPTION
## Issue being fixed or feature implemented
The contract_create and contract_update functions only matched ECDSA_HASH160 key types when finding authentication keys, ignoring ECDSA_SECP256K1 keys entirely. This caused identities with ECDSA_SECP256K1 authentication keys to fail contract operations with "No matching authentication key found" errors.

## What was done?
Added ecdsa_public_key_matches_identity_key helper function that correctly handles both key types:
- ECDSA_SECP256K1: compares full 33-byte compressed public key
- ECDSA_HASH160: compares 20-byte hash160

This matches the correct pattern already used in the identity state transitions module.

## How Has This Been Tested?

## Breaking Changes
None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [ ] I have made corresponding changes to the documentation if needed

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved key validation to correctly handle multiple ECDSA key formats during contract creation and updates, increasing compatibility with diverse identity key configurations. No public API or signature changes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->