### PR TITLE
test(drive-abci): add tests for address_funds query modules

### DIFF
--- a/packages/rs-drive-abci/src/query/address_funds/address_info/v0/mod.rs
+++ b/packages/rs-drive-abci/src/query/address_funds/address_info/v0/mod.rs
@@ -65,3 +65,197 @@ impl<C> Platform<C> {
         Ok(QueryValidationResult::new_with_data(response))
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::query::tests::setup_platform;
+    use dpp::address_funds::PlatformAddress;
+    use dpp::block::block_info::BlockInfo;
+    use dpp::dashcore::Network;
+    use drive::util::batch::drive_op_batch::{AddressFundsOperationType, DriveOperation};
+
+    const TEST_ADDRESS: PlatformAddress = PlatformAddress::P2pkh([10; 20]);
+    const TEST_NONCE: u32 = 5;
+    const TEST_BALANCE: u64 = 1_000_000;
+
+    fn setup_address_balance(
+        platform: &Platform<crate::rpc::core::MockCoreRPCLike>,
+        platform_version: &PlatformVersion,
+    ) {
+        let operations = vec![DriveOperation::AddressFundsOperation(
+            AddressFundsOperationType::SetBalanceToAddress {
+                address: TEST_ADDRESS,
+                nonce: TEST_NONCE,
+                balance: TEST_BALANCE,
+            },
+        )];
+
+        platform
+            .drive
+            .apply_drive_operations(
+                operations,
+                true,
+                &BlockInfo::default(),
+                None,
+                platform_version,
+                None,
+            )
+            .expect("expected to apply operations");
+    }
+
+    #[test]
+    fn test_invalid_address_bytes() {
+        let (platform, state, version) = setup_platform(None, Network::Testnet, None);
+
+        let request = GetAddressInfoRequestV0 {
+            address: vec![0xFF, 0xFF], // invalid address bytes
+            prove: false,
+        };
+
+        let result = platform
+            .query_address_info_v0(request, &state, version)
+            .expect("should return validation result");
+
+        assert!(
+            !result.errors.is_empty(),
+            "expected validation errors for invalid address"
+        );
+        assert!(matches!(
+            result.errors.as_slice(),
+            [QueryError::InvalidArgument(msg)] if msg.contains("invalid key_of_type")
+        ));
+    }
+
+    #[test]
+    fn test_address_not_found_returns_none_balance() {
+        let (platform, state, version) = setup_platform(None, Network::Testnet, None);
+
+        let unknown_address = PlatformAddress::P2pkh([99; 20]);
+        let address_bytes = unknown_address.to_bytes();
+
+        let request = GetAddressInfoRequestV0 {
+            address: address_bytes.clone(),
+            prove: false,
+        };
+
+        let result = platform
+            .query_address_info_v0(request, &state, version)
+            .expect("expected query to succeed");
+
+        assert!(result.errors.is_empty(), "expected no errors");
+        let response = result.data.expect("expected response data");
+        match response.result {
+            Some(get_address_info_response_v0::Result::AddressInfoEntry(entry)) => {
+                assert_eq!(entry.address, address_bytes);
+                assert!(
+                    entry.balance_and_nonce.is_none(),
+                    "expected no balance for unknown address"
+                );
+            }
+            other => panic!("expected AddressInfoEntry result, got {:?}", other),
+        }
+        assert!(response.metadata.is_some());
+    }
+
+    #[test]
+    fn test_address_info_fetch_with_balance() {
+        let (platform, state, version) = setup_platform(None, Network::Testnet, None);
+
+        setup_address_balance(&platform, version);
+
+        let address_bytes = TEST_ADDRESS.to_bytes();
+
+        let request = GetAddressInfoRequestV0 {
+            address: address_bytes.clone(),
+            prove: false,
+        };
+
+        let result = platform
+            .query_address_info_v0(request, &state, version)
+            .expect("expected query to succeed");
+
+        assert!(result.errors.is_empty(), "expected no errors");
+        let response = result.data.expect("expected response data");
+        match response.result {
+            Some(get_address_info_response_v0::Result::AddressInfoEntry(entry)) => {
+                assert_eq!(entry.address, address_bytes);
+                let ban = entry.balance_and_nonce.expect("expected balance and nonce");
+                assert_eq!(ban.balance, TEST_BALANCE);
+                assert_eq!(ban.nonce, TEST_NONCE);
+            }
+            other => panic!("expected AddressInfoEntry result, got {:?}", other),
+        }
+        assert!(response.metadata.is_some());
+    }
+
+    #[test]
+    fn test_address_info_proof_with_balance() {
+        let (platform, state, version) = setup_platform(None, Network::Testnet, None);
+
+        setup_address_balance(&platform, version);
+
+        let address_bytes = TEST_ADDRESS.to_bytes();
+
+        let request = GetAddressInfoRequestV0 {
+            address: address_bytes,
+            prove: true,
+        };
+
+        let result = platform
+            .query_address_info_v0(request, &state, version)
+            .expect("expected query to succeed");
+
+        assert!(result.errors.is_empty(), "expected no errors");
+        let response = result.data.expect("expected response data");
+        assert!(matches!(
+            response.result,
+            Some(get_address_info_response_v0::Result::Proof(_))
+        ));
+        assert!(response.metadata.is_some());
+    }
+
+    #[test]
+    fn test_address_info_proof_absence() {
+        let (platform, state, version) = setup_platform(None, Network::Testnet, None);
+
+        let unknown_address = PlatformAddress::P2pkh([99; 20]);
+        let address_bytes = unknown_address.to_bytes();
+
+        let request = GetAddressInfoRequestV0 {
+            address: address_bytes,
+            prove: true,
+        };
+
+        let result = platform
+            .query_address_info_v0(request, &state, version)
+            .expect("expected query to succeed");
+
+        assert!(result.errors.is_empty(), "expected no errors");
+        let response = result.data.expect("expected response data");
+        assert!(matches!(
+            response.result,
+            Some(get_address_info_response_v0::Result::Proof(_))
+        ));
+        assert!(response.metadata.is_some());
+    }
+
+    #[test]
+    fn test_address_info_empty_address_bytes() {
+        let (platform, state, version) = setup_platform(None, Network::Testnet, None);
+
+        let request = GetAddressInfoRequestV0 {
+            address: vec![],
+            prove: false,
+        };
+
+        let result = platform
+            .query_address_info_v0(request, &state, version)
+            .expect("should return validation result");
+
+        assert!(
+            !result.errors.is_empty(),
+            "expected validation errors for empty address"
+        );
+    }
+}

--- a/packages/rs-drive-abci/src/query/address_funds/addresses_branch_state/v0/mod.rs
+++ b/packages/rs-drive-abci/src/query/address_funds/addresses_branch_state/v0/mod.rs
@@ -30,3 +30,158 @@ impl<C> Platform<C> {
         Ok(QueryValidationResult::new_with_data(response))
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::query::tests::setup_platform;
+    use dpp::dashcore::Network;
+    use drive::drive::{Checkpoint, CheckpointInfo};
+    use drive::grovedb::GroveDb;
+    use std::collections::BTreeMap;
+    use std::sync::Arc;
+
+    #[test]
+    fn test_branch_state_no_checkpoint_returns_error() {
+        // Without checkpoints, the branch query should return an error
+        // because prove_address_funds_branch_query uses GroveDBToUse::Checkpoint(height)
+        let (platform, state, version) = setup_platform(None, Network::Testnet, None);
+
+        let request = GetAddressesBranchStateRequestV0 {
+            key: vec![0; 1],
+            depth: 2,
+            checkpoint_height: 0,
+        };
+
+        let result = platform.query_addresses_branch_state_v0(request, &state, version);
+
+        // The branch query uses `?` so errors propagate as Err, not as validation errors
+        assert!(
+            result.is_err(),
+            "expected error when no checkpoint is available"
+        );
+    }
+
+    #[test]
+    fn test_branch_state_invalid_depth_returns_error() {
+        let (platform, state, version) = setup_platform(None, Network::Testnet, None);
+
+        // Use a depth of 0 which should be below the minimum allowed depth
+        let request = GetAddressesBranchStateRequestV0 {
+            key: vec![0; 1],
+            depth: 0,
+            checkpoint_height: 0,
+        };
+
+        let result = platform.query_addresses_branch_state_v0(request, &state, version);
+
+        assert!(
+            result.is_err(),
+            "expected error for depth outside allowed range"
+        );
+    }
+
+    #[test]
+    fn test_branch_state_max_depth_exceeded_returns_error() {
+        let (platform, state, version) = setup_platform(None, Network::Testnet, None);
+
+        // Use a very large depth (255) which should be above the maximum
+        let request = GetAddressesBranchStateRequestV0 {
+            key: vec![0; 1],
+            depth: 255,
+            checkpoint_height: 0,
+        };
+
+        let result = platform.query_addresses_branch_state_v0(request, &state, version);
+
+        assert!(
+            result.is_err(),
+            "expected error for depth above max allowed range"
+        );
+    }
+
+    #[test]
+    fn test_branch_state_with_checkpoint_returns_proof() {
+        use dpp::address_funds::PlatformAddress;
+        use dpp::block::block_info::BlockInfo;
+        use drive::util::batch::drive_op_batch::{AddressFundsOperationType, DriveOperation};
+
+        let (platform, state, version) = setup_platform(None, Network::Testnet, None);
+
+        // Insert address balances so the addresses tree is not empty
+        let operations = vec![
+            DriveOperation::AddressFundsOperation(AddressFundsOperationType::SetBalanceToAddress {
+                address: PlatformAddress::P2pkh([10; 20]),
+                nonce: 1,
+                balance: 1_000_000,
+            }),
+            DriveOperation::AddressFundsOperation(AddressFundsOperationType::SetBalanceToAddress {
+                address: PlatformAddress::P2sh([20; 20]),
+                nonce: 2,
+                balance: 2_000_000,
+            }),
+        ];
+        platform
+            .drive
+            .apply_drive_operations(operations, true, &BlockInfo::default(), None, version, None)
+            .expect("expected to apply operations");
+
+        let checkpoint_height = 1u64;
+
+        // Create a checkpoint from the current grovedb state (which now has addresses)
+        let checkpoint_path = platform
+            .config
+            .db_path
+            .join("checkpoints")
+            .join(checkpoint_height.to_string());
+        std::fs::create_dir_all(checkpoint_path.parent().unwrap())
+            .expect("expected to create checkpoints dir");
+        platform
+            .drive
+            .grove
+            .create_checkpoint(&checkpoint_path)
+            .expect("expected to create checkpoint");
+
+        let checkpoint_db =
+            GroveDb::open(&checkpoint_path).expect("expected to open checkpoint db");
+        let checkpoint = Checkpoint::new(checkpoint_db, checkpoint_path);
+
+        let mut checkpoints_map = BTreeMap::new();
+        checkpoints_map.insert(
+            checkpoint_height,
+            CheckpointInfo::new(1000, Arc::new(checkpoint)),
+        );
+        platform.drive.checkpoints.store(Arc::new(checkpoints_map));
+
+        // The min_depth from the platform version
+        let min_depth = version
+            .drive
+            .methods
+            .address_funds
+            .address_funds_query_min_depth;
+
+        // Use a valid address key from the tree
+        let addr_key = PlatformAddress::P2pkh([10; 20]).to_bytes();
+
+        let request = GetAddressesBranchStateRequestV0 {
+            key: addr_key,
+            depth: min_depth as u32,
+            checkpoint_height,
+        };
+
+        let result = platform
+            .query_addresses_branch_state_v0(request, &state, version)
+            .expect("expected query to succeed with checkpoint");
+
+        assert!(
+            result.errors.is_empty(),
+            "expected no errors with checkpoint"
+        );
+        let response = result.data.expect("expected response data");
+        // The merk_proof should be non-empty
+        assert!(
+            !response.merk_proof.is_empty(),
+            "expected non-empty merk proof"
+        );
+    }
+}

--- a/packages/rs-drive-abci/src/query/address_funds/addresses_infos/v0/mod.rs
+++ b/packages/rs-drive-abci/src/query/address_funds/addresses_infos/v0/mod.rs
@@ -191,22 +191,29 @@ mod tests {
             Some(get_addresses_infos_response_v0::Result::AddressInfoEntries(entries)) => {
                 assert_eq!(entries.address_info_entries.len(), 2);
 
-                // Find entries by address bytes
+                // Verify each address entry and track which were seen
+                let mut saw_addr1 = false;
+                let mut saw_addr2 = false;
                 for entry in &entries.address_info_entries {
                     let ban = entry
                         .balance_and_nonce
                         .as_ref()
                         .expect("expected balance and nonce");
                     if entry.address == ADDR1.to_bytes() {
+                        assert!(!saw_addr1, "duplicate ADDR1 entry");
+                        saw_addr1 = true;
                         assert_eq!(ban.balance, BALANCE1);
                         assert_eq!(ban.nonce, NONCE1);
                     } else if entry.address == ADDR2.to_bytes() {
+                        assert!(!saw_addr2, "duplicate ADDR2 entry");
+                        saw_addr2 = true;
                         assert_eq!(ban.balance, BALANCE2);
                         assert_eq!(ban.nonce, NONCE2);
                     } else {
                         panic!("unexpected address in response");
                     }
                 }
+                assert!(saw_addr1 && saw_addr2, "expected both addresses");
             }
             other => panic!("expected AddressInfoEntries result, got {:?}", other),
         }

--- a/packages/rs-drive-abci/src/query/address_funds/addresses_infos/v0/mod.rs
+++ b/packages/rs-drive-abci/src/query/address_funds/addresses_infos/v0/mod.rs
@@ -73,3 +73,232 @@ impl<C> Platform<C> {
         Ok(QueryValidationResult::new_with_data(response))
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::query::tests::setup_platform;
+    use dpp::address_funds::PlatformAddress;
+    use dpp::block::block_info::BlockInfo;
+    use dpp::dashcore::Network;
+    use drive::util::batch::drive_op_batch::{AddressFundsOperationType, DriveOperation};
+
+    const ADDR1: PlatformAddress = PlatformAddress::P2pkh([10; 20]);
+    const ADDR2: PlatformAddress = PlatformAddress::P2sh([11; 20]);
+    const NONCE1: u32 = 5;
+    const NONCE2: u32 = 7;
+    const BALANCE1: u64 = 1_000_000;
+    const BALANCE2: u64 = 2_000_000;
+
+    fn setup_two_address_balances(
+        platform: &Platform<crate::rpc::core::MockCoreRPCLike>,
+        platform_version: &PlatformVersion,
+    ) {
+        let operations = vec![
+            DriveOperation::AddressFundsOperation(AddressFundsOperationType::SetBalanceToAddress {
+                address: ADDR1,
+                nonce: NONCE1,
+                balance: BALANCE1,
+            }),
+            DriveOperation::AddressFundsOperation(AddressFundsOperationType::SetBalanceToAddress {
+                address: ADDR2,
+                nonce: NONCE2,
+                balance: BALANCE2,
+            }),
+        ];
+
+        platform
+            .drive
+            .apply_drive_operations(
+                operations,
+                true,
+                &BlockInfo::default(),
+                None,
+                platform_version,
+                None,
+            )
+            .expect("expected to apply operations");
+    }
+
+    #[test]
+    fn test_invalid_address_in_list() {
+        let (platform, state, version) = setup_platform(None, Network::Testnet, None);
+
+        let request = GetAddressesInfosRequestV0 {
+            addresses: vec![vec![0xFF, 0xFF]], // invalid address bytes
+            prove: false,
+        };
+
+        let result = platform
+            .query_addresses_infos_v0(request, &state, version)
+            .expect("should return validation result");
+
+        assert!(
+            !result.errors.is_empty(),
+            "expected validation errors for invalid address"
+        );
+        assert!(matches!(
+            result.errors.as_slice(),
+            [QueryError::InvalidArgument(msg)] if msg.contains("invalid key_of_type")
+        ));
+    }
+
+    #[test]
+    fn test_empty_addresses_list() {
+        let (platform, state, version) = setup_platform(None, Network::Testnet, None);
+
+        let request = GetAddressesInfosRequestV0 {
+            addresses: vec![],
+            prove: false,
+        };
+
+        let result = platform
+            .query_addresses_infos_v0(request, &state, version)
+            .expect("expected query to succeed");
+
+        assert!(result.errors.is_empty(), "expected no errors");
+        let response = result.data.expect("expected response data");
+        match response.result {
+            Some(get_addresses_infos_response_v0::Result::AddressInfoEntries(entries)) => {
+                assert!(
+                    entries.address_info_entries.is_empty(),
+                    "expected empty entries"
+                );
+            }
+            other => panic!("expected AddressInfoEntries result, got {:?}", other),
+        }
+        assert!(response.metadata.is_some());
+    }
+
+    #[test]
+    fn test_addresses_infos_fetch_multiple_existing() {
+        let (platform, state, version) = setup_platform(None, Network::Testnet, None);
+
+        setup_two_address_balances(&platform, version);
+
+        let request = GetAddressesInfosRequestV0 {
+            addresses: vec![ADDR1.to_bytes(), ADDR2.to_bytes()],
+            prove: false,
+        };
+
+        let result = platform
+            .query_addresses_infos_v0(request, &state, version)
+            .expect("expected query to succeed");
+
+        assert!(result.errors.is_empty(), "expected no errors");
+        let response = result.data.expect("expected response data");
+        match response.result {
+            Some(get_addresses_infos_response_v0::Result::AddressInfoEntries(entries)) => {
+                assert_eq!(entries.address_info_entries.len(), 2);
+
+                // Find entries by address bytes
+                for entry in &entries.address_info_entries {
+                    let ban = entry
+                        .balance_and_nonce
+                        .as_ref()
+                        .expect("expected balance and nonce");
+                    if entry.address == ADDR1.to_bytes() {
+                        assert_eq!(ban.balance, BALANCE1);
+                        assert_eq!(ban.nonce, NONCE1);
+                    } else if entry.address == ADDR2.to_bytes() {
+                        assert_eq!(ban.balance, BALANCE2);
+                        assert_eq!(ban.nonce, NONCE2);
+                    } else {
+                        panic!("unexpected address in response");
+                    }
+                }
+            }
+            other => panic!("expected AddressInfoEntries result, got {:?}", other),
+        }
+        assert!(response.metadata.is_some());
+    }
+
+    #[test]
+    fn test_addresses_infos_fetch_with_unknown_address() {
+        let (platform, state, version) = setup_platform(None, Network::Testnet, None);
+
+        setup_two_address_balances(&platform, version);
+
+        let unknown = PlatformAddress::P2pkh([99; 20]);
+        let request = GetAddressesInfosRequestV0 {
+            addresses: vec![ADDR1.to_bytes(), unknown.to_bytes()],
+            prove: false,
+        };
+
+        let result = platform
+            .query_addresses_infos_v0(request, &state, version)
+            .expect("expected query to succeed");
+
+        assert!(result.errors.is_empty(), "expected no errors");
+        let response = result.data.expect("expected response data");
+        match response.result {
+            Some(get_addresses_infos_response_v0::Result::AddressInfoEntries(entries)) => {
+                assert_eq!(entries.address_info_entries.len(), 2);
+
+                for entry in &entries.address_info_entries {
+                    if entry.address == ADDR1.to_bytes() {
+                        let ban = entry
+                            .balance_and_nonce
+                            .as_ref()
+                            .expect("expected balance and nonce for addr1");
+                        assert_eq!(ban.balance, BALANCE1);
+                        assert_eq!(ban.nonce, NONCE1);
+                    } else if entry.address == unknown.to_bytes() {
+                        assert!(
+                            entry.balance_and_nonce.is_none(),
+                            "expected no balance for unknown address"
+                        );
+                    } else {
+                        panic!("unexpected address in response");
+                    }
+                }
+            }
+            other => panic!("expected AddressInfoEntries result, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_addresses_infos_proof_multiple() {
+        let (platform, state, version) = setup_platform(None, Network::Testnet, None);
+
+        setup_two_address_balances(&platform, version);
+
+        let request = GetAddressesInfosRequestV0 {
+            addresses: vec![ADDR1.to_bytes(), ADDR2.to_bytes()],
+            prove: true,
+        };
+
+        let result = platform
+            .query_addresses_infos_v0(request, &state, version)
+            .expect("expected query to succeed");
+
+        assert!(result.errors.is_empty(), "expected no errors");
+        let response = result.data.expect("expected response data");
+        assert!(matches!(
+            response.result,
+            Some(get_addresses_infos_response_v0::Result::Proof(_))
+        ));
+        assert!(response.metadata.is_some());
+    }
+
+    #[test]
+    fn test_addresses_infos_proof_empty_list() {
+        let (platform, state, version) = setup_platform(None, Network::Testnet, None);
+
+        let request = GetAddressesInfosRequestV0 {
+            addresses: vec![],
+            prove: true,
+        };
+
+        let result = platform
+            .query_addresses_infos_v0(request, &state, version)
+            .expect("should return validation result");
+
+        // Proving with an empty list of addresses returns a validation error
+        // because GroveDB cannot generate a proof for an empty query
+        assert!(
+            !result.errors.is_empty(),
+            "expected validation errors for empty address list proof"
+        );
+    }
+}

--- a/packages/rs-drive-abci/src/query/address_funds/addresses_trunk_state/v0/mod.rs
+++ b/packages/rs-drive-abci/src/query/address_funds/addresses_trunk_state/v0/mod.rs
@@ -31,3 +31,95 @@ impl<C> Platform<C> {
         Ok(QueryValidationResult::new_with_data(response))
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::query::tests::setup_platform;
+    use dpp::dashcore::Network;
+    use drive::drive::{Checkpoint, CheckpointInfo};
+    use drive::grovedb::GroveDb;
+    use std::collections::BTreeMap;
+    use std::sync::Arc;
+
+    #[test]
+    fn test_trunk_state_no_checkpoint_returns_validation_errors() {
+        // Without checkpoints, prove_address_funds_trunk_query returns an error.
+        // The check_validation_result_with_data! macro converts this to a
+        // validation result with errors (not a function-level Err).
+        let (platform, state, version) = setup_platform(None, Network::Testnet, None);
+
+        let request = GetAddressesTrunkStateRequestV0 {};
+
+        let result = platform
+            .query_addresses_trunk_state_v0(request, &state, version)
+            .expect("should return Ok with validation errors, not Err");
+
+        assert!(
+            !result.errors.is_empty(),
+            "expected validation errors when no checkpoint is available"
+        );
+    }
+
+    #[test]
+    fn test_trunk_state_no_checkpoint_with_initial_state() {
+        // Even with genesis state set up, there are still no checkpoints,
+        // so the trunk query should still return validation errors.
+        let (platform, state, version) = setup_platform(Some((1, 1500)), Network::Testnet, None);
+
+        let request = GetAddressesTrunkStateRequestV0 {};
+
+        let result = platform
+            .query_addresses_trunk_state_v0(request, &state, version)
+            .expect("should return Ok with validation errors, not Err");
+
+        assert!(
+            !result.errors.is_empty(),
+            "expected validation errors when no checkpoint is available"
+        );
+    }
+
+    #[test]
+    fn test_trunk_state_with_checkpoint_returns_proof() {
+        let (platform, state, version) = setup_platform(None, Network::Testnet, None);
+
+        // Create a checkpoint from the current grovedb state
+        let checkpoint_path = platform.config.db_path.join("checkpoints").join("1");
+        std::fs::create_dir_all(checkpoint_path.parent().unwrap())
+            .expect("expected to create checkpoints dir");
+        platform
+            .drive
+            .grove
+            .create_checkpoint(&checkpoint_path)
+            .expect("expected to create checkpoint");
+
+        let checkpoint_db =
+            GroveDb::open(&checkpoint_path).expect("expected to open checkpoint db");
+        let checkpoint = Checkpoint::new(checkpoint_db, checkpoint_path);
+
+        let mut checkpoints_map = BTreeMap::new();
+        checkpoints_map.insert(1u64, CheckpointInfo::new(1000, Arc::new(checkpoint)));
+        platform.drive.checkpoints.store(Arc::new(checkpoints_map));
+
+        // Also set up checkpoint_platform_states
+        let mut checkpoint_states = BTreeMap::new();
+        checkpoint_states.insert(1u64, state.clone());
+        platform
+            .checkpoint_platform_states
+            .store(Arc::new(checkpoint_states));
+
+        let request = GetAddressesTrunkStateRequestV0 {};
+
+        let result = platform
+            .query_addresses_trunk_state_v0(request, &state, version)
+            .expect("expected query to succeed");
+
+        assert!(
+            result.errors.is_empty(),
+            "expected no errors with checkpoint available"
+        );
+        let response = result.data.expect("expected response data");
+        assert!(response.proof.is_some(), "expected proof in response");
+        assert!(response.metadata.is_some(), "expected metadata in response");
+    }
+}

--- a/packages/rs-drive-abci/src/query/address_funds/recent_address_balance_changes/v0/mod.rs
+++ b/packages/rs-drive-abci/src/query/address_funds/recent_address_balance_changes/v0/mod.rs
@@ -93,3 +93,319 @@ impl<C> Platform<C> {
         Ok(QueryValidationResult::new_with_data(response))
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::query::tests::setup_platform;
+    use dpp::address_funds::PlatformAddress;
+    use dpp::balances::credits::CreditOperation;
+    use dpp::dashcore::Network;
+    use std::collections::BTreeMap;
+
+    const ADDR1: PlatformAddress = PlatformAddress::P2pkh([10; 20]);
+    const ADDR2: PlatformAddress = PlatformAddress::P2sh([11; 20]);
+
+    fn store_balance_changes(
+        platform: &Platform<crate::rpc::core::MockCoreRPCLike>,
+        block_height: u64,
+        changes: BTreeMap<PlatformAddress, CreditOperation>,
+        platform_version: &PlatformVersion,
+    ) {
+        platform
+            .drive
+            .store_address_balances_for_block(
+                &changes,
+                block_height,
+                1000 * block_height,
+                None,
+                platform_version,
+            )
+            .expect("expected to store address balances");
+    }
+
+    #[test]
+    fn test_no_balance_changes_returns_empty() {
+        let (platform, state, version) = setup_platform(None, Network::Testnet, None);
+
+        let request = GetRecentAddressBalanceChangesRequestV0 {
+            start_height: 0,
+            prove: false,
+        };
+
+        let result = platform
+            .query_recent_address_balance_changes_v0(request, &state, version)
+            .expect("expected query to succeed");
+
+        assert!(result.errors.is_empty(), "expected no errors");
+        let response = result.data.expect("expected response data");
+        match response.result {
+            Some(
+                get_recent_address_balance_changes_response_v0::Result::AddressBalanceUpdateEntries(
+                    entries,
+                ),
+            ) => {
+                assert!(
+                    entries.block_changes.is_empty(),
+                    "expected no block changes"
+                );
+            }
+            other => panic!(
+                "expected AddressBalanceUpdateEntries result, got {:?}",
+                other
+            ),
+        }
+        assert!(response.metadata.is_some());
+    }
+
+    #[test]
+    fn test_fetch_set_credits_operation() {
+        let (platform, state, version) = setup_platform(None, Network::Testnet, None);
+
+        let mut changes = BTreeMap::new();
+        changes.insert(ADDR1, CreditOperation::SetCredits(500_000));
+
+        store_balance_changes(&platform, 100, changes, version);
+
+        let request = GetRecentAddressBalanceChangesRequestV0 {
+            start_height: 0,
+            prove: false,
+        };
+
+        let result = platform
+            .query_recent_address_balance_changes_v0(request, &state, version)
+            .expect("expected query to succeed");
+
+        assert!(result.errors.is_empty(), "expected no errors");
+        let response = result.data.expect("expected response data");
+        match response.result {
+            Some(
+                get_recent_address_balance_changes_response_v0::Result::AddressBalanceUpdateEntries(
+                    entries,
+                ),
+            ) => {
+                assert_eq!(entries.block_changes.len(), 1);
+                let block_change = &entries.block_changes[0];
+                assert_eq!(block_change.block_height, 100);
+                assert_eq!(block_change.changes.len(), 1);
+                let change = &block_change.changes[0];
+                assert_eq!(change.address, ADDR1.to_bytes());
+                assert!(matches!(
+                    change.operation,
+                    Some(address_balance_change::Operation::SetBalance(500_000))
+                ));
+            }
+            other => panic!(
+                "expected AddressBalanceUpdateEntries result, got {:?}",
+                other
+            ),
+        }
+    }
+
+    #[test]
+    fn test_fetch_add_to_credits_operation() {
+        let (platform, state, version) = setup_platform(None, Network::Testnet, None);
+
+        let mut changes = BTreeMap::new();
+        changes.insert(ADDR2, CreditOperation::AddToCredits(250_000));
+
+        store_balance_changes(&platform, 200, changes, version);
+
+        let request = GetRecentAddressBalanceChangesRequestV0 {
+            start_height: 0,
+            prove: false,
+        };
+
+        let result = platform
+            .query_recent_address_balance_changes_v0(request, &state, version)
+            .expect("expected query to succeed");
+
+        assert!(result.errors.is_empty(), "expected no errors");
+        let response = result.data.expect("expected response data");
+        match response.result {
+            Some(
+                get_recent_address_balance_changes_response_v0::Result::AddressBalanceUpdateEntries(
+                    entries,
+                ),
+            ) => {
+                assert_eq!(entries.block_changes.len(), 1);
+                let change = &entries.block_changes[0].changes[0];
+                assert_eq!(change.address, ADDR2.to_bytes());
+                assert!(matches!(
+                    change.operation,
+                    Some(address_balance_change::Operation::AddToBalance(250_000))
+                ));
+            }
+            other => panic!(
+                "expected AddressBalanceUpdateEntries result, got {:?}",
+                other
+            ),
+        }
+    }
+
+    #[test]
+    fn test_fetch_multiple_blocks() {
+        let (platform, state, version) = setup_platform(None, Network::Testnet, None);
+
+        // Store changes for two blocks
+        let mut changes1 = BTreeMap::new();
+        changes1.insert(ADDR1, CreditOperation::SetCredits(100_000));
+        store_balance_changes(&platform, 100, changes1, version);
+
+        let mut changes2 = BTreeMap::new();
+        changes2.insert(ADDR2, CreditOperation::AddToCredits(200_000));
+        store_balance_changes(&platform, 200, changes2, version);
+
+        let request = GetRecentAddressBalanceChangesRequestV0 {
+            start_height: 0,
+            prove: false,
+        };
+
+        let result = platform
+            .query_recent_address_balance_changes_v0(request, &state, version)
+            .expect("expected query to succeed");
+
+        assert!(result.errors.is_empty(), "expected no errors");
+        let response = result.data.expect("expected response data");
+        match response.result {
+            Some(
+                get_recent_address_balance_changes_response_v0::Result::AddressBalanceUpdateEntries(
+                    entries,
+                ),
+            ) => {
+                assert_eq!(entries.block_changes.len(), 2);
+                // Block changes should be ordered by block height
+                assert_eq!(entries.block_changes[0].block_height, 100);
+                assert_eq!(entries.block_changes[1].block_height, 200);
+            }
+            other => panic!(
+                "expected AddressBalanceUpdateEntries result, got {:?}",
+                other
+            ),
+        }
+    }
+
+    #[test]
+    fn test_fetch_with_start_height_filter() {
+        let (platform, state, version) = setup_platform(None, Network::Testnet, None);
+
+        let mut changes1 = BTreeMap::new();
+        changes1.insert(ADDR1, CreditOperation::SetCredits(100_000));
+        store_balance_changes(&platform, 100, changes1, version);
+
+        let mut changes2 = BTreeMap::new();
+        changes2.insert(ADDR2, CreditOperation::AddToCredits(200_000));
+        store_balance_changes(&platform, 200, changes2, version);
+
+        // Query starting from height 200 - should only get the second block
+        let request = GetRecentAddressBalanceChangesRequestV0 {
+            start_height: 200,
+            prove: false,
+        };
+
+        let result = platform
+            .query_recent_address_balance_changes_v0(request, &state, version)
+            .expect("expected query to succeed");
+
+        assert!(result.errors.is_empty(), "expected no errors");
+        let response = result.data.expect("expected response data");
+        match response.result {
+            Some(
+                get_recent_address_balance_changes_response_v0::Result::AddressBalanceUpdateEntries(
+                    entries,
+                ),
+            ) => {
+                assert_eq!(entries.block_changes.len(), 1);
+                assert_eq!(entries.block_changes[0].block_height, 200);
+            }
+            other => panic!(
+                "expected AddressBalanceUpdateEntries result, got {:?}",
+                other
+            ),
+        }
+    }
+
+    #[test]
+    fn test_prove_no_balance_changes() {
+        let (platform, state, version) = setup_platform(None, Network::Testnet, None);
+
+        let request = GetRecentAddressBalanceChangesRequestV0 {
+            start_height: 0,
+            prove: true,
+        };
+
+        let result = platform
+            .query_recent_address_balance_changes_v0(request, &state, version)
+            .expect("expected query to succeed");
+
+        assert!(result.errors.is_empty(), "expected no errors");
+        let response = result.data.expect("expected response data");
+        assert!(matches!(
+            response.result,
+            Some(get_recent_address_balance_changes_response_v0::Result::Proof(_))
+        ));
+        assert!(response.metadata.is_some());
+    }
+
+    #[test]
+    fn test_prove_with_balance_changes() {
+        let (platform, state, version) = setup_platform(None, Network::Testnet, None);
+
+        let mut changes = BTreeMap::new();
+        changes.insert(ADDR1, CreditOperation::SetCredits(500_000));
+        store_balance_changes(&platform, 100, changes, version);
+
+        let request = GetRecentAddressBalanceChangesRequestV0 {
+            start_height: 0,
+            prove: true,
+        };
+
+        let result = platform
+            .query_recent_address_balance_changes_v0(request, &state, version)
+            .expect("expected query to succeed");
+
+        assert!(result.errors.is_empty(), "expected no errors");
+        let response = result.data.expect("expected response data");
+        assert!(matches!(
+            response.result,
+            Some(get_recent_address_balance_changes_response_v0::Result::Proof(_))
+        ));
+        assert!(response.metadata.is_some());
+    }
+
+    #[test]
+    fn test_fetch_multiple_addresses_in_one_block() {
+        let (platform, state, version) = setup_platform(None, Network::Testnet, None);
+
+        let mut changes = BTreeMap::new();
+        changes.insert(ADDR1, CreditOperation::SetCredits(100_000));
+        changes.insert(ADDR2, CreditOperation::AddToCredits(200_000));
+        store_balance_changes(&platform, 100, changes, version);
+
+        let request = GetRecentAddressBalanceChangesRequestV0 {
+            start_height: 0,
+            prove: false,
+        };
+
+        let result = platform
+            .query_recent_address_balance_changes_v0(request, &state, version)
+            .expect("expected query to succeed");
+
+        assert!(result.errors.is_empty(), "expected no errors");
+        let response = result.data.expect("expected response data");
+        match response.result {
+            Some(
+                get_recent_address_balance_changes_response_v0::Result::AddressBalanceUpdateEntries(
+                    entries,
+                ),
+            ) => {
+                assert_eq!(entries.block_changes.len(), 1);
+                assert_eq!(entries.block_changes[0].changes.len(), 2);
+            }
+            other => panic!(
+                "expected AddressBalanceUpdateEntries result, got {:?}",
+                other
+            ),
+        }
+    }
+}

--- a/packages/rs-drive-abci/src/query/address_funds/recent_compacted_address_balance_changes/v0/mod.rs
+++ b/packages/rs-drive-abci/src/query/address_funds/recent_compacted_address_balance_changes/v0/mod.rs
@@ -118,3 +118,309 @@ impl<C> Platform<C> {
         Ok(QueryValidationResult::new_with_data(response))
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::query::tests::setup_platform;
+    use dpp::address_funds::PlatformAddress;
+    use dpp::balances::credits::CreditOperation;
+    use dpp::dashcore::Network;
+    use std::collections::BTreeMap;
+
+    const ADDR1: PlatformAddress = PlatformAddress::P2pkh([10; 20]);
+    const ADDR2: PlatformAddress = PlatformAddress::P2sh([11; 20]);
+
+    fn store_balance_changes(
+        platform: &Platform<crate::rpc::core::MockCoreRPCLike>,
+        block_height: u64,
+        changes: BTreeMap<PlatformAddress, CreditOperation>,
+        platform_version: &PlatformVersion,
+    ) {
+        platform
+            .drive
+            .store_address_balances_for_block(
+                &changes,
+                block_height,
+                1000 * block_height,
+                None,
+                platform_version,
+            )
+            .expect("expected to store address balances");
+    }
+
+    #[test]
+    fn test_no_compacted_changes_returns_empty() {
+        let (platform, state, version) = setup_platform(None, Network::Testnet, None);
+
+        let request = GetRecentCompactedAddressBalanceChangesRequestV0 {
+            start_block_height: 0,
+            prove: false,
+        };
+
+        let result = platform
+            .query_recent_compacted_address_balance_changes_v0(request, &state, version)
+            .expect("expected query to succeed");
+
+        assert!(result.errors.is_empty(), "expected no errors");
+        let response = result.data.expect("expected response data");
+        match response.result {
+            Some(get_recent_compacted_address_balance_changes_response_v0::Result::CompactedAddressBalanceUpdateEntries(entries)) => {
+                assert!(
+                    entries.compacted_block_changes.is_empty(),
+                    "expected no compacted block changes"
+                );
+            }
+            other => panic!("expected CompactedAddressBalanceUpdateEntries result, got {:?}", other),
+        }
+        assert!(response.metadata.is_some());
+    }
+
+    #[test]
+    fn test_prove_no_compacted_changes() {
+        let (platform, state, version) = setup_platform(None, Network::Testnet, None);
+
+        let request = GetRecentCompactedAddressBalanceChangesRequestV0 {
+            start_block_height: 0,
+            prove: true,
+        };
+
+        let result = platform
+            .query_recent_compacted_address_balance_changes_v0(request, &state, version)
+            .expect("expected query to succeed");
+
+        assert!(result.errors.is_empty(), "expected no errors");
+        let response = result.data.expect("expected response data");
+        assert!(matches!(
+            response.result,
+            Some(get_recent_compacted_address_balance_changes_response_v0::Result::Proof(_))
+        ));
+        assert!(response.metadata.is_some());
+    }
+
+    #[test]
+    fn test_fetch_compacted_after_storing_enough_blocks_for_compaction() {
+        // Store many small blocks so that compaction gets triggered by the
+        // store_address_balances_for_block logic. This tests the full pipeline:
+        // store -> compact -> fetch compacted.
+        let (platform, state, version) = setup_platform(None, Network::Testnet, None);
+
+        // Store many individual block changes to trigger compaction
+        for i in 1..=200 {
+            let mut changes = BTreeMap::new();
+            changes.insert(ADDR1, CreditOperation::SetCredits(1000 * i));
+            store_balance_changes(&platform, i, changes, version);
+        }
+
+        let request = GetRecentCompactedAddressBalanceChangesRequestV0 {
+            start_block_height: 0,
+            prove: false,
+        };
+
+        let result = platform
+            .query_recent_compacted_address_balance_changes_v0(request, &state, version)
+            .expect("expected query to succeed");
+
+        assert!(result.errors.is_empty(), "expected no errors");
+        let response = result.data.expect("expected response data");
+        match response.result {
+            Some(get_recent_compacted_address_balance_changes_response_v0::Result::CompactedAddressBalanceUpdateEntries(entries)) => {
+                // After 200 blocks, compaction should have occurred at least once
+                // The exact number depends on compaction thresholds
+                assert!(
+                    !entries.compacted_block_changes.is_empty(),
+                    "expected compacted block changes after many blocks stored"
+                );
+
+                // Verify structure of compacted entries
+                for compacted in &entries.compacted_block_changes {
+                    assert!(
+                        compacted.start_block_height <= compacted.end_block_height,
+                        "start_block should be <= end_block"
+                    );
+                    assert!(
+                        !compacted.changes.is_empty(),
+                        "each compacted entry should have changes"
+                    );
+                    for change in &compacted.changes {
+                        assert!(
+                            change.operation.is_some(),
+                            "each change should have an operation"
+                        );
+                    }
+                }
+            }
+            other => panic!("expected CompactedAddressBalanceUpdateEntries result, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_prove_compacted_after_storing_blocks() {
+        let (platform, state, version) = setup_platform(None, Network::Testnet, None);
+
+        // Store enough blocks to trigger compaction
+        for i in 1..=200 {
+            let mut changes = BTreeMap::new();
+            changes.insert(ADDR1, CreditOperation::SetCredits(1000 * i));
+            store_balance_changes(&platform, i, changes, version);
+        }
+
+        let request = GetRecentCompactedAddressBalanceChangesRequestV0 {
+            start_block_height: 0,
+            prove: true,
+        };
+
+        let result = platform
+            .query_recent_compacted_address_balance_changes_v0(request, &state, version)
+            .expect("expected query to succeed");
+
+        assert!(result.errors.is_empty(), "expected no errors");
+        let response = result.data.expect("expected response data");
+        assert!(matches!(
+            response.result,
+            Some(get_recent_compacted_address_balance_changes_response_v0::Result::Proof(_))
+        ));
+        assert!(response.metadata.is_some());
+    }
+
+    #[test]
+    fn test_fetch_with_start_height_filter() {
+        let (platform, state, version) = setup_platform(None, Network::Testnet, None);
+
+        // Store enough blocks to trigger compaction
+        for i in 1..=200 {
+            let mut changes = BTreeMap::new();
+            changes.insert(ADDR1, CreditOperation::SetCredits(1000 * i));
+            store_balance_changes(&platform, i, changes, version);
+        }
+
+        // Query from a high start block height
+        let request = GetRecentCompactedAddressBalanceChangesRequestV0 {
+            start_block_height: 10000,
+            prove: false,
+        };
+
+        let result = platform
+            .query_recent_compacted_address_balance_changes_v0(request, &state, version)
+            .expect("expected query to succeed");
+
+        assert!(result.errors.is_empty(), "expected no errors");
+        let response = result.data.expect("expected response data");
+        match response.result {
+            Some(get_recent_compacted_address_balance_changes_response_v0::Result::CompactedAddressBalanceUpdateEntries(entries)) => {
+                // No compacted entries should exist starting from height 10000
+                assert!(
+                    entries.compacted_block_changes.is_empty(),
+                    "expected no compacted changes for future start height"
+                );
+            }
+            other => panic!("expected CompactedAddressBalanceUpdateEntries result, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_fetch_multiple_addresses_in_compacted() {
+        let (platform, state, version) = setup_platform(None, Network::Testnet, None);
+
+        // Store blocks with multiple addresses
+        for i in 1..=200 {
+            let mut changes = BTreeMap::new();
+            changes.insert(ADDR1, CreditOperation::SetCredits(1000 * i));
+            changes.insert(ADDR2, CreditOperation::AddToCredits(500 * i));
+            store_balance_changes(&platform, i, changes, version);
+        }
+
+        let request = GetRecentCompactedAddressBalanceChangesRequestV0 {
+            start_block_height: 0,
+            prove: false,
+        };
+
+        let result = platform
+            .query_recent_compacted_address_balance_changes_v0(request, &state, version)
+            .expect("expected query to succeed");
+
+        assert!(result.errors.is_empty(), "expected no errors");
+        let response = result.data.expect("expected response data");
+        match response.result {
+            Some(get_recent_compacted_address_balance_changes_response_v0::Result::CompactedAddressBalanceUpdateEntries(entries)) => {
+                assert!(
+                    !entries.compacted_block_changes.is_empty(),
+                    "expected compacted entries"
+                );
+                // Each compacted entry should have changes for both addresses
+                for compacted in &entries.compacted_block_changes {
+                    assert!(
+                        compacted.changes.len() >= 1,
+                        "expected at least one address change per compacted entry"
+                    );
+                }
+            }
+            other => panic!("expected CompactedAddressBalanceUpdateEntries result, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_compacted_add_to_credits_operations_branch() {
+        // This test specifically exercises the AddToCreditsOperations branch
+        // by only storing AddToCredits operations so compaction produces
+        // BlockAwareCreditOperation::AddToCreditsOperations.
+        let (platform, state, version) = setup_platform(None, Network::Testnet, None);
+
+        // Store only AddToCredits operations for many blocks
+        for i in 1..=200 {
+            let mut changes = BTreeMap::new();
+            changes.insert(ADDR1, CreditOperation::AddToCredits(100));
+            store_balance_changes(&platform, i, changes, version);
+        }
+
+        let request = GetRecentCompactedAddressBalanceChangesRequestV0 {
+            start_block_height: 0,
+            prove: false,
+        };
+
+        let result = platform
+            .query_recent_compacted_address_balance_changes_v0(request, &state, version)
+            .expect("expected query to succeed");
+
+        assert!(result.errors.is_empty(), "expected no errors");
+        let response = result.data.expect("expected response data");
+        match response.result {
+            Some(get_recent_compacted_address_balance_changes_response_v0::Result::CompactedAddressBalanceUpdateEntries(entries)) => {
+                assert!(
+                    !entries.compacted_block_changes.is_empty(),
+                    "expected compacted block changes"
+                );
+
+                // Look for AddToCreditsOperations entries
+                let mut found_add_to_credits = false;
+                for compacted in &entries.compacted_block_changes {
+                    for change in &compacted.changes {
+                        match &change.operation {
+                            Some(compacted_address_balance_change::Operation::AddToCreditsOperations(ops)) => {
+                                found_add_to_credits = true;
+                                assert!(
+                                    !ops.entries.is_empty(),
+                                    "AddToCreditsOperations should have entries"
+                                );
+                                // Each entry should have a block height and credits
+                                for entry in &ops.entries {
+                                    assert!(entry.credits > 0, "credits should be positive");
+                                }
+                            }
+                            Some(compacted_address_balance_change::Operation::SetCredits(_)) => {
+                                // SetCredits can also appear if the very last block
+                                // before compaction was not yet compacted
+                            }
+                            None => panic!("expected operation to be present"),
+                        }
+                    }
+                }
+                assert!(
+                    found_add_to_credits,
+                    "expected at least one AddToCreditsOperations entry in compacted results"
+                );
+            }
+            other => panic!("expected CompactedAddressBalanceUpdateEntries result, got {:?}", other),
+        }
+    }
+}

--- a/packages/rs-drive-abci/src/query/address_funds/recent_compacted_address_balance_changes/v0/mod.rs
+++ b/packages/rs-drive-abci/src/query/address_funds/recent_compacted_address_balance_changes/v0/mod.rs
@@ -347,13 +347,20 @@ mod tests {
                     !entries.compacted_block_changes.is_empty(),
                     "expected compacted entries"
                 );
-                // Each compacted entry should have changes for both addresses
-                for compacted in &entries.compacted_block_changes {
-                    assert!(
-                        compacted.changes.len() >= 1,
-                        "expected at least one address change per compacted entry"
-                    );
-                }
+                // Verify that both addresses appear across the compacted entries
+                let all_addresses: std::collections::BTreeSet<Vec<u8>> = entries
+                    .compacted_block_changes
+                    .iter()
+                    .flat_map(|c| c.changes.iter().map(|ch| ch.address.clone()))
+                    .collect();
+                assert!(
+                    all_addresses.contains(&ADDR1.to_bytes()),
+                    "missing ADDR1 in compacted changes"
+                );
+                assert!(
+                    all_addresses.contains(&ADDR2.to_bytes()),
+                    "missing ADDR2 in compacted changes"
+                );
             }
             other => panic!("expected CompactedAddressBalanceUpdateEntries result, got {:?}", other),
         }


### PR DESCRIPTION
## Issue being fixed or feature implemented

Adding comprehensive test coverage for the `address_funds` query modules in `rs-drive-abci` which were at 0% coverage.

## What was done?

Added 34 tests across all 6 `address_funds` v0 query modules:

- **`address_info/v0`** (6 tests): Invalid address bytes, empty address, not found (none balance), fetch with balance, proof with balance, proof absence
- **`addresses_branch_state/v0`** (4 tests): No checkpoint error, invalid depth, max depth exceeded, successful proof with checkpoint
- **`addresses_infos/v0`** (7 tests): Invalid address, empty list, multiple existing, with unknown address, proof multiple, proof empty list (error case)
- **`addresses_trunk_state/v0`** (3 tests): No checkpoint validation error, no checkpoint with genesis state, successful proof with checkpoint
- **`recent_address_balance_changes/v0`** (8 tests): Empty results, SetCredits operation, AddToCredits operation, multiple blocks, start height filter, prove empty, prove with data, multiple addresses per block
- **`recent_compacted_address_balance_changes/v0`** (7 tests): Empty results, prove empty, after compaction trigger, prove after compaction, start height filter, multiple addresses, AddToCreditsOperations branch coverage

Tests follow existing patterns from `identity_based_queries` and `prefunded_specialized_balances` modules, using `setup_platform()` and Drive operations for state setup. Checkpoint-dependent tests (trunk/branch state) create real GroveDB checkpoints.

## How Has This Been Tested?

All 34 tests pass locally:
```
cargo test --package drive-abci -- query::address_funds
test result: ok. 34 passed; 0 failed; 0 ignored
```

## Breaking Changes

None. This PR only adds tests.

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [x] I have made corresponding changes to the documentation if needed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test suites for address query features covering invalid inputs, error handling, checkpointed vs non-checkpointed queries, proof/no-proof paths, balance tracking across blocks, recent and compacted change aggregation, multi-address scenarios, start-height filtering, and response metadata/shape validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->