### PR TITLE
feat(drive): allow deleting non-empty trees in targeted batch operations

### DIFF
--- a/packages/rs-drive-abci/src/execution/platform_events/block_processing_end_events/process_block_fees_and_validate_sum_trees/v0/mod.rs
+++ b/packages/rs-drive-abci/src/execution/platform_events/block_processing_end_events/process_block_fees_and_validate_sum_trees/v0/mod.rs
@@ -21,6 +21,7 @@ use dpp::version::PlatformVersion;
 use drive::drive::Drive;
 use drive::grovedb::Transaction;
 use drive::util::batch::DriveOperation;
+use drive::util::grove_operations::BatchApplyDriveOperation;
 
 use crate::error::execution::ExecutionError;
 use crate::error::Error;
@@ -148,7 +149,7 @@ impl<CoreRPCLike> Platform<CoreRPCLike> {
             &platform_version.drive,
         )?;
 
-        self.drive.apply_drive_operations(
+        self.drive.apply_drive_operations_with_options(
             batch,
             true,
             &block_info.to_block_info(epoch_info.try_into()?),
@@ -159,6 +160,10 @@ impl<CoreRPCLike> Platform<CoreRPCLike> {
                     .block_platform_state()
                     .previous_fee_versions(),
             ),
+            BatchApplyDriveOperation {
+                allow_deleting_non_empty_trees: true,
+                deleting_non_empty_trees_returns_error: false,
+            },
         )?;
 
         let outcome = processed_block_fees_outcome::v0::ProcessedBlockFeesOutcome {

--- a/packages/rs-drive/src/util/batch/drive_op_batch/drive_methods/apply_drive_operations/mod.rs
+++ b/packages/rs-drive/src/util/batch/drive_op_batch/drive_methods/apply_drive_operations/mod.rs
@@ -1,6 +1,7 @@
 mod v0;
 
 use crate::util::batch::DriveOperation;
+use crate::util::grove_operations::BatchApplyDriveOperation;
 
 use crate::drive::Drive;
 use crate::error::{drive::DriveError, Error};
@@ -57,6 +58,42 @@ impl Drive {
             ),
             version => Err(Error::Drive(DriveError::UnknownVersionMismatch {
                 method: "apply_drive_operations".to_string(),
+                known_versions: vec![0],
+                received: version,
+            })),
+        }
+    }
+
+    /// Like `apply_drive_operations` but with custom options controlling
+    /// tree deletion behavior.
+    #[allow(clippy::too_many_arguments)]
+    pub fn apply_drive_operations_with_options(
+        &self,
+        operations: Vec<DriveOperation>,
+        apply: bool,
+        block_info: &BlockInfo,
+        transaction: TransactionArg,
+        platform_version: &PlatformVersion,
+        previous_fee_versions: Option<&CachedEpochIndexFeeVersions>,
+        batch_apply_drive_operation: BatchApplyDriveOperation,
+    ) -> Result<FeeResult, Error> {
+        match platform_version
+            .drive
+            .methods
+            .batch_operations
+            .apply_drive_operations_with_options
+        {
+            0 => self.apply_drive_operations_with_options_v0(
+                operations,
+                apply,
+                block_info,
+                transaction,
+                platform_version,
+                previous_fee_versions,
+                batch_apply_drive_operation,
+            ),
+            version => Err(Error::Drive(DriveError::UnknownVersionMismatch {
+                method: "apply_drive_operations_with_options".to_string(),
                 known_versions: vec![0],
                 received: version,
             })),

--- a/packages/rs-drive/src/util/batch/drive_op_batch/drive_methods/apply_drive_operations/v0/mod.rs
+++ b/packages/rs-drive/src/util/batch/drive_op_batch/drive_methods/apply_drive_operations/v0/mod.rs
@@ -1,4 +1,5 @@
 use crate::util::batch::DriveOperation;
+use crate::util::grove_operations::BatchApplyDriveOperation;
 
 use crate::drive::Drive;
 use crate::error::Error;
@@ -21,21 +22,6 @@ use std::collections::HashMap;
 
 impl Drive {
     /// Applies a list of high level DriveOperations to the drive, and calculates the fee for them.
-    ///
-    /// # Arguments
-    ///
-    /// * `operations` - A vector of `DriveOperation`s to apply to the drive.
-    /// * `apply` - A boolean flag indicating whether to apply the changes or only estimate costs.
-    /// * `block_info` - A reference to information about the current block.
-    /// * `transaction` - Transaction arguments.
-    ///
-    /// # Returns
-    ///
-    /// Returns a `Result` containing the `FeeResult` if the operations are successfully applied,
-    /// otherwise an `Error`.
-    ///
-    /// If `apply` is set to true, it applies the low-level drive operations and updates side info accordingly.
-    /// If not, it only estimates the costs and updates estimated costs with layer info.
     #[inline(always)]
     pub(crate) fn apply_drive_operations_v0(
         &self,
@@ -45,6 +31,31 @@ impl Drive {
         transaction: TransactionArg,
         platform_version: &PlatformVersion,
         previous_fee_versions: Option<&CachedEpochIndexFeeVersions>,
+    ) -> Result<FeeResult, Error> {
+        self.apply_drive_operations_with_options_v0(
+            operations,
+            apply,
+            block_info,
+            transaction,
+            platform_version,
+            previous_fee_versions,
+            BatchApplyDriveOperation::default(),
+        )
+    }
+
+    /// Like `apply_drive_operations_v0` but with custom options controlling
+    /// tree deletion behavior.
+    #[inline(always)]
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) fn apply_drive_operations_with_options_v0(
+        &self,
+        operations: Vec<DriveOperation>,
+        apply: bool,
+        block_info: &BlockInfo,
+        transaction: TransactionArg,
+        platform_version: &PlatformVersion,
+        previous_fee_versions: Option<&CachedEpochIndexFeeVersions>,
+        batch_apply_drive_operation: BatchApplyDriveOperation,
     ) -> Result<FeeResult, Error> {
         if operations.is_empty() {
             return Ok(FeeResult::default());
@@ -74,10 +85,11 @@ impl Drive {
 
         let mut cost_operations = vec![];
 
-        self.apply_batch_low_level_drive_operations(
+        self.apply_batch_low_level_drive_operations_with_options(
             estimated_costs_only_with_layer_info,
             transaction,
             low_level_operations,
+            batch_apply_drive_operation,
             &mut cost_operations,
             &platform_version.drive,
         )?;

--- a/packages/rs-drive/src/util/grove_operations/grove_apply_batch_with_add_costs/mod.rs
+++ b/packages/rs-drive/src/util/grove_operations/grove_apply_batch_with_add_costs/mod.rs
@@ -6,6 +6,7 @@ use crate::drive::Drive;
 use crate::error::drive::DriveError;
 use crate::error::Error;
 use crate::fees::op::LowLevelDriveOperation;
+use crate::util::grove_operations::BatchApplyDriveOperation;
 
 use dpp::version::drive_versions::DriveVersion;
 
@@ -42,6 +43,38 @@ impl Drive {
             ),
             version => Err(Error::Drive(DriveError::UnknownVersionMismatch {
                 method: "grove_apply_batch_with_add_costs".to_string(),
+                known_versions: vec![0],
+                received: version,
+            })),
+        }
+    }
+
+    /// Applies the given groveDB operations batch with custom options
+    /// controlling tree deletion behavior.
+    pub fn grove_apply_batch_with_add_costs_with_options(
+        &self,
+        ops: GroveDbOpBatch,
+        validate: bool,
+        transaction: TransactionArg,
+        batch_apply_drive_operation: BatchApplyDriveOperation,
+        drive_operations: &mut Vec<LowLevelDriveOperation>,
+        drive_version: &DriveVersion,
+    ) -> Result<(), Error> {
+        match drive_version
+            .grove_methods
+            .apply
+            .grove_apply_batch_with_options
+        {
+            0 => self.grove_apply_batch_with_add_costs_with_options_v0(
+                ops,
+                validate,
+                transaction,
+                batch_apply_drive_operation,
+                drive_operations,
+                drive_version,
+            ),
+            version => Err(Error::Drive(DriveError::UnknownVersionMismatch {
+                method: "grove_apply_batch_with_add_costs_with_options".to_string(),
                 known_versions: vec![0],
                 received: version,
             })),

--- a/packages/rs-drive/src/util/grove_operations/grove_apply_batch_with_add_costs/v0/mod.rs
+++ b/packages/rs-drive/src/util/grove_operations/grove_apply_batch_with_add_costs/v0/mod.rs
@@ -6,6 +6,7 @@ use crate::query::GroveError;
 use crate::util::batch::grovedb_op_batch::GroveDbOpBatchV0Methods;
 use crate::util::batch::GroveDbOpBatch;
 use crate::util::grove_operations::push_drive_operation_result;
+use crate::util::grove_operations::BatchApplyDriveOperation;
 use crate::util::storage_flags::StorageFlags;
 use grovedb::batch::{BatchApplyOptions, QualifiedGroveDbOp};
 use grovedb::TransactionArg;
@@ -18,6 +19,26 @@ impl Drive {
         ops: GroveDbOpBatch,
         validate: bool,
         transaction: TransactionArg,
+        drive_operations: &mut Vec<LowLevelDriveOperation>,
+        drive_version: &DriveVersion,
+    ) -> Result<(), Error> {
+        self.grove_apply_batch_with_add_costs_with_options_v0(
+            ops,
+            validate,
+            transaction,
+            BatchApplyDriveOperation::default(),
+            drive_operations,
+            drive_version,
+        )
+    }
+
+    /// Applies the given groveDB operations batch with custom options.
+    pub(super) fn grove_apply_batch_with_add_costs_with_options_v0(
+        &self,
+        ops: GroveDbOpBatch,
+        validate: bool,
+        transaction: TransactionArg,
+        batch_apply_drive_operation: BatchApplyDriveOperation,
         drive_operations: &mut Vec<LowLevelDriveOperation>,
         drive_version: &DriveVersion,
     ) -> Result<(), Error> {
@@ -65,8 +86,10 @@ impl Drive {
             Some(BatchApplyOptions {
                 validate_insertion_does_not_override: validate,
                 validate_insertion_does_not_override_tree: validate,
-                allow_deleting_non_empty_trees: false,
-                deleting_non_empty_trees_returns_error: true,
+                allow_deleting_non_empty_trees: batch_apply_drive_operation
+                    .allow_deleting_non_empty_trees,
+                deleting_non_empty_trees_returns_error: batch_apply_drive_operation
+                    .deleting_non_empty_trees_returns_error,
                 disable_operation_consistency_check: !self.config.batching_consistency_verification,
                 base_root_storage_is_free: true,
                 batch_pause_height: None,

--- a/packages/rs-drive/src/util/grove_operations/grove_batch_operations_costs/mod.rs
+++ b/packages/rs-drive/src/util/grove_operations/grove_batch_operations_costs/mod.rs
@@ -6,6 +6,7 @@ use crate::drive::Drive;
 use crate::error::drive::DriveError;
 use crate::error::Error;
 use crate::fees::op::LowLevelDriveOperation;
+use crate::util::grove_operations::BatchApplyDriveOperation;
 
 use dpp::version::drive_versions::DriveVersion;
 
@@ -49,6 +50,38 @@ impl Drive {
             ),
             version => Err(Error::Drive(DriveError::UnknownVersionMismatch {
                 method: "grove_batch_operations_costs".to_string(),
+                known_versions: vec![0],
+                received: version,
+            })),
+        }
+    }
+
+    /// Like `grove_batch_operations_costs` but with custom options controlling
+    /// tree deletion behavior.
+    pub fn grove_batch_operations_costs_with_options(
+        &self,
+        ops: GroveDbOpBatch,
+        estimated_layer_info: HashMap<KeyInfoPath, EstimatedLayerInformation>,
+        validate: bool,
+        batch_apply_drive_operation: BatchApplyDriveOperation,
+        drive_operations: &mut Vec<LowLevelDriveOperation>,
+        drive_version: &DriveVersion,
+    ) -> Result<(), Error> {
+        match drive_version
+            .grove_methods
+            .costs
+            .grove_batch_operations_costs
+        {
+            0 => self.grove_batch_operations_costs_with_options_v0(
+                ops,
+                estimated_layer_info,
+                validate,
+                batch_apply_drive_operation,
+                drive_operations,
+                drive_version,
+            ),
+            version => Err(Error::Drive(DriveError::UnknownVersionMismatch {
+                method: "grove_batch_operations_costs_with_options".to_string(),
                 known_versions: vec![0],
                 received: version,
             })),

--- a/packages/rs-drive/src/util/grove_operations/grove_batch_operations_costs/v0/mod.rs
+++ b/packages/rs-drive/src/util/grove_operations/grove_batch_operations_costs/v0/mod.rs
@@ -4,6 +4,7 @@ use crate::fees::op::LowLevelDriveOperation;
 use crate::query::GroveError;
 use crate::util::batch::GroveDbOpBatch;
 use crate::util::grove_operations::push_drive_operation_result;
+use crate::util::grove_operations::BatchApplyDriveOperation;
 use grovedb::batch::estimated_costs::EstimatedCostsType::AverageCaseCostsType;
 use grovedb::batch::{BatchApplyOptions, KeyInfoPath};
 use grovedb::{EstimatedLayerInformation, GroveDb};
@@ -20,14 +21,37 @@ impl Drive {
         drive_operations: &mut Vec<LowLevelDriveOperation>,
         drive_version: &DriveVersion,
     ) -> Result<(), Error> {
+        self.grove_batch_operations_costs_with_options_v0(
+            ops,
+            estimated_layer_info,
+            validate,
+            BatchApplyDriveOperation::default(),
+            drive_operations,
+            drive_version,
+        )
+    }
+
+    /// Like `grove_batch_operations_costs_v0` but with custom options controlling
+    /// tree deletion behavior.
+    pub(super) fn grove_batch_operations_costs_with_options_v0(
+        &self,
+        ops: GroveDbOpBatch,
+        estimated_layer_info: HashMap<KeyInfoPath, EstimatedLayerInformation>,
+        validate: bool,
+        batch_apply_drive_operation: BatchApplyDriveOperation,
+        drive_operations: &mut Vec<LowLevelDriveOperation>,
+        drive_version: &DriveVersion,
+    ) -> Result<(), Error> {
         let cost_context = GroveDb::estimated_case_operations_for_batch(
             AverageCaseCostsType(estimated_layer_info),
             ops.operations,
             Some(BatchApplyOptions {
                 validate_insertion_does_not_override: validate,
                 validate_insertion_does_not_override_tree: validate,
-                allow_deleting_non_empty_trees: false,
-                deleting_non_empty_trees_returns_error: true,
+                allow_deleting_non_empty_trees: batch_apply_drive_operation
+                    .allow_deleting_non_empty_trees,
+                deleting_non_empty_trees_returns_error: batch_apply_drive_operation
+                    .deleting_non_empty_trees_returns_error,
                 disable_operation_consistency_check: false,
                 base_root_storage_is_free: true,
                 batch_pause_height: None,

--- a/packages/rs-drive/src/util/grove_operations/mod.rs
+++ b/packages/rs-drive/src/util/grove_operations/mod.rs
@@ -531,3 +531,22 @@ pub enum GroveDBToUse {
     /// Use a specific checkpoint at the given block height
     Checkpoint(u64),
 }
+
+/// Options controlling how a batch of drive operations is applied to GroveDB.
+#[derive(Debug, Clone, Copy)]
+pub struct BatchApplyDriveOperation {
+    /// Allow `DeleteTree` operations to target trees that still have children.
+    pub allow_deleting_non_empty_trees: bool,
+    /// When `true`, GroveDB returns an error when a non-empty tree deletion is
+    /// attempted (even if allowed).
+    pub deleting_non_empty_trees_returns_error: bool,
+}
+
+impl Default for BatchApplyDriveOperation {
+    fn default() -> Self {
+        Self {
+            allow_deleting_non_empty_trees: false,
+            deleting_non_empty_trees_returns_error: true,
+        }
+    }
+}

--- a/packages/rs-drive/src/util/operations/apply_batch_grovedb_operations/mod.rs
+++ b/packages/rs-drive/src/util/operations/apply_batch_grovedb_operations/mod.rs
@@ -5,6 +5,7 @@ use crate::drive::Drive;
 use crate::error::{drive::DriveError, Error};
 use crate::fees::op::LowLevelDriveOperation;
 use crate::util::batch::GroveDbOpBatch;
+use crate::util::grove_operations::BatchApplyDriveOperation;
 use dpp::version::drive_versions::DriveVersion;
 use grovedb::batch::KeyInfoPath;
 use grovedb::{EstimatedLayerInformation, TransactionArg};
@@ -52,6 +53,40 @@ impl Drive {
             ),
             version => Err(Error::Drive(DriveError::UnknownVersionMismatch {
                 method: "apply_batch_grovedb_operations".to_string(),
+                known_versions: vec![0],
+                received: version,
+            })),
+        }
+    }
+
+    /// Like `apply_batch_grovedb_operations` but with custom options controlling
+    /// tree deletion behavior.
+    pub(crate) fn apply_batch_grovedb_operations_with_options(
+        &self,
+        estimated_costs_only_with_layer_info: Option<
+            HashMap<KeyInfoPath, EstimatedLayerInformation>,
+        >,
+        transaction: TransactionArg,
+        batch_operations: GroveDbOpBatch,
+        batch_apply_drive_operation: BatchApplyDriveOperation,
+        drive_operations: &mut Vec<LowLevelDriveOperation>,
+        drive_version: &DriveVersion,
+    ) -> Result<(), Error> {
+        match drive_version
+            .methods
+            .operations
+            .apply_batch_grovedb_operations_with_options
+        {
+            0 => self.apply_batch_grovedb_operations_with_options_v0(
+                estimated_costs_only_with_layer_info,
+                transaction,
+                batch_operations,
+                batch_apply_drive_operation,
+                drive_operations,
+                drive_version,
+            ),
+            version => Err(Error::Drive(DriveError::UnknownVersionMismatch {
+                method: "apply_batch_grovedb_operations_with_options".to_string(),
                 known_versions: vec![0],
                 received: version,
             })),

--- a/packages/rs-drive/src/util/operations/apply_batch_grovedb_operations/v0/mod.rs
+++ b/packages/rs-drive/src/util/operations/apply_batch_grovedb_operations/v0/mod.rs
@@ -3,6 +3,7 @@ use crate::drive::Drive;
 use crate::error::Error;
 use crate::fees::op::LowLevelDriveOperation;
 use crate::util::batch::GroveDbOpBatch;
+use crate::util::grove_operations::BatchApplyDriveOperation;
 use dpp::version::drive_versions::DriveVersion;
 use grovedb::batch::KeyInfoPath;
 use grovedb::{EstimatedLayerInformation, TransactionArg};
@@ -42,6 +43,41 @@ impl Drive {
                 batch_operations,
                 false,
                 transaction,
+                drive_operations,
+                drive_version,
+            )?;
+        }
+        Ok(())
+    }
+
+    /// Like `apply_batch_grovedb_operations_v0` but with custom options
+    /// controlling tree deletion behavior.
+    pub(super) fn apply_batch_grovedb_operations_with_options_v0(
+        &self,
+        estimated_costs_only_with_layer_info: Option<
+            HashMap<KeyInfoPath, EstimatedLayerInformation>,
+        >,
+        transaction: TransactionArg,
+        batch_operations: GroveDbOpBatch,
+        batch_apply_drive_operation: BatchApplyDriveOperation,
+        drive_operations: &mut Vec<LowLevelDriveOperation>,
+        drive_version: &DriveVersion,
+    ) -> Result<(), Error> {
+        if let Some(estimated_layer_info) = estimated_costs_only_with_layer_info {
+            self.grove_batch_operations_costs_with_options(
+                batch_operations,
+                estimated_layer_info,
+                false,
+                batch_apply_drive_operation,
+                drive_operations,
+                drive_version,
+            )?;
+        } else {
+            self.grove_apply_batch_with_add_costs_with_options(
+                batch_operations,
+                false,
+                transaction,
+                batch_apply_drive_operation,
                 drive_operations,
                 drive_version,
             )?;

--- a/packages/rs-drive/src/util/operations/apply_batch_low_level_drive_operations/mod.rs
+++ b/packages/rs-drive/src/util/operations/apply_batch_low_level_drive_operations/mod.rs
@@ -4,6 +4,7 @@ mod v0;
 use crate::drive::Drive;
 use crate::error::{drive::DriveError, Error};
 use crate::fees::op::LowLevelDriveOperation;
+use crate::util::grove_operations::BatchApplyDriveOperation;
 
 use dpp::version::drive_versions::DriveVersion;
 use grovedb::batch::KeyInfoPath;
@@ -52,6 +53,40 @@ impl Drive {
             ),
             version => Err(Error::Drive(DriveError::UnknownVersionMismatch {
                 method: "apply_batch_low_level_drive_operations".to_string(),
+                known_versions: vec![0],
+                received: version,
+            })),
+        }
+    }
+
+    /// Like `apply_batch_low_level_drive_operations` but with custom options
+    /// controlling tree deletion behavior.
+    pub fn apply_batch_low_level_drive_operations_with_options(
+        &self,
+        estimated_costs_only_with_layer_info: Option<
+            HashMap<KeyInfoPath, EstimatedLayerInformation>,
+        >,
+        transaction: TransactionArg,
+        batch_operations: Vec<LowLevelDriveOperation>,
+        batch_apply_drive_operation: BatchApplyDriveOperation,
+        drive_operations: &mut Vec<LowLevelDriveOperation>,
+        drive_version: &DriveVersion,
+    ) -> Result<(), Error> {
+        match drive_version
+            .methods
+            .operations
+            .apply_batch_low_level_drive_operations_with_options
+        {
+            0 => self.apply_batch_low_level_drive_operations_with_options_v0(
+                estimated_costs_only_with_layer_info,
+                transaction,
+                batch_operations,
+                batch_apply_drive_operation,
+                drive_operations,
+                drive_version,
+            ),
+            version => Err(Error::Drive(DriveError::UnknownVersionMismatch {
+                method: "apply_batch_low_level_drive_operations_with_options".to_string(),
                 known_versions: vec![0],
                 received: version,
             })),

--- a/packages/rs-drive/src/util/operations/apply_batch_low_level_drive_operations/v0/mod.rs
+++ b/packages/rs-drive/src/util/operations/apply_batch_low_level_drive_operations/v0/mod.rs
@@ -3,6 +3,7 @@ use crate::drive::Drive;
 use crate::error::Error;
 use crate::fees::op::LowLevelDriveOperation;
 use crate::util::batch::grovedb_op_batch::GroveDbOpBatchV0Methods;
+use crate::util::grove_operations::BatchApplyDriveOperation;
 use dpp::version::drive_versions::DriveVersion;
 use grovedb::batch::KeyInfoPath;
 use grovedb::{EstimatedLayerInformation, TransactionArg};
@@ -29,6 +30,37 @@ impl Drive {
                 estimated_costs_only_with_layer_info,
                 transaction,
                 grove_db_operations,
+                drive_operations,
+                drive_version,
+            )?;
+        }
+        drive_operations.append(&mut other_operations);
+        Ok(())
+    }
+
+    /// Like `apply_batch_low_level_drive_operations_v0` but with custom options
+    /// controlling tree deletion behavior.
+    pub(crate) fn apply_batch_low_level_drive_operations_with_options_v0(
+        &self,
+        estimated_costs_only_with_layer_info: Option<
+            HashMap<KeyInfoPath, EstimatedLayerInformation>,
+        >,
+        transaction: TransactionArg,
+        batch_operations: Vec<LowLevelDriveOperation>,
+        batch_apply_drive_operation: BatchApplyDriveOperation,
+        drive_operations: &mut Vec<LowLevelDriveOperation>,
+        drive_version: &DriveVersion,
+    ) -> Result<(), Error> {
+        let (grove_db_operations, mut other_operations) =
+            LowLevelDriveOperation::grovedb_operations_batch_consume_with_leftovers(
+                batch_operations,
+            );
+        if !grove_db_operations.is_empty() {
+            self.apply_batch_grovedb_operations_with_options(
+                estimated_costs_only_with_layer_info,
+                transaction,
+                grove_db_operations,
+                batch_apply_drive_operation,
                 drive_operations,
                 drive_version,
             )?;

--- a/packages/rs-platform-version/src/version/drive_versions/drive_grove_method_versions/mod.rs
+++ b/packages/rs-platform-version/src/version/drive_versions/drive_grove_method_versions/mod.rs
@@ -69,6 +69,7 @@ pub struct DriveGroveBatchMethodVersions {
 pub struct DriveGroveApplyMethodVersions {
     pub grove_apply_operation: FeatureVersion,
     pub grove_apply_batch: FeatureVersion,
+    pub grove_apply_batch_with_options: FeatureVersion,
     pub grove_apply_partial_batch: FeatureVersion,
 }
 

--- a/packages/rs-platform-version/src/version/drive_versions/drive_grove_method_versions/v1.rs
+++ b/packages/rs-platform-version/src/version/drive_versions/drive_grove_method_versions/v1.rs
@@ -58,6 +58,7 @@ pub const DRIVE_GROVE_METHOD_VERSIONS_V1: DriveGroveMethodVersions = DriveGroveM
     apply: DriveGroveApplyMethodVersions {
         grove_apply_operation: 0,
         grove_apply_batch: 0,
+        grove_apply_batch_with_options: 0,
         grove_apply_partial_batch: 0,
     },
     costs: DriveGroveCostMethodVersions {

--- a/packages/rs-platform-version/src/version/drive_versions/mod.rs
+++ b/packages/rs-platform-version/src/version/drive_versions/mod.rs
@@ -161,13 +161,16 @@ pub struct DriveOperationsMethodVersion {
     pub apply_partial_batch_low_level_drive_operations: FeatureVersion,
     pub apply_partial_batch_grovedb_operations: FeatureVersion,
     pub apply_batch_low_level_drive_operations: FeatureVersion,
+    pub apply_batch_low_level_drive_operations_with_options: FeatureVersion,
     pub apply_batch_grovedb_operations: FeatureVersion,
+    pub apply_batch_grovedb_operations_with_options: FeatureVersion,
 }
 
 #[derive(Clone, Debug, Default)]
 pub struct DriveBatchOperationsMethodVersion {
     pub convert_drive_operations_to_grove_operations: FeatureVersion,
     pub apply_drive_operations: FeatureVersion,
+    pub apply_drive_operations_with_options: FeatureVersion,
 }
 
 #[derive(Clone, Debug, Default)]

--- a/packages/rs-platform-version/src/version/drive_versions/v1.rs
+++ b/packages/rs-platform-version/src/version/drive_versions/v1.rs
@@ -80,12 +80,15 @@ pub const DRIVE_VERSION_V1: DriveVersion = DriveVersion {
             apply_partial_batch_low_level_drive_operations: 0,
             apply_partial_batch_grovedb_operations: 0,
             apply_batch_low_level_drive_operations: 0,
+            apply_batch_low_level_drive_operations_with_options: 0,
             apply_batch_grovedb_operations: 0,
+            apply_batch_grovedb_operations_with_options: 0,
         },
         state_transitions: DRIVE_STATE_TRANSITION_METHOD_VERSIONS_V1,
         batch_operations: DriveBatchOperationsMethodVersion {
             convert_drive_operations_to_grove_operations: 0,
             apply_drive_operations: 0,
+            apply_drive_operations_with_options: 0,
         },
         platform_state: DrivePlatformStateMethodVersions {
             fetch_platform_state_bytes: 0,

--- a/packages/rs-platform-version/src/version/drive_versions/v2.rs
+++ b/packages/rs-platform-version/src/version/drive_versions/v2.rs
@@ -80,12 +80,15 @@ pub const DRIVE_VERSION_V2: DriveVersion = DriveVersion {
             apply_partial_batch_low_level_drive_operations: 0,
             apply_partial_batch_grovedb_operations: 0,
             apply_batch_low_level_drive_operations: 0,
+            apply_batch_low_level_drive_operations_with_options: 0,
             apply_batch_grovedb_operations: 0,
+            apply_batch_grovedb_operations_with_options: 0,
         },
         state_transitions: DRIVE_STATE_TRANSITION_METHOD_VERSIONS_V1,
         batch_operations: DriveBatchOperationsMethodVersion {
             convert_drive_operations_to_grove_operations: 0,
             apply_drive_operations: 0,
+            apply_drive_operations_with_options: 0,
         },
         platform_state: DrivePlatformStateMethodVersions {
             fetch_platform_state_bytes: 0,

--- a/packages/rs-platform-version/src/version/drive_versions/v3.rs
+++ b/packages/rs-platform-version/src/version/drive_versions/v3.rs
@@ -80,12 +80,15 @@ pub const DRIVE_VERSION_V3: DriveVersion = DriveVersion {
             apply_partial_batch_low_level_drive_operations: 0,
             apply_partial_batch_grovedb_operations: 0,
             apply_batch_low_level_drive_operations: 0,
+            apply_batch_low_level_drive_operations_with_options: 0,
             apply_batch_grovedb_operations: 0,
+            apply_batch_grovedb_operations_with_options: 0,
         },
         state_transitions: DRIVE_STATE_TRANSITION_METHOD_VERSIONS_V1,
         batch_operations: DriveBatchOperationsMethodVersion {
             convert_drive_operations_to_grove_operations: 0,
             apply_drive_operations: 0,
+            apply_drive_operations_with_options: 0,
         },
         platform_state: DrivePlatformStateMethodVersions {
             fetch_platform_state_bytes: 0,

--- a/packages/rs-platform-version/src/version/drive_versions/v4.rs
+++ b/packages/rs-platform-version/src/version/drive_versions/v4.rs
@@ -80,12 +80,15 @@ pub const DRIVE_VERSION_V4: DriveVersion = DriveVersion {
             apply_partial_batch_low_level_drive_operations: 0,
             apply_partial_batch_grovedb_operations: 0,
             apply_batch_low_level_drive_operations: 0,
+            apply_batch_low_level_drive_operations_with_options: 0,
             apply_batch_grovedb_operations: 0,
+            apply_batch_grovedb_operations_with_options: 0,
         },
         state_transitions: DRIVE_STATE_TRANSITION_METHOD_VERSIONS_V1,
         batch_operations: DriveBatchOperationsMethodVersion {
             convert_drive_operations_to_grove_operations: 0,
             apply_drive_operations: 0,
+            apply_drive_operations_with_options: 0,
         },
         platform_state: DrivePlatformStateMethodVersions {
             fetch_platform_state_bytes: 0,

--- a/packages/rs-platform-version/src/version/drive_versions/v5.rs
+++ b/packages/rs-platform-version/src/version/drive_versions/v5.rs
@@ -82,12 +82,15 @@ pub const DRIVE_VERSION_V5: DriveVersion = DriveVersion {
             apply_partial_batch_low_level_drive_operations: 0,
             apply_partial_batch_grovedb_operations: 0,
             apply_batch_low_level_drive_operations: 0,
+            apply_batch_low_level_drive_operations_with_options: 0,
             apply_batch_grovedb_operations: 0,
+            apply_batch_grovedb_operations_with_options: 0,
         },
         state_transitions: DRIVE_STATE_TRANSITION_METHOD_VERSIONS_V1,
         batch_operations: DriveBatchOperationsMethodVersion {
             convert_drive_operations_to_grove_operations: 0,
             apply_drive_operations: 0,
+            apply_drive_operations_with_options: 0,
         },
         platform_state: DrivePlatformStateMethodVersions {
             fetch_platform_state_bytes: 0,

--- a/packages/rs-platform-version/src/version/drive_versions/v6.rs
+++ b/packages/rs-platform-version/src/version/drive_versions/v6.rs
@@ -84,12 +84,15 @@ pub const DRIVE_VERSION_V6: DriveVersion = DriveVersion {
             apply_partial_batch_low_level_drive_operations: 0,
             apply_partial_batch_grovedb_operations: 0,
             apply_batch_low_level_drive_operations: 0,
+            apply_batch_low_level_drive_operations_with_options: 0,
             apply_batch_grovedb_operations: 0,
+            apply_batch_grovedb_operations_with_options: 0,
         },
         state_transitions: DRIVE_STATE_TRANSITION_METHOD_VERSIONS_V2, //changed
         batch_operations: DriveBatchOperationsMethodVersion {
             convert_drive_operations_to_grove_operations: 0,
             apply_drive_operations: 0,
+            apply_drive_operations_with_options: 0,
         },
         platform_state: DrivePlatformStateMethodVersions {
             fetch_platform_state_bytes: 0,

--- a/packages/rs-platform-version/src/version/drive_versions/v7.rs
+++ b/packages/rs-platform-version/src/version/drive_versions/v7.rs
@@ -81,12 +81,15 @@ pub const DRIVE_VERSION_V7: DriveVersion = DriveVersion {
             apply_partial_batch_low_level_drive_operations: 0,
             apply_partial_batch_grovedb_operations: 0,
             apply_batch_low_level_drive_operations: 0,
+            apply_batch_low_level_drive_operations_with_options: 0,
             apply_batch_grovedb_operations: 0,
+            apply_batch_grovedb_operations_with_options: 0,
         },
         state_transitions: DRIVE_STATE_TRANSITION_METHOD_VERSIONS_V2,
         batch_operations: DriveBatchOperationsMethodVersion {
             convert_drive_operations_to_grove_operations: 0,
             apply_drive_operations: 0,
+            apply_drive_operations_with_options: 0,
         },
         platform_state: DrivePlatformStateMethodVersions {
             fetch_platform_state_bytes: 0,

--- a/packages/rs-platform-version/src/version/mocks/v2_test.rs
+++ b/packages/rs-platform-version/src/version/mocks/v2_test.rs
@@ -118,11 +118,14 @@ pub const TEST_PLATFORM_V2: PlatformVersion = PlatformVersion {
                 apply_partial_batch_low_level_drive_operations: 0,
                 apply_partial_batch_grovedb_operations: 0,
                 apply_batch_low_level_drive_operations: 0,
+                apply_batch_low_level_drive_operations_with_options: 0,
                 apply_batch_grovedb_operations: 0,
+                apply_batch_grovedb_operations_with_options: 0,
             },
             batch_operations: DriveBatchOperationsMethodVersion {
                 convert_drive_operations_to_grove_operations: 0,
                 apply_drive_operations: 0,
+                apply_drive_operations_with_options: 0,
             },
             state_transitions: DRIVE_STATE_TRANSITION_METHOD_VERSIONS_V1,
             platform_state: DrivePlatformStateMethodVersions {


### PR DESCRIPTION
## Issue being fixed or feature implemented

Prepares for GroveDB PR 599 which will enforce emptiness checks on `DeleteTree` operations. The epoch proposers tree is deleted (with proposers still in it) during fee distribution — this will fail once the GroveDB change lands.

## What was done?

Added parallel `_with_options` methods through the entire drive batch-apply chain, leaving all existing methods and callers untouched:

- `BatchApplyDriveOperation` — new options struct with `allow_deleting_non_empty_trees` and `deleting_non_empty_trees_returns_error` fields (defaults: `false` / `true`)
- `grove_apply_batch_with_add_costs_with_options` — passes options to GroveDB `BatchApplyOptions`
- `apply_batch_grovedb_operations_with_options` → `apply_batch_low_level_drive_operations_with_options` → `apply_drive_operations_with_options` — threaded through each layer

Only one production caller uses the new path: `process_block_fees_and_validate_sum_trees_v0`, which now calls `apply_drive_operations_with_options` with `allow_deleting_non_empty_trees: true`.

## How Has This Been Tested?

- `cargo check -p drive` — compiles clean
- `cargo check -p drive-abci` — compiles clean

## Breaking Changes

None. All existing methods and their callers are unchanged.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation

For repository code-owners and collaborators only
- [ ] I have assigned this pull request to a milestone

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduces configurable batch operation options allowing control over deletion of non-empty trees and whether such deletions return errors.
  * Exposes "with options" variants of batch application APIs so callers can pass explicit behavior flags.
  * Adds default-safe option values while enabling callers to override deletion/error handling per operation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->