### PR TITLE
feat(swift-sdk): update iOS build destination to use generic simulator

### DIFF
--- a/packages/rs-dapi/Cargo.toml
+++ b/packages/rs-dapi/Cargo.toml
@@ -87,8 +87,8 @@ prometheus = "0.14"
 once_cell = "1.19"
 
 # Dash Core RPC client
-dashcore-rpc = { path = "../../../rust-dashcore/rpc-client" }
-dash-spv = { path = "../../../rust-dashcore/dash-spv" }
+dashcore-rpc = { git = "https://github.com/dashpay/rust-dashcore", rev = "3202614f145b847c5cf9aeecf76139c21ce04e9b" }
+dash-spv = { git = "https://github.com/dashpay/rust-dashcore", rev = "3202614f145b847c5cf9aeecf76139c21ce04e9b" }
 
 rs-dash-event-bus = { path = "../rs-dash-event-bus" }
 

--- a/packages/rs-dpp/Cargo.toml
+++ b/packages/rs-dpp/Cargo.toml
@@ -24,7 +24,7 @@ chrono = { version = "0.4.35", default-features = false, features = [
 ] }
 chrono-tz = { version = "0.8", optional = true }
 ciborium = { version = "0.2.2", optional = true }
-dashcore = { path = "../../../rust-dashcore/dash", features = [
+dashcore = { git = "https://github.com/dashpay/rust-dashcore", rev = "3202614f145b847c5cf9aeecf76139c21ce04e9b", features = [
   "std",
   "secp-recovery",
   "rand",
@@ -32,10 +32,10 @@ dashcore = { path = "../../../rust-dashcore/dash", features = [
   "serde",
   "eddsa",
 ], default-features = false }
-key-wallet = { path = "../../../rust-dashcore/key-wallet", optional = true }
-key-wallet-manager = { path = "../../../rust-dashcore/key-wallet-manager", optional = true }
-dash-spv = { path = "../../../rust-dashcore/dash-spv", optional = true }
-dashcore-rpc = { path = "../../../rust-dashcore/rpc-client", optional = true }
+key-wallet = { git = "https://github.com/dashpay/rust-dashcore", rev = "3202614f145b847c5cf9aeecf76139c21ce04e9b", optional = true }
+key-wallet-manager = { git = "https://github.com/dashpay/rust-dashcore", rev = "3202614f145b847c5cf9aeecf76139c21ce04e9b", optional = true }
+dash-spv = { git = "https://github.com/dashpay/rust-dashcore", rev = "3202614f145b847c5cf9aeecf76139c21ce04e9b", optional = true }
+dashcore-rpc = { git = "https://github.com/dashpay/rust-dashcore", rev = "3202614f145b847c5cf9aeecf76139c21ce04e9b", optional = true }
 
 env_logger = { version = "0.11" }
 getrandom = { version = "0.2", features = ["js"] }

--- a/packages/rs-platform-encryption/Cargo.toml
+++ b/packages/rs-platform-encryption/Cargo.toml
@@ -8,7 +8,7 @@ description = "Cryptographic utilities for Dash Platform (DIP-15 DashPay encrypt
 
 [dependencies]
 # Cryptography
-dashcore = { path = "../../../rust-dashcore/dash" }
+dashcore = { git = "https://github.com/dashpay/rust-dashcore", rev = "3202614f145b847c5cf9aeecf76139c21ce04e9b" }
 aes = "0.8"
 cbc = "0.1"
 sha2 = "0.10"

--- a/packages/rs-platform-wallet-ffi/Cargo.toml
+++ b/packages/rs-platform-wallet-ffi/Cargo.toml
@@ -23,8 +23,8 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 
 # Core dependencies (for Network type)
-dashcore = { path = "../../../rust-dashcore/dash" }
-key-wallet = { path = "../../../rust-dashcore/key-wallet" }
+dashcore = { git = "https://github.com/dashpay/rust-dashcore", rev = "3202614f145b847c5cf9aeecf76139c21ce04e9b" }
+key-wallet = { git = "https://github.com/dashpay/rust-dashcore", rev = "3202614f145b847c5cf9aeecf76139c21ce04e9b" }
 
 # Error handling
 thiserror = "1.0"

--- a/packages/rs-platform-wallet/Cargo.toml
+++ b/packages/rs-platform-wallet/Cargo.toml
@@ -13,11 +13,11 @@ dash-sdk = { path = "../rs-sdk", default-features = false, features = ["dashpay-
 platform-encryption = { path = "../rs-platform-encryption" }
 
 # Key wallet dependencies (from rust-dashcore)
-key-wallet = { path = "../../../rust-dashcore/key-wallet" }
-key-wallet-manager = { path = "../../../rust-dashcore/key-wallet-manager", optional = true }
+key-wallet = { git = "https://github.com/dashpay/rust-dashcore", rev = "3202614f145b847c5cf9aeecf76139c21ce04e9b" }
+key-wallet-manager = { git = "https://github.com/dashpay/rust-dashcore", rev = "3202614f145b847c5cf9aeecf76139c21ce04e9b", optional = true }
 
 # Core dependencies
-dashcore = { path = "../../../rust-dashcore/dash" }
+dashcore = { git = "https://github.com/dashpay/rust-dashcore", rev = "3202614f145b847c5cf9aeecf76139c21ce04e9b" }
 
 # Standard dependencies
 thiserror = "1.0"

--- a/packages/rs-sdk-ffi/Cargo.toml
+++ b/packages/rs-sdk-ffi/Cargo.toml
@@ -23,7 +23,7 @@ simple-signer = { path = "../simple-signer" }
 
 
 # Core SDK integration (always included for unified SDK)
-dash-spv-ffi = { path = "../../../rust-dashcore/dash-spv-ffi", optional = true }
+dash-spv-ffi = { git = "https://github.com/dashpay/rust-dashcore", rev = "3202614f145b847c5cf9aeecf76139c21ce04e9b", optional = true }
 
 # Platform Wallet integration for DashPay support
 platform-wallet-ffi = { path = "../rs-platform-wallet-ffi" }

--- a/packages/rs-sdk-ffi/build_ios.sh
+++ b/packages/rs-sdk-ffi/build_ios.sh
@@ -218,8 +218,8 @@ typedef struct FFIAccountCollection { unsigned char _private[0]; } FFIAccountCol
 typedef struct FFIBLSAccount { unsigned char _private[0]; } FFIBLSAccount;
 typedef struct FFIEdDSAAccount { unsigned char _private[0]; } FFIEdDSAAccount;
 typedef struct FFIAddressPool { unsigned char _private[0]; } FFIAddressPool;
-typedef struct FFIManagedAccountCollection { unsigned char _private[0]; } FFIManagedAccountCollection;
-typedef struct FFIManagedAccount { unsigned char _private[0]; } FFIManagedAccount;
+typedef struct FFIManagedCoreAccountCollection { unsigned char _private[0]; } FFIManagedCoreAccountCollection;
+typedef struct FFIManagedCoreAccount { unsigned char _private[0]; } FFIManagedCoreAccount;
 // Platform SDK opaque handles
 typedef struct SDKHandle { unsigned char _private[0]; } SDKHandle;
 typedef struct DataContractHandle { unsigned char _private[0]; } DataContractHandle;

--- a/packages/rs-sdk-ffi/build_ios.sh
+++ b/packages/rs-sdk-ffi/build_ios.sh
@@ -13,13 +13,16 @@ PROJECT_NAME="rs_sdk_ffi"
 
 # Parse arguments
 BUILD_ARCH="${1:-arm}"
+CLEAN_BUILD=0
 
 # Parse command line arguments
 for arg in "$@"; do
     case $arg in
         arm|x86|universal)
             BUILD_ARCH="$arg"
-            shift
+            ;;
+        --clean)
+            CLEAN_BUILD=1
             ;;
     esac
 done
@@ -69,6 +72,34 @@ else
     # Default to ARM
     check_target "aarch64-apple-ios"
     check_target "aarch64-apple-ios-sim"
+fi
+
+# Detect if rust-dashcore has changed since last iOS build
+RUST_DASHCORE_DIR="$PROJECT_ROOT/../rust-dashcore"
+HASHFILE="$PROJECT_ROOT/target/.rust_dashcore_ios_hash"
+if [[ -d "$RUST_DASHCORE_DIR" ]]; then
+    CURRENT_HASH=$(find "$RUST_DASHCORE_DIR/dash/src" "$RUST_DASHCORE_DIR/key-wallet/src" "$RUST_DASHCORE_DIR/dash-spv/src" "$RUST_DASHCORE_DIR/dash-spv-ffi/src" "$RUST_DASHCORE_DIR/key-wallet-manager/src" -name '*.rs' 2>/dev/null | sort | xargs cat 2>/dev/null | shasum -a 256 | cut -d' ' -f1)
+    PREV_HASH=""
+    if [[ -f "$HASHFILE" ]]; then
+        PREV_HASH=$(cat "$HASHFILE")
+    fi
+    if [[ "$CURRENT_HASH" != "$PREV_HASH" ]]; then
+        echo -e "${YELLOW}rust-dashcore changes detected — cleaning cached iOS build artifacts${NC}"
+        CLEAN_BUILD=1
+    fi
+fi
+
+if [[ "$CLEAN_BUILD" -eq 1 ]]; then
+    echo -e "${GREEN}Cleaning rs-sdk-ffi and dependencies for iOS targets...${NC}"
+    cargo clean --release --target aarch64-apple-ios -p rs-sdk-ffi 2>/dev/null || true
+    cargo clean --release --target aarch64-apple-ios-sim -p rs-sdk-ffi 2>/dev/null || true
+    cargo clean --release --target x86_64-apple-ios -p rs-sdk-ffi 2>/dev/null || true
+    # Also clean path-dependency crates that cargo may cache
+    for pkg in dashcore key-wallet key-wallet-manager dash-spv dash-spv-ffi rs-platform-wallet rs-platform-wallet-ffi; do
+        cargo clean --release --target aarch64-apple-ios -p "$pkg" 2>/dev/null || true
+        cargo clean --release --target aarch64-apple-ios-sim -p "$pkg" 2>/dev/null || true
+        cargo clean --release --target x86_64-apple-ios -p "$pkg" 2>/dev/null || true
+    done
 fi
 
 # Build for iOS device (arm64) - always needed
@@ -470,6 +501,12 @@ else
     echo -e "${RED}✗ XCFramework creation failed${NC}"
     cat /tmp/xcframework.log
     exit 1
+fi
+
+# Save rust-dashcore hash so next build can detect changes
+if [[ -n "${CURRENT_HASH:-}" ]]; then
+    mkdir -p "$(dirname "$HASHFILE")"
+    echo "$CURRENT_HASH" > "$HASHFILE"
 fi
 
 echo -e "\n${GREEN}Build complete!${NC}"

--- a/packages/rs-sdk-ffi/build_ios.sh
+++ b/packages/rs-sdk-ffi/build_ios.sh
@@ -74,17 +74,17 @@ else
     check_target "aarch64-apple-ios-sim"
 fi
 
-# Detect if rust-dashcore has changed since last iOS build
+# Detect if rust-dashcore is a local path dependency and has changed since last iOS build
 RUST_DASHCORE_DIR="$PROJECT_ROOT/../rust-dashcore"
 HASHFILE="$PROJECT_ROOT/target/.rust_dashcore_ios_hash"
-if [[ -d "$RUST_DASHCORE_DIR" ]]; then
+if [[ -d "$RUST_DASHCORE_DIR" ]] && grep -q 'path.*rust-dashcore' "$PROJECT_ROOT/packages/rs-sdk-ffi/Cargo.toml" "$PROJECT_ROOT/packages/rs-dpp/Cargo.toml" 2>/dev/null; then
     CURRENT_HASH=$(find "$RUST_DASHCORE_DIR/dash/src" "$RUST_DASHCORE_DIR/key-wallet/src" "$RUST_DASHCORE_DIR/dash-spv/src" "$RUST_DASHCORE_DIR/dash-spv-ffi/src" "$RUST_DASHCORE_DIR/key-wallet-manager/src" -name '*.rs' 2>/dev/null | sort | xargs cat 2>/dev/null | shasum -a 256 | cut -d' ' -f1)
     PREV_HASH=""
     if [[ -f "$HASHFILE" ]]; then
         PREV_HASH=$(cat "$HASHFILE")
     fi
     if [[ "$CURRENT_HASH" != "$PREV_HASH" ]]; then
-        echo -e "${YELLOW}rust-dashcore changes detected — cleaning cached iOS build artifacts${NC}"
+        echo -e "${YELLOW}Local rust-dashcore changes detected — cleaning cached iOS build artifacts${NC}"
         CLEAN_BUILD=1
     fi
 fi

--- a/packages/swift-sdk/Sources/SwiftDashSDK/KeyWallet/KeyWalletTypes.swift
+++ b/packages/swift-sdk/Sources/SwiftDashSDK/KeyWallet/KeyWalletTypes.swift
@@ -413,7 +413,7 @@ public struct ManagedAccountCollectionSummary {
     public let hasProviderOperatorKeys: Bool
     public let hasProviderPlatformKeys: Bool
     
-    init(ffiSummary: FFIManagedAccountCollectionSummary) {
+    init(ffiSummary: FFIManagedCoreAccountCollectionSummary) {
         // Convert BIP44 indices
         if ffiSummary.bip44_count > 0, let indices = ffiSummary.bip44_indices {
             self.bip44Indices = Array(UnsafeBufferPointer(start: indices, count: ffiSummary.bip44_count))

--- a/packages/swift-sdk/Sources/SwiftDashSDK/KeyWallet/ManagedAccount.swift
+++ b/packages/swift-sdk/Sources/SwiftDashSDK/KeyWallet/ManagedAccount.swift
@@ -3,51 +3,51 @@ import DashSDKFFI
 
 /// Swift wrapper for a managed account with address pool management
 public class ManagedAccount {
-    internal let handle: UnsafeMutablePointer<FFIManagedAccount>
+    internal let handle: UnsafeMutablePointer<FFIManagedCoreAccount>
     private let manager: WalletManager
     
-    internal init(handle: UnsafeMutablePointer<FFIManagedAccount>, manager: WalletManager) {
+    internal init(handle: UnsafeMutablePointer<FFIManagedCoreAccount>, manager: WalletManager) {
         self.handle = handle
         self.manager = manager
     }
     
     deinit {
-        managed_account_free(handle)
+        managed_core_account_free(handle)
     }
     
     // MARK: - Properties
     
     /// Get the network this account is on
     public var network: KeyWalletNetwork {
-        let ffiNetwork = managed_account_get_network(handle)
+        let ffiNetwork = managed_core_account_get_network(handle)
         return KeyWalletNetwork(ffiNetwork: ffiNetwork)
     }
     
     /// Get the account type
     public var accountType: AccountType? {
         var index: UInt32 = 0
-        let ffiType = managed_account_get_account_type(handle, &index)
+        let ffiType = managed_core_account_get_account_type(handle, &index)
         return AccountType(ffiType: ffiType)
     }
     
     /// Check if this is a watch-only account
     public var isWatchOnly: Bool {
-        return managed_account_get_is_watch_only(handle)
+        return managed_core_account_get_is_watch_only(handle)
     }
     
     /// Get the account index
     public var index: UInt32 {
-        return managed_account_get_index(handle)
+        return managed_core_account_get_index(handle)
     }
     
     /// Get the transaction count
     public var transactionCount: UInt32 {
-        return managed_account_get_transaction_count(handle)
+        return managed_core_account_get_transaction_count(handle)
     }
     
     /// Get the UTXO count
     public var utxoCount: UInt32 {
-        return managed_account_get_utxo_count(handle)
+        return managed_core_account_get_utxo_count(handle)
     }
 
     // MARK: - Transactions
@@ -59,7 +59,7 @@ public class ManagedAccount {
         var transactionsPtr: UnsafeMutablePointer<FFITransactionRecord>?
         var count: size_t = 0
 
-        let success = managed_account_get_transactions(handle, &transactionsPtr, &count)
+        let success = managed_core_account_get_transactions(handle, &transactionsPtr, &count)
 
         guard success else {
             throw KeyWalletError.invalidState("Failed to get transactions from managed account")
@@ -71,7 +71,7 @@ public class ManagedAccount {
         }
 
         defer {
-            managed_account_free_transactions(transactionsPtr, count)
+            managed_core_account_free_transactions(transactionsPtr, count)
         }
 
         // Convert FFI transactions to Swift transactions
@@ -137,7 +137,7 @@ public class ManagedAccount {
     /// Get the balance for this account
     public func getBalance() throws -> Balance {
         var ffiBalance = FFIBalance()
-        let success = managed_account_get_balance(handle, &ffiBalance)
+        let success = managed_core_account_get_balance(handle, &ffiBalance)
         
         guard success else {
             throw KeyWalletError.invalidState("Failed to get balance for managed account")
@@ -150,7 +150,7 @@ public class ManagedAccount {
     
     /// Get the external address pool
     public func getExternalAddressPool() -> AddressPool? {
-        guard let poolHandle = managed_account_get_external_address_pool(handle) else {
+        guard let poolHandle = managed_core_account_get_external_address_pool(handle) else {
             return nil
         }
         return AddressPool(handle: poolHandle)
@@ -158,7 +158,7 @@ public class ManagedAccount {
     
     /// Get the internal address pool
     public func getInternalAddressPool() -> AddressPool? {
-        guard let poolHandle = managed_account_get_internal_address_pool(handle) else {
+        guard let poolHandle = managed_core_account_get_internal_address_pool(handle) else {
             return nil
         }
         return AddressPool(handle: poolHandle)
@@ -168,7 +168,7 @@ public class ManagedAccount {
     /// - Parameter poolType: The type of address pool to get
     /// - Returns: The address pool if it exists
     public func getAddressPool(type poolType: AddressPoolType) -> AddressPool? {
-        guard let poolHandle = managed_account_get_address_pool(handle, poolType.ffiValue) else {
+        guard let poolHandle = managed_core_account_get_address_pool(handle, poolType.ffiValue) else {
             return nil
         }
         return AddressPool(handle: poolHandle)

--- a/packages/swift-sdk/Sources/SwiftDashSDK/KeyWallet/ManagedAccountCollection.swift
+++ b/packages/swift-sdk/Sources/SwiftDashSDK/KeyWallet/ManagedAccountCollection.swift
@@ -3,10 +3,10 @@ import DashSDKFFI
 
 /// Swift wrapper for a collection of managed accounts
 public class ManagedAccountCollection {
-    private let handle: UnsafeMutablePointer<FFIManagedAccountCollection>
+    private let handle: UnsafeMutablePointer<FFIManagedCoreAccountCollection>
     private let manager: WalletManager
     
-    internal init(handle: UnsafeMutablePointer<FFIManagedAccountCollection>, manager: WalletManager) {
+    internal init(handle: UnsafeMutablePointer<FFIManagedCoreAccountCollection>, manager: WalletManager) {
         self.handle = handle
         self.manager = manager
     }
@@ -211,7 +211,7 @@ public class ManagedAccountCollection {
         guard let rawPointer = managed_account_collection_get_provider_operator_keys(handle) else {
             return nil
         }
-        let accountHandle = rawPointer.assumingMemoryBound(to: FFIManagedAccount.self)
+        let accountHandle = rawPointer.assumingMemoryBound(to: FFIManagedCoreAccount.self)
         return ManagedAccount(handle: accountHandle, manager: manager)
     }
     
@@ -225,7 +225,7 @@ public class ManagedAccountCollection {
         guard let rawPointer = managed_account_collection_get_provider_platform_keys(handle) else {
             return nil
         }
-        let accountHandle = rawPointer.assumingMemoryBound(to: FFIManagedAccount.self)
+        let accountHandle = rawPointer.assumingMemoryBound(to: FFIManagedCoreAccount.self)
         return ManagedAccount(handle: accountHandle, manager: manager)
     }
     

--- a/packages/swift-sdk/Sources/SwiftDashSDK/KeyWallet/WalletManager.swift
+++ b/packages/swift-sdk/Sources/SwiftDashSDK/KeyWallet/WalletManager.swift
@@ -431,7 +431,7 @@ public class WalletManager {
         
         defer {
             if result.error_message != nil {
-                managed_account_result_free_error(&result)
+                managed_core_account_result_free_error(&result)
             }
         }
         
@@ -461,7 +461,7 @@ public class WalletManager {
         
         defer {
             if result.error_message != nil {
-                managed_account_result_free_error(&result)
+                managed_core_account_result_free_error(&result)
             }
         }
         

--- a/packages/swift-sdk/SwiftExampleApp/test_account_collection.swift
+++ b/packages/swift-sdk/SwiftExampleApp/test_account_collection.swift
@@ -24,7 +24,7 @@ print("   - Identity topup accounts via managed_account_collection_get_identity_
 print("   - Provider accounts (voting keys, owner keys, etc.)")
 print()
 print("3. For each account, it:")
-print("   - Gets balance using managed_account_get_balance()")
+print("   - Gets balance using managed_core_account_get_balance()")
 print("   - Returns account information with proper labels")
 print("   - Uses unique indices for UI display")
 print()

--- a/packages/swift-sdk/build_ios.sh
+++ b/packages/swift-sdk/build_ios.sh
@@ -82,19 +82,11 @@ fi
 echo "3) Verifying Swift builds (if Xcode available)"
 if command -v xcodebuild >/dev/null 2>&1; then
   set +e
-  # Try to find an available iPhone simulator
-  SIMULATOR_ID=$(xcrun simctl list devices available | grep -i "iPhone" | grep -i "Shutdown\|Booted" | head -1 | sed -E 's/.*\(([A-F0-9-]+)\).*/\1/')
-  if [[ -z "$SIMULATOR_ID" ]]; then
-    # Fallback to generic destination
-    DESTINATION='platform=iOS Simulator,name=Any iOS Simulator Device'
-  else
-    DESTINATION="platform=iOS Simulator,id=$SIMULATOR_ID"
-  fi
-  
   xcodebuild -project "$SCRIPT_DIR/SwiftExampleApp/SwiftExampleApp.xcodeproj" \
              -scheme SwiftExampleApp \
              -sdk iphonesimulator \
-             -destination "$DESTINATION" \
+             -destination 'generic/platform=iOS Simulator' \
+             EXCLUDED_ARCHS=x86_64 \
              -quiet build
   XC_STATUS=$?
   set -e

--- a/packages/swift-sdk/build_ios.sh
+++ b/packages/swift-sdk/build_ios.sh
@@ -4,6 +4,14 @@ set -euo pipefail
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 REPO_ROOT="$( cd "$SCRIPT_DIR/../.." && pwd )"
 
+# Pass --clean through to rs-sdk-ffi if requested
+EXTRA_ARGS=""
+for arg in "$@"; do
+  case $arg in
+    --clean) EXTRA_ARGS="$EXTRA_ARGS --clean" ;;
+  esac
+done
+
 echo "=== SwiftDashSDK iOS Build (Unified) ==="
 
 echo "1) Building Rust FFI (rs-sdk-ffi)"
@@ -12,7 +20,7 @@ if [[ ! -x ./build_ios.sh ]]; then
   echo "❌ Missing rs-sdk-ffi/build_ios.sh"
   exit 1
 fi
-./build_ios.sh
+./build_ios.sh $EXTRA_ARGS
 popd >/dev/null
 
 # Expected output from rs-sdk-ffi

--- a/packages/swift-sdk/verify_build.sh
+++ b/packages/swift-sdk/verify_build.sh
@@ -15,7 +15,8 @@ if command -v xcodebuild >/dev/null 2>&1; then
   xcodebuild -project "$SCRIPT_DIR/SwiftExampleApp/SwiftExampleApp.xcodeproj" \
              -scheme SwiftExampleApp \
              -sdk iphonesimulator \
-             -destination 'platform=iOS Simulator,name=iPhone 16' \
+             -destination 'generic/platform=iOS Simulator' \
+             EXCLUDED_ARCHS=x86_64 \
              -quiet build
   XC_STATUS=$?
   set -e


### PR DESCRIPTION
## Issue being fixed or feature implemented
This update addresses issues with finding available iPhone simulators during the build process.

## What was done?
- Changed the build destination in both `build_ios.sh` and `verify_build.sh` to use a generic iOS simulator instead of attempting to find a specific device.
- Added the `EXCLUDED_ARCHS=x86_64` flag to exclude x86_64 architecture during the build.

## How Has This Been Tested?
The changes were tested by executing the build scripts in an environment with Xcode available, confirming that the builds complete successfully with the new destination settings.

## Breaking Changes
None

## Checklist
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests

  **For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone