### PR TITLE
ci: narrow Rust CI filters to exclude JS-only files in shared packages

### DIFF
--- a/.github/package-filters/rs-packages-direct.yml
+++ b/.github/package-filters/rs-packages-direct.yml
@@ -1,20 +1,32 @@
 wallet-utils-contract:
-  - packages/wallet-utils-contract/**
+  - packages/wallet-utils-contract/src/**
+  - packages/wallet-utils-contract/schema/**
+  - packages/wallet-utils-contract/Cargo.toml
 
 token-history-contract:
-  - packages/token-history-contract/**
+  - packages/token-history-contract/src/**
+  - packages/token-history-contract/schema/**
+  - packages/token-history-contract/Cargo.toml
 
 dashpay-contract:
-  - packages/dashpay-contract/**
+  - packages/dashpay-contract/src/**
+  - packages/dashpay-contract/schema/**
+  - packages/dashpay-contract/Cargo.toml
 
 masternode-reward-shares-contract:
-  - packages/masternode-reward-shares-contract/**
+  - packages/masternode-reward-shares-contract/src/**
+  - packages/masternode-reward-shares-contract/schema/**
+  - packages/masternode-reward-shares-contract/Cargo.toml
 
 withdrawals-contract:
-  - packages/withdrawals-contract/**
+  - packages/withdrawals-contract/src/**
+  - packages/withdrawals-contract/schema/**
+  - packages/withdrawals-contract/Cargo.toml
 
 dpns-contract:
-  - packages/dpns-contract/**
+  - packages/dpns-contract/src/**
+  - packages/dpns-contract/schema/**
+  - packages/dpns-contract/Cargo.toml
 
 json-schema-compatibility-validator:
   - packages/rs-json-schema-compatibility-validator/**
@@ -23,10 +35,12 @@ dpp:
   - packages/rs-dpp/**
 
 wasm-dpp:
-  - packages/wasm-dpp/**
+  - packages/wasm-dpp/src/**
+  - packages/wasm-dpp/Cargo.toml
 
 wasm-dpp2:
-  - packages/wasm-dpp2/**
+  - packages/wasm-dpp2/src/**
+  - packages/wasm-dpp2/Cargo.toml
 
 drive:
   - packages/rs-drive/**
@@ -35,7 +49,10 @@ drive-abci:
   - packages/rs-drive-abci/**
 
 dapi-grpc:
-  - packages/dapi-grpc/**
+  - packages/dapi-grpc/src/**
+  - packages/dapi-grpc/protos/**
+  - packages/dapi-grpc/build.rs
+  - packages/dapi-grpc/Cargo.toml
 
 rs-dapi-client:
   - packages/rs-dapi-client/**
@@ -47,4 +64,5 @@ rs-sdk-ffi:
   - packages/rs-sdk-ffi/**
 
 wasm-sdk:
-  - packages/wasm-sdk/**
+  - packages/wasm-sdk/src/**
+  - packages/wasm-sdk/Cargo.toml

--- a/.github/package-filters/rs-packages-no-workflows.yml
+++ b/.github/package-filters/rs-packages-no-workflows.yml
@@ -1,20 +1,32 @@
 wallet-utils-contract: &wallet-utils-contract
-  - packages/wallet-utils-contract/**
+  - packages/wallet-utils-contract/src/**
+  - packages/wallet-utils-contract/schema/**
+  - packages/wallet-utils-contract/Cargo.toml
 
 token-history-contract: &token-history-contract
-  - packages/token-history-contract/**
+  - packages/token-history-contract/src/**
+  - packages/token-history-contract/schema/**
+  - packages/token-history-contract/Cargo.toml
 
 dashpay-contract: &dashpay-contract
-  - packages/dashpay-contract/**
+  - packages/dashpay-contract/src/**
+  - packages/dashpay-contract/schema/**
+  - packages/dashpay-contract/Cargo.toml
 
 masternode-reward-shares-contract: &masternode-reward-shares-contract
-  - packages/masternode-reward-shares-contract/**
+  - packages/masternode-reward-shares-contract/src/**
+  - packages/masternode-reward-shares-contract/schema/**
+  - packages/masternode-reward-shares-contract/Cargo.toml
 
 withdrawals-contract: &withdrawals-contract
-  - packages/withdrawals-contract/**
+  - packages/withdrawals-contract/src/**
+  - packages/withdrawals-contract/schema/**
+  - packages/withdrawals-contract/Cargo.toml
 
 dpns-contract: &dpns-contract
-  - packages/dpns-contract/**
+  - packages/dpns-contract/src/**
+  - packages/dpns-contract/schema/**
+  - packages/dpns-contract/Cargo.toml
 
 json-schema-compatibility-validator: &json-schema-compatibility-validator
   - packages/rs-json-schema-compatibility-validator/**
@@ -36,11 +48,13 @@ dpp: &dpp
   - packages/rs-platform-versioning/**
 
 wasm-dpp:
-  - packages/wasm-dpp/**
+  - packages/wasm-dpp/src/**
+  - packages/wasm-dpp/Cargo.toml
   - *dpp
 
 wasm-dpp2:
-  - packages/wasm-dpp2/**
+  - packages/wasm-dpp2/src/**
+  - packages/wasm-dpp2/Cargo.toml
   - *dpp
 
 drive: &drive
@@ -54,7 +68,10 @@ drive-abci:
 dapi-grpc: &dapi_grpc
   - packages/rs-platform-version/**
   - packages/rs-dash-platform-macros/**
-  - packages/dapi-grpc/**
+  - packages/dapi-grpc/src/**
+  - packages/dapi-grpc/protos/**
+  - packages/dapi-grpc/build.rs
+  - packages/dapi-grpc/Cargo.toml
 
 rs-dapi-client: &dapi_client
   - packages/rs-dapi-client/**
@@ -74,6 +91,6 @@ rs-sdk-ffi:
   - *drive
 
 wasm-sdk:
-  - .github/workflows/tests*
-  - packages/wasm-sdk/**
+  - packages/wasm-sdk/src/**
+  - packages/wasm-sdk/Cargo.toml
   - *sdk

--- a/.github/package-filters/rs-packages.yml
+++ b/.github/package-filters/rs-packages.yml
@@ -1,26 +1,38 @@
 wallet-utils-contract: &wallet-utils-contract
   - .github/workflows/tests*
-  - packages/wallet-utils-contract/**
+  - packages/wallet-utils-contract/src/**
+  - packages/wallet-utils-contract/schema/**
+  - packages/wallet-utils-contract/Cargo.toml
 
 token-history-contract: &token-history-contract
   - .github/workflows/tests*
-  - packages/token-history-contract/**
+  - packages/token-history-contract/src/**
+  - packages/token-history-contract/schema/**
+  - packages/token-history-contract/Cargo.toml
 
 dashpay-contract: &dashpay-contract
   - .github/workflows/tests*
-  - packages/dashpay-contract/**
+  - packages/dashpay-contract/src/**
+  - packages/dashpay-contract/schema/**
+  - packages/dashpay-contract/Cargo.toml
 
 masternode-reward-shares-contract: &masternode-reward-shares-contract
   - .github/workflows/tests*
-  - packages/masternode-reward-shares-contract/**
+  - packages/masternode-reward-shares-contract/src/**
+  - packages/masternode-reward-shares-contract/schema/**
+  - packages/masternode-reward-shares-contract/Cargo.toml
 
 withdrawals-contract: &withdrawals-contract
   - .github/workflows/tests*
-  - packages/withdrawals-contract/**
+  - packages/withdrawals-contract/src/**
+  - packages/withdrawals-contract/schema/**
+  - packages/withdrawals-contract/Cargo.toml
 
 dpns-contract: &dpns-contract
   - .github/workflows/tests*
-  - packages/dpns-contract/**
+  - packages/dpns-contract/src/**
+  - packages/dpns-contract/schema/**
+  - packages/dpns-contract/Cargo.toml
 
 json-schema-compatibility-validator: &json-schema-compatibility-validator
   - .github/workflows/tests*
@@ -45,12 +57,14 @@ dpp: &dpp
 
 wasm-dpp:
   - .github/workflows/tests*
-  - packages/wasm-dpp/**
+  - packages/wasm-dpp/src/**
+  - packages/wasm-dpp/Cargo.toml
   - *dpp
 
 wasm-dpp2:
   - .github/workflows/tests*
-  - packages/wasm-dpp2/**
+  - packages/wasm-dpp2/src/**
+  - packages/wasm-dpp2/Cargo.toml
   - *dpp
 
 drive: &drive
@@ -67,7 +81,10 @@ dapi-grpc: &dapi_grpc
   - .github/workflows/tests*
   - packages/rs-platform-version/**
   - packages/rs-dash-platform-macros/**
-  - packages/dapi-grpc/**
+  - packages/dapi-grpc/src/**
+  - packages/dapi-grpc/protos/**
+  - packages/dapi-grpc/build.rs
+  - packages/dapi-grpc/Cargo.toml
 
 rs-dapi-client: &dapi_client
   - .github/workflows/tests*
@@ -97,5 +114,6 @@ rs-sdk-ffi:
 
 wasm-sdk:
   - .github/workflows/tests*
-  - packages/wasm-sdk/**
+  - packages/wasm-sdk/src/**
+  - packages/wasm-sdk/Cargo.toml
   - *sdk


### PR DESCRIPTION
## Summary

- Replace broad `packages/foo/**` globs with specific Rust-only patterns (`src/**`, `schema/**`, `Cargo.toml`, etc.) for the 10 shared packages that exist in both Cargo.toml and package.json workspaces
- Prevents the entire Rust test matrix (17+ suites) from triggering on JS-only changes (e.g., `package.json` updates, `.js` file edits) in contract packages, dapi-grpc, and wasm-* packages
- Pure Rust packages (`rs-*`) are unchanged since they have no JS files

## Issue being fixed or feature being added

Fixes excessive CI resource usage: PR #3174 (sinon upgrade) only changed JS `package.json` files yet triggered all 17+ Rust test suites due to broad globs matching JS files in shared packages, which then cascaded through YAML anchor dependencies (contract → dpp → drive → drive-abci → etc.).

### Root cause

`dorny/paths-filter` evaluates patterns with `some()` (OR) logic — a negation pattern `!foo/package.json` returns FALSE for that file, but positive pattern `foo/**` returns TRUE, so `some()` still returns TRUE. The fix uses specific positive-only patterns instead of trying negation.

### Impact

| Scenario | Before | After |
|---|---|---|
| `package.json` change in contract | 17+ Rust test suites | 0 |
| `.js` file change in dapi-grpc | 5+ Rust test suites cascade | 0 |
| `src/lib.rs` change in contract | All downstream Rust tests | Same (correct) |
| `Cargo.toml` change in contract | All downstream Rust tests | Same (correct) |
| `schema/*.json` change in contract | All downstream Rust tests | Same (correct) |

### Safety net

Nightly cron runs test everything regardless of filters — any missed trigger is caught within 24 hours.

## Test plan

- [ ] Verify next JS-only PR shows empty `rs-packages` in the `changes` job output with no Rust test jobs spawned
- [ ] Verify a Rust source change (e.g., in a contract `src/`) still triggers the correct downstream test cascade
- [ ] Confirm nightly cron still runs all test suites regardless

🤖 Generated with [Claude Code](https://claude.com/claude-code)