### PR TITLE
ci(swift-sdk): skip PR comment for forked PRs

### DIFF
--- a/.github/workflows/swift-sdk-build.yml
+++ b/.github/workflows/swift-sdk-build.yml
@@ -259,7 +259,7 @@ jobs:
           retention-days: 14
 
       - name: Comment/update PR with artifact link and usage guide (skip if unchanged)
-        if: github.event_name == 'pull_request'
+        if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
         uses: actions/github-script@v7
         with:
           script: |


### PR DESCRIPTION
## Issue

The Swift SDK build workflow fails on forked PRs because the "Comment/update PR with artifact link" step tries to write a PR comment, but forked PRs using `on: pull_request` get a read-only `GITHUB_TOKEN` → 403.

This was missed when #3120 fixed the same class of issue in the main CI workflows.

## Fix

Skip the comment step entirely for fork PRs by checking `github.event.pull_request.head.repo.full_name == github.repository`. In-repo PRs still get the artifact comment as before.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * CI step behavior tightened: the PR workflow step now runs only for pull requests originating from the same repository; contributions from forks will skip this step.
  * This reduces unintended runs for external PRs while preserving other workflow behaviors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->