### PR TITLE
fix(dashmate): lower HP node RAM requirement to 7.3GB

### DIFF
--- a/packages/dashmate/src/doctor/verifySystemRequirementsFactory.js
+++ b/packages/dashmate/src/doctor/verifySystemRequirementsFactory.js
@@ -29,7 +29,7 @@ export default function verifySystemRequirementsFactory() {
   ) {
     const MINIMUM_CPU_CORES = isHP ? 4 : 2;
     const MINIMUM_CPU_FREQUENCY = 2.4; // GHz
-    const MINIMUM_RAM = isHP ? 8 : 4; // GB
+    const MINIMUM_RAM = isHP ? 7.3 : 4; // GB
     const MINIMUM_DISK_SPACE = overrideRequirements.diskSpace ?? (isHP ? 200 : 100); // GB
 
     const problems = [];

--- a/packages/dashmate/src/doctor/verifySystemRequirementsFactory.js
+++ b/packages/dashmate/src/doctor/verifySystemRequirementsFactory.js
@@ -29,7 +29,7 @@ export default function verifySystemRequirementsFactory() {
   ) {
     const MINIMUM_CPU_CORES = isHP ? 4 : 2;
     const MINIMUM_CPU_FREQUENCY = 2.4; // GHz
-    const MINIMUM_RAM = isHP ? 7.3 : 4; // GB
+    const MINIMUM_RAM = isHP ? 7.3 : 3.6; // GB
     const MINIMUM_DISK_SPACE = overrideRequirements.diskSpace ?? (isHP ? 200 : 100); // GB
 
     const problems = [];


### PR DESCRIPTION
Nodes with a nominal 8GB allocation typically only have ~7.6GB usable due to OS and firmware overhead, causing them to fail the system requirements check. Lower the threshold to 7.3GB to accommodate this.

<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
Nodes will give errors despite being very close to the 8GB requirements for evonodes due to variances from VM hosts. Done the same for regular masternodes (3.6GB instead of 4)


## What was done?
Lowered evonodes to 7.3GB required
Lowered masternodes to 3.6GB required

## How Has This Been Tested?
Tested on local


## Breaking Changes
None


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [ ] I have made corresponding changes to the documentation if needed

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated system memory requirements for HP and non-HP configurations to lower thresholds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->