### PR TITLE
ci: consolidate formatting and clippy into workspace-wide jobs

### DIFF
--- a/.github/workflows/tests-rs-doctests.yml
+++ b/.github/workflows/tests-rs-doctests.yml
@@ -3,7 +3,7 @@ on:
 
 jobs:
   doctests:
-    name: Doctests
+    name: Doctests backup
     runs-on: ubuntu-24.04
     timeout-minutes: 20
     permissions:

--- a/.github/workflows/tests-rs-package.yml
+++ b/.github/workflows/tests-rs-package.yml
@@ -15,64 +15,8 @@ on:
         default: "[]"
 
 jobs:
-  lint:
-    name: Linting
-    runs-on: ubuntu-24.04
-    if: contains(fromJSON(inputs.direct-packages), inputs.package)
-    permissions:
-      id-token: write
-      contents: read
-    timeout-minutes: 15
-    steps:
-      - name: Check out repo
-        uses: actions/checkout@v4
-
-      - name: Setup Rust
-        uses: ./.github/actions/rust
-        with:
-          components: clippy
-
-      - name: Setup sccache
-        uses: ./.github/actions/sccache
-        with:
-          bucket: ${{ vars.CACHE_S3_BUCKET }}
-          region: ${{ vars.CACHE_REGION }}
-          endpoint: ${{ vars.CACHE_S3_ENDPOINT }}
-          access_key_id: ${{ secrets.CACHE_KEY_ID }}
-          secret_access_key: ${{ secrets.CACHE_SECRET_KEY }}
-
-      - name: Install librocksdb
-        uses: ./.github/actions/librocksdb
-
-      - uses: clechasseur/rs-clippy-check@v4
-        with:
-          args: --package ${{ inputs.package }} --all-features --locked -- --no-deps -D warnings
-        env:
-          ROCKSDB_STATIC: "/opt/rocksdb/usr/local/lib/librocksdb.a"
-          ROCKSDB_LIB_DIR: "/opt/rocksdb/usr/local/lib"
-          SNAPPY_STATIC: "/usr/lib/x86_64-linux-gnu/libsnappy.a"
-          SNAPPY_LIB_DIR: "/usr/lib/x86_64-linux-gnu"
-
-  formatting:
-    name: Formatting
-    runs-on: ubuntu-24.04
-    if: contains(fromJSON(inputs.direct-packages), inputs.package)
-    timeout-minutes: 5
-    steps:
-      - name: Check out repo
-        uses: actions/checkout@v4
-
-      - name: Setup Rust
-        uses: ./.github/actions/rust
-        with:
-          components: rustfmt
-          cache: false
-
-      # We don't use cache for this step, nothing to cache here
-      # This step doesn't need librocksdb, so we don't install it
-
-      - name: Check formatting
-        run: cargo fmt --check --package=${{ inputs.package }}
+  # Linting and formatting are now handled by tests-rs-workspace.yml
+  # (consolidated workspace-wide fmt + clippy on Mac runner with Ubuntu fallback)
 
   unused_deps:
     name: Unused dependencies

--- a/.github/workflows/tests-rs-workspace.yml
+++ b/.github/workflows/tests-rs-workspace.yml
@@ -102,7 +102,7 @@ jobs:
           CARGO_PROFILE_DEV_CODEGEN_UNITS: "256"
 
   test-ubuntu:
-    name: "Tests (shard ${{ matrix.partition }}/6)"
+    name: "Tests backup (shard ${{ matrix.partition }}/6)"
     runs-on: ubuntu-24.04
     timeout-minutes: 30
     permissions:
@@ -251,7 +251,7 @@ jobs:
           retention-days: 3
 
   lint-ubuntu:
-    name: "Formatting & Linting"
+    name: "Formatting & Linting backup"
     runs-on: ubuntu-24.04
     timeout-minutes: 20
     permissions:

--- a/.github/workflows/tests-rs-workspace.yml
+++ b/.github/workflows/tests-rs-workspace.yml
@@ -47,6 +47,17 @@ jobs:
         with:
           cache: false
 
+      - name: Check formatting
+        run: cargo fmt --check --all
+
+      - name: Clippy lints
+        run: |
+          cargo clippy \
+            --workspace \
+            --all-features \
+            --locked \
+            -- --no-deps -D warnings
+
       - name: Run tests
         run: |
           cargo nextest run \
@@ -238,6 +249,84 @@ jobs:
           path: core-dumps.zip
           if-no-files-found: ignore
           retention-days: 3
+
+  lint-ubuntu:
+    name: "Formatting & Linting"
+    runs-on: ubuntu-24.04
+    timeout-minutes: 20
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - name: Wait and check if Mac runner is available
+        id: check-mac
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          sleep 15
+          MAC_STATUS=$(gh api repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/jobs \
+            --jq '.jobs[] | select(.name == "Rust workspace tests / Tests (macOS)") | .status' 2>/dev/null || echo "unknown")
+          echo "mac-status=$MAC_STATUS" >> "$GITHUB_OUTPUT"
+          if [ "$MAC_STATUS" = "in_progress" ]; then
+            echo "Mac runner picked up the job — skipping Ubuntu fallback"
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "Mac runner not available (status: $MAC_STATUS) — running on Ubuntu"
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Check out repo
+        if: steps.check-mac.outputs.skip == 'false'
+        uses: actions/checkout@v4
+
+      - name: Strip cdylib crate-types (incompatible with static rocksdb)
+        if: steps.check-mac.outputs.skip == 'false'
+        run: |
+          sed -i 's/\["cdylib", "rlib"\]/["rlib"]/' packages/rs-sdk/Cargo.toml packages/wasm-drive-verify/Cargo.toml
+          sed -i 's/\["cdylib", "lib"\]/["lib"]/' packages/wasm-dpp2/Cargo.toml
+          sed -i 's/\["cdylib"\]/["rlib"]/' packages/wasm-sdk/Cargo.toml
+          sed -i 's/\["staticlib", "cdylib", "rlib"\]/["staticlib", "rlib"]/g' packages/rs-sdk-ffi/Cargo.toml packages/rs-platform-wallet-ffi/Cargo.toml
+
+      - name: Setup Rust
+        if: steps.check-mac.outputs.skip == 'false'
+        uses: ./.github/actions/rust
+        with:
+          components: rustfmt, clippy
+
+      - name: Setup sccache
+        if: steps.check-mac.outputs.skip == 'false'
+        uses: ./.github/actions/sccache
+        with:
+          bucket: ${{ vars.CACHE_S3_BUCKET }}
+          region: ${{ vars.CACHE_REGION }}
+          endpoint: ${{ vars.CACHE_S3_ENDPOINT }}
+          access_key_id: ${{ secrets.CACHE_KEY_ID }}
+          secret_access_key: ${{ secrets.CACHE_SECRET_KEY }}
+
+      - name: Install librocksdb
+        if: steps.check-mac.outputs.skip == 'false'
+        uses: ./.github/actions/librocksdb
+
+      - name: Check formatting
+        if: steps.check-mac.outputs.skip == 'false'
+        run: cargo fmt --check --all
+
+      - name: Clippy lints
+        if: steps.check-mac.outputs.skip == 'false'
+        run: |
+          cargo clippy \
+            --workspace \
+            --all-features \
+            --locked \
+            -- --no-deps -D warnings
+        env:
+          CARGO_INCREMENTAL: "0"
+          CARGO_PROFILE_DEV_DEBUG: "0"
+          SCCACHE_S3_KEY_PREFIX: ${{ runner.os }}/sccache/${{ runner.arch }}/linux-gnu
+          ROCKSDB_STATIC: "/opt/rocksdb/usr/local/lib/librocksdb.a"
+          ROCKSDB_LIB_DIR: "/opt/rocksdb/usr/local/lib"
+          SNAPPY_STATIC: "/usr/lib/x86_64-linux-gnu/libsnappy.a"
+          SNAPPY_LIB_DIR: "/usr/lib/x86_64-linux-gnu"
 
   zk-tests:
     name: ZK / Shielded tests


### PR DESCRIPTION
## Summary
- Move per-package `cargo fmt` and `cargo clippy` checks from `tests-rs-package.yml` into workspace-wide jobs in `tests-rs-workspace.yml`
- Mac runner runs `cargo fmt --check --all` and `cargo clippy --workspace` before tests (fast failure)
- New Ubuntu "Formatting & Linting" fallback job with the same Mac availability check pattern
- Reduces runner count from N (one per changed package) to 1 for formatting and linting
- Per-package `unused_deps`, `detect_structure_changes`, and `check_each_feature` jobs are unchanged

## Test plan
- [ ] Verify `cargo fmt --check --all` runs on Mac runner
- [ ] Verify `cargo clippy --workspace` runs on Mac runner
- [ ] Verify Ubuntu lint fallback skips when Mac is available
- [ ] Verify per-package lint/formatting jobs no longer appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)