### PR TITLE
fix(drive-abci): guard purpose cast overflow in identities_contract_keys query

### DIFF
--- a/packages/rs-drive-abci/src/query/identity_based_queries/identities_contract_keys/v0/mod.rs
+++ b/packages/rs-drive-abci/src/query/identity_based_queries/identities_contract_keys/v0/mod.rs
@@ -55,14 +55,19 @@ impl<C> Platform<C> {
 
         let purposes = check_validation_result_with_data!(purposes
             .into_iter()
-            .map(
-                |purpose| Purpose::try_from(purpose as u8).map_err(|_| QueryError::Query(
-                    QuerySyntaxError::InvalidKeyParameter(format!(
+            .map(|purpose| {
+                if purpose < 0 || purpose > u8::MAX as i32 {
+                    return Err(QueryError::Query(QuerySyntaxError::InvalidKeyParameter(
+                        "purpose out of bounds".to_string(),
+                    )));
+                }
+                Purpose::try_from(purpose as u8).map_err(|_| {
+                    QueryError::Query(QuerySyntaxError::InvalidKeyParameter(format!(
                         "purpose {} not recognized",
                         purpose
-                    ))
-                ))
-            )
+                    )))
+                })
+            })
             .collect::<Result<Vec<Purpose>, QueryError>>());
 
         let response = if prove {


### PR DESCRIPTION
## Summary
- Add bounds check before casting `purpose` from `i32` to `u8` in `identities_contract_keys` query
- Without this check, values >= 256 silently wrap (e.g., 256 becomes 0, which is a valid `Purpose::AUTHENTICATION`)
- Negative values also silently wrap
- Now returns `InvalidKeyParameter("purpose out of bounds")` for out-of-range values
- Found during test coverage work in PR #3271

## Test plan
- [ ] Verify `purpose: 256` returns error instead of silently wrapping to 0
- [ ] Verify `purpose: -1` returns error

🤖 Generated with [Claude Code](https://claude.com/claude-code)