### PR TITLE
ci: add missing scopes to PR title linter

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -51,6 +51,10 @@ jobs:
             bench-suite
             release
             wasm-sdk
+            platform-wallet
+            swift-example-app
+            kotlin-sdk
+            kotlin-example-app
           requireScope: false
           # Configure additional validation for the subject based on a regex.
           # This example ensures the subject doesn't start with an uppercase character.


### PR DESCRIPTION
## Summary
- Add `platform-wallet`, `swift-example-app`, `kotlin-sdk`, and `kotlin-example-app` to the allowed scopes in the semantic PR title linter

## Test plan
- [ ] Verify PR title linter passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)