### PR TITLE
fix(platform): update grovedb dependency to allow for larger proof sizes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2483,7 +2483,7 @@ dependencies = [
 [[package]]
 name = "grovedb"
 version = "4.0.0"
-source = "git+https://github.com/dashpay/grovedb?rev=a7bc60a6760c395e90489c655eee84ae75003af4#a7bc60a6760c395e90489c655eee84ae75003af4"
+source = "git+https://github.com/dashpay/grovedb?rev=86562f65d9ec08bea28dc9981663cd2a63dc7f3b#86562f65d9ec08bea28dc9981663cd2a63dc7f3b"
 dependencies = [
  "axum 0.8.8",
  "bincode 2.0.0-rc.3",
@@ -2516,7 +2516,7 @@ dependencies = [
 [[package]]
 name = "grovedb-costs"
 version = "4.0.0"
-source = "git+https://github.com/dashpay/grovedb?rev=a7bc60a6760c395e90489c655eee84ae75003af4#a7bc60a6760c395e90489c655eee84ae75003af4"
+source = "git+https://github.com/dashpay/grovedb?rev=86562f65d9ec08bea28dc9981663cd2a63dc7f3b#86562f65d9ec08bea28dc9981663cd2a63dc7f3b"
 dependencies = [
  "integer-encoding",
  "intmap",
@@ -2526,7 +2526,7 @@ dependencies = [
 [[package]]
 name = "grovedb-element"
 version = "4.0.0"
-source = "git+https://github.com/dashpay/grovedb?rev=a7bc60a6760c395e90489c655eee84ae75003af4#a7bc60a6760c395e90489c655eee84ae75003af4"
+source = "git+https://github.com/dashpay/grovedb?rev=86562f65d9ec08bea28dc9981663cd2a63dc7f3b#86562f65d9ec08bea28dc9981663cd2a63dc7f3b"
 dependencies = [
  "bincode 2.0.0-rc.3",
  "bincode_derive",
@@ -2541,7 +2541,7 @@ dependencies = [
 [[package]]
 name = "grovedb-epoch-based-storage-flags"
 version = "4.0.0"
-source = "git+https://github.com/dashpay/grovedb?rev=a7bc60a6760c395e90489c655eee84ae75003af4#a7bc60a6760c395e90489c655eee84ae75003af4"
+source = "git+https://github.com/dashpay/grovedb?rev=86562f65d9ec08bea28dc9981663cd2a63dc7f3b#86562f65d9ec08bea28dc9981663cd2a63dc7f3b"
 dependencies = [
  "grovedb-costs",
  "hex",
@@ -2553,7 +2553,7 @@ dependencies = [
 [[package]]
 name = "grovedb-merk"
 version = "4.0.0"
-source = "git+https://github.com/dashpay/grovedb?rev=a7bc60a6760c395e90489c655eee84ae75003af4#a7bc60a6760c395e90489c655eee84ae75003af4"
+source = "git+https://github.com/dashpay/grovedb?rev=86562f65d9ec08bea28dc9981663cd2a63dc7f3b#86562f65d9ec08bea28dc9981663cd2a63dc7f3b"
 dependencies = [
  "bincode 2.0.0-rc.3",
  "bincode_derive",
@@ -2578,7 +2578,7 @@ dependencies = [
 [[package]]
 name = "grovedb-path"
 version = "4.0.0"
-source = "git+https://github.com/dashpay/grovedb?rev=a7bc60a6760c395e90489c655eee84ae75003af4#a7bc60a6760c395e90489c655eee84ae75003af4"
+source = "git+https://github.com/dashpay/grovedb?rev=86562f65d9ec08bea28dc9981663cd2a63dc7f3b#86562f65d9ec08bea28dc9981663cd2a63dc7f3b"
 dependencies = [
  "hex",
 ]
@@ -2586,7 +2586,7 @@ dependencies = [
 [[package]]
 name = "grovedb-storage"
 version = "4.0.0"
-source = "git+https://github.com/dashpay/grovedb?rev=a7bc60a6760c395e90489c655eee84ae75003af4#a7bc60a6760c395e90489c655eee84ae75003af4"
+source = "git+https://github.com/dashpay/grovedb?rev=86562f65d9ec08bea28dc9981663cd2a63dc7f3b#86562f65d9ec08bea28dc9981663cd2a63dc7f3b"
 dependencies = [
  "blake3",
  "grovedb-costs",
@@ -2605,7 +2605,7 @@ dependencies = [
 [[package]]
 name = "grovedb-version"
 version = "4.0.0"
-source = "git+https://github.com/dashpay/grovedb?rev=a7bc60a6760c395e90489c655eee84ae75003af4#a7bc60a6760c395e90489c655eee84ae75003af4"
+source = "git+https://github.com/dashpay/grovedb?rev=86562f65d9ec08bea28dc9981663cd2a63dc7f3b#86562f65d9ec08bea28dc9981663cd2a63dc7f3b"
 dependencies = [
  "thiserror 2.0.17",
  "versioned-feature-core 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2614,7 +2614,7 @@ dependencies = [
 [[package]]
 name = "grovedb-visualize"
 version = "4.0.0"
-source = "git+https://github.com/dashpay/grovedb?rev=a7bc60a6760c395e90489c655eee84ae75003af4#a7bc60a6760c395e90489c655eee84ae75003af4"
+source = "git+https://github.com/dashpay/grovedb?rev=86562f65d9ec08bea28dc9981663cd2a63dc7f3b#86562f65d9ec08bea28dc9981663cd2a63dc7f3b"
 dependencies = [
  "hex",
  "itertools 0.14.0",
@@ -2623,7 +2623,7 @@ dependencies = [
 [[package]]
 name = "grovedbg-types"
 version = "4.0.0"
-source = "git+https://github.com/dashpay/grovedb?rev=a7bc60a6760c395e90489c655eee84ae75003af4#a7bc60a6760c395e90489c655eee84ae75003af4"
+source = "git+https://github.com/dashpay/grovedb?rev=86562f65d9ec08bea28dc9981663cd2a63dc7f3b#86562f65d9ec08bea28dc9981663cd2a63dc7f3b"
 dependencies = [
  "serde",
  "serde_with 3.16.1",

--- a/packages/rs-drive-abci/src/abci/handler/prepare_proposal.rs
+++ b/packages/rs-drive-abci/src/abci/handler/prepare_proposal.rs
@@ -213,26 +213,10 @@ where
             // Such state transitions must be invalidated by check tx, but they might
             // still be added to mempool due to inconsistency between check tx and tx processing
             // (fees calculation) or malicious proposer.
-            StateTransitionExecutionResult::UnpaidConsensusError(consensus_error) => {
-                tracing::trace!(
-                    "UnpaidConsensusError at height {}, round {}: {:?}",
-                    request.height,
-                    request.round,
-                    consensus_error
-                );
-                TxAction::Removed
-            }
+            StateTransitionExecutionResult::UnpaidConsensusError(_) => TxAction::Removed,
             // We shouldn't include in the block any state transitions that produced an internal error
             // during execution
-            StateTransitionExecutionResult::InternalError(error_message) => {
-                tracing::debug!(
-                    "InternalError at height {}, round {}: {}",
-                    request.height,
-                    request.round,
-                    error_message
-                );
-                TxAction::Removed
-            }
+            StateTransitionExecutionResult::InternalError(_) => TxAction::Removed,
             // State Transition was not executed as it reached the maximum time limit
             StateTransitionExecutionResult::NotExecuted(..) => TxAction::Delayed,
         };

--- a/packages/rs-drive-abci/src/abci/handler/prepare_proposal.rs
+++ b/packages/rs-drive-abci/src/abci/handler/prepare_proposal.rs
@@ -213,9 +213,6 @@ where
             // Such state transitions must be invalidated by check tx, but they might
             // still be added to mempool due to inconsistency between check tx and tx processing
             // (fees calculation) or malicious proposer.
-            // Such state transitions must be invalidated by check tx, but they might
-            // still be added to mempool due to inconsistency between check tx and tx processing
-            // (fees calculation) or malicious proposer.
             StateTransitionExecutionResult::UnpaidConsensusError(consensus_error) => {
                 tracing::trace!(
                     "UnpaidConsensusError at height {}, round {}: {:?}",

--- a/packages/rs-drive-abci/src/abci/handler/prepare_proposal.rs
+++ b/packages/rs-drive-abci/src/abci/handler/prepare_proposal.rs
@@ -213,10 +213,29 @@ where
             // Such state transitions must be invalidated by check tx, but they might
             // still be added to mempool due to inconsistency between check tx and tx processing
             // (fees calculation) or malicious proposer.
-            StateTransitionExecutionResult::UnpaidConsensusError(_) => TxAction::Removed,
+            // Such state transitions must be invalidated by check tx, but they might
+            // still be added to mempool due to inconsistency between check tx and tx processing
+            // (fees calculation) or malicious proposer.
+            StateTransitionExecutionResult::UnpaidConsensusError(consensus_error) => {
+                tracing::trace!(
+                    "UnpaidConsensusError at height {}, round {}: {:?}",
+                    request.height,
+                    request.round,
+                    consensus_error
+                );
+                TxAction::Removed
+            }
             // We shouldn't include in the block any state transitions that produced an internal error
             // during execution
-            StateTransitionExecutionResult::InternalError(_) => TxAction::Removed,
+            StateTransitionExecutionResult::InternalError(error_message) => {
+                tracing::debug!(
+                    "InternalError at height {}, round {}: {}",
+                    request.height,
+                    request.round,
+                    error_message
+                );
+                TxAction::Removed
+            }
             // State Transition was not executed as it reached the maximum time limit
             StateTransitionExecutionResult::NotExecuted(..) => TxAction::Delayed,
         };

--- a/packages/rs-drive-abci/src/query/address_funds/recent_compacted_address_balance_changes/v0/mod.rs
+++ b/packages/rs-drive-abci/src/query/address_funds/recent_compacted_address_balance_changes/v0/mod.rs
@@ -28,8 +28,8 @@ impl<C> Platform<C> {
         platform_version: &PlatformVersion,
     ) -> Result<QueryValidationResult<GetRecentCompactedAddressBalanceChangesResponseV0>, Error>
     {
-        // Limit the number of compacted entries we return
-        let limit = Some(100u16);
+        // Limit the number of compacted entries we return (max 25 to stay within proof size limits)
+        let limit = Some(25u16);
 
         let response = if prove {
             let proof = self.drive.prove_compacted_address_balance_changes(

--- a/packages/rs-drive-abci/tests/strategy_tests/strategy.rs
+++ b/packages/rs-drive-abci/tests/strategy_tests/strategy.rs
@@ -295,6 +295,7 @@ pub struct NetworkStrategy {
     pub query_testing: Option<QueryStrategy>,
     pub verify_state_transition_results: bool,
     pub max_tx_bytes_per_block: u64,
+    pub max_addresses_to_choose_from_in_cache: Option<u32>,
     pub independent_process_proposal_verification: bool,
     pub sign_chain_locks: bool,
     pub sign_instant_locks: bool,
@@ -318,6 +319,7 @@ impl Default for NetworkStrategy {
             query_testing: None,
             verify_state_transition_results: false,
             max_tx_bytes_per_block: 44800,
+            max_addresses_to_choose_from_in_cache: Some(50),
             independent_process_proposal_verification: false,
             sign_chain_locks: false,
             sign_instant_locks: false,
@@ -1284,6 +1286,17 @@ impl NetworkStrategy {
                                 rng,
                                 platform_version,
                             ) else {
+                                tracing::debug!(
+                                    block_height = block_info.height,
+                                    ?amount_range,
+                                    available_to_spend = current_addresses_with_balance
+                                        .available_for_spending_count(),
+                                    max_available_balance =
+                                        current_addresses_with_balance.max_available_balance(),
+                                    committed = current_addresses_with_balance.committed_count(),
+                                    staged = current_addresses_with_balance.staged_count(),
+                                    "no funds for transfer"
+                                );
                                 // no funds left
                                 break;
                             };
@@ -2212,8 +2225,11 @@ impl NetworkStrategy {
             let output_amount = rng.gen_range(output_range.clone());
             let output_address = signer.add_random_address_key(rng);
             // Register the output address with balance
-            current_addresses_with_balance
-                .register_new_address(output_address.clone(), output_amount);
+            current_addresses_with_balance.register_new_address_keep_only_highest(
+                output_address.clone(),
+                output_amount,
+                self.max_addresses_to_choose_from_in_cache,
+            );
             (output_address, output_amount)
         });
 
@@ -2251,9 +2267,6 @@ impl NetworkStrategy {
         let inputs =
             current_addresses_with_balance.take_random_amounts_with_range(amount_range, rng)?;
 
-        let fee_strategy = fee_strategy
-            .clone()
-            .unwrap_or(vec![AddressFundsFeeStrategyStep::ReduceOutput(0)]);
         tracing::debug!(?inputs, "Preparing address funds transfer transition");
 
         // Calculate total input amount (we'll distribute this among outputs)
@@ -2261,6 +2274,15 @@ impl NetworkStrategy {
 
         // Generate random number of outputs within the specified range
         let output_count = rng.gen_range(output_count_range.clone()).max(1) as usize;
+
+        // Generate fee strategy: if not provided, reduce from outputs sequentially
+        // Limited to 4 steps due to max_address_fee_strategies platform constraint
+        let fee_strategy = fee_strategy.clone().unwrap_or_else(|| {
+            let max_steps = output_count.min(4);
+            (0..max_steps as u16)
+                .map(AddressFundsFeeStrategyStep::ReduceOutput)
+                .collect()
+        });
 
         // Create output addresses and distribute funds evenly
         let amount_per_output = total_input / output_count as Credits;
@@ -2406,9 +2428,11 @@ impl NetworkStrategy {
             );
 
         let address = signer.add_random_address_key(rng);
-        current_addresses_with_balance
-            .addresses_in_block_with_new_balance
-            .insert(address, (0, funded_amount));
+        current_addresses_with_balance.register_new_address_keep_only_highest(
+            address,
+            funded_amount,
+            self.max_addresses_to_choose_from_in_cache,
+        );
         let mut outputs = BTreeMap::new();
         outputs.insert(address.clone(), None);
 

--- a/packages/rs-drive-abci/tests/strategy_tests/test_cases/address_tests.rs
+++ b/packages/rs-drive-abci/tests/strategy_tests/test_cases/address_tests.rs
@@ -3508,4 +3508,208 @@ mod tests {
             }
         }
     }
+
+    /// Test for high-throughput address operations with many output addresses.
+    ///
+    /// This test verifies that:
+    /// 1. Funding operations correctly create addresses
+    /// 2. Transfer operations can use funded addresses and create many outputs
+    /// 3. The operation ordering (funding before transfers) works correctly
+    ///
+    /// Key insight: Each address can only be used ONCE per block (to avoid nonce conflicts).
+    /// Funding operations create new addresses in "staged" state. After block commit,
+    /// they become "committed" and available for transfers in subsequent blocks.
+    #[test]
+    fn run_chain_high_throughput_address_operations() {
+        drive_abci::logging::init_for_tests(LogLevel::Silent);
+
+        let strategy = NetworkStrategy {
+            strategy: Strategy {
+                start_contracts: vec![],
+                operations: vec![
+                    // IMPORTANT: Funding MUST come before transfers in the operations list!
+                    // Block N: funding creates addresses in staged -> committed at block end
+                    // Block N+1: transfers can use those committed addresses
+                    Operation {
+                        op_type: OperationType::AddressFundingFromCoreAssetLock(
+                            dash_to_credits!(100)..=dash_to_credits!(100), // 100 DASH to support 128 outputs
+                        ),
+                        frequency: Frequency {
+                            times_per_block_range: 19..20, // Fund 19 addresses per block
+                            chance_per_block: None,
+                        },
+                    },
+                    // Transfers with 128 outputs to generate many addresses
+                    // Transfer amount is TOTAL taken from input, divided among outputs
+                    // Need ~13 DASH to give each of 128 outputs ~0.1 DASH plus cover fees
+                    Operation {
+                        op_type: OperationType::AddressTransfer(
+                            dash_to_credits!(15)..=dash_to_credits!(15), // 15 DASH total for 128 outputs
+                            128..=128, // 128 output addresses per transfer
+                            None,      // Don't reuse existing addresses as outputs
+                            None,      // Use default fee strategy
+                        ),
+                        frequency: Frequency {
+                            times_per_block_range: 15..20, // 15-19 transfers per block
+                            chance_per_block: None,
+                        },
+                    },
+                ],
+                start_identities: StartIdentities::default(),
+                start_addresses: StartAddresses::default(),
+                identity_inserts: IdentityInsertInfo {
+                    frequency: Frequency {
+                        times_per_block_range: 5..10,
+                        chance_per_block: None,
+                    },
+                    ..Default::default()
+                },
+                identity_contract_nonce_gaps: None,
+                signer: None,
+            },
+            total_hpmns: 100,
+            extra_normal_mns: 0,
+            validator_quorum_count: 24,
+            chain_lock_quorum_count: 24,
+            upgrading_info: None,
+            proposer_strategy: Default::default(),
+            rotate_quorums: false,
+            failure_testing: None,
+            query_testing: None,
+            verify_state_transition_results: false,
+            sign_instant_locks: false,
+            max_tx_bytes_per_block: 500000, // Increase to allow large transfers
+            ..Default::default()
+        };
+
+        let config = PlatformConfig {
+            validator_set: ValidatorSetConfig::default_100_67(),
+            chain_lock: ChainLockConfig::default_100_67(),
+            instant_lock: InstantLockConfig::default_100_67(),
+            execution: ExecutionConfig {
+                verify_sum_trees: true,
+                ..Default::default()
+            },
+            block_spacing_ms: 1000,
+            testing_configs: PlatformTestConfig::default_minimal_verifications(),
+            ..Default::default()
+        };
+
+        let mut platform = TestPlatformBuilder::new()
+            .with_config(config.clone())
+            .build_with_mock_rpc();
+
+        let blocks_to_run = 5;
+
+        let outcome = run_chain_for_strategy(
+            &mut platform,
+            blocks_to_run,
+            strategy,
+            config,
+            15,
+            &mut None,
+            &mut None,
+        );
+
+        // Count executed operations by type
+        let mut funding_ops = 0;
+        let mut transfer_ops = 0;
+        let mut total_outputs = 0;
+        let mut total_failed = 0;
+
+        for (_block_height, results) in &outcome.state_transition_results_per_block {
+            for (state_transition, result) in results {
+                if result.code != 0 {
+                    total_failed += 1;
+                    continue;
+                }
+
+                match state_transition {
+                    StateTransition::AddressFundingFromAssetLock(_) => {
+                        funding_ops += 1;
+                    }
+                    StateTransition::AddressFundsTransfer(transfer) => {
+                        transfer_ops += 1;
+                        total_outputs += transfer.outputs().len();
+                    }
+                    _ => {}
+                }
+            }
+        }
+
+        // Verify exact counts (deterministic with fixed seed)
+        assert_eq!(funding_ops, 76, "expected 76 funding operations");
+        assert_eq!(transfer_ops, 47, "expected 47 transfer operations");
+        assert_eq!(total_outputs, 6016, "expected 6016 output addresses");
+        assert_eq!(total_failed, 0, "expected no failed operations");
+
+        // Verify final address state
+        assert_eq!(
+            outcome.addresses_with_balance.staged_count(),
+            0,
+            "expected no staged addresses at end"
+        );
+        assert_eq!(
+            outcome.addresses_with_balance.committed_count(),
+            6092,
+            "expected 6092 committed addresses"
+        );
+
+        // All committed addresses should have positive balance
+        let zero_balance_count = outcome
+            .addresses_with_balance
+            .addresses_with_balance
+            .iter()
+            .filter(|(_, (_, balance))| *balance == 0)
+            .count();
+        assert_eq!(zero_balance_count, 0, "expected no zero-balance addresses");
+
+        // Drop outcome to release platform references before querying
+        drop(outcome);
+
+        // Query for compacted address balance blobs
+        let platform_version = PlatformVersion::latest();
+        let platform_state = platform.platform.state.load();
+
+        let request = GetRecentCompactedAddressBalanceChangesRequest {
+            version: Some(CompactedChangesRequestVersion::V0(
+                GetRecentCompactedAddressBalanceChangesRequestV0 {
+                    start_block_height: 0,
+                    prove: false,
+                },
+            )),
+        };
+
+        let result = platform
+            .platform
+            .query_recent_compacted_address_balance_changes(
+                request,
+                &platform_state,
+                platform_version,
+            )
+            .expect("expected to query compacted blobs");
+
+        assert!(
+            result.errors.is_empty(),
+            "query errors: {:?}",
+            result.errors
+        );
+
+        let response = result.into_data().expect("expected response data");
+
+        let compacted_entries =
+            match response.version.expect("expected version") {
+                CompactedChangesResponseVersion::V0(v0) => {
+                    match v0.result.expect("expected result") {
+                    get_recent_compacted_address_balance_changes_response_v0::Result::CompactedAddressBalanceUpdateEntries(entries) => {
+                        entries.compacted_block_changes.len()
+                    }
+                    _ => panic!("expected entries, not proof"),
+                }
+                }
+            };
+
+        // With 6000+ addresses across 5 blocks, compaction triggers at 2048 addresses threshold
+        assert_eq!(compacted_entries, 2, "expected 2 compacted blobs");
+    }
 }

--- a/packages/rs-drive-abci/tests/strategy_tests/test_cases/address_tests.rs
+++ b/packages/rs-drive-abci/tests/strategy_tests/test_cases/address_tests.rs
@@ -3576,7 +3576,7 @@ mod tests {
             rotate_quorums: false,
             failure_testing: None,
             query_testing: None,
-            verify_state_transition_results: false,
+            verify_state_transition_results: true,
             sign_instant_locks: false,
             max_tx_bytes_per_block: 500000, // Increase to allow large transfers
             ..Default::default()

--- a/packages/rs-drive-abci/tests/strategy_tests/verify_state_transitions.rs
+++ b/packages/rs-drive-abci/tests/strategy_tests/verify_state_transitions.rs
@@ -196,6 +196,7 @@ fn assert_action_outputs_state(
     transition_outputs: &BTreeMap<PlatformAddress, Credits>,
     action_outputs: &BTreeMap<PlatformAddress, Credits>,
     proof_address_infos: &BTreeMap<PlatformAddress, Option<(AddressNonce, Credits)>>,
+    input_count: usize,
     context: &str,
 ) {
     assert_eq!(
@@ -203,6 +204,17 @@ fn assert_action_outputs_state(
         transition_outputs.len(),
         "{context}: action outputs length mismatch"
     );
+
+    let output_count = transition_outputs.len();
+
+    // Calculate expected max fee based on input/output counts
+    // From rs-platform-version: input_cost=500_000, output_cost=6_000_000
+    let input_cost: Credits = 500_000;
+    let output_cost: Credits = 6_000_000;
+    let expected_max_fee =
+        (input_count as Credits * input_cost) + (output_count as Credits * output_cost);
+    // Add 15% margin for additional processing/storage fees
+    let fee_with_margin = expected_max_fee + (expected_max_fee * 15 / 100);
 
     for (address, transition_balance) in transition_outputs {
         let Some(action_balance) = action_outputs.get(address) else {
@@ -219,16 +231,16 @@ fn assert_action_outputs_state(
             address
         );
 
-        // // we cannot be sure that the proof balance matches the action/transition balance here,
-        // // as it can also contain initial balance of the output.
-        // let fee_guesstimate = 100_000_000; // allow for some fee margin; TODO: confirm with Sam
-        // assert!(
-        //     *proof_balance >= *transition_balance - fee_guesstimate,
-        //     "{context}: proof balance {} should be >= transition balance {} minus fees {fee_guesstimate} for address {:?}",
-        //     proof_balance,
-        //     action_balance,
-        //     address
-        // );
+        // The proof balance may be lower than transition balance if fees were
+        // deducted from this output via ReduceOutput fee strategy
+        assert!(
+            *proof_balance >= transition_balance.saturating_sub(fee_with_margin),
+            "{context}: proof balance {} should be >= transition balance {} minus max fees {} for address {:?}",
+            proof_balance,
+            transition_balance,
+            fee_with_margin,
+            address
+        );
     }
 }
 
@@ -1274,6 +1286,7 @@ pub(crate) fn verify_state_transitions_were_or_were_not_executed(
                             address_funds_transfer_transition.outputs(),
                             address_funds_transfer_action.outputs(),
                             &proof_address_infos_map,
+                            address_funds_transfer_transition.inputs().len(),
                             "address funds transfer outputs",
                         );
                     } else {

--- a/packages/rs-drive-abci/tests/strategy_tests/verify_state_transitions.rs
+++ b/packages/rs-drive-abci/tests/strategy_tests/verify_state_transitions.rs
@@ -213,8 +213,8 @@ fn assert_action_outputs_state(
     let output_cost: Credits = 6_000_000;
     let expected_max_fee =
         (input_count as Credits * input_cost) + (output_count as Credits * output_cost);
-    // Add 15% margin for additional processing/storage fees
-    let fee_with_margin = expected_max_fee + (expected_max_fee * 15 / 100);
+    // Add 20% margin plus fixed buffer for additional processing/storage fees
+    let fee_with_margin = expected_max_fee + (expected_max_fee * 20 / 100) + 1_000_000;
 
     for (address, transition_balance) in transition_outputs {
         let Some(action_balance) = action_outputs.get(address) else {

--- a/packages/rs-drive-abci/tests/strategy_tests/verify_state_transitions.rs
+++ b/packages/rs-drive-abci/tests/strategy_tests/verify_state_transitions.rs
@@ -219,16 +219,16 @@ fn assert_action_outputs_state(
             address
         );
 
-        // we cannot be sure that the proof balance matches the action/transition balance here,
-        // as it can also contain initial balance of the output.
-        let fee_guesstimate = 100_000_000; // allow for some fee margin; TODO: confirm with Sam
-        assert!(
-            *proof_balance >= *transition_balance - fee_guesstimate,
-            "{context}: proof balance {} should be >= transition balance {} minus fees {fee_guesstimate} for address {:?}",
-            proof_balance,
-            action_balance,
-            address
-        );
+        // // we cannot be sure that the proof balance matches the action/transition balance here,
+        // // as it can also contain initial balance of the output.
+        // let fee_guesstimate = 100_000_000; // allow for some fee margin; TODO: confirm with Sam
+        // assert!(
+        //     *proof_balance >= *transition_balance - fee_guesstimate,
+        //     "{context}: proof balance {} should be >= transition balance {} minus fees {fee_guesstimate} for address {:?}",
+        //     proof_balance,
+        //     action_balance,
+        //     address
+        // );
     }
 }
 

--- a/packages/rs-drive/Cargo.toml
+++ b/packages/rs-drive/Cargo.toml
@@ -52,12 +52,12 @@ enum-map = { version = "2.0.3", optional = true }
 intmap = { version = "3.0.1", features = ["serde"], optional = true }
 chrono = { version = "0.4.35", optional = true }
 itertools = { version = "0.13", optional = true }
-grovedb = { git = "https://github.com/dashpay/grovedb", rev = "a7bc60a6760c395e90489c655eee84ae75003af4", optional = true, default-features = false }
-grovedb-costs = { git = "https://github.com/dashpay/grovedb", rev = "a7bc60a6760c395e90489c655eee84ae75003af4", optional = true }
-grovedb-path = { git = "https://github.com/dashpay/grovedb", rev = "a7bc60a6760c395e90489c655eee84ae75003af4" }
-grovedb-storage = { git = "https://github.com/dashpay/grovedb", rev = "a7bc60a6760c395e90489c655eee84ae75003af4", optional = true }
-grovedb-version = { git = "https://github.com/dashpay/grovedb", rev = "a7bc60a6760c395e90489c655eee84ae75003af4" }
-grovedb-epoch-based-storage-flags = { git = "https://github.com/dashpay/grovedb", rev = "a7bc60a6760c395e90489c655eee84ae75003af4" }
+grovedb = { git = "https://github.com/dashpay/grovedb", rev = "86562f65d9ec08bea28dc9981663cd2a63dc7f3b", optional = true, default-features = false }
+grovedb-costs = { git = "https://github.com/dashpay/grovedb", rev = "86562f65d9ec08bea28dc9981663cd2a63dc7f3b", optional = true }
+grovedb-path = { git = "https://github.com/dashpay/grovedb", rev = "86562f65d9ec08bea28dc9981663cd2a63dc7f3b" }
+grovedb-storage = { git = "https://github.com/dashpay/grovedb", rev = "86562f65d9ec08bea28dc9981663cd2a63dc7f3b", optional = true }
+grovedb-version = { git = "https://github.com/dashpay/grovedb", rev = "86562f65d9ec08bea28dc9981663cd2a63dc7f3b" }
+grovedb-epoch-based-storage-flags = { git = "https://github.com/dashpay/grovedb", rev = "86562f65d9ec08bea28dc9981663cd2a63dc7f3b" }
 
 [dev-dependencies]
 criterion = "0.5"

--- a/packages/rs-platform-version/Cargo.toml
+++ b/packages/rs-platform-version/Cargo.toml
@@ -11,7 +11,7 @@ license = "MIT"
 thiserror = { version = "2.0.12" }
 bincode = { version = "=2.0.0-rc.3" }
 versioned-feature-core = { git = "https://github.com/dashpay/versioned-feature-core", version = "1.0.0" }
-grovedb-version = { git = "https://github.com/dashpay/grovedb", rev = "a7bc60a6760c395e90489c655eee84ae75003af4" }
+grovedb-version = { git = "https://github.com/dashpay/grovedb", rev = "86562f65d9ec08bea28dc9981663cd2a63dc7f3b" }
 once_cell = "1.19.0"
 
 [features]

--- a/packages/strategy-tests/src/addresses_with_balance.rs
+++ b/packages/strategy-tests/src/addresses_with_balance.rs
@@ -76,6 +76,67 @@ impl AddressesWithBalance {
         }
     }
 
+    /// Returns the total balance across all tracked addresses.
+    ///
+    /// This sums the effective balance of each address (staged if present,
+    /// otherwise committed).
+    pub fn total_balance(&self) -> Credits {
+        let mut seen = std::collections::BTreeSet::new();
+        let mut total: Credits = 0;
+
+        // Sum staged balances
+        for (addr, (_, balance)) in &self.addresses_in_block_with_new_balance {
+            total = total.saturating_add(*balance);
+            seen.insert(addr);
+        }
+
+        // Sum committed balances for addresses not in staged
+        for (addr, (_, balance)) in &self.addresses_with_balance {
+            if !seen.contains(addr) {
+                total = total.saturating_add(*balance);
+            }
+        }
+
+        total
+    }
+
+    /// Returns the total balance of committed addresses only.
+    pub fn committed_balance(&self) -> Credits {
+        self.addresses_with_balance
+            .values()
+            .map(|(_, balance)| *balance)
+            .fold(0, |acc, b| acc.saturating_add(b))
+    }
+
+    /// Returns the number of committed addresses.
+    pub fn committed_count(&self) -> usize {
+        self.addresses_with_balance.len()
+    }
+
+    /// Returns the number of staged (in-block) addresses.
+    pub fn staged_count(&self) -> usize {
+        self.addresses_in_block_with_new_balance.len()
+    }
+
+    /// Returns the number of committed addresses available for spending
+    /// (not already used this block).
+    pub fn available_for_spending_count(&self) -> usize {
+        self.addresses_with_balance
+            .keys()
+            .filter(|addr| !self.addresses_in_block_with_new_balance.contains_key(*addr))
+            .count()
+    }
+
+    /// Returns the maximum balance among addresses available for spending.
+    pub fn max_available_balance(&self) -> Credits {
+        self.addresses_with_balance
+            .iter()
+            .filter(|(addr, _)| !self.addresses_in_block_with_new_balance.contains_key(*addr))
+            .map(|(_, (_, balance))| *balance)
+            .max()
+            .unwrap_or(0)
+    }
+
     /// Commits all staged (in-block) updates into the committed map.
     ///
     /// Call this after a block has been successfully processed. All addresses
@@ -428,6 +489,42 @@ impl AddressesWithBalance {
     pub fn register_new_address(&mut self, address: PlatformAddress, balance: Credits) {
         self.addresses_in_block_with_new_balance
             .insert(address, (0, balance));
+    }
+
+    /// Registers a new address and keeps only the top N addresses by balance.
+    ///
+    /// Use this when creating many addresses but you only want to track the highest
+    /// balance ones (e.g., for memory efficiency in stress tests).
+    ///
+    /// After inserting the new address, if the total count of staged addresses
+    /// exceeds `keep_top_n`, the lowest balance addresses are removed until
+    /// only `keep_top_n` remain.
+    ///
+    /// Note: This only affects the staged map (`addresses_in_block_with_new_balance`),
+    /// not the committed map.
+    pub fn register_new_address_keep_only_highest(
+        &mut self,
+        address: PlatformAddress,
+        balance: Credits,
+        keep_top_n: Option<u32>,
+    ) {
+        self.addresses_in_block_with_new_balance
+            .insert(address, (0, balance));
+
+        if let Some(keep_top_n) = keep_top_n {
+            // If we exceed the limit, keep only the top N by balance
+            if self.addresses_in_block_with_new_balance.len() > keep_top_n as usize {
+                // Take the map and sort by balance descending
+                let mut entries: Vec<_> = mem::take(&mut self.addresses_in_block_with_new_balance)
+                    .into_iter()
+                    .collect();
+                entries.sort_by(|a, b| b.1 .1.cmp(&a.1 .1)); // Sort by balance descending
+                entries.truncate(keep_top_n as usize);
+
+                // Rebuild the map with only top N
+                self.addresses_in_block_with_new_balance = entries.into_iter().collect();
+            }
+        }
     }
 
     /// Resets an address's nonce to a specific value, preserving its current balance.

--- a/packages/strategy-tests/src/lib.rs
+++ b/packages/strategy-tests/src/lib.rs
@@ -2201,6 +2201,7 @@ impl Strategy {
                             let Some(inputs) = current_addresses_with_balance
                                 .take_random_amounts_with_range(amount_range, rng)
                             else {
+                                eprintln!("no funds left on block {}", block_info.height);
                                 // no funds left
                                 break;
                             };


### PR DESCRIPTION
## Issue being fixed or feature implemented
Update the dependencies of the `grovedb` package to the latest commit. There was an issue with large values in proofs that is now fixed.

## What was done?
- Updated the `grovedb` and related dependencies in `Cargo.toml` from the previous commit hash `a7bc60a6760c395e90489c655eee84ae75003af4` to the new commit hash `86562f65d9ec08bea28dc9981663cd2a63dc7f3b`.

## How Has This Been Tested?
The changes were validated through existing unit and integration tests. We also added an extra strategy test.

## Breaking Changes
None

## Checklist
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests

  **For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Limited recent compacted address balance change query results to 25 entries to avoid oversized proofs.

* **New Features**
  * Added optional cache limit to keep only top-N addresses and new aggregated balance/count queries.

* **Tests**
  * Added high‑throughput address operation tests and updated fee/assertion checks; improved debug logging for no-funds conditions.

* **Chores**
  * Updated GroveDB-related dependencies to a single newer revision.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->