### PR TITLE
chore: update dashcore dependency in rs-platform-encryption to use workspace dep

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1416,16 +1416,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "dash-network"
-version = "0.42.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=2bd764fdc071828939d9dc8dd872c39bae906b04#2bd764fdc071828939d9dc8dd872c39bae906b04"
-dependencies = [
- "bincode",
- "bincode_derive",
- "hex",
-]
-
-[[package]]
 name = "dash-platform-balance-checker"
 version = "3.1.0-dev.1"
 dependencies = [
@@ -1502,8 +1492,8 @@ dependencies = [
  "blsful",
  "chrono",
  "clap",
- "dashcore 0.42.0 (git+https://github.com/dashpay/rust-dashcore?rev=0bc6592bd41037ffc532d813d4c0828bea7cf882)",
- "dashcore_hashes 0.42.0 (git+https://github.com/dashpay/rust-dashcore?rev=0bc6592bd41037ffc532d813d4c0828bea7cf882)",
+ "dashcore",
+ "dashcore_hashes",
  "futures",
  "hex",
  "hickory-resolver",
@@ -1532,7 +1522,7 @@ dependencies = [
  "cbindgen 0.29.2",
  "clap",
  "dash-spv",
- "dashcore 0.42.0 (git+https://github.com/dashpay/rust-dashcore?rev=0bc6592bd41037ffc532d813d4c0828bea7cf882)",
+ "dashcore",
  "env_logger 0.10.2",
  "hex",
  "key-wallet",
@@ -1562,9 +1552,9 @@ dependencies = [
  "bitvec",
  "blake3",
  "blsful",
- "dash-network 0.42.0 (git+https://github.com/dashpay/rust-dashcore?rev=0bc6592bd41037ffc532d813d4c0828bea7cf882)",
- "dashcore-private 0.42.0 (git+https://github.com/dashpay/rust-dashcore?rev=0bc6592bd41037ffc532d813d4c0828bea7cf882)",
- "dashcore_hashes 0.42.0 (git+https://github.com/dashpay/rust-dashcore?rev=0bc6592bd41037ffc532d813d4c0828bea7cf882)",
+ "dash-network",
+ "dashcore-private",
+ "dashcore_hashes",
  "ed25519-dalek",
  "hex",
  "hex_lit",
@@ -1576,36 +1566,9 @@ dependencies = [
 ]
 
 [[package]]
-name = "dashcore"
-version = "0.42.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=2bd764fdc071828939d9dc8dd872c39bae906b04#2bd764fdc071828939d9dc8dd872c39bae906b04"
-dependencies = [
- "anyhow",
- "bech32 0.9.1",
- "bincode",
- "bincode_derive",
- "bitvec",
- "blake3",
- "dash-network 0.42.0 (git+https://github.com/dashpay/rust-dashcore?rev=2bd764fdc071828939d9dc8dd872c39bae906b04)",
- "dashcore-private 0.42.0 (git+https://github.com/dashpay/rust-dashcore?rev=2bd764fdc071828939d9dc8dd872c39bae906b04)",
- "dashcore_hashes 0.42.0 (git+https://github.com/dashpay/rust-dashcore?rev=2bd764fdc071828939d9dc8dd872c39bae906b04)",
- "hex",
- "hex_lit",
- "log",
- "rustversion",
- "secp256k1",
- "thiserror 2.0.18",
-]
-
-[[package]]
 name = "dashcore-private"
 version = "0.42.0"
 source = "git+https://github.com/dashpay/rust-dashcore?rev=0bc6592bd41037ffc532d813d4c0828bea7cf882#0bc6592bd41037ffc532d813d4c0828bea7cf882"
-
-[[package]]
-name = "dashcore-private"
-version = "0.42.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=2bd764fdc071828939d9dc8dd872c39bae906b04#2bd764fdc071828939d9dc8dd872c39bae906b04"
 
 [[package]]
 name = "dashcore-rpc"
@@ -1626,7 +1589,7 @@ version = "0.42.0"
 source = "git+https://github.com/dashpay/rust-dashcore?rev=0bc6592bd41037ffc532d813d4c0828bea7cf882#0bc6592bd41037ffc532d813d4c0828bea7cf882"
 dependencies = [
  "bincode",
- "dashcore 0.42.0 (git+https://github.com/dashpay/rust-dashcore?rev=0bc6592bd41037ffc532d813d4c0828bea7cf882)",
+ "dashcore",
  "hex",
  "key-wallet",
  "serde",
@@ -1641,20 +1604,10 @@ version = "0.42.0"
 source = "git+https://github.com/dashpay/rust-dashcore?rev=0bc6592bd41037ffc532d813d4c0828bea7cf882#0bc6592bd41037ffc532d813d4c0828bea7cf882"
 dependencies = [
  "bincode",
- "dashcore-private 0.42.0 (git+https://github.com/dashpay/rust-dashcore?rev=0bc6592bd41037ffc532d813d4c0828bea7cf882)",
+ "dashcore-private",
  "rs-x11-hash",
  "secp256k1",
  "serde",
-]
-
-[[package]]
-name = "dashcore_hashes"
-version = "0.42.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=2bd764fdc071828939d9dc8dd872c39bae906b04#2bd764fdc071828939d9dc8dd872c39bae906b04"
-dependencies = [
- "bincode",
- "dashcore-private 0.42.0 (git+https://github.com/dashpay/rust-dashcore?rev=2bd764fdc071828939d9dc8dd872c39bae906b04)",
- "secp256k1",
 ]
 
 [[package]]
@@ -1842,7 +1795,7 @@ dependencies = [
  "chrono-tz",
  "ciborium",
  "dash-spv",
- "dashcore 0.42.0 (git+https://github.com/dashpay/rust-dashcore?rev=0bc6592bd41037ffc532d813d4c0828bea7cf882)",
+ "dashcore",
  "dashcore-rpc",
  "data-contracts",
  "derive_more 1.0.0",
@@ -3495,10 +3448,10 @@ dependencies = [
  "bip39",
  "bitflags 2.11.0",
  "bs58",
- "dash-network 0.42.0 (git+https://github.com/dashpay/rust-dashcore?rev=0bc6592bd41037ffc532d813d4c0828bea7cf882)",
- "dashcore 0.42.0 (git+https://github.com/dashpay/rust-dashcore?rev=0bc6592bd41037ffc532d813d4c0828bea7cf882)",
- "dashcore-private 0.42.0 (git+https://github.com/dashpay/rust-dashcore?rev=0bc6592bd41037ffc532d813d4c0828bea7cf882)",
- "dashcore_hashes 0.42.0 (git+https://github.com/dashpay/rust-dashcore?rev=0bc6592bd41037ffc532d813d4c0828bea7cf882)",
+ "dash-network",
+ "dashcore",
+ "dashcore-private",
+ "dashcore_hashes",
  "getrandom 0.2.17",
  "hex",
  "hkdf",
@@ -3518,8 +3471,8 @@ version = "0.42.0"
 source = "git+https://github.com/dashpay/rust-dashcore?rev=0bc6592bd41037ffc532d813d4c0828bea7cf882#0bc6592bd41037ffc532d813d4c0828bea7cf882"
 dependencies = [
  "cbindgen 0.29.2",
- "dash-network 0.42.0 (git+https://github.com/dashpay/rust-dashcore?rev=0bc6592bd41037ffc532d813d4c0828bea7cf882)",
- "dashcore 0.42.0 (git+https://github.com/dashpay/rust-dashcore?rev=0bc6592bd41037ffc532d813d4c0828bea7cf882)",
+ "dash-network",
+ "dashcore",
  "hex",
  "key-wallet",
  "key-wallet-manager",
@@ -3535,8 +3488,8 @@ source = "git+https://github.com/dashpay/rust-dashcore?rev=0bc6592bd41037ffc532d
 dependencies = [
  "async-trait",
  "bincode",
- "dashcore 0.42.0 (git+https://github.com/dashpay/rust-dashcore?rev=0bc6592bd41037ffc532d813d4c0828bea7cf882)",
- "dashcore_hashes 0.42.0 (git+https://github.com/dashpay/rust-dashcore?rev=0bc6592bd41037ffc532d813d4c0828bea7cf882)",
+ "dashcore",
+ "dashcore_hashes",
  "key-wallet",
  "rayon",
  "secp256k1",
@@ -4364,7 +4317,7 @@ version = "2.1.1"
 dependencies = [
  "aes",
  "cbc",
- "dashcore 0.42.0 (git+https://github.com/dashpay/rust-dashcore?rev=2bd764fdc071828939d9dc8dd872c39bae906b04)",
+ "dashcore",
  "hex",
  "sha2",
  "thiserror 1.0.69",
@@ -4440,7 +4393,7 @@ version = "3.1.0-dev.1"
 dependencies = [
  "async-trait",
  "dash-sdk",
- "dashcore 0.42.0 (git+https://github.com/dashpay/rust-dashcore?rev=0bc6592bd41037ffc532d813d4c0828bea7cf882)",
+ "dashcore",
  "dpp",
  "indexmap 2.13.0",
  "key-wallet",
@@ -4454,7 +4407,7 @@ dependencies = [
 name = "platform-wallet-ffi"
 version = "2.1.1"
 dependencies = [
- "dashcore 0.42.0 (git+https://github.com/dashpay/rust-dashcore?rev=0bc6592bd41037ffc532d813d4c0828bea7cf882)",
+ "dashcore",
  "dpp",
  "key-wallet",
  "lazy_static",

--- a/packages/rs-platform-encryption/Cargo.toml
+++ b/packages/rs-platform-encryption/Cargo.toml
@@ -8,7 +8,7 @@ description = "Cryptographic utilities for Dash Platform (DIP-15 DashPay encrypt
 
 [dependencies]
 # Cryptography
-dashcore = { git = "https://github.com/dashpay/rust-dashcore", rev = "2bd764fdc071828939d9dc8dd872c39bae906b04" }
+dashcore = { workspace = true }
 aes = "0.8"
 cbc = "0.1"
 sha2 = "0.10"


### PR DESCRIPTION
quick fix for the dashcore dependency in rs-platform-encryption

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency resolution for dashcore from external reference to workspace-based approach, improving build configuration management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->