### PR TITLE
fix(drive): consolidate historical contract proof verification retry logic

### DIFF
--- a/packages/rs-drive/src/verify/contract/mod.rs
+++ b/packages/rs-drive/src/verify/contract/mod.rs
@@ -1,3 +1,97 @@
+use crate::error::Error;
+
 mod verify_contract;
 mod verify_contract_history;
 mod verify_contract_return_serialization;
+
+fn retry_contract_verification_with_history<R, RetryFn, HasPresentContractFn>(
+    result: Result<R, Error>,
+    contract_known_keeps_history: Option<bool>,
+    contract_id: [u8; 32],
+    in_multiple_contract_proof_form: bool,
+    retry: RetryFn,
+    has_present_contract: HasPresentContractFn,
+) -> Result<R, Error>
+where
+    RetryFn: FnOnce() -> Result<R, Error>,
+    HasPresentContractFn: Fn(&R) -> bool,
+{
+    if contract_known_keeps_history.is_some() {
+        return result;
+    }
+
+    match &result {
+        Ok(value) if has_present_contract(value) => result,
+        Ok(_) => {
+            tracing::debug!(
+                ?contract_id,
+                keeps_history = false,
+                retry_keeps_history = true,
+                in_multiple_contract_proof_form,
+                "retrying contract verification with history enabled after absence"
+            );
+
+            let retry_result = retry();
+            if matches!(retry_result.as_ref(), Ok(value) if has_present_contract(value)) {
+                retry_result
+            } else {
+                result
+            }
+        }
+        Err(error) => {
+            tracing::debug!(
+                ?contract_id,
+                keeps_history = false,
+                retry_keeps_history = true,
+                in_multiple_contract_proof_form,
+                error = ?error,
+                "retrying contract verification with history enabled after error"
+            );
+
+            let retry_result = retry();
+            if matches!(retry_result.as_ref(), Ok(value) if has_present_contract(value)) {
+                retry_result
+            } else {
+                result
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::retry_contract_verification_with_history;
+    use crate::error::proof::ProofError;
+    use crate::error::Error;
+
+    #[test]
+    fn should_preserve_original_error_when_retry_returns_absence() {
+        let result = retry_contract_verification_with_history(
+            Err(Error::Proof(ProofError::IncompleteProof("first error"))),
+            None,
+            [1; 32],
+            false,
+            || Ok(None::<u8>),
+            Option::is_some,
+        );
+
+        assert!(matches!(
+            result,
+            Err(Error::Proof(ProofError::IncompleteProof("first error")))
+        ));
+    }
+
+    #[test]
+    fn should_return_retry_result_when_retry_finds_contract_after_error() {
+        let result = retry_contract_verification_with_history(
+            Err(Error::Proof(ProofError::IncompleteProof("first error"))),
+            None,
+            [1; 32],
+            false,
+            || Ok(Some(7u8)),
+            Option::is_some,
+        );
+
+        assert!(matches!(result, Ok(Some(7))));
+    }
+}

--- a/packages/rs-drive/src/verify/contract/verify_contract/v0/mod.rs
+++ b/packages/rs-drive/src/verify/contract/verify_contract/v0/mod.rs
@@ -56,7 +56,10 @@ impl Drive {
         if contract_known_keeps_history.is_none() {
             match &result {
                 Ok((_, Some(_))) => result,
-                _ => {
+                // Ok(None) is a valid absence proof — contract genuinely doesn't exist.
+                // Don't retry; the server builds a non-historical query for missing contracts.
+                Ok((_, None)) => result,
+                Err(_) => {
                     tracing::debug!(
                         ?contract_id,
                         "retrying contract verification with history enabled"

--- a/packages/rs-drive/src/verify/contract/verify_contract/v0/mod.rs
+++ b/packages/rs-drive/src/verify/contract/verify_contract/v0/mod.rs
@@ -42,10 +42,49 @@ impl Drive {
         contract_id: [u8; 32],
         platform_version: &PlatformVersion,
     ) -> Result<(RootHash, Option<DataContract>), Error> {
-        let path_query = match (
+        let keeps_history = contract_known_keeps_history.unwrap_or(false);
+
+        let result = Self::verify_contract_v0_given_history(
+            proof,
+            keeps_history,
+            is_proof_subset,
             in_multiple_contract_proof_form,
-            contract_known_keeps_history.unwrap_or_default(),
-        ) {
+            contract_id,
+            platform_version,
+        );
+
+        if contract_known_keeps_history.is_none() {
+            match &result {
+                Ok((_, Some(_))) => result,
+                _ => {
+                    tracing::debug!(
+                        ?contract_id,
+                        "retrying contract verification with history enabled"
+                    );
+                    Self::verify_contract_v0_given_history(
+                        proof,
+                        true,
+                        is_proof_subset,
+                        in_multiple_contract_proof_form,
+                        contract_id,
+                        platform_version,
+                    )
+                }
+            }
+        } else {
+            result
+        }
+    }
+
+    fn verify_contract_v0_given_history(
+        proof: &[u8],
+        keeps_history: bool,
+        is_proof_subset: bool,
+        in_multiple_contract_proof_form: bool,
+        contract_id: [u8; 32],
+        platform_version: &PlatformVersion,
+    ) -> Result<(RootHash, Option<DataContract>), Error> {
+        let path_query = match (in_multiple_contract_proof_form, keeps_history) {
             (true, true) => Self::fetch_historical_contracts_query(&[contract_id]),
             (true, false) => Self::fetch_non_historical_contracts_query(&[contract_id]),
             (false, true) => Self::fetch_contract_with_history_latest_query(contract_id, true),
@@ -67,25 +106,7 @@ impl Drive {
                 &platform_version.drive.grove_version,
             )
         };
-        let (root_hash, mut proved_key_values) = match result.map_err(Error::from) {
-            Ok(ok_result) => ok_result,
-            Err(e) => {
-                return if contract_known_keeps_history.is_none() {
-                    tracing::debug!(?path_query,error=?e, "retrying contract verification with history enabled");
-                    // most likely we are trying to prove a historical contract
-                    Self::verify_contract(
-                        proof,
-                        Some(true),
-                        is_proof_subset,
-                        in_multiple_contract_proof_form,
-                        contract_id,
-                        platform_version,
-                    )
-                } else {
-                    Err(e)
-                };
-            }
-        };
+        let (root_hash, mut proved_key_values) = result.map_err(Error::from)?;
         if proved_key_values.is_empty() {
             return Err(Error::Proof(ProofError::WrongElementCount {
                 expected: 1,
@@ -94,7 +115,7 @@ impl Drive {
         }
         if proved_key_values.len() == 1 {
             let (path, key, maybe_element) = proved_key_values.remove(0);
-            if contract_known_keeps_history.unwrap_or_default() {
+            if keeps_history {
                 if path != contract_keeping_history_root_path(&contract_id) {
                     return Err(Error::Proof(ProofError::CorruptedProof(
                         "we did not get back an element for the correct path for the historical contract".to_string(),
@@ -125,26 +146,9 @@ impl Drive {
                                 .map_err(Error::from)
                         })
                 })
-                .transpose();
-            match contract {
-                Ok(contract) => Ok((root_hash, contract)),
-                Err(e) => {
-                    if contract_known_keeps_history.is_some() {
-                        // just return error
-                        Err(e)
-                    } else {
-                        tracing::debug!(?path_query,error=?e, "retry contract verification with history enabled");
-                        Self::verify_contract(
-                            proof,
-                            Some(true),
-                            is_proof_subset,
-                            in_multiple_contract_proof_form,
-                            contract_id,
-                            platform_version,
-                        )
-                    }
-                }
-            }
+                .transpose()?;
+
+            Ok((root_hash, contract))
         } else {
             Err(Error::Proof(ProofError::TooManyElements(
                 "expected one contract id",

--- a/packages/rs-drive/src/verify/contract/verify_contract/v0/mod.rs
+++ b/packages/rs-drive/src/verify/contract/verify_contract/v0/mod.rs
@@ -53,30 +53,52 @@ impl Drive {
             platform_version,
         );
 
+        // When the caller doesn't know whether the contract keeps history, retry with
+        // history enabled to recover historical contracts whose non-historical attempt
+        // either errored or produced an absence proof. A successful retry returning a
+        // contract supersedes both cases. If the retry does not produce a contract,
+        // the original outcome is preserved: Ok((_, None)) absence proofs remain valid
+        // for genuinely missing contracts, and original errors are returned unchanged.
         if contract_known_keeps_history.is_none() {
             match &result {
-                Ok((_, Some(_))) => result,
-                // Ok(None) is a valid absence proof — contract genuinely doesn't exist.
-                // Don't retry; the server builds a non-historical query for missing contracts.
-                Ok((_, None)) => result,
-                Err(_) => {
+                Ok((_, Some(_))) => return result,
+                Ok((_, None)) => {
                     tracing::debug!(
                         ?contract_id,
-                        "retrying contract verification with history enabled"
+                        "retrying contract verification with history enabled after absence"
                     );
-                    Self::verify_contract_v0_given_history(
+                    let retry = Self::verify_contract_v0_given_history(
                         proof,
                         true,
                         is_proof_subset,
                         in_multiple_contract_proof_form,
                         contract_id,
                         platform_version,
-                    )
+                    );
+                    if let Ok((_, Some(_))) = retry {
+                        return retry;
+                    }
+                }
+                Err(_) => {
+                    tracing::debug!(
+                        ?contract_id,
+                        "retrying contract verification with history enabled after error"
+                    );
+                    let retry = Self::verify_contract_v0_given_history(
+                        proof,
+                        true,
+                        is_proof_subset,
+                        in_multiple_contract_proof_form,
+                        contract_id,
+                        platform_version,
+                    );
+                    if retry.is_ok() {
+                        return retry;
+                    }
                 }
             }
-        } else {
-            result
         }
+        result
     }
 
     fn verify_contract_v0_given_history(

--- a/packages/rs-drive/src/verify/contract/verify_contract/v0/mod.rs
+++ b/packages/rs-drive/src/verify/contract/verify_contract/v0/mod.rs
@@ -4,6 +4,7 @@ use crate::drive::contract::paths::{contract_keeping_history_root_path, contract
 use crate::drive::Drive;
 use crate::error::proof::ProofError;
 use crate::error::Error;
+use crate::verify::contract::retry_contract_verification_with_history;
 use crate::verify::RootHash;
 use dpp::prelude::DataContract;
 use dpp::serialization::PlatformDeserializableWithPotentialValidationFromVersionedStructure;
@@ -53,52 +54,23 @@ impl Drive {
             platform_version,
         );
 
-        // When the caller doesn't know whether the contract keeps history, retry with
-        // history enabled to recover historical contracts whose non-historical attempt
-        // either errored or produced an absence proof. A successful retry returning a
-        // contract supersedes both cases. If the retry does not produce a contract,
-        // the original outcome is preserved: Ok((_, None)) absence proofs remain valid
-        // for genuinely missing contracts, and original errors are returned unchanged.
-        if contract_known_keeps_history.is_none() {
-            match &result {
-                Ok((_, Some(_))) => return result,
-                Ok((_, None)) => {
-                    tracing::debug!(
-                        ?contract_id,
-                        "retrying contract verification with history enabled after absence"
-                    );
-                    let retry = Self::verify_contract_v0_given_history(
-                        proof,
-                        true,
-                        is_proof_subset,
-                        in_multiple_contract_proof_form,
-                        contract_id,
-                        platform_version,
-                    );
-                    if let Ok((_, Some(_))) = retry {
-                        return retry;
-                    }
-                }
-                Err(_) => {
-                    tracing::debug!(
-                        ?contract_id,
-                        "retrying contract verification with history enabled after error"
-                    );
-                    let retry = Self::verify_contract_v0_given_history(
-                        proof,
-                        true,
-                        is_proof_subset,
-                        in_multiple_contract_proof_form,
-                        contract_id,
-                        platform_version,
-                    );
-                    if retry.is_ok() {
-                        return retry;
-                    }
-                }
-            }
-        }
-        result
+        retry_contract_verification_with_history(
+            result,
+            contract_known_keeps_history,
+            contract_id,
+            in_multiple_contract_proof_form,
+            || {
+                Self::verify_contract_v0_given_history(
+                    proof,
+                    true,
+                    is_proof_subset,
+                    in_multiple_contract_proof_form,
+                    contract_id,
+                    platform_version,
+                )
+            },
+            |(_, contract)| contract.is_some(),
+        )
     }
 
     fn verify_contract_v0_given_history(

--- a/packages/rs-drive/src/verify/contract/verify_contract_return_serialization/v0/mod.rs
+++ b/packages/rs-drive/src/verify/contract/verify_contract_return_serialization/v0/mod.rs
@@ -58,7 +58,10 @@ impl Drive {
         if contract_known_keeps_history.is_none() {
             match &result {
                 Ok((_, Some(_))) => result,
-                _ => {
+                // Ok(None) is a valid absence proof — contract genuinely doesn't exist.
+                // Don't retry; the server builds a non-historical query for missing contracts.
+                Ok((_, None)) => result,
+                Err(_) => {
                     tracing::debug!(
                         ?contract_id,
                         "retrying contract verification with history enabled"

--- a/packages/rs-drive/src/verify/contract/verify_contract_return_serialization/v0/mod.rs
+++ b/packages/rs-drive/src/verify/contract/verify_contract_return_serialization/v0/mod.rs
@@ -44,10 +44,49 @@ impl Drive {
         contract_id: [u8; 32],
         platform_version: &PlatformVersion,
     ) -> Result<VerifyContractReturn, Error> {
-        let path_query = match (
+        let keeps_history = contract_known_keeps_history.unwrap_or(false);
+
+        let result = Self::verify_contract_return_serialization_v0_given_history(
+            proof,
+            keeps_history,
+            is_proof_subset,
             in_multiple_contract_proof_form,
-            contract_known_keeps_history.unwrap_or_default(),
-        ) {
+            contract_id,
+            platform_version,
+        );
+
+        if contract_known_keeps_history.is_none() {
+            match &result {
+                Ok((_, Some(_))) => result,
+                _ => {
+                    tracing::debug!(
+                        ?contract_id,
+                        "retrying contract verification with history enabled"
+                    );
+                    Self::verify_contract_return_serialization_v0_given_history(
+                        proof,
+                        true,
+                        is_proof_subset,
+                        in_multiple_contract_proof_form,
+                        contract_id,
+                        platform_version,
+                    )
+                }
+            }
+        } else {
+            result
+        }
+    }
+
+    fn verify_contract_return_serialization_v0_given_history(
+        proof: &[u8],
+        keeps_history: bool,
+        is_proof_subset: bool,
+        in_multiple_contract_proof_form: bool,
+        contract_id: [u8; 32],
+        platform_version: &PlatformVersion,
+    ) -> Result<VerifyContractReturn, Error> {
+        let path_query = match (in_multiple_contract_proof_form, keeps_history) {
             (true, true) => Self::fetch_historical_contracts_query(&[contract_id]),
             (true, false) => Self::fetch_non_historical_contracts_query(&[contract_id]),
             (false, true) => Self::fetch_contract_with_history_latest_query(contract_id, true),
@@ -69,25 +108,7 @@ impl Drive {
                 &platform_version.drive.grove_version,
             )
         };
-        let (root_hash, mut proved_key_values) = match result.map_err(Error::from) {
-            Ok(ok_result) => ok_result,
-            Err(e) => {
-                return if contract_known_keeps_history.is_none() {
-                    tracing::debug!(?path_query,error=?e, "retrying contract verification with history enabled");
-                    // most likely we are trying to prove a historical contract
-                    Self::verify_contract_return_serialization_v0(
-                        proof,
-                        Some(true),
-                        is_proof_subset,
-                        in_multiple_contract_proof_form,
-                        contract_id,
-                        platform_version,
-                    )
-                } else {
-                    Err(e)
-                };
-            }
-        };
+        let (root_hash, mut proved_key_values) = result.map_err(Error::from)?;
         if proved_key_values.is_empty() {
             return Err(Error::Proof(ProofError::WrongElementCount {
                 expected: 1,
@@ -96,7 +117,7 @@ impl Drive {
         }
         if proved_key_values.len() == 1 {
             let (path, key, maybe_element) = proved_key_values.remove(0);
-            if contract_known_keeps_history.unwrap_or_default() {
+            if keeps_history {
                 if path != contract_keeping_history_root_path(&contract_id) {
                     return Err(Error::Proof(ProofError::CorruptedProof(
                         "we did not get back an element for the correct path for the historical contract".to_string(),
@@ -134,26 +155,9 @@ impl Drive {
                             ))
                         })
                 })
-                .transpose();
-            match contract {
-                Ok(contract) => Ok((root_hash, contract)),
-                Err(e) => {
-                    if contract_known_keeps_history.is_some() {
-                        // just return error
-                        Err(e)
-                    } else {
-                        tracing::debug!(?path_query,error=?e, "retry contract verification with history enabled");
-                        Self::verify_contract_return_serialization_v0(
-                            proof,
-                            Some(true),
-                            is_proof_subset,
-                            in_multiple_contract_proof_form,
-                            contract_id,
-                            platform_version,
-                        )
-                    }
-                }
-            }
+                .transpose()?;
+
+            Ok((root_hash, contract))
         } else {
             Err(Error::Proof(ProofError::TooManyElements(
                 "expected one contract id",

--- a/packages/rs-drive/src/verify/contract/verify_contract_return_serialization/v0/mod.rs
+++ b/packages/rs-drive/src/verify/contract/verify_contract_return_serialization/v0/mod.rs
@@ -55,30 +55,52 @@ impl Drive {
             platform_version,
         );
 
+        // When the caller doesn't know whether the contract keeps history, retry with
+        // history enabled to recover historical contracts whose non-historical attempt
+        // either errored or produced an absence proof. A successful retry returning a
+        // contract supersedes both cases. If the retry does not produce a contract,
+        // the original outcome is preserved: Ok((_, None)) absence proofs remain valid
+        // for genuinely missing contracts, and original errors are returned unchanged.
         if contract_known_keeps_history.is_none() {
             match &result {
-                Ok((_, Some(_))) => result,
-                // Ok(None) is a valid absence proof — contract genuinely doesn't exist.
-                // Don't retry; the server builds a non-historical query for missing contracts.
-                Ok((_, None)) => result,
-                Err(_) => {
+                Ok((_, Some(_))) => return result,
+                Ok((_, None)) => {
                     tracing::debug!(
                         ?contract_id,
-                        "retrying contract verification with history enabled"
+                        "retrying contract verification with history enabled after absence"
                     );
-                    Self::verify_contract_return_serialization_v0_given_history(
+                    let retry = Self::verify_contract_return_serialization_v0_given_history(
                         proof,
                         true,
                         is_proof_subset,
                         in_multiple_contract_proof_form,
                         contract_id,
                         platform_version,
-                    )
+                    );
+                    if let Ok((_, Some(_))) = retry {
+                        return retry;
+                    }
+                }
+                Err(_) => {
+                    tracing::debug!(
+                        ?contract_id,
+                        "retrying contract verification with history enabled after error"
+                    );
+                    let retry = Self::verify_contract_return_serialization_v0_given_history(
+                        proof,
+                        true,
+                        is_proof_subset,
+                        in_multiple_contract_proof_form,
+                        contract_id,
+                        platform_version,
+                    );
+                    if retry.is_ok() {
+                        return retry;
+                    }
                 }
             }
-        } else {
-            result
         }
+        result
     }
 
     fn verify_contract_return_serialization_v0_given_history(

--- a/packages/rs-drive/src/verify/contract/verify_contract_return_serialization/v0/mod.rs
+++ b/packages/rs-drive/src/verify/contract/verify_contract_return_serialization/v0/mod.rs
@@ -2,6 +2,7 @@ use crate::drive::contract::paths::{contract_keeping_history_root_path, contract
 use crate::drive::Drive;
 use crate::error::proof::ProofError;
 use crate::error::Error;
+use crate::verify::contract::retry_contract_verification_with_history;
 use crate::verify::RootHash;
 use dpp::prelude::DataContract;
 use dpp::serialization::PlatformDeserializableWithPotentialValidationFromVersionedStructure;
@@ -55,52 +56,23 @@ impl Drive {
             platform_version,
         );
 
-        // When the caller doesn't know whether the contract keeps history, retry with
-        // history enabled to recover historical contracts whose non-historical attempt
-        // either errored or produced an absence proof. A successful retry returning a
-        // contract supersedes both cases. If the retry does not produce a contract,
-        // the original outcome is preserved: Ok((_, None)) absence proofs remain valid
-        // for genuinely missing contracts, and original errors are returned unchanged.
-        if contract_known_keeps_history.is_none() {
-            match &result {
-                Ok((_, Some(_))) => return result,
-                Ok((_, None)) => {
-                    tracing::debug!(
-                        ?contract_id,
-                        "retrying contract verification with history enabled after absence"
-                    );
-                    let retry = Self::verify_contract_return_serialization_v0_given_history(
-                        proof,
-                        true,
-                        is_proof_subset,
-                        in_multiple_contract_proof_form,
-                        contract_id,
-                        platform_version,
-                    );
-                    if let Ok((_, Some(_))) = retry {
-                        return retry;
-                    }
-                }
-                Err(_) => {
-                    tracing::debug!(
-                        ?contract_id,
-                        "retrying contract verification with history enabled after error"
-                    );
-                    let retry = Self::verify_contract_return_serialization_v0_given_history(
-                        proof,
-                        true,
-                        is_proof_subset,
-                        in_multiple_contract_proof_form,
-                        contract_id,
-                        platform_version,
-                    );
-                    if retry.is_ok() {
-                        return retry;
-                    }
-                }
-            }
-        }
-        result
+        retry_contract_verification_with_history(
+            result,
+            contract_known_keeps_history,
+            contract_id,
+            in_multiple_contract_proof_form,
+            || {
+                Self::verify_contract_return_serialization_v0_given_history(
+                    proof,
+                    true,
+                    is_proof_subset,
+                    in_multiple_contract_proof_form,
+                    contract_id,
+                    platform_version,
+                )
+            },
+            |(_, contract)| contract.is_some(),
+        )
     }
 
     fn verify_contract_return_serialization_v0_given_history(

--- a/packages/rs-drive/tests/query_tests.rs
+++ b/packages/rs-drive/tests/query_tests.rs
@@ -4735,41 +4735,38 @@ mod tests {
             proof_contract.expect("expected contract, not None - retry must work")
         );
 
-        // Test 2: Some(true) - explicit historical path must be handled without panic
-        let result_true = Drive::verify_contract(
+        // Test 2: Some(true) - direct historical, must succeed since proof was generated
+        // for a historical contract
+        let (proof_root_hash_2, proof_contract_2) = Drive::verify_contract(
             contract_proof.as_slice(),
             Some(true),
             false,
             false,
             latest_contract.id().into_buffer(),
             platform_version,
+        )
+        .expect("verification with Some(true) should succeed for historical contract");
+        assert_eq!(root_hash, proof_root_hash_2);
+        assert_eq!(
+            latest_contract,
+            proof_contract_2.expect("expected contract with explicit history flag")
         );
-        match result_true {
-            Ok((proof_root_hash_2, Some(proof_contract_2))) => {
-                assert_eq!(root_hash, proof_root_hash_2);
-                assert_eq!(latest_contract, proof_contract_2);
-            }
-            Ok((_, None)) => {}
-            Err(_) => {}
-        }
 
-        // Test 3: Some(false) - explicit non-historical path must be handled without panic
-        let result_false = Drive::verify_contract(
+        // Test 3: Some(false) - contract still exists regardless of history-flag hint.
+        let (proof_root_hash_3, proof_contract_3) = Drive::verify_contract(
             contract_proof.as_slice(),
             Some(false),
             false,
             false,
             latest_contract.id().into_buffer(),
             platform_version,
+        )
+        .expect("verification with Some(false) should still return the existing contract");
+        assert_eq!(root_hash, proof_root_hash_3);
+        assert_eq!(
+            latest_contract,
+            proof_contract_3.expect("expected contract with explicit non-history flag")
         );
-        match result_false {
-            Ok((proof_root_hash_3, Some(proof_contract_3))) => {
-                assert_eq!(root_hash, proof_root_hash_3);
-                assert_eq!(latest_contract, proof_contract_3);
-            }
-            Ok((_, None)) => {}
-            Err(_) => {}
-        }
 
         // Test 4: verify_contract_return_serialization with None
         let (proof_root_hash_4, proof_contract_4) = Drive::verify_contract_return_serialization(

--- a/packages/rs-drive/tests/query_tests.rs
+++ b/packages/rs-drive/tests/query_tests.rs
@@ -59,6 +59,7 @@ use base64::Engine;
 #[cfg(feature = "server")]
 use dpp::block::block_info::BlockInfo;
 use dpp::data_contract::accessors::v0::DataContractV0Getters;
+use dpp::data_contract::accessors::v0::DataContractV0Setters;
 use dpp::data_contract::config::v1::DataContractConfigSettersV1;
 use dpp::data_contract::conversion::value::v0::DataContractValueConversionMethodsV0;
 use dpp::data_contract::document_type::methods::DocumentTypeV0Methods;
@@ -4685,6 +4686,104 @@ mod tests {
             contract,
             proof_returned_contract.expect("expected to get a contract")
         );
+    }
+
+    #[test]
+    fn test_contract_keeps_history_verify_with_unknown_history_flag() {
+        // Regression test: when contract_known_keeps_history is None,
+        // verification must still succeed for historical contracts.
+        let (drive, contract) = setup_references_tests(10, 3334);
+        let platform_version = PlatformVersion::latest();
+
+        // Apply an update so the contract has an actual history entry and latest historical path.
+        let mut latest_contract = contract.clone();
+        latest_contract.set_version(contract.version() + 1);
+        drive
+            .apply_contract(
+                &latest_contract,
+                BlockInfo::default(),
+                true,
+                StorageFlags::optional_default_as_cow(),
+                None,
+                platform_version,
+            )
+            .expect("contract update should be applied");
+
+        let root_hash = drive
+            .grove
+            .root_hash(None, &platform_version.drive.grove_version)
+            .unwrap()
+            .expect("there is always a root hash");
+
+        let contract_proof = drive
+            .prove_contract(latest_contract.id().into_buffer(), None, platform_version)
+            .expect("expected to get proof");
+
+        // Test 1: None (unknown) - MUST succeed via retry
+        let (proof_root_hash, proof_contract) = Drive::verify_contract(
+            contract_proof.as_slice(),
+            None,
+            false,
+            false,
+            latest_contract.id().into_buffer(),
+            platform_version,
+        )
+        .expect("verification with None should succeed for historical contract");
+        assert_eq!(root_hash, proof_root_hash);
+        assert_eq!(
+            latest_contract,
+            proof_contract.expect("expected contract, not None - retry must work")
+        );
+
+        // Test 2: Some(true) - explicit historical path must be handled without panic
+        let result_true = Drive::verify_contract(
+            contract_proof.as_slice(),
+            Some(true),
+            false,
+            false,
+            latest_contract.id().into_buffer(),
+            platform_version,
+        );
+        match result_true {
+            Ok((proof_root_hash_2, Some(proof_contract_2))) => {
+                assert_eq!(root_hash, proof_root_hash_2);
+                assert_eq!(latest_contract, proof_contract_2);
+            }
+            Ok((_, None)) => {}
+            Err(_) => {}
+        }
+
+        // Test 3: Some(false) - explicit non-historical path must be handled without panic
+        let result_false = Drive::verify_contract(
+            contract_proof.as_slice(),
+            Some(false),
+            false,
+            false,
+            latest_contract.id().into_buffer(),
+            platform_version,
+        );
+        match result_false {
+            Ok((proof_root_hash_3, Some(proof_contract_3))) => {
+                assert_eq!(root_hash, proof_root_hash_3);
+                assert_eq!(latest_contract, proof_contract_3);
+            }
+            Ok((_, None)) => {}
+            Err(_) => {}
+        }
+
+        // Test 4: verify_contract_return_serialization with None
+        let (proof_root_hash_4, proof_contract_4) = Drive::verify_contract_return_serialization(
+            contract_proof.as_slice(),
+            None,
+            false,
+            false,
+            latest_contract.id().into_buffer(),
+            platform_version,
+        )
+        .expect("return_serialization with None should succeed for historical contract");
+        assert_eq!(root_hash, proof_root_hash_4);
+        let (deserialized, _bytes) = proof_contract_4.expect("expected contract+bytes, not None");
+        assert_eq!(latest_contract, deserialized);
     }
 
     #[cfg(feature = "server")]

--- a/packages/rs-drive/tests/query_tests.rs
+++ b/packages/rs-drive/tests/query_tests.rs
@@ -60,6 +60,7 @@ use base64::Engine;
 use dpp::block::block_info::BlockInfo;
 use dpp::data_contract::accessors::v0::DataContractV0Getters;
 use dpp::data_contract::accessors::v0::DataContractV0Setters;
+use dpp::data_contract::config::v0::DataContractConfigSettersV0;
 use dpp::data_contract::config::v1::DataContractConfigSettersV1;
 use dpp::data_contract::conversion::value::v0::DataContractValueConversionMethodsV0;
 use dpp::data_contract::document_type::methods::DocumentTypeV0Methods;
@@ -919,6 +920,14 @@ pub fn setup_withdrawal_tests(
 #[cfg(feature = "server")]
 /// Sets up the References contract to test queries on.
 pub fn setup_references_tests(_count: u32, _seed: u64) -> (Drive, DataContract) {
+    setup_references_tests_with_keeps_history(_count, _seed, false)
+}
+
+pub fn setup_references_tests_with_keeps_history(
+    _count: u32,
+    _seed: u64,
+    keeps_history: bool,
+) -> (Drive, DataContract) {
     let drive = setup_drive(Some(DriveConfig::default()));
 
     let db_transaction = drive.grove.start_transaction();
@@ -940,7 +949,9 @@ pub fn setup_references_tests(_count: u32, _seed: u64) -> (Drive, DataContract) 
         "tests/supporting_files/contract/references/references_with_contract_history.json",
         None,
         None,
-        None::<fn(&mut DataContract)>,
+        Some(|contract: &mut DataContract| {
+            contract.config_mut().set_keeps_history(keeps_history);
+        }),
         Some(&db_transaction),
         None,
     );
@@ -4692,7 +4703,7 @@ mod tests {
     fn test_contract_keeps_history_verify_with_unknown_history_flag() {
         // Regression test: when contract_known_keeps_history is None,
         // verification must still succeed for historical contracts.
-        let (drive, contract) = setup_references_tests(10, 3334);
+        let (drive, contract) = setup_references_tests_with_keeps_history(10, 3334, true);
         let platform_version = PlatformVersion::latest();
 
         // Apply an update so the contract has an actual history entry and latest historical path.
@@ -4701,7 +4712,10 @@ mod tests {
         drive
             .apply_contract(
                 &latest_contract,
-                BlockInfo::default(),
+                BlockInfo {
+                    time_ms: 1,
+                    ..Default::default()
+                },
                 true,
                 StorageFlags::optional_default_as_cow(),
                 None,
@@ -4719,7 +4733,7 @@ mod tests {
             .prove_contract(latest_contract.id().into_buffer(), None, platform_version)
             .expect("expected to get proof");
 
-        // Test 1: None (unknown) - MUST succeed via retry
+        // Test 1: None (unknown) - verification must succeed, and may use retry behavior.
         let (proof_root_hash, proof_contract) = Drive::verify_contract(
             contract_proof.as_slice(),
             None,
@@ -4728,12 +4742,11 @@ mod tests {
             latest_contract.id().into_buffer(),
             platform_version,
         )
-        .expect("verification with None should succeed for historical contract");
+        .expect("verification with None should succeed");
         assert_eq!(root_hash, proof_root_hash);
-        assert_eq!(
-            latest_contract,
-            proof_contract.expect("expected contract, not None - retry must work")
-        );
+        if let Some(contract) = proof_contract {
+            assert_eq!(latest_contract, contract);
+        }
 
         // Test 2: Some(true) - direct historical, must succeed since proof was generated
         // for a historical contract
@@ -4752,19 +4765,33 @@ mod tests {
             proof_contract_2.expect("expected contract with explicit history flag")
         );
 
-        // Test 3: Some(false) - contract still exists regardless of history-flag hint.
+        // Test 3: Some(false) - explicit non-historical contract must verify to existing value.
+        let (non_historical_drive, non_historical_contract) =
+            setup_references_tests_with_keeps_history(10, 3334, false);
+        let non_historical_root_hash = non_historical_drive
+            .grove
+            .root_hash(None, &platform_version.drive.grove_version)
+            .unwrap()
+            .expect("there is always a root hash");
+        let non_historical_proof = non_historical_drive
+            .prove_contract(
+                non_historical_contract.id().into_buffer(),
+                None,
+                platform_version,
+            )
+            .expect("expected to get proof");
         let (proof_root_hash_3, proof_contract_3) = Drive::verify_contract(
-            contract_proof.as_slice(),
+            non_historical_proof.as_slice(),
             Some(false),
             false,
             false,
-            latest_contract.id().into_buffer(),
+            non_historical_contract.id().into_buffer(),
             platform_version,
         )
-        .expect("verification with Some(false) should still return the existing contract");
-        assert_eq!(root_hash, proof_root_hash_3);
+        .expect("verification with Some(false) should return the existing contract");
+        assert_eq!(non_historical_root_hash, proof_root_hash_3);
         assert_eq!(
-            latest_contract,
+            non_historical_contract,
             proof_contract_3.expect("expected contract with explicit non-history flag")
         );
 
@@ -4779,8 +4806,9 @@ mod tests {
         )
         .expect("return_serialization with None should succeed for historical contract");
         assert_eq!(root_hash, proof_root_hash_4);
-        let (deserialized, _bytes) = proof_contract_4.expect("expected contract+bytes, not None");
-        assert_eq!(latest_contract, deserialized);
+        if let Some((deserialized, _bytes)) = proof_contract_4 {
+            assert_eq!(latest_contract, deserialized);
+        }
     }
 
     #[cfg(feature = "server")]

--- a/packages/rs-drive/tests/query_tests.rs
+++ b/packages/rs-drive/tests/query_tests.rs
@@ -4733,7 +4733,10 @@ mod tests {
             .prove_contract(latest_contract.id().into_buffer(), None, platform_version)
             .expect("expected to get proof");
 
-        // Test 1: None (unknown) - verification must succeed, and may use retry behavior.
+        // Test 1: None (unknown) on a historical contract.
+        // Verification must transparently retry with history enabled and return the
+        // updated historical contract — callers do not need to know the keeps_history
+        // flag in advance.
         let (proof_root_hash, proof_contract) = Drive::verify_contract(
             contract_proof.as_slice(),
             None,
@@ -4742,11 +4745,14 @@ mod tests {
             latest_contract.id().into_buffer(),
             platform_version,
         )
-        .expect("verification with None should succeed");
+        .expect("verification with None should succeed for a historical contract");
         assert_eq!(root_hash, proof_root_hash);
-        if let Some(contract) = proof_contract {
-            assert_eq!(latest_contract, contract);
-        }
+        assert_eq!(
+            latest_contract,
+            proof_contract.expect(
+                "historical contract should be recovered via retry when keeps_history is unknown",
+            ),
+        );
 
         // Test 2: Some(true) - direct historical, must succeed since proof was generated
         // for a historical contract
@@ -4795,7 +4801,9 @@ mod tests {
             proof_contract_3.expect("expected contract with explicit non-history flag")
         );
 
-        // Test 4: verify_contract_return_serialization with None
+        // Test 4: verify_contract_return_serialization with None on a historical contract
+        // mirrors Test 1 — the historical contract must be recovered via retry when the
+        // keeps_history flag is unknown.
         let (proof_root_hash_4, proof_contract_4) = Drive::verify_contract_return_serialization(
             contract_proof.as_slice(),
             None,
@@ -4804,11 +4812,59 @@ mod tests {
             latest_contract.id().into_buffer(),
             platform_version,
         )
-        .expect("return_serialization with None should succeed for historical contract");
+        .expect("return_serialization with None should succeed for a historical contract");
         assert_eq!(root_hash, proof_root_hash_4);
-        if let Some((deserialized, _bytes)) = proof_contract_4 {
-            assert_eq!(latest_contract, deserialized);
-        }
+        let (proof_contract_4_data, _proof_contract_4_bytes) = proof_contract_4.expect(
+            "return_serialization should recover the historical contract when keeps_history is unknown",
+        );
+        assert_eq!(latest_contract, proof_contract_4_data);
+
+        // Test 5: None (unknown) for a non-existent contract — verify_contract must
+        // return Ok((root_hash, None)) for a genuine absence proof rather than retrying
+        // with history and turning it into an error.
+        let non_existent_id = [0xffu8; 32];
+        let non_existent_proof = drive
+            .prove_contract(non_existent_id, None, platform_version)
+            .expect("expected to get proof for non-existent contract");
+
+        let (proof_root_hash_5, proof_contract_5) = Drive::verify_contract(
+            non_existent_proof.as_slice(),
+            None,
+            false,
+            false,
+            non_existent_id,
+            platform_version,
+        )
+        .expect("verify_contract with None must succeed for a non-existent contract");
+        assert_eq!(
+            root_hash, proof_root_hash_5,
+            "absence proof must report the same root hash"
+        );
+        assert!(
+            proof_contract_5.is_none(),
+            "verify_contract with None must return Ok((_, None)) for a non-existent contract"
+        );
+
+        // Test 6: same coverage for verify_contract_return_serialization.
+        let (proof_root_hash_6, proof_contract_6) = Drive::verify_contract_return_serialization(
+            non_existent_proof.as_slice(),
+            None,
+            false,
+            false,
+            non_existent_id,
+            platform_version,
+        )
+        .expect(
+            "verify_contract_return_serialization with None must succeed for a non-existent contract",
+        );
+        assert_eq!(
+            root_hash, proof_root_hash_6,
+            "absence proof must report the same root hash for return_serialization"
+        );
+        assert!(
+            proof_contract_6.is_none(),
+            "verify_contract_return_serialization with None must return Ok((_, None)) for a non-existent contract"
+        );
     }
 
     #[cfg(feature = "server")]


### PR DESCRIPTION
## Issue

When `getDataContract` is called for a contract with `keepsHistory: true`, it returns "Data contract not found" even though `getDataContractHistory` succeeds for the same contract.

**Root cause:** In `verify_contract_v0`, when `contract_known_keeps_history` is `None` (as it always is from `FromProof<GetDataContractRequest>`), the code defaults to the non-historical path. If that returns `Ok(None)` (contract not found on the non-historical path), it never retries with the historical path — it only retried on `Err(_)`.

## Changes

### Core fix (both `verify_contract` and `verify_contract_return_serialization`)
- Extracted `_given_history` helpers that perform verification with a known history flag
- Consolidated retry logic into the entry point: when `contract_known_keeps_history` is `None`, retry with `keeps_history = true` if the first attempt returns `Err(_)` **or** `Ok((_, None))`
- Removed scattered retry logic from deep inside the function body

### Tests
- Added `test_contract_keeps_history_verify_with_unknown_history_flag` regression test covering:
  1. `None` (unknown) — must succeed via retry for historical contracts
  2. `Some(true)` — direct historical verification
  3. `Some(false)` — non-historical contract verification
  4. `verify_contract_return_serialization` with `None` — parallel path coverage

### Validation
- `cargo test -p drive` ✅
- `cargo clippy -p drive -- -D warnings` ✅


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced contract verification with history-aware logic for improved handling of contract data

* **Bug Fixes**
  * Improved retry mechanism when contract history status is unknown or unspecified

* **Tests**
  * Added regression test for contract verification scenarios with unknown history flags, covering multiple verification paths
<!-- end of auto-generated comment: release notes by coderabbit.ai -->