### PR TITLE
ci: add rs-dapi to package change detection filters

### DIFF
--- a/.github/package-filters/rs-packages-direct.yml
+++ b/.github/package-filters/rs-packages-direct.yml
@@ -55,6 +55,9 @@ dapi-grpc:
   - packages/dapi-grpc/build.rs
   - packages/dapi-grpc/Cargo.toml
 
+rs-dapi:
+  - packages/rs-dapi/**
+
 rs-dapi-client:
   - packages/rs-dapi-client/**
 

--- a/.github/package-filters/rs-packages-no-workflows.yml
+++ b/.github/package-filters/rs-packages-no-workflows.yml
@@ -74,6 +74,10 @@ dapi-grpc: &dapi_grpc
   - packages/dapi-grpc/build.rs
   - packages/dapi-grpc/Cargo.toml
 
+rs-dapi:
+  - packages/rs-dapi/**
+  - *dapi_grpc
+
 rs-dapi-client: &dapi_client
   - packages/rs-dapi-client/**
   - *dapi_grpc


### PR DESCRIPTION
## Summary
- Add `rs-dapi` to `rs-packages-no-workflows.yml` and `rs-packages-direct.yml`
- Previously, changes to `packages/rs-dapi/` did not trigger any CI jobs (tests, clippy, fmt)

## Test plan
- [ ] Verify changes to `packages/rs-dapi/` now trigger workspace tests and per-package checks

🤖 Generated with [Claude Code](https://claude.com/claude-code)