### PR TITLE
fix(ffi): post-merge compilation fixes for iOS SDK

### DIFF
--- a/packages/rs-platform-wallet-ffi/Cargo.toml
+++ b/packages/rs-platform-wallet-ffi/Cargo.toml
@@ -31,6 +31,7 @@ thiserror = "1.0"
 
 [dev-dependencies]
 tempfile = "3.8"
+dpp = { path = "../rs-dpp", features = ["fixtures-and-mocks"] }
 
 [features]
 default = []

--- a/packages/rs-platform-wallet-ffi/src/contact.rs
+++ b/packages/rs-platform-wallet-ffi/src/contact.rs
@@ -355,89 +355,99 @@ mod tests {
 
     #[test]
     fn test_get_sent_contact_request_ids() {
-        let identity = create_test_identity();
-        let managed = platform_wallet::managed_identity::ManagedIdentity::new(identity);
-        let handle = MANAGED_IDENTITY_STORAGE.insert(managed);
+        unsafe {
+            let identity = create_test_identity();
+            let managed = platform_wallet::managed_identity::ManagedIdentity::new(identity);
+            let handle = MANAGED_IDENTITY_STORAGE.insert(managed);
 
-        let mut array = IdentifierArray {
-            items: std::ptr::null_mut(),
-            count: 0,
-        };
-        let mut error = PlatformWalletFFIError::success();
+            let mut array = IdentifierArray {
+                items: std::ptr::null_mut(),
+                count: 0,
+            };
+            let mut error = PlatformWalletFFIError::success();
 
-        let result = managed_identity_get_sent_contact_request_ids(handle, &mut array, &mut error);
-        assert_eq!(result, PlatformWalletFFIResult::Success);
-        assert_eq!(array.count, 0); // Should be empty for new identity
+            let result =
+                managed_identity_get_sent_contact_request_ids(handle, &mut array, &mut error);
+            assert_eq!(result, PlatformWalletFFIResult::Success);
+            assert_eq!(array.count, 0); // Should be empty for new identity
 
-        // Cleanup
-        platform_wallet_identifier_array_free(array);
-        crate::managed_identity_destroy(handle);
+            // Cleanup
+            platform_wallet_identifier_array_free(array);
+            crate::managed_identity_destroy(handle);
+        }
     }
 
     #[test]
     fn test_get_incoming_contact_request_ids() {
-        let identity = create_test_identity();
-        let managed = platform_wallet::managed_identity::ManagedIdentity::new(identity);
-        let handle = MANAGED_IDENTITY_STORAGE.insert(managed);
+        unsafe {
+            let identity = create_test_identity();
+            let managed = platform_wallet::managed_identity::ManagedIdentity::new(identity);
+            let handle = MANAGED_IDENTITY_STORAGE.insert(managed);
 
-        let mut array = IdentifierArray {
-            items: std::ptr::null_mut(),
-            count: 0,
-        };
-        let mut error = PlatformWalletFFIError::success();
+            let mut array = IdentifierArray {
+                items: std::ptr::null_mut(),
+                count: 0,
+            };
+            let mut error = PlatformWalletFFIError::success();
 
-        let result =
-            managed_identity_get_incoming_contact_request_ids(handle, &mut array, &mut error);
-        assert_eq!(result, PlatformWalletFFIResult::Success);
-        assert_eq!(array.count, 0);
+            let result =
+                managed_identity_get_incoming_contact_request_ids(handle, &mut array, &mut error);
+            assert_eq!(result, PlatformWalletFFIResult::Success);
+            assert_eq!(array.count, 0);
 
-        // Cleanup
-        platform_wallet_identifier_array_free(array);
-        crate::managed_identity_destroy(handle);
+            // Cleanup
+            platform_wallet_identifier_array_free(array);
+            crate::managed_identity_destroy(handle);
+        }
     }
 
     #[test]
     fn test_get_established_contact_ids() {
-        let identity = create_test_identity();
-        let managed = platform_wallet::managed_identity::ManagedIdentity::new(identity);
-        let handle = MANAGED_IDENTITY_STORAGE.insert(managed);
+        unsafe {
+            let identity = create_test_identity();
+            let managed = platform_wallet::managed_identity::ManagedIdentity::new(identity);
+            let handle = MANAGED_IDENTITY_STORAGE.insert(managed);
 
-        let mut array = IdentifierArray {
-            items: std::ptr::null_mut(),
-            count: 0,
-        };
-        let mut error = PlatformWalletFFIError::success();
+            let mut array = IdentifierArray {
+                items: std::ptr::null_mut(),
+                count: 0,
+            };
+            let mut error = PlatformWalletFFIError::success();
 
-        let result = managed_identity_get_established_contact_ids(handle, &mut array, &mut error);
-        assert_eq!(result, PlatformWalletFFIResult::Success);
-        assert_eq!(array.count, 0);
+            let result =
+                managed_identity_get_established_contact_ids(handle, &mut array, &mut error);
+            assert_eq!(result, PlatformWalletFFIResult::Success);
+            assert_eq!(array.count, 0);
 
-        // Cleanup
-        platform_wallet_identifier_array_free(array);
-        crate::managed_identity_destroy(handle);
+            // Cleanup
+            platform_wallet_identifier_array_free(array);
+            crate::managed_identity_destroy(handle);
+        }
     }
 
     #[test]
     fn test_is_contact_established() {
-        let identity = create_test_identity();
-        let managed = platform_wallet::managed_identity::ManagedIdentity::new(identity);
-        let handle = MANAGED_IDENTITY_STORAGE.insert(managed);
+        unsafe {
+            let identity = create_test_identity();
+            let managed = platform_wallet::managed_identity::ManagedIdentity::new(identity);
+            let handle = MANAGED_IDENTITY_STORAGE.insert(managed);
 
-        let contact_id = Identifier::random();
-        let id_bytes: IdentifierBytes = contact_id.into();
-        let mut error = PlatformWalletFFIError::success();
+            let contact_id = Identifier::random();
+            let id_bytes: IdentifierBytes = contact_id.into();
+            let mut error = PlatformWalletFFIError::success();
 
-        let mut is_established = true;
-        let result = managed_identity_is_contact_established(
-            handle,
-            id_bytes,
-            &mut is_established,
-            &mut error,
-        );
-        assert_eq!(result, PlatformWalletFFIResult::Success);
-        assert_eq!(is_established, false);
+            let mut is_established = true;
+            let result = managed_identity_is_contact_established(
+                handle,
+                id_bytes,
+                &mut is_established,
+                &mut error,
+            );
+            assert_eq!(result, PlatformWalletFFIResult::Success);
+            assert!(!is_established);
 
-        // Cleanup
-        crate::managed_identity_destroy(handle);
+            // Cleanup
+            crate::managed_identity_destroy(handle);
+        }
     }
 }

--- a/packages/rs-platform-wallet-ffi/src/contact_request.rs
+++ b/packages/rs-platform-wallet-ffi/src/contact_request.rs
@@ -506,74 +506,82 @@ mod tests {
 
     #[test]
     fn test_contact_request_getters() {
-        let sender_id = Identifier::from([1u8; 32]);
-        let recipient_id = Identifier::from([2u8; 32]);
-        let encrypted_key = vec![5u8; 96];
+        unsafe {
+            let sender_id = Identifier::from([1u8; 32]);
+            let recipient_id = Identifier::from([2u8; 32]);
+            let encrypted_key = vec![5u8; 96];
 
-        let request = ContactRequest::new(
-            sender_id,
-            recipient_id,
-            0,
-            1,
-            42,
-            encrypted_key.clone(),
-            100_000,
-            1_700_000_000,
-        );
+            let request = ContactRequest::new(
+                sender_id,
+                recipient_id,
+                0,
+                1,
+                42,
+                encrypted_key.clone(),
+                100_000,
+                1_700_000_000,
+            );
 
-        let handle = CONTACT_REQUEST_STORAGE.insert(request);
-        let mut error = PlatformWalletFFIError::success();
+            let handle = CONTACT_REQUEST_STORAGE.insert(request);
+            let mut error = PlatformWalletFFIError::success();
 
-        // Test sender ID
-        let mut out_id = IdentifierBytes { bytes: [0u8; 32] };
-        let result = contact_request_get_sender_id(handle, &mut out_id, &mut error);
-        assert_eq!(result, PlatformWalletFFIResult::Success);
-        assert_eq!(out_id.bytes, [1u8; 32]);
+            // Test sender ID
+            let mut out_id = IdentifierBytes { bytes: [0u8; 32] };
+            let result = contact_request_get_sender_id(handle, &mut out_id, &mut error);
+            assert_eq!(result, PlatformWalletFFIResult::Success);
+            assert_eq!(out_id.bytes, [1u8; 32]);
 
-        // Test recipient ID
-        let result = contact_request_get_recipient_id(handle, &mut out_id, &mut error);
-        assert_eq!(result, PlatformWalletFFIResult::Success);
-        assert_eq!(out_id.bytes, [2u8; 32]);
+            // Test recipient ID
+            let result = contact_request_get_recipient_id(handle, &mut out_id, &mut error);
+            assert_eq!(result, PlatformWalletFFIResult::Success);
+            assert_eq!(out_id.bytes, [2u8; 32]);
 
-        // Test sender key index
-        let mut sender_key_idx = 0u32;
-        let result = contact_request_get_sender_key_index(handle, &mut sender_key_idx, &mut error);
-        assert_eq!(result, PlatformWalletFFIResult::Success);
-        assert_eq!(sender_key_idx, 0);
+            // Test sender key index
+            let mut sender_key_idx = 0u32;
+            let result =
+                contact_request_get_sender_key_index(handle, &mut sender_key_idx, &mut error);
+            assert_eq!(result, PlatformWalletFFIResult::Success);
+            assert_eq!(sender_key_idx, 0);
 
-        // Test recipient key index
-        let mut recipient_key_idx = 0u32;
-        let result =
-            contact_request_get_recipient_key_index(handle, &mut recipient_key_idx, &mut error);
-        assert_eq!(result, PlatformWalletFFIResult::Success);
-        assert_eq!(recipient_key_idx, 1);
+            // Test recipient key index
+            let mut recipient_key_idx = 0u32;
+            let result =
+                contact_request_get_recipient_key_index(handle, &mut recipient_key_idx, &mut error);
+            assert_eq!(result, PlatformWalletFFIResult::Success);
+            assert_eq!(recipient_key_idx, 1);
 
-        // Test account reference
-        let mut account_ref = 0u32;
-        let result = contact_request_get_account_reference(handle, &mut account_ref, &mut error);
-        assert_eq!(result, PlatformWalletFFIResult::Success);
-        assert_eq!(account_ref, 42);
+            // Test account reference
+            let mut account_ref = 0u32;
+            let result =
+                contact_request_get_account_reference(handle, &mut account_ref, &mut error);
+            assert_eq!(result, PlatformWalletFFIResult::Success);
+            assert_eq!(account_ref, 42);
 
-        // Test created_at
-        let mut created_at = 0u64;
-        let result = contact_request_get_created_at(handle, &mut created_at, &mut error);
-        assert_eq!(result, PlatformWalletFFIResult::Success);
-        assert_eq!(created_at, 1_700_000_000);
+            // Test created_at
+            let mut created_at = 0u64;
+            let result = contact_request_get_created_at(handle, &mut created_at, &mut error);
+            assert_eq!(result, PlatformWalletFFIResult::Success);
+            assert_eq!(created_at, 1_700_000_000);
 
-        // Test encrypted public key
-        let mut bytes_ptr: *mut u8 = std::ptr::null_mut();
-        let mut len: usize = 0;
-        let result =
-            contact_request_get_encrypted_public_key(handle, &mut bytes_ptr, &mut len, &mut error);
-        assert_eq!(result, PlatformWalletFFIResult::Success);
-        assert_eq!(len, 96);
-        assert!(!bytes_ptr.is_null());
+            // Test encrypted public key
+            let mut bytes_ptr: *mut u8 = std::ptr::null_mut();
+            let mut len: usize = 0;
+            let result = contact_request_get_encrypted_public_key(
+                handle,
+                &mut bytes_ptr,
+                &mut len,
+                &mut error,
+            );
+            assert_eq!(result, PlatformWalletFFIResult::Success);
+            assert_eq!(len, 96);
+            assert!(!bytes_ptr.is_null());
 
-        let bytes_slice = unsafe { std::slice::from_raw_parts(bytes_ptr, len) };
-        assert_eq!(bytes_slice, &encrypted_key[..]);
+            let bytes_slice = std::slice::from_raw_parts(bytes_ptr, len);
+            assert_eq!(bytes_slice, &encrypted_key[..]);
 
-        // Clean up
-        crate::platform_wallet_bytes_free(bytes_ptr, len);
-        contact_request_destroy(handle);
+            // Clean up
+            crate::platform_wallet_bytes_free(bytes_ptr, len);
+            contact_request_destroy(handle);
+        }
     }
 }

--- a/packages/rs-platform-wallet-ffi/src/error.rs
+++ b/packages/rs-platform-wallet-ffi/src/error.rs
@@ -73,13 +73,17 @@ mod tests {
 
     #[test]
     fn test_error_creation() {
-        let error =
-            PlatformWalletFFIError::new(PlatformWalletFFIResult::ErrorInvalidHandle, "Test error");
-        assert_eq!(error.code, PlatformWalletFFIResult::ErrorInvalidHandle);
-        assert!(!error.message.is_null());
+        unsafe {
+            let error = PlatformWalletFFIError::new(
+                PlatformWalletFFIResult::ErrorInvalidHandle,
+                "Test error",
+            );
+            assert_eq!(error.code, PlatformWalletFFIResult::ErrorInvalidHandle);
+            assert!(!error.message.is_null());
 
-        // Clean up
-        platform_wallet_ffi_error_free(error);
+            // Clean up
+            platform_wallet_ffi_error_free(error);
+        }
     }
 
     #[test]
@@ -91,8 +95,10 @@ mod tests {
 
     #[test]
     fn test_error_free() {
-        let error = PlatformWalletFFIError::new(PlatformWalletFFIResult::ErrorUnknown, "Test");
-        platform_wallet_ffi_error_free(error);
-        // Should not crash
+        unsafe {
+            let error = PlatformWalletFFIError::new(PlatformWalletFFIResult::ErrorUnknown, "Test");
+            platform_wallet_ffi_error_free(error);
+            // Should not crash
+        }
     }
 }

--- a/packages/rs-platform-wallet-ffi/src/identity_manager.rs
+++ b/packages/rs-platform-wallet-ffi/src/identity_manager.rs
@@ -410,69 +410,81 @@ mod tests {
 
     #[test]
     fn test_create_identity_manager() {
-        let mut handle: Handle = NULL_HANDLE;
-        let mut error = PlatformWalletFFIError::success();
+        unsafe {
+            let mut handle: Handle = NULL_HANDLE;
+            let mut error = PlatformWalletFFIError::success();
 
-        let result = identity_manager_create(&mut handle, &mut error);
+            let result = identity_manager_create(&mut handle, &mut error);
 
-        assert_eq!(result, PlatformWalletFFIResult::Success);
-        assert_ne!(handle, NULL_HANDLE);
+            assert_eq!(result, PlatformWalletFFIResult::Success);
+            assert_ne!(handle, NULL_HANDLE);
 
-        // Cleanup
-        identity_manager_destroy(handle);
+            // Cleanup
+            identity_manager_destroy(handle);
+        }
     }
 
     #[test]
     fn test_get_identity_count() {
-        let mut handle: Handle = NULL_HANDLE;
-        let mut error = PlatformWalletFFIError::success();
+        unsafe {
+            let mut handle: Handle = NULL_HANDLE;
+            let mut error = PlatformWalletFFIError::success();
 
-        identity_manager_create(&mut handle, &mut error);
+            identity_manager_create(&mut handle, &mut error);
 
-        let mut count: usize = 0;
-        let result = identity_manager_get_identity_count(handle, &mut count, &mut error);
+            let mut count: usize = 0;
+            let result = identity_manager_get_identity_count(handle, &mut count, &mut error);
 
-        assert_eq!(result, PlatformWalletFFIResult::Success);
-        assert_eq!(count, 0);
+            assert_eq!(result, PlatformWalletFFIResult::Success);
+            assert_eq!(count, 0);
 
-        // Cleanup
-        identity_manager_destroy(handle);
+            // Cleanup
+            identity_manager_destroy(handle);
+        }
     }
 
     #[test]
     fn test_set_and_get_primary_identity() {
-        let mut manager_handle: Handle = NULL_HANDLE;
-        let mut error = PlatformWalletFFIError::success();
+        unsafe {
+            let mut manager_handle: Handle = NULL_HANDLE;
+            let mut error = PlatformWalletFFIError::success();
 
-        identity_manager_create(&mut manager_handle, &mut error);
+            identity_manager_create(&mut manager_handle, &mut error);
 
-        let identity_id = Identifier::random();
-        let id_bytes: IdentifierBytes = identity_id.into();
+            let identity_id = Identifier::random();
+            let id_bytes: IdentifierBytes = identity_id.into();
 
-        // Create and add a managed identity
-        let identity = create_test_identity();
-        let managed_identity = ManagedIdentity::new(identity);
-        let identity_handle = MANAGED_IDENTITY_STORAGE.insert(managed_identity);
+            // Create and add a managed identity
+            let identity = create_test_identity();
+            let managed_identity = ManagedIdentity::new(identity);
+            let identity_handle = MANAGED_IDENTITY_STORAGE.insert(managed_identity);
 
-        identity_manager_add_identity(manager_handle, identity_handle, &mut error);
+            identity_manager_add_identity(manager_handle, identity_handle, &mut error);
 
-        // Set primary identity
-        let result = identity_manager_set_primary_identity(manager_handle, id_bytes, &mut error);
-        assert_eq!(result, PlatformWalletFFIResult::Success);
+            // Set primary identity
+            let result =
+                identity_manager_set_primary_identity(manager_handle, id_bytes, &mut error);
+            assert_eq!(result, PlatformWalletFFIResult::Success);
 
-        // Get primary identity
-        let mut retrieved_id = IdentifierBytes { bytes: [0u8; 32] };
-        let result =
-            identity_manager_get_primary_identity_id(manager_handle, &mut retrieved_id, &mut error);
-        assert_eq!(result, PlatformWalletFFIResult::Success);
+            // Get primary identity
+            let mut retrieved_id = IdentifierBytes { bytes: [0u8; 32] };
+            let result = identity_manager_get_primary_identity_id(
+                manager_handle,
+                &mut retrieved_id,
+                &mut error,
+            );
+            assert_eq!(result, PlatformWalletFFIResult::Success);
 
-        // Cleanup
-        identity_manager_destroy(manager_handle);
+            // Cleanup
+            identity_manager_destroy(manager_handle);
+        }
     }
 
     #[test]
     fn test_destroy_invalid_handle() {
-        let result = identity_manager_destroy(9999);
-        assert_eq!(result, PlatformWalletFFIResult::ErrorInvalidHandle);
+        unsafe {
+            let result = identity_manager_destroy(9999);
+            assert_eq!(result, PlatformWalletFFIResult::ErrorInvalidHandle);
+        }
     }
 }

--- a/packages/rs-platform-wallet-ffi/src/managed_identity.rs
+++ b/packages/rs-platform-wallet-ffi/src/managed_identity.rs
@@ -400,81 +400,88 @@ mod tests {
 
     #[test]
     fn test_get_and_set_label() {
-        let identity = create_test_identity();
-        let managed = platform_wallet::managed_identity::ManagedIdentity::new(identity);
-        let handle = MANAGED_IDENTITY_STORAGE.insert(managed);
+        unsafe {
+            let identity = create_test_identity();
+            let managed = platform_wallet::managed_identity::ManagedIdentity::new(identity);
+            let handle = MANAGED_IDENTITY_STORAGE.insert(managed);
 
-        let label = std::ffi::CString::new("Test Identity").unwrap();
-        let mut error = PlatformWalletFFIError::success();
+            let label = std::ffi::CString::new("Test Identity").unwrap();
+            let mut error = PlatformWalletFFIError::success();
 
-        let result = managed_identity_set_label(handle, label.as_ptr(), &mut error);
-        assert_eq!(result, PlatformWalletFFIResult::Success);
+            let result = managed_identity_set_label(handle, label.as_ptr(), &mut error);
+            assert_eq!(result, PlatformWalletFFIResult::Success);
 
-        let mut label_ptr: *mut c_char = std::ptr::null_mut();
-        let result = managed_identity_get_label(handle, &mut label_ptr, &mut error);
-        assert_eq!(result, PlatformWalletFFIResult::Success);
-        assert!(!label_ptr.is_null());
+            let mut label_ptr: *mut c_char = std::ptr::null_mut();
+            let result = managed_identity_get_label(handle, &mut label_ptr, &mut error);
+            assert_eq!(result, PlatformWalletFFIResult::Success);
+            assert!(!label_ptr.is_null());
 
-        let retrieved_label = unsafe { std::ffi::CStr::from_ptr(label_ptr).to_str().unwrap() };
-        assert_eq!(retrieved_label, "Test Identity");
+            let retrieved_label = std::ffi::CStr::from_ptr(label_ptr).to_str().unwrap();
+            assert_eq!(retrieved_label, "Test Identity");
 
-        // Cleanup
-        platform_wallet_string_free(label_ptr);
-        managed_identity_destroy(handle);
+            // Cleanup
+            platform_wallet_string_free(label_ptr);
+            managed_identity_destroy(handle);
+        }
     }
 
     #[test]
     fn test_get_balance() {
-        let identity = create_test_identity();
-        let managed = platform_wallet::managed_identity::ManagedIdentity::new(identity);
-        let handle = MANAGED_IDENTITY_STORAGE.insert(managed);
+        unsafe {
+            let identity = create_test_identity();
+            let managed = platform_wallet::managed_identity::ManagedIdentity::new(identity);
+            let handle = MANAGED_IDENTITY_STORAGE.insert(managed);
 
-        let mut balance: u64 = 0;
-        let mut error = PlatformWalletFFIError::success();
+            let mut balance: u64 = 0;
+            let mut error = PlatformWalletFFIError::success();
 
-        let result = managed_identity_get_balance(handle, &mut balance, &mut error);
-        assert_eq!(result, PlatformWalletFFIResult::Success);
+            let result = managed_identity_get_balance(handle, &mut balance, &mut error);
+            assert_eq!(result, PlatformWalletFFIResult::Success);
 
-        // Cleanup
-        managed_identity_destroy(handle);
+            // Cleanup
+            managed_identity_destroy(handle);
+        }
     }
 
     #[test]
     fn test_block_time_operations() {
-        let identity = create_test_identity();
-        let managed = platform_wallet::managed_identity::ManagedIdentity::new(identity);
-        let handle = MANAGED_IDENTITY_STORAGE.insert(managed);
+        unsafe {
+            let identity = create_test_identity();
+            let managed = platform_wallet::managed_identity::ManagedIdentity::new(identity);
+            let handle = MANAGED_IDENTITY_STORAGE.insert(managed);
 
-        let block_time = BlockTime {
-            height: 100,
-            core_height: 200,
-            timestamp: 1234567890,
-        };
+            let block_time = BlockTime {
+                height: 100,
+                core_height: 200,
+                timestamp: 1234567890,
+            };
 
-        let mut error = PlatformWalletFFIError::success();
+            let mut error = PlatformWalletFFIError::success();
 
-        // Set block time
-        let result =
-            managed_identity_set_last_updated_balance_block_time(handle, block_time, &mut error);
-        assert_eq!(result, PlatformWalletFFIResult::Success);
+            // Set block time
+            let result = managed_identity_set_last_updated_balance_block_time(
+                handle, block_time, &mut error,
+            );
+            assert_eq!(result, PlatformWalletFFIResult::Success);
 
-        // Get block time
-        let mut retrieved_bt = BlockTime {
-            height: 0,
-            core_height: 0,
-            timestamp: 0,
-        };
-        let result = managed_identity_get_last_updated_balance_block_time(
-            handle,
-            &mut retrieved_bt,
-            &mut error,
-        );
-        assert_eq!(result, PlatformWalletFFIResult::Success);
-        assert_eq!(retrieved_bt.height, 100);
-        assert_eq!(retrieved_bt.core_height, 200);
-        assert_eq!(retrieved_bt.timestamp, 1234567890);
+            // Get block time
+            let mut retrieved_bt = BlockTime {
+                height: 0,
+                core_height: 0,
+                timestamp: 0,
+            };
+            let result = managed_identity_get_last_updated_balance_block_time(
+                handle,
+                &mut retrieved_bt,
+                &mut error,
+            );
+            assert_eq!(result, PlatformWalletFFIResult::Success);
+            assert_eq!(retrieved_bt.height, 100);
+            assert_eq!(retrieved_bt.core_height, 200);
+            assert_eq!(retrieved_bt.timestamp, 1234567890);
 
-        // Cleanup
-        managed_identity_destroy(handle);
+            // Cleanup
+            managed_identity_destroy(handle);
+        }
     }
 }

--- a/packages/rs-platform-wallet-ffi/src/platform_wallet_info.rs
+++ b/packages/rs-platform-wallet-ffi/src/platform_wallet_info.rs
@@ -334,78 +334,86 @@ mod tests {
 
     #[test]
     fn test_create_from_seed() {
-        let seed = [0u8; 64];
-        let mut handle: Handle = NULL_HANDLE;
-        let mut error = PlatformWalletFFIError::success();
+        unsafe {
+            let seed = [0u8; 64];
+            let mut handle: Handle = NULL_HANDLE;
+            let mut error = PlatformWalletFFIError::success();
 
-        let result = platform_wallet_info_create_from_seed(
-            Network::Testnet,
-            seed.as_ptr(),
-            seed.len(),
-            &mut handle,
-            &mut error,
-        );
+            let result = platform_wallet_info_create_from_seed(
+                Network::Testnet,
+                seed.as_ptr(),
+                seed.len(),
+                &mut handle,
+                &mut error,
+            );
 
-        assert_eq!(result, PlatformWalletFFIResult::Success);
-        assert_ne!(handle, NULL_HANDLE);
+            assert_eq!(result, PlatformWalletFFIResult::Success);
+            assert_ne!(handle, NULL_HANDLE);
 
-        // Cleanup
-        platform_wallet_info_destroy(handle);
+            // Cleanup
+            platform_wallet_info_destroy(handle);
+        }
     }
 
     #[test]
     fn test_create_from_mnemonic() {
-        let mnemonic = std::ffi::CString::new(
+        unsafe {
+            let mnemonic = std::ffi::CString::new(
             "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about"
         ).unwrap();
 
-        let mut handle: Handle = NULL_HANDLE;
-        let mut error = PlatformWalletFFIError::success();
+            let mut handle: Handle = NULL_HANDLE;
+            let mut error = PlatformWalletFFIError::success();
 
-        let result = platform_wallet_info_create_from_mnemonic(
-            Network::Testnet,
-            mnemonic.as_ptr(),
-            std::ptr::null(),
-            &mut handle,
-            &mut error,
-        );
+            let result = platform_wallet_info_create_from_mnemonic(
+                Network::Testnet,
+                mnemonic.as_ptr(),
+                std::ptr::null(),
+                &mut handle,
+                &mut error,
+            );
 
-        assert_eq!(result, PlatformWalletFFIResult::Success);
-        assert_ne!(handle, NULL_HANDLE);
+            assert_eq!(result, PlatformWalletFFIResult::Success);
+            assert_ne!(handle, NULL_HANDLE);
 
-        // Cleanup
-        platform_wallet_info_destroy(handle);
+            // Cleanup
+            platform_wallet_info_destroy(handle);
+        }
     }
 
     #[test]
     #[ignore] // Stubbed - requires serde support on PlatformWalletInfo
     fn test_to_json() {
-        let seed = [0u8; 64];
-        let mut handle: Handle = NULL_HANDLE;
-        let mut error = PlatformWalletFFIError::success();
+        unsafe {
+            let seed = [0u8; 64];
+            let mut handle: Handle = NULL_HANDLE;
+            let mut error = PlatformWalletFFIError::success();
 
-        platform_wallet_info_create_from_seed(
-            Network::Testnet,
-            seed.as_ptr(),
-            seed.len(),
-            &mut handle,
-            &mut error,
-        );
+            platform_wallet_info_create_from_seed(
+                Network::Testnet,
+                seed.as_ptr(),
+                seed.len(),
+                &mut handle,
+                &mut error,
+            );
 
-        let mut json_ptr: *mut c_char = std::ptr::null_mut();
-        let result = platform_wallet_info_to_json(handle, &mut json_ptr, &mut error);
+            let mut json_ptr: *mut c_char = std::ptr::null_mut();
+            let result = platform_wallet_info_to_json(handle, &mut json_ptr, &mut error);
 
-        assert_eq!(result, PlatformWalletFFIResult::Success);
-        assert!(!json_ptr.is_null());
+            assert_eq!(result, PlatformWalletFFIResult::Success);
+            assert!(!json_ptr.is_null());
 
-        // Cleanup
-        platform_wallet_string_free(json_ptr);
-        platform_wallet_info_destroy(handle);
+            // Cleanup
+            platform_wallet_string_free(json_ptr);
+            platform_wallet_info_destroy(handle);
+        }
     }
 
     #[test]
     fn test_destroy_invalid_handle() {
-        let result = platform_wallet_info_destroy(9999);
-        assert_eq!(result, PlatformWalletFFIResult::ErrorInvalidHandle);
+        unsafe {
+            let result = platform_wallet_info_destroy(9999);
+            assert_eq!(result, PlatformWalletFFIResult::ErrorInvalidHandle);
+        }
     }
 }

--- a/packages/rs-platform-wallet-ffi/src/types.rs
+++ b/packages/rs-platform-wallet-ffi/src/types.rs
@@ -166,13 +166,15 @@ mod tests {
 
     #[test]
     fn test_identifier_array_with_items() {
-        let id1 = dpp::prelude::Identifier::random();
-        let id2 = dpp::prelude::Identifier::random();
+        unsafe {
+            let id1 = dpp::prelude::Identifier::random();
+            let id2 = dpp::prelude::Identifier::random();
 
-        let array = IdentifierArray::new(vec![id1, id2]);
-        assert!(!array.items.is_null());
-        assert_eq!(array.count, 2);
+            let array = IdentifierArray::new(vec![id1, id2]);
+            assert!(!array.items.is_null());
+            assert_eq!(array.count, 2);
 
-        platform_wallet_identifier_array_free(array);
+            platform_wallet_identifier_array_free(array);
+        }
     }
 }

--- a/packages/rs-platform-wallet-ffi/src/utils.rs
+++ b/packages/rs-platform-wallet-ffi/src/utils.rs
@@ -253,72 +253,78 @@ mod tests {
 
     #[test]
     fn test_serialize_deserialize_json_bytes() {
-        let json = std::ffi::CString::new(r#"{"test":"value"}"#).unwrap();
-        let mut bytes: *mut c_uchar = std::ptr::null_mut();
-        let mut len: usize = 0;
-        let mut error = PlatformWalletFFIError::success();
+        unsafe {
+            let json = std::ffi::CString::new(r#"{"test":"value"}"#).unwrap();
+            let mut bytes: *mut c_uchar = std::ptr::null_mut();
+            let mut len: usize = 0;
+            let mut error = PlatformWalletFFIError::success();
 
-        // Serialize
-        let result = platform_wallet_serialize_to_json_bytes(
-            json.as_ptr(),
-            &mut bytes,
-            &mut len,
-            &mut error,
-        );
-        assert_eq!(result, PlatformWalletFFIResult::Success);
-        assert!(!bytes.is_null());
-        assert!(len > 0);
+            // Serialize
+            let result = platform_wallet_serialize_to_json_bytes(
+                json.as_ptr(),
+                &mut bytes,
+                &mut len,
+                &mut error,
+            );
+            assert_eq!(result, PlatformWalletFFIResult::Success);
+            assert!(!bytes.is_null());
+            assert!(len > 0);
 
-        // Deserialize
-        let mut json_out: *mut c_char = std::ptr::null_mut();
-        let result =
-            platform_wallet_deserialize_from_json_bytes(bytes, len, &mut json_out, &mut error);
-        assert_eq!(result, PlatformWalletFFIResult::Success);
-        assert!(!json_out.is_null());
+            // Deserialize
+            let mut json_out: *mut c_char = std::ptr::null_mut();
+            let result =
+                platform_wallet_deserialize_from_json_bytes(bytes, len, &mut json_out, &mut error);
+            assert_eq!(result, PlatformWalletFFIResult::Success);
+            assert!(!json_out.is_null());
 
-        let json_str = unsafe { std::ffi::CStr::from_ptr(json_out).to_str().unwrap() };
-        assert_eq!(json_str, r#"{"test":"value"}"#);
+            let json_str = std::ffi::CStr::from_ptr(json_out).to_str().unwrap();
+            assert_eq!(json_str, r#"{"test":"value"}"#);
 
-        // Cleanup
-        platform_wallet_bytes_free(bytes, len);
-        crate::platform_wallet_string_free(json_out);
+            // Cleanup
+            platform_wallet_bytes_free(bytes, len);
+            crate::platform_wallet_string_free(json_out);
+        }
     }
 
     #[test]
     fn test_generate_random_identifier() {
-        let mut id = crate::types::IdentifierBytes { bytes: [0u8; 32] };
-        let mut error = PlatformWalletFFIError::success();
+        unsafe {
+            let mut id = crate::types::IdentifierBytes { bytes: [0u8; 32] };
+            let mut error = PlatformWalletFFIError::success();
 
-        let result = platform_wallet_generate_random_identifier(&mut id, &mut error);
-        assert_eq!(result, PlatformWalletFFIResult::Success);
+            let result = platform_wallet_generate_random_identifier(&mut id, &mut error);
+            assert_eq!(result, PlatformWalletFFIResult::Success);
 
-        // Check that it's not all zeros
-        assert_ne!(id.bytes, [0u8; 32]);
+            // Check that it's not all zeros
+            assert_ne!(id.bytes, [0u8; 32]);
+        }
     }
 
     #[test]
     fn test_identifier_to_from_hex() {
-        let mut id = crate::types::IdentifierBytes { bytes: [0u8; 32] };
-        let mut error = PlatformWalletFFIError::success();
+        unsafe {
+            let mut id = crate::types::IdentifierBytes { bytes: [0u8; 32] };
+            let mut error = PlatformWalletFFIError::success();
 
-        // Generate random ID
-        platform_wallet_generate_random_identifier(&mut id, &mut error);
+            // Generate random ID
+            platform_wallet_generate_random_identifier(&mut id, &mut error);
 
-        // Convert to hex
-        let mut hex: *mut c_char = std::ptr::null_mut();
-        let result = platform_wallet_identifier_to_hex(id, &mut hex, &mut error);
-        assert_eq!(result, PlatformWalletFFIResult::Success);
-        assert!(!hex.is_null());
+            // Convert to hex
+            let mut hex: *mut c_char = std::ptr::null_mut();
+            let result = platform_wallet_identifier_to_hex(id, &mut hex, &mut error);
+            assert_eq!(result, PlatformWalletFFIResult::Success);
+            assert!(!hex.is_null());
 
-        // Convert back from hex
-        let mut id2 = crate::types::IdentifierBytes { bytes: [0u8; 32] };
-        let result = platform_wallet_identifier_from_hex(hex, &mut id2, &mut error);
-        assert_eq!(result, PlatformWalletFFIResult::Success);
+            // Convert back from hex
+            let mut id2 = crate::types::IdentifierBytes { bytes: [0u8; 32] };
+            let result = platform_wallet_identifier_from_hex(hex, &mut id2, &mut error);
+            assert_eq!(result, PlatformWalletFFIResult::Success);
 
-        // Should match
-        assert_eq!(id.bytes, id2.bytes);
+            // Should match
+            assert_eq!(id.bytes, id2.bytes);
 
-        // Cleanup
-        crate::platform_wallet_string_free(hex);
+            // Cleanup
+            crate::platform_wallet_string_free(hex);
+        }
     }
 }

--- a/packages/rs-platform-wallet-ffi/tests/comprehensive_tests.rs
+++ b/packages/rs-platform-wallet-ffi/tests/comprehensive_tests.rs
@@ -12,618 +12,661 @@ use test_data::scenarios;
 
 #[test]
 fn test_contact_request_field_access() {
-    // Create Alice with outgoing requests
-    let (alice, requests) = scenarios::alice_with_pending_sent_requests();
-    let alice_handle = MANAGED_IDENTITY_STORAGE.insert(alice);
+    unsafe {
+        // Create Alice with outgoing requests
+        let (alice, _requests) = scenarios::alice_with_pending_sent_requests();
+        let alice_handle = MANAGED_IDENTITY_STORAGE.insert(alice);
 
-    let bob = identities::bob();
-    let bob_id_bytes: IdentifierBytes = bob.identity.id().into();
+        let bob = identities::bob();
+        let bob_id_bytes: IdentifierBytes = bob.identity.id().into();
 
-    let mut error = PlatformWalletFFIError::success();
+        let mut error = PlatformWalletFFIError::success();
 
-    // Get the contact request for Bob
-    let mut request_handle: Handle = NULL_HANDLE;
-    let result = managed_identity_get_sent_contact_request(
-        alice_handle,
-        bob_id_bytes,
-        &mut request_handle,
-        &mut error,
-    );
-    assert_eq!(result, PlatformWalletFFIResult::Success);
-    assert_ne!(request_handle, NULL_HANDLE);
-
-    // Verify sender ID
-    let mut sender_id = IdentifierBytes { bytes: [0u8; 32] };
-    let result = contact_request_get_sender_id(request_handle, &mut sender_id, &mut error);
-    assert_eq!(result, PlatformWalletFFIResult::Success);
-    assert_eq!(sender_id.bytes, [1u8; 32]); // Alice's ID
-
-    // Verify recipient ID
-    let mut recipient_id = IdentifierBytes { bytes: [0u8; 32] };
-    let result = contact_request_get_recipient_id(request_handle, &mut recipient_id, &mut error);
-    assert_eq!(result, PlatformWalletFFIResult::Success);
-    assert_eq!(recipient_id.bytes, [2u8; 32]); // Bob's ID
-
-    // Verify sender key index
-    let mut sender_key_idx = 999u32;
-    let result =
-        contact_request_get_sender_key_index(request_handle, &mut sender_key_idx, &mut error);
-    assert_eq!(result, PlatformWalletFFIResult::Success);
-    assert_eq!(sender_key_idx, 0);
-
-    // Verify recipient key index
-    let mut recipient_key_idx = 999u32;
-    let result =
-        contact_request_get_recipient_key_index(request_handle, &mut recipient_key_idx, &mut error);
-    assert_eq!(result, PlatformWalletFFIResult::Success);
-    assert_eq!(recipient_key_idx, 1);
-
-    // Verify account reference
-    let mut account_ref = 999u32;
-    let result =
-        contact_request_get_account_reference(request_handle, &mut account_ref, &mut error);
-    assert_eq!(result, PlatformWalletFFIResult::Success);
-    assert_eq!(account_ref, 0);
-
-    // Verify timestamp
-    let mut created_at = 0u64;
-    let result = contact_request_get_created_at(request_handle, &mut created_at, &mut error);
-    assert_eq!(result, PlatformWalletFFIResult::Success);
-    assert_eq!(created_at, 1_700_000_000);
-
-    // Verify encrypted public key
-    let mut bytes_ptr: *mut u8 = std::ptr::null_mut();
-    let mut len: usize = 0;
-    let result = contact_request_get_encrypted_public_key(
-        request_handle,
-        &mut bytes_ptr,
-        &mut len,
-        &mut error,
-    );
-    assert_eq!(result, PlatformWalletFFIResult::Success);
-    assert!(!bytes_ptr.is_null());
-    assert_eq!(len, 96);
-
-    // Cleanup
-    platform_wallet_bytes_free(bytes_ptr, len);
-    contact_request_destroy(request_handle);
-    managed_identity_destroy(alice_handle);
-}
-
-#[test]
-fn test_incoming_contact_request_retrieval() {
-    // Create Alice with incoming requests
-    let (alice, requests) = scenarios::alice_with_pending_incoming_requests();
-    let alice_handle = MANAGED_IDENTITY_STORAGE.insert(alice);
-
-    let bob = identities::bob();
-    let bob_id_bytes: IdentifierBytes = bob.identity.id().into();
-
-    let mut error = PlatformWalletFFIError::success();
-
-    // Get the incoming contact request from Bob
-    let mut request_handle: Handle = NULL_HANDLE;
-    let result = managed_identity_get_incoming_contact_request(
-        alice_handle,
-        bob_id_bytes,
-        &mut request_handle,
-        &mut error,
-    );
-    assert_eq!(result, PlatformWalletFFIResult::Success);
-    assert_ne!(request_handle, NULL_HANDLE);
-
-    // Verify it's from Bob to Alice
-    let mut sender_id = IdentifierBytes { bytes: [0u8; 32] };
-    let result = contact_request_get_sender_id(request_handle, &mut sender_id, &mut error);
-    assert_eq!(result, PlatformWalletFFIResult::Success);
-    assert_eq!(sender_id.bytes, [2u8; 32]); // Bob's ID
-
-    let mut recipient_id = IdentifierBytes { bytes: [0u8; 32] };
-    let result = contact_request_get_recipient_id(request_handle, &mut recipient_id, &mut error);
-    assert_eq!(result, PlatformWalletFFIResult::Success);
-    assert_eq!(recipient_id.bytes, [1u8; 32]); // Alice's ID
-
-    // Cleanup
-    contact_request_destroy(request_handle);
-    managed_identity_destroy(alice_handle);
-}
-
-#[test]
-fn test_multiple_contact_requests() {
-    // Create Alice with 3 outgoing requests
-    let (alice, requests) = scenarios::alice_with_pending_sent_requests();
-    let alice_handle = MANAGED_IDENTITY_STORAGE.insert(alice);
-
-    let mut error = PlatformWalletFFIError::success();
-
-    // Get all sent contact request IDs
-    let mut array = IdentifierArray {
-        items: std::ptr::null_mut(),
-        count: 0,
-    };
-    let result =
-        managed_identity_get_sent_contact_request_ids(alice_handle, &mut array, &mut error);
-    assert_eq!(result, PlatformWalletFFIResult::Success);
-    assert_eq!(array.count, 3);
-
-    // Verify we can retrieve each request
-    for i in 0..array.count {
-        let id_bytes = unsafe { *array.items.add(i) };
+        // Get the contact request for Bob
         let mut request_handle: Handle = NULL_HANDLE;
         let result = managed_identity_get_sent_contact_request(
             alice_handle,
-            id_bytes,
+            bob_id_bytes,
             &mut request_handle,
             &mut error,
         );
         assert_eq!(result, PlatformWalletFFIResult::Success);
         assert_ne!(request_handle, NULL_HANDLE);
 
-        contact_request_destroy(request_handle);
-    }
+        // Verify sender ID
+        let mut sender_id = IdentifierBytes { bytes: [0u8; 32] };
+        let result = contact_request_get_sender_id(request_handle, &mut sender_id, &mut error);
+        assert_eq!(result, PlatformWalletFFIResult::Success);
+        assert_eq!(sender_id.bytes, [1u8; 32]); // Alice's ID
 
-    // Cleanup
-    platform_wallet_identifier_array_free(array);
-    managed_identity_destroy(alice_handle);
+        // Verify recipient ID
+        let mut recipient_id = IdentifierBytes { bytes: [0u8; 32] };
+        let result =
+            contact_request_get_recipient_id(request_handle, &mut recipient_id, &mut error);
+        assert_eq!(result, PlatformWalletFFIResult::Success);
+        assert_eq!(recipient_id.bytes, [2u8; 32]); // Bob's ID
+
+        // Verify sender key index
+        let mut sender_key_idx = 999u32;
+        let result =
+            contact_request_get_sender_key_index(request_handle, &mut sender_key_idx, &mut error);
+        assert_eq!(result, PlatformWalletFFIResult::Success);
+        assert_eq!(sender_key_idx, 0);
+
+        // Verify recipient key index
+        let mut recipient_key_idx = 999u32;
+        let result = contact_request_get_recipient_key_index(
+            request_handle,
+            &mut recipient_key_idx,
+            &mut error,
+        );
+        assert_eq!(result, PlatformWalletFFIResult::Success);
+        assert_eq!(recipient_key_idx, 1);
+
+        // Verify account reference
+        let mut account_ref = 999u32;
+        let result =
+            contact_request_get_account_reference(request_handle, &mut account_ref, &mut error);
+        assert_eq!(result, PlatformWalletFFIResult::Success);
+        assert_eq!(account_ref, 0);
+
+        // Verify timestamp
+        let mut created_at = 0u64;
+        let result = contact_request_get_created_at(request_handle, &mut created_at, &mut error);
+        assert_eq!(result, PlatformWalletFFIResult::Success);
+        assert_eq!(created_at, 1_700_000_000);
+
+        // Verify encrypted public key
+        let mut bytes_ptr: *mut u8 = std::ptr::null_mut();
+        let mut len: usize = 0;
+        let result = contact_request_get_encrypted_public_key(
+            request_handle,
+            &mut bytes_ptr,
+            &mut len,
+            &mut error,
+        );
+        assert_eq!(result, PlatformWalletFFIResult::Success);
+        assert!(!bytes_ptr.is_null());
+        assert_eq!(len, 96);
+
+        // Cleanup
+        platform_wallet_bytes_free(bytes_ptr, len);
+        contact_request_destroy(request_handle);
+        managed_identity_destroy(alice_handle);
+    }
+}
+
+#[test]
+fn test_incoming_contact_request_retrieval() {
+    unsafe {
+        // Create Alice with incoming requests
+        let (alice, _requests) = scenarios::alice_with_pending_incoming_requests();
+        let alice_handle = MANAGED_IDENTITY_STORAGE.insert(alice);
+
+        let bob = identities::bob();
+        let bob_id_bytes: IdentifierBytes = bob.identity.id().into();
+
+        let mut error = PlatformWalletFFIError::success();
+
+        // Get the incoming contact request from Bob
+        let mut request_handle: Handle = NULL_HANDLE;
+        let result = managed_identity_get_incoming_contact_request(
+            alice_handle,
+            bob_id_bytes,
+            &mut request_handle,
+            &mut error,
+        );
+        assert_eq!(result, PlatformWalletFFIResult::Success);
+        assert_ne!(request_handle, NULL_HANDLE);
+
+        // Verify it's from Bob to Alice
+        let mut sender_id = IdentifierBytes { bytes: [0u8; 32] };
+        let result = contact_request_get_sender_id(request_handle, &mut sender_id, &mut error);
+        assert_eq!(result, PlatformWalletFFIResult::Success);
+        assert_eq!(sender_id.bytes, [2u8; 32]); // Bob's ID
+
+        let mut recipient_id = IdentifierBytes { bytes: [0u8; 32] };
+        let result =
+            contact_request_get_recipient_id(request_handle, &mut recipient_id, &mut error);
+        assert_eq!(result, PlatformWalletFFIResult::Success);
+        assert_eq!(recipient_id.bytes, [1u8; 32]); // Alice's ID
+
+        // Cleanup
+        contact_request_destroy(request_handle);
+        managed_identity_destroy(alice_handle);
+    }
+}
+
+#[test]
+fn test_multiple_contact_requests() {
+    unsafe {
+        // Create Alice with 3 outgoing requests
+        let (alice, _requests) = scenarios::alice_with_pending_sent_requests();
+        let alice_handle = MANAGED_IDENTITY_STORAGE.insert(alice);
+
+        let mut error = PlatformWalletFFIError::success();
+
+        // Get all sent contact request IDs
+        let mut array = IdentifierArray {
+            items: std::ptr::null_mut(),
+            count: 0,
+        };
+        let result =
+            managed_identity_get_sent_contact_request_ids(alice_handle, &mut array, &mut error);
+        assert_eq!(result, PlatformWalletFFIResult::Success);
+        assert_eq!(array.count, 3);
+
+        // Verify we can retrieve each request
+        for i in 0..array.count {
+            let id_bytes = *array.items.add(i);
+            let mut request_handle: Handle = NULL_HANDLE;
+            let result = managed_identity_get_sent_contact_request(
+                alice_handle,
+                id_bytes,
+                &mut request_handle,
+                &mut error,
+            );
+            assert_eq!(result, PlatformWalletFFIResult::Success);
+            assert_ne!(request_handle, NULL_HANDLE);
+
+            contact_request_destroy(request_handle);
+        }
+
+        // Cleanup
+        platform_wallet_identifier_array_free(array);
+        managed_identity_destroy(alice_handle);
+    }
 }
 
 #[test]
 fn test_established_contacts() {
-    // Create Alice with established contacts
-    let (alice, contacts) = scenarios::alice_with_established_contacts();
-    let alice_handle = MANAGED_IDENTITY_STORAGE.insert(alice);
+    unsafe {
+        // Create Alice with established contacts
+        let (alice, _contacts) = scenarios::alice_with_established_contacts();
+        let alice_handle = MANAGED_IDENTITY_STORAGE.insert(alice);
 
-    let mut error = PlatformWalletFFIError::success();
+        let mut error = PlatformWalletFFIError::success();
 
-    // Get all established contact IDs
-    let mut array = IdentifierArray {
-        items: std::ptr::null_mut(),
-        count: 0,
-    };
-    let result = managed_identity_get_established_contact_ids(alice_handle, &mut array, &mut error);
-    assert_eq!(result, PlatformWalletFFIResult::Success);
-    assert_eq!(array.count, 2); // Bob and Carol
+        // Get all established contact IDs
+        let mut array = IdentifierArray {
+            items: std::ptr::null_mut(),
+            count: 0,
+        };
+        let result =
+            managed_identity_get_established_contact_ids(alice_handle, &mut array, &mut error);
+        assert_eq!(result, PlatformWalletFFIResult::Success);
+        assert_eq!(array.count, 2); // Bob and Carol
 
-    // Check if Bob is established
-    let bob_id_bytes: IdentifierBytes = identities::bob().identity.id().into();
-    let mut is_established = false;
-    let result = managed_identity_is_contact_established(
-        alice_handle,
-        bob_id_bytes,
-        &mut is_established,
-        &mut error,
-    );
-    assert_eq!(result, PlatformWalletFFIResult::Success);
-    assert!(is_established);
+        // Check if Bob is established
+        let bob_id_bytes: IdentifierBytes = identities::bob().identity.id().into();
+        let mut is_established = false;
+        let result = managed_identity_is_contact_established(
+            alice_handle,
+            bob_id_bytes,
+            &mut is_established,
+            &mut error,
+        );
+        assert_eq!(result, PlatformWalletFFIResult::Success);
+        assert!(is_established);
 
-    // Check if Dave is NOT established
-    let dave_id_bytes: IdentifierBytes = identities::dave().identity.id().into();
-    let mut is_established = true;
-    let result = managed_identity_is_contact_established(
-        alice_handle,
-        dave_id_bytes,
-        &mut is_established,
-        &mut error,
-    );
-    assert_eq!(result, PlatformWalletFFIResult::Success);
-    assert!(!is_established);
+        // Check if Dave is NOT established
+        let dave_id_bytes: IdentifierBytes = identities::dave().identity.id().into();
+        let mut is_established = true;
+        let result = managed_identity_is_contact_established(
+            alice_handle,
+            dave_id_bytes,
+            &mut is_established,
+            &mut error,
+        );
+        assert_eq!(result, PlatformWalletFFIResult::Success);
+        assert!(!is_established);
 
-    // Cleanup
-    platform_wallet_identifier_array_free(array);
-    managed_identity_destroy(alice_handle);
+        // Cleanup
+        platform_wallet_identifier_array_free(array);
+        managed_identity_destroy(alice_handle);
+    }
 }
 
 #[test]
 fn test_mixed_contact_scenario() {
-    // Create Alice with all types of contacts
-    let alice = scenarios::alice_with_mixed_contacts();
-    let alice_handle = MANAGED_IDENTITY_STORAGE.insert(alice);
+    unsafe {
+        // Create Alice with all types of contacts
+        let alice = scenarios::alice_with_mixed_contacts();
+        let alice_handle = MANAGED_IDENTITY_STORAGE.insert(alice);
 
-    let mut error = PlatformWalletFFIError::success();
+        let mut error = PlatformWalletFFIError::success();
 
-    // Verify established contacts count
-    let mut established_array = IdentifierArray {
-        items: std::ptr::null_mut(),
-        count: 0,
-    };
-    managed_identity_get_established_contact_ids(alice_handle, &mut established_array, &mut error);
-    assert_eq!(established_array.count, 1); // Only Bob
+        // Verify established contacts count
+        let mut established_array = IdentifierArray {
+            items: std::ptr::null_mut(),
+            count: 0,
+        };
+        managed_identity_get_established_contact_ids(
+            alice_handle,
+            &mut established_array,
+            &mut error,
+        );
+        assert_eq!(established_array.count, 1); // Only Bob
 
-    // Verify sent requests count
-    let mut sent_array = IdentifierArray {
-        items: std::ptr::null_mut(),
-        count: 0,
-    };
-    managed_identity_get_sent_contact_request_ids(alice_handle, &mut sent_array, &mut error);
-    assert_eq!(sent_array.count, 1); // Only Carol
+        // Verify sent requests count
+        let mut sent_array = IdentifierArray {
+            items: std::ptr::null_mut(),
+            count: 0,
+        };
+        managed_identity_get_sent_contact_request_ids(alice_handle, &mut sent_array, &mut error);
+        assert_eq!(sent_array.count, 1); // Only Carol
 
-    // Verify incoming requests count
-    let mut incoming_array = IdentifierArray {
-        items: std::ptr::null_mut(),
-        count: 0,
-    };
-    managed_identity_get_incoming_contact_request_ids(
-        alice_handle,
-        &mut incoming_array,
-        &mut error,
-    );
-    assert_eq!(incoming_array.count, 2); // Dave and Eve
+        // Verify incoming requests count
+        let mut incoming_array = IdentifierArray {
+            items: std::ptr::null_mut(),
+            count: 0,
+        };
+        managed_identity_get_incoming_contact_request_ids(
+            alice_handle,
+            &mut incoming_array,
+            &mut error,
+        );
+        assert_eq!(incoming_array.count, 2); // Dave and Eve
 
-    // Cleanup
-    platform_wallet_identifier_array_free(established_array);
-    platform_wallet_identifier_array_free(sent_array);
-    platform_wallet_identifier_array_free(incoming_array);
-    managed_identity_destroy(alice_handle);
+        // Cleanup
+        platform_wallet_identifier_array_free(established_array);
+        platform_wallet_identifier_array_free(sent_array);
+        platform_wallet_identifier_array_free(incoming_array);
+        managed_identity_destroy(alice_handle);
+    }
 }
 
 #[test]
 fn test_identity_manager_with_multiple_identities() {
-    use dpp::identity::accessors::IdentityGettersV0;
+    unsafe {
+        use dpp::identity::accessors::IdentityGettersV0;
 
-    let mut error = PlatformWalletFFIError::success();
+        let mut error = PlatformWalletFFIError::success();
 
-    // Create identity manager
-    let mut manager_handle: Handle = NULL_HANDLE;
-    let result = identity_manager_create(&mut manager_handle, &mut error);
-    assert_eq!(result, PlatformWalletFFIResult::Success);
+        // Create identity manager
+        let mut manager_handle: Handle = NULL_HANDLE;
+        let result = identity_manager_create(&mut manager_handle, &mut error);
+        assert_eq!(result, PlatformWalletFFIResult::Success);
 
-    // Add Alice, Bob, and Carol
-    let alice = identities::alice();
-    let bob = identities::bob();
-    let carol = identities::carol();
+        // Add Alice, Bob, and Carol
+        let alice = identities::alice();
+        let bob = identities::bob();
+        let carol = identities::carol();
 
-    let alice_id = alice.identity.id();
-    let bob_id = bob.identity.id();
-    let carol_id = carol.identity.id();
+        let alice_id = alice.identity.id();
+        let _bob_id = bob.identity.id();
+        let _carol_id = carol.identity.id();
 
-    let alice_handle = MANAGED_IDENTITY_STORAGE.insert(alice);
-    let bob_handle = MANAGED_IDENTITY_STORAGE.insert(bob);
-    let carol_handle = MANAGED_IDENTITY_STORAGE.insert(carol);
+        let alice_handle = MANAGED_IDENTITY_STORAGE.insert(alice);
+        let bob_handle = MANAGED_IDENTITY_STORAGE.insert(bob);
+        let carol_handle = MANAGED_IDENTITY_STORAGE.insert(carol);
 
-    identity_manager_add_identity(manager_handle, alice_handle, &mut error);
-    identity_manager_add_identity(manager_handle, bob_handle, &mut error);
-    identity_manager_add_identity(manager_handle, carol_handle, &mut error);
+        identity_manager_add_identity(manager_handle, alice_handle, &mut error);
+        identity_manager_add_identity(manager_handle, bob_handle, &mut error);
+        identity_manager_add_identity(manager_handle, carol_handle, &mut error);
 
-    // Verify count
-    let mut count: usize = 0;
-    let result = identity_manager_get_identity_count(manager_handle, &mut count, &mut error);
-    assert_eq!(result, PlatformWalletFFIResult::Success);
-    assert_eq!(count, 3);
+        // Verify count
+        let mut count: usize = 0;
+        let result = identity_manager_get_identity_count(manager_handle, &mut count, &mut error);
+        assert_eq!(result, PlatformWalletFFIResult::Success);
+        assert_eq!(count, 3);
 
-    // Get all identity IDs
-    let mut array = IdentifierArray {
-        items: std::ptr::null_mut(),
-        count: 0,
-    };
-    let result = identity_manager_get_all_identity_ids(manager_handle, &mut array, &mut error);
-    assert_eq!(result, PlatformWalletFFIResult::Success);
-    assert_eq!(array.count, 3);
+        // Get all identity IDs
+        let mut array = IdentifierArray {
+            items: std::ptr::null_mut(),
+            count: 0,
+        };
+        let result = identity_manager_get_all_identity_ids(manager_handle, &mut array, &mut error);
+        assert_eq!(result, PlatformWalletFFIResult::Success);
+        assert_eq!(array.count, 3);
 
-    // Set Alice as primary
-    let alice_id_bytes: IdentifierBytes = alice_id.into();
-    let result = identity_manager_set_primary_identity(manager_handle, alice_id_bytes, &mut error);
-    assert_eq!(result, PlatformWalletFFIResult::Success);
+        // Set Alice as primary
+        let alice_id_bytes: IdentifierBytes = alice_id.into();
+        let result =
+            identity_manager_set_primary_identity(manager_handle, alice_id_bytes, &mut error);
+        assert_eq!(result, PlatformWalletFFIResult::Success);
 
-    // Get primary
-    let mut primary_id = IdentifierBytes { bytes: [0u8; 32] };
-    let result =
-        identity_manager_get_primary_identity_id(manager_handle, &mut primary_id, &mut error);
-    assert_eq!(result, PlatformWalletFFIResult::Success);
-    assert_eq!(primary_id.bytes, alice_id_bytes.bytes);
+        // Get primary
+        let mut primary_id = IdentifierBytes { bytes: [0u8; 32] };
+        let result =
+            identity_manager_get_primary_identity_id(manager_handle, &mut primary_id, &mut error);
+        assert_eq!(result, PlatformWalletFFIResult::Success);
+        assert_eq!(primary_id.bytes, alice_id_bytes.bytes);
 
-    // Cleanup
-    platform_wallet_identifier_array_free(array);
-    identity_manager_destroy(manager_handle);
+        // Cleanup
+        platform_wallet_identifier_array_free(array);
+        identity_manager_destroy(manager_handle);
+    }
 }
 
 #[test]
 fn test_managed_identity_label_operations() {
-    let alice = identities::alice();
-    let alice_handle = MANAGED_IDENTITY_STORAGE.insert(alice);
+    unsafe {
+        let alice = identities::alice();
+        let alice_handle = MANAGED_IDENTITY_STORAGE.insert(alice);
 
-    let mut error = PlatformWalletFFIError::success();
+        let mut error = PlatformWalletFFIError::success();
 
-    // Get current label
-    let mut label_ptr: *mut std::os::raw::c_char = std::ptr::null_mut();
-    let result = managed_identity_get_label(alice_handle, &mut label_ptr, &mut error);
-    assert_eq!(result, PlatformWalletFFIResult::Success);
-    assert!(!label_ptr.is_null());
+        // Get current label
+        let mut label_ptr: *mut std::os::raw::c_char = std::ptr::null_mut();
+        let result = managed_identity_get_label(alice_handle, &mut label_ptr, &mut error);
+        assert_eq!(result, PlatformWalletFFIResult::Success);
+        assert!(!label_ptr.is_null());
 
-    let label = unsafe { std::ffi::CStr::from_ptr(label_ptr).to_str().unwrap() };
-    assert_eq!(label, "Alice");
-    platform_wallet_string_free(label_ptr);
+        let label = std::ffi::CStr::from_ptr(label_ptr).to_str().unwrap();
+        assert_eq!(label, "Alice");
+        platform_wallet_string_free(label_ptr);
 
-    // Set new label
-    let new_label = CString::new("Alice the Great").unwrap();
-    let result = managed_identity_set_label(alice_handle, new_label.as_ptr(), &mut error);
-    assert_eq!(result, PlatformWalletFFIResult::Success);
+        // Set new label
+        let new_label = CString::new("Alice the Great").unwrap();
+        let result = managed_identity_set_label(alice_handle, new_label.as_ptr(), &mut error);
+        assert_eq!(result, PlatformWalletFFIResult::Success);
 
-    // Verify new label
-    let mut label_ptr: *mut std::os::raw::c_char = std::ptr::null_mut();
-    let result = managed_identity_get_label(alice_handle, &mut label_ptr, &mut error);
-    assert_eq!(result, PlatformWalletFFIResult::Success);
+        // Verify new label
+        let mut label_ptr: *mut std::os::raw::c_char = std::ptr::null_mut();
+        let result = managed_identity_get_label(alice_handle, &mut label_ptr, &mut error);
+        assert_eq!(result, PlatformWalletFFIResult::Success);
 
-    let label = unsafe { std::ffi::CStr::from_ptr(label_ptr).to_str().unwrap() };
-    assert_eq!(label, "Alice the Great");
-    platform_wallet_string_free(label_ptr);
+        let label = std::ffi::CStr::from_ptr(label_ptr).to_str().unwrap();
+        assert_eq!(label, "Alice the Great");
+        platform_wallet_string_free(label_ptr);
 
-    // Cleanup
-    managed_identity_destroy(alice_handle);
+        // Cleanup
+        managed_identity_destroy(alice_handle);
+    }
 }
 
 #[test]
 fn test_managed_identity_balance_and_block_time() {
-    use dpp::identity::accessors::IdentityGettersV0;
+    unsafe {
+        use dpp::identity::accessors::IdentityGettersV0;
 
-    let alice = identities::alice();
-    let expected_balance = alice.identity.balance();
-    let alice_handle = MANAGED_IDENTITY_STORAGE.insert(alice);
+        let alice = identities::alice();
+        let expected_balance = alice.identity.balance();
+        let alice_handle = MANAGED_IDENTITY_STORAGE.insert(alice);
 
-    let mut error = PlatformWalletFFIError::success();
+        let mut error = PlatformWalletFFIError::success();
 
-    // Get balance
-    let mut balance: u64 = 0;
-    let result = managed_identity_get_balance(alice_handle, &mut balance, &mut error);
-    assert_eq!(result, PlatformWalletFFIResult::Success);
-    assert_eq!(balance, expected_balance);
+        // Get balance
+        let mut balance: u64 = 0;
+        let result = managed_identity_get_balance(alice_handle, &mut balance, &mut error);
+        assert_eq!(result, PlatformWalletFFIResult::Success);
+        assert_eq!(balance, expected_balance);
 
-    // Set balance block time
-    let block_time = BlockTime {
-        height: 123_456,
-        core_height: 987_654,
-        timestamp: 1_700_000_000,
-    };
-    let result =
-        managed_identity_set_last_updated_balance_block_time(alice_handle, block_time, &mut error);
-    assert_eq!(result, PlatformWalletFFIResult::Success);
+        // Set balance block time
+        let block_time = BlockTime {
+            height: 123_456,
+            core_height: 987_654,
+            timestamp: 1_700_000_000,
+        };
+        let result = managed_identity_set_last_updated_balance_block_time(
+            alice_handle,
+            block_time,
+            &mut error,
+        );
+        assert_eq!(result, PlatformWalletFFIResult::Success);
 
-    // Get balance block time
-    let mut retrieved_bt = BlockTime {
-        height: 0,
-        core_height: 0,
-        timestamp: 0,
-    };
-    let result = managed_identity_get_last_updated_balance_block_time(
-        alice_handle,
-        &mut retrieved_bt,
-        &mut error,
-    );
-    assert_eq!(result, PlatformWalletFFIResult::Success);
-    assert_eq!(retrieved_bt.height, 123_456);
-    assert_eq!(retrieved_bt.core_height, 987_654);
-    assert_eq!(retrieved_bt.timestamp, 1_700_000_000);
+        // Get balance block time
+        let mut retrieved_bt = BlockTime {
+            height: 0,
+            core_height: 0,
+            timestamp: 0,
+        };
+        let result = managed_identity_get_last_updated_balance_block_time(
+            alice_handle,
+            &mut retrieved_bt,
+            &mut error,
+        );
+        assert_eq!(result, PlatformWalletFFIResult::Success);
+        assert_eq!(retrieved_bt.height, 123_456);
+        assert_eq!(retrieved_bt.core_height, 987_654);
+        assert_eq!(retrieved_bt.timestamp, 1_700_000_000);
 
-    // Cleanup
-    managed_identity_destroy(alice_handle);
+        // Cleanup
+        managed_identity_destroy(alice_handle);
+    }
 }
 
 #[test]
 fn test_error_handling_invalid_handles() {
-    let mut error = PlatformWalletFFIError::success();
-    let invalid_handle = 99999;
+    unsafe {
+        let mut error = PlatformWalletFFIError::success();
+        let invalid_handle = 99999;
 
-    // Try to get identity with invalid handle
-    let mut id_bytes = IdentifierBytes { bytes: [0u8; 32] };
-    let result = managed_identity_get_id(invalid_handle, &mut id_bytes, &mut error);
-    assert_eq!(result, PlatformWalletFFIResult::ErrorInvalidHandle);
-    assert!(!error.message.is_null());
-    platform_wallet_ffi_error_free(error);
+        // Try to get identity with invalid handle
+        let mut id_bytes = IdentifierBytes { bytes: [0u8; 32] };
+        let result = managed_identity_get_id(invalid_handle, &mut id_bytes, &mut error);
+        assert_eq!(result, PlatformWalletFFIResult::ErrorInvalidHandle);
+        assert!(!error.message.is_null());
+        platform_wallet_ffi_error_free(error);
 
-    // Try to get contact request with invalid handle
-    error = PlatformWalletFFIError::success();
-    let result = contact_request_get_sender_id(invalid_handle, &mut id_bytes, &mut error);
-    assert_eq!(result, PlatformWalletFFIResult::ErrorInvalidHandle);
-    platform_wallet_ffi_error_free(error);
+        // Try to get contact request with invalid handle
+        error = PlatformWalletFFIError::success();
+        let result = contact_request_get_sender_id(invalid_handle, &mut id_bytes, &mut error);
+        assert_eq!(result, PlatformWalletFFIResult::ErrorInvalidHandle);
+        platform_wallet_ffi_error_free(error);
 
-    // Try to destroy invalid handle
-    let result = managed_identity_destroy(invalid_handle);
-    assert_eq!(result, PlatformWalletFFIResult::ErrorInvalidHandle);
+        // Try to destroy invalid handle
+        let result = managed_identity_destroy(invalid_handle);
+        assert_eq!(result, PlatformWalletFFIResult::ErrorInvalidHandle);
+    }
 }
 
 #[test]
 fn test_error_handling_null_pointers() {
-    let alice = identities::alice();
-    let alice_handle = MANAGED_IDENTITY_STORAGE.insert(alice);
+    unsafe {
+        let alice = identities::alice();
+        let alice_handle = MANAGED_IDENTITY_STORAGE.insert(alice);
 
-    // Try to get ID with null output pointer
-    let result = managed_identity_get_id(alice_handle, std::ptr::null_mut(), std::ptr::null_mut());
-    assert_eq!(result, PlatformWalletFFIResult::ErrorNullPointer);
+        // Try to get ID with null output pointer
+        let result =
+            managed_identity_get_id(alice_handle, std::ptr::null_mut(), std::ptr::null_mut());
+        assert_eq!(result, PlatformWalletFFIResult::ErrorNullPointer);
 
-    // Try to get balance with null output pointer
-    let result =
-        managed_identity_get_balance(alice_handle, std::ptr::null_mut(), std::ptr::null_mut());
-    assert_eq!(result, PlatformWalletFFIResult::ErrorNullPointer);
+        // Try to get balance with null output pointer
+        let result =
+            managed_identity_get_balance(alice_handle, std::ptr::null_mut(), std::ptr::null_mut());
+        assert_eq!(result, PlatformWalletFFIResult::ErrorNullPointer);
 
-    // Try to get sent requests with null output pointer
-    let result = managed_identity_get_sent_contact_request_ids(
-        alice_handle,
-        std::ptr::null_mut(),
-        std::ptr::null_mut(),
-    );
-    assert_eq!(result, PlatformWalletFFIResult::ErrorNullPointer);
+        // Try to get sent requests with null output pointer
+        let result = managed_identity_get_sent_contact_request_ids(
+            alice_handle,
+            std::ptr::null_mut(),
+            std::ptr::null_mut(),
+        );
+        assert_eq!(result, PlatformWalletFFIResult::ErrorNullPointer);
 
-    // Cleanup
-    managed_identity_destroy(alice_handle);
+        // Cleanup
+        managed_identity_destroy(alice_handle);
+    }
 }
 
 #[test]
 fn test_contact_request_not_found() {
-    let alice = identities::alice(); // Has no contacts by default
-    let alice_handle = MANAGED_IDENTITY_STORAGE.insert(alice);
+    unsafe {
+        let alice = identities::alice(); // Has no contacts by default
+        let alice_handle = MANAGED_IDENTITY_STORAGE.insert(alice);
 
-    let mut error = PlatformWalletFFIError::success();
-    let eve_id_bytes: IdentifierBytes = identities::eve().identity.id().into();
+        let mut error = PlatformWalletFFIError::success();
+        let eve_id_bytes: IdentifierBytes = identities::eve().identity.id().into();
 
-    // Try to get non-existent sent request
-    let mut request_handle: Handle = NULL_HANDLE;
-    let result = managed_identity_get_sent_contact_request(
-        alice_handle,
-        eve_id_bytes,
-        &mut request_handle,
-        &mut error,
-    );
-    assert_eq!(result, PlatformWalletFFIResult::ErrorContactNotFound);
-    assert!(!error.message.is_null());
+        // Try to get non-existent sent request
+        let mut request_handle: Handle = NULL_HANDLE;
+        let result = managed_identity_get_sent_contact_request(
+            alice_handle,
+            eve_id_bytes,
+            &mut request_handle,
+            &mut error,
+        );
+        assert_eq!(result, PlatformWalletFFIResult::ErrorContactNotFound);
+        assert!(!error.message.is_null());
 
-    // Cleanup
-    platform_wallet_ffi_error_free(error);
-    managed_identity_destroy(alice_handle);
+        // Cleanup
+        platform_wallet_ffi_error_free(error);
+        managed_identity_destroy(alice_handle);
+    }
 }
 
 #[test]
 fn test_identifier_operations() {
-    let mut error = PlatformWalletFFIError::success();
+    unsafe {
+        let mut error = PlatformWalletFFIError::success();
 
-    // Generate random identifier
-    let mut id = IdentifierBytes { bytes: [0u8; 32] };
-    let result = platform_wallet_generate_random_identifier(&mut id, &mut error);
-    assert_eq!(result, PlatformWalletFFIResult::Success);
-    // Should not be all zeros
-    assert_ne!(id.bytes, [0u8; 32]);
+        // Generate random identifier
+        let mut id = IdentifierBytes { bytes: [0u8; 32] };
+        let result = platform_wallet_generate_random_identifier(&mut id, &mut error);
+        assert_eq!(result, PlatformWalletFFIResult::Success);
+        // Should not be all zeros
+        assert_ne!(id.bytes, [0u8; 32]);
 
-    // Convert to string (actually Base58, despite function name)
-    let mut id_string: *mut std::os::raw::c_char = std::ptr::null_mut();
-    let result = platform_wallet_identifier_to_hex(id, &mut id_string, &mut error);
-    assert_eq!(result, PlatformWalletFFIResult::Success);
-    assert!(!id_string.is_null());
+        // Convert to string (actually Base58, despite function name)
+        let mut id_string: *mut std::os::raw::c_char = std::ptr::null_mut();
+        let result = platform_wallet_identifier_to_hex(id, &mut id_string, &mut error);
+        assert_eq!(result, PlatformWalletFFIResult::Success);
+        assert!(!id_string.is_null());
 
-    let id_str = unsafe { std::ffi::CStr::from_ptr(id_string).to_str().unwrap() };
-    assert_eq!(id_str.len(), 44); // Base58-encoded identifier is 44 chars
+        let id_str = std::ffi::CStr::from_ptr(id_string).to_str().unwrap();
+        assert_eq!(id_str.len(), 44); // Base58-encoded identifier is 44 chars
 
-    // Convert back from string
-    let mut id2 = IdentifierBytes { bytes: [0u8; 32] };
-    let result = platform_wallet_identifier_from_hex(id_string, &mut id2, &mut error);
-    assert_eq!(result, PlatformWalletFFIResult::Success);
+        // Convert back from string
+        let mut id2 = IdentifierBytes { bytes: [0u8; 32] };
+        let result = platform_wallet_identifier_from_hex(id_string, &mut id2, &mut error);
+        assert_eq!(result, PlatformWalletFFIResult::Success);
 
-    // Should match original
-    assert_eq!(id.bytes, id2.bytes);
+        // Should match original
+        assert_eq!(id.bytes, id2.bytes);
 
-    // Cleanup
-    platform_wallet_string_free(id_string);
+        // Cleanup
+        platform_wallet_string_free(id_string);
+    }
 }
 
 #[test]
 fn test_memory_lifecycle() {
-    // Test proper creation and destruction of multiple objects
+    unsafe {
+        // Test proper creation and destruction of multiple objects
 
-    // Create multiple managed identities
-    let alice = identities::alice();
-    let bob = identities::bob();
-    let carol = identities::carol();
+        // Create multiple managed identities
+        let alice = identities::alice();
+        let bob = identities::bob();
+        let carol = identities::carol();
 
-    let alice_handle = MANAGED_IDENTITY_STORAGE.insert(alice);
-    let bob_handle = MANAGED_IDENTITY_STORAGE.insert(bob);
-    let carol_handle = MANAGED_IDENTITY_STORAGE.insert(carol);
+        let alice_handle = MANAGED_IDENTITY_STORAGE.insert(alice);
+        let bob_handle = MANAGED_IDENTITY_STORAGE.insert(bob);
+        let carol_handle = MANAGED_IDENTITY_STORAGE.insert(carol);
 
-    // Verify they exist
-    let mut error = PlatformWalletFFIError::success();
-    let mut id = IdentifierBytes { bytes: [0u8; 32] };
+        // Verify they exist
+        let mut error = PlatformWalletFFIError::success();
+        let mut id = IdentifierBytes { bytes: [0u8; 32] };
 
-    assert_eq!(
-        managed_identity_get_id(alice_handle, &mut id, &mut error),
-        PlatformWalletFFIResult::Success
-    );
-    assert_eq!(
-        managed_identity_get_id(bob_handle, &mut id, &mut error),
-        PlatformWalletFFIResult::Success
-    );
-    assert_eq!(
-        managed_identity_get_id(carol_handle, &mut id, &mut error),
-        PlatformWalletFFIResult::Success
-    );
+        assert_eq!(
+            managed_identity_get_id(alice_handle, &mut id, &mut error),
+            PlatformWalletFFIResult::Success
+        );
+        assert_eq!(
+            managed_identity_get_id(bob_handle, &mut id, &mut error),
+            PlatformWalletFFIResult::Success
+        );
+        assert_eq!(
+            managed_identity_get_id(carol_handle, &mut id, &mut error),
+            PlatformWalletFFIResult::Success
+        );
 
-    // Destroy Alice
-    assert_eq!(
-        managed_identity_destroy(alice_handle),
-        PlatformWalletFFIResult::Success
-    );
+        // Destroy Alice
+        assert_eq!(
+            managed_identity_destroy(alice_handle),
+            PlatformWalletFFIResult::Success
+        );
 
-    // Alice should be gone, but Bob and Carol should still exist
-    assert_eq!(
-        managed_identity_get_id(alice_handle, &mut id, &mut error),
-        PlatformWalletFFIResult::ErrorInvalidHandle
-    );
-    platform_wallet_ffi_error_free(error);
-    error = PlatformWalletFFIError::success();
+        // Alice should be gone, but Bob and Carol should still exist
+        assert_eq!(
+            managed_identity_get_id(alice_handle, &mut id, &mut error),
+            PlatformWalletFFIResult::ErrorInvalidHandle
+        );
+        platform_wallet_ffi_error_free(error);
+        error = PlatformWalletFFIError::success();
 
-    assert_eq!(
-        managed_identity_get_id(bob_handle, &mut id, &mut error),
-        PlatformWalletFFIResult::Success
-    );
-    assert_eq!(
-        managed_identity_get_id(carol_handle, &mut id, &mut error),
-        PlatformWalletFFIResult::Success
-    );
+        assert_eq!(
+            managed_identity_get_id(bob_handle, &mut id, &mut error),
+            PlatformWalletFFIResult::Success
+        );
+        assert_eq!(
+            managed_identity_get_id(carol_handle, &mut id, &mut error),
+            PlatformWalletFFIResult::Success
+        );
 
-    // Cleanup remaining
-    managed_identity_destroy(bob_handle);
-    managed_identity_destroy(carol_handle);
+        // Cleanup remaining
+        managed_identity_destroy(bob_handle);
+        managed_identity_destroy(carol_handle);
 
-    // Double destroy should fail
-    assert_eq!(
-        managed_identity_destroy(bob_handle),
-        PlatformWalletFFIResult::ErrorInvalidHandle
-    );
+        // Double destroy should fail
+        assert_eq!(
+            managed_identity_destroy(bob_handle),
+            PlatformWalletFFIResult::ErrorInvalidHandle
+        );
+    }
 }
 
 #[test]
 fn test_concurrent_identity_operations() {
-    // Test that operations on different identities don't interfere
+    unsafe {
+        // Test that operations on different identities don't interfere
 
-    let (alice, alice_requests) = scenarios::alice_with_pending_sent_requests();
-    let (bob, bob_requests) = scenarios::alice_with_pending_incoming_requests(); // Reuse for Bob
-    let carol = scenarios::alice_with_mixed_contacts(); // Reuse for Carol
+        let (alice, _alice_requests) = scenarios::alice_with_pending_sent_requests();
+        let (bob, _bob_requests) = scenarios::alice_with_pending_incoming_requests(); // Reuse for Bob
+        let carol = scenarios::alice_with_mixed_contacts(); // Reuse for Carol
 
-    let alice_handle = MANAGED_IDENTITY_STORAGE.insert(alice);
-    let bob_handle = MANAGED_IDENTITY_STORAGE.insert(bob);
-    let carol_handle = MANAGED_IDENTITY_STORAGE.insert(carol);
+        let alice_handle = MANAGED_IDENTITY_STORAGE.insert(alice);
+        let bob_handle = MANAGED_IDENTITY_STORAGE.insert(bob);
+        let carol_handle = MANAGED_IDENTITY_STORAGE.insert(carol);
 
-    let mut error = PlatformWalletFFIError::success();
+        let mut error = PlatformWalletFFIError::success();
 
-    // Verify Alice has 3 sent requests
-    let mut alice_array = IdentifierArray {
-        items: std::ptr::null_mut(),
-        count: 0,
-    };
-    managed_identity_get_sent_contact_request_ids(alice_handle, &mut alice_array, &mut error);
-    assert_eq!(alice_array.count, 3);
+        // Verify Alice has 3 sent requests
+        let mut alice_array = IdentifierArray {
+            items: std::ptr::null_mut(),
+            count: 0,
+        };
+        managed_identity_get_sent_contact_request_ids(alice_handle, &mut alice_array, &mut error);
+        assert_eq!(alice_array.count, 3);
 
-    // Verify Bob has 3 incoming requests (we reused the scenario)
-    let mut bob_array = IdentifierArray {
-        items: std::ptr::null_mut(),
-        count: 0,
-    };
-    managed_identity_get_incoming_contact_request_ids(bob_handle, &mut bob_array, &mut error);
-    assert_eq!(bob_array.count, 3);
+        // Verify Bob has 3 incoming requests (we reused the scenario)
+        let mut bob_array = IdentifierArray {
+            items: std::ptr::null_mut(),
+            count: 0,
+        };
+        managed_identity_get_incoming_contact_request_ids(bob_handle, &mut bob_array, &mut error);
+        assert_eq!(bob_array.count, 3);
 
-    // Verify Carol has mixed contacts
-    let mut carol_sent = IdentifierArray {
-        items: std::ptr::null_mut(),
-        count: 0,
-    };
-    managed_identity_get_sent_contact_request_ids(carol_handle, &mut carol_sent, &mut error);
-    assert_eq!(carol_sent.count, 1);
+        // Verify Carol has mixed contacts
+        let mut carol_sent = IdentifierArray {
+            items: std::ptr::null_mut(),
+            count: 0,
+        };
+        managed_identity_get_sent_contact_request_ids(carol_handle, &mut carol_sent, &mut error);
+        assert_eq!(carol_sent.count, 1);
 
-    // Operations on Alice shouldn't affect Bob or Carol
-    let new_label = CString::new("Alice Updated").unwrap();
-    managed_identity_set_label(alice_handle, new_label.as_ptr(), &mut error);
+        // Operations on Alice shouldn't affect Bob or Carol
+        let new_label = CString::new("Alice Updated").unwrap();
+        managed_identity_set_label(alice_handle, new_label.as_ptr(), &mut error);
 
-    // Bob's incoming requests should still be 3
-    let mut bob_array2 = IdentifierArray {
-        items: std::ptr::null_mut(),
-        count: 0,
-    };
-    managed_identity_get_incoming_contact_request_ids(bob_handle, &mut bob_array2, &mut error);
-    assert_eq!(bob_array2.count, 3);
+        // Bob's incoming requests should still be 3
+        let mut bob_array2 = IdentifierArray {
+            items: std::ptr::null_mut(),
+            count: 0,
+        };
+        managed_identity_get_incoming_contact_request_ids(bob_handle, &mut bob_array2, &mut error);
+        assert_eq!(bob_array2.count, 3);
 
-    // Cleanup
-    platform_wallet_identifier_array_free(alice_array);
-    platform_wallet_identifier_array_free(bob_array);
-    platform_wallet_identifier_array_free(bob_array2);
-    platform_wallet_identifier_array_free(carol_sent);
-    managed_identity_destroy(alice_handle);
-    managed_identity_destroy(bob_handle);
-    managed_identity_destroy(carol_handle);
+        // Cleanup
+        platform_wallet_identifier_array_free(alice_array);
+        platform_wallet_identifier_array_free(bob_array);
+        platform_wallet_identifier_array_free(bob_array2);
+        platform_wallet_identifier_array_free(carol_sent);
+        managed_identity_destroy(alice_handle);
+        managed_identity_destroy(bob_handle);
+        managed_identity_destroy(carol_handle);
+    }
 }
 
 // ============================================================================
@@ -632,235 +675,262 @@ fn test_concurrent_identity_operations() {
 
 #[test]
 fn test_get_established_contact_and_fields() {
-    use dpp::identity::accessors::IdentityGettersV0;
+    unsafe {
+        use dpp::identity::accessors::IdentityGettersV0;
 
-    // Create Alice with established contacts
-    let (alice, _contacts) = test_data::scenarios::alice_with_established_contacts();
-    let alice_handle = MANAGED_IDENTITY_STORAGE.insert(alice.clone());
+        // Create Alice with established contacts
+        let (alice, _contacts) = test_data::scenarios::alice_with_established_contacts();
+        let alice_handle = MANAGED_IDENTITY_STORAGE.insert(alice.clone());
 
-    let bob_id = test_data::identities::bob().identity.id();
-    let bob_id_bytes: IdentifierBytes = bob_id.into();
+        let bob_id = test_data::identities::bob().identity.id();
+        let bob_id_bytes: IdentifierBytes = bob_id.into();
 
-    let mut contact_handle: Handle = NULL_HANDLE;
-    let mut error = PlatformWalletFFIError::success();
+        let mut contact_handle: Handle = NULL_HANDLE;
+        let mut error = PlatformWalletFFIError::success();
 
-    // Get established contact
-    let result = managed_identity_get_established_contact(
-        alice_handle,
-        bob_id_bytes,
-        &mut contact_handle,
-        &mut error,
-    );
+        // Get established contact
+        let result = managed_identity_get_established_contact(
+            alice_handle,
+            bob_id_bytes,
+            &mut contact_handle,
+            &mut error,
+        );
 
-    assert_eq!(result, PlatformWalletFFIResult::Success);
-    assert_ne!(contact_handle, NULL_HANDLE);
+        assert_eq!(result, PlatformWalletFFIResult::Success);
+        assert_ne!(contact_handle, NULL_HANDLE);
 
-    // Get contact ID
-    let mut retrieved_id = IdentifierBytes { bytes: [0u8; 32] };
-    let result = established_contact_get_contact_id(contact_handle, &mut retrieved_id, &mut error);
-    assert_eq!(result, PlatformWalletFFIResult::Success);
-    assert_eq!(retrieved_id.bytes, bob_id_bytes.bytes);
+        // Get contact ID
+        let mut retrieved_id = IdentifierBytes { bytes: [0u8; 32] };
+        let result =
+            established_contact_get_contact_id(contact_handle, &mut retrieved_id, &mut error);
+        assert_eq!(result, PlatformWalletFFIResult::Success);
+        assert_eq!(retrieved_id.bytes, bob_id_bytes.bytes);
 
-    // Cleanup
-    established_contact_destroy(contact_handle);
-    managed_identity_destroy(alice_handle);
+        // Cleanup
+        established_contact_destroy(contact_handle);
+        managed_identity_destroy(alice_handle);
+    }
 }
 
 #[test]
 fn test_established_contact_outgoing_and_incoming_requests() {
-    use dpp::identity::accessors::IdentityGettersV0;
+    unsafe {
+        use dpp::identity::accessors::IdentityGettersV0;
 
-    let (alice, _contacts) = test_data::scenarios::alice_with_established_contacts();
-    let alice_handle = MANAGED_IDENTITY_STORAGE.insert(alice.clone());
+        let (alice, _contacts) = test_data::scenarios::alice_with_established_contacts();
+        let alice_handle = MANAGED_IDENTITY_STORAGE.insert(alice.clone());
 
-    let bob_id = test_data::identities::bob().identity.id();
-    let bob_id_bytes: IdentifierBytes = bob_id.into();
+        let bob_id = test_data::identities::bob().identity.id();
+        let bob_id_bytes: IdentifierBytes = bob_id.into();
 
-    let mut contact_handle: Handle = NULL_HANDLE;
-    let mut error = PlatformWalletFFIError::success();
+        let mut contact_handle: Handle = NULL_HANDLE;
+        let mut error = PlatformWalletFFIError::success();
 
-    managed_identity_get_established_contact(
-        alice_handle,
-        bob_id_bytes,
-        &mut contact_handle,
-        &mut error,
-    );
+        managed_identity_get_established_contact(
+            alice_handle,
+            bob_id_bytes,
+            &mut contact_handle,
+            &mut error,
+        );
 
-    // Get outgoing request
-    let mut outgoing_handle: Handle = NULL_HANDLE;
-    let result =
-        established_contact_get_outgoing_request(contact_handle, &mut outgoing_handle, &mut error);
-    assert_eq!(result, PlatformWalletFFIResult::Success);
-    assert_ne!(outgoing_handle, NULL_HANDLE);
+        // Get outgoing request
+        let mut outgoing_handle: Handle = NULL_HANDLE;
+        let result = established_contact_get_outgoing_request(
+            contact_handle,
+            &mut outgoing_handle,
+            &mut error,
+        );
+        assert_eq!(result, PlatformWalletFFIResult::Success);
+        assert_ne!(outgoing_handle, NULL_HANDLE);
 
-    // Get incoming request
-    let mut incoming_handle: Handle = NULL_HANDLE;
-    let result =
-        established_contact_get_incoming_request(contact_handle, &mut incoming_handle, &mut error);
-    assert_eq!(result, PlatformWalletFFIResult::Success);
-    assert_ne!(incoming_handle, NULL_HANDLE);
+        // Get incoming request
+        let mut incoming_handle: Handle = NULL_HANDLE;
+        let result = established_contact_get_incoming_request(
+            contact_handle,
+            &mut incoming_handle,
+            &mut error,
+        );
+        assert_eq!(result, PlatformWalletFFIResult::Success);
+        assert_ne!(incoming_handle, NULL_HANDLE);
 
-    // Verify the requests have correct sender/recipient
-    let alice_id = alice.identity.id();
-    let mut sender_id = IdentifierBytes { bytes: [0u8; 32] };
-    let mut recipient_id = IdentifierBytes { bytes: [0u8; 32] };
+        // Verify the requests have correct sender/recipient
+        let alice_id = alice.identity.id();
+        let mut sender_id = IdentifierBytes { bytes: [0u8; 32] };
+        let mut recipient_id = IdentifierBytes { bytes: [0u8; 32] };
 
-    // Outgoing: from alice to bob
-    contact_request_get_sender_id(outgoing_handle, &mut sender_id, &mut error);
-    contact_request_get_recipient_id(outgoing_handle, &mut recipient_id, &mut error);
-    assert_eq!(sender_id.bytes, IdentifierBytes::from(alice_id).bytes);
-    assert_eq!(recipient_id.bytes, bob_id_bytes.bytes);
+        // Outgoing: from alice to bob
+        contact_request_get_sender_id(outgoing_handle, &mut sender_id, &mut error);
+        contact_request_get_recipient_id(outgoing_handle, &mut recipient_id, &mut error);
+        assert_eq!(sender_id.bytes, IdentifierBytes::from(alice_id).bytes);
+        assert_eq!(recipient_id.bytes, bob_id_bytes.bytes);
 
-    // Incoming: from bob to alice
-    contact_request_get_sender_id(incoming_handle, &mut sender_id, &mut error);
-    contact_request_get_recipient_id(incoming_handle, &mut recipient_id, &mut error);
-    assert_eq!(sender_id.bytes, bob_id_bytes.bytes);
-    assert_eq!(recipient_id.bytes, IdentifierBytes::from(alice_id).bytes);
+        // Incoming: from bob to alice
+        contact_request_get_sender_id(incoming_handle, &mut sender_id, &mut error);
+        contact_request_get_recipient_id(incoming_handle, &mut recipient_id, &mut error);
+        assert_eq!(sender_id.bytes, bob_id_bytes.bytes);
+        assert_eq!(recipient_id.bytes, IdentifierBytes::from(alice_id).bytes);
 
-    // Cleanup
-    contact_request_destroy(outgoing_handle);
-    contact_request_destroy(incoming_handle);
-    established_contact_destroy(contact_handle);
-    managed_identity_destroy(alice_handle);
+        // Cleanup
+        contact_request_destroy(outgoing_handle);
+        contact_request_destroy(incoming_handle);
+        established_contact_destroy(contact_handle);
+        managed_identity_destroy(alice_handle);
+    }
 }
 
 #[test]
 fn test_established_contact_request_fields() {
-    use dpp::identity::accessors::IdentityGettersV0;
+    unsafe {
+        use dpp::identity::accessors::IdentityGettersV0;
 
-    let (alice, _contacts) = test_data::scenarios::alice_with_established_contacts();
-    let alice_handle = MANAGED_IDENTITY_STORAGE.insert(alice.clone());
+        let (alice, _contacts) = test_data::scenarios::alice_with_established_contacts();
+        let alice_handle = MANAGED_IDENTITY_STORAGE.insert(alice.clone());
 
-    let bob_id = test_data::identities::bob().identity.id();
-    let bob_id_bytes: IdentifierBytes = bob_id.into();
+        let bob_id = test_data::identities::bob().identity.id();
+        let bob_id_bytes: IdentifierBytes = bob_id.into();
 
-    let mut contact_handle: Handle = NULL_HANDLE;
-    let mut error = PlatformWalletFFIError::success();
+        let mut contact_handle: Handle = NULL_HANDLE;
+        let mut error = PlatformWalletFFIError::success();
 
-    managed_identity_get_established_contact(
-        alice_handle,
-        bob_id_bytes,
-        &mut contact_handle,
-        &mut error,
-    );
+        managed_identity_get_established_contact(
+            alice_handle,
+            bob_id_bytes,
+            &mut contact_handle,
+            &mut error,
+        );
 
-    // Get outgoing request and verify all fields
-    let mut outgoing_handle: Handle = NULL_HANDLE;
-    established_contact_get_outgoing_request(contact_handle, &mut outgoing_handle, &mut error);
+        // Get outgoing request and verify all fields
+        let mut outgoing_handle: Handle = NULL_HANDLE;
+        established_contact_get_outgoing_request(contact_handle, &mut outgoing_handle, &mut error);
 
-    let mut sender_key_idx: u32 = 0;
-    let mut recipient_key_idx: u32 = 0;
-    let mut account_ref: u32 = 0;
-    let mut created_at: u64 = 0;
+        let mut sender_key_idx: u32 = 0;
+        let mut recipient_key_idx: u32 = 0;
+        let mut account_ref: u32 = 0;
+        let mut created_at: u64 = 0;
 
-    contact_request_get_sender_key_index(outgoing_handle, &mut sender_key_idx, &mut error);
-    contact_request_get_recipient_key_index(outgoing_handle, &mut recipient_key_idx, &mut error);
-    contact_request_get_account_reference(outgoing_handle, &mut account_ref, &mut error);
-    contact_request_get_created_at(outgoing_handle, &mut created_at, &mut error);
+        contact_request_get_sender_key_index(outgoing_handle, &mut sender_key_idx, &mut error);
+        contact_request_get_recipient_key_index(
+            outgoing_handle,
+            &mut recipient_key_idx,
+            &mut error,
+        );
+        contact_request_get_account_reference(outgoing_handle, &mut account_ref, &mut error);
+        contact_request_get_created_at(outgoing_handle, &mut created_at, &mut error);
 
-    // The test data should have specific values
-    assert_eq!(sender_key_idx, 0);
-    assert_eq!(recipient_key_idx, 1);
-    assert_eq!(account_ref, 0);
-    assert!(created_at > 0);
+        // The test data should have specific values
+        assert_eq!(sender_key_idx, 0);
+        assert_eq!(recipient_key_idx, 1);
+        assert_eq!(account_ref, 0);
+        assert!(created_at > 0);
 
-    // Get encrypted public key
-    let mut bytes_ptr: *mut std::os::raw::c_uchar = std::ptr::null_mut();
-    let mut len: usize = 0;
-    let result = contact_request_get_encrypted_public_key(
-        outgoing_handle,
-        &mut bytes_ptr,
-        &mut len,
-        &mut error,
-    );
-    assert_eq!(result, PlatformWalletFFIResult::Success);
-    assert_eq!(len, 96); // Standard encrypted key length
-    assert!(!bytes_ptr.is_null());
+        // Get encrypted public key
+        let mut bytes_ptr: *mut std::os::raw::c_uchar = std::ptr::null_mut();
+        let mut len: usize = 0;
+        let result = contact_request_get_encrypted_public_key(
+            outgoing_handle,
+            &mut bytes_ptr,
+            &mut len,
+            &mut error,
+        );
+        assert_eq!(result, PlatformWalletFFIResult::Success);
+        assert_eq!(len, 96); // Standard encrypted key length
+        assert!(!bytes_ptr.is_null());
 
-    // Cleanup
-    platform_wallet_bytes_free(bytes_ptr, len);
-    contact_request_destroy(outgoing_handle);
-    established_contact_destroy(contact_handle);
-    managed_identity_destroy(alice_handle);
+        // Cleanup
+        platform_wallet_bytes_free(bytes_ptr, len);
+        contact_request_destroy(outgoing_handle);
+        established_contact_destroy(contact_handle);
+        managed_identity_destroy(alice_handle);
+    }
 }
 
 #[test]
 fn test_get_nonexistent_established_contact() {
-    let alice = test_data::identities::alice();
-    let alice_handle = MANAGED_IDENTITY_STORAGE.insert(alice);
+    unsafe {
+        let alice = test_data::identities::alice();
+        let alice_handle = MANAGED_IDENTITY_STORAGE.insert(alice);
 
-    let nonexistent_id = IdentifierBytes { bytes: [99u8; 32] };
+        let nonexistent_id = IdentifierBytes { bytes: [99u8; 32] };
 
-    let mut contact_handle: Handle = NULL_HANDLE;
-    let mut error = PlatformWalletFFIError::success();
+        let mut contact_handle: Handle = NULL_HANDLE;
+        let mut error = PlatformWalletFFIError::success();
 
-    let result = managed_identity_get_established_contact(
-        alice_handle,
-        nonexistent_id,
-        &mut contact_handle,
-        &mut error,
-    );
+        let result = managed_identity_get_established_contact(
+            alice_handle,
+            nonexistent_id,
+            &mut contact_handle,
+            &mut error,
+        );
 
-    assert_eq!(result, PlatformWalletFFIResult::ErrorContactNotFound);
-    assert_eq!(contact_handle, NULL_HANDLE);
+        assert_eq!(result, PlatformWalletFFIResult::ErrorContactNotFound);
+        assert_eq!(contact_handle, NULL_HANDLE);
 
-    // Cleanup
-    managed_identity_destroy(alice_handle);
+        // Cleanup
+        managed_identity_destroy(alice_handle);
+    }
 }
 
 #[test]
 fn test_established_contact_destroy_invalid_handle() {
-    let result = established_contact_destroy(9999);
-    assert_eq!(result, PlatformWalletFFIResult::ErrorInvalidHandle);
+    unsafe {
+        let result = established_contact_destroy(9999);
+        assert_eq!(result, PlatformWalletFFIResult::ErrorInvalidHandle);
+    }
 }
 
 #[test]
 fn test_multiple_established_contacts() {
-    use dpp::identity::accessors::IdentityGettersV0;
+    unsafe {
+        use dpp::identity::accessors::IdentityGettersV0;
 
-    let (alice, _contacts) = test_data::scenarios::alice_with_established_contacts();
-    let alice_handle = MANAGED_IDENTITY_STORAGE.insert(alice.clone());
+        let (alice, _contacts) = test_data::scenarios::alice_with_established_contacts();
+        let alice_handle = MANAGED_IDENTITY_STORAGE.insert(alice.clone());
 
-    let bob_id = test_data::identities::bob().identity.id();
-    let carol_id = test_data::identities::carol().identity.id();
+        let bob_id = test_data::identities::bob().identity.id();
+        let carol_id = test_data::identities::carol().identity.id();
 
-    let mut error = PlatformWalletFFIError::success();
+        let mut error = PlatformWalletFFIError::success();
 
-    // Get Bob contact
-    let mut bob_contact_handle: Handle = NULL_HANDLE;
-    let result = managed_identity_get_established_contact(
-        alice_handle,
-        bob_id.into(),
-        &mut bob_contact_handle,
-        &mut error,
-    );
-    assert_eq!(result, PlatformWalletFFIResult::Success);
+        // Get Bob contact
+        let mut bob_contact_handle: Handle = NULL_HANDLE;
+        let result = managed_identity_get_established_contact(
+            alice_handle,
+            bob_id.into(),
+            &mut bob_contact_handle,
+            &mut error,
+        );
+        assert_eq!(result, PlatformWalletFFIResult::Success);
 
-    // Get Carol contact
-    let mut carol_contact_handle: Handle = NULL_HANDLE;
-    let result = managed_identity_get_established_contact(
-        alice_handle,
-        carol_id.into(),
-        &mut carol_contact_handle,
-        &mut error,
-    );
-    assert_eq!(result, PlatformWalletFFIResult::Success);
+        // Get Carol contact
+        let mut carol_contact_handle: Handle = NULL_HANDLE;
+        let result = managed_identity_get_established_contact(
+            alice_handle,
+            carol_id.into(),
+            &mut carol_contact_handle,
+            &mut error,
+        );
+        assert_eq!(result, PlatformWalletFFIResult::Success);
 
-    // Verify Bob's contact ID
-    let mut retrieved_bob_id = IdentifierBytes { bytes: [0u8; 32] };
-    established_contact_get_contact_id(bob_contact_handle, &mut retrieved_bob_id, &mut error);
-    assert_eq!(retrieved_bob_id.bytes, IdentifierBytes::from(bob_id).bytes);
+        // Verify Bob's contact ID
+        let mut retrieved_bob_id = IdentifierBytes { bytes: [0u8; 32] };
+        established_contact_get_contact_id(bob_contact_handle, &mut retrieved_bob_id, &mut error);
+        assert_eq!(retrieved_bob_id.bytes, IdentifierBytes::from(bob_id).bytes);
 
-    // Verify Carol's contact ID
-    let mut retrieved_carol_id = IdentifierBytes { bytes: [0u8; 32] };
-    established_contact_get_contact_id(carol_contact_handle, &mut retrieved_carol_id, &mut error);
-    assert_eq!(
-        retrieved_carol_id.bytes,
-        IdentifierBytes::from(carol_id).bytes
-    );
+        // Verify Carol's contact ID
+        let mut retrieved_carol_id = IdentifierBytes { bytes: [0u8; 32] };
+        established_contact_get_contact_id(
+            carol_contact_handle,
+            &mut retrieved_carol_id,
+            &mut error,
+        );
+        assert_eq!(
+            retrieved_carol_id.bytes,
+            IdentifierBytes::from(carol_id).bytes
+        );
 
-    // Cleanup
-    established_contact_destroy(bob_contact_handle);
-    established_contact_destroy(carol_contact_handle);
-    managed_identity_destroy(alice_handle);
+        // Cleanup
+        established_contact_destroy(bob_contact_handle);
+        established_contact_destroy(carol_contact_handle);
+        managed_identity_destroy(alice_handle);
+    }
 }

--- a/packages/rs-platform-wallet-ffi/tests/integration_tests.rs
+++ b/packages/rs-platform-wallet-ffi/tests/integration_tests.rs
@@ -15,311 +15,330 @@ fn test_library_init_and_version() {
 
 #[test]
 fn test_wallet_creation_and_destruction() {
-    let seed = [0u8; 64];
-    let mut handle: Handle = NULL_HANDLE;
-    let mut error = PlatformWalletFFIError::success();
+    unsafe {
+        let seed = [0u8; 64];
+        let mut handle: Handle = NULL_HANDLE;
+        let mut error = PlatformWalletFFIError::success();
 
-    let result = platform_wallet_info_create_from_seed(
-        Network::Testnet,
-        seed.as_ptr(),
-        seed.len(),
-        &mut handle,
-        &mut error,
-    );
+        let result = platform_wallet_info_create_from_seed(
+            Network::Testnet,
+            seed.as_ptr(),
+            seed.len(),
+            &mut handle,
+            &mut error,
+        );
 
-    assert_eq!(result, PlatformWalletFFIResult::Success);
-    assert_ne!(handle, NULL_HANDLE);
+        assert_eq!(result, PlatformWalletFFIResult::Success);
+        assert_ne!(handle, NULL_HANDLE);
 
-    let result = platform_wallet_info_destroy(handle);
-    assert_eq!(result, PlatformWalletFFIResult::Success);
+        let result = platform_wallet_info_destroy(handle);
+        assert_eq!(result, PlatformWalletFFIResult::Success);
 
-    // Double destroy should fail
-    let result = platform_wallet_info_destroy(handle);
-    assert_eq!(result, PlatformWalletFFIResult::ErrorInvalidHandle);
+        // Double destroy should fail
+        let result = platform_wallet_info_destroy(handle);
+        assert_eq!(result, PlatformWalletFFIResult::ErrorInvalidHandle);
+    }
 }
 
 #[test]
 fn test_wallet_from_mnemonic() {
-    let mnemonic = CString::new(
+    unsafe {
+        let mnemonic = CString::new(
         "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about"
     ).unwrap();
 
-    let mut handle: Handle = NULL_HANDLE;
-    let mut error = PlatformWalletFFIError::success();
+        let mut handle: Handle = NULL_HANDLE;
+        let mut error = PlatformWalletFFIError::success();
 
-    let result = platform_wallet_info_create_from_mnemonic(
-        Network::Testnet,
-        mnemonic.as_ptr(),
-        std::ptr::null(),
-        &mut handle,
-        &mut error,
-    );
+        let result = platform_wallet_info_create_from_mnemonic(
+            Network::Testnet,
+            mnemonic.as_ptr(),
+            std::ptr::null(),
+            &mut handle,
+            &mut error,
+        );
 
-    assert_eq!(result, PlatformWalletFFIResult::Success);
-    assert_ne!(handle, NULL_HANDLE);
+        assert_eq!(result, PlatformWalletFFIResult::Success);
+        assert_ne!(handle, NULL_HANDLE);
 
-    platform_wallet_info_destroy(handle);
+        platform_wallet_info_destroy(handle);
+    }
 }
 
 #[test]
 #[ignore] // Stubbed - requires PlatformWalletInfo
 fn test_identity_manager_workflow() {
-    // Create identity manager
-    let mut manager_handle: Handle = NULL_HANDLE;
-    let mut error = PlatformWalletFFIError::success();
+    unsafe {
+        // Create identity manager
+        let mut manager_handle: Handle = NULL_HANDLE;
+        let mut error = PlatformWalletFFIError::success();
 
-    let result = identity_manager_create(&mut manager_handle, &mut error);
-    assert_eq!(result, PlatformWalletFFIResult::Success);
+        let result = identity_manager_create(&mut manager_handle, &mut error);
+        assert_eq!(result, PlatformWalletFFIResult::Success);
 
-    // Check initial count
-    let mut count: usize = 0;
-    let result = identity_manager_get_identity_count(manager_handle, &mut count, &mut error);
-    assert_eq!(result, PlatformWalletFFIResult::Success);
-    assert_eq!(count, 0);
+        // Check initial count
+        let mut count: usize = 0;
+        let result = identity_manager_get_identity_count(manager_handle, &mut count, &mut error);
+        assert_eq!(result, PlatformWalletFFIResult::Success);
+        assert_eq!(count, 0);
 
-    // Create a mock identity for testing
-    let identity = dpp::tests::fixtures::get_identity_fixture(0).unwrap();
-    let identity_id = identity.id();
-    let managed = platform_wallet::managed_identity::ManagedIdentity::new(identity);
-    let identity_handle = MANAGED_IDENTITY_STORAGE.insert(managed);
+        // Create a mock identity for testing
+        let identity = dpp::tests::fixtures::get_identity_fixture(0).unwrap();
+        let identity_id = identity.id();
+        let managed = platform_wallet::managed_identity::ManagedIdentity::new(identity);
+        let identity_handle = MANAGED_IDENTITY_STORAGE.insert(managed);
 
-    let result = identity_manager_add_identity(manager_handle, identity_handle, &mut error);
-    assert_eq!(result, PlatformWalletFFIResult::Success);
+        let result = identity_manager_add_identity(manager_handle, identity_handle, &mut error);
+        assert_eq!(result, PlatformWalletFFIResult::Success);
 
-    // Check count increased
-    let result = identity_manager_get_identity_count(manager_handle, &mut count, &mut error);
-    assert_eq!(result, PlatformWalletFFIResult::Success);
-    assert_eq!(count, 1);
+        // Check count increased
+        let result = identity_manager_get_identity_count(manager_handle, &mut count, &mut error);
+        assert_eq!(result, PlatformWalletFFIResult::Success);
+        assert_eq!(count, 1);
 
-    // Set as primary
-    let id_bytes: IdentifierBytes = identity_id.into();
-    let result = identity_manager_set_primary_identity(manager_handle, id_bytes, &mut error);
-    assert_eq!(result, PlatformWalletFFIResult::Success);
+        // Set as primary
+        let id_bytes: IdentifierBytes = identity_id.into();
+        let result = identity_manager_set_primary_identity(manager_handle, id_bytes, &mut error);
+        assert_eq!(result, PlatformWalletFFIResult::Success);
 
-    // Get primary
-    let mut retrieved_id = IdentifierBytes { bytes: [0u8; 32] };
-    let result =
-        identity_manager_get_primary_identity_id(manager_handle, &mut retrieved_id, &mut error);
-    assert_eq!(result, PlatformWalletFFIResult::Success);
-    assert_eq!(retrieved_id.bytes, id_bytes.bytes);
+        // Get primary
+        let mut retrieved_id = IdentifierBytes { bytes: [0u8; 32] };
+        let result =
+            identity_manager_get_primary_identity_id(manager_handle, &mut retrieved_id, &mut error);
+        assert_eq!(result, PlatformWalletFFIResult::Success);
+        assert_eq!(retrieved_id.bytes, id_bytes.bytes);
 
-    // Get all identity IDs
-    let mut array = IdentifierArray {
-        items: std::ptr::null_mut(),
-        count: 0,
-    };
-    let result = identity_manager_get_all_identity_ids(manager_handle, &mut array, &mut error);
-    assert_eq!(result, PlatformWalletFFIResult::Success);
-    assert_eq!(array.count, 1);
+        // Get all identity IDs
+        let mut array = IdentifierArray {
+            items: std::ptr::null_mut(),
+            count: 0,
+        };
+        let result = identity_manager_get_all_identity_ids(manager_handle, &mut array, &mut error);
+        assert_eq!(result, PlatformWalletFFIResult::Success);
+        assert_eq!(array.count, 1);
 
-    platform_wallet_identifier_array_free(array);
+        platform_wallet_identifier_array_free(array);
 
-    // Cleanup
-    identity_manager_destroy(manager_handle);
+        // Cleanup
+        identity_manager_destroy(manager_handle);
+    }
 }
 
 #[test]
 #[ignore] // Stubbed - requires PlatformWalletInfo
 fn test_managed_identity_operations() {
-    let identity = dpp::tests::fixtures::get_identity_fixture(0).unwrap();
-    let managed = platform_wallet::managed_identity::ManagedIdentity::new(identity);
-    let handle = MANAGED_IDENTITY_STORAGE.insert(managed);
+    unsafe {
+        let identity = dpp::tests::fixtures::get_identity_fixture(0).unwrap();
+        let managed = platform_wallet::managed_identity::ManagedIdentity::new(identity);
+        let handle = MANAGED_IDENTITY_STORAGE.insert(managed);
 
-    let mut error = PlatformWalletFFIError::success();
+        let mut error = PlatformWalletFFIError::success();
 
-    // Get ID
-    let mut id_bytes = IdentifierBytes { bytes: [0u8; 32] };
-    let result = managed_identity_get_id(handle, &mut id_bytes, &mut error);
-    assert_eq!(result, PlatformWalletFFIResult::Success);
+        // Get ID
+        let mut id_bytes = IdentifierBytes { bytes: [0u8; 32] };
+        let result = managed_identity_get_id(handle, &mut id_bytes, &mut error);
+        assert_eq!(result, PlatformWalletFFIResult::Success);
 
-    // Get balance
-    let mut balance: u64 = 0;
-    let result = managed_identity_get_balance(handle, &mut balance, &mut error);
-    assert_eq!(result, PlatformWalletFFIResult::Success);
+        // Get balance
+        let mut balance: u64 = 0;
+        let result = managed_identity_get_balance(handle, &mut balance, &mut error);
+        assert_eq!(result, PlatformWalletFFIResult::Success);
 
-    // Set and get label
-    let label = CString::new("Test Identity").unwrap();
-    let result = managed_identity_set_label(handle, label.as_ptr(), &mut error);
-    assert_eq!(result, PlatformWalletFFIResult::Success);
+        // Set and get label
+        let label = CString::new("Test Identity").unwrap();
+        let result = managed_identity_set_label(handle, label.as_ptr(), &mut error);
+        assert_eq!(result, PlatformWalletFFIResult::Success);
 
-    let mut label_ptr: *mut std::os::raw::c_char = std::ptr::null_mut();
-    let result = managed_identity_get_label(handle, &mut label_ptr, &mut error);
-    assert_eq!(result, PlatformWalletFFIResult::Success);
-    assert!(!label_ptr.is_null());
+        let mut label_ptr: *mut std::os::raw::c_char = std::ptr::null_mut();
+        let result = managed_identity_get_label(handle, &mut label_ptr, &mut error);
+        assert_eq!(result, PlatformWalletFFIResult::Success);
+        assert!(!label_ptr.is_null());
 
-    let retrieved_label = unsafe { std::ffi::CStr::from_ptr(label_ptr).to_str().unwrap() };
-    assert_eq!(retrieved_label, "Test Identity");
+        let retrieved_label = std::ffi::CStr::from_ptr(label_ptr).to_str().unwrap();
+        assert_eq!(retrieved_label, "Test Identity");
 
-    platform_wallet_string_free(label_ptr);
+        platform_wallet_string_free(label_ptr);
 
-    // Set and get block time
-    let block_time = BlockTime {
-        height: 100,
-        core_height: 200,
-        timestamp: 1234567890,
-    };
+        // Set and get block time
+        let block_time = BlockTime {
+            height: 100,
+            core_height: 200,
+            timestamp: 1234567890,
+        };
 
-    let result =
-        managed_identity_set_last_updated_balance_block_time(handle, block_time, &mut error);
-    assert_eq!(result, PlatformWalletFFIResult::Success);
+        let result =
+            managed_identity_set_last_updated_balance_block_time(handle, block_time, &mut error);
+        assert_eq!(result, PlatformWalletFFIResult::Success);
 
-    let mut retrieved_bt = BlockTime {
-        height: 0,
-        core_height: 0,
-        timestamp: 0,
-    };
-    let result =
-        managed_identity_get_last_updated_balance_block_time(handle, &mut retrieved_bt, &mut error);
-    assert_eq!(result, PlatformWalletFFIResult::Success);
-    assert_eq!(retrieved_bt.height, 100);
-    assert_eq!(retrieved_bt.core_height, 200);
+        let mut retrieved_bt = BlockTime {
+            height: 0,
+            core_height: 0,
+            timestamp: 0,
+        };
+        let result = managed_identity_get_last_updated_balance_block_time(
+            handle,
+            &mut retrieved_bt,
+            &mut error,
+        );
+        assert_eq!(result, PlatformWalletFFIResult::Success);
+        assert_eq!(retrieved_bt.height, 100);
+        assert_eq!(retrieved_bt.core_height, 200);
 
-    // Cleanup
-    managed_identity_destroy(handle);
+        // Cleanup
+        managed_identity_destroy(handle);
+    }
 }
 
 #[test]
 #[ignore] // TODO: Requires serde support on PlatformWalletInfo
 fn test_serialization() {
-    let seed = [0u8; 64];
-    let mut handle: Handle = NULL_HANDLE;
-    let mut error = PlatformWalletFFIError::success();
+    unsafe {
+        let seed = [0u8; 64];
+        let mut handle: Handle = NULL_HANDLE;
+        let mut error = PlatformWalletFFIError::success();
 
-    platform_wallet_info_create_from_seed(
-        Network::Testnet,
-        seed.as_ptr(),
-        seed.len(),
-        &mut handle,
-        &mut error,
-    );
+        platform_wallet_info_create_from_seed(
+            Network::Testnet,
+            seed.as_ptr(),
+            seed.len(),
+            &mut handle,
+            &mut error,
+        );
 
-    // Serialize to JSON - function not yet implemented
-    // let mut json_ptr: *mut std::os::raw::c_char = std::ptr::null_mut();
-    // let result = platform_wallet_info_to_json(handle, &mut json_ptr, &mut error);
-    // assert_eq!(result, PlatformWalletFFIResult::Success);
-    // assert!(!json_ptr.is_null());
+        // Serialize to JSON - function not yet implemented
+        // let mut json_ptr: *mut std::os::raw::c_char = std::ptr::null_mut();
+        // let result = platform_wallet_info_to_json(handle, &mut json_ptr, &mut error);
+        // assert_eq!(result, PlatformWalletFFIResult::Success);
+        // assert!(!json_ptr.is_null());
 
-    // let json_str = unsafe { std::ffi::CStr::from_ptr(json_ptr).to_str().unwrap() };
-    // assert!(!json_str.is_empty());
-    // assert!(json_str.contains("wallet_info"));
+        // let json_str = unsafe { std::ffi::CStr::from_ptr(json_ptr).to_str().unwrap() };
+        // assert!(!json_str.is_empty());
+        // assert!(json_str.contains("wallet_info"));
 
-    // platform_wallet_string_free(json_ptr);
-    platform_wallet_info_destroy(handle);
+        // platform_wallet_string_free(json_ptr);
+        platform_wallet_info_destroy(handle);
+    }
 }
 
 #[test]
 fn test_utils_identifier_operations() {
-    let mut error = PlatformWalletFFIError::success();
+    unsafe {
+        let mut error = PlatformWalletFFIError::success();
 
-    // Generate random identifier
-    let mut id1 = IdentifierBytes { bytes: [0u8; 32] };
-    let result = platform_wallet_generate_random_identifier(&mut id1, &mut error);
-    assert_eq!(result, PlatformWalletFFIResult::Success);
+        // Generate random identifier
+        let mut id1 = IdentifierBytes { bytes: [0u8; 32] };
+        let result = platform_wallet_generate_random_identifier(&mut id1, &mut error);
+        assert_eq!(result, PlatformWalletFFIResult::Success);
 
-    // Convert to hex
-    let mut hex: *mut std::os::raw::c_char = std::ptr::null_mut();
-    let result = platform_wallet_identifier_to_hex(id1, &mut hex, &mut error);
-    assert_eq!(result, PlatformWalletFFIResult::Success);
-    assert!(!hex.is_null());
+        // Convert to hex
+        let mut hex: *mut std::os::raw::c_char = std::ptr::null_mut();
+        let result = platform_wallet_identifier_to_hex(id1, &mut hex, &mut error);
+        assert_eq!(result, PlatformWalletFFIResult::Success);
+        assert!(!hex.is_null());
 
-    // Convert back from hex
-    let mut id2 = IdentifierBytes { bytes: [0u8; 32] };
-    let result = platform_wallet_identifier_from_hex(hex, &mut id2, &mut error);
-    assert_eq!(result, PlatformWalletFFIResult::Success);
+        // Convert back from hex
+        let mut id2 = IdentifierBytes { bytes: [0u8; 32] };
+        let result = platform_wallet_identifier_from_hex(hex, &mut id2, &mut error);
+        assert_eq!(result, PlatformWalletFFIResult::Success);
 
-    // Should match
-    assert_eq!(id1.bytes, id2.bytes);
+        // Should match
+        assert_eq!(id1.bytes, id2.bytes);
 
-    platform_wallet_string_free(hex);
+        platform_wallet_string_free(hex);
+    }
 }
 
 #[test]
 fn test_error_handling() {
-    let mut error = PlatformWalletFFIError::success();
+    unsafe {
+        let mut error = PlatformWalletFFIError::success();
 
-    // Try to get identity from invalid handle
-    let invalid_handle = 9999;
-    let mut id_bytes = IdentifierBytes { bytes: [0u8; 32] };
-    let result = managed_identity_get_id(invalid_handle, &mut id_bytes, &mut error);
-    assert_eq!(result, PlatformWalletFFIResult::ErrorInvalidHandle);
+        // Try to get identity from invalid handle
+        let invalid_handle = 9999;
+        let mut id_bytes = IdentifierBytes { bytes: [0u8; 32] };
+        let result = managed_identity_get_id(invalid_handle, &mut id_bytes, &mut error);
+        assert_eq!(result, PlatformWalletFFIResult::ErrorInvalidHandle);
 
-    // Error should have message
-    assert!(!error.message.is_null());
-    platform_wallet_ffi_error_free(error);
+        // Error should have message
+        assert!(!error.message.is_null());
+        platform_wallet_ffi_error_free(error);
 
-    // Try to create wallet with null pointer
-    let result = platform_wallet_info_create_from_seed(
-        Network::Testnet,
-        std::ptr::null(),
-        0,
-        std::ptr::null_mut(),
-        std::ptr::null_mut(),
-    );
-    assert_eq!(result, PlatformWalletFFIResult::ErrorNullPointer);
+        // Try to create wallet with null pointer
+        let result = platform_wallet_info_create_from_seed(
+            Network::Testnet,
+            std::ptr::null(),
+            0,
+            std::ptr::null_mut(),
+            std::ptr::null_mut(),
+        );
+        assert_eq!(result, PlatformWalletFFIResult::ErrorNullPointer);
+    }
 }
 
 #[test]
 #[ignore] // Stubbed - requires PlatformWalletInfo
 fn test_full_workflow() {
-    // Initialize
-    platform_wallet_ffi_init();
+    unsafe {
+        // Initialize
+        platform_wallet_ffi_init();
 
-    let mut error = PlatformWalletFFIError::success();
+        let mut error = PlatformWalletFFIError::success();
 
-    // Create wallet from mnemonic
-    let mnemonic = CString::new(
+        // Create wallet from mnemonic
+        let mnemonic = CString::new(
         "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about"
     ).unwrap();
 
-    let mut wallet_handle: Handle = NULL_HANDLE;
-    let result = platform_wallet_info_create_from_mnemonic(
-        Network::Testnet,
-        mnemonic.as_ptr(),
-        std::ptr::null(),
-        &mut wallet_handle,
-        &mut error,
-    );
-    assert_eq!(result, PlatformWalletFFIResult::Success);
+        let mut wallet_handle: Handle = NULL_HANDLE;
+        let result = platform_wallet_info_create_from_mnemonic(
+            Network::Testnet,
+            mnemonic.as_ptr(),
+            std::ptr::null(),
+            &mut wallet_handle,
+            &mut error,
+        );
+        assert_eq!(result, PlatformWalletFFIResult::Success);
 
-    // Create identity manager
-    let mut manager_handle: Handle = NULL_HANDLE;
-    let result = identity_manager_create(&mut manager_handle, &mut error);
-    assert_eq!(result, PlatformWalletFFIResult::Success);
+        // Create identity manager
+        let mut manager_handle: Handle = NULL_HANDLE;
+        let result = identity_manager_create(&mut manager_handle, &mut error);
+        assert_eq!(result, PlatformWalletFFIResult::Success);
 
-    // Create identity
-    let identity = dpp::tests::fixtures::get_identity_fixture(0).unwrap();
-    let managed = platform_wallet::managed_identity::ManagedIdentity::new(identity);
-    let identity_id = managed.identity.id();
-    let identity_handle = MANAGED_IDENTITY_STORAGE.insert(managed);
+        // Create identity
+        let identity = dpp::tests::fixtures::get_identity_fixture(0).unwrap();
+        let managed = platform_wallet::managed_identity::ManagedIdentity::new(identity);
+        let identity_id = managed.identity.id();
+        let identity_handle = MANAGED_IDENTITY_STORAGE.insert(managed);
 
-    // Set identity label
-    let label = CString::new("My Primary Identity").unwrap();
-    managed_identity_set_label(identity_handle, label.as_ptr(), &mut error);
+        // Set identity label
+        let label = CString::new("My Primary Identity").unwrap();
+        managed_identity_set_label(identity_handle, label.as_ptr(), &mut error);
 
-    // Add identity to manager
-    identity_manager_add_identity(manager_handle, identity_handle, &mut error);
+        // Add identity to manager
+        identity_manager_add_identity(manager_handle, identity_handle, &mut error);
 
-    // Set as primary
-    let id_bytes: IdentifierBytes = identity_id.into();
-    identity_manager_set_primary_identity(manager_handle, id_bytes, &mut error);
+        // Set as primary
+        let id_bytes: IdentifierBytes = identity_id.into();
+        identity_manager_set_primary_identity(manager_handle, id_bytes, &mut error);
 
-    // Set identity manager on wallet
-    let result =
-        platform_wallet_info_set_identity_manager(wallet_handle, manager_handle, &mut error);
-    assert_eq!(result, PlatformWalletFFIResult::Success);
+        // Set identity manager on wallet
+        let result =
+            platform_wallet_info_set_identity_manager(wallet_handle, manager_handle, &mut error);
+        assert_eq!(result, PlatformWalletFFIResult::Success);
 
-    // Get identity manager back
-    let mut retrieved_manager_handle: Handle = NULL_HANDLE;
-    let result = platform_wallet_info_get_identity_manager(
-        wallet_handle,
-        &mut retrieved_manager_handle,
-        &mut error,
-    );
-    assert_eq!(result, PlatformWalletFFIResult::Success);
-    assert_ne!(retrieved_manager_handle, NULL_HANDLE);
+        // Get identity manager back
+        let mut retrieved_manager_handle: Handle = NULL_HANDLE;
+        let result = platform_wallet_info_get_identity_manager(
+            wallet_handle,
+            &mut retrieved_manager_handle,
+            &mut error,
+        );
+        assert_eq!(result, PlatformWalletFFIResult::Success);
+        assert_ne!(retrieved_manager_handle, NULL_HANDLE);
 
-    // Cleanup
-    identity_manager_destroy(retrieved_manager_handle);
-    identity_manager_destroy(manager_handle);
-    platform_wallet_info_destroy(wallet_handle);
+        // Cleanup
+        identity_manager_destroy(retrieved_manager_handle);
+        identity_manager_destroy(manager_handle);
+        platform_wallet_info_destroy(wallet_handle);
+    }
 }

--- a/packages/rs-platform-wallet-ffi/tests/test_data/mod.rs
+++ b/packages/rs-platform-wallet-ffi/tests/test_data/mod.rs
@@ -3,6 +3,8 @@
 //! This module provides realistic fake data for testing contact requests,
 //! identities, and other platform wallet operations.
 
+#![allow(dead_code)]
+
 use dpp::identity::{Identity, IdentityPublicKey, KeyType, Purpose, SecurityLevel};
 use dpp::prelude::Identifier;
 use platform_wallet::{ContactRequest, EstablishedContact, ManagedIdentity};
@@ -99,8 +101,7 @@ pub fn create_contact_request(
     let mut encrypted_public_key = Vec::with_capacity(96);
     // Simulate encrypted data with some pattern
     for i in 0..96 {
-        let val =
-            (sender_id.as_bytes()[i % 32].wrapping_add(recipient_id.as_bytes()[i % 32])) as u8;
+        let val = sender_id.as_bytes()[i % 32].wrapping_add(recipient_id.as_bytes()[i % 32]);
         encrypted_public_key.push(val);
     }
 

--- a/packages/rs-sdk-ffi/src/address/transitions/top_up_from_asset_lock.rs
+++ b/packages/rs-sdk-ffi/src/address/transitions/top_up_from_asset_lock.rs
@@ -5,12 +5,7 @@
 use dash_sdk::dpp::address_funds::{
     AddressFundsFeeStrategy, AddressFundsFeeStrategyStep, PlatformAddress,
 };
-use dash_sdk::dpp::dashcore::secp256k1::SecretKey;
-use dash_sdk::dpp::dashcore::Network;
-use dash_sdk::dpp::dashcore::PrivateKey;
 use dash_sdk::dpp::fee::Credits;
-use dash_sdk::dpp::identity::signer::Signer;
-use dash_sdk::dpp::prelude::AssetLockProof;
 use dash_sdk::platform::transition::top_up_address::TopUpAddress;
 use std::collections::BTreeMap;
 use std::panic::{self, AssertUnwindSafe};
@@ -116,6 +111,7 @@ pub unsafe extern "C" fn dash_sdk_address_top_up_from_asset_lock(
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 unsafe fn dash_sdk_address_top_up_from_asset_lock_inner(
     sdk_handle: *const SDKHandle,
     proof_type: DashSDKAssetLockProofType,

--- a/packages/rs-sdk-ffi/src/address/transitions/transfer.rs
+++ b/packages/rs-sdk-ffi/src/address/transitions/transfer.rs
@@ -23,7 +23,7 @@ use crate::types::{
 use crate::{DashSDKError, DashSDKErrorCode, DashSDKResult, FFIError};
 
 /// Simple address signer that holds private keys for addresses
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub struct AddressSigner {
     /// Maps address hash to private key
     keys: BTreeMap<[u8; 20], PrivateKey>,
@@ -31,9 +31,7 @@ pub struct AddressSigner {
 
 impl AddressSigner {
     pub fn new() -> Self {
-        Self {
-            keys: BTreeMap::new(),
-        }
+        Self::default()
     }
 
     pub fn add_key(&mut self, address: &PlatformAddress, private_key: PrivateKey) {

--- a/packages/rs-sdk-ffi/src/address/transitions/withdraw.rs
+++ b/packages/rs-sdk-ffi/src/address/transitions/withdraw.rs
@@ -103,6 +103,7 @@ pub unsafe extern "C" fn dash_sdk_address_withdraw_funds(
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 unsafe fn dash_sdk_address_withdraw_funds_inner(
     sdk_handle: *const SDKHandle,
     inputs: *const DashSDKAddressTransferInput,

--- a/packages/rs-sdk-ffi/src/address_sync/provider.rs
+++ b/packages/rs-sdk-ffi/src/address_sync/provider.rs
@@ -64,14 +64,14 @@ pub struct AddressProviderVTable {
 
     /// Check if there are still pending addresses (optional, can be NULL)
     /// If null, the default implementation (pending_addresses is non-empty) is used
-    pub has_pending: Option<HasPendingFn>,
+    pub has_pending: Option<unsafe extern "C" fn(context: *mut c_void) -> bool>,
 
     /// Get the highest found index (optional, can be NULL)
-    /// If null, returns None
-    pub highest_found_index: Option<GetHighestFoundIndexFn>,
+    /// If null, returns None (u32::MAX means none found)
+    pub highest_found_index: Option<unsafe extern "C" fn(context: *mut c_void) -> u32>,
 
     /// Optional destructor for cleanup (can be NULL)
-    pub destroy: Option<DestroyProviderFn>,
+    pub destroy: Option<unsafe extern "C" fn(context: *mut c_void)>,
 }
 
 /// FFI-compatible address provider using callbacks

--- a/packages/rs-sdk-ffi/src/identity/create_from_addresses.rs
+++ b/packages/rs-sdk-ffi/src/identity/create_from_addresses.rs
@@ -1,13 +1,10 @@
 //! Identity creation from addresses operations
 
-use dash_sdk::dpp::address_funds::{
-    AddressFundsFeeStrategy, AddressFundsFeeStrategyStep, PlatformAddress,
-};
+use dash_sdk::dpp::address_funds::PlatformAddress;
 use dash_sdk::dpp::dashcore::secp256k1::SecretKey;
 use dash_sdk::dpp::dashcore::{Network, PrivateKey};
 use dash_sdk::dpp::fee::Credits;
-use dash_sdk::dpp::identity::signer::Signer;
-use dash_sdk::dpp::identity::{Identity, IdentityPublicKey};
+use dash_sdk::dpp::identity::Identity;
 use dash_sdk::dpp::prelude::AddressNonce;
 use dash_sdk::platform::transition::put_identity::PutIdentity;
 use std::collections::BTreeMap;

--- a/packages/rs-sdk-ffi/src/identity/transfer_to_addresses.rs
+++ b/packages/rs-sdk-ffi/src/identity/transfer_to_addresses.rs
@@ -3,10 +3,7 @@
 use dash_sdk::dpp::address_funds::PlatformAddress;
 use dash_sdk::dpp::fee::Credits;
 use dash_sdk::dpp::identity::accessors::IdentityGettersV0;
-use dash_sdk::dpp::identity::signer::Signer;
-use dash_sdk::dpp::identity::{Identity, IdentityPublicKey};
-use dash_sdk::dpp::platform_value::string_encoding::Encoding;
-use dash_sdk::dpp::prelude::Identifier;
+use dash_sdk::dpp::identity::Identity;
 use dash_sdk::platform::transition::transfer_to_addresses::TransferToAddresses;
 use std::collections::BTreeMap;
 use std::panic::{self, AssertUnwindSafe};

--- a/packages/rs-sdk-ffi/src/lib.rs
+++ b/packages/rs-sdk-ffi/src/lib.rs
@@ -52,6 +52,7 @@ pub use error::*;
 pub use evonode::*;
 pub use group::*;
 pub use identity::*;
+#[allow(unused_imports)]
 pub use platform_wallet_types::*;
 pub use protocol_version::*;
 pub use sdk::*;

--- a/packages/rs-sdk-ffi/src/platform_wallet_types.rs
+++ b/packages/rs-sdk-ffi/src/platform_wallet_types.rs
@@ -1,5 +1,6 @@
 // Re-export Platform Wallet FFI types for cbindgen to pick up
 
+#[allow(unused_imports)]
 pub use platform_wallet_ffi::{
     BlockTime, Handle, IdentifierArray, IdentifierBytes, PlatformWalletFFIError,
     PlatformWalletFFIResult, NULL_HANDLE,

--- a/packages/rs-sdk/src/lib.rs
+++ b/packages/rs-sdk/src/lib.rs
@@ -81,8 +81,6 @@ pub use dpp::dashcore_rpc;
 pub use drive;
 pub use drive_proof_verifier::types as query_types;
 pub use drive_proof_verifier::Error as ProofVerifierError;
-#[cfg(feature = "wallet")]
-pub use platform_wallet;
 pub use rs_dapi_client as dapi_client;
 pub mod sync;
 

--- a/packages/swift-sdk/Sources/SwiftDashSDK/Core/SPV/SPVTypes.swift
+++ b/packages/swift-sdk/Sources/SwiftDashSDK/Core/SPV/SPVTypes.swift
@@ -62,7 +62,7 @@ public struct SPVBlockHeadersProgress: Sendable {
 
     public init(_ ffi: FFIBlockHeadersProgress) {
         state = SPVSyncState(rawValue: ffi.state.rawValue) ?? .unknown
-        currentHeight = ffi.current_height
+        currentHeight = ffi.tip_height
         targetHeight = ffi.target_height
         processed = ffi.processed
         buffered = ffi.buffered

--- a/packages/swift-sdk/Sources/SwiftDashSDK/KeyWallet/README.md
+++ b/packages/swift-sdk/Sources/SwiftDashSDK/KeyWallet/README.md
@@ -89,25 +89,24 @@ let addresses = try managed.getExternalAddressRange(
 ### Transaction Management
 
 ```swift
-// Build a transaction
+// Build and sign a transaction in one step
 let outputs = [
     Transaction.Output(address: "XqHiz8EXYbTAtBEYs4pWTHh7ipEDQcNQeT", amount: 100000000)
 ]
 
-let txData = try Transaction.build(
+let result = try Transaction.buildAndSign(
+    manager: walletManager,
     wallet: wallet,
     accountIndex: 0,
     outputs: outputs,
-    feePerKB: 1000
+    feeRate: .normal
 )
-
-// Sign the transaction
-let signedTx = try Transaction.sign(wallet: wallet, transactionData: txData)
+print("Fee paid: \(result.fee) duffs")
 
 // Check if a transaction belongs to the wallet
 let checkResult = try Transaction.check(
     wallet: wallet,
-    transactionData: signedTx,
+    transactionData: result.transactionData,
     context: .mempool
 )
 

--- a/packages/swift-sdk/Sources/SwiftDashSDK/KeyWallet/Transaction.swift
+++ b/packages/swift-sdk/Sources/SwiftDashSDK/KeyWallet/Transaction.swift
@@ -1,60 +1,92 @@
 import Foundation
 import DashSDKFFI
 
+/// Fee rate for transaction building
+public enum FeeRate: UInt32, Sendable {
+    case economy = 0
+    case normal = 1
+    case priority = 2
+
+    var ffiValue: FFIFeeRate {
+        FFIFeeRate(rawValue: self.rawValue)
+    }
+}
+
+/// Result of building and signing a transaction
+public struct BuildAndSignResult: Sendable {
+    /// The signed transaction bytes
+    public let transactionData: Data
+    /// The fee paid in duffs
+    public let fee: UInt64
+}
+
 /// Transaction utilities for wallet operations
 public class Transaction {
-    
+
     /// Transaction output for building transactions
     public struct Output {
         public let address: String
         public let amount: UInt64
-        
+
         public init(address: String, amount: UInt64) {
             self.address = address
             self.amount = amount
         }
-        
+
         func toFFI() -> FFITxOutput {
             return address.withCString { addressCStr in
                 FFITxOutput(address: addressCStr, amount: amount)
             }
         }
     }
-    
-    /// Build a transaction
+
+    /// Build and sign a transaction in a single operation
+    ///
+    /// This uses the wallet manager's coin selection and key derivation to build
+    /// a fully signed transaction ready for broadcast.
+    ///
     /// - Parameters:
-    ///   - wallet: The wallet to build from
-    ///   - accountIndex: The account index to use
+    ///   - manager: The wallet manager that manages the wallet
+    ///   - wallet: The wallet to build and sign from
+    ///   - accountIndex: The BIP44 account index to use
     ///   - outputs: The transaction outputs
-    ///   - feePerKB: Fee per kilobyte in satoshis
-    /// - Returns: The unsigned transaction bytes
-    public static func build(wallet: Wallet,
-                            accountIndex: UInt32 = 0,
-                            outputs: [Output],
-                            feePerKB: UInt64) throws -> Data {
+    ///   - feeRate: The fee rate level (economy, normal, or priority)
+    /// - Returns: A result containing the signed transaction bytes and the fee paid
+    public static func buildAndSign(manager: WalletManager,
+                                    wallet: Wallet,
+                                    accountIndex: UInt32 = 0,
+                                    outputs: [Output],
+                                    feeRate: FeeRate = .normal) throws -> BuildAndSignResult {
         guard !outputs.isEmpty else {
             throw KeyWalletError.invalidInput("Transaction must have at least one output")
         }
-        
+
+        guard !wallet.isWatchOnly else {
+            throw KeyWalletError.invalidState("Cannot build and sign with watch-only wallet")
+        }
+
         var error = FFIError()
         var txBytesPtr: UnsafeMutablePointer<UInt8>?
         var txLen: size_t = 0
-        
+        var feeOut: UInt64 = 0
+
         // Convert outputs to FFI format
         let ffiOutputs = outputs.map { $0.toFFI() }
-        
+
         let success = ffiOutputs.withUnsafeBufferPointer { outputsPtr in
-            wallet_build_transaction(
+            wallet_build_and_sign_transaction(
+                manager.ffiHandle,
                 wallet.ffiHandle,
                 accountIndex,
                 outputsPtr.baseAddress,
                 outputs.count,
-                feePerKB,
+                feeRate.ffiValue,
+                &feeOut,
                 &txBytesPtr,
                 &txLen,
                 &error)
         }
-        
+
         defer {
             if error.message != nil {
                 error_message_free(error.message)
@@ -63,58 +95,17 @@ public class Transaction {
                 transaction_bytes_free(ptr)
             }
         }
-        
+
         guard success, let ptr = txBytesPtr else {
             throw KeyWalletError(ffiError: error)
         }
-        
+
         // Copy the transaction data before freeing
         let txData = Data(bytes: ptr, count: txLen)
-        
-        return txData
+
+        return BuildAndSignResult(transactionData: txData, fee: feeOut)
     }
-    
-    /// Sign a transaction
-    /// - Parameters:
-    ///   - wallet: The wallet to sign with
-    ///   - transactionData: The unsigned transaction bytes
-    /// - Returns: The signed transaction bytes
-    public static func sign(wallet: Wallet, transactionData: Data) throws -> Data {
-        guard !wallet.isWatchOnly else {
-            throw KeyWalletError.invalidState("Cannot sign with watch-only wallet")
-        }
-        
-        var error = FFIError()
-        var signedTxPtr: UnsafeMutablePointer<UInt8>?
-        var signedLen: size_t = 0
-        
-        let success = transactionData.withUnsafeBytes { txBytes in
-            let txPtr = txBytes.bindMemory(to: UInt8.self).baseAddress
-            return wallet_sign_transaction(
-                wallet.ffiHandle,
-                txPtr, transactionData.count,
-                &signedTxPtr, &signedLen, &error)
-        }
-        
-        defer {
-            if error.message != nil {
-                error_message_free(error.message)
-            }
-            if let ptr = signedTxPtr {
-                transaction_bytes_free(ptr)
-            }
-        }
-        
-        guard success, let ptr = signedTxPtr else {
-            throw KeyWalletError(ffiError: error)
-        }
-        
-        // Copy the signed transaction data before freeing
-        let signedData = Data(bytes: ptr, count: signedLen)
-        
-        return signedData
-    }
-    
+
     /// Check if a transaction belongs to a wallet
     /// - Parameters:
     ///   - wallet: The wallet to check against
@@ -134,14 +125,14 @@ public class Transaction {
                             updateState: Bool = true) throws -> TransactionCheckResult {
         var error = FFIError()
         var result = FFITransactionCheckResult()
-        
+
         let success = transactionData.withUnsafeBytes { txBytes in
             let txPtr = txBytes.bindMemory(to: UInt8.self).baseAddress
-            
+
             if let hash = blockHash {
                 return hash.withUnsafeBytes { hashBytes in
                     let hashPtr = hashBytes.bindMemory(to: UInt8.self).baseAddress
-                    
+
                     return wallet_check_transaction(
                         wallet.ffiHandle,
                         txPtr, transactionData.count,
@@ -156,45 +147,45 @@ public class Transaction {
                     timestamp, updateState, &result, &error)
             }
         }
-        
+
         defer {
             if error.message != nil {
                 error_message_free(error.message)
             }
             transaction_check_result_free(&result)
         }
-        
+
         guard success else {
             throw KeyWalletError(ffiError: error)
         }
-        
+
         return TransactionCheckResult(ffiResult: result)
     }
-    
+
     /// Classify a transaction for routing
     /// - Parameter transactionData: The transaction bytes
     /// - Returns: A string describing the transaction type
     public static func classify(_ transactionData: Data) throws -> String {
         var error = FFIError()
-        
+
         let classificationPtr = transactionData.withUnsafeBytes { txBytes in
             let txPtr = txBytes.bindMemory(to: UInt8.self).baseAddress
             return transaction_classify(txPtr, transactionData.count, &error)
         }
-        
+
         defer {
             if error.message != nil {
                 error_message_free(error.message)
             }
         }
-        
+
         guard let ptr = classificationPtr else {
             throw KeyWalletError(ffiError: error)
         }
-        
+
         let classification = String(cString: ptr)
         string_free(ptr)
-        
+
         return classification
     }
 }


### PR DESCRIPTION
## Summary

- Fix clippy violations across `platform-wallet-ffi` and `rs-sdk-ffi` after merging `v3.1-dev` into `feat/iOSSupport`
- Mark all `pub extern "C" fn` that dereference raw pointers as `unsafe` (clippy `not_unsafe_ptr_arg_deref`)
- Fix UB in `AddressProviderVTable` by using `Option<fn>` for nullable function pointers instead of transmute-to-null hack
- Inline `Option<fn>` types in `AddressProviderVTable` struct so cbindgen generates valid C (nullable function pointers)
- Remove unused imports, fix needless references, unnecessary casts, and other clippy warnings
- Wrap test function bodies in `unsafe` blocks where needed after FFI functions became `unsafe`
- Add `dpp` with `fixtures-and-mocks` feature to dev-dependencies for test compilation
- Fix Swift `SPVTypes.swift` to use renamed `tip_height` field (was `current_height`)
- Replace non-existent `wallet_build_transaction`/`wallet_sign_transaction` Swift calls with actual `wallet_build_and_sign_transaction` FFI function

## Test plan
- [x] `cargo check -p platform-wallet-ffi --tests` passes with zero warnings
- [x] `cargo check -p rs-sdk-ffi` passes with zero warnings
- [x] `cargo clippy -p platform-wallet-ffi --tests -p rs-sdk-ffi` passes with zero warnings from these crates
- [x] cbindgen generates valid C header (no `Option<...>` in output)
- [ ] `./build_ios.sh` produces xcframework and Swift build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>