### PR TITLE
ci: skip gRPC coverage PR comment on fork PRs

### DIFF
--- a/.github/workflows/tests-rs-sdk-grpc-coverage.yml
+++ b/.github/workflows/tests-rs-sdk-grpc-coverage.yml
@@ -76,7 +76,7 @@ jobs:
           path: grpc-coverage-report.txt
           
       - name: Comment PR
-        if: github.event_name == 'pull_request' && (steps.coverage.outputs.cache_modified == 'true' || steps.coverage.outputs.status == 'failure')
+        if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && (steps.coverage.outputs.cache_modified == 'true' || steps.coverage.outputs.status == 'failure')
         uses: actions/github-script@v7
         with:
           script: |


### PR DESCRIPTION
**Option B** (alternative to #3135)

Skip the Comment PR step when the PR comes from a fork (`head.repo.full_name != repository`). Fork PRs don't get write permissions for `GITHUB_TOKEN`, causing the comment step to fail with `Resource not accessible by integration`.

The coverage check itself still runs and fails/passes normally. The report is available as a build artifact. Comments still post on internal PRs.