### PR TITLE
ci: include shielded tests in push coverage runs

### DIFF
--- a/.github/workflows/tests-rs-workspace.yml
+++ b/.github/workflows/tests-rs-workspace.yml
@@ -129,7 +129,11 @@ jobs:
 
       - name: Run tests with coverage
         run: |
-          cargo llvm-cov nextest \
+          FILTER_ARGS=""
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            FILTER_ARGS="-E 'not test(/shield/)'"
+          fi
+          eval cargo llvm-cov nextest \
             --package drive \
             --package dpp \
             --package drive-abci \
@@ -152,7 +156,7 @@ jobs:
             --package keyword-search-contract \
             --all-features \
             --locked \
-            -E 'not test(/shield/)' \
+            $FILTER_ARGS \
             --lcov --output-path lcov.info
         env:
           RUST_MIN_STACK: 4194304
@@ -264,7 +268,11 @@ jobs:
         if: steps.check-mac.outputs.skip == 'false'
         run: |
           ulimit -c unlimited
-          cargo nextest run \
+          FILTER_ARGS=""
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            FILTER_ARGS="-E 'not test(/shield/)'"
+          fi
+          eval cargo nextest run \
             --package drive \
             --package dpp \
             --package drive-abci \
@@ -287,7 +295,7 @@ jobs:
             --package keyword-search-contract \
             --all-features \
             --locked \
-            -E 'not test(/shield/)' \
+            $FILTER_ARGS \
             --partition count:${{ matrix.partition }}/4
         env:
           RUST_MIN_STACK: 4194304


### PR DESCRIPTION
## Summary
- On PR events, shielded tests remain excluded (unchanged behavior)
- On push (merge to dev), schedule, and workflow_dispatch, shielded tests are now included in coverage runs
- Applies to both macOS coverage job and Ubuntu fallback sharded tests

## Test plan
- [ ] Verify PR CI still excludes shielded tests (filter applied)
- [ ] Verify push to `v*-dev` includes shielded tests in coverage (no filter)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized test execution workflow to streamline CI/CD processes during pull requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->