### PR TITLE
ci: fail gRPC coverage check on missing queries, remove PR comment

### DIFF
--- a/.github/workflows/tests-rs-sdk-grpc-coverage.yml
+++ b/.github/workflows/tests-rs-sdk-grpc-coverage.yml
@@ -30,7 +30,6 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-      pull-requests: write
     steps:
       - name: Check out repo
         uses: actions/checkout@v4
@@ -45,13 +44,9 @@ jobs:
       - name: Check gRPC coverage
         id: coverage
         run: |
-          # Run the coverage check
-          if python .github/scripts/check-grpc-coverage.py; then
-            echo "status=success" >> $GITHUB_OUTPUT
-          else
-            echo "status=failure" >> $GITHUB_OUTPUT
-          fi
-          
+          # Run the coverage check — script exits non-zero if new queries are missing
+          python .github/scripts/check-grpc-coverage.py
+
           # Check if cache was modified
           if git diff --quiet .github/grpc-queries-cache.json; then
             echo "cache_modified=false" >> $GITHUB_OUTPUT
@@ -74,50 +69,3 @@ jobs:
         with:
           name: grpc-coverage-report
           path: grpc-coverage-report.txt
-          
-      - name: Comment PR
-        if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && (steps.coverage.outputs.cache_modified == 'true' || steps.coverage.outputs.status == 'failure')
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const fs = require('fs');
-            const reportPath = 'grpc-coverage-report.txt';
-            
-            if (fs.existsSync(reportPath)) {
-              const report = fs.readFileSync(reportPath, 'utf8');
-              const status = '${{ steps.coverage.outputs.status }}' === 'success' ? '✅' : '❌';
-              
-              // Find existing comment
-              const { data: comments } = await github.rest.issues.listComments({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: context.issue.number,
-              });
-              
-              const botComment = comments.find(comment => 
-                comment.user.type === 'Bot' && 
-                comment.body.includes('gRPC Query Coverage Report')
-              );
-              
-              const body = `### ${status} gRPC Query Coverage Report\n\n\`\`\`\n${report}\n\`\`\``;
-              
-              if (botComment) {
-                await github.rest.issues.updateComment({
-                  owner: context.repo.owner,
-                  repo: context.repo.repo,
-                  comment_id: botComment.id,
-                  body: body
-                });
-              } else {
-                await github.rest.issues.createComment({
-                  owner: context.repo.owner,
-                  repo: context.repo.repo,
-                  issue_number: context.issue.number,
-                  body: body
-                });
-              }
-            }
-
-      - name: Fail if new queries are missing
-        if: steps.coverage.outputs.status == 'failure'
-        run: exit 1


### PR DESCRIPTION
**Option A** (alternative to #3136)

Simplify the gRPC coverage workflow:
- Let the Python script's exit code drive pass/fail directly (fails if any new queries are missing)
- Remove the PR comment step entirely — coverage report is available as a build artifact
- Drop `pull-requests: write` permission (no longer needed)

This solves the fork PR failure since no comment is attempted. Also makes the workflow simpler — missing coverage shows up as a red CI check rather than a comment.

## Validation

**What was tested:**
- `Check gRPC query coverage` CI workflow — validates that the Python script exit code correctly gates coverage enforcement
- Fork PR simulation: confirmed no `pull-requests: write` permission errors occur since comment step is removed

**Results:**
- `Check gRPC query coverage` — pass (10s, GitHub Actions CI)
- `Build JS packages / Build JS` — pass (11m11s)
- `JS dependency versions check` — pass
- `Rust crates security audit` — pass
- All other applicable CI checks passed

**Environment:** GitHub Actions CI (ubuntu-latest)
