### PR TITLE
test(drive-abci): improve validator_queries test coverage

### DIFF
--- a/packages/rs-drive-abci/src/query/validator_queries/proposed_block_counts_by_evonode_ids/mod.rs
+++ b/packages/rs-drive-abci/src/query/validator_queries/proposed_block_counts_by_evonode_ids/mod.rs
@@ -65,3 +65,54 @@ impl<C> Platform<C> {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::query::tests::setup_platform;
+    use dapi_grpc::platform::v0::get_evonodes_proposed_epoch_blocks_by_ids_request::GetEvonodesProposedEpochBlocksByIdsRequestV0;
+    use dpp::dashcore::Network;
+
+    #[test]
+    fn test_missing_version_returns_decoding_error() {
+        let (platform, state, version) = setup_platform(Some((1, 1)), Network::Testnet, None);
+
+        let request = GetEvonodesProposedEpochBlocksByIdsRequest { version: None };
+
+        let result = platform
+            .query_proposed_block_counts_by_evonode_ids(request, &state, version)
+            .expect("expected query to succeed");
+
+        assert!(matches!(
+            result.errors.as_slice(),
+            [QueryError::DecodingError(msg)] if msg.contains("by ids")
+        ));
+    }
+
+    #[test]
+    fn test_v0_request_passes_through() {
+        let (platform, state, version) = setup_platform(Some((1, 1)), Network::Testnet, None);
+
+        let request = GetEvonodesProposedEpochBlocksByIdsRequest {
+            version: Some(RequestVersion::V0(
+                GetEvonodesProposedEpochBlocksByIdsRequestV0 {
+                    epoch: Some(0),
+                    ids: vec![vec![0u8; 32]],
+                    prove: true,
+                },
+            )),
+        };
+
+        let result = platform
+            .query_proposed_block_counts_by_evonode_ids(request, &state, version)
+            .expect("expected query to succeed");
+
+        assert!(result.errors.is_empty());
+        assert!(matches!(
+            result.data,
+            Some(GetEvonodesProposedEpochBlocksResponse {
+                version: Some(ResponseVersion::V0(_)),
+            })
+        ));
+    }
+}

--- a/packages/rs-drive-abci/src/query/validator_queries/proposed_block_counts_by_evonode_ids/v0/mod.rs
+++ b/packages/rs-drive-abci/src/query/validator_queries/proposed_block_counts_by_evonode_ids/v0/mod.rs
@@ -109,3 +109,206 @@ impl<C> Platform<C> {
         Ok(QueryValidationResult::new_with_data(response))
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::query::tests::setup_platform;
+    use dpp::dashcore::Network;
+
+    #[test]
+    fn test_query_too_many_ids() {
+        let (platform, state, version) = setup_platform(Some((1, 1)), Network::Testnet, None);
+
+        let ids: Vec<Vec<u8>> = (0..=platform.platform.config.drive.max_query_limit)
+            .map(|i| {
+                let mut id = [0u8; 32];
+                id[0] = (i & 0xFF) as u8;
+                id[1] = ((i >> 8) & 0xFF) as u8;
+                id.to_vec()
+            })
+            .collect();
+
+        let request = GetEvonodesProposedEpochBlocksByIdsRequestV0 {
+            epoch: Some(0),
+            ids,
+            prove: false,
+        };
+
+        let result = platform
+            .query_proposed_block_counts_by_evonode_ids_v0(request, &state, version)
+            .expect("expected query to succeed");
+
+        assert!(matches!(
+            result.errors.as_slice(),
+            [QueryError::TooManyElements(msg)] if msg.contains("ids at a time")
+        ));
+    }
+
+    #[test]
+    fn test_query_invalid_id_length() {
+        let (platform, state, version) = setup_platform(Some((1, 1)), Network::Testnet, None);
+
+        let request = GetEvonodesProposedEpochBlocksByIdsRequestV0 {
+            epoch: Some(0),
+            ids: vec![vec![1, 2, 3]], // too short
+            prove: false,
+        };
+
+        let result = platform
+            .query_proposed_block_counts_by_evonode_ids_v0(request, &state, version)
+            .expect("expected query to succeed");
+
+        assert!(matches!(
+            result.errors.as_slice(),
+            [QueryError::InvalidArgument(msg)] if msg.contains("32 bytes")
+        ));
+    }
+
+    #[test]
+    fn test_query_epoch_too_high() {
+        let (platform, state, version) = setup_platform(Some((1, 1)), Network::Testnet, None);
+
+        let request = GetEvonodesProposedEpochBlocksByIdsRequestV0 {
+            epoch: Some(u16::MAX as u32),
+            ids: vec![vec![0u8; 32]],
+            prove: false,
+        };
+
+        let result = platform
+            .query_proposed_block_counts_by_evonode_ids_v0(request, &state, version)
+            .expect("expected query to succeed");
+
+        assert!(matches!(
+            result.errors.as_slice(),
+            [QueryError::InvalidArgument(msg)] if msg.contains("epoch must be within a normal range")
+        ));
+    }
+
+    #[test]
+    fn test_query_no_epoch_uses_current_prove() {
+        let (platform, state, version) = setup_platform(Some((1, 1)), Network::Testnet, None);
+
+        let request = GetEvonodesProposedEpochBlocksByIdsRequestV0 {
+            epoch: None,
+            ids: vec![vec![0u8; 32]],
+            prove: true,
+        };
+
+        let result = platform
+            .query_proposed_block_counts_by_evonode_ids_v0(request, &state, version)
+            .expect("expected query to succeed");
+
+        assert!(result.errors.is_empty());
+        assert!(matches!(
+            result.data,
+            Some(GetEvonodesProposedEpochBlocksResponseV0 {
+                result: Some(get_evonodes_proposed_epoch_blocks_response_v0::Result::Proof(_)),
+                metadata: Some(_),
+            })
+        ));
+    }
+
+    #[test]
+    fn test_query_empty_ids_non_prove() {
+        let (platform, state, version) = setup_platform(Some((1, 1)), Network::Testnet, None);
+
+        let request = GetEvonodesProposedEpochBlocksByIdsRequestV0 {
+            epoch: Some(0),
+            ids: vec![],
+            prove: false,
+        };
+
+        let result = platform
+            .query_proposed_block_counts_by_evonode_ids_v0(request, &state, version)
+            .expect("expected query to succeed");
+
+        assert!(result.errors.is_empty());
+        if let Some(GetEvonodesProposedEpochBlocksResponseV0 {
+            result:
+                Some(
+                    get_evonodes_proposed_epoch_blocks_response_v0::Result::EvonodesProposedBlockCountsInfo(
+                        info,
+                    ),
+                ),
+            metadata: Some(_),
+        }) = result.data
+        {
+            assert!(info.evonodes_proposed_block_counts.is_empty());
+        } else {
+            panic!("expected EvonodesProposedBlockCountsInfo result");
+        }
+    }
+
+    #[test]
+    fn test_query_multiple_ids_prove() {
+        let (platform, state, version) = setup_platform(Some((1, 1)), Network::Testnet, None);
+
+        let request = GetEvonodesProposedEpochBlocksByIdsRequestV0 {
+            epoch: Some(0),
+            ids: vec![vec![1u8; 32], vec![2u8; 32]],
+            prove: true,
+        };
+
+        let result = platform
+            .query_proposed_block_counts_by_evonode_ids_v0(request, &state, version)
+            .expect("expected query to succeed");
+
+        assert!(result.errors.is_empty());
+        assert!(matches!(
+            result.data,
+            Some(GetEvonodesProposedEpochBlocksResponseV0 {
+                result: Some(get_evonodes_proposed_epoch_blocks_response_v0::Result::Proof(_)),
+                metadata: Some(_),
+            })
+        ));
+    }
+
+    #[test]
+    fn test_query_valid_ids_prove() {
+        let (platform, state, version) = setup_platform(Some((1, 1)), Network::Testnet, None);
+
+        let request = GetEvonodesProposedEpochBlocksByIdsRequestV0 {
+            epoch: Some(0),
+            ids: vec![vec![1u8; 32]],
+            prove: true,
+        };
+
+        let result = platform
+            .query_proposed_block_counts_by_evonode_ids_v0(request, &state, version)
+            .expect("expected query to succeed");
+
+        assert!(result.errors.is_empty());
+        assert!(matches!(
+            result.data,
+            Some(GetEvonodesProposedEpochBlocksResponseV0 {
+                result: Some(get_evonodes_proposed_epoch_blocks_response_v0::Result::Proof(_)),
+                metadata: Some(_),
+            })
+        ));
+    }
+
+    #[test]
+    fn test_query_with_explicit_epoch_prove() {
+        let (platform, state, version) = setup_platform(Some((1, 1)), Network::Testnet, None);
+
+        let request = GetEvonodesProposedEpochBlocksByIdsRequestV0 {
+            epoch: Some(5),
+            ids: vec![vec![0u8; 32]],
+            prove: true,
+        };
+
+        let result = platform
+            .query_proposed_block_counts_by_evonode_ids_v0(request, &state, version)
+            .expect("expected query to succeed");
+
+        assert!(result.errors.is_empty());
+        assert!(matches!(
+            result.data,
+            Some(GetEvonodesProposedEpochBlocksResponseV0 {
+                result: Some(get_evonodes_proposed_epoch_blocks_response_v0::Result::Proof(_)),
+                metadata: Some(_),
+            })
+        ));
+    }
+}

--- a/packages/rs-drive-abci/src/query/validator_queries/proposed_block_counts_by_range/mod.rs
+++ b/packages/rs-drive-abci/src/query/validator_queries/proposed_block_counts_by_range/mod.rs
@@ -65,3 +65,55 @@ impl<C> Platform<C> {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::query::tests::setup_platform;
+    use dapi_grpc::platform::v0::get_evonodes_proposed_epoch_blocks_by_range_request::GetEvonodesProposedEpochBlocksByRangeRequestV0;
+    use dpp::dashcore::Network;
+
+    #[test]
+    fn test_missing_version_returns_decoding_error() {
+        let (platform, state, version) = setup_platform(Some((1, 1)), Network::Testnet, None);
+
+        let request = GetEvonodesProposedEpochBlocksByRangeRequest { version: None };
+
+        let result = platform
+            .query_proposed_block_counts_by_range(request, &state, version)
+            .expect("expected query to succeed");
+
+        assert!(matches!(
+            result.errors.as_slice(),
+            [QueryError::DecodingError(msg)] if msg.contains("by range")
+        ));
+    }
+
+    #[test]
+    fn test_v0_request_passes_through() {
+        let (platform, state, version) = setup_platform(Some((1, 1)), Network::Testnet, None);
+
+        let request = GetEvonodesProposedEpochBlocksByRangeRequest {
+            version: Some(RequestVersion::V0(
+                GetEvonodesProposedEpochBlocksByRangeRequestV0 {
+                    epoch: Some(0),
+                    limit: Some(10),
+                    start: None,
+                    prove: false,
+                },
+            )),
+        };
+
+        let result = platform
+            .query_proposed_block_counts_by_range(request, &state, version)
+            .expect("expected query to succeed");
+
+        assert!(result.errors.is_empty());
+        assert!(matches!(
+            result.data,
+            Some(GetEvonodesProposedEpochBlocksResponse {
+                version: Some(ResponseVersion::V0(_)),
+            })
+        ));
+    }
+}

--- a/packages/rs-drive-abci/src/query/validator_queries/proposed_block_counts_by_range/v0/mod.rs
+++ b/packages/rs-drive-abci/src/query/validator_queries/proposed_block_counts_by_range/v0/mod.rs
@@ -141,3 +141,319 @@ impl<C> Platform<C> {
         Ok(QueryValidationResult::new_with_data(response))
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::query::tests::setup_platform;
+    use dpp::dashcore::Network;
+
+    #[test]
+    fn test_query_limit_zero_returns_error() {
+        let (platform, _state, _version) = setup_platform(Some((1, 1)), Network::Testnet, None);
+
+        let request = GetEvonodesProposedEpochBlocksByRangeRequestV0 {
+            epoch: Some(0),
+            limit: Some(0),
+            start: None,
+            prove: false,
+        };
+
+        let result = platform.query_proposed_block_counts_by_range_v0(request, &_state, _version);
+
+        assert!(result.is_err(), "limit of 0 should return an error");
+    }
+
+    #[test]
+    fn test_query_limit_exceeds_max_returns_error() {
+        let (platform, state, version) = setup_platform(Some((1, 1)), Network::Testnet, None);
+
+        let over_limit = platform.platform.config.drive.max_query_limit as u32 + 1;
+        let request = GetEvonodesProposedEpochBlocksByRangeRequestV0 {
+            epoch: Some(0),
+            limit: Some(over_limit),
+            start: None,
+            prove: false,
+        };
+
+        let result = platform.query_proposed_block_counts_by_range_v0(request, &state, version);
+
+        assert!(result.is_err(), "limit over max should return an error");
+    }
+
+    #[test]
+    fn test_query_limit_exceeds_u16_max_returns_error() {
+        let (platform, state, version) = setup_platform(Some((1, 1)), Network::Testnet, None);
+
+        let request = GetEvonodesProposedEpochBlocksByRangeRequestV0 {
+            epoch: Some(0),
+            limit: Some(u16::MAX as u32 + 1),
+            start: None,
+            prove: false,
+        };
+
+        let result = platform.query_proposed_block_counts_by_range_v0(request, &state, version);
+
+        assert!(
+            result.is_err(),
+            "limit over u16::MAX should return an error"
+        );
+    }
+
+    #[test]
+    fn test_query_no_limit_uses_default() {
+        let (platform, state, version) = setup_platform(Some((1, 1)), Network::Testnet, None);
+
+        let request = GetEvonodesProposedEpochBlocksByRangeRequestV0 {
+            epoch: Some(0),
+            limit: None,
+            start: None,
+            prove: false,
+        };
+
+        let result = platform
+            .query_proposed_block_counts_by_range_v0(request, &state, version)
+            .expect("expected query to succeed");
+
+        assert!(result.errors.is_empty());
+        assert!(matches!(
+            result.data,
+            Some(GetEvonodesProposedEpochBlocksResponseV0 {
+                result: Some(
+                    get_evonodes_proposed_epoch_blocks_response_v0::Result::EvonodesProposedBlockCountsInfo(_)
+                ),
+                metadata: Some(_),
+            })
+        ));
+    }
+
+    #[test]
+    fn test_query_invalid_start_after_length() {
+        let (platform, state, version) = setup_platform(Some((1, 1)), Network::Testnet, None);
+
+        let request = GetEvonodesProposedEpochBlocksByRangeRequestV0 {
+            epoch: Some(0),
+            limit: Some(10),
+            start: Some(Start::StartAfter(vec![1, 2, 3])), // not 32 bytes
+            prove: false,
+        };
+
+        let result = platform
+            .query_proposed_block_counts_by_range_v0(request, &state, version)
+            .expect("expected query to succeed");
+
+        assert!(matches!(
+            result.errors.as_slice(),
+            [QueryError::Query(
+                QuerySyntaxError::InvalidStartsWithClause(_)
+            )]
+        ));
+    }
+
+    #[test]
+    fn test_query_invalid_start_at_length() {
+        let (platform, state, version) = setup_platform(Some((1, 1)), Network::Testnet, None);
+
+        let request = GetEvonodesProposedEpochBlocksByRangeRequestV0 {
+            epoch: Some(0),
+            limit: Some(10),
+            start: Some(Start::StartAt(vec![1, 2, 3, 4])), // not 32 bytes
+            prove: false,
+        };
+
+        let result = platform
+            .query_proposed_block_counts_by_range_v0(request, &state, version)
+            .expect("expected query to succeed");
+
+        assert!(matches!(
+            result.errors.as_slice(),
+            [QueryError::Query(
+                QuerySyntaxError::InvalidStartsWithClause(_)
+            )]
+        ));
+    }
+
+    #[test]
+    fn test_query_epoch_too_high() {
+        let (platform, state, version) = setup_platform(Some((1, 1)), Network::Testnet, None);
+
+        let request = GetEvonodesProposedEpochBlocksByRangeRequestV0 {
+            epoch: Some(u16::MAX as u32),
+            limit: Some(10),
+            start: None,
+            prove: false,
+        };
+
+        let result = platform
+            .query_proposed_block_counts_by_range_v0(request, &state, version)
+            .expect("expected query to succeed");
+
+        assert!(matches!(
+            result.errors.as_slice(),
+            [QueryError::InvalidArgument(msg)] if msg.contains("epoch must be within a normal range")
+        ));
+    }
+
+    #[test]
+    fn test_query_no_epoch_uses_current() {
+        let (platform, state, version) = setup_platform(Some((1, 1)), Network::Testnet, None);
+
+        let request = GetEvonodesProposedEpochBlocksByRangeRequestV0 {
+            epoch: None,
+            limit: Some(10),
+            start: None,
+            prove: false,
+        };
+
+        let result = platform
+            .query_proposed_block_counts_by_range_v0(request, &state, version)
+            .expect("expected query to succeed");
+
+        assert!(result.errors.is_empty());
+        assert!(matches!(
+            result.data,
+            Some(GetEvonodesProposedEpochBlocksResponseV0 {
+                result: Some(
+                    get_evonodes_proposed_epoch_blocks_response_v0::Result::EvonodesProposedBlockCountsInfo(_)
+                ),
+                metadata: Some(_),
+            })
+        ));
+    }
+
+    #[test]
+    fn test_query_non_prove_empty_results() {
+        let (platform, state, version) = setup_platform(Some((1, 1)), Network::Testnet, None);
+
+        let request = GetEvonodesProposedEpochBlocksByRangeRequestV0 {
+            epoch: Some(0),
+            limit: Some(10),
+            start: None,
+            prove: false,
+        };
+
+        let result = platform
+            .query_proposed_block_counts_by_range_v0(request, &state, version)
+            .expect("expected query to succeed");
+
+        assert!(result.errors.is_empty());
+        if let Some(GetEvonodesProposedEpochBlocksResponseV0 {
+            result:
+                Some(
+                    get_evonodes_proposed_epoch_blocks_response_v0::Result::EvonodesProposedBlockCountsInfo(
+                        info,
+                    ),
+                ),
+            metadata: Some(_),
+        }) = result.data
+        {
+            assert!(info.evonodes_proposed_block_counts.is_empty());
+        } else {
+            panic!("expected EvonodesProposedBlockCountsInfo result");
+        }
+    }
+
+    #[test]
+    fn test_query_prove_path() {
+        let (platform, state, version) = setup_platform(Some((1, 1)), Network::Testnet, None);
+
+        let request = GetEvonodesProposedEpochBlocksByRangeRequestV0 {
+            epoch: Some(0),
+            limit: Some(10),
+            start: None,
+            prove: true,
+        };
+
+        let result = platform
+            .query_proposed_block_counts_by_range_v0(request, &state, version)
+            .expect("expected query to succeed");
+
+        assert!(result.errors.is_empty());
+        assert!(matches!(
+            result.data,
+            Some(GetEvonodesProposedEpochBlocksResponseV0 {
+                result: Some(get_evonodes_proposed_epoch_blocks_response_v0::Result::Proof(_)),
+                metadata: Some(_),
+            })
+        ));
+    }
+
+    #[test]
+    fn test_query_with_valid_start_after() {
+        let (platform, state, version) = setup_platform(Some((1, 1)), Network::Testnet, None);
+
+        let request = GetEvonodesProposedEpochBlocksByRangeRequestV0 {
+            epoch: Some(0),
+            limit: Some(10),
+            start: Some(Start::StartAfter(vec![0u8; 32])),
+            prove: false,
+        };
+
+        let result = platform
+            .query_proposed_block_counts_by_range_v0(request, &state, version)
+            .expect("expected query to succeed");
+
+        assert!(result.errors.is_empty());
+        assert!(matches!(
+            result.data,
+            Some(GetEvonodesProposedEpochBlocksResponseV0 {
+                result: Some(
+                    get_evonodes_proposed_epoch_blocks_response_v0::Result::EvonodesProposedBlockCountsInfo(_)
+                ),
+                metadata: Some(_),
+            })
+        ));
+    }
+
+    #[test]
+    fn test_query_with_valid_start_at() {
+        let (platform, state, version) = setup_platform(Some((1, 1)), Network::Testnet, None);
+
+        let request = GetEvonodesProposedEpochBlocksByRangeRequestV0 {
+            epoch: Some(0),
+            limit: Some(10),
+            start: Some(Start::StartAt(vec![0u8; 32])),
+            prove: false,
+        };
+
+        let result = platform
+            .query_proposed_block_counts_by_range_v0(request, &state, version)
+            .expect("expected query to succeed");
+
+        assert!(result.errors.is_empty());
+        assert!(matches!(
+            result.data,
+            Some(GetEvonodesProposedEpochBlocksResponseV0 {
+                result: Some(
+                    get_evonodes_proposed_epoch_blocks_response_v0::Result::EvonodesProposedBlockCountsInfo(_)
+                ),
+                metadata: Some(_),
+            })
+        ));
+    }
+
+    #[test]
+    fn test_query_with_valid_start_at_prove() {
+        let (platform, state, version) = setup_platform(Some((1, 1)), Network::Testnet, None);
+
+        let request = GetEvonodesProposedEpochBlocksByRangeRequestV0 {
+            epoch: Some(0),
+            limit: Some(10),
+            start: Some(Start::StartAt(vec![0u8; 32])),
+            prove: true,
+        };
+
+        let result = platform
+            .query_proposed_block_counts_by_range_v0(request, &state, version)
+            .expect("expected query to succeed");
+
+        assert!(result.errors.is_empty());
+        assert!(matches!(
+            result.data,
+            Some(GetEvonodesProposedEpochBlocksResponseV0 {
+                result: Some(get_evonodes_proposed_epoch_blocks_response_v0::Result::Proof(_)),
+                metadata: Some(_),
+            })
+        ));
+    }
+}


### PR DESCRIPTION
## Issue being fixed or feature implemented

Improve test coverage for `packages/rs-drive-abci/src/query/validator_queries/` module, which previously had 0% coverage across all files.

## What was done?

Added 25 unit tests covering the `validator_queries` module:

**`proposed_block_counts_by_evonode_ids/v0`** (8 tests):
- Too many IDs exceeding max query limit
- Invalid ID length (not 32 bytes)
- Epoch value exceeding valid range
- No epoch provided (defaults to current epoch)
- Empty IDs list (non-prove path)
- Multiple IDs with proof
- Single ID with proof
- Explicit epoch with proof

**`proposed_block_counts_by_range/v0`** (13 tests):
- Limit of zero returns error
- Limit exceeding max query limit returns error
- Limit exceeding u16::MAX returns error
- No limit uses default query limit
- Invalid StartAfter identifier length
- Invalid StartAt identifier length
- Epoch value exceeding valid range
- No epoch provided (defaults to current epoch)
- Empty range results (non-prove path)
- Prove path returns proof
- Valid StartAfter with non-prove path
- Valid StartAt with non-prove path
- Valid StartAt with prove path

**Version dispatch** (4 tests across both modules):
- Missing version returns decoding error
- V0 request passes through correctly

## How Has This Been Tested?

All 25 tests pass locally:
```
cargo test --package drive-abci --all-features -- validator_queries
test result: ok. 25 passed; 0 failed; 0 ignored
```

## Breaking Changes

None. Test-only changes.

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [x] I have made corresponding changes to the documentation if needed