### PR TITLE
fix(swift-sdk): fixed wallet balance calculation

### DIFF
--- a/packages/swift-sdk/Sources/SwiftDashSDK/Core/Models/HDWalletModels.swift
+++ b/packages/swift-sdk/Sources/SwiftDashSDK/Core/Models/HDWalletModels.swift
@@ -30,22 +30,20 @@ public struct AccountInfo: Identifiable, Hashable, Sendable {
     public let category: AccountCategory
     public let index: UInt32? // present only for indexed account types
     public let label: String
-    public let balance: (confirmed: UInt64, unconfirmed: UInt64)
+    public let balance: Balance
     public let addressCount: (external: Int, internal: Int)
-    public let nextReceiveAddress: String?
 
     public init(category: AccountCategory,
                 index: UInt32? = nil,
                 label: String,
-                balance: (confirmed: UInt64, unconfirmed: UInt64),
-                addressCount: (external: Int, internal: Int),
-                nextReceiveAddress: String?) {
+                balance: Balance,
+                addressCount: (external: Int, internal: Int)) {
         self.category = category
         self.index = index
         self.label = label
         self.balance = balance
         self.addressCount = addressCount
-        self.nextReceiveAddress = nextReceiveAddress
+
         // Build a stable id
         if let idx = index {
             self.id = "\(category)-\(idx)"

--- a/packages/swift-sdk/Sources/SwiftDashSDK/Core/Wallet/CoreWalletManager.swift
+++ b/packages/swift-sdk/Sources/SwiftDashSDK/Core/Wallet/CoreWalletManager.swift
@@ -158,14 +158,27 @@ public class CoreWalletManager: ObservableObject {
         return managedAccount.getTransactions()
     }
 
-    public func getBalance(for wallet: HDWallet, accountIndex: UInt32 = 0) -> Balance {
-        let managedAccount = try! sdkWalletManager.getManagedAccount(
-            walletId: wallet.walletId,
-            accountIndex: accountIndex,
-            accountType: .standardBIP44
-        )
+    public func getBalance(for wallet: HDWallet) -> Balance {
+        let accounts = self.getAccounts(for: wallet)
 
-        return try! managedAccount.getBalance()
+        var confirmed: UInt64 = 0
+        var unconfirmed: UInt64 = 0
+        var immature: UInt64 = 0
+        var locked: UInt64 = 0
+
+        for account in accounts {
+            confirmed += account.balance.confirmed
+            unconfirmed += account.balance.unconfirmed
+            immature += account.balance.immature
+            locked += account.balance.locked
+        }
+
+        return Balance(
+            confirmed: confirmed,
+            unconfirmed: unconfirmed,
+            immature: immature,
+            locked: locked
+        )
     }
 
     public func getReceiveAddress(for wallet: HDWallet, accountIndex: UInt32 = 0) -> String {
@@ -177,8 +190,10 @@ public class CoreWalletManager: ObservableObject {
     ///   - wallet: The wallet containing the account
     ///   - accountInfo: The account info to get details for
     /// - Returns: Detailed account information
-    public func getAccountDetails(for wallet: HDWallet, accountInfo: AccountInfo) async throws -> AccountDetailInfo {
-        let collection = try sdkWalletManager.getManagedAccountCollection(walletId: wallet.walletId)
+    public func getAccountDetails(for wallet: HDWallet, accountInfo: AccountInfo) -> AccountDetailInfo? {
+        let collection = sdkWalletManager.getManagedAccountCollection(walletId: wallet.walletId)
+
+        guard let collection else { return nil }
 
         // Resolve managed account from category and optional index
         var managed: ManagedAccount?
@@ -331,8 +346,11 @@ public class CoreWalletManager: ObservableObject {
     /// - Parameters:
     ///   - wallet: The wallet model
     /// - Returns: Account information including balances and address counts
-    public func getAccounts(for wallet: HDWallet) async throws -> [AccountInfo] {
-        let collection = try sdkWalletManager.getManagedAccountCollection(walletId: wallet.walletId)
+    public func getAccounts(for wallet: HDWallet) -> [AccountInfo] {
+        let collection = sdkWalletManager.getManagedAccountCollection(walletId: wallet.walletId)
+
+        guard let collection else { return [] }
+
         var list: [AccountInfo] = []
 
         func counts(_ m: ManagedAccount) -> (Int, Int) {
@@ -345,63 +363,63 @@ public class CoreWalletManager: ObservableObject {
         // BIP44
         for idx in collection.getBIP44Indices() {
             if let m = collection.getBIP44Account(at: idx) {
-                let b = try? m.getBalance()
+                let b = m.getBalance()
                 let c = counts(m)
-                list.append(AccountInfo(category: .bip44, index: idx, label: "Account \(idx)", balance: (b?.confirmed ?? 0, b?.unconfirmed ?? 0), addressCount: (c.0, c.1), nextReceiveAddress: nil))
+                list.append(AccountInfo(category: .bip44, index: idx, label: "Account \(idx)", balance: b, addressCount: c))
             }
         }
         // BIP32 (5000+)
         for raw in collection.getBIP32Indices() {
             if let m = collection.getBIP32Account(at: raw) {
-                let b = try? m.getBalance()
+                let b = m.getBalance()
                 let c = counts(m)
-                list.append(AccountInfo(category: .bip32, index: raw, label: "BIP32 \(raw)", balance: (b?.confirmed ?? 0, b?.unconfirmed ?? 0), addressCount: (c.0, c.1), nextReceiveAddress: nil))
+                list.append(AccountInfo(category: .bip32, index: raw, label: "BIP32 \(raw)", balance: b, addressCount: c))
             }
         }
         // CoinJoin (1000+)
         for raw in collection.getCoinJoinIndices() {
             if let m = collection.getCoinJoinAccount(at: raw) {
-                let b = try? m.getBalance()
+                let b = m.getBalance()
                 var total = 0
                 if let p = m.getAddressPool(type: .single), let infos = try? p.getAddresses(from: 0, to: 1000) { total = infos.count }
-                list.append(AccountInfo(category: .coinjoin, index: raw, label: "CoinJoin \(raw)", balance: (b?.confirmed ?? 0, b?.unconfirmed ?? 0), addressCount: (total, 0), nextReceiveAddress: nil))
+                list.append(AccountInfo(category: .coinjoin, index: raw, label: "CoinJoin \(raw)", balance: b, addressCount: (total, 0)))
             }
         }
         // Identity accounts
         if let m = collection.getIdentityRegistrationAccount() {
-            let b = try? m.getBalance()
-            list.append(AccountInfo(category: .identityRegistration, label: "Identity Registration", balance: (b?.confirmed ?? 0, b?.unconfirmed ?? 0), addressCount: (0, 0), nextReceiveAddress: nil))
+            let b = m.getBalance()
+            list.append(AccountInfo(category: .identityRegistration, label: "Identity Registration", balance: b, addressCount: (0, 0)))
         }
         if let m = collection.getIdentityInvitationAccount() {
-            let b = try? m.getBalance()
-            list.append(AccountInfo(category: .identityInvitation, label: "Identity Invitation", balance: (b?.confirmed ?? 0, b?.unconfirmed ?? 0), addressCount: (0, 0), nextReceiveAddress: nil))
+            let b = m.getBalance()
+            list.append(AccountInfo(category: .identityInvitation, label: "Identity Invitation", balance: b, addressCount: (0, 0)))
         }
         if let m = collection.getIdentityTopUpNotBoundAccount() {
-            let b = try? m.getBalance()
-            list.append(AccountInfo(category: .identityTopupNotBound, label: "Identity Topup (Not Bound)", balance: (b?.confirmed ?? 0, b?.unconfirmed ?? 0), addressCount: (0, 0), nextReceiveAddress: nil))
+            let b = m.getBalance()
+            list.append(AccountInfo(category: .identityTopupNotBound, label: "Identity Topup (Not Bound)", balance: b, addressCount: (0, 0)))
         }
         for raw in collection.getIdentityTopUpIndices() {
             if let m = collection.getIdentityTopUpAccount(registrationIndex: raw) {
-                let b = try? m.getBalance()
-                list.append(AccountInfo(category: .identityTopup, index: raw, label: "Identity Topup \(raw)", balance: (b?.confirmed ?? 0, b?.unconfirmed ?? 0), addressCount: (0, 0), nextReceiveAddress: nil))
+                let b = m.getBalance()
+                list.append(AccountInfo(category: .identityTopup, index: raw, label: "Identity Topup \(raw)", balance: b, addressCount: (0, 0)))
             }
         }
         // Provider
         if let m = collection.getProviderVotingKeysAccount() {
-            let b = try? m.getBalance()
-            list.append(AccountInfo(category: .providerVotingKeys, label: "Provider Voting Keys", balance: (b?.confirmed ?? 0, b?.unconfirmed ?? 0), addressCount: (0, 0), nextReceiveAddress: nil))
+            let b = m.getBalance()
+            list.append(AccountInfo(category: .providerVotingKeys, label: "Provider Voting Keys", balance: b, addressCount: (0, 0)))
         }
         if let m = collection.getProviderOwnerKeysAccount() {
-            let b = try? m.getBalance()
-            list.append(AccountInfo(category: .providerOwnerKeys, label: "Provider Owner Keys", balance: (b?.confirmed ?? 0, b?.unconfirmed ?? 0), addressCount: (0, 0), nextReceiveAddress: nil))
+            let b = m.getBalance()
+            list.append(AccountInfo(category: .providerOwnerKeys, label: "Provider Owner Keys", balance: b, addressCount: (0, 0)))
         }
         if let m = collection.getProviderOperatorKeysAccount() {
-            let b = try? m.getBalance()
-            list.append(AccountInfo(category: .providerOperatorKeys, label: "Provider Operator Keys (BLS)", balance: (b?.confirmed ?? 0, b?.unconfirmed ?? 0), addressCount: (0, 0), nextReceiveAddress: nil))
+            let b = m.getBalance()
+            list.append(AccountInfo(category: .providerOperatorKeys, label: "Provider Operator Keys (BLS)", balance: b, addressCount: (0, 0)))
         }
         if let m = collection.getProviderPlatformKeysAccount() {
-            let b = try? m.getBalance()
-            list.append(AccountInfo(category: .providerPlatformKeys, label: "Provider Platform Keys (EdDSA)", balance: (b?.confirmed ?? 0, b?.unconfirmed ?? 0), addressCount: (0, 0), nextReceiveAddress: nil))
+            let b = m.getBalance()
+            list.append(AccountInfo(category: .providerPlatformKeys, label: "Provider Platform Keys (EdDSA)", balance: b, addressCount: (0, 0)))
         }
 
         // Sort BIP44 by index first, then other types below

--- a/packages/swift-sdk/Sources/SwiftDashSDK/KeyWallet/ManagedAccount.swift
+++ b/packages/swift-sdk/Sources/SwiftDashSDK/KeyWallet/ManagedAccount.swift
@@ -116,12 +116,13 @@ public class ManagedAccount {
     // MARK: - Balance
 
     /// Get the balance for this account
-    public func getBalance() throws -> Balance {
+    public func getBalance() -> Balance {
         var ffiBalance = FFIBalance()
         let success = managed_core_account_get_balance(handle, &ffiBalance)
 
         guard success else {
-            throw KeyWalletError.invalidState("Failed to get balance for managed account")
+            // managed_core_account_get_balance can only fail if handle or ffiBalance are null
+            preconditionFailure("managed_core_account_get_balance failed, invalid state")
         }
 
         return Balance(ffiBalance: ffiBalance)

--- a/packages/swift-sdk/Sources/SwiftDashSDK/KeyWallet/WalletManager.swift
+++ b/packages/swift-sdk/Sources/SwiftDashSDK/KeyWallet/WalletManager.swift
@@ -477,9 +477,9 @@ public class WalletManager {
     /// - Parameters:
     ///   - walletId: The wallet ID
     /// - Returns: The managed account collection
-    public func getManagedAccountCollection(walletId: Data) throws -> ManagedAccountCollection {
+    public func getManagedAccountCollection(walletId: Data) -> ManagedAccountCollection? {
         guard walletId.count == 32 else {
-            throw KeyWalletError.invalidInput("Wallet ID must be exactly 32 bytes")
+            return nil
         }
 
         var error = FFIError()
@@ -496,7 +496,7 @@ public class WalletManager {
         }
 
         guard let collection = collectionHandle else {
-            throw KeyWalletError(ffiError: error)
+            return nil
         }
 
         return ManagedAccountCollection(handle: collection, manager: self)

--- a/packages/swift-sdk/SwiftExampleApp/SwiftExampleApp/Core/Views/AccountDetailView.swift
+++ b/packages/swift-sdk/SwiftExampleApp/SwiftExampleApp/Core/Views/AccountDetailView.swift
@@ -25,11 +25,7 @@ struct AccountDetailView: View {
 
     var body: some View {
         ScrollView {
-            if isLoading {
-                ProgressView("Loading account details...")
-                    .padding()
-                    .frame(maxWidth: .infinity, maxHeight: .infinity)
-            } else if let error = errorMessage {
+            if let error = errorMessage {
                 ContentUnavailableView(
                     "Failed to Load Details",
                     systemImage: "exclamationmark.triangle",
@@ -62,7 +58,7 @@ struct AccountDetailView: View {
         .navigationTitle(account.label)
         .navigationBarTitleDisplayMode(.large)
         .task {
-            await loadAccountDetails()
+            loadAccountDetails()
         }
         .sheet(isPresented: $showingPINPrompt) {
             PINPromptView(
@@ -622,26 +618,14 @@ struct AccountDetailView: View {
 
     // MARK: - Data Loading
 
-    private func loadAccountDetails() async {
-        isLoading = true
-        errorMessage = nil
-
-        do {
-            // Get extended public key and other details
-            let details = try await walletService.walletManager.getAccountDetails(
-                for: wallet,
-                accountInfo: account
-            )
-
-            await MainActor.run {
-                self.detailInfo = details
-                self.isLoading = false
-            }
-        } catch {
-            await MainActor.run {
-                self.errorMessage = error.localizedDescription
-                self.isLoading = false
-            }
+    private func loadAccountDetails() {
+        if let details = walletService.walletManager.getAccountDetails(
+            for: wallet,
+            accountInfo: account
+        ) {
+            self.detailInfo = details
+        } else {
+            self.errorMessage = "Unable to load account details"
         }
     }
 }

--- a/packages/swift-sdk/SwiftExampleApp/SwiftExampleApp/Core/Views/AccountListView.swift
+++ b/packages/swift-sdk/SwiftExampleApp/SwiftExampleApp/Core/Views/AccountListView.swift
@@ -9,21 +9,10 @@ struct AccountListView: View {
     @EnvironmentObject var walletService: WalletService
     let wallet: HDWallet
     @State private var accounts: [AccountInfo] = []
-    @State private var isLoading = true
-    @State private var errorMessage: String?
 
     var body: some View {
         ZStack {
-            if isLoading {
-                ProgressView("Loading accounts...")
-                    .frame(maxWidth: .infinity, maxHeight: .infinity)
-            } else if let error = errorMessage {
-                ContentUnavailableView(
-                    "Failed to Load Accounts",
-                    systemImage: "exclamationmark.triangle",
-                    description: Text(error)
-                )
-            } else if accounts.isEmpty {
+            if accounts.isEmpty {
                 ContentUnavailableView(
                     "No Accounts",
                     systemImage: "folder",
@@ -37,32 +26,16 @@ struct AccountListView: View {
                 }
                 .listStyle(.plain)
                 .refreshable {
-                    await loadAccounts()
+                    loadAccounts()
                 }
             }
-        }
-        .task {
-            await loadAccounts()
+        }.task {
+            loadAccounts()
         }
     }
 
-    private func loadAccounts() async {
-        isLoading = true
-        errorMessage = nil
-
-        do {
-            // Get accounts from wallet manager
-            let fetchedAccounts = try await walletService.walletManager.getAccounts(for: wallet)
-            await MainActor.run {
-                self.accounts = fetchedAccounts
-                self.isLoading = false
-            }
-        } catch {
-            await MainActor.run {
-                self.errorMessage = error.localizedDescription
-                self.isLoading = false
-            }
-        }
+    private func loadAccounts() {
+        self.accounts = walletService.walletManager.getAccounts(for: wallet)
     }
 }
 
@@ -207,33 +180,6 @@ struct AccountRowView: View {
                     }
 
                     Spacer()
-                }
-            }
-
-            // Next receive address (if available and appropriate for account type)
-            if shouldShowBalance, let address = account.nextReceiveAddress {
-                HStack {
-                    Text("Receive:")
-                        .font(.caption)
-                        .foregroundColor(.secondary)
-
-                    Text(address)
-                        .font(.system(.caption, design: .monospaced))
-                        .lineLimit(1)
-                        .truncationMode(.middle)
-                        .foregroundColor(.secondary)
-
-                    Button(action: {
-                        // Copy address to clipboard
-                        #if os(iOS)
-                        UIPasteboard.general.string = address
-                        #endif
-                    }) {
-                        Image(systemName: "doc.on.doc")
-                            .font(.caption)
-                            .foregroundColor(.secondary)
-                    }
-                    .buttonStyle(.plain)
                 }
             }
         }

--- a/packages/swift-sdk/SwiftExampleApp/SwiftExampleApp/Core/Views/WalletDetailView.swift
+++ b/packages/swift-sdk/SwiftExampleApp/SwiftExampleApp/Core/Views/WalletDetailView.swift
@@ -278,7 +278,7 @@ struct WalletInfoView: View {
                         Text(wallet.createdAt, style: .date)
                             .foregroundColor(.secondary)
                     }
-                    
+
                     HStack {
                         Text("Wallet ID")
                         Spacer()
@@ -385,22 +385,18 @@ struct WalletInfoView: View {
 
     private func loadAccountCounts() async {
         // TODO: This can probably be refactored now with with single network manager?
+        let count = walletService.walletManager.getAccounts(for: wallet).count
+
         if mainnetEnabled {
-            if let list = try? await walletService.walletManager.getAccounts(for: wallet) {
-                mainnetAccountCount = list.count
-            }
+            mainnetAccountCount = count
         } else { mainnetAccountCount = nil }
 
         if testnetEnabled {
-            if let list = try? await walletService.walletManager.getAccounts(for: wallet) {
-                testnetAccountCount = list.count
-            }
+            testnetAccountCount = count
         } else { testnetAccountCount = nil }
 
         if devnetEnabled {
-            if let list = try? await walletService.walletManager.getAccounts(for: wallet) {
-                devnetAccountCount = list.count
-            }
+            devnetAccountCount = count
         } else { devnetAccountCount = nil }
     }
 
@@ -464,11 +460,11 @@ struct BalanceCardView: View {
     let wallet: HDWallet
     @EnvironmentObject var unifiedAppState: UnifiedAppState
     @EnvironmentObject var walletService: WalletService
-    
+
     var platformBalance: UInt64 {
         // Only sum balances of identities that belong to this specific wallet
         // and are on the same network
-        
+
         return unifiedAppState.platformState.identities
             .filter { identity in
                 // Check if identity belongs to this wallet and is on the same network
@@ -493,7 +489,7 @@ struct BalanceCardView: View {
                 Text("Wallet Balance")
                     .font(.subheadline)
                     .foregroundColor(.secondary)
-                
+
                 Text(balance.formattedTotal)
                     .font(.system(size: 36, weight: .bold, design: .rounded))
             }


### PR DESCRIPTION
Wallet balance was implemented by retrieving Main account balance, this PR fixes that and replaces that logic with the sum of all account balances inside a wallet


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [ ] I have made corresponding changes to the documentation if needed

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Removed transient loading indicators and alternate error paths in account list/detail views for more immediate UI feedback.
  * Consolidated balance reporting to a single Balance representation so displayed balances are consistent.

* **Chores**
  * Removed the next-receive-address from account displays and related UI controls.
  * Switched account and balance loading to synchronous, non-throwing flows for more predictable view updates.

* **Refactor**
  * Streamlined per-network account counting to avoid repeated fetches.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->