### PR TITLE
ci: add codecov carryforward flag for shielded tests

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,6 +1,12 @@
 codecov:
   require_ci_to_pass: true
 
+flags:
+  rust:
+    carryforward: false
+  rust-shielded:
+    carryforward: true
+
 ignore:
   - "**/test_utils.rs"
   - "**/test_utils/**"

--- a/.github/workflows/tests-rs-workspace.yml
+++ b/.github/workflows/tests-rs-workspace.yml
@@ -175,7 +175,7 @@ jobs:
         uses: codecov/codecov-action@v5
         with:
           files: lcov.info
-          flags: rust-mac
+          flags: rust
           token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: false
 
@@ -527,6 +527,8 @@ jobs:
 
       - name: Setup Rust
         uses: ./.github/actions/rust
+        with:
+          components: llvm-tools
 
       - name: Setup sccache
         uses: ./.github/actions/sccache
@@ -541,16 +543,18 @@ jobs:
         uses: ./.github/actions/librocksdb
 
       - uses: taiki-e/install-action@cargo-nextest
+      - uses: taiki-e/install-action@cargo-llvm-cov
 
-      - name: Run ZK / Shielded tests
+      - name: Run ZK / Shielded tests with coverage
         run: |
-          cargo nextest run \
+          cargo llvm-cov nextest \
             --package dpp \
             --package drive-abci \
             --package drive \
             --all-features \
             --locked \
-            -E 'test(/shield/)'
+            -E 'test(/shield/)' \
+            --lcov --output-path lcov-shielded.info
         env:
           RUST_MIN_STACK: 4194304
           CARGO_INCREMENTAL: "0"
@@ -561,3 +565,12 @@ jobs:
           ROCKSDB_LIB_DIR: "/opt/rocksdb/usr/local/lib"
           SNAPPY_STATIC: "/usr/lib/x86_64-linux-gnu/libsnappy.a"
           SNAPPY_LIB_DIR: "/usr/lib/x86_64-linux-gnu"
+
+      - name: Upload shielded coverage
+        if: always()
+        uses: codecov/codecov-action@v5
+        with:
+          files: lcov-shielded.info
+          flags: rust-shielded
+          token: ${{ secrets.CODECOV_TOKEN }}
+          fail_ci_if_error: false


### PR DESCRIPTION
## Summary
- Add two Codecov flags in `.codecov.yml`:
  - `rust` — main test coverage (always runs, no carryforward)
  - `rust-shielded` — ZK/shielded test coverage (`carryforward: true`)
- When a PR doesn't trigger ZK tests, Codecov carries forward the last known shielded coverage instead of treating it as zero
- Fixes misleading negative coverage diffs on PRs that don't touch shielded code
- Adds `cargo-llvm-cov` instrumentation to the ZK tests job with `rust-shielded` flag upload

## Test plan
- [ ] Verify PR coverage diffs no longer show negative from missing shielded coverage
- [ ] Verify ZK tests upload coverage with `rust-shielded` flag when they run
- [ ] Verify carryforward works when ZK tests don't run

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Enhanced code coverage reporting infrastructure with updated CI/CD pipeline configuration.
  * Improved test coverage tracking for Rust workspace components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->