### PR TITLE
test: fix Map key serialization in js-value-to-json test

### DIFF
--- a/packages/wasm-dpp2/tests/unit/js-value-to-json.spec.ts
+++ b/packages/wasm-dpp2/tests/unit/js-value-to-json.spec.ts
@@ -163,8 +163,8 @@ describe('testJsValueToJson', () => {
 
         // This simulates getEvonodesProposedEpochBlocksByIds which returns Map<string, bigint>
         const map = new Map([
-          [id1, 100n],
-          [id2, 200n],
+          [id1.toBase58(), 100n],
+          [id2.toBase58(), 200n],
         ]);
 
         const json = wasm.testJsValueToJson(map);


### PR DESCRIPTION
## Issue being fixed or feature implemented
The test was using raw identifier objects as Map keys, but the actual implementation (`getEvonodesProposedEpochBlocksByIds`) returns Maps with Base58-encoded string keys. This mismatch could cause the test to not properly validate the serialization behavior.

## What was done?
Updated the test case in `js-value-to-json.spec.ts` to convert identifier keys to Base58 format using `.toBase58()` before adding them to the Map. This aligns the test data structure with the actual behavior of the function being tested.

## How Has This Been Tested?
The existing unit test `testJsValueToJson` in `packages/wasm-dpp2/tests/unit/js-value-to-json.spec.ts` covers this change. The test validates that Maps with bigint values are correctly serialized to JSON format.

## Breaking Changes
None

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have added or updated relevant unit/integration/functional/e2e tests

https://claude.ai/code/session_014qzm7D1ZTqEt2h6vze6r42