### PR TITLE
test(drive-abci): improve identity state transition validation coverage

### DIFF
--- a/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/identity_credit_transfer/mod.rs
+++ b/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/identity_credit_transfer/mod.rs
@@ -123,21 +123,100 @@ impl StateTransitionStateValidation for IdentityCreditTransferTransition {
 mod tests {
     use super::*;
     use crate::config::{PlatformConfig, PlatformTestConfig};
-    use crate::execution::validation::state_transition::tests::setup_identity_return_master_key;
     use crate::platform_types::state_transitions_processing_result::StateTransitionExecutionResult;
-    use crate::test::helpers::setup::TestPlatformBuilder;
+    use crate::rpc::core::MockCoreRPCLike;
+    use crate::test::helpers::setup::{TempPlatform, TestPlatformBuilder};
     use assert_matches::assert_matches;
     use dpp::block::block_info::BlockInfo;
     use dpp::consensus::ConsensusError;
     use dpp::dash_to_credits;
+    use dpp::fee::Credits;
     use dpp::identity::accessors::IdentityGettersV0;
     use dpp::identity::identity_public_key::accessors::v0::IdentityPublicKeyGettersV0;
     use dpp::identity::signer::Signer;
+    use dpp::identity::{Identity, IdentityPublicKey, IdentityV0, KeyType, Purpose, SecurityLevel};
+    use dpp::prelude::Identifier;
     use dpp::serialization::{PlatformSerializable, Signable};
     use dpp::state_transition::identity_credit_transfer_transition::v0::IdentityCreditTransferTransitionV0;
     use dpp::state_transition::identity_credit_transfer_transition::IdentityCreditTransferTransition;
     use dpp::state_transition::StateTransition;
     use platform_version::version::PlatformVersion;
+    use rand::rngs::StdRng;
+    use rand::SeedableRng;
+    use simple_signer::signer::SimpleSigner;
+    use std::collections::BTreeMap;
+
+    /// Creates an identity with a master authentication key and a TRANSFER purpose key,
+    /// adds it to the platform, and returns the identity, signer, and transfer key.
+    fn setup_identity_with_transfer_key(
+        platform: &mut TempPlatform<MockCoreRPCLike>,
+        seed: u64,
+        credits: Credits,
+    ) -> (Identity, SimpleSigner, IdentityPublicKey) {
+        let platform_version = PlatformVersion::latest();
+        let mut signer = SimpleSigner::default();
+        let mut rng = StdRng::seed_from_u64(seed);
+
+        let (master_key, master_private_key) =
+            IdentityPublicKey::random_ecdsa_master_authentication_key_with_rng(
+                0,
+                &mut rng,
+                platform_version,
+            )
+            .expect("expected to get key pair");
+
+        signer.add_identity_public_key(master_key.clone(), master_private_key);
+
+        let (critical_public_key, private_key) =
+            IdentityPublicKey::random_ecdsa_critical_level_authentication_key_with_rng(
+                1,
+                &mut rng,
+                platform_version,
+            )
+            .expect("expected to get key pair");
+
+        signer.add_identity_public_key(critical_public_key.clone(), private_key);
+
+        let (transfer_key, transfer_private_key) =
+            IdentityPublicKey::random_key_with_known_attributes(
+                2,
+                &mut rng,
+                Purpose::TRANSFER,
+                SecurityLevel::CRITICAL,
+                KeyType::ECDSA_SECP256K1,
+                None,
+                platform_version,
+            )
+            .expect("expected to get transfer key pair");
+
+        signer.add_identity_public_key(transfer_key.clone(), transfer_private_key);
+
+        let identity: Identity = IdentityV0 {
+            id: Identifier::random_with_rng(&mut rng),
+            public_keys: BTreeMap::from([
+                (0, master_key),
+                (1, critical_public_key),
+                (2, transfer_key.clone()),
+            ]),
+            balance: credits,
+            revision: 0,
+        }
+        .into();
+
+        platform
+            .drive
+            .add_new_identity(
+                identity.clone(),
+                false,
+                &BlockInfo::default(),
+                true,
+                None,
+                platform_version,
+            )
+            .expect("expected to add a new identity");
+
+        (identity, signer, transfer_key)
+    }
 
     fn create_signed_transfer(
         identity_id: dpp::prelude::Identifier,
@@ -180,8 +259,8 @@ mod tests {
             .build_with_mock_rpc()
             .set_genesis_state();
 
-        let (identity, signer, _, key) =
-            setup_identity_return_master_key(&mut platform, 500, dash_to_credits!(1.0));
+        let (identity, signer, transfer_key) =
+            setup_identity_with_transfer_key(&mut platform, 500, dash_to_credits!(1.0));
 
         let platform_state = platform.state.load();
 
@@ -192,7 +271,7 @@ mod tests {
             200_000,
             1,
             &signer,
-            &key,
+            &transfer_key,
         );
 
         let transaction = platform.drive.grove.start_transaction();
@@ -234,22 +313,19 @@ mod tests {
             .build_with_mock_rpc()
             .set_genesis_state();
 
-        let (identity, signer, _, key) =
-            setup_identity_return_master_key(&mut platform, 500, dash_to_credits!(1.0));
-
-        let (recipient, _, _, _) =
-            setup_identity_return_master_key(&mut platform, 501, dash_to_credits!(0.5));
+        let (identity, signer, transfer_key) =
+            setup_identity_with_transfer_key(&mut platform, 500, dash_to_credits!(1.0));
 
         let platform_state = platform.state.load();
 
         // Transfer amount below minimum (100_000)
         let transfer_bytes = create_signed_transfer(
             identity.id(),
-            recipient.id(),
-            99_999, // below MIN_TRANSFER_AMOUNT of 100_000
+            Identifier::random(), // any valid recipient
+            99_999,               // below MIN_TRANSFER_AMOUNT of 100_000
             1,
             &signer,
-            &key,
+            &transfer_key,
         );
 
         let transaction = platform.drive.grove.start_transaction();
@@ -291,37 +367,29 @@ mod tests {
             .build_with_mock_rpc()
             .set_genesis_state();
 
-        // Create an identity that exists (recipient) and one that does not (sender)
-        let (recipient, _, _, _) =
-            setup_identity_return_master_key(&mut platform, 501, dash_to_credits!(0.5));
-
-        // Create an identity but don't add it to the platform
-        let (non_existent, signer, _, key) =
-            setup_identity_return_master_key(&mut platform, 502, dash_to_credits!(1.0));
-
-        // Now remove the sender from the platform by creating a fresh platform state
-        // Actually, we need to use an identity that was added but simulate "not found"
-        // The simpler approach: use process_raw with the sender who doesn't exist in identity tree
-        // We can't easily do this without first removing. Instead, let's test by using
-        // a non-existent identity_id in the transition
+        // Create an identity with a transfer key (will be used to sign, but the
+        // transition will reference a non-existent sender identity_id)
+        let (_existing_identity, signer, transfer_key) =
+            setup_identity_with_transfer_key(&mut platform, 502, dash_to_credits!(1.0));
 
         let platform_state = platform.state.load();
 
-        let fake_sender_id = dpp::prelude::Identifier::random();
+        // Use a fake sender identity_id that doesn't exist in the platform
+        let fake_sender_id = Identifier::random();
         let transfer: IdentityCreditTransferTransition = IdentityCreditTransferTransitionV0 {
             identity_id: fake_sender_id,
-            recipient_id: recipient.id(),
+            recipient_id: Identifier::random(),
             amount: 200_000,
             nonce: 1,
             user_fee_increase: 0,
-            signature_public_key_id: key.id(),
+            signature_public_key_id: transfer_key.id(),
             signature: Default::default(),
         }
         .into();
 
         let mut st: StateTransition = transfer.into();
         let data = st.signable_bytes().expect("signable bytes");
-        st.set_signature(signer.sign(&key, data.as_slice()).expect("sign"));
+        st.set_signature(signer.sign(&transfer_key, data.as_slice()).expect("sign"));
         let transfer_bytes = st.serialize_to_bytes().expect("serialize");
 
         let transaction = platform.drive.grove.start_transaction();
@@ -365,11 +433,11 @@ mod tests {
             .set_genesis_state();
 
         // Create sender with very low balance
-        let (sender, signer, _, key) =
-            setup_identity_return_master_key(&mut platform, 600, dash_to_credits!(0.001));
+        let (sender, signer, transfer_key) =
+            setup_identity_with_transfer_key(&mut platform, 600, dash_to_credits!(0.001));
 
-        let (recipient, _, _, _) =
-            setup_identity_return_master_key(&mut platform, 601, dash_to_credits!(0.5));
+        let (recipient, _, _) =
+            setup_identity_with_transfer_key(&mut platform, 601, dash_to_credits!(0.5));
 
         let platform_state = platform.state.load();
 
@@ -380,7 +448,7 @@ mod tests {
             dash_to_credits!(1.0), // more than the 0.001 balance
             1,
             &signer,
-            &key,
+            &transfer_key,
         );
 
         let transaction = platform.drive.grove.start_transaction();
@@ -398,10 +466,13 @@ mod tests {
             )
             .expect("expected to process state transition");
 
-        // Should get a paid consensus error (identity exists but insufficient balance)
+        // Insufficient balance is caught by the balance pre-check which returns
+        // an unpaid consensus error since the identity can't afford processing fees
         assert_matches!(
             processing_result.execution_results().as_slice(),
-            [StateTransitionExecutionResult::PaidConsensusError { .. }]
+            [StateTransitionExecutionResult::UnpaidConsensusError(
+                ConsensusError::StateError(_)
+            )]
         );
     }
 
@@ -421,15 +492,21 @@ mod tests {
             .build_with_mock_rpc()
             .set_genesis_state();
 
-        let (sender, signer, _, key) =
-            setup_identity_return_master_key(&mut platform, 700, dash_to_credits!(1.0));
+        let (sender, signer, transfer_key) =
+            setup_identity_with_transfer_key(&mut platform, 700, dash_to_credits!(1.0));
 
         let platform_state = platform.state.load();
 
         // Transfer to a non-existent recipient
-        let fake_recipient_id = dpp::prelude::Identifier::random();
-        let transfer_bytes =
-            create_signed_transfer(sender.id(), fake_recipient_id, 200_000, 1, &signer, &key);
+        let fake_recipient_id = Identifier::random();
+        let transfer_bytes = create_signed_transfer(
+            sender.id(),
+            fake_recipient_id,
+            200_000,
+            1,
+            &signer,
+            &transfer_key,
+        );
 
         let transaction = platform.drive.grove.start_transaction();
 
@@ -446,10 +523,14 @@ mod tests {
             )
             .expect("expected to process state transition");
 
-        // Recipient not found should result in a paid consensus error
+        // Recipient not found returns IdentityNotFoundError (a SignatureError variant)
+        // as an unpaid consensus error since the state validation doesn't produce
+        // an execution event on failure
         assert_matches!(
             processing_result.execution_results().as_slice(),
-            [StateTransitionExecutionResult::PaidConsensusError { .. }]
+            [StateTransitionExecutionResult::UnpaidConsensusError(
+                ConsensusError::SignatureError(_)
+            )]
         );
     }
 
@@ -469,11 +550,11 @@ mod tests {
             .build_with_mock_rpc()
             .set_genesis_state();
 
-        let (sender, signer, _, key) =
-            setup_identity_return_master_key(&mut platform, 800, dash_to_credits!(1.0));
+        let (sender, signer, transfer_key) =
+            setup_identity_with_transfer_key(&mut platform, 800, dash_to_credits!(1.0));
 
-        let (recipient, _, _, _) =
-            setup_identity_return_master_key(&mut platform, 801, dash_to_credits!(0.5));
+        let (recipient, _, _) =
+            setup_identity_with_transfer_key(&mut platform, 801, dash_to_credits!(0.5));
 
         let platform_state = platform.state.load();
 
@@ -484,7 +565,7 @@ mod tests {
             transfer_amount,
             1,
             &signer,
-            &key,
+            &transfer_key,
         );
 
         let transaction = platform.drive.grove.start_transaction();

--- a/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/identity_credit_transfer/mod.rs
+++ b/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/identity_credit_transfer/mod.rs
@@ -401,7 +401,7 @@ mod tests {
         // Should get a paid consensus error (identity exists but insufficient balance)
         assert_matches!(
             processing_result.execution_results().as_slice(),
-            [StateTransitionExecutionResult::PaidConsensusError(..)]
+            [StateTransitionExecutionResult::PaidConsensusError { .. }]
         );
     }
 
@@ -449,7 +449,7 @@ mod tests {
         // Recipient not found should result in a paid consensus error
         assert_matches!(
             processing_result.execution_results().as_slice(),
-            [StateTransitionExecutionResult::PaidConsensusError(..)]
+            [StateTransitionExecutionResult::PaidConsensusError { .. }]
         );
     }
 

--- a/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/identity_credit_transfer/mod.rs
+++ b/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/identity_credit_transfer/mod.rs
@@ -118,3 +118,406 @@ impl StateTransitionStateValidation for IdentityCreditTransferTransition {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::{PlatformConfig, PlatformTestConfig};
+    use crate::execution::validation::state_transition::tests::setup_identity_return_master_key;
+    use crate::platform_types::state_transitions_processing_result::StateTransitionExecutionResult;
+    use crate::test::helpers::setup::TestPlatformBuilder;
+    use assert_matches::assert_matches;
+    use dpp::block::block_info::BlockInfo;
+    use dpp::consensus::ConsensusError;
+    use dpp::dash_to_credits;
+    use dpp::identity::accessors::IdentityGettersV0;
+    use dpp::identity::identity_public_key::accessors::v0::IdentityPublicKeyGettersV0;
+    use dpp::identity::signer::Signer;
+    use dpp::serialization::{PlatformSerializable, Signable};
+    use dpp::state_transition::identity_credit_transfer_transition::v0::IdentityCreditTransferTransitionV0;
+    use dpp::state_transition::identity_credit_transfer_transition::IdentityCreditTransferTransition;
+    use dpp::state_transition::StateTransition;
+    use platform_version::version::PlatformVersion;
+
+    fn create_signed_transfer(
+        identity_id: dpp::prelude::Identifier,
+        recipient_id: dpp::prelude::Identifier,
+        amount: u64,
+        nonce: u64,
+        signer: &simple_signer::signer::SimpleSigner,
+        key: &dpp::identity::IdentityPublicKey,
+    ) -> Vec<u8> {
+        let transfer: IdentityCreditTransferTransition = IdentityCreditTransferTransitionV0 {
+            identity_id,
+            recipient_id,
+            amount,
+            nonce,
+            user_fee_increase: 0,
+            signature_public_key_id: key.id(),
+            signature: Default::default(),
+        }
+        .into();
+
+        let mut st: StateTransition = transfer.into();
+        let data = st.signable_bytes().expect("expected signable bytes");
+        st.set_signature(signer.sign(key, data.as_slice()).expect("expected to sign"));
+        st.serialize_to_bytes().expect("expected to serialize")
+    }
+
+    #[test]
+    fn test_identity_credit_transfer_to_self_rejected() {
+        let platform_version = PlatformVersion::latest();
+        let platform_config = PlatformConfig {
+            testing_configs: PlatformTestConfig {
+                disable_instant_lock_signature_verification: true,
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+
+        let mut platform = TestPlatformBuilder::new()
+            .with_config(platform_config)
+            .build_with_mock_rpc()
+            .set_genesis_state();
+
+        let (identity, signer, _, key) =
+            setup_identity_return_master_key(&mut platform, 500, dash_to_credits!(1.0));
+
+        let platform_state = platform.state.load();
+
+        // Try to transfer to self -- same identity_id and recipient_id
+        let transfer_bytes = create_signed_transfer(
+            identity.id(),
+            identity.id(), // self-transfer
+            200_000,
+            1,
+            &signer,
+            &key,
+        );
+
+        let transaction = platform.drive.grove.start_transaction();
+
+        let processing_result = platform
+            .platform
+            .process_raw_state_transitions(
+                &vec![transfer_bytes],
+                &platform_state,
+                &BlockInfo::default(),
+                &transaction,
+                platform_version,
+                true,
+                None,
+            )
+            .expect("expected to process state transition");
+
+        assert_matches!(
+            processing_result.execution_results().as_slice(),
+            [StateTransitionExecutionResult::UnpaidConsensusError(
+                ConsensusError::BasicError(_)
+            )]
+        );
+    }
+
+    #[test]
+    fn test_identity_credit_transfer_below_minimum_amount_rejected() {
+        let platform_version = PlatformVersion::latest();
+        let platform_config = PlatformConfig {
+            testing_configs: PlatformTestConfig {
+                disable_instant_lock_signature_verification: true,
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+
+        let mut platform = TestPlatformBuilder::new()
+            .with_config(platform_config)
+            .build_with_mock_rpc()
+            .set_genesis_state();
+
+        let (identity, signer, _, key) =
+            setup_identity_return_master_key(&mut platform, 500, dash_to_credits!(1.0));
+
+        let (recipient, _, _, _) =
+            setup_identity_return_master_key(&mut platform, 501, dash_to_credits!(0.5));
+
+        let platform_state = platform.state.load();
+
+        // Transfer amount below minimum (100_000)
+        let transfer_bytes = create_signed_transfer(
+            identity.id(),
+            recipient.id(),
+            99_999, // below MIN_TRANSFER_AMOUNT of 100_000
+            1,
+            &signer,
+            &key,
+        );
+
+        let transaction = platform.drive.grove.start_transaction();
+
+        let processing_result = platform
+            .platform
+            .process_raw_state_transitions(
+                &vec![transfer_bytes],
+                &platform_state,
+                &BlockInfo::default(),
+                &transaction,
+                platform_version,
+                true,
+                None,
+            )
+            .expect("expected to process state transition");
+
+        assert_matches!(
+            processing_result.execution_results().as_slice(),
+            [StateTransitionExecutionResult::UnpaidConsensusError(
+                ConsensusError::BasicError(_)
+            )]
+        );
+    }
+
+    #[test]
+    fn test_identity_credit_transfer_sender_not_found() {
+        let platform_version = PlatformVersion::latest();
+        let platform_config = PlatformConfig {
+            testing_configs: PlatformTestConfig {
+                disable_instant_lock_signature_verification: true,
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+
+        let mut platform = TestPlatformBuilder::new()
+            .with_config(platform_config)
+            .build_with_mock_rpc()
+            .set_genesis_state();
+
+        // Create an identity that exists (recipient) and one that does not (sender)
+        let (recipient, _, _, _) =
+            setup_identity_return_master_key(&mut platform, 501, dash_to_credits!(0.5));
+
+        // Create an identity but don't add it to the platform
+        let (non_existent, signer, _, key) =
+            setup_identity_return_master_key(&mut platform, 502, dash_to_credits!(1.0));
+
+        // Now remove the sender from the platform by creating a fresh platform state
+        // Actually, we need to use an identity that was added but simulate "not found"
+        // The simpler approach: use process_raw with the sender who doesn't exist in identity tree
+        // We can't easily do this without first removing. Instead, let's test by using
+        // a non-existent identity_id in the transition
+
+        let platform_state = platform.state.load();
+
+        let fake_sender_id = dpp::prelude::Identifier::random();
+        let transfer: IdentityCreditTransferTransition = IdentityCreditTransferTransitionV0 {
+            identity_id: fake_sender_id,
+            recipient_id: recipient.id(),
+            amount: 200_000,
+            nonce: 1,
+            user_fee_increase: 0,
+            signature_public_key_id: key.id(),
+            signature: Default::default(),
+        }
+        .into();
+
+        let mut st: StateTransition = transfer.into();
+        let data = st.signable_bytes().expect("signable bytes");
+        st.set_signature(signer.sign(&key, data.as_slice()).expect("sign"));
+        let transfer_bytes = st.serialize_to_bytes().expect("serialize");
+
+        let transaction = platform.drive.grove.start_transaction();
+
+        let processing_result = platform
+            .platform
+            .process_raw_state_transitions(
+                &vec![transfer_bytes],
+                &platform_state,
+                &BlockInfo::default(),
+                &transaction,
+                platform_version,
+                true,
+                None,
+            )
+            .expect("expected to process state transition");
+
+        // Sender identity not found should result in a consensus error
+        assert_matches!(
+            processing_result.execution_results().as_slice(),
+            [StateTransitionExecutionResult::UnpaidConsensusError(
+                ConsensusError::SignatureError(_)
+            )]
+        );
+    }
+
+    #[test]
+    fn test_identity_credit_transfer_insufficient_balance() {
+        let platform_version = PlatformVersion::latest();
+        let platform_config = PlatformConfig {
+            testing_configs: PlatformTestConfig {
+                disable_instant_lock_signature_verification: true,
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+
+        let mut platform = TestPlatformBuilder::new()
+            .with_config(platform_config)
+            .build_with_mock_rpc()
+            .set_genesis_state();
+
+        // Create sender with very low balance
+        let (sender, signer, _, key) =
+            setup_identity_return_master_key(&mut platform, 600, dash_to_credits!(0.001));
+
+        let (recipient, _, _, _) =
+            setup_identity_return_master_key(&mut platform, 601, dash_to_credits!(0.5));
+
+        let platform_state = platform.state.load();
+
+        // Try to transfer more than the sender's balance
+        let transfer_bytes = create_signed_transfer(
+            sender.id(),
+            recipient.id(),
+            dash_to_credits!(1.0), // more than the 0.001 balance
+            1,
+            &signer,
+            &key,
+        );
+
+        let transaction = platform.drive.grove.start_transaction();
+
+        let processing_result = platform
+            .platform
+            .process_raw_state_transitions(
+                &vec![transfer_bytes],
+                &platform_state,
+                &BlockInfo::default(),
+                &transaction,
+                platform_version,
+                true,
+                None,
+            )
+            .expect("expected to process state transition");
+
+        // Should get a paid consensus error (identity exists but insufficient balance)
+        assert_matches!(
+            processing_result.execution_results().as_slice(),
+            [StateTransitionExecutionResult::PaidConsensusError(..)]
+        );
+    }
+
+    #[test]
+    fn test_identity_credit_transfer_recipient_not_found() {
+        let platform_version = PlatformVersion::latest();
+        let platform_config = PlatformConfig {
+            testing_configs: PlatformTestConfig {
+                disable_instant_lock_signature_verification: true,
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+
+        let mut platform = TestPlatformBuilder::new()
+            .with_config(platform_config)
+            .build_with_mock_rpc()
+            .set_genesis_state();
+
+        let (sender, signer, _, key) =
+            setup_identity_return_master_key(&mut platform, 700, dash_to_credits!(1.0));
+
+        let platform_state = platform.state.load();
+
+        // Transfer to a non-existent recipient
+        let fake_recipient_id = dpp::prelude::Identifier::random();
+        let transfer_bytes =
+            create_signed_transfer(sender.id(), fake_recipient_id, 200_000, 1, &signer, &key);
+
+        let transaction = platform.drive.grove.start_transaction();
+
+        let processing_result = platform
+            .platform
+            .process_raw_state_transitions(
+                &vec![transfer_bytes],
+                &platform_state,
+                &BlockInfo::default(),
+                &transaction,
+                platform_version,
+                true,
+                None,
+            )
+            .expect("expected to process state transition");
+
+        // Recipient not found should result in a paid consensus error
+        assert_matches!(
+            processing_result.execution_results().as_slice(),
+            [StateTransitionExecutionResult::PaidConsensusError(..)]
+        );
+    }
+
+    #[test]
+    fn test_identity_credit_transfer_successful() {
+        let platform_version = PlatformVersion::latest();
+        let platform_config = PlatformConfig {
+            testing_configs: PlatformTestConfig {
+                disable_instant_lock_signature_verification: true,
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+
+        let mut platform = TestPlatformBuilder::new()
+            .with_config(platform_config)
+            .build_with_mock_rpc()
+            .set_genesis_state();
+
+        let (sender, signer, _, key) =
+            setup_identity_return_master_key(&mut platform, 800, dash_to_credits!(1.0));
+
+        let (recipient, _, _, _) =
+            setup_identity_return_master_key(&mut platform, 801, dash_to_credits!(0.5));
+
+        let platform_state = platform.state.load();
+
+        let transfer_amount = 500_000u64;
+        let transfer_bytes = create_signed_transfer(
+            sender.id(),
+            recipient.id(),
+            transfer_amount,
+            1,
+            &signer,
+            &key,
+        );
+
+        let transaction = platform.drive.grove.start_transaction();
+
+        let processing_result = platform
+            .platform
+            .process_raw_state_transitions(
+                &vec![transfer_bytes],
+                &platform_state,
+                &BlockInfo::default(),
+                &transaction,
+                platform_version,
+                true,
+                None,
+            )
+            .expect("expected to process state transition");
+
+        assert_eq!(processing_result.valid_count(), 1);
+
+        platform
+            .drive
+            .grove
+            .commit_transaction(transaction)
+            .unwrap()
+            .expect("expected to commit");
+
+        // Verify recipient balance increased
+        let recipient_balance = platform
+            .drive
+            .fetch_identity_balance(recipient.id().into_buffer(), None, platform_version)
+            .expect("expected to get balance")
+            .expect("expected balance to exist");
+
+        assert!(recipient_balance > dash_to_credits!(0.5));
+    }
+}

--- a/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/identity_top_up/mod.rs
+++ b/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/identity_top_up/mod.rs
@@ -384,4 +384,103 @@ mod tests {
 
         assert_eq!(identity_balance, 149993606160); // about 0.5 Dash starting balance + 1 Dash asset lock top up
     }
+
+    #[test]
+    fn test_identity_top_up_for_nonexistent_identity() {
+        let platform_version = PlatformVersion::latest();
+        let platform_config = PlatformConfig {
+            testing_configs: PlatformTestConfig {
+                disable_instant_lock_signature_verification: true,
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+
+        let platform = TestPlatformBuilder::new()
+            .with_config(platform_config)
+            .build_with_mock_rpc()
+            .set_initial_state_structure();
+
+        let platform_state = platform.state.load();
+
+        let mut signer = SimpleSigner::default();
+
+        let mut rng = StdRng::seed_from_u64(567);
+
+        let (master_key, master_private_key) =
+            IdentityPublicKey::random_ecdsa_master_authentication_key(
+                0,
+                Some(58),
+                platform_version,
+            )
+            .expect("expected to get key pair");
+
+        signer.add_identity_public_key(master_key.clone(), master_private_key);
+
+        let (critical_public_key, private_key) =
+            IdentityPublicKey::random_ecdsa_critical_level_authentication_key(
+                1,
+                Some(999),
+                platform_version,
+            )
+            .expect("expected to get key pair");
+
+        // Create identity but do NOT add it to the platform
+        let identity_not_in_system: Identity = IdentityV0 {
+            id: Identifier::random_with_rng(&mut rng),
+            public_keys: BTreeMap::from([
+                (0, master_key.clone()),
+                (1, critical_public_key.clone()),
+            ]),
+            balance: 50000000000,
+            revision: 0,
+        }
+        .into();
+
+        signer.add_identity_public_key(critical_public_key.clone(), private_key);
+
+        let (_, pk) = ECDSA_SECP256K1
+            .random_public_and_private_key_data(&mut rng, platform_version)
+            .unwrap();
+
+        let asset_lock_proof = instant_asset_lock_proof_fixture(
+            Some(PrivateKey::from_byte_array(&pk, Network::Testnet).unwrap()),
+            None,
+        );
+
+        let identity_top_up_transition: StateTransition =
+            IdentityTopUpTransition::try_from_identity(
+                &identity_not_in_system,
+                asset_lock_proof,
+                pk.as_slice(),
+                0,
+                platform_version,
+                None,
+            )
+            .expect("expected an identity top up transition");
+
+        let identity_top_up_serialized_transition = identity_top_up_transition
+            .serialize_to_bytes()
+            .expect("serialized state transition");
+
+        let transaction = platform.drive.grove.start_transaction();
+
+        let processing_result = platform
+            .platform
+            .process_raw_state_transitions(
+                &vec![identity_top_up_serialized_transition],
+                &platform_state,
+                &BlockInfo::default(),
+                &transaction,
+                platform_version,
+                false,
+                None,
+            )
+            .expect("expected to process state transition");
+
+        // Identity not found should result in an error (unpaid since identity can't be charged)
+        assert_eq!(processing_result.valid_count(), 0);
+        assert_eq!(processing_result.invalid_paid_count(), 0);
+        assert_eq!(processing_result.invalid_unpaid_count(), 1);
+    }
 }

--- a/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/identity_update/mod.rs
+++ b/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/identity_update/mod.rs
@@ -1264,4 +1264,564 @@ mod tests {
             })
         );
     }
+
+    #[test]
+    fn test_identity_update_empty_transition_rejected() {
+        let platform_version = PlatformVersion::latest();
+        let platform_config = PlatformConfig {
+            testing_configs: PlatformTestConfig {
+                disable_instant_lock_signature_verification: true,
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+
+        let mut platform = TestPlatformBuilder::new()
+            .with_config(platform_config)
+            .build_with_mock_rpc()
+            .set_genesis_state();
+
+        let (identity, signer, _, key) =
+            setup_identity_return_master_key(&mut platform, 958, dash_to_credits!(0.1));
+
+        let platform_state = platform.state.load();
+
+        // Create transition with neither keys to add nor keys to disable
+        let update_transition: IdentityUpdateTransition = IdentityUpdateTransitionV0 {
+            identity_id: identity.id(),
+            revision: 1,
+            nonce: 1,
+            add_public_keys: vec![],
+            disable_public_keys: vec![],
+            user_fee_increase: 0,
+            signature_public_key_id: key.id(),
+            signature: Default::default(),
+        }
+        .into();
+
+        let mut update_transition: StateTransition = update_transition.into();
+        let data = update_transition
+            .signable_bytes()
+            .expect("expected signable bytes");
+        update_transition.set_signature(
+            signer
+                .sign(&key, data.as_slice())
+                .expect("expected to sign"),
+        );
+
+        let transition_bytes = update_transition
+            .serialize_to_bytes()
+            .expect("expected to serialize");
+
+        let transaction = platform.drive.grove.start_transaction();
+
+        let processing_result = platform
+            .platform
+            .process_raw_state_transitions(
+                &vec![transition_bytes],
+                &platform_state,
+                &BlockInfo::default(),
+                &transaction,
+                platform_version,
+                true,
+                None,
+            )
+            .expect("expected to process state transition");
+
+        // Empty update should be rejected with BasicError
+        assert_matches!(
+            processing_result.execution_results().as_slice(),
+            [StateTransitionExecutionResult::UnpaidConsensusError(
+                ConsensusError::BasicError(_)
+            )]
+        );
+    }
+
+    #[test]
+    fn test_identity_update_too_many_keys_to_disable() {
+        let platform_version = PlatformVersion::latest();
+        let platform_config = PlatformConfig {
+            testing_configs: PlatformTestConfig {
+                disable_instant_lock_signature_verification: true,
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+
+        let mut platform = TestPlatformBuilder::new()
+            .with_config(platform_config)
+            .build_with_mock_rpc()
+            .set_genesis_state();
+
+        let (identity, signer, _, key) =
+            setup_identity_return_master_key(&mut platform, 958, dash_to_credits!(0.1));
+
+        let platform_state = platform.state.load();
+
+        // Try to disable more than MAX_KEYS_TO_DISABLE (10) keys
+        let disable_keys: Vec<u32> = (1..=11).collect();
+
+        let update_transition: IdentityUpdateTransition = IdentityUpdateTransitionV0 {
+            identity_id: identity.id(),
+            revision: 1,
+            nonce: 1,
+            add_public_keys: vec![],
+            disable_public_keys: disable_keys,
+            user_fee_increase: 0,
+            signature_public_key_id: key.id(),
+            signature: Default::default(),
+        }
+        .into();
+
+        let mut update_transition: StateTransition = update_transition.into();
+        let data = update_transition
+            .signable_bytes()
+            .expect("expected signable bytes");
+        update_transition.set_signature(
+            signer
+                .sign(&key, data.as_slice())
+                .expect("expected to sign"),
+        );
+
+        let transition_bytes = update_transition
+            .serialize_to_bytes()
+            .expect("expected to serialize");
+
+        let transaction = platform.drive.grove.start_transaction();
+
+        let processing_result = platform
+            .platform
+            .process_raw_state_transitions(
+                &vec![transition_bytes],
+                &platform_state,
+                &BlockInfo::default(),
+                &transaction,
+                platform_version,
+                true,
+                None,
+            )
+            .expect("expected to process state transition");
+
+        // Should be rejected for exceeding max keys to disable
+        assert_matches!(
+            processing_result.execution_results().as_slice(),
+            [StateTransitionExecutionResult::UnpaidConsensusError(
+                ConsensusError::StateError(_)
+            )]
+        );
+    }
+
+    #[test]
+    fn test_identity_update_duplicate_key_ids_to_disable() {
+        let platform_version = PlatformVersion::latest();
+        let platform_config = PlatformConfig {
+            testing_configs: PlatformTestConfig {
+                disable_instant_lock_signature_verification: true,
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+
+        let mut platform = TestPlatformBuilder::new()
+            .with_config(platform_config)
+            .build_with_mock_rpc()
+            .set_genesis_state();
+
+        let (identity, signer, _, key) =
+            setup_identity_return_master_key(&mut platform, 958, dash_to_credits!(0.1));
+
+        let platform_state = platform.state.load();
+
+        // Duplicate key ID 1 in the disable list
+        let update_transition: IdentityUpdateTransition = IdentityUpdateTransitionV0 {
+            identity_id: identity.id(),
+            revision: 1,
+            nonce: 1,
+            add_public_keys: vec![],
+            disable_public_keys: vec![1, 1],
+            user_fee_increase: 0,
+            signature_public_key_id: key.id(),
+            signature: Default::default(),
+        }
+        .into();
+
+        let mut update_transition: StateTransition = update_transition.into();
+        let data = update_transition
+            .signable_bytes()
+            .expect("expected signable bytes");
+        update_transition.set_signature(
+            signer
+                .sign(&key, data.as_slice())
+                .expect("expected to sign"),
+        );
+
+        let transition_bytes = update_transition
+            .serialize_to_bytes()
+            .expect("expected to serialize");
+
+        let transaction = platform.drive.grove.start_transaction();
+
+        let processing_result = platform
+            .platform
+            .process_raw_state_transitions(
+                &vec![transition_bytes],
+                &platform_state,
+                &BlockInfo::default(),
+                &transaction,
+                platform_version,
+                true,
+                None,
+            )
+            .expect("expected to process state transition");
+
+        // Duplicate key IDs should be rejected
+        assert_matches!(
+            processing_result.execution_results().as_slice(),
+            [StateTransitionExecutionResult::UnpaidConsensusError(
+                ConsensusError::BasicError(_)
+            )]
+        );
+    }
+
+    #[test]
+    fn test_identity_update_disabling_key_id_also_being_added() {
+        let platform_version = PlatformVersion::latest();
+        let platform_config = PlatformConfig {
+            testing_configs: PlatformTestConfig {
+                disable_instant_lock_signature_verification: true,
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+
+        let mut platform = TestPlatformBuilder::new()
+            .with_config(platform_config)
+            .build_with_mock_rpc()
+            .set_genesis_state();
+
+        let (identity, signer, _, key) =
+            setup_identity_return_master_key(&mut platform, 958, dash_to_credits!(0.1));
+
+        let platform_state = platform.state.load();
+
+        let secp = Secp256k1::new();
+        let mut rng = StdRng::seed_from_u64(292);
+        let new_key_pair = Keypair::new(&secp, &mut rng);
+
+        // Add a key with id 2 and also disable key id 2 in the same transition
+        let new_key = IdentityPublicKeyInCreationV0 {
+            id: 2,
+            purpose: Purpose::AUTHENTICATION,
+            security_level: SecurityLevel::HIGH,
+            key_type: ECDSA_SECP256K1,
+            read_only: false,
+            data: new_key_pair.public_key().serialize().to_vec().into(),
+            signature: Default::default(),
+            contract_bounds: None,
+        };
+
+        let update_transition: IdentityUpdateTransition = IdentityUpdateTransitionV0 {
+            identity_id: identity.id(),
+            revision: 1,
+            nonce: 1,
+            add_public_keys: vec![IdentityPublicKeyInCreation::V0(new_key)],
+            disable_public_keys: vec![2], // same id as the key being added
+            user_fee_increase: 0,
+            signature_public_key_id: key.id(),
+            signature: Default::default(),
+        }
+        .into();
+
+        let mut update_transition: StateTransition = update_transition.into();
+        let data = update_transition
+            .signable_bytes()
+            .expect("expected signable bytes");
+        update_transition.set_signature(
+            signer
+                .sign(&key, data.as_slice())
+                .expect("expected to sign"),
+        );
+
+        let transition_bytes = update_transition
+            .serialize_to_bytes()
+            .expect("expected to serialize");
+
+        let transaction = platform.drive.grove.start_transaction();
+
+        let processing_result = platform
+            .platform
+            .process_raw_state_transitions(
+                &vec![transition_bytes],
+                &platform_state,
+                &BlockInfo::default(),
+                &transaction,
+                platform_version,
+                true,
+                None,
+            )
+            .expect("expected to process state transition");
+
+        // Should reject because disabling a key id that's also being added
+        assert_matches!(
+            processing_result.execution_results().as_slice(),
+            [StateTransitionExecutionResult::UnpaidConsensusError(
+                ConsensusError::BasicError(_)
+            )]
+        );
+    }
+
+    #[test]
+    fn test_identity_update_wrong_revision() {
+        let platform_version = PlatformVersion::latest();
+        let platform_config = PlatformConfig {
+            testing_configs: PlatformTestConfig {
+                disable_instant_lock_signature_verification: true,
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+
+        let mut platform = TestPlatformBuilder::new()
+            .with_config(platform_config)
+            .build_with_mock_rpc()
+            .set_genesis_state();
+
+        let (identity, signer, _, key) =
+            setup_identity_return_master_key(&mut platform, 958, dash_to_credits!(0.1));
+
+        let platform_state = platform.state.load();
+
+        // Use wrong revision (5 instead of 1)
+        let update_transition: IdentityUpdateTransition = IdentityUpdateTransitionV0 {
+            identity_id: identity.id(),
+            revision: 5, // wrong -- should be 1 (current is 0)
+            nonce: 1,
+            add_public_keys: vec![],
+            disable_public_keys: vec![1],
+            user_fee_increase: 0,
+            signature_public_key_id: key.id(),
+            signature: Default::default(),
+        }
+        .into();
+
+        let mut update_transition: StateTransition = update_transition.into();
+        let data = update_transition
+            .signable_bytes()
+            .expect("expected signable bytes");
+        update_transition.set_signature(
+            signer
+                .sign(&key, data.as_slice())
+                .expect("expected to sign"),
+        );
+
+        let transition_bytes = update_transition
+            .serialize_to_bytes()
+            .expect("expected to serialize");
+
+        let transaction = platform.drive.grove.start_transaction();
+
+        let processing_result = platform
+            .platform
+            .process_raw_state_transitions(
+                &vec![transition_bytes],
+                &platform_state,
+                &BlockInfo::default(),
+                &transaction,
+                platform_version,
+                true,
+                None,
+            )
+            .expect("expected to process state transition");
+
+        // Wrong revision should be a paid consensus error (state error)
+        assert_matches!(
+            processing_result.execution_results().as_slice(),
+            [StateTransitionExecutionResult::PaidConsensusError(..)]
+        );
+    }
+
+    #[test]
+    fn test_identity_update_disabling_nonexistent_key() {
+        let platform_version = PlatformVersion::latest();
+        let platform_config = PlatformConfig {
+            testing_configs: PlatformTestConfig {
+                disable_instant_lock_signature_verification: true,
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+
+        let mut platform = TestPlatformBuilder::new()
+            .with_config(platform_config)
+            .build_with_mock_rpc()
+            .set_genesis_state();
+
+        let (identity, signer, _, key) =
+            setup_identity_return_master_key(&mut platform, 958, dash_to_credits!(0.1));
+
+        let platform_state = platform.state.load();
+
+        // Try to disable key id 99 which doesn't exist
+        let update_transition: IdentityUpdateTransition = IdentityUpdateTransitionV0 {
+            identity_id: identity.id(),
+            revision: 1,
+            nonce: 1,
+            add_public_keys: vec![],
+            disable_public_keys: vec![99],
+            user_fee_increase: 0,
+            signature_public_key_id: key.id(),
+            signature: Default::default(),
+        }
+        .into();
+
+        let mut update_transition: StateTransition = update_transition.into();
+        let data = update_transition
+            .signable_bytes()
+            .expect("expected signable bytes");
+        update_transition.set_signature(
+            signer
+                .sign(&key, data.as_slice())
+                .expect("expected to sign"),
+        );
+
+        let transition_bytes = update_transition
+            .serialize_to_bytes()
+            .expect("expected to serialize");
+
+        let transaction = platform.drive.grove.start_transaction();
+
+        let processing_result = platform
+            .platform
+            .process_raw_state_transitions(
+                &vec![transition_bytes],
+                &platform_state,
+                &BlockInfo::default(),
+                &transaction,
+                platform_version,
+                true,
+                None,
+            )
+            .expect("expected to process state transition");
+
+        // Disabling nonexistent key should result in a paid consensus error
+        assert_matches!(
+            processing_result.execution_results().as_slice(),
+            [StateTransitionExecutionResult::PaidConsensusError(..)]
+        );
+    }
+
+    #[test]
+    fn test_identity_update_adding_key_with_existing_id() {
+        let platform_version = PlatformVersion::latest();
+        let platform_config = PlatformConfig {
+            testing_configs: PlatformTestConfig {
+                disable_instant_lock_signature_verification: true,
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+
+        let mut platform = TestPlatformBuilder::new()
+            .with_config(platform_config)
+            .build_with_mock_rpc()
+            .set_genesis_state();
+
+        let (identity, signer, _, key) =
+            setup_identity_return_master_key(&mut platform, 958, dash_to_credits!(0.1));
+
+        let platform_state = platform.state.load();
+
+        let secp = Secp256k1::new();
+        let mut rng = StdRng::seed_from_u64(292);
+        let new_key_pair = Keypair::new(&secp, &mut rng);
+
+        let signable_transition: IdentityUpdateTransition = IdentityUpdateTransitionV0 {
+            identity_id: identity.id(),
+            revision: 1,
+            nonce: 1,
+            add_public_keys: vec![IdentityPublicKeyInCreation::V0(
+                IdentityPublicKeyInCreationV0 {
+                    id: 1, // key id 1 already exists on the identity
+                    purpose: Purpose::AUTHENTICATION,
+                    security_level: SecurityLevel::HIGH,
+                    key_type: ECDSA_SECP256K1,
+                    read_only: false,
+                    data: new_key_pair.public_key().serialize().to_vec().into(),
+                    signature: Default::default(),
+                    contract_bounds: None,
+                },
+            )],
+            disable_public_keys: vec![],
+            user_fee_increase: 0,
+            signature_public_key_id: key.id(),
+            signature: Default::default(),
+        }
+        .into();
+
+        let signable_st: StateTransition = signable_transition.into();
+        let signable_bytes = signable_st
+            .signable_bytes()
+            .expect("expected signable bytes");
+
+        // Sign the new key
+        let secret = new_key_pair.secret_key();
+        let key_sig =
+            signer::sign(&signable_bytes, &secret.secret_bytes()).expect("expected to sign");
+
+        let mut new_key = IdentityPublicKeyInCreationV0 {
+            id: 1, // existing key ID
+            purpose: Purpose::AUTHENTICATION,
+            security_level: SecurityLevel::HIGH,
+            key_type: ECDSA_SECP256K1,
+            read_only: false,
+            data: new_key_pair.public_key().serialize().to_vec().into(),
+            signature: Default::default(),
+            contract_bounds: None,
+        };
+        new_key.signature = key_sig.to_vec().into();
+
+        let update_transition: IdentityUpdateTransition = IdentityUpdateTransitionV0 {
+            identity_id: identity.id(),
+            revision: 1,
+            nonce: 1,
+            add_public_keys: vec![IdentityPublicKeyInCreation::V0(new_key)],
+            disable_public_keys: vec![],
+            user_fee_increase: 0,
+            signature_public_key_id: key.id(),
+            signature: Default::default(),
+        }
+        .into();
+
+        let mut update_transition: StateTransition = update_transition.into();
+        update_transition.set_signature(
+            signer
+                .sign(&key, signable_bytes.as_slice())
+                .expect("expected to sign"),
+        );
+
+        let transition_bytes = update_transition
+            .serialize_to_bytes()
+            .expect("expected to serialize");
+
+        let transaction = platform.drive.grove.start_transaction();
+
+        let processing_result = platform
+            .platform
+            .process_raw_state_transitions(
+                &vec![transition_bytes],
+                &platform_state,
+                &BlockInfo::default(),
+                &transaction,
+                platform_version,
+                true,
+                None,
+            )
+            .expect("expected to process state transition");
+
+        // Adding key with an existing ID should result in a paid consensus error
+        assert_matches!(
+            processing_result.execution_results().as_slice(),
+            [StateTransitionExecutionResult::PaidConsensusError(..)]
+        );
+    }
 }

--- a/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/identity_update/mod.rs
+++ b/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/identity_update/mod.rs
@@ -1636,7 +1636,7 @@ mod tests {
         // Wrong revision should be a paid consensus error (state error)
         assert_matches!(
             processing_result.execution_results().as_slice(),
-            [StateTransitionExecutionResult::PaidConsensusError(..)]
+            [StateTransitionExecutionResult::PaidConsensusError { .. }]
         );
     }
 
@@ -1706,7 +1706,7 @@ mod tests {
         // Disabling nonexistent key should result in a paid consensus error
         assert_matches!(
             processing_result.execution_results().as_slice(),
-            [StateTransitionExecutionResult::PaidConsensusError(..)]
+            [StateTransitionExecutionResult::PaidConsensusError { .. }]
         );
     }
 
@@ -1821,7 +1821,7 @@ mod tests {
         // Adding key with an existing ID should result in a paid consensus error
         assert_matches!(
             processing_result.execution_results().as_slice(),
-            [StateTransitionExecutionResult::PaidConsensusError(..)]
+            [StateTransitionExecutionResult::PaidConsensusError { .. }]
         );
     }
 }


### PR DESCRIPTION
## Summary
Add 14 tests covering uncovered error branches in identity state transition validation:
- **identity_credit_transfer**: self-transfer rejection, min amount check, sender/recipient not found, insufficient balance, happy path
- **identity_update**: empty transition, too many keys to disable, duplicate key IDs, disable+add conflict, wrong revision, nonexistent key, duplicate key ID
- **identity_top_up**: nonexistent identity

## Test plan
- [x] All tests pass locally
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test coverage for identity operations including credit transfers, top-ups, and updates, ensuring comprehensive validation of various scenarios and edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->