### PR TITLE
feat(dpp): add client-side validation to remaining ST construction methods

### DIFF
--- a/packages/rs-dpp/src/state_transition/state_transitions/identity/identity_credit_transfer_transition/v0/v0_methods.rs
+++ b/packages/rs-dpp/src/state_transition/state_transitions/identity/identity_credit_transfer_transition/v0/v0_methods.rs
@@ -110,3 +110,168 @@ impl IdentityCreditTransferTransitionMethodsV0 for IdentityCreditTransferTransit
         Ok(transition)
     }
 }
+
+#[cfg(all(test, feature = "state-transition-signing"))]
+mod tests {
+    use crate::address_funds::AddressWitness;
+    use crate::consensus::basic::BasicError;
+    use crate::consensus::ConsensusError;
+    use crate::identity::accessors::{IdentityGettersV0, IdentitySettersV0};
+    use crate::identity::identity_public_key::accessors::v0::IdentityPublicKeyGettersV0;
+    use crate::identity::identity_public_key::v0::IdentityPublicKeyV0;
+    use crate::identity::signer::Signer;
+    use crate::identity::{Identity, IdentityPublicKey, KeyType, Purpose, SecurityLevel};
+    use crate::state_transition::identity_credit_transfer_transition::methods::IdentityCreditTransferTransitionMethodsV0;
+    use crate::state_transition::identity_credit_transfer_transition::v0::IdentityCreditTransferTransitionV0;
+    use crate::ProtocolError;
+    use platform_value::BinaryData;
+    use platform_value::Identifier;
+    use platform_version::version::LATEST_PLATFORM_VERSION;
+
+    #[derive(Debug)]
+    struct TestIdentitySigner {
+        allowed_key_id: u32,
+    }
+
+    impl Signer<IdentityPublicKey> for TestIdentitySigner {
+        fn sign(
+            &self,
+            _key: &IdentityPublicKey,
+            _data: &[u8],
+        ) -> Result<BinaryData, ProtocolError> {
+            Ok(vec![0; 65].into())
+        }
+
+        fn sign_create_witness(
+            &self,
+            _key: &IdentityPublicKey,
+            _data: &[u8],
+        ) -> Result<AddressWitness, ProtocolError> {
+            Err(ProtocolError::NotSupported(
+                "sign_create_witness is not used in these tests".to_string(),
+            ))
+        }
+
+        fn can_sign_with(&self, key: &IdentityPublicKey) -> bool {
+            key.id() == self.allowed_key_id
+        }
+    }
+
+    fn transfer_key(key_id: u32) -> IdentityPublicKey {
+        IdentityPublicKeyV0 {
+            id: key_id,
+            purpose: Purpose::TRANSFER,
+            security_level: SecurityLevel::CRITICAL,
+            contract_bounds: None,
+            key_type: KeyType::ECDSA_SECP256K1,
+            read_only: false,
+            data: vec![2; 33].into(),
+            disabled_at: None,
+        }
+        .into()
+    }
+
+    fn identity_with_transfer_key(identity_id: Identifier, key_id: u32) -> Identity {
+        let mut identity =
+            Identity::default_versioned(LATEST_PLATFORM_VERSION).expect("expected identity");
+        identity.set_id(identity_id);
+        identity.add_public_key(transfer_key(key_id));
+        identity
+    }
+
+    #[test]
+    fn should_return_identity_credit_transfer_to_self_error_when_recipient_is_sender() {
+        let identity_id = Identifier::random();
+        let identity = identity_with_transfer_key(identity_id, 1);
+        let min_transfer_amount = LATEST_PLATFORM_VERSION
+            .fee_version
+            .state_transition_min_fees
+            .credit_transfer;
+
+        let result = IdentityCreditTransferTransitionV0::try_from_identity(
+            &identity,
+            identity_id,
+            min_transfer_amount,
+            0,
+            TestIdentitySigner { allowed_key_id: 1 },
+            None,
+            1,
+            LATEST_PLATFORM_VERSION,
+            None,
+        );
+
+        match result {
+            Err(ProtocolError::ConsensusError(consensus_error)) => {
+                assert!(matches!(
+                    consensus_error.as_ref(),
+                    ConsensusError::BasicError(BasicError::IdentityCreditTransferToSelfError(_))
+                ));
+            }
+            other => panic!("expected to-self consensus error, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn should_return_invalid_identity_credit_transfer_amount_error_when_below_minimum() {
+        let identity_id = Identifier::random();
+        let identity = identity_with_transfer_key(identity_id, 1);
+        let min_transfer_amount = LATEST_PLATFORM_VERSION
+            .fee_version
+            .state_transition_min_fees
+            .credit_transfer;
+        assert!(
+            min_transfer_amount > 0,
+            "minimum transfer amount must be positive"
+        );
+        let below_min_amount = min_transfer_amount - 1;
+
+        let result = IdentityCreditTransferTransitionV0::try_from_identity(
+            &identity,
+            Identifier::random(),
+            below_min_amount,
+            0,
+            TestIdentitySigner { allowed_key_id: 1 },
+            None,
+            1,
+            LATEST_PLATFORM_VERSION,
+            None,
+        );
+
+        match result {
+            Err(ProtocolError::ConsensusError(consensus_error)) => {
+                assert!(matches!(
+                    consensus_error.as_ref(),
+                    ConsensusError::BasicError(
+                        BasicError::InvalidIdentityCreditTransferAmountError(error)
+                    ) if error.amount() == below_min_amount
+                        && error.min_amount() == min_transfer_amount
+                ));
+            }
+            other => panic!("expected invalid amount consensus error, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn should_succeed_when_transfer_amount_equals_minimum() {
+        let identity_id = Identifier::random();
+        let identity = identity_with_transfer_key(identity_id, 1);
+        let min_transfer_amount = LATEST_PLATFORM_VERSION
+            .fee_version
+            .state_transition_min_fees
+            .credit_transfer;
+
+        let result = IdentityCreditTransferTransitionV0::try_from_identity(
+            &identity,
+            Identifier::random(),
+            min_transfer_amount,
+            0,
+            TestIdentitySigner { allowed_key_id: 1 },
+            None,
+            1,
+            LATEST_PLATFORM_VERSION,
+            None,
+        );
+
+        assert!(result.is_ok(), "expected boundary amount to be valid");
+    }
+}

--- a/packages/rs-dpp/src/state_transition/state_transitions/identity/identity_credit_transfer_transition/v0/v0_methods.rs
+++ b/packages/rs-dpp/src/state_transition/state_transitions/identity/identity_credit_transfer_transition/v0/v0_methods.rs
@@ -1,5 +1,8 @@
 #[cfg(feature = "state-transition-signing")]
 use crate::{
+    consensus::basic::identity::{
+        IdentityCreditTransferToSelfError, InvalidIdentityCreditTransferAmountError,
+    },
     identity::{
         accessors::IdentityGettersV0,
         identity_public_key::accessors::v0::IdentityPublicKeyGettersV0, signer::Signer, Identity,
@@ -29,9 +32,21 @@ impl IdentityCreditTransferTransitionMethodsV0 for IdentityCreditTransferTransit
         signer: S,
         signing_withdrawal_key_to_use: Option<&IdentityPublicKey>,
         nonce: IdentityNonce,
-        _platform_version: &PlatformVersion,
+        platform_version: &PlatformVersion,
         _version: Option<FeatureVersion>,
     ) -> Result<StateTransition, ProtocolError> {
+        let _ = platform_version;
+
+        if identity.id() == to_identity_with_identifier {
+            let error = IdentityCreditTransferToSelfError::default();
+            return Err(ProtocolError::ConsensusError(Box::new(error.into())));
+        }
+
+        if amount < 100000 {
+            let error = InvalidIdentityCreditTransferAmountError::new(amount, 100000);
+            return Err(ProtocolError::ConsensusError(Box::new(error.into())));
+        }
+
         let mut transition: StateTransition = IdentityCreditTransferTransitionV0 {
             identity_id: identity.id(),
             recipient_id: to_identity_with_identifier,

--- a/packages/rs-dpp/src/state_transition/state_transitions/identity/identity_credit_transfer_transition/v0/v0_methods.rs
+++ b/packages/rs-dpp/src/state_transition/state_transitions/identity/identity_credit_transfer_transition/v0/v0_methods.rs
@@ -35,15 +35,18 @@ impl IdentityCreditTransferTransitionMethodsV0 for IdentityCreditTransferTransit
         platform_version: &PlatformVersion,
         _version: Option<FeatureVersion>,
     ) -> Result<StateTransition, ProtocolError> {
-        let _ = platform_version;
+        let min_transfer_amount = platform_version
+            .fee_version
+            .state_transition_min_fees
+            .credit_transfer;
 
         if identity.id() == to_identity_with_identifier {
             let error = IdentityCreditTransferToSelfError::default();
             return Err(ProtocolError::ConsensusError(Box::new(error.into())));
         }
 
-        if amount < 100000 {
-            let error = InvalidIdentityCreditTransferAmountError::new(amount, 100000);
+        if amount < min_transfer_amount {
+            let error = InvalidIdentityCreditTransferAmountError::new(amount, min_transfer_amount);
             return Err(ProtocolError::ConsensusError(Box::new(error.into())));
         }
 

--- a/packages/rs-dpp/src/state_transition/state_transitions/identity/identity_topup_transition/v0/v0_methods.rs
+++ b/packages/rs-dpp/src/state_transition/state_transitions/identity/identity_topup_transition/v0/v0_methods.rs
@@ -31,9 +31,20 @@ impl IdentityTopUpTransitionMethodsV0 for IdentityTopUpTransitionV0 {
         asset_lock_proof: AssetLockProof,
         asset_lock_proof_private_key: &[u8],
         user_fee_increase: UserFeeIncrease,
-        _platform_version: &PlatformVersion,
+        platform_version: &PlatformVersion,
         _version: Option<FeatureVersion>,
     ) -> Result<StateTransition, ProtocolError> {
+        #[cfg(feature = "validation")]
+        {
+            let validation_result = asset_lock_proof.validate_structure(platform_version)?;
+            if !validation_result.is_valid() {
+                let first_error = validation_result.errors.into_iter().next().unwrap();
+                return Err(ProtocolError::ConsensusError(Box::new(first_error)));
+            }
+        }
+
+        let _ = platform_version;
+
         let identity_top_up_transition = IdentityTopUpTransitionV0 {
             asset_lock_proof,
             identity_id: identity.id(),

--- a/packages/rs-dpp/src/state_transition/state_transitions/identity/identity_topup_transition/v0/v0_methods.rs
+++ b/packages/rs-dpp/src/state_transition/state_transitions/identity/identity_topup_transition/v0/v0_methods.rs
@@ -37,8 +37,7 @@ impl IdentityTopUpTransitionMethodsV0 for IdentityTopUpTransitionV0 {
         #[cfg(feature = "validation")]
         {
             let validation_result = asset_lock_proof.validate_structure(platform_version)?;
-            if !validation_result.is_valid() {
-                let first_error = validation_result.errors.into_iter().next().unwrap();
+            if let Some(first_error) = validation_result.errors.into_iter().next() {
                 return Err(ProtocolError::ConsensusError(Box::new(first_error)));
             }
         }

--- a/packages/rs-dpp/src/state_transition/state_transitions/identity/identity_topup_transition/v0/v0_methods.rs
+++ b/packages/rs-dpp/src/state_transition/state_transitions/identity/identity_topup_transition/v0/v0_methods.rs
@@ -42,6 +42,7 @@ impl IdentityTopUpTransitionMethodsV0 for IdentityTopUpTransitionV0 {
             }
         }
 
+        #[cfg(not(feature = "validation"))]
         let _ = platform_version;
 
         let identity_top_up_transition = IdentityTopUpTransitionV0 {


### PR DESCRIPTION
## Issue Being Fixed or Feature Description

Adds client-side validation to the remaining state transition construction methods that lack it, following the pattern established in #3096.

**Context:** shumkov's [review on #3096](https://github.com/dashpay/platform/pull/3096#discussion_r2039266920) asked for validation to be added consistently across all ST construction methods. This PR covers the identity credit transfer and identity top-up transitions.

## What was done?

### IdentityCreditTransferTransition (`try_from_identity`)
- **Self-transfer check:** Returns `IdentityCreditTransferToSelfError` if `identity_id == recipient_id`
- **Minimum amount check:** Returns `InvalidIdentityCreditTransferAmountError` if `amount < 100_000` credits

These checks mirror the server-side `validate_basic_structure_v0` in `rs-drive-abci`, catching invalid transfers before they're signed and broadcast.

### IdentityTopUpTransition (`try_from_identity`)
- **Asset lock proof validation:** Calls `AssetLockProof::validate_structure()` to validate the proof before constructing the transition
- Gated behind `#[cfg(feature = "validation")]` since `validate_structure` requires that feature

### What's NOT covered (and why)

| State Transition | Reason Not Covered |
|---|---|
| `IdentityCreditWithdrawalTransition` | Server-side validation is disabled (returns `UnsupportedFeatureError`) — no meaningful checks to port |
| `MasternodeVoteTransition` | No structural validation exists server-side |
| `DataContractCreate/UpdateTransition` | Validation requires `Network` parameter not available in the constructor; SDK-level `put_contract.rs` already calls `ensure_valid_state_transition_structure` |

## How Has This Been Tested?

- `cargo check -p dpp --features "state-transition-signing"` ✅
- `cargo check -p dpp --features "state-transition-signing,validation"` ✅
- `cargo check -p dash-sdk` ✅
- `cargo test -p dpp --features "state-transition-signing" -- identity_credit_transfer` ✅ (3 tests pass)

## Breaking Changes

None. Existing valid transitions continue to work. Invalid transitions that would have been rejected server-side are now caught earlier at construction time.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional tests
- [x] I have made corresponding changes to the documentation
- [x] I have added the PR to a GitHub project board (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Validation for identity credit transfers to block self-transfers and enforce a minimum transfer amount.

* **Improvements**
  * Stricter validation for identity top-up transactions, including asset lock proof verification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Validation

1. **What was tested**
   - `cargo test -p dash-sdk --lib` — client-side validation integration
   - `cargo test -p dpp --lib` — validation logic unit tests

2. **Results**
   - All Rust checks passing on CI

3. **Environment**
   - GitHub Actions CI on dashpay/platform
