### PR TITLE
test(drive): add verify proof coverage for tokens and voting v0 modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -90,3 +90,4 @@ book/book/
 grpc-coverage-report.txt
 
 __pycache__/
+.claude/worktrees/

--- a/packages/rs-drive/src/verify/tokens/verify_token_infos_for_identity_id/v0/mod.rs
+++ b/packages/rs-drive/src/verify/tokens/verify_token_infos_for_identity_id/v0/mod.rs
@@ -72,3 +72,178 @@ impl Drive {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::util::test_helpers::setup::setup_drive_with_initial_state_structure;
+    use dpp::block::block_info::BlockInfo;
+    use dpp::data_contract::accessors::v1::DataContractV1Getters;
+    use dpp::data_contract::associated_token::token_configuration::v0::TokenConfigurationV0;
+    use dpp::data_contract::associated_token::token_configuration::TokenConfiguration;
+    use dpp::data_contract::config::v0::DataContractConfigV0;
+    use dpp::data_contract::config::DataContractConfig;
+    use dpp::data_contract::v1::DataContractV1;
+    use dpp::identity::accessors::IdentityGettersV0;
+    use dpp::identity::Identity;
+    use dpp::prelude::DataContract;
+    use dpp::tokens::info::v0::IdentityTokenInfoV0;
+    use dpp::version::PlatformVersion;
+    use std::collections::BTreeMap;
+
+    fn create_token_contract(_platform_version: &PlatformVersion) -> DataContract {
+        DataContract::V1(DataContractV1 {
+            id: Default::default(),
+            version: 0,
+            owner_id: Default::default(),
+            document_types: Default::default(),
+            config: DataContractConfig::V0(DataContractConfigV0 {
+                can_be_deleted: false,
+                readonly: false,
+                keeps_history: false,
+                documents_keep_history_contract_default: false,
+                documents_mutable_contract_default: false,
+                documents_can_be_deleted_contract_default: false,
+                requires_identity_encryption_bounded_key: None,
+                requires_identity_decryption_bounded_key: None,
+            }),
+            schema_defs: None,
+            created_at: None,
+            updated_at: None,
+            created_at_block_height: None,
+            updated_at_block_height: None,
+            created_at_epoch: None,
+            updated_at_epoch: None,
+            groups: Default::default(),
+            tokens: BTreeMap::from([(
+                0,
+                TokenConfiguration::V0(TokenConfigurationV0::default_most_restrictive()),
+            )]),
+            keywords: Vec::new(),
+            description: None,
+        })
+    }
+
+    #[test]
+    fn should_prove_and_verify_token_infos_for_identity_id_with_frozen_token() {
+        let drive = setup_drive_with_initial_state_structure(None);
+        let platform_version = PlatformVersion::latest();
+
+        let identity = Identity::random_identity(3, Some(14), platform_version)
+            .expect("expected a platform identity");
+        let identity_id = identity.id().to_buffer();
+
+        let contract = create_token_contract(platform_version);
+        let token_id = contract.token_id(0).expect("expected token at position 0");
+
+        drive
+            .add_new_identity(
+                identity.clone(),
+                false,
+                &BlockInfo::default(),
+                true,
+                None,
+                platform_version,
+            )
+            .expect("expected to add an identity");
+
+        drive
+            .insert_contract(
+                &contract,
+                BlockInfo::default(),
+                true,
+                None,
+                platform_version,
+            )
+            .expect("expected to insert contract");
+
+        // Freeze the identity for this token
+        drive
+            .token_freeze(
+                token_id,
+                identity.id(),
+                &BlockInfo::default(),
+                true,
+                None,
+                platform_version,
+            )
+            .expect("expected to freeze token");
+
+        // Generate proof
+        let token_ids = vec![token_id.to_buffer()];
+        let proof = drive
+            .prove_identity_token_infos(&token_ids, identity_id, None, platform_version)
+            .expect("expected to get proof");
+
+        let (_, infos): (_, BTreeMap<[u8; 32], Option<IdentityTokenInfo>>) =
+            Drive::verify_token_infos_for_identity_id(
+                proof.as_slice(),
+                &token_ids,
+                identity_id,
+                false,
+                platform_version,
+            )
+            .expect("expected proof verification to succeed");
+
+        assert_eq!(infos.len(), 1);
+        assert_eq!(
+            infos.get(&token_id.to_buffer()),
+            Some(&Some(IdentityTokenInfo::V0(IdentityTokenInfoV0 {
+                frozen: true
+            })))
+        );
+    }
+
+    #[test]
+    fn should_prove_and_verify_absent_token_infos_for_identity_id() {
+        let drive = setup_drive_with_initial_state_structure(None);
+        let platform_version = PlatformVersion::latest();
+
+        let identity = Identity::random_identity(3, Some(14), platform_version)
+            .expect("expected a platform identity");
+        let identity_id = identity.id().to_buffer();
+
+        let contract = create_token_contract(platform_version);
+        let token_id = contract.token_id(0).expect("expected token at position 0");
+
+        drive
+            .add_new_identity(
+                identity.clone(),
+                false,
+                &BlockInfo::default(),
+                true,
+                None,
+                platform_version,
+            )
+            .expect("expected to add an identity");
+
+        drive
+            .insert_contract(
+                &contract,
+                BlockInfo::default(),
+                true,
+                None,
+                platform_version,
+            )
+            .expect("expected to insert contract");
+
+        // No freeze -- info should be absent
+        let token_ids = vec![token_id.to_buffer()];
+        let proof = drive
+            .prove_identity_token_infos(&token_ids, identity_id, None, platform_version)
+            .expect("expected to get proof");
+
+        let (_, infos): (_, BTreeMap<[u8; 32], Option<IdentityTokenInfo>>) =
+            Drive::verify_token_infos_for_identity_id(
+                proof.as_slice(),
+                &token_ids,
+                identity_id,
+                false,
+                platform_version,
+            )
+            .expect("expected proof verification to succeed");
+
+        assert_eq!(infos.len(), 1);
+        assert_eq!(infos.get(&token_id.to_buffer()), Some(&None));
+    }
+}

--- a/packages/rs-drive/src/verify/tokens/verify_token_infos_for_identity_ids/v0/mod.rs
+++ b/packages/rs-drive/src/verify/tokens/verify_token_infos_for_identity_ids/v0/mod.rs
@@ -63,3 +63,201 @@ impl Drive {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::util::test_helpers::setup::setup_drive_with_initial_state_structure;
+    use dpp::block::block_info::BlockInfo;
+    use dpp::data_contract::accessors::v1::DataContractV1Getters;
+    use dpp::data_contract::associated_token::token_configuration::v0::TokenConfigurationV0;
+    use dpp::data_contract::associated_token::token_configuration::TokenConfiguration;
+    use dpp::data_contract::config::v0::DataContractConfigV0;
+    use dpp::data_contract::config::DataContractConfig;
+    use dpp::data_contract::v1::DataContractV1;
+    use dpp::identity::accessors::IdentityGettersV0;
+    use dpp::identity::Identity;
+    use dpp::prelude::DataContract;
+    use dpp::tokens::info::v0::IdentityTokenInfoV0;
+    use dpp::version::PlatformVersion;
+    use std::collections::BTreeMap;
+
+    fn create_token_contract() -> DataContract {
+        DataContract::V1(DataContractV1 {
+            id: Default::default(),
+            version: 0,
+            owner_id: Default::default(),
+            document_types: Default::default(),
+            config: DataContractConfig::V0(DataContractConfigV0 {
+                can_be_deleted: false,
+                readonly: false,
+                keeps_history: false,
+                documents_keep_history_contract_default: false,
+                documents_mutable_contract_default: false,
+                documents_can_be_deleted_contract_default: false,
+                requires_identity_encryption_bounded_key: None,
+                requires_identity_decryption_bounded_key: None,
+            }),
+            schema_defs: None,
+            created_at: None,
+            updated_at: None,
+            created_at_block_height: None,
+            updated_at_block_height: None,
+            created_at_epoch: None,
+            updated_at_epoch: None,
+            groups: Default::default(),
+            tokens: BTreeMap::from([(
+                0,
+                TokenConfiguration::V0(TokenConfigurationV0::default_most_restrictive()),
+            )]),
+            keywords: Vec::new(),
+            description: None,
+        })
+    }
+
+    #[test]
+    fn should_prove_and_verify_token_infos_for_multiple_identity_ids() {
+        let drive = setup_drive_with_initial_state_structure(None);
+        let platform_version = PlatformVersion::latest();
+
+        let identity1 = Identity::random_identity(3, Some(14), platform_version)
+            .expect("expected a platform identity");
+        let identity2 = Identity::random_identity(3, Some(15), platform_version)
+            .expect("expected a platform identity");
+
+        let contract = create_token_contract();
+        let token_id = contract.token_id(0).expect("expected token at position 0");
+
+        // Add both identities
+        drive
+            .add_new_identity(
+                identity1.clone(),
+                false,
+                &BlockInfo::default(),
+                true,
+                None,
+                platform_version,
+            )
+            .expect("expected to add identity 1");
+
+        drive
+            .add_new_identity(
+                identity2.clone(),
+                false,
+                &BlockInfo::default(),
+                true,
+                None,
+                platform_version,
+            )
+            .expect("expected to add identity 2");
+
+        drive
+            .insert_contract(
+                &contract,
+                BlockInfo::default(),
+                true,
+                None,
+                platform_version,
+            )
+            .expect("expected to insert contract");
+
+        // Freeze only identity1 for this token
+        drive
+            .token_freeze(
+                token_id,
+                identity1.id(),
+                &BlockInfo::default(),
+                true,
+                None,
+                platform_version,
+            )
+            .expect("expected to freeze token for identity1");
+
+        let identity_ids = vec![identity1.id().to_buffer(), identity2.id().to_buffer()];
+
+        let proof = drive
+            .prove_identities_token_infos(
+                token_id.to_buffer(),
+                &identity_ids,
+                None,
+                platform_version,
+            )
+            .expect("expected to get proof");
+
+        let (_, infos): (_, BTreeMap<[u8; 32], Option<IdentityTokenInfo>>) =
+            Drive::verify_token_infos_for_identity_ids(
+                proof.as_slice(),
+                token_id.to_buffer(),
+                &identity_ids,
+                false,
+                platform_version,
+            )
+            .expect("expected proof verification to succeed");
+
+        assert_eq!(infos.len(), 2);
+        assert_eq!(
+            infos.get(&identity1.id().to_buffer()),
+            Some(&Some(IdentityTokenInfo::V0(IdentityTokenInfoV0 {
+                frozen: true
+            })))
+        );
+        assert_eq!(infos.get(&identity2.id().to_buffer()), Some(&None));
+    }
+
+    #[test]
+    fn should_prove_and_verify_absent_token_infos_for_identity_ids() {
+        let drive = setup_drive_with_initial_state_structure(None);
+        let platform_version = PlatformVersion::latest();
+
+        let identity = Identity::random_identity(3, Some(14), platform_version)
+            .expect("expected a platform identity");
+
+        let contract = create_token_contract();
+        let token_id = contract.token_id(0).expect("expected token at position 0");
+
+        drive
+            .add_new_identity(
+                identity.clone(),
+                false,
+                &BlockInfo::default(),
+                true,
+                None,
+                platform_version,
+            )
+            .expect("expected to add an identity");
+
+        drive
+            .insert_contract(
+                &contract,
+                BlockInfo::default(),
+                true,
+                None,
+                platform_version,
+            )
+            .expect("expected to insert contract");
+
+        let identity_ids = vec![identity.id().to_buffer()];
+
+        let proof = drive
+            .prove_identities_token_infos(
+                token_id.to_buffer(),
+                &identity_ids,
+                None,
+                platform_version,
+            )
+            .expect("expected to get proof");
+
+        let (_, infos): (_, BTreeMap<[u8; 32], Option<IdentityTokenInfo>>) =
+            Drive::verify_token_infos_for_identity_ids(
+                proof.as_slice(),
+                token_id.to_buffer(),
+                &identity_ids,
+                false,
+                platform_version,
+            )
+            .expect("expected proof verification to succeed");
+
+        assert_eq!(infos.len(), 1);
+        assert_eq!(infos.get(&identity.id().to_buffer()), Some(&None));
+    }
+}

--- a/packages/rs-drive/src/verify/tokens/verify_token_statuses/v0/mod.rs
+++ b/packages/rs-drive/src/verify/tokens/verify_token_statuses/v0/mod.rs
@@ -63,3 +63,130 @@ impl Drive {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::util::test_helpers::setup::setup_drive_with_initial_state_structure;
+    use dpp::block::block_info::BlockInfo;
+    use dpp::data_contract::accessors::v1::DataContractV1Getters;
+    use dpp::data_contract::associated_token::token_configuration::v0::TokenConfigurationV0;
+    use dpp::data_contract::associated_token::token_configuration::TokenConfiguration;
+    use dpp::data_contract::config::v0::DataContractConfigV0;
+    use dpp::data_contract::config::DataContractConfig;
+    use dpp::data_contract::v1::DataContractV1;
+    use dpp::prelude::DataContract;
+    use dpp::tokens::status::v0::TokenStatusV0;
+    use dpp::version::PlatformVersion;
+    use std::collections::BTreeMap;
+
+    fn create_token_contract() -> DataContract {
+        DataContract::V1(DataContractV1 {
+            id: Default::default(),
+            version: 0,
+            owner_id: Default::default(),
+            document_types: Default::default(),
+            config: DataContractConfig::V0(DataContractConfigV0 {
+                can_be_deleted: false,
+                readonly: false,
+                keeps_history: false,
+                documents_keep_history_contract_default: false,
+                documents_mutable_contract_default: false,
+                documents_can_be_deleted_contract_default: false,
+                requires_identity_encryption_bounded_key: None,
+                requires_identity_decryption_bounded_key: None,
+            }),
+            schema_defs: None,
+            created_at: None,
+            updated_at: None,
+            created_at_block_height: None,
+            updated_at_block_height: None,
+            created_at_epoch: None,
+            updated_at_epoch: None,
+            groups: Default::default(),
+            tokens: BTreeMap::from([(
+                0,
+                TokenConfiguration::V0(TokenConfigurationV0::default_most_restrictive()),
+            )]),
+            keywords: Vec::new(),
+            description: None,
+        })
+    }
+
+    #[test]
+    fn should_prove_and_verify_token_statuses_paused() {
+        let drive = setup_drive_with_initial_state_structure(None);
+        let platform_version = PlatformVersion::latest();
+
+        let contract = create_token_contract();
+        let token_id = contract.token_id(0).expect("expected token at position 0");
+
+        drive
+            .insert_contract(
+                &contract,
+                BlockInfo::default(),
+                true,
+                None,
+                platform_version,
+            )
+            .expect("expected to insert contract");
+
+        // Pause the token
+        drive
+            .token_apply_status(
+                token_id.to_buffer(),
+                TokenStatus::new(true, platform_version).expect("expected token status"),
+                &BlockInfo::default(),
+                true,
+                None,
+                platform_version,
+            )
+            .expect("expected to pause token");
+
+        let token_ids = vec![token_id.to_buffer()];
+        let proof = drive
+            .prove_token_statuses(&token_ids, None, platform_version)
+            .expect("expected to get proof");
+
+        let (_, statuses): (_, BTreeMap<[u8; 32], Option<TokenStatus>>) =
+            Drive::verify_token_statuses(
+                proof.as_slice(),
+                &token_ids,
+                false,
+                platform_version,
+            )
+            .expect("expected proof verification to succeed");
+
+        assert_eq!(statuses.len(), 1);
+        assert_eq!(
+            statuses.get(&token_id.to_buffer()),
+            Some(&Some(TokenStatus::V0(TokenStatusV0 { paused: true })))
+        );
+    }
+
+    #[test]
+    fn should_prove_and_verify_absent_token_statuses() {
+        let drive = setup_drive_with_initial_state_structure(None);
+        let platform_version = PlatformVersion::latest();
+
+        // Use a non-existent token id
+        let non_existent_token_id = [0u8; 32];
+        let token_ids = vec![non_existent_token_id];
+
+        let proof = drive
+            .prove_token_statuses(&token_ids, None, platform_version)
+            .expect("expected to get proof");
+
+        let (_, statuses): (_, BTreeMap<[u8; 32], Option<TokenStatus>>) =
+            Drive::verify_token_statuses(
+                proof.as_slice(),
+                &token_ids,
+                false,
+                platform_version,
+            )
+            .expect("expected proof verification to succeed");
+
+        assert_eq!(statuses.len(), 1);
+        assert_eq!(statuses.get(&non_existent_token_id), Some(&None));
+    }
+}

--- a/packages/rs-drive/src/verify/tokens/verify_token_statuses/v0/mod.rs
+++ b/packages/rs-drive/src/verify/tokens/verify_token_statuses/v0/mod.rs
@@ -149,13 +149,8 @@ mod tests {
             .expect("expected to get proof");
 
         let (_, statuses): (_, BTreeMap<[u8; 32], Option<TokenStatus>>) =
-            Drive::verify_token_statuses(
-                proof.as_slice(),
-                &token_ids,
-                false,
-                platform_version,
-            )
-            .expect("expected proof verification to succeed");
+            Drive::verify_token_statuses(proof.as_slice(), &token_ids, false, platform_version)
+                .expect("expected proof verification to succeed");
 
         assert_eq!(statuses.len(), 1);
         assert_eq!(
@@ -178,13 +173,8 @@ mod tests {
             .expect("expected to get proof");
 
         let (_, statuses): (_, BTreeMap<[u8; 32], Option<TokenStatus>>) =
-            Drive::verify_token_statuses(
-                proof.as_slice(),
-                &token_ids,
-                false,
-                platform_version,
-            )
-            .expect("expected proof verification to succeed");
+            Drive::verify_token_statuses(proof.as_slice(), &token_ids, false, platform_version)
+                .expect("expected proof verification to succeed");
 
         assert_eq!(statuses.len(), 1);
         assert_eq!(statuses.get(&non_existent_token_id), Some(&None));

--- a/packages/rs-drive/src/verify/tokens/verify_token_total_supply_and_aggregated_identity_balance/v0/mod.rs
+++ b/packages/rs-drive/src/verify/tokens/verify_token_total_supply_and_aggregated_identity_balance/v0/mod.rs
@@ -178,14 +178,13 @@ mod tests {
             )
             .expect("expected to get proof");
 
-        let (_, total_balance) =
-            Drive::verify_token_total_supply_and_aggregated_identity_balance(
-                proof.as_slice(),
-                token_id.to_buffer(),
-                false,
-                platform_version,
-            )
-            .expect("expected proof verification to succeed");
+        let (_, total_balance) = Drive::verify_token_total_supply_and_aggregated_identity_balance(
+            proof.as_slice(),
+            token_id.to_buffer(),
+            false,
+            platform_version,
+        )
+        .expect("expected proof verification to succeed");
 
         // base_supply from default_most_restrictive is 100000, plus our mint of 1000
         let expected_supply = (100000 + mint_amount) as i64;

--- a/packages/rs-drive/src/verify/tokens/verify_token_total_supply_and_aggregated_identity_balance/v0/mod.rs
+++ b/packages/rs-drive/src/verify/tokens/verify_token_total_supply_and_aggregated_identity_balance/v0/mod.rs
@@ -71,3 +71,128 @@ impl Drive {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::util::test_helpers::setup::setup_drive_with_initial_state_structure;
+    use dpp::block::block_info::BlockInfo;
+    use dpp::data_contract::accessors::v1::DataContractV1Getters;
+    use dpp::data_contract::associated_token::token_configuration::v0::TokenConfigurationV0;
+    use dpp::data_contract::associated_token::token_configuration::TokenConfiguration;
+    use dpp::data_contract::config::v0::DataContractConfigV0;
+    use dpp::data_contract::config::DataContractConfig;
+    use dpp::data_contract::v1::DataContractV1;
+    use dpp::identity::accessors::IdentityGettersV0;
+    use dpp::identity::Identity;
+    use dpp::prelude::DataContract;
+    use dpp::version::PlatformVersion;
+    use std::collections::BTreeMap;
+
+    fn create_token_contract() -> DataContract {
+        DataContract::V1(DataContractV1 {
+            id: Default::default(),
+            version: 0,
+            owner_id: Default::default(),
+            document_types: Default::default(),
+            config: DataContractConfig::V0(DataContractConfigV0 {
+                can_be_deleted: false,
+                readonly: false,
+                keeps_history: false,
+                documents_keep_history_contract_default: false,
+                documents_mutable_contract_default: false,
+                documents_can_be_deleted_contract_default: false,
+                requires_identity_encryption_bounded_key: None,
+                requires_identity_decryption_bounded_key: None,
+            }),
+            schema_defs: None,
+            created_at: None,
+            updated_at: None,
+            created_at_block_height: None,
+            updated_at_block_height: None,
+            created_at_epoch: None,
+            updated_at_epoch: None,
+            groups: Default::default(),
+            tokens: BTreeMap::from([(
+                0,
+                TokenConfiguration::V0(TokenConfigurationV0::default_most_restrictive()),
+            )]),
+            keywords: Vec::new(),
+            description: None,
+        })
+    }
+
+    #[test]
+    fn should_prove_and_verify_token_total_supply_and_aggregated_balance() {
+        let drive = setup_drive_with_initial_state_structure(None);
+        let platform_version = PlatformVersion::latest();
+
+        let identity = Identity::random_identity(3, Some(14), platform_version)
+            .expect("expected a platform identity");
+        let identity_id = identity.id().to_buffer();
+
+        let contract = create_token_contract();
+        let token_id = contract.token_id(0).expect("expected token at position 0");
+
+        drive
+            .add_new_identity(
+                identity.clone(),
+                false,
+                &BlockInfo::default(),
+                true,
+                None,
+                platform_version,
+            )
+            .expect("expected to add an identity");
+
+        drive
+            .insert_contract(
+                &contract,
+                BlockInfo::default(),
+                true,
+                None,
+                platform_version,
+            )
+            .expect("expected to insert contract");
+
+        let mint_amount = 1000u64;
+        drive
+            .token_mint(
+                token_id.to_buffer(),
+                identity_id,
+                mint_amount,
+                true,
+                false,
+                &BlockInfo::default(),
+                true,
+                None,
+                platform_version,
+            )
+            .expect("expected to mint tokens");
+
+        let proof = drive
+            .prove_token_total_supply_and_aggregated_identity_balances(
+                token_id.to_buffer(),
+                None,
+                platform_version,
+            )
+            .expect("expected to get proof");
+
+        let (_, total_balance) =
+            Drive::verify_token_total_supply_and_aggregated_identity_balance(
+                proof.as_slice(),
+                token_id.to_buffer(),
+                false,
+                platform_version,
+            )
+            .expect("expected proof verification to succeed");
+
+        // base_supply from default_most_restrictive is 100000, plus our mint of 1000
+        let expected_supply = (100000 + mint_amount) as i64;
+        assert_eq!(total_balance.token_supply, expected_supply);
+        assert_eq!(
+            total_balance.aggregated_token_account_balances,
+            expected_supply
+        );
+    }
+}

--- a/packages/rs-drive/src/verify/voting/verify_contests_proof/v0/mod.rs
+++ b/packages/rs-drive/src/verify/voting/verify_contests_proof/v0/mod.rs
@@ -87,3 +87,75 @@ impl ResolvedVotePollsByDocumentTypeQuery<'_> {
         Ok((root_hash, values))
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::util::object_size_info::DataContractResolvedInfo;
+    use crate::util::test_helpers::setup::setup_drive_with_initial_state_structure;
+    use dpp::block::block_info::BlockInfo;
+    use dpp::tests::json_document::json_document_to_contract;
+    use std::sync::Arc;
+
+    #[test]
+    fn should_prove_and_verify_empty_contests_proof() {
+        let drive = setup_drive_with_initial_state_structure(None);
+        let platform_version = PlatformVersion::latest();
+
+        let data_contract = json_document_to_contract(
+            "tests/supporting_files/contract/dpns/dpns-contract-contested-unique-index.json",
+            false,
+            platform_version,
+        )
+        .expect("expected to create a data contract");
+
+        // Insert the DPNS contract so its paths exist in the store
+        drive
+            .insert_contract(
+                &data_contract,
+                BlockInfo::default(),
+                true,
+                None,
+                platform_version,
+            )
+            .expect("expected to insert contract");
+
+        let doc_type_name = String::from("domain");
+        let index_name = String::from("parentNameAndLabel");
+        let start_index_values = vec![Value::Text("dash".to_string())];
+        let end_index_values = vec![];
+        let start_at_value = None;
+        let arc_contract = Arc::new(data_contract);
+
+        let query = ResolvedVotePollsByDocumentTypeQuery {
+            contract: DataContractResolvedInfo::ArcDataContract(arc_contract),
+            document_type_name: &doc_type_name,
+            index_name: &index_name,
+            start_index_values: &start_index_values,
+            end_index_values: &end_index_values,
+            start_at_value: &start_at_value,
+            limit: Some(10),
+            order_ascending: true,
+        };
+
+        // Build path query and generate proof from drive
+        let index = query.index().expect("expected to get index");
+        let path_query = query
+            .construct_path_query_with_known_index(index, platform_version)
+            .expect("expected to construct path query");
+        let proof = drive
+            .grove_get_proved_path_query(
+                &path_query,
+                None,
+                &mut vec![],
+                &platform_version.drive,
+            )
+            .expect("expected to get proof");
+
+        let (_, values) = query
+            .verify_contests_proof(proof.as_slice(), platform_version)
+            .expect("expected proof verification to succeed");
+
+        assert!(values.is_empty());
+    }
+}

--- a/packages/rs-drive/src/verify/voting/verify_contests_proof/v0/mod.rs
+++ b/packages/rs-drive/src/verify/voting/verify_contests_proof/v0/mod.rs
@@ -144,12 +144,7 @@ mod tests {
             .construct_path_query_with_known_index(index, platform_version)
             .expect("expected to construct path query");
         let proof = drive
-            .grove_get_proved_path_query(
-                &path_query,
-                None,
-                &mut vec![],
-                &platform_version.drive,
-            )
+            .grove_get_proved_path_query(&path_query, None, &mut vec![], &platform_version.drive)
             .expect("expected to get proof");
 
         let (_, values) = query

--- a/packages/rs-drive/src/verify/voting/verify_identity_votes_given_proof/v0/mod.rs
+++ b/packages/rs-drive/src/verify/voting/verify_identity_votes_given_proof/v0/mod.rs
@@ -66,3 +66,44 @@ impl ContestedResourceVotesGivenByIdentityQuery {
         Ok((root_hash, voters))
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::util::test_helpers::setup::setup_drive_with_initial_state_structure;
+    use dpp::version::PlatformVersion;
+    use std::collections::BTreeMap;
+
+    #[test]
+    fn should_prove_and_verify_empty_identity_votes_given() {
+        let drive = setup_drive_with_initial_state_structure(None);
+        let platform_version = PlatformVersion::latest();
+
+        let identity_id = Identifier::random();
+
+        let query = ContestedResourceVotesGivenByIdentityQuery {
+            identity_id,
+            offset: None,
+            limit: Some(10),
+            start_at: None,
+            order_ascending: true,
+        };
+
+        let (proof, _) = query
+            .clone()
+            .execute_with_proof(&drive, None, None, platform_version)
+            .expect("expected to execute query with proof");
+
+        let contract_lookup_fn: &ContractLookupFn = &|_id| Ok(None);
+
+        let (_, votes): (_, BTreeMap<Identifier, ResourceVote>) = query
+            .verify_identity_votes_given_proof(
+                proof.as_slice(),
+                contract_lookup_fn,
+                platform_version,
+            )
+            .expect("expected proof verification to succeed");
+
+        assert!(votes.is_empty());
+    }
+}

--- a/packages/rs-drive/src/verify/voting/verify_masternode_vote/v0/mod.rs
+++ b/packages/rs-drive/src/verify/voting/verify_masternode_vote/v0/mod.rs
@@ -123,3 +123,78 @@ impl Drive {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::util::test_helpers::setup::setup_drive_with_initial_state_structure;
+    use dpp::data_contract::accessors::v0::DataContractV0Getters;
+    use dpp::tests::json_document::json_document_to_contract;
+    use dpp::voting::vote_choices::resource_vote_choice::ResourceVoteChoice;
+    use dpp::voting::vote_polls::contested_document_resource_vote_poll::ContestedDocumentResourceVotePoll;
+    use dpp::voting::vote_polls::VotePoll;
+    use dpp::voting::votes::resource_vote::v0::ResourceVoteV0;
+    use dpp::voting::votes::resource_vote::ResourceVote;
+    use dpp::prelude::Identifier;
+
+    #[test]
+    fn should_prove_and_verify_absent_masternode_vote() {
+        let drive = setup_drive_with_initial_state_structure(None);
+        let platform_version = PlatformVersion::latest();
+
+        let data_contract = json_document_to_contract(
+            "tests/supporting_files/contract/dpns/dpns-contract.json",
+            false,
+            platform_version,
+        )
+        .expect("expected to create a data contract");
+
+        let masternode_pro_tx_hash = [1u8; 32];
+        let contender_id = Identifier::from([2u8; 32]);
+
+        let vote = Vote::ResourceVote(ResourceVote::V0(ResourceVoteV0 {
+            vote_poll: VotePoll::ContestedDocumentResourceVotePoll(
+                ContestedDocumentResourceVotePoll {
+                    contract_id: data_contract.id(),
+                    document_type_name: "domain".to_string(),
+                    index_name: "parentNameAndLabel".to_string(),
+                    index_values: vec![
+                        dpp::platform_value::Value::Text("dash".to_string()),
+                    ],
+                },
+            ),
+            resource_vote_choice: ResourceVoteChoice::TowardsIdentity(contender_id),
+        }));
+
+        // Build the path query as the verify function would
+        let path = vote_contested_resource_identity_votes_tree_path_for_identity_vec(
+            &masternode_pro_tx_hash,
+        );
+        let vote_id = vote.vote_poll_unique_id().expect("expected vote poll unique id");
+        let mut query = Query::new();
+        query.insert_key(vote_id.to_vec());
+        let path_query = PathQuery::new(path, SizedQuery::new(query, Some(1), None));
+
+        // Generate a proof using the path query
+        let proof = drive
+            .grove_get_proved_path_query(
+                &path_query,
+                None,
+                &mut vec![],
+                &platform_version.drive,
+            )
+            .expect("expected to get proof");
+
+        let (_, maybe_vote) = Drive::verify_masternode_vote(
+            proof.as_slice(),
+            masternode_pro_tx_hash,
+            &vote,
+            &data_contract,
+            false,
+            platform_version,
+        )
+        .expect("expected proof verification to succeed");
+
+        assert_eq!(maybe_vote, None);
+    }
+}

--- a/packages/rs-drive/src/verify/voting/verify_masternode_vote/v0/mod.rs
+++ b/packages/rs-drive/src/verify/voting/verify_masternode_vote/v0/mod.rs
@@ -129,13 +129,13 @@ mod tests {
     use super::*;
     use crate::util::test_helpers::setup::setup_drive_with_initial_state_structure;
     use dpp::data_contract::accessors::v0::DataContractV0Getters;
+    use dpp::prelude::Identifier;
     use dpp::tests::json_document::json_document_to_contract;
     use dpp::voting::vote_choices::resource_vote_choice::ResourceVoteChoice;
     use dpp::voting::vote_polls::contested_document_resource_vote_poll::ContestedDocumentResourceVotePoll;
     use dpp::voting::vote_polls::VotePoll;
     use dpp::voting::votes::resource_vote::v0::ResourceVoteV0;
     use dpp::voting::votes::resource_vote::ResourceVote;
-    use dpp::prelude::Identifier;
 
     #[test]
     fn should_prove_and_verify_absent_masternode_vote() {
@@ -158,9 +158,7 @@ mod tests {
                     contract_id: data_contract.id(),
                     document_type_name: "domain".to_string(),
                     index_name: "parentNameAndLabel".to_string(),
-                    index_values: vec![
-                        dpp::platform_value::Value::Text("dash".to_string()),
-                    ],
+                    index_values: vec![dpp::platform_value::Value::Text("dash".to_string())],
                 },
             ),
             resource_vote_choice: ResourceVoteChoice::TowardsIdentity(contender_id),
@@ -170,19 +168,16 @@ mod tests {
         let path = vote_contested_resource_identity_votes_tree_path_for_identity_vec(
             &masternode_pro_tx_hash,
         );
-        let vote_id = vote.vote_poll_unique_id().expect("expected vote poll unique id");
+        let vote_id = vote
+            .vote_poll_unique_id()
+            .expect("expected vote poll unique id");
         let mut query = Query::new();
         query.insert_key(vote_id.to_vec());
         let path_query = PathQuery::new(path, SizedQuery::new(query, Some(1), None));
 
         // Generate a proof using the path query
         let proof = drive
-            .grove_get_proved_path_query(
-                &path_query,
-                None,
-                &mut vec![],
-                &platform_version.drive,
-            )
+            .grove_get_proved_path_query(&path_query, None, &mut vec![], &platform_version.drive)
             .expect("expected to get proof");
 
         let (_, maybe_vote) = Drive::verify_masternode_vote(

--- a/packages/rs-drive/src/verify/voting/verify_specialized_balance/v0/mod.rs
+++ b/packages/rs-drive/src/verify/voting/verify_specialized_balance/v0/mod.rs
@@ -92,3 +92,73 @@ impl Drive {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::util::test_helpers::setup::setup_drive_with_initial_state_structure;
+    use dpp::identifier::Identifier;
+    use dpp::version::PlatformVersion;
+
+    #[test]
+    fn should_prove_and_verify_specialized_balance_present() {
+        let drive = setup_drive_with_initial_state_structure(None);
+        let platform_version = PlatformVersion::latest();
+
+        let balance_id = Identifier::random();
+        let amount = 500u64;
+
+        drive
+            .add_prefunded_specialized_balance(
+                balance_id,
+                amount,
+                None,
+                platform_version,
+            )
+            .expect("expected to add prefunded specialized balance");
+
+        let proof = drive
+            .prove_prefunded_specialized_balance(
+                balance_id.to_buffer(),
+                None,
+                platform_version,
+            )
+            .expect("expected to get proof");
+
+        let (_, balance) = Drive::verify_specialized_balance(
+            proof.as_slice(),
+            balance_id.to_buffer(),
+            false,
+            platform_version,
+        )
+        .expect("expected proof verification to succeed");
+
+        assert_eq!(balance, Some(amount));
+    }
+
+    #[test]
+    fn should_prove_and_verify_absent_specialized_balance() {
+        let drive = setup_drive_with_initial_state_structure(None);
+        let platform_version = PlatformVersion::latest();
+
+        let non_existent_balance_id = [0u8; 32];
+
+        let proof = drive
+            .prove_prefunded_specialized_balance(
+                non_existent_balance_id,
+                None,
+                platform_version,
+            )
+            .expect("expected to get proof");
+
+        let (_, balance) = Drive::verify_specialized_balance(
+            proof.as_slice(),
+            non_existent_balance_id,
+            false,
+            platform_version,
+        )
+        .expect("expected proof verification to succeed");
+
+        assert_eq!(balance, None);
+    }
+}

--- a/packages/rs-drive/src/verify/voting/verify_specialized_balance/v0/mod.rs
+++ b/packages/rs-drive/src/verify/voting/verify_specialized_balance/v0/mod.rs
@@ -109,20 +109,11 @@ mod tests {
         let amount = 500u64;
 
         drive
-            .add_prefunded_specialized_balance(
-                balance_id,
-                amount,
-                None,
-                platform_version,
-            )
+            .add_prefunded_specialized_balance(balance_id, amount, None, platform_version)
             .expect("expected to add prefunded specialized balance");
 
         let proof = drive
-            .prove_prefunded_specialized_balance(
-                balance_id.to_buffer(),
-                None,
-                platform_version,
-            )
+            .prove_prefunded_specialized_balance(balance_id.to_buffer(), None, platform_version)
             .expect("expected to get proof");
 
         let (_, balance) = Drive::verify_specialized_balance(
@@ -144,11 +135,7 @@ mod tests {
         let non_existent_balance_id = [0u8; 32];
 
         let proof = drive
-            .prove_prefunded_specialized_balance(
-                non_existent_balance_id,
-                None,
-                platform_version,
-            )
+            .prove_prefunded_specialized_balance(non_existent_balance_id, None, platform_version)
             .expect("expected to get proof");
 
         let (_, balance) = Drive::verify_specialized_balance(

--- a/packages/rs-drive/src/verify/voting/verify_vote_poll_vote_state_proof/v0/mod.rs
+++ b/packages/rs-drive/src/verify/voting/verify_vote_poll_vote_state_proof/v0/mod.rs
@@ -405,12 +405,7 @@ mod tests {
             .expect("expected to construct path query");
 
         let proof = drive
-            .grove_get_proved_path_query(
-                &path_query,
-                None,
-                &mut vec![],
-                &platform_version.drive,
-            )
+            .grove_get_proved_path_query(&path_query, None, &mut vec![], &platform_version.drive)
             .expect("expected to get proof");
 
         let (_, result) = query

--- a/packages/rs-drive/src/verify/voting/verify_vote_poll_vote_state_proof/v0/mod.rs
+++ b/packages/rs-drive/src/verify/voting/verify_vote_poll_vote_state_proof/v0/mod.rs
@@ -346,3 +346,80 @@ impl ResolvedContestedDocumentVotePollDriveQuery<'_> {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::drive::votes::resolved::vote_polls::contested_document_resource_vote_poll::ContestedDocumentResourceVotePollWithContractInfoAllowBorrowed;
+    use crate::query::vote_poll_vote_state_query::ContestedDocumentVotePollDriveQueryResultType;
+    use crate::util::object_size_info::DataContractResolvedInfo;
+    use crate::util::test_helpers::setup::setup_drive_with_initial_state_structure;
+    use dpp::block::block_info::BlockInfo;
+    use dpp::tests::json_document::json_document_to_contract;
+    use std::sync::Arc;
+
+    #[test]
+    fn should_prove_and_verify_empty_vote_poll_vote_state_proof_documents() {
+        let drive = setup_drive_with_initial_state_structure(None);
+        let platform_version = PlatformVersion::latest();
+
+        let data_contract = json_document_to_contract(
+            "tests/supporting_files/contract/dpns/dpns-contract-contested-unique-index.json",
+            false,
+            platform_version,
+        )
+        .expect("expected to create a data contract");
+
+        // Insert the DPNS contract so its paths exist in the store
+        drive
+            .insert_contract(
+                &data_contract,
+                BlockInfo::default(),
+                true,
+                None,
+                platform_version,
+            )
+            .expect("expected to insert contract");
+
+        let arc_contract = Arc::new(data_contract);
+
+        let query = ResolvedContestedDocumentVotePollDriveQuery {
+            vote_poll: ContestedDocumentResourceVotePollWithContractInfoAllowBorrowed {
+                contract: DataContractResolvedInfo::ArcDataContract(arc_contract),
+                document_type_name: "domain".to_string(),
+                index_name: "parentNameAndLabel".to_string(),
+                index_values: vec![
+                    dpp::platform_value::Value::Text("dash".to_string()),
+                    dpp::platform_value::Value::Text("test".to_string()),
+                ],
+            },
+            result_type: ContestedDocumentVotePollDriveQueryResultType::Documents,
+            offset: None,
+            limit: Some(10),
+            start_at: None,
+            allow_include_locked_and_abstaining_vote_tally: false,
+        };
+
+        let path_query = query
+            .construct_path_query(platform_version)
+            .expect("expected to construct path query");
+
+        let proof = drive
+            .grove_get_proved_path_query(
+                &path_query,
+                None,
+                &mut vec![],
+                &platform_version.drive,
+            )
+            .expect("expected to get proof");
+
+        let (_, result) = query
+            .verify_vote_poll_vote_state_proof(proof.as_slice(), platform_version)
+            .expect("expected proof verification to succeed");
+
+        assert!(result.contenders.is_empty());
+        assert_eq!(result.locked_vote_tally, None);
+        assert_eq!(result.abstaining_vote_tally, None);
+        assert_eq!(result.winner, None);
+    }
+}

--- a/packages/rs-drive/src/verify/voting/verify_vote_poll_votes_proof/v0/mod.rs
+++ b/packages/rs-drive/src/verify/voting/verify_vote_poll_votes_proof/v0/mod.rs
@@ -47,3 +47,77 @@ impl ResolvedContestedDocumentVotePollVotesDriveQuery<'_> {
         Ok((root_hash, voters))
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::drive::votes::resolved::vote_polls::contested_document_resource_vote_poll::ContestedDocumentResourceVotePollWithContractInfoAllowBorrowed;
+    use crate::util::object_size_info::DataContractResolvedInfo;
+    use crate::util::test_helpers::setup::setup_drive_with_initial_state_structure;
+    use dpp::block::block_info::BlockInfo;
+    use dpp::tests::json_document::json_document_to_contract;
+    use std::sync::Arc;
+
+    #[test]
+    fn should_prove_and_verify_empty_vote_poll_votes_proof() {
+        let drive = setup_drive_with_initial_state_structure(None);
+        let platform_version = PlatformVersion::latest();
+
+        let data_contract = json_document_to_contract(
+            "tests/supporting_files/contract/dpns/dpns-contract-contested-unique-index.json",
+            false,
+            platform_version,
+        )
+        .expect("expected to create a data contract");
+
+        // Insert the DPNS contract so its paths exist in the store
+        drive
+            .insert_contract(
+                &data_contract,
+                BlockInfo::default(),
+                true,
+                None,
+                platform_version,
+            )
+            .expect("expected to insert contract");
+
+        let arc_contract = Arc::new(data_contract);
+        let contestant_id = Identifier::random();
+
+        let query = ResolvedContestedDocumentVotePollVotesDriveQuery {
+            vote_poll: ContestedDocumentResourceVotePollWithContractInfoAllowBorrowed {
+                contract: DataContractResolvedInfo::ArcDataContract(arc_contract),
+                document_type_name: "domain".to_string(),
+                index_name: "parentNameAndLabel".to_string(),
+                index_values: vec![
+                    dpp::platform_value::Value::Text("dash".to_string()),
+                    dpp::platform_value::Value::Text("test".to_string()),
+                ],
+            },
+            contestant_id,
+            offset: None,
+            limit: Some(10),
+            start_at: None,
+            order_ascending: true,
+        };
+
+        let path_query = query
+            .construct_path_query(platform_version)
+            .expect("expected to construct path query");
+
+        let proof = drive
+            .grove_get_proved_path_query(
+                &path_query,
+                None,
+                &mut vec![],
+                &platform_version.drive,
+            )
+            .expect("expected to get proof");
+
+        let (_, voters) = query
+            .verify_vote_poll_votes_proof(proof.as_slice(), platform_version)
+            .expect("expected proof verification to succeed");
+
+        assert!(voters.is_empty());
+    }
+}

--- a/packages/rs-drive/src/verify/voting/verify_vote_poll_votes_proof/v0/mod.rs
+++ b/packages/rs-drive/src/verify/voting/verify_vote_poll_votes_proof/v0/mod.rs
@@ -106,12 +106,7 @@ mod tests {
             .expect("expected to construct path query");
 
         let proof = drive
-            .grove_get_proved_path_query(
-                &path_query,
-                None,
-                &mut vec![],
-                &platform_version.drive,
-            )
+            .grove_get_proved_path_query(&path_query, None, &mut vec![], &platform_version.drive)
             .expect("expected to get proof");
 
         let (_, voters) = query

--- a/packages/rs-drive/src/verify/voting/verify_vote_polls_end_date_query/v0/mod.rs
+++ b/packages/rs-drive/src/verify/voting/verify_vote_polls_end_date_query/v0/mod.rs
@@ -83,3 +83,35 @@ impl VotePollsByEndDateDriveQuery {
         Ok((root_hash, vote_polls_by_end_date))
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::util::test_helpers::setup::setup_drive_with_initial_state_structure;
+    use dpp::version::PlatformVersion;
+
+    #[test]
+    fn should_prove_and_verify_empty_vote_polls_by_end_date() {
+        let drive = setup_drive_with_initial_state_structure(None);
+        let platform_version = PlatformVersion::latest();
+
+        let query = VotePollsByEndDateDriveQuery {
+            start_time: None,
+            end_time: None,
+            limit: Some(10),
+            offset: None,
+            order_ascending: true,
+        };
+
+        let (proof, _) = query
+            .clone()
+            .execute_with_proof(&drive, None, None, platform_version)
+            .expect("expected to execute query with proof");
+
+        let (_, result): (_, BTreeMap<TimestampMillis, Vec<VotePoll>>) = query
+            .verify_vote_polls_by_end_date_proof(proof.as_slice(), platform_version)
+            .expect("expected proof verification to succeed");
+
+        assert!(result.is_empty());
+    }
+}

--- a/packages/rs-drive/tests/supporting_files/contract/dpns/dpns-contract-contested-unique-index.json
+++ b/packages/rs-drive/tests/supporting_files/contract/dpns/dpns-contract-contested-unique-index.json
@@ -1,0 +1,169 @@
+{
+  "$formatVersion": "0",
+  "id": "DWBXe9EXFPHxvbArQgT45uQR5gMmi8dfMpLhR5KSbwnZ",
+  "ownerId": "2QjL594djCH2NyDsn45vd6yQjEDHupMKo7CEGVTHtQxU",
+  "version": 1,
+  "documentSchemas": {
+    "domain": {
+      "documentsMutable": false,
+      "canBeDeleted": true,
+      "transferable": 1,
+      "tradeMode": 1,
+      "type": "object",
+      "indices": [
+        {
+          "name": "parentNameAndLabel",
+          "properties": [
+            {
+              "normalizedParentDomainName": "asc"
+            },
+            {
+              "normalizedLabel": "asc"
+            }
+          ],
+          "unique": true,
+          "contested": {
+            "fieldMatches": [
+              {
+                "field": "normalizedLabel",
+                "regexPattern": "^[a-zA-Z01]{3,19}$"
+              }
+            ],
+            "resolution": 0,
+            "description": "If the normalized label part of this index is less than 20 characters (all alphabet a-z and 0 and 1) then this index is non unique while contest resolution takes place."
+          }
+        },
+        {
+          "name": "identityId",
+          "nullSearchable": false,
+          "properties": [
+            {
+              "records.identity": "asc"
+            }
+          ]
+        }
+      ],
+      "properties": {
+        "label": {
+          "type": "string",
+          "pattern": "^[a-zA-Z0-9][a-zA-Z0-9-]{0,61}[a-zA-Z0-9]$",
+          "minLength": 3,
+          "maxLength": 63,
+          "position": 0,
+          "description": "Domain label. e.g. 'Bob'."
+        },
+        "normalizedLabel": {
+          "type": "string",
+          "pattern": "^[a-hj-km-np-z0-9][a-hj-km-np-z0-9-]{0,61}[a-hj-km-np-z0-9]$",
+          "maxLength": 63,
+          "position": 1,
+          "description": "Domain label converted to lowercase for case-insensitive uniqueness validation. \"o\", \"i\" and \"l\" replaced with \"0\" and \"1\" to mitigate homograph attack. e.g. 'b0b'",
+          "$comment": "Must be equal to the label in lowercase. \"o\", \"i\" and \"l\" must be replaced with \"0\" and \"1\"."
+        },
+        "parentDomainName": {
+          "type": "string",
+          "pattern": "^$|^[a-zA-Z0-9][a-zA-Z0-9-]{0,61}[a-zA-Z0-9]$",
+          "minLength": 0,
+          "maxLength": 63,
+          "position": 2,
+          "description": "A full parent domain name. e.g. 'dash'."
+        },
+        "normalizedParentDomainName": {
+          "type": "string",
+          "pattern": "^$|^[a-hj-km-np-z0-9][a-hj-km-np-z0-9-\\.]{0,61}[a-hj-km-np-z0-9]$",
+          "minLength": 0,
+          "maxLength": 63,
+          "position": 3,
+          "description": "A parent domain name in lowercase for case-insensitive uniqueness validation. \"o\", \"i\" and \"l\" replaced with \"0\" and \"1\" to mitigate homograph attack. e.g. 'dash'",
+          "$comment": "Must either be equal to an existing domain or empty to create a top level domain. \"o\", \"i\" and \"l\" must be replaced with \"0\" and \"1\". Only the data contract owner can create top level domains."
+        },
+        "preorderSalt": {
+          "type": "array",
+          "byteArray": true,
+          "minItems": 32,
+          "maxItems": 32,
+          "position": 4,
+          "description": "Salt used in the preorder document"
+        },
+        "records": {
+          "type": "object",
+          "properties": {
+            "identity": {
+              "type": "array",
+              "byteArray": true,
+              "minItems": 32,
+              "maxItems": 32,
+              "position": 1,
+              "contentMediaType": "application/x.dash.dpp.identifier",
+              "description": "Identifier name record that refers to an Identity"
+            }
+          },
+          "minProperties": 1,
+          "position": 5,
+          "additionalProperties": false
+        },
+        "subdomainRules": {
+          "type": "object",
+          "properties": {
+            "allowSubdomains": {
+              "type": "boolean",
+              "description": "This option defines who can create subdomains: true - anyone; false - only the domain owner",
+              "$comment": "Only the domain owner is allowed to create subdomains for non top-level domains",
+              "position": 0
+            }
+          },
+          "position": 6,
+          "description": "Subdomain rules allow domain owners to define rules for subdomains",
+          "additionalProperties": false,
+          "required": [
+            "allowSubdomains"
+          ]
+        }
+      },
+      "required": [
+        "$createdAt",
+        "$updatedAt",
+        "$transferredAt",
+        "label",
+        "normalizedLabel",
+        "normalizedParentDomainName",
+        "preorderSalt",
+        "records",
+        "subdomainRules"
+      ],
+      "additionalProperties": false,
+      "$comment": "In order to register a domain you need to create a preorder. The preorder step is needed to prevent man-in-the-middle attacks. normalizedLabel + '.' + normalizedParentDomain must not be longer than 253 chars length as defined by RFC 1035. Domain documents are immutable: modification and deletion are restricted"
+    },
+    "preorder": {
+      "documentsMutable": false,
+      "canBeDeleted": true,
+      "type": "object",
+      "indices": [
+        {
+          "name": "saltedHash",
+          "properties": [
+            {
+              "saltedDomainHash": "asc"
+            }
+          ],
+          "unique": true
+        }
+      ],
+      "properties": {
+        "saltedDomainHash": {
+          "type": "array",
+          "byteArray": true,
+          "minItems": 32,
+          "maxItems": 32,
+          "position": 0,
+          "description": "Double sha-256 of the concatenation of a 32 byte random salt and a normalized domain name"
+        }
+      },
+      "required": [
+        "saltedDomainHash"
+      ],
+      "additionalProperties": false,
+      "$comment": "Preorder documents are immutable: modification and deletion are restricted"
+    }
+  }
+}


### PR DESCRIPTION
## Issue being fixed or feature implemented

Improves test coverage for `packages/rs-drive/src/verify/` by adding tests for 11 `v0/mod.rs` files that previously had 0% coverage.

## What was done?

Added `#[cfg(test)]` modules with prove-and-verify round-trip tests to all 11 zero-coverage verify v0 files:

**Token verify tests (4 files):**
- `verify_token_infos_for_identity_id/v0` -- tests frozen identity info and absent case
- `verify_token_infos_for_identity_ids/v0` -- tests multi-identity lookup (one frozen, one absent)
- `verify_token_statuses/v0` -- tests paused token status and absent status
- `verify_token_total_supply_and_aggregated_identity_balance/v0` -- tests minted token supply verification

**Voting verify tests (7 files):**
- `verify_specialized_balance/v0` -- tests present and absent prefunded balance
- `verify_vote_polls_end_date_query/v0` -- tests empty vote polls result
- `verify_identity_votes_given_proof/v0` -- tests empty votes given result
- `verify_masternode_vote/v0` -- tests absent masternode vote
- `verify_contests_proof/v0` -- tests empty contests result
- `verify_vote_poll_vote_state_proof/v0` -- tests empty contenders result
- `verify_vote_poll_votes_proof/v0` -- tests empty voters result

Each test follows the existing codebase pattern: set up drive state, generate a proof using the corresponding prove/query function, then verify the proof through the verify function under test.

Also added `dpns-contract-contested-unique-index.json` test fixture (copied from rs-drive-abci) needed by the voting contest tests.

## How Has This Been Tested?

All 15 new tests pass:
```
cargo test -p drive --lib "verify::" -- --test-threads=4
# test result: ok. 164 passed; 0 failed; 0 ignored
```

No clippy warnings introduced by the new code.

## Breaking Changes

None. This PR only adds tests.

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [x] I have made corresponding changes to the documentation if needed

Generated with [Claude Code](https://claude.com/claude-code)