### PR TITLE
ci: gate Ubuntu backup runners on UBUNTU_BACKUP_ENABLED variable

### DIFF
--- a/.github/workflows/tests-rs-doctests.yml
+++ b/.github/workflows/tests-rs-doctests.yml
@@ -4,6 +4,7 @@ on:
 jobs:
   doctests:
     name: Doctests backup
+    if: vars.UBUNTU_BACKUP_ENABLED == 'true'
     runs-on: ubuntu-24.04
     timeout-minutes: 20
     permissions:

--- a/.github/workflows/tests-rs-workspace.yml
+++ b/.github/workflows/tests-rs-workspace.yml
@@ -199,6 +199,7 @@ jobs:
 
   test-ubuntu:
     name: "Tests backup (shard ${{ matrix.partition }}/4)"
+    if: vars.UBUNTU_BACKUP_ENABLED == 'true'
     runs-on: ubuntu-24.04
     timeout-minutes: 30
     permissions:
@@ -352,6 +353,7 @@ jobs:
 
   lint-ubuntu:
     name: "Formatting & Linting backup"
+    if: vars.UBUNTU_BACKUP_ENABLED == 'true'
     runs-on: ubuntu-24.04
     timeout-minutes: 20
     permissions:


### PR DESCRIPTION
## Summary
- All Ubuntu backup jobs (test shards, formatting/linting, doctests) now only run when repository variable `UBUNTU_BACKUP_ENABLED` is `true`
- Toggle at **Settings > Variables > Actions** — no code changes needed
- When Mac runners are healthy: leave unset or `false` (saves ~6 Ubuntu runners per PR)
- When Mac runners are down: set to `true` to enable fallback

## Setup
1. Go to https://github.com/dashpay/platform/settings/variables/actions
2. Add variable `UBUNTU_BACKUP_ENABLED` with value `true` or `false`
3. If not set, defaults to disabled (Ubuntu backups don't run)

## Test plan
- [ ] Verify Ubuntu backup jobs are skipped when variable is unset/false
- [ ] Verify Ubuntu backup jobs run when variable is `true`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated continuous integration workflows to conditionally execute test and lint jobs based on environment configuration settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->