### PR TITLE
feat(swift-sdk): add support for v3 queries

### DIFF
--- a/packages/rs-dapi-client/src/transport/tonic_channel.rs
+++ b/packages/rs-dapi-client/src/transport/tonic_channel.rs
@@ -21,10 +21,18 @@ pub fn create_channel(
     let host = uri.host().expect("Failed to get host from URI").to_string();
 
     let mut builder = Channel::builder(uri);
+    
+    // Start with webpki roots (bundled Mozilla certificates) which work on all platforms
+    // Try to add native roots only on platforms where they're available (not iOS)
     let mut tls_config = ClientTlsConfig::new()
-        .with_native_roots()
         .with_webpki_roots()
         .assume_http2(true);
+    
+    // Try to add native roots - this may fail on iOS, which is fine since we have webpki roots
+    #[cfg(not(any(target_os = "ios", target_os = "tvos", target_os = "watchos")))]
+    {
+        tls_config = tls_config.with_native_roots();
+    }
 
     if let Some(settings) = settings {
         if let Some(timeout) = settings.connect_timeout {

--- a/packages/rs-sdk-ffi/src/address/mod.rs
+++ b/packages/rs-sdk-ffi/src/address/mod.rs
@@ -1,0 +1,6 @@
+//! Address query operations
+
+pub mod queries;
+
+// Re-export query functions
+pub use queries::*;

--- a/packages/rs-sdk-ffi/src/address/queries/balance_changes.rs
+++ b/packages/rs-sdk-ffi/src/address/queries/balance_changes.rs
@@ -1,0 +1,150 @@
+//! Recent address balance changes query operations
+
+use dash_sdk::dpp::balances::credits::CreditOperation;
+use dash_sdk::platform::query::RecentAddressBalanceChangesQuery;
+use dash_sdk::platform::Fetch;
+use drive_proof_verifier::types::RecentAddressBalanceChanges;
+use std::panic::{self, AssertUnwindSafe};
+
+use crate::sdk::SDKWrapper;
+use crate::types::{
+    DashSDKAddressBalanceChange, DashSDKBlockBalanceChanges, DashSDKCreditOperationType,
+    DashSDKRecentBalanceChanges, SDKHandle,
+};
+use crate::{DashSDKError, DashSDKErrorCode, DashSDKResult, FFIError};
+
+/// Fetch recent address balance changes starting from a specific block height.
+///
+/// This returns all address balance changes that occurred since the specified start height.
+/// Useful for syncing wallet balances after the initial sync.
+///
+/// # Parameters
+/// - `sdk_handle`: SDK handle
+/// - `start_height`: Block height to start fetching changes from
+/// - `prove`: Whether to include proofs (currently always fetches with proofs for verification)
+///
+/// # Returns
+/// DashSDKResult with data_type = RecentBalanceChanges containing block-by-block changes
+///
+/// # Safety
+/// - `sdk_handle` must be a valid, non-null pointer.
+/// - On success, returns a DashSDKRecentBalanceChanges pointer; caller must free it using `dash_sdk_recent_balance_changes_free`.
+#[no_mangle]
+pub unsafe extern "C" fn dash_sdk_address_fetch_recent_balance_changes(
+    sdk_handle: *const SDKHandle,
+    start_height: u64,
+) -> DashSDKResult {
+    // Wrap the entire function in catch_unwind to prevent panics from crashing the app
+    let result = panic::catch_unwind(AssertUnwindSafe(|| {
+        dash_sdk_address_fetch_recent_balance_changes_inner(sdk_handle, start_height)
+    }));
+
+    match result {
+        Ok(result) => result,
+        Err(panic_info) => {
+            let panic_message = if let Some(s) = panic_info.downcast_ref::<&str>() {
+                s.to_string()
+            } else if let Some(s) = panic_info.downcast_ref::<String>() {
+                s.clone()
+            } else {
+                "Unknown panic occurred during recent balance changes fetch".to_string()
+            };
+            DashSDKResult::error(DashSDKError::new(
+                DashSDKErrorCode::InternalError,
+                format!(
+                    "Panic during recent balance changes fetch: {}",
+                    panic_message
+                ),
+            ))
+        }
+    }
+}
+
+unsafe fn dash_sdk_address_fetch_recent_balance_changes_inner(
+    sdk_handle: *const SDKHandle,
+    start_height: u64,
+) -> DashSDKResult {
+    if sdk_handle.is_null() {
+        return DashSDKResult::error(DashSDKError::new(
+            DashSDKErrorCode::InvalidParameter,
+            "SDK handle is null".to_string(),
+        ));
+    }
+
+    let wrapper = &*(sdk_handle as *const SDKWrapper);
+
+    let result: Result<DashSDKRecentBalanceChanges, FFIError> = wrapper.runtime.block_on(async {
+        // Fetch recent balance changes using Fetch trait
+        let query = RecentAddressBalanceChangesQuery::new(start_height);
+        let changes_opt = RecentAddressBalanceChanges::fetch(&wrapper.sdk, query)
+            .await
+            .map_err(FFIError::from)?;
+
+        let changes = changes_opt.unwrap_or_default();
+        let block_changes = changes.into_inner();
+
+        // Convert to FFI format
+        let mut blocks: Vec<DashSDKBlockBalanceChanges> = Vec::new();
+
+        for block in block_changes {
+            let mut address_changes: Vec<DashSDKAddressBalanceChange> = Vec::new();
+
+            for (address, operation) in block.changes.iter() {
+                let address_bytes = address.to_bytes();
+                let address_len = address_bytes.len();
+                let address_ptr = address_bytes.as_ptr() as *mut u8;
+                std::mem::forget(address_bytes);
+
+                let (op_type, credits) = match operation {
+                    CreditOperation::SetCredits(c) => {
+                        (DashSDKCreditOperationType::SetCredits, *c)
+                    }
+                    CreditOperation::AddToCredits(c) => {
+                        (DashSDKCreditOperationType::AddToCredits, *c)
+                    }
+                };
+
+                address_changes.push(DashSDKAddressBalanceChange {
+                    address: address_ptr,
+                    address_len,
+                    operation_type: op_type,
+                    credits,
+                });
+            }
+
+            let changes_count = address_changes.len();
+            let changes_ptr = if address_changes.is_empty() {
+                std::ptr::null_mut()
+            } else {
+                let ptr = address_changes.as_ptr() as *mut DashSDKAddressBalanceChange;
+                std::mem::forget(address_changes);
+                ptr
+            };
+
+            blocks.push(DashSDKBlockBalanceChanges {
+                block_height: block.block_height,
+                changes: changes_ptr,
+                changes_count,
+            });
+        }
+
+        let blocks_count = blocks.len();
+        let blocks_ptr = if blocks.is_empty() {
+            std::ptr::null_mut()
+        } else {
+            let ptr = blocks.as_ptr() as *mut DashSDKBlockBalanceChanges;
+            std::mem::forget(blocks);
+            ptr
+        };
+
+        Ok(DashSDKRecentBalanceChanges {
+            blocks: blocks_ptr,
+            blocks_count,
+        })
+    });
+
+    match result {
+        Ok(changes) => DashSDKResult::success_recent_balance_changes(changes),
+        Err(e) => DashSDKResult::error(e.into()),
+    }
+}

--- a/packages/rs-sdk-ffi/src/address/queries/branch_state.rs
+++ b/packages/rs-sdk-ffi/src/address/queries/branch_state.rs
@@ -1,0 +1,257 @@
+//! Branch state query operations for address synchronization
+
+use dash_sdk::dapi_client::{DapiRequest, IntoInner, RequestSettings};
+use dash_sdk::dapi_grpc::platform::v0::{
+    get_addresses_branch_state_request, get_addresses_branch_state_response,
+    GetAddressesBranchStateRequest,
+};
+use dash_sdk::dpp::version::PlatformVersion;
+use dash_sdk::drive::drive::Drive;
+use std::panic::{self, AssertUnwindSafe};
+
+use crate::sdk::SDKWrapper;
+use crate::types::{DashSDKBranchState, DashSDKLeafBoundary, DashSDKTrunkStateElement, SDKHandle};
+use crate::{DashSDKError, DashSDKErrorCode, DashSDKResult, FFIError};
+
+/// Fetch the branch state of a subtree in the address tree.
+///
+/// This is used after a trunk state query to explore subtrees indicated by leaf boundaries.
+/// The result contains elements (addresses with balances) and deeper leaf boundaries.
+///
+/// # Parameters
+/// - `sdk_handle`: SDK handle
+/// - `key`: Leaf boundary key bytes from trunk state
+/// - `key_len`: Length of key bytes
+/// - `depth`: Query depth (how deep to explore)
+/// - `expected_hash`: Expected hash of the subtree root (32 bytes, for proof verification)
+/// - `checkpoint_height`: Block height from trunk state response for consistency
+///
+/// # Returns
+/// DashSDKResult with data_type = BranchState containing elements and leaf boundaries
+///
+/// # Safety
+/// - `sdk_handle`, `key`, and `expected_hash` must be valid, non-null pointers.
+/// - `key` must point to a valid byte array of length `key_len`.
+/// - `expected_hash` must point to exactly 32 bytes.
+/// - On success, returns a DashSDKBranchState pointer; caller must free it using `dash_sdk_branch_state_free`.
+#[no_mangle]
+pub unsafe extern "C" fn dash_sdk_address_fetch_branch_state(
+    sdk_handle: *const SDKHandle,
+    key: *const u8,
+    key_len: usize,
+    depth: u32,
+    expected_hash: *const u8,
+    checkpoint_height: u64,
+) -> DashSDKResult {
+    // Wrap the entire function in catch_unwind to prevent panics from crashing the app
+    let result = panic::catch_unwind(AssertUnwindSafe(|| {
+        dash_sdk_address_fetch_branch_state_inner(
+            sdk_handle,
+            key,
+            key_len,
+            depth,
+            expected_hash,
+            checkpoint_height,
+        )
+    }));
+
+    match result {
+        Ok(result) => result,
+        Err(panic_info) => {
+            let panic_message = if let Some(s) = panic_info.downcast_ref::<&str>() {
+                s.to_string()
+            } else if let Some(s) = panic_info.downcast_ref::<String>() {
+                s.clone()
+            } else {
+                "Unknown panic occurred during branch state fetch".to_string()
+            };
+            DashSDKResult::error(DashSDKError::new(
+                DashSDKErrorCode::InternalError,
+                format!("Panic during branch state fetch: {}", panic_message),
+            ))
+        }
+    }
+}
+
+unsafe fn dash_sdk_address_fetch_branch_state_inner(
+    sdk_handle: *const SDKHandle,
+    key: *const u8,
+    key_len: usize,
+    depth: u32,
+    expected_hash: *const u8,
+    checkpoint_height: u64,
+) -> DashSDKResult {
+    if sdk_handle.is_null() {
+        return DashSDKResult::error(DashSDKError::new(
+            DashSDKErrorCode::InvalidParameter,
+            "SDK handle is null".to_string(),
+        ));
+    }
+
+    if key.is_null() || key_len == 0 {
+        return DashSDKResult::error(DashSDKError::new(
+            DashSDKErrorCode::InvalidParameter,
+            "Key is null or empty".to_string(),
+        ));
+    }
+
+    if expected_hash.is_null() {
+        return DashSDKResult::error(DashSDKError::new(
+            DashSDKErrorCode::InvalidParameter,
+            "Expected hash is null".to_string(),
+        ));
+    }
+
+    let wrapper = &*(sdk_handle as *const SDKWrapper);
+
+    // Convert inputs to Rust types
+    let key_slice = std::slice::from_raw_parts(key, key_len);
+    let key_vec: Vec<u8> = key_slice.to_vec();
+
+    let hash_slice = std::slice::from_raw_parts(expected_hash, 32);
+    let mut hash_array: [u8; 32] = [0u8; 32];
+    hash_array.copy_from_slice(hash_slice);
+
+    let result: Result<DashSDKBranchState, FFIError> = wrapper.runtime.block_on(async {
+        // Build the request
+        let request = GetAddressesBranchStateRequest {
+            version: Some(get_addresses_branch_state_request::Version::V0(
+                get_addresses_branch_state_request::GetAddressesBranchStateRequestV0 {
+                    key: key_vec.clone(),
+                    depth,
+                    checkpoint_height,
+                },
+            )),
+        };
+
+        // Execute the request
+        use dash_sdk::dapi_grpc::platform::v0::GetAddressesBranchStateResponse;
+        let response: GetAddressesBranchStateResponse = request
+            .execute(&wrapper.sdk, RequestSettings::default())
+            .await
+            .map_err(|e| FFIError::InternalError(format!("Branch state request failed: {}", e)))?
+            .into_inner();
+
+        // Extract merk proof
+        let proof_bytes = match response.version {
+            Some(get_addresses_branch_state_response::Version::V0(v0)) => v0.merk_proof,
+            None => {
+                return Err(FFIError::InternalError(
+                    "Empty response version".to_string(),
+                ));
+            }
+        };
+
+        // Get platform version
+        let platform_version = PlatformVersion::latest();
+
+        // Verify the proof and get branch result
+        let branch_result = Drive::verify_address_funds_branch_query(
+            &proof_bytes,
+            key_vec,
+            depth as u8,
+            hash_array,
+            platform_version,
+        )
+        .map_err(|e| FFIError::InternalError(format!("Proof verification failed: {}", e)))?;
+
+        // Convert elements to FFI format
+        let mut elements: Vec<DashSDKTrunkStateElement> = Vec::new();
+        for (elem_key, element) in branch_result.elements.iter() {
+            if let Some((balance, nonce)) = extract_balance_nonce_from_element(element) {
+                let elem_key_vec: Vec<u8> = elem_key.clone();
+                let elem_key_len = elem_key_vec.len();
+                let elem_key_ptr = elem_key_vec.as_ptr() as *mut u8;
+                std::mem::forget(elem_key_vec);
+
+                elements.push(DashSDKTrunkStateElement {
+                    key: elem_key_ptr,
+                    key_len: elem_key_len,
+                    nonce,
+                    balance,
+                });
+            }
+        }
+
+        // Convert leaf keys to FFI format
+        let mut leaf_boundaries: Vec<DashSDKLeafBoundary> = Vec::new();
+        for (leaf_key, leaf_info) in branch_result.leaf_keys.iter() {
+            let leaf_key_vec: Vec<u8> = leaf_key.clone();
+            let leaf_key_len = leaf_key_vec.len();
+            let leaf_key_ptr = leaf_key_vec.as_ptr() as *mut u8;
+            std::mem::forget(leaf_key_vec);
+
+            leaf_boundaries.push(DashSDKLeafBoundary {
+                key: leaf_key_ptr,
+                key_len: leaf_key_len,
+                hash: leaf_info.hash,
+                estimated_count: leaf_info.count.unwrap_or(0),
+            });
+        }
+
+        // Convert to raw arrays
+        let elements_count = elements.len();
+        let elements_ptr = if elements.is_empty() {
+            std::ptr::null_mut()
+        } else {
+            let ptr = elements.as_ptr() as *mut DashSDKTrunkStateElement;
+            std::mem::forget(elements);
+            ptr
+        };
+
+        let leaf_boundaries_count = leaf_boundaries.len();
+        let leaf_boundaries_ptr = if leaf_boundaries.is_empty() {
+            std::ptr::null_mut()
+        } else {
+            let ptr = leaf_boundaries.as_ptr() as *mut DashSDKLeafBoundary;
+            std::mem::forget(leaf_boundaries);
+            ptr
+        };
+
+        Ok(DashSDKBranchState {
+            elements: elements_ptr,
+            elements_count,
+            leaf_boundaries: leaf_boundaries_ptr,
+            leaf_boundaries_count,
+        })
+    });
+
+    match result {
+        Ok(state) => DashSDKResult::success_branch_state(state),
+        Err(e) => DashSDKResult::error(e.into()),
+    }
+}
+
+/// Extract balance and nonce from a GroveDB Element.
+/// Returns None if the element format is not recognized.
+fn extract_balance_nonce_from_element(
+    element: &dash_sdk::drive::grovedb::Element,
+) -> Option<(u64, u32)> {
+    use dash_sdk::drive::grovedb::Element;
+
+    match element {
+        Element::Item(data, _) => {
+            // Address funds are encoded as: nonce (4 bytes) + balance (8 bytes)
+            if data.len() >= 12 {
+                let nonce = u32::from_be_bytes([data[0], data[1], data[2], data[3]]);
+                let balance = u64::from_be_bytes([
+                    data[4], data[5], data[6], data[7], data[8], data[9], data[10], data[11],
+                ]);
+                Some((balance, nonce))
+            } else if data.len() >= 8 {
+                // Fallback: just balance
+                let balance = u64::from_be_bytes([
+                    data[0], data[1], data[2], data[3], data[4], data[5], data[6], data[7],
+                ]);
+                Some((balance, 0))
+            } else {
+                None
+            }
+        }
+        Element::SumItem(balance, _) => {
+            // SumItem directly contains the balance
+            Some((*balance as u64, 0))
+        }
+        _ => None,
+    }
+}

--- a/packages/rs-sdk-ffi/src/address/queries/compacted_balance_changes.rs
+++ b/packages/rs-sdk-ffi/src/address/queries/compacted_balance_changes.rs
@@ -1,0 +1,179 @@
+//! Recent compacted address balance changes query operations
+
+use dash_sdk::dpp::balances::credits::BlockAwareCreditOperation;
+use dash_sdk::platform::query::RecentCompactedAddressBalanceChangesQuery;
+use dash_sdk::platform::Fetch;
+use drive_proof_verifier::types::RecentCompactedAddressBalanceChanges;
+use std::panic::{self, AssertUnwindSafe};
+
+use crate::sdk::SDKWrapper;
+use crate::types::{
+    DashSDKBlockAwareCreditOperationType, DashSDKBlockHeightCreditEntry,
+    DashSDKCompactedAddressChange, DashSDKCompactedBalanceChanges, DashSDKCompactedBlockRange,
+    SDKHandle,
+};
+use crate::{DashSDKError, DashSDKErrorCode, DashSDKResult, FFIError};
+
+/// Fetch recent compacted address balance changes starting from a specific block height.
+///
+/// This returns compacted (merged) address balance changes since the specified start height.
+/// Useful for efficient syncing when blocks have been merged into ranges.
+///
+/// # Parameters
+/// - `sdk_handle`: SDK handle
+/// - `start_block_height`: Block height to start fetching changes from
+///
+/// # Returns
+/// DashSDKResult with data_type = CompactedBalanceChanges containing range-by-range compacted changes
+///
+/// # Safety
+/// - `sdk_handle` must be a valid, non-null pointer.
+/// - On success, returns a DashSDKCompactedBalanceChanges pointer; caller must free it using `dash_sdk_compacted_balance_changes_free`.
+#[no_mangle]
+pub unsafe extern "C" fn dash_sdk_address_fetch_compacted_balance_changes(
+    sdk_handle: *const SDKHandle,
+    start_block_height: u64,
+) -> DashSDKResult {
+    // Wrap the entire function in catch_unwind to prevent panics from crashing the app
+    let result = panic::catch_unwind(AssertUnwindSafe(|| {
+        dash_sdk_address_fetch_compacted_balance_changes_inner(sdk_handle, start_block_height)
+    }));
+
+    match result {
+        Ok(result) => result,
+        Err(panic_info) => {
+            let panic_message = if let Some(s) = panic_info.downcast_ref::<&str>() {
+                s.to_string()
+            } else if let Some(s) = panic_info.downcast_ref::<String>() {
+                s.clone()
+            } else {
+                "Unknown panic occurred during compacted balance changes fetch".to_string()
+            };
+            DashSDKResult::error(DashSDKError::new(
+                DashSDKErrorCode::InternalError,
+                format!(
+                    "Panic during compacted balance changes fetch: {}",
+                    panic_message
+                ),
+            ))
+        }
+    }
+}
+
+unsafe fn dash_sdk_address_fetch_compacted_balance_changes_inner(
+    sdk_handle: *const SDKHandle,
+    start_block_height: u64,
+) -> DashSDKResult {
+    if sdk_handle.is_null() {
+        return DashSDKResult::error(DashSDKError::new(
+            DashSDKErrorCode::InvalidParameter,
+            "SDK handle is null".to_string(),
+        ));
+    }
+
+    let wrapper = &*(sdk_handle as *const SDKWrapper);
+
+    let result: Result<DashSDKCompactedBalanceChanges, FFIError> =
+        wrapper.runtime.block_on(async {
+            // Fetch compacted balance changes using Fetch trait
+            let query = RecentCompactedAddressBalanceChangesQuery::new(start_block_height);
+            let changes_opt = RecentCompactedAddressBalanceChanges::fetch(&wrapper.sdk, query)
+                .await
+                .map_err(FFIError::from)?;
+
+            let changes = changes_opt.unwrap_or_default();
+            let compacted_ranges = changes.into_inner();
+
+            // Convert to FFI format
+            let mut ranges: Vec<DashSDKCompactedBlockRange> = Vec::new();
+
+            for range in compacted_ranges {
+                let mut address_changes: Vec<DashSDKCompactedAddressChange> = Vec::new();
+
+                for (address, operation) in range.changes.iter() {
+                    let address_bytes = address.to_bytes();
+                    let address_len = address_bytes.len();
+                    let address_ptr = address_bytes.as_ptr() as *mut u8;
+                    std::mem::forget(address_bytes);
+
+                    let (op_type, set_value, entries_ptr, entries_count) = match operation {
+                        BlockAwareCreditOperation::SetCredits(credits) => (
+                            DashSDKBlockAwareCreditOperationType::BlockAwareSetCredits,
+                            *credits,
+                            std::ptr::null_mut(),
+                            0,
+                        ),
+                        BlockAwareCreditOperation::AddToCreditsOperations(map) => {
+                            let entries: Vec<DashSDKBlockHeightCreditEntry> = map
+                                .iter()
+                                .map(|(height, credits)| DashSDKBlockHeightCreditEntry {
+                                    block_height: *height,
+                                    credits: *credits,
+                                })
+                                .collect();
+
+                            let count = entries.len();
+                            let ptr = if entries.is_empty() {
+                                std::ptr::null_mut()
+                            } else {
+                                let ptr = entries.as_ptr() as *mut DashSDKBlockHeightCreditEntry;
+                                std::mem::forget(entries);
+                                ptr
+                            };
+
+                            (
+                                DashSDKBlockAwareCreditOperationType::BlockAwareAddToCreditsOperations,
+                                0,
+                                ptr,
+                                count,
+                            )
+                        }
+                    };
+
+                    address_changes.push(DashSDKCompactedAddressChange {
+                        address: address_ptr,
+                        address_len,
+                        operation_type: op_type,
+                        set_credits_value: set_value,
+                        add_entries: entries_ptr,
+                        add_entries_count: entries_count,
+                    });
+                }
+
+                let changes_count = address_changes.len();
+                let changes_ptr = if address_changes.is_empty() {
+                    std::ptr::null_mut()
+                } else {
+                    let ptr = address_changes.as_ptr() as *mut DashSDKCompactedAddressChange;
+                    std::mem::forget(address_changes);
+                    ptr
+                };
+
+                ranges.push(DashSDKCompactedBlockRange {
+                    start_block_height: range.start_block_height,
+                    end_block_height: range.end_block_height,
+                    changes: changes_ptr,
+                    changes_count,
+                });
+            }
+
+            let ranges_count = ranges.len();
+            let ranges_ptr = if ranges.is_empty() {
+                std::ptr::null_mut()
+            } else {
+                let ptr = ranges.as_ptr() as *mut DashSDKCompactedBlockRange;
+                std::mem::forget(ranges);
+                ptr
+            };
+
+            Ok(DashSDKCompactedBalanceChanges {
+                ranges: ranges_ptr,
+                ranges_count,
+            })
+        });
+
+    match result {
+        Ok(changes) => DashSDKResult::success_compacted_balance_changes(changes),
+        Err(e) => DashSDKResult::error(e.into()),
+    }
+}

--- a/packages/rs-sdk-ffi/src/address/queries/info.rs
+++ b/packages/rs-sdk-ffi/src/address/queries/info.rs
@@ -1,0 +1,129 @@
+//! Address info query operations
+
+use dash_sdk::dpp::address_funds::PlatformAddress;
+use dash_sdk::platform::Fetch;
+use drive_proof_verifier::types::AddressInfo;
+use std::panic::{self, AssertUnwindSafe};
+
+use crate::sdk::SDKWrapper;
+use crate::types::{DashSDKAddressInfo, SDKHandle};
+use crate::{DashSDKError, DashSDKErrorCode, DashSDKResult, FFIError};
+
+/// Fetch information about a Platform address including its nonce and balance.
+///
+/// # Parameters
+/// - `sdk_handle`: SDK handle
+/// - `address_bytes`: Address bytes (variable length, typically 20-32 bytes)
+/// - `address_len`: Length of address bytes
+///
+/// # Returns
+/// DashSDKResult with data_type = AddressInfo containing address, nonce, and balance
+///
+/// # Safety
+/// - `sdk_handle` and `address_bytes` must be valid, non-null pointers.
+/// - `address_bytes` must point to a valid byte array of length `address_len` and remain valid for the duration of the call.
+/// - On success, returns a DashSDKAddressInfo pointer inside `DashSDKResult`; caller must free it using `dash_sdk_address_info_free`.
+#[no_mangle]
+pub unsafe extern "C" fn dash_sdk_address_fetch_info(
+    sdk_handle: *const SDKHandle,
+    address_bytes: *const u8,
+    address_len: usize,
+) -> DashSDKResult {
+    // Wrap the entire function in catch_unwind to prevent panics from crashing the app
+    let result = panic::catch_unwind(AssertUnwindSafe(|| {
+        dash_sdk_address_fetch_info_inner(sdk_handle, address_bytes, address_len)
+    }));
+
+    match result {
+        Ok(result) => result,
+        Err(panic_info) => {
+            let panic_message = if let Some(s) = panic_info.downcast_ref::<&str>() {
+                s.to_string()
+            } else if let Some(s) = panic_info.downcast_ref::<String>() {
+                s.clone()
+            } else {
+                "Unknown panic occurred during address fetch".to_string()
+            };
+            DashSDKResult::error(DashSDKError::new(
+                DashSDKErrorCode::InternalError,
+                format!("Panic during address fetch: {}", panic_message),
+            ))
+        }
+    }
+}
+
+unsafe fn dash_sdk_address_fetch_info_inner(
+    sdk_handle: *const SDKHandle,
+    address_bytes: *const u8,
+    address_len: usize,
+) -> DashSDKResult {
+    if sdk_handle.is_null() || address_bytes.is_null() || address_len == 0 {
+        return DashSDKResult::error(DashSDKError::new(
+            DashSDKErrorCode::InvalidParameter,
+            "SDK handle, address bytes, or address length is invalid".to_string(),
+        ));
+    }
+
+    let wrapper = &*(sdk_handle as *const SDKWrapper);
+
+    // Convert address bytes to PlatformAddress
+    let address_slice = std::slice::from_raw_parts(address_bytes, address_len);
+    
+    // Log the address bytes for debugging
+    let address_hex: String = address_slice.iter().map(|b| format!("{:02x}", b)).collect();
+    tracing::debug!(address_hex = %address_hex, address_len = address_len, "Attempting to fetch address info");
+
+    let address = match PlatformAddress::from_bytes(address_slice) {
+        Ok(addr) => addr,
+        Err(e) => {
+            tracing::error!(error = %e, address_hex = %address_hex, "Failed to parse PlatformAddress");
+            return DashSDKResult::error(DashSDKError::new(
+                DashSDKErrorCode::InvalidParameter,
+                format!("Invalid address bytes (len={}): {}", address_len, e),
+            ))
+        }
+    };
+
+    let result: Result<DashSDKAddressInfo, FFIError> = wrapper.runtime.block_on(async {
+        // Fetch address info using Fetch trait
+        let address_info = AddressInfo::fetch(&wrapper.sdk, address)
+            .await
+            .map_err(FFIError::from)?;
+
+        match address_info {
+            Some(info) => {
+                // Convert address to bytes
+                let address_bytes_vec = info.address.to_bytes();
+                let address_len = address_bytes_vec.len();
+                let address_ptr = address_bytes_vec.as_ptr() as *mut u8;
+                std::mem::forget(address_bytes_vec); // Prevent deallocation
+
+                Ok(DashSDKAddressInfo {
+                    address: address_ptr,
+                    address_len,
+                    nonce: info.nonce,
+                    balance: info.balance,
+                })
+            }
+            None => {
+                // Address not found - return with max values to indicate not found
+                let address_bytes_vec = address.to_bytes();
+                let address_len = address_bytes_vec.len();
+                let address_ptr = address_bytes_vec.as_ptr() as *mut u8;
+                std::mem::forget(address_bytes_vec);
+
+                Ok(DashSDKAddressInfo {
+                    address: address_ptr,
+                    address_len,
+                    nonce: u32::MAX,
+                    balance: u64::MAX,
+                })
+            }
+        }
+    });
+
+    match result {
+        Ok(info) => DashSDKResult::success_address_info(info),
+        Err(e) => DashSDKResult::error(e.into()),
+    }
+}

--- a/packages/rs-sdk-ffi/src/address/queries/infos.rs
+++ b/packages/rs-sdk-ffi/src/address/queries/infos.rs
@@ -1,0 +1,208 @@
+//! Multiple addresses info query operations
+
+use dash_sdk::dpp::address_funds::PlatformAddress;
+use dash_sdk::platform::FetchMany;
+use drive_proof_verifier::types::{AddressInfo, AddressInfos};
+use std::collections::BTreeSet;
+use std::panic::{self, AssertUnwindSafe};
+
+use crate::sdk::SDKWrapper;
+use crate::types::{DashSDKAddressInfoEntry, DashSDKAddressInfoMap, SDKHandle};
+use crate::{DashSDKError, DashSDKErrorCode, DashSDKResult, FFIError};
+
+/// Fetch information about multiple Platform addresses including their nonces and balances.
+///
+/// # Parameters
+/// - `sdk_handle`: SDK handle
+/// - `addresses`: Array of address byte arrays
+/// - `address_lengths`: Array of lengths for each address (must match addresses array length)
+/// - `addresses_count`: Number of addresses in the array
+///
+/// # Returns
+/// DashSDKResult with data_type = AddressInfoMap containing addresses mapped to their info
+///
+/// # Safety
+/// - `sdk_handle`, `addresses`, and `address_lengths` must be valid, non-null pointers.
+/// - `addresses` must point to an array of `*const u8` of length `addresses_count`.
+/// - `address_lengths` must point to an array of `usize` of length `addresses_count`.
+/// - Each address pointer in `addresses` must point to valid bytes of the corresponding length.
+/// - All pointers must remain valid for the duration of the call.
+/// - On success, returns a DashSDKAddressInfoMap pointer inside `DashSDKResult`; caller must free it using `dash_sdk_address_info_map_free`.
+#[no_mangle]
+pub unsafe extern "C" fn dash_sdk_addresses_fetch_infos(
+    sdk_handle: *const SDKHandle,
+    addresses: *const *const u8,
+    address_lengths: *const usize,
+    addresses_count: usize,
+) -> DashSDKResult {
+    // Wrap the entire function in catch_unwind to prevent panics from crashing the app
+    let result = panic::catch_unwind(AssertUnwindSafe(|| {
+        dash_sdk_addresses_fetch_infos_inner(sdk_handle, addresses, address_lengths, addresses_count)
+    }));
+
+    match result {
+        Ok(result) => result,
+        Err(panic_info) => {
+            let panic_message = if let Some(s) = panic_info.downcast_ref::<&str>() {
+                s.to_string()
+            } else if let Some(s) = panic_info.downcast_ref::<String>() {
+                s.clone()
+            } else {
+                "Unknown panic occurred during addresses fetch".to_string()
+            };
+            DashSDKResult::error(DashSDKError::new(
+                DashSDKErrorCode::InternalError,
+                format!("Panic during addresses fetch: {}", panic_message),
+            ))
+        }
+    }
+}
+
+unsafe fn dash_sdk_addresses_fetch_infos_inner(
+    sdk_handle: *const SDKHandle,
+    addresses: *const *const u8,
+    address_lengths: *const usize,
+    addresses_count: usize,
+) -> DashSDKResult {
+    if sdk_handle.is_null()
+        || (addresses.is_null() && addresses_count > 0)
+        || (address_lengths.is_null() && addresses_count > 0)
+    {
+        return DashSDKResult::error(DashSDKError::new(
+            DashSDKErrorCode::InvalidParameter,
+            "SDK handle, addresses, or address lengths is null".to_string(),
+        ));
+    }
+
+    if addresses_count == 0 {
+        // Return empty map for empty input
+        let map = DashSDKAddressInfoMap {
+            entries: std::ptr::null_mut(),
+            count: 0,
+        };
+        return DashSDKResult::success_address_info_map(map);
+    }
+
+    let wrapper = &*(sdk_handle as *const SDKWrapper);
+
+    tracing::debug!(addresses_count = addresses_count, "Attempting to fetch multiple addresses info");
+
+    // Convert raw pointers to PlatformAddress set
+    let addresses_slice = std::slice::from_raw_parts(addresses, addresses_count);
+    let lengths_slice = std::slice::from_raw_parts(address_lengths, addresses_count);
+
+    let platform_addresses: Result<BTreeSet<PlatformAddress>, DashSDKError> = addresses_slice
+        .iter()
+        .enumerate()
+        .map(|(i, &addr_ptr)| {
+            if addr_ptr.is_null() {
+                return Err(DashSDKError::new(
+                    DashSDKErrorCode::InvalidParameter,
+                    format!("Address pointer at index {} is null", i),
+                ));
+            }
+
+            let len = lengths_slice[i];
+            if len == 0 {
+                return Err(DashSDKError::new(
+                    DashSDKErrorCode::InvalidParameter,
+                    format!("Address length at index {} is zero", i),
+                ));
+            }
+
+            let address_slice = std::slice::from_raw_parts(addr_ptr, len);
+            PlatformAddress::from_bytes(address_slice).map_err(|e| {
+                DashSDKError::new(
+                    DashSDKErrorCode::InvalidParameter,
+                    format!("Invalid address bytes at index {}: {}", i, e),
+                )
+            })
+        })
+        .collect();
+
+    let platform_addresses = match platform_addresses {
+        Ok(addrs) => addrs,
+        Err(e) => return DashSDKResult::error(e),
+    };
+
+    // Keep copies of original addresses and their corresponding PlatformAddress for result mapping
+    let original_addresses_with_platform: Result<Vec<(Vec<u8>, PlatformAddress)>, DashSDKError> =
+        addresses_slice
+            .iter()
+            .enumerate()
+            .map(|(i, &addr_ptr)| {
+                let len = lengths_slice[i];
+                let address_slice = std::slice::from_raw_parts(addr_ptr, len);
+                let address_bytes = address_slice.to_vec();
+                // Find the corresponding PlatformAddress from the set
+                let platform_address = platform_addresses
+                    .iter()
+                    .find(|&addr| addr.to_bytes() == address_bytes)
+                    .copied()
+                    .ok_or_else(|| {
+                        DashSDKError::new(
+                            DashSDKErrorCode::InvalidParameter,
+                            format!(
+                                "Could not find address at index {} in platform_addresses",
+                                i
+                            ),
+                        )
+                    })?;
+                Ok((address_bytes, platform_address))
+            })
+            .collect();
+
+    let original_addresses_with_platform = match original_addresses_with_platform {
+        Ok(addrs) => addrs,
+        Err(e) => return DashSDKResult::error(e),
+    };
+
+    let result: Result<DashSDKAddressInfoMap, FFIError> = wrapper.runtime.block_on(async {
+        // Fetch addresses infos
+        let address_infos: AddressInfos =
+            AddressInfo::fetch_many(&wrapper.sdk, platform_addresses)
+                .await
+                .map_err(FFIError::from)?;
+
+        // Convert to entries array
+        let mut entries: Vec<DashSDKAddressInfoEntry> =
+            Vec::with_capacity(addresses_count);
+
+        // Process results in the same order as input
+        for (address_bytes, platform_address) in original_addresses_with_platform.iter() {
+            let address_info = address_infos.get(platform_address).and_then(|opt| opt.as_ref());
+
+            let (nonce, balance) = match address_info {
+                Some(info) => (info.nonce, info.balance),
+                None => (u32::MAX, u64::MAX), // Not found
+            };
+
+            // Allocate address bytes
+            let address_bytes_vec = address_bytes.clone();
+            let address_len = address_bytes_vec.len();
+            let address_ptr = address_bytes_vec.as_ptr() as *mut u8;
+            std::mem::forget(address_bytes_vec); // Prevent deallocation
+
+            entries.push(DashSDKAddressInfoEntry {
+                address: address_ptr,
+                address_len,
+                nonce,
+                balance,
+            });
+        }
+
+        let count = entries.len();
+        let entries_ptr = entries.as_mut_ptr();
+        std::mem::forget(entries); // Prevent deallocation
+
+        Ok(DashSDKAddressInfoMap {
+            entries: entries_ptr,
+            count,
+        })
+    });
+
+    match result {
+        Ok(map) => DashSDKResult::success_address_info_map(map),
+        Err(e) => DashSDKResult::error(e.into()),
+    }
+}

--- a/packages/rs-sdk-ffi/src/address/queries/mod.rs
+++ b/packages/rs-sdk-ffi/src/address/queries/mod.rs
@@ -2,7 +2,9 @@
 
 pub mod info;
 pub mod infos;
+pub mod trunk_state;
 
 // Re-export main functions for convenient access
 pub use info::dash_sdk_address_fetch_info;
 pub use infos::dash_sdk_addresses_fetch_infos;
+pub use trunk_state::dash_sdk_address_fetch_trunk_state;

--- a/packages/rs-sdk-ffi/src/address/queries/mod.rs
+++ b/packages/rs-sdk-ffi/src/address/queries/mod.rs
@@ -1,11 +1,13 @@
 //! Address query operations
 
+pub mod balance_changes;
 pub mod branch_state;
 pub mod info;
 pub mod infos;
 pub mod trunk_state;
 
 // Re-export main functions for convenient access
+pub use balance_changes::dash_sdk_address_fetch_recent_balance_changes;
 pub use branch_state::dash_sdk_address_fetch_branch_state;
 pub use info::dash_sdk_address_fetch_info;
 pub use infos::dash_sdk_addresses_fetch_infos;

--- a/packages/rs-sdk-ffi/src/address/queries/mod.rs
+++ b/packages/rs-sdk-ffi/src/address/queries/mod.rs
@@ -1,0 +1,8 @@
+//! Address query operations
+
+pub mod info;
+pub mod infos;
+
+// Re-export main functions for convenient access
+pub use info::dash_sdk_address_fetch_info;
+pub use infos::dash_sdk_addresses_fetch_infos;

--- a/packages/rs-sdk-ffi/src/address/queries/mod.rs
+++ b/packages/rs-sdk-ffi/src/address/queries/mod.rs
@@ -1,10 +1,12 @@
 //! Address query operations
 
+pub mod branch_state;
 pub mod info;
 pub mod infos;
 pub mod trunk_state;
 
 // Re-export main functions for convenient access
+pub use branch_state::dash_sdk_address_fetch_branch_state;
 pub use info::dash_sdk_address_fetch_info;
 pub use infos::dash_sdk_addresses_fetch_infos;
 pub use trunk_state::dash_sdk_address_fetch_trunk_state;

--- a/packages/rs-sdk-ffi/src/address/queries/mod.rs
+++ b/packages/rs-sdk-ffi/src/address/queries/mod.rs
@@ -2,6 +2,7 @@
 
 pub mod balance_changes;
 pub mod branch_state;
+pub mod compacted_balance_changes;
 pub mod info;
 pub mod infos;
 pub mod trunk_state;
@@ -9,6 +10,7 @@ pub mod trunk_state;
 // Re-export main functions for convenient access
 pub use balance_changes::dash_sdk_address_fetch_recent_balance_changes;
 pub use branch_state::dash_sdk_address_fetch_branch_state;
+pub use compacted_balance_changes::dash_sdk_address_fetch_compacted_balance_changes;
 pub use info::dash_sdk_address_fetch_info;
 pub use infos::dash_sdk_addresses_fetch_infos;
 pub use trunk_state::dash_sdk_address_fetch_trunk_state;

--- a/packages/rs-sdk-ffi/src/address/queries/trunk_state.rs
+++ b/packages/rs-sdk-ffi/src/address/queries/trunk_state.rs
@@ -1,0 +1,182 @@
+//! Trunk state query operations for address synchronization
+
+use dash_sdk::platform::Fetch;
+use drive_proof_verifier::types::PlatformAddressTrunkState;
+use std::panic::{self, AssertUnwindSafe};
+
+use crate::sdk::SDKWrapper;
+use crate::types::{DashSDKLeafBoundary, DashSDKTrunkState, DashSDKTrunkStateElement, SDKHandle};
+use crate::{DashSDKError, DashSDKErrorCode, DashSDKResult, FFIError};
+
+/// Fetch the trunk state of the address tree for privacy-preserving address synchronization.
+///
+/// The trunk state contains:
+/// - Elements: Addresses with balances found at the top levels of the tree
+/// - Leaf boundaries: Subtrees that require further branch queries to explore
+///
+/// # Parameters
+/// - `sdk_handle`: SDK handle
+///
+/// # Returns
+/// DashSDKResult with data_type = TrunkState containing elements and leaf boundaries
+///
+/// # Safety
+/// - `sdk_handle` must be a valid, non-null pointer.
+/// - On success, returns a DashSDKTrunkState pointer; caller must free it using `dash_sdk_trunk_state_free`.
+#[no_mangle]
+pub unsafe extern "C" fn dash_sdk_address_fetch_trunk_state(
+    sdk_handle: *const SDKHandle,
+) -> DashSDKResult {
+    // Wrap the entire function in catch_unwind to prevent panics from crashing the app
+    let result = panic::catch_unwind(AssertUnwindSafe(|| {
+        dash_sdk_address_fetch_trunk_state_inner(sdk_handle)
+    }));
+
+    match result {
+        Ok(result) => result,
+        Err(panic_info) => {
+            let panic_message = if let Some(s) = panic_info.downcast_ref::<&str>() {
+                s.to_string()
+            } else if let Some(s) = panic_info.downcast_ref::<String>() {
+                s.clone()
+            } else {
+                "Unknown panic occurred during trunk state fetch".to_string()
+            };
+            DashSDKResult::error(DashSDKError::new(
+                DashSDKErrorCode::InternalError,
+                format!("Panic during trunk state fetch: {}", panic_message),
+            ))
+        }
+    }
+}
+
+unsafe fn dash_sdk_address_fetch_trunk_state_inner(
+    sdk_handle: *const SDKHandle,
+) -> DashSDKResult {
+    if sdk_handle.is_null() {
+        return DashSDKResult::error(DashSDKError::new(
+            DashSDKErrorCode::InvalidParameter,
+            "SDK handle is null".to_string(),
+        ));
+    }
+
+    let wrapper = &*(sdk_handle as *const SDKWrapper);
+
+    let result: Result<DashSDKTrunkState, FFIError> = wrapper.runtime.block_on(async {
+        // Fetch trunk state using Fetch trait with empty query (no parameters)
+        let (trunk_state_opt, metadata) =
+            PlatformAddressTrunkState::fetch_with_metadata(&wrapper.sdk, (), None)
+                .await
+                .map_err(FFIError::from)?;
+
+        let trunk_state = trunk_state_opt.ok_or_else(|| {
+            FFIError::NotFound("Trunk state not available".to_string())
+        })?;
+
+        let grove_result = trunk_state.into_inner();
+        let checkpoint_height = metadata.height;
+
+        // Convert elements to FFI format
+        let mut elements: Vec<DashSDKTrunkStateElement> = Vec::new();
+        for (key, element) in grove_result.elements.iter() {
+            // Extract balance and nonce from Element
+            // Element is typically Item with encoded balance/nonce
+            if let Some((balance, nonce)) = extract_balance_nonce_from_element(element) {
+                let key_vec: Vec<u8> = key.clone();
+                let key_len = key_vec.len();
+                let key_ptr = key_vec.as_ptr() as *mut u8;
+                std::mem::forget(key_vec);
+
+                elements.push(DashSDKTrunkStateElement {
+                    key: key_ptr,
+                    key_len,
+                    nonce,
+                    balance,
+                });
+            }
+        }
+
+        // Convert leaf keys to FFI format
+        // leaf_keys is a BTreeMap<Vec<u8>, LeafInfo>
+        let mut leaf_boundaries: Vec<DashSDKLeafBoundary> = Vec::new();
+        for (key, leaf_info) in grove_result.leaf_keys.iter() {
+            let key_vec: Vec<u8> = key.clone();
+            let key_len = key_vec.len();
+            let key_ptr = key_vec.as_ptr() as *mut u8;
+            std::mem::forget(key_vec);
+
+            leaf_boundaries.push(DashSDKLeafBoundary {
+                key: key_ptr,
+                key_len,
+                hash: leaf_info.hash,
+                estimated_count: leaf_info.count.unwrap_or(0),
+            });
+        }
+
+        // Convert to raw arrays
+        let elements_count = elements.len();
+        let elements_ptr = if elements.is_empty() {
+            std::ptr::null_mut()
+        } else {
+            let ptr = elements.as_ptr() as *mut DashSDKTrunkStateElement;
+            std::mem::forget(elements);
+            ptr
+        };
+
+        let leaf_boundaries_count = leaf_boundaries.len();
+        let leaf_boundaries_ptr = if leaf_boundaries.is_empty() {
+            std::ptr::null_mut()
+        } else {
+            let ptr = leaf_boundaries.as_ptr() as *mut DashSDKLeafBoundary;
+            std::mem::forget(leaf_boundaries);
+            ptr
+        };
+
+        Ok(DashSDKTrunkState {
+            elements: elements_ptr,
+            elements_count,
+            leaf_boundaries: leaf_boundaries_ptr,
+            leaf_boundaries_count,
+            checkpoint_height,
+        })
+    });
+
+    match result {
+        Ok(state) => DashSDKResult::success_trunk_state(state),
+        Err(e) => DashSDKResult::error(e.into()),
+    }
+}
+
+/// Extract balance and nonce from a GroveDB Element.
+/// Returns None if the element format is not recognized.
+fn extract_balance_nonce_from_element(
+    element: &dash_sdk::drive::grovedb::Element,
+) -> Option<(u64, u32)> {
+    use dash_sdk::drive::grovedb::Element;
+
+    match element {
+        Element::Item(data, _) => {
+            // Address funds are encoded as: nonce (4 bytes) + balance (8 bytes)
+            if data.len() >= 12 {
+                let nonce = u32::from_be_bytes([data[0], data[1], data[2], data[3]]);
+                let balance = u64::from_be_bytes([
+                    data[4], data[5], data[6], data[7], data[8], data[9], data[10], data[11],
+                ]);
+                Some((balance, nonce))
+            } else if data.len() >= 8 {
+                // Fallback: just balance
+                let balance = u64::from_be_bytes([
+                    data[0], data[1], data[2], data[3], data[4], data[5], data[6], data[7],
+                ]);
+                Some((balance, 0))
+            } else {
+                None
+            }
+        }
+        Element::SumItem(balance, _) => {
+            // SumItem directly contains the balance
+            Some((*balance as u64, 0))
+        }
+        _ => None,
+    }
+}

--- a/packages/rs-sdk-ffi/src/lib.rs
+++ b/packages/rs-sdk-ffi/src/lib.rs
@@ -5,6 +5,7 @@
 //! This crate provides C-compatible FFI bindings for both Dash Core (SPV) and Platform SDKs,
 //! enabling cross-platform applications to interact with the complete Dash ecosystem through C interfaces.
 
+mod address;
 mod address_sync;
 mod callback_bridge;
 mod contested_resource;
@@ -36,6 +37,7 @@ mod voting;
 #[cfg(test)]
 mod test_utils;
 
+pub use address::*;
 pub use address_sync::*;
 pub use callback_bridge::*;
 pub use contested_resource::*;

--- a/packages/rs-sdk-ffi/src/types.rs
+++ b/packages/rs-sdk-ffi/src/types.rs
@@ -96,6 +96,8 @@ pub enum DashSDKResultDataType {
     TrunkState = 10,
     /// Branch state for address synchronization
     BranchState = 11,
+    /// Recent address balance changes
+    RecentBalanceChanges = 12,
 }
 
 /// Binary data container for results
@@ -214,6 +216,49 @@ pub struct DashSDKBranchState {
     pub leaf_boundaries_count: usize,
 }
 
+/// Credit operation type
+#[repr(C)]
+#[derive(Debug, Clone, Copy)]
+pub enum DashSDKCreditOperationType {
+    /// Setting credits to a value
+    SetCredits = 0,
+    /// Adding to credits
+    AddToCredits = 1,
+}
+
+/// A single balance change for an address
+#[repr(C)]
+pub struct DashSDKAddressBalanceChange {
+    /// Address bytes
+    pub address: *mut u8,
+    /// Length of address bytes
+    pub address_len: usize,
+    /// Operation type
+    pub operation_type: DashSDKCreditOperationType,
+    /// Credit amount
+    pub credits: u64,
+}
+
+/// Balance changes for a single block
+#[repr(C)]
+pub struct DashSDKBlockBalanceChanges {
+    /// Block height
+    pub block_height: u64,
+    /// Array of balance changes
+    pub changes: *mut DashSDKAddressBalanceChange,
+    /// Number of changes
+    pub changes_count: usize,
+}
+
+/// Recent address balance changes across multiple blocks
+#[repr(C)]
+pub struct DashSDKRecentBalanceChanges {
+    /// Array of block balance changes
+    pub blocks: *mut DashSDKBlockBalanceChanges,
+    /// Number of blocks
+    pub blocks_count: usize,
+}
+
 /// Result type for FFI functions that return data
 #[repr(C)]
 pub struct DashSDKResult {
@@ -312,6 +357,15 @@ impl DashSDKResult {
         DashSDKResult {
             data_type: DashSDKResultDataType::BranchState,
             data: Box::into_raw(Box::new(state)) as *mut c_void,
+            error: std::ptr::null_mut(),
+        }
+    }
+
+    /// Create a success result with recent balance changes
+    pub fn success_recent_balance_changes(changes: DashSDKRecentBalanceChanges) -> Self {
+        DashSDKResult {
+            data_type: DashSDKResultDataType::RecentBalanceChanges,
+            data: Box::into_raw(Box::new(changes)) as *mut c_void,
             error: std::ptr::null_mut(),
         }
     }
@@ -673,6 +727,39 @@ pub unsafe extern "C" fn dash_sdk_branch_state_free(state: *mut DashSDKBranchSta
             }
         }
         let _ = Vec::from_raw_parts(state.leaf_boundaries, state.leaf_boundaries_count, state.leaf_boundaries_count);
+    }
+}
+
+/// Free a recent balance changes structure
+///
+/// # Safety
+/// - `changes` must be a valid pointer to `DashSDKRecentBalanceChanges` allocated by this SDK.
+/// - It may be null (no-op). When non-null, this frees all blocks, changes, addresses, and the struct.
+/// - Do not access `changes` after this call.
+#[no_mangle]
+pub unsafe extern "C" fn dash_sdk_recent_balance_changes_free(changes: *mut DashSDKRecentBalanceChanges) {
+    if changes.is_null() {
+        return;
+    }
+
+    let changes = Box::from_raw(changes);
+    
+    // Free blocks
+    if !changes.blocks.is_null() && changes.blocks_count > 0 {
+        let blocks_slice = std::slice::from_raw_parts_mut(changes.blocks, changes.blocks_count);
+        for block in blocks_slice.iter() {
+            // Free changes within each block
+            if !block.changes.is_null() && block.changes_count > 0 {
+                let changes_slice = std::slice::from_raw_parts_mut(block.changes, block.changes_count);
+                for change in changes_slice.iter() {
+                    if !change.address.is_null() && change.address_len > 0 {
+                        let _ = Vec::from_raw_parts(change.address, change.address_len, change.address_len);
+                    }
+                }
+                let _ = Vec::from_raw_parts(block.changes, block.changes_count, block.changes_count);
+            }
+        }
+        let _ = Vec::from_raw_parts(changes.blocks, changes.blocks_count, changes.blocks_count);
     }
 }
 

--- a/packages/rs-sdk-ffi/src/types.rs
+++ b/packages/rs-sdk-ffi/src/types.rs
@@ -88,6 +88,10 @@ pub enum DashSDKResultDataType {
     IdentityBalanceMap = 6,
     /// Public key handle
     ResultPublicKeyHandle = 7,
+    /// Address info (single address with balance and nonce)
+    AddressInfo = 8,
+    /// Map of addresses to their info
+    AddressInfoMap = 9,
 }
 
 /// Binary data container for results
@@ -113,6 +117,41 @@ pub struct DashSDKIdentityBalanceEntry {
 pub struct DashSDKIdentityBalanceMap {
     /// Array of entries
     pub entries: *mut DashSDKIdentityBalanceEntry,
+    /// Number of entries
+    pub count: usize,
+}
+
+/// Information about a Platform address including its nonce and balance
+#[repr(C)]
+pub struct DashSDKAddressInfo {
+    /// Address bytes (variable length, typically 20-32 bytes)
+    pub address: *mut u8,
+    /// Length of address bytes
+    pub address_len: usize,
+    /// Nonce associated with the address (u32::MAX means address not found)
+    pub nonce: u32,
+    /// Balance in credits (u64::MAX means address not found)
+    pub balance: u64,
+}
+
+/// Single entry in an address info map
+#[repr(C)]
+pub struct DashSDKAddressInfoEntry {
+    /// Address bytes (variable length, typically 20-32 bytes)
+    pub address: *mut u8,
+    /// Length of address bytes
+    pub address_len: usize,
+    /// Nonce associated with the address (u32::MAX means address not found)
+    pub nonce: u32,
+    /// Balance in credits (u64::MAX means address not found)
+    pub balance: u64,
+}
+
+/// Map of addresses to their info
+#[repr(C)]
+pub struct DashSDKAddressInfoMap {
+    /// Array of entries
+    pub entries: *mut DashSDKAddressInfoEntry,
     /// Number of entries
     pub count: usize,
 }
@@ -178,6 +217,24 @@ impl DashSDKResult {
     pub fn success_identity_balance_map(map: DashSDKIdentityBalanceMap) -> Self {
         DashSDKResult {
             data_type: DashSDKResultDataType::IdentityBalanceMap,
+            data: Box::into_raw(Box::new(map)) as *mut c_void,
+            error: std::ptr::null_mut(),
+        }
+    }
+
+    /// Create a success result with address info
+    pub fn success_address_info(info: DashSDKAddressInfo) -> Self {
+        DashSDKResult {
+            data_type: DashSDKResultDataType::AddressInfo,
+            data: Box::into_raw(Box::new(info)) as *mut c_void,
+            error: std::ptr::null_mut(),
+        }
+    }
+
+    /// Create a success result with an address info map
+    pub fn success_address_info_map(map: DashSDKAddressInfoMap) -> Self {
+        DashSDKResult {
+            data_type: DashSDKResultDataType::AddressInfoMap,
             data: Box::into_raw(Box::new(map)) as *mut c_void,
             error: std::ptr::null_mut(),
         }
@@ -423,6 +480,48 @@ pub unsafe extern "C" fn dash_sdk_identity_balance_map_free(map: *mut DashSDKIde
     let map = Box::from_raw(map);
     if !map.entries.is_null() && map.count > 0 {
         // Free the entries array
+        let _ = Vec::from_raw_parts(map.entries, map.count, map.count);
+    }
+}
+
+/// Free an address info structure
+///
+/// # Safety
+/// - `info` must be a valid pointer to `DashSDKAddressInfo` allocated by this SDK.
+/// - It may be null (no-op). When non-null, this frees the address bytes and the struct.
+/// - Do not access `info` after this call.
+#[no_mangle]
+pub unsafe extern "C" fn dash_sdk_address_info_free(info: *mut DashSDKAddressInfo) {
+    if info.is_null() {
+        return;
+    }
+
+    let info = Box::from_raw(info);
+    if !info.address.is_null() && info.address_len > 0 {
+        let _ = Vec::from_raw_parts(info.address, info.address_len, info.address_len);
+    }
+}
+
+/// Free an address info map
+///
+/// # Safety
+/// - `map` must be a valid, non-dangling pointer returned by this SDK.
+/// - It may be null (no-op). When non-null, this frees all entries, their address bytes, and the struct.
+/// - Using `map` after this function returns is undefined behavior.
+#[no_mangle]
+pub unsafe extern "C" fn dash_sdk_address_info_map_free(map: *mut DashSDKAddressInfoMap) {
+    if map.is_null() {
+        return;
+    }
+
+    let map = Box::from_raw(map);
+    if !map.entries.is_null() && map.count > 0 {
+        let entries_slice = std::slice::from_raw_parts_mut(map.entries, map.count);
+        for entry in entries_slice.iter() {
+            if !entry.address.is_null() && entry.address_len > 0 {
+                let _ = Vec::from_raw_parts(entry.address, entry.address_len, entry.address_len);
+            }
+        }
         let _ = Vec::from_raw_parts(map.entries, map.count, map.count);
     }
 }

--- a/packages/rs-sdk-ffi/src/types.rs
+++ b/packages/rs-sdk-ffi/src/types.rs
@@ -92,6 +92,8 @@ pub enum DashSDKResultDataType {
     AddressInfo = 8,
     /// Map of addresses to their info
     AddressInfoMap = 9,
+    /// Trunk state for address synchronization
+    TrunkState = 10,
 }
 
 /// Binary data container for results
@@ -154,6 +156,47 @@ pub struct DashSDKAddressInfoMap {
     pub entries: *mut DashSDKAddressInfoEntry,
     /// Number of entries
     pub count: usize,
+}
+
+/// Single element in trunk state (address with balance/nonce)
+#[repr(C)]
+pub struct DashSDKTrunkStateElement {
+    /// Address key bytes
+    pub key: *mut u8,
+    /// Length of key bytes
+    pub key_len: usize,
+    /// Nonce associated with the address
+    pub nonce: u32,
+    /// Balance in credits
+    pub balance: u64,
+}
+
+/// Leaf boundary in trunk state (subtree that needs further queries)
+#[repr(C)]
+pub struct DashSDKLeafBoundary {
+    /// Leaf key bytes
+    pub key: *mut u8,
+    /// Length of key bytes
+    pub key_len: usize,
+    /// Expected hash (32 bytes)
+    pub hash: [u8; 32],
+    /// Estimated element count in this subtree (0 if unknown)
+    pub estimated_count: u64,
+}
+
+/// Trunk state for address synchronization
+#[repr(C)]
+pub struct DashSDKTrunkState {
+    /// Array of elements (addresses with balances found at trunk level)
+    pub elements: *mut DashSDKTrunkStateElement,
+    /// Number of elements
+    pub elements_count: usize,
+    /// Array of leaf boundaries (subtrees needing branch queries)
+    pub leaf_boundaries: *mut DashSDKLeafBoundary,
+    /// Number of leaf boundaries
+    pub leaf_boundaries_count: usize,
+    /// Checkpoint height for consistency
+    pub checkpoint_height: u64,
 }
 
 /// Result type for FFI functions that return data
@@ -236,6 +279,15 @@ impl DashSDKResult {
         DashSDKResult {
             data_type: DashSDKResultDataType::AddressInfoMap,
             data: Box::into_raw(Box::new(map)) as *mut c_void,
+            error: std::ptr::null_mut(),
+        }
+    }
+
+    /// Create a success result with trunk state
+    pub fn success_trunk_state(state: DashSDKTrunkState) -> Self {
+        DashSDKResult {
+            data_type: DashSDKResultDataType::TrunkState,
+            data: Box::into_raw(Box::new(state)) as *mut c_void,
             error: std::ptr::null_mut(),
         }
     }
@@ -523,6 +575,43 @@ pub unsafe extern "C" fn dash_sdk_address_info_map_free(map: *mut DashSDKAddress
             }
         }
         let _ = Vec::from_raw_parts(map.entries, map.count, map.count);
+    }
+}
+
+/// Free a trunk state structure
+///
+/// # Safety
+/// - `state` must be a valid pointer to `DashSDKTrunkState` allocated by this SDK.
+/// - It may be null (no-op). When non-null, this frees all elements, leaf boundaries, and the struct.
+/// - Do not access `state` after this call.
+#[no_mangle]
+pub unsafe extern "C" fn dash_sdk_trunk_state_free(state: *mut DashSDKTrunkState) {
+    if state.is_null() {
+        return;
+    }
+
+    let state = Box::from_raw(state);
+    
+    // Free elements
+    if !state.elements.is_null() && state.elements_count > 0 {
+        let elements_slice = std::slice::from_raw_parts_mut(state.elements, state.elements_count);
+        for element in elements_slice.iter() {
+            if !element.key.is_null() && element.key_len > 0 {
+                let _ = Vec::from_raw_parts(element.key, element.key_len, element.key_len);
+            }
+        }
+        let _ = Vec::from_raw_parts(state.elements, state.elements_count, state.elements_count);
+    }
+    
+    // Free leaf boundaries
+    if !state.leaf_boundaries.is_null() && state.leaf_boundaries_count > 0 {
+        let boundaries_slice = std::slice::from_raw_parts_mut(state.leaf_boundaries, state.leaf_boundaries_count);
+        for boundary in boundaries_slice.iter() {
+            if !boundary.key.is_null() && boundary.key_len > 0 {
+                let _ = Vec::from_raw_parts(boundary.key, boundary.key_len, boundary.key_len);
+            }
+        }
+        let _ = Vec::from_raw_parts(state.leaf_boundaries, state.leaf_boundaries_count, state.leaf_boundaries_count);
     }
 }
 

--- a/packages/rs-sdk-ffi/src/types.rs
+++ b/packages/rs-sdk-ffi/src/types.rs
@@ -94,6 +94,8 @@ pub enum DashSDKResultDataType {
     AddressInfoMap = 9,
     /// Trunk state for address synchronization
     TrunkState = 10,
+    /// Branch state for address synchronization
+    BranchState = 11,
 }
 
 /// Binary data container for results
@@ -199,6 +201,19 @@ pub struct DashSDKTrunkState {
     pub checkpoint_height: u64,
 }
 
+/// Branch state for address synchronization (result of branch query)
+#[repr(C)]
+pub struct DashSDKBranchState {
+    /// Array of elements (addresses with balances found in this branch)
+    pub elements: *mut DashSDKTrunkStateElement,
+    /// Number of elements
+    pub elements_count: usize,
+    /// Array of leaf boundaries (deeper subtrees needing further queries)
+    pub leaf_boundaries: *mut DashSDKLeafBoundary,
+    /// Number of leaf boundaries
+    pub leaf_boundaries_count: usize,
+}
+
 /// Result type for FFI functions that return data
 #[repr(C)]
 pub struct DashSDKResult {
@@ -287,6 +302,15 @@ impl DashSDKResult {
     pub fn success_trunk_state(state: DashSDKTrunkState) -> Self {
         DashSDKResult {
             data_type: DashSDKResultDataType::TrunkState,
+            data: Box::into_raw(Box::new(state)) as *mut c_void,
+            error: std::ptr::null_mut(),
+        }
+    }
+
+    /// Create a success result with branch state
+    pub fn success_branch_state(state: DashSDKBranchState) -> Self {
+        DashSDKResult {
+            data_type: DashSDKResultDataType::BranchState,
             data: Box::into_raw(Box::new(state)) as *mut c_void,
             error: std::ptr::null_mut(),
         }
@@ -586,6 +610,43 @@ pub unsafe extern "C" fn dash_sdk_address_info_map_free(map: *mut DashSDKAddress
 /// - Do not access `state` after this call.
 #[no_mangle]
 pub unsafe extern "C" fn dash_sdk_trunk_state_free(state: *mut DashSDKTrunkState) {
+    if state.is_null() {
+        return;
+    }
+
+    let state = Box::from_raw(state);
+    
+    // Free elements
+    if !state.elements.is_null() && state.elements_count > 0 {
+        let elements_slice = std::slice::from_raw_parts_mut(state.elements, state.elements_count);
+        for element in elements_slice.iter() {
+            if !element.key.is_null() && element.key_len > 0 {
+                let _ = Vec::from_raw_parts(element.key, element.key_len, element.key_len);
+            }
+        }
+        let _ = Vec::from_raw_parts(state.elements, state.elements_count, state.elements_count);
+    }
+    
+    // Free leaf boundaries
+    if !state.leaf_boundaries.is_null() && state.leaf_boundaries_count > 0 {
+        let boundaries_slice = std::slice::from_raw_parts_mut(state.leaf_boundaries, state.leaf_boundaries_count);
+        for boundary in boundaries_slice.iter() {
+            if !boundary.key.is_null() && boundary.key_len > 0 {
+                let _ = Vec::from_raw_parts(boundary.key, boundary.key_len, boundary.key_len);
+            }
+        }
+        let _ = Vec::from_raw_parts(state.leaf_boundaries, state.leaf_boundaries_count, state.leaf_boundaries_count);
+    }
+}
+
+/// Free a branch state structure
+///
+/// # Safety
+/// - `state` must be a valid pointer to `DashSDKBranchState` allocated by this SDK.
+/// - It may be null (no-op). When non-null, this frees all elements, leaf boundaries, and the struct.
+/// - Do not access `state` after this call.
+#[no_mangle]
+pub unsafe extern "C" fn dash_sdk_branch_state_free(state: *mut DashSDKBranchState) {
     if state.is_null() {
         return;
     }

--- a/packages/rs-sdk-ffi/src/types.rs
+++ b/packages/rs-sdk-ffi/src/types.rs
@@ -98,6 +98,8 @@ pub enum DashSDKResultDataType {
     BranchState = 11,
     /// Recent address balance changes
     RecentBalanceChanges = 12,
+    /// Recent compacted address balance changes
+    CompactedBalanceChanges = 13,
 }
 
 /// Binary data container for results
@@ -259,6 +261,64 @@ pub struct DashSDKRecentBalanceChanges {
     pub blocks_count: usize,
 }
 
+/// Block-aware credit operation type for compacted balance changes
+#[repr(C)]
+#[derive(Debug, Clone, Copy)]
+pub enum DashSDKBlockAwareCreditOperationType {
+    /// Set credits to a final value
+    BlockAwareSetCredits = 0,
+    /// Add to credits with block height entries
+    BlockAwareAddToCreditsOperations = 1,
+}
+
+/// Entry for block height to credits mapping
+#[repr(C)]
+pub struct DashSDKBlockHeightCreditEntry {
+    /// Block height
+    pub block_height: u64,
+    /// Credit amount
+    pub credits: u64,
+}
+
+/// A compacted balance change for an address (supports block-aware operations)
+#[repr(C)]
+pub struct DashSDKCompactedAddressChange {
+    /// Address bytes
+    pub address: *mut u8,
+    /// Length of address bytes
+    pub address_len: usize,
+    /// Operation type
+    pub operation_type: DashSDKBlockAwareCreditOperationType,
+    /// For SetCredits: the final value; for AddToCreditsOperations: ignored (use entries)
+    pub set_credits_value: u64,
+    /// For AddToCreditsOperations: array of block height/credit entries
+    pub add_entries: *mut DashSDKBlockHeightCreditEntry,
+    /// Number of entries (0 for SetCredits)
+    pub add_entries_count: usize,
+}
+
+/// Compacted balance changes for a range of blocks
+#[repr(C)]
+pub struct DashSDKCompactedBlockRange {
+    /// Start block height of the range
+    pub start_block_height: u64,
+    /// End block height of the range
+    pub end_block_height: u64,
+    /// Array of address changes
+    pub changes: *mut DashSDKCompactedAddressChange,
+    /// Number of changes
+    pub changes_count: usize,
+}
+
+/// Recent compacted address balance changes across multiple ranges
+#[repr(C)]
+pub struct DashSDKCompactedBalanceChanges {
+    /// Array of compacted block ranges
+    pub ranges: *mut DashSDKCompactedBlockRange,
+    /// Number of ranges
+    pub ranges_count: usize,
+}
+
 /// Result type for FFI functions that return data
 #[repr(C)]
 pub struct DashSDKResult {
@@ -365,6 +425,15 @@ impl DashSDKResult {
     pub fn success_recent_balance_changes(changes: DashSDKRecentBalanceChanges) -> Self {
         DashSDKResult {
             data_type: DashSDKResultDataType::RecentBalanceChanges,
+            data: Box::into_raw(Box::new(changes)) as *mut c_void,
+            error: std::ptr::null_mut(),
+        }
+    }
+
+    /// Create a success result with compacted balance changes
+    pub fn success_compacted_balance_changes(changes: DashSDKCompactedBalanceChanges) -> Self {
+        DashSDKResult {
+            data_type: DashSDKResultDataType::CompactedBalanceChanges,
             data: Box::into_raw(Box::new(changes)) as *mut c_void,
             error: std::ptr::null_mut(),
         }
@@ -760,6 +829,44 @@ pub unsafe extern "C" fn dash_sdk_recent_balance_changes_free(changes: *mut Dash
             }
         }
         let _ = Vec::from_raw_parts(changes.blocks, changes.blocks_count, changes.blocks_count);
+    }
+}
+
+/// Free a compacted balance changes structure
+///
+/// # Safety
+/// - `changes` must be a valid pointer to `DashSDKCompactedBalanceChanges` allocated by this SDK.
+/// - It may be null (no-op). When non-null, this frees all ranges, changes, addresses, entries, and the struct.
+/// - Do not access `changes` after this call.
+#[no_mangle]
+pub unsafe extern "C" fn dash_sdk_compacted_balance_changes_free(changes: *mut DashSDKCompactedBalanceChanges) {
+    if changes.is_null() {
+        return;
+    }
+
+    let changes = Box::from_raw(changes);
+    
+    // Free ranges
+    if !changes.ranges.is_null() && changes.ranges_count > 0 {
+        let ranges_slice = std::slice::from_raw_parts_mut(changes.ranges, changes.ranges_count);
+        for range in ranges_slice.iter() {
+            // Free changes within each range
+            if !range.changes.is_null() && range.changes_count > 0 {
+                let changes_slice = std::slice::from_raw_parts_mut(range.changes, range.changes_count);
+                for change in changes_slice.iter() {
+                    // Free address
+                    if !change.address.is_null() && change.address_len > 0 {
+                        let _ = Vec::from_raw_parts(change.address, change.address_len, change.address_len);
+                    }
+                    // Free add entries
+                    if !change.add_entries.is_null() && change.add_entries_count > 0 {
+                        let _ = Vec::from_raw_parts(change.add_entries, change.add_entries_count, change.add_entries_count);
+                    }
+                }
+                let _ = Vec::from_raw_parts(range.changes, range.changes_count, range.changes_count);
+            }
+        }
+        let _ = Vec::from_raw_parts(changes.ranges, changes.ranges_count, changes.ranges_count);
     }
 }
 

--- a/packages/swift-sdk/Sources/SwiftDashSDK/Address/Addresses.swift
+++ b/packages/swift-sdk/Sources/SwiftDashSDK/Address/Addresses.swift
@@ -466,6 +466,86 @@ public class Addresses: @unchecked Sendable {
         )
     }
     
+    // MARK: - Recent Balance Changes Query
+    
+    /// Fetch recent address balance changes starting from a specific block height.
+    ///
+    /// This returns all address balance changes that occurred since the specified start height.
+    /// Useful for syncing wallet balances after the initial sync.
+    ///
+    /// - Parameter startHeight: Block height to start fetching changes from
+    /// - Returns: RecentBalanceChanges containing block-by-block changes
+    /// - Throws: SDKError if the query fails
+    public func getRecentBalanceChanges(startHeight: UInt64) throws -> RecentBalanceChanges {
+        guard let sdk = sdk, let handle = sdk.handle else {
+            throw SDKError.invalidState("SDK not initialized")
+        }
+        
+        let result = dash_sdk_address_fetch_recent_balance_changes(handle, startHeight)
+        
+        // Check for errors
+        if let error = result.error {
+            let sdkError = SDKError.fromDashSDKError(error.pointee)
+            dash_sdk_error_free(error)
+            throw sdkError
+        }
+        
+        guard let dataPtr = result.data else {
+            // No changes found - return empty result
+            return RecentBalanceChanges(blocks: [])
+        }
+        
+        // Parse DashSDKRecentBalanceChanges
+        let changesPtr = dataPtr.assumingMemoryBound(to: DashSDKRecentBalanceChanges.self)
+        let ffiChanges = changesPtr.pointee
+        
+        // Convert blocks
+        var blocks: [BlockBalanceChanges] = []
+        if ffiChanges.blocks_count > 0 && ffiChanges.blocks != nil {
+            for i in 0..<ffiChanges.blocks_count {
+                let ffiBlock = ffiChanges.blocks![Int(i)]
+                
+                // Convert address changes within this block
+                var addressChanges: [AddressBalanceChange] = []
+                if ffiBlock.changes_count > 0 && ffiBlock.changes != nil {
+                    for j in 0..<ffiBlock.changes_count {
+                        let ffiChange = ffiBlock.changes![Int(j)]
+                        
+                        let addressData: Data
+                        if ffiChange.address != nil && ffiChange.address_len > 0 {
+                            addressData = Data(bytes: ffiChange.address!, count: Int(ffiChange.address_len))
+                        } else {
+                            continue
+                        }
+                        
+                        // Map operation type: 0 = SetCredits, 1 = AddToCredits
+                        let operation: CreditOperationType
+                        if ffiChange.operation_type.rawValue == 0 {
+                            operation = .setCredits(credits: ffiChange.credits)
+                        } else {
+                            operation = .addToCredits(credits: ffiChange.credits)
+                        }
+                        
+                        addressChanges.append(AddressBalanceChange(
+                            addressBytes: addressData,
+                            operation: operation
+                        ))
+                    }
+                }
+                
+                blocks.append(BlockBalanceChanges(
+                    blockHeight: ffiBlock.block_height,
+                    changes: addressChanges
+                ))
+            }
+        }
+        
+        // Free the FFI struct
+        dash_sdk_recent_balance_changes_free(changesPtr)
+        
+        return RecentBalanceChanges(blocks: blocks)
+    }
+    
     // MARK: - Convenience Methods
 
     /// Get the balance for a single address

--- a/packages/swift-sdk/Sources/SwiftDashSDK/Address/Addresses.swift
+++ b/packages/swift-sdk/Sources/SwiftDashSDK/Address/Addresses.swift
@@ -260,6 +260,99 @@ public class Addresses: @unchecked Sendable {
         return try getInfos(addressesBytesList: addressesBytesList)
     }
 
+    // MARK: - Trunk State Query
+    
+    /// Fetch the trunk state of the address tree for privacy-preserving address synchronization.
+    ///
+    /// The trunk state contains:
+    /// - Elements: Addresses with balances found at the top levels of the tree
+    /// - Leaf boundaries: Subtrees that require further branch queries to explore
+    ///
+    /// This is a low-level API used for privacy-preserving address synchronization.
+    /// Most applications should use the higher-level sync methods instead.
+    ///
+    /// - Returns: PlatformTrunkState containing elements and leaf boundaries
+    /// - Throws: SDKError if the query fails
+    public func getTrunkState() throws -> PlatformTrunkState {
+        guard let sdk = sdk, let handle = sdk.handle else {
+            throw SDKError.invalidState("SDK not initialized")
+        }
+        
+        let result = dash_sdk_address_fetch_trunk_state(handle)
+        
+        // Check for errors
+        if let error = result.error {
+            let sdkError = SDKError.fromDashSDKError(error.pointee)
+            dash_sdk_error_free(error)
+            throw sdkError
+        }
+        
+        guard let dataPtr = result.data else {
+            throw SDKError.invalidState("No trunk state data returned")
+        }
+        
+        // Parse DashSDKTrunkState
+        let statePtr = dataPtr.assumingMemoryBound(to: DashSDKTrunkState.self)
+        let ffiState = statePtr.pointee
+        
+        // Convert elements
+        var elements: [TrunkStateElement] = []
+        if ffiState.elements_count > 0 && ffiState.elements != nil {
+            for i in 0..<ffiState.elements_count {
+                let ffiElement = ffiState.elements![Int(i)]
+                
+                let keyData: Data
+                if ffiElement.key != nil && ffiElement.key_len > 0 {
+                    keyData = Data(bytes: ffiElement.key!, count: Int(ffiElement.key_len))
+                } else {
+                    continue
+                }
+                
+                elements.append(TrunkStateElement(
+                    key: keyData,
+                    nonce: ffiElement.nonce,
+                    balance: ffiElement.balance
+                ))
+            }
+        }
+        
+        // Convert leaf boundaries
+        var leafBoundaries: [LeafBoundary] = []
+        if ffiState.leaf_boundaries_count > 0 && ffiState.leaf_boundaries != nil {
+            for i in 0..<ffiState.leaf_boundaries_count {
+                let ffiBoundary = ffiState.leaf_boundaries![Int(i)]
+                
+                let keyData: Data
+                if ffiBoundary.key != nil && ffiBoundary.key_len > 0 {
+                    keyData = Data(bytes: ffiBoundary.key!, count: Int(ffiBoundary.key_len))
+                } else {
+                    continue
+                }
+                
+                // Convert fixed-size array to Data
+                var hashArray = ffiBoundary.hash
+                let hashData = Data(bytes: &hashArray, count: 32)
+                
+                leafBoundaries.append(LeafBoundary(
+                    key: keyData,
+                    hash: hashData,
+                    estimatedCount: ffiBoundary.estimated_count
+                ))
+            }
+        }
+        
+        let checkpointHeight = ffiState.checkpoint_height
+        
+        // Free the FFI struct
+        dash_sdk_trunk_state_free(statePtr)
+        
+        return PlatformTrunkState(
+            elements: elements,
+            leafBoundaries: leafBoundaries,
+            checkpointHeight: checkpointHeight
+        )
+    }
+    
     // MARK: - Convenience Methods
 
     /// Get the balance for a single address

--- a/packages/swift-sdk/Sources/SwiftDashSDK/Address/Addresses.swift
+++ b/packages/swift-sdk/Sources/SwiftDashSDK/Address/Addresses.swift
@@ -353,6 +353,119 @@ public class Addresses: @unchecked Sendable {
         )
     }
     
+    // MARK: - Branch State Query
+    
+    /// Fetch the branch state of a subtree in the address tree.
+    ///
+    /// This is used after a trunk state query to explore subtrees indicated by leaf boundaries.
+    /// The result contains elements (addresses with balances) and deeper leaf boundaries.
+    ///
+    /// - Parameters:
+    ///   - key: Leaf boundary key bytes from trunk state
+    ///   - depth: Query depth (how deep to explore)
+    ///   - expectedHash: Expected hash of the subtree root (32 bytes, for proof verification)
+    ///   - checkpointHeight: Block height from trunk state response for consistency
+    /// - Returns: PlatformBranchState containing elements and leaf boundaries
+    /// - Throws: SDKError if the query fails
+    public func getBranchState(
+        key: Data,
+        depth: UInt32,
+        expectedHash: Data,
+        checkpointHeight: UInt64
+    ) throws -> PlatformBranchState {
+        guard let sdk = sdk, let handle = sdk.handle else {
+            throw SDKError.invalidState("SDK not initialized")
+        }
+        
+        guard expectedHash.count == 32 else {
+            throw SDKError.invalidParameter("Expected hash must be exactly 32 bytes, got \(expectedHash.count)")
+        }
+        
+        let result = key.withUnsafeBytes { (keyBuffer: UnsafeRawBufferPointer) -> DashSDKResult in
+            expectedHash.withUnsafeBytes { (hashBuffer: UnsafeRawBufferPointer) -> DashSDKResult in
+                let keyPtr = keyBuffer.baseAddress?.assumingMemoryBound(to: UInt8.self)
+                let hashPtr = hashBuffer.baseAddress?.assumingMemoryBound(to: UInt8.self)
+                return dash_sdk_address_fetch_branch_state(
+                    handle,
+                    keyPtr,
+                    UInt(key.count),
+                    depth,
+                    hashPtr,
+                    checkpointHeight
+                )
+            }
+        }
+        
+        // Check for errors
+        if let error = result.error {
+            let sdkError = SDKError.fromDashSDKError(error.pointee)
+            dash_sdk_error_free(error)
+            throw sdkError
+        }
+        
+        guard let dataPtr = result.data else {
+            throw SDKError.invalidState("No branch state data returned")
+        }
+        
+        // Parse DashSDKBranchState
+        let statePtr = dataPtr.assumingMemoryBound(to: DashSDKBranchState.self)
+        let ffiState = statePtr.pointee
+        
+        // Convert elements (same structure as trunk state)
+        var elements: [TrunkStateElement] = []
+        if ffiState.elements_count > 0 && ffiState.elements != nil {
+            for i in 0..<ffiState.elements_count {
+                let ffiElement = ffiState.elements![Int(i)]
+                
+                let keyData: Data
+                if ffiElement.key != nil && ffiElement.key_len > 0 {
+                    keyData = Data(bytes: ffiElement.key!, count: Int(ffiElement.key_len))
+                } else {
+                    continue
+                }
+                
+                elements.append(TrunkStateElement(
+                    key: keyData,
+                    nonce: ffiElement.nonce,
+                    balance: ffiElement.balance
+                ))
+            }
+        }
+        
+        // Convert leaf boundaries
+        var leafBoundaries: [LeafBoundary] = []
+        if ffiState.leaf_boundaries_count > 0 && ffiState.leaf_boundaries != nil {
+            for i in 0..<ffiState.leaf_boundaries_count {
+                let ffiBoundary = ffiState.leaf_boundaries![Int(i)]
+                
+                let boundaryKeyData: Data
+                if ffiBoundary.key != nil && ffiBoundary.key_len > 0 {
+                    boundaryKeyData = Data(bytes: ffiBoundary.key!, count: Int(ffiBoundary.key_len))
+                } else {
+                    continue
+                }
+                
+                // Convert fixed-size array to Data
+                var hashArray = ffiBoundary.hash
+                let hashData = Data(bytes: &hashArray, count: 32)
+                
+                leafBoundaries.append(LeafBoundary(
+                    key: boundaryKeyData,
+                    hash: hashData,
+                    estimatedCount: ffiBoundary.estimated_count
+                ))
+            }
+        }
+        
+        // Free the FFI struct
+        dash_sdk_branch_state_free(statePtr)
+        
+        return PlatformBranchState(
+            elements: elements,
+            leafBoundaries: leafBoundaries
+        )
+    }
+    
     // MARK: - Convenience Methods
 
     /// Get the balance for a single address

--- a/packages/swift-sdk/Sources/SwiftDashSDK/Address/Addresses.swift
+++ b/packages/swift-sdk/Sources/SwiftDashSDK/Address/Addresses.swift
@@ -546,6 +546,96 @@ public class Addresses: @unchecked Sendable {
         return RecentBalanceChanges(blocks: blocks)
     }
     
+    // MARK: - Compacted Balance Changes Query
+    
+    /// Fetch recent compacted address balance changes starting from a specific block height.
+    ///
+    /// This returns compacted (merged) address balance changes since the specified start height.
+    /// Compacted changes merge multiple blocks into ranges, which is more efficient for syncing.
+    /// The BlockAwareCreditOperation preserves per-block granularity for partial sync.
+    ///
+    /// - Parameter startBlockHeight: Block height to start fetching changes from
+    /// - Returns: CompactedBalanceChanges containing range-by-range compacted changes
+    /// - Throws: SDKError if the query fails
+    public func getCompactedBalanceChanges(startBlockHeight: UInt64) throws -> CompactedBalanceChanges {
+        guard let sdk = sdk, let handle = sdk.handle else {
+            throw SDKError.invalidState("SDK not initialized")
+        }
+        
+        let result = dash_sdk_address_fetch_compacted_balance_changes(handle, startBlockHeight)
+        
+        // Check for errors
+        if let error = result.error {
+            let sdkError = SDKError.fromDashSDKError(error.pointee)
+            dash_sdk_error_free(error)
+            throw sdkError
+        }
+        
+        guard let dataPtr = result.data else {
+            // No changes found - return empty result
+            return CompactedBalanceChanges(ranges: [])
+        }
+        
+        // Parse DashSDKCompactedBalanceChanges
+        let changesPtr = dataPtr.assumingMemoryBound(to: DashSDKCompactedBalanceChanges.self)
+        let ffiChanges = changesPtr.pointee
+        
+        // Convert ranges
+        var ranges: [CompactedBlockRange] = []
+        if ffiChanges.ranges_count > 0 && ffiChanges.ranges != nil {
+            for i in 0..<ffiChanges.ranges_count {
+                let ffiRange = ffiChanges.ranges![Int(i)]
+                
+                // Convert address changes within this range
+                var addressChanges: [CompactedAddressChange] = []
+                if ffiRange.changes_count > 0 && ffiRange.changes != nil {
+                    for j in 0..<ffiRange.changes_count {
+                        let ffiChange = ffiRange.changes![Int(j)]
+                        
+                        let addressData: Data
+                        if ffiChange.address != nil && ffiChange.address_len > 0 {
+                            addressData = Data(bytes: ffiChange.address!, count: Int(ffiChange.address_len))
+                        } else {
+                            continue
+                        }
+                        
+                        // Map operation type: 0 = BlockAwareSetCredits, 1 = BlockAwareAddToCreditsOperations
+                        let operation: BlockAwareCreditOperation
+                        if ffiChange.operation_type.rawValue == 0 { // BlockAwareSetCredits
+                            operation = .setCredits(credits: ffiChange.set_credits_value)
+                        } else { // BlockAwareAddToCreditsOperations
+                            // Parse add entries
+                            var entries: [(blockHeight: UInt64, credits: UInt64)] = []
+                            if ffiChange.add_entries_count > 0 && ffiChange.add_entries != nil {
+                                for k in 0..<ffiChange.add_entries_count {
+                                    let entry = ffiChange.add_entries![Int(k)]
+                                    entries.append((blockHeight: entry.block_height, credits: entry.credits))
+                                }
+                            }
+                            operation = .addToCreditsOperations(entries: entries)
+                        }
+                        
+                        addressChanges.append(CompactedAddressChange(
+                            addressBytes: addressData,
+                            operation: operation
+                        ))
+                    }
+                }
+                
+                ranges.append(CompactedBlockRange(
+                    startBlockHeight: ffiRange.start_block_height,
+                    endBlockHeight: ffiRange.end_block_height,
+                    changes: addressChanges
+                ))
+            }
+        }
+        
+        // Free the FFI struct
+        dash_sdk_compacted_balance_changes_free(changesPtr)
+        
+        return CompactedBalanceChanges(ranges: ranges)
+    }
+    
     // MARK: - Convenience Methods
 
     /// Get the balance for a single address

--- a/packages/swift-sdk/Sources/SwiftDashSDK/Address/Addresses.swift
+++ b/packages/swift-sdk/Sources/SwiftDashSDK/Address/Addresses.swift
@@ -1,0 +1,301 @@
+import Foundation
+import DashSDKFFI
+
+/// Service for fetching Platform address information
+public class Addresses: @unchecked Sendable {
+    private weak var sdk: SDK?
+
+    init(sdk: SDK) {
+        self.sdk = sdk
+    }
+
+    // MARK: - Single Address Query
+
+    /// Fetch information about a single Platform address
+    ///
+    /// - Parameter addressBytes: Address bytes (21 bytes: type byte + 20-byte hash)
+    /// - Returns: PlatformAddressInfo containing nonce and balance, or nil if address not found
+    /// - Throws: SDKError if the query fails
+    public func getInfo(addressBytes: Data) throws -> PlatformAddressInfo? {
+        guard let sdk = sdk, let handle = sdk.handle else {
+            throw SDKError.invalidState("SDK not initialized")
+        }
+
+        guard addressBytes.count == 21 else {
+            throw SDKError.invalidParameter("Address bytes must be exactly 21 bytes (1 type + 20 hash), got \(addressBytes.count)")
+        }
+
+        let result = addressBytes.withUnsafeBytes { (buffer: UnsafeRawBufferPointer) -> DashSDKResult in
+            let ptr = buffer.baseAddress?.assumingMemoryBound(to: UInt8.self)
+            return dash_sdk_address_fetch_info(handle, ptr, UInt(addressBytes.count))
+        }
+
+        // Check for errors
+        if let error = result.error {
+            let sdkError = SDKError.fromDashSDKError(error.pointee)
+            dash_sdk_error_free(error)
+            throw sdkError
+        }
+
+        guard let dataPtr = result.data else {
+            return nil
+        }
+
+        // Parse DashSDKAddressInfo
+        let infoPtr = dataPtr.assumingMemoryBound(to: DashSDKAddressInfo.self)
+        let ffiInfo = infoPtr.pointee
+        let addressInfo = PlatformAddressInfo(from: ffiInfo)
+
+        // Free the FFI struct
+        dash_sdk_address_info_free(infoPtr)
+
+        // Return nil if address not found (indicated by max values)
+        if !addressInfo.isFound {
+            return nil
+        }
+
+        return addressInfo
+    }
+
+    /// Fetch information about a single Platform address using hex string
+    ///
+    /// - Parameter addressHex: Hex-encoded address (42 characters for 21 bytes)
+    /// - Returns: PlatformAddressInfo containing nonce and balance, or nil if address not found
+    /// - Throws: SDKError if the query fails or hex is invalid
+    public func getInfo(addressHex: String) throws -> PlatformAddressInfo? {
+        guard let addressBytes = Data(hexString: addressHex) else {
+            throw SDKError.invalidParameter("Invalid hex string for address")
+        }
+        return try getInfo(addressBytes: addressBytes)
+    }
+
+    /// Fetch information about a single Platform address using bech32m string
+    ///
+    /// - Parameter bech32mAddress: Bech32m-encoded address (e.g., "tdashevo1qqyfsqyzcn5hzu7echru54njypdq0v4d7gv8pkdf")
+    /// - Returns: PlatformAddressInfo containing nonce and balance, or nil if address not found
+    /// - Throws: SDKError if the query fails or bech32m is invalid
+    public func getInfo(bech32mAddress: String) throws -> PlatformAddressInfo? {
+        guard let decoded = Bech32m.decode(bech32mAddress) else {
+            throw SDKError.invalidParameter("Invalid bech32m address")
+        }
+        guard decoded.data.count == 21 else {
+            throw SDKError.invalidParameter("Invalid Platform address: expected 21 bytes, got \(decoded.data.count)")
+        }
+        return try getInfo(addressBytes: decoded.data)
+    }
+
+    /// Fetch information about a single Platform address (auto-detects format)
+    ///
+    /// - Parameter address: Address string - can be hex (42 chars) or bech32m (tdashevo1.../dashevo1...)
+    /// - Returns: PlatformAddressInfo containing nonce and balance, or nil if address not found
+    /// - Throws: SDKError if the query fails or address format is invalid
+    public func getInfo(address: String) throws -> PlatformAddressInfo? {
+        let trimmed = address.trimmingCharacters(in: .whitespacesAndNewlines)
+
+        // Check if it's a bech32m address (starts with dashevo1 or tdashevo1)
+        if trimmed.lowercased().hasPrefix("dashevo1") || trimmed.lowercased().hasPrefix("tdashevo1") {
+            return try getInfo(bech32mAddress: trimmed)
+        }
+
+        // Otherwise try as hex
+        return try getInfo(addressHex: trimmed)
+    }
+
+    // MARK: - Multiple Addresses Query
+
+    /// Fetch information about multiple Platform addresses
+    ///
+    /// - Parameter addressesBytesList: Array of address bytes (each 21 bytes)
+    /// - Returns: PlatformAddressInfosResult containing info for all queried addresses
+    /// - Throws: SDKError if the query fails
+    public func getInfos(addressesBytesList: [Data]) throws -> PlatformAddressInfosResult {
+        guard let sdk = sdk, let handle = sdk.handle else {
+            throw SDKError.invalidState("SDK not initialized")
+        }
+
+        guard !addressesBytesList.isEmpty else {
+            return PlatformAddressInfosResult(infos: [:])
+        }
+
+        // Validate all addresses
+        for (index, bytes) in addressesBytesList.enumerated() {
+            guard bytes.count == 21 else {
+                throw SDKError.invalidParameter("Address at index \(index) must be exactly 21 bytes, got \(bytes.count)")
+            }
+        }
+
+        // Prepare arrays for FFI call
+        var addressPointers: [UnsafePointer<UInt8>?] = []
+        var addressLengths: [UInt] = []
+        var addressData: [Data] = [] // Keep data alive during the call
+
+        for bytes in addressesBytesList {
+            addressData.append(bytes)
+        }
+
+        // Create pointers
+        for data in addressData {
+            let pointer = data.withUnsafeBytes { (buffer: UnsafeRawBufferPointer) -> UnsafePointer<UInt8>? in
+                return buffer.baseAddress?.assumingMemoryBound(to: UInt8.self)
+            }
+            addressPointers.append(pointer)
+            addressLengths.append(UInt(data.count))
+        }
+
+        // Call FFI
+        let result = addressPointers.withUnsafeBufferPointer { pointersBuffer -> DashSDKResult in
+            addressLengths.withUnsafeBufferPointer { lengthsBuffer -> DashSDKResult in
+                return dash_sdk_addresses_fetch_infos(
+                    handle,
+                    pointersBuffer.baseAddress,
+                    lengthsBuffer.baseAddress,
+                    UInt(addressesBytesList.count)
+                )
+            }
+        }
+
+        // Check for errors
+        if let error = result.error {
+            let sdkError = SDKError.fromDashSDKError(error.pointee)
+            dash_sdk_error_free(error)
+            throw sdkError
+        }
+
+        guard let dataPtr = result.data else {
+            return PlatformAddressInfosResult(infos: [:])
+        }
+
+        // Parse DashSDKAddressInfoMap
+        let mapPtr = dataPtr.assumingMemoryBound(to: DashSDKAddressInfoMap.self)
+        let map = mapPtr.pointee
+
+        var infos: [Data: PlatformAddressInfo] = [:]
+
+        if map.count > 0 && map.entries != nil {
+            for i in 0..<map.count {
+                let entry = map.entries![Int(i)]
+
+                let addressBytes: Data
+                if entry.address != nil && entry.address_len > 0 {
+                  addressBytes = Data(bytes: entry.address!, count: Int(entry.address_len))
+                } else {
+                    continue
+                }
+
+                let info = PlatformAddressInfo(
+                    addressBytes: addressBytes,
+                    nonce: entry.nonce,
+                    balance: entry.balance
+                )
+
+                infos[addressBytes] = info
+            }
+        }
+
+        // Free the FFI map
+        dash_sdk_address_info_map_free(mapPtr)
+
+        return PlatformAddressInfosResult(infos: infos)
+    }
+
+    /// Fetch information about multiple Platform addresses using hex strings
+    ///
+    /// - Parameter addressHexList: Array of hex-encoded addresses
+    /// - Returns: PlatformAddressInfosResult containing info for all queried addresses
+    /// - Throws: SDKError if the query fails or any hex is invalid
+    public func getInfos(addressHexList: [String]) throws -> PlatformAddressInfosResult {
+        let addressesBytesList = try addressHexList.enumerated().map { (index, hex) -> Data in
+            guard let bytes = Data(hexString: hex) else {
+                throw SDKError.invalidParameter("Invalid hex string at index \(index)")
+            }
+            return bytes
+        }
+        return try getInfos(addressesBytesList: addressesBytesList)
+    }
+
+    /// Fetch information about multiple Platform addresses using bech32m strings
+    ///
+    /// - Parameter bech32mAddresses: Array of bech32m-encoded addresses
+    /// - Returns: PlatformAddressInfosResult containing info for all queried addresses
+    /// - Throws: SDKError if the query fails or any bech32m is invalid
+    public func getInfos(bech32mAddresses: [String]) throws -> PlatformAddressInfosResult {
+        let addressesBytesList = try bech32mAddresses.enumerated().map { (index, bech32m) -> Data in
+            guard let decoded = Bech32m.decode(bech32m) else {
+                throw SDKError.invalidParameter("Invalid bech32m address at index \(index)")
+            }
+            guard decoded.data.count == 21 else {
+                throw SDKError.invalidParameter("Invalid Platform address at index \(index): expected 21 bytes")
+            }
+            return decoded.data
+        }
+        return try getInfos(addressesBytesList: addressesBytesList)
+    }
+
+    /// Fetch information about multiple Platform addresses (auto-detects format)
+    ///
+    /// - Parameter addresses: Array of address strings - can be hex or bech32m (mixed formats allowed)
+    /// - Returns: PlatformAddressInfosResult containing info for all queried addresses
+    /// - Throws: SDKError if the query fails or any address format is invalid
+    public func getInfos(addresses: [String]) throws -> PlatformAddressInfosResult {
+        let addressesBytesList = try addresses.enumerated().map { (index, address) -> Data in
+            let trimmed = address.trimmingCharacters(in: .whitespacesAndNewlines)
+
+            // Check if it's a bech32m address
+            if trimmed.lowercased().hasPrefix("dashevo1") || trimmed.lowercased().hasPrefix("tdashevo1") {
+                guard let decoded = Bech32m.decode(trimmed) else {
+                    throw SDKError.invalidParameter("Invalid bech32m address at index \(index)")
+                }
+                guard decoded.data.count == 21 else {
+                    throw SDKError.invalidParameter("Invalid Platform address at index \(index): expected 21 bytes")
+                }
+                return decoded.data
+            }
+
+            // Otherwise try as hex
+            guard let bytes = Data(hexString: trimmed) else {
+                throw SDKError.invalidParameter("Invalid address format at index \(index)")
+            }
+            return bytes
+        }
+        return try getInfos(addressesBytesList: addressesBytesList)
+    }
+
+    // MARK: - Convenience Methods
+
+    /// Get the balance for a single address
+    ///
+    /// - Parameter addressBytes: Address bytes (21 bytes)
+    /// - Returns: Balance in credits, or nil if address not found
+    /// - Throws: SDKError if the query fails
+    public func getBalance(addressBytes: Data) throws -> UInt64? {
+        return try getInfo(addressBytes: addressBytes)?.balance
+    }
+
+    /// Get the nonce for a single address
+    ///
+    /// - Parameter addressBytes: Address bytes (21 bytes)
+    /// - Returns: Nonce value, or nil if address not found
+    /// - Throws: SDKError if the query fails
+    public func getNonce(addressBytes: Data) throws -> UInt32? {
+        return try getInfo(addressBytes: addressBytes)?.nonce
+    }
+
+    /// Check if an address exists on Platform
+    ///
+    /// - Parameter addressBytes: Address bytes (21 bytes)
+    /// - Returns: true if the address has been used on Platform
+    /// - Throws: SDKError if the query fails
+    public func exists(addressBytes: Data) throws -> Bool {
+        return try getInfo(addressBytes: addressBytes) != nil
+    }
+
+    /// Get total balance across multiple addresses
+    ///
+    /// - Parameter addressesBytesList: Array of address bytes
+    /// - Returns: Total balance in credits across all found addresses
+    /// - Throws: SDKError if the query fails
+    public func getTotalBalance(addressesBytesList: [Data]) throws -> UInt64 {
+        let result = try getInfos(addressesBytesList: addressesBytesList)
+        return result.totalBalance
+    }
+}

--- a/packages/swift-sdk/Sources/SwiftDashSDK/Address/PlatformAddressInfo.swift
+++ b/packages/swift-sdk/Sources/SwiftDashSDK/Address/PlatformAddressInfo.swift
@@ -227,6 +227,103 @@ public struct RecentBalanceChanges: Sendable {
     }
 }
 
+// MARK: - Compacted Balance Changes Types
+
+/// Block-aware credit operation - can be a final set value or individual adds by block height
+public enum BlockAwareCreditOperation: Sendable, Equatable {
+    /// Credits were set to a final value (overwrites previous)
+    case setCredits(credits: UInt64)
+    /// Individual add-to-credits operations with their block heights (preserved for partial sync)
+    case addToCreditsOperations(entries: [(blockHeight: UInt64, credits: UInt64)])
+    
+    /// Get the total credits (final value for setCredits, sum of adds for addToCreditsOperations)
+    public var totalCredits: UInt64 {
+        switch self {
+        case .setCredits(let credits):
+            return credits
+        case .addToCreditsOperations(let entries):
+            return entries.reduce(0) { $0 + $1.credits }
+        }
+    }
+    
+    public static func == (lhs: BlockAwareCreditOperation, rhs: BlockAwareCreditOperation) -> Bool {
+        switch (lhs, rhs) {
+        case (.setCredits(let c1), .setCredits(let c2)):
+            return c1 == c2
+        case (.addToCreditsOperations(let e1), .addToCreditsOperations(let e2)):
+            guard e1.count == e2.count else { return false }
+            for (entry1, entry2) in zip(e1, e2) {
+                if entry1.blockHeight != entry2.blockHeight || entry1.credits != entry2.credits {
+                    return false
+                }
+            }
+            return true
+        default:
+            return false
+        }
+    }
+}
+
+/// A compacted balance change for an address
+public struct CompactedAddressChange: Sendable, Equatable {
+    /// Address bytes
+    public let addressBytes: Data
+    
+    /// Block-aware operation (SetCredits or AddToCreditsOperations)
+    public let operation: BlockAwareCreditOperation
+    
+    /// Convert address bytes to hex string
+    public var addressHex: String {
+        return addressBytes.map { String(format: "%02x", $0) }.joined()
+    }
+    
+    /// Convert address bytes to bech32m string
+    public func toBech32m(network: DashSDKNetwork) -> String? {
+        guard addressBytes.count == 21 else { return nil }
+        let hrp: String
+        if network.rawValue == 0 {
+            hrp = "dashevo"
+        } else {
+            hrp = "tdashevo"
+        }
+        return Bech32m.encode(hrp: hrp, data: addressBytes)
+    }
+}
+
+/// Compacted balance changes for a range of blocks
+public struct CompactedBlockRange: Sendable, Equatable {
+    /// Start block height of the range
+    public let startBlockHeight: UInt64
+    
+    /// End block height of the range
+    public let endBlockHeight: UInt64
+    
+    /// Balance changes in this range
+    public let changes: [CompactedAddressChange]
+    
+    /// Height range
+    public var heightRange: ClosedRange<UInt64> {
+        return startBlockHeight...endBlockHeight
+    }
+}
+
+/// Recent compacted balance changes across multiple ranges
+public struct CompactedBalanceChanges: Sendable {
+    /// Compacted block ranges
+    public let ranges: [CompactedBlockRange]
+    
+    /// Total number of address changes across all ranges
+    public var totalChangesCount: Int {
+        return ranges.reduce(0) { $0 + $1.changes.count }
+    }
+    
+    /// Overall height range (if any ranges present)
+    public var heightRange: ClosedRange<UInt64>? {
+        guard let first = ranges.first, let last = ranges.last else { return nil }
+        return first.startBlockHeight...last.endBlockHeight
+    }
+}
+
 // MARK: - Bech32m Encoding/Decoding Helper
 
 /// Bech32m encoding/decoding helper for Platform addresses

--- a/packages/swift-sdk/Sources/SwiftDashSDK/Address/PlatformAddressInfo.swift
+++ b/packages/swift-sdk/Sources/SwiftDashSDK/Address/PlatformAddressInfo.swift
@@ -86,6 +86,65 @@ public struct PlatformAddressInfosResult: Sendable {
     }
 }
 
+// MARK: - Trunk State Types
+
+/// Element in trunk state - an address with balance/nonce found at trunk level
+public struct TrunkStateElement: Sendable, Equatable {
+    /// Address key bytes
+    public let key: Data
+    
+    /// Nonce for the address
+    public let nonce: UInt32
+    
+    /// Balance in credits
+    public let balance: UInt64
+    
+    /// Convert key to hex string
+    public var keyHex: String {
+        return key.map { String(format: "%02x", $0) }.joined()
+    }
+}
+
+/// Leaf boundary in trunk state - subtree that needs further branch queries
+public struct LeafBoundary: Sendable, Equatable {
+    /// Leaf key bytes
+    public let key: Data
+    
+    /// Expected hash (32 bytes)
+    public let hash: Data
+    
+    /// Estimated element count in this subtree (0 if unknown)
+    public let estimatedCount: UInt64
+    
+    /// Convert key to hex string
+    public var keyHex: String {
+        return key.map { String(format: "%02x", $0) }.joined()
+    }
+    
+    /// Convert hash to hex string
+    public var hashHex: String {
+        return hash.map { String(format: "%02x", $0) }.joined()
+    }
+}
+
+/// Trunk state for address synchronization
+/// Contains addresses found at top levels and leaf boundaries for subtrees needing further queries
+public struct PlatformTrunkState: Sendable {
+    /// Elements (addresses with balances) found at trunk level
+    public let elements: [TrunkStateElement]
+    
+    /// Leaf boundaries (subtrees needing branch queries)
+    public let leafBoundaries: [LeafBoundary]
+    
+    /// Checkpoint height for consistency
+    public let checkpointHeight: UInt64
+    
+    /// Total balance across all elements
+    public var totalBalance: UInt64 {
+        return elements.reduce(0) { $0 + $1.balance }
+    }
+}
+
 // MARK: - Bech32m Encoding/Decoding Helper
 
 /// Bech32m encoding/decoding helper for Platform addresses

--- a/packages/swift-sdk/Sources/SwiftDashSDK/Address/PlatformAddressInfo.swift
+++ b/packages/swift-sdk/Sources/SwiftDashSDK/Address/PlatformAddressInfo.swift
@@ -145,6 +145,21 @@ public struct PlatformTrunkState: Sendable {
     }
 }
 
+/// Branch state for address synchronization
+/// Contains addresses found in a specific branch and deeper leaf boundaries
+public struct PlatformBranchState: Sendable {
+    /// Elements (addresses with balances) found in this branch
+    public let elements: [TrunkStateElement]
+    
+    /// Leaf boundaries (deeper subtrees needing further queries)
+    public let leafBoundaries: [LeafBoundary]
+    
+    /// Total balance across all elements in this branch
+    public var totalBalance: UInt64 {
+        return elements.reduce(0) { $0 + $1.balance }
+    }
+}
+
 // MARK: - Bech32m Encoding/Decoding Helper
 
 /// Bech32m encoding/decoding helper for Platform addresses

--- a/packages/swift-sdk/Sources/SwiftDashSDK/Address/PlatformAddressInfo.swift
+++ b/packages/swift-sdk/Sources/SwiftDashSDK/Address/PlatformAddressInfo.swift
@@ -1,0 +1,283 @@
+import Foundation
+import DashSDKFFI
+
+/// Information about a Platform address including its nonce and balance
+/// Note: This is distinct from KeyWallet's AddressInfo which contains local wallet address info
+public struct PlatformAddressInfo: Sendable, Equatable, Codable {
+    /// Address bytes (21 bytes: 1 byte type + 20 bytes hash)
+    public let addressBytes: Data
+    
+    /// Nonce associated with the address
+    public let nonce: UInt32
+    
+    /// Balance in credits
+    public let balance: UInt64
+    
+    /// Whether the address was found on Platform
+    public var isFound: Bool {
+        return nonce != UInt32.max && balance != UInt64.max
+    }
+    
+    /// Initialize from address bytes, nonce, and balance
+    public init(addressBytes: Data, nonce: UInt32, balance: UInt64) {
+        self.addressBytes = addressBytes
+        self.nonce = nonce
+        self.balance = balance
+    }
+    
+    /// Create a PlatformAddressInfo from FFI DashSDKAddressInfo
+    internal init(from ffi: DashSDKAddressInfo) {
+        if ffi.address != nil && ffi.address_len > 0 {
+          self.addressBytes = Data(bytes: ffi.address!, count: Int(ffi.address_len))
+        } else {
+            self.addressBytes = Data()
+        }
+        self.nonce = ffi.nonce
+        self.balance = ffi.balance
+    }
+    
+    /// Convert address bytes to hex string
+    public var addressHex: String {
+        return addressBytes.map { String(format: "%02x", $0) }.joined()
+    }
+    
+    /// Convert address bytes to bech32m string (requires network parameter)
+    /// Format: [type_byte][20_byte_hash]
+    public func toBech32m(network: DashSDKNetwork) -> String? {
+        guard addressBytes.count == 21 else { return nil }
+        
+        // Get HRP based on network
+        // DashSDKNetwork raw values: 0 = mainnet, 1 = testnet, 2 = regtest, 3 = devnet, 4 = local
+        let hrp: String
+        if network.rawValue == 0 {
+            hrp = "dashevo"  // mainnet
+        } else {
+            hrp = "tdashevo"  // testnet, devnet, regtest, local
+        }
+        
+        // Use bech32m encoding
+        return Bech32m.encode(hrp: hrp, data: addressBytes)
+    }
+}
+
+/// Result for fetching multiple Platform address infos
+public struct PlatformAddressInfosResult: Sendable {
+    /// Dictionary mapping address bytes to their info
+    public let infos: [Data: PlatformAddressInfo]
+    
+    /// Get info for a specific address
+    public func info(for addressBytes: Data) -> PlatformAddressInfo? {
+        return infos[addressBytes]
+    }
+    
+    /// Get all found addresses (with valid balance/nonce)
+    public var foundAddresses: [PlatformAddressInfo] {
+        return infos.values.filter { $0.isFound }
+    }
+    
+    /// Get all not-found addresses
+    public var notFoundAddresses: [PlatformAddressInfo] {
+        return infos.values.filter { !$0.isFound }
+    }
+    
+    /// Total balance across all found addresses
+    public var totalBalance: UInt64 {
+        return foundAddresses.reduce(0) { $0 + $1.balance }
+    }
+}
+
+// MARK: - Bech32m Encoding/Decoding Helper
+
+/// Bech32m encoding/decoding helper for Platform addresses
+public enum Bech32m {
+    private static let charset = "qpzry9x8gf2tvdw0s3jn54khce6mua7l"
+    private static let charsetMap: [Character: UInt8] = {
+        var map: [Character: UInt8] = [:]
+        for (index, char) in charset.enumerated() {
+            map[char] = UInt8(index)
+        }
+        return map
+    }()
+    
+    /// Decode result containing HRP and data
+    public struct DecodeResult {
+        public let hrp: String
+        public let data: Data
+    }
+    
+    /// Decode a bech32m string to HRP and data bytes
+    /// - Parameter bech32m: The bech32m encoded string (e.g., "tdashevo1qqyfsqyzcn5hzu7echru54njypdq0v4d7gv8pkdf")
+    /// - Returns: DecodeResult with hrp and data, or nil if invalid
+    public static func decode(_ bech32m: String) -> DecodeResult? {
+        let lowercased = bech32m.lowercased()
+        
+        // Find the separator '1'
+        guard let separatorIndex = lowercased.lastIndex(of: "1") else {
+            return nil
+        }
+        
+        let hrp = String(lowercased[..<separatorIndex])
+        let dataPartStart = lowercased.index(after: separatorIndex)
+        let dataPart = String(lowercased[dataPartStart...])
+        
+        // HRP must be 1-83 characters, data part must be at least 6 characters (checksum)
+        guard hrp.count >= 1 && hrp.count <= 83 && dataPart.count >= 6 else {
+            return nil
+        }
+        
+        // Decode data part characters to 5-bit values
+        var values: [UInt8] = []
+        for char in dataPart {
+            guard let value = charsetMap[char] else {
+                return nil // Invalid character
+            }
+            values.append(value)
+        }
+        
+        // Verify checksum
+        guard verifyChecksum(hrp: hrp, values: values) else {
+            return nil
+        }
+        
+        // Remove checksum (last 6 values)
+        let dataValues = Array(values.dropLast(6))
+        
+        // Convert from 5-bit to 8-bit
+        guard let data = convertFrom5Bit(dataValues) else {
+            return nil
+        }
+        
+        return DecodeResult(hrp: hrp, data: Data(data))
+    }
+    
+    /// Check if a string is a valid bech32m Platform address
+    public static func isValidPlatformAddress(_ address: String) -> Bool {
+        guard let result = decode(address) else {
+            return false
+        }
+        // Valid Platform addresses have dashevo or tdashevo HRP and 21 bytes of data
+        let validHrp = result.hrp == "dashevo" || result.hrp == "tdashevo"
+        let validLength = result.data.count == 21
+        return validHrp && validLength
+    }
+    
+    /// Debug: Decode a bech32m address and return details for troubleshooting
+    public static func debugDecode(_ address: String) -> (hrp: String?, byteCount: Int?, hex: String?, error: String?) {
+        guard let result = decode(address) else {
+            return (nil, nil, nil, "Failed to decode bech32m address")
+        }
+        let hex = result.data.map { String(format: "%02x", $0) }.joined()
+        return (result.hrp, result.data.count, hex, nil)
+    }
+    
+    /// Encode data to bech32m string
+    public static func encode(hrp: String, data: Data) -> String? {
+        let values = convertTo5Bit(Array(data))
+        guard !values.isEmpty else { return nil }
+        
+        let checksum = createChecksum(hrp: hrp, values: values)
+        let combined = values + checksum
+        
+        var result = hrp + "1"
+        for value in combined {
+            let index = charset.index(charset.startIndex, offsetBy: Int(value))
+            result.append(charset[index])
+        }
+        
+        return result
+    }
+    
+    private static func convertTo5Bit(_ data: [UInt8]) -> [UInt8] {
+        var result: [UInt8] = []
+        var acc: UInt32 = 0
+        var bits: UInt32 = 0
+        
+        for byte in data {
+            acc = (acc << 8) | UInt32(byte)
+            bits += 8
+            while bits >= 5 {
+                bits -= 5
+                result.append(UInt8((acc >> bits) & 0x1f))
+            }
+        }
+        
+        if bits > 0 {
+            result.append(UInt8((acc << (5 - bits)) & 0x1f))
+        }
+        
+        return result
+    }
+    
+    private static func convertFrom5Bit(_ data: [UInt8]) -> [UInt8]? {
+        var result: [UInt8] = []
+        var acc: UInt32 = 0
+        var bits: UInt32 = 0
+        
+        for value in data {
+            guard value < 32 else { return nil }
+            acc = (acc << 5) | UInt32(value)
+            bits += 5
+            while bits >= 8 {
+                bits -= 8
+                result.append(UInt8((acc >> bits) & 0xff))
+            }
+        }
+        
+        // Check for invalid padding - remaining bits must be zero and less than 5
+        if bits > 4 {
+            return nil
+        }
+        // The remaining padding bits (if any) must all be zero
+        let paddingMask = (UInt32(1) << bits) - 1
+        if (acc & paddingMask) != 0 {
+            return nil
+        }
+        
+        return result
+    }
+    
+    private static func polymod(_ values: [UInt8]) -> UInt32 {
+        let generator: [UInt32] = [0x3b6a57b2, 0x26508e6d, 0x1ea119fa, 0x3d4233dd, 0x2a1462b3]
+        var chk: UInt32 = 1
+        
+        for value in values {
+            let top = chk >> 25
+            chk = ((chk & 0x1ffffff) << 5) ^ UInt32(value)
+            for i in 0..<5 {
+                if (top >> i) & 1 != 0 {
+                    chk ^= generator[i]
+                }
+            }
+        }
+        
+        return chk
+    }
+    
+    private static func hrpExpand(_ hrp: String) -> [UInt8] {
+        var result: [UInt8] = []
+        for char in hrp {
+            result.append(UInt8(char.asciiValue! >> 5))
+        }
+        result.append(0)
+        for char in hrp {
+            result.append(UInt8(char.asciiValue! & 31))
+        }
+        return result
+    }
+    
+    private static func verifyChecksum(hrp: String, values: [UInt8]) -> Bool {
+        let expanded = hrpExpand(hrp) + values
+        return polymod(expanded) == 0x2bc830a3 // bech32m constant
+    }
+    
+    private static func createChecksum(hrp: String, values: [UInt8]) -> [UInt8] {
+        let enc = hrpExpand(hrp) + values + [0, 0, 0, 0, 0, 0]
+        let mod = polymod(enc) ^ 0x2bc830a3 // bech32m constant
+        
+        var result: [UInt8] = []
+        for i in 0..<6 {
+            result.append(UInt8((mod >> (5 * (5 - i))) & 31))
+        }
+        return result
+    }
+}

--- a/packages/swift-sdk/Sources/SwiftDashSDK/Address/PlatformAddressInfo.swift
+++ b/packages/swift-sdk/Sources/SwiftDashSDK/Address/PlatformAddressInfo.swift
@@ -160,6 +160,73 @@ public struct PlatformBranchState: Sendable {
     }
 }
 
+// MARK: - Recent Balance Changes Types
+
+/// Credit operation type
+public enum CreditOperationType: Sendable, Equatable, Codable {
+    case setCredits(credits: UInt64)
+    case addToCredits(credits: UInt64)
+    
+    public var credits: UInt64 {
+        switch self {
+        case .setCredits(let credits), .addToCredits(let credits):
+            return credits
+        }
+    }
+}
+
+/// A single balance change for an address
+public struct AddressBalanceChange: Sendable, Equatable {
+    /// Address bytes
+    public let addressBytes: Data
+    
+    /// Credit operation type and amount
+    public let operation: CreditOperationType
+    
+    /// Convert address bytes to hex string
+    public var addressHex: String {
+        return addressBytes.map { String(format: "%02x", $0) }.joined()
+    }
+    
+    /// Convert address bytes to bech32m string
+    public func toBech32m(network: DashSDKNetwork) -> String? {
+        guard addressBytes.count == 21 else { return nil }
+        let hrp: String
+        if network.rawValue == 0 {
+            hrp = "dashevo"
+        } else {
+            hrp = "tdashevo"
+        }
+        return Bech32m.encode(hrp: hrp, data: addressBytes)
+    }
+}
+
+/// Balance changes for a single block
+public struct BlockBalanceChanges: Sendable, Equatable {
+    /// Block height
+    public let blockHeight: UInt64
+    
+    /// Balance changes in this block
+    public let changes: [AddressBalanceChange]
+}
+
+/// Recent balance changes across multiple blocks
+public struct RecentBalanceChanges: Sendable {
+    /// Block-by-block balance changes
+    public let blocks: [BlockBalanceChanges]
+    
+    /// Total number of balance changes across all blocks
+    public var totalChangesCount: Int {
+        return blocks.reduce(0) { $0 + $1.changes.count }
+    }
+    
+    /// Height range (if any blocks present)
+    public var heightRange: ClosedRange<UInt64>? {
+        guard let first = blocks.first, let last = blocks.last else { return nil }
+        return first.blockHeight...last.blockHeight
+    }
+}
+
 // MARK: - Bech32m Encoding/Decoding Helper
 
 /// Bech32m encoding/decoding helper for Platform addresses

--- a/packages/swift-sdk/Sources/SwiftDashSDK/SDK.swift
+++ b/packages/swift-sdk/Sources/SwiftDashSDK/SDK.swift
@@ -65,6 +65,9 @@ public final class SDK: @unchecked Sendable {
     /// Contracts operations  
     public lazy var contracts = Contracts(sdk: self)
     
+    /// Address operations (balance, nonce queries)
+    public lazy var addresses = Addresses(sdk: self)
+    
     /// Initialize the SDK library (call once at app startup)
     public static func initialize() {
         dash_sdk_init()

--- a/packages/swift-sdk/SwiftExampleApp/SwiftExampleApp/Views/AddressQueriesView.swift
+++ b/packages/swift-sdk/SwiftExampleApp/SwiftExampleApp/Views/AddressQueriesView.swift
@@ -41,6 +41,18 @@ struct AddressQueriesView: View {
                 }
                 .padding(.vertical, 4)
             }
+            
+            NavigationLink(destination: GetBranchStateView()) {
+                VStack(alignment: .leading, spacing: 4) {
+                    Text("Get Branch State")
+                        .font(.headline)
+                    Text("Query a specific branch of the address tree")
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                        .lineLimit(2)
+                }
+                .padding(.vertical, 4)
+            }
         }
         .navigationTitle("Address Queries")
         .navigationBarTitleDisplayMode(.inline)
@@ -634,19 +646,67 @@ struct GetTrunkStateView: View {
                                 // Leaf boundaries section
                                 if !state.leafBoundaries.isEmpty {
                                     VStack(alignment: .leading, spacing: 8) {
-                                        Text("Leaf Boundaries (\(state.leafBoundaries.count))")
+                                        Text("Leaf Boundaries (\(state.leafBoundaries.count)) - Tap to copy")
                                             .font(.subheadline)
                                             .fontWeight(.semibold)
                                         
-                                        ForEach(Array(state.leafBoundaries.enumerated()), id: \.offset) { index, boundary in
-                                            VStack(alignment: .leading, spacing: 4) {
-                                                Text("Key: \(boundary.keyHex.prefix(16))...")
+                                        Button(action: {
+                                            UIPasteboard.general.string = "\(state.checkpointHeight)"
+                                        }) {
+                                            HStack {
+                                                Text("Checkpoint Height: \(state.checkpointHeight)")
                                                     .font(.caption)
-                                                    .monospaced()
-                                                Text("Hash: \(boundary.hashHex.prefix(16))...")
+                                                Image(systemName: "doc.on.doc")
                                                     .font(.caption2)
-                                                    .monospaced()
-                                                    .foregroundColor(.secondary)
+                                            }
+                                        }
+                                        .buttonStyle(.plain)
+                                        .foregroundColor(.blue)
+                                        
+                                        ForEach(Array(state.leafBoundaries.enumerated()), id: \.offset) { index, boundary in
+                                            VStack(alignment: .leading, spacing: 6) {
+                                                HStack {
+                                                    Text("Key:")
+                                                        .font(.caption)
+                                                        .frame(width: 40, alignment: .leading)
+                                                    Button(action: {
+                                                        UIPasteboard.general.string = boundary.keyHex
+                                                    }) {
+                                                        HStack(spacing: 4) {
+                                                            Text(boundary.keyHex)
+                                                                .font(.caption2)
+                                                                .monospaced()
+                                                                .lineLimit(1)
+                                                                .truncationMode(.middle)
+                                                            Image(systemName: "doc.on.doc")
+                                                                .font(.caption2)
+                                                        }
+                                                    }
+                                                    .buttonStyle(.plain)
+                                                    .foregroundColor(.blue)
+                                                }
+                                                
+                                                HStack {
+                                                    Text("Hash:")
+                                                        .font(.caption)
+                                                        .frame(width: 40, alignment: .leading)
+                                                    Button(action: {
+                                                        UIPasteboard.general.string = boundary.hashHex
+                                                    }) {
+                                                        HStack(spacing: 4) {
+                                                            Text(boundary.hashHex)
+                                                                .font(.caption2)
+                                                                .monospaced()
+                                                                .lineLimit(1)
+                                                                .truncationMode(.middle)
+                                                            Image(systemName: "doc.on.doc")
+                                                                .font(.caption2)
+                                                        }
+                                                    }
+                                                    .buttonStyle(.plain)
+                                                    .foregroundColor(.blue)
+                                                }
+                                                
                                                 if boundary.estimatedCount > 0 {
                                                     Text("Est. count: \(boundary.estimatedCount)")
                                                         .font(.caption)
@@ -654,6 +714,7 @@ struct GetTrunkStateView: View {
                                                 }
                                             }
                                             .padding(8)
+                                            .frame(maxWidth: .infinity, alignment: .leading)
                                             .background(Color.orange.opacity(0.05))
                                             .cornerRadius(6)
                                         }
@@ -686,6 +747,324 @@ struct GetTrunkStateView: View {
                 
                 await MainActor.run {
                     result = trunkState
+                    showResult = true
+                    isLoading = false
+                }
+            } catch {
+                await MainActor.run {
+                    errorMessage = error.localizedDescription
+                    showResult = true
+                    isLoading = false
+                }
+            }
+        }
+    }
+}
+
+// MARK: - Get Branch State View
+
+struct GetBranchStateView: View {
+    @EnvironmentObject var appState: UnifiedAppState
+    @State private var keyHex: String = ""
+    @State private var depth: String = "6"  // Valid range: 6-9
+    @State private var expectedHashHex: String = ""
+    @State private var checkpointHeight: String = ""
+    @State private var isLoading = false
+    @State private var result: PlatformBranchState?
+    @State private var errorMessage: String?
+    @State private var showResult = false
+    
+    var body: some View {
+        ScrollView {
+            VStack(spacing: 20) {
+                // Header
+                VStack(alignment: .leading, spacing: 8) {
+                    Text("Get Branch State")
+                        .font(.title2)
+                        .fontWeight(.bold)
+                    
+                    Text("Query a specific branch of the address tree. Use leaf boundary info from a trunk state query.")
+                        .font(.body)
+                        .foregroundColor(.secondary)
+                    
+                    Text("This is a low-level API. Parameters come from trunk state leaf boundaries.")
+                        .font(.caption)
+                        .foregroundColor(.orange)
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding()
+                
+                // Inputs
+                VStack(alignment: .leading, spacing: 16) {
+                    VStack(alignment: .leading, spacing: 4) {
+                        Text("Key (hex)")
+                            .font(.subheadline)
+                            .fontWeight(.medium)
+                        TextField("Leaf boundary key from trunk state", text: $keyHex)
+                            .textFieldStyle(RoundedBorderTextFieldStyle())
+                            .autocapitalization(.none)
+                            .disableAutocorrection(true)
+                    }
+                    
+                    VStack(alignment: .leading, spacing: 4) {
+                        Text("Depth (6-9)")
+                            .font(.subheadline)
+                            .fontWeight(.medium)
+                        TextField("Query depth (6-9)", text: $depth)
+                            .textFieldStyle(RoundedBorderTextFieldStyle())
+                            .keyboardType(.numberPad)
+                    }
+                    
+                    VStack(alignment: .leading, spacing: 4) {
+                        Text("Expected Hash (hex, 64 chars)")
+                            .font(.subheadline)
+                            .fontWeight(.medium)
+                        TextField("Hash from leaf boundary info", text: $expectedHashHex)
+                            .textFieldStyle(RoundedBorderTextFieldStyle())
+                            .autocapitalization(.none)
+                            .disableAutocorrection(true)
+                    }
+                    
+                    VStack(alignment: .leading, spacing: 4) {
+                        Text("Checkpoint Height")
+                            .font(.subheadline)
+                            .fontWeight(.medium)
+                        TextField("Height from trunk state", text: $checkpointHeight)
+                            .textFieldStyle(RoundedBorderTextFieldStyle())
+                            .keyboardType(.numberPad)
+                    }
+                }
+                .padding(.horizontal)
+                
+                // Query Button
+                Button(action: fetchBranchState) {
+                    HStack {
+                        if isLoading {
+                            ProgressView()
+                                .progressViewStyle(CircularProgressViewStyle(tint: .white))
+                                .scaleEffect(0.8)
+                        } else {
+                            Image(systemName: "arrow.branch")
+                        }
+                        Text(isLoading ? "Fetching..." : "Fetch Branch State")
+                            .fontWeight(.semibold)
+                    }
+                    .frame(maxWidth: .infinity)
+                    .padding()
+                    .background(isLoading || !isFormValid ? Color.gray : Color.blue)
+                    .foregroundColor(.white)
+                    .cornerRadius(10)
+                }
+                .disabled(isLoading || !isFormValid || appState.platformState.sdk == nil)
+                .padding(.horizontal)
+                
+                // Result
+                if showResult {
+                    VStack(alignment: .leading, spacing: 12) {
+                        Text("Result")
+                            .font(.headline)
+                        
+                        if let error = errorMessage {
+                            HStack {
+                                Image(systemName: "xmark.circle.fill")
+                                    .foregroundColor(.red)
+                                Text(error)
+                                    .foregroundColor(.red)
+                            }
+                            .padding()
+                            .background(Color.red.opacity(0.1))
+                            .cornerRadius(8)
+                        } else if let state = result {
+                            VStack(alignment: .leading, spacing: 16) {
+                                // Summary
+                                VStack(alignment: .leading, spacing: 8) {
+                                    HStack {
+                                        Label("Elements", systemImage: "person.2")
+                                        Spacer()
+                                        Text("\(state.elements.count)")
+                                            .fontWeight(.medium)
+                                    }
+                                    
+                                    HStack {
+                                        Label("Leaf Boundaries", systemImage: "leaf")
+                                        Spacer()
+                                        Text("\(state.leafBoundaries.count)")
+                                            .fontWeight(.medium)
+                                    }
+                                    
+                                    if !state.elements.isEmpty {
+                                        VStack(alignment: .leading, spacing: 4) {
+                                            Text("Total Balance")
+                                                .font(.subheadline)
+                                            Text("\(formatCredits(state.totalBalance)) credits")
+                                                .fontWeight(.medium)
+                                            Text("\(formatDash(state.totalBalance)) DASH")
+                                                .foregroundColor(.blue)
+                                        }
+                                    }
+                                }
+                                .font(.subheadline)
+                                .padding()
+                                .background(Color.gray.opacity(0.1))
+                                .cornerRadius(8)
+                                
+                                // Elements section
+                                if !state.elements.isEmpty {
+                                    VStack(alignment: .leading, spacing: 8) {
+                                        Text("Elements (\(state.elements.count))")
+                                            .font(.subheadline)
+                                            .fontWeight(.semibold)
+                                        
+                                        ForEach(Array(state.elements.enumerated()), id: \.offset) { _, element in
+                                            VStack(alignment: .leading, spacing: 4) {
+                                                Text("Key: \(element.keyHex.prefix(16))...")
+                                                    .font(.caption)
+                                                    .monospaced()
+                                                HStack {
+                                                    Text("\(formatCredits(element.balance)) credits")
+                                                    Spacer()
+                                                    Text("Nonce: \(element.nonce)")
+                                                }
+                                                .font(.caption)
+                                                .foregroundColor(.secondary)
+                                            }
+                                            .padding(8)
+                                            .background(Color.green.opacity(0.05))
+                                            .cornerRadius(6)
+                                        }
+                                    }
+                                }
+                                
+                                // Leaf boundaries section
+                                if !state.leafBoundaries.isEmpty {
+                                    VStack(alignment: .leading, spacing: 8) {
+                                        Text("Leaf Boundaries (\(state.leafBoundaries.count)) - Tap to copy")
+                                            .font(.subheadline)
+                                            .fontWeight(.semibold)
+                                        
+                                        ForEach(Array(state.leafBoundaries.enumerated()), id: \.offset) { _, boundary in
+                                            VStack(alignment: .leading, spacing: 6) {
+                                                HStack {
+                                                    Text("Key:")
+                                                        .font(.caption)
+                                                        .frame(width: 40, alignment: .leading)
+                                                    Button(action: {
+                                                        UIPasteboard.general.string = boundary.keyHex
+                                                    }) {
+                                                        HStack(spacing: 4) {
+                                                            Text(boundary.keyHex)
+                                                                .font(.caption2)
+                                                                .monospaced()
+                                                                .lineLimit(1)
+                                                                .truncationMode(.middle)
+                                                            Image(systemName: "doc.on.doc")
+                                                                .font(.caption2)
+                                                        }
+                                                    }
+                                                    .buttonStyle(.plain)
+                                                    .foregroundColor(.blue)
+                                                }
+                                                
+                                                HStack {
+                                                    Text("Hash:")
+                                                        .font(.caption)
+                                                        .frame(width: 40, alignment: .leading)
+                                                    Button(action: {
+                                                        UIPasteboard.general.string = boundary.hashHex
+                                                    }) {
+                                                        HStack(spacing: 4) {
+                                                            Text(boundary.hashHex)
+                                                                .font(.caption2)
+                                                                .monospaced()
+                                                                .lineLimit(1)
+                                                                .truncationMode(.middle)
+                                                            Image(systemName: "doc.on.doc")
+                                                                .font(.caption2)
+                                                        }
+                                                    }
+                                                    .buttonStyle(.plain)
+                                                    .foregroundColor(.blue)
+                                                }
+                                                
+                                                if boundary.estimatedCount > 0 {
+                                                    Text("Est. count: \(boundary.estimatedCount)")
+                                                        .font(.caption)
+                                                        .foregroundColor(.secondary)
+                                                }
+                                            }
+                                            .padding(8)
+                                            .frame(maxWidth: .infinity, alignment: .leading)
+                                            .background(Color.orange.opacity(0.05))
+                                            .cornerRadius(6)
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                    .padding()
+                }
+                
+                Spacer()
+            }
+        }
+        .navigationTitle("Get Branch State")
+        .navigationBarTitleDisplayMode(.inline)
+    }
+    
+    private var isFormValid: Bool {
+        guard let depthValue = UInt32(depth) else { return false }
+        return !keyHex.isEmpty && 
+            !expectedHashHex.isEmpty && 
+            expectedHashHex.count == 64 &&
+            !checkpointHeight.isEmpty &&
+            depthValue >= 6 && depthValue <= 9 &&
+            UInt64(checkpointHeight) != nil
+    }
+    
+    private func fetchBranchState() {
+        guard let sdk = appState.platformState.sdk else { return }
+        
+        guard let keyData = Data(hexString: keyHex) else {
+            errorMessage = "Invalid key hex"
+            showResult = true
+            return
+        }
+        
+        guard let hashData = Data(hexString: expectedHashHex), hashData.count == 32 else {
+            errorMessage = "Invalid expected hash hex (must be 64 hex characters = 32 bytes)"
+            showResult = true
+            return
+        }
+        
+        guard let depthValue = UInt32(depth), depthValue >= 6 && depthValue <= 9 else {
+            errorMessage = "Depth must be between 6 and 9"
+            showResult = true
+            return
+        }
+        
+        guard let heightValue = UInt64(checkpointHeight) else {
+            errorMessage = "Invalid checkpoint height"
+            showResult = true
+            return
+        }
+        
+        isLoading = true
+        errorMessage = nil
+        result = nil
+        showResult = false
+        
+        Task {
+            do {
+                let branchState = try sdk.addresses.getBranchState(
+                    key: keyData,
+                    depth: depthValue,
+                    expectedHash: hashData,
+                    checkpointHeight: heightValue
+                )
+                
+                await MainActor.run {
+                    result = branchState
                     showResult = true
                     isLoading = false
                 }

--- a/packages/swift-sdk/SwiftExampleApp/SwiftExampleApp/Views/AddressQueriesView.swift
+++ b/packages/swift-sdk/SwiftExampleApp/SwiftExampleApp/Views/AddressQueriesView.swift
@@ -1,0 +1,569 @@
+import SwiftUI
+import SwiftDashSDK
+
+struct AddressQueriesView: View {
+    @EnvironmentObject var appState: UnifiedAppState
+    
+    var body: some View {
+        List {
+            NavigationLink(destination: GetAddressInfoView()) {
+                VStack(alignment: .leading, spacing: 4) {
+                    Text("Get Address Info")
+                        .font(.headline)
+                    Text("Fetch balance and nonce for a single Platform address")
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                        .lineLimit(2)
+                }
+                .padding(.vertical, 4)
+            }
+            
+            NavigationLink(destination: GetAddressesInfosView()) {
+                VStack(alignment: .leading, spacing: 4) {
+                    Text("Get Addresses Infos")
+                        .font(.headline)
+                    Text("Fetch balance and nonce for multiple Platform addresses")
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                        .lineLimit(2)
+                }
+                .padding(.vertical, 4)
+            }
+        }
+        .navigationTitle("Address Queries")
+        .navigationBarTitleDisplayMode(.inline)
+    }
+}
+
+// MARK: - Get Address Info View
+
+struct GetAddressInfoView: View {
+    @EnvironmentObject var appState: UnifiedAppState
+    @State private var addressInput: String = ""
+    @State private var isLoading = false
+    @State private var result: PlatformAddressInfo?
+    @State private var errorMessage: String?
+    @State private var showResult = false
+    
+    // Test addresses
+    private let testBech32m = "tdashevo1qqyfsqyzcn5hzu7echru54njypdq0v4d7gv8pkdf"
+    private let testAddressHex = "00" + "1234567890abcdef1234567890abcdef12345678"
+    
+    var body: some View {
+        ScrollView {
+            VStack(spacing: 20) {
+                // Header
+                VStack(alignment: .leading, spacing: 8) {
+                    Text("Get Address Info")
+                        .font(.title2)
+                        .fontWeight(.bold)
+                    
+                    Text("Query the balance and nonce for a Platform address. Supports both bech32m (tdashevo1.../dashevo1...) and hex formats.")
+                        .font(.body)
+                        .foregroundColor(.secondary)
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding()
+                
+                // Input
+                VStack(alignment: .leading, spacing: 8) {
+                    Text("Address")
+                        .font(.subheadline)
+                        .fontWeight(.medium)
+                    
+                    TextField("Enter bech32m or hex address", text: $addressInput)
+                        .textFieldStyle(RoundedBorderTextFieldStyle())
+                        .autocapitalization(.none)
+                        .disableAutocorrection(true)
+                    
+                    HStack {
+                        Button("Use Bech32m Test") {
+                            addressInput = testBech32m
+                        }
+                        .font(.caption)
+                        .foregroundColor(.blue)
+                        
+                        Text("•")
+                            .foregroundColor(.secondary)
+                        
+                        Button("Use Hex Test") {
+                            addressInput = testAddressHex
+                        }
+                        .font(.caption)
+                        .foregroundColor(.blue)
+                    }
+                    
+                    // Format indicator
+                    if !addressInput.isEmpty {
+                        VStack(alignment: .leading, spacing: 4) {
+                            HStack {
+                                Image(systemName: detectedFormat.icon)
+                                    .foregroundColor(detectedFormat.color)
+                                Text(detectedFormat.description)
+                                    .font(.caption)
+                                    .foregroundColor(.secondary)
+                            }
+                            
+                            // Debug info for bech32m
+                            if addressInput.lowercased().hasPrefix("dashevo1") || addressInput.lowercased().hasPrefix("tdashevo1") {
+                                let debug = Bech32m.debugDecode(addressInput)
+                                if let hex = debug.hex, let count = debug.byteCount {
+                                    Text("Decoded: \(count) bytes")
+                                        .font(.caption2)
+                                        .foregroundColor(.secondary)
+                                    Text("Hex: \(hex)")
+                                        .font(.caption2)
+                                        .foregroundColor(.secondary)
+                                        .lineLimit(1)
+                                } else if let error = debug.error {
+                                    Text("Error: \(error)")
+                                        .font(.caption2)
+                                        .foregroundColor(.red)
+                                }
+                            }
+                        }
+                    }
+                }
+                .padding(.horizontal)
+                
+                // Query Button
+                Button(action: fetchAddressInfo) {
+                    HStack {
+                        if isLoading {
+                            ProgressView()
+                                .progressViewStyle(CircularProgressViewStyle(tint: .white))
+                                .scaleEffect(0.8)
+                        } else {
+                            Image(systemName: "magnifyingglass")
+                        }
+                        Text(isLoading ? "Fetching..." : "Fetch Address Info")
+                            .fontWeight(.semibold)
+                    }
+                    .frame(maxWidth: .infinity)
+                    .padding()
+                    .background(isLoading || addressInput.isEmpty ? Color.gray : Color.blue)
+                    .foregroundColor(.white)
+                    .cornerRadius(10)
+                }
+                .disabled(isLoading || addressInput.isEmpty || appState.platformState.sdk == nil)
+                .padding(.horizontal)
+                
+                // Result
+                if showResult {
+                    VStack(alignment: .leading, spacing: 12) {
+                        Text("Result")
+                            .font(.headline)
+                        
+                        if let error = errorMessage {
+                            HStack {
+                                Image(systemName: "xmark.circle.fill")
+                                    .foregroundColor(.red)
+                                Text(error)
+                                    .foregroundColor(.red)
+                            }
+                            .padding()
+                            .background(Color.red.opacity(0.1))
+                            .cornerRadius(8)
+                        } else if let info = result {
+                            VStack(alignment: .leading, spacing: 8) {
+                                // Show bech32m address (use testnet prefix based on input)
+                                // DashSDKNetwork: 0 = mainnet, 1 = testnet
+                                let network = addressInput.lowercased().hasPrefix("tdashevo") 
+                                    ? DashSDKNetwork(rawValue: 1)  // testnet
+                                    : DashSDKNetwork(rawValue: 0)  // mainnet
+                                let bech32mAddress = info.toBech32m(network: network) ?? info.addressHex
+                                
+                                ResultRow(label: "Address", value: bech32mAddress)
+                                BalanceRow(label: "Balance", credits: info.balance)
+                                ResultRow(label: "Nonce", value: "\(info.nonce)")
+                                ResultRow(label: "Found", value: info.isFound ? "Yes" : "No")
+                            }
+                            .padding()
+                            .background(Color.green.opacity(0.1))
+                            .cornerRadius(8)
+                        } else {
+                            HStack {
+                                Image(systemName: "questionmark.circle")
+                                    .foregroundColor(.orange)
+                                Text("Address not found on Platform")
+                                    .foregroundColor(.orange)
+                            }
+                            .padding()
+                            .background(Color.orange.opacity(0.1))
+                            .cornerRadius(8)
+                        }
+                    }
+                    .padding()
+                }
+                
+                Spacer()
+            }
+        }
+        .navigationTitle("Get Address Info")
+        .navigationBarTitleDisplayMode(.inline)
+    }
+    
+    // Format detection
+    private var detectedFormat: (icon: String, color: Color, description: String) {
+        let trimmed = addressInput.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        
+        if trimmed.hasPrefix("dashevo1") || trimmed.hasPrefix("tdashevo1") {
+            if Bech32m.isValidPlatformAddress(trimmed) {
+                return ("checkmark.circle.fill", .green, "Valid bech32m address")
+            } else {
+                return ("xmark.circle.fill", .red, "Invalid bech32m address")
+            }
+        } else if trimmed.count == 42 && trimmed.allSatisfy({ $0.isHexDigit }) {
+            return ("checkmark.circle.fill", .green, "Hex format (42 characters)")
+        } else if !trimmed.isEmpty {
+            return ("questionmark.circle", .orange, "Unknown format")
+        }
+        return ("circle", .gray, "")
+    }
+    
+    private func fetchAddressInfo() {
+        guard let sdk = appState.platformState.sdk else { return }
+        
+        isLoading = true
+        errorMessage = nil
+        result = nil
+        showResult = false
+        
+        Task {
+            do {
+                // Use auto-detecting method
+                let info = try sdk.addresses.getInfo(address: addressInput)
+                
+                await MainActor.run {
+                    result = info
+                    showResult = true
+                    isLoading = false
+                }
+            } catch {
+                await MainActor.run {
+                    errorMessage = error.localizedDescription
+                    showResult = true
+                    isLoading = false
+                }
+            }
+        }
+    }
+}
+
+// MARK: - Get Addresses Infos View
+
+struct GetAddressesInfosView: View {
+    @EnvironmentObject var appState: UnifiedAppState
+    @State private var addressesText: String = ""
+    @State private var isLoading = false
+    @State private var result: PlatformAddressInfosResult?
+    @State private var errorMessage: String?
+    @State private var showResult = false
+    
+    // Test addresses (mixed formats)
+    private let testBech32mAddresses = """
+    tdashevo1qqyfsqyzcn5hzu7echru54njypdq0v4d7gv8pkdf
+    tdashevo1qq0rs5w7e3xv6ls3f7s4hz82e44p29e38fqlmhs
+    """
+    
+    private let testHexAddresses = """
+    001234567890abcdef1234567890abcdef12345678
+    00abcdef1234567890abcdef1234567890abcdef12
+    """
+    
+    var body: some View {
+        ScrollView {
+            VStack(spacing: 20) {
+                // Header
+                VStack(alignment: .leading, spacing: 8) {
+                    Text("Get Addresses Infos")
+                        .font(.title2)
+                        .fontWeight(.bold)
+                    
+                    Text("Query balance and nonce for multiple Platform addresses. Enter one address per line. Supports bech32m and hex formats (can be mixed).")
+                        .font(.body)
+                        .foregroundColor(.secondary)
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding()
+                
+                // Input
+                VStack(alignment: .leading, spacing: 8) {
+                    Text("Addresses (one per line)")
+                        .font(.subheadline)
+                        .fontWeight(.medium)
+                    
+                    TextEditor(text: $addressesText)
+                        .frame(height: 120)
+                        .overlay(
+                            RoundedRectangle(cornerRadius: 8)
+                                .stroke(Color.gray.opacity(0.3), lineWidth: 1)
+                        )
+                        .autocapitalization(.none)
+                        .disableAutocorrection(true)
+                    
+                    HStack {
+                        Button("Use Bech32m Test") {
+                            addressesText = testBech32mAddresses
+                        }
+                        .font(.caption)
+                        .foregroundColor(.blue)
+                        
+                        Text("•")
+                            .foregroundColor(.secondary)
+                        
+                        Button("Use Hex Test") {
+                            addressesText = testHexAddresses
+                        }
+                        .font(.caption)
+                        .foregroundColor(.blue)
+                    }
+                }
+                .padding(.horizontal)
+                
+                // Query Button
+                Button(action: fetchAddressesInfos) {
+                    HStack {
+                        if isLoading {
+                            ProgressView()
+                                .progressViewStyle(CircularProgressViewStyle(tint: .white))
+                                .scaleEffect(0.8)
+                        } else {
+                            Image(systemName: "magnifyingglass")
+                        }
+                        Text(isLoading ? "Fetching..." : "Fetch Addresses Infos")
+                            .fontWeight(.semibold)
+                    }
+                    .frame(maxWidth: .infinity)
+                    .padding()
+                    .background(isLoading || addressesText.isEmpty ? Color.gray : Color.blue)
+                    .foregroundColor(.white)
+                    .cornerRadius(10)
+                }
+                .disabled(isLoading || addressesText.isEmpty || appState.platformState.sdk == nil)
+                .padding(.horizontal)
+                
+                // Result
+                if showResult {
+                    VStack(alignment: .leading, spacing: 12) {
+                        Text("Result")
+                            .font(.headline)
+                        
+                        if let error = errorMessage {
+                            HStack {
+                                Image(systemName: "xmark.circle.fill")
+                                    .foregroundColor(.red)
+                                Text(error)
+                                    .foregroundColor(.red)
+                            }
+                            .padding()
+                            .background(Color.red.opacity(0.1))
+                            .cornerRadius(8)
+                        } else if let result = result {
+                            // Determine network from input
+                            // DashSDKNetwork: 0 = mainnet, 1 = testnet
+                            let isTestnet = addressesText.lowercased().contains("tdashevo")
+                            let network = isTestnet 
+                                ? DashSDKNetwork(rawValue: 1)  // testnet
+                                : DashSDKNetwork(rawValue: 0)  // mainnet
+                            
+                            VStack(alignment: .leading, spacing: 12) {
+                                // Summary
+                                HStack {
+                                    Text("Total: \(result.infos.count)")
+                                    Spacer()
+                                    Text("Found: \(result.foundAddresses.count)")
+                                        .foregroundColor(.green)
+                                    Text("Not Found: \(result.notFoundAddresses.count)")
+                                        .foregroundColor(.orange)
+                                }
+                                .font(.subheadline)
+                                .padding()
+                                .background(Color.gray.opacity(0.1))
+                                .cornerRadius(8)
+                                
+                                // Total balance in both formats
+                                VStack(alignment: .leading, spacing: 4) {
+                                    Text("Total Balance")
+                                        .font(.subheadline)
+                                        .fontWeight(.medium)
+                                    Text("\(formatCredits(result.totalBalance)) credits")
+                                        .font(.caption)
+                                        .foregroundColor(.secondary)
+                                    Text("\(formatDash(result.totalBalance)) DASH")
+                                        .font(.caption)
+                                        .foregroundColor(.blue)
+                                }
+                                .padding(8)
+                                .background(Color.blue.opacity(0.05))
+                                .cornerRadius(6)
+                                
+                                // Individual results
+                                ForEach(Array(result.infos.values), id: \.addressHex) { info in
+                                    let bech32mAddress = info.toBech32m(network: network) ?? info.addressHex
+                                    
+                                    VStack(alignment: .leading, spacing: 4) {
+                                        HStack {
+                                            Image(systemName: info.isFound ? "checkmark.circle.fill" : "questionmark.circle")
+                                                .foregroundColor(info.isFound ? .green : .orange)
+                                            Text(bech32mAddress)
+                                                .font(.caption)
+                                                .monospaced()
+                                                .lineLimit(1)
+                                        }
+                                        if info.isFound {
+                                            HStack {
+                                                VStack(alignment: .leading) {
+                                                    Text("\(formatCredits(info.balance)) credits")
+                                                    Text("\(formatDash(info.balance)) DASH")
+                                                        .foregroundColor(.blue)
+                                                }
+                                                Spacer()
+                                                Text("Nonce: \(info.nonce)")
+                                            }
+                                            .font(.caption)
+                                            .foregroundColor(.secondary)
+                                        }
+                                    }
+                                    .padding(8)
+                                    .background(info.isFound ? Color.green.opacity(0.05) : Color.orange.opacity(0.05))
+                                    .cornerRadius(6)
+                                }
+                            }
+                        }
+                    }
+                    .padding()
+                }
+                
+                Spacer()
+            }
+        }
+        .navigationTitle("Get Addresses Infos")
+        .navigationBarTitleDisplayMode(.inline)
+    }
+    
+    private func fetchAddressesInfos() {
+        guard let sdk = appState.platformState.sdk else { return }
+        
+        isLoading = true
+        errorMessage = nil
+        result = nil
+        showResult = false
+        
+        // Parse addresses from text
+        let addresses = addressesText
+            .components(separatedBy: .newlines)
+            .map { $0.trimmingCharacters(in: .whitespaces) }
+            .filter { !$0.isEmpty }
+        
+        guard !addresses.isEmpty else {
+            errorMessage = "No valid addresses entered"
+            showResult = true
+            isLoading = false
+            return
+        }
+        
+        Task {
+            do {
+                // Use auto-detecting method that handles both bech32m and hex
+                let infosResult = try sdk.addresses.getInfos(addresses: addresses)
+                
+                await MainActor.run {
+                    result = infosResult
+                    showResult = true
+                    isLoading = false
+                }
+            } catch {
+                await MainActor.run {
+                    errorMessage = error.localizedDescription
+                    showResult = true
+                    isLoading = false
+                }
+            }
+        }
+    }
+}
+
+// MARK: - Helper Functions
+
+/// Credits per Dash: 1 DASH = 10^11 credits = 100,000,000,000 credits
+private let creditsPerDash: UInt64 = 100_000_000_000
+
+/// Format credits with thousands separator
+private func formatCredits(_ credits: UInt64) -> String {
+    let formatter = NumberFormatter()
+    formatter.numberStyle = .decimal
+    formatter.groupingSeparator = ","
+    return formatter.string(from: NSNumber(value: credits)) ?? "\(credits)"
+}
+
+/// Convert credits to Dash with proper decimal formatting
+private func formatDash(_ credits: UInt64) -> String {
+    let dash = Double(credits) / Double(creditsPerDash)
+    let formatter = NumberFormatter()
+    formatter.numberStyle = .decimal
+    formatter.minimumFractionDigits = 0
+    formatter.maximumFractionDigits = 8
+    formatter.groupingSeparator = ","
+    return formatter.string(from: NSNumber(value: dash)) ?? String(format: "%.8f", dash)
+}
+
+// MARK: - Helper Views
+
+struct ResultRow: View {
+    let label: String
+    let value: String
+    
+    var body: some View {
+        HStack {
+            Text(label)
+                .font(.subheadline)
+                .foregroundColor(.secondary)
+            Spacer()
+            Text(value)
+                .font(.subheadline)
+                .fontWeight(.medium)
+                .lineLimit(1)
+        }
+    }
+}
+
+/// Balance row showing both credits and Dash
+struct BalanceRow: View {
+    let label: String
+    let credits: UInt64
+    
+    var body: some View {
+        VStack(alignment: .leading, spacing: 2) {
+            HStack {
+                Text(label)
+                    .font(.subheadline)
+                    .foregroundColor(.secondary)
+                Spacer()
+            }
+            HStack {
+                Spacer()
+                VStack(alignment: .trailing, spacing: 2) {
+                    Text("\(formatCredits(credits)) credits")
+                        .font(.subheadline)
+                        .fontWeight(.medium)
+                    Text("\(formatDash(credits)) DASH")
+                        .font(.caption)
+                        .foregroundColor(.blue)
+                        .fontWeight(.semibold)
+                }
+            }
+        }
+    }
+}
+
+// MARK: - Previews
+
+struct AddressQueriesView_Previews: PreviewProvider {
+    static var previews: some View {
+        NavigationView {
+            AddressQueriesView()
+                .environmentObject(UnifiedAppState())
+        }
+    }
+}

--- a/packages/swift-sdk/SwiftExampleApp/SwiftExampleApp/Views/AddressQueriesView.swift
+++ b/packages/swift-sdk/SwiftExampleApp/SwiftExampleApp/Views/AddressQueriesView.swift
@@ -65,6 +65,18 @@ struct AddressQueriesView: View {
                 }
                 .padding(.vertical, 4)
             }
+            
+            NavigationLink(destination: GetCompactedBalanceChangesView()) {
+                VStack(alignment: .leading, spacing: 4) {
+                    Text("Get Compacted Balance Changes")
+                        .font(.headline)
+                    Text("Fetch compacted (merged) address balance changes")
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                        .lineLimit(2)
+                }
+                .padding(.vertical, 4)
+            }
         }
         .navigationTitle("Address Queries")
         .navigationBarTitleDisplayMode(.inline)
@@ -1364,6 +1376,334 @@ struct AddressBalanceChangeView: View {
                 Text("(\(formatDash(change.operation.credits)) DASH)")
                     .font(.caption2)
                     .foregroundColor(.blue)
+            }
+        }
+        .padding()
+        .background(Color.gray.opacity(0.05))
+        .cornerRadius(8)
+        .padding(.leading, 16)
+    }
+}
+
+// MARK: - Get Compacted Balance Changes View
+
+struct GetCompactedBalanceChangesView: View {
+    @EnvironmentObject var appState: UnifiedAppState
+    @State private var startHeightInput: String = "0"
+    @State private var isLoading = false
+    @State private var result: CompactedBalanceChanges?
+    @State private var errorMessage: String?
+    @State private var showResult = false
+    
+    var body: some View {
+        ScrollView {
+            VStack(spacing: 20) {
+                // Header
+                VStack(alignment: .leading, spacing: 8) {
+                    Text("Get Compacted Balance Changes")
+                        .font(.title2)
+                        .fontWeight(.bold)
+                    
+                    Text("Fetch compacted (merged) address balance changes since a block height. Compacted changes merge multiple blocks into ranges for efficient syncing.")
+                        .font(.body)
+                        .foregroundColor(.secondary)
+                    
+                    Text("BlockAwareCreditOperation preserves per-block granularity for partial sync scenarios.")
+                        .font(.caption)
+                        .foregroundColor(.orange)
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding()
+                
+                // Input
+                VStack(alignment: .leading, spacing: 8) {
+                    Text("Start Block Height")
+                        .font(.subheadline)
+                        .fontWeight(.medium)
+                    
+                    TextField("Enter start block height", text: $startHeightInput)
+                        .textFieldStyle(RoundedBorderTextFieldStyle())
+                        .keyboardType(.numberPad)
+                    
+                    Text("Enter 0 to get all compacted balance changes")
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                }
+                .padding(.horizontal)
+                
+                // Fetch Button
+                Button(action: fetchCompactedChanges) {
+                    HStack {
+                        if isLoading {
+                            ProgressView()
+                                .progressViewStyle(CircularProgressViewStyle(tint: .white))
+                        } else {
+                            Image(systemName: "arrow.triangle.merge")
+                        }
+                        Text(isLoading ? "Fetching..." : "Fetch Compacted Changes")
+                    }
+                    .frame(maxWidth: .infinity)
+                    .padding()
+                    .background(Color.purple)
+                    .foregroundColor(.white)
+                    .cornerRadius(10)
+                }
+                .disabled(isLoading || !isFormValid)
+                .opacity((isLoading || !isFormValid) ? 0.6 : 1.0)
+                .padding(.horizontal)
+                
+                // Result
+                if showResult {
+                    if let error = errorMessage {
+                        VStack(alignment: .leading, spacing: 8) {
+                            Label("Error", systemImage: "exclamationmark.triangle.fill")
+                                .foregroundColor(.red)
+                                .font(.headline)
+                            Text(error)
+                                .font(.body)
+                                .foregroundColor(.red)
+                        }
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .padding()
+                        .background(Color.red.opacity(0.1))
+                        .cornerRadius(10)
+                        .padding(.horizontal)
+                    } else if let changes = result {
+                        // Get network from SDK
+                        let network = appState.platformState.sdk?.network ?? DashSDKNetwork(rawValue: 1)
+                        CompactedBalanceChangesResultView(changes: changes, network: network)
+                            .padding(.horizontal)
+                    }
+                }
+                
+                Spacer()
+            }
+        }
+        .navigationTitle("Compacted Balance Changes")
+        .navigationBarTitleDisplayMode(.inline)
+    }
+    
+    private var isFormValid: Bool {
+        return UInt64(startHeightInput) != nil
+    }
+    
+    private func fetchCompactedChanges() {
+        guard let sdk = appState.platformState.sdk else { return }
+        guard let startHeight = UInt64(startHeightInput) else {
+            errorMessage = "Invalid start height"
+            showResult = true
+            return
+        }
+        
+        isLoading = true
+        errorMessage = nil
+        result = nil
+        showResult = false
+        
+        Task {
+            do {
+                let changes = try sdk.addresses.getCompactedBalanceChanges(startBlockHeight: startHeight)
+                
+                await MainActor.run {
+                    result = changes
+                    showResult = true
+                    isLoading = false
+                }
+            } catch {
+                await MainActor.run {
+                    errorMessage = error.localizedDescription
+                    showResult = true
+                    isLoading = false
+                }
+            }
+        }
+    }
+}
+
+// MARK: - Compacted Balance Changes Result View
+
+struct CompactedBalanceChangesResultView: View {
+    let changes: CompactedBalanceChanges
+    let network: DashSDKNetwork
+    
+    var body: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            // Summary
+            VStack(alignment: .leading, spacing: 12) {
+                Label("Summary", systemImage: "list.bullet.rectangle")
+                    .font(.headline)
+                
+                ResultRow(label: "Ranges", value: "\(changes.ranges.count)")
+                ResultRow(label: "Total Changes", value: "\(changes.totalChangesCount)")
+                
+                if let range = changes.heightRange {
+                    ResultRow(label: "Height Range", value: "\(range.lowerBound) - \(range.upperBound)")
+                }
+            }
+            .padding()
+            .background(Color.gray.opacity(0.1))
+            .cornerRadius(10)
+            
+            // Range-by-range details
+            if !changes.ranges.isEmpty {
+                VStack(alignment: .leading, spacing: 12) {
+                    Label("Compacted Changes by Range", systemImage: "cube.fill")
+                        .font(.headline)
+                    
+                    ForEach(Array(changes.ranges.enumerated()), id: \.offset) { _, range in
+                        CompactedBlockRangeView(range: range, network: network)
+                    }
+                }
+            } else {
+                Text("No compacted balance changes found from the specified block height.")
+                    .font(.body)
+                    .foregroundColor(.secondary)
+                    .padding()
+            }
+        }
+    }
+}
+
+struct CompactedBlockRangeView: View {
+    let range: CompactedBlockRange
+    let network: DashSDKNetwork
+    
+    @State private var isExpanded = false
+    
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Button(action: { isExpanded.toggle() }) {
+                HStack {
+                    VStack(alignment: .leading, spacing: 4) {
+                        Text("Block \(range.startBlockHeight) - \(range.endBlockHeight)")
+                            .font(.subheadline)
+                            .fontWeight(.semibold)
+                        Text("\(range.changes.count) address(es)")
+                            .font(.caption)
+                            .foregroundColor(.secondary)
+                    }
+                    Spacer()
+                    Image(systemName: isExpanded ? "chevron.up" : "chevron.down")
+                        .foregroundColor(.secondary)
+                }
+                .padding()
+                .background(Color.purple.opacity(0.1))
+                .cornerRadius(8)
+            }
+            .buttonStyle(PlainButtonStyle())
+            
+            if isExpanded {
+                ForEach(Array(range.changes.enumerated()), id: \.offset) { _, change in
+                    CompactedAddressChangeView(change: change, network: network)
+                }
+            }
+        }
+    }
+}
+
+struct CompactedAddressChangeView: View {
+    let change: CompactedAddressChange
+    let network: DashSDKNetwork
+    
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            // Address
+            if let bech32m = change.toBech32m(network: network) {
+                VStack(alignment: .leading, spacing: 2) {
+                    Text("Address")
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                    Text(bech32m)
+                        .font(.system(.caption, design: .monospaced))
+                        .lineLimit(1)
+                        .truncationMode(.middle)
+                }
+            } else {
+                VStack(alignment: .leading, spacing: 2) {
+                    Text("Address (hex)")
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                    Text(change.addressHex)
+                        .font(.system(.caption, design: .monospaced))
+                        .lineLimit(1)
+                        .truncationMode(.middle)
+                }
+            }
+            
+            // Operation
+            VStack(alignment: .leading, spacing: 4) {
+                switch change.operation {
+                case .setCredits(let credits):
+                    HStack {
+                        Text("Operation")
+                            .font(.caption)
+                            .foregroundColor(.secondary)
+                        Spacer()
+                        HStack(spacing: 4) {
+                            Image(systemName: "equal")
+                                .foregroundColor(.orange)
+                            Text("Set to \(formatCredits(credits))")
+                                .font(.caption)
+                                .fontWeight(.medium)
+                        }
+                    }
+                    HStack {
+                        Spacer()
+                        Text("(\(formatDash(credits)) DASH)")
+                            .font(.caption2)
+                            .foregroundColor(.blue)
+                    }
+                    
+                case .addToCreditsOperations(let entries):
+                    HStack {
+                        Text("Operation")
+                            .font(.caption)
+                            .foregroundColor(.secondary)
+                        Spacer()
+                        HStack(spacing: 4) {
+                            Image(systemName: "plus.square.on.square")
+                                .foregroundColor(.green)
+                            Text("\(entries.count) Add Operation(s)")
+                                .font(.caption)
+                                .fontWeight(.medium)
+                        }
+                    }
+                    
+                    // Show each add entry
+                    ForEach(Array(entries.enumerated()), id: \.offset) { _, entry in
+                        HStack {
+                            Text("Block \(entry.blockHeight)")
+                                .font(.caption2)
+                                .foregroundColor(.secondary)
+                            Spacer()
+                            VStack(alignment: .trailing) {
+                                Text("+\(formatCredits(entry.credits)) credits")
+                                    .font(.caption2)
+                                Text("+\(formatDash(entry.credits)) DASH")
+                                    .font(.caption2)
+                                    .foregroundColor(.blue)
+                            }
+                        }
+                        .padding(.leading, 16)
+                    }
+                    
+                    // Total
+                    HStack {
+                        Text("Total")
+                            .font(.caption)
+                            .fontWeight(.medium)
+                        Spacer()
+                        VStack(alignment: .trailing) {
+                            Text("\(formatCredits(change.operation.totalCredits)) credits")
+                                .font(.caption)
+                                .fontWeight(.medium)
+                            Text("\(formatDash(change.operation.totalCredits)) DASH")
+                                .font(.caption)
+                                .foregroundColor(.blue)
+                                .fontWeight(.semibold)
+                        }
+                    }
+                }
             }
         }
         .padding()

--- a/packages/swift-sdk/SwiftExampleApp/SwiftExampleApp/Views/AddressQueriesView.swift
+++ b/packages/swift-sdk/SwiftExampleApp/SwiftExampleApp/Views/AddressQueriesView.swift
@@ -29,6 +29,18 @@ struct AddressQueriesView: View {
                 }
                 .padding(.vertical, 4)
             }
+            
+            NavigationLink(destination: GetTrunkStateView()) {
+                VStack(alignment: .leading, spacing: 4) {
+                    Text("Get Trunk State")
+                        .font(.headline)
+                    Text("Fetch address tree trunk state for privacy-preserving sync")
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                        .lineLimit(2)
+                }
+                .padding(.vertical, 4)
+            }
         }
         .navigationTitle("Address Queries")
         .navigationBarTitleDisplayMode(.inline)
@@ -470,6 +482,210 @@ struct GetAddressesInfosView: View {
                 
                 await MainActor.run {
                     result = infosResult
+                    showResult = true
+                    isLoading = false
+                }
+            } catch {
+                await MainActor.run {
+                    errorMessage = error.localizedDescription
+                    showResult = true
+                    isLoading = false
+                }
+            }
+        }
+    }
+}
+
+// MARK: - Get Trunk State View
+
+struct GetTrunkStateView: View {
+    @EnvironmentObject var appState: UnifiedAppState
+    @State private var isLoading = false
+    @State private var result: PlatformTrunkState?
+    @State private var errorMessage: String?
+    @State private var showResult = false
+    
+    var body: some View {
+        ScrollView {
+            VStack(spacing: 20) {
+                // Header
+                VStack(alignment: .leading, spacing: 8) {
+                    Text("Get Trunk State")
+                        .font(.title2)
+                        .fontWeight(.bold)
+                    
+                    Text("Fetch the trunk state of the address tree. This returns addresses at the top levels of the tree and leaf boundaries for subtrees that need further queries.")
+                        .font(.body)
+                        .foregroundColor(.secondary)
+                    
+                    Text("This is a low-level API used for privacy-preserving address synchronization.")
+                        .font(.caption)
+                        .foregroundColor(.orange)
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding()
+                
+                // Query Button
+                Button(action: fetchTrunkState) {
+                    HStack {
+                        if isLoading {
+                            ProgressView()
+                                .progressViewStyle(CircularProgressViewStyle(tint: .white))
+                                .scaleEffect(0.8)
+                        } else {
+                            Image(systemName: "square.stack.3d.up")
+                        }
+                        Text(isLoading ? "Fetching..." : "Fetch Trunk State")
+                            .fontWeight(.semibold)
+                    }
+                    .frame(maxWidth: .infinity)
+                    .padding()
+                    .background(isLoading ? Color.gray : Color.blue)
+                    .foregroundColor(.white)
+                    .cornerRadius(10)
+                }
+                .disabled(isLoading || appState.platformState.sdk == nil)
+                .padding(.horizontal)
+                
+                // Result
+                if showResult {
+                    VStack(alignment: .leading, spacing: 12) {
+                        Text("Result")
+                            .font(.headline)
+                        
+                        if let error = errorMessage {
+                            HStack {
+                                Image(systemName: "xmark.circle.fill")
+                                    .foregroundColor(.red)
+                                Text(error)
+                                    .foregroundColor(.red)
+                            }
+                            .padding()
+                            .background(Color.red.opacity(0.1))
+                            .cornerRadius(8)
+                        } else if let state = result {
+                            VStack(alignment: .leading, spacing: 16) {
+                                // Summary
+                                VStack(alignment: .leading, spacing: 8) {
+                                    HStack {
+                                        Label("Checkpoint Height", systemImage: "number.square")
+                                        Spacer()
+                                        Text("\(state.checkpointHeight)")
+                                            .fontWeight(.medium)
+                                    }
+                                    
+                                    HStack {
+                                        Label("Elements", systemImage: "person.2")
+                                        Spacer()
+                                        Text("\(state.elements.count)")
+                                            .fontWeight(.medium)
+                                    }
+                                    
+                                    HStack {
+                                        Label("Leaf Boundaries", systemImage: "leaf")
+                                        Spacer()
+                                        Text("\(state.leafBoundaries.count)")
+                                            .fontWeight(.medium)
+                                    }
+                                    
+                                    if !state.elements.isEmpty {
+                                        VStack(alignment: .leading, spacing: 4) {
+                                            Text("Total Balance")
+                                                .font(.subheadline)
+                                            Text("\(formatCredits(state.totalBalance)) credits")
+                                                .fontWeight(.medium)
+                                            Text("\(formatDash(state.totalBalance)) DASH")
+                                                .foregroundColor(.blue)
+                                        }
+                                    }
+                                }
+                                .font(.subheadline)
+                                .padding()
+                                .background(Color.gray.opacity(0.1))
+                                .cornerRadius(8)
+                                
+                                // Elements section
+                                if !state.elements.isEmpty {
+                                    VStack(alignment: .leading, spacing: 8) {
+                                        Text("Elements (\(state.elements.count))")
+                                            .font(.subheadline)
+                                            .fontWeight(.semibold)
+                                        
+                                        ForEach(Array(state.elements.enumerated()), id: \.offset) { index, element in
+                                            VStack(alignment: .leading, spacing: 4) {
+                                                Text("Key: \(element.keyHex.prefix(16))...")
+                                                    .font(.caption)
+                                                    .monospaced()
+                                                HStack {
+                                                    Text("\(formatCredits(element.balance)) credits")
+                                                    Spacer()
+                                                    Text("Nonce: \(element.nonce)")
+                                                }
+                                                .font(.caption)
+                                                .foregroundColor(.secondary)
+                                            }
+                                            .padding(8)
+                                            .background(Color.green.opacity(0.05))
+                                            .cornerRadius(6)
+                                        }
+                                    }
+                                }
+                                
+                                // Leaf boundaries section
+                                if !state.leafBoundaries.isEmpty {
+                                    VStack(alignment: .leading, spacing: 8) {
+                                        Text("Leaf Boundaries (\(state.leafBoundaries.count))")
+                                            .font(.subheadline)
+                                            .fontWeight(.semibold)
+                                        
+                                        ForEach(Array(state.leafBoundaries.enumerated()), id: \.offset) { index, boundary in
+                                            VStack(alignment: .leading, spacing: 4) {
+                                                Text("Key: \(boundary.keyHex.prefix(16))...")
+                                                    .font(.caption)
+                                                    .monospaced()
+                                                Text("Hash: \(boundary.hashHex.prefix(16))...")
+                                                    .font(.caption2)
+                                                    .monospaced()
+                                                    .foregroundColor(.secondary)
+                                                if boundary.estimatedCount > 0 {
+                                                    Text("Est. count: \(boundary.estimatedCount)")
+                                                        .font(.caption)
+                                                        .foregroundColor(.secondary)
+                                                }
+                                            }
+                                            .padding(8)
+                                            .background(Color.orange.opacity(0.05))
+                                            .cornerRadius(6)
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                    .padding()
+                }
+                
+                Spacer()
+            }
+        }
+        .navigationTitle("Get Trunk State")
+        .navigationBarTitleDisplayMode(.inline)
+    }
+    
+    private func fetchTrunkState() {
+        guard let sdk = appState.platformState.sdk else { return }
+        
+        isLoading = true
+        errorMessage = nil
+        result = nil
+        showResult = false
+        
+        Task {
+            do {
+                let trunkState = try sdk.addresses.getTrunkState()
+                
+                await MainActor.run {
+                    result = trunkState
                     showResult = true
                     isLoading = false
                 }

--- a/packages/swift-sdk/SwiftExampleApp/SwiftExampleApp/Views/AddressQueriesView.swift
+++ b/packages/swift-sdk/SwiftExampleApp/SwiftExampleApp/Views/AddressQueriesView.swift
@@ -53,6 +53,18 @@ struct AddressQueriesView: View {
                 }
                 .padding(.vertical, 4)
             }
+            
+            NavigationLink(destination: GetRecentBalanceChangesView()) {
+                VStack(alignment: .leading, spacing: 4) {
+                    Text("Get Recent Balance Changes")
+                        .font(.headline)
+                    Text("Fetch address balance changes since a block height")
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                        .lineLimit(2)
+                }
+                .padding(.vertical, 4)
+            }
         }
         .navigationTitle("Address Queries")
         .navigationBarTitleDisplayMode(.inline)
@@ -1076,6 +1088,288 @@ struct GetBranchStateView: View {
                 }
             }
         }
+    }
+}
+
+// MARK: - Get Recent Balance Changes View
+
+struct GetRecentBalanceChangesView: View {
+    @EnvironmentObject var appState: UnifiedAppState
+    @State private var startHeightInput: String = "0"
+    @State private var isLoading = false
+    @State private var result: RecentBalanceChanges?
+    @State private var errorMessage: String?
+    @State private var showResult = false
+    
+    var body: some View {
+        ScrollView {
+            VStack(spacing: 20) {
+                // Header
+                VStack(alignment: .leading, spacing: 8) {
+                    Text("Get Recent Balance Changes")
+                        .font(.title2)
+                        .fontWeight(.bold)
+                    
+                    Text("Fetch all address balance changes that occurred since the specified block height. Useful for syncing wallet balances after initial sync.")
+                        .font(.body)
+                        .foregroundColor(.secondary)
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding()
+                
+                // Input
+                VStack(alignment: .leading, spacing: 8) {
+                    Text("Start Block Height")
+                        .font(.subheadline)
+                        .fontWeight(.medium)
+                    
+                    TextField("Enter start block height", text: $startHeightInput)
+                        .textFieldStyle(RoundedBorderTextFieldStyle())
+                        .keyboardType(.numberPad)
+                    
+                    Text("Enter 0 to get all recent balance changes")
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                }
+                .padding(.horizontal)
+                
+                // Fetch Button
+                Button(action: fetchRecentChanges) {
+                    HStack {
+                        if isLoading {
+                            ProgressView()
+                                .progressViewStyle(CircularProgressViewStyle(tint: .white))
+                        } else {
+                            Image(systemName: "arrow.triangle.2.circlepath")
+                        }
+                        Text(isLoading ? "Fetching..." : "Fetch Recent Changes")
+                    }
+                    .frame(maxWidth: .infinity)
+                    .padding()
+                    .background(Color.blue)
+                    .foregroundColor(.white)
+                    .cornerRadius(10)
+                }
+                .disabled(isLoading || !isFormValid)
+                .opacity((isLoading || !isFormValid) ? 0.6 : 1.0)
+                .padding(.horizontal)
+                
+                // Result
+                if showResult {
+                    if let error = errorMessage {
+                        VStack(alignment: .leading, spacing: 8) {
+                            Label("Error", systemImage: "exclamationmark.triangle.fill")
+                                .foregroundColor(.red)
+                                .font(.headline)
+                            Text(error)
+                                .font(.body)
+                                .foregroundColor(.red)
+                        }
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .padding()
+                        .background(Color.red.opacity(0.1))
+                        .cornerRadius(10)
+                        .padding(.horizontal)
+                    } else if let changes = result {
+                        // Get network from SDK (0 = mainnet, 1 = testnet)
+                        let network = appState.platformState.sdk?.network ?? DashSDKNetwork(rawValue: 1)
+                        RecentBalanceChangesResultView(changes: changes, network: network)
+                            .padding(.horizontal)
+                    }
+                }
+                
+                Spacer()
+            }
+        }
+        .navigationTitle("Recent Balance Changes")
+        .navigationBarTitleDisplayMode(.inline)
+    }
+    
+    private var isFormValid: Bool {
+        return UInt64(startHeightInput) != nil
+    }
+    
+    private func fetchRecentChanges() {
+        guard let sdk = appState.platformState.sdk else { return }
+        guard let startHeight = UInt64(startHeightInput) else {
+            errorMessage = "Invalid start height"
+            showResult = true
+            return
+        }
+        
+        isLoading = true
+        errorMessage = nil
+        result = nil
+        showResult = false
+        
+        Task {
+            do {
+                let changes = try sdk.addresses.getRecentBalanceChanges(startHeight: startHeight)
+                
+                await MainActor.run {
+                    result = changes
+                    showResult = true
+                    isLoading = false
+                }
+            } catch {
+                await MainActor.run {
+                    errorMessage = error.localizedDescription
+                    showResult = true
+                    isLoading = false
+                }
+            }
+        }
+    }
+}
+
+// MARK: - Recent Balance Changes Result View
+
+struct RecentBalanceChangesResultView: View {
+    let changes: RecentBalanceChanges
+    let network: DashSDKNetwork
+    
+    var body: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            // Summary
+            VStack(alignment: .leading, spacing: 12) {
+                Label("Summary", systemImage: "list.bullet.rectangle")
+                    .font(.headline)
+                
+                ResultRow(label: "Blocks", value: "\(changes.blocks.count)")
+                ResultRow(label: "Total Changes", value: "\(changes.totalChangesCount)")
+                
+                if let range = changes.heightRange {
+                    ResultRow(label: "Height Range", value: "\(range.lowerBound) - \(range.upperBound)")
+                }
+            }
+            .padding()
+            .background(Color.gray.opacity(0.1))
+            .cornerRadius(10)
+            
+            // Block-by-block details
+            if !changes.blocks.isEmpty {
+                VStack(alignment: .leading, spacing: 12) {
+                    Label("Balance Changes by Block", systemImage: "cube.fill")
+                        .font(.headline)
+                    
+                    ForEach(Array(changes.blocks.enumerated()), id: \.offset) { _, block in
+                        BlockBalanceChangesView(block: block, network: network)
+                    }
+                }
+            } else {
+                Text("No balance changes found from the specified block height.")
+                    .font(.body)
+                    .foregroundColor(.secondary)
+                    .padding()
+            }
+        }
+    }
+}
+
+struct BlockBalanceChangesView: View {
+    let block: BlockBalanceChanges
+    let network: DashSDKNetwork
+    
+    @State private var isExpanded = false
+    
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Button(action: { isExpanded.toggle() }) {
+                HStack {
+                    VStack(alignment: .leading, spacing: 4) {
+                        Text("Block \(block.blockHeight)")
+                            .font(.subheadline)
+                            .fontWeight(.semibold)
+                        Text("\(block.changes.count) change(s)")
+                            .font(.caption)
+                            .foregroundColor(.secondary)
+                    }
+                    Spacer()
+                    Image(systemName: isExpanded ? "chevron.up" : "chevron.down")
+                        .foregroundColor(.secondary)
+                }
+                .padding()
+                .background(Color.blue.opacity(0.1))
+                .cornerRadius(8)
+            }
+            .buttonStyle(PlainButtonStyle())
+            
+            if isExpanded {
+                ForEach(Array(block.changes.enumerated()), id: \.offset) { _, change in
+                    AddressBalanceChangeView(change: change, network: network)
+                }
+            }
+        }
+    }
+}
+
+struct AddressBalanceChangeView: View {
+    let change: AddressBalanceChange
+    let network: DashSDKNetwork
+    
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            // Address
+            if let bech32m = change.toBech32m(network: network) {
+                VStack(alignment: .leading, spacing: 2) {
+                    Text("Address")
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                    Text(bech32m)
+                        .font(.system(.caption, design: .monospaced))
+                        .lineLimit(1)
+                        .truncationMode(.middle)
+                }
+            } else {
+                VStack(alignment: .leading, spacing: 2) {
+                    Text("Address (hex)")
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                    Text(change.addressHex)
+                        .font(.system(.caption, design: .monospaced))
+                        .lineLimit(1)
+                        .truncationMode(.middle)
+                }
+            }
+            
+            // Operation
+            HStack {
+                Text("Operation")
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+                Spacer()
+                switch change.operation {
+                case .setCredits(let credits):
+                    HStack(spacing: 4) {
+                        Image(systemName: "equal")
+                            .foregroundColor(.orange)
+                        Text("Set to \(formatCredits(credits))")
+                            .font(.caption)
+                            .fontWeight(.medium)
+                    }
+                case .addToCredits(let credits):
+                    HStack(spacing: 4) {
+                        Image(systemName: "plus")
+                            .foregroundColor(.green)
+                        Text("Add \(formatCredits(credits))")
+                            .font(.caption)
+                            .fontWeight(.medium)
+                    }
+                }
+            }
+            
+            // Dash equivalent
+            HStack {
+                Spacer()
+                Text("(\(formatDash(change.operation.credits)) DASH)")
+                    .font(.caption2)
+                    .foregroundColor(.blue)
+            }
+        }
+        .padding()
+        .background(Color.gray.opacity(0.05))
+        .cornerRadius(8)
+        .padding(.leading, 16)
     }
 }
 

--- a/packages/swift-sdk/SwiftExampleApp/SwiftExampleApp/Views/PlatformQueriesView.swift
+++ b/packages/swift-sdk/SwiftExampleApp/SwiftExampleApp/Views/PlatformQueriesView.swift
@@ -13,6 +13,7 @@ struct PlatformQueriesView: View {
         case epoch = "Epoch & Block"
         case token = "Token"
         case group = "Group"
+        case addresses = "Addresses"
         case system = "System & Utility"
         case diagnostics = "Diagnostics"
         
@@ -27,6 +28,7 @@ struct PlatformQueriesView: View {
             case .epoch: return "clock"
             case .token: return "dollarsign.circle"
             case .group: return "person.3"
+            case .addresses: return "wallet.pass"
             case .system: return "gear"
             case .diagnostics: return "stethoscope"
             }
@@ -43,6 +45,7 @@ struct PlatformQueriesView: View {
             case .epoch: return "Epoch and block information"
             case .token: return "Token balances and information"
             case .group: return "Group management queries"
+            case .addresses: return "Platform address balance and nonce queries"
             case .system: return "System status and utilities"
             case .diagnostics: return "Test and diagnose platform queries"
             }
@@ -82,49 +85,54 @@ struct QueryCategoryDetailView: View {
     @EnvironmentObject var appState: UnifiedAppState
     
     var body: some View {
-        List {
-            ForEach(queries(for: category), id: \.name) { query in
-                if query.name == "runAllQueries" {
-                    NavigationLink(destination: DiagnosticsView()) {
-                        VStack(alignment: .leading, spacing: 4) {
-                            Text(query.label)
-                                .font(.headline)
-                            Text(query.description)
-                                .font(.caption)
-                                .foregroundColor(.secondary)
-                                .lineLimit(2)
+        // Special handling for addresses category - use dedicated view
+        if category == .addresses {
+            AddressQueriesView()
+        } else {
+            List {
+                ForEach(queries(for: category), id: \.name) { query in
+                    if query.name == "runAllQueries" {
+                        NavigationLink(destination: DiagnosticsView()) {
+                            VStack(alignment: .leading, spacing: 4) {
+                                Text(query.label)
+                                    .font(.headline)
+                                Text(query.description)
+                                    .font(.caption)
+                                    .foregroundColor(.secondary)
+                                    .lineLimit(2)
+                            }
+                            .padding(.vertical, 4)
                         }
-                        .padding(.vertical, 4)
-                    }
-                } else if query.name == "testDPNSQueries" {
-                    NavigationLink(destination: DPNSTestView()) {
-                        VStack(alignment: .leading, spacing: 4) {
-                            Text(query.label)
-                                .font(.headline)
-                            Text(query.description)
-                                .font(.caption)
-                                .foregroundColor(.secondary)
-                                .lineLimit(2)
+                    } else if query.name == "testDPNSQueries" {
+                        NavigationLink(destination: DPNSTestView()) {
+                            VStack(alignment: .leading, spacing: 4) {
+                                Text(query.label)
+                                    .font(.headline)
+                                Text(query.description)
+                                    .font(.caption)
+                                    .foregroundColor(.secondary)
+                                    .lineLimit(2)
+                            }
+                            .padding(.vertical, 4)
                         }
-                        .padding(.vertical, 4)
-                    }
-                } else {
-                    NavigationLink(destination: QueryDetailView(query: query)) {
-                        VStack(alignment: .leading, spacing: 4) {
-                            Text(query.label)
-                                .font(.headline)
-                            Text(query.description)
-                                .font(.caption)
-                                .foregroundColor(.secondary)
-                                .lineLimit(2)
+                    } else {
+                        NavigationLink(destination: QueryDetailView(query: query)) {
+                            VStack(alignment: .leading, spacing: 4) {
+                                Text(query.label)
+                                    .font(.headline)
+                                Text(query.description)
+                                    .font(.caption)
+                                    .foregroundColor(.secondary)
+                                    .lineLimit(2)
+                            }
+                            .padding(.vertical, 4)
                         }
-                        .padding(.vertical, 4)
                     }
                 }
             }
+            .navigationTitle(category.rawValue)
+            .navigationBarTitleDisplayMode(.inline)
         }
-        .navigationTitle(category.rawValue)
-        .navigationBarTitleDisplayMode(.inline)
     }
     
     private func queries(for category: PlatformQueriesView.QueryCategory) -> [QueryDefinition] {
@@ -221,6 +229,13 @@ struct QueryCategoryDetailView: View {
                 QueryDefinition(name: "getTotalCreditsInPlatform", label: "Get Total Credits in Platform", description: "Get total credits in the platform"),
                 QueryDefinition(name: "getCurrentQuorumsInfo", label: "Get Current Quorums Info", description: "Get information about current validator quorums"),
                 QueryDefinition(name: "getPrefundedSpecializedBalance", label: "Get Prefunded Specialized Balance", description: "Get balance of a prefunded specialized account")
+            ]
+            
+        case .addresses:
+            // Addresses use a dedicated view, but define queries for completeness
+            return [
+                QueryDefinition(name: "getAddressInfo", label: "Get Address Info", description: "Fetch balance and nonce for a single Platform address"),
+                QueryDefinition(name: "getAddressesInfos", label: "Get Addresses Infos", description: "Fetch balance and nonce for multiple Platform addresses")
             ]
             
         case .diagnostics:

--- a/packages/swift-sdk/build_ios.sh
+++ b/packages/swift-sdk/build_ios.sh
@@ -82,10 +82,19 @@ fi
 echo "3) Verifying Swift builds (if Xcode available)"
 if command -v xcodebuild >/dev/null 2>&1; then
   set +e
+  # Try to find an available iPhone simulator
+  SIMULATOR_ID=$(xcrun simctl list devices available | grep -i "iPhone" | grep -i "Shutdown\|Booted" | head -1 | sed -E 's/.*\(([A-F0-9-]+)\).*/\1/')
+  if [[ -z "$SIMULATOR_ID" ]]; then
+    # Fallback to generic destination
+    DESTINATION='platform=iOS Simulator,name=Any iOS Simulator Device'
+  else
+    DESTINATION="platform=iOS Simulator,id=$SIMULATOR_ID"
+  fi
+  
   xcodebuild -project "$SCRIPT_DIR/SwiftExampleApp/SwiftExampleApp.xcodeproj" \
              -scheme SwiftExampleApp \
              -sdk iphonesimulator \
-             -destination 'platform=iOS Simulator,name=iPhone 16' \
+             -destination "$DESTINATION" \
              -quiet build
   XC_STATUS=$?
   set -e


### PR DESCRIPTION
## Issue being fixed or feature implemented

This PR adds iOS support for the Dash Platform SDK, including:
- Fix for `bls-signatures` compilation on Apple Silicon (arm64)
- Fix for TLS certificate loading on iOS
- New FFI bindings for Platform address queries (`getAddressInfo`, `getAddressesInfos`)
- Swift SDK wrapper and example app UI for address queries

## What was done?

### iOS Build Fixes
- Enabled `apple` feature for `bls-signatures` in `rs-drive-abci/Cargo.toml` to fix arm64 compilation
- Modified `rs-dapi-client/src/transport/tonic_channel.rs` to conditionally compile native TLS root loading (not supported on iOS)
- Updated `swift-sdk/build_ios.sh` to dynamically find available iOS simulators

### Address Query FFI Implementation (`rs-sdk-ffi`)
- Added `DashSDKAddressInfo` and `DashSDKAddressInfoMap` C-compatible types in `types.rs`
- Implemented `dash_sdk_address_fetch_info()` for single address queries
- Implemented `dash_sdk_addresses_fetch_infos()` for batch address queries
- Added panic protection with `catch_unwind` for FFI safety
- Added memory management functions for proper cleanup

### Swift SDK Integration
- Created `PlatformAddressInfo` model with bech32m encoding support
- Created `Addresses` service class with convenience methods
- Integrated into main `SDK` class
- Added `AddressQueriesView` SwiftUI view with support for:
  - Single and batch address lookups
  - Auto-detection of address format (bech32m/hex)
  - Display of balance in both credits and DASH

## How Has This Been Tested?

- Built iOS XCFramework using `build_ios.sh`
- Tested address queries in SwiftExampleApp on iOS Simulator
- Verified bech32m address encoding/decoding
- Tested error handling and panic protection

## Breaking Changes

None

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [ ] I have made corresponding changes to the documentation if needed

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone