### PR TITLE
refactor(sdk)!: fix type inconsistencies across wasm-sdk and js-evo-sdk

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4317,7 +4317,6 @@ version = "3.0.0"
 dependencies = [
  "bincode",
  "grovedb-version",
- "once_cell",
  "thiserror 2.0.17",
  "versioned-feature-core 1.0.0 (git+https://github.com/dashpay/versioned-feature-core)",
 ]

--- a/packages/js-evo-sdk/src/addresses/facade.ts
+++ b/packages/js-evo-sdk/src/addresses/facade.ts
@@ -25,7 +25,9 @@ export class AddressesFacade {
    * @param address - The platform address to query (PlatformAddress, Uint8Array, or bech32m string)
    * @returns ProofMetadataResponse containing PlatformAddressInfo with proof information
    */
-  async getWithProof(address: wasm.PlatformAddressLike): Promise<wasm.ProofMetadataResponseTyped<wasm.PlatformAddressInfo>> {
+  async getWithProof(
+    address: wasm.PlatformAddressLike,
+  ): Promise<wasm.ProofMetadataResponseTyped<wasm.PlatformAddressInfo | undefined>> {
     const w = await this.sdk.getWasmSdkConnected();
     return w.getAddressInfoWithProofInfo(address);
   }
@@ -37,7 +39,7 @@ export class AddressesFacade {
    * @returns Map of PlatformAddress to PlatformAddressInfo (or undefined for unfunded addresses)
    */
   async getMany(
-    addresses: wasm.PlatformAddressLike[],
+    addresses: wasm.PlatformAddressLikeArray,
   ): Promise<Map<wasm.PlatformAddress, wasm.PlatformAddressInfo | undefined>> {
     const w = await this.sdk.getWasmSdkConnected();
     return w.getAddressesInfos(addresses);
@@ -50,7 +52,7 @@ export class AddressesFacade {
    * @returns ProofMetadataResponse containing Map of PlatformAddress to PlatformAddressInfo
    */
   async getManyWithProof(
-    addresses: wasm.PlatformAddressLike[],
+    addresses: wasm.PlatformAddressLikeArray,
   ): Promise<wasm.ProofMetadataResponseTyped<Map<wasm.PlatformAddress, wasm.PlatformAddressInfo | undefined>>> {
     const w = await this.sdk.getWasmSdkConnected();
     return w.getAddressesInfosWithProofInfo(addresses);
@@ -80,7 +82,9 @@ export class AddressesFacade {
    * });
    * ```
    */
-  async transfer(options: wasm.AddressFundsTransferOptions): Promise<Map<wasm.PlatformAddress, wasm.PlatformAddressInfo>> {
+  async transfer(
+    options: wasm.AddressFundsTransferOptions,
+  ): Promise<Map<wasm.PlatformAddress, wasm.PlatformAddressInfo>> {
     const w = await this.sdk.getWasmSdkConnected();
     return w.addressFundsTransfer(options);
   }
@@ -142,7 +146,9 @@ export class AddressesFacade {
    * });
    * ```
    */
-  async withdraw(options: wasm.AddressFundsWithdrawOptions): Promise<Map<wasm.PlatformAddress, wasm.PlatformAddressInfo>> {
+  async withdraw(
+    options: wasm.AddressFundsWithdrawOptions,
+  ): Promise<Map<wasm.PlatformAddress, wasm.PlatformAddressInfo>> {
     const w = await this.sdk.getWasmSdkConnected();
     return w.addressFundsWithdraw(options);
   }
@@ -175,7 +181,9 @@ export class AddressesFacade {
    * console.log(`Updated addresses:`, result.addressInfos);
    * ```
    */
-  async transferFromIdentity(options: wasm.IdentityTransferToAddressesOptions): Promise<wasm.IdentityTransferToAddressesResult> {
+  async transferFromIdentity(
+    options: wasm.IdentityTransferToAddressesOptions,
+  ): Promise<wasm.IdentityTransferToAddressesResult> {
     const w = await this.sdk.getWasmSdkConnected();
     return w.identityTransferToAddresses(options);
   }
@@ -211,7 +219,9 @@ export class AddressesFacade {
    * });
    * ```
    */
-  async fundFromAssetLock(options: wasm.AddressFundingFromAssetLockOptions): Promise<Map<wasm.PlatformAddress, wasm.PlatformAddressInfo>> {
+  async fundFromAssetLock(
+    options: wasm.AddressFundingFromAssetLockOptions,
+  ): Promise<Map<wasm.PlatformAddress, wasm.PlatformAddressInfo>> {
     const w = await this.sdk.getWasmSdkConnected();
     return w.addressFundingFromAssetLock(options);
   }
@@ -251,7 +261,9 @@ export class AddressesFacade {
    * console.log('Updated addresses:', result.addressInfos);
    * ```
    */
-  async createIdentity(options: wasm.IdentityCreateFromAddressesOptions): Promise<wasm.IdentityCreateFromAddressesResult> {
+  async createIdentity(
+    options: wasm.IdentityCreateFromAddressesOptions,
+  ): Promise<wasm.IdentityCreateFromAddressesResult> {
     const w = await this.sdk.getWasmSdkConnected();
     return w.identityCreateFromAddresses(options);
   }

--- a/packages/js-evo-sdk/src/contracts/facade.ts
+++ b/packages/js-evo-sdk/src/contracts/facade.ts
@@ -13,7 +13,8 @@ export class ContractsFacade {
     return w.getDataContract(contractId);
   }
 
-  async fetchWithProof(contractId: wasm.IdentifierLike): Promise<wasm.ProofMetadataResponseTyped<wasm.DataContract>> {
+  async fetchWithProof(contractId: wasm.IdentifierLike):
+    Promise<wasm.ProofMetadataResponseTyped<wasm.DataContract>> {
     const w = await this.sdk.getWasmSdkConnected();
     return w.getDataContractWithProofInfo(contractId);
   }
@@ -23,17 +24,23 @@ export class ContractsFacade {
     return w.getDataContractHistory(query);
   }
 
-  async getHistoryWithProof(query: wasm.DataContractHistoryQuery): Promise<wasm.ProofMetadataResponseTyped<Map<bigint, wasm.DataContract>>> {
+  async getHistoryWithProof(
+    query: wasm.DataContractHistoryQuery,
+  ): Promise<wasm.ProofMetadataResponseTyped<Map<bigint, wasm.DataContract>>> {
     const w = await this.sdk.getWasmSdkConnected();
     return w.getDataContractHistoryWithProofInfo(query);
   }
 
-  async getMany(contractIds: wasm.IdentifierLike[]): Promise<Map<wasm.Identifier, wasm.DataContract | undefined>> {
+  async getMany(contractIds: wasm.IdentifierLikeArray): Promise<Map<wasm.Identifier, wasm.DataContract | undefined>> {
     const w = await this.sdk.getWasmSdkConnected();
     return w.getDataContracts(contractIds);
   }
 
-  async getManyWithProof(contractIds: wasm.IdentifierLike[]): Promise<wasm.ProofMetadataResponseTyped<Map<wasm.Identifier, wasm.DataContract | undefined>>> {
+  async getManyWithProof(
+    contractIds: wasm.IdentifierLikeArray,
+  ): Promise<wasm.ProofMetadataResponseTyped<
+    Map<wasm.Identifier, wasm.DataContract | undefined>
+  >> {
     const w = await this.sdk.getWasmSdkConnected();
     return w.getDataContractsWithProofInfo(contractIds);
   }

--- a/packages/js-evo-sdk/src/documents/facade.ts
+++ b/packages/js-evo-sdk/src/documents/facade.ts
@@ -14,17 +14,26 @@ export class DocumentsFacade {
     return w.getDocuments(query);
   }
 
-  async queryWithProof(query: wasm.DocumentsQuery): Promise<wasm.ProofMetadataResponseTyped<Map<wasm.Identifier, wasm.Document | undefined>>> {
+  async queryWithProof(
+    query: wasm.DocumentsQuery,
+  ): Promise<wasm.ProofMetadataResponseTyped<
+    Map<wasm.Identifier, wasm.Document | undefined>
+  >> {
     const w = await this.sdk.getWasmSdkConnected();
     return w.getDocumentsWithProofInfo(query);
   }
 
-  async get(contractId: wasm.IdentifierLike, type: string, documentId: wasm.IdentifierLike): Promise<wasm.Document | undefined> {
+  async get(contractId: wasm.IdentifierLike, type: string, documentId: wasm.IdentifierLike):
+    Promise<wasm.Document | undefined> {
     const w = await this.sdk.getWasmSdkConnected();
     return w.getDocument(contractId, type, documentId);
   }
 
-  async getWithProof(contractId: wasm.IdentifierLike, type: string, documentId: wasm.IdentifierLike): Promise<wasm.ProofMetadataResponseTyped<wasm.Document | undefined>> {
+  async getWithProof(
+    contractId: wasm.IdentifierLike,
+    type: string,
+    documentId: wasm.IdentifierLike,
+  ): Promise<wasm.ProofMetadataResponseTyped<wasm.Document | undefined>> {
     const w = await this.sdk.getWasmSdkConnected();
     return w.getDocumentWithProofInfo(contractId, type, documentId);
   }

--- a/packages/js-evo-sdk/src/dpns/facade.ts
+++ b/packages/js-evo-sdk/src/dpns/facade.ts
@@ -53,7 +53,8 @@ export class DpnsFacade {
     return w.getDpnsUsernamesWithProofInfo(query);
   }
 
-  async usernameWithProof(identityId: wasm.IdentifierLike): Promise<wasm.ProofMetadataResponseTyped<string | null>> {
+  async usernameWithProof(identityId: wasm.IdentifierLike):
+    Promise<wasm.ProofMetadataResponseTyped<string | undefined>> {
     const w = await this.sdk.getWasmSdkConnected();
     return w.getDpnsUsernameWithProofInfo(identityId);
   }
@@ -63,7 +64,9 @@ export class DpnsFacade {
     return w.getDpnsUsernameByName(username);
   }
 
-  async getUsernameByNameWithProof(username: string): Promise<wasm.ProofMetadataResponseTyped<wasm.DpnsUsernameInfo | null>> {
+  async getUsernameByNameWithProof(
+    username: string,
+  ): Promise<wasm.ProofMetadataResponseTyped<wasm.DpnsUsernameInfo | undefined>> {
     const w = await this.sdk.getWasmSdkConnected();
     return w.getDpnsUsernameByNameWithProofInfo(username);
   }

--- a/packages/js-evo-sdk/src/epoch/facade.ts
+++ b/packages/js-evo-sdk/src/epoch/facade.ts
@@ -15,7 +15,11 @@ export class EpochFacade {
     return w.getEpochsInfo(query);
   }
 
-  async epochsInfoWithProof(query: EpochsQuery = {}): Promise<wasm.ProofMetadataResponseTyped<Map<number, wasm.ExtendedEpochInfo | undefined>>> {
+  async epochsInfoWithProof(
+    query: EpochsQuery = {},
+  ): Promise<wasm.ProofMetadataResponseTyped<
+    Map<number, wasm.ExtendedEpochInfo | undefined>
+  >> {
     const w = await this.sdk.getWasmSdkConnected();
     return w.getEpochsInfoWithProofInfo(query);
   }
@@ -25,23 +29,32 @@ export class EpochFacade {
     return w.getFinalizedEpochInfos(query);
   }
 
-  async finalizedInfosWithProof(query: FinalizedEpochsQuery): Promise<wasm.ProofMetadataResponseTyped<Map<number, wasm.FinalizedEpochInfo | undefined>>> {
+  async finalizedInfosWithProof(
+    query: FinalizedEpochsQuery,
+  ): Promise<wasm.ProofMetadataResponseTyped<
+    Map<number, wasm.FinalizedEpochInfo | undefined>
+  >> {
     const w = await this.sdk.getWasmSdkConnected();
     return w.getFinalizedEpochInfosWithProofInfo(query);
   }
 
-  async current(): Promise<wasm.ExtendedEpochInfo> { const w = await this.sdk.getWasmSdkConnected(); return w.getCurrentEpoch(); }
+  async current(): Promise<wasm.ExtendedEpochInfo> {
+    const w = await this.sdk.getWasmSdkConnected();
+    return w.getCurrentEpoch();
+  }
   async currentWithProof(): Promise<wasm.ProofMetadataResponseTyped<wasm.ExtendedEpochInfo>> {
     const w = await this.sdk.getWasmSdkConnected();
     return w.getCurrentEpochWithProofInfo();
   }
 
-  async evonodesProposedBlocksByIds(epoch: number, ids: string[]): Promise<Map<wasm.Identifier, bigint>> {
+  async evonodesProposedBlocksByIds(epoch: number, ids: wasm.ProTxHashLikeArray):
+    Promise<Map<wasm.Identifier, bigint>> {
     const w = await this.sdk.getWasmSdkConnected();
     return w.getEvonodesProposedEpochBlocksByIds(epoch, ids);
   }
 
-  async evonodesProposedBlocksByIdsWithProof(epoch: number, ids: string[]): Promise<wasm.ProofMetadataResponseTyped<unknown>> {
+  async evonodesProposedBlocksByIdsWithProof(epoch: number, ids: wasm.ProTxHashLikeArray):
+    Promise<wasm.ProofMetadataResponseTyped<Map<wasm.Identifier, bigint>>> {
     const w = await this.sdk.getWasmSdkConnected();
     return w.getEvonodesProposedEpochBlocksByIdsWithProofInfo(epoch, ids);
   }
@@ -51,7 +64,9 @@ export class EpochFacade {
     return w.getEvonodesProposedEpochBlocksByRange(query);
   }
 
-  async evonodesProposedBlocksByRangeWithProof(query: EvonodeProposedBlocksRangeQuery): Promise<wasm.ProofMetadataResponseTyped<unknown>> {
+  async evonodesProposedBlocksByRangeWithProof(
+    query: EvonodeProposedBlocksRangeQuery,
+  ): Promise<wasm.ProofMetadataResponseTyped<Map<wasm.Identifier, bigint>>> {
     const w = await this.sdk.getWasmSdkConnected();
     return w.getEvonodesProposedEpochBlocksByRangeWithProofInfo(query);
   }

--- a/packages/js-evo-sdk/src/group/facade.ts
+++ b/packages/js-evo-sdk/src/group/facade.ts
@@ -10,7 +10,8 @@ export class GroupFacade {
     return w.getGroupInfo(contractId, groupContractPosition);
   }
 
-  async infoWithProof(contractId: wasm.IdentifierLike, groupContractPosition: number): Promise<wasm.ProofMetadataResponseTyped<wasm.Group | undefined>> {
+  async infoWithProof(contractId: wasm.IdentifierLike, groupContractPosition: number):
+    Promise<wasm.ProofMetadataResponseTyped<wasm.Group | undefined>> {
     const w = await this.sdk.getWasmSdkConnected();
     return w.getGroupInfoWithProofInfo(contractId, groupContractPosition);
   }
@@ -20,7 +21,11 @@ export class GroupFacade {
     return w.getGroupInfos(query);
   }
 
-  async infosWithProof(query: wasm.GroupInfosQuery): Promise<wasm.ProofMetadataResponseTyped<Map<number, wasm.Group | undefined>>> {
+  async infosWithProof(
+    query: wasm.GroupInfosQuery,
+  ): Promise<wasm.ProofMetadataResponseTyped<
+    Map<number, wasm.Group | undefined>
+  >> {
     const w = await this.sdk.getWasmSdkConnected();
     return w.getGroupInfosWithProofInfo(query);
   }
@@ -30,7 +35,9 @@ export class GroupFacade {
     return w.getGroupMembers(query);
   }
 
-  async membersWithProof(query: wasm.GroupMembersQuery): Promise<wasm.ProofMetadataResponseTyped<Map<wasm.Identifier, bigint>>> {
+  async membersWithProof(
+    query: wasm.GroupMembersQuery,
+  ): Promise<wasm.ProofMetadataResponseTyped<Map<wasm.Identifier, bigint>>> {
     const w = await this.sdk.getWasmSdkConnected();
     return w.getGroupMembersWithProofInfo(query);
   }
@@ -40,7 +47,9 @@ export class GroupFacade {
     return w.getIdentityGroups(query);
   }
 
-  async identityGroupsWithProof(query: wasm.IdentityGroupsQuery): Promise<wasm.ProofMetadataResponseTyped<wasm.IdentityGroupInfo[]>> {
+  async identityGroupsWithProof(
+    query: wasm.IdentityGroupsQuery,
+  ): Promise<wasm.ProofMetadataResponseTyped<wasm.IdentityGroupInfo[]>> {
     const w = await this.sdk.getWasmSdkConnected();
     return w.getIdentityGroupsWithProofInfo(query);
   }
@@ -50,7 +59,11 @@ export class GroupFacade {
     return w.getGroupActions(query);
   }
 
-  async actionsWithProof(query: wasm.GroupActionsQuery): Promise<wasm.ProofMetadataResponseTyped<Map<wasm.Identifier, wasm.GroupAction | undefined>>> {
+  async actionsWithProof(
+    query: wasm.GroupActionsQuery,
+  ): Promise<wasm.ProofMetadataResponseTyped<
+    Map<wasm.Identifier, wasm.GroupAction | undefined>
+  >> {
     const w = await this.sdk.getWasmSdkConnected();
     return w.getGroupActionsWithProofInfo(query);
   }
@@ -60,17 +73,25 @@ export class GroupFacade {
     return w.getGroupActionSigners(query);
   }
 
-  async actionSignersWithProof(query: wasm.GroupActionSignersQuery): Promise<wasm.ProofMetadataResponseTyped<Map<wasm.Identifier, bigint>>> {
+  async actionSignersWithProof(
+    query: wasm.GroupActionSignersQuery,
+  ): Promise<wasm.ProofMetadataResponseTyped<Map<wasm.Identifier, bigint>>> {
     const w = await this.sdk.getWasmSdkConnected();
     return w.getGroupActionSignersWithProofInfo(query);
   }
 
-  async groupsDataContracts(dataContractIds: wasm.IdentifierLike[]): Promise<Map<wasm.Identifier, Map<number, wasm.Group | undefined>>> {
+  async groupsDataContracts(
+    dataContractIds: wasm.IdentifierLikeArray,
+  ): Promise<Map<wasm.Identifier, Map<number, wasm.Group | undefined>>> {
     const w = await this.sdk.getWasmSdkConnected();
     return w.getGroupsDataContracts(dataContractIds);
   }
 
-  async groupsDataContractsWithProof(dataContractIds: wasm.IdentifierLike[]): Promise<wasm.ProofMetadataResponseTyped<Map<wasm.Identifier, Map<number, wasm.Group | undefined>>>> {
+  async groupsDataContractsWithProof(
+    dataContractIds: wasm.IdentifierLikeArray,
+  ): Promise<wasm.ProofMetadataResponseTyped<
+    Map<wasm.Identifier, Map<number, wasm.Group | undefined>>
+  >> {
     const w = await this.sdk.getWasmSdkConnected();
     return w.getGroupsDataContractsWithProofInfo(dataContractIds);
   }
@@ -80,17 +101,23 @@ export class GroupFacade {
     return w.getContestedResources(query);
   }
 
-  async contestedResourcesWithProof(query: wasm.VotePollsByDocumentTypeQuery): Promise<wasm.ProofMetadataResponseTyped<Array<any>>> {
+  async contestedResourcesWithProof(
+    query: wasm.VotePollsByDocumentTypeQuery,
+  ): Promise<wasm.ProofMetadataResponseTyped<Array<any>>> {
     const w = await this.sdk.getWasmSdkConnected();
     return w.getContestedResourcesWithProofInfo(query);
   }
 
-  async contestedResourceVotersForIdentity(query: wasm.ContestedResourceVotersForIdentityQuery): Promise<wasm.Identifier[]> {
+  async contestedResourceVotersForIdentity(
+    query: wasm.ContestedResourceVotersForIdentityQuery,
+  ): Promise<wasm.Identifier[]> {
     const w = await this.sdk.getWasmSdkConnected();
     return w.getContestedResourceVotersForIdentity(query);
   }
 
-  async contestedResourceVotersForIdentityWithProof(query: wasm.ContestedResourceVotersForIdentityQuery): Promise<wasm.ProofMetadataResponseTyped<wasm.Identifier[]>> {
+  async contestedResourceVotersForIdentityWithProof(
+    query: wasm.ContestedResourceVotersForIdentityQuery,
+  ): Promise<wasm.ProofMetadataResponseTyped<wasm.Identifier[]>> {
     const w = await this.sdk.getWasmSdkConnected();
     return w.getContestedResourceVotersForIdentityWithProofInfo(query);
   }

--- a/packages/js-evo-sdk/src/identities/facade.ts
+++ b/packages/js-evo-sdk/src/identities/facade.ts
@@ -13,7 +13,8 @@ export class IdentitiesFacade {
     return w.getIdentity(identityId);
   }
 
-  async fetchWithProof(identityId: wasm.IdentifierLike): Promise<wasm.ProofMetadataResponseTyped<wasm.Identity>> {
+  async fetchWithProof(identityId: wasm.IdentifierLike):
+    Promise<wasm.ProofMetadataResponseTyped<wasm.Identity | undefined>> {
     const w = await this.sdk.getWasmSdkConnected();
     return w.getIdentityWithProofInfo(identityId);
   }
@@ -28,77 +29,107 @@ export class IdentitiesFacade {
     return w.getIdentityKeys(query);
   }
 
-  async getKeysWithProof(query: wasm.IdentityKeysQuery): Promise<wasm.ProofMetadataResponseTyped<wasm.IdentityPublicKey[]>> {
+  async getKeysWithProof(
+    query: wasm.IdentityKeysQuery,
+  ): Promise<wasm.ProofMetadataResponseTyped<wasm.IdentityPublicKey[]>> {
     const w = await this.sdk.getWasmSdkConnected();
     return w.getIdentityKeysWithProofInfo(query);
   }
 
-  async nonce(identityId: wasm.IdentifierLike): Promise<bigint | null | undefined> {
+  async nonce(identityId: wasm.IdentifierLike): Promise<bigint | undefined> {
     const w = await this.sdk.getWasmSdkConnected();
     return w.getIdentityNonce(identityId);
   }
 
-  async nonceWithProof(identityId: wasm.IdentifierLike): Promise<wasm.ProofMetadataResponseTyped<bigint | null | undefined>> {
+  async nonceWithProof(
+    identityId: wasm.IdentifierLike,
+  ): Promise<wasm.ProofMetadataResponseTyped<bigint | undefined>> {
     const w = await this.sdk.getWasmSdkConnected();
     return w.getIdentityNonceWithProofInfo(identityId);
   }
 
-  async contractNonce(identityId: wasm.IdentifierLike, contractId: wasm.IdentifierLike): Promise<bigint | null | undefined> {
+  async contractNonce(identityId: wasm.IdentifierLike, contractId: wasm.IdentifierLike):
+    Promise<bigint | undefined> {
     const w = await this.sdk.getWasmSdkConnected();
     return w.getIdentityContractNonce(identityId, contractId);
   }
 
-  async contractNonceWithProof(identityId: wasm.IdentifierLike, contractId: wasm.IdentifierLike): Promise<wasm.ProofMetadataResponseTyped<bigint | null | undefined>> {
+  async contractNonceWithProof(
+    identityId: wasm.IdentifierLike,
+    contractId: wasm.IdentifierLike,
+  ): Promise<wasm.ProofMetadataResponseTyped<bigint | undefined>> {
     const w = await this.sdk.getWasmSdkConnected();
     return w.getIdentityContractNonceWithProofInfo(identityId, contractId);
   }
 
-  async balance(identityId: wasm.IdentifierLike): Promise<bigint | null | undefined> {
+  async balance(identityId: wasm.IdentifierLike): Promise<bigint | undefined> {
     const w = await this.sdk.getWasmSdkConnected();
     return w.getIdentityBalance(identityId);
   }
 
-  async balanceWithProof(identityId: wasm.IdentifierLike): Promise<wasm.ProofMetadataResponseTyped<bigint | null | undefined>> {
+  async balanceWithProof(
+    identityId: wasm.IdentifierLike,
+  ): Promise<wasm.ProofMetadataResponseTyped<bigint | undefined>> {
     const w = await this.sdk.getWasmSdkConnected();
     return w.getIdentityBalanceWithProofInfo(identityId);
   }
 
-  async balances(identityIds: wasm.IdentifierLike[]): Promise<Map<wasm.Identifier, bigint | null>> {
+  async balances(identityIds: wasm.IdentifierLikeArray): Promise<Map<wasm.Identifier, bigint | undefined>> {
     const w = await this.sdk.getWasmSdkConnected();
     return w.getIdentitiesBalances(identityIds);
   }
 
-  async balancesWithProof(identityIds: wasm.IdentifierLike[]): Promise<wasm.ProofMetadataResponseTyped<Map<wasm.Identifier, bigint | null>>> {
+  async balancesWithProof(
+    identityIds: wasm.IdentifierLikeArray,
+  ): Promise<wasm.ProofMetadataResponseTyped<
+    Map<wasm.Identifier, bigint | undefined>
+  >> {
     const w = await this.sdk.getWasmSdkConnected();
     return w.getIdentitiesBalancesWithProofInfo(identityIds);
   }
 
-  async balanceAndRevision(identityId: wasm.IdentifierLike): Promise<wasm.IdentityBalanceAndRevision | null | undefined> {
+  async balanceAndRevision(
+    identityId: wasm.IdentifierLike,
+  ): Promise<wasm.IdentityBalanceAndRevision | undefined> {
     const w = await this.sdk.getWasmSdkConnected();
     return w.getIdentityBalanceAndRevision(identityId);
   }
 
-  async balanceAndRevisionWithProof(identityId: wasm.IdentifierLike): Promise<wasm.ProofMetadataResponseTyped<wasm.IdentityBalanceAndRevision | null | undefined>> {
+  async balanceAndRevisionWithProof(
+    identityId: wasm.IdentifierLike,
+  ): Promise<wasm.ProofMetadataResponseTyped<
+    wasm.IdentityBalanceAndRevision | undefined
+  >> {
     const w = await this.sdk.getWasmSdkConnected();
     return w.getIdentityBalanceAndRevisionWithProofInfo(identityId);
   }
 
-  async byPublicKeyHash(publicKeyHash: string | Uint8Array): Promise<wasm.Identity | null | undefined> {
+  async byPublicKeyHash(publicKeyHash: wasm.PublicKeyHashLike): Promise<wasm.Identity | undefined> {
     const w = await this.sdk.getWasmSdkConnected();
     return w.getIdentityByPublicKeyHash(publicKeyHash);
   }
 
-  async byPublicKeyHashWithProof(publicKeyHash: string | Uint8Array): Promise<wasm.ProofMetadataResponseTyped<wasm.Identity | null | undefined>> {
+  async byPublicKeyHashWithProof(
+    publicKeyHash: wasm.PublicKeyHashLike,
+  ): Promise<wasm.ProofMetadataResponseTyped<
+    wasm.Identity | undefined
+  >> {
     const w = await this.sdk.getWasmSdkConnected();
     return w.getIdentityByPublicKeyHashWithProofInfo(publicKeyHash);
   }
 
-  async byNonUniquePublicKeyHash(publicKeyHash: string | Uint8Array, startAfter?: wasm.IdentifierLike): Promise<wasm.Identity[]> {
+  async byNonUniquePublicKeyHash(
+    publicKeyHash: wasm.PublicKeyHashLike,
+    startAfter?: wasm.IdentifierLike,
+  ): Promise<wasm.Identity[]> {
     const w = await this.sdk.getWasmSdkConnected();
     return w.getIdentityByNonUniquePublicKeyHash(publicKeyHash, startAfter);
   }
 
-  async byNonUniquePublicKeyHashWithProof(publicKeyHash: string | Uint8Array, startAfter?: wasm.IdentifierLike): Promise<wasm.ProofMetadataResponseTyped<wasm.Identity[]>> {
+  async byNonUniquePublicKeyHashWithProof(
+    publicKeyHash: wasm.PublicKeyHashLike,
+    startAfter?: wasm.IdentifierLike,
+  ): Promise<wasm.ProofMetadataResponseTyped<wasm.Identity[]>> {
     const w = await this.sdk.getWasmSdkConnected();
     return w.getIdentityByNonUniquePublicKeyHashWithProofInfo(publicKeyHash, startAfter || undefined);
   }
@@ -108,17 +139,23 @@ export class IdentitiesFacade {
     return w.getIdentitiesContractKeys(query);
   }
 
-  async contractKeysWithProof(query: wasm.IdentitiesContractKeysQuery): Promise<wasm.ProofMetadataResponseTyped<wasm.IdentityContractKeys[]>> {
+  async contractKeysWithProof(
+    query: wasm.IdentitiesContractKeysQuery,
+  ): Promise<wasm.ProofMetadataResponseTyped<wasm.IdentityContractKeys[]>> {
     const w = await this.sdk.getWasmSdkConnected();
     return w.getIdentitiesContractKeysWithProofInfo(query);
   }
 
-  async tokenBalances(identityId: wasm.IdentifierLike, tokenIds: wasm.IdentifierLike[]): Promise<Map<wasm.Identifier, bigint>> {
+  async tokenBalances(identityId: wasm.IdentifierLike, tokenIds: wasm.IdentifierLikeArray):
+    Promise<Map<wasm.Identifier, bigint>> {
     const w = await this.sdk.getWasmSdkConnected();
     return w.getIdentityTokenBalances(identityId, tokenIds);
   }
 
-  async tokenBalancesWithProof(identityId: wasm.IdentifierLike, tokenIds: wasm.IdentifierLike[]): Promise<wasm.ProofMetadataResponseTyped<Map<wasm.Identifier, bigint>>> {
+  async tokenBalancesWithProof(
+    identityId: wasm.IdentifierLike,
+    tokenIds: wasm.IdentifierLikeArray,
+  ): Promise<wasm.ProofMetadataResponseTyped<Map<wasm.Identifier, bigint>>> {
     const w = await this.sdk.getWasmSdkConnected();
     return w.getIdentityTokenBalancesWithProofInfo(identityId, tokenIds);
   }

--- a/packages/js-evo-sdk/src/protocol/facade.ts
+++ b/packages/js-evo-sdk/src/protocol/facade.ts
@@ -14,12 +14,16 @@ export class ProtocolFacade {
     return w.getProtocolVersionUpgradeStateWithProofInfo();
   }
 
-  async versionUpgradeVoteStatus(startProTxHash: string | Uint8Array, count: number): Promise<Map<string, wasm.ProtocolVersionUpgradeVoteStatus>> {
+  async versionUpgradeVoteStatus(startProTxHash: wasm.ProTxHashLike | undefined, count: number):
+    Promise<Map<string, wasm.ProtocolVersionUpgradeVoteStatus>> {
     const w = await this.sdk.getWasmSdkConnected();
     return w.getProtocolVersionUpgradeVoteStatus(startProTxHash, count);
   }
 
-  async versionUpgradeVoteStatusWithProof(startProTxHash: string | Uint8Array, count: number): Promise<wasm.ProofMetadataResponseTyped<unknown>> {
+  async versionUpgradeVoteStatusWithProof(startProTxHash: wasm.ProTxHashLike | undefined, count: number):
+    Promise<wasm.ProofMetadataResponseTyped<
+      Map<string, wasm.ProtocolVersionUpgradeVoteStatus>
+    >> {
     const w = await this.sdk.getWasmSdkConnected();
     return w.getProtocolVersionUpgradeVoteStatusWithProofInfo(startProTxHash, count);
   }

--- a/packages/js-evo-sdk/src/system/facade.ts
+++ b/packages/js-evo-sdk/src/system/facade.ts
@@ -15,7 +15,7 @@ export class SystemFacade {
     return w.getCurrentQuorumsInfo();
   }
 
-  async totalCreditsInPlatform(): Promise<bigint | undefined> {
+  async totalCreditsInPlatform(): Promise<bigint> {
     const w = await this.sdk.getWasmSdkConnected();
     return w.getTotalCreditsInPlatform();
   }
@@ -25,12 +25,18 @@ export class SystemFacade {
     return w.getTotalCreditsInPlatformWithProofInfo();
   }
 
-  async prefundedSpecializedBalance(identityId: wasm.IdentifierLike): Promise<wasm.PrefundedSpecializedBalance | undefined> {
+  async prefundedSpecializedBalance(
+    identityId: wasm.IdentifierLike,
+  ): Promise<wasm.PrefundedSpecializedBalance> {
     const w = await this.sdk.getWasmSdkConnected();
     return w.getPrefundedSpecializedBalance(identityId);
   }
 
-  async prefundedSpecializedBalanceWithProof(identityId: wasm.IdentifierLike): Promise<wasm.ProofMetadataResponseTyped<wasm.PrefundedSpecializedBalance | undefined>> {
+  async prefundedSpecializedBalanceWithProof(
+    identityId: wasm.IdentifierLike,
+  ): Promise<wasm.ProofMetadataResponseTyped<
+    wasm.PrefundedSpecializedBalance | undefined
+  >> {
     const w = await this.sdk.getWasmSdkConnected();
     return w.getPrefundedSpecializedBalanceWithProofInfo(identityId);
   }
@@ -45,7 +51,8 @@ export class SystemFacade {
     return w.getPathElements(path, keys);
   }
 
-  async pathElementsWithProof(path: string[], keys: string[]): Promise<wasm.ProofMetadataResponseTyped<wasm.PathElement[]>> {
+  async pathElementsWithProof(path: string[], keys: string[]):
+    Promise<wasm.ProofMetadataResponseTyped<wasm.PathElement[]>> {
     const w = await this.sdk.getWasmSdkConnected();
     return w.getPathElementsWithProofInfo(path, keys);
   }

--- a/packages/js-evo-sdk/src/tokens/facade.ts
+++ b/packages/js-evo-sdk/src/tokens/facade.ts
@@ -24,67 +24,97 @@ export class TokensFacade {
     return w.getTokenTotalSupply(tokenId);
   }
 
-  async totalSupplyWithProof(tokenId: wasm.IdentifierLike): Promise<wasm.ProofMetadataResponseTyped<wasm.TokenTotalSupply | null>> {
+  async totalSupplyWithProof(
+    tokenId: wasm.IdentifierLike,
+  ): Promise<wasm.ProofMetadataResponseTyped<wasm.TokenTotalSupply | undefined>> {
     const w = await this.sdk.getWasmSdkConnected();
     return w.getTokenTotalSupplyWithProofInfo(tokenId);
   }
 
-  async statuses(tokenIds: wasm.IdentifierLike[]): Promise<Map<wasm.Identifier, wasm.TokenStatus>> {
+  async statuses(tokenIds: wasm.IdentifierLikeArray): Promise<Map<wasm.Identifier, wasm.TokenStatus>> {
     const w = await this.sdk.getWasmSdkConnected();
     return w.getTokenStatuses(tokenIds);
   }
 
-  async statusesWithProof(tokenIds: wasm.IdentifierLike[]): Promise<wasm.ProofMetadataResponseTyped<Map<wasm.Identifier, wasm.TokenStatus>>> {
+  async statusesWithProof(
+    tokenIds: wasm.IdentifierLikeArray,
+  ): Promise<wasm.ProofMetadataResponseTyped<
+    Map<wasm.Identifier, wasm.TokenStatus>
+  >> {
     const w = await this.sdk.getWasmSdkConnected();
     return w.getTokenStatusesWithProofInfo(tokenIds);
   }
 
-  async balances(identityIds: wasm.IdentifierLike[], tokenId: wasm.IdentifierLike): Promise<Map<wasm.Identifier, bigint>> {
+  async balances(identityIds: wasm.IdentifierLikeArray, tokenId: wasm.IdentifierLike):
+    Promise<Map<wasm.Identifier, bigint>> {
     const w = await this.sdk.getWasmSdkConnected();
     return w.getIdentitiesTokenBalances(identityIds, tokenId);
   }
 
-  async balancesWithProof(identityIds: wasm.IdentifierLike[], tokenId: wasm.IdentifierLike): Promise<wasm.ProofMetadataResponseTyped<Map<wasm.Identifier, bigint>>> {
+  async balancesWithProof(
+    identityIds: wasm.IdentifierLikeArray,
+    tokenId: wasm.IdentifierLike,
+  ): Promise<wasm.ProofMetadataResponseTyped<Map<wasm.Identifier, bigint>>> {
     const w = await this.sdk.getWasmSdkConnected();
     return w.getIdentitiesTokenBalancesWithProofInfo(identityIds, tokenId);
   }
 
-  async identityBalances(identityId: wasm.IdentifierLike, tokenIds: wasm.IdentifierLike[]): Promise<Map<wasm.Identifier, bigint>> {
+  async identityBalances(identityId: wasm.IdentifierLike, tokenIds: wasm.IdentifierLikeArray):
+    Promise<Map<wasm.Identifier, bigint>> {
     const w = await this.sdk.getWasmSdkConnected();
     return w.getIdentityTokenBalances(identityId, tokenIds);
   }
 
-  async identityBalancesWithProof(identityId: wasm.IdentifierLike, tokenIds: wasm.IdentifierLike[]): Promise<wasm.ProofMetadataResponseTyped<Map<wasm.Identifier, bigint>>> {
+  async identityBalancesWithProof(
+    identityId: wasm.IdentifierLike,
+    tokenIds: wasm.IdentifierLikeArray,
+  ): Promise<wasm.ProofMetadataResponseTyped<Map<wasm.Identifier, bigint>>> {
     const w = await this.sdk.getWasmSdkConnected();
     return w.getIdentityTokenBalancesWithProofInfo(identityId, tokenIds);
   }
 
-  async identityTokenInfos(identityId: wasm.IdentifierLike, tokenIds: wasm.IdentifierLike[]): Promise<Map<wasm.Identifier, wasm.IdentityTokenInfo>> {
+  async identityTokenInfos(identityId: wasm.IdentifierLike, tokenIds: wasm.IdentifierLikeArray):
+    Promise<Map<wasm.Identifier, wasm.IdentityTokenInfo>> {
     const w = await this.sdk.getWasmSdkConnected();
     return w.getIdentityTokenInfos(identityId, tokenIds);
   }
 
-  async identitiesTokenInfos(identityIds: wasm.IdentifierLike[], tokenId: wasm.IdentifierLike): Promise<Map<wasm.Identifier, wasm.IdentityTokenInfo>> {
+  async identitiesTokenInfos(identityIds: wasm.IdentifierLikeArray, tokenId: wasm.IdentifierLike):
+    Promise<Map<wasm.Identifier, wasm.IdentityTokenInfo>> {
     const w = await this.sdk.getWasmSdkConnected();
     return w.getIdentitiesTokenInfos(identityIds, tokenId);
   }
 
-  async identityTokenInfosWithProof(identityId: wasm.IdentifierLike, tokenIds: wasm.IdentifierLike[]): Promise<wasm.ProofMetadataResponseTyped<Map<wasm.Identifier, wasm.IdentityTokenInfo>>> {
+  async identityTokenInfosWithProof(
+    identityId: wasm.IdentifierLike,
+    tokenIds: wasm.IdentifierLikeArray,
+  ): Promise<wasm.ProofMetadataResponseTyped<
+    Map<wasm.Identifier, wasm.IdentityTokenInfo>
+  >> {
     const w = await this.sdk.getWasmSdkConnected();
     return w.getIdentityTokenInfosWithProofInfo(identityId, tokenIds);
   }
 
-  async identitiesTokenInfosWithProof(identityIds: wasm.IdentifierLike[], tokenId: wasm.IdentifierLike): Promise<wasm.ProofMetadataResponseTyped<Map<wasm.Identifier, wasm.IdentityTokenInfo>>> {
+  async identitiesTokenInfosWithProof(
+    identityIds: wasm.IdentifierLikeArray,
+    tokenId: wasm.IdentifierLike,
+  ): Promise<wasm.ProofMetadataResponseTyped<
+    Map<wasm.Identifier, wasm.IdentityTokenInfo>
+  >> {
     const w = await this.sdk.getWasmSdkConnected();
     return w.getIdentitiesTokenInfosWithProofInfo(identityIds, tokenId);
   }
 
-  async directPurchasePrices(tokenIds: wasm.IdentifierLike[]): Promise<Map<wasm.Identifier, wasm.TokenPriceInfo>> {
+  async directPurchasePrices(tokenIds: wasm.IdentifierLikeArray): Promise<Map<wasm.Identifier, wasm.TokenPriceInfo>> {
     const w = await this.sdk.getWasmSdkConnected();
     return w.getTokenDirectPurchasePrices(tokenIds);
   }
 
-  async directPurchasePricesWithProof(tokenIds: wasm.IdentifierLike[]): Promise<wasm.ProofMetadataResponseTyped<Map<wasm.Identifier, wasm.TokenPriceInfo>>> {
+  async directPurchasePricesWithProof(
+    tokenIds: wasm.IdentifierLikeArray,
+  ): Promise<wasm.ProofMetadataResponseTyped<
+    Map<wasm.Identifier, wasm.TokenPriceInfo>
+  >> {
     const w = await this.sdk.getWasmSdkConnected();
     return w.getTokenDirectPurchasePricesWithProofInfo(tokenIds);
   }
@@ -94,17 +124,29 @@ export class TokensFacade {
     return w.getTokenContractInfo(contractId);
   }
 
-  async contractInfoWithProof(contractId: wasm.IdentifierLike): Promise<wasm.ProofMetadataResponseTyped<wasm.TokenContractInfo | undefined>> {
+  async contractInfoWithProof(
+    contractId: wasm.IdentifierLike,
+  ): Promise<wasm.ProofMetadataResponseTyped<
+    wasm.TokenContractInfo | undefined
+  >> {
     const w = await this.sdk.getWasmSdkConnected();
     return w.getTokenContractInfoWithProofInfo(contractId);
   }
 
-  async perpetualDistributionLastClaim(identityId: wasm.IdentifierLike, tokenId: wasm.IdentifierLike): Promise<wasm.RewardDistributionMoment | undefined> {
+  async perpetualDistributionLastClaim(
+    identityId: wasm.IdentifierLike,
+    tokenId: wasm.IdentifierLike,
+  ): Promise<wasm.RewardDistributionMoment | undefined> {
     const w = await this.sdk.getWasmSdkConnected();
     return w.getTokenPerpetualDistributionLastClaim(identityId, tokenId);
   }
 
-  async perpetualDistributionLastClaimWithProof(identityId: wasm.IdentifierLike, tokenId: wasm.IdentifierLike): Promise<wasm.ProofMetadataResponseTyped<wasm.RewardDistributionMoment | undefined>> {
+  async perpetualDistributionLastClaimWithProof(
+    identityId: wasm.IdentifierLike,
+    tokenId: wasm.IdentifierLike,
+  ): Promise<wasm.ProofMetadataResponseTyped<
+    wasm.RewardDistributionMoment | undefined
+  >> {
     const w = await this.sdk.getWasmSdkConnected();
     return w.getTokenPerpetualDistributionLastClaimWithProofInfo(identityId, tokenId);
   }

--- a/packages/js-evo-sdk/src/voting/facade.ts
+++ b/packages/js-evo-sdk/src/voting/facade.ts
@@ -5,22 +5,34 @@ export class VotingFacade {
   private sdk: EvoSDK;
   constructor(sdk: EvoSDK) { this.sdk = sdk; }
 
-  async contestedResourceVoteState(query: wasm.ContestedResourceVoteStateQuery): Promise<wasm.ContestedResourceVoteState> {
+  async contestedResourceVoteState(
+    query: wasm.ContestedResourceVoteStateQuery,
+  ): Promise<wasm.ContestedResourceVoteState> {
     const w = await this.sdk.getWasmSdkConnected();
     return w.getContestedResourceVoteState(query);
   }
 
-  async contestedResourceVoteStateWithProof(query: wasm.ContestedResourceVoteStateQuery): Promise<wasm.ProofMetadataResponseTyped<wasm.ContestedResourceVoteState>> {
+  async contestedResourceVoteStateWithProof(
+    query: wasm.ContestedResourceVoteStateQuery,
+  ): Promise<wasm.ProofMetadataResponseTyped<
+    wasm.ContestedResourceVoteState
+  >> {
     const w = await this.sdk.getWasmSdkConnected();
     return w.getContestedResourceVoteStateWithProofInfo(query);
   }
 
-  async contestedResourceIdentityVotes(query: wasm.ContestedResourceIdentityVotesQuery): Promise<Map<wasm.Identifier, wasm.ResourceVote>> {
+  async contestedResourceIdentityVotes(
+    query: wasm.ContestedResourceIdentityVotesQuery,
+  ): Promise<Map<wasm.Identifier, wasm.ResourceVote>> {
     const w = await this.sdk.getWasmSdkConnected();
     return w.getContestedResourceIdentityVotes(query);
   }
 
-  async contestedResourceIdentityVotesWithProof(query: wasm.ContestedResourceIdentityVotesQuery): Promise<wasm.ProofMetadataResponseTyped<Map<wasm.Identifier, wasm.ResourceVote>>> {
+  async contestedResourceIdentityVotesWithProof(
+    query: wasm.ContestedResourceIdentityVotesQuery,
+  ): Promise<wasm.ProofMetadataResponseTyped<
+    Map<wasm.Identifier, wasm.ResourceVote>
+  >> {
     const w = await this.sdk.getWasmSdkConnected();
     return w.getContestedResourceIdentityVotesWithProofInfo(query);
   }
@@ -28,13 +40,17 @@ export class VotingFacade {
   async votePollsByEndDate(query?: wasm.VotePollsByEndDateQuery): Promise<wasm.VotePollsByEndDateEntry[]> {
     const w = await this.sdk.getWasmSdkConnected();
 
-    return w.getVotePollsByEndDate(query ?? null);
+    return w.getVotePollsByEndDate(query);
   }
 
-  async votePollsByEndDateWithProof(query?: wasm.VotePollsByEndDateQuery): Promise<wasm.ProofMetadataResponseTyped<wasm.VotePollsByEndDateEntry[]>> {
+  async votePollsByEndDateWithProof(
+    query?: wasm.VotePollsByEndDateQuery,
+  ): Promise<wasm.ProofMetadataResponseTyped<
+    wasm.VotePollsByEndDateEntry[]
+  >> {
     const w = await this.sdk.getWasmSdkConnected();
 
-    return w.getVotePollsByEndDateWithProofInfo(query ?? null);
+    return w.getVotePollsByEndDateWithProofInfo(query);
   }
 
   async masternodeVote(options: wasm.MasternodeVoteOptions): Promise<void> {

--- a/packages/js-evo-sdk/src/wallet/functions.ts
+++ b/packages/js-evo-sdk/src/wallet/functions.ts
@@ -4,55 +4,67 @@ import type { NetworkLike } from '../wasm.js';
 export namespace wallet {
   export async function generateMnemonic(params?: wasm.GenerateMnemonicParams): Promise<string> {
     await wasm.ensureInitialized();
-    return wasm.WasmSdk.generateMnemonic(params ?? null);
+    return wasm.WasmSdk.generateMnemonic(params);
   }
 
   export async function validateMnemonic(mnemonic: string, languageCode?: string): Promise<boolean> {
     await wasm.ensureInitialized();
-    return wasm.WasmSdk.validateMnemonic(mnemonic, languageCode ?? null);
+    return wasm.WasmSdk.validateMnemonic(mnemonic, languageCode);
   }
 
   export async function mnemonicToSeed(mnemonic: string, passphrase?: string): Promise<Uint8Array> {
     await wasm.ensureInitialized();
-    return wasm.WasmSdk.mnemonicToSeed(mnemonic, passphrase ?? null);
+    return wasm.WasmSdk.mnemonicToSeed(mnemonic, passphrase);
   }
 
-  export async function deriveKeyFromSeedPhrase(params: wasm.DeriveKeyFromSeedPhraseParams): Promise<wasm.SeedPhraseKeyInfo> {
+  export async function deriveKeyFromSeedPhrase(
+    params: wasm.DeriveKeyFromSeedPhraseParams,
+  ): Promise<wasm.SeedPhraseKeyInfo> {
     await wasm.ensureInitialized();
     return wasm.WasmSdk.deriveKeyFromSeedPhrase(params);
   }
 
-  export async function deriveKeyFromSeedWithPath(params: wasm.DeriveKeyFromSeedWithPathParams): Promise<wasm.PathDerivedKeyInfo> {
+  export async function deriveKeyFromSeedWithPath(
+    params: wasm.DeriveKeyFromSeedWithPathParams,
+  ): Promise<wasm.PathDerivedKeyInfo> {
     await wasm.ensureInitialized();
     return wasm.WasmSdk.deriveKeyFromSeedWithPath(params);
   }
 
-  export async function deriveKeyFromSeedWithExtendedPath(params: wasm.DeriveKeyFromSeedWithExtendedPathParams): Promise<wasm.DerivedKeyInfo> {
+  export async function deriveKeyFromSeedWithExtendedPath(
+    params: wasm.DeriveKeyFromSeedWithExtendedPathParams,
+  ): Promise<wasm.DerivedKeyInfo> {
     await wasm.ensureInitialized();
     return wasm.WasmSdk.deriveKeyFromSeedWithExtendedPath(params);
   }
 
-  export async function deriveDashpayContactKey(params: wasm.DeriveDashpayContactKeyParams): Promise<wasm.DashpayContactKeyInfo> {
+  export async function deriveDashpayContactKey(
+    params: wasm.DeriveDashpayContactKeyParams,
+  ): Promise<wasm.DashpayContactKeyInfo> {
     await wasm.ensureInitialized();
     return wasm.WasmSdk.deriveDashpayContactKey(params);
   }
 
-  export async function derivationPathBip44Mainnet(account: number, change: number, index: number): Promise<wasm.DerivationPathInfo> {
+  export async function derivationPathBip44Mainnet(account: number, change: number, index: number):
+    Promise<wasm.DerivationPathInfo> {
     await wasm.ensureInitialized();
     return wasm.WasmSdk.derivationPathBip44Mainnet(account, change, index);
   }
 
-  export async function derivationPathBip44Testnet(account: number, change: number, index: number): Promise<wasm.DerivationPathInfo> {
+  export async function derivationPathBip44Testnet(account: number, change: number, index: number):
+    Promise<wasm.DerivationPathInfo> {
     await wasm.ensureInitialized();
     return wasm.WasmSdk.derivationPathBip44Testnet(account, change, index);
   }
 
-  export async function derivationPathDip9Mainnet(featureType: number, account: number, index: number): Promise<wasm.DerivationPathInfo> {
+  export async function derivationPathDip9Mainnet(featureType: number, account: number, index: number):
+    Promise<wasm.DerivationPathInfo> {
     await wasm.ensureInitialized();
     return wasm.WasmSdk.derivationPathDip9Mainnet(featureType, account, index);
   }
 
-  export async function derivationPathDip9Testnet(featureType: number, account: number, index: number): Promise<wasm.DerivationPathInfo> {
+  export async function derivationPathDip9Testnet(featureType: number, account: number, index: number):
+    Promise<wasm.DerivationPathInfo> {
     await wasm.ensureInitialized();
     return wasm.WasmSdk.derivationPathDip9Testnet(featureType, account, index);
   }

--- a/packages/js-evo-sdk/tests/karma/options.cjs
+++ b/packages/js-evo-sdk/tests/karma/options.cjs
@@ -1,4 +1,3 @@
-/* eslint-disable import-x/no-extraneous-dependencies */
 const webpack = require('webpack');
 const karmaMocha = require('karma-mocha');
 const karmaMochaReporter = require('karma-mocha-reporter');

--- a/packages/js-evo-sdk/tests/unit/facades/identities.spec.ts
+++ b/packages/js-evo-sdk/tests/unit/facades/identities.spec.ts
@@ -32,6 +32,7 @@ describe('IdentitiesFacade', () => {
   let getIdentityByNonUniquePublicKeyHashStub: SinonStub;
   let getIdentityByNonUniquePublicKeyHashWithProofInfoStub: SinonStub;
   let getIdentitiesContractKeysStub: SinonStub;
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   let getIdentitiesContractKeysWithProofInfoStub: SinonStub;
   let getIdentityTokenBalancesStub: SinonStub;
   let getIdentityTokenBalancesWithProofInfoStub: SinonStub;
@@ -43,7 +44,7 @@ describe('IdentitiesFacade', () => {
 
   beforeEach(async function setup() {
     await init();
-    const builder = wasmSDKPackage.WasmSdkBuilder.testnetTrusted();
+    const builder = wasmSDKPackage.WasmSdkBuilder.testnet();
     wasmSdk = await builder.build();
     client = EvoSDK.fromWasm(wasmSdk);
 
@@ -75,7 +76,8 @@ describe('IdentitiesFacade', () => {
       metadata: {},
     });
     getIdentityContractNonceStub = this.sinon.stub(wasmSdk, 'getIdentityContractNonce').resolves(BigInt(0));
-    getIdentityContractNonceWithProofInfoStub = this.sinon.stub(wasmSdk, 'getIdentityContractNonceWithProofInfo').resolves({
+    getIdentityContractNonceWithProofInfoStub = this.sinon
+      .stub(wasmSdk, 'getIdentityContractNonceWithProofInfo').resolves({
       data: BigInt(0),
       proof: {},
       metadata: {},
@@ -109,7 +111,8 @@ describe('IdentitiesFacade', () => {
         proof: {},
         metadata: {},
       });
-    getIdentityByNonUniquePublicKeyHashStub = this.sinon.stub(wasmSdk, 'getIdentityByNonUniquePublicKeyHash').resolves([]);
+    getIdentityByNonUniquePublicKeyHashStub = this.sinon
+      .stub(wasmSdk, 'getIdentityByNonUniquePublicKeyHash').resolves([]);
     getIdentityByNonUniquePublicKeyHashWithProofInfoStub = this.sinon
       .stub(wasmSdk, 'getIdentityByNonUniquePublicKeyHashWithProofInfo').resolves({
         data: [],
@@ -124,7 +127,8 @@ describe('IdentitiesFacade', () => {
         metadata: {},
       });
     getIdentityTokenBalancesStub = this.sinon.stub(wasmSdk, 'getIdentityTokenBalances').resolves(new Map());
-    getIdentityTokenBalancesWithProofInfoStub = this.sinon.stub(wasmSdk, 'getIdentityTokenBalancesWithProofInfo').resolves({
+    getIdentityTokenBalancesWithProofInfoStub = this.sinon
+      .stub(wasmSdk, 'getIdentityTokenBalancesWithProofInfo').resolves({
       data: new Map(),
       proof: {},
       metadata: {},

--- a/packages/rs-platform-version/Cargo.toml
+++ b/packages/rs-platform-version/Cargo.toml
@@ -12,7 +12,6 @@ thiserror = { version = "2.0.12" }
 bincode = { version = "=2.0.1" }
 versioned-feature-core = { git = "https://github.com/dashpay/versioned-feature-core", version = "1.0.0" }
 grovedb-version = { git = "https://github.com/dashpay/grovedb", rev = "33dfd48a1718160cb333fa95424be491785f1897" }
-once_cell = "1.19.0"
 
 [features]
 mock-versions = []

--- a/packages/wasm-dpp2/src/core/pro_tx_hash.rs
+++ b/packages/wasm-dpp2/src/core/pro_tx_hash.rs
@@ -17,7 +17,7 @@ const PRO_TX_HASH_LIKE_TS: &str = r#"
  * - Uint8Array: 32 bytes in internal byte order
  */
 export type ProTxHashLike = ProTxHash | string | Uint8Array;
-export type ProTxHashLikeArray = Array<ProTxHash | string | Uint8Array>;
+export type ProTxHashLikeArray = Array<ProTxHashLike>;
 "#;
 
 /// Extern type for flexible ProTxHash input
@@ -26,7 +26,7 @@ extern "C" {
     #[wasm_bindgen(typescript_type = "ProTxHashLike")]
     pub type ProTxHashLikeJs;
 
-    #[wasm_bindgen(typescript_type = "ProTxHashLike | null")]
+    #[wasm_bindgen(typescript_type = "ProTxHashLike | undefined")]
     pub type ProTxHashLikeNullableJs;
 
     #[wasm_bindgen(typescript_type = "ProTxHashLikeArray")]

--- a/packages/wasm-dpp2/src/identifier.rs
+++ b/packages/wasm-dpp2/src/identifier.rs
@@ -19,7 +19,7 @@ pub struct IdentifierWasm(Identifier);
 #[wasm_bindgen(typescript_custom_section)]
 const IDENTIFIER_TS_HELPERS: &str = r#"
 export type IdentifierLike = Identifier | Uint8Array | string;
-export type IdentifierLikeArray = Array<Identifier | Uint8Array | string>;
+export type IdentifierLikeArray = Array<IdentifierLike>;
 export type IdentifierLikeOrUndefined = Identifier | Uint8Array | string | undefined;
 "#;
 

--- a/packages/wasm-dpp2/src/platform_address/address.rs
+++ b/packages/wasm-dpp2/src/platform_address/address.rs
@@ -28,7 +28,7 @@ export type PlatformAddressLike = PlatformAddress | Uint8Array | string;
 /**
  * An array of Platform addresses.
  */
-export type PlatformAddressLikeArray = Array<PlatformAddress | Uint8Array | string>;
+export type PlatformAddressLikeArray = Array<PlatformAddressLike>;
 "#;
 
 #[wasm_bindgen]

--- a/packages/wasm-sdk/src/dpns.rs
+++ b/packages/wasm-sdk/src/dpns.rs
@@ -457,7 +457,7 @@ impl WasmSdk {
 
     #[wasm_bindgen(
         js_name = "getDpnsUsernameByNameWithProofInfo",
-        unchecked_return_type = "ProofMetadataResponseTyped<DpnsUsernameInfo | null>"
+        unchecked_return_type = "ProofMetadataResponseTyped<DpnsUsernameInfo | undefined>"
     )]
     pub async fn get_dpns_username_by_name_with_proof_info(
         &self,
@@ -558,7 +558,7 @@ impl WasmSdk {
 
     #[wasm_bindgen(
         js_name = "getDpnsUsernameWithProofInfo",
-        unchecked_return_type = "ProofMetadataResponseTyped<string | null>"
+        unchecked_return_type = "ProofMetadataResponseTyped<string | undefined>"
     )]
     pub async fn get_dpns_username_with_proof_info(
         &self,

--- a/packages/wasm-sdk/src/queries/identity.rs
+++ b/packages/wasm-sdk/src/queries/identity.rs
@@ -324,7 +324,7 @@ impl WasmSdk {
 
     #[wasm_bindgen(
         js_name = "getIdentityWithProofInfo",
-        unchecked_return_type = "ProofMetadataResponseTyped<Identity | null>"
+        unchecked_return_type = "ProofMetadataResponseTyped<Identity | undefined>"
     )]
     pub async fn get_identity_with_proof_info(
         &self,
@@ -552,7 +552,7 @@ impl WasmSdk {
 
     #[wasm_bindgen(
         js_name = "getIdentityNonceWithProofInfo",
-        unchecked_return_type = "ProofMetadataResponseTyped<bigint | null>"
+        unchecked_return_type = "ProofMetadataResponseTyped<bigint | undefined>"
     )]
     pub async fn get_identity_nonce_with_proof_info(
         &self,
@@ -602,7 +602,7 @@ impl WasmSdk {
 
     #[wasm_bindgen(
         js_name = "getIdentityContractNonceWithProofInfo",
-        unchecked_return_type = "ProofMetadataResponseTyped<bigint | null>"
+        unchecked_return_type = "ProofMetadataResponseTyped<bigint | undefined>"
     )]
     pub async fn get_identity_contract_nonce_with_proof_info(
         &self,
@@ -656,7 +656,7 @@ impl WasmSdk {
 
     #[wasm_bindgen(
         js_name = "getIdentitiesBalances",
-        unchecked_return_type = "Map<Identifier, bigint | null>"
+        unchecked_return_type = "Map<Identifier, bigint | undefined>"
     )]
     pub async fn get_identities_balances(
         &self,
@@ -910,7 +910,7 @@ impl WasmSdk {
 
     #[wasm_bindgen(
         js_name = "getIdentityBalanceWithProofInfo",
-        unchecked_return_type = "ProofMetadataResponseTyped<bigint | null>"
+        unchecked_return_type = "ProofMetadataResponseTyped<bigint | undefined>"
     )]
     pub async fn get_identity_balance_with_proof_info(
         &self,
@@ -939,7 +939,7 @@ impl WasmSdk {
 
     #[wasm_bindgen(
         js_name = "getIdentitiesBalancesWithProofInfo",
-        unchecked_return_type = "ProofMetadataResponseTyped<Map<Identifier, bigint | null>>"
+        unchecked_return_type = "ProofMetadataResponseTyped<Map<Identifier, bigint | undefined>>"
     )]
     pub async fn get_identities_balances_with_proof_info(
         &self,
@@ -982,7 +982,7 @@ impl WasmSdk {
 
     #[wasm_bindgen(
         js_name = "getIdentityBalanceAndRevisionWithProofInfo",
-        unchecked_return_type = "ProofMetadataResponseTyped<IdentityBalanceAndRevision | null>"
+        unchecked_return_type = "ProofMetadataResponseTyped<IdentityBalanceAndRevision | undefined>"
     )]
     pub async fn get_identity_balance_and_revision_with_proof_info(
         &self,
@@ -1013,7 +1013,7 @@ impl WasmSdk {
 
     #[wasm_bindgen(
         js_name = "getIdentityByPublicKeyHashWithProofInfo",
-        unchecked_return_type = "ProofMetadataResponseTyped<Identity | null>"
+        unchecked_return_type = "ProofMetadataResponseTyped<Identity | undefined>"
     )]
     pub async fn get_identity_by_public_key_hash_with_proof_info(
         &self,

--- a/packages/wasm-sdk/src/queries/token.rs
+++ b/packages/wasm-sdk/src/queries/token.rs
@@ -609,7 +609,7 @@ impl WasmSdk {
 
     #[wasm_bindgen(
         js_name = "getTokenTotalSupplyWithProofInfo",
-        unchecked_return_type = "ProofMetadataResponseTyped<TokenTotalSupply | null>"
+        unchecked_return_type = "ProofMetadataResponseTyped<TokenTotalSupply | undefined>"
     )]
     pub async fn get_token_total_supply_with_proof_info(
         &self,
@@ -828,7 +828,7 @@ impl WasmSdk {
 
     #[wasm_bindgen(
         js_name = "getTokenPerpetualDistributionLastClaimWithProofInfo",
-        unchecked_return_type = "ProofMetadataResponseTyped<TokenLastClaim | undefined>"
+        unchecked_return_type = "ProofMetadataResponseTyped<RewardDistributionMoment | undefined>"
     )]
     pub async fn get_token_perpetual_distribution_last_claim_with_proof_info(
         &self,


### PR DESCRIPTION
## Issue being fixed or feature implemented

Type inconsistencies between the wasm-sdk Rust layer and the js-evo-sdk TypeScript facades resulted in incorrect nullability annotations, unknown return types, and inconsistent parameter types that hurt developer experience and could mask runtime errors.

## What was done?

- **Unified optional return types**: Changed `| null` to `| undefined` in `unchecked_return_type` macro to match JavaScript/TypeScript conventions where WASM returns `undefined` (not `null`) for absent values
- **Replaced `unknown` return types** with actual wasm types in all js-evo-sdk facade methods (e.g., `Promise<unknown>` → `Promise<wasm.TokenMintResult>`)
- **Introduced named array type aliases**: `IdentifierLikeArray`, `PlatformAddressLikeArray`, `ProTxHashLikeArray` for cleaner function signatures instead of raw `IdentifierLike[]`
- **Fixed `TokenLastClaim` → `RewardDistributionMoment`** mapping in `unchecked_return_type` to match the actual Rust type export
- **Corrected `ProTxHashLike` nullability**: Use `ProTxHashLike | undefined` instead of `string | Uint8Array | null`
- **Removed unnecessary `?? null` coercions** in facade methods where the wasm layer already handles optional parameters
- **Fixed missing `| undefined`** in proof return types that incorrectly declared non-optional results
- **Removed unused `once_cell` dependency** from `rs-platform-version`
- **Fixed eslint max-len warnings** in facade files by reformatting long type signatures

## How Has This Been Tested?

- Existing unit tests in `js-evo-sdk` updated and passing (e.g., `identities.spec.ts` mock adjustments)
- Type-checked with TypeScript compiler — no type errors in facade files
- Wasm-sdk unit tests remain green

## Breaking Changes

No breaking changes at runtime. TypeScript return types are now more precise (e.g., `unknown` → specific type, `| null` → `| undefined`), which may surface compile-time errors in downstream code that was relying on the looser types.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [x] I have made corresponding changes to the documentation if needed

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added document management actions: create, replace, delete, transfer, purchase, and set price.
  - Expanded proof-enabled queries and batch lookups across the SDK.

- Refactor
  - Standardized optional results to use undefined (replacing null) for more consistent responses.
  - Unified batch input parameters to typed array aliases across addresses, contracts, identities, tokens, groups, and epoch queries.
  - Some values are now guaranteed (e.g., total platform credits, prefunded balances).
  - Certain proof responses now return maps for clearer keyed results.

- Tests
  - Updated test configuration to use a different network preset.

- Chores
  - Lint cleanup and minor dependency removal.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->