### PR TITLE
ci: skip tests on merge if coverage matches PR run

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -3,7 +3,7 @@ codecov:
 
 flags:
   rust:
-    carryforward: false
+    carryforward: true
 
 ignore:
   - "**/test_utils.rs"

--- a/.github/workflows/tests-rs-workspace.yml
+++ b/.github/workflows/tests-rs-workspace.yml
@@ -123,7 +123,21 @@ jobs:
           done
           echo "No immutable/append_only structure violations found"
 
+      - name: Check if coverage can be reused
+        id: coverage-cache
+        run: |
+          CURRENT_TREE=$(git rev-parse HEAD^{tree})
+          CACHED_TREE=$(cat target/lcov-tree-hash 2>/dev/null || echo "none")
+          if [ "$CURRENT_TREE" = "$CACHED_TREE" ] && [ -f lcov.info ]; then
+            echo "reuse=true" >> "$GITHUB_OUTPUT"
+            echo "Tree hash matches ($CURRENT_TREE) — reusing coverage from previous run"
+          else
+            echo "reuse=false" >> "$GITHUB_OUTPUT"
+            echo "Tree hash changed ($CACHED_TREE -> $CURRENT_TREE) — running tests"
+          fi
+
       - name: Run tests with coverage
+        if: steps.coverage-cache.outputs.reuse == 'false'
         run: |
           cargo llvm-cov nextest \
             --package drive \
@@ -149,6 +163,7 @@ jobs:
             --all-features \
             --locked \
             --lcov --output-path lcov.info
+          git rev-parse HEAD^{tree} > target/lcov-tree-hash
         env:
           RUST_MIN_STACK: 4194304
           CARGO_PROFILE_DEV_DEBUG: "0"


### PR DESCRIPTION
## Summary
- On self-hosted Mac runners, compare git tree hash to detect if code is identical to the last coverage run
- When a PR merges, the merge commit has the same tree hash as the PR head — so we skip tests and re-upload the existing `lcov.info` (~10s instead of ~4min)
- Tree hash is saved to `target/lcov-tree-hash` after each test run
- If the tree hash doesn't match (new code), tests run normally

## How it works
1. `git rev-parse HEAD^{tree}` gets the tree hash (represents actual code content, ignoring commit metadata)
2. Compare to `target/lcov-tree-hash` saved from the last test run
3. If match + `lcov.info` exists → skip tests, upload existing coverage
4. If no match → run tests, save new tree hash

## Test plan
- [ ] First run: tests execute, tree hash saved
- [ ] Subsequent push with same code (merge): tests skipped, coverage uploaded
- [ ] Push with new code: tests run normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)