### PR TITLE
fix(wasm-sdk): invalid get_address_info return object

### DIFF
--- a/packages/wasm-sdk/src/queries/address.rs
+++ b/packages/wasm-sdk/src/queries/address.rs
@@ -102,7 +102,7 @@ impl WasmSdk {
         let data = match address_info {
             Some(info) => {
                 let wrapper = PlatformAddressInfoWasm::from(info);
-                wrapper.to_object()?
+                wrapper.into()
             }
             None => JsValue::UNDEFINED,
         };
@@ -147,7 +147,7 @@ impl WasmSdk {
             let value = match address_infos.get(&address).and_then(|opt| opt.as_ref()) {
                 Some(info) => {
                     let wrapper = PlatformAddressInfoWasm::from(info.clone());
-                    wrapper.to_object()?
+                    wrapper.into()
                 }
                 None => JsValue::UNDEFINED,
             };
@@ -197,7 +197,7 @@ impl WasmSdk {
             let value = match address_infos.get(&address).and_then(|opt| opt.as_ref()) {
                 Some(info) => {
                     let wrapper = PlatformAddressInfoWasm::from(info.clone());
-                    wrapper.to_object()?
+                    wrapper.into()
                 }
                 None => JsValue::UNDEFINED,
             };

--- a/packages/wasm-sdk/src/queries/address.rs
+++ b/packages/wasm-sdk/src/queries/address.rs
@@ -83,7 +83,7 @@ impl WasmSdk {
     /// @returns ProofMetadataResponse containing PlatformAddressInfo with proof information
     #[wasm_bindgen(
         js_name = "getAddressInfoWithProofInfo",
-        unchecked_return_type = "ProofMetadataResponseTyped<PlatformAddressInfo>"
+        unchecked_return_type = "ProofMetadataResponseTyped<PlatformAddressInfo | undefined>"
     )]
     pub async fn get_address_info_with_proof_info(
         &self,
@@ -197,7 +197,7 @@ impl WasmSdk {
             let value = match address_infos.get(&address).and_then(|opt| opt.as_ref()) {
                 Some(info) => {
                     let wrapper = PlatformAddressInfoWasm::from(info.clone());
-                    wrapper.into()
+                    wrapper.to_object()?
                 }
                 None => JsValue::UNDEFINED,
             };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
```
1) Platform address queries
       getAddressInfoWithProofInfo() returns proof info for address query:
     AssertionError: expected 5 to equal 5n
      at Context.<anonymous> (file:///home/runner/work/platform/platform/packages/wasm-sdk/tests/functional/addresses.spec.mjs:48:31)
      at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
  2) Platform address queries
       getAddressesInfos() returns map of address infos:
     AssertionError: expected undefined to be truthy
      at Context.<anonymous> (file:///home/runner/work/platform/platform/packages/wasm-sdk/tests/functional/addresses.spec.mjs:69:25)
      at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
  3) Platform address queries
       getAddressesInfosWithProofInfo() returns proof info for multiple addresses:
     AssertionError: expected undefined to be truthy
      at Context.<anonymous> (file:///home/runner/work/platform/platform/packages/wasm-sdk/tests/functional/addresses.spec.mjs:91:25)
      at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
```

## What was done?
<!--- Describe your changes in detail -->
- return `PlatformAddressInfoWasm` instead of plain object

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Now tests above are passing.

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [x] I have made corresponding changes to the documentation if needed

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed address query methods to properly handle cases where address information is unavailable, returning undefined instead of errors to improve API reliability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->