### PR TITLE
chore: let claude auto-detect base branch in pr-description skill

### DIFF
--- a/.claude/skills/pr-description/SKILL.md
+++ b/.claude/skills/pr-description/SKILL.md
@@ -11,8 +11,9 @@ Generate a pull request title and description for the current branch using the p
 ## Steps
 
 1. Determine the base branch:
-   - Use the argument if provided, otherwise default to `v2.1-dev`
-   - Verify with `git branch -r` if unsure
+   - Use the argument if provided
+   - Otherwise, auto-detect: `git remote set-head origin --auto >/dev/null 2>&1 && git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's|refs/remotes/||'`
+   - Fall back to `v3.1-dev` if the command above fails
 
 2. Gather context by running these git commands:
    - `git log --oneline $(git merge-base HEAD <base>)..HEAD` — all commits on this branch


### PR DESCRIPTION
## Issue being fixed or feature implemented

The `pr-description` Claude Code skill had the base branch hardcoded to `v2.1-dev`, which is outdated. This caused incorrect diff comparisons when generating PR descriptions.

## What was done?

- Replaced the hardcoded `v2.1-dev` default with auto-detection via `git symbolic-ref refs/remotes/origin/HEAD`
- Added a fallback to `v3.1-dev` if auto-detection fails
- The skill still accepts an explicit argument to override both

## How Has This Been Tested?

Manual verification — the skill correctly resolves the base branch on the current repository.

## Breaking Changes

None

## Checklist:
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [ ] I have made corresponding changes to the documentation if needed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced base branch auto-detection mechanism with improved fallback strategy
  * Updated default version handling for more intelligent branch selection

<!-- end of auto-generated comment: release notes by coderabbit.ai -->