### PR TITLE
refactor(sdk): get rid of static trusted contexts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5878,6 +5878,7 @@ name = "simple-signer"
 version = "3.0.0"
 dependencies = [
  "base64 0.22.1",
+ "bincode",
  "dpp",
  "hex",
  "tracing",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4317,7 +4317,6 @@ version = "3.0.0"
 dependencies = [
  "bincode",
  "grovedb-version",
- "once_cell",
  "thiserror 2.0.17",
  "versioned-feature-core 1.0.0 (git+https://github.com/dashpay/versioned-feature-core)",
 ]
@@ -5879,7 +5878,6 @@ name = "simple-signer"
 version = "3.0.0"
 dependencies = [
  "base64 0.22.1",
- "bincode",
  "dpp",
  "hex",
  "tracing",

--- a/packages/js-evo-sdk/src/sdk.ts
+++ b/packages/js-evo-sdk/src/sdk.ts
@@ -69,7 +69,9 @@ export class EvoSDK {
   }
 
   get wasm(): wasm.WasmSdk {
-    if (!this.wasmSdk) throw new Error('SDK is not connected. Call EvoSDK#connect() first.');
+    if (!this.wasmSdk) {
+      throw new Error('SDK is not connected. Call EvoSDK#connect() first.');
+    }
     return this.wasmSdk;
   }
 
@@ -83,47 +85,59 @@ export class EvoSDK {
   }
 
   async connect(): Promise<void> {
-    if (this.wasmSdk) return; // idempotent
+    if (this.wasmSdk) {
+      return; // idempotent
+    }
     await initWasm();
 
-    const { network, trusted, version, proofs, settings, logs, addresses } = this.options;
+    const { network, version, proofs, settings, logs, addresses } = this.options;
 
-    let builder: wasm.WasmSdkBuilder;
-
-    // If specific addresses are provided, use them instead of network presets
-    if (addresses && addresses.length > 0) {
-      // Prefetch trusted quorums for the network before creating builder with addresses
-      if (network === 'mainnet') {
-        await wasm.WasmSdk.prefetchTrustedQuorumsMainnet();
-      } else if (network === 'testnet') {
-        await wasm.WasmSdk.prefetchTrustedQuorumsTestnet();
-      } else if (network === 'local') {
-        await wasm.WasmSdk.prefetchTrustedQuorumsLocal();
-      }
-      builder = wasm.WasmSdkBuilder.withAddresses(addresses, network);
-    } else if (network === 'mainnet') {
-      await wasm.WasmSdk.prefetchTrustedQuorumsMainnet();
-
-      builder = trusted ? wasm.WasmSdkBuilder.mainnetTrusted() : wasm.WasmSdkBuilder.mainnet();
+    // Prefetch trusted context (quorums + masternode addresses) for the network
+    let context: wasm.WasmTrustedContext | undefined;
+    if (network === 'mainnet') {
+      context = await wasm.WasmTrustedContext.prefetchMainnet();
     } else if (network === 'testnet') {
-      await wasm.WasmSdk.prefetchTrustedQuorumsTestnet();
-
-      builder = trusted ? wasm.WasmSdkBuilder.testnetTrusted() : wasm.WasmSdkBuilder.testnet();
+      context = await wasm.WasmTrustedContext.prefetchTestnet();
     } else if (network === 'local') {
-      // Default local dashmate gateway and quorum list sidecar
-      await wasm.WasmSdk.prefetchTrustedQuorumsLocal();
-
-      builder = trusted ? wasm.WasmSdkBuilder.localTrusted() : wasm.WasmSdkBuilder.local();
+      context = await wasm.WasmTrustedContext.prefetchLocal();
     } else {
       throw new Error(`Unknown network: ${network}`);
     }
 
-    if (version) builder = builder.withVersion(version);
-    if (typeof proofs === 'boolean') builder = builder.withProofs(proofs);
-    if (logs) builder = builder.withLogs(logs);
+    let builder: wasm.WasmSdkBuilder;
+
+    if (addresses && addresses.length > 0) {
+      builder = wasm.WasmSdkBuilder.withAddresses(addresses, network);
+    } else if (network === 'mainnet') {
+      builder = wasm.WasmSdkBuilder.mainnet();
+    } else if (network === 'testnet') {
+      builder = wasm.WasmSdkBuilder.testnet();
+    } else {
+      builder = wasm.WasmSdkBuilder.local();
+    }
+
+    // Attach trusted context for proof verification and discovered addresses
+    if (context) {
+      builder = builder.withTrustedContext(context);
+    }
+
+    if (version) {
+      builder = builder.withVersion(version);
+    }
+    if (typeof proofs === 'boolean') {
+      builder = builder.withProofs(proofs);
+    }
+    if (logs) {
+      builder = builder.withLogs(logs);
+    }
     if (settings) {
       const { connectTimeoutMs, timeoutMs, retries, banFailedAddress } = settings;
-      builder = builder.withSettings(connectTimeoutMs ?? null, timeoutMs ?? null, retries ?? null, banFailedAddress ?? null);
+      builder = builder.withSettings(
+        connectTimeoutMs ?? null,
+        timeoutMs ?? null,
+        retries ?? null,
+        banFailedAddress ?? null,
+      );
     }
 
     this.wasmSdk = builder.build();

--- a/packages/js-evo-sdk/src/sdk.ts
+++ b/packages/js-evo-sdk/src/sdk.ts
@@ -90,18 +90,20 @@ export class EvoSDK {
     }
     await initWasm();
 
-    const { network, version, proofs, settings, logs, addresses } = this.options;
+    const { network, trusted, version, proofs, settings, logs, addresses } = this.options;
 
-    // Prefetch trusted context (quorums + masternode addresses) for the network
+    // Prefetch trusted context only when trusted mode is requested
     let context: wasm.WasmTrustedContext | undefined;
-    if (network === 'mainnet') {
-      context = await wasm.WasmTrustedContext.prefetchMainnet();
-    } else if (network === 'testnet') {
-      context = await wasm.WasmTrustedContext.prefetchTestnet();
-    } else if (network === 'local') {
-      context = await wasm.WasmTrustedContext.prefetchLocal();
-    } else {
-      throw new Error(`Unknown network: ${network}`);
+    if (trusted) {
+      if (network === 'mainnet') {
+        context = await wasm.WasmTrustedContext.prefetchMainnet();
+      } else if (network === 'testnet') {
+        context = await wasm.WasmTrustedContext.prefetchTestnet();
+      } else if (network === 'local') {
+        context = await wasm.WasmTrustedContext.prefetchLocal();
+      } else {
+        throw new Error(`Unknown network: ${network}`);
+      }
     }
 
     let builder: wasm.WasmSdkBuilder;
@@ -112,8 +114,10 @@ export class EvoSDK {
       builder = wasm.WasmSdkBuilder.mainnet();
     } else if (network === 'testnet') {
       builder = wasm.WasmSdkBuilder.testnet();
-    } else {
+    } else if (network === 'local') {
       builder = wasm.WasmSdkBuilder.local();
+    } else {
+      throw new Error(`Unknown network: ${network}`);
     }
 
     // Attach trusted context for proof verification and discovered addresses

--- a/packages/js-evo-sdk/tests/unit/facades/addresses.spec.ts
+++ b/packages/js-evo-sdk/tests/unit/facades/addresses.spec.ts
@@ -15,7 +15,7 @@ describe('AddressesFacade', () => {
 
   beforeEach(async function setup() {
     await init();
-    const builder = wasmSDKPackage.WasmSdkBuilder.testnetTrusted();
+    const builder = wasmSDKPackage.WasmSdkBuilder.testnet();
     wasmSdk = await builder.build();
     client = EvoSDK.fromWasm(wasmSdk);
 

--- a/packages/js-evo-sdk/tests/unit/facades/contracts.spec.ts
+++ b/packages/js-evo-sdk/tests/unit/facades/contracts.spec.ts
@@ -21,7 +21,7 @@ describe('ContractsFacade', () => {
 
   beforeEach(async function setup() {
     await init();
-    const builder = wasmSDKPackage.WasmSdkBuilder.testnetTrusted();
+    const builder = wasmSDKPackage.WasmSdkBuilder.testnet();
     wasmSdk = await builder.build();
     client = EvoSDK.fromWasm(wasmSdk);
 

--- a/packages/js-evo-sdk/tests/unit/facades/documents.spec.ts
+++ b/packages/js-evo-sdk/tests/unit/facades/documents.spec.ts
@@ -23,7 +23,7 @@ describe('DocumentsFacade', () => {
 
   beforeEach(async function setup() {
     await init();
-    const builder = wasmSDKPackage.WasmSdkBuilder.testnetTrusted();
+    const builder = wasmSDKPackage.WasmSdkBuilder.testnet();
     wasmSdk = await builder.build();
     client = EvoSDK.fromWasm(wasmSdk);
 

--- a/packages/js-evo-sdk/tests/unit/facades/dpns.spec.ts
+++ b/packages/js-evo-sdk/tests/unit/facades/dpns.spec.ts
@@ -19,7 +19,7 @@ describe('DPNSFacade', () => {
 
   beforeEach(async function setup() {
     await init();
-    const builder = wasmSDKPackage.WasmSdkBuilder.testnetTrusted();
+    const builder = wasmSDKPackage.WasmSdkBuilder.testnet();
     wasmSdk = await builder.build();
     client = EvoSDK.fromWasm(wasmSdk);
 

--- a/packages/js-evo-sdk/tests/unit/facades/epoch.spec.ts
+++ b/packages/js-evo-sdk/tests/unit/facades/epoch.spec.ts
@@ -20,7 +20,7 @@ describe('EpochFacade', () => {
 
   beforeEach(async function setup() {
     await init();
-    const builder = wasmSDKPackage.WasmSdkBuilder.testnetTrusted();
+    const builder = wasmSDKPackage.WasmSdkBuilder.testnet();
     wasmSdk = await builder.build();
     client = EvoSDK.fromWasm(wasmSdk);
 

--- a/packages/js-evo-sdk/tests/unit/facades/group.spec.ts
+++ b/packages/js-evo-sdk/tests/unit/facades/group.spec.ts
@@ -28,7 +28,7 @@ describe('GroupFacade', () => {
 
   beforeEach(async function setup() {
     await init();
-    const builder = wasmSDKPackage.WasmSdkBuilder.testnetTrusted();
+    const builder = wasmSDKPackage.WasmSdkBuilder.testnet();
     wasmSdk = await builder.build();
     client = EvoSDK.fromWasm(wasmSdk);
 

--- a/packages/js-evo-sdk/tests/unit/facades/identities.spec.ts
+++ b/packages/js-evo-sdk/tests/unit/facades/identities.spec.ts
@@ -32,6 +32,7 @@ describe('IdentitiesFacade', () => {
   let getIdentityByNonUniquePublicKeyHashStub: SinonStub;
   let getIdentityByNonUniquePublicKeyHashWithProofInfoStub: SinonStub;
   let getIdentitiesContractKeysStub: SinonStub;
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   let getIdentitiesContractKeysWithProofInfoStub: SinonStub;
   let getIdentityTokenBalancesStub: SinonStub;
   let getIdentityTokenBalancesWithProofInfoStub: SinonStub;
@@ -43,7 +44,7 @@ describe('IdentitiesFacade', () => {
 
   beforeEach(async function setup() {
     await init();
-    const builder = wasmSDKPackage.WasmSdkBuilder.testnetTrusted();
+    const builder = wasmSDKPackage.WasmSdkBuilder.testnet();
     wasmSdk = await builder.build();
     client = EvoSDK.fromWasm(wasmSdk);
 
@@ -75,7 +76,8 @@ describe('IdentitiesFacade', () => {
       metadata: {},
     });
     getIdentityContractNonceStub = this.sinon.stub(wasmSdk, 'getIdentityContractNonce').resolves(BigInt(0));
-    getIdentityContractNonceWithProofInfoStub = this.sinon.stub(wasmSdk, 'getIdentityContractNonceWithProofInfo').resolves({
+    getIdentityContractNonceWithProofInfoStub = this.sinon
+      .stub(wasmSdk, 'getIdentityContractNonceWithProofInfo').resolves({
       data: BigInt(0),
       proof: {},
       metadata: {},
@@ -109,7 +111,8 @@ describe('IdentitiesFacade', () => {
         proof: {},
         metadata: {},
       });
-    getIdentityByNonUniquePublicKeyHashStub = this.sinon.stub(wasmSdk, 'getIdentityByNonUniquePublicKeyHash').resolves([]);
+    getIdentityByNonUniquePublicKeyHashStub = this.sinon
+      .stub(wasmSdk, 'getIdentityByNonUniquePublicKeyHash').resolves([]);
     getIdentityByNonUniquePublicKeyHashWithProofInfoStub = this.sinon
       .stub(wasmSdk, 'getIdentityByNonUniquePublicKeyHashWithProofInfo').resolves({
         data: [],
@@ -124,7 +127,8 @@ describe('IdentitiesFacade', () => {
         metadata: {},
       });
     getIdentityTokenBalancesStub = this.sinon.stub(wasmSdk, 'getIdentityTokenBalances').resolves(new Map());
-    getIdentityTokenBalancesWithProofInfoStub = this.sinon.stub(wasmSdk, 'getIdentityTokenBalancesWithProofInfo').resolves({
+    getIdentityTokenBalancesWithProofInfoStub = this.sinon
+      .stub(wasmSdk, 'getIdentityTokenBalancesWithProofInfo').resolves({
       data: new Map(),
       proof: {},
       metadata: {},

--- a/packages/js-evo-sdk/tests/unit/facades/protocol.spec.ts
+++ b/packages/js-evo-sdk/tests/unit/facades/protocol.spec.ts
@@ -14,7 +14,7 @@ describe('ProtocolFacade', () => {
 
   beforeEach(async function setup() {
     await init();
-    const builder = wasmSDKPackage.WasmSdkBuilder.testnetTrusted();
+    const builder = wasmSDKPackage.WasmSdkBuilder.testnet();
     wasmSdk = await builder.build();
     client = EvoSDK.fromWasm(wasmSdk);
 

--- a/packages/js-evo-sdk/tests/unit/facades/system.spec.ts
+++ b/packages/js-evo-sdk/tests/unit/facades/system.spec.ts
@@ -19,7 +19,7 @@ describe('SystemFacade', () => {
 
   beforeEach(async function setup() {
     await init();
-    const builder = wasmSDKPackage.WasmSdkBuilder.testnetTrusted();
+    const builder = wasmSDKPackage.WasmSdkBuilder.testnet();
     wasmSdk = await builder.build();
     client = EvoSDK.fromWasm(wasmSdk);
 

--- a/packages/js-evo-sdk/tests/unit/facades/tokens.spec.ts
+++ b/packages/js-evo-sdk/tests/unit/facades/tokens.spec.ts
@@ -47,7 +47,7 @@ describe('TokensFacade', () => {
 
   beforeEach(async function setup() {
     await init();
-    const builder = wasmSDKPackage.WasmSdkBuilder.testnetTrusted();
+    const builder = wasmSDKPackage.WasmSdkBuilder.testnet();
     wasmSdk = await builder.build();
     client = EvoSDK.fromWasm(wasmSdk);
 

--- a/packages/js-evo-sdk/tests/unit/facades/voting.spec.ts
+++ b/packages/js-evo-sdk/tests/unit/facades/voting.spec.ts
@@ -24,7 +24,7 @@ describe('VotingFacade', () => {
 
   beforeEach(async function setup() {
     await init();
-    const builder = wasmSDKPackage.WasmSdkBuilder.testnetTrusted();
+    const builder = wasmSDKPackage.WasmSdkBuilder.testnet();
     wasmSdk = await builder.build();
     client = EvoSDK.fromWasm(wasmSdk);
 

--- a/packages/rs-platform-version/Cargo.toml
+++ b/packages/rs-platform-version/Cargo.toml
@@ -12,7 +12,6 @@ thiserror = { version = "2.0.12" }
 bincode = { version = "=2.0.1" }
 versioned-feature-core = { git = "https://github.com/dashpay/versioned-feature-core", version = "1.0.0" }
 grovedb-version = { git = "https://github.com/dashpay/grovedb", rev = "33dfd48a1718160cb333fa95424be491785f1897" }
-once_cell = "1.19.0"
 
 [features]
 mock-versions = []

--- a/packages/rs-sdk/src/sdk.rs
+++ b/packages/rs-sdk/src/sdk.rs
@@ -889,6 +889,12 @@ impl SdkBuilder {
         }
     }
 
+    /// Replace the address list on this builder.
+    pub fn with_address_list(mut self, addresses: AddressList) -> Self {
+        self.addresses = Some(addresses);
+        self
+    }
+
     /// Create a new SdkBuilder that will generate mock client.
     pub fn new_mock() -> Self {
         Self::default()

--- a/packages/simple-signer/Cargo.toml
+++ b/packages/simple-signer/Cargo.toml
@@ -16,7 +16,6 @@ state-transitions = [
 ]
 
 [dependencies]
-bincode = { version = "=2.0.1", features = ["serde"] }
 dpp = { path = "../rs-dpp", default-features = false, features = [
     "ed25519-dalek",
 ] }

--- a/packages/simple-signer/Cargo.toml
+++ b/packages/simple-signer/Cargo.toml
@@ -19,6 +19,10 @@ state-transitions = [
 dpp = { path = "../rs-dpp", default-features = false, features = [
     "ed25519-dalek",
 ] }
+bincode = { version = "=2.0.1", features = ["serde"] }
 base64 = { version = "0.22.1" }
 hex = { version = "0.4.3" }
 tracing = "0.1.41"
+
+[package.metadata.cargo-machete]
+ignored = ["bincode"]

--- a/packages/wasm-sdk/src/context_provider.rs
+++ b/packages/wasm-sdk/src/context_provider.rs
@@ -8,14 +8,23 @@ use dash_sdk::{
 };
 use wasm_bindgen::prelude::wasm_bindgen;
 
+use crate::error::WasmSdkError;
+
 #[wasm_bindgen]
 #[derive(Clone)]
 pub struct WasmContext {}
 
-/// A wrapper for TrustedHttpContextProvider that works in WASM
+/// A wrapper for TrustedHttpContextProvider that works in WASM.
+///
+/// Holds pre-fetched quorum keys and discovered masternode addresses for
+/// proof verification and network connectivity. Create one via the async
+/// `prefetchMainnet()`, `prefetchTestnet()`, or `prefetchLocal()` factory
+/// methods, then pass it to a builder via `withTrustedContext()`.
+#[wasm_bindgen]
 #[derive(Clone)]
 pub struct WasmTrustedContext {
     inner: std::sync::Arc<rs_sdk_trusted_context_provider::TrustedHttpContextProvider>,
+    discovered_addresses: Vec<rs_dapi_client::Address>,
 }
 
 impl ContextProvider for WasmContext {
@@ -35,7 +44,6 @@ impl ContextProvider for WasmContext {
         _id: &Identifier,
         _platform_version: &PlatformVersion,
     ) -> Result<Option<Arc<DataContract>>, ContextProviderError> {
-        // Return None for now - this means the contract will be fetched from the network
         Ok(None)
     }
 
@@ -43,14 +51,6 @@ impl ContextProvider for WasmContext {
         &self,
         token_id: &Identifier,
     ) -> Result<Option<TokenConfiguration>, ContextProviderError> {
-        // For WASM context without trusted provider, we need to fetch token configuration
-        // from the network. This is a simplified implementation that would need to be
-        // enhanced with actual network fetching logic in a production environment.
-
-        // TODO: Implement actual token configuration fetching from network
-        // For now, we'll return None which will cause the proof verification to fail
-        // with a clearer error message indicating missing token configuration
-
         tracing::warn!(
             token_id = %token_id,
             "Token configuration not available in WASM context - this will cause proof verification to fail. Use trusted context builders for proof verification."
@@ -60,8 +60,6 @@ impl ContextProvider for WasmContext {
     }
 
     fn get_platform_activation_height(&self) -> Result<CoreBlockHeight, ContextProviderError> {
-        // Return a reasonable default for platform activation height
-        // This is the height at which Platform was activated on testnet
         Ok(1)
     }
 }
@@ -73,7 +71,6 @@ impl ContextProvider for WasmTrustedContext {
         quorum_hash: [u8; 32],
         core_chain_locked_height: u32,
     ) -> Result<[u8; 48], ContextProviderError> {
-        // Delegate to the inner provider
         self.inner
             .get_quorum_public_key(quorum_type, quorum_hash, core_chain_locked_height)
     }
@@ -98,82 +95,135 @@ impl ContextProvider for WasmTrustedContext {
     }
 }
 
+// JS-exported async factory methods
+#[wasm_bindgen]
 impl WasmTrustedContext {
-    pub fn new_mainnet() -> Result<Self, ContextProviderError> {
+    /// Pre-fetch quorum keys and masternode addresses for mainnet.
+    ///
+    /// Returns a ready-to-use `WasmTrustedContext` that can be passed to
+    /// `WasmSdkBuilder.mainnet().withTrustedContext(context)`.
+    #[wasm_bindgen(js_name = "prefetchMainnet")]
+    pub async fn prefetch_mainnet() -> Result<WasmTrustedContext, WasmSdkError> {
         let inner = rs_sdk_trusted_context_provider::TrustedHttpContextProvider::new(
             dash_sdk::dpp::dashcore::Network::Dash,
             None,
             std::num::NonZeroUsize::new(100).unwrap(),
         )
-        .map_err(|e| ContextProviderError::Generic(e.to_string()))?
-        .with_refetch_if_not_found(false); // Disable refetch since we'll pre-fetch
+        .map_err(|e| WasmSdkError::generic(format!("Failed to create context provider: {}", e)))?
+        .with_refetch_if_not_found(false);
 
-        Ok(Self {
-            inner: std::sync::Arc::new(inner),
+        let inner = Arc::new(inner);
+
+        inner
+            .update_quorum_caches()
+            .await
+            .map_err(|e| WasmSdkError::generic(format!("Failed to prefetch quorums: {}", e)))?;
+
+        let discovered_addresses = Self::fetch_addresses_from(&inner).await?;
+
+        Ok(WasmTrustedContext {
+            inner,
+            discovered_addresses,
         })
     }
 
-    pub fn new_testnet() -> Result<Self, ContextProviderError> {
+    /// Pre-fetch quorum keys and masternode addresses for testnet.
+    ///
+    /// Returns a ready-to-use `WasmTrustedContext` that can be passed to
+    /// `WasmSdkBuilder.testnet().withTrustedContext(context)`.
+    #[wasm_bindgen(js_name = "prefetchTestnet")]
+    pub async fn prefetch_testnet() -> Result<WasmTrustedContext, WasmSdkError> {
         let inner = rs_sdk_trusted_context_provider::TrustedHttpContextProvider::new(
             dash_sdk::dpp::dashcore::Network::Testnet,
             None,
             std::num::NonZeroUsize::new(100).unwrap(),
         )
-        .map_err(|e| ContextProviderError::Generic(e.to_string()))?
-        .with_refetch_if_not_found(false); // Disable refetch since we'll pre-fetch
+        .map_err(|e| WasmSdkError::generic(format!("Failed to create context provider: {}", e)))?
+        .with_refetch_if_not_found(false);
 
-        Ok(Self {
-            inner: std::sync::Arc::new(inner),
+        let inner = Arc::new(inner);
+
+        inner
+            .update_quorum_caches()
+            .await
+            .map_err(|e| WasmSdkError::generic(format!("Failed to prefetch quorums: {}", e)))?;
+
+        let discovered_addresses = Self::fetch_addresses_from(&inner).await?;
+
+        Ok(WasmTrustedContext {
+            inner,
+            discovered_addresses,
         })
     }
 
-    pub fn new_local() -> Result<Self, ContextProviderError> {
-        Self::new_local_with_url("http://127.0.0.1:2444")
+    /// Pre-fetch quorum keys and masternode addresses for a local network.
+    ///
+    /// Uses the default local quorum sidecar URL (`http://127.0.0.1:2444`).
+    ///
+    /// Returns a ready-to-use `WasmTrustedContext` that can be passed to
+    /// `WasmSdkBuilder.local().withTrustedContext(context)`.
+    #[wasm_bindgen(js_name = "prefetchLocal")]
+    pub async fn prefetch_local() -> Result<WasmTrustedContext, WasmSdkError> {
+        Self::prefetch_local_with_url("http://127.0.0.1:2444").await
     }
 
-    pub fn new_local_with_url(base_url: &str) -> Result<Self, ContextProviderError> {
+    /// Pre-fetch quorum keys and masternode addresses for a local network
+    /// using a custom quorum sidecar URL.
+    #[wasm_bindgen(js_name = "prefetchLocalWithUrl")]
+    pub async fn prefetch_local_with_url(
+        base_url: &str,
+    ) -> Result<WasmTrustedContext, WasmSdkError> {
         let inner = rs_sdk_trusted_context_provider::TrustedHttpContextProvider::new_with_url(
             dash_sdk::dpp::dashcore::Network::Regtest,
             base_url.to_string(),
             std::num::NonZeroUsize::new(100).unwrap(),
         )
-        .map_err(|e| ContextProviderError::Generic(e.to_string()))?
+        .map_err(|e| WasmSdkError::generic(format!("Failed to create context provider: {}", e)))?
         .with_refetch_if_not_found(false);
 
-        Ok(Self {
-            inner: std::sync::Arc::new(inner),
+        let inner = Arc::new(inner);
+
+        inner
+            .update_quorum_caches()
+            .await
+            .map_err(|e| WasmSdkError::generic(format!("Failed to prefetch quorums: {}", e)))?;
+
+        let discovered_addresses = Self::fetch_addresses_from(&inner).await?;
+
+        Ok(WasmTrustedContext {
+            inner,
+            discovered_addresses,
         })
     }
+}
 
-    /// Pre-fetch quorum information to populate the cache
-    pub async fn prefetch_quorums(&self) -> Result<(), ContextProviderError> {
-        self.inner.update_quorum_caches().await.map_err(|e| {
-            ContextProviderError::Generic(format!("Failed to prefetch quorums: {}", e))
-        })
-    }
-
-    pub async fn fetch_masternode_addresses(
-        &self,
-    ) -> Result<rs_dapi_client::AddressList, ContextProviderError> {
-        let urls = self.inner.fetch_masternode_addresses().await.map_err(|e| {
-            ContextProviderError::Generic(format!("Failed to fetch masternodes: {}", e))
-        })?;
+impl WasmTrustedContext {
+    /// Fetch masternode addresses from the trusted provider and convert to `Vec<Address>`.
+    async fn fetch_addresses_from(
+        inner: &rs_sdk_trusted_context_provider::TrustedHttpContextProvider,
+    ) -> Result<Vec<rs_dapi_client::Address>, WasmSdkError> {
+        let urls = inner
+            .fetch_masternode_addresses()
+            .await
+            .map_err(|e| WasmSdkError::generic(format!("Failed to fetch masternodes: {}", e)))?;
 
         let mut addresses = Vec::new();
         for url in urls {
             let uri = dash_sdk::sdk::Uri::from_maybe_shared(url.to_string()).map_err(|e| {
-                ContextProviderError::Generic(format!("Invalid masternode URI '{}': {}", url, e))
+                WasmSdkError::generic(format!("Invalid masternode URI '{}': {}", url, e))
             })?;
             let address = rs_dapi_client::Address::try_from(uri).map_err(|e| {
-                ContextProviderError::Generic(format!(
-                    "Invalid masternode address '{}': {}",
-                    url, e
-                ))
+                WasmSdkError::generic(format!("Invalid masternode address '{}': {}", url, e))
             })?;
             addresses.push(address);
         }
 
-        Ok(rs_dapi_client::AddressList::from_iter(addresses))
+        Ok(addresses)
+    }
+
+    /// Get the discovered addresses (for use by the builder).
+    pub(crate) fn discovered_addresses(&self) -> &[rs_dapi_client::Address] {
+        &self.discovered_addresses
     }
 
     /// Add a data contract to the known contracts cache
@@ -182,13 +232,11 @@ impl WasmTrustedContext {
     }
 
     /// Get a data contract from the known contracts cache
-    /// Returns None if the contract is not in the cache
     pub fn get_known_contract(&self, id: &Identifier) -> Option<Arc<DataContract>> {
         self.inner.get_known_contract(id)
     }
 
     /// Remove a data contract from the known contracts cache
-    /// Returns true if the contract was present and removed, false otherwise
     pub fn remove_known_contract(&self, id: &Identifier) -> bool {
         self.inner.remove_known_contract(id)
     }

--- a/packages/wasm-sdk/src/context_provider.rs
+++ b/packages/wasm-sdk/src/context_provider.rs
@@ -44,6 +44,7 @@ impl ContextProvider for WasmContext {
         _id: &Identifier,
         _platform_version: &PlatformVersion,
     ) -> Result<Option<Arc<DataContract>>, ContextProviderError> {
+        // Return None for now - this means the contract will be fetched from the network
         Ok(None)
     }
 
@@ -51,6 +52,12 @@ impl ContextProvider for WasmContext {
         &self,
         token_id: &Identifier,
     ) -> Result<Option<TokenConfiguration>, ContextProviderError> {
+        // For WASM context without trusted provider, we need to fetch token configuration
+        // from the network. This is a simplified implementation that would need to be
+        // enhanced with actual network fetching logic in a production environment.
+        // TODO: Implement actual token configuration fetching from network
+        // For now, we'll return None which will cause the proof verification to fail
+        // with a clearer error message indicating missing token configuration
         tracing::warn!(
             token_id = %token_id,
             "Token configuration not available in WASM context - this will cause proof verification to fail. Use trusted context builders for proof verification."
@@ -60,6 +67,8 @@ impl ContextProvider for WasmContext {
     }
 
     fn get_platform_activation_height(&self) -> Result<CoreBlockHeight, ContextProviderError> {
+        // Return a reasonable default for platform activation height
+        // This is the height at which Platform was activated on testnet
         Ok(1)
     }
 }
@@ -71,6 +80,7 @@ impl ContextProvider for WasmTrustedContext {
         quorum_hash: [u8; 32],
         core_chain_locked_height: u32,
     ) -> Result<[u8; 48], ContextProviderError> {
+        // Delegate to the inner provider
         self.inner
             .get_quorum_public_key(quorum_type, quorum_hash, core_chain_locked_height)
     }

--- a/packages/wasm-sdk/src/queries/token.rs
+++ b/packages/wasm-sdk/src/queries/token.rs
@@ -881,27 +881,16 @@ impl WasmSdk {
         &self,
         token_id: Identifier,
     ) -> Result<(), WasmSdkError> {
-        use crate::sdk::{LOCAL_TRUSTED_CONTEXT, MAINNET_TRUSTED_CONTEXT, TESTNET_TRUSTED_CONTEXT};
-        use dash_sdk::dpp::dashcore::Network;
         use dash_sdk::dpp::data_contract::accessors::v1::DataContractV1Getters;
         use dash_sdk::dpp::tokens::contract_info::v0::TokenContractInfoV0Accessors;
         use dash_sdk::dpp::tokens::contract_info::TokenContractInfo;
 
-        // Step 1: Check trusted context is initialized before doing any network fetches
-        let network = self.network();
-        let context_initialized = match network {
-            Network::Dash => MAINNET_TRUSTED_CONTEXT.lock().unwrap().is_some(),
-            Network::Testnet => TESTNET_TRUSTED_CONTEXT.lock().unwrap().is_some(),
-            Network::Regtest => LOCAL_TRUSTED_CONTEXT.lock().unwrap().is_some(),
-            _ => false,
-        };
-
-        if !context_initialized {
-            return Err(WasmSdkError::generic(format!(
-                "Trusted context not initialized for network {:?}. Call prefetch methods first.",
-                network
-            )));
-        }
+        // Step 1: Verify trusted context is available
+        let trusted_context = self.trusted_context().ok_or_else(|| {
+            WasmSdkError::generic(
+                "Trusted context not initialized. Use a trusted builder with a prefetched cache.",
+            )
+        })?;
 
         // Step 2: Fetch TokenContractInfo to get contract_id and position
         let token_contract_info = TokenContractInfo::fetch(self.as_ref(), token_id)
@@ -931,31 +920,7 @@ impl WasmSdk {
             .clone();
 
         // Step 5: Add the token configuration to the trusted context cache
-        // We already verified the context is initialized above, so unwrap is safe
-        match network {
-            Network::Dash => {
-                let guard = MAINNET_TRUSTED_CONTEXT.lock().unwrap();
-                guard
-                    .as_ref()
-                    .unwrap()
-                    .add_known_token_configuration(token_id, token_configuration);
-            }
-            Network::Testnet => {
-                let guard = TESTNET_TRUSTED_CONTEXT.lock().unwrap();
-                guard
-                    .as_ref()
-                    .unwrap()
-                    .add_known_token_configuration(token_id, token_configuration);
-            }
-            Network::Regtest => {
-                let guard = LOCAL_TRUSTED_CONTEXT.lock().unwrap();
-                guard
-                    .as_ref()
-                    .unwrap()
-                    .add_known_token_configuration(token_id, token_configuration);
-            }
-            _ => unreachable!(), // Already checked above
-        }
+        trusted_context.add_known_token_configuration(token_id, token_configuration);
 
         Ok(())
     }

--- a/packages/wasm-sdk/src/sdk.rs
+++ b/packages/wasm-sdk/src/sdk.rs
@@ -3,25 +3,11 @@ use crate::error::WasmSdkError;
 use dash_sdk::dpp::version::PlatformVersion;
 use dash_sdk::sdk::Uri;
 use dash_sdk::{Sdk, SdkBuilder};
-use once_cell::sync::Lazy;
 use rs_dapi_client::{Address, RequestSettings};
 use std::ops::{Deref, DerefMut};
-use std::sync::Mutex;
 use std::time::Duration;
 use wasm_bindgen::prelude::wasm_bindgen;
-pub(crate) static MAINNET_TRUSTED_CONTEXT: Lazy<Mutex<Option<WasmTrustedContext>>> =
-    Lazy::new(|| Mutex::new(None));
-pub(crate) static TESTNET_TRUSTED_CONTEXT: Lazy<Mutex<Option<WasmTrustedContext>>> =
-    Lazy::new(|| Mutex::new(None));
-pub(crate) static LOCAL_TRUSTED_CONTEXT: Lazy<Mutex<Option<WasmTrustedContext>>> =
-    Lazy::new(|| Mutex::new(None));
-const DEFAULT_LOCAL_QUORUM_URL: &str = "http://127.0.0.1:2444";
-static MAINNET_DISCOVERED_ADDRESSES: Lazy<Mutex<Option<Vec<Address>>>> =
-    Lazy::new(|| Mutex::new(None));
-static TESTNET_DISCOVERED_ADDRESSES: Lazy<Mutex<Option<Vec<Address>>>> =
-    Lazy::new(|| Mutex::new(None));
-static LOCAL_DISCOVERED_ADDRESSES: Lazy<Mutex<Option<Vec<Address>>>> =
-    Lazy::new(|| Mutex::new(None));
+
 fn parse_addresses(addresses: &'static [&str]) -> Vec<Address> {
     addresses
         .iter()
@@ -33,7 +19,6 @@ fn parse_addresses(addresses: &'static [&str]) -> Vec<Address> {
         .collect()
 }
 fn default_mainnet_addresses() -> Vec<Address> {
-    // Trimmed seed list to keep bundle size small; used only if no prefetched cache is available.
     parse_addresses(&[
         "https://149.28.241.190:443",
         "https://198.7.115.48:443",
@@ -57,91 +42,52 @@ fn default_testnet_addresses() -> Vec<Address> {
 fn default_local_addresses() -> Vec<Address> {
     parse_addresses(&["https://127.0.0.1:2443"])
 }
-async fn fetch_and_cache_addresses(
-    trusted_context: &WasmTrustedContext,
-    cache: &Lazy<Mutex<Option<Vec<Address>>>>,
-) -> Result<(), WasmSdkError> {
-    let address_list = trusted_context
-        .fetch_masternode_addresses()
-        .await
-        .map_err(|e| WasmSdkError::generic(format!("Failed to fetch masternodes: {}", e)))?;
-    let addresses: Vec<Address> = address_list
-        .into_iter()
-        .map(|(addr, _status)| addr)
-        .collect();
-    *cache.lock().unwrap() = Some(addresses);
-    Ok(())
-}
 
 #[wasm_bindgen]
-pub struct WasmSdk(Sdk);
-// Dereference JsSdk to Sdk so that we can use &JsSdk everywhere where &sdk is needed
-impl std::ops::Deref for WasmSdk {
+pub struct WasmSdk {
+    sdk: Sdk,
+    trusted_context: Option<WasmTrustedContext>,
+}
+
+// Dereference WasmSdk to Sdk so that we can use &WasmSdk everywhere where &Sdk is needed
+impl Deref for WasmSdk {
     type Target = Sdk;
     fn deref(&self) -> &Self::Target {
-        &self.0
+        &self.sdk
     }
 }
 
 impl AsRef<Sdk> for WasmSdk {
     fn as_ref(&self) -> &Sdk {
-        &self.0
-    }
-}
-
-impl From<Sdk> for WasmSdk {
-    fn from(sdk: Sdk) -> Self {
-        WasmSdk(sdk)
+        &self.sdk
     }
 }
 
 #[wasm_bindgen]
 impl WasmSdk {
     pub fn version(&self) -> u32 {
-        self.0.version().protocol_version
+        self.sdk.version().protocol_version
     }
 
     /// Get reference to the inner SDK for direct gRPC calls
     pub(crate) fn inner_sdk(&self) -> &Sdk {
-        &self.0
+        &self.sdk
     }
 
-    /// Get the network this SDK is configured for
-    pub(crate) fn network(&self) -> dash_sdk::dpp::dashcore::Network {
-        self.0.network
+    /// Get a reference to the trusted context, if available
+    pub(crate) fn trusted_context(&self) -> Option<&WasmTrustedContext> {
+        self.trusted_context.as_ref()
     }
 }
 
 impl WasmSdk {
     /// Add a data contract to the context provider's cache.
-    /// This is needed so that subsequent operations (like document transitions)
-    /// can verify proofs that reference this contract.
     pub(crate) fn add_contract_to_context_cache(
         &self,
         contract: &dash_sdk::dpp::data_contract::DataContract,
     ) -> Result<(), crate::error::WasmSdkError> {
-        match self.network() {
-            dash_sdk::dpp::dashcore::Network::Testnet => {
-                let guard = TESTNET_TRUSTED_CONTEXT.lock().unwrap();
-                if let Some(context) = guard.as_ref() {
-                    context.add_known_contract(contract.clone());
-                }
-            }
-            dash_sdk::dpp::dashcore::Network::Dash => {
-                let guard = MAINNET_TRUSTED_CONTEXT.lock().unwrap();
-                if let Some(context) = guard.as_ref() {
-                    context.add_known_contract(contract.clone());
-                }
-            }
-            dash_sdk::dpp::dashcore::Network::Regtest => {
-                let guard = LOCAL_TRUSTED_CONTEXT.lock().unwrap();
-                if let Some(context) = guard.as_ref() {
-                    context.add_known_contract(contract.clone());
-                }
-            }
-            _ => {
-                // Other networks don't use trusted context, so nothing to cache
-            }
+        if let Some(ref context) = self.trusted_context {
+            context.add_known_contract(contract.clone());
         }
         Ok(())
     }
@@ -150,15 +96,9 @@ impl WasmSdk {
 #[wasm_bindgen]
 impl WasmSdk {
     /// Forces reload of the identity nonce from Platform on the next state transition.
-    ///
-    /// This clears the cached nonce for the given identity, ensuring that the next
-    /// state transition will fetch the current nonce from Platform instead of using
-    /// a potentially stale cached value.
-    ///
-    /// @param identityId - The identifier of the identity whose nonce cache should be cleared
     #[wasm_bindgen(js_name = "refreshIdentityNonce")]
     pub async fn refresh_identity_nonce(&self, identity_id: wasm_dpp2::identifier::IdentifierWasm) {
-        self.0.refresh_identity_nonce(&identity_id.into()).await;
+        self.sdk.refresh_identity_nonce(&identity_id.into()).await;
     }
 
     /// Get a cached contract from the trusted context if available
@@ -166,112 +106,53 @@ impl WasmSdk {
         &self,
         contract_id: &dash_sdk::platform::Identifier,
     ) -> Option<std::sync::Arc<dash_sdk::platform::DataContract>> {
-        match self.network() {
-            dash_sdk::dpp::dashcore::Network::Testnet => {
-                let guard = TESTNET_TRUSTED_CONTEXT.lock().unwrap();
-                guard
-                    .as_ref()
-                    .and_then(|ctx| ctx.get_known_contract(contract_id))
-            }
-            dash_sdk::dpp::dashcore::Network::Dash => {
-                let guard = MAINNET_TRUSTED_CONTEXT.lock().unwrap();
-                guard
-                    .as_ref()
-                    .and_then(|ctx| ctx.get_known_contract(contract_id))
-            }
-            dash_sdk::dpp::dashcore::Network::Regtest => {
-                let guard = LOCAL_TRUSTED_CONTEXT.lock().unwrap();
-                guard
-                    .as_ref()
-                    .and_then(|ctx| ctx.get_known_contract(contract_id))
-            }
-            _ => None,
-        }
+        self.trusted_context
+            .as_ref()
+            .and_then(|ctx| ctx.get_known_contract(contract_id))
     }
 
     /// Cache a contract in the trusted context
     pub(crate) fn cache_contract(&self, contract: dash_sdk::platform::DataContract) {
-        match self.network() {
-            dash_sdk::dpp::dashcore::Network::Testnet => {
-                if let Some(ref context) = *TESTNET_TRUSTED_CONTEXT.lock().unwrap() {
-                    context.add_known_contract(contract);
-                }
-            }
-            dash_sdk::dpp::dashcore::Network::Dash => {
-                if let Some(ref context) = *MAINNET_TRUSTED_CONTEXT.lock().unwrap() {
-                    context.add_known_contract(contract);
-                }
-            }
-            dash_sdk::dpp::dashcore::Network::Regtest => {
-                if let Some(ref context) = *LOCAL_TRUSTED_CONTEXT.lock().unwrap() {
-                    context.add_known_contract(contract);
-                }
-            }
-            _ => {} // Other networks don't use trusted context
+        if let Some(ref context) = self.trusted_context {
+            context.add_known_contract(contract);
         }
     }
 
     /// Fetch a contract, checking cache first
-    /// Returns the contract from cache if available, otherwise fetches from network and caches it
     pub(crate) async fn get_or_fetch_contract(
         &self,
         contract_id: dash_sdk::platform::Identifier,
     ) -> Result<dash_sdk::platform::DataContract, crate::error::WasmSdkError> {
         use dash_sdk::platform::Fetch;
 
-        // Check cache first
         if let Some(cached) = self.get_cached_contract(&contract_id) {
             return Ok((*cached).clone());
         }
 
-        // Fetch from network
         let contract = dash_sdk::platform::DataContract::fetch(self.as_ref(), contract_id)
             .await?
             .ok_or_else(|| crate::error::WasmSdkError::not_found("Data contract not found"))?;
 
-        // Cache for future use
         self.cache_contract(contract.clone());
 
         Ok(contract)
     }
 
     /// Remove a contract from the cache
-    /// This allows forcing a fresh fetch on next access
     pub(crate) fn remove_cached_contract(
         &self,
         contract_id: &dash_sdk::platform::Identifier,
     ) -> bool {
-        match self.network() {
-            dash_sdk::dpp::dashcore::Network::Testnet => {
-                let guard = TESTNET_TRUSTED_CONTEXT.lock().unwrap();
-                guard
-                    .as_ref()
-                    .map(|ctx| ctx.remove_known_contract(contract_id))
-                    .unwrap_or(false)
-            }
-            dash_sdk::dpp::dashcore::Network::Dash => {
-                let guard = MAINNET_TRUSTED_CONTEXT.lock().unwrap();
-                guard
-                    .as_ref()
-                    .map(|ctx| ctx.remove_known_contract(contract_id))
-                    .unwrap_or(false)
-            }
-            dash_sdk::dpp::dashcore::Network::Regtest => {
-                let guard = LOCAL_TRUSTED_CONTEXT.lock().unwrap();
-                guard
-                    .as_ref()
-                    .map(|ctx| ctx.remove_known_contract(contract_id))
-                    .unwrap_or(false)
-            }
-            _ => false,
-        }
+        self.trusted_context
+            .as_ref()
+            .map(|ctx| ctx.remove_known_contract(contract_id))
+            .unwrap_or(false)
     }
 }
 
 #[wasm_bindgen]
 impl WasmSdk {
     /// Remove a data contract from the cache.
-    /// This forces a fresh fetch from the network on the next access.
     /// Returns true if the contract was in the cache and was removed.
     #[wasm_bindgen(js_name = "removeCachedContract")]
     pub fn remove_cached_contract_js(
@@ -284,74 +165,21 @@ impl WasmSdk {
 }
 
 #[wasm_bindgen]
-impl WasmSdk {
-    #[wasm_bindgen(js_name = "prefetchTrustedQuorumsMainnet")]
-    pub async fn prefetch_trusted_quorums_mainnet() -> Result<(), WasmSdkError> {
-        let trusted_context = WasmTrustedContext::new_mainnet()
-            .map_err(|e| WasmSdkError::from(dash_sdk::Error::from(e)))?;
-
-        trusted_context
-            .prefetch_quorums()
-            .await
-            .map_err(|e| WasmSdkError::from(dash_sdk::Error::from(e)))?;
-
-        fetch_and_cache_addresses(&trusted_context, &MAINNET_DISCOVERED_ADDRESSES).await?;
-
-        // Store the context for later use
-        *MAINNET_TRUSTED_CONTEXT.lock().unwrap() = Some(trusted_context);
-
-        Ok(())
-    }
-
-    #[wasm_bindgen(js_name = "prefetchTrustedQuorumsTestnet")]
-    pub async fn prefetch_trusted_quorums_testnet() -> Result<(), WasmSdkError> {
-        let trusted_context = WasmTrustedContext::new_testnet()
-            .map_err(|e| WasmSdkError::from(dash_sdk::Error::from(e)))?;
-
-        trusted_context
-            .prefetch_quorums()
-            .await
-            .map_err(|e| WasmSdkError::from(dash_sdk::Error::from(e)))?;
-
-        fetch_and_cache_addresses(&trusted_context, &TESTNET_DISCOVERED_ADDRESSES).await?;
-
-        // Store the context for later use
-        *TESTNET_TRUSTED_CONTEXT.lock().unwrap() = Some(trusted_context);
-
-        Ok(())
-    }
-
-    #[wasm_bindgen(js_name = "prefetchTrustedQuorumsLocal")]
-    pub async fn prefetch_trusted_quorums_local() -> Result<(), WasmSdkError> {
-        let trusted_context = WasmTrustedContext::new_local_with_url(DEFAULT_LOCAL_QUORUM_URL)
-            .map_err(|e| WasmSdkError::from(dash_sdk::Error::from(e)))?;
-
-        trusted_context
-            .prefetch_quorums()
-            .await
-            .map_err(|e| WasmSdkError::from(dash_sdk::Error::from(e)))?;
-
-        fetch_and_cache_addresses(&trusted_context, &LOCAL_DISCOVERED_ADDRESSES).await?;
-
-        *LOCAL_TRUSTED_CONTEXT.lock().unwrap() = Some(trusted_context);
-
-        Ok(())
-    }
+pub struct WasmSdkBuilder {
+    inner: SdkBuilder,
+    trusted_context: Option<WasmTrustedContext>,
 }
-
-#[wasm_bindgen]
-pub struct WasmSdkBuilder(SdkBuilder);
 
 impl Deref for WasmSdkBuilder {
     type Target = SdkBuilder;
     fn deref(&self) -> &Self::Target {
-        &self.0
+        &self.inner
     }
 }
 
 impl DerefMut for WasmSdkBuilder {
     fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut self.0
+        &mut self.inner
     }
 }
 
@@ -368,12 +196,6 @@ impl WasmSdkBuilder {
     /// # Arguments
     /// * `addresses` - Array of HTTPS URLs (e.g., ["https://127.0.0.1:1443"])
     /// * `network` - Network identifier: "mainnet", "testnet" or "local"
-    ///
-    /// # Example
-    /// ```javascript
-    /// const builder = WasmSdkBuilder.withAddresses(['https://127.0.0.1:1443'], 'testnet');
-    /// const sdk = builder.build();
-    /// ```
     #[wasm_bindgen(js_name = "withAddresses")]
     pub fn new_with_addresses(
         addresses: Vec<String>,
@@ -382,7 +204,6 @@ impl WasmSdkBuilder {
         use dash_sdk::dpp::dashcore::Network;
         use dash_sdk::sdk::Uri;
 
-        // Parse and validate addresses
         if addresses.is_empty() {
             return Err(WasmSdkError::invalid_argument(
                 "Addresses must be a non-empty array",
@@ -401,7 +222,6 @@ impl WasmSdkBuilder {
 
         let parsed_addresses = parsed_addresses.map_err(WasmSdkError::invalid_argument)?;
 
-        // Parse network - mainnet, testnet and local are supported
         let network = match network.to_lowercase().as_str() {
             "mainnet" => Network::Dash,
             "testnet" => Network::Testnet,
@@ -415,200 +235,95 @@ impl WasmSdkBuilder {
         };
 
         let address_list = dash_sdk::sdk::AddressList::from_iter(parsed_addresses);
-        let sdk_builder = match network {
-            Network::Dash => {
-                let address_list = address_list.clone();
+        let sdk_builder = SdkBuilder::new(address_list)
+            .with_network(network)
+            .with_context_provider(WasmContext {});
 
-                // Use the cached trusted context if available for mainnet
-                let context = {
-                    let guard = MAINNET_TRUSTED_CONTEXT.lock().unwrap();
-                    guard.clone()
-                }
-                .map(Ok)
-                .unwrap_or_else(|| {
-                    WasmTrustedContext::new_mainnet()
-                        .map_err(|e| WasmSdkError::from(dash_sdk::Error::from(e)))
-                })?;
-
-                SdkBuilder::new(address_list)
-                    .with_network(network)
-                    .with_context_provider(context)
-            }
-            Network::Testnet => {
-                let address_list = address_list.clone();
-
-                // Use the cached trusted context if available for testnet
-                let context = {
-                    let guard = TESTNET_TRUSTED_CONTEXT.lock().unwrap();
-                    guard.clone()
-                }
-                .map(Ok)
-                .unwrap_or_else(|| {
-                    WasmTrustedContext::new_testnet()
-                        .map_err(|e| WasmSdkError::from(dash_sdk::Error::from(e)))
-                })?;
-
-                SdkBuilder::new(address_list)
-                    .with_network(network)
-                    .with_context_provider(context)
-            }
-            Network::Regtest => {
-                let address_list = address_list.clone();
-
-                let context = {
-                    let guard = LOCAL_TRUSTED_CONTEXT.lock().unwrap();
-                    guard.clone()
-                }
-                .map(Ok)
-                .unwrap_or_else(|| {
-                    WasmTrustedContext::new_local()
-                        .map_err(|e| WasmSdkError::from(dash_sdk::Error::from(e)))
-                })?;
-
-                SdkBuilder::new(address_list)
-                    .with_network(network)
-                    .with_context_provider(context)
-            }
-            _ => unreachable!("Network already validated to mainnet, testnet or local"),
-        };
-
-        Ok(Self(sdk_builder))
+        Ok(Self {
+            inner: sdk_builder,
+            trusted_context: None,
+        })
     }
 
     #[wasm_bindgen(js_name = "mainnet")]
     pub fn new_mainnet() -> Self {
-        let mainnet_addresses = MAINNET_DISCOVERED_ADDRESSES
-            .lock()
-            .unwrap()
-            .clone()
-            .unwrap_or_else(default_mainnet_addresses);
-
-        let address_list = dash_sdk::sdk::AddressList::from_iter(mainnet_addresses);
+        let address_list = dash_sdk::sdk::AddressList::from_iter(default_mainnet_addresses());
         let sdk_builder = SdkBuilder::new(address_list)
             .with_network(dash_sdk::dpp::dashcore::Network::Dash)
             .with_context_provider(WasmContext {});
 
-        Self(sdk_builder)
+        Self {
+            inner: sdk_builder,
+            trusted_context: None,
+        }
+    }
+
+    #[wasm_bindgen(js_name = "testnet")]
+    pub fn new_testnet() -> Self {
+        let address_list = dash_sdk::sdk::AddressList::from_iter(default_testnet_addresses());
+        let sdk_builder = SdkBuilder::new(address_list)
+            .with_network(dash_sdk::dpp::dashcore::Network::Testnet)
+            .with_context_provider(WasmContext {});
+
+        Self {
+            inner: sdk_builder,
+            trusted_context: None,
+        }
     }
 
     /// Create a new SdkBuilder preconfigured for a local network using default dashmate gateway.
     #[wasm_bindgen(js_name = "local")]
     pub fn new_local() -> Self {
-        // Dashmate local gateway defaults to 2443
-        let local_addresses = vec!["https://127.0.0.1:2443".parse().unwrap()];
-
-        let address_list = dash_sdk::sdk::AddressList::from_iter(local_addresses);
+        let address_list = dash_sdk::sdk::AddressList::from_iter(default_local_addresses());
         let sdk_builder = SdkBuilder::new(address_list)
             .with_network(dash_sdk::dpp::dashcore::Network::Regtest)
             .with_context_provider(WasmContext {});
 
-        Self(sdk_builder)
+        Self {
+            inner: sdk_builder,
+            trusted_context: None,
+        }
     }
 
-    #[wasm_bindgen(js_name = "localTrusted")]
-    pub fn new_local_trusted() -> Result<Self, WasmSdkError> {
-        let trusted_context = {
-            let mut guard = LOCAL_TRUSTED_CONTEXT.lock().unwrap();
-            if let Some(ctx) = guard.as_ref() {
-                ctx.clone()
-            } else {
-                let new_ctx = WasmTrustedContext::new_local()
-                    .map_err(|e| WasmSdkError::from(dash_sdk::Error::from(e)))?;
-                *guard = Some(new_ctx.clone());
-                new_ctx
-            }
+    /// Attach a pre-fetched trusted context to this builder.
+    ///
+    /// The context provides quorum keys for proof verification and
+    /// discovered masternode addresses for network connectivity.
+    /// If the context has discovered addresses, they replace the
+    /// builder's current address list.
+    ///
+    /// # Example
+    /// ```javascript
+    /// const context = await WasmTrustedContext.prefetchTestnet();
+    /// const builder = WasmSdkBuilder.testnet().withTrustedContext(context);
+    /// const sdk = builder.build();
+    /// ```
+    #[wasm_bindgen(js_name = "withTrustedContext")]
+    pub fn with_trusted_context(self, context: &WasmTrustedContext) -> Self {
+        let discovered = context.discovered_addresses();
+
+        // Replace address list with discovered addresses if available
+        let inner = if !discovered.is_empty() {
+            let address_list = dash_sdk::sdk::AddressList::from_iter(discovered.to_vec());
+            self.inner
+                .with_address_list(address_list)
+                .with_context_provider(context.clone())
+        } else {
+            self.inner.with_context_provider(context.clone())
         };
 
-        let local_addresses = LOCAL_DISCOVERED_ADDRESSES
-            .lock()
-            .unwrap()
-            .clone()
-            .unwrap_or_else(default_local_addresses);
-
-        let address_list = dash_sdk::sdk::AddressList::from_iter(local_addresses);
-        let sdk_builder = SdkBuilder::new(address_list)
-            .with_network(dash_sdk::dpp::dashcore::Network::Regtest)
-            .with_context_provider(trusted_context);
-
-        Ok(Self(sdk_builder))
-    }
-
-    #[wasm_bindgen(js_name = "mainnetTrusted")]
-    pub fn new_mainnet_trusted() -> Result<Self, WasmSdkError> {
-        // Use the cached context if available, otherwise create a new one and store it
-        let trusted_context = {
-            let mut guard = MAINNET_TRUSTED_CONTEXT.lock().unwrap();
-            if let Some(ctx) = guard.as_ref() {
-                ctx.clone()
-            } else {
-                let new_ctx = WasmTrustedContext::new_mainnet()
-                    .map_err(|e| WasmSdkError::from(dash_sdk::Error::from(e)))?;
-                *guard = Some(new_ctx.clone());
-                new_ctx
-            }
-        };
-
-        let mainnet_addresses = MAINNET_DISCOVERED_ADDRESSES
-            .lock()
-            .unwrap()
-            .clone()
-            .unwrap_or_else(default_mainnet_addresses);
-
-        let address_list = dash_sdk::sdk::AddressList::from_iter(mainnet_addresses);
-        let sdk_builder = SdkBuilder::new(address_list)
-            .with_network(dash_sdk::dpp::dashcore::Network::Dash)
-            .with_context_provider(trusted_context);
-
-        Ok(Self(sdk_builder))
-    }
-
-    #[wasm_bindgen(js_name = "testnet")]
-    pub fn new_testnet() -> Self {
-        let testnet_addresses = TESTNET_DISCOVERED_ADDRESSES
-            .lock()
-            .unwrap()
-            .clone()
-            .unwrap_or_else(default_testnet_addresses);
-
-        let address_list = dash_sdk::sdk::AddressList::from_iter(testnet_addresses);
-        let sdk_builder = SdkBuilder::new(address_list)
-            .with_network(dash_sdk::dpp::dashcore::Network::Testnet)
-            .with_context_provider(WasmContext {});
-
-        Self(sdk_builder)
-    }
-
-    #[wasm_bindgen(js_name = "testnetTrusted")]
-    pub fn new_testnet_trusted() -> Result<Self, WasmSdkError> {
-        // Use the cached context if available, otherwise create a new one and store it
-        let trusted_context = {
-            let mut guard = TESTNET_TRUSTED_CONTEXT.lock().unwrap();
-            if let Some(ctx) = guard.as_ref() {
-                ctx.clone()
-            } else {
-                let new_ctx = WasmTrustedContext::new_testnet()
-                    .map_err(|e| WasmSdkError::from(dash_sdk::Error::from(e)))?;
-                *guard = Some(new_ctx.clone());
-                new_ctx
-            }
-        };
-
-        let testnet_addresses = TESTNET_DISCOVERED_ADDRESSES
-            .lock()
-            .unwrap()
-            .clone()
-            .unwrap_or_else(default_testnet_addresses);
-
-        let address_list = dash_sdk::sdk::AddressList::from_iter(testnet_addresses);
-        let sdk_builder = SdkBuilder::new(address_list)
-            .with_network(dash_sdk::dpp::dashcore::Network::Testnet)
-            .with_context_provider(trusted_context);
-
-        Ok(Self(sdk_builder))
+        Self {
+            inner,
+            trusted_context: Some(context.clone()),
+        }
     }
 
     pub fn build(self) -> Result<WasmSdk, WasmSdkError> {
-        self.0.build().map(WasmSdk).map_err(WasmSdkError::from)
+        let sdk = self.inner.build().map_err(WasmSdkError::from)?;
+        Ok(WasmSdk {
+            sdk,
+            trusted_context: self.trusted_context,
+        })
     }
 
     #[wasm_bindgen(js_name = "withContextProvider")]
@@ -616,17 +331,13 @@ impl WasmSdkBuilder {
         self,
         #[wasm_bindgen(js_name = "contextProvider")] context_provider: WasmContext,
     ) -> Self {
-        WasmSdkBuilder(self.0.with_context_provider(context_provider))
+        Self {
+            inner: self.inner.with_context_provider(context_provider),
+            trusted_context: None,
+        }
     }
 
     /// Configure platform version to use.
-    ///
-    /// Available versions:
-    /// - 1: Platform version 1
-    /// - 2: Platform version 2
-    /// - ... up to latest version
-    ///
-    /// Defaults to latest version if not specified.
     #[wasm_bindgen(js_name = "withVersion")]
     pub fn with_version(
         self,
@@ -639,16 +350,13 @@ impl WasmSdkBuilder {
             ))
         })?;
 
-        Ok(WasmSdkBuilder(self.0.with_version(version)))
+        Ok(Self {
+            inner: self.inner.with_version(version),
+            trusted_context: self.trusted_context,
+        })
     }
 
     /// Configure request settings for the SDK.
-    ///
-    /// Settings include:
-    /// - connect_timeout_ms: Timeout for establishing connection (in milliseconds)
-    /// - timeout_ms: Timeout for single request (in milliseconds)
-    /// - retries: Number of retries in case of failed requests
-    /// - ban_failed_address: Whether to ban DAPI address if node not responded or responded with error
     #[wasm_bindgen(js_name = "withSettings")]
     pub fn with_settings(
         self,
@@ -675,7 +383,10 @@ impl WasmSdkBuilder {
             settings.ban_failed_address = Some(ban);
         }
 
-        WasmSdkBuilder(self.0.with_settings(settings))
+        Self {
+            inner: self.inner.with_settings(settings),
+            trusted_context: self.trusted_context,
+        }
     }
 
     #[wasm_bindgen(js_name = "withProofs")]
@@ -683,16 +394,16 @@ impl WasmSdkBuilder {
         self,
         #[wasm_bindgen(js_name = "enableProofs")] enable_proofs: bool,
     ) -> Self {
-        WasmSdkBuilder(self.0.with_proofs(enable_proofs))
+        Self {
+            inner: self.inner.with_proofs(enable_proofs),
+            trusted_context: self.trusted_context,
+        }
     }
 }
 
 #[wasm_bindgen]
 impl WasmSdk {
     /// Configure tracing/logging level or filter (static, global)
-    ///
-    /// Accepts simple levels: "off", "error", "warn", "info", "debug", "trace"
-    /// or a full EnvFilter string like: "wasm_sdk=debug,rs_dapi_client=warn"
     #[wasm_bindgen(js_name = "setLogLevel")]
     pub fn set_log_level(
         #[wasm_bindgen(js_name = "levelOrFilter")] level_or_filter: &str,
@@ -704,7 +415,6 @@ impl WasmSdk {
 #[wasm_bindgen]
 impl WasmSdkBuilder {
     /// Configure tracing/logging via the builder
-    /// Returns a new builder with logging configured
     #[wasm_bindgen(js_name = "withLogs")]
     pub fn with_logs(
         self,

--- a/packages/wasm-sdk/src/sdk.rs
+++ b/packages/wasm-sdk/src/sdk.rs
@@ -18,6 +18,7 @@ fn parse_addresses(addresses: &'static [&str]) -> Vec<Address> {
         })
         .collect()
 }
+// Mainnet addresses from mnowatch.org
 fn default_mainnet_addresses() -> Vec<Address> {
     parse_addresses(&[
         "https://149.28.241.190:443",
@@ -27,6 +28,7 @@ fn default_mainnet_addresses() -> Vec<Address> {
         "https://5.189.164.253:443",
     ])
 }
+// Testnet addresses from https://quorums.testnet.networks.dash.org/masternodes
 fn default_testnet_addresses() -> Vec<Address> {
     parse_addresses(&[
         "https://52.12.176.90:1443",
@@ -338,6 +340,13 @@ impl WasmSdkBuilder {
     }
 
     /// Configure platform version to use.
+    ///
+    /// Available versions:
+    /// - 1: Platform version 1
+    /// - 2: Platform version 2
+    /// - ... up to latest version
+    ///
+    /// Defaults to latest version if not specified.
     #[wasm_bindgen(js_name = "withVersion")]
     pub fn with_version(
         self,
@@ -357,6 +366,12 @@ impl WasmSdkBuilder {
     }
 
     /// Configure request settings for the SDK.
+    ///
+    /// Settings include:
+    /// - connect_timeout_ms: Timeout for establishing connection (in milliseconds)
+    /// - timeout_ms: Timeout for single request (in milliseconds)
+    /// - retries: Number of retries in case of failed requests
+    /// - ban_failed_address: Whether to ban DAPI address if node not responded or responded with error
     #[wasm_bindgen(js_name = "withSettings")]
     pub fn with_settings(
         self,
@@ -404,6 +419,9 @@ impl WasmSdkBuilder {
 #[wasm_bindgen]
 impl WasmSdk {
     /// Configure tracing/logging level or filter (static, global)
+    ///
+    /// Accepts simple levels: "off", "error", "warn", "info", "debug", "trace"
+    /// or a full EnvFilter string like: "wasm_sdk=debug,rs_dapi_client=warn"
     #[wasm_bindgen(js_name = "setLogLevel")]
     pub fn set_log_level(
         #[wasm_bindgen(js_name = "levelOrFilter")] level_or_filter: &str,
@@ -415,6 +433,7 @@ impl WasmSdk {
 #[wasm_bindgen]
 impl WasmSdkBuilder {
     /// Configure tracing/logging via the builder
+    /// Returns a new builder with logging configured
     #[wasm_bindgen(js_name = "withLogs")]
     pub fn with_logs(
         self,

--- a/packages/wasm-sdk/tests/functional/addresses.spec.ts
+++ b/packages/wasm-sdk/tests/functional/addresses.spec.ts
@@ -13,8 +13,8 @@ describe('Platform Address Queries', function describePlatformAddressQueries() {
 
   before(async () => {
     await init();
-    await sdk.WasmSdk.prefetchTrustedQuorumsLocal();
-    const builder = sdk.WasmSdkBuilder.localTrusted();
+    const context = await sdk.WasmTrustedContext.prefetchLocal();
+    const builder = sdk.WasmSdkBuilder.local().withTrustedContext(context);
     client = await builder.build();
 
     // Use the test addresses created by SDK_TEST_DATA=true during genesis

--- a/packages/wasm-sdk/tests/functional/contracts.spec.ts
+++ b/packages/wasm-sdk/tests/functional/contracts.spec.ts
@@ -11,8 +11,8 @@ describe('Data Contract Queries', function describeDataContractQueries() {
 
   before(async () => {
     await init();
-    await sdk.WasmSdk.prefetchTrustedQuorumsLocal();
-    const builder = sdk.WasmSdkBuilder.localTrusted();
+    const context = await sdk.WasmTrustedContext.prefetchLocal();
+    const builder = sdk.WasmSdkBuilder.local().withTrustedContext(context);
     client = await builder.build();
   });
 

--- a/packages/wasm-sdk/tests/functional/dpns.spec.ts
+++ b/packages/wasm-sdk/tests/functional/dpns.spec.ts
@@ -12,8 +12,8 @@ describe('Document Queries', function describeDocumentQueries() {
 
   before(async () => {
     await init();
-    await sdk.WasmSdk.prefetchTrustedQuorumsLocal();
-    builder = sdk.WasmSdkBuilder.localTrusted();
+    const context = await sdk.WasmTrustedContext.prefetchLocal();
+    builder = sdk.WasmSdkBuilder.local().withTrustedContext(context);
     client = await builder.build();
   });
 

--- a/packages/wasm-sdk/tests/functional/epochs-blocks.spec.ts
+++ b/packages/wasm-sdk/tests/functional/epochs-blocks.spec.ts
@@ -9,8 +9,8 @@ describe('Epochs and Evonode Blocks', function describeEpochs() {
 
   before(async () => {
     await init();
-    await sdk.WasmSdk.prefetchTrustedQuorumsLocal();
-    const builder = sdk.WasmSdkBuilder.localTrusted();
+    const context = await sdk.WasmTrustedContext.prefetchLocal();
+    const builder = sdk.WasmSdkBuilder.local().withTrustedContext(context);
     client = await builder.build();
 
     // Get the proTxHash from the node status

--- a/packages/wasm-sdk/tests/functional/groups.spec.ts
+++ b/packages/wasm-sdk/tests/functional/groups.spec.ts
@@ -9,8 +9,8 @@ describe('Groups', function describeGroups() {
 
   before(async () => {
     await init();
-    await sdk.WasmSdk.prefetchTrustedQuorumsLocal();
-    builder = sdk.WasmSdkBuilder.localTrusted();
+    const context = await sdk.WasmTrustedContext.prefetchLocal();
+    builder = sdk.WasmSdkBuilder.local().withTrustedContext(context);
     client = await builder.build();
   });
 

--- a/packages/wasm-sdk/tests/functional/identities.spec.ts
+++ b/packages/wasm-sdk/tests/functional/identities.spec.ts
@@ -16,8 +16,8 @@ describe('Identities', function describeIdentities() {
 
   before(async () => {
     await init();
-    await sdk.WasmSdk.prefetchTrustedQuorumsLocal();
-    builder = sdk.WasmSdkBuilder.localTrusted();
+    const context = await sdk.WasmTrustedContext.prefetchLocal();
+    builder = sdk.WasmSdkBuilder.local().withTrustedContext(context);
     client = await builder.build();
   });
 

--- a/packages/wasm-sdk/tests/functional/protocol.spec.ts
+++ b/packages/wasm-sdk/tests/functional/protocol.spec.ts
@@ -9,8 +9,8 @@ describe('Protocol', function describeProtocol() {
 
   before(async () => {
     await init();
-    await sdk.WasmSdk.prefetchTrustedQuorumsLocal();
-    const builder = sdk.WasmSdkBuilder.localTrusted();
+    const context = await sdk.WasmTrustedContext.prefetchLocal();
+    const builder = sdk.WasmSdkBuilder.local().withTrustedContext(context);
     client = await builder.build();
 
     // Get the proTxHash from the node status

--- a/packages/wasm-sdk/tests/functional/status.spec.ts
+++ b/packages/wasm-sdk/tests/functional/status.spec.ts
@@ -9,8 +9,8 @@ describe('Status', function describeStatus() {
 
   before(async () => {
     await init();
-    await sdk.WasmSdk.prefetchTrustedQuorumsLocal();
-    builder = sdk.WasmSdkBuilder.localTrusted();
+    const context = await sdk.WasmTrustedContext.prefetchLocal();
+    builder = sdk.WasmSdkBuilder.local().withTrustedContext(context);
     client = await builder.build();
   });
 

--- a/packages/wasm-sdk/tests/functional/system.spec.ts
+++ b/packages/wasm-sdk/tests/functional/system.spec.ts
@@ -9,8 +9,8 @@ describe('System', function describeSystem() {
 
   before(async () => {
     await init();
-    await sdk.WasmSdk.prefetchTrustedQuorumsLocal();
-    builder = sdk.WasmSdkBuilder.localTrusted();
+    const context = await sdk.WasmTrustedContext.prefetchLocal();
+    builder = sdk.WasmSdkBuilder.local().withTrustedContext(context);
     client = await builder.build();
   });
 

--- a/packages/wasm-sdk/tests/functional/token-pricing.spec.ts
+++ b/packages/wasm-sdk/tests/functional/token-pricing.spec.ts
@@ -10,8 +10,8 @@ describe('TokenPricing', function describeTokenPricing() {
 
   before(async () => {
     await init();
-    await sdk.WasmSdk.prefetchTrustedQuorumsLocal();
-    builder = sdk.WasmSdkBuilder.localTrusted();
+    const context = await sdk.WasmTrustedContext.prefetchLocal();
+    builder = sdk.WasmSdkBuilder.local().withTrustedContext(context);
     client = await builder.build();
   });
 

--- a/packages/wasm-sdk/tests/functional/tokens.spec.ts
+++ b/packages/wasm-sdk/tests/functional/tokens.spec.ts
@@ -16,8 +16,8 @@ describe('Tokens', function describeTokens() {
 
   before(async () => {
     await init();
-    await sdk.WasmSdk.prefetchTrustedQuorumsLocal();
-    builder = sdk.WasmSdkBuilder.localTrusted();
+    const context = await sdk.WasmTrustedContext.prefetchLocal();
+    builder = sdk.WasmSdkBuilder.local().withTrustedContext(context);
     client = await builder.build();
   });
 

--- a/packages/wasm-sdk/tests/functional/transitions/contracts.spec.ts
+++ b/packages/wasm-sdk/tests/functional/transitions/contracts.spec.ts
@@ -25,8 +25,8 @@ describe('Contract State Transitions', function describeContractStateTransitions
 
   before(async () => {
     await init();
-    await sdk.WasmSdk.prefetchTrustedQuorumsLocal();
-    const builder = sdk.WasmSdkBuilder.localTrusted();
+    const context = await sdk.WasmTrustedContext.prefetchLocal();
+    const builder = sdk.WasmSdkBuilder.local().withTrustedContext(context);
     client = await builder.build();
   });
 

--- a/packages/wasm-sdk/tests/functional/transitions/documents.spec.ts
+++ b/packages/wasm-sdk/tests/functional/transitions/documents.spec.ts
@@ -32,8 +32,8 @@ describe('Document State Transitions', function describeDocumentStateTransitions
 
   before(async () => {
     await init();
-    await sdk.WasmSdk.prefetchTrustedQuorumsLocal();
-    const builder = sdk.WasmSdkBuilder.localTrusted();
+    const context = await sdk.WasmTrustedContext.prefetchLocal();
+    const builder = sdk.WasmSdkBuilder.local().withTrustedContext(context);
     client = await builder.build();
   });
 

--- a/packages/wasm-sdk/tests/functional/transitions/dpns.spec.ts
+++ b/packages/wasm-sdk/tests/functional/transitions/dpns.spec.ts
@@ -30,8 +30,8 @@ describe('DPNS State Transitions', function describeDpnsStateTransitions() {
 
   before(async () => {
     await init();
-    await sdk.WasmSdk.prefetchTrustedQuorumsLocal();
-    const builder = sdk.WasmSdkBuilder.localTrusted();
+    const context = await sdk.WasmTrustedContext.prefetchLocal();
+    const builder = sdk.WasmSdkBuilder.local().withTrustedContext(context);
     client = await builder.build();
   });
 

--- a/packages/wasm-sdk/tests/functional/transitions/identity.spec.ts
+++ b/packages/wasm-sdk/tests/functional/transitions/identity.spec.ts
@@ -28,8 +28,8 @@ describe('Identity State Transitions', function describeIdentityStateTransitions
 
   before(async () => {
     await init();
-    await sdk.WasmSdk.prefetchTrustedQuorumsLocal();
-    const builder = sdk.WasmSdkBuilder.localTrusted();
+    const context = await sdk.WasmTrustedContext.prefetchLocal();
+    const builder = sdk.WasmSdkBuilder.local().withTrustedContext(context);
     client = await builder.build();
   });
 

--- a/packages/wasm-sdk/tests/functional/transitions/tokens.spec.ts
+++ b/packages/wasm-sdk/tests/functional/transitions/tokens.spec.ts
@@ -32,8 +32,8 @@ describe('Token State Transitions', function describeTokenStateTransitions() {
 
   before(async () => {
     await init();
-    await sdk.WasmSdk.prefetchTrustedQuorumsLocal();
-    const builder = sdk.WasmSdkBuilder.localTrusted();
+    const context = await sdk.WasmTrustedContext.prefetchLocal();
+    const builder = sdk.WasmSdkBuilder.local().withTrustedContext(context);
     client = await builder.build();
   });
 

--- a/packages/wasm-sdk/tests/functional/utilities.spec.ts
+++ b/packages/wasm-sdk/tests/functional/utilities.spec.ts
@@ -6,9 +6,9 @@ describe('Utilities', function describeUtilities() {
 
   before(async () => { await init(); });
 
-  describe('prefetchTrustedQuorumsLocal()', () => {
+  describe('WasmTrustedContext.prefetchLocal()', () => {
     it('should prefetch trusted quorums for local', async () => {
-      await sdk.WasmSdk.prefetchTrustedQuorumsLocal();
+      await sdk.WasmTrustedContext.prefetchLocal();
     });
   });
 

--- a/packages/wasm-sdk/tests/functional/voting.spec.ts
+++ b/packages/wasm-sdk/tests/functional/voting.spec.ts
@@ -10,8 +10,8 @@ describe('Voting', function describeVoting() {
 
   before(async () => {
     await init();
-    await sdk.WasmSdk.prefetchTrustedQuorumsLocal();
-    builder = sdk.WasmSdkBuilder.localTrusted();
+    const context = await sdk.WasmTrustedContext.prefetchLocal();
+    builder = sdk.WasmSdkBuilder.local().withTrustedContext(context);
     client = await builder.build();
   });
 

--- a/packages/wasm-sdk/tests/unit/builder.spec.ts
+++ b/packages/wasm-sdk/tests/unit/builder.spec.ts
@@ -26,6 +26,10 @@ describe('WasmSdkBuilder', () => {
     it('should expose local method', () => {
       expect(sdk.WasmSdkBuilder.local).to.be.a('function');
     });
+
+    it('should expose withAddresses method', () => {
+      expect(sdk.WasmSdkBuilder.withAddresses).to.be.a('function');
+    });
   });
 
   describe('testnet()', () => {

--- a/packages/wasm-sdk/tests/unit/builder.spec.ts
+++ b/packages/wasm-sdk/tests/unit/builder.spec.ts
@@ -23,12 +23,8 @@ describe('WasmSdkBuilder', () => {
       expect(sdk.WasmSdkBuilder.testnet).to.be.a('function');
     });
 
-    it('should expose mainnetTrusted method', () => {
-      expect(sdk.WasmSdkBuilder.mainnetTrusted).to.be.a('function');
-    });
-
-    it('should expose testnetTrusted method', () => {
-      expect(sdk.WasmSdkBuilder.testnetTrusted).to.be.a('function');
+    it('should expose local method', () => {
+      expect(sdk.WasmSdkBuilder.local).to.be.a('function');
     });
   });
 


### PR DESCRIPTION
## Issue being fixed or feature implemented

The wasm-sdk used 6 `Lazy<Mutex<Option<T>>>` static globals for managing trusted context and discovered masternode addresses. This shared mutable state made the SDK harder to reason about, prevented multiple SDK instances with different configurations, and coupled context lifetime to the process rather than the SDK instance.

## What was done?

Replaced all 6 static globals with instance-owned state by introducing `WasmTrustedContext` as a JS-exported object with async prefetch factories:

**Rust changes:**
- `WasmTrustedContext` now holds `Arc<TrustedHttpContextProvider>` + `Vec<Address>` with `prefetchMainnet()`, `prefetchTestnet()`, `prefetchLocal()`, `prefetchLocalWithUrl()` async factory methods
- `WasmSdkBuilder` gained `withTrustedContext(context)` that sets the context provider and replaces addresses with discovered ones
- `WasmSdk` is now a named struct with `trusted_context: Option<WasmTrustedContext>` for contract/token cache access
- Removed `prefetchTrustedQuorums*` static methods from `WasmSdk`
- Removed `*Trusted()` builder methods (replaced by `builder.local().withTrustedContext(context)`)
- Removed all 6 `Lazy<Mutex<Option<T>>>` statics and their `once_cell`/`std::sync::Mutex` imports
- Added `with_address_list()` to `SdkBuilder` in rs-sdk
- Simplified `prefetch_token_configuration` in `queries/token.rs` to use `self.trusted_context` directly

**JS changes:**
- `EvoSDK.connect()` updated to prefetch `WasmTrustedContext` and pass it via `withTrustedContext()`
- Fixed all eslint warnings across js-evo-sdk (max-len, curly, unused vars)

**New JS API:**

```js
// Before:
await WasmSdk.prefetchTrustedQuorumsLocal();
const builder = WasmSdkBuilder.localTrusted();

// After:
const context = await WasmTrustedContext.prefetchLocal();
const builder = WasmSdkBuilder.local().withTrustedContext(context);
```

## How Has This Been Tested?

- `cargo fmt --all` — clean
- `cargo clippy -p wasm-sdk -p dash-sdk` — clean
- wasm-sdk build (`./build.sh`) — success
- wasm-sdk unit tests — 212 passed
- js-evo-sdk build — success
- js-evo-sdk unit tests — 172 passed (Node.js + Chrome headless)
- js-evo-sdk eslint — 0 errors, 0 warnings

## Breaking Changes

- `WasmSdk.prefetchTrustedQuorumsMainnet/Testnet/Local()` removed — use `WasmTrustedContext.prefetchMainnet/Testnet/Local()` instead
- `WasmSdkBuilder.mainnetTrusted/testnetTrusted/localTrusted()` removed — use `WasmSdkBuilder.mainnet/testnet/local().withTrustedContext(context)` instead
- `WasmSdkBuilder.withAddresses()` no longer accepts an optional cache parameter

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [x] I have made corresponding changes to the documentation if needed

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New trusted-context prefetch factories (mainnet/testnet/local) and ability to attach a prefetched trusted context to a builder; builder now supports per-instance wiring, addresses, version, proofs, logs, and settings.
  * Rust SDK: added builder step to replace address lists.

* **Bug Fixes**
  * Unknown-network cases now fail fast with explicit errors.

* **Tests**
  * Updated unit and functional tests to use the new trusted-context + builder flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->