### PR TITLE
ci: reduce Ubuntu backup shards from 6 to 4

### DIFF
--- a/.github/workflows/tests-rs-doctests.yml
+++ b/.github/workflows/tests-rs-doctests.yml
@@ -16,12 +16,17 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           sleep 15
-          MAC_STATUS=$(gh api repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/jobs \
-            --jq '.jobs[] | select(.name == "Rust workspace tests / Tests (macOS)") | .status' 2>/dev/null || echo "unknown")
+          MAC_JOB=$(gh api repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/jobs \
+            --jq '.jobs[] | select(.name == "Rust workspace tests / Tests (macOS)")' 2>/dev/null || echo "{}")
+          MAC_STATUS=$(echo "$MAC_JOB" | jq -r '.status // "unknown"')
+          MAC_CONCLUSION=$(echo "$MAC_JOB" | jq -r '.conclusion // ""')
           echo "mac-status=$MAC_STATUS" >> "$GITHUB_OUTPUT"
           if [ "$MAC_STATUS" = "in_progress" ]; then
             echo "Mac runner picked up the job — skipping Ubuntu doctests"
             echo "skip=true" >> "$GITHUB_OUTPUT"
+          elif [ "$MAC_STATUS" = "completed" ] && [ "$MAC_CONCLUSION" = "failure" ]; then
+            echo "Mac runner already failed — failing Ubuntu fallback too"
+            exit 1
           else
             echo "Mac runner not available (status: $MAC_STATUS) — running doctests on Ubuntu"
             echo "skip=false" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/tests-rs-workspace.yml
+++ b/.github/workflows/tests-rs-workspace.yml
@@ -166,7 +166,7 @@ jobs:
           CARGO_PROFILE_DEV_CODEGEN_UNITS: "256"
 
   test-ubuntu:
-    name: "Tests backup (shard ${{ matrix.partition }}/6)"
+    name: "Tests backup (shard ${{ matrix.partition }}/4)"
     runs-on: ubuntu-24.04
     timeout-minutes: 30
     permissions:
@@ -175,7 +175,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        partition: [1, 2, 3, 4, 5, 6]
+        partition: [1, 2, 3, 4]
     steps:
       - name: Wait and check if Mac runner is available
         id: check-mac
@@ -183,12 +183,17 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           sleep 15
-          MAC_STATUS=$(gh api repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/jobs \
-            --jq '.jobs[] | select(.name == "Rust workspace tests / Tests (macOS)") | .status' 2>/dev/null || echo "unknown")
+          MAC_JOB=$(gh api repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/jobs \
+            --jq '.jobs[] | select(.name == "Rust workspace tests / Tests (macOS)")' 2>/dev/null || echo "{}")
+          MAC_STATUS=$(echo "$MAC_JOB" | jq -r '.status // "unknown"')
+          MAC_CONCLUSION=$(echo "$MAC_JOB" | jq -r '.conclusion // ""')
           echo "mac-status=$MAC_STATUS" >> "$GITHUB_OUTPUT"
           if [ "$MAC_STATUS" = "in_progress" ]; then
             echo "Mac runner picked up the job — skipping Ubuntu fallback"
             echo "skip=true" >> "$GITHUB_OUTPUT"
+          elif [ "$MAC_STATUS" = "completed" ] && [ "$MAC_CONCLUSION" = "failure" ]; then
+            echo "Mac runner already failed — failing Ubuntu fallback too"
+            exit 1
           else
             echo "Mac runner not available (status: $MAC_STATUS) — running on Ubuntu"
             echo "skip=false" >> "$GITHUB_OUTPUT"
@@ -268,7 +273,7 @@ jobs:
             --all-features \
             --locked \
             -E 'not test(/shield/)' \
-            --partition count:${{ matrix.partition }}/6
+            --partition count:${{ matrix.partition }}/4
         env:
           RUST_MIN_STACK: 4194304
           CARGO_INCREMENTAL: "0"
@@ -309,7 +314,7 @@ jobs:
         if: failure() && steps.check-mac.outputs.skip == 'false'
         uses: actions/upload-artifact@v4
         with:
-          name: core-dumps-shard-${{ matrix.partition }}-of-6
+          name: core-dumps-shard-${{ matrix.partition }}-of-4
           path: core-dumps.zip
           if-no-files-found: ignore
           retention-days: 3
@@ -328,12 +333,17 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           sleep 15
-          MAC_STATUS=$(gh api repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/jobs \
-            --jq '.jobs[] | select(.name == "Rust workspace tests / Tests (macOS)") | .status' 2>/dev/null || echo "unknown")
+          MAC_JOB=$(gh api repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/jobs \
+            --jq '.jobs[] | select(.name == "Rust workspace tests / Tests (macOS)")' 2>/dev/null || echo "{}")
+          MAC_STATUS=$(echo "$MAC_JOB" | jq -r '.status // "unknown"')
+          MAC_CONCLUSION=$(echo "$MAC_JOB" | jq -r '.conclusion // ""')
           echo "mac-status=$MAC_STATUS" >> "$GITHUB_OUTPUT"
           if [ "$MAC_STATUS" = "in_progress" ]; then
             echo "Mac runner picked up the job — skipping Ubuntu fallback"
             echo "skip=true" >> "$GITHUB_OUTPUT"
+          elif [ "$MAC_STATUS" = "completed" ] && [ "$MAC_CONCLUSION" = "failure" ]; then
+            echo "Mac runner already failed — failing Ubuntu fallback too"
+            exit 1
           else
             echo "Mac runner not available (status: $MAC_STATUS) — running on Ubuntu"
             echo "skip=false" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Summary
- Reduce Ubuntu backup test shards from 6 to 4 — these only run when the Mac runner is unavailable
- Update Mac status check in all Ubuntu backup jobs (test shards, lint, doctests): if the Mac runner already completed with failure within the 15s wait period, Ubuntu jobs now fail immediately instead of running a redundant test suite

Three outcomes at the 15s check:
- Mac **in_progress** → Ubuntu skips (Mac is handling it)
- Mac **completed + failure** → Ubuntu fails immediately
- Mac **queued/unknown** → Ubuntu runs tests (Mac not available)

## Test plan
- [ ] Verify 4 shards cover all tests when Mac runner is unavailable
- [ ] Verify Ubuntu jobs fail fast when Mac runner has already failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)