### PR TITLE
fix(dpp): add missing #[test] attribute to should_set_empty_schema_defs

### DIFF
--- a/packages/rs-dpp/src/data_contract/v0/methods/schema.rs
+++ b/packages/rs-dpp/src/data_contract/v0/methods/schema.rs
@@ -209,6 +209,11 @@ mod test {
             .set_schema_defs(None, true, &mut vec![], platform_version)
             .expect("should set defs");
 
-        assert_eq!(None, data_contract.schema_defs())
+        assert_eq!(None, data_contract.schema_defs());
+        assert_eq!(
+            1,
+            data_contract.document_types().len(),
+            "document types should be preserved after clearing schema defs"
+        );
     }
 }

--- a/packages/rs-dpp/src/data_contract/v0/methods/schema.rs
+++ b/packages/rs-dpp/src/data_contract/v0/methods/schema.rs
@@ -161,6 +161,7 @@ mod test {
         assert_eq!(defs_map.as_ref(), data_contract.schema_defs())
     }
 
+    #[test]
     fn should_set_empty_schema_defs() {
         let platform_version = PlatformVersion::latest();
 
@@ -175,13 +176,25 @@ mod test {
 
         let defs_map = Some(defs.into_btree_string_map().expect("should convert to map"));
 
+        let schema = platform_value!({
+            "type": "object",
+            "properties": {
+                "a": {
+                    "type": "string",
+                    "maxLength": 10,
+                    "position": 0
+                }
+            },
+            "additionalProperties": false,
+        });
+
         let serialization_format = DataContractInSerializationFormatV0 {
             id: Identifier::random(),
             config,
             version: 0,
             owner_id: Default::default(),
             schema_defs: defs_map,
-            document_schemas: Default::default(),
+            document_schemas: BTreeMap::from([("document_type_name".to_string(), schema)]),
         };
 
         let mut data_contract = DataContractV0::try_from_platform_versioned(

--- a/packages/rs-dpp/src/data_contract/v1/methods/schema.rs
+++ b/packages/rs-dpp/src/data_contract/v1/methods/schema.rs
@@ -209,6 +209,11 @@ mod test {
             .set_schema_defs(None, true, &mut vec![], platform_version)
             .expect("should set defs");
 
-        assert_eq!(None, data_contract.schema_defs())
+        assert_eq!(None, data_contract.schema_defs());
+        assert_eq!(
+            1,
+            data_contract.document_types().len(),
+            "document types should be preserved after clearing schema defs"
+        );
     }
 }

--- a/packages/rs-dpp/src/data_contract/v1/methods/schema.rs
+++ b/packages/rs-dpp/src/data_contract/v1/methods/schema.rs
@@ -161,6 +161,7 @@ mod test {
         assert_eq!(defs_map.as_ref(), data_contract.schema_defs())
     }
 
+    #[test]
     fn should_set_empty_schema_defs() {
         let platform_version = PlatformVersion::latest();
 
@@ -175,13 +176,25 @@ mod test {
 
         let defs_map = Some(defs.into_btree_string_map().expect("should convert to map"));
 
+        let schema = platform_value!({
+            "type": "object",
+            "properties": {
+                "a": {
+                    "type": "string",
+                    "maxLength": 10,
+                    "position": 0
+                }
+            },
+            "additionalProperties": false,
+        });
+
         let serialization_format = DataContractInSerializationFormatV0 {
             id: Identifier::random(),
             config,
             version: 0,
             owner_id: Default::default(),
             schema_defs: defs_map,
-            document_schemas: Default::default(),
+            document_schemas: BTreeMap::from([("document_type_name".to_string(), schema)]),
         };
 
         let mut data_contract = DataContractV1::try_from_platform_versioned(


### PR DESCRIPTION
## Problem

`should_set_empty_schema_defs()` exists in both v0 and v1 DataContract schema test modules inside `#[cfg(test)] mod tests`, but was shipped without the `#[test]` attribute. The test runner silently skips these functions — they compile but never execute.

Introduced in #3077 (`d6f4eb9`, @shumkov) — the function was added to the test module but the `#[test]` attribute was never included. The test was DOA from day one. 🍝

Additionally, the test body used `document_schemas: Default::default()` (empty `BTreeMap`), which now fails validation with `DocumentTypesAreMissingError`. Fixed by adding a minimal document schema matching the pattern from the adjacent `should_set_a_new_schema_defs` test.

## Fix

1. Add `#[test]` attribute to both v0 and v1 versions
2. Add a dummy document schema so contract creation doesn't fail validation
3. Both tests now pass: `cargo test -p dpp --lib -- should_set_empty_schema_defs`

## Files changed
2 files — `packages/rs-dpp/src/data_contract/{v0,v1}/methods/schema.rs`

Found during SDK test quality audit (tracker thepastaclaw/tracker#12).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test coverage for data contract schema operations to validate behavior when clearing schema definitions and handling empty schema states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->