### PR TITLE
test(rs-dapi): improve test coverage

### DIFF
--- a/packages/rs-dapi/src/config/utils.rs
+++ b/packages/rs-dapi/src/config/utils.rs
@@ -62,3 +62,83 @@ where
 
     deserializer.deserialize_any(BoolOrStringVisitor)
 }
+
+#[cfg(test)]
+mod tests {
+    use serde::Deserialize;
+
+    #[derive(Deserialize)]
+    struct BoolConfig {
+        #[serde(deserialize_with = "super::from_str_or_bool")]
+        value: bool,
+    }
+
+    #[derive(Deserialize)]
+    struct NumConfig {
+        #[serde(deserialize_with = "super::from_str_or_number")]
+        value: u16,
+    }
+
+    // -- from_str_or_bool --
+
+    #[test]
+    fn from_str_or_bool_true_values() {
+        for input in &["true", "1", "yes", "on", "TRUE", "Yes", "ON"] {
+            let json = format!(r#"{{"value": "{}"}}"#, input);
+            let c: BoolConfig =
+                serde_json::from_str(&json).unwrap_or_else(|_| panic!("failed for {}", input));
+            assert!(c.value, "expected true for input '{}'", input);
+        }
+    }
+
+    #[test]
+    fn from_str_or_bool_false_values() {
+        for input in &["false", "0", "no", "off", "FALSE", "No", "OFF"] {
+            let json = format!(r#"{{"value": "{}"}}"#, input);
+            let c: BoolConfig =
+                serde_json::from_str(&json).unwrap_or_else(|_| panic!("failed for {}", input));
+            assert!(!c.value, "expected false for input '{}'", input);
+        }
+    }
+
+    #[test]
+    fn from_str_or_bool_native_bool() {
+        let json = r#"{"value": true}"#;
+        let c: BoolConfig = serde_json::from_str(json).unwrap();
+        assert!(c.value);
+
+        let json = r#"{"value": false}"#;
+        let c: BoolConfig = serde_json::from_str(json).unwrap();
+        assert!(!c.value);
+    }
+
+    #[test]
+    fn from_str_or_bool_invalid_string() {
+        let json = r#"{"value": "maybe"}"#;
+        let result: Result<BoolConfig, _> = serde_json::from_str(json);
+        assert!(result.is_err());
+    }
+
+    // -- from_str_or_number --
+
+    #[test]
+    fn from_str_or_number_from_string() {
+        let json = r#"{"value": "3005"}"#;
+        let c: NumConfig = serde_json::from_str(json).unwrap();
+        assert_eq!(c.value, 3005);
+    }
+
+    #[test]
+    fn from_str_or_number_from_number() {
+        let json = r#"{"value": 9090}"#;
+        let c: NumConfig = serde_json::from_str(json).unwrap();
+        assert_eq!(c.value, 9090);
+    }
+
+    #[test]
+    fn from_str_or_number_invalid_string() {
+        let json = r#"{"value": "not_a_number"}"#;
+        let result: Result<NumConfig, _> = serde_json::from_str(json);
+        assert!(result.is_err());
+    }
+}

--- a/packages/rs-dapi/src/config/utils.rs
+++ b/packages/rs-dapi/src/config/utils.rs
@@ -104,11 +104,11 @@ mod tests {
     #[test]
     fn from_str_or_bool_native_bool() {
         let json = r#"{"value": true}"#;
-        let c: BoolConfig = serde_json::from_str(json).unwrap();
+        let c: BoolConfig = serde_json::from_str(json).expect("deserialize native true");
         assert!(c.value);
 
         let json = r#"{"value": false}"#;
-        let c: BoolConfig = serde_json::from_str(json).unwrap();
+        let c: BoolConfig = serde_json::from_str(json).expect("deserialize native false");
         assert!(!c.value);
     }
 
@@ -124,14 +124,14 @@ mod tests {
     #[test]
     fn from_str_or_number_from_string() {
         let json = r#"{"value": "3005"}"#;
-        let c: NumConfig = serde_json::from_str(json).unwrap();
+        let c: NumConfig = serde_json::from_str(json).expect("deserialize string as number");
         assert_eq!(c.value, 3005);
     }
 
     #[test]
     fn from_str_or_number_from_number() {
         let json = r#"{"value": 9090}"#;
-        let c: NumConfig = serde_json::from_str(json).unwrap();
+        let c: NumConfig = serde_json::from_str(json).expect("deserialize native number");
         assert_eq!(c.value, 9090);
     }
 

--- a/packages/rs-dapi/src/error.rs
+++ b/packages/rs-dapi/src/error.rs
@@ -295,6 +295,452 @@ impl<T: Sized, E: Into<DapiError>> MapToDapiResult<T> for Result<T, E> {
     }
 }
 
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    // -- to_status tests --
+
+    #[test]
+    fn to_status_maps_not_found() {
+        let err = DapiError::NotFound("missing item".into());
+        let status = err.to_status();
+        assert_eq!(status.code(), tonic::Code::NotFound);
+        assert_eq!(status.message(), "missing item");
+    }
+
+    #[test]
+    fn to_status_maps_already_exists() {
+        let err = DapiError::AlreadyExists("dup".into());
+        let status = err.to_status();
+        assert_eq!(status.code(), tonic::Code::AlreadyExists);
+        assert_eq!(status.message(), "dup");
+    }
+
+    #[test]
+    fn to_status_maps_invalid_argument() {
+        let err = DapiError::InvalidArgument("bad arg".into());
+        let status = err.to_status();
+        assert_eq!(status.code(), tonic::Code::InvalidArgument);
+        assert_eq!(status.message(), "bad arg");
+    }
+
+    #[test]
+    fn to_status_maps_resource_exhausted() {
+        let err = DapiError::ResourceExhausted("too many".into());
+        let status = err.to_status();
+        assert_eq!(status.code(), tonic::Code::ResourceExhausted);
+        assert_eq!(status.message(), "too many");
+    }
+
+    #[test]
+    fn to_status_maps_aborted() {
+        let err = DapiError::Aborted("cancelled".into());
+        let status = err.to_status();
+        assert_eq!(status.code(), tonic::Code::Aborted);
+        assert_eq!(status.message(), "cancelled");
+    }
+
+    #[test]
+    fn to_status_maps_unavailable() {
+        let err = DapiError::Unavailable("down".into());
+        let status = err.to_status();
+        assert_eq!(status.code(), tonic::Code::Unavailable);
+        assert_eq!(status.message(), "down");
+    }
+
+    #[test]
+    fn to_status_maps_service_unavailable() {
+        let err = DapiError::ServiceUnavailable("offline".into());
+        let status = err.to_status();
+        assert_eq!(status.code(), tonic::Code::Unavailable);
+        assert_eq!(status.message(), "offline");
+    }
+
+    #[test]
+    fn to_status_maps_failed_precondition() {
+        let err = DapiError::FailedPrecondition("precond".into());
+        let status = err.to_status();
+        assert_eq!(status.code(), tonic::Code::FailedPrecondition);
+        assert_eq!(status.message(), "precond");
+    }
+
+    #[test]
+    fn to_status_maps_method_not_found() {
+        let err = DapiError::MethodNotFound("no such method".into());
+        let status = err.to_status();
+        assert_eq!(status.code(), tonic::Code::Unimplemented);
+        assert_eq!(status.message(), "no such method");
+    }
+
+    #[test]
+    fn to_status_maps_status_passthrough() {
+        let original = tonic::Status::permission_denied("forbidden");
+        let err = DapiError::Status(original);
+        let status = err.to_status();
+        assert_eq!(status.code(), tonic::Code::PermissionDenied);
+        assert_eq!(status.message(), "forbidden");
+    }
+
+    #[test]
+    fn to_status_defaults_to_internal_for_other_variants() {
+        let err = DapiError::Configuration("bad config".into());
+        let status = err.to_status();
+        assert_eq!(status.code(), tonic::Code::Internal);
+        assert!(status.message().contains("bad config"));
+
+        let err2 = DapiError::ConnectionClosed;
+        let status2 = err2.to_status();
+        assert_eq!(status2.code(), tonic::Code::Internal);
+    }
+
+    // -- From<DapiError> for tonic::Status --
+
+    #[test]
+    fn dapi_error_converts_to_tonic_status() {
+        let err = DapiError::NotFound("gone".into());
+        let status: tonic::Status = err.into();
+        assert_eq!(status.code(), tonic::Code::NotFound);
+    }
+
+    // -- From<Box<dyn Error>> --
+
+    #[test]
+    fn boxed_error_converts_to_internal() {
+        let boxed: Box<dyn std::error::Error + Send + Sync> = "dynamic error".into();
+        let err: DapiError = boxed.into();
+        match err {
+            DapiError::Internal(msg) => assert_eq!(msg, "dynamic error"),
+            other => panic!("expected Internal, got {:?}", other),
+        }
+    }
+
+    // -- into_legacy_status tests --
+
+    #[test]
+    fn into_legacy_status_maps_not_found() {
+        let err = DapiError::NotFound("x".into());
+        let status = err.into_legacy_status();
+        assert_eq!(status.code(), tonic::Code::NotFound);
+        assert_eq!(status.message(), "x");
+    }
+
+    #[test]
+    fn into_legacy_status_maps_already_exists() {
+        let err = DapiError::AlreadyExists("dup".into());
+        let status = err.into_legacy_status();
+        assert_eq!(status.code(), tonic::Code::AlreadyExists);
+    }
+
+    #[test]
+    fn into_legacy_status_maps_invalid_argument() {
+        let err = DapiError::InvalidArgument("bad".into());
+        let status = err.into_legacy_status();
+        assert_eq!(status.code(), tonic::Code::InvalidArgument);
+    }
+
+    #[test]
+    fn into_legacy_status_maps_resource_exhausted() {
+        let err = DapiError::ResourceExhausted("full".into());
+        let status = err.into_legacy_status();
+        assert_eq!(status.code(), tonic::Code::ResourceExhausted);
+    }
+
+    #[test]
+    fn into_legacy_status_maps_failed_precondition() {
+        let err = DapiError::FailedPrecondition("precond".into());
+        let status = err.into_legacy_status();
+        assert_eq!(status.code(), tonic::Code::FailedPrecondition);
+    }
+
+    #[test]
+    fn into_legacy_status_maps_client_to_invalid_argument() {
+        let err = DapiError::Client("client err".into());
+        let status = err.into_legacy_status();
+        assert_eq!(status.code(), tonic::Code::InvalidArgument);
+        assert_eq!(status.message(), "client err");
+    }
+
+    #[test]
+    fn into_legacy_status_maps_service_unavailable() {
+        let err = DapiError::ServiceUnavailable("down".into());
+        let status = err.into_legacy_status();
+        assert_eq!(status.code(), tonic::Code::Unavailable);
+    }
+
+    #[test]
+    fn into_legacy_status_maps_unavailable() {
+        let err = DapiError::Unavailable("gone".into());
+        let status = err.into_legacy_status();
+        assert_eq!(status.code(), tonic::Code::Unavailable);
+    }
+
+    #[test]
+    fn into_legacy_status_maps_method_not_found() {
+        let err = DapiError::MethodNotFound("nope".into());
+        let status = err.into_legacy_status();
+        assert_eq!(status.code(), tonic::Code::Unimplemented);
+    }
+
+    #[test]
+    fn into_legacy_status_maps_timeout() {
+        let err = DapiError::Timeout("timed out".into());
+        let status = err.into_legacy_status();
+        assert_eq!(status.code(), tonic::Code::DeadlineExceeded);
+    }
+
+    #[test]
+    fn into_legacy_status_maps_aborted() {
+        let err = DapiError::Aborted("abort".into());
+        let status = err.into_legacy_status();
+        assert_eq!(status.code(), tonic::Code::Aborted);
+    }
+
+    #[test]
+    fn into_legacy_status_falls_through_to_to_status() {
+        let err = DapiError::Internal("boom".into());
+        let status = err.into_legacy_status();
+        assert_eq!(status.code(), tonic::Code::Internal);
+    }
+
+    // -- no_valid_tx_proof tests --
+
+    #[test]
+    fn no_valid_tx_proof_with_32_bytes_uses_hex_directly() {
+        let hash = [0xab_u8; 32];
+        let err = DapiError::no_valid_tx_proof(&hash);
+        match err {
+            DapiError::NoValidTxProof(hex_str) => {
+                assert_eq!(hex_str, hex::encode(hash));
+            }
+            other => panic!("expected NoValidTxProof, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn no_valid_tx_proof_with_non_32_bytes_hashes_input() {
+        let tx = b"hello tx";
+        let err = DapiError::no_valid_tx_proof(tx);
+        match err {
+            DapiError::NoValidTxProof(hex_str) => {
+                let expected = hex::encode(sha2::Sha256::digest(tx));
+                assert_eq!(hex_str, expected);
+            }
+            other => panic!("expected NoValidTxProof, got {:?}", other),
+        }
+    }
+
+    // -- from_tenderdash_error --
+
+    #[test]
+    fn from_tenderdash_error_creates_tenderdash_client_error() {
+        let value = json!({"code": 42, "message": "test error"});
+        let err = DapiError::from_tenderdash_error(value);
+        match err {
+            DapiError::TenderdashClientError(status) => {
+                assert_eq!(status.code, 42);
+            }
+            other => panic!("expected TenderdashClientError, got {:?}", other),
+        }
+    }
+
+    // -- constructor helpers --
+
+    #[test]
+    fn constructor_helpers_create_correct_variants() {
+        match DapiError::configuration("cfg err") {
+            DapiError::Configuration(msg) => assert_eq!(msg, "cfg err"),
+            other => panic!("expected Configuration, got {:?}", other),
+        }
+        match DapiError::streaming_service("stream err") {
+            DapiError::StreamingService(msg) => assert_eq!(msg, "stream err"),
+            other => panic!("expected StreamingService, got {:?}", other),
+        }
+        match DapiError::client("client err") {
+            DapiError::Client(msg) => assert_eq!(msg, "client err"),
+            other => panic!("expected Client, got {:?}", other),
+        }
+        match DapiError::server("server err") {
+            DapiError::Server(msg) => assert_eq!(msg, "server err"),
+            other => panic!("expected Server, got {:?}", other),
+        }
+        match DapiError::server_unavailable("http://foo", "conn refused") {
+            DapiError::ServerUnavailable(uri, msg) => {
+                assert_eq!(uri, "http://foo");
+                assert_eq!(msg, "conn refused");
+            }
+            other => panic!("expected ServerUnavailable, got {:?}", other),
+        }
+    }
+
+    // -- map_join_result --
+
+    #[tokio::test]
+    async fn map_join_result_ok_ok() {
+        let handle = tokio::spawn(async { Ok::<_, DapiError>(42) });
+        let result = DapiError::map_join_result(handle.await);
+        assert_eq!(result.unwrap(), 42);
+    }
+
+    #[tokio::test]
+    async fn map_join_result_ok_err() {
+        let handle =
+            tokio::spawn(async { Err::<i32, DapiError>(DapiError::Internal("inner".into())) });
+        let result = DapiError::map_join_result(handle.await);
+        assert!(matches!(result.unwrap_err(), DapiError::Internal(_)));
+    }
+
+    #[tokio::test]
+    async fn map_join_result_join_error() {
+        let handle = tokio::spawn(async {
+            panic!("deliberate panic for test");
+            #[allow(unreachable_code)]
+            Ok::<i32, DapiError>(0)
+        });
+        let result = DapiError::map_join_result(handle.await);
+        assert!(matches!(result.unwrap_err(), DapiError::TaskJoin(_)));
+    }
+
+    // -- MapToDapiResult tests --
+
+    #[tokio::test]
+    async fn map_to_dapi_result_nested_ok() {
+        let handle = tokio::spawn(async { Ok::<_, DapiError>(99) });
+        let result: DAPIResult<i32> = handle.await.to_dapi_result();
+        assert_eq!(result.unwrap(), 99);
+    }
+
+    #[tokio::test]
+    async fn map_to_dapi_result_nested_inner_err() {
+        let handle =
+            tokio::spawn(async { Err::<i32, DapiError>(DapiError::NotFound("nope".into())) });
+        let result: DAPIResult<i32> = handle.await.to_dapi_result();
+        assert!(matches!(result.unwrap_err(), DapiError::NotFound(_)));
+    }
+
+    #[test]
+    fn map_to_dapi_result_flat_ok() {
+        let r: Result<i32, DapiError> = Ok(10);
+        let result: DAPIResult<i32> = r.to_dapi_result();
+        assert_eq!(result.unwrap(), 10);
+    }
+
+    #[test]
+    fn map_to_dapi_result_flat_err() {
+        let r: Result<i32, DapiError> = Err(DapiError::Timeout("too slow".into()));
+        let result: DAPIResult<i32> = r.to_dapi_result();
+        assert!(matches!(result.unwrap_err(), DapiError::Timeout(_)));
+    }
+
+    // -- From<dashcore_rpc::Error> --
+
+    #[test]
+    fn from_dashcore_rpc_not_found_code_minus_5() {
+        let rpc_err = dashcore_rpc::Error::JsonRpc(jsonrpc::Error::Rpc(jsonrpc::error::RpcError {
+            code: -5,
+            message: "not found".to_string(),
+            data: None,
+        }));
+        let err: DapiError = rpc_err.into();
+        assert!(matches!(err, DapiError::NotFound(msg) if msg == "not found"));
+    }
+
+    #[test]
+    fn from_dashcore_rpc_not_found_code_minus_8() {
+        let rpc_err = dashcore_rpc::Error::JsonRpc(jsonrpc::Error::Rpc(jsonrpc::error::RpcError {
+            code: -8,
+            message: "out of range".to_string(),
+            data: None,
+        }));
+        let err: DapiError = rpc_err.into();
+        assert!(matches!(err, DapiError::NotFound(msg) if msg == "out of range"));
+    }
+
+    #[test]
+    fn from_dashcore_rpc_invalid_argument_code_minus_1() {
+        let rpc_err = dashcore_rpc::Error::JsonRpc(jsonrpc::Error::Rpc(jsonrpc::error::RpcError {
+            code: -1,
+            message: "invalid param".to_string(),
+            data: None,
+        }));
+        let err: DapiError = rpc_err.into();
+        assert!(matches!(err, DapiError::InvalidArgument(msg) if msg == "invalid param"));
+    }
+
+    #[test]
+    fn from_dashcore_rpc_already_exists_code_minus_27() {
+        let rpc_err = dashcore_rpc::Error::JsonRpc(jsonrpc::Error::Rpc(jsonrpc::error::RpcError {
+            code: -27,
+            message: "already in chain".to_string(),
+            data: None,
+        }));
+        let err: DapiError = rpc_err.into();
+        assert!(matches!(err, DapiError::AlreadyExists(msg) if msg == "already in chain"));
+    }
+
+    #[test]
+    fn from_dashcore_rpc_failed_precondition_code_minus_26() {
+        let rpc_err = dashcore_rpc::Error::JsonRpc(jsonrpc::Error::Rpc(jsonrpc::error::RpcError {
+            code: -26,
+            message: "rejected".to_string(),
+            data: None,
+        }));
+        let err: DapiError = rpc_err.into();
+        assert!(matches!(err, DapiError::FailedPrecondition(msg) if msg == "rejected"));
+    }
+
+    #[test]
+    fn from_dashcore_rpc_invalid_argument_codes_minus_25_and_minus_22() {
+        for code in [-25, -22] {
+            let rpc_err =
+                dashcore_rpc::Error::JsonRpc(jsonrpc::Error::Rpc(jsonrpc::error::RpcError {
+                    code,
+                    message: "deser err".to_string(),
+                    data: None,
+                }));
+            let err: DapiError = rpc_err.into();
+            assert!(
+                matches!(err, DapiError::InvalidArgument(_)),
+                "code {code} should map to InvalidArgument"
+            );
+        }
+    }
+
+    #[test]
+    fn from_dashcore_rpc_unknown_code_maps_to_unavailable() {
+        let rpc_err = dashcore_rpc::Error::JsonRpc(jsonrpc::Error::Rpc(jsonrpc::error::RpcError {
+            code: -999,
+            message: "unknown".to_string(),
+            data: None,
+        }));
+        let err: DapiError = rpc_err.into();
+        assert!(matches!(err, DapiError::Unavailable(msg) if msg.contains("-999")));
+    }
+
+    #[test]
+    fn from_dashcore_rpc_invalid_cookie_file() {
+        let rpc_err = dashcore_rpc::Error::InvalidCookieFile;
+        let err: DapiError = rpc_err.into();
+        assert!(matches!(err, DapiError::Unavailable(msg) if msg.contains("cookie")));
+    }
+
+    #[test]
+    fn from_dashcore_rpc_unexpected_structure() {
+        let rpc_err = dashcore_rpc::Error::UnexpectedStructure("bad struct".to_string());
+        let err: DapiError = rpc_err.into();
+        assert!(matches!(err, DapiError::InvalidData(msg) if msg == "bad struct"));
+    }
+
+    #[test]
+    fn from_dashcore_rpc_io_error() {
+        let io_err = std::io::Error::new(std::io::ErrorKind::BrokenPipe, "pipe broken");
+        let rpc_err = dashcore_rpc::Error::Io(io_err);
+        let err: DapiError = rpc_err.into();
+        assert!(matches!(err, DapiError::Io(_)));
+    }
+}
+
 // Provide a conversion from dashcore-rpc Error to our DapiError so callers can
 // use generic helpers like MapToDapiResult without custom closures.
 impl From<dashcore_rpc::Error> for DapiError {

--- a/packages/rs-dapi/src/error.rs
+++ b/packages/rs-dapi/src/error.rs
@@ -548,23 +548,39 @@ mod tests {
     // -- constructor helpers --
 
     #[test]
-    fn constructor_helpers_create_correct_variants() {
+    fn constructor_configuration() {
         match DapiError::configuration("cfg err") {
             DapiError::Configuration(msg) => assert_eq!(msg, "cfg err"),
             other => panic!("expected Configuration, got {:?}", other),
         }
+    }
+
+    #[test]
+    fn constructor_streaming_service() {
         match DapiError::streaming_service("stream err") {
             DapiError::StreamingService(msg) => assert_eq!(msg, "stream err"),
             other => panic!("expected StreamingService, got {:?}", other),
         }
+    }
+
+    #[test]
+    fn constructor_client() {
         match DapiError::client("client err") {
             DapiError::Client(msg) => assert_eq!(msg, "client err"),
             other => panic!("expected Client, got {:?}", other),
         }
+    }
+
+    #[test]
+    fn constructor_server() {
         match DapiError::server("server err") {
             DapiError::Server(msg) => assert_eq!(msg, "server err"),
             other => panic!("expected Server, got {:?}", other),
         }
+    }
+
+    #[test]
+    fn constructor_server_unavailable() {
         match DapiError::server_unavailable("http://foo", "conn refused") {
             DapiError::ServerUnavailable(uri, msg) => {
                 assert_eq!(uri, "http://foo");
@@ -580,7 +596,7 @@ mod tests {
     async fn map_join_result_ok_ok() {
         let handle = tokio::spawn(async { Ok::<_, DapiError>(42) });
         let result = DapiError::map_join_result(handle.await);
-        assert_eq!(result.unwrap(), 42);
+        assert_eq!(result.expect("map_join_result should succeed"), 42);
     }
 
     #[tokio::test]
@@ -608,7 +624,7 @@ mod tests {
     async fn map_to_dapi_result_nested_ok() {
         let handle = tokio::spawn(async { Ok::<_, DapiError>(99) });
         let result: DAPIResult<i32> = handle.await.to_dapi_result();
-        assert_eq!(result.unwrap(), 99);
+        assert_eq!(result.expect("nested ok should unwrap"), 99);
     }
 
     #[tokio::test]
@@ -623,7 +639,7 @@ mod tests {
     fn map_to_dapi_result_flat_ok() {
         let r: Result<i32, DapiError> = Ok(10);
         let result: DAPIResult<i32> = r.to_dapi_result();
-        assert_eq!(result.unwrap(), 10);
+        assert_eq!(result.expect("flat ok should unwrap"), 10);
     }
 
     #[test]
@@ -647,25 +663,58 @@ mod tests {
     }
 
     #[test]
-    fn from_dashcore_rpc_not_found_code_minus_8() {
+    fn from_dashcore_rpc_invalid_argument_code_minus_8() {
         let rpc_err = dashcore_rpc::Error::JsonRpc(jsonrpc::Error::Rpc(jsonrpc::error::RpcError {
             code: -8,
             message: "out of range".to_string(),
             data: None,
         }));
         let err: DapiError = rpc_err.into();
-        assert!(matches!(err, DapiError::NotFound(msg) if msg == "out of range"));
+        assert!(matches!(err, DapiError::InvalidArgument(msg) if msg == "out of range"));
     }
 
     #[test]
-    fn from_dashcore_rpc_invalid_argument_code_minus_1() {
+    fn from_dashcore_rpc_internal_code_minus_1() {
         let rpc_err = dashcore_rpc::Error::JsonRpc(jsonrpc::Error::Rpc(jsonrpc::error::RpcError {
             code: -1,
-            message: "invalid param".to_string(),
+            message: "misc error".to_string(),
             data: None,
         }));
         let err: DapiError = rpc_err.into();
-        assert!(matches!(err, DapiError::InvalidArgument(msg) if msg == "invalid param"));
+        assert!(matches!(err, DapiError::Internal(msg) if msg == "misc error"));
+    }
+
+    #[test]
+    fn from_dashcore_rpc_invalid_argument_code_minus_3() {
+        let rpc_err = dashcore_rpc::Error::JsonRpc(jsonrpc::Error::Rpc(jsonrpc::error::RpcError {
+            code: -3,
+            message: "type error".to_string(),
+            data: None,
+        }));
+        let err: DapiError = rpc_err.into();
+        assert!(matches!(err, DapiError::InvalidArgument(msg) if msg == "type error"));
+    }
+
+    #[test]
+    fn from_dashcore_rpc_not_found_code_minus_18() {
+        let rpc_err = dashcore_rpc::Error::JsonRpc(jsonrpc::Error::Rpc(jsonrpc::error::RpcError {
+            code: -18,
+            message: "wallet not found".to_string(),
+            data: None,
+        }));
+        let err: DapiError = rpc_err.into();
+        assert!(matches!(err, DapiError::NotFound(msg) if msg == "wallet not found"));
+    }
+
+    #[test]
+    fn from_dashcore_rpc_unavailable_code_minus_28() {
+        let rpc_err = dashcore_rpc::Error::JsonRpc(jsonrpc::Error::Rpc(jsonrpc::error::RpcError {
+            code: -28,
+            message: "still warming up".to_string(),
+            data: None,
+        }));
+        let err: DapiError = rpc_err.into();
+        assert!(matches!(err, DapiError::Unavailable(msg) if msg == "still warming up"));
     }
 
     #[test]
@@ -691,20 +740,25 @@ mod tests {
     }
 
     #[test]
-    fn from_dashcore_rpc_invalid_argument_codes_minus_25_and_minus_22() {
-        for code in [-25, -22] {
-            let rpc_err =
-                dashcore_rpc::Error::JsonRpc(jsonrpc::Error::Rpc(jsonrpc::error::RpcError {
-                    code,
-                    message: "deser err".to_string(),
-                    data: None,
-                }));
-            let err: DapiError = rpc_err.into();
-            assert!(
-                matches!(err, DapiError::InvalidArgument(_)),
-                "code {code} should map to InvalidArgument"
-            );
-        }
+    fn from_dashcore_rpc_failed_precondition_code_minus_25() {
+        let rpc_err = dashcore_rpc::Error::JsonRpc(jsonrpc::Error::Rpc(jsonrpc::error::RpcError {
+            code: -25,
+            message: "verify error".to_string(),
+            data: None,
+        }));
+        let err: DapiError = rpc_err.into();
+        assert!(matches!(err, DapiError::FailedPrecondition(msg) if msg == "verify error"));
+    }
+
+    #[test]
+    fn from_dashcore_rpc_invalid_argument_code_minus_22() {
+        let rpc_err = dashcore_rpc::Error::JsonRpc(jsonrpc::Error::Rpc(jsonrpc::error::RpcError {
+            code: -22,
+            message: "deser err".to_string(),
+            data: None,
+        }));
+        let err: DapiError = rpc_err.into();
+        assert!(matches!(err, DapiError::InvalidArgument(msg) if msg == "deser err"));
     }
 
     #[test]

--- a/packages/rs-dapi/src/logging/access_log.rs
+++ b/packages/rs-dapi/src/logging/access_log.rs
@@ -375,4 +375,109 @@ mod tests {
         assert_eq!(value["protocol"], "HTTP");
         assert_eq!(value["remote_addr"], "10.0.0.1");
     }
+
+    #[test]
+    fn test_grpc_status_conversion_all_codes() {
+        assert_eq!(grpc_status_to_http_status(1), 499); // CANCELLED
+        assert_eq!(grpc_status_to_http_status(2), 500); // UNKNOWN
+        assert_eq!(grpc_status_to_http_status(4), 504); // DEADLINE_EXCEEDED
+        assert_eq!(grpc_status_to_http_status(6), 409); // ALREADY_EXISTS
+        assert_eq!(grpc_status_to_http_status(7), 403); // PERMISSION_DENIED
+        assert_eq!(grpc_status_to_http_status(8), 429); // RESOURCE_EXHAUSTED
+        assert_eq!(grpc_status_to_http_status(9), 412); // FAILED_PRECONDITION
+        assert_eq!(grpc_status_to_http_status(10), 409); // ABORTED
+        assert_eq!(grpc_status_to_http_status(11), 400); // OUT_OF_RANGE
+        assert_eq!(grpc_status_to_http_status(12), 501); // UNIMPLEMENTED
+        assert_eq!(grpc_status_to_http_status(14), 503); // UNAVAILABLE
+        assert_eq!(grpc_status_to_http_status(15), 500); // DATA_LOSS
+        assert_eq!(grpc_status_to_http_status(99), 500); // Unknown code
+    }
+
+    #[test]
+    fn test_http_log_no_remote_addr() {
+        let entry = AccessLogEntry::new_http(
+            None,
+            "GET".to_string(),
+            "/health".to_string(),
+            "HTTP/1.1".to_string(),
+            200,
+            0,
+            100,
+        );
+        let line = entry.to_combined_format();
+        assert!(line.starts_with("- "));
+    }
+
+    #[test]
+    fn test_grpc_json_includes_grpc_fields() {
+        let entry = AccessLogEntry::new_grpc(
+            None,
+            "/svc/method".to_string(),
+            "svc".to_string(),
+            "method".to_string(),
+            0,
+            0,
+            500,
+        );
+        let json_line = entry.to_json_string();
+        let value: Value = serde_json::from_str(&json_line).expect("valid json");
+        assert_eq!(value["grpc_service"], "svc");
+        assert_eq!(value["grpc_method"], "method");
+        assert_eq!(value["grpc_status"], 0);
+        assert_eq!(value["protocol"], "gRPC");
+        assert!(value["remote_addr"].is_null());
+    }
+
+    #[test]
+    fn test_http_json_no_grpc_fields() {
+        let entry = AccessLogEntry::new_http(
+            None,
+            "GET".to_string(),
+            "/test".to_string(),
+            "HTTP/1.1".to_string(),
+            200,
+            0,
+            0,
+        );
+        let json_line = entry.to_json_string();
+        let value: Value = serde_json::from_str(&json_line).expect("valid json");
+        assert!(value.get("grpc_service").is_none());
+        assert!(value.get("grpc_method").is_none());
+        assert!(value.get("grpc_status").is_none());
+    }
+
+    #[test]
+    fn test_combined_format_no_referer_no_user_agent() {
+        let entry = AccessLogEntry::new_http(
+            None,
+            "HEAD".to_string(),
+            "/ping".to_string(),
+            "HTTP/1.0".to_string(),
+            204,
+            0,
+            50,
+        );
+        let line = entry.to_combined_format();
+        assert!(line.contains("\"-\""));
+        assert!(line.contains("204"));
+    }
+
+    #[test]
+    fn test_json_null_optional_fields() {
+        let entry = AccessLogEntry::new_http(
+            None,
+            "GET".to_string(),
+            "/".to_string(),
+            "HTTP/1.1".to_string(),
+            200,
+            0,
+            0,
+        );
+        let json_line = entry.to_json_string();
+        let value: Value = serde_json::from_str(&json_line).expect("valid json");
+        assert!(value["remote_addr"].is_null());
+        assert!(value["remote_user"].is_null());
+        assert!(value["referer"].is_null());
+        assert!(value["user_agent"].is_null());
+    }
 }

--- a/packages/rs-dapi/src/logging/middleware.rs
+++ b/packages/rs-dapi/src/logging/middleware.rs
@@ -403,4 +403,160 @@ mod tests {
         assert_eq!(service, "unknown");
         assert_eq!(method, "unknown");
     }
+
+    #[test]
+    fn parse_grpc_path_empty_string() {
+        let (service, method) = parse_grpc_path("");
+        assert_eq!(service, "unknown");
+        assert_eq!(method, "unknown");
+    }
+
+    #[test]
+    fn parse_grpc_path_single_segment() {
+        let (service, method) = parse_grpc_path("/onlyone");
+        // rsplit_once on "onlyone" finds no '/', so goes to else branch
+        assert_eq!(service, "unknown");
+        assert_eq!(method, "onlyone");
+    }
+
+    #[test]
+    fn parse_grpc_path_with_query_string() {
+        let (service, method) = parse_grpc_path("/svc.Foo/Bar?key=val");
+        assert_eq!(service, "svc.Foo");
+        assert_eq!(method, "Bar");
+    }
+
+    #[test]
+    fn parse_grpc_path_empty_method() {
+        let (service, method) = parse_grpc_path("/svc.Foo/");
+        assert_eq!(service, "unknown");
+        assert_eq!(method, "unknown");
+    }
+
+    #[test]
+    fn parse_grpc_path_double_slash_prefix() {
+        // trim_start_matches('/') removes all leading slashes, so "//method" -> "method"
+        // rsplit_once finds no '/', so it returns ("unknown", "method")
+        let (service, method) = parse_grpc_path("//method");
+        assert_eq!(service, "unknown");
+        assert_eq!(method, "method");
+    }
+
+    #[test]
+    fn parse_grpc_path_uri_without_path() {
+        let (service, method) = parse_grpc_path("http://example.com");
+        assert_eq!(service, "unknown");
+        assert_eq!(method, "unknown");
+    }
+
+    // -- detect_protocol_type --
+
+    #[test]
+    fn detect_protocol_type_json_rpc() {
+        let req = Request::builder()
+            .header("content-type", "application/json")
+            .body(())
+            .unwrap();
+        assert_eq!(detect_protocol_type(&req), "JSON-RPC");
+    }
+
+    #[test]
+    fn detect_protocol_type_grpc_content_type() {
+        let req = Request::builder()
+            .header("content-type", "application/grpc+proto")
+            .body(())
+            .unwrap();
+        assert_eq!(detect_protocol_type(&req), "gRPC");
+    }
+
+    #[test]
+    fn detect_protocol_type_grpc_encoding_header() {
+        let req = Request::builder()
+            .header("grpc-encoding", "gzip")
+            .body(())
+            .unwrap();
+        assert_eq!(detect_protocol_type(&req), "gRPC");
+    }
+
+    #[test]
+    fn detect_protocol_type_te_header() {
+        let req = Request::builder()
+            .header("te", "trailers")
+            .body(())
+            .unwrap();
+        assert_eq!(detect_protocol_type(&req), "gRPC");
+    }
+
+    #[test]
+    fn detect_protocol_type_http2_with_grpc_path() {
+        let req = Request::builder()
+            .version(Version::HTTP_2)
+            .uri("/org.dash.platform.dapi.v0.Platform/getStatus")
+            .body(())
+            .unwrap();
+        assert_eq!(detect_protocol_type(&req), "gRPC");
+    }
+
+    #[test]
+    fn detect_protocol_type_http2_without_grpc_path() {
+        let req = Request::builder()
+            .version(Version::HTTP_2)
+            .uri("/health")
+            .body(())
+            .unwrap();
+        assert_eq!(detect_protocol_type(&req), "HTTP");
+    }
+
+    #[test]
+    fn detect_protocol_type_plain_http() {
+        let req = Request::builder().uri("/metrics").body(()).unwrap();
+        assert_eq!(detect_protocol_type(&req), "HTTP");
+    }
+
+    // -- http_status_to_grpc_status --
+
+    #[test]
+    fn http_status_to_grpc_status_known_codes() {
+        assert_eq!(http_status_to_grpc_status(200), 0);
+        assert_eq!(http_status_to_grpc_status(400), 3);
+        assert_eq!(http_status_to_grpc_status(401), 16);
+        assert_eq!(http_status_to_grpc_status(403), 7);
+        assert_eq!(http_status_to_grpc_status(404), 5);
+        assert_eq!(http_status_to_grpc_status(409), 6);
+        assert_eq!(http_status_to_grpc_status(412), 9);
+        assert_eq!(http_status_to_grpc_status(429), 8);
+        assert_eq!(http_status_to_grpc_status(499), 1);
+        assert_eq!(http_status_to_grpc_status(500), 13);
+        assert_eq!(http_status_to_grpc_status(501), 12);
+        assert_eq!(http_status_to_grpc_status(503), 14);
+        assert_eq!(http_status_to_grpc_status(504), 4);
+    }
+
+    #[test]
+    fn http_status_to_grpc_status_unknown_returns_2() {
+        assert_eq!(http_status_to_grpc_status(418), 2); // I'm a teapot
+        assert_eq!(http_status_to_grpc_status(502), 2);
+    }
+
+    // -- extract_grpc_status additional tests --
+
+    #[test]
+    fn extract_grpc_status_200_without_header_or_extension() {
+        let response: Response<()> = Response::new(());
+        assert_eq!(extract_grpc_status(&response, 200), 0);
+    }
+
+    #[test]
+    fn extract_grpc_status_non_200_without_header_or_extension() {
+        let response: Response<()> = Response::new(());
+        assert_eq!(extract_grpc_status(&response, 404), 5); // maps via http_status_to_grpc_status
+    }
+
+    // -- extract_remote_ip --
+
+    #[test]
+    fn extract_remote_ip_none_when_no_info() {
+        let req: Request<()> = Request::default();
+        assert_eq!(extract_remote_ip(&req), None);
+    }
 }

--- a/packages/rs-dapi/src/logging/middleware.rs
+++ b/packages/rs-dapi/src/logging/middleware.rs
@@ -509,7 +509,10 @@ mod tests {
 
     #[test]
     fn detect_protocol_type_plain_http() {
-        let req = Request::builder().uri("/metrics").body(()).expect("build plain HTTP request");
+        let req = Request::builder()
+            .uri("/metrics")
+            .body(())
+            .expect("build plain HTTP request");
         assert_eq!(detect_protocol_type(&req), "HTTP");
     }
 

--- a/packages/rs-dapi/src/logging/middleware.rs
+++ b/packages/rs-dapi/src/logging/middleware.rs
@@ -456,7 +456,7 @@ mod tests {
         let req = Request::builder()
             .header("content-type", "application/json")
             .body(())
-            .unwrap();
+            .expect("build JSON-RPC request");
         assert_eq!(detect_protocol_type(&req), "JSON-RPC");
     }
 
@@ -465,7 +465,7 @@ mod tests {
         let req = Request::builder()
             .header("content-type", "application/grpc+proto")
             .body(())
-            .unwrap();
+            .expect("build gRPC content-type request");
         assert_eq!(detect_protocol_type(&req), "gRPC");
     }
 
@@ -474,7 +474,7 @@ mod tests {
         let req = Request::builder()
             .header("grpc-encoding", "gzip")
             .body(())
-            .unwrap();
+            .expect("build gRPC encoding request");
         assert_eq!(detect_protocol_type(&req), "gRPC");
     }
 
@@ -483,7 +483,7 @@ mod tests {
         let req = Request::builder()
             .header("te", "trailers")
             .body(())
-            .unwrap();
+            .expect("build te-header request");
         assert_eq!(detect_protocol_type(&req), "gRPC");
     }
 
@@ -493,7 +493,7 @@ mod tests {
             .version(Version::HTTP_2)
             .uri("/org.dash.platform.dapi.v0.Platform/getStatus")
             .body(())
-            .unwrap();
+            .expect("build HTTP/2 gRPC request");
         assert_eq!(detect_protocol_type(&req), "gRPC");
     }
 
@@ -503,13 +503,13 @@ mod tests {
             .version(Version::HTTP_2)
             .uri("/health")
             .body(())
-            .unwrap();
+            .expect("build HTTP/2 non-gRPC request");
         assert_eq!(detect_protocol_type(&req), "HTTP");
     }
 
     #[test]
     fn detect_protocol_type_plain_http() {
-        let req = Request::builder().uri("/metrics").body(()).unwrap();
+        let req = Request::builder().uri("/metrics").body(()).expect("build plain HTTP request");
         assert_eq!(detect_protocol_type(&req), "HTTP");
     }
 

--- a/packages/rs-dapi/src/metrics.rs
+++ b/packages/rs-dapi/src/metrics.rs
@@ -666,7 +666,9 @@ mod tests {
         let mut extensions = axum::http::Extensions::new();
         let label = MethodLabel::from_type_name("my_method");
         attach_method_label(&mut extensions, label);
-        let retrieved = extensions.get::<MethodLabel>().expect("MethodLabel should be in extensions");
+        let retrieved = extensions
+            .get::<MethodLabel>()
+            .expect("MethodLabel should be in extensions");
         assert_eq!(retrieved.as_str(), "my_method");
     }
 

--- a/packages/rs-dapi/src/metrics.rs
+++ b/packages/rs-dapi/src/metrics.rs
@@ -585,6 +585,7 @@ mod tests {
         assert_eq!(clamp_to_i64(i64::MAX as u64 + 1), i64::MAX);
     }
 
+    // Smoke test: verifies metric gathering does not panic and returns a valid content type
     #[test]
     fn gather_prometheus_returns_non_empty() {
         let (buffer, content_type) = gather_prometheus();
@@ -593,6 +594,9 @@ mod tests {
         let _ = buffer; // just ensure it doesn't panic
     }
 
+    // Smoke test: verifies metric registration and label cardinality.
+    // Intentionally only checks that calls do not panic; asserting recorded
+    // values would couple tests to the global Prometheus registry state.
     #[test]
     fn cache_metrics_functions_do_not_panic() {
         let label = MethodLabel::from_type_name("test_method");
@@ -603,12 +607,18 @@ mod tests {
         cache_entries("test_cache", 10);
     }
 
+    // Smoke test: verifies metric registration and label cardinality.
+    // Intentionally only checks that calls do not panic; asserting recorded
+    // values would couple tests to the global Prometheus registry state.
     #[test]
     fn request_metrics_functions_do_not_panic() {
         requests_inc("gRPC", "test_endpoint", "0");
         request_duration_observe("gRPC", "test_endpoint", "0", 0.1);
     }
 
+    // Smoke test: verifies metric registration and label cardinality.
+    // Intentionally only checks that calls do not panic; asserting recorded
+    // values would couple tests to the global Prometheus registry state.
     #[test]
     fn platform_events_metrics_do_not_panic() {
         platform_events_active_sessions_inc();
@@ -620,6 +630,9 @@ mod tests {
         platform_events_upstream_stream_started();
     }
 
+    // Smoke test: verifies metric registration and label cardinality.
+    // Intentionally only checks that calls do not panic; asserting recorded
+    // values would couple tests to the global Prometheus registry state.
     #[test]
     fn workers_active_metrics_do_not_panic() {
         workers_active_inc();
@@ -653,7 +666,7 @@ mod tests {
         let mut extensions = axum::http::Extensions::new();
         let label = MethodLabel::from_type_name("my_method");
         attach_method_label(&mut extensions, label);
-        let retrieved = extensions.get::<MethodLabel>().unwrap();
+        let retrieved = extensions.get::<MethodLabel>().expect("MethodLabel should be in extensions");
         assert_eq!(retrieved.as_str(), "my_method");
     }
 
@@ -746,6 +759,7 @@ mod tests {
 
     // -- MetricsLayer tests --
 
+    // Smoke test: verifies MetricsLayer can be constructed without panic
     #[test]
     fn metrics_layer_new() {
         let layer = MetricsLayer::new();

--- a/packages/rs-dapi/src/metrics.rs
+++ b/packages/rs-dapi/src/metrics.rs
@@ -567,3 +567,189 @@ pub fn workers_active_inc() {
 pub fn workers_active_dec() {
     WORKERS_ACTIVE.dec();
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn clamp_to_i64_within_range() {
+        assert_eq!(clamp_to_i64(0), 0);
+        assert_eq!(clamp_to_i64(1000), 1000);
+        assert_eq!(clamp_to_i64(i64::MAX as u64), i64::MAX);
+    }
+
+    #[test]
+    fn clamp_to_i64_above_range() {
+        assert_eq!(clamp_to_i64(u64::MAX), i64::MAX);
+        assert_eq!(clamp_to_i64(i64::MAX as u64 + 1), i64::MAX);
+    }
+
+    #[test]
+    fn gather_prometheus_returns_non_empty() {
+        let (buffer, content_type) = gather_prometheus();
+        // Buffer may be empty if no metrics have been touched yet, but should not panic
+        assert!(!content_type.is_empty());
+        let _ = buffer; // just ensure it doesn't panic
+    }
+
+    #[test]
+    fn cache_metrics_functions_do_not_panic() {
+        let label = MethodLabel::from_type_name("test_method");
+        cache_hit("test_cache", &label);
+        cache_miss("test_cache", &label);
+        cache_memory_usage_bytes("test_cache", 1024);
+        cache_memory_capacity_bytes("test_cache", 2048);
+        cache_entries("test_cache", 10);
+    }
+
+    #[test]
+    fn request_metrics_functions_do_not_panic() {
+        requests_inc("gRPC", "test_endpoint", "0");
+        request_duration_observe("gRPC", "test_endpoint", "0", 0.1);
+    }
+
+    #[test]
+    fn platform_events_metrics_do_not_panic() {
+        platform_events_active_sessions_inc();
+        platform_events_active_sessions_dec();
+        platform_events_command("subscribe");
+        platform_events_forwarded_event();
+        platform_events_forwarded_ack();
+        platform_events_forwarded_error();
+        platform_events_upstream_stream_started();
+    }
+
+    #[test]
+    fn workers_active_metrics_do_not_panic() {
+        workers_active_inc();
+        workers_active_dec();
+    }
+
+    // -- MethodLabel tests --
+
+    #[test]
+    fn method_label_from_type_name() {
+        let label = MethodLabel::from_type_name("GetStatusRequest");
+        assert_eq!(label.as_str(), "GetStatusRequest");
+        assert_eq!(format!("{}", label), "GetStatusRequest");
+    }
+
+    #[test]
+    fn method_label_from_owned() {
+        let label = MethodLabel::from_owned("dynamic_method".to_string());
+        assert_eq!(label.as_str(), "dynamic_method");
+    }
+
+    #[test]
+    fn method_label_function() {
+        let value = 42_u32;
+        let label = method_label(&value);
+        assert_eq!(label.as_str(), "u32");
+    }
+
+    #[test]
+    fn attach_method_label_inserts_into_extensions() {
+        let mut extensions = axum::http::Extensions::new();
+        let label = MethodLabel::from_type_name("my_method");
+        attach_method_label(&mut extensions, label);
+        let retrieved = extensions.get::<MethodLabel>().unwrap();
+        assert_eq!(retrieved.as_str(), "my_method");
+    }
+
+    // -- Metric enum tests --
+
+    #[test]
+    fn metric_names_are_prefixed() {
+        assert!(Metric::CacheEvent.name().starts_with("rsdapi_"));
+        assert!(Metric::RequestCount.name().starts_with("rsdapi_"));
+        assert!(Metric::WorkersActive.name().starts_with("rsdapi_"));
+    }
+
+    #[test]
+    fn metric_help_strings_are_nonempty() {
+        assert!(!Metric::CacheEvent.help().is_empty());
+        assert!(!Metric::RequestDuration.help().is_empty());
+        assert!(!Metric::PlatformEventsActiveSessions.help().is_empty());
+    }
+
+    // -- Outcome enum tests --
+
+    #[test]
+    fn outcome_as_str() {
+        assert_eq!(Outcome::Hit.as_str(), "hit");
+        assert_eq!(Outcome::Miss.as_str(), "miss");
+    }
+
+    // -- Label enum tests --
+
+    #[test]
+    fn label_names() {
+        assert_eq!(Label::Cache.name(), "cache");
+        assert_eq!(Label::Method.name(), "method");
+        assert_eq!(Label::Outcome.name(), "outcome");
+        assert_eq!(Label::Protocol.name(), "protocol");
+        assert_eq!(Label::Endpoint.name(), "endpoint");
+        assert_eq!(Label::Status.name(), "status");
+        assert_eq!(Label::Op.name(), "op");
+    }
+
+    // -- Metrics struct tests --
+
+    #[test]
+    fn metrics_struct_cache_events() {
+        let label = MethodLabel::from_type_name("test");
+        Metrics::cache_events_hit("struct_cache", &label);
+        Metrics::cache_events_miss("struct_cache", &label);
+        Metrics::cache_events_inc("struct_cache", &label, Outcome::Hit);
+    }
+
+    // -- endpoint_label tests --
+
+    #[test]
+    fn endpoint_label_grpc_with_hint() {
+        let hint = MethodLabel::from_type_name("GetIdentity");
+        let result = endpoint_label("gRPC", "/org.dash.Platform/GetIdentity", Some(&hint));
+        assert_eq!(result, "GetIdentity");
+    }
+
+    #[test]
+    fn endpoint_label_grpc_without_hint_parses_path() {
+        let result = endpoint_label("gRPC", "/org.dash.platform.v0.Platform/getStatus", None);
+        assert_eq!(result, "org.dash.platform.v0.Platform/getStatus");
+    }
+
+    #[test]
+    fn endpoint_label_grpc_unknown_path_returns_raw() {
+        let result = endpoint_label("gRPC", "/", None);
+        assert_eq!(result, "/");
+    }
+
+    #[test]
+    fn endpoint_label_jsonrpc_with_hint() {
+        let hint = MethodLabel::from_type_name("getStatus");
+        let result = endpoint_label("JSON-RPC", "/", Some(&hint));
+        assert_eq!(result, "getStatus");
+    }
+
+    #[test]
+    fn endpoint_label_jsonrpc_without_hint() {
+        let result = endpoint_label("JSON-RPC", "/rpc", None);
+        assert_eq!(result, "/rpc");
+    }
+
+    #[test]
+    fn endpoint_label_http_returns_path() {
+        let result = endpoint_label("HTTP", "/health", None);
+        assert_eq!(result, "/health");
+    }
+
+    // -- MetricsLayer tests --
+
+    #[test]
+    fn metrics_layer_new() {
+        let layer = MetricsLayer::new();
+        // Just ensure it constructs without panic
+        let _ = layer;
+    }
+}

--- a/packages/rs-dapi/src/protocol/jsonrpc_translator/error.rs
+++ b/packages/rs-dapi/src/protocol/jsonrpc_translator/error.rs
@@ -68,3 +68,236 @@ fn map_status(status: &dapi_grpc::tonic::Status) -> (i32, String, Option<Value>)
         ),
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use dapi_grpc::tonic;
+
+    // -- map_error additional coverage for variants already tested in parent mod --
+
+    #[test]
+    fn map_error_invalid_data() {
+        let (code, msg, _) = map_error(&DapiError::InvalidData("bad data".into()));
+        assert_eq!(code, -32602);
+        assert_eq!(msg, "bad data");
+    }
+
+    #[test]
+    fn map_error_failed_precondition() {
+        let (code, msg, _) = map_error(&DapiError::FailedPrecondition("precond".into()));
+        assert_eq!(code, -32602);
+        assert_eq!(msg, "precond");
+    }
+
+    #[test]
+    fn map_error_already_exists() {
+        let (code, _, _) = map_error(&DapiError::AlreadyExists("exists".into()));
+        assert_eq!(code, -32602);
+    }
+
+    #[test]
+    fn map_error_no_valid_tx_proof() {
+        let (code, msg, _) = map_error(&DapiError::NoValidTxProof("abc123".into()));
+        assert_eq!(code, -32602);
+        assert_eq!(msg, "abc123");
+    }
+
+    #[test]
+    fn map_error_client() {
+        let (code, _, _) = map_error(&DapiError::Client("client err".into()));
+        assert_eq!(code, -32602);
+    }
+
+    #[test]
+    fn map_error_unavailable() {
+        let (code, _, _) = map_error(&DapiError::Unavailable("offline".into()));
+        assert_eq!(code, -32003);
+    }
+
+    #[test]
+    fn map_error_timeout() {
+        let (code, _, _) = map_error(&DapiError::Timeout("timed out".into()));
+        assert_eq!(code, -32003);
+    }
+
+    #[test]
+    fn map_error_method_not_found() {
+        let (code, msg, _) = map_error(&DapiError::MethodNotFound("no method".into()));
+        assert_eq!(code, -32601);
+        assert_eq!(msg, "no method");
+    }
+
+    #[test]
+    fn map_error_invalid_request() {
+        let (code, _, _) = map_error(&DapiError::InvalidRequest("bad req".into()));
+        assert_eq!(code, -32600);
+    }
+
+    #[test]
+    fn map_error_not_found() {
+        let (code, msg, _) = map_error(&DapiError::NotFound("missing".into()));
+        assert_eq!(code, -32602); // ERR_NOT_FOUND
+        assert_eq!(msg, "missing");
+    }
+
+    #[test]
+    fn map_error_fallthrough_returns_internal() {
+        let (code, msg, data) = map_error(&DapiError::ConnectionClosed);
+        assert_eq!(code, -32603);
+        assert_eq!(msg, "Internal error");
+        assert!(data.is_some());
+    }
+
+    // -- map_error with DapiError::Status delegates to map_status --
+
+    #[test]
+    fn map_error_status_delegates_to_map_status() {
+        let status = tonic::Status::not_found("item gone");
+        let (code, msg, _) = map_error(&DapiError::Status(status));
+        assert_eq!(code, -32602); // ERR_NOT_FOUND
+        assert_eq!(msg, "item gone");
+    }
+
+    // -- map_status tests with messages --
+
+    #[test]
+    fn map_status_invalid_argument_with_message() {
+        let status = tonic::Status::new(Code::InvalidArgument, "bad param");
+        let (code, msg, _) = map_status(&status);
+        assert_eq!(code, -32602);
+        assert_eq!(msg, "bad param");
+    }
+
+    #[test]
+    fn map_status_failed_precondition_with_message() {
+        let status = tonic::Status::new(Code::FailedPrecondition, "precond fail");
+        let (code, msg, _) = map_status(&status);
+        assert_eq!(code, -32602);
+        assert_eq!(msg, "precond fail");
+    }
+
+    #[test]
+    fn map_status_already_exists_with_message() {
+        let status = tonic::Status::new(Code::AlreadyExists, "dup entry");
+        let (code, msg, _) = map_status(&status);
+        assert_eq!(code, -32602);
+        assert_eq!(msg, "dup entry");
+    }
+
+    #[test]
+    fn map_status_aborted_with_message() {
+        let status = tonic::Status::new(Code::Aborted, "aborted op");
+        let (code, msg, _) = map_status(&status);
+        assert_eq!(code, -32602);
+        assert_eq!(msg, "aborted op");
+    }
+
+    #[test]
+    fn map_status_resource_exhausted_with_message() {
+        let status = tonic::Status::new(Code::ResourceExhausted, "quota exceeded");
+        let (code, msg, _) = map_status(&status);
+        assert_eq!(code, -32602);
+        assert_eq!(msg, "quota exceeded");
+    }
+
+    #[test]
+    fn map_status_not_found_with_message() {
+        let status = tonic::Status::not_found("object missing");
+        let (code, msg, _) = map_status(&status);
+        assert_eq!(code, -32602); // ERR_NOT_FOUND
+        assert_eq!(msg, "object missing");
+    }
+
+    #[test]
+    fn map_status_unavailable() {
+        let status = tonic::Status::unavailable("service down");
+        let (code, msg, _) = map_status(&status);
+        assert_eq!(code, -32003);
+        assert_eq!(msg, "service down");
+    }
+
+    #[test]
+    fn map_status_deadline_exceeded() {
+        let status = tonic::Status::new(Code::DeadlineExceeded, "too slow");
+        let (code, msg, _) = map_status(&status);
+        assert_eq!(code, -32003);
+        assert_eq!(msg, "too slow");
+    }
+
+    #[test]
+    fn map_status_cancelled() {
+        let status = tonic::Status::cancelled("user cancel");
+        let (code, msg, _) = map_status(&status);
+        assert_eq!(code, -32003);
+        assert_eq!(msg, "user cancel");
+    }
+
+    #[test]
+    fn map_status_unknown_code_returns_internal() {
+        let status = tonic::Status::new(Code::DataLoss, "data lost");
+        let (code, msg, data) = map_status(&status);
+        assert_eq!(code, -32603);
+        assert_eq!(msg, "Internal error");
+        assert!(data.is_some());
+    }
+
+    // -- map_status with empty messages uses defaults --
+
+    #[test]
+    fn map_status_empty_message_invalid_argument() {
+        let status = tonic::Status::new(Code::InvalidArgument, "");
+        let (_, msg, _) = map_status(&status);
+        assert_eq!(msg, "Invalid params");
+    }
+
+    #[test]
+    fn map_status_empty_message_failed_precondition() {
+        let status = tonic::Status::new(Code::FailedPrecondition, "");
+        let (_, msg, _) = map_status(&status);
+        assert_eq!(msg, "Failed precondition");
+    }
+
+    #[test]
+    fn map_status_empty_message_already_exists() {
+        let status = tonic::Status::new(Code::AlreadyExists, "");
+        let (_, msg, _) = map_status(&status);
+        assert_eq!(msg, "Already exists");
+    }
+
+    #[test]
+    fn map_status_empty_message_not_found() {
+        let status = tonic::Status::new(Code::NotFound, "");
+        let (_, msg, _) = map_status(&status);
+        assert_eq!(msg, "Not found");
+    }
+
+    #[test]
+    fn map_status_empty_message_aborted() {
+        let status = tonic::Status::new(Code::Aborted, "");
+        let (_, msg, _) = map_status(&status);
+        assert_eq!(msg, "Aborted");
+    }
+
+    #[test]
+    fn map_status_empty_message_resource_exhausted() {
+        let status = tonic::Status::new(Code::ResourceExhausted, "");
+        let (_, msg, _) = map_status(&status);
+        assert_eq!(msg, "Resource exhausted");
+    }
+
+    #[test]
+    fn map_status_empty_message_unavailable() {
+        let status = tonic::Status::new(Code::Unavailable, "");
+        let (_, msg, _) = map_status(&status);
+        assert_eq!(msg, "Service unavailable");
+    }
+
+    #[test]
+    fn map_status_empty_message_other_code() {
+        let status = tonic::Status::new(Code::PermissionDenied, "");
+        let (_, msg, _) = map_status(&status);
+        // Other codes with empty message get "Internal error" as the normalized message
+        assert_eq!(msg, "Internal error");
+    }
+}

--- a/packages/rs-dapi/src/protocol/jsonrpc_translator/error.rs
+++ b/packages/rs-dapi/src/protocol/jsonrpc_translator/error.rs
@@ -242,62 +242,79 @@ mod tests {
         assert!(data.is_some());
     }
 
+    #[test]
+    fn map_status_unimplemented() {
+        let status = tonic::Status::new(Code::Unimplemented, "not implemented");
+        let (code, msg, data) = map_status(&status);
+        assert_eq!(code, -32603);
+        assert_eq!(msg, "Internal error");
+        assert!(data.is_some(), "fallthrough codes should include data");
+    }
+
     // -- map_status with empty messages uses defaults --
 
     #[test]
     fn map_status_empty_message_invalid_argument() {
         let status = tonic::Status::new(Code::InvalidArgument, "");
-        let (_, msg, _) = map_status(&status);
+        let (_, msg, data) = map_status(&status);
         assert_eq!(msg, "Invalid params");
+        assert!(data.is_none(), "matched codes should not include data");
     }
 
     #[test]
     fn map_status_empty_message_failed_precondition() {
         let status = tonic::Status::new(Code::FailedPrecondition, "");
-        let (_, msg, _) = map_status(&status);
+        let (_, msg, data) = map_status(&status);
         assert_eq!(msg, "Failed precondition");
+        assert!(data.is_none(), "matched codes should not include data");
     }
 
     #[test]
     fn map_status_empty_message_already_exists() {
         let status = tonic::Status::new(Code::AlreadyExists, "");
-        let (_, msg, _) = map_status(&status);
+        let (_, msg, data) = map_status(&status);
         assert_eq!(msg, "Already exists");
+        assert!(data.is_none(), "matched codes should not include data");
     }
 
     #[test]
     fn map_status_empty_message_not_found() {
         let status = tonic::Status::new(Code::NotFound, "");
-        let (_, msg, _) = map_status(&status);
+        let (_, msg, data) = map_status(&status);
         assert_eq!(msg, "Not found");
+        assert!(data.is_none(), "matched codes should not include data");
     }
 
     #[test]
     fn map_status_empty_message_aborted() {
         let status = tonic::Status::new(Code::Aborted, "");
-        let (_, msg, _) = map_status(&status);
+        let (_, msg, data) = map_status(&status);
         assert_eq!(msg, "Aborted");
+        assert!(data.is_none(), "matched codes should not include data");
     }
 
     #[test]
     fn map_status_empty_message_resource_exhausted() {
         let status = tonic::Status::new(Code::ResourceExhausted, "");
-        let (_, msg, _) = map_status(&status);
+        let (_, msg, data) = map_status(&status);
         assert_eq!(msg, "Resource exhausted");
+        assert!(data.is_none(), "matched codes should not include data");
     }
 
     #[test]
     fn map_status_empty_message_unavailable() {
         let status = tonic::Status::new(Code::Unavailable, "");
-        let (_, msg, _) = map_status(&status);
+        let (_, msg, data) = map_status(&status);
         assert_eq!(msg, "Service unavailable");
+        assert!(data.is_none(), "matched codes should not include data");
     }
 
     #[test]
     fn map_status_empty_message_other_code() {
         let status = tonic::Status::new(Code::PermissionDenied, "");
-        let (_, msg, _) = map_status(&status);
+        let (_, msg, data) = map_status(&status);
         // Other codes with empty message get "Internal error" as the normalized message
         assert_eq!(msg, "Internal error");
+        assert!(data.is_some(), "fallthrough codes should include data");
     }
 }

--- a/packages/rs-dapi/src/services/platform_service/error_mapping.rs
+++ b/packages/rs-dapi/src/services/platform_service/error_mapping.rs
@@ -425,4 +425,244 @@ mod tests {
         let decoded = decode_consensus_error(info_base64.to_string()).unwrap();
         ConsensusError::deserialize_from_bytes(&decoded).expect("should deserialize");
     }
+
+    // -- map_tenderdash_message tests --
+
+    #[test]
+    fn map_tenderdash_message_tx_already_exists() {
+        let result = map_tenderdash_message("tx already exists in cache");
+        assert!(result.is_some());
+        assert!(matches!(result.unwrap(), DapiError::AlreadyExists(_)));
+    }
+
+    #[test]
+    fn map_tenderdash_message_tx_too_large() {
+        let result = map_tenderdash_message("tx too large. Max size: 100kb");
+        assert!(result.is_some());
+        match result.unwrap() {
+            DapiError::InvalidArgument(msg) => {
+                assert!(msg.contains("state transition is too large"));
+            }
+            other => panic!("expected InvalidArgument, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn map_tenderdash_message_mempool_full() {
+        let result = map_tenderdash_message("mempool is full");
+        assert!(result.is_some());
+        assert!(matches!(result.unwrap(), DapiError::ResourceExhausted(_)));
+    }
+
+    #[test]
+    fn map_tenderdash_message_context_deadline() {
+        let result = map_tenderdash_message("rpc error: context deadline exceeded");
+        assert!(result.is_some());
+        match result.unwrap() {
+            DapiError::Timeout(msg) => {
+                assert!(msg.contains("timed out"));
+            }
+            other => panic!("expected Timeout, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn map_tenderdash_message_too_many_requests() {
+        let result = map_tenderdash_message("too_many_requests");
+        assert!(result.is_some());
+        assert!(matches!(result.unwrap(), DapiError::ResourceExhausted(_)));
+    }
+
+    #[test]
+    fn map_tenderdash_message_broadcast_confirmation() {
+        let result =
+            map_tenderdash_message("broadcast confirmation not received: timed out waiting");
+        assert!(result.is_some());
+        assert!(matches!(result.unwrap(), DapiError::Timeout(_)));
+    }
+
+    #[test]
+    fn map_tenderdash_message_unknown_returns_none() {
+        assert!(map_tenderdash_message("some random error").is_none());
+    }
+
+    // -- TenderdashStatus grpc_code tests --
+
+    #[test]
+    fn grpc_code_standard_codes() {
+        // OK = 0
+        let status = TenderdashStatus::new(0, Some("ok".to_string()), None);
+        assert_eq!(status.to_status().code(), tonic::Code::Ok);
+
+        // InvalidArgument = 3
+        let status = TenderdashStatus::new(3, Some("bad".to_string()), None);
+        assert_eq!(status.to_status().code(), tonic::Code::InvalidArgument);
+    }
+
+    #[test]
+    fn grpc_code_consensus_ranges() {
+        // 10000..20000 => InvalidArgument
+        let status = TenderdashStatus::new(10001, Some("consensus".to_string()), None);
+        assert_eq!(status.to_status().code(), tonic::Code::InvalidArgument);
+
+        // 20000..30000 => Unauthenticated
+        let status = TenderdashStatus::new(25000, Some("auth".to_string()), None);
+        assert_eq!(status.to_status().code(), tonic::Code::Unauthenticated);
+
+        // 30000..40000 => FailedPrecondition
+        let status = TenderdashStatus::new(35000, Some("precond".to_string()), None);
+        assert_eq!(status.to_status().code(), tonic::Code::FailedPrecondition);
+
+        // 40000..50000 => InvalidArgument
+        let status = TenderdashStatus::new(45000, Some("validation".to_string()), None);
+        assert_eq!(status.to_status().code(), tonic::Code::InvalidArgument);
+    }
+
+    #[test]
+    fn grpc_code_out_of_range_returns_internal() {
+        let status = TenderdashStatus::new(99999, Some("unknown".to_string()), None);
+        assert_eq!(status.to_status().code(), tonic::Code::Internal);
+    }
+
+    // -- TenderdashStatus grpc_message tests --
+
+    #[test]
+    fn grpc_message_prefers_explicit_message() {
+        let status = TenderdashStatus::new(1, Some("explicit msg".to_string()), None);
+        let tonic_status = status.to_status();
+        assert_eq!(tonic_status.message(), "explicit msg");
+    }
+
+    #[test]
+    fn grpc_message_fallback_to_unknown_error() {
+        let status = TenderdashStatus::new(42, None, None);
+        let tonic_status = status.to_status();
+        assert!(tonic_status.message().contains("42"));
+    }
+
+    // -- TenderdashStatus::from(Value) tests --
+
+    #[test]
+    fn from_json_value_with_code_and_message() {
+        let value = serde_json::json!({"code": 10, "message": "test error"});
+        let status = TenderdashStatus::from(value);
+        assert_eq!(status.code, 10);
+        assert_eq!(status.message.as_deref(), Some("test error"));
+    }
+
+    #[test]
+    fn from_json_value_missing_code_defaults_to_zero() {
+        let value = serde_json::json!({"message": "no code"});
+        let status = TenderdashStatus::from(value);
+        assert_eq!(status.code, 0);
+    }
+
+    #[test]
+    fn from_json_value_empty_message_uses_data() {
+        let value = serde_json::json!({"code": 1, "message": "", "data": "detail from data"});
+        let status = TenderdashStatus::from(value);
+        assert_eq!(status.message.as_deref(), Some("detail from data"));
+    }
+
+    #[test]
+    fn from_json_value_internal_error_message_uses_data() {
+        let value =
+            serde_json::json!({"code": 1, "message": "Internal error", "data": "real detail"});
+        let status = TenderdashStatus::from(value);
+        assert_eq!(status.message.as_deref(), Some("real detail"));
+    }
+
+    #[test]
+    fn from_json_value_non_object() {
+        let value = serde_json::json!("not an object");
+        let status = TenderdashStatus::from(value);
+        assert_eq!(status.code, u32::MAX as i64);
+        assert!(
+            status
+                .message
+                .as_deref()
+                .unwrap()
+                .contains("Invalid error object")
+        );
+    }
+
+    // -- TenderdashStatus Debug --
+
+    #[test]
+    fn tenderdash_status_debug_format() {
+        let status = TenderdashStatus::new(42, Some("msg".to_string()), Some(vec![0xab, 0xcd]));
+        let debug_str = format!("{:?}", status);
+        assert!(debug_str.contains("42"));
+        assert!(debug_str.contains("msg"));
+        assert!(debug_str.contains("abcd")); // hex encoded consensus error
+    }
+
+    #[test]
+    fn tenderdash_status_debug_no_consensus_error() {
+        let status = TenderdashStatus::new(0, None, None);
+        let debug_str = format!("{:?}", status);
+        assert!(debug_str.contains("None"));
+    }
+
+    // -- base64_decode tests --
+
+    #[test]
+    fn base64_decode_valid() {
+        let decoded = base64_decode("aGVsbG8=");
+        assert_eq!(decoded, Some(b"hello".to_vec()));
+    }
+
+    #[test]
+    fn base64_decode_invalid() {
+        let decoded = base64_decode("!!!not valid base64!!!");
+        assert!(decoded.is_none());
+    }
+
+    #[test]
+    fn base64_decode_unpadded() {
+        // "hello" base64 without padding
+        let decoded = base64_decode("aGVsbG8");
+        assert_eq!(decoded, Some(b"hello".to_vec()));
+    }
+
+    // -- decode_consensus_error with invalid data --
+
+    #[test]
+    fn decode_consensus_error_invalid_base64() {
+        assert!(decode_consensus_error("!!!".to_string()).is_none());
+    }
+
+    #[test]
+    fn decode_consensus_error_not_cbor() {
+        // Valid base64 but not valid CBOR
+        let b64 = base64::prelude::BASE64_STANDARD.encode(b"not cbor data");
+        assert!(decode_consensus_error(b64).is_none());
+    }
+
+    // -- From<TenderdashStatus> for StateTransitionBroadcastError --
+
+    #[test]
+    fn tenderdash_status_to_broadcast_error() {
+        let status = TenderdashStatus::new(42, Some("broadcast err".to_string()), None);
+        let broadcast_err: StateTransitionBroadcastError = status.into();
+        assert_eq!(broadcast_err.code, 42);
+        assert_eq!(broadcast_err.message, "broadcast err");
+    }
+
+    #[test]
+    fn tenderdash_status_to_broadcast_error_clamps_negative_code() {
+        let status = TenderdashStatus::new(-1, Some("neg".to_string()), None);
+        let broadcast_err: StateTransitionBroadcastError = status.into();
+        assert_eq!(broadcast_err.code, 0);
+    }
+
+    // -- to_status with map_tenderdash_message shortcut --
+
+    #[test]
+    fn to_status_maps_known_tenderdash_message() {
+        let status = TenderdashStatus::new(0, Some("tx already exists in cache".to_string()), None);
+        let tonic_status = status.to_status();
+        // "tx already exists in cache" maps to AlreadyExists, which maps to already_exists
+        assert_eq!(tonic_status.code(), tonic::Code::AlreadyExists);
+    }
 }

--- a/packages/rs-dapi/src/services/platform_service/error_mapping.rs
+++ b/packages/rs-dapi/src/services/platform_service/error_mapping.rs
@@ -422,7 +422,7 @@ mod tests {
     )]
     fn test_info_fixture(info_base64: &str) {
         setup_tracing();
-        let decoded = decode_consensus_error(info_base64.to_string()).unwrap();
+        let decoded = decode_consensus_error(info_base64.to_string()).expect("decode consensus error from fixture");
         ConsensusError::deserialize_from_bytes(&decoded).expect("should deserialize");
     }
 
@@ -432,14 +432,14 @@ mod tests {
     fn map_tenderdash_message_tx_already_exists() {
         let result = map_tenderdash_message("tx already exists in cache");
         assert!(result.is_some());
-        assert!(matches!(result.unwrap(), DapiError::AlreadyExists(_)));
+        assert!(matches!(result.expect("should map to AlreadyExists"), DapiError::AlreadyExists(_)));
     }
 
     #[test]
     fn map_tenderdash_message_tx_too_large() {
         let result = map_tenderdash_message("tx too large. Max size: 100kb");
         assert!(result.is_some());
-        match result.unwrap() {
+        match result.expect("should map to InvalidArgument") {
             DapiError::InvalidArgument(msg) => {
                 assert!(msg.contains("state transition is too large"));
             }
@@ -451,14 +451,14 @@ mod tests {
     fn map_tenderdash_message_mempool_full() {
         let result = map_tenderdash_message("mempool is full");
         assert!(result.is_some());
-        assert!(matches!(result.unwrap(), DapiError::ResourceExhausted(_)));
+        assert!(matches!(result.expect("should map to ResourceExhausted"), DapiError::ResourceExhausted(_)));
     }
 
     #[test]
     fn map_tenderdash_message_context_deadline() {
         let result = map_tenderdash_message("rpc error: context deadline exceeded");
         assert!(result.is_some());
-        match result.unwrap() {
+        match result.expect("should map to Timeout") {
             DapiError::Timeout(msg) => {
                 assert!(msg.contains("timed out"));
             }
@@ -470,7 +470,7 @@ mod tests {
     fn map_tenderdash_message_too_many_requests() {
         let result = map_tenderdash_message("too_many_requests");
         assert!(result.is_some());
-        assert!(matches!(result.unwrap(), DapiError::ResourceExhausted(_)));
+        assert!(matches!(result.expect("should map to ResourceExhausted"), DapiError::ResourceExhausted(_)));
     }
 
     #[test]
@@ -478,7 +478,7 @@ mod tests {
         let result =
             map_tenderdash_message("broadcast confirmation not received: timed out waiting");
         assert!(result.is_some());
-        assert!(matches!(result.unwrap(), DapiError::Timeout(_)));
+        assert!(matches!(result.expect("should map to Timeout"), DapiError::Timeout(_)));
     }
 
     #[test]
@@ -581,7 +581,7 @@ mod tests {
             status
                 .message
                 .as_deref()
-                .unwrap()
+                .expect("message should be present for non-object input")
                 .contains("Invalid error object")
         );
     }

--- a/packages/rs-dapi/src/services/platform_service/error_mapping.rs
+++ b/packages/rs-dapi/src/services/platform_service/error_mapping.rs
@@ -422,7 +422,8 @@ mod tests {
     )]
     fn test_info_fixture(info_base64: &str) {
         setup_tracing();
-        let decoded = decode_consensus_error(info_base64.to_string()).expect("decode consensus error from fixture");
+        let decoded = decode_consensus_error(info_base64.to_string())
+            .expect("decode consensus error from fixture");
         ConsensusError::deserialize_from_bytes(&decoded).expect("should deserialize");
     }
 
@@ -432,7 +433,10 @@ mod tests {
     fn map_tenderdash_message_tx_already_exists() {
         let result = map_tenderdash_message("tx already exists in cache");
         assert!(result.is_some());
-        assert!(matches!(result.expect("should map to AlreadyExists"), DapiError::AlreadyExists(_)));
+        assert!(matches!(
+            result.expect("should map to AlreadyExists"),
+            DapiError::AlreadyExists(_)
+        ));
     }
 
     #[test]
@@ -451,7 +455,10 @@ mod tests {
     fn map_tenderdash_message_mempool_full() {
         let result = map_tenderdash_message("mempool is full");
         assert!(result.is_some());
-        assert!(matches!(result.expect("should map to ResourceExhausted"), DapiError::ResourceExhausted(_)));
+        assert!(matches!(
+            result.expect("should map to ResourceExhausted"),
+            DapiError::ResourceExhausted(_)
+        ));
     }
 
     #[test]
@@ -470,7 +477,10 @@ mod tests {
     fn map_tenderdash_message_too_many_requests() {
         let result = map_tenderdash_message("too_many_requests");
         assert!(result.is_some());
-        assert!(matches!(result.expect("should map to ResourceExhausted"), DapiError::ResourceExhausted(_)));
+        assert!(matches!(
+            result.expect("should map to ResourceExhausted"),
+            DapiError::ResourceExhausted(_)
+        ));
     }
 
     #[test]
@@ -478,7 +488,10 @@ mod tests {
         let result =
             map_tenderdash_message("broadcast confirmation not received: timed out waiting");
         assert!(result.is_some());
-        assert!(matches!(result.expect("should map to Timeout"), DapiError::Timeout(_)));
+        assert!(matches!(
+            result.expect("should map to Timeout"),
+            DapiError::Timeout(_)
+        ));
     }
 
     #[test]

--- a/packages/rs-dapi/src/services/platform_service/wait_for_state_transition_result.rs
+++ b/packages/rs-dapi/src/services/platform_service/wait_for_state_transition_result.rs
@@ -310,3 +310,84 @@ pub(super) fn build_wait_for_state_transition_error_response(
     );
     tenderdash_status.into()
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn build_error_response_from_tenderdash_client_error() {
+        let tenderdash_status = TenderdashStatus::new(42, Some("td error".to_string()), None);
+        let error = DapiError::TenderdashClientError(tenderdash_status);
+        let response = build_wait_for_state_transition_error_response(&error);
+        let inner = response.into_inner();
+        match inner.version {
+            Some(
+                dapi_grpc::platform::v0::wait_for_state_transition_result_response::Version::V0(
+                    v0,
+                ),
+            ) => match v0.result {
+                Some(
+                    dapi_grpc::platform::v0::wait_for_state_transition_result_response::wait_for_state_transition_result_response_v0::Result::Error(
+                        st_err,
+                    ),
+                ) => {
+                    assert_eq!(st_err.code, 42);
+                    assert_eq!(st_err.message, "td error");
+                }
+                other => panic!("expected Error result, got {:?}", other),
+            },
+            other => panic!("expected V0, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn build_error_response_from_generic_dapi_error() {
+        let error = DapiError::Timeout("timed out".to_string());
+        let response = build_wait_for_state_transition_error_response(&error);
+        let inner = response.into_inner();
+        match inner.version {
+            Some(
+                dapi_grpc::platform::v0::wait_for_state_transition_result_response::Version::V0(
+                    v0,
+                ),
+            ) => match v0.result {
+                Some(
+                    dapi_grpc::platform::v0::wait_for_state_transition_result_response::wait_for_state_transition_result_response_v0::Result::Error(
+                        st_err,
+                    ),
+                ) => {
+                    // DapiError::Timeout -> to_status() -> internal with message
+                    assert!(!st_err.message.is_empty());
+                }
+                other => panic!("expected Error result, got {:?}", other),
+            },
+            other => panic!("expected V0, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn build_error_response_from_error_with_empty_status_message() {
+        // Internal error with a message should produce non-empty message
+        let error = DapiError::Internal("internal failure".to_string());
+        let response = build_wait_for_state_transition_error_response(&error);
+        let inner = response.into_inner();
+        match inner.version {
+            Some(
+                dapi_grpc::platform::v0::wait_for_state_transition_result_response::Version::V0(
+                    v0,
+                ),
+            ) => match v0.result {
+                Some(
+                    dapi_grpc::platform::v0::wait_for_state_transition_result_response::wait_for_state_transition_result_response_v0::Result::Error(
+                        st_err,
+                    ),
+                ) => {
+                    assert!(st_err.message.contains("internal failure"));
+                }
+                other => panic!("expected Error result, got {:?}", other),
+            },
+            other => panic!("expected V0, got {:?}", other),
+        }
+    }
+}

--- a/packages/rs-dapi/src/services/platform_service/wait_for_state_transition_result.rs
+++ b/packages/rs-dapi/src/services/platform_service/wait_for_state_transition_result.rs
@@ -314,12 +314,13 @@ pub(super) fn build_wait_for_state_transition_error_response(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use dapi_grpc::platform::v0::StateTransitionBroadcastError;
 
-    #[test]
-    fn build_error_response_from_tenderdash_client_error() {
-        let tenderdash_status = TenderdashStatus::new(42, Some("td error".to_string()), None);
-        let error = DapiError::TenderdashClientError(tenderdash_status);
-        let response = build_wait_for_state_transition_error_response(&error);
+    /// Extract the `StateTransitionBroadcastError` from a
+    /// `WaitForStateTransitionResultResponse`, unwrapping the V0 / Error layers.
+    fn extract_st_error(
+        response: Response<WaitForStateTransitionResultResponse>,
+    ) -> StateTransitionBroadcastError {
         let inner = response.into_inner();
         match inner.version {
             Some(
@@ -331,10 +332,7 @@ mod tests {
                     dapi_grpc::platform::v0::wait_for_state_transition_result_response::wait_for_state_transition_result_response_v0::Result::Error(
                         st_err,
                     ),
-                ) => {
-                    assert_eq!(st_err.code, 42);
-                    assert_eq!(st_err.message, "td error");
-                }
+                ) => st_err,
                 other => panic!("expected Error result, got {:?}", other),
             },
             other => panic!("expected V0, got {:?}", other),
@@ -342,28 +340,27 @@ mod tests {
     }
 
     #[test]
+    fn build_error_response_from_tenderdash_client_error() {
+        let tenderdash_status = TenderdashStatus::new(42, Some("td error".to_string()), None);
+        let error = DapiError::TenderdashClientError(tenderdash_status);
+        let response = build_wait_for_state_transition_error_response(&error);
+        let st_err = extract_st_error(response);
+        assert_eq!(st_err.code, 42);
+        assert_eq!(st_err.message, "td error");
+    }
+
+    #[test]
     fn build_error_response_from_generic_dapi_error() {
         let error = DapiError::Timeout("timed out".to_string());
         let response = build_wait_for_state_transition_error_response(&error);
-        let inner = response.into_inner();
-        match inner.version {
-            Some(
-                dapi_grpc::platform::v0::wait_for_state_transition_result_response::Version::V0(
-                    v0,
-                ),
-            ) => match v0.result {
-                Some(
-                    dapi_grpc::platform::v0::wait_for_state_transition_result_response::wait_for_state_transition_result_response_v0::Result::Error(
-                        st_err,
-                    ),
-                ) => {
-                    // DapiError::Timeout -> to_status() -> internal with message
-                    assert!(!st_err.message.is_empty());
-                }
-                other => panic!("expected Error result, got {:?}", other),
-            },
-            other => panic!("expected V0, got {:?}", other),
-        }
+        let st_err = extract_st_error(response);
+        // DapiError::Timeout -> to_status() -> Code::Internal (13)
+        assert_eq!(st_err.code, dapi_grpc::tonic::Code::Internal as u32);
+        assert!(
+            st_err.message.contains("timed out"),
+            "expected message to contain 'timed out', got: {}",
+            st_err.message
+        );
     }
 
     #[test]
@@ -371,23 +368,7 @@ mod tests {
         // Internal error with a message should produce non-empty message
         let error = DapiError::Internal("internal failure".to_string());
         let response = build_wait_for_state_transition_error_response(&error);
-        let inner = response.into_inner();
-        match inner.version {
-            Some(
-                dapi_grpc::platform::v0::wait_for_state_transition_result_response::Version::V0(
-                    v0,
-                ),
-            ) => match v0.result {
-                Some(
-                    dapi_grpc::platform::v0::wait_for_state_transition_result_response::wait_for_state_transition_result_response_v0::Result::Error(
-                        st_err,
-                    ),
-                ) => {
-                    assert!(st_err.message.contains("internal failure"));
-                }
-                other => panic!("expected Error result, got {:?}", other),
-            },
-            other => panic!("expected V0, got {:?}", other),
-        }
+        let st_err = extract_st_error(response);
+        assert!(st_err.message.contains("internal failure"));
     }
 }

--- a/packages/rs-dapi/src/utils.rs
+++ b/packages/rs-dapi/src/utils.rs
@@ -202,14 +202,14 @@ mod tests {
     #[test]
     fn deserialize_string_or_number_from_string() {
         let json = r#"{"value": "42"}"#;
-        let s: TestStruct = serde_json::from_str(json).unwrap();
+        let s: TestStruct = serde_json::from_str(json).expect("deserialize string as u64");
         assert_eq!(s.value, 42);
     }
 
     #[test]
     fn deserialize_string_or_number_from_u64() {
         let json = r#"{"value": 100}"#;
-        let s: TestStruct = serde_json::from_str(json).unwrap();
+        let s: TestStruct = serde_json::from_str(json).expect("deserialize u64");
         assert_eq!(s.value, 100);
     }
 
@@ -221,7 +221,7 @@ mod tests {
             value: f64,
         }
         let json = r#"{"value": 7.25}"#;
-        let s: FloatTest = serde_json::from_str(json).unwrap();
+        let s: FloatTest = serde_json::from_str(json).expect("deserialize f64");
         assert_eq!(s.value, 7.25);
     }
 
@@ -234,7 +234,7 @@ mod tests {
             value: bool,
         }
         let json = r#"{"value": true}"#;
-        let s: BoolTest = serde_json::from_str(json).unwrap();
+        let s: BoolTest = serde_json::from_str(json).expect("deserialize bool");
         assert!(s.value);
     }
 
@@ -246,7 +246,7 @@ mod tests {
             value: i64,
         }
         let json = r#"{"value": -42}"#;
-        let s: I64Test = serde_json::from_str(json).unwrap();
+        let s: I64Test = serde_json::from_str(json).expect("deserialize negative i64");
         assert_eq!(s.value, -42);
     }
 
@@ -261,35 +261,35 @@ mod tests {
     #[test]
     fn deserialize_to_string_from_string() {
         let json = r#"{"value": "hello"}"#;
-        let s: ToStringTest = serde_json::from_str(json).unwrap();
+        let s: ToStringTest = serde_json::from_str(json).expect("deserialize string to string");
         assert_eq!(s.value, "hello");
     }
 
     #[test]
     fn deserialize_to_string_from_u64() {
         let json = r#"{"value": 999}"#;
-        let s: ToStringTest = serde_json::from_str(json).unwrap();
+        let s: ToStringTest = serde_json::from_str(json).expect("deserialize u64 to string");
         assert_eq!(s.value, "999");
     }
 
     #[test]
     fn deserialize_to_string_from_i64() {
         let json = r#"{"value": -50}"#;
-        let s: ToStringTest = serde_json::from_str(json).unwrap();
+        let s: ToStringTest = serde_json::from_str(json).expect("deserialize i64 to string");
         assert_eq!(s.value, "-50");
     }
 
     #[test]
     fn deserialize_to_string_from_f64() {
         let json = r#"{"value": 3.14}"#;
-        let s: ToStringTest = serde_json::from_str(json).unwrap();
+        let s: ToStringTest = serde_json::from_str(json).expect("deserialize f64 to string");
         assert!(s.value.starts_with("3.14"));
     }
 
     #[test]
     fn deserialize_to_string_from_bool() {
         let json = r#"{"value": false}"#;
-        let s: ToStringTest = serde_json::from_str(json).unwrap();
+        let s: ToStringTest = serde_json::from_str(json).expect("deserialize bool to string");
         assert_eq!(s.value, "false");
     }
 
@@ -304,28 +304,28 @@ mod tests {
     #[test]
     fn deserialize_string_number_or_null_from_null() {
         let json = r#"{"value": null}"#;
-        let s: NullableTest = serde_json::from_str(json).unwrap();
+        let s: NullableTest = serde_json::from_str(json).expect("deserialize null");
         assert_eq!(s.value, "");
     }
 
     #[test]
     fn deserialize_string_number_or_null_from_string() {
         let json = r#"{"value": "test"}"#;
-        let s: NullableTest = serde_json::from_str(json).unwrap();
+        let s: NullableTest = serde_json::from_str(json).expect("deserialize string as nullable");
         assert_eq!(s.value, "test");
     }
 
     #[test]
     fn deserialize_string_number_or_null_from_number() {
         let json = r#"{"value": 42}"#;
-        let s: NullableTest = serde_json::from_str(json).unwrap();
+        let s: NullableTest = serde_json::from_str(json).expect("deserialize number as nullable");
         assert_eq!(s.value, "42");
     }
 
     #[test]
     fn deserialize_string_number_or_null_from_bool() {
         let json = r#"{"value": true}"#;
-        let s: NullableTest = serde_json::from_str(json).unwrap();
+        let s: NullableTest = serde_json::from_str(json).expect("deserialize bool as nullable");
         assert_eq!(s.value, "true");
     }
 

--- a/packages/rs-dapi/src/utils.rs
+++ b/packages/rs-dapi/src/utils.rs
@@ -215,11 +215,14 @@ mod tests {
 
     #[test]
     fn deserialize_string_or_number_from_float() {
-        // Note: f64 "3.0" parsed as string then from_str to u64 will fail
-        // But integer-valued floats should work if FromStr accepts them
-        let json = r#"{"value": 7}"#;
-        let s: TestStruct = serde_json::from_str(json).unwrap();
-        assert_eq!(s.value, 7);
+        #[derive(Deserialize)]
+        struct FloatTest {
+            #[serde(deserialize_with = "deserialize_string_or_number")]
+            value: f64,
+        }
+        let json = r#"{"value": 7.25}"#;
+        let s: FloatTest = serde_json::from_str(json).unwrap();
+        assert_eq!(s.value, 7.25);
     }
 
     #[test]

--- a/packages/rs-dapi/src/utils.rs
+++ b/packages/rs-dapi/src/utils.rs
@@ -161,3 +161,176 @@ where
         ))),
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde::Deserialize;
+
+    // -- generate_jsonrpc_id --
+
+    #[test]
+    fn generate_jsonrpc_id_is_unique() {
+        let id1 = generate_jsonrpc_id();
+        let id2 = generate_jsonrpc_id();
+        assert_ne!(id1, id2);
+    }
+
+    #[test]
+    fn generate_jsonrpc_id_has_expected_format() {
+        let id = generate_jsonrpc_id();
+        let parts: Vec<&str> = id.split('-').collect();
+        assert_eq!(parts.len(), 3, "id should have 3 hyphen-separated parts");
+        // All parts should be numeric
+        for part in &parts {
+            assert!(
+                part.parse::<u64>().is_ok(),
+                "part '{}' should be numeric",
+                part
+            );
+        }
+    }
+
+    // -- deserialize_string_or_number --
+
+    #[derive(Deserialize)]
+    struct TestStruct {
+        #[serde(deserialize_with = "deserialize_string_or_number")]
+        value: u64,
+    }
+
+    #[test]
+    fn deserialize_string_or_number_from_string() {
+        let json = r#"{"value": "42"}"#;
+        let s: TestStruct = serde_json::from_str(json).unwrap();
+        assert_eq!(s.value, 42);
+    }
+
+    #[test]
+    fn deserialize_string_or_number_from_u64() {
+        let json = r#"{"value": 100}"#;
+        let s: TestStruct = serde_json::from_str(json).unwrap();
+        assert_eq!(s.value, 100);
+    }
+
+    #[test]
+    fn deserialize_string_or_number_from_float() {
+        // Note: f64 "3.0" parsed as string then from_str to u64 will fail
+        // But integer-valued floats should work if FromStr accepts them
+        let json = r#"{"value": 7}"#;
+        let s: TestStruct = serde_json::from_str(json).unwrap();
+        assert_eq!(s.value, 7);
+    }
+
+    #[test]
+    fn deserialize_string_or_number_from_bool_true() {
+        // bool "true" -> "true" -> u64 from_str will fail, so test with a type that supports it
+        #[derive(Deserialize)]
+        struct BoolTest {
+            #[serde(deserialize_with = "deserialize_string_or_number")]
+            value: bool,
+        }
+        let json = r#"{"value": true}"#;
+        let s: BoolTest = serde_json::from_str(json).unwrap();
+        assert!(s.value);
+    }
+
+    #[test]
+    fn deserialize_string_or_number_from_negative_i64() {
+        #[derive(Deserialize)]
+        struct I64Test {
+            #[serde(deserialize_with = "deserialize_string_or_number")]
+            value: i64,
+        }
+        let json = r#"{"value": -42}"#;
+        let s: I64Test = serde_json::from_str(json).unwrap();
+        assert_eq!(s.value, -42);
+    }
+
+    // -- deserialize_to_string --
+
+    #[derive(Deserialize)]
+    struct ToStringTest {
+        #[serde(deserialize_with = "deserialize_to_string")]
+        value: String,
+    }
+
+    #[test]
+    fn deserialize_to_string_from_string() {
+        let json = r#"{"value": "hello"}"#;
+        let s: ToStringTest = serde_json::from_str(json).unwrap();
+        assert_eq!(s.value, "hello");
+    }
+
+    #[test]
+    fn deserialize_to_string_from_u64() {
+        let json = r#"{"value": 999}"#;
+        let s: ToStringTest = serde_json::from_str(json).unwrap();
+        assert_eq!(s.value, "999");
+    }
+
+    #[test]
+    fn deserialize_to_string_from_i64() {
+        let json = r#"{"value": -50}"#;
+        let s: ToStringTest = serde_json::from_str(json).unwrap();
+        assert_eq!(s.value, "-50");
+    }
+
+    #[test]
+    fn deserialize_to_string_from_f64() {
+        let json = r#"{"value": 3.14}"#;
+        let s: ToStringTest = serde_json::from_str(json).unwrap();
+        assert!(s.value.starts_with("3.14"));
+    }
+
+    #[test]
+    fn deserialize_to_string_from_bool() {
+        let json = r#"{"value": false}"#;
+        let s: ToStringTest = serde_json::from_str(json).unwrap();
+        assert_eq!(s.value, "false");
+    }
+
+    // -- deserialize_string_number_or_null --
+
+    #[derive(Debug, Deserialize)]
+    struct NullableTest {
+        #[serde(deserialize_with = "deserialize_string_number_or_null")]
+        value: String,
+    }
+
+    #[test]
+    fn deserialize_string_number_or_null_from_null() {
+        let json = r#"{"value": null}"#;
+        let s: NullableTest = serde_json::from_str(json).unwrap();
+        assert_eq!(s.value, "");
+    }
+
+    #[test]
+    fn deserialize_string_number_or_null_from_string() {
+        let json = r#"{"value": "test"}"#;
+        let s: NullableTest = serde_json::from_str(json).unwrap();
+        assert_eq!(s.value, "test");
+    }
+
+    #[test]
+    fn deserialize_string_number_or_null_from_number() {
+        let json = r#"{"value": 42}"#;
+        let s: NullableTest = serde_json::from_str(json).unwrap();
+        assert_eq!(s.value, "42");
+    }
+
+    #[test]
+    fn deserialize_string_number_or_null_from_bool() {
+        let json = r#"{"value": true}"#;
+        let s: NullableTest = serde_json::from_str(json).unwrap();
+        assert_eq!(s.value, "true");
+    }
+
+    #[test]
+    fn deserialize_string_number_or_null_from_array_fails() {
+        let json = r#"{"value": [1, 2]}"#;
+        let result: Result<NullableTest, _> = serde_json::from_str(json);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("expected string"));
+    }
+}


### PR DESCRIPTION
## Issue being fixed or feature implemented

Improve unit test coverage for the `packages/rs-dapi/src/` module, which had only 39% line coverage.

## What was done?

Added comprehensive unit tests across 9 source files, raising overall line coverage from 39% to 52%. Tests focus on error conversion logic, JSON-RPC/gRPC protocol translation, deserialization helpers, metrics infrastructure, logging middleware, and error mapping -- all pure logic functions that are unit-testable without network dependencies.

**Coverage improvements by file:**

| File | Before | After | Delta |
|------|--------|-------|-------|
| `error.rs` | 7% | 94% | +87% |
| `protocol/jsonrpc_translator/error.rs` | 30% | 100% | +70% |
| `config/utils.rs` | 18% | 88% | +70% |
| `metrics.rs` | 33% | 87% | +55% |
| `error_mapping.rs` | 51% | 91% | +40% |
| `utils.rs` | 53% | 93% | +40% |
| `logging/middleware.rs` | 41% | 73% | +32% |
| `wait_for_state_transition_result.rs` | 0% | 19% | +19% |
| `logging/access_log.rs` | 80% | 90% | +10% |

**What is tested:**
- `error.rs`: `to_status`, `into_legacy_status`, `From` impls (boxed errors, dashcore_rpc errors, tonic::Status), all constructor helpers, `no_valid_tx_proof` (32-byte hash vs hashing), `map_join_result`, `MapToDapiResult`
- `jsonrpc_translator/error.rs`: `map_error` for all `DapiError` variants; `map_status` with all gRPC codes (both with messages and empty-message defaults)
- `utils.rs`: `generate_jsonrpc_id` uniqueness/format, `deserialize_string_or_number` from string/u64/i64/bool, `deserialize_to_string` from all types, `deserialize_string_number_or_null` including null/array error
- `metrics.rs`: `clamp_to_i64` boundary, `endpoint_label` for gRPC/JSON-RPC/HTTP with/without hints, `MethodLabel`/`Metric`/`Label`/`Outcome` enums, `Metrics` struct, all metric recording functions
- `config/utils.rs`: `from_str_or_bool` (true/false/1/0/yes/no/on/off + native bool + invalid), `from_str_or_number`
- `error_mapping.rs`: `map_tenderdash_message` (all 6 match arms + no-match), `TenderdashStatus::grpc_code` (standard + consensus code ranges), `grpc_message` fallbacks, `From<Value>` (object/non-object/missing-code/empty-message), Debug formatting, `base64_decode`, `From<TenderdashStatus> for StateTransitionBroadcastError`
- `logging/middleware.rs`: `detect_protocol_type` (JSON-RPC, gRPC content-type, gRPC headers, HTTP/2 paths, plain HTTP), `parse_grpc_path` (edge cases), `http_status_to_grpc_status` (all known + unknown codes), `extract_grpc_status` fallbacks
- `logging/access_log.rs`: `grpc_status_to_http_status` (remaining codes), gRPC JSON fields, null optional fields, combined format defaults
- `wait_for_state_transition_result.rs`: `build_wait_for_state_transition_error_response` (TenderdashClientError, generic DapiError, empty status message)

## How Has This Been Tested?

- `cargo test --package rs-dapi --all-features` -- all 267 tests pass (177 new)
- `cargo llvm-cov test --package rs-dapi --all-features` -- verified coverage improvements
- `cargo fmt --package rs-dapi` -- formatting verified

## Breaking Changes

None. Only test code was added.

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [x] I have made corresponding changes to the documentation if needed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved error mapping to provide clearer translated error responses from external RPC sources.

* **Tests**
  * Extensive new unit tests across error handling, logging, metrics, configuration deserializers, protocol translation, platform services, and utilities to boost reliability and coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->