### PR TITLE
ci: preserve Mac runner build cache with 200GB safety valve

### DIFF
--- a/.github/workflows/tests-rs-workspace.yml
+++ b/.github/workflows/tests-rs-workspace.yml
@@ -22,7 +22,8 @@ jobs:
 
       - name: Clean target if too large
         run: |
-          SIZE=$(du -sm target 2>/dev/null | cut -f1 || echo 0)
+          SIZE=$(du -sm target 2>/dev/null | cut -f1 || true)
+          SIZE=${SIZE:-0}
           echo "target/ size: ${SIZE}MB"
           if [ "$SIZE" -gt 200000 ]; then
             echo "target/ exceeds 200GB — cleaning"

--- a/.github/workflows/tests-rs-workspace.yml
+++ b/.github/workflows/tests-rs-workspace.yml
@@ -17,11 +17,20 @@ jobs:
     steps:
       - name: Check out repo
         uses: actions/checkout@v4
+        with:
+          clean: false
+
+      - name: Clean target if too large
+        run: |
+          SIZE=$(du -sm target 2>/dev/null | cut -f1 || echo 0)
+          echo "target/ size: ${SIZE}MB"
+          if [ "$SIZE" -gt 200000 ]; then
+            echo "target/ exceeds 200GB — cleaning"
+            cargo clean
+          fi
 
       - name: Install build dependencies
         run: |
-          # Ensure homebrew binaries take precedence over /usr/local/bin
-          # (mac-runner-2 has a broken /usr/local/bin/cmake that gets SIGKILLed)
           echo "/opt/homebrew/bin" >> $GITHUB_PATH
           echo "/opt/homebrew/opt/llvm/bin" >> $GITHUB_PATH
           brew list cmake &>/dev/null || brew install cmake


### PR DESCRIPTION
## Summary
- Disable `git clean` on checkout (`clean: false`) so the `target/` directory persists between runs on self-hosted Mac runners, enabling cargo's incremental build cache
- Add safety valve: run `cargo clean` if `target/` exceeds 200GB to prevent disk exhaustion
- Remove stale comments from previous debugging

## Test plan
- [ ] Verify Mac runner preserves `target/` between runs (no full recompilation)
- [ ] Verify `target/` size check logs current size
- [ ] Verify cargo clean triggers if size exceeds 200GB threshold

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized CI/CD pipeline performance by retaining checkout state between runs.
  * Enhanced build reliability with automatic cleanup of large build artifacts to prevent disk space issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->