### PR TITLE
ci: kill stale gpg-agent and locks before Codecov upload on Mac runners

### DIFF
--- a/.github/workflows/tests-rs-workspace.yml
+++ b/.github/workflows/tests-rs-workspace.yml
@@ -163,6 +163,10 @@ jobs:
           CARGO_PROFILE_DEV_DEBUG: "0"
           CARGO_PROFILE_DEV_CODEGEN_UNITS: "256"
 
+      - name: Reset GPG agent (fix stale keyboxd lock on self-hosted runners)
+        if: always()
+        run: gpgconf --kill all 2>/dev/null || true
+
       - name: Upload coverage
         if: always()
         uses: codecov/codecov-action@v5

--- a/.github/workflows/tests-rs-workspace.yml
+++ b/.github/workflows/tests-rs-workspace.yml
@@ -163,9 +163,12 @@ jobs:
           CARGO_PROFILE_DEV_DEBUG: "0"
           CARGO_PROFILE_DEV_CODEGEN_UNITS: "256"
 
-      - name: Reset GPG agent (fix stale keyboxd lock on self-hosted runners)
+      - name: Reset GPG state (fix stale keyboxd locks on self-hosted runners)
         if: always()
-        run: gpgconf --kill all 2>/dev/null || true
+        run: |
+          gpgconf --kill all 2>/dev/null || true
+          rm -rf ~/.gnupg/public-keys.d/*.lock 2>/dev/null || true
+          rm -rf ~/.gnupg/.#* 2>/dev/null || true
 
       - name: Upload coverage
         if: always()


### PR DESCRIPTION
## Summary
- Add `gpgconf --kill all` before the Codecov upload step on Mac runners
- Self-hosted runners accumulate stale `keyboxd` locks between runs, causing GPG signature verification to hang with `database_open waiting for lock` errors

## Test plan
- [ ] Verify Codecov upload succeeds on Mac runner without GPG lock errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)