### PR TITLE
fix(platform-wallet): fix flaky Base58 identifier length assertion

### DIFF
--- a/packages/rs-platform-wallet-ffi/tests/comprehensive_tests.rs
+++ b/packages/rs-platform-wallet-ffi/tests/comprehensive_tests.rs
@@ -526,7 +526,12 @@ fn test_identifier_operations() {
         assert!(!id_string.is_null());
 
         let id_str = std::ffi::CStr::from_ptr(id_string).to_str().unwrap();
-        assert_eq!(id_str.len(), 44); // Base58-encoded identifier is 44 chars
+        // Base58-encoded 32-byte identifier is 43-44 chars (variable length encoding)
+        assert!(
+            id_str.len() == 43 || id_str.len() == 44,
+            "Expected Base58 identifier length 43-44, got {}",
+            id_str.len()
+        );
 
         // Convert back from string
         let mut id2 = IdentifierBytes { bytes: [0u8; 32] };


### PR DESCRIPTION
## Issue being fixed or feature implemented

`test_identifier_operations` in `platform-wallet-ffi` intermittently fails because it asserts that a Base58-encoded 32-byte identifier is exactly 44 characters. Base58 encoding produces variable-length output (43-44 chars for 32 bytes), so the test fails when the random identifier happens to encode to 43 chars.

Discovered during CI run of #3244 — shard 6 failed with `assertion left == right failed: left: 43, right: 44` at `comprehensive_tests.rs:529`.

## What was done?

- Changed `assert_eq!(id_str.len(), 44)` to accept either 43 or 44 characters, matching the actual Base58 encoding behavior

## How Has This Been Tested?

- The fix is a test-only change — the assertion now matches the correct behavior of Base58 encoding

## Breaking Changes

None.

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [ ] I have made corresponding changes to the documentation if needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated identifier validation tests to support flexible length requirements with improved error messaging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->