### PR TITLE
fix(sdk): default to nonce 0 for first-time identity/contract interactions

### DIFF
--- a/packages/rs-sdk/src/internal_cache/mod.rs
+++ b/packages/rs-sdk/src/internal_cache/mod.rs
@@ -150,7 +150,7 @@ impl NonceCache {
                             tracing::debug!(
                                 identity_id = %identity_id,
                                 "Platform returned no nonce for identity; \
-                                 defaulting to 0 (first interaction)"
+                                 defaulting to 0 (unknown identity, node missing data, or first interaction)"
                             );
                             0
                         });

--- a/packages/rs-sdk/src/internal_cache/mod.rs
+++ b/packages/rs-sdk/src/internal_cache/mod.rs
@@ -715,10 +715,7 @@ mod nonce_cache_tests {
 
         // Platform returns None (identity has never interacted with contract).
         sdk.mock()
-            .expect_fetch::<IdentityContractNonceFetcher, _>(
-                (identity_id, contract_id),
-                None,
-            )
+            .expect_fetch::<IdentityContractNonceFetcher, _>((identity_id, contract_id), None)
             .await
             .expect("set mock expectation");
 

--- a/packages/rs-sdk/src/internal_cache/mod.rs
+++ b/packages/rs-sdk/src/internal_cache/mod.rs
@@ -70,10 +70,7 @@ pub(crate) struct IdentityContractPair {
 ///
 /// # First-time interactions
 ///
-/// A `None` response from Platform simply means the identity has not
-/// yet interacted with the given contract (or Platform at all).  The
-/// fetch closure defaults to nonce `0` in that case, allowing first
-/// document creations to succeed without special-casing by callers.
+/// `None` from Platform → nonce `0` (matches Drive's `unwrap_or_default()`).
 pub(crate) struct NonceCache {
     identity_nonces: Mutex<LruCache<Identifier, NonceCacheEntry>>,
     contract_nonces: Mutex<LruCache<IdentityContractPair, NonceCacheEntry>>,
@@ -143,15 +140,8 @@ impl NonceCache {
             settings,
             self.default_stale_time_s,
             || async move {
-                // `None` means the nonce path does not exist in GroveDB.
-                // This is indistinguishable from "identity does not exist"
-                // because GroveDB proofs only attest presence/absence of a
-                // leaf — they cannot tell us *which* ancestor is missing.
-                // Drive's own non-proven query handler applies the same
-                // `unwrap_or_default()` logic, so defaulting to 0 here
-                // keeps the SDK consistent with the server.  Callers that
-                // need to verify the identity exists should do so before
-                // requesting a nonce.
+                // None = first interaction (or missing identity — GroveDB
+                // can't distinguish). Matches Drive's unwrap_or_default().
                 let nonce =
                     IdentityNonceFetcher::fetch_with_settings(sdk, identity_id, request_settings)
                         .await?
@@ -191,10 +181,7 @@ impl NonceCache {
             settings,
             self.default_stale_time_s,
             || async move {
-                // See the comment in `get_identity_nonce` — the same
-                // GroveDB limitation applies: `None` can mean "no nonce
-                // yet", "identity missing", or "contract missing".
-                // Drive defaults to 0 in all three cases; we do the same.
+                // Same as get_identity_nonce: None → 0.
                 let nonce = IdentityContractNonceFetcher::fetch_with_settings(
                     sdk,
                     (identity_id, contract_id),

--- a/packages/rs-sdk/src/internal_cache/mod.rs
+++ b/packages/rs-sdk/src/internal_cache/mod.rs
@@ -143,6 +143,15 @@ impl NonceCache {
             settings,
             self.default_stale_time_s,
             || async move {
+                // `None` means the nonce path does not exist in GroveDB.
+                // This is indistinguishable from "identity does not exist"
+                // because GroveDB proofs only attest presence/absence of a
+                // leaf — they cannot tell us *which* ancestor is missing.
+                // Drive's own non-proven query handler applies the same
+                // `unwrap_or_default()` logic, so defaulting to 0 here
+                // keeps the SDK consistent with the server.  Callers that
+                // need to verify the identity exists should do so before
+                // requesting a nonce.
                 let nonce =
                     IdentityNonceFetcher::fetch_with_settings(sdk, identity_id, request_settings)
                         .await?
@@ -182,6 +191,10 @@ impl NonceCache {
             settings,
             self.default_stale_time_s,
             || async move {
+                // See the comment in `get_identity_nonce` — the same
+                // GroveDB limitation applies: `None` can mean "no nonce
+                // yet", "identity missing", or "contract missing".
+                // Drive defaults to 0 in all three cases; we do the same.
                 let nonce = IdentityContractNonceFetcher::fetch_with_settings(
                     sdk,
                     (identity_id, contract_id),

--- a/packages/rs-sdk/src/internal_cache/mod.rs
+++ b/packages/rs-sdk/src/internal_cache/mod.rs
@@ -683,7 +683,7 @@ mod nonce_cache_tests {
 
     // --- First-time interaction: None → nonce 0 (issue #3169) ---
     #[tokio::test]
-    async fn first_identity_nonce_defaults_to_zero() {
+    async fn first_identity_nonce_defaults_to_zero_then_bumps_to_one() {
         use drive_proof_verifier::types::IdentityNonceFetcher;
 
         let mut sdk = crate::Sdk::new_mock();
@@ -705,7 +705,7 @@ mod nonce_cache_tests {
     }
 
     #[tokio::test]
-    async fn first_identity_contract_nonce_defaults_to_zero() {
+    async fn first_identity_contract_nonce_defaults_to_zero_then_bumps_to_one() {
         use drive_proof_verifier::types::IdentityContractNonceFetcher;
 
         let mut sdk = crate::Sdk::new_mock();
@@ -731,6 +731,28 @@ mod nonce_cache_tests {
             nonce, 1,
             "first identity-contract nonce should be 1 (0 bumped)"
         );
+    }
+
+    #[tokio::test]
+    async fn first_identity_nonce_defaults_to_zero_without_bump() {
+        use drive_proof_verifier::types::IdentityNonceFetcher;
+
+        let mut sdk = crate::Sdk::new_mock();
+        let identity_id = Identifier::default();
+        let settings = PutSettings::default();
+
+        // Platform returns None (identity has never interacted).
+        sdk.mock()
+            .expect_fetch::<IdentityNonceFetcher, _>(identity_id, None)
+            .await
+            .expect("set mock expectation");
+
+        // bump_first=false: should return the raw default of 0.
+        let nonce = sdk
+            .get_identity_nonce(identity_id, false, Some(settings))
+            .await
+            .unwrap();
+        assert_eq!(nonce, 0, "first identity nonce without bump should be 0");
     }
 
     // --- Different keys are isolated ---

--- a/packages/rs-sdk/src/internal_cache/mod.rs
+++ b/packages/rs-sdk/src/internal_cache/mod.rs
@@ -68,12 +68,12 @@ pub(crate) struct IdentityContractPair {
 /// transactions fail silently, the cache may advance past the on-chain
 /// nonce until the next re-fetch realigns it.
 ///
-/// # DAPI node staleness
+/// # First-time interactions
 ///
-/// A stale DAPI node may report an identity as unknown.  The fetch
-/// closure surfaces this as [`Error::IdentityNonceNotFound`] rather
-/// than defaulting to nonce 0.  Worst case: one state transition
-/// attempt fails and must be retried against a different node.
+/// A `None` response from Platform simply means the identity has not
+/// yet interacted with the given contract (or Platform at all).  The
+/// fetch closure defaults to nonce `0` in that case, allowing first
+/// document creations to succeed without special-casing by callers.
 pub(crate) struct NonceCache {
     identity_nonces: Mutex<LruCache<Identifier, NonceCacheEntry>>,
     contract_nonces: Mutex<LruCache<IdentityContractPair, NonceCacheEntry>>,
@@ -143,20 +143,19 @@ impl NonceCache {
             settings,
             self.default_stale_time_s,
             || async move {
-                let fetcher =
+                let nonce =
                     IdentityNonceFetcher::fetch_with_settings(sdk, identity_id, request_settings)
                         .await?
-                        .ok_or_else(|| {
-                            tracing::warn!(
+                        .map(|fetcher| fetcher.0)
+                        .unwrap_or_else(|| {
+                            tracing::debug!(
                                 identity_id = %identity_id,
                                 "Platform returned no nonce for identity; \
-                                 node may be stale or identity may not exist yet"
+                                 defaulting to 0 (first interaction)"
                             );
-                            Error::IdentityNonceNotFound(format!(
-                                "identity {identity_id}: platform returned no nonce"
-                            ))
-                        })?;
-                Ok(fetcher.0)
+                            0
+                        });
+                Ok(nonce)
             },
         )
         .await
@@ -183,25 +182,23 @@ impl NonceCache {
             settings,
             self.default_stale_time_s,
             || async move {
-                let fetcher = IdentityContractNonceFetcher::fetch_with_settings(
+                let nonce = IdentityContractNonceFetcher::fetch_with_settings(
                     sdk,
                     (identity_id, contract_id),
                     request_settings,
                 )
                 .await?
-                .ok_or_else(|| {
-                    tracing::warn!(
+                .map(|fetcher| fetcher.0)
+                .unwrap_or_else(|| {
+                    tracing::debug!(
                         identity_id = %identity_id,
                         contract_id = %contract_id,
                         "Platform returned no nonce for identity-contract pair; \
-                         node may be stale or identity may not exist yet"
+                         defaulting to 0 (first interaction)"
                     );
-                    Error::IdentityNonceNotFound(format!(
-                        "identity {identity_id} contract {contract_id}: \
-                         platform returned no nonce"
-                    ))
-                })?;
-                Ok(fetcher.0)
+                    0
+                });
+                Ok(nonce)
             },
         )
         .await
@@ -262,10 +259,7 @@ impl NonceCache {
     ///
     /// # Errors
     ///
-    /// - Returns whatever error `fetch_from_platform` produces, including
-    ///   [`Error::IdentityNonceNotFound`] when the queried DAPI node does
-    ///   not know the identity. Callers should retry in that case; a
-    ///   different node will likely have the data.
+    /// - Returns whatever error `fetch_from_platform` produces.
     /// - Returns [`Error::NonceOverflow`] if bumping would wrap past the
     ///   40-bit nonce value filter.
     async fn get_or_fetch_nonce<K: Hash + Eq + Copy + Debug, F, Fut>(
@@ -685,6 +679,58 @@ mod nonce_cache_tests {
             .await
             .unwrap();
         assert_eq!(nonce, 21);
+    }
+
+    // --- First-time interaction: None → nonce 0 (issue #3169) ---
+    #[tokio::test]
+    async fn first_identity_nonce_defaults_to_zero() {
+        use drive_proof_verifier::types::IdentityNonceFetcher;
+
+        let mut sdk = crate::Sdk::new_mock();
+        let identity_id = Identifier::default();
+        let settings = PutSettings::default();
+
+        // Platform returns None (identity has never interacted).
+        sdk.mock()
+            .expect_fetch::<IdentityNonceFetcher, _>(identity_id, None)
+            .await
+            .expect("set mock expectation");
+
+        // Should default to 0 and bump to 1.
+        let nonce = sdk
+            .get_identity_nonce(identity_id, true, Some(settings))
+            .await
+            .unwrap();
+        assert_eq!(nonce, 1, "first identity nonce should be 1 (0 bumped)");
+    }
+
+    #[tokio::test]
+    async fn first_identity_contract_nonce_defaults_to_zero() {
+        use drive_proof_verifier::types::IdentityContractNonceFetcher;
+
+        let mut sdk = crate::Sdk::new_mock();
+        let identity_id = Identifier::default();
+        let contract_id = Identifier::from([1u8; 32]);
+        let settings = PutSettings::default();
+
+        // Platform returns None (identity has never interacted with contract).
+        sdk.mock()
+            .expect_fetch::<IdentityContractNonceFetcher, _>(
+                (identity_id, contract_id),
+                None,
+            )
+            .await
+            .expect("set mock expectation");
+
+        // Should default to 0 and bump to 1.
+        let nonce = sdk
+            .get_identity_contract_nonce(identity_id, contract_id, true, Some(settings))
+            .await
+            .unwrap();
+        assert_eq!(
+            nonce, 1,
+            "first identity-contract nonce should be 1 (0 bumped)"
+        );
     }
 
     // --- Different keys are isolated ---

--- a/packages/rs-sdk/src/sdk.rs
+++ b/packages/rs-sdk/src/sdk.rs
@@ -328,11 +328,8 @@ impl Sdk {
     }
 
     /// Get or fetch identity nonce, querying Platform when stale or absent.
-    ///
-    /// Returns `0` when Platform has no nonce for this identity, which
-    /// means either the identity has never submitted a state transition,
-    /// or the identity does not exist. This method does **not** verify
-    /// identity existence — callers should do so separately if needed.
+    /// Returns `0` for first interactions **and** non-existent identities
+    /// (GroveDB cannot distinguish the two). Does not verify identity existence.
     pub async fn get_identity_nonce(
         &self,
         identity_id: Identifier,
@@ -356,12 +353,8 @@ impl Sdk {
     }
 
     /// Get or fetch identity-contract nonce, querying Platform when stale or absent.
-    ///
-    /// Returns `0` when Platform has no nonce for the pair, which means
-    /// the identity has never interacted with this contract, or the
-    /// identity/contract does not exist. This method does **not** verify
-    /// identity or contract existence — callers should do so separately
-    /// if needed.
+    /// Returns `0` for first interactions **and** non-existent identity/contract
+    /// (GroveDB cannot distinguish the two). Does not verify existence.
     pub async fn get_identity_contract_nonce(
         &self,
         identity_id: Identifier,

--- a/packages/rs-sdk/src/sdk.rs
+++ b/packages/rs-sdk/src/sdk.rs
@@ -328,8 +328,8 @@ impl Sdk {
     }
 
     /// Get or fetch identity nonce, querying Platform when stale or absent.
-    /// Returns `0` for first interactions **and** non-existent identities
-    /// (GroveDB cannot distinguish the two). Does not verify identity existence.
+    /// Returns `0` for first interactions **and** non-existent identities.
+    /// Does not verify identity existence.
     pub async fn get_identity_nonce(
         &self,
         identity_id: Identifier,
@@ -353,8 +353,8 @@ impl Sdk {
     }
 
     /// Get or fetch identity-contract nonce, querying Platform when stale or absent.
-    /// Returns `0` for first interactions **and** non-existent identity/contract
-    /// (GroveDB cannot distinguish the two). Does not verify existence.
+    /// Returns `0` for first interactions **and** non-existent identity/contract.
+    /// Does not verify identity or contract existence.
     pub async fn get_identity_contract_nonce(
         &self,
         identity_id: Identifier,

--- a/packages/rs-sdk/src/sdk.rs
+++ b/packages/rs-sdk/src/sdk.rs
@@ -354,8 +354,9 @@ impl Sdk {
     }
 
     /// Get or fetch identity-contract nonce, querying Platform when stale or absent.
-    /// Returns `0` for first interactions **and** non-existent identity/contract.
-    /// Does not verify identity or contract existence.
+    /// Treats a missing nonce as `0` before applying the optional bump; on first
+    /// interaction this may return `0` or `1` depending on `bump_first`. Does not
+    /// verify identity or contract existence.
     pub async fn get_identity_contract_nonce(
         &self,
         identity_id: Identifier,

--- a/packages/rs-sdk/src/sdk.rs
+++ b/packages/rs-sdk/src/sdk.rs
@@ -331,13 +331,10 @@ impl Sdk {
     /// querying Platform if the cached value is stale or absent. Optionally
     /// increments the nonce before storing it, based on the provided settings.
     ///
-    /// # Errors
+    /// # First-time interactions
     ///
-    /// Returns [`Error::IdentityNonceNotFound`] if the queried DAPI node
-    /// does not know the identity (e.g. the node is stale or the identity
-    /// was just created). The worst-case impact is that the caller must
-    /// retry the state transition; the next attempt will re-fetch from
-    /// Platform and likely reach an up-to-date node.
+    /// If Platform returns no nonce for the identity (first interaction or
+    /// stale node), the cache defaults to nonce `0`.
     pub async fn get_identity_nonce(
         &self,
         identity_id: Identifier,
@@ -365,11 +362,10 @@ impl Sdk {
     /// Optionally increments the nonce before storing it, based on the provided
     /// settings.
     ///
-    /// # Errors
+    /// # First-time interactions
     ///
-    /// Returns [`Error::IdentityNonceNotFound`] if the queried DAPI node
-    /// does not know the identity–contract pair. See
-    /// [`get_identity_nonce`](Self::get_identity_nonce) for details.
+    /// If Platform returns no nonce for the identity–contract pair (first
+    /// interaction or stale node), the cache defaults to nonce `0`.
     pub async fn get_identity_contract_nonce(
         &self,
         identity_id: Identifier,

--- a/packages/rs-sdk/src/sdk.rs
+++ b/packages/rs-sdk/src/sdk.rs
@@ -328,8 +328,9 @@ impl Sdk {
     }
 
     /// Get or fetch identity nonce, querying Platform when stale or absent.
-    /// Returns `0` for first interactions **and** non-existent identities.
-    /// Does not verify identity existence.
+    /// Treats a missing nonce as `0` before applying the optional bump; on first
+    /// interaction this may return `0` or `1` depending on `bump_first`. Does not
+    /// verify identity existence.
     pub async fn get_identity_nonce(
         &self,
         identity_id: Identifier,

--- a/packages/rs-sdk/src/sdk.rs
+++ b/packages/rs-sdk/src/sdk.rs
@@ -328,7 +328,11 @@ impl Sdk {
     }
 
     /// Get or fetch identity nonce, querying Platform when stale or absent.
-    /// Returns `0` for first-time interactions (no nonce on Platform yet).
+    ///
+    /// Returns `0` when Platform has no nonce for this identity, which
+    /// means either the identity has never submitted a state transition,
+    /// or the identity does not exist. This method does **not** verify
+    /// identity existence — callers should do so separately if needed.
     pub async fn get_identity_nonce(
         &self,
         identity_id: Identifier,
@@ -352,7 +356,12 @@ impl Sdk {
     }
 
     /// Get or fetch identity-contract nonce, querying Platform when stale or absent.
-    /// Returns `0` for first-time interactions (no nonce on Platform yet).
+    ///
+    /// Returns `0` when Platform has no nonce for the pair, which means
+    /// the identity has never interacted with this contract, or the
+    /// identity/contract does not exist. This method does **not** verify
+    /// identity or contract existence — callers should do so separately
+    /// if needed.
     pub async fn get_identity_contract_nonce(
         &self,
         identity_id: Identifier,

--- a/packages/rs-sdk/src/sdk.rs
+++ b/packages/rs-sdk/src/sdk.rs
@@ -327,14 +327,8 @@ impl Sdk {
         }
     }
 
-    /// Updates or fetches the nonce for a given identity from the cache,
-    /// querying Platform if the cached value is stale or absent. Optionally
-    /// increments the nonce before storing it, based on the provided settings.
-    ///
-    /// # First-time interactions
-    ///
-    /// If Platform returns no nonce for the identity (first interaction or
-    /// stale node), the cache defaults to nonce `0`.
+    /// Get or fetch identity nonce, querying Platform when stale or absent.
+    /// Returns `0` for first-time interactions (no nonce on Platform yet).
     pub async fn get_identity_nonce(
         &self,
         identity_id: Identifier,
@@ -357,15 +351,8 @@ impl Sdk {
         Ok(nonce)
     }
 
-    /// Updates or fetches the nonce for a given identity and contract pair from
-    /// the cache, querying Platform if the cached value is stale or absent.
-    /// Optionally increments the nonce before storing it, based on the provided
-    /// settings.
-    ///
-    /// # First-time interactions
-    ///
-    /// If Platform returns no nonce for the identity–contract pair (first
-    /// interaction or stale node), the cache defaults to nonce `0`.
+    /// Get or fetch identity-contract nonce, querying Platform when stale or absent.
+    /// Returns `0` for first-time interactions (no nonce on Platform yet).
     pub async fn get_identity_contract_nonce(
         &self,
         identity_id: Identifier,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

When an identity interacts with a contract for the first time, Platform returns `None` for the nonce. The SDK previously surfaced this as `Error::IdentityNonceNotFound`, causing `document_create` (and other state transitions) to fail on first use.

Closes #3169

## What was done?
<!--- Describe your changes in detail -->

- **`NonceCache::get_identity_nonce` / `get_identity_contract_nonce`** (`internal_cache/mod.rs`): Changed `None` response from Platform to default to nonce `0` (via `unwrap_or_else`) instead of returning `Error::IdentityNonceNotFound`. This matches Drive's own `unwrap_or_default()` behavior. Downgraded log level from `warn` to `debug`.
- **`Sdk::get_identity_nonce` / `get_identity_contract_nonce`** (`sdk.rs`): Replaced verbose doc comments with concise descriptions clarifying that a missing nonce is treated as `0` before applying the optional bump.
- **`NonceCache::get_or_fetch_nonce`** (`internal_cache/mod.rs`): Simplified error doc — removed `IdentityNonceNotFound` reference since it's no longer returned.
- Added 3 regression tests covering `None → 0` defaulting:
  - `first_identity_nonce_defaults_to_zero_then_bumps_to_one` — `bump_first=true`
  - `first_identity_contract_nonce_defaults_to_zero_then_bumps_to_one` — `bump_first=true`
  - `first_identity_nonce_defaults_to_zero_without_bump` — `bump_first=false`, directly verifies the `0` default

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

```bash
cargo test -p dash-sdk --lib -- first_identity_nonce first_identity_contract_nonce
```

3 new unit tests in `packages/rs-sdk/src/internal_cache/mod.rs` using mock SDK with `expect_fetch` returning `None` to simulate first-time interactions.

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->

None. The `Error::IdentityNonceNotFound` variant still exists but is no longer returned by the nonce cache. Callers that previously caught this error will simply stop seeing it — no API signature changes.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [x] I have made corresponding changes to the documentation if needed

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone

<sub>🤖 Co-authored by [Claudius the Magnificent](https://github.com/lklimek/claudius) AI Agent</sub>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * First-time interactions now treat missing identity and contract nonces as zero, avoiding previous error paths and enabling bump-on-demand.

* **Tests**
  * Added tests covering default-zero nonce behavior and bump/no-bump scenarios for first-time interactions.

* **Documentation**
  * Updated API docs to simplify error wording and document the new defaulting behavior for nonce retrieval.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->