### PR TITLE
refactor!: change Map keys from Identifier objects to string representations

### DIFF
--- a/packages/js-evo-sdk/src/addresses/facade.ts
+++ b/packages/js-evo-sdk/src/addresses/facade.ts
@@ -40,7 +40,7 @@ export class AddressesFacade {
    */
   async getMany(
     addresses: wasm.PlatformAddressLikeArray,
-  ): Promise<Map<wasm.PlatformAddress, wasm.PlatformAddressInfo | undefined>> {
+  ): Promise<Map<string, wasm.PlatformAddressInfo | undefined>> {
     const w = await this.sdk.getWasmSdkConnected();
     return w.getAddressesInfos(addresses);
   }
@@ -53,7 +53,7 @@ export class AddressesFacade {
    */
   async getManyWithProof(
     addresses: wasm.PlatformAddressLikeArray,
-  ): Promise<wasm.ProofMetadataResponseTyped<Map<wasm.PlatformAddress, wasm.PlatformAddressInfo | undefined>>> {
+  ): Promise<wasm.ProofMetadataResponseTyped<Map<string, wasm.PlatformAddressInfo | undefined>>> {
     const w = await this.sdk.getWasmSdkConnected();
     return w.getAddressesInfosWithProofInfo(addresses);
   }
@@ -84,7 +84,7 @@ export class AddressesFacade {
    */
   async transfer(
     options: wasm.AddressFundsTransferOptions,
-  ): Promise<Map<wasm.PlatformAddress, wasm.PlatformAddressInfo>> {
+  ): Promise<Map<string, wasm.PlatformAddressInfo>> {
     const w = await this.sdk.getWasmSdkConnected();
     return w.addressFundsTransfer(options);
   }
@@ -148,7 +148,7 @@ export class AddressesFacade {
    */
   async withdraw(
     options: wasm.AddressFundsWithdrawOptions,
-  ): Promise<Map<wasm.PlatformAddress, wasm.PlatformAddressInfo>> {
+  ): Promise<Map<string, wasm.PlatformAddressInfo>> {
     const w = await this.sdk.getWasmSdkConnected();
     return w.addressFundsWithdraw(options);
   }
@@ -221,7 +221,7 @@ export class AddressesFacade {
    */
   async fundFromAssetLock(
     options: wasm.AddressFundingFromAssetLockOptions,
-  ): Promise<Map<wasm.PlatformAddress, wasm.PlatformAddressInfo>> {
+  ): Promise<Map<string, wasm.PlatformAddressInfo>> {
     const w = await this.sdk.getWasmSdkConnected();
     return w.addressFundingFromAssetLock(options);
   }

--- a/packages/js-evo-sdk/src/contracts/facade.ts
+++ b/packages/js-evo-sdk/src/contracts/facade.ts
@@ -31,7 +31,7 @@ export class ContractsFacade {
     return w.getDataContractHistoryWithProofInfo(query);
   }
 
-  async getMany(contractIds: wasm.IdentifierLikeArray): Promise<Map<wasm.Identifier, wasm.DataContract | undefined>> {
+  async getMany(contractIds: wasm.IdentifierLikeArray): Promise<Map<string, wasm.DataContract | undefined>> {
     const w = await this.sdk.getWasmSdkConnected();
     return w.getDataContracts(contractIds);
   }
@@ -39,7 +39,7 @@ export class ContractsFacade {
   async getManyWithProof(
     contractIds: wasm.IdentifierLikeArray,
   ): Promise<wasm.ProofMetadataResponseTyped<
-    Map<wasm.Identifier, wasm.DataContract | undefined>
+    Map<string, wasm.DataContract | undefined>
   >> {
     const w = await this.sdk.getWasmSdkConnected();
     return w.getDataContractsWithProofInfo(contractIds);

--- a/packages/js-evo-sdk/src/documents/facade.ts
+++ b/packages/js-evo-sdk/src/documents/facade.ts
@@ -9,7 +9,7 @@ export class DocumentsFacade {
   }
 
   // Query many documents
-  async query(query: wasm.DocumentsQuery): Promise<Map<wasm.Identifier, wasm.Document | undefined>> {
+  async query(query: wasm.DocumentsQuery): Promise<Map<string, wasm.Document | undefined>> {
     const w = await this.sdk.getWasmSdkConnected();
     return w.getDocuments(query);
   }
@@ -17,7 +17,7 @@ export class DocumentsFacade {
   async queryWithProof(
     query: wasm.DocumentsQuery,
   ): Promise<wasm.ProofMetadataResponseTyped<
-    Map<wasm.Identifier, wasm.Document | undefined>
+    Map<string, wasm.Document | undefined>
   >> {
     const w = await this.sdk.getWasmSdkConnected();
     return w.getDocumentsWithProofInfo(query);

--- a/packages/js-evo-sdk/src/epoch/facade.ts
+++ b/packages/js-evo-sdk/src/epoch/facade.ts
@@ -48,25 +48,25 @@ export class EpochFacade {
   }
 
   async evonodesProposedBlocksByIds(epoch: number, ids: wasm.ProTxHashLikeArray):
-    Promise<Map<wasm.Identifier, bigint>> {
+    Promise<Map<string, bigint>> {
     const w = await this.sdk.getWasmSdkConnected();
     return w.getEvonodesProposedEpochBlocksByIds(epoch, ids);
   }
 
   async evonodesProposedBlocksByIdsWithProof(epoch: number, ids: wasm.ProTxHashLikeArray):
-    Promise<wasm.ProofMetadataResponseTyped<Map<wasm.Identifier, bigint>>> {
+    Promise<wasm.ProofMetadataResponseTyped<Map<string, bigint>>> {
     const w = await this.sdk.getWasmSdkConnected();
     return w.getEvonodesProposedEpochBlocksByIdsWithProofInfo(epoch, ids);
   }
 
-  async evonodesProposedBlocksByRange(query: EvonodeProposedBlocksRangeQuery): Promise<Map<wasm.Identifier, bigint>> {
+  async evonodesProposedBlocksByRange(query: EvonodeProposedBlocksRangeQuery): Promise<Map<string, bigint>> {
     const w = await this.sdk.getWasmSdkConnected();
     return w.getEvonodesProposedEpochBlocksByRange(query);
   }
 
   async evonodesProposedBlocksByRangeWithProof(
     query: EvonodeProposedBlocksRangeQuery,
-  ): Promise<wasm.ProofMetadataResponseTyped<Map<wasm.Identifier, bigint>>> {
+  ): Promise<wasm.ProofMetadataResponseTyped<Map<string, bigint>>> {
     const w = await this.sdk.getWasmSdkConnected();
     return w.getEvonodesProposedEpochBlocksByRangeWithProofInfo(query);
   }

--- a/packages/js-evo-sdk/src/group/facade.ts
+++ b/packages/js-evo-sdk/src/group/facade.ts
@@ -30,14 +30,14 @@ export class GroupFacade {
     return w.getGroupInfosWithProofInfo(query);
   }
 
-  async members(query: wasm.GroupMembersQuery): Promise<Map<wasm.Identifier, bigint>> {
+  async members(query: wasm.GroupMembersQuery): Promise<Map<string, bigint>> {
     const w = await this.sdk.getWasmSdkConnected();
     return w.getGroupMembers(query);
   }
 
   async membersWithProof(
     query: wasm.GroupMembersQuery,
-  ): Promise<wasm.ProofMetadataResponseTyped<Map<wasm.Identifier, bigint>>> {
+  ): Promise<wasm.ProofMetadataResponseTyped<Map<string, bigint>>> {
     const w = await this.sdk.getWasmSdkConnected();
     return w.getGroupMembersWithProofInfo(query);
   }
@@ -54,7 +54,7 @@ export class GroupFacade {
     return w.getIdentityGroupsWithProofInfo(query);
   }
 
-  async actions(query: wasm.GroupActionsQuery): Promise<Map<wasm.Identifier, wasm.GroupAction | undefined>> {
+  async actions(query: wasm.GroupActionsQuery): Promise<Map<string, wasm.GroupAction | undefined>> {
     const w = await this.sdk.getWasmSdkConnected();
     return w.getGroupActions(query);
   }
@@ -62,27 +62,27 @@ export class GroupFacade {
   async actionsWithProof(
     query: wasm.GroupActionsQuery,
   ): Promise<wasm.ProofMetadataResponseTyped<
-    Map<wasm.Identifier, wasm.GroupAction | undefined>
+    Map<string, wasm.GroupAction | undefined>
   >> {
     const w = await this.sdk.getWasmSdkConnected();
     return w.getGroupActionsWithProofInfo(query);
   }
 
-  async actionSigners(query: wasm.GroupActionSignersQuery): Promise<Map<wasm.Identifier, bigint>> {
+  async actionSigners(query: wasm.GroupActionSignersQuery): Promise<Map<string, bigint>> {
     const w = await this.sdk.getWasmSdkConnected();
     return w.getGroupActionSigners(query);
   }
 
   async actionSignersWithProof(
     query: wasm.GroupActionSignersQuery,
-  ): Promise<wasm.ProofMetadataResponseTyped<Map<wasm.Identifier, bigint>>> {
+  ): Promise<wasm.ProofMetadataResponseTyped<Map<string, bigint>>> {
     const w = await this.sdk.getWasmSdkConnected();
     return w.getGroupActionSignersWithProofInfo(query);
   }
 
   async groupsDataContracts(
     dataContractIds: wasm.IdentifierLikeArray,
-  ): Promise<Map<wasm.Identifier, Map<number, wasm.Group | undefined>>> {
+  ): Promise<Map<string, Map<number, wasm.Group | undefined>>> {
     const w = await this.sdk.getWasmSdkConnected();
     return w.getGroupsDataContracts(dataContractIds);
   }
@@ -90,7 +90,7 @@ export class GroupFacade {
   async groupsDataContractsWithProof(
     dataContractIds: wasm.IdentifierLikeArray,
   ): Promise<wasm.ProofMetadataResponseTyped<
-    Map<wasm.Identifier, Map<number, wasm.Group | undefined>>
+    Map<string, Map<number, wasm.Group | undefined>>
   >> {
     const w = await this.sdk.getWasmSdkConnected();
     return w.getGroupsDataContractsWithProofInfo(dataContractIds);

--- a/packages/js-evo-sdk/src/identities/facade.ts
+++ b/packages/js-evo-sdk/src/identities/facade.ts
@@ -74,7 +74,7 @@ export class IdentitiesFacade {
     return w.getIdentityBalanceWithProofInfo(identityId);
   }
 
-  async balances(identityIds: wasm.IdentifierLikeArray): Promise<Map<wasm.Identifier, bigint | undefined>> {
+  async balances(identityIds: wasm.IdentifierLikeArray): Promise<Map<string, bigint | undefined>> {
     const w = await this.sdk.getWasmSdkConnected();
     return w.getIdentitiesBalances(identityIds);
   }
@@ -82,7 +82,7 @@ export class IdentitiesFacade {
   async balancesWithProof(
     identityIds: wasm.IdentifierLikeArray,
   ): Promise<wasm.ProofMetadataResponseTyped<
-    Map<wasm.Identifier, bigint | undefined>
+    Map<string, bigint | undefined>
   >> {
     const w = await this.sdk.getWasmSdkConnected();
     return w.getIdentitiesBalancesWithProofInfo(identityIds);
@@ -147,7 +147,7 @@ export class IdentitiesFacade {
   }
 
   async tokenBalances(identityId: wasm.IdentifierLike, tokenIds: wasm.IdentifierLikeArray):
-    Promise<Map<wasm.Identifier, bigint>> {
+    Promise<Map<string, bigint>> {
     const w = await this.sdk.getWasmSdkConnected();
     return w.getIdentityTokenBalances(identityId, tokenIds);
   }
@@ -155,7 +155,7 @@ export class IdentitiesFacade {
   async tokenBalancesWithProof(
     identityId: wasm.IdentifierLike,
     tokenIds: wasm.IdentifierLikeArray,
-  ): Promise<wasm.ProofMetadataResponseTyped<Map<wasm.Identifier, bigint>>> {
+  ): Promise<wasm.ProofMetadataResponseTyped<Map<string, bigint>>> {
     const w = await this.sdk.getWasmSdkConnected();
     return w.getIdentityTokenBalancesWithProofInfo(identityId, tokenIds);
   }

--- a/packages/js-evo-sdk/src/tokens/facade.ts
+++ b/packages/js-evo-sdk/src/tokens/facade.ts
@@ -31,7 +31,7 @@ export class TokensFacade {
     return w.getTokenTotalSupplyWithProofInfo(tokenId);
   }
 
-  async statuses(tokenIds: wasm.IdentifierLikeArray): Promise<Map<wasm.Identifier, wasm.TokenStatus>> {
+  async statuses(tokenIds: wasm.IdentifierLikeArray): Promise<Map<string, wasm.TokenStatus>> {
     const w = await this.sdk.getWasmSdkConnected();
     return w.getTokenStatuses(tokenIds);
   }
@@ -39,14 +39,14 @@ export class TokensFacade {
   async statusesWithProof(
     tokenIds: wasm.IdentifierLikeArray,
   ): Promise<wasm.ProofMetadataResponseTyped<
-    Map<wasm.Identifier, wasm.TokenStatus>
+    Map<string, wasm.TokenStatus>
   >> {
     const w = await this.sdk.getWasmSdkConnected();
     return w.getTokenStatusesWithProofInfo(tokenIds);
   }
 
   async balances(identityIds: wasm.IdentifierLikeArray, tokenId: wasm.IdentifierLike):
-    Promise<Map<wasm.Identifier, bigint>> {
+    Promise<Map<string, bigint>> {
     const w = await this.sdk.getWasmSdkConnected();
     return w.getIdentitiesTokenBalances(identityIds, tokenId);
   }
@@ -54,13 +54,13 @@ export class TokensFacade {
   async balancesWithProof(
     identityIds: wasm.IdentifierLikeArray,
     tokenId: wasm.IdentifierLike,
-  ): Promise<wasm.ProofMetadataResponseTyped<Map<wasm.Identifier, bigint>>> {
+  ): Promise<wasm.ProofMetadataResponseTyped<Map<string, bigint>>> {
     const w = await this.sdk.getWasmSdkConnected();
     return w.getIdentitiesTokenBalancesWithProofInfo(identityIds, tokenId);
   }
 
   async identityBalances(identityId: wasm.IdentifierLike, tokenIds: wasm.IdentifierLikeArray):
-    Promise<Map<wasm.Identifier, bigint>> {
+    Promise<Map<string, bigint>> {
     const w = await this.sdk.getWasmSdkConnected();
     return w.getIdentityTokenBalances(identityId, tokenIds);
   }
@@ -68,19 +68,19 @@ export class TokensFacade {
   async identityBalancesWithProof(
     identityId: wasm.IdentifierLike,
     tokenIds: wasm.IdentifierLikeArray,
-  ): Promise<wasm.ProofMetadataResponseTyped<Map<wasm.Identifier, bigint>>> {
+  ): Promise<wasm.ProofMetadataResponseTyped<Map<string, bigint>>> {
     const w = await this.sdk.getWasmSdkConnected();
     return w.getIdentityTokenBalancesWithProofInfo(identityId, tokenIds);
   }
 
   async identityTokenInfos(identityId: wasm.IdentifierLike, tokenIds: wasm.IdentifierLikeArray):
-    Promise<Map<wasm.Identifier, wasm.IdentityTokenInfo>> {
+    Promise<Map<string, wasm.IdentityTokenInfo>> {
     const w = await this.sdk.getWasmSdkConnected();
     return w.getIdentityTokenInfos(identityId, tokenIds);
   }
 
   async identitiesTokenInfos(identityIds: wasm.IdentifierLikeArray, tokenId: wasm.IdentifierLike):
-    Promise<Map<wasm.Identifier, wasm.IdentityTokenInfo>> {
+    Promise<Map<string, wasm.IdentityTokenInfo>> {
     const w = await this.sdk.getWasmSdkConnected();
     return w.getIdentitiesTokenInfos(identityIds, tokenId);
   }
@@ -89,7 +89,7 @@ export class TokensFacade {
     identityId: wasm.IdentifierLike,
     tokenIds: wasm.IdentifierLikeArray,
   ): Promise<wasm.ProofMetadataResponseTyped<
-    Map<wasm.Identifier, wasm.IdentityTokenInfo>
+    Map<string, wasm.IdentityTokenInfo>
   >> {
     const w = await this.sdk.getWasmSdkConnected();
     return w.getIdentityTokenInfosWithProofInfo(identityId, tokenIds);
@@ -99,13 +99,13 @@ export class TokensFacade {
     identityIds: wasm.IdentifierLikeArray,
     tokenId: wasm.IdentifierLike,
   ): Promise<wasm.ProofMetadataResponseTyped<
-    Map<wasm.Identifier, wasm.IdentityTokenInfo>
+    Map<string, wasm.IdentityTokenInfo>
   >> {
     const w = await this.sdk.getWasmSdkConnected();
     return w.getIdentitiesTokenInfosWithProofInfo(identityIds, tokenId);
   }
 
-  async directPurchasePrices(tokenIds: wasm.IdentifierLikeArray): Promise<Map<wasm.Identifier, wasm.TokenPriceInfo>> {
+  async directPurchasePrices(tokenIds: wasm.IdentifierLikeArray): Promise<Map<string, wasm.TokenPriceInfo>> {
     const w = await this.sdk.getWasmSdkConnected();
     return w.getTokenDirectPurchasePrices(tokenIds);
   }
@@ -113,7 +113,7 @@ export class TokensFacade {
   async directPurchasePricesWithProof(
     tokenIds: wasm.IdentifierLikeArray,
   ): Promise<wasm.ProofMetadataResponseTyped<
-    Map<wasm.Identifier, wasm.TokenPriceInfo>
+    Map<string, wasm.TokenPriceInfo>
   >> {
     const w = await this.sdk.getWasmSdkConnected();
     return w.getTokenDirectPurchasePricesWithProofInfo(tokenIds);

--- a/packages/js-evo-sdk/src/voting/facade.ts
+++ b/packages/js-evo-sdk/src/voting/facade.ts
@@ -23,7 +23,7 @@ export class VotingFacade {
 
   async contestedResourceIdentityVotes(
     query: wasm.ContestedResourceIdentityVotesQuery,
-  ): Promise<Map<wasm.Identifier, wasm.ResourceVote>> {
+  ): Promise<Map<string, wasm.ResourceVote>> {
     const w = await this.sdk.getWasmSdkConnected();
     return w.getContestedResourceIdentityVotes(query);
   }
@@ -31,7 +31,7 @@ export class VotingFacade {
   async contestedResourceIdentityVotesWithProof(
     query: wasm.ContestedResourceIdentityVotesQuery,
   ): Promise<wasm.ProofMetadataResponseTyped<
-    Map<wasm.Identifier, wasm.ResourceVote>
+    Map<string, wasm.ResourceVote>
   >> {
     const w = await this.sdk.getWasmSdkConnected();
     return w.getContestedResourceIdentityVotesWithProofInfo(query);


### PR DESCRIPTION
## Issue being fixed or feature implemented
Map return types in WASM SDK methods were using `Identifier` objects as keys, which created inconsistency and complexity in the JavaScript API. This change standardizes Map keys to use string representations (base58 for identifiers, hex for addresses/proTxHashes) for better usability and consistency.

## What was done?
- Changed all WASM SDK query methods that return `Map<Identifier, T>` to return `Map<string, T>` where keys are base58-encoded identifier strings
- Changed all methods returning `Map<PlatformAddress, T>` to use hex-encoded address strings as keys
- Changed epoch-related methods returning `Map<ProTxHash, T>` to use hex-encoded proTxHash strings as keys
- Updated `unchecked_return_type` annotations in Rust to reflect the new string-based key types
- Updated TypeScript facade methods to reflect the new return types
- Updated unit tests to use string keys instead of Identifier objects when constructing Maps
- Added `From<dpp::platform_value::Identifier>` implementation for `ProTxHashWasm` to support conversion

Affected methods include:
- Token queries: `getIdentitiesTokenBalances`, `getIdentityTokenInfos`, `getIdentitiesTokenInfos`, `getTokenStatuses`, `getTokenDirectPurchasePrices`, etc.
- Group queries: `getGroupMembers`, `getGroupActions`, `getGroupActionSigners`, `getGroupsDataContracts`, etc.
- Identity queries: `getIdentitiesBalances`, `getIdentityTokenBalances`, etc.
- Address queries: `getAddressesInfos`, `addressFundsTransfer`, `addressFundsWithdraw`, etc.
- Data contract queries: `getDataContracts`
- Document queries: `getDocuments`
- Voting queries: `getContestedResourceIdentityVotes`
- Epoch queries: `getEvonodesProposedEpochBlocksByIds`, `getEvonodesProposedEpochBlocksByRange`, etc.

## How Has This Been Tested?
Existing functional and unit tests have been updated to work with the new string-based key format. The changes maintain backward compatibility at the Rust level while providing a cleaner JavaScript API. Tests in `epochs-blocks.spec.ts`, `Group.spec.ts`, `ProofResult.spec.ts`, `TokenConfiguration.spec.ts`, and `TokenDistributionRules.spec.ts` have been updated to reflect the new Map key format.

## Breaking Changes
**YES** - This is a breaking change for JavaScript consumers of the WASM SDK.

Map keys returned from WASM SDK methods have changed from `Identifier` objects to `string` values:
- Identifier-based maps now use base58-encoded strings as keys
- PlatformAddress-based maps now use hex-encoded strings as keys  
- ProTxHash-based maps now use hex-encoded strings as keys

Code that previously accessed maps like `map.get(identifierObject)` must now use `map.get(identifierObject.toBase58())` or work directly with string keys.

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have updated relevant unit/integration/functional tests
- [x] I have added "!" to the title and described breaking changes in the corresponding section

https://claude.ai/code/session_01BoRC8w8LUDD6kgExZaJ13P

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Breaking Changes**
  * Query method return types updated across addresses, contracts, documents, epochs, groups, identities, tokens, and voting modules. Maps now use string-based keys instead of object keys, improving data access patterns and serialization compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->