### PR TITLE
fix(ci): target only upgrade_fork_tests in nightly workflow

### DIFF
--- a/.github/workflows/tests-rs-nightly-long-running.yml
+++ b/.github/workflows/tests-rs-nightly-long-running.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Install librocksdb
         uses: ./.github/actions/librocksdb
 
-      - name: Run ignored (long-running) tests
+      - name: Run nightly-only upgrade fork tests
         run: |
           ulimit -c unlimited
           RUST_MIN_STACK=4194304 cargo test \
@@ -44,7 +44,7 @@ jobs:
             --test strategy_tests \
             --all-features \
             --locked \
-            -- --ignored
+            -- --ignored "upgrade_fork_tests"
         env:
           SCCACHE_S3_KEY_PREFIX: ${{ runner.os }}/sccache/${{ runner.arch }}/linux-gnu
           ROCKSDB_STATIC: "/opt/rocksdb/usr/local/lib/librocksdb.a"


### PR DESCRIPTION
## Issue being fixed or feature implemented

The nightly workflow used `-- --ignored` which would run **all** ignored tests, including pre-existing `#[ignore]` tests in other modules (logging, config, check_tx, document_query, token distribution) that are intentionally skipped.

## What was done?

Added a test name filter so the nightly workflow only runs ignored tests matching `upgrade_fork_tests`:

```bash
-- --ignored "upgrade_fork_tests"
```

## How Has This Been Tested?

Verified locally that `cargo test --test strategy_tests -- --ignored "upgrade_fork_tests"` runs exactly 4 tests (the upgrade fork tests) and not the 9 other `#[ignore]` tests in the crate.

## Breaking Changes

None.

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [x] I have made corresponding changes to the documentation if needed

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal testing infrastructure and CI/CD workflow configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->