### PR TITLE
docs(drive-abci): document that direct purchases bypass token pause by design

### DIFF
--- a/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/batch/action_validation/token/token_direct_purchase_transition_action/state_v0/mod.rs
+++ b/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/batch/action_validation/token/token_direct_purchase_transition_action/state_v0/mod.rs
@@ -28,6 +28,11 @@ pub(in crate::execution::validation::state_transition::state_transitions::batch:
     ) -> Result<SimpleConsensusValidationResult, Error>;
 }
 impl TokenDirectPurchaseTransitionActionStateValidationV0 for TokenDirectPurchaseTransitionAction {
+    // Security note: direct purchases intentionally do NOT check token pause status.
+    // A paused token restricts transfers but not purchases. This allows token issuers
+    // to pause trading/movement while still permitting new buyers to acquire tokens
+    // (e.g., during a distribution event or when transfers are temporarily frozen for
+    // compliance reasons). This is by design, not a missing check.
     fn validate_state_v0(
         &self,
         platform: &PlatformStateRef,


### PR DESCRIPTION
## Summary
- Add security comment to direct purchase validation explaining why pause check is intentionally absent
- Prevents future security audits from flagging it as a missing check

## Context
A security audit flagged that direct purchase validation does not check `token_status.paused()` unlike transfer validation. This is **by design**: a paused token restricts transfers but not purchases. This allows token issuers to pause trading/movement while still permitting new buyers to acquire tokens.

## Test plan
- [x] Comment only, no code changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)