### PR TITLE
feat(wasm-sdk): auto-generate entropy for document creation when not provided

### DIFF
--- a/packages/wasm-sdk/src/state_transitions/document.rs
+++ b/packages/wasm-sdk/src/state_transitions/document.rs
@@ -51,7 +51,8 @@ export interface DocumentCreateOptions {
   /**
    * The document to create.
    * Use `new Document(...)` or `Document.fromJSON(...)` to construct it.
-   * Must include dataContractId, documentTypeName, ownerId, and entropy.
+   * Must include dataContractId, documentTypeName, and ownerId.
+   * Entropy is optional - if not set, it will be auto-generated.
    */
   document: Document;
 
@@ -108,19 +109,23 @@ impl WasmSdk {
         let contract_id: Identifier = document_wasm.get_data_contract_id().into();
         let document_type_name = document_wasm.get_document_type_name();
 
-        // Get entropy from document
-        let entropy = document_wasm.get_entropy().ok_or_else(|| {
-            WasmSdkError::invalid_argument("Document must have entropy set for creation")
-        })?;
-
-        if entropy.len() != 32 {
-            return Err(WasmSdkError::invalid_argument(
-                "Document entropy must be exactly 32 bytes",
-            ));
-        }
-
-        let mut entropy_array = [0u8; 32];
-        entropy_array.copy_from_slice(&entropy);
+        // Get entropy from document, or generate if not set
+        let entropy_array = match document_wasm.get_entropy() {
+            Some(entropy) if entropy.len() == 32 => {
+                let mut arr = [0u8; 32];
+                arr.copy_from_slice(&entropy);
+                arr
+            }
+            _ => {
+                // Auto-generate entropy if not provided
+                use dash_sdk::dpp::util::entropy_generator::{
+                    DefaultEntropyGenerator, EntropyGenerator,
+                };
+                DefaultEntropyGenerator.generate().map_err(|e| {
+                    WasmSdkError::generic(format!("Failed to generate entropy: {}", e))
+                })?
+            }
+        };
 
         // Extract identity key from options
         let identity_key_wasm =


### PR DESCRIPTION
## Issue being fixed or feature implemented

When creating documents via `sdk.documentCreate()`, the SDK threw an error if the Document didn't have entropy set: "Document must have entropy set for creation". This was a breaking change for downstream SDKs (Evo SDK, Wazam SDK) that create documents via `fromObject()`, `fromJSON()`, or `fromBytes()` which don't auto-generate entropy like the constructor does.

## What was done?

Modified `document_create` in `packages/wasm-sdk/src/state_transitions/document.rs` to auto-generate entropy when not provided, instead of throwing an error:

- If entropy is provided and valid (32 bytes), it uses the provided entropy
- If entropy is missing or invalid, it auto-generates using `DefaultEntropyGenerator`
- Updated TypeScript documentation to reflect that entropy is now optional

This is a backward-compatible change - existing code that sets entropy continues to work.

## How Has This Been Tested?

- `cargo check -p wasm-sdk` passes
- `cargo fmt -p wasm-sdk` applied

## Breaking Changes

None. This change makes the API more lenient by accepting documents without entropy set.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [ ] I have made corresponding changes to the documentation if needed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Document creation entropy field is now optional and will be automatically generated if not provided.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->