### PR TITLE
feat(wasm-sdk,swift-sdk): add DIP-17 platform address derivation paths

### DIFF
--- a/packages/swift-sdk/Sources/SwiftDashSDK/KeyWallet/KeyDerivation.swift
+++ b/packages/swift-sdk/Sources/SwiftDashSDK/KeyWallet/KeyDerivation.swift
@@ -203,22 +203,76 @@ public class KeyDerivation {
         defer {
             pathBuffer.deallocate()
         }
-        
+
         let success = derivation_identity_authentication_path(
             network.ffiValue, identityIndex, keyIndex,
             pathBuffer, maxPathLen, &error)
-        
+
         defer {
             if error.message != nil {
                 error_message_free(error.message)
             }
         }
-        
+
         guard success else {
             throw KeyWalletError(ffiError: error)
         }
-        
+
         return String(cString: pathBuffer)
+    }
+
+    // MARK: - DIP-17 Platform Address Paths
+    // Key classes: 0 = payment (external), 1 = internal/change (reserved), 2 = funding
+
+    /// Get platform address funding path (DIP-17, key_class 2)
+    /// Path format: m/9'/coin_type'/17'/account'/2'/index
+    /// Used in asset locks to fund platform addresses
+    /// - Parameters:
+    ///   - network: The network type
+    ///   - accountIndex: The account index (typically 0)
+    ///   - fundingIndex: The funding key index
+    /// - Returns: The derivation path string
+    public static func getPlatformAddressFundingPath(network: KeyWalletNetwork = .mainnet,
+                                                    accountIndex: UInt32 = 0,
+                                                    fundingIndex: UInt32) -> String {
+        let coinType: UInt32 = network == .mainnet ? 5 : 1
+        // DIP-17 path: m/9'/coin_type'/17'/account'/2'/index
+        // All components except the final index are hardened
+        return "m/9'/\(coinType)'/17'/\(accountIndex)'/2'/\(fundingIndex)"
+    }
+
+    /// Get platform address payment path (DIP-17, key_class 0)
+    /// Path format: m/9'/coin_type'/17'/account'/0'/index
+    /// Used for receiving/sending to platform addresses
+    /// - Parameters:
+    ///   - network: The network type
+    ///   - accountIndex: The account index (typically 0)
+    ///   - addressIndex: The address index
+    /// - Returns: The derivation path string
+    public static func getPlatformAddressPaymentPath(network: KeyWalletNetwork = .mainnet,
+                                                    accountIndex: UInt32 = 0,
+                                                    addressIndex: UInt32) -> String {
+        let coinType: UInt32 = network == .mainnet ? 5 : 1
+        // DIP-17 path: m/9'/coin_type'/17'/account'/0'/index
+        // All components except the final index are hardened
+        return "m/9'/\(coinType)'/17'/\(accountIndex)'/0'/\(addressIndex)"
+    }
+
+    /// Get platform address internal/change path (DIP-17, key_class 1)
+    /// Path format: m/9'/coin_type'/17'/account'/1'/index
+    /// Reserved for wallet internal/change purposes (not currently used)
+    /// - Parameters:
+    ///   - network: The network type
+    ///   - accountIndex: The account index (typically 0)
+    ///   - addressIndex: The address index
+    /// - Returns: The derivation path string
+    public static func getPlatformAddressInternalPath(network: KeyWalletNetwork = .mainnet,
+                                                     accountIndex: UInt32 = 0,
+                                                     addressIndex: UInt32) -> String {
+        let coinType: UInt32 = network == .mainnet ? 5 : 1
+        // DIP-17 path: m/9'/coin_type'/17'/account'/1'/index
+        // All components except the final index are hardened
+        return "m/9'/\(coinType)'/17'/\(accountIndex)'/1'/\(addressIndex)"
     }
     
     /// Parse a derivation path string to indices

--- a/packages/swift-sdk/Sources/SwiftDashSDK/KeyWallet/KeyWalletTypes.swift
+++ b/packages/swift-sdk/Sources/SwiftDashSDK/KeyWallet/KeyWalletTypes.swift
@@ -71,11 +71,15 @@ public enum AccountType: UInt32 {
     case providerOwnerKeys = 8
     case providerOperatorKeys = 9
     case providerPlatformKeys = 10
-    
+    /// Platform address funding keys (DIP-17, key_class 2)
+    /// Used in asset locks to fund platform addresses
+    /// Path: m/9'/coin_type'/17'/account'/2'/index
+    case platformAddressFunding = 11
+
     var ffiValue: FFIAccountType {
         FFIAccountType(rawValue: self.rawValue)
     }
-    
+
     init(ffiType: FFIAccountType) {
         self = AccountType(rawValue: ffiType.rawValue) ?? .standardBIP44
     }
@@ -309,7 +313,8 @@ public struct AccountCollectionSummary {
     public let hasProviderOwnerKeys: Bool
     public let hasProviderOperatorKeys: Bool
     public let hasProviderPlatformKeys: Bool
-    
+    // TODO: Add hasPlatformAddressFunding when FFI support is available
+
     init(ffiSummary: FFIAccountCollectionSummary) {
         // Convert BIP44 indices
         if ffiSummary.bip44_count > 0, let indices = ffiSummary.bip44_indices {
@@ -363,7 +368,8 @@ public struct ManagedAccountCollectionSummary {
     public let hasProviderOwnerKeys: Bool
     public let hasProviderOperatorKeys: Bool
     public let hasProviderPlatformKeys: Bool
-    
+    // TODO: Add hasPlatformAddressFunding when FFI support is available
+
     init(ffiSummary: FFIManagedAccountCollectionSummary) {
         // Convert BIP44 indices
         if ffiSummary.bip44_count > 0, let indices = ffiSummary.bip44_indices {

--- a/packages/wasm-sdk/src/wallet/key_derivation.rs
+++ b/packages/wasm-sdk/src/wallet/key_derivation.rs
@@ -103,6 +103,15 @@ pub const DIP13_PURPOSE: u32 = 9;
 /// DIP13 feature for identity keys
 pub const DIP13_IDENTITY_FEATURE: u32 = 5;
 
+/// DIP17 feature for platform payment addresses
+pub const DIP17_FEATURE: u32 = 17;
+/// Platform key class for payment addresses (receiving/sending)
+pub const PLATFORM_KEY_CLASS_PAYMENT: u32 = 0;
+/// Platform key class for internal/change addresses (reserved, not currently used)
+pub const PLATFORM_KEY_CLASS_INTERNAL: u32 = 1;
+/// Platform key class for funding keys (used in asset locks to fund platform addresses)
+pub const PLATFORM_KEY_CLASS_FUNDING: u32 = 2;
+
 /// Standard BIP44 derivation path for Dash
 /// m/44'/5'/account'/change/index for mainnet
 /// m/44'/1'/account'/change/index for testnet
@@ -237,6 +246,24 @@ pub struct Dip13DerivationPathWasm {
     pub description: String,
 }
 
+/// DIP-17 derivation path for platform payment addresses
+/// Path format: m/9'/coin_type'/17'/account'/key_class'/index
+#[wasm_bindgen(getter_with_clone, js_name = "Dip17DerivationPathInfo")]
+#[derive(Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Dip17DerivationPathWasm {
+    pub path: String,
+    pub purpose: u32,
+    #[wasm_bindgen(js_name = "coinType")]
+    pub coin_type: u32,
+    pub feature: u32,
+    pub account: u32,
+    #[wasm_bindgen(js_name = "keyClass")]
+    pub key_class: u32,
+    pub index: u32,
+    pub description: String,
+}
+
 #[wasm_bindgen(getter_with_clone, js_name = "SeedPhraseKeyInfo")]
 #[derive(Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -268,6 +295,7 @@ pub struct PathDerivedKeyInfoWasm {
 
 impl_wasm_serde_conversions!(DerivationPathWasm, DerivationPathInfo);
 impl_wasm_serde_conversions!(Dip13DerivationPathWasm, Dip13DerivationPathInfo);
+impl_wasm_serde_conversions!(Dip17DerivationPathWasm, Dip17DerivationPathInfo);
 impl_wasm_serde_conversions!(SeedPhraseKeyInfoWasm, SeedPhraseKeyInfo);
 impl_wasm_serde_conversions!(PathDerivedKeyInfoWasm, PathDerivedKeyInfo);
 
@@ -583,6 +611,130 @@ impl WasmSdk {
             account,
             description: "DIP13 HD identity key path (testnet)".to_string(),
         }
+    }
+
+    /// Create a DIP17 mainnet derivation path for platform payment addresses
+    /// Path format: m/9'/5'/17'/account'/key_class'/index
+    /// Use key_class 0 for payment addresses, 1 for internal/change (reserved), 2 for funding keys
+    #[wasm_bindgen(js_name = "derivationPathDip17Mainnet")]
+    pub fn derivation_path_dip17_mainnet(
+        account: u32,
+        #[wasm_bindgen(js_name = "keyClass")] key_class: u32,
+        index: u32,
+    ) -> Dip17DerivationPathWasm {
+        let path_str = format!(
+            "m/{}'/{}'/{}'/{}'/{}'/{}",
+            DIP9_FEATURE_TYPE,
+            DASH_COIN_TYPE,
+            DIP17_FEATURE,
+            account,
+            key_class,
+            index
+        );
+
+        let description = match key_class {
+            PLATFORM_KEY_CLASS_PAYMENT => "DIP17 platform payment address path (mainnet)".to_string(),
+            PLATFORM_KEY_CLASS_INTERNAL => "DIP17 platform internal/change address path (mainnet, reserved)".to_string(),
+            PLATFORM_KEY_CLASS_FUNDING => "DIP17 platform address funding key path (mainnet)".to_string(),
+            _ => format!("DIP17 platform path with key_class {} (mainnet)", key_class),
+        };
+
+        Dip17DerivationPathWasm {
+            path: path_str,
+            purpose: DIP9_FEATURE_TYPE,
+            coin_type: DASH_COIN_TYPE,
+            feature: DIP17_FEATURE,
+            account,
+            key_class,
+            index,
+            description,
+        }
+    }
+
+    /// Create a DIP17 testnet derivation path for platform payment addresses
+    /// Path format: m/9'/1'/17'/account'/key_class'/index
+    /// Use key_class 0 for payment addresses, 1 for internal/change (reserved), 2 for funding keys
+    #[wasm_bindgen(js_name = "derivationPathDip17Testnet")]
+    pub fn derivation_path_dip17_testnet(
+        account: u32,
+        #[wasm_bindgen(js_name = "keyClass")] key_class: u32,
+        index: u32,
+    ) -> Dip17DerivationPathWasm {
+        let path_str = format!(
+            "m/{}'/{}'/{}'/{}'/{}'/{}",
+            DIP9_FEATURE_TYPE,
+            TESTNET_COIN_TYPE,
+            DIP17_FEATURE,
+            account,
+            key_class,
+            index
+        );
+
+        let description = match key_class {
+            PLATFORM_KEY_CLASS_PAYMENT => "DIP17 platform payment address path (testnet)".to_string(),
+            PLATFORM_KEY_CLASS_INTERNAL => "DIP17 platform internal/change address path (testnet, reserved)".to_string(),
+            PLATFORM_KEY_CLASS_FUNDING => "DIP17 platform address funding key path (testnet)".to_string(),
+            _ => format!("DIP17 platform path with key_class {} (testnet)", key_class),
+        };
+
+        Dip17DerivationPathWasm {
+            path: path_str,
+            purpose: DIP9_FEATURE_TYPE,
+            coin_type: TESTNET_COIN_TYPE,
+            feature: DIP17_FEATURE,
+            account,
+            key_class,
+            index,
+            description,
+        }
+    }
+
+    /// Create a DIP17 mainnet derivation path for platform payment addresses (key_class 0)
+    /// Path format: m/9'/5'/17'/0'/0'/index
+    /// Convenience method with default account=0 and key_class=0 (payment)
+    #[wasm_bindgen(js_name = "platformAddressPaymentPathMainnet")]
+    pub fn platform_address_payment_path_mainnet(index: u32) -> Dip17DerivationPathWasm {
+        Self::derivation_path_dip17_mainnet(0, PLATFORM_KEY_CLASS_PAYMENT, index)
+    }
+
+    /// Create a DIP17 testnet derivation path for platform payment addresses (key_class 0)
+    /// Path format: m/9'/1'/17'/0'/0'/index
+    /// Convenience method with default account=0 and key_class=0 (payment)
+    #[wasm_bindgen(js_name = "platformAddressPaymentPathTestnet")]
+    pub fn platform_address_payment_path_testnet(index: u32) -> Dip17DerivationPathWasm {
+        Self::derivation_path_dip17_testnet(0, PLATFORM_KEY_CLASS_PAYMENT, index)
+    }
+
+    /// Create a DIP17 mainnet derivation path for platform internal/change addresses (key_class 1)
+    /// Path format: m/9'/5'/17'/0'/1'/index
+    /// Convenience method with default account=0 and key_class=1 (internal, reserved)
+    #[wasm_bindgen(js_name = "platformAddressInternalPathMainnet")]
+    pub fn platform_address_internal_path_mainnet(index: u32) -> Dip17DerivationPathWasm {
+        Self::derivation_path_dip17_mainnet(0, PLATFORM_KEY_CLASS_INTERNAL, index)
+    }
+
+    /// Create a DIP17 testnet derivation path for platform internal/change addresses (key_class 1)
+    /// Path format: m/9'/1'/17'/0'/1'/index
+    /// Convenience method with default account=0 and key_class=1 (internal, reserved)
+    #[wasm_bindgen(js_name = "platformAddressInternalPathTestnet")]
+    pub fn platform_address_internal_path_testnet(index: u32) -> Dip17DerivationPathWasm {
+        Self::derivation_path_dip17_testnet(0, PLATFORM_KEY_CLASS_INTERNAL, index)
+    }
+
+    /// Create a DIP17 mainnet derivation path for platform address funding keys (key_class 2)
+    /// Path format: m/9'/5'/17'/0'/2'/index
+    /// Convenience method with default account=0 and key_class=2 (funding)
+    #[wasm_bindgen(js_name = "platformAddressFundingPathMainnet")]
+    pub fn platform_address_funding_path_mainnet(index: u32) -> Dip17DerivationPathWasm {
+        Self::derivation_path_dip17_mainnet(0, PLATFORM_KEY_CLASS_FUNDING, index)
+    }
+
+    /// Create a DIP17 testnet derivation path for platform address funding keys (key_class 2)
+    /// Path format: m/9'/1'/17'/0'/2'/index
+    /// Convenience method with default account=0 and key_class=2 (funding)
+    #[wasm_bindgen(js_name = "platformAddressFundingPathTestnet")]
+    pub fn platform_address_funding_path_testnet(index: u32) -> Dip17DerivationPathWasm {
+        Self::derivation_path_dip17_testnet(0, PLATFORM_KEY_CLASS_FUNDING, index)
     }
 
     /// Get child public key from extended public key

--- a/packages/wasm-sdk/tests/unit/derivation.spec.mjs
+++ b/packages/wasm-sdk/tests/unit/derivation.spec.mjs
@@ -45,6 +45,84 @@ describe('Key derivation', () => {
       const t = sdk.WasmSdk.derivationPathDip13Testnet(0);
       expect(t.path).to.equal("m/9'/1'/0'");
     });
+
+    it('DIP17 platform address payment path mainnet/testnet', () => {
+      // Test generic DIP17 method with key_class 0 (payment)
+      const m = sdk.WasmSdk.derivationPathDip17Mainnet(0, 0, 0);
+      expect(m.path).to.equal("m/9'/5'/17'/0'/0'/0");
+      expect(m.purpose).to.equal(9);
+      expect(m.coinType).to.equal(5);
+      expect(m.feature).to.equal(17);
+      expect(m.account).to.equal(0);
+      expect(m.keyClass).to.equal(0);
+      expect(m.index).to.equal(0);
+      expect(m.description).to.equal('DIP17 platform payment address path (mainnet)');
+
+      const t = sdk.WasmSdk.derivationPathDip17Testnet(0, 0, 0);
+      expect(t.path).to.equal("m/9'/1'/17'/0'/0'/0");
+      expect(t.coinType).to.equal(1);
+      expect(t.description).to.equal('DIP17 platform payment address path (testnet)');
+    });
+
+    it('DIP17 platform address internal/change path (reserved)', () => {
+      // Test generic DIP17 method with key_class 1 (internal/change, reserved)
+      const m = sdk.WasmSdk.derivationPathDip17Mainnet(0, 1, 0);
+      expect(m.path).to.equal("m/9'/5'/17'/0'/1'/0");
+      expect(m.keyClass).to.equal(1);
+      expect(m.description).to.equal('DIP17 platform internal/change address path (mainnet, reserved)');
+
+      const t = sdk.WasmSdk.derivationPathDip17Testnet(0, 1, 0);
+      expect(t.path).to.equal("m/9'/1'/17'/0'/1'/0");
+      expect(t.description).to.equal('DIP17 platform internal/change address path (testnet, reserved)');
+    });
+
+    it('DIP17 platform address funding path mainnet/testnet', () => {
+      // Test generic DIP17 method with key_class 2 (funding)
+      const m = sdk.WasmSdk.derivationPathDip17Mainnet(0, 2, 0);
+      expect(m.path).to.equal("m/9'/5'/17'/0'/2'/0");
+      expect(m.keyClass).to.equal(2);
+      expect(m.description).to.equal('DIP17 platform address funding key path (mainnet)');
+
+      const t = sdk.WasmSdk.derivationPathDip17Testnet(0, 2, 0);
+      expect(t.path).to.equal("m/9'/1'/17'/0'/2'/0");
+      expect(t.description).to.equal('DIP17 platform address funding key path (testnet)');
+    });
+
+    it('DIP17 convenience methods for payment paths', () => {
+      // Test convenience method with default account=0, key_class=0
+      const m = sdk.WasmSdk.platformAddressPaymentPathMainnet(5);
+      expect(m.path).to.equal("m/9'/5'/17'/0'/0'/5");
+      expect(m.index).to.equal(5);
+      expect(m.keyClass).to.equal(0);
+
+      const t = sdk.WasmSdk.platformAddressPaymentPathTestnet(10);
+      expect(t.path).to.equal("m/9'/1'/17'/0'/0'/10");
+      expect(t.index).to.equal(10);
+    });
+
+    it('DIP17 convenience methods for internal paths (reserved)', () => {
+      // Test convenience method with default account=0, key_class=1
+      const m = sdk.WasmSdk.platformAddressInternalPathMainnet(2);
+      expect(m.path).to.equal("m/9'/5'/17'/0'/1'/2");
+      expect(m.index).to.equal(2);
+      expect(m.keyClass).to.equal(1);
+
+      const t = sdk.WasmSdk.platformAddressInternalPathTestnet(4);
+      expect(t.path).to.equal("m/9'/1'/17'/0'/1'/4");
+      expect(t.index).to.equal(4);
+    });
+
+    it('DIP17 convenience methods for funding paths', () => {
+      // Test convenience method with default account=0, key_class=2
+      const m = sdk.WasmSdk.platformAddressFundingPathMainnet(3);
+      expect(m.path).to.equal("m/9'/5'/17'/0'/2'/3");
+      expect(m.index).to.equal(3);
+      expect(m.keyClass).to.equal(2);
+
+      const t = sdk.WasmSdk.platformAddressFundingPathTestnet(7);
+      expect(t.path).to.equal("m/9'/1'/17'/0'/2'/7");
+      expect(t.index).to.equal(7);
+    });
   });
 
   describe('Derive by path', () => {
@@ -100,6 +178,30 @@ describe('Key derivation', () => {
         mnemonic: seed, passphrase: null, path: 'm/9/5/5/0/0', network: 'mainnet',
       });
       expect(hardened.address).to.not.equal(nonHardened.address);
+    });
+
+    it('DIP17 platform address funding key derivation', () => {
+      // Test deriving a key using DIP17 funding path: m/9'/5'/17'/0'/2'/0
+      const pathInfo = sdk.WasmSdk.platformAddressFundingPathMainnet(0);
+      const r = sdk.WasmSdk.deriveKeyFromSeedWithPath({
+        mnemonic: seed, passphrase: null, path: pathInfo.path, network: 'mainnet',
+      });
+      expect(r).to.exist();
+      expect(r.path).to.equal("m/9'/5'/17'/0'/2'/0");
+      expect(r.address.startsWith('X')).to.equal(true);
+      expect(r.privateKeyWif).to.be.a('string');
+    });
+
+    it('DIP17 platform address payment key derivation', () => {
+      // Test deriving a key using DIP17 payment path: m/9'/1'/17'/0'/0'/0
+      const pathInfo = sdk.WasmSdk.platformAddressPaymentPathTestnet(0);
+      const r = sdk.WasmSdk.deriveKeyFromSeedWithPath({
+        mnemonic: seed, passphrase: null, path: pathInfo.path, network: 'testnet',
+      });
+      expect(r).to.exist();
+      expect(r.path).to.equal("m/9'/1'/17'/0'/0'/0");
+      expect(r.address.startsWith('y')).to.equal(true);
+      expect(r.privateKeyHex).to.be.a('string');
     });
   });
 


### PR DESCRIPTION
Add support for DIP-17 derivation paths for platform addresses:
- Path format: m/9'/coin_type'/17'/account'/key_class'/index
- Key classes: 0 (payment), 1 (internal/change, reserved), 2 (funding)

WASM SDK changes:
- Add DIP-17 constants and Dip17DerivationPathWasm struct
- Add derivation_path_dip17_mainnet/testnet methods
- Add convenience methods for payment, internal, and funding paths
- Add comprehensive unit tests for all DIP-17 paths

Swift SDK changes:
- Add platformAddressFunding AccountType variant
- Add getPlatformAddressFundingPath, getPlatformAddressPaymentPath, and getPlatformAddressInternalPath derivation methods

<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->


## What was done?
<!--- Describe your changes in detail -->


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [ ] I have made corresponding changes to the documentation if needed

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone
