### PR TITLE
fix(rs-sdk-ffi): prevent heap corruption from Vec capacity mismatch in FFI

### DIFF
--- a/packages/rs-sdk-ffi/src/dpns/queries/contested.rs
+++ b/packages/rs-sdk-ffi/src/dpns/queries/contested.rs
@@ -331,12 +331,19 @@ pub unsafe extern "C" fn dash_sdk_dpns_get_current_contests(
                 });
             }
 
+            let count = entries.len();
+            let entries_ptr = if entries.is_empty() {
+                std::ptr::null_mut()
+            } else {
+                let boxed = entries.into_boxed_slice();
+                Box::into_raw(boxed) as *mut DashSDKNameTimestamp
+            };
+
             let list = Box::new(DashSDKNameTimestampList {
-                entries: entries.as_mut_ptr(),
-                count: entries.len(),
+                entries: entries_ptr,
+                count,
             });
 
-            std::mem::forget(entries); // Prevent deallocation
             Box::into_raw(list)
         }
         Err(_) => std::ptr::null_mut(),
@@ -511,16 +518,22 @@ pub unsafe extern "C" fn dash_sdk_dpns_get_non_resolved_contests_for_identity(
                     });
                 }
 
+                let contender_count = contenders.len();
+                let contenders_ptr = if contenders.is_empty() {
+                    std::ptr::null_mut()
+                } else {
+                    let boxed = contenders.into_boxed_slice();
+                    Box::into_raw(boxed) as *mut DashSDKContender
+                };
+
                 let contest_info_c = DashSDKContestInfo {
-                    contenders: contenders.as_mut_ptr(),
-                    contender_count: contenders.len(),
+                    contenders: contenders_ptr,
+                    contender_count,
                     abstain_votes: contest_info.contenders.abstain_vote_tally.unwrap_or(0),
                     lock_votes: contest_info.contenders.lock_vote_tally.unwrap_or(0),
                     end_time: contest_info.end_time,
                     has_winner: contest_info.contenders.winner.is_some(),
                 };
-
-                std::mem::forget(contenders); // Prevent deallocation
 
                 names.push(DashSDKContestedName {
                     name: c_name,
@@ -528,12 +541,19 @@ pub unsafe extern "C" fn dash_sdk_dpns_get_non_resolved_contests_for_identity(
                 });
             }
 
+            let names_count = names.len();
+            let names_ptr = if names.is_empty() {
+                std::ptr::null_mut()
+            } else {
+                let boxed = names.into_boxed_slice();
+                Box::into_raw(boxed) as *mut DashSDKContestedName
+            };
+
             let list = Box::new(DashSDKContestedNamesList {
-                names: names.as_mut_ptr(),
-                count: names.len(),
+                names: names_ptr,
+                count: names_count,
             });
 
-            std::mem::forget(names); // Prevent deallocation
             Box::into_raw(list)
         }
         Err(_) => std::ptr::null_mut(),
@@ -597,16 +617,22 @@ pub unsafe extern "C" fn dash_sdk_dpns_get_contested_non_resolved_usernames(
                     });
                 }
 
+                let contender_count = contenders.len();
+                let contenders_ptr = if contenders.is_empty() {
+                    std::ptr::null_mut()
+                } else {
+                    let boxed = contenders.into_boxed_slice();
+                    Box::into_raw(boxed) as *mut DashSDKContender
+                };
+
                 let contest_info_c = DashSDKContestInfo {
-                    contenders: contenders.as_mut_ptr(),
-                    contender_count: contenders.len(),
+                    contenders: contenders_ptr,
+                    contender_count,
                     abstain_votes: contest_info.contenders.abstain_vote_tally.unwrap_or(0),
                     lock_votes: contest_info.contenders.lock_vote_tally.unwrap_or(0),
                     end_time: contest_info.end_time,
                     has_winner: contest_info.contenders.winner.is_some(),
                 };
-
-                std::mem::forget(contenders); // Prevent deallocation
 
                 names.push(DashSDKContestedName {
                     name: c_name,
@@ -614,12 +640,19 @@ pub unsafe extern "C" fn dash_sdk_dpns_get_contested_non_resolved_usernames(
                 });
             }
 
+            let names_count = names.len();
+            let names_ptr = if names.is_empty() {
+                std::ptr::null_mut()
+            } else {
+                let boxed = names.into_boxed_slice();
+                Box::into_raw(boxed) as *mut DashSDKContestedName
+            };
+
             let list = Box::new(DashSDKContestedNamesList {
-                names: names.as_mut_ptr(),
-                count: names.len(),
+                names: names_ptr,
+                count: names_count,
             });
 
-            std::mem::forget(names); // Prevent deallocation
             Box::into_raw(list)
         }
         Err(_) => std::ptr::null_mut(),

--- a/packages/rs-sdk-ffi/src/identity/create_from_addresses.rs
+++ b/packages/rs-sdk-ffi/src/identity/create_from_addresses.rs
@@ -245,10 +245,9 @@ unsafe fn dash_sdk_identity_create_from_addresses_inner(
             let entries: Vec<DashSDKAddressInfoEntry> = address_infos
                 .iter()
                 .map(|(address, info_opt)| {
-                    let address_bytes = address.to_bytes();
+                    let address_bytes = address.to_bytes().into_boxed_slice();
                     let address_len = address_bytes.len();
-                    let address_ptr = address_bytes.as_ptr() as *mut u8;
-                    std::mem::forget(address_bytes);
+                    let address_ptr = Box::into_raw(address_bytes) as *mut u8;
 
                     // Handle Option<AddressInfo>
                     let (nonce, balance) = match info_opt {

--- a/packages/rs-sdk-ffi/src/identity/keys.rs
+++ b/packages/rs-sdk-ffi/src/identity/keys.rs
@@ -297,9 +297,9 @@ pub unsafe extern "C" fn dash_sdk_identity_public_key_to_bytes(
     let config = bincode::config::standard();
     match bincode::encode_to_vec(key, config) {
         Ok(bytes) => {
-            let len = bytes.len();
-            let ptr = bytes.as_ptr() as *mut u8;
-            std::mem::forget(bytes); // Prevent deallocation
+            let boxed = bytes.into_boxed_slice();
+            let len = boxed.len();
+            let ptr = Box::into_raw(boxed) as *mut u8;
             *out_bytes = ptr;
             *out_len = len;
             DashSDKResult::success(std::ptr::null_mut())

--- a/packages/rs-sdk-ffi/src/identity/queries/identities_balances.rs
+++ b/packages/rs-sdk-ffi/src/identity/queries/identities_balances.rs
@@ -90,8 +90,12 @@ pub unsafe extern "C" fn dash_sdk_identities_fetch_balances(
         }
 
         let count = entries.len();
-        let entries_ptr = entries.as_mut_ptr();
-        std::mem::forget(entries); // Prevent deallocation
+        let entries_ptr = if entries.is_empty() {
+            std::ptr::null_mut()
+        } else {
+            let boxed = entries.into_boxed_slice();
+            Box::into_raw(boxed) as *mut DashSDKIdentityBalanceEntry
+        };
 
         Ok(DashSDKIdentityBalanceMap {
             entries: entries_ptr,

--- a/packages/rs-sdk-ffi/src/identity/top_up_from_addresses.rs
+++ b/packages/rs-sdk-ffi/src/identity/top_up_from_addresses.rs
@@ -181,10 +181,9 @@ unsafe fn dash_sdk_identity_top_up_from_addresses_inner(
             let entries: Vec<DashSDKAddressInfoEntry> = address_infos
                 .iter()
                 .map(|(address, info_opt)| {
-                    let address_bytes = address.to_bytes();
+                    let address_bytes = address.to_bytes().into_boxed_slice();
                     let address_len = address_bytes.len();
-                    let address_ptr = address_bytes.as_ptr() as *mut u8;
-                    std::mem::forget(address_bytes);
+                    let address_ptr = Box::into_raw(address_bytes) as *mut u8;
 
                     // Handle Option<AddressInfo>
                     let (nonce, balance) = match info_opt {

--- a/packages/rs-sdk-ffi/src/identity/transfer_to_addresses.rs
+++ b/packages/rs-sdk-ffi/src/identity/transfer_to_addresses.rs
@@ -195,10 +195,9 @@ unsafe fn dash_sdk_identity_transfer_credits_to_addresses_inner(
             let entries: Vec<DashSDKAddressInfoEntry> = address_infos
                 .iter()
                 .map(|(address, info_opt)| {
-                    let address_bytes = address.to_bytes();
+                    let address_bytes = address.to_bytes().into_boxed_slice();
                     let address_len = address_bytes.len();
-                    let address_ptr = address_bytes.as_ptr() as *mut u8;
-                    std::mem::forget(address_bytes);
+                    let address_ptr = Box::into_raw(address_bytes) as *mut u8;
 
                     // Handle Option<AddressInfo>
                     let (nonce, balance) = match info_opt {

--- a/packages/rs-sdk-ffi/src/types.rs
+++ b/packages/rs-sdk-ffi/src/types.rs
@@ -1165,3 +1165,112 @@ pub unsafe extern "C" fn dash_sdk_name_timestamp_list_free(list: *mut DashSDKNam
         let _ = Vec::from_raw_parts(list.entries, list.count, list.count);
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Proves that `DashSDKResult::success_binary` discards Vec capacity,
+    /// which causes `dash_sdk_binary_data_free` to reconstruct the Vec with
+    /// `len` used as `capacity`. When the original Vec had capacity > len,
+    /// the free function passes the wrong size to the allocator -- this is
+    /// undefined behavior per the `GlobalAlloc::dealloc` contract.
+    ///
+    /// This test does NOT invoke the buggy free path (doing so would be
+    /// actual UB). Instead it demonstrates that the capacity information is
+    /// irrecoverably lost during the `success_binary` roundtrip.
+    #[test]
+    fn test_success_binary_loses_vec_capacity() {
+        // 1. Create a Vec with more capacity than length.
+        let mut vec: Vec<u8> = Vec::with_capacity(100);
+        vec.extend_from_slice(&[1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+
+        let original_len = vec.len(); // 10
+        let original_capacity = vec.capacity(); // >= 100
+
+        assert_eq!(original_len, 10);
+        assert!(
+            original_capacity >= 100,
+            "Vec::with_capacity(100) should have capacity >= 100, got {}",
+            original_capacity
+        );
+        assert!(
+            original_capacity > original_len,
+            "capacity ({}) must be greater than len ({}) for this test to be meaningful",
+            original_capacity,
+            original_len
+        );
+
+        // 2. Pass through success_binary -- this calls `data.as_ptr()`,
+        //    captures `data.len()`, then `mem::forget(data)`.
+        //    The capacity is never stored anywhere.
+        let result = DashSDKResult::success_binary(vec);
+
+        // 3. The result should contain binary data.
+        assert_eq!(result.data_type, DashSDKResultDataType::BinaryData);
+        assert!(!result.data.is_null());
+
+        // 4. Extract the DashSDKBinaryData to inspect what was stored.
+        let binary_data = unsafe { &*(result.data as *const DashSDKBinaryData) };
+
+        // 5. Prove the mismatch: DashSDKBinaryData only has `len`, which
+        //    equals the original Vec's length -- NOT its capacity.
+        assert_eq!(
+            binary_data.len, original_len,
+            "DashSDKBinaryData.len should equal the original Vec length"
+        );
+
+        // 6. The struct has no capacity field. If dash_sdk_binary_data_free
+        //    were called, it would do:
+        //
+        //      Vec::from_raw_parts(data.data, data.len, data.len)
+        //                                              ^^^^^^^^
+        //                                       capacity = len = 10
+        //
+        //    But the actual allocation was for capacity >= 100. The allocator
+        //    would be asked to deallocate 10 bytes from an allocation that
+        //    was originally 100+ bytes -- undefined behavior.
+        assert!(
+            binary_data.len < original_capacity,
+            "BUG CONFIRMED: DashSDKBinaryData.len ({}) < original capacity ({}). \
+             The free function will reconstruct Vec with capacity={} but the \
+             allocator originally allocated {} bytes. This is UB on dealloc.",
+            binary_data.len,
+            original_capacity,
+            binary_data.len,
+            original_capacity
+        );
+
+        // 7. Clean up safely: we reconstruct the Vec with the CORRECT
+        //    capacity to avoid triggering the very UB we are proving exists.
+        //    This is the key insight -- only we (the test) know the true
+        //    capacity. The FFI consumer would not.
+        unsafe {
+            let binary_data = Box::from_raw(result.data as *mut DashSDKBinaryData);
+            let _ = Vec::from_raw_parts(binary_data.data, binary_data.len, original_capacity);
+        }
+    }
+
+    /// Proves that DashSDKBinaryData has no capacity field, making it
+    /// structurally impossible to perform a correct deallocation when
+    /// the original Vec's capacity differs from its length.
+    #[test]
+    fn test_binary_data_struct_has_no_capacity_field() {
+        // DashSDKBinaryData is repr(C) with two fields: *mut u8 and usize.
+        // On a 64-bit platform, that is exactly 16 bytes (8 + 8).
+        // A correct representation would need a third field for capacity,
+        // making it 24 bytes.
+        let struct_size = std::mem::size_of::<DashSDKBinaryData>();
+
+        // Two pointer-sized fields: data pointer + len
+        let expected_size = std::mem::size_of::<*mut u8>() + std::mem::size_of::<usize>();
+
+        assert_eq!(
+            struct_size, expected_size,
+            "DashSDKBinaryData is {} bytes (only ptr + len). \
+             It would need {} more bytes for a capacity field.",
+            struct_size,
+            std::mem::size_of::<usize>()
+        );
+    }
+}

--- a/packages/rs-sdk-ffi/src/types.rs
+++ b/packages/rs-sdk-ffi/src/types.rs
@@ -407,9 +407,11 @@ impl DashSDKResult {
 
     /// Create a success result with binary data
     pub fn success_binary(data: Vec<u8>) -> Self {
+        // Use into_boxed_slice() to shrink capacity to exactly len,
+        // so that the free function can safely reconstruct with capacity == len.
+        let data = data.into_boxed_slice();
         let len = data.len();
-        let data_ptr = data.as_ptr() as *mut u8;
-        std::mem::forget(data); // Prevent deallocation
+        let data_ptr = Box::into_raw(data) as *mut u8;
 
         let binary_data = Box::new(DashSDKBinaryData {
             data: data_ptr,
@@ -1170,40 +1172,32 @@ pub unsafe extern "C" fn dash_sdk_name_timestamp_list_free(list: *mut DashSDKNam
 mod tests {
     use super::*;
 
-    /// Proves that `DashSDKResult::success_binary` discards Vec capacity,
-    /// which causes `dash_sdk_binary_data_free` to reconstruct the Vec with
-    /// `len` used as `capacity`. When the original Vec had capacity > len,
-    /// the free function passes the wrong size to the allocator -- this is
-    /// undefined behavior per the `GlobalAlloc::dealloc` contract.
-    ///
-    /// This test does NOT invoke the buggy free path (doing so would be
-    /// actual UB). Instead it demonstrates that the capacity information is
-    /// irrecoverably lost during the `success_binary` roundtrip.
+    /// Verifies that `DashSDKResult::success_binary` now correctly shrinks
+    /// Vec capacity to match len via `into_boxed_slice()`, so that the free
+    /// function can safely reconstruct with `Vec::from_raw_parts(ptr, len, len)`.
     #[test]
-    fn test_success_binary_loses_vec_capacity() {
+    fn test_success_binary_preserves_capacity_via_shrink() {
         // 1. Create a Vec with more capacity than length.
         let mut vec: Vec<u8> = Vec::with_capacity(100);
         vec.extend_from_slice(&[1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
 
         let original_len = vec.len(); // 10
-        let original_capacity = vec.capacity(); // >= 100
 
         assert_eq!(original_len, 10);
         assert!(
-            original_capacity >= 100,
+            vec.capacity() >= 100,
             "Vec::with_capacity(100) should have capacity >= 100, got {}",
-            original_capacity
+            vec.capacity()
         );
         assert!(
-            original_capacity > original_len,
+            vec.capacity() > original_len,
             "capacity ({}) must be greater than len ({}) for this test to be meaningful",
-            original_capacity,
+            vec.capacity(),
             original_len
         );
 
-        // 2. Pass through success_binary -- this calls `data.as_ptr()`,
-        //    captures `data.len()`, then `mem::forget(data)`.
-        //    The capacity is never stored anywhere.
+        // 2. Pass through success_binary -- this now uses into_boxed_slice()
+        //    which shrinks the allocation so capacity == len.
         let result = DashSDKResult::success_binary(vec);
 
         // 3. The result should contain binary data.
@@ -1213,53 +1207,52 @@ mod tests {
         // 4. Extract the DashSDKBinaryData to inspect what was stored.
         let binary_data = unsafe { &*(result.data as *const DashSDKBinaryData) };
 
-        // 5. Prove the mismatch: DashSDKBinaryData only has `len`, which
-        //    equals the original Vec's length -- NOT its capacity.
+        // 5. Verify len is correct.
         assert_eq!(
             binary_data.len, original_len,
             "DashSDKBinaryData.len should equal the original Vec length"
         );
 
-        // 6. The struct has no capacity field. If dash_sdk_binary_data_free
-        //    were called, it would do:
-        //
-        //      Vec::from_raw_parts(data.data, data.len, data.len)
-        //                                              ^^^^^^^^
-        //                                       capacity = len = 10
-        //
-        //    But the actual allocation was for capacity >= 100. The allocator
-        //    would be asked to deallocate 10 bytes from an allocation that
-        //    was originally 100+ bytes -- undefined behavior.
-        assert!(
-            binary_data.len < original_capacity,
-            "BUG CONFIRMED: DashSDKBinaryData.len ({}) < original capacity ({}). \
-             The free function will reconstruct Vec with capacity={} but the \
-             allocator originally allocated {} bytes. This is UB on dealloc.",
-            binary_data.len,
-            original_capacity,
-            binary_data.len,
-            original_capacity
-        );
-
-        // 7. Clean up safely: we reconstruct the Vec with the CORRECT
-        //    capacity to avoid triggering the very UB we are proving exists.
-        //    This is the key insight -- only we (the test) know the true
-        //    capacity. The FFI consumer would not.
+        // 6. Now it is safe to free via the FFI free function because
+        //    the allocation was shrunk so capacity == len. Verify this
+        //    by calling the actual free function.
         unsafe {
-            let binary_data = Box::from_raw(result.data as *mut DashSDKBinaryData);
-            let _ = Vec::from_raw_parts(binary_data.data, binary_data.len, original_capacity);
+            dash_sdk_binary_data_free(result.data as *mut DashSDKBinaryData);
         }
     }
 
-    /// Proves that DashSDKBinaryData has no capacity field, making it
-    /// structurally impossible to perform a correct deallocation when
-    /// the original Vec's capacity differs from its length.
+    /// Verifies the full roundtrip: create a Vec with extra capacity, pass it
+    /// through success_binary, read back the data, and free it. This exercises
+    /// the exact code path that was previously UB.
+    #[test]
+    fn test_success_binary_roundtrip_with_extra_capacity() {
+        let payload: Vec<u8> = (0u8..=255).collect(); // len == 256
+        let mut vec = Vec::with_capacity(1024);
+        vec.extend_from_slice(&payload);
+        assert!(vec.capacity() >= 1024);
+        assert_eq!(vec.len(), 256);
+
+        let result = DashSDKResult::success_binary(vec);
+
+        // Verify the data content is intact.
+        let binary_data = unsafe { &*(result.data as *const DashSDKBinaryData) };
+        assert_eq!(binary_data.len, 256);
+        let slice = unsafe { std::slice::from_raw_parts(binary_data.data, binary_data.len) };
+        assert_eq!(slice, &payload[..]);
+
+        // Free safely -- this was previously UB when capacity != len.
+        unsafe {
+            dash_sdk_binary_data_free(result.data as *mut DashSDKBinaryData);
+        }
+    }
+
+    /// Verifies that DashSDKBinaryData has only two fields (ptr + len).
+    /// The fix ensures capacity == len via into_boxed_slice(), so no
+    /// capacity field is needed in the struct.
     #[test]
     fn test_binary_data_struct_has_no_capacity_field() {
         // DashSDKBinaryData is repr(C) with two fields: *mut u8 and usize.
         // On a 64-bit platform, that is exactly 16 bytes (8 + 8).
-        // A correct representation would need a third field for capacity,
-        // making it 24 bytes.
         let struct_size = std::mem::size_of::<DashSDKBinaryData>();
 
         // Two pointer-sized fields: data pointer + len
@@ -1268,9 +1261,8 @@ mod tests {
         assert_eq!(
             struct_size, expected_size,
             "DashSDKBinaryData is {} bytes (only ptr + len). \
-             It would need {} more bytes for a capacity field.",
+             The fix guarantees capacity == len via into_boxed_slice().",
             struct_size,
-            std::mem::size_of::<usize>()
         );
     }
 }


### PR DESCRIPTION
## Summary
- Fix undefined behavior where `Vec::from_raw_parts` was called with wrong capacity in FFI free functions
- Use `into_boxed_slice()` to guarantee `capacity == len` before crossing FFI boundary

## Issue
`success_binary()` captured Vec's `len` and pointer via `mem::forget()` but discarded `capacity`. The free function reconstructed with `Vec::from_raw_parts(ptr, len, len)`, passing `len` as capacity. When the original Vec had `capacity > len`, the allocator received wrong deallocation size (UB).

## Test plan
- [x] Test verifies capacity is preserved after fix
- [x] cargo test passes
- [x] cargo clippy clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)