### PR TITLE
perf(drive-abci): consolidate shielded test proof generation for faster CI

### DIFF
--- a/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/shield/tests.rs
+++ b/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/shield/tests.rs
@@ -3,7 +3,8 @@ mod tests {
     use crate::execution::validation::state_transition::state_transitions::shielded_common::compute_platform_sighash;
     use crate::execution::validation::state_transition::state_transitions::test_helpers::{
         create_dummy_serialized_action, create_dummy_witness, create_platform_address,
-        process_transition, setup_address_with_balance, setup_platform, TestAddressSigner,
+        get_proving_key, process_transition, serialize_authorized_bundle_with_flags,
+        setup_address_with_balance, setup_platform, TestAddressSigner,
     };
     use crate::platform_types::state_transitions_processing_result::StateTransitionExecutionResult;
     use assert_matches::assert_matches;
@@ -24,13 +25,12 @@ mod tests {
     use dpp::state_transition::shield_transition::ShieldTransition;
     use dpp::state_transition::StateTransition;
     use grovedb_commitment_tree::{
-        Anchor, Authorized as OrchardAuthorized, Builder, Bundle, BundleType, DashMemo,
-        Flags as OrchardFlags, FullViewingKey, NoteValue, ProvingKey, Scope, SpendingKey,
+        Anchor, Builder, BundleType, DashMemo, Flags as OrchardFlags, FullViewingKey, NoteValue,
+        Scope, SpendingKey,
     };
     use platform_version::version::PlatformVersion;
     use rand::rngs::OsRng;
     use std::collections::BTreeMap;
-    use std::sync::OnceLock;
 
     // ==========================================
     // Helper Functions (transition-specific)
@@ -129,49 +129,8 @@ mod tests {
         )
     }
 
-    // ==========================================
-    // Orchard Proving Key (cached, ~30s to build)
-    // ==========================================
-
-    static TEST_PROVING_KEY: OnceLock<ProvingKey> = OnceLock::new();
-    fn get_proving_key() -> &'static ProvingKey {
-        TEST_PROVING_KEY.get_or_init(ProvingKey::build)
-    }
-
-    /// Extract serialized fields from an authorized Orchard bundle into the
-    /// platform-compatible format: (actions, flags, value_balance, anchor, proof, binding_sig).
-    fn serialize_authorized_bundle(
-        bundle: &Bundle<OrchardAuthorized, i64, DashMemo>,
-    ) -> (Vec<SerializedAction>, u8, i64, [u8; 32], Vec<u8>, [u8; 64]) {
-        let actions: Vec<SerializedAction> = bundle
-            .actions()
-            .iter()
-            .map(|action| {
-                let enc = action.encrypted_note();
-                let mut encrypted_note = Vec::with_capacity(216);
-                encrypted_note.extend_from_slice(&enc.epk_bytes);
-                encrypted_note.extend_from_slice(enc.enc_ciphertext.as_ref());
-                encrypted_note.extend_from_slice(&enc.out_ciphertext);
-
-                SerializedAction {
-                    nullifier: action.nullifier().to_bytes(),
-                    rk: <[u8; 32]>::from(action.rk()),
-                    cmx: action.cmx().to_bytes(),
-                    encrypted_note,
-                    cv_net: action.cv_net().to_bytes(),
-                    spend_auth_sig: <[u8; 64]>::from(action.authorization()),
-                }
-            })
-            .collect();
-
-        let flags = bundle.flags().to_byte();
-        let value_balance = *bundle.value_balance();
-        let anchor = bundle.anchor().to_bytes();
-        let proof = bundle.authorization().proof().as_ref().to_vec();
-        let binding_sig = <[u8; 64]>::from(bundle.authorization().binding_signature());
-
-        (actions, flags, value_balance, anchor, proof, binding_sig)
-    }
+    // (Orchard ProvingKey and serialize_authorized_bundle are now shared
+    //  via test_helpers::get_proving_key / serialize_authorized_bundle_with_flags)
 
     // ==========================================
     // STRUCTURE VALIDATION TESTS (BasicError)
@@ -838,7 +797,7 @@ mod tests {
 
             // --- Extract serialized fields from the authorized bundle ---
             let (actions, _flags, value_balance, anchor_bytes, proof_bytes, binding_sig) =
-                serialize_authorized_bundle(&bundle);
+                serialize_authorized_bundle_with_flags(&bundle);
 
             // value_balance should be negative for shield (money going into pool)
             assert!(value_balance < 0);
@@ -1016,7 +975,7 @@ mod tests {
             let bundle = proven.apply_signatures(rng, sighash, &[]).unwrap();
 
             let (actions, _flags, value_balance, anchor_bytes, proof_bytes, binding_sig) =
-                serialize_authorized_bundle(&bundle);
+                serialize_authorized_bundle_with_flags(&bundle);
 
             assert!(value_balance < 0);
             let honest_shield_amount = (-value_balance) as u64;
@@ -1132,7 +1091,7 @@ mod tests {
             let bundle = proven.apply_signatures(rng, sighash, &[]).unwrap();
 
             let (actions, _flags, value_balance, anchor_bytes, proof_bytes, binding_sig) =
-                serialize_authorized_bundle(&bundle);
+                serialize_authorized_bundle_with_flags(&bundle);
 
             assert_eq!(
                 (-value_balance) as u64,
@@ -1195,52 +1154,10 @@ mod tests {
         use dpp::state_transition::proof_result::StateTransitionProofResult;
         use drive::drive::Drive;
         use grovedb_commitment_tree::{
-            Anchor, Authorized as OrchardAuthorized, Builder, Bundle, BundleType, DashMemo,
-            Flags as OrchardFlags, FullViewingKey, NoteValue, ProvingKey, Scope, SpendingKey,
+            Anchor, Builder, BundleType, DashMemo, Flags as OrchardFlags, FullViewingKey,
+            NoteValue, Scope, SpendingKey,
         };
         use rand::rngs::OsRng;
-        use std::sync::OnceLock;
-
-        static TEST_PROVING_KEY: OnceLock<ProvingKey> = OnceLock::new();
-        fn get_proving_key() -> &'static ProvingKey {
-            TEST_PROVING_KEY.get_or_init(ProvingKey::build)
-        }
-
-        /// Extract serialized fields from an authorized Orchard bundle into the
-        /// platform-compatible format: (actions, flags, value_balance, anchor, proof, binding_sig).
-        /// Returns `i64` for value_balance (shield bundles have negative value_balance).
-        fn serialize_authorized_bundle(
-            bundle: &Bundle<OrchardAuthorized, i64, DashMemo>,
-        ) -> (Vec<SerializedAction>, u8, i64, [u8; 32], Vec<u8>, [u8; 64]) {
-            let actions: Vec<SerializedAction> = bundle
-                .actions()
-                .iter()
-                .map(|action| {
-                    let enc = action.encrypted_note();
-                    let mut encrypted_note = Vec::with_capacity(216);
-                    encrypted_note.extend_from_slice(&enc.epk_bytes);
-                    encrypted_note.extend_from_slice(enc.enc_ciphertext.as_ref());
-                    encrypted_note.extend_from_slice(&enc.out_ciphertext);
-
-                    SerializedAction {
-                        nullifier: action.nullifier().to_bytes(),
-                        rk: <[u8; 32]>::from(action.rk()),
-                        cmx: action.cmx().to_bytes(),
-                        encrypted_note,
-                        cv_net: action.cv_net().to_bytes(),
-                        spend_auth_sig: <[u8; 64]>::from(action.authorization()),
-                    }
-                })
-                .collect();
-
-            let flags = bundle.flags().to_byte();
-            let value_balance = *bundle.value_balance();
-            let anchor = bundle.anchor().to_bytes();
-            let proof = bundle.authorization().proof().as_ref().to_vec();
-            let binding_sig = <[u8; 64]>::from(bundle.authorization().binding_signature());
-
-            (actions, flags, value_balance, anchor, proof, binding_sig)
-        }
 
         #[test]
         fn test_shield_prove_and_verify_address_balances() {
@@ -1283,7 +1200,7 @@ mod tests {
 
             // --- Extract serialized fields from the authorized bundle ---
             let (actions, _flags, value_balance, anchor_bytes, proof_bytes, binding_sig) =
-                serialize_authorized_bundle(&bundle);
+                serialize_authorized_bundle_with_flags(&bundle);
 
             // value_balance should be negative for shield (money going into pool)
             assert!(value_balance < 0);

--- a/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/shield_from_asset_lock/tests.rs
+++ b/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/shield_from_asset_lock/tests.rs
@@ -2,7 +2,8 @@
 mod tests {
     use crate::execution::validation::state_transition::state_transitions::shielded_common::compute_platform_sighash;
     use crate::execution::validation::state_transition::state_transitions::test_helpers::{
-        create_dummy_serialized_action, process_transition, setup_platform,
+        create_dummy_serialized_action, get_proving_key, process_transition,
+        serialize_authorized_bundle_with_flags, setup_platform,
     };
     use crate::platform_types::state_transitions_processing_result::StateTransitionExecutionResult;
     use assert_matches::assert_matches;
@@ -21,14 +22,13 @@ mod tests {
     use dpp::state_transition::StateTransition;
     use dpp::tests::fixtures::instant_asset_lock_proof_fixture;
     use grovedb_commitment_tree::{
-        Anchor, Authorized as OrchardAuthorized, Builder, Bundle, BundleType, DashMemo,
-        Flags as OrchardFlags, FullViewingKey, NoteValue, ProvingKey, Scope, SpendingKey,
+        Anchor, Builder, BundleType, DashMemo, Flags as OrchardFlags, FullViewingKey, NoteValue,
+        Scope, SpendingKey,
     };
     use platform_version::version::PlatformVersion;
     use rand::prelude::StdRng;
     use rand::rngs::OsRng;
     use rand::SeedableRng;
-    use std::sync::OnceLock;
 
     // ==========================================
     // Helper Functions (transition-specific)
@@ -121,49 +121,8 @@ mod tests {
         ))
     }
 
-    // ==========================================
-    // Orchard Proving Key (cached, ~30s to build)
-    // ==========================================
-
-    static TEST_PROVING_KEY: OnceLock<ProvingKey> = OnceLock::new();
-    fn get_proving_key() -> &'static ProvingKey {
-        TEST_PROVING_KEY.get_or_init(ProvingKey::build)
-    }
-
-    /// Extract serialized fields from an authorized Orchard bundle into the
-    /// platform-compatible format: (actions, flags, value_balance, anchor, proof, binding_sig).
-    fn serialize_authorized_bundle(
-        bundle: &Bundle<OrchardAuthorized, i64, DashMemo>,
-    ) -> (Vec<SerializedAction>, u8, i64, [u8; 32], Vec<u8>, [u8; 64]) {
-        let actions: Vec<SerializedAction> = bundle
-            .actions()
-            .iter()
-            .map(|action| {
-                let enc = action.encrypted_note();
-                let mut encrypted_note = Vec::with_capacity(216);
-                encrypted_note.extend_from_slice(&enc.epk_bytes);
-                encrypted_note.extend_from_slice(enc.enc_ciphertext.as_ref());
-                encrypted_note.extend_from_slice(&enc.out_ciphertext);
-
-                SerializedAction {
-                    nullifier: action.nullifier().to_bytes(),
-                    rk: <[u8; 32]>::from(action.rk()),
-                    cmx: action.cmx().to_bytes(),
-                    encrypted_note,
-                    cv_net: action.cv_net().to_bytes(),
-                    spend_auth_sig: <[u8; 64]>::from(action.authorization()),
-                }
-            })
-            .collect();
-
-        let flags = bundle.flags().to_byte();
-        let value_balance = *bundle.value_balance();
-        let anchor = bundle.anchor().to_bytes();
-        let proof = bundle.authorization().proof().as_ref().to_vec();
-        let binding_sig = <[u8; 64]>::from(bundle.authorization().binding_signature());
-
-        (actions, flags, value_balance, anchor, proof, binding_sig)
-    }
+    // (Orchard ProvingKey and serialize_authorized_bundle are now shared
+    //  via test_helpers::get_proving_key / serialize_authorized_bundle_with_flags)
 
     // ==========================================
     // STRUCTURE VALIDATION TESTS (BasicError)
@@ -491,7 +450,7 @@ mod tests {
             let bundle = proven.apply_signatures(orchard_rng, sighash, &[]).unwrap();
 
             let (actions, _flags, value_balance, anchor_bytes, proof_bytes, binding_sig) =
-                serialize_authorized_bundle(&bundle);
+                serialize_authorized_bundle_with_flags(&bundle);
 
             // value_balance should be negative for shield (money going into pool)
             assert!(value_balance < 0);
@@ -624,7 +583,7 @@ mod tests {
             let bundle = proven.apply_signatures(orchard_rng, sighash, &[]).unwrap();
 
             let (actions, _flags, value_balance, anchor_bytes, proof_bytes, binding_sig) =
-                serialize_authorized_bundle(&bundle);
+                serialize_authorized_bundle_with_flags(&bundle);
 
             assert!(value_balance < 0);
             let honest_shield_amount = (-value_balance) as u64;
@@ -693,7 +652,7 @@ mod tests {
             let bundle = proven.apply_signatures(orchard_rng, sighash, &[]).unwrap();
 
             let (mut actions, _flags, value_balance, anchor_bytes, proof_bytes, binding_sig) =
-                serialize_authorized_bundle(&bundle);
+                serialize_authorized_bundle_with_flags(&bundle);
 
             // Zero out all spend_auth_sig values
             for action in actions.iter_mut() {
@@ -738,49 +697,10 @@ mod tests {
         use dpp::state_transition::proof_result::StateTransitionProofResult;
         use drive::drive::Drive;
         use grovedb_commitment_tree::{
-            Anchor, Authorized as OrchardAuthorized, Builder, Bundle, BundleType, DashMemo,
-            Flags as OrchardFlags, FullViewingKey, NoteValue, ProvingKey, Scope, SpendingKey,
+            Anchor, Builder, BundleType, DashMemo, Flags as OrchardFlags, FullViewingKey,
+            NoteValue, Scope, SpendingKey,
         };
         use rand::rngs::OsRng;
-        use std::sync::OnceLock;
-
-        static TEST_PROVING_KEY: OnceLock<ProvingKey> = OnceLock::new();
-        fn get_proving_key() -> &'static ProvingKey {
-            TEST_PROVING_KEY.get_or_init(ProvingKey::build)
-        }
-
-        fn serialize_authorized_bundle(
-            bundle: &Bundle<OrchardAuthorized, i64, DashMemo>,
-        ) -> (Vec<SerializedAction>, u8, i64, [u8; 32], Vec<u8>, [u8; 64]) {
-            let actions: Vec<SerializedAction> = bundle
-                .actions()
-                .iter()
-                .map(|action| {
-                    let enc = action.encrypted_note();
-                    let mut encrypted_note = Vec::with_capacity(216);
-                    encrypted_note.extend_from_slice(&enc.epk_bytes);
-                    encrypted_note.extend_from_slice(enc.enc_ciphertext.as_ref());
-                    encrypted_note.extend_from_slice(&enc.out_ciphertext);
-
-                    SerializedAction {
-                        nullifier: action.nullifier().to_bytes(),
-                        rk: <[u8; 32]>::from(action.rk()),
-                        cmx: action.cmx().to_bytes(),
-                        encrypted_note,
-                        cv_net: action.cv_net().to_bytes(),
-                        spend_auth_sig: <[u8; 64]>::from(action.authorization()),
-                    }
-                })
-                .collect();
-
-            let flags = bundle.flags().to_byte();
-            let value_balance = *bundle.value_balance();
-            let anchor = bundle.anchor().to_bytes();
-            let proof = bundle.authorization().proof().as_ref().to_vec();
-            let binding_sig = <[u8; 64]>::from(bundle.authorization().binding_signature());
-
-            (actions, flags, value_balance, anchor, proof, binding_sig)
-        }
 
         #[test]
         fn test_shield_from_asset_lock_prove_and_verify() {
@@ -824,7 +744,7 @@ mod tests {
             let bundle = proven.apply_signatures(orchard_rng, sighash, &[]).unwrap();
 
             let (actions, _flags, value_balance, anchor_bytes, proof_bytes, binding_sig) =
-                serialize_authorized_bundle(&bundle);
+                serialize_authorized_bundle_with_flags(&bundle);
 
             assert!(value_balance < 0);
             let shield_amount = (-value_balance) as u64;

--- a/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/shielded_transfer/tests.rs
+++ b/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/shielded_transfer/tests.rs
@@ -2,8 +2,9 @@
 mod tests {
     use crate::execution::validation::state_transition::state_transitions::shielded_common::compute_platform_sighash;
     use crate::execution::validation::state_transition::state_transitions::test_helpers::{
-        create_dummy_serialized_action, insert_anchor_into_state, insert_nullifier_into_state,
-        process_transition, set_pool_total_balance, setup_platform,
+        create_dummy_serialized_action, get_proving_key, insert_anchor_into_state,
+        insert_nullifier_into_state, process_transition, serialize_authorized_bundle_u64,
+        set_pool_total_balance, setup_platform,
     };
     use crate::platform_types::state_transitions_processing_result::StateTransitionExecutionResult;
     use assert_matches::assert_matches;
@@ -255,47 +256,11 @@ mod tests {
     mod proof_verification {
         use super::*;
         use grovedb_commitment_tree::{
-            Anchor, Authorized as OrchardAuthorized, Builder, Bundle, BundleType,
-            ClientMemoryCommitmentTree, DashMemo, ExtractedNoteCommitment, FullViewingKey,
-            MerklePath, Note, NoteValue, Position, ProvingKey, RandomSeed, Retention, Rho, Scope,
-            SpendAuthorizingKey, SpendingKey,
+            Anchor, Builder, BundleType, ClientMemoryCommitmentTree, DashMemo,
+            ExtractedNoteCommitment, FullViewingKey, MerklePath, Note, NoteValue, Position,
+            RandomSeed, Retention, Rho, Scope, SpendAuthorizingKey, SpendingKey,
         };
         use rand::rngs::OsRng;
-        use std::sync::OnceLock;
-
-        static TEST_PROVING_KEY: OnceLock<ProvingKey> = OnceLock::new();
-        fn get_proving_key() -> &'static ProvingKey {
-            TEST_PROVING_KEY.get_or_init(ProvingKey::build)
-        }
-
-        fn serialize_authorized_bundle(
-            bundle: &Bundle<OrchardAuthorized, i64, DashMemo>,
-        ) -> (Vec<SerializedAction>, u64, [u8; 32], Vec<u8>, [u8; 64]) {
-            let actions: Vec<SerializedAction> = bundle
-                .actions()
-                .iter()
-                .map(|action| {
-                    let enc = action.encrypted_note();
-                    let mut encrypted_note = Vec::with_capacity(216);
-                    encrypted_note.extend_from_slice(&enc.epk_bytes);
-                    encrypted_note.extend_from_slice(enc.enc_ciphertext.as_ref());
-                    encrypted_note.extend_from_slice(&enc.out_ciphertext);
-                    SerializedAction {
-                        nullifier: action.nullifier().to_bytes(),
-                        rk: <[u8; 32]>::from(action.rk()),
-                        cmx: action.cmx().to_bytes(),
-                        encrypted_note,
-                        cv_net: action.cv_net().to_bytes(),
-                        spend_auth_sig: <[u8; 64]>::from(action.authorization()),
-                    }
-                })
-                .collect();
-            let value_balance = *bundle.value_balance() as u64;
-            let anchor = bundle.anchor().to_bytes();
-            let proof = bundle.authorization().proof().as_ref().to_vec();
-            let binding_sig = <[u8; 64]>::from(bundle.authorization().binding_signature());
-            (actions, value_balance, anchor, proof, binding_sig)
-        }
 
         #[test]
         fn test_invalid_proof_returns_shielded_proof_error() {
@@ -380,7 +345,7 @@ mod tests {
 
             // --- Extract serialized fields ---
             let (actions, value_balance, anchor_bytes, proof_bytes, binding_sig) =
-                serialize_authorized_bundle(&bundle);
+                serialize_authorized_bundle_u64(&bundle);
 
             assert_eq!(value_balance, MINIMUM_FEE_2_ACTIONS);
 
@@ -459,51 +424,15 @@ mod tests {
     mod fee_validation {
         use super::*;
         use grovedb_commitment_tree::{
-            Anchor, Authorized as OrchardAuthorized, Builder, Bundle, BundleType,
-            ClientMemoryCommitmentTree, DashMemo, ExtractedNoteCommitment, FullViewingKey,
-            MerklePath, Note, NoteValue, Position, ProvingKey, RandomSeed, Retention, Rho, Scope,
-            SpendAuthorizingKey, SpendingKey,
+            Anchor, Builder, BundleType, ClientMemoryCommitmentTree, DashMemo,
+            ExtractedNoteCommitment, FullViewingKey, MerklePath, Note, NoteValue, Position,
+            RandomSeed, Retention, Rho, Scope, SpendAuthorizingKey, SpendingKey,
         };
         use rand::rngs::OsRng;
-        use std::sync::OnceLock;
 
         const MINIMUM_FEE_2_ACTIONS: u64 = 123_097_600;
         const MINIMUM_FEE_3_ACTIONS: u64 = 134_646_400;
         const MINIMUM_FEE_4_ACTIONS: u64 = 146_195_200;
-
-        static TEST_PROVING_KEY: OnceLock<ProvingKey> = OnceLock::new();
-        fn get_proving_key() -> &'static ProvingKey {
-            TEST_PROVING_KEY.get_or_init(ProvingKey::build)
-        }
-
-        fn serialize_authorized_bundle(
-            bundle: &Bundle<OrchardAuthorized, i64, DashMemo>,
-        ) -> (Vec<SerializedAction>, u64, [u8; 32], Vec<u8>, [u8; 64]) {
-            let actions: Vec<SerializedAction> = bundle
-                .actions()
-                .iter()
-                .map(|action| {
-                    let enc = action.encrypted_note();
-                    let mut encrypted_note = Vec::with_capacity(216);
-                    encrypted_note.extend_from_slice(&enc.epk_bytes);
-                    encrypted_note.extend_from_slice(enc.enc_ciphertext.as_ref());
-                    encrypted_note.extend_from_slice(&enc.out_ciphertext);
-                    SerializedAction {
-                        nullifier: action.nullifier().to_bytes(),
-                        rk: <[u8; 32]>::from(action.rk()),
-                        cmx: action.cmx().to_bytes(),
-                        encrypted_note,
-                        cv_net: action.cv_net().to_bytes(),
-                        spend_auth_sig: <[u8; 64]>::from(action.authorization()),
-                    }
-                })
-                .collect();
-            let value_balance = *bundle.value_balance() as u64;
-            let anchor = bundle.anchor().to_bytes();
-            let proof = bundle.authorization().proof().as_ref().to_vec();
-            let binding_sig = <[u8; 64]>::from(bundle.authorization().binding_signature());
-            (actions, value_balance, anchor, proof, binding_sig)
-        }
 
         /// Helper to create a dummy action with a unique seed (avoids duplicate nullifiers).
         fn create_dummy_action(seed: u8) -> SerializedAction {
@@ -677,7 +606,7 @@ mod tests {
             let proven = unauthorized.create_proof(pk, &mut rng).unwrap();
             let bundle = proven.apply_signatures(rng, sighash, &[ask]).unwrap();
 
-            serialize_authorized_bundle(&bundle)
+            serialize_authorized_bundle_u64(&bundle)
         }
 
         #[test]
@@ -756,50 +685,14 @@ mod tests {
     mod security_audit {
         use super::*;
         use grovedb_commitment_tree::{
-            Anchor, Authorized as OrchardAuthorized, Builder, Bundle, BundleType,
-            ClientMemoryCommitmentTree, DashMemo, ExtractedNoteCommitment, FullViewingKey,
-            MerklePath, Note, NoteValue, Position, ProvingKey, RandomSeed, Retention, Rho, Scope,
-            SpendAuthorizingKey, SpendingKey,
+            Builder, BundleType, ClientMemoryCommitmentTree, DashMemo, ExtractedNoteCommitment,
+            FullViewingKey, MerklePath, Note, NoteValue, Position, RandomSeed, Retention, Rho,
+            Scope, SpendAuthorizingKey, SpendingKey,
         };
         use rand::rngs::OsRng;
-        use std::sync::OnceLock;
 
         /// Minimum fee for 2 actions (Orchard builder always produces ≥2).
         const MINIMUM_FEE_2_ACTIONS: u64 = 123_097_600;
-
-        static TEST_PROVING_KEY: OnceLock<ProvingKey> = OnceLock::new();
-        fn get_proving_key() -> &'static ProvingKey {
-            TEST_PROVING_KEY.get_or_init(ProvingKey::build)
-        }
-
-        fn serialize_authorized_bundle(
-            bundle: &Bundle<OrchardAuthorized, i64, DashMemo>,
-        ) -> (Vec<SerializedAction>, u64, [u8; 32], Vec<u8>, [u8; 64]) {
-            let actions: Vec<SerializedAction> = bundle
-                .actions()
-                .iter()
-                .map(|action| {
-                    let enc = action.encrypted_note();
-                    let mut encrypted_note = Vec::with_capacity(216);
-                    encrypted_note.extend_from_slice(&enc.epk_bytes);
-                    encrypted_note.extend_from_slice(enc.enc_ciphertext.as_ref());
-                    encrypted_note.extend_from_slice(&enc.out_ciphertext);
-                    SerializedAction {
-                        nullifier: action.nullifier().to_bytes(),
-                        rk: <[u8; 32]>::from(action.rk()),
-                        cmx: action.cmx().to_bytes(),
-                        encrypted_note,
-                        cv_net: action.cv_net().to_bytes(),
-                        spend_auth_sig: <[u8; 64]>::from(action.authorization()),
-                    }
-                })
-                .collect();
-            let value_balance = *bundle.value_balance() as u64;
-            let anchor = bundle.anchor().to_bytes();
-            let proof = bundle.authorization().proof().as_ref().to_vec();
-            let binding_sig = <[u8; 64]>::from(bundle.authorization().binding_signature());
-            (actions, value_balance, anchor, proof, binding_sig)
-        }
 
         /// Build a valid Orchard bundle for shielded transfer tests.
         /// Includes sufficient fee (value_balance = MINIMUM_FEE_2_ACTIONS).
@@ -851,7 +744,7 @@ mod tests {
             let proven = unauthorized.create_proof(pk, &mut rng).unwrap();
             let bundle = proven.apply_signatures(rng, sighash, &[ask]).unwrap();
 
-            serialize_authorized_bundle(&bundle)
+            serialize_authorized_bundle_u64(&bundle)
         }
 
         /// AUDIT REGRESSION: Mutating value_balance is now caught by BatchValidator.
@@ -1022,49 +915,13 @@ mod tests {
         use dpp::state_transition::shielded_transfer_transition::accessors::ShieldedTransferTransitionAccessorsV0;
         use drive::drive::Drive;
         use grovedb_commitment_tree::{
-            Anchor, Authorized as OrchardAuthorized, Builder, Bundle, BundleType,
-            ClientMemoryCommitmentTree, DashMemo, ExtractedNoteCommitment, FullViewingKey, Note,
-            NoteValue, Position, ProvingKey, RandomSeed, Retention, Rho, Scope,
+            Builder, BundleType, ClientMemoryCommitmentTree, DashMemo, ExtractedNoteCommitment,
+            FullViewingKey, Note, NoteValue, Position, RandomSeed, Retention, Rho, Scope,
             SpendAuthorizingKey, SpendingKey,
         };
         use rand::rngs::OsRng;
-        use std::sync::OnceLock;
 
         const MINIMUM_FEE_2_ACTIONS: u64 = 123_097_600;
-
-        static TEST_PROVING_KEY: OnceLock<ProvingKey> = OnceLock::new();
-        fn get_proving_key() -> &'static ProvingKey {
-            TEST_PROVING_KEY.get_or_init(ProvingKey::build)
-        }
-
-        fn serialize_authorized_bundle(
-            bundle: &Bundle<OrchardAuthorized, i64, DashMemo>,
-        ) -> (Vec<SerializedAction>, u64, [u8; 32], Vec<u8>, [u8; 64]) {
-            let actions: Vec<SerializedAction> = bundle
-                .actions()
-                .iter()
-                .map(|action| {
-                    let enc = action.encrypted_note();
-                    let mut encrypted_note = Vec::with_capacity(216);
-                    encrypted_note.extend_from_slice(&enc.epk_bytes);
-                    encrypted_note.extend_from_slice(enc.enc_ciphertext.as_ref());
-                    encrypted_note.extend_from_slice(&enc.out_ciphertext);
-                    SerializedAction {
-                        nullifier: action.nullifier().to_bytes(),
-                        rk: <[u8; 32]>::from(action.rk()),
-                        cmx: action.cmx().to_bytes(),
-                        encrypted_note,
-                        cv_net: action.cv_net().to_bytes(),
-                        spend_auth_sig: <[u8; 64]>::from(action.authorization()),
-                    }
-                })
-                .collect();
-            let value_balance = *bundle.value_balance() as u64;
-            let anchor = bundle.anchor().to_bytes();
-            let proof = bundle.authorization().proof().as_ref().to_vec();
-            let binding_sig = <[u8; 64]>::from(bundle.authorization().binding_signature());
-            (actions, value_balance, anchor, proof, binding_sig)
-        }
 
         #[test]
         fn test_shielded_transfer_prove_and_verify_nullifiers() {
@@ -1120,7 +977,7 @@ mod tests {
             let bundle = proven.apply_signatures(rng, sighash, &[ask]).unwrap();
 
             let (actions, value_balance, anchor_bytes, proof_bytes, binding_sig) =
-                serialize_authorized_bundle(&bundle);
+                serialize_authorized_bundle_u64(&bundle);
 
             // --- Set up pool state ---
             set_pool_total_balance(&platform, 500_000_000);

--- a/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/shielded_withdrawal/tests.rs
+++ b/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/shielded_withdrawal/tests.rs
@@ -2,8 +2,9 @@
 mod tests {
     use crate::execution::validation::state_transition::state_transitions::shielded_common::compute_platform_sighash;
     use crate::execution::validation::state_transition::state_transitions::test_helpers::{
-        create_dummy_serialized_action, insert_anchor_into_state, insert_dummy_encrypted_notes,
-        insert_nullifier_into_state, process_transition, set_pool_total_balance, setup_platform,
+        create_dummy_serialized_action, get_proving_key, insert_anchor_into_state,
+        insert_dummy_encrypted_notes, insert_nullifier_into_state, process_transition,
+        serialize_authorized_bundle_i64, set_pool_total_balance, setup_platform,
     };
     use crate::platform_types::state_transitions_processing_result::StateTransitionExecutionResult;
     use assert_matches::assert_matches;
@@ -347,47 +348,11 @@ mod tests {
     mod proof_verification {
         use super::*;
         use grovedb_commitment_tree::{
-            Authorized as OrchardAuthorized, Builder, Bundle, BundleType,
-            ClientMemoryCommitmentTree, DashMemo, ExtractedNoteCommitment, FullViewingKey, Note,
-            NoteValue, Position, ProvingKey, RandomSeed, Retention, Rho, Scope,
+            Builder, BundleType, ClientMemoryCommitmentTree, DashMemo, ExtractedNoteCommitment,
+            FullViewingKey, Note, NoteValue, Position, RandomSeed, Retention, Rho, Scope,
             SpendAuthorizingKey, SpendingKey,
         };
         use rand::rngs::OsRng;
-        use std::sync::OnceLock;
-
-        static TEST_PROVING_KEY: OnceLock<ProvingKey> = OnceLock::new();
-        fn get_proving_key() -> &'static ProvingKey {
-            TEST_PROVING_KEY.get_or_init(ProvingKey::build)
-        }
-
-        fn serialize_authorized_bundle(
-            bundle: &Bundle<OrchardAuthorized, i64, DashMemo>,
-        ) -> (Vec<SerializedAction>, i64, [u8; 32], Vec<u8>, [u8; 64]) {
-            let actions: Vec<SerializedAction> = bundle
-                .actions()
-                .iter()
-                .map(|action| {
-                    let enc = action.encrypted_note();
-                    let mut encrypted_note = Vec::with_capacity(216);
-                    encrypted_note.extend_from_slice(&enc.epk_bytes);
-                    encrypted_note.extend_from_slice(enc.enc_ciphertext.as_ref());
-                    encrypted_note.extend_from_slice(&enc.out_ciphertext);
-                    SerializedAction {
-                        nullifier: action.nullifier().to_bytes(),
-                        rk: <[u8; 32]>::from(action.rk()),
-                        cmx: action.cmx().to_bytes(),
-                        encrypted_note,
-                        cv_net: action.cv_net().to_bytes(),
-                        spend_auth_sig: <[u8; 64]>::from(action.authorization()),
-                    }
-                })
-                .collect();
-            let value_balance = *bundle.value_balance();
-            let anchor = bundle.anchor().to_bytes();
-            let proof = bundle.authorization().proof().as_ref().to_vec();
-            let binding_sig = <[u8; 64]>::from(bundle.authorization().binding_signature());
-            (actions, value_balance, anchor, proof, binding_sig)
-        }
 
         #[test]
         fn test_invalid_proof_returns_shielded_proof_error() {
@@ -473,7 +438,7 @@ mod tests {
 
             // --- Extract serialized fields ---
             let (actions, value_balance, anchor_bytes, proof_bytes, binding_sig) =
-                serialize_authorized_bundle(&bundle);
+                serialize_authorized_bundle_i64(&bundle);
 
             // value_balance should be 499,995,000 (500M spent - 5K output)
             assert_eq!(value_balance, 499_995_000);
@@ -557,47 +522,11 @@ mod tests {
     mod security_audit {
         use super::*;
         use grovedb_commitment_tree::{
-            Authorized as OrchardAuthorized, Builder, Bundle, BundleType,
-            ClientMemoryCommitmentTree, DashMemo, ExtractedNoteCommitment, FullViewingKey, Note,
-            NoteValue, Position, ProvingKey, RandomSeed, Retention, Rho, Scope,
+            Builder, BundleType, ClientMemoryCommitmentTree, DashMemo, ExtractedNoteCommitment,
+            FullViewingKey, Note, NoteValue, Position, RandomSeed, Retention, Rho, Scope,
             SpendAuthorizingKey, SpendingKey,
         };
         use rand::rngs::OsRng;
-        use std::sync::OnceLock;
-
-        static TEST_PROVING_KEY: OnceLock<ProvingKey> = OnceLock::new();
-        fn get_proving_key() -> &'static ProvingKey {
-            TEST_PROVING_KEY.get_or_init(ProvingKey::build)
-        }
-
-        fn serialize_authorized_bundle(
-            bundle: &Bundle<OrchardAuthorized, i64, DashMemo>,
-        ) -> (Vec<SerializedAction>, i64, [u8; 32], Vec<u8>, [u8; 64]) {
-            let actions: Vec<SerializedAction> = bundle
-                .actions()
-                .iter()
-                .map(|action| {
-                    let enc = action.encrypted_note();
-                    let mut encrypted_note = Vec::with_capacity(216);
-                    encrypted_note.extend_from_slice(&enc.epk_bytes);
-                    encrypted_note.extend_from_slice(enc.enc_ciphertext.as_ref());
-                    encrypted_note.extend_from_slice(&enc.out_ciphertext);
-                    SerializedAction {
-                        nullifier: action.nullifier().to_bytes(),
-                        rk: <[u8; 32]>::from(action.rk()),
-                        cmx: action.cmx().to_bytes(),
-                        encrypted_note,
-                        cv_net: action.cv_net().to_bytes(),
-                        spend_auth_sig: <[u8; 64]>::from(action.authorization()),
-                    }
-                })
-                .collect();
-            let value_balance = *bundle.value_balance();
-            let anchor = bundle.anchor().to_bytes();
-            let proof = bundle.authorization().proof().as_ref().to_vec();
-            let binding_sig = <[u8; 64]>::from(bundle.authorization().binding_signature());
-            (actions, value_balance, anchor, proof, binding_sig)
-        }
 
         /// Build a valid Orchard bundle for shielded withdrawal tests (spend > output).
         /// The `output_script` and `unshielding_amount` are bound to the sighash so that
@@ -650,7 +579,7 @@ mod tests {
             let proven = unauthorized.create_proof(pk, &mut rng).unwrap();
             let bundle = proven.apply_signatures(rng, sighash, &[ask]).unwrap();
 
-            serialize_authorized_bundle(&bundle)
+            serialize_authorized_bundle_i64(&bundle)
         }
 
         /// AUDIT REGRESSION: Zeroed binding signature is caught by BatchValidator.
@@ -902,48 +831,13 @@ mod tests {
         use dpp::system_data_contracts::{load_system_data_contract, SystemDataContract};
         use drive::drive::Drive;
         use grovedb_commitment_tree::{
-            Authorized as OrchardAuthorized, Builder, Bundle, BundleType,
-            ClientMemoryCommitmentTree, DashMemo, ExtractedNoteCommitment, FullViewingKey, Note,
-            NoteValue, Position, ProvingKey, RandomSeed, Retention, Rho, Scope,
+            Builder, BundleType, ClientMemoryCommitmentTree, DashMemo, ExtractedNoteCommitment,
+            FullViewingKey, Note, NoteValue, Position, RandomSeed, Retention, Rho, Scope,
             SpendAuthorizingKey, SpendingKey,
         };
         use rand::rngs::OsRng;
         use std::collections::BTreeMap;
-        use std::sync::{Arc, OnceLock};
-
-        static TEST_PROVING_KEY: OnceLock<ProvingKey> = OnceLock::new();
-        fn get_proving_key() -> &'static ProvingKey {
-            TEST_PROVING_KEY.get_or_init(ProvingKey::build)
-        }
-
-        fn serialize_authorized_bundle(
-            bundle: &Bundle<OrchardAuthorized, i64, DashMemo>,
-        ) -> (Vec<SerializedAction>, i64, [u8; 32], Vec<u8>, [u8; 64]) {
-            let actions: Vec<SerializedAction> = bundle
-                .actions()
-                .iter()
-                .map(|action| {
-                    let enc = action.encrypted_note();
-                    let mut encrypted_note = Vec::with_capacity(216);
-                    encrypted_note.extend_from_slice(&enc.epk_bytes);
-                    encrypted_note.extend_from_slice(enc.enc_ciphertext.as_ref());
-                    encrypted_note.extend_from_slice(&enc.out_ciphertext);
-                    SerializedAction {
-                        nullifier: action.nullifier().to_bytes(),
-                        rk: <[u8; 32]>::from(action.rk()),
-                        cmx: action.cmx().to_bytes(),
-                        encrypted_note,
-                        cv_net: action.cv_net().to_bytes(),
-                        spend_auth_sig: <[u8; 64]>::from(action.authorization()),
-                    }
-                })
-                .collect();
-            let value_balance = *bundle.value_balance();
-            let anchor = bundle.anchor().to_bytes();
-            let proof = bundle.authorization().proof().as_ref().to_vec();
-            let binding_sig = <[u8; 64]>::from(bundle.authorization().binding_signature());
-            (actions, value_balance, anchor, proof, binding_sig)
-        }
+        use std::sync::Arc;
 
         #[test]
         fn test_shielded_withdrawal_prove_and_verify_nullifiers_and_document() {
@@ -1000,7 +894,7 @@ mod tests {
 
             // --- Extract serialized fields ---
             let (actions, value_balance, anchor_bytes, proof_bytes, binding_sig) =
-                serialize_authorized_bundle(&bundle);
+                serialize_authorized_bundle_i64(&bundle);
 
             // value_balance should be 499,995,000 (500M spent - 5K output)
             assert_eq!(value_balance, 499_995_000);

--- a/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/test_helpers.rs
+++ b/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/test_helpers.rs
@@ -649,7 +649,8 @@ pub fn serialize_authorized_bundle_u64(
     bundle: &Bundle<OrchardAuthorized, i64, DashMemo>,
 ) -> (Vec<SerializedAction>, u64, [u8; 32], Vec<u8>, [u8; 64]) {
     let actions = serialize_bundle_actions(bundle);
-    let value_balance = *bundle.value_balance() as u64;
+    let value_balance = u64::try_from(*bundle.value_balance())
+        .expect("shielded-transfer requires a non-negative value_balance");
     let anchor = bundle.anchor().to_bytes();
     let proof = bundle.authorization().proof().as_ref().to_vec();
     let binding_sig = <[u8; 64]>::from(bundle.authorization().binding_signature());

--- a/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/test_helpers.rs
+++ b/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/test_helpers.rs
@@ -605,3 +605,95 @@ pub fn insert_dummy_encrypted_notes(platform: &TempPlatform<MockCoreRPCLike>, co
             .expect("should commit transaction");
     }
 }
+
+// ==========================================
+// Shared Orchard Proving Key & Serialization
+// ==========================================
+
+use grovedb_commitment_tree::{Authorized as OrchardAuthorized, Bundle, DashMemo, ProvingKey};
+use std::sync::OnceLock;
+
+/// Single process-wide proving key shared by ALL shielded tests.
+///
+/// `ProvingKey::build()` costs ~1-2 s. Previously every test module had its
+/// own `static OnceLock<ProvingKey>`, so running N modules in parallel could
+/// build the key N times simultaneously.  With a single static the key is
+/// built at most once per test binary invocation.
+static SHARED_PROVING_KEY: OnceLock<ProvingKey> = OnceLock::new();
+
+/// Returns a reference to the lazily-initialized proving key.
+pub fn get_proving_key() -> &'static ProvingKey {
+    SHARED_PROVING_KEY.get_or_init(ProvingKey::build)
+}
+
+/// Serialize an authorized Orchard bundle into the platform-compatible
+/// format used by **spend** transitions (unshield, shielded-withdrawal).
+///
+/// Returns `(actions, value_balance_i64, anchor, proof, binding_sig)`.
+pub fn serialize_authorized_bundle_i64(
+    bundle: &Bundle<OrchardAuthorized, i64, DashMemo>,
+) -> (Vec<SerializedAction>, i64, [u8; 32], Vec<u8>, [u8; 64]) {
+    let actions = serialize_bundle_actions(bundle);
+    let value_balance = *bundle.value_balance();
+    let anchor = bundle.anchor().to_bytes();
+    let proof = bundle.authorization().proof().as_ref().to_vec();
+    let binding_sig = <[u8; 64]>::from(bundle.authorization().binding_signature());
+    (actions, value_balance, anchor, proof, binding_sig)
+}
+
+/// Serialize an authorized Orchard bundle into the platform-compatible
+/// format used by **shielded-transfer** transitions (value_balance as `u64`).
+///
+/// Returns `(actions, value_balance_u64, anchor, proof, binding_sig)`.
+pub fn serialize_authorized_bundle_u64(
+    bundle: &Bundle<OrchardAuthorized, i64, DashMemo>,
+) -> (Vec<SerializedAction>, u64, [u8; 32], Vec<u8>, [u8; 64]) {
+    let actions = serialize_bundle_actions(bundle);
+    let value_balance = *bundle.value_balance() as u64;
+    let anchor = bundle.anchor().to_bytes();
+    let proof = bundle.authorization().proof().as_ref().to_vec();
+    let binding_sig = <[u8; 64]>::from(bundle.authorization().binding_signature());
+    (actions, value_balance, anchor, proof, binding_sig)
+}
+
+/// Serialize an authorized Orchard bundle into the platform-compatible
+/// format used by **shield** transitions (includes flags byte).
+///
+/// Returns `(actions, flags, value_balance_i64, anchor, proof, binding_sig)`.
+pub fn serialize_authorized_bundle_with_flags(
+    bundle: &Bundle<OrchardAuthorized, i64, DashMemo>,
+) -> (Vec<SerializedAction>, u8, i64, [u8; 32], Vec<u8>, [u8; 64]) {
+    let actions = serialize_bundle_actions(bundle);
+    let flags = bundle.flags().to_byte();
+    let value_balance = *bundle.value_balance();
+    let anchor = bundle.anchor().to_bytes();
+    let proof = bundle.authorization().proof().as_ref().to_vec();
+    let binding_sig = <[u8; 64]>::from(bundle.authorization().binding_signature());
+    (actions, flags, value_balance, anchor, proof, binding_sig)
+}
+
+/// Internal helper: extract `Vec<SerializedAction>` from bundle actions.
+fn serialize_bundle_actions(
+    bundle: &Bundle<OrchardAuthorized, i64, DashMemo>,
+) -> Vec<SerializedAction> {
+    bundle
+        .actions()
+        .iter()
+        .map(|action| {
+            let enc = action.encrypted_note();
+            let mut encrypted_note = Vec::with_capacity(216);
+            encrypted_note.extend_from_slice(&enc.epk_bytes);
+            encrypted_note.extend_from_slice(enc.enc_ciphertext.as_ref());
+            encrypted_note.extend_from_slice(&enc.out_ciphertext);
+
+            SerializedAction {
+                nullifier: action.nullifier().to_bytes(),
+                rk: <[u8; 32]>::from(action.rk()),
+                cmx: action.cmx().to_bytes(),
+                encrypted_note,
+                cv_net: action.cv_net().to_bytes(),
+                spend_auth_sig: <[u8; 64]>::from(action.authorization()),
+            }
+        })
+        .collect()
+}

--- a/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/unshield/tests.rs
+++ b/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/unshield/tests.rs
@@ -2,8 +2,9 @@
 mod tests {
     use crate::execution::validation::state_transition::state_transitions::shielded_common::compute_platform_sighash;
     use crate::execution::validation::state_transition::state_transitions::test_helpers::{
-        create_dummy_serialized_action, insert_anchor_into_state, insert_dummy_encrypted_notes,
-        insert_nullifier_into_state, process_transition, set_pool_total_balance, setup_platform,
+        create_dummy_serialized_action, get_proving_key, insert_anchor_into_state,
+        insert_dummy_encrypted_notes, insert_nullifier_into_state, process_transition,
+        serialize_authorized_bundle_i64, set_pool_total_balance, setup_platform,
     };
     use crate::platform_types::state_transitions_processing_result::StateTransitionExecutionResult;
     use assert_matches::assert_matches;
@@ -319,47 +320,11 @@ mod tests {
     mod proof_verification {
         use super::*;
         use grovedb_commitment_tree::{
-            Anchor, Authorized as OrchardAuthorized, Builder, Bundle, BundleType,
-            ClientMemoryCommitmentTree, DashMemo, ExtractedNoteCommitment, FullViewingKey,
-            MerklePath, Note, NoteValue, Position, ProvingKey, RandomSeed, Retention, Rho, Scope,
-            SpendAuthorizingKey, SpendingKey,
+            Anchor, Builder, BundleType, ClientMemoryCommitmentTree, DashMemo,
+            ExtractedNoteCommitment, FullViewingKey, MerklePath, Note, NoteValue, Position,
+            RandomSeed, Retention, Rho, Scope, SpendAuthorizingKey, SpendingKey,
         };
         use rand::rngs::OsRng;
-        use std::sync::OnceLock;
-
-        static TEST_PROVING_KEY: OnceLock<ProvingKey> = OnceLock::new();
-        fn get_proving_key() -> &'static ProvingKey {
-            TEST_PROVING_KEY.get_or_init(ProvingKey::build)
-        }
-
-        fn serialize_authorized_bundle(
-            bundle: &Bundle<OrchardAuthorized, i64, DashMemo>,
-        ) -> (Vec<SerializedAction>, i64, [u8; 32], Vec<u8>, [u8; 64]) {
-            let actions: Vec<SerializedAction> = bundle
-                .actions()
-                .iter()
-                .map(|action| {
-                    let enc = action.encrypted_note();
-                    let mut encrypted_note = Vec::with_capacity(216);
-                    encrypted_note.extend_from_slice(&enc.epk_bytes);
-                    encrypted_note.extend_from_slice(enc.enc_ciphertext.as_ref());
-                    encrypted_note.extend_from_slice(&enc.out_ciphertext);
-                    SerializedAction {
-                        nullifier: action.nullifier().to_bytes(),
-                        rk: <[u8; 32]>::from(action.rk()),
-                        cmx: action.cmx().to_bytes(),
-                        encrypted_note,
-                        cv_net: action.cv_net().to_bytes(),
-                        spend_auth_sig: <[u8; 64]>::from(action.authorization()),
-                    }
-                })
-                .collect();
-            let value_balance = *bundle.value_balance();
-            let anchor = bundle.anchor().to_bytes();
-            let proof = bundle.authorization().proof().as_ref().to_vec();
-            let binding_sig = <[u8; 64]>::from(bundle.authorization().binding_signature());
-            (actions, value_balance, anchor, proof, binding_sig)
-        }
 
         #[test]
         fn test_invalid_proof_returns_shielded_proof_error() {
@@ -442,7 +407,7 @@ mod tests {
 
             // --- Extract serialized fields ---
             let (actions, value_balance, anchor_bytes, proof_bytes, binding_sig) =
-                serialize_authorized_bundle(&bundle);
+                serialize_authorized_bundle_i64(&bundle);
 
             // value_balance should be 499,995,000 (500M spent - 5K output)
             assert_eq!(value_balance, 499_995_000);
@@ -514,47 +479,11 @@ mod tests {
     mod security_audit {
         use super::*;
         use grovedb_commitment_tree::{
-            Anchor, Authorized as OrchardAuthorized, Builder, Bundle, BundleType,
-            ClientMemoryCommitmentTree, DashMemo, ExtractedNoteCommitment, FullViewingKey,
-            MerklePath, Note, NoteValue, Position, ProvingKey, RandomSeed, Retention, Rho, Scope,
-            SpendAuthorizingKey, SpendingKey,
+            Anchor, Builder, BundleType, ClientMemoryCommitmentTree, DashMemo,
+            ExtractedNoteCommitment, FullViewingKey, MerklePath, Note, NoteValue, Position,
+            RandomSeed, Retention, Rho, Scope, SpendAuthorizingKey, SpendingKey,
         };
         use rand::rngs::OsRng;
-        use std::sync::OnceLock;
-
-        static TEST_PROVING_KEY: OnceLock<ProvingKey> = OnceLock::new();
-        fn get_proving_key() -> &'static ProvingKey {
-            TEST_PROVING_KEY.get_or_init(ProvingKey::build)
-        }
-
-        fn serialize_authorized_bundle(
-            bundle: &Bundle<OrchardAuthorized, i64, DashMemo>,
-        ) -> (Vec<SerializedAction>, i64, [u8; 32], Vec<u8>, [u8; 64]) {
-            let actions: Vec<SerializedAction> = bundle
-                .actions()
-                .iter()
-                .map(|action| {
-                    let enc = action.encrypted_note();
-                    let mut encrypted_note = Vec::with_capacity(216);
-                    encrypted_note.extend_from_slice(&enc.epk_bytes);
-                    encrypted_note.extend_from_slice(enc.enc_ciphertext.as_ref());
-                    encrypted_note.extend_from_slice(&enc.out_ciphertext);
-                    SerializedAction {
-                        nullifier: action.nullifier().to_bytes(),
-                        rk: <[u8; 32]>::from(action.rk()),
-                        cmx: action.cmx().to_bytes(),
-                        encrypted_note,
-                        cv_net: action.cv_net().to_bytes(),
-                        spend_auth_sig: <[u8; 64]>::from(action.authorization()),
-                    }
-                })
-                .collect();
-            let value_balance = *bundle.value_balance();
-            let anchor = bundle.anchor().to_bytes();
-            let proof = bundle.authorization().proof().as_ref().to_vec();
-            let binding_sig = <[u8; 64]>::from(bundle.authorization().binding_signature());
-            (actions, value_balance, anchor, proof, binding_sig)
-        }
 
         /// Build a valid Orchard bundle for unshield tests (spend > output).
         /// The `output_address` and `unshielding_amount` are bound to the sighash so that
@@ -607,7 +536,7 @@ mod tests {
             let proven = unauthorized.create_proof(pk, &mut rng).unwrap();
             let bundle = proven.apply_signatures(rng, sighash, &[ask]).unwrap();
 
-            serialize_authorized_bundle(&bundle)
+            serialize_authorized_bundle_i64(&bundle)
         }
 
         /// AUDIT REGRESSION: Mutating value_balance is now caught by BatchValidator.
@@ -760,47 +689,11 @@ mod tests {
         use dpp::state_transition::unshield_transition::accessors::UnshieldTransitionAccessorsV0;
         use drive::drive::Drive;
         use grovedb_commitment_tree::{
-            Authorized as OrchardAuthorized, Builder, Bundle, BundleType,
-            ClientMemoryCommitmentTree, DashMemo, ExtractedNoteCommitment, FullViewingKey, Note,
-            NoteValue, Position, ProvingKey, RandomSeed, Retention, Rho, Scope,
+            Builder, BundleType, ClientMemoryCommitmentTree, DashMemo, ExtractedNoteCommitment,
+            FullViewingKey, Note, NoteValue, Position, RandomSeed, Retention, Rho, Scope,
             SpendAuthorizingKey, SpendingKey,
         };
         use rand::rngs::OsRng;
-        use std::sync::OnceLock;
-
-        static TEST_PROVING_KEY: OnceLock<ProvingKey> = OnceLock::new();
-        fn get_proving_key() -> &'static ProvingKey {
-            TEST_PROVING_KEY.get_or_init(ProvingKey::build)
-        }
-
-        fn serialize_authorized_bundle(
-            bundle: &Bundle<OrchardAuthorized, i64, DashMemo>,
-        ) -> (Vec<SerializedAction>, i64, [u8; 32], Vec<u8>, [u8; 64]) {
-            let actions: Vec<SerializedAction> = bundle
-                .actions()
-                .iter()
-                .map(|action| {
-                    let enc = action.encrypted_note();
-                    let mut encrypted_note = Vec::with_capacity(216);
-                    encrypted_note.extend_from_slice(&enc.epk_bytes);
-                    encrypted_note.extend_from_slice(enc.enc_ciphertext.as_ref());
-                    encrypted_note.extend_from_slice(&enc.out_ciphertext);
-                    SerializedAction {
-                        nullifier: action.nullifier().to_bytes(),
-                        rk: <[u8; 32]>::from(action.rk()),
-                        cmx: action.cmx().to_bytes(),
-                        encrypted_note,
-                        cv_net: action.cv_net().to_bytes(),
-                        spend_auth_sig: <[u8; 64]>::from(action.authorization()),
-                    }
-                })
-                .collect();
-            let value_balance = *bundle.value_balance();
-            let anchor = bundle.anchor().to_bytes();
-            let proof = bundle.authorization().proof().as_ref().to_vec();
-            let binding_sig = <[u8; 64]>::from(bundle.authorization().binding_signature());
-            (actions, value_balance, anchor, proof, binding_sig)
-        }
 
         #[test]
         fn test_unshield_prove_and_verify_nullifiers_and_address() {
@@ -865,7 +758,7 @@ mod tests {
 
             // --- Extract serialized fields ---
             let (actions, value_balance, anchor_bytes, proof_bytes, binding_sig) =
-                serialize_authorized_bundle(&bundle);
+                serialize_authorized_bundle_i64(&bundle);
 
             // value_balance should be 499,995,000 (500M spent - 5K output)
             assert_eq!(value_balance, 499_995_000);


### PR DESCRIPTION
## Issue being fixed or feature implemented

Shielded/ZK tests in `packages/rs-drive-abci/` were slow because each test module independently built its own `ProvingKey` (~1-2 s each). With 14 separate `static OnceLock<ProvingKey>` instances across 5 test files, running tests in parallel could trigger N simultaneous key builds.

## What was done?

- **Consolidated proving key**: Replaced 14 independent `static OnceLock<ProvingKey>` instances (in nested `mod` blocks across `shield/tests.rs`, `shield_from_asset_lock/tests.rs`, `shielded_transfer/tests.rs`, `shielded_withdrawal/tests.rs`, and `unshield/tests.rs`) with a single process-wide `SHARED_PROVING_KEY` in `test_helpers.rs`. The key is now built at most once per test binary invocation.

- **Extracted serialization helpers**: Created three shared functions in `test_helpers.rs`:
  - `serialize_authorized_bundle_i64()` — for unshield and shielded-withdrawal transitions
  - `serialize_authorized_bundle_u64()` — for shielded-transfer transitions
  - `serialize_authorized_bundle_with_flags()` — for shield and shield-from-asset-lock transitions

  This eliminates 14 identical copies of `serialize_authorized_bundle()` (~430 lines of duplicated boilerplate).

- **Net reduction**: 161 lines added, 588 lines removed (-427 net).

## How Has This Been Tested?

- `cargo check --package drive-abci --tests` — compiles cleanly with zero new warnings
- `cargo test --package drive-abci -- --test-threads=1 tests::proof_verification` — all 14 proof verification tests pass
- `cargo fmt --package drive-abci` — formatting verified

## Breaking Changes

None. This is a test-only refactoring with no changes to production code.

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [x] I have made corresponding changes to the documentation if needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Consolidated shielded transaction validation test utilities into centralized helpers to improve maintainability and eliminate code duplication across multiple test modules.

* **Chores**  
  * Reorganized internal test infrastructure for cryptographic bundle serialization and proving key handling in shield, shielded transfer, shielded withdrawal, and unshielding transaction validation tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->