### PR TITLE
feat(rs-sdk): implement incremental address balance synchronization

### DIFF
--- a/packages/rs-sdk-ffi/src/address_sync/mod.rs
+++ b/packages/rs-sdk-ffi/src/address_sync/mod.rs
@@ -255,6 +255,7 @@ fn convert_sync_result(result: AddressSyncResult) -> DashSDKAddressSyncResult {
         highest_found_index: result.highest_found_index.unwrap_or(u32::MAX),
         has_highest_found_index: result.highest_found_index.is_some(),
         new_sync_height: result.new_sync_height,
+        new_sync_timestamp: result.new_sync_timestamp,
         metrics,
     }
 }

--- a/packages/rs-sdk-ffi/src/address_sync/mod.rs
+++ b/packages/rs-sdk-ffi/src/address_sync/mod.rs
@@ -23,6 +23,12 @@ use tracing::{debug, error, info};
 /// using privacy-preserving chunk queries. It supports HD wallet gap limit behavior
 /// where finding a used address extends the search range.
 ///
+/// The `last_sync_timestamp` parameter controls incremental vs full-scan behavior:
+/// - Pass 0 to force a full tree scan (first sync, or when no previous timestamp exists).
+/// - Pass a non-zero unix timestamp (seconds since epoch) from the previous sync to
+///   enable incremental-only mode when the elapsed time is within
+///   `config.full_rescan_after_time_s`.
+///
 /// # Safety
 /// - `sdk_handle` must be a valid SDK handle created by this SDK
 /// - `provider` must be a valid pointer to an AddressProviderFFI structure
@@ -33,6 +39,7 @@ pub unsafe extern "C" fn dash_sdk_sync_address_balances(
     sdk_handle: *const SDKHandle,
     provider: *mut AddressProviderFFI,
     config: *const DashSDKAddressSyncConfig,
+    last_sync_timestamp: u64,
 ) -> *mut DashSDKAddressSyncResult {
     info!("dash_sdk_sync_address_balances: called");
 
@@ -62,19 +69,26 @@ pub unsafe extern "C" fn dash_sdk_sync_address_balances(
         })
     };
 
+    // Convert timestamp: 0 means no previous sync (full scan)
+    let last_sync_ts = if last_sync_timestamp == 0 {
+        None
+    } else {
+        Some(last_sync_timestamp)
+    };
+
     debug!(
-        "dash_sdk_sync_address_balances: running sync with config: {:?}",
-        rust_config
+        "dash_sdk_sync_address_balances: running sync with config: {:?}, last_sync_timestamp: {:?}",
+        rust_config, last_sync_ts
     );
 
     // Create the callback-based provider wrapper
     let mut callback_provider = CallbackAddressProvider::new(provider_ffi);
 
-    // Execute the sync (pass None for last_sync_timestamp — FFI caller doesn't provide it yet)
+    // Execute the sync
     let result = wrapper.runtime.block_on(async {
         wrapper
             .sdk
-            .sync_address_balances(&mut callback_provider, rust_config, None)
+            .sync_address_balances(&mut callback_provider, rust_config, last_sync_ts)
             .await
     });
 
@@ -98,6 +112,12 @@ pub unsafe extern "C" fn dash_sdk_sync_address_balances(
 ///
 /// This is an alternative version that returns a DashSDKResult for better error handling.
 ///
+/// The `last_sync_timestamp` parameter controls incremental vs full-scan behavior:
+/// - Pass 0 to force a full tree scan (first sync, or when no previous timestamp exists).
+/// - Pass a non-zero unix timestamp (seconds since epoch) from the previous sync to
+///   enable incremental-only mode when the elapsed time is within
+///   `config.full_rescan_after_time_s`.
+///
 /// # Safety
 /// - `sdk_handle` must be a valid SDK handle created by this SDK
 /// - `provider` must be a valid pointer to an AddressProviderFFI structure
@@ -107,6 +127,7 @@ pub unsafe extern "C" fn dash_sdk_sync_address_balances_with_result(
     sdk_handle: *const SDKHandle,
     provider: *mut AddressProviderFFI,
     config: *const DashSDKAddressSyncConfig,
+    last_sync_timestamp: u64,
 ) -> DashSDKResult {
     info!("dash_sdk_sync_address_balances_with_result: called");
 
@@ -142,14 +163,21 @@ pub unsafe extern "C" fn dash_sdk_sync_address_balances_with_result(
         })
     };
 
+    // Convert timestamp: 0 means no previous sync (full scan)
+    let last_sync_ts = if last_sync_timestamp == 0 {
+        None
+    } else {
+        Some(last_sync_timestamp)
+    };
+
     // Create the callback-based provider wrapper
     let mut callback_provider = CallbackAddressProvider::new(provider_ffi);
 
-    // Execute the sync (pass None for last_sync_timestamp — FFI caller doesn't provide it yet)
+    // Execute the sync
     let result = wrapper.runtime.block_on(async {
         wrapper
             .sdk
-            .sync_address_balances(&mut callback_provider, rust_config, None)
+            .sync_address_balances(&mut callback_provider, rust_config, last_sync_ts)
             .await
     });
 
@@ -226,6 +254,7 @@ fn convert_sync_result(result: AddressSyncResult) -> DashSDKAddressSyncResult {
         absent_count,
         highest_found_index: result.highest_found_index.unwrap_or(u32::MAX),
         has_highest_found_index: result.highest_found_index.is_some(),
+        new_sync_height: result.new_sync_height,
         metrics,
     }
 }

--- a/packages/rs-sdk-ffi/src/address_sync/mod.rs
+++ b/packages/rs-sdk-ffi/src/address_sync/mod.rs
@@ -57,6 +57,7 @@ pub unsafe extern "C" fn dash_sdk_sync_address_balances(
             min_privacy_count: (*config).min_privacy_count,
             max_concurrent_requests: (*config).max_concurrent_requests as usize,
             max_iterations: (*config).max_iterations as usize,
+            full_rescan_after_time_s: (*config).full_rescan_after_time_s,
             request_settings: RequestSettings::default(),
         })
     };
@@ -69,11 +70,11 @@ pub unsafe extern "C" fn dash_sdk_sync_address_balances(
     // Create the callback-based provider wrapper
     let mut callback_provider = CallbackAddressProvider::new(provider_ffi);
 
-    // Execute the sync
+    // Execute the sync (pass None for last_sync_timestamp — FFI caller doesn't provide it yet)
     let result = wrapper.runtime.block_on(async {
         wrapper
             .sdk
-            .sync_address_balances(&mut callback_provider, rust_config)
+            .sync_address_balances(&mut callback_provider, rust_config, None)
             .await
     });
 
@@ -136,6 +137,7 @@ pub unsafe extern "C" fn dash_sdk_sync_address_balances_with_result(
             min_privacy_count: (*config).min_privacy_count,
             max_concurrent_requests: (*config).max_concurrent_requests as usize,
             max_iterations: (*config).max_iterations as usize,
+            full_rescan_after_time_s: (*config).full_rescan_after_time_s,
             request_settings: RequestSettings::default(),
         })
     };
@@ -143,11 +145,11 @@ pub unsafe extern "C" fn dash_sdk_sync_address_balances_with_result(
     // Create the callback-based provider wrapper
     let mut callback_provider = CallbackAddressProvider::new(provider_ffi);
 
-    // Execute the sync
+    // Execute the sync (pass None for last_sync_timestamp — FFI caller doesn't provide it yet)
     let result = wrapper.runtime.block_on(async {
         wrapper
             .sdk
-            .sync_address_balances(&mut callback_provider, rust_config)
+            .sync_address_balances(&mut callback_provider, rust_config, None)
             .await
     });
 

--- a/packages/rs-sdk-ffi/src/address_sync/mod.rs
+++ b/packages/rs-sdk-ffi/src/address_sync/mod.rs
@@ -399,6 +399,7 @@ mod tests {
         assert_eq!(config.min_privacy_count, 32);
         assert_eq!(config.max_concurrent_requests, 10);
         assert_eq!(config.max_iterations, 50);
+        assert_eq!(config.full_rescan_after_time_s, 7 * 24 * 60 * 60);
     }
 
     #[test]

--- a/packages/rs-sdk-ffi/src/address_sync/types.rs
+++ b/packages/rs-sdk-ffi/src/address_sync/types.rs
@@ -134,10 +134,15 @@ pub struct DashSDKAddressSyncResult {
 
     /// The new sync height to store for the next incremental sync.
     ///
-    /// The caller should save this value alongside the current timestamp.
-    /// On the next call, pass the saved timestamp as `last_sync_timestamp`
-    /// and return this height from the provider's `last_sync_height()`.
+    /// Return this value from the provider's `last_sync_height()` on the
+    /// next call.
     pub new_sync_height: u64,
+
+    /// Platform block time (Unix seconds) at the point of the latest response.
+    ///
+    /// Pass this value as `last_sync_timestamp` on the next call to
+    /// `dash_sdk_sync_address_balances`.
+    pub new_sync_timestamp: u64,
 
     /// Metrics about the sync process
     pub metrics: DashSDKAddressSyncMetrics,

--- a/packages/rs-sdk-ffi/src/address_sync/types.rs
+++ b/packages/rs-sdk-ffi/src/address_sync/types.rs
@@ -56,7 +56,7 @@ impl Default for DashSDKAddressSyncConfig {
 #[repr(C)]
 #[derive(Debug, Clone, Copy, Default)]
 pub struct DashSDKAddressSyncMetrics {
-    /// Number of trunk queries (always 1 for a successful sync)
+    /// Number of trunk queries (0 for incremental-only, 1 for full scan)
     pub trunk_queries: u32,
 
     /// Number of branch queries

--- a/packages/rs-sdk-ffi/src/address_sync/types.rs
+++ b/packages/rs-sdk-ffi/src/address_sync/types.rs
@@ -28,6 +28,17 @@ pub struct DashSDKAddressSyncConfig {
     ///
     /// Default: 50
     pub max_iterations: u32,
+
+    /// Maximum age in seconds before a full tree rescan is forced.
+    ///
+    /// When `last_sync_timestamp` is provided, elapsed time is compared against
+    /// this threshold. If exceeded, a full tree rescan is performed instead of
+    /// incremental-only catch-up.
+    ///
+    /// Set to 0 to always do a full tree scan.
+    ///
+    /// Default: 604800 (7 days)
+    pub full_rescan_after_time_s: u64,
 }
 
 impl Default for DashSDKAddressSyncConfig {
@@ -36,6 +47,7 @@ impl Default for DashSDKAddressSyncConfig {
             min_privacy_count: 32,
             max_concurrent_requests: 10,
             max_iterations: 50,
+            full_rescan_after_time_s: 7 * 24 * 60 * 60,
         }
     }
 }

--- a/packages/rs-sdk-ffi/src/address_sync/types.rs
+++ b/packages/rs-sdk-ffi/src/address_sync/types.rs
@@ -132,6 +132,13 @@ pub struct DashSDKAddressSyncResult {
     /// Whether highest_found_index is valid
     pub has_highest_found_index: bool,
 
+    /// The new sync height to store for the next incremental sync.
+    ///
+    /// The caller should save this value alongside the current timestamp.
+    /// On the next call, pass the saved timestamp as `last_sync_timestamp`
+    /// and return this height from the provider's `last_sync_height()`.
+    pub new_sync_height: u64,
+
     /// Metrics about the sync process
     pub metrics: DashSDKAddressSyncMetrics,
 }

--- a/packages/rs-sdk/src/platform/address_sync/mod.rs
+++ b/packages/rs-sdk/src/platform/address_sync/mod.rs
@@ -1,43 +1,44 @@
-//! Address balance synchronization using trunk/branch chunk queries.
+//! Address balance synchronization using trunk/branch chunk queries with
+//! incremental catch-up.
 //!
 //! This module provides privacy-preserving address balance synchronization for wallets.
-//! It uses an iterative query process that fetches chunks of the address tree rather than
-//! individual addresses, providing privacy by making it unclear which specific addresses
-//! are being queried.
+//! It combines two strategies:
 //!
-//! # Query Strategy
+//! 1. **Tree scan** (trunk/branch): Privacy-preserving bulk query of the address tree.
+//!    Used for initial sync or when the last sync is stale.
 //!
-//! 1. **Trunk Query**: Gets the top N levels of the address tree, returning
-//!    elements (addresses with balances) and leaf keys with their expected hashes.
+//! 2. **Incremental catch-up** (compacted + recent blocks): Fetches balance changes
+//!    block-by-block from a known height to chain tip. Fast for frequent re-syncs.
 //!
-//! 2. **Branch Queries**: For keys not found in trunk, trace through the tree
-//!    structure to find which leaf subtree contains each target key, then query
-//!    only those specific branches.
+//! # Sync Modes
 //!
-//! # Privacy Considerations
+//! The behavior depends on [`AddressSyncConfig::last_sync_height`]:
 //!
-//! The module ensures that result sets are sufficiently large to provide privacy.
-//! When a subtree is too small (fewer elements than `min_privacy_count`), the query
-//! is redirected to an ancestor subtree with sufficient elements.
+//! - **`None` or `Some(0)`** — Full tree scan, then incremental catch-up from
+//!   the tree snapshot to chain tip.
+//! - **`Some(height)`** — Incremental-only from that height (unless the height
+//!   is too old per `full_rescan_after_time_s`, in which case a full scan runs).
 //!
 //! # Example
 //!
 //! ```rust,ignore
-//! use dash_sdk::{Sdk, platform::address_sync::{AddressProvider, sync_address_balances}};
+//! use dash_sdk::{Sdk, platform::address_sync::{AddressProvider, AddressSyncConfig}};
 //!
-//! // Implement AddressProvider for your wallet type
-//! struct MyWallet { /* ... */ }
-//! impl AddressProvider for MyWallet { /* ... */ }
-//!
-//! let mut wallet = MyWallet::new();
+//! // First sync — full tree scan + catch-up
 //! let result = sdk.sync_address_balances(&mut wallet, None).await?;
+//! let saved_height = result.new_sync_height;
 //!
-//! println!("Found {} addresses with balances", result.found.len());
-//! println!("Proved {} addresses absent", result.absent.len());
+//! // Subsequent sync — incremental only
+//! let config = AddressSyncConfig {
+//!     last_sync_height: Some(saved_height),
+//!     ..Default::default()
+//! };
+//! let result = sdk.sync_address_balances(&mut wallet, Some(config)).await?;
+//! let saved_height = result.new_sync_height; // store for next time
 //! ```
 
 mod provider;
-mod tracker;
+pub(crate) mod tracker;
 mod types;
 
 pub use provider::AddressProvider;
@@ -52,8 +53,11 @@ use crate::sync::retry;
 use crate::Sdk;
 use dapi_grpc::platform::v0::{
     get_addresses_branch_state_request, get_addresses_branch_state_response,
-    GetAddressesBranchStateRequest,
+    get_recent_address_balance_changes_request,
+    get_recent_compacted_address_balance_changes_request, GetAddressesBranchStateRequest,
+    GetRecentAddressBalanceChangesRequest, GetRecentCompactedAddressBalanceChangesRequest,
 };
+use dpp::balances::credits::{BlockAwareCreditOperation, CreditOperation};
 use dpp::prelude::AddressNonce;
 use dpp::version::PlatformVersion;
 use drive::drive::Drive;
@@ -61,7 +65,9 @@ use drive::grovedb::{
     calculate_max_tree_depth_from_count, Element, GroveBranchQueryResult, GroveTrunkQueryResult,
     LeafInfo,
 };
-use drive_proof_verifier::types::PlatformAddressTrunkState;
+use drive_proof_verifier::types::{
+    PlatformAddressTrunkState, RecentAddressBalanceChanges, RecentCompactedAddressBalanceChanges,
+};
 use futures::stream::{FuturesUnordered, StreamExt};
 use rs_dapi_client::{
     DapiRequest, ExecutionError, ExecutionResponse, InnerInto, IntoInner, RequestSettings,
@@ -70,11 +76,15 @@ use std::collections::{BTreeSet, HashMap};
 use tracing::{debug, trace, warn};
 use tracker::KeyLeafTracker;
 
-/// Synchronize address balances using trunk/branch chunk queries.
+/// Server limit for compacted address balance changes per request.
+const COMPACTED_BATCH_LIMIT: usize = 25;
+/// Server limit for recent address balance changes per request.
+const RECENT_BATCH_LIMIT: usize = 100;
+
+/// Synchronize address balances using trunk/branch chunk queries with
+/// incremental block-based catch-up.
 ///
-/// This function discovers address balances for addresses supplied by the provider,
-/// using privacy-preserving chunk queries. It supports HD wallet gap limit behavior
-/// where finding a used address extends the search range.
+/// See [module docs](self) for full description of sync modes.
 ///
 /// # Arguments
 /// - `sdk`: The SDK instance for making network requests.
@@ -82,20 +92,9 @@ use tracker::KeyLeafTracker;
 /// - `config`: Optional configuration; uses defaults if `None`.
 ///
 /// # Returns
-/// - `Ok(AddressSyncResult)`: Contains found addresses with balances/nonces and absent addresses.
+/// - `Ok(AddressSyncResult)`: Contains found addresses with balances/nonces and absent addresses,
+///   plus `new_sync_height` to pass back on the next call.
 /// - `Err(Error)`: If the sync fails after exhausting retries.
-///
-/// # Example
-///
-/// ```rust,ignore
-/// use dash_sdk::platform::address_sync::{sync_address_balances, AddressSyncConfig};
-///
-/// let config = AddressSyncConfig {
-///     min_privacy_count: 64,  // Require larger result sets for more privacy
-///     ..Default::default()
-/// };
-/// let result = sync_address_balances(&sdk, &mut wallet, Some(config)).await?;
-/// ```
 pub async fn sync_address_balances<P: AddressProvider>(
     sdk: &Sdk,
     provider: &mut P,
@@ -118,6 +117,76 @@ pub async fn sync_address_balances<P: AddressProvider>(
         return Ok(result);
     }
 
+    // Decide whether to do a full tree scan or incremental-only
+    let incremental_start = match config.last_sync_height {
+        Some(height) if height > 0 => {
+            if config.full_rescan_after_time_s > 0 {
+                // TODO: could probe chain tip timestamp here to compare
+                // For now, if full_rescan_after_time_s > 0, always do full scan
+                // (the caller can set full_rescan_after_time_s = 0 to skip this)
+                None
+            } else {
+                // Always do incremental when height is provided and threshold is 0
+                Some(height)
+            }
+        }
+        _ => None,
+    };
+
+    let catch_up_from = if let Some(start_height) = incremental_start {
+        // Incremental-only mode — skip the tree scan, seed result from current_balances
+        debug!(
+            "Address sync: incremental-only from height {}",
+            start_height
+        );
+        for (index, key, funds) in provider.current_balances() {
+            result.found.insert((index, key), funds);
+        }
+        start_height
+    } else {
+        // Full tree scan
+        let scan_height = full_tree_scan(
+            sdk,
+            &config,
+            provider,
+            &mut key_to_index,
+            &mut result,
+            platform_version,
+        )
+        .await?;
+        scan_height
+    };
+
+    // Incremental catch-up from catch_up_from to chain tip
+    incremental_catch_up(
+        sdk,
+        &key_to_index,
+        catch_up_from,
+        provider,
+        &mut result,
+        config.request_settings,
+    )
+    .await?;
+
+    // Set highest found index from provider
+    result.highest_found_index = provider.highest_found_index();
+
+    Ok(result)
+}
+
+// ── Full tree scan ───────────────────────────────────────────────────
+
+/// Perform the full trunk/branch tree scan.
+///
+/// Returns the checkpoint height from the trunk query.
+async fn full_tree_scan<P: AddressProvider>(
+    sdk: &Sdk,
+    config: &AddressSyncConfig,
+    provider: &mut P,
+    key_to_index: &mut HashMap<AddressKey, AddressIndex>,
+    result: &mut AddressSyncResult,
+    platform_version: &PlatformVersion,
+) -> Result<u64, Error> {
     // Step 1: Execute trunk query
     let (trunk_result, checkpoint_height) =
         execute_trunk_query(sdk, config.request_settings, &mut result.metrics).await?;
@@ -131,7 +200,7 @@ pub async fn sync_address_balances<P: AddressProvider>(
 
     // Step 2: Process trunk result
     let mut tracker = KeyLeafTracker::new();
-    process_trunk_result(&trunk_result, provider, &mut result, &mut tracker)?;
+    process_trunk_result(&trunk_result, provider, result, &mut tracker)?;
 
     // Step 3: Iterative branch queries
     let min_query_depth = platform_version
@@ -188,8 +257,8 @@ pub async fn sync_address_balances<P: AddressProvider>(
                 &branch_result,
                 &leaf_key,
                 provider,
-                &key_to_index,
-                &mut result,
+                key_to_index,
+                result,
                 &mut tracker,
             )?;
         }
@@ -199,7 +268,6 @@ pub async fn sync_address_balances<P: AddressProvider>(
             if !key_to_index.contains_key(&key) {
                 key_to_index.insert(key.clone(), index);
                 // New key needs to be traced - it will be picked up in next iteration
-                // For now, trace it using the trunk result if possible
                 if let Some((leaf_key, info)) = trunk_result.trace_key_to_leaf(&key) {
                     tracker.add_key(key, leaf_key, info);
                 }
@@ -215,11 +283,212 @@ pub async fn sync_address_balances<P: AddressProvider>(
         );
     }
 
-    // Set highest found index from provider
-    result.highest_found_index = provider.highest_found_index();
-
-    Ok(result)
+    Ok(checkpoint_height)
 }
+
+// ── Incremental catch-up ─────────────────────────────────────────────
+
+/// Perform incremental block-based catch-up using compacted + recent address
+/// balance changes RPCs.
+///
+/// Updates `result.found` with new balance values and sets `result.new_sync_height`.
+async fn incremental_catch_up<P: AddressProvider>(
+    sdk: &Sdk,
+    key_to_index: &HashMap<AddressKey, AddressIndex>,
+    start_height: u64,
+    provider: &mut P,
+    result: &mut AddressSyncResult,
+    settings: RequestSettings,
+) -> Result<(), Error> {
+    // Build a reverse lookup from PlatformAddress bytes to (index, key) for
+    // efficient matching against change entries.
+    let address_key_lookup: HashMap<Vec<u8>, (AddressIndex, AddressKey)> = key_to_index
+        .iter()
+        .map(|(key, &index)| (key.clone(), (index, key.clone())))
+        .collect();
+
+    let mut current_height = start_height;
+    let mut had_successful_query = false;
+
+    // Phase 1 — Compacted (historical) catch-up
+    loop {
+        let request = GetRecentCompactedAddressBalanceChangesRequest {
+            version: Some(
+                get_recent_compacted_address_balance_changes_request::Version::V0(
+                    get_recent_compacted_address_balance_changes_request::GetRecentCompactedAddressBalanceChangesRequestV0 {
+                        start_block_height: current_height,
+                        prove: true,
+                    },
+                ),
+            ),
+        };
+
+        let changes: Option<RecentCompactedAddressBalanceChanges> =
+            match RecentCompactedAddressBalanceChanges::fetch_with_settings(sdk, request, settings)
+                .await
+            {
+                Ok(changes) => changes,
+                Err(e) if !had_successful_query => {
+                    // First query failed — server may not support incremental
+                    // RPCs or may not have data for this height. Treat as
+                    // "no incremental data available" rather than hard error.
+                    debug!(
+                        "Compacted address balance changes query failed (non-fatal): {}",
+                        e
+                    );
+                    break;
+                }
+                Err(e) => return Err(e),
+            };
+
+        let entries = match changes {
+            Some(c) => c.into_inner(),
+            None => break,
+        };
+
+        if entries.is_empty() {
+            break;
+        }
+
+        let entry_count = entries.len();
+        result.metrics.compacted_queries += 1;
+        had_successful_query = true;
+
+        for entry in &entries {
+            for (platform_addr, credit_op) in &entry.changes {
+                let addr_bytes = platform_addr.to_bytes();
+                if let Some((index, key)) = address_key_lookup.get(&addr_bytes) {
+                    let current_balance = result
+                        .found
+                        .get(&(*index, key.clone()))
+                        .map(|f| f.balance)
+                        .unwrap_or(0);
+
+                    let new_balance = match credit_op {
+                        BlockAwareCreditOperation::SetCredits(credits) => *credits,
+                        BlockAwareCreditOperation::AddToCreditsOperations(operations) => {
+                            let total_to_add: u64 = operations
+                                .iter()
+                                .filter(|(height, _)| **height >= current_height)
+                                .map(|(_, credits)| *credits)
+                                .sum();
+                            current_balance.saturating_add(total_to_add)
+                        }
+                    };
+
+                    if new_balance != current_balance {
+                        let nonce = result
+                            .found
+                            .get(&(*index, key.clone()))
+                            .map(|f| f.nonce)
+                            .unwrap_or(0);
+                        let funds = AddressFunds {
+                            nonce,
+                            balance: new_balance,
+                        };
+                        result.found.insert((*index, key.clone()), funds);
+                        provider.on_address_found(*index, key, funds);
+                    }
+                }
+            }
+
+            if entry.end_block_height + 1 > current_height {
+                current_height = entry.end_block_height + 1;
+            }
+        }
+
+        if entry_count < COMPACTED_BATCH_LIMIT {
+            break;
+        }
+    }
+
+    // Phase 2 — Recent (per-block) changes
+    loop {
+        let request = GetRecentAddressBalanceChangesRequest {
+            version: Some(
+                get_recent_address_balance_changes_request::Version::V0(
+                    get_recent_address_balance_changes_request::GetRecentAddressBalanceChangesRequestV0 {
+                        start_height: current_height,
+                        prove: true,
+                    },
+                ),
+            ),
+        };
+
+        let changes: Option<RecentAddressBalanceChanges> =
+            match RecentAddressBalanceChanges::fetch_with_settings(sdk, request, settings).await {
+                Ok(changes) => changes,
+                Err(e) if !had_successful_query => {
+                    debug!(
+                        "Recent address balance changes query failed (non-fatal): {}",
+                        e
+                    );
+                    break;
+                }
+                Err(e) => return Err(e),
+            };
+
+        let entries = match changes {
+            Some(c) => c.into_inner(),
+            None => break,
+        };
+
+        if entries.is_empty() {
+            break;
+        }
+
+        let entry_count = entries.len();
+        result.metrics.recent_queries += 1;
+        had_successful_query = true;
+
+        for entry in &entries {
+            for (platform_addr, credit_op) in &entry.changes {
+                let addr_bytes = platform_addr.to_bytes();
+                if let Some((index, key)) = address_key_lookup.get(&addr_bytes) {
+                    let current_balance = result
+                        .found
+                        .get(&(*index, key.clone()))
+                        .map(|f| f.balance)
+                        .unwrap_or(0);
+
+                    let new_balance = match credit_op {
+                        CreditOperation::SetCredits(credits) => *credits,
+                        CreditOperation::AddToCredits(credits) => {
+                            current_balance.saturating_add(*credits)
+                        }
+                    };
+
+                    if new_balance != current_balance {
+                        let nonce = result
+                            .found
+                            .get(&(*index, key.clone()))
+                            .map(|f| f.nonce)
+                            .unwrap_or(0);
+                        let funds = AddressFunds {
+                            nonce,
+                            balance: new_balance,
+                        };
+                        result.found.insert((*index, key.clone()), funds);
+                        provider.on_address_found(*index, key, funds);
+                    }
+                }
+            }
+
+            if entry.block_height + 1 > current_height {
+                current_height = entry.block_height + 1;
+            }
+        }
+
+        if entry_count < RECENT_BATCH_LIMIT {
+            break;
+        }
+    }
+
+    result.new_sync_height = current_height;
+    Ok(())
+}
+
+// ── Tree scan helpers ────────────────────────────────────────────────
 
 /// Execute the trunk query and return the verified result.
 async fn execute_trunk_query(
@@ -532,12 +801,20 @@ impl TryFrom<&Element> for AddressFunds {
 
 // SDK integration impl
 impl Sdk {
-    /// Synchronize address balances using privacy-preserving trunk/branch chunk queries.
+    /// Synchronize address balances using privacy-preserving trunk/branch chunk
+    /// queries with incremental block-based catch-up.
     ///
     /// This method discovers address balances for addresses supplied by the provider,
     /// using an iterative query process that fetches chunks of the address tree rather
     /// than individual addresses. This provides privacy by making it unclear which
     /// specific addresses are being queried.
+    ///
+    /// After the tree scan, incremental catch-up fetches balance changes from the
+    /// checkpoint height to chain tip so the result is as fresh as possible.
+    ///
+    /// On subsequent calls, pass [`AddressSyncResult::new_sync_height`] back via
+    /// [`AddressSyncConfig::last_sync_height`] to skip the tree scan and only
+    /// fetch incremental changes.
     ///
     /// # Arguments
     /// - `provider`: An implementation of [`AddressProvider`] that supplies addresses
@@ -553,22 +830,16 @@ impl Sdk {
     /// ```rust,ignore
     /// use dash_sdk::{Sdk, platform::address_sync::{AddressProvider, AddressSyncConfig}};
     ///
-    /// // Implement AddressProvider for your wallet type
-    /// struct MyWallet { /* ... */ }
-    /// impl AddressProvider for MyWallet { /* ... */ }
+    /// // First sync — full tree scan + catch-up
+    /// let result = sdk.sync_address_balances(&mut wallet, None).await?;
+    /// let saved_height = result.new_sync_height;
     ///
-    /// let sdk = Sdk::new(/* ... */);
-    /// let mut wallet = MyWallet::new();
-    ///
+    /// // Subsequent sync — incremental only
     /// let config = AddressSyncConfig {
-    ///     min_privacy_count: 64,
+    ///     last_sync_height: Some(saved_height),
     ///     ..Default::default()
     /// };
-    ///
     /// let result = sdk.sync_address_balances(&mut wallet, Some(config)).await?;
-    /// println!("Found {} addresses with {} total balance",
-    ///     result.found.len(),
-    ///     result.total_balance());
     /// ```
     pub async fn sync_address_balances<P: AddressProvider>(
         &self,
@@ -593,5 +864,31 @@ mod tests {
         let item = Element::Item(vec![1, 2, 3], None);
         let err = AddressFunds::try_from(&item).unwrap_err();
         assert!(matches!(err, Error::InvalidProvedResponse(_)));
+    }
+
+    #[test]
+    fn test_default_config_has_no_last_sync_height() {
+        let config = AddressSyncConfig::default();
+        assert!(config.last_sync_height.is_none());
+        assert_eq!(config.full_rescan_after_time_s, 0);
+    }
+
+    #[test]
+    fn test_default_result_has_zero_new_sync_height() {
+        let result = AddressSyncResult::new();
+        assert_eq!(result.new_sync_height, 0);
+        assert_eq!(result.checkpoint_height, 0);
+    }
+
+    #[test]
+    fn test_metrics_total_includes_incremental() {
+        let metrics = AddressSyncMetrics {
+            trunk_queries: 1,
+            branch_queries: 3,
+            compacted_queries: 2,
+            recent_queries: 1,
+            ..Default::default()
+        };
+        assert_eq!(metrics.total_queries(), 7);
     }
 }

--- a/packages/rs-sdk/src/platform/address_sync/mod.rs
+++ b/packages/rs-sdk/src/platform/address_sync/mod.rs
@@ -12,12 +12,15 @@
 //!
 //! # Sync Modes
 //!
-//! The behavior depends on [`AddressSyncConfig::last_sync_height`]:
+//! The behavior depends on the `last_sync_timestamp` parameter passed to
+//! [`sync_address_balances`]:
 //!
-//! - **`None` or `Some(0)`** — Full tree scan, then incremental catch-up from
-//!   the tree snapshot to chain tip.
-//! - **`Some(height)`** — Incremental-only from that height (unless the height
-//!   is too old per `full_rescan_after_time_s`, in which case a full scan runs).
+//! - **`None`** — Full tree scan, then incremental catch-up from the tree
+//!   snapshot to chain tip.
+//! - **`Some(timestamp)`** — Incremental-only from
+//!   [`AddressProvider::last_sync_height`] (unless the elapsed time exceeds
+//!   [`AddressSyncConfig::full_rescan_after_time_s`], in which case a full
+//!   scan runs).
 //!
 //! # Example
 //!

--- a/packages/rs-sdk/src/platform/address_sync/mod.rs
+++ b/packages/rs-sdk/src/platform/address_sync/mod.rs
@@ -25,16 +25,14 @@
 //! use dash_sdk::{Sdk, platform::address_sync::{AddressProvider, AddressSyncConfig}};
 //!
 //! // First sync — full tree scan + catch-up
-//! let result = sdk.sync_address_balances(&mut wallet, None).await?;
-//! let saved_height = result.new_sync_height;
+//! let result = sdk.sync_address_balances(&mut wallet, None, None).await?;
+//! let saved_timestamp = std::time::SystemTime::now()
+//!     .duration_since(std::time::UNIX_EPOCH).unwrap().as_secs();
 //!
-//! // Subsequent sync — incremental only
-//! let config = AddressSyncConfig {
-//!     last_sync_height: Some(saved_height),
-//!     ..Default::default()
-//! };
-//! let result = sdk.sync_address_balances(&mut wallet, Some(config)).await?;
-//! let saved_height = result.new_sync_height; // store for next time
+//! // Subsequent sync — incremental only (unless too old per full_rescan_after_time_s)
+//! let result = sdk.sync_address_balances(&mut wallet, None, Some(saved_timestamp)).await?;
+//! let saved_timestamp = std::time::SystemTime::now()
+//!     .duration_since(std::time::UNIX_EPOCH).unwrap().as_secs();
 //! ```
 
 mod provider;
@@ -90,6 +88,12 @@ const RECENT_BATCH_LIMIT: usize = 100;
 /// - `sdk`: The SDK instance for making network requests.
 /// - `provider`: An implementation of [`AddressProvider`] that supplies addresses.
 /// - `config`: Optional configuration; uses defaults if `None`.
+/// - `last_sync_timestamp`: Optional Unix timestamp (seconds) of the last successful
+///   sync. When provided together with a non-zero
+///   [`full_rescan_after_time_s`](AddressSyncConfig::full_rescan_after_time_s), the
+///   function compares `now - last_sync_timestamp` to decide whether a full tree
+///   rescan is needed or incremental-only catch-up suffices.
+///   Pass `None` to always perform a full tree scan.
 ///
 /// # Returns
 /// - `Ok(AddressSyncResult)`: Contains found addresses with balances/nonces and absent addresses,
@@ -99,6 +103,7 @@ pub async fn sync_address_balances<P: AddressProvider>(
     sdk: &Sdk,
     provider: &mut P,
     config: Option<AddressSyncConfig>,
+    last_sync_timestamp: Option<u64>,
 ) -> Result<AddressSyncResult, Error> {
     let config = config.unwrap_or_default();
     let platform_version = sdk.version();
@@ -117,24 +122,35 @@ pub async fn sync_address_balances<P: AddressProvider>(
         return Ok(result);
     }
 
-    // Decide whether to do a full tree scan or incremental-only
-    let incremental_start = match config.last_sync_height {
-        Some(height) if height > 0 => {
-            if config.full_rescan_after_time_s > 0 {
-                // TODO: could probe chain tip timestamp here to compare
-                // For now, if full_rescan_after_time_s > 0, always do full scan
-                // (the caller can set full_rescan_after_time_s = 0 to skip this)
-                None
+    // Decide whether to do a full tree scan or incremental-only.
+    //
+    // Incremental-only is chosen when ALL of these are true:
+    //   1. last_sync_timestamp is provided
+    //   2. full_rescan_after_time_s > 0
+    //   3. elapsed time since last sync < full_rescan_after_time_s
+    let needs_full_scan = match last_sync_timestamp {
+        Some(last_ts) if config.full_rescan_after_time_s > 0 => {
+            let now_secs = std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .map(|d| d.as_secs())
+                .unwrap_or(0);
+            let elapsed = now_secs.saturating_sub(last_ts);
+            if elapsed >= config.full_rescan_after_time_s {
+                debug!(
+                    "Address sync: full rescan needed (elapsed {}s >= threshold {}s)",
+                    elapsed, config.full_rescan_after_time_s
+                );
+                true
             } else {
-                // Always do incremental when height is provided and threshold is 0
-                Some(height)
+                false
             }
         }
-        _ => None,
+        _ => true,
     };
 
-    let catch_up_from = if let Some(start_height) = incremental_start {
+    let catch_up_from = if !needs_full_scan {
         // Incremental-only mode — skip the tree scan, seed result from current_balances
+        let start_height = provider.last_sync_height();
         debug!(
             "Address sync: incremental-only from height {}",
             start_height
@@ -812,14 +828,18 @@ impl Sdk {
     /// After the tree scan, incremental catch-up fetches balance changes from the
     /// checkpoint height to chain tip so the result is as fresh as possible.
     ///
-    /// On subsequent calls, pass [`AddressSyncResult::new_sync_height`] back via
-    /// [`AddressSyncConfig::last_sync_height`] to skip the tree scan and only
-    /// fetch incremental changes.
+    /// On subsequent calls, pass the current timestamp as `last_sync_timestamp` so
+    /// the function can decide whether a full tree rescan is needed or incremental-
+    /// only catch-up suffices. The provider should implement
+    /// [`AddressProvider::last_sync_height`] and [`AddressProvider::current_balances`]
+    /// to supply the state from the previous sync.
     ///
     /// # Arguments
     /// - `provider`: An implementation of [`AddressProvider`] that supplies addresses
     ///   and handles callbacks when addresses are found or proven absent.
     /// - `config`: Optional configuration; uses defaults if `None`.
+    /// - `last_sync_timestamp`: Optional Unix timestamp (seconds) of the last
+    ///   successful sync. Pass `None` to always perform a full tree scan.
     ///
     /// # Returns
     /// - `Ok(AddressSyncResult)`: Contains found addresses with balances/nonces and absent addresses.
@@ -830,23 +850,22 @@ impl Sdk {
     /// ```rust,ignore
     /// use dash_sdk::{Sdk, platform::address_sync::{AddressProvider, AddressSyncConfig}};
     ///
-    /// // First sync — full tree scan + catch-up
-    /// let result = sdk.sync_address_balances(&mut wallet, None).await?;
+    /// // First sync — full tree scan + catch-up (no timestamp)
+    /// let result = sdk.sync_address_balances(&mut wallet, None, None).await?;
     /// let saved_height = result.new_sync_height;
+    /// let saved_timestamp = now_secs(); // store current time
     ///
-    /// // Subsequent sync — incremental only
-    /// let config = AddressSyncConfig {
-    ///     last_sync_height: Some(saved_height),
-    ///     ..Default::default()
-    /// };
-    /// let result = sdk.sync_address_balances(&mut wallet, Some(config)).await?;
+    /// // Subsequent sync — incremental only if within threshold
+    /// // (provider returns saved_height from last_sync_height())
+    /// let result = sdk.sync_address_balances(&mut wallet, None, Some(saved_timestamp)).await?;
     /// ```
     pub async fn sync_address_balances<P: AddressProvider>(
         &self,
         provider: &mut P,
         config: Option<AddressSyncConfig>,
+        last_sync_timestamp: Option<u64>,
     ) -> Result<AddressSyncResult, Error> {
-        sync_address_balances(self, provider, config).await
+        sync_address_balances(self, provider, config, last_sync_timestamp).await
     }
 }
 
@@ -867,10 +886,11 @@ mod tests {
     }
 
     #[test]
-    fn test_default_config_has_no_last_sync_height() {
+    fn test_default_config_values() {
         let config = AddressSyncConfig::default();
-        assert!(config.last_sync_height.is_none());
-        assert_eq!(config.full_rescan_after_time_s, 0);
+        assert_eq!(config.full_rescan_after_time_s, 7 * 24 * 60 * 60);
+        assert_eq!(config.min_privacy_count, 32);
+        assert_eq!(config.max_iterations, 50);
     }
 
     #[test]

--- a/packages/rs-sdk/src/platform/address_sync/mod.rs
+++ b/packages/rs-sdk/src/platform/address_sync/mod.rs
@@ -26,13 +26,13 @@
 //!
 //! // First sync — full tree scan + catch-up
 //! let result = sdk.sync_address_balances(&mut wallet, None, None).await?;
-//! let saved_timestamp = std::time::SystemTime::now()
-//!     .duration_since(std::time::UNIX_EPOCH).unwrap().as_secs();
+//! let saved_height = result.new_sync_height;       // store for provider.last_sync_height()
+//! let saved_timestamp = result.new_sync_timestamp;  // store for last_sync_timestamp param
 //!
 //! // Subsequent sync — incremental only (unless too old per full_rescan_after_time_s)
 //! let result = sdk.sync_address_balances(&mut wallet, None, Some(saved_timestamp)).await?;
-//! let saved_timestamp = std::time::SystemTime::now()
-//!     .duration_since(std::time::UNIX_EPOCH).unwrap().as_secs();
+//! let saved_height = result.new_sync_height;
+//! let saved_timestamp = result.new_sync_timestamp;
 //! ```
 
 mod provider;
@@ -88,16 +88,17 @@ const RECENT_BATCH_LIMIT: usize = 100;
 /// - `sdk`: The SDK instance for making network requests.
 /// - `provider`: An implementation of [`AddressProvider`] that supplies addresses.
 /// - `config`: Optional configuration; uses defaults if `None`.
-/// - `last_sync_timestamp`: Optional Unix timestamp (seconds) of the last successful
-///   sync. When provided together with a non-zero
-///   [`full_rescan_after_time_s`](AddressSyncConfig::full_rescan_after_time_s), the
-///   function compares `now - last_sync_timestamp` to decide whether a full tree
-///   rescan is needed or incremental-only catch-up suffices.
+/// - `last_sync_timestamp`: Optional block time (Unix seconds) from the previous
+///   sync's [`AddressSyncResult::new_sync_timestamp`]. When provided together
+///   with a non-zero [`full_rescan_after_time_s`](AddressSyncConfig::full_rescan_after_time_s),
+///   the function compares `now - last_sync_timestamp` to decide whether a full
+///   tree rescan is needed or incremental-only catch-up suffices.
 ///   Pass `None` to always perform a full tree scan.
 ///
 /// # Returns
-/// - `Ok(AddressSyncResult)`: Contains found addresses with balances/nonces and absent addresses,
-///   plus `new_sync_height` to pass back on the next call.
+/// - `Ok(AddressSyncResult)`: Contains found addresses with balances/nonces,
+///   absent addresses, plus `new_sync_height` and `new_sync_timestamp` to
+///   persist for the next call.
 /// - `Err(Error)`: If the sync fails after exhausting retries.
 pub async fn sync_address_balances<P: AddressProvider>(
     sdk: &Sdk,
@@ -161,7 +162,7 @@ pub async fn sync_address_balances<P: AddressProvider>(
         start_height
     } else {
         // Full tree scan
-        let scan_height = full_tree_scan(
+        let (scan_height, block_time_ms) = full_tree_scan(
             sdk,
             &config,
             provider,
@@ -170,6 +171,8 @@ pub async fn sync_address_balances<P: AddressProvider>(
             platform_version,
         )
         .await?;
+        // Seed timestamp from the trunk query (may be updated by incremental phase)
+        result.new_sync_timestamp = block_time_ms / 1000;
         scan_height
     };
 
@@ -194,7 +197,7 @@ pub async fn sync_address_balances<P: AddressProvider>(
 
 /// Perform the full trunk/branch tree scan.
 ///
-/// Returns the checkpoint height from the trunk query.
+/// Returns `(checkpoint_height, block_time_ms)` from the trunk query.
 async fn full_tree_scan<P: AddressProvider>(
     sdk: &Sdk,
     config: &AddressSyncConfig,
@@ -202,9 +205,9 @@ async fn full_tree_scan<P: AddressProvider>(
     key_to_index: &mut HashMap<AddressKey, AddressIndex>,
     result: &mut AddressSyncResult,
     platform_version: &PlatformVersion,
-) -> Result<u64, Error> {
+) -> Result<(u64, u64), Error> {
     // Step 1: Execute trunk query
-    let (trunk_result, checkpoint_height) =
+    let (trunk_result, checkpoint_height, block_time_ms) =
         execute_trunk_query(sdk, config.request_settings, &mut result.metrics).await?;
     result.checkpoint_height = checkpoint_height;
 
@@ -299,7 +302,7 @@ async fn full_tree_scan<P: AddressProvider>(
         );
     }
 
-    Ok(checkpoint_height)
+    Ok((checkpoint_height, block_time_ms))
 }
 
 // ── Incremental catch-up ─────────────────────────────────────────────
@@ -339,11 +342,15 @@ async fn incremental_catch_up<P: AddressProvider>(
             ),
         };
 
-        let changes: Option<RecentCompactedAddressBalanceChanges> =
-            match RecentCompactedAddressBalanceChanges::fetch_with_settings(sdk, request, settings)
-                .await
+        let (changes, metadata): (Option<RecentCompactedAddressBalanceChanges>, _) =
+            match RecentCompactedAddressBalanceChanges::fetch_with_metadata(
+                sdk,
+                request,
+                Some(settings),
+            )
+            .await
             {
-                Ok(changes) => changes,
+                Ok(result) => result,
                 Err(e) if !had_successful_query => {
                     // First query failed — server may not support incremental
                     // RPCs or may not have data for this height. Treat as
@@ -361,6 +368,8 @@ async fn incremental_catch_up<P: AddressProvider>(
             Some(c) => c.into_inner(),
             None => break,
         };
+
+        result.new_sync_timestamp = metadata.time_ms / 1000;
 
         if entries.is_empty() {
             break;
@@ -387,7 +396,7 @@ async fn incremental_catch_up<P: AddressProvider>(
                                 .iter()
                                 .filter(|(height, _)| **height >= current_height)
                                 .map(|(_, credits)| *credits)
-                                .sum();
+                                .fold(0u64, |acc, c| acc.saturating_add(c));
                             current_balance.saturating_add(total_to_add)
                         }
                     };
@@ -408,8 +417,8 @@ async fn incremental_catch_up<P: AddressProvider>(
                 }
             }
 
-            if entry.end_block_height + 1 > current_height {
-                current_height = entry.end_block_height + 1;
+            if entry.end_block_height.saturating_add(1) > current_height {
+                current_height = entry.end_block_height.saturating_add(1);
             }
         }
 
@@ -431,9 +440,11 @@ async fn incremental_catch_up<P: AddressProvider>(
             ),
         };
 
-        let changes: Option<RecentAddressBalanceChanges> =
-            match RecentAddressBalanceChanges::fetch_with_settings(sdk, request, settings).await {
-                Ok(changes) => changes,
+        let (changes, metadata): (Option<RecentAddressBalanceChanges>, _) =
+            match RecentAddressBalanceChanges::fetch_with_metadata(sdk, request, Some(settings))
+                .await
+            {
+                Ok(result) => result,
                 Err(e) if !had_successful_query => {
                     debug!(
                         "Recent address balance changes query failed (non-fatal): {}",
@@ -448,6 +459,8 @@ async fn incremental_catch_up<P: AddressProvider>(
             Some(c) => c.into_inner(),
             None => break,
         };
+
+        result.new_sync_timestamp = metadata.time_ms / 1000;
 
         if entries.is_empty() {
             break;
@@ -490,8 +503,8 @@ async fn incremental_catch_up<P: AddressProvider>(
                 }
             }
 
-            if entry.block_height + 1 > current_height {
-                current_height = entry.block_height + 1;
+            if entry.block_height.saturating_add(1) > current_height {
+                current_height = entry.block_height.saturating_add(1);
             }
         }
 
@@ -507,11 +520,13 @@ async fn incremental_catch_up<P: AddressProvider>(
 // ── Tree scan helpers ────────────────────────────────────────────────
 
 /// Execute the trunk query and return the verified result.
+///
+/// Returns `(trunk_result, checkpoint_height, block_time_ms)`.
 async fn execute_trunk_query(
     sdk: &Sdk,
     settings: RequestSettings,
     metrics: &mut AddressSyncMetrics,
-) -> Result<(GroveTrunkQueryResult, u64), Error> {
+) -> Result<(GroveTrunkQueryResult, u64, u64), Error> {
     let (trunk_state, metadata) =
         PlatformAddressTrunkState::fetch_with_metadata(sdk, (), Some(settings)).await?;
 
@@ -522,7 +537,7 @@ async fn execute_trunk_query(
 
     metrics.total_elements_seen += trunk_state.elements.len();
 
-    Ok((trunk_state.into_inner(), metadata.height))
+    Ok((trunk_state.into_inner(), metadata.height, metadata.time_ms))
 }
 
 /// Process the trunk query result.
@@ -828,21 +843,26 @@ impl Sdk {
     /// After the tree scan, incremental catch-up fetches balance changes from the
     /// checkpoint height to chain tip so the result is as fresh as possible.
     ///
-    /// On subsequent calls, pass the current timestamp as `last_sync_timestamp` so
-    /// the function can decide whether a full tree rescan is needed or incremental-
-    /// only catch-up suffices. The provider should implement
-    /// [`AddressProvider::last_sync_height`] and [`AddressProvider::current_balances`]
-    /// to supply the state from the previous sync.
+    /// On subsequent calls, pass [`AddressSyncResult::new_sync_timestamp`] as
+    /// `last_sync_timestamp` so the function can decide whether a full tree
+    /// rescan is needed or incremental-only catch-up suffices. The provider
+    /// should implement [`AddressProvider::last_sync_height`] (returning the
+    /// stored [`AddressSyncResult::new_sync_height`]) and
+    /// [`AddressProvider::current_balances`] to supply state from the previous
+    /// sync.
     ///
     /// # Arguments
     /// - `provider`: An implementation of [`AddressProvider`] that supplies addresses
     ///   and handles callbacks when addresses are found or proven absent.
     /// - `config`: Optional configuration; uses defaults if `None`.
-    /// - `last_sync_timestamp`: Optional Unix timestamp (seconds) of the last
-    ///   successful sync. Pass `None` to always perform a full tree scan.
+    /// - `last_sync_timestamp`: Optional block time (Unix seconds) from the
+    ///   previous sync's [`AddressSyncResult::new_sync_timestamp`].
+    ///   Pass `None` to always perform a full tree scan.
     ///
     /// # Returns
-    /// - `Ok(AddressSyncResult)`: Contains found addresses with balances/nonces and absent addresses.
+    /// - `Ok(AddressSyncResult)`: Contains found addresses with balances/nonces,
+    ///   absent addresses, `new_sync_height` and `new_sync_timestamp` to store
+    ///   for the next call.
     /// - `Err(Error)`: If the sync fails after exhausting retries.
     ///
     /// # Example
@@ -852,11 +872,10 @@ impl Sdk {
     ///
     /// // First sync — full tree scan + catch-up (no timestamp)
     /// let result = sdk.sync_address_balances(&mut wallet, None, None).await?;
-    /// let saved_height = result.new_sync_height;
-    /// let saved_timestamp = now_secs(); // store current time
+    /// let saved_height = result.new_sync_height;       // → provider.last_sync_height()
+    /// let saved_timestamp = result.new_sync_timestamp;  // → last_sync_timestamp param
     ///
     /// // Subsequent sync — incremental only if within threshold
-    /// // (provider returns saved_height from last_sync_height())
     /// let result = sdk.sync_address_balances(&mut wallet, None, Some(saved_timestamp)).await?;
     /// ```
     pub async fn sync_address_balances<P: AddressProvider>(

--- a/packages/rs-sdk/src/platform/address_sync/provider.rs
+++ b/packages/rs-sdk/src/platform/address_sync/provider.rs
@@ -106,12 +106,24 @@ pub trait AddressProvider: Send {
     ///
     /// Returns tuples of `(index, address_key, funds)` for addresses that have
     /// known state from a previous sync. This is used during incremental-only
-    /// mode (when [`AddressSyncConfig::last_sync_height`] is set) to provide
-    /// base balances for applying `AddToCredits` delta operations.
+    /// mode to provide base balances for applying `AddToCredits` delta operations.
     ///
     /// Default returns an empty list, which is appropriate for full tree scan
     /// mode where the trunk/branch queries provide absolute balance values.
     fn current_balances(&self) -> Vec<(AddressIndex, AddressKey, AddressFunds)> {
         Vec::new()
+    }
+
+    /// Get the last sync height from a previous sync.
+    ///
+    /// Returns the [`AddressSyncResult::new_sync_height`] value from the
+    /// previous call. Used as the starting block height for incremental-only
+    /// catch-up. The caller should store this value after each sync and
+    /// return it here on subsequent calls.
+    ///
+    /// Default returns `0`, which means incremental catch-up starts from
+    /// the genesis block (effectively a full catch-up).
+    fn last_sync_height(&self) -> u64 {
+        0
     }
 }

--- a/packages/rs-sdk/src/platform/address_sync/provider.rs
+++ b/packages/rs-sdk/src/platform/address_sync/provider.rs
@@ -101,4 +101,17 @@ pub trait AddressProvider: Send {
     ///
     /// Used for reporting and gap extension logic.
     fn highest_found_index(&self) -> Option<AddressIndex>;
+
+    /// Get current known balances for incremental catch-up.
+    ///
+    /// Returns tuples of `(index, address_key, funds)` for addresses that have
+    /// known state from a previous sync. This is used during incremental-only
+    /// mode (when [`AddressSyncConfig::last_sync_height`] is set) to provide
+    /// base balances for applying `AddToCredits` delta operations.
+    ///
+    /// Default returns an empty list, which is appropriate for full tree scan
+    /// mode where the trunk/branch queries provide absolute balance values.
+    fn current_balances(&self) -> Vec<(AddressIndex, AddressKey, AddressFunds)> {
+        Vec::new()
+    }
 }

--- a/packages/rs-sdk/src/platform/address_sync/provider.rs
+++ b/packages/rs-sdk/src/platform/address_sync/provider.rs
@@ -116,7 +116,7 @@ pub trait AddressProvider: Send {
 
     /// Get the last sync height from a previous sync.
     ///
-    /// Returns the [`AddressSyncResult::new_sync_height`] value from the
+    /// Returns the [`new_sync_height`](super::AddressSyncResult::new_sync_height) value from the
     /// previous call. Used as the starting block height for incremental-only
     /// catch-up. The caller should store this value after each sync and
     /// return it here on subsequent calls.

--- a/packages/rs-sdk/src/platform/address_sync/types.rs
+++ b/packages/rs-sdk/src/platform/address_sync/types.rs
@@ -53,31 +53,16 @@ pub struct AddressSyncConfig {
     /// Default: 50
     pub max_iterations: usize,
 
-    /// Last sync height from a previous call.
-    ///
-    /// - `None` or `Some(0)` — perform a full trunk/branch tree scan, then
-    ///   incremental block-based catch-up from the tree snapshot to chain tip.
-    /// - `Some(height)` — if the height is recent enough (within
-    ///   [`full_rescan_after_time_s`](Self::full_rescan_after_time_s) seconds
-    ///   of current time), skip the tree scan and only do incremental
-    ///   block-based catch-up from that height.
-    ///
-    /// The caller should store [`AddressSyncResult::new_sync_height`] after
-    /// each call and pass it back here on the next call.
-    pub last_sync_height: Option<u64>,
-
     /// Maximum age in seconds before a full tree rescan is forced.
     ///
-    /// When [`last_sync_height`](Self::last_sync_height) is provided, the
-    /// function compares elapsed time to decide whether incremental catch-up
-    /// alone is sufficient. If the gap exceeds this threshold, a full rescan
-    /// is performed instead.
+    /// When `last_sync_timestamp` is passed to [`sync_address_balances`], the
+    /// function compares `now - last_sync_timestamp` against this threshold.
+    /// If the elapsed time exceeds this value, a full tree rescan is performed
+    /// instead of incremental-only catch-up.
     ///
-    /// Set to `0` to always do incremental when a height is provided (the
-    /// caller can reset `last_sync_height` to `None` when they want a full
-    /// rescan).
+    /// Set to `0` to always do a full tree scan regardless of the timestamp.
     ///
-    /// Default: 0 (always incremental when height is provided)
+    /// Default: 604800 (7 days)
     pub full_rescan_after_time_s: u64,
 
     /// Request settings for undergoing address sync queries.
@@ -90,8 +75,7 @@ impl Default for AddressSyncConfig {
             min_privacy_count: 32,
             max_concurrent_requests: 10,
             max_iterations: 50,
-            last_sync_height: None,
-            full_rescan_after_time_s: 0,
+            full_rescan_after_time_s: 7 * 24 * 60 * 60, // 7 days
             request_settings: RequestSettings::default(),
         }
     }
@@ -124,12 +108,13 @@ pub struct AddressSyncResult {
     /// Only meaningful when a full tree scan was performed.
     pub checkpoint_height: u64,
 
-    /// The new sync height to pass back on the next call as
-    /// [`AddressSyncConfig::last_sync_height`].
+    /// The new sync height to pass back on the next call via the
+    /// `last_sync_timestamp` parameter.
     ///
     /// This is the highest block height seen from the incremental phase
     /// (or the checkpoint height if no incremental phase ran). The caller
-    /// should store this and pass it back on the next call.
+    /// should store this alongside the current timestamp, then pass them
+    /// back on the next call.
     pub new_sync_height: u64,
 }
 

--- a/packages/rs-sdk/src/platform/address_sync/types.rs
+++ b/packages/rs-sdk/src/platform/address_sync/types.rs
@@ -53,6 +53,33 @@ pub struct AddressSyncConfig {
     /// Default: 50
     pub max_iterations: usize,
 
+    /// Last sync height from a previous call.
+    ///
+    /// - `None` or `Some(0)` — perform a full trunk/branch tree scan, then
+    ///   incremental block-based catch-up from the tree snapshot to chain tip.
+    /// - `Some(height)` — if the height is recent enough (within
+    ///   [`full_rescan_after_time_s`](Self::full_rescan_after_time_s) seconds
+    ///   of current time), skip the tree scan and only do incremental
+    ///   block-based catch-up from that height.
+    ///
+    /// The caller should store [`AddressSyncResult::new_sync_height`] after
+    /// each call and pass it back here on the next call.
+    pub last_sync_height: Option<u64>,
+
+    /// Maximum age in seconds before a full tree rescan is forced.
+    ///
+    /// When [`last_sync_height`](Self::last_sync_height) is provided, the
+    /// function compares elapsed time to decide whether incremental catch-up
+    /// alone is sufficient. If the gap exceeds this threshold, a full rescan
+    /// is performed instead.
+    ///
+    /// Set to `0` to always do incremental when a height is provided (the
+    /// caller can reset `last_sync_height` to `None` when they want a full
+    /// rescan).
+    ///
+    /// Default: 0 (always incremental when height is provided)
+    pub full_rescan_after_time_s: u64,
+
     /// Request settings for undergoing address sync queries.
     pub request_settings: RequestSettings,
 }
@@ -63,6 +90,8 @@ impl Default for AddressSyncConfig {
             min_privacy_count: 32,
             max_concurrent_requests: 10,
             max_iterations: 50,
+            last_sync_height: None,
+            full_rescan_after_time_s: 0,
             request_settings: RequestSettings::default(),
         }
     }
@@ -89,11 +118,19 @@ pub struct AddressSyncResult {
     /// Metrics about the sync process.
     pub metrics: AddressSyncMetrics,
 
-    /// The checkpoint height at which balances were synced.
+    /// The checkpoint height from the trunk/branch tree scan.
     ///
-    /// This is the block height from which terminal balance updates should start
-    /// to catch any changes that occurred after the checkpoint.
+    /// This is the block height at which the tree snapshot was taken.
+    /// Only meaningful when a full tree scan was performed.
     pub checkpoint_height: u64,
+
+    /// The new sync height to pass back on the next call as
+    /// [`AddressSyncConfig::last_sync_height`].
+    ///
+    /// This is the highest block height seen from the incremental phase
+    /// (or the checkpoint height if no incremental phase ran). The caller
+    /// should store this and pass it back on the next call.
+    pub new_sync_height: u64,
 }
 
 impl AddressSyncResult {
@@ -105,6 +142,7 @@ impl AddressSyncResult {
             highest_found_index: None,
             metrics: AddressSyncMetrics::default(),
             checkpoint_height: 0,
+            new_sync_height: 0,
         }
     }
 
@@ -131,7 +169,7 @@ impl Default for AddressSyncResult {
 /// Metrics about the synchronization process.
 #[derive(Debug, Default, Clone)]
 pub struct AddressSyncMetrics {
-    /// Number of trunk queries (always 1 for a successful sync).
+    /// Number of trunk queries (0 for incremental-only, 1 for full scan).
     pub trunk_queries: usize,
 
     /// Number of branch queries.
@@ -148,12 +186,18 @@ pub struct AddressSyncMetrics {
 
     /// Number of iterations (0 = trunk only, 1+ = trunk plus branch rounds).
     pub iterations: usize,
+
+    /// Number of compacted incremental queries.
+    pub compacted_queries: usize,
+
+    /// Number of recent incremental queries.
+    pub recent_queries: usize,
 }
 
 impl AddressSyncMetrics {
-    /// Get total number of queries (trunk + branch).
+    /// Get total number of queries (trunk + branch + incremental).
     pub fn total_queries(&self) -> usize {
-        self.trunk_queries + self.branch_queries
+        self.trunk_queries + self.branch_queries + self.compacted_queries + self.recent_queries
     }
 
     /// Get average proof size in bytes.

--- a/packages/rs-sdk/src/platform/address_sync/types.rs
+++ b/packages/rs-sdk/src/platform/address_sync/types.rs
@@ -108,14 +108,22 @@ pub struct AddressSyncResult {
     /// Only meaningful when a full tree scan was performed.
     pub checkpoint_height: u64,
 
-    /// The new sync height to pass back on the next call via the
-    /// `last_sync_timestamp` parameter.
+    /// The highest block height seen from the incremental phase
+    /// (or the checkpoint height if no incremental phase ran).
     ///
-    /// This is the highest block height seen from the incremental phase
-    /// (or the checkpoint height if no incremental phase ran). The caller
-    /// should store this alongside the current timestamp, then pass them
-    /// back on the next call.
+    /// After each sync the caller should persist two values:
+    /// 1. This `new_sync_height` — return it from
+    ///    [`AddressProvider::last_sync_height`] on the next call.
+    /// 2. [`new_sync_timestamp`](Self::new_sync_timestamp) — pass it as the
+    ///    `last_sync_timestamp` parameter of [`sync_address_balances`].
     pub new_sync_height: u64,
+
+    /// Platform block time (Unix seconds) at the point of the latest response.
+    ///
+    /// Store this value and pass it back as `last_sync_timestamp` on the next
+    /// call to [`sync_address_balances`]. The function compares it against the
+    /// current wall-clock time to decide whether a full tree rescan is needed.
+    pub new_sync_timestamp: u64,
 }
 
 impl AddressSyncResult {
@@ -128,6 +136,7 @@ impl AddressSyncResult {
             metrics: AddressSyncMetrics::default(),
             checkpoint_height: 0,
             new_sync_height: 0,
+            new_sync_timestamp: 0,
         }
     }
 

--- a/packages/rs-sdk/tests/fetch/address_sync.rs
+++ b/packages/rs-sdk/tests/fetch/address_sync.rs
@@ -78,7 +78,7 @@ async fn test_sync_address_balances() {
         (2, key_unknown.clone()),
     ]);
 
-    let result = sync_address_balances(&sdk, &mut provider, None)
+    let result = sync_address_balances(&sdk, &mut provider, None, None)
         .await
         .expect("sync address balances");
 


### PR DESCRIPTION
## Issue being fixed or feature implemented
This update introduces incremental address balance synchronization to enhance the efficiency of address balance updates.

## What was done?
- Implemented a new incremental catch-up mechanism that allows for fetching balance changes block-by-block from a known height to the chain tip, reducing the need for full tree scans on subsequent syncs.
- Updated the `AddressSyncConfig` to include `last_sync_height` and `full_rescan_after_time_s` parameters, allowing for more flexible synchronization strategies.
- Modified the `sync_address_balances` function to conditionally perform either a full tree scan or incremental catch-up based on the provided configuration.
- Added new methods in the `AddressProvider` trait to support fetching current known balances during incremental syncs.

## How Has This Been Tested?
- Unit tests have been added to verify the behavior of the new incremental sync mechanism and to ensure that the default configurations are functioning as expected.

## Breaking Changes
None

## Checklist
- [ ] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have added ! to the title and described breaking changes in the corresponding section if my code contains any.

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Incremental address-balance sync with automatic catch‑up, server batch limits for compacted and recent changes, and optional full rescan (default 7 days).
  * Sync result now returns next sync height and timestamp; metrics distinguish compacted vs recent incremental queries.

* **Public API**
  * Provider interface extended to expose current balances and last sync height.
  * Public sync call and FFI bindings accept the new timestamp and config parameter.

* **Tests**
  * Added tests for defaults and incremental metrics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->