### PR TITLE
ci: exclude draft PRs from test-suite-gate approval requirement

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -217,7 +217,7 @@ jobs:
       - changes
       - check-secrets
     # Require manual approval only on PRs when test-suite code hasn't changed
-    if: ${{ needs.check-secrets.outputs.has_ecr == 'true' && needs.changes.outputs.test-suite != 'true' && github.event_name != 'schedule' && github.event_name != 'workflow_dispatch' }}
+    if: ${{ needs.check-secrets.outputs.has_ecr == 'true' && needs.changes.outputs.test-suite != 'true' && github.event_name != 'schedule' && github.event_name != 'workflow_dispatch' && !github.event.pull_request.draft }}
     runs-on: ubuntu-24.04
     environment: test-suite-approval
     steps:


### PR DESCRIPTION
## Summary

Follow-up to #3185 — adds draft PR exclusion to `test-suite-gate` for consistency with `build-images-gate`.

`build-images-gate` explicitly excludes draft PRs with `!github.event.pull_request.draft`, but `test-suite-gate` was missing this check. Draft PRs shouldn't trigger the manual approval gate.

## Changes

Single-line addition to `.github/workflows/tests.yml`: added `&& !github.event.pull_request.draft` to the `test-suite-gate` job's `if` condition.

## Validation

- YAML syntax validated
- Both gate jobs now have matching draft PR exclusion conditions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflow to automatically skip manual approval for draft pull requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->