### PR TITLE
fix(wasm-sdk): increment address nonce in identity_create_from_addresses

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7350,6 +7350,7 @@ dependencies = [
  "serde_json",
  "sha2",
  "thiserror 2.0.17",
+ "tokio",
  "tracing",
  "tracing-subscriber",
  "tracing-wasm",

--- a/packages/wasm-sdk/Cargo.toml
+++ b/packages/wasm-sdk/Cargo.toml
@@ -93,6 +93,7 @@ wasm-dpp2 = { path = "../wasm-dpp2" }
 
 [dev-dependencies]
 wasm-sdk = { path = ".", features = ["mocks", "all-system-contracts"] }
+tokio = { version = "1.40", features = ["macros", "rt-multi-thread"] }
 
 [profile.release]
 opt-level = "z"

--- a/packages/wasm-sdk/src/state_transitions/addresses.rs
+++ b/packages/wasm-sdk/src/state_transitions/addresses.rs
@@ -989,3 +989,75 @@ async fn fetch_nonces_into_address_map(
 
     Ok(inputs)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use dash_sdk::Sdk;
+    use drive_proof_verifier::types::AddressInfos;
+
+    /// Verify that `fetch_nonces_into_address_map` returns the **next** nonce
+    /// (current + 1) for every input address, matching the `nonce_inc()` pattern
+    /// used by rs-sdk's transfer/top_up/withdraw operations.
+    ///
+    /// This is a regression test for <https://github.com/dashpay/platform/issues/3083>
+    /// where the function was returning the current nonce instead of the next one.
+    #[tokio::test]
+    async fn fetch_nonces_returns_incremented_nonces() {
+        let mut sdk = Sdk::new_mock();
+
+        let addr_a = PlatformAddress::P2pkh([10; 20]);
+        let addr_b = PlatformAddress::P2sh([11; 20]);
+        let nonce_a: AddressNonce = 5;
+        let nonce_b: AddressNonce = 0;
+        let balance_a: Credits = 1_000_000;
+        let balance_b: Credits = 2_000_000;
+
+        let mock_response: AddressInfos = [
+            (
+                addr_a,
+                Some(AddressInfo {
+                    address: addr_a,
+                    nonce: nonce_a,
+                    balance: balance_a,
+                }),
+            ),
+            (
+                addr_b,
+                Some(AddressInfo {
+                    address: addr_b,
+                    nonce: nonce_b,
+                    balance: balance_b,
+                }),
+            ),
+        ]
+        .into_iter()
+        .collect();
+
+        let query = BTreeSet::from([addr_a, addr_b]);
+        sdk.mock()
+            .expect_fetch_many::<PlatformAddress, AddressInfo, _, AddressInfos>(
+                query,
+                Some(mock_response),
+            )
+            .await
+            .expect("set up mock expectation");
+
+        let inputs_map = BTreeMap::from([(addr_a, 500_000u64), (addr_b, 1_000_000u64)]);
+        let result = fetch_nonces_into_address_map(&sdk, inputs_map)
+            .await
+            .expect("fetch_nonces_into_address_map should succeed");
+
+        assert_eq!(result.len(), 2);
+        assert_eq!(
+            result[&addr_a],
+            (nonce_a + 1, 500_000),
+            "nonce for addr_a must be incremented by 1"
+        );
+        assert_eq!(
+            result[&addr_b],
+            (nonce_b + 1, 1_000_000),
+            "nonce for addr_b (starting at 0) must be incremented to 1"
+        );
+    }
+}

--- a/packages/wasm-sdk/src/state_transitions/addresses.rs
+++ b/packages/wasm-sdk/src/state_transitions/addresses.rs
@@ -979,7 +979,9 @@ async fn fetch_nonces_into_address_map(
                         address_requested, amount, info_received.balance
                     )))?
                 }
-                let nonce = info_received.nonce;
+                // Platform expects the next nonce (current + 1), matching
+                // nonce_inc() used by rs-sdk's transfer/top_up/withdraw.
+                let nonce = info_received.nonce + 1;
                 Ok((address_requested, (nonce, amount)))
             },
         )


### PR DESCRIPTION
## Summary

- Fixes off-by-one nonce bug in `identity_create_from_addresses`: the WASM SDK was sending the **current** address nonce, but the platform expects **current + 1**
- Aligns `fetch_nonces_into_address_map` with the `nonce_inc()` pattern already used by rs-sdk's `transfer_address_funds`, `top_up_from_addresses`, and `withdraw_address_funds`

Closes #3083

## Test plan

- [ ] Verify `identity_create_from_addresses` no longer gets rejected with a nonce mismatch error
- [ ] Confirm existing address-based state transitions (transfer, top-up, withdraw) still work correctly
- [ ] Run `cargo check -p wasm-sdk` — passes cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected nonce computation for addresses so subsequent transfers, top-ups, and withdrawals use the expected next nonce, preventing out-of-order or replay issues.
* **Tests**
  * Added regression tests to verify nonces are incremented as expected across address operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->