### PR TITLE
fix(drive): replace unchecked integer casts with try_from

### DIFF
--- a/packages/rs-drive/src/drive/saved_block_transactions/store_nullifiers/v0/mod.rs
+++ b/packages/rs-drive/src/drive/saved_block_transactions/store_nullifiers/v0/mod.rs
@@ -60,7 +60,11 @@ impl Drive {
         })?;
 
         // The sum value is the number of nullifiers
-        let entry_count = nullifiers.len() as i64;
+        let entry_count = i64::try_from(nullifiers.len()).map_err(|_| {
+            Error::Drive(crate::error::drive::DriveError::CorruptedDriveState(
+                "nullifier count exceeds i64::MAX".to_string(),
+            ))
+        })?;
 
         // Store in the SavedBlockTransactions/Nullifiers count sum tree with block height as key
         let path: [&[u8]; 2] = Drive::saved_block_transactions_nullifiers_path();

--- a/packages/rs-drive/src/verify/shielded/verify_shielded_nullifiers/v0/mod.rs
+++ b/packages/rs-drive/src/verify/shielded/verify_shielded_nullifiers/v0/mod.rs
@@ -19,7 +19,13 @@ impl Drive {
             path: shielded_credit_pool_nullifiers_path_vec(),
             query: SizedQuery {
                 query,
-                limit: Some(nullifiers.len() as u16),
+                limit: Some(
+                    u16::try_from(nullifiers.len()).map_err(|_| {
+                        Error::Drive(crate::error::drive::DriveError::CorruptedDriveState(
+                            "nullifier count exceeds u16::MAX".to_string(),
+                        ))
+                    })?,
+                ),
                 offset: None,
             },
         };


### PR DESCRIPTION
## Issue being fixed or feature implemented

Two unchecked integer casts could silently truncate values:
- `nullifiers.len() as i64` in store_nullifiers (overflow on large counts)
- `nullifiers.len() as u16` in verify_shielded_nullifiers (truncation above 65535)

## What was done?

Replaced both with `try_from()` that returns proper errors instead of silently truncating.

## How Has This Been Tested?

- `cargo check -p drive` — compiles cleanly

## Breaking Changes

None.

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [ ] I have made corresponding changes to the documentation if needed