### PR TITLE
fix(drive): guard against max_elements=0 in encrypted notes verification

### DIFF
--- a/packages/rs-drive/src/verify/shielded/verify_shielded_encrypted_notes/v0/mod.rs
+++ b/packages/rs-drive/src/verify/shielded/verify_shielded_encrypted_notes/v0/mod.rs
@@ -15,9 +15,15 @@ impl Drive {
         verify_subset_of_proof: bool,
         platform_version: &PlatformVersion,
     ) -> Result<(RootHash, Vec<(Vec<u8>, Vec<u8>, Vec<u8>)>), Error> {
+        if max_elements == 0 {
+            return Err(Error::Drive(DriveError::CorruptedElementType(
+                "max_elements must be greater than zero",
+            )));
+        }
+
         // start_index must be chunk-aligned (multiple of max_elements)
         let chunk_size = max_elements as u64;
-        if chunk_size > 0 && start_index % chunk_size != 0 {
+        if start_index % chunk_size != 0 {
             return Err(Error::Drive(DriveError::CorruptedElementType(
                 "start_index is not chunk-aligned; must be a multiple of max_elements",
             )));


### PR DESCRIPTION
## Issue being fixed or feature implemented

When `max_elements=0` is passed to `verify_shielded_encrypted_notes`, `limit` becomes 0 and `start_index + limit - 1` underflows (u64 wrapping subtraction), producing an incorrect range query.

## What was done?

Added an early error return when `max_elements == 0`. Also simplified the chunk alignment check since `chunk_size > 0` is now guaranteed.

## How Has This Been Tested?

- `cargo check -p drive` — compiles cleanly

## Breaking Changes

None.

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [ ] I have made corresponding changes to the documentation if needed