### PR TITLE
fix(swift-sdk): fixed ios app transaction display

### DIFF
--- a/packages/swift-sdk/Sources/SwiftDashSDK/Core/Wallet/CoreWalletManager.swift
+++ b/packages/swift-sdk/Sources/SwiftDashSDK/Core/Wallet/CoreWalletManager.swift
@@ -18,11 +18,11 @@ public class CoreWalletManager: ObservableObject {
     private let sdkWalletManager: WalletManager
     private let modelContainer: ModelContainer
     private let storage = WalletStorage()
-    
+
     /// Initialize with a valid SPVClient instance
     init(spvClient: SPVClient, modelContainer: ModelContainer) throws {
         print("=== WalletManager.init START ===")
-        
+
         self.sdkWalletManager = try spvClient.getWalletManager()
         self.modelContainer = modelContainer
 
@@ -36,7 +36,7 @@ public class CoreWalletManager: ObservableObject {
     // MARK: - Wallet Management
     public func createWallet(label: String, mnemonic: String, pin: String, isImport: Bool = false) async throws -> HDWallet {
         print("WalletManager.createWallet called")
-        
+
         print("Validating provided mnemonic...")
         guard SwiftDashSDK.Mnemonic.validate(mnemonic) else {
             print("Mnemonic validation failed")
@@ -80,7 +80,7 @@ public class CoreWalletManager: ObservableObject {
         // Create HDWallet model for SwiftUI
         let network = AppNetwork(network: sdkWalletManager.network)
         let wallet = HDWallet(walletId: walletId, serializedWalletBytes: serializedBytes, label: label, network: network, isImported: isImport)
-        
+
         do {
             let seed = try SwiftDashSDK.Mnemonic.toSeed(mnemonic: mnemonic)
             _ = try storage.storeSeed(seed, pin: pin)
@@ -88,14 +88,14 @@ public class CoreWalletManager: ObservableObject {
             print("Failed to store seed: \(error)")
             // Continue anyway - wallet is already created
         }
-        
+
         // Insert wallet into context ans save it
         modelContainer.mainContext.insert(wallet)
         try modelContainer.mainContext.save()
-        
+
         return wallet
-    } 
-    
+    }
+
     public func deleteWallet(_ wallet: HDWallet) async throws {
         let walletId = wallet.id
 
@@ -112,14 +112,14 @@ public class CoreWalletManager: ObservableObject {
         try modelContainer.mainContext.save()
         return wallet
     }
-    
+
     public func decryptSeed(_ encryptedSeed: Data?) -> Data? {
         // This method is used internally by other services
         // In a real implementation, this would decrypt using the current PIN
         // For now, return nil to indicate manual unlock is needed
         return nil
     }
-    
+
     public func changeWalletPIN(currentPIN: String, newPIN: String) async throws {
         // Retrieve seed with current PIN
         let seed = try storage.retrieveSeed(pin: currentPIN)
@@ -139,7 +139,7 @@ public class CoreWalletManager: ObservableObject {
     public func unlockWithBiometric() async throws -> Data {
         return try storage.retrieveSeedWithBiometric()
     }
-    
+
     // MARK: - Account Management
 
     /// Get transactions for a wallet
@@ -155,10 +155,7 @@ public class CoreWalletManager: ObservableObject {
             accountType: .standardBIP44
         )
 
-        // Get current height (TODO: get from SPV client when available)
-        let currentHeight: UInt32 = 0
-
-        return try! managedAccount.getTransactions(currentHeight: currentHeight)
+        return managedAccount.getTransactions()
     }
 
     public func getBalance(for wallet: HDWallet, accountIndex: UInt32 = 0) -> Balance {
@@ -167,14 +164,14 @@ public class CoreWalletManager: ObservableObject {
             accountIndex: accountIndex,
             accountType: .standardBIP44
         )
-        
+
         return try! managedAccount.getBalance()
     }
-    
+
     public func getReceiveAddress(for wallet: HDWallet, accountIndex: UInt32 = 0) -> String {
         return try! sdkWalletManager.getReceiveAddress(walletId: wallet.walletId, accountIndex: accountIndex)
     }
-    
+
     /// Get detailed account information including xpub and addresses
     /// - Parameters:
     ///   - wallet: The wallet containing the account
@@ -416,7 +413,7 @@ public class CoreWalletManager: ObservableObject {
         }
         return list
     }
-    
+
     // MARK: - Private Methods
 
     private func loadWallets() async {
@@ -428,9 +425,9 @@ public class CoreWalletManager: ObservableObject {
             self.error = WalletError.databaseError(error.localizedDescription)
             return
         }
-            
+
         // Try to import each wallet into the FFI wallet manager
-        // If it succeeds, we store the HDWallet for later querying. If it fails, 
+        // If it succeeds, we store the HDWallet for later querying. If it fails,
         // we log the error and remove that wallet from the database.
         for wallet in wallets {
             do {
@@ -443,7 +440,7 @@ public class CoreWalletManager: ObservableObject {
                 }
 
                 self.wallets.append(wallet)
-                
+
                 print("Successfully restored wallet '\(wallet.label)' to FFI wallet manager")
             } catch {
                 modelContainer.mainContext.delete(wallet)

--- a/packages/swift-sdk/Sources/SwiftDashSDK/KeyWallet/ManagedAccount.swift
+++ b/packages/swift-sdk/Sources/SwiftDashSDK/KeyWallet/ManagedAccount.swift
@@ -53,25 +53,26 @@ public class ManagedAccount {
     // MARK: - Transactions
 
     /// Get all transactions for this account
-    /// - Parameter currentHeight: Current blockchain height for calculating confirmations
     /// - Returns: Array of transactions
-    public func getTransactions(currentHeight: UInt32 = 0) throws -> [WalletTransaction] {
-        var transactionsPtr: UnsafeMutablePointer<FFITransactionRecord>?
+    public func getTransactions() -> [WalletTransaction] {
+        var ptr: UnsafeMutablePointer<FFITransactionRecord>?
         var count: size_t = 0
 
-        let success = managed_core_account_get_transactions(handle, &transactionsPtr, &count)
+        let success = managed_core_account_get_transactions(handle, &ptr, &count)
 
         guard success else {
-            throw KeyWalletError.invalidState("Failed to get transactions from managed account")
+            preconditionFailure(
+              "Invalid state: managed_core_account_get_transactions can only fail if any pointer is nil"
+            )
         }
 
         // Handle empty case
-        guard count > 0, let ptr = transactionsPtr else {
+        guard count > 0, let ptr else {
             return []
         }
 
         defer {
-            managed_core_account_free_transactions(transactionsPtr, count)
+            managed_core_account_free_transactions(ptr, count)
         }
 
         // Convert FFI transactions to Swift transactions
@@ -80,24 +81,6 @@ public class ManagedAccount {
 
         for i in 0..<count {
             let ffiTx = ptr.advanced(by: i).pointee
-
-            // Calculate confirmations
-            let confirmations: Int
-            if ffiTx.height > 0 && currentHeight >= ffiTx.height {
-                confirmations = Int(currentHeight - ffiTx.height) + 1
-            } else {
-                confirmations = 0
-            }
-
-            // Determine transaction type
-            let type: String
-            if ffiTx.net_amount > 0 {
-                type = "received"
-            } else if ffiTx.net_amount < 0 {
-                type = "sent"
-            } else {
-                type = "self"
-            }
 
             // Convert txid to hex string
             let txidHex = withUnsafeBytes(of: ffiTx.txid) { buffer in
@@ -117,12 +100,10 @@ public class ManagedAccount {
             let transaction = WalletTransaction(
                 txid: txidHex,
                 netAmount: ffiTx.net_amount,
-                height: ffiTx.height > 0 ? ffiTx.height : nil,
+                height: ffiTx.height,
                 blockHash: blockHashHex,
                 timestamp: ffiTx.timestamp,
                 fee: ffiTx.fee > 0 ? ffiTx.fee : nil,
-                confirmations: confirmations,
-                type: type,
                 isOurs: ffiTx.is_ours
             )
 
@@ -183,30 +164,24 @@ public struct WalletTransaction: Identifiable {
     public let txid: String
     /// Net amount for the account (positive = received, negative = sent)
     public let netAmount: Int64
-    /// Block height if confirmed
-    public let height: UInt32?
+    /// Block height, 0 if not confirmed
+    public let height: UInt32
     /// Block hash if confirmed (hex string)
     public let blockHash: String?
     /// Unix timestamp
     public let timestamp: UInt64
     /// Fee if known
     public let fee: UInt64?
-    /// Number of confirmations
-    public let confirmations: Int
-    /// Transaction type: "received", "sent", or "self"
-    public let type: String
     /// Whether this is our transaction
     public let isOurs: Bool
 
     public init(
         txid: String,
         netAmount: Int64,
-        height: UInt32?,
+        height: UInt32,
         blockHash: String?,
         timestamp: UInt64,
         fee: UInt64?,
-        confirmations: Int,
-        type: String,
         isOurs: Bool
     ) {
         self.txid = txid
@@ -215,8 +190,6 @@ public struct WalletTransaction: Identifiable {
         self.blockHash = blockHash
         self.timestamp = timestamp
         self.fee = fee
-        self.confirmations = confirmations
-        self.type = type
         self.isOurs = isOurs
     }
 
@@ -227,7 +200,7 @@ public struct WalletTransaction: Identifiable {
 
     /// Is the transaction confirmed
     public var isConfirmed: Bool {
-        return confirmations > 0
+        return blockHash != nil && height > 0
     }
 
     /// Formatted amount string

--- a/packages/swift-sdk/SwiftExampleApp/SwiftExampleApp/Core/Views/TransactionDetailView.swift
+++ b/packages/swift-sdk/SwiftExampleApp/SwiftExampleApp/Core/Views/TransactionDetailView.swift
@@ -7,41 +7,35 @@ struct TransactionDetailView: View {
     @State private var showCopiedAlert = false
 
     private var typeDescription: String {
-        switch transaction.type {
-        case "received":
+        switch transaction.netAmount {
+        case let amount where amount > 0:
             return "Received"
-        case "sent":
+        case let amount where amount < 0:
             return "Sent"
-        case "self":
-            return "Self-Transfer"
         default:
-            return "Unknown"
+            return "Self-Transfer"
         }
     }
 
     private var typeIcon: String {
-        switch transaction.type {
-        case "received":
+        switch transaction.netAmount {
+        case let amount where amount > 0:
             return "arrow.down.circle.fill"
-        case "sent":
+        case let amount where amount < 0:
             return "arrow.up.circle.fill"
-        case "self":
-            return "arrow.triangle.2.circlepath"
         default:
-            return "questionmark.circle"
+            return "arrow.triangle.2.circlepath"
         }
     }
 
     private var typeColor: Color {
-        switch transaction.type {
-        case "received":
+        switch transaction.netAmount {
+        case let amount where amount > 0:
             return .green
-        case "sent":
+        case let amount where amount < 0:
             return .red
-        case "self":
-            return .blue
         default:
-            return .gray
+            return .blue
         }
     }
 
@@ -69,9 +63,7 @@ struct TransactionDetailView: View {
                     VStack(spacing: 16) {
                         TransactionDetailRow(
                             label: "Status",
-                            value: transaction.confirmations == 0 ? "Pending" :
-                                   transaction.confirmations < 6 ? "\(transaction.confirmations) confirmations" :
-                                   "Confirmed"
+                            value: !transaction.isConfirmed ? "Pending" : "Confirmed"
                         )
 
                         TransactionDetailRow(
@@ -79,14 +71,14 @@ struct TransactionDetailView: View {
                             value: formatDate(transaction.date)
                         )
 
-                        if let height = transaction.height {
+                        if transaction.height != 0 {
                             TransactionDetailRow(
                                 label: "Block Height",
-                                value: "\(height)"
+                                value: "\(transaction.height)"
                             )
                         }
 
-                        if let fee = transaction.formattedFee, transaction.type == "sent" {
+                        if let fee = transaction.formattedFee, transaction.netAmount < 0 {
                             TransactionDetailRow(
                                 label: "Network Fee",
                                 value: fee
@@ -239,8 +231,6 @@ struct TransactionDetailRow: View {
             blockHash: "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f",
             timestamp: UInt64(Date().timeIntervalSince1970),
             fee: 226,
-            confirmations: 6,
-            type: "received",
             isOurs: false
         )
     )

--- a/packages/swift-sdk/SwiftExampleApp/SwiftExampleApp/Core/Views/TransactionListView.swift
+++ b/packages/swift-sdk/SwiftExampleApp/SwiftExampleApp/Core/Views/TransactionListView.swift
@@ -8,9 +8,6 @@ struct TransactionListView: View {
     let wallet: HDWallet
 
     @State private var transactions: [WalletTransaction] = []
-    @State private var isLoading = false
-    @State private var errorMessage: String?
-    @State private var showError = false
     @State private var selectedTransaction: WalletTransaction?
 
     private var sortedTransactions: [WalletTransaction] {
@@ -19,10 +16,7 @@ struct TransactionListView: View {
 
     var body: some View {
         ZStack {
-            if isLoading {
-                ProgressView("Loading transactions...")
-                    .frame(maxWidth: .infinity, maxHeight: .infinity)
-            } else if transactions.isEmpty {
+            if transactions.isEmpty {
                 emptyStateView
             } else {
                 transactionsList
@@ -30,19 +24,14 @@ struct TransactionListView: View {
         }
         .navigationTitle("Transactions")
         .navigationBarTitleDisplayMode(.inline)
-        .alert("Error", isPresented: $showError) {
-            Button("OK", role: .cancel) {}
-        } message: {
-            Text(errorMessage ?? "Unknown error occurred")
-        }
         .sheet(item: $selectedTransaction) { transaction in
             TransactionDetailView(transaction: transaction)
         }
         .task {
-            await loadTransactions()
+            loadTransactions()
         }
         .refreshable {
-            await loadTransactions()
+            loadTransactions()
         }
     }
 
@@ -52,12 +41,12 @@ struct TransactionListView: View {
                 .font(.system(size: 60))
                 .foregroundColor(.gray)
 
-            Text("No Transactions Yet")
+            Text("No transactions found.")
                 .font(.headline)
 
             Text("Transactions will appear here once you send or receive Dash")
                 .font(.caption)
-                .foregroundColor(.secondary)
+                .foregroundColor(.gray)
                 .multilineTextAlignment(.center)
                 .padding(.horizontal)
         }
@@ -78,16 +67,8 @@ struct TransactionListView: View {
         .listStyle(.insetGrouped)
     }
 
-    private func loadTransactions() async {
-        isLoading = true
-        defer { isLoading = false }
-
-        // Get transactions from the wallet manager
-        let fetchedTransactions = walletService.walletManager.getTransactions(for: wallet)
-
-        await MainActor.run {
-            self.transactions = fetchedTransactions
-        }
+    private func loadTransactions() {
+        self.transactions = walletService.walletManager.getTransactions(for: wallet)
     }
 }
 
@@ -97,69 +78,54 @@ struct TransactionRowView: View {
     let transaction: WalletTransaction
 
     private var typeIcon: String {
-        switch transaction.type {
-        case "received":
+        switch transaction.netAmount {
+        case let amount where amount > 0:
             return "arrow.down.circle.fill"
-        case "sent":
+        case let amount where amount < 0:
             return "arrow.up.circle.fill"
-        case "self":
-            return "arrow.triangle.2.circlepath"
         default:
-            return "questionmark.circle"
+            return "arrow.triangle.2.circlepath"
         }
     }
 
     private var typeColor: Color {
-        switch transaction.type {
-        case "received":
+        switch transaction.netAmount {
+        case let amount where amount > 0:
             return .green
-        case "sent":
+        case let amount where amount < 0:
             return .red
-        case "self":
-            return .blue
         default:
-            return .gray
+            return .blue
         }
     }
 
+
     @ViewBuilder
     private var confirmationBadge: some View {
-        if transaction.confirmations == 0 {
-                HStack(spacing: 4) {
-                    Image(systemName: "clock")
-                        .font(.caption2)
-                    Text("Pending")
-                        .font(.caption2)
-                }
-                .padding(.horizontal, 6)
-                .padding(.vertical, 2)
-                .background(Color.orange.opacity(0.2))
-                .foregroundColor(.orange)
-                .cornerRadius(4)
-            } else if transaction.confirmations < 6 {
-                HStack(spacing: 4) {
-                    Image(systemName: "checkmark.circle")
-                        .font(.caption2)
-                    Text("\(transaction.confirmations)")
-                        .font(.caption2)
-                }
-                .padding(.horizontal, 6)
-                .padding(.vertical, 2)
-                .background(Color.blue.opacity(0.2))
-                .foregroundColor(.blue)
-                .cornerRadius(4)
-            } else {
-                HStack(spacing: 4) {
-                    Image(systemName: "checkmark.circle.fill")
-                        .font(.caption2)
-                    Text("Confirmed")
-                        .font(.caption2)
-                }
-                .padding(.horizontal, 6)
-                .padding(.vertical, 2)
-                .background(Color.green.opacity(0.2))
-                .foregroundColor(.green)
-                .cornerRadius(4)
+        if !transaction.isConfirmed {
+            HStack(spacing: 4) {
+                Image(systemName: "clock")
+                    .font(.caption2)
+                Text("Pending")
+                    .font(.caption2)
+            }
+            .padding(.horizontal, 6)
+            .padding(.vertical, 2)
+            .background(Color.orange.opacity(0.2))
+            .foregroundColor(.orange)
+            .cornerRadius(4)
+        } else {
+            HStack(spacing: 4) {
+                Image(systemName: "checkmark.circle.fill")
+                    .font(.caption2)
+                Text("Confirmed")
+                    .font(.caption2)
+            }
+            .padding(.horizontal, 6)
+            .padding(.vertical, 2)
+            .background(Color.green.opacity(0.2))
+            .foregroundColor(.green)
+            .cornerRadius(4)
         }
     }
 
@@ -172,33 +138,36 @@ struct TransactionRowView: View {
                 .frame(width: 40)
 
             VStack(alignment: .leading, spacing: 4) {
-                // Transaction ID (truncated)
-                Text(transaction.truncatedTxid)
-                    .font(.system(.subheadline, design: .monospaced))
-                    .foregroundColor(.primary)
+                // Transaction ID (truncated) and timestamp
+                HStack {
+                    Text(transaction.truncatedTxid)
+                        .font(.system(.subheadline, design: .monospaced))
+                        .foregroundColor(.primary)
 
-                // Date and confirmation
-                HStack(spacing: 8) {
+                        Spacer()
+
                     Text(transaction.date, style: .relative)
                         .font(.caption)
                         .foregroundColor(.secondary)
-
-                    confirmationBadge
                 }
-            }
 
-            Spacer()
+                // confirmation and amount
+                HStack {
+                  confirmationBadge
 
-            // Amount
-            VStack(alignment: .trailing, spacing: 2) {
-                Text(transaction.formattedAmount)
-                    .font(.headline)
-                    .foregroundColor(typeColor)
+                  Spacer()
 
-                if let fee = transaction.formattedFee, transaction.type == "sent" {
-                    Text("Fee: \(fee)")
-                        .font(.caption2)
-                        .foregroundColor(.secondary)
+                  VStack(alignment: .trailing, spacing: 2) {
+                      Text(transaction.formattedAmount)
+                          .font(.headline)
+                          .foregroundColor(typeColor)
+
+                      if let fee = transaction.formattedFee, transaction.netAmount < 0 {
+                          Text("Fee: \(fee)")
+                              .font(.caption2)
+                              .foregroundColor(.secondary)
+                      }
+                  }
                 }
             }
         }


### PR DESCRIPTION
The transactions list view was messy and trying to display information without following the FFI specification:

  - Made the UI more compact and elegant imo
  - if a transaction is confirmed is decided following the FFI documentation, removing in the process the _half confirmed_ state, that's an information not provided by the FFI  


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [x] I have made corresponding changes to the documentation if needed

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Confirmation shown as "Pending" or "Confirmed" instead of numeric counts
  * Transaction model simplified (fewer metadata fields) and retrieval no longer throws

* **Wallet**
  * Wallet creation and persistence flow improved; seeds are generated and stored with stronger persistence and error handling

* **UI**
  * Transaction list streamlined to a tappable list, removing separate loading/error states
  * Transaction type, icon, and color now derive from amount sign
  * Fees and block height render only when applicable
<!-- end of auto-generated comment: release notes by coderabbit.ai -->