### PR TITLE
test(drive-abci): add comprehensive tests for token query v0 modules

### DIFF
--- a/packages/rs-drive-abci/src/query/mod.rs
+++ b/packages/rs-drive-abci/src/query/mod.rs
@@ -160,4 +160,411 @@ pub(crate) mod tests {
             [QueryError::InvalidArgument(msg)] if msg.contains("id must be a valid identifier (32 bytes long)")
         ));
     }
+
+    /// Set up a platform with token state for testing token queries.
+    ///
+    /// Creates 3 identities and a data contract with 3 tokens.
+    /// Token 0: minted 100 to identity 1, 100 to identity 2. Identity 2 frozen on token 0.
+    /// Token 1: minted 200 to identity 1, 100 to identity 3. Token 1 is paused.
+    /// Token 2: minted 300 to identity 1, 200 to identity 2. Has pre-programmed distributions.
+    ///
+    /// Returns (platform, state, version, contract_id, [token_id_0, token_id_1, token_id_2],
+    ///          [identity_id_1, identity_id_2, identity_id_3])
+    #[allow(clippy::type_complexity)]
+    pub fn setup_platform_with_token_state<'a>() -> (
+        TempPlatform<MockCoreRPCLike>,
+        Arc<PlatformState>,
+        &'a PlatformVersion,
+        [u8; 32],
+        [[u8; 32]; 3],
+        [[u8; 32]; 3],
+    ) {
+        use dpp::data_contract::associated_token::token_configuration::v0::TokenConfigurationV0;
+        use dpp::data_contract::associated_token::token_configuration_convention::v0::TokenConfigurationConventionV0;
+        use dpp::data_contract::associated_token::token_distribution_rules::v0::TokenDistributionRulesV0;
+        use dpp::data_contract::associated_token::token_distribution_rules::TokenDistributionRules;
+        use dpp::data_contract::associated_token::token_keeps_history_rules::v0::TokenKeepsHistoryRulesV0;
+        use dpp::data_contract::associated_token::token_marketplace_rules::v0::TokenMarketplaceRulesV0;
+        use dpp::data_contract::associated_token::token_perpetual_distribution::distribution_function::DistributionFunction;
+        use dpp::data_contract::associated_token::token_perpetual_distribution::distribution_recipient::TokenDistributionRecipient;
+        use dpp::data_contract::associated_token::token_perpetual_distribution::reward_distribution_type::RewardDistributionType;
+        use dpp::data_contract::associated_token::token_perpetual_distribution::v0::TokenPerpetualDistributionV0;
+        use dpp::data_contract::associated_token::token_perpetual_distribution::TokenPerpetualDistribution;
+        use dpp::data_contract::associated_token::token_pre_programmed_distribution::v0::TokenPreProgrammedDistributionV0;
+        use dpp::data_contract::associated_token::token_pre_programmed_distribution::TokenPreProgrammedDistribution;
+        use dpp::data_contract::change_control_rules::authorized_action_takers::AuthorizedActionTakers;
+        use dpp::data_contract::change_control_rules::v0::ChangeControlRulesV0;
+        use dpp::data_contract::config::DataContractConfig;
+        use dpp::data_contract::group::v0::GroupV0;
+        use dpp::data_contract::group::Group;
+        use dpp::data_contract::v1::DataContractV1;
+        use dpp::data_contract::{TokenConfiguration, INITIAL_DATA_CONTRACT_VERSION};
+        use dpp::identifier::Identifier;
+        use dpp::identity::accessors::IdentitySettersV0;
+        use dpp::identity::Identity;
+        use dpp::prelude::IdentityPublicKey;
+        use dpp::tokens::calculate_token_id;
+        use dpp::tokens::status::v0::TokenStatusV0;
+        use dpp::tokens::status::TokenStatus;
+        use dpp::tokens::token_pricing_schedule::TokenPricingSchedule;
+        use rand::rngs::StdRng;
+        use rand::SeedableRng;
+        use std::collections::BTreeMap;
+        use dpp::identity::identity_public_key::accessors::v0::IdentityPublicKeyGettersV0;
+
+        let (platform, state, version) = setup_platform(Some((1, 1)), Network::Testnet, None);
+
+        let identity_id_1 = [1u8; 32];
+        let identity_id_2 = [2u8; 32];
+        let identity_id_3 = [3u8; 32];
+        let contract_id = [3u8; 32];
+
+        let token_id_0 = calculate_token_id(&contract_id, 0);
+        let token_id_1 = calculate_token_id(&contract_id, 1);
+        let token_id_2 = calculate_token_id(&contract_id, 2);
+
+        // Register identities
+        let credits_per_identity: u64 = 10_000_000_000_000;
+        let total_credits = credits_per_identity * 3;
+        platform
+            .platform
+            .drive
+            .add_to_system_credits(total_credits, None, version)
+            .expect("expected to add system credits");
+
+        let mut rng = StdRng::seed_from_u64(0u64);
+        let non_unique_key = IdentityPublicKey::random_voting_key_with_rng(11, &mut rng, version)
+            .expect("expected to create voting key");
+
+        for id_bytes in [identity_id_1, identity_id_2, identity_id_3] {
+            let id = Identifier::new(id_bytes);
+            let mut identity =
+                Identity::create_basic_identity(id, version).expect("expected to create identity");
+            identity.set_balance(credits_per_identity);
+
+            let seed = id_bytes[0];
+            let mut rng = StdRng::seed_from_u64(seed as u64);
+            let mut keys =
+                IdentityPublicKey::main_keys_with_random_authentication_keys_with_private_keys_with_rng(
+                    3, &mut rng, version,
+                )
+                .expect("expected to create keys");
+
+            let transfer_key =
+                IdentityPublicKey::random_masternode_transfer_key_with_rng(3, &mut rng, version)
+                    .expect("expected to create transfer key");
+            keys.push(transfer_key);
+            keys.push(non_unique_key.clone());
+
+            identity.set_public_keys(keys.into_iter().map(|(key, _)| (key.id(), key)).collect());
+
+            platform
+                .platform
+                .drive
+                .add_new_identity(identity, false, &BlockInfo::genesis(), true, None, version)
+                .expect("expected to add identity");
+        }
+
+        // Create data contract with tokens
+        let groups = [
+            (
+                0,
+                Group::V0(GroupV0 {
+                    members: [
+                        (Identifier::new(identity_id_1), 1),
+                        (Identifier::new(identity_id_2), 1),
+                    ]
+                    .into(),
+                    required_power: 1,
+                }),
+            ),
+            (
+                1,
+                Group::V0(GroupV0 {
+                    members: [
+                        (Identifier::new(identity_id_1), 1),
+                        (Identifier::new(identity_id_2), 1),
+                        (Identifier::new(identity_id_3), 1),
+                    ]
+                    .into(),
+                    required_power: 3,
+                }),
+            ),
+            (
+                2,
+                Group::V0(GroupV0 {
+                    members: [
+                        (Identifier::new(identity_id_1), 1),
+                        (Identifier::new(identity_id_3), 1),
+                    ]
+                    .into(),
+                    required_power: 1,
+                }),
+            ),
+        ]
+        .into();
+
+        let token_configuration = TokenConfiguration::V0(TokenConfigurationV0 {
+            conventions: TokenConfigurationConventionV0 {
+                localizations: Default::default(),
+                decimals: 8,
+            }
+            .into(),
+            conventions_change_rules: ChangeControlRulesV0::default().into(),
+            base_supply: 100000,
+            max_supply: None,
+            keeps_history: TokenKeepsHistoryRulesV0::default().into(),
+            start_as_paused: false,
+            allow_transfer_to_frozen_balance: true,
+            max_supply_change_rules: ChangeControlRulesV0 {
+                authorized_to_make_change: AuthorizedActionTakers::ContractOwner,
+                admin_action_takers: Default::default(),
+                changing_authorized_action_takers_to_no_one_allowed: false,
+                changing_admin_action_takers_to_no_one_allowed: false,
+                self_changing_admin_action_takers_allowed: false,
+            }
+            .into(),
+            distribution_rules: TokenDistributionRulesV0 {
+                perpetual_distribution: Some(TokenPerpetualDistribution::V0(
+                    TokenPerpetualDistributionV0 {
+                        distribution_type: RewardDistributionType::BlockBasedDistribution {
+                            interval: 10,
+                            function: DistributionFunction::FixedAmount { amount: 100 },
+                        },
+                        distribution_recipient: TokenDistributionRecipient::ContractOwner,
+                    },
+                )),
+                perpetual_distribution_rules: ChangeControlRulesV0::default().into(),
+                pre_programmed_distribution: None,
+                new_tokens_destination_identity: None,
+                new_tokens_destination_identity_rules: ChangeControlRulesV0::default().into(),
+                minting_allow_choosing_destination: true,
+                minting_allow_choosing_destination_rules: ChangeControlRulesV0::default().into(),
+                change_direct_purchase_pricing_rules: ChangeControlRulesV0 {
+                    authorized_to_make_change: AuthorizedActionTakers::ContractOwner,
+                    admin_action_takers: Default::default(),
+                    changing_authorized_action_takers_to_no_one_allowed: false,
+                    changing_admin_action_takers_to_no_one_allowed: false,
+                    self_changing_admin_action_takers_allowed: false,
+                }
+                .into(),
+            }
+            .into(),
+            marketplace_rules: TokenMarketplaceRulesV0 {
+                trade_mode: Default::default(),
+                trade_mode_change_rules: ChangeControlRulesV0::default().into(),
+            }
+            .into(),
+            manual_minting_rules: ChangeControlRulesV0 {
+                authorized_to_make_change: AuthorizedActionTakers::Group(0),
+                admin_action_takers: Default::default(),
+                changing_authorized_action_takers_to_no_one_allowed: false,
+                changing_admin_action_takers_to_no_one_allowed: false,
+                self_changing_admin_action_takers_allowed: false,
+            }
+            .into(),
+            manual_burning_rules: ChangeControlRulesV0 {
+                authorized_to_make_change: AuthorizedActionTakers::Group(2),
+                admin_action_takers: Default::default(),
+                changing_authorized_action_takers_to_no_one_allowed: false,
+                changing_admin_action_takers_to_no_one_allowed: false,
+                self_changing_admin_action_takers_allowed: false,
+            }
+            .into(),
+            freeze_rules: ChangeControlRulesV0 {
+                authorized_to_make_change: AuthorizedActionTakers::ContractOwner,
+                admin_action_takers: Default::default(),
+                changing_authorized_action_takers_to_no_one_allowed: false,
+                changing_admin_action_takers_to_no_one_allowed: false,
+                self_changing_admin_action_takers_allowed: false,
+            }
+            .into(),
+            unfreeze_rules: ChangeControlRulesV0 {
+                authorized_to_make_change: AuthorizedActionTakers::ContractOwner,
+                admin_action_takers: Default::default(),
+                changing_authorized_action_takers_to_no_one_allowed: false,
+                changing_admin_action_takers_to_no_one_allowed: false,
+                self_changing_admin_action_takers_allowed: false,
+            }
+            .into(),
+            destroy_frozen_funds_rules: ChangeControlRulesV0 {
+                authorized_to_make_change: AuthorizedActionTakers::ContractOwner,
+                admin_action_takers: Default::default(),
+                changing_authorized_action_takers_to_no_one_allowed: false,
+                changing_admin_action_takers_to_no_one_allowed: false,
+                self_changing_admin_action_takers_allowed: false,
+            }
+            .into(),
+            emergency_action_rules: ChangeControlRulesV0 {
+                authorized_to_make_change: AuthorizedActionTakers::ContractOwner,
+                admin_action_takers: Default::default(),
+                changing_authorized_action_takers_to_no_one_allowed: false,
+                changing_admin_action_takers_to_no_one_allowed: false,
+                self_changing_admin_action_takers_allowed: false,
+            }
+            .into(),
+            main_control_group: None,
+            main_control_group_can_be_modified: Default::default(),
+            description: Some("Some token description".to_string()),
+        });
+
+        // Token 2 gets pre-programmed distributions
+        let mut token_configuration_2 = token_configuration.clone();
+        if let TokenConfiguration::V0(ref mut cfg) = token_configuration_2 {
+            if let TokenDistributionRules::V0(ref mut rules) = cfg.distribution_rules {
+                rules.pre_programmed_distribution = Some(TokenPreProgrammedDistribution::V0(
+                    TokenPreProgrammedDistributionV0 {
+                        distributions: BTreeMap::from([
+                            (
+                                1000,
+                                BTreeMap::from([
+                                    (Identifier::new(identity_id_1), 500),
+                                    (Identifier::new(identity_id_2), 300),
+                                ]),
+                            ),
+                            (
+                                5000,
+                                BTreeMap::from([(Identifier::new(identity_id_1), 1000)]),
+                            ),
+                            (
+                                10000,
+                                BTreeMap::from([
+                                    (Identifier::new(identity_id_2), 750),
+                                    (Identifier::new(identity_id_3), 250),
+                                ]),
+                            ),
+                        ]),
+                    },
+                ));
+            }
+        }
+
+        let tokens = [
+            (0, token_configuration.clone()),
+            (1, token_configuration),
+            (2, token_configuration_2),
+        ]
+        .into();
+
+        let data_contract = DataContract::V1(DataContractV1 {
+            id: Identifier::new(contract_id),
+            config: DataContractConfig::default_for_version(version)
+                .expect("expected contract config"),
+            version: INITIAL_DATA_CONTRACT_VERSION,
+            owner_id: Identifier::new(identity_id_1),
+            document_types: Default::default(),
+            schema_defs: Default::default(),
+            created_at: None,
+            updated_at: None,
+            created_at_block_height: None,
+            updated_at_block_height: None,
+            created_at_epoch: None,
+            updated_at_epoch: None,
+            groups,
+            tokens,
+            keywords: vec!["cat".into(), "white".into()],
+            description: Some("Some contract description".to_string()),
+        });
+
+        let block_info = BlockInfo::genesis();
+
+        platform
+            .platform
+            .drive
+            .apply_contract(&data_contract, block_info, true, None, None, version)
+            .expect("expected to apply contract");
+
+        // Mint tokens
+        // Token 0: 100 to identity_1, 100 to identity_2
+        // Token 1: 200 to identity_1, 100 to identity_3
+        // Token 2: 300 to identity_1, 200 to identity_2
+        for (token_id, id, amount) in [
+            (token_id_0, identity_id_1, 100u64),
+            (token_id_0, identity_id_2, 100),
+            (token_id_1, identity_id_1, 200),
+            (token_id_1, identity_id_3, 100),
+            (token_id_2, identity_id_1, 300),
+            (token_id_2, identity_id_2, 200),
+        ] {
+            platform
+                .platform
+                .drive
+                .token_mint(
+                    token_id,
+                    id,
+                    amount,
+                    false,
+                    false,
+                    &block_info,
+                    true,
+                    None,
+                    version,
+                )
+                .expect("expected to mint tokens");
+        }
+
+        // Freeze identity 2 on token 0
+        platform
+            .platform
+            .drive
+            .token_freeze(
+                Identifier::new(token_id_0),
+                Identifier::new(identity_id_2),
+                &block_info,
+                true,
+                None,
+                version,
+            )
+            .expect("expected to freeze");
+
+        // Pause token 1
+        let status = TokenStatus::V0(TokenStatusV0 { paused: true });
+        platform
+            .platform
+            .drive
+            .token_apply_status(token_id_1, status, &block_info, true, None, version)
+            .expect("expected to apply status");
+
+        // Set direct purchase prices
+        platform
+            .platform
+            .drive
+            .token_set_direct_purchase_price(
+                token_id_1,
+                Some(TokenPricingSchedule::SinglePrice(25)),
+                &block_info,
+                true,
+                None,
+                version,
+            )
+            .expect("expected to set direct purchase price");
+
+        let pricing = TokenPricingSchedule::SetPrices(
+            (0..=900)
+                .step_by(100)
+                .map(|amount| (amount, 1000 - amount))
+                .collect(),
+        );
+        platform
+            .platform
+            .drive
+            .token_set_direct_purchase_price(
+                token_id_2,
+                Some(pricing),
+                &block_info,
+                true,
+                None,
+                version,
+            )
+            .expect("expected to set direct purchase price");
+
+        (
+            platform,
+            state,
+            version,
+            contract_id,
+            [token_id_0, token_id_1, token_id_2],
+            [identity_id_1, identity_id_2, identity_id_3],
+        )
+    }
 }

--- a/packages/rs-drive-abci/src/query/token_queries/identities_token_balances/v0/mod.rs
+++ b/packages/rs-drive-abci/src/query/token_queries/identities_token_balances/v0/mod.rs
@@ -89,3 +89,166 @@ impl<C> Platform<C> {
         Ok(QueryValidationResult::new_with_data(response))
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::query::tests::setup_platform;
+    use crate::query::tests::setup_platform_with_token_state;
+    use dapi_grpc::platform::v0::get_identities_token_balances_response::get_identities_token_balances_response_v0;
+    use dpp::dashcore::Network;
+
+    #[test]
+    fn test_invalid_token_id() {
+        let (platform, state, version) = setup_platform(None, Network::Testnet, None);
+
+        let request = GetIdentitiesTokenBalancesRequestV0 {
+            token_id: vec![0; 8], // invalid: not 32 bytes
+            identity_ids: vec![vec![0; 32]],
+            prove: false,
+        };
+
+        let result = platform
+            .query_identities_token_balances_v0(request, &state, version)
+            .expect("expected query to succeed");
+
+        assert!(matches!(
+            result.errors.as_slice(),
+            [QueryError::InvalidArgument(msg)] if msg.contains("token_id")
+        ));
+    }
+
+    #[test]
+    fn test_invalid_identity_id() {
+        let (platform, state, version) = setup_platform(None, Network::Testnet, None);
+
+        let request = GetIdentitiesTokenBalancesRequestV0 {
+            token_id: vec![0; 32],
+            identity_ids: vec![vec![0; 8]], // invalid
+            prove: false,
+        };
+
+        let result = platform
+            .query_identities_token_balances_v0(request, &state, version)
+            .expect("expected query to succeed");
+
+        assert!(matches!(
+            result.errors.as_slice(),
+            [QueryError::InvalidArgument(msg)] if msg.contains("identity_id")
+        ));
+    }
+
+    #[test]
+    fn test_query_with_empty_state() {
+        let (platform, state, version) = setup_platform(None, Network::Testnet, None);
+
+        let request = GetIdentitiesTokenBalancesRequestV0 {
+            token_id: vec![0; 32],
+            identity_ids: vec![vec![0; 32]],
+            prove: false,
+        };
+
+        let result = platform
+            .query_identities_token_balances_v0(request, &state, version)
+            .expect("expected query to succeed");
+
+        assert!(result.errors.is_empty());
+        assert!(result.data.is_some());
+        let data = result.data.unwrap();
+        match data.result {
+            Some(get_identities_token_balances_response_v0::Result::IdentityTokenBalances(
+                balances,
+            )) => {
+                assert_eq!(balances.identity_token_balances.len(), 1);
+                // Balance should be None (no token exists)
+                assert!(balances.identity_token_balances[0].balance.is_none());
+            }
+            _ => panic!("expected IdentityTokenBalances result"),
+        }
+    }
+
+    #[test]
+    fn test_query_with_proof() {
+        let (platform, state, version) = setup_platform(None, Network::Testnet, None);
+
+        let request = GetIdentitiesTokenBalancesRequestV0 {
+            token_id: vec![0; 32],
+            identity_ids: vec![vec![0; 32]],
+            prove: true,
+        };
+
+        let result = platform
+            .query_identities_token_balances_v0(request, &state, version)
+            .expect("expected query to succeed");
+
+        assert!(result.errors.is_empty());
+        assert!(matches!(
+            result.data,
+            Some(GetIdentitiesTokenBalancesResponseV0 {
+                result: Some(get_identities_token_balances_response_v0::Result::Proof(_)),
+                metadata: Some(_),
+            })
+        ));
+    }
+
+    #[test]
+    fn test_query_with_token_data() {
+        let (platform, state, version, _, token_ids, identity_ids) =
+            setup_platform_with_token_state();
+
+        let request = GetIdentitiesTokenBalancesRequestV0 {
+            token_id: token_ids[0].to_vec(),
+            identity_ids: vec![identity_ids[0].to_vec(), identity_ids[1].to_vec()],
+            prove: false,
+        };
+
+        let result = platform
+            .query_identities_token_balances_v0(request, &state, version)
+            .expect("expected query to succeed");
+
+        assert!(result.errors.is_empty());
+        let data = result.data.unwrap();
+        match data.result {
+            Some(get_identities_token_balances_response_v0::Result::IdentityTokenBalances(
+                balances,
+            )) => {
+                assert_eq!(balances.identity_token_balances.len(), 2);
+                // Identity 1 has base_supply (100000) + minted (100) = 100100
+                // Identity 2 has minted (100)
+                let mut found_balances: Vec<u64> = balances
+                    .identity_token_balances
+                    .iter()
+                    .filter_map(|e| e.balance)
+                    .collect();
+                found_balances.sort();
+                assert_eq!(found_balances, vec![100, 100100]);
+            }
+            _ => panic!("expected IdentityTokenBalances result"),
+        }
+    }
+
+    #[test]
+    fn test_query_with_token_data_proof() {
+        let (platform, state, version, _, token_ids, identity_ids) =
+            setup_platform_with_token_state();
+
+        let request = GetIdentitiesTokenBalancesRequestV0 {
+            token_id: token_ids[0].to_vec(),
+            identity_ids: vec![identity_ids[0].to_vec()],
+            prove: true,
+        };
+
+        let result = platform
+            .query_identities_token_balances_v0(request, &state, version)
+            .expect("expected query to succeed");
+
+        assert!(result.errors.is_empty());
+        assert!(matches!(
+            result.data,
+            Some(GetIdentitiesTokenBalancesResponseV0 {
+                result: Some(get_identities_token_balances_response_v0::Result::Proof(_)),
+                metadata: Some(_),
+            })
+        ));
+    }
+}

--- a/packages/rs-drive-abci/src/query/token_queries/identities_token_infos/v0/mod.rs
+++ b/packages/rs-drive-abci/src/query/token_queries/identities_token_infos/v0/mod.rs
@@ -95,3 +95,184 @@ impl<C> Platform<C> {
         Ok(QueryValidationResult::new_with_data(response))
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::query::tests::setup_platform;
+    use crate::query::tests::setup_platform_with_token_state;
+    use dapi_grpc::platform::v0::get_identities_token_infos_response::get_identities_token_infos_response_v0;
+    use dpp::dashcore::Network;
+
+    #[test]
+    fn test_invalid_token_id() {
+        let (platform, state, version) = setup_platform(None, Network::Testnet, None);
+
+        let request = GetIdentitiesTokenInfosRequestV0 {
+            token_id: vec![0; 8],
+            identity_ids: vec![vec![0; 32]],
+            prove: false,
+        };
+
+        let result = platform
+            .query_identities_token_infos_v0(request, &state, version)
+            .expect("expected query to succeed");
+
+        assert!(matches!(
+            result.errors.as_slice(),
+            [QueryError::InvalidArgument(msg)] if msg.contains("token_id")
+        ));
+    }
+
+    #[test]
+    fn test_invalid_identity_id() {
+        let (platform, state, version) = setup_platform(None, Network::Testnet, None);
+
+        let request = GetIdentitiesTokenInfosRequestV0 {
+            token_id: vec![0; 32],
+            identity_ids: vec![vec![0; 8]],
+            prove: false,
+        };
+
+        let result = platform
+            .query_identities_token_infos_v0(request, &state, version)
+            .expect("expected query to succeed");
+
+        assert!(matches!(
+            result.errors.as_slice(),
+            [QueryError::InvalidArgument(msg)] if msg.contains("identity_id")
+        ));
+    }
+
+    #[test]
+    fn test_query_with_empty_state() {
+        let (platform, state, version) = setup_platform(None, Network::Testnet, None);
+
+        let request = GetIdentitiesTokenInfosRequestV0 {
+            token_id: vec![0; 32],
+            identity_ids: vec![vec![0; 32]],
+            prove: false,
+        };
+
+        let result = platform
+            .query_identities_token_infos_v0(request, &state, version)
+            .expect("expected query to succeed");
+
+        assert!(result.errors.is_empty());
+        assert!(result.data.is_some());
+        let data = result.data.unwrap();
+        match data.result {
+            Some(get_identities_token_infos_response_v0::Result::IdentityTokenInfos(infos)) => {
+                assert_eq!(infos.token_infos.len(), 1);
+                // Info should be None (no token exists)
+                assert!(infos.token_infos[0].info.is_none());
+            }
+            _ => panic!("expected IdentityTokenInfos result"),
+        }
+    }
+
+    #[test]
+    fn test_query_with_proof() {
+        let (platform, state, version) = setup_platform(None, Network::Testnet, None);
+
+        let request = GetIdentitiesTokenInfosRequestV0 {
+            token_id: vec![0; 32],
+            identity_ids: vec![vec![0; 32]],
+            prove: true,
+        };
+
+        let result = platform
+            .query_identities_token_infos_v0(request, &state, version)
+            .expect("expected query to succeed");
+
+        assert!(result.errors.is_empty());
+        assert!(matches!(
+            result.data,
+            Some(GetIdentitiesTokenInfosResponseV0 {
+                result: Some(get_identities_token_infos_response_v0::Result::Proof(_)),
+                metadata: Some(_),
+            })
+        ));
+    }
+
+    #[test]
+    fn test_query_with_token_data_not_frozen() {
+        let (platform, state, version, _, token_ids, identity_ids) =
+            setup_platform_with_token_state();
+
+        // Identity 1 is NOT frozen on token 0 - no explicit info record is stored
+        let request = GetIdentitiesTokenInfosRequestV0 {
+            token_id: token_ids[0].to_vec(),
+            identity_ids: vec![identity_ids[0].to_vec()],
+            prove: false,
+        };
+
+        let result = platform
+            .query_identities_token_infos_v0(request, &state, version)
+            .expect("expected query to succeed");
+
+        assert!(result.errors.is_empty());
+        let data = result.data.unwrap();
+        match data.result {
+            Some(get_identities_token_infos_response_v0::Result::IdentityTokenInfos(infos)) => {
+                assert_eq!(infos.token_infos.len(), 1);
+                // Unfrozen identities have no info record, so info is None
+                assert!(infos.token_infos[0].info.is_none());
+            }
+            _ => panic!("expected IdentityTokenInfos result"),
+        }
+    }
+
+    #[test]
+    fn test_query_with_token_data_frozen() {
+        let (platform, state, version, _, token_ids, identity_ids) =
+            setup_platform_with_token_state();
+
+        // Identity 2 IS frozen on token 0
+        let request = GetIdentitiesTokenInfosRequestV0 {
+            token_id: token_ids[0].to_vec(),
+            identity_ids: vec![identity_ids[1].to_vec()],
+            prove: false,
+        };
+
+        let result = platform
+            .query_identities_token_infos_v0(request, &state, version)
+            .expect("expected query to succeed");
+
+        assert!(result.errors.is_empty());
+        let data = result.data.unwrap();
+        match data.result {
+            Some(get_identities_token_infos_response_v0::Result::IdentityTokenInfos(infos)) => {
+                assert_eq!(infos.token_infos.len(), 1);
+                let info = infos.token_infos[0].info.as_ref().expect("expected info");
+                assert!(info.frozen);
+            }
+            _ => panic!("expected IdentityTokenInfos result"),
+        }
+    }
+
+    #[test]
+    fn test_query_with_token_data_proof() {
+        let (platform, state, version, _, token_ids, identity_ids) =
+            setup_platform_with_token_state();
+
+        let request = GetIdentitiesTokenInfosRequestV0 {
+            token_id: token_ids[0].to_vec(),
+            identity_ids: vec![identity_ids[0].to_vec()],
+            prove: true,
+        };
+
+        let result = platform
+            .query_identities_token_infos_v0(request, &state, version)
+            .expect("expected query to succeed");
+
+        assert!(result.errors.is_empty());
+        assert!(matches!(
+            result.data,
+            Some(GetIdentitiesTokenInfosResponseV0 {
+                result: Some(get_identities_token_infos_response_v0::Result::Proof(_)),
+                metadata: Some(_),
+            })
+        ));
+    }
+}

--- a/packages/rs-drive-abci/src/query/token_queries/identity_token_balances/v0/mod.rs
+++ b/packages/rs-drive-abci/src/query/token_queries/identity_token_balances/v0/mod.rs
@@ -87,3 +87,166 @@ impl<C> Platform<C> {
         Ok(QueryValidationResult::new_with_data(response))
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::query::tests::setup_platform;
+    use crate::query::tests::setup_platform_with_token_state;
+    use dapi_grpc::platform::v0::get_identity_token_balances_response::get_identity_token_balances_response_v0;
+    use dpp::dashcore::Network;
+
+    #[test]
+    fn test_invalid_identity_id() {
+        let (platform, state, version) = setup_platform(None, Network::Testnet, None);
+
+        let request = GetIdentityTokenBalancesRequestV0 {
+            identity_id: vec![0; 8],
+            token_ids: vec![vec![0; 32]],
+            prove: false,
+        };
+
+        let result = platform
+            .query_identity_token_balances_v0(request, &state, version)
+            .expect("expected query to succeed");
+
+        assert!(matches!(
+            result.errors.as_slice(),
+            [QueryError::InvalidArgument(msg)] if msg.contains("identity_id")
+        ));
+    }
+
+    #[test]
+    fn test_invalid_token_id() {
+        let (platform, state, version) = setup_platform(None, Network::Testnet, None);
+
+        let request = GetIdentityTokenBalancesRequestV0 {
+            identity_id: vec![0; 32],
+            token_ids: vec![vec![0; 8]],
+            prove: false,
+        };
+
+        let result = platform
+            .query_identity_token_balances_v0(request, &state, version)
+            .expect("expected query to succeed");
+
+        assert!(matches!(
+            result.errors.as_slice(),
+            [QueryError::InvalidArgument(msg)] if msg.contains("token_id")
+        ));
+    }
+
+    #[test]
+    fn test_query_with_empty_state() {
+        let (platform, state, version) = setup_platform(None, Network::Testnet, None);
+
+        let request = GetIdentityTokenBalancesRequestV0 {
+            identity_id: vec![0; 32],
+            token_ids: vec![vec![0; 32]],
+            prove: false,
+        };
+
+        let result = platform
+            .query_identity_token_balances_v0(request, &state, version)
+            .expect("expected query to succeed");
+
+        assert!(result.errors.is_empty());
+        let data = result.data.unwrap();
+        match data.result {
+            Some(get_identity_token_balances_response_v0::Result::TokenBalances(balances)) => {
+                assert_eq!(balances.token_balances.len(), 1);
+                assert!(balances.token_balances[0].balance.is_none());
+            }
+            _ => panic!("expected TokenBalances result"),
+        }
+    }
+
+    #[test]
+    fn test_query_with_proof() {
+        let (platform, state, version) = setup_platform(None, Network::Testnet, None);
+
+        let request = GetIdentityTokenBalancesRequestV0 {
+            identity_id: vec![0; 32],
+            token_ids: vec![vec![0; 32]],
+            prove: true,
+        };
+
+        let result = platform
+            .query_identity_token_balances_v0(request, &state, version)
+            .expect("expected query to succeed");
+
+        assert!(result.errors.is_empty());
+        assert!(matches!(
+            result.data,
+            Some(GetIdentityTokenBalancesResponseV0 {
+                result: Some(get_identity_token_balances_response_v0::Result::Proof(_)),
+                metadata: Some(_),
+            })
+        ));
+    }
+
+    #[test]
+    fn test_query_with_token_data() {
+        let (platform, state, version, _, token_ids, identity_ids) =
+            setup_platform_with_token_state();
+
+        // Identity 1 has: token_0=100, token_1=200, token_2=300
+        let request = GetIdentityTokenBalancesRequestV0 {
+            identity_id: identity_ids[0].to_vec(),
+            token_ids: vec![
+                token_ids[0].to_vec(),
+                token_ids[1].to_vec(),
+                token_ids[2].to_vec(),
+            ],
+            prove: false,
+        };
+
+        let result = platform
+            .query_identity_token_balances_v0(request, &state, version)
+            .expect("expected query to succeed");
+
+        assert!(result.errors.is_empty());
+        let data = result.data.unwrap();
+        match data.result {
+            Some(get_identity_token_balances_response_v0::Result::TokenBalances(balances)) => {
+                assert_eq!(balances.token_balances.len(), 3);
+                let mut total = 0u64;
+                for entry in &balances.token_balances {
+                    total += entry.balance.unwrap_or(0);
+                }
+                // Identity 1 balances include base_supply (100000) per token:
+                // token_0: 100000 + 100 = 100100
+                // token_1: 100000 + 200 = 100200
+                // token_2: 100000 + 300 = 100300
+                // Total = 300600
+                assert_eq!(total, 300600);
+            }
+            _ => panic!("expected TokenBalances result"),
+        }
+    }
+
+    #[test]
+    fn test_query_with_token_data_proof() {
+        let (platform, state, version, _, token_ids, identity_ids) =
+            setup_platform_with_token_state();
+
+        let request = GetIdentityTokenBalancesRequestV0 {
+            identity_id: identity_ids[0].to_vec(),
+            token_ids: vec![token_ids[0].to_vec()],
+            prove: true,
+        };
+
+        let result = platform
+            .query_identity_token_balances_v0(request, &state, version)
+            .expect("expected query to succeed");
+
+        assert!(result.errors.is_empty());
+        assert!(matches!(
+            result.data,
+            Some(GetIdentityTokenBalancesResponseV0 {
+                result: Some(get_identity_token_balances_response_v0::Result::Proof(_)),
+                metadata: Some(_),
+            })
+        ));
+    }
+}

--- a/packages/rs-drive-abci/src/query/token_queries/identity_token_infos/v0/mod.rs
+++ b/packages/rs-drive-abci/src/query/token_queries/identity_token_infos/v0/mod.rs
@@ -90,3 +90,159 @@ impl<C> Platform<C> {
         Ok(QueryValidationResult::new_with_data(response))
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::query::tests::setup_platform;
+    use crate::query::tests::setup_platform_with_token_state;
+    use dapi_grpc::platform::v0::get_identity_token_infos_response::get_identity_token_infos_response_v0;
+    use dpp::dashcore::Network;
+
+    #[test]
+    fn test_invalid_identity_id() {
+        let (platform, state, version) = setup_platform(None, Network::Testnet, None);
+
+        let request = GetIdentityTokenInfosRequestV0 {
+            identity_id: vec![0; 8],
+            token_ids: vec![vec![0; 32]],
+            prove: false,
+        };
+
+        let result = platform
+            .query_identity_token_infos_v0(request, &state, version)
+            .expect("expected query to succeed");
+
+        assert!(matches!(
+            result.errors.as_slice(),
+            [QueryError::InvalidArgument(msg)] if msg.contains("identity_id")
+        ));
+    }
+
+    #[test]
+    fn test_invalid_token_id() {
+        let (platform, state, version) = setup_platform(None, Network::Testnet, None);
+
+        let request = GetIdentityTokenInfosRequestV0 {
+            identity_id: vec![0; 32],
+            token_ids: vec![vec![0; 8]],
+            prove: false,
+        };
+
+        let result = platform
+            .query_identity_token_infos_v0(request, &state, version)
+            .expect("expected query to succeed");
+
+        assert!(matches!(
+            result.errors.as_slice(),
+            [QueryError::InvalidArgument(msg)] if msg.contains("token_id")
+        ));
+    }
+
+    #[test]
+    fn test_query_with_empty_state() {
+        let (platform, state, version) = setup_platform(None, Network::Testnet, None);
+
+        let request = GetIdentityTokenInfosRequestV0 {
+            identity_id: vec![0; 32],
+            token_ids: vec![vec![0; 32]],
+            prove: false,
+        };
+
+        let result = platform
+            .query_identity_token_infos_v0(request, &state, version)
+            .expect("expected query to succeed");
+
+        assert!(result.errors.is_empty());
+        let data = result.data.unwrap();
+        match data.result {
+            Some(get_identity_token_infos_response_v0::Result::TokenInfos(infos)) => {
+                assert_eq!(infos.token_infos.len(), 1);
+                assert!(infos.token_infos[0].info.is_none());
+            }
+            _ => panic!("expected TokenInfos result"),
+        }
+    }
+
+    #[test]
+    fn test_query_with_proof() {
+        let (platform, state, version) = setup_platform(None, Network::Testnet, None);
+
+        let request = GetIdentityTokenInfosRequestV0 {
+            identity_id: vec![0; 32],
+            token_ids: vec![vec![0; 32]],
+            prove: true,
+        };
+
+        let result = platform
+            .query_identity_token_infos_v0(request, &state, version)
+            .expect("expected query to succeed");
+
+        assert!(result.errors.is_empty());
+        assert!(matches!(
+            result.data,
+            Some(GetIdentityTokenInfosResponseV0 {
+                result: Some(get_identity_token_infos_response_v0::Result::Proof(_)),
+                metadata: Some(_),
+            })
+        ));
+    }
+
+    #[test]
+    fn test_query_with_token_data() {
+        let (platform, state, version, _, token_ids, identity_ids) =
+            setup_platform_with_token_state();
+
+        // Identity 2: frozen on token_0, no info on token_1, has balance on token_2
+        let request = GetIdentityTokenInfosRequestV0 {
+            identity_id: identity_ids[1].to_vec(),
+            token_ids: vec![token_ids[0].to_vec(), token_ids[2].to_vec()],
+            prove: false,
+        };
+
+        let result = platform
+            .query_identity_token_infos_v0(request, &state, version)
+            .expect("expected query to succeed");
+
+        assert!(result.errors.is_empty());
+        let data = result.data.unwrap();
+        match data.result {
+            Some(get_identity_token_infos_response_v0::Result::TokenInfos(infos)) => {
+                assert_eq!(infos.token_infos.len(), 2);
+                // One of them should be frozen (token_0 for identity_2)
+                let frozen_count = infos
+                    .token_infos
+                    .iter()
+                    .filter(|e| e.info.as_ref().map_or(false, |i| i.frozen))
+                    .count();
+                assert_eq!(frozen_count, 1);
+            }
+            _ => panic!("expected TokenInfos result"),
+        }
+    }
+
+    #[test]
+    fn test_query_with_token_data_proof() {
+        let (platform, state, version, _, token_ids, identity_ids) =
+            setup_platform_with_token_state();
+
+        let request = GetIdentityTokenInfosRequestV0 {
+            identity_id: identity_ids[0].to_vec(),
+            token_ids: vec![token_ids[0].to_vec()],
+            prove: true,
+        };
+
+        let result = platform
+            .query_identity_token_infos_v0(request, &state, version)
+            .expect("expected query to succeed");
+
+        assert!(result.errors.is_empty());
+        assert!(matches!(
+            result.data,
+            Some(GetIdentityTokenInfosResponseV0 {
+                result: Some(get_identity_token_infos_response_v0::Result::Proof(_)),
+                metadata: Some(_),
+            })
+        ));
+    }
+}

--- a/packages/rs-drive-abci/src/query/token_queries/token_contract_info/v0/mod.rs
+++ b/packages/rs-drive-abci/src/query/token_queries/token_contract_info/v0/mod.rs
@@ -67,3 +67,146 @@ impl<C> Platform<C> {
         Ok(QueryValidationResult::new_with_data(response))
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::query::tests::setup_platform;
+    use crate::query::tests::setup_platform_with_token_state;
+    use dapi_grpc::platform::v0::get_token_contract_info_response::get_token_contract_info_response_v0;
+    use dpp::dashcore::Network;
+
+    #[test]
+    fn test_invalid_token_id() {
+        let (platform, state, version) = setup_platform(None, Network::Testnet, None);
+
+        let request = GetTokenContractInfoRequestV0 {
+            token_id: vec![0; 8],
+            prove: false,
+        };
+
+        let result = platform
+            .query_token_contract_info_v0(request, &state, version)
+            .expect("expected query to succeed");
+
+        assert!(matches!(
+            result.errors.as_slice(),
+            [QueryError::InvalidArgument(msg)] if msg.contains("token_id")
+        ));
+    }
+
+    #[test]
+    fn test_query_token_not_found() {
+        let (platform, state, version) = setup_platform(None, Network::Testnet, None);
+
+        let request = GetTokenContractInfoRequestV0 {
+            token_id: vec![0; 32],
+            prove: false,
+        };
+
+        let result = platform
+            .query_token_contract_info_v0(request, &state, version)
+            .expect("expected query to succeed");
+
+        assert!(result.errors.is_empty());
+        // When token doesn't exist, result should be None (no data)
+        let data = result.data.unwrap();
+        assert!(data.result.is_none());
+    }
+
+    #[test]
+    fn test_query_with_proof() {
+        let (platform, state, version) = setup_platform(None, Network::Testnet, None);
+
+        let request = GetTokenContractInfoRequestV0 {
+            token_id: vec![0; 32],
+            prove: true,
+        };
+
+        let result = platform
+            .query_token_contract_info_v0(request, &state, version)
+            .expect("expected query to succeed");
+
+        assert!(result.errors.is_empty());
+        assert!(matches!(
+            result.data,
+            Some(GetTokenContractInfoResponseV0 {
+                result: Some(get_token_contract_info_response_v0::Result::Proof(_)),
+                metadata: Some(_),
+            })
+        ));
+    }
+
+    #[test]
+    fn test_query_with_token_data() {
+        let (platform, state, version, contract_id, token_ids, _) =
+            setup_platform_with_token_state();
+
+        let request = GetTokenContractInfoRequestV0 {
+            token_id: token_ids[0].to_vec(),
+            prove: false,
+        };
+
+        let result = platform
+            .query_token_contract_info_v0(request, &state, version)
+            .expect("expected query to succeed");
+
+        assert!(result.errors.is_empty());
+        let data = result.data.unwrap();
+        match data.result {
+            Some(get_token_contract_info_response_v0::Result::Data(info)) => {
+                assert_eq!(info.contract_id, contract_id.to_vec());
+                assert_eq!(info.token_contract_position, 0);
+            }
+            _ => panic!("expected Data result"),
+        }
+    }
+
+    #[test]
+    fn test_query_with_token_data_position_1() {
+        let (platform, state, version, contract_id, token_ids, _) =
+            setup_platform_with_token_state();
+
+        let request = GetTokenContractInfoRequestV0 {
+            token_id: token_ids[1].to_vec(),
+            prove: false,
+        };
+
+        let result = platform
+            .query_token_contract_info_v0(request, &state, version)
+            .expect("expected query to succeed");
+
+        assert!(result.errors.is_empty());
+        let data = result.data.unwrap();
+        match data.result {
+            Some(get_token_contract_info_response_v0::Result::Data(info)) => {
+                assert_eq!(info.contract_id, contract_id.to_vec());
+                assert_eq!(info.token_contract_position, 1);
+            }
+            _ => panic!("expected Data result"),
+        }
+    }
+
+    #[test]
+    fn test_query_with_token_data_proof() {
+        let (platform, state, version, _, token_ids, _) = setup_platform_with_token_state();
+
+        let request = GetTokenContractInfoRequestV0 {
+            token_id: token_ids[0].to_vec(),
+            prove: true,
+        };
+
+        let result = platform
+            .query_token_contract_info_v0(request, &state, version)
+            .expect("expected query to succeed");
+
+        assert!(result.errors.is_empty());
+        assert!(matches!(
+            result.data,
+            Some(GetTokenContractInfoResponseV0 {
+                result: Some(get_token_contract_info_response_v0::Result::Proof(_)),
+                metadata: Some(_),
+            })
+        ));
+    }
+}

--- a/packages/rs-drive-abci/src/query/token_queries/token_direct_purchase_prices/v0/mod.rs
+++ b/packages/rs-drive-abci/src/query/token_queries/token_direct_purchase_prices/v0/mod.rs
@@ -103,3 +103,255 @@ impl<C> Platform<C> {
         Ok(QueryValidationResult::new_with_data(response))
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::query::tests::setup_platform;
+    use crate::query::tests::setup_platform_with_token_state;
+    use dapi_grpc::platform::v0::get_token_direct_purchase_prices_response::get_token_direct_purchase_prices_response_v0;
+    use dpp::dashcore::Network;
+
+    #[test]
+    fn test_empty_token_ids() {
+        let (platform, state, version) = setup_platform(None, Network::Testnet, None);
+
+        let request = GetTokenDirectPurchasePricesRequestV0 {
+            token_ids: vec![],
+            prove: false,
+        };
+
+        let result = platform
+            .query_token_direct_purchase_prices_v0(request, &state, version)
+            .expect("expected query to succeed");
+
+        assert!(matches!(
+            result.errors.as_slice(),
+            [QueryError::InvalidArgument(msg)] if msg.contains("at least one token id")
+        ));
+    }
+
+    #[test]
+    fn test_invalid_token_id() {
+        let (platform, state, version) = setup_platform(None, Network::Testnet, None);
+
+        let request = GetTokenDirectPurchasePricesRequestV0 {
+            token_ids: vec![vec![0; 8]],
+            prove: false,
+        };
+
+        let result = platform
+            .query_token_direct_purchase_prices_v0(request, &state, version)
+            .expect("expected query to succeed");
+
+        assert!(matches!(
+            result.errors.as_slice(),
+            [QueryError::InvalidArgument(msg)] if msg.contains("token_ids")
+        ));
+    }
+
+    #[test]
+    fn test_query_with_empty_state() {
+        let (platform, state, version) = setup_platform(None, Network::Testnet, None);
+
+        let request = GetTokenDirectPurchasePricesRequestV0 {
+            token_ids: vec![vec![0; 32]],
+            prove: false,
+        };
+
+        let result = platform
+            .query_token_direct_purchase_prices_v0(request, &state, version)
+            .expect("expected query to succeed");
+
+        assert!(result.errors.is_empty());
+        let data = result.data.unwrap();
+        match data.result {
+            Some(
+                get_token_direct_purchase_prices_response_v0::Result::TokenDirectPurchasePrices(
+                    prices,
+                ),
+            ) => {
+                assert_eq!(prices.token_direct_purchase_price.len(), 1);
+                // Price should be None for nonexistent token
+                assert!(prices.token_direct_purchase_price[0].price.is_none());
+            }
+            _ => panic!("expected TokenDirectPurchasePrices result"),
+        }
+    }
+
+    #[test]
+    fn test_query_with_proof() {
+        let (platform, state, version) = setup_platform(None, Network::Testnet, None);
+
+        let request = GetTokenDirectPurchasePricesRequestV0 {
+            token_ids: vec![vec![0; 32]],
+            prove: true,
+        };
+
+        let result = platform
+            .query_token_direct_purchase_prices_v0(request, &state, version)
+            .expect("expected query to succeed");
+
+        assert!(result.errors.is_empty());
+        assert!(matches!(
+            result.data,
+            Some(GetTokenDirectPurchasePricesResponseV0 {
+                result: Some(get_token_direct_purchase_prices_response_v0::Result::Proof(
+                    _
+                )),
+                metadata: Some(_),
+            })
+        ));
+    }
+
+    #[test]
+    fn test_query_with_fixed_price() {
+        let (platform, state, version, _, token_ids, _) = setup_platform_with_token_state();
+
+        // Token 1 has a fixed price of 25
+        let request = GetTokenDirectPurchasePricesRequestV0 {
+            token_ids: vec![token_ids[1].to_vec()],
+            prove: false,
+        };
+
+        let result = platform
+            .query_token_direct_purchase_prices_v0(request, &state, version)
+            .expect("expected query to succeed");
+
+        assert!(result.errors.is_empty());
+        let data = result.data.unwrap();
+        match data.result {
+            Some(
+                get_token_direct_purchase_prices_response_v0::Result::TokenDirectPurchasePrices(
+                    prices,
+                ),
+            ) => {
+                assert_eq!(prices.token_direct_purchase_price.len(), 1);
+                match &prices.token_direct_purchase_price[0].price {
+                    Some(Price::FixedPrice(price)) => assert_eq!(*price, 25),
+                    other => panic!("expected FixedPrice, got {:?}", other),
+                }
+            }
+            _ => panic!("expected TokenDirectPurchasePrices result"),
+        }
+    }
+
+    #[test]
+    fn test_query_with_variable_price() {
+        let (platform, state, version, _, token_ids, _) = setup_platform_with_token_state();
+
+        // Token 2 has a variable pricing schedule
+        let request = GetTokenDirectPurchasePricesRequestV0 {
+            token_ids: vec![token_ids[2].to_vec()],
+            prove: false,
+        };
+
+        let result = platform
+            .query_token_direct_purchase_prices_v0(request, &state, version)
+            .expect("expected query to succeed");
+
+        assert!(result.errors.is_empty());
+        let data = result.data.unwrap();
+        match data.result {
+            Some(
+                get_token_direct_purchase_prices_response_v0::Result::TokenDirectPurchasePrices(
+                    prices,
+                ),
+            ) => {
+                assert_eq!(prices.token_direct_purchase_price.len(), 1);
+                match &prices.token_direct_purchase_price[0].price {
+                    Some(Price::VariablePrice(schedule)) => {
+                        assert!(!schedule.price_for_quantity.is_empty());
+                    }
+                    other => panic!("expected VariablePrice, got {:?}", other),
+                }
+            }
+            _ => panic!("expected TokenDirectPurchasePrices result"),
+        }
+    }
+
+    #[test]
+    fn test_query_no_price_set() {
+        let (platform, state, version, _, token_ids, _) = setup_platform_with_token_state();
+
+        // Token 0 has no direct purchase price set
+        let request = GetTokenDirectPurchasePricesRequestV0 {
+            token_ids: vec![token_ids[0].to_vec()],
+            prove: false,
+        };
+
+        let result = platform
+            .query_token_direct_purchase_prices_v0(request, &state, version)
+            .expect("expected query to succeed");
+
+        assert!(result.errors.is_empty());
+        let data = result.data.unwrap();
+        match data.result {
+            Some(
+                get_token_direct_purchase_prices_response_v0::Result::TokenDirectPurchasePrices(
+                    prices,
+                ),
+            ) => {
+                assert_eq!(prices.token_direct_purchase_price.len(), 1);
+                assert!(prices.token_direct_purchase_price[0].price.is_none());
+            }
+            _ => panic!("expected TokenDirectPurchasePrices result"),
+        }
+    }
+
+    #[test]
+    fn test_query_multiple_tokens() {
+        let (platform, state, version, _, token_ids, _) = setup_platform_with_token_state();
+
+        let request = GetTokenDirectPurchasePricesRequestV0 {
+            token_ids: vec![
+                token_ids[0].to_vec(),
+                token_ids[1].to_vec(),
+                token_ids[2].to_vec(),
+            ],
+            prove: false,
+        };
+
+        let result = platform
+            .query_token_direct_purchase_prices_v0(request, &state, version)
+            .expect("expected query to succeed");
+
+        assert!(result.errors.is_empty());
+        let data = result.data.unwrap();
+        match data.result {
+            Some(
+                get_token_direct_purchase_prices_response_v0::Result::TokenDirectPurchasePrices(
+                    prices,
+                ),
+            ) => {
+                assert_eq!(prices.token_direct_purchase_price.len(), 3);
+            }
+            _ => panic!("expected TokenDirectPurchasePrices result"),
+        }
+    }
+
+    #[test]
+    fn test_query_with_data_proof() {
+        let (platform, state, version, _, token_ids, _) = setup_platform_with_token_state();
+
+        let request = GetTokenDirectPurchasePricesRequestV0 {
+            token_ids: vec![token_ids[0].to_vec()],
+            prove: true,
+        };
+
+        let result = platform
+            .query_token_direct_purchase_prices_v0(request, &state, version)
+            .expect("expected query to succeed");
+
+        assert!(result.errors.is_empty());
+        assert!(matches!(
+            result.data,
+            Some(GetTokenDirectPurchasePricesResponseV0 {
+                result: Some(get_token_direct_purchase_prices_response_v0::Result::Proof(
+                    _
+                )),
+                metadata: Some(_),
+            })
+        ));
+    }
+}

--- a/packages/rs-drive-abci/src/query/token_queries/token_perpetual_distribution_last_claim/v0/mod.rs
+++ b/packages/rs-drive-abci/src/query/token_queries/token_perpetual_distribution_last_claim/v0/mod.rs
@@ -172,3 +172,247 @@ impl<C> Platform<C> {
         Ok(QueryValidationResult::new_with_data(response))
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::query::tests::setup_platform;
+    use crate::query::tests::setup_platform_with_token_state;
+    use dapi_grpc::platform::v0::get_token_perpetual_distribution_last_claim_response::get_token_perpetual_distribution_last_claim_response_v0;
+    use dpp::dashcore::Network;
+
+    #[test]
+    fn test_invalid_token_id() {
+        let (platform, state, version) = setup_platform(None, Network::Testnet, None);
+
+        let request = GetTokenPerpetualDistributionLastClaimRequestV0 {
+            token_id: vec![0; 8],
+            contract_info: None,
+            identity_id: vec![0; 32],
+            prove: false,
+        };
+
+        let result = platform
+            .query_token_perpetual_distribution_last_claim_v0(request, &state, version)
+            .expect("expected query to succeed");
+
+        assert!(matches!(
+            result.errors.as_slice(),
+            [QueryError::InvalidArgument(msg)] if msg.contains("token_id")
+        ));
+    }
+
+    #[test]
+    fn test_invalid_identity_id() {
+        let (platform, state, version) = setup_platform(None, Network::Testnet, None);
+
+        let request = GetTokenPerpetualDistributionLastClaimRequestV0 {
+            token_id: vec![0; 32],
+            contract_info: None,
+            identity_id: vec![0; 8],
+            prove: false,
+        };
+
+        let result = platform
+            .query_token_perpetual_distribution_last_claim_v0(request, &state, version)
+            .expect("expected query to succeed");
+
+        assert!(matches!(
+            result.errors.as_slice(),
+            [QueryError::InvalidArgument(msg)] if msg.contains("identity_id")
+        ));
+    }
+
+    #[test]
+    fn test_query_with_proof() {
+        let (platform, state, version) = setup_platform(None, Network::Testnet, None);
+
+        let request = GetTokenPerpetualDistributionLastClaimRequestV0 {
+            token_id: vec![0; 32],
+            contract_info: None,
+            identity_id: vec![0; 32],
+            prove: true,
+        };
+
+        let result = platform
+            .query_token_perpetual_distribution_last_claim_v0(request, &state, version)
+            .expect("expected query to succeed");
+
+        assert!(result.errors.is_empty());
+        assert!(matches!(
+            result.data,
+            Some(GetTokenPerpetualDistributionLastClaimResponseV0 {
+                result: Some(
+                    get_token_perpetual_distribution_last_claim_response_v0::Result::Proof(_)
+                ),
+                metadata: Some(_),
+            })
+        ));
+    }
+
+    #[test]
+    fn test_query_without_contract_info_raw() {
+        let (platform, state, version, _, token_ids, identity_ids) =
+            setup_platform_with_token_state();
+
+        // Query without contract_info - should return raw bytes
+        let request = GetTokenPerpetualDistributionLastClaimRequestV0 {
+            token_id: token_ids[0].to_vec(),
+            contract_info: None,
+            identity_id: identity_ids[0].to_vec(),
+            prove: false,
+        };
+
+        let result = platform
+            .query_token_perpetual_distribution_last_claim_v0(request, &state, version)
+            .expect("expected query to succeed");
+
+        assert!(result.errors.is_empty());
+        let data = result.data.unwrap();
+        match data.result {
+            Some(get_token_perpetual_distribution_last_claim_response_v0::Result::LastClaim(
+                claim,
+            )) => {
+                // paid_at might be None if no distribution has happened yet
+                // The important thing is the query succeeds
+                let _ = claim.paid_at;
+            }
+            _ => panic!("expected LastClaim result"),
+        }
+    }
+
+    #[test]
+    fn test_query_with_contract_info() {
+        let (platform, state, version, contract_id, token_ids, identity_ids) =
+            setup_platform_with_token_state();
+
+        let request = GetTokenPerpetualDistributionLastClaimRequestV0 {
+            token_id: token_ids[0].to_vec(),
+            contract_info: Some(ContractTokenInfo {
+                contract_id: contract_id.to_vec(),
+                token_contract_position: 0,
+            }),
+            identity_id: identity_ids[0].to_vec(),
+            prove: false,
+        };
+
+        let result = platform
+            .query_token_perpetual_distribution_last_claim_v0(request, &state, version)
+            .expect("expected query to succeed");
+
+        assert!(result.errors.is_empty());
+        let data = result.data.unwrap();
+        match data.result {
+            Some(get_token_perpetual_distribution_last_claim_response_v0::Result::LastClaim(
+                claim,
+            )) => {
+                // No distribution has been executed yet, so paid_at should be None
+                let _ = claim.paid_at;
+            }
+            _ => panic!("expected LastClaim result"),
+        }
+    }
+
+    #[test]
+    fn test_query_with_invalid_contract_id() {
+        let (platform, state, version, _, token_ids, identity_ids) =
+            setup_platform_with_token_state();
+
+        let request = GetTokenPerpetualDistributionLastClaimRequestV0 {
+            token_id: token_ids[0].to_vec(),
+            contract_info: Some(ContractTokenInfo {
+                contract_id: vec![0; 8], // invalid
+                token_contract_position: 0,
+            }),
+            identity_id: identity_ids[0].to_vec(),
+            prove: false,
+        };
+
+        let result = platform
+            .query_token_perpetual_distribution_last_claim_v0(request, &state, version)
+            .expect("expected query to succeed");
+
+        assert!(matches!(
+            result.errors.as_slice(),
+            [QueryError::InvalidArgument(msg)] if msg.contains("contract_id")
+        ));
+    }
+
+    #[test]
+    fn test_query_with_contract_not_found() {
+        let (platform, state, version, _, token_ids, identity_ids) =
+            setup_platform_with_token_state();
+
+        let request = GetTokenPerpetualDistributionLastClaimRequestV0 {
+            token_id: token_ids[0].to_vec(),
+            contract_info: Some(ContractTokenInfo {
+                contract_id: vec![99; 32], // nonexistent
+                token_contract_position: 0,
+            }),
+            identity_id: identity_ids[0].to_vec(),
+            prove: false,
+        };
+
+        let result = platform
+            .query_token_perpetual_distribution_last_claim_v0(request, &state, version)
+            .expect("expected query to succeed");
+
+        assert!(matches!(
+            result.errors.as_slice(),
+            [QueryError::NotFound(msg)] if msg.contains("contract")
+        ));
+    }
+
+    #[test]
+    fn test_query_with_token_position_too_large() {
+        let (platform, state, version, contract_id, token_ids, identity_ids) =
+            setup_platform_with_token_state();
+
+        let request = GetTokenPerpetualDistributionLastClaimRequestV0 {
+            token_id: token_ids[0].to_vec(),
+            contract_info: Some(ContractTokenInfo {
+                contract_id: contract_id.to_vec(),
+                token_contract_position: u32::MAX, // too large
+            }),
+            identity_id: identity_ids[0].to_vec(),
+            prove: false,
+        };
+
+        let result = platform
+            .query_token_perpetual_distribution_last_claim_v0(request, &state, version)
+            .expect("expected query to succeed");
+
+        assert!(matches!(
+            result.errors.as_slice(),
+            [QueryError::InvalidArgument(msg)] if msg.contains("token_contract_position")
+        ));
+    }
+
+    #[test]
+    fn test_query_with_data_proof() {
+        let (platform, state, version, _, token_ids, identity_ids) =
+            setup_platform_with_token_state();
+
+        let request = GetTokenPerpetualDistributionLastClaimRequestV0 {
+            token_id: token_ids[0].to_vec(),
+            contract_info: None,
+            identity_id: identity_ids[0].to_vec(),
+            prove: true,
+        };
+
+        let result = platform
+            .query_token_perpetual_distribution_last_claim_v0(request, &state, version)
+            .expect("expected query to succeed");
+
+        assert!(result.errors.is_empty());
+        assert!(matches!(
+            result.data,
+            Some(GetTokenPerpetualDistributionLastClaimResponseV0 {
+                result: Some(
+                    get_token_perpetual_distribution_last_claim_response_v0::Result::Proof(_)
+                ),
+                metadata: Some(_),
+            })
+        ));
+    }
+}

--- a/packages/rs-drive-abci/src/query/token_queries/token_pre_programmed_distributions/v0/mod.rs
+++ b/packages/rs-drive-abci/src/query/token_queries/token_pre_programmed_distributions/v0/mod.rs
@@ -141,3 +141,274 @@ impl<C> Platform<C> {
         Ok(QueryValidationResult::new_with_data(response))
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::query::tests::setup_platform;
+    use crate::query::tests::setup_platform_with_token_state;
+    use dapi_grpc::platform::v0::get_token_pre_programmed_distributions_response::get_token_pre_programmed_distributions_response_v0;
+    use dpp::dashcore::Network;
+
+    #[test]
+    fn test_invalid_token_id() {
+        let (platform, state, version) = setup_platform(None, Network::Testnet, None);
+
+        let request = GetTokenPreProgrammedDistributionsRequestV0 {
+            token_id: vec![0; 8],
+            start_at_info: None,
+            limit: None,
+            prove: false,
+        };
+
+        let result = platform
+            .query_token_pre_programmed_distributions_v0(request, &state, version)
+            .expect("expected query to succeed");
+
+        assert!(matches!(
+            result.errors.as_slice(),
+            [QueryError::InvalidArgument(msg)] if msg.contains("token_id")
+        ));
+    }
+
+    #[test]
+    fn test_query_with_empty_state() {
+        let (platform, state, version) = setup_platform(None, Network::Testnet, None);
+
+        let request = GetTokenPreProgrammedDistributionsRequestV0 {
+            token_id: vec![0; 32],
+            start_at_info: None,
+            limit: None,
+            prove: false,
+        };
+
+        let result = platform
+            .query_token_pre_programmed_distributions_v0(request, &state, version)
+            .expect("expected query to succeed");
+
+        assert!(result.errors.is_empty());
+        let data = result.data.unwrap();
+        match data.result {
+            Some(
+                get_token_pre_programmed_distributions_response_v0::Result::TokenDistributions(
+                    dists,
+                ),
+            ) => {
+                assert!(dists.token_distributions.is_empty());
+            }
+            _ => panic!("expected TokenDistributions result"),
+        }
+    }
+
+    #[test]
+    fn test_query_with_proof() {
+        let (platform, state, version) = setup_platform(None, Network::Testnet, None);
+
+        let request = GetTokenPreProgrammedDistributionsRequestV0 {
+            token_id: vec![0; 32],
+            start_at_info: None,
+            limit: None,
+            prove: true,
+        };
+
+        let result = platform
+            .query_token_pre_programmed_distributions_v0(request, &state, version)
+            .expect("expected query to succeed");
+
+        assert!(result.errors.is_empty());
+        assert!(matches!(
+            result.data,
+            Some(GetTokenPreProgrammedDistributionsResponseV0 {
+                result: Some(get_token_pre_programmed_distributions_response_v0::Result::Proof(_)),
+                metadata: Some(_),
+            })
+        ));
+    }
+
+    #[test]
+    fn test_query_with_distribution_data() {
+        let (platform, state, version, _, token_ids, _) = setup_platform_with_token_state();
+
+        // Token 2 has pre-programmed distributions at timestamps 1000, 5000, 10000
+        let request = GetTokenPreProgrammedDistributionsRequestV0 {
+            token_id: token_ids[2].to_vec(),
+            start_at_info: None,
+            limit: None,
+            prove: false,
+        };
+
+        let result = platform
+            .query_token_pre_programmed_distributions_v0(request, &state, version)
+            .expect("expected query to succeed");
+
+        assert!(result.errors.is_empty());
+        let data = result.data.unwrap();
+        match data.result {
+            Some(
+                get_token_pre_programmed_distributions_response_v0::Result::TokenDistributions(
+                    dists,
+                ),
+            ) => {
+                assert_eq!(dists.token_distributions.len(), 3);
+                // Verify timestamps
+                let timestamps: Vec<u64> = dists
+                    .token_distributions
+                    .iter()
+                    .map(|d| d.timestamp)
+                    .collect();
+                assert!(timestamps.contains(&1000));
+                assert!(timestamps.contains(&5000));
+                assert!(timestamps.contains(&10000));
+            }
+            _ => panic!("expected TokenDistributions result"),
+        }
+    }
+
+    #[test]
+    fn test_query_with_limit() {
+        let (platform, state, version, _, token_ids, _) = setup_platform_with_token_state();
+
+        let request = GetTokenPreProgrammedDistributionsRequestV0 {
+            token_id: token_ids[2].to_vec(),
+            start_at_info: None,
+            limit: Some(2),
+            prove: false,
+        };
+
+        let result = platform
+            .query_token_pre_programmed_distributions_v0(request, &state, version)
+            .expect("expected query to succeed");
+
+        assert!(result.errors.is_empty());
+        let data = result.data.unwrap();
+        match data.result {
+            Some(
+                get_token_pre_programmed_distributions_response_v0::Result::TokenDistributions(
+                    dists,
+                ),
+            ) => {
+                // With limit=2, we should get fewer distributions than the full set (3)
+                assert!(dists.token_distributions.len() < 3);
+                assert!(!dists.token_distributions.is_empty());
+            }
+            _ => panic!("expected TokenDistributions result"),
+        }
+    }
+
+    #[test]
+    fn test_query_with_start_at() {
+        let (platform, state, version, _, token_ids, _) = setup_platform_with_token_state();
+
+        let request = GetTokenPreProgrammedDistributionsRequestV0 {
+            token_id: token_ids[2].to_vec(),
+            start_at_info: Some(StartAtInfo {
+                start_time_ms: 5000,
+                start_recipient: None,
+                start_recipient_included: None,
+            }),
+            limit: None,
+            prove: false,
+        };
+
+        let result = platform
+            .query_token_pre_programmed_distributions_v0(request, &state, version)
+            .expect("expected query to succeed");
+
+        assert!(result.errors.is_empty());
+        let data = result.data.unwrap();
+        match data.result {
+            Some(
+                get_token_pre_programmed_distributions_response_v0::Result::TokenDistributions(
+                    dists,
+                ),
+            ) => {
+                // Should return distributions starting from 5000 onwards
+                assert!(!dists.token_distributions.is_empty());
+                for d in &dists.token_distributions {
+                    assert!(d.timestamp >= 5000);
+                }
+            }
+            _ => panic!("expected TokenDistributions result"),
+        }
+    }
+
+    #[test]
+    fn test_query_with_invalid_start_recipient() {
+        let (platform, state, version, _, token_ids, _) = setup_platform_with_token_state();
+
+        let request = GetTokenPreProgrammedDistributionsRequestV0 {
+            token_id: token_ids[2].to_vec(),
+            start_at_info: Some(StartAtInfo {
+                start_time_ms: 1000,
+                start_recipient: Some(vec![0; 8]), // invalid
+                start_recipient_included: None,
+            }),
+            limit: None,
+            prove: false,
+        };
+
+        let result = platform
+            .query_token_pre_programmed_distributions_v0(request, &state, version)
+            .expect("expected query to succeed");
+
+        assert!(matches!(
+            result.errors.as_slice(),
+            [QueryError::InvalidArgument(msg)] if msg.contains("start_recipient")
+        ));
+    }
+
+    #[test]
+    fn test_query_no_distributions_for_token() {
+        let (platform, state, version, _, token_ids, _) = setup_platform_with_token_state();
+
+        // Token 0 has no pre-programmed distributions
+        let request = GetTokenPreProgrammedDistributionsRequestV0 {
+            token_id: token_ids[0].to_vec(),
+            start_at_info: None,
+            limit: None,
+            prove: false,
+        };
+
+        let result = platform
+            .query_token_pre_programmed_distributions_v0(request, &state, version)
+            .expect("expected query to succeed");
+
+        assert!(result.errors.is_empty());
+        let data = result.data.unwrap();
+        match data.result {
+            Some(
+                get_token_pre_programmed_distributions_response_v0::Result::TokenDistributions(
+                    dists,
+                ),
+            ) => {
+                assert!(dists.token_distributions.is_empty());
+            }
+            _ => panic!("expected TokenDistributions result"),
+        }
+    }
+
+    #[test]
+    fn test_query_with_data_proof() {
+        let (platform, state, version, _, token_ids, _) = setup_platform_with_token_state();
+
+        let request = GetTokenPreProgrammedDistributionsRequestV0 {
+            token_id: token_ids[2].to_vec(),
+            start_at_info: None,
+            limit: None,
+            prove: true,
+        };
+
+        let result = platform
+            .query_token_pre_programmed_distributions_v0(request, &state, version)
+            .expect("expected query to succeed");
+
+        assert!(result.errors.is_empty());
+        assert!(matches!(
+            result.data,
+            Some(GetTokenPreProgrammedDistributionsResponseV0 {
+                result: Some(get_token_pre_programmed_distributions_response_v0::Result::Proof(_)),
+                metadata: Some(_),
+            })
+        ));
+    }
+}

--- a/packages/rs-drive-abci/src/query/token_queries/token_status/v0/mod.rs
+++ b/packages/rs-drive-abci/src/query/token_queries/token_status/v0/mod.rs
@@ -74,3 +74,188 @@ impl<C> Platform<C> {
         Ok(QueryValidationResult::new_with_data(response))
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::query::tests::setup_platform;
+    use crate::query::tests::setup_platform_with_token_state;
+    use dapi_grpc::platform::v0::get_token_statuses_response::get_token_statuses_response_v0;
+    use dpp::dashcore::Network;
+
+    #[test]
+    fn test_invalid_token_id() {
+        let (platform, state, version) = setup_platform(None, Network::Testnet, None);
+
+        let request = GetTokenStatusesRequestV0 {
+            token_ids: vec![vec![0; 8]],
+            prove: false,
+        };
+
+        let result = platform
+            .query_token_statuses_v0(request, &state, version)
+            .expect("expected query to succeed");
+
+        assert!(matches!(
+            result.errors.as_slice(),
+            [QueryError::InvalidArgument(msg)] if msg.contains("token_id")
+        ));
+    }
+
+    #[test]
+    fn test_query_with_empty_state() {
+        let (platform, state, version) = setup_platform(None, Network::Testnet, None);
+
+        let request = GetTokenStatusesRequestV0 {
+            token_ids: vec![vec![0; 32]],
+            prove: false,
+        };
+
+        let result = platform
+            .query_token_statuses_v0(request, &state, version)
+            .expect("expected query to succeed");
+
+        assert!(result.errors.is_empty());
+        let data = result.data.unwrap();
+        match data.result {
+            Some(get_token_statuses_response_v0::Result::TokenStatuses(statuses)) => {
+                assert_eq!(statuses.token_statuses.len(), 1);
+                // Status should be None for nonexistent token
+                assert!(statuses.token_statuses[0].paused.is_none());
+            }
+            _ => panic!("expected TokenStatuses result"),
+        }
+    }
+
+    #[test]
+    fn test_query_with_proof() {
+        let (platform, state, version) = setup_platform(None, Network::Testnet, None);
+
+        let request = GetTokenStatusesRequestV0 {
+            token_ids: vec![vec![0; 32]],
+            prove: true,
+        };
+
+        let result = platform
+            .query_token_statuses_v0(request, &state, version)
+            .expect("expected query to succeed");
+
+        assert!(result.errors.is_empty());
+        assert!(matches!(
+            result.data,
+            Some(GetTokenStatusesResponseV0 {
+                result: Some(get_token_statuses_response_v0::Result::Proof(_)),
+                metadata: Some(_),
+            })
+        ));
+    }
+
+    #[test]
+    fn test_query_token_not_paused() {
+        let (platform, state, version, _, token_ids, _) = setup_platform_with_token_state();
+
+        // Token 0 is NOT paused - status may be None or Some(false) depending on
+        // whether initial status was written
+        let request = GetTokenStatusesRequestV0 {
+            token_ids: vec![token_ids[0].to_vec()],
+            prove: false,
+        };
+
+        let result = platform
+            .query_token_statuses_v0(request, &state, version)
+            .expect("expected query to succeed");
+
+        assert!(result.errors.is_empty());
+        let data = result.data.unwrap();
+        match data.result {
+            Some(get_token_statuses_response_v0::Result::TokenStatuses(statuses)) => {
+                assert_eq!(statuses.token_statuses.len(), 1);
+                // Token 0 was not explicitly paused, so paused is either None or Some(false)
+                assert_ne!(statuses.token_statuses[0].paused, Some(true));
+            }
+            _ => panic!("expected TokenStatuses result"),
+        }
+    }
+
+    #[test]
+    fn test_query_token_paused() {
+        let (platform, state, version, _, token_ids, _) = setup_platform_with_token_state();
+
+        // Token 1 IS paused
+        let request = GetTokenStatusesRequestV0 {
+            token_ids: vec![token_ids[1].to_vec()],
+            prove: false,
+        };
+
+        let result = platform
+            .query_token_statuses_v0(request, &state, version)
+            .expect("expected query to succeed");
+
+        assert!(result.errors.is_empty());
+        let data = result.data.unwrap();
+        match data.result {
+            Some(get_token_statuses_response_v0::Result::TokenStatuses(statuses)) => {
+                assert_eq!(statuses.token_statuses.len(), 1);
+                assert_eq!(statuses.token_statuses[0].paused, Some(true));
+            }
+            _ => panic!("expected TokenStatuses result"),
+        }
+    }
+
+    #[test]
+    fn test_query_multiple_tokens() {
+        let (platform, state, version, _, token_ids, _) = setup_platform_with_token_state();
+
+        let request = GetTokenStatusesRequestV0 {
+            token_ids: vec![
+                token_ids[0].to_vec(),
+                token_ids[1].to_vec(),
+                token_ids[2].to_vec(),
+            ],
+            prove: false,
+        };
+
+        let result = platform
+            .query_token_statuses_v0(request, &state, version)
+            .expect("expected query to succeed");
+
+        assert!(result.errors.is_empty());
+        let data = result.data.unwrap();
+        match data.result {
+            Some(get_token_statuses_response_v0::Result::TokenStatuses(statuses)) => {
+                assert_eq!(statuses.token_statuses.len(), 3);
+                // Exactly one should be paused (token_1)
+                let paused_count = statuses
+                    .token_statuses
+                    .iter()
+                    .filter(|s| s.paused == Some(true))
+                    .count();
+                assert_eq!(paused_count, 1);
+            }
+            _ => panic!("expected TokenStatuses result"),
+        }
+    }
+
+    #[test]
+    fn test_query_with_data_proof() {
+        let (platform, state, version, _, token_ids, _) = setup_platform_with_token_state();
+
+        let request = GetTokenStatusesRequestV0 {
+            token_ids: vec![token_ids[0].to_vec(), token_ids[1].to_vec()],
+            prove: true,
+        };
+
+        let result = platform
+            .query_token_statuses_v0(request, &state, version)
+            .expect("expected query to succeed");
+
+        assert!(result.errors.is_empty());
+        assert!(matches!(
+            result.data,
+            Some(GetTokenStatusesResponseV0 {
+                result: Some(get_token_statuses_response_v0::Result::Proof(_)),
+                metadata: Some(_),
+            })
+        ));
+    }
+}

--- a/packages/rs-drive-abci/src/query/token_queries/token_total_supply/v0/mod.rs
+++ b/packages/rs-drive-abci/src/query/token_queries/token_total_supply/v0/mod.rs
@@ -82,3 +82,151 @@ impl<C> Platform<C> {
         Ok(QueryValidationResult::new_with_data(response))
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::query::tests::setup_platform;
+    use crate::query::tests::setup_platform_with_token_state;
+    use dapi_grpc::platform::v0::get_token_total_supply_response::get_token_total_supply_response_v0;
+    use dpp::dashcore::Network;
+
+    #[test]
+    fn test_invalid_token_id() {
+        let (platform, state, version) = setup_platform(None, Network::Testnet, None);
+
+        let request = GetTokenTotalSupplyRequestV0 {
+            token_id: vec![0; 8],
+            prove: false,
+        };
+
+        let result = platform
+            .query_token_total_supply_v0(request, &state, version)
+            .expect("expected query to succeed");
+
+        assert!(matches!(
+            result.errors.as_slice(),
+            [QueryError::InvalidArgument(msg)] if msg.contains("token_id")
+        ));
+    }
+
+    #[test]
+    fn test_query_token_not_found() {
+        let (platform, state, version) = setup_platform(None, Network::Testnet, None);
+
+        let request = GetTokenTotalSupplyRequestV0 {
+            token_id: vec![0; 32],
+            prove: false,
+        };
+
+        let result = platform
+            .query_token_total_supply_v0(request, &state, version)
+            .expect("expected query to succeed");
+
+        assert!(matches!(
+            result.errors.as_slice(),
+            [QueryError::NotFound(msg)] if msg.contains("Token")
+        ));
+    }
+
+    #[test]
+    fn test_query_with_proof() {
+        let (platform, state, version) = setup_platform(None, Network::Testnet, None);
+
+        let request = GetTokenTotalSupplyRequestV0 {
+            token_id: vec![0; 32],
+            prove: true,
+        };
+
+        let result = platform
+            .query_token_total_supply_v0(request, &state, version)
+            .expect("expected query to succeed");
+
+        assert!(result.errors.is_empty());
+        assert!(matches!(
+            result.data,
+            Some(GetTokenTotalSupplyResponseV0 {
+                result: Some(get_token_total_supply_response_v0::Result::Proof(_)),
+                metadata: Some(_),
+            })
+        ));
+    }
+
+    #[test]
+    fn test_query_with_token_data() {
+        let (platform, state, version, _, token_ids, _) = setup_platform_with_token_state();
+
+        // Token 0: base_supply=100000, minted 100 to id1 + 100 to id2 = 200 additional
+        let request = GetTokenTotalSupplyRequestV0 {
+            token_id: token_ids[0].to_vec(),
+            prove: false,
+        };
+
+        let result = platform
+            .query_token_total_supply_v0(request, &state, version)
+            .expect("expected query to succeed");
+
+        assert!(result.errors.is_empty());
+        let data = result.data.unwrap();
+        match data.result {
+            Some(get_token_total_supply_response_v0::Result::TokenTotalSupply(entry)) => {
+                assert_eq!(entry.token_id, token_ids[0].to_vec());
+                // Total supply = base_supply (100000) + minted (100 + 100) = 100200
+                assert_eq!(entry.total_system_amount, 100200);
+                // Aggregated identity balances = base_supply + minted = 100100 + 100 = 100200
+                assert_eq!(entry.total_aggregated_amount_in_user_accounts, 100200);
+            }
+            _ => panic!("expected TokenTotalSupply result"),
+        }
+    }
+
+    #[test]
+    fn test_query_with_token_data_token_1() {
+        let (platform, state, version, _, token_ids, _) = setup_platform_with_token_state();
+
+        // Token 1: base_supply=100000, minted 200 to id1 + 100 to id3 = 300 additional
+        let request = GetTokenTotalSupplyRequestV0 {
+            token_id: token_ids[1].to_vec(),
+            prove: false,
+        };
+
+        let result = platform
+            .query_token_total_supply_v0(request, &state, version)
+            .expect("expected query to succeed");
+
+        assert!(result.errors.is_empty());
+        let data = result.data.unwrap();
+        match data.result {
+            Some(get_token_total_supply_response_v0::Result::TokenTotalSupply(entry)) => {
+                // Total supply = base_supply (100000) + minted (200 + 100) = 100300
+                assert_eq!(entry.total_system_amount, 100300);
+                // Aggregated identity balances = 100200 + 100 = 100300
+                assert_eq!(entry.total_aggregated_amount_in_user_accounts, 100300);
+            }
+            _ => panic!("expected TokenTotalSupply result"),
+        }
+    }
+
+    #[test]
+    fn test_query_with_data_proof() {
+        let (platform, state, version, _, token_ids, _) = setup_platform_with_token_state();
+
+        let request = GetTokenTotalSupplyRequestV0 {
+            token_id: token_ids[0].to_vec(),
+            prove: true,
+        };
+
+        let result = platform
+            .query_token_total_supply_v0(request, &state, version)
+            .expect("expected query to succeed");
+
+        assert!(result.errors.is_empty());
+        assert!(matches!(
+            result.data,
+            Some(GetTokenTotalSupplyResponseV0 {
+                result: Some(get_token_total_supply_response_v0::Result::Proof(_)),
+                metadata: Some(_),
+            })
+        ));
+    }
+}


### PR DESCRIPTION
## Issue being fixed or feature implemented

Add unit test coverage for all 10 token query v0 modules in `packages/rs-drive-abci/src/query/token_queries/`, which previously had 0% coverage.

## What was done?

Added 71 comprehensive unit tests across all 10 token query v0/mod.rs files:

| Module | Tests | Coverage Areas |
|--------|-------|---------------|
| `identities_token_balances` | 6 | invalid token_id, invalid identity_id, empty state, proof, data, data+proof |
| `identities_token_infos` | 7 | invalid token_id, invalid identity_id, empty state, proof, not_frozen, frozen, data+proof |
| `identity_token_balances` | 6 | invalid identity_id, invalid token_id, empty state, proof, data, data+proof |
| `identity_token_infos` | 6 | invalid identity_id, invalid token_id, empty state, proof, data, data+proof |
| `token_contract_info` | 6 | invalid token_id, not_found, proof, data pos0, data pos1, data+proof |
| `token_direct_purchase_prices` | 9 | empty ids, invalid token_id, empty state, proof, fixed price, variable price, no price, multiple tokens, data+proof |
| `token_perpetual_distribution_last_claim` | 8 | invalid token_id, invalid identity_id, proof, raw without contract, with contract info, invalid contract_id, contract not found, position too large, data+proof |
| `token_pre_programmed_distributions` | 9 | invalid token_id, empty state, proof, data, limit, start_at, invalid start_recipient, no distributions, data+proof |
| `token_status` | 7 | invalid token_id, empty state, proof, not paused, paused, multiple tokens, data+proof |
| `token_total_supply` | 7 | invalid token_id, not found, proof, data token0, data token1, data+proof |

Also added a reusable `setup_platform_with_token_state()` helper function to `query::tests` that creates:
- 3 test identities with keys and credits
- A data contract with 3 tokens (including groups, perpetual distributions, and pre-programmed distributions)
- Minted token balances across identities
- Frozen identity state (identity 2 on token 0)
- Paused token state (token 1)
- Direct purchase pricing (fixed for token 1, variable schedule for token 2)

## How Has This Been Tested?

All 71 tests pass:
```
cargo test -p drive-abci -- query::token_queries
test result: ok. 71 passed; 0 failed; 0 ignored; 0 measured; 1313 filtered out
```

Each test exercises both the validation error paths and the successful query paths (with and without proofs), targeting >93% line coverage for each v0/mod.rs file.

## Breaking Changes

None.

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [x] I have made corresponding changes to the documentation if needed