### PR TITLE
fix(sdk): outdated platfrom version in JS SDK

### DIFF
--- a/packages/wasm-dpp2/src/version.rs
+++ b/packages/wasm-dpp2/src/version.rs
@@ -1,21 +1,13 @@
 use crate::error::WasmDppError;
+use crate::impl_wasm_type_info;
+use crate::utils::{IntoWasm, try_to_u32};
 use dpp::version::PlatformVersion;
-use dpp::version::v1::PLATFORM_V1;
-use dpp::version::v2::PLATFORM_V2;
-use dpp::version::v3::PLATFORM_V3;
-use dpp::version::v4::PLATFORM_V4;
-use dpp::version::v5::PLATFORM_V5;
-use dpp::version::v6::PLATFORM_V6;
-use dpp::version::v7::PLATFORM_V7;
-use dpp::version::v8::PLATFORM_V8;
-use dpp::version::v9::PLATFORM_V9;
-use dpp::version::v10::PLATFORM_V10;
 use wasm_bindgen::JsValue;
 use wasm_bindgen::prelude::wasm_bindgen;
 
 #[wasm_bindgen(typescript_custom_section)]
 const PLATFORM_VERSION_LIKE_TS: &str = r#"
-export type PlatformVersionLike = PlatformVersion | string | number;
+export type PlatformVersionLike = PlatformVersion | number;
 "#;
 
 #[wasm_bindgen]
@@ -41,20 +33,56 @@ impl TryFrom<PlatformVersionLikeJs> for PlatformVersion {
 }
 
 #[wasm_bindgen(js_name = "PlatformVersion")]
-#[derive(Default)]
-#[allow(non_camel_case_types)]
-pub enum PlatformVersionWasm {
-    #[default]
-    PLATFORM_V1 = 1,
-    PLATFORM_V2 = 2,
-    PLATFORM_V3 = 3,
-    PLATFORM_V4 = 4,
-    PLATFORM_V5 = 5,
-    PLATFORM_V6 = 6,
-    PLATFORM_V7 = 7,
-    PLATFORM_V8 = 8,
-    PLATFORM_V9 = 9,
-    PLATFORM_V10 = 10,
+#[derive(Clone)]
+pub struct PlatformVersionWasm {
+    version: u32,
+}
+
+impl_wasm_type_info!(PlatformVersionWasm, PlatformVersion);
+
+#[wasm_bindgen(js_class = "PlatformVersion")]
+impl PlatformVersionWasm {
+    #[wasm_bindgen(constructor)]
+    pub fn new(version: u32) -> Result<PlatformVersionWasm, WasmDppError> {
+        PlatformVersion::get(version).map_err(|_| {
+            WasmDppError::invalid_argument(format!("unknown platform version: {}", version))
+        })?;
+        Ok(PlatformVersionWasm { version })
+    }
+
+    #[wasm_bindgen(js_name = "latest")]
+    pub fn latest() -> PlatformVersionWasm {
+        PlatformVersionWasm {
+            version: PlatformVersion::latest().protocol_version,
+        }
+    }
+
+    #[wasm_bindgen(js_name = "first")]
+    pub fn first() -> PlatformVersionWasm {
+        PlatformVersionWasm {
+            version: PlatformVersion::first().protocol_version,
+        }
+    }
+
+    #[wasm_bindgen(js_name = "current")]
+    pub fn current() -> PlatformVersionWasm {
+        PlatformVersionWasm {
+            version: PlatformVersion::desired().protocol_version,
+        }
+    }
+
+    #[wasm_bindgen(getter)]
+    pub fn version(&self) -> u32 {
+        self.version
+    }
+}
+
+impl Default for PlatformVersionWasm {
+    fn default() -> Self {
+        PlatformVersionWasm {
+            version: PlatformVersion::desired().protocol_version,
+        }
+    }
 }
 
 impl TryFrom<&JsValue> for PlatformVersionWasm {
@@ -66,51 +94,19 @@ impl TryFrom<&JsValue> for PlatformVersionWasm {
             return Ok(Self::default());
         }
 
-        if value.is_string() {
-            match value.as_string() {
-                None => Err(WasmDppError::invalid_argument(
-                    "cannot read value from enum",
-                )),
-                Some(enum_val) => match enum_val.to_lowercase().as_str() {
-                    "platform_v1" => Ok(PlatformVersionWasm::PLATFORM_V1),
-                    "platform_v2" => Ok(PlatformVersionWasm::PLATFORM_V2),
-                    "platform_v3" => Ok(PlatformVersionWasm::PLATFORM_V3),
-                    "platform_v4" => Ok(PlatformVersionWasm::PLATFORM_V4),
-                    "platform_v5" => Ok(PlatformVersionWasm::PLATFORM_V5),
-                    "platform_v6" => Ok(PlatformVersionWasm::PLATFORM_V6),
-                    "platform_v7" => Ok(PlatformVersionWasm::PLATFORM_V7),
-                    "platform_v8" => Ok(PlatformVersionWasm::PLATFORM_V8),
-                    "platform_v9" => Ok(PlatformVersionWasm::PLATFORM_V9),
-                    "platform_v10" => Ok(PlatformVersionWasm::PLATFORM_V10),
-                    _ => Err(WasmDppError::invalid_argument(format!(
-                        "unknown platform version value: {}",
-                        enum_val
-                    ))),
-                },
-            }
-        } else {
-            match value.as_f64() {
-                None => Err(WasmDppError::invalid_argument(
-                    "cannot read value from enum",
-                )),
-                Some(enum_val) => match enum_val as u8 {
-                    1 => Ok(PlatformVersionWasm::PLATFORM_V1),
-                    2 => Ok(PlatformVersionWasm::PLATFORM_V2),
-                    3 => Ok(PlatformVersionWasm::PLATFORM_V3),
-                    4 => Ok(PlatformVersionWasm::PLATFORM_V4),
-                    5 => Ok(PlatformVersionWasm::PLATFORM_V5),
-                    6 => Ok(PlatformVersionWasm::PLATFORM_V6),
-                    7 => Ok(PlatformVersionWasm::PLATFORM_V7),
-                    8 => Ok(PlatformVersionWasm::PLATFORM_V8),
-                    9 => Ok(PlatformVersionWasm::PLATFORM_V9),
-                    10 => Ok(PlatformVersionWasm::PLATFORM_V10),
-                    _ => Err(WasmDppError::invalid_argument(format!(
-                        "unknown platform version value: {}",
-                        enum_val
-                    ))),
-                },
-            }
+        // Detect PlatformVersionWasm instance via to_wasm
+        if let Ok(wasm_ref) = value.to_wasm::<PlatformVersionWasm>("PlatformVersion") {
+            return Ok(wasm_ref.clone());
         }
+
+        // Otherwise treat as raw number
+        let version = try_to_u32(value, "platformVersion")?;
+
+        PlatformVersion::get(version).map_err(|_| {
+            WasmDppError::invalid_argument(format!("unknown platform version: {}", version))
+        })?;
+
+        Ok(PlatformVersionWasm { version })
     }
 }
 
@@ -122,36 +118,10 @@ impl TryFrom<JsValue> for PlatformVersionWasm {
     }
 }
 
-impl From<PlatformVersionWasm> for String {
-    fn from(version: PlatformVersionWasm) -> String {
-        match version {
-            PlatformVersionWasm::PLATFORM_V1 => String::from("PLATFORM_V1"),
-            PlatformVersionWasm::PLATFORM_V2 => String::from("PLATFORM_V2"),
-            PlatformVersionWasm::PLATFORM_V3 => String::from("PLATFORM_V3"),
-            PlatformVersionWasm::PLATFORM_V4 => String::from("PLATFORM_V4"),
-            PlatformVersionWasm::PLATFORM_V5 => String::from("PLATFORM_V5"),
-            PlatformVersionWasm::PLATFORM_V6 => String::from("PLATFORM_V6"),
-            PlatformVersionWasm::PLATFORM_V7 => String::from("PLATFORM_V7"),
-            PlatformVersionWasm::PLATFORM_V8 => String::from("PLATFORM_V8"),
-            PlatformVersionWasm::PLATFORM_V9 => String::from("PLATFORM_V9"),
-            PlatformVersionWasm::PLATFORM_V10 => String::from("PLATFORM_V10"),
-        }
-    }
-}
-
 impl From<PlatformVersionWasm> for PlatformVersion {
     fn from(value: PlatformVersionWasm) -> Self {
-        match value {
-            PlatformVersionWasm::PLATFORM_V1 => PLATFORM_V1,
-            PlatformVersionWasm::PLATFORM_V2 => PLATFORM_V2,
-            PlatformVersionWasm::PLATFORM_V3 => PLATFORM_V3,
-            PlatformVersionWasm::PLATFORM_V4 => PLATFORM_V4,
-            PlatformVersionWasm::PLATFORM_V5 => PLATFORM_V5,
-            PlatformVersionWasm::PLATFORM_V6 => PLATFORM_V6,
-            PlatformVersionWasm::PLATFORM_V7 => PLATFORM_V7,
-            PlatformVersionWasm::PLATFORM_V8 => PLATFORM_V8,
-            PlatformVersionWasm::PLATFORM_V9 => PLATFORM_V9,
-            PlatformVersionWasm::PLATFORM_V10 => PLATFORM_V10,
-        }
+        PlatformVersion::get(value.version)
+            .expect("PlatformVersionWasm should always contain a valid version")
+            .clone()
     }
 }

--- a/packages/wasm-dpp2/src/version.rs
+++ b/packages/wasm-dpp2/src/version.rs
@@ -34,9 +34,7 @@ impl TryFrom<PlatformVersionLikeJs> for PlatformVersion {
 
 #[wasm_bindgen(js_name = "PlatformVersion")]
 #[derive(Clone)]
-pub struct PlatformVersionWasm {
-    version: u32,
-}
+pub struct PlatformVersionWasm(u32);
 
 impl_wasm_type_info!(PlatformVersionWasm, PlatformVersion);
 
@@ -47,41 +45,33 @@ impl PlatformVersionWasm {
         PlatformVersion::get(version).map_err(|_| {
             WasmDppError::invalid_argument(format!("unknown platform version: {}", version))
         })?;
-        Ok(PlatformVersionWasm { version })
+        Ok(PlatformVersionWasm(version))
     }
 
     #[wasm_bindgen(js_name = "latest")]
     pub fn latest() -> PlatformVersionWasm {
-        PlatformVersionWasm {
-            version: PlatformVersion::latest().protocol_version,
-        }
+        PlatformVersionWasm(PlatformVersion::latest().protocol_version)
     }
 
     #[wasm_bindgen(js_name = "first")]
     pub fn first() -> PlatformVersionWasm {
-        PlatformVersionWasm {
-            version: PlatformVersion::first().protocol_version,
-        }
+        PlatformVersionWasm(PlatformVersion::first().protocol_version)
     }
 
     #[wasm_bindgen(js_name = "current")]
     pub fn current() -> PlatformVersionWasm {
-        PlatformVersionWasm {
-            version: PlatformVersion::desired().protocol_version,
-        }
+        PlatformVersionWasm(PlatformVersion::desired().protocol_version)
     }
 
     #[wasm_bindgen(getter)]
     pub fn version(&self) -> u32 {
-        self.version
+        self.0
     }
 }
 
 impl Default for PlatformVersionWasm {
     fn default() -> Self {
-        PlatformVersionWasm {
-            version: PlatformVersion::desired().protocol_version,
-        }
+        PlatformVersionWasm(PlatformVersion::desired().protocol_version)
     }
 }
 
@@ -106,7 +96,7 @@ impl TryFrom<&JsValue> for PlatformVersionWasm {
             WasmDppError::invalid_argument(format!("unknown platform version: {}", version))
         })?;
 
-        Ok(PlatformVersionWasm { version })
+        Ok(PlatformVersionWasm(version))
     }
 }
 
@@ -120,7 +110,7 @@ impl TryFrom<JsValue> for PlatformVersionWasm {
 
 impl From<PlatformVersionWasm> for PlatformVersion {
     fn from(value: PlatformVersionWasm) -> Self {
-        PlatformVersion::get(value.version)
+        PlatformVersion::get(value.0)
             .expect("PlatformVersionWasm should always contain a valid version")
             .clone()
     }

--- a/packages/wasm-dpp2/tests/unit/DataContract.spec.ts
+++ b/packages/wasm-dpp2/tests/unit/DataContract.spec.ts
@@ -61,17 +61,17 @@ describe('DataContract', () => {
 
       const dataContract = wasm.DataContract.fromJSON(json, true);
 
-      expect(dataContract.toBytes()).to.deep.equal(fromHexString(dataContractBytes));
+      expect(dataContract.toBytes(new PlatformVersion(1))).to.deep.equal(fromHexString(dataContractBytes));
 
       const dataContractFromBytes = wasm.DataContract.fromBytes(
-        dataContract.toBytes(),
+        dataContract.toBytes(new PlatformVersion(1)),
         false,
-        PlatformVersion.PLATFORM_V1,
+        new PlatformVersion(1),
       );
 
       expect(dataContract).to.be.an.instanceof(wasm.DataContract);
 
-      expect(dataContractFromBytes.toBytes()).to.deep.equal(fromHexString(dataContractBytes));
+      expect(dataContractFromBytes.toBytes(new PlatformVersion(1))).to.deep.equal(fromHexString(dataContractBytes));
     });
 
     it('should allow to create DataContract from bytes without full validation', () => {
@@ -80,7 +80,7 @@ describe('DataContract', () => {
       const dataContractFromBytes = wasm.DataContract.fromBytes(
         fromHexString(dataContractBytes),
         false,
-        PlatformVersion.PLATFORM_V1,
+        new PlatformVersion(1),
       );
       const dataContractFromValue = wasm.DataContract.fromJSON(json, true);
 
@@ -103,15 +103,15 @@ describe('DataContract', () => {
   describe('fromObject()', () => {
     it('should allow to create DataContract from object produced by toObject', () => {
       const originalContract = wasm.DataContract.fromJSON(json, true);
-      const objectRepresentation = originalContract.toObject(PlatformVersion.PLATFORM_V1);
+      const objectRepresentation = originalContract.toObject(new PlatformVersion(1));
 
       const reconstructedContract = wasm.DataContract.fromObject(
         objectRepresentation,
         true,
-        PlatformVersion.PLATFORM_V1,
+        new PlatformVersion(1),
       );
 
-      expect(reconstructedContract.toObject(PlatformVersion.PLATFORM_V1)).to.deep.equal(
+      expect(reconstructedContract.toObject(new PlatformVersion(1))).to.deep.equal(
         objectRepresentation,
       );
     });
@@ -124,11 +124,11 @@ describe('DataContract', () => {
       const dataContract = wasm.DataContract.fromBytes(
         fromHexString(dataContractBytes),
         true,
-        PlatformVersion.PLATFORM_V1,
+        new PlatformVersion(1),
       );
 
-      const base64 = dataContract.toBase64(PlatformVersion.PLATFORM_V1);
-      const bytes = dataContract.toBytes(PlatformVersion.PLATFORM_V1);
+      const base64 = dataContract.toBase64(new PlatformVersion(1));
+      const bytes = dataContract.toBytes(new PlatformVersion(1));
       const bytesFromBase64 = Buffer.from(base64, 'base64');
 
       expect(bytesFromBase64).to.deep.equal(Buffer.from(bytes));
@@ -136,11 +136,11 @@ describe('DataContract', () => {
       const dataContractFromBase64 = wasm.DataContract.fromBase64(
         base64,
         true,
-        PlatformVersion.PLATFORM_V1,
+        new PlatformVersion(1),
       );
 
       const actualBytes = Buffer.from(
-        dataContractFromBase64.toBytes(PlatformVersion.PLATFORM_V1),
+        dataContractFromBase64.toBytes(new PlatformVersion(1)),
       );
       expect(actualBytes).to.deep.equal(Buffer.from(bytes));
     });
@@ -150,7 +150,7 @@ describe('DataContract', () => {
     it('should allow to get json', () => {
       const dataContract = wasm.DataContract.fromJSON(json, true);
 
-      expect(dataContract.toJSON()).to.deep.equal(json);
+      expect(dataContract.toJSON(new PlatformVersion(1))).to.deep.equal(json);
     });
   });
 
@@ -232,7 +232,7 @@ describe('DataContract', () => {
 
       const newConfig = { ...oldConfig, canBeDeleted: !oldConfig.canBeDeleted };
 
-      dataContract.setConfig(newConfig, PlatformVersion.PLATFORM_V1);
+      dataContract.setConfig(newConfig, new PlatformVersion(1));
 
       expect(dataContract.config).to.deep.equal(newConfig);
     });
@@ -247,7 +247,7 @@ describe('DataContract', () => {
         pupup: json.documentSchemas.withdrawal,
       };
 
-      dataContract.setSchemas(newSchema, null, true, PlatformVersion.PLATFORM_V1);
+      dataContract.setSchemas(newSchema, null, true, new PlatformVersion(1));
 
       const { schemas } = dataContract;
 

--- a/packages/wasm-dpp2/tests/unit/DataContractCreateStateTransition.spec.ts
+++ b/packages/wasm-dpp2/tests/unit/DataContractCreateStateTransition.spec.ts
@@ -13,7 +13,7 @@ before(async () => {
 describe('DataContractCreateTransition', () => {
   describe('constructor()', () => {
     it('should create transition from data contract', () => {
-      const dataContract = wasm.DataContract.fromJSON(value, false, PlatformVersion.PLATFORM_V1);
+      const dataContract = wasm.DataContract.fromJSON(value, false, new PlatformVersion(1));
 
       const dataContractTransition = new wasm.DataContractCreateTransition(dataContract, BigInt(1));
 
@@ -24,7 +24,7 @@ describe('DataContractCreateTransition', () => {
 
   describe('toBytes()', () => {
     it('should convert transition to bytes', () => {
-      const dataContract = wasm.DataContract.fromJSON(value, false, PlatformVersion.PLATFORM_V1);
+      const dataContract = wasm.DataContract.fromJSON(value, false, new PlatformVersion(1));
 
       const dataContractTransition = new wasm.DataContractCreateTransition(dataContract, BigInt(1));
 
@@ -37,7 +37,7 @@ describe('DataContractCreateTransition', () => {
 
   describe('fromBytes()', () => {
     it('should create transition from bytes', () => {
-      const dataContract = wasm.DataContract.fromJSON(value, false, PlatformVersion.PLATFORM_V1);
+      const dataContract = wasm.DataContract.fromJSON(value, false, new PlatformVersion(1));
 
       const dataContractTransition = new wasm.DataContractCreateTransition(dataContract, BigInt(1));
 
@@ -54,7 +54,7 @@ describe('DataContractCreateTransition', () => {
 
   describe('toStateTransition()', () => {
     it('should convert to state transition', () => {
-      const dataContract = wasm.DataContract.fromJSON(value, false, PlatformVersion.PLATFORM_V1);
+      const dataContract = wasm.DataContract.fromJSON(value, false, new PlatformVersion(1));
 
       const dataContractTransition = new wasm.DataContractCreateTransition(dataContract, BigInt(1));
 
@@ -68,7 +68,7 @@ describe('DataContractCreateTransition', () => {
 
   describe('fromStateTransition()', () => {
     it('should create transition from state transition', () => {
-      const dataContract = wasm.DataContract.fromJSON(value, false, PlatformVersion.PLATFORM_V1);
+      const dataContract = wasm.DataContract.fromJSON(value, false, new PlatformVersion(1));
 
       const dataContractTransition = new wasm.DataContractCreateTransition(dataContract, BigInt(1));
 
@@ -82,7 +82,7 @@ describe('DataContractCreateTransition', () => {
 
   describe('featureVersion', () => {
     it('should return feature version', () => {
-      const dataContract = wasm.DataContract.fromJSON(value, false, PlatformVersion.PLATFORM_V1);
+      const dataContract = wasm.DataContract.fromJSON(value, false, new PlatformVersion(1));
 
       const dataContractTransition = new wasm.DataContractCreateTransition(dataContract, BigInt(1));
 
@@ -92,7 +92,7 @@ describe('DataContractCreateTransition', () => {
 
   describe('verifyProtocolVersion()', () => {
     it('should return true for valid protocol version', () => {
-      const dataContract = wasm.DataContract.fromJSON(value, false, PlatformVersion.PLATFORM_V1);
+      const dataContract = wasm.DataContract.fromJSON(value, false, new PlatformVersion(1));
 
       const dataContractTransition = new wasm.DataContractCreateTransition(dataContract, BigInt(1));
 
@@ -100,7 +100,7 @@ describe('DataContractCreateTransition', () => {
     });
 
     it('should throw for invalid protocol version', () => {
-      const dataContract = wasm.DataContract.fromJSON(value, false, PlatformVersion.PLATFORM_V1);
+      const dataContract = wasm.DataContract.fromJSON(value, false, new PlatformVersion(1));
 
       const dataContractTransition = new wasm.DataContractCreateTransition(dataContract, BigInt(1));
 
@@ -115,7 +115,7 @@ describe('DataContractCreateTransition', () => {
 
   describe('getDataContract()', () => {
     it('should return data contract', () => {
-      const dataContract = wasm.DataContract.fromJSON(value, false, PlatformVersion.PLATFORM_V1);
+      const dataContract = wasm.DataContract.fromJSON(value, false, new PlatformVersion(1));
 
       const dataContractTransition = new wasm.DataContractCreateTransition(dataContract, BigInt(1));
 
@@ -129,15 +129,15 @@ describe('DataContractCreateTransition', () => {
     it('should set the data contract', () => {
       const [dataContractBytes] = dataContractsBytes;
 
-      const dataContract = wasm.DataContract.fromJSON(value, false, PlatformVersion.PLATFORM_V1);
+      const dataContract = wasm.DataContract.fromJSON(value, false, new PlatformVersion(1));
 
       const dataContractTransition = new wasm.DataContractCreateTransition(dataContract, BigInt(1));
 
-      const newDataContract = wasm.DataContract.fromBytes(fromHexString(dataContractBytes), false, PlatformVersion.PLATFORM_V1);
+      const newDataContract = wasm.DataContract.fromBytes(fromHexString(dataContractBytes), false, new PlatformVersion(1));
 
       dataContractTransition.setDataContract(newDataContract);
 
-      expect(fromHexString(dataContractBytes)).to.deep.equal(dataContractTransition.getDataContract().toBytes());
+      expect(fromHexString(dataContractBytes)).to.deep.equal(dataContractTransition.getDataContract().toBytes(new PlatformVersion(1)));
     });
   });
 });

--- a/packages/wasm-dpp2/tests/unit/DataContractUpdateStateTransition.spec.ts
+++ b/packages/wasm-dpp2/tests/unit/DataContractUpdateStateTransition.spec.ts
@@ -13,7 +13,7 @@ before(async () => {
 describe('DataContractUpdateTransition', () => {
   describe('constructor()', () => {
     it('should create transition from data contract', () => {
-      const dataContract = wasm.DataContract.fromJSON(value, false, PlatformVersion.PLATFORM_V1);
+      const dataContract = wasm.DataContract.fromJSON(value, false, new PlatformVersion(1));
 
       const dataContractTransition = new wasm.DataContractUpdateTransition(dataContract, BigInt(1));
 
@@ -24,7 +24,7 @@ describe('DataContractUpdateTransition', () => {
 
   describe('toBytes()', () => {
     it('should convert transition to bytes', () => {
-      const dataContract = wasm.DataContract.fromJSON(value, false, PlatformVersion.PLATFORM_V1);
+      const dataContract = wasm.DataContract.fromJSON(value, false, new PlatformVersion(1));
 
       const dataContractTransition = new wasm.DataContractUpdateTransition(dataContract, BigInt(1));
 
@@ -37,7 +37,7 @@ describe('DataContractUpdateTransition', () => {
 
   describe('fromBytes()', () => {
     it('should create transition from bytes', () => {
-      const dataContract = wasm.DataContract.fromJSON(value, false, PlatformVersion.PLATFORM_V1);
+      const dataContract = wasm.DataContract.fromJSON(value, false, new PlatformVersion(1));
 
       const dataContractTransition = new wasm.DataContractUpdateTransition(dataContract, BigInt(1));
 
@@ -54,7 +54,7 @@ describe('DataContractUpdateTransition', () => {
 
   describe('toStateTransition()', () => {
     it('should convert to state transition', () => {
-      const dataContract = wasm.DataContract.fromJSON(value, false, PlatformVersion.PLATFORM_V1);
+      const dataContract = wasm.DataContract.fromJSON(value, false, new PlatformVersion(1));
 
       const dataContractTransition = new wasm.DataContractUpdateTransition(dataContract, BigInt(1));
 
@@ -68,7 +68,7 @@ describe('DataContractUpdateTransition', () => {
 
   describe('fromStateTransition()', () => {
     it('should create transition from state transition', () => {
-      const dataContract = wasm.DataContract.fromJSON(value, false, PlatformVersion.PLATFORM_V1);
+      const dataContract = wasm.DataContract.fromJSON(value, false, new PlatformVersion(1));
 
       const dataContractTransition = new wasm.DataContractUpdateTransition(dataContract, BigInt(1));
 
@@ -82,7 +82,7 @@ describe('DataContractUpdateTransition', () => {
 
   describe('featureVersion', () => {
     it('should return feature version', () => {
-      const dataContract = wasm.DataContract.fromJSON(value, false, PlatformVersion.PLATFORM_V1);
+      const dataContract = wasm.DataContract.fromJSON(value, false, new PlatformVersion(1));
 
       const dataContractTransition = new wasm.DataContractUpdateTransition(dataContract, BigInt(1));
 
@@ -92,7 +92,7 @@ describe('DataContractUpdateTransition', () => {
 
   describe('verifyProtocolVersion()', () => {
     it('should return true for valid protocol version', () => {
-      const dataContract = wasm.DataContract.fromJSON(value, false, PlatformVersion.PLATFORM_V1);
+      const dataContract = wasm.DataContract.fromJSON(value, false, new PlatformVersion(1));
 
       const dataContractTransition = new wasm.DataContractUpdateTransition(dataContract, BigInt(1));
 
@@ -100,7 +100,7 @@ describe('DataContractUpdateTransition', () => {
     });
 
     it('should throw for invalid protocol version', () => {
-      const dataContract = wasm.DataContract.fromJSON(value, false, PlatformVersion.PLATFORM_V1);
+      const dataContract = wasm.DataContract.fromJSON(value, false, new PlatformVersion(1));
 
       const dataContractTransition = new wasm.DataContractUpdateTransition(dataContract, BigInt(1));
 
@@ -115,7 +115,7 @@ describe('DataContractUpdateTransition', () => {
 
   describe('getDataContract()', () => {
     it('should return data contract', () => {
-      const dataContract = wasm.DataContract.fromJSON(value, false, PlatformVersion.PLATFORM_V1);
+      const dataContract = wasm.DataContract.fromJSON(value, false, new PlatformVersion(1));
 
       const dataContractTransition = new wasm.DataContractUpdateTransition(dataContract, BigInt(1));
 
@@ -129,15 +129,15 @@ describe('DataContractUpdateTransition', () => {
     it('should set the data contract', () => {
       const [dataContractBytes] = dataContractsBytes;
 
-      const dataContract = wasm.DataContract.fromJSON(value, false, PlatformVersion.PLATFORM_V1);
+      const dataContract = wasm.DataContract.fromJSON(value, false, new PlatformVersion(1));
 
       const dataContractTransition = new wasm.DataContractUpdateTransition(dataContract, BigInt(1));
 
-      const newDataContract = wasm.DataContract.fromBytes(fromHexString(dataContractBytes), false, PlatformVersion.PLATFORM_V1);
+      const newDataContract = wasm.DataContract.fromBytes(fromHexString(dataContractBytes), false, new PlatformVersion(1));
 
       dataContractTransition.setDataContract(newDataContract);
 
-      expect(fromHexString(dataContractBytes)).to.deep.equal(newDataContract.toBytes());
+      expect(fromHexString(dataContractBytes)).to.deep.equal(newDataContract.toBytes(new PlatformVersion(1)));
     });
   });
 });

--- a/packages/wasm-dpp2/tests/unit/Document.spec.ts
+++ b/packages/wasm-dpp2/tests/unit/Document.spec.ts
@@ -65,10 +65,10 @@ describe('Document', () => {
         fromHexString(documentBytes),
         dataContract,
         'note',
-        PlatformVersion.PLATFORM_V1,
+        new PlatformVersion(1),
       );
 
-      const bytes = documentInstance.toBytes(dataContract, PlatformVersion.PLATFORM_V1);
+      const bytes = documentInstance.toBytes(dataContract, new PlatformVersion(1));
 
       expect(bytes).to.deep.equal(fromHexString(documentBytes));
     });
@@ -81,7 +81,7 @@ describe('Document', () => {
         fromHexString(documentBytes),
         dataContract,
         'note',
-        PlatformVersion.PLATFORM_V1,
+        new PlatformVersion(1),
       );
 
       expect(documentInstance.dataContractId.toBase58()).to.equal(dataContract.id.toBase58());


### PR DESCRIPTION
## Issue being fixed or feature implemented

`PlatformVersionWasm` was a manually-maintained enum (`V1`–`V10`) that required 6 separate code changes every time a new platform version was added in Rust. It was already out of sync — Rust had `V1`–`V12` while WASM only had `V1`–`V10`.

## What was done?

Replaced `PlatformVersionWasm` enum with a `u32` wrapper struct that automatically adapts to any number of platform versions without code changes:

- **Struct wrapping `u32`** — constructor validates via `PlatformVersion::get()`, so only valid versions are accepted
- **Static methods** — `latest()`, `first()`, `current()` delegate to `PlatformVersion` statics instead of hardcoding values
- **Default** — uses `PlatformVersion::desired()` (current protocol version) instead of hardcoded `1`
- **Instance detection** — uses `impl_wasm_type_info!` macro and `to_wasm()` pattern consistent with other WASM types
- **Input validation** — uses `try_to_u32()` for numeric input (handles NaN, Infinity, fractional values)
- **Removed** — `parse_version_string()` helper, string handling in `TryFrom`, unused `From<PlatformVersionWasm> for String`
- **TypeScript type** — `PlatformVersionLike` simplified to `PlatformVersion | number` (removed `string`)
- **Tests updated** — all 4 test files use `new PlatformVersion(1)` instead of `PlatformVersion.PLATFORM_V1`, explicit version passed where comparing against v1 fixtures

## How Has This Been Tested?

- `cargo fmt -p wasm-dpp2 -- --check` — clean
- `cargo clippy -p wasm-dpp2 --target wasm32-unknown-unknown` — clean
- `cargo check -p wasm-dpp2 --target wasm32-unknown-unknown` — compiles
- `cargo check -p wasm-sdk --target wasm32-unknown-unknown` — compiles
- `yarn workspace dash build` — compiles
- Full WASM build (`build.sh` + `bundle.cjs`) — success
- `yarn workspace @dashevo/wasm-dpp2 test` — **718 passing, 0 failing**

## Breaking Changes

- `PlatformVersion.PLATFORM_V1`, `PlatformVersion.PLATFORM_V2`, etc. no longer exist. Use `new PlatformVersion(1)`, `new PlatformVersion(2)`, etc.
- `PlatformVersionLike` no longer accepts `string` — only `PlatformVersion | number`
- Default platform version when omitted is now `current` (desired) instead of `1`

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [x] I have made corresponding changes to the documentation if needed

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Restructured PlatformVersionWasm API from enum-based design to struct-based with new constructors and static methods for accessing latest, first, and current platform versions.
  * Updated version specification to use numeric format.

* **Tests**
  * Updated test cases to align with new PlatformVersion API.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->