### PR TITLE
test(drive-abci): improve validator_set_update v2 coverage, ignore v0/v1

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -17,6 +17,8 @@ ignore:
   - "packages/wasm-dpp/**"
   - "packages/wasm-dpp2/**"
   - "packages/wasm-sdk/**"
+  - "**/block_end/validator_set_update/v0/**"
+  - "**/block_end/validator_set_update/v1/**"
 
 coverage:
   status:

--- a/packages/rs-drive-abci/src/execution/platform_events/block_end/validator_set_update/mod.rs
+++ b/packages/rs-drive-abci/src/execution/platform_events/block_end/validator_set_update/mod.rs
@@ -149,4 +149,827 @@ mod tests {
             _ => panic!("expected UnknownVersionMismatch error"),
         }
     }
+
+    mod v2_tests {
+        use super::*;
+        use crate::execution::types::block_execution_context::v0::BlockExecutionContextV0Getters;
+        use crate::platform_types::platform_state::PlatformStateV0Methods;
+        use dpp::block::block_info::BlockInfo;
+        use dpp::block::extended_block_info::v0::ExtendedBlockInfoV0;
+        use dpp::block::extended_block_info::ExtendedBlockInfo;
+        use dpp::bls_signatures::{Bls12381G2Impl, SecretKey};
+        use dpp::core_types::validator::v0::ValidatorV0;
+        use dpp::core_types::validator_set::v0::ValidatorSetV0;
+        use dpp::core_types::validator_set::ValidatorSet;
+        use dpp::dashcore::hashes::Hash;
+        use dpp::dashcore::{ProTxHash, PubkeyHash, QuorumHash};
+        use indexmap::IndexMap;
+        use rand::rngs::StdRng;
+        use rand::SeedableRng;
+
+        /// Initialize a tracing subscriber at DEBUG level so that tracing::debug!
+        /// macro arguments are fully evaluated, improving code coverage metrics.
+        fn init_debug_tracing() -> tracing::subscriber::DefaultGuard {
+            let subscriber = tracing_subscriber::fmt()
+                .with_max_level(tracing::Level::DEBUG)
+                .with_test_writer()
+                .finish();
+            tracing::subscriber::set_default(subscriber)
+        }
+
+        /// Helper to create a ValidatorSetV0 with members whose ProTxHash values
+        /// are derived from the given byte seeds. Members are inserted into a BTreeMap,
+        /// so they are sorted by ProTxHash.
+        fn make_validator_set(
+            quorum_hash: QuorumHash,
+            member_seeds: &[u8],
+            rng: &mut StdRng,
+        ) -> ValidatorSet {
+            let threshold_public_key = SecretKey::<Bls12381G2Impl>::random(&mut *rng).public_key();
+            let mut members = BTreeMap::new();
+            for &seed in member_seeds {
+                let mut hash_bytes = [0u8; 32];
+                hash_bytes[31] = seed;
+                let pro_tx_hash = ProTxHash::from_byte_array(hash_bytes);
+                let public_key = Some(SecretKey::<Bls12381G2Impl>::random(&mut *rng).public_key());
+                let node_id = PubkeyHash::from_byte_array([seed; 20]);
+                let validator = ValidatorV0 {
+                    pro_tx_hash,
+                    public_key,
+                    node_ip: format!("10.0.0.{}", seed),
+                    node_id,
+                    core_port: 9999,
+                    platform_http_port: 1443,
+                    platform_p2p_port: 26656,
+                    is_banned: false,
+                };
+                members.insert(pro_tx_hash, validator);
+            }
+            ValidatorSet::V0(ValidatorSetV0 {
+                quorum_hash,
+                quorum_index: None,
+                core_height: 100,
+                members,
+                threshold_public_key,
+            })
+        }
+
+        fn quorum_hash_from_seed(seed: u8) -> QuorumHash {
+            let mut bytes = [0u8; 32];
+            bytes[31] = seed;
+            QuorumHash::from_byte_array(bytes)
+        }
+
+        fn make_extended_block_info(
+            quorum_hash: [u8; 32],
+            proposer_pro_tx_hash: [u8; 32],
+            height: u64,
+        ) -> ExtendedBlockInfo {
+            ExtendedBlockInfo::V0(ExtendedBlockInfoV0 {
+                basic_info: BlockInfo {
+                    time_ms: 1_000_000,
+                    height,
+                    core_height: 100,
+                    epoch: Default::default(),
+                },
+                app_hash: [0u8; 32],
+                quorum_hash,
+                block_id_hash: [0u8; 32],
+                proposer_pro_tx_hash,
+                signature: [0u8; 96],
+                round: 0,
+            })
+        }
+
+        /// No rotation needed: proposer is mid-quorum, same quorum, no changes.
+        /// Covers the else branch at line 200 and the "no validator set update" path at line 212.
+        #[test]
+        fn v2_no_rotation_no_changes() {
+            let _guard = init_debug_tracing();
+            let platform = TestPlatformBuilder::new()
+                .build_with_mock_rpc()
+                .set_genesis_state();
+
+            let mut rng = StdRng::seed_from_u64(42);
+            let qh = quorum_hash_from_seed(1);
+            // Members: seeds 10, 20, 30. BTreeMap sorts by ProTxHash bytes.
+            // [0..0,10] < [0..0,20] < [0..0,30]
+            let vs = make_validator_set(qh, &[10, 20, 30], &mut rng);
+
+            let mut validator_sets = IndexMap::new();
+            validator_sets.insert(qh, vs);
+
+            // Set up platform_state: current quorum = qh, proposer = member 20 (middle)
+            let mut platform_state = platform.state.load().as_ref().clone();
+            platform_state.set_current_validator_set_quorum_hash(qh);
+            platform_state.set_validator_sets(validator_sets.clone());
+            // last_committed info: same quorum, proposer 10 (before 20 = no wrap)
+            let mut proposer_bytes = [0u8; 32];
+            proposer_bytes[31] = 10;
+            platform_state.set_last_committed_block_info(Some(make_extended_block_info(
+                *qh.as_byte_array(),
+                proposer_bytes,
+                5,
+            )));
+
+            // block_platform_state is same as platform_state
+            let block_platform_state = platform_state.clone();
+            let mut block_execution_context = make_block_execution_context(block_platform_state);
+
+            // proposer is member 20 (not last member = 30, not wrapping around)
+            let mut proposer = [0u8; 32];
+            proposer[31] = 20;
+
+            let result = platform
+                .validator_set_update_v2(proposer, &platform_state, &mut block_execution_context)
+                .expect("should succeed");
+
+            assert!(result.is_none(), "no rotation and no changes expected");
+        }
+
+        /// No rotation but validator set has changed (e.g., IP changed).
+        /// Covers the "validator set update without rotation" path at line 204-211.
+        #[test]
+        fn v2_no_rotation_with_validator_change() {
+            let _guard = init_debug_tracing();
+            let platform = TestPlatformBuilder::new()
+                .build_with_mock_rpc()
+                .set_genesis_state();
+
+            let mut rng = StdRng::seed_from_u64(43);
+            let qh = quorum_hash_from_seed(1);
+            let vs = make_validator_set(qh, &[10, 20, 30], &mut rng);
+
+            let mut validator_sets = IndexMap::new();
+            validator_sets.insert(qh, vs.clone());
+
+            // platform_state has original validator set
+            let mut platform_state = platform.state.load().as_ref().clone();
+            platform_state.set_current_validator_set_quorum_hash(qh);
+            platform_state.set_validator_sets(validator_sets.clone());
+            let mut proposer_bytes = [0u8; 32];
+            proposer_bytes[31] = 10;
+            platform_state.set_last_committed_block_info(Some(make_extended_block_info(
+                *qh.as_byte_array(),
+                proposer_bytes,
+                5,
+            )));
+
+            // block_platform_state has a modified validator set (different IP for one member)
+            let mut modified_vs = vs.clone();
+            let ValidatorSet::V0(ref mut v0) = modified_vs;
+            let first_key = *v0.members.keys().next().unwrap();
+            v0.members.get_mut(&first_key).unwrap().node_ip = "10.0.0.99".to_string();
+            let mut block_validator_sets = IndexMap::new();
+            block_validator_sets.insert(qh, modified_vs);
+
+            let mut block_platform_state = platform_state.clone();
+            block_platform_state.set_validator_sets(block_validator_sets);
+
+            let mut block_execution_context = make_block_execution_context(block_platform_state);
+
+            // proposer is member 20 (middle, not triggering rotation)
+            let mut proposer = [0u8; 32];
+            proposer[31] = 20;
+
+            let result = platform
+                .validator_set_update_v2(proposer, &platform_state, &mut block_execution_context)
+                .expect("should succeed");
+
+            assert!(
+                result.is_some(),
+                "should return update due to validator change"
+            );
+        }
+
+        /// Rotation triggered because proposer is the last member of the quorum.
+        /// With 2 quorums, should rotate to the next one.
+        /// Covers lines 46-62 (last member match) and 134-172 (rotation to next quorum).
+        #[test]
+        fn v2_rotation_last_member_two_quorums() {
+            let _guard = init_debug_tracing();
+            let platform = TestPlatformBuilder::new()
+                .build_with_mock_rpc()
+                .set_genesis_state();
+
+            let mut rng = StdRng::seed_from_u64(44);
+            let qh1 = quorum_hash_from_seed(1);
+            let qh2 = quorum_hash_from_seed(2);
+            let vs1 = make_validator_set(qh1, &[10, 20, 30], &mut rng);
+            let vs2 = make_validator_set(qh2, &[40, 50, 60], &mut rng);
+
+            let mut validator_sets = IndexMap::new();
+            validator_sets.insert(qh1, vs1.clone());
+            validator_sets.insert(qh2, vs2.clone());
+
+            let mut platform_state = platform.state.load().as_ref().clone();
+            platform_state.set_current_validator_set_quorum_hash(qh1);
+            platform_state.set_validator_sets(validator_sets.clone());
+            // Set last committed block info so last_committed_quorum_hash works
+            let mut proposer_bytes = [0u8; 32];
+            proposer_bytes[31] = 20;
+            platform_state.set_last_committed_block_info(Some(make_extended_block_info(
+                *qh1.as_byte_array(),
+                proposer_bytes,
+                5,
+            )));
+
+            // block_platform_state has same validator sets
+            let block_platform_state = platform_state.clone();
+            let mut block_execution_context = make_block_execution_context(block_platform_state);
+
+            // Proposer is the LAST member (seed 30 -> highest ProTxHash in BTreeMap)
+            let mut proposer = [0u8; 32];
+            proposer[31] = 30;
+
+            let result = platform
+                .validator_set_update_v2(proposer, &platform_state, &mut block_execution_context)
+                .expect("should succeed");
+
+            assert!(result.is_some(), "should rotate to next quorum");
+
+            // Verify the next quorum hash was set on block execution context
+            let next_qh = block_execution_context
+                .block_platform_state()
+                .next_validator_set_quorum_hash();
+            assert_eq!(*next_qh, Some(qh2));
+        }
+
+        /// Rotation triggered because the validator set has no members (empty quorum).
+        /// With only 1 quorum in system -> quorum_count == 1 -> Ok(None).
+        /// Covers lines 63-70 (no members) and line 133 (single quorum = no rotation).
+        #[test]
+        fn v2_rotation_empty_members_single_quorum() {
+            let _guard = init_debug_tracing();
+            let platform = TestPlatformBuilder::new()
+                .build_with_mock_rpc()
+                .set_genesis_state();
+
+            let mut rng = StdRng::seed_from_u64(45);
+            let qh = quorum_hash_from_seed(1);
+            let threshold_pk = SecretKey::<Bls12381G2Impl>::random(&mut rng).public_key();
+            let empty_vs = ValidatorSet::V0(ValidatorSetV0 {
+                quorum_hash: qh,
+                quorum_index: None,
+                core_height: 100,
+                members: BTreeMap::new(),
+                threshold_public_key: threshold_pk,
+            });
+
+            let mut validator_sets = IndexMap::new();
+            validator_sets.insert(qh, empty_vs);
+
+            let mut platform_state = platform.state.load().as_ref().clone();
+            platform_state.set_current_validator_set_quorum_hash(qh);
+            platform_state.set_validator_sets(validator_sets.clone());
+
+            let block_platform_state = platform_state.clone();
+            let mut block_execution_context = make_block_execution_context(block_platform_state);
+
+            let result = platform
+                .validator_set_update_v2([0u8; 32], &platform_state, &mut block_execution_context)
+                .expect("should succeed");
+
+            // Only one quorum, so no rotation target
+            assert!(result.is_none(), "single quorum means no rotation target");
+        }
+
+        /// Rotation triggered because proposer wraps around (new proposer < last proposer)
+        /// with more than one quorum available.
+        /// Covers lines 76-99 (wrap-around detection).
+        #[test]
+        fn v2_rotation_proposer_wrap_around() {
+            let _guard = init_debug_tracing();
+            let platform = TestPlatformBuilder::new()
+                .build_with_mock_rpc()
+                .set_genesis_state();
+
+            let mut rng = StdRng::seed_from_u64(46);
+            let qh1 = quorum_hash_from_seed(1);
+            let qh2 = quorum_hash_from_seed(2);
+            let vs1 = make_validator_set(qh1, &[10, 20, 30], &mut rng);
+            let vs2 = make_validator_set(qh2, &[40, 50, 60], &mut rng);
+
+            let mut validator_sets = IndexMap::new();
+            validator_sets.insert(qh1, vs1);
+            validator_sets.insert(qh2, vs2);
+
+            let mut platform_state = platform.state.load().as_ref().clone();
+            platform_state.set_current_validator_set_quorum_hash(qh1);
+            platform_state.set_validator_sets(validator_sets.clone());
+
+            // last committed: same quorum (qh1), proposer = 20
+            let mut last_proposer = [0u8; 32];
+            last_proposer[31] = 20;
+            platform_state.set_last_committed_block_info(Some(make_extended_block_info(
+                *qh1.as_byte_array(),
+                last_proposer,
+                5,
+            )));
+
+            let block_platform_state = platform_state.clone();
+            let mut block_execution_context = make_block_execution_context(block_platform_state);
+
+            // New proposer = 10 which is LESS than last proposer = 20 -> wrap around
+            // Same quorum and >1 quorum in system -> triggers rotation
+            let mut proposer = [0u8; 32];
+            proposer[31] = 10;
+
+            let result = platform
+                .validator_set_update_v2(proposer, &platform_state, &mut block_execution_context)
+                .expect("should succeed");
+
+            assert!(result.is_some(), "should rotate due to wrap-around");
+        }
+
+        /// Rotation triggered because the current quorum is not in the new block's validator sets.
+        /// Covers lines 100-113 (quorum removed from block state).
+        #[test]
+        fn v2_rotation_quorum_removed() {
+            let _guard = init_debug_tracing();
+            let platform = TestPlatformBuilder::new()
+                .build_with_mock_rpc()
+                .set_genesis_state();
+
+            let mut rng = StdRng::seed_from_u64(47);
+            let qh1 = quorum_hash_from_seed(1);
+            let qh2 = quorum_hash_from_seed(2);
+            let qh3 = quorum_hash_from_seed(3);
+            let vs1 = make_validator_set(qh1, &[10, 20, 30], &mut rng);
+            let vs2 = make_validator_set(qh2, &[40, 50, 60], &mut rng);
+            let vs3 = make_validator_set(qh3, &[70, 80, 90], &mut rng);
+
+            // platform_state has qh1, qh2
+            let mut platform_validator_sets = IndexMap::new();
+            platform_validator_sets.insert(qh1, vs1);
+            platform_validator_sets.insert(qh2, vs2);
+
+            let mut platform_state = platform.state.load().as_ref().clone();
+            platform_state.set_current_validator_set_quorum_hash(qh1);
+            platform_state.set_validator_sets(platform_validator_sets);
+
+            // block_platform_state does NOT have qh1, has qh2, qh3 instead
+            let mut block_validator_sets = IndexMap::new();
+            block_validator_sets.insert(qh2, make_validator_set(qh2, &[40, 50, 60], &mut rng));
+            block_validator_sets.insert(qh3, vs3);
+
+            let mut block_platform_state = platform_state.clone();
+            block_platform_state.set_validator_sets(block_validator_sets);
+
+            let mut block_execution_context = make_block_execution_context(block_platform_state);
+
+            let result = platform
+                .validator_set_update_v2([0u8; 32], &platform_state, &mut block_execution_context)
+                .expect("should succeed");
+
+            assert!(
+                result.is_some(),
+                "should rotate because current quorum was removed"
+            );
+            // Should rotate to qh2 (next index after qh1 that still exists in block state)
+            let next_qh = block_execution_context
+                .block_platform_state()
+                .next_validator_set_quorum_hash();
+            assert_eq!(*next_qh, Some(qh2));
+        }
+
+        /// All quorums changed: platform_state quorums don't exist in block state.
+        /// Falls through the rotation loop and hits the "all quorums changed" fallback.
+        /// Covers lines 179-194.
+        #[test]
+        fn v2_rotation_all_quorums_changed() {
+            let _guard = init_debug_tracing();
+            let platform = TestPlatformBuilder::new()
+                .build_with_mock_rpc()
+                .set_genesis_state();
+
+            let mut rng = StdRng::seed_from_u64(48);
+            let qh1 = quorum_hash_from_seed(1);
+            let qh2 = quorum_hash_from_seed(2);
+            let vs1 = make_validator_set(qh1, &[10, 20, 30], &mut rng);
+            let vs2 = make_validator_set(qh2, &[40, 50, 60], &mut rng);
+
+            let mut platform_validator_sets = IndexMap::new();
+            platform_validator_sets.insert(qh1, vs1);
+            platform_validator_sets.insert(qh2, vs2);
+
+            let mut platform_state = platform.state.load().as_ref().clone();
+            platform_state.set_current_validator_set_quorum_hash(qh1);
+            platform_state.set_validator_sets(platform_validator_sets);
+
+            // block state has entirely different quorums
+            let qh3 = quorum_hash_from_seed(3);
+            let qh4 = quorum_hash_from_seed(4);
+            let vs3 = make_validator_set(qh3, &[70, 80, 90], &mut rng);
+            let vs4 = make_validator_set(qh4, &[100, 110, 120], &mut rng);
+
+            let mut block_validator_sets = IndexMap::new();
+            block_validator_sets.insert(qh3, vs3);
+            block_validator_sets.insert(qh4, vs4);
+
+            let mut block_platform_state = platform_state.clone();
+            block_platform_state.set_validator_sets(block_validator_sets);
+
+            let mut block_execution_context = make_block_execution_context(block_platform_state);
+
+            // Trigger rotation via quorum removal (qh1 not in block state)
+            let result = platform
+                .validator_set_update_v2([0u8; 32], &platform_state, &mut block_execution_context)
+                .expect("should succeed");
+
+            assert!(result.is_some(), "should rotate to first of new quorums");
+            // Should pick the first quorum in block state
+            let next_qh = block_execution_context
+                .block_platform_state()
+                .next_validator_set_quorum_hash();
+            assert_eq!(*next_qh, Some(qh3));
+        }
+
+        /// Rotation with > 10 quorums: tests the `oldest_quorum_index_we_can_go_to = count - 2`
+        /// branch.
+        /// Covers lines 136-142 (count > 10 branch).
+        #[test]
+        fn v2_rotation_more_than_ten_quorums() {
+            let _guard = init_debug_tracing();
+            let platform = TestPlatformBuilder::new()
+                .build_with_mock_rpc()
+                .set_genesis_state();
+
+            let mut rng = StdRng::seed_from_u64(49);
+
+            // Create 12 quorums
+            let mut validator_sets = IndexMap::new();
+            let mut quorum_hashes = Vec::new();
+            for i in 1..=12u8 {
+                let qh = quorum_hash_from_seed(i);
+                quorum_hashes.push(qh);
+                let base_seed = i * 10;
+                let vs =
+                    make_validator_set(qh, &[base_seed, base_seed + 1, base_seed + 2], &mut rng);
+                validator_sets.insert(qh, vs);
+            }
+
+            let mut platform_state = platform.state.load().as_ref().clone();
+            platform_state.set_current_validator_set_quorum_hash(quorum_hashes[0]);
+            platform_state.set_validator_sets(validator_sets.clone());
+
+            let block_platform_state = platform_state.clone();
+            let mut block_execution_context = make_block_execution_context(block_platform_state);
+
+            // Propose the last member of qh[0] to trigger rotation via last-member path
+            // The members are sorted by ProTxHash. For seeds [10,11,12],
+            // the last is seed 12.
+            let mut proposer = [0u8; 32];
+            proposer[31] = 12;
+
+            let result = platform
+                .validator_set_update_v2(proposer, &platform_state, &mut block_execution_context)
+                .expect("should succeed");
+
+            assert!(result.is_some(), "should rotate with >10 quorums");
+            // With >10 quorums, oldest_quorum_index_we_can_go_to = 12 - 2 = 10
+            // current index = 0, next = 1, which is quorum_hashes[1]
+            let next_qh = block_execution_context
+                .block_platform_state()
+                .next_validator_set_quorum_hash();
+            assert_eq!(*next_qh, Some(quorum_hashes[1]));
+        }
+
+        /// Rotation with > 10 quorums where current quorum is near the end,
+        /// so index wraps back to 0.
+        /// Covers the wrap-around in lines 143-147 (index + 1 >= oldest_quorum_index_we_can_go_to).
+        #[test]
+        fn v2_rotation_more_than_ten_quorums_wrap_to_zero() {
+            let _guard = init_debug_tracing();
+            let platform = TestPlatformBuilder::new()
+                .build_with_mock_rpc()
+                .set_genesis_state();
+
+            let mut rng = StdRng::seed_from_u64(50);
+
+            // Create 12 quorums
+            let mut validator_sets = IndexMap::new();
+            let mut quorum_hashes = Vec::new();
+            for i in 1..=12u8 {
+                let qh = quorum_hash_from_seed(i);
+                quorum_hashes.push(qh);
+                let base_seed = i * 10;
+                let vs =
+                    make_validator_set(qh, &[base_seed, base_seed + 1, base_seed + 2], &mut rng);
+                validator_sets.insert(qh, vs);
+            }
+
+            // Set current quorum to index 9 (0-based), so index+1 = 10 >= count-2 = 10
+            // This should wrap to index 0
+            let mut platform_state = platform.state.load().as_ref().clone();
+            platform_state.set_current_validator_set_quorum_hash(quorum_hashes[9]);
+            platform_state.set_validator_sets(validator_sets.clone());
+
+            let block_platform_state = platform_state.clone();
+            let mut block_execution_context = make_block_execution_context(block_platform_state);
+
+            // Trigger rotation: use last member of quorum at index 9
+            // quorum_hashes[9] has seeds [100, 101, 102], last = 102
+            let mut proposer = [0u8; 32];
+            proposer[31] = 102;
+
+            let result = platform
+                .validator_set_update_v2(proposer, &platform_state, &mut block_execution_context)
+                .expect("should succeed");
+
+            assert!(result.is_some(), "should rotate with wrap to index 0");
+            let next_qh = block_execution_context
+                .block_platform_state()
+                .next_validator_set_quorum_hash();
+            // Should wrap to index 0 = quorum_hashes[0]
+            assert_eq!(*next_qh, Some(quorum_hashes[0]));
+        }
+
+        /// Rotation loop: next quorum in platform_state was removed from block state,
+        /// so the loop continues to the one after.
+        /// Covers the loop continuation path at lines 173-176.
+        #[test]
+        fn v2_rotation_skip_removed_quorum_in_loop() {
+            let _guard = init_debug_tracing();
+            let platform = TestPlatformBuilder::new()
+                .build_with_mock_rpc()
+                .set_genesis_state();
+
+            let mut rng = StdRng::seed_from_u64(51);
+            let qh1 = quorum_hash_from_seed(1);
+            let qh2 = quorum_hash_from_seed(2);
+            let qh3 = quorum_hash_from_seed(3);
+            let vs1 = make_validator_set(qh1, &[10, 20, 30], &mut rng);
+            let vs2 = make_validator_set(qh2, &[40, 50, 60], &mut rng);
+            let vs3 = make_validator_set(qh3, &[70, 80, 90], &mut rng);
+
+            // platform_state has all three quorums
+            let mut platform_validator_sets = IndexMap::new();
+            platform_validator_sets.insert(qh1, vs1);
+            platform_validator_sets.insert(qh2, vs2);
+            platform_validator_sets.insert(qh3, vs3.clone());
+
+            let mut platform_state = platform.state.load().as_ref().clone();
+            platform_state.set_current_validator_set_quorum_hash(qh1);
+            platform_state.set_validator_sets(platform_validator_sets);
+
+            // block state has qh1 and qh3 but NOT qh2
+            // So when rotating from qh1, index goes to qh2 (not found), then qh3 (found)
+            let mut block_validator_sets = IndexMap::new();
+            block_validator_sets.insert(qh1, make_validator_set(qh1, &[10, 20, 30], &mut rng));
+            block_validator_sets.insert(qh3, make_validator_set(qh3, &[70, 80, 90], &mut rng));
+
+            let mut block_platform_state = platform_state.clone();
+            block_platform_state.set_validator_sets(block_validator_sets);
+
+            let mut block_execution_context = make_block_execution_context(block_platform_state);
+
+            // Trigger rotation via last member of qh1 (seed 30)
+            let mut proposer = [0u8; 32];
+            proposer[31] = 30;
+
+            let result = platform
+                .validator_set_update_v2(proposer, &platform_state, &mut block_execution_context)
+                .expect("should succeed");
+
+            assert!(
+                result.is_some(),
+                "should skip removed qh2 and rotate to qh3"
+            );
+            let next_qh = block_execution_context
+                .block_platform_state()
+                .next_validator_set_quorum_hash();
+            assert_eq!(*next_qh, Some(qh3));
+        }
+
+        /// Rotation with empty block state quorums: no new quorums to choose from.
+        /// Covers line 196-197 ("no new quorums to choose from" -> Ok(None)).
+        #[test]
+        fn v2_rotation_no_new_quorums_available() {
+            let _guard = init_debug_tracing();
+            let platform = TestPlatformBuilder::new()
+                .build_with_mock_rpc()
+                .set_genesis_state();
+
+            let mut rng = StdRng::seed_from_u64(52);
+            let qh1 = quorum_hash_from_seed(1);
+            let qh2 = quorum_hash_from_seed(2);
+            let vs1 = make_validator_set(qh1, &[10, 20, 30], &mut rng);
+            let vs2 = make_validator_set(qh2, &[40, 50, 60], &mut rng);
+
+            let mut platform_validator_sets = IndexMap::new();
+            platform_validator_sets.insert(qh1, vs1);
+            platform_validator_sets.insert(qh2, vs2);
+
+            let mut platform_state = platform.state.load().as_ref().clone();
+            platform_state.set_current_validator_set_quorum_hash(qh1);
+            platform_state.set_validator_sets(platform_validator_sets);
+
+            // block state has NO quorums at all
+            let mut block_platform_state = platform_state.clone();
+            block_platform_state.set_validator_sets(IndexMap::new());
+
+            let mut block_execution_context = make_block_execution_context(block_platform_state);
+
+            let result = platform
+                .validator_set_update_v2([0u8; 32], &platform_state, &mut block_execution_context)
+                .expect("should succeed");
+
+            // All quorums changed path, block state empty, no first() -> Ok(None)
+            assert!(
+                result.is_none(),
+                "no new quorums available, should return None"
+            );
+        }
+
+        /// Rotation triggered, but quorum_count == 0 in platform_state.
+        /// This requires an unusual setup: current quorum hash is in validator_sets
+        /// but after get_index_of succeeds, the len() is 0. This is actually impossible
+        /// in practice (if get_index_of succeeds, len >= 1), so let's test the
+        /// CorruptedCachedState error when current quorum hash is NOT in platform_state.
+        /// Covers lines 119-126 (error when current quorum not found in platform_state).
+        #[test]
+        fn v2_rotation_current_quorum_not_in_platform_state() {
+            let _guard = init_debug_tracing();
+            let platform = TestPlatformBuilder::new()
+                .build_with_mock_rpc()
+                .set_genesis_state();
+
+            let mut rng = StdRng::seed_from_u64(53);
+            let qh1 = quorum_hash_from_seed(1);
+            let qh2 = quorum_hash_from_seed(2);
+            let vs2 = make_validator_set(qh2, &[40, 50, 60], &mut rng);
+
+            // platform_state: current quorum is qh1, but validator_sets only has qh2
+            let mut platform_validator_sets = IndexMap::new();
+            platform_validator_sets.insert(qh2, vs2.clone());
+
+            let mut platform_state = platform.state.load().as_ref().clone();
+            platform_state.set_current_validator_set_quorum_hash(qh1);
+            platform_state.set_validator_sets(platform_validator_sets);
+
+            // block_platform_state has qh2 but not qh1 -> triggers rotation
+            let mut block_validator_sets = IndexMap::new();
+            block_validator_sets.insert(qh2, vs2);
+
+            let mut block_platform_state = platform_state.clone();
+            block_platform_state.set_validator_sets(block_validator_sets);
+
+            let mut block_execution_context = make_block_execution_context(block_platform_state);
+
+            let result = platform.validator_set_update_v2(
+                [0u8; 32],
+                &platform_state,
+                &mut block_execution_context,
+            );
+
+            assert!(
+                result.is_err(),
+                "should error: current quorum not in platform_state validator_sets"
+            );
+            match result {
+                Err(Error::Execution(ExecutionError::CorruptedCachedState(msg))) => {
+                    assert!(
+                        msg.contains("perform_rotation"),
+                        "error should mention perform_rotation: {}",
+                        msg
+                    );
+                }
+                other => panic!("expected CorruptedCachedState error, got {:?}", other),
+            }
+        }
+
+        /// Rotation with exactly 1 quorum: last member triggers rotation but
+        /// there's only one quorum so result is Ok(None).
+        /// Covers line 133 (count == 1 -> no rotation possible).
+        #[test]
+        fn v2_rotation_single_quorum_last_member() {
+            let _guard = init_debug_tracing();
+            let platform = TestPlatformBuilder::new()
+                .build_with_mock_rpc()
+                .set_genesis_state();
+
+            let mut rng = StdRng::seed_from_u64(54);
+            let qh = quorum_hash_from_seed(1);
+            let vs = make_validator_set(qh, &[10, 20, 30], &mut rng);
+
+            let mut validator_sets = IndexMap::new();
+            validator_sets.insert(qh, vs);
+
+            let mut platform_state = platform.state.load().as_ref().clone();
+            platform_state.set_current_validator_set_quorum_hash(qh);
+            platform_state.set_validator_sets(validator_sets.clone());
+
+            let block_platform_state = platform_state.clone();
+            let mut block_execution_context = make_block_execution_context(block_platform_state);
+
+            // Proposer is the last member (seed 30)
+            let mut proposer = [0u8; 32];
+            proposer[31] = 30;
+
+            let result = platform
+                .validator_set_update_v2(proposer, &platform_state, &mut block_execution_context)
+                .expect("should succeed");
+
+            assert!(
+                result.is_none(),
+                "single quorum: rotation triggers but no target"
+            );
+        }
+
+        /// Wrap-around detection does NOT trigger with only 1 quorum.
+        /// Even though new_proposer < last_proposer, validator_sets().len() == 1.
+        /// Covers the `platform_state.validator_sets().len() > 1` guard at line 81.
+        #[test]
+        fn v2_wrap_around_not_triggered_single_quorum() {
+            let _guard = init_debug_tracing();
+            let platform = TestPlatformBuilder::new()
+                .build_with_mock_rpc()
+                .set_genesis_state();
+
+            let mut rng = StdRng::seed_from_u64(55);
+            let qh = quorum_hash_from_seed(1);
+            let vs = make_validator_set(qh, &[10, 20, 30], &mut rng);
+
+            let mut validator_sets = IndexMap::new();
+            validator_sets.insert(qh, vs);
+
+            let mut platform_state = platform.state.load().as_ref().clone();
+            platform_state.set_current_validator_set_quorum_hash(qh);
+            platform_state.set_validator_sets(validator_sets.clone());
+            // Last committed on same quorum, proposer = 20
+            let mut last_proposer = [0u8; 32];
+            last_proposer[31] = 20;
+            platform_state.set_last_committed_block_info(Some(make_extended_block_info(
+                *qh.as_byte_array(),
+                last_proposer,
+                5,
+            )));
+
+            let block_platform_state = platform_state.clone();
+            let mut block_execution_context = make_block_execution_context(block_platform_state);
+
+            // New proposer = 10 < last proposer = 20, but only 1 quorum -> no rotation
+            let mut proposer = [0u8; 32];
+            proposer[31] = 10;
+
+            let result = platform
+                .validator_set_update_v2(proposer, &platform_state, &mut block_execution_context)
+                .expect("should succeed");
+
+            assert!(
+                result.is_none(),
+                "wrap-around should not trigger rotation with single quorum"
+            );
+        }
+
+        /// Wrap-around detection does NOT trigger when quorum changed between blocks
+        /// (last_committed_quorum_hash != current_validator_set_quorum_hash).
+        /// Covers the first condition at line 76-79.
+        #[test]
+        fn v2_wrap_around_not_triggered_different_quorum() {
+            let _guard = init_debug_tracing();
+            let platform = TestPlatformBuilder::new()
+                .build_with_mock_rpc()
+                .set_genesis_state();
+
+            let mut rng = StdRng::seed_from_u64(56);
+            let qh1 = quorum_hash_from_seed(1);
+            let qh2 = quorum_hash_from_seed(2);
+            let vs1 = make_validator_set(qh1, &[10, 20, 30], &mut rng);
+            let vs2 = make_validator_set(qh2, &[40, 50, 60], &mut rng);
+
+            let mut validator_sets = IndexMap::new();
+            validator_sets.insert(qh1, vs1);
+            validator_sets.insert(qh2, vs2);
+
+            let mut platform_state = platform.state.load().as_ref().clone();
+            platform_state.set_current_validator_set_quorum_hash(qh1);
+            platform_state.set_validator_sets(validator_sets.clone());
+            // Last committed was on DIFFERENT quorum (qh2), proposer = 20
+            let mut last_proposer = [0u8; 32];
+            last_proposer[31] = 20;
+            platform_state.set_last_committed_block_info(Some(make_extended_block_info(
+                *qh2.as_byte_array(),
+                last_proposer,
+                5,
+            )));
+
+            let block_platform_state = platform_state.clone();
+            let mut block_execution_context = make_block_execution_context(block_platform_state);
+
+            // New proposer = 10 < last proposer = 20 but different quorum -> no wrap
+            let mut proposer = [0u8; 32];
+            proposer[31] = 10;
+
+            let result = platform
+                .validator_set_update_v2(proposer, &platform_state, &mut block_execution_context)
+                .expect("should succeed");
+
+            assert!(
+                result.is_none(),
+                "wrap-around should not trigger when last block was on different quorum"
+            );
+        }
+    }
 }


### PR DESCRIPTION
## Issue being fixed or feature implemented

Improve test coverage for the `validator_set_update` v2 module in drive-abci, and exclude superseded v0/v1 implementations from Codecov reporting.

## What was done?

**Codecov ignore list** (`.codecov.yml`):
- Added `**/block_end/validator_set_update/v0/**` and `**/block_end/validator_set_update/v1/**` to the ignore section since these versions are superseded by v2.

**15 new unit tests** for `validator_set_update_v2` covering all logical branches:

| Test | Branch covered |
|------|----------------|
| `v2_no_rotation_no_changes` | No rotation, no validator changes -> `Ok(None)` |
| `v2_no_rotation_with_validator_change` | No rotation but validator IP changed -> `Ok(Some(update))` |
| `v2_rotation_last_member_two_quorums` | Last member of quorum triggers rotation to next quorum |
| `v2_rotation_empty_members_single_quorum` | Empty validator set triggers rotation, single quorum = no target |
| `v2_rotation_proposer_wrap_around` | Proposer wraps around (new < last) with >1 quorum |
| `v2_rotation_quorum_removed` | Current quorum removed from block state |
| `v2_rotation_all_quorums_changed` | All quorums replaced, falls back to first in block state |
| `v2_rotation_more_than_ten_quorums` | >10 quorums uses `count - 2` limit |
| `v2_rotation_more_than_ten_quorums_wrap_to_zero` | >10 quorums with index wrap to 0 |
| `v2_rotation_skip_removed_quorum_in_loop` | Rotation loop skips removed quorum |
| `v2_rotation_no_new_quorums_available` | No quorums in block state -> `Ok(None)` |
| `v2_rotation_current_quorum_not_in_platform_state` | CorruptedCachedState error path |
| `v2_rotation_single_quorum_last_member` | Single quorum, last member -> no rotation target |
| `v2_wrap_around_not_triggered_single_quorum` | Wrap-around guard: single quorum prevents rotation |
| `v2_wrap_around_not_triggered_different_quorum` | Wrap-around guard: different quorum prevents rotation |

All logical code paths in v2 are exercised. Remaining uncovered lines in llvm-cov are exclusively `tracing::debug!` macro format argument expressions (a known LLVM-COV instrumentation artifact with the tracing crate's lazy evaluation pattern) and the logically unreachable `quorum_count == 0` error branch.

## How Has This Been Tested?

- All 16 tests pass locally (`cargo test --package drive-abci --all-features --lib -- validator_set_update::tests`)
- Coverage verified via `cargo llvm-cov`

## Breaking Changes

None.

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [x] I have made corresponding changes to the documentation if needed