### PR TITLE
ci: use pull_request_target for milestone assignment workflow

### DIFF
--- a/.github/workflows/milestone.yml
+++ b/.github/workflows/milestone.yml
@@ -1,7 +1,7 @@
 name: Assign Milestone
 
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, reopened, edited]
 
 jobs:


### PR DESCRIPTION
## Issue being fixed

The milestone assignment workflow fails on fork PRs with `Resource not accessible by integration` because `pull_request` events from forks get a read-only `GITHUB_TOKEN`.

## What was done?

Changed `pull_request` → `pull_request_target` in `milestone.yml`.

This is safe because the workflow:
- Does **not** check out any code
- Does **not** build or execute anything from the PR
- Only reads `context.payload.pull_request` metadata (base branch name)
- Only writes the milestone via GitHub API

`pull_request_target` runs in the context of the base branch, giving it the base repo's `GITHUB_TOKEN` with the declared `pull-requests: write` and `issues: write` permissions.

## Breaking Changes

None.