### PR TITLE
fix(drive): use RootTree enum instead of magic number 72u8

### DIFF
--- a/packages/rs-drive/src/prove/prove_state_transition/v0/mod.rs
+++ b/packages/rs-drive/src/prove/prove_state_transition/v0/mod.rs
@@ -1,4 +1,4 @@
-use crate::drive::Drive;
+use crate::drive::{Drive, RootTree};
 use crate::error::proof::ProofError;
 use crate::error::Error;
 use crate::prove::prove_state_transition::ProofCreationResult;
@@ -401,7 +401,7 @@ impl Drive {
                 query.insert_key(outpoint_bytes.to_vec());
 
                 PathQuery::new(
-                    vec![vec![72u8]], // RootTree::SpentAssetLockTransactions
+                    vec![vec![RootTree::SpentAssetLockTransactions as u8]],
                     grovedb::SizedQuery::new(query, Some(1), None),
                 )
             }


### PR DESCRIPTION
## Issue being fixed or feature implemented

The ShieldFromAssetLock proof query hardcoded `72u8` for the SpentAssetLockTransactions root tree path. If the enum value ever changes, this would silently break.

## What was done?

Replaced `vec![72u8]` with `vec![RootTree::SpentAssetLockTransactions as u8]`.

## How Has This Been Tested?

- `cargo check -p drive` — compiles cleanly

## Breaking Changes

None.

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [ ] I have made corresponding changes to the documentation if needed