### PR TITLE
fix(drive): match min_depth between prove and verify for trunk query

### DIFF
--- a/packages/rs-drive/src/verify/shielded/verify_nullifiers_trunk_query/v0/mod.rs
+++ b/packages/rs-drive/src/verify/shielded/verify_nullifiers_trunk_query/v0/mod.rs
@@ -13,6 +13,11 @@ impl Drive {
         platform_version: &PlatformVersion,
     ) -> Result<(RootHash, GroveTrunkQueryResult), Error> {
         let path = nullifiers_path_for_pool(pool_type, pool_identifier)?;
+        let min_depth = platform_version
+            .drive
+            .methods
+            .shielded
+            .nullifiers_query_min_depth;
         let max_depth = platform_version
             .drive
             .methods
@@ -21,8 +26,8 @@ impl Drive {
 
         let query = PathTrunkChunkQuery {
             path,
+            min_depth: Some(min_depth),
             max_depth,
-            min_depth: None,
         };
 
         let (root_hash, result) = GroveDb::verify_trunk_chunk_proof(


### PR DESCRIPTION
## Issue being fixed or feature implemented

The prove side of `prove_nullifiers_trunk_query_v0` passes `min_depth: Some(min_depth)` from the platform version config, but the verify side (`verify_nullifiers_trunk_query_v0`) was passing `min_depth: None`. This parameter mismatch would cause proof verification failures.

## What was done?

Updated `verify_nullifiers_trunk_query_v0` to read `nullifiers_query_min_depth` from the platform version and pass `min_depth: Some(min_depth)`, matching the prove side.

## How Has This Been Tested?

- `cargo check -p drive` — compiles cleanly

## Breaking Changes

None.

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [ ] I have made corresponding changes to the documentation if needed