### PR TITLE
fix(sdk): use deterministic identity ID in address funding proof verification

### DIFF
--- a/packages/rs-dpp/src/state_transition/traits/state_transition_identity_id_from_inputs.rs
+++ b/packages/rs-dpp/src/state_transition/traits/state_transition_identity_id_from_inputs.rs
@@ -21,8 +21,9 @@ pub trait StateTransitionIdentityIdFromInputs: StateTransitionWitnessSigned {
 /// Helper that computes the identity ID from input addresses and nonces.
 /// Nonces should represent state after creation of the identity (eg. be incremented by 1).
 ///
-/// Internal use only; see `StateTransitionIdentityIdFromInputs` trait.
-pub(crate) fn identity_id_from_input_addresses(
+/// This is the canonical way to derive the deterministic identity ID from
+/// address-funded identity creation inputs.
+pub fn identity_id_from_input_addresses(
     input_addresses: &BTreeMap<PlatformAddress, (AddressNonce, Credits)>,
 ) -> Result<Identifier, ProtocolError> {
     if input_addresses.is_empty() {

--- a/packages/rs-sdk/src/platform/transition/put_identity.rs
+++ b/packages/rs-sdk/src/platform/transition/put_identity.rs
@@ -16,6 +16,7 @@ use dpp::identity::IdentityPublicKey;
 use dpp::prelude::{AddressNonce, AssetLockProof, Identity};
 use dpp::state_transition::identity_create_from_addresses_transition::methods::IdentityCreateFromAddressesTransitionMethodsV0;
 use dpp::state_transition::identity_create_from_addresses_transition::IdentityCreateFromAddressesTransition;
+use dpp::state_transition::identity_id_from_input_addresses;
 use dpp::state_transition::proof_result::StateTransitionProofResult;
 use dpp::state_transition::StateTransition;
 use drive_proof_verifier::types::AddressInfos;
@@ -169,6 +170,12 @@ async fn put_identity_with_address_funding<
         .and_then(|settings| settings.user_fee_increase)
         .unwrap_or_default();
 
+    // Compute the expected identity ID deterministically from the input addresses
+    // and nonces BEFORE they're moved into try_from_inputs_with_signer. This must
+    // NOT use identity.id(), which may be a caller-supplied placeholder that doesn't
+    // match the platform-computed ID. See https://github.com/dashpay/platform/issues/3095
+    let expected_identity_id = identity_id_from_input_addresses(&inputs)?;
+
     let state_transition = IdentityCreateFromAddressesTransition::try_from_inputs_with_signer(
         identity,
         inputs,
@@ -179,6 +186,7 @@ async fn put_identity_with_address_funding<
         user_fee_increase,
         sdk.version(),
     )?;
+
     ensure_valid_state_transition_structure(&state_transition, sdk.version())?;
 
     match state_transition
@@ -190,11 +198,10 @@ async fn put_identity_with_address_funding<
             address_infos_map,
         ) => {
             let proved_identity_id = proved_identity.id();
-            if proved_identity_id != identity.id() {
+            if proved_identity_id != expected_identity_id {
                 return Err(Error::InvalidProvedResponse(format!(
-                    "proof returned identity {} but {} was created",
-                    proved_identity_id,
-                    identity.id()
+                    "proof returned identity {} but {} was expected (derived from input addresses)",
+                    proved_identity_id, expected_identity_id
                 )));
             }
 


### PR DESCRIPTION
## Issue Being Fixed

Closes https://github.com/dashpay/platform/issues/3095

## What Was Changed

In `put_identity_with_address_funding`, the proof verification compared `proved_identity_id` against `identity.id()` — the caller's placeholder ID — instead of the deterministically computed ID derived from input addresses and nonces. This always fails when the caller passes an identity with a non-matching placeholder ID (which is the normal case for address-funded identity creation, especially from the WASM SDK).

### Fix (2 files, 14 insertions / 6 deletions)

1. **`rs-dpp`**: Made `identity_id_from_input_addresses()` public (was `pub(crate)`) so rs-sdk can call it
2. **`rs-sdk`**: Compute `expected_identity_id` from `&inputs` before they're consumed by `try_from_inputs_with_signer`, then use that for the proof check instead of `identity.id()`

## Validation

- Verified that `identity_id_from_input_addresses` is the canonical function used by rs-dpp internally for deriving identity IDs from address-funded creation inputs
- Confirmed `&inputs` is borrowed before the move into `try_from_inputs_with_signer`, so no ownership issues
- The WASM SDK path (`put_identity_create_from_addresses`) was checked and already returns the proved identity (with correct ID) from the result, so no changes needed there


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Identity ID derivation from address-funded inputs is now available as a public API.

* **Bug Fixes**
  * Improved identity validation to more reliably derive and verify identity IDs from input data.
  * Enhanced error messages for clearer feedback during identity verification failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->