### PR TITLE
test(drive-abci): improve execution types test coverage

### DIFF
--- a/packages/rs-drive-abci/src/execution/types/block_fees/mod.rs
+++ b/packages/rs-drive-abci/src/execution/types/block_fees/mod.rs
@@ -72,3 +72,58 @@ impl BlockFeesV0Methods for BlockFees {
         BlockFees::V0(BlockFeesV0::from_fees(storage_fee, processing_fee))
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use dpp::fee::epoch::CreditsPerEpoch;
+
+    fn make_block_fees() -> BlockFees {
+        BlockFees::from_fees(500, 300)
+    }
+
+    #[test]
+    fn block_fees_wrapper_getters_delegate_correctly() {
+        let fees = make_block_fees();
+        assert_eq!(fees.storage_fee(), 500);
+        assert_eq!(fees.processing_fee(), 300);
+        assert!(fees.refunds_per_epoch().is_empty());
+    }
+
+    #[test]
+    fn block_fees_wrapper_setters_delegate_correctly() {
+        let mut fees = make_block_fees();
+        fees.set_processing_fee(999);
+        fees.set_storage_fee(888);
+        assert_eq!(fees.processing_fee(), 999);
+        assert_eq!(fees.storage_fee(), 888);
+
+        let mut refunds = CreditsPerEpoch::default();
+        refunds.insert(2, 100);
+        fees.set_refunds_per_epoch(refunds);
+        assert_eq!(*fees.refunds_per_epoch().get(&2).unwrap(), 100);
+    }
+
+    #[test]
+    fn block_fees_wrapper_refunds_per_epoch_mut() {
+        let mut fees = make_block_fees();
+        fees.refunds_per_epoch_mut().insert(7, 42);
+        assert_eq!(*fees.refunds_per_epoch().get(&7).unwrap(), 42);
+    }
+
+    #[test]
+    fn block_fees_wrapper_refunds_per_epoch_owned() {
+        let mut fees = make_block_fees();
+        fees.refunds_per_epoch_mut().insert(3, 55);
+        let owned = fees.refunds_per_epoch_owned();
+        assert_eq!(*owned.get(&3).unwrap(), 55);
+    }
+
+    #[test]
+    fn block_fees_from_v0_conversion() {
+        let v0 = BlockFeesV0::from_fees(10, 20);
+        let fees: BlockFees = v0.into();
+        assert_eq!(fees.storage_fee(), 10);
+        assert_eq!(fees.processing_fee(), 20);
+    }
+}

--- a/packages/rs-drive-abci/src/execution/types/block_fees/v0/mod.rs
+++ b/packages/rs-drive-abci/src/execution/types/block_fees/v0/mod.rs
@@ -107,3 +107,99 @@ impl From<FeeResult> for BlockFeesV0 {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use dpp::fee::epoch::CreditsPerEpoch;
+    use dpp::fee::fee_result::FeeResult;
+
+    fn make_block_fees() -> BlockFeesV0 {
+        BlockFeesV0 {
+            processing_fee: 100,
+            storage_fee: 200,
+            refunds_per_epoch: CreditsPerEpoch::default(),
+        }
+    }
+
+    #[test]
+    fn block_fees_v0_getters_return_correct_values() {
+        let fees = make_block_fees();
+        assert_eq!(fees.processing_fee(), 100);
+        assert_eq!(fees.storage_fee(), 200);
+        assert!(fees.refunds_per_epoch().is_empty());
+    }
+
+    #[test]
+    fn block_fees_v0_setters_update_values() {
+        let mut fees = make_block_fees();
+        fees.set_processing_fee(500);
+        fees.set_storage_fee(600);
+        assert_eq!(fees.processing_fee(), 500);
+        assert_eq!(fees.storage_fee(), 600);
+
+        let mut refunds = CreditsPerEpoch::default();
+        refunds.insert(0, 42);
+        fees.set_refunds_per_epoch(refunds);
+        assert_eq!(*fees.refunds_per_epoch().get(&0).unwrap(), 42);
+    }
+
+    #[test]
+    fn block_fees_v0_refunds_per_epoch_mut_allows_mutation() {
+        let mut fees = make_block_fees();
+        fees.refunds_per_epoch_mut().insert(5, 999);
+        assert_eq!(*fees.refunds_per_epoch().get(&5).unwrap(), 999);
+    }
+
+    #[test]
+    fn block_fees_v0_refunds_per_epoch_owned_consumes() {
+        let mut fees = make_block_fees();
+        fees.refunds_per_epoch_mut().insert(3, 77);
+        let owned = fees.refunds_per_epoch_owned();
+        assert_eq!(*owned.get(&3).unwrap(), 77);
+    }
+
+    #[test]
+    fn block_fees_v0_from_fees_sets_correct_values() {
+        let fees = BlockFeesV0::from_fees(300, 400);
+        assert_eq!(fees.storage_fee(), 300);
+        assert_eq!(fees.processing_fee(), 400);
+        assert!(fees.refunds_per_epoch().is_empty());
+    }
+
+    #[test]
+    fn block_fees_v0_default_is_zero() {
+        let fees = BlockFeesV0::default();
+        assert_eq!(fees.processing_fee(), 0);
+        assert_eq!(fees.storage_fee(), 0);
+        assert!(fees.refunds_per_epoch().is_empty());
+    }
+
+    #[test]
+    fn block_fees_v0_from_fee_result() {
+        let fee_result = FeeResult {
+            storage_fee: 1000,
+            processing_fee: 2000,
+            ..Default::default()
+        };
+        let block_fees = BlockFeesV0::from(fee_result);
+        assert_eq!(block_fees.storage_fee(), 1000);
+        assert_eq!(block_fees.processing_fee(), 2000);
+        assert!(block_fees.refunds_per_epoch().is_empty());
+    }
+
+    #[test]
+    fn block_fees_v0_serialization_roundtrip() {
+        let mut fees = make_block_fees();
+        fees.refunds_per_epoch_mut().insert(1, 50);
+        let serialized = serde_json::to_string(&fees).expect("serialization should succeed");
+        let deserialized: BlockFeesV0 =
+            serde_json::from_str(&serialized).expect("deserialization should succeed");
+        assert_eq!(deserialized.processing_fee(), fees.processing_fee());
+        assert_eq!(deserialized.storage_fee(), fees.storage_fee());
+        assert_eq!(
+            deserialized.refunds_per_epoch().get(&1),
+            fees.refunds_per_epoch().get(&1)
+        );
+    }
+}

--- a/packages/rs-drive-abci/src/execution/types/block_state_info/mod.rs
+++ b/packages/rs-drive-abci/src/execution/types/block_state_info/mod.rs
@@ -182,3 +182,115 @@ impl BlockStateInfoV0Methods for BlockStateInfo {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::execution::types::block_state_info::v0::BlockStateInfoV0;
+    use dpp::block::epoch::Epoch;
+
+    fn make_wrapper() -> BlockStateInfo {
+        BlockStateInfo::V0(BlockStateInfoV0 {
+            height: 10,
+            round: 2,
+            block_time_ms: 1_700_000_000_000,
+            previous_block_time_ms: Some(1_699_999_990_000),
+            proposer_pro_tx_hash: [1u8; 32],
+            core_chain_locked_height: 500,
+            block_hash: Some([0xAA; 32]),
+            app_hash: Some([0xBB; 32]),
+        })
+    }
+
+    #[test]
+    fn wrapper_getters_delegate_correctly() {
+        let info = make_wrapper();
+        assert_eq!(info.height(), 10);
+        assert_eq!(info.round(), 2);
+        assert_eq!(info.block_time_ms(), 1_700_000_000_000);
+        assert_eq!(info.previous_block_time_ms(), Some(1_699_999_990_000));
+        assert_eq!(info.proposer_pro_tx_hash(), [1u8; 32]);
+        assert_eq!(info.core_chain_locked_height(), 500);
+        assert_eq!(info.block_hash(), Some([0xAA; 32]));
+        assert_eq!(info.app_hash(), Some([0xBB; 32]));
+    }
+
+    #[test]
+    fn wrapper_setters_delegate_correctly() {
+        let mut info = make_wrapper();
+        info.set_height(20);
+        info.set_round(3);
+        info.set_block_time_ms(2_000_000_000_000);
+        info.set_previous_block_time_ms(None);
+        info.set_proposer_pro_tx_hash([2u8; 32]);
+        info.set_core_chain_locked_height(600);
+        info.set_block_hash(None);
+        info.set_app_hash(None);
+
+        assert_eq!(info.height(), 20);
+        assert_eq!(info.round(), 3);
+        assert_eq!(info.block_time_ms(), 2_000_000_000_000);
+        assert_eq!(info.previous_block_time_ms(), None);
+        assert_eq!(info.proposer_pro_tx_hash(), [2u8; 32]);
+        assert_eq!(info.core_chain_locked_height(), 600);
+        assert_eq!(info.block_hash(), None);
+        assert_eq!(info.app_hash(), None);
+    }
+
+    #[test]
+    fn wrapper_to_block_info() {
+        let info = make_wrapper();
+        let epoch = Epoch::new(1).unwrap();
+        let block_info = info.to_block_info(epoch);
+        assert_eq!(block_info.height, 10);
+        assert_eq!(block_info.core_height, 500);
+    }
+
+    #[test]
+    fn wrapper_next_block_to() {
+        let info = make_wrapper();
+        assert!(info.next_block_to(9, 500).unwrap());
+        assert!(!info.next_block_to(10, 500).unwrap());
+    }
+
+    #[test]
+    fn wrapper_matches_current_block() {
+        let info = make_wrapper();
+        assert!(info.matches_current_block(10, 2, [0xAA; 32]).unwrap());
+        assert!(!info.matches_current_block(11, 2, [0xAA; 32]).unwrap());
+    }
+
+    #[test]
+    fn wrapper_matches_expected_block_info() {
+        let info = make_wrapper();
+        assert!(info
+            .matches_expected_block_info(10, 2, 500, [1u8; 32], [0xAA; 32], [0xBB; 32])
+            .unwrap());
+        assert!(!info
+            .matches_expected_block_info(10, 2, 501, [1u8; 32], [0xAA; 32], [0xBB; 32])
+            .unwrap());
+    }
+
+    #[test]
+    fn from_v0_conversion() {
+        let v0 = BlockStateInfoV0 {
+            height: 1,
+            round: 0,
+            block_time_ms: 0,
+            previous_block_time_ms: None,
+            proposer_pro_tx_hash: [0u8; 32],
+            core_chain_locked_height: 0,
+            block_hash: None,
+            app_hash: None,
+        };
+        let info: BlockStateInfo = v0.into();
+        assert_eq!(info.height(), 1);
+    }
+
+    #[test]
+    fn equality_works() {
+        let a = make_wrapper();
+        let b = make_wrapper();
+        assert_eq!(a, b);
+    }
+}

--- a/packages/rs-drive-abci/src/execution/types/block_state_info/v0/mod.rs
+++ b/packages/rs-drive-abci/src/execution/types/block_state_info/v0/mod.rs
@@ -308,3 +308,248 @@ impl BlockStateInfoV0Setters for BlockStateInfoV0 {
         self.app_hash = app_hash;
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::platform_types::block_proposal::v0::BlockProposal;
+    use dpp::block::epoch::Epoch;
+    use tenderdash_abci::proto::version::Consensus;
+
+    fn make_block_state_info() -> BlockStateInfoV0 {
+        BlockStateInfoV0 {
+            height: 10,
+            round: 2,
+            block_time_ms: 1_700_000_000_000,
+            previous_block_time_ms: Some(1_699_999_990_000),
+            proposer_pro_tx_hash: [1u8; 32],
+            core_chain_locked_height: 500,
+            block_hash: Some([0xAA; 32]),
+            app_hash: Some([0xBB; 32]),
+        }
+    }
+
+    #[test]
+    fn getters_return_correct_values() {
+        let info = make_block_state_info();
+        assert_eq!(info.height(), 10);
+        assert_eq!(info.round(), 2);
+        assert_eq!(info.block_time_ms(), 1_700_000_000_000);
+        assert_eq!(info.previous_block_time_ms(), Some(1_699_999_990_000));
+        assert_eq!(info.proposer_pro_tx_hash(), [1u8; 32]);
+        assert_eq!(info.core_chain_locked_height(), 500);
+        assert_eq!(info.block_hash(), Some([0xAA; 32]));
+        assert_eq!(info.app_hash(), Some([0xBB; 32]));
+    }
+
+    #[test]
+    fn setters_update_values() {
+        let mut info = make_block_state_info();
+        info.set_height(20);
+        info.set_round(5);
+        info.set_block_time_ms(2_000_000_000_000);
+        info.set_previous_block_time_ms(None);
+        info.set_proposer_pro_tx_hash([2u8; 32]);
+        info.set_core_chain_locked_height(600);
+        info.set_block_hash(None);
+        info.set_app_hash(None);
+
+        assert_eq!(info.height(), 20);
+        assert_eq!(info.round(), 5);
+        assert_eq!(info.block_time_ms(), 2_000_000_000_000);
+        assert_eq!(info.previous_block_time_ms(), None);
+        assert_eq!(info.proposer_pro_tx_hash(), [2u8; 32]);
+        assert_eq!(info.core_chain_locked_height(), 600);
+        assert_eq!(info.block_hash(), None);
+        assert_eq!(info.app_hash(), None);
+    }
+
+    #[test]
+    fn to_block_info_produces_correct_block_info() {
+        let info = make_block_state_info();
+        let epoch = Epoch::new(3).unwrap();
+        let block_info = info.to_block_info(epoch);
+        assert_eq!(block_info.time_ms, 1_700_000_000_000);
+        assert_eq!(block_info.height, 10);
+        assert_eq!(block_info.core_height, 500);
+        assert_eq!(block_info.epoch.index, 3);
+    }
+
+    #[test]
+    fn next_block_to_returns_true_for_sequential_block() {
+        let info = make_block_state_info(); // height=10, core_chain_locked_height=500
+        assert!(info.next_block_to(9, 500).unwrap());
+        assert!(info.next_block_to(9, 400).unwrap());
+    }
+
+    #[test]
+    fn next_block_to_returns_false_for_non_sequential_height() {
+        let info = make_block_state_info(); // height=10
+        assert!(!info.next_block_to(10, 500).unwrap());
+        assert!(!info.next_block_to(8, 500).unwrap());
+    }
+
+    #[test]
+    fn next_block_to_returns_false_for_core_height_regression() {
+        let info = make_block_state_info(); // core_chain_locked_height=500
+        assert!(!info.next_block_to(9, 501).unwrap());
+    }
+
+    #[test]
+    fn matches_current_block_returns_true_for_matching() {
+        let info = make_block_state_info(); // height=10, round=2, block_hash=Some([0xAA; 32])
+        assert!(info.matches_current_block(10, 2, [0xAA; 32]).unwrap());
+    }
+
+    #[test]
+    fn matches_current_block_returns_false_for_wrong_height() {
+        let info = make_block_state_info();
+        assert!(!info.matches_current_block(11, 2, [0xAA; 32]).unwrap());
+    }
+
+    #[test]
+    fn matches_current_block_returns_false_for_wrong_round() {
+        let info = make_block_state_info();
+        assert!(!info.matches_current_block(10, 3, [0xAA; 32]).unwrap());
+    }
+
+    #[test]
+    fn matches_current_block_returns_false_for_wrong_hash() {
+        let info = make_block_state_info();
+        assert!(!info.matches_current_block(10, 2, [0xBB; 32]).unwrap());
+    }
+
+    #[test]
+    fn matches_current_block_returns_false_when_no_block_hash() {
+        let mut info = make_block_state_info();
+        info.block_hash = None;
+        assert!(!info.matches_current_block(10, 2, [0xAA; 32]).unwrap());
+    }
+
+    #[test]
+    fn matches_current_block_error_on_bad_hash_size() {
+        let info = make_block_state_info();
+        // Provide a Vec that can't convert to [u8; 32]
+        let bad_hash: Vec<u8> = vec![0u8; 16];
+        let result = info.matches_current_block(10, 2, bad_hash);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn matches_expected_block_info_returns_true_for_exact_match() {
+        let info = make_block_state_info();
+        assert!(info
+            .matches_expected_block_info(10, 2, 500, [1u8; 32], [0xAA; 32], [0xBB; 32])
+            .unwrap());
+    }
+
+    #[test]
+    fn matches_expected_block_info_returns_false_for_wrong_core_height() {
+        let info = make_block_state_info();
+        assert!(!info
+            .matches_expected_block_info(10, 2, 501, [1u8; 32], [0xAA; 32], [0xBB; 32])
+            .unwrap());
+    }
+
+    #[test]
+    fn matches_expected_block_info_returns_false_for_wrong_proposer() {
+        let info = make_block_state_info();
+        assert!(!info
+            .matches_expected_block_info(10, 2, 500, [9u8; 32], [0xAA; 32], [0xBB; 32])
+            .unwrap());
+    }
+
+    #[test]
+    fn matches_expected_block_info_returns_false_for_wrong_app_hash() {
+        let info = make_block_state_info();
+        assert!(!info
+            .matches_expected_block_info(10, 2, 500, [1u8; 32], [0xAA; 32], [0xCC; 32])
+            .unwrap());
+    }
+
+    #[test]
+    fn matches_expected_block_info_returns_false_when_no_block_hash() {
+        let mut info = make_block_state_info();
+        info.block_hash = None;
+        assert!(!info
+            .matches_expected_block_info(10, 2, 500, [1u8; 32], [0xAA; 32], [0xBB; 32])
+            .unwrap());
+    }
+
+    #[test]
+    fn matches_expected_block_info_returns_false_when_no_app_hash() {
+        let mut info = make_block_state_info();
+        info.app_hash = None;
+        assert!(!info
+            .matches_expected_block_info(10, 2, 500, [1u8; 32], [0xAA; 32], [0xBB; 32])
+            .unwrap());
+    }
+
+    #[test]
+    fn matches_expected_block_info_error_on_bad_commit_hash() {
+        let info = make_block_state_info();
+        let bad_hash: Vec<u8> = vec![0u8; 5];
+        let good_app_hash: Vec<u8> = vec![0xBB; 32];
+        let result =
+            info.matches_expected_block_info(10, 2, 500, [1u8; 32], bad_hash, good_app_hash);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn matches_expected_block_info_error_on_bad_app_hash() {
+        let info = make_block_state_info();
+        let good_commit_hash: Vec<u8> = vec![0xAA; 32];
+        let bad_hash: Vec<u8> = vec![0u8; 5];
+        let result =
+            info.matches_expected_block_info(10, 2, 500, [1u8; 32], good_commit_hash, bad_hash);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn from_block_proposal_creates_correct_state_info() {
+        let empty_txs = vec![];
+        let proposal = BlockProposal {
+            consensus_versions: Consensus { block: 1, app: 1 },
+            block_hash: Some([0xDD; 32]),
+            height: 42,
+            round: 3,
+            block_time_ms: 1_700_000_000_000,
+            core_chain_locked_height: 800,
+            core_chain_lock_update: None,
+            proposed_app_version: 1,
+            proposer_pro_tx_hash: [5u8; 32],
+            validator_set_quorum_hash: [0u8; 32],
+            raw_state_transitions: &empty_txs,
+        };
+        let info = BlockStateInfoV0::from_block_proposal(&proposal, Some(1_699_999_000_000));
+        assert_eq!(info.height(), 42);
+        assert_eq!(info.round(), 3);
+        assert_eq!(info.block_time_ms(), 1_700_000_000_000);
+        assert_eq!(info.previous_block_time_ms(), Some(1_699_999_000_000));
+        assert_eq!(info.proposer_pro_tx_hash(), [5u8; 32]);
+        assert_eq!(info.core_chain_locked_height(), 800);
+        assert_eq!(info.block_hash(), Some([0xDD; 32]));
+        assert_eq!(info.app_hash(), None);
+    }
+
+    #[test]
+    fn from_block_proposal_with_no_previous_time() {
+        let empty_txs = vec![];
+        let proposal = BlockProposal {
+            consensus_versions: Consensus { block: 1, app: 1 },
+            block_hash: None,
+            height: 1,
+            round: 0,
+            block_time_ms: 1_000_000,
+            core_chain_locked_height: 1,
+            core_chain_lock_update: None,
+            proposed_app_version: 1,
+            proposer_pro_tx_hash: [0u8; 32],
+            validator_set_quorum_hash: [0u8; 32],
+            raw_state_transitions: &empty_txs,
+        };
+        let info = BlockStateInfoV0::from_block_proposal(&proposal, None);
+        assert_eq!(info.previous_block_time_ms(), None);
+        assert_eq!(info.block_hash(), None);
+    }
+}

--- a/packages/rs-drive-abci/src/execution/types/execution_operation/mod.rs
+++ b/packages/rs-drive-abci/src/execution/types/execution_operation/mod.rs
@@ -279,3 +279,263 @@ impl ValidationOperation {
         Ok(())
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use dpp::fee::fee_result::FeeResult;
+    use dpp::identity::KeyType;
+    use dpp::validation::operations::ProtocolValidationOperation;
+    use platform_version::version::PlatformVersion;
+
+    fn platform_version() -> &'static PlatformVersion {
+        PlatformVersion::latest()
+    }
+
+    #[test]
+    fn retrieve_identity_info_only_balance() {
+        let info = RetrieveIdentityInfo::only_balance();
+        assert_eq!(info.query_by_key_id_key_count, 0);
+        assert!(info.request_balance);
+        assert!(!info.request_revision);
+    }
+
+    #[test]
+    fn retrieve_identity_info_only_revision() {
+        let info = RetrieveIdentityInfo::only_revision();
+        assert_eq!(info.query_by_key_id_key_count, 0);
+        assert!(!info.request_balance);
+        assert!(info.request_revision);
+    }
+
+    #[test]
+    fn retrieve_identity_info_one_key() {
+        let info = RetrieveIdentityInfo::one_key();
+        assert_eq!(info.query_by_key_id_key_count, 1);
+        assert!(!info.request_balance);
+        assert!(!info.request_revision);
+    }
+
+    #[test]
+    fn retrieve_identity_info_one_key_and_balance_and_revision() {
+        let info = RetrieveIdentityInfo::one_key_and_balance_and_revision();
+        assert_eq!(info.query_by_key_id_key_count, 1);
+        assert!(info.request_balance);
+        assert!(info.request_revision);
+    }
+
+    #[test]
+    fn retrieve_identity_info_one_key_and_balance() {
+        let info = RetrieveIdentityInfo::one_key_and_balance();
+        assert_eq!(info.query_by_key_id_key_count, 1);
+        assert!(info.request_balance);
+        assert!(!info.request_revision);
+    }
+
+    #[test]
+    fn retrieve_identity_info_one_key_and_revision() {
+        let info = RetrieveIdentityInfo::one_key_and_revision();
+        assert_eq!(info.query_by_key_id_key_count, 1);
+        assert!(!info.request_balance);
+        assert!(info.request_revision);
+    }
+
+    #[test]
+    fn add_many_empty_operations_is_noop() {
+        let mut fee_result = FeeResult::default();
+        ValidationOperation::add_many_to_fee_result(&[], &mut fee_result, platform_version())
+            .unwrap();
+        assert_eq!(fee_result.processing_fee, 0);
+        assert_eq!(fee_result.storage_fee, 0);
+    }
+
+    #[test]
+    fn add_many_signature_verification() {
+        let ops = vec![ValidationOperation::SignatureVerification(
+            SignatureVerificationOperation::new(KeyType::ECDSA_SECP256K1),
+        )];
+        let mut fee_result = FeeResult::default();
+        ValidationOperation::add_many_to_fee_result(&ops, &mut fee_result, platform_version())
+            .unwrap();
+        assert!(fee_result.processing_fee > 0);
+    }
+
+    #[test]
+    fn add_many_precalculated_operation() {
+        let precalc = FeeResult {
+            processing_fee: 100,
+            storage_fee: 50,
+            ..Default::default()
+        };
+        let ops = vec![ValidationOperation::PrecalculatedOperation(precalc)];
+        let mut fee_result = FeeResult::default();
+        ValidationOperation::add_many_to_fee_result(&ops, &mut fee_result, platform_version())
+            .unwrap();
+        assert_eq!(fee_result.processing_fee, 100);
+        assert_eq!(fee_result.storage_fee, 50);
+    }
+
+    #[test]
+    fn add_many_single_sha256() {
+        let ops = vec![ValidationOperation::SingleSha256(2)];
+        let mut fee_result = FeeResult::default();
+        ValidationOperation::add_many_to_fee_result(&ops, &mut fee_result, platform_version())
+            .unwrap();
+        let pv = platform_version();
+        let expected =
+            pv.fee_version.hashing.single_sha256_base + pv.fee_version.hashing.sha256_per_block * 2;
+        assert_eq!(fee_result.processing_fee, expected);
+    }
+
+    #[test]
+    fn add_many_double_sha256() {
+        let ops = vec![ValidationOperation::DoubleSha256(3)];
+        let mut fee_result = FeeResult::default();
+        ValidationOperation::add_many_to_fee_result(&ops, &mut fee_result, platform_version())
+            .unwrap();
+        let pv = platform_version();
+        let expected =
+            pv.fee_version.hashing.single_sha256_base + pv.fee_version.hashing.sha256_per_block * 3;
+        assert_eq!(fee_result.processing_fee, expected);
+    }
+
+    #[test]
+    fn add_many_ripemd160() {
+        let ops = vec![ValidationOperation::Ripemd160(4)];
+        let mut fee_result = FeeResult::default();
+        ValidationOperation::add_many_to_fee_result(&ops, &mut fee_result, platform_version())
+            .unwrap();
+        let pv = platform_version();
+        let expected = pv.fee_version.hashing.ripemd160_per_block * 4;
+        assert_eq!(fee_result.processing_fee, expected);
+    }
+
+    #[test]
+    fn add_many_retrieve_identity_balance_only() {
+        let ops = vec![ValidationOperation::RetrieveIdentity(
+            RetrieveIdentityInfo::only_balance(),
+        )];
+        let mut fee_result = FeeResult::default();
+        ValidationOperation::add_many_to_fee_result(&ops, &mut fee_result, platform_version())
+            .unwrap();
+        assert!(fee_result.processing_fee > 0);
+    }
+
+    #[test]
+    fn add_many_retrieve_identity_revision_only() {
+        let ops = vec![ValidationOperation::RetrieveIdentity(
+            RetrieveIdentityInfo::only_revision(),
+        )];
+        let mut fee_result = FeeResult::default();
+        ValidationOperation::add_many_to_fee_result(&ops, &mut fee_result, platform_version())
+            .unwrap();
+        assert!(fee_result.processing_fee > 0);
+    }
+
+    #[test]
+    fn add_many_retrieve_identity_one_key_and_balance_and_revision() {
+        let ops = vec![ValidationOperation::RetrieveIdentity(
+            RetrieveIdentityInfo::one_key_and_balance_and_revision(),
+        )];
+        let mut fee_result = FeeResult::default();
+        ValidationOperation::add_many_to_fee_result(&ops, &mut fee_result, platform_version())
+            .unwrap();
+        assert!(fee_result.processing_fee > 0);
+    }
+
+    #[test]
+    fn add_many_retrieve_identity_no_balance_no_revision_no_keys() {
+        // Tests the (false, false) branch with 0 keys
+        let ops = vec![ValidationOperation::RetrieveIdentity(
+            RetrieveIdentityInfo {
+                query_by_key_id_key_count: 0,
+                request_balance: false,
+                request_revision: false,
+            },
+        )];
+        let mut fee_result = FeeResult::default();
+        ValidationOperation::add_many_to_fee_result(&ops, &mut fee_result, platform_version())
+            .unwrap();
+        // Base cost is 0 when both flags are false and no keys
+        assert_eq!(fee_result.processing_fee, 0);
+    }
+
+    #[test]
+    fn add_many_retrieve_prefunded_specialized_balance() {
+        let ops = vec![ValidationOperation::RetrievePrefundedSpecializedBalance];
+        let mut fee_result = FeeResult::default();
+        ValidationOperation::add_many_to_fee_result(&ops, &mut fee_result, platform_version())
+            .unwrap();
+        assert!(fee_result.processing_fee > 0);
+    }
+
+    #[test]
+    fn add_many_validate_key_structure() {
+        let ops = vec![ValidationOperation::ValidateKeyStructure(5)];
+        let mut fee_result = FeeResult::default();
+        ValidationOperation::add_many_to_fee_result(&ops, &mut fee_result, platform_version())
+            .unwrap();
+        let pv = platform_version();
+        let expected = pv.fee_version.processing.validate_key_structure * 5;
+        assert_eq!(fee_result.processing_fee, expected);
+    }
+
+    #[test]
+    fn add_many_protocol_operation() {
+        let ops = vec![ValidationOperation::Protocol(
+            ProtocolValidationOperation::DocumentTypeSchemaValidationForSize(100),
+        )];
+        let mut fee_result = FeeResult::default();
+        ValidationOperation::add_many_to_fee_result(&ops, &mut fee_result, platform_version())
+            .unwrap();
+        assert!(fee_result.processing_fee > 0);
+    }
+
+    #[test]
+    fn add_many_perform_network_threshold_signing() {
+        let ops = vec![ValidationOperation::PerformNetworkThresholdSigning];
+        let mut fee_result = FeeResult::default();
+        ValidationOperation::add_many_to_fee_result(&ops, &mut fee_result, platform_version())
+            .unwrap();
+        assert!(fee_result.processing_fee > 0);
+    }
+
+    #[test]
+    fn add_many_retrieve_identity_token_balance() {
+        let ops = vec![ValidationOperation::RetrieveIdentityTokenBalance];
+        let mut fee_result = FeeResult::default();
+        ValidationOperation::add_many_to_fee_result(&ops, &mut fee_result, platform_version())
+            .unwrap();
+        assert!(fee_result.processing_fee > 0);
+    }
+
+    #[test]
+    fn add_many_retrieve_address_nonce_and_balance() {
+        let ops = vec![ValidationOperation::RetrieveAddressNonceAndBalance(3)];
+        let mut fee_result = FeeResult::default();
+        ValidationOperation::add_many_to_fee_result(&ops, &mut fee_result, platform_version())
+            .unwrap();
+        let pv = platform_version();
+        let expected = pv
+            .fee_version
+            .processing
+            .fetch_key_with_type_nonce_and_balance_cost
+            * 3;
+        assert_eq!(fee_result.processing_fee, expected);
+    }
+
+    #[test]
+    fn add_many_multiple_operations_accumulate() {
+        let ops = vec![
+            ValidationOperation::SingleSha256(1),
+            ValidationOperation::SingleSha256(1),
+        ];
+        let mut fee_result = FeeResult::default();
+        ValidationOperation::add_many_to_fee_result(&ops, &mut fee_result, platform_version())
+            .unwrap();
+        let pv = platform_version();
+        let single =
+            pv.fee_version.hashing.single_sha256_base + pv.fee_version.hashing.sha256_per_block;
+        assert_eq!(fee_result.processing_fee, single * 2);
+    }
+}

--- a/packages/rs-drive-abci/src/execution/types/execution_operation/signature_verification_operation.rs
+++ b/packages/rs-drive-abci/src/execution/types/execution_operation/signature_verification_operation.rs
@@ -26,3 +26,56 @@ impl OperationLike for SignatureVerificationOperation {
         Ok(0)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use platform_version::version::PlatformVersion;
+
+    #[test]
+    fn new_creates_operation_with_correct_type() {
+        let op = SignatureVerificationOperation::new(KeyType::ECDSA_SECP256K1);
+        assert_eq!(op.signature_type, KeyType::ECDSA_SECP256K1);
+    }
+
+    #[test]
+    fn processing_cost_returns_nonzero_for_ecdsa() {
+        let op = SignatureVerificationOperation::new(KeyType::ECDSA_SECP256K1);
+        let cost = op.processing_cost(PlatformVersion::latest()).unwrap();
+        assert!(cost > 0, "ECDSA verification cost should be nonzero");
+    }
+
+    #[test]
+    fn processing_cost_returns_nonzero_for_bls() {
+        let op = SignatureVerificationOperation::new(KeyType::BLS12_381);
+        let cost = op.processing_cost(PlatformVersion::latest()).unwrap();
+        assert!(cost > 0, "BLS verification cost should be nonzero");
+    }
+
+    #[test]
+    fn processing_cost_returns_nonzero_for_eddsa() {
+        let op = SignatureVerificationOperation::new(KeyType::EDDSA_25519_HASH160);
+        let cost = op.processing_cost(PlatformVersion::latest()).unwrap();
+        assert!(cost > 0, "EDDSA verification cost should be nonzero");
+    }
+
+    #[test]
+    fn storage_cost_is_always_zero() {
+        let op = SignatureVerificationOperation::new(KeyType::ECDSA_SECP256K1);
+        let cost = op.storage_cost(PlatformVersion::latest()).unwrap();
+        assert_eq!(cost, 0);
+    }
+
+    #[test]
+    fn different_key_types_have_different_processing_costs() {
+        let pv = PlatformVersion::latest();
+        let ecdsa_cost = SignatureVerificationOperation::new(KeyType::ECDSA_SECP256K1)
+            .processing_cost(pv)
+            .unwrap();
+        let bls_cost = SignatureVerificationOperation::new(KeyType::BLS12_381)
+            .processing_cost(pv)
+            .unwrap();
+        // BLS verification is typically more expensive
+        assert_ne!(ecdsa_cost, bls_cost);
+    }
+}

--- a/packages/rs-drive-abci/src/execution/types/fees_in_pools/v0/mod.rs
+++ b/packages/rs-drive-abci/src/execution/types/fees_in_pools/v0/mod.rs
@@ -19,3 +19,70 @@ impl fmt::Display for FeesInPoolsV0 {
         write!(f, "}}")
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn display_formats_correctly() {
+        let fees = FeesInPoolsV0 {
+            processing_fees: 100,
+            storage_fees: 200,
+        };
+        let output = format!("{}", fees);
+        assert!(output.contains("processing_fees: 100"));
+        assert!(output.contains("storage_fees: 200"));
+        assert!(output.contains("FeesInPoolsV0"));
+    }
+
+    #[test]
+    fn display_with_zero_fees() {
+        let fees = FeesInPoolsV0 {
+            processing_fees: 0,
+            storage_fees: 0,
+        };
+        let output = format!("{}", fees);
+        assert!(output.contains("processing_fees: 0"));
+        assert!(output.contains("storage_fees: 0"));
+    }
+
+    #[test]
+    fn serialization_roundtrip() {
+        let fees = FeesInPoolsV0 {
+            processing_fees: 42,
+            storage_fees: 84,
+        };
+        let serialized = serde_json::to_string(&fees).unwrap();
+        let deserialized: FeesInPoolsV0 = serde_json::from_str(&serialized).unwrap();
+        assert_eq!(fees, deserialized);
+    }
+
+    #[test]
+    fn equality() {
+        let a = FeesInPoolsV0 {
+            processing_fees: 10,
+            storage_fees: 20,
+        };
+        let b = FeesInPoolsV0 {
+            processing_fees: 10,
+            storage_fees: 20,
+        };
+        let c = FeesInPoolsV0 {
+            processing_fees: 10,
+            storage_fees: 21,
+        };
+        assert_eq!(a, b);
+        assert_ne!(a, c);
+    }
+
+    #[test]
+    fn clone_produces_equal_value() {
+        let fees = FeesInPoolsV0 {
+            processing_fees: 999,
+            storage_fees: 888,
+        };
+        let cloned = fees;
+        assert_eq!(fees, cloned);
+    }
+}

--- a/packages/rs-drive-abci/src/execution/types/processed_block_fees_outcome/v0/mod.rs
+++ b/packages/rs-drive-abci/src/execution/types/processed_block_fees_outcome/v0/mod.rs
@@ -35,3 +35,45 @@ impl fmt::Display for ProcessedBlockFeesOutcome {
         write!(f, "}}")
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::execution::types::fees_in_pools::v0::FeesInPoolsV0;
+    use crate::execution::types::proposer_payouts::v0::ProposersPayouts;
+
+    #[test]
+    fn display_with_payouts_and_refunds() {
+        let outcome = ProcessedBlockFeesOutcome {
+            fees_in_pools: FeesInPoolsV0 {
+                processing_fees: 100,
+                storage_fees: 200,
+            },
+            payouts: Some(ProposersPayouts {
+                proposers_paid_count: 3,
+                paid_epoch_index: 5,
+            }),
+            refunded_epochs_count: Some(2),
+        };
+        let output = format!("{}", outcome);
+        assert!(output.contains("ProcessedBlockFeesOutcome"));
+        assert!(output.contains("fees_in_pools:"));
+        assert!(output.contains("proposers_paid_count: 3"));
+        assert!(output.contains("refunded_epochs_count: 2"));
+    }
+
+    #[test]
+    fn display_with_no_payouts_and_no_refunds() {
+        let outcome = ProcessedBlockFeesOutcome {
+            fees_in_pools: FeesInPoolsV0 {
+                processing_fees: 0,
+                storage_fees: 0,
+            },
+            payouts: None,
+            refunded_epochs_count: None,
+        };
+        let output = format!("{}", outcome);
+        assert!(output.contains("payouts: None"));
+        assert!(output.contains("refunded_epochs_count: None"));
+    }
+}

--- a/packages/rs-drive-abci/src/execution/types/proposer_payouts/v0/mod.rs
+++ b/packages/rs-drive-abci/src/execution/types/proposer_payouts/v0/mod.rs
@@ -23,3 +23,49 @@ impl fmt::Display for ProposersPayouts {
         write!(f, "}}")
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn display_formats_correctly() {
+        let payouts = ProposersPayouts {
+            proposers_paid_count: 5,
+            paid_epoch_index: 42,
+        };
+        let output = format!("{}", payouts);
+        assert!(output.contains("proposers_paid_count: 5"));
+        assert!(output.contains("paid_epoch_index: 42"));
+        assert!(output.contains("ProposersPayouts"));
+    }
+
+    #[test]
+    fn display_with_zero_values() {
+        let payouts = ProposersPayouts {
+            proposers_paid_count: 0,
+            paid_epoch_index: 0,
+        };
+        let output = format!("{}", payouts);
+        assert!(output.contains("proposers_paid_count: 0"));
+        assert!(output.contains("paid_epoch_index: 0"));
+    }
+
+    #[test]
+    fn equality() {
+        let a = ProposersPayouts {
+            proposers_paid_count: 3,
+            paid_epoch_index: 7,
+        };
+        let b = ProposersPayouts {
+            proposers_paid_count: 3,
+            paid_epoch_index: 7,
+        };
+        let c = ProposersPayouts {
+            proposers_paid_count: 4,
+            paid_epoch_index: 7,
+        };
+        assert_eq!(a, b);
+        assert_ne!(a, c);
+    }
+}

--- a/packages/rs-drive-abci/src/execution/types/state_transition_container/mod.rs
+++ b/packages/rs-drive-abci/src/execution/types/state_transition_container/mod.rs
@@ -40,3 +40,52 @@ impl<'a> Into<Vec<DecodedStateTransition<'a>>> for StateTransitionContainer<'a> 
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::execution::types::state_transition_container::v0::InvalidWithProtocolErrorStateTransition;
+    use dpp::ProtocolError;
+    use std::time::Duration;
+
+    fn make_test_st<'a>(raw: &'a [u8]) -> DecodedStateTransition<'a> {
+        DecodedStateTransition::FailedToDecode(InvalidWithProtocolErrorStateTransition {
+            raw,
+            error: ProtocolError::Generic("test".to_string()),
+            elapsed_time: Duration::from_millis(1),
+        })
+    }
+
+    #[test]
+    fn wrapper_ref_iterator() {
+        let raw = b"data";
+        let v0 = StateTransitionContainerV0::new(vec![make_test_st(raw)]);
+        let container: StateTransitionContainer = v0.into();
+        assert_eq!((&container).into_iter().count(), 1);
+    }
+
+    #[test]
+    fn wrapper_owned_iterator() {
+        let raw = b"data";
+        let v0 = StateTransitionContainerV0::new(vec![make_test_st(raw)]);
+        let container: StateTransitionContainer = v0.into();
+        assert_eq!(container.into_iter().count(), 1);
+    }
+
+    #[test]
+    fn wrapper_into_vec() {
+        let raw = b"data";
+        let v0 = StateTransitionContainerV0::new(vec![make_test_st(raw), make_test_st(raw)]);
+        let container: StateTransitionContainer = v0.into();
+        let vec: Vec<DecodedStateTransition> = container.into();
+        assert_eq!(vec.len(), 2);
+    }
+
+    #[test]
+    fn from_v0_conversion() {
+        let raw = b"data";
+        let v0 = StateTransitionContainerV0::new(vec![make_test_st(raw)]);
+        let container: StateTransitionContainer = v0.into();
+        assert!(matches!(container, StateTransitionContainer::V0(_)));
+    }
+}

--- a/packages/rs-drive-abci/src/execution/types/state_transition_container/v0/mod.rs
+++ b/packages/rs-drive-abci/src/execution/types/state_transition_container/v0/mod.rs
@@ -74,3 +74,105 @@ impl<'a> Into<Vec<DecodedStateTransition<'a>>> for StateTransitionContainerV0<'a
         self.state_transitions
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_test_st<'a>(raw: &'a [u8]) -> DecodedStateTransition<'a> {
+        // Use FailedToDecode variant since ProtocolError is easy to construct
+        DecodedStateTransition::FailedToDecode(InvalidWithProtocolErrorStateTransition {
+            raw,
+            error: ProtocolError::Generic("test".to_string()),
+            elapsed_time: Duration::from_millis(10),
+        })
+    }
+
+    #[test]
+    fn new_container_stores_transitions() {
+        let raw = b"test_data";
+        let transitions = vec![make_test_st(raw)];
+        let container = StateTransitionContainerV0::new(transitions);
+        let items: Vec<_> = container.into_iter().collect();
+        assert_eq!(items.len(), 1);
+    }
+
+    #[test]
+    fn ref_iterator_yields_references() {
+        let raw1 = b"data1";
+        let raw2 = b"data2";
+        let transitions = vec![make_test_st(raw1), make_test_st(raw2)];
+        let container = StateTransitionContainerV0::new(transitions);
+        let items: Vec<_> = (&container).into_iter().collect();
+        assert_eq!(items.len(), 2);
+    }
+
+    #[test]
+    fn owned_iterator_consumes_container() {
+        let raw = b"data";
+        let transitions = vec![make_test_st(raw)];
+        let container = StateTransitionContainerV0::new(transitions);
+        let items: Vec<_> = container.into_iter().collect();
+        assert_eq!(items.len(), 1);
+    }
+
+    #[test]
+    fn into_vec_conversion() {
+        let raw = b"data";
+        let transitions = vec![make_test_st(raw), make_test_st(raw)];
+        let container = StateTransitionContainerV0::new(transitions);
+        let vec: Vec<DecodedStateTransition> = container.into();
+        assert_eq!(vec.len(), 2);
+    }
+
+    #[test]
+    fn empty_container_iterates_zero_times() {
+        let container = StateTransitionContainerV0::new(vec![]);
+        assert_eq!((&container).into_iter().count(), 0);
+        assert_eq!(container.into_iter().count(), 0);
+    }
+
+    fn make_invalid_encoding_st<'a>(raw: &'a [u8]) -> DecodedStateTransition<'a> {
+        use dpp::consensus::basic::unsupported_version_error::UnsupportedVersionError;
+        use dpp::consensus::basic::BasicError;
+        DecodedStateTransition::InvalidEncoding(InvalidStateTransition {
+            raw,
+            error: ConsensusError::BasicError(BasicError::UnsupportedVersionError(
+                UnsupportedVersionError::new(99, 0, 1),
+            )),
+            elapsed_time: Duration::from_millis(5),
+        })
+    }
+
+    #[test]
+    fn invalid_encoding_variant() {
+        let raw = b"bad_data";
+        let st = make_invalid_encoding_st(raw);
+        let container = StateTransitionContainerV0::new(vec![st]);
+        let items: Vec<_> = container.into_iter().collect();
+        assert_eq!(items.len(), 1);
+        assert!(matches!(
+            items[0],
+            DecodedStateTransition::InvalidEncoding(_)
+        ));
+    }
+
+    #[test]
+    fn mixed_variants_in_container() {
+        let raw1 = b"good";
+        let raw2 = b"bad";
+        let st1 = make_test_st(raw1);
+        let st2 = make_invalid_encoding_st(raw2);
+        let container = StateTransitionContainerV0::new(vec![st1, st2]);
+        let items: Vec<_> = container.into_iter().collect();
+        assert_eq!(items.len(), 2);
+        assert!(matches!(
+            items[0],
+            DecodedStateTransition::FailedToDecode(_)
+        ));
+        assert!(matches!(
+            items[1],
+            DecodedStateTransition::InvalidEncoding(_)
+        ));
+    }
+}

--- a/packages/rs-drive-abci/src/execution/types/state_transition_execution_context/mod.rs
+++ b/packages/rs-drive-abci/src/execution/types/state_transition_execution_context/mod.rs
@@ -127,3 +127,107 @@ impl DefaultForPlatformVersion for StateTransitionExecutionContext {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::execution::types::execution_operation::signature_verification_operation::SignatureVerificationOperation;
+    use crate::execution::types::execution_operation::RetrieveIdentityInfo;
+    use dpp::identity::KeyType;
+    use dpp::validation::operations::ProtocolValidationOperation;
+    use dpp::version::DefaultForPlatformVersion;
+
+    fn make_context() -> StateTransitionExecutionContext {
+        StateTransitionExecutionContext::default_for_platform_version(PlatformVersion::latest())
+            .unwrap()
+    }
+
+    #[test]
+    fn default_context_starts_with_no_operations() {
+        let ctx = make_context();
+        assert!(ctx.operations_slice().is_empty());
+    }
+
+    #[test]
+    fn default_context_not_in_dry_run() {
+        let ctx = make_context();
+        assert!(!ctx.in_dry_run());
+    }
+
+    #[test]
+    fn enable_disable_dry_run() {
+        let mut ctx = make_context();
+        ctx.enable_dry_run();
+        assert!(ctx.in_dry_run());
+        ctx.disable_dry_run();
+        assert!(!ctx.in_dry_run());
+    }
+
+    #[test]
+    fn add_operation_increases_count() {
+        let mut ctx = make_context();
+        ctx.add_operation(ValidationOperation::SingleSha256(1));
+        assert_eq!(ctx.operations_slice().len(), 1);
+    }
+
+    #[test]
+    fn add_operations_batch() {
+        let mut ctx = make_context();
+        ctx.add_operations(vec![
+            ValidationOperation::SingleSha256(1),
+            ValidationOperation::DoubleSha256(2),
+        ]);
+        assert_eq!(ctx.operations_slice().len(), 2);
+    }
+
+    #[test]
+    fn add_dpp_operations_wraps_in_protocol() {
+        let mut ctx = make_context();
+        ctx.add_dpp_operations(vec![
+            ProtocolValidationOperation::DocumentTypeSchemaValidationForSize(50),
+        ]);
+        assert_eq!(ctx.operations_slice().len(), 1);
+        assert!(matches!(
+            ctx.operations_slice()[0],
+            ValidationOperation::Protocol(_)
+        ));
+    }
+
+    #[test]
+    fn operations_consume_returns_all_operations() {
+        let mut ctx = make_context();
+        ctx.add_operation(ValidationOperation::Ripemd160(1));
+        ctx.add_operation(ValidationOperation::SingleSha256(2));
+        let ops = ctx.operations_consume();
+        assert_eq!(ops.len(), 2);
+    }
+
+    #[test]
+    fn fee_cost_empty_context_returns_zero() {
+        let ctx = make_context();
+        let fee = ctx.fee_cost(PlatformVersion::latest()).unwrap();
+        assert_eq!(fee.processing_fee, 0);
+        assert_eq!(fee.storage_fee, 0);
+    }
+
+    #[test]
+    fn fee_cost_with_operations_returns_nonzero() {
+        let mut ctx = make_context();
+        ctx.add_operation(ValidationOperation::SignatureVerification(
+            SignatureVerificationOperation::new(KeyType::ECDSA_SECP256K1),
+        ));
+        ctx.add_operation(ValidationOperation::RetrieveIdentity(
+            RetrieveIdentityInfo::only_balance(),
+        ));
+        let fee = ctx.fee_cost(PlatformVersion::latest()).unwrap();
+        assert!(fee.processing_fee > 0);
+    }
+
+    #[test]
+    fn from_v0_conversion() {
+        let v0 = StateTransitionExecutionContextV0::default();
+        let ctx: StateTransitionExecutionContext = v0.into();
+        assert!(!ctx.in_dry_run());
+        assert!(ctx.operations_slice().is_empty());
+    }
+}

--- a/packages/rs-drive-abci/src/execution/types/unpaid_epoch/mod.rs
+++ b/packages/rs-drive-abci/src/execution/types/unpaid_epoch/mod.rs
@@ -139,3 +139,74 @@ impl UnpaidEpochV0Setters for UnpaidEpoch {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::execution::types::unpaid_epoch::v0::UnpaidEpochV0;
+
+    fn make_unpaid_epoch() -> UnpaidEpoch {
+        UnpaidEpoch::V0(UnpaidEpochV0 {
+            epoch_index: 3,
+            next_unpaid_epoch_index: 4,
+            epoch_start_time: 500_000,
+            start_block_height: 50,
+            next_epoch_start_block_height: 150,
+            start_block_core_height: 25,
+            next_epoch_start_block_core_height: 35,
+            protocol_version: 1,
+            fee_multiplier: 100,
+        })
+    }
+
+    #[test]
+    fn wrapper_getters_delegate_correctly() {
+        let epoch = make_unpaid_epoch();
+        assert_eq!(epoch.epoch_index(), 3);
+        assert_eq!(epoch.next_unpaid_epoch_index(), 4);
+        assert_eq!(epoch.epoch_start_time(), 500_000);
+        assert_eq!(epoch.start_block_height(), 50);
+        assert_eq!(epoch.next_epoch_start_block_height(), 150);
+        assert_eq!(epoch.start_block_core_height(), 25);
+        assert_eq!(epoch.next_epoch_start_block_core_height(), 35);
+        assert_eq!(epoch.protocol_version(), 1);
+        assert_eq!(epoch.fee_multiplier(), 100);
+    }
+
+    #[test]
+    fn wrapper_setters_delegate_correctly() {
+        let mut epoch = make_unpaid_epoch();
+        epoch.set_epoch_index(10);
+        epoch.set_next_unpaid_epoch_index(11);
+        epoch.set_epoch_start_time(999);
+        epoch.set_start_block_height(1000);
+        epoch.set_next_epoch_start_block_height(2000);
+        epoch.set_start_block_core_height(80);
+        epoch.set_next_epoch_start_block_core_height(90);
+        epoch.set_protocol_version(5);
+        epoch.set_fee_multiplier(300);
+
+        assert_eq!(epoch.epoch_index(), 10);
+        assert_eq!(epoch.next_unpaid_epoch_index(), 11);
+        assert_eq!(epoch.epoch_start_time(), 999);
+        assert_eq!(epoch.start_block_height(), 1000);
+        assert_eq!(epoch.next_epoch_start_block_height(), 2000);
+        assert_eq!(epoch.start_block_core_height(), 80);
+        assert_eq!(epoch.next_epoch_start_block_core_height(), 90);
+        assert_eq!(epoch.protocol_version(), 5);
+        assert_eq!(epoch.fee_multiplier(), 300);
+    }
+
+    #[test]
+    fn wrapper_block_count_delegates_correctly() {
+        let epoch = make_unpaid_epoch();
+        assert_eq!(epoch.block_count().unwrap(), 100);
+    }
+
+    #[test]
+    fn from_v0_conversion() {
+        let v0 = UnpaidEpochV0::default();
+        let epoch: UnpaidEpoch = v0.into();
+        assert_eq!(epoch.epoch_index(), 0);
+    }
+}

--- a/packages/rs-drive-abci/src/execution/types/unpaid_epoch/v0/mod.rs
+++ b/packages/rs-drive-abci/src/execution/types/unpaid_epoch/v0/mod.rs
@@ -173,3 +173,97 @@ impl UnpaidEpochV0Setters for UnpaidEpochV0 {
         self.fee_multiplier = fee_multiplier;
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_unpaid_epoch() -> UnpaidEpochV0 {
+        UnpaidEpochV0 {
+            epoch_index: 5,
+            next_unpaid_epoch_index: 6,
+            epoch_start_time: 1_000_000,
+            start_block_height: 100,
+            next_epoch_start_block_height: 200,
+            start_block_core_height: 50,
+            next_epoch_start_block_core_height: 60,
+            protocol_version: 1,
+            fee_multiplier: 150,
+        }
+    }
+
+    #[test]
+    fn getters_return_correct_values() {
+        let epoch = make_unpaid_epoch();
+        assert_eq!(epoch.epoch_index(), 5);
+        assert_eq!(epoch.next_unpaid_epoch_index(), 6);
+        assert_eq!(epoch.epoch_start_time(), 1_000_000);
+        assert_eq!(epoch.start_block_height(), 100);
+        assert_eq!(epoch.next_epoch_start_block_height(), 200);
+        assert_eq!(epoch.start_block_core_height(), 50);
+        assert_eq!(epoch.next_epoch_start_block_core_height(), 60);
+        assert_eq!(epoch.protocol_version(), 1);
+        assert_eq!(epoch.fee_multiplier(), 150);
+    }
+
+    #[test]
+    fn setters_update_all_fields() {
+        let mut epoch = UnpaidEpochV0::default();
+        epoch.set_epoch_index(10);
+        epoch.set_next_unpaid_epoch_index(11);
+        epoch.set_epoch_start_time(2_000_000);
+        epoch.set_start_block_height(500);
+        epoch.set_next_epoch_start_block_height(600);
+        epoch.set_start_block_core_height(100);
+        epoch.set_next_epoch_start_block_core_height(110);
+        epoch.set_protocol_version(2);
+        epoch.set_fee_multiplier(200);
+
+        assert_eq!(epoch.epoch_index(), 10);
+        assert_eq!(epoch.next_unpaid_epoch_index(), 11);
+        assert_eq!(epoch.epoch_start_time(), 2_000_000);
+        assert_eq!(epoch.start_block_height(), 500);
+        assert_eq!(epoch.next_epoch_start_block_height(), 600);
+        assert_eq!(epoch.start_block_core_height(), 100);
+        assert_eq!(epoch.next_epoch_start_block_core_height(), 110);
+        assert_eq!(epoch.protocol_version(), 2);
+        assert_eq!(epoch.fee_multiplier(), 200);
+    }
+
+    #[test]
+    fn block_count_returns_difference() {
+        let epoch = make_unpaid_epoch();
+        // next_epoch_start_block_height(200) - start_block_height(100) = 100
+        assert_eq!(epoch.block_count().unwrap(), 100);
+    }
+
+    #[test]
+    fn block_count_returns_zero_for_same_heights() {
+        let mut epoch = make_unpaid_epoch();
+        epoch.set_start_block_height(100);
+        epoch.set_next_epoch_start_block_height(100);
+        assert_eq!(epoch.block_count().unwrap(), 0);
+    }
+
+    #[test]
+    fn block_count_returns_error_on_underflow() {
+        let mut epoch = make_unpaid_epoch();
+        epoch.set_start_block_height(200);
+        epoch.set_next_epoch_start_block_height(100);
+        assert!(epoch.block_count().is_err());
+    }
+
+    #[test]
+    fn default_values_are_zero() {
+        let epoch = UnpaidEpochV0::default();
+        assert_eq!(epoch.epoch_index(), 0);
+        assert_eq!(epoch.next_unpaid_epoch_index(), 0);
+        assert_eq!(epoch.epoch_start_time(), 0);
+        assert_eq!(epoch.start_block_height(), 0);
+        assert_eq!(epoch.next_epoch_start_block_height(), 0);
+        assert_eq!(epoch.start_block_core_height(), 0);
+        assert_eq!(epoch.next_epoch_start_block_core_height(), 0);
+        assert_eq!(epoch.protocol_version(), 0);
+        assert_eq!(epoch.fee_multiplier(), 0);
+    }
+}

--- a/packages/rs-drive-abci/src/execution/types/update_state_masternode_list_outcome/v0/mod.rs
+++ b/packages/rs-drive-abci/src/execution/types/update_state_masternode_list_outcome/v0/mod.rs
@@ -24,3 +24,24 @@ impl Default for UpdateStateMasternodeListOutcome {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_has_zero_heights() {
+        let outcome = UpdateStateMasternodeListOutcome::default();
+        assert_eq!(outcome.masternode_list_diff.base_height, 0);
+        assert_eq!(outcome.masternode_list_diff.block_height, 0);
+    }
+
+    #[test]
+    fn default_has_empty_lists() {
+        let outcome = UpdateStateMasternodeListOutcome::default();
+        assert!(outcome.masternode_list_diff.added_mns.is_empty());
+        assert!(outcome.masternode_list_diff.removed_mns.is_empty());
+        assert!(outcome.masternode_list_diff.updated_mns.is_empty());
+        assert!(outcome.removed_masternodes.is_empty());
+    }
+}


### PR DESCRIPTION
## Issue being fixed or feature implemented

Improve unit test coverage for the `packages/rs-drive-abci/src/execution/types/` module, which previously had no tests at all.

## What was done?

Added 115 unit tests across 15 files in the `execution/types` module:

- **block_fees** (v0 + wrapper): getters, setters, `from_fees`, `From<FeeResult>`, serialization roundtrip
- **block_state_info** (v0 + wrapper): getters, setters, `to_block_info`, `next_block_to` (sequential/non-sequential/core height regression), `matches_current_block` (match/mismatch/no hash/bad size), `matches_expected_block_info` (full match/wrong fields/missing hashes/bad sizes), `from_block_proposal`
- **execution_operation**: all 6 `RetrieveIdentityInfo` constructors, `add_many_to_fee_result` covering all 13 `ValidationOperation` variants (signature verification, precalculated, SHA256, double SHA256, RIPEMD160, identity retrieval with all 4 balance/revision flag combos, prefunded balance, key validation, protocol validation, network threshold signing, token balance, address nonce, accumulation)
- **signature_verification_operation**: processing cost for ECDSA/BLS/EDDSA, storage cost always zero, different key types yield different costs
- **state_transition_execution_context**: add single/batch/dpp operations, dry run enable/disable, operations_consume, fee_cost, default_for_platform_version
- **unpaid_epoch** (v0 + wrapper): all getters, all setters, block_count (normal/zero/underflow error), default values
- **fees_in_pools**: Display formatting, serialization, equality, Copy
- **proposer_payouts**: Display formatting, equality
- **processed_block_fees_outcome**: Display with/without payouts and refunds
- **state_transition_container** (v0 + wrapper): ref/owned iterators, Into<Vec>, empty container, InvalidEncoding/FailedToDecode variants, mixed variants
- **update_state_masternode_list_outcome**: Default impl produces zero heights and empty lists

## How Has This Been Tested?

All 115 tests pass locally via `cargo test -p drive-abci --lib execution::types::` in under 1 second. Tests are pure unit tests with no I/O, database, or network dependencies.

## Breaking Changes

None. This PR only adds `#[cfg(test)]` modules.

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [x] I have made corresponding changes to the documentation if needed