### PR TITLE
test(drive-abci): improve abci module test coverage

### DIFF
--- a/packages/rs-drive-abci/src/abci/app/check_tx.rs
+++ b/packages/rs-drive-abci/src/abci/app/check_tx.rs
@@ -97,3 +97,54 @@ where
 pub fn error_into_status(error: Error) -> tonic::Status {
     tonic::Status::internal(error.to_string())
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::error::execution::ExecutionError;
+    use crate::rpc::core::MockCoreRPCLike;
+
+    #[test]
+    fn error_into_status_produces_internal_status() {
+        let error = Error::Execution(ExecutionError::CorruptedCodeExecution("test error message"));
+        let status = error_into_status(error);
+
+        assert_eq!(status.code(), tonic::Code::Internal);
+        assert!(status.message().contains("test error message"));
+    }
+
+    #[test]
+    fn error_into_status_preserves_error_message() {
+        let error = Error::Execution(ExecutionError::NotInTransaction("no active transaction"));
+        let status = error_into_status(error);
+
+        assert!(status.message().contains("no active transaction"));
+    }
+
+    #[test]
+    fn check_tx_abci_application_debug_format() {
+        // Verify the Debug implementation for CheckTxAbciApplication produces expected output
+        let platform =
+            crate::test::helpers::setup::TestPlatformBuilder::new().build_with_mock_rpc();
+
+        let core_rpc = MockCoreRPCLike::new();
+
+        let app = CheckTxAbciApplication::new(Arc::new(platform.platform), Arc::new(core_rpc));
+
+        let debug_str = format!("{:?}", app);
+        assert_eq!(debug_str, "<CheckTxAbciApplication>");
+    }
+
+    #[test]
+    fn check_tx_abci_application_platform_returns_platform() {
+        let platform =
+            crate::test::helpers::setup::TestPlatformBuilder::new().build_with_mock_rpc();
+
+        let core_rpc = MockCoreRPCLike::new();
+
+        let app = CheckTxAbciApplication::new(Arc::new(platform.platform), Arc::new(core_rpc));
+
+        // Just verify we can call platform() without panicking
+        let _platform_ref = app.platform();
+    }
+}

--- a/packages/rs-drive-abci/src/abci/app/consensus.rs
+++ b/packages/rs-drive-abci/src/abci/app/consensus.rs
@@ -83,6 +83,79 @@ impl<C> Debug for ConsensusAbciApplication<'_, C> {
     }
 }
 
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::rpc::core::MockCoreRPCLike;
+
+    #[test]
+    fn consensus_abci_application_debug_format() {
+        let platform =
+            crate::test::helpers::setup::TestPlatformBuilder::new().build_with_mock_rpc();
+
+        let app = ConsensusAbciApplication::new(&platform.platform);
+
+        let debug_str = format!("{:?}", app);
+        assert_eq!(debug_str, "<ConsensusAbciApplication>");
+    }
+
+    #[test]
+    fn consensus_abci_application_platform_returns_reference() {
+        let platform =
+            crate::test::helpers::setup::TestPlatformBuilder::new().build_with_mock_rpc();
+
+        let app = ConsensusAbciApplication::<MockCoreRPCLike>::new(&platform.platform);
+        let _platform_ref = app.platform();
+    }
+
+    #[test]
+    fn consensus_abci_application_block_execution_context_is_initially_none() {
+        let platform =
+            crate::test::helpers::setup::TestPlatformBuilder::new().build_with_mock_rpc();
+
+        let app = ConsensusAbciApplication::<MockCoreRPCLike>::new(&platform.platform);
+
+        let ctx = app.block_execution_context().read().unwrap();
+        assert!(ctx.is_none());
+    }
+
+    #[test]
+    fn consensus_abci_application_transaction_is_initially_none() {
+        let platform =
+            crate::test::helpers::setup::TestPlatformBuilder::new().build_with_mock_rpc();
+
+        let app = ConsensusAbciApplication::<MockCoreRPCLike>::new(&platform.platform);
+
+        let tx = app.transaction().read().unwrap();
+        assert!(tx.is_none());
+    }
+
+    #[test]
+    fn consensus_abci_application_start_transaction_creates_transaction() {
+        let platform =
+            crate::test::helpers::setup::TestPlatformBuilder::new().build_with_mock_rpc();
+
+        let app = ConsensusAbciApplication::<MockCoreRPCLike>::new(&platform.platform);
+
+        app.start_transaction();
+
+        let tx = app.transaction().read().unwrap();
+        assert!(tx.is_some());
+    }
+
+    #[test]
+    fn consensus_abci_application_commit_without_transaction_fails() {
+        let platform =
+            crate::test::helpers::setup::TestPlatformBuilder::new().build_with_mock_rpc();
+
+        let app = ConsensusAbciApplication::<MockCoreRPCLike>::new(&platform.platform);
+        let platform_version = PlatformVersion::latest();
+
+        let result = app.commit_transaction(platform_version);
+        assert!(result.is_err());
+    }
+}
+
 impl<C> tenderdash_abci::Application for ConsensusAbciApplication<'_, C>
 where
     C: CoreRPCLike,

--- a/packages/rs-drive-abci/src/abci/app/execution_result.rs
+++ b/packages/rs-drive-abci/src/abci/app/execution_result.rs
@@ -49,3 +49,139 @@ impl TryIntoPlatformVersioned<Option<ExecTxResult>> for StateTransitionExecution
         Ok(response)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::platform_types::state_transitions_processing_result::NotExecutedReason;
+    use dpp::consensus::ConsensusError;
+    use dpp::fee::fee_result::FeeResult;
+    use std::collections::BTreeMap;
+
+    #[test]
+    fn successful_execution_produces_result_with_zero_code() {
+        let platform_version = PlatformVersion::latest();
+
+        let fee_result = FeeResult {
+            storage_fee: 100,
+            processing_fee: 50,
+            ..Default::default()
+        };
+
+        let execution_result = StateTransitionExecutionResult::SuccessfulExecution {
+            estimated_fees: None,
+            fee_result: fee_result.clone(),
+            address_balance_changes: BTreeMap::new(),
+        };
+
+        let result: Option<ExecTxResult> = execution_result
+            .try_into_platform_versioned(platform_version)
+            .expect("conversion should succeed");
+
+        let tx_result = result.expect("should produce Some result");
+        assert_eq!(tx_result.code, 0);
+        assert_eq!(
+            tx_result.gas_used,
+            fee_result.total_base_fee() as SignedCredits
+        );
+    }
+
+    #[test]
+    fn unpaid_consensus_error_produces_result_with_error_code() {
+        let platform_version = PlatformVersion::latest();
+
+        let consensus_error = ConsensusError::DefaultError;
+        let execution_result =
+            StateTransitionExecutionResult::UnpaidConsensusError(consensus_error);
+
+        let result: Option<ExecTxResult> = execution_result
+            .try_into_platform_versioned(platform_version)
+            .expect("conversion should succeed");
+
+        let tx_result = result.expect("should produce Some result");
+        assert_ne!(tx_result.code, 0);
+        assert_eq!(tx_result.gas_used, 0);
+        assert!(!tx_result.info.is_empty());
+    }
+
+    #[test]
+    fn paid_consensus_error_produces_result_with_fees_and_error_code() {
+        let platform_version = PlatformVersion::latest();
+
+        let consensus_error = ConsensusError::DefaultError;
+        let fee_result = FeeResult {
+            storage_fee: 0,
+            processing_fee: 200,
+            ..Default::default()
+        };
+
+        let execution_result = StateTransitionExecutionResult::PaidConsensusError {
+            error: consensus_error,
+            actual_fees: fee_result.clone(),
+        };
+
+        let result: Option<ExecTxResult> = execution_result
+            .try_into_platform_versioned(platform_version)
+            .expect("conversion should succeed");
+
+        let tx_result = result.expect("should produce Some result");
+        assert_ne!(tx_result.code, 0);
+        assert_eq!(
+            tx_result.gas_used,
+            fee_result.total_base_fee() as SignedCredits
+        );
+        assert!(!tx_result.info.is_empty());
+    }
+
+    #[test]
+    fn internal_error_produces_result_with_internal_code() {
+        let platform_version = PlatformVersion::latest();
+
+        let execution_result =
+            StateTransitionExecutionResult::InternalError("something broke".to_string());
+
+        let result: Option<ExecTxResult> = execution_result
+            .try_into_platform_versioned(platform_version)
+            .expect("conversion should succeed");
+
+        let tx_result = result.expect("should produce Some result");
+        // Internal error code is 13
+        assert_eq!(tx_result.code, 13);
+        assert!(tx_result.info.is_empty());
+    }
+
+    #[test]
+    fn not_executed_produces_none() {
+        let platform_version = PlatformVersion::latest();
+
+        let execution_result =
+            StateTransitionExecutionResult::NotExecuted(NotExecutedReason::ProposerRanOutOfTime);
+
+        let result: Option<ExecTxResult> = execution_result
+            .try_into_platform_versioned(platform_version)
+            .expect("conversion should succeed");
+
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn successful_execution_with_zero_fees() {
+        let platform_version = PlatformVersion::latest();
+
+        let fee_result = FeeResult::default();
+
+        let execution_result = StateTransitionExecutionResult::SuccessfulExecution {
+            estimated_fees: None,
+            fee_result,
+            address_balance_changes: BTreeMap::new(),
+        };
+
+        let result: Option<ExecTxResult> = execution_result
+            .try_into_platform_versioned(platform_version)
+            .expect("conversion should succeed");
+
+        let tx_result = result.expect("should produce Some result");
+        assert_eq!(tx_result.code, 0);
+        assert_eq!(tx_result.gas_used, 0);
+    }
+}

--- a/packages/rs-drive-abci/src/abci/app/full.rs
+++ b/packages/rs-drive-abci/src/abci/app/full.rs
@@ -83,6 +83,97 @@ impl<C> Debug for FullAbciApplication<'_, C> {
     }
 }
 
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::rpc::core::MockCoreRPCLike;
+
+    #[test]
+    fn full_abci_application_debug_format() {
+        let platform =
+            crate::test::helpers::setup::TestPlatformBuilder::new().build_with_mock_rpc();
+
+        let app = FullAbciApplication::new(&platform.platform);
+
+        let debug_str = format!("{:?}", app);
+        assert_eq!(debug_str, "<FullAbciApplication>");
+    }
+
+    #[test]
+    fn full_abci_application_platform_returns_reference() {
+        let platform =
+            crate::test::helpers::setup::TestPlatformBuilder::new().build_with_mock_rpc();
+
+        let app = FullAbciApplication::<MockCoreRPCLike>::new(&platform.platform);
+        let _platform_ref = app.platform();
+    }
+
+    #[test]
+    fn full_abci_application_block_execution_context_is_initially_none() {
+        let platform =
+            crate::test::helpers::setup::TestPlatformBuilder::new().build_with_mock_rpc();
+
+        let app = FullAbciApplication::<MockCoreRPCLike>::new(&platform.platform);
+
+        let ctx = app.block_execution_context().read().unwrap();
+        assert!(ctx.is_none());
+    }
+
+    #[test]
+    fn full_abci_application_transaction_is_initially_none() {
+        let platform =
+            crate::test::helpers::setup::TestPlatformBuilder::new().build_with_mock_rpc();
+
+        let app = FullAbciApplication::<MockCoreRPCLike>::new(&platform.platform);
+
+        let tx = app.transaction().read().unwrap();
+        assert!(tx.is_none());
+    }
+
+    #[test]
+    fn full_abci_application_start_transaction_creates_transaction() {
+        let platform =
+            crate::test::helpers::setup::TestPlatformBuilder::new().build_with_mock_rpc();
+
+        let app = FullAbciApplication::<MockCoreRPCLike>::new(&platform.platform);
+
+        app.start_transaction();
+
+        let tx = app.transaction().read().unwrap();
+        assert!(tx.is_some());
+    }
+
+    #[test]
+    fn full_abci_application_commit_without_transaction_fails() {
+        let platform =
+            crate::test::helpers::setup::TestPlatformBuilder::new().build_with_mock_rpc();
+
+        let app = FullAbciApplication::<MockCoreRPCLike>::new(&platform.platform);
+        let platform_version = PlatformVersion::latest();
+
+        let result = app.commit_transaction(platform_version);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn full_abci_application_start_and_commit_transaction_succeeds() {
+        let platform =
+            crate::test::helpers::setup::TestPlatformBuilder::new().build_with_mock_rpc();
+
+        let app = FullAbciApplication::<MockCoreRPCLike>::new(&platform.platform);
+        let platform_version = PlatformVersion::latest();
+
+        app.start_transaction();
+
+        let result = app.commit_transaction(platform_version);
+        assert!(result.is_ok());
+
+        // After commit, transaction should be consumed
+        let tx = app.transaction().read().unwrap();
+        assert!(tx.is_none());
+    }
+}
+
 impl<C> tenderdash_abci::Application for FullAbciApplication<'_, C>
 where
     C: CoreRPCLike,

--- a/packages/rs-drive-abci/src/abci/config.rs
+++ b/packages/rs-drive-abci/src/abci/config.rs
@@ -61,3 +61,137 @@ impl Default for AbciConfig {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_genesis_height_returns_one() {
+        assert_eq!(AbciConfig::default_genesis_height(), 1);
+    }
+
+    #[test]
+    fn default_genesis_core_height_returns_one() {
+        assert_eq!(AbciConfig::default_genesis_core_height(), 1);
+    }
+
+    #[test]
+    fn default_config_has_expected_values() {
+        let config = AbciConfig::default();
+        assert_eq!(config.consensus_bind_address, "tcp://127.0.0.1:1234");
+        assert_eq!(config.genesis_height, 1);
+        assert_eq!(config.genesis_core_height, 1);
+        assert_eq!(config.chain_id, "chain_id");
+        assert!(config.log.is_empty());
+        assert!(config.proposer_tx_processing_time_limit.is_none());
+    }
+
+    #[test]
+    fn config_serializes_and_deserializes_roundtrip() {
+        // proposer_tx_processing_time_limit uses a custom string-only deserializer,
+        // so roundtrip only works when the field is None (serializes as null)
+        let config = AbciConfig {
+            consensus_bind_address: "tcp://0.0.0.0:5678".to_string(),
+            genesis_height: 42,
+            genesis_core_height: 10,
+            chain_id: "test-chain".to_string(),
+            log: Default::default(),
+            proposer_tx_processing_time_limit: None,
+        };
+
+        let serialized = serde_json::to_string(&config).expect("should serialize");
+        let deserialized: AbciConfig =
+            serde_json::from_str(&serialized).expect("should deserialize");
+
+        assert_eq!(deserialized.consensus_bind_address, "tcp://0.0.0.0:5678");
+        assert_eq!(deserialized.genesis_height, 42);
+        assert_eq!(deserialized.genesis_core_height, 10);
+        assert_eq!(deserialized.chain_id, "test-chain");
+        assert!(deserialized.proposer_tx_processing_time_limit.is_none());
+    }
+
+    #[test]
+    fn config_deserialization_uses_defaults_for_missing_fields() {
+        // Only the renamed field is mandatory; all others have defaults
+        let json = r#"{"abci_consensus_bind_address": "tcp://1.2.3.4:9999"}"#;
+        let config: AbciConfig = serde_json::from_str(json).expect("should deserialize");
+
+        assert_eq!(config.consensus_bind_address, "tcp://1.2.3.4:9999");
+        assert_eq!(config.genesis_height, 1);
+        assert_eq!(config.genesis_core_height, 1);
+        assert_eq!(config.chain_id, "");
+        assert!(config.proposer_tx_processing_time_limit.is_none());
+    }
+
+    #[test]
+    fn config_serialization_uses_renamed_field() {
+        let config = AbciConfig::default();
+        let serialized = serde_json::to_value(&config).expect("should serialize");
+
+        // The field should be serialized as "abci_consensus_bind_address"
+        assert!(serialized.get("abci_consensus_bind_address").is_some());
+        assert!(serialized.get("consensus_bind_address").is_none());
+    }
+
+    #[test]
+    fn config_clone_produces_equal_values() {
+        let config = AbciConfig {
+            consensus_bind_address: "unix:///tmp/test.sock".to_string(),
+            genesis_height: 100,
+            genesis_core_height: 50,
+            chain_id: "clone-test".to_string(),
+            log: Default::default(),
+            proposer_tx_processing_time_limit: Some(1000),
+        };
+
+        let cloned = config.clone();
+        assert_eq!(cloned.consensus_bind_address, config.consensus_bind_address);
+        assert_eq!(cloned.genesis_height, config.genesis_height);
+        assert_eq!(cloned.genesis_core_height, config.genesis_core_height);
+        assert_eq!(cloned.chain_id, config.chain_id);
+        assert_eq!(
+            cloned.proposer_tx_processing_time_limit,
+            config.proposer_tx_processing_time_limit
+        );
+    }
+
+    #[test]
+    fn config_debug_format_is_not_empty() {
+        let config = AbciConfig::default();
+        let debug_str = format!("{:?}", config);
+        assert!(!debug_str.is_empty());
+        assert!(debug_str.contains("AbciConfig"));
+    }
+
+    #[test]
+    fn config_deserializes_proposer_tx_processing_time_limit_from_string() {
+        // The from_opt_str_or_number deserializer should accept string values
+        let json = r#"{"abci_consensus_bind_address": "tcp://x:1", "proposer_tx_processing_time_limit": "250"}"#;
+        let config: AbciConfig = serde_json::from_str(json).expect("should deserialize");
+        assert_eq!(config.proposer_tx_processing_time_limit, Some(250));
+    }
+
+    #[test]
+    fn config_rejects_raw_number_for_proposer_tx_processing_time_limit() {
+        // The custom from_opt_str_or_number deserializer only accepts strings,
+        // not raw JSON numbers
+        let json = r#"{"abci_consensus_bind_address": "tcp://x:1", "proposer_tx_processing_time_limit": 750}"#;
+        let result = serde_json::from_str::<AbciConfig>(json);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn config_deserializes_null_proposer_tx_processing_time_limit() {
+        let json = r#"{"abci_consensus_bind_address": "tcp://x:1", "proposer_tx_processing_time_limit": null}"#;
+        let config: AbciConfig = serde_json::from_str(json).expect("should deserialize");
+        assert!(config.proposer_tx_processing_time_limit.is_none());
+    }
+
+    #[test]
+    fn config_deserializes_empty_string_as_none_for_proposer_tx_processing_time_limit() {
+        let json = r#"{"abci_consensus_bind_address": "tcp://x:1", "proposer_tx_processing_time_limit": ""}"#;
+        let config: AbciConfig = serde_json::from_str(json).expect("should deserialize");
+        assert!(config.proposer_tx_processing_time_limit.is_none());
+    }
+}

--- a/packages/rs-drive-abci/src/abci/error.rs
+++ b/packages/rs-drive-abci/src/abci/error.rs
@@ -91,3 +91,170 @@ pub enum AbciError {
     #[error("invalid state transition error: {0}")]
     InvalidStateTransition(#[from] ConsensusError),
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn invalid_state_display() {
+        let err = AbciError::InvalidState("bad state".to_string());
+        assert_eq!(err.to_string(), "invalid state: bad state");
+    }
+
+    #[test]
+    fn request_for_wrong_block_received_display() {
+        let err = AbciError::RequestForWrongBlockReceived("wrong block".to_string());
+        assert_eq!(
+            err.to_string(),
+            "request does not match current block: wrong block"
+        );
+    }
+
+    #[test]
+    fn vote_extension_mismatch_received_display() {
+        let err = AbciError::VoteExtensionMismatchReceived {
+            got: vec![],
+            expected: vec![],
+        };
+        assert_eq!(
+            err.to_string(),
+            "votes extensions mismatch: got [], expected []"
+        );
+    }
+
+    #[test]
+    fn vote_extensions_signature_invalid_display() {
+        let err = AbciError::VoteExtensionsSignatureInvalid;
+        assert_eq!(
+            err.to_string(),
+            "one of votes extension signatures is invalid"
+        );
+    }
+
+    #[test]
+    fn invalid_vote_extensions_verification_display() {
+        let err = AbciError::InvalidVoteExtensionsVerification;
+        assert_eq!(err.to_string(), "invalid votes extensions verification");
+    }
+
+    #[test]
+    fn withdrawal_transactions_db_load_error_display() {
+        let err = AbciError::WithdrawalTransactionsDBLoadError("db fail".to_string());
+        assert_eq!(
+            err.to_string(),
+            "cannot load withdrawal transactions: db fail"
+        );
+    }
+
+    #[test]
+    fn finalize_block_received_before_processing_display() {
+        let err = AbciError::FinalizeBlockReceivedBeforeProcessing("not processed yet".to_string());
+        assert_eq!(
+            err.to_string(),
+            "finalize block received before processing from Tenderdash: not processed yet"
+        );
+    }
+
+    #[test]
+    fn wrong_block_received_display() {
+        let err = AbciError::WrongBlockReceived("bad block".to_string());
+        assert_eq!(err.to_string(), "wrong block from Tenderdash: bad block");
+    }
+
+    #[test]
+    fn wrong_finalize_block_received_display() {
+        let err = AbciError::WrongFinalizeBlockReceived("bad finalize".to_string());
+        assert_eq!(
+            err.to_string(),
+            "wrong finalize block from Tenderdash: bad finalize"
+        );
+    }
+
+    #[test]
+    fn bad_request_data_size_display() {
+        let err = AbciError::BadRequestDataSize("size mismatch".to_string());
+        assert_eq!(
+            err.to_string(),
+            "data received from Tenderdash could not be converted: size mismatch"
+        );
+    }
+
+    #[test]
+    fn bad_request_display() {
+        let err = AbciError::BadRequest("invalid request".to_string());
+        assert_eq!(
+            err.to_string(),
+            "bad request received from Tenderdash: invalid request"
+        );
+    }
+
+    #[test]
+    fn bad_initialization_display() {
+        let err = AbciError::BadInitialization("init failed".to_string());
+        assert_eq!(err.to_string(), "bad initialization: init failed");
+    }
+
+    #[test]
+    fn bad_commit_signature_display() {
+        let err = AbciError::BadCommitSignature("sig mismatch".to_string());
+        assert_eq!(err.to_string(), "bad commit signature: sig mismatch");
+    }
+
+    #[test]
+    fn invalid_chain_lock_display() {
+        let err = AbciError::InvalidChainLock("lock invalid".to_string());
+        assert_eq!(err.to_string(), "invalid chain lock: lock invalid");
+    }
+
+    #[test]
+    fn chain_locked_block_not_known_by_core_display() {
+        let err = AbciError::ChainLockedBlockNotKnownByCore("unknown block".to_string());
+        assert_eq!(
+            err.to_string(),
+            "chain lock is for a block not known by core: unknown block"
+        );
+    }
+
+    #[test]
+    fn abci_version_mismatch_display() {
+        let err = AbciError::AbciVersionMismatch {
+            tenderdash: "1.0".to_string(),
+            drive: "2.0".to_string(),
+        };
+        assert!(err.to_string().contains("1.0"));
+        assert!(err.to_string().contains("2.0"));
+    }
+
+    #[test]
+    fn invalid_state_transition_display() {
+        let consensus_error = ConsensusError::DefaultError;
+        let err = AbciError::InvalidStateTransition(consensus_error);
+        assert_eq!(
+            err.to_string(),
+            "invalid state transition error: default error"
+        );
+    }
+
+    #[test]
+    fn tenderdash_proto_display() {
+        let proto_err = tenderdash_abci::proto::Error::try_from_protobuf("proto fail".to_string());
+        let err = AbciError::TenderdashProto(proto_err);
+        assert!(err.to_string().contains("proto fail"));
+    }
+
+    #[test]
+    fn error_debug_format_is_not_empty() {
+        let err = AbciError::InvalidState("test".to_string());
+        let debug = format!("{:?}", err);
+        assert!(!debug.is_empty());
+        assert!(debug.contains("InvalidState"));
+    }
+
+    #[test]
+    fn consensus_error_converts_to_abci_error() {
+        let consensus_err = ConsensusError::DefaultError;
+        let abci_err: AbciError = consensus_err.into();
+        assert!(matches!(abci_err, AbciError::InvalidStateTransition(_)));
+    }
+}

--- a/packages/rs-drive-abci/src/abci/handler/echo.rs
+++ b/packages/rs-drive-abci/src/abci/handler/echo.rs
@@ -12,3 +12,56 @@ where
         message: request.message,
     })
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::rpc::core::MockCoreRPCLike;
+    use crate::test::helpers::setup::TestPlatformBuilder;
+
+    #[test]
+    fn echo_returns_same_message() {
+        let platform = TestPlatformBuilder::new().build_with_mock_rpc();
+
+        let app = crate::abci::app::FullAbciApplication::new(&platform.platform);
+
+        let request = proto::RequestEcho {
+            message: "hello world".to_string(),
+        };
+
+        let response = echo::<_, MockCoreRPCLike>(&app, request).expect("echo should succeed");
+
+        assert_eq!(response.message, "hello world");
+    }
+
+    #[test]
+    fn echo_returns_empty_message() {
+        let platform = TestPlatformBuilder::new().build_with_mock_rpc();
+
+        let app = crate::abci::app::FullAbciApplication::new(&platform.platform);
+
+        let request = proto::RequestEcho {
+            message: String::new(),
+        };
+
+        let response = echo::<_, MockCoreRPCLike>(&app, request).expect("echo should succeed");
+
+        assert_eq!(response.message, "");
+    }
+
+    #[test]
+    fn echo_preserves_special_characters() {
+        let platform = TestPlatformBuilder::new().build_with_mock_rpc();
+
+        let app = crate::abci::app::FullAbciApplication::new(&platform.platform);
+
+        let special_msg = "test\n\ttab\r\nnewline unicode: \u{1F600}";
+        let request = proto::RequestEcho {
+            message: special_msg.to_string(),
+        };
+
+        let response = echo::<_, MockCoreRPCLike>(&app, request).expect("echo should succeed");
+
+        assert_eq!(response.message, special_msg);
+    }
+}

--- a/packages/rs-drive-abci/src/abci/handler/error/consensus.rs
+++ b/packages/rs-drive-abci/src/abci/handler/error/consensus.rs
@@ -35,3 +35,46 @@ impl AbciResponseInfoGetter for ConsensusError {
         Ok(encoded_info)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn response_info_for_version_returns_non_empty_base64_for_default_error() {
+        let platform_version = PlatformVersion::latest();
+        let error = ConsensusError::DefaultError;
+
+        let result = error.response_info_for_version(platform_version);
+        assert!(result.is_ok(), "should produce response info");
+
+        let info = result.unwrap();
+        assert!(!info.is_empty(), "response info should not be empty");
+
+        // Verify it is valid base64 by decoding
+        use dpp::platform_value::string_encoding::{decode, Encoding as Dec};
+        let decoded = decode(&info, Dec::Base64).expect("should decode base64");
+        assert!(!decoded.is_empty(), "decoded data should not be empty");
+    }
+
+    #[test]
+    fn response_info_contains_serialized_error_data() {
+        let platform_version = PlatformVersion::latest();
+        let error = ConsensusError::DefaultError;
+
+        let info = error
+            .response_info_for_version(platform_version)
+            .expect("should produce response info");
+
+        // Decode base64 and then decode CBOR to verify the structure
+        use dpp::platform_value::string_encoding::{decode, Encoding as Dec};
+        let decoded_bytes = decode(&info, Dec::Base64).expect("should decode base64");
+
+        // Verify CBOR can be parsed (the structure contains "data" -> "serializedError")
+        let value: ciborium::Value =
+            ciborium::from_reader(&decoded_bytes[..]).expect("should parse CBOR");
+
+        // The value should be a map
+        assert!(value.is_map(), "CBOR value should be a map");
+    }
+}

--- a/packages/rs-drive-abci/src/abci/handler/error/mod.rs
+++ b/packages/rs-drive-abci/src/abci/handler/error/mod.rs
@@ -196,3 +196,275 @@ pub fn error_into_exception(error: Error) -> proto::ResponseException {
         error: error.to_string(),
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::error::execution::ExecutionError;
+
+    #[test]
+    fn handler_error_code_cancelled() {
+        let err = HandlerError::Cancelled("cancelled".into());
+        assert_eq!(err.code(), HandlerErrorCode::Cancelled as u32);
+        assert_eq!(err.code(), 1);
+    }
+
+    #[test]
+    fn handler_error_code_unknown() {
+        let err = HandlerError::Unknown("unknown".into());
+        assert_eq!(err.code(), HandlerErrorCode::Unknown as u32);
+        assert_eq!(err.code(), 2);
+    }
+
+    #[test]
+    fn handler_error_code_invalid_argument() {
+        let err = HandlerError::InvalidArgument("bad arg".into());
+        assert_eq!(err.code(), HandlerErrorCode::InvalidArgument as u32);
+        assert_eq!(err.code(), 3);
+    }
+
+    #[test]
+    fn handler_error_code_deadline_exceeded() {
+        let err = HandlerError::DeadlineExceeded("timeout".into());
+        assert_eq!(err.code(), HandlerErrorCode::DeadlineExceeded as u32);
+        assert_eq!(err.code(), 4);
+    }
+
+    #[test]
+    fn handler_error_code_not_found() {
+        let err = HandlerError::NotFound("missing".into());
+        assert_eq!(err.code(), HandlerErrorCode::NotFound as u32);
+        assert_eq!(err.code(), 5);
+    }
+
+    #[test]
+    fn handler_error_code_already_exists() {
+        let err = HandlerError::AlreadyExists("exists".into());
+        assert_eq!(err.code(), HandlerErrorCode::AlreadyExists as u32);
+        assert_eq!(err.code(), 6);
+    }
+
+    #[test]
+    fn handler_error_code_permission_denied() {
+        let err = HandlerError::PermissionDenied("denied".into());
+        assert_eq!(err.code(), HandlerErrorCode::PermissionDenied as u32);
+        assert_eq!(err.code(), 7);
+    }
+
+    #[test]
+    fn handler_error_code_resource_exhausted() {
+        let err = HandlerError::ResourceExhausted("exhausted".into());
+        assert_eq!(err.code(), HandlerErrorCode::ResourceExhausted as u32);
+        assert_eq!(err.code(), 8);
+    }
+
+    #[test]
+    fn handler_error_code_failed_precondition() {
+        let err = HandlerError::FailedPrecondition("precondition".into());
+        assert_eq!(err.code(), HandlerErrorCode::FailedPrecondition as u32);
+        assert_eq!(err.code(), 9);
+    }
+
+    #[test]
+    fn handler_error_code_aborted() {
+        let err = HandlerError::Aborted("aborted".into());
+        assert_eq!(err.code(), HandlerErrorCode::Aborted as u32);
+        assert_eq!(err.code(), 10);
+    }
+
+    #[test]
+    fn handler_error_code_out_of_range() {
+        let err = HandlerError::OutOfRange("range".into());
+        assert_eq!(err.code(), HandlerErrorCode::OutOfRange as u32);
+        assert_eq!(err.code(), 11);
+    }
+
+    #[test]
+    fn handler_error_code_unimplemented() {
+        let err = HandlerError::Unimplemented("not impl".into());
+        assert_eq!(err.code(), HandlerErrorCode::Unimplemented as u32);
+        assert_eq!(err.code(), 12);
+    }
+
+    #[test]
+    fn handler_error_code_internal() {
+        let err = HandlerError::Internal("internal".into());
+        assert_eq!(err.code(), HandlerErrorCode::Internal as u32);
+        assert_eq!(err.code(), 13);
+    }
+
+    #[test]
+    fn handler_error_code_unavailable() {
+        let err = HandlerError::Unavailable("unavailable".into());
+        assert_eq!(err.code(), HandlerErrorCode::Unavailable as u32);
+        assert_eq!(err.code(), 14);
+    }
+
+    #[test]
+    fn handler_error_code_data_loss() {
+        let err = HandlerError::DataLoss("data lost".into());
+        assert_eq!(err.code(), HandlerErrorCode::DataLoss as u32);
+        assert_eq!(err.code(), 15);
+    }
+
+    #[test]
+    fn handler_error_code_unauthenticated() {
+        let err = HandlerError::Unauthenticated("unauth".into());
+        assert_eq!(err.code(), HandlerErrorCode::Unauthenticated as u32);
+        assert_eq!(err.code(), 16);
+    }
+
+    #[test]
+    fn handler_error_code_consensus_error() {
+        let consensus_error = ConsensusError::DefaultError;
+        let err = HandlerError::StateTransitionConsensusError(consensus_error);
+        // DefaultError has code 1
+        assert_eq!(err.code(), 1);
+    }
+
+    #[test]
+    fn handler_error_message_returns_inner_string() {
+        let test_cases = vec![
+            (
+                HandlerError::Cancelled("cancelled msg".into()),
+                "cancelled msg",
+            ),
+            (HandlerError::Unknown("unknown msg".into()), "unknown msg"),
+            (HandlerError::InvalidArgument("arg msg".into()), "arg msg"),
+            (
+                HandlerError::DeadlineExceeded("deadline msg".into()),
+                "deadline msg",
+            ),
+            (
+                HandlerError::NotFound("not found msg".into()),
+                "not found msg",
+            ),
+            (
+                HandlerError::AlreadyExists("exists msg".into()),
+                "exists msg",
+            ),
+            (
+                HandlerError::PermissionDenied("denied msg".into()),
+                "denied msg",
+            ),
+            (
+                HandlerError::ResourceExhausted("exhausted msg".into()),
+                "exhausted msg",
+            ),
+            (
+                HandlerError::FailedPrecondition("precond msg".into()),
+                "precond msg",
+            ),
+            (HandlerError::Aborted("aborted msg".into()), "aborted msg"),
+            (HandlerError::OutOfRange("range msg".into()), "range msg"),
+            (
+                HandlerError::Unimplemented("unimpl msg".into()),
+                "unimpl msg",
+            ),
+            (
+                HandlerError::Internal("internal msg".into()),
+                "internal msg",
+            ),
+            (
+                HandlerError::Unavailable("unavail msg".into()),
+                "unavail msg",
+            ),
+            (HandlerError::DataLoss("loss msg".into()), "loss msg"),
+            (
+                HandlerError::Unauthenticated("unauth msg".into()),
+                "unauth msg",
+            ),
+        ];
+
+        for (err, expected) in test_cases {
+            assert_eq!(err.message(), expected, "message mismatch for {:?}", err);
+        }
+    }
+
+    #[test]
+    fn handler_error_message_consensus_error() {
+        let consensus_error = ConsensusError::DefaultError;
+        let err = HandlerError::StateTransitionConsensusError(consensus_error);
+        // ConsensusError::DefaultError displays as "default error"
+        assert_eq!(err.message(), "default error");
+    }
+
+    #[test]
+    fn handler_error_response_info_returns_base64_encoded_cbor() {
+        let err = HandlerError::Internal("some internal error".into());
+        let info = err.response_info().expect("should produce response info");
+
+        // The result should be a non-empty base64 string
+        assert!(!info.is_empty());
+
+        // It should be valid base64
+        use dpp::platform_value::string_encoding::{decode, Encoding};
+        let decoded = decode(&info, Encoding::Base64).expect("should be valid base64");
+        assert!(!decoded.is_empty());
+    }
+
+    #[test]
+    fn handler_error_display_matches_message() {
+        let err = HandlerError::Internal("display test".into());
+        assert_eq!(err.to_string(), "display test");
+
+        let err = HandlerError::NotFound("missing item".into());
+        assert_eq!(err.to_string(), "missing item");
+    }
+
+    #[test]
+    fn handler_error_from_query_error_not_found() {
+        let query_err = QueryError::NotFound("item not found".to_string());
+        let handler_err = HandlerError::from(&query_err);
+        assert!(matches!(handler_err, HandlerError::NotFound(_)));
+        assert_eq!(handler_err.message(), "item not found");
+    }
+
+    #[test]
+    fn handler_error_from_query_error_invalid_argument() {
+        let query_err = QueryError::InvalidArgument("bad argument".to_string());
+        let handler_err = HandlerError::from(&query_err);
+        assert!(matches!(handler_err, HandlerError::InvalidArgument(_)));
+        assert_eq!(handler_err.message(), "bad argument");
+    }
+
+    #[test]
+    fn handler_error_from_query_error_query() {
+        use drive::error::query::QuerySyntaxError;
+        let query_err = QueryError::Query(QuerySyntaxError::InvalidSQL("bad sql".to_string()));
+        let handler_err = HandlerError::from(&query_err);
+        assert!(matches!(handler_err, HandlerError::InvalidArgument(_)));
+    }
+
+    #[test]
+    fn handler_error_from_query_error_other_maps_to_unknown() {
+        let query_err = QueryError::DecodingError("decoding failed".to_string());
+        let handler_err = HandlerError::from(&query_err);
+        assert!(matches!(handler_err, HandlerError::Unknown(_)));
+    }
+
+    #[test]
+    fn handler_error_from_consensus_error() {
+        let consensus_err = ConsensusError::DefaultError;
+        let handler_err = HandlerError::from(&consensus_err);
+        assert!(matches!(
+            handler_err,
+            HandlerError::StateTransitionConsensusError(_)
+        ));
+    }
+
+    #[test]
+    fn handler_error_from_error() {
+        let error = Error::Execution(ExecutionError::CorruptedCodeExecution("test failure"));
+        let handler_err = HandlerError::from(&error);
+        assert!(matches!(handler_err, HandlerError::Internal(_)));
+        assert!(handler_err.message().contains("test failure"));
+    }
+
+    #[test]
+    fn error_into_exception_produces_response_exception() {
+        let error = Error::Execution(ExecutionError::CorruptedCodeExecution("exception test"));
+        let exception = error_into_exception(error);
+        assert!(exception.error.contains("exception test"));
+    }
+}


### PR DESCRIPTION
## Issue being fixed or feature implemented

Improve test coverage for the `packages/rs-drive-abci/src/abci/` module which previously had zero unit tests.

## What was done?

Added 88 comprehensive unit tests across 9 files in the abci module:

- **config.rs** (10 tests): Default values, serialization/deserialization roundtrip, field renaming via serde, custom `from_opt_str_or_number` deserializer behavior (string parsing, null handling, empty string, rejection of raw numbers), clone, debug formatting
- **error.rs** (17 tests): Display formatting for all `AbciError` variants (`InvalidState`, `RequestForWrongBlockReceived`, `VoteExtensionMismatchReceived`, `VoteExtensionsSignatureInvalid`, `InvalidVoteExtensionsVerification`, `WithdrawalTransactionsDBLoadError`, `FinalizeBlockReceivedBeforeProcessing`, `WrongBlockReceived`, `WrongFinalizeBlockReceived`, `BadRequestDataSize`, `BadRequest`, `BadInitialization`, `BadCommitSignature`, `InvalidChainLock`, `ChainLockedBlockNotKnownByCore`, `AbciVersionMismatch`, `InvalidStateTransition`, `TenderdashProto`), debug formatting, `From<ConsensusError>` conversion
- **handler/error/mod.rs** (31 tests): `HandlerError::code()` for all 16 error variants plus consensus error, `message()` for all variants, `response_info()` producing valid base64-encoded CBOR, `Display` trait, `From<&QueryError>` (NotFound, InvalidArgument, Query, other), `From<&ConsensusError>`, `From<&Error>`, `error_into_exception`
- **handler/error/consensus.rs** (2 tests): `AbciResponseInfoGetter::response_info_for_version` producing valid base64 and parseable CBOR with correct structure
- **handler/echo.rs** (3 tests): Echo handler returning same message, empty message, special characters
- **app/execution_result.rs** (6 tests): `TryIntoPlatformVersioned<Option<ExecTxResult>>` for all `StateTransitionExecutionResult` variants (successful execution with fees, zero fees, unpaid consensus error, paid consensus error, internal error, not executed)
- **app/check_tx.rs** (4 tests): `error_into_status` producing internal tonic status, preserving error messages, `CheckTxAbciApplication` debug format and platform accessor
- **app/consensus.rs** (6 tests): `ConsensusAbciApplication` debug format, platform accessor, initial state (no block context, no transaction), transaction start, commit without transaction failure
- **app/full.rs** (7 tests): `FullAbciApplication` debug format, platform accessor, initial state, transaction start, commit without transaction failure, full start-and-commit lifecycle

## How Has This Been Tested?

All 88 tests pass locally:
```
cargo test -p drive-abci --lib -- abci::
test result: ok. 88 passed; 0 failed; 0 ignored; 0 measured; 1515 filtered out
```

Tests run quickly (< 0.3s total) since they use `TestPlatformBuilder::build_with_mock_rpc()` and avoid heavy integration-level setup.

## Breaking Changes

None. This PR only adds `#[cfg(test)]` modules to existing source files.

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [x] I have made corresponding changes to the documentation if needed