### PR TITLE
ci: benchmark code coverage on Mac runner

### DIFF
--- a/.github/workflows/tests-rs-workspace.yml
+++ b/.github/workflows/tests-rs-workspace.yml
@@ -46,6 +46,10 @@ jobs:
         uses: ./.github/actions/rust
         with:
           cache: false
+          components: llvm-tools
+
+      - name: Install cargo-llvm-cov
+        run: cargo install cargo-llvm-cov 2>/dev/null || true
 
       - name: Check formatting
         run: cargo fmt --check --all
@@ -122,9 +126,9 @@ jobs:
           done
           echo "No immutable/append_only structure violations found"
 
-      - name: Run tests
+      - name: Run tests with coverage
         run: |
-          cargo nextest run \
+          cargo llvm-cov nextest \
             --package drive \
             --package dpp \
             --package drive-abci \
@@ -147,11 +151,21 @@ jobs:
             --package keyword-search-contract \
             --all-features \
             --locked \
-            -E 'not test(/shield/)'
+            -E 'not test(/shield/)' \
+            --lcov --output-path lcov.info
         env:
           RUST_MIN_STACK: 4194304
           CARGO_PROFILE_DEV_DEBUG: "0"
           CARGO_PROFILE_DEV_CODEGEN_UNITS: "256"
+
+      - name: Upload coverage
+        if: always()
+        uses: codecov/codecov-action@v5
+        with:
+          files: lcov.info
+          flags: rust-mac
+          token: ${{ secrets.CODECOV_TOKEN }}
+          fail_ci_if_error: false
 
       - name: Run doctests
         if: ${{ inputs.doctests-changed }}


### PR DESCRIPTION
## Summary
- Switch Mac runner tests from `cargo nextest` to `cargo llvm-cov nextest` to benchmark the performance impact of coverage instrumentation
- Uploads lcov report to Codecov
- **This is a benchmarking PR** — compare Mac runner duration with vs without coverage to decide if we want it permanently

Baseline (no coverage): ~3-5 min on Mac runner
Expected with coverage: TBD

## Test plan
- [ ] Compare Mac runner test duration with coverage vs without
- [ ] Verify coverage report uploads to Codecov

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced testing and code coverage infrastructure for improved quality assurance processes across platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->