### PR TITLE
feat(swift-sdk): add v3 state transitions

### DIFF
--- a/packages/rs-sdk-ffi/src/address/mod.rs
+++ b/packages/rs-sdk-ffi/src/address/mod.rs
@@ -1,6 +1,10 @@
-//! Address query operations
+//! Address operations (queries and state transitions)
 
 pub mod queries;
+pub mod transitions;
 
 // Re-export query functions
 pub use queries::*;
+
+// Re-export transition functions
+pub use transitions::*;

--- a/packages/rs-sdk-ffi/src/address/transitions/mod.rs
+++ b/packages/rs-sdk-ffi/src/address/transitions/mod.rs
@@ -1,0 +1,17 @@
+//! Address state transition operations
+
+mod transfer;
+mod withdraw;
+mod top_up_from_asset_lock;
+
+// Re-export transfer function
+pub use transfer::dash_sdk_address_transfer_funds;
+
+// Re-export withdraw function
+pub use withdraw::dash_sdk_address_withdraw_funds;
+
+// Re-export top-up function
+pub use top_up_from_asset_lock::dash_sdk_address_top_up_from_asset_lock;
+
+// Re-export AddressSigner for use in other modules
+pub use transfer::AddressSigner;

--- a/packages/rs-sdk-ffi/src/address/transitions/top_up_from_asset_lock.rs
+++ b/packages/rs-sdk-ffi/src/address/transitions/top_up_from_asset_lock.rs
@@ -1,0 +1,312 @@
+//! Address top-up from asset lock state transition
+//!
+//! This module provides FFI functions to top up Platform addresses using asset lock proofs.
+
+use dash_sdk::dpp::address_funds::{AddressFundsFeeStrategy, AddressFundsFeeStrategyStep, PlatformAddress};
+use dash_sdk::dpp::dashcore::Network;
+use dash_sdk::dpp::dashcore::secp256k1::SecretKey;
+use dash_sdk::dpp::dashcore::PrivateKey;
+use dash_sdk::dpp::fee::Credits;
+use dash_sdk::dpp::identity::signer::Signer;
+use dash_sdk::dpp::prelude::AssetLockProof;
+use dash_sdk::platform::transition::top_up_address::TopUpAddress;
+use std::collections::BTreeMap;
+use std::panic::{self, AssertUnwindSafe};
+
+use crate::address::transitions::transfer::AddressSigner;
+use crate::identity::{
+    convert_put_settings, create_chain_asset_lock_proof, create_instant_asset_lock_proof,
+    parse_private_key,
+};
+use crate::sdk::SDKWrapper;
+use crate::types::{
+    DashSDKAddressInfoEntry, DashSDKAddressInfoMap, DashSDKAddressTransferOutput,
+    DashSDKPutSettings, SDKHandle,
+};
+use crate::{DashSDKError, DashSDKErrorCode, DashSDKResult, FFIError};
+
+/// Asset lock proof type
+#[repr(C)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DashSDKAssetLockProofType {
+    /// Instant lock proof
+    Instant = 0,
+    /// Chain lock proof
+    Chain = 1,
+}
+
+/// Top up Platform addresses using an asset lock proof
+///
+/// # Parameters
+/// - `sdk_handle`: SDK handle
+/// - `proof_type`: Type of asset lock proof (Instant or Chain)
+/// - For Instant: `instant_lock_bytes`, `instant_lock_len`, `transaction_bytes`, `transaction_len`, `output_index`
+/// - For Chain: `core_chain_locked_height`, `out_point_bytes` (36 bytes)
+/// - `asset_lock_private_key`: Private key for the asset lock (32 bytes)
+/// - `outputs`: Array of output addresses with optional amounts
+/// - `outputs_count`: Number of output entries
+/// - `fee_from_input_index`: Which input index to deduct fees from (0-based, max 65535)
+/// - `put_settings`: Optional settings for the operation (can be null for defaults)
+///
+/// # Returns
+/// DashSDKResult with data_type = AddressInfoMap containing updated address balances
+///
+/// # Safety
+/// - All pointers must be valid and non-null (except put_settings which can be null).
+/// - Arrays must contain at least the specified count of elements.
+/// - Private key must be exactly 32 bytes.
+/// - For Chain proof: out_point_bytes must be exactly 36 bytes.
+#[no_mangle]
+pub unsafe extern "C" fn dash_sdk_address_top_up_from_asset_lock(
+    sdk_handle: *const SDKHandle,
+    proof_type: DashSDKAssetLockProofType,
+    // Instant lock parameters
+    instant_lock_bytes: *const u8,
+    instant_lock_len: usize,
+    transaction_bytes: *const u8,
+    transaction_len: usize,
+    output_index: u32,
+    // Chain lock parameters
+    core_chain_locked_height: u32,
+    out_point_bytes: *const [u8; 36],
+    // Common parameters
+    asset_lock_private_key: *const [u8; 32],
+    outputs: *const DashSDKAddressTransferOutput,
+    outputs_count: usize,
+    fee_from_input_index: u16,
+    put_settings: *const DashSDKPutSettings,
+) -> DashSDKResult {
+    // Wrap in catch_unwind for panic safety
+    let result = panic::catch_unwind(AssertUnwindSafe(|| {
+        dash_sdk_address_top_up_from_asset_lock_inner(
+            sdk_handle,
+            proof_type,
+            instant_lock_bytes,
+            instant_lock_len,
+            transaction_bytes,
+            transaction_len,
+            output_index,
+            core_chain_locked_height,
+            out_point_bytes,
+            asset_lock_private_key,
+            outputs,
+            outputs_count,
+            fee_from_input_index,
+            put_settings,
+        )
+    }));
+
+    match result {
+        Ok(result) => result,
+        Err(panic_info) => {
+            let panic_message = if let Some(s) = panic_info.downcast_ref::<&str>() {
+                s.to_string()
+            } else if let Some(s) = panic_info.downcast_ref::<String>() {
+                s.clone()
+            } else {
+                "Unknown panic occurred during address top-up".to_string()
+            };
+            DashSDKResult::error(DashSDKError::new(
+                DashSDKErrorCode::InternalError,
+                format!("Panic during address top-up: {}", panic_message),
+            ))
+        }
+    }
+}
+
+unsafe fn dash_sdk_address_top_up_from_asset_lock_inner(
+    sdk_handle: *const SDKHandle,
+    proof_type: DashSDKAssetLockProofType,
+    instant_lock_bytes: *const u8,
+    instant_lock_len: usize,
+    transaction_bytes: *const u8,
+    transaction_len: usize,
+    output_index: u32,
+    core_chain_locked_height: u32,
+    out_point_bytes: *const [u8; 36],
+    asset_lock_private_key: *const [u8; 32],
+    outputs: *const DashSDKAddressTransferOutput,
+    outputs_count: usize,
+    fee_from_input_index: u16,
+    put_settings: *const DashSDKPutSettings,
+) -> DashSDKResult {
+    // Validate parameters
+    if sdk_handle.is_null() {
+        return DashSDKResult::error(DashSDKError::new(
+            DashSDKErrorCode::InvalidParameter,
+            "SDK handle is null".to_string(),
+        ));
+    }
+
+    if asset_lock_private_key.is_null() {
+        return DashSDKResult::error(DashSDKError::new(
+            DashSDKErrorCode::InvalidParameter,
+            "Asset lock private key is null".to_string(),
+        ));
+    }
+
+    if outputs.is_null() || outputs_count == 0 {
+        return DashSDKResult::error(DashSDKError::new(
+            DashSDKErrorCode::InvalidParameter,
+            "Outputs array is null or empty".to_string(),
+        ));
+    }
+
+    let wrapper = &*(sdk_handle as *const SDKWrapper);
+
+    // Create asset lock proof based on type
+    let asset_lock_proof = match proof_type {
+        DashSDKAssetLockProofType::Instant => {
+            if instant_lock_bytes.is_null() || transaction_bytes.is_null() {
+                return DashSDKResult::error(DashSDKError::new(
+                    DashSDKErrorCode::InvalidParameter,
+                    "Instant lock requires instant_lock_bytes and transaction_bytes".to_string(),
+                ));
+            }
+            match create_instant_asset_lock_proof(
+                instant_lock_bytes,
+                instant_lock_len,
+                transaction_bytes,
+                transaction_len,
+                output_index,
+            ) {
+                Ok(proof) => proof,
+                Err(e) => {
+                    return DashSDKResult::error(DashSDKError::new(
+                        DashSDKErrorCode::InvalidParameter,
+                        format!("Failed to create instant asset lock proof: {}", e),
+                    ))
+                }
+            }
+        }
+        DashSDKAssetLockProofType::Chain => {
+            if out_point_bytes.is_null() {
+                return DashSDKResult::error(DashSDKError::new(
+                    DashSDKErrorCode::InvalidParameter,
+                    "Chain lock requires out_point_bytes".to_string(),
+                ));
+            }
+            match create_chain_asset_lock_proof(core_chain_locked_height, out_point_bytes) {
+                Ok(proof) => proof,
+                Err(e) => {
+                    return DashSDKResult::error(DashSDKError::new(
+                        DashSDKErrorCode::InvalidParameter,
+                        format!("Failed to create chain asset lock proof: {}", e),
+                    ))
+                }
+            }
+        }
+    };
+
+    // Parse private key
+    let private_key = match parse_private_key(asset_lock_private_key) {
+        Ok(key) => key,
+        Err(e) => {
+            return DashSDKResult::error(DashSDKError::new(
+                DashSDKErrorCode::InvalidParameter,
+                format!("Failed to parse private key: {}", e),
+            ))
+        }
+    };
+
+    // Parse outputs
+    let mut output_map: BTreeMap<PlatformAddress, Option<Credits>> = BTreeMap::new();
+    let outputs_slice = std::slice::from_raw_parts(outputs, outputs_count);
+    for (i, output) in outputs_slice.iter().enumerate() {
+        if output.address.is_null() || output.address_len == 0 {
+            return DashSDKResult::error(DashSDKError::new(
+                DashSDKErrorCode::InvalidParameter,
+                format!("Output {} has null or empty address", i),
+            ));
+        }
+
+        let address_bytes = std::slice::from_raw_parts(output.address, output.address_len);
+        let address = match PlatformAddress::from_bytes(address_bytes) {
+            Ok(addr) => addr,
+            Err(e) => {
+                return DashSDKResult::error(DashSDKError::new(
+                    DashSDKErrorCode::InvalidParameter,
+                    format!("Failed to parse output address {}: {}", i, e),
+                ))
+            }
+        };
+
+        // Amount is optional (None means SDK will calculate)
+        let amount = if output.amount > 0 {
+            Some(output.amount)
+        } else {
+            None
+        };
+
+        output_map.insert(address, amount);
+    }
+
+    // Create fee strategy: deduct from input (index 0, since we have no inputs)
+    // For asset lock top-up, fees are typically deducted from the asset lock output
+    let fee_strategy: AddressFundsFeeStrategy =
+        vec![AddressFundsFeeStrategyStep::DeductFromInput(fee_from_input_index)];
+
+    // Create signer (empty since we don't have address inputs for asset lock top-up)
+    let signer = AddressSigner::new();
+
+    // Convert settings
+    let settings = convert_put_settings(put_settings);
+
+    // Execute the top-up
+    let result: Result<DashSDKAddressInfoMap, FFIError> = wrapper.runtime.block_on(async {
+        // Use TopUpAddress trait - we need to call it on the output map
+        let address_infos = output_map
+            .top_up(
+                &wrapper.sdk,
+                asset_lock_proof,
+                private_key,
+                fee_strategy,
+                &signer,
+                settings,
+            )
+            .await
+            .map_err(FFIError::from)?;
+
+        // Convert to FFI type (same as transfer)
+        let entries: Vec<DashSDKAddressInfoEntry> = address_infos
+            .iter()
+            .map(|(address, info_opt)| {
+                let address_bytes = address.to_bytes();
+                let address_len = address_bytes.len();
+                let address_ptr = address_bytes.as_ptr() as *mut u8;
+                std::mem::forget(address_bytes);
+
+                // Handle Option<AddressInfo>
+                let (nonce, balance) = match info_opt {
+                    Some(info) => (info.nonce, info.balance),
+                    None => (u32::MAX, u64::MAX), // Sentinel values for not found
+                };
+
+                DashSDKAddressInfoEntry {
+                    address: address_ptr,
+                    address_len,
+                    nonce,
+                    balance,
+                }
+            })
+            .collect();
+
+        let entries_len = entries.len();
+        let entries_ptr = if entries.is_empty() {
+            std::ptr::null_mut()
+        } else {
+            let boxed = entries.into_boxed_slice();
+            Box::into_raw(boxed) as *mut DashSDKAddressInfoEntry
+        };
+
+        Ok(DashSDKAddressInfoMap {
+            entries: entries_ptr,
+            count: entries_len,
+        })
+    });
+
+    match result {
+        Ok(map) => DashSDKResult::success_address_info_map(map),
+        Err(e) => DashSDKResult::error(e.into()),
+    }
+}

--- a/packages/rs-sdk-ffi/src/address/transitions/transfer.rs
+++ b/packages/rs-sdk-ffi/src/address/transitions/transfer.rs
@@ -1,0 +1,330 @@
+//! Address funds transfer state transition
+//!
+//! This module provides FFI functions to transfer funds between Platform addresses.
+
+use dash_sdk::dpp::address_funds::{AddressFundsFeeStrategy, AddressFundsFeeStrategyStep, PlatformAddress, AddressWitness};
+use dash_sdk::dpp::dashcore::secp256k1::SecretKey;
+use dash_sdk::dpp::dashcore::{PrivateKey, Network};
+use dash_sdk::dpp::fee::Credits;
+use dash_sdk::dpp::identity::signer::Signer;
+use dash_sdk::dpp::platform_value::BinaryData;
+use dash_sdk::dpp::ProtocolError;
+use dash_sdk::platform::transition::transfer_address_funds::TransferAddressFunds;
+use std::collections::BTreeMap;
+use std::panic::{self, AssertUnwindSafe};
+
+use crate::sdk::SDKWrapper;
+use crate::types::{
+    DashSDKAddressInfoEntry, DashSDKAddressInfoMap, DashSDKAddressTransferInput,
+    DashSDKAddressTransferOutput, SDKHandle,
+};
+use crate::{DashSDKError, DashSDKErrorCode, DashSDKResult, FFIError};
+
+/// Simple address signer that holds private keys for addresses
+#[derive(Debug)]
+pub struct AddressSigner {
+    /// Maps address hash to private key
+    keys: BTreeMap<[u8; 20], PrivateKey>,
+}
+
+impl AddressSigner {
+    pub fn new() -> Self {
+        Self {
+            keys: BTreeMap::new(),
+        }
+    }
+
+    pub fn add_key(&mut self, address: &PlatformAddress, private_key: PrivateKey) {
+        let hash = match address {
+            PlatformAddress::P2pkh(hash) => *hash,
+            PlatformAddress::P2sh(hash) => *hash,
+        };
+        self.keys.insert(hash, private_key);
+    }
+}
+
+impl Signer<PlatformAddress> for AddressSigner {
+    fn sign(&self, key: &PlatformAddress, data: &[u8]) -> Result<BinaryData, ProtocolError> {
+        let hash = match key {
+            PlatformAddress::P2pkh(hash) => hash,
+            PlatformAddress::P2sh(hash) => hash,
+        };
+
+        let private_key = self.keys.get(hash).ok_or_else(|| {
+            ProtocolError::Generic(format!(
+                "No private key found for address hash {}",
+                hex::encode(hash)
+            ))
+        })?;
+
+        // Sign the data using dashcore signer
+        let signature = dash_sdk::dpp::dashcore::signer::sign(data, private_key.inner.as_ref())
+            .map_err(|e| ProtocolError::Generic(format!("Signing failed: {}", e)))?;
+
+        Ok(BinaryData::new(signature.to_vec()))
+    }
+
+    fn sign_create_witness(
+        &self,
+        key: &PlatformAddress,
+        data: &[u8],
+    ) -> Result<AddressWitness, ProtocolError> {
+        let hash = match key {
+            PlatformAddress::P2pkh(hash) => hash,
+            PlatformAddress::P2sh(hash) => hash,
+        };
+
+        let private_key = self.keys.get(hash).ok_or_else(|| {
+            ProtocolError::Generic(format!(
+                "No private key found for address hash {}",
+                hex::encode(hash)
+            ))
+        })?;
+
+        // Sign the data
+        let signature = dash_sdk::dpp::dashcore::signer::sign(data, private_key.inner.as_ref())
+            .map_err(|e| ProtocolError::Generic(format!("Signing failed: {}", e)))?;
+
+        // Create P2PKH witness (most common for single key)
+        Ok(AddressWitness::P2pkh {
+            signature: BinaryData::new(signature.to_vec()),
+        })
+    }
+
+    fn can_sign_with(&self, key: &PlatformAddress) -> bool {
+        let hash = match key {
+            PlatformAddress::P2pkh(hash) => hash,
+            PlatformAddress::P2sh(hash) => hash,
+        };
+        self.keys.contains_key(hash)
+    }
+}
+
+/// Transfer funds between Platform addresses
+///
+/// # Parameters
+/// - `sdk_handle`: SDK handle
+/// - `inputs`: Array of input addresses with amounts and private keys
+/// - `inputs_count`: Number of input entries
+/// - `outputs`: Array of output addresses with amounts
+/// - `outputs_count`: Number of output entries
+/// - `fee_from_input_index`: Which input index to deduct fees from (0-based, max 65535)
+///
+/// # Returns
+/// DashSDKResult with data_type = AddressInfoMap containing updated address balances
+///
+/// # Safety
+/// - All pointers must be valid and non-null.
+/// - Arrays must contain at least the specified count of elements.
+/// - Private keys must be exactly 32 bytes.
+#[no_mangle]
+pub unsafe extern "C" fn dash_sdk_address_transfer_funds(
+    sdk_handle: *const SDKHandle,
+    inputs: *const DashSDKAddressTransferInput,
+    inputs_count: usize,
+    outputs: *const DashSDKAddressTransferOutput,
+    outputs_count: usize,
+    fee_from_input_index: u16,
+) -> DashSDKResult {
+    // Wrap in catch_unwind for panic safety
+    let result = panic::catch_unwind(AssertUnwindSafe(|| {
+        dash_sdk_address_transfer_funds_inner(
+            sdk_handle,
+            inputs,
+            inputs_count,
+            outputs,
+            outputs_count,
+            fee_from_input_index,
+        )
+    }));
+
+    match result {
+        Ok(result) => result,
+        Err(panic_info) => {
+            let panic_message = if let Some(s) = panic_info.downcast_ref::<&str>() {
+                s.to_string()
+            } else if let Some(s) = panic_info.downcast_ref::<String>() {
+                s.clone()
+            } else {
+                "Unknown panic occurred during address transfer".to_string()
+            };
+            DashSDKResult::error(DashSDKError::new(
+                DashSDKErrorCode::InternalError,
+                format!("Panic during address transfer: {}", panic_message),
+            ))
+        }
+    }
+}
+
+unsafe fn dash_sdk_address_transfer_funds_inner(
+    sdk_handle: *const SDKHandle,
+    inputs: *const DashSDKAddressTransferInput,
+    inputs_count: usize,
+    outputs: *const DashSDKAddressTransferOutput,
+    outputs_count: usize,
+    fee_from_input_index: u16,
+) -> DashSDKResult {
+    // Validate parameters
+    if sdk_handle.is_null() {
+        return DashSDKResult::error(DashSDKError::new(
+            DashSDKErrorCode::InvalidParameter,
+            "SDK handle is null".to_string(),
+        ));
+    }
+
+    if inputs.is_null() || inputs_count == 0 {
+        return DashSDKResult::error(DashSDKError::new(
+            DashSDKErrorCode::InvalidParameter,
+            "Inputs array is null or empty".to_string(),
+        ));
+    }
+
+    if outputs.is_null() || outputs_count == 0 {
+        return DashSDKResult::error(DashSDKError::new(
+            DashSDKErrorCode::InvalidParameter,
+            "Outputs array is null or empty".to_string(),
+        ));
+    }
+
+    if (fee_from_input_index as usize) >= inputs_count {
+        return DashSDKResult::error(DashSDKError::new(
+            DashSDKErrorCode::InvalidParameter,
+            format!(
+                "Fee input index {} is out of bounds (inputs count: {})",
+                fee_from_input_index, inputs_count
+            ),
+        ));
+    }
+
+    let wrapper = &*(sdk_handle as *const SDKWrapper);
+
+    // Parse inputs and create signer
+    let mut input_map: BTreeMap<PlatformAddress, Credits> = BTreeMap::new();
+    let mut signer = AddressSigner::new();
+
+    let inputs_slice = std::slice::from_raw_parts(inputs, inputs_count);
+    for (i, input) in inputs_slice.iter().enumerate() {
+        if input.address.is_null() || input.address_len == 0 {
+            return DashSDKResult::error(DashSDKError::new(
+                DashSDKErrorCode::InvalidParameter,
+                format!("Input {} has null or empty address", i),
+            ));
+        }
+
+        if input.private_key.is_null() {
+            return DashSDKResult::error(DashSDKError::new(
+                DashSDKErrorCode::InvalidParameter,
+                format!("Input {} has null private key", i),
+            ));
+        }
+
+        let address_bytes = std::slice::from_raw_parts(input.address, input.address_len);
+        let address = match PlatformAddress::from_bytes(address_bytes) {
+            Ok(addr) => addr,
+            Err(e) => {
+                return DashSDKResult::error(DashSDKError::new(
+                    DashSDKErrorCode::InvalidParameter,
+                    format!("Failed to parse input address {}: {}", i, e),
+                ))
+            }
+        };
+
+        // Parse private key (32 bytes)
+        let pk_bytes = std::slice::from_raw_parts(input.private_key, 32);
+        let secret_key = match SecretKey::from_slice(pk_bytes) {
+            Ok(sk) => sk,
+            Err(e) => {
+                return DashSDKResult::error(DashSDKError::new(
+                    DashSDKErrorCode::InvalidParameter,
+                    format!("Failed to parse private key for input {}: {}", i, e),
+                ))
+            }
+        };
+
+        // Create PrivateKey (network doesn't matter for signing)
+        let private_key = PrivateKey::new(secret_key, Network::Testnet);
+        
+        signer.add_key(&address, private_key);
+        input_map.insert(address, input.amount);
+    }
+
+    // Parse outputs
+    let mut output_map: BTreeMap<PlatformAddress, Credits> = BTreeMap::new();
+    let outputs_slice = std::slice::from_raw_parts(outputs, outputs_count);
+    for (i, output) in outputs_slice.iter().enumerate() {
+        if output.address.is_null() || output.address_len == 0 {
+            return DashSDKResult::error(DashSDKError::new(
+                DashSDKErrorCode::InvalidParameter,
+                format!("Output {} has null or empty address", i),
+            ));
+        }
+
+        let address_bytes = std::slice::from_raw_parts(output.address, output.address_len);
+        let address = match PlatformAddress::from_bytes(address_bytes) {
+            Ok(addr) => addr,
+            Err(e) => {
+                return DashSDKResult::error(DashSDKError::new(
+                    DashSDKErrorCode::InvalidParameter,
+                    format!("Failed to parse output address {}: {}", i, e),
+                ))
+            }
+        };
+
+        output_map.insert(address, output.amount);
+    }
+
+    // Create fee strategy: deduct from specified input
+    let fee_strategy: AddressFundsFeeStrategy =
+        vec![AddressFundsFeeStrategyStep::DeductFromInput(fee_from_input_index)];
+
+    // Execute the transfer
+    let result: Result<DashSDKAddressInfoMap, FFIError> = wrapper.runtime.block_on(async {
+        let address_infos = wrapper
+            .sdk
+            .transfer_address_funds(input_map, output_map, fee_strategy, &signer, None)
+            .await
+            .map_err(FFIError::from)?;
+
+        // Convert to FFI type
+        let entries: Vec<DashSDKAddressInfoEntry> = address_infos
+            .iter()
+            .map(|(address, info_opt)| {
+                let address_bytes = address.to_bytes();
+                let address_len = address_bytes.len();
+                let address_ptr = address_bytes.as_ptr() as *mut u8;
+                std::mem::forget(address_bytes);
+
+                // Handle Option<AddressInfo>
+                let (nonce, balance) = match info_opt {
+                    Some(info) => (info.nonce, info.balance),
+                    None => (u32::MAX, u64::MAX), // Sentinel values for not found
+                };
+
+                DashSDKAddressInfoEntry {
+                    address: address_ptr,
+                    address_len,
+                    nonce,
+                    balance,
+                }
+            })
+            .collect();
+
+        let entries_len = entries.len();
+        let entries_ptr = if entries.is_empty() {
+            std::ptr::null_mut()
+        } else {
+            let boxed = entries.into_boxed_slice();
+            Box::into_raw(boxed) as *mut DashSDKAddressInfoEntry
+        };
+
+        Ok(DashSDKAddressInfoMap {
+            entries: entries_ptr,
+            count: entries_len,
+        })
+    });
+
+    match result {
+        Ok(map) => DashSDKResult::success_address_info_map(map),
+        Err(e) => DashSDKResult::error(e.into()),
+    }
+}

--- a/packages/rs-sdk-ffi/src/address/transitions/withdraw.rs
+++ b/packages/rs-sdk-ffi/src/address/transitions/withdraw.rs
@@ -1,0 +1,315 @@
+//! Address credit withdrawal state transition
+//!
+//! This module provides FFI functions to withdraw credits from Platform addresses to Core (L1) addresses.
+
+use dash_sdk::dpp::address_funds::{AddressFundsFeeStrategy, AddressFundsFeeStrategyStep, PlatformAddress};
+use dash_sdk::dpp::dashcore::address::NetworkUnchecked;
+use dash_sdk::dpp::dashcore::{Address, Network};
+use dash_sdk::dpp::dashcore::secp256k1::SecretKey;
+use dash_sdk::dpp::dashcore::PrivateKey;
+use dash_sdk::dpp::fee::Credits;
+use dash_sdk::dpp::identity::core_script::CoreScript;
+use dash_sdk::dpp::withdrawal::Pooling;
+use dash_sdk::platform::transition::address_credit_withdrawal::WithdrawAddressFunds;
+use std::collections::BTreeMap;
+use std::ffi::CStr;
+use std::os::raw::c_char;
+use std::panic::{self, AssertUnwindSafe};
+use std::str::FromStr;
+
+use super::transfer::AddressSigner;
+use crate::sdk::SDKWrapper;
+use crate::types::{
+    DashSDKAddressInfoEntry, DashSDKAddressInfoMap, DashSDKAddressTransferInput, DashSDKPooling,
+    SDKHandle,
+};
+use crate::{DashSDKError, DashSDKErrorCode, DashSDKResult, FFIError};
+
+impl From<DashSDKPooling> for Pooling {
+    fn from(p: DashSDKPooling) -> Self {
+        match p {
+            DashSDKPooling::Never => Pooling::Never,
+            DashSDKPooling::IfAvailable => Pooling::IfAvailable,
+            DashSDKPooling::Standard => Pooling::Standard,
+        }
+    }
+}
+
+/// Withdraw credits from Platform addresses to a Core (L1) address
+///
+/// # Parameters
+/// - `sdk_handle`: SDK handle
+/// - `inputs`: Array of input addresses with amounts and private keys
+/// - `inputs_count`: Number of input entries
+/// - `core_address`: Base58-encoded Dash Core address to withdraw to (null-terminated C string)
+/// - `core_fee_per_byte`: Core network fee per byte (0 means use default)
+/// - `pooling`: Pooling strategy for the withdrawal
+/// - `fee_from_input_index`: Which input index to deduct fees from (0-based, max 65535)
+/// - `change_address`: Optional change address (Platform address bytes, null if not used)
+/// - `change_address_len`: Length of change address bytes (0 if not used)
+///
+/// # Returns
+/// DashSDKResult with data_type = AddressInfoMap containing updated address balances
+///
+/// # Safety
+/// - All pointers must be valid and non-null (except change_address which can be null).
+/// - Arrays must contain at least the specified count of elements.
+/// - Private keys must be exactly 32 bytes.
+/// - `core_address` must be a valid NUL-terminated C string.
+#[no_mangle]
+pub unsafe extern "C" fn dash_sdk_address_withdraw_funds(
+    sdk_handle: *const SDKHandle,
+    inputs: *const DashSDKAddressTransferInput,
+    inputs_count: usize,
+    core_address: *const c_char,
+    core_fee_per_byte: u32,
+    pooling: DashSDKPooling,
+    fee_from_input_index: u16,
+    change_address: *const u8,
+    change_address_len: usize,
+) -> DashSDKResult {
+    // Wrap in catch_unwind for panic safety
+    let result = panic::catch_unwind(AssertUnwindSafe(|| {
+        dash_sdk_address_withdraw_funds_inner(
+            sdk_handle,
+            inputs,
+            inputs_count,
+            core_address,
+            core_fee_per_byte,
+            pooling,
+            fee_from_input_index,
+            change_address,
+            change_address_len,
+        )
+    }));
+
+    match result {
+        Ok(result) => result,
+        Err(panic_info) => {
+            let panic_message = if let Some(s) = panic_info.downcast_ref::<&str>() {
+                s.to_string()
+            } else if let Some(s) = panic_info.downcast_ref::<String>() {
+                s.clone()
+            } else {
+                "Unknown panic occurred during address withdrawal".to_string()
+            };
+            DashSDKResult::error(DashSDKError::new(
+                DashSDKErrorCode::InternalError,
+                format!("Panic during address withdrawal: {}", panic_message),
+            ))
+        }
+    }
+}
+
+unsafe fn dash_sdk_address_withdraw_funds_inner(
+    sdk_handle: *const SDKHandle,
+    inputs: *const DashSDKAddressTransferInput,
+    inputs_count: usize,
+    core_address: *const c_char,
+    core_fee_per_byte: u32,
+    pooling: DashSDKPooling,
+    fee_from_input_index: u16,
+    change_address: *const u8,
+    change_address_len: usize,
+) -> DashSDKResult {
+    // Validate parameters
+    if sdk_handle.is_null() {
+        return DashSDKResult::error(DashSDKError::new(
+            DashSDKErrorCode::InvalidParameter,
+            "SDK handle is null".to_string(),
+        ));
+    }
+
+    if inputs.is_null() || inputs_count == 0 {
+        return DashSDKResult::error(DashSDKError::new(
+            DashSDKErrorCode::InvalidParameter,
+            "Inputs array is null or empty".to_string(),
+        ));
+    }
+
+    if core_address.is_null() {
+        return DashSDKResult::error(DashSDKError::new(
+            DashSDKErrorCode::InvalidParameter,
+            "Core address is null".to_string(),
+        ));
+    }
+
+    if (fee_from_input_index as usize) >= inputs_count {
+        return DashSDKResult::error(DashSDKError::new(
+            DashSDKErrorCode::InvalidParameter,
+            format!(
+                "Fee input index {} is out of bounds (inputs count: {})",
+                fee_from_input_index, inputs_count
+            ),
+        ));
+    }
+
+    let wrapper = &*(sdk_handle as *const SDKWrapper);
+
+    // Parse core address
+    let core_address_str = match CStr::from_ptr(core_address).to_str() {
+        Ok(s) => s,
+        Err(e) => {
+            return DashSDKResult::error(DashSDKError::new(
+                DashSDKErrorCode::InvalidParameter,
+                format!("Failed to parse core address C string: {}", e),
+            ))
+        }
+    };
+
+    let dash_address = match Address::<NetworkUnchecked>::from_str(core_address_str) {
+        Ok(addr) => addr.assume_checked(),
+        Err(e) => {
+            return DashSDKResult::error(DashSDKError::new(
+                DashSDKErrorCode::InvalidParameter,
+                format!("Invalid Dash Core address '{}': {}", core_address_str, e),
+            ))
+        }
+    };
+
+    // Create CoreScript from the address
+    let output_script = CoreScript::new(dash_address.script_pubkey());
+
+    // Parse inputs and create signer (same as transfer)
+    let mut input_map: BTreeMap<PlatformAddress, Credits> = BTreeMap::new();
+    let mut signer = AddressSigner::new();
+
+    let inputs_slice = std::slice::from_raw_parts(inputs, inputs_count);
+    for (i, input) in inputs_slice.iter().enumerate() {
+        if input.address.is_null() || input.address_len == 0 {
+            return DashSDKResult::error(DashSDKError::new(
+                DashSDKErrorCode::InvalidParameter,
+                format!("Input {} has null or empty address", i),
+            ));
+        }
+
+        if input.private_key.is_null() {
+            return DashSDKResult::error(DashSDKError::new(
+                DashSDKErrorCode::InvalidParameter,
+                format!("Input {} has null private key", i),
+            ));
+        }
+
+        let address_bytes = std::slice::from_raw_parts(input.address, input.address_len);
+        let address = match PlatformAddress::from_bytes(address_bytes) {
+            Ok(addr) => addr,
+            Err(e) => {
+                return DashSDKResult::error(DashSDKError::new(
+                    DashSDKErrorCode::InvalidParameter,
+                    format!("Failed to parse input address {}: {}", i, e),
+                ))
+            }
+        };
+
+        // Parse private key (32 bytes)
+        let pk_bytes = std::slice::from_raw_parts(input.private_key, 32);
+        let secret_key = match SecretKey::from_slice(pk_bytes) {
+            Ok(sk) => sk,
+            Err(e) => {
+                return DashSDKResult::error(DashSDKError::new(
+                    DashSDKErrorCode::InvalidParameter,
+                    format!("Failed to parse private key for input {}: {}", i, e),
+                ))
+            }
+        };
+
+        // Create PrivateKey (network doesn't matter for signing)
+        let private_key = PrivateKey::new(secret_key, Network::Testnet);
+
+        signer.add_key(&address, private_key);
+        input_map.insert(address, input.amount);
+    }
+
+    // Parse optional change address
+    let change_output: Option<(PlatformAddress, Credits)> = if !change_address.is_null()
+        && change_address_len > 0
+    {
+        let change_bytes = std::slice::from_raw_parts(change_address, change_address_len);
+        match PlatformAddress::from_bytes(change_bytes) {
+            Ok(addr) => {
+                // For change output, we don't know the amount upfront (it's calculated by the SDK)
+                // So we pass 0 and let the SDK calculate it
+                Some((addr, 0))
+            }
+            Err(e) => {
+                return DashSDKResult::error(DashSDKError::new(
+                    DashSDKErrorCode::InvalidParameter,
+                    format!("Failed to parse change address: {}", e),
+                ))
+            }
+        }
+    } else {
+        None
+    };
+
+    // Create fee strategy: deduct from specified input
+    let fee_strategy: AddressFundsFeeStrategy =
+        vec![AddressFundsFeeStrategyStep::DeductFromInput(fee_from_input_index)];
+
+    // Use default core fee if 0
+    let core_fee = if core_fee_per_byte > 0 {
+        core_fee_per_byte
+    } else {
+        1 // Default
+    };
+
+    // Execute the withdrawal
+    let result: Result<DashSDKAddressInfoMap, FFIError> = wrapper.runtime.block_on(async {
+        let address_infos = wrapper
+            .sdk
+            .withdraw_address_funds(
+                input_map,
+                change_output,
+                fee_strategy,
+                core_fee,
+                pooling.into(),
+                output_script,
+                &signer,
+                None,
+            )
+            .await
+            .map_err(FFIError::from)?;
+
+        // Convert to FFI type (same as transfer)
+        let entries: Vec<DashSDKAddressInfoEntry> = address_infos
+            .iter()
+            .map(|(address, info_opt)| {
+                let address_bytes = address.to_bytes();
+                let address_len = address_bytes.len();
+                let address_ptr = address_bytes.as_ptr() as *mut u8;
+                std::mem::forget(address_bytes);
+
+                // Handle Option<AddressInfo>
+                let (nonce, balance) = match info_opt {
+                    Some(info) => (info.nonce, info.balance),
+                    None => (u32::MAX, u64::MAX), // Sentinel values for not found
+                };
+
+                DashSDKAddressInfoEntry {
+                    address: address_ptr,
+                    address_len,
+                    nonce,
+                    balance,
+                }
+            })
+            .collect();
+
+        let entries_len = entries.len();
+        let entries_ptr = if entries.is_empty() {
+            std::ptr::null_mut()
+        } else {
+            let boxed = entries.into_boxed_slice();
+            Box::into_raw(boxed) as *mut DashSDKAddressInfoEntry
+        };
+
+        Ok(DashSDKAddressInfoMap {
+            entries: entries_ptr,
+            count: entries_len,
+        })
+    });
+
+    match result {
+        Ok(map) => DashSDKResult::success_address_info_map(map),
+        Err(e) => DashSDKResult::error(e.into()),
+    }
+}

--- a/packages/rs-sdk-ffi/src/identity/create_from_addresses.rs
+++ b/packages/rs-sdk-ffi/src/identity/create_from_addresses.rs
@@ -1,0 +1,311 @@
+//! Identity creation from addresses operations
+
+use dash_sdk::dpp::address_funds::{AddressFundsFeeStrategy, AddressFundsFeeStrategyStep, PlatformAddress};
+use dash_sdk::dpp::dashcore::secp256k1::SecretKey;
+use dash_sdk::dpp::dashcore::{Network, PrivateKey};
+use dash_sdk::dpp::fee::Credits;
+use dash_sdk::dpp::identity::signer::Signer;
+use dash_sdk::dpp::identity::{Identity, IdentityPublicKey};
+use dash_sdk::dpp::prelude::AddressNonce;
+use dash_sdk::platform::transition::put_identity::PutIdentity;
+use std::collections::BTreeMap;
+use std::panic::{self, AssertUnwindSafe};
+
+use crate::address::transitions::AddressSigner;
+use crate::identity::helpers::convert_put_settings;
+use crate::sdk::SDKWrapper;
+use crate::types::{
+    dash_sdk_address_info_map_free, DashSDKAddressInfoEntry, DashSDKAddressInfoMap,
+    DashSDKAddressTransferInput, DashSDKAddressTransferOutput, DashSDKPutSettings,
+    DashSDKResultDataType, IdentityHandle, SDKHandle,
+};
+use crate::{DashSDKError, DashSDKErrorCode, DashSDKResult, FFIError};
+
+/// Result for identity creation from addresses
+#[repr(C)]
+pub struct DashSDKIdentityCreateFromAddressesResult {
+    /// Created identity handle (must be freed separately)
+    pub identity_handle: *mut IdentityHandle,
+    /// Address info map
+    pub address_info_map: DashSDKAddressInfoMap,
+}
+
+/// Create an identity funded by Platform addresses
+///
+/// # Parameters
+/// - `sdk_handle`: SDK handle
+/// - `identity_handle`: Identity to create (must be prepared with public keys)
+/// - `inputs`: Array of input addresses with amounts, nonces, and private keys
+/// - `inputs_count`: Number of input entries
+/// - `output`: Optional output address with amount (for change)
+/// - `identity_signer_handle`: Cryptographic signer for identity
+/// - `put_settings`: Optional settings for the operation (can be null for defaults)
+///
+/// # Returns
+/// DashSDKResult with custom data type containing created identity handle and address infos
+///
+/// # Safety
+/// - All pointers must be valid and non-null (except put_settings and output which can be null).
+/// - Arrays must contain at least the specified count of elements.
+/// - Private keys must be exactly 32 bytes.
+#[no_mangle]
+pub unsafe extern "C" fn dash_sdk_identity_create_from_addresses(
+    sdk_handle: *const SDKHandle,
+    identity_handle: *const IdentityHandle,
+    inputs: *const DashSDKAddressTransferInput,
+    inputs_count: usize,
+    output: *const DashSDKAddressTransferOutput,
+    identity_signer_handle: *const crate::types::SignerHandle,
+    put_settings: *const DashSDKPutSettings,
+) -> DashSDKResult {
+    // Wrap in catch_unwind for panic safety
+    let result = panic::catch_unwind(AssertUnwindSafe(|| {
+        dash_sdk_identity_create_from_addresses_inner(
+            sdk_handle,
+            identity_handle,
+            inputs,
+            inputs_count,
+            output,
+            identity_signer_handle,
+            put_settings,
+        )
+    }));
+
+    match result {
+        Ok(result) => result,
+        Err(panic_info) => {
+            let panic_message = if let Some(s) = panic_info.downcast_ref::<&str>() {
+                s.to_string()
+            } else if let Some(s) = panic_info.downcast_ref::<String>() {
+                s.clone()
+            } else {
+                "Unknown panic occurred during identity creation from addresses".to_string()
+            };
+            DashSDKResult::error(DashSDKError::new(
+                DashSDKErrorCode::InternalError,
+                format!("Panic during identity creation from addresses: {}", panic_message),
+            ))
+        }
+    }
+}
+
+unsafe fn dash_sdk_identity_create_from_addresses_inner(
+    sdk_handle: *const SDKHandle,
+    identity_handle: *const IdentityHandle,
+    inputs: *const DashSDKAddressTransferInput,
+    inputs_count: usize,
+    output: *const DashSDKAddressTransferOutput,
+    identity_signer_handle: *const crate::types::SignerHandle,
+    put_settings: *const DashSDKPutSettings,
+) -> DashSDKResult {
+    // Validate parameters
+    if sdk_handle.is_null() {
+        return DashSDKResult::error(DashSDKError::new(
+            DashSDKErrorCode::InvalidParameter,
+            "SDK handle is null".to_string(),
+        ));
+    }
+
+    if identity_handle.is_null() {
+        return DashSDKResult::error(DashSDKError::new(
+            DashSDKErrorCode::InvalidParameter,
+            "Identity handle is null".to_string(),
+        ));
+    }
+
+    if inputs.is_null() || inputs_count == 0 {
+        return DashSDKResult::error(DashSDKError::new(
+            DashSDKErrorCode::InvalidParameter,
+            "Inputs array is null or empty".to_string(),
+        ));
+    }
+
+    if identity_signer_handle.is_null() {
+        return DashSDKResult::error(DashSDKError::new(
+            DashSDKErrorCode::InvalidParameter,
+            "Identity signer handle is null".to_string(),
+        ));
+    }
+
+    let wrapper = &*(sdk_handle as *const SDKWrapper);
+    let identity = &*(identity_handle as *const Identity);
+    let identity_signer = &*(identity_signer_handle as *const crate::signer::VTableSigner);
+
+    // Parse inputs and create address signer (same as address transfer)
+    let mut input_map: BTreeMap<PlatformAddress, (AddressNonce, Credits)> = BTreeMap::new();
+    let mut address_signer = AddressSigner::new();
+
+    let inputs_slice = std::slice::from_raw_parts(inputs, inputs_count);
+    for (i, input) in inputs_slice.iter().enumerate() {
+        if input.address.is_null() || input.address_len == 0 {
+            return DashSDKResult::error(DashSDKError::new(
+                DashSDKErrorCode::InvalidParameter,
+                format!("Input {} has null or empty address", i),
+            ));
+        }
+
+        if input.private_key.is_null() {
+            return DashSDKResult::error(DashSDKError::new(
+                DashSDKErrorCode::InvalidParameter,
+                format!("Input {} has null private key", i),
+            ));
+        }
+
+        let address_bytes = std::slice::from_raw_parts(input.address, input.address_len);
+        let address = match PlatformAddress::from_bytes(address_bytes) {
+            Ok(addr) => addr,
+            Err(e) => {
+                return DashSDKResult::error(DashSDKError::new(
+                    DashSDKErrorCode::InvalidParameter,
+                    format!("Failed to parse input address {}: {}", i, e),
+                ))
+            }
+        };
+
+        // Parse private key (32 bytes)
+        let pk_bytes = std::slice::from_raw_parts(input.private_key, 32);
+        let secret_key = match SecretKey::from_slice(pk_bytes) {
+            Ok(sk) => sk,
+            Err(e) => {
+                return DashSDKResult::error(DashSDKError::new(
+                    DashSDKErrorCode::InvalidParameter,
+                    format!("Failed to parse private key for input {}: {}", i, e),
+                ))
+            }
+        };
+
+        // Create PrivateKey (network doesn't matter for signing)
+        let private_key = PrivateKey::new(secret_key, Network::Testnet);
+
+        address_signer.add_key(&address, private_key);
+        // Use nonce from input, or fetch if 0
+        let nonce = if input.nonce == 0 {
+            // For now, we'll require nonce to be provided
+            // In a full implementation, we'd fetch it here
+            return DashSDKResult::error(DashSDKError::new(
+                DashSDKErrorCode::InvalidParameter,
+                format!("Input {} requires non-zero nonce (auto-fetch not yet implemented)", i),
+            ));
+        } else {
+            AddressNonce::from(input.nonce)
+        };
+        input_map.insert(address, (nonce, input.amount));
+    }
+
+    // Parse optional output
+    let output_option = if output.is_null() {
+        None
+    } else {
+        let out = &*output;
+        if out.address.is_null() || out.address_len == 0 {
+            return DashSDKResult::error(DashSDKError::new(
+                DashSDKErrorCode::InvalidParameter,
+                "Output address is null or empty".to_string(),
+            ));
+        }
+
+        let address_bytes = std::slice::from_raw_parts(out.address, out.address_len);
+        let address = match PlatformAddress::from_bytes(address_bytes) {
+            Ok(addr) => addr,
+            Err(e) => {
+                return DashSDKResult::error(DashSDKError::new(
+                    DashSDKErrorCode::InvalidParameter,
+                    format!("Failed to parse output address: {}", e),
+                ))
+            }
+        };
+
+        Some((address, out.amount))
+    };
+
+    // Convert settings
+    let settings = convert_put_settings(put_settings);
+
+    // Execute the creation
+    let result: Result<DashSDKIdentityCreateFromAddressesResult, FFIError> =
+        wrapper.runtime.block_on(async {
+            let (created_identity, address_infos) = identity
+                .put_with_address_funding(
+                    &wrapper.sdk,
+                    input_map,
+                    output_option,
+                    identity_signer,
+                    &address_signer,
+                    settings,
+                )
+                .await
+                .map_err(FFIError::from)?;
+
+            // Convert address infos to FFI type
+            let entries: Vec<DashSDKAddressInfoEntry> = address_infos
+                .iter()
+                .map(|(address, info_opt)| {
+                    let address_bytes = address.to_bytes();
+                    let address_len = address_bytes.len();
+                    let address_ptr = address_bytes.as_ptr() as *mut u8;
+                    std::mem::forget(address_bytes);
+
+                    // Handle Option<AddressInfo>
+                    let (nonce, balance) = match info_opt {
+                        Some(info) => (info.nonce, info.balance),
+                        None => (u32::MAX, u64::MAX), // Sentinel values for not found
+                    };
+
+                    DashSDKAddressInfoEntry {
+                        address: address_ptr,
+                        address_len,
+                        nonce,
+                        balance,
+                    }
+                })
+                .collect();
+
+            let entries_len = entries.len();
+            let entries_ptr = if entries.is_empty() {
+                std::ptr::null_mut()
+            } else {
+                let boxed = entries.into_boxed_slice();
+                Box::into_raw(boxed) as *mut DashSDKAddressInfoEntry
+            };
+
+            // Box the created identity to create a handle
+            let identity_handle = Box::into_raw(Box::new(created_identity)) as *mut IdentityHandle;
+
+            Ok(DashSDKIdentityCreateFromAddressesResult {
+                identity_handle,
+                address_info_map: DashSDKAddressInfoMap {
+                    entries: entries_ptr,
+                    count: entries_len,
+                },
+            })
+        });
+
+    match result {
+        Ok(create_result) => {
+            let boxed = Box::new(create_result);
+            DashSDKResult {
+                data_type: DashSDKResultDataType::IdentityCreateFromAddressesResult,
+                data: Box::into_raw(boxed) as *mut std::os::raw::c_void,
+                error: std::ptr::null_mut(),
+            }
+        }
+        Err(e) => DashSDKResult::error(e.into()),
+    }
+}
+
+/// Free the result from identity creation from addresses
+///
+/// # Safety
+/// - `result` must be a valid pointer returned by `dash_sdk_identity_create_from_addresses` and not previously freed.
+/// - The identity handle inside the result must be freed separately using `dash_sdk_identity_destroy`.
+#[no_mangle]
+pub unsafe extern "C" fn dash_sdk_identity_create_from_addresses_result_free(
+    result: *mut DashSDKIdentityCreateFromAddressesResult,
+) {
+    if !result.is_null() {
+        let result = Box::from_raw(result);
+        // Free the address info map using the function from types.rs
+        dash_sdk_address_info_map_free(&result.address_info_map as *const _ as *mut _);
+        // Note: identity_handle must be freed separately by the caller using dash_sdk_identity_destroy
+    }
+}

--- a/packages/rs-sdk-ffi/src/identity/mod.rs
+++ b/packages/rs-sdk-ffi/src/identity/mod.rs
@@ -1,6 +1,7 @@
 //! Identity operations
 
 mod create;
+mod create_from_addresses;
 mod create_from_components;
 mod get_public_key;
 mod helpers;
@@ -12,7 +13,9 @@ mod put;
 mod queries;
 mod test_transfer;
 mod topup;
+mod top_up_from_addresses;
 mod transfer;
+mod transfer_to_addresses;
 mod withdraw;
 
 // Re-export all public functions for convenient access
@@ -35,6 +38,21 @@ pub use put::{
 pub use test_transfer::dash_sdk_test_identity_transfer_crash;
 pub use topup::{
     dash_sdk_identity_topup_with_instant_lock, dash_sdk_identity_topup_with_instant_lock_and_wait,
+};
+pub use top_up_from_addresses::{
+    dash_sdk_identity_top_up_from_addresses,
+    dash_sdk_identity_top_up_from_addresses_result_free,
+    DashSDKIdentityTopUpFromAddressesResult,
+};
+pub use transfer_to_addresses::{
+    dash_sdk_identity_transfer_credits_to_addresses,
+    dash_sdk_identity_transfer_to_addresses_result_free,
+    DashSDKIdentityTransferToAddressesResult,
+};
+pub use create_from_addresses::{
+    dash_sdk_identity_create_from_addresses,
+    dash_sdk_identity_create_from_addresses_result_free,
+    DashSDKIdentityCreateFromAddressesResult,
 };
 pub use transfer::{
     dash_sdk_identity_transfer_credits, dash_sdk_transfer_credits_result_free,

--- a/packages/rs-sdk-ffi/src/identity/top_up_from_addresses.rs
+++ b/packages/rs-sdk-ffi/src/identity/top_up_from_addresses.rs
@@ -1,0 +1,244 @@
+//! Identity top-up from addresses operations
+
+use dash_sdk::dpp::address_funds::PlatformAddress;
+use dash_sdk::dpp::dashcore::Network;
+use dash_sdk::dpp::dashcore::secp256k1::SecretKey;
+use dash_sdk::dpp::dashcore::PrivateKey;
+use dash_sdk::dpp::fee::Credits;
+use dash_sdk::dpp::prelude::Identity;
+use dash_sdk::platform::transition::top_up_identity_from_addresses::TopUpIdentityFromAddresses;
+use std::collections::BTreeMap;
+use std::panic::{self, AssertUnwindSafe};
+
+use crate::address::transitions::AddressSigner;
+use crate::identity::helpers::convert_put_settings;
+use crate::sdk::SDKWrapper;
+use crate::types::{
+    dash_sdk_address_info_map_free, DashSDKAddressInfoEntry, DashSDKAddressInfoMap,
+    DashSDKAddressTransferInput, DashSDKPutSettings, DashSDKResultDataType, IdentityHandle,
+    SDKHandle,
+};
+use crate::{DashSDKError, DashSDKErrorCode, DashSDKResult, FFIError};
+
+/// Result for identity top-up from addresses
+#[repr(C)]
+pub struct DashSDKIdentityTopUpFromAddressesResult {
+    /// Updated identity balance
+    pub identity_balance: u64,
+    /// Address info map
+    pub address_info_map: DashSDKAddressInfoMap,
+}
+
+/// Top up an identity using Platform address balances
+///
+/// # Parameters
+/// - `sdk_handle`: SDK handle
+/// - `identity_handle`: Identity to top up
+/// - `inputs`: Array of input addresses with amounts and private keys
+/// - `inputs_count`: Number of input entries
+///
+/// # Returns
+/// DashSDKResult with custom data type containing identity balance and address infos
+///
+/// # Safety
+/// - All pointers must be valid and non-null (except put_settings which can be null).
+/// - Arrays must contain at least the specified count of elements.
+/// - Private keys must be exactly 32 bytes.
+#[no_mangle]
+pub unsafe extern "C" fn dash_sdk_identity_top_up_from_addresses(
+    sdk_handle: *const SDKHandle,
+    identity_handle: *const IdentityHandle,
+    inputs: *const DashSDKAddressTransferInput,
+    inputs_count: usize,
+    put_settings: *const DashSDKPutSettings,
+) -> DashSDKResult {
+    // Wrap in catch_unwind for panic safety
+    let result = panic::catch_unwind(AssertUnwindSafe(|| {
+        dash_sdk_identity_top_up_from_addresses_inner(
+            sdk_handle,
+            identity_handle,
+            inputs,
+            inputs_count,
+            put_settings,
+        )
+    }));
+
+    match result {
+        Ok(result) => result,
+        Err(panic_info) => {
+            let panic_message = if let Some(s) = panic_info.downcast_ref::<&str>() {
+                s.to_string()
+            } else if let Some(s) = panic_info.downcast_ref::<String>() {
+                s.clone()
+            } else {
+                "Unknown panic occurred during identity top-up from addresses".to_string()
+            };
+            DashSDKResult::error(DashSDKError::new(
+                DashSDKErrorCode::InternalError,
+                format!("Panic during identity top-up from addresses: {}", panic_message),
+            ))
+        }
+    }
+}
+
+unsafe fn dash_sdk_identity_top_up_from_addresses_inner(
+    sdk_handle: *const SDKHandle,
+    identity_handle: *const IdentityHandle,
+    inputs: *const DashSDKAddressTransferInput,
+    inputs_count: usize,
+    put_settings: *const DashSDKPutSettings,
+) -> DashSDKResult {
+    // Validate parameters
+    if sdk_handle.is_null() {
+        return DashSDKResult::error(DashSDKError::new(
+            DashSDKErrorCode::InvalidParameter,
+            "SDK handle is null".to_string(),
+        ));
+    }
+
+    if identity_handle.is_null() {
+        return DashSDKResult::error(DashSDKError::new(
+            DashSDKErrorCode::InvalidParameter,
+            "Identity handle is null".to_string(),
+        ));
+    }
+
+    if inputs.is_null() || inputs_count == 0 {
+        return DashSDKResult::error(DashSDKError::new(
+            DashSDKErrorCode::InvalidParameter,
+            "Inputs array is null or empty".to_string(),
+        ));
+    }
+
+    let wrapper = &*(sdk_handle as *const SDKWrapper);
+    let identity = &*(identity_handle as *const Identity);
+
+    // Parse inputs and create signer (same as address transfer)
+    let mut input_map: BTreeMap<PlatformAddress, Credits> = BTreeMap::new();
+    let mut signer = AddressSigner::new();
+
+    let inputs_slice = std::slice::from_raw_parts(inputs, inputs_count);
+    for (i, input) in inputs_slice.iter().enumerate() {
+        if input.address.is_null() || input.address_len == 0 {
+            return DashSDKResult::error(DashSDKError::new(
+                DashSDKErrorCode::InvalidParameter,
+                format!("Input {} has null or empty address", i),
+            ));
+        }
+
+        if input.private_key.is_null() {
+            return DashSDKResult::error(DashSDKError::new(
+                DashSDKErrorCode::InvalidParameter,
+                format!("Input {} has null private key", i),
+            ));
+        }
+
+        let address_bytes = std::slice::from_raw_parts(input.address, input.address_len);
+        let address = match PlatformAddress::from_bytes(address_bytes) {
+            Ok(addr) => addr,
+            Err(e) => {
+                return DashSDKResult::error(DashSDKError::new(
+                    DashSDKErrorCode::InvalidParameter,
+                    format!("Failed to parse input address {}: {}", i, e),
+                ))
+            }
+        };
+
+        // Parse private key (32 bytes)
+        let pk_bytes = std::slice::from_raw_parts(input.private_key, 32);
+        let secret_key = match SecretKey::from_slice(pk_bytes) {
+            Ok(sk) => sk,
+            Err(e) => {
+                return DashSDKResult::error(DashSDKError::new(
+                    DashSDKErrorCode::InvalidParameter,
+                    format!("Failed to parse private key for input {}: {}", i, e),
+                ))
+            }
+        };
+
+        // Create PrivateKey (network doesn't matter for signing)
+        let private_key = PrivateKey::new(secret_key, Network::Testnet);
+
+        signer.add_key(&address, private_key);
+        input_map.insert(address, input.amount);
+    }
+
+    // Convert settings
+    let settings = convert_put_settings(put_settings);
+
+    // Execute the top-up
+    let result: Result<DashSDKIdentityTopUpFromAddressesResult, FFIError> =
+        wrapper.runtime.block_on(async {
+            let (address_infos, identity_balance) = identity
+                .top_up_from_addresses(&wrapper.sdk, input_map, &signer, settings)
+                .await
+                .map_err(FFIError::from)?;
+
+            // Convert address infos to FFI type
+            let entries: Vec<DashSDKAddressInfoEntry> = address_infos
+                .iter()
+                .map(|(address, info_opt)| {
+                    let address_bytes = address.to_bytes();
+                    let address_len = address_bytes.len();
+                    let address_ptr = address_bytes.as_ptr() as *mut u8;
+                    std::mem::forget(address_bytes);
+
+                    // Handle Option<AddressInfo>
+                    let (nonce, balance) = match info_opt {
+                        Some(info) => (info.nonce, info.balance),
+                        None => (u32::MAX, u64::MAX), // Sentinel values for not found
+                    };
+
+                    DashSDKAddressInfoEntry {
+                        address: address_ptr,
+                        address_len,
+                        nonce,
+                        balance,
+                    }
+                })
+                .collect();
+
+            let entries_len = entries.len();
+            let entries_ptr = if entries.is_empty() {
+                std::ptr::null_mut()
+            } else {
+                let boxed = entries.into_boxed_slice();
+                Box::into_raw(boxed) as *mut DashSDKAddressInfoEntry
+            };
+
+            Ok(DashSDKIdentityTopUpFromAddressesResult {
+                identity_balance,
+                address_info_map: DashSDKAddressInfoMap {
+                    entries: entries_ptr,
+                    count: entries_len,
+                },
+            })
+        });
+
+    match result {
+        Ok(top_up_result) => {
+            let boxed = Box::new(top_up_result);
+            DashSDKResult {
+                data_type: DashSDKResultDataType::IdentityTopUpFromAddressesResult,
+                data: Box::into_raw(boxed) as *mut std::os::raw::c_void,
+                error: std::ptr::null_mut(),
+            }
+        }
+        Err(e) => DashSDKResult::error(e.into()),
+    }
+}
+
+/// Free the result from identity top-up from addresses
+///
+/// # Safety
+/// - `result` must be a valid pointer returned by `dash_sdk_identity_top_up_from_addresses` and not previously freed.
+#[no_mangle]
+pub unsafe extern "C" fn dash_sdk_identity_top_up_from_addresses_result_free(
+    result: *mut DashSDKIdentityTopUpFromAddressesResult,
+) {
+    if !result.is_null() {
+        let result = Box::from_raw(result);
+        // Free the address info map using the function from types.rs
+        dash_sdk_address_info_map_free(&result.address_info_map as *const _ as *mut _);
+    }
+}

--- a/packages/rs-sdk-ffi/src/identity/transfer_to_addresses.rs
+++ b/packages/rs-sdk-ffi/src/identity/transfer_to_addresses.rs
@@ -1,0 +1,261 @@
+//! Identity credit transfer to addresses operations
+
+use dash_sdk::dpp::address_funds::PlatformAddress;
+use dash_sdk::dpp::fee::Credits;
+use dash_sdk::dpp::identity::accessors::IdentityGettersV0;
+use dash_sdk::dpp::identity::signer::Signer;
+use dash_sdk::dpp::identity::{Identity, IdentityPublicKey};
+use dash_sdk::dpp::platform_value::string_encoding::Encoding;
+use dash_sdk::dpp::prelude::Identifier;
+use dash_sdk::platform::transition::transfer_to_addresses::TransferToAddresses;
+use std::collections::BTreeMap;
+use std::panic::{self, AssertUnwindSafe};
+
+use crate::identity::helpers::convert_put_settings;
+use crate::sdk::SDKWrapper;
+use crate::types::{
+    dash_sdk_address_info_map_free, DashSDKAddressInfoEntry, DashSDKAddressInfoMap,
+    DashSDKAddressTransferOutput, DashSDKPutSettings, DashSDKResultDataType, IdentityHandle,
+    SDKHandle,
+};
+use crate::{DashSDKError, DashSDKErrorCode, DashSDKResult, FFIError};
+
+/// Result for identity transfer to addresses
+#[repr(C)]
+pub struct DashSDKIdentityTransferToAddressesResult {
+    /// Updated identity balance
+    pub identity_balance: u64,
+    /// Address info map
+    pub address_info_map: DashSDKAddressInfoMap,
+}
+
+/// Transfer credits from an identity to Platform addresses
+///
+/// # Parameters
+/// - `sdk_handle`: SDK handle
+/// - `identity_handle`: Identity to transfer from
+/// - `outputs`: Array of output addresses with amounts
+/// - `outputs_count`: Number of output entries
+/// - `public_key_id`: ID of the public key to use for signing (0 = auto-select TRANSFER key)
+/// - `signer_handle`: Cryptographic signer for identity
+/// - `put_settings`: Optional settings for the operation (can be null for defaults)
+///
+/// # Returns
+/// DashSDKResult with custom data type containing identity balance and address infos
+///
+/// # Safety
+/// - All pointers must be valid and non-null (except put_settings which can be null).
+/// - Arrays must contain at least the specified count of elements.
+#[no_mangle]
+pub unsafe extern "C" fn dash_sdk_identity_transfer_credits_to_addresses(
+    sdk_handle: *const SDKHandle,
+    identity_handle: *const IdentityHandle,
+    outputs: *const DashSDKAddressTransferOutput,
+    outputs_count: usize,
+    public_key_id: u32,
+    signer_handle: *const crate::types::SignerHandle,
+    put_settings: *const DashSDKPutSettings,
+) -> DashSDKResult {
+    // Wrap in catch_unwind for panic safety
+    let result = panic::catch_unwind(AssertUnwindSafe(|| {
+        dash_sdk_identity_transfer_credits_to_addresses_inner(
+            sdk_handle,
+            identity_handle,
+            outputs,
+            outputs_count,
+            public_key_id,
+            signer_handle,
+            put_settings,
+        )
+    }));
+
+    match result {
+        Ok(result) => result,
+        Err(panic_info) => {
+            let panic_message = if let Some(s) = panic_info.downcast_ref::<&str>() {
+                s.to_string()
+            } else if let Some(s) = panic_info.downcast_ref::<String>() {
+                s.clone()
+            } else {
+                "Unknown panic occurred during identity transfer to addresses".to_string()
+            };
+            DashSDKResult::error(DashSDKError::new(
+                DashSDKErrorCode::InternalError,
+                format!("Panic during identity transfer to addresses: {}", panic_message),
+            ))
+        }
+    }
+}
+
+unsafe fn dash_sdk_identity_transfer_credits_to_addresses_inner(
+    sdk_handle: *const SDKHandle,
+    identity_handle: *const IdentityHandle,
+    outputs: *const DashSDKAddressTransferOutput,
+    outputs_count: usize,
+    public_key_id: u32,
+    signer_handle: *const crate::types::SignerHandle,
+    put_settings: *const DashSDKPutSettings,
+) -> DashSDKResult {
+    // Validate parameters
+    if sdk_handle.is_null() {
+        return DashSDKResult::error(DashSDKError::new(
+            DashSDKErrorCode::InvalidParameter,
+            "SDK handle is null".to_string(),
+        ));
+    }
+
+    if identity_handle.is_null() {
+        return DashSDKResult::error(DashSDKError::new(
+            DashSDKErrorCode::InvalidParameter,
+            "Identity handle is null".to_string(),
+        ));
+    }
+
+    if outputs.is_null() || outputs_count == 0 {
+        return DashSDKResult::error(DashSDKError::new(
+            DashSDKErrorCode::InvalidParameter,
+            "Outputs array is null or empty".to_string(),
+        ));
+    }
+
+    if signer_handle.is_null() {
+        return DashSDKResult::error(DashSDKError::new(
+            DashSDKErrorCode::InvalidParameter,
+            "Signer handle is null".to_string(),
+        ));
+    }
+
+    let wrapper = &*(sdk_handle as *const SDKWrapper);
+    let identity = &*(identity_handle as *const Identity);
+    let signer = &*(signer_handle as *const crate::signer::VTableSigner);
+
+    // Parse outputs
+    let mut recipient_map: BTreeMap<PlatformAddress, Credits> = BTreeMap::new();
+    let outputs_slice = std::slice::from_raw_parts(outputs, outputs_count);
+    for (i, output) in outputs_slice.iter().enumerate() {
+        if output.address.is_null() || output.address_len == 0 {
+            return DashSDKResult::error(DashSDKError::new(
+                DashSDKErrorCode::InvalidParameter,
+                format!("Output {} has null or empty address", i),
+            ));
+        }
+
+        let address_bytes = std::slice::from_raw_parts(output.address, output.address_len);
+        let address = match PlatformAddress::from_bytes(address_bytes) {
+            Ok(addr) => addr,
+            Err(e) => {
+                return DashSDKResult::error(DashSDKError::new(
+                    DashSDKErrorCode::InvalidParameter,
+                    format!("Failed to parse output address {}: {}", i, e),
+                ))
+            }
+        };
+
+        if output.amount == 0 {
+            return DashSDKResult::error(DashSDKError::new(
+                DashSDKErrorCode::InvalidParameter,
+                format!("Output {} has zero amount", i),
+            ));
+        }
+
+        recipient_map.insert(address, output.amount);
+    }
+
+    // Get signing key (if public_key_id is 0, use auto-select)
+    use dash_sdk::dpp::identity::identity_public_key::accessors::v0::IdentityPublicKeyGettersV0;
+    let signing_key = if public_key_id == 0 {
+        None
+    } else {
+        // Find the public key by ID
+        identity
+            .public_keys()
+            .iter()
+            .find(|(_, pk)| pk.id() == public_key_id)
+            .map(|(_, pk)| pk)
+    };
+
+    // Convert settings
+    let settings = convert_put_settings(put_settings);
+
+    // Execute the transfer
+    let result: Result<DashSDKIdentityTransferToAddressesResult, FFIError> =
+        wrapper.runtime.block_on(async {
+            let (address_infos, identity_balance) = identity
+                .transfer_credits_to_addresses(
+                    &wrapper.sdk,
+                    recipient_map,
+                    signing_key,
+                    signer,
+                    settings,
+                )
+                .await
+                .map_err(FFIError::from)?;
+
+            // Convert address infos to FFI type
+            let entries: Vec<DashSDKAddressInfoEntry> = address_infos
+                .iter()
+                .map(|(address, info_opt)| {
+                    let address_bytes = address.to_bytes();
+                    let address_len = address_bytes.len();
+                    let address_ptr = address_bytes.as_ptr() as *mut u8;
+                    std::mem::forget(address_bytes);
+
+                    // Handle Option<AddressInfo>
+                    let (nonce, balance) = match info_opt {
+                        Some(info) => (info.nonce, info.balance),
+                        None => (u32::MAX, u64::MAX), // Sentinel values for not found
+                    };
+
+                    DashSDKAddressInfoEntry {
+                        address: address_ptr,
+                        address_len,
+                        nonce,
+                        balance,
+                    }
+                })
+                .collect();
+
+            let entries_len = entries.len();
+            let entries_ptr = if entries.is_empty() {
+                std::ptr::null_mut()
+            } else {
+                let boxed = entries.into_boxed_slice();
+                Box::into_raw(boxed) as *mut DashSDKAddressInfoEntry
+            };
+
+            Ok(DashSDKIdentityTransferToAddressesResult {
+                identity_balance,
+                address_info_map: DashSDKAddressInfoMap {
+                    entries: entries_ptr,
+                    count: entries_len,
+                },
+            })
+        });
+
+    match result {
+        Ok(transfer_result) => {
+            let boxed = Box::new(transfer_result);
+            DashSDKResult {
+                data_type: DashSDKResultDataType::IdentityTransferToAddressesResult,
+                data: Box::into_raw(boxed) as *mut std::os::raw::c_void,
+                error: std::ptr::null_mut(),
+            }
+        }
+        Err(e) => DashSDKResult::error(e.into()),
+    }
+}
+
+/// Free the result from identity transfer to addresses
+///
+/// # Safety
+/// - `result` must be a valid pointer returned by `dash_sdk_identity_transfer_credits_to_addresses` and not previously freed.
+#[no_mangle]
+pub unsafe extern "C" fn dash_sdk_identity_transfer_to_addresses_result_free(
+    result: *mut DashSDKIdentityTransferToAddressesResult,
+) {
+    if !result.is_null() {
+        let result = Box::from_raw(result);
+        // Free the address info map using the function from types.rs
+        dash_sdk_address_info_map_free(&result.address_info_map as *const _ as *mut _);
+    }
+}

--- a/packages/rs-sdk-ffi/src/types.rs
+++ b/packages/rs-sdk-ffi/src/types.rs
@@ -99,7 +99,13 @@ pub enum DashSDKResultDataType {
     /// Recent address balance changes
     RecentBalanceChanges = 12,
     /// Recent compacted address balance changes
-    CompactedBalanceChanges = 13,
+    CompactedBalanceChanges = 16,
+    /// Identity top-up from addresses result
+    IdentityTopUpFromAddressesResult = 13,
+    /// Identity transfer to addresses result
+    IdentityTransferToAddressesResult = 14,
+    /// Identity create from addresses result
+    IdentityCreateFromAddressesResult = 15,
 }
 
 /// Binary data container for results
@@ -317,6 +323,56 @@ pub struct DashSDKCompactedBalanceChanges {
     pub ranges: *mut DashSDKCompactedBlockRange,
     /// Number of ranges
     pub ranges_count: usize,
+}
+
+// MARK: - Address State Transition Types
+
+/// Input entry for address transfer (address with amount and private key)
+#[repr(C)]
+pub struct DashSDKAddressTransferInput {
+    /// Address bytes (variable length, typically 21 bytes: 1 type + 20 hash)
+    pub address: *const u8,
+    /// Length of address bytes
+    pub address_len: usize,
+    /// Amount to spend from this address
+    pub amount: u64,
+    /// Nonce for this address (0 = auto-fetch)
+    pub nonce: u32,
+    /// Private key for signing (32 bytes)
+    pub private_key: *const u8,
+}
+
+/// Output entry for address transfer (address with amount)
+#[repr(C)]
+pub struct DashSDKAddressTransferOutput {
+    /// Address bytes (variable length, typically 21 bytes: 1 type + 20 hash)
+    pub address: *const u8,
+    /// Length of address bytes
+    pub address_len: usize,
+    /// Amount to receive at this address
+    pub amount: u64,
+}
+
+/// Pooling strategy for withdrawals
+#[repr(C)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DashSDKPooling {
+    /// Never pool withdrawals
+    Never = 0,
+    /// Pool if available
+    IfAvailable = 1,
+    /// Standard pooling
+    Standard = 2,
+}
+
+/// Asset lock proof type
+#[repr(C)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DashSDKAssetLockProofType {
+    /// Instant lock proof
+    Instant = 0,
+    /// Chain lock proof
+    Chain = 1,
 }
 
 /// Result type for FFI functions that return data

--- a/packages/swift-sdk/Sources/SwiftDashSDK/Address/Addresses.swift
+++ b/packages/swift-sdk/Sources/SwiftDashSDK/Address/Addresses.swift
@@ -636,6 +636,579 @@ public class Addresses: @unchecked Sendable {
         return CompactedBalanceChanges(ranges: ranges)
     }
     
+    // MARK: - State Transitions
+    
+    /// Input for address transfer operation
+    public struct AddressTransferInput {
+        /// Address bytes (21 bytes: type byte + 20-byte hash)
+        public let addressBytes: Data
+        /// Amount to spend from this address in credits
+        public let amount: UInt64
+        /// Nonce for this address (0 = auto-fetch, used for identity transitions)
+        public let nonce: UInt32
+        /// Private key for signing (32 bytes)
+        public let privateKey: Data
+        
+        public init(addressBytes: Data, amount: UInt64, nonce: UInt32 = 0, privateKey: Data) {
+            self.addressBytes = addressBytes
+            self.amount = amount
+            self.nonce = nonce
+            self.privateKey = privateKey
+        }
+    }
+    
+    /// Output for address transfer operation
+    public struct AddressTransferOutput {
+        /// Address bytes (21 bytes: type byte + 20-byte hash)
+        public let addressBytes: Data
+        /// Amount to receive at this address in credits
+        public let amount: UInt64
+        
+        public init(addressBytes: Data, amount: UInt64) {
+            self.addressBytes = addressBytes
+            self.amount = amount
+        }
+    }
+    
+    /// Transfer funds between Platform addresses
+    ///
+    /// This is a state transition that moves credits from input addresses to output addresses.
+    /// Each input address must have a corresponding private key for signing.
+    ///
+    /// - Parameters:
+    ///   - inputs: Array of input addresses with amounts and private keys
+    ///   - outputs: Array of output addresses with amounts
+    ///   - feeFromInputIndex: Which input to deduct fees from (0-based, default 0)
+    /// - Returns: PlatformAddressInfosResult containing updated address balances after transfer
+    /// - Throws: SDKError if the transfer fails
+    public func transferFunds(
+        inputs: [AddressTransferInput],
+        outputs: [AddressTransferOutput],
+        feeFromInputIndex: UInt16 = 0
+    ) throws -> PlatformAddressInfosResult {
+        guard let sdk = sdk, let handle = sdk.handle else {
+            throw SDKError.invalidState("SDK not initialized")
+        }
+        
+        guard !inputs.isEmpty else {
+            throw SDKError.invalidParameter("Inputs array is empty")
+        }
+        
+        guard !outputs.isEmpty else {
+            throw SDKError.invalidParameter("Outputs array is empty")
+        }
+        
+        guard feeFromInputIndex < inputs.count else {
+            throw SDKError.invalidParameter("Fee input index \(feeFromInputIndex) is out of bounds (inputs count: \(inputs.count))")
+        }
+        
+        // Validate inputs
+        for (index, input) in inputs.enumerated() {
+            guard input.addressBytes.count == 21 else {
+                throw SDKError.invalidParameter("Input address at index \(index) must be 21 bytes, got \(input.addressBytes.count)")
+            }
+            guard input.privateKey.count == 32 else {
+                throw SDKError.invalidParameter("Private key at index \(index) must be 32 bytes, got \(input.privateKey.count)")
+            }
+        }
+        
+        // Validate outputs
+        for (index, output) in outputs.enumerated() {
+            guard output.addressBytes.count == 21 else {
+                throw SDKError.invalidParameter("Output address at index \(index) must be 21 bytes, got \(output.addressBytes.count)")
+            }
+        }
+        
+        // Create FFI input structs
+        var ffiInputs: [DashSDKAddressTransferInput] = []
+        var inputData: [(address: Data, privateKey: Data)] = [] // Keep data alive
+        
+        for input in inputs {
+            inputData.append((address: input.addressBytes, privateKey: input.privateKey))
+        }
+        
+        for (index, data) in inputData.enumerated() {
+            let addressPtr = data.address.withUnsafeBytes { buffer -> UnsafePointer<UInt8>? in
+                return buffer.baseAddress?.assumingMemoryBound(to: UInt8.self)
+            }
+            let privateKeyPtr = data.privateKey.withUnsafeBytes { buffer -> UnsafePointer<UInt8>? in
+                return buffer.baseAddress?.assumingMemoryBound(to: UInt8.self)
+            }
+            
+            ffiInputs.append(DashSDKAddressTransferInput(
+                address: addressPtr,
+                address_len: UInt(data.address.count),
+                amount: inputs[index].amount,
+                nonce: inputs[index].nonce,
+                private_key: privateKeyPtr
+            ))
+        }
+        
+        // Create FFI output structs
+        var ffiOutputs: [DashSDKAddressTransferOutput] = []
+        var outputData: [Data] = [] // Keep data alive
+        
+        for output in outputs {
+            outputData.append(output.addressBytes)
+        }
+        
+        for (index, data) in outputData.enumerated() {
+            let addressPtr = data.withUnsafeBytes { buffer -> UnsafePointer<UInt8>? in
+                return buffer.baseAddress?.assumingMemoryBound(to: UInt8.self)
+            }
+            
+            ffiOutputs.append(DashSDKAddressTransferOutput(
+                address: addressPtr,
+                address_len: UInt(data.count),
+                amount: outputs[index].amount
+            ))
+        }
+        
+        // Call FFI
+        let result = ffiInputs.withUnsafeMutableBufferPointer { inputsBuffer -> DashSDKResult in
+            ffiOutputs.withUnsafeMutableBufferPointer { outputsBuffer -> DashSDKResult in
+                return dash_sdk_address_transfer_funds(
+                    handle,
+                    inputsBuffer.baseAddress,
+                    UInt(inputs.count),
+                    outputsBuffer.baseAddress,
+                    UInt(outputs.count),
+                    feeFromInputIndex
+                )
+            }
+        }
+        
+        // Check for errors
+        if let error = result.error {
+            let sdkError = SDKError.fromDashSDKError(error.pointee)
+            dash_sdk_error_free(error)
+            throw sdkError
+        }
+        
+        guard let dataPtr = result.data else {
+            return PlatformAddressInfosResult(infos: [:])
+        }
+        
+        // Parse DashSDKAddressInfoMap
+        let mapPtr = dataPtr.assumingMemoryBound(to: DashSDKAddressInfoMap.self)
+        let map = mapPtr.pointee
+        
+        var infos: [Data: PlatformAddressInfo] = [:]
+        
+        if map.count > 0 && map.entries != nil {
+            for i in 0..<map.count {
+                let entry = map.entries![Int(i)]
+                
+                let addressBytes: Data
+                if entry.address != nil && entry.address_len > 0 {
+                    addressBytes = Data(bytes: entry.address!, count: Int(entry.address_len))
+                } else {
+                    continue
+                }
+                
+                let info = PlatformAddressInfo(
+                    addressBytes: addressBytes,
+                    nonce: entry.nonce,
+                    balance: entry.balance
+                )
+                
+                infos[addressBytes] = info
+            }
+        }
+        
+        // Free the FFI map
+        dash_sdk_address_info_map_free(mapPtr)
+        
+        return PlatformAddressInfosResult(infos: infos)
+    }
+    
+    /// Pooling strategy for withdrawals
+    public enum PoolingStrategy {
+        /// Never pool withdrawals
+        case never
+        /// Pool if available
+        case ifAvailable
+        /// Standard pooling
+        case standard
+        
+        var ffiValue: DashSDKPooling {
+            switch self {
+            // DashSDKPooling is a C enum; Swift doesn't always import named cases.
+            case .never: return DashSDKPooling(rawValue: 0)
+            case .ifAvailable: return DashSDKPooling(rawValue: 1)
+            case .standard: return DashSDKPooling(rawValue: 2)
+            }
+        }
+    }
+    
+    /// Withdraw credits from Platform addresses to a Core (L1) Dash address
+    ///
+    /// This is a state transition that moves credits from Platform addresses to a Dash Core (L1) address.
+    /// Each input address must have a corresponding private key for signing.
+    ///
+    /// - Parameters:
+    ///   - inputs: Array of input addresses with amounts and private keys
+    ///   - coreAddress: Base58-encoded Dash Core address to withdraw to (e.g., "y...")
+    ///   - coreFeePerByte: Core network fee per byte (0 means use default of 1)
+    ///   - pooling: Pooling strategy for the withdrawal (default: .never)
+    ///   - feeFromInputIndex: Which input to deduct fees from (0-based, default 0)
+    ///   - changeAddress: Optional Platform address for change (nil if not used)
+    /// - Returns: PlatformAddressInfosResult containing updated address balances after withdrawal
+    /// - Throws: SDKError if the withdrawal fails
+    public func withdrawFunds(
+        inputs: [AddressTransferInput],
+        coreAddress: String,
+        coreFeePerByte: UInt32 = 0,
+        pooling: PoolingStrategy = .never,
+        feeFromInputIndex: UInt16 = 0,
+        changeAddress: Data? = nil
+    ) throws -> PlatformAddressInfosResult {
+        guard let sdk = sdk, let handle = sdk.handle else {
+            throw SDKError.invalidState("SDK not initialized")
+        }
+        
+        guard !inputs.isEmpty else {
+            throw SDKError.invalidParameter("Inputs array is empty")
+        }
+        
+        guard !coreAddress.isEmpty else {
+            throw SDKError.invalidParameter("Core address is empty")
+        }
+        
+        guard feeFromInputIndex < inputs.count else {
+            throw SDKError.invalidParameter("Fee input index \(feeFromInputIndex) is out of bounds (inputs count: \(inputs.count))")
+        }
+        
+        // Validate inputs
+        for (index, input) in inputs.enumerated() {
+            guard input.addressBytes.count == 21 else {
+                throw SDKError.invalidParameter("Input address at index \(index) must be 21 bytes, got \(input.addressBytes.count)")
+            }
+            guard input.privateKey.count == 32 else {
+                throw SDKError.invalidParameter("Private key at index \(index) must be 32 bytes, got \(input.privateKey.count)")
+            }
+        }
+        
+        // Validate change address if provided
+        if let change = changeAddress {
+            guard change.count == 21 else {
+                throw SDKError.invalidParameter("Change address must be 21 bytes, got \(change.count)")
+            }
+        }
+        
+        // Create FFI input structs (same as transfer)
+        var ffiInputs: [DashSDKAddressTransferInput] = []
+        var inputData: [(address: Data, privateKey: Data)] = [] // Keep data alive
+        
+        for input in inputs {
+            inputData.append((address: input.addressBytes, privateKey: input.privateKey))
+        }
+        
+        for (index, data) in inputData.enumerated() {
+            let addressPtr = data.address.withUnsafeBytes { buffer -> UnsafePointer<UInt8>? in
+                return buffer.baseAddress?.assumingMemoryBound(to: UInt8.self)
+            }
+            let privateKeyPtr = data.privateKey.withUnsafeBytes { buffer -> UnsafePointer<UInt8>? in
+                return buffer.baseAddress?.assumingMemoryBound(to: UInt8.self)
+            }
+            
+            ffiInputs.append(DashSDKAddressTransferInput(
+                address: addressPtr,
+                address_len: UInt(data.address.count),
+                amount: inputs[index].amount,
+                nonce: inputs[index].nonce,
+                private_key: privateKeyPtr
+            ))
+        }
+        
+        // Convert core address to C string
+        let coreAddressCString = coreAddress.utf8CString
+        
+        // Prepare change address pointer
+        var changeAddressPtr: UnsafePointer<UInt8>? = nil
+        var changeAddressLen: UInt = 0
+        if let change = changeAddress {
+            changeAddressPtr = change.withUnsafeBytes { buffer -> UnsafePointer<UInt8>? in
+                return buffer.baseAddress?.assumingMemoryBound(to: UInt8.self)
+            }
+            changeAddressLen = UInt(change.count)
+        }
+        
+        // Call FFI
+        let result = ffiInputs.withUnsafeMutableBufferPointer { inputsBuffer -> DashSDKResult in
+            coreAddressCString.withUnsafeBufferPointer { coreAddressBuffer -> DashSDKResult in
+                let coreAddressPtr = coreAddressBuffer.baseAddress
+                return dash_sdk_address_withdraw_funds(
+                    handle,
+                    inputsBuffer.baseAddress,
+                    UInt(inputs.count),
+                    coreAddressPtr,
+                    coreFeePerByte,
+                    pooling.ffiValue,
+                    feeFromInputIndex,
+                    changeAddressPtr,
+                    changeAddressLen
+                )
+            }
+        }
+        
+        // Check for errors
+        if let error = result.error {
+            let sdkError = SDKError.fromDashSDKError(error.pointee)
+            dash_sdk_error_free(error)
+            throw sdkError
+        }
+        
+        guard let dataPtr = result.data else {
+            return PlatformAddressInfosResult(infos: [:])
+        }
+        
+        // Parse DashSDKAddressInfoMap (same as transfer)
+        let mapPtr = dataPtr.assumingMemoryBound(to: DashSDKAddressInfoMap.self)
+        let map = mapPtr.pointee
+        
+        var infos: [Data: PlatformAddressInfo] = [:]
+        
+        if map.count > 0 && map.entries != nil {
+            for i in 0..<map.count {
+                let entry = map.entries![Int(i)]
+                
+                let addressBytes: Data
+                if entry.address != nil && entry.address_len > 0 {
+                    addressBytes = Data(bytes: entry.address!, count: Int(entry.address_len))
+                } else {
+                    continue
+                }
+                
+                let info = PlatformAddressInfo(
+                    addressBytes: addressBytes,
+                    nonce: entry.nonce,
+                    balance: entry.balance
+                )
+                
+                infos[addressBytes] = info
+            }
+        }
+        
+        // Free the FFI map
+        dash_sdk_address_info_map_free(mapPtr)
+        
+        return PlatformAddressInfosResult(infos: infos)
+    }
+    
+    /// Asset lock proof type
+    public enum AssetLockProofType {
+        /// Instant lock proof
+        case instant
+        /// Chain lock proof
+        case chain
+        
+        var ffiValue: DashSDKAssetLockProofType {
+            switch self {
+            case .instant: return DashSDKAssetLockProofType(rawValue: 0)
+            case .chain: return DashSDKAssetLockProofType(rawValue: 1)
+            }
+        }
+    }
+    
+    /// Top up Platform addresses using an asset lock proof
+    ///
+    /// This is a state transition that funds Platform addresses from a Dash Core asset lock (instant or chain lock).
+    ///
+    /// - Parameters:
+    ///   - proofType: Type of asset lock proof (.instant or .chain)
+    ///   - instantLockData: For instant lock: instant lock bytes
+    ///   - transactionData: For instant lock: transaction bytes
+    ///   - outputIndex: For instant lock: output index in the transaction
+    ///   - coreChainLockedHeight: For chain lock: core chain locked height
+    ///   - outPoint: For chain lock: out point bytes (36 bytes: 32 txid + 4 vout)
+    ///   - assetLockPrivateKey: Private key for the asset lock (32 bytes)
+    ///   - outputs: Array of output addresses with optional amounts (nil means SDK calculates)
+    ///   - feeFromInputIndex: Which input index to deduct fees from (0-based, default 0)
+    /// - Returns: PlatformAddressInfosResult containing updated address balances after top-up
+    /// - Throws: SDKError if the top-up fails
+    public func topUpAddressFromAssetLock(
+        proofType: AssetLockProofType,
+        instantLockData: Data?,
+        transactionData: Data?,
+        outputIndex: UInt32,
+        coreChainLockedHeight: UInt32,
+        outPoint: Data?,
+        assetLockPrivateKey: Data,
+        outputs: [AddressTransferOutput],
+        feeFromInputIndex: UInt16 = 0
+    ) throws -> PlatformAddressInfosResult {
+        guard let sdk = sdk, let handle = sdk.handle else {
+            throw SDKError.invalidState("SDK not initialized")
+        }
+        
+        guard assetLockPrivateKey.count == 32 else {
+            throw SDKError.invalidParameter("Asset lock private key must be 32 bytes, got \(assetLockPrivateKey.count)")
+        }
+        
+        guard !outputs.isEmpty else {
+            throw SDKError.invalidParameter("Outputs array is empty")
+        }
+        
+        // Validate proof type specific parameters
+        switch proofType {
+        case .instant:
+            guard let instantLock = instantLockData, !instantLock.isEmpty else {
+                throw SDKError.invalidParameter("Instant lock requires instantLockData")
+            }
+            guard let transaction = transactionData, !transaction.isEmpty else {
+                throw SDKError.invalidParameter("Instant lock requires transactionData")
+            }
+        case .chain:
+            guard let outPointData = outPoint, outPointData.count == 36 else {
+                throw SDKError.invalidParameter("Chain lock requires outPoint with exactly 36 bytes (32 txid + 4 vout)")
+            }
+        }
+        
+        // Validate outputs
+        for (index, output) in outputs.enumerated() {
+            guard output.addressBytes.count == 21 else {
+                throw SDKError.invalidParameter("Output address at index \(index) must be 21 bytes, got \(output.addressBytes.count)")
+            }
+        }
+        
+        // Prepare proof parameters
+        let instantLockPtr: UnsafePointer<UInt8>?
+        let instantLockLen: UInt
+        let transactionPtr: UnsafePointer<UInt8>?
+        let transactionLen: UInt
+        
+        if proofType == .instant, let instantLock = instantLockData, let transaction = transactionData {
+            instantLockPtr = instantLock.withUnsafeBytes { buffer -> UnsafePointer<UInt8>? in
+                return buffer.baseAddress?.assumingMemoryBound(to: UInt8.self)
+            }
+            instantLockLen = UInt(instantLock.count)
+            transactionPtr = transaction.withUnsafeBytes { buffer -> UnsafePointer<UInt8>? in
+                return buffer.baseAddress?.assumingMemoryBound(to: UInt8.self)
+            }
+            transactionLen = UInt(transaction.count)
+        } else {
+            instantLockPtr = nil
+            instantLockLen = 0
+            transactionPtr = nil
+            transactionLen = 0
+        }
+        
+        // Prepare chain lock parameters - C fixed-size arrays become tuples in Swift
+        var outPointTuple: (UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8,
+                            UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8,
+                            UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8,
+                            UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8,
+                            UInt8, UInt8, UInt8, UInt8)?
+        if proofType == .chain, let outPointData = outPoint {
+            guard outPointData.count == 36 else {
+                throw SDKError.invalidParameter("Out point must be exactly 36 bytes")
+            }
+            let bytes = Array(outPointData)
+            outPointTuple = (bytes[0], bytes[1], bytes[2], bytes[3], bytes[4], bytes[5], bytes[6], bytes[7],
+                            bytes[8], bytes[9], bytes[10], bytes[11], bytes[12], bytes[13], bytes[14], bytes[15],
+                            bytes[16], bytes[17], bytes[18], bytes[19], bytes[20], bytes[21], bytes[22], bytes[23],
+                            bytes[24], bytes[25], bytes[26], bytes[27], bytes[28], bytes[29], bytes[30], bytes[31],
+                            bytes[32], bytes[33], bytes[34], bytes[35])
+        }
+        let outPointPtr = outPointTuple.map { withUnsafePointer(to: $0) { $0 } }
+        
+        // Create FFI output structs
+        var ffiOutputs: [DashSDKAddressTransferOutput] = []
+        var outputData: [Data] = [] // Keep data alive
+        
+        for output in outputs {
+            outputData.append(output.addressBytes)
+        }
+        
+        for (index, data) in outputData.enumerated() {
+            let addressPtr = data.withUnsafeBytes { buffer -> UnsafePointer<UInt8>? in
+                return buffer.baseAddress?.assumingMemoryBound(to: UInt8.self)
+            }
+            
+            ffiOutputs.append(DashSDKAddressTransferOutput(
+                address: addressPtr,
+                address_len: UInt(data.count),
+                amount: outputs[index].amount
+            ))
+        }
+        
+        // Prepare private key - C fixed-size arrays become tuples in Swift
+        let privateKeyBytes = Array(assetLockPrivateKey)
+        let privateKeyTuple = (privateKeyBytes[0], privateKeyBytes[1], privateKeyBytes[2], privateKeyBytes[3],
+                               privateKeyBytes[4], privateKeyBytes[5], privateKeyBytes[6], privateKeyBytes[7],
+                               privateKeyBytes[8], privateKeyBytes[9], privateKeyBytes[10], privateKeyBytes[11],
+                               privateKeyBytes[12], privateKeyBytes[13], privateKeyBytes[14], privateKeyBytes[15],
+                               privateKeyBytes[16], privateKeyBytes[17], privateKeyBytes[18], privateKeyBytes[19],
+                               privateKeyBytes[20], privateKeyBytes[21], privateKeyBytes[22], privateKeyBytes[23],
+                               privateKeyBytes[24], privateKeyBytes[25], privateKeyBytes[26], privateKeyBytes[27],
+                               privateKeyBytes[28], privateKeyBytes[29], privateKeyBytes[30], privateKeyBytes[31])
+        let privateKeyPtr = withUnsafePointer(to: privateKeyTuple) { $0 }
+        
+        // Call FFI
+        let result = ffiOutputs.withUnsafeMutableBufferPointer { outputsBuffer -> DashSDKResult in
+            dash_sdk_address_top_up_from_asset_lock(
+                handle,
+                proofType.ffiValue,
+                instantLockPtr,
+                instantLockLen,
+                transactionPtr,
+                transactionLen,
+                outputIndex,
+                coreChainLockedHeight,
+                outPointPtr,
+                privateKeyPtr,
+                outputsBuffer.baseAddress,
+                UInt(outputs.count),
+                feeFromInputIndex,
+                nil // put_settings
+            )
+        }
+        
+        // Check for errors
+        if let error = result.error {
+            let sdkError = SDKError.fromDashSDKError(error.pointee)
+            dash_sdk_error_free(error)
+            throw sdkError
+        }
+        
+        guard let dataPtr = result.data else {
+            return PlatformAddressInfosResult(infos: [:])
+        }
+        
+        // Parse DashSDKAddressInfoMap (same as transfer)
+        let mapPtr = dataPtr.assumingMemoryBound(to: DashSDKAddressInfoMap.self)
+        let map = mapPtr.pointee
+        
+        var infos: [Data: PlatformAddressInfo] = [:]
+        
+        if map.count > 0 && map.entries != nil {
+            for i in 0..<map.count {
+                let entry = map.entries![Int(i)]
+                
+                let addressBytes: Data
+                if entry.address != nil && entry.address_len > 0 {
+                    addressBytes = Data(bytes: entry.address!, count: Int(entry.address_len))
+                } else {
+                    continue
+                }
+                
+                let info = PlatformAddressInfo(
+                    addressBytes: addressBytes,
+                    nonce: entry.nonce,
+                    balance: entry.balance
+                )
+                
+                infos[addressBytes] = info
+            }
+        }
+        
+        // Free the FFI map
+        dash_sdk_address_info_map_free(mapPtr)
+        
+        return PlatformAddressInfosResult(infos: infos)
+    }
+    
     // MARK: - Convenience Methods
 
     /// Get the balance for a single address
@@ -673,5 +1246,490 @@ public class Addresses: @unchecked Sendable {
     public func getTotalBalance(addressesBytesList: [Data]) throws -> UInt64 {
         let result = try getInfos(addressesBytesList: addressesBytesList)
         return result.totalBalance
+    }
+    
+    // MARK: - Identity State Transitions (Address-Related)
+    
+    /// Top up an identity using Platform address balances
+    ///
+    /// - Parameters:
+    ///   - identityId: Base58-encoded identity ID
+    ///   - inputs: Array of input addresses with amounts and private keys
+    /// - Returns: Tuple of (updated identity balance, updated address infos)
+    /// - Throws: SDKError if the operation fails
+    /// - Note: This requires fetching the identity first to get a handle
+    @MainActor
+    public func topUpIdentityFromAddresses(
+        identityId: String,
+        inputs: [AddressTransferInput]
+    ) async throws -> (identityBalance: UInt64, addressInfos: PlatformAddressInfosResult) {
+        guard let sdk = sdk, let handle = sdk.handle else {
+            throw SDKError.invalidState("SDK not initialized")
+        }
+        
+        guard !inputs.isEmpty else {
+            throw SDKError.invalidParameter("Inputs array is empty")
+        }
+        
+        // Fetch identity JSON and parse to get handle
+        let identityJSON = try await sdk.identityGet(identityId: identityId)
+        guard let identityJSONString = try? JSONSerialization.data(withJSONObject: identityJSON),
+              let jsonString = String(data: identityJSONString, encoding: .utf8) else {
+            throw SDKError.serializationError("Failed to serialize identity JSON")
+        }
+        
+        // Parse identity JSON to get handle
+        let parseResult = jsonString.withCString { cString in
+            dash_sdk_identity_parse_json(cString)
+        }
+        
+        guard parseResult.error == nil else {
+            let error = parseResult.error!.pointee
+            defer { dash_sdk_error_free(parseResult.error) }
+            throw SDKError.fromDashSDKError(error)
+        }
+        
+        guard let identityHandlePtr = parseResult.data else {
+            throw SDKError.internalError("Failed to parse identity")
+        }
+        
+        let identityHandle = identityHandlePtr.assumingMemoryBound(to: IdentityHandle.self)
+        defer { dash_sdk_identity_destroy(identityHandle) }
+        
+        // Prepare FFI inputs
+        var ffiInputs: [DashSDKAddressTransferInput] = []
+        var inputData: [Data] = [] // Keep data alive
+        
+        for input in inputs {
+            inputData.append(input.addressBytes)
+            inputData.append(input.privateKey)
+        }
+        
+        for (index, input) in inputs.enumerated() {
+            let addressPtr = inputData[index * 2].withUnsafeBytes { buffer -> UnsafePointer<UInt8>? in
+                return buffer.baseAddress?.assumingMemoryBound(to: UInt8.self)
+            }
+            
+            let privateKeyPtr = inputData[index * 2 + 1].withUnsafeBytes { buffer -> UnsafePointer<UInt8>? in
+                guard buffer.count == 32 else { return nil }
+                return buffer.baseAddress?.assumingMemoryBound(to: UInt8.self)
+            }
+            
+            guard let pkPtr = privateKeyPtr else {
+                throw SDKError.invalidParameter("Invalid private key at index \(index)")
+            }
+            
+            ffiInputs.append(DashSDKAddressTransferInput(
+                address: addressPtr,
+                address_len: UInt(input.addressBytes.count),
+                amount: input.amount,
+                nonce: input.nonce,
+                private_key: pkPtr
+            ))
+        }
+        
+        // Call FFI
+        let result = ffiInputs.withUnsafeMutableBufferPointer { inputsBuffer -> DashSDKResult in
+            dash_sdk_identity_top_up_from_addresses(
+                handle,
+                UnsafePointer(identityHandle),
+                inputsBuffer.baseAddress,
+                UInt(inputs.count),
+                nil // put_settings
+            )
+        }
+        
+        // Check for errors
+        if let error = result.error {
+            let sdkError = SDKError.fromDashSDKError(error.pointee)
+            dash_sdk_error_free(error)
+            throw sdkError
+        }
+        
+        guard let dataPtr = result.data else {
+            throw SDKError.internalError("No result data returned")
+        }
+        
+        // Parse result
+        let resultPtr = dataPtr.assumingMemoryBound(to: DashSDKIdentityTopUpFromAddressesResult.self)
+        let ffiResult = resultPtr.pointee
+        
+        // Parse address info map
+        var infos: [Data: PlatformAddressInfo] = [:]
+        if ffiResult.address_info_map.count > 0 && ffiResult.address_info_map.entries != nil {
+            for i in 0..<ffiResult.address_info_map.count {
+                let entry = ffiResult.address_info_map.entries![Int(i)]
+                
+                let addressBytes: Data
+                if entry.address != nil && entry.address_len > 0 {
+                    addressBytes = Data(bytes: entry.address!, count: Int(entry.address_len))
+                } else {
+                    continue
+                }
+                
+                let info = PlatformAddressInfo(
+                    addressBytes: addressBytes,
+                    nonce: entry.nonce,
+                    balance: entry.balance
+                )
+                
+                infos[addressBytes] = info
+            }
+        }
+        
+        // Free the result
+        dash_sdk_identity_top_up_from_addresses_result_free(resultPtr)
+        
+        return (ffiResult.identity_balance, PlatformAddressInfosResult(infos: infos))
+    }
+    
+    /// Transfer credits from an identity to Platform addresses
+    ///
+    /// - Parameters:
+    ///   - identityId: Base58-encoded identity ID
+    ///   - outputs: Array of output addresses with amounts
+    ///   - identityPrivateKey: Private key for the identity (32 bytes) - used to create signer
+    ///   - publicKeyId: ID of the public key to use for signing (0 = auto-select TRANSFER key)
+    /// - Returns: Tuple of (updated identity balance, updated address infos)
+    /// - Throws: SDKError if the operation fails
+    @MainActor
+    public func transferCreditsToAddresses(
+        identityId: String,
+        outputs: [AddressTransferOutput],
+        identityPrivateKey: Data,
+        publicKeyId: UInt32 = 0
+    ) async throws -> (identityBalance: UInt64, addressInfos: PlatformAddressInfosResult) {
+        guard let sdk = sdk, let handle = sdk.handle else {
+            throw SDKError.invalidState("SDK not initialized")
+        }
+        
+        guard identityPrivateKey.count == 32 else {
+            throw SDKError.invalidParameter("Identity private key must be 32 bytes, got \(identityPrivateKey.count)")
+        }
+        
+        guard !outputs.isEmpty else {
+            throw SDKError.invalidParameter("Outputs array is empty")
+        }
+        
+        // Fetch identity JSON and parse to get handle
+        let identityJSON = try await sdk.identityGet(identityId: identityId)
+        guard let identityJSONString = try? JSONSerialization.data(withJSONObject: identityJSON),
+              let jsonString = String(data: identityJSONString, encoding: .utf8) else {
+            throw SDKError.serializationError("Failed to serialize identity JSON")
+        }
+        
+        // Parse identity JSON to get handle
+        let parseResult = jsonString.withCString { cString in
+            dash_sdk_identity_parse_json(cString)
+        }
+        
+        guard parseResult.error == nil else {
+            let error = parseResult.error!.pointee
+            defer { dash_sdk_error_free(parseResult.error) }
+            throw SDKError.fromDashSDKError(error)
+        }
+        
+        guard let identityHandlePtr = parseResult.data else {
+            throw SDKError.internalError("Failed to parse identity")
+        }
+        
+        let identityHandle = identityHandlePtr.assumingMemoryBound(to: IdentityHandle.self)
+        defer { dash_sdk_identity_destroy(identityHandle) }
+        
+        // Create signer from private key
+        let signerResult = identityPrivateKey.withUnsafeBytes { keyBytes in
+            dash_sdk_signer_create_from_private_key(
+                keyBytes.bindMemory(to: UInt8.self).baseAddress!,
+                UInt(identityPrivateKey.count)
+            )
+        }
+        
+        guard signerResult.error == nil,
+              let signer = signerResult.data else {
+            if let error = signerResult.error {
+                let sdkError = SDKError.fromDashSDKError(error.pointee)
+                dash_sdk_error_free(error)
+                throw sdkError
+            }
+            throw SDKError.internalError("Failed to create signer")
+        }
+        
+        defer {
+            dash_sdk_signer_destroy(signer.assumingMemoryBound(to: SignerHandle.self))
+        }
+        
+        // Prepare FFI outputs
+        var ffiOutputs: [DashSDKAddressTransferOutput] = []
+        var outputData: [Data] = [] // Keep data alive
+        
+        for output in outputs {
+            outputData.append(output.addressBytes)
+        }
+        
+        for (index, data) in outputData.enumerated() {
+            let addressPtr = data.withUnsafeBytes { buffer -> UnsafePointer<UInt8>? in
+                return buffer.baseAddress?.assumingMemoryBound(to: UInt8.self)
+            }
+            
+            ffiOutputs.append(DashSDKAddressTransferOutput(
+                address: addressPtr,
+                address_len: UInt(data.count),
+                amount: outputs[index].amount
+            ))
+        }
+        
+        // Call FFI
+        let result = ffiOutputs.withUnsafeMutableBufferPointer { outputsBuffer -> DashSDKResult in
+            dash_sdk_identity_transfer_credits_to_addresses(
+                handle,
+                UnsafePointer(identityHandle),
+                outputsBuffer.baseAddress,
+                UInt(outputs.count),
+                publicKeyId,
+                signer.assumingMemoryBound(to: SignerHandle.self),
+                nil // put_settings
+            )
+        }
+        
+        // Check for errors
+        if let error = result.error {
+            let sdkError = SDKError.fromDashSDKError(error.pointee)
+            dash_sdk_error_free(error)
+            throw sdkError
+        }
+        
+        guard let dataPtr = result.data else {
+            throw SDKError.internalError("No result data returned")
+        }
+        
+        // Parse result
+        let resultPtr = dataPtr.assumingMemoryBound(to: DashSDKIdentityTransferToAddressesResult.self)
+        let ffiResult = resultPtr.pointee
+        
+        // Parse address info map
+        var infos: [Data: PlatformAddressInfo] = [:]
+        if ffiResult.address_info_map.count > 0 && ffiResult.address_info_map.entries != nil {
+            for i in 0..<ffiResult.address_info_map.count {
+                let entry = ffiResult.address_info_map.entries![Int(i)]
+                
+                let addressBytes: Data
+                if entry.address != nil && entry.address_len > 0 {
+                    addressBytes = Data(bytes: entry.address!, count: Int(entry.address_len))
+                } else {
+                    continue
+                }
+                
+                let info = PlatformAddressInfo(
+                    addressBytes: addressBytes,
+                    nonce: entry.nonce,
+                    balance: entry.balance
+                )
+                
+                infos[addressBytes] = info
+            }
+        }
+        
+        // Free the result
+        dash_sdk_identity_transfer_to_addresses_result_free(resultPtr)
+        
+        return (ffiResult.identity_balance, PlatformAddressInfosResult(infos: infos))
+    }
+    
+    /// Create an identity funded by Platform addresses
+    ///
+    /// - Parameters:
+    ///   - identityId: Base58-encoded identity ID (must be prepared with public keys)
+    ///   - inputs: Array of input addresses with amounts, nonces, and private keys
+    ///   - output: Optional output address with amount (for change)
+    ///   - identityPrivateKey: Private key for the identity (32 bytes) - used to create signer
+    /// - Returns: Tuple of (created identity handle, updated address infos)
+    /// - Throws: SDKError if the operation fails
+    /// - Note: The returned identity handle must be freed using dash_sdk_identity_destroy
+    @MainActor
+    public func createIdentityFromAddresses(
+        identityId: String,
+        inputs: [AddressTransferInput],
+        output: AddressTransferOutput?,
+        identityPrivateKey: Data
+    ) async throws -> (identityHandle: OpaquePointer, addressInfos: PlatformAddressInfosResult) {
+        guard let sdk = sdk, let handle = sdk.handle else {
+            throw SDKError.invalidState("SDK not initialized")
+        }
+        
+        guard identityPrivateKey.count == 32 else {
+            throw SDKError.invalidParameter("Identity private key must be 32 bytes, got \(identityPrivateKey.count)")
+        }
+        
+        guard !inputs.isEmpty else {
+            throw SDKError.invalidParameter("Inputs array is empty")
+        }
+        
+        // Fetch identity JSON and parse to get handle
+        let identityJSON = try await sdk.identityGet(identityId: identityId)
+        guard let identityJSONString = try? JSONSerialization.data(withJSONObject: identityJSON),
+              let jsonString = String(data: identityJSONString, encoding: .utf8) else {
+            throw SDKError.serializationError("Failed to serialize identity JSON")
+        }
+        
+        // Parse identity JSON to get handle
+        let parseResult = jsonString.withCString { cString in
+            dash_sdk_identity_parse_json(cString)
+        }
+        
+        guard parseResult.error == nil else {
+            let error = parseResult.error!.pointee
+            defer { dash_sdk_error_free(parseResult.error) }
+            throw SDKError.fromDashSDKError(error)
+        }
+        
+        guard let identityHandlePtr = parseResult.data else {
+            throw SDKError.internalError("Failed to parse identity")
+        }
+        
+        let identityHandle = identityHandlePtr.assumingMemoryBound(to: IdentityHandle.self)
+        // Note: We don't destroy this handle here because it will be replaced by the created identity
+        
+        // Create signer from private key
+        let signerResult = identityPrivateKey.withUnsafeBytes { keyBytes in
+            dash_sdk_signer_create_from_private_key(
+                keyBytes.bindMemory(to: UInt8.self).baseAddress!,
+                UInt(identityPrivateKey.count)
+            )
+        }
+        
+        guard signerResult.error == nil,
+              let signer = signerResult.data else {
+            dash_sdk_identity_destroy(identityHandle) // Clean up identity handle
+            if let error = signerResult.error {
+                let sdkError = SDKError.fromDashSDKError(error.pointee)
+                dash_sdk_error_free(error)
+                throw sdkError
+            }
+            throw SDKError.internalError("Failed to create signer")
+        }
+        
+        defer {
+            dash_sdk_signer_destroy(signer.assumingMemoryBound(to: SignerHandle.self))
+        }
+        
+        // Prepare FFI inputs
+        var ffiInputs: [DashSDKAddressTransferInput] = []
+        var inputData: [(address: Data, privateKey: Data)] = [] // Keep data alive
+        
+        for input in inputs {
+            inputData.append((address: input.addressBytes, privateKey: input.privateKey))
+        }
+        
+        for (index, data) in inputData.enumerated() {
+            let addressPtr = data.address.withUnsafeBytes { buffer -> UnsafePointer<UInt8>? in
+                return buffer.baseAddress?.assumingMemoryBound(to: UInt8.self)
+            }
+            
+            let privateKeyPtr = data.privateKey.withUnsafeBytes { buffer -> UnsafePointer<UInt8>? in
+                guard buffer.count == 32 else { return nil }
+                return buffer.baseAddress?.assumingMemoryBound(to: UInt8.self)
+            }
+            
+            guard let pkPtr = privateKeyPtr else {
+                dash_sdk_identity_destroy(identityHandle) // Clean up
+                throw SDKError.invalidParameter("Invalid private key at index \(index)")
+            }
+            
+            ffiInputs.append(DashSDKAddressTransferInput(
+                address: addressPtr,
+                address_len: UInt(data.address.count),
+                amount: inputs[index].amount,
+                nonce: inputs[index].nonce,
+                private_key: pkPtr
+            ))
+        }
+        
+        // Prepare optional output
+        var ffiOutput: UnsafePointer<DashSDKAddressTransferOutput>? = nil
+        var outputData: Data? = nil
+        var outputPtr: UnsafePointer<UInt8>? = nil
+        
+        if let output = output {
+            outputData = output.addressBytes
+            outputPtr = outputData!.withUnsafeBytes { buffer -> UnsafePointer<UInt8>? in
+                return buffer.baseAddress?.assumingMemoryBound(to: UInt8.self)
+            }
+            
+            var outputStruct = DashSDKAddressTransferOutput(
+                address: outputPtr,
+                address_len: UInt(output.addressBytes.count),
+                amount: output.amount
+            )
+            ffiOutput = withUnsafePointer(to: &outputStruct) { $0 }
+        }
+        
+        // Call FFI
+        let result = ffiInputs.withUnsafeMutableBufferPointer { inputsBuffer -> DashSDKResult in
+            dash_sdk_identity_create_from_addresses(
+                handle,
+                UnsafePointer(identityHandle),
+                inputsBuffer.baseAddress,
+                UInt(inputs.count),
+                ffiOutput,
+                signer.assumingMemoryBound(to: SignerHandle.self),
+                nil // put_settings
+            )
+        }
+        
+        // Clean up the original identity handle (it will be replaced)
+        dash_sdk_identity_destroy(identityHandle)
+        
+        // Check for errors
+        if let error = result.error {
+            let sdkError = SDKError.fromDashSDKError(error.pointee)
+            dash_sdk_error_free(error)
+            throw sdkError
+        }
+        
+        guard let dataPtr = result.data else {
+            throw SDKError.internalError("No result data returned")
+        }
+        
+        // Parse result
+        let resultPtr = dataPtr.assumingMemoryBound(to: DashSDKIdentityCreateFromAddressesResult.self)
+        let ffiResult = resultPtr.pointee
+        
+        // Parse address info map
+        var infos: [Data: PlatformAddressInfo] = [:]
+        if ffiResult.address_info_map.count > 0 && ffiResult.address_info_map.entries != nil {
+            for i in 0..<ffiResult.address_info_map.count {
+                let entry = ffiResult.address_info_map.entries![Int(i)]
+                
+                let addressBytes: Data
+                if entry.address != nil && entry.address_len > 0 {
+                    addressBytes = Data(bytes: entry.address!, count: Int(entry.address_len))
+                } else {
+                    continue
+                }
+                
+                let info = PlatformAddressInfo(
+                    addressBytes: addressBytes,
+                    nonce: entry.nonce,
+                    balance: entry.balance
+                )
+                
+                infos[addressBytes] = info
+            }
+        }
+        
+        // The identity handle is in the result - extract it before freeing
+        guard let identityHandlePtr = ffiResult.identity_handle else {
+            dash_sdk_identity_create_from_addresses_result_free(resultPtr)
+            throw SDKError.internalError("No identity handle returned from create operation")
+        }
+        
+        // Free the result (but keep the identity handle - caller must free it)
+        dash_sdk_identity_create_from_addresses_result_free(resultPtr)
+        
+        // Convert UnsafeMutablePointer<IdentityHandle> to OpaquePointer
+        // OpaquePointer initializer returns optional, so we force unwrap since we know it's valid
+        let createdIdentityHandle = OpaquePointer(UnsafeRawPointer(identityHandlePtr))!
+        
+        return (createdIdentityHandle, PlatformAddressInfosResult(infos: infos))
     }
 }

--- a/packages/swift-sdk/SwiftExampleApp/SwiftExampleApp/Views/AddressQueriesView.swift
+++ b/packages/swift-sdk/SwiftExampleApp/SwiftExampleApp/Views/AddressQueriesView.swift
@@ -78,7 +78,7 @@ struct AddressQueriesView: View {
                 .padding(.vertical, 4)
             }
         }
-        .navigationTitle("Address Queries")
+        .navigationTitle("Address Operations")
         .navigationBarTitleDisplayMode(.inline)
     }
 }
@@ -1710,6 +1710,1956 @@ struct CompactedAddressChangeView: View {
         .background(Color.gray.opacity(0.05))
         .cornerRadius(8)
         .padding(.leading, 16)
+    }
+}
+
+// MARK: - Transfer Address Funds View
+
+struct TransferAddressFundsView: View {
+    @EnvironmentObject var appState: UnifiedAppState
+    
+    // Input state
+    @State private var inputAddressHex: String = ""
+    @State private var inputAmount: String = ""
+    @State private var inputPrivateKeyHex: String = ""
+    
+    // Output state
+    @State private var outputAddressHex: String = ""
+    @State private var outputAmount: String = ""
+    
+    // Result state
+    @State private var isLoading = false
+    @State private var result: PlatformAddressInfosResult?
+    @State private var errorMessage: String?
+    @State private var showResult = false
+    
+    var body: some View {
+        ScrollView {
+            VStack(spacing: 20) {
+                // Header
+                VStack(alignment: .leading, spacing: 8) {
+                    Text("Transfer Address Funds")
+                        .font(.title2)
+                        .fontWeight(.bold)
+                    
+                    Text("Transfer credits between Platform addresses. This creates a state transition on-chain.")
+                        .font(.body)
+                        .foregroundColor(.secondary)
+                    
+                    Text("⚠️ This is an on-chain transaction. Requires valid addresses with funds and correct private keys.")
+                        .font(.caption)
+                        .foregroundColor(.orange)
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding()
+                
+                // Input Address Section
+                VStack(alignment: .leading, spacing: 12) {
+                    Text("Input (Source)")
+                        .font(.headline)
+                        .foregroundColor(.green)
+                    
+                    VStack(alignment: .leading, spacing: 4) {
+                        Text("Address (hex, 42 chars)")
+                            .font(.subheadline)
+                            .fontWeight(.medium)
+                        TextField("00...(21 bytes = 42 hex chars)", text: $inputAddressHex)
+                            .textFieldStyle(RoundedBorderTextFieldStyle())
+                            .autocapitalization(.none)
+                            .disableAutocorrection(true)
+                            .monospaced()
+                    }
+                    
+                    VStack(alignment: .leading, spacing: 4) {
+                        Text("Amount (credits)")
+                            .font(.subheadline)
+                            .fontWeight(.medium)
+                        TextField("e.g., 1000000000", text: $inputAmount)
+                            .textFieldStyle(RoundedBorderTextFieldStyle())
+                            .keyboardType(.numberPad)
+                        if let amount = UInt64(inputAmount), amount > 0 {
+                            Text("\(formatDash(amount)) DASH")
+                                .font(.caption)
+                                .foregroundColor(.blue)
+                        }
+                    }
+                    
+                    VStack(alignment: .leading, spacing: 4) {
+                        Text("Private Key (hex, 64 chars)")
+                            .font(.subheadline)
+                            .fontWeight(.medium)
+                        SecureField("32-byte private key as hex", text: $inputPrivateKeyHex)
+                            .textFieldStyle(RoundedBorderTextFieldStyle())
+                            .autocapitalization(.none)
+                            .disableAutocorrection(true)
+                            .monospaced()
+                        Text("Keep your private key secure!")
+                            .font(.caption)
+                            .foregroundColor(.red)
+                    }
+                }
+                .padding()
+                .background(Color.green.opacity(0.05))
+                .cornerRadius(10)
+                .padding(.horizontal)
+                
+                // Output Address Section
+                VStack(alignment: .leading, spacing: 12) {
+                    Text("Output (Destination)")
+                        .font(.headline)
+                        .foregroundColor(.blue)
+                    
+                    VStack(alignment: .leading, spacing: 4) {
+                        Text("Address (hex, 42 chars)")
+                            .font(.subheadline)
+                            .fontWeight(.medium)
+                        TextField("00...(21 bytes = 42 hex chars)", text: $outputAddressHex)
+                            .textFieldStyle(RoundedBorderTextFieldStyle())
+                            .autocapitalization(.none)
+                            .disableAutocorrection(true)
+                            .monospaced()
+                    }
+                    
+                    VStack(alignment: .leading, spacing: 4) {
+                        Text("Amount (credits)")
+                            .font(.subheadline)
+                            .fontWeight(.medium)
+                        TextField("e.g., 500000000", text: $outputAmount)
+                            .textFieldStyle(RoundedBorderTextFieldStyle())
+                            .keyboardType(.numberPad)
+                        if let amount = UInt64(outputAmount), amount > 0 {
+                            Text("\(formatDash(amount)) DASH")
+                                .font(.caption)
+                                .foregroundColor(.blue)
+                        }
+                    }
+                }
+                .padding()
+                .background(Color.blue.opacity(0.05))
+                .cornerRadius(10)
+                .padding(.horizontal)
+                
+                // Info about fees
+                VStack(alignment: .leading, spacing: 4) {
+                    HStack {
+                        Image(systemName: "info.circle")
+                        Text("Fee Info")
+                    }
+                    .font(.subheadline)
+                    .fontWeight(.medium)
+                    
+                    Text("Network fees will be deducted from the input amount. The output amount should be less than input to cover fees.")
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                }
+                .padding()
+                .background(Color.gray.opacity(0.1))
+                .cornerRadius(10)
+                .padding(.horizontal)
+                
+                // Transfer Button
+                Button(action: executeTransfer) {
+                    HStack {
+                        if isLoading {
+                            ProgressView()
+                                .progressViewStyle(CircularProgressViewStyle(tint: .white))
+                        } else {
+                            Image(systemName: "arrow.right.circle.fill")
+                        }
+                        Text(isLoading ? "Transferring..." : "Execute Transfer")
+                            .fontWeight(.semibold)
+                    }
+                    .frame(maxWidth: .infinity)
+                    .padding()
+                    .background(isLoading || !isFormValid ? Color.gray : Color.orange)
+                    .foregroundColor(.white)
+                    .cornerRadius(10)
+                }
+                .disabled(isLoading || !isFormValid || appState.platformState.sdk == nil)
+                .padding(.horizontal)
+                
+                // Result
+                if showResult {
+                    VStack(alignment: .leading, spacing: 12) {
+                        Text("Result")
+                            .font(.headline)
+                        
+                        if let error = errorMessage {
+                            HStack(alignment: .top) {
+                                Image(systemName: "xmark.circle.fill")
+                                    .foregroundColor(.red)
+                                Text(error)
+                                    .foregroundColor(.red)
+                            }
+                            .padding()
+                            .background(Color.red.opacity(0.1))
+                            .cornerRadius(8)
+                        } else if let result = result {
+                            VStack(alignment: .leading, spacing: 12) {
+                                Label("Transfer Successful!", systemImage: "checkmark.circle.fill")
+                                    .foregroundColor(.green)
+                                    .font(.headline)
+                                
+                                Text("Updated Balances:")
+                                    .font(.subheadline)
+                                    .fontWeight(.medium)
+                                
+                                ForEach(Array(result.infos.values), id: \.addressHex) { info in
+                                    VStack(alignment: .leading, spacing: 4) {
+                                        Text(info.addressHex.prefix(20) + "...")
+                                            .font(.caption)
+                                            .monospaced()
+                                        HStack {
+                                            Text("\(formatCredits(info.balance)) credits")
+                                            Text("•")
+                                            Text("\(formatDash(info.balance)) DASH")
+                                                .foregroundColor(.blue)
+                                        }
+                                        .font(.caption)
+                                    }
+                                    .padding(8)
+                                    .background(Color.green.opacity(0.1))
+                                    .cornerRadius(6)
+                                }
+                            }
+                            .padding()
+                            .background(Color.green.opacity(0.05))
+                            .cornerRadius(8)
+                        }
+                    }
+                    .padding()
+                }
+                
+                Spacer()
+            }
+        }
+        .navigationTitle("Transfer Funds")
+        .navigationBarTitleDisplayMode(.inline)
+    }
+    
+    private var isFormValid: Bool {
+        guard inputAddressHex.count == 42,
+              inputPrivateKeyHex.count == 64,
+              outputAddressHex.count == 42,
+              let inputAmt = UInt64(inputAmount), inputAmt > 0,
+              let outputAmt = UInt64(outputAmount), outputAmt > 0
+        else { return false }
+        
+        // Basic hex validation
+        let hexChars = CharacterSet(charactersIn: "0123456789abcdefABCDEF")
+        guard inputAddressHex.unicodeScalars.allSatisfy({ hexChars.contains($0) }),
+              inputPrivateKeyHex.unicodeScalars.allSatisfy({ hexChars.contains($0) }),
+              outputAddressHex.unicodeScalars.allSatisfy({ hexChars.contains($0) })
+        else { return false }
+        
+        return true
+    }
+    
+    private func executeTransfer() {
+        guard let sdk = appState.platformState.sdk else { return }
+        
+        guard let inputAddressData = Data(hexString: inputAddressHex),
+              let privateKeyData = Data(hexString: inputPrivateKeyHex),
+              let outputAddressData = Data(hexString: outputAddressHex),
+              let inputAmt = UInt64(inputAmount),
+              let outputAmt = UInt64(outputAmount)
+        else {
+            errorMessage = "Invalid input data"
+            showResult = true
+            return
+        }
+        
+        isLoading = true
+        errorMessage = nil
+        result = nil
+        showResult = false
+        
+        Task {
+            do {
+                let inputs = [
+                    Addresses.AddressTransferInput(
+                        addressBytes: inputAddressData,
+                        amount: inputAmt,
+                        nonce: 0,
+                        privateKey: privateKeyData
+                    )
+                ]
+                
+                let outputs = [
+                    Addresses.AddressTransferOutput(
+                        addressBytes: outputAddressData,
+                        amount: outputAmt
+                    )
+                ]
+                
+                let transferResult = try sdk.addresses.transferFunds(
+                    inputs: inputs,
+                    outputs: outputs,
+                    feeFromInputIndex: 0
+                )
+                
+                await MainActor.run {
+                    result = transferResult
+                    showResult = true
+                    isLoading = false
+                }
+            } catch {
+                await MainActor.run {
+                    errorMessage = error.localizedDescription
+                    showResult = true
+                    isLoading = false
+                }
+            }
+        }
+    }
+}
+
+// MARK: - Withdraw Address Funds View
+
+struct WithdrawAddressFundsView: View {
+    @EnvironmentObject var appState: UnifiedAppState
+    
+    // Input state
+    @State private var inputAddressHex: String = ""
+    @State private var inputAmount: String = ""
+    @State private var inputPrivateKeyHex: String = ""
+    
+    // Core address state
+    @State private var coreAddress: String = ""
+    
+    // Optional change address
+    @State private var changeAddressHex: String = ""
+    @State private var useChangeAddress: Bool = false
+    
+    // Advanced options
+    @State private var coreFeePerByte: String = "1"
+    @State private var poolingStrategy: Addresses.PoolingStrategy = .never
+    
+    // Result state
+    @State private var isLoading = false
+    @State private var result: PlatformAddressInfosResult?
+    @State private var errorMessage: String?
+    @State private var showResult = false
+    
+    var body: some View {
+        ScrollView {
+            VStack(spacing: 20) {
+                // Header
+                VStack(alignment: .leading, spacing: 8) {
+                    Text("Withdraw Address Funds")
+                        .font(.title2)
+                        .fontWeight(.bold)
+                    
+                    Text("Withdraw credits from Platform addresses to a Dash Core (L1) address. This creates a state transition on-chain.")
+                        .font(.body)
+                        .foregroundColor(.secondary)
+                    
+                    Text("⚠️ This is an on-chain transaction. Requires valid Platform addresses with funds and correct private keys.")
+                        .font(.caption)
+                        .foregroundColor(.orange)
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding()
+                
+                // Input Address Section
+                VStack(alignment: .leading, spacing: 12) {
+                    Text("Input (Source Platform Address)")
+                        .font(.headline)
+                        .foregroundColor(.green)
+                    
+                    VStack(alignment: .leading, spacing: 4) {
+                        Text("Address (hex, 42 chars)")
+                            .font(.subheadline)
+                            .fontWeight(.medium)
+                        TextField("00...(21 bytes = 42 hex chars)", text: $inputAddressHex)
+                            .textFieldStyle(RoundedBorderTextFieldStyle())
+                            .autocapitalization(.none)
+                            .disableAutocorrection(true)
+                            .monospaced()
+                    }
+                    
+                    VStack(alignment: .leading, spacing: 4) {
+                        Text("Amount (credits)")
+                            .font(.subheadline)
+                            .fontWeight(.medium)
+                        TextField("e.g., 1000000000", text: $inputAmount)
+                            .textFieldStyle(RoundedBorderTextFieldStyle())
+                            .keyboardType(.numberPad)
+                        if let amount = UInt64(inputAmount), amount > 0 {
+                            Text("\(formatDash(amount)) DASH")
+                                .font(.caption)
+                                .foregroundColor(.blue)
+                        }
+                    }
+                    
+                    VStack(alignment: .leading, spacing: 4) {
+                        Text("Private Key (hex, 64 chars)")
+                            .font(.subheadline)
+                            .fontWeight(.medium)
+                        SecureField("32-byte private key as hex", text: $inputPrivateKeyHex)
+                            .textFieldStyle(RoundedBorderTextFieldStyle())
+                            .autocapitalization(.none)
+                            .disableAutocorrection(true)
+                            .monospaced()
+                        Text("Keep your private key secure!")
+                            .font(.caption)
+                            .foregroundColor(.red)
+                    }
+                }
+                .padding()
+                .background(Color.green.opacity(0.05))
+                .cornerRadius(10)
+                .padding(.horizontal)
+                
+                // Core Address Section
+                VStack(alignment: .leading, spacing: 12) {
+                    Text("Core (L1) Address (Destination)")
+                        .font(.headline)
+                        .foregroundColor(.blue)
+                    
+                    VStack(alignment: .leading, spacing: 4) {
+                        Text("Dash Core Address (base58)")
+                            .font(.subheadline)
+                            .fontWeight(.medium)
+                        TextField("e.g., yP8A3...", text: $coreAddress)
+                            .textFieldStyle(RoundedBorderTextFieldStyle())
+                            .autocapitalization(.none)
+                            .disableAutocorrection(true)
+                        Text("Base58-encoded Dash Core address (L1)")
+                            .font(.caption)
+                            .foregroundColor(.secondary)
+                    }
+                }
+                .padding()
+                .background(Color.blue.opacity(0.05))
+                .cornerRadius(10)
+                .padding(.horizontal)
+                
+                // Optional Change Address
+                VStack(alignment: .leading, spacing: 12) {
+                    Toggle("Use Change Address", isOn: $useChangeAddress)
+                        .font(.headline)
+                    
+                    if useChangeAddress {
+                        VStack(alignment: .leading, spacing: 4) {
+                            Text("Change Address (hex, 42 chars)")
+                                .font(.subheadline)
+                                .fontWeight(.medium)
+                            TextField("00...(21 bytes = 42 hex chars)", text: $changeAddressHex)
+                                .textFieldStyle(RoundedBorderTextFieldStyle())
+                                .autocapitalization(.none)
+                                .disableAutocorrection(true)
+                                .monospaced()
+                            Text("Platform address to receive change (optional)")
+                                .font(.caption)
+                                .foregroundColor(.secondary)
+                        }
+                    }
+                }
+                .padding()
+                .background(Color.gray.opacity(0.05))
+                .cornerRadius(10)
+                .padding(.horizontal)
+                
+                // Advanced Options
+                VStack(alignment: .leading, spacing: 12) {
+                    Text("Advanced Options")
+                        .font(.headline)
+                    
+                    VStack(alignment: .leading, spacing: 4) {
+                        Text("Core Fee Per Byte")
+                            .font(.subheadline)
+                            .fontWeight(.medium)
+                        TextField("e.g., 1", text: $coreFeePerByte)
+                            .textFieldStyle(RoundedBorderTextFieldStyle())
+                            .keyboardType(.numberPad)
+                        Text("0 means use default (1)")
+                            .font(.caption)
+                            .foregroundColor(.secondary)
+                    }
+                    
+                    VStack(alignment: .leading, spacing: 4) {
+                        Text("Pooling Strategy")
+                            .font(.subheadline)
+                            .fontWeight(.medium)
+                        Picker("Pooling", selection: $poolingStrategy) {
+                            Text("Never").tag(Addresses.PoolingStrategy.never)
+                            Text("If Available").tag(Addresses.PoolingStrategy.ifAvailable)
+                            Text("Standard").tag(Addresses.PoolingStrategy.standard)
+                        }
+                        .pickerStyle(SegmentedPickerStyle())
+                    }
+                }
+                .padding()
+                .background(Color.gray.opacity(0.05))
+                .cornerRadius(10)
+                .padding(.horizontal)
+                
+                // Info about fees
+                VStack(alignment: .leading, spacing: 4) {
+                    HStack {
+                        Image(systemName: "info.circle")
+                        Text("Fee Info")
+                    }
+                    .font(.subheadline)
+                    .fontWeight(.medium)
+                    
+                    Text("Network fees will be deducted from the input amount. Change (if any) will be sent to the change address if provided, otherwise it's lost.")
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                }
+                .padding()
+                .background(Color.gray.opacity(0.1))
+                .cornerRadius(10)
+                .padding(.horizontal)
+                
+                // Withdraw Button
+                Button(action: executeWithdrawal) {
+                    HStack {
+                        if isLoading {
+                            ProgressView()
+                                .progressViewStyle(CircularProgressViewStyle(tint: .white))
+                        } else {
+                            Image(systemName: "arrow.down.circle.fill")
+                        }
+                        Text(isLoading ? "Withdrawing..." : "Execute Withdrawal")
+                            .fontWeight(.semibold)
+                    }
+                    .frame(maxWidth: .infinity)
+                    .padding()
+                    .background(isLoading || !isFormValid ? Color.gray : Color.purple)
+                    .foregroundColor(.white)
+                    .cornerRadius(10)
+                }
+                .disabled(isLoading || !isFormValid || appState.platformState.sdk == nil)
+                .padding(.horizontal)
+                
+                // Result
+                if showResult {
+                    VStack(alignment: .leading, spacing: 12) {
+                        Text("Result")
+                            .font(.headline)
+                        
+                        if let error = errorMessage {
+                            HStack(alignment: .top) {
+                                Image(systemName: "xmark.circle.fill")
+                                    .foregroundColor(.red)
+                                Text(error)
+                                    .foregroundColor(.red)
+                            }
+                            .padding()
+                            .background(Color.red.opacity(0.1))
+                            .cornerRadius(8)
+                        } else if let result = result {
+                            VStack(alignment: .leading, spacing: 12) {
+                                Label("Withdrawal Successful!", systemImage: "checkmark.circle.fill")
+                                    .foregroundColor(.green)
+                                    .font(.headline)
+                                
+                                Text("Updated Balances:")
+                                    .font(.subheadline)
+                                    .fontWeight(.medium)
+                                
+                                ForEach(Array(result.infos.values), id: \.addressHex) { info in
+                                    VStack(alignment: .leading, spacing: 4) {
+                                        Text(info.addressHex.prefix(20) + "...")
+                                            .font(.caption)
+                                            .monospaced()
+                                        HStack {
+                                            Text("\(formatCredits(info.balance)) credits")
+                                            Text("•")
+                                            Text("\(formatDash(info.balance)) DASH")
+                                                .foregroundColor(.blue)
+                                        }
+                                        .font(.caption)
+                                    }
+                                    .padding(8)
+                                    .background(Color.green.opacity(0.1))
+                                    .cornerRadius(6)
+                                }
+                            }
+                            .padding()
+                            .background(Color.green.opacity(0.05))
+                            .cornerRadius(8)
+                        }
+                    }
+                    .padding()
+                }
+                
+                Spacer()
+            }
+        }
+        .navigationTitle("Withdraw Funds")
+        .navigationBarTitleDisplayMode(.inline)
+    }
+    
+    private var isFormValid: Bool {
+        guard inputAddressHex.count == 42,
+              inputPrivateKeyHex.count == 64,
+              !coreAddress.isEmpty,
+              let inputAmt = UInt64(inputAmount), inputAmt > 0
+        else { return false }
+        
+        // Basic hex validation
+        let hexChars = CharacterSet(charactersIn: "0123456789abcdefABCDEF")
+        guard inputAddressHex.unicodeScalars.allSatisfy({ hexChars.contains($0) }),
+              inputPrivateKeyHex.unicodeScalars.allSatisfy({ hexChars.contains($0) })
+        else { return false }
+        
+        // Validate change address if used
+        if useChangeAddress {
+            guard changeAddressHex.count == 42,
+                  changeAddressHex.unicodeScalars.allSatisfy({ hexChars.contains($0) })
+            else { return false }
+        }
+        
+        return true
+    }
+    
+    private func executeWithdrawal() {
+        guard let sdk = appState.platformState.sdk else { return }
+        
+        guard let inputAddressData = Data(hexString: inputAddressHex),
+              let privateKeyData = Data(hexString: inputPrivateKeyHex),
+              let inputAmt = UInt64(inputAmount)
+        else {
+            errorMessage = "Invalid input data"
+            showResult = true
+            return
+        }
+        
+        let coreFee = UInt32(coreFeePerByte) ?? 0
+        
+        isLoading = true
+        errorMessage = nil
+        result = nil
+        showResult = false
+        
+        Task {
+            do {
+                let inputs = [
+                    Addresses.AddressTransferInput(
+                        addressBytes: inputAddressData,
+                        amount: inputAmt,
+                        nonce: 0,
+                        privateKey: privateKeyData
+                    )
+                ]
+                
+                let changeAddressData: Data? = if useChangeAddress, let change = Data(hexString: changeAddressHex) {
+                    change
+                } else {
+                    nil
+                }
+                
+                let withdrawalResult = try sdk.addresses.withdrawFunds(
+                    inputs: inputs,
+                    coreAddress: coreAddress,
+                    coreFeePerByte: coreFee,
+                    pooling: poolingStrategy,
+                    feeFromInputIndex: 0,
+                    changeAddress: changeAddressData
+                )
+                
+                await MainActor.run {
+                    result = withdrawalResult
+                    showResult = true
+                    isLoading = false
+                }
+            } catch {
+                await MainActor.run {
+                    errorMessage = error.localizedDescription
+                    showResult = true
+                    isLoading = false
+                }
+            }
+        }
+    }
+}
+
+// MARK: - Top Up Address From Asset Lock View
+
+struct TopUpAddressFromAssetLockView: View {
+    @EnvironmentObject var appState: UnifiedAppState
+    
+    @State private var proofType: Addresses.AssetLockProofType = Addresses.AssetLockProofType.instant
+    @State private var outputAddressHex: String = ""
+    @State private var outputAmount: String = ""
+    @State private var assetLockPrivateKeyHex: String = ""
+    
+    // Instant lock fields
+    @State private var instantLockHex: String = ""
+    @State private var transactionHex: String = ""
+    @State private var outputIndex: String = "0"
+    
+    // Chain lock fields
+    @State private var coreChainLockedHeight: String = ""
+    @State private var outPointHex: String = ""
+    
+    @State private var isLoading = false
+    @State private var result: PlatformAddressInfosResult?
+    @State private var errorMessage: String?
+    @State private var showResult = false
+    
+    var body: some View {
+        ScrollView {
+            VStack(spacing: 20) {
+                // Header
+                VStack(alignment: .leading, spacing: 8) {
+                    Text("Top Up Address (Asset Lock)")
+                        .font(.title2)
+                        .fontWeight(.bold)
+                    
+                    Text("Fund Platform addresses from a Dash Core asset lock (instant or chain lock).")
+                        .font(.body)
+                        .foregroundColor(.secondary)
+                    
+                    Text("⚠️ This requires proper asset lock proof data from Dash Core transactions.")
+                        .font(.caption)
+                        .foregroundColor(.orange)
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding()
+                
+                // Proof Type Selector
+                VStack(alignment: .leading, spacing: 12) {
+                    Text("Asset Lock Proof Type")
+                        .font(.headline)
+                    
+                    Picker("Proof Type", selection: $proofType) {
+                        Text("Instant Lock").tag(Addresses.AssetLockProofType.instant as Addresses.AssetLockProofType)
+                        Text("Chain Lock").tag(Addresses.AssetLockProofType.chain as Addresses.AssetLockProofType)
+                    }
+                    .pickerStyle(SegmentedPickerStyle())
+                }
+                .padding()
+                .background(Color.gray.opacity(0.05))
+                .cornerRadius(10)
+                .padding(.horizontal)
+                
+                // Proof-specific fields
+                if proofType == Addresses.AssetLockProofType.instant {
+                    VStack(alignment: .leading, spacing: 12) {
+                        Text("Instant Lock Proof")
+                            .font(.headline)
+                            .foregroundColor(.blue)
+                        
+                        VStack(alignment: .leading, spacing: 4) {
+                            Text("Instant Lock (hex)")
+                                .font(.subheadline)
+                                .fontWeight(.medium)
+                            TextField("Instant lock bytes as hex", text: $instantLockHex)
+                                .textFieldStyle(RoundedBorderTextFieldStyle())
+                                .autocapitalization(.none)
+                                .disableAutocorrection(true)
+                                .monospaced()
+                        }
+                        
+                        VStack(alignment: .leading, spacing: 4) {
+                            Text("Transaction (hex)")
+                                .font(.subheadline)
+                                .fontWeight(.medium)
+                            TextField("Transaction bytes as hex", text: $transactionHex)
+                                .textFieldStyle(RoundedBorderTextFieldStyle())
+                                .autocapitalization(.none)
+                                .disableAutocorrection(true)
+                                .monospaced()
+                        }
+                        
+                        VStack(alignment: .leading, spacing: 4) {
+                            Text("Output Index")
+                                .font(.subheadline)
+                                .fontWeight(.medium)
+                            TextField("0", text: $outputIndex)
+                                .textFieldStyle(RoundedBorderTextFieldStyle())
+                                .keyboardType(.numberPad)
+                        }
+                    }
+                    .padding()
+                    .background(Color.blue.opacity(0.05))
+                    .cornerRadius(10)
+                    .padding(.horizontal)
+                } else {
+                    VStack(alignment: .leading, spacing: 12) {
+                        Text("Chain Lock Proof")
+                            .font(.headline)
+                            .foregroundColor(.purple)
+                        
+                        VStack(alignment: .leading, spacing: 4) {
+                            Text("Core Chain Locked Height")
+                                .font(.subheadline)
+                                .fontWeight(.medium)
+                            TextField("Block height", text: $coreChainLockedHeight)
+                                .textFieldStyle(RoundedBorderTextFieldStyle())
+                                .keyboardType(.numberPad)
+                        }
+                        
+                        VStack(alignment: .leading, spacing: 4) {
+                            Text("Out Point (hex, 72 chars)")
+                                .font(.subheadline)
+                                .fontWeight(.medium)
+                            TextField("36 bytes = 72 hex chars (32 txid + 4 vout)", text: $outPointHex)
+                                .textFieldStyle(RoundedBorderTextFieldStyle())
+                                .autocapitalization(.none)
+                                .disableAutocorrection(true)
+                                .monospaced()
+                        }
+                    }
+                    .padding()
+                    .background(Color.purple.opacity(0.05))
+                    .cornerRadius(10)
+                    .padding(.horizontal)
+                }
+                
+                // Output Address
+                VStack(alignment: .leading, spacing: 12) {
+                    Text("Output (Platform Address)")
+                        .font(.headline)
+                        .foregroundColor(.green)
+                    
+                    VStack(alignment: .leading, spacing: 4) {
+                        Text("Address (hex, 42 chars)")
+                            .font(.subheadline)
+                            .fontWeight(.medium)
+                        TextField("00...(21 bytes = 42 hex chars)", text: $outputAddressHex)
+                            .textFieldStyle(RoundedBorderTextFieldStyle())
+                            .autocapitalization(.none)
+                            .disableAutocorrection(true)
+                            .monospaced()
+                    }
+                    
+                    VStack(alignment: .leading, spacing: 4) {
+                        Text("Amount (credits, optional)")
+                            .font(.subheadline)
+                            .fontWeight(.medium)
+                        TextField("0 = SDK calculates", text: $outputAmount)
+                            .textFieldStyle(RoundedBorderTextFieldStyle())
+                            .keyboardType(.numberPad)
+                        if let amount = UInt64(outputAmount), amount > 0 {
+                            Text("\(formatDash(amount)) DASH")
+                                .font(.caption)
+                                .foregroundColor(.blue)
+                        }
+                    }
+                }
+                .padding()
+                .background(Color.green.opacity(0.05))
+                .cornerRadius(10)
+                .padding(.horizontal)
+                
+                // Private Key
+                VStack(alignment: .leading, spacing: 12) {
+                    Text("Asset Lock Private Key")
+                        .font(.headline)
+                        .foregroundColor(.red)
+                    
+                    VStack(alignment: .leading, spacing: 4) {
+                        Text("Private Key (hex, 64 chars)")
+                            .font(.subheadline)
+                            .fontWeight(.medium)
+                        SecureField("32-byte private key as hex", text: $assetLockPrivateKeyHex)
+                            .textFieldStyle(RoundedBorderTextFieldStyle())
+                            .autocapitalization(.none)
+                            .disableAutocorrection(true)
+                            .monospaced()
+                        Text("Keep your private key secure!")
+                            .font(.caption)
+                            .foregroundColor(.red)
+                    }
+                }
+                .padding()
+                .background(Color.red.opacity(0.05))
+                .cornerRadius(10)
+                .padding(.horizontal)
+                
+                // Top Up Button
+                Button(action: executeTopUp) {
+                    HStack {
+                        if isLoading {
+                            ProgressView()
+                                .progressViewStyle(CircularProgressViewStyle(tint: .white))
+                        } else {
+                            Image(systemName: "arrow.up.circle.fill")
+                        }
+                        Text(isLoading ? "Topping Up..." : "Execute Top Up")
+                            .fontWeight(.semibold)
+                    }
+                    .frame(maxWidth: .infinity)
+                    .padding()
+                    .background(isLoading || !isFormValid ? Color.gray : Color.orange)
+                    .foregroundColor(.white)
+                    .cornerRadius(10)
+                }
+                .disabled(isLoading || !isFormValid || appState.platformState.sdk == nil)
+                .padding(.horizontal)
+                
+                // Result
+                if showResult {
+                    VStack(alignment: .leading, spacing: 12) {
+                        Text("Result")
+                            .font(.headline)
+                        
+                        if let error = errorMessage {
+                            HStack(alignment: .top) {
+                                Image(systemName: "xmark.circle.fill")
+                                    .foregroundColor(.red)
+                                Text(error)
+                                    .foregroundColor(.red)
+                            }
+                            .padding()
+                            .background(Color.red.opacity(0.1))
+                            .cornerRadius(8)
+                        } else if let result = result {
+                            VStack(alignment: .leading, spacing: 12) {
+                                Label("Top Up Successful!", systemImage: "checkmark.circle.fill")
+                                    .foregroundColor(.green)
+                                    .font(.headline)
+                                
+                                Text("Updated Balances:")
+                                    .font(.subheadline)
+                                    .fontWeight(.medium)
+                                
+                                ForEach(Array(result.infos.values), id: \.addressHex) { info in
+                                    VStack(alignment: .leading, spacing: 4) {
+                                        Text(info.addressHex.prefix(20) + "...")
+                                            .font(.caption)
+                                            .monospaced()
+                                        HStack {
+                                            Text("\(formatCredits(info.balance)) credits")
+                                            Text("•")
+                                            Text("\(formatDash(info.balance)) DASH")
+                                                .foregroundColor(.blue)
+                                        }
+                                        .font(.caption)
+                                    }
+                                    .padding(8)
+                                    .background(Color.green.opacity(0.1))
+                                    .cornerRadius(6)
+                                }
+                            }
+                            .padding()
+                            .background(Color.green.opacity(0.05))
+                            .cornerRadius(8)
+                        }
+                    }
+                    .padding()
+                }
+                
+                Spacer()
+            }
+        }
+        .navigationTitle("Top Up Address")
+        .navigationBarTitleDisplayMode(.inline)
+    }
+    
+    private var isFormValid: Bool {
+        guard outputAddressHex.count == 42,
+              assetLockPrivateKeyHex.count == 64
+        else { return false }
+        
+        let hexChars = CharacterSet(charactersIn: "0123456789abcdefABCDEF")
+        guard outputAddressHex.unicodeScalars.allSatisfy({ hexChars.contains($0) }),
+              assetLockPrivateKeyHex.unicodeScalars.allSatisfy({ hexChars.contains($0) })
+        else { return false }
+        
+        if proofType == Addresses.AssetLockProofType.instant {
+            guard !instantLockHex.isEmpty,
+                  !transactionHex.isEmpty,
+                  UInt32(outputIndex) != nil
+            else { return false }
+        } else {
+            guard !coreChainLockedHeight.isEmpty,
+                  outPointHex.count == 72,
+                  UInt32(coreChainLockedHeight) != nil,
+                  outPointHex.unicodeScalars.allSatisfy({ hexChars.contains($0) })
+            else { return false }
+        }
+        
+        return true
+    }
+    
+    private func executeTopUp() {
+        guard let sdk = appState.platformState.sdk else { return }
+        
+        guard let outputAddressData = Data(hexString: outputAddressHex),
+              let privateKeyData = Data(hexString: assetLockPrivateKeyHex)
+        else {
+            errorMessage = "Invalid input data"
+            showResult = true
+            return
+        }
+        
+        let outputAmountValue = UInt64(outputAmount) ?? 0
+        
+        isLoading = true
+        errorMessage = nil
+        result = nil
+        showResult = false
+        
+        Task {
+            do {
+                let outputs = [
+                    Addresses.AddressTransferOutput(
+                        addressBytes: outputAddressData,
+                        amount: outputAmountValue
+                    )
+                ]
+                
+                let result: PlatformAddressInfosResult
+                
+                if proofType == Addresses.AssetLockProofType.instant {
+                    guard let instantLockData = Data(hexString: instantLockHex),
+                          let transactionData = Data(hexString: transactionHex),
+                          let outputIdx = UInt32(outputIndex)
+                    else {
+                        await MainActor.run {
+                            errorMessage = "Invalid instant lock data"
+                            showResult = true
+                            isLoading = false
+                        }
+                        return
+                    }
+                    
+                    result = try sdk.addresses.topUpAddressFromAssetLock(
+                        proofType: Addresses.AssetLockProofType.instant,
+                        instantLockData: instantLockData,
+                        transactionData: transactionData,
+                        outputIndex: outputIdx,
+                        coreChainLockedHeight: 0,
+                        outPoint: nil,
+                        assetLockPrivateKey: privateKeyData,
+                        outputs: outputs
+                    )
+                } else {
+                    guard let outPointData = Data(hexString: outPointHex),
+                          let height = UInt32(coreChainLockedHeight)
+                    else {
+                        await MainActor.run {
+                            errorMessage = "Invalid chain lock data"
+                            showResult = true
+                            isLoading = false
+                        }
+                        return
+                    }
+                    
+                    result = try sdk.addresses.topUpAddressFromAssetLock(
+                        proofType: Addresses.AssetLockProofType.chain,
+                        instantLockData: nil,
+                        transactionData: nil,
+                        outputIndex: 0,
+                        coreChainLockedHeight: height,
+                        outPoint: outPointData,
+                        assetLockPrivateKey: privateKeyData,
+                        outputs: outputs
+                    )
+                }
+                
+                await MainActor.run {
+                    self.result = result
+                    showResult = true
+                    isLoading = false
+                }
+            } catch {
+                await MainActor.run {
+                    errorMessage = error.localizedDescription
+                    showResult = true
+                    isLoading = false
+                }
+            }
+        }
+    }
+}
+
+// MARK: - Top Up Identity From Addresses View
+
+struct TopUpIdentityFromAddressesView: View {
+    @EnvironmentObject var appState: UnifiedAppState
+    
+    @State private var identityId: String = ""
+    @State private var inputAddressHex: String = ""
+    @State private var inputAmount: String = ""
+    @State private var inputNonce: String = "0"
+    @State private var inputPrivateKeyHex: String = ""
+    
+    @State private var isLoading = false
+    @State private var result: (identityBalance: UInt64, addressInfos: PlatformAddressInfosResult)?
+    @State private var errorMessage: String?
+    @State private var showResult = false
+    
+    var body: some View {
+        ScrollView {
+            VStack(spacing: 20) {
+                // Header
+                VStack(alignment: .leading, spacing: 8) {
+                    Text("Top Up Identity (From Addresses)")
+                        .font(.title2)
+                        .fontWeight(.bold)
+                    
+                    Text("Top up an identity using Platform address balances.")
+                        .font(.body)
+                        .foregroundColor(.secondary)
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding()
+                
+                // Identity ID
+                VStack(alignment: .leading, spacing: 12) {
+                    Text("Identity ID")
+                        .font(.headline)
+                        .foregroundColor(.blue)
+                    
+                    VStack(alignment: .leading, spacing: 4) {
+                        Text("Base58-encoded Identity ID")
+                            .font(.subheadline)
+                            .fontWeight(.medium)
+                        TextField("e.g., 5Xy...", text: $identityId)
+                            .textFieldStyle(RoundedBorderTextFieldStyle())
+                            .autocapitalization(.none)
+                            .disableAutocorrection(true)
+                    }
+                }
+                .padding()
+                .background(Color.blue.opacity(0.05))
+                .cornerRadius(10)
+                .padding(.horizontal)
+                
+                // Input Address
+                VStack(alignment: .leading, spacing: 12) {
+                    Text("Input Address")
+                        .font(.headline)
+                        .foregroundColor(.green)
+                    
+                    VStack(alignment: .leading, spacing: 4) {
+                        Text("Address (hex, 42 chars)")
+                            .font(.subheadline)
+                            .fontWeight(.medium)
+                        TextField("00...(21 bytes = 42 hex chars)", text: $inputAddressHex)
+                            .textFieldStyle(RoundedBorderTextFieldStyle())
+                            .autocapitalization(.none)
+                            .disableAutocorrection(true)
+                            .monospaced()
+                    }
+                    
+                    VStack(alignment: .leading, spacing: 4) {
+                        Text("Amount (credits)")
+                            .font(.subheadline)
+                            .fontWeight(.medium)
+                        TextField("0", text: $inputAmount)
+                            .textFieldStyle(RoundedBorderTextFieldStyle())
+                            .keyboardType(.numberPad)
+                        if let amount = UInt64(inputAmount), amount > 0 {
+                            Text("\(formatDash(amount)) DASH")
+                                .font(.caption)
+                                .foregroundColor(.blue)
+                        }
+                    }
+                    
+                    VStack(alignment: .leading, spacing: 4) {
+                        Text("Nonce (0 = auto-fetch)")
+                            .font(.subheadline)
+                            .fontWeight(.medium)
+                        TextField("0", text: $inputNonce)
+                            .textFieldStyle(RoundedBorderTextFieldStyle())
+                            .keyboardType(.numberPad)
+                    }
+                    
+                    VStack(alignment: .leading, spacing: 4) {
+                        Text("Private Key (hex, 64 chars)")
+                            .font(.subheadline)
+                            .fontWeight(.medium)
+                        SecureField("32-byte private key as hex", text: $inputPrivateKeyHex)
+                            .textFieldStyle(RoundedBorderTextFieldStyle())
+                            .autocapitalization(.none)
+                            .disableAutocorrection(true)
+                            .monospaced()
+                        Text("Keep your private key secure!")
+                            .font(.caption)
+                            .foregroundColor(.red)
+                    }
+                }
+                .padding()
+                .background(Color.green.opacity(0.05))
+                .cornerRadius(10)
+                .padding(.horizontal)
+                
+                // Execute Button
+                Button(action: executeTopUp) {
+                    HStack {
+                        if isLoading {
+                            ProgressView()
+                                .progressViewStyle(CircularProgressViewStyle(tint: .white))
+                        } else {
+                            Image(systemName: "arrow.up.circle.fill")
+                        }
+                        Text(isLoading ? "Topping Up..." : "Execute Top Up")
+                            .fontWeight(.semibold)
+                    }
+                    .frame(maxWidth: .infinity)
+                    .padding()
+                    .background(isLoading || !isFormValid ? Color.gray : Color.orange)
+                    .foregroundColor(.white)
+                    .cornerRadius(10)
+                }
+                .disabled(isLoading || !isFormValid || appState.platformState.sdk == nil)
+                .padding(.horizontal)
+                
+                // Result
+                if showResult {
+                    VStack(alignment: .leading, spacing: 12) {
+                        Text("Result")
+                            .font(.headline)
+                        
+                        if let error = errorMessage {
+                            HStack(alignment: .top) {
+                                Image(systemName: "xmark.circle.fill")
+                                    .foregroundColor(.red)
+                                Text(error)
+                                    .foregroundColor(.red)
+                            }
+                            .padding()
+                            .background(Color.red.opacity(0.1))
+                            .cornerRadius(8)
+                        } else if let result = result {
+                            VStack(alignment: .leading, spacing: 12) {
+                                Label("Top Up Successful!", systemImage: "checkmark.circle.fill")
+                                    .foregroundColor(.green)
+                                    .font(.headline)
+                                
+                                VStack(alignment: .leading, spacing: 4) {
+                                    Text("Identity Balance:")
+                                        .font(.subheadline)
+                                        .fontWeight(.medium)
+                                    HStack {
+                                        Text("\(formatCredits(result.identityBalance)) credits")
+                                        Text("•")
+                                        Text("\(formatDash(result.identityBalance)) DASH")
+                                            .foregroundColor(.blue)
+                                    }
+                                    .font(.caption)
+                                }
+                                .padding(8)
+                                .background(Color.green.opacity(0.1))
+                                .cornerRadius(6)
+                                
+                                Text("Updated Address Balances:")
+                                    .font(.subheadline)
+                                    .fontWeight(.medium)
+                                
+                                ForEach(Array(result.addressInfos.infos.values), id: \.addressHex) { info in
+                                    VStack(alignment: .leading, spacing: 4) {
+                                        Text(info.addressHex.prefix(20) + "...")
+                                            .font(.caption)
+                                            .monospaced()
+                                        HStack {
+                                            Text("\(formatCredits(info.balance)) credits")
+                                            Text("•")
+                                            Text("\(formatDash(info.balance)) DASH")
+                                                .foregroundColor(.blue)
+                                        }
+                                        .font(.caption)
+                                    }
+                                    .padding(8)
+                                    .background(Color.green.opacity(0.1))
+                                    .cornerRadius(6)
+                                }
+                            }
+                            .padding()
+                            .background(Color.green.opacity(0.05))
+                            .cornerRadius(8)
+                        }
+                    }
+                    .padding()
+                }
+                
+                Spacer()
+            }
+        }
+        .navigationTitle("Top Up Identity")
+        .navigationBarTitleDisplayMode(.inline)
+    }
+    
+    private var isFormValid: Bool {
+        guard !identityId.isEmpty,
+              inputAddressHex.count == 42,
+              inputPrivateKeyHex.count == 64,
+              let amount = UInt64(inputAmount), amount > 0
+        else { return false }
+        
+        let hexChars = CharacterSet(charactersIn: "0123456789abcdefABCDEF")
+        guard inputAddressHex.unicodeScalars.allSatisfy({ hexChars.contains($0) }),
+              inputPrivateKeyHex.unicodeScalars.allSatisfy({ hexChars.contains($0) })
+        else { return false }
+        
+        return true
+    }
+    
+    private func executeTopUp() {
+        guard let sdk = appState.platformState.sdk else { return }
+        
+        guard let inputAddressData = Data(hexString: inputAddressHex),
+              let privateKeyData = Data(hexString: inputPrivateKeyHex),
+              let amount = UInt64(inputAmount),
+              let nonce = UInt32(inputNonce)
+        else {
+            errorMessage = "Invalid input data"
+            showResult = true
+            return
+        }
+        
+        isLoading = true
+        errorMessage = nil
+        result = nil
+        showResult = false
+        
+        Task { @MainActor in
+            do {
+                let inputs = [
+                    Addresses.AddressTransferInput(
+                        addressBytes: inputAddressData,
+                        amount: amount,
+                        nonce: nonce,
+                        privateKey: privateKeyData
+                    )
+                ]
+                
+                let result = try await sdk.addresses.topUpIdentityFromAddresses(
+                    identityId: identityId,
+                    inputs: inputs
+                )
+                
+                self.result = result
+                showResult = true
+                isLoading = false
+            } catch {
+                errorMessage = error.localizedDescription
+                showResult = true
+                isLoading = false
+            }
+        }
+    }
+}
+
+// MARK: - Transfer Identity To Addresses View
+
+struct TransferIdentityToAddressesView: View {
+    @EnvironmentObject var appState: UnifiedAppState
+    
+    @State private var identityId: String = ""
+    @State private var outputAddressHex: String = ""
+    @State private var outputAmount: String = ""
+    @State private var identityPrivateKeyHex: String = ""
+    @State private var publicKeyId: String = "0"
+    
+    @State private var isLoading = false
+    @State private var result: (identityBalance: UInt64, addressInfos: PlatformAddressInfosResult)?
+    @State private var errorMessage: String?
+    @State private var showResult = false
+    
+    var body: some View {
+        ScrollView {
+            VStack(spacing: 20) {
+                // Header
+                VStack(alignment: .leading, spacing: 8) {
+                    Text("Transfer Identity → Addresses")
+                        .font(.title2)
+                        .fontWeight(.bold)
+                    
+                    Text("Transfer credits from an identity to Platform addresses.")
+                        .font(.body)
+                        .foregroundColor(.secondary)
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding()
+                
+                // Identity ID
+                VStack(alignment: .leading, spacing: 12) {
+                    Text("Identity ID")
+                        .font(.headline)
+                        .foregroundColor(.blue)
+                    
+                    VStack(alignment: .leading, spacing: 4) {
+                        Text("Base58-encoded Identity ID")
+                            .font(.subheadline)
+                            .fontWeight(.medium)
+                        TextField("e.g., 5Xy...", text: $identityId)
+                            .textFieldStyle(RoundedBorderTextFieldStyle())
+                            .autocapitalization(.none)
+                            .disableAutocorrection(true)
+                    }
+                }
+                .padding()
+                .background(Color.blue.opacity(0.05))
+                .cornerRadius(10)
+                .padding(.horizontal)
+                
+                // Output Address
+                VStack(alignment: .leading, spacing: 12) {
+                    Text("Output Address")
+                        .font(.headline)
+                        .foregroundColor(.green)
+                    
+                    VStack(alignment: .leading, spacing: 4) {
+                        Text("Address (hex, 42 chars)")
+                            .font(.subheadline)
+                            .fontWeight(.medium)
+                        TextField("00...(21 bytes = 42 hex chars)", text: $outputAddressHex)
+                            .textFieldStyle(RoundedBorderTextFieldStyle())
+                            .autocapitalization(.none)
+                            .disableAutocorrection(true)
+                            .monospaced()
+                    }
+                    
+                    VStack(alignment: .leading, spacing: 4) {
+                        Text("Amount (credits)")
+                            .font(.subheadline)
+                            .fontWeight(.medium)
+                        TextField("0", text: $outputAmount)
+                            .textFieldStyle(RoundedBorderTextFieldStyle())
+                            .keyboardType(.numberPad)
+                        if let amount = UInt64(outputAmount), amount > 0 {
+                            Text("\(formatDash(amount)) DASH")
+                                .font(.caption)
+                                .foregroundColor(.blue)
+                        }
+                    }
+                }
+                .padding()
+                .background(Color.green.opacity(0.05))
+                .cornerRadius(10)
+                .padding(.horizontal)
+                
+                // Identity Private Key
+                VStack(alignment: .leading, spacing: 12) {
+                    Text("Identity Private Key")
+                        .font(.headline)
+                        .foregroundColor(.red)
+                    
+                    VStack(alignment: .leading, spacing: 4) {
+                        Text("Private Key (hex, 64 chars)")
+                            .font(.subheadline)
+                            .fontWeight(.medium)
+                        SecureField("32-byte private key as hex", text: $identityPrivateKeyHex)
+                            .textFieldStyle(RoundedBorderTextFieldStyle())
+                            .autocapitalization(.none)
+                            .disableAutocorrection(true)
+                            .monospaced()
+                        Text("Keep your private key secure!")
+                            .font(.caption)
+                            .foregroundColor(.red)
+                    }
+                    
+                    VStack(alignment: .leading, spacing: 4) {
+                        Text("Public Key ID (0 = auto-select TRANSFER key)")
+                            .font(.subheadline)
+                            .fontWeight(.medium)
+                        TextField("0", text: $publicKeyId)
+                            .textFieldStyle(RoundedBorderTextFieldStyle())
+                            .keyboardType(.numberPad)
+                    }
+                }
+                .padding()
+                .background(Color.red.opacity(0.05))
+                .cornerRadius(10)
+                .padding(.horizontal)
+                
+                // Execute Button
+                Button(action: executeTransfer) {
+                    HStack {
+                        if isLoading {
+                            ProgressView()
+                                .progressViewStyle(CircularProgressViewStyle(tint: .white))
+                        } else {
+                            Image(systemName: "arrow.right.circle.fill")
+                        }
+                        Text(isLoading ? "Transferring..." : "Execute Transfer")
+                            .fontWeight(.semibold)
+                    }
+                    .frame(maxWidth: .infinity)
+                    .padding()
+                    .background(isLoading || !isFormValid ? Color.gray : Color.orange)
+                    .foregroundColor(.white)
+                    .cornerRadius(10)
+                }
+                .disabled(isLoading || !isFormValid || appState.platformState.sdk == nil)
+                .padding(.horizontal)
+                
+                // Result
+                if showResult {
+                    VStack(alignment: .leading, spacing: 12) {
+                        Text("Result")
+                            .font(.headline)
+                        
+                        if let error = errorMessage {
+                            HStack(alignment: .top) {
+                                Image(systemName: "xmark.circle.fill")
+                                    .foregroundColor(.red)
+                                Text(error)
+                                    .foregroundColor(.red)
+                            }
+                            .padding()
+                            .background(Color.red.opacity(0.1))
+                            .cornerRadius(8)
+                        } else if let result = result {
+                            VStack(alignment: .leading, spacing: 12) {
+                                Label("Transfer Successful!", systemImage: "checkmark.circle.fill")
+                                    .foregroundColor(.green)
+                                    .font(.headline)
+                                
+                                VStack(alignment: .leading, spacing: 4) {
+                                    Text("Identity Balance:")
+                                        .font(.subheadline)
+                                        .fontWeight(.medium)
+                                    HStack {
+                                        Text("\(formatCredits(result.identityBalance)) credits")
+                                        Text("•")
+                                        Text("\(formatDash(result.identityBalance)) DASH")
+                                            .foregroundColor(.blue)
+                                    }
+                                    .font(.caption)
+                                }
+                                .padding(8)
+                                .background(Color.green.opacity(0.1))
+                                .cornerRadius(6)
+                                
+                                Text("Updated Address Balances:")
+                                    .font(.subheadline)
+                                    .fontWeight(.medium)
+                                
+                                ForEach(Array(result.addressInfos.infos.values), id: \.addressHex) { info in
+                                    VStack(alignment: .leading, spacing: 4) {
+                                        Text(info.addressHex.prefix(20) + "...")
+                                            .font(.caption)
+                                            .monospaced()
+                                        HStack {
+                                            Text("\(formatCredits(info.balance)) credits")
+                                            Text("•")
+                                            Text("\(formatDash(info.balance)) DASH")
+                                                .foregroundColor(.blue)
+                                        }
+                                        .font(.caption)
+                                    }
+                                    .padding(8)
+                                    .background(Color.green.opacity(0.1))
+                                    .cornerRadius(6)
+                                }
+                            }
+                            .padding()
+                            .background(Color.green.opacity(0.05))
+                            .cornerRadius(8)
+                        }
+                    }
+                    .padding()
+                }
+                
+                Spacer()
+            }
+        }
+        .navigationTitle("Transfer Identity → Addresses")
+        .navigationBarTitleDisplayMode(.inline)
+    }
+    
+    private var isFormValid: Bool {
+        guard !identityId.isEmpty,
+              outputAddressHex.count == 42,
+              identityPrivateKeyHex.count == 64,
+              let amount = UInt64(outputAmount), amount > 0
+        else { return false }
+        
+        let hexChars = CharacterSet(charactersIn: "0123456789abcdefABCDEF")
+        guard outputAddressHex.unicodeScalars.allSatisfy({ hexChars.contains($0) }),
+              identityPrivateKeyHex.unicodeScalars.allSatisfy({ hexChars.contains($0) })
+        else { return false }
+        
+        return true
+    }
+    
+    private func executeTransfer() {
+        guard let sdk = appState.platformState.sdk else { return }
+        
+        guard let outputAddressData = Data(hexString: outputAddressHex),
+              let privateKeyData = Data(hexString: identityPrivateKeyHex),
+              let amount = UInt64(outputAmount),
+              let pkId = UInt32(publicKeyId)
+        else {
+            errorMessage = "Invalid input data"
+            showResult = true
+            return
+        }
+        
+        isLoading = true
+        errorMessage = nil
+        result = nil
+        showResult = false
+        
+        Task { @MainActor in
+            do {
+                let outputs = [
+                    Addresses.AddressTransferOutput(
+                        addressBytes: outputAddressData,
+                        amount: amount
+                    )
+                ]
+                
+                let result = try await sdk.addresses.transferCreditsToAddresses(
+                    identityId: identityId,
+                    outputs: outputs,
+                    identityPrivateKey: privateKeyData,
+                    publicKeyId: pkId
+                )
+                
+                self.result = result
+                showResult = true
+                isLoading = false
+            } catch {
+                errorMessage = error.localizedDescription
+                showResult = true
+                isLoading = false
+            }
+        }
+    }
+}
+
+// MARK: - Create Identity From Addresses View
+
+struct CreateIdentityFromAddressesView: View {
+    @EnvironmentObject var appState: UnifiedAppState
+    
+    @State private var identityId: String = ""
+    @State private var inputAddressHex: String = ""
+    @State private var inputAmount: String = ""
+    @State private var inputNonce: String = "0"
+    @State private var inputPrivateKeyHex: String = ""
+    @State private var useChangeAddress: Bool = false
+    @State private var changeAddressHex: String = ""
+    @State private var changeAmount: String = ""
+    @State private var identityPrivateKeyHex: String = ""
+    
+    @State private var isLoading = false
+    @State private var result: (identityHandle: OpaquePointer, addressInfos: PlatformAddressInfosResult)?
+    @State private var errorMessage: String?
+    @State private var showResult = false
+    
+    var body: some View {
+        ScrollView {
+            VStack(spacing: 20) {
+                // Header
+                VStack(alignment: .leading, spacing: 8) {
+                    Text("Create Identity (From Addresses)")
+                        .font(.title2)
+                        .fontWeight(.bold)
+                    
+                    Text("Create a new identity funded by Platform address balances.")
+                        .font(.body)
+                        .foregroundColor(.secondary)
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding()
+                
+                // Identity ID
+                VStack(alignment: .leading, spacing: 12) {
+                    Text("Identity ID")
+                        .font(.headline)
+                        .foregroundColor(.blue)
+                    
+                    VStack(alignment: .leading, spacing: 4) {
+                        Text("Base58-encoded Identity ID (must have public keys)")
+                            .font(.subheadline)
+                            .fontWeight(.medium)
+                        TextField("e.g., 5Xy...", text: $identityId)
+                            .textFieldStyle(RoundedBorderTextFieldStyle())
+                            .autocapitalization(.none)
+                            .disableAutocorrection(true)
+                        Text("The identity must be prepared with public keys before creation.")
+                            .font(.caption)
+                            .foregroundColor(.secondary)
+                    }
+                }
+                .padding()
+                .background(Color.blue.opacity(0.05))
+                .cornerRadius(10)
+                .padding(.horizontal)
+                
+                // Input Address
+                VStack(alignment: .leading, spacing: 12) {
+                    Text("Input Address (Funding)")
+                        .font(.headline)
+                        .foregroundColor(.green)
+                    
+                    VStack(alignment: .leading, spacing: 4) {
+                        Text("Address (hex, 42 chars)")
+                            .font(.subheadline)
+                            .fontWeight(.medium)
+                        TextField("00...(21 bytes = 42 hex chars)", text: $inputAddressHex)
+                            .textFieldStyle(RoundedBorderTextFieldStyle())
+                            .autocapitalization(.none)
+                            .disableAutocorrection(true)
+                            .monospaced()
+                    }
+                    
+                    VStack(alignment: .leading, spacing: 4) {
+                        Text("Amount (credits)")
+                            .font(.subheadline)
+                            .fontWeight(.medium)
+                        TextField("0", text: $inputAmount)
+                            .textFieldStyle(RoundedBorderTextFieldStyle())
+                            .keyboardType(.numberPad)
+                        if let amount = UInt64(inputAmount), amount > 0 {
+                            Text("\(formatDash(amount)) DASH")
+                                .font(.caption)
+                                .foregroundColor(.blue)
+                        }
+                    }
+                    
+                    VStack(alignment: .leading, spacing: 4) {
+                        Text("Nonce (required)")
+                            .font(.subheadline)
+                            .fontWeight(.medium)
+                        TextField("0", text: $inputNonce)
+                            .textFieldStyle(RoundedBorderTextFieldStyle())
+                            .keyboardType(.numberPad)
+                    }
+                    
+                    VStack(alignment: .leading, spacing: 4) {
+                        Text("Private Key (hex, 64 chars)")
+                            .font(.subheadline)
+                            .fontWeight(.medium)
+                        SecureField("32-byte private key as hex", text: $inputPrivateKeyHex)
+                            .textFieldStyle(RoundedBorderTextFieldStyle())
+                            .autocapitalization(.none)
+                            .disableAutocorrection(true)
+                            .monospaced()
+                        Text("Keep your private key secure!")
+                            .font(.caption)
+                            .foregroundColor(.red)
+                    }
+                }
+                .padding()
+                .background(Color.green.opacity(0.05))
+                .cornerRadius(10)
+                .padding(.horizontal)
+                
+                // Change Address
+                VStack(alignment: .leading, spacing: 12) {
+                    Toggle("Use Change Address", isOn: $useChangeAddress)
+                        .font(.headline)
+                    
+                    if useChangeAddress {
+                        VStack(alignment: .leading, spacing: 4) {
+                            Text("Change Address (hex, 42 chars)")
+                                .font(.subheadline)
+                                .fontWeight(.medium)
+                            TextField("00...(21 bytes = 42 hex chars)", text: $changeAddressHex)
+                                .textFieldStyle(RoundedBorderTextFieldStyle())
+                                .autocapitalization(.none)
+                                .disableAutocorrection(true)
+                                .monospaced()
+                        }
+                        
+                        VStack(alignment: .leading, spacing: 4) {
+                            Text("Change Amount (credits, optional)")
+                                .font(.subheadline)
+                                .fontWeight(.medium)
+                            TextField("0 = SDK calculates", text: $changeAmount)
+                                .textFieldStyle(RoundedBorderTextFieldStyle())
+                                .keyboardType(.numberPad)
+                        }
+                    }
+                }
+                .padding()
+                .background(Color.purple.opacity(0.05))
+                .cornerRadius(10)
+                .padding(.horizontal)
+                
+                // Identity Private Key
+                VStack(alignment: .leading, spacing: 12) {
+                    Text("Identity Private Key")
+                        .font(.headline)
+                        .foregroundColor(.red)
+                    
+                    VStack(alignment: .leading, spacing: 4) {
+                        Text("Private Key (hex, 64 chars)")
+                            .font(.subheadline)
+                            .fontWeight(.medium)
+                        SecureField("32-byte private key as hex", text: $identityPrivateKeyHex)
+                            .textFieldStyle(RoundedBorderTextFieldStyle())
+                            .autocapitalization(.none)
+                            .disableAutocorrection(true)
+                            .monospaced()
+                        Text("Keep your private key secure!")
+                            .font(.caption)
+                            .foregroundColor(.red)
+                    }
+                }
+                .padding()
+                .background(Color.red.opacity(0.05))
+                .cornerRadius(10)
+                .padding(.horizontal)
+                
+                // Execute Button
+                Button(action: executeCreate) {
+                    HStack {
+                        if isLoading {
+                            ProgressView()
+                                .progressViewStyle(CircularProgressViewStyle(tint: .white))
+                        } else {
+                            Image(systemName: "plus.circle.fill")
+                        }
+                        Text(isLoading ? "Creating..." : "Execute Create")
+                            .fontWeight(.semibold)
+                    }
+                    .frame(maxWidth: .infinity)
+                    .padding()
+                    .background(isLoading || !isFormValid ? Color.gray : Color.orange)
+                    .foregroundColor(.white)
+                    .cornerRadius(10)
+                }
+                .disabled(isLoading || !isFormValid || appState.platformState.sdk == nil)
+                .padding(.horizontal)
+                
+                // Result
+                if showResult {
+                    VStack(alignment: .leading, spacing: 12) {
+                        Text("Result")
+                            .font(.headline)
+                        
+                        if let error = errorMessage {
+                            HStack(alignment: .top) {
+                                Image(systemName: "xmark.circle.fill")
+                                    .foregroundColor(.red)
+                                Text(error)
+                                    .foregroundColor(.red)
+                            }
+                            .padding()
+                            .background(Color.red.opacity(0.1))
+                            .cornerRadius(8)
+                        } else if let result = result {
+                            VStack(alignment: .leading, spacing: 12) {
+                                Label("Identity Created Successfully!", systemImage: "checkmark.circle.fill")
+                                    .foregroundColor(.green)
+                                    .font(.headline)
+                                
+                                Text("Identity handle created. Updated Address Balances:")
+                                    .font(.subheadline)
+                                    .fontWeight(.medium)
+                                
+                                ForEach(Array(result.addressInfos.infos.values), id: \.addressHex) { info in
+                                    VStack(alignment: .leading, spacing: 4) {
+                                        Text(info.addressHex.prefix(20) + "...")
+                                            .font(.caption)
+                                            .monospaced()
+                                        HStack {
+                                            Text("\(formatCredits(info.balance)) credits")
+                                            Text("•")
+                                            Text("\(formatDash(info.balance)) DASH")
+                                                .foregroundColor(.blue)
+                                        }
+                                        .font(.caption)
+                                    }
+                                    .padding(8)
+                                    .background(Color.green.opacity(0.1))
+                                    .cornerRadius(6)
+                                }
+                                
+                                Text("⚠️ Note: Identity handle must be freed using dash_sdk_identity_destroy")
+                                    .font(.caption)
+                                    .foregroundColor(.orange)
+                            }
+                            .padding()
+                            .background(Color.green.opacity(0.05))
+                            .cornerRadius(8)
+                        }
+                    }
+                    .padding()
+                }
+                
+                Spacer()
+            }
+        }
+        .navigationTitle("Create Identity")
+        .navigationBarTitleDisplayMode(.inline)
+    }
+    
+    private var isFormValid: Bool {
+        guard !identityId.isEmpty,
+              inputAddressHex.count == 42,
+              inputPrivateKeyHex.count == 64,
+              identityPrivateKeyHex.count == 64,
+              let amount = UInt64(inputAmount), amount > 0,
+              UInt32(inputNonce) != nil
+        else { return false }
+        
+        if useChangeAddress {
+            guard changeAddressHex.count == 42 else { return false }
+        }
+        
+        let hexChars = CharacterSet(charactersIn: "0123456789abcdefABCDEF")
+        guard inputAddressHex.unicodeScalars.allSatisfy({ hexChars.contains($0) }),
+              inputPrivateKeyHex.unicodeScalars.allSatisfy({ hexChars.contains($0) }),
+              identityPrivateKeyHex.unicodeScalars.allSatisfy({ hexChars.contains($0) })
+        else { return false }
+        
+        if useChangeAddress {
+            guard changeAddressHex.unicodeScalars.allSatisfy({ hexChars.contains($0) }) else { return false }
+        }
+        
+        return true
+    }
+    
+    private func executeCreate() {
+        guard let sdk = appState.platformState.sdk else { return }
+        
+        guard let inputAddressData = Data(hexString: inputAddressHex),
+              let inputPrivateKeyData = Data(hexString: inputPrivateKeyHex),
+              let identityPrivateKeyData = Data(hexString: identityPrivateKeyHex),
+              let amount = UInt64(inputAmount),
+              let nonce = UInt32(inputNonce)
+        else {
+            errorMessage = "Invalid input data"
+            showResult = true
+            return
+        }
+        
+        isLoading = true
+        errorMessage = nil
+        result = nil
+        showResult = false
+        
+        Task { @MainActor in
+            do {
+                let inputs = [
+                    Addresses.AddressTransferInput(
+                        addressBytes: inputAddressData,
+                        amount: amount,
+                        nonce: nonce,
+                        privateKey: inputPrivateKeyData
+                    )
+                ]
+                
+                var output: Addresses.AddressTransferOutput? = nil
+                if useChangeAddress, let changeAddressData = Data(hexString: changeAddressHex) {
+                    let changeAmt = UInt64(changeAmount) ?? 0
+                    output = Addresses.AddressTransferOutput(
+                        addressBytes: changeAddressData,
+                        amount: changeAmt
+                    )
+                }
+                
+                let result = try await sdk.addresses.createIdentityFromAddresses(
+                    identityId: identityId,
+                    inputs: inputs,
+                    output: output,
+                    identityPrivateKey: identityPrivateKeyData
+                )
+                
+                self.result = result
+                showResult = true
+                isLoading = false
+            } catch {
+                errorMessage = error.localizedDescription
+                showResult = true
+                isLoading = false
+            }
+        }
     }
 }
 

--- a/packages/swift-sdk/SwiftExampleApp/SwiftExampleApp/Views/StateTransitionsView.swift
+++ b/packages/swift-sdk/SwiftExampleApp/SwiftExampleApp/Views/StateTransitionsView.swift
@@ -6,6 +6,7 @@ struct StateTransitionsView: View {
     @EnvironmentObject var appState: UnifiedAppState
     
     enum TransitionCategory: String, CaseIterable {
+        case address = "Address"
         case identity = "Identity"
         case dataContract = "Data Contract"
         case document = "Document"
@@ -14,6 +15,7 @@ struct StateTransitionsView: View {
         
         var icon: String {
             switch self {
+            case .address: return "building.columns.fill"
             case .identity: return "person.fill"
             case .dataContract: return "doc.text.fill"
             case .document: return "doc.fill"
@@ -24,6 +26,7 @@ struct StateTransitionsView: View {
         
         var description: String {
             switch self {
+            case .address: return "Transfer and withdraw credits using Platform addresses"
             case .identity: return "Create, update, and manage identities"
             case .dataContract: return "Deploy and update data contracts"
             case .document: return "Create and manage documents"

--- a/packages/swift-sdk/SwiftExampleApp/SwiftExampleApp/Views/TransitionCategoryView.swift
+++ b/packages/swift-sdk/SwiftExampleApp/SwiftExampleApp/Views/TransitionCategoryView.swift
@@ -7,6 +7,9 @@ struct TransitionCategoryView: View {
     
     var transitions: [(key: String, label: String, description: String)] {
         switch category {
+        case .address:
+            // Address transitions use dedicated SwiftUI flows (not the generic TransitionDetailView).
+            return []
         case .identity:
             return [
                 ("identityCreate", "Create Identity", "Create a new identity with initial credits"),
@@ -48,6 +51,83 @@ struct TransitionCategoryView: View {
     }
     
     var body: some View {
+        if category == .address {
+            List {
+                NavigationLink(destination: TransferAddressFundsView()) {
+                    VStack(alignment: .leading, spacing: 8) {
+                        Text("Transfer Address Funds")
+                            .font(.headline)
+                        Text("Transfer credits between Platform addresses")
+                            .font(.caption)
+                            .foregroundColor(.secondary)
+                            .lineLimit(2)
+                    }
+                    .padding(.vertical, 4)
+                }
+                
+                NavigationLink(destination: WithdrawAddressFundsView()) {
+                    VStack(alignment: .leading, spacing: 8) {
+                        Text("Withdraw Address Funds")
+                            .font(.headline)
+                        Text("Withdraw credits from Platform to Core (L1)")
+                            .font(.caption)
+                            .foregroundColor(.secondary)
+                            .lineLimit(2)
+                    }
+                    .padding(.vertical, 4)
+                }
+                
+                NavigationLink(destination: TopUpAddressFromAssetLockView()) {
+                    VStack(alignment: .leading, spacing: 8) {
+                        Text("Top Up Address (Asset Lock)")
+                            .font(.headline)
+                        Text("Fund Platform addresses from Dash Core asset lock")
+                            .font(.caption)
+                            .foregroundColor(.secondary)
+                            .lineLimit(2)
+                    }
+                    .padding(.vertical, 4)
+                }
+                
+                NavigationLink(destination: TopUpIdentityFromAddressesView()) {
+                    VStack(alignment: .leading, spacing: 8) {
+                        Text("Top Up Identity (From Addresses)")
+                            .font(.headline)
+                        Text("Top up identity using Platform address balances")
+                            .font(.caption)
+                            .foregroundColor(.secondary)
+                            .lineLimit(2)
+                    }
+                    .padding(.vertical, 4)
+                }
+                
+                NavigationLink(destination: TransferIdentityToAddressesView()) {
+                    VStack(alignment: .leading, spacing: 8) {
+                        Text("Transfer Identity → Addresses")
+                            .font(.headline)
+                        Text("Transfer credits from identity to Platform addresses")
+                            .font(.caption)
+                            .foregroundColor(.secondary)
+                            .lineLimit(2)
+                    }
+                    .padding(.vertical, 4)
+                }
+                
+                NavigationLink(destination: CreateIdentityFromAddressesView()) {
+                    VStack(alignment: .leading, spacing: 8) {
+                        Text("Create Identity (From Addresses)")
+                            .font(.headline)
+                        Text("Create identity funded by Platform addresses")
+                            .font(.caption)
+                            .foregroundColor(.secondary)
+                            .lineLimit(2)
+                    }
+                    .padding(.vertical, 4)
+                }
+            }
+            .navigationTitle(category.rawValue)
+            .navigationBarTitleDisplayMode(.inline)
+        } else {
         List {
             ForEach(transitions, id: \.key) { transition in
                 NavigationLink(destination: TransitionDetailView(
@@ -68,6 +148,7 @@ struct TransitionCategoryView: View {
         }
         .navigationTitle(category.rawValue)
         .navigationBarTitleDisplayMode(.inline)
+        }
     }
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This PR implements support for all 6 address-related state transitions from Dash Platform v3.0, along with 4 new address query operations. These features enable iOS applications to fully interact with Platform addresses, including transferring funds, withdrawing to Core addresses, and managing identity funding operations.

## What was done?
<!--- Describe your changes in detail -->

### Address State Transitions (6 total)

1. **AddressFundsTransferTransition** - Transfer credits between Platform addresses
   - Rust FFI: `dash_sdk_address_transfer_funds`
   - Swift SDK: `Addresses.transferFunds(inputs:outputs:feeFromInputIndex:)`
   - UI: `TransferAddressFundsView` with input/output address management

2. **AddressCreditWithdrawalTransition** - Withdraw credits from Platform addresses to Core (L1) Dash addresses
   - Rust FFI: `dash_sdk_address_withdraw_funds`
   - Swift SDK: `Addresses.withdrawFunds(inputs:coreAddress:coreFeePerByte:pooling:feeFromInputIndex:changeAddress:)`
   - UI: `WithdrawAddressFundsView` with pooling strategy selection

3. **AddressFundingFromAssetLockTransition** - Top up Platform address from asset lock
   - Rust FFI: `dash_sdk_address_top_up_from_asset_lock`
   - Swift SDK: `Addresses.topUpAddressFromAssetLock(...)`
   - UI: `TopUpAddressFromAssetLockView` supporting both instant and chain lock proofs

4. **IdentityTopUpFromAddressesTransition** - Top up identity using Platform address balances
   - Rust FFI: `dash_sdk_identity_top_up_from_addresses`
   - Swift SDK: `Addresses.topUpIdentityFromAddresses(identityId:inputs:)`
   - UI: `TopUpIdentityFromAddressesView`

5. **IdentityCreditTransferToAddressesTransition** - Transfer credits from identity to Platform addresses
   - Rust FFI: `dash_sdk_identity_transfer_credits_to_addresses`
   - Swift SDK: `Addresses.transferCreditsToAddresses(identityId:outputs:identityPrivateKey:publicKeyId:)`
   - UI: `TransferIdentityToAddressesView`

6. **IdentityCreateFromAddressesTransition** - Create identity funded by Platform addresses
   - Rust FFI: `dash_sdk_identity_create_from_addresses`
   - Swift SDK: `Addresses.createIdentityFromAddresses(identityId:inputs:output:identityPrivateKey:)`
   - UI: `CreateIdentityFromAddressesView`

### Address Queries (4 new)

1. **getAddressesTrunkState** - Fetch top-level state of address tree
   - Rust FFI: `dash_sdk_address_fetch_trunk_state`
   - Swift SDK: `Addresses.getTrunkState()`
   - UI: `GetTrunkStateView` with copy functionality for keys and hashes

2. **getAddressesBranchState** - Fetch state of specific branch in address tree
   - Rust FFI: `dash_sdk_address_fetch_branch_state`
   - Swift SDK: `Addresses.getBranchState(key:depth:expectedHash:checkpointHeight:)`
   - UI: `GetBranchStateView` with expanded fields to prevent truncation

3. **getRecentAddressBalanceChanges** - Fetch recent, uncompacted address balance changes
   - Rust FFI: `dash_sdk_address_fetch_recent_balance_changes`
   - Swift SDK: `Addresses.getRecentBalanceChanges(startHeight:)`
   - UI: `GetRecentBalanceChangesView` with block-by-block change display

4. **getRecentCompactedAddressBalanceChanges** - Fetch recent, compacted address balance changes
   - Rust FFI: `dash_sdk_address_fetch_compacted_balance_changes`
   - Swift SDK: `Addresses.getCompactedBalanceChanges(startBlockHeight:)`
   - UI: `GetCompactedBalanceChangesView` with compacted range display

### Additional Features

- **Bech32m Address Support**: Full encoding/decoding support for bech32m Platform addresses
  - `Bech32m.decode(_:)` and `Bech32m.isValidPlatformAddress(_:)` helper methods
  - Auto-detection of address format (hex or bech32m) in query methods
  - Display of addresses in bech32m format in UI
  - Balance display in both credits and DASH (1 DASH = 10^11 credits)

- **UI Organization**: All address-related state transitions are accessible through "Platform -> State Transitions -> Address" menu, separate from address queries

### Technical Implementation

- **Rust FFI Layer**: All state transitions implemented with proper error handling, memory management, and panic protection
- **Swift SDK**: Type-safe Swift wrappers with async/await support and proper resource cleanup
- **iOS UI**: Complete SwiftUI forms with validation, error handling, and result display
- **Type Safety**: Fixed-size array interop handled correctly (OutPointTuple, PrivateKeyTuple for C compatibility)

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other area of the code, etc. -->

- **Build Verification**: All Rust FFI code compiles successfully for iOS (arm64 device and simulator)
- **Swift Compilation**: Swift SDK and Example App compile without errors
- **UI Testing**: All 6 state transition views and 4 query views are accessible and functional in the iOS Example App
- **Integration**: State transitions are properly integrated into the navigation hierarchy under "Platform -> State Transitions -> Address"
- **Address Format Support**: Tested with both hex and bech32m address formats
- **Error Handling**: Verified error messages display correctly for invalid inputs

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->

No breaking changes. This is a feature addition that extends the existing `Addresses` service class with new methods and adds new UI views.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [ ] I have made corresponding changes to the documentation if needed

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone
