### PR TITLE
fix(drive-abci): add input bounds to batch query endpoints

### DIFF
--- a/packages/rs-drive-abci/src/query/address_funds/addresses_infos/v0/mod.rs
+++ b/packages/rs-drive-abci/src/query/address_funds/addresses_infos/v0/mod.rs
@@ -13,6 +13,7 @@ use dpp::address_funds::PlatformAddress;
 use dpp::check_validation_result_with_data;
 use dpp::validation::ValidationResult;
 use dpp::version::PlatformVersion;
+use drive::error::query::QuerySyntaxError;
 use drive::util::grove_operations::GroveDBToUse;
 use std::collections::BTreeMap;
 
@@ -23,6 +24,15 @@ impl<C> Platform<C> {
         platform_state: &PlatformState,
         platform_version: &PlatformVersion,
     ) -> Result<QueryValidationResult<GetAddressesInfosResponseV0>, Error> {
+        if addresses.len() > platform_version.drive_abci.query.max_returned_elements as usize {
+            return Ok(QueryValidationResult::new_with_error(QueryError::Query(
+                QuerySyntaxError::InvalidLimit(format!(
+                    "trying to get {} addresses infos, maximum is {}",
+                    addresses.len(),
+                    platform_version.drive_abci.query.max_returned_elements
+                )),
+            )));
+        }
         // Parse all keys of type
         let addresses: Vec<PlatformAddress> = check_validation_result_with_data!(addresses
             .into_iter()
@@ -141,6 +151,55 @@ mod tests {
             result.errors.as_slice(),
             [QueryError::InvalidArgument(msg)] if msg.contains("invalid key_of_type")
         ));
+    }
+
+    #[test]
+    fn test_addresses_exceeding_max_limit_is_rejected() {
+        let (platform, state, version) = setup_platform(None, Network::Testnet, None);
+        let max = version.drive_abci.query.max_returned_elements as usize;
+
+        let request = GetAddressesInfosRequestV0 {
+            addresses: (0..=max)
+                .map(|i| PlatformAddress::P2pkh([i as u8; 20]).to_bytes())
+                .collect(),
+            prove: false,
+        };
+
+        let result = platform
+            .query_addresses_infos_v0(request, &state, version)
+            .expect("expected query to succeed");
+
+        assert!(matches!(
+            result.errors.as_slice(),
+            [QueryError::Query(
+                drive::error::query::QuerySyntaxError::InvalidLimit(_)
+            )]
+        ));
+    }
+
+    #[test]
+    fn test_addresses_at_max_limit_is_accepted() {
+        let (platform, state, version) = setup_platform(None, Network::Testnet, None);
+        let max = version.drive_abci.query.max_returned_elements as usize;
+
+        let request = GetAddressesInfosRequestV0 {
+            addresses: (0..max)
+                .map(|i| PlatformAddress::P2pkh([i as u8; 20]).to_bytes())
+                .collect(),
+            prove: false,
+        };
+
+        let result = platform
+            .query_addresses_infos_v0(request, &state, version)
+            .expect("expected query to succeed");
+
+        assert!(
+            !result.errors.iter().any(|e| matches!(
+                e,
+                QueryError::Query(drive::error::query::QuerySyntaxError::InvalidLimit(_))
+            )),
+            "should not be rejected at exactly the max limit"
+        );
     }
 
     #[test]

--- a/packages/rs-drive-abci/src/query/data_contract_based_queries/data_contracts/v0/mod.rs
+++ b/packages/rs-drive-abci/src/query/data_contract_based_queries/data_contracts/v0/mod.rs
@@ -15,6 +15,7 @@ use dpp::serialization::PlatformSerializableWithPlatformVersion;
 use dpp::validation::ValidationResult;
 use dpp::version::PlatformVersion;
 use dpp::{check_validation_result_with_data, ProtocolError};
+use drive::error::query::QuerySyntaxError;
 use drive::util::grove_operations::GroveDBToUse;
 
 impl<C> Platform<C> {
@@ -24,6 +25,15 @@ impl<C> Platform<C> {
         platform_state: &PlatformState,
         platform_version: &PlatformVersion,
     ) -> Result<QueryValidationResult<GetDataContractsResponseV0>, Error> {
+        if ids.len() > platform_version.drive_abci.query.max_returned_elements as usize {
+            return Ok(QueryValidationResult::new_with_error(QueryError::Query(
+                QuerySyntaxError::InvalidLimit(format!(
+                    "trying to get {} data contracts, maximum is {}",
+                    ids.len(),
+                    platform_version.drive_abci.query.max_returned_elements
+                )),
+            )));
+        }
         let contract_ids = check_validation_result_with_data!(ids
             .into_iter()
             .map(|contract_id_vec| {
@@ -130,6 +140,51 @@ mod tests {
                 metadata: Some(_),
             }) if contracts.data_contract_entries.len() == 1 && contracts.data_contract_entries[0].data_contract.is_none()
         ));
+    }
+
+    #[test]
+    fn test_ids_exceeding_max_limit_is_rejected() {
+        let (platform, state, version) = setup_platform(None, Network::Testnet, None);
+        let max = version.drive_abci.query.max_returned_elements as usize;
+
+        let request = GetDataContractsRequestV0 {
+            ids: (0..=max).map(|i| vec![i as u8; 32]).collect(),
+            prove: false,
+        };
+
+        let result = platform
+            .query_data_contracts_v0(request, &state, version)
+            .expect("expected query to succeed");
+
+        assert!(matches!(
+            result.errors.as_slice(),
+            [QueryError::Query(
+                drive::error::query::QuerySyntaxError::InvalidLimit(_)
+            )]
+        ));
+    }
+
+    #[test]
+    fn test_ids_at_max_limit_is_accepted() {
+        let (platform, state, version) = setup_platform(None, Network::Testnet, None);
+        let max = version.drive_abci.query.max_returned_elements as usize;
+
+        let request = GetDataContractsRequestV0 {
+            ids: (0..max).map(|i| vec![i as u8; 32]).collect(),
+            prove: false,
+        };
+
+        let result = platform
+            .query_data_contracts_v0(request, &state, version)
+            .expect("expected query to succeed");
+
+        assert!(
+            !result.errors.iter().any(|e| matches!(
+                e,
+                QueryError::Query(drive::error::query::QuerySyntaxError::InvalidLimit(_))
+            )),
+            "should not be rejected at exactly the max limit"
+        );
     }
 
     #[test]

--- a/packages/rs-drive-abci/src/query/identity_based_queries/balances/v0/mod.rs
+++ b/packages/rs-drive-abci/src/query/identity_based_queries/balances/v0/mod.rs
@@ -12,6 +12,7 @@ use dpp::check_validation_result_with_data;
 use dpp::identifier::Identifier;
 use dpp::validation::ValidationResult;
 use dpp::version::PlatformVersion;
+use drive::error::query::QuerySyntaxError;
 use drive::util::grove_operations::GroveDBToUse;
 
 impl<C> Platform<C> {
@@ -21,6 +22,15 @@ impl<C> Platform<C> {
         platform_state: &PlatformState,
         platform_version: &PlatformVersion,
     ) -> Result<QueryValidationResult<GetIdentitiesBalancesResponseV0>, Error> {
+        if ids.len() > platform_version.drive_abci.query.max_returned_elements as usize {
+            return Ok(QueryValidationResult::new_with_error(QueryError::Query(
+                QuerySyntaxError::InvalidLimit(format!(
+                    "trying to get {} identities balances, maximum is {}",
+                    ids.len(),
+                    platform_version.drive_abci.query.max_returned_elements
+                )),
+            )));
+        }
         let identifiers = check_validation_result_with_data!(ids
             .into_iter()
             .map(|identity_id| {
@@ -226,6 +236,52 @@ mod tests {
             result.errors.as_slice(),
             [QueryError::InvalidArgument(msg)] if msg.contains("id must be a valid identifier (32 bytes long)")
         ));
+    }
+
+    #[test]
+    fn test_ids_exceeding_max_limit_is_rejected() {
+        let (platform, state, version) = setup_platform(None, Network::Testnet, None);
+        let max = version.drive_abci.query.max_returned_elements as usize;
+
+        let request = GetIdentitiesBalancesRequestV0 {
+            ids: (0..=max).map(|i| vec![i as u8; 32]).collect(),
+            prove: false,
+        };
+
+        let result = platform
+            .query_identities_balances_v0(request, &state, version)
+            .expect("expected query to succeed");
+
+        assert!(matches!(
+            result.errors.as_slice(),
+            [QueryError::Query(
+                drive::error::query::QuerySyntaxError::InvalidLimit(_)
+            )]
+        ));
+    }
+
+    #[test]
+    fn test_ids_at_max_limit_is_accepted() {
+        let (platform, state, version) = setup_platform(None, Network::Testnet, None);
+        let max = version.drive_abci.query.max_returned_elements as usize;
+
+        let request = GetIdentitiesBalancesRequestV0 {
+            ids: (0..max).map(|i| vec![i as u8; 32]).collect(),
+            prove: false,
+        };
+
+        let result = platform
+            .query_identities_balances_v0(request, &state, version)
+            .expect("expected query to succeed");
+
+        // Should not have a limit error -- it should pass validation
+        assert!(
+            !result.errors.iter().any(|e| matches!(
+                e,
+                QueryError::Query(drive::error::query::QuerySyntaxError::InvalidLimit(_))
+            )),
+            "should not be rejected at exactly the max limit"
+        );
     }
 
     #[test]

--- a/packages/rs-drive-abci/src/query/identity_based_queries/identities_contract_keys/v0/mod.rs
+++ b/packages/rs-drive-abci/src/query/identity_based_queries/identities_contract_keys/v0/mod.rs
@@ -30,6 +30,15 @@ impl<C> Platform<C> {
         platform_state: &PlatformState,
         platform_version: &PlatformVersion,
     ) -> Result<QueryValidationResult<GetIdentitiesContractKeysResponseV0>, Error> {
+        if identities_ids.len() > platform_version.drive_abci.query.max_returned_elements as usize {
+            return Ok(QueryValidationResult::new_with_error(QueryError::Query(
+                QuerySyntaxError::InvalidLimit(format!(
+                    "trying to get {} identities contract keys, maximum is {}",
+                    identities_ids.len(),
+                    platform_version.drive_abci.query.max_returned_elements
+                )),
+            )));
+        }
         let identities_ids = check_validation_result_with_data!(identities_ids
             .into_iter()
             .map(|identity_id| {
@@ -223,6 +232,65 @@ mod tests {
             result.errors.as_slice(),
             [QueryError::Query(QuerySyntaxError::InvalidKeyParameter(msg))] if msg.contains("purpose")
         ));
+    }
+
+    #[test]
+    fn test_identities_ids_exceeding_max_limit_is_rejected() {
+        let (platform, state, platform_version) =
+            setup_platform(Some((1, 1)), Network::Testnet, None);
+        let max = platform_version.drive_abci.query.max_returned_elements as usize;
+
+        let dashpay = platform.drive.cache.system_data_contracts.load_dashpay();
+
+        let request = GetIdentitiesContractKeysRequestV0 {
+            identities_ids: (0..=max).map(|i| vec![i as u8; 32]).collect(),
+            contract_id: dashpay.id().to_vec(),
+            document_type_name: Some("contactRequest".to_string()),
+            purposes: vec![Purpose::ENCRYPTION as i32],
+            prove: false,
+        };
+
+        let result = platform
+            .query_identities_contract_keys_v0(request, &state, platform_version)
+            .expect("query should not fail");
+
+        assert!(matches!(
+            result.errors.as_slice(),
+            [crate::error::query::QueryError::Query(
+                drive::error::query::QuerySyntaxError::InvalidLimit(_)
+            )]
+        ));
+    }
+
+    #[test]
+    fn test_identities_ids_at_max_limit_is_accepted() {
+        let (platform, state, platform_version) =
+            setup_platform(Some((1, 1)), Network::Testnet, None);
+        let max = platform_version.drive_abci.query.max_returned_elements as usize;
+
+        let dashpay = platform.drive.cache.system_data_contracts.load_dashpay();
+
+        let request = GetIdentitiesContractKeysRequestV0 {
+            identities_ids: (0..max).map(|i| vec![i as u8; 32]).collect(),
+            contract_id: dashpay.id().to_vec(),
+            document_type_name: Some("contactRequest".to_string()),
+            purposes: vec![Purpose::ENCRYPTION as i32],
+            prove: false,
+        };
+
+        let result = platform
+            .query_identities_contract_keys_v0(request, &state, platform_version)
+            .expect("query should not fail");
+
+        assert!(
+            !result.errors.iter().any(|e| matches!(
+                e,
+                crate::error::query::QueryError::Query(
+                    drive::error::query::QuerySyntaxError::InvalidLimit(_)
+                )
+            )),
+            "should not be rejected at exactly the max limit"
+        );
     }
 
     #[test]

--- a/packages/rs-drive-abci/src/query/token_queries/identities_token_balances/v0/mod.rs
+++ b/packages/rs-drive-abci/src/query/token_queries/identities_token_balances/v0/mod.rs
@@ -10,6 +10,7 @@ use dpp::check_validation_result_with_data;
 use dpp::identifier::Identifier;
 use dpp::validation::ValidationResult;
 use dpp::version::PlatformVersion;
+use drive::error::query::QuerySyntaxError;
 use drive::util::grove_operations::GroveDBToUse;
 use crate::query::response_metadata::CheckpointUsed;
 
@@ -24,6 +25,15 @@ impl<C> Platform<C> {
         platform_state: &PlatformState,
         platform_version: &PlatformVersion,
     ) -> Result<QueryValidationResult<GetIdentitiesTokenBalancesResponseV0>, Error> {
+        if identity_ids.len() > platform_version.drive_abci.query.max_returned_elements as usize {
+            return Ok(QueryValidationResult::new_with_error(QueryError::Query(
+                QuerySyntaxError::InvalidLimit(format!(
+                    "trying to get {} identities token balances, maximum is {}",
+                    identity_ids.len(),
+                    platform_version.drive_abci.query.max_returned_elements
+                )),
+            )));
+        }
         let token_id: Identifier =
             check_validation_result_with_data!(token_id.try_into().map_err(|_| {
                 QueryError::InvalidArgument(
@@ -189,6 +199,53 @@ mod tests {
                 metadata: Some(_),
             })
         ));
+    }
+
+    #[test]
+    fn test_identity_ids_exceeding_max_limit_is_rejected() {
+        let (platform, state, version) = setup_platform(None, Network::Testnet, None);
+        let max = version.drive_abci.query.max_returned_elements as usize;
+
+        let request = GetIdentitiesTokenBalancesRequestV0 {
+            token_id: vec![0; 32],
+            identity_ids: (0..=max).map(|i| vec![i as u8; 32]).collect(),
+            prove: false,
+        };
+
+        let result = platform
+            .query_identities_token_balances_v0(request, &state, version)
+            .expect("expected query to succeed");
+
+        assert!(matches!(
+            result.errors.as_slice(),
+            [QueryError::Query(
+                drive::error::query::QuerySyntaxError::InvalidLimit(_)
+            )]
+        ));
+    }
+
+    #[test]
+    fn test_identity_ids_at_max_limit_is_accepted() {
+        let (platform, state, version) = setup_platform(None, Network::Testnet, None);
+        let max = version.drive_abci.query.max_returned_elements as usize;
+
+        let request = GetIdentitiesTokenBalancesRequestV0 {
+            token_id: vec![0; 32],
+            identity_ids: (0..max).map(|i| vec![i as u8; 32]).collect(),
+            prove: false,
+        };
+
+        let result = platform
+            .query_identities_token_balances_v0(request, &state, version)
+            .expect("expected query to succeed");
+
+        assert!(
+            !result.errors.iter().any(|e| matches!(
+                e,
+                QueryError::Query(drive::error::query::QuerySyntaxError::InvalidLimit(_))
+            )),
+            "should not be rejected at exactly the max limit"
+        );
     }
 
     #[test]

--- a/packages/rs-drive-abci/src/query/token_queries/identities_token_infos/v0/mod.rs
+++ b/packages/rs-drive-abci/src/query/token_queries/identities_token_infos/v0/mod.rs
@@ -11,6 +11,7 @@ use dpp::identifier::Identifier;
 use dpp::tokens::info::v0::IdentityTokenInfoV0Accessors;
 use dpp::validation::ValidationResult;
 use dpp::version::PlatformVersion;
+use drive::error::query::QuerySyntaxError;
 use drive::util::grove_operations::GroveDBToUse;
 use crate::query::response_metadata::CheckpointUsed;
 
@@ -25,6 +26,15 @@ impl<C> Platform<C> {
         platform_state: &PlatformState,
         platform_version: &PlatformVersion,
     ) -> Result<QueryValidationResult<GetIdentitiesTokenInfosResponseV0>, Error> {
+        if identity_ids.len() > platform_version.drive_abci.query.max_returned_elements as usize {
+            return Ok(QueryValidationResult::new_with_error(QueryError::Query(
+                QuerySyntaxError::InvalidLimit(format!(
+                    "trying to get {} identities token infos, maximum is {}",
+                    identity_ids.len(),
+                    platform_version.drive_abci.query.max_returned_elements
+                )),
+            )));
+        }
         let token_id: Identifier =
             check_validation_result_with_data!(token_id.try_into().map_err(|_| {
                 QueryError::InvalidArgument(
@@ -193,6 +203,53 @@ mod tests {
                 metadata: Some(_),
             })
         ));
+    }
+
+    #[test]
+    fn test_identity_ids_exceeding_max_limit_is_rejected() {
+        let (platform, state, version) = setup_platform(None, Network::Testnet, None);
+        let max = version.drive_abci.query.max_returned_elements as usize;
+
+        let request = GetIdentitiesTokenInfosRequestV0 {
+            token_id: vec![0; 32],
+            identity_ids: (0..=max).map(|i| vec![i as u8; 32]).collect(),
+            prove: false,
+        };
+
+        let result = platform
+            .query_identities_token_infos_v0(request, &state, version)
+            .expect("expected query to succeed");
+
+        assert!(matches!(
+            result.errors.as_slice(),
+            [QueryError::Query(
+                drive::error::query::QuerySyntaxError::InvalidLimit(_)
+            )]
+        ));
+    }
+
+    #[test]
+    fn test_identity_ids_at_max_limit_is_accepted() {
+        let (platform, state, version) = setup_platform(None, Network::Testnet, None);
+        let max = version.drive_abci.query.max_returned_elements as usize;
+
+        let request = GetIdentitiesTokenInfosRequestV0 {
+            token_id: vec![0; 32],
+            identity_ids: (0..max).map(|i| vec![i as u8; 32]).collect(),
+            prove: false,
+        };
+
+        let result = platform
+            .query_identities_token_infos_v0(request, &state, version)
+            .expect("expected query to succeed");
+
+        assert!(
+            !result.errors.iter().any(|e| matches!(
+                e,
+                QueryError::Query(drive::error::query::QuerySyntaxError::InvalidLimit(_))
+            )),
+            "should not be rejected at exactly the max limit"
+        );
     }
 
     #[test]

--- a/packages/rs-drive-abci/src/query/token_queries/identity_token_balances/v0/mod.rs
+++ b/packages/rs-drive-abci/src/query/token_queries/identity_token_balances/v0/mod.rs
@@ -10,6 +10,7 @@ use dpp::check_validation_result_with_data;
 use dpp::identifier::Identifier;
 use dpp::validation::ValidationResult;
 use dpp::version::PlatformVersion;
+use drive::error::query::QuerySyntaxError;
 use drive::util::grove_operations::GroveDBToUse;
 use crate::query::response_metadata::CheckpointUsed;
 
@@ -24,6 +25,15 @@ impl<C> Platform<C> {
         platform_state: &PlatformState,
         platform_version: &PlatformVersion,
     ) -> Result<QueryValidationResult<GetIdentityTokenBalancesResponseV0>, Error> {
+        if token_ids.len() > platform_version.drive_abci.query.max_returned_elements as usize {
+            return Ok(QueryValidationResult::new_with_error(QueryError::Query(
+                QuerySyntaxError::InvalidLimit(format!(
+                    "trying to get {} identity token balances, maximum is {}",
+                    token_ids.len(),
+                    platform_version.drive_abci.query.max_returned_elements
+                )),
+            )));
+        }
         let identity_id: Identifier =
             check_validation_result_with_data!(identity_id.try_into().map_err(|_| {
                 QueryError::InvalidArgument(
@@ -183,6 +193,53 @@ mod tests {
                 metadata: Some(_),
             })
         ));
+    }
+
+    #[test]
+    fn test_token_ids_exceeding_max_limit_is_rejected() {
+        let (platform, state, version) = setup_platform(None, Network::Testnet, None);
+        let max = version.drive_abci.query.max_returned_elements as usize;
+
+        let request = GetIdentityTokenBalancesRequestV0 {
+            identity_id: vec![0; 32],
+            token_ids: (0..=max).map(|i| vec![i as u8; 32]).collect(),
+            prove: false,
+        };
+
+        let result = platform
+            .query_identity_token_balances_v0(request, &state, version)
+            .expect("expected query to succeed");
+
+        assert!(matches!(
+            result.errors.as_slice(),
+            [QueryError::Query(
+                drive::error::query::QuerySyntaxError::InvalidLimit(_)
+            )]
+        ));
+    }
+
+    #[test]
+    fn test_token_ids_at_max_limit_is_accepted() {
+        let (platform, state, version) = setup_platform(None, Network::Testnet, None);
+        let max = version.drive_abci.query.max_returned_elements as usize;
+
+        let request = GetIdentityTokenBalancesRequestV0 {
+            identity_id: vec![0; 32],
+            token_ids: (0..max).map(|i| vec![i as u8; 32]).collect(),
+            prove: false,
+        };
+
+        let result = platform
+            .query_identity_token_balances_v0(request, &state, version)
+            .expect("expected query to succeed");
+
+        assert!(
+            !result.errors.iter().any(|e| matches!(
+                e,
+                QueryError::Query(drive::error::query::QuerySyntaxError::InvalidLimit(_))
+            )),
+            "should not be rejected at exactly the max limit"
+        );
     }
 
     #[test]

--- a/packages/rs-drive-abci/src/query/token_queries/identity_token_infos/v0/mod.rs
+++ b/packages/rs-drive-abci/src/query/token_queries/identity_token_infos/v0/mod.rs
@@ -11,6 +11,7 @@ use dpp::identifier::Identifier;
 use dpp::tokens::info::v0::IdentityTokenInfoV0Accessors;
 use dpp::validation::ValidationResult;
 use dpp::version::PlatformVersion;
+use drive::error::query::QuerySyntaxError;
 use drive::util::grove_operations::GroveDBToUse;
 use crate::query::response_metadata::CheckpointUsed;
 
@@ -25,6 +26,15 @@ impl<C> Platform<C> {
         platform_state: &PlatformState,
         platform_version: &PlatformVersion,
     ) -> Result<QueryValidationResult<GetIdentityTokenInfosResponseV0>, Error> {
+        if token_ids.len() > platform_version.drive_abci.query.max_returned_elements as usize {
+            return Ok(QueryValidationResult::new_with_error(QueryError::Query(
+                QuerySyntaxError::InvalidLimit(format!(
+                    "trying to get {} identity token infos, maximum is {}",
+                    token_ids.len(),
+                    platform_version.drive_abci.query.max_returned_elements
+                )),
+            )));
+        }
         let identity_id: Identifier =
             check_validation_result_with_data!(identity_id.try_into().map_err(|_| {
                 QueryError::InvalidArgument(
@@ -186,6 +196,53 @@ mod tests {
                 metadata: Some(_),
             })
         ));
+    }
+
+    #[test]
+    fn test_token_ids_exceeding_max_limit_is_rejected() {
+        let (platform, state, version) = setup_platform(None, Network::Testnet, None);
+        let max = version.drive_abci.query.max_returned_elements as usize;
+
+        let request = GetIdentityTokenInfosRequestV0 {
+            identity_id: vec![0; 32],
+            token_ids: (0..=max).map(|i| vec![i as u8; 32]).collect(),
+            prove: false,
+        };
+
+        let result = platform
+            .query_identity_token_infos_v0(request, &state, version)
+            .expect("expected query to succeed");
+
+        assert!(matches!(
+            result.errors.as_slice(),
+            [QueryError::Query(
+                drive::error::query::QuerySyntaxError::InvalidLimit(_)
+            )]
+        ));
+    }
+
+    #[test]
+    fn test_token_ids_at_max_limit_is_accepted() {
+        let (platform, state, version) = setup_platform(None, Network::Testnet, None);
+        let max = version.drive_abci.query.max_returned_elements as usize;
+
+        let request = GetIdentityTokenInfosRequestV0 {
+            identity_id: vec![0; 32],
+            token_ids: (0..max).map(|i| vec![i as u8; 32]).collect(),
+            prove: false,
+        };
+
+        let result = platform
+            .query_identity_token_infos_v0(request, &state, version)
+            .expect("expected query to succeed");
+
+        assert!(
+            !result.errors.iter().any(|e| matches!(
+                e,
+                QueryError::Query(drive::error::query::QuerySyntaxError::InvalidLimit(_))
+            )),
+            "should not be rejected at exactly the max limit"
+        );
     }
 
     #[test]

--- a/packages/rs-drive-abci/src/query/token_queries/token_direct_purchase_prices/v0/mod.rs
+++ b/packages/rs-drive-abci/src/query/token_queries/token_direct_purchase_prices/v0/mod.rs
@@ -16,6 +16,7 @@ use dpp::check_validation_result_with_data;
 use dpp::tokens::token_pricing_schedule::TokenPricingSchedule;
 use dpp::validation::ValidationResult;
 use dpp::version::PlatformVersion;
+use drive::error::query::QuerySyntaxError;
 use drive::util::grove_operations::GroveDBToUse;
 
 impl<C> Platform<C> {
@@ -25,6 +26,15 @@ impl<C> Platform<C> {
         platform_state: &PlatformState,
         platform_version: &PlatformVersion,
     ) -> Result<QueryValidationResult<GetTokenDirectPurchasePricesResponseV0>, Error> {
+        if token_ids.len() > platform_version.drive_abci.query.max_returned_elements as usize {
+            return Ok(QueryValidationResult::new_with_error(QueryError::Query(
+                QuerySyntaxError::InvalidLimit(format!(
+                    "trying to get {} token direct purchase prices, maximum is {}",
+                    token_ids.len(),
+                    platform_version.drive_abci.query.max_returned_elements
+                )),
+            )));
+        }
         if token_ids.is_empty() {
             return Ok(QueryValidationResult::new_with_error(
                 QueryError::InvalidArgument(
@@ -129,6 +139,51 @@ mod tests {
             result.errors.as_slice(),
             [QueryError::InvalidArgument(msg)] if msg.contains("at least one token id")
         ));
+    }
+
+    #[test]
+    fn test_token_ids_exceeding_max_limit_is_rejected() {
+        let (platform, state, version) = setup_platform(None, Network::Testnet, None);
+        let max = version.drive_abci.query.max_returned_elements as usize;
+
+        let request = GetTokenDirectPurchasePricesRequestV0 {
+            token_ids: (0..=max).map(|i| vec![i as u8; 32]).collect(),
+            prove: false,
+        };
+
+        let result = platform
+            .query_token_direct_purchase_prices_v0(request, &state, version)
+            .expect("expected query to succeed");
+
+        assert!(matches!(
+            result.errors.as_slice(),
+            [QueryError::Query(
+                drive::error::query::QuerySyntaxError::InvalidLimit(_)
+            )]
+        ));
+    }
+
+    #[test]
+    fn test_token_ids_at_max_limit_is_accepted() {
+        let (platform, state, version) = setup_platform(None, Network::Testnet, None);
+        let max = version.drive_abci.query.max_returned_elements as usize;
+
+        let request = GetTokenDirectPurchasePricesRequestV0 {
+            token_ids: (0..max).map(|i| vec![i as u8; 32]).collect(),
+            prove: false,
+        };
+
+        let result = platform
+            .query_token_direct_purchase_prices_v0(request, &state, version)
+            .expect("expected query to succeed");
+
+        assert!(
+            !result.errors.iter().any(|e| matches!(
+                e,
+                QueryError::Query(drive::error::query::QuerySyntaxError::InvalidLimit(_))
+            )),
+            "should not be rejected at exactly the max limit"
+        );
     }
 
     #[test]

--- a/packages/rs-drive-abci/src/query/token_queries/token_status/v0/mod.rs
+++ b/packages/rs-drive-abci/src/query/token_queries/token_status/v0/mod.rs
@@ -15,6 +15,7 @@ use dpp::check_validation_result_with_data;
 use dpp::tokens::status::v0::TokenStatusV0Accessors;
 use dpp::validation::ValidationResult;
 use dpp::version::PlatformVersion;
+use drive::error::query::QuerySyntaxError;
 use drive::util::grove_operations::GroveDBToUse;
 
 impl<C> Platform<C> {
@@ -24,6 +25,15 @@ impl<C> Platform<C> {
         platform_state: &PlatformState,
         platform_version: &PlatformVersion,
     ) -> Result<QueryValidationResult<GetTokenStatusesResponseV0>, Error> {
+        if token_ids.len() > platform_version.drive_abci.query.max_returned_elements as usize {
+            return Ok(QueryValidationResult::new_with_error(QueryError::Query(
+                QuerySyntaxError::InvalidLimit(format!(
+                    "trying to get {} token statuses, maximum is {}",
+                    token_ids.len(),
+                    platform_version.drive_abci.query.max_returned_elements
+                )),
+            )));
+        }
         let token_ids: Vec<[u8; 32]> = check_validation_result_with_data!(token_ids
             .into_iter()
             .map(|token_id| {
@@ -100,6 +110,51 @@ mod tests {
             result.errors.as_slice(),
             [QueryError::InvalidArgument(msg)] if msg.contains("token_id")
         ));
+    }
+
+    #[test]
+    fn test_token_ids_exceeding_max_limit_is_rejected() {
+        let (platform, state, version) = setup_platform(None, Network::Testnet, None);
+        let max = version.drive_abci.query.max_returned_elements as usize;
+
+        let request = GetTokenStatusesRequestV0 {
+            token_ids: (0..=max).map(|i| vec![i as u8; 32]).collect(),
+            prove: false,
+        };
+
+        let result = platform
+            .query_token_statuses_v0(request, &state, version)
+            .expect("expected query to succeed");
+
+        assert!(matches!(
+            result.errors.as_slice(),
+            [QueryError::Query(
+                drive::error::query::QuerySyntaxError::InvalidLimit(_)
+            )]
+        ));
+    }
+
+    #[test]
+    fn test_token_ids_at_max_limit_is_accepted() {
+        let (platform, state, version) = setup_platform(None, Network::Testnet, None);
+        let max = version.drive_abci.query.max_returned_elements as usize;
+
+        let request = GetTokenStatusesRequestV0 {
+            token_ids: (0..max).map(|i| vec![i as u8; 32]).collect(),
+            prove: false,
+        };
+
+        let result = platform
+            .query_token_statuses_v0(request, &state, version)
+            .expect("expected query to succeed");
+
+        assert!(
+            !result.errors.iter().any(|e| matches!(
+                e,
+                QueryError::Query(drive::error::query::QuerySyntaxError::InvalidLimit(_))
+            )),
+            "should not be rejected at exactly the max limit"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Issue being fixed or feature implemented

Security audit found that multiple batch query endpoints accept unlimited ID arrays with no bounds check. A malicious client can send millions of IDs, causing memory exhaustion and CPU starvation. The `GetPathElements` endpoint correctly enforces `max_returned_elements` limits, but these did not:

- `GetIdentitiesBalances` - `ids` vector unbounded
- `GetDataContracts` - `ids` vector unbounded
- `GetIdentitiesTokenBalances` - `identity_ids` vector unbounded
- `GetIdentitiesTokenInfos` - `identity_ids` vector unbounded
- `GetIdentityTokenBalances` - `token_ids` vector unbounded
- `GetIdentityTokenInfos` - `token_ids` vector unbounded
- `GetTokenStatuses` - `token_ids` vector unbounded
- `GetTokenDirectPurchasePrices` - `token_ids` vector unbounded
- `GetIdentitiesContractKeys` - `identities_ids` vector unbounded
- `GetAddressesInfos` - `addresses` vector unbounded

## What was done?

Added `max_returned_elements` bounds checking to all 10 vulnerable batch query endpoints, following the exact pattern from the `GetPathElements` reference implementation. Each endpoint now checks the input array length against `platform_version.drive_abci.query.max_returned_elements` and returns `QuerySyntaxError::InvalidLimit` when exceeded.

Also added comprehensive tests for each endpoint verifying:
- Queries exceeding the limit are rejected with `InvalidLimit` error
- Queries at exactly the limit are accepted (boundary test)

## How Has This Been Tested?

- [x] Tests verify queries exceeding limit are rejected (20 new tests total, 2 per endpoint)
- [x] Tests verify queries within/at limit still work
- [x] `cargo check -p drive-abci` passes
- [x] `cargo clippy -p drive-abci` clean
- [x] `cargo fmt --all` applied

## Breaking Changes

None. Clients sending more than `max_returned_elements` (currently 100) IDs in a single batch query will now receive an error instead of the server attempting to process the request. This is the intended behavior matching the existing `GetPathElements` endpoint.

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [x] I have made corresponding changes to the documentation if needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)