### PR TITLE
feat(drive): adapt to grovedb SubelementsDeletionBehavior per-op enum

### DIFF
--- a/.github/grpc-queries-cache.json
+++ b/.github/grpc-queries-cache.json
@@ -161,5 +161,5 @@
       "status": "implemented"
     }
   },
-  "last_updated": "2026-03-09T17:59:53.810832"
+  "last_updated": "2026-03-09T18:55:01.909809"
 }

--- a/.github/grpc-queries-cache.json
+++ b/.github/grpc-queries-cache.json
@@ -161,5 +161,5 @@
       "status": "implemented"
     }
   },
-  "last_updated": "2026-03-05T17:22:30.340784"
+  "last_updated": "2026-03-09T17:59:53.810832"
 }

--- a/.github/grpc-queries-cache.json
+++ b/.github/grpc-queries-cache.json
@@ -161,5 +161,5 @@
       "status": "implemented"
     }
   },
-  "last_updated": "2026-03-09T18:55:01.909809"
+  "last_updated": "2026-03-09T19:01:18.591500"
 }

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2033,7 +2033,7 @@ dependencies = [
  "dpp",
  "enum-map",
  "grovedb",
- "grovedb-costs 4.0.0 (git+https://github.com/dashpay/grovedb?rev=a7b878f72279a4893a7e9dc0ab2973ca0b09ce69)",
+ "grovedb-costs 4.0.0 (git+https://github.com/dashpay/grovedb?rev=a20add8d9327b31198eebddd9d78d3cbf940367c)",
  "grovedb-epoch-based-storage-flags",
  "grovedb-path",
  "grovedb-storage",
@@ -2727,15 +2727,15 @@ dependencies = [
 [[package]]
 name = "grovedb"
 version = "4.0.0"
-source = "git+https://github.com/dashpay/grovedb?rev=a7b878f72279a4893a7e9dc0ab2973ca0b09ce69#a7b878f72279a4893a7e9dc0ab2973ca0b09ce69"
+source = "git+https://github.com/dashpay/grovedb?rev=a20add8d9327b31198eebddd9d78d3cbf940367c#a20add8d9327b31198eebddd9d78d3cbf940367c"
 dependencies = [
  "axum 0.8.8",
  "bincode",
  "bincode_derive",
  "blake3",
  "grovedb-bulk-append-tree",
- "grovedb-commitment-tree 4.0.0 (git+https://github.com/dashpay/grovedb?rev=a7b878f72279a4893a7e9dc0ab2973ca0b09ce69)",
- "grovedb-costs 4.0.0 (git+https://github.com/dashpay/grovedb?rev=a7b878f72279a4893a7e9dc0ab2973ca0b09ce69)",
+ "grovedb-commitment-tree 4.0.0 (git+https://github.com/dashpay/grovedb?rev=a20add8d9327b31198eebddd9d78d3cbf940367c)",
+ "grovedb-costs 4.0.0 (git+https://github.com/dashpay/grovedb?rev=a20add8d9327b31198eebddd9d78d3cbf940367c)",
  "grovedb-dense-fixed-sized-merkle-tree",
  "grovedb-element",
  "grovedb-merk",
@@ -2765,11 +2765,11 @@ dependencies = [
 [[package]]
 name = "grovedb-bulk-append-tree"
 version = "4.0.0"
-source = "git+https://github.com/dashpay/grovedb?rev=a7b878f72279a4893a7e9dc0ab2973ca0b09ce69#a7b878f72279a4893a7e9dc0ab2973ca0b09ce69"
+source = "git+https://github.com/dashpay/grovedb?rev=a20add8d9327b31198eebddd9d78d3cbf940367c#a20add8d9327b31198eebddd9d78d3cbf940367c"
 dependencies = [
  "bincode",
  "blake3",
- "grovedb-costs 4.0.0 (git+https://github.com/dashpay/grovedb?rev=a7b878f72279a4893a7e9dc0ab2973ca0b09ce69)",
+ "grovedb-costs 4.0.0 (git+https://github.com/dashpay/grovedb?rev=a20add8d9327b31198eebddd9d78d3cbf940367c)",
  "grovedb-dense-fixed-sized-merkle-tree",
  "grovedb-merkle-mountain-range",
  "grovedb-query",
@@ -2793,11 +2793,11 @@ dependencies = [
 [[package]]
 name = "grovedb-commitment-tree"
 version = "4.0.0"
-source = "git+https://github.com/dashpay/grovedb?rev=a7b878f72279a4893a7e9dc0ab2973ca0b09ce69#a7b878f72279a4893a7e9dc0ab2973ca0b09ce69"
+source = "git+https://github.com/dashpay/grovedb?rev=a20add8d9327b31198eebddd9d78d3cbf940367c#a20add8d9327b31198eebddd9d78d3cbf940367c"
 dependencies = [
  "blake3",
  "grovedb-bulk-append-tree",
- "grovedb-costs 4.0.0 (git+https://github.com/dashpay/grovedb?rev=a7b878f72279a4893a7e9dc0ab2973ca0b09ce69)",
+ "grovedb-costs 4.0.0 (git+https://github.com/dashpay/grovedb?rev=a20add8d9327b31198eebddd9d78d3cbf940367c)",
  "grovedb-storage",
  "incrementalmerkletree",
  "orchard",
@@ -2817,7 +2817,7 @@ dependencies = [
 [[package]]
 name = "grovedb-costs"
 version = "4.0.0"
-source = "git+https://github.com/dashpay/grovedb?rev=a7b878f72279a4893a7e9dc0ab2973ca0b09ce69#a7b878f72279a4893a7e9dc0ab2973ca0b09ce69"
+source = "git+https://github.com/dashpay/grovedb?rev=a20add8d9327b31198eebddd9d78d3cbf940367c#a20add8d9327b31198eebddd9d78d3cbf940367c"
 dependencies = [
  "integer-encoding",
  "intmap",
@@ -2827,11 +2827,11 @@ dependencies = [
 [[package]]
 name = "grovedb-dense-fixed-sized-merkle-tree"
 version = "4.0.0"
-source = "git+https://github.com/dashpay/grovedb?rev=a7b878f72279a4893a7e9dc0ab2973ca0b09ce69#a7b878f72279a4893a7e9dc0ab2973ca0b09ce69"
+source = "git+https://github.com/dashpay/grovedb?rev=a20add8d9327b31198eebddd9d78d3cbf940367c#a20add8d9327b31198eebddd9d78d3cbf940367c"
 dependencies = [
  "bincode",
  "blake3",
- "grovedb-costs 4.0.0 (git+https://github.com/dashpay/grovedb?rev=a7b878f72279a4893a7e9dc0ab2973ca0b09ce69)",
+ "grovedb-costs 4.0.0 (git+https://github.com/dashpay/grovedb?rev=a20add8d9327b31198eebddd9d78d3cbf940367c)",
  "grovedb-query",
  "grovedb-storage",
  "thiserror 2.0.18",
@@ -2840,7 +2840,7 @@ dependencies = [
 [[package]]
 name = "grovedb-element"
 version = "4.0.0"
-source = "git+https://github.com/dashpay/grovedb?rev=a7b878f72279a4893a7e9dc0ab2973ca0b09ce69#a7b878f72279a4893a7e9dc0ab2973ca0b09ce69"
+source = "git+https://github.com/dashpay/grovedb?rev=a20add8d9327b31198eebddd9d78d3cbf940367c#a20add8d9327b31198eebddd9d78d3cbf940367c"
 dependencies = [
  "bincode",
  "bincode_derive",
@@ -2855,9 +2855,9 @@ dependencies = [
 [[package]]
 name = "grovedb-epoch-based-storage-flags"
 version = "4.0.0"
-source = "git+https://github.com/dashpay/grovedb?rev=a7b878f72279a4893a7e9dc0ab2973ca0b09ce69#a7b878f72279a4893a7e9dc0ab2973ca0b09ce69"
+source = "git+https://github.com/dashpay/grovedb?rev=a20add8d9327b31198eebddd9d78d3cbf940367c#a20add8d9327b31198eebddd9d78d3cbf940367c"
 dependencies = [
- "grovedb-costs 4.0.0 (git+https://github.com/dashpay/grovedb?rev=a7b878f72279a4893a7e9dc0ab2973ca0b09ce69)",
+ "grovedb-costs 4.0.0 (git+https://github.com/dashpay/grovedb?rev=a20add8d9327b31198eebddd9d78d3cbf940367c)",
  "hex",
  "integer-encoding",
  "intmap",
@@ -2867,7 +2867,7 @@ dependencies = [
 [[package]]
 name = "grovedb-merk"
 version = "4.0.0"
-source = "git+https://github.com/dashpay/grovedb?rev=a7b878f72279a4893a7e9dc0ab2973ca0b09ce69#a7b878f72279a4893a7e9dc0ab2973ca0b09ce69"
+source = "git+https://github.com/dashpay/grovedb?rev=a20add8d9327b31198eebddd9d78d3cbf940367c#a20add8d9327b31198eebddd9d78d3cbf940367c"
 dependencies = [
  "bincode",
  "bincode_derive",
@@ -2875,7 +2875,7 @@ dependencies = [
  "byteorder",
  "colored",
  "ed",
- "grovedb-costs 4.0.0 (git+https://github.com/dashpay/grovedb?rev=a7b878f72279a4893a7e9dc0ab2973ca0b09ce69)",
+ "grovedb-costs 4.0.0 (git+https://github.com/dashpay/grovedb?rev=a20add8d9327b31198eebddd9d78d3cbf940367c)",
  "grovedb-element",
  "grovedb-path",
  "grovedb-query",
@@ -2893,18 +2893,18 @@ dependencies = [
 [[package]]
 name = "grovedb-merkle-mountain-range"
 version = "4.0.0"
-source = "git+https://github.com/dashpay/grovedb?rev=a7b878f72279a4893a7e9dc0ab2973ca0b09ce69#a7b878f72279a4893a7e9dc0ab2973ca0b09ce69"
+source = "git+https://github.com/dashpay/grovedb?rev=a20add8d9327b31198eebddd9d78d3cbf940367c#a20add8d9327b31198eebddd9d78d3cbf940367c"
 dependencies = [
  "bincode",
  "blake3",
- "grovedb-costs 4.0.0 (git+https://github.com/dashpay/grovedb?rev=a7b878f72279a4893a7e9dc0ab2973ca0b09ce69)",
+ "grovedb-costs 4.0.0 (git+https://github.com/dashpay/grovedb?rev=a20add8d9327b31198eebddd9d78d3cbf940367c)",
  "grovedb-storage",
 ]
 
 [[package]]
 name = "grovedb-path"
 version = "4.0.0"
-source = "git+https://github.com/dashpay/grovedb?rev=a7b878f72279a4893a7e9dc0ab2973ca0b09ce69#a7b878f72279a4893a7e9dc0ab2973ca0b09ce69"
+source = "git+https://github.com/dashpay/grovedb?rev=a20add8d9327b31198eebddd9d78d3cbf940367c#a20add8d9327b31198eebddd9d78d3cbf940367c"
 dependencies = [
  "hex",
 ]
@@ -2912,12 +2912,12 @@ dependencies = [
 [[package]]
 name = "grovedb-query"
 version = "4.0.0"
-source = "git+https://github.com/dashpay/grovedb?rev=a7b878f72279a4893a7e9dc0ab2973ca0b09ce69#a7b878f72279a4893a7e9dc0ab2973ca0b09ce69"
+source = "git+https://github.com/dashpay/grovedb?rev=a20add8d9327b31198eebddd9d78d3cbf940367c#a20add8d9327b31198eebddd9d78d3cbf940367c"
 dependencies = [
  "bincode",
  "byteorder",
  "ed",
- "grovedb-costs 4.0.0 (git+https://github.com/dashpay/grovedb?rev=a7b878f72279a4893a7e9dc0ab2973ca0b09ce69)",
+ "grovedb-costs 4.0.0 (git+https://github.com/dashpay/grovedb?rev=a20add8d9327b31198eebddd9d78d3cbf940367c)",
  "grovedb-storage",
  "hex",
  "indexmap 2.13.0",
@@ -2928,10 +2928,10 @@ dependencies = [
 [[package]]
 name = "grovedb-storage"
 version = "4.0.0"
-source = "git+https://github.com/dashpay/grovedb?rev=a7b878f72279a4893a7e9dc0ab2973ca0b09ce69#a7b878f72279a4893a7e9dc0ab2973ca0b09ce69"
+source = "git+https://github.com/dashpay/grovedb?rev=a20add8d9327b31198eebddd9d78d3cbf940367c#a20add8d9327b31198eebddd9d78d3cbf940367c"
 dependencies = [
  "blake3",
- "grovedb-costs 4.0.0 (git+https://github.com/dashpay/grovedb?rev=a7b878f72279a4893a7e9dc0ab2973ca0b09ce69)",
+ "grovedb-costs 4.0.0 (git+https://github.com/dashpay/grovedb?rev=a20add8d9327b31198eebddd9d78d3cbf940367c)",
  "grovedb-path",
  "grovedb-visualize",
  "hex",
@@ -2947,7 +2947,7 @@ dependencies = [
 [[package]]
 name = "grovedb-version"
 version = "4.0.0"
-source = "git+https://github.com/dashpay/grovedb?rev=a7b878f72279a4893a7e9dc0ab2973ca0b09ce69#a7b878f72279a4893a7e9dc0ab2973ca0b09ce69"
+source = "git+https://github.com/dashpay/grovedb?rev=a20add8d9327b31198eebddd9d78d3cbf940367c#a20add8d9327b31198eebddd9d78d3cbf940367c"
 dependencies = [
  "thiserror 2.0.18",
  "versioned-feature-core 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2956,7 +2956,7 @@ dependencies = [
 [[package]]
 name = "grovedb-visualize"
 version = "4.0.0"
-source = "git+https://github.com/dashpay/grovedb?rev=a7b878f72279a4893a7e9dc0ab2973ca0b09ce69#a7b878f72279a4893a7e9dc0ab2973ca0b09ce69"
+source = "git+https://github.com/dashpay/grovedb?rev=a20add8d9327b31198eebddd9d78d3cbf940367c#a20add8d9327b31198eebddd9d78d3cbf940367c"
 dependencies = [
  "hex",
  "itertools 0.14.0",
@@ -2965,7 +2965,7 @@ dependencies = [
 [[package]]
 name = "grovedbg-types"
 version = "4.0.0"
-source = "git+https://github.com/dashpay/grovedb?rev=a7b878f72279a4893a7e9dc0ab2973ca0b09ce69#a7b878f72279a4893a7e9dc0ab2973ca0b09ce69"
+source = "git+https://github.com/dashpay/grovedb?rev=a20add8d9327b31198eebddd9d78d3cbf940367c#a20add8d9327b31198eebddd9d78d3cbf940367c"
 dependencies = [
  "serde",
  "serde_with 3.17.0",
@@ -6061,7 +6061,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2033,7 +2033,7 @@ dependencies = [
  "dpp",
  "enum-map",
  "grovedb",
- "grovedb-costs 4.0.0 (git+https://github.com/dashpay/grovedb?rev=a20add8d9327b31198eebddd9d78d3cbf940367c)",
+ "grovedb-costs 4.0.0 (git+https://github.com/dashpay/grovedb?rev=2c9117cf3d77c2ffda060f45242d238fb01dca84)",
  "grovedb-epoch-based-storage-flags",
  "grovedb-path",
  "grovedb-storage",
@@ -2727,15 +2727,15 @@ dependencies = [
 [[package]]
 name = "grovedb"
 version = "4.0.0"
-source = "git+https://github.com/dashpay/grovedb?rev=a20add8d9327b31198eebddd9d78d3cbf940367c#a20add8d9327b31198eebddd9d78d3cbf940367c"
+source = "git+https://github.com/dashpay/grovedb?rev=2c9117cf3d77c2ffda060f45242d238fb01dca84#2c9117cf3d77c2ffda060f45242d238fb01dca84"
 dependencies = [
  "axum 0.8.8",
  "bincode",
  "bincode_derive",
  "blake3",
  "grovedb-bulk-append-tree",
- "grovedb-commitment-tree 4.0.0 (git+https://github.com/dashpay/grovedb?rev=a20add8d9327b31198eebddd9d78d3cbf940367c)",
- "grovedb-costs 4.0.0 (git+https://github.com/dashpay/grovedb?rev=a20add8d9327b31198eebddd9d78d3cbf940367c)",
+ "grovedb-commitment-tree 4.0.0 (git+https://github.com/dashpay/grovedb?rev=2c9117cf3d77c2ffda060f45242d238fb01dca84)",
+ "grovedb-costs 4.0.0 (git+https://github.com/dashpay/grovedb?rev=2c9117cf3d77c2ffda060f45242d238fb01dca84)",
  "grovedb-dense-fixed-sized-merkle-tree",
  "grovedb-element",
  "grovedb-merk",
@@ -2765,16 +2765,30 @@ dependencies = [
 [[package]]
 name = "grovedb-bulk-append-tree"
 version = "4.0.0"
-source = "git+https://github.com/dashpay/grovedb?rev=a20add8d9327b31198eebddd9d78d3cbf940367c#a20add8d9327b31198eebddd9d78d3cbf940367c"
+source = "git+https://github.com/dashpay/grovedb?rev=2c9117cf3d77c2ffda060f45242d238fb01dca84#2c9117cf3d77c2ffda060f45242d238fb01dca84"
 dependencies = [
  "bincode",
  "blake3",
- "grovedb-costs 4.0.0 (git+https://github.com/dashpay/grovedb?rev=a20add8d9327b31198eebddd9d78d3cbf940367c)",
+ "grovedb-costs 4.0.0 (git+https://github.com/dashpay/grovedb?rev=2c9117cf3d77c2ffda060f45242d238fb01dca84)",
  "grovedb-dense-fixed-sized-merkle-tree",
  "grovedb-merkle-mountain-range",
  "grovedb-query",
  "grovedb-storage",
  "hex",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "grovedb-commitment-tree"
+version = "4.0.0"
+source = "git+https://github.com/dashpay/grovedb?rev=2c9117cf3d77c2ffda060f45242d238fb01dca84#2c9117cf3d77c2ffda060f45242d238fb01dca84"
+dependencies = [
+ "blake3",
+ "grovedb-bulk-append-tree",
+ "grovedb-costs 4.0.0 (git+https://github.com/dashpay/grovedb?rev=2c9117cf3d77c2ffda060f45242d238fb01dca84)",
+ "grovedb-storage",
+ "incrementalmerkletree",
+ "orchard",
  "thiserror 2.0.18",
 ]
 
@@ -2791,16 +2805,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "grovedb-commitment-tree"
+name = "grovedb-costs"
 version = "4.0.0"
-source = "git+https://github.com/dashpay/grovedb?rev=a20add8d9327b31198eebddd9d78d3cbf940367c#a20add8d9327b31198eebddd9d78d3cbf940367c"
+source = "git+https://github.com/dashpay/grovedb?rev=2c9117cf3d77c2ffda060f45242d238fb01dca84#2c9117cf3d77c2ffda060f45242d238fb01dca84"
 dependencies = [
- "blake3",
- "grovedb-bulk-append-tree",
- "grovedb-costs 4.0.0 (git+https://github.com/dashpay/grovedb?rev=a20add8d9327b31198eebddd9d78d3cbf940367c)",
- "grovedb-storage",
- "incrementalmerkletree",
- "orchard",
+ "integer-encoding",
+ "intmap",
  "thiserror 2.0.18",
 ]
 
@@ -2815,23 +2825,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "grovedb-costs"
-version = "4.0.0"
-source = "git+https://github.com/dashpay/grovedb?rev=a20add8d9327b31198eebddd9d78d3cbf940367c#a20add8d9327b31198eebddd9d78d3cbf940367c"
-dependencies = [
- "integer-encoding",
- "intmap",
- "thiserror 2.0.18",
-]
-
-[[package]]
 name = "grovedb-dense-fixed-sized-merkle-tree"
 version = "4.0.0"
-source = "git+https://github.com/dashpay/grovedb?rev=a20add8d9327b31198eebddd9d78d3cbf940367c#a20add8d9327b31198eebddd9d78d3cbf940367c"
+source = "git+https://github.com/dashpay/grovedb?rev=2c9117cf3d77c2ffda060f45242d238fb01dca84#2c9117cf3d77c2ffda060f45242d238fb01dca84"
 dependencies = [
  "bincode",
  "blake3",
- "grovedb-costs 4.0.0 (git+https://github.com/dashpay/grovedb?rev=a20add8d9327b31198eebddd9d78d3cbf940367c)",
+ "grovedb-costs 4.0.0 (git+https://github.com/dashpay/grovedb?rev=2c9117cf3d77c2ffda060f45242d238fb01dca84)",
  "grovedb-query",
  "grovedb-storage",
  "thiserror 2.0.18",
@@ -2840,7 +2840,7 @@ dependencies = [
 [[package]]
 name = "grovedb-element"
 version = "4.0.0"
-source = "git+https://github.com/dashpay/grovedb?rev=a20add8d9327b31198eebddd9d78d3cbf940367c#a20add8d9327b31198eebddd9d78d3cbf940367c"
+source = "git+https://github.com/dashpay/grovedb?rev=2c9117cf3d77c2ffda060f45242d238fb01dca84#2c9117cf3d77c2ffda060f45242d238fb01dca84"
 dependencies = [
  "bincode",
  "bincode_derive",
@@ -2855,9 +2855,9 @@ dependencies = [
 [[package]]
 name = "grovedb-epoch-based-storage-flags"
 version = "4.0.0"
-source = "git+https://github.com/dashpay/grovedb?rev=a20add8d9327b31198eebddd9d78d3cbf940367c#a20add8d9327b31198eebddd9d78d3cbf940367c"
+source = "git+https://github.com/dashpay/grovedb?rev=2c9117cf3d77c2ffda060f45242d238fb01dca84#2c9117cf3d77c2ffda060f45242d238fb01dca84"
 dependencies = [
- "grovedb-costs 4.0.0 (git+https://github.com/dashpay/grovedb?rev=a20add8d9327b31198eebddd9d78d3cbf940367c)",
+ "grovedb-costs 4.0.0 (git+https://github.com/dashpay/grovedb?rev=2c9117cf3d77c2ffda060f45242d238fb01dca84)",
  "hex",
  "integer-encoding",
  "intmap",
@@ -2867,7 +2867,7 @@ dependencies = [
 [[package]]
 name = "grovedb-merk"
 version = "4.0.0"
-source = "git+https://github.com/dashpay/grovedb?rev=a20add8d9327b31198eebddd9d78d3cbf940367c#a20add8d9327b31198eebddd9d78d3cbf940367c"
+source = "git+https://github.com/dashpay/grovedb?rev=2c9117cf3d77c2ffda060f45242d238fb01dca84#2c9117cf3d77c2ffda060f45242d238fb01dca84"
 dependencies = [
  "bincode",
  "bincode_derive",
@@ -2875,7 +2875,7 @@ dependencies = [
  "byteorder",
  "colored",
  "ed",
- "grovedb-costs 4.0.0 (git+https://github.com/dashpay/grovedb?rev=a20add8d9327b31198eebddd9d78d3cbf940367c)",
+ "grovedb-costs 4.0.0 (git+https://github.com/dashpay/grovedb?rev=2c9117cf3d77c2ffda060f45242d238fb01dca84)",
  "grovedb-element",
  "grovedb-path",
  "grovedb-query",
@@ -2893,18 +2893,18 @@ dependencies = [
 [[package]]
 name = "grovedb-merkle-mountain-range"
 version = "4.0.0"
-source = "git+https://github.com/dashpay/grovedb?rev=a20add8d9327b31198eebddd9d78d3cbf940367c#a20add8d9327b31198eebddd9d78d3cbf940367c"
+source = "git+https://github.com/dashpay/grovedb?rev=2c9117cf3d77c2ffda060f45242d238fb01dca84#2c9117cf3d77c2ffda060f45242d238fb01dca84"
 dependencies = [
  "bincode",
  "blake3",
- "grovedb-costs 4.0.0 (git+https://github.com/dashpay/grovedb?rev=a20add8d9327b31198eebddd9d78d3cbf940367c)",
+ "grovedb-costs 4.0.0 (git+https://github.com/dashpay/grovedb?rev=2c9117cf3d77c2ffda060f45242d238fb01dca84)",
  "grovedb-storage",
 ]
 
 [[package]]
 name = "grovedb-path"
 version = "4.0.0"
-source = "git+https://github.com/dashpay/grovedb?rev=a20add8d9327b31198eebddd9d78d3cbf940367c#a20add8d9327b31198eebddd9d78d3cbf940367c"
+source = "git+https://github.com/dashpay/grovedb?rev=2c9117cf3d77c2ffda060f45242d238fb01dca84#2c9117cf3d77c2ffda060f45242d238fb01dca84"
 dependencies = [
  "hex",
 ]
@@ -2912,12 +2912,12 @@ dependencies = [
 [[package]]
 name = "grovedb-query"
 version = "4.0.0"
-source = "git+https://github.com/dashpay/grovedb?rev=a20add8d9327b31198eebddd9d78d3cbf940367c#a20add8d9327b31198eebddd9d78d3cbf940367c"
+source = "git+https://github.com/dashpay/grovedb?rev=2c9117cf3d77c2ffda060f45242d238fb01dca84#2c9117cf3d77c2ffda060f45242d238fb01dca84"
 dependencies = [
  "bincode",
  "byteorder",
  "ed",
- "grovedb-costs 4.0.0 (git+https://github.com/dashpay/grovedb?rev=a20add8d9327b31198eebddd9d78d3cbf940367c)",
+ "grovedb-costs 4.0.0 (git+https://github.com/dashpay/grovedb?rev=2c9117cf3d77c2ffda060f45242d238fb01dca84)",
  "grovedb-storage",
  "hex",
  "indexmap 2.13.0",
@@ -2928,10 +2928,10 @@ dependencies = [
 [[package]]
 name = "grovedb-storage"
 version = "4.0.0"
-source = "git+https://github.com/dashpay/grovedb?rev=a20add8d9327b31198eebddd9d78d3cbf940367c#a20add8d9327b31198eebddd9d78d3cbf940367c"
+source = "git+https://github.com/dashpay/grovedb?rev=2c9117cf3d77c2ffda060f45242d238fb01dca84#2c9117cf3d77c2ffda060f45242d238fb01dca84"
 dependencies = [
  "blake3",
- "grovedb-costs 4.0.0 (git+https://github.com/dashpay/grovedb?rev=a20add8d9327b31198eebddd9d78d3cbf940367c)",
+ "grovedb-costs 4.0.0 (git+https://github.com/dashpay/grovedb?rev=2c9117cf3d77c2ffda060f45242d238fb01dca84)",
  "grovedb-path",
  "grovedb-visualize",
  "hex",
@@ -2947,7 +2947,7 @@ dependencies = [
 [[package]]
 name = "grovedb-version"
 version = "4.0.0"
-source = "git+https://github.com/dashpay/grovedb?rev=a20add8d9327b31198eebddd9d78d3cbf940367c#a20add8d9327b31198eebddd9d78d3cbf940367c"
+source = "git+https://github.com/dashpay/grovedb?rev=2c9117cf3d77c2ffda060f45242d238fb01dca84#2c9117cf3d77c2ffda060f45242d238fb01dca84"
 dependencies = [
  "thiserror 2.0.18",
  "versioned-feature-core 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2956,7 +2956,7 @@ dependencies = [
 [[package]]
 name = "grovedb-visualize"
 version = "4.0.0"
-source = "git+https://github.com/dashpay/grovedb?rev=a20add8d9327b31198eebddd9d78d3cbf940367c#a20add8d9327b31198eebddd9d78d3cbf940367c"
+source = "git+https://github.com/dashpay/grovedb?rev=2c9117cf3d77c2ffda060f45242d238fb01dca84#2c9117cf3d77c2ffda060f45242d238fb01dca84"
 dependencies = [
  "hex",
  "itertools 0.14.0",
@@ -2965,7 +2965,7 @@ dependencies = [
 [[package]]
 name = "grovedbg-types"
 version = "4.0.0"
-source = "git+https://github.com/dashpay/grovedb?rev=a20add8d9327b31198eebddd9d78d3cbf940367c#a20add8d9327b31198eebddd9d78d3cbf940367c"
+source = "git+https://github.com/dashpay/grovedb?rev=2c9117cf3d77c2ffda060f45242d238fb01dca84#2c9117cf3d77c2ffda060f45242d238fb01dca84"
 dependencies = [
  "serde",
  "serde_with 3.17.0",

--- a/packages/rs-dpp/src/state_transition/traits/state_transition_identity_id_from_inputs.rs
+++ b/packages/rs-dpp/src/state_transition/traits/state_transition_identity_id_from_inputs.rs
@@ -21,8 +21,9 @@ pub trait StateTransitionIdentityIdFromInputs: StateTransitionWitnessSigned {
 /// Helper that computes the identity ID from input addresses and nonces.
 /// Nonces should represent state after creation of the identity (eg. be incremented by 1).
 ///
-/// Internal use only; see `StateTransitionIdentityIdFromInputs` trait.
-pub(crate) fn identity_id_from_input_addresses(
+/// This is the canonical way to derive the deterministic identity ID from
+/// address-funded identity creation inputs.
+pub fn identity_id_from_input_addresses(
     input_addresses: &BTreeMap<PlatformAddress, (AddressNonce, Credits)>,
 ) -> Result<Identifier, ProtocolError> {
     if input_addresses.is_empty() {

--- a/packages/rs-drive-abci/src/execution/platform_events/block_processing_end_events/process_block_fees_and_validate_sum_trees/v0/mod.rs
+++ b/packages/rs-drive-abci/src/execution/platform_events/block_processing_end_events/process_block_fees_and_validate_sum_trees/v0/mod.rs
@@ -21,7 +21,6 @@ use dpp::version::PlatformVersion;
 use drive::drive::Drive;
 use drive::grovedb::Transaction;
 use drive::util::batch::DriveOperation;
-use drive::util::grove_operations::BatchApplyDriveOperation;
 
 use crate::error::execution::ExecutionError;
 use crate::error::Error;
@@ -149,7 +148,7 @@ impl<CoreRPCLike> Platform<CoreRPCLike> {
             &platform_version.drive,
         )?;
 
-        self.drive.apply_drive_operations_with_options(
+        self.drive.apply_drive_operations(
             batch,
             true,
             &block_info.to_block_info(epoch_info.try_into()?),
@@ -160,10 +159,6 @@ impl<CoreRPCLike> Platform<CoreRPCLike> {
                     .block_platform_state()
                     .previous_fee_versions(),
             ),
-            BatchApplyDriveOperation {
-                allow_deleting_non_empty_trees: true,
-                deleting_non_empty_trees_returns_error: false,
-            },
         )?;
 
         let outcome = processed_block_fees_outcome::v0::ProcessedBlockFeesOutcome {

--- a/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/batch/tests/document/deletion.rs
+++ b/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/batch/tests/document/deletion.rs
@@ -141,7 +141,7 @@ mod deletion_tests {
 
         assert_eq!(processing_result.valid_count(), 1);
 
-        assert_eq!(processing_result.aggregated_fees().processing_fee, 1666860);
+        assert_eq!(processing_result.aggregated_fees().processing_fee, 1963260);
 
         let issues = platform
             .drive
@@ -482,7 +482,7 @@ mod deletion_tests {
 
         assert_eq!(processing_result.valid_count(), 1);
 
-        assert_eq!(processing_result.aggregated_fees().processing_fee, 2762400);
+        assert_eq!(processing_result.aggregated_fees().processing_fee, 3884300);
 
         let issues = platform
             .drive

--- a/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/batch/tests/document/deletion.rs
+++ b/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/batch/tests/document/deletion.rs
@@ -141,7 +141,7 @@ mod deletion_tests {
 
         assert_eq!(processing_result.valid_count(), 1);
 
-        assert_eq!(processing_result.aggregated_fees().processing_fee, 1963260);
+        assert_eq!(processing_result.aggregated_fees().processing_fee, 1666860);
 
         let issues = platform
             .drive
@@ -482,7 +482,7 @@ mod deletion_tests {
 
         assert_eq!(processing_result.valid_count(), 1);
 
-        assert_eq!(processing_result.aggregated_fees().processing_fee, 3884300);
+        assert_eq!(processing_result.aggregated_fees().processing_fee, 2762400);
 
         let issues = platform
             .drive

--- a/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/batch/tests/document/nft.rs
+++ b/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/batch/tests/document/nft.rs
@@ -702,7 +702,7 @@ mod nft_tests {
 
         assert_eq!(processing_result.aggregated_fees().storage_fee, 64611000);
 
-        assert_eq!(processing_result.aggregated_fees().processing_fee, 4080480);
+        assert_eq!(processing_result.aggregated_fees().processing_fee, 4520280);
 
         assert_eq!(
             processing_result
@@ -746,7 +746,7 @@ mod nft_tests {
             .expect("expected that purchaser exists");
 
         // the buyer paid 0.1, but also storage and processing fees
-        assert_eq!(buyers_balance, dash_to_credits!(0.9) - 68691480);
+        assert_eq!(buyers_balance, dash_to_credits!(0.9) - 69131280);
     }
 
     #[test]
@@ -1219,7 +1219,7 @@ mod nft_tests {
 
         assert_eq!(processing_result.aggregated_fees().storage_fee, 64611000);
 
-        assert_eq!(processing_result.aggregated_fees().processing_fee, 4345280);
+        assert_eq!(processing_result.aggregated_fees().processing_fee, 4790840);
 
         assert_eq!(
             processing_result
@@ -1263,7 +1263,7 @@ mod nft_tests {
             .expect("expected that purchaser exists");
 
         // the buyer paid 0.1, but also storage and processing fees
-        assert_eq!(buyers_balance, dash_to_credits!(0.9) - 68956280);
+        assert_eq!(buyers_balance, dash_to_credits!(0.9) - 69401840);
     }
 
     #[test]
@@ -1601,7 +1601,7 @@ mod nft_tests {
 
         assert_eq!(processing_result.aggregated_fees().storage_fee, 64611000);
 
-        assert_eq!(processing_result.aggregated_fees().processing_fee, 4080480);
+        assert_eq!(processing_result.aggregated_fees().processing_fee, 4520280);
 
         assert_eq!(
             processing_result
@@ -1645,7 +1645,7 @@ mod nft_tests {
             .expect("expected that purchaser exists");
 
         // the buyer paid 0.1, but also storage and processing fees
-        assert_eq!(buyers_balance, dash_to_credits!(0.9) - 68691480);
+        assert_eq!(buyers_balance, dash_to_credits!(0.9) - 69131280);
     }
 
     #[test]

--- a/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/batch/tests/document/nft.rs
+++ b/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/batch/tests/document/nft.rs
@@ -702,7 +702,7 @@ mod nft_tests {
 
         assert_eq!(processing_result.aggregated_fees().storage_fee, 64611000);
 
-        assert_eq!(processing_result.aggregated_fees().processing_fee, 4520280);
+        assert_eq!(processing_result.aggregated_fees().processing_fee, 4080480);
 
         assert_eq!(
             processing_result
@@ -746,7 +746,7 @@ mod nft_tests {
             .expect("expected that purchaser exists");
 
         // the buyer paid 0.1, but also storage and processing fees
-        assert_eq!(buyers_balance, dash_to_credits!(0.9) - 69131280);
+        assert_eq!(buyers_balance, dash_to_credits!(0.9) - 68691480);
     }
 
     #[test]
@@ -1219,7 +1219,7 @@ mod nft_tests {
 
         assert_eq!(processing_result.aggregated_fees().storage_fee, 64611000);
 
-        assert_eq!(processing_result.aggregated_fees().processing_fee, 4790840);
+        assert_eq!(processing_result.aggregated_fees().processing_fee, 4345280);
 
         assert_eq!(
             processing_result
@@ -1263,7 +1263,7 @@ mod nft_tests {
             .expect("expected that purchaser exists");
 
         // the buyer paid 0.1, but also storage and processing fees
-        assert_eq!(buyers_balance, dash_to_credits!(0.9) - 69401840);
+        assert_eq!(buyers_balance, dash_to_credits!(0.9) - 68956280);
     }
 
     #[test]
@@ -1601,7 +1601,7 @@ mod nft_tests {
 
         assert_eq!(processing_result.aggregated_fees().storage_fee, 64611000);
 
-        assert_eq!(processing_result.aggregated_fees().processing_fee, 4520280);
+        assert_eq!(processing_result.aggregated_fees().processing_fee, 4080480);
 
         assert_eq!(
             processing_result
@@ -1645,7 +1645,7 @@ mod nft_tests {
             .expect("expected that purchaser exists");
 
         // the buyer paid 0.1, but also storage and processing fees
-        assert_eq!(buyers_balance, dash_to_credits!(0.9) - 69131280);
+        assert_eq!(buyers_balance, dash_to_credits!(0.9) - 68691480);
     }
 
     #[test]

--- a/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/batch/tests/document/transfer.rs
+++ b/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/batch/tests/document/transfer.rs
@@ -386,7 +386,7 @@ mod transfer_tests {
             Some(14992395)
         );
 
-        assert_eq!(processing_result.aggregated_fees().processing_fee, 3369260);
+        assert_eq!(processing_result.aggregated_fees().processing_fee, 3721740);
 
         let query_sender_results = platform
             .drive
@@ -632,7 +632,7 @@ mod transfer_tests {
             Some(14992395)
         );
 
-        assert_eq!(processing_result.aggregated_fees().processing_fee, 3631040);
+        assert_eq!(processing_result.aggregated_fees().processing_fee, 3983520);
 
         let query_sender_results = platform
             .drive
@@ -884,7 +884,7 @@ mod transfer_tests {
             Some(14992395)
         );
 
-        assert_eq!(processing_result.aggregated_fees().processing_fee, 3369260);
+        assert_eq!(processing_result.aggregated_fees().processing_fee, 3721740);
 
         let query_sender_results = platform
             .drive
@@ -1440,7 +1440,7 @@ mod transfer_tests {
 
         assert_eq!(processing_result.valid_count(), 1);
 
-        assert_eq!(processing_result.aggregated_fees().processing_fee, 3991900);
+        assert_eq!(processing_result.aggregated_fees().processing_fee, 4431700);
 
         let query_sender_results = platform
             .drive

--- a/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/batch/tests/document/transfer.rs
+++ b/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/batch/tests/document/transfer.rs
@@ -386,7 +386,7 @@ mod transfer_tests {
             Some(14992395)
         );
 
-        assert_eq!(processing_result.aggregated_fees().processing_fee, 3721740);
+        assert_eq!(processing_result.aggregated_fees().processing_fee, 3369260);
 
         let query_sender_results = platform
             .drive
@@ -632,7 +632,7 @@ mod transfer_tests {
             Some(14992395)
         );
 
-        assert_eq!(processing_result.aggregated_fees().processing_fee, 3983520);
+        assert_eq!(processing_result.aggregated_fees().processing_fee, 3631040);
 
         let query_sender_results = platform
             .drive
@@ -884,7 +884,7 @@ mod transfer_tests {
             Some(14992395)
         );
 
-        assert_eq!(processing_result.aggregated_fees().processing_fee, 3721740);
+        assert_eq!(processing_result.aggregated_fees().processing_fee, 3369260);
 
         let query_sender_results = platform
             .drive
@@ -1440,7 +1440,7 @@ mod transfer_tests {
 
         assert_eq!(processing_result.valid_count(), 1);
 
-        assert_eq!(processing_result.aggregated_fees().processing_fee, 4431700);
+        assert_eq!(processing_result.aggregated_fees().processing_fee, 3991900);
 
         let query_sender_results = platform
             .drive

--- a/packages/rs-drive/Cargo.toml
+++ b/packages/rs-drive/Cargo.toml
@@ -52,12 +52,12 @@ enum-map = { version = "2.0.3", optional = true }
 intmap = { version = "3.0.1", features = ["serde"], optional = true }
 chrono = { version = "0.4.35", optional = true }
 itertools = { version = "0.13", optional = true }
-grovedb = { git = "https://github.com/dashpay/grovedb", rev = "a20add8d9327b31198eebddd9d78d3cbf940367c", optional = true, default-features = false }
-grovedb-costs = { git = "https://github.com/dashpay/grovedb", rev = "a20add8d9327b31198eebddd9d78d3cbf940367c", optional = true }
-grovedb-path = { git = "https://github.com/dashpay/grovedb", rev = "a20add8d9327b31198eebddd9d78d3cbf940367c" }
-grovedb-storage = { git = "https://github.com/dashpay/grovedb", rev = "a20add8d9327b31198eebddd9d78d3cbf940367c", optional = true }
-grovedb-version = { git = "https://github.com/dashpay/grovedb", rev = "a20add8d9327b31198eebddd9d78d3cbf940367c" }
-grovedb-epoch-based-storage-flags = { git = "https://github.com/dashpay/grovedb", rev = "a20add8d9327b31198eebddd9d78d3cbf940367c" }
+grovedb = { git = "https://github.com/dashpay/grovedb", rev = "2c9117cf3d77c2ffda060f45242d238fb01dca84", optional = true, default-features = false }
+grovedb-costs = { git = "https://github.com/dashpay/grovedb", rev = "2c9117cf3d77c2ffda060f45242d238fb01dca84", optional = true }
+grovedb-path = { git = "https://github.com/dashpay/grovedb", rev = "2c9117cf3d77c2ffda060f45242d238fb01dca84" }
+grovedb-storage = { git = "https://github.com/dashpay/grovedb", rev = "2c9117cf3d77c2ffda060f45242d238fb01dca84", optional = true }
+grovedb-version = { git = "https://github.com/dashpay/grovedb", rev = "2c9117cf3d77c2ffda060f45242d238fb01dca84" }
+grovedb-epoch-based-storage-flags = { git = "https://github.com/dashpay/grovedb", rev = "2c9117cf3d77c2ffda060f45242d238fb01dca84" }
 
 [dev-dependencies]
 criterion = "0.5"

--- a/packages/rs-drive/Cargo.toml
+++ b/packages/rs-drive/Cargo.toml
@@ -52,12 +52,12 @@ enum-map = { version = "2.0.3", optional = true }
 intmap = { version = "3.0.1", features = ["serde"], optional = true }
 chrono = { version = "0.4.35", optional = true }
 itertools = { version = "0.13", optional = true }
-grovedb = { git = "https://github.com/dashpay/grovedb", rev = "a7b878f72279a4893a7e9dc0ab2973ca0b09ce69", optional = true, default-features = false }
-grovedb-costs = { git = "https://github.com/dashpay/grovedb", rev = "a7b878f72279a4893a7e9dc0ab2973ca0b09ce69", optional = true }
-grovedb-path = { git = "https://github.com/dashpay/grovedb", rev = "a7b878f72279a4893a7e9dc0ab2973ca0b09ce69" }
-grovedb-storage = { git = "https://github.com/dashpay/grovedb", rev = "a7b878f72279a4893a7e9dc0ab2973ca0b09ce69", optional = true }
-grovedb-version = { git = "https://github.com/dashpay/grovedb", rev = "a7b878f72279a4893a7e9dc0ab2973ca0b09ce69" }
-grovedb-epoch-based-storage-flags = { git = "https://github.com/dashpay/grovedb", rev = "a7b878f72279a4893a7e9dc0ab2973ca0b09ce69" }
+grovedb = { git = "https://github.com/dashpay/grovedb", rev = "a20add8d9327b31198eebddd9d78d3cbf940367c", optional = true, default-features = false }
+grovedb-costs = { git = "https://github.com/dashpay/grovedb", rev = "a20add8d9327b31198eebddd9d78d3cbf940367c", optional = true }
+grovedb-path = { git = "https://github.com/dashpay/grovedb", rev = "a20add8d9327b31198eebddd9d78d3cbf940367c" }
+grovedb-storage = { git = "https://github.com/dashpay/grovedb", rev = "a20add8d9327b31198eebddd9d78d3cbf940367c", optional = true }
+grovedb-version = { git = "https://github.com/dashpay/grovedb", rev = "a20add8d9327b31198eebddd9d78d3cbf940367c" }
+grovedb-epoch-based-storage-flags = { git = "https://github.com/dashpay/grovedb", rev = "a20add8d9327b31198eebddd9d78d3cbf940367c" }
 
 [dev-dependencies]
 criterion = "0.5"

--- a/packages/rs-drive/src/drive/credit_pools/epochs/operations_factory.rs
+++ b/packages/rs-drive/src/drive/credit_pools/epochs/operations_factory.rs
@@ -20,7 +20,7 @@ use dpp::fee::Credits;
 use dpp::prelude::Identifier;
 use dpp::util::deserializer::ProtocolVersion;
 use dpp::version::PlatformVersion;
-use grovedb::batch::QualifiedGroveDbOp;
+use grovedb::batch::{QualifiedGroveDbOp, SubelementsDeletionBehavior};
 use grovedb::{Element, TransactionArg, TreeType};
 
 /// Operations on Epochs
@@ -297,6 +297,7 @@ impl EpochOperations for Epoch {
             self.get_path_vec(),
             KEY_PROPOSERS.to_vec(),
             TreeType::NormalTree,
+            SubelementsDeletionBehavior::DeleteChildren,
         )
     }
 

--- a/packages/rs-drive/src/drive/initialization/v0/mod.rs
+++ b/packages/rs-drive/src/drive/initialization/v0/mod.rs
@@ -1360,7 +1360,7 @@ mod tests {
                 drive_version,
             )
             .expect("expected to get root elements");
-        assert_eq!(proof.len(), 251); //it + left + right + parent + sibling + parent sibling + grandparent
+        assert_eq!(proof.len(), 286); //it + left + right + parent + sibling + parent sibling + grandparent
 
         let mut query = Query::new();
         query.insert_key(vec![RootTree::Pools as u8]);
@@ -1381,7 +1381,7 @@ mod tests {
                 drive_version,
             )
             .expect("expected to get root elements");
-        assert_eq!(proof.len(), 253); //it + left + parent + sibling + parent sibling + grandparent
+        assert_eq!(proof.len(), 288); //it + left + parent + sibling + parent sibling + grandparent
 
         let mut query = Query::new();
         query.insert_key(vec![RootTree::WithdrawalTransactions as u8]);
@@ -1402,7 +1402,7 @@ mod tests {
                 drive_version,
             )
             .expect("expected to get root elements");
-        assert_eq!(proof.len(), 251); //it + left + right + parent + sibling + parent sibling + grandparent
+        assert_eq!(proof.len(), 286); //it + left + right + parent + sibling + parent sibling + grandparent
 
         let mut query = Query::new();
         query.insert_key(vec![RootTree::Votes as u8]);
@@ -1423,7 +1423,7 @@ mod tests {
                 drive_version,
             )
             .expect("expected to get root elements");
-        assert_eq!(proof.len(), 251); //it + left + right + parent + sibling + parent sibling + grandparent
+        assert_eq!(proof.len(), 286); //it + left + right + parent + sibling + parent sibling + grandparent
 
         // Merk Level 3
 
@@ -1490,7 +1490,7 @@ mod tests {
                 drive_version,
             )
             .expect("expected to get root elements");
-        assert_eq!(proof.len(), 288); //it + parent + sibling + parent sibling + grandparent + grandparent sibling + great-grandparent
+        assert_eq!(proof.len(), 321); //it + parent + sibling + parent sibling + grandparent + grandparent sibling + great-grandparent
 
         let mut query = Query::new();
         query.insert_key(vec![RootTree::AddressBalances as u8]);
@@ -1511,7 +1511,7 @@ mod tests {
                 drive_version,
             )
             .expect("expected to get root elements");
-        assert_eq!(proof.len(), 252); //it + parent + sibling + parent sibling + grandparent + grandparent sibling + great-grandparent
+        assert_eq!(proof.len(), 287); //it + parent + sibling + parent sibling + grandparent + grandparent sibling + great-grandparent
 
         let mut query = Query::new();
         query.insert_key(vec![RootTree::SpentAssetLockTransactions as u8]);
@@ -1574,7 +1574,7 @@ mod tests {
                 drive_version,
             )
             .expect("expected to get root elements");
-        assert_eq!(proof.len(), 251); //it + parent + sibling + parent sibling + grandparent + grandparent sibling + great-grandparent
+        assert_eq!(proof.len(), 286); //it + parent + sibling + parent sibling + grandparent + grandparent sibling + great-grandparent
 
         let mut query = Query::new();
         query.insert_key(vec![RootTree::Versions as u8]);
@@ -1595,7 +1595,7 @@ mod tests {
                 drive_version,
             )
             .expect("expected to get root elements");
-        assert_eq!(proof.len(), 251); //it + parent + sibling + parent sibling + grandparent + grandparent sibling + great-grandparent
+        assert_eq!(proof.len(), 286); //it + parent + sibling + parent sibling + grandparent + grandparent sibling + great-grandparent
 
         // Merk Level 4
 
@@ -1618,6 +1618,6 @@ mod tests {
                 drive_version,
             )
             .expect("expected to get root elements");
-        assert_eq!(proof.len(), 287); //it + parent + parent sibling + grandparent + grandparent sibling + great-grandparent + great-grandparent sibling + great-great-grandparent
+        assert_eq!(proof.len(), 320); //it + parent + parent sibling + grandparent + grandparent sibling + great-grandparent + great-grandparent sibling + great-great-grandparent
     }
 }

--- a/packages/rs-drive/src/state_transition_action/action_convert_to_operations/system/penalize_shielded_pool.rs
+++ b/packages/rs-drive/src/state_transition_action/action_convert_to_operations/system/penalize_shielded_pool.rs
@@ -27,14 +27,15 @@ impl DriveHighLevelOperationConverter for PenalizeShieldedPoolAction {
                 }
 
                 // 2. Deduct penalty from pool total balance
-                let new_total_balance =
-                    v0.current_total_balance
-                        .checked_sub(v0.penalty_amount)
-                        .ok_or_else(|| {
-                            Error::Drive(DriveError::CorruptedDriveState(
-                                "shielded pool total balance underflow when subtracting penalty_amount".to_string(),
-                            ))
-                        })?;
+                let new_total_balance = v0
+                    .current_total_balance
+                    .checked_sub(v0.penalty_amount)
+                    .ok_or_else(|| {
+                        Error::Drive(DriveError::CorruptedDriveState(
+                            "shielded pool total balance underflow when subtracting penalty_amount"
+                                .to_string(),
+                        ))
+                    })?;
                 ops.push(DriveOperation::ShieldedPoolOperation(
                     ShieldedPoolOperationType::UpdateTotalBalance { new_total_balance },
                 ));

--- a/packages/rs-drive/src/util/batch/drive_op_batch/drive_methods/apply_drive_operations/mod.rs
+++ b/packages/rs-drive/src/util/batch/drive_op_batch/drive_methods/apply_drive_operations/mod.rs
@@ -1,7 +1,6 @@
 mod v0;
 
 use crate::util::batch::DriveOperation;
-use crate::util::grove_operations::BatchApplyDriveOperation;
 
 use crate::drive::Drive;
 use crate::error::{drive::DriveError, Error};
@@ -58,42 +57,6 @@ impl Drive {
             ),
             version => Err(Error::Drive(DriveError::UnknownVersionMismatch {
                 method: "apply_drive_operations".to_string(),
-                known_versions: vec![0],
-                received: version,
-            })),
-        }
-    }
-
-    /// Like `apply_drive_operations` but with custom options controlling
-    /// tree deletion behavior.
-    #[allow(clippy::too_many_arguments)]
-    pub fn apply_drive_operations_with_options(
-        &self,
-        operations: Vec<DriveOperation>,
-        apply: bool,
-        block_info: &BlockInfo,
-        transaction: TransactionArg,
-        platform_version: &PlatformVersion,
-        previous_fee_versions: Option<&CachedEpochIndexFeeVersions>,
-        batch_apply_drive_operation: BatchApplyDriveOperation,
-    ) -> Result<FeeResult, Error> {
-        match platform_version
-            .drive
-            .methods
-            .batch_operations
-            .apply_drive_operations_with_options
-        {
-            0 => self.apply_drive_operations_with_options_v0(
-                operations,
-                apply,
-                block_info,
-                transaction,
-                platform_version,
-                previous_fee_versions,
-                batch_apply_drive_operation,
-            ),
-            version => Err(Error::Drive(DriveError::UnknownVersionMismatch {
-                method: "apply_drive_operations_with_options".to_string(),
                 known_versions: vec![0],
                 received: version,
             })),

--- a/packages/rs-drive/src/util/batch/drive_op_batch/drive_methods/apply_drive_operations/v0/mod.rs
+++ b/packages/rs-drive/src/util/batch/drive_op_batch/drive_methods/apply_drive_operations/v0/mod.rs
@@ -1,5 +1,4 @@
 use crate::util::batch::DriveOperation;
-use crate::util::grove_operations::BatchApplyDriveOperation;
 
 use crate::drive::Drive;
 use crate::error::Error;
@@ -22,6 +21,21 @@ use std::collections::HashMap;
 
 impl Drive {
     /// Applies a list of high level DriveOperations to the drive, and calculates the fee for them.
+    ///
+    /// # Arguments
+    ///
+    /// * `operations` - A vector of `DriveOperation`s to apply to the drive.
+    /// * `apply` - A boolean flag indicating whether to apply the changes or only estimate costs.
+    /// * `block_info` - A reference to information about the current block.
+    /// * `transaction` - Transaction arguments.
+    ///
+    /// # Returns
+    ///
+    /// Returns a `Result` containing the `FeeResult` if the operations are successfully applied,
+    /// otherwise an `Error`.
+    ///
+    /// If `apply` is set to true, it applies the low-level drive operations and updates side info accordingly.
+    /// If not, it only estimates the costs and updates estimated costs with layer info.
     #[inline(always)]
     pub(crate) fn apply_drive_operations_v0(
         &self,
@@ -31,31 +45,6 @@ impl Drive {
         transaction: TransactionArg,
         platform_version: &PlatformVersion,
         previous_fee_versions: Option<&CachedEpochIndexFeeVersions>,
-    ) -> Result<FeeResult, Error> {
-        self.apply_drive_operations_with_options_v0(
-            operations,
-            apply,
-            block_info,
-            transaction,
-            platform_version,
-            previous_fee_versions,
-            BatchApplyDriveOperation::default(),
-        )
-    }
-
-    /// Like `apply_drive_operations_v0` but with custom options controlling
-    /// tree deletion behavior.
-    #[inline(always)]
-    #[allow(clippy::too_many_arguments)]
-    pub(crate) fn apply_drive_operations_with_options_v0(
-        &self,
-        operations: Vec<DriveOperation>,
-        apply: bool,
-        block_info: &BlockInfo,
-        transaction: TransactionArg,
-        platform_version: &PlatformVersion,
-        previous_fee_versions: Option<&CachedEpochIndexFeeVersions>,
-        batch_apply_drive_operation: BatchApplyDriveOperation,
     ) -> Result<FeeResult, Error> {
         if operations.is_empty() {
             return Ok(FeeResult::default());
@@ -85,11 +74,10 @@ impl Drive {
 
         let mut cost_operations = vec![];
 
-        self.apply_batch_low_level_drive_operations_with_options(
+        self.apply_batch_low_level_drive_operations(
             estimated_costs_only_with_layer_info,
             transaction,
             low_level_operations,
-            batch_apply_drive_operation,
             &mut cost_operations,
             &platform_version.drive,
         )?;

--- a/packages/rs-drive/src/util/batch/drive_op_batch/finalize_task.rs
+++ b/packages/rs-drive/src/util/batch/drive_op_batch/finalize_task.rs
@@ -18,11 +18,7 @@ pub trait DriveOperationFinalizationTasks {
 }
 
 impl DriveOperationFinalizeTask {
-    pub fn execute(
-        self,
-        drive: &Drive,
-        _platform_version: &PlatformVersion,
-    ) -> Result<(), Error> {
+    pub fn execute(self, drive: &Drive, _platform_version: &PlatformVersion) -> Result<(), Error> {
         match self {
             DriveOperationFinalizeTask::RemoveDataContractFromCache { contract_id } => {
                 drive.cache.data_contracts.remove(contract_id.to_buffer());

--- a/packages/rs-drive/src/util/batch/grovedb_op_batch/mod.rs
+++ b/packages/rs-drive/src/util/batch/grovedb_op_batch/mod.rs
@@ -16,7 +16,10 @@ use dpp::block::epoch::Epoch;
 use dpp::identity::{Purpose, SecurityLevel};
 use dpp::prelude::Identifier;
 use grovedb::batch::key_info::KeyInfo;
-use grovedb::batch::{GroveDbOpConsistencyResults, GroveOp, KeyInfoPath, QualifiedGroveDbOp};
+use grovedb::batch::{
+    GroveDbOpConsistencyResults, GroveOp, KeyInfoPath, QualifiedGroveDbOp,
+    SubelementsDeletionBehavior,
+};
 use grovedb::operations::proof::util::hex_to_ascii;
 use grovedb::{Element, TreeType};
 use std::borrow::Cow;
@@ -590,9 +593,15 @@ impl GroveDbOpBatchV0Methods for GroveDbOpBatch {
     }
 
     /// Adds a `Delete` tree operation to a list of GroveDB ops.
+    /// Uses `DontCheck` because callers (e.g. `batch_delete_up_tree_while_empty`)
+    /// have already verified the tree is empty.
     fn add_delete_tree(&mut self, path: Vec<Vec<u8>>, key: Vec<u8>, tree_type: TreeType) {
-        self.operations
-            .push(QualifiedGroveDbOp::delete_tree_op(path, key, tree_type))
+        self.operations.push(QualifiedGroveDbOp::delete_tree_op(
+            path,
+            key,
+            tree_type,
+            SubelementsDeletionBehavior::DontCheck,
+        ))
     }
 
     /// Adds an `Insert` operation with an element to a list of GroveDB ops.

--- a/packages/rs-drive/src/util/grove_operations/batch_insert_empty_tree_if_not_exists/v0/mod.rs
+++ b/packages/rs-drive/src/util/grove_operations/batch_insert_empty_tree_if_not_exists/v0/mod.rs
@@ -52,7 +52,7 @@ impl Drive {
                         } else if let GroveOperation(grove_op) = previous_drive_operation {
                             if grove_op.key == Some(KeyInfo::KnownKey(key.to_vec()))
                                 && grove_op.path == path
-                                && matches!(grove_op.op, GroveOp::DeleteTree(_))
+                                && matches!(grove_op.op, GroveOp::DeleteTree(_, _))
                             {
                                 found = true;
                                 existing_operations.remove(i);
@@ -119,7 +119,7 @@ impl Drive {
                         } else if let GroveOperation(grove_op) = previous_drive_operation {
                             if grove_op.key == Some(KeyInfo::KnownKey(key.to_vec()))
                                 && grove_op.path == path
-                                && matches!(grove_op.op, GroveOp::DeleteTree(_))
+                                && matches!(grove_op.op, GroveOp::DeleteTree(_, _))
                             {
                                 found = true;
                                 existing_operations.remove(i);
@@ -184,7 +184,7 @@ impl Drive {
                         } else if let GroveOperation(grove_op) = previous_drive_operation {
                             if grove_op.key == Some(KeyInfo::KnownKey(key.to_vec()))
                                 && grove_op.path == path
-                                && matches!(grove_op.op, GroveOp::DeleteTree(_))
+                                && matches!(grove_op.op, GroveOp::DeleteTree(_, _))
                             {
                                 found = true;
                                 existing_operations.remove(i);
@@ -249,7 +249,7 @@ impl Drive {
                         } else if let GroveOperation(grove_op) = previous_drive_operation {
                             if grove_op.key == Some(KeyInfo::KnownKey(key.to_vec()))
                                 && grove_op.path == path
-                                && matches!(grove_op.op, GroveOp::DeleteTree(_))
+                                && matches!(grove_op.op, GroveOp::DeleteTree(_, _))
                             {
                                 found = true;
                                 existing_operations.remove(i);

--- a/packages/rs-drive/src/util/grove_operations/batch_remove_raw/v0/mod.rs
+++ b/packages/rs-drive/src/util/grove_operations/batch_remove_raw/v0/mod.rs
@@ -45,7 +45,7 @@ impl Drive {
                         "we should not be seeing internal grovedb operations",
                     )));
                 }
-                Some(GroveOp::Delete) | Some(GroveOp::DeleteTree(_)) => false,
+                Some(GroveOp::Delete) | Some(GroveOp::DeleteTree(_, _)) => false,
                 _ => true,
             };
 

--- a/packages/rs-drive/src/util/grove_operations/grove_apply_batch_with_add_costs/mod.rs
+++ b/packages/rs-drive/src/util/grove_operations/grove_apply_batch_with_add_costs/mod.rs
@@ -6,7 +6,6 @@ use crate::drive::Drive;
 use crate::error::drive::DriveError;
 use crate::error::Error;
 use crate::fees::op::LowLevelDriveOperation;
-use crate::util::grove_operations::BatchApplyDriveOperation;
 
 use dpp::version::drive_versions::DriveVersion;
 
@@ -43,38 +42,6 @@ impl Drive {
             ),
             version => Err(Error::Drive(DriveError::UnknownVersionMismatch {
                 method: "grove_apply_batch_with_add_costs".to_string(),
-                known_versions: vec![0],
-                received: version,
-            })),
-        }
-    }
-
-    /// Applies the given groveDB operations batch with custom options
-    /// controlling tree deletion behavior.
-    pub fn grove_apply_batch_with_add_costs_with_options(
-        &self,
-        ops: GroveDbOpBatch,
-        validate: bool,
-        transaction: TransactionArg,
-        batch_apply_drive_operation: BatchApplyDriveOperation,
-        drive_operations: &mut Vec<LowLevelDriveOperation>,
-        drive_version: &DriveVersion,
-    ) -> Result<(), Error> {
-        match drive_version
-            .grove_methods
-            .apply
-            .grove_apply_batch_with_options
-        {
-            0 => self.grove_apply_batch_with_add_costs_with_options_v0(
-                ops,
-                validate,
-                transaction,
-                batch_apply_drive_operation,
-                drive_operations,
-                drive_version,
-            ),
-            version => Err(Error::Drive(DriveError::UnknownVersionMismatch {
-                method: "grove_apply_batch_with_add_costs_with_options".to_string(),
                 known_versions: vec![0],
                 received: version,
             })),

--- a/packages/rs-drive/src/util/grove_operations/grove_apply_batch_with_add_costs/v0/mod.rs
+++ b/packages/rs-drive/src/util/grove_operations/grove_apply_batch_with_add_costs/v0/mod.rs
@@ -65,8 +65,6 @@ impl Drive {
             Some(BatchApplyOptions {
                 validate_insertion_does_not_override: validate,
                 validate_insertion_does_not_override_tree: validate,
-                allow_deleting_non_empty_trees: false,
-                deleting_non_empty_trees_returns_error: true,
                 disable_operation_consistency_check: !self.config.batching_consistency_verification,
                 base_root_storage_is_free: true,
                 batch_pause_height: None,

--- a/packages/rs-drive/src/util/grove_operations/grove_apply_batch_with_add_costs/v0/mod.rs
+++ b/packages/rs-drive/src/util/grove_operations/grove_apply_batch_with_add_costs/v0/mod.rs
@@ -6,7 +6,6 @@ use crate::query::GroveError;
 use crate::util::batch::grovedb_op_batch::GroveDbOpBatchV0Methods;
 use crate::util::batch::GroveDbOpBatch;
 use crate::util::grove_operations::push_drive_operation_result;
-use crate::util::grove_operations::BatchApplyDriveOperation;
 use crate::util::storage_flags::StorageFlags;
 use grovedb::batch::{BatchApplyOptions, QualifiedGroveDbOp};
 use grovedb::TransactionArg;
@@ -19,26 +18,6 @@ impl Drive {
         ops: GroveDbOpBatch,
         validate: bool,
         transaction: TransactionArg,
-        drive_operations: &mut Vec<LowLevelDriveOperation>,
-        drive_version: &DriveVersion,
-    ) -> Result<(), Error> {
-        self.grove_apply_batch_with_add_costs_with_options_v0(
-            ops,
-            validate,
-            transaction,
-            BatchApplyDriveOperation::default(),
-            drive_operations,
-            drive_version,
-        )
-    }
-
-    /// Applies the given groveDB operations batch with custom options.
-    pub(super) fn grove_apply_batch_with_add_costs_with_options_v0(
-        &self,
-        ops: GroveDbOpBatch,
-        validate: bool,
-        transaction: TransactionArg,
-        batch_apply_drive_operation: BatchApplyDriveOperation,
         drive_operations: &mut Vec<LowLevelDriveOperation>,
         drive_version: &DriveVersion,
     ) -> Result<(), Error> {
@@ -86,10 +65,8 @@ impl Drive {
             Some(BatchApplyOptions {
                 validate_insertion_does_not_override: validate,
                 validate_insertion_does_not_override_tree: validate,
-                allow_deleting_non_empty_trees: batch_apply_drive_operation
-                    .allow_deleting_non_empty_trees,
-                deleting_non_empty_trees_returns_error: batch_apply_drive_operation
-                    .deleting_non_empty_trees_returns_error,
+                allow_deleting_non_empty_trees: false,
+                deleting_non_empty_trees_returns_error: true,
                 disable_operation_consistency_check: !self.config.batching_consistency_verification,
                 base_root_storage_is_free: true,
                 batch_pause_height: None,

--- a/packages/rs-drive/src/util/grove_operations/grove_apply_partial_batch_with_add_costs/v0/mod.rs
+++ b/packages/rs-drive/src/util/grove_operations/grove_apply_partial_batch_with_add_costs/v0/mod.rs
@@ -50,8 +50,6 @@ impl Drive {
             Some(BatchApplyOptions {
                 validate_insertion_does_not_override: validate,
                 validate_insertion_does_not_override_tree: validate,
-                allow_deleting_non_empty_trees: false,
-                deleting_non_empty_trees_returns_error: true,
                 disable_operation_consistency_check: false,
                 base_root_storage_is_free: true,
                 batch_pause_height: None,

--- a/packages/rs-drive/src/util/grove_operations/grove_batch_operations_costs/mod.rs
+++ b/packages/rs-drive/src/util/grove_operations/grove_batch_operations_costs/mod.rs
@@ -6,7 +6,6 @@ use crate::drive::Drive;
 use crate::error::drive::DriveError;
 use crate::error::Error;
 use crate::fees::op::LowLevelDriveOperation;
-use crate::util::grove_operations::BatchApplyDriveOperation;
 
 use dpp::version::drive_versions::DriveVersion;
 
@@ -50,38 +49,6 @@ impl Drive {
             ),
             version => Err(Error::Drive(DriveError::UnknownVersionMismatch {
                 method: "grove_batch_operations_costs".to_string(),
-                known_versions: vec![0],
-                received: version,
-            })),
-        }
-    }
-
-    /// Like `grove_batch_operations_costs` but with custom options controlling
-    /// tree deletion behavior.
-    pub fn grove_batch_operations_costs_with_options(
-        &self,
-        ops: GroveDbOpBatch,
-        estimated_layer_info: HashMap<KeyInfoPath, EstimatedLayerInformation>,
-        validate: bool,
-        batch_apply_drive_operation: BatchApplyDriveOperation,
-        drive_operations: &mut Vec<LowLevelDriveOperation>,
-        drive_version: &DriveVersion,
-    ) -> Result<(), Error> {
-        match drive_version
-            .grove_methods
-            .costs
-            .grove_batch_operations_costs
-        {
-            0 => self.grove_batch_operations_costs_with_options_v0(
-                ops,
-                estimated_layer_info,
-                validate,
-                batch_apply_drive_operation,
-                drive_operations,
-                drive_version,
-            ),
-            version => Err(Error::Drive(DriveError::UnknownVersionMismatch {
-                method: "grove_batch_operations_costs_with_options".to_string(),
                 known_versions: vec![0],
                 received: version,
             })),

--- a/packages/rs-drive/src/util/grove_operations/grove_batch_operations_costs/v0/mod.rs
+++ b/packages/rs-drive/src/util/grove_operations/grove_batch_operations_costs/v0/mod.rs
@@ -26,8 +26,6 @@ impl Drive {
             Some(BatchApplyOptions {
                 validate_insertion_does_not_override: validate,
                 validate_insertion_does_not_override_tree: validate,
-                allow_deleting_non_empty_trees: false,
-                deleting_non_empty_trees_returns_error: true,
                 disable_operation_consistency_check: false,
                 base_root_storage_is_free: true,
                 batch_pause_height: None,

--- a/packages/rs-drive/src/util/grove_operations/grove_batch_operations_costs/v0/mod.rs
+++ b/packages/rs-drive/src/util/grove_operations/grove_batch_operations_costs/v0/mod.rs
@@ -4,7 +4,6 @@ use crate::fees::op::LowLevelDriveOperation;
 use crate::query::GroveError;
 use crate::util::batch::GroveDbOpBatch;
 use crate::util::grove_operations::push_drive_operation_result;
-use crate::util::grove_operations::BatchApplyDriveOperation;
 use grovedb::batch::estimated_costs::EstimatedCostsType::AverageCaseCostsType;
 use grovedb::batch::{BatchApplyOptions, KeyInfoPath};
 use grovedb::{EstimatedLayerInformation, GroveDb};
@@ -21,37 +20,14 @@ impl Drive {
         drive_operations: &mut Vec<LowLevelDriveOperation>,
         drive_version: &DriveVersion,
     ) -> Result<(), Error> {
-        self.grove_batch_operations_costs_with_options_v0(
-            ops,
-            estimated_layer_info,
-            validate,
-            BatchApplyDriveOperation::default(),
-            drive_operations,
-            drive_version,
-        )
-    }
-
-    /// Like `grove_batch_operations_costs_v0` but with custom options controlling
-    /// tree deletion behavior.
-    pub(super) fn grove_batch_operations_costs_with_options_v0(
-        &self,
-        ops: GroveDbOpBatch,
-        estimated_layer_info: HashMap<KeyInfoPath, EstimatedLayerInformation>,
-        validate: bool,
-        batch_apply_drive_operation: BatchApplyDriveOperation,
-        drive_operations: &mut Vec<LowLevelDriveOperation>,
-        drive_version: &DriveVersion,
-    ) -> Result<(), Error> {
         let cost_context = GroveDb::estimated_case_operations_for_batch(
             AverageCaseCostsType(estimated_layer_info),
             ops.operations,
             Some(BatchApplyOptions {
                 validate_insertion_does_not_override: validate,
                 validate_insertion_does_not_override_tree: validate,
-                allow_deleting_non_empty_trees: batch_apply_drive_operation
-                    .allow_deleting_non_empty_trees,
-                deleting_non_empty_trees_returns_error: batch_apply_drive_operation
-                    .deleting_non_empty_trees_returns_error,
+                allow_deleting_non_empty_trees: false,
+                deleting_non_empty_trees_returns_error: true,
                 disable_operation_consistency_check: false,
                 base_root_storage_is_free: true,
                 batch_pause_height: None,

--- a/packages/rs-drive/src/util/grove_operations/mod.rs
+++ b/packages/rs-drive/src/util/grove_operations/mod.rs
@@ -531,22 +531,3 @@ pub enum GroveDBToUse {
     /// Use a specific checkpoint at the given block height
     Checkpoint(u64),
 }
-
-/// Options controlling how a batch of drive operations is applied to GroveDB.
-#[derive(Debug, Clone, Copy)]
-pub struct BatchApplyDriveOperation {
-    /// Allow `DeleteTree` operations to target trees that still have children.
-    pub allow_deleting_non_empty_trees: bool,
-    /// When `true`, GroveDB returns an error when a non-empty tree deletion is
-    /// attempted (even if allowed).
-    pub deleting_non_empty_trees_returns_error: bool,
-}
-
-impl Default for BatchApplyDriveOperation {
-    fn default() -> Self {
-        Self {
-            allow_deleting_non_empty_trees: false,
-            deleting_non_empty_trees_returns_error: true,
-        }
-    }
-}

--- a/packages/rs-drive/src/util/operations/apply_batch_grovedb_operations/mod.rs
+++ b/packages/rs-drive/src/util/operations/apply_batch_grovedb_operations/mod.rs
@@ -5,7 +5,6 @@ use crate::drive::Drive;
 use crate::error::{drive::DriveError, Error};
 use crate::fees::op::LowLevelDriveOperation;
 use crate::util::batch::GroveDbOpBatch;
-use crate::util::grove_operations::BatchApplyDriveOperation;
 use dpp::version::drive_versions::DriveVersion;
 use grovedb::batch::KeyInfoPath;
 use grovedb::{EstimatedLayerInformation, TransactionArg};
@@ -53,40 +52,6 @@ impl Drive {
             ),
             version => Err(Error::Drive(DriveError::UnknownVersionMismatch {
                 method: "apply_batch_grovedb_operations".to_string(),
-                known_versions: vec![0],
-                received: version,
-            })),
-        }
-    }
-
-    /// Like `apply_batch_grovedb_operations` but with custom options controlling
-    /// tree deletion behavior.
-    pub(crate) fn apply_batch_grovedb_operations_with_options(
-        &self,
-        estimated_costs_only_with_layer_info: Option<
-            HashMap<KeyInfoPath, EstimatedLayerInformation>,
-        >,
-        transaction: TransactionArg,
-        batch_operations: GroveDbOpBatch,
-        batch_apply_drive_operation: BatchApplyDriveOperation,
-        drive_operations: &mut Vec<LowLevelDriveOperation>,
-        drive_version: &DriveVersion,
-    ) -> Result<(), Error> {
-        match drive_version
-            .methods
-            .operations
-            .apply_batch_grovedb_operations_with_options
-        {
-            0 => self.apply_batch_grovedb_operations_with_options_v0(
-                estimated_costs_only_with_layer_info,
-                transaction,
-                batch_operations,
-                batch_apply_drive_operation,
-                drive_operations,
-                drive_version,
-            ),
-            version => Err(Error::Drive(DriveError::UnknownVersionMismatch {
-                method: "apply_batch_grovedb_operations_with_options".to_string(),
                 known_versions: vec![0],
                 received: version,
             })),

--- a/packages/rs-drive/src/util/operations/apply_batch_grovedb_operations/v0/mod.rs
+++ b/packages/rs-drive/src/util/operations/apply_batch_grovedb_operations/v0/mod.rs
@@ -3,7 +3,6 @@ use crate::drive::Drive;
 use crate::error::Error;
 use crate::fees::op::LowLevelDriveOperation;
 use crate::util::batch::GroveDbOpBatch;
-use crate::util::grove_operations::BatchApplyDriveOperation;
 use dpp::version::drive_versions::DriveVersion;
 use grovedb::batch::KeyInfoPath;
 use grovedb::{EstimatedLayerInformation, TransactionArg};
@@ -43,41 +42,6 @@ impl Drive {
                 batch_operations,
                 false,
                 transaction,
-                drive_operations,
-                drive_version,
-            )?;
-        }
-        Ok(())
-    }
-
-    /// Like `apply_batch_grovedb_operations_v0` but with custom options
-    /// controlling tree deletion behavior.
-    pub(super) fn apply_batch_grovedb_operations_with_options_v0(
-        &self,
-        estimated_costs_only_with_layer_info: Option<
-            HashMap<KeyInfoPath, EstimatedLayerInformation>,
-        >,
-        transaction: TransactionArg,
-        batch_operations: GroveDbOpBatch,
-        batch_apply_drive_operation: BatchApplyDriveOperation,
-        drive_operations: &mut Vec<LowLevelDriveOperation>,
-        drive_version: &DriveVersion,
-    ) -> Result<(), Error> {
-        if let Some(estimated_layer_info) = estimated_costs_only_with_layer_info {
-            self.grove_batch_operations_costs_with_options(
-                batch_operations,
-                estimated_layer_info,
-                false,
-                batch_apply_drive_operation,
-                drive_operations,
-                drive_version,
-            )?;
-        } else {
-            self.grove_apply_batch_with_add_costs_with_options(
-                batch_operations,
-                false,
-                transaction,
-                batch_apply_drive_operation,
                 drive_operations,
                 drive_version,
             )?;

--- a/packages/rs-drive/src/util/operations/apply_batch_low_level_drive_operations/mod.rs
+++ b/packages/rs-drive/src/util/operations/apply_batch_low_level_drive_operations/mod.rs
@@ -4,7 +4,6 @@ mod v0;
 use crate::drive::Drive;
 use crate::error::{drive::DriveError, Error};
 use crate::fees::op::LowLevelDriveOperation;
-use crate::util::grove_operations::BatchApplyDriveOperation;
 
 use dpp::version::drive_versions::DriveVersion;
 use grovedb::batch::KeyInfoPath;
@@ -53,40 +52,6 @@ impl Drive {
             ),
             version => Err(Error::Drive(DriveError::UnknownVersionMismatch {
                 method: "apply_batch_low_level_drive_operations".to_string(),
-                known_versions: vec![0],
-                received: version,
-            })),
-        }
-    }
-
-    /// Like `apply_batch_low_level_drive_operations` but with custom options
-    /// controlling tree deletion behavior.
-    pub fn apply_batch_low_level_drive_operations_with_options(
-        &self,
-        estimated_costs_only_with_layer_info: Option<
-            HashMap<KeyInfoPath, EstimatedLayerInformation>,
-        >,
-        transaction: TransactionArg,
-        batch_operations: Vec<LowLevelDriveOperation>,
-        batch_apply_drive_operation: BatchApplyDriveOperation,
-        drive_operations: &mut Vec<LowLevelDriveOperation>,
-        drive_version: &DriveVersion,
-    ) -> Result<(), Error> {
-        match drive_version
-            .methods
-            .operations
-            .apply_batch_low_level_drive_operations_with_options
-        {
-            0 => self.apply_batch_low_level_drive_operations_with_options_v0(
-                estimated_costs_only_with_layer_info,
-                transaction,
-                batch_operations,
-                batch_apply_drive_operation,
-                drive_operations,
-                drive_version,
-            ),
-            version => Err(Error::Drive(DriveError::UnknownVersionMismatch {
-                method: "apply_batch_low_level_drive_operations_with_options".to_string(),
                 known_versions: vec![0],
                 received: version,
             })),

--- a/packages/rs-drive/src/util/operations/apply_batch_low_level_drive_operations/v0/mod.rs
+++ b/packages/rs-drive/src/util/operations/apply_batch_low_level_drive_operations/v0/mod.rs
@@ -3,7 +3,6 @@ use crate::drive::Drive;
 use crate::error::Error;
 use crate::fees::op::LowLevelDriveOperation;
 use crate::util::batch::grovedb_op_batch::GroveDbOpBatchV0Methods;
-use crate::util::grove_operations::BatchApplyDriveOperation;
 use dpp::version::drive_versions::DriveVersion;
 use grovedb::batch::KeyInfoPath;
 use grovedb::{EstimatedLayerInformation, TransactionArg};
@@ -30,37 +29,6 @@ impl Drive {
                 estimated_costs_only_with_layer_info,
                 transaction,
                 grove_db_operations,
-                drive_operations,
-                drive_version,
-            )?;
-        }
-        drive_operations.append(&mut other_operations);
-        Ok(())
-    }
-
-    /// Like `apply_batch_low_level_drive_operations_v0` but with custom options
-    /// controlling tree deletion behavior.
-    pub(crate) fn apply_batch_low_level_drive_operations_with_options_v0(
-        &self,
-        estimated_costs_only_with_layer_info: Option<
-            HashMap<KeyInfoPath, EstimatedLayerInformation>,
-        >,
-        transaction: TransactionArg,
-        batch_operations: Vec<LowLevelDriveOperation>,
-        batch_apply_drive_operation: BatchApplyDriveOperation,
-        drive_operations: &mut Vec<LowLevelDriveOperation>,
-        drive_version: &DriveVersion,
-    ) -> Result<(), Error> {
-        let (grove_db_operations, mut other_operations) =
-            LowLevelDriveOperation::grovedb_operations_batch_consume_with_leftovers(
-                batch_operations,
-            );
-        if !grove_db_operations.is_empty() {
-            self.apply_batch_grovedb_operations_with_options(
-                estimated_costs_only_with_layer_info,
-                transaction,
-                grove_db_operations,
-                batch_apply_drive_operation,
                 drive_operations,
                 drive_version,
             )?;

--- a/packages/rs-platform-version/Cargo.toml
+++ b/packages/rs-platform-version/Cargo.toml
@@ -11,7 +11,7 @@ license = "MIT"
 thiserror = { version = "2.0.12" }
 bincode = { version = "=2.0.1" }
 versioned-feature-core = { git = "https://github.com/dashpay/versioned-feature-core", version = "1.0.0" }
-grovedb-version = { git = "https://github.com/dashpay/grovedb", rev = "a7b878f72279a4893a7e9dc0ab2973ca0b09ce69" }
+grovedb-version = { git = "https://github.com/dashpay/grovedb", rev = "a20add8d9327b31198eebddd9d78d3cbf940367c" }
 
 [features]
 mock-versions = []

--- a/packages/rs-platform-version/Cargo.toml
+++ b/packages/rs-platform-version/Cargo.toml
@@ -11,7 +11,7 @@ license = "MIT"
 thiserror = { version = "2.0.12" }
 bincode = { version = "=2.0.1" }
 versioned-feature-core = { git = "https://github.com/dashpay/versioned-feature-core", version = "1.0.0" }
-grovedb-version = { git = "https://github.com/dashpay/grovedb", rev = "a20add8d9327b31198eebddd9d78d3cbf940367c" }
+grovedb-version = { git = "https://github.com/dashpay/grovedb", rev = "2c9117cf3d77c2ffda060f45242d238fb01dca84" }
 
 [features]
 mock-versions = []

--- a/packages/rs-platform-version/src/version/drive_versions/drive_grove_method_versions/mod.rs
+++ b/packages/rs-platform-version/src/version/drive_versions/drive_grove_method_versions/mod.rs
@@ -69,7 +69,6 @@ pub struct DriveGroveBatchMethodVersions {
 pub struct DriveGroveApplyMethodVersions {
     pub grove_apply_operation: FeatureVersion,
     pub grove_apply_batch: FeatureVersion,
-    pub grove_apply_batch_with_options: FeatureVersion,
     pub grove_apply_partial_batch: FeatureVersion,
 }
 

--- a/packages/rs-platform-version/src/version/drive_versions/drive_grove_method_versions/v1.rs
+++ b/packages/rs-platform-version/src/version/drive_versions/drive_grove_method_versions/v1.rs
@@ -58,7 +58,6 @@ pub const DRIVE_GROVE_METHOD_VERSIONS_V1: DriveGroveMethodVersions = DriveGroveM
     apply: DriveGroveApplyMethodVersions {
         grove_apply_operation: 0,
         grove_apply_batch: 0,
-        grove_apply_batch_with_options: 0,
         grove_apply_partial_batch: 0,
     },
     costs: DriveGroveCostMethodVersions {

--- a/packages/rs-platform-version/src/version/drive_versions/mod.rs
+++ b/packages/rs-platform-version/src/version/drive_versions/mod.rs
@@ -161,16 +161,13 @@ pub struct DriveOperationsMethodVersion {
     pub apply_partial_batch_low_level_drive_operations: FeatureVersion,
     pub apply_partial_batch_grovedb_operations: FeatureVersion,
     pub apply_batch_low_level_drive_operations: FeatureVersion,
-    pub apply_batch_low_level_drive_operations_with_options: FeatureVersion,
     pub apply_batch_grovedb_operations: FeatureVersion,
-    pub apply_batch_grovedb_operations_with_options: FeatureVersion,
 }
 
 #[derive(Clone, Debug, Default)]
 pub struct DriveBatchOperationsMethodVersion {
     pub convert_drive_operations_to_grove_operations: FeatureVersion,
     pub apply_drive_operations: FeatureVersion,
-    pub apply_drive_operations_with_options: FeatureVersion,
 }
 
 #[derive(Clone, Debug, Default)]

--- a/packages/rs-platform-version/src/version/drive_versions/v1.rs
+++ b/packages/rs-platform-version/src/version/drive_versions/v1.rs
@@ -80,15 +80,12 @@ pub const DRIVE_VERSION_V1: DriveVersion = DriveVersion {
             apply_partial_batch_low_level_drive_operations: 0,
             apply_partial_batch_grovedb_operations: 0,
             apply_batch_low_level_drive_operations: 0,
-            apply_batch_low_level_drive_operations_with_options: 0,
             apply_batch_grovedb_operations: 0,
-            apply_batch_grovedb_operations_with_options: 0,
         },
         state_transitions: DRIVE_STATE_TRANSITION_METHOD_VERSIONS_V1,
         batch_operations: DriveBatchOperationsMethodVersion {
             convert_drive_operations_to_grove_operations: 0,
             apply_drive_operations: 0,
-            apply_drive_operations_with_options: 0,
         },
         platform_state: DrivePlatformStateMethodVersions {
             fetch_platform_state_bytes: 0,

--- a/packages/rs-platform-version/src/version/drive_versions/v2.rs
+++ b/packages/rs-platform-version/src/version/drive_versions/v2.rs
@@ -80,15 +80,12 @@ pub const DRIVE_VERSION_V2: DriveVersion = DriveVersion {
             apply_partial_batch_low_level_drive_operations: 0,
             apply_partial_batch_grovedb_operations: 0,
             apply_batch_low_level_drive_operations: 0,
-            apply_batch_low_level_drive_operations_with_options: 0,
             apply_batch_grovedb_operations: 0,
-            apply_batch_grovedb_operations_with_options: 0,
         },
         state_transitions: DRIVE_STATE_TRANSITION_METHOD_VERSIONS_V1,
         batch_operations: DriveBatchOperationsMethodVersion {
             convert_drive_operations_to_grove_operations: 0,
             apply_drive_operations: 0,
-            apply_drive_operations_with_options: 0,
         },
         platform_state: DrivePlatformStateMethodVersions {
             fetch_platform_state_bytes: 0,

--- a/packages/rs-platform-version/src/version/drive_versions/v3.rs
+++ b/packages/rs-platform-version/src/version/drive_versions/v3.rs
@@ -80,15 +80,12 @@ pub const DRIVE_VERSION_V3: DriveVersion = DriveVersion {
             apply_partial_batch_low_level_drive_operations: 0,
             apply_partial_batch_grovedb_operations: 0,
             apply_batch_low_level_drive_operations: 0,
-            apply_batch_low_level_drive_operations_with_options: 0,
             apply_batch_grovedb_operations: 0,
-            apply_batch_grovedb_operations_with_options: 0,
         },
         state_transitions: DRIVE_STATE_TRANSITION_METHOD_VERSIONS_V1,
         batch_operations: DriveBatchOperationsMethodVersion {
             convert_drive_operations_to_grove_operations: 0,
             apply_drive_operations: 0,
-            apply_drive_operations_with_options: 0,
         },
         platform_state: DrivePlatformStateMethodVersions {
             fetch_platform_state_bytes: 0,

--- a/packages/rs-platform-version/src/version/drive_versions/v4.rs
+++ b/packages/rs-platform-version/src/version/drive_versions/v4.rs
@@ -80,15 +80,12 @@ pub const DRIVE_VERSION_V4: DriveVersion = DriveVersion {
             apply_partial_batch_low_level_drive_operations: 0,
             apply_partial_batch_grovedb_operations: 0,
             apply_batch_low_level_drive_operations: 0,
-            apply_batch_low_level_drive_operations_with_options: 0,
             apply_batch_grovedb_operations: 0,
-            apply_batch_grovedb_operations_with_options: 0,
         },
         state_transitions: DRIVE_STATE_TRANSITION_METHOD_VERSIONS_V1,
         batch_operations: DriveBatchOperationsMethodVersion {
             convert_drive_operations_to_grove_operations: 0,
             apply_drive_operations: 0,
-            apply_drive_operations_with_options: 0,
         },
         platform_state: DrivePlatformStateMethodVersions {
             fetch_platform_state_bytes: 0,

--- a/packages/rs-platform-version/src/version/drive_versions/v5.rs
+++ b/packages/rs-platform-version/src/version/drive_versions/v5.rs
@@ -82,15 +82,12 @@ pub const DRIVE_VERSION_V5: DriveVersion = DriveVersion {
             apply_partial_batch_low_level_drive_operations: 0,
             apply_partial_batch_grovedb_operations: 0,
             apply_batch_low_level_drive_operations: 0,
-            apply_batch_low_level_drive_operations_with_options: 0,
             apply_batch_grovedb_operations: 0,
-            apply_batch_grovedb_operations_with_options: 0,
         },
         state_transitions: DRIVE_STATE_TRANSITION_METHOD_VERSIONS_V1,
         batch_operations: DriveBatchOperationsMethodVersion {
             convert_drive_operations_to_grove_operations: 0,
             apply_drive_operations: 0,
-            apply_drive_operations_with_options: 0,
         },
         platform_state: DrivePlatformStateMethodVersions {
             fetch_platform_state_bytes: 0,

--- a/packages/rs-platform-version/src/version/drive_versions/v6.rs
+++ b/packages/rs-platform-version/src/version/drive_versions/v6.rs
@@ -84,15 +84,12 @@ pub const DRIVE_VERSION_V6: DriveVersion = DriveVersion {
             apply_partial_batch_low_level_drive_operations: 0,
             apply_partial_batch_grovedb_operations: 0,
             apply_batch_low_level_drive_operations: 0,
-            apply_batch_low_level_drive_operations_with_options: 0,
             apply_batch_grovedb_operations: 0,
-            apply_batch_grovedb_operations_with_options: 0,
         },
         state_transitions: DRIVE_STATE_TRANSITION_METHOD_VERSIONS_V2, //changed
         batch_operations: DriveBatchOperationsMethodVersion {
             convert_drive_operations_to_grove_operations: 0,
             apply_drive_operations: 0,
-            apply_drive_operations_with_options: 0,
         },
         platform_state: DrivePlatformStateMethodVersions {
             fetch_platform_state_bytes: 0,

--- a/packages/rs-platform-version/src/version/drive_versions/v7.rs
+++ b/packages/rs-platform-version/src/version/drive_versions/v7.rs
@@ -81,15 +81,12 @@ pub const DRIVE_VERSION_V7: DriveVersion = DriveVersion {
             apply_partial_batch_low_level_drive_operations: 0,
             apply_partial_batch_grovedb_operations: 0,
             apply_batch_low_level_drive_operations: 0,
-            apply_batch_low_level_drive_operations_with_options: 0,
             apply_batch_grovedb_operations: 0,
-            apply_batch_grovedb_operations_with_options: 0,
         },
         state_transitions: DRIVE_STATE_TRANSITION_METHOD_VERSIONS_V2,
         batch_operations: DriveBatchOperationsMethodVersion {
             convert_drive_operations_to_grove_operations: 0,
             apply_drive_operations: 0,
-            apply_drive_operations_with_options: 0,
         },
         platform_state: DrivePlatformStateMethodVersions {
             fetch_platform_state_bytes: 0,

--- a/packages/rs-platform-version/src/version/mocks/v2_test.rs
+++ b/packages/rs-platform-version/src/version/mocks/v2_test.rs
@@ -118,14 +118,11 @@ pub const TEST_PLATFORM_V2: PlatformVersion = PlatformVersion {
                 apply_partial_batch_low_level_drive_operations: 0,
                 apply_partial_batch_grovedb_operations: 0,
                 apply_batch_low_level_drive_operations: 0,
-                apply_batch_low_level_drive_operations_with_options: 0,
                 apply_batch_grovedb_operations: 0,
-                apply_batch_grovedb_operations_with_options: 0,
             },
             batch_operations: DriveBatchOperationsMethodVersion {
                 convert_drive_operations_to_grove_operations: 0,
                 apply_drive_operations: 0,
-                apply_drive_operations_with_options: 0,
             },
             state_transitions: DRIVE_STATE_TRANSITION_METHOD_VERSIONS_V1,
             platform_state: DrivePlatformStateMethodVersions {

--- a/packages/rs-sdk/src/platform/transition/put_identity.rs
+++ b/packages/rs-sdk/src/platform/transition/put_identity.rs
@@ -16,6 +16,7 @@ use dpp::identity::IdentityPublicKey;
 use dpp::prelude::{AddressNonce, AssetLockProof, Identity};
 use dpp::state_transition::identity_create_from_addresses_transition::methods::IdentityCreateFromAddressesTransitionMethodsV0;
 use dpp::state_transition::identity_create_from_addresses_transition::IdentityCreateFromAddressesTransition;
+use dpp::state_transition::identity_id_from_input_addresses;
 use dpp::state_transition::proof_result::StateTransitionProofResult;
 use dpp::state_transition::StateTransition;
 use drive_proof_verifier::types::AddressInfos;
@@ -169,6 +170,12 @@ async fn put_identity_with_address_funding<
         .and_then(|settings| settings.user_fee_increase)
         .unwrap_or_default();
 
+    // Compute the expected identity ID deterministically from the input addresses
+    // and nonces BEFORE they're moved into try_from_inputs_with_signer. This must
+    // NOT use identity.id(), which may be a caller-supplied placeholder that doesn't
+    // match the platform-computed ID. See https://github.com/dashpay/platform/issues/3095
+    let expected_identity_id = identity_id_from_input_addresses(&inputs)?;
+
     let state_transition = IdentityCreateFromAddressesTransition::try_from_inputs_with_signer(
         identity,
         inputs,
@@ -179,6 +186,7 @@ async fn put_identity_with_address_funding<
         user_fee_increase,
         sdk.version(),
     )?;
+
     ensure_valid_state_transition_structure(&state_transition, sdk.version())?;
 
     match state_transition
@@ -190,11 +198,10 @@ async fn put_identity_with_address_funding<
             address_infos_map,
         ) => {
             let proved_identity_id = proved_identity.id();
-            if proved_identity_id != identity.id() {
+            if proved_identity_id != expected_identity_id {
                 return Err(Error::InvalidProvedResponse(format!(
-                    "proof returned identity {} but {} was created",
-                    proved_identity_id,
-                    identity.id()
+                    "proof returned identity {} but {} was expected (derived from input addresses)",
+                    proved_identity_id, expected_identity_id
                 )));
             }
 


### PR DESCRIPTION
## Summary
- Upgrades grovedb to rev `a20add8d` which replaces global `BatchApplyOptions` fields (`allow_deleting_non_empty_trees`, `deleting_non_empty_trees_returns_error`) with per-op `SubelementsDeletionBehavior` enum on `DeleteTree` operations
- Uses `DontCheck` for `batch_delete_up_tree_while_empty` (caller already verifies emptiness), `DeleteChildren` for `delete_proposers_tree` (intentionally non-empty tree)
- Updates `GroveOp::DeleteTree` pattern matches for the new 2-field variant
- Updates proof size assertions for latest protocol version and fee assertions in drive-abci tests

## Issue being addressed
Adapts platform to [grovedb PR #634](https://github.com/niceDeve/grovedb/pull/634) which moves deletion behavior from a batch-global option to a per-operation setting.

## Test plan
- [x] `cargo test -p drive-abci` — all 1212 tests pass
- [x] `test_initial_state_structure_proper_heights_in_latest_protocol_version` — passes
- [ ] Older protocol version proof height tests (first, v10, v11) fail due to grovedb sum tree proof encoding changes — these are upstream grovedb issues that need separate resolution

🤖 Generated with [Claude Code](https://claude.com/claude-code)