### PR TITLE
fix(drive): correct tree types in shielded pool estimated costs

### DIFF
--- a/packages/rs-drive/src/drive/shielded/estimated_costs.rs
+++ b/packages/rs-drive/src/drive/shielded/estimated_costs.rs
@@ -88,9 +88,9 @@ impl Drive {
                         SomeSumTrees {
                             sum_trees_weight: 0,
                             big_sum_trees_weight: 0,
-                            count_trees_weight: 0,
+                            count_trees_weight: 1, // nullifiers (ProvableCountTree)
                             count_sum_trees_weight: 0,
-                            non_sum_trees_weight: 2, // nullifiers + anchors
+                            non_sum_trees_weight: 1, // anchors
                         },
                         None,
                         3, // 3 subtrees: notes (CommitmentTree), nullifiers, anchors
@@ -113,11 +113,11 @@ impl Drive {
         );
 
         // Nullifiers tree: [AddressBalances, "s", 2]
-        // NormalTree - stores spent nullifiers (32-byte key -> empty item)
+        // ProvableCountTree - stores spent nullifiers (32-byte key -> empty item)
         estimated_costs_only_with_layer_info.insert(
             KeyInfoPath::from_known_path(shielded_credit_pool_nullifiers_path()),
             EstimatedLayerInformation {
-                tree_type: TreeType::NormalTree,
+                tree_type: TreeType::ProvableCountTree,
                 estimated_layer_count: EstimatedLevel(16, false),
                 estimated_layer_sizes: AllItems(NULLIFIER_KEY_SIZE, 0, None),
             },


### PR DESCRIPTION
## Issue being fixed or feature implemented

The fee estimation for the shielded pool used incorrect tree types, causing inaccurate cost calculations.

## What was done?

- Nullifiers tree: `NormalTree` → `ProvableCountTree` to match `empty_provable_count_tree()` used in initialization
- Pool children weights: `count_trees_weight: 1` for nullifiers, `non_sum_trees_weight: 1` for anchors only (was `count_trees_weight: 0, non_sum_trees_weight: 2`)

## How Has This Been Tested?

- `cargo check -p drive` — compiles cleanly

## Breaking Changes

None.

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [ ] I have made corresponding changes to the documentation if needed