### PR TITLE
fix(drive): import nullifier constants instead of duplicating them

### DIFF
--- a/packages/rs-drive/src/verify/shielded/verify_compacted_nullifier_changes/v0/mod.rs
+++ b/packages/rs-drive/src/verify/shielded/verify_compacted_nullifier_changes/v0/mod.rs
@@ -1,11 +1,9 @@
+use crate::drive::saved_block_transactions::COMPACTED_NULLIFIERS_KEY_U8;
 use crate::drive::Drive;
 use crate::drive::RootTree;
 use crate::error::proof::ProofError;
 use crate::error::Error;
 use crate::verify::RootHash;
-
-/// The subtree key for compacted nullifiers storage as u8
-const COMPACTED_NULLIFIERS_KEY_U8: u8 = b'o';
 use grovedb::operations::proof::{GroveDBProof, ProofBytes};
 use grovedb::{
     GroveDb, MerkProofDecoder, MerkProofNode, MerkProofOp, PathQuery, Query, SizedQuery,

--- a/packages/rs-drive/src/verify/shielded/verify_recent_nullifier_changes/v0/mod.rs
+++ b/packages/rs-drive/src/verify/shielded/verify_recent_nullifier_changes/v0/mod.rs
@@ -1,11 +1,9 @@
+use crate::drive::saved_block_transactions::NULLIFIERS_KEY_U8;
 use crate::drive::Drive;
 use crate::drive::RootTree;
 use crate::error::proof::ProofError;
 use crate::error::Error;
 use crate::verify::RootHash;
-
-/// The subtree key for nullifiers storage as u8
-const NULLIFIERS_KEY_U8: u8 = b'n';
 use grovedb::{Element, GroveDb, PathQuery, Query, SizedQuery};
 use platform_version::version::PlatformVersion;
 


### PR DESCRIPTION
## Issue being fixed or feature implemented

`NULLIFIERS_KEY_U8` and `COMPACTED_NULLIFIERS_KEY_U8` were defined locally in verify modules instead of importing from `saved_block_transactions::queries`. If the canonical value changes, these local copies would silently diverge, breaking proof verification.

## What was done?

Replaced local constant definitions with imports from `crate::drive::saved_block_transactions`.

## How Has This Been Tested?

- `cargo check -p drive` — compiles cleanly

## Breaking Changes

None.

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [ ] I have made corresponding changes to the documentation if needed