### PR TITLE
fix(ci): install gpg on Mac runners for Codecov upload

### DIFF
--- a/.github/workflows/tests-rs-workspace.yml
+++ b/.github/workflows/tests-rs-workspace.yml
@@ -41,6 +41,7 @@ jobs:
           brew list cmake &>/dev/null || brew install cmake
           brew list gmp &>/dev/null || brew install gmp
           brew list llvm &>/dev/null || brew install llvm
+          brew list gnupg &>/dev/null || brew install gnupg
 
       - name: Setup Rust
         uses: ./.github/actions/rust


### PR DESCRIPTION
## Summary
- Install `gnupg` via brew on Mac runners — required by `codecov-action@v5` to verify the uploader binary

## Test plan
- [ ] Verify Codecov upload step succeeds on Mac runner

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD infrastructure build dependencies to ensure proper environment setup during testing workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->