### PR TITLE
build(sdk): remove unmaintained rustls-pemfile, update lru to 0.16.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1451,7 +1451,7 @@ dependencies = [
  "platform-wallet",
  "rs-dapi-client",
  "rs-sdk-trusted-context-provider",
- "rustls-pemfile",
+ "rustls-pki-types",
  "sanitize-filename",
  "serde",
  "serde_json",
@@ -2683,8 +2683,6 @@ version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
- "allocator-api2",
- "equivalent",
  "foldhash 0.1.5",
 ]
 
@@ -2694,6 +2692,8 @@ version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 dependencies = [
+ "allocator-api2",
+ "equivalent",
  "foldhash 0.2.0",
 ]
 
@@ -3574,11 +3574,11 @@ checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "lru"
-version = "0.12.5"
+version = "0.16.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
+checksum = "a1dc47f592c06f33f8e3aea9591776ec7c9f9e4124778ff8a3c3b87159f7e593"
 dependencies = [
- "hashbrown 0.15.5",
+ "hashbrown 0.16.1",
 ]
 
 [[package]]
@@ -5355,15 +5355,6 @@ dependencies = [
  "rustls-pki-types",
  "schannel",
  "security-framework 3.5.1",
-]
-
-[[package]]
-name = "rustls-pemfile"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
-dependencies = [
- "rustls-pki-types",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1451,7 +1451,6 @@ dependencies = [
  "platform-wallet",
  "rs-dapi-client",
  "rs-sdk-trusted-context-provider",
- "rustls-pki-types",
  "sanitize-filename",
  "serde",
  "serde_json",

--- a/packages/rs-dapi-client/Cargo.toml
+++ b/packages/rs-dapi-client/Cargo.toml
@@ -56,7 +56,7 @@ tracing = "0.1.41"
 tokio = { version = "1.40", default-features = false }
 sha2 = { version = "0.10", optional = true }
 hex = { version = "0.4.3", optional = true }
-lru = { version = "0.12.3" }
+lru = { version = "0.16.3" }
 serde = { version = "1.0.219", optional = true, features = ["derive"] }
 serde_json = { version = "1.0.140", optional = true }
 chrono = { version = "0.4.38", features = ["serde"] }

--- a/packages/rs-sdk-trusted-context-provider/Cargo.toml
+++ b/packages/rs-sdk-trusted-context-provider/Cargo.toml
@@ -18,7 +18,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 thiserror = "2.0"
 tracing = "0.1.41"
-lru = "0.12.5"
+lru = "0.16.3"
 arc-swap = "1.7.1"
 hex = "0.4.3"
 futures = "0.3"

--- a/packages/rs-sdk/Cargo.toml
+++ b/packages/rs-sdk/Cargo.toml
@@ -37,7 +37,7 @@ dotenvy = { version = "0.15.7", optional = true }
 envy = { version = "0.4.2", optional = true }
 futures = { version = "0.3.30" }
 derive_more = { version = "1.0", features = ["from"] }
-lru = { version = "0.12.5", optional = true }
+lru = { version = "0.16.3", optional = true }
 bip37-bloom-filter = { git = "https://github.com/dashpay/rs-bip37-bloom-filter", branch = "develop" }
 zeroize = { version = "1.8", features = ["derive"] }
 

--- a/packages/rs-sdk/Cargo.toml
+++ b/packages/rs-sdk/Cargo.toml
@@ -21,7 +21,7 @@ drive-proof-verifier = { path = "../rs-drive-proof-verifier", default-features =
 dash-context-provider = { path = "../rs-context-provider", default-features = false }
 dash-platform-macros = { path = "../rs-dash-platform-macros" }
 http = { version = "1.1" }
-rustls-pemfile = { version = "2.0.0" }
+rustls-pki-types = { version = "1.13.2" }
 thiserror = "2.0.17"
 tokio = { version = "1.40", features = ["macros", "time"] }
 tokio-util = { version = "0.7.12" }

--- a/packages/rs-sdk/Cargo.toml
+++ b/packages/rs-sdk/Cargo.toml
@@ -21,7 +21,6 @@ drive-proof-verifier = { path = "../rs-drive-proof-verifier", default-features =
 dash-context-provider = { path = "../rs-context-provider", default-features = false }
 dash-platform-macros = { path = "../rs-dash-platform-macros" }
 http = { version = "1.1" }
-rustls-pki-types = { version = "1.13.2" }
 thiserror = "2.0.17"
 tokio = { version = "1.40", features = ["macros", "time"] }
 tokio-util = { version = "0.7.12" }

--- a/packages/rs-sdk/src/sdk.rs
+++ b/packages/rs-sdk/src/sdk.rs
@@ -950,18 +950,10 @@ impl SdkBuilder {
         self,
         certificate_file_path: impl AsRef<Path>,
     ) -> std::io::Result<Self> {
-        let pem = std::fs::read(certificate_file_path)?;
+        use rustls_pki_types::pem::PemObject;
 
-        // parse the certificate and check if it's valid
-        let mut verified_pem = std::io::BufReader::new(pem.as_slice());
-        rustls_pemfile::certs(&mut verified_pem)
-            .next()
-            .ok_or_else(|| {
-                std::io::Error::new(
-                    std::io::ErrorKind::InvalidData,
-                    "No valid certificates found in the file",
-                )
-            })??;
+        let pem = rustls_pki_types::CertificateDer::from_pem_file(certificate_file_path)
+            .map_err(|err| std::io::Error::new(std::io::ErrorKind::InvalidData, err))?;
 
         let cert = Certificate::from_pem(pem);
         Ok(self.with_ca_certificate(cert))
@@ -1378,5 +1370,27 @@ mod test {
         let result = super::verify_metadata_time(&metadata, now_time, tolerance);
 
         assert_eq!(result.is_err(), expect_err);
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    #[test]
+    fn test_load_ca_certificate() {
+        let cert_dir = std::path::PathBuf::from("/etc/ssl/certs");
+        let pem_path = std::fs::read_dir(cert_dir)
+            .expect("should read ssl certificates directory")
+            .find_map(|entry| {
+                entry.ok().and_then(|entry| {
+                    let path = entry.path();
+                    match path.extension().and_then(|ext| ext.to_str()) {
+                        Some("pem") => Some(path),
+                        _ => None,
+                    }
+                })
+            })
+            .expect("should find at least one certificate");
+
+        SdkBuilder::new_mock()
+            .with_ca_certificate_file(pem_path)
+            .expect("should load CA certificate file");
     }
 }

--- a/packages/rs-sdk/src/sdk.rs
+++ b/packages/rs-sdk/src/sdk.rs
@@ -1372,34 +1372,4 @@ mod test {
 
         assert_eq!(result.is_err(), expect_err);
     }
-
-    #[cfg(all(target_os = "linux", not(target_arch = "wasm32")))]
-    #[test]
-    fn test_load_correct_ca_certificate() {
-        let cert_dir = std::path::PathBuf::from("/etc/ssl/certs");
-        let pem_path = std::fs::read_dir(cert_dir)
-            .expect("should read ssl certificates directory")
-            .find_map(|entry| {
-                entry.ok().and_then(|entry| {
-                    let path = entry.path();
-                    match path.extension().and_then(|ext| ext.to_str()) {
-                        Some("pem") => Some(path),
-                        _ => None,
-                    }
-                })
-            })
-            .expect("should find at least one certificate");
-
-        SdkBuilder::new_mock()
-            .with_ca_certificate_file(pem_path)
-            .expect("should load CA certificate file");
-    }
-
-    #[cfg(all(target_os = "linux", not(target_arch = "wasm32")))]
-    #[test]
-    fn test_load_incorrect_ca_certificate() {
-        SdkBuilder::new_mock()
-            .with_ca_certificate_file("/etc/group")
-            .expect("should load CA certificate file");
-    }
 }

--- a/packages/rs-sdk/src/sdk.rs
+++ b/packages/rs-sdk/src/sdk.rs
@@ -935,6 +935,10 @@ impl SdkBuilder {
     /// Used mainly for testing purposes and local networks.
     ///
     /// If not set, uses standard system CA certificates.
+    ///
+    /// ## Parameters
+    ///
+    /// - `pem_certificate`: PEM-encoded CA certificate. User must ensure that the certificate is valid.
     #[cfg(not(target_arch = "wasm32"))]
     pub fn with_ca_certificate(mut self, pem_certificate: Certificate) -> Self {
         self.ca_certificate = Some(pem_certificate);
@@ -950,28 +954,8 @@ impl SdkBuilder {
         self,
         certificate_file_path: impl AsRef<Path>,
     ) -> std::io::Result<Self> {
-        use rustls_pki_types::pem::SectionKind;
-        use std::io::ErrorKind;
-
         let pem = std::fs::read(certificate_file_path)?;
-
-        // parse the certificate and check if it's valid
-        let mut pem_buf = std::io::BufReader::new(pem.as_slice());
-
-        let (kind, pem_cert) = rustls_pki_types::pem::from_buf(&mut pem_buf)
-            .map_err(|err| std::io::Error::new(std::io::ErrorKind::InvalidData, err))?
-            .ok_or(std::io::Error::new(
-                ErrorKind::InvalidData,
-                "no PEM data found in certificate file",
-            ))?;
-        if kind != SectionKind::Certificate {
-            return Err(std::io::Error::new(
-                ErrorKind::InvalidData,
-                format!("expected PEM section of kind Certificate, found {:?}", kind),
-            ));
-        };
-
-        let cert = Certificate::from_pem(pem_cert);
+        let cert = Certificate::from_pem(pem);
 
         Ok(self.with_ca_certificate(cert))
     }
@@ -1391,7 +1375,7 @@ mod test {
 
     #[cfg(all(target_os = "linux", not(target_arch = "wasm32")))]
     #[test]
-    fn test_load_ca_certificate() {
+    fn test_load_correct_ca_certificate() {
         let cert_dir = std::path::PathBuf::from("/etc/ssl/certs");
         let pem_path = std::fs::read_dir(cert_dir)
             .expect("should read ssl certificates directory")
@@ -1408,6 +1392,14 @@ mod test {
 
         SdkBuilder::new_mock()
             .with_ca_certificate_file(pem_path)
+            .expect("should load CA certificate file");
+    }
+
+    #[cfg(all(target_os = "linux", not(target_arch = "wasm32")))]
+    #[test]
+    fn test_load_incorrect_ca_certificate() {
+        SdkBuilder::new_mock()
+            .with_ca_certificate_file("/etc/group")
             .expect("should load CA certificate file");
     }
 }

--- a/packages/rs-sdk/src/sdk.rs
+++ b/packages/rs-sdk/src/sdk.rs
@@ -941,7 +941,7 @@ impl SdkBuilder {
         self
     }
 
-    /// Load CA certificate from file.
+    /// Load CA certificate from a PEM-encoded file.
     ///
     /// This is a convenience method that reads the certificate from a file and sets it using
     /// [SdkBuilder::with_ca_certificate()].
@@ -950,12 +950,29 @@ impl SdkBuilder {
         self,
         certificate_file_path: impl AsRef<Path>,
     ) -> std::io::Result<Self> {
-        use rustls_pki_types::pem::PemObject;
+        use rustls_pki_types::pem::SectionKind;
+        use std::io::ErrorKind;
 
-        let pem = rustls_pki_types::CertificateDer::from_pem_file(certificate_file_path)
-            .map_err(|err| std::io::Error::new(std::io::ErrorKind::InvalidData, err))?;
+        let pem = std::fs::read(certificate_file_path)?;
 
-        let cert = Certificate::from_pem(pem);
+        // parse the certificate and check if it's valid
+        let mut pem_buf = std::io::BufReader::new(pem.as_slice());
+
+        let (kind, pem_cert) = rustls_pki_types::pem::from_buf(&mut pem_buf)
+            .map_err(|err| std::io::Error::new(std::io::ErrorKind::InvalidData, err))?
+            .ok_or(std::io::Error::new(
+                ErrorKind::InvalidData,
+                "no PEM data found in certificate file",
+            ))?;
+        if kind != SectionKind::Certificate {
+            return Err(std::io::Error::new(
+                ErrorKind::InvalidData,
+                format!("expected PEM section of kind Certificate, found {:?}", kind),
+            ));
+        };
+
+        let cert = Certificate::from_pem(pem_cert);
+
         Ok(self.with_ca_certificate(cert))
     }
 
@@ -1372,7 +1389,7 @@ mod test {
         assert_eq!(result.is_err(), expect_err);
     }
 
-    #[cfg(not(target_arch = "wasm32"))]
+    #[cfg(all(target_os = "linux", not(target_arch = "wasm32")))]
     #[test]
     fn test_load_ca_certificate() {
         let cert_dir = std::path::PathBuf::from("/etc/ssl/certs");


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented

rustls-pemfile is unmaintained as per https://rustsec.org/advisories/RUSTSEC-2025-0134
LRU has minor issue https://rustsec.org/advisories/RUSTSEC-2026-0002

## What was done?

* replaced rustls-pemfile with rustls-pki-types
* updated lru to 0.16.3

## How Has This Been Tested?

Github Actions green

## Breaking Changes

None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [ ] I have made corresponding changes to the documentation if needed

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated lru dependency to v0.16.3 across packages.
  * Removed an older PEM-parsing dependency.
  * Simplified CA certificate file loading behavior (no public API changes).

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->