### PR TITLE
docs(wasm-dpp): document no-op user fee increase methods on vote transition

### DIFF
--- a/packages/wasm-dpp/src/voting/state_transition/masternode_vote_transition/mod.rs
+++ b/packages/wasm-dpp/src/voting/state_transition/masternode_vote_transition/mod.rs
@@ -224,6 +224,7 @@ impl MasternodeVoteTransitionWasm {
     }
 
     /// Masternode vote transitions do not support user fee increase; always returns 0.
+    /// This method is kept for API compatibility.
     #[wasm_bindgen(js_name=getUserFeeIncrease)]
     pub fn get_user_fee_increase(&self) -> u16 {
         0

--- a/packages/wasm-dpp/src/voting/state_transition/masternode_vote_transition/mod.rs
+++ b/packages/wasm-dpp/src/voting/state_transition/masternode_vote_transition/mod.rs
@@ -223,11 +223,14 @@ impl MasternodeVoteTransitionWasm {
         self.0.is_voting_state_transition()
     }
 
+    /// Masternode vote transitions do not support user fee increase; always returns 0.
     #[wasm_bindgen(js_name=getUserFeeIncrease)]
     pub fn get_user_fee_increase(&self) -> u16 {
         0
     }
 
+    /// Masternode vote transitions do not support user fee increase.
+    /// This method is kept for API compatibility and intentionally does nothing.
     #[wasm_bindgen(js_name=setUserFeeIncrease)]
     pub fn set_user_fee_increase(&mut self, _user_fee_increase: u16) {}
 


### PR DESCRIPTION
## Summary

Add doc comments to the no-op `get_user_fee_increase` / `set_user_fee_increase` methods on `MasternodeVoteTransitionWasm`, explaining they exist for API compatibility and are intentionally no-ops.

This addresses a CodeRabbit nitpick from #3183.

## Validation

- `cargo check -p wasm-dpp` — compiles clean.
- Doc-only change, no behavior change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Exposed getter and setter for Masternode vote user fee increase in the WASM API; getter returns 0 and setter is a no-op.

* **Documentation**
  * Clarified that user fee increases are not supported for Masternode vote transitions and that the exposed methods are API-compatible stubs with no effect.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->