### PR TITLE
test(rs-dapi): improve test coverage for rs-dapi-client

### DIFF
--- a/packages/rs-dapi-client/src/address_list.rs
+++ b/packages/rs-dapi-client/src/address_list.rs
@@ -392,4 +392,204 @@ mod tests {
         assert_eq!(live_addresses.len(), 1);
         assert!(live_addresses.contains(&addr1));
     }
+
+    #[test]
+    fn test_address_try_from_uri_without_host() {
+        let uri: Uri = Uri::from_str("/path/only").unwrap();
+        let result = Address::try_from(uri);
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert!(matches!(err, AddressListError::InvalidAddressUri(_)));
+    }
+
+    #[test]
+    fn test_address_from_str_invalid_uri() {
+        // Use a string with invalid URI characters that http::Uri rejects
+        let result = Address::from_str("not a valid uri\x00");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_address_uri_accessor() {
+        let addr: Address = "http://127.0.0.1:3000".parse().unwrap();
+        let uri = addr.uri();
+        assert_eq!(uri.host(), Some("127.0.0.1"));
+    }
+
+    #[test]
+    fn test_address_partial_eq_with_uri() {
+        let addr: Address = "http://127.0.0.1:3000".parse().unwrap();
+        let uri = Uri::from_str("http://127.0.0.1:3000").unwrap();
+        assert!(addr == uri);
+
+        let other_uri = Uri::from_str("http://127.0.0.1:4000").unwrap();
+        assert!(addr != other_uri);
+    }
+
+    #[test]
+    fn test_address_display() {
+        let addr: Address = "http://127.0.0.1:3000".parse().unwrap();
+        let display = format!("{}", addr);
+        assert!(display.contains("127.0.0.1"));
+    }
+
+    #[test]
+    fn test_address_status_is_banned() {
+        let mut status = AddressStatus::default();
+        assert!(!status.is_banned());
+
+        status.ban(&Duration::from_secs(60));
+        assert!(status.is_banned());
+
+        status.unban();
+        assert!(!status.is_banned());
+    }
+
+    #[test]
+    fn test_address_status_exponential_ban() {
+        let mut status = AddressStatus::default();
+        let base_period = Duration::from_secs(1);
+
+        // First ban: coefficient = exp(0) = 1, period = 1s
+        status.ban(&base_period);
+        assert_eq!(status.ban_count, 1);
+        assert!(status.banned_until.is_some());
+
+        // Second ban: coefficient = exp(1) ~= 2.718, period ~= 2.718s
+        status.ban(&base_period);
+        assert_eq!(status.ban_count, 2);
+    }
+
+    #[test]
+    fn test_address_list_is_empty() {
+        let list = AddressList::new();
+        assert!(list.is_empty());
+
+        let mut list = AddressList::new();
+        list.add("http://127.0.0.1:3000".parse().unwrap());
+        assert!(!list.is_empty());
+    }
+
+    #[test]
+    fn test_address_list_len() {
+        let mut list = AddressList::new();
+        assert_eq!(list.len(), 0);
+
+        list.add("http://127.0.0.1:3000".parse().unwrap());
+        assert_eq!(list.len(), 1);
+
+        list.add("http://127.0.0.1:3001".parse().unwrap());
+        assert_eq!(list.len(), 2);
+    }
+
+    #[test]
+    fn test_address_list_add_duplicate() {
+        let mut list = AddressList::new();
+        let addr: Address = "http://127.0.0.1:3000".parse().unwrap();
+
+        assert!(list.add(addr.clone()));
+        assert!(!list.add(addr)); // duplicate returns false
+        assert_eq!(list.len(), 1);
+    }
+
+    #[test]
+    fn test_address_list_remove() {
+        let mut list = AddressList::new();
+        let addr: Address = "http://127.0.0.1:3000".parse().unwrap();
+
+        list.add(addr.clone());
+        assert_eq!(list.len(), 1);
+
+        let removed = list.remove(&addr);
+        assert!(removed.is_some());
+        assert_eq!(list.len(), 0);
+
+        // Removing non-existent address returns None
+        let removed = list.remove(&addr);
+        assert!(removed.is_none());
+    }
+
+    #[test]
+    fn test_address_list_ban_nonexistent() {
+        let list = AddressList::new();
+        let addr: Address = "http://127.0.0.1:3000".parse().unwrap();
+        assert!(!list.ban(&addr));
+    }
+
+    #[test]
+    fn test_address_list_unban_nonexistent() {
+        let list = AddressList::new();
+        let addr: Address = "http://127.0.0.1:3000".parse().unwrap();
+        assert!(!list.unban(&addr));
+    }
+
+    #[test]
+    fn test_address_list_is_banned() {
+        let mut list = AddressList::new();
+        let addr: Address = "http://127.0.0.1:3000".parse().unwrap();
+        let unknown: Address = "http://127.0.0.1:9999".parse().unwrap();
+
+        list.add(addr.clone());
+
+        assert!(!list.is_banned(&addr));
+        assert!(!list.is_banned(&unknown)); // unknown returns false
+
+        list.ban(&addr);
+        assert!(list.is_banned(&addr));
+    }
+
+    #[test]
+    fn test_address_list_from_str() {
+        let list: AddressList = "http://127.0.0.1:3000,http://127.0.0.1:3001"
+            .parse()
+            .unwrap();
+        assert_eq!(list.len(), 2);
+    }
+
+    #[test]
+    fn test_address_list_from_str_single() {
+        let list: AddressList = "http://127.0.0.1:3000".parse().unwrap();
+        assert_eq!(list.len(), 1);
+    }
+
+    #[test]
+    fn test_address_list_from_str_invalid() {
+        let result: Result<AddressList, _> = "not a valid uri\x00".parse();
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_address_list_get_live_address_returns_none_when_empty() {
+        let list = AddressList::new();
+        assert!(list.get_live_address().is_none());
+    }
+
+    #[test]
+    fn test_address_list_get_live_address_returns_some_when_available() {
+        let mut list = AddressList::new();
+        list.add("http://127.0.0.1:3000".parse().unwrap());
+        assert!(list.get_live_address().is_some());
+    }
+
+    #[test]
+    fn test_address_list_into_iter() {
+        let mut list = AddressList::new();
+        list.add("http://127.0.0.1:3000".parse().unwrap());
+        list.add("http://127.0.0.1:3001".parse().unwrap());
+
+        let items: Vec<_> = list.into_iter().collect();
+        assert_eq!(items.len(), 2);
+    }
+
+    #[test]
+    fn test_address_list_with_settings() {
+        let list = AddressList::with_settings(Duration::from_secs(120));
+        assert!(list.is_empty());
+    }
+
+    #[test]
+    fn test_address_list_default() {
+        let list = AddressList::default();
+        assert!(list.is_empty());
+    }
 }

--- a/packages/rs-dapi-client/src/connection_pool.rs
+++ b/packages/rs-dapi-client/src/connection_pool.rs
@@ -172,3 +172,196 @@ impl From<&PoolItem> for PoolPrefix {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use dapi_grpc::tonic::transport::Channel;
+    use std::str::FromStr;
+
+    fn test_uri() -> Uri {
+        Uri::from_str("http://127.0.0.1:3000").unwrap()
+    }
+
+    fn make_platform_pool_item() -> PoolItem {
+        let channel = Channel::builder(test_uri()).connect_lazy();
+        PoolItem::Platform(PlatformGrpcClient::new(channel))
+    }
+
+    fn make_core_pool_item() -> PoolItem {
+        let channel = Channel::builder(test_uri()).connect_lazy();
+        PoolItem::Core(CoreGrpcClient::new(channel))
+    }
+
+    #[test]
+    fn test_connection_pool_new() {
+        let pool = ConnectionPool::new(10);
+        let result = pool.get(PoolPrefix::Platform, &test_uri(), None);
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn test_connection_pool_default() {
+        let pool = ConnectionPool::default();
+        let result = pool.get(PoolPrefix::Core, &test_uri(), None);
+        assert!(result.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_connection_pool_put_and_get_platform() {
+        let pool = ConnectionPool::new(10);
+        let uri = test_uri();
+        let item = make_platform_pool_item();
+
+        pool.put(&uri, None, item);
+
+        let result = pool.get(PoolPrefix::Platform, &uri, None);
+        assert!(result.is_some());
+        assert!(matches!(result.unwrap(), PoolItem::Platform(_)));
+    }
+
+    #[tokio::test]
+    async fn test_connection_pool_put_and_get_core() {
+        let pool = ConnectionPool::new(10);
+        let uri = test_uri();
+        let item = make_core_pool_item();
+
+        pool.put(&uri, None, item);
+
+        let result = pool.get(PoolPrefix::Core, &uri, None);
+        assert!(result.is_some());
+        assert!(matches!(result.unwrap(), PoolItem::Core(_)));
+    }
+
+    #[tokio::test]
+    async fn test_connection_pool_get_or_create_creates_new() {
+        let pool = ConnectionPool::new(10);
+        let uri = test_uri();
+
+        let result: Result<PoolItem, String> =
+            pool.get_or_create(PoolPrefix::Platform, &uri, None, || {
+                Ok(make_platform_pool_item())
+            });
+
+        assert!(result.is_ok());
+
+        // Second call should return cached version
+        let mut create_called = false;
+        let result2: Result<PoolItem, String> =
+            pool.get_or_create(PoolPrefix::Platform, &uri, None, || {
+                create_called = true;
+                Ok(make_platform_pool_item())
+            });
+
+        assert!(result2.is_ok());
+        assert!(
+            !create_called,
+            "create should not be called for cached item"
+        );
+    }
+
+    #[test]
+    fn test_connection_pool_get_or_create_error_not_cached() {
+        let pool = ConnectionPool::new(10);
+        let uri = test_uri();
+
+        let result: Result<PoolItem, String> =
+            pool.get_or_create(PoolPrefix::Platform, &uri, None, || {
+                Err("creation failed".to_string())
+            });
+
+        assert!(result.is_err());
+
+        // Pool should still be empty after failed creation
+        let cached = pool.get(PoolPrefix::Platform, &uri, None);
+        assert!(cached.is_none());
+    }
+
+    #[test]
+    fn test_pool_prefix_display() {
+        assert_eq!(format!("{}", PoolPrefix::Core), "Core");
+        assert_eq!(format!("{}", PoolPrefix::Platform), "Platform");
+    }
+
+    #[tokio::test]
+    async fn test_pool_prefix_from_pool_item() {
+        let platform_item = make_platform_pool_item();
+        let prefix: PoolPrefix = (&platform_item).into();
+        assert!(matches!(prefix, PoolPrefix::Platform));
+
+        let core_item = make_core_pool_item();
+        let prefix: PoolPrefix = (&core_item).into();
+        assert!(matches!(prefix, PoolPrefix::Core));
+    }
+
+    #[tokio::test]
+    async fn test_pool_item_from_platform_client() {
+        let channel = Channel::builder(test_uri()).connect_lazy();
+        let client = PlatformGrpcClient::new(channel);
+        let item: PoolItem = client.into();
+        assert!(matches!(item, PoolItem::Platform(_)));
+    }
+
+    #[tokio::test]
+    async fn test_pool_item_from_core_client() {
+        let channel = Channel::builder(test_uri()).connect_lazy();
+        let client = CoreGrpcClient::new(channel);
+        let item: PoolItem = client.into();
+        assert!(matches!(item, PoolItem::Core(_)));
+    }
+
+    #[tokio::test]
+    async fn test_pool_item_into_platform_client() {
+        let item = make_platform_pool_item();
+        let _client: PlatformGrpcClient = item.into();
+    }
+
+    #[tokio::test]
+    async fn test_pool_item_into_core_client() {
+        let item = make_core_pool_item();
+        let _client: CoreGrpcClient = item.into();
+    }
+
+    #[tokio::test]
+    #[should_panic(expected = "ClientType is not Platform")]
+    async fn test_pool_item_core_into_platform_panics() {
+        let item = make_core_pool_item();
+        let _client: PlatformGrpcClient = item.into();
+    }
+
+    #[tokio::test]
+    #[should_panic(expected = "ClientType is not Core")]
+    async fn test_pool_item_platform_into_core_panics() {
+        let item = make_platform_pool_item();
+        let _client: CoreGrpcClient = item.into();
+    }
+
+    #[tokio::test]
+    async fn test_connection_pool_different_prefixes_different_keys() {
+        let pool = ConnectionPool::new(10);
+        let uri = test_uri();
+
+        pool.put(&uri, None, make_platform_pool_item());
+
+        // Core prefix should not find a Platform item
+        let result = pool.get(PoolPrefix::Core, &uri, None);
+        assert!(result.is_none());
+
+        // Platform prefix should find it
+        let result = pool.get(PoolPrefix::Platform, &uri, None);
+        assert!(result.is_some());
+    }
+
+    #[tokio::test]
+    async fn test_connection_pool_clone_shares_data() {
+        let pool = ConnectionPool::new(10);
+        let pool_clone = pool.clone();
+        let uri = test_uri();
+
+        pool.put(&uri, None, make_platform_pool_item());
+
+        // Clone should see the same data
+        let result = pool_clone.get(PoolPrefix::Platform, &uri, None);
+        assert!(result.is_some());
+    }
+}

--- a/packages/rs-dapi-client/src/dapi_client.rs
+++ b/packages/rs-dapi-client/src/dapi_client.rs
@@ -220,6 +220,302 @@ pub fn update_address_ban_status<R, E>(
     };
 }
 
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn mock_address() -> crate::Address {
+        "http://127.0.0.1:3000".parse().expect("valid address")
+    }
+
+    fn make_applied_settings(ban: bool) -> AppliedRequestSettings {
+        AppliedRequestSettings {
+            connect_timeout: None,
+            timeout: Duration::from_secs(10),
+            retries: 5,
+            ban_failed_address: ban,
+            max_decoding_message_size: None,
+            #[cfg(not(target_arch = "wasm32"))]
+            ca_certificate: None,
+        }
+    }
+
+    #[test]
+    fn test_can_retry_no_available_addresses() {
+        let err = DapiClientError::NoAvailableAddresses;
+        assert!(!err.can_retry());
+    }
+
+    #[test]
+    fn test_can_retry_no_available_addresses_to_retry() {
+        let transport_err = TransportError::Grpc(dapi_grpc::tonic::Status::unavailable("gone"));
+        let err = DapiClientError::NoAvailableAddressesToRetry(Box::new(transport_err));
+        assert!(!err.can_retry());
+    }
+
+    #[test]
+    fn test_can_retry_transport_retryable() {
+        let transport_err =
+            TransportError::Grpc(dapi_grpc::tonic::Status::unavailable("temporary"));
+        let err = DapiClientError::Transport(transport_err);
+        assert!(err.can_retry());
+    }
+
+    #[test]
+    fn test_can_retry_transport_non_retryable() {
+        let transport_err = TransportError::Grpc(dapi_grpc::tonic::Status::not_found("permanent"));
+        let err = DapiClientError::Transport(transport_err);
+        assert!(!err.can_retry());
+    }
+
+    #[test]
+    fn test_can_retry_address_list_error() {
+        let err =
+            DapiClientError::AddressList(AddressListError::InvalidAddressUri("bad".to_string()));
+        assert!(!err.can_retry());
+    }
+
+    #[cfg(feature = "mocks")]
+    #[test]
+    fn test_can_retry_mock_error() {
+        let err = DapiClientError::Mock(crate::mock::MockError::MockExpectationNotFound(
+            "test".to_string(),
+        ));
+        assert!(!err.can_retry());
+    }
+
+    #[test]
+    fn test_is_no_available_addresses() {
+        assert!(DapiClientError::NoAvailableAddresses.is_no_available_addresses());
+
+        let transport_err = TransportError::Grpc(dapi_grpc::tonic::Status::unavailable("gone"));
+        assert!(
+            DapiClientError::NoAvailableAddressesToRetry(Box::new(transport_err))
+                .is_no_available_addresses()
+        );
+
+        let transport_err =
+            TransportError::Grpc(dapi_grpc::tonic::Status::unavailable("temporary"));
+        assert!(!DapiClientError::Transport(transport_err).is_no_available_addresses());
+    }
+
+    #[test]
+    fn test_update_address_ban_status_success_unbans() {
+        let mut address_list = AddressList::new();
+        let addr = mock_address();
+        address_list.add(addr.clone());
+        address_list.ban(&addr);
+        assert!(address_list.is_banned(&addr));
+
+        let result: ExecutionResult<i32, DapiClientError> = Ok(ExecutionResponse {
+            inner: 42,
+            retries: 0,
+            address: addr.clone(),
+        });
+
+        update_address_ban_status(&address_list, &result, &make_applied_settings(true));
+
+        assert!(!address_list.is_banned(&addr));
+    }
+
+    #[test]
+    fn test_update_address_ban_status_success_on_unbanned_is_noop() {
+        let mut address_list = AddressList::new();
+        let addr = mock_address();
+        address_list.add(addr.clone());
+
+        let result: ExecutionResult<i32, DapiClientError> = Ok(ExecutionResponse {
+            inner: 42,
+            retries: 0,
+            address: addr.clone(),
+        });
+
+        // Should not panic or change anything
+        update_address_ban_status(&address_list, &result, &make_applied_settings(true));
+        assert!(!address_list.is_banned(&addr));
+    }
+
+    #[test]
+    fn test_update_address_ban_status_retryable_error_bans_address() {
+        let mut address_list = AddressList::new();
+        let addr = mock_address();
+        address_list.add(addr.clone());
+
+        let transport_err =
+            TransportError::Grpc(dapi_grpc::tonic::Status::unavailable("temporary"));
+        let result: ExecutionResult<i32, DapiClientError> = Err(ExecutionError {
+            inner: DapiClientError::Transport(transport_err),
+            retries: 0,
+            address: Some(addr.clone()),
+        });
+
+        update_address_ban_status(&address_list, &result, &make_applied_settings(true));
+        assert!(address_list.is_banned(&addr));
+    }
+
+    #[test]
+    fn test_update_address_ban_status_retryable_error_ban_disabled() {
+        let mut address_list = AddressList::new();
+        let addr = mock_address();
+        address_list.add(addr.clone());
+
+        let transport_err =
+            TransportError::Grpc(dapi_grpc::tonic::Status::unavailable("temporary"));
+        let result: ExecutionResult<i32, DapiClientError> = Err(ExecutionError {
+            inner: DapiClientError::Transport(transport_err),
+            retries: 0,
+            address: Some(addr.clone()),
+        });
+
+        update_address_ban_status(&address_list, &result, &make_applied_settings(false));
+        // With ban disabled, the address should NOT be banned
+        assert!(!address_list.is_banned(&addr));
+    }
+
+    #[test]
+    fn test_update_address_ban_status_non_retryable_error_does_not_ban() {
+        let mut address_list = AddressList::new();
+        let addr = mock_address();
+        address_list.add(addr.clone());
+
+        let result: ExecutionResult<i32, DapiClientError> = Err(ExecutionError {
+            inner: DapiClientError::NoAvailableAddresses,
+            retries: 0,
+            address: Some(addr.clone()),
+        });
+
+        update_address_ban_status(&address_list, &result, &make_applied_settings(true));
+        assert!(!address_list.is_banned(&addr));
+    }
+
+    #[test]
+    fn test_update_address_ban_status_retryable_error_no_address() {
+        let address_list = AddressList::new();
+
+        let transport_err =
+            TransportError::Grpc(dapi_grpc::tonic::Status::unavailable("temporary"));
+        let result: ExecutionResult<i32, DapiClientError> = Err(ExecutionError {
+            inner: DapiClientError::Transport(transport_err),
+            retries: 0,
+            address: None,
+        });
+
+        // Should not panic when address is None
+        update_address_ban_status(&address_list, &result, &make_applied_settings(true));
+    }
+
+    #[test]
+    fn test_update_address_ban_status_unban_removed_address() {
+        let mut address_list = AddressList::new();
+        let addr = mock_address();
+        address_list.add(addr.clone());
+        address_list.ban(&addr);
+
+        // Remove the address
+        address_list.remove(&addr);
+
+        let result: ExecutionResult<i32, DapiClientError> = Ok(ExecutionResponse {
+            inner: 42,
+            retries: 0,
+            address: addr.clone(),
+        });
+
+        // Should not panic when trying to unban a removed address
+        update_address_ban_status(&address_list, &result, &make_applied_settings(true));
+    }
+
+    #[test]
+    fn test_update_address_ban_status_ban_removed_address() {
+        let address_list = AddressList::new();
+        let addr = mock_address();
+
+        let transport_err =
+            TransportError::Grpc(dapi_grpc::tonic::Status::unavailable("temporary"));
+        let result: ExecutionResult<i32, DapiClientError> = Err(ExecutionError {
+            inner: DapiClientError::Transport(transport_err),
+            retries: 0,
+            address: Some(addr),
+        });
+
+        // Should not panic when trying to ban an address not in the list
+        update_address_ban_status(&address_list, &result, &make_applied_settings(true));
+    }
+
+    #[test]
+    fn test_dapi_client_new() {
+        let address_list: AddressList = "http://127.0.0.1:3000,http://127.0.0.1:3001"
+            .parse()
+            .unwrap();
+        let client = DapiClient::new(address_list, RequestSettings::default());
+        assert_eq!(client.address_list().len(), 2);
+    }
+
+    #[test]
+    fn test_dapi_client_get_live_addresses() {
+        let address_list: AddressList = "http://127.0.0.1:3000,http://127.0.0.1:3001"
+            .parse()
+            .unwrap();
+        let client = DapiClient::new(address_list, RequestSettings::default());
+        let live = client.get_live_addresses();
+        assert_eq!(live.len(), 2);
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    #[test]
+    fn test_dapi_client_with_ca_certificate() {
+        let address_list: AddressList = "http://127.0.0.1:3000".parse().unwrap();
+        let client = DapiClient::new(address_list, RequestSettings::default());
+        let cert = dapi_grpc::tonic::transport::Certificate::from_pem("fake-pem-data");
+        let client = client.with_ca_certificate(cert);
+        assert!(client.ca_certificate.is_some());
+    }
+
+    #[cfg(feature = "mocks")]
+    #[test]
+    fn test_dapi_client_error_mock_serialize_deserialize() {
+        use dapi_grpc::mock::Mockable;
+
+        let err = DapiClientError::NoAvailableAddresses;
+        let serialized = err.mock_serialize().expect("should serialize");
+        let deserialized =
+            DapiClientError::mock_deserialize(&serialized).expect("should deserialize");
+        assert!(matches!(
+            deserialized,
+            DapiClientError::NoAvailableAddresses
+        ));
+    }
+
+    #[cfg(feature = "mocks")]
+    #[test]
+    fn test_dapi_client_error_transport_mock_roundtrip() {
+        use dapi_grpc::mock::Mockable;
+
+        let transport_err = TransportError::Grpc(dapi_grpc::tonic::Status::unavailable("test"));
+        let err = DapiClientError::Transport(transport_err);
+        let serialized = err.mock_serialize().expect("should serialize");
+        let deserialized =
+            DapiClientError::mock_deserialize(&serialized).expect("should deserialize");
+        assert!(matches!(deserialized, DapiClientError::Transport(_)));
+    }
+
+    #[test]
+    fn test_dapi_client_error_display() {
+        let err = DapiClientError::NoAvailableAddresses;
+        let display = format!("{}", err);
+        assert!(display.contains("no available addresses"));
+
+        let transport_err = TransportError::Grpc(dapi_grpc::tonic::Status::unavailable("gone"));
+        let err = DapiClientError::NoAvailableAddressesToRetry(Box::new(transport_err));
+        let display = format!("{}", err);
+        assert!(display.contains("no available addresses to retry"));
+
+        let err =
+            DapiClientError::AddressList(AddressListError::InvalidAddressUri("bad".to_string()));
+        let display = format!("{}", err);
+        assert!(display.contains("address list error"));
+    }
+}
+
 #[async_trait]
 impl DapiRequestExecutor for DapiClient {
     /// Execute the [DapiRequest](crate::DapiRequest).

--- a/packages/rs-dapi-client/src/executor.rs
+++ b/packages/rs-dapi-client/src/executor.rs
@@ -228,3 +228,176 @@ where
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn mock_address() -> Address {
+        "http://127.0.0.1:3000".parse().expect("valid address")
+    }
+
+    fn mock_response() -> ExecutionResponse<i32> {
+        ExecutionResponse {
+            inner: 42,
+            retries: 3,
+            address: mock_address(),
+        }
+    }
+
+    fn mock_error() -> ExecutionError<String> {
+        ExecutionError {
+            inner: "test error".to_string(),
+            retries: 2,
+            address: Some(mock_address()),
+        }
+    }
+
+    #[test]
+    fn test_execution_error_partial_eq() {
+        let err1 = mock_error();
+        let err2 = mock_error();
+        assert_eq!(err1, err2);
+
+        let err3 = ExecutionError {
+            inner: "different".to_string(),
+            retries: 2,
+            address: Some(mock_address()),
+        };
+        assert_ne!(err1, err3);
+
+        let err4 = ExecutionError {
+            inner: "test error".to_string(),
+            retries: 5,
+            address: Some(mock_address()),
+        };
+        assert_ne!(err1, err4);
+    }
+
+    #[test]
+    fn test_execution_result_from_response() {
+        let response = mock_response();
+        let result: ExecutionResult<i32, String> = response.into();
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap().inner, 42);
+    }
+
+    #[test]
+    fn test_execution_result_from_error() {
+        let error = mock_error();
+        let result: ExecutionResult<i32, String> = error.into();
+        assert!(result.is_err());
+        assert_eq!(result.unwrap_err().inner, "test error");
+    }
+
+    #[test]
+    fn test_execution_result_inner_into_ok() {
+        let response = mock_response();
+        let result: ExecutionResult<i32, String> = Ok(response);
+        let converted: ExecutionResult<i64, String> = result.inner_into();
+        assert!(converted.is_ok());
+        assert_eq!(converted.unwrap().inner, 42i64);
+    }
+
+    #[test]
+    fn test_execution_result_inner_into_err() {
+        let error = mock_error();
+        let result: ExecutionResult<i32, String> = Err(error);
+        let converted: ExecutionResult<i64, String> = result.inner_into();
+        assert!(converted.is_err());
+        assert_eq!(converted.unwrap_err().inner, "test error");
+    }
+
+    #[test]
+    fn test_wrap_to_execution_result_ok() {
+        let context = mock_response();
+        let inner_result: Result<i64, String> = Ok(100);
+        let wrapped: ExecutionResult<i64, String> = inner_result.wrap_to_execution_result(&context);
+
+        let response = wrapped.unwrap();
+        assert_eq!(response.inner, 100);
+        assert_eq!(response.retries, 3);
+        assert_eq!(response.address, mock_address());
+    }
+
+    #[test]
+    fn test_wrap_to_execution_result_err() {
+        let context = mock_response();
+        let inner_result: Result<i64, String> = Err("wrapped error".to_string());
+        let wrapped: ExecutionResult<i64, String> = inner_result.wrap_to_execution_result(&context);
+
+        let error = wrapped.unwrap_err();
+        assert_eq!(error.inner, "wrapped error");
+        assert_eq!(error.retries, 3);
+        assert_eq!(error.address, Some(mock_address()));
+    }
+
+    #[test]
+    fn test_execution_response_into_inner() {
+        let response = mock_response();
+        let inner: i32 = response.into_inner();
+        assert_eq!(inner, 42);
+    }
+
+    #[test]
+    fn test_execution_response_inner_into() {
+        let response = mock_response();
+        let converted: ExecutionResponse<i64> = response.inner_into();
+        assert_eq!(converted.inner, 42i64);
+        assert_eq!(converted.retries, 3);
+    }
+
+    #[test]
+    fn test_execution_error_into_inner() {
+        let error = mock_error();
+        let inner: String = error.into_inner();
+        assert_eq!(inner, "test error");
+    }
+
+    #[test]
+    fn test_execution_error_inner_into() {
+        let error = mock_error();
+        let converted: ExecutionError<String> = error.inner_into();
+        assert_eq!(converted.inner, "test error");
+        assert_eq!(converted.retries, 2);
+    }
+
+    #[test]
+    fn test_execution_result_into_inner_ok() {
+        let result: ExecutionResult<i32, String> = Ok(mock_response());
+        let inner: Result<i32, String> = result.into_inner();
+        assert_eq!(inner.unwrap(), 42);
+    }
+
+    #[test]
+    fn test_execution_result_into_inner_err() {
+        let result: ExecutionResult<i32, String> = Err(mock_error());
+        let inner: Result<i32, String> = result.into_inner();
+        assert_eq!(inner.unwrap_err(), "test error");
+    }
+
+    #[test]
+    fn test_execution_error_can_retry_delegates() {
+        // Test that ExecutionError's CanRetry impl delegates correctly
+        // We need a type that implements CanRetry
+        use crate::DapiClientError;
+
+        let inner = DapiClientError::NoAvailableAddresses;
+        let error = ExecutionError {
+            inner,
+            retries: 0,
+            address: None,
+        };
+
+        assert!(!error.can_retry());
+        assert!(error.is_no_available_addresses());
+    }
+
+    #[cfg(feature = "mocks")]
+    #[test]
+    fn test_execution_response_default() {
+        let response: ExecutionResponse<i32> = ExecutionResponse::default();
+        assert_eq!(response.inner, 0);
+        assert_eq!(response.retries, 0);
+    }
+}

--- a/packages/rs-dapi-client/src/request_settings.rs
+++ b/packages/rs-dapi-client/src/request_settings.rs
@@ -106,3 +106,97 @@ impl AppliedRequestSettings {
         self
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_request_settings_override_by() {
+        let base = RequestSettings {
+            timeout: Some(Duration::from_secs(5)),
+            retries: Some(3),
+            connect_timeout: Some(Duration::from_secs(2)),
+            ban_failed_address: Some(true),
+            max_decoding_message_size: Some(1024),
+        };
+
+        // Override with partial settings
+        let override_settings = RequestSettings {
+            timeout: Some(Duration::from_secs(10)),
+            retries: None,
+            connect_timeout: None,
+            ban_failed_address: None,
+            max_decoding_message_size: None,
+        };
+
+        let result = base.override_by(override_settings);
+        assert_eq!(result.timeout, Some(Duration::from_secs(10))); // overridden
+        assert_eq!(result.retries, Some(3)); // preserved from base
+        assert_eq!(result.connect_timeout, Some(Duration::from_secs(2))); // preserved
+        assert_eq!(result.ban_failed_address, Some(true)); // preserved
+        assert_eq!(result.max_decoding_message_size, Some(1024)); // preserved
+    }
+
+    #[test]
+    fn test_request_settings_override_by_empty() {
+        let base = RequestSettings {
+            timeout: Some(Duration::from_secs(5)),
+            retries: Some(3),
+            connect_timeout: None,
+            ban_failed_address: None,
+            max_decoding_message_size: None,
+        };
+
+        let result = base.override_by(RequestSettings::default());
+        assert_eq!(result.timeout, Some(Duration::from_secs(5)));
+        assert_eq!(result.retries, Some(3));
+    }
+
+    #[test]
+    fn test_request_settings_finalize_defaults() {
+        let settings = RequestSettings::default();
+        let applied = settings.finalize();
+
+        assert_eq!(applied.connect_timeout, None);
+        assert_eq!(applied.timeout, Duration::from_secs(10));
+        assert_eq!(applied.retries, 5);
+        assert!(applied.ban_failed_address);
+        assert!(applied.max_decoding_message_size.is_none());
+    }
+
+    #[test]
+    fn test_request_settings_finalize_custom() {
+        let settings = RequestSettings {
+            connect_timeout: Some(Duration::from_secs(3)),
+            timeout: Some(Duration::from_secs(30)),
+            retries: Some(10),
+            ban_failed_address: Some(false),
+            max_decoding_message_size: Some(4096),
+        };
+
+        let applied = settings.finalize();
+        assert_eq!(applied.connect_timeout, Some(Duration::from_secs(3)));
+        assert_eq!(applied.timeout, Duration::from_secs(30));
+        assert_eq!(applied.retries, 10);
+        assert!(!applied.ban_failed_address);
+        assert_eq!(applied.max_decoding_message_size, Some(4096));
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    #[test]
+    fn test_applied_settings_with_ca_certificate_none() {
+        let applied = RequestSettings::default().finalize();
+        let result = applied.with_ca_certificate(None);
+        assert!(result.ca_certificate.is_none());
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    #[test]
+    fn test_applied_settings_with_ca_certificate_some() {
+        let applied = RequestSettings::default().finalize();
+        let cert = Certificate::from_pem("fake-pem-data");
+        let result = applied.with_ca_certificate(Some(cert));
+        assert!(result.ca_certificate.is_some());
+    }
+}

--- a/packages/rs-dapi-client/src/transport.rs
+++ b/packages/rs-dapi-client/src/transport.rs
@@ -148,3 +148,119 @@ pub trait TransportClient: Send + Sized {
         pool: &ConnectionPool,
     ) -> Result<Self, TransportError>;
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use dapi_grpc::tonic::Code;
+
+    #[test]
+    fn test_tonic_status_can_retry_retryable_codes() {
+        let retryable_codes = vec![
+            Code::Ok,
+            Code::DataLoss,
+            Code::Cancelled,
+            Code::Unknown,
+            Code::DeadlineExceeded,
+            Code::ResourceExhausted,
+            Code::Aborted,
+            Code::Internal,
+            Code::Unavailable,
+        ];
+
+        for code in retryable_codes {
+            let status = dapi_grpc::tonic::Status::new(code, "test");
+            assert!(
+                status.can_retry(),
+                "Expected code {:?} to be retryable",
+                code
+            );
+        }
+    }
+
+    #[test]
+    fn test_tonic_status_can_retry_non_retryable_codes() {
+        let non_retryable_codes = vec![
+            Code::InvalidArgument,
+            Code::NotFound,
+            Code::AlreadyExists,
+            Code::PermissionDenied,
+            Code::FailedPrecondition,
+            Code::OutOfRange,
+            Code::Unimplemented,
+            Code::Unauthenticated,
+        ];
+
+        for code in non_retryable_codes {
+            let status = dapi_grpc::tonic::Status::new(code, "test");
+            assert!(
+                !status.can_retry(),
+                "Expected code {:?} to be non-retryable",
+                code
+            );
+        }
+    }
+
+    #[test]
+    fn test_transport_error_can_retry() {
+        let retryable = TransportError::Grpc(dapi_grpc::tonic::Status::unavailable("temporary"));
+        assert!(retryable.can_retry());
+
+        let non_retryable = TransportError::Grpc(dapi_grpc::tonic::Status::not_found("permanent"));
+        assert!(!non_retryable.can_retry());
+    }
+
+    #[test]
+    fn test_transport_error_clone() {
+        let original = TransportError::Grpc(dapi_grpc::tonic::Status::unavailable("test message"));
+
+        let cloned = original.clone();
+
+        match (&original, &cloned) {
+            (TransportError::Grpc(orig), TransportError::Grpc(clone)) => {
+                assert_eq!(orig.code(), clone.code());
+                assert_eq!(orig.message(), clone.message());
+            }
+        }
+    }
+
+    #[test]
+    fn test_transport_error_display() {
+        let err = TransportError::Grpc(dapi_grpc::tonic::Status::unavailable("service down"));
+        let display = format!("{}", err);
+        assert!(display.contains("service down"));
+    }
+
+    #[cfg(feature = "mocks")]
+    #[test]
+    fn test_transport_error_mock_roundtrip() {
+        let original =
+            TransportError::Grpc(dapi_grpc::tonic::Status::unavailable("test roundtrip"));
+        let serialized = original.mock_serialize().expect("should serialize");
+        let deserialized =
+            TransportError::mock_deserialize(&serialized).expect("should deserialize");
+
+        match deserialized {
+            TransportError::Grpc(status) => {
+                assert_eq!(status.code(), Code::Unavailable);
+            }
+        }
+    }
+
+    #[cfg(feature = "mocks")]
+    #[test]
+    fn test_boxed_transport_error_mock_roundtrip() {
+        let original = Box::new(TransportError::Grpc(dapi_grpc::tonic::Status::internal(
+            "boxed test",
+        )));
+        let serialized = original.mock_serialize().expect("should serialize");
+        let deserialized =
+            Box::<TransportError>::mock_deserialize(&serialized).expect("should deserialize");
+
+        match *deserialized {
+            TransportError::Grpc(status) => {
+                assert_eq!(status.code(), Code::Internal);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Issue being fixed or feature implemented

Improve test coverage for the `rs-dapi-client` package to catch regressions and document expected behavior of core modules.

## What was done?

Added 87 new unit tests across 6 source files in `packages/rs-dapi-client/src/`, targeting previously uncovered code paths:

| File | Before (unit only) | After (unit only) |
|------|-------------------|-------------------|
| address_list.rs | 60% | 98.8% |
| connection_pool.rs | 0% | 96.6% |
| dapi_client.rs | 0% | 59.3% |
| executor.rs | 0% | 94.3% |
| request_settings.rs | 24.3% | 100% |
| transport.rs | 0% | 89% |

Key areas tested:
- **address_list**: URI validation errors, address removal, ban/unban edge cases, `FromStr` parsing, `is_empty`/`len`, `PartialEq<Uri>`, `Display`
- **connection_pool**: Pool put/get/get_or_create, error non-caching, `PoolPrefix` Display/From, `PoolItem` conversions and panic paths, clone sharing
- **dapi_client**: `CanRetry` for all error variants, `is_no_available_addresses`, `update_address_ban_status` (ban/unban/disabled/removed/no-address), `DapiClient` construction, `with_ca_certificate`, `Mockable` roundtrips
- **executor**: `ExecutionError` `PartialEq`, `From` conversions, `InnerInto` for `ExecutionResult`, `WrapToExecutionResult`, `CanRetry` delegation, `ExecutionResponse` default
- **request_settings**: `override_by` merging, `finalize` defaults and custom, `with_ca_certificate`
- **transport**: tonic `Status` `CanRetry` for all gRPC codes, `TransportError` clone/display, `Mockable` roundtrips

Note: `dapi_client.rs` execute loop (the `DapiRequestExecutor::execute` impl) remains at lower coverage because it requires actual transport layer connections that cannot be easily unit-tested. This code path is exercised by integration tests in `dash-sdk`.

## How Has This Been Tested?

- `cargo test -p rs-dapi-client --all-features` -- all 92 unit tests pass
- `cargo fmt --package rs-dapi-client` -- formatting verified
- Coverage measured with `cargo llvm-cov`

## Breaking Changes

None.

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [x] I have made corresponding changes to the documentation if needed