### PR TITLE
ci: allow thepastaclaw fork PRs to run on macOS runner

### DIFF
--- a/.github/workflows/tests-rs-workspace.yml
+++ b/.github/workflows/tests-rs-workspace.yml
@@ -13,6 +13,7 @@ jobs:
     if: >-
       github.event_name != 'pull_request'
       || github.event.pull_request.head.repo.full_name == github.repository
+      || github.event.pull_request.head.repo.owner.login == 'thepastaclaw'
     timeout-minutes: 30
     steps:
       - name: Check out repo


### PR DESCRIPTION
## Summary
- Allow PRs from thepastaclaw's fork to run on the self-hosted macOS ARM64 runner
- Currently fork PRs skip all Rust tests because the macOS job condition requires `head.repo.full_name == github.repository`

## Context
thepastaclaw has 11 open PRs, none of which can run Rust tests because they're from a fork. The Ubuntu backup runners are also disabled (`UBUNTU_BACKUP_ENABLED != true`), so zero Rust test coverage runs for any fork PR.

## Test plan
- [x] Once merged, thepastaclaw's PRs will trigger macOS Rust tests on re-push

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated test workflow configuration to improve macOS testing scenarios for contributed pull requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->