### PR TITLE
ci: fix codecov upload using CLI do-upload command

### DIFF
--- a/.github/workflows/tests-rs-workspace.yml
+++ b/.github/workflows/tests-rs-workspace.yml
@@ -163,21 +163,20 @@ jobs:
           CARGO_PROFILE_DEV_DEBUG: "0"
           CARGO_PROFILE_DEV_CODEGEN_UNITS: "256"
 
-      - name: Reset GPG state (fix stale keyboxd locks on self-hosted runners)
-        if: always()
-        run: |
-          gpgconf --kill all 2>/dev/null || true
-          rm -rf ~/.gnupg/public-keys.d/*.lock 2>/dev/null || true
-          rm -rf ~/.gnupg/.#* 2>/dev/null || true
-
       - name: Upload coverage
         if: always()
-        uses: codecov/codecov-action@v5
-        with:
-          files: lcov.info
-          flags: rust-mac
-          token: ${{ secrets.CODECOV_TOKEN }}
-          fail_ci_if_error: false
+        run: |
+          curl -Os https://cli.codecov.io/latest/macos/codecov
+          chmod +x codecov
+          ./codecov do-upload \
+            --token "$CODECOV_TOKEN" \
+            --git-service github \
+            --file lcov.info \
+            --flag rust-mac \
+            --branch "${{ github.ref_name }}" \
+            --sha "${{ github.sha }}" || true
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
       - name: Run doctests
         if: ${{ inputs.doctests-changed }}


### PR DESCRIPTION
## Summary
- Replace `codecov/codecov-action@v5` with direct CLI `do-upload` command
- The action uses the legacy `upload-coverage` command with CLI v11, which doesn't properly create reports (shows "Missing Head Report" on Codecov)
- `do-upload` is the correct command for CLI v11+ and properly processes lcov reports
- Removes the GPG workaround since we no longer use the action (which needed GPG for signature verification)

## Test plan
- [ ] Verify Codecov shows coverage data after merge to v3.1-dev
- [ ] Verify badge shows percentage instead of "unknown"

🤖 Generated with [Claude Code](https://claude.com/claude-code)