### PR TITLE
refactor(swift-sdk): extract validation logic

### DIFF
--- a/packages/swift-sdk/Sources/SwiftDashSDK/Utils/Validation.swift
+++ b/packages/swift-sdk/Sources/SwiftDashSDK/Utils/Validation.swift
@@ -58,6 +58,41 @@ public enum AddressValidator {
     public static func validateIdentityId(_ id: String) -> Bool {
         !id.trimmingCharacters(in: .whitespaces).isEmpty
     }
+
+    /// Validates a bech32m Platform address (dashevo1... or tdashevo1...).
+    /// - Returns: `true` if string is a valid bech32m address with correct HRP and 21 bytes of data.
+    public static func validateBech32mAddress(_ address: String) -> Bool {
+        Bech32m.isValidPlatformAddress(address)
+    }
+
+    /// Validates an address in either hex (42 chars) or bech32m format.
+    /// - Returns: `true` if string is valid in either format.
+    public static func validateAddress(_ address: String) -> Bool {
+        let trimmed = address.trimmingCharacters(in: .whitespacesAndNewlines)
+        if trimmed.lowercased().hasPrefix("dashevo1") || trimmed.lowercased().hasPrefix("tdashevo1") {
+            return validateBech32mAddress(trimmed)
+        }
+        return validateHexAddress(trimmed)
+    }
+
+    /// Validates a 32-byte hash in hex format (64 characters).
+    /// - Returns: `true` if string is exactly 64 hex characters.
+    public static func validateHash(_ hex: String) -> Bool {
+        validateHexString(hex, byteLength: 32)
+    }
+
+    /// Validates an identity ID in hex format (64 characters = 32 bytes).
+    /// - Returns: `true` if string is exactly 64 hex characters.
+    public static func validateIdentityIdHex(_ hex: String) -> Bool {
+        validateHexString(hex, byteLength: 32)
+    }
+
+    /// Checks if a string is a valid hex identity ID (64 chars).
+    /// Useful for format detection (hex vs base58).
+    /// - Returns: `true` if string is exactly 64 hex characters.
+    public static func isHexIdentityId(_ id: String) -> Bool {
+        validateHexString(id, byteLength: 32)
+    }
 }
 
 // MARK: - Transfer Input Validator

--- a/packages/swift-sdk/SwiftExampleApp/SwiftExampleApp/Views/AddressQueriesView.swift
+++ b/packages/swift-sdk/SwiftExampleApp/SwiftExampleApp/Views/AddressQueriesView.swift
@@ -943,7 +943,7 @@ struct GetBranchStateView: View {
 
   private var isFormValid: Bool {
     guard let depthValue = UInt32(depth) else { return false }
-    return !keyHex.isEmpty && !expectedHashHex.isEmpty && expectedHashHex.count == 64
+    return !keyHex.isEmpty && AddressValidator.validateHash(expectedHashHex)
       && !checkpointHeight.isEmpty && depthValue >= 6 && depthValue <= 9
       && UInt64(checkpointHeight) != nil
   }

--- a/packages/swift-sdk/SwiftExampleApp/SwiftExampleApp/Views/DocumentWithPriceView.swift
+++ b/packages/swift-sdk/SwiftExampleApp/SwiftExampleApp/Views/DocumentWithPriceView.swift
@@ -167,9 +167,9 @@ struct DocumentWithPriceView: View {
             return data.count == 32
         }
         
-        // Check if it's a valid hex string (64 characters)
-        if id.count == 64 {
-            return id.allSatisfy { $0.isHexDigit }
+        // Check if it's a valid hex string (64 characters = 32 bytes)
+        if AddressValidator.isHexIdentityId(id) {
+            return true
         }
         
         return false

--- a/packages/swift-sdk/SwiftExampleApp/SwiftExampleApp/Views/TransitionDetailView.swift
+++ b/packages/swift-sdk/SwiftExampleApp/SwiftExampleApp/Views/TransitionDetailView.swift
@@ -1934,8 +1934,8 @@ struct TransitionDetailView: View {
       .replacingOccurrences(of: "0x", with: "")
       .trimmingCharacters(in: .whitespacesAndNewlines)
 
-    // If it's hex (64 chars), convert to base58
-    if cleanId.count == 64, let data = Data(hexString: cleanId) {
+    // If it's hex (64 chars = 32 bytes), convert to base58
+    if AddressValidator.isHexIdentityId(cleanId), let data = Data(hexString: cleanId) {
       return data.toBase58String()
     }
 

--- a/packages/swift-sdk/SwiftExampleApp/SwiftExampleAppTests/ValidationTests.swift
+++ b/packages/swift-sdk/SwiftExampleApp/SwiftExampleAppTests/ValidationTests.swift
@@ -1,0 +1,403 @@
+import XCTest
+@testable import SwiftDashSDK
+
+final class ValidationTests: XCTestCase {
+
+    // MARK: - AddressValidator Tests
+
+    func testValidateHexAddress_valid42CharHex() {
+        // 42 hex characters = 21 bytes (valid Platform address)
+        let validAddress = "00aaff11223344556677889900aabbccddeeff0011"
+        XCTAssertTrue(AddressValidator.validateHexAddress(validAddress))
+    }
+
+    func testValidateHexAddress_invalidLength() {
+        // Too short
+        XCTAssertFalse(AddressValidator.validateHexAddress("00aabb"))
+        // Too long
+        XCTAssertFalse(AddressValidator.validateHexAddress("00aaff11223344556677889900aabbccddeeff001122"))
+        // Empty
+        XCTAssertFalse(AddressValidator.validateHexAddress(""))
+    }
+
+    func testValidateHexAddress_invalidCharacters() {
+        // Contains 'g' which is not valid hex
+        let invalidHex = "00aaff11223344556677889900aabbccddeeff00gg"
+        XCTAssertFalse(AddressValidator.validateHexAddress(invalidHex))
+        // Contains spaces
+        XCTAssertFalse(AddressValidator.validateHexAddress("00 aabb"))
+    }
+
+    func testValidatePrivateKey_valid64CharHex() {
+        // 64 hex characters = 32 bytes (valid private key)
+        let validKey = "aaff11223344556677889900aabbccddeeff0011223344556677889900112233"
+        XCTAssertTrue(AddressValidator.validatePrivateKey(validKey))
+    }
+
+    func testValidatePrivateKey_invalidLength() {
+        // Too short
+        XCTAssertFalse(AddressValidator.validatePrivateKey("aabbccdd"))
+        // Too long
+        XCTAssertFalse(AddressValidator.validatePrivateKey("aaff11223344556677889900aabbccddeeff001122334455667788990011223355"))
+        // Empty
+        XCTAssertFalse(AddressValidator.validatePrivateKey(""))
+    }
+
+    func testValidateHexString_customByteLength() {
+        // 36 bytes = 72 hex characters (outpoint)
+        let valid72 = String(repeating: "ab", count: 36)
+        XCTAssertTrue(AddressValidator.validateHexString(valid72, byteLength: 36))
+        XCTAssertFalse(AddressValidator.validateHexString(valid72, byteLength: 32))
+    }
+
+    func testValidateAmount_validPositive() {
+        XCTAssertEqual(AddressValidator.validateAmount("100"), 100)
+        XCTAssertEqual(AddressValidator.validateAmount("1"), 1)
+        XCTAssertEqual(AddressValidator.validateAmount("18446744073709551615"), UInt64.max) // max UInt64
+        XCTAssertEqual(AddressValidator.validateAmount("  500  "), 500) // whitespace trimmed
+    }
+
+    func testValidateAmount_invalid() {
+        XCTAssertNil(AddressValidator.validateAmount("0")) // zero not allowed
+        XCTAssertNil(AddressValidator.validateAmount("-100")) // negative
+        XCTAssertNil(AddressValidator.validateAmount("abc"))
+        XCTAssertNil(AddressValidator.validateAmount(""))
+        XCTAssertNil(AddressValidator.validateAmount("12.5")) // decimal
+    }
+
+    func testValidateIdentityId_valid() {
+        XCTAssertTrue(AddressValidator.validateIdentityId("someIdentityId123"))
+        XCTAssertTrue(AddressValidator.validateIdentityId("aaff11223344556677889900aabbccddeeff0011223344556677889900112233"))
+    }
+
+    func testValidateIdentityId_invalid() {
+        XCTAssertFalse(AddressValidator.validateIdentityId(""))
+        XCTAssertFalse(AddressValidator.validateIdentityId("   "))
+    }
+
+    func testValidateBech32mAddress_valid() {
+        // Valid testnet address (tdashevo1...)
+        // Using a well-formed bech32m address
+        let validTestnetAddress = "tdashevo1qz4242424242424242424242424242424g4dj6u7"
+        XCTAssertTrue(AddressValidator.validateBech32mAddress(validTestnetAddress))
+    }
+
+    func testValidateBech32mAddress_invalid() {
+        // Wrong HRP
+        XCTAssertFalse(AddressValidator.validateBech32mAddress("bitcoin1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq"))
+        // No separator
+        XCTAssertFalse(AddressValidator.validateBech32mAddress("tdashevoqqqqqqqqqqq"))
+        // Empty
+        XCTAssertFalse(AddressValidator.validateBech32mAddress(""))
+        // Random string
+        XCTAssertFalse(AddressValidator.validateBech32mAddress("notanaddress"))
+    }
+
+    func testValidateAddress_autoDetect() {
+        // Hex address
+        let hexAddr = "00aaff11223344556677889900aabbccddeeff0011"
+        XCTAssertTrue(AddressValidator.validateAddress(hexAddr))
+
+        // Bech32m address (if valid)
+        let bech32mAddr = "tdashevo1qz4242424242424242424242424242424g4dj6u7"
+        XCTAssertTrue(AddressValidator.validateAddress(bech32mAddr))
+
+        // Invalid
+        XCTAssertFalse(AddressValidator.validateAddress("invalid"))
+    }
+
+    // MARK: - TransferInputValidator Tests
+
+    func testTransferInputValidator_allValid() {
+        let result = TransferInputValidator.validate(
+            inputAddressHex: "00aaff11223344556677889900aabbccddeeff0011",
+            inputPrivateKeyHex: "aaff11223344556677889900aabbccddeeff0011223344556677889900112233",
+            outputAddressHex: "11bbcc22334455667788990011aabbccddeeff0022",
+            inputAmount: "1000",
+            outputAmount: "500"
+        )
+        XCTAssertTrue(result.isValid)
+        XCTAssertTrue(result.errors.isEmpty)
+    }
+
+    func testTransferInputValidator_invalidInputAddress() {
+        let result = TransferInputValidator.validate(
+            inputAddressHex: "invalid",
+            inputPrivateKeyHex: "aaff11223344556677889900aabbccddeeff0011223344556677889900112233",
+            outputAddressHex: "11bbcc22334455667788990011aabbccddeeff0022",
+            inputAmount: "1000",
+            outputAmount: "500"
+        )
+        XCTAssertFalse(result.isValid)
+        XCTAssertTrue(result.errors.contains { $0.contains("Input address") })
+    }
+
+    func testTransferInputValidator_invalidPrivateKey() {
+        let result = TransferInputValidator.validate(
+            inputAddressHex: "00aaff11223344556677889900aabbccddeeff0011",
+            inputPrivateKeyHex: "tooshort",
+            outputAddressHex: "11bbcc22334455667788990011aabbccddeeff0022",
+            inputAmount: "1000",
+            outputAmount: "500"
+        )
+        XCTAssertFalse(result.isValid)
+        XCTAssertTrue(result.errors.contains { $0.contains("Private key") })
+    }
+
+    func testTransferInputValidator_inputLessThanOutput() {
+        let result = TransferInputValidator.validate(
+            inputAddressHex: "00aaff11223344556677889900aabbccddeeff0011",
+            inputPrivateKeyHex: "aaff11223344556677889900aabbccddeeff0011223344556677889900112233",
+            outputAddressHex: "11bbcc22334455667788990011aabbccddeeff0022",
+            inputAmount: "500",
+            outputAmount: "1000"
+        )
+        XCTAssertFalse(result.isValid)
+        XCTAssertTrue(result.errors.contains { $0.contains("Input amount must be greater") })
+    }
+
+    func testTransferInputValidator_multipleErrors() {
+        let result = TransferInputValidator.validate(
+            inputAddressHex: "bad",
+            inputPrivateKeyHex: "bad",
+            outputAddressHex: "bad",
+            inputAmount: "abc",
+            outputAmount: "xyz"
+        )
+        XCTAssertFalse(result.isValid)
+        XCTAssertEqual(result.errors.count, 5)
+    }
+
+    // MARK: - WithdrawInputValidator Tests
+
+    func testWithdrawInputValidator_allValid() {
+        let result = WithdrawInputValidator.validate(
+            inputAddressHex: "00aaff11223344556677889900aabbccddeeff0011",
+            inputPrivateKeyHex: "aaff11223344556677889900aabbccddeeff0011223344556677889900112233",
+            coreAddress: "yXdMkHQZwWqtQNzCLXWPWrZvJT4RCJGxkp",
+            inputAmount: "1000",
+            useChangeAddress: false,
+            changeAddressHex: ""
+        )
+        XCTAssertTrue(result.isValid)
+        XCTAssertTrue(result.errors.isEmpty)
+    }
+
+    func testWithdrawInputValidator_withChangeAddress() {
+        let result = WithdrawInputValidator.validate(
+            inputAddressHex: "00aaff11223344556677889900aabbccddeeff0011",
+            inputPrivateKeyHex: "aaff11223344556677889900aabbccddeeff0011223344556677889900112233",
+            coreAddress: "yXdMkHQZwWqtQNzCLXWPWrZvJT4RCJGxkp",
+            inputAmount: "1000",
+            useChangeAddress: true,
+            changeAddressHex: "22ccdd33445566778899001122aabbccddeeff0033"
+        )
+        XCTAssertTrue(result.isValid)
+    }
+
+    func testWithdrawInputValidator_invalidChangeAddress() {
+        let result = WithdrawInputValidator.validate(
+            inputAddressHex: "00aaff11223344556677889900aabbccddeeff0011",
+            inputPrivateKeyHex: "aaff11223344556677889900aabbccddeeff0011223344556677889900112233",
+            coreAddress: "yXdMkHQZwWqtQNzCLXWPWrZvJT4RCJGxkp",
+            inputAmount: "1000",
+            useChangeAddress: true,
+            changeAddressHex: "invalid"
+        )
+        XCTAssertFalse(result.isValid)
+        XCTAssertTrue(result.errors.contains { $0.contains("Change address") })
+    }
+
+    func testWithdrawInputValidator_emptyCoreAddress() {
+        let result = WithdrawInputValidator.validate(
+            inputAddressHex: "00aaff11223344556677889900aabbccddeeff0011",
+            inputPrivateKeyHex: "aaff11223344556677889900aabbccddeeff0011223344556677889900112233",
+            coreAddress: "",
+            inputAmount: "1000",
+            useChangeAddress: false,
+            changeAddressHex: ""
+        )
+        XCTAssertFalse(result.isValid)
+        XCTAssertTrue(result.errors.contains { $0.contains("Core address") })
+    }
+
+    // MARK: - TopUpAddressFromAssetLockValidator Tests
+
+    func testTopUpValidator_validInstant() {
+        let result = TopUpAddressFromAssetLockValidator.validate(
+            outputAddressHex: "00aaff11223344556677889900aabbccddeeff0011",
+            assetLockPrivateKeyHex: "aaff11223344556677889900aabbccddeeff0011223344556677889900112233",
+            proofType: .instant,
+            instantLockHex: "someinstantlockdata",
+            transactionHex: "sometxdata",
+            outputIndex: "0",
+            coreChainLockedHeight: "",
+            outPointHex: ""
+        )
+        XCTAssertTrue(result.isValid)
+    }
+
+    func testTopUpValidator_validChain() {
+        let outpoint72 = String(repeating: "ab", count: 36) // 72 hex chars
+        let result = TopUpAddressFromAssetLockValidator.validate(
+            outputAddressHex: "00aaff11223344556677889900aabbccddeeff0011",
+            assetLockPrivateKeyHex: "aaff11223344556677889900aabbccddeeff0011223344556677889900112233",
+            proofType: .chain,
+            instantLockHex: "",
+            transactionHex: "",
+            outputIndex: "",
+            coreChainLockedHeight: "12345",
+            outPointHex: outpoint72
+        )
+        XCTAssertTrue(result.isValid)
+    }
+
+    func testTopUpValidator_invalidOutpoint() {
+        let result = TopUpAddressFromAssetLockValidator.validate(
+            outputAddressHex: "00aaff11223344556677889900aabbccddeeff0011",
+            assetLockPrivateKeyHex: "aaff11223344556677889900aabbccddeeff0011223344556677889900112233",
+            proofType: .chain,
+            instantLockHex: "",
+            transactionHex: "",
+            outputIndex: "",
+            coreChainLockedHeight: "12345",
+            outPointHex: "tooshort"
+        )
+        XCTAssertFalse(result.isValid)
+        XCTAssertTrue(result.errors.contains { $0.contains("Outpoint") })
+    }
+
+    // MARK: - IdentityTopUpFromAddressesValidator Tests
+
+    func testIdentityTopUpValidator_valid() {
+        let result = IdentityTopUpFromAddressesValidator.validate(
+            identityId: "someIdentityId",
+            inputAddressHex: "00aaff11223344556677889900aabbccddeeff0011",
+            inputPrivateKeyHex: "aaff11223344556677889900aabbccddeeff0011223344556677889900112233",
+            amount: "1000"
+        )
+        XCTAssertTrue(result.isValid)
+    }
+
+    func testIdentityTopUpValidator_emptyIdentityId() {
+        let result = IdentityTopUpFromAddressesValidator.validate(
+            identityId: "",
+            inputAddressHex: "00aaff11223344556677889900aabbccddeeff0011",
+            inputPrivateKeyHex: "aaff11223344556677889900aabbccddeeff0011223344556677889900112233",
+            amount: "1000"
+        )
+        XCTAssertFalse(result.isValid)
+        XCTAssertTrue(result.errors.contains { $0.contains("Identity ID") })
+    }
+
+    // MARK: - IdentityTransferToAddressesValidator Tests
+
+    func testIdentityTransferValidator_valid() {
+        let result = IdentityTransferToAddressesValidator.validate(
+            identityId: "someIdentityId",
+            outputAddressHex: "00aaff11223344556677889900aabbccddeeff0011",
+            identityPrivateKeyHex: "aaff11223344556677889900aabbccddeeff0011223344556677889900112233",
+            amount: "1000"
+        )
+        XCTAssertTrue(result.isValid)
+    }
+
+    // MARK: - IdentityCreateFromAddressesValidator Tests
+
+    func testIdentityCreateValidator_valid() {
+        let result = IdentityCreateFromAddressesValidator.validate(
+            identityId: "someIdentityId",
+            inputAddressHex: "00aaff11223344556677889900aabbccddeeff0011",
+            inputPrivateKeyHex: "aaff11223344556677889900aabbccddeeff0011223344556677889900112233",
+            identityPrivateKeyHex: "bbff11223344556677889900aabbccddeeff0011223344556677889900112233",
+            amount: "1000",
+            nonce: "0",
+            useChangeAddress: false,
+            changeAddressHex: ""
+        )
+        XCTAssertTrue(result.isValid)
+    }
+
+    func testIdentityCreateValidator_invalidNonce() {
+        let result = IdentityCreateFromAddressesValidator.validate(
+            identityId: "someIdentityId",
+            inputAddressHex: "00aaff11223344556677889900aabbccddeeff0011",
+            inputPrivateKeyHex: "aaff11223344556677889900aabbccddeeff0011223344556677889900112233",
+            identityPrivateKeyHex: "bbff11223344556677889900aabbccddeeff0011223344556677889900112233",
+            amount: "1000",
+            nonce: "notanumber",
+            useChangeAddress: false,
+            changeAddressHex: ""
+        )
+        XCTAssertFalse(result.isValid)
+        XCTAssertTrue(result.errors.contains { $0.contains("Nonce") })
+    }
+
+    func testIdentityCreateValidator_invalidChangeAddress() {
+        let result = IdentityCreateFromAddressesValidator.validate(
+            identityId: "someIdentityId",
+            inputAddressHex: "00aaff11223344556677889900aabbccddeeff0011",
+            inputPrivateKeyHex: "aaff11223344556677889900aabbccddeeff0011223344556677889900112233",
+            identityPrivateKeyHex: "bbff11223344556677889900aabbccddeeff0011223344556677889900112233",
+            amount: "1000",
+            nonce: "0",
+            useChangeAddress: true,
+            changeAddressHex: "invalid"
+        )
+        XCTAssertFalse(result.isValid)
+        XCTAssertTrue(result.errors.contains { $0.contains("Change address") })
+    }
+
+    // MARK: - ValidationResult Tests
+
+    func testValidationResult_valid() {
+        let result = ValidationResult.valid()
+        XCTAssertTrue(result.isValid)
+        XCTAssertTrue(result.errors.isEmpty)
+    }
+
+    func testValidationResult_invalid() {
+        let result = ValidationResult.invalid(["Error 1", "Error 2"])
+        XCTAssertFalse(result.isValid)
+        XCTAssertEqual(result.errors.count, 2)
+    }
+
+    func testValidationResult_invalidWithEmptyErrors() {
+        // When errors is empty, isValid should be true
+        let result = ValidationResult.invalid([])
+        XCTAssertTrue(result.isValid)
+    }
+
+    // MARK: - Hash Validation Tests
+
+    func testValidateHash_valid64CharHex() {
+        let validHash = "aaff11223344556677889900aabbccddeeff0011223344556677889900112233"
+        XCTAssertTrue(AddressValidator.validateHash(validHash))
+    }
+
+    func testValidateHash_invalidLength() {
+        XCTAssertFalse(AddressValidator.validateHash("aabbccdd"))
+        XCTAssertFalse(AddressValidator.validateHash(""))
+    }
+
+    // MARK: - Identity ID Hex Validation Tests
+
+    func testValidateIdentityIdHex_valid() {
+        let validId = "aaff11223344556677889900aabbccddeeff0011223344556677889900112233"
+        XCTAssertTrue(AddressValidator.validateIdentityIdHex(validId))
+    }
+
+    func testIsHexIdentityId_valid() {
+        let validId = "aaff11223344556677889900aabbccddeeff0011223344556677889900112233"
+        XCTAssertTrue(AddressValidator.isHexIdentityId(validId))
+    }
+
+    func testIsHexIdentityId_invalid() {
+        // Too short (base58 style)
+        XCTAssertFalse(AddressValidator.isHexIdentityId("4EfA9Wam5vEXTbYbP8YFZP35o9F"))
+        // Empty
+        XCTAssertFalse(AddressValidator.isHexIdentityId(""))
+        // Invalid chars
+        XCTAssertFalse(AddressValidator.isHexIdentityId("ggff11223344556677889900aabbccddeeff0011223344556677889900112233"))
+    }
+}


### PR DESCRIPTION
## Issue being fixed or feature implemented

Phase 1 of Swift SDK refactoring plan: Extract validation logic from views into centralized, reusable, testable validators following MVVM pattern.

## What was done?

- Add new validator methods to AddressValidator:
  - `validateBech32mAddress()` for bech32m Platform addresses
  - `validateAddress()` with auto-detection (hex or bech32m)
  - `validateHash()` for 32-byte hashes
  - `validateIdentityIdHex()` and `isHexIdentityId()` for identity IDs

- Create comprehensive unit tests for all validators (39 tests) covering:
  - AddressValidator
  - TransferInputValidator
  - WithdrawInputValidator
  - TopUpAddressFromAssetLockValidator
  - IdentityTopUpFromAddressesValidator
  - IdentityTransferToAddressesValidator
  - IdentityCreateFromAddressesValidator

- Update views to use centralized validators:
  - AddressQueriesView: use `validateHash()`
  - DocumentWithPriceView: use `isHexIdentityId()`
  - TransitionDetailView: use `isHexIdentityId()`

## How Has This Been Tested?

- All 39 validation unit tests pass
- Build verified with `./build_ios.sh`
- Tested on iOS Simulator (iPhone 16, iOS 18.6)

## Breaking Changes

None

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [ ] I have made corresponding changes to the documentation if needed

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone