### PR TITLE
fix(sdk): remove unused Sdk::parse_proof and Sdk::parse_proof_with_metadata

### DIFF
--- a/packages/rs-sdk/src/sdk.rs
+++ b/packages/rs-sdk/src/sdk.rs
@@ -240,27 +240,6 @@ impl Sdk {
             .expect("mock should be created")
     }
 
-    /// Retrieve object `O` from proof contained in `request` (of type `R`) and `response`.
-    ///
-    /// This method is used to retrieve objects from proofs returned by Dash Platform.
-    ///
-    /// ## Generic Parameters
-    ///
-    /// - `R`: Type of the request that was used to fetch the proof.
-    /// - `O`: Type of the object to be retrieved from the proof.
-    pub(crate) async fn parse_proof<R, O: FromProof<R> + MockResponse>(
-        &self,
-        request: O::Request,
-        response: O::Response,
-    ) -> Result<Option<O>, Error>
-    where
-        O::Request: Mockable + TransportRequest,
-    {
-        self.parse_proof_with_metadata(request, response)
-            .await
-            .map(|result| result.0)
-    }
-
     /// Return freshness criteria (height tolerance and time tolerance) for given request method.
     ///
     /// Note that if self.metadata_height_tolerance or self.metadata_time_tolerance_ms is None,
@@ -277,29 +256,6 @@ impl Sdk {
                 self.metadata_time_tolerance_ms,
             ),
         }
-    }
-
-    /// Retrieve object `O` from proof contained in `request` (of type `R`) and `response`.
-    ///
-    /// This method is used to retrieve objects from proofs returned by Dash Platform.
-    ///
-    /// ## Generic Parameters
-    ///
-    /// - `R`: Type of the request that was used to fetch the proof.
-    /// - `O`: Type of the object to be retrieved from the proof.
-    pub(crate) async fn parse_proof_with_metadata<R, O: FromProof<R> + MockResponse>(
-        &self,
-        request: O::Request,
-        response: O::Response,
-    ) -> Result<(Option<O>, ResponseMetadata), Error>
-    where
-        O::Request: Mockable + TransportRequest,
-    {
-        let (object, metadata, _proof) = self
-            .parse_proof_with_metadata_and_proof(request, response)
-            .await?;
-
-        Ok((object, metadata))
     }
 
     /// Verify response metadata against the current state of the SDK.


### PR DESCRIPTION
## Summary

Remove unused `Sdk::parse_proof` and `Sdk::parse_proof_with_metadata` methods from `packages/rs-sdk/src/sdk.rs`.

These two methods became dead code — their last external caller (in `fetch_many.rs`) was removed when the fetch paths were refactored to call `parse_proof_with_metadata_and_proof` directly. The methods only called each other internally, with no external entry points remaining.

The mock's `MockDashPlatformSdk::parse_proof_with_metadata` (in `mock/sdk.rs`) is a separate method and is unaffected.

## Changes

- Removed `Sdk::parse_proof` (wrapper that discarded metadata)
- Removed `Sdk::parse_proof_with_metadata` (wrapper that discarded proof)
- 44 lines deleted, 0 added

## Verification

- `cargo clippy --package dash-sdk --all-features --locked -- --no-deps -D warnings` — clean
- `cargo fmt --check --package=dash-sdk` — clean


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Removed internal helper methods for parsing proof-derived objects. Code paths previously using these methods will require updates to use alternative approaches directly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->