### PR TITLE
ci(tests): use mold linker for faster test binary linking

### DIFF
--- a/.github/workflows/tests-rs-workspace.yml
+++ b/.github/workflows/tests-rs-workspace.yml
@@ -34,6 +34,14 @@ jobs:
           sed -i 's/\["cdylib"\]/["rlib"]/' packages/wasm-sdk/Cargo.toml
           sed -i 's/\["staticlib", "cdylib", "rlib"\]/["staticlib", "rlib"]/g' packages/rs-sdk-ffi/Cargo.toml packages/rs-platform-wallet-ffi/Cargo.toml
 
+      - name: Install mold linker
+        run: sudo apt-get install -y mold
+
+      - name: Configure mold as linker
+        run: |
+          sed -i '/^\[target\.x86_64-unknown-linux-gnu\]$/a linker = "clang"' .cargo/config.toml
+          sed -i '/^\[target\.x86_64-unknown-linux-gnu\]/,/^rustflags/{s/^rustflags = \[/rustflags = [\n    "-C", "link-arg=-fuse-ld=mold",/}' .cargo/config.toml
+
       - name: Setup Rust
         uses: ./.github/actions/rust
 
@@ -153,6 +161,14 @@ jobs:
           sed -i 's/\["cdylib", "lib"\]/["lib"]/' packages/wasm-dpp2/Cargo.toml
           sed -i 's/\["cdylib"\]/["rlib"]/' packages/wasm-sdk/Cargo.toml
           sed -i 's/\["staticlib", "cdylib", "rlib"\]/["staticlib", "rlib"]/g' packages/rs-sdk-ffi/Cargo.toml packages/rs-platform-wallet-ffi/Cargo.toml
+
+      - name: Install mold linker
+        run: sudo apt-get install -y mold
+
+      - name: Configure mold as linker
+        run: |
+          sed -i '/^\[target\.x86_64-unknown-linux-gnu\]$/a linker = "clang"' .cargo/config.toml
+          sed -i '/^\[target\.x86_64-unknown-linux-gnu\]/,/^rustflags/{s/^rustflags = \[/rustflags = [\n    "-C", "link-arg=-fuse-ld=mold",/}' .cargo/config.toml
 
       - name: Setup Rust
         uses: ./.github/actions/rust


### PR DESCRIPTION
## Issue being fixed or feature implemented

Test compilation in CI is bottlenecked on linking ~20 large test binaries (100-170M each). Even with 100% sccache hit rate, the compile phase takes ~3 minutes due to link time.

## What was done?

- Install `mold` linker via apt on CI runners
- Configure mold as the linker for `x86_64-unknown-linux-gnu` in `.cargo/config.toml` (appended at CI time, not committed)
- Applied to both the sharded test job and the ZK test job

Mold is 2-5x faster than lld for linking large binaries. Expected savings: ~30-60 seconds per shard.

## How Has This Been Tested?

- CI will run on this PR — compare compile times against baseline (previous run showed ~3min compile with 100% sccache hits)
- First run will have sccache misses due to changed rustflags; second run will show true steady-state improvement
- Tested sed commands locally to verify correct `.cargo/config.toml` modification

## Breaking Changes

None — CI-only changes.

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [ ] I have made corresponding changes to the documentation if needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized build infrastructure for Linux environments.

---

**Note:** This is an internal build configuration update with no visible impact to end-users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->