### PR TITLE
fix(sdk): propagate PutSettings in token freeze/mint/unfreeze/set_price transitions

### DIFF
--- a/packages/rs-sdk/src/platform/tokens/transitions/freeze.rs
+++ b/packages/rs-sdk/src/platform/tokens/transitions/freeze.rs
@@ -63,12 +63,14 @@ impl Sdk {
     ) -> Result<FreezeResult, Error> {
         let platform_version = self.version();
 
+        let put_settings = freeze_tokens_transition_builder.settings;
+
         let state_transition = freeze_tokens_transition_builder
             .sign(self, signing_key, signer, platform_version)
             .await?;
 
         let proof_result = state_transition
-            .broadcast_and_wait::<StateTransitionProofResult>(self, None)
+            .broadcast_and_wait::<StateTransitionProofResult>(self, put_settings)
             .await?;
 
         match proof_result {

--- a/packages/rs-sdk/src/platform/tokens/transitions/mint.rs
+++ b/packages/rs-sdk/src/platform/tokens/transitions/mint.rs
@@ -63,12 +63,14 @@ impl Sdk {
     ) -> Result<MintResult, Error> {
         let platform_version = self.version();
 
+        let put_settings = mint_tokens_transition_builder.settings;
+
         let state_transition = mint_tokens_transition_builder
             .sign(self, signing_key, signer, platform_version)
             .await?;
 
         let proof_result = state_transition
-            .broadcast_and_wait::<StateTransitionProofResult>(self, None)
+            .broadcast_and_wait::<StateTransitionProofResult>(self, put_settings)
             .await?;
 
         match proof_result {

--- a/packages/rs-sdk/src/platform/tokens/transitions/set_price_for_direct_purchase.rs
+++ b/packages/rs-sdk/src/platform/tokens/transitions/set_price_for_direct_purchase.rs
@@ -68,12 +68,14 @@ impl Sdk {
     ) -> Result<SetPriceResult, Error> {
         let platform_version = self.version();
 
+        let put_settings = set_price_transition_builder.settings;
+
         let state_transition = set_price_transition_builder
             .sign(self, signing_key, signer, platform_version)
             .await?;
 
         let proof_result = state_transition
-            .broadcast_and_wait::<StateTransitionProofResult>(self, None)
+            .broadcast_and_wait::<StateTransitionProofResult>(self, put_settings)
             .await?;
 
         match proof_result {

--- a/packages/rs-sdk/src/platform/tokens/transitions/unfreeze.rs
+++ b/packages/rs-sdk/src/platform/tokens/transitions/unfreeze.rs
@@ -62,12 +62,14 @@ impl Sdk {
     ) -> Result<UnfreezeResult, Error> {
         let platform_version = self.version();
 
+        let put_settings = unfreeze_tokens_transition_builder.settings;
+
         let state_transition = unfreeze_tokens_transition_builder
             .sign(self, signing_key, signer, platform_version)
             .await?;
 
         let proof_result = state_transition
-            .broadcast_and_wait::<StateTransitionProofResult>(self, None)
+            .broadcast_and_wait::<StateTransitionProofResult>(self, put_settings)
             .await?;
 
         match proof_result {


### PR DESCRIPTION
## Issue being fixed or feature implemented

Token transition methods for `freeze`, `mint`, `unfreeze`, and `set_price_for_direct_purchase` pass `None` to `broadcast_and_wait` instead of the builder's `settings` field. This silently ignores any caller-provided `PutSettings` (retry config, timeout, etc.).

Split out from #3092 per review feedback ("1 PR = 1 thing").

## What was done?

Extract `settings` from the transition builder before `sign()` consumes it, then pass it to `broadcast_and_wait`. This matches the pattern already used in `destroy_frozen_funds`.

**Before:**
```rust
let state_transition = freeze_tokens_transition_builder
    .sign(self, signing_key, signer, platform_version).await?;
let proof_result = state_transition
    .broadcast_and_wait::<StateTransitionProofResult>(self, None)  // ← settings dropped
    .await?;
```

**After:**
```rust
let put_settings = freeze_tokens_transition_builder.settings;  // ← extract before sign
let state_transition = freeze_tokens_transition_builder
    .sign(self, signing_key, signer, platform_version).await?;
let proof_result = state_transition
    .broadcast_and_wait::<StateTransitionProofResult>(self, put_settings)  // ← propagated
    .await?;
```

Applied to: `freeze.rs`, `mint.rs`, `unfreeze.rs`, `set_price_for_direct_purchase.rs`

All other token transitions (`burn`, `claim`, `config_update`, `direct_purchase`, `emergency_action`, `transfer`, `destroy_frozen_funds`) already propagate settings correctly.

## How Has This Been Tested?

Code review — the fix is mechanical and matches the existing correct pattern in `destroy_frozen_funds.rs`.

## Breaking Changes

None. This is a bug fix — callers who set `PutSettings` on these builders will now have them respected as intended.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**Bug Fixes**
- Token transition operations including freeze, mint, set price for direct purchase, and unfreeze now properly utilize configured settings during proof broadcasting, replacing previous null value defaults. This ensures consistent and reliable verification behavior across all token-related transactions while maintaining backward compatibility without affecting the public API surface or existing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Validation

1. **What was tested**
   - CI checks on this PR (Rust packages linting, tests, builds)

2. **Results**
   - All Rust CI checks passing

3. **Environment**
   - GitHub Actions CI for `dashpay/platform`
