### PR TITLE
ci: restore GPG cleanup step before Codecov upload

### DIFF
--- a/.github/workflows/tests-rs-workspace.yml
+++ b/.github/workflows/tests-rs-workspace.yml
@@ -163,6 +163,13 @@ jobs:
           CARGO_PROFILE_DEV_DEBUG: "0"
           CARGO_PROFILE_DEV_CODEGEN_UNITS: "256"
 
+      - name: Reset GPG state (fix stale keyboxd locks on self-hosted runners)
+        if: always()
+        run: |
+          gpgconf --kill all 2>/dev/null || true
+          rm -rf ~/.gnupg/public-keys.d/*.lock 2>/dev/null || true
+          rm -rf ~/.gnupg/.#* 2>/dev/null || true
+
       - name: Upload coverage
         if: always()
         uses: codecov/codecov-action@v5


### PR DESCRIPTION
## Summary
- Restore the GPG cleanup step that was reverted in #3278
- The GPG cleanup wasn't the cause of the Codecov "Missing Head Report" issue
- Self-hosted runners still need stale keyboxd locks cleaned up

## Test plan
- [ ] Verify GPG errors don't appear in Codecov upload step

🤖 Generated with [Claude Code](https://claude.com/claude-code)