### PR TITLE
ci(tests): add self-hosted Mac runner with Ubuntu shard fallback

### DIFF
--- a/.github/workflows/tests-rs-doctests.yml
+++ b/.github/workflows/tests-rs-doctests.yml
@@ -6,11 +6,39 @@ jobs:
     name: Doctests
     runs-on: ubuntu-24.04
     timeout-minutes: 20
+    permissions:
+      id-token: write
+      contents: read
     steps:
+      - name: Wait and check if Mac runner is available
+        id: check-mac
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          sleep 15
+          MAC_STATUS=$(gh api repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/jobs \
+            --jq '.jobs[] | select(.name == "Rust workspace tests / Tests (macOS)") | .status' 2>/dev/null || echo "unknown")
+          echo "mac-status=$MAC_STATUS" >> "$GITHUB_OUTPUT"
+          if [ "$MAC_STATUS" = "in_progress" ]; then
+            echo "Mac runner picked up the job — skipping Ubuntu doctests"
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "Mac runner not available (status: $MAC_STATUS) — running doctests on Ubuntu"
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Free disk space
+        if: steps.check-mac.outputs.skip == 'false'
+        run: |
+          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /usr/local/share/powershell /usr/share/swift
+          df -h /
+
       - name: Check out repo
+        if: steps.check-mac.outputs.skip == 'false'
         uses: actions/checkout@v4
 
       - name: Strip cdylib crate-types (incompatible with static rocksdb)
+        if: steps.check-mac.outputs.skip == 'false'
         run: |
           sed -i 's/\["cdylib", "rlib"\]/["rlib"]/' packages/rs-sdk/Cargo.toml packages/wasm-drive-verify/Cargo.toml
           sed -i 's/\["cdylib", "lib"\]/["lib"]/' packages/wasm-dpp2/Cargo.toml
@@ -18,16 +46,37 @@ jobs:
           sed -i 's/\["staticlib", "cdylib", "rlib"\]/["staticlib", "rlib"]/g' packages/rs-sdk-ffi/Cargo.toml packages/rs-platform-wallet-ffi/Cargo.toml
 
       - name: Setup Rust
+        if: steps.check-mac.outputs.skip == 'false'
         uses: ./.github/actions/rust
 
-      - uses: Swatinem/rust-cache@v2
+      - name: Setup sccache
+        if: steps.check-mac.outputs.skip == 'false'
+        uses: ./.github/actions/sccache
         with:
-          cache-on-failure: "true"
+          bucket: ${{ vars.CACHE_S3_BUCKET }}
+          region: ${{ vars.CACHE_REGION }}
+          endpoint: ${{ vars.CACHE_S3_ENDPOINT }}
+          access_key_id: ${{ secrets.CACHE_KEY_ID }}
+          secret_access_key: ${{ secrets.CACHE_SECRET_KEY }}
+
+      - name: Install librocksdb
+        if: steps.check-mac.outputs.skip == 'false'
+        uses: ./.github/actions/librocksdb
 
       - name: Run doctests
+        if: steps.check-mac.outputs.skip == 'false'
         run: |
           cargo test \
             --workspace \
             --all-features \
             --locked \
             --doc
+        env:
+          CARGO_INCREMENTAL: "0"
+          CARGO_PROFILE_DEV_DEBUG: "0"
+          CARGO_PROFILE_DEV_CODEGEN_UNITS: "256"
+          SCCACHE_S3_KEY_PREFIX: ${{ runner.os }}/sccache/${{ runner.arch }}/linux-gnu
+          ROCKSDB_STATIC: "/opt/rocksdb/usr/local/lib/librocksdb.a"
+          ROCKSDB_LIB_DIR: "/opt/rocksdb/usr/local/lib"
+          SNAPPY_STATIC: "/usr/lib/x86_64-linux-gnu/libsnappy.a"
+          SNAPPY_LIB_DIR: "/usr/lib/x86_64-linux-gnu"

--- a/.github/workflows/tests-rs-workspace.yml
+++ b/.github/workflows/tests-rs-workspace.yml
@@ -20,11 +20,13 @@ jobs:
 
       - name: Install build dependencies
         run: |
+          # Ensure homebrew binaries take precedence over /usr/local/bin
+          # (mac-runner-2 has a broken /usr/local/bin/cmake that gets SIGKILLed)
+          echo "/opt/homebrew/bin" >> $GITHUB_PATH
+          echo "/opt/homebrew/opt/llvm/bin" >> $GITHUB_PATH
           brew list cmake &>/dev/null || brew install cmake
           brew list gmp &>/dev/null || brew install gmp
           brew list llvm &>/dev/null || brew install llvm
-          # Homebrew LLVM is keg-only — add to PATH for cmake compiler detection
-          echo "/opt/homebrew/opt/llvm/bin" >> $GITHUB_PATH
 
       - name: Setup Rust
         uses: ./.github/actions/rust

--- a/.github/workflows/tests-rs-workspace.yml
+++ b/.github/workflows/tests-rs-workspace.yml
@@ -22,6 +22,8 @@ jobs:
         run: |
           brew list cmake &>/dev/null || brew install cmake
           brew list gmp &>/dev/null || brew install gmp
+          # Homebrew LLVM is keg-only — add to PATH for cmake compiler detection
+          echo "/opt/homebrew/opt/llvm/bin" >> $GITHUB_PATH
 
       - name: Setup Rust
         uses: ./.github/actions/rust

--- a/.github/workflows/tests-rs-workspace.yml
+++ b/.github/workflows/tests-rs-workspace.yml
@@ -9,7 +9,8 @@ on:
 jobs:
   test-mac:
     name: Tests (macOS)
-    runs-on: [self-hosted, macOS, ARM64]
+    # TODO: remove debug-target label after confirming fix on runner-2
+    runs-on: [self-hosted, macOS, ARM64, debug-target]
     if: >-
       github.event_name != 'pull_request'
       || github.event.pull_request.head.repo.full_name == github.repository
@@ -32,8 +33,6 @@ jobs:
         uses: ./.github/actions/rust
         with:
           cache: false
-
-      - uses: taiki-e/install-action@cargo-nextest
 
       - name: Debug cmake environment
         run: |

--- a/.github/workflows/tests-rs-workspace.yml
+++ b/.github/workflows/tests-rs-workspace.yml
@@ -9,8 +9,7 @@ on:
 jobs:
   test-mac:
     name: Tests (macOS)
-    # TODO: remove debug-target label after confirming fix on runner-2
-    runs-on: [self-hosted, macOS, ARM64, debug-target]
+    runs-on: [self-hosted, macOS, ARM64]
     if: >-
       github.event_name != 'pull_request'
       || github.event.pull_request.head.repo.full_name == github.repository
@@ -33,27 +32,6 @@ jobs:
         uses: ./.github/actions/rust
         with:
           cache: false
-
-      - name: Debug cmake environment
-        run: |
-          echo "=== PATH ==="
-          echo "$PATH"
-          echo "=== cmake ==="
-          which cmake && cmake --version
-          echo "=== clang ==="
-          which clang && clang --version 2>&1 | head -3
-          echo "=== xcrun ==="
-          xcrun --show-sdk-path 2>&1 || echo "xcrun failed — no CLT?"
-          echo "=== test bls-dash-sys cmake ==="
-          BLS_ROOT="$HOME/.cargo/git/checkouts/bls-signatures-8f6fe588daa69dbb/0842b17"
-          if [ -d "$BLS_ROOT" ]; then
-            rm -rf "$BLS_ROOT/build"
-            mkdir -p "$BLS_ROOT/build"
-            cd "$BLS_ROOT/build"
-            cmake .. -DBUILD_BLS_PYTHON_BINDINGS=0 -DBUILD_BLS_TESTS=0 -DBUILD_BLS_BENCHMARKS=0 -DBUILD_BLS_JS_BINDINGS=0 2>&1 || echo "cmake exit code: $?"
-          else
-            echo "bls checkout not found (cargo will fetch it)"
-          fi
 
       - name: Run tests
         run: |

--- a/.github/workflows/tests-rs-workspace.yml
+++ b/.github/workflows/tests-rs-workspace.yml
@@ -64,6 +64,17 @@ jobs:
           CARGO_PROFILE_DEV_DEBUG: "0"
           CARGO_PROFILE_DEV_CODEGEN_UNITS: "256"
 
+      - name: Run doctests
+        run: |
+          cargo test \
+            --workspace \
+            --all-features \
+            --locked \
+            --doc
+        env:
+          CARGO_PROFILE_DEV_DEBUG: "0"
+          CARGO_PROFILE_DEV_CODEGEN_UNITS: "256"
+
   test-ubuntu:
     name: "Tests (shard ${{ matrix.partition }}/6)"
     runs-on: ubuntu-24.04

--- a/.github/workflows/tests-rs-workspace.yml
+++ b/.github/workflows/tests-rs-workspace.yml
@@ -25,6 +25,8 @@ jobs:
 
       - name: Setup Rust
         uses: ./.github/actions/rust
+        with:
+          cache: false
 
       - uses: taiki-e/install-action@cargo-nextest
 

--- a/.github/workflows/tests-rs-workspace.yml
+++ b/.github/workflows/tests-rs-workspace.yml
@@ -22,6 +22,7 @@ jobs:
         run: |
           brew list cmake &>/dev/null || brew install cmake
           brew list gmp &>/dev/null || brew install gmp
+          brew list llvm &>/dev/null || brew install llvm
           # Homebrew LLVM is keg-only — add to PATH for cmake compiler detection
           echo "/opt/homebrew/opt/llvm/bin" >> $GITHUB_PATH
 

--- a/.github/workflows/tests-rs-workspace.yml
+++ b/.github/workflows/tests-rs-workspace.yml
@@ -72,6 +72,10 @@ jobs:
           CARGO_PROFILE_DEV_DEBUG: "0"
           CARGO_PROFILE_DEV_CODEGEN_UNITS: "256"
           SCCACHE_S3_KEY_PREFIX: ${{ runner.os }}/sccache/${{ runner.arch }}/darwin
+          # Override sccache CC/CXX wrapping — cmake in bls-dash-sys build.rs
+          # can't handle compound "sccache clang" values on macOS
+          CC: clang
+          CXX: clang++
 
   test-ubuntu:
     name: "Tests (shard ${{ matrix.partition }}/6)"

--- a/.github/workflows/tests-rs-workspace.yml
+++ b/.github/workflows/tests-rs-workspace.yml
@@ -7,32 +7,19 @@ on:
         default: false
 
 jobs:
-  test:
-    name: "Tests (shard ${{ matrix.partition }}/6)"
-    runs-on: ubuntu-24.04
+  test-mac:
+    name: Tests (macOS)
+    runs-on: [self-hosted, macOS, ARM64]
+    if: >-
+      github.event_name != 'pull_request'
+      || github.event.pull_request.head.repo.full_name == github.repository
     timeout-minutes: 30
     permissions:
       id-token: write
       contents: read
-    strategy:
-      fail-fast: false
-      matrix:
-        partition: [1, 2, 3, 4, 5, 6]
     steps:
-      - name: Free disk space
-        run: |
-          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /usr/local/share/powershell /usr/share/swift
-          df -h /
-
       - name: Check out repo
         uses: actions/checkout@v4
-
-      - name: Strip cdylib crate-types (incompatible with static rocksdb)
-        run: |
-          sed -i 's/\["cdylib", "rlib"\]/["rlib"]/' packages/rs-sdk/Cargo.toml packages/wasm-drive-verify/Cargo.toml
-          sed -i 's/\["cdylib", "lib"\]/["lib"]/' packages/wasm-dpp2/Cargo.toml
-          sed -i 's/\["cdylib"\]/["rlib"]/' packages/wasm-sdk/Cargo.toml
-          sed -i 's/\["staticlib", "cdylib", "rlib"\]/["staticlib", "rlib"]/g' packages/rs-sdk-ffi/Cargo.toml packages/rs-platform-wallet-ffi/Cargo.toml
 
       - name: Setup Rust
         uses: ./.github/actions/rust
@@ -46,18 +33,118 @@ jobs:
           access_key_id: ${{ secrets.CACHE_KEY_ID }}
           secret_access_key: ${{ secrets.CACHE_SECRET_KEY }}
 
+      - uses: taiki-e/install-action@cargo-nextest
+
+      - name: Run tests
+        run: |
+          cargo nextest run \
+            --package drive \
+            --package dpp \
+            --package drive-abci \
+            --package dash-sdk \
+            --package platform-value \
+            --package rs-dapi \
+            --package platform-wallet \
+            --package rs-sdk-ffi \
+            --package platform-wallet-ffi \
+            --package rs-dapi-client \
+            --package platform-serialization \
+            --package dapi-grpc \
+            --package json-schema-compatibility-validator \
+            --package dashpay-contract \
+            --package dpns-contract \
+            --package masternode-reward-shares-contract \
+            --package withdrawals-contract \
+            --package token-history-contract \
+            --package wallet-utils-contract \
+            --package keyword-search-contract \
+            --all-features \
+            --locked \
+            -E 'not test(/shield/)'
+        env:
+          RUST_MIN_STACK: 4194304
+          CARGO_INCREMENTAL: "0"
+          CARGO_PROFILE_DEV_DEBUG: "0"
+          CARGO_PROFILE_DEV_CODEGEN_UNITS: "256"
+          SCCACHE_S3_KEY_PREFIX: ${{ runner.os }}/sccache/${{ runner.arch }}/darwin
+
+  test-ubuntu:
+    name: "Tests (shard ${{ matrix.partition }}/6)"
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    permissions:
+      id-token: write
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        partition: [1, 2, 3, 4, 5, 6]
+    steps:
+      - name: Wait and check if Mac runner is available
+        id: check-mac
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          sleep 15
+          MAC_STATUS=$(gh api repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/jobs \
+            --jq '.jobs[] | select(.name == "Rust workspace tests / Tests (macOS)") | .status' 2>/dev/null || echo "unknown")
+          echo "mac-status=$MAC_STATUS" >> "$GITHUB_OUTPUT"
+          if [ "$MAC_STATUS" = "in_progress" ]; then
+            echo "Mac runner picked up the job — skipping Ubuntu fallback"
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "Mac runner not available (status: $MAC_STATUS) — running on Ubuntu"
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Free disk space
+        if: steps.check-mac.outputs.skip == 'false'
+        run: |
+          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /usr/local/share/powershell /usr/share/swift
+          df -h /
+
+      - name: Check out repo
+        if: steps.check-mac.outputs.skip == 'false'
+        uses: actions/checkout@v4
+
+      - name: Strip cdylib crate-types (incompatible with static rocksdb)
+        if: steps.check-mac.outputs.skip == 'false'
+        run: |
+          sed -i 's/\["cdylib", "rlib"\]/["rlib"]/' packages/rs-sdk/Cargo.toml packages/wasm-drive-verify/Cargo.toml
+          sed -i 's/\["cdylib", "lib"\]/["lib"]/' packages/wasm-dpp2/Cargo.toml
+          sed -i 's/\["cdylib"\]/["rlib"]/' packages/wasm-sdk/Cargo.toml
+          sed -i 's/\["staticlib", "cdylib", "rlib"\]/["staticlib", "rlib"]/g' packages/rs-sdk-ffi/Cargo.toml packages/rs-platform-wallet-ffi/Cargo.toml
+
+      - name: Setup Rust
+        if: steps.check-mac.outputs.skip == 'false'
+        uses: ./.github/actions/rust
+
+      - name: Setup sccache
+        if: steps.check-mac.outputs.skip == 'false'
+        uses: ./.github/actions/sccache
+        with:
+          bucket: ${{ vars.CACHE_S3_BUCKET }}
+          region: ${{ vars.CACHE_REGION }}
+          endpoint: ${{ vars.CACHE_S3_ENDPOINT }}
+          access_key_id: ${{ secrets.CACHE_KEY_ID }}
+          secret_access_key: ${{ secrets.CACHE_SECRET_KEY }}
+
       - name: Install librocksdb
+        if: steps.check-mac.outputs.skip == 'false'
         uses: ./.github/actions/librocksdb
 
       - uses: taiki-e/install-action@cargo-nextest
+        if: steps.check-mac.outputs.skip == 'false'
 
       - name: Configure core dumps
+        if: steps.check-mac.outputs.skip == 'false'
         run: |
           sudo mkdir /cores
           sudo chmod 777 /cores
           sudo bash -c 'echo "/cores/%e.%p.%t" > /proc/sys/kernel/core_pattern'
 
       - name: Run tests (shard ${{ matrix.partition }}/6)
+        if: steps.check-mac.outputs.skip == 'false'
         run: |
           ulimit -c unlimited
           cargo nextest run \
@@ -97,7 +184,7 @@ jobs:
           SNAPPY_LIB_DIR: "/usr/lib/x86_64-linux-gnu"
 
       - name: Collect crash artifacts
-        if: failure()
+        if: failure() && steps.check-mac.outputs.skip == 'false'
         run: |
           set -euo pipefail
           shopt -s nullglob
@@ -122,7 +209,7 @@ jobs:
           (cd "${ARTIFACT_DIR}" && zip -9 -r ../core-dumps.zip .)
 
       - name: Upload core dumps
-        if: failure()
+        if: failure() && steps.check-mac.outputs.skip == 'false'
         uses: actions/upload-artifact@v4
         with:
           name: core-dumps-shard-${{ matrix.partition }}-of-6

--- a/.github/workflows/tests-rs-workspace.yml
+++ b/.github/workflows/tests-rs-workspace.yml
@@ -21,6 +21,11 @@ jobs:
       - name: Check out repo
         uses: actions/checkout@v4
 
+      - name: Install build dependencies
+        run: |
+          brew list cmake &>/dev/null || brew install cmake
+          brew list gmp &>/dev/null || brew install gmp
+
       - name: Setup Rust
         uses: ./.github/actions/rust
 

--- a/.github/workflows/tests-rs-workspace.yml
+++ b/.github/workflows/tests-rs-workspace.yml
@@ -14,9 +14,6 @@ jobs:
       github.event_name != 'pull_request'
       || github.event.pull_request.head.repo.full_name == github.repository
     timeout-minutes: 30
-    permissions:
-      id-token: write
-      contents: read
     steps:
       - name: Check out repo
         uses: actions/checkout@v4
@@ -28,15 +25,6 @@ jobs:
 
       - name: Setup Rust
         uses: ./.github/actions/rust
-
-      - name: Setup sccache
-        uses: ./.github/actions/sccache
-        with:
-          bucket: ${{ vars.CACHE_S3_BUCKET }}
-          region: ${{ vars.CACHE_REGION }}
-          endpoint: ${{ vars.CACHE_S3_ENDPOINT }}
-          access_key_id: ${{ secrets.CACHE_KEY_ID }}
-          secret_access_key: ${{ secrets.CACHE_SECRET_KEY }}
 
       - uses: taiki-e/install-action@cargo-nextest
 
@@ -68,14 +56,8 @@ jobs:
             -E 'not test(/shield/)'
         env:
           RUST_MIN_STACK: 4194304
-          CARGO_INCREMENTAL: "0"
           CARGO_PROFILE_DEV_DEBUG: "0"
           CARGO_PROFILE_DEV_CODEGEN_UNITS: "256"
-          SCCACHE_S3_KEY_PREFIX: ${{ runner.os }}/sccache/${{ runner.arch }}/darwin
-          # Override sccache CC/CXX wrapping — cmake in bls-dash-sys build.rs
-          # can't handle compound "sccache clang" values on macOS
-          CC: clang
-          CXX: clang++
 
   test-ubuntu:
     name: "Tests (shard ${{ matrix.partition }}/6)"

--- a/.github/workflows/tests-rs-workspace.yml
+++ b/.github/workflows/tests-rs-workspace.yml
@@ -33,6 +33,27 @@ jobs:
 
       - uses: taiki-e/install-action@cargo-nextest
 
+      - name: Debug cmake environment
+        run: |
+          echo "=== PATH ==="
+          echo "$PATH"
+          echo "=== cmake ==="
+          which cmake && cmake --version
+          echo "=== clang ==="
+          which clang && clang --version 2>&1 | head -3
+          echo "=== xcrun ==="
+          xcrun --show-sdk-path 2>&1 || echo "xcrun failed — no CLT?"
+          echo "=== test bls-dash-sys cmake ==="
+          BLS_ROOT="$HOME/.cargo/git/checkouts/bls-signatures-8f6fe588daa69dbb/0842b17"
+          if [ -d "$BLS_ROOT" ]; then
+            rm -rf "$BLS_ROOT/build"
+            mkdir -p "$BLS_ROOT/build"
+            cd "$BLS_ROOT/build"
+            cmake .. -DBUILD_BLS_PYTHON_BINDINGS=0 -DBUILD_BLS_TESTS=0 -DBUILD_BLS_BENCHMARKS=0 -DBUILD_BLS_JS_BINDINGS=0 2>&1 || echo "cmake exit code: $?"
+          else
+            echo "bls checkout not found (cargo will fetch it)"
+          fi
+
       - name: Run tests
         run: |
           cargo nextest run \


### PR DESCRIPTION
## Issue being fixed or feature implemented

Rust workspace tests take ~6 minutes per shard on Ubuntu runners, with ~3 minutes spent just downloading cached artifacts from S3. A self-hosted Mac ARM64 runner can run all tests without sharding, using its local disk cache for near-instant compilation.

## What was done?

Adopted the same pattern used in [dashpay/grovedb](https://github.com/dashpay/grovedb):

- **`test-mac` job**: Runs all tests (no sharding) on `[self-hosted, macOS, ARM64]`. Only triggers for same-repo PRs (not forks, since they can't access self-hosted runners).
- **`test-ubuntu` job**: 6-shard fallback on `ubuntu-24.04`. Each shard waits 15 seconds and checks if the Mac runner picked up its job. If yes, all Ubuntu shards skip themselves. If no, they proceed normally.
- **`zk-tests` job**: Unchanged — still conditional on ZK code changes.

### Mac runner differences from Ubuntu:
- No sharding needed (fast enough for single job)
- No cdylib stripping (not needed on macOS)
- No `librocksdb` action (macOS builds differently)
- No disk space cleanup (self-hosted has ample space)
- Uses `darwin` sccache prefix

## How Has This Been Tested?

- CI will exercise both paths — Mac runner if available, Ubuntu fallback otherwise
- Ubuntu fallback path is identical to the current tested workflow

## Breaking Changes

None.

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [ ] I have made corresponding changes to the documentation if needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI tests reworked: added a dedicated macOS test job so mac runners take precedence.
  * Ubuntu path now detects mac runner availability and conditionally runs steps when needed, falling back when none available.
  * Test execution enhanced with partitioning; artifact and core-dump collection are gated to run only when appropriate, improving reliability and resource use.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->