### PR TITLE
fix(swift-sdk): made executeAsync generic implement Sendable

### DIFF
--- a/packages/swift-sdk/Sources/SwiftDashSDK/Utils/StateManagement.swift
+++ b/packages/swift-sdk/Sources/SwiftDashSDK/Utils/StateManagement.swift
@@ -144,7 +144,7 @@ public enum AsyncOperation {
     ///   - onComplete: Called when operation completes (success or failure).
     ///   - operation: The async operation to run.
     @MainActor
-    public static func execute<T>(
+    public static func execute<T: Sendable>(
         onStart: (() -> Void)? = nil,
         onSuccess: ((T) -> Void)? = nil,
         onError: ((String) -> Void)? = nil,

--- a/packages/swift-sdk/SwiftExampleApp/SwiftExampleApp/ViewModels/BaseViewModel.swift
+++ b/packages/swift-sdk/SwiftExampleApp/SwiftExampleApp/ViewModels/BaseViewModel.swift
@@ -72,7 +72,7 @@ class BaseViewModel: ObservableObject {
     ///   - operation: The async operation to execute.
     /// - Returns: The result of the operation, or nil if it failed.
     @discardableResult
-    func executeAsync<T>(
+    func executeAsync<T: Sendable>(
         showResultOnSuccess: Bool = true,
         operation: () async throws -> T
     ) async -> T? {


### PR DESCRIPTION
Fixed the compile issue by forcing T to implement Sendable in executeAsync


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [ ] I have made corresponding changes to the documentation if needed

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone
