### PR TITLE
ci(drive): move long-running upgrade tests to nightly schedule

### DIFF
--- a/.github/workflows/tests-rs-nightly-long-running.yml
+++ b/.github/workflows/tests-rs-nightly-long-running.yml
@@ -1,0 +1,88 @@
+name: "Nightly: Long-running Rust tests"
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 22 * * *" # 22:00 UTC daily, 1 hour before main nightly tests
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  upgrade-fork-tests:
+    name: Version upgrade tests
+    runs-on: ubuntu-24.04
+    timeout-minutes: 45
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - name: Check out repo
+        uses: actions/checkout@v4
+
+      - name: Setup Rust
+        uses: ./.github/actions/rust
+
+      - name: Setup sccache
+        uses: ./.github/actions/sccache
+        with:
+          bucket: ${{ vars.CACHE_S3_BUCKET }}
+          region: ${{ vars.CACHE_REGION }}
+          endpoint: ${{ vars.CACHE_S3_ENDPOINT }}
+          access_key_id: ${{ secrets.CACHE_KEY_ID }}
+          secret_access_key: ${{ secrets.CACHE_SECRET_KEY }}
+
+      - name: Install librocksdb
+        uses: ./.github/actions/librocksdb
+
+      - name: Run ignored (long-running) tests
+        run: |
+          ulimit -c unlimited
+          RUST_MIN_STACK=4194304 cargo test \
+            --package drive-abci \
+            --test strategy_tests \
+            --all-features \
+            --locked \
+            -- --ignored
+        env:
+          SCCACHE_S3_KEY_PREFIX: ${{ runner.os }}/sccache/${{ runner.arch }}/linux-gnu
+          ROCKSDB_STATIC: "/opt/rocksdb/usr/local/lib/librocksdb.a"
+          ROCKSDB_LIB_DIR: "/opt/rocksdb/usr/local/lib"
+          SNAPPY_STATIC: "/usr/lib/x86_64-linux-gnu/libsnappy.a"
+          SNAPPY_LIB_DIR: "/usr/lib/x86_64-linux-gnu"
+
+      - name: Collect crash artifacts
+        if: failure()
+        run: |
+          set -euo pipefail
+          shopt -s nullglob
+
+          if ! compgen -G "/cores/*" > /dev/null; then
+            echo "No core dumps were produced; skipping artifact archive."
+            exit 0
+          fi
+
+          ARTIFACT_DIR=crash-artifacts
+          rm -rf "${ARTIFACT_DIR}"
+          mkdir -p "${ARTIFACT_DIR}/cores" "${ARTIFACT_DIR}/binaries"
+
+          cp -a /cores/. "${ARTIFACT_DIR}/cores/"
+
+          BIN_PREFIX=drive_abci
+          for path in target/debug/deps/${BIN_PREFIX}-* target/debug/${BIN_PREFIX}-*; do
+            if [[ -f "$path" && -x "$path" ]]; then
+              cp -a "$path" "${ARTIFACT_DIR}/binaries/"
+            fi
+          done
+
+          (cd "${ARTIFACT_DIR}" && zip -9 -r ../core-dumps.zip .)
+
+      - name: Upload core dumps
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: core-dumps-drive-abci-nightly
+          path: core-dumps.zip
+          if-no-files-found: ignore
+          retention-days: 3

--- a/packages/rs-drive-abci/tests/strategy_tests/test_cases/upgrade_fork_tests.rs
+++ b/packages/rs-drive-abci/tests/strategy_tests/test_cases/upgrade_fork_tests.rs
@@ -30,6 +30,7 @@ mod tests {
     use strategy_tests::{IdentityInsertInfo, StartAddresses, StartIdentities, Strategy};
 
     #[test]
+    #[ignore] // Long-running: runs in nightly CI only
     #[stack_size(4 * 1024 * 1024)]
     fn run_chain_version_upgrade() {
         let platform_version = PlatformVersion::first();
@@ -544,6 +545,7 @@ mod tests {
     }
 
     #[test]
+    #[ignore] // Long-running: runs in nightly CI only
     #[stack_size(4 * 1024 * 1024)]
     fn run_chain_version_upgrade_slow_upgrade() {
         let strategy = NetworkStrategy {
@@ -770,6 +772,7 @@ mod tests {
     }
 
     #[test]
+    #[ignore] // Long-running: runs in nightly CI only
     #[stack_size(4 * 1024 * 1024)]
     fn run_chain_version_upgrade_slow_upgrade_quick_reversion_after_lock_in() {
         drive_abci::logging::init_for_tests(LogLevel::Silent);
@@ -1097,6 +1100,7 @@ mod tests {
     }
 
     #[test]
+    #[ignore] // Long-running: runs in nightly CI only
     #[stack_size(4 * 1024 * 1024)]
     fn run_chain_version_upgrade_multiple_versions() {
         let strategy = NetworkStrategy {


### PR DESCRIPTION
## Issue being fixed or feature implemented

Long-running version upgrade strategy tests (15-20s locally, slower on CI) run on every PR push, consuming CI resources unnecessarily. These tests don't need to run on every commit — nightly coverage is sufficient.

## What was done?

- Marked 4 slow upgrade fork tests with `#[ignore]` in `upgrade_fork_tests.rs`:
  - `run_chain_version_upgrade` (~6s local)
  - `run_chain_version_upgrade_slow_upgrade` (~15s local)
  - `run_chain_version_upgrade_slow_upgrade_quick_reversion_after_lock_in` (~20s local)
  - `run_chain_version_upgrade_multiple_versions` (~7s local)
- Kept `run_chain_quick_version_upgrade` (~0.8s) in regular CI
- Added `.github/workflows/tests-rs-nightly-long-running.yml`:
  - Runs at 22:00 UTC daily (1 hour before the main nightly tests at 23:00 UTC)
  - Executes `cargo test --package drive-abci --test strategy_tests -- --ignored`
  - Also supports `workflow_dispatch` for manual runs
  - Includes crash artifact collection on failure

## How Has This Been Tested?

All 5 upgrade tests verified locally with `cargo test -- --ignored`. The `#[ignore]` attribute is standard Rust — `cargo test` skips ignored tests by default, and `cargo test -- --ignored` runs only ignored tests.

## Breaking Changes

None.

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [x] I have made corresponding changes to the documentation if needed

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Marked long-running tests to execute in automated nightly CI runs.

* **Chores**
  * Added new nightly workflow for continuous integration, configured with sccache optimization, core dump collection on failures, and artifact retention.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->