### PR TITLE
ci(swift-sdk): add workflow permissions for PR comment posting

### DIFF
--- a/.github/workflows/swift-sdk-build.yml
+++ b/.github/workflows/swift-sdk-build.yml
@@ -13,6 +13,11 @@ on:
       - 'packages/rs-*/**'
       - '.github/workflows/swift-sdk-build.yml'
 
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+
 jobs:
   swift-sdk-build:
     name: Swift SDK and Example build (warnings as errors)


### PR DESCRIPTION
## Summary

The Swift SDK build workflow's post-build step uses `actions/github-script@v7` to post PR comments with artifact/xcframework info. It calls `github.rest.issues.createComment` and `github.rest.issues.updateComment`, which require `issues: write` permission.

Without an explicit `permissions` block, the workflow inherits the repo default (read-only for `GITHUB_TOKEN` on fork PRs), causing a 403 error that fails the entire CI check — even though the xcframework build itself succeeded.

## Changes

Added a workflow-level `permissions` block to `.github/workflows/swift-sdk-build.yml`:

- `contents: read` — required for `actions/checkout`
- `pull-requests: write` — required for PR interaction
- `issues: write` — required for `issues.createComment`/`updateComment` API calls

## Context

Observed on PR #3137 where the Swift SDK build succeeded but the comment posting step 403'd, failing CI.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**Chores**
* Updated CI/CD workflow permissions to follow security best practices.

---

*Note: This release contains only internal infrastructure updates with no user-facing changes.*

<!-- end of auto-generated comment: release notes by coderabbit.ai -->