### PR TITLE
feat(swift-sdk): send transaction

### DIFF
--- a/packages/swift-sdk/Sources/SwiftDashSDK/Core/Wallet/CoreWalletManager.swift
+++ b/packages/swift-sdk/Sources/SwiftDashSDK/Core/Wallet/CoreWalletManager.swift
@@ -304,6 +304,15 @@ public class CoreWalletManager: ObservableObject {
 
     // MARK: - Account Management
 
+    /// Build a signed transaction
+    /// - Parameters:
+    ///   - accountIndex: The account index to use
+    ///   - outputs: The transaction outputs
+    /// - Returns: The signed transaction bytes
+    public func buildSignedTransaction(for wallet: HDWallet, accIndex: UInt32, outputs: [Transaction.Output]) throws -> (Data, UInt64) {
+        try sdkWalletManager.buildSignedTransaction(for: wallet, accIndex: accIndex, outputs: outputs)
+    }
+
     /// Get transactions for a wallet
     /// - Parameters:
     ///   - wallet: The wallet to get transactions for

--- a/packages/swift-sdk/Sources/SwiftDashSDK/KeyWallet/Transaction.swift
+++ b/packages/swift-sdk/Sources/SwiftDashSDK/KeyWallet/Transaction.swift
@@ -1,14 +1,6 @@
 import Foundation
 import DashSDKFFI
 
-/// Result of building and signing a transaction
-public struct BuildAndSignResult: Sendable {
-    /// The signed transaction bytes
-    public let transactionData: Data
-    /// The fee paid in duffs
-    public let fee: UInt64
-}
-
 /// Transaction utilities for wallet operations
 public class Transaction {
 
@@ -23,9 +15,11 @@ public class Transaction {
         }
 
         func toFFI() -> FFITxOutput {
-            return address.withCString { addressCStr in
-                FFITxOutput(address: addressCStr, amount: amount)
-            }
+            // TODO: This memory is not being freed, FFI must free FFITxOutput
+            // or expose a method to do it
+            let cString = strdup(address)
+
+            return FFITxOutput(address: cString, amount: amount)
         }
     }
 

--- a/packages/swift-sdk/Sources/SwiftDashSDK/KeyWallet/Wallet.swift
+++ b/packages/swift-sdk/Sources/SwiftDashSDK/KeyWallet/Wallet.swift
@@ -406,7 +406,7 @@ public class Wallet {
 
         return count
     }
-    
+
     // MARK: - Key Derivation
 
     /// Get the extended public key for an account

--- a/packages/swift-sdk/Sources/SwiftDashSDK/KeyWallet/WalletManager.swift
+++ b/packages/swift-sdk/Sources/SwiftDashSDK/KeyWallet/WalletManager.swift
@@ -387,6 +387,64 @@ public class WalletManager {
         return success
     }
 
+    /// Build a signed transaction
+    /// - Parameters:
+    ///   - accIndex: The account index to use
+    ///   - outputs: The transaction outputs
+    /// - Returns: The signed transaction bytes and the fee
+    public func buildSignedTransaction(for wallet: HDWallet, accIndex: UInt32, outputs: [Transaction.Output]) throws -> (Data, UInt64) {
+        guard !outputs.isEmpty else {
+            throw KeyWalletError.invalidInput("Transaction must have at least one output")
+        }
+
+        var error = FFIError()
+        var txBytesPtr: UnsafeMutablePointer<UInt8>?
+        var txLen: size_t = 0
+
+        var fee: UInt64 = 0
+
+        guard let wallet = try self.getWallet(id: wallet.walletId) else {
+            throw KeyWalletError.walletError("Wallet not found in manager")
+        }
+
+        let ffiOutputs = outputs.map { $0.toFFI() }
+
+        let success = ffiOutputs.withUnsafeBufferPointer { outputsPtr in
+            wallet_build_and_sign_transaction(
+                self.handle,
+                wallet.ffiHandle,
+                accIndex,
+                outputsPtr.baseAddress,
+                outputs.count,
+                1000,
+                &fee,
+                &txBytesPtr,
+                &txLen,
+                &error)
+        }
+
+        defer {
+            if error.message != nil {
+                error_message_free(error.message)
+            }
+            for _ in ffiOutputs {
+              // TODO: Memory leak, FFI doesnt expose a way to free the address
+            }
+            if let ptr = txBytesPtr {
+                transaction_bytes_free(ptr)
+            }
+        }
+
+        guard success, let ptr = txBytesPtr else {
+            throw KeyWalletError(ffiError: error)
+        }
+
+        // Copy the transaction data before freeing
+        let txData = Data(bytes: ptr, count: txLen)
+
+        return (txData, fee)
+    }
+
     // MARK: - Block Height Management
 
     /// Get the current block height for a network

--- a/packages/swift-sdk/SwiftExampleApp/SwiftExampleApp/Core/ViewModels/SendViewModel.swift
+++ b/packages/swift-sdk/SwiftExampleApp/SwiftExampleApp/Core/ViewModels/SendViewModel.swift
@@ -270,8 +270,20 @@ class SendViewModel: ObservableObject {
                 successMessage = "Transfer to Platform complete"
 
             case .coreToCore:
-                // TODO: Implement standard Core → Core transaction
-                error = "Core to Core transfer not yet implemented"
+                let outputs = [
+                    Transaction.Output(address: recipientAddress, amount: amount)
+                ]
+
+                // TODO: The model is using hardoced estimated fees
+                let (tx, _) = try walletService.walletManager
+                    .buildSignedTransaction(
+                        for: wallet,
+                        accIndex: 0,
+                        outputs: outputs
+                    )
+
+                try walletService.broadcastTransaction(tx)
+                successMessage = "Transfer to Core complete"
             }
 
             // Refresh shielded balance

--- a/packages/swift-sdk/SwiftExampleApp/SwiftExampleApp/Core/Views/CreateWalletView.swift
+++ b/packages/swift-sdk/SwiftExampleApp/SwiftExampleApp/Core/Views/CreateWalletView.swift
@@ -285,7 +285,7 @@ struct CreateWalletView: View {
         Task {
             do {
                 print("=== STARTING WALLET CREATION ===")
-                
+
                 let mnemonic = (showImportOption ? importMnemonic : mnemonic)
                 print("PIN length: \(walletPin.count)")
                 print("Import option enabled: \(showImportOption)")


### PR DESCRIPTION
This PR adds the required logic to the swift-sdk to be able to send transactions from core to core

Note: If you restart the SPVCklient you can see the transaction as pending, if not, you have to wait for it to get mined to see it. This isnt the expected behaviour, I am already talking with Kevin trying to know what it happening 

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [x] I have made corresponding changes to the documentation if needed

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Wallets can broadcast transactions and build/sign transactions with selectable fee rates (Economy, Normal, Priority).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->