### PR TITLE
fix(sdk): remove unsafe Copy derive and fix ContextProviderWrapper leak

### DIFF
--- a/packages/rs-sdk-ffi/src/sdk.rs
+++ b/packages/rs-sdk-ffi/src/sdk.rs
@@ -591,8 +591,20 @@ pub unsafe extern "C" fn dash_sdk_create_with_callbacks(
     let wrapper = Box::new(ContextProviderWrapper::new(context_provider));
     let context_provider_handle = Box::into_raw(wrapper) as *mut ContextProviderHandle;
 
+    // Read fields from the caller's config individually rather than copying
+    // the struct (which would duplicate the raw `dapi_addresses` pointer).
+    // The pointer is only borrowed for the duration of this call; the
+    // downstream `dash_sdk_create_extended` reads and copies the string data
+    // immediately before returning.
+    let config_ref = &*config;
     let extended_config = DashSDKConfigExtended {
-        base_config: *config,
+        base_config: DashSDKConfig {
+            network: config_ref.network,
+            dapi_addresses: config_ref.dapi_addresses,
+            skip_asset_lock_proof_verification: config_ref.skip_asset_lock_proof_verification,
+            request_retry_count: config_ref.request_retry_count,
+            request_timeout_ms: config_ref.request_timeout_ms,
+        },
         context_provider: context_provider_handle,
         core_sdk_handle: std::ptr::null_mut(),
     };

--- a/packages/rs-sdk-ffi/src/sdk.rs
+++ b/packages/rs-sdk-ffi/src/sdk.rs
@@ -610,7 +610,13 @@ pub unsafe extern "C" fn dash_sdk_create_with_callbacks(
     };
 
     // Use the extended creation function
-    dash_sdk_create_extended(&extended_config)
+    let result = dash_sdk_create_extended(&extended_config);
+
+    // Reclaim the context provider wrapper - the SDK has already cloned what it needs
+    // via `provider_wrapper.provider()` inside `dash_sdk_create_extended`.
+    let _ = Box::from_raw(context_provider_handle as *mut ContextProviderWrapper);
+
+    result
 }
 
 /// Get the current network the SDK is connected to

--- a/packages/rs-sdk-ffi/src/types.rs
+++ b/packages/rs-sdk-ffi/src/types.rs
@@ -51,14 +51,28 @@ pub enum DashSDKNetwork {
     SDKLocal = 4,
 }
 
-/// SDK configuration
+/// SDK configuration passed from C callers.
+///
+/// # Pointer lifetime
+///
+/// `dapi_addresses` is a borrowed `*const c_char` whose memory is owned by the
+/// caller. The pointer is **only read during the FFI entry-point call** (e.g.,
+/// `dash_sdk_create`, `dash_sdk_create_trusted`, `dash_sdk_create_with_callbacks`)
+/// and the string data is copied into Rust-owned memory immediately. Callers may
+/// free the original C string as soon as the creation function returns.
+///
+/// `Copy` is intentionally **not** derived: duplicating raw pointers via implicit
+/// copies risks use-after-free if the original string is freed while a copy is
+/// still in use.
 #[repr(C)]
-#[derive(Copy, Clone)]
 pub struct DashSDKConfig {
     /// Network to connect to
     pub network: DashSDKNetwork,
     /// Comma-separated list of DAPI addresses (e.g., "http://127.0.0.1:3000,http://127.0.0.1:3001")
-    /// If null or empty, will use mock SDK
+    /// If null or empty, will use mock SDK.
+    ///
+    /// This pointer is only read during the creation call; the string data is
+    /// immediately copied into Rust-owned memory.
     pub dapi_addresses: *const c_char,
     /// Skip asset lock proof verification (for testing)
     pub skip_asset_lock_proof_verification: bool,


### PR DESCRIPTION
## Summary
- Remove `Copy`/`Clone` derive from `DashSDKConfig` which contains `*const c_char`
- Fix `ContextProviderWrapper` memory leak in `dash_sdk_create_with_callbacks`

## Issues
1. `DashSDKConfig` derived `Copy` despite containing a raw pointer, risking use-after-free on implicit copies.
2. `dash_sdk_create_with_callbacks` converted `ContextProviderWrapper` to a raw pointer via `Box::into_raw` but never reclaimed it. The SDK only borrows the provider during creation, so the wrapper leaked on every call.

## Test plan
- [x] All existing tests pass
- [x] cargo clippy clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)