### PR TITLE
test(drive-abci): improve abci handler test coverage

### DIFF
--- a/packages/rs-drive-abci/src/abci/handler/extend_vote.rs
+++ b/packages/rs-drive-abci/src/abci/handler/extend_vote.rs
@@ -186,6 +186,12 @@ mod tests {
 
         let result = extend_vote::<_, MockCoreRPCLike>(&app, request);
         assert!(result.is_err());
+        let err_string = result.unwrap_err().to_string();
+        assert!(
+            err_string.contains("request does not match current block"),
+            "Expected wrong block error, got: {}",
+            err_string
+        );
     }
 
     #[test]

--- a/packages/rs-drive-abci/src/abci/handler/extend_vote.rs
+++ b/packages/rs-drive-abci/src/abci/handler/extend_vote.rs
@@ -51,3 +51,170 @@ where
 
     Ok(proto::ResponseExtendVote { vote_extensions })
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::abci::app::FullAbciApplication;
+    use crate::execution::types::block_execution_context::v0::BlockExecutionContextV0;
+    use crate::execution::types::block_execution_context::BlockExecutionContext;
+    use crate::execution::types::block_state_info::v0::BlockStateInfoV0;
+    use crate::execution::types::block_state_info::BlockStateInfo;
+    use crate::platform_types::epoch_info::v0::EpochInfoV0;
+    use crate::platform_types::epoch_info::EpochInfo;
+    use crate::platform_types::platform_state::PlatformState;
+    use crate::platform_types::withdrawal::unsigned_withdrawal_txs::v0::UnsignedWithdrawalTxs;
+    use crate::rpc::core::MockCoreRPCLike;
+    use crate::test::helpers::setup::TestPlatformBuilder;
+    use dpp::version::PlatformVersion;
+    use std::collections::BTreeMap;
+
+    fn make_test_block_execution_context(
+        height: u64,
+        round: u32,
+        block_hash: Option<[u8; 32]>,
+        platform: &crate::platform_types::platform::Platform<MockCoreRPCLike>,
+    ) -> BlockExecutionContext {
+        let platform_version = PlatformVersion::latest();
+        BlockExecutionContext::V0(BlockExecutionContextV0 {
+            block_state_info: BlockStateInfo::V0(BlockStateInfoV0 {
+                height,
+                round,
+                block_time_ms: 1_000_000,
+                previous_block_time_ms: None,
+                proposer_pro_tx_hash: [0u8; 32],
+                core_chain_locked_height: 1,
+                block_hash,
+                app_hash: None,
+            }),
+            epoch_info: EpochInfo::V0(EpochInfoV0 {
+                current_epoch_index: 0,
+                previous_epoch_index: None,
+                is_epoch_change: false,
+            }),
+            unsigned_withdrawal_transactions: UnsignedWithdrawalTxs::default(),
+            block_address_balance_changes: BTreeMap::new(),
+            block_platform_state: PlatformState::default_with_protocol_versions(
+                platform_version.protocol_version,
+                platform_version.protocol_version,
+                &platform.config,
+            )
+            .expect("should create default platform state"),
+            proposer_results: None,
+        })
+    }
+
+    #[test]
+    fn extend_vote_fails_when_no_block_execution_context() {
+        let platform = TestPlatformBuilder::new()
+            .with_latest_protocol_version()
+            .build_with_mock_rpc();
+
+        let app = FullAbciApplication::<MockCoreRPCLike>::new(&platform.platform);
+
+        let request = proto::RequestExtendVote {
+            hash: vec![0u8; 32],
+            height: 10,
+            round: 0,
+        };
+
+        let result = extend_vote::<_, MockCoreRPCLike>(&app, request);
+        assert!(result.is_err());
+        let err_string = result.unwrap_err().to_string();
+        assert!(
+            err_string.contains("block execution context must be set"),
+            "Expected block execution context error, got: {}",
+            err_string
+        );
+    }
+
+    #[test]
+    fn extend_vote_fails_when_block_hash_does_not_match() {
+        let platform = TestPlatformBuilder::new()
+            .with_latest_protocol_version()
+            .build_with_mock_rpc();
+
+        let app = FullAbciApplication::<MockCoreRPCLike>::new(&platform.platform);
+
+        // Set block context at height 10, round 0 with specific hash
+        let context =
+            make_test_block_execution_context(10, 0, Some([0xAA; 32]), &platform.platform);
+        app.block_execution_context
+            .write()
+            .unwrap()
+            .replace(context);
+
+        // Request with a different hash
+        let request = proto::RequestExtendVote {
+            hash: vec![0xBB; 32],
+            height: 10,
+            round: 0,
+        };
+
+        let result = extend_vote::<_, MockCoreRPCLike>(&app, request);
+        assert!(result.is_err());
+        let err_string = result.unwrap_err().to_string();
+        assert!(
+            err_string.contains("request does not match current block"),
+            "Expected wrong block error, got: {}",
+            err_string
+        );
+    }
+
+    #[test]
+    fn extend_vote_fails_when_height_does_not_match() {
+        let platform = TestPlatformBuilder::new()
+            .with_latest_protocol_version()
+            .build_with_mock_rpc();
+
+        let app = FullAbciApplication::<MockCoreRPCLike>::new(&platform.platform);
+
+        // Set block context at height 10, round 0
+        let context =
+            make_test_block_execution_context(10, 0, Some([0xAA; 32]), &platform.platform);
+        app.block_execution_context
+            .write()
+            .unwrap()
+            .replace(context);
+
+        // Request for a different height
+        let request = proto::RequestExtendVote {
+            hash: vec![0xAA; 32],
+            height: 20,
+            round: 0,
+        };
+
+        let result = extend_vote::<_, MockCoreRPCLike>(&app, request);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn extend_vote_succeeds_with_matching_block_and_empty_withdrawals() {
+        let platform = TestPlatformBuilder::new()
+            .with_latest_protocol_version()
+            .build_with_mock_rpc();
+
+        let app = FullAbciApplication::<MockCoreRPCLike>::new(&platform.platform);
+
+        // Set block context at height 10, round 0 with specific hash
+        let context =
+            make_test_block_execution_context(10, 0, Some([0xAA; 32]), &platform.platform);
+        app.block_execution_context
+            .write()
+            .unwrap()
+            .replace(context);
+
+        // Request with matching hash, height, round
+        let request = proto::RequestExtendVote {
+            hash: vec![0xAA; 32],
+            height: 10,
+            round: 0,
+        };
+
+        let response =
+            extend_vote::<_, MockCoreRPCLike>(&app, request).expect("extend_vote should succeed");
+
+        // No withdrawal transactions, so no vote extensions
+        assert!(response.vote_extensions.is_empty());
+    }
+}

--- a/packages/rs-drive-abci/src/abci/handler/finalize_block.rs
+++ b/packages/rs-drive-abci/src/abci/handler/finalize_block.rs
@@ -128,13 +128,12 @@ mod tests {
         };
 
         let result = finalize_block::<_, MockCoreRPCLike>(&app, request);
-        assert!(result.is_err());
-        let err_string = result.unwrap_err().to_string();
         assert!(
-            err_string.contains("not in transaction")
-                || err_string.contains("trying to finalize block without"),
-            "Expected 'not in transaction' error, got: {}",
-            err_string
+            matches!(
+                result,
+                Err(Error::Execution(ExecutionError::NotInTransaction(_)))
+            ),
+            "Expected NotInTransaction error, got: {result:?}"
         );
     }
 
@@ -157,12 +156,12 @@ mod tests {
         };
 
         let result = finalize_block::<_, MockCoreRPCLike>(&app, request);
-        assert!(result.is_err());
-        let err_string = result.unwrap_err().to_string();
         assert!(
-            err_string.contains("block execution context must be set"),
-            "Expected 'block execution context must be set' error, got: {}",
-            err_string
+            matches!(
+                result,
+                Err(Error::Execution(ExecutionError::CorruptedCodeExecution(_)))
+            ),
+            "Expected CorruptedCodeExecution error, got: {result:?}"
         );
     }
 }

--- a/packages/rs-drive-abci/src/abci/handler/finalize_block.rs
+++ b/packages/rs-drive-abci/src/abci/handler/finalize_block.rs
@@ -103,3 +103,66 @@ where
 
     Ok(proto::ResponseFinalizeBlock { retain_height: 0 })
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::abci::app::{FullAbciApplication, TransactionalApplication};
+    use crate::rpc::core::MockCoreRPCLike;
+    use crate::test::helpers::setup::TestPlatformBuilder;
+
+    #[test]
+    fn finalize_block_fails_when_no_transaction() {
+        let platform = TestPlatformBuilder::new()
+            .with_latest_protocol_version()
+            .build_with_mock_rpc();
+
+        let app = FullAbciApplication::<MockCoreRPCLike>::new(&platform.platform);
+
+        // No transaction started, no block execution context
+        let request = proto::RequestFinalizeBlock {
+            hash: vec![0u8; 32],
+            height: 1,
+            round: 0,
+            ..Default::default()
+        };
+
+        let result = finalize_block::<_, MockCoreRPCLike>(&app, request);
+        assert!(result.is_err());
+        let err_string = result.unwrap_err().to_string();
+        assert!(
+            err_string.contains("not in transaction")
+                || err_string.contains("trying to finalize block without"),
+            "Expected 'not in transaction' error, got: {}",
+            err_string
+        );
+    }
+
+    #[test]
+    fn finalize_block_fails_when_no_block_execution_context() {
+        let platform = TestPlatformBuilder::new()
+            .with_latest_protocol_version()
+            .build_with_mock_rpc();
+
+        let app = FullAbciApplication::<MockCoreRPCLike>::new(&platform.platform);
+
+        // Start a transaction but do not set block execution context
+        app.start_transaction();
+
+        let request = proto::RequestFinalizeBlock {
+            hash: vec![0u8; 32],
+            height: 1,
+            round: 0,
+            ..Default::default()
+        };
+
+        let result = finalize_block::<_, MockCoreRPCLike>(&app, request);
+        assert!(result.is_err());
+        let err_string = result.unwrap_err().to_string();
+        assert!(
+            err_string.contains("block execution context must be set"),
+            "Expected 'block execution context must be set' error, got: {}",
+            err_string
+        );
+    }
+}

--- a/packages/rs-drive-abci/src/abci/handler/info.rs
+++ b/packages/rs-drive-abci/src/abci/handler/info.rs
@@ -95,3 +95,63 @@ where
 
     Ok(response)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::abci::app::FullAbciApplication;
+    use crate::rpc::core::MockCoreRPCLike;
+    use crate::test::helpers::setup::TestPlatformBuilder;
+
+    #[test]
+    fn info_abci_version_mismatch_returns_error() {
+        let platform = TestPlatformBuilder::new()
+            .with_latest_protocol_version()
+            .build_with_mock_rpc();
+
+        let app = FullAbciApplication::new(&platform.platform);
+
+        // Use a valid semver but with a much higher minor version to guarantee mismatch.
+        // The check_version function panics on non-semver strings, so we must
+        // provide a valid semver that does not satisfy the compatibility requirement.
+        let request = proto::RequestInfo {
+            version: "test".to_string(),
+            block_version: 0,
+            p2p_version: 0,
+            abci_version: "999.999.999".to_string(),
+        };
+
+        let result = info::<_, MockCoreRPCLike>(&app, request);
+
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        let err_string = err.to_string();
+        assert!(
+            err_string.contains("ABCI version mismatch"),
+            "Expected ABCI version mismatch error, got: {}",
+            err_string
+        );
+    }
+
+    #[test]
+    fn info_successful_handshake_returns_response() {
+        let platform = TestPlatformBuilder::new()
+            .with_latest_protocol_version()
+            .build_with_mock_rpc();
+
+        let app = FullAbciApplication::new(&platform.platform);
+
+        let request = proto::RequestInfo {
+            version: "test".to_string(),
+            block_version: 0,
+            p2p_version: 0,
+            abci_version: tenderdash_abci::proto::ABCI_VERSION.to_string(),
+        };
+
+        let response = info::<_, MockCoreRPCLike>(&app, request).expect("info should succeed");
+
+        assert_eq!(response.last_block_height, 0);
+        assert!(!response.version.is_empty());
+        assert!(response.app_version > 0);
+    }
+}

--- a/packages/rs-drive-abci/src/abci/handler/info.rs
+++ b/packages/rs-drive-abci/src/abci/handler/info.rs
@@ -151,7 +151,10 @@ mod tests {
         let response = info::<_, MockCoreRPCLike>(&app, request).expect("info should succeed");
 
         assert_eq!(response.last_block_height, 0);
-        assert!(!response.version.is_empty());
-        assert!(response.app_version > 0);
+        assert_eq!(response.version, env!("CARGO_PKG_VERSION"));
+        assert_eq!(
+            response.app_version,
+            DESIRED_PLATFORM_VERSION.protocol_version as u64
+        );
     }
 }

--- a/packages/rs-drive-abci/src/abci/handler/init_chain.rs
+++ b/packages/rs-drive-abci/src/abci/handler/init_chain.rs
@@ -40,3 +40,86 @@ where
 
     Ok(response)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::abci::app::FullAbciApplication;
+    use crate::execution::types::block_execution_context::v0::BlockExecutionContextV0;
+    use crate::execution::types::block_execution_context::BlockExecutionContext;
+    use crate::execution::types::block_state_info::v0::BlockStateInfoV0;
+    use crate::execution::types::block_state_info::BlockStateInfo;
+    use crate::platform_types::epoch_info::v0::EpochInfoV0;
+    use crate::platform_types::epoch_info::EpochInfo;
+    use crate::platform_types::platform_state::PlatformState;
+    use crate::platform_types::withdrawal::unsigned_withdrawal_txs::v0::UnsignedWithdrawalTxs;
+    use crate::rpc::core::MockCoreRPCLike;
+    use crate::test::helpers::setup::TestPlatformBuilder;
+    use dpp::version::PlatformVersion;
+    use std::collections::BTreeMap;
+
+    #[test]
+    fn init_chain_drops_existing_block_execution_context() {
+        let platform = TestPlatformBuilder::new()
+            .with_latest_protocol_version()
+            .build_with_mock_rpc();
+
+        let app = FullAbciApplication::<MockCoreRPCLike>::new(&platform.platform);
+        let platform_version = PlatformVersion::latest();
+
+        // Place an existing block execution context to exercise the "drop" branch
+        let existing_context = BlockExecutionContext::V0(BlockExecutionContextV0 {
+            block_state_info: BlockStateInfo::V0(BlockStateInfoV0 {
+                height: 5,
+                round: 0,
+                block_time_ms: 1_000_000,
+                previous_block_time_ms: None,
+                proposer_pro_tx_hash: [0u8; 32],
+                core_chain_locked_height: 1,
+                block_hash: None,
+                app_hash: None,
+            }),
+            epoch_info: EpochInfo::V0(EpochInfoV0 {
+                current_epoch_index: 0,
+                previous_epoch_index: None,
+                is_epoch_change: false,
+            }),
+            unsigned_withdrawal_transactions: UnsignedWithdrawalTxs::default(),
+            block_address_balance_changes: BTreeMap::new(),
+            block_platform_state: PlatformState::default_with_protocol_versions(
+                platform_version.protocol_version,
+                platform_version.protocol_version,
+                &platform.config,
+            )
+            .expect("should create default platform state"),
+            proposer_results: None,
+        });
+
+        app.block_execution_context
+            .write()
+            .unwrap()
+            .replace(existing_context);
+
+        // The block execution context is now present, init_chain should drop it
+        // and then attempt to initialize the chain
+        // We are not providing a valid genesis request, so this will likely fail
+        // after dropping the context, but that still exercises the drop path
+
+        let request = proto::RequestInitChain {
+            time: Some(tenderdash_abci::proto::google::protobuf::Timestamp {
+                seconds: 1700000000,
+                nanos: 0,
+            }),
+            chain_id: "test-chain".to_string(),
+            ..Default::default()
+        };
+
+        // The result will fail because init_chain requires valid genesis data,
+        // but the important thing is that the drop path was exercised.
+        // We just verify that block_execution_context was cleared.
+        let _result = init_chain::<_, MockCoreRPCLike>(&app, request);
+
+        // The block execution context should have been taken (dropped)
+        // during init_chain before it processes genesis state
+    }
+}

--- a/packages/rs-drive-abci/src/abci/handler/init_chain.rs
+++ b/packages/rs-drive-abci/src/abci/handler/init_chain.rs
@@ -117,9 +117,11 @@ mod tests {
         // The result will fail because init_chain requires valid genesis data,
         // but the important thing is that the drop path was exercised.
         // We just verify that block_execution_context was cleared.
-        let _result = init_chain::<_, MockCoreRPCLike>(&app, request);
+        let _ = init_chain::<_, MockCoreRPCLike>(&app, request);
 
-        // The block execution context should have been taken (dropped)
-        // during init_chain before it processes genesis state
+        assert!(
+            app.block_execution_context.read().unwrap().is_none(),
+            "expected init_chain to clear existing block execution context"
+        );
     }
 }

--- a/packages/rs-drive-abci/src/abci/handler/verify_vote_extension.rs
+++ b/packages/rs-drive-abci/src/abci/handler/verify_vote_extension.rs
@@ -94,3 +94,208 @@ where
         status: VerifyStatus::Accept.into(),
     })
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::abci::app::FullAbciApplication;
+    use crate::execution::types::block_execution_context::v0::BlockExecutionContextV0;
+    use crate::execution::types::block_execution_context::BlockExecutionContext;
+    use crate::execution::types::block_state_info::v0::BlockStateInfoV0;
+    use crate::execution::types::block_state_info::BlockStateInfo;
+    use crate::platform_types::epoch_info::v0::EpochInfoV0;
+    use crate::platform_types::epoch_info::EpochInfo;
+    use crate::platform_types::platform_state::PlatformState;
+    use crate::platform_types::withdrawal::unsigned_withdrawal_txs::v0::UnsignedWithdrawalTxs;
+    use crate::rpc::core::MockCoreRPCLike;
+    use crate::test::helpers::setup::TestPlatformBuilder;
+    use dpp::version::PlatformVersion;
+    use std::collections::BTreeMap;
+
+    fn make_test_block_execution_context(
+        height: u64,
+        round: u32,
+        block_hash: Option<[u8; 32]>,
+        platform: &crate::platform_types::platform::Platform<MockCoreRPCLike>,
+    ) -> BlockExecutionContext {
+        let platform_version = PlatformVersion::latest();
+        BlockExecutionContext::V0(BlockExecutionContextV0 {
+            block_state_info: BlockStateInfo::V0(BlockStateInfoV0 {
+                height,
+                round,
+                block_time_ms: 1_000_000,
+                previous_block_time_ms: None,
+                proposer_pro_tx_hash: [0u8; 32],
+                core_chain_locked_height: 1,
+                block_hash,
+                app_hash: None,
+            }),
+            epoch_info: EpochInfo::V0(EpochInfoV0 {
+                current_epoch_index: 0,
+                previous_epoch_index: None,
+                is_epoch_change: false,
+            }),
+            unsigned_withdrawal_transactions: UnsignedWithdrawalTxs::default(),
+            block_address_balance_changes: BTreeMap::new(),
+            block_platform_state: PlatformState::default_with_protocol_versions(
+                platform_version.protocol_version,
+                platform_version.protocol_version,
+                &platform.config,
+            )
+            .expect("should create default platform state"),
+            proposer_results: None,
+        })
+    }
+
+    #[test]
+    fn verify_vote_extension_rejects_when_no_block_execution_context() {
+        let platform = TestPlatformBuilder::new()
+            .with_latest_protocol_version()
+            .build_with_mock_rpc();
+
+        let app = FullAbciApplication::<MockCoreRPCLike>::new(&platform.platform);
+
+        // No block execution context is set
+        let request = proto::RequestVerifyVoteExtension {
+            hash: vec![0u8; 32],
+            validator_pro_tx_hash: vec![0u8; 32],
+            height: 10,
+            round: 0,
+            vote_extensions: vec![],
+        };
+
+        let response = verify_vote_extension::<_, MockCoreRPCLike>(&app, request)
+            .expect("should return Ok with Reject status");
+
+        assert_eq!(response.status, VerifyStatus::Reject as i32);
+    }
+
+    #[test]
+    fn verify_vote_extension_rejects_when_height_mismatch() {
+        let platform = TestPlatformBuilder::new()
+            .with_latest_protocol_version()
+            .build_with_mock_rpc();
+
+        let app = FullAbciApplication::<MockCoreRPCLike>::new(&platform.platform);
+
+        // Set block execution context at height 10
+        let context =
+            make_test_block_execution_context(10, 0, Some([0xAA; 32]), &platform.platform);
+        app.block_execution_context
+            .write()
+            .unwrap()
+            .replace(context);
+
+        // Request verification for a different height (20)
+        let request = proto::RequestVerifyVoteExtension {
+            hash: vec![0u8; 32],
+            validator_pro_tx_hash: vec![0u8; 32],
+            height: 20,
+            round: 0,
+            vote_extensions: vec![],
+        };
+
+        let response = verify_vote_extension::<_, MockCoreRPCLike>(&app, request)
+            .expect("should return Ok with Reject status");
+
+        assert_eq!(response.status, VerifyStatus::Reject as i32);
+    }
+
+    #[test]
+    fn verify_vote_extension_accepts_matching_empty_withdrawals() {
+        let platform = TestPlatformBuilder::new()
+            .with_latest_protocol_version()
+            .build_with_mock_rpc();
+
+        let app = FullAbciApplication::<MockCoreRPCLike>::new(&platform.platform);
+
+        // Set block execution context at height 10, with empty withdrawal transactions
+        let context =
+            make_test_block_execution_context(10, 0, Some([0xAA; 32]), &platform.platform);
+        app.block_execution_context
+            .write()
+            .unwrap()
+            .replace(context);
+
+        // Request with matching empty vote extensions
+        let request = proto::RequestVerifyVoteExtension {
+            hash: vec![0u8; 32],
+            validator_pro_tx_hash: vec![0u8; 32],
+            height: 10,
+            round: 0,
+            vote_extensions: vec![],
+        };
+
+        let response = verify_vote_extension::<_, MockCoreRPCLike>(&app, request)
+            .expect("should return Ok with Accept status");
+
+        assert_eq!(response.status, VerifyStatus::Accept as i32);
+    }
+
+    #[test]
+    fn verify_vote_extension_rejects_mismatched_withdrawals() {
+        let platform = TestPlatformBuilder::new()
+            .with_latest_protocol_version()
+            .build_with_mock_rpc();
+
+        let app = FullAbciApplication::<MockCoreRPCLike>::new(&platform.platform);
+
+        // Set block execution context at height 10 with empty withdrawal transactions
+        let context =
+            make_test_block_execution_context(10, 0, Some([0xAA; 32]), &platform.platform);
+        app.block_execution_context
+            .write()
+            .unwrap()
+            .replace(context);
+
+        // Request with non-empty vote extensions (mismatch)
+        let request = proto::RequestVerifyVoteExtension {
+            hash: vec![0u8; 32],
+            validator_pro_tx_hash: vec![0u8; 32],
+            height: 10,
+            round: 0,
+            vote_extensions: vec![proto::ExtendVoteExtension {
+                r#type: 0,
+                extension: vec![1, 2, 3],
+                sign_request_id: None,
+            }],
+        };
+
+        let response = verify_vote_extension::<_, MockCoreRPCLike>(&app, request)
+            .expect("should return Ok with Reject status");
+
+        assert_eq!(response.status, VerifyStatus::Reject as i32);
+    }
+
+    #[test]
+    fn verify_vote_extension_accepts_different_round_same_height() {
+        let platform = TestPlatformBuilder::new()
+            .with_latest_protocol_version()
+            .build_with_mock_rpc();
+
+        let app = FullAbciApplication::<MockCoreRPCLike>::new(&platform.platform);
+
+        // Set block execution context at height 10, round 1
+        let context =
+            make_test_block_execution_context(10, 1, Some([0xAA; 32]), &platform.platform);
+        app.block_execution_context
+            .write()
+            .unwrap()
+            .replace(context);
+
+        // Request for same height but different round (round 5)
+        // This should still be accepted since only height needs to match
+        let request = proto::RequestVerifyVoteExtension {
+            hash: vec![0u8; 32],
+            validator_pro_tx_hash: vec![0u8; 32],
+            height: 10,
+            round: 5,
+            vote_extensions: vec![],
+        };
+
+        let response = verify_vote_extension::<_, MockCoreRPCLike>(&app, request)
+            .expect("should return Ok with Accept status");
+
+        assert_eq!(response.status, VerifyStatus::Accept as i32);
+    }
+}


### PR DESCRIPTION
## Issue being fixed or feature implemented

Improve test coverage for the `packages/rs-drive-abci/src/abci/handler/` module by adding unit tests for previously uncovered error branches and edge cases.

## What was done?

Added targeted unit tests to five handler files that previously lacked test coverage for error paths:

**info.rs** (2 tests):
- ABCI version mismatch returns proper error
- Successful handshake returns valid response with version info

**extend_vote.rs** (4 tests):
- Missing block execution context returns error
- Block hash mismatch returns "request does not match current block" error
- Height mismatch returns error
- Matching block with empty withdrawals succeeds

**verify_vote_extension.rs** (5 tests):
- No block execution context returns Reject status
- Height mismatch returns Reject status
- Empty matching withdrawals returns Accept status
- Mismatched withdrawal vote extensions returns Reject status
- Different round but same height still returns Accept (correct behavior per code comments)

**finalize_block.rs** (2 tests):
- No transaction started returns "not in transaction" error
- Transaction exists but no block execution context returns proper error

**init_chain.rs** (1 test):
- Existing block execution context is properly dropped during init_chain

## How Has This Been Tested?

All 47 handler tests pass:
```
cargo test --package drive-abci --lib --features mocks -- abci::handler
test result: ok. 47 passed; 0 failed; 0 ignored; 0 measured; 1893 filtered out
```

Code passes clippy with no warnings:
```
cargo clippy --package drive-abci --lib --features mocks -- -D warnings
```

## Breaking Changes

None. This PR only adds test code.

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [x] I have made corresponding changes to the documentation if needed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added extensive unit tests across ABCI handlers (extend vote, verify vote extension, finalize block, info, init chain). Includes new test helpers and covers error scenarios when required contexts or versions are missing/mismatched, state-drop behavior, parameter validation, and successful execution paths. No public interfaces changed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->