### PR TITLE
test(sdk): fix functional tests for local network and token config update

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -6,6 +6,7 @@ ignore:
   - "**/test_utils/**"
   - "**/tests.rs"
   - "**/tests/**"
+  - "**/test/**"
   - "packages/strategy-tests/**"
   - "packages/rs-sdk-ffi/**"
   - "packages/rs-platform-wallet-ffi/**"

--- a/.github/actions/local-network/action.yaml
+++ b/.github/actions/local-network/action.yaml
@@ -85,7 +85,6 @@ runs:
         # Replace Drive and RS-DAPI images with new org and tag in dashmate config
         sed -i -E "s/dashpay\/(drive|rs-dapi):[^\"]+/${{ inputs.image_org }}\/\1:${SHA_TAG}/g" ${{ env.HOME }}/.dashmate/config.json
 
-        cat ${{ env.HOME }}/.dashmate/config.json
 
     - name: Start local network
       shell: bash

--- a/packages/rs-drive-abci/src/execution/platform_events/initialization/create_genesis_state/test/tokens.rs
+++ b/packages/rs-drive-abci/src/execution/platform_events/initialization/create_genesis_state/test/tokens.rs
@@ -276,7 +276,14 @@ impl<C> Platform<C> {
             keeps_history: TokenKeepsHistoryRulesV0::default().into(),
             start_as_paused: false,
             allow_transfer_to_frozen_balance: true,
-            max_supply_change_rules: ChangeControlRulesV0::default().into(),
+            max_supply_change_rules: ChangeControlRulesV0 {
+                authorized_to_make_change: AuthorizedActionTakers::ContractOwner,
+                admin_action_takers: Default::default(),
+                changing_authorized_action_takers_to_no_one_allowed: false,
+                changing_admin_action_takers_to_no_one_allowed: false,
+                self_changing_admin_action_takers_allowed: false,
+            }
+            .into(),
             distribution_rules: TokenDistributionRulesV0 {
                 perpetual_distribution: Some(TokenPerpetualDistribution::V0(
                     TokenPerpetualDistributionV0 {

--- a/packages/wasm-sdk/src/context_provider.rs
+++ b/packages/wasm-sdk/src/context_provider.rs
@@ -168,13 +168,13 @@ impl WasmTrustedContext {
 
     /// Pre-fetch quorum keys and masternode addresses for a local network.
     ///
-    /// Uses the default local quorum sidecar URL (`http://127.0.0.1:2444`).
+    /// Uses the default local quorum sidecar URL (`http://127.0.0.1:22444`).
     ///
     /// Returns a ready-to-use `WasmTrustedContext` that can be passed to
     /// `WasmSdkBuilder.local().withTrustedContext(context)`.
     #[wasm_bindgen(js_name = "prefetchLocal")]
     pub async fn prefetch_local() -> Result<WasmTrustedContext, WasmSdkError> {
-        Self::prefetch_local_with_url("http://127.0.0.1:2444").await
+        Self::prefetch_local_with_url("http://127.0.0.1:22444").await
     }
 
     /// Pre-fetch quorum keys and masternode addresses for a local network

--- a/packages/wasm-sdk/tests/functional/transitions/tokens.spec.ts
+++ b/packages/wasm-sdk/tests/functional/transitions/tokens.spec.ts
@@ -205,8 +205,9 @@ describe('Token State Transitions', function describeTokenStateTransitions() {
       // Token operations require CRITICAL security level (key index 1)
       const { signer, identityKey } = createTestSignerAndKey(sdk, 1, 1);
 
-      // Create a MaxSupply config change item (set max supply to 10000)
-      const configurationChangeItem = sdk.TokenConfigurationChangeItem.MaxSupplyItem(10000n);
+      // Create a MaxSupply config change item (set max supply to 1_000_000)
+      // Must be above the current supply (base 100_000 + perpetual distribution)
+      const configurationChangeItem = sdk.TokenConfigurationChangeItem.MaxSupplyItem(1_000_000n);
 
       const result = await client.tokenConfigUpdate({
         dataContractId: testData.tokenContracts[0].contractId,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

WASM SDK functional tests were failing in two ways:
1. All 18 test suites failed in their `before all` hook because `WasmTrustedContext.prefetchLocal()` used the wrong port (`2444` instead of `22444`) — local dashmate applies a `+20000` offset to the base port
2. The `tokenConfigUpdate` test failed because the test tried to set `maxSupply` to `10000`, but the token's current supply was already `100300` (base `100000` + perpetual distribution)

Additionally, Codecov's patch check was incorrectly flagging test genesis data files under `test/` directories.

## What was done?
<!--- Describe your changes in detail -->

- **`packages/wasm-sdk/src/context_provider.rs`**: Fix `prefetch_local()` to use correct quorum sidecar port `22444` (was `2444`); update doc comment accordingly
- **`packages/wasm-sdk/tests/functional/transitions/tokens.spec.ts`**: Increase `MaxSupplyItem` value from `10000n` to `1_000_000n` to exceed the token's current supply
- **`packages/rs-drive-abci/src/execution/platform_events/initialization/create_genesis_state/test/tokens.rs`**: Explicitly set `max_supply_change_rules` to allow `ContractOwner` to change max supply (was defaulting to `NoOne`, causing auth rejection)
- **`.github/actions/local-network/action.yaml`**: Remove `cat` of `config.json` — config may contain sensitive data and the output is not useful
- **`.codecov.yml`**: Add `**/test/**` to ignore list — consistent with existing `**/tests/**` exclusion; test fixture/genesis data files should not count against patch coverage

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->

- `packages/wasm-sdk/tests/functional/transitions/tokens.spec.ts` — covers the `tokenConfigUpdate` fix; 87 passing, 0 failing
- `packages/rs-drive-abci/src/execution/platform_events/initialization/create_genesis_state/test/tokens.rs` — verified via `drive-abci` unit tests (all passing)
- CI functional tests: 18 failing → 0 failing after port and genesis data fixes

## Breaking Changes
<!--- Please describe any breaking changes your code introduces -->

None.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [x] I have made corresponding changes to the documentation if needed

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone