### PR TITLE
feat(sdk): add client-side validate_structure() to remaining state transitions

### DIFF
--- a/packages/rs-dpp/src/state_transition/state_transitions/address_funds/address_credit_withdrawal_transition/v0/v0_methods.rs
+++ b/packages/rs-dpp/src/state_transition/state_transitions/address_funds/address_credit_withdrawal_transition/v0/v0_methods.rs
@@ -14,6 +14,8 @@ use crate::serialization::Signable;
 use crate::state_transition::address_credit_withdrawal_transition::methods::AddressCreditWithdrawalTransitionMethodsV0;
 use crate::state_transition::address_credit_withdrawal_transition::v0::AddressCreditWithdrawalTransitionV0;
 #[cfg(feature = "state-transition-signing")]
+use crate::state_transition::StateTransitionStructureValidation;
+#[cfg(feature = "state-transition-signing")]
 use crate::withdrawal::Pooling;
 #[cfg(feature = "state-transition-signing")]
 use crate::{
@@ -35,7 +37,7 @@ impl AddressCreditWithdrawalTransitionMethodsV0 for AddressCreditWithdrawalTrans
         output_script: CoreScript,
         signer: &S,
         user_fee_increase: UserFeeIncrease,
-        _platform_version: &PlatformVersion,
+        platform_version: &PlatformVersion,
     ) -> Result<StateTransition, ProtocolError> {
         tracing::debug!("try_from_inputs_with_signer: Started");
         tracing::debug!(
@@ -65,6 +67,14 @@ impl AddressCreditWithdrawalTransitionMethodsV0 for AddressCreditWithdrawalTrans
             .keys()
             .map(|address| signer.sign_create_witness(address, &signable_bytes))
             .collect::<Result<Vec<AddressWitness>, ProtocolError>>()?;
+
+        // Validate the fully-constructed transition structure
+        let validation_result =
+            address_credit_withdrawal_transition.validate_structure(platform_version);
+        if !validation_result.is_valid() {
+            let first_error = validation_result.errors.into_iter().next().unwrap();
+            return Err(ProtocolError::ConsensusError(Box::new(first_error)));
+        }
 
         tracing::debug!("try_from_inputs_with_signer: Successfully created transition");
         Ok(address_credit_withdrawal_transition.into())

--- a/packages/rs-dpp/src/state_transition/state_transitions/address_funds/address_funding_from_asset_lock_transition/v0/v0_methods.rs
+++ b/packages/rs-dpp/src/state_transition/state_transitions/address_funds/address_funding_from_asset_lock_transition/v0/v0_methods.rs
@@ -14,6 +14,8 @@ use crate::serialization::Signable;
 use crate::state_transition::address_funding_from_asset_lock_transition::methods::AddressFundingFromAssetLockTransitionMethodsV0;
 use crate::state_transition::address_funding_from_asset_lock_transition::v0::AddressFundingFromAssetLockTransitionV0;
 #[cfg(feature = "state-transition-signing")]
+use crate::state_transition::StateTransitionStructureValidation;
+#[cfg(feature = "state-transition-signing")]
 use crate::{prelude::UserFeeIncrease, state_transition::StateTransition, ProtocolError};
 #[cfg(feature = "state-transition-signing")]
 use dashcore::signer;
@@ -30,7 +32,7 @@ impl AddressFundingFromAssetLockTransitionMethodsV0 for AddressFundingFromAssetL
         fee_strategy: AddressFundsFeeStrategy,
         signer: &S,
         user_fee_increase: UserFeeIncrease,
-        _platform_version: &PlatformVersion,
+        platform_version: &PlatformVersion,
     ) -> Result<StateTransition, ProtocolError> {
         tracing::debug!("try_from_asset_lock_with_signer: Started");
         tracing::debug!(
@@ -63,6 +65,13 @@ impl AddressFundingFromAssetLockTransitionMethodsV0 for AddressFundingFromAssetL
             .keys()
             .map(|address| signer.sign_create_witness(address, &signable_bytes))
             .collect::<Result<Vec<AddressWitness>, ProtocolError>>()?;
+
+        // Validate the fully-constructed transition structure
+        let validation_result = address_funding_transition.validate_structure(platform_version);
+        if !validation_result.is_valid() {
+            let first_error = validation_result.errors.into_iter().next().unwrap();
+            return Err(ProtocolError::ConsensusError(Box::new(first_error)));
+        }
 
         tracing::debug!("try_from_asset_lock_with_signer: Successfully created transition");
         Ok(address_funding_transition.into())

--- a/packages/rs-dpp/src/state_transition/state_transitions/address_funds/address_funds_transfer_transition/v0/v0_methods.rs
+++ b/packages/rs-dpp/src/state_transition/state_transitions/address_funds/address_funds_transfer_transition/v0/v0_methods.rs
@@ -12,6 +12,8 @@ use crate::serialization::Signable;
 use crate::state_transition::address_funds_transfer_transition::methods::AddressFundsTransferTransitionMethodsV0;
 use crate::state_transition::address_funds_transfer_transition::v0::AddressFundsTransferTransitionV0;
 #[cfg(feature = "state-transition-signing")]
+use crate::state_transition::StateTransitionStructureValidation;
+#[cfg(feature = "state-transition-signing")]
 use crate::{
     prelude::{AddressNonce, UserFeeIncrease},
     state_transition::StateTransition,
@@ -28,7 +30,7 @@ impl AddressFundsTransferTransitionMethodsV0 for AddressFundsTransferTransitionV
         fee_strategy: AddressFundsFeeStrategy,
         signer: &S,
         user_fee_increase: UserFeeIncrease,
-        _platform_version: &PlatformVersion,
+        platform_version: &PlatformVersion,
     ) -> Result<StateTransition, ProtocolError> {
         tracing::debug!("try_from_inputs_with_signer: Started");
         tracing::debug!(
@@ -54,6 +56,13 @@ impl AddressFundsTransferTransitionMethodsV0 for AddressFundsTransferTransitionV
             .keys()
             .map(|address| signer.sign_create_witness(address, &signable_bytes))
             .collect::<Result<Vec<AddressWitness>, ProtocolError>>()?;
+
+        // Validate the fully-constructed transition structure
+        let validation_result = address_funds_transition.validate_structure(platform_version);
+        if !validation_result.is_valid() {
+            let first_error = validation_result.errors.into_iter().next().unwrap();
+            return Err(ProtocolError::ConsensusError(Box::new(first_error)));
+        }
 
         tracing::debug!("try_from_inputs_with_signer: Successfully created transition");
         Ok(address_funds_transition.into())

--- a/packages/rs-dpp/src/state_transition/state_transitions/identity/identity_create_from_addresses_transition/v0/v0_methods.rs
+++ b/packages/rs-dpp/src/state_transition/state_transitions/identity/identity_create_from_addresses_transition/v0/v0_methods.rs
@@ -20,6 +20,8 @@ use crate::state_transition::StateTransitionType;
 // Crate: Feature-Gated (state-transition-signing)
 // ============================
 #[cfg(feature = "state-transition-signing")]
+use crate::state_transition::StateTransitionStructureValidation;
+#[cfg(feature = "state-transition-signing")]
 use crate::{
     address_funds::AddressFundsFeeStrategy,
     identity::{
@@ -46,7 +48,7 @@ impl IdentityCreateFromAddressesTransitionMethodsV0 for IdentityCreateFromAddres
         identity_public_key_signer: &S,
         address_signer: &WS,
         user_fee_increase: UserFeeIncrease,
-        _platform_version: &PlatformVersion,
+        platform_version: &PlatformVersion,
     ) -> Result<StateTransition, ProtocolError> {
         // Create the unsigned transition
         let mut identity_create_from_addresses_transition =
@@ -89,6 +91,14 @@ impl IdentityCreateFromAddressesTransitionMethodsV0 for IdentityCreateFromAddres
             .keys()
             .map(|address| address_signer.sign_create_witness(address, &signable_bytes))
             .collect::<Result<Vec<_>, ProtocolError>>()?;
+
+        // Validate the fully-constructed transition structure
+        let validation_result =
+            identity_create_from_addresses_transition.validate_structure(platform_version);
+        if !validation_result.is_valid() {
+            let first_error = validation_result.errors.into_iter().next().unwrap();
+            return Err(ProtocolError::ConsensusError(Box::new(first_error)));
+        }
 
         Ok(identity_create_from_addresses_transition.into())
     }

--- a/packages/rs-dpp/src/state_transition/state_transitions/identity/identity_credit_transfer_to_addresses_transition/v0/v0_methods.rs
+++ b/packages/rs-dpp/src/state_transition/state_transitions/identity/identity_credit_transfer_to_addresses_transition/v0/v0_methods.rs
@@ -6,6 +6,8 @@ use crate::address_funds::PlatformAddress;
 #[cfg(feature = "state-transition-signing")]
 use crate::fee::Credits;
 #[cfg(feature = "state-transition-signing")]
+use crate::state_transition::StateTransitionStructureValidation;
+#[cfg(feature = "state-transition-signing")]
 use crate::{
     identity::{
         accessors::IdentityGettersV0,
@@ -35,22 +37,31 @@ impl IdentityCreditTransferToAddressesTransitionMethodsV0
         signer: &S,
         signing_withdrawal_key_to_use: Option<&IdentityPublicKey>,
         nonce: IdentityNonce,
-        _platform_version: &PlatformVersion,
+        platform_version: &PlatformVersion,
         _version: Option<FeatureVersion>,
     ) -> Result<StateTransition, ProtocolError> {
         tracing::debug!("try_from_identity: Started");
         tracing::debug!(identity_id = %identity.id(), "try_from_identity");
         tracing::debug!(recipient_addresses = ?to_recipient_addresses, has_signing_key = signing_withdrawal_key_to_use.is_some(), "try_from_identity inputs");
 
-        let mut transition: StateTransition = IdentityCreditTransferToAddressesTransitionV0 {
+        let transition_v0 = IdentityCreditTransferToAddressesTransitionV0 {
             identity_id: identity.id(),
             recipient_addresses: to_recipient_addresses,
             nonce,
             user_fee_increase,
             signature_public_key_id: 0,
             signature: Default::default(),
+        };
+
+        // Validate structure before .into() conversion and signing, since this transition
+        // uses sign_external on the StateTransition rather than setting witnesses on the V0 struct.
+        let validation_result = transition_v0.validate_structure(platform_version);
+        if !validation_result.is_valid() {
+            let first_error = validation_result.errors.into_iter().next().unwrap();
+            return Err(ProtocolError::ConsensusError(Box::new(first_error)));
         }
-        .into();
+
+        let mut transition: StateTransition = transition_v0.into();
 
         let identity_public_key = match signing_withdrawal_key_to_use {
             Some(key) => {

--- a/packages/rs-dpp/src/state_transition/state_transitions/identity/identity_topup_from_addresses_transition/v0/v0_methods.rs
+++ b/packages/rs-dpp/src/state_transition/state_transitions/identity/identity_topup_from_addresses_transition/v0/v0_methods.rs
@@ -19,6 +19,7 @@ use {
         prelude::{AddressNonce, UserFeeIncrease},
         serialization::Signable,
         state_transition::StateTransition,
+        state_transition::StateTransitionStructureValidation,
         version::FeatureVersion,
         ProtocolError,
     },
@@ -33,7 +34,7 @@ impl IdentityTopUpFromAddressesTransitionMethodsV0 for IdentityTopUpFromAddresse
         inputs: BTreeMap<PlatformAddress, (AddressNonce, Credits)>,
         signer: &S,
         user_fee_increase: UserFeeIncrease,
-        _platform_version: &PlatformVersion,
+        platform_version: &PlatformVersion,
         _version: Option<FeatureVersion>,
     ) -> Result<StateTransition, ProtocolError> {
         let mut identity_top_up_from_addresses_transition =
@@ -57,6 +58,14 @@ impl IdentityTopUpFromAddressesTransitionMethodsV0 for IdentityTopUpFromAddresse
             .keys()
             .map(|address| signer.sign_create_witness(address, &signable_bytes))
             .collect::<Result<Vec<AddressWitness>, ProtocolError>>()?;
+
+        // Validate the fully-constructed transition structure
+        let validation_result =
+            identity_top_up_from_addresses_transition.validate_structure(platform_version);
+        if !validation_result.is_valid() {
+            let first_error = validation_result.errors.into_iter().next().unwrap();
+            return Err(ProtocolError::ConsensusError(Box::new(first_error)));
+        }
 
         Ok(identity_top_up_from_addresses_transition.into())
     }


### PR DESCRIPTION
## Issue Being Fixed
Follow-up to #3096 per [shumkov's review comment](https://github.com/dashpay/platform/pull/3096#discussion_r2821999590): add client-side structure validation to the remaining state transitions for consistent SDK behavior.

## What Was Done

Added `validate_structure()` calls to 6 state transition SDK construction methods, following the same pattern established in #3096. This ensures invalid transitions are caught early on the client side before being submitted to the network.

### State transitions updated:

| State Transition | Construction Method | Validation Placement |
|---|---|---|
| `AddressCreditWithdrawalTransition` | `try_from_inputs_with_signer` | After `input_witnesses` set |
| `AddressFundingFromAssetLockTransition` | `try_from_asset_lock_with_signer` | After signature + `input_witnesses` set |
| `AddressFundsTransferTransition` | `try_from_inputs_with_signer` | After `input_witnesses` set |
| `IdentityCreateFromAddressesTransition` | `try_from_inputs_with_signer` | After public key sigs + `input_witnesses` set |
| `IdentityCreditTransferToAddressesTransition` | `try_from_identity` | Before `.into()` conversion |
| `IdentityTopUpFromAddressesTransition` | `try_from_inputs_with_signer` | After `input_witnesses` set |

### Pattern used (same as #3096):
```rust
let validation_result = transition.validate_structure(platform_version);
if !validation_result.is_valid() {
    let first_error = validation_result.errors.into_iter().next().unwrap();
    return Err(ProtocolError::ConsensusError(Box::new(first_error)));
}
```

### Notes:
- For address-based transitions with `input_witnesses`, validation is called **after** witnesses are populated (since `validate_structure()` checks `inputs.len() == input_witnesses.len()`)
- For `IdentityCreditTransferToAddressesTransition`, the V0 struct is validated **before** the `.into()` conversion since it doesn't have witnesses
- `IdentityCreateFromAddressesTransition` already had public key validation from #3096; this adds the full structure validation on top

<details>
<summary>Build output</summary>

`cargo check -p dpp --features state-transition-signing,state-transition-validation` — zero errors, zero warnings.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added structural validation for multiple transaction types (address credit withdrawals, address funding, address transfers, and identity operations) to ensure data integrity and catch errors earlier in the processing pipeline.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->