### PR TITLE
docs(drive-abci): document that unrestricted GetPathElements is by design

### DIFF
--- a/packages/rs-drive-abci/src/query/system/path_elements/v0/mod.rs
+++ b/packages/rs-drive-abci/src/query/system/path_elements/v0/mod.rs
@@ -17,6 +17,12 @@ use drive::error::query::QuerySyntaxError;
 use drive::util::grove_operations::GroveDBToUse;
 
 impl<C> Platform<C> {
+    // Security note: this endpoint intentionally allows querying ANY path in GroveDB.
+    // All platform state is public and authenticated -- every element has a Merkle
+    // proof back to the state root signed by the validator quorum. There is no
+    // concept of "private" vs "public" paths. Restricting paths here would not
+    // improve security since the same data is accessible through other query
+    // endpoints or by running a full node.
     pub(super) fn query_path_elements_v0(
         &self,
         GetPathElementsRequestV0 { path, keys, prove }: GetPathElementsRequestV0,


### PR DESCRIPTION
## Summary
- Add security comment to `query_path_elements_v0` explaining why unrestricted path access is intentional
- Prevents future security audits from flagging it as an information disclosure issue

## Context
A security audit flagged `GetPathElements` as allowing arbitrary path access to "internal system data." This is a **false positive**: all Dash Platform state is public and authenticated. Every element in GroveDB has a Merkle proof back to the state root signed by the validator quorum. There is no concept of private vs public paths -- the same data is accessible through other query endpoints or by running a full node. Restricting paths would add complexity with zero security benefit.

## Test plan
- [x] Comment only, no code changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)