### PR TITLE
ci: run all tests everywhere, remove shielded/non-shielded split

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -4,8 +4,6 @@ codecov:
 flags:
   rust:
     carryforward: false
-  rust-shielded:
-    carryforward: true
 
 ignore:
   - "**/test_utils.rs"

--- a/.github/workflows/tests-rs-workspace.yml
+++ b/.github/workflows/tests-rs-workspace.yml
@@ -1,10 +1,6 @@
 on:
   workflow_call:
     inputs:
-      zk-changed:
-        description: Whether ZK/shielded related code has changed
-        type: boolean
-        default: false
       doctests-changed:
         description: Whether doc comments with code examples have changed
         type: boolean
@@ -129,11 +125,7 @@ jobs:
 
       - name: Run tests with coverage
         run: |
-          FILTER_ARGS=""
-          if [ "${{ github.event_name }}" = "pull_request" ]; then
-            FILTER_ARGS="-E 'not test(/shield/)'"
-          fi
-          eval cargo llvm-cov nextest \
+          cargo llvm-cov nextest \
             --package drive \
             --package dpp \
             --package drive-abci \
@@ -156,7 +148,6 @@ jobs:
             --package keyword-search-contract \
             --all-features \
             --locked \
-            $FILTER_ARGS \
             --lcov --output-path lcov.info
         env:
           RUST_MIN_STACK: 4194304
@@ -275,11 +266,7 @@ jobs:
         if: steps.check-mac.outputs.skip == 'false'
         run: |
           ulimit -c unlimited
-          FILTER_ARGS=""
-          if [ "${{ github.event_name }}" = "pull_request" ]; then
-            FILTER_ARGS="-E 'not test(/shield/)'"
-          fi
-          eval cargo nextest run \
+          cargo nextest run \
             --package drive \
             --package dpp \
             --package drive-abci \
@@ -302,7 +289,6 @@ jobs:
             --package keyword-search-contract \
             --all-features \
             --locked \
-            $FILTER_ARGS \
             --partition count:${{ matrix.partition }}/4
         env:
           RUST_MIN_STACK: 4194304
@@ -501,76 +487,3 @@ jobs:
           done
           echo "No immutable/append_only structure violations found"
 
-  zk-tests:
-    name: ZK / Shielded tests
-    if: ${{ inputs.zk-changed }}
-    runs-on: ubuntu-24.04
-    timeout-minutes: 30
-    permissions:
-      id-token: write
-      contents: read
-    steps:
-      - name: Free disk space
-        run: |
-          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /usr/local/share/powershell /usr/share/swift
-          df -h /
-
-      - name: Check out repo
-        uses: actions/checkout@v4
-
-      - name: Strip cdylib crate-types (incompatible with static rocksdb)
-        run: |
-          sed -i 's/\["cdylib", "rlib"\]/["rlib"]/' packages/rs-sdk/Cargo.toml packages/wasm-drive-verify/Cargo.toml
-          sed -i 's/\["cdylib", "lib"\]/["lib"]/' packages/wasm-dpp2/Cargo.toml
-          sed -i 's/\["cdylib"\]/["rlib"]/' packages/wasm-sdk/Cargo.toml
-          sed -i 's/\["staticlib", "cdylib", "rlib"\]/["staticlib", "rlib"]/g' packages/rs-sdk-ffi/Cargo.toml packages/rs-platform-wallet-ffi/Cargo.toml
-
-      - name: Setup Rust
-        uses: ./.github/actions/rust
-        with:
-          components: llvm-tools
-
-      - name: Setup sccache
-        uses: ./.github/actions/sccache
-        with:
-          bucket: ${{ vars.CACHE_S3_BUCKET }}
-          region: ${{ vars.CACHE_REGION }}
-          endpoint: ${{ vars.CACHE_S3_ENDPOINT }}
-          access_key_id: ${{ secrets.CACHE_KEY_ID }}
-          secret_access_key: ${{ secrets.CACHE_SECRET_KEY }}
-
-      - name: Install librocksdb
-        uses: ./.github/actions/librocksdb
-
-      - uses: taiki-e/install-action@cargo-nextest
-      - uses: taiki-e/install-action@cargo-llvm-cov
-
-      - name: Run ZK / Shielded tests with coverage
-        run: |
-          cargo llvm-cov nextest \
-            --package dpp \
-            --package drive-abci \
-            --package drive \
-            --all-features \
-            --locked \
-            -E 'test(/shield/)' \
-            --lcov --output-path lcov-shielded.info
-        env:
-          RUST_MIN_STACK: 4194304
-          CARGO_INCREMENTAL: "0"
-          CARGO_PROFILE_DEV_DEBUG: "0"
-          CARGO_PROFILE_DEV_CODEGEN_UNITS: "256"
-          SCCACHE_S3_KEY_PREFIX: ${{ runner.os }}/sccache/${{ runner.arch }}/linux-gnu
-          ROCKSDB_STATIC: "/opt/rocksdb/usr/local/lib/librocksdb.a"
-          ROCKSDB_LIB_DIR: "/opt/rocksdb/usr/local/lib"
-          SNAPPY_STATIC: "/usr/lib/x86_64-linux-gnu/libsnappy.a"
-          SNAPPY_LIB_DIR: "/usr/lib/x86_64-linux-gnu"
-
-      - name: Upload shielded coverage
-        if: always()
-        uses: codecov/codecov-action@v5
-        with:
-          files: lcov-shielded.info
-          flags: rust-shielded
-          token: ${{ secrets.CODECOV_TOKEN }}
-          fail_ci_if_error: false

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -46,7 +46,6 @@ jobs:
       js-packages-direct: ${{ steps.override.outputs.js-packages-direct || steps.filter-js-direct.outputs.changes }}
       rs-packages: ${{ steps.override.outputs.rs-packages || steps.filter-rs.outputs.changes }}
       rs-workflows-changed: ${{ steps.filter-rs-workflows.outputs.rs-workflows }}
-      zk-changed: ${{ steps.override.outputs.zk-changed || steps.filter-zk.outputs.zk-changed }}
       doctests-changed: ${{ steps.override.outputs.doctests-changed || steps.filter-doctests.outputs.doctests-changed }}
       swift-sdk-changed: ${{ steps.override.outputs.swift-sdk-changed || steps.filter-swift-sdk.outputs.swift-sdk-changed }}
       version-changed: ${{ steps.override.outputs.version-changed || steps.filter-version.outputs.version-changed }}
@@ -97,34 +96,6 @@ jobs:
             echo "Platform version unchanged"
           fi
 
-      - name: Check for ZK / shielded code changes
-        id: filter-zk
-        if: ${{ github.event_name != 'workflow_dispatch' }}
-        run: |
-          BASE_SHA="${{ github.event.pull_request.base.sha || github.event.before || 'HEAD~1' }}"
-          CHANGED=$(git diff --name-only "$BASE_SHA"...HEAD 2>/dev/null || git diff --name-only HEAD~1)
-
-          # Check for direct shielded/ZK code changes
-          if echo "$CHANGED" | grep -qE \
-            'packages/rs-dpp/src/shielded/|packages/rs-dpp/src/address_funds/orchard|packages/rs-dpp/src/state_transition/state_transitions/shielded/|packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/shield|packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/shielded_|packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/unshield|packages/rs-drive/src/state_transition_action/shielded/|packages/rs-drive/src/verify/shielded/|packages/rs-drive-abci/tests/strategy_tests/test_cases/shielded_tests'; then
-            echo "zk-changed=true" >> "$GITHUB_OUTPUT"
-            echo "ZK-related files changed — ZK tests will run"
-            exit 0
-          fi
-
-          # Check for grovedb version changes (commitment-tree underpins shielded code)
-          GROVEDB_FILES=$(echo "$CHANGED" | grep -E 'Cargo\.(toml|lock)$' || true)
-          if [ -n "$GROVEDB_FILES" ]; then
-            if git diff "$BASE_SHA"...HEAD -- $GROVEDB_FILES 2>/dev/null | grep -qE 'grovedb.*rev\s*=|name = "grovedb'; then
-              echo "zk-changed=true" >> "$GITHUB_OUTPUT"
-              echo "GroveDB version changed — ZK tests will run"
-              exit 0
-            fi
-          fi
-
-          echo "zk-changed=false" >> "$GITHUB_OUTPUT"
-          echo "No ZK-related changes — skipping ZK tests"
-
       - name: Check for doctest changes
         id: filter-doctests
         if: ${{ github.event_name != 'workflow_dispatch' }}
@@ -163,7 +134,6 @@ jobs:
           echo "js-packages=$(to_json .github/package-filters/js-packages-no-workflows.yml)" >> "$GITHUB_OUTPUT"
           echo "js-packages-direct=$(to_json .github/package-filters/js-packages-direct.yml)" >> "$GITHUB_OUTPUT"
           echo "rs-packages=$(to_json .github/package-filters/rs-packages-no-workflows.yml)" >> "$GITHUB_OUTPUT"
-          echo 'zk-changed=true' >> "$GITHUB_OUTPUT"
           echo 'doctests-changed=true' >> "$GITHUB_OUTPUT"
           echo 'swift-sdk-changed=true' >> "$GITHUB_OUTPUT"
           echo 'version-changed=true' >> "$GITHUB_OUTPUT"
@@ -216,7 +186,6 @@ jobs:
     secrets: inherit
     uses: ./.github/workflows/tests-rs-workspace.yml
     with:
-      zk-changed: ${{ needs.changes.outputs.zk-changed == 'true' }}
       doctests-changed: ${{ needs.changes.outputs.doctests-changed == 'true' }}
 
   rs-doctests:


### PR DESCRIPTION
## Summary
- Remove the shielded/non-shielded test split entirely
- Mac runner and Ubuntu backup shards now run **all tests** including shielded
- Delete the separate ZK tests job, zk-changed detection step, and rust-shielded codecov flag
- **-122 lines** of CI configuration removed

This adds ~45s to Mac runner time but:
- Coverage reports are always complete
- PR diffs are always accurate (no false -2% from missing shielded coverage)
- No more carryforward flag complexity

## Test plan
- [ ] Verify Mac runner runs shielded tests
- [ ] Verify PR coverage diffs are accurate
- [ ] Verify no "ZK / Shielded tests" job appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Simplified test workflows by removing special-case gating and filtering for certain test groups.
  * Removed dedicated coverage generation and upload for shielded builds.
  * Streamlined CI test invocation to run a broader set of packages without PR-specific exclusions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->