### PR TITLE
refactor(sdk): re-use sdk methods

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7355,7 +7355,6 @@ dependencies = [
  "serde-wasm-bindgen 0.5.0 (git+https://github.com/dashpay/serde-wasm-bindgen?branch=fix%2Fuint8array-to-bytes)",
  "serde_json",
  "sha2",
- "simple-signer",
  "thiserror 2.0.17",
  "tracing",
  "tracing-subscriber",

--- a/packages/js-evo-sdk/tests/unit/facades/dpns.spec.mjs
+++ b/packages/js-evo-sdk/tests/unit/facades/dpns.spec.mjs
@@ -34,15 +34,23 @@ describe('DPNSFacade', () => {
   it('name resolution and registration forward correctly', async () => {
     await client.dpns.isNameAvailable('label');
     await client.dpns.resolveName('name');
+
+    // New API uses identity, identityKey, and signer instead of identityId/publicKeyId/privateKeyWif
+    const mockIdentity = {};
+    const mockIdentityKey = {};
+    const mockSigner = {};
     await client.dpns.registerName({
-      label: 'l', identityId: 'i', publicKeyId: 1, privateKeyWif: 'w',
+      label: 'l',
+      identity: mockIdentity,
+      identityKey: mockIdentityKey,
+      signer: mockSigner,
     });
     await client.dpns.usernames({ identityId: 'i', limit: 2 });
     await client.dpns.username('i');
     await client.dpns.usernamesWithProof({ identityId: 'i', limit: 3 });
     await client.dpns.usernameWithProof('i');
-    await client.dpns.getUsernameByName('u');
-    await client.dpns.getUsernameByNameWithProof('u');
+    await client.dpns.getUsernameByName('u.dash');
+    await client.dpns.getUsernameByNameWithProof('u.dash');
 
     expect(wasmSdk.dpnsIsNameAvailable).to.be.calledOnceWithExactly('label');
     expect(wasmSdk.dpnsResolveName).to.be.calledOnceWithExactly('name');
@@ -51,93 +59,8 @@ describe('DPNSFacade', () => {
     expect(wasmSdk.getDpnsUsername).to.be.calledOnceWithExactly('i');
     expect(wasmSdk.getDpnsUsernamesWithProofInfo).to.be.calledOnceWithExactly({ identityId: 'i', limit: 3 });
     expect(wasmSdk.getDpnsUsernameWithProofInfo).to.be.calledOnceWithExactly('i');
-    expect(wasmSdk.getDpnsUsernameByName).to.be.calledOnceWithExactly('u');
-    expect(wasmSdk.getDpnsUsernameByNameWithProofInfo).to.be.calledOnceWithExactly('u');
+    expect(wasmSdk.getDpnsUsernameByName).to.be.calledOnceWithExactly('u.dash');
+    expect(wasmSdk.getDpnsUsernameByNameWithProofInfo).to.be.calledOnceWithExactly('u.dash');
   });
 
-  describe('registerName validation', () => {
-    it('should throw error when publicKeyId is not provided', async () => {
-      try {
-        await client.dpns.registerName({
-          label: 'test',
-          identityId: 'someId',
-          privateKeyWif: 'someKey',
-          // publicKeyId intentionally omitted
-        });
-        expect.fail('Should have thrown an error');
-      } catch (error) {
-        expect(error.message).to.include('publicKeyId is required');
-        expect(error.message).to.include('CRITICAL or HIGH security level');
-      }
-    });
-
-    it('should throw error when publicKeyId is undefined', async () => {
-      try {
-        await client.dpns.registerName({
-          label: 'test',
-          identityId: 'someId',
-          publicKeyId: undefined,
-          privateKeyWif: 'someKey',
-        });
-        expect.fail('Should have thrown an error');
-      } catch (error) {
-        expect(error.message).to.include('publicKeyId is required');
-        expect(error.message).to.include('CRITICAL or HIGH security level');
-      }
-    });
-
-    it('should throw error when publicKeyId is null', async () => {
-      try {
-        await client.dpns.registerName({
-          label: 'test',
-          identityId: 'someId',
-          publicKeyId: null,
-          privateKeyWif: 'someKey',
-        });
-        expect.fail('Should have thrown an error');
-      } catch (error) {
-        expect(error.message).to.include('publicKeyId is required');
-        expect(error.message).to.include('CRITICAL or HIGH security level');
-      }
-    });
-
-    it('should throw error when publicKeyId is negative', async () => {
-      try {
-        await client.dpns.registerName({
-          label: 'test',
-          identityId: 'someId',
-          publicKeyId: -1,
-          privateKeyWif: 'someKey',
-        });
-        expect.fail('Should have thrown an error');
-      } catch (error) {
-        expect(error.message).to.include('must be a non-negative number');
-        expect(error.message).to.include('got: -1');
-      }
-    });
-
-    it('should throw error when publicKeyId is not a number', async () => {
-      try {
-        await client.dpns.registerName({
-          label: 'test',
-          identityId: 'someId',
-          publicKeyId: '1',
-          privateKeyWif: 'someKey',
-        });
-        expect.fail('Should have thrown an error');
-      } catch (error) {
-        expect(error.message).to.include('must be a non-negative number');
-      }
-    });
-
-    it('should accept valid publicKeyId', async () => {
-      await client.dpns.registerName({
-        label: 'test',
-        identityId: 'someId',
-        publicKeyId: 1,
-        privateKeyWif: 'someKey',
-      });
-      expect(wasmSdk.dpnsRegisterName).to.be.calledOnce();
-    });
-  });
 });

--- a/packages/js-evo-sdk/tests/unit/facades/dpns.spec.mjs
+++ b/packages/js-evo-sdk/tests/unit/facades/dpns.spec.mjs
@@ -35,7 +35,7 @@ describe('DPNSFacade', () => {
     await client.dpns.isNameAvailable('label');
     await client.dpns.resolveName('name');
 
-    // New API uses identity, identityKey, and signer instead of identityId/publicKeyId/privateKeyWif
+    // New API uses identity, identityKey, signer instead of identityId/publicKeyId/privateKeyWif
     const mockIdentity = {};
     const mockIdentityKey = {};
     const mockSigner = {};
@@ -62,5 +62,4 @@ describe('DPNSFacade', () => {
     expect(wasmSdk.getDpnsUsernameByName).to.be.calledOnceWithExactly('u.dash');
     expect(wasmSdk.getDpnsUsernameByNameWithProofInfo).to.be.calledOnceWithExactly('u.dash');
   });
-
 });

--- a/packages/wasm-sdk/Cargo.toml
+++ b/packages/wasm-sdk/Cargo.toml
@@ -59,7 +59,6 @@ dash-sdk = { path = "../rs-sdk", features = [
   "serde",
   "core_key_wallet",
 ], default-features = false }
-simple-signer = { path = "../simple-signer", features = ["state-transitions"] }
 drive = { path = "../rs-drive", default-features = false, features = [
   "verify",
 ] }

--- a/packages/wasm-sdk/src/dpns.rs
+++ b/packages/wasm-sdk/src/dpns.rs
@@ -257,10 +257,11 @@ impl WasmSdk {
         identity_id: Identifier,
         limit: Option<u32>,
     ) -> Result<Array, WasmSdkError> {
-        // Use rs-sdk method
+        // Use rs-sdk method with resolved limit for consistency with proof path
+        let resolved_limit = resolve_dpns_usernames_limit(limit);
         let usernames = self
             .as_ref()
-            .get_dpns_usernames_by_identity(identity_id, limit)
+            .get_dpns_usernames_by_identity(identity_id, Some(resolved_limit))
             .await?;
 
         let array = Array::new();

--- a/packages/wasm-sdk/src/dpns.rs
+++ b/packages/wasm-sdk/src/dpns.rs
@@ -252,37 +252,22 @@ impl WasmSdk {
         Ok(Arc::new(contract))
     }
 
-    async fn prepare_dpns_usernames_query(
-        &self,
-        identity_id: Identifier,
-        limit: Option<u32>,
-    ) -> Result<DocumentQuery, WasmSdkError> {
-        let dpns_contract = self.get_dpns_contract().await?;
-
-        let mut query = DocumentQuery::new(dpns_contract, DPNS_DOCUMENT_TYPE)?;
-
-        let where_clause = WhereClause {
-            field: "records.identity".to_string(),
-            operator: WhereOperator::Equal,
-            value: Value::Identifier(identity_id.to_buffer()),
-        };
-
-        query = query.with_where(where_clause);
-        query.limit = resolve_dpns_usernames_limit(limit);
-
-        Ok(query)
-    }
-
     async fn fetch_dpns_usernames(
         &self,
         identity_id: Identifier,
         limit: Option<u32>,
     ) -> Result<Array, WasmSdkError> {
-        let query = self
-            .prepare_dpns_usernames_query(identity_id, limit)
+        // Use rs-sdk method
+        let usernames = self
+            .as_ref()
+            .get_dpns_usernames_by_identity(identity_id, limit)
             .await?;
-        let documents_result: Documents = Document::fetch_many(self.as_ref(), query).await?;
-        Ok(usernames_from_documents(documents_result))
+
+        let array = Array::new();
+        for username in usernames {
+            array.push(&JsValue::from_str(&username.full_name));
+        }
+        Ok(array)
     }
 
     async fn fetch_dpns_usernames_with_proof(
@@ -290,9 +275,23 @@ impl WasmSdk {
         identity_id: Identifier,
         limit: Option<u32>,
     ) -> Result<ProofMetadataResponseWasm, WasmSdkError> {
-        let query = self
-            .prepare_dpns_usernames_query(identity_id, limit)
-            .await?;
+        // For proof queries, we still need to use document query directly
+        // as rs-sdk doesn't have a with_proof variant
+        let dpns_contract = self.get_dpns_contract().await?;
+
+        let query = DocumentQuery {
+            data_contract: dpns_contract,
+            document_type_name: DPNS_DOCUMENT_TYPE.to_string(),
+            where_clauses: vec![WhereClause {
+                field: "records.identity".to_string(),
+                operator: WhereOperator::Equal,
+                value: Value::Identifier(identity_id.to_buffer()),
+            }],
+            order_by_clauses: vec![],
+            limit: resolve_dpns_usernames_limit(limit),
+            start: None,
+        };
+
         let (documents_result, metadata, proof) =
             Document::fetch_many_with_metadata_and_proof(self.as_ref(), query, None).await?;
         let usernames_array = usernames_from_documents(documents_result);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
DPNS methods in JS SDK should re-use existing rs sdk methods

## What was done?
<!--- Describe your changes in detail -->
- https://github.com/dashpay/platform/commit/68e57b6692ee201fe2933aac544abffab6d09a4b
- refactored dpns methods to reuse existing rs sdk methods

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
With exiting tests

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [x] I have made corresponding changes to the documentation if needed

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * DPNS username retrieval: non-proof calls now return a simple array of full-name strings; proof-enabled calls continue to return usernames with metadata and cryptographic proof.

* **Breaking Changes**
  * DPNS registerName payload updated to { identity, identityKey, signer }.
  * Username lookup inputs now expect full names (e.g., "u.dash").

* **Chores**
  * Removed an unused SDK dependency from the build.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->