### PR TITLE
fix(rs-dapi): remove unused functions and unnecessary cast

### DIFF
--- a/packages/rs-dapi/src/clients/core_client.rs
+++ b/packages/rs-dapi/src/clients/core_client.rs
@@ -90,7 +90,7 @@ impl CoreClient {
             .guarded_blocking_call(|client| client.get_block_count())
             .await??;
 
-        Ok(height as u32)
+        Ok(height)
     }
 
     /// Fetch verbose transaction metadata by txid hex string.

--- a/packages/rs-dapi/src/services/streaming_service/bloom.rs
+++ b/packages/rs-dapi/src/services/streaming_service/bloom.rs
@@ -3,34 +3,6 @@ use std::sync::Arc;
 use dashcore_rpc::dashcore::bloom::{BloomFilter as CoreBloomFilter, BloomFlags};
 use dashcore_rpc::dashcore::script::Instruction;
 use dashcore_rpc::dashcore::{OutPoint, ScriptBuf, Transaction as CoreTx, Txid};
-use dpp::dashcore::Script;
-
-/// Extract pubkey hash from P2PKH script
-fn extract_pubkey_hash(script: &Script) -> Option<Vec<u8>> {
-    let bytes = script.as_bytes();
-    // P2PKH: OP_DUP OP_HASH160 <20 bytes> OP_EQUALVERIFY OP_CHECKSIG
-    if bytes.len() == 25
-        && bytes[0] == 0x76  // OP_DUP
-        && bytes[1] == 0xa9  // OP_HASH160
-        && bytes[2] == 0x14  // Push 20 bytes
-        && bytes[23] == 0x88 // OP_EQUALVERIFY
-        && bytes[24] == 0xac
-    // OP_CHECKSIG
-    {
-        Some(bytes[3..23].to_vec())
-    } else {
-        None
-    }
-}
-
-/// Convert outpoint to bytes for bloom filter
-fn outpoint_to_bytes(outpoint: &OutPoint) -> Vec<u8> {
-    let mut bytes = Vec::with_capacity(36);
-    bytes.extend_from_slice(&outpoint.txid[..]);
-    bytes.extend_from_slice(&outpoint.vout.to_le_bytes());
-    bytes
-}
-
 fn script_matches(filter: &CoreBloomFilter, script: &ScriptBuf) -> bool {
     let script_bytes = script.as_bytes();
     if filter.contains(script_bytes) {


### PR DESCRIPTION
## Summary
- Remove unused `extract_pubkey_hash` and `outpoint_to_bytes` functions from `bloom.rs`
- Remove unnecessary `u32 -> u32` cast in `core_client.rs`
- Remove unused `dpp::dashcore::Script` import

Fixes clippy warnings that break the new workspace-wide `cargo clippy -- -D warnings` check.

## Test plan
- [ ] Verify `cargo clippy -p rs-dapi --all-features -- --no-deps -D warnings` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)