### PR TITLE
refactor(swift-sdk): extract key management logic into centralized KeyManager

### DIFF
--- a/packages/swift-sdk/Sources/SwiftDashSDK/KeyWallet/KeyManager.swift
+++ b/packages/swift-sdk/Sources/SwiftDashSDK/KeyWallet/KeyManager.swift
@@ -1,0 +1,459 @@
+import Foundation
+import DashSDKFFI
+
+// MARK: - Key Manager Errors
+
+/// Errors that can occur during key management operations
+public enum KeyManagerError: LocalizedError, Sendable {
+  case keyNotFound(String)
+  case privateKeyNotFound(KeyID)
+  case invalidKeyFormat(String)
+  case signerCreationFailed(String)
+  case keychainError(String)
+  case noSuitableKey(String)
+
+  public var errorDescription: String? {
+    switch self {
+    case .keyNotFound(let message):
+      return "Key not found: \(message)"
+    case .privateKeyNotFound(let keyId):
+      return "Private key not found for key ID \(keyId). Please add the private key first."
+    case .invalidKeyFormat(let message):
+      return "Invalid key format: \(message)"
+    case .signerCreationFailed(let message):
+      return "Failed to create signer: \(message)"
+    case .keychainError(let message):
+      return "Keychain error: \(message)"
+    case .noSuitableKey(let message):
+      return "No suitable key found: \(message)"
+    }
+  }
+}
+
+// MARK: - Key Manager
+
+/// Centralized key management for Dash Platform identities.
+///
+/// This class provides a unified interface for:
+/// - Finding keys by purpose (transfer, authentication, etc.)
+/// - Retrieving private keys from secure storage
+/// - Creating signers for SDK operations
+/// - Validating keys
+///
+/// Example usage:
+/// ```swift
+/// let keyManager = KeyManager(keychainManager: KeychainManager.shared)
+///
+/// // Get transfer key for an identity
+/// if let transferKey = try keyManager.getTransferKey(for: identity) {
+///     // Create signer for transfer operation
+///     let signer = try keyManager.createSigner(
+///         for: identity,
+///         keyIndex: transferKey.id
+///     )
+///     defer { keyManager.destroySigner(signer) }
+///     // Use signer...
+/// }
+/// ```
+public final class KeyManager: Sendable {
+
+  /// The keychain manager used for private key storage/retrieval
+  private let keychainManager: KeychainManager
+
+  /// Initialize with a keychain manager
+  /// - Parameter keychainManager: The keychain manager to use
+  /// - Note: If you want to use the shared instance, pass `KeychainManager.shared` explicitly
+  public init(keychainManager: KeychainManager) {
+    self.keychainManager = keychainManager
+  }
+
+  /// Initialize with the shared keychain manager (convenience)
+  /// - Note: This must be called from a MainActor context since KeychainManager.shared is @MainActor
+  @MainActor
+  public static func withSharedKeychain() -> KeyManager {
+    return KeyManager(keychainManager: KeychainManager.shared)
+  }
+
+  // MARK: - Key Selection
+
+  /// Find a transfer key for an identity
+  /// - Parameter identity: The identity to find a transfer key for
+  /// - Returns: A transfer key if found, nil otherwise
+  /// - Note: This only returns the public key. Use `getPrivateKey(for:keyIndex:from:)` to check if private key is available.
+  public func getTransferKey(for identity: DPPIdentity) -> IdentityPublicKey? {
+    // Prefer critical transfer key, then any transfer key
+    if let criticalKey = identity.publicKeys.values.first(where: {
+      $0.purpose == .transfer && $0.securityLevel == .critical && !$0.isDisabled
+    }) {
+      return criticalKey
+    }
+
+    return identity.publicKeys.values.first(where: {
+      $0.purpose == .transfer && !$0.isDisabled
+    })
+  }
+
+  /// Find an authentication key for an identity
+  /// - Parameter identity: The identity to find an authentication key for
+  /// - Returns: An authentication key if found, nil otherwise
+  /// - Note: This only returns the public key. Use `getPrivateKey(for:keyIndex:from:)` to check if private key is available.
+  public func getAuthenticationKey(for identity: DPPIdentity) -> IdentityPublicKey? {
+    // Prefer critical authentication key, then any authentication key
+    if let criticalKey = identity.publicKeys.values.first(where: {
+      $0.purpose == .authentication && $0.securityLevel == .critical && !$0.isDisabled
+    }) {
+      return criticalKey
+    }
+
+    return identity.publicKeys.values.first(where: {
+      $0.purpose == .authentication && !$0.isDisabled
+    })
+  }
+
+  /// Find a key by purpose for an identity
+  /// - Parameters:
+  ///   - identity: The identity to find a key for
+  ///   - purpose: The key purpose to find
+  /// - Returns: A key with the specified purpose if found, nil otherwise
+  /// - Note: This only returns the public key. Use `getPrivateKey(for:keyIndex:from:)` to check if private key is available.
+  public func getKeyByPurpose(for identity: DPPIdentity, purpose: KeyPurpose) -> IdentityPublicKey? {
+    // Prefer critical key, then any key with the purpose
+    if let criticalKey = identity.publicKeys.values.first(where: {
+      $0.purpose == purpose && $0.securityLevel == .critical && !$0.isDisabled
+    }) {
+      return criticalKey
+    }
+
+    return identity.publicKeys.values.first(where: {
+      $0.purpose == purpose && !$0.isDisabled
+    })
+  }
+
+  /// Find a key that meets specific requirements
+  /// - Parameters:
+  ///   - identity: The identity to find a key for
+  ///   - purpose: Optional key purpose requirement
+  ///   - securityLevel: Optional minimum security level requirement
+  ///   - preferCritical: Whether to prefer critical keys (default: true)
+  /// - Returns: A key meeting the requirements if found, nil otherwise
+  public func findKey(
+    for identity: DPPIdentity,
+    purpose: KeyPurpose? = nil,
+    minimumSecurityLevel: SecurityLevel? = nil,
+    preferCritical: Bool = true
+  ) -> IdentityPublicKey? {
+    let keys = identity.publicKeys.values.filter { !$0.isDisabled }
+
+    // Filter by purpose if specified
+    let filteredKeys = purpose != nil
+    ? keys.filter { $0.purpose == purpose }
+    : keys
+
+    // Filter by security level if specified
+    let securityFilteredKeys = minimumSecurityLevel != nil
+    ? filteredKeys.filter { $0.securityLevel.rawValue <= minimumSecurityLevel!.rawValue }
+    : filteredKeys
+
+    guard !securityFilteredKeys.isEmpty else {
+      return nil
+    }
+
+    // Prefer critical if requested
+    if preferCritical {
+      if let criticalKey = securityFilteredKeys.first(where: { $0.securityLevel == .critical }) {
+        return criticalKey
+      }
+    }
+
+    // Return first matching key
+    return securityFilteredKeys.first
+  }
+
+  // MARK: - Private Key Retrieval
+
+  /// Get private key for a specific key index from an identity
+  /// - Parameters:
+  ///   - identity: The identity
+  ///   - keyIndex: The key index to retrieve
+  /// - Returns: The private key data if found
+  /// - Throws: `KeyManagerError.privateKeyNotFound` if the key is not in keychain
+  /// - Note: This method must be called from a MainActor context
+  @MainActor
+  public func getPrivateKey(for identity: DPPIdentity, keyIndex: KeyID) throws -> Data {
+    guard let privateKeyData = keychainManager.retrievePrivateKey(
+      identityId: identity.id,
+      keyIndex: Int32(keyIndex)
+    ) else {
+      throw KeyManagerError.privateKeyNotFound(keyIndex)
+    }
+    return privateKeyData
+  }
+
+  /// Check if a private key is available for a key
+  /// - Parameters:
+  ///   - identity: The identity
+  ///   - keyIndex: The key index to check
+  /// - Returns: True if private key is available in keychain
+  /// - Note: This method must be called from a MainActor context
+  @MainActor
+  public func hasPrivateKey(for identity: DPPIdentity, keyIndex: KeyID) -> Bool {
+    return keychainManager.hasPrivateKey(identityId: identity.id, keyIndex: Int32(keyIndex))
+  }
+
+  /// Find a key with available private key that meets requirements
+  /// - Parameters:
+  ///   - identity: The identity to find a key for
+  ///   - purpose: Optional key purpose requirement
+  ///   - minimumSecurityLevel: Optional minimum security level requirement
+  ///   - preferCritical: Whether to prefer critical keys (default: true)
+  /// - Returns: A key with available private key meeting the requirements, nil otherwise
+  /// - Note: This method must be called from a MainActor context
+  @MainActor
+  public func findKeyWithPrivateKey(
+    for identity: DPPIdentity,
+    purpose: KeyPurpose? = nil,
+    minimumSecurityLevel: SecurityLevel? = nil,
+    preferCritical: Bool = true
+  ) -> (key: IdentityPublicKey, privateKey: Data)? {
+    // First find suitable keys
+    guard let suitableKey = findKey(
+      for: identity,
+      purpose: purpose,
+      minimumSecurityLevel: minimumSecurityLevel,
+      preferCritical: preferCritical
+    ) else {
+      return nil
+    }
+
+    // Check if private key is available
+    guard let privateKeyData = try? getPrivateKey(for: identity, keyIndex: suitableKey.id) else {
+      return nil
+    }
+
+    return (suitableKey, privateKeyData)
+  }
+
+  // MARK: - Signer Creation
+
+  /// Create a signer from private key data
+  /// - Parameter privateKeyData: The private key data (32 bytes)
+  /// - Returns: An OpaquePointer to the signer handle
+  /// - Throws: `KeyManagerError.signerCreationFailed` if signer creation fails
+  /// - Note: The returned signer must be destroyed with `destroySigner(_:)` when done
+  public func createSigner(from privateKeyData: Data) throws -> OpaquePointer {
+    // Validate private key length
+    guard privateKeyData.count == 32 else {
+      throw KeyManagerError.invalidKeyFormat("Private key must be 32 bytes, got \(privateKeyData.count)")
+    }
+
+    let signerResult = privateKeyData.withUnsafeBytes { keyBytes in
+      dash_sdk_signer_create_from_private_key(
+        keyBytes.bindMemory(to: UInt8.self).baseAddress!,
+        UInt(privateKeyData.count)
+      )
+    }
+
+    guard signerResult.error == nil else {
+      let error = signerResult.error!.pointee
+      defer { dash_sdk_error_free(signerResult.error) }
+      let message = error.message != nil ? String(cString: error.message!) : "Unknown error"
+      throw KeyManagerError.signerCreationFailed(message)
+    }
+
+    guard let signer = signerResult.data else {
+      throw KeyManagerError.signerCreationFailed("No signer data returned")
+    }
+
+    return OpaquePointer(signer)
+  }
+
+  /// Create a signer for a specific key in an identity
+  /// - Parameters:
+  ///   - identity: The identity
+  ///   - keyIndex: The key index to create a signer for
+  /// - Returns: An OpaquePointer to the signer handle
+  /// - Throws: `KeyManagerError.privateKeyNotFound` if private key is not available
+  /// - Throws: `KeyManagerError.signerCreationFailed` if signer creation fails
+  /// - Note: The returned signer must be destroyed with `destroySigner(_:)` when done
+  /// - Note: This method must be called from a MainActor context
+  @MainActor
+  public func createSigner(for identity: DPPIdentity, keyIndex: KeyID) throws -> OpaquePointer {
+    let privateKeyData = try getPrivateKey(for: identity, keyIndex: keyIndex)
+    return try createSigner(from: privateKeyData)
+  }
+
+  /// Create a transfer signer for an identity (convenience method)
+  /// - Parameter identity: The identity to create a transfer signer for
+  /// - Returns: A tuple containing the transfer key and signer handle
+  /// - Throws: `KeyManagerError.noSuitableKey` if no transfer key with private key is found
+  /// - Throws: `KeyManagerError.signerCreationFailed` if signer creation fails
+  /// - Note: The returned signer must be destroyed with `destroySigner(_:)` when done
+  /// - Note: This method must be called from a MainActor context
+  @MainActor
+  public func createTransferSigner(for identity: DPPIdentity) throws -> (key: IdentityPublicKey, signer: OpaquePointer) {
+    guard let transferKey = getTransferKey(for: identity) else {
+      throw KeyManagerError.noSuitableKey("No transfer key found for identity")
+    }
+
+    let signer = try createSigner(for: identity, keyIndex: transferKey.id)
+    return (transferKey, signer)
+  }
+
+  /// Create an authentication signer for an identity (convenience method)
+  /// - Parameter identity: The identity to create an authentication signer for
+  /// - Returns: A tuple containing the authentication key and signer handle
+  /// - Throws: `KeyManagerError.noSuitableKey` if no authentication key with private key is found
+  /// - Throws: `KeyManagerError.signerCreationFailed` if signer creation fails
+  /// - Note: The returned signer must be destroyed with `destroySigner(_:)` when done
+  /// - Note: This method must be called from a MainActor context
+  @MainActor
+  public func createAuthenticationSigner(for identity: DPPIdentity) throws -> (key: IdentityPublicKey, signer: OpaquePointer) {
+    guard let authKey = getAuthenticationKey(for: identity) else {
+      throw KeyManagerError.noSuitableKey("No authentication key found for identity")
+    }
+
+    let signer = try createSigner(for: identity, keyIndex: authKey.id)
+    return (authKey, signer)
+  }
+
+  /// Create a signer for a key that meets specific requirements
+  /// - Parameters:
+  ///   - identity: The identity to create a signer for
+  ///   - purpose: Optional key purpose requirement
+  ///   - minimumSecurityLevel: Optional minimum security level requirement
+  ///   - preferCritical: Whether to prefer critical keys (default: true)
+  /// - Returns: A tuple containing the selected key and signer handle
+  /// - Throws: `KeyManagerError.noSuitableKey` if no suitable key with private key is found
+  /// - Throws: `KeyManagerError.signerCreationFailed` if signer creation fails
+  /// - Note: The returned signer must be destroyed with `destroySigner(_:)` when done
+  /// - Note: This method must be called from a MainActor context
+  @MainActor
+  public func createSignerForKey(
+    for identity: DPPIdentity,
+    purpose: KeyPurpose? = nil,
+    minimumSecurityLevel: SecurityLevel? = nil,
+    preferCritical: Bool = true
+  ) throws -> (key: IdentityPublicKey, signer: OpaquePointer) {
+    guard let (key, privateKey) = findKeyWithPrivateKey(
+      for: identity,
+      purpose: purpose,
+      minimumSecurityLevel: minimumSecurityLevel,
+      preferCritical: preferCritical
+    ) else {
+      let purposeDesc = purpose != nil ? " with purpose \(purpose!.name)" : ""
+      let securityDesc = minimumSecurityLevel != nil ? " with security level \(minimumSecurityLevel!.name) or higher" : ""
+      throw KeyManagerError.noSuitableKey("No suitable key\(purposeDesc)\(securityDesc) with available private key found")
+    }
+
+    let signer = try createSigner(from: privateKey)
+    return (key, signer)
+  }
+
+  /// Destroy a signer handle
+  /// - Parameter signer: The signer handle to destroy
+  public func destroySigner(_ signer: OpaquePointer) {
+    let signerPtr = UnsafeMutablePointer<SignerHandle>(signer)
+    dash_sdk_signer_destroy(signerPtr)
+  }
+
+  // MARK: - Key Validation
+
+  /// Validate that a private key matches a public key
+  /// - Parameters:
+  ///   - privateKeyData: The private key data
+  ///   - publicKey: The public key to validate against
+  ///   - isTestnet: Whether this is for testnet (default: true)
+  /// - Returns: True if the private key matches the public key
+  public func validatePrivateKey(
+    _ privateKeyData: Data,
+    matches publicKey: IdentityPublicKey,
+    isTestnet: Bool = true
+  ) -> Bool {
+    let privateKeyHex = privateKeyData.toHexString()
+    let publicKeyHex = publicKey.data.toHexString()
+
+    return KeyValidation.validatePrivateKeyForPublicKey(
+      privateKeyHex: privateKeyHex,
+      publicKeyHex: publicKeyHex,
+      keyType: publicKey.keyType,
+      isTestnet: isTestnet
+    )
+  }
+
+  /// Validate private key format and length
+  /// - Parameter privateKeyData: The private key data to validate
+  /// - Returns: True if the private key has valid format (32 bytes)
+  public func validatePrivateKeyFormat(_ privateKeyData: Data) -> Bool {
+    return privateKeyData.count == 32
+  }
+}
+
+// MARK: - Convenience Extensions
+
+extension KeyManager {
+  /// Find a key suitable for document operations (requires AUTHENTICATION purpose)
+  /// - Parameters:
+  ///   - identity: The identity to find a key for
+  ///   - minimumSecurityLevel: The minimum security level required (default: .high)
+  /// - Returns: A key suitable for document operations if found, nil otherwise
+  public func findDocumentSigningKey(
+    for identity: DPPIdentity,
+    minimumSecurityLevel: SecurityLevel = .high
+  ) -> IdentityPublicKey? {
+    return findKey(
+      for: identity,
+      purpose: .authentication,
+      minimumSecurityLevel: minimumSecurityLevel,
+      preferCritical: true
+    )
+  }
+
+  /// Find a key suitable for contract operations (requires CRITICAL + AUTHENTICATION)
+  /// - Parameter identity: The identity to find a key for
+  /// - Returns: A key suitable for contract operations if found, nil otherwise
+  public func findContractSigningKey(for identity: DPPIdentity) -> IdentityPublicKey? {
+    return findKey(
+      for: identity,
+      purpose: .authentication,
+      minimumSecurityLevel: .critical,
+      preferCritical: true
+    )
+  }
+
+  /// Create a signer for document operations
+  /// - Parameters:
+  ///   - identity: The identity to create a signer for
+  ///   - minimumSecurityLevel: The minimum security level required (default: .high)
+  /// - Returns: A tuple containing the selected key and signer handle
+  /// - Throws: `KeyManagerError.noSuitableKey` if no suitable key with private key is found
+  /// - Note: The returned signer must be destroyed with `destroySigner(_:)` when done
+  /// - Note: This method must be called from a MainActor context
+  @MainActor
+  public func createDocumentSigner(
+    for identity: DPPIdentity,
+    minimumSecurityLevel: SecurityLevel = .high
+  ) throws -> (key: IdentityPublicKey, signer: OpaquePointer) {
+    return try createSignerForKey(
+      for: identity,
+      purpose: .authentication,
+      minimumSecurityLevel: minimumSecurityLevel,
+      preferCritical: true
+    )
+  }
+
+  /// Create a signer for contract operations (requires CRITICAL + AUTHENTICATION)
+  /// - Parameter identity: The identity to create a signer for
+  /// - Returns: A tuple containing the selected key and signer handle
+  /// - Throws: `KeyManagerError.noSuitableKey` if no suitable key with private key is found
+  /// - Note: The returned signer must be destroyed with `destroySigner(_:)` when done
+  /// - Note: This method must be called from a MainActor context
+  @MainActor
+  public func createContractSigner(for identity: DPPIdentity) throws -> (key: IdentityPublicKey, signer: OpaquePointer) {
+    return try createSignerForKey(
+      for: identity,
+      purpose: .authentication,
+      minimumSecurityLevel: .critical,
+      preferCritical: true
+    )
+  }
+}

--- a/packages/swift-sdk/Sources/SwiftDashSDK/SDK.swift
+++ b/packages/swift-sdk/Sources/SwiftDashSDK/SDK.swift
@@ -3,632 +3,627 @@ import DashSDKFFI
 
 // MARK: - Data Extensions
 extension Data {
-    /// Convert Data to Base58 string
-    public func toBase58() -> String {
-        let alphabet = "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz"
-        var bytes = Array(self)
-        var encoded = ""
-        var zeroCount = 0
-        
-        // Count leading zeros
-        for byte in bytes {
-            if byte == 0 {
-                zeroCount += 1
-            } else {
-                break
-            }
-        }
-        
-        // Remove leading zeros for processing
-        bytes = Array(bytes.dropFirst(zeroCount))
-        
-        // Convert bytes to base58
-        while !bytes.isEmpty {
-            var remainder: UInt = 0
-            var newBytes: [UInt8] = []
-            
-            for byte in bytes {
-                let temp = UInt(byte) + remainder * 256
-                remainder = temp % 58
-                let quotient = temp / 58
-                if !newBytes.isEmpty || quotient > 0 {
-                    newBytes.append(UInt8(quotient))
-                }
-            }
-            
-            bytes = newBytes
-            encoded = String(alphabet[alphabet.index(alphabet.startIndex, offsetBy: Int(remainder))]) + encoded
-        }
-        
-        // Add '1' for each leading zero byte
-        encoded = String(repeating: "1", count: zeroCount) + encoded
-        
-        return encoded
+  /// Convert Data to Base58 string
+  public func toBase58() -> String {
+    let alphabet = "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz"
+    var bytes = Array(self)
+    var encoded = ""
+    var zeroCount = 0
+
+    // Count leading zeros
+    for byte in bytes {
+      if byte == 0 {
+        zeroCount += 1
+      } else {
+        break
+      }
     }
-    
-    /// Convert to hex string
-    public func toHexString() -> String {
-        return self.map { String(format: "%02x", $0) }.joined()
+
+    // Remove leading zeros for processing
+    bytes = Array(bytes.dropFirst(zeroCount))
+
+    // Convert bytes to base58
+    while !bytes.isEmpty {
+      var remainder: UInt = 0
+      var newBytes: [UInt8] = []
+
+      for byte in bytes {
+        let temp = UInt(byte) + remainder * 256
+        remainder = temp % 58
+        let quotient = temp / 58
+        if !newBytes.isEmpty || quotient > 0 {
+          newBytes.append(UInt8(quotient))
+        }
+      }
+
+      bytes = newBytes
+      encoded = String(alphabet[alphabet.index(alphabet.startIndex, offsetBy: Int(remainder))]) + encoded
     }
+
+    // Add '1' for each leading zero byte
+    encoded = String(repeating: "1", count: zeroCount) + encoded
+
+    return encoded
+  }
 }
 
 /// Swift wrapper for the Dash Platform SDK
 public final class SDK: @unchecked Sendable {
-    public private(set) var handle: UnsafeMutablePointer<SDKHandle>?
+  public private(set) var handle: UnsafeMutablePointer<SDKHandle>?
 
-    /// The network this SDK instance is connected to
-    public private(set) var network: Network = DashSDKNetwork(rawValue: 1) // Default to testnet
+  /// The network this SDK instance is connected to
+  public private(set) var network: Network = DashSDKNetwork(rawValue: 1) // Default to testnet
 
-    /// Identities operations
-    public lazy var identities = Identities(sdk: self)
-    
-    /// Contracts operations  
-    public lazy var contracts = Contracts(sdk: self)
-    
-    /// Address operations (balance, nonce queries)
-    public lazy var addresses = Addresses(sdk: self)
-    
-    /// Initialize the SDK library (call once at app startup)
-    public static func initialize() {
-        dash_sdk_init()
-    }
-    
-    /// Log levels for SDK debugging
-    public enum LogLevel: UInt8 {
-        case error = 0
-        case warn = 1
-        case info = 2
-        case debug = 3
-        case trace = 4
-    }
-    
-    /// Enable logging for gRPC and SDK operations
-    /// This will log all network requests, including endpoints being contacted
-    public static func enableLogging(level: LogLevel = .debug) {
-        dash_sdk_enable_logging(level.rawValue)
-        print("🔵 SDK: Logging enabled at level: \(level)")
+  /// Identities operations
+  public lazy var identities = Identities(sdk: self)
+
+  /// Contracts operations
+  public lazy var contracts = Contracts(sdk: self)
+
+  /// Address operations (balance, nonce queries)
+  public lazy var addresses = Addresses(sdk: self)
+
+  /// Initialize the SDK library (call once at app startup)
+  public static func initialize() {
+    dash_sdk_init()
+  }
+
+  /// Log levels for SDK debugging
+  public enum LogLevel: UInt8 {
+    case error = 0
+    case warn = 1
+    case info = 2
+    case debug = 3
+    case trace = 4
+  }
+
+  /// Enable logging for gRPC and SDK operations
+  /// This will log all network requests, including endpoints being contacted
+  public static func enableLogging(level: LogLevel = .debug) {
+    dash_sdk_enable_logging(level.rawValue)
+    print("🔵 SDK: Logging enabled at level: \(level)")
+  }
+
+  /// Initialize SPV logging with configurable output options
+  /// - Parameters:
+  ///   - level: Log level (defaults to .info if nil)
+  ///   - enableConsole: Whether to output logs to console/stderr
+  ///   - logDirectory: Directory for log files (nil to disable file logging)
+  ///   - maxFiles: Maximum archived log files to retain (ignored if logDirectory is nil)
+  /// - Returns: true if logging was initialized successfully
+  @discardableResult
+  public static func initializeSPVLogging(
+    level: LogLevel? = nil,
+    enableConsole: Bool = true,
+    logDirectory: String? = nil,
+    maxFiles: UInt = 5
+  ) -> Bool {
+    let levelString: String? = level.map { lvl in
+      switch lvl {
+      case .error: return "error"
+      case .warn: return "warn"
+      case .info: return "info"
+      case .debug: return "debug"
+      case .trace: return "trace"
+      }
     }
 
-    /// Initialize SPV logging with configurable output options
-    /// - Parameters:
-    ///   - level: Log level (defaults to .info if nil)
-    ///   - enableConsole: Whether to output logs to console/stderr
-    ///   - logDirectory: Directory for log files (nil to disable file logging)
-    ///   - maxFiles: Maximum archived log files to retain (ignored if logDirectory is nil)
-    /// - Returns: true if logging was initialized successfully
-    @discardableResult
-    public static func initializeSPVLogging(
-        level: LogLevel? = nil,
-        enableConsole: Bool = true,
-        logDirectory: String? = nil,
-        maxFiles: UInt = 5
-    ) -> Bool {
-        let levelString: String? = level.map { lvl in
-            switch lvl {
-            case .error: return "error"
-            case .warn: return "warn"
-            case .info: return "info"
-            case .debug: return "debug"
-            case .trace: return "trace"
-            }
+    let result: Int32
+    if let levelStr = levelString {
+      if let logDir = logDirectory {
+        result = levelStr.withCString { levelCStr in
+          logDir.withCString { dirCStr in
+            dash_spv_ffi_init_logging(levelCStr, enableConsole, dirCStr, maxFiles)
+          }
         }
+      } else {
+        result = levelStr.withCString { levelCStr in
+          dash_spv_ffi_init_logging(levelCStr, enableConsole, nil, maxFiles)
+        }
+      }
+    } else {
+      if let logDir = logDirectory {
+        result = logDir.withCString { dirCStr in
+          dash_spv_ffi_init_logging(nil, enableConsole, dirCStr, maxFiles)
+        }
+      } else {
+        result = dash_spv_ffi_init_logging(nil, enableConsole, nil, maxFiles)
+      }
+    }
 
-        let result: Int32
-        if let levelStr = levelString {
-            if let logDir = logDirectory {
-                result = levelStr.withCString { levelCStr in
-                    logDir.withCString { dirCStr in
-                        dash_spv_ffi_init_logging(levelCStr, enableConsole, dirCStr, maxFiles)
-                    }
-                }
-            } else {
-                result = levelStr.withCString { levelCStr in
-                    dash_spv_ffi_init_logging(levelCStr, enableConsole, nil, maxFiles)
-                }
-            }
-        } else {
-            if let logDir = logDirectory {
-                result = logDir.withCString { dirCStr in
-                    dash_spv_ffi_init_logging(nil, enableConsole, dirCStr, maxFiles)
-                }
-            } else {
-                result = dash_spv_ffi_init_logging(nil, enableConsole, nil, maxFiles)
-            }
-        }
+    let success = result == 0
+    if success {
+      print("🔵 SDK: SPV logging initialized (level: \(levelString ?? "default"), console: \(enableConsole))")
+    } else {
+      print("⚠️ SDK: SPV logging initialization returned code \(result)")
+    }
+    return success
+  }
 
-        let success = result == 0
-        if success {
-            print("🔵 SDK: SPV logging initialized (level: \(levelString ?? "default"), console: \(enableConsole))")
-        } else {
-            print("⚠️ SDK: SPV logging initialization returned code \(result)")
-        }
-        return success
+  /// Local Platform DAPI addresses; override via UserDefaults key "platformDAPIAddresses"
+  private static var platformDAPIAddresses: String {
+    if let override = UserDefaults.standard.string(forKey: "platformDAPIAddresses"), !override.isEmpty {
+      return override
     }
-    
-    /// Local Platform DAPI addresses; override via UserDefaults key "platformDAPIAddresses"
-    private static var platformDAPIAddresses: String {
-        if let override = UserDefaults.standard.string(forKey: "platformDAPIAddresses"), !override.isEmpty {
-            return override
-        }
-        return "http://127.0.0.1:1443"
+    return "http://127.0.0.1:1443"
+  }
+
+  /// Create a new SDK instance with trusted setup
+  ///
+  /// This uses a trusted context provider that fetches quorum keys and
+  /// data contracts from trusted HTTP endpoints instead of requiring proof verification.
+  /// This is suitable for mobile applications where proof verification would be resource-intensive.
+  public init(network: Network) throws {
+    print("🔵 SDK.init: Creating SDK with network: \(network)")
+    var config = DashSDKConfig()
+
+    // Map network - in C enums, Swift imports them as raw values
+    config.network = network
+    print("🔵 SDK.init: Network config set to: \(config.network)")
+
+    // Default to SDK-provided addresses; may override below
+    config.dapi_addresses = nil
+
+    config.skip_asset_lock_proof_verification = false
+    config.request_retry_count = 1
+    config.request_timeout_ms = 8000 // 8 seconds
+
+    // Create SDK with trusted setup
+    print("🔵 SDK.init: Creating SDK with trusted setup...")
+    let result: DashSDKResult
+    // Force local DAPI regardless of selected network when enabled
+    let forceLocal = UserDefaults.standard.bool(forKey: "useLocalhostPlatform")
+    if forceLocal {
+      let localAddresses = Self.platformDAPIAddresses
+      print("🔵 SDK.init: Using local DAPI addresses: \(localAddresses)")
+      result = localAddresses.withCString { addressesCStr -> DashSDKResult in
+        var mutableConfig = config
+        mutableConfig.dapi_addresses = addressesCStr
+        print("🔵 SDK.init: Calling dash_sdk_create_trusted...")
+        return dash_sdk_create_trusted(&mutableConfig)
+      }
+    } else {
+      print("🔵 SDK.init: Using default network addresses")
+      result = dash_sdk_create_trusted(&config)
     }
-    
-    /// Create a new SDK instance with trusted setup
-    /// 
-    /// This uses a trusted context provider that fetches quorum keys and
-    /// data contracts from trusted HTTP endpoints instead of requiring proof verification.
-    /// This is suitable for mobile applications where proof verification would be resource-intensive.
-    public init(network: Network) throws {
-        print("🔵 SDK.init: Creating SDK with network: \(network)")
-        var config = DashSDKConfig()
-        
-        // Map network - in C enums, Swift imports them as raw values
-        config.network = network
-        print("🔵 SDK.init: Network config set to: \(config.network)")
-        
-        // Default to SDK-provided addresses; may override below
-        config.dapi_addresses = nil
-        
-        config.skip_asset_lock_proof_verification = false
-        config.request_retry_count = 1
-        config.request_timeout_ms = 8000 // 8 seconds
-        
-        // Create SDK with trusted setup
-        print("🔵 SDK.init: Creating SDK with trusted setup...")
-        let result: DashSDKResult
-        // Force local DAPI regardless of selected network when enabled
-        let forceLocal = UserDefaults.standard.bool(forKey: "useLocalhostPlatform")
-        if forceLocal {
-            let localAddresses = Self.platformDAPIAddresses
-            print("🔵 SDK.init: Using local DAPI addresses: \(localAddresses)")
-            result = localAddresses.withCString { addressesCStr -> DashSDKResult in
-                var mutableConfig = config
-                mutableConfig.dapi_addresses = addressesCStr
-                print("🔵 SDK.init: Calling dash_sdk_create_trusted...")
-                return dash_sdk_create_trusted(&mutableConfig)
-            }
-        } else {
-            print("🔵 SDK.init: Using default network addresses")
-            result = dash_sdk_create_trusted(&config)
-        }
-        print("🔵 SDK.init: dash_sdk_create_trusted returned")
-        
-        // Check for errors
-        if result.error != nil {
-            let error = result.error!.pointee
-            let errorMessage = error.message != nil ? String(cString: error.message!) : "Unknown error"
-            defer {
-                dash_sdk_error_free(result.error)
-            }
-            
-            throw SDKError.internalError("Failed to create SDK: \(errorMessage)")
-        }
-        
-        guard result.data != nil else {
-            throw SDKError.internalError("No SDK handle returned")
-        }
-        
-        // Store the handle and network
-        handle = result.data?.assumingMemoryBound(to: SDKHandle.self)
-        self.network = network
+    print("🔵 SDK.init: dash_sdk_create_trusted returned")
+
+    // Check for errors
+    if result.error != nil {
+      let error = result.error!.pointee
+      let errorMessage = error.message != nil ? String(cString: error.message!) : "Unknown error"
+      defer {
+        dash_sdk_error_free(result.error)
+      }
+
+      throw SDKError.internalError("Failed to create SDK: \(errorMessage)")
     }
-    
-    /// Load known contracts into the trusted context provider
-    /// This avoids network calls for these contracts when they're needed
-    public func loadKnownContracts(_ contracts: [(id: String, data: Data)]) throws {
-        guard let handle = handle else {
-            throw SDKError.invalidState("SDK not initialized")
-        }
-        
-        guard !contracts.isEmpty else {
-            return // Nothing to do
-        }
-        
-        // Prepare contract IDs as comma-separated string
-        let contractIds = contracts.map { $0.id }.joined(separator: ",")
-        
-        // Prepare arrays of contract data
-        let contractDataPointers = contracts.map { contract in
-            contract.data.withUnsafeBytes { bytes in
-                bytes.baseAddress?.assumingMemoryBound(to: UInt8.self)
-            }
-        }
-        
-        let contractLengths = contracts.map { $0.data.count }
-        
-        // Call the FFI function
-        let result = contractIds.withCString { idsCStr in
-            contractDataPointers.withUnsafeBufferPointer { dataPointers in
-                contractLengths.withUnsafeBufferPointer { lengths in
-                    dash_sdk_add_known_contracts(
-                        handle,
-                        idsCStr,
-                        dataPointers.baseAddress,
-                        lengths.baseAddress,
-                        UInt(contracts.count)
-                    )
-                }
-            }
-        }
-        
-        // Check for errors
-        if result.error != nil {
-            let error = result.error!.pointee
-            let errorMessage = error.message != nil ? String(cString: error.message!) : "Unknown error"
-            defer {
-                dash_sdk_error_free(result.error)
-            }
-            
-            throw SDKError.internalError("Failed to add known contracts: \(errorMessage)")
-        }
-        
-        print("✅ Successfully loaded \(contracts.count) known contracts into SDK")
+
+    guard result.data != nil else {
+      throw SDKError.internalError("No SDK handle returned")
     }
-    
-    deinit {
-        if let handle = handle {
-            dash_sdk_destroy(handle)
-        }
+
+    // Store the handle and network
+    handle = result.data?.assumingMemoryBound(to: SDKHandle.self)
+    self.network = network
+  }
+
+  /// Load known contracts into the trusted context provider
+  /// This avoids network calls for these contracts when they're needed
+  public func loadKnownContracts(_ contracts: [(id: String, data: Data)]) throws {
+    guard let handle = handle else {
+      throw SDKError.invalidState("SDK not initialized")
     }
-    
-    /// Get SDK status including mode and quorum count
-    public func getStatus() throws -> SDKStatus {
-        guard let handle = handle else {
-            throw SDKError.invalidState("SDK not initialized")
-        }
-        
-        let result = dash_sdk_get_status(handle)
-        
-        // Check for error
-        if result.error != nil {
-            let error = result.error!.pointee
-            let errorMessage = error.message != nil ? String(cString: error.message!) : "Unknown error"
-            defer {
-                dash_sdk_error_free(result.error)
-            }
-            throw SDKError.internalError("Failed to get SDK status: \(errorMessage)")
-        }
-        
-        // Parse the JSON result
-        guard result.data != nil else {
-            throw SDKError.internalError("No status data returned")
-        }
-        
-        let jsonCStr = result.data.assumingMemoryBound(to: CChar.self)
-        let jsonStr = String(cString: jsonCStr)
-        defer {
-            dash_sdk_string_free(jsonCStr)
-        }
-        
-        guard let data = jsonStr.data(using: String.Encoding.utf8) else {
-            throw SDKError.serializationError("Invalid JSON data")
-        }
-        
-        do {
-            let decoder = JSONDecoder()
-            return try decoder.decode(SDKStatus.self, from: data)
-        } catch {
-            throw SDKError.serializationError("Failed to decode status: \(error)")
-        }
+
+    guard !contracts.isEmpty else {
+      return // Nothing to do
     }
-    
-    // TODO: Re-enable when CDashSDKFFI module is working
-    // /// Test the new FFI connection
-    // public func testNewFFI() -> Bool {
-    //     guard let newHandle = newFFIHandle else {
-    //         print("No new FFI handle available")
-    //         return false
-    //     }
-    //     
-    //     // Try to get the network from the new FFI
-    //     let sdkHandle = UnsafePointer<dash_sdk_SDKHandle>(OpaquePointer(newHandle))
-    //     let network = dash_sdk_get_network(sdkHandle)
-    //     
-    //     print("New FFI network: \(network)")
-    //     return true
-    // }
-    
-    /// Get an identity by ID
-    @MainActor
-    public func getIdentity(id: String) async throws -> Identity? {
-        // This would call the C function to get identity
-        // For now, return nil as placeholder
-        return nil
+
+    // Prepare contract IDs as comma-separated string
+    let contractIds = contracts.map { $0.id }.joined(separator: ",")
+
+    // Prepare arrays of contract data
+    let contractDataPointers = contracts.map { contract in
+      contract.data.withUnsafeBytes { bytes in
+        bytes.baseAddress?.assumingMemoryBound(to: UInt8.self)
+      }
     }
-    
-    /// Get a data contract by ID
-    @MainActor
-    public func getDataContract(id: String) async throws -> DataContract? {
-        // This would call the C function to get data contract
-        // For now, return nil as placeholder
-        return nil
+
+    let contractLengths = contracts.map { $0.data.count }
+
+    // Call the FFI function
+    let result = contractIds.withCString { idsCStr in
+      contractDataPointers.withUnsafeBufferPointer { dataPointers in
+        contractLengths.withUnsafeBufferPointer { lengths in
+          dash_sdk_add_known_contracts(
+            handle,
+            idsCStr,
+            dataPointers.baseAddress,
+            lengths.baseAddress,
+            UInt(contracts.count)
+          )
+        }
+      }
     }
+
+    // Check for errors
+    if result.error != nil {
+      let error = result.error!.pointee
+      let errorMessage = error.message != nil ? String(cString: error.message!) : "Unknown error"
+      defer {
+        dash_sdk_error_free(result.error)
+      }
+
+      throw SDKError.internalError("Failed to add known contracts: \(errorMessage)")
+    }
+
+    print("✅ Successfully loaded \(contracts.count) known contracts into SDK")
+  }
+
+  deinit {
+    if let handle = handle {
+      dash_sdk_destroy(handle)
+    }
+  }
+
+  /// Get SDK status including mode and quorum count
+  public func getStatus() throws -> SDKStatus {
+    guard let handle = handle else {
+      throw SDKError.invalidState("SDK not initialized")
+    }
+
+    let result = dash_sdk_get_status(handle)
+
+    // Check for error
+    if result.error != nil {
+      let error = result.error!.pointee
+      let errorMessage = error.message != nil ? String(cString: error.message!) : "Unknown error"
+      defer {
+        dash_sdk_error_free(result.error)
+      }
+      throw SDKError.internalError("Failed to get SDK status: \(errorMessage)")
+    }
+
+    // Parse the JSON result
+    guard result.data != nil else {
+      throw SDKError.internalError("No status data returned")
+    }
+
+    let jsonCStr = result.data.assumingMemoryBound(to: CChar.self)
+    let jsonStr = String(cString: jsonCStr)
+    defer {
+      dash_sdk_string_free(jsonCStr)
+    }
+
+    guard let data = jsonStr.data(using: String.Encoding.utf8) else {
+      throw SDKError.serializationError("Invalid JSON data")
+    }
+
+    do {
+      let decoder = JSONDecoder()
+      return try decoder.decode(SDKStatus.self, from: data)
+    } catch {
+      throw SDKError.serializationError("Failed to decode status: \(error)")
+    }
+  }
+
+  // TODO: Re-enable when CDashSDKFFI module is working
+  // /// Test the new FFI connection
+  // public func testNewFFI() -> Bool {
+  //     guard let newHandle = newFFIHandle else {
+  //         print("No new FFI handle available")
+  //         return false
+  //     }
+  //
+  //     // Try to get the network from the new FFI
+  //     let sdkHandle = UnsafePointer<dash_sdk_SDKHandle>(OpaquePointer(newHandle))
+  //     let network = dash_sdk_get_network(sdkHandle)
+  //
+  //     print("New FFI network: \(network)")
+  //     return true
+  // }
+
+  /// Get an identity by ID
+  @MainActor
+  public func getIdentity(id: String) async throws -> Identity? {
+    // This would call the C function to get identity
+    // For now, return nil as placeholder
+    return nil
+  }
+
+  /// Get a data contract by ID
+  @MainActor
+  public func getDataContract(id: String) async throws -> DataContract? {
+    // This would call the C function to get data contract
+    // For now, return nil as placeholder
+    return nil
+  }
 }
 
 /// SDK Status information
 public struct SDKStatus: Codable {
-    public let version: String
-    public let network: String
-    public let mode: String
-    public let quorumCount: Int
+  public let version: String
+  public let network: String
+  public let mode: String
+  public let quorumCount: Int
 }
 
 /// SDK Error handling
 public enum SDKError: Error {
-    case invalidParameter(String)
-    case invalidState(String)
-    case networkError(String)
-    case serializationError(String)
-    case protocolError(String)
-    case cryptoError(String)
-    case notFound(String)
-    case timeout(String)
-    case notImplemented(String)
-    case internalError(String)
-    case unknown(String)
-    
-    public static func fromDashSDKError(_ error: DashSDKError) -> SDKError {
-        let message = error.message != nil ? String(cString: error.message!) : "Unknown error"
-        
-        switch error.code {
-        case DashSDKErrorCode(rawValue: 1): // Invalid parameter
-            return .invalidParameter(message)
-        case DashSDKErrorCode(rawValue: 2): // Invalid state
-            return .invalidState(message)
-        case DashSDKErrorCode(rawValue: 3): // Network error
-            return .networkError(message)
-        case DashSDKErrorCode(rawValue: 4): // Serialization error
-            return .serializationError(message)
-        case DashSDKErrorCode(rawValue: 5): // Protocol error
-            return .protocolError(message)
-        case DashSDKErrorCode(rawValue: 6): // Crypto error
-            return .cryptoError(message)
-        case DashSDKErrorCode(rawValue: 7): // Not found
-            return .notFound(message)
-        case DashSDKErrorCode(rawValue: 8): // Timeout
-            return .timeout(message)
-        case DashSDKErrorCode(rawValue: 9): // Not implemented
-            return .notImplemented(message)
-        case DashSDKErrorCode(rawValue: 99): // Internal error
-            return .internalError(message)
-        default:
-            return .unknown(message)
-        }
+  case invalidParameter(String)
+  case invalidState(String)
+  case networkError(String)
+  case serializationError(String)
+  case protocolError(String)
+  case cryptoError(String)
+  case notFound(String)
+  case timeout(String)
+  case notImplemented(String)
+  case internalError(String)
+  case unknown(String)
+
+  public static func fromDashSDKError(_ error: DashSDKError) -> SDKError {
+    let message = error.message != nil ? String(cString: error.message!) : "Unknown error"
+
+    switch error.code {
+    case DashSDKErrorCode(rawValue: 1): // Invalid parameter
+      return .invalidParameter(message)
+    case DashSDKErrorCode(rawValue: 2): // Invalid state
+      return .invalidState(message)
+    case DashSDKErrorCode(rawValue: 3): // Network error
+      return .networkError(message)
+    case DashSDKErrorCode(rawValue: 4): // Serialization error
+      return .serializationError(message)
+    case DashSDKErrorCode(rawValue: 5): // Protocol error
+      return .protocolError(message)
+    case DashSDKErrorCode(rawValue: 6): // Crypto error
+      return .cryptoError(message)
+    case DashSDKErrorCode(rawValue: 7): // Not found
+      return .notFound(message)
+    case DashSDKErrorCode(rawValue: 8): // Timeout
+      return .timeout(message)
+    case DashSDKErrorCode(rawValue: 9): // Not implemented
+      return .notImplemented(message)
+    case DashSDKErrorCode(rawValue: 99): // Internal error
+      return .internalError(message)
+    default:
+      return .unknown(message)
     }
+  }
 }
 
 extension SDKError: LocalizedError {
-    public var errorDescription: String? {
-        switch self {
-        case .invalidParameter(let message):
-            return "Invalid Parameter: \(message)"
-        case .invalidState(let message):
-            return "Invalid State: \(message)"
-        case .networkError(let message):
-            return "Network Error: \(message)"
-        case .serializationError(let message):
-            return "Serialization Error: \(message)"
-        case .protocolError(let message):
-            return "Protocol Error: \(message)"
-        case .cryptoError(let message):
-            return "Cryptographic Error: \(message)"
-        case .notFound(let message):
-            return "Not Found: \(message)"
-        case .timeout(let message):
-            return "Operation Timed Out: \(message)"
-        case .notImplemented(let message):
-            return "Feature Not Implemented: \(message)"
-        case .internalError(let message):
-            return "Internal Error: \(message)"
-        case .unknown(let message):
-            return "Unknown Error: \(message)"
-        }
+  public var errorDescription: String? {
+    switch self {
+    case .invalidParameter(let message):
+      return "Invalid Parameter: \(message)"
+    case .invalidState(let message):
+      return "Invalid State: \(message)"
+    case .networkError(let message):
+      return "Network Error: \(message)"
+    case .serializationError(let message):
+      return "Serialization Error: \(message)"
+    case .protocolError(let message):
+      return "Protocol Error: \(message)"
+    case .cryptoError(let message):
+      return "Cryptographic Error: \(message)"
+    case .notFound(let message):
+      return "Not Found: \(message)"
+    case .timeout(let message):
+      return "Operation Timed Out: \(message)"
+    case .notImplemented(let message):
+      return "Feature Not Implemented: \(message)"
+    case .internalError(let message):
+      return "Internal Error: \(message)"
+    case .unknown(let message):
+      return "Unknown Error: \(message)"
     }
+  }
 }
 
 
 /// Identities operations
 public class Identities {
-    private weak var sdk: SDK?
-    
-    init(sdk: SDK) {
-        self.sdk = sdk
+  private weak var sdk: SDK?
+
+  init(sdk: SDK) {
+    self.sdk = sdk
+  }
+
+  /// Get an identity by ID
+  public func get(id: String) throws -> Identity? {
+    guard let sdk = sdk, let _ = sdk.handle else {
+      throw SDKError.invalidState("SDK not initialized")
     }
-    
-    /// Get an identity by ID
-    public func get(id: String) throws -> Identity? {
-        guard let sdk = sdk, let _ = sdk.handle else {
-            throw SDKError.invalidState("SDK not initialized")
+
+    // TODO: Call C function to get identity
+    // For now, return nil
+    return nil
+  }
+
+  /// Get an identity by ID using Data
+  public func get(id: Data) throws -> Identity? {
+    guard id.count == 32 else {
+      throw SDKError.invalidParameter("Identity ID must be exactly 32 bytes")
+    }
+
+    // Convert Data to hex string for now
+    return try get(id: id.toHexString())
+  }
+
+  /// Get a single identity balance
+  public func getBalance(id: Data) throws -> UInt64 {
+    guard let sdk = sdk, let handle = sdk.handle else {
+      throw SDKError.invalidState("SDK not initialized")
+    }
+
+    guard id.count == 32 else {
+      throw SDKError.invalidParameter("Identity ID must be exactly 32 bytes")
+    }
+
+    // Convert Data to Base58 string (the FFI expects string IDs)
+    let idString = id.toBase58()
+
+    let result = idString.withCString { cString in
+      // Handle is OpaquePointer which Swift should convert automatically
+      return dash_sdk_identity_fetch_balance(handle, cString)
+    }
+
+    // Check for errors
+    if result.error != nil {
+      let error = result.error!.pointee
+      defer {
+        dash_sdk_error_free(result.error)
+      }
+      throw SDKError.fromDashSDKError(error)
+    }
+
+    guard result.data != nil else {
+      throw SDKError.internalError("No balance data returned")
+    }
+
+    // Parse the balance from result
+    let balancePtr = result.data.assumingMemoryBound(to: UInt64.self)
+    let balance = balancePtr.pointee
+
+    // Free the result data
+    dash_sdk_bytes_free(result.data)
+
+    return balance
+  }
+
+  /// Fetch balances for multiple identities using Data (32-byte arrays)
+  /// - Parameter ids: Array of identity IDs as Data objects (must be exactly 32 bytes each)
+  /// - Returns: Dictionary mapping identity IDs (as Data) to their balances (nil if identity not found)
+  public func fetchBalances(ids: [Data]) throws -> [Data: UInt64?] {
+    guard let sdk = sdk, let handle = sdk.handle else {
+      throw SDKError.invalidState("SDK not initialized")
+    }
+
+    guard !ids.isEmpty else {
+      return [:]
+    }
+
+    // Validate all IDs are 32 bytes
+    for id in ids {
+      guard id.count == 32 else {
+        throw SDKError.invalidParameter("Identity ID must be exactly 32 bytes, got \(id.count)")
+      }
+    }
+
+    // Convert Data to byte arrays
+    let idByteArrays: [[UInt8]] = ids.map { Array($0) }
+
+    // Create array of 32-byte arrays for FFI
+    let idArrays: [(UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8,
+                    UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8,
+                    UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8,
+                    UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8)] =
+    idByteArrays.map { bytes in
+      (bytes[0], bytes[1], bytes[2], bytes[3], bytes[4], bytes[5], bytes[6], bytes[7],
+       bytes[8], bytes[9], bytes[10], bytes[11], bytes[12], bytes[13], bytes[14], bytes[15],
+       bytes[16], bytes[17], bytes[18], bytes[19], bytes[20], bytes[21], bytes[22], bytes[23],
+       bytes[24], bytes[25], bytes[26], bytes[27], bytes[28], bytes[29], bytes[30], bytes[31])
+    }
+
+    let result = idArrays.withUnsafeBufferPointer { buffer -> DashSDKResult in
+      let idsPtr = buffer.baseAddress
+      // The handle is already the correct type for the C function
+      return dash_sdk_identities_fetch_balances(handle, idsPtr, UInt(ids.count))
+    }
+
+    // Check for errors
+    if result.error != nil {
+      let error = result.error!.pointee
+      defer {
+        dash_sdk_error_free(result.error)
+      }
+      throw SDKError.fromDashSDKError(error)
+    }
+
+    guard result.data != nil else {
+      throw SDKError.internalError("No data returned from fetch balances")
+    }
+
+    // Parse the identity balance map
+    let mapPtr = result.data.assumingMemoryBound(to: DashSDKIdentityBalanceMap.self)
+    let map = mapPtr.pointee
+
+    var balances: [Data: UInt64?] = [:]
+
+    if map.count > 0 && map.entries != nil {
+      for i in 0..<map.count {
+        let entry = map.entries[Int(i)]
+        let idData = withUnsafeBytes(of: entry.identity_id) { Data($0) }
+
+        // Check if balance is u64::MAX (which means not found)
+        if entry.balance == UInt64.max {
+          balances[idData] = nil
+        } else {
+          balances[idData] = entry.balance
         }
-        
-        // TODO: Call C function to get identity
-        // For now, return nil
+      }
+    }
+
+    // Free the result
+    dash_sdk_identity_balance_map_free(mapPtr)
+
+    // Make sure all requested IDs are in the result
+    for id in ids {
+      if balances[id] == nil {
+        balances[id] = nil
+      }
+    }
+
+    return balances
+  }
+
+  // Helper function to convert hex string to bytes
+  private func hexToBytes(_ hex: String) -> [UInt8]? {
+    let hex = hex.trimmingCharacters(in: .whitespacesAndNewlines)
+    guard hex.count == 64 else { return nil } // 32 bytes = 64 hex chars
+
+    var bytes = [UInt8]()
+    var index = hex.startIndex
+
+    while index < hex.endIndex {
+      let nextIndex = hex.index(index, offsetBy: 2)
+      let byteString = hex[index..<nextIndex]
+
+      if let byte = UInt8(byteString, radix: 16) {
+        bytes.append(byte)
+      } else {
         return nil
+      }
+
+      index = nextIndex
     }
-    
-    /// Get an identity by ID using Data
-    public func get(id: Data) throws -> Identity? {
-        guard id.count == 32 else {
-            throw SDKError.invalidParameter("Identity ID must be exactly 32 bytes")
-        }
-        
-        // Convert Data to hex string for now
-        return try get(id: id.toHexString())
-    }
-    
-    /// Get a single identity balance
-    public func getBalance(id: Data) throws -> UInt64 {
-        guard let sdk = sdk, let handle = sdk.handle else {
-            throw SDKError.invalidState("SDK not initialized")
-        }
-        
-        guard id.count == 32 else {
-            throw SDKError.invalidParameter("Identity ID must be exactly 32 bytes")
-        }
-        
-        // Convert Data to Base58 string (the FFI expects string IDs)
-        let idString = id.toBase58()
-        
-        let result = idString.withCString { cString in
-            // Handle is OpaquePointer which Swift should convert automatically
-            return dash_sdk_identity_fetch_balance(handle, cString)
-        }
-        
-        // Check for errors
-        if result.error != nil {
-            let error = result.error!.pointee
-            defer {
-                dash_sdk_error_free(result.error)
-            }
-            throw SDKError.fromDashSDKError(error)
-        }
-        
-        guard result.data != nil else {
-            throw SDKError.internalError("No balance data returned")
-        }
-        
-        // Parse the balance from result
-        let balancePtr = result.data.assumingMemoryBound(to: UInt64.self)
-        let balance = balancePtr.pointee
-        
-        // Free the result data
-        dash_sdk_bytes_free(result.data)
-        
-        return balance
-    }
-    
-    /// Fetch balances for multiple identities using Data (32-byte arrays)
-    /// - Parameter ids: Array of identity IDs as Data objects (must be exactly 32 bytes each)
-    /// - Returns: Dictionary mapping identity IDs (as Data) to their balances (nil if identity not found)
-    public func fetchBalances(ids: [Data]) throws -> [Data: UInt64?] {
-        guard let sdk = sdk, let handle = sdk.handle else {
-            throw SDKError.invalidState("SDK not initialized")
-        }
-        
-        guard !ids.isEmpty else {
-            return [:]
-        }
-        
-        // Validate all IDs are 32 bytes
-        for id in ids {
-            guard id.count == 32 else {
-                throw SDKError.invalidParameter("Identity ID must be exactly 32 bytes, got \(id.count)")
-            }
-        }
-        
-        // Convert Data to byte arrays
-        let idByteArrays: [[UInt8]] = ids.map { Array($0) }
-        
-        // Create array of 32-byte arrays for FFI
-        let idArrays: [(UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8,
-                        UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8,
-                        UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8,
-                        UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8)] = 
-            idByteArrays.map { bytes in
-                (bytes[0], bytes[1], bytes[2], bytes[3], bytes[4], bytes[5], bytes[6], bytes[7],
-                 bytes[8], bytes[9], bytes[10], bytes[11], bytes[12], bytes[13], bytes[14], bytes[15],
-                 bytes[16], bytes[17], bytes[18], bytes[19], bytes[20], bytes[21], bytes[22], bytes[23],
-                 bytes[24], bytes[25], bytes[26], bytes[27], bytes[28], bytes[29], bytes[30], bytes[31])
-            }
-        
-        let result = idArrays.withUnsafeBufferPointer { buffer -> DashSDKResult in
-            let idsPtr = buffer.baseAddress
-            // The handle is already the correct type for the C function
-            return dash_sdk_identities_fetch_balances(handle, idsPtr, UInt(ids.count))
-        }
-        
-        // Check for errors
-        if result.error != nil {
-            let error = result.error!.pointee
-            defer {
-                dash_sdk_error_free(result.error)
-            }
-            throw SDKError.fromDashSDKError(error)
-        }
-        
-        guard result.data != nil else {
-            throw SDKError.internalError("No data returned from fetch balances")
-        }
-        
-        // Parse the identity balance map
-        let mapPtr = result.data.assumingMemoryBound(to: DashSDKIdentityBalanceMap.self)
-        let map = mapPtr.pointee
-        
-        var balances: [Data: UInt64?] = [:]
-        
-        if map.count > 0 && map.entries != nil {
-            for i in 0..<map.count {
-                let entry = map.entries[Int(i)]
-                let idData = withUnsafeBytes(of: entry.identity_id) { Data($0) }
-                
-                // Check if balance is u64::MAX (which means not found)
-                if entry.balance == UInt64.max {
-                    balances[idData] = nil
-                } else {
-                    balances[idData] = entry.balance
-                }
-            }
-        }
-        
-        // Free the result
-        dash_sdk_identity_balance_map_free(mapPtr)
-        
-        // Make sure all requested IDs are in the result
-        for id in ids {
-            if balances[id] == nil {
-                balances[id] = nil
-            }
-        }
-        
-        return balances
-    }
-    
-    // Helper function to convert hex string to bytes
-    private func hexToBytes(_ hex: String) -> [UInt8]? {
-        let hex = hex.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard hex.count == 64 else { return nil } // 32 bytes = 64 hex chars
-        
-        var bytes = [UInt8]()
-        var index = hex.startIndex
-        
-        while index < hex.endIndex {
-            let nextIndex = hex.index(index, offsetBy: 2)
-            let byteString = hex[index..<nextIndex]
-            
-            if let byte = UInt8(byteString, radix: 16) {
-                bytes.append(byte)
-            } else {
-                return nil
-            }
-            
-            index = nextIndex
-        }
-        
-        return bytes.count == 32 ? bytes : nil
-    }
-    
-    // Helper function to convert bytes to hex string
-    private func bytesToHex(_ bytes: [UInt8]) -> String {
-        return bytes.map { String(format: "%02x", $0) }.joined()
-    }
+
+    return bytes.count == 32 ? bytes : nil
+  }
+
+  // Helper function to convert bytes to hex string
+  private func bytesToHex(_ bytes: [UInt8]) -> String {
+    return bytes.map { String(format: "%02x", $0) }.joined()
+  }
 }
 
 /// Contracts operations
 public class Contracts {
-    private weak var sdk: SDK?
-    
-    init(sdk: SDK) {
-        self.sdk = sdk
+  private weak var sdk: SDK?
+
+  init(sdk: SDK) {
+    self.sdk = sdk
+  }
+
+  /// Get a data contract by ID
+  public func get(id: String) throws -> DataContract? {
+    guard let sdk = sdk, let _ = sdk.handle else {
+      throw SDKError.invalidState("SDK not initialized")
     }
-    
-    /// Get a data contract by ID
-    public func get(id: String) throws -> DataContract? {
-        guard let sdk = sdk, let _ = sdk.handle else {
-            throw SDKError.invalidState("SDK not initialized")
-        }
-        
-        // TODO: Call C function to get data contract
-        // For now, return nil
-        return nil
-    }
+
+    // TODO: Call C function to get data contract
+    // For now, return nil
+    return nil
+  }
 }

--- a/packages/swift-sdk/Sources/SwiftDashSDK/Utils/DataExtensions.swift
+++ b/packages/swift-sdk/Sources/SwiftDashSDK/Utils/DataExtensions.swift
@@ -92,4 +92,9 @@ extension Data {
 
         return encoded
     }
+
+    /// Convert to hex string
+    public func toHexString() -> String {
+        return self.map { String(format: "%02x", $0) }.joined()
+    }
 }

--- a/packages/swift-sdk/SwiftExampleApp/SwiftExampleApp/Views/KeysListView.swift
+++ b/packages/swift-sdk/SwiftExampleApp/SwiftExampleApp/Views/KeysListView.swift
@@ -2,414 +2,422 @@ import SwiftUI
 import SwiftDashSDK
 
 struct KeysListView: View {
-    struct IdentifiableInt: Identifiable { let id: Int }
-    let identity: IdentityModel
-    @State private var showingPrivateKey: IdentifiableInt? = nil
-    @State private var copiedKeyId: Int? = nil
-    
-    private var privateKeysAvailableCount: Int {
-        identity.publicKeys.filter { publicKey in
-            hasPrivateKey(for: publicKey.id)
-        }.count
-    }
-    
-    var body: some View {
-        List {
-            // Public Keys Section
-            Section("Public Keys") {
-                ForEach(identity.publicKeys.sorted(by: { $0.id < $1.id }), id: \.id) { publicKey in
-                    if hasPrivateKey(for: publicKey.id) {
-                        // For keys with private keys, use a button instead of NavigationLink
-                        Button(action: {
-                            print("🔑 View Private button pressed for key \(publicKey.id)")
-                            showingPrivateKey = IdentifiableInt(id: Int(publicKey.id))
-                        }) {
-                            KeyRowView(
-                                publicKey: publicKey,
-                                privateKeyAvailable: true
-                            )
-                        }
-                        .foregroundColor(.primary)
-                    } else {
-                        // For keys without private keys, use NavigationLink
-                        NavigationLink(destination: KeyDetailView(identity: identity, publicKey: publicKey)) {
-                            KeyRowView(
-                                publicKey: publicKey,
-                                privateKeyAvailable: false
-                            )
-                        }
-                    }
-                }
+  struct IdentifiableInt: Identifiable { let id: Int }
+  let identity: IdentityModel
+  @State private var showingPrivateKey: IdentifiableInt? = nil
+  @State private var copiedKeyId: Int? = nil
+
+  private var privateKeysAvailableCount: Int {
+    identity.publicKeys.filter { publicKey in
+      hasPrivateKey(for: publicKey.id)
+    }.count
+  }
+
+  var body: some View {
+    List {
+      // Public Keys Section
+      Section("Public Keys") {
+        ForEach(identity.publicKeys.sorted(by: { $0.id < $1.id }), id: \.id) { publicKey in
+          if hasPrivateKey(for: publicKey.id) {
+            // For keys with private keys, use a button instead of NavigationLink
+            Button(action: {
+              print("🔑 View Private button pressed for key \(publicKey.id)")
+              showingPrivateKey = IdentifiableInt(id: Int(publicKey.id))
+            }) {
+              KeyRowView(
+                publicKey: publicKey,
+                privateKeyAvailable: true
+              )
             }
-            
-            // Summary Section
-            Section("Key Summary") {
-                HStack {
-                    Label("Total Public Keys", systemImage: "key")
-                    Spacer()
-                    Text("\(identity.publicKeys.count)")
-                        .foregroundColor(.secondary)
-                }
-                
-                HStack {
-                    Label("Private Keys Available", systemImage: "key.fill")
-                    Spacer()
-                    Text("\(privateKeysAvailableCount)")
-                        .foregroundColor(.green)
-                }
-                
-                if identity.votingPrivateKey != nil {
-                    HStack {
-                        Label("Voting Key", systemImage: "hand.raised.fill")
-                        Spacer()
-                        Text("Available")
-                            .foregroundColor(.green)
-                    }
-                }
-                
-                if identity.ownerPrivateKey != nil {
-                    HStack {
-                        Label("Owner Key", systemImage: "person.badge.key.fill")
-                        Spacer()
-                        Text("Available")
-                            .foregroundColor(.green)
-                    }
-                }
+            .foregroundColor(.primary)
+          } else {
+            // For keys without private keys, use NavigationLink
+            NavigationLink(destination: KeyDetailView(identity: identity, publicKey: publicKey)) {
+              KeyRowView(
+                publicKey: publicKey,
+                privateKeyAvailable: false
+              )
             }
+          }
         }
-        .navigationTitle("Identity Keys")
-        .navigationBarTitleDisplayMode(.inline)
-        .sheet(item: $showingPrivateKey) { keyId in
-            let _ = print("🔑 Sheet presenting for keyId: \(keyId.id)")
-            PrivateKeyView(
-                identity: identity,
-                keyId: UInt32(keyId.id),
-                onCopy: { keyId in
-                    copiedKeyId = keyId
-                    DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
-                        copiedKeyId = nil
-                    }
-                }
-            )
+      }
+
+      // Summary Section
+      Section("Key Summary") {
+        HStack {
+          Label("Total Public Keys", systemImage: "key")
+          Spacer()
+          Text("\(identity.publicKeys.count)")
+            .foregroundColor(.secondary)
         }
-        .overlay(alignment: .bottom) {
-            if let copiedId = copiedKeyId {
-                CopiedToast(message: "Private key #\(copiedId) copied")
-                    .transition(.move(edge: .bottom).combined(with: .opacity))
-            }
+
+        HStack {
+          Label("Private Keys Available", systemImage: "key.fill")
+          Spacer()
+          Text("\(privateKeysAvailableCount)")
+            .foregroundColor(.green)
         }
+
+        if identity.votingPrivateKey != nil {
+          HStack {
+            Label("Voting Key", systemImage: "hand.raised.fill")
+            Spacer()
+            Text("Available")
+              .foregroundColor(.green)
+          }
+        }
+
+        if identity.ownerPrivateKey != nil {
+          HStack {
+            Label("Owner Key", systemImage: "person.badge.key.fill")
+            Spacer()
+            Text("Available")
+              .foregroundColor(.green)
+          }
+        }
+      }
     }
-    
-    private func hasPrivateKey(for keyId: UInt32) -> Bool {
-        // Check if we have a private key for this key ID in keychain
-        let hasKey = KeychainManager.shared.hasPrivateKey(identityId: identity.id, keyIndex: Int32(keyId))
-        print("🔑 Checking private key for keyId: \(keyId) - found: \(hasKey)")
-        return hasKey
+    .navigationTitle("Identity Keys")
+    .navigationBarTitleDisplayMode(.inline)
+    .sheet(item: $showingPrivateKey) { keyId in
+      let _ = print("🔑 Sheet presenting for keyId: \(keyId.id)")
+      PrivateKeyView(
+        identity: identity,
+        keyId: UInt32(keyId.id),
+        onCopy: { keyId in
+          copiedKeyId = keyId
+          DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
+            copiedKeyId = nil
+          }
+        }
+      )
     }
+    .overlay(alignment: .bottom) {
+      if let copiedId = copiedKeyId {
+        CopiedToast(message: "Private key #\(copiedId) copied")
+          .transition(.move(edge: .bottom).combined(with: .opacity))
+      }
+    }
+  }
+
+  private func hasPrivateKey(for keyId: UInt32) -> Bool {
+    // Check if we have a private key for this key ID in keychain
+    let hasKey = KeychainManager.shared.hasPrivateKey(identityId: identity.id, keyIndex: Int32(keyId))
+    print("🔑 Checking private key for keyId: \(keyId) - found: \(hasKey)")
+    return hasKey
+  }
 }
 
 struct KeyRowView: View {
-    let publicKey: IdentityPublicKey
-    let privateKeyAvailable: Bool
-    
-    var body: some View {
-        VStack(alignment: .leading, spacing: 8) {
-            // Key Header
-            HStack {
-                VStack(alignment: .leading, spacing: 2) {
-                    Text("Key #\(publicKey.id)")
-                        .font(.headline)
-                    Text(publicKey.purpose.name)
-                        .font(.caption)
-                        .foregroundColor(.secondary)
-                }
-                
-                Spacer()
-                
-                VStack(alignment: .trailing, spacing: 2) {
-                    SecurityLevelBadge(level: publicKey.securityLevel)
-                    if privateKeyAvailable {
-                        Label("View Private", systemImage: "eye.fill")
-                            .font(.caption2)
-                            .foregroundColor(.blue)
-                    }
-                }
-            }
-            
-            // Key Type and Properties
-            HStack(spacing: 12) {
-                Label(publicKey.keyType.name, systemImage: "signature")
-                    .font(.caption2)
-                
-                if publicKey.readOnly {
-                    Label("Read Only", systemImage: "lock.fill")
-                        .font(.caption2)
-                        .foregroundColor(.orange)
-                }
-                
-                if publicKey.disabledAt != nil {
-                    Label("Disabled", systemImage: "xmark.circle.fill")
-                        .font(.caption2)
-                        .foregroundColor(.red)
-                }
-            }
-            
-            // Public Key Data
-            VStack(alignment: .leading, spacing: 4) {
-                Text("Public Key:")
-                    .font(.caption2)
-                    .fontWeight(.medium)
-                Text(publicKey.data.toHexString())
-                    .font(.system(.caption2, design: .monospaced))
-                    .lineLimit(2)
-                    .truncationMode(.middle)
-                    .foregroundColor(.secondary)
-            }
-            .padding(.top, 4)
+  let publicKey: IdentityPublicKey
+  let privateKeyAvailable: Bool
+
+  var body: some View {
+    VStack(alignment: .leading, spacing: 8) {
+      // Key Header
+      HStack {
+        VStack(alignment: .leading, spacing: 2) {
+          Text("Key #\(publicKey.id)")
+            .font(.headline)
+          Text(publicKey.purpose.name)
+            .font(.caption)
+            .foregroundColor(.secondary)
         }
-        .padding(.vertical, 4)
+
+        Spacer()
+
+        VStack(alignment: .trailing, spacing: 2) {
+          SecurityLevelBadge(level: publicKey.securityLevel)
+          if privateKeyAvailable {
+            Label("View Private", systemImage: "eye.fill")
+              .font(.caption2)
+              .foregroundColor(.blue)
+          }
+        }
+      }
+
+      // Key Type and Properties
+      HStack(spacing: 12) {
+        Label(publicKey.keyType.name, systemImage: "signature")
+          .font(.caption2)
+
+        if publicKey.readOnly {
+          Label("Read Only", systemImage: "lock.fill")
+            .font(.caption2)
+            .foregroundColor(.orange)
+        }
+
+        if publicKey.disabledAt != nil {
+          Label("Disabled", systemImage: "xmark.circle.fill")
+            .font(.caption2)
+            .foregroundColor(.red)
+        }
+      }
+
+      // Public Key Data
+      VStack(alignment: .leading, spacing: 4) {
+        Text("Public Key:")
+          .font(.caption2)
+          .fontWeight(.medium)
+        Text(publicKey.data.toHexString())
+          .font(.system(.caption2, design: .monospaced))
+          .lineLimit(2)
+          .truncationMode(.middle)
+          .foregroundColor(.secondary)
+      }
+      .padding(.top, 4)
     }
+    .padding(.vertical, 4)
+  }
 }
 
 struct PrivateKeyView: View {
-    let identity: IdentityModel
-    let keyId: UInt32
-    let onCopy: (Int) -> Void
-    @Environment(\.dismiss) var dismiss
-    @EnvironmentObject var appState: AppState
-    @State private var showingPrivateKey = false
-    @State private var showForgetKeyAlert = false
-    
-    var body: some View {
-        let _ = print("🔑 PrivateKeyView initialized for keyId: \(keyId)")
-        NavigationView {
-            VStack(spacing: 20) {
-                // Warning
-                VStack(spacing: 12) {
-                    Image(systemName: "exclamationmark.triangle.fill")
-                        .font(.largeTitle)
-                        .foregroundColor(.orange)
-                    
-                    Text("Private Key Warning")
-                        .font(.headline)
-                    
-                    Text("Never share your private key with anyone. Anyone with access to this key can control your identity and spend your funds.")
-                        .multilineTextAlignment(.center)
-                        .font(.caption)
-                        .foregroundColor(.secondary)
+  let identity: IdentityModel
+  let keyId: UInt32
+  let onCopy: (Int) -> Void
+  @Environment(\.dismiss) var dismiss
+  @EnvironmentObject var appState: AppState
+  @State private var showingPrivateKey = false
+  @State private var showForgetKeyAlert = false
+
+  var body: some View {
+    let _ = print("🔑 PrivateKeyView initialized for keyId: \(keyId)")
+    NavigationView {
+      VStack(spacing: 20) {
+        // Warning
+        VStack(spacing: 12) {
+          Image(systemName: "exclamationmark.triangle.fill")
+            .font(.largeTitle)
+            .foregroundColor(.orange)
+
+          Text("Private Key Warning")
+            .font(.headline)
+
+          Text("Never share your private key with anyone. Anyone with access to this key can control your identity and spend your funds.")
+            .multilineTextAlignment(.center)
+            .font(.caption)
+            .foregroundColor(.secondary)
+        }
+        .padding()
+        .background(Color.orange.opacity(0.1))
+        .cornerRadius(12)
+
+        // Key Info
+        VStack(alignment: .leading, spacing: 8) {
+          HStack {
+            Text("Key ID:")
+            Spacer()
+            Text("#\(keyId)")
+              .fontWeight(.medium)
+          }
+
+          if let publicKey = identity.publicKeys.first(where: { $0.id == keyId }) {
+            HStack {
+              Text("Purpose:")
+              Spacer()
+              Text(publicKey.purpose.name)
+                .fontWeight(.medium)
+            }
+
+            HStack {
+              Text("Type:")
+              Spacer()
+              Text(publicKey.keyType.name)
+                .fontWeight(.medium)
+            }
+          }
+        }
+        .padding()
+        .background(Color.gray.opacity(0.1))
+        .cornerRadius(12)
+
+        // Private Key Display
+        if showingPrivateKey {
+          if let privateKeyData = getPrivateKey(for: keyId),
+             let publicKey = identity.publicKeys.first(where: { $0.id == keyId }) {
+            VStack(alignment: .leading, spacing: 16) {
+              // Hex Format
+              VStack(alignment: .leading, spacing: 8) {
+                Text("Private Key (Hex):")
+                  .font(.caption)
+                  .fontWeight(.medium)
+
+                Text(privateKeyData.toHexString())
+                  .font(.system(.caption, design: .monospaced))
+                  .padding()
+                  .frame(maxWidth: .infinity, alignment: .leading)
+                  .background(Color.black.opacity(0.05))
+                  .cornerRadius(8)
+                  .textSelection(.enabled)
+                  .fixedSize(horizontal: false, vertical: true)
+
+                Button(action: {
+                  UIPasteboard.general.string = privateKeyData.toHexString()
+                  onCopy(Int(keyId))
+                }) {
+                  Label("Copy Hex", systemImage: "doc.on.doc")
+                    .frame(maxWidth: .infinity)
                 }
-                .padding()
-                .background(Color.orange.opacity(0.1))
-                .cornerRadius(12)
-                
-                // Key Info
+                .buttonStyle(.bordered)
+              }
+
+              // WIF Format - only for ECDSA key types
+              if publicKey.keyType == .ecdsaSecp256k1 || publicKey.keyType == .ecdsaHash160 {
                 VStack(alignment: .leading, spacing: 8) {
-                    HStack {
-                        Text("Key ID:")
-                        Spacer()
-                        Text("#\(keyId)")
-                            .fontWeight(.medium)
-                    }
-                    
-                    if let publicKey = identity.publicKeys.first(where: { $0.id == keyId }) {
-                        HStack {
-                            Text("Purpose:")
-                            Spacer()
-                            Text(publicKey.purpose.name)
-                                .fontWeight(.medium)
-                        }
-                        
-                        HStack {
-                            Text("Type:")
-                            Spacer()
-                            Text(publicKey.keyType.name)
-                                .fontWeight(.medium)
-                        }
-                    }
-                }
-                .padding()
-                .background(Color.gray.opacity(0.1))
-                .cornerRadius(12)
-                
-                // Private Key Display
-                if showingPrivateKey {
-                    if let privateKeyData = getPrivateKey(for: keyId),
-                       let publicKey = identity.publicKeys.first(where: { $0.id == keyId }) {
-                        VStack(alignment: .leading, spacing: 16) {
-                            // Hex Format
-                            VStack(alignment: .leading, spacing: 8) {
-                                Text("Private Key (Hex):")
-                                    .font(.caption)
-                                    .fontWeight(.medium)
-                                
-                                Text(privateKeyData.toHexString())
-                                    .font(.system(.caption, design: .monospaced))
-                                    .padding()
-                                    .frame(maxWidth: .infinity, alignment: .leading)
-                                    .background(Color.black.opacity(0.05))
-                                    .cornerRadius(8)
-                                    .textSelection(.enabled)
-                                    .fixedSize(horizontal: false, vertical: true)
-                                
-                                Button(action: {
-                                    UIPasteboard.general.string = privateKeyData.toHexString()
-                                    onCopy(Int(keyId))
-                                }) {
-                                    Label("Copy Hex", systemImage: "doc.on.doc")
-                                        .frame(maxWidth: .infinity)
-                                }
-                                .buttonStyle(.bordered)
-                            }
-                            
-                            // WIF Format - only for ECDSA key types
-                            if publicKey.keyType == .ecdsaSecp256k1 || publicKey.keyType == .ecdsaHash160 {
-                                VStack(alignment: .leading, spacing: 8) {
-                                    Text("Private Key (WIF):")
-                                        .font(.caption)
-                                        .fontWeight(.medium)
-                                    
-                                    if let wif = getWIFForPrivateKey(privateKeyData) {
-                                        Text(wif)
-                                            .font(.system(.caption, design: .monospaced))
-                                            .padding()
-                                            .frame(maxWidth: .infinity, alignment: .leading)
-                                            .background(Color.black.opacity(0.05))
-                                            .cornerRadius(8)
-                                            .textSelection(.enabled)
-                                            .fixedSize(horizontal: false, vertical: true)
-                                        
-                                        Button(action: {
-                                            UIPasteboard.general.string = wif
-                                            onCopy(Int(keyId))
-                                        }) {
-                                            Label("Copy WIF", systemImage: "doc.on.doc")
-                                                .frame(maxWidth: .infinity)
-                                        }
-                                        .buttonStyle(.bordered)
-                                    } else {
-                                        Text("Unable to encode to WIF format")
-                                            .foregroundColor(.red)
-                                            .font(.caption)
-                                    }
-                                }
-                            }
-                            
-                            Button(action: {
-                                dismiss()
-                            }) {
-                                Label("Done", systemImage: "checkmark.circle")
-                                    .frame(maxWidth: .infinity)
-                            }
-                            .buttonStyle(.borderedProminent)
-                            
-                            Button(action: {
-                                showForgetKeyAlert = true
-                            }) {
-                                Label("Forget Private Key", systemImage: "trash")
-                                    .frame(maxWidth: .infinity)
-                            }
-                            .buttonStyle(.bordered)
-                            .foregroundColor(.red)
-                        }
-                    } else {
-                        Text("Private key not available")
-                            .foregroundColor(.red)
-                    }
-                } else {
+                  Text("Private Key (WIF):")
+                    .font(.caption)
+                    .fontWeight(.medium)
+
+                  if let wif = getWIFForPrivateKey(privateKeyData) {
+                    Text(wif)
+                      .font(.system(.caption, design: .monospaced))
+                      .padding()
+                      .frame(maxWidth: .infinity, alignment: .leading)
+                      .background(Color.black.opacity(0.05))
+                      .cornerRadius(8)
+                      .textSelection(.enabled)
+                      .fixedSize(horizontal: false, vertical: true)
+
                     Button(action: {
-                        print("🔑 Reveal button pressed for keyId: \(keyId)")
-                        showingPrivateKey = true
+                      UIPasteboard.general.string = wif
+                      onCopy(Int(keyId))
                     }) {
-                        Label("Reveal Private Key", systemImage: "eye.fill")
-                            .frame(maxWidth: .infinity)
+                      Label("Copy WIF", systemImage: "doc.on.doc")
+                        .frame(maxWidth: .infinity)
                     }
-                    .buttonStyle(.borderedProminent)
-                    .tint(.orange)
+                    .buttonStyle(.bordered)
+                  } else {
+                    Text("Unable to encode to WIF format")
+                      .foregroundColor(.red)
+                      .font(.caption)
+                  }
                 }
-                
-                Spacer()
+              }
+
+              Button(action: {
+                dismiss()
+              }) {
+                Label("Done", systemImage: "checkmark.circle")
+                  .frame(maxWidth: .infinity)
+              }
+              .buttonStyle(.borderedProminent)
+
+              Button(action: {
+                showForgetKeyAlert = true
+              }) {
+                Label("Forget Private Key", systemImage: "trash")
+                  .frame(maxWidth: .infinity)
+              }
+              .buttonStyle(.bordered)
+              .foregroundColor(.red)
             }
-            .padding()
-            .navigationTitle("Private Key #\(keyId)")
-            .navigationBarTitleDisplayMode(.inline)
-            .toolbar {
-                ToolbarItem(placement: .navigationBarTrailing) {
-                    Button("Done") {
-                        dismiss()
-                    }
-                }
-            }
-            .alert("Forget Private Key?", isPresented: $showForgetKeyAlert) {
-                Button("Cancel", role: .cancel) {}
-                Button("Forget", role: .destructive) {
-                    forgetPrivateKey()
-                }
-            } message: {
-                Text("Are you sure you want to forget this private key? This action cannot be undone and you will need to re-enter the key to use it again.")
-            }
+          } else {
+            Text("Private key not available")
+              .foregroundColor(.red)
+          }
+        } else {
+          Button(action: {
+            print("🔑 Reveal button pressed for keyId: \(keyId)")
+            showingPrivateKey = true
+          }) {
+            Label("Reveal Private Key", systemImage: "eye.fill")
+              .frame(maxWidth: .infinity)
+          }
+          .buttonStyle(.borderedProminent)
+          .tint(.orange)
         }
-    }
-    
-    private func forgetPrivateKey() {
-        // Remove from keychain
-        let removed = KeychainManager.shared.deletePrivateKey(identityId: identity.id, keyIndex: Int32(keyId))
-        
-        if removed {
-            // Update the persistent public key to clear the reference
-            appState.removePrivateKeyReference(identityId: identity.id, keyId: Int32(keyId))
+
+        Spacer()
+      }
+      .padding()
+      .navigationTitle("Private Key #\(keyId)")
+      .navigationBarTitleDisplayMode(.inline)
+      .toolbar {
+        ToolbarItem(placement: .navigationBarTrailing) {
+          Button("Done") {
             dismiss()
+          }
         }
+      }
+      .alert("Forget Private Key?", isPresented: $showForgetKeyAlert) {
+        Button("Cancel", role: .cancel) {}
+        Button("Forget", role: .destructive) {
+          forgetPrivateKey()
+        }
+      } message: {
+        Text("Are you sure you want to forget this private key? This action cannot be undone and you will need to re-enter the key to use it again.")
+      }
     }
-    
-    private func getPrivateKey(for keyId: UInt32) -> Data? {
-        // Retrieve the actual stored private key from keychain
-        let privateKey = KeychainManager.shared.retrievePrivateKey(identityId: identity.id, keyIndex: Int32(keyId))
-        print("🔑 Retrieving private key for identity: \(identity.id.toHexString()), keyId: \(keyId)")
-        print("🔑 Private key found: \(privateKey != nil ? "Yes (\(privateKey!.count) bytes)" : "No")")
-        return privateKey
+  }
+
+  private func forgetPrivateKey() {
+    // Remove from keychain
+    let removed = KeychainManager.shared.deletePrivateKey(identityId: identity.id, keyIndex: Int32(keyId))
+
+    if removed {
+      // Update the persistent public key to clear the reference
+      appState.removePrivateKeyReference(identityId: identity.id, keyId: Int32(keyId))
+      dismiss()
     }
-    
-    private func getWIFForPrivateKey(_ privateKeyData: Data) -> String? {
-        return WIFParser.encodeToWIF(privateKeyData, isTestnet: true)
-    }
+  }
+
+  @MainActor
+  private func getPrivateKey(for keyId: UInt32) -> Data? {
+    // Use KeyManager to retrieve private key
+    let dppIdentity = DPPIdentity(
+      id: identity.id,
+      publicKeys: Dictionary(uniqueKeysWithValues: identity.publicKeys.map { ($0.id, $0) }),
+      balance: identity.balance,
+      revision: 0
+    )
+    let keyManager = KeyManager.withSharedKeychain()
+    let privateKey = try? keyManager.getPrivateKey(for: dppIdentity, keyIndex: keyId)
+    print("🔑 Retrieving private key for identity: \(identity.id.toHexString()), keyId: \(keyId)")
+    print("🔑 Private key found: \(privateKey != nil ? "Yes (\(privateKey!.count) bytes)" : "No")")
+    return privateKey
+  }
+
+  private func getWIFForPrivateKey(_ privateKeyData: Data) -> String? {
+    return WIFParser.encodeToWIF(privateKeyData, isTestnet: true)
+  }
 }
 
 struct SecurityLevelBadge: View {
-    let level: SecurityLevel
-    
-    var body: some View {
-        Text(level.name.uppercased())
-            .font(.caption2)
-            .padding(.horizontal, 8)
-            .padding(.vertical, 2)
-            .background(backgroundColor)
-            .foregroundColor(.white)
-            .cornerRadius(4)
+  let level: SecurityLevel
+
+  var body: some View {
+    Text(level.name.uppercased())
+      .font(.caption2)
+      .padding(.horizontal, 8)
+      .padding(.vertical, 2)
+      .background(backgroundColor)
+      .foregroundColor(.white)
+      .cornerRadius(4)
+  }
+
+  private var backgroundColor: Color {
+    switch level {
+    case .master: return .red
+    case .critical: return .orange
+    case .high: return .blue
+    case .medium: return .green
     }
-    
-    private var backgroundColor: Color {
-        switch level {
-        case .master: return .red
-        case .critical: return .orange
-        case .high: return .blue
-        case .medium: return .green
-        }
-    }
+  }
 }
 
 struct CopiedToast: View {
-    let message: String
-    
-    var body: some View {
-        Text(message)
-            .font(.caption)
-            .padding(.horizontal, 16)
-            .padding(.vertical, 8)
-            .background(Color.black.opacity(0.8))
-            .foregroundColor(.white)
-            .cornerRadius(20)
-            .padding(.bottom, 50)
-    }
+  let message: String
+
+  var body: some View {
+    Text(message)
+      .font(.caption)
+      .padding(.horizontal, 16)
+      .padding(.vertical, 8)
+      .background(Color.black.opacity(0.8))
+      .foregroundColor(.white)
+      .cornerRadius(20)
+      .padding(.bottom, 50)
+  }
 }
 
 

--- a/packages/swift-sdk/SwiftExampleApp/SwiftExampleApp/Views/RegisterNameView.swift
+++ b/packages/swift-sdk/SwiftExampleApp/SwiftExampleApp/Views/RegisterNameView.swift
@@ -2,659 +2,644 @@ import SwiftUI
 import SwiftDashSDK
 
 struct RegisterNameView: View {
-    let identity: IdentityModel
-    @EnvironmentObject var appState: AppState
-    @Environment(\.dismiss) var dismiss
-    
-    @State private var username = ""
-    @State private var isChecking = false
-    @State private var isAvailable: Bool? = nil
-    @State private var isContested = false
-    @State private var errorMessage = ""
-    @State private var showingError = false
-    @State private var checkTimer: Timer? = nil
-    @State private var lastCheckedName = ""
-    @State private var isRegistering = false
-    @State private var registrationSuccess = false
-    
-    private var normalizedUsername: String {
-        // Use the FFI function to normalize the username
-        let trimmed = username.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !trimmed.isEmpty else { return "" }
-        
-        return trimmed.withCString { namePtr in
-            let result = dash_sdk_dpns_normalize_username(namePtr)
-            defer { 
-                if let error = result.error {
-                    dash_sdk_error_free(error)
-                }
-                if let dataPtr = result.data {
-                    dash_sdk_string_free(dataPtr.assumingMemoryBound(to: CChar.self))
-                }
-            }
-            
-            if result.error == nil, let dataPtr = result.data {
-                return String(cString: dataPtr.assumingMemoryBound(to: CChar.self))
-            }
-            return trimmed.lowercased() // Fallback to simple lowercasing
+  let identity: IdentityModel
+  @EnvironmentObject var appState: AppState
+  @Environment(\.dismiss) var dismiss
+
+  @State private var username = ""
+  @State private var isChecking = false
+  @State private var isAvailable: Bool? = nil
+  @State private var isContested = false
+  @State private var errorMessage = ""
+  @State private var showingError = false
+  @State private var checkTimer: Timer? = nil
+  @State private var lastCheckedName = ""
+  @State private var isRegistering = false
+  @State private var registrationSuccess = false
+
+  private var normalizedUsername: String {
+    // Use the FFI function to normalize the username
+    let trimmed = username.trimmingCharacters(in: .whitespacesAndNewlines)
+    guard !trimmed.isEmpty else { return "" }
+
+    return trimmed.withCString { namePtr in
+      let result = dash_sdk_dpns_normalize_username(namePtr)
+      defer {
+        if let error = result.error {
+          dash_sdk_error_free(error)
         }
+        if let dataPtr = result.data {
+          dash_sdk_string_free(dataPtr.assumingMemoryBound(to: CChar.self))
+        }
+      }
+
+      if result.error == nil, let dataPtr = result.data {
+        return String(cString: dataPtr.assumingMemoryBound(to: CChar.self))
+      }
+      return trimmed.lowercased() // Fallback to simple lowercasing
     }
-    
-    private enum ValidationStatus {
-        case valid
-        case notLongEnough
-        case tooLong
-        case invalidCharacters
-        case invalidHyphenPlacement
+  }
+
+  private enum ValidationStatus {
+    case valid
+    case notLongEnough
+    case tooLong
+    case invalidCharacters
+    case invalidHyphenPlacement
+  }
+
+  private var validationStatus: ValidationStatus {
+    let name = normalizedUsername
+
+    // Check basic length first
+    if name.count < 3 {
+      return .notLongEnough
     }
-    
-    private var validationStatus: ValidationStatus {
-        let name = normalizedUsername
-        
-        // Check basic length first
-        if name.count < 3 {
-            return .notLongEnough
-        }
-        if name.count > 63 {
-            return .tooLong
-        }
-        
-        // Use FFI function to validate
-        let isValid = name.withCString { namePtr in
-            let result = dash_sdk_dpns_is_valid_username(namePtr)
-            return result == 1
-        }
-        
-        if isValid {
-            return .valid
-        }
-        
-        // If not valid, determine the specific reason
-        // Check for invalid characters
-        let validCharsPattern = "^[a-z0-9-]+$"
-        let validCharsRegex = try? NSRegularExpression(pattern: validCharsPattern, options: [])
-        let range = NSRange(location: 0, length: name.utf16.count)
-        if validCharsRegex?.firstMatch(in: name, options: [], range: range) == nil {
-            return .invalidCharacters
-        }
-        
-        // Check hyphen rules
-        if name.hasPrefix("-") || name.hasSuffix("-") || name.contains("--") {
-            return .invalidHyphenPlacement
-        }
-        
-        return .invalidCharacters // Default for any other invalid case
+    if name.count > 63 {
+      return .tooLong
     }
-    
-    private var isValidUsername: Bool {
-        // Use the FFI function directly
-        guard !normalizedUsername.isEmpty else { return false }
-        
-        return normalizedUsername.withCString { namePtr in
-            let result = dash_sdk_dpns_is_valid_username(namePtr)
-            return result == 1
-        }
+
+    // Use FFI function to validate
+    let isValid = name.withCString { namePtr in
+      let result = dash_sdk_dpns_is_valid_username(namePtr)
+      return result == 1
     }
-    
-    private var validationMessage: String {
-        // Use the FFI function to get validation message
-        guard !normalizedUsername.isEmpty else { return "" }
-        
-        return normalizedUsername.withCString { namePtr in
-            let result = dash_sdk_dpns_get_validation_message(namePtr)
-            defer { 
-                if let error = result.error {
-                    dash_sdk_error_free(error)
-                }
-                if let dataPtr = result.data {
-                    dash_sdk_string_free(dataPtr.assumingMemoryBound(to: CChar.self))
-                }
-            }
-            
-            if result.error == nil, let dataPtr = result.data {
-                let message = String(cString: dataPtr.assumingMemoryBound(to: CChar.self))
-                return message == "valid" ? "" : message
-            }
-            
-            // Fallback to our own messages
-            switch validationStatus {
-            case .valid:
-                return ""
-            case .notLongEnough:
-                return "Name must be at least 3 characters long"
-            case .tooLong:
-                return "Name must be 63 characters or less"
-            case .invalidCharacters:
-                return "Name can only contain letters, numbers, and hyphens"
-            case .invalidHyphenPlacement:
-                return "Hyphens cannot be at the start/end or consecutive"
-            }
-        }
+
+    if isValid {
+      return .valid
     }
-    
-    private var isNameContested: Bool {
-        // Only check if name is valid
-        guard isValidUsername else { return false }
-        
-        // Use the FFI function to check if the name is contested
-        return normalizedUsername.withCString { namePtr in
-            let result = dash_sdk_dpns_is_contested_username(namePtr)
-            return result == 1
-        }
+
+    // If not valid, determine the specific reason
+    // Check for invalid characters
+    let validCharsPattern = "^[a-z0-9-]+$"
+    let validCharsRegex = try? NSRegularExpression(pattern: validCharsPattern, options: [])
+    let range = NSRange(location: 0, length: name.utf16.count)
+    if validCharsRegex?.firstMatch(in: name, options: [], range: range) == nil {
+      return .invalidCharacters
     }
-    
-    var body: some View {
-        NavigationView {
-            Form {
-                Section("Choose Your Username") {
-                    TextField("Enter username", text: $username)
-                        .textContentType(.username)
-                        .autocapitalization(.none)
-                        .autocorrectionDisabled(true)
-                        .modifier(UsernameChangeHandler(username: $username) {
-                            // Cancel any existing timer
-                            checkTimer?.invalidate()
-                            
-                            // Reset availability if name changed
-                            if normalizedUsername != lastCheckedName {
-                                isAvailable = nil
-                                isChecking = false
-                            }
-                            
-                            errorMessage = ""
-                            // Update contested status
-                            isContested = isNameContested
-                            
-                            // Start new timer if name is valid
-                            if isValidUsername && normalizedUsername != lastCheckedName {
-                                checkTimer = Timer.scheduledTimer(withTimeInterval: 0.5, repeats: false) { _ in
-                                    Task {
-                                        await checkAvailabilityAutomatically()
-                                    }
-                                }
-                            }
-                        })
-                    
-                    if !normalizedUsername.isEmpty {
-                        VStack(alignment: .leading, spacing: 4) {
-                            HStack {
-                                Text("Normalized: ")
-                                    .font(.caption)
-                                    .foregroundColor(.secondary)
-                                Text("\(normalizedUsername).dash")
-                                    .font(.caption)
-                                    .foregroundColor(.blue)
-                            }
-                            
-                            // Show validation status
-                            if validationStatus != .valid {
-                                HStack {
-                                    Image(systemName: "exclamationmark.circle.fill")
-                                        .foregroundColor(.red)
-                                        .font(.caption)
-                                    Text(validationMessage)
-                                        .font(.caption)
-                                        .foregroundColor(.red)
-                                }
-                            }
-                        }
-                    }
-                }
-                
-                Section("Name Information") {
-                    HStack {
-                        Text("Validity")
-                        Spacer()
-                        if !normalizedUsername.isEmpty {
-                            switch validationStatus {
-                            case .valid:
-                                Label("Valid", systemImage: "checkmark.circle.fill")
-                                    .foregroundColor(.green)
-                            case .notLongEnough:
-                                Label("Not Long Enough", systemImage: "xmark.circle.fill")
-                                    .foregroundColor(.red)
-                            case .tooLong:
-                                Label("Too Long", systemImage: "xmark.circle.fill")
-                                    .foregroundColor(.red)
-                            case .invalidCharacters, .invalidHyphenPlacement:
-                                Label("Not Valid", systemImage: "xmark.circle.fill")
-                                    .foregroundColor(.red)
-                            }
-                        } else {
-                            Text("Enter a name")
-                                .foregroundColor(.secondary)
-                        }
-                    }
-                    
-                    if isValidUsername {
-                        HStack {
-                            Text("Availability")
-                            Spacer()
-                            if isChecking {
-                                ProgressView()
-                                    .scaleEffect(0.8)
-                            } else if let available = isAvailable {
-                                if available {
-                                    Label("Available", systemImage: "checkmark.circle.fill")
-                                        .foregroundColor(.green)
-                                } else {
-                                    Label("Taken", systemImage: "xmark.circle.fill")
-                                        .foregroundColor(.red)
-                                }
-                            } else {
-                                Text("Not checked")
-                                    .foregroundColor(.secondary)
-                            }
-                        }
-                    }
-                    
-                    HStack {
-                        Text("Contest Status")
-                        Spacer()
-                        if isContested {
-                            Label("Contested", systemImage: "flag.fill")
-                                .foregroundColor(.orange)
-                        } else {
-                            Label("Regular", systemImage: "checkmark.circle")
-                                .foregroundColor(.green)
-                        }
-                    }
-                }
-                
-                if isContested && !normalizedUsername.isEmpty {
-                    Section("Contest Warning") {
-                        HStack {
-                            Image(systemName: "exclamationmark.triangle.fill")
-                                .foregroundColor(.orange)
-                            VStack(alignment: .leading, spacing: 4) {
-                                Text("Contested Name")
-                                    .font(.headline)
-                                    .foregroundColor(.orange)
-                                Text("This name is less than 20 characters with only letters (a-z, A-Z), digits (0, 1), and hyphens. It requires a masternode vote contest to register.")
-                                    .font(.caption)
-                                    .foregroundColor(.secondary)
-                            }
-                        }
-                        .padding(.vertical, 4)
-                    }
-                }
-                
-                Section {
-                    Button(action: registerName) {
-                        HStack {
-                            if isRegistering {
-                                ProgressView()
-                                    .progressViewStyle(CircularProgressViewStyle(tint: .white))
-                                    .scaleEffect(0.8)
-                                Text("Registering...")
-                            } else {
-                                Image(systemName: "plus.circle.fill")
-                                Text("Register Name")
-                            }
-                        }
-                        .foregroundColor(.white)
-                        .frame(maxWidth: .infinity)
-                        .padding()
-                        .background(isValidUsername && isAvailable == true && !isRegistering ? Color.blue : Color.gray)
-                        .cornerRadius(10)
-                    }
-                    .disabled(!isValidUsername || isAvailable != true || isRegistering)
-                    .listRowInsets(EdgeInsets())
-                    .listRowBackground(Color.clear)
-                }
-            }
-            .navigationTitle("Register DPNS Name")
-            .navigationBarTitleDisplayMode(.inline)
-            .toolbar {
-                ToolbarItem(placement: .navigationBarLeading) {
-                    Button("Cancel") {
-                        dismiss()
-                    }
-                }
-            }
-            .alert("Error", isPresented: $showingError) {
-                Button("OK") { }
-            } message: {
-                Text(errorMessage)
-            }
-            .onDisappear {
-                // Clean up timer when view disappears
-                checkTimer?.invalidate()
-                checkTimer = nil
-            }
-        }
+
+    // Check hyphen rules
+    if name.hasPrefix("-") || name.hasSuffix("-") || name.contains("--") {
+      return .invalidHyphenPlacement
     }
-    
-    private func checkAvailabilityAutomatically() async {
-        // Store the name we're checking
-        lastCheckedName = normalizedUsername
-        
-        // Start showing the checking indicator
-        await MainActor.run {
-            isChecking = true
+
+    return .invalidCharacters // Default for any other invalid case
+  }
+
+  private var isValidUsername: Bool {
+    // Use the FFI function directly
+    guard !normalizedUsername.isEmpty else { return false }
+
+    return normalizedUsername.withCString { namePtr in
+      let result = dash_sdk_dpns_is_valid_username(namePtr)
+      return result == 1
+    }
+  }
+
+  private var validationMessage: String {
+    // Use the FFI function to get validation message
+    guard !normalizedUsername.isEmpty else { return "" }
+
+    return normalizedUsername.withCString { namePtr in
+      let result = dash_sdk_dpns_get_validation_message(namePtr)
+      defer {
+        if let error = result.error {
+          dash_sdk_error_free(error)
         }
-        
-        // Use the SDK to check availability
-        guard let sdk = appState.sdk else {
-            await MainActor.run {
-                errorMessage = "SDK not initialized"
-                showingError = true
+        if let dataPtr = result.data {
+          dash_sdk_string_free(dataPtr.assumingMemoryBound(to: CChar.self))
+        }
+      }
+
+      if result.error == nil, let dataPtr = result.data {
+        let message = String(cString: dataPtr.assumingMemoryBound(to: CChar.self))
+        return message == "valid" ? "" : message
+      }
+
+      // Fallback to our own messages
+      switch validationStatus {
+      case .valid:
+        return ""
+      case .notLongEnough:
+        return "Name must be at least 3 characters long"
+      case .tooLong:
+        return "Name must be 63 characters or less"
+      case .invalidCharacters:
+        return "Name can only contain letters, numbers, and hyphens"
+      case .invalidHyphenPlacement:
+        return "Hyphens cannot be at the start/end or consecutive"
+      }
+    }
+  }
+
+  private var isNameContested: Bool {
+    // Only check if name is valid
+    guard isValidUsername else { return false }
+
+    // Use the FFI function to check if the name is contested
+    return normalizedUsername.withCString { namePtr in
+      let result = dash_sdk_dpns_is_contested_username(namePtr)
+      return result == 1
+    }
+  }
+
+  var body: some View {
+    NavigationView {
+      Form {
+        Section("Choose Your Username") {
+          TextField("Enter username", text: $username)
+            .textContentType(.username)
+            .autocapitalization(.none)
+            .autocorrectionDisabled(true)
+            .modifier(UsernameChangeHandler(username: $username) {
+              // Cancel any existing timer
+              checkTimer?.invalidate()
+
+              // Reset availability if name changed
+              if normalizedUsername != lastCheckedName {
+                isAvailable = nil
                 isChecking = false
-            }
-            return
-        }
-        
-        do {
-            let available = try await sdk.dpnsCheckAvailability(name: normalizedUsername)
-            
-            await MainActor.run {
-                isAvailable = available
-                isChecking = false
-                if !available {
-                    errorMessage = "This name is already registered"
+              }
+
+              errorMessage = ""
+              // Update contested status
+              isContested = isNameContested
+
+              // Start new timer if name is valid
+              if isValidUsername && normalizedUsername != lastCheckedName {
+                checkTimer = Timer.scheduledTimer(withTimeInterval: 0.5, repeats: false) { _ in
+                  Task {
+                    await checkAvailabilityAutomatically()
+                  }
                 }
+              }
+            })
+
+          if !normalizedUsername.isEmpty {
+            VStack(alignment: .leading, spacing: 4) {
+              HStack {
+                Text("Normalized: ")
+                  .font(.caption)
+                  .foregroundColor(.secondary)
+                Text("\(normalizedUsername).dash")
+                  .font(.caption)
+                  .foregroundColor(.blue)
+              }
+
+              // Show validation status
+              if validationStatus != .valid {
+                HStack {
+                  Image(systemName: "exclamationmark.circle.fill")
+                    .foregroundColor(.red)
+                    .font(.caption)
+                  Text(validationMessage)
+                    .font(.caption)
+                    .foregroundColor(.red)
+                }
+              }
             }
-        } catch {
-            await MainActor.run {
-                // If we get an error, assume unavailable
-                isAvailable = false
-                isChecking = false
-                errorMessage = "Failed to check availability: \(error.localizedDescription)"
-                // Don't show error alert for automatic checks
-            }
+          }
         }
+
+        Section("Name Information") {
+          HStack {
+            Text("Validity")
+            Spacer()
+            if !normalizedUsername.isEmpty {
+              switch validationStatus {
+              case .valid:
+                Label("Valid", systemImage: "checkmark.circle.fill")
+                  .foregroundColor(.green)
+              case .notLongEnough:
+                Label("Not Long Enough", systemImage: "xmark.circle.fill")
+                  .foregroundColor(.red)
+              case .tooLong:
+                Label("Too Long", systemImage: "xmark.circle.fill")
+                  .foregroundColor(.red)
+              case .invalidCharacters, .invalidHyphenPlacement:
+                Label("Not Valid", systemImage: "xmark.circle.fill")
+                  .foregroundColor(.red)
+              }
+            } else {
+              Text("Enter a name")
+                .foregroundColor(.secondary)
+            }
+          }
+
+          if isValidUsername {
+            HStack {
+              Text("Availability")
+              Spacer()
+              if isChecking {
+                ProgressView()
+                  .scaleEffect(0.8)
+              } else if let available = isAvailable {
+                if available {
+                  Label("Available", systemImage: "checkmark.circle.fill")
+                    .foregroundColor(.green)
+                } else {
+                  Label("Taken", systemImage: "xmark.circle.fill")
+                    .foregroundColor(.red)
+                }
+              } else {
+                Text("Not checked")
+                  .foregroundColor(.secondary)
+              }
+            }
+          }
+
+          HStack {
+            Text("Contest Status")
+            Spacer()
+            if isContested {
+              Label("Contested", systemImage: "flag.fill")
+                .foregroundColor(.orange)
+            } else {
+              Label("Regular", systemImage: "checkmark.circle")
+                .foregroundColor(.green)
+            }
+          }
+        }
+
+        if isContested && !normalizedUsername.isEmpty {
+          Section("Contest Warning") {
+            HStack {
+              Image(systemName: "exclamationmark.triangle.fill")
+                .foregroundColor(.orange)
+              VStack(alignment: .leading, spacing: 4) {
+                Text("Contested Name")
+                  .font(.headline)
+                  .foregroundColor(.orange)
+                Text("This name is less than 20 characters with only letters (a-z, A-Z), digits (0, 1), and hyphens. It requires a masternode vote contest to register.")
+                  .font(.caption)
+                  .foregroundColor(.secondary)
+              }
+            }
+            .padding(.vertical, 4)
+          }
+        }
+
+        Section {
+          Button(action: registerName) {
+            HStack {
+              if isRegistering {
+                ProgressView()
+                  .progressViewStyle(CircularProgressViewStyle(tint: .white))
+                  .scaleEffect(0.8)
+                Text("Registering...")
+              } else {
+                Image(systemName: "plus.circle.fill")
+                Text("Register Name")
+              }
+            }
+            .foregroundColor(.white)
+            .frame(maxWidth: .infinity)
+            .padding()
+            .background(isValidUsername && isAvailable == true && !isRegistering ? Color.blue : Color.gray)
+            .cornerRadius(10)
+          }
+          .disabled(!isValidUsername || isAvailable != true || isRegistering)
+          .listRowInsets(EdgeInsets())
+          .listRowBackground(Color.clear)
+        }
+      }
+      .navigationTitle("Register DPNS Name")
+      .navigationBarTitleDisplayMode(.inline)
+      .toolbar {
+        ToolbarItem(placement: .navigationBarLeading) {
+          Button("Cancel") {
+            dismiss()
+          }
+        }
+      }
+      .alert("Error", isPresented: $showingError) {
+        Button("OK") { }
+      } message: {
+        Text(errorMessage)
+      }
+      .onDisappear {
+        // Clean up timer when view disappears
+        checkTimer?.invalidate()
+        checkTimer = nil
+      }
     }
-    
-    private func registerName() {
-        guard let sdk = appState.sdk,
-              let handle = sdk.handle else {
-            errorMessage = "SDK not initialized"
-            showingError = true
-            return
+  }
+
+  private func checkAvailabilityAutomatically() async {
+    // Store the name we're checking
+    lastCheckedName = normalizedUsername
+
+    // Start showing the checking indicator
+    await MainActor.run {
+      isChecking = true
+    }
+
+    // Use the SDK to check availability
+    guard let sdk = appState.sdk else {
+      await MainActor.run {
+        errorMessage = "SDK not initialized"
+        showingError = true
+        isChecking = false
+      }
+      return
+    }
+
+    do {
+      let available = try await sdk.dpnsCheckAvailability(name: normalizedUsername)
+
+      await MainActor.run {
+        isAvailable = available
+        isChecking = false
+        if !available {
+          errorMessage = "This name is already registered"
         }
-        
-        // Find a suitable authentication key with a private key available
-        // DPNS registration requires HIGH or CRITICAL security level authentication keys
-        var selectedKey: IdentityPublicKey? = nil
-        var privateKeyData: Data? = nil
-        
-        // Try to find a suitable authentication key with private key
-        for publicKey in identity.publicKeys {
-            // Check if this is an authentication key with proper security level
-            if publicKey.purpose == .authentication && 
-               (publicKey.securityLevel == .high || publicKey.securityLevel == .critical) {
-                // Try to retrieve the private key from keychain
-                if let keyData = KeychainManager.shared.retrievePrivateKey(
-                    identityId: identity.id,
-                    keyIndex: Int32(publicKey.id)
-                ) {
-                    selectedKey = publicKey
-                    privateKeyData = keyData
-                    print("✅ Found private key for authentication key #\(publicKey.id) with security level: \(publicKey.securityLevel)")
-                    break
-                }
-            }
+      }
+    } catch {
+      await MainActor.run {
+        // If we get an error, assume unavailable
+        isAvailable = false
+        isChecking = false
+        errorMessage = "Failed to check availability: \(error.localizedDescription)"
+        // Don't show error alert for automatic checks
+      }
+    }
+  }
+
+  private func registerName() {
+    guard let sdk = appState.sdk,
+          let handle = sdk.handle else {
+      errorMessage = "SDK not initialized"
+      showingError = true
+      return
+    }
+
+    isRegistering = true
+
+    Task {
+      do {
+        // Use KeyManager to find authentication key with HIGH or CRITICAL security level
+        let dppIdentity = DPPIdentity(
+          id: identity.id,
+          publicKeys: Dictionary(uniqueKeysWithValues: identity.publicKeys.map { ($0.id, $0) }),
+          balance: identity.balance,
+          revision: 0
+        )
+
+        let keyManager = await MainActor.run { KeyManager.withSharedKeychain() }
+        let keyResult = await MainActor.run {
+          keyManager.findKeyWithPrivateKey(
+            for: dppIdentity,
+            purpose: .authentication,
+            minimumSecurityLevel: .high,
+            preferCritical: true
+          )
         }
-        
-        guard let privateKey = privateKeyData,
-              let publicKey = selectedKey else {
+
+        guard let (publicKey, privateKey) = keyResult else {
+          await MainActor.run {
             errorMessage = "No HIGH or CRITICAL security authentication key with private key available. DPNS registration requires a HIGH or CRITICAL security level authentication key."
             showingError = true
-            return
+            isRegistering = false
+          }
+          return
         }
-        
-        isRegistering = true
-        
-        Task {
-            do {
-                // Create identity handle from components
-                let identityHandle = identity.id.withUnsafeBytes { idBytes in
-                    // Create public keys array
-                    var pubKeys: [DashSDKPublicKeyData] = []
-                    for key in identity.publicKeys {
-                        // Get the raw key data
-                        let keyData = key.data
-                        keyData.withUnsafeBytes { keyBytes in
-                            let keyStruct = DashSDKPublicKeyData(
-                                id: UInt8(key.id),
-                                purpose: key.purpose.rawValue,
-                                security_level: key.securityLevel.rawValue,
-                                key_type: key.keyType.rawValue,
-                                read_only: key.readOnly,
-                                data: keyBytes.baseAddress?.assumingMemoryBound(to: UInt8.self),
-                                data_len: UInt(keyBytes.count),
-                                disabled_at: key.disabledAt ?? 0
-                            )
-                            pubKeys.append(keyStruct)
-                        }
-                    }
-                    
-                    return pubKeys.withUnsafeBufferPointer { keysPtr in
-                        dash_sdk_identity_create_from_components(
-                            idBytes.baseAddress?.assumingMemoryBound(to: UInt8.self),
-                            keysPtr.baseAddress,
-                            UInt(keysPtr.count),
-                            identity.balance,
-                            0  // revision
-                        )
-                    }
-                }
-                
-                guard identityHandle.error == nil,
-                      let identityPtr = identityHandle.data else {
-                    if let error = identityHandle.error {
-                        let errorMsg = error.pointee.message != nil ? String(cString: error.pointee.message!) : "Failed to create identity"
-                        dash_sdk_error_free(error)
-                        throw SDKError.internalError(errorMsg)
-                    }
-                    throw SDKError.internalError("Failed to create identity from components")
-                }
-                
-                let identityOpaquePtr = OpaquePointer(identityPtr)
-                defer {
-                    // Clean up identity - need to find the destroy function
-                    // dash_sdk_identity_destroy(identityOpaquePtr)
-                }
-                
-                // Create public key handle
-                let publicKeyHandle = publicKey.data.withUnsafeBytes { keyBytes in
-                    dash_sdk_identity_public_key_create_from_data(
-                        UInt32(publicKey.id),
-                        publicKey.keyType.rawValue,
-                        publicKey.purpose.rawValue,
-                        publicKey.securityLevel.rawValue,
-                        keyBytes.baseAddress?.assumingMemoryBound(to: UInt8.self),
-                        UInt(keyBytes.count),
-                        publicKey.readOnly,
-                        publicKey.disabledAt ?? 0
-                    )
-                }
-                
-                guard publicKeyHandle.error == nil,
-                      let publicKeyPtr = publicKeyHandle.data else {
-                    if let error = publicKeyHandle.error {
-                        let errorMsg = error.pointee.message != nil ? String(cString: error.pointee.message!) : "Failed to create public key"
-                        dash_sdk_error_free(error)
-                        throw SDKError.internalError(errorMsg)
-                    }
-                    throw SDKError.internalError("Failed to create public key from data")
-                }
-                
-                let publicKeyTypedPtr = publicKeyPtr.assumingMemoryBound(to: IdentityPublicKeyHandle.self)
-                defer {
-                    dash_sdk_identity_public_key_destroy(publicKeyTypedPtr)
-                }
-                
-                // Create signer from private key
-                let signerResult = privateKey.withUnsafeBytes { bytes in
-                    dash_sdk_signer_create_from_private_key(
-                        bytes.baseAddress?.assumingMemoryBound(to: UInt8.self),
-                        UInt(privateKey.count)
-                    )
-                }
-                
-                guard signerResult.error == nil,
-                      let signerData = signerResult.data else {
-                    if let error = signerResult.error {
-                        let errorMsg = error.pointee.message != nil ? String(cString: error.pointee.message!) : "Failed to create signer"
-                        dash_sdk_error_free(error)
-                        throw SDKError.internalError(errorMsg)
-                    }
-                    throw SDKError.internalError("Failed to create signer")
-                }
-                
-                let signerHandle = signerData.assumingMemoryBound(to: SignerHandle.self)
-                defer {
-                    dash_sdk_signer_destroy(signerHandle)
-                }
-                
-                // Register the DPNS name
-                let result = normalizedUsername.withCString { namePtr in
-                    dash_sdk_dpns_register_name(
-                        handle,
-                        namePtr,
-                        UnsafeRawPointer(identityOpaquePtr),
-                        UnsafeRawPointer(publicKeyTypedPtr),
-                        UnsafeRawPointer(signerHandle)
-                    )
-                }
-                
-                // Handle the result
-                if let error = result.error {
-                    let errorMsg = error.pointee.message != nil ? String(cString: error.pointee.message!) : "Registration failed"
-                    dash_sdk_error_free(error)
-                    throw SDKError.internalError(errorMsg)
-                }
-                
-                guard let dataPtr = result.data else {
-                    throw SDKError.internalError("No registration result returned")
-                }
-                
-                // The result contains the registration info
-                let registrationResult = dataPtr.assumingMemoryBound(to: DpnsRegistrationResult.self)
-                defer {
-                    dash_sdk_dpns_registration_result_free(registrationResult)
-                }
-                
-                // Success! Update the identity with the new DPNS name
-                let registeredName = "\(normalizedUsername).dash"
-                
-                await MainActor.run {
-                    // Calculate contest end time based on network
-                    let currentTime = Date()
-                    let contestDuration: TimeInterval = appState.currentNetwork == .mainnet ? 
-                        (14 * 24 * 60 * 60) : // 14 days for mainnet
-                        (90 * 60) // 90 minutes for testnet
-                    let endTime = currentTime.addingTimeInterval(contestDuration)
-                    let endTimeMillis = UInt64(endTime.timeIntervalSince1970 * 1000)
-                    
-                    if isContested {
-                        // For contested names, add to contested list
-                        if let index = appState.identities.firstIndex(where: { $0.id == identity.id }) {
-                            var updatedIdentity = appState.identities[index]
-                            
-                            // Add to contested names list
-                            if !updatedIdentity.contestedDpnsNames.contains(normalizedUsername) {
-                                updatedIdentity.contestedDpnsNames.append(normalizedUsername)
-                            }
-                            
-                            // Create contest info showing user as only contender
-                            // Note: During contender registration period, there are no votes yet
-                            let contestInfo: [String: Any] = [
-                                "contenders": [[
-                                    "identifier": identity.idString,
-                                    "votes": "ResourceVote { vote_choice: TowardsIdentity, strength: 0 }"
-                                ]],
-                                "abstainVotes": 0,
-                                "lockVotes": 0,
-                                "endTime": endTimeMillis,
-                                "hasWinner": false
-                            ]
-                            updatedIdentity.contestedDpnsInfo[normalizedUsername] = contestInfo
-                            
-                            appState.identities[index] = updatedIdentity
-                            
-                            // Use the new update function to persist
-                            appState.updateIdentityDPNSNames(
-                                id: identity.id,
-                                dpnsNames: updatedIdentity.dpnsNames,
-                                contestedNames: updatedIdentity.contestedDpnsNames,
-                                contestedInfo: updatedIdentity.contestedDpnsInfo
-                            )
-                        }
-                    } else {
-                        // For regular names, add to regular list and set as primary
-                        if let index = appState.identities.firstIndex(where: { $0.id == identity.id }) {
-                            var updatedIdentity = appState.identities[index]
-                            
-                            // Add to regular names list
-                            if !updatedIdentity.dpnsNames.contains(normalizedUsername) {
-                                updatedIdentity.dpnsNames.append(normalizedUsername)
-                            }
-                            
-                            // Set as primary name if no primary exists
-                            if updatedIdentity.dpnsName == nil {
-                                updatedIdentity.dpnsName = normalizedUsername
-                            }
-                            
-                            appState.identities[index] = updatedIdentity
-                            
-                            // Use the new update function to persist
-                            appState.updateIdentityDPNSNames(
-                                id: identity.id,
-                                dpnsNames: updatedIdentity.dpnsNames,
-                                contestedNames: updatedIdentity.contestedDpnsNames,
-                                contestedInfo: updatedIdentity.contestedDpnsInfo
-                            )
-                        }
-                    }
-                    
-                    registrationSuccess = true
-                    errorMessage = isContested ? 
-                        "Successfully started contest for \(normalizedUsername)! Voting ends in \(appState.currentNetwork == .mainnet ? "14 days" : "90 minutes")." :
-                        "Successfully registered \(registeredName)!"
-                    showingError = true
-                    isRegistering = false
-                }
-                
-                // Dismiss the view after a short delay
-                try? await Task.sleep(nanoseconds: 2_000_000_000)
-                await MainActor.run {
-                    dismiss()
-                }
-                
-            } catch {
-                await MainActor.run {
-                    errorMessage = "Registration failed: \(error.localizedDescription)"
-                    showingError = true
-                    isRegistering = false
-                }
+
+        print("✅ Found private key for authentication key #\(publicKey.id) with security level: \(publicKey.securityLevel)")
+        // Create identity handle from components
+        let identityHandle = identity.id.withUnsafeBytes { idBytes in
+          // Create public keys array
+          var pubKeys: [DashSDKPublicKeyData] = []
+          for key in identity.publicKeys {
+            // Get the raw key data
+            let keyData = key.data
+            keyData.withUnsafeBytes { keyBytes in
+              let keyStruct = DashSDKPublicKeyData(
+                id: UInt8(key.id),
+                purpose: key.purpose.rawValue,
+                security_level: key.securityLevel.rawValue,
+                key_type: key.keyType.rawValue,
+                read_only: key.readOnly,
+                data: keyBytes.baseAddress?.assumingMemoryBound(to: UInt8.self),
+                data_len: UInt(keyBytes.count),
+                disabled_at: key.disabledAt ?? 0
+              )
+              pubKeys.append(keyStruct)
             }
+          }
+
+          return pubKeys.withUnsafeBufferPointer { keysPtr in
+            dash_sdk_identity_create_from_components(
+              idBytes.baseAddress?.assumingMemoryBound(to: UInt8.self),
+              keysPtr.baseAddress,
+              UInt(keysPtr.count),
+              identity.balance,
+              0  // revision
+            )
+          }
         }
+
+        guard identityHandle.error == nil,
+              let identityPtr = identityHandle.data else {
+          if let error = identityHandle.error {
+            let errorMsg = error.pointee.message != nil ? String(cString: error.pointee.message!) : "Failed to create identity"
+            dash_sdk_error_free(error)
+            throw SDKError.internalError(errorMsg)
+          }
+          throw SDKError.internalError("Failed to create identity from components")
+        }
+
+        let identityOpaquePtr = OpaquePointer(identityPtr)
+        defer {
+          // Clean up identity - need to find the destroy function
+          // dash_sdk_identity_destroy(identityOpaquePtr)
+        }
+
+        // Create public key handle
+        let publicKeyHandle = publicKey.data.withUnsafeBytes { keyBytes in
+          dash_sdk_identity_public_key_create_from_data(
+            UInt32(publicKey.id),
+            publicKey.keyType.rawValue,
+            publicKey.purpose.rawValue,
+            publicKey.securityLevel.rawValue,
+            keyBytes.baseAddress?.assumingMemoryBound(to: UInt8.self),
+            UInt(keyBytes.count),
+            publicKey.readOnly,
+            publicKey.disabledAt ?? 0
+          )
+        }
+
+        guard publicKeyHandle.error == nil,
+              let publicKeyPtr = publicKeyHandle.data else {
+          if let error = publicKeyHandle.error {
+            let errorMsg = error.pointee.message != nil ? String(cString: error.pointee.message!) : "Failed to create public key"
+            dash_sdk_error_free(error)
+            throw SDKError.internalError(errorMsg)
+          }
+          throw SDKError.internalError("Failed to create public key from data")
+        }
+
+        let publicKeyTypedPtr = publicKeyPtr.assumingMemoryBound(to: IdentityPublicKeyHandle.self)
+        defer {
+          dash_sdk_identity_public_key_destroy(publicKeyTypedPtr)
+        }
+
+        // Create signer from private key using KeyManager
+        let signer = try await MainActor.run {
+          try keyManager.createSigner(from: privateKey)
+        }
+        defer {
+          keyManager.destroySigner(signer)
+        }
+
+        let signerHandle = UnsafeMutablePointer<SignerHandle>(signer)
+
+        // Register the DPNS name
+        let result = normalizedUsername.withCString { namePtr in
+          dash_sdk_dpns_register_name(
+            handle,
+            namePtr,
+            UnsafeRawPointer(identityOpaquePtr),
+            UnsafeRawPointer(publicKeyTypedPtr),
+            UnsafeRawPointer(signerHandle)
+          )
+        }
+
+        // Handle the result
+        if let error = result.error {
+          let errorMsg = error.pointee.message != nil ? String(cString: error.pointee.message!) : "Registration failed"
+          dash_sdk_error_free(error)
+          throw SDKError.internalError(errorMsg)
+        }
+
+        guard let dataPtr = result.data else {
+          throw SDKError.internalError("No registration result returned")
+        }
+
+        // The result contains the registration info
+        let registrationResult = dataPtr.assumingMemoryBound(to: DpnsRegistrationResult.self)
+        defer {
+          dash_sdk_dpns_registration_result_free(registrationResult)
+        }
+
+        // Success! Update the identity with the new DPNS name
+        let registeredName = "\(normalizedUsername).dash"
+
+        await MainActor.run {
+          // Calculate contest end time based on network
+          let currentTime = Date()
+          let contestDuration: TimeInterval = appState.currentNetwork == .mainnet ?
+          (14 * 24 * 60 * 60) : // 14 days for mainnet
+          (90 * 60) // 90 minutes for testnet
+          let endTime = currentTime.addingTimeInterval(contestDuration)
+          let endTimeMillis = UInt64(endTime.timeIntervalSince1970 * 1000)
+
+          if isContested {
+            // For contested names, add to contested list
+            if let index = appState.identities.firstIndex(where: { $0.id == identity.id }) {
+              var updatedIdentity = appState.identities[index]
+
+              // Add to contested names list
+              if !updatedIdentity.contestedDpnsNames.contains(normalizedUsername) {
+                updatedIdentity.contestedDpnsNames.append(normalizedUsername)
+              }
+
+              // Create contest info showing user as only contender
+              // Note: During contender registration period, there are no votes yet
+              let contestInfo: [String: Any] = [
+                "contenders": [[
+                  "identifier": identity.idString,
+                  "votes": "ResourceVote { vote_choice: TowardsIdentity, strength: 0 }"
+                ]],
+                "abstainVotes": 0,
+                "lockVotes": 0,
+                "endTime": endTimeMillis,
+                "hasWinner": false
+              ]
+              updatedIdentity.contestedDpnsInfo[normalizedUsername] = contestInfo
+
+              appState.identities[index] = updatedIdentity
+
+              // Use the new update function to persist
+              appState.updateIdentityDPNSNames(
+                id: identity.id,
+                dpnsNames: updatedIdentity.dpnsNames,
+                contestedNames: updatedIdentity.contestedDpnsNames,
+                contestedInfo: updatedIdentity.contestedDpnsInfo
+              )
+            }
+          } else {
+            // For regular names, add to regular list and set as primary
+            if let index = appState.identities.firstIndex(where: { $0.id == identity.id }) {
+              var updatedIdentity = appState.identities[index]
+
+              // Add to regular names list
+              if !updatedIdentity.dpnsNames.contains(normalizedUsername) {
+                updatedIdentity.dpnsNames.append(normalizedUsername)
+              }
+
+              // Set as primary name if no primary exists
+              if updatedIdentity.dpnsName == nil {
+                updatedIdentity.dpnsName = normalizedUsername
+              }
+
+              appState.identities[index] = updatedIdentity
+
+              // Use the new update function to persist
+              appState.updateIdentityDPNSNames(
+                id: identity.id,
+                dpnsNames: updatedIdentity.dpnsNames,
+                contestedNames: updatedIdentity.contestedDpnsNames,
+                contestedInfo: updatedIdentity.contestedDpnsInfo
+              )
+            }
+          }
+
+          registrationSuccess = true
+          errorMessage = isContested ?
+          "Successfully started contest for \(normalizedUsername)! Voting ends in \(appState.currentNetwork == .mainnet ? "14 days" : "90 minutes")." :
+          "Successfully registered \(registeredName)!"
+          showingError = true
+          isRegistering = false
+        }
+
+        // Dismiss the view after a short delay
+        try? await Task.sleep(nanoseconds: 2_000_000_000)
+        await MainActor.run {
+          dismiss()
+        }
+
+      } catch {
+        await MainActor.run {
+          errorMessage = "Registration failed: \(error.localizedDescription)"
+          showingError = true
+          isRegistering = false
+        }
+      }
     }
+  }
 
 }
 
 private struct UsernameChangeHandler: ViewModifier {
-    @Binding var username: String
-    let onChange: () -> Void
-    func body(content: Content) -> some View {
-        if #available(iOS 17.0, *) {
-            content.onChange(of: username) { _, _ in onChange() }
-        } else {
-            content.onChange(of: username) { _ in onChange() }
-        }
+  @Binding var username: String
+  let onChange: () -> Void
+  func body(content: Content) -> some View {
+    if #available(iOS 17.0, *) {
+      content.onChange(of: username) { _, _ in onChange() }
+    } else {
+      content.onChange(of: username) { _ in onChange() }
     }
+  }
 }
 
 // Preview
 struct RegisterNameView_Previews: PreviewProvider {
-    static var previews: some View {
-        RegisterNameView(identity: IdentityModel(
-            id: Data(repeating: 0, count: 32),
-            balance: 1000000,
-            isLocal: false
-        ))
-        .environmentObject(AppState())
-    }
+  static var previews: some View {
+    RegisterNameView(identity: IdentityModel(
+      id: Data(repeating: 0, count: 32),
+      balance: 1000000,
+      isLocal: false
+    ))
+    .environmentObject(AppState())
+  }
 }

--- a/packages/swift-sdk/SwiftExampleApp/SwiftExampleApp/Views/TransitionDetailView.swift
+++ b/packages/swift-sdk/SwiftExampleApp/SwiftExampleApp/Views/TransitionDetailView.swift
@@ -4,2491 +4,1957 @@ import DashSDKFFI
 import SwiftData
 
 struct TransitionDetailView: View {
-    let transitionKey: String
-    let transitionLabel: String
-    
-    @EnvironmentObject var appState: UnifiedAppState
-    @State private var selectedIdentityId: String = ""
-    @State private var isExecuting = false
-    @State private var showResult = false
-    @State private var resultText = ""
-    @State private var isError = false
-    
-    // Dynamic form inputs
-    @State private var formInputs: [String: String] = [:]
-    @State private var checkboxInputs: [String: Bool] = [:]
-    @State private var selectedContractId: String = ""
-    @State private var selectedDocumentType: String = ""
-    @State private var documentFieldValues: [String: Any] = [:]
-    
-    // Query for data contracts
-    @Query private var dataContracts: [PersistentDataContract]
-    
-    var needsIdentitySelection: Bool {
-        transitionKey != "identityCreate"
+  let transitionKey: String
+  let transitionLabel: String
+
+  @EnvironmentObject var appState: UnifiedAppState
+  @State private var selectedIdentityId: String = ""
+  @State private var isExecuting = false
+  @State private var showResult = false
+  @State private var resultText = ""
+  @State private var isError = false
+
+  // Dynamic form inputs
+  @State private var formInputs: [String: String] = [:]
+  @State private var checkboxInputs: [String: Bool] = [:]
+  @State private var selectedContractId: String = ""
+  @State private var selectedDocumentType: String = ""
+  @State private var documentFieldValues: [String: Any] = [:]
+
+  // Query for data contracts
+  @Query private var dataContracts: [PersistentDataContract]
+
+  var needsIdentitySelection: Bool {
+    transitionKey != "identityCreate"
+  }
+
+  // Computed property that properly observes state changes
+  var isButtonEnabled: Bool {
+    if transitionKey == "documentPurchase" {
+      // For document purchase, enable if all fields are filled AND canPurchaseDocument is true
+      let hasContractId = !formInputs["contractId", default: ""].isEmpty
+      let hasDocumentType = !formInputs["documentType", default: ""].isEmpty
+      let hasDocumentId = !formInputs["documentId", default: ""].isEmpty
+      let canPurchase = appState.transitionState.canPurchaseDocument
+
+      print("DEBUG: Button enabled check - contract: \(hasContractId), type: \(hasDocumentType), id: \(hasDocumentId), canPurchase: \(canPurchase), executing: \(isExecuting)")
+
+      // Enable if all fields are filled and document can be purchased
+      return hasContractId && hasDocumentType && hasDocumentId && canPurchase && !isExecuting
+    } else {
+      return isFormValid() && !isExecuting
     }
-    
-    // Computed property that properly observes state changes
-    var isButtonEnabled: Bool {
-        if transitionKey == "documentPurchase" {
-            // For document purchase, enable if all fields are filled AND canPurchaseDocument is true
-            let hasContractId = !formInputs["contractId", default: ""].isEmpty
-            let hasDocumentType = !formInputs["documentType", default: ""].isEmpty
-            let hasDocumentId = !formInputs["documentId", default: ""].isEmpty
-            let canPurchase = appState.transitionState.canPurchaseDocument
-            
-            print("DEBUG: Button enabled check - contract: \(hasContractId), type: \(hasDocumentType), id: \(hasDocumentId), canPurchase: \(canPurchase), executing: \(isExecuting)")
-            
-            // Enable if all fields are filled and document can be purchased
-            return hasContractId && hasDocumentType && hasDocumentId && canPurchase && !isExecuting
-        } else {
-            return isFormValid() && !isExecuting
+  }
+
+  var body: some View {
+    ScrollView {
+      VStack(alignment: .leading, spacing: 20) {
+        // Description
+        if let transition = getTransitionDefinition(transitionKey) {
+          Text(transition.description)
+            .font(.subheadline)
+            .foregroundColor(.secondary)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(.horizontal)
+            .padding(.top)
         }
-    }
-    
-    var body: some View {
-        ScrollView {
-            VStack(alignment: .leading, spacing: 20) {
-                // Description
-                if let transition = getTransitionDefinition(transitionKey) {
-                    Text(transition.description)
-                        .font(.subheadline)
-                        .foregroundColor(.secondary)
-                        .frame(maxWidth: .infinity, alignment: .leading)
-                        .padding(.horizontal)
-                        .padding(.top)
-                }
-                
-                // Identity Selector (for all transitions except Identity Create)
-                if needsIdentitySelection {
-                    identitySelector
-                        .padding(.horizontal)
-                }
-                
-                // Dynamic Form Inputs
-                if let transition = getTransitionDefinition(transitionKey) {
-                    VStack(alignment: .leading, spacing: 16) {
-                        ForEach(transition.inputs, id: \.name) { input in
-                            // Special handling for document fields
-                            if input.name == "documentFields" && input.type == "json" {
-                                documentFieldsInput(for: input)
-                            } else {
-                                TransitionInputView(
-                                    input: enrichedInput(for: input),
-                                    value: binding(for: input),
-                                    checkboxValue: checkboxBinding(for: input),
-                                    onSpecialAction: handleSpecialAction
-                                )
-                                .environmentObject(appState)
-                            }
-                        }
-                    }
-                    .padding(.horizontal)
-                }
-                
-                // Execute Button
-                if !needsIdentitySelection || !selectedIdentityId.isEmpty {
-                    executeButton
-                        .padding(.horizontal)
-                        .padding(.top)
-                }
-                
-                // Result Display
-                if showResult {
-                    resultView
-                        .padding(.horizontal)
-                }
-                
-                Spacer(minLength: 20)
+
+        // Identity Selector (for all transitions except Identity Create)
+        if needsIdentitySelection {
+          identitySelector
+            .padding(.horizontal)
+        }
+
+        // Dynamic Form Inputs
+        if let transition = getTransitionDefinition(transitionKey) {
+          VStack(alignment: .leading, spacing: 16) {
+            ForEach(transition.inputs, id: \.name) { input in
+              // Special handling for document fields
+              if input.name == "documentFields" && input.type == "json" {
+                documentFieldsInput(for: input)
+              } else {
+                TransitionInputView(
+                  input: enrichedInput(for: input),
+                  value: binding(for: input),
+                  checkboxValue: checkboxBinding(for: input),
+                  onSpecialAction: handleSpecialAction
+                )
+                .environmentObject(appState)
+              }
             }
+          }
+          .padding(.horizontal)
         }
-        .navigationTitle(transitionLabel)
-        .navigationBarTitleDisplayMode(.inline)
-        .onAppear {
-            clearForm()
+
+        // Execute Button
+        if !needsIdentitySelection || !selectedIdentityId.isEmpty {
+          executeButton
+            .padding(.horizontal)
+            .padding(.top)
         }
+
+        // Result Display
+        if showResult {
+          resultView
+            .padding(.horizontal)
+        }
+
+        Spacer(minLength: 20)
+      }
     }
-    
-    private var identitySelector: some View {
-        VStack(alignment: .leading, spacing: 12) {
-            Text("Select Identity")
-                .font(.headline)
-            
-            if appState.platformState.identities.isEmpty {
-                Text("No identities available. Create one first.")
-                    .font(.caption)
-                    .foregroundColor(.secondary)
-                    .padding()
-                    .frame(maxWidth: .infinity, alignment: .leading)
-                    .background(Color.orange.opacity(0.1))
-                    .cornerRadius(8)
-            } else {
-                Picker("Identity", selection: $selectedIdentityId) {
-                    ForEach(appState.platformState.identities, id: \.idString) { identity in
-                        Text(identity.displayName)
-                            .tag(identity.idString)
-                    }
-                }
-                .pickerStyle(MenuPickerStyle())
-                .padding()
-                .frame(maxWidth: .infinity, alignment: .leading)
-                .background(Color.gray.opacity(0.1))
-                .cornerRadius(8)
-            }
-        }
+    .navigationTitle(transitionLabel)
+    .navigationBarTitleDisplayMode(.inline)
+    .onAppear {
+      clearForm()
     }
-    
-    @ViewBuilder
-    private var executeButton: some View {
-        // Explicitly read the state to ensure SwiftUI tracks the dependency
-        let canPurchase = transitionKey == "documentPurchase" ? appState.transitionState.canPurchaseDocument : true
-        let enabled = isButtonEnabled
-        let _ = print("DEBUG: executeButton render - isButtonEnabled: \(enabled), canPurchase: \(canPurchase), background: \(enabled ? "blue" : "gray")")
-        
-        Button(action: executeTransition) {
-            if isExecuting {
-                ProgressView()
-                    .progressViewStyle(CircularProgressViewStyle(tint: .white))
-                    .scaleEffect(0.8)
-            } else {
-                Text("Execute Transition")
-                    .fontWeight(.semibold)
-            }
+  }
+
+  private var identitySelector: some View {
+    VStack(alignment: .leading, spacing: 12) {
+      Text("Select Identity")
+        .font(.headline)
+
+      if appState.platformState.identities.isEmpty {
+        Text("No identities available. Create one first.")
+          .font(.caption)
+          .foregroundColor(.secondary)
+          .padding()
+          .frame(maxWidth: .infinity, alignment: .leading)
+          .background(Color.orange.opacity(0.1))
+          .cornerRadius(8)
+      } else {
+        Picker("Identity", selection: $selectedIdentityId) {
+          ForEach(appState.platformState.identities, id: \.idString) { identity in
+            Text(identity.displayName)
+              .tag(identity.idString)
+          }
         }
-        .frame(maxWidth: .infinity)
+        .pickerStyle(MenuPickerStyle())
         .padding()
-        .background(enabled ? Color.blue : Color.gray)
-        .foregroundColor(.white)
-        .cornerRadius(10)
-        .disabled(!enabled)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(Color.gray.opacity(0.1))
+        .cornerRadius(8)
+      }
     }
-    
-    private var resultView: some View {
-        VStack(alignment: .leading, spacing: 12) {
-            HStack {
-                Image(systemName: isError ? "xmark.circle.fill" : "checkmark.circle.fill")
-                    .foregroundColor(isError ? .red : .green)
-                Text(isError ? "Error" : "Success")
-                    .font(.headline)
-                Spacer()
-                Button("Copy") {
-                    UIPasteboard.general.string = resultText
+  }
+
+  @ViewBuilder
+  private var executeButton: some View {
+    // Explicitly read the state to ensure SwiftUI tracks the dependency
+    let canPurchase = transitionKey == "documentPurchase" ? appState.transitionState.canPurchaseDocument : true
+    let enabled = isButtonEnabled
+    let _ = print("DEBUG: executeButton render - isButtonEnabled: \(enabled), canPurchase: \(canPurchase), background: \(enabled ? "blue" : "gray")")
+
+    Button(action: executeTransition) {
+      if isExecuting {
+        ProgressView()
+          .progressViewStyle(CircularProgressViewStyle(tint: .white))
+          .scaleEffect(0.8)
+      } else {
+        Text("Execute Transition")
+          .fontWeight(.semibold)
+      }
+    }
+    .frame(maxWidth: .infinity)
+    .padding()
+    .background(enabled ? Color.blue : Color.gray)
+    .foregroundColor(.white)
+    .cornerRadius(10)
+    .disabled(!enabled)
+  }
+
+  private var resultView: some View {
+    VStack(alignment: .leading, spacing: 12) {
+      HStack {
+        Image(systemName: isError ? "xmark.circle.fill" : "checkmark.circle.fill")
+          .foregroundColor(isError ? .red : .green)
+        Text(isError ? "Error" : "Success")
+          .font(.headline)
+        Spacer()
+        Button("Copy") {
+          UIPasteboard.general.string = resultText
+        }
+        .font(.caption)
+        .padding(.trailing, 8)
+        Button("Dismiss") {
+          showResult = false
+          resultText = ""
+        }
+        .font(.caption)
+      }
+
+      ScrollView {
+        Text(resultText)
+          .font(.system(.caption, design: .monospaced))
+          .frame(maxWidth: .infinity, alignment: .leading)
+      }
+      .frame(maxHeight: 200)
+      .padding(8)
+      .background(Color.gray.opacity(0.1))
+      .cornerRadius(8)
+    }
+    .padding()
+    .background(isError ? Color.red.opacity(0.1) : Color.green.opacity(0.1))
+    .cornerRadius(10)
+  }
+
+  // MARK: - Document Fields Input
+
+  @ViewBuilder
+  private func documentFieldsInput(for input: TransitionInput) -> some View {
+    VStack(alignment: .leading, spacing: 8) {
+      HStack {
+        Text(input.label)
+          .font(.subheadline)
+          .fontWeight(.medium)
+        if input.required {
+          Text("*")
+            .foregroundColor(.red)
+        }
+      }
+
+      let contractId = formInputs["contractId"] ?? selectedContractId
+      let documentTypeName = formInputs["documentType"] ?? selectedDocumentType
+
+      if contractId.isEmpty || documentTypeName.isEmpty {
+        Text("Please select a contract and document type first")
+          .font(.caption)
+          .foregroundColor(.secondary)
+          .padding()
+          .frame(maxWidth: .infinity, alignment: .leading)
+          .background(Color.orange.opacity(0.1))
+          .cornerRadius(8)
+      } else if let contract = dataContracts.first(where: { $0.idBase58 == contractId }),
+                let documentTypes = contract.documentTypes {
+        if let documentType = documentTypes.first(where: { $0.name == documentTypeName }) {
+          DocumentFieldsView(
+            documentType: documentType,
+            fieldValues: Binding(
+              get: { documentFieldValues },
+              set: { newValues in
+                documentFieldValues = newValues
+                // Convert to JSON string for the form
+                if let jsonData = try? JSONSerialization.data(withJSONObject: newValues, options: [.prettyPrinted]),
+                   let jsonString = String(data: jsonData, encoding: .utf8) {
+                  formInputs["documentFields"] = jsonString
                 }
-                .font(.caption)
-                .padding(.trailing, 8)
-                Button("Dismiss") {
-                    showResult = false
-                    resultText = ""
-                }
-                .font(.caption)
-            }
-            
-            ScrollView {
-                Text(resultText)
-                    .font(.system(.caption, design: .monospaced))
-                    .frame(maxWidth: .infinity, alignment: .leading)
-            }
-            .frame(maxHeight: 200)
-            .padding(8)
-            .background(Color.gray.opacity(0.1))
+              }
+            )
+          )
+        } else {
+          Text("Document type '\(documentTypeName)' not found in contract")
+            .font(.caption)
+            .foregroundColor(.secondary)
+            .padding()
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .background(Color.orange.opacity(0.1))
             .cornerRadius(8)
         }
-        .padding()
-        .background(isError ? Color.red.opacity(0.1) : Color.green.opacity(0.1))
-        .cornerRadius(10)
+      } else {
+        Text("Invalid contract or document type selected")
+          .font(.caption)
+          .foregroundColor(.secondary)
+          .padding()
+          .frame(maxWidth: .infinity, alignment: .leading)
+          .background(Color.red.opacity(0.1))
+          .cornerRadius(8)
+      }
+
+      if let help = input.help {
+        Text(help)
+          .font(.caption2)
+          .foregroundColor(.secondary)
+      }
     }
-    
-    // MARK: - Document Fields Input
-    
-    @ViewBuilder
-    private func documentFieldsInput(for input: TransitionInput) -> some View {
-        VStack(alignment: .leading, spacing: 8) {
-            HStack {
-                Text(input.label)
-                    .font(.subheadline)
-                    .fontWeight(.medium)
-                if input.required {
-                    Text("*")
-                        .foregroundColor(.red)
-                }
-            }
-            
-            let contractId = formInputs["contractId"] ?? selectedContractId
-            let documentTypeName = formInputs["documentType"] ?? selectedDocumentType
-            
-            if contractId.isEmpty || documentTypeName.isEmpty {
-                Text("Please select a contract and document type first")
-                    .font(.caption)
-                    .foregroundColor(.secondary)
-                    .padding()
-                    .frame(maxWidth: .infinity, alignment: .leading)
-                    .background(Color.orange.opacity(0.1))
-                    .cornerRadius(8)
-            } else if let contract = dataContracts.first(where: { $0.idBase58 == contractId }),
-                      let documentTypes = contract.documentTypes {
-                if let documentType = documentTypes.first(where: { $0.name == documentTypeName }) {
-                    DocumentFieldsView(
-                        documentType: documentType,
-                        fieldValues: Binding(
-                            get: { documentFieldValues },
-                            set: { newValues in
-                                documentFieldValues = newValues
-                                // Convert to JSON string for the form
-                                if let jsonData = try? JSONSerialization.data(withJSONObject: newValues, options: [.prettyPrinted]),
-                                   let jsonString = String(data: jsonData, encoding: .utf8) {
-                                    formInputs["documentFields"] = jsonString
-                                }
-                            }
-                        )
-                    )
-                } else {
-                    Text("Document type '\(documentTypeName)' not found in contract")
-                        .font(.caption)
-                        .foregroundColor(.secondary)
-                        .padding()
-                        .frame(maxWidth: .infinity, alignment: .leading)
-                        .background(Color.orange.opacity(0.1))
-                        .cornerRadius(8)
-                }
-            } else {
-                Text("Invalid contract or document type selected")
-                    .font(.caption)
-                    .foregroundColor(.secondary)
-                    .padding()
-                    .frame(maxWidth: .infinity, alignment: .leading)
-                    .background(Color.red.opacity(0.1))
-                    .cornerRadius(8)
-            }
-            
-            if let help = input.help {
-                Text(help)
-                    .font(.caption2)
-                    .foregroundColor(.secondary)
-            }
+  }
+
+  // MARK: - Helper Methods
+
+  private func binding(for input: TransitionInput) -> Binding<String> {
+    Binding(
+      get: { formInputs[input.name] ?? input.defaultValue ?? "" },
+      set: { formInputs[input.name] = $0 }
+    )
+  }
+
+  private func checkboxBinding(for input: TransitionInput) -> Binding<Bool> {
+    Binding(
+      get: { checkboxInputs[input.name] ?? false },
+      set: { checkboxInputs[input.name] = $0 }
+    )
+  }
+
+  private func clearForm() {
+    formInputs.removeAll()
+    checkboxInputs.removeAll()
+
+    // Reset transition state
+    appState.transitionState.reset()
+
+    // Set default values
+    if let transition = getTransitionDefinition(transitionKey) {
+      for input in transition.inputs {
+        if let defaultValue = input.defaultValue {
+          formInputs[input.name] = defaultValue
         }
+      }
     }
-    
-    // MARK: - Helper Methods
-    
-    private func binding(for input: TransitionInput) -> Binding<String> {
-        Binding(
-            get: { formInputs[input.name] ?? input.defaultValue ?? "" },
-            set: { formInputs[input.name] = $0 }
-        )
+
+    // Set the first identity as default if we need identity selection
+    if needsIdentitySelection && !appState.platformState.identities.isEmpty {
+      selectedIdentityId = appState.platformState.identities.first?.idString ?? ""
     }
-    
-    private func checkboxBinding(for input: TransitionInput) -> Binding<Bool> {
-        Binding(
-            get: { checkboxInputs[input.name] ?? false },
-            set: { checkboxInputs[input.name] = $0 }
-        )
-    }
-    
-    private func clearForm() {
-        formInputs.removeAll()
-        checkboxInputs.removeAll()
-        
-        // Reset transition state
-        appState.transitionState.reset()
-        
-        // Set default values
-        if let transition = getTransitionDefinition(transitionKey) {
-            for input in transition.inputs {
-                if let defaultValue = input.defaultValue {
-                    formInputs[input.name] = defaultValue
-                }
+
+    showResult = false
+    resultText = ""
+    isError = false
+  }
+
+  private func isFormValid() -> Bool {
+    guard let transition = getTransitionDefinition(transitionKey) else { return false }
+
+    // Special validation for document purchase
+    if transitionKey == "documentPurchase" {
+      // Debug: Show all form inputs
+      print("DEBUG: Current formInputs: \(formInputs)")
+      print("DEBUG: selectedContractId: \(selectedContractId)")
+      print("DEBUG: selectedDocumentType: \(selectedDocumentType)")
+
+      // Check if all required fields are filled
+      for input in transition.inputs {
+        if input.required {
+          var value = formInputs[input.name] ?? ""
+
+          // Special handling for contract and document type - check both formInputs and selected* variables
+          if input.name == "contractId" && value.isEmpty {
+            value = selectedContractId
+            if !value.isEmpty {
+              formInputs["contractId"] = value  // Update formInputs
             }
-        }
-        
-        // Set the first identity as default if we need identity selection
-        if needsIdentitySelection && !appState.platformState.identities.isEmpty {
-            selectedIdentityId = appState.platformState.identities.first?.idString ?? ""
-        }
-        
-        showResult = false
-        resultText = ""
-        isError = false
-    }
-    
-    private func isFormValid() -> Bool {
-        guard let transition = getTransitionDefinition(transitionKey) else { return false }
-        
-        // Special validation for document purchase
-        if transitionKey == "documentPurchase" {
-            // Debug: Show all form inputs
-            print("DEBUG: Current formInputs: \(formInputs)")
-            print("DEBUG: selectedContractId: \(selectedContractId)")
-            print("DEBUG: selectedDocumentType: \(selectedDocumentType)")
-            
-            // Check if all required fields are filled
-            for input in transition.inputs {
-                if input.required {
-                    var value = formInputs[input.name] ?? ""
-                    
-                    // Special handling for contract and document type - check both formInputs and selected* variables
-                    if input.name == "contractId" && value.isEmpty {
-                        value = selectedContractId
-                        if !value.isEmpty {
-                            formInputs["contractId"] = value  // Update formInputs
-                        }
-                    }
-                    if input.name == "documentType" && value.isEmpty {
-                        value = selectedDocumentType
-                        if !value.isEmpty {
-                            formInputs["documentType"] = value  // Update formInputs
-                        }
-                    }
-                    
-                    if value.isEmpty {
-                        print("DEBUG: Form invalid - missing required field: \(input.name), value: '\(value)'")
-                        return false
-                    }
-                }
+          }
+          if input.name == "documentType" && value.isEmpty {
+            value = selectedDocumentType
+            if !value.isEmpty {
+              formInputs["documentType"] = value  // Update formInputs
             }
-            // Also check if the document can be purchased
-            // Force re-evaluation of the published property
-            let canPurchase = appState.transitionState.canPurchaseDocument
-            print("DEBUG: Document purchase form validation - canPurchase: \(canPurchase), price: \(String(describing: appState.transitionState.documentPrice))")
-            return canPurchase
+          }
+
+          if value.isEmpty {
+            print("DEBUG: Form invalid - missing required field: \(input.name), value: '\(value)'")
+            return false
+          }
         }
-        
-        // Standard validation for other transitions
-        for input in transition.inputs {
-            if input.required {
-                if input.type == "checkbox" {
-                    // Checkboxes are always valid
-                    continue
-                } else {
-                    let value = formInputs[input.name] ?? ""
-                    if value.isEmpty {
-                        return false
-                    }
-                }
-            }
-        }
-        
-        return true
+      }
+      // Also check if the document can be purchased
+      // Force re-evaluation of the published property
+      let canPurchase = appState.transitionState.canPurchaseDocument
+      print("DEBUG: Document purchase form validation - canPurchase: \(canPurchase), price: \(String(describing: appState.transitionState.documentPrice))")
+      return canPurchase
     }
-    
-    private func handleSpecialAction(_ action: String) {
-        if action.starts(with: "contractSelected:") {
-            let contractId = String(action.dropFirst("contractSelected:".count))
-            selectedContractId = contractId
-            formInputs["contractId"] = contractId
-            // Clear document type when contract changes
-            selectedDocumentType = ""
-            formInputs["documentType"] = ""
-        } else if action.starts(with: "documentTypeSelected:") {
-            let docType = String(action.dropFirst("documentTypeSelected:".count))
-            selectedDocumentType = docType
-            formInputs["documentType"] = docType
-            // Fetch schema for the selected document type
-            fetchDocumentSchema(contractId: selectedContractId, documentType: docType)
+
+    // Standard validation for other transitions
+    for input in transition.inputs {
+      if input.required {
+        if input.type == "checkbox" {
+          // Checkboxes are always valid
+          continue
         } else {
-            switch action {
-            case "generateTestSeed":
-                // Generate a test seed phrase
-                formInputs["seedPhrase"] = generateTestSeedPhrase()
-            case "fetchDocumentSchema":
-                if !selectedContractId.isEmpty && !selectedDocumentType.isEmpty {
-                    fetchDocumentSchema(contractId: selectedContractId, documentType: selectedDocumentType)
-                }
-            case "loadExistingDocument":
-                // TODO: Load existing document
-                break
-            case "fetchContestedResources":
-                // TODO: Fetch contested resources
-                break
-            default:
-                break
-            }
+          let value = formInputs[input.name] ?? ""
+          if value.isEmpty {
+            return false
+          }
         }
+      }
     }
-    
-    private func generateTestSeedPhrase() -> String {
-        // This is a placeholder - in production, use proper BIP39 generation
-        return "test seed phrase for development only do not use in production ever please"
+
+    return true
+  }
+
+  private func handleSpecialAction(_ action: String) {
+    if action.starts(with: "contractSelected:") {
+      let contractId = String(action.dropFirst("contractSelected:".count))
+      selectedContractId = contractId
+      formInputs["contractId"] = contractId
+      // Clear document type when contract changes
+      selectedDocumentType = ""
+      formInputs["documentType"] = ""
+    } else if action.starts(with: "documentTypeSelected:") {
+      let docType = String(action.dropFirst("documentTypeSelected:".count))
+      selectedDocumentType = docType
+      formInputs["documentType"] = docType
+      // Fetch schema for the selected document type
+      fetchDocumentSchema(contractId: selectedContractId, documentType: docType)
+    } else {
+      switch action {
+      case "generateTestSeed":
+        // Generate a test seed phrase
+        formInputs["seedPhrase"] = generateTestSeedPhrase()
+      case "fetchDocumentSchema":
+        if !selectedContractId.isEmpty && !selectedDocumentType.isEmpty {
+          fetchDocumentSchema(contractId: selectedContractId, documentType: selectedDocumentType)
+        }
+      case "loadExistingDocument":
+        // TODO: Load existing document
+        break
+      case "fetchContestedResources":
+        // TODO: Fetch contested resources
+        break
+      default:
+        break
+      }
     }
-    
-    private func getTransitionDefinition(_ key: String) -> TransitionDefinition? {
-        return TransitionDefinitions.all[key]
+  }
+
+  private func generateTestSeedPhrase() -> String {
+    // This is a placeholder - in production, use proper BIP39 generation
+    return "test seed phrase for development only do not use in production ever please"
+  }
+
+  private func getTransitionDefinition(_ key: String) -> TransitionDefinition? {
+    return TransitionDefinitions.all[key]
+  }
+
+  // MARK: - Transition Execution
+
+  private func executeTransition() {
+    Task {
+      await performTransition()
     }
-    
-    // MARK: - Transition Execution
-    
-    private func executeTransition() {
-        Task {
-            await performTransition()
-        }
+  }
+
+  @MainActor
+  private func performTransition() async {
+    isExecuting = true
+    defer { isExecuting = false }
+
+    do {
+      let result = try await executeStateTransition()
+
+      // Format the result as JSON
+      let data = try JSONSerialization.data(withJSONObject: result, options: .prettyPrinted)
+      resultText = String(data: data, encoding: .utf8) ?? "Success"
+      isError = false
+      showResult = true
+    } catch {
+      resultText = error.localizedDescription
+      isError = true
+      showResult = true
     }
-    
-    @MainActor
-    private func performTransition() async {
-        isExecuting = true
-        defer { isExecuting = false }
-        
-        do {
-            let result = try await executeStateTransition()
-            
-            // Format the result as JSON
-            let data = try JSONSerialization.data(withJSONObject: result, options: .prettyPrinted)
-            resultText = String(data: data, encoding: .utf8) ?? "Success"
-            isError = false
-            showResult = true
-        } catch {
-            resultText = error.localizedDescription
-            isError = true
-            showResult = true
-        }
+  }
+
+  private func executeStateTransition() async throws -> Any {
+    guard let sdk = appState.sdk else {
+      throw SDKError.invalidState("SDK not initialized")
     }
-    
-    private func executeStateTransition() async throws -> Any {
-        guard let sdk = appState.sdk else {
-            throw SDKError.invalidState("SDK not initialized")
-        }
-        
-        switch transitionKey {
-        case "identityCreate":
-            return try await executeIdentityCreate(sdk: sdk)
-            
-        case "identityTopUp":
-            return try await executeIdentityTopUp(sdk: sdk)
-            
-        case "identityCreditTransfer":
-            return try await executeIdentityCreditTransfer(sdk: sdk)
-            
-        case "identityCreditWithdrawal":
-            return try await executeIdentityCreditWithdrawal(sdk: sdk)
-            
-        case "documentCreate":
-            return try await executeDocumentCreate(sdk: sdk)
-            
-        case "documentReplace":
-            return try await executeDocumentReplace(sdk: sdk)
-            
-        case "documentDelete":
-            return try await executeDocumentDelete(sdk: sdk)
-            
-        case "documentTransfer":
-            return try await executeDocumentTransfer(sdk: sdk)
-            
-        case "documentUpdatePrice":
-            return try await executeDocumentUpdatePrice(sdk: sdk)
-            
-        case "documentPurchase":
-            return try await executeDocumentPurchase(sdk: sdk)
-            
-        case "tokenMint":
-            return try await executeTokenMint(sdk: sdk)
-            
-        case "tokenBurn":
-            return try await executeTokenBurn(sdk: sdk)
-            
-        case "tokenFreeze":
-            return try await executeTokenFreeze(sdk: sdk)
-            
-        case "tokenUnfreeze":
-            return try await executeTokenUnfreeze(sdk: sdk)
-            
-        case "tokenDestroyFrozenFunds":
-            return try await executeTokenDestroyFrozenFunds(sdk: sdk)
-            
-        case "tokenClaim":
-            return try await executeTokenClaim(sdk: sdk)
-            
-        case "tokenTransfer":
-            return try await executeTokenTransfer(sdk: sdk)
-            
-        case "tokenSetPrice":
-            return try await executeTokenSetPrice(sdk: sdk)
-            
-        case "dataContractCreate":
-            return try await executeDataContractCreate(sdk: sdk)
-            
-        case "dataContractUpdate":
-            return try await executeDataContractUpdate(sdk: sdk)
-            
-        default:
-            throw SDKError.notImplemented("State transition '\(transitionKey)' not yet implemented")
-        }
+
+    switch transitionKey {
+    case "identityCreate":
+      return try await executeIdentityCreate(sdk: sdk)
+
+    case "identityTopUp":
+      return try await executeIdentityTopUp(sdk: sdk)
+
+    case "identityCreditTransfer":
+      return try await executeIdentityCreditTransfer(sdk: sdk)
+
+    case "identityCreditWithdrawal":
+      return try await executeIdentityCreditWithdrawal(sdk: sdk)
+
+    case "documentCreate":
+      return try await executeDocumentCreate(sdk: sdk)
+
+    case "documentReplace":
+      return try await executeDocumentReplace(sdk: sdk)
+
+    case "documentDelete":
+      return try await executeDocumentDelete(sdk: sdk)
+
+    case "documentTransfer":
+      return try await executeDocumentTransfer(sdk: sdk)
+
+    case "documentUpdatePrice":
+      return try await executeDocumentUpdatePrice(sdk: sdk)
+
+    case "documentPurchase":
+      return try await executeDocumentPurchase(sdk: sdk)
+
+    case "tokenMint":
+      return try await executeTokenMint(sdk: sdk)
+
+    case "tokenBurn":
+      return try await executeTokenBurn(sdk: sdk)
+
+    case "tokenFreeze":
+      return try await executeTokenFreeze(sdk: sdk)
+
+    case "tokenUnfreeze":
+      return try await executeTokenUnfreeze(sdk: sdk)
+
+    case "tokenDestroyFrozenFunds":
+      return try await executeTokenDestroyFrozenFunds(sdk: sdk)
+
+    case "tokenClaim":
+      return try await executeTokenClaim(sdk: sdk)
+
+    case "tokenTransfer":
+      return try await executeTokenTransfer(sdk: sdk)
+
+    case "tokenSetPrice":
+      return try await executeTokenSetPrice(sdk: sdk)
+
+    case "dataContractCreate":
+      return try await executeDataContractCreate(sdk: sdk)
+
+    case "dataContractUpdate":
+      return try await executeDataContractUpdate(sdk: sdk)
+
+    default:
+      throw SDKError.notImplemented("State transition '\(transitionKey)' not yet implemented")
     }
-    
-    // MARK: - Individual State Transition Implementations
-    
-    private func executeIdentityCreate(sdk: SDK) async throws -> Any {
-        let identityData = try await sdk.identityCreate()
-        
-        // Extract identity ID from the response
-        guard let idString = identityData["id"] as? String,
-              let idData = Data(hexString: idString), idData.count == 32 else {
-            throw SDKError.invalidParameter("Invalid identity ID in response")
-        }
-        
-        // Extract balance
-        var balance: UInt64 = 0
-        if let balanceValue = identityData["balance"] {
-            if let balanceNum = balanceValue as? NSNumber {
-                balance = balanceNum.uint64Value
-            } else if let balanceString = balanceValue as? String,
-                      let balanceUInt = UInt64(balanceString) {
-                balance = balanceUInt
-            }
-        }
-        
-        // Add the new identity to our list
-        let identityModel = IdentityModel(
-            id: idData,
-            balance: balance,
-            isLocal: false,
-            alias: formInputs["alias"],
-            dpnsName: nil
-        )
-        
-        await MainActor.run {
-            appState.platformState.addIdentity(identityModel)
-        }
-        
-        return [
-            "identityId": idString,
-            "balance": balance,
-            "message": "Identity created successfully"
-        ]
+  }
+
+  // MARK: - Individual State Transition Implementations
+
+  private func executeIdentityCreate(sdk: SDK) async throws -> Any {
+    let identityData = try await sdk.identityCreate()
+
+    // Extract identity ID from the response
+    guard let idString = identityData["id"] as? String,
+          let idData = Data(hexString: idString), idData.count == 32 else {
+      throw SDKError.invalidParameter("Invalid identity ID in response")
     }
-    
-    private func executeIdentityTopUp(sdk: SDK) async throws -> Any {
-        guard !selectedIdentityId.isEmpty,
-              appState.platformState.identities.contains(where: { $0.idString == selectedIdentityId }) else {
-            throw SDKError.invalidParameter("No identity selected")
-        }
-        
-        throw SDKError.notImplemented("Identity top-up requires proper Identity handle conversion")
+
+    // Extract balance
+    var balance: UInt64 = 0
+    if let balanceValue = identityData["balance"] {
+      if let balanceNum = balanceValue as? NSNumber {
+        balance = balanceNum.uint64Value
+      } else if let balanceString = balanceValue as? String,
+                let balanceUInt = UInt64(balanceString) {
+        balance = balanceUInt
+      }
     }
-    
-    private func executeIdentityCreditTransfer(sdk: SDK) async throws -> Any {
-        guard !selectedIdentityId.isEmpty,
-              let fromIdentity = appState.platformState.identities.first(where: { $0.idString == selectedIdentityId }) else {
-            throw SDKError.invalidParameter("No identity selected")
-        }
-        
-        guard let toIdentityId = formInputs["toIdentityId"], !toIdentityId.isEmpty else {
-            throw SDKError.invalidParameter("Recipient identity ID is required")
-        }
-        
-        guard let amountString = formInputs["amount"],
-              let amount = UInt64(amountString) else {
-            throw SDKError.invalidParameter("Invalid amount")
-        }
-        
-        // Normalize the recipient identity ID to base58
-        let normalizedToIdentityId = normalizeIdentityId(toIdentityId)
-        
-        // Find the transfer key from the identity's public keys
-        let transferKey = fromIdentity.publicKeys.first { key in
-            key.purpose == .transfer
-        }
-        
-        guard let transferKey = transferKey else {
-            throw SDKError.invalidParameter("No transfer key found for this identity")
-        }
-        
-        // Get the actual private key from keychain
-        guard let privateKeyData = KeychainManager.shared.retrievePrivateKey(
-            identityId: fromIdentity.id,
-            keyIndex: Int32(transferKey.id)
-        ) else {
-            throw SDKError.invalidParameter("Private key not found for transfer key #\(transferKey.id). Please add the private key first.")
-        }
-        
-        print("🔑 Using private key for key #\(transferKey.id): \(privateKeyData.toHexString())")
-        
-        let signerResult = privateKeyData.withUnsafeBytes { keyBytes in
-            dash_sdk_signer_create_from_private_key(
-                keyBytes.bindMemory(to: UInt8.self).baseAddress!,
-                UInt(privateKeyData.count)
-            )
-        }
-        
-        guard signerResult.error == nil,
-              let signer = signerResult.data else {
-            throw SDKError.internalError("Failed to create signer")
-        }
-        
-        defer {
-            dash_sdk_signer_destroy(signer.assumingMemoryBound(to: SignerHandle.self))
-        }
-        
-        // Use the convenience method with DPPIdentity
-        let dppIdentity = DPPIdentity(
-            id: fromIdentity.id,
-            publicKeys: Dictionary(uniqueKeysWithValues: fromIdentity.publicKeys.map { ($0.id, $0) }),
-            balance: fromIdentity.balance,
-            revision: 0
-        )
-        
-        let (senderBalance, receiverBalance) = try await sdk.transferCredits(
-            from: dppIdentity,
-            toIdentityId: normalizedToIdentityId,
-            amount: amount,
-            signer: OpaquePointer(signer)
-        )
-        
-        // Update sender's balance in our local state
-        await MainActor.run {
-            appState.platformState.updateIdentityBalance(id: fromIdentity.id, newBalance: senderBalance)
-        }
-        
-        return [
-            "senderIdentityId": fromIdentity.idString,
-            "senderBalance": senderBalance,
-            "receiverIdentityId": normalizedToIdentityId,
-            "receiverBalance": receiverBalance,
-            "transferAmount": amount,
-            "message": "Credits transferred successfully"
-        ]
+
+    // Add the new identity to our list
+    let identityModel = IdentityModel(
+      id: idData,
+      balance: balance,
+      isLocal: false,
+      alias: formInputs["alias"],
+      dpnsName: nil
+    )
+
+    await MainActor.run {
+      appState.platformState.addIdentity(identityModel)
     }
-    
-    private func executeIdentityCreditWithdrawal(sdk: SDK) async throws -> Any {
-        guard !selectedIdentityId.isEmpty,
-              let identity = appState.platformState.identities.first(where: { $0.idString == selectedIdentityId }) else {
-            throw SDKError.invalidParameter("No identity selected")
-        }
-        
-        guard let toAddress = formInputs["toAddress"], !toAddress.isEmpty else {
-            throw SDKError.invalidParameter("Recipient address is required")
-        }
-        
-        guard let amountString = formInputs["amount"],
-              let amount = UInt64(amountString) else {
-            throw SDKError.invalidParameter("Invalid amount")
-        }
-        
-        let coreFeePerByteString = formInputs["coreFeePerByte"] ?? "0"
-        let coreFeePerByte = UInt32(coreFeePerByteString) ?? 0
-        
-        // Find the transfer key for withdrawal
-        let transferKey = identity.publicKeys.first { key in
-            key.purpose == .transfer
-        }
-        
-        guard let transferKey = transferKey else {
-            throw SDKError.invalidParameter("No transfer key found for this identity")
-        }
-        
-        // Get the actual private key from keychain
-        guard let privateKeyData = KeychainManager.shared.retrievePrivateKey(
-            identityId: identity.id,
-            keyIndex: Int32(transferKey.id)
-        ) else {
-            throw SDKError.invalidParameter("Private key not found for transfer key #\(transferKey.id). Please add the private key first.")
-        }
-        
-        let signerResult = privateKeyData.withUnsafeBytes { keyBytes in
-            dash_sdk_signer_create_from_private_key(
-                keyBytes.bindMemory(to: UInt8.self).baseAddress!,
-                UInt(privateKeyData.count)
-            )
-        }
-        
-        guard signerResult.error == nil,
-              let signer = signerResult.data else {
-            throw SDKError.internalError("Failed to create signer")
-        }
-        
-        defer {
-            dash_sdk_signer_destroy(signer.assumingMemoryBound(to: SignerHandle.self))
-        }
-        
-        // Use the DPPIdentity for withdrawal
-        let dppIdentity = DPPIdentity(
-            id: identity.id,
-            publicKeys: Dictionary(uniqueKeysWithValues: identity.publicKeys.map { ($0.id, $0) }),
-            balance: identity.balance,
-            revision: 0
-        )
-        
-        let newBalance = try await sdk.withdrawFromIdentity(
-            dppIdentity,
-            amount: amount,
-            toAddress: toAddress,
-            coreFeePerByte: coreFeePerByte,
-            signer: OpaquePointer(signer)
-        )
-        
-        // Update identity's balance in our local state
-        await MainActor.run {
-            appState.platformState.updateIdentityBalance(id: identity.id, newBalance: newBalance)
-        }
-        
-        return [
-            "identityId": identity.idString,
-            "withdrawnAmount": amount,
-            "toAddress": toAddress,
-            "coreFeePerByte": coreFeePerByte,
-            "newBalance": newBalance,
-            "message": "Credits withdrawn successfully"
-        ]
+
+    return [
+      "identityId": idString,
+      "balance": balance,
+      "message": "Identity created successfully"
+    ]
+  }
+
+  private func executeIdentityTopUp(sdk: SDK) async throws -> Any {
+    guard !selectedIdentityId.isEmpty,
+          appState.platformState.identities.contains(where: { $0.idString == selectedIdentityId }) else {
+      throw SDKError.invalidParameter("No identity selected")
     }
-    
-    private func executeDocumentCreate(sdk: SDK) async throws -> Any {
-        guard !selectedIdentityId.isEmpty,
-              let ownerIdentity = appState.platformState.identities.first(where: { $0.idString == selectedIdentityId }) else {
-            throw SDKError.invalidParameter("No identity selected")
-        }
-        
-        guard let contractId = formInputs["contractId"], !contractId.isEmpty else {
-            throw SDKError.invalidParameter("Data contract ID is required")
-        }
-        
-        guard let documentType = formInputs["documentType"], !documentType.isEmpty else {
-            throw SDKError.invalidParameter("Document type is required")
-        }
-        
-        guard let propertiesJson = formInputs["documentFields"], !propertiesJson.isEmpty else {
-            throw SDKError.invalidParameter("Document properties are required")
-        }
-        
-        // Parse the JSON properties
-        guard let propertiesData = propertiesJson.data(using: .utf8),
-              let properties = try? JSONSerialization.jsonObject(with: propertiesData) as? [String: Any] else {
-            throw SDKError.invalidParameter("Invalid JSON in properties field")
-        }
-        
-        // Determine the required security level for this document type
-        var requiredSecurityLevel: SecurityLevel = .high // Default to HIGH as per DPP
-        
-        // Try to get the document type's security requirement from persistent storage
-        // Convert contractId (base58 string) to Data for comparison
-        let contractIdData = Data.identifier(fromBase58: contractId) ?? Data()
-        let descriptor = FetchDescriptor<PersistentDataContract>(
-            predicate: #Predicate { $0.id == contractIdData }
-        )
-        if let persistentContract = try? appState.modelContainer.mainContext.fetch(descriptor).first,
-           let documentTypes = persistentContract.documentTypes,
-           let docType = documentTypes.first(where: { $0.name == documentType }) {
-            // Security level in storage: 0=MASTER, 1=CRITICAL, 2=HIGH, 3=MEDIUM
-            requiredSecurityLevel = SecurityLevel(rawValue: UInt8(docType.securityLevel)) ?? .high
-            print("📋 Document type '\(documentType)' requires security level: \(requiredSecurityLevel.name)")
-        } else {
-            print("⚠️ Could not determine security level for document type '\(documentType)', using default: HIGH")
-        }
-        
-        // Find a key for signing - must meet security requirements
-        print("🔑 Available keys for identity:")
-        for key in ownerIdentity.publicKeys {
-            print("  - ID: \(key.id), Purpose: \(key.purpose.name), Security: \(key.securityLevel.name), Disabled: \(key.isDisabled)")
-        }
-        
-        // For document operations, we need AUTHENTICATION purpose keys
-        // The key's security level must be equal to or stronger than the document's requirement
-        let suitableKeys = ownerIdentity.publicKeys.filter { key in
-            // Never use disabled keys
-            guard !key.isDisabled else { return false }
-            
-            // Must be AUTHENTICATION purpose for document operations
-            guard key.purpose == .authentication else { return false }
-            
-            // Security level must meet or exceed requirement (lower rawValue = higher security)
-            guard key.securityLevel.rawValue <= requiredSecurityLevel.rawValue else { return false }
-            
-            return true
-        }.sorted { k1, k2 in
-            // Sort by security level preference:
-            // 1. Exact match (e.g., MEDIUM for MEDIUM requirement)
-            // 2. Next level up (e.g., HIGH for MEDIUM requirement)
-            // 3. Higher levels (e.g., CRITICAL for MEDIUM requirement)
-            
-            // If one matches exactly and the other doesn't, prefer exact match
-            if k1.securityLevel == requiredSecurityLevel && k2.securityLevel != requiredSecurityLevel {
-                return true
-            }
-            if k1.securityLevel != requiredSecurityLevel && k2.securityLevel == requiredSecurityLevel {
-                return false
-            }
-            
-            // If neither matches exactly, prefer the one closer to the requirement
-            // (higher rawValue = lower security, so we want the highest rawValue that still meets the requirement)
-            if k1.securityLevel != requiredSecurityLevel && k2.securityLevel != requiredSecurityLevel {
-                // Both are stronger than required, prefer the weaker (closer to requirement)
-                if k1.securityLevel.rawValue > k2.securityLevel.rawValue {
-                    return true
-                } else if k1.securityLevel.rawValue < k2.securityLevel.rawValue {
-                    return false
-                }
-            }
-            
-            // If same security level, prefer lower ID (non-master keys)
-            return k1.id < k2.id
-        }
-        
-        // Try to find a key with its private key available
-        var finalSigningKey: IdentityPublicKey? = nil
-        var privateKeyData: Data? = nil
-        
-        for key in suitableKeys {
-            print("🔑 Trying key: ID: \(key.id), Purpose: \(key.purpose.name), Security: \(key.securityLevel.name)")
-            
-            // Try to get the private key from keychain
-            if let keyData = KeychainManager.shared.retrievePrivateKey(
-                identityId: ownerIdentity.id,
-                keyIndex: Int32(key.id)
-            ) {
-                print("✅ Found private key for key #\(key.id)")
-                finalSigningKey = key
-                privateKeyData = keyData
-                break
-            } else {
-                print("⚠️ Private key not found for key #\(key.id), trying next suitable key...")
-            }
-        }
-        
-        guard let selectedKey = finalSigningKey, let keyData = privateKeyData else {
-            let availableKeys = ownerIdentity.publicKeys.map { 
-                "ID: \($0.id), Purpose: \($0.purpose.name), Security: \($0.securityLevel.name)" 
-            }.joined(separator: "\n  ")
-            
-            let triedKeys = suitableKeys.map { 
-                "ID: \($0.id) (\($0.securityLevel.name))" 
-            }.joined(separator: ", ")
-            
-            throw SDKError.invalidParameter(
-                "No suitable key with available private key found for signing document type '\(documentType)' (requires \(requiredSecurityLevel.name) security with AUTHENTICATION purpose).\n\nTried keys: \(triedKeys)\n\nAll available keys:\n  \(availableKeys)\n\nPlease add the private key for one of the suitable keys."
-            )
-        }
-        
-        print("🔑 Selected signing key: ID: \(selectedKey.id), Purpose: \(selectedKey.purpose.name), Security: \(selectedKey.securityLevel.name)")
-        
-        // Create signer using the already retrieved private key data
-        let signerResult = keyData.withUnsafeBytes { keyBytes in
-            dash_sdk_signer_create_from_private_key(
-                keyBytes.bindMemory(to: UInt8.self).baseAddress!,
-                UInt(keyData.count)
-            )
-        }
-        
-        guard signerResult.error == nil,
-              let signer = signerResult.data else {
-            throw SDKError.internalError("Failed to create signer")
-        }
-        
-        defer {
-            dash_sdk_signer_destroy(signer.assumingMemoryBound(to: SignerHandle.self))
-        }
-        
-        // Use the DPPIdentity for document creation
-        let dppIdentity = DPPIdentity(
-            id: ownerIdentity.id,
-            publicKeys: Dictionary(uniqueKeysWithValues: ownerIdentity.publicKeys.map { ($0.id, $0) }),
-            balance: ownerIdentity.balance,
-            revision: 0
-        )
-        
-        let result = try await sdk.documentCreate(
-            contractId: contractId,
-            documentType: documentType,
-            ownerIdentity: dppIdentity,
-            properties: properties,
-            signer: OpaquePointer(signer)
-        )
-        
-        return result
+
+    throw SDKError.notImplemented("Identity top-up requires proper Identity handle conversion")
+  }
+
+  private func executeIdentityCreditTransfer(sdk: SDK) async throws -> Any {
+    guard !selectedIdentityId.isEmpty,
+          let fromIdentity = appState.platformState.identities.first(where: { $0.idString == selectedIdentityId }) else {
+      throw SDKError.invalidParameter("No identity selected")
     }
-    
-    private func executeDocumentDelete(sdk: SDK) async throws -> Any {
-        guard !selectedIdentityId.isEmpty,
-              let ownerIdentity = appState.platformState.identities.first(where: { $0.idString == selectedIdentityId }) else {
-            throw SDKError.invalidParameter("No identity selected")
-        }
-        
-        guard let contractId = formInputs["contractId"], !contractId.isEmpty else {
-            throw SDKError.invalidParameter("Data contract is required")
-        }
-        
-        guard let documentType = formInputs["documentType"], !documentType.isEmpty else {
-            throw SDKError.invalidParameter("Document type is required")
-        }
-        
-        guard let documentId = formInputs["documentId"], !documentId.isEmpty else {
-            throw SDKError.invalidParameter("Document ID is required")
-        }
-        
-        // Use the DPPIdentity
-        let dppIdentity = DPPIdentity(
-            id: ownerIdentity.id,
-            publicKeys: Dictionary(uniqueKeysWithValues: ownerIdentity.publicKeys.map { ($0.id, $0) }),
-            balance: ownerIdentity.balance,
-            revision: 0
-        )
-        
-        // Find a suitable signing key with private key available
-        // For delete, we typically use the critical key (ID 1)
-        var privateKeyData: Data?
-        var selectedKey: IdentityPublicKey?
-        
-        // First try to find the critical key (ID 1)
-        if let criticalKey = ownerIdentity.publicKeys.first(where: { $0.id == 1 && $0.securityLevel == .critical }) {
-            if let keyData = KeychainManager.shared.retrievePrivateKey(
-                identityId: ownerIdentity.id,
-                keyIndex: Int32(criticalKey.id)
-            ) {
-                selectedKey = criticalKey
-                privateKeyData = keyData
-            }
-        }
-        
-        // If critical key not found or no private key, try any authentication key
-        if selectedKey == nil {
-            for key in ownerIdentity.publicKeys.filter({ $0.purpose == .authentication }) {
-                if let keyData = KeychainManager.shared.retrievePrivateKey(
-                    identityId: ownerIdentity.id,
-                    keyIndex: Int32(key.id)
-                ) {
-                    selectedKey = key
-                    privateKeyData = keyData
-                    break
-                }
-            }
-        }
-        
-        guard selectedKey != nil, let keyData = privateKeyData else {
-            throw SDKError.invalidParameter("No suitable key with available private key found for signing")
-        }
-        
-        // Create signer using the private key
-        let signerResult = keyData.withUnsafeBytes { keyBytes in
-            dash_sdk_signer_create_from_private_key(
-                keyBytes.bindMemory(to: UInt8.self).baseAddress!,
-                UInt(keyData.count)
-            )
-        }
-        
-        guard signerResult.error == nil,
-              let signer = signerResult.data else {
-            throw SDKError.internalError("Failed to create signer")
-        }
-        
-        defer {
-            dash_sdk_signer_destroy(signer.assumingMemoryBound(to: SignerHandle.self))
-        }
-        
-        // Call the document delete function
-        try await sdk.documentDelete(
-            contractId: contractId,
-            documentType: documentType,
-            documentId: documentId,
-            ownerIdentity: dppIdentity,
-            signer: OpaquePointer(signer)
-        )
-        
-        return ["message": "Document deleted successfully"]
+
+    guard let toIdentityId = formInputs["toIdentityId"], !toIdentityId.isEmpty else {
+      throw SDKError.invalidParameter("Recipient identity ID is required")
     }
-    
-    private func executeDocumentTransfer(sdk: SDK) async throws -> Any {
-        guard !selectedIdentityId.isEmpty else {
-            throw SDKError.invalidParameter("No identity selected")
-        }
-        
-        guard let contractId = formInputs["contractId"], !contractId.isEmpty else {
-            throw SDKError.invalidParameter("Data contract is required")
-        }
-        
-        guard let documentType = formInputs["documentType"], !documentType.isEmpty else {
-            throw SDKError.invalidParameter("Document type is required")
-        }
-        
-        guard let documentId = formInputs["documentId"], !documentId.isEmpty else {
-            throw SDKError.invalidParameter("Document ID is required")
-        }
-        
-        guard let recipientId = formInputs["recipientId"], !recipientId.isEmpty else {
-            throw SDKError.invalidParameter("Recipient identity is required")
-        }
-        
-        // Validate that recipient is not the same as sender
-        if recipientId == selectedIdentityId {
-            throw SDKError.invalidParameter("Cannot transfer document to yourself")
-        }
-        
-        // Get the owner identity from persistent storage
-        guard let ownerIdentity = appState.platformState.identities.first(where: { $0.idString == selectedIdentityId }) else {
-            throw SDKError.invalidParameter("Selected identity not found")
-        }
-        
-        // Use the DPPIdentity
-        let fromIdentity = DPPIdentity(
-            id: ownerIdentity.id,
-            publicKeys: Dictionary(uniqueKeysWithValues: ownerIdentity.publicKeys.map { ($0.id, $0) }),
-            balance: ownerIdentity.balance,
-            revision: 0
-        )
-        
-        // Find a suitable signing key with private key available
-        var privateKeyData: Data?
-        var selectedKey: IdentityPublicKey?
-        
-        // For transfer, try to find the critical key (ID 1) first
-        if let criticalKey = ownerIdentity.publicKeys.first(where: { $0.id == 1 && $0.securityLevel == .critical }) {
-            if let keyData = KeychainManager.shared.retrievePrivateKey(
-                identityId: ownerIdentity.id,
-                keyIndex: Int32(criticalKey.id)
-            ) {
-                selectedKey = criticalKey
-                privateKeyData = keyData
-            }
-        }
-        
-        // If critical key not found or no private key, try any authentication key
-        if selectedKey == nil {
-            for key in ownerIdentity.publicKeys.filter({ $0.purpose == .authentication }) {
-                if let keyData = KeychainManager.shared.retrievePrivateKey(
-                    identityId: ownerIdentity.id,
-                    keyIndex: Int32(key.id)
-                ) {
-                    selectedKey = key
-                    privateKeyData = keyData
-                    break
-                }
-            }
-        }
-        
-        guard let keyData = privateKeyData else {
-            throw SDKError.invalidParameter("No suitable key with available private key found for signing")
-        }
-        
-        // Create signer using the private key
-        let signerResult = keyData.withUnsafeBytes { keyBytes in
-            dash_sdk_signer_create_from_private_key(
-                keyBytes.bindMemory(to: UInt8.self).baseAddress!,
-                UInt(keyData.count)
-            )
-        }
-        
-        guard signerResult.error == nil,
-              let signer = signerResult.data else {
-            throw SDKError.internalError("Failed to create signer")
-        }
-        
-        defer {
-            dash_sdk_signer_destroy(signer.assumingMemoryBound(to: SignerHandle.self))
-        }
-        
-        // Call the document transfer function
-        let result = try await sdk.documentTransfer(
-            contractId: contractId,
-            documentType: documentType,
-            documentId: documentId,
-            fromIdentity: fromIdentity,
-            toIdentityId: recipientId,
-            signer: OpaquePointer(signer)
-        )
-        
-        return result
+
+    guard let amountString = formInputs["amount"],
+          let amount = UInt64(amountString) else {
+      throw SDKError.invalidParameter("Invalid amount")
     }
-    
-    private func executeDocumentUpdatePrice(sdk: SDK) async throws -> Any {
-        guard !selectedIdentityId.isEmpty else {
-            throw SDKError.invalidParameter("No identity selected")
-        }
-        
-        guard let contractId = formInputs["contractId"], !contractId.isEmpty else {
-            throw SDKError.invalidParameter("Data contract is required")
-        }
-        
-        guard let documentType = formInputs["documentType"], !documentType.isEmpty else {
-            throw SDKError.invalidParameter("Document type is required")
-        }
-        
-        guard let documentId = formInputs["documentId"], !documentId.isEmpty else {
-            throw SDKError.invalidParameter("Document ID is required")
-        }
-        
-        guard let newPriceStr = formInputs["newPrice"], !newPriceStr.isEmpty else {
-            throw SDKError.invalidParameter("New price is required")
-        }
-        
-        guard let newPrice = UInt64(newPriceStr) else {
-            throw SDKError.invalidParameter("Invalid price format")
-        }
-        
-        // Get the owner identity from persistent storage
-        guard let ownerIdentity = appState.platformState.identities.first(where: { $0.idString == selectedIdentityId }) else {
-            throw SDKError.invalidParameter("Selected identity not found")
-        }
-        
-        // Use the DPPIdentity
-        let ownerDPPIdentity = DPPIdentity(
-            id: ownerIdentity.id,
-            publicKeys: Dictionary(uniqueKeysWithValues: ownerIdentity.publicKeys.map { ($0.id, $0) }),
-            balance: ownerIdentity.balance,
-            revision: 0
-        )
-        
-        // Find a suitable signing key with private key available
-        var privateKeyData: Data?
-        var selectedKey: IdentityPublicKey?
-        
-        // For update price, try to find the critical key (ID 1) first
-        if let criticalKey = ownerIdentity.publicKeys.first(where: { $0.id == 1 && $0.securityLevel == .critical }) {
-            if let keyData = KeychainManager.shared.retrievePrivateKey(
-                identityId: ownerIdentity.id,
-                keyIndex: Int32(criticalKey.id)
-            ) {
-                selectedKey = criticalKey
-                privateKeyData = keyData
-            }
-        }
-        
-        // If critical key not found or no private key, try any authentication key
-        if selectedKey == nil {
-            for key in ownerIdentity.publicKeys.filter({ $0.purpose == .authentication }) {
-                if let keyData = KeychainManager.shared.retrievePrivateKey(
-                    identityId: ownerIdentity.id,
-                    keyIndex: Int32(key.id)
-                ) {
-                    selectedKey = key
-                    privateKeyData = keyData
-                    break
-                }
-            }
-        }
-        
-        guard let keyData = privateKeyData else {
-            throw SDKError.invalidParameter("No suitable key with available private key found for signing")
-        }
-        
-        // Create signer using the private key
-        let signerResult = keyData.withUnsafeBytes { keyBytes in
-            dash_sdk_signer_create_from_private_key(
-                keyBytes.bindMemory(to: UInt8.self).baseAddress!,
-                UInt(keyData.count)
-            )
-        }
-        
-        guard signerResult.error == nil,
-              let signer = signerResult.data else {
-            throw SDKError.internalError("Failed to create signer")
-        }
-        
-        defer {
-            dash_sdk_signer_destroy(signer.assumingMemoryBound(to: SignerHandle.self))
-        }
-        
-        // Call the document update price function
-        let result = try await sdk.documentUpdatePrice(
-            contractId: contractId,
-            documentType: documentType,
-            documentId: documentId,
-            newPrice: newPrice,
-            ownerIdentity: ownerDPPIdentity,
-            signer: OpaquePointer(signer)
-        )
-        
-        return result
+
+    // Normalize the recipient identity ID to base58
+    let normalizedToIdentityId = normalizeIdentityId(toIdentityId)
+
+    // Use the convenience method with DPPIdentity
+    let dppIdentity = DPPIdentity(
+      id: fromIdentity.id,
+      publicKeys: Dictionary(uniqueKeysWithValues: fromIdentity.publicKeys.map { ($0.id, $0) }),
+      balance: fromIdentity.balance,
+      revision: 0
+    )
+
+    // Use KeyManager to create transfer signer
+    let keyManager = await MainActor.run { KeyManager.withSharedKeychain() }
+    let (transferKey, signer) = try await MainActor.run {
+      try keyManager.createTransferSigner(for: dppIdentity)
     }
-    
-    private func executeDocumentPurchase(sdk: SDK) async throws -> Any {
-        guard !selectedIdentityId.isEmpty,
-              let purchaserIdentity = appState.platformState.identities.first(where: { $0.idString == selectedIdentityId }) else {
-            throw SDKError.invalidParameter("No identity selected")
-        }
-        
-        guard let contractId = formInputs["contractId"], !contractId.isEmpty else {
-            throw SDKError.invalidParameter("Data contract is required")
-        }
-        
-        guard let documentType = formInputs["documentType"], !documentType.isEmpty else {
-            throw SDKError.invalidParameter("Document type is required")
-        }
-        
-        guard let documentId = formInputs["documentId"], !documentId.isEmpty else {
-            throw SDKError.invalidParameter("Document ID is required")
-        }
-        
-        // Check if we can purchase (this should already be validated by the button state)
-        if let error = appState.transitionState.documentPurchaseError {
-            throw SDKError.invalidParameter(error)
-        }
-        
-        // Get the price that was fetched by DocumentWithPriceView
-        guard let price = appState.transitionState.documentPrice else {
-            throw SDKError.invalidParameter("Document price not available. Please enter a valid document ID to fetch its price.")
-        }
-        
-        // Validate that the document is actually for sale (price > 0)
-        if price == 0 {
-            throw SDKError.invalidParameter("This document is not for sale")
-        }
-        
-        // Get the selected signing key
-        guard let selectedKey = purchaserIdentity.publicKeys.first(where: { key in
-            // Check if we have the private key for this public key
-            let privateKey = KeychainManager.shared.retrievePrivateKey(identityId: purchaserIdentity.id, keyIndex: Int32(key.id))
-            return privateKey != nil
-        }) else {
-            throw SDKError.invalidParameter("No key with available private key found for signing")
-        }
-        
-        // Get the private key data
-        guard let keyData = KeychainManager.shared.retrievePrivateKey(identityId: purchaserIdentity.id, keyIndex: Int32(selectedKey.id)) else {
-            throw SDKError.invalidParameter("No suitable key with available private key found for signing")
-        }
-      
-      // Use the DPPIdentity
-      let fromIdentity = DPPIdentity(
-          id: purchaserIdentity.id,
-          publicKeys: Dictionary(uniqueKeysWithValues: purchaserIdentity.publicKeys.map { ($0.id, $0) }),
-          balance: purchaserIdentity.balance,
-          revision: 0
+    defer {
+      keyManager.destroySigner(signer)
+    }
+
+    print("🔑 Using transfer key #\(transferKey.id)")
+
+    let (senderBalance, receiverBalance) = try await sdk.transferCredits(
+      from: dppIdentity,
+      toIdentityId: normalizedToIdentityId,
+      amount: amount,
+      signer: signer
+    )
+
+    // Update sender's balance in our local state
+    await MainActor.run {
+      appState.platformState.updateIdentityBalance(id: fromIdentity.id, newBalance: senderBalance)
+    }
+
+    return [
+      "senderIdentityId": fromIdentity.idString,
+      "senderBalance": senderBalance,
+      "receiverIdentityId": normalizedToIdentityId,
+      "receiverBalance": receiverBalance,
+      "transferAmount": amount,
+      "message": "Credits transferred successfully"
+    ]
+  }
+
+  private func executeIdentityCreditWithdrawal(sdk: SDK) async throws -> Any {
+    guard !selectedIdentityId.isEmpty,
+          let identity = appState.platformState.identities.first(where: { $0.idString == selectedIdentityId }) else {
+      throw SDKError.invalidParameter("No identity selected")
+    }
+
+    guard let toAddress = formInputs["toAddress"], !toAddress.isEmpty else {
+      throw SDKError.invalidParameter("Recipient address is required")
+    }
+
+    guard let amountString = formInputs["amount"],
+          let amount = UInt64(amountString) else {
+      throw SDKError.invalidParameter("Invalid amount")
+    }
+
+    let coreFeePerByteString = formInputs["coreFeePerByte"] ?? "0"
+    let coreFeePerByte = UInt32(coreFeePerByteString) ?? 0
+
+    // Use the DPPIdentity for withdrawal
+    let dppIdentity = DPPIdentity(
+      id: identity.id,
+      publicKeys: Dictionary(uniqueKeysWithValues: identity.publicKeys.map { ($0.id, $0) }),
+      balance: identity.balance,
+      revision: 0
+    )
+
+    // Use KeyManager to create transfer signer
+    let keyManager = await MainActor.run { KeyManager.withSharedKeychain() }
+    let (transferKey, signer) = try await MainActor.run {
+      try keyManager.createTransferSigner(for: dppIdentity)
+    }
+    defer {
+      keyManager.destroySigner(signer)
+    }
+
+    let newBalance = try await sdk.withdrawFromIdentity(
+      dppIdentity,
+      amount: amount,
+      toAddress: toAddress,
+      coreFeePerByte: coreFeePerByte,
+      signer: signer
+    )
+
+    // Update identity's balance in our local state
+    await MainActor.run {
+      appState.platformState.updateIdentityBalance(id: identity.id, newBalance: newBalance)
+    }
+
+    return [
+      "identityId": identity.idString,
+      "withdrawnAmount": amount,
+      "toAddress": toAddress,
+      "coreFeePerByte": coreFeePerByte,
+      "newBalance": newBalance,
+      "message": "Credits withdrawn successfully"
+    ]
+  }
+
+  private func executeDocumentCreate(sdk: SDK) async throws -> Any {
+    guard !selectedIdentityId.isEmpty,
+          let ownerIdentity = appState.platformState.identities.first(where: { $0.idString == selectedIdentityId }) else {
+      throw SDKError.invalidParameter("No identity selected")
+    }
+
+    guard let contractId = formInputs["contractId"], !contractId.isEmpty else {
+      throw SDKError.invalidParameter("Data contract ID is required")
+    }
+
+    guard let documentType = formInputs["documentType"], !documentType.isEmpty else {
+      throw SDKError.invalidParameter("Document type is required")
+    }
+
+    guard let propertiesJson = formInputs["documentFields"], !propertiesJson.isEmpty else {
+      throw SDKError.invalidParameter("Document properties are required")
+    }
+
+    // Parse the JSON properties
+    guard let propertiesData = propertiesJson.data(using: .utf8),
+          let properties = try? JSONSerialization.jsonObject(with: propertiesData) as? [String: Any] else {
+      throw SDKError.invalidParameter("Invalid JSON in properties field")
+    }
+
+    // Determine the required security level for this document type
+    var requiredSecurityLevel: SecurityLevel = .high // Default to HIGH as per DPP
+
+    // Try to get the document type's security requirement from persistent storage
+    // Convert contractId (base58 string) to Data for comparison
+    let contractIdData = Data.identifier(fromBase58: contractId) ?? Data()
+    let descriptor = FetchDescriptor<PersistentDataContract>(
+      predicate: #Predicate { $0.id == contractIdData }
+    )
+    if let persistentContract = try? appState.modelContainer.mainContext.fetch(descriptor).first,
+       let documentTypes = persistentContract.documentTypes,
+       let docType = documentTypes.first(where: { $0.name == documentType }) {
+      // Security level in storage: 0=MASTER, 1=CRITICAL, 2=HIGH, 3=MEDIUM
+      requiredSecurityLevel = SecurityLevel(rawValue: UInt8(docType.securityLevel)) ?? .high
+      print("📋 Document type '\(documentType)' requires security level: \(requiredSecurityLevel.name)")
+    } else {
+      print("⚠️ Could not determine security level for document type '\(documentType)', using default: HIGH")
+    }
+
+    // Use the DPPIdentity for document creation
+    let dppIdentity = DPPIdentity(
+      id: ownerIdentity.id,
+      publicKeys: Dictionary(uniqueKeysWithValues: ownerIdentity.publicKeys.map { ($0.id, $0) }),
+      balance: ownerIdentity.balance,
+      revision: 0
+    )
+
+    // Use KeyManager to find authentication key with required security level and create signer
+    let keyManager = await MainActor.run { KeyManager.withSharedKeychain() }
+    let (selectedKey, signer) = try await MainActor.run {
+      try keyManager.createDocumentSigner(
+        for: dppIdentity,
+        minimumSecurityLevel: requiredSecurityLevel
       )
-        
-        // Create signer using the private key
-        let signerResult = keyData.withUnsafeBytes { keyBytes in
-            dash_sdk_signer_create_from_private_key(
-                keyBytes.bindMemory(to: UInt8.self).baseAddress!,
-                UInt(keyData.count)
-            )
-        }
-        
-        guard signerResult.error == nil,
-              let signer = signerResult.data else {
-            throw SDKError.internalError("Failed to create signer")
-        }
-        
-        defer {
-            dash_sdk_signer_destroy(signer.assumingMemoryBound(to: SignerHandle.self))
-        }
-        
-        // Call the document purchase function
-        let result = try await sdk.documentPurchase(
-            contractId: contractId,
-            documentType: documentType,
-            documentId: documentId,
-            purchaserIdentity: fromIdentity,
-            price: price,
-            signer: OpaquePointer(signer)
-        )
-        
-        return result
     }
-    
-    private func executeDocumentReplace(sdk: SDK) async throws -> Any {
-        guard !selectedIdentityId.isEmpty,
-              let ownerIdentity = appState.platformState.identities.first(where: { $0.idString == selectedIdentityId }) else {
-            throw SDKError.invalidParameter("No identity selected")
-        }
-        
-        guard let contractId = formInputs["contractId"], !contractId.isEmpty else {
-            throw SDKError.invalidParameter("Data contract ID is required")
-        }
-        
-        guard let documentType = formInputs["documentType"], !documentType.isEmpty else {
-            throw SDKError.invalidParameter("Document type is required")
-        }
-        
-        guard let documentId = formInputs["documentId"], !documentId.isEmpty else {
-            throw SDKError.invalidParameter("Document ID is required")
-        }
-        
-        guard let propertiesJson = formInputs["documentFields"], !propertiesJson.isEmpty else {
-            throw SDKError.invalidParameter("Document properties are required")
-        }
-        
-        // Parse the JSON properties
-        guard let propertiesData = propertiesJson.data(using: .utf8),
-              let properties = try? JSONSerialization.jsonObject(with: propertiesData) as? [String: Any] else {
-            throw SDKError.invalidParameter("Invalid JSON in properties field")
-        }
-        
-        // Determine the required security level for this document type (similar to create)
-        var requiredSecurityLevel: SecurityLevel = .high // Default to HIGH as per DPP
-        
-        // Try to get the document type's security requirement from persistent storage
-        let contractIdData = Data.identifier(fromBase58: contractId) ?? Data()
-        let descriptor = FetchDescriptor<PersistentDataContract>(
-            predicate: #Predicate { $0.id == contractIdData }
-        )
-        if let persistentContract = try? appState.modelContainer.mainContext.fetch(descriptor).first,
-           let documentTypes = persistentContract.documentTypes,
-           let docType = documentTypes.first(where: { $0.name == documentType }) {
-            requiredSecurityLevel = SecurityLevel(rawValue: UInt8(docType.securityLevel)) ?? .high
-            print("📋 Document type '\(documentType)' requires security level: \(requiredSecurityLevel.name)")
-        } else {
-            print("⚠️ Could not determine security level for document type '\(documentType)', using default: HIGH")
-        }
-        
-        // Find a key for signing - must meet security requirements
-        print("🔑 Available keys for identity:")
-        for key in ownerIdentity.publicKeys {
-            print("  - ID: \(key.id), Purpose: \(key.purpose.name), Security: \(key.securityLevel.name), Disabled: \(key.isDisabled)")
-        }
-        
-        // For document operations, we need AUTHENTICATION purpose keys
-        let suitableKeys = ownerIdentity.publicKeys.filter { key in
-            guard !key.isDisabled else { return false }
-            guard key.purpose == .authentication else { return false }
-            guard key.securityLevel.rawValue <= requiredSecurityLevel.rawValue else { return false }
-            return true
-        }.sorted { k1, k2 in
-            // Prefer exact match, then closer to requirement
-            if k1.securityLevel == requiredSecurityLevel && k2.securityLevel != requiredSecurityLevel {
-                return true
-            }
-            if k1.securityLevel != requiredSecurityLevel && k2.securityLevel == requiredSecurityLevel {
-                return false
-            }
-            if k1.securityLevel != requiredSecurityLevel && k2.securityLevel != requiredSecurityLevel {
-                if k1.securityLevel.rawValue > k2.securityLevel.rawValue {
-                    return true
-                }
-            }
-            return k1.id < k2.id
-        }
-        
-        guard !suitableKeys.isEmpty else {
-            print("❌ No suitable keys found for document type '\(documentType)' (requires \(requiredSecurityLevel.name) security)")
-            throw SDKError.invalidParameter(
-                "No suitable keys found for signing document type '\(documentType)' (requires \(requiredSecurityLevel.name) security with AUTHENTICATION purpose)"
-            )
-        }
-        
-        // Find a key with a private key available
-        var selectedKey: IdentityPublicKey?
-        var keyData: Data?
-        
-        for candidateKey in suitableKeys {
-            print("🔍 Checking key ID \(candidateKey.id) for private key...")
-            
-            // Get private key from keychain
-            if let privateKeyData = KeychainManager.shared.retrievePrivateKey(
-                identityId: ownerIdentity.id,
-                keyIndex: Int32(candidateKey.id)
-            ) {
-                selectedKey = candidateKey
-                keyData = privateKeyData
-                print("✅ Found private key for key ID \(candidateKey.id)")
-                break
-            } else {
-                print("⚠️ No private key found for key ID \(candidateKey.id)")
-            }
-        }
-        
-        guard let selectedKey = selectedKey, let keyData = keyData else {
-            let availableKeys = ownerIdentity.publicKeys.map { 
-                "ID: \($0.id), Purpose: \($0.purpose.name), Security: \($0.securityLevel.name)" 
-            }.joined(separator: "\n  ")
-            
-            let triedKeys = suitableKeys.map { 
-                "ID: \($0.id) (\($0.securityLevel.name))" 
-            }.joined(separator: ", ")
-            
-            throw SDKError.invalidParameter(
-                "No suitable key with available private key found for signing document type '\(documentType)' (requires \(requiredSecurityLevel.name) security with AUTHENTICATION purpose).\n\nTried keys: \(triedKeys)\n\nAll available keys:\n  \(availableKeys)\n\nPlease add the private key for one of the suitable keys."
-            )
-        }
-        
-        print("🔑 Selected signing key: ID: \(selectedKey.id), Purpose: \(selectedKey.purpose.name), Security: \(selectedKey.securityLevel.name)")
-        
-        // Create signer using the already retrieved private key data
-        let signerResult = keyData.withUnsafeBytes { keyBytes in
-            dash_sdk_signer_create_from_private_key(
-                keyBytes.bindMemory(to: UInt8.self).baseAddress!,
-                UInt(keyData.count)
-            )
-        }
-        
-        guard signerResult.error == nil,
-              let signer = signerResult.data else {
-            throw SDKError.internalError("Failed to create signer")
-        }
-        
-        defer {
-            dash_sdk_signer_destroy(signer.assumingMemoryBound(to: SignerHandle.self))
-        }
-        
-        // Use the DPPIdentity for document replacement
-        let dppIdentity = DPPIdentity(
-            id: ownerIdentity.id,
-            publicKeys: Dictionary(uniqueKeysWithValues: ownerIdentity.publicKeys.map { ($0.id, $0) }),
-            balance: ownerIdentity.balance,
-            revision: 0
-        )
-        
-        let result = try await sdk.documentReplace(
-            contractId: contractId,
-            documentType: documentType,
-            documentId: documentId,
-            ownerIdentity: dppIdentity,
-            properties: properties,
-            signer: OpaquePointer(signer)
-        )
-        
-        return result
+    defer {
+      keyManager.destroySigner(signer)
     }
-    
-    private func executeTokenMint(sdk: SDK) async throws -> Any {
-        guard !selectedIdentityId.isEmpty,
-              let identity = appState.platformState.identities.first(where: { $0.idString == selectedIdentityId }) else {
-            throw SDKError.invalidParameter("No identity selected")
-        }
-        
-        // Parse the token selection (format: "contractId:position")
-        guard let tokenSelection = formInputs["token"], !tokenSelection.isEmpty else {
-            throw SDKError.invalidParameter("No token selected")
-        }
-        
-        let components = tokenSelection.split(separator: ":")
-        guard components.count == 2 else {
-            throw SDKError.invalidParameter("Invalid token selection format")
-        }
-        
-        let contractId = String(components[0])
-        
-        guard let amountString = formInputs["amount"], !amountString.isEmpty else {
-            throw SDKError.invalidParameter("Amount is required")
-        }
-        
-        // The issuedToIdentityId is optional - if not provided, tokens go to the contract owner
-        let recipientIdString = formInputs["issuedToIdentityId"]?.isEmpty == false ? formInputs["issuedToIdentityId"] : nil
-        
-        // Parse amount based on whether it contains a decimal
-        let amount: UInt64
-        if amountString.contains(".") {
-            // Handle decimal input (e.g., "1.5" tokens)
-            guard let doubleValue = Double(amountString) else {
-                throw SDKError.invalidParameter("Invalid amount format")
-            }
-            // Convert to smallest unit (assuming 8 decimal places like Dash)
-            amount = UInt64(doubleValue * 100_000_000)
-        } else {
-            // Handle integer input
-            guard let intValue = UInt64(amountString) else {
-                throw SDKError.invalidParameter("Invalid amount format")
-            }
-            amount = intValue
-        }
-        
-        // Find the minting key - for tokens, we need a critical security level key
-        // First try to find a critical key with OWNER purpose, then fall back to critical AUTHENTICATION
-        
-        // Debug: log all available keys
-        print("🔑 TOKEN MINT: Available keys for identity:")
-        for key in identity.publicKeys {
-            print("  - Key \(key.id): purpose=\(key.purpose), securityLevel=\(key.securityLevel)")
-        }
-        
-        let mintingKey = identity.publicKeys.first { key in
-            key.securityLevel == .critical && (key.purpose == .owner || key.purpose == .authentication)
-        }
-        
-        guard let mintingKey = mintingKey else {
-            throw SDKError.invalidParameter("No suitable key found for minting. Need a CRITICAL security level key with OWNER or AUTHENTICATION purpose.")
-        }
-        
-        print("🔑 TOKEN MINT: Selected key \(mintingKey.id) with purpose \(mintingKey.purpose) and security level \(mintingKey.securityLevel)")
-        
-        // Get the private key from keychain
-        guard let privateKeyData = KeychainManager.shared.retrievePrivateKey(
-            identityId: identity.id,
-            keyIndex: Int32(mintingKey.id)
-        ) else {
-            throw SDKError.invalidParameter("Private key not found for minting key #\(mintingKey.id). Please add the private key first.")
-        }
-        
-        // Create signer
-        let signerResult = privateKeyData.withUnsafeBytes { keyBytes in
-            dash_sdk_signer_create_from_private_key(
-                keyBytes.bindMemory(to: UInt8.self).baseAddress!,
-                UInt(privateKeyData.count)
-            )
-        }
-        
-        guard signerResult.error == nil,
-              let signer = signerResult.data else {
-            throw SDKError.internalError("Failed to create signer")
-        }
-        
-        defer {
-            dash_sdk_signer_destroy(signer.assumingMemoryBound(to: SignerHandle.self))
-        }
-        
-        // Use the DPPIdentity for minting
-        let dppIdentity = DPPIdentity(
-            id: identity.id,
-            publicKeys: Dictionary(uniqueKeysWithValues: identity.publicKeys.map { ($0.id, $0) }),
-            balance: identity.balance,
-            revision: 0
-        )
-        
-        let note = formInputs["publicNote"]?.isEmpty == false ? formInputs["publicNote"] : nil
-        
-        let result = try await sdk.tokenMint(
-            contractId: contractId,
-            recipientId: recipientIdString,
-            amount: amount,
-            ownerIdentity: dppIdentity,
-            keyId: mintingKey.id,
-            signer: OpaquePointer(signer),
-            note: note
-        )
-        
-        return result
+
+    print("🔑 Selected signing key: ID: \(selectedKey.id), Purpose: \(selectedKey.purpose.name), Security: \(selectedKey.securityLevel.name)")
+
+    let result = try await sdk.documentCreate(
+      contractId: contractId,
+      documentType: documentType,
+      ownerIdentity: dppIdentity,
+      properties: properties,
+      signer: signer
+    )
+
+    return result
+  }
+
+  private func executeDocumentDelete(sdk: SDK) async throws -> Any {
+    guard !selectedIdentityId.isEmpty,
+          let ownerIdentity = appState.platformState.identities.first(where: { $0.idString == selectedIdentityId }) else {
+      throw SDKError.invalidParameter("No identity selected")
     }
-    
-    private func executeTokenBurn(sdk: SDK) async throws -> Any {
-        guard !selectedIdentityId.isEmpty,
-              let identity = appState.platformState.identities.first(where: { $0.idString == selectedIdentityId }) else {
-            throw SDKError.invalidParameter("No identity selected")
-        }
-        
-        // Parse the token selection (format: "contractId:position")
-        guard let tokenSelection = formInputs["token"], !tokenSelection.isEmpty else {
-            throw SDKError.invalidParameter("No token selected")
-        }
-        
-        let components = tokenSelection.split(separator: ":")
-        guard components.count == 2 else {
-            throw SDKError.invalidParameter("Invalid token selection format")
-        }
-        
-        let contractId = String(components[0])
-        
-        guard let amountString = formInputs["amount"], !amountString.isEmpty else {
-            throw SDKError.invalidParameter("Amount is required")
-        }
-        
-        // Parse amount based on whether it contains a decimal
-        let amount: UInt64
-        if amountString.contains(".") {
-            // Handle decimal input (e.g., "1.5" tokens)
-            guard let doubleValue = Double(amountString) else {
-                throw SDKError.invalidParameter("Invalid amount format")
-            }
-            // Convert to smallest unit (assuming 8 decimal places like Dash)
-            amount = UInt64(doubleValue * 100_000_000)
-        } else {
-            // Handle integer input
-            guard let intValue = UInt64(amountString) else {
-                throw SDKError.invalidParameter("Invalid amount format")
-            }
-            amount = intValue
-        }
-        
-        // Find the burning key - for tokens, we need a critical security level key
-        // First try to find a critical key with OWNER purpose, then fall back to critical AUTHENTICATION
-        let burningKey = identity.publicKeys.first { key in
-            key.securityLevel == .critical && (key.purpose == .owner || key.purpose == .authentication)
-        }
-        
-        guard let burningKey = burningKey else {
-            throw SDKError.invalidParameter("No suitable key found for burning. Need a CRITICAL security level key with OWNER or AUTHENTICATION purpose.")
-        }
-        
-        // Get the private key from keychain
-        guard let privateKeyData = KeychainManager.shared.retrievePrivateKey(
-            identityId: identity.id,
-            keyIndex: Int32(burningKey.id)
-        ) else {
-            throw SDKError.invalidParameter("Private key not found for burning key #\(burningKey.id). Please add the private key first.")
-        }
-        
-        // Create signer
-        let signerResult = privateKeyData.withUnsafeBytes { keyBytes in
-            dash_sdk_signer_create_from_private_key(
-                keyBytes.bindMemory(to: UInt8.self).baseAddress!,
-                UInt(privateKeyData.count)
-            )
-        }
-        
-        guard signerResult.error == nil,
-              let signer = signerResult.data else {
-            throw SDKError.internalError("Failed to create signer")
-        }
-        
-        defer {
-            dash_sdk_signer_destroy(signer.assumingMemoryBound(to: SignerHandle.self))
-        }
-        
-        // Use the DPPIdentity for burning
-        let dppIdentity = DPPIdentity(
-            id: identity.id,
-            publicKeys: Dictionary(uniqueKeysWithValues: identity.publicKeys.map { ($0.id, $0) }),
-            balance: identity.balance,
-            revision: 0
-        )
-        
-        let note = formInputs["note"]?.isEmpty == false ? formInputs["note"] : nil
-        
-        let result = try await sdk.tokenBurn(
-            contractId: contractId,
-            amount: amount,
-            ownerIdentity: dppIdentity,
-            keyId: burningKey.id,
-            signer: OpaquePointer(signer),
-            note: note
-        )
-        
-        return result
+
+    guard let contractId = formInputs["contractId"], !contractId.isEmpty else {
+      throw SDKError.invalidParameter("Data contract is required")
     }
-    
-    private func executeTokenFreeze(sdk: SDK) async throws -> Any {
-        guard !selectedIdentityId.isEmpty,
-              let identity = appState.platformState.identities.first(where: { $0.idString == selectedIdentityId }) else {
-            throw SDKError.invalidParameter("No identity selected")
-        }
-        
-        // Parse the token selection (format: "contractId:position")
-        guard let tokenSelection = formInputs["token"], !tokenSelection.isEmpty else {
-            throw SDKError.invalidParameter("No token selected")
-        }
-        
-        let components = tokenSelection.split(separator: ":")
-        guard components.count == 2 else {
-            throw SDKError.invalidParameter("Invalid token selection format")
-        }
-        
-        let contractId = String(components[0])
-        
-        guard let targetIdentityId = formInputs["targetIdentityId"], !targetIdentityId.isEmpty else {
-            throw SDKError.invalidParameter("Target identity ID is required")
-        }
-        
-        // Find the freezing key - for tokens, we need a critical security level key
-        // First try to find a critical key with OWNER purpose, then fall back to critical AUTHENTICATION
-        let freezingKey = identity.publicKeys.first { key in
-            key.securityLevel == .critical && (key.purpose == .owner || key.purpose == .authentication)
-        }
-        
-        guard let freezingKey = freezingKey else {
-            throw SDKError.invalidParameter("No suitable key found for freezing. Need a CRITICAL security level key with OWNER or AUTHENTICATION purpose.")
-        }
-        
-        // Get the private key from keychain
-        guard let privateKeyData = KeychainManager.shared.retrievePrivateKey(
-            identityId: identity.id,
-            keyIndex: Int32(freezingKey.id)
-        ) else {
-            throw SDKError.invalidParameter("Private key not found for freezing key #\(freezingKey.id). Please add the private key first.")
-        }
-        
-        // Create signer
-        let signerResult = privateKeyData.withUnsafeBytes { keyBytes in
-            dash_sdk_signer_create_from_private_key(
-                keyBytes.bindMemory(to: UInt8.self).baseAddress!,
-                UInt(privateKeyData.count)
-            )
-        }
-        
-        guard signerResult.error == nil,
-              let signer = signerResult.data else {
-            throw SDKError.internalError("Failed to create signer")
-        }
-        
-        defer {
-            dash_sdk_signer_destroy(signer.assumingMemoryBound(to: SignerHandle.self))
-        }
-        
-        // Use the DPPIdentity for freezing
-        let dppIdentity = DPPIdentity(
-            id: identity.id,
-            publicKeys: Dictionary(uniqueKeysWithValues: identity.publicKeys.map { ($0.id, $0) }),
-            balance: identity.balance,
-            revision: 0
-        )
-        
-        let note = formInputs["note"]?.isEmpty == false ? formInputs["note"] : nil
-        
-        let result = try await sdk.tokenFreeze(
-            contractId: contractId,
-            targetIdentityId: targetIdentityId,
-            ownerIdentity: dppIdentity,
-            keyId: freezingKey.id,
-            signer: OpaquePointer(signer),
-            note: note
-        )
-        
-        return result
+
+    guard let documentType = formInputs["documentType"], !documentType.isEmpty else {
+      throw SDKError.invalidParameter("Document type is required")
     }
-    
-    private func executeTokenUnfreeze(sdk: SDK) async throws -> Any {
-        guard !selectedIdentityId.isEmpty,
-              let identity = appState.platformState.identities.first(where: { $0.idString == selectedIdentityId }) else {
-            throw SDKError.invalidParameter("No identity selected")
-        }
-        
-        // Parse the token selection (format: "contractId:position")
-        guard let tokenSelection = formInputs["token"], !tokenSelection.isEmpty else {
-            throw SDKError.invalidParameter("No token selected")
-        }
-        
-        let components = tokenSelection.split(separator: ":")
-        guard components.count == 2 else {
-            throw SDKError.invalidParameter("Invalid token selection format")
-        }
-        
-        let contractId = String(components[0])
-        
-        guard let targetIdentityId = formInputs["targetIdentityId"], !targetIdentityId.isEmpty else {
-            throw SDKError.invalidParameter("Target identity ID is required")
-        }
-        
-        // Find the unfreezing key - for tokens, we need a critical security level key
-        // First try to find a critical key with OWNER purpose, then fall back to critical AUTHENTICATION
-        let unfreezingKey = identity.publicKeys.first { key in
-            key.securityLevel == .critical && (key.purpose == .owner || key.purpose == .authentication)
-        }
-        
-        guard let unfreezingKey = unfreezingKey else {
-            throw SDKError.invalidParameter("No suitable key found for unfreezing. Need a CRITICAL security level key with OWNER or AUTHENTICATION purpose.")
-        }
-        
-        // Get the private key from keychain
-        guard let privateKeyData = KeychainManager.shared.retrievePrivateKey(
-            identityId: identity.id,
-            keyIndex: Int32(unfreezingKey.id)
-        ) else {
-            throw SDKError.invalidParameter("Private key not found for unfreezing key #\(unfreezingKey.id). Please add the private key first.")
-        }
-        
-        // Create signer
-        let signerResult = privateKeyData.withUnsafeBytes { keyBytes in
-            dash_sdk_signer_create_from_private_key(
-                keyBytes.bindMemory(to: UInt8.self).baseAddress!,
-                UInt(privateKeyData.count)
-            )
-        }
-        
-        guard signerResult.error == nil,
-              let signerHandle = signerResult.data else {
-            let errorString = signerResult.error?.pointee.message != nil ?
-                String(cString: signerResult.error!.pointee.message) : "Failed to create signer"
-            dash_sdk_error_free(signerResult.error)
-            throw SDKError.internalError(errorString)
-        }
-        
-        defer {
-            dash_sdk_signer_destroy(signerHandle.assumingMemoryBound(to: SignerHandle.self))
-        }
-        
-        // Use the DPPIdentity for unfreezing
-        let dppIdentity = DPPIdentity(
-            id: identity.id,
-            publicKeys: Dictionary(uniqueKeysWithValues: identity.publicKeys.map { ($0.id, $0) }),
-            balance: identity.balance,
-            revision: 0
-        )
-        
-        let result = try await sdk.tokenUnfreeze(
-            contractId: contractId,
-            targetIdentityId: targetIdentityId,
-            ownerIdentity: dppIdentity,
-            keyId: unfreezingKey.id,
-            signer: OpaquePointer(signerHandle),
-            note: formInputs["note"]
-        )
-        
-        return result
+
+    guard let documentId = formInputs["documentId"], !documentId.isEmpty else {
+      throw SDKError.invalidParameter("Document ID is required")
     }
-    
-    private func executeTokenDestroyFrozenFunds(sdk: SDK) async throws -> Any {
-        guard !selectedIdentityId.isEmpty,
-              let identity = appState.platformState.identities.first(where: { $0.idString == selectedIdentityId }) else {
-            throw SDKError.invalidParameter("No identity selected")
-        }
-        
-        // Parse the token selection (format: "contractId:position")
-        guard let tokenSelection = formInputs["token"], !tokenSelection.isEmpty else {
-            throw SDKError.invalidParameter("No token selected")
-        }
-        
-        let components = tokenSelection.split(separator: ":")
-        guard components.count == 2 else {
-            throw SDKError.invalidParameter("Invalid token selection format")
-        }
-        
-        let contractId = String(components[0])
-        
-        guard let frozenIdentityId = formInputs["frozenIdentityId"], !frozenIdentityId.isEmpty else {
-            throw SDKError.invalidParameter("Frozen identity ID is required")
-        }
-        
-        // Find the destroy frozen funds key - for tokens, we need a critical security level key
-        // First try to find a critical key with OWNER purpose, then fall back to critical AUTHENTICATION
-        let destroyKey = identity.publicKeys.first { key in
-            key.securityLevel == .critical && (key.purpose == .owner || key.purpose == .authentication)
-        }
-        
-        guard let destroyKey = destroyKey else {
-            throw SDKError.invalidParameter("No suitable key found for destroying frozen funds. Need a CRITICAL security level key with OWNER or AUTHENTICATION purpose.")
-        }
-        
-        // Get the private key from keychain
-        guard let privateKeyData = KeychainManager.shared.retrievePrivateKey(
-            identityId: identity.id,
-            keyIndex: Int32(destroyKey.id)
-        ) else {
-            throw SDKError.invalidParameter("Private key not found for destroy key #\(destroyKey.id). Please add the private key first.")
-        }
-        
-        // Create signer
-        let signerResult = privateKeyData.withUnsafeBytes { keyBytes in
-            dash_sdk_signer_create_from_private_key(
-                keyBytes.bindMemory(to: UInt8.self).baseAddress!,
-                UInt(privateKeyData.count)
-            )
-        }
-        
-        guard signerResult.error == nil,
-              let signerHandle = signerResult.data else {
-            let errorString = signerResult.error?.pointee.message != nil ?
-                String(cString: signerResult.error!.pointee.message) : "Failed to create signer"
-            dash_sdk_error_free(signerResult.error)
-            throw SDKError.internalError(errorString)
-        }
-        
-        defer {
-            dash_sdk_signer_destroy(signerHandle.assumingMemoryBound(to: SignerHandle.self))
-        }
-        
-        // Use the DPPIdentity for destroying frozen funds
-        let dppIdentity = DPPIdentity(
-            id: identity.id,
-            publicKeys: Dictionary(uniqueKeysWithValues: identity.publicKeys.map { ($0.id, $0) }),
-            balance: identity.balance,
-            revision: 0
-        )
-        
-        let result = try await sdk.tokenDestroyFrozenFunds(
-            contractId: contractId,
-            frozenIdentityId: frozenIdentityId,
-            ownerIdentity: dppIdentity,
-            keyId: destroyKey.id,
-            signer: OpaquePointer(signerHandle),
-            note: formInputs["note"]
-        )
-        
-        return result
+
+    // Use the DPPIdentity
+    let dppIdentity = DPPIdentity(
+      id: ownerIdentity.id,
+      publicKeys: Dictionary(uniqueKeysWithValues: ownerIdentity.publicKeys.map { ($0.id, $0) }),
+      balance: ownerIdentity.balance,
+      revision: 0
+    )
+
+    // Use KeyManager to find authentication key with private key and create signer
+    let keyManager = await MainActor.run { KeyManager.withSharedKeychain() }
+    let (selectedKey, signer) = try await MainActor.run {
+      try keyManager.createSignerForKey(
+        for: dppIdentity,
+        purpose: .authentication,
+        minimumSecurityLevel: nil,
+        preferCritical: true
+      )
     }
-    
-    private func executeTokenClaim(sdk: SDK) async throws -> Any {
-        guard !selectedIdentityId.isEmpty,
-              let identity = appState.platformState.identities.first(where: { $0.idString == selectedIdentityId }) else {
-            throw SDKError.invalidParameter("No identity selected")
-        }
-        
-        // Parse the token selection (format: "contractId:position")
-        guard let tokenSelection = formInputs["token"], !tokenSelection.isEmpty else {
-            throw SDKError.invalidParameter("No token selected")
-        }
-        
-        let components = tokenSelection.split(separator: ":")
-        guard components.count == 2 else {
-            throw SDKError.invalidParameter("Invalid token selection format")
-        }
-        
-        let contractId = String(components[0])
-        
-        guard let distributionType = formInputs["distributionType"], !distributionType.isEmpty else {
-            throw SDKError.invalidParameter("Distribution type is required")
-        }
-        
-        // Find the claiming key - for tokens, we need a critical security level key
-        let claimingKey = identity.publicKeys.first { key in
-            key.securityLevel == .critical && (key.purpose == .owner || key.purpose == .authentication)
-        }
-        
-        guard let claimingKey = claimingKey else {
-            throw SDKError.invalidParameter("No suitable key found for claiming. Need a CRITICAL security level key with OWNER or AUTHENTICATION purpose.")
-        }
-        
-        // Get the private key from keychain
-        guard let privateKeyData = KeychainManager.shared.retrievePrivateKey(
-            identityId: identity.id,
-            keyIndex: Int32(claimingKey.id)
-        ) else {
-            throw SDKError.invalidParameter("Private key not found for claiming key #\(claimingKey.id). Please add the private key first.")
-        }
-        
-        // Create signer using the same pattern as other token operations
-        let signerResult = privateKeyData.withUnsafeBytes { keyBytes in
-            dash_sdk_signer_create_from_private_key(
-                keyBytes.bindMemory(to: UInt8.self).baseAddress!,
-                UInt(privateKeyData.count)
-            )
-        }
-        
-        guard signerResult.error == nil,
-              let signer = signerResult.data else {
-            throw SDKError.internalError("Failed to create signer")
-        }
-        
-        defer {
-            dash_sdk_signer_destroy(signer.assumingMemoryBound(to: SignerHandle.self))
-        }
-        
-        // Use the DPPIdentity for claiming
-        let dppIdentity = DPPIdentity(
-            id: identity.id,
-            publicKeys: Dictionary(uniqueKeysWithValues: identity.publicKeys.map { ($0.id, $0) }),
-            balance: identity.balance,
-            revision: 0
-        )
-        
-        let note = formInputs["publicNote"]?.isEmpty == false ? formInputs["publicNote"] : nil
-        
-        let result = try await sdk.tokenClaim(
-            contractId: contractId,
-            distributionType: distributionType,
-            ownerIdentity: dppIdentity,
-            keyId: claimingKey.id,
-            signer: OpaquePointer(signer),
-            note: note
-        )
-        
-        return result
+    defer {
+      keyManager.destroySigner(signer)
     }
-    
-    private func executeTokenTransfer(sdk: SDK) async throws -> Any {
-        guard !selectedIdentityId.isEmpty,
-              let identity = appState.platformState.identities.first(where: { $0.idString == selectedIdentityId }) else {
-            throw SDKError.invalidParameter("No identity selected")
-        }
-        
-        // Parse the token selection (format: "contractId:position")
-        guard let tokenSelection = formInputs["token"], !tokenSelection.isEmpty else {
-            throw SDKError.invalidParameter("No token selected")
-        }
-        
-        let components = tokenSelection.split(separator: ":")
-        guard components.count == 2 else {
-            throw SDKError.invalidParameter("Invalid token selection format")
-        }
-        
-        let contractId = String(components[0])
-        
-        guard let recipientId = formInputs["recipientId"], !recipientId.isEmpty else {
-            throw SDKError.invalidParameter("Recipient identity ID is required")
-        }
-        
-        guard let amountString = formInputs["amount"], !amountString.isEmpty else {
-            throw SDKError.invalidParameter("Amount is required")
-        }
-        
-        // Parse amount based on whether it contains a decimal
-        let amount: UInt64
-        if amountString.contains(".") {
-            // Handle decimal input (e.g., "1.5" tokens)
-            guard let doubleValue = Double(amountString) else {
-                throw SDKError.invalidParameter("Invalid amount format")
-            }
-            // Convert to smallest unit (assuming 8 decimal places like Dash)
-            amount = UInt64(doubleValue * 100_000_000)
-        } else {
-            // Handle integer input
-            guard let intValue = UInt64(amountString) else {
-                throw SDKError.invalidParameter("Invalid amount format")
-            }
-            amount = intValue
-        }
-        
-        // Find the transfer key - for tokens, we need a critical security level key
-        let transferKey = identity.publicKeys.first { key in
-            key.securityLevel == .critical && (key.purpose == .owner || key.purpose == .authentication)
-        }
-        
-        guard let transferKey = transferKey else {
-            throw SDKError.invalidParameter("No suitable key found for transfer. Need a CRITICAL security level key with OWNER or AUTHENTICATION purpose.")
-        }
-        
-        // Get the private key from keychain
-        guard let privateKeyData = KeychainManager.shared.retrievePrivateKey(
-            identityId: identity.id,
-            keyIndex: Int32(transferKey.id)
-        ) else {
-            throw SDKError.invalidParameter("Private key not found for transfer key #\(transferKey.id). Please add the private key first.")
-        }
-        
-        // Create signer using the same pattern as other token operations
-        let signerResult = privateKeyData.withUnsafeBytes { keyBytes in
-            dash_sdk_signer_create_from_private_key(
-                keyBytes.bindMemory(to: UInt8.self).baseAddress!,
-                UInt(privateKeyData.count)
-            )
-        }
-        
-        guard signerResult.error == nil,
-              let signer = signerResult.data else {
-            throw SDKError.internalError("Failed to create signer")
-        }
-        
-        defer {
-            dash_sdk_signer_destroy(signer.assumingMemoryBound(to: SignerHandle.self))
-        }
-        
-        // Use the DPPIdentity for transfer
-        let dppIdentity = DPPIdentity(
-            id: identity.id,
-            publicKeys: Dictionary(uniqueKeysWithValues: identity.publicKeys.map { ($0.id, $0) }),
-            balance: identity.balance,
-            revision: 0
-        )
-        
-        let note = formInputs["note"]?.isEmpty == false ? formInputs["note"] : nil
-        
-        let result = try await sdk.tokenTransfer(
-            contractId: contractId,
-            recipientId: recipientId,
-            amount: amount,
-            ownerIdentity: dppIdentity,
-            keyId: transferKey.id,
-            signer: OpaquePointer(signer),
-            note: note
-        )
-        
-        return result
+
+    // Call the document delete function
+    try await sdk.documentDelete(
+      contractId: contractId,
+      documentType: documentType,
+      documentId: documentId,
+      ownerIdentity: dppIdentity,
+      signer: signer
+    )
+
+    return ["message": "Document deleted successfully"]
+  }
+
+  private func executeDocumentTransfer(sdk: SDK) async throws -> Any {
+    guard !selectedIdentityId.isEmpty else {
+      throw SDKError.invalidParameter("No identity selected")
     }
-    
-    private func executeTokenSetPrice(sdk: SDK) async throws -> Any {
-        guard !selectedIdentityId.isEmpty,
-              let identity = appState.platformState.identities.first(where: { $0.idString == selectedIdentityId }) else {
-            throw SDKError.invalidParameter("No identity selected")
-        }
-        
-        // Parse the token selection (format: "contractId:position")
-        guard let tokenSelection = formInputs["token"], !tokenSelection.isEmpty else {
-            throw SDKError.invalidParameter("No token selected")
-        }
-        
-        let components = tokenSelection.split(separator: ":")
-        guard components.count == 2 else {
-            throw SDKError.invalidParameter("Invalid token selection format")
-        }
-        
-        let contractId = String(components[0])
-        
-        guard let priceType = formInputs["priceType"], !priceType.isEmpty else {
-            throw SDKError.invalidParameter("Price type is required")
-        }
-        
-        // Price data is optional - empty means remove pricing
-        let priceData = formInputs["priceData"]?.isEmpty == false ? formInputs["priceData"] : nil
-        
-        // Find the pricing key - for tokens, we need a critical security level key
-        let pricingKey = identity.publicKeys.first { key in
-            key.securityLevel == .critical && (key.purpose == .owner || key.purpose == .authentication)
-        }
-        
-        guard let pricingKey = pricingKey else {
-            throw SDKError.invalidParameter("No suitable key found for setting price. Need a CRITICAL security level key with OWNER or AUTHENTICATION purpose.")
-        }
-        
-        // Get the private key from keychain
-        guard let privateKeyData = KeychainManager.shared.retrievePrivateKey(
-            identityId: identity.id,
-            keyIndex: Int32(pricingKey.id)
-        ) else {
-            throw SDKError.invalidParameter("Private key not found for pricing key #\(pricingKey.id). Please add the private key first.")
-        }
-        
-        // Create signer using the same pattern as other token operations
-        let signerResult = privateKeyData.withUnsafeBytes { keyBytes in
-            dash_sdk_signer_create_from_private_key(
-                keyBytes.bindMemory(to: UInt8.self).baseAddress!,
-                UInt(privateKeyData.count)
-            )
-        }
-        
-        guard signerResult.error == nil,
-              let signer = signerResult.data else {
-            throw SDKError.internalError("Failed to create signer")
-        }
-        
-        defer {
-            dash_sdk_signer_destroy(signer.assumingMemoryBound(to: SignerHandle.self))
-        }
-        
-        // Use the DPPIdentity for setting price
-        let dppIdentity = DPPIdentity(
-            id: identity.id,
-            publicKeys: Dictionary(uniqueKeysWithValues: identity.publicKeys.map { ($0.id, $0) }),
-            balance: identity.balance,
-            revision: 0
-        )
-        
-        let note = formInputs["publicNote"]?.isEmpty == false ? formInputs["publicNote"] : nil
-        
-        let result = try await sdk.tokenSetPrice(
-            contractId: contractId,
-            pricingType: priceType,
-            priceData: priceData,
-            ownerIdentity: dppIdentity,
-            keyId: pricingKey.id,
-            signer: OpaquePointer(signer),
-            note: note
-        )
-        
-        return result
+
+    guard let contractId = formInputs["contractId"], !contractId.isEmpty else {
+      throw SDKError.invalidParameter("Data contract is required")
     }
-    
-    private func executeDataContractCreate(sdk: SDK) async throws -> Any {
-        guard !selectedIdentityId.isEmpty,
-              let ownerIdentity = appState.platformState.identities.first(where: { $0.idString == selectedIdentityId }) else {
-            throw SDKError.invalidParameter("No identity selected")
-        }
-        
-        // Parse document schemas if provided
-        var documentSchemas: [String: Any]? = nil
-        if let schemasJson = formInputs["documentSchemas"], !schemasJson.isEmpty {
-            guard let data = schemasJson.data(using: .utf8),
-                  let parsed = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
-                throw SDKError.serializationError("Invalid document schemas JSON")
-            }
-            documentSchemas = parsed
-        }
-        
-        // Parse token schemas if provided
-        var tokenSchemas: [String: Any]? = nil
-        if let tokensJson = formInputs["tokenSchemas"], !tokensJson.isEmpty {
-            guard let data = tokensJson.data(using: .utf8),
-                  let parsed = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
-                throw SDKError.serializationError("Invalid token schemas JSON")
-            }
-            tokenSchemas = parsed
-        }
-        
-        // Parse groups if provided
-        var groups: [[String: Any]]? = nil
-        if let groupsJson = formInputs["groups"], !groupsJson.isEmpty {
-            guard let data = groupsJson.data(using: .utf8),
-                  let parsed = try? JSONSerialization.jsonObject(with: data) as? [[String: Any]] else {
-                throw SDKError.serializationError("Invalid groups JSON")
-            }
-            groups = parsed
-        }
-        
-        // Build contract configuration
-        var contractConfig: [String: Any] = [:]
-        
-        // Add boolean configurations
-        if formInputs["canBeDeleted"] == "true" {
-            contractConfig["canBeDeleted"] = true
-        }
-        if formInputs["readonly"] == "true" {
-            contractConfig["readonly"] = true
-        }
-        if formInputs["keepsHistory"] == "true" {
-            contractConfig["keepsHistory"] = true
-        }
-        if formInputs["documentsKeepHistoryContractDefault"] == "true" {
-            contractConfig["documentsKeepHistoryContractDefault"] = true
-        }
-        if formInputs["documentsMutableContractDefault"] == "true" {
-            contractConfig["documentsMutableContractDefault"] = true
-        }
-        if formInputs["documentsCanBeDeletedContractDefault"] == "true" {
-            contractConfig["documentsCanBeDeletedContractDefault"] = true
-        }
-        if formInputs["requiresIdentityEncryptionBoundedKey"] == "true" {
-            contractConfig["requiresIdentityEncryptionBoundedKey"] = true
-        }
-        if formInputs["requiresIdentityDecryptionBoundedKey"] == "true" {
-            contractConfig["requiresIdentityDecryptionBoundedKey"] = true
-        }
-        
-        // Add optional text fields
-        if let keywords = formInputs["keywords"], !keywords.isEmpty {
-            contractConfig["keywords"] = keywords.split(separator: ",").map { $0.trimmingCharacters(in: .whitespaces) }
-        }
-        if let description = formInputs["description"], !description.isEmpty {
-            contractConfig["description"] = description
-        }
-        
-        // Validate that at least one schema is provided
-        if documentSchemas == nil && tokenSchemas == nil {
-            throw SDKError.invalidParameter("At least one document schema or token schema must be provided")
-        }
-        
-        // Find a critical authentication key for contract creation (required)
-        let signingKey = ownerIdentity.publicKeys.first { key in
-            key.securityLevel == .critical && key.purpose == .authentication
-        }
-        
-        guard let signingKey = signingKey else {
-            throw SDKError.invalidParameter("No critical authentication key found for signing contract creation. Data contract registration requires a critical AUTHENTICATION key.")
-        }
-        
-        // Get the private key from keychain
-        guard let privateKeyData = KeychainManager.shared.retrievePrivateKey(
-            identityId: ownerIdentity.id,
-            keyIndex: Int32(signingKey.id)
-        ) else {
-            throw SDKError.invalidParameter("Private key not found for key #\(signingKey.id). Please add the private key first.")
-        }
-        
-        // Create signer
-        let signerResult = privateKeyData.withUnsafeBytes { keyBytes in
-            dash_sdk_signer_create_from_private_key(
-                keyBytes.bindMemory(to: UInt8.self).baseAddress!,
-                UInt(privateKeyData.count)
-            )
-        }
-        
-        guard signerResult.error == nil,
-              let signer = signerResult.data else {
-            throw SDKError.internalError("Failed to create signer")
-        }
-        
-        defer {
-            dash_sdk_signer_destroy(signer.assumingMemoryBound(to: SignerHandle.self))
-        }
-        
-        // Use the DPPIdentity for contract creation
-        let dppIdentity = DPPIdentity(
-            id: ownerIdentity.id,
-            publicKeys: Dictionary(uniqueKeysWithValues: ownerIdentity.publicKeys.map { ($0.id, $0) }),
-            balance: ownerIdentity.balance,
-            revision: 0
+
+    guard let documentType = formInputs["documentType"], !documentType.isEmpty else {
+      throw SDKError.invalidParameter("Document type is required")
+    }
+
+    guard let documentId = formInputs["documentId"], !documentId.isEmpty else {
+      throw SDKError.invalidParameter("Document ID is required")
+    }
+
+    guard let recipientId = formInputs["recipientId"], !recipientId.isEmpty else {
+      throw SDKError.invalidParameter("Recipient identity is required")
+    }
+
+    // Validate that recipient is not the same as sender
+    if recipientId == selectedIdentityId {
+      throw SDKError.invalidParameter("Cannot transfer document to yourself")
+    }
+
+    // Get the owner identity from persistent storage
+    guard let ownerIdentity = appState.platformState.identities.first(where: { $0.idString == selectedIdentityId }) else {
+      throw SDKError.invalidParameter("Selected identity not found")
+    }
+
+    // Use the DPPIdentity
+    let fromIdentity = DPPIdentity(
+      id: ownerIdentity.id,
+      publicKeys: Dictionary(uniqueKeysWithValues: ownerIdentity.publicKeys.map { ($0.id, $0) }),
+      balance: ownerIdentity.balance,
+      revision: 0
+    )
+
+    // Use KeyManager to find authentication key with private key and create signer
+    let keyManager = await MainActor.run { KeyManager.withSharedKeychain() }
+    let (selectedKey, signer) = try await MainActor.run {
+      try keyManager.createSignerForKey(
+        for: fromIdentity,
+        purpose: .authentication,
+        minimumSecurityLevel: nil,
+        preferCritical: true
+      )
+    }
+    defer {
+      keyManager.destroySigner(signer)
+    }
+
+    // Call the document transfer function
+    let result = try await sdk.documentTransfer(
+      contractId: contractId,
+      documentType: documentType,
+      documentId: documentId,
+      fromIdentity: fromIdentity,
+      toIdentityId: recipientId,
+      signer: signer
+    )
+
+    return result
+  }
+
+  private func executeDocumentUpdatePrice(sdk: SDK) async throws -> Any {
+    guard !selectedIdentityId.isEmpty else {
+      throw SDKError.invalidParameter("No identity selected")
+    }
+
+    guard let contractId = formInputs["contractId"], !contractId.isEmpty else {
+      throw SDKError.invalidParameter("Data contract is required")
+    }
+
+    guard let documentType = formInputs["documentType"], !documentType.isEmpty else {
+      throw SDKError.invalidParameter("Document type is required")
+    }
+
+    guard let documentId = formInputs["documentId"], !documentId.isEmpty else {
+      throw SDKError.invalidParameter("Document ID is required")
+    }
+
+    guard let newPriceStr = formInputs["newPrice"], !newPriceStr.isEmpty else {
+      throw SDKError.invalidParameter("New price is required")
+    }
+
+    guard let newPrice = UInt64(newPriceStr) else {
+      throw SDKError.invalidParameter("Invalid price format")
+    }
+
+    // Get the owner identity from persistent storage
+    guard let ownerIdentity = appState.platformState.identities.first(where: { $0.idString == selectedIdentityId }) else {
+      throw SDKError.invalidParameter("Selected identity not found")
+    }
+
+    // Use the DPPIdentity
+    let ownerDPPIdentity = DPPIdentity(
+      id: ownerIdentity.id,
+      publicKeys: Dictionary(uniqueKeysWithValues: ownerIdentity.publicKeys.map { ($0.id, $0) }),
+      balance: ownerIdentity.balance,
+      revision: 0
+    )
+
+    // Use KeyManager to find authentication key with private key and create signer
+    let keyManager = await MainActor.run { KeyManager.withSharedKeychain() }
+    let (selectedKey, signer) = try await MainActor.run {
+      try keyManager.createSignerForKey(
+        for: ownerDPPIdentity,
+        purpose: .authentication,
+        minimumSecurityLevel: nil,
+        preferCritical: true
+      )
+    }
+    defer {
+      keyManager.destroySigner(signer)
+    }
+
+    // Call the document update price function
+    let result = try await sdk.documentUpdatePrice(
+      contractId: contractId,
+      documentType: documentType,
+      documentId: documentId,
+      newPrice: newPrice,
+      ownerIdentity: ownerDPPIdentity,
+      signer: signer
+    )
+
+    return result
+  }
+
+  private func executeDocumentPurchase(sdk: SDK) async throws -> Any {
+    guard !selectedIdentityId.isEmpty,
+          let purchaserIdentity = appState.platformState.identities.first(where: { $0.idString == selectedIdentityId }) else {
+      throw SDKError.invalidParameter("No identity selected")
+    }
+
+    guard let contractId = formInputs["contractId"], !contractId.isEmpty else {
+      throw SDKError.invalidParameter("Data contract is required")
+    }
+
+    guard let documentType = formInputs["documentType"], !documentType.isEmpty else {
+      throw SDKError.invalidParameter("Document type is required")
+    }
+
+    guard let documentId = formInputs["documentId"], !documentId.isEmpty else {
+      throw SDKError.invalidParameter("Document ID is required")
+    }
+
+    // Check if we can purchase (this should already be validated by the button state)
+    if let error = appState.transitionState.documentPurchaseError {
+      throw SDKError.invalidParameter(error)
+    }
+
+    // Get the price that was fetched by DocumentWithPriceView
+    guard let price = appState.transitionState.documentPrice else {
+      throw SDKError.invalidParameter("Document price not available. Please enter a valid document ID to fetch its price.")
+    }
+
+    // Validate that the document is actually for sale (price > 0)
+    if price == 0 {
+      throw SDKError.invalidParameter("This document is not for sale")
+    }
+
+    // Use the DPPIdentity
+    let fromIdentity = DPPIdentity(
+      id: purchaserIdentity.id,
+      publicKeys: Dictionary(uniqueKeysWithValues: purchaserIdentity.publicKeys.map { ($0.id, $0) }),
+      balance: purchaserIdentity.balance,
+      revision: 0
+    )
+
+    // Use KeyManager to find any key with private key and create signer
+    let keyManager = await MainActor.run { KeyManager.withSharedKeychain() }
+    let (selectedKey, signer) = try await MainActor.run {
+      try keyManager.createSignerForKey(
+        for: fromIdentity,
+        purpose: nil,
+        minimumSecurityLevel: nil,
+        preferCritical: true
+      )
+    }
+    defer {
+      keyManager.destroySigner(signer)
+    }
+
+    // Call the document purchase function
+    let result = try await sdk.documentPurchase(
+      contractId: contractId,
+      documentType: documentType,
+      documentId: documentId,
+      purchaserIdentity: fromIdentity,
+      price: price,
+      signer: signer
+    )
+
+    return result
+  }
+
+  private func executeDocumentReplace(sdk: SDK) async throws -> Any {
+    guard !selectedIdentityId.isEmpty,
+          let ownerIdentity = appState.platformState.identities.first(where: { $0.idString == selectedIdentityId }) else {
+      throw SDKError.invalidParameter("No identity selected")
+    }
+
+    guard let contractId = formInputs["contractId"], !contractId.isEmpty else {
+      throw SDKError.invalidParameter("Data contract ID is required")
+    }
+
+    guard let documentType = formInputs["documentType"], !documentType.isEmpty else {
+      throw SDKError.invalidParameter("Document type is required")
+    }
+
+    guard let documentId = formInputs["documentId"], !documentId.isEmpty else {
+      throw SDKError.invalidParameter("Document ID is required")
+    }
+
+    guard let propertiesJson = formInputs["documentFields"], !propertiesJson.isEmpty else {
+      throw SDKError.invalidParameter("Document properties are required")
+    }
+
+    // Parse the JSON properties
+    guard let propertiesData = propertiesJson.data(using: .utf8),
+          let properties = try? JSONSerialization.jsonObject(with: propertiesData) as? [String: Any] else {
+      throw SDKError.invalidParameter("Invalid JSON in properties field")
+    }
+
+    // Determine the required security level for this document type (similar to create)
+    var requiredSecurityLevel: SecurityLevel = .high // Default to HIGH as per DPP
+
+    // Try to get the document type's security requirement from persistent storage
+    let contractIdData = Data.identifier(fromBase58: contractId) ?? Data()
+    let descriptor = FetchDescriptor<PersistentDataContract>(
+      predicate: #Predicate { $0.id == contractIdData }
+    )
+    if let persistentContract = try? appState.modelContainer.mainContext.fetch(descriptor).first,
+       let documentTypes = persistentContract.documentTypes,
+       let docType = documentTypes.first(where: { $0.name == documentType }) {
+      requiredSecurityLevel = SecurityLevel(rawValue: UInt8(docType.securityLevel)) ?? .high
+      print("📋 Document type '\(documentType)' requires security level: \(requiredSecurityLevel.name)")
+    } else {
+      print("⚠️ Could not determine security level for document type '\(documentType)', using default: HIGH")
+    }
+
+    // Find a key for signing - must meet security requirements
+    print("🔑 Available keys for identity:")
+    for key in ownerIdentity.publicKeys {
+      print("  - ID: \(key.id), Purpose: \(key.purpose.name), Security: \(key.securityLevel.name), Disabled: \(key.isDisabled)")
+    }
+
+    // Use the DPPIdentity for document replacement
+    let dppIdentity = DPPIdentity(
+      id: ownerIdentity.id,
+      publicKeys: Dictionary(uniqueKeysWithValues: ownerIdentity.publicKeys.map { ($0.id, $0) }),
+      balance: ownerIdentity.balance,
+      revision: 0
+    )
+
+    // Use KeyManager to find authentication key with required security level and create signer
+    let keyManager = await MainActor.run { KeyManager.withSharedKeychain() }
+    let (selectedKey, signer) = try await MainActor.run {
+      try keyManager.createDocumentSigner(
+        for: dppIdentity,
+        minimumSecurityLevel: requiredSecurityLevel
+      )
+    }
+    defer {
+      keyManager.destroySigner(signer)
+    }
+
+    print("🔑 Selected signing key: ID: \(selectedKey.id), Purpose: \(selectedKey.purpose.name), Security: \(selectedKey.securityLevel.name)")
+
+    let result = try await sdk.documentReplace(
+      contractId: contractId,
+      documentType: documentType,
+      documentId: documentId,
+      ownerIdentity: dppIdentity,
+      properties: properties,
+      signer: signer
+    )
+
+    return result
+  }
+
+  private func executeTokenMint(sdk: SDK) async throws -> Any {
+    guard !selectedIdentityId.isEmpty,
+          let identity = appState.platformState.identities.first(where: { $0.idString == selectedIdentityId }) else {
+      throw SDKError.invalidParameter("No identity selected")
+    }
+
+    // Parse the token selection (format: "contractId:position")
+    guard let tokenSelection = formInputs["token"], !tokenSelection.isEmpty else {
+      throw SDKError.invalidParameter("No token selected")
+    }
+
+    let components = tokenSelection.split(separator: ":")
+    guard components.count == 2 else {
+      throw SDKError.invalidParameter("Invalid token selection format")
+    }
+
+    let contractId = String(components[0])
+
+    guard let amountString = formInputs["amount"], !amountString.isEmpty else {
+      throw SDKError.invalidParameter("Amount is required")
+    }
+
+    // The issuedToIdentityId is optional - if not provided, tokens go to the contract owner
+    let recipientIdString = formInputs["issuedToIdentityId"]?.isEmpty == false ? formInputs["issuedToIdentityId"] : nil
+
+    // Parse amount based on whether it contains a decimal
+    let amount: UInt64
+    if amountString.contains(".") {
+      // Handle decimal input (e.g., "1.5" tokens)
+      guard let doubleValue = Double(amountString) else {
+        throw SDKError.invalidParameter("Invalid amount format")
+      }
+      // Convert to smallest unit (assuming 8 decimal places like Dash)
+      amount = UInt64(doubleValue * 100_000_000)
+    } else {
+      // Handle integer input
+      guard let intValue = UInt64(amountString) else {
+        throw SDKError.invalidParameter("Invalid amount format")
+      }
+      amount = intValue
+    }
+
+    // Find the minting key - for tokens, we need a critical security level key
+    // Use the DPPIdentity for minting
+    let dppIdentity = DPPIdentity(
+      id: identity.id,
+      publicKeys: Dictionary(uniqueKeysWithValues: identity.publicKeys.map { ($0.id, $0) }),
+      balance: identity.balance,
+      revision: 0
+    )
+
+    // Use KeyManager to find critical key with owner or authentication purpose
+    let keyManager = await MainActor.run { KeyManager.withSharedKeychain() }
+    let mintingKey: IdentityPublicKey
+    let signer: OpaquePointer
+
+    // Try owner purpose first
+    let ownerResult = try? await MainActor.run {
+      try keyManager.createSignerForKey(
+        for: dppIdentity,
+        purpose: .owner,
+        minimumSecurityLevel: .critical,
+        preferCritical: true
+      )
+    }
+
+    if let (key, sig) = ownerResult {
+      mintingKey = key
+      signer = sig
+    } else {
+      // Fall back to authentication
+      let (key, sig) = try await MainActor.run {
+        try keyManager.createSignerForKey(
+          for: dppIdentity,
+          purpose: .authentication,
+          minimumSecurityLevel: .critical,
+          preferCritical: true
         )
-        
-        let result = try await sdk.dataContractCreate(
-            identity: dppIdentity,
-            documentSchemas: documentSchemas,
-            tokenSchemas: tokenSchemas,
-            groups: groups,
-            contractConfig: contractConfig,
-            signer: OpaquePointer(signer)
+      }
+      mintingKey = key
+      signer = sig
+    }
+    defer {
+      keyManager.destroySigner(signer)
+    }
+
+    print("🔑 TOKEN MINT: Selected key \(mintingKey.id) with purpose \(mintingKey.purpose) and security level \(mintingKey.securityLevel)")
+
+    let note = formInputs["publicNote"]?.isEmpty == false ? formInputs["publicNote"] : nil
+
+    let result = try await sdk.tokenMint(
+      contractId: contractId,
+      recipientId: recipientIdString,
+      amount: amount,
+      ownerIdentity: dppIdentity,
+      keyId: mintingKey.id,
+      signer: signer,
+      note: note
+    )
+
+    return result
+  }
+
+  private func executeTokenBurn(sdk: SDK) async throws -> Any {
+    guard !selectedIdentityId.isEmpty,
+          let identity = appState.platformState.identities.first(where: { $0.idString == selectedIdentityId }) else {
+      throw SDKError.invalidParameter("No identity selected")
+    }
+
+    // Parse the token selection (format: "contractId:position")
+    guard let tokenSelection = formInputs["token"], !tokenSelection.isEmpty else {
+      throw SDKError.invalidParameter("No token selected")
+    }
+
+    let components = tokenSelection.split(separator: ":")
+    guard components.count == 2 else {
+      throw SDKError.invalidParameter("Invalid token selection format")
+    }
+
+    let contractId = String(components[0])
+
+    guard let amountString = formInputs["amount"], !amountString.isEmpty else {
+      throw SDKError.invalidParameter("Amount is required")
+    }
+
+    // Parse amount based on whether it contains a decimal
+    let amount: UInt64
+    if amountString.contains(".") {
+      // Handle decimal input (e.g., "1.5" tokens)
+      guard let doubleValue = Double(amountString) else {
+        throw SDKError.invalidParameter("Invalid amount format")
+      }
+      // Convert to smallest unit (assuming 8 decimal places like Dash)
+      amount = UInt64(doubleValue * 100_000_000)
+    } else {
+      // Handle integer input
+      guard let intValue = UInt64(amountString) else {
+        throw SDKError.invalidParameter("Invalid amount format")
+      }
+      amount = intValue
+    }
+
+    // Use the DPPIdentity for burning
+    let dppIdentity = DPPIdentity(
+      id: identity.id,
+      publicKeys: Dictionary(uniqueKeysWithValues: identity.publicKeys.map { ($0.id, $0) }),
+      balance: identity.balance,
+      revision: 0
+    )
+
+    // Use KeyManager to find critical key with owner or authentication purpose
+    let keyManager = await MainActor.run { KeyManager.withSharedKeychain() }
+    let burningKey: IdentityPublicKey
+    let signer: OpaquePointer
+
+    // Try owner purpose first
+    let ownerResult = try? await MainActor.run {
+      try keyManager.createSignerForKey(
+        for: dppIdentity,
+        purpose: .owner,
+        minimumSecurityLevel: .critical,
+        preferCritical: true
+      )
+    }
+
+    if let (key, sig) = ownerResult {
+      burningKey = key
+      signer = sig
+    } else {
+      // Fall back to authentication
+      let (key, sig) = try await MainActor.run {
+        try keyManager.createSignerForKey(
+          for: dppIdentity,
+          purpose: .authentication,
+          minimumSecurityLevel: .critical,
+          preferCritical: true
         )
-        
-        return result
+      }
+      burningKey = key
+      signer = sig
     }
-    
-    private func executeDataContractUpdate(sdk: SDK) async throws -> Any {
-        guard let contractId = formInputs["dataContractId"], !contractId.isEmpty else {
-            throw SDKError.invalidParameter("Data contract ID is required")
-        }
-        
-        guard !selectedIdentityId.isEmpty,
-              let ownerIdentity = appState.platformState.identities.first(where: { $0.idString == selectedIdentityId }) else {
-            throw SDKError.invalidParameter("No identity selected")
-        }
-        
-        // Parse new document schemas if provided
-        var newDocumentSchemas: [String: Any]? = nil
-        if let schemasJson = formInputs["newDocumentSchemas"], !schemasJson.isEmpty {
-            guard let data = schemasJson.data(using: .utf8),
-                  let parsed = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
-                throw SDKError.serializationError("Invalid document schemas JSON")
-            }
-            newDocumentSchemas = parsed
-        }
-        
-        // Parse new token schemas if provided
-        var newTokenSchemas: [String: Any]? = nil
-        if let tokensJson = formInputs["newTokenSchemas"], !tokensJson.isEmpty {
-            guard let data = tokensJson.data(using: .utf8),
-                  let parsed = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
-                throw SDKError.serializationError("Invalid token schemas JSON")
-            }
-            newTokenSchemas = parsed
-        }
-        
-        // Parse new groups if provided
-        var newGroups: [[String: Any]]? = nil
-        if let groupsJson = formInputs["newGroups"], !groupsJson.isEmpty {
-            guard let data = groupsJson.data(using: .utf8),
-                  let parsed = try? JSONSerialization.jsonObject(with: data) as? [[String: Any]] else {
-                throw SDKError.serializationError("Invalid groups JSON")
-            }
-            newGroups = parsed
-        }
-        
-        // Validate that at least one update is provided
-        if newDocumentSchemas == nil && newTokenSchemas == nil && newGroups == nil {
-            throw SDKError.invalidParameter("At least one update (document schemas, token schemas, or groups) must be provided")
-        }
-        
-        // Find a critical authentication key for contract update (required)
-        let signingKey = ownerIdentity.publicKeys.first { key in
-            key.securityLevel == .critical && key.purpose == .authentication
-        }
-        
-        guard let signingKey = signingKey else {
-            throw SDKError.invalidParameter("No critical authentication key found for signing contract update. Data contract updates require a critical AUTHENTICATION key.")
-        }
-        
-        // Get the private key from keychain
-        guard let privateKeyData = KeychainManager.shared.retrievePrivateKey(
-            identityId: ownerIdentity.id,
-            keyIndex: Int32(signingKey.id)
-        ) else {
-            throw SDKError.invalidParameter("Private key not found for key #\(signingKey.id). Please add the private key first.")
-        }
-        
-        // Create signer
-        let signerResult = privateKeyData.withUnsafeBytes { keyBytes in
-            dash_sdk_signer_create_from_private_key(
-                keyBytes.bindMemory(to: UInt8.self).baseAddress!,
-                UInt(privateKeyData.count)
-            )
-        }
-        
-        guard signerResult.error == nil,
-              let signer = signerResult.data else {
-            throw SDKError.internalError("Failed to create signer")
-        }
-        
-        defer {
-            dash_sdk_signer_destroy(signer.assumingMemoryBound(to: SignerHandle.self))
-        }
-        
-        // Use the DPPIdentity for contract update
-        let dppIdentity = DPPIdentity(
-            id: ownerIdentity.id,
-            publicKeys: Dictionary(uniqueKeysWithValues: ownerIdentity.publicKeys.map { ($0.id, $0) }),
-            balance: ownerIdentity.balance,
-            revision: 0
-        )
-        
-        let result = try await sdk.dataContractUpdate(
-            contractId: contractId,
-            identity: dppIdentity,
-            newDocumentSchemas: newDocumentSchemas,
-            newTokenSchemas: newTokenSchemas,
-            newGroups: newGroups,
-            signer: OpaquePointer(signer)
-        )
-        
-        return result
+    defer {
+      keyManager.destroySigner(signer)
     }
-    
-    // MARK: - Helper Functions
-    
-    private func enrichedInput(for input: TransitionInput) -> TransitionInput {
-        // For document type picker, pass the selected contract ID in placeholder
-        if input.name == "documentType" && input.type == "documentTypePicker" {
-            return TransitionInput(
-                name: input.name,
-                type: input.type,
-                label: input.label,
-                required: input.required,
-                placeholder: selectedContractId.isEmpty ? formInputs["contractId"] : selectedContractId,
-                help: input.help,
-                defaultValue: input.defaultValue,
-                options: input.options,
-                action: "transition:\(transitionKey)",  // Pass the transition context
-                min: input.min,
-                max: input.max
-            )
-        }
-        
-        // For documentWithPrice picker, pass contract, document type, and identity ID in action field
-        if input.type == "documentWithPrice" {
-            let contractId = formInputs["contractId"] ?? ""
-            let documentType = formInputs["documentType"] ?? ""
-            let identityId = selectedIdentityId
-            return TransitionInput(
-                name: input.name,
-                type: input.type,
-                label: input.label,
-                required: input.required,
-                placeholder: input.placeholder,
-                help: input.help,
-                defaultValue: input.defaultValue,
-                options: input.options,
-                action: "\(contractId)|\(documentType)|\(identityId)",  // Pass all values separated by |
-                min: input.min,
-                max: input.max
-            )
-        }
-        
-        // For contract picker, pass the transition context
-        if input.name == "contractId" && input.type == "contractPicker" {
-            return TransitionInput(
-                name: input.name,
-                type: input.type,
-                label: input.label,
-                required: input.required,
-                placeholder: input.placeholder,
-                help: input.help,
-                defaultValue: input.defaultValue,
-                options: input.options,
-                action: "transition:\(transitionKey)",  // Pass the transition context
-                min: input.min,
-                max: input.max
-            )
-        }
-        
-        // For recipient identity picker in credit transfer, pass the sender identity ID
-        // Pass sender identity ID to exclude it from recipients for transfers
-        if (input.name == "toIdentityId" && input.type == "identityPicker" && transitionKey == "identityCreditTransfer") ||
-           (input.name == "recipientId" && input.type == "identityPicker" && transitionKey == "documentTransfer") {
-            return TransitionInput(
-                name: input.name,
-                type: input.type,
-                label: input.label,
-                required: input.required,
-                placeholder: selectedIdentityId,  // Pass sender identity ID to exclude it from recipients
-                help: input.help,
-                defaultValue: input.defaultValue,
-                options: input.options,
-                action: input.action,
-                min: input.min,
-                max: input.max
-            )
-        }
-        
-        return input
+
+    let note = formInputs["note"]?.isEmpty == false ? formInputs["note"] : nil
+
+    let result = try await sdk.tokenBurn(
+      contractId: contractId,
+      amount: amount,
+      ownerIdentity: dppIdentity,
+      keyId: burningKey.id,
+      signer: signer,
+      note: note
+    )
+
+    return result
+  }
+
+  private func executeTokenFreeze(sdk: SDK) async throws -> Any {
+    guard !selectedIdentityId.isEmpty,
+          let identity = appState.platformState.identities.first(where: { $0.idString == selectedIdentityId }) else {
+      throw SDKError.invalidParameter("No identity selected")
     }
-    
-    private func fetchDocumentSchema(contractId: String, documentType: String) {
-        // TODO: Implement fetching schema and generating dynamic form
-        // For now, provide a template based on common patterns
-        var schemaTemplate = "{\n"
-        
-        // Common document type templates
-        switch documentType.lowercased() {
-        case "note", "message":
-            schemaTemplate += "  \"message\": \"Enter your message here\"\n"
-        case "profile", "user":
-            schemaTemplate += "  \"displayName\": \"John Doe\",\n"
-            schemaTemplate += "  \"bio\": \"About me...\"\n"
-        case "post":
-            schemaTemplate += "  \"title\": \"Post title\",\n"
-            schemaTemplate += "  \"content\": \"Post content...\"\n"
-        default:
-            schemaTemplate += "  // Add document fields here\n"
-        }
-        
-        schemaTemplate += "}"
-        formInputs["documentFields"] = schemaTemplate
+
+    // Parse the token selection (format: "contractId:position")
+    guard let tokenSelection = formInputs["token"], !tokenSelection.isEmpty else {
+      throw SDKError.invalidParameter("No token selected")
     }
-    
-    private func normalizeIdentityId(_ identityId: String) -> String {
-        // Remove any prefix
-        let cleanId = identityId
-            .replacingOccurrences(of: "id:", with: "")
-            .replacingOccurrences(of: "0x", with: "")
-            .trimmingCharacters(in: .whitespacesAndNewlines)
-        
-        // If it's hex (64 chars), convert to base58
-        if cleanId.count == 64, let data = Data(hexString: cleanId) {
-            return data.toBase58String()
-        }
-        
-        // Otherwise assume it's already base58
-        return cleanId
+
+    let components = tokenSelection.split(separator: ":")
+    guard components.count == 2 else {
+      throw SDKError.invalidParameter("Invalid token selection format")
     }
+
+    let contractId = String(components[0])
+
+    guard let targetIdentityId = formInputs["targetIdentityId"], !targetIdentityId.isEmpty else {
+      throw SDKError.invalidParameter("Target identity ID is required")
+    }
+
+    // Use the DPPIdentity for freezing
+    let dppIdentity = DPPIdentity(
+      id: identity.id,
+      publicKeys: Dictionary(uniqueKeysWithValues: identity.publicKeys.map { ($0.id, $0) }),
+      balance: identity.balance,
+      revision: 0
+    )
+
+    // Use KeyManager to create token operation signer
+    let keyManager = await MainActor.run { KeyManager.withSharedKeychain() }
+    let (freezingKey, signer) = try await createTokenOperationSigner(for: dppIdentity)
+    defer {
+      keyManager.destroySigner(signer)
+    }
+
+    let note = formInputs["note"]?.isEmpty == false ? formInputs["note"] : nil
+
+    let result = try await sdk.tokenFreeze(
+      contractId: contractId,
+      targetIdentityId: targetIdentityId,
+      ownerIdentity: dppIdentity,
+      keyId: freezingKey.id,
+      signer: signer,
+      note: note
+    )
+
+    return result
+  }
+
+  private func executeTokenUnfreeze(sdk: SDK) async throws -> Any {
+    guard !selectedIdentityId.isEmpty,
+          let identity = appState.platformState.identities.first(where: { $0.idString == selectedIdentityId }) else {
+      throw SDKError.invalidParameter("No identity selected")
+    }
+
+    // Parse the token selection (format: "contractId:position")
+    guard let tokenSelection = formInputs["token"], !tokenSelection.isEmpty else {
+      throw SDKError.invalidParameter("No token selected")
+    }
+
+    let components = tokenSelection.split(separator: ":")
+    guard components.count == 2 else {
+      throw SDKError.invalidParameter("Invalid token selection format")
+    }
+
+    let contractId = String(components[0])
+
+    guard let targetIdentityId = formInputs["targetIdentityId"], !targetIdentityId.isEmpty else {
+      throw SDKError.invalidParameter("Target identity ID is required")
+    }
+
+    // Use the DPPIdentity for unfreezing
+    let dppIdentity = DPPIdentity(
+      id: identity.id,
+      publicKeys: Dictionary(uniqueKeysWithValues: identity.publicKeys.map { ($0.id, $0) }),
+      balance: identity.balance,
+      revision: 0
+    )
+
+    // Use KeyManager to create token operation signer
+    let keyManager = await MainActor.run { KeyManager.withSharedKeychain() }
+    let (unfreezingKey, signer) = try await createTokenOperationSigner(for: dppIdentity)
+    defer {
+      keyManager.destroySigner(signer)
+    }
+
+    let result = try await sdk.tokenUnfreeze(
+      contractId: contractId,
+      targetIdentityId: targetIdentityId,
+      ownerIdentity: dppIdentity,
+      keyId: unfreezingKey.id,
+      signer: signer,
+      note: formInputs["note"]
+    )
+
+    return result
+  }
+
+  private func executeTokenDestroyFrozenFunds(sdk: SDK) async throws -> Any {
+    guard !selectedIdentityId.isEmpty,
+          let identity = appState.platformState.identities.first(where: { $0.idString == selectedIdentityId }) else {
+      throw SDKError.invalidParameter("No identity selected")
+    }
+
+    // Parse the token selection (format: "contractId:position")
+    guard let tokenSelection = formInputs["token"], !tokenSelection.isEmpty else {
+      throw SDKError.invalidParameter("No token selected")
+    }
+
+    let components = tokenSelection.split(separator: ":")
+    guard components.count == 2 else {
+      throw SDKError.invalidParameter("Invalid token selection format")
+    }
+
+    let contractId = String(components[0])
+
+    guard let frozenIdentityId = formInputs["frozenIdentityId"], !frozenIdentityId.isEmpty else {
+      throw SDKError.invalidParameter("Frozen identity ID is required")
+    }
+
+    // Use the DPPIdentity for destroying frozen funds
+    let dppIdentity = DPPIdentity(
+      id: identity.id,
+      publicKeys: Dictionary(uniqueKeysWithValues: identity.publicKeys.map { ($0.id, $0) }),
+      balance: identity.balance,
+      revision: 0
+    )
+
+    // Use KeyManager to create token operation signer
+    let keyManager = await MainActor.run { KeyManager.withSharedKeychain() }
+    let (destroyKey, signer) = try await createTokenOperationSigner(for: dppIdentity)
+    defer {
+      keyManager.destroySigner(signer)
+    }
+
+    let result = try await sdk.tokenDestroyFrozenFunds(
+      contractId: contractId,
+      frozenIdentityId: frozenIdentityId,
+      ownerIdentity: dppIdentity,
+      keyId: destroyKey.id,
+      signer: signer,
+      note: formInputs["note"]
+    )
+
+    return result
+  }
+
+  private func executeTokenClaim(sdk: SDK) async throws -> Any {
+    guard !selectedIdentityId.isEmpty,
+          let identity = appState.platformState.identities.first(where: { $0.idString == selectedIdentityId }) else {
+      throw SDKError.invalidParameter("No identity selected")
+    }
+
+    // Parse the token selection (format: "contractId:position")
+    guard let tokenSelection = formInputs["token"], !tokenSelection.isEmpty else {
+      throw SDKError.invalidParameter("No token selected")
+    }
+
+    let components = tokenSelection.split(separator: ":")
+    guard components.count == 2 else {
+      throw SDKError.invalidParameter("Invalid token selection format")
+    }
+
+    let contractId = String(components[0])
+
+    guard let distributionType = formInputs["distributionType"], !distributionType.isEmpty else {
+      throw SDKError.invalidParameter("Distribution type is required")
+    }
+
+    // Use the DPPIdentity for claiming
+    let dppIdentity = DPPIdentity(
+      id: identity.id,
+      publicKeys: Dictionary(uniqueKeysWithValues: identity.publicKeys.map { ($0.id, $0) }),
+      balance: identity.balance,
+      revision: 0
+    )
+
+    // Use KeyManager to create token operation signer
+    let keyManager = await MainActor.run { KeyManager.withSharedKeychain() }
+    let (claimingKey, signer) = try await createTokenOperationSigner(for: dppIdentity)
+    defer {
+      keyManager.destroySigner(signer)
+    }
+
+    let note = formInputs["publicNote"]?.isEmpty == false ? formInputs["publicNote"] : nil
+
+    let result = try await sdk.tokenClaim(
+      contractId: contractId,
+      distributionType: distributionType,
+      ownerIdentity: dppIdentity,
+      keyId: claimingKey.id,
+      signer: signer,
+      note: note
+    )
+
+    return result
+  }
+
+  private func executeTokenTransfer(sdk: SDK) async throws -> Any {
+    guard !selectedIdentityId.isEmpty,
+          let identity = appState.platformState.identities.first(where: { $0.idString == selectedIdentityId }) else {
+      throw SDKError.invalidParameter("No identity selected")
+    }
+
+    // Parse the token selection (format: "contractId:position")
+    guard let tokenSelection = formInputs["token"], !tokenSelection.isEmpty else {
+      throw SDKError.invalidParameter("No token selected")
+    }
+
+    let components = tokenSelection.split(separator: ":")
+    guard components.count == 2 else {
+      throw SDKError.invalidParameter("Invalid token selection format")
+    }
+
+    let contractId = String(components[0])
+
+    guard let recipientId = formInputs["recipientId"], !recipientId.isEmpty else {
+      throw SDKError.invalidParameter("Recipient identity ID is required")
+    }
+
+    guard let amountString = formInputs["amount"], !amountString.isEmpty else {
+      throw SDKError.invalidParameter("Amount is required")
+    }
+
+    // Parse amount based on whether it contains a decimal
+    let amount: UInt64
+    if amountString.contains(".") {
+      // Handle decimal input (e.g., "1.5" tokens)
+      guard let doubleValue = Double(amountString) else {
+        throw SDKError.invalidParameter("Invalid amount format")
+      }
+      // Convert to smallest unit (assuming 8 decimal places like Dash)
+      amount = UInt64(doubleValue * 100_000_000)
+    } else {
+      // Handle integer input
+      guard let intValue = UInt64(amountString) else {
+        throw SDKError.invalidParameter("Invalid amount format")
+      }
+      amount = intValue
+    }
+
+    // Use the DPPIdentity for transfer
+    let dppIdentity = DPPIdentity(
+      id: identity.id,
+      publicKeys: Dictionary(uniqueKeysWithValues: identity.publicKeys.map { ($0.id, $0) }),
+      balance: identity.balance,
+      revision: 0
+    )
+
+    // Use KeyManager to create token operation signer
+    let keyManager = await MainActor.run { KeyManager.withSharedKeychain() }
+    let (transferKey, signer) = try await createTokenOperationSigner(for: dppIdentity)
+    defer {
+      keyManager.destroySigner(signer)
+    }
+
+    let note = formInputs["note"]?.isEmpty == false ? formInputs["note"] : nil
+
+    let result = try await sdk.tokenTransfer(
+      contractId: contractId,
+      recipientId: recipientId,
+      amount: amount,
+      ownerIdentity: dppIdentity,
+      keyId: transferKey.id,
+      signer: signer,
+      note: note
+    )
+
+    return result
+  }
+
+  private func executeTokenSetPrice(sdk: SDK) async throws -> Any {
+    guard !selectedIdentityId.isEmpty,
+          let identity = appState.platformState.identities.first(where: { $0.idString == selectedIdentityId }) else {
+      throw SDKError.invalidParameter("No identity selected")
+    }
+
+    // Parse the token selection (format: "contractId:position")
+    guard let tokenSelection = formInputs["token"], !tokenSelection.isEmpty else {
+      throw SDKError.invalidParameter("No token selected")
+    }
+
+    let components = tokenSelection.split(separator: ":")
+    guard components.count == 2 else {
+      throw SDKError.invalidParameter("Invalid token selection format")
+    }
+
+    let contractId = String(components[0])
+
+    guard let priceType = formInputs["priceType"], !priceType.isEmpty else {
+      throw SDKError.invalidParameter("Price type is required")
+    }
+
+    // Price data is optional - empty means remove pricing
+    let priceData = formInputs["priceData"]?.isEmpty == false ? formInputs["priceData"] : nil
+
+    // Use the DPPIdentity for setting price
+    let dppIdentity = DPPIdentity(
+      id: identity.id,
+      publicKeys: Dictionary(uniqueKeysWithValues: identity.publicKeys.map { ($0.id, $0) }),
+      balance: identity.balance,
+      revision: 0
+    )
+
+    // Use KeyManager to create token operation signer
+    let keyManager = await MainActor.run { KeyManager.withSharedKeychain() }
+    let (pricingKey, signer) = try await createTokenOperationSigner(for: dppIdentity)
+    defer {
+      keyManager.destroySigner(signer)
+    }
+
+    let note = formInputs["publicNote"]?.isEmpty == false ? formInputs["publicNote"] : nil
+
+    let result = try await sdk.tokenSetPrice(
+      contractId: contractId,
+      pricingType: priceType,
+      priceData: priceData,
+      ownerIdentity: dppIdentity,
+      keyId: pricingKey.id,
+      signer: signer,
+      note: note
+    )
+
+    return result
+  }
+
+  private func executeDataContractCreate(sdk: SDK) async throws -> Any {
+    guard !selectedIdentityId.isEmpty,
+          let ownerIdentity = appState.platformState.identities.first(where: { $0.idString == selectedIdentityId }) else {
+      throw SDKError.invalidParameter("No identity selected")
+    }
+
+    // Parse document schemas if provided
+    var documentSchemas: [String: Any]? = nil
+    if let schemasJson = formInputs["documentSchemas"], !schemasJson.isEmpty {
+      guard let data = schemasJson.data(using: .utf8),
+            let parsed = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+        throw SDKError.serializationError("Invalid document schemas JSON")
+      }
+      documentSchemas = parsed
+    }
+
+    // Parse token schemas if provided
+    var tokenSchemas: [String: Any]? = nil
+    if let tokensJson = formInputs["tokenSchemas"], !tokensJson.isEmpty {
+      guard let data = tokensJson.data(using: .utf8),
+            let parsed = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+        throw SDKError.serializationError("Invalid token schemas JSON")
+      }
+      tokenSchemas = parsed
+    }
+
+    // Parse groups if provided
+    var groups: [[String: Any]]? = nil
+    if let groupsJson = formInputs["groups"], !groupsJson.isEmpty {
+      guard let data = groupsJson.data(using: .utf8),
+            let parsed = try? JSONSerialization.jsonObject(with: data) as? [[String: Any]] else {
+        throw SDKError.serializationError("Invalid groups JSON")
+      }
+      groups = parsed
+    }
+
+    // Build contract configuration
+    var contractConfig: [String: Any] = [:]
+
+    // Add boolean configurations
+    if formInputs["canBeDeleted"] == "true" {
+      contractConfig["canBeDeleted"] = true
+    }
+    if formInputs["readonly"] == "true" {
+      contractConfig["readonly"] = true
+    }
+    if formInputs["keepsHistory"] == "true" {
+      contractConfig["keepsHistory"] = true
+    }
+    if formInputs["documentsKeepHistoryContractDefault"] == "true" {
+      contractConfig["documentsKeepHistoryContractDefault"] = true
+    }
+    if formInputs["documentsMutableContractDefault"] == "true" {
+      contractConfig["documentsMutableContractDefault"] = true
+    }
+    if formInputs["documentsCanBeDeletedContractDefault"] == "true" {
+      contractConfig["documentsCanBeDeletedContractDefault"] = true
+    }
+    if formInputs["requiresIdentityEncryptionBoundedKey"] == "true" {
+      contractConfig["requiresIdentityEncryptionBoundedKey"] = true
+    }
+    if formInputs["requiresIdentityDecryptionBoundedKey"] == "true" {
+      contractConfig["requiresIdentityDecryptionBoundedKey"] = true
+    }
+
+    // Add optional text fields
+    if let keywords = formInputs["keywords"], !keywords.isEmpty {
+      contractConfig["keywords"] = keywords.split(separator: ",").map { $0.trimmingCharacters(in: .whitespaces) }
+    }
+    if let description = formInputs["description"], !description.isEmpty {
+      contractConfig["description"] = description
+    }
+
+    // Validate that at least one schema is provided
+    if documentSchemas == nil && tokenSchemas == nil {
+      throw SDKError.invalidParameter("At least one document schema or token schema must be provided")
+    }
+
+    // Use the DPPIdentity for contract creation
+    let dppIdentity = DPPIdentity(
+      id: ownerIdentity.id,
+      publicKeys: Dictionary(uniqueKeysWithValues: ownerIdentity.publicKeys.map { ($0.id, $0) }),
+      balance: ownerIdentity.balance,
+      revision: 0
+    )
+
+    // Use KeyManager to create contract signer (requires CRITICAL + AUTHENTICATION)
+    let keyManager = await MainActor.run { KeyManager.withSharedKeychain() }
+    let (signingKey, signer) = try await MainActor.run {
+      try keyManager.createContractSigner(for: dppIdentity)
+    }
+    defer {
+      keyManager.destroySigner(signer)
+    }
+
+    let result = try await sdk.dataContractCreate(
+      identity: dppIdentity,
+      documentSchemas: documentSchemas,
+      tokenSchemas: tokenSchemas,
+      groups: groups,
+      contractConfig: contractConfig,
+      signer: signer
+    )
+
+    return result
+  }
+
+  private func executeDataContractUpdate(sdk: SDK) async throws -> Any {
+    guard let contractId = formInputs["dataContractId"], !contractId.isEmpty else {
+      throw SDKError.invalidParameter("Data contract ID is required")
+    }
+
+    guard !selectedIdentityId.isEmpty,
+          let ownerIdentity = appState.platformState.identities.first(where: { $0.idString == selectedIdentityId }) else {
+      throw SDKError.invalidParameter("No identity selected")
+    }
+
+    // Parse new document schemas if provided
+    var newDocumentSchemas: [String: Any]? = nil
+    if let schemasJson = formInputs["newDocumentSchemas"], !schemasJson.isEmpty {
+      guard let data = schemasJson.data(using: .utf8),
+            let parsed = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+        throw SDKError.serializationError("Invalid document schemas JSON")
+      }
+      newDocumentSchemas = parsed
+    }
+
+    // Parse new token schemas if provided
+    var newTokenSchemas: [String: Any]? = nil
+    if let tokensJson = formInputs["newTokenSchemas"], !tokensJson.isEmpty {
+      guard let data = tokensJson.data(using: .utf8),
+            let parsed = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+        throw SDKError.serializationError("Invalid token schemas JSON")
+      }
+      newTokenSchemas = parsed
+    }
+
+    // Parse new groups if provided
+    var newGroups: [[String: Any]]? = nil
+    if let groupsJson = formInputs["newGroups"], !groupsJson.isEmpty {
+      guard let data = groupsJson.data(using: .utf8),
+            let parsed = try? JSONSerialization.jsonObject(with: data) as? [[String: Any]] else {
+        throw SDKError.serializationError("Invalid groups JSON")
+      }
+      newGroups = parsed
+    }
+
+    // Validate that at least one update is provided
+    if newDocumentSchemas == nil && newTokenSchemas == nil && newGroups == nil {
+      throw SDKError.invalidParameter("At least one update (document schemas, token schemas, or groups) must be provided")
+    }
+
+    // Use the DPPIdentity for contract update
+    let dppIdentity = DPPIdentity(
+      id: ownerIdentity.id,
+      publicKeys: Dictionary(uniqueKeysWithValues: ownerIdentity.publicKeys.map { ($0.id, $0) }),
+      balance: ownerIdentity.balance,
+      revision: 0
+    )
+
+    // Use KeyManager to create contract signer (requires CRITICAL + AUTHENTICATION)
+    let keyManager = await MainActor.run { KeyManager.withSharedKeychain() }
+    let (signingKey, signer) = try await MainActor.run {
+      try keyManager.createContractSigner(for: dppIdentity)
+    }
+    defer {
+      keyManager.destroySigner(signer)
+    }
+
+    let result = try await sdk.dataContractUpdate(
+      contractId: contractId,
+      identity: dppIdentity,
+      newDocumentSchemas: newDocumentSchemas,
+      newTokenSchemas: newTokenSchemas,
+      newGroups: newGroups,
+      signer: signer
+    )
+
+    return result
+  }
+
+  // MARK: - Helper Functions
+
+  /// Helper function to create a signer for token operations (requires critical owner or authentication key)
+  @MainActor
+  private func createTokenOperationSigner(for identity: DPPIdentity) throws -> (key: IdentityPublicKey, signer: OpaquePointer) {
+    let keyManager = KeyManager.withSharedKeychain()
+
+    // Try owner purpose first
+    if let (key, sig) = try? keyManager.createSignerForKey(
+      for: identity,
+      purpose: .owner,
+      minimumSecurityLevel: .critical,
+      preferCritical: true
+    ) {
+      return (key, sig)
+    }
+
+    // Fall back to authentication
+    return try keyManager.createSignerForKey(
+      for: identity,
+      purpose: .authentication,
+      minimumSecurityLevel: .critical,
+      preferCritical: true
+    )
+  }
+
+  private func enrichedInput(for input: TransitionInput) -> TransitionInput {
+    // For document type picker, pass the selected contract ID in placeholder
+    if input.name == "documentType" && input.type == "documentTypePicker" {
+      return TransitionInput(
+        name: input.name,
+        type: input.type,
+        label: input.label,
+        required: input.required,
+        placeholder: selectedContractId.isEmpty ? formInputs["contractId"] : selectedContractId,
+        help: input.help,
+        defaultValue: input.defaultValue,
+        options: input.options,
+        action: "transition:\(transitionKey)",  // Pass the transition context
+        min: input.min,
+        max: input.max
+      )
+    }
+
+    // For documentWithPrice picker, pass contract, document type, and identity ID in action field
+    if input.type == "documentWithPrice" {
+      let contractId = formInputs["contractId"] ?? ""
+      let documentType = formInputs["documentType"] ?? ""
+      let identityId = selectedIdentityId
+      return TransitionInput(
+        name: input.name,
+        type: input.type,
+        label: input.label,
+        required: input.required,
+        placeholder: input.placeholder,
+        help: input.help,
+        defaultValue: input.defaultValue,
+        options: input.options,
+        action: "\(contractId)|\(documentType)|\(identityId)",  // Pass all values separated by |
+        min: input.min,
+        max: input.max
+      )
+    }
+
+    // For contract picker, pass the transition context
+    if input.name == "contractId" && input.type == "contractPicker" {
+      return TransitionInput(
+        name: input.name,
+        type: input.type,
+        label: input.label,
+        required: input.required,
+        placeholder: input.placeholder,
+        help: input.help,
+        defaultValue: input.defaultValue,
+        options: input.options,
+        action: "transition:\(transitionKey)",  // Pass the transition context
+        min: input.min,
+        max: input.max
+      )
+    }
+
+    // For recipient identity picker in credit transfer, pass the sender identity ID
+    // Pass sender identity ID to exclude it from recipients for transfers
+    if (input.name == "toIdentityId" && input.type == "identityPicker" && transitionKey == "identityCreditTransfer") ||
+        (input.name == "recipientId" && input.type == "identityPicker" && transitionKey == "documentTransfer") {
+      return TransitionInput(
+        name: input.name,
+        type: input.type,
+        label: input.label,
+        required: input.required,
+        placeholder: selectedIdentityId,  // Pass sender identity ID to exclude it from recipients
+        help: input.help,
+        defaultValue: input.defaultValue,
+        options: input.options,
+        action: input.action,
+        min: input.min,
+        max: input.max
+      )
+    }
+
+    return input
+  }
+
+  private func fetchDocumentSchema(contractId: String, documentType: String) {
+    // TODO: Implement fetching schema and generating dynamic form
+    // For now, provide a template based on common patterns
+    var schemaTemplate = "{\n"
+
+    // Common document type templates
+    switch documentType.lowercased() {
+    case "note", "message":
+      schemaTemplate += "  \"message\": \"Enter your message here\"\n"
+    case "profile", "user":
+      schemaTemplate += "  \"displayName\": \"John Doe\",\n"
+      schemaTemplate += "  \"bio\": \"About me...\"\n"
+    case "post":
+      schemaTemplate += "  \"title\": \"Post title\",\n"
+      schemaTemplate += "  \"content\": \"Post content...\"\n"
+    default:
+      schemaTemplate += "  // Add document fields here\n"
+    }
+
+    schemaTemplate += "}"
+    formInputs["documentFields"] = schemaTemplate
+  }
+
+  private func normalizeIdentityId(_ identityId: String) -> String {
+    // Remove any prefix
+    let cleanId = identityId
+      .replacingOccurrences(of: "id:", with: "")
+      .replacingOccurrences(of: "0x", with: "")
+      .trimmingCharacters(in: .whitespacesAndNewlines)
+
+    // If it's hex (64 chars), convert to base58
+    if cleanId.count == 64, let data = Data(hexString: cleanId) {
+      return data.toBase58String()
+    }
+
+    // Otherwise assume it's already base58
+    return cleanId
+  }
 }
 
 // Extension for IdentityModel display name
 extension IdentityModel {
-    var displayName: String {
-        if let alias = alias, !alias.isEmpty {
-            return alias
-        } else if let mainDpnsName = mainDpnsName, !mainDpnsName.isEmpty {
-            return mainDpnsName
-        } else if let dpnsName = dpnsName, !dpnsName.isEmpty {
-            return dpnsName
-        } else {
-            return String(idHexString.prefix(12)) + "..."
-        }
+  var displayName: String {
+    if let alias = alias, !alias.isEmpty {
+      return alias
+    } else if let mainDpnsName = mainDpnsName, !mainDpnsName.isEmpty {
+      return mainDpnsName
+    } else if let dpnsName = dpnsName, !dpnsName.isEmpty {
+      return dpnsName
+    } else {
+      return String(idHexString.prefix(12)) + "..."
     }
+  }
 }


### PR DESCRIPTION
!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

refactor: extract key management logic into centralized KeyManager

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This PR implements **Phase 3** of the refactoring plan: Extract Key Management. Key management logic was duplicated across 24+ methods in multiple views, making it difficult to maintain, test, and ensure consistent behavior. This change centralizes all key operations into a single `KeyManager` class.

**Problems solved:**
- Key selection logic was duplicated across 22 execute methods in `TransitionDetailView`
- Inconsistent error handling for key operations
- Hard to test key management logic embedded in views
- Security-critical code scattered across multiple files
- Changes to key selection logic required updating 20+ places

## What was done?
<!--- Describe your changes in detail -->

### 1. Created `KeyManager.swift` (`Sources/SwiftDashSDK/KeyWallet/KeyManager.swift`)
   - **Key Selection Methods:**
     - `getTransferKey(for:)` - finds transfer keys (prefers critical)
     - `getAuthenticationKey(for:)` - finds authentication keys (prefers critical)
     - `getKeyByPurpose(for:purpose:)` - finds keys by specific purpose
     - `findKey(for:purpose:minimumSecurityLevel:preferCritical:)` - flexible key finding with security level requirements
     - `findKeyWithPrivateKey(...)` - finds key with available private key in keychain
   
   - **Signer Creation Methods:**
     - `createSigner(from:)` - creates signer from private key data
     - `createSigner(for:keyIndex:)` - creates signer for specific key
     - `createTransferSigner(for:)` - convenience for transfer operations
     - `createAuthenticationSigner(for:)` - convenience for authentication operations
     - `createDocumentSigner(for:minimumSecurityLevel:)` - for document operations (requires AUTHENTICATION purpose)
     - `createContractSigner(for:)` - for contract operations (requires CRITICAL + AUTHENTICATION)
     - `createSignerForKey(...)` - flexible signer creation with purpose/security requirements
     - `destroySigner(_:)` - cleanup method
   
   - **Key Validation:**
     - `validatePrivateKey(_:matches:isTestnet:)` - validates private key matches public key
     - `validatePrivateKeyFormat(_:)` - validates key format (32 bytes)
   
   - **Error Handling:**
     - `KeyManagerError` enum with descriptive error messages for all key operations

### 2. Refactored `TransitionDetailView.swift` (22 execute methods)
   All methods now use `KeyManager` instead of direct `KeychainManager` calls:
   
   - **Identity Operations:**
     - `executeIdentityCreditTransfer` - uses `createTransferSigner`
     - `executeIdentityCreditWithdrawal` - uses `createTransferSigner`
   
   - **Document Operations:**
     - `executeDocumentCreate` - uses `createDocumentSigner` with security level requirements
     - `executeDocumentDelete` - uses `createSignerForKey` (authentication)
     - `executeDocumentTransfer` - uses `createSignerForKey` (authentication)
     - `executeDocumentUpdatePrice` - uses `createSignerForKey` (authentication)
     - `executeDocumentPurchase` - uses `createSignerForKey`
     - `executeDocumentReplace` - uses `createDocumentSigner` with security level requirements
   
   - **Token Operations:**
     - `executeTokenMint` - uses helper for critical owner/authentication key
     - `executeTokenBurn` - uses helper for critical owner/authentication key
     - `executeTokenFreeze` - uses helper for critical owner/authentication key
     - `executeTokenUnfreeze` - uses helper for critical owner/authentication key
     - `executeTokenDestroyFrozenFunds` - uses helper for critical owner/authentication key
     - `executeTokenClaim` - uses helper for critical owner/authentication key
     - `executeTokenTransfer` - uses helper for critical owner/authentication key
     - `executeTokenSetPrice` - uses helper for critical owner/authentication key
   
   - **Contract Operations:**
     - `executeDataContractCreate` - uses `createContractSigner` (CRITICAL + AUTHENTICATION)
     - `executeDataContractUpdate` - uses `createContractSigner` (CRITICAL + AUTHENTICATION)
   
   - **Helper Function:**
     - Added `createTokenOperationSigner(for:)` helper for token operations requiring critical owner/authentication keys

### 3. Refactored Other Views
   - **`RegisterNameView.swift`:**
     - Replaced manual key finding loop with `KeyManager.findKeyWithPrivateKey`
     - Replaced manual signer creation with `KeyManager.createSigner`
   
   - **`KeysListView.swift`:**
     - Updated `getPrivateKey(for:)` to use `KeyManager.getPrivateKey`

### 4. Code Cleanup
   - Removed ~500+ lines of duplicated key-finding and signer-creation code
   - Removed all direct calls to `KeychainManager.shared.retrievePrivateKey` from views
   - Removed all direct calls to `dash_sdk_signer_create_from_private_key` from views
   - Consistent error messages through `KeyManagerError`

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

### Test Execution
- **All unit tests pass:** 0 failed, only expected skipped tests
- **All integration tests pass:** Credit transfer, identity operations, document operations
- **All UI tests pass:** Launch tests and example UI tests
- **Build succeeds:** No compilation errors

### Test Results Summary

✅ All test suites passed
✅ TransactionTests: 7 passed, 3 skipped (expected)
✅ DebugTests: 8 passed
✅ CrashDebugTests: 2 passed
✅ MinimalAsyncTest: 4 passed
✅ StateTransitionTests: All skipped (expected - require env vars)
✅ SimpleTransitionTests: All skipped (expected - require env vars)
✅ UI Tests: All passed