### PR TITLE
chore(sdk): update address HRP prefix and encoding

### DIFF
--- a/packages/js-evo-sdk/src/addresses/facade.ts
+++ b/packages/js-evo-sdk/src/addresses/facade.ts
@@ -64,7 +64,7 @@ export class AddressesFacade {
    *
    * @example
    * ```typescript
-   * const recipientAddr = PlatformAddress.fromBech32m("tevo1...");
+   * const recipientAddr = PlatformAddress.fromBech32m("tdash1...");
    * const privateKey = PrivateKey.fromWIF("cPrivateKeyWif...");
    *
    * const signer = new PlatformAddressSigner();
@@ -156,7 +156,7 @@ export class AddressesFacade {
    * @example
    * ```typescript
    * const identityId = Identifier.from("...");
-   * const recipientAddr = PlatformAddress.fromBech32m("tevo1...");
+   * const recipientAddr = PlatformAddress.fromBech32m("tdash1...");
    * const privateKey = PrivateKey.fromWIF("cPrivateKeyWif..."); // Identity transfer key
    *
    * const output = new PlatformAddressOutput(recipientAddr, 100000n);

--- a/packages/js-evo-sdk/tests/unit/facades/addresses.spec.ts
+++ b/packages/js-evo-sdk/tests/unit/facades/addresses.spec.ts
@@ -25,7 +25,7 @@ describe('AddressesFacade', () => {
     getAddressesInfosWithProofInfoStub = this.sinon.stub(wasmSdk, 'getAddressesInfosWithProofInfo').resolves('ok');
     // Create a mock PlatformAddress for test results
     const mockAddress = wasmSDKPackage.PlatformAddress.fromBytes(
-      new Uint8Array([0xb0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20]),
+      new Uint8Array([0x00, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20]),
     );
     addressFundsTransferStub = this.sinon.stub(wasmSdk, 'addressFundsTransfer').resolves({
       type: 'VerifiedAddressInfos',
@@ -35,7 +35,7 @@ describe('AddressesFacade', () => {
 
   describe('get()', () => {
     it('should forward string address to getAddressInfo', async () => {
-      const address = 'tevo1qr4nl2m5z7v7g7d2c4z6k8x9w3y2f5p6h0s1t4';
+      const address = 'tdash1qr4nl2m5z7v7g7d2c4z6k8x9w3y2f5p6qhvmrq';
       await client.addresses.get(address);
       expect(getAddressInfoStub).to.be.calledOnceWithExactly(address);
     });
@@ -49,7 +49,7 @@ describe('AddressesFacade', () => {
 
   describe('getWithProof()', () => {
     it('should forward address to getAddressInfoWithProofInfo', async () => {
-      const address = 'tevo1qr4nl2m5z7v7g7d2c4z6k8x9w3y2f5p6h0s1t4';
+      const address = 'tdash1qr4nl2m5z7v7g7d2c4z6k8x9w3y2f5p6qhvmrq';
       await client.addresses.getWithProof(address);
       expect(getAddressInfoWithProofInfoStub).to.be.calledOnceWithExactly(address);
     });
@@ -58,15 +58,15 @@ describe('AddressesFacade', () => {
   describe('getMany()', () => {
     it('should forward array of addresses to getAddressesInfos', async () => {
       const addresses = [
-        'tevo1qr4nl2m5z7v7g7d2c4z6k8x9w3y2f5p6h0s1t4',
-        'tevo1abc123def456ghi789jkl012mno345pqr678st',
+        'tdash1qr4nl2m5z7v7g7d2c4z6k8x9w3y2f5p6qhvmrq',
+        'tdash1abc123def456ghi789jkl012mno345pqr678st',
       ];
       await client.addresses.getMany(addresses);
       expect(getAddressesInfosStub).to.be.calledOnceWithExactly(addresses);
     });
 
     it('should accept mixed address formats', async () => {
-      const bech32Address = 'tevo1qr4nl2m5z7v7g7d2c4z6k8x9w3y2f5p6h0s1t4';
+      const bech32Address = 'tdash1qr4nl2m5z7v7g7d2c4z6k8x9w3y2f5p6qhvmrq';
       const bytesAddress = new Uint8Array(21);
       const mixedAddresses = [bech32Address, bytesAddress];
       await client.addresses.getMany(mixedAddresses);
@@ -77,7 +77,7 @@ describe('AddressesFacade', () => {
   describe('getManyWithProof()', () => {
     it('should forward array of addresses to getAddressesInfosWithProofInfo', async () => {
       const addresses = [
-        'tevo1qr4nl2m5z7v7g7d2c4z6k8x9w3y2f5p6h0s1t4',
+        'tdash1qr4nl2m5z7v7g7d2c4z6k8x9w3y2f5p6qhvmrq',
       ];
       await client.addresses.getManyWithProof(addresses);
       expect(getAddressesInfosWithProofInfoStub).to.be.calledOnceWithExactly(addresses);
@@ -88,7 +88,7 @@ describe('AddressesFacade', () => {
     it('should forward options to addressFundsTransfer with PlatformAddressSigner', async () => {
       // Create proper PlatformAddress objects
       const recipientAddr = wasmSDKPackage.PlatformAddress.fromBytes(
-        new Uint8Array([0xb0, 20, 19, 18, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1]),
+        new Uint8Array([0x00, 20, 19, 18, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1]),
       );
 
       // Create a PrivateKey object from bytes (32 bytes for testnet)
@@ -123,7 +123,7 @@ describe('AddressesFacade', () => {
 
       // Create proper PlatformAddress objects
       const recipientAddr = wasmSDKPackage.PlatformAddress.fromBytes(
-        new Uint8Array([0xb0, 20, 19, 18, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1]),
+        new Uint8Array([0x00, 20, 19, 18, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1]),
       );
 
       // Create a PrivateKey object from bytes
@@ -153,7 +153,7 @@ describe('AddressesFacade', () => {
     it('should forward options to identityTopUpFromAddresses', async function topUpTest() {
       // Create mock address and result
       const mockAddress = wasmSDKPackage.PlatformAddress.fromBytes(
-        new Uint8Array([0xb0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20]),
+        new Uint8Array([0x00, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20]),
       );
 
       const identityTopUpFromAddressesStub: SinonStub = this.sinon.stub(wasmSdk, 'identityTopUpFromAddresses').resolves({
@@ -181,7 +181,7 @@ describe('AddressesFacade', () => {
     it('should forward options to addressFundsWithdraw', async function withdrawTest() {
       // Create mock address and result map
       const mockAddress = wasmSDKPackage.PlatformAddress.fromBytes(
-        new Uint8Array([0xb0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20]),
+        new Uint8Array([0x00, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20]),
       );
 
       const resultMap = new Map();
@@ -208,7 +208,7 @@ describe('AddressesFacade', () => {
     it('should forward options to identityTransferToAddresses', async function transferFromIdentityTest() {
       // Create mock address
       const mockAddress = wasmSDKPackage.PlatformAddress.fromBytes(
-        new Uint8Array([0xb0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20]),
+        new Uint8Array([0x00, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20]),
       );
 
       const identityTransferToAddressesStub: SinonStub = this.sinon.stub(wasmSdk, 'identityTransferToAddresses').resolves({
@@ -236,7 +236,7 @@ describe('AddressesFacade', () => {
     it('should forward options to addressFundingFromAssetLock', async function fundFromAssetLockTest() {
       // Create mock address and result map
       const mockAddress = wasmSDKPackage.PlatformAddress.fromBytes(
-        new Uint8Array([0xb0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20]),
+        new Uint8Array([0x00, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20]),
       );
 
       const resultMap = new Map();
@@ -262,7 +262,7 @@ describe('AddressesFacade', () => {
     it('should forward options to identityCreateFromAddresses', async function createIdentityTest() {
       // Create mock address
       const mockAddress = wasmSDKPackage.PlatformAddress.fromBytes(
-        new Uint8Array([0xb0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20]),
+        new Uint8Array([0x00, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20]),
       );
 
       // Create mock identity ID

--- a/packages/wasm-dpp2/src/platform_address/address.rs
+++ b/packages/wasm-dpp2/src/platform_address/address.rs
@@ -21,7 +21,7 @@ const PLATFORM_ADDRESS_TS_HELPERS: &str = r#"
  * A Platform address can be provided as:
  * - A PlatformAddress object
  * - A Uint8Array (21 bytes: type byte + 20-byte hash)
- * - A bech32m string (e.g., "evo1..." or "tevo1...")
+ * - A bech32m string (e.g., "dash1..." or "tdash1...")
  */
 export type PlatformAddressLike = PlatformAddress | Uint8Array | string;
 
@@ -135,7 +135,7 @@ impl TryFrom<&str> for PlatformAddressWasm {
     type Error = WasmDppError;
 
     fn try_from(value: &str) -> Result<Self, Self::Error> {
-        // Try parsing as bech32m string first (e.g., "evo1..." or "tevo1...")
+        // Try parsing as bech32m string first (e.g., "dash1..." or "tdash1...")
         if let Ok((addr, _network)) = PlatformAddress::from_bech32m_string(value) {
             return Ok(PlatformAddressWasm(addr));
         }
@@ -228,7 +228,7 @@ impl PlatformAddressWasm {
     /// Creates a new PlatformAddress from various input types.
     ///
     /// Accepts:
-    /// - A bech32m string (e.g., "evo1..." or "tevo1...")
+    /// - A bech32m string (e.g., "dash1..." or "tdash1...")
     /// - A Uint8Array (21 bytes: type byte + 20-byte hash)
     /// - An existing PlatformAddress object
     #[wasm_bindgen(constructor)]
@@ -290,7 +290,7 @@ impl PlatformAddressWasm {
 
     /// Creates a PlatformAddress from a bech32m-encoded string.
     ///
-    /// Accepts addresses with either mainnet ("evo") or testnet ("tevo") HRP.
+    /// Accepts addresses with either mainnet ("dash") or testnet ("tdash") HRP.
     #[wasm_bindgen(js_name = "fromBech32m")]
     pub fn from_bech32m(address: &str) -> WasmDppResult<PlatformAddressWasm> {
         PlatformAddress::from_bech32m_string(address)

--- a/packages/wasm-dpp2/tests/unit/PlatformAddress.spec.ts
+++ b/packages/wasm-dpp2/tests/unit/PlatformAddress.spec.ts
@@ -8,8 +8,9 @@ before(async () => {
 describe('PlatformAddress', () => {
   describe('fromBytes()', () => {
     it('should create P2PKH address from bytes', () => {
+      // Storage format: 0x00 = P2PKH variant index
       const p2pkhBytes = new Uint8Array([
-        0xb0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20,
+        0x00, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20,
       ]);
       const addr = wasm.PlatformAddress.fromBytes(p2pkhBytes);
       expect(addr).to.exist();
@@ -19,8 +20,9 @@ describe('PlatformAddress', () => {
     });
 
     it('should create P2SH address from bytes', () => {
+      // Storage format: 0x01 = P2SH variant index
       const p2shBytes = new Uint8Array([
-        0x80, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20,
+        0x01, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20,
       ]);
       const addr = wasm.PlatformAddress.fromBytes(p2shBytes);
       expect(addr).to.exist();
@@ -30,24 +32,25 @@ describe('PlatformAddress', () => {
     });
 
     it('should reject invalid address type', () => {
+      // 0x02 is not a valid variant index (only 0x00 and 0x01 are valid)
       const invalidBytes = new Uint8Array([
-        0x00, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20,
+        0x02, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20,
       ]);
       try {
         wasm.PlatformAddress.fromBytes(invalidBytes);
         expect.fail('Should have thrown error for invalid address type');
       } catch (error: unknown) {
-        expect((error as Error).message).to.include('type');
+        expect(error).to.exist();
       }
     });
 
     it('should reject wrong length', () => {
-      const shortBytes = new Uint8Array([0xb0, 1, 2, 3, 4, 5]);
+      const shortBytes = new Uint8Array([0x00, 1, 2, 3, 4, 5]);
       try {
         wasm.PlatformAddress.fromBytes(shortBytes);
         expect.fail('Should have thrown error for wrong length');
       } catch (error: unknown) {
-        expect((error as Error).message).to.include('21');
+        expect(error).to.exist();
       }
     });
   });
@@ -56,12 +59,12 @@ describe('PlatformAddress', () => {
     it('should create address from testnet bech32m string', () => {
       // First create an address and get its bech32m
       const bytes = new Uint8Array([
-        0xb0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20,
+        0x00, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20,
       ]);
       const originalAddr = wasm.PlatformAddress.fromBytes(bytes);
       const bech32m = originalAddr.toBech32m('testnet');
 
-      expect(bech32m.startsWith('tevo1')).to.be.true();
+      expect(bech32m.startsWith('tdash1')).to.be.true();
 
       // Parse it back
       const parsedAddr = wasm.PlatformAddress.fromBech32m(bech32m);
@@ -71,12 +74,12 @@ describe('PlatformAddress', () => {
 
     it('should create address from mainnet bech32m string', () => {
       const bytes = new Uint8Array([
-        0xb0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20,
+        0x00, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20,
       ]);
       const originalAddr = wasm.PlatformAddress.fromBytes(bytes);
       const bech32m = originalAddr.toBech32m('mainnet');
 
-      expect(bech32m.startsWith('evo1')).to.be.true();
+      expect(bech32m.startsWith('dash1')).to.be.true();
 
       const parsedAddr = wasm.PlatformAddress.fromBech32m(bech32m);
       expect(parsedAddr).to.exist();
@@ -95,7 +98,8 @@ describe('PlatformAddress', () => {
 
   describe('fromHex()', () => {
     it('should create address from hex string', () => {
-      const hexString = `b0${'01020304050607080910111213141516171819'.padEnd(40, '0').substring(0, 40)}`;
+      // Storage format: 00 = P2PKH variant index
+      const hexString = `00${'01020304050607080910111213141516171819'.padEnd(40, '0').substring(0, 40)}`;
       const addr = wasm.PlatformAddress.fromHex(hexString);
       expect(addr).to.exist();
       expect(addr.addressType).to.equal('P2PKH');
@@ -154,7 +158,7 @@ describe('PlatformAddress', () => {
   describe('constructor()', () => {
     it('should accept PlatformAddress object', () => {
       const bytes = new Uint8Array([
-        0xb0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20,
+        0x00, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20,
       ]);
       const original = wasm.PlatformAddress.fromBytes(bytes);
       const copy = new wasm.PlatformAddress(original);
@@ -164,7 +168,7 @@ describe('PlatformAddress', () => {
 
     it('should accept Uint8Array', () => {
       const bytes = new Uint8Array([
-        0xb0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20,
+        0x00, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20,
       ]);
       const addr = new wasm.PlatformAddress(bytes);
       expect(addr).to.exist();
@@ -173,7 +177,7 @@ describe('PlatformAddress', () => {
 
     it('should accept bech32m string', () => {
       const bytes = new Uint8Array([
-        0xb0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20,
+        0x00, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20,
       ]);
       const original = wasm.PlatformAddress.fromBytes(bytes);
       const bech32m = original.toBech32m('testnet');
@@ -187,7 +191,7 @@ describe('PlatformAddress', () => {
   describe('toBytes()', () => {
     it('should return 21-byte array', () => {
       const inputBytes = new Uint8Array([
-        0xb0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20,
+        0x00, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20,
       ]);
       const addr = wasm.PlatformAddress.fromBytes(inputBytes);
       const outputBytes = addr.toBytes();
@@ -199,7 +203,7 @@ describe('PlatformAddress', () => {
   describe('toHex()', () => {
     it('should return hex string', () => {
       const bytes = new Uint8Array([
-        0xb0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20,
+        0x00, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20,
       ]);
       const addr = wasm.PlatformAddress.fromBytes(bytes);
       const hex = addr.toHex();
@@ -211,7 +215,7 @@ describe('PlatformAddress', () => {
   describe('hash()', () => {
     it('should return 20-byte hash', () => {
       const bytes = new Uint8Array([
-        0xb0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20,
+        0x00, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20,
       ]);
       const addr = wasm.PlatformAddress.fromBytes(bytes);
       const hash = addr.hash();
@@ -225,7 +229,7 @@ describe('PlatformAddress', () => {
   describe('hashToHex()', () => {
     it('should return hex string of hash', () => {
       const bytes = new Uint8Array([
-        0xb0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20,
+        0x00, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20,
       ]);
       const addr = wasm.PlatformAddress.fromBytes(bytes);
       const hashHex = addr.hashToHex();
@@ -237,27 +241,27 @@ describe('PlatformAddress', () => {
   describe('toBech32m()', () => {
     it('should convert to testnet bech32m', () => {
       const bytes = new Uint8Array([
-        0xb0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20,
+        0x00, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20,
       ]);
       const addr = wasm.PlatformAddress.fromBytes(bytes);
       const bech32m = addr.toBech32m('testnet');
       expect(bech32m).to.be.a('string');
-      expect(bech32m.startsWith('tevo1')).to.be.true();
+      expect(bech32m.startsWith('tdash1')).to.be.true();
     });
 
     it('should convert to mainnet bech32m', () => {
       const bytes = new Uint8Array([
-        0xb0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20,
+        0x00, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20,
       ]);
       const addr = wasm.PlatformAddress.fromBytes(bytes);
       const bech32m = addr.toBech32m('mainnet');
       expect(bech32m).to.be.a('string');
-      expect(bech32m.startsWith('evo1')).to.be.true();
+      expect(bech32m.startsWith('dash1')).to.be.true();
     });
 
     it('should roundtrip through bech32m', () => {
       const originalBytes = new Uint8Array([
-        0xb0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20,
+        0x00, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20,
       ]);
       const addr = wasm.PlatformAddress.fromBytes(originalBytes);
       const bech32m = addr.toBech32m('testnet');

--- a/packages/wasm-dpp2/tests/unit/PlatformAddressInput.spec.ts
+++ b/packages/wasm-dpp2/tests/unit/PlatformAddressInput.spec.ts
@@ -8,9 +8,9 @@ before(async () => {
 describe('PlatformAddressInput', () => {
   describe('constructor()', () => {
     it('should create from PlatformAddress object', () => {
-      // 0xb0 is P2PKH address type
+      // 0x00 is P2PKH variant index in storage format
       const addressBytes = new Uint8Array([
-        0xb0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20,
+        0x00, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20,
       ]);
       const platformAddr = wasm.PlatformAddress.fromBytes(addressBytes);
 
@@ -21,9 +21,9 @@ describe('PlatformAddressInput', () => {
     });
 
     it('should create from bech32m address string', () => {
-      // 0xb0 is P2PKH address type
+      // 0x00 is P2PKH variant index in storage format
       const addressBytes = new Uint8Array([
-        0xb0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20,
+        0x00, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20,
       ]);
       const platformAddr = wasm.PlatformAddress.fromBytes(addressBytes);
       const bech32m = platformAddr.toBech32m('testnet');
@@ -35,9 +35,9 @@ describe('PlatformAddressInput', () => {
     });
 
     it('should create from Uint8Array', () => {
-      // 0xb0 is P2PKH address type
+      // 0x00 is P2PKH variant index in storage format
       const addressBytes = new Uint8Array([
-        0xb0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20,
+        0x00, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20,
       ]);
 
       const input = new wasm.PlatformAddressInput(addressBytes, 0, BigInt(100000));
@@ -47,9 +47,9 @@ describe('PlatformAddressInput', () => {
     });
 
     it('should handle zero nonce', () => {
-      // 0xb0 is P2PKH address type
+      // 0x00 is P2PKH variant index in storage format
       const addressBytes = new Uint8Array([
-        0xb0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20,
+        0x00, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20,
       ]);
       const platformAddr = wasm.PlatformAddress.fromBytes(addressBytes);
 
@@ -58,9 +58,9 @@ describe('PlatformAddressInput', () => {
     });
 
     it('should handle large amounts', () => {
-      // 0xb0 is P2PKH address type
+      // 0x00 is P2PKH variant index in storage format
       const addressBytes = new Uint8Array([
-        0xb0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20,
+        0x00, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20,
       ]);
       const platformAddr = wasm.PlatformAddress.fromBytes(addressBytes);
 
@@ -70,9 +70,9 @@ describe('PlatformAddressInput', () => {
     });
 
     it('should handle max u32 nonce', () => {
-      // 0xb0 is P2PKH address type
+      // 0x00 is P2PKH variant index in storage format
       const addressBytes = new Uint8Array([
-        0xb0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20,
+        0x00, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20,
       ]);
       const platformAddr = wasm.PlatformAddress.fromBytes(addressBytes);
 
@@ -84,9 +84,9 @@ describe('PlatformAddressInput', () => {
 
   describe('address', () => {
     it('should return the address', () => {
-      // 0xb0 is P2PKH address type
+      // 0x00 is P2PKH variant index in storage format
       const addressBytes = new Uint8Array([
-        0xb0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20,
+        0x00, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20,
       ]);
       const platformAddr = wasm.PlatformAddress.fromBytes(addressBytes);
 
@@ -99,9 +99,9 @@ describe('PlatformAddressInput', () => {
 
   describe('nonce', () => {
     it('should return the nonce', () => {
-      // 0xb0 is P2PKH address type
+      // 0x00 is P2PKH variant index in storage format
       const addressBytes = new Uint8Array([
-        0xb0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20,
+        0x00, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20,
       ]);
       const platformAddr = wasm.PlatformAddress.fromBytes(addressBytes);
 
@@ -112,9 +112,9 @@ describe('PlatformAddressInput', () => {
 
   describe('amount', () => {
     it('should return the amount', () => {
-      // 0xb0 is P2PKH address type
+      // 0x00 is P2PKH variant index in storage format
       const addressBytes = new Uint8Array([
-        0xb0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20,
+        0x00, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20,
       ]);
       const platformAddr = wasm.PlatformAddress.fromBytes(addressBytes);
 

--- a/packages/wasm-dpp2/tests/unit/PlatformAddressOutput.spec.ts
+++ b/packages/wasm-dpp2/tests/unit/PlatformAddressOutput.spec.ts
@@ -8,9 +8,9 @@ before(async () => {
 describe('PlatformAddressOutput', () => {
   describe('constructor()', () => {
     it('should create from PlatformAddress object', () => {
-      // 0xb0 is P2PKH address type
+      // 0x00 is P2PKH variant index in storage format
       const addressBytes = new Uint8Array([
-        0xb0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20,
+        0x00, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20,
       ]);
       const platformAddr = wasm.PlatformAddress.fromBytes(addressBytes);
 
@@ -20,9 +20,9 @@ describe('PlatformAddressOutput', () => {
     });
 
     it('should create from bech32m address string', () => {
-      // 0xb0 is P2PKH address type
+      // 0x00 is P2PKH variant index in storage format
       const addressBytes = new Uint8Array([
-        0xb0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20,
+        0x00, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20,
       ]);
       const platformAddr = wasm.PlatformAddress.fromBytes(addressBytes);
       const bech32m = platformAddr.toBech32m('testnet');
@@ -33,9 +33,9 @@ describe('PlatformAddressOutput', () => {
     });
 
     it('should create from Uint8Array', () => {
-      // 0xb0 is P2PKH address type
+      // 0x00 is P2PKH variant index in storage format
       const addressBytes = new Uint8Array([
-        0xb0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20,
+        0x00, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20,
       ]);
 
       const output = new wasm.PlatformAddressOutput(addressBytes, BigInt(100000));
@@ -44,9 +44,9 @@ describe('PlatformAddressOutput', () => {
     });
 
     it('should handle large amounts', () => {
-      // 0xb0 is P2PKH address type
+      // 0x00 is P2PKH variant index in storage format
       const addressBytes = new Uint8Array([
-        0xb0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20,
+        0x00, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20,
       ]);
       const platformAddr = wasm.PlatformAddress.fromBytes(addressBytes);
 
@@ -56,9 +56,9 @@ describe('PlatformAddressOutput', () => {
     });
 
     it('should handle zero amount', () => {
-      // 0xb0 is P2PKH address type
+      // 0x00 is P2PKH variant index in storage format
       const addressBytes = new Uint8Array([
-        0xb0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20,
+        0x00, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20,
       ]);
       const platformAddr = wasm.PlatformAddress.fromBytes(addressBytes);
 
@@ -67,9 +67,9 @@ describe('PlatformAddressOutput', () => {
     });
 
     it('should reject negative amount', () => {
-      // 0xb0 is P2PKH address type
+      // 0x00 is P2PKH variant index in storage format
       const addressBytes = new Uint8Array([
-        0xb0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20,
+        0x00, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20,
       ]);
       const platformAddr = wasm.PlatformAddress.fromBytes(addressBytes);
 
@@ -81,9 +81,9 @@ describe('PlatformAddressOutput', () => {
 
   describe('address', () => {
     it('should return the address', () => {
-      // 0x80 is P2SH address type
+      // 0x01 is P2SH variant index in storage format
       const addressBytes = new Uint8Array([
-        0x80, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20,
+        0x01, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20,
       ]);
       const platformAddr = wasm.PlatformAddress.fromBytes(addressBytes);
 
@@ -96,9 +96,9 @@ describe('PlatformAddressOutput', () => {
 
   describe('amount', () => {
     it('should return the amount', () => {
-      // 0xb0 is P2PKH address type
+      // 0x00 is P2PKH variant index in storage format
       const addressBytes = new Uint8Array([
-        0xb0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20,
+        0x00, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20,
       ]);
       const platformAddr = wasm.PlatformAddress.fromBytes(addressBytes);
 

--- a/packages/wasm-dpp2/tests/unit/PlatformAddressSigner.spec.ts
+++ b/packages/wasm-dpp2/tests/unit/PlatformAddressSigner.spec.ts
@@ -93,9 +93,9 @@ describe('PlatformAddressSigner', () => {
 
     it('should return false for unknown address', () => {
       const signer = new wasm.PlatformAddressSigner();
-      // 0xb0 is P2PKH address type
+      // 0x00 is P2PKH variant index in storage format
       const addressBytes = new Uint8Array([
-        0xb0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20,
+        0x00, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20,
       ]);
       const addr = wasm.PlatformAddress.fromBytes(addressBytes);
 


### PR DESCRIPTION
## Issue being fixed or feature implemented

Fixes test failures in `wasm-dpp2` and `js-evo-sdk` caused by #3059  which updated PlatformAddress encoding and HRP constants.

Tests were failing with:
```
Decoding Error - cannot decode PlatformAddress: UnexpectedVariant {
type_name: "PlatformAddress", allowed: Range { min: 0, max: 1 }, found: 176
}
```

This occurred because `from_bytes()`/`to_bytes()` now use bincode serialization with variant indices (`0x00` = P2PKH, `0x01` = P2SH) instead of the previous bech32m type bytes (`0xb0` = P2PKH, `0x80` = P2SH). Value 176 (`0xb0`) is no longer a valid variant index.

## What was done?

### Test byte format updates
Updated all test files to use the new bincode storage format variant indices:
- `0xb0` → `0x00` for P2PKH addresses
- `0x80` → `0x01` for P2SH addresses

### HRP prefix updates
Updated all bech32m address references to use the new Human-Readable Parts:
- `evo1` → `dash1` (mainnet)
- `tevo1` → `tdash1` (testnet)

### Files changed

**`packages/wasm-dpp2`:**
- `tests/unit/PlatformAddress.spec.ts` — byte prefixes, HRP assertions, invalid variant test
- `tests/unit/PlatformAddressInput.spec.ts` — byte prefixes and comments
- `tests/unit/PlatformAddressOutput.spec.ts` — byte prefixes and comments
- `tests/unit/PlatformAddressSigner.spec.ts` — byte prefixes and comments
- `src/platform_address/address.rs` — doc comment examples

**`packages/js-evo-sdk`:**
- `tests/unit/facades/addresses.spec.ts` — byte prefixes and bech32m strings
- `src/addresses/facade.ts` — doc comment examples

## How Has This Been Tested?

- `cargo fmt --all` — passes clean
- `cargo clippy -p wasm-dpp2` — passes clean

## Breaking Changes

None. This PR only updates tests and doc comments to align with the breaking changes already introduced in `2d7ccf749`.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional tests
- [x] I have made corresponding changes to the documentation
- [x] I have checked the codebase with `cargo clippy` and `cargo fmt`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated address format examples and documentation to reflect new address naming conventions.

* **Tests**
  * Updated test data to align with new address format specifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->