### PR TITLE
fix(drive): replace expect/unwrap with error propagation in production code

### DIFF
--- a/packages/rs-drive/src/drive/saved_block_transactions/fetch_compacted_nullifiers/v0/mod.rs
+++ b/packages/rs-drive/src/drive/saved_block_transactions/fetch_compacted_nullifiers/v0/mod.rs
@@ -77,12 +77,20 @@ impl Drive {
             let start_block = u64::from_be_bytes(
                 key[0..8]
                     .try_into()
-                    .expect("slice is exactly 8 bytes from a 16-byte key"),
+                    .map_err(|_| {
+                        Error::Protocol(Box::new(ProtocolError::CorruptedSerialization(
+                            "invalid compacted key slice".to_string(),
+                        )))
+                    })?,
             );
             let end_block = u64::from_be_bytes(
                 key[8..16]
                     .try_into()
-                    .expect("slice is exactly 8 bytes from a 16-byte key"),
+                    .map_err(|_| {
+                        Error::Protocol(Box::new(ProtocolError::CorruptedSerialization(
+                            "invalid compacted key slice".to_string(),
+                        )))
+                    })?,
             );
 
             // Only include if end_block >= start_block_height (range contains our block)
@@ -157,12 +165,20 @@ impl Drive {
             let start_block = u64::from_be_bytes(
                 key[0..8]
                     .try_into()
-                    .expect("slice is exactly 8 bytes from a 16-byte key"),
+                    .map_err(|_| {
+                        Error::Protocol(Box::new(ProtocolError::CorruptedSerialization(
+                            "invalid compacted key slice".to_string(),
+                        )))
+                    })?,
             );
             let end_block = u64::from_be_bytes(
                 key[8..16]
                     .try_into()
-                    .expect("slice is exactly 8 bytes from a 16-byte key"),
+                    .map_err(|_| {
+                        Error::Protocol(Box::new(ProtocolError::CorruptedSerialization(
+                            "invalid compacted key slice".to_string(),
+                        )))
+                    })?,
             );
 
             // Skip if this is the same range we got from descending query
@@ -235,7 +251,11 @@ impl Drive {
                 let end_block = u64::from_be_bytes(
                     key[8..16]
                         .try_into()
-                        .expect("slice is exactly 8 bytes from a 16-byte key"),
+                        .map_err(|_| {
+                        Error::Protocol(Box::new(ProtocolError::CorruptedSerialization(
+                            "invalid compacted key slice".to_string(),
+                        )))
+                    })?,
                 );
                 // If this range contains start_block_height, use its exact key
                 if end_block >= start_block_height {

--- a/packages/rs-drive/src/verify/shielded/verify_compacted_nullifier_changes/v0/mod.rs
+++ b/packages/rs-drive/src/verify/shielded/verify_compacted_nullifier_changes/v0/mod.rs
@@ -113,16 +113,11 @@ impl Drive {
             if key.len() != 16 {
                 return None;
             }
-            let range_start = u64::from_be_bytes(
-                key[0..8]
-                    .try_into()
-                    .expect("slice is exactly 8 bytes from a 16-byte key"),
-            );
-            let range_end = u64::from_be_bytes(
-                key[8..16]
-                    .try_into()
-                    .expect("slice is exactly 8 bytes from a 16-byte key"),
-            );
+            // Safety: length verified to be 16 above
+            let range_start =
+                u64::from_be_bytes(key[0..8].try_into().expect("len checked to be 16"));
+            let range_end =
+                u64::from_be_bytes(key[8..16].try_into().expect("len checked to be 16"));
 
             // Check if this range contains start_block_height
             if range_start <= start_block_height && start_block_height <= range_end {
@@ -175,12 +170,20 @@ impl Drive {
             let range_start = u64::from_be_bytes(
                 key[0..8]
                     .try_into()
-                    .expect("slice is exactly 8 bytes from a 16-byte key"),
+                    .map_err(|_| {
+                        Error::Proof(ProofError::CorruptedProof(
+                            "invalid key slice length for block height".to_string(),
+                        ))
+                    })?,
             );
             let range_end = u64::from_be_bytes(
                 key[8..16]
                     .try_into()
-                    .expect("slice is exactly 8 bytes from a 16-byte key"),
+                    .map_err(|_| {
+                        Error::Proof(ProofError::CorruptedProof(
+                            "invalid key slice length for block height".to_string(),
+                        ))
+                    })?,
             );
 
             // Get the serialized data from the Item element


### PR DESCRIPTION
## Issue being fixed or feature implemented

Production code in `fetch_compacted_nullifiers` and `verify_compacted_nullifier_changes` used `.expect()` which would panic on invalid data instead of returning errors.

## What was done?

Replaced `.expect()` calls with `map_err` + `?` error propagation in functions that return `Result`. Retained `.expect()` only inside `find_map` closures where `?` isn't available, with safety comments explaining the preceding length guard.

## How Has This Been Tested?

- `cargo check -p drive` — compiles cleanly

## Breaking Changes

None.

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [ ] I have made corresponding changes to the documentation if needed