### PR TITLE
fix(drive): use historical path query for contracts with keeps_history=true

### DIFF
--- a/packages/rs-dpp/src/data_contract/serialized_version/mod.rs
+++ b/packages/rs-dpp/src/data_contract/serialized_version/mod.rs
@@ -1,5 +1,6 @@
 use super::EMPTY_KEYWORDS;
 use crate::data_contract::associated_token::token_configuration::TokenConfiguration;
+use crate::data_contract::config::DataContractConfig;
 use crate::data_contract::group::Group;
 use crate::data_contract::serialized_version::v0::DataContractInSerializationFormatV0;
 use crate::data_contract::serialized_version::v1::DataContractInSerializationFormatV1;
@@ -138,6 +139,14 @@ impl DataContractInSerializationFormat {
         match self {
             DataContractInSerializationFormat::V0(v0) => v0.version,
             DataContractInSerializationFormat::V1(v1) => v1.version,
+        }
+    }
+
+    /// Returns the config for the data contract.
+    pub fn config(&self) -> &DataContractConfig {
+        match self {
+            DataContractInSerializationFormat::V0(v0) => &v0.config,
+            DataContractInSerializationFormat::V1(v1) => &v1.config,
         }
     }
 

--- a/packages/rs-drive-abci/tests/strategy_tests/test_cases/data_contract_history_tests.rs
+++ b/packages/rs-drive-abci/tests/strategy_tests/test_cases/data_contract_history_tests.rs
@@ -15,7 +15,9 @@ mod tests {
     use crate::execution::run_chain_for_strategy;
     use crate::strategy::NetworkStrategy;
     use dpp::data_contract::accessors::v0::DataContractV0Getters;
-    use dpp::data_contract::config::v0::{DataContractConfigGettersV0, DataContractConfigSettersV0};
+    use dpp::data_contract::config::v0::{
+        DataContractConfigGettersV0, DataContractConfigSettersV0,
+    };
     use dpp::tests::json_document::json_document_to_created_contract;
     use drive_abci::config::{
         ChainLockConfig, ExecutionConfig, InstantLockConfig, PlatformConfig, PlatformTestConfig,
@@ -109,9 +111,17 @@ mod tests {
 
         // Verify all state transitions succeeded (including contract creation)
         for (block_height, tx_results) in outcome.state_transition_results_per_block.iter() {
-            println!("Block {}: {} state transitions", block_height, tx_results.len());
+            println!(
+                "Block {}: {} state transitions",
+                block_height,
+                tx_results.len()
+            );
             for (state_transition, result) in tx_results {
-                println!("  ST type: {:?}, code: {}", state_transition.state_transition_type(), result.code);
+                println!(
+                    "  ST type: {:?}, code: {}",
+                    state_transition.state_transition_type(),
+                    result.code
+                );
                 assert_eq!(
                     result.code, 0,
                     "state transition got code {} : {:?}",
@@ -138,13 +148,7 @@ mod tests {
             .abci_app
             .platform
             .drive
-            .fetch_contract(
-                contract_id.to_buffer(),
-                None,
-                None,
-                None,
-                platform_version,
-            )
+            .fetch_contract(contract_id.to_buffer(), None, None, None, platform_version)
             .value
             .expect("expected to execute the fetch of a contract")
             .expect("expected to get a contract fetch info");

--- a/packages/rs-drive-abci/tests/strategy_tests/test_cases/data_contract_history_tests.rs
+++ b/packages/rs-drive-abci/tests/strategy_tests/test_cases/data_contract_history_tests.rs
@@ -1,0 +1,299 @@
+//! Regression tests for data contract history (keeps_history) proof verification.
+//!
+//! These tests verify that contracts with `keeps_history=true` can be created and updated
+//! successfully, with proper proof verification.
+//!
+//! Bug fixed: When creating/updating a data contract with `keeps_history=true`, the proof
+//! verification would fail with "proof did not contain contract with id ... expected to
+//! exist because of state transition (create)".
+//!
+//! Root cause: In `prove_state_transition_v0`, the code always used non-historical path
+//! queries regardless of whether the contract had `keeps_history=true`.
+
+#[cfg(test)]
+mod tests {
+    use crate::execution::run_chain_for_strategy;
+    use crate::strategy::NetworkStrategy;
+    use dpp::data_contract::accessors::v0::DataContractV0Getters;
+    use dpp::data_contract::config::v0::{DataContractConfigGettersV0, DataContractConfigSettersV0};
+    use dpp::tests::json_document::json_document_to_created_contract;
+    use drive_abci::config::{
+        ChainLockConfig, ExecutionConfig, InstantLockConfig, PlatformConfig, PlatformTestConfig,
+        ValidatorSetConfig,
+    };
+    use drive_abci::test::helpers::setup::TestPlatformBuilder;
+    use platform_version::version::PlatformVersion;
+    use strategy_tests::frequency::Frequency;
+    use strategy_tests::{IdentityInsertInfo, StartAddresses, StartIdentities, Strategy};
+
+    /// Regression test for historical contract proof verification bug.
+    ///
+    /// Bug: When creating a data contract with `keeps_history=true`, the proof
+    /// verification would fail with "proof did not contain contract with id ...
+    /// expected to exist because of state transition (create)".
+    ///
+    /// Root cause: In `prove_state_transition_v0`, the code always used
+    /// `contract_ids_to_non_historical_path_query` regardless of whether
+    /// the contract had `keeps_history=true`.
+    #[test]
+    fn run_chain_create_contract_with_keeps_history_true() {
+        let platform_version = PlatformVersion::latest();
+
+        // Load a base contract and modify it to enable keeps_history
+        let mut contract = json_document_to_created_contract(
+            "tests/supporting_files/contract/dashpay/dashpay-contract-all-mutable.json",
+            1,
+            true,
+            platform_version,
+        )
+        .expect("expected to get contract from a json document");
+
+        // Enable keeps_history on the contract configuration
+        contract
+            .data_contract_mut()
+            .config_mut()
+            .set_keeps_history(true);
+
+        let strategy = NetworkStrategy {
+            strategy: Strategy {
+                start_contracts: vec![(contract.clone(), None)],
+                operations: vec![],
+                start_identities: StartIdentities::default(),
+                start_addresses: StartAddresses::default(),
+                identity_inserts: IdentityInsertInfo {
+                    frequency: Frequency {
+                        times_per_block_range: 1..2,
+                        chance_per_block: None,
+                    },
+                    ..Default::default()
+                },
+                identity_contract_nonce_gaps: None,
+                signer: None,
+            },
+            total_hpmns: 100,
+            extra_normal_mns: 0,
+            validator_quorum_count: 24,
+            chain_lock_quorum_count: 24,
+            upgrading_info: None,
+            proposer_strategy: Default::default(),
+            rotate_quorums: false,
+            failure_testing: None,
+            query_testing: None,
+            // CRITICAL: This flag enables proof verification for all state transitions
+            // This is what catches the bug - proof verification fails without the fix
+            verify_state_transition_results: true,
+            ..Default::default()
+        };
+
+        let config = PlatformConfig {
+            validator_set: ValidatorSetConfig::default_100_67(),
+            chain_lock: ChainLockConfig::default_100_67(),
+            instant_lock: InstantLockConfig::default_100_67(),
+            execution: ExecutionConfig {
+                verify_sum_trees: true,
+                ..Default::default()
+            },
+            block_spacing_ms: 3000,
+            testing_configs: PlatformTestConfig::default_minimal_verifications(),
+            ..Default::default()
+        };
+
+        let mut platform = TestPlatformBuilder::new()
+            .with_config(config.clone())
+            .build_with_mock_rpc();
+
+        // Run the chain - this will create identities and the contract with keeps_history=true
+        // The verify_state_transition_results flag ensures proofs are verified
+        let outcome =
+            run_chain_for_strategy(&mut platform, 2, strategy, config, 15, &mut None, &mut None);
+
+        // Verify all state transitions succeeded (including contract creation)
+        for (block_height, tx_results) in outcome.state_transition_results_per_block.iter() {
+            println!("Block {}: {} state transitions", block_height, tx_results.len());
+            for (state_transition, result) in tx_results {
+                println!("  ST type: {:?}, code: {}", state_transition.state_transition_type(), result.code);
+                assert_eq!(
+                    result.code, 0,
+                    "state transition got code {} : {:?}",
+                    result.code, state_transition
+                );
+            }
+        }
+
+        // Verify we can fetch the contract and it has keeps_history enabled
+        // The contract ID is regenerated when the state transition is created,
+        // so we need to get the actual ID from the strategy's contracts
+        let contract_id = outcome
+            .strategy
+            .strategy
+            .start_contracts
+            .first()
+            .expect("expected at least one contract")
+            .0
+            .data_contract()
+            .id();
+        println!("Looking for contract with ID: {:?}", contract_id);
+
+        let fetched_contract = outcome
+            .abci_app
+            .platform
+            .drive
+            .fetch_contract(
+                contract_id.to_buffer(),
+                None,
+                None,
+                None,
+                platform_version,
+            )
+            .value
+            .expect("expected to execute the fetch of a contract")
+            .expect("expected to get a contract fetch info");
+
+        // Verify the contract has keeps_history enabled
+        assert!(
+            fetched_contract.contract.config().keeps_history(),
+            "Contract should have keeps_history=true"
+        );
+    }
+
+    /// Test both historical and non-historical contract creation in the same chain
+    /// to ensure both paths work correctly.
+    #[test]
+    fn run_chain_create_contracts_with_and_without_history() {
+        let platform_version = PlatformVersion::latest();
+
+        // Contract 1: keeps_history = true
+        let mut historical_contract = json_document_to_created_contract(
+            "tests/supporting_files/contract/dashpay/dashpay-contract-all-mutable.json",
+            1,
+            true,
+            platform_version,
+        )
+        .expect("expected to get contract from a json document");
+        historical_contract
+            .data_contract_mut()
+            .config_mut()
+            .set_keeps_history(true);
+
+        // Contract 2: keeps_history = false (default)
+        let non_historical_contract = json_document_to_created_contract(
+            "tests/supporting_files/contract/dashpay/dashpay-contract-all-mutable.json",
+            2,
+            true,
+            platform_version,
+        )
+        .expect("expected to get contract from a json document");
+        // Note: keeps_history defaults to false, so we don't need to set it
+
+        let strategy = NetworkStrategy {
+            strategy: Strategy {
+                start_contracts: vec![
+                    (historical_contract.clone(), None),
+                    (non_historical_contract.clone(), None),
+                ],
+                operations: vec![],
+                start_identities: StartIdentities::default(),
+                start_addresses: StartAddresses::default(),
+                identity_inserts: IdentityInsertInfo {
+                    frequency: Frequency {
+                        times_per_block_range: 2..3, // Create 2 identities per block
+                        chance_per_block: None,
+                    },
+                    ..Default::default()
+                },
+                identity_contract_nonce_gaps: None,
+                signer: None,
+            },
+            total_hpmns: 100,
+            extra_normal_mns: 0,
+            validator_quorum_count: 24,
+            chain_lock_quorum_count: 24,
+            upgrading_info: None,
+            proposer_strategy: Default::default(),
+            rotate_quorums: false,
+            failure_testing: None,
+            query_testing: None,
+            verify_state_transition_results: true,
+            ..Default::default()
+        };
+
+        let config = PlatformConfig {
+            validator_set: ValidatorSetConfig::default_100_67(),
+            chain_lock: ChainLockConfig::default_100_67(),
+            instant_lock: InstantLockConfig::default_100_67(),
+            execution: ExecutionConfig {
+                verify_sum_trees: true,
+                ..Default::default()
+            },
+            block_spacing_ms: 3000,
+            testing_configs: PlatformTestConfig::default_minimal_verifications(),
+            ..Default::default()
+        };
+
+        let mut platform = TestPlatformBuilder::new()
+            .with_config(config.clone())
+            .build_with_mock_rpc();
+
+        let outcome =
+            run_chain_for_strategy(&mut platform, 3, strategy, config, 15, &mut None, &mut None);
+
+        // Verify all state transitions succeeded
+        for tx_results_per_block in outcome.state_transition_results_per_block.values() {
+            for (state_transition, result) in tx_results_per_block {
+                assert_eq!(
+                    result.code, 0,
+                    "state transition got code {} : {:?}",
+                    result.code, state_transition
+                );
+            }
+        }
+
+        // Get the actual contract IDs from the strategy (they get regenerated)
+        let contracts = &outcome.strategy.strategy.start_contracts;
+        assert_eq!(contracts.len(), 2, "Expected 2 contracts");
+
+        // Verify historical contract exists and has correct keeps_history setting
+        let historical_id = contracts[0].0.data_contract().id();
+        let fetched_historical = outcome
+            .abci_app
+            .platform
+            .drive
+            .fetch_contract(
+                historical_id.to_buffer(),
+                None,
+                None,
+                None,
+                platform_version,
+            )
+            .value
+            .expect("expected to fetch contract")
+            .expect("expected contract fetch info");
+
+        assert!(
+            fetched_historical.contract.config().keeps_history(),
+            "Historical contract should have keeps_history=true"
+        );
+
+        // Verify non-historical contract exists and has correct keeps_history setting
+        let non_historical_id = contracts[1].0.data_contract().id();
+        let fetched_non_historical = outcome
+            .abci_app
+            .platform
+            .drive
+            .fetch_contract(
+                non_historical_id.to_buffer(),
+                None,
+                None,
+                None,
+                platform_version,
+            )
+            .value
+            .expect("expected to fetch contract")
+            .expect("expected contract fetch info");
+
+        assert!(
+            !fetched_non_historical.contract.config().keeps_history(),
+            "Non-historical contract should have keeps_history=false"
+        );
+    }
+}

--- a/packages/rs-drive-abci/tests/strategy_tests/test_cases/mod.rs
+++ b/packages/rs-drive-abci/tests/strategy_tests/test_cases/mod.rs
@@ -3,6 +3,7 @@ mod basic_tests;
 mod chain_lock_update_tests;
 mod core_height_increase;
 mod core_update_tests;
+mod data_contract_history_tests;
 mod identity_and_document_tests;
 mod identity_transfer_tests;
 mod token_tests;

--- a/packages/rs-drive-abci/tests/strategy_tests/verify_state_transitions.rs
+++ b/packages/rs-drive-abci/tests/strategy_tests/verify_state_transitions.rs
@@ -1,6 +1,7 @@
 use dpp::address_funds::PlatformAddress;
 use dpp::block::block_info::BlockInfo;
 use dpp::data_contract::accessors::v0::DataContractV0Getters;
+use dpp::data_contract::config::v0::DataContractConfigGettersV0;
 use dpp::data_contract::document_type::accessors::DocumentTypeV0Getters;
 use dpp::document::{Document, DocumentV0Getters};
 use dpp::fee::Credits;
@@ -397,9 +398,13 @@ pub(crate) fn verify_state_transitions_were_or_were_not_executed(
                     // let fetched_contract = abci_app
                     //     .platform.drive.fetch_contract(data_contract_create.data_contract_ref().id().into_buffer(), None, None, None, platform_version).unwrap().unwrap();
                     // we expect to get an identity that matches the state transition
+                    let keeps_history = data_contract_create
+                        .data_contract_ref()
+                        .config()
+                        .keeps_history();
                     let (root_hash, contract) = Drive::verify_contract(
                         &response_proof.grovedb_proof,
-                        None,
+                        Some(keeps_history),
                         false,
                         true,
                         data_contract_create.data_contract_ref().id().into_buffer(),
@@ -426,15 +431,19 @@ pub(crate) fn verify_state_transitions_were_or_were_not_executed(
                 }
                 StateTransitionAction::DataContractUpdateAction(data_contract_update) => {
                     // we expect to get an identity that matches the state transition
+                    let keeps_history = data_contract_update
+                        .data_contract_ref()
+                        .config()
+                        .keeps_history();
                     let (root_hash, contract) = Drive::verify_contract(
                         &response_proof.grovedb_proof,
-                        None,
+                        Some(keeps_history),
                         false,
                         true,
                         data_contract_update.data_contract_ref().id().into_buffer(),
                         platform_version,
                     )
-                    .expect("expected to verify full identity");
+                    .expect("expected to verify contract");
                     assert_eq!(
                         &root_hash,
                         expected_root_hash,

--- a/packages/rs-drive/src/prove/prove_state_transition/v0/mod.rs
+++ b/packages/rs-drive/src/prove/prove_state_transition/v0/mod.rs
@@ -21,6 +21,8 @@ use dpp::state_transition::batch_transition::batched_transition::token_transitio
 use dpp::state_transition::batch_transition::batched_transition::BatchedTransitionRef;
 use dpp::state_transition::batch_transition::document_base_transition::v0::v0_methods::DocumentBaseTransitionV0Methods;
 use dpp::state_transition::batch_transition::document_create_transition::v0::v0_methods::DocumentCreateTransitionV0Methods;
+use dpp::state_transition::data_contract_create_transition::accessors::DataContractCreateTransitionAccessorsV0;
+use dpp::state_transition::data_contract_update_transition::accessors::DataContractUpdateTransitionAccessorsV0;
 use dpp::state_transition::identity_create_from_addresses_transition::accessors::IdentityCreateFromAddressesTransitionAccessorsV0;
 use dpp::state_transition::identity_create_transition::accessors::IdentityCreateTransitionAccessorsV0;
 use dpp::state_transition::identity_credit_transfer_to_addresses_transition::accessors::IdentityCreditTransferToAddressesTransitionAccessorsV0;
@@ -32,8 +34,6 @@ use dpp::state_transition::identity_update_transition::accessors::IdentityUpdate
 use dpp::state_transition::masternode_vote_transition::accessors::MasternodeVoteTransitionAccessorsV0;
 use dpp::state_transition::StateTransitionIdentityIdFromInputs;
 use dpp::state_transition::StateTransitionWitnessSigned;
-use dpp::state_transition::data_contract_create_transition::accessors::DataContractCreateTransitionAccessorsV0;
-use dpp::state_transition::data_contract_update_transition::accessors::DataContractUpdateTransitionAccessorsV0;
 use dpp::state_transition::{StateTransition, StateTransitionLike, StateTransitionOwned};
 use dpp::voting::votes::resource_vote::accessors::v0::ResourceVoteGettersV0;
 use dpp::voting::votes::Vote;

--- a/packages/rs-drive/src/prove/prove_state_transition/v0/mod.rs
+++ b/packages/rs-drive/src/prove/prove_state_transition/v0/mod.rs
@@ -7,6 +7,7 @@ use crate::query::{
 };
 use crate::verify::state_transition::state_transition_execution_path_queries::TryTransitionIntoPathQuery;
 use dpp::data_contract::accessors::v0::DataContractV0Getters;
+use dpp::data_contract::config::v0::DataContractConfigGettersV0;
 use dpp::data_contract::document_type::accessors::DocumentTypeV0Getters;
 use dpp::identifier::Identifier;
 use dpp::state_transition::address_credit_withdrawal_transition::accessors::AddressCreditWithdrawalTransitionAccessorsV0;
@@ -31,6 +32,8 @@ use dpp::state_transition::identity_update_transition::accessors::IdentityUpdate
 use dpp::state_transition::masternode_vote_transition::accessors::MasternodeVoteTransitionAccessorsV0;
 use dpp::state_transition::StateTransitionIdentityIdFromInputs;
 use dpp::state_transition::StateTransitionWitnessSigned;
+use dpp::state_transition::data_contract_create_transition::accessors::DataContractCreateTransitionAccessorsV0;
+use dpp::state_transition::data_contract_update_transition::accessors::DataContractUpdateTransitionAccessorsV0;
 use dpp::state_transition::{StateTransition, StateTransitionLike, StateTransitionOwned};
 use dpp::voting::votes::resource_vote::accessors::v0::ResourceVoteGettersV0;
 use dpp::voting::votes::Vote;
@@ -45,6 +48,14 @@ fn contract_ids_to_non_historical_path_query(contract_ids: &[Identifier]) -> Pat
     path_query
 }
 
+fn contract_ids_to_historical_path_query(contract_ids: &[Identifier]) -> PathQuery {
+    let contract_ids: Vec<_> = contract_ids.iter().map(|id| id.to_buffer()).collect();
+
+    let mut path_query = Drive::fetch_historical_contracts_query(&contract_ids);
+    path_query.query.limit = None;
+    path_query
+}
+
 impl Drive {
     pub(super) fn prove_state_transition_v0(
         &self,
@@ -54,10 +65,18 @@ impl Drive {
     ) -> Result<ProofCreationResult<Vec<u8>>, Error> {
         let path_query = match state_transition {
             StateTransition::DataContractCreate(st) => {
-                contract_ids_to_non_historical_path_query(&st.modified_data_ids())
+                if st.data_contract().config().keeps_history() {
+                    contract_ids_to_historical_path_query(&st.modified_data_ids())
+                } else {
+                    contract_ids_to_non_historical_path_query(&st.modified_data_ids())
+                }
             }
             StateTransition::DataContractUpdate(st) => {
-                contract_ids_to_non_historical_path_query(&st.modified_data_ids())
+                if st.data_contract().config().keeps_history() {
+                    contract_ids_to_historical_path_query(&st.modified_data_ids())
+                } else {
+                    contract_ids_to_non_historical_path_query(&st.modified_data_ids())
+                }
             }
             StateTransition::Batch(st) => {
                 if st.transitions_len() > 1 {


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
When creating/updating a data contract with keeps_history=true, the proof verification would fail with "proof did not contain contract with id ...".

Root cause: In prove_state_transition_v0, the code always used non-historical path queries regardless of whether the contract had keeps_history=true.


## What was done?
Fix:
- Check keeps_history() config on data contract and use appropriate path query
- Update verify_state_transitions.rs to pass keeps_history to Drive::verify_contract
- Add config() accessor to DataContractInSerializationFormat


## How Has This Been Tested?
Includes regression tests that verify:
- Contract creation with keeps_history=true works with proof verification
- Both historical and non-historical contracts work correctly together


## Breaking Changes
None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [ ] I have made corresponding changes to the documentation if needed

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added regression tests covering data contract history: creation and verification with historical tracking enabled and mixed-history scenarios.

* **Bug Fixes**
  * Verification now respects a contract's historical tracking flag, ensuring correct proof paths for contracts with and without history.

* **Refactor**
  * Centralized access to contract configuration and adjusted query logic to support history-aware data lookups.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->