### PR TITLE
chore: add shumkov as code owner for SDK packages

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,10 @@
 * @QuantumExplorer
+
+# SDK packages
+/packages/rs-sdk/ @QuantumExplorer @shumkov
+/packages/rs-sdk-ffi/ @QuantumExplorer @shumkov
+/packages/rs-sdk-trusted-context-provider/ @QuantumExplorer @shumkov
+/packages/js-dash-sdk/ @QuantumExplorer @shumkov
+/packages/js-evo-sdk/ @QuantumExplorer @shumkov
+/packages/wasm-sdk/ @QuantumExplorer @shumkov
+/packages/swift-sdk/ @QuantumExplorer @shumkov


### PR DESCRIPTION
Adds @shumkov as a code owner for all SDK-related packages so PRs touching SDK code automatically request his review.

**Paths added:**
- `/packages/rs-sdk/`
- `/packages/rs-sdk-ffi/`
- `/packages/rs-sdk-trusted-context-provider/`
- `/packages/js-dash-sdk/`
- `/packages/js-evo-sdk/`
- `/packages/wasm-sdk/`
- `/packages/swift-sdk/`

The global `* @QuantumExplorer` rule is preserved as the default.