### PR TITLE
feat(dapi): allow setting max grpc response size

### DIFF
--- a/packages/rs-dapi-client/src/request_settings.rs
+++ b/packages/rs-dapi-client/src/request_settings.rs
@@ -31,6 +31,8 @@ pub struct RequestSettings {
     pub retries: Option<usize>,
     /// Ban DAPI address if node not responded or responded with error.
     pub ban_failed_address: Option<bool>,
+    /// Maximum gRPC response size in bytes (decoding limit).
+    pub max_decoding_message_size: Option<usize>,
 }
 
 impl RequestSettings {
@@ -42,6 +44,7 @@ impl RequestSettings {
             timeout: None,
             retries: None,
             ban_failed_address: None,
+            max_decoding_message_size: None,
         }
     }
 
@@ -54,6 +57,9 @@ impl RequestSettings {
             timeout: rhs.timeout.or(self.timeout),
             retries: rhs.retries.or(self.retries),
             ban_failed_address: rhs.ban_failed_address.or(self.ban_failed_address),
+            max_decoding_message_size: rhs
+                .max_decoding_message_size
+                .or(self.max_decoding_message_size),
         }
     }
 
@@ -66,6 +72,7 @@ impl RequestSettings {
             ban_failed_address: self
                 .ban_failed_address
                 .unwrap_or(DEFAULT_BAN_FAILED_ADDRESS),
+            max_decoding_message_size: self.max_decoding_message_size,
             #[cfg(not(target_arch = "wasm32"))]
             ca_certificate: None,
         }
@@ -83,6 +90,8 @@ pub struct AppliedRequestSettings {
     pub retries: usize,
     /// Ban DAPI address if node not responded or responded with error.
     pub ban_failed_address: bool,
+    /// Maximum gRPC response size in bytes (decoding limit).
+    pub max_decoding_message_size: Option<usize>,
     /// Certificate Authority certificate to use for verifying the server's certificate.
     #[cfg(not(target_arch = "wasm32"))]
     pub ca_certificate: Option<Certificate>,

--- a/packages/rs-dapi-client/src/transport/grpc.rs
+++ b/packages/rs-dapi-client/src/transport/grpc.rs
@@ -38,7 +38,13 @@ impl TransportClient for PlatformGrpcClient {
                 &uri,
                 Some(settings),
                 || match create_channel(uri.clone(), Some(settings)) {
-                    Ok(channel) => Ok(Self::new(channel).into()),
+                    Ok(channel) => {
+                        let mut client = Self::new(channel);
+                        if let Some(max_size) = settings.max_decoding_message_size {
+                            client = client.max_decoding_message_size(max_size);
+                        }
+                        Ok(client.into())
+                    }
                     Err(e) => Err(dapi_grpc::tonic::Status::invalid_argument(format!(
                         "Channel creation failed: {}",
                         e
@@ -75,7 +81,13 @@ impl TransportClient for CoreGrpcClient {
                 &uri,
                 Some(settings),
                 || match create_channel(uri.clone(), Some(settings)) {
-                    Ok(channel) => Ok(Self::new(channel).into()),
+                    Ok(channel) => {
+                        let mut client = Self::new(channel);
+                        if let Some(max_size) = settings.max_decoding_message_size {
+                            client = client.max_decoding_message_size(max_size);
+                        }
+                        Ok(client.into())
+                    }
                     Err(e) => Err(dapi_grpc::tonic::Status::invalid_argument(format!(
                         "Channel creation failed: {}",
                         e
@@ -234,6 +246,7 @@ impl_transport_request_grpc!(
         retries: Some(0),
         ban_failed_address: None,
         connect_timeout: None,
+        max_decoding_message_size: None,
     },
     wait_for_state_transition_result
 );
@@ -474,6 +487,7 @@ impl_transport_request_grpc!(
         ban_failed_address: None,
         connect_timeout: None,
         retries: None,
+        max_decoding_message_size: None,
     },
     subscribe_to_transactions_with_proofs
 );
@@ -674,6 +688,11 @@ impl_transport_request_grpc!(
     platform_proto::GetRecentCompactedAddressBalanceChangesRequest,
     platform_proto::GetRecentCompactedAddressBalanceChangesResponse,
     PlatformGrpcClient,
-    RequestSettings::default(),
+    RequestSettings {
+        // GetRecentCompactedAddressBalanceChangesResponse can have 100 values * 2048 addresses * ~44  bytes each = ~9MB
+        // We set it to 16MB to be safe
+        max_decoding_message_size: Some(16 * 1024 * 1024),
+        ..RequestSettings::default()
+    },
     get_recent_compacted_address_balance_changes
 );

--- a/packages/rs-drive-abci/src/query/address_funds/recent_compacted_address_balance_changes/v0/mod.rs
+++ b/packages/rs-drive-abci/src/query/address_funds/recent_compacted_address_balance_changes/v0/mod.rs
@@ -29,6 +29,7 @@ impl<C> Platform<C> {
     ) -> Result<QueryValidationResult<GetRecentCompactedAddressBalanceChangesResponseV0>, Error>
     {
         // Limit the number of compacted entries we return (max 25 to stay within proof size limits)
+        // Ensure it matches limit set in rs-drive-proof-verifier/src/proof.rs for RecentCompactedAddressBalanceChanges
         let limit = Some(25u16);
 
         let response = if prove {

--- a/packages/rs-drive-proof-verifier/src/proof.rs
+++ b/packages/rs-drive-proof-verifier/src/proof.rs
@@ -1024,7 +1024,9 @@ impl FromProof<platform::GetRecentCompactedAddressBalanceChangesRequest>
             }
         };
 
-        let limit = Some(100u16); // Same limit as in query handler
+        // Ensure it is the same limit as in query handler; see
+        // packages/rs-drive-abci/src/query/address_funds/recent_compacted_address_balance_changes/v0/mod.rs
+        let limit = Some(25u16);
 
         let (root_hash, verified_changes) = Drive::verify_compacted_address_balance_changes(
             &proof.grovedb_proof,

--- a/packages/rs-drive/src/verify/address_funds/verify_compacted_address_balance_changes/v0/mod.rs
+++ b/packages/rs-drive/src/verify/address_funds/verify_compacted_address_balance_changes/v0/mod.rs
@@ -18,6 +18,7 @@ use std::collections::BTreeMap;
 use super::VerifiedCompactedAddressBalanceChanges;
 
 /// Extract KV entries from merk proof bytes using the proper decoder.
+#[allow(clippy::type_complexity)]
 fn extract_kv_entries_from_merk_proof(merk_proof: &[u8]) -> Result<Vec<(Vec<u8>, Vec<u8>)>, Error> {
     let mut entries = Vec::new();
 

--- a/packages/rs-drive/src/verify/address_funds/verify_compacted_address_balance_changes/v0/mod.rs
+++ b/packages/rs-drive/src/verify/address_funds/verify_compacted_address_balance_changes/v0/mod.rs
@@ -18,20 +18,29 @@ use std::collections::BTreeMap;
 use super::VerifiedCompactedAddressBalanceChanges;
 
 /// Extract KV entries from merk proof bytes using the proper decoder.
-fn extract_kv_entries_from_merk_proof(merk_proof: &[u8]) -> Vec<(Vec<u8>, Vec<u8>)> {
+fn extract_kv_entries_from_merk_proof(merk_proof: &[u8]) -> Result<Vec<(Vec<u8>, Vec<u8>)>, Error> {
     let mut entries = Vec::new();
 
-    for op in MerkProofDecoder::new(merk_proof).flatten() {
+    let decoder = MerkProofDecoder::new(merk_proof);
+
+    for op in decoder {
         match op {
-            MerkProofOp::Push(MerkProofNode::KV(key, value))
-            | MerkProofOp::PushInverted(MerkProofNode::KV(key, value)) => {
+            Ok(MerkProofOp::Push(MerkProofNode::KV(key, value)))
+            | Ok(MerkProofOp::PushInverted(MerkProofNode::KV(key, value))) => {
                 entries.push((key, value));
+            }
+            Err(e) => {
+                tracing::error!(%e, "merk proof decode error");
+                return Err(Error::Proof(ProofError::CorruptedProof(format!(
+                    "failed to decode merk proof op: {}",
+                    e
+                ))));
             }
             _ => {}
         }
     }
 
-    entries
+    Ok(entries)
 }
 
 impl Drive {
@@ -81,6 +90,7 @@ impl Drive {
         // if there's a containing range for start_block_height
         let kv_entries = compacted_layer
             .map(|layer| extract_kv_entries_from_merk_proof(&layer.merk_proof))
+            .transpose()?
             .unwrap_or_default();
 
         // Look for a KV entry where the range contains start_block_height

--- a/packages/rs-sdk/src/sdk.rs
+++ b/packages/rs-sdk/src/sdk.rs
@@ -67,6 +67,7 @@ const DEFAULT_REQUEST_SETTINGS: RequestSettings = RequestSettings {
     timeout: None,
     ban_failed_address: None,
     connect_timeout: None,
+    max_decoding_message_size: None,
 };
 
 /// a type to represent staleness in seconds

--- a/packages/wasm-sdk/src/settings.rs
+++ b/packages/wasm-sdk/src/settings.rs
@@ -69,6 +69,7 @@ impl From<RequestSettingsInput> for RequestSettings {
             timeout: input.timeout_ms.map(Duration::from_millis),
             connect_timeout: input.connect_timeout_ms.map(Duration::from_millis),
             ban_failed_address: input.ban_failed_address,
+            max_decoding_message_size: None,
         }
     }
 }

--- a/packages/wasm-sdk/src/settings.rs
+++ b/packages/wasm-sdk/src/settings.rs
@@ -60,6 +60,7 @@ struct RequestSettingsInput {
     timeout_ms: Option<u64>,
     connect_timeout_ms: Option<u64>,
     ban_failed_address: Option<bool>,
+    max_decoding_message_size: Option<u64>,
 }
 
 impl From<RequestSettingsInput> for RequestSettings {
@@ -69,7 +70,7 @@ impl From<RequestSettingsInput> for RequestSettings {
             timeout: input.timeout_ms.map(Duration::from_millis),
             connect_timeout: input.connect_timeout_ms.map(Duration::from_millis),
             ban_failed_address: input.ban_failed_address,
-            max_decoding_message_size: None,
+            max_decoding_message_size: input.max_decoding_message_size.map(|v| v as usize),
         }
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
 
`GetRecentCompactedAddressBalanceChangesResponse` can have 100 values * 2048 addresses * ~44  bytes each = ~9MB.
Right now, we have a default limit of gRPC response in rs-sdk and rs-dapi set to default 4MB. 

This causes errors like:

```
 error=Grpc(Status { code: OutOfRange, message: "Error, decoded message length too large: found 9037453 bytes, the limit is: 4194304 bytes"
```

## What was done?

Added mechanism to `rs-dapi-client` that allows setting max response size.
Set  max response size for `GetRecentCompactedAddressBalanceChangesResponse` to 16MB to be safe.


## How Has This Been Tested?

To be tested during testnet testing.

## Breaking Changes

None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [ ] I have made corresponding changes to the documentation if needed

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Performance Improvements**
  * Optimized handling of large response payloads through enhanced message decoding size configuration, improving reliability for data-intensive operations.
  * Refined processing parameters for address balance queries to ensure stable performance under load.
  * Enhanced overall data transfer efficiency across multiple request types.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->