### PR TITLE
ci: skip JS build when no JS-related code changed

### DIFF
--- a/.github/package-filters/js-packages-direct.yml
+++ b/.github/package-filters/js-packages-direct.yml
@@ -22,6 +22,9 @@
 '@dashevo/wasm-dpp':
   - packages/wasm-dpp/**
 
+'@dashevo/wasm-dpp2':
+  - packages/wasm-dpp2/**
+
 '@dashevo/dapi-grpc':
   - packages/dapi-grpc/**
 

--- a/.github/package-filters/js-packages-no-workflows.yml
+++ b/.github/package-filters/js-packages-no-workflows.yml
@@ -35,6 +35,10 @@
   - packages/rs-platform-versioning/**
   - packages/rs-dpp/**
 
+'@dashevo/wasm-dpp2': &wasm-dpp2
+  - packages/wasm-dpp2/**
+  - *wasm-dpp
+
 '@dashevo/dapi-grpc': &dapi-grpc
   - packages/dapi-grpc/**
   - *grpc-common

--- a/.github/package-filters/js-packages.yml
+++ b/.github/package-filters/js-packages.yml
@@ -43,6 +43,11 @@
   - packages/rs-platform-versioning/**
   - packages/rs-dpp/**
 
+'@dashevo/wasm-dpp2': &wasm-dpp2
+  - .github/workflows/tests*
+  - packages/wasm-dpp2/**
+  - *wasm-dpp
+
 '@dashevo/dapi-grpc': &dapi-grpc
   - .github/workflows/tests*
   - packages/dapi-grpc/**

--- a/.github/package-filters/test-suite-triggers.yml
+++ b/.github/package-filters/test-suite-triggers.yml
@@ -5,6 +5,7 @@ run:
   - packages/js-dash-sdk/**
   - packages/js-dapi-client/**
   - packages/wasm-dpp/**
+  - packages/wasm-dpp2/**
   - packages/dapi-grpc/**
   - packages/js-grpc-common/**
   - packages/dash-spv/**

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -82,7 +82,9 @@ jobs:
 
   build-js:
     name: Build JS packages
-    if: ${{ github.event_name == 'push' || github.event_name == 'workflow_dispatch' || github.event_name == 'schedule' || !github.event.pull_request.draft }}
+    needs:
+      - changes
+    if: ${{ needs.changes.outputs.js-packages != '[]' || needs.changes.outputs.test-suite == 'true' }}
     secrets: inherit
     uses: ./.github/workflows/tests-build-js.yml
 


### PR DESCRIPTION
## Issue being fixed or feature implemented

`build-js` runs unconditionally on every non-draft PR, even for changes that only touch swift-sdk, rs-sdk, or other non-JS code.

## What was done?

Made `build-js` depend on the `changes` job and only run when:
- Any JS package has changes (`js-packages != '[]'`), OR
- Test-suite-related code changed (`test-suite == 'true'`) — since the test suite runs JS tests against a local network even for Rust-only changes

Downstream jobs (`js-packages`, `js-codeql`, etc.) that depend on `build-js` are naturally skipped when it's skipped.

## How Has This Been Tested?

- Verified workflow YAML syntax
- Confirmed downstream job dependency chain handles skipped `build-js` correctly

## Breaking Changes

None.

## Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [ ] I have made corresponding changes to the documentation if needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Adjusted build/test orchestration so JS build runs only when relevant changes or test-suite flag are present.
  * Added the new wasm-dpp2 package to package filtering and to CI test-suite triggers so changes there are included in workflows and tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->