### PR TITLE
test(platform): improve platform-serialization test coverage

### DIFF
--- a/packages/rs-platform-serialization/src/de/impl_tuples.rs
+++ b/packages/rs-platform-serialization/src/de/impl_tuples.rs
@@ -54,3 +54,53 @@ impl_tuple!(A, B, C, D, E, F, G, H, I, J, K, L, M);
 impl_tuple!(A, B, C, D, E, F, G, H, I, J, K, L, M, N);
 impl_tuple!(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O);
 impl_tuple!(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P);
+
+#[cfg(test)]
+mod tests {
+    use bincode::config;
+    use platform_version::version::PlatformVersion;
+
+    fn cfg() -> impl bincode::config::Config {
+        config::standard().with_big_endian().with_no_limit()
+    }
+
+    fn pv() -> &'static PlatformVersion {
+        PlatformVersion::first()
+    }
+
+    #[test]
+    fn tuple_1_decode() {
+        let value: (u32,) = (42,);
+        let encoded = crate::platform_encode_to_vec(value, cfg(), pv()).unwrap();
+        let decoded: (u32,) =
+            crate::platform_versioned_decode_from_slice(&encoded, cfg(), pv()).unwrap();
+        assert_eq!(decoded, value);
+    }
+
+    #[test]
+    fn tuple_2_decode() {
+        let value: (u8, i16) = (255, -100);
+        let encoded = crate::platform_encode_to_vec(value, cfg(), pv()).unwrap();
+        let decoded: (u8, i16) =
+            crate::platform_versioned_decode_from_slice(&encoded, cfg(), pv()).unwrap();
+        assert_eq!(decoded, value);
+    }
+
+    #[test]
+    fn tuple_3_decode() {
+        let value: (bool, u32, i64) = (true, 42, -999);
+        let encoded = crate::platform_encode_to_vec(value, cfg(), pv()).unwrap();
+        let decoded: (bool, u32, i64) =
+            crate::platform_versioned_decode_from_slice(&encoded, cfg(), pv()).unwrap();
+        assert_eq!(decoded, value);
+    }
+
+    #[test]
+    fn tuple_borrow_decode() {
+        let value: (u8, u16) = (1, 2);
+        let encoded = crate::platform_encode_to_vec(value, cfg(), pv()).unwrap();
+        let decoded: (u8, u16) =
+            crate::platform_versioned_borrow_decode_from_slice(&encoded, cfg(), pv()).unwrap();
+        assert_eq!(decoded, value);
+    }
+}

--- a/packages/rs-platform-serialization/src/de/mod.rs
+++ b/packages/rs-platform-serialization/src/de/mod.rs
@@ -201,6 +201,15 @@ pub(crate) fn decode_slice_len<D: Decoder<Context = crate::BincodeContext>>(
 mod tests {
     use super::*;
     use bincode::config;
+    use platform_version::version::PlatformVersion;
+
+    fn cfg() -> impl bincode::config::Config {
+        config::standard().with_big_endian().with_no_limit()
+    }
+
+    fn pv() -> &'static PlatformVersion {
+        PlatformVersion::first()
+    }
 
     /// Helper: encode a u64 varint using bincode big-endian standard config,
     /// then attempt to decode it as a collection length via `decode_slice_len`.
@@ -240,6 +249,544 @@ mod tests {
         match try_decode_len(u64::MAX) {
             Err(DecodeError::LimitExceeded) => {} // expected
             other => panic!("expected LimitExceeded, got {:?}", other),
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // decode_option_variant
+    // -----------------------------------------------------------------------
+
+    fn try_decode_option_variant(byte: u8) -> Result<Option<()>, DecodeError> {
+        let data = bincode::encode_to_vec(byte, cfg()).unwrap();
+        let reader = bincode::de::read::SliceReader::new(&data);
+        let mut decoder = bincode::de::DecoderImpl::new(reader, cfg(), ());
+        decode_option_variant(&mut decoder, "test::Option")
+    }
+
+    #[test]
+    fn decode_option_variant_none() {
+        assert_eq!(try_decode_option_variant(0).unwrap(), None);
+    }
+
+    #[test]
+    fn decode_option_variant_some() {
+        assert_eq!(try_decode_option_variant(1).unwrap(), Some(()));
+    }
+
+    #[test]
+    fn decode_option_variant_invalid() {
+        match try_decode_option_variant(2) {
+            Err(DecodeError::UnexpectedVariant { found: 2, .. }) => {}
+            other => panic!("expected UnexpectedVariant, got {:?}", other),
+        }
+        match try_decode_option_variant(255) {
+            Err(DecodeError::UnexpectedVariant { found: 255, .. }) => {}
+            other => panic!("expected UnexpectedVariant, got {:?}", other),
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // PlatformVersionedDecode for Option<T>
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn option_some_round_trip() {
+        let value: Option<u32> = Some(42);
+        let encoded = crate::platform_encode_to_vec(value, cfg(), pv()).unwrap();
+        let decoded: Option<u32> =
+            crate::platform_versioned_decode_from_slice(&encoded, cfg(), pv()).unwrap();
+        assert_eq!(decoded, Some(42));
+    }
+
+    #[test]
+    fn option_none_round_trip() {
+        let value: Option<u32> = None;
+        let encoded = crate::platform_encode_to_vec(value, cfg(), pv()).unwrap();
+        let decoded: Option<u32> =
+            crate::platform_versioned_decode_from_slice(&encoded, cfg(), pv()).unwrap();
+        assert_eq!(decoded, None);
+    }
+
+    // -----------------------------------------------------------------------
+    // PlatformVersionedDecode for Result<T, U>
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn result_ok_round_trip() {
+        let value: Result<u32, u8> = Ok(123);
+        let encoded = crate::platform_encode_to_vec(value, cfg(), pv()).unwrap();
+        let decoded: Result<u32, u8> =
+            crate::platform_versioned_decode_from_slice(&encoded, cfg(), pv()).unwrap();
+        assert_eq!(decoded, Ok(123));
+    }
+
+    #[test]
+    fn result_err_round_trip() {
+        let value: Result<u32, u8> = Err(99);
+        let encoded = crate::platform_encode_to_vec(value, cfg(), pv()).unwrap();
+        let decoded: Result<u32, u8> =
+            crate::platform_versioned_decode_from_slice(&encoded, cfg(), pv()).unwrap();
+        assert_eq!(decoded, Err(99));
+    }
+
+    #[test]
+    fn result_invalid_variant() {
+        // Manually encode variant tag 2 (invalid for Result which expects 0 or 1)
+        let mut data = bincode::encode_to_vec(2u32, cfg()).unwrap();
+        // Append some dummy payload bytes
+        data.extend_from_slice(&[0u8; 8]);
+        let result =
+            crate::platform_versioned_decode_from_slice::<Result<u32, u8>, _>(&data, cfg(), pv());
+        match result {
+            Err(DecodeError::UnexpectedVariant { found: 2, .. }) => {}
+            other => panic!("expected UnexpectedVariant, got {:?}", other),
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // PlatformVersionedDecode for Bound<T>
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn bound_unbounded_round_trip() {
+        use core::ops::Bound;
+        let value: Bound<u32> = Bound::Unbounded;
+        let encoded = crate::platform_encode_to_vec(value, cfg(), pv()).unwrap();
+        let decoded: Bound<u32> =
+            crate::platform_versioned_decode_from_slice(&encoded, cfg(), pv()).unwrap();
+        assert_eq!(decoded, Bound::Unbounded);
+    }
+
+    #[test]
+    fn bound_included_round_trip() {
+        use core::ops::Bound;
+        let value: Bound<u32> = Bound::Included(10);
+        let encoded = crate::platform_encode_to_vec(value, cfg(), pv()).unwrap();
+        let decoded: Bound<u32> =
+            crate::platform_versioned_decode_from_slice(&encoded, cfg(), pv()).unwrap();
+        assert_eq!(decoded, Bound::Included(10));
+    }
+
+    #[test]
+    fn bound_excluded_round_trip() {
+        use core::ops::Bound;
+        let value: Bound<u32> = Bound::Excluded(20);
+        let encoded = crate::platform_encode_to_vec(value, cfg(), pv()).unwrap();
+        let decoded: Bound<u32> =
+            crate::platform_versioned_decode_from_slice(&encoded, cfg(), pv()).unwrap();
+        assert_eq!(decoded, Bound::Excluded(20));
+    }
+
+    #[test]
+    fn bound_invalid_variant() {
+        use core::ops::Bound;
+        // variant 3 is invalid for Bound (valid: 0, 1, 2)
+        let mut data = bincode::encode_to_vec(3u32, cfg()).unwrap();
+        data.extend_from_slice(&[0u8; 8]);
+        let result =
+            crate::platform_versioned_decode_from_slice::<Bound<u32>, _>(&data, cfg(), pv());
+        match result {
+            Err(DecodeError::UnexpectedVariant { found: 3, .. }) => {}
+            other => panic!("expected UnexpectedVariant, got {:?}", other),
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // Array decode: u8 optimization vs non-u8 path
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn array_u8_decode_round_trip() {
+        // This triggers the u8-optimized path in [T; N] decode
+        let value: [u8; 4] = [0xDE, 0xAD, 0xBE, 0xEF];
+        let encoded = crate::platform_encode_to_vec(value, cfg(), pv()).unwrap();
+        let decoded: [u8; 4] =
+            crate::platform_versioned_decode_from_slice(&encoded, cfg(), pv()).unwrap();
+        assert_eq!(decoded, value);
+    }
+
+    #[test]
+    fn array_non_u8_decode_round_trip() {
+        // This triggers the non-u8 path through collect_into_array
+        let value: [u32; 3] = [100, 200, 300];
+        let encoded = crate::platform_encode_to_vec(value, cfg(), pv()).unwrap();
+        let decoded: [u32; 3] =
+            crate::platform_versioned_decode_from_slice(&encoded, cfg(), pv()).unwrap();
+        assert_eq!(decoded, value);
+    }
+
+    #[test]
+    fn array_borrow_decode_u8_path() {
+        let value: [u8; 8] = [1, 2, 3, 4, 5, 6, 7, 8];
+        let encoded = crate::platform_encode_to_vec(value, cfg(), pv()).unwrap();
+        let decoded: [u8; 8] =
+            crate::platform_versioned_borrow_decode_from_slice(&encoded, cfg(), pv()).unwrap();
+        assert_eq!(decoded, value);
+    }
+
+    #[test]
+    fn array_borrow_decode_non_u8_path() {
+        let value: [i16; 4] = [-1, 0, 1, 32767];
+        let encoded = crate::platform_encode_to_vec(value, cfg(), pv()).unwrap();
+        let decoded: [i16; 4] =
+            crate::platform_versioned_borrow_decode_from_slice(&encoded, cfg(), pv()).unwrap();
+        assert_eq!(decoded, value);
+    }
+
+    // -----------------------------------------------------------------------
+    // Cell / RefCell
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn cell_round_trip() {
+        use core::cell::Cell;
+        let value = Cell::new(42u32);
+        let encoded = crate::platform_encode_to_vec(&value, cfg(), pv()).unwrap();
+        let decoded: Cell<u32> =
+            crate::platform_versioned_decode_from_slice(&encoded, cfg(), pv()).unwrap();
+        assert_eq!(decoded.get(), 42);
+    }
+
+    #[test]
+    fn refcell_round_trip() {
+        use core::cell::RefCell;
+        let value = RefCell::new(99u16);
+        let encoded = crate::platform_encode_to_vec(&value, cfg(), pv()).unwrap();
+        let decoded: RefCell<u16> =
+            crate::platform_versioned_decode_from_slice(&encoded, cfg(), pv()).unwrap();
+        assert_eq!(*decoded.borrow(), 99);
+    }
+
+    // -----------------------------------------------------------------------
+    // Range / RangeInclusive
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn range_round_trip() {
+        let value: core::ops::Range<u32> = 10..20;
+        let encoded = crate::platform_encode_to_vec(value.clone(), cfg(), pv()).unwrap();
+        let decoded: core::ops::Range<u32> =
+            crate::platform_versioned_decode_from_slice(&encoded, cfg(), pv()).unwrap();
+        assert_eq!(decoded, value);
+    }
+
+    #[test]
+    fn range_inclusive_round_trip() {
+        let value: core::ops::RangeInclusive<i32> = -5..=5;
+        let encoded = crate::platform_encode_to_vec(value.clone(), cfg(), pv()).unwrap();
+        let decoded: core::ops::RangeInclusive<i32> =
+            crate::platform_versioned_decode_from_slice(&encoded, cfg(), pv()).unwrap();
+        assert_eq!(decoded, value);
+    }
+
+    // -----------------------------------------------------------------------
+    // PhantomData / unit
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn unit_round_trip() {
+        let value = ();
+        let encoded = crate::platform_encode_to_vec(value, cfg(), pv()).unwrap();
+        let decoded: () =
+            crate::platform_versioned_decode_from_slice(&encoded, cfg(), pv()).unwrap();
+        assert_eq!(decoded, ());
+    }
+
+    #[test]
+    fn phantom_data_round_trip() {
+        use core::marker::PhantomData;
+        let value: PhantomData<u32> = PhantomData;
+        let encoded = crate::platform_encode_to_vec(value, cfg(), pv()).unwrap();
+        let decoded: PhantomData<u32> =
+            crate::platform_versioned_decode_from_slice(&encoded, cfg(), pv()).unwrap();
+        assert_eq!(decoded, PhantomData);
+    }
+
+    // -----------------------------------------------------------------------
+    // Primitive type round-trips (representative subset)
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn bool_round_trip() {
+        for value in [true, false] {
+            let encoded = crate::platform_encode_to_vec(value, cfg(), pv()).unwrap();
+            let decoded: bool =
+                crate::platform_versioned_decode_from_slice(&encoded, cfg(), pv()).unwrap();
+            assert_eq!(decoded, value);
+        }
+    }
+
+    #[test]
+    fn char_round_trip() {
+        for value in ['a', '\u{1F600}', '\0'] {
+            let encoded = crate::platform_encode_to_vec(value, cfg(), pv()).unwrap();
+            let decoded: char =
+                crate::platform_versioned_decode_from_slice(&encoded, cfg(), pv()).unwrap();
+            assert_eq!(decoded, value);
+        }
+    }
+
+    #[test]
+    fn f64_round_trip() {
+        let value: f64 = core::f64::consts::PI;
+        let encoded = crate::platform_encode_to_vec(value, cfg(), pv()).unwrap();
+        let decoded: f64 =
+            crate::platform_versioned_decode_from_slice(&encoded, cfg(), pv()).unwrap();
+        assert_eq!(decoded, value);
+    }
+
+    #[test]
+    fn duration_round_trip() {
+        let value = core::time::Duration::new(123, 456_789);
+        let encoded = crate::platform_encode_to_vec(value, cfg(), pv()).unwrap();
+        let decoded: core::time::Duration =
+            crate::platform_versioned_decode_from_slice(&encoded, cfg(), pv()).unwrap();
+        assert_eq!(decoded, value);
+    }
+
+    #[test]
+    fn borrow_decode_byte_slice() {
+        // Use bincode's own encode for &[u8] to match the borrow decode path
+        let data: &[u8] = b"hello bytes";
+        let encoded = bincode::encode_to_vec(data, cfg()).unwrap();
+        let decoded: &[u8] =
+            crate::platform_versioned_borrow_decode_from_slice(&encoded, cfg(), pv()).unwrap();
+        assert_eq!(decoded, data);
+    }
+
+    #[test]
+    fn borrow_decode_str() {
+        let data = "borrow me";
+        let encoded = crate::platform_encode_to_vec(data, cfg(), pv()).unwrap();
+        let decoded: &str =
+            crate::platform_versioned_borrow_decode_from_slice(&encoded, cfg(), pv()).unwrap();
+        assert_eq!(decoded, data);
+    }
+
+    // -----------------------------------------------------------------------
+    // NonZero type round-trips (cover the delegation impls in de/impls.rs)
+    // -----------------------------------------------------------------------
+
+    macro_rules! nonzero_round_trip_test {
+        ($name:ident, $ty:ty, $val:expr) => {
+            #[test]
+            fn $name() {
+                let value: $ty = <$ty>::new($val).unwrap();
+                let encoded = crate::platform_encode_to_vec(value, cfg(), pv()).unwrap();
+                let decoded: $ty =
+                    crate::platform_versioned_decode_from_slice(&encoded, cfg(), pv()).unwrap();
+                assert_eq!(decoded, value);
+            }
+        };
+    }
+
+    nonzero_round_trip_test!(nonzero_u8_round_trip, core::num::NonZeroU8, 1);
+    nonzero_round_trip_test!(nonzero_u16_round_trip, core::num::NonZeroU16, 100);
+    nonzero_round_trip_test!(nonzero_u32_round_trip, core::num::NonZeroU32, 1000);
+    nonzero_round_trip_test!(nonzero_u64_round_trip, core::num::NonZeroU64, 10000);
+    nonzero_round_trip_test!(nonzero_u128_round_trip, core::num::NonZeroU128, 100000);
+    nonzero_round_trip_test!(nonzero_usize_round_trip, core::num::NonZeroUsize, 42);
+    nonzero_round_trip_test!(nonzero_i8_round_trip, core::num::NonZeroI8, -1);
+    nonzero_round_trip_test!(nonzero_i16_round_trip, core::num::NonZeroI16, -100);
+    nonzero_round_trip_test!(nonzero_i32_round_trip, core::num::NonZeroI32, -1000);
+    nonzero_round_trip_test!(nonzero_i64_round_trip, core::num::NonZeroI64, -10000);
+    nonzero_round_trip_test!(nonzero_i128_round_trip, core::num::NonZeroI128, -100000);
+    nonzero_round_trip_test!(nonzero_isize_round_trip, core::num::NonZeroIsize, -42);
+
+    // -----------------------------------------------------------------------
+    // Remaining primitive types (i8, i16, i32, i64, i128, isize, u128, f32)
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn i8_round_trip() {
+        let value: i8 = -128;
+        let encoded = crate::platform_encode_to_vec(value, cfg(), pv()).unwrap();
+        let decoded: i8 =
+            crate::platform_versioned_decode_from_slice(&encoded, cfg(), pv()).unwrap();
+        assert_eq!(decoded, value);
+    }
+
+    #[test]
+    fn i16_round_trip() {
+        let value: i16 = -32768;
+        let encoded = crate::platform_encode_to_vec(value, cfg(), pv()).unwrap();
+        let decoded: i16 =
+            crate::platform_versioned_decode_from_slice(&encoded, cfg(), pv()).unwrap();
+        assert_eq!(decoded, value);
+    }
+
+    #[test]
+    fn i32_round_trip() {
+        let value: i32 = -2_000_000;
+        let encoded = crate::platform_encode_to_vec(value, cfg(), pv()).unwrap();
+        let decoded: i32 =
+            crate::platform_versioned_decode_from_slice(&encoded, cfg(), pv()).unwrap();
+        assert_eq!(decoded, value);
+    }
+
+    #[test]
+    fn i128_round_trip() {
+        let value: i128 = i128::MIN;
+        let encoded = crate::platform_encode_to_vec(value, cfg(), pv()).unwrap();
+        let decoded: i128 =
+            crate::platform_versioned_decode_from_slice(&encoded, cfg(), pv()).unwrap();
+        assert_eq!(decoded, value);
+    }
+
+    #[test]
+    fn isize_round_trip() {
+        let value: isize = -999;
+        let encoded = crate::platform_encode_to_vec(value, cfg(), pv()).unwrap();
+        let decoded: isize =
+            crate::platform_versioned_decode_from_slice(&encoded, cfg(), pv()).unwrap();
+        assert_eq!(decoded, value);
+    }
+
+    #[test]
+    fn u128_round_trip() {
+        let value: u128 = u128::MAX;
+        let encoded = crate::platform_encode_to_vec(value, cfg(), pv()).unwrap();
+        let decoded: u128 =
+            crate::platform_versioned_decode_from_slice(&encoded, cfg(), pv()).unwrap();
+        assert_eq!(decoded, value);
+    }
+
+    #[test]
+    fn usize_round_trip() {
+        let value: usize = 12345;
+        let encoded = crate::platform_encode_to_vec(value, cfg(), pv()).unwrap();
+        let decoded: usize =
+            crate::platform_versioned_decode_from_slice(&encoded, cfg(), pv()).unwrap();
+        assert_eq!(decoded, value);
+    }
+
+    #[test]
+    fn f32_round_trip() {
+        let value: f32 = core::f32::consts::E;
+        let encoded = crate::platform_encode_to_vec(value, cfg(), pv()).unwrap();
+        let decoded: f32 =
+            crate::platform_versioned_decode_from_slice(&encoded, cfg(), pv()).unwrap();
+        assert_eq!(decoded, value);
+    }
+
+    // -----------------------------------------------------------------------
+    // Borrow-decode round-trips for Cell, RefCell, Option, Range, etc.
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn cell_borrow_decode_round_trip() {
+        use core::cell::Cell;
+        let value = Cell::new(77u32);
+        let encoded = crate::platform_encode_to_vec(&value, cfg(), pv()).unwrap();
+        let decoded: Cell<u32> =
+            crate::platform_versioned_borrow_decode_from_slice(&encoded, cfg(), pv()).unwrap();
+        assert_eq!(decoded.get(), 77);
+    }
+
+    #[test]
+    fn refcell_borrow_decode_round_trip() {
+        use core::cell::RefCell;
+        let value = RefCell::new(88u16);
+        let encoded = crate::platform_encode_to_vec(&value, cfg(), pv()).unwrap();
+        let decoded: RefCell<u16> =
+            crate::platform_versioned_borrow_decode_from_slice(&encoded, cfg(), pv()).unwrap();
+        assert_eq!(*decoded.borrow(), 88);
+    }
+
+    #[test]
+    fn option_borrow_decode_some() {
+        let value: Option<u32> = Some(42);
+        let encoded = crate::platform_encode_to_vec(value, cfg(), pv()).unwrap();
+        let decoded: Option<u32> =
+            crate::platform_versioned_borrow_decode_from_slice(&encoded, cfg(), pv()).unwrap();
+        assert_eq!(decoded, Some(42));
+    }
+
+    #[test]
+    fn option_borrow_decode_none() {
+        let value: Option<u32> = None;
+        let encoded = crate::platform_encode_to_vec(value, cfg(), pv()).unwrap();
+        let decoded: Option<u32> =
+            crate::platform_versioned_borrow_decode_from_slice(&encoded, cfg(), pv()).unwrap();
+        assert_eq!(decoded, None);
+    }
+
+    #[test]
+    fn result_borrow_decode_ok() {
+        let value: Result<u32, u8> = Ok(123);
+        let encoded = crate::platform_encode_to_vec(value, cfg(), pv()).unwrap();
+        let decoded: Result<u32, u8> =
+            crate::platform_versioned_borrow_decode_from_slice(&encoded, cfg(), pv()).unwrap();
+        assert_eq!(decoded, Ok(123));
+    }
+
+    #[test]
+    fn result_borrow_decode_err() {
+        let value: Result<u32, u8> = Err(99);
+        let encoded = crate::platform_encode_to_vec(value, cfg(), pv()).unwrap();
+        let decoded: Result<u32, u8> =
+            crate::platform_versioned_borrow_decode_from_slice(&encoded, cfg(), pv()).unwrap();
+        assert_eq!(decoded, Err(99));
+    }
+
+    #[test]
+    fn result_borrow_decode_invalid_variant() {
+        let mut data = bincode::encode_to_vec(2u32, cfg()).unwrap();
+        data.extend_from_slice(&[0u8; 8]);
+        let result = crate::platform_versioned_borrow_decode_from_slice::<Result<u32, u8>, _>(
+            &data,
+            cfg(),
+            pv(),
+        );
+        match result {
+            Err(DecodeError::UnexpectedVariant { found: 2, .. }) => {}
+            other => panic!("expected UnexpectedVariant, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn range_borrow_decode_round_trip() {
+        let value: core::ops::Range<u32> = 5..15;
+        let encoded = crate::platform_encode_to_vec(value.clone(), cfg(), pv()).unwrap();
+        let decoded: core::ops::Range<u32> =
+            crate::platform_versioned_borrow_decode_from_slice(&encoded, cfg(), pv()).unwrap();
+        assert_eq!(decoded, value);
+    }
+
+    #[test]
+    fn range_inclusive_borrow_decode_round_trip() {
+        let value: core::ops::RangeInclusive<i32> = -10..=10;
+        let encoded = crate::platform_encode_to_vec(value.clone(), cfg(), pv()).unwrap();
+        let decoded: core::ops::RangeInclusive<i32> =
+            crate::platform_versioned_borrow_decode_from_slice(&encoded, cfg(), pv()).unwrap();
+        assert_eq!(decoded, value);
+    }
+
+    #[test]
+    fn bound_borrow_decode_all_variants() {
+        use core::ops::Bound;
+        for value in [
+            Bound::Unbounded,
+            Bound::Included(10u32),
+            Bound::Excluded(20u32),
+        ] {
+            let encoded = crate::platform_encode_to_vec(value, cfg(), pv()).unwrap();
+            let decoded: Bound<u32> =
+                crate::platform_versioned_borrow_decode_from_slice(&encoded, cfg(), pv()).unwrap();
+            assert_eq!(decoded, value);
+        }
+    }
+
+    #[test]
+    fn bound_borrow_decode_invalid_variant() {
+        use core::ops::Bound;
+        let mut data = bincode::encode_to_vec(3u32, cfg()).unwrap();
+        data.extend_from_slice(&[0u8; 8]);
+        let result =
+            crate::platform_versioned_borrow_decode_from_slice::<Bound<u32>, _>(&data, cfg(), pv());
+        match result {
+            Err(DecodeError::UnexpectedVariant { found: 3, .. }) => {}
+            other => panic!("expected UnexpectedVariant, got {:?}", other),
         }
     }
 }

--- a/packages/rs-platform-serialization/src/enc/impls.rs
+++ b/packages/rs-platform-serialization/src/enc/impls.rs
@@ -596,3 +596,241 @@ where
         Ok(())
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use bincode::config;
+    use platform_version::version::PlatformVersion;
+
+    fn cfg() -> impl bincode::config::Config {
+        config::standard().with_big_endian().with_no_limit()
+    }
+
+    fn pv() -> &'static PlatformVersion {
+        PlatformVersion::first()
+    }
+
+    /// Helper to encode and then decode, verifying round-trip.
+    fn round_trip<T>(value: T) -> T
+    where
+        T: PlatformVersionEncode + crate::PlatformVersionedDecode,
+    {
+        let encoded = crate::platform_encode_to_vec(value, cfg(), pv()).unwrap();
+        crate::platform_versioned_decode_from_slice(&encoded, cfg(), pv()).unwrap()
+    }
+
+    // -----------------------------------------------------------------------
+    // Slice encode: u8 optimization vs generic path
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn encode_u8_slice_optimization() {
+        // Exercise the TypeId::of::<u8>() fast path in [T] encode via Vec
+        let data: Vec<u8> = vec![1, 2, 3, 4, 5];
+        let encoded = crate::platform_encode_to_vec(&data, cfg(), pv()).unwrap();
+        let decoded: Vec<u8> =
+            crate::platform_versioned_decode_from_slice(&encoded, cfg(), pv()).unwrap();
+        assert_eq!(decoded, data);
+    }
+
+    #[test]
+    fn encode_non_u8_slice() {
+        // Exercise the generic (non-u8) path in [T] encode
+        let data: Vec<u32> = vec![100, 200, 300];
+        let encoded = crate::platform_encode_to_vec(&data, cfg(), pv()).unwrap();
+        let decoded: Vec<u32> =
+            crate::platform_versioned_decode_from_slice(&encoded, cfg(), pv()).unwrap();
+        assert_eq!(decoded, data);
+    }
+
+    #[test]
+    fn encode_empty_slice() {
+        let data: &[u8] = &[];
+        let encoded = crate::platform_encode_to_vec(data, cfg(), pv()).unwrap();
+        let decoded: Vec<u8> =
+            crate::platform_versioned_decode_from_slice(&encoded, cfg(), pv()).unwrap();
+        assert!(decoded.is_empty());
+    }
+
+    // -----------------------------------------------------------------------
+    // Array encode
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn encode_array_u32() {
+        let value: [u32; 3] = [10, 20, 30];
+        assert_eq!(round_trip(value), value);
+    }
+
+    #[test]
+    fn encode_array_single_element() {
+        let value: [u64; 1] = [42];
+        assert_eq!(round_trip(value), value);
+    }
+
+    // -----------------------------------------------------------------------
+    // Option encode
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn encode_option_some() {
+        let value: Option<i32> = Some(-42);
+        assert_eq!(round_trip(value), value);
+    }
+
+    #[test]
+    fn encode_option_none() {
+        let value: Option<i32> = None;
+        assert_eq!(round_trip(value), value);
+    }
+
+    // -----------------------------------------------------------------------
+    // Result encode
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn encode_result_ok() {
+        let value: Result<u32, u8> = Ok(42);
+        assert_eq!(round_trip(value), value);
+    }
+
+    #[test]
+    fn encode_result_err() {
+        let value: Result<u32, u8> = Err(1);
+        assert_eq!(round_trip(value), value);
+    }
+
+    // -----------------------------------------------------------------------
+    // Cell / RefCell encode
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn encode_cell() {
+        let value = Cell::new(77u32);
+        let encoded = crate::platform_encode_to_vec(&value, cfg(), pv()).unwrap();
+        let decoded: u32 =
+            crate::platform_versioned_decode_from_slice(&encoded, cfg(), pv()).unwrap();
+        assert_eq!(decoded, 77);
+    }
+
+    #[test]
+    fn encode_refcell() {
+        let value = RefCell::new(88u16);
+        let encoded = crate::platform_encode_to_vec(&value, cfg(), pv()).unwrap();
+        let decoded: u16 =
+            crate::platform_versioned_decode_from_slice(&encoded, cfg(), pv()).unwrap();
+        assert_eq!(decoded, 88);
+    }
+
+    #[test]
+    fn encode_refcell_already_borrowed_returns_error() {
+        let value = RefCell::new(42u32);
+        let _borrow = value.borrow_mut(); // hold a mutable borrow
+        let result = crate::platform_encode_to_vec(&value, cfg(), pv());
+        assert!(result.is_err());
+    }
+
+    // -----------------------------------------------------------------------
+    // str encode
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn encode_str() {
+        let value = "hello platform";
+        let encoded = crate::platform_encode_to_vec(value, cfg(), pv()).unwrap();
+        let decoded: String =
+            crate::platform_versioned_decode_from_slice(&encoded, cfg(), pv()).unwrap();
+        assert_eq!(decoded, value);
+    }
+
+    // -----------------------------------------------------------------------
+    // Reference encode
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn encode_ref() {
+        let value: u32 = 42;
+        let encoded = crate::platform_encode_to_vec(&value, cfg(), pv()).unwrap();
+        let decoded: u32 =
+            crate::platform_versioned_decode_from_slice(&encoded, cfg(), pv()).unwrap();
+        assert_eq!(decoded, value);
+    }
+
+    // -----------------------------------------------------------------------
+    // Tuple encode
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn encode_tuple_1() {
+        let value: (u32,) = (42,);
+        assert_eq!(round_trip(value), value);
+    }
+
+    #[test]
+    fn encode_tuple_2() {
+        let value: (u32, i8) = (42, -1);
+        assert_eq!(round_trip(value), value);
+    }
+
+    #[test]
+    fn encode_tuple_3() {
+        let value: (u8, u16, u32) = (1, 2, 3);
+        assert_eq!(round_trip(value), value);
+    }
+
+    #[test]
+    fn encode_tuple_4() {
+        let value: (u8, u16, u32, u64) = (1, 2, 3, 4);
+        assert_eq!(round_trip(value), value);
+    }
+
+    #[test]
+    fn encode_tuple_5() {
+        let value: (u8, u16, u32, u64, bool) = (1, 2, 3, 4, true);
+        assert_eq!(round_trip(value), value);
+    }
+
+    // -----------------------------------------------------------------------
+    // Duration / Range / RangeInclusive / Bound
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn encode_duration() {
+        let value = Duration::new(60, 500_000_000);
+        assert_eq!(round_trip(value), value);
+    }
+
+    #[test]
+    fn encode_range() {
+        let value = 10u32..20u32;
+        assert_eq!(round_trip(value.clone()), value);
+    }
+
+    #[test]
+    fn encode_range_inclusive() {
+        let value = 10u32..=20u32;
+        assert_eq!(round_trip(value.clone()), value);
+    }
+
+    #[test]
+    fn encode_bound_unbounded() {
+        use core::ops::Bound;
+        let value: Bound<u32> = Bound::Unbounded;
+        assert_eq!(round_trip(value), value);
+    }
+
+    #[test]
+    fn encode_bound_included() {
+        use core::ops::Bound;
+        let value: Bound<u32> = Bound::Included(5);
+        assert_eq!(round_trip(value), value);
+    }
+
+    #[test]
+    fn encode_bound_excluded() {
+        use core::ops::Bound;
+        let value: Bound<u32> = Bound::Excluded(5);
+        assert_eq!(round_trip(value), value);
+    }
+}

--- a/packages/rs-platform-serialization/src/enc/mod.rs
+++ b/packages/rs-platform-serialization/src/enc/mod.rs
@@ -63,3 +63,52 @@ pub(crate) fn encode_option_variant<E: Encoder, T>(
 pub(crate) fn encode_slice_len<E: Encoder>(encoder: &mut E, len: usize) -> Result<(), EncodeError> {
     (len as u64).encode(encoder)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use bincode::config;
+
+    fn cfg() -> impl bincode::config::Config {
+        config::standard().with_big_endian().with_no_limit()
+    }
+
+    #[test]
+    fn encode_option_variant_none() {
+        let value: Option<u32> = None;
+        let mut writer = VecWriter::default();
+        let mut encoder = bincode::enc::EncoderImpl::new(&mut writer, cfg());
+        encode_option_variant(&mut encoder, &value).unwrap();
+        drop(encoder);
+        assert_eq!(writer.inner, &[0u8]);
+    }
+
+    #[test]
+    fn encode_option_variant_some() {
+        let value: Option<u32> = Some(42);
+        let mut writer = VecWriter::default();
+        let mut encoder = bincode::enc::EncoderImpl::new(&mut writer, cfg());
+        encode_option_variant(&mut encoder, &value).unwrap();
+        drop(encoder);
+        assert_eq!(writer.inner, &[1u8]);
+    }
+
+    #[test]
+    fn encode_slice_len_encodes_as_u64() {
+        let mut writer = VecWriter::default();
+        let mut encoder = bincode::enc::EncoderImpl::new(&mut writer, cfg());
+        encode_slice_len(&mut encoder, 5).unwrap();
+        drop(encoder);
+        // 5 as u64 in big-endian varint
+        let expected = bincode::encode_to_vec(5u64, cfg()).unwrap();
+        assert_eq!(writer.inner, expected);
+    }
+
+    #[test]
+    fn vec_writer_write_impl() {
+        let mut writer = VecWriter::default();
+        bincode::enc::write::Writer::write(&mut writer, b"hello").unwrap();
+        bincode::enc::write::Writer::write(&mut writer, b" world").unwrap();
+        assert_eq!(writer.inner, b"hello world");
+    }
+}

--- a/packages/rs-platform-serialization/src/features/impl_alloc.rs
+++ b/packages/rs-platform-serialization/src/features/impl_alloc.rs
@@ -714,3 +714,376 @@ where
         Ok(vec.into())
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloc::collections::{BTreeMap, BTreeSet, BinaryHeap, VecDeque};
+    use bincode::config;
+
+    fn cfg() -> impl bincode::config::Config {
+        config::standard().with_big_endian().with_no_limit()
+    }
+
+    fn pv() -> &'static PlatformVersion {
+        PlatformVersion::first()
+    }
+
+    fn round_trip<T>(value: T) -> T
+    where
+        T: PlatformVersionEncode + crate::PlatformVersionedDecode,
+    {
+        let encoded = crate::platform_encode_to_vec(value, cfg(), pv()).unwrap();
+        crate::platform_versioned_decode_from_slice(&encoded, cfg(), pv()).unwrap()
+    }
+
+    // -----------------------------------------------------------------------
+    // platform_encode_to_vec
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn encode_to_vec_basic() {
+        let encoded = crate::platform_encode_to_vec(42u32, cfg(), pv()).unwrap();
+        assert!(!encoded.is_empty());
+        let decoded: u32 =
+            crate::platform_versioned_decode_from_slice(&encoded, cfg(), pv()).unwrap();
+        assert_eq!(decoded, 42);
+    }
+
+    // -----------------------------------------------------------------------
+    // Vec<T> encode/decode: u8 optimization vs generic
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn vec_u8_round_trip() {
+        let value: Vec<u8> = vec![0, 1, 2, 255, 128];
+        assert_eq!(round_trip(value.clone()), value);
+    }
+
+    #[test]
+    fn vec_u32_round_trip() {
+        let value: Vec<u32> = vec![100, 200, 300];
+        assert_eq!(round_trip(value.clone()), value);
+    }
+
+    #[test]
+    fn vec_empty_round_trip() {
+        let value: Vec<u32> = vec![];
+        assert_eq!(round_trip(value.clone()), value);
+    }
+
+    // -----------------------------------------------------------------------
+    // BTreeMap
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn btree_map_round_trip() {
+        let mut map = BTreeMap::new();
+        map.insert(1u32, "one".to_string());
+        map.insert(2, "two".to_string());
+        map.insert(3, "three".to_string());
+        assert_eq!(round_trip(map.clone()), map);
+    }
+
+    #[test]
+    fn btree_map_empty_round_trip() {
+        let map: BTreeMap<u32, String> = BTreeMap::new();
+        assert_eq!(round_trip(map.clone()), map);
+    }
+
+    // -----------------------------------------------------------------------
+    // BTreeSet
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn btree_set_round_trip() {
+        let mut set = BTreeSet::new();
+        set.insert(10u32);
+        set.insert(20);
+        set.insert(30);
+        assert_eq!(round_trip(set.clone()), set);
+    }
+
+    // -----------------------------------------------------------------------
+    // BinaryHeap
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn binary_heap_round_trip() {
+        let mut heap = BinaryHeap::new();
+        heap.push(3u32);
+        heap.push(1);
+        heap.push(2);
+        let result = round_trip(heap);
+        // BinaryHeap doesn't implement Eq, so compare sorted vecs
+        let sorted: Vec<u32> = result.into_sorted_vec();
+        assert_eq!(sorted, vec![1, 2, 3]);
+    }
+
+    // -----------------------------------------------------------------------
+    // VecDeque
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn vec_deque_round_trip() {
+        let mut deque = VecDeque::new();
+        deque.push_back(1u32);
+        deque.push_back(2);
+        deque.push_front(0);
+        assert_eq!(round_trip(deque.clone()), deque);
+    }
+
+    // -----------------------------------------------------------------------
+    // String
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn string_round_trip() {
+        let value = "hello world".to_string();
+        assert_eq!(round_trip(value.clone()), value);
+    }
+
+    #[test]
+    fn string_empty_round_trip() {
+        let value = String::new();
+        assert_eq!(round_trip(value.clone()), value);
+    }
+
+    // -----------------------------------------------------------------------
+    // Box<T>, Box<str>, Box<[T]>
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn box_round_trip() {
+        let value = Box::new(42u32);
+        assert_eq!(round_trip(value.clone()), value);
+    }
+
+    #[test]
+    fn box_str_round_trip() {
+        let value: Box<str> = "boxed string".into();
+        assert_eq!(round_trip(value.clone()), value);
+    }
+
+    #[test]
+    fn box_slice_round_trip() {
+        let value: Box<[u32]> = vec![1, 2, 3].into_boxed_slice();
+        assert_eq!(round_trip(value.clone()), value);
+    }
+
+    // -----------------------------------------------------------------------
+    // Rc<T>, Rc<[T]>
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn rc_round_trip() {
+        let value = Rc::new(42u32);
+        let encoded = crate::platform_encode_to_vec(&value, cfg(), pv()).unwrap();
+        let decoded: Rc<u32> =
+            crate::platform_versioned_decode_from_slice(&encoded, cfg(), pv()).unwrap();
+        assert_eq!(*decoded, 42);
+    }
+
+    #[test]
+    fn rc_slice_round_trip() {
+        let value: Rc<[u32]> = vec![1, 2, 3].into();
+        let encoded = crate::platform_encode_to_vec(&value, cfg(), pv()).unwrap();
+        let decoded: Rc<[u32]> =
+            crate::platform_versioned_decode_from_slice(&encoded, cfg(), pv()).unwrap();
+        assert_eq!(&*decoded, &[1, 2, 3]);
+    }
+
+    // -----------------------------------------------------------------------
+    // Arc<T>, Arc<str>, Arc<[T]>
+    // -----------------------------------------------------------------------
+
+    #[cfg(target_has_atomic = "ptr")]
+    #[test]
+    fn arc_round_trip() {
+        let value = Arc::new(42u32);
+        let encoded = crate::platform_encode_to_vec(&value, cfg(), pv()).unwrap();
+        let decoded: Arc<u32> =
+            crate::platform_versioned_decode_from_slice(&encoded, cfg(), pv()).unwrap();
+        assert_eq!(*decoded, 42);
+    }
+
+    #[cfg(target_has_atomic = "ptr")]
+    #[test]
+    fn arc_str_round_trip() {
+        let value: Arc<str> = Arc::from("arc string");
+        let encoded = crate::platform_encode_to_vec(&value, cfg(), pv()).unwrap();
+        let decoded: Arc<str> =
+            crate::platform_versioned_decode_from_slice(&encoded, cfg(), pv()).unwrap();
+        assert_eq!(&*decoded, "arc string");
+    }
+
+    #[cfg(target_has_atomic = "ptr")]
+    #[test]
+    fn arc_slice_round_trip() {
+        let value: Arc<[u32]> = vec![10, 20, 30].into();
+        let encoded = crate::platform_encode_to_vec(&value, cfg(), pv()).unwrap();
+        let decoded: Arc<[u32]> =
+            crate::platform_versioned_decode_from_slice(&encoded, cfg(), pv()).unwrap();
+        assert_eq!(&*decoded, &[10, 20, 30]);
+    }
+
+    // -----------------------------------------------------------------------
+    // Cow
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn cow_owned_round_trip() {
+        let value: Cow<str> = Cow::Owned("owned".to_string());
+        let encoded = crate::platform_encode_to_vec(&value, cfg(), pv()).unwrap();
+        let decoded: Cow<str> =
+            crate::platform_versioned_decode_from_slice(&encoded, cfg(), pv()).unwrap();
+        assert_eq!(decoded, "owned");
+    }
+
+    // -----------------------------------------------------------------------
+    // VecWriter (alloc version)
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn vec_writer_with_capacity() {
+        let writer = VecWriter::with_capacity(100);
+        let collected = writer.collect();
+        assert!(collected.is_empty());
+        assert!(collected.capacity() >= 100);
+    }
+
+    // -----------------------------------------------------------------------
+    // Borrow-decode paths for collection types
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn btree_map_borrow_decode() {
+        let mut map = BTreeMap::new();
+        map.insert(1u32, 10u32);
+        map.insert(2, 20);
+        let encoded = crate::platform_encode_to_vec(&map, cfg(), pv()).unwrap();
+        let decoded: BTreeMap<u32, u32> =
+            crate::platform_versioned_borrow_decode_from_slice(&encoded, cfg(), pv()).unwrap();
+        assert_eq!(decoded, map);
+    }
+
+    #[test]
+    fn btree_set_borrow_decode() {
+        let mut set = BTreeSet::new();
+        set.insert(1u32);
+        set.insert(2);
+        let encoded = crate::platform_encode_to_vec(&set, cfg(), pv()).unwrap();
+        let decoded: BTreeSet<u32> =
+            crate::platform_versioned_borrow_decode_from_slice(&encoded, cfg(), pv()).unwrap();
+        assert_eq!(decoded, set);
+    }
+
+    #[test]
+    fn binary_heap_borrow_decode() {
+        let mut heap = BinaryHeap::new();
+        heap.push(5u32);
+        heap.push(3);
+        heap.push(7);
+        let encoded = crate::platform_encode_to_vec(&heap, cfg(), pv()).unwrap();
+        let decoded: BinaryHeap<u32> =
+            crate::platform_versioned_borrow_decode_from_slice(&encoded, cfg(), pv()).unwrap();
+        let sorted: Vec<u32> = decoded.into_sorted_vec();
+        assert_eq!(sorted, vec![3, 5, 7]);
+    }
+
+    #[test]
+    fn vec_deque_borrow_decode() {
+        let mut deque = VecDeque::new();
+        deque.push_back(1u32);
+        deque.push_back(2);
+        let encoded = crate::platform_encode_to_vec(&deque, cfg(), pv()).unwrap();
+        let decoded: VecDeque<u32> =
+            crate::platform_versioned_borrow_decode_from_slice(&encoded, cfg(), pv()).unwrap();
+        assert_eq!(decoded, deque);
+    }
+
+    #[test]
+    fn vec_borrow_decode() {
+        let value: Vec<u32> = vec![1, 2, 3];
+        let encoded = crate::platform_encode_to_vec(&value, cfg(), pv()).unwrap();
+        let decoded: Vec<u32> =
+            crate::platform_versioned_borrow_decode_from_slice(&encoded, cfg(), pv()).unwrap();
+        assert_eq!(decoded, value);
+    }
+
+    #[test]
+    fn box_borrow_decode() {
+        let value = Box::new(42u32);
+        let encoded = crate::platform_encode_to_vec(&value, cfg(), pv()).unwrap();
+        let decoded: Box<u32> =
+            crate::platform_versioned_borrow_decode_from_slice(&encoded, cfg(), pv()).unwrap();
+        assert_eq!(decoded, value);
+    }
+
+    #[test]
+    fn box_slice_borrow_decode() {
+        let value: Box<[u32]> = vec![10, 20, 30].into_boxed_slice();
+        let encoded = crate::platform_encode_to_vec(&value, cfg(), pv()).unwrap();
+        let decoded: Box<[u32]> =
+            crate::platform_versioned_borrow_decode_from_slice(&encoded, cfg(), pv()).unwrap();
+        assert_eq!(decoded, value);
+    }
+
+    #[test]
+    fn rc_borrow_decode() {
+        let value = Rc::new(42u32);
+        let encoded = crate::platform_encode_to_vec(&value, cfg(), pv()).unwrap();
+        let decoded: Rc<u32> =
+            crate::platform_versioned_borrow_decode_from_slice(&encoded, cfg(), pv()).unwrap();
+        assert_eq!(*decoded, 42);
+    }
+
+    #[test]
+    fn rc_slice_borrow_decode() {
+        let value: Rc<[u32]> = vec![1, 2, 3].into();
+        let encoded = crate::platform_encode_to_vec(&value, cfg(), pv()).unwrap();
+        let decoded: Rc<[u32]> =
+            crate::platform_versioned_borrow_decode_from_slice(&encoded, cfg(), pv()).unwrap();
+        assert_eq!(&*decoded, &[1, 2, 3]);
+    }
+
+    #[cfg(target_has_atomic = "ptr")]
+    #[test]
+    fn arc_borrow_decode() {
+        let value = Arc::new(42u32);
+        let encoded = crate::platform_encode_to_vec(&value, cfg(), pv()).unwrap();
+        let decoded: Arc<u32> =
+            crate::platform_versioned_borrow_decode_from_slice(&encoded, cfg(), pv()).unwrap();
+        assert_eq!(*decoded, 42);
+    }
+
+    #[cfg(target_has_atomic = "ptr")]
+    #[test]
+    fn arc_str_borrow_decode() {
+        let value: Arc<str> = Arc::from("test arc str");
+        let encoded = crate::platform_encode_to_vec(&value, cfg(), pv()).unwrap();
+        let decoded: Arc<str> =
+            crate::platform_versioned_borrow_decode_from_slice(&encoded, cfg(), pv()).unwrap();
+        assert_eq!(&*decoded, "test arc str");
+    }
+
+    #[cfg(target_has_atomic = "ptr")]
+    #[test]
+    fn arc_slice_borrow_decode() {
+        let value: Arc<[u32]> = vec![10, 20].into();
+        let encoded = crate::platform_encode_to_vec(&value, cfg(), pv()).unwrap();
+        let decoded: Arc<[u32]> =
+            crate::platform_versioned_borrow_decode_from_slice(&encoded, cfg(), pv()).unwrap();
+        assert_eq!(&*decoded, &[10, 20]);
+    }
+
+    #[test]
+    fn cow_borrow_decode() {
+        use alloc::borrow::Cow;
+        let value = "borrowed cow";
+        let encoded = crate::platform_encode_to_vec(&value, cfg(), pv()).unwrap();
+        let decoded: Cow<str> =
+            crate::platform_versioned_borrow_decode_from_slice(&encoded, cfg(), pv()).unwrap();
+        assert_eq!(&*decoded, value);
+    }
+}

--- a/packages/rs-platform-serialization/src/features/impl_std.rs
+++ b/packages/rs-platform-serialization/src/features/impl_std.rs
@@ -556,3 +556,242 @@ where
         Ok(())
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use bincode::config;
+
+    fn cfg() -> impl bincode::config::Config {
+        config::standard().with_big_endian().with_no_limit()
+    }
+
+    fn pv() -> &'static PlatformVersion {
+        PlatformVersion::first()
+    }
+
+    fn round_trip<T>(value: T) -> T
+    where
+        T: PlatformVersionEncode + crate::PlatformVersionedDecode,
+    {
+        let encoded = crate::platform_encode_to_vec(value, cfg(), pv()).unwrap();
+        crate::platform_versioned_decode_from_slice(&encoded, cfg(), pv()).unwrap()
+    }
+
+    // -----------------------------------------------------------------------
+    // HashMap
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn hash_map_round_trip() {
+        let mut map = HashMap::new();
+        map.insert("a".to_string(), 1u32);
+        map.insert("b".to_string(), 2);
+        let decoded = round_trip(map.clone());
+        assert_eq!(decoded, map);
+    }
+
+    #[test]
+    fn hash_map_empty_round_trip() {
+        let map: HashMap<String, u32> = HashMap::new();
+        let decoded = round_trip(map.clone());
+        assert_eq!(decoded, map);
+    }
+
+    // -----------------------------------------------------------------------
+    // HashSet
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn hash_set_round_trip() {
+        let mut set = HashSet::new();
+        set.insert(10u32);
+        set.insert(20);
+        set.insert(30);
+        let decoded = round_trip(set.clone());
+        assert_eq!(decoded, set);
+    }
+
+    // -----------------------------------------------------------------------
+    // Mutex
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn mutex_round_trip() {
+        let value = Mutex::new(42u32);
+        let encoded = crate::platform_encode_to_vec(&value, cfg(), pv()).unwrap();
+        let decoded: Mutex<u32> =
+            crate::platform_versioned_decode_from_slice(&encoded, cfg(), pv()).unwrap();
+        assert_eq!(*decoded.lock().unwrap(), 42);
+    }
+
+    // -----------------------------------------------------------------------
+    // RwLock
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn rwlock_round_trip() {
+        let value = RwLock::new(99u32);
+        let encoded = crate::platform_encode_to_vec(&value, cfg(), pv()).unwrap();
+        let decoded: RwLock<u32> =
+            crate::platform_versioned_decode_from_slice(&encoded, cfg(), pv()).unwrap();
+        assert_eq!(*decoded.read().unwrap(), 99);
+    }
+
+    // -----------------------------------------------------------------------
+    // CString / &CStr
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn cstring_round_trip() {
+        let value = CString::new("hello").unwrap();
+        let encoded = crate::platform_encode_to_vec(&value, cfg(), pv()).unwrap();
+        let decoded: CString =
+            crate::platform_versioned_decode_from_slice(&encoded, cfg(), pv()).unwrap();
+        assert_eq!(decoded, value);
+    }
+
+    #[test]
+    fn cstr_encode() {
+        let cstr = CString::new("test").unwrap();
+        let cstr_ref: &CStr = cstr.as_c_str();
+        let encoded = crate::platform_encode_to_vec(&cstr_ref, cfg(), pv()).unwrap();
+        let decoded: CString =
+            crate::platform_versioned_decode_from_slice(&encoded, cfg(), pv()).unwrap();
+        assert_eq!(decoded.as_c_str(), cstr_ref);
+    }
+
+    // -----------------------------------------------------------------------
+    // SystemTime
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn system_time_round_trip() {
+        let value = SystemTime::now();
+        let encoded = crate::platform_encode_to_vec(value, cfg(), pv()).unwrap();
+        let decoded: SystemTime =
+            crate::platform_versioned_decode_from_slice(&encoded, cfg(), pv()).unwrap();
+        assert_eq!(decoded, value);
+    }
+
+    // -----------------------------------------------------------------------
+    // PathBuf / &Path
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn pathbuf_encode() {
+        let value = PathBuf::from("/tmp/test");
+        let encoded = crate::platform_encode_to_vec(&value, cfg(), pv()).unwrap();
+        assert!(!encoded.is_empty());
+    }
+
+    #[test]
+    fn path_ref_encode() {
+        let path = Path::new("/tmp/test");
+        let encoded = crate::platform_encode_to_vec(&path, cfg(), pv()).unwrap();
+        assert!(!encoded.is_empty());
+    }
+
+    #[test]
+    fn path_borrow_decode() {
+        let path = Path::new("/usr/local");
+        let encoded = crate::platform_encode_to_vec(&path, cfg(), pv()).unwrap();
+        let decoded: &Path =
+            crate::platform_versioned_borrow_decode_from_slice(&encoded, cfg(), pv()).unwrap();
+        assert_eq!(decoded, path);
+    }
+
+    // -----------------------------------------------------------------------
+    // IP addresses
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn ipv4_round_trip() {
+        let value = Ipv4Addr::new(192, 168, 1, 1);
+        assert_eq!(round_trip(value), value);
+    }
+
+    #[test]
+    fn ipv6_round_trip() {
+        let value = Ipv6Addr::LOCALHOST;
+        assert_eq!(round_trip(value), value);
+    }
+
+    #[test]
+    fn ip_addr_v4_round_trip() {
+        let value = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1));
+        assert_eq!(round_trip(value), value);
+    }
+
+    #[test]
+    fn ip_addr_v6_round_trip() {
+        let value = IpAddr::V6(Ipv6Addr::LOCALHOST);
+        assert_eq!(round_trip(value), value);
+    }
+
+    // -----------------------------------------------------------------------
+    // Socket addresses
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn socket_addr_v4_round_trip() {
+        let value = SocketAddrV4::new(Ipv4Addr::new(127, 0, 0, 1), 8080);
+        assert_eq!(round_trip(value), value);
+    }
+
+    #[test]
+    fn socket_addr_v6_round_trip() {
+        let value = SocketAddrV6::new(Ipv6Addr::LOCALHOST, 443, 0, 0);
+        assert_eq!(round_trip(value), value);
+    }
+
+    #[test]
+    fn socket_addr_round_trip() {
+        let value = SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::new(0, 0, 0, 0), 3000));
+        assert_eq!(round_trip(value), value);
+    }
+
+    // -----------------------------------------------------------------------
+    // Borrow-decode paths for std types
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn hash_map_borrow_decode() {
+        let mut map = HashMap::new();
+        map.insert(1u32, 10u32);
+        map.insert(2, 20);
+        let encoded = crate::platform_encode_to_vec(&map, cfg(), pv()).unwrap();
+        let decoded: HashMap<u32, u32> =
+            crate::platform_versioned_borrow_decode_from_slice(&encoded, cfg(), pv()).unwrap();
+        assert_eq!(decoded, map);
+    }
+
+    #[test]
+    fn hash_set_borrow_decode() {
+        let mut set = HashSet::new();
+        set.insert(1u32);
+        set.insert(2);
+        let encoded = crate::platform_encode_to_vec(&set, cfg(), pv()).unwrap();
+        let decoded: HashSet<u32> =
+            crate::platform_versioned_borrow_decode_from_slice(&encoded, cfg(), pv()).unwrap();
+        assert_eq!(decoded, set);
+    }
+
+    #[test]
+    fn mutex_borrow_decode() {
+        let value = Mutex::new(42u32);
+        let encoded = crate::platform_encode_to_vec(&value, cfg(), pv()).unwrap();
+        let decoded: Mutex<u32> =
+            crate::platform_versioned_borrow_decode_from_slice(&encoded, cfg(), pv()).unwrap();
+        assert_eq!(*decoded.lock().unwrap(), 42);
+    }
+
+    #[test]
+    fn rwlock_borrow_decode() {
+        let value = RwLock::new(99u32);
+        let encoded = crate::platform_encode_to_vec(&value, cfg(), pv()).unwrap();
+        let decoded: RwLock<u32> =
+            crate::platform_versioned_borrow_decode_from_slice(&encoded, cfg(), pv()).unwrap();
+        assert_eq!(*decoded.read().unwrap(), 99);
+    }
+}

--- a/packages/rs-platform-serialization/src/lib.rs
+++ b/packages/rs-platform-serialization/src/lib.rs
@@ -106,3 +106,91 @@ pub fn platform_versioned_decode_from_reader<D: PlatformVersionedDecode, R: Read
     let mut decoder = DecoderImpl::<_, C, crate::BincodeContext>::new(reader, config, ());
     D::platform_versioned_decode(&mut decoder, platform_version)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use bincode::config;
+    use platform_version::version::PlatformVersion;
+
+    fn cfg() -> impl Config {
+        config::standard().with_big_endian().with_no_limit()
+    }
+
+    fn pv() -> &'static PlatformVersion {
+        PlatformVersion::first()
+    }
+
+    // -----------------------------------------------------------------------
+    // Top-level encode/decode round-trip functions
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn encode_into_slice_and_decode_round_trip() {
+        let value: u32 = 42;
+        let mut buf = [0u8; 64];
+        let written = platform_encode_into_slice(value, &mut buf, cfg(), pv()).unwrap();
+        assert!(written > 0);
+
+        let decoded: u32 =
+            platform_versioned_decode_from_slice(&buf[..written], cfg(), pv()).unwrap();
+        assert_eq!(decoded, value);
+    }
+
+    #[test]
+    fn encode_into_slice_too_small_returns_error() {
+        let value: u64 = u64::MAX;
+        let mut buf = [0u8; 1]; // too small for a u64
+        let result = platform_encode_into_slice(value, &mut buf, cfg(), pv());
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn encode_into_writer_round_trip() {
+        let value: u16 = 1234;
+        let mut writer = enc::VecWriter::default();
+        encode_into_writer(value, &mut writer, cfg(), pv()).unwrap();
+
+        let encoded = platform_encode_to_vec(value, cfg(), pv()).unwrap();
+        let decoded: u16 = platform_versioned_decode_from_slice(&encoded, cfg(), pv()).unwrap();
+        assert_eq!(decoded, value);
+    }
+
+    #[test]
+    fn borrow_decode_from_slice_str() {
+        let value = "hello world";
+        let encoded = platform_encode_to_vec(value, cfg(), pv()).unwrap();
+
+        let decoded: &str =
+            platform_versioned_borrow_decode_from_slice(&encoded, cfg(), pv()).unwrap();
+        assert_eq!(decoded, value);
+    }
+
+    #[test]
+    fn decode_from_reader() {
+        let value: i64 = -99999;
+        let encoded = platform_encode_to_vec(value, cfg(), pv()).unwrap();
+
+        let reader = bincode::de::read::SliceReader::new(&encoded);
+        let decoded: i64 = platform_versioned_decode_from_reader(reader, cfg(), pv()).unwrap();
+        assert_eq!(decoded, value);
+    }
+
+    #[test]
+    fn decode_from_slice_empty_input_fails() {
+        let result = platform_versioned_decode_from_slice::<u32, _>(&[], cfg(), pv());
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn decode_from_slice_truncated_input_fails() {
+        let encoded = platform_encode_to_vec(42u32, cfg(), pv()).unwrap();
+        // only give half the bytes
+        let result = platform_versioned_decode_from_slice::<u32, _>(
+            &encoded[..encoded.len() / 2],
+            cfg(),
+            pv(),
+        );
+        assert!(result.is_err());
+    }
+}


### PR DESCRIPTION
## Issue being fixed or feature implemented

Improve test coverage for the `platform-serialization` crate from 9% to 95%+ line coverage.

## What was done?

Added 155 new unit tests across all modules in `packages/rs-platform-serialization/src/`:

- **`lib.rs`**: Tests for top-level `platform_encode_into_slice`, `encode_into_writer`, `platform_versioned_decode_from_slice`, `platform_versioned_borrow_decode_from_slice`, and `platform_versioned_decode_from_reader` functions, including error cases (truncated input, buffer too small)
- **`de/mod.rs`**: Tests for `decode_option_variant` (all variants including invalid), `Option<T>` and `Result<T,U>` decode (including invalid variant error paths), `Bound<T>` decode (all three variants + invalid), array decode with u8 optimization and generic paths, `Cell`/`RefCell` round-trips, `Range`/`RangeInclusive`, all NonZero integer types, remaining primitive types, and borrow-decode paths for all applicable types
- **`de/impl_tuples.rs`**: Tuple decode tests for 1-3 element tuples plus borrow-decode
- **`enc/mod.rs`**: Tests for `encode_option_variant`, `encode_slice_len`, and `VecWriter`
- **`enc/impls.rs`**: Tests for slice encode (u8 optimization vs generic), array encode, `Option`/`Result` encode, `Cell`/`RefCell` encode (including `RefCell` borrow error), `str`/reference encode, tuple encode (1-5 elements), `Duration`/`Range`/`RangeInclusive`/`Bound`
- **`features/impl_alloc.rs`**: Tests for `platform_encode_to_vec`, `Vec<T>` (u8 optimization vs generic), `BTreeMap`/`BTreeSet`/`BinaryHeap`/`VecDeque`, `String`, `Box<T>`/`Box<str>`/`Box<[T]>`, `Rc`/`Arc` (including `Arc<str>` and slices), `Cow`, `VecWriter`, and borrow-decode paths for all collection/smart-pointer types
- **`features/impl_std.rs`**: Tests for `HashMap`/`HashSet`, `Mutex`/`RwLock`, `CString`/`CStr`, `SystemTime`, `PathBuf`/`Path`, all IP address types, all socket address types, and borrow-decode paths

Coverage results (unit tests only):
| File | Before | After |
|------|--------|-------|
| lib.rs | 44% | 100% |
| de/mod.rs | 55% | 97% |
| de/impls.rs | 2% | 96% |
| de/impl_tuples.rs | 0% | 100% |
| de/impl_core.rs | 0% | 68% |
| enc/mod.rs | 0% | 86% |
| enc/impls.rs | 4% | 100% |
| features/impl_alloc.rs | 18% | 99% |
| features/impl_std.rs | 0% | 87% |
| **TOTAL** | **9%** | **95%** |

Remaining uncovered code is deprecated/dead-code functions (marked `#[deprecated]`), error-propagation arms of `?` operators, and the `Guard::drop` path in `collect_into_array` which requires iterator exhaustion mid-decode.

## How Has This Been Tested?

- All 160 tests pass via `cargo test -p platform-serialization`
- Coverage verified via `cargo llvm-cov test --package platform-serialization`
- Tests formatted with `cargo fmt --package platform-serialization`

## Breaking Changes

None. This PR only adds test code.

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [x] I have made corresponding changes to the documentation if needed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for serialization and deserialization functionality across primitive types, collections, standard library types, and various encoding/decoding paths.
  * Tests verify round-trip encoding, boundary conditions, error handling, and borrow-based decoding scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->