### PR TITLE
test(dpp): add validate_structure error path tests for withdrawal and transfer transitions

### DIFF
--- a/packages/rs-dpp/src/state_transition/state_transitions/address_funds/address_credit_withdrawal_transition/v0/state_transition_validation.rs
+++ b/packages/rs-dpp/src/state_transition/state_transitions/address_funds/address_credit_withdrawal_transition/v0/state_transition_validation.rs
@@ -254,6 +254,286 @@ mod tests {
     use rand::SeedableRng;
     use std::collections::BTreeMap;
 
+    fn valid_withdrawal_transition() -> AddressCreditWithdrawalTransitionV0 {
+        use rand::SeedableRng;
+
+        let input_amount = 1_000_000_000u64;
+        AddressCreditWithdrawalTransitionV0 {
+            inputs: [(PlatformAddress::P2pkh([1u8; 20]), (0, input_amount))].into(),
+            input_witnesses: vec![AddressWitness::P2pkh {
+                signature: vec![0u8; 65].into(),
+            }],
+            fee_strategy: vec![AddressFundsFeeStrategyStep::DeductFromInput(0)],
+            core_fee_per_byte: 1,
+            output_script: CoreScript::random_p2pkh(&mut rand::rngs::StdRng::seed_from_u64(42)),
+            pooling: Pooling::Never,
+            output: None,
+            user_fee_increase: 0,
+        }
+    }
+
+    fn p2pkh_address(index: usize) -> PlatformAddress {
+        let mut bytes = [0u8; 20];
+        bytes[0] = (index & 0xff) as u8;
+        bytes[1] = ((index >> 8) & 0xff) as u8;
+        bytes[2] = ((index >> 16) & 0xff) as u8;
+        bytes[3] = ((index >> 24) & 0xff) as u8;
+        PlatformAddress::P2pkh(bytes)
+    }
+
+    fn make_inputs_and_witnesses(
+        count: usize,
+        amount: u64,
+    ) -> (BTreeMap<PlatformAddress, (u32, u64)>, Vec<AddressWitness>) {
+        let inputs = (0..count)
+            .map(|i| (p2pkh_address(i), (i as u32, amount)))
+            .collect();
+        let witnesses = (0..count)
+            .map(|_| AddressWitness::P2pkh {
+                signature: vec![0u8; 65].into(),
+            })
+            .collect();
+        (inputs, witnesses)
+    }
+
+    #[test]
+    fn should_return_invalid_result_if_no_inputs() {
+        let platform_version = PlatformVersion::latest();
+
+        let mut transition = valid_withdrawal_transition();
+        transition.inputs = BTreeMap::new();
+        transition.input_witnesses = vec![];
+
+        let result = transition.validate_structure(platform_version);
+
+        assert_matches!(
+            result.errors.as_slice(),
+            [crate::consensus::ConsensusError::BasicError(BasicError::TransitionNoInputsError(_))]
+        );
+    }
+
+    #[test]
+    fn should_return_invalid_result_if_over_max_inputs() {
+        let platform_version = PlatformVersion::latest();
+        let max_inputs = platform_version.dpp.state_transitions.max_address_inputs as usize;
+
+        let mut transition = valid_withdrawal_transition();
+        let (inputs, witnesses) = make_inputs_and_witnesses(max_inputs + 1, 1_000_000_000);
+        transition.inputs = inputs;
+        transition.input_witnesses = witnesses;
+
+        let result = transition.validate_structure(platform_version);
+
+        assert_matches!(
+            result.errors.as_slice(),
+            [crate::consensus::ConsensusError::BasicError(
+                BasicError::TransitionOverMaxInputsError(_)
+            )]
+        );
+    }
+
+    #[test]
+    fn should_return_invalid_result_if_witness_count_mismatch() {
+        let platform_version = PlatformVersion::latest();
+
+        let mut transition = valid_withdrawal_transition();
+        transition.input_witnesses.push(AddressWitness::P2pkh {
+            signature: vec![0u8; 65].into(),
+        });
+
+        let result = transition.validate_structure(platform_version);
+
+        assert_matches!(
+            result.errors.as_slice(),
+            [crate::consensus::ConsensusError::BasicError(
+                BasicError::InputWitnessCountMismatchError(_)
+            )]
+        );
+    }
+
+    #[test]
+    fn should_return_invalid_result_if_output_address_also_input() {
+        let platform_version = PlatformVersion::latest();
+
+        let mut transition = valid_withdrawal_transition();
+        let input_address = transition
+            .inputs
+            .keys()
+            .next()
+            .expect("valid transition has one input")
+            .clone();
+        transition.output = Some((input_address, 1000));
+
+        let result = transition.validate_structure(platform_version);
+
+        assert_matches!(
+            result.errors.as_slice(),
+            [crate::consensus::ConsensusError::BasicError(
+                BasicError::OutputAddressAlsoInputError(_)
+            )]
+        );
+    }
+
+    #[test]
+    fn should_return_invalid_result_if_fee_strategy_empty() {
+        let platform_version = PlatformVersion::latest();
+
+        let mut transition = valid_withdrawal_transition();
+        transition.fee_strategy = vec![];
+
+        let result = transition.validate_structure(platform_version);
+
+        assert_matches!(
+            result.errors.as_slice(),
+            [crate::consensus::ConsensusError::BasicError(BasicError::FeeStrategyEmptyError(_))]
+        );
+    }
+
+    #[test]
+    fn should_return_invalid_result_if_fee_strategy_too_many_steps() {
+        let platform_version = PlatformVersion::latest();
+        let max_fee_strategies = platform_version
+            .dpp
+            .state_transitions
+            .max_address_fee_strategies as usize;
+        let step_count = max_fee_strategies + 1;
+
+        let mut transition = valid_withdrawal_transition();
+        let (inputs, witnesses) = make_inputs_and_witnesses(step_count, 1_000_000_000);
+        transition.inputs = inputs;
+        transition.input_witnesses = witnesses;
+        transition.fee_strategy = (0..step_count)
+            .map(|i| AddressFundsFeeStrategyStep::DeductFromInput(i as u16))
+            .collect();
+
+        let result = transition.validate_structure(platform_version);
+
+        assert_matches!(
+            result.errors.as_slice(),
+            [crate::consensus::ConsensusError::BasicError(
+                BasicError::FeeStrategyTooManyStepsError(_)
+            )]
+        );
+    }
+
+    #[test]
+    fn should_return_invalid_result_if_fee_strategy_duplicate() {
+        let platform_version = PlatformVersion::latest();
+
+        let mut transition = valid_withdrawal_transition();
+        transition.fee_strategy = vec![
+            AddressFundsFeeStrategyStep::DeductFromInput(0),
+            AddressFundsFeeStrategyStep::DeductFromInput(0),
+        ];
+
+        let result = transition.validate_structure(platform_version);
+
+        assert_matches!(
+            result.errors.as_slice(),
+            [crate::consensus::ConsensusError::BasicError(
+                BasicError::FeeStrategyDuplicateError(_)
+            )]
+        );
+    }
+
+    #[test]
+    fn should_return_invalid_result_if_fee_strategy_index_out_of_bounds() {
+        let platform_version = PlatformVersion::latest();
+
+        let mut transition = valid_withdrawal_transition();
+        transition.fee_strategy = vec![AddressFundsFeeStrategyStep::DeductFromInput(999)];
+
+        let result = transition.validate_structure(platform_version);
+
+        assert_matches!(
+            result.errors.as_slice(),
+            [crate::consensus::ConsensusError::BasicError(
+                BasicError::FeeStrategyIndexOutOfBoundsError(_)
+            )]
+        );
+    }
+
+    #[test]
+    fn should_return_invalid_result_if_input_below_minimum() {
+        let platform_version = PlatformVersion::latest();
+
+        let mut transition = valid_withdrawal_transition();
+        transition.inputs = [(PlatformAddress::P2pkh([1u8; 20]), (0, 1))].into();
+
+        let result = transition.validate_structure(platform_version);
+
+        assert_matches!(
+            result.errors.as_slice(),
+            [crate::consensus::ConsensusError::BasicError(BasicError::InputBelowMinimumError(_))]
+        );
+    }
+
+    #[test]
+    fn should_return_invalid_result_if_output_below_minimum() {
+        let platform_version = PlatformVersion::latest();
+
+        let mut transition = valid_withdrawal_transition();
+        transition.output = Some((PlatformAddress::P2pkh([2u8; 20]), 1));
+
+        let result = transition.validate_structure(platform_version);
+
+        assert_matches!(
+            result.errors.as_slice(),
+            [crate::consensus::ConsensusError::BasicError(BasicError::OutputBelowMinimumError(_))]
+        );
+    }
+
+    #[test]
+    fn should_return_invalid_result_if_pooling_not_never() {
+        let platform_version = PlatformVersion::latest();
+
+        let mut transition = valid_withdrawal_transition();
+        transition.pooling = Pooling::IfAvailable;
+
+        let result = transition.validate_structure(platform_version);
+
+        assert_matches!(
+            result.errors.as_slice(),
+            [crate::consensus::ConsensusError::BasicError(
+                BasicError::NotImplementedCreditWithdrawalTransitionPoolingError(_)
+            )]
+        );
+    }
+
+    #[test]
+    fn should_return_invalid_result_if_core_fee_not_fibonacci() {
+        let platform_version = PlatformVersion::latest();
+
+        let mut transition = valid_withdrawal_transition();
+        transition.core_fee_per_byte = 4;
+
+        let result = transition.validate_structure(platform_version);
+
+        assert_matches!(
+            result.errors.as_slice(),
+            [crate::consensus::ConsensusError::BasicError(
+                BasicError::InvalidCreditWithdrawalTransitionCoreFeeError(_)
+            )]
+        );
+    }
+
+    #[test]
+    fn should_return_invalid_result_if_output_script_invalid() {
+        let platform_version = PlatformVersion::latest();
+
+        let mut transition = valid_withdrawal_transition();
+        transition.output_script = CoreScript::from_bytes(vec![0x51]);
+
+        let result = transition.validate_structure(platform_version);
+
+        assert_matches!(
+            result.errors.as_slice(),
+            [crate::consensus::ConsensusError::BasicError(
+                BasicError::InvalidCreditWithdrawalTransitionOutputScriptError(_)
+            )]
+        );
+    }
+
     #[test]
     fn should_return_invalid_result_if_input_sum_overflows() {
         let platform_version = PlatformVersion::latest();
@@ -286,5 +566,39 @@ mod tests {
                 BasicError::OverflowError(_)
             )]
         );
+    }
+
+    #[test]
+    fn should_return_invalid_result_if_withdrawal_below_min() {
+        let platform_version = PlatformVersion::latest();
+        let min_input_amount = platform_version
+            .dpp
+            .state_transitions
+            .address_funds
+            .min_input_amount;
+        assert!(min_input_amount < MIN_WITHDRAWAL_AMOUNT);
+
+        let mut transition = valid_withdrawal_transition();
+        transition.inputs = [(PlatformAddress::P2pkh([1u8; 20]), (0, min_input_amount))].into();
+        transition.output = None;
+
+        let result = transition.validate_structure(platform_version);
+
+        assert_matches!(
+            result.errors.as_slice(),
+            [crate::consensus::ConsensusError::BasicError(
+                BasicError::WithdrawalBelowMinAmountError(_)
+            )]
+        );
+    }
+
+    #[test]
+    fn should_return_valid_result_for_valid_transition() {
+        let platform_version = PlatformVersion::latest();
+        let transition = valid_withdrawal_transition();
+
+        let result = transition.validate_structure(platform_version);
+
+        assert_matches!(result.errors.as_slice(), []);
     }
 }

--- a/packages/rs-dpp/src/state_transition/state_transitions/address_funds/address_credit_withdrawal_transition/v0/state_transition_validation.rs
+++ b/packages/rs-dpp/src/state_transition/state_transitions/address_funds/address_credit_withdrawal_transition/v0/state_transition_validation.rs
@@ -255,8 +255,6 @@ mod tests {
     use std::collections::BTreeMap;
 
     fn valid_withdrawal_transition() -> AddressCreditWithdrawalTransitionV0 {
-        use rand::SeedableRng;
-
         let input_amount = 1_000_000_000u64;
         AddressCreditWithdrawalTransitionV0 {
             inputs: [(PlatformAddress::P2pkh([1u8; 20]), (0, input_amount))].into(),
@@ -400,6 +398,15 @@ mod tests {
             .dpp
             .state_transitions
             .max_address_fee_strategies as usize;
+        let max_inputs = platform_version.dpp.state_transitions.max_address_inputs as usize;
+        // Invariant: fee-strategy limit must be less than input limit,
+        // otherwise validation order would make this test assert the wrong error.
+        assert!(
+            max_fee_strategies < max_inputs,
+            "max_address_fee_strategies ({}) must be < max_address_inputs ({})",
+            max_fee_strategies,
+            max_inputs
+        );
         let step_count = max_fee_strategies + 1;
 
         let mut transition = valid_withdrawal_transition();
@@ -596,6 +603,24 @@ mod tests {
             result.errors.as_slice(),
             [crate::consensus::ConsensusError::BasicError(
                 BasicError::WithdrawalBelowMinAmountError(_)
+            )]
+        );
+    }
+
+    #[test]
+    fn should_return_invalid_result_if_output_equals_input_sum() {
+        let platform_version = PlatformVersion::latest();
+        let mut transition = valid_withdrawal_transition();
+        // output_amount == input_sum → withdrawal would be zero → balance mismatch
+        let input_amount = transition.inputs.values().next().unwrap().1;
+        transition.output = Some((PlatformAddress::P2pkh([2u8; 20]), input_amount));
+
+        let result = transition.validate_structure(platform_version);
+
+        assert_matches!(
+            result.errors.as_slice(),
+            [crate::consensus::ConsensusError::BasicError(
+                BasicError::WithdrawalBalanceMismatchError(_)
             )]
         );
     }

--- a/packages/rs-dpp/src/state_transition/state_transitions/address_funds/address_credit_withdrawal_transition/v0/state_transition_validation.rs
+++ b/packages/rs-dpp/src/state_transition/state_transitions/address_funds/address_credit_withdrawal_transition/v0/state_transition_validation.rs
@@ -308,7 +308,9 @@ mod tests {
 
         assert_matches!(
             result.errors.as_slice(),
-            [crate::consensus::ConsensusError::BasicError(BasicError::TransitionNoInputsError(_))]
+            [crate::consensus::ConsensusError::BasicError(
+                BasicError::TransitionNoInputsError(_)
+            )]
         );
     }
 
@@ -385,7 +387,9 @@ mod tests {
 
         assert_matches!(
             result.errors.as_slice(),
-            [crate::consensus::ConsensusError::BasicError(BasicError::FeeStrategyEmptyError(_))]
+            [crate::consensus::ConsensusError::BasicError(
+                BasicError::FeeStrategyEmptyError(_)
+            )]
         );
     }
 
@@ -464,7 +468,9 @@ mod tests {
 
         assert_matches!(
             result.errors.as_slice(),
-            [crate::consensus::ConsensusError::BasicError(BasicError::InputBelowMinimumError(_))]
+            [crate::consensus::ConsensusError::BasicError(
+                BasicError::InputBelowMinimumError(_)
+            )]
         );
     }
 
@@ -479,7 +485,9 @@ mod tests {
 
         assert_matches!(
             result.errors.as_slice(),
-            [crate::consensus::ConsensusError::BasicError(BasicError::OutputBelowMinimumError(_))]
+            [crate::consensus::ConsensusError::BasicError(
+                BasicError::OutputBelowMinimumError(_)
+            )]
         );
     }
 

--- a/packages/rs-dpp/src/state_transition/state_transitions/identity/identity_credit_transfer_to_addresses_transition/v0/state_transition_validation.rs
+++ b/packages/rs-dpp/src/state_transition/state_transitions/identity/identity_credit_transfer_to_addresses_transition/v0/state_transition_validation.rs
@@ -135,7 +135,11 @@ mod tests {
     #[test]
     fn should_return_valid_result_for_valid_transition() {
         let platform_version = PlatformVersion::latest();
-        let min_output = platform_version.dpp.state_transitions.address_funds.min_output_amount;
+        let min_output = platform_version
+            .dpp
+            .state_transitions
+            .address_funds
+            .min_output_amount;
         let transition = IdentityCreditTransferToAddressesTransitionV0 {
             recipient_addresses: [(PlatformAddress::P2pkh([1u8; 20]), min_output)].into(),
             ..Default::default()

--- a/packages/rs-dpp/src/state_transition/state_transitions/identity/identity_credit_transfer_to_addresses_transition/v0/state_transition_validation.rs
+++ b/packages/rs-dpp/src/state_transition/state_transitions/identity/identity_credit_transfer_to_addresses_transition/v0/state_transition_validation.rs
@@ -78,6 +78,77 @@ mod tests {
     use std::collections::BTreeMap;
 
     #[test]
+    fn should_return_invalid_result_if_no_recipients() {
+        let platform_version = PlatformVersion::latest();
+        let transition = IdentityCreditTransferToAddressesTransitionV0 {
+            recipient_addresses: BTreeMap::new(),
+            ..Default::default()
+        };
+        let result = transition.validate_structure(platform_version);
+        assert_matches!(
+            result.errors.as_slice(),
+            [crate::consensus::ConsensusError::BasicError(
+                BasicError::TransitionNoOutputsError(_)
+            )]
+        );
+    }
+
+    #[test]
+    fn should_return_invalid_result_if_over_max_recipients() {
+        let platform_version = PlatformVersion::latest();
+        let max = platform_version.dpp.state_transitions.max_address_outputs as usize;
+        let mut recipient_addresses = BTreeMap::new();
+        for i in 0..=max {
+            let mut addr = [0u8; 20];
+            addr[0..2].copy_from_slice(&(i as u16).to_le_bytes());
+            recipient_addresses.insert(PlatformAddress::P2pkh(addr), 1_000_000_000);
+        }
+        let transition = IdentityCreditTransferToAddressesTransitionV0 {
+            recipient_addresses,
+            ..Default::default()
+        };
+        let result = transition.validate_structure(platform_version);
+        assert_matches!(
+            result.errors.as_slice(),
+            [crate::consensus::ConsensusError::BasicError(
+                BasicError::TransitionOverMaxOutputsError(_)
+            )]
+        );
+    }
+
+    #[test]
+    fn should_return_invalid_result_if_amount_below_minimum() {
+        let platform_version = PlatformVersion::latest();
+        let transition = IdentityCreditTransferToAddressesTransitionV0 {
+            recipient_addresses: [(PlatformAddress::P2pkh([1u8; 20]), 1)].into(),
+            ..Default::default()
+        };
+        let result = transition.validate_structure(platform_version);
+        assert_matches!(
+            result.errors.as_slice(),
+            [crate::consensus::ConsensusError::BasicError(
+                BasicError::OutputBelowMinimumError(_)
+            )]
+        );
+    }
+
+    #[test]
+    fn should_return_valid_result_for_valid_transition() {
+        let platform_version = PlatformVersion::latest();
+        let min_output = platform_version.dpp.state_transitions.address_funds.min_output_amount;
+        let transition = IdentityCreditTransferToAddressesTransitionV0 {
+            recipient_addresses: [(PlatformAddress::P2pkh([1u8; 20]), min_output)].into(),
+            ..Default::default()
+        };
+        let result = transition.validate_structure(platform_version);
+        assert!(
+            result.errors.is_empty(),
+            "expected valid result, got: {:?}",
+            result.errors
+        );
+    }
+
+    #[test]
     fn should_return_invalid_result_if_recipient_sum_overflows() {
         let platform_version = PlatformVersion::latest();
 

--- a/packages/rs-dpp/src/state_transition/state_transitions/identity/identity_credit_transfer_to_addresses_transition/v0/state_transition_validation.rs
+++ b/packages/rs-dpp/src/state_transition/state_transitions/identity/identity_credit_transfer_to_addresses_transition/v0/state_transition_validation.rs
@@ -100,7 +100,7 @@ mod tests {
         let mut recipient_addresses = BTreeMap::new();
         for i in 0..=max {
             let mut addr = [0u8; 20];
-            addr[0..2].copy_from_slice(&(i as u16).to_le_bytes());
+            addr[0..4].copy_from_slice(&(i as u32).to_le_bytes());
             recipient_addresses.insert(PlatformAddress::P2pkh(addr), 1_000_000_000);
         }
         let transition = IdentityCreditTransferToAddressesTransitionV0 {
@@ -145,11 +145,7 @@ mod tests {
             ..Default::default()
         };
         let result = transition.validate_structure(platform_version);
-        assert!(
-            result.errors.is_empty(),
-            "expected valid result, got: {:?}",
-            result.errors
-        );
+        assert_matches!(result.errors.as_slice(), []);
     }
 
     #[test]


### PR DESCRIPTION
## Issue Being Fixed

Tracker: thepastaclaw/tracker#14 (parent: #11)

Addresses findings I-03 and I-04 from the rs-dpp test quality audit.

## What was done

Added missing validation error path tests for two state transition `validate_structure` methods.

### I-04: `IdentityCreditTransferToAddressesTransitionV0::validate_structure` — 1 test → 5 tests
- `should_return_invalid_result_if_no_recipients` — empty recipient map → `TransitionNoOutputsError`
- `should_return_invalid_result_if_over_max_recipients` — max+1 recipients → `TransitionOverMaxOutputsError`
- `should_return_invalid_result_if_amount_below_minimum` — amount=1 → `OutputBelowMinimumError`
- `should_return_valid_result_for_valid_transition` — happy path with min_output_amount
- (existing) `should_return_invalid_result_if_recipient_sum_overflows`

### I-03: `AddressCreditWithdrawalTransitionV0::validate_structure` — 1 test → 16 tests
Added a `valid_withdrawal_transition()` baseline helper, then one-mutation-per-test:
- `should_return_invalid_result_if_no_inputs` → `TransitionNoInputsError`
- `should_return_invalid_result_if_over_max_inputs` → `TransitionOverMaxInputsError`
- `should_return_invalid_result_if_witness_count_mismatch` → `InputWitnessCountMismatchError`
- `should_return_invalid_result_if_output_address_also_input` → `OutputAddressAlsoInputError`
- `should_return_invalid_result_if_fee_strategy_empty` → `FeeStrategyEmptyError`
- `should_return_invalid_result_if_fee_strategy_too_many_steps` → `FeeStrategyTooManyStepsError`
- `should_return_invalid_result_if_fee_strategy_duplicate` → `FeeStrategyDuplicateError`
- `should_return_invalid_result_if_fee_strategy_index_out_of_bounds` → `FeeStrategyIndexOutOfBoundsError`
- `should_return_invalid_result_if_input_below_minimum` → `InputBelowMinimumError`
- `should_return_invalid_result_if_output_below_minimum` → `OutputBelowMinimumError`
- `should_return_invalid_result_if_pooling_not_never` → `NotImplementedCreditWithdrawalTransitionPoolingError`
- `should_return_invalid_result_if_core_fee_not_fibonacci` → `InvalidCreditWithdrawalTransitionCoreFeeError`
- `should_return_invalid_result_if_output_script_invalid` → `InvalidCreditWithdrawalTransitionOutputScriptError`
- `should_return_invalid_result_if_withdrawal_below_min` → `WithdrawalBelowMinAmountError`
- `should_return_valid_result_for_valid_transition` — happy path
- (existing) `should_return_invalid_result_if_input_sum_overflows`

All tests compile and pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded test suite for address credit withdrawal transition validation with comprehensive edge case coverage.
  * Added validation tests for identity credit transfer transitions covering recipient limits and amount constraints.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Validation

1. **What was tested**
   - `cargo test -p dpp --lib`

2. **Results**
   - Added transition-structure error-path tests compile and pass in the dpp test suite.

3. **Environment**
   - Local development environment for `dashpay/platform` (Rust unit tests)
