### PR TITLE
test(drive-abci): improve replay module test coverage

### DIFF
--- a/packages/rs-drive-abci/src/replay/cli.rs
+++ b/packages/rs-drive-abci/src/replay/cli.rs
@@ -83,3 +83,110 @@ fn parse_line_number(raw: &str) -> Result<usize, String> {
         )
     })
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ---- SkipSelector::matches ----
+
+    #[test]
+    fn skip_selector_line_matches_exact() {
+        let selector = SkipSelector::Line(42);
+        assert!(selector.matches(42));
+        assert!(!selector.matches(41));
+        assert!(!selector.matches(43));
+    }
+
+    #[test]
+    fn skip_selector_range_matches_inclusive() {
+        let selector = SkipSelector::Range { start: 10, end: 20 };
+        assert!(!selector.matches(9));
+        assert!(selector.matches(10));
+        assert!(selector.matches(15));
+        assert!(selector.matches(20));
+        assert!(!selector.matches(21));
+    }
+
+    #[test]
+    fn skip_selector_range_single_element() {
+        let selector = SkipSelector::Range { start: 5, end: 5 };
+        assert!(selector.matches(5));
+        assert!(!selector.matches(4));
+        assert!(!selector.matches(6));
+    }
+
+    // ---- parse_skip_selector ----
+
+    #[test]
+    fn parse_skip_selector_single_line() {
+        let result = parse_skip_selector("42").unwrap();
+        assert!(matches!(result, SkipSelector::Line(42)));
+    }
+
+    #[test]
+    fn parse_skip_selector_range() {
+        let result = parse_skip_selector("10-20").unwrap();
+        match result {
+            SkipSelector::Range { start, end } => {
+                assert_eq!(start, 10);
+                assert_eq!(end, 20);
+            }
+            _ => panic!("expected Range"),
+        }
+    }
+
+    #[test]
+    fn parse_skip_selector_with_whitespace() {
+        let result = parse_skip_selector("  42  ").unwrap();
+        assert!(matches!(result, SkipSelector::Line(42)));
+    }
+
+    #[test]
+    fn parse_skip_selector_empty_error() {
+        let err = parse_skip_selector("").unwrap_err();
+        assert!(err.contains("cannot be empty"));
+    }
+
+    #[test]
+    fn parse_skip_selector_whitespace_only_error() {
+        let err = parse_skip_selector("   ").unwrap_err();
+        assert!(err.contains("cannot be empty"));
+    }
+
+    #[test]
+    fn parse_skip_selector_inverted_range_error() {
+        let err = parse_skip_selector("20-10").unwrap_err();
+        assert!(err.contains("start must be <= end"));
+    }
+
+    #[test]
+    fn parse_skip_selector_non_numeric_error() {
+        let err = parse_skip_selector("abc").unwrap_err();
+        assert!(err.contains("invalid skip target"));
+    }
+
+    #[test]
+    fn parse_skip_selector_range_non_numeric_start() {
+        let err = parse_skip_selector("abc-10").unwrap_err();
+        assert!(err.contains("invalid skip target"));
+    }
+
+    #[test]
+    fn parse_skip_selector_range_non_numeric_end() {
+        let err = parse_skip_selector("10-xyz").unwrap_err();
+        assert!(err.contains("invalid skip target"));
+    }
+
+    #[test]
+    fn parse_skip_selector_equal_range() {
+        let result = parse_skip_selector("5-5").unwrap();
+        match result {
+            SkipSelector::Range { start, end } => {
+                assert_eq!(start, 5);
+                assert_eq!(end, 5);
+            }
+            _ => panic!("expected Range"),
+        }
+    }
+}

--- a/packages/rs-drive-abci/src/replay/log_ingest.rs
+++ b/packages/rs-drive-abci/src/replay/log_ingest.rs
@@ -1209,4 +1209,747 @@ mod tests {
     const TESTNET_FINALIZE_BLOCK_ONE: &str = r#"Request { value: Some(FinalizeBlock(RequestFinalizeBlock { commit: Some(CommitInfo { round: 0, quorum_hash: [0, 0, 0, 175, 88, 108, 85, 57, 26, 90, 172, 207, 12, 99, 142, 240, 100, 211, 71, 145, 227, 27, 243, 154, 158, 173, 160, 199, 112, 203, 8, 120], block_signature: [135, 31, 49, 75, 118, 108, 104, 68, 227, 56, 171, 253, 41, 152, 98, 72, 166, 144, 178, 146, 18, 67, 56, 20, 130, 110, 158, 62, 6, 77, 138, 57, 113, 138, 206, 99, 241, 112, 245, 11, 237, 77, 36, 214, 24, 174, 166, 1, 21, 165, 233, 228, 11, 201, 201, 241, 5, 23, 224, 16, 178, 200, 142, 7, 105, 222, 229, 179, 82, 115, 216, 243, 16, 48, 204, 162, 100, 154, 25, 120, 1, 85, 170, 219, 228, 3, 170, 60, 81, 141, 68, 116, 22, 7, 239, 249], threshold_vote_extensions: [] }), misbehavior: [], hash: [8, 250, 2, 194, 126, 192, 57, 11, 163, 1, 228, 252, 126, 61, 126, 173, 179, 80, 200, 25, 62, 62, 98, 160, 147, 104, 151, 6, 227, 162, 11, 250], height: 1, round: 0, block: Some(Block { header: Some(Header { version: Some(Consensus { block: 14, app: 1 }), chain_id: "dash-testnet-51", height: 1, time: Some(Timestamp { seconds: 1721353209, nanos: 0 }), last_block_id: Some(BlockId { hash: [], part_set_header: Some(PartSetHeader { total: 0, hash: [] }), state_id: [] }), last_commit_hash: [227, 176, 196, 66, 152, 252, 28, 20, 154, 251, 244, 200, 153, 111, 185, 36, 39, 174, 65, 228, 100, 155, 147, 76, 164, 149, 153, 27, 120, 82, 184, 85], data_hash: [227, 176, 196, 66, 152, 252, 28, 20, 154, 251, 244, 200, 153, 111, 185, 36, 39, 174, 65, 228, 100, 155, 147, 76, 164, 149, 153, 27, 120, 82, 184, 85], validators_hash: [151, 116, 141, 147, 83, 105, 231, 87, 207, 88, 182, 176, 208, 225, 89, 251, 214, 179, 23, 205, 112, 160, 49, 250, 160, 132, 171, 97, 31, 189, 74, 77], next_validators_hash: [67, 141, 67, 156, 14, 170, 45, 148, 50, 130, 83, 98, 80, 9, 168, 59, 20, 74, 245, 208, 222, 120, 248, 14, 0, 20, 181, 247, 167, 138, 75, 141], consensus_hash: [180, 208, 169, 232, 73, 81, 202, 221, 119, 226, 150, 68, 128, 3, 115, 113, 118, 178, 89, 72, 173, 246, 104, 172, 110, 192, 105, 38, 200, 31, 172, 134], next_consensus_hash: [180, 208, 169, 232, 73, 81, 202, 221, 119, 226, 150, 68, 128, 3, 115, 113, 118, 178, 89, 72, 173, 246, 104, 172, 110, 192, 105, 38, 200, 31, 172, 134], app_hash: [191, 12, 203, 156, 160, 113, 186, 1, 174, 110, 103, 160, 192, 144, 249, 120, 3, 210, 109, 86, 214, 117, 220, 213, 19, 23, 129, 203, 202, 200, 236, 143], results_hash: [227, 176, 196, 66, 152, 252, 28, 20, 154, 251, 244, 200, 153, 111, 185, 36, 39, 174, 65, 228, 100, 155, 147, 76, 164, 149, 153, 27, 120, 82, 184, 85], evidence_hash: [227, 176, 196, 66, 152, 252, 28, 20, 154, 251, 244, 200, 153, 111, 185, 36, 39, 174, 65, 228, 100, 155, 147, 76, 164, 149, 153, 27, 120, 82, 184, 85], proposed_app_version: 1, proposer_pro_tx_hash: [5, 182, 135, 151, 131, 68, 250, 36, 51, 178, 170, 153, 212, 31, 100, 62, 45, 133, 129, 167, 137, 205, 194, 48, 132, 136, 156, 236, 165, 36, 78, 168], core_chain_locked_height: 1090319 }), data: Some(Data { txs: [] }), evidence: Some(EvidenceList { evidence: [] }), last_commit: Some(Commit { height: 0, round: 0, block_id: Some(BlockId { hash: [], part_set_header: Some(PartSetHeader { total: 0, hash: [] }), state_id: [] }), quorum_hash: [], threshold_block_signature: [], threshold_vote_extensions: [] }), core_chain_lock: Some(CoreChainLock { core_block_height: 1090319, core_block_hash: [188, 208, 158, 250, 148, 183, 195, 57, 139, 20, 13, 219, 224, 167, 123, 230, 49, 159, 25, 154, 160, 12, 51, 34, 68, 102, 209, 84, 48, 1, 0, 0], signature: [149, 121, 58, 158, 78, 248, 78, 170, 243, 117, 235, 255, 251, 46, 2, 74, 179, 31, 158, 246, 193, 93, 23, 193, 136, 122, 196, 15, 108, 247, 172, 6, 169, 101, 215, 149, 150, 32, 35, 97, 252, 255, 134, 112, 170, 172, 13, 222, 3, 228, 106, 52, 44, 158, 242, 165, 19, 40, 253, 34, 104, 130, 246, 229, 84, 55, 221, 223, 40, 152, 72, 43, 159, 46, 78, 5, 1, 158, 149, 145, 239, 220, 27, 196, 104, 176, 16, 54, 90, 38, 68, 184, 43, 57, 17, 245] }) }), block_id: Some(BlockId { hash: [8, 250, 2, 194, 126, 192, 57, 11, 163, 1, 228, 252, 126, 61, 126, 173, 179, 80, 200, 25, 62, 62, 98, 160, 147, 104, 151, 6, 227, 162, 11, 250], part_set_header: Some(PartSetHeader { total: 1, hash: [67, 44, 224, 208, 150, 55, 48, 6, 49, 94, 42, 158, 112, 26, 240, 103, 185, 51, 202, 165, 106, 78, 124, 206, 99, 140, 58, 172, 22, 209, 227, 68] }), state_id: [209, 145, 66, 195, 68, 86, 204, 201, 247, 175, 60, 157, 38, 207, 138, 107, 56, 77, 204, 254, 146, 83, 246, 110, 152, 76, 39, 22, 153, 243, 181, 131] }) })) }"#;
 
     const TESTNET_FINALIZE_BLOCK_TWO: &str = r#"Request { value: Some(FinalizeBlock(RequestFinalizeBlock { commit: Some(CommitInfo { round: 1, quorum_hash: [0, 0, 0, 217, 55, 192, 219, 26, 45, 97, 224, 140, 152, 79, 68, 251, 208, 148, 3, 190, 152, 206, 230, 126, 107, 37, 117, 76, 217, 104, 133, 231], block_signature: [151, 132, 224, 84, 5, 251, 44, 38, 191, 110, 146, 82, 255, 249, 7, 150, 50, 168, 38, 237, 69, 227, 135, 55, 144, 47, 4, 155, 3, 138, 102, 99, 154, 133, 217, 187, 169, 154, 174, 115, 139, 173, 105, 25, 62, 73, 129, 87, 7, 28, 172, 121, 137, 254, 243, 31, 71, 185, 143, 151, 213, 225, 44, 199, 70, 25, 157, 230, 75, 62, 81, 254, 217, 86, 171, 220, 120, 188, 69, 24, 109, 222, 98, 224, 102, 201, 145, 82, 53, 13, 228, 150, 0, 137, 116, 16], threshold_vote_extensions: [] }), misbehavior: [], hash: [98, 147, 39, 112, 110, 207, 177, 37, 173, 61, 20, 160, 95, 228, 179, 90, 184, 83, 202, 86, 64, 254, 53, 133, 57, 32, 50, 21, 253, 32, 16, 172], height: 2, round: 1, block: Some(Block { header: Some(Header { version: Some(Consensus { block: 14, app: 1 }), chain_id: "dash-testnet-51", height: 2, time: Some(Timestamp { seconds: 1724575888, nanos: 328000000 }), last_block_id: Some(BlockId { hash: [8, 250, 2, 194, 126, 192, 57, 11, 163, 1, 228, 252, 126, 61, 126, 173, 179, 80, 200, 25, 62, 62, 98, 160, 147, 104, 151, 6, 227, 162, 11, 250], part_set_header: Some(PartSetHeader { total: 1, hash: [67, 44, 224, 208, 150, 55, 48, 6, 49, 94, 42, 158, 112, 26, 240, 103, 185, 51, 202, 165, 106, 78, 124, 206, 99, 140, 58, 172, 22, 209, 227, 68] }), state_id: [209, 145, 66, 195, 68, 86, 204, 201, 247, 175, 60, 157, 38, 207, 138, 107, 56, 77, 204, 254, 146, 83, 246, 110, 152, 76, 39, 22, 153, 243, 181, 131] }), last_commit_hash: [125, 172, 60, 185, 43, 201, 215, 188, 72, 11, 207, 101, 109, 98, 7, 127, 216, 155, 4, 101, 230, 18, 156, 15, 99, 93, 122, 164, 178, 27, 60, 194], data_hash: [227, 176, 196, 66, 152, 252, 28, 20, 154, 251, 244, 200, 153, 111, 185, 36, 39, 174, 65, 228, 100, 155, 147, 76, 164, 149, 153, 27, 120, 82, 184, 85], validators_hash: [67, 141, 67, 156, 14, 170, 45, 148, 50, 130, 83, 98, 80, 9, 168, 59, 20, 74, 245, 208, 222, 120, 248, 14, 0, 20, 181, 247, 167, 138, 75, 141], next_validators_hash: [67, 141, 67, 156, 14, 170, 45, 148, 50, 130, 83, 98, 80, 9, 168, 59, 20, 74, 245, 208, 222, 120, 248, 14, 0, 20, 181, 247, 167, 138, 75, 141], consensus_hash: [180, 208, 169, 232, 73, 81, 202, 221, 119, 226, 150, 68, 128, 3, 115, 113, 118, 178, 89, 72, 173, 246, 104, 172, 110, 192, 105, 38, 200, 31, 172, 134], next_consensus_hash: [180, 208, 169, 232, 73, 81, 202, 221, 119, 226, 150, 68, 128, 3, 115, 113, 118, 178, 89, 72, 173, 246, 104, 172, 110, 192, 105, 38, 200, 31, 172, 134], app_hash: [77, 189, 142, 170, 172, 111, 216, 169, 207, 157, 71, 134, 71, 149, 189, 31, 53, 102, 178, 80, 54, 238, 37, 128, 18, 176, 16, 200, 2, 126, 109, 200], results_hash: [227, 176, 196, 66, 152, 252, 28, 20, 154, 251, 244, 200, 153, 111, 185, 36, 39, 174, 65, 228, 100, 155, 147, 76, 164, 149, 153, 27, 120, 82, 184, 85], evidence_hash: [227, 176, 196, 66, 152, 252, 28, 20, 154, 251, 244, 200, 153, 111, 185, 36, 39, 174, 65, 228, 100, 155, 147, 76, 164, 149, 153, 27, 120, 82, 184, 85], proposed_app_version: 1, proposer_pro_tx_hash: [20, 61, 205, 106, 107, 118, 132, 253, 224, 30, 136, 161, 14, 93, 101, 222, 154, 41, 36, 76, 94, 205, 88, 109, 20, 163, 66, 101, 112, 37, 241, 19], core_chain_locked_height: 1090320 }), data: Some(Data { txs: [] }), evidence: Some(EvidenceList { evidence: [] }), last_commit: Some(Commit { height: 1, round: 0, block_id: Some(BlockId { hash: [8, 250, 2, 194, 126, 192, 57, 11, 163, 1, 228, 252, 126, 61, 126, 173, 179, 80, 200, 25, 62, 62, 98, 160, 147, 104, 151, 6, 227, 162, 11, 250], part_set_header: Some(PartSetHeader { total: 1, hash: [67, 44, 224, 208, 150, 55, 48, 6, 49, 94, 42, 158, 112, 26, 240, 103, 185, 51, 202, 165, 106, 78, 124, 206, 99, 140, 58, 172, 22, 209, 227, 68] }), state_id: [209, 145, 66, 195, 68, 86, 204, 201, 247, 175, 60, 157, 38, 207, 138, 107, 56, 77, 204, 254, 146, 83, 246, 110, 152, 76, 39, 22, 153, 243, 181, 131] }), quorum_hash: [0, 0, 0, 175, 88, 108, 85, 57, 26, 90, 172, 207, 12, 99, 142, 240, 100, 211, 71, 145, 227, 27, 243, 154, 158, 173, 160, 199, 112, 203, 8, 120], threshold_block_signature: [135, 31, 49, 75, 118, 108, 104, 68, 227, 56, 171, 253, 41, 152, 98, 72, 166, 144, 178, 146, 18, 67, 56, 20, 130, 110, 158, 62, 6, 77, 138, 57, 113, 138, 206, 99, 241, 112, 245, 11, 237, 77, 36, 214, 24, 174, 166, 1, 21, 165, 233, 228, 11, 201, 201, 241, 5, 23, 224, 16, 178, 200, 142, 7, 105, 222, 229, 179, 82, 115, 216, 243, 16, 48, 204, 162, 100, 154, 25, 120, 1, 85, 170, 219, 228, 3, 170, 60, 81, 141, 68, 116, 22, 7, 239, 249], threshold_vote_extensions: [] }), core_chain_lock: Some(CoreChainLock { core_block_height: 1090320, core_block_hash: [26, 216, 69, 45, 191, 148, 30, 6, 168, 162, 186, 137, 78, 18, 75, 156, 96, 37, 84, 103, 102, 16, 247, 253, 135, 49, 45, 177, 223, 0, 0, 0], signature: [180, 194, 224, 93, 153, 74, 203, 51, 184, 6, 210, 221, 105, 118, 214, 63, 153, 251, 150, 114, 108, 127, 204, 60, 218, 225, 67, 219, 1, 243, 242, 197, 83, 108, 245, 71, 67, 13, 18, 17, 65, 133, 148, 4, 209, 211, 188, 233, 24, 183, 215, 105, 227, 42, 217, 128, 60, 80, 202, 225, 220, 209, 240, 9, 200, 195, 48, 13, 154, 13, 142, 216, 112, 83, 180, 84, 254, 238, 233, 201, 141, 58, 116, 171, 125, 110, 118, 14, 225, 89, 66, 58, 3, 9, 42, 179] }) }), block_id: Some(BlockId { hash: [98, 147, 39, 112, 110, 207, 177, 37, 173, 61, 20, 160, 95, 228, 179, 90, 184, 83, 202, 86, 64, 254, 53, 133, 57, 32, 50, 21, 253, 32, 16, 172], part_set_header: Some(PartSetHeader { total: 1, hash: [200, 235, 186, 216, 169, 238, 109, 8, 187, 66, 3, 161, 186, 230, 247, 3, 129, 181, 218, 148, 158, 153, 68, 17, 111, 14, 75, 230, 202, 104, 255, 47] }), state_id: [45, 73, 190, 78, 51, 91, 154, 204, 110, 181, 196, 96, 54, 5, 235, 82, 94, 133, 4, 141, 52, 209, 253, 137, 36, 137, 200, 161, 182, 225, 218, 147] }) })) }"#;
+
+    // ---- DebugValueParser tests ----
+
+    fn parse_value(raw: &str) -> ParsedValue {
+        DebugValueParser::new(raw)
+            .parse()
+            .expect("should parse successfully")
+    }
+
+    #[test]
+    fn parser_null_value() {
+        let val = parse_value("None");
+        assert!(matches!(val, ParsedValue::Null));
+    }
+
+    #[test]
+    fn parser_bool_true() {
+        let val = parse_value("true");
+        assert!(matches!(val, ParsedValue::Bool(true)));
+    }
+
+    #[test]
+    fn parser_bool_false() {
+        let val = parse_value("false");
+        assert!(matches!(val, ParsedValue::Bool(false)));
+    }
+
+    #[test]
+    fn parser_number_positive() {
+        let val = parse_value("42");
+        assert!(matches!(val, ParsedValue::Number(ref s) if s == "42"));
+    }
+
+    #[test]
+    fn parser_number_negative() {
+        let val = parse_value("-5");
+        assert!(matches!(val, ParsedValue::Number(ref s) if s == "-5"));
+    }
+
+    #[test]
+    fn parser_string_simple() {
+        let val = parse_value(r#""hello""#);
+        assert!(matches!(val, ParsedValue::String(ref s) if s == "hello"));
+    }
+
+    #[test]
+    fn parser_string_escaped() {
+        let val = parse_value(r#""he\"llo""#);
+        assert!(matches!(val, ParsedValue::String(ref s) if s == r#"he"llo"#));
+    }
+
+    #[test]
+    fn parser_string_escape_sequences() {
+        let val = parse_value(r#""a\nb\rc\td\\e""#);
+        assert!(matches!(val, ParsedValue::String(ref s) if s == "a\nb\rc\td\\e"));
+    }
+
+    #[test]
+    fn parser_empty_array() {
+        let val = parse_value("[]");
+        match val {
+            ParsedValue::Array(items) => assert!(items.is_empty()),
+            _ => panic!("expected array"),
+        }
+    }
+
+    #[test]
+    fn parser_array_of_numbers() {
+        let val = parse_value("[1, 2, 3]");
+        match val {
+            ParsedValue::Array(items) => assert_eq!(items.len(), 3),
+            _ => panic!("expected array"),
+        }
+    }
+
+    #[test]
+    fn parser_empty_object() {
+        let val = parse_value("{}");
+        match val {
+            ParsedValue::Object(map) => assert!(map.is_empty()),
+            _ => panic!("expected object"),
+        }
+    }
+
+    #[test]
+    fn parser_object_with_fields() {
+        let val = parse_value("{ a: 1, b: 2 }");
+        match val {
+            ParsedValue::Object(map) => {
+                assert_eq!(map.len(), 2);
+                assert!(map.contains_key("a"));
+                assert!(map.contains_key("b"));
+            }
+            _ => panic!("expected object"),
+        }
+    }
+
+    #[test]
+    fn parser_some_wrapping() {
+        let val = parse_value("Some(42)");
+        assert!(matches!(val, ParsedValue::Number(ref s) if s == "42"));
+    }
+
+    #[test]
+    fn parser_tagged_struct() {
+        let val = parse_value("MyStruct { field: 1 }");
+        match val {
+            ParsedValue::Tagged { tag, value } => {
+                assert_eq!(tag, "MyStruct");
+                assert!(matches!(*value, ParsedValue::Object(_)));
+            }
+            _ => panic!("expected tagged"),
+        }
+    }
+
+    #[test]
+    fn parser_tagged_variant() {
+        let val = parse_value("MyEnum(42)");
+        match val {
+            ParsedValue::Tagged { tag, value } => {
+                assert_eq!(tag, "MyEnum");
+                assert!(matches!(*value, ParsedValue::Number(ref s) if s == "42"));
+            }
+            _ => panic!("expected tagged"),
+        }
+    }
+
+    #[test]
+    fn parser_trailing_characters_error() {
+        let result = DebugValueParser::new("42 extra").parse();
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn parser_empty_input_error() {
+        let result = DebugValueParser::new("").parse();
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn parser_unterminated_string_error() {
+        let result = DebugValueParser::new(r#""unterminated"#).parse();
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn parser_bare_object_without_tag() {
+        let val = parse_value("{ key: 42 }");
+        match val {
+            ParsedValue::Object(map) => {
+                assert!(map.contains_key("key"));
+            }
+            _ => panic!("expected object"),
+        }
+    }
+
+    // ---- ParsedValue methods ----
+
+    #[test]
+    fn parsed_value_into_object_direct() {
+        let map = BTreeMap::new();
+        let val = ParsedValue::Object(map);
+        assert!(val.into_object().is_ok());
+    }
+
+    #[test]
+    fn parsed_value_into_object_tagged() {
+        let map = BTreeMap::new();
+        let val = ParsedValue::Tagged {
+            tag: "Wrapper".to_string(),
+            value: Box::new(ParsedValue::Object(map)),
+        };
+        assert!(val.into_object().is_ok());
+    }
+
+    #[test]
+    fn parsed_value_into_object_wrong_type() {
+        let val = ParsedValue::Number("42".to_string());
+        assert!(val.into_object().is_err());
+    }
+
+    #[test]
+    fn parsed_value_to_string_value_string() {
+        let val = ParsedValue::String("hello".to_string());
+        assert_eq!(val.to_string_value().unwrap(), "hello");
+    }
+
+    #[test]
+    fn parsed_value_to_string_value_number() {
+        let val = ParsedValue::Number("42".to_string());
+        assert_eq!(val.to_string_value().unwrap(), "42");
+    }
+
+    #[test]
+    fn parsed_value_to_string_value_tagged() {
+        let val = ParsedValue::Tagged {
+            tag: "T".to_string(),
+            value: Box::new(ParsedValue::String("inner".to_string())),
+        };
+        assert_eq!(val.to_string_value().unwrap(), "inner");
+    }
+
+    #[test]
+    fn parsed_value_to_string_value_wrong_type() {
+        let val = ParsedValue::Bool(true);
+        assert!(val.to_string_value().is_err());
+    }
+
+    // ---- Helper functions ----
+
+    #[test]
+    fn normalize_type_tag_simple() {
+        assert_eq!(normalize_type_tag("Timestamp"), "Timestamp");
+    }
+
+    #[test]
+    fn normalize_type_tag_with_path() {
+        assert_eq!(normalize_type_tag("some::module::Timestamp"), "Timestamp");
+    }
+
+    #[test]
+    fn normalize_field_key_normal() {
+        assert_eq!(normalize_field_key("field".to_string()), "field");
+    }
+
+    #[test]
+    fn normalize_field_key_raw() {
+        assert_eq!(normalize_field_key("r#type".to_string()), "type");
+    }
+
+    #[test]
+    fn camel_to_upper_snake_single() {
+        assert_eq!(camel_to_upper_snake("Default"), "DEFAULT");
+    }
+
+    #[test]
+    fn camel_to_upper_snake_multi() {
+        assert_eq!(
+            camel_to_upper_snake("ThresholdRecover"),
+            "THRESHOLD_RECOVER"
+        );
+    }
+
+    #[test]
+    fn camel_to_upper_snake_empty() {
+        assert_eq!(camel_to_upper_snake(""), "");
+    }
+
+    #[test]
+    fn is_enum_variant_identifier_valid() {
+        assert!(is_enum_variant_identifier("Accept"));
+        assert!(is_enum_variant_identifier("ThresholdRecover"));
+        assert!(is_enum_variant_identifier("Variant123"));
+    }
+
+    #[test]
+    fn is_enum_variant_identifier_invalid() {
+        assert!(!is_enum_variant_identifier("lowercase"));
+        assert!(!is_enum_variant_identifier(""));
+        assert!(!is_enum_variant_identifier("123"));
+    }
+
+    #[test]
+    fn normalize_identifier_value_consensus_version() {
+        let val = normalize_identifier_value("ConsensusVersion0".to_string());
+        assert!(matches!(val, ParsedValue::Number(ref s) if s == "0"));
+    }
+
+    #[test]
+    fn normalize_identifier_value_consensus_version_bare() {
+        // "ConsensusVersion" alone without digits -- not a ConsensusVersion pattern
+        let val = normalize_identifier_value("ConsensusVersion".to_string());
+        // Should fall through to enum variant check (starts uppercase)
+        assert!(matches!(val, ParsedValue::Tagged { ref tag, .. } if tag == "EnumVariant"));
+    }
+
+    #[test]
+    fn normalize_identifier_value_enum_variant() {
+        let val = normalize_identifier_value("Accept".to_string());
+        match val {
+            ParsedValue::Tagged { tag, value } => {
+                assert_eq!(tag, "EnumVariant");
+                assert!(matches!(*value, ParsedValue::String(ref s) if s == "Accept"));
+            }
+            _ => panic!("expected Tagged EnumVariant"),
+        }
+    }
+
+    #[test]
+    fn normalize_identifier_value_lowercase() {
+        let val = normalize_identifier_value("lowercase".to_string());
+        assert!(matches!(val, ParsedValue::String(ref s) if s == "lowercase"));
+    }
+
+    // ---- format_timestamp / format_duration ----
+
+    #[test]
+    fn format_timestamp_valid() {
+        let mut map = BTreeMap::new();
+        map.insert(
+            "seconds".to_string(),
+            ParsedValue::Number("1721353209".to_string()),
+        );
+        map.insert("nanos".to_string(), ParsedValue::Number("0".to_string()));
+        let result = format_timestamp(ParsedValue::Object(map));
+        assert!(result.is_ok());
+        let ts = result.unwrap();
+        assert!(ts.contains("2024"));
+    }
+
+    #[test]
+    fn format_timestamp_nanos_out_of_range() {
+        let mut map = BTreeMap::new();
+        map.insert("seconds".to_string(), ParsedValue::Number("0".to_string()));
+        map.insert(
+            "nanos".to_string(),
+            ParsedValue::Number("2000000000".to_string()),
+        );
+        let result = format_timestamp(ParsedValue::Object(map));
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn format_duration_valid() {
+        let mut map = BTreeMap::new();
+        map.insert("seconds".to_string(), ParsedValue::Number("30".to_string()));
+        map.insert("nanos".to_string(), ParsedValue::Number("0".to_string()));
+        let result = format_duration(ParsedValue::Object(map));
+        assert!(result.is_ok());
+        let d = result.unwrap();
+        assert_eq!(d, "30000000000");
+    }
+
+    #[test]
+    fn format_duration_negative_seconds_error() {
+        let mut map = BTreeMap::new();
+        map.insert("seconds".to_string(), ParsedValue::Number("-1".to_string()));
+        map.insert("nanos".to_string(), ParsedValue::Number("0".to_string()));
+        let result = format_duration(ParsedValue::Object(map));
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn format_duration_nanos_too_large_error() {
+        let mut map = BTreeMap::new();
+        map.insert("seconds".to_string(), ParsedValue::Number("0".to_string()));
+        map.insert(
+            "nanos".to_string(),
+            ParsedValue::Number("1000000000".to_string()),
+        );
+        let result = format_duration(ParsedValue::Object(map));
+        assert!(result.is_err());
+    }
+
+    // ---- parse_number_field / parse_number_value ----
+
+    #[test]
+    fn parse_number_field_none_defaults_to_zero() {
+        assert_eq!(parse_number_field(None, "test").unwrap(), 0);
+    }
+
+    #[test]
+    fn parse_number_field_some_number() {
+        let val = ParsedValue::Number("42".to_string());
+        assert_eq!(parse_number_field(Some(val), "test").unwrap(), 42);
+    }
+
+    #[test]
+    fn parse_number_value_string() {
+        let val = ParsedValue::String("100".to_string());
+        assert_eq!(parse_number_value(val, "test").unwrap(), 100);
+    }
+
+    #[test]
+    fn parse_number_value_bool_true() {
+        let val = ParsedValue::Bool(true);
+        assert_eq!(parse_number_value(val, "test").unwrap(), 1);
+    }
+
+    #[test]
+    fn parse_number_value_bool_false() {
+        let val = ParsedValue::Bool(false);
+        assert_eq!(parse_number_value(val, "test").unwrap(), 0);
+    }
+
+    #[test]
+    fn parse_number_value_tagged() {
+        let val = ParsedValue::Tagged {
+            tag: "T".to_string(),
+            value: Box::new(ParsedValue::Number("99".to_string())),
+        };
+        assert_eq!(parse_number_value(val, "test").unwrap(), 99);
+    }
+
+    #[test]
+    fn parse_number_value_object_error() {
+        let val = ParsedValue::Object(BTreeMap::new());
+        assert!(parse_number_value(val, "test").is_err());
+    }
+
+    #[test]
+    fn parse_number_value_array_error() {
+        let val = ParsedValue::Array(vec![]);
+        assert!(parse_number_value(val, "test").is_err());
+    }
+
+    #[test]
+    fn parse_number_value_invalid_string() {
+        let val = ParsedValue::String("not_a_number".to_string());
+        assert!(parse_number_value(val, "test").is_err());
+    }
+
+    // ---- array_to_hex ----
+
+    #[test]
+    fn array_to_hex_valid() {
+        let values = vec![
+            ParsedValue::Number("255".to_string()),
+            ParsedValue::Number("0".to_string()),
+            ParsedValue::Number("171".to_string()),
+        ];
+        let result = array_to_hex(values).unwrap();
+        assert_eq!(result, "ff00ab");
+    }
+
+    #[test]
+    fn array_to_hex_empty() {
+        let result = array_to_hex(vec![]).unwrap();
+        assert_eq!(result, "");
+    }
+
+    #[test]
+    fn array_to_hex_out_of_range() {
+        let values = vec![ParsedValue::Number("256".to_string())];
+        assert!(array_to_hex(values).is_err());
+    }
+
+    #[test]
+    fn array_to_hex_wrong_type() {
+        let values = vec![ParsedValue::Bool(true)];
+        assert!(array_to_hex(values).is_err());
+    }
+
+    // ---- Deserializer tests ----
+
+    #[test]
+    fn deserialize_bool_from_string_true() {
+        use serde::Deserialize;
+        let val = ParsedValue::String("true".to_string());
+        let result = bool::deserialize(val).unwrap();
+        assert!(result);
+    }
+
+    #[test]
+    fn deserialize_bool_from_string_false() {
+        use serde::Deserialize;
+        let val = ParsedValue::String("false".to_string());
+        let result = bool::deserialize(val).unwrap();
+        assert!(!result);
+    }
+
+    #[test]
+    fn deserialize_bool_from_tagged() {
+        use serde::Deserialize;
+        let val = ParsedValue::Tagged {
+            tag: "T".to_string(),
+            value: Box::new(ParsedValue::Bool(true)),
+        };
+        let result = bool::deserialize(val).unwrap();
+        assert!(result);
+    }
+
+    #[test]
+    fn deserialize_i64_from_number() {
+        use serde::Deserialize;
+        let val = ParsedValue::Number("-42".to_string());
+        let result = i64::deserialize(val).unwrap();
+        assert_eq!(result, -42);
+    }
+
+    #[test]
+    fn deserialize_u64_from_number() {
+        use serde::Deserialize;
+        let val = ParsedValue::Number("42".to_string());
+        let result = u64::deserialize(val).unwrap();
+        assert_eq!(result, 42);
+    }
+
+    #[test]
+    fn deserialize_f32_from_number() {
+        use serde::Deserialize;
+        let val = ParsedValue::Number("3".to_string());
+        let result = f32::deserialize(val).unwrap();
+        assert!((result - 3.0).abs() < f32::EPSILON);
+    }
+
+    #[test]
+    fn deserialize_f64_from_number() {
+        use serde::Deserialize;
+        let val = ParsedValue::Number("3".to_string());
+        let result = f64::deserialize(val).unwrap();
+        assert!((result - 3.0).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn deserialize_string_from_bool() {
+        use serde::Deserialize;
+        let val = ParsedValue::Bool(true);
+        let result = String::deserialize(val).unwrap();
+        assert_eq!(result, "true");
+    }
+
+    #[test]
+    fn deserialize_string_from_array_as_hex() {
+        use serde::Deserialize;
+        let val = ParsedValue::Array(vec![
+            ParsedValue::Number("255".to_string()),
+            ParsedValue::Number("0".to_string()),
+        ]);
+        let result = String::deserialize(val).unwrap();
+        assert_eq!(result, "ff00");
+    }
+
+    #[test]
+    fn deserialize_option_null() {
+        use serde::Deserialize;
+        let val = ParsedValue::Null;
+        let result = Option::<i32>::deserialize(val).unwrap();
+        assert_eq!(result, None);
+    }
+
+    #[test]
+    fn deserialize_option_some() {
+        use serde::Deserialize;
+        let val = ParsedValue::Number("42".to_string());
+        let result = Option::<i32>::deserialize(val).unwrap();
+        assert_eq!(result, Some(42));
+    }
+
+    #[test]
+    fn deserialize_unit_from_null() {
+        use serde::Deserialize;
+        let val = ParsedValue::Null;
+        let result = <()>::deserialize(val).unwrap();
+        assert_eq!(result, ());
+    }
+
+    #[test]
+    fn deserialize_vec_from_array() {
+        use serde::Deserialize;
+        let val = ParsedValue::Array(vec![
+            ParsedValue::Number("1".to_string()),
+            ParsedValue::Number("2".to_string()),
+            ParsedValue::Number("3".to_string()),
+        ]);
+        let result = Vec::<i32>::deserialize(val).unwrap();
+        assert_eq!(result, vec![1, 2, 3]);
+    }
+
+    #[test]
+    fn deserialize_map_from_object() {
+        use serde::Deserialize;
+        use std::collections::HashMap;
+        let mut map = BTreeMap::new();
+        map.insert("a".to_string(), ParsedValue::Number("1".to_string()));
+        map.insert("b".to_string(), ParsedValue::Number("2".to_string()));
+        let val = ParsedValue::Object(map);
+        let result = HashMap::<String, i32>::deserialize(val).unwrap();
+        assert_eq!(result.len(), 2);
+        assert_eq!(result["a"], 1);
+        assert_eq!(result["b"], 2);
+    }
+
+    #[test]
+    fn deserialize_bytes_from_array() {
+        // Test the deserialize_bytes code path via deserialize_any + byte array
+        let values = vec![
+            ParsedValue::Number("1".to_string()),
+            ParsedValue::Number("2".to_string()),
+            ParsedValue::Number("3".to_string()),
+        ];
+        let val = ParsedValue::Array(values);
+        // Use deserialize_seq to verify array deserialization works
+        use serde::Deserialize;
+        let result = Vec::<u8>::deserialize(val).unwrap();
+        assert_eq!(result, vec![1, 2, 3]);
+    }
+
+    #[test]
+    fn deserialize_ignored_any() {
+        use serde::Deserialize;
+        let val = ParsedValue::Number("42".to_string());
+        let result = serde::de::IgnoredAny::deserialize(val);
+        assert!(result.is_ok());
+    }
+
+    // ---- convert_parsed_request ----
+
+    #[test]
+    fn convert_parsed_request_without_request_tag() {
+        // Should fall through to parse_request_variant directly
+        let val = ParsedValue::Tagged {
+            tag: "Info".to_string(),
+            value: Box::new(ParsedValue::Object({
+                let mut m = BTreeMap::new();
+                m.insert(
+                    "version".to_string(),
+                    ParsedValue::String("1.0".to_string()),
+                );
+                m.insert(
+                    "block_version".to_string(),
+                    ParsedValue::Number("14".to_string()),
+                );
+                m.insert(
+                    "p2p_version".to_string(),
+                    ParsedValue::Number("10".to_string()),
+                );
+                m.insert(
+                    "abci_version".to_string(),
+                    ParsedValue::String("1.0".to_string()),
+                );
+                m
+            })),
+        };
+        let result = convert_parsed_request(val).unwrap();
+        assert!(result.is_some());
+        assert!(matches!(result.unwrap(), LoadedRequest::Info(_)));
+    }
+
+    #[test]
+    fn parse_request_variant_unsupported() {
+        let val = ParsedValue::Tagged {
+            tag: "Unknown".to_string(),
+            value: Box::new(ParsedValue::Object(BTreeMap::new())),
+        };
+        let result = parse_request_variant(val);
+        assert!(result.is_err());
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("unsupported request variant"));
+    }
+
+    #[test]
+    fn parse_request_variant_flush_returns_none() {
+        let val = ParsedValue::Tagged {
+            tag: "Flush".to_string(),
+            value: Box::new(ParsedValue::Object(BTreeMap::new())),
+        };
+        let result = parse_request_variant(val).unwrap();
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn parse_request_variant_missing_tag() {
+        let val = ParsedValue::Number("42".to_string());
+        let result = parse_request_variant(val);
+        assert!(result.is_err());
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("missing request variant tag"));
+    }
+
+    // ---- parse_seconds_nanos ----
+
+    #[test]
+    fn parse_seconds_nanos_missing_fields_default_to_zero() {
+        let map = BTreeMap::new();
+        let (seconds, nanos) = parse_seconds_nanos(ParsedValue::Object(map), "test").unwrap();
+        assert_eq!(seconds, 0);
+        assert_eq!(nanos, 0);
+    }
+
+    #[test]
+    fn parse_seconds_nanos_tagged_wrapping() {
+        let mut map = BTreeMap::new();
+        map.insert("seconds".to_string(), ParsedValue::Number("10".to_string()));
+        let val = ParsedValue::Tagged {
+            tag: "T".to_string(),
+            value: Box::new(ParsedValue::Object(map)),
+        };
+        let (seconds, _) = parse_seconds_nanos(val, "test").unwrap();
+        assert_eq!(seconds, 10);
+    }
+
+    #[test]
+    fn parse_seconds_nanos_wrong_type() {
+        let val = ParsedValue::Number("42".to_string());
+        let result = parse_seconds_nanos(val, "test");
+        assert!(result.is_err());
+    }
+
+    // ---- ParseError ----
+
+    #[test]
+    fn parse_error_display() {
+        let err = ParseError::new("test error");
+        assert_eq!(format!("{}", err), "test error");
+    }
+
+    #[test]
+    fn parse_error_from_box() {
+        let boxed: Box<dyn std::error::Error> = "inner error".into();
+        let err = ParseError::from(boxed);
+        assert_eq!(err.message, "inner error");
+    }
+
+    // ---- PrepareProposal parsing ----
+
+    #[test]
+    fn parses_prepare_proposal() {
+        let raw = r#"Request { value: Some(PrepareProposal(RequestPrepareProposal { max_tx_bytes: 2097152, txs: [], local_last_commit: None, misbehavior: [], height: 100, round: 0, time: Some(Timestamp { seconds: 1721353209, nanos: 0 }), next_validators_hash: [], core_chain_locked_height: 1090319, core_chain_lock_update: None, proposer_pro_tx_hash: [], proposed_app_version: 1, version: None, quorum_hash: [], quorum_type: 0 })) }"#;
+        let result = parse_from_log(raw);
+        assert!(matches!(result, LoadedRequest::Prepare(_)));
+    }
+
+    // ---- deserialize_any through tagged ----
+
+    #[test]
+    fn deserialize_any_tagged_unwraps() {
+        use serde::Deserialize;
+        let val = ParsedValue::Tagged {
+            tag: "Wrapper".to_string(),
+            value: Box::new(ParsedValue::Number("42".to_string())),
+        };
+        let result = i64::deserialize(val).unwrap();
+        assert_eq!(result, 42);
+    }
+
+    // ---- vote_extension_type_from_name ----
+
+    #[test]
+    fn vote_extension_type_default() {
+        let result = vote_extension_type_from_name("Default");
+        assert!(result.is_some());
+    }
+
+    #[test]
+    fn vote_extension_type_unknown() {
+        let result = vote_extension_type_from_name("NonexistentVariant");
+        assert!(result.is_none());
+    }
 }

--- a/packages/rs-drive-abci/src/replay/mod.rs
+++ b/packages/rs-drive-abci/src/replay/mod.rs
@@ -308,3 +308,531 @@ impl RequestSequenceValidator {
         Ok(())
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use runner::LoadedRequest;
+    use std::io::Write;
+    use tenderdash_abci::proto::abci::{
+        RequestFinalizeBlock, RequestInfo, RequestInitChain, RequestProcessProposal,
+    };
+
+    // ---- update_known_height ----
+
+    #[test]
+    fn update_known_height_from_none() {
+        let mut current = None;
+        update_known_height(&mut current, Some(10));
+        assert_eq!(current, Some(10));
+    }
+
+    #[test]
+    fn update_known_height_higher() {
+        let mut current = Some(5);
+        update_known_height(&mut current, Some(10));
+        assert_eq!(current, Some(10));
+    }
+
+    #[test]
+    fn update_known_height_lower_ignored() {
+        let mut current = Some(10);
+        update_known_height(&mut current, Some(5));
+        assert_eq!(current, Some(10));
+    }
+
+    #[test]
+    fn update_known_height_equal_ignored() {
+        let mut current = Some(10);
+        update_known_height(&mut current, Some(10));
+        assert_eq!(current, Some(10));
+    }
+
+    #[test]
+    fn update_known_height_none_new_ignored() {
+        let mut current = Some(10);
+        update_known_height(&mut current, None);
+        assert_eq!(current, Some(10));
+    }
+
+    #[test]
+    fn update_known_height_both_none() {
+        let mut current = None;
+        update_known_height(&mut current, None);
+        assert_eq!(current, None);
+    }
+
+    // ---- should_skip_item ----
+
+    fn make_replay_item(line: usize, request: LoadedRequest) -> ReplayItem {
+        ReplayItem::from_log(std::path::Path::new("/test.log"), line, None, None, request)
+    }
+
+    #[test]
+    fn should_skip_item_no_selectors() {
+        let item = make_replay_item(10, LoadedRequest::Info(RequestInfo::default()));
+        assert!(!should_skip_item(&item, &[]));
+    }
+
+    #[test]
+    fn should_skip_item_matching_line() {
+        let item = make_replay_item(10, LoadedRequest::Info(RequestInfo::default()));
+        let skip = vec![SkipSelector::Line(10)];
+        assert!(should_skip_item(&item, &skip));
+    }
+
+    #[test]
+    fn should_skip_item_non_matching_line() {
+        let item = make_replay_item(10, LoadedRequest::Info(RequestInfo::default()));
+        let skip = vec![SkipSelector::Line(11)];
+        assert!(!should_skip_item(&item, &skip));
+    }
+
+    #[test]
+    fn should_skip_item_in_range() {
+        let item = make_replay_item(15, LoadedRequest::Info(RequestInfo::default()));
+        let skip = vec![SkipSelector::Range { start: 10, end: 20 }];
+        assert!(should_skip_item(&item, &skip));
+    }
+
+    #[test]
+    fn should_skip_item_outside_range() {
+        let item = make_replay_item(25, LoadedRequest::Info(RequestInfo::default()));
+        let skip = vec![SkipSelector::Range { start: 10, end: 20 }];
+        assert!(!should_skip_item(&item, &skip));
+    }
+
+    #[test]
+    fn should_skip_item_multiple_selectors() {
+        let item = make_replay_item(25, LoadedRequest::Info(RequestInfo::default()));
+        let skip = vec![
+            SkipSelector::Line(10),
+            SkipSelector::Range { start: 20, end: 30 },
+        ];
+        assert!(should_skip_item(&item, &skip));
+    }
+
+    // ---- RequestSequenceValidator ----
+
+    #[test]
+    fn validator_empty_sequence_ok() {
+        let validator = RequestSequenceValidator::new(PathBuf::from("/test.log"));
+        validator.finish().unwrap();
+    }
+
+    #[test]
+    fn validator_complete_height_ok() {
+        let mut validator = RequestSequenceValidator::new(PathBuf::from("/test.log"));
+
+        let process = make_replay_item(
+            1,
+            LoadedRequest::Process(RequestProcessProposal {
+                height: 1,
+                ..Default::default()
+            }),
+        );
+        let finalize = make_replay_item(
+            2,
+            LoadedRequest::Finalize(RequestFinalizeBlock {
+                height: 1,
+                ..Default::default()
+            }),
+        );
+
+        validator.observe(&process).unwrap();
+        validator.observe(&finalize).unwrap();
+        validator.finish().unwrap();
+    }
+
+    #[test]
+    fn validator_two_consecutive_heights_ok() {
+        let mut validator = RequestSequenceValidator::new(PathBuf::from("/test.log"));
+
+        let items = [
+            make_replay_item(
+                1,
+                LoadedRequest::Process(RequestProcessProposal {
+                    height: 1,
+                    ..Default::default()
+                }),
+            ),
+            make_replay_item(
+                2,
+                LoadedRequest::Finalize(RequestFinalizeBlock {
+                    height: 1,
+                    ..Default::default()
+                }),
+            ),
+            make_replay_item(
+                3,
+                LoadedRequest::Process(RequestProcessProposal {
+                    height: 2,
+                    ..Default::default()
+                }),
+            ),
+            make_replay_item(
+                4,
+                LoadedRequest::Finalize(RequestFinalizeBlock {
+                    height: 2,
+                    ..Default::default()
+                }),
+            ),
+        ];
+
+        for item in &items {
+            validator.observe(item).unwrap();
+        }
+        validator.finish().unwrap();
+    }
+
+    #[test]
+    fn validator_finalize_before_process_error() {
+        let mut validator = RequestSequenceValidator::new(PathBuf::from("/test.log"));
+        let finalize = make_replay_item(
+            1,
+            LoadedRequest::Finalize(RequestFinalizeBlock {
+                height: 1,
+                ..Default::default()
+            }),
+        );
+        let err = validator.observe(&finalize).unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("finalize_block before process_proposal"),
+            "unexpected error: {}",
+            err
+        );
+    }
+
+    #[test]
+    fn validator_out_of_order_height_error() {
+        let mut validator = RequestSequenceValidator::new(PathBuf::from("/test.log"));
+
+        let items = [
+            make_replay_item(
+                1,
+                LoadedRequest::Process(RequestProcessProposal {
+                    height: 5,
+                    ..Default::default()
+                }),
+            ),
+            make_replay_item(
+                2,
+                LoadedRequest::Finalize(RequestFinalizeBlock {
+                    height: 5,
+                    ..Default::default()
+                }),
+            ),
+        ];
+        for item in &items {
+            validator.observe(item).unwrap();
+        }
+
+        let bad = make_replay_item(
+            3,
+            LoadedRequest::Process(RequestProcessProposal {
+                height: 3,
+                ..Default::default()
+            }),
+        );
+        let err = validator.observe(&bad).unwrap_err();
+        assert!(
+            err.to_string().contains("out-of-order height"),
+            "unexpected error: {}",
+            err
+        );
+    }
+
+    #[test]
+    fn validator_skipped_heights_error() {
+        let mut validator = RequestSequenceValidator::new(PathBuf::from("/test.log"));
+
+        let items = [
+            make_replay_item(
+                1,
+                LoadedRequest::Process(RequestProcessProposal {
+                    height: 1,
+                    ..Default::default()
+                }),
+            ),
+            make_replay_item(
+                2,
+                LoadedRequest::Finalize(RequestFinalizeBlock {
+                    height: 1,
+                    ..Default::default()
+                }),
+            ),
+        ];
+        for item in &items {
+            validator.observe(item).unwrap();
+        }
+
+        let skip = make_replay_item(
+            3,
+            LoadedRequest::Process(RequestProcessProposal {
+                height: 3,
+                ..Default::default()
+            }),
+        );
+        let err = validator.observe(&skip).unwrap_err();
+        assert!(
+            err.to_string().contains("skipped heights"),
+            "unexpected error: {}",
+            err
+        );
+    }
+
+    #[test]
+    fn validator_missing_pair_on_height_change_error() {
+        let mut validator = RequestSequenceValidator::new(PathBuf::from("/test.log"));
+
+        // Only process, no finalize for height 1
+        let process = make_replay_item(
+            1,
+            LoadedRequest::Process(RequestProcessProposal {
+                height: 1,
+                ..Default::default()
+            }),
+        );
+        validator.observe(&process).unwrap();
+
+        // Jump to height 2
+        let process2 = make_replay_item(
+            2,
+            LoadedRequest::Process(RequestProcessProposal {
+                height: 2,
+                ..Default::default()
+            }),
+        );
+        let err = validator.observe(&process2).unwrap_err();
+        assert!(
+            err.to_string().contains("missing process/finalize pair"),
+            "unexpected error: {}",
+            err
+        );
+    }
+
+    #[test]
+    fn validator_finish_incomplete_height_error() {
+        let mut validator = RequestSequenceValidator::new(PathBuf::from("/test.log"));
+
+        let process = make_replay_item(
+            1,
+            LoadedRequest::Process(RequestProcessProposal {
+                height: 1,
+                ..Default::default()
+            }),
+        );
+        validator.observe(&process).unwrap();
+
+        let err = validator.finish().unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("ended before height 1 had both process_proposal and finalize_block"),
+            "unexpected error: {}",
+            err
+        );
+    }
+
+    #[test]
+    fn validator_info_request_ignored() {
+        let mut validator = RequestSequenceValidator::new(PathBuf::from("/test.log"));
+        let info = make_replay_item(1, LoadedRequest::Info(RequestInfo::default()));
+        validator.observe(&info).unwrap();
+        validator.finish().unwrap();
+    }
+
+    #[test]
+    fn validator_init_chain_ignored() {
+        let mut validator = RequestSequenceValidator::new(PathBuf::from("/test.log"));
+        // InitChain returns height 0, which is treated as no block_height match (not Process/Finalize)
+        let init = make_replay_item(1, LoadedRequest::InitChain(RequestInitChain::default()));
+        validator.observe(&init).unwrap();
+        // InitChain is neither Process nor Finalize, so no error
+    }
+
+    // ---- LogRequestStream integration tests ----
+
+    #[test]
+    fn log_stream_reads_info_request() {
+        let dir = tempfile::tempdir().unwrap();
+        let log_path = dir.path().join("test.log");
+        {
+            let mut f = std::fs::File::create(&log_path).unwrap();
+            writeln!(
+                f,
+                r#"{{"timestamp":"2024-01-01T00:00:00Z","fields":{{"message":"received ABCI request","request":"Request {{ value: Some(Info(RequestInfo {{ version: \"1.0\", block_version: 14, p2p_version: 10, abci_version: \"1.0\" }})) }}"}},"span":{{"endpoint":"info"}}}}"#
+            )
+            .unwrap();
+        }
+        let mut stream = LogRequestStream::open(&log_path).unwrap();
+        let item = stream.next_item().unwrap().expect("expected an item");
+        assert!(matches!(item.request, LoadedRequest::Info(_)));
+        assert!(stream.next_item().unwrap().is_none());
+    }
+
+    #[test]
+    fn log_stream_skips_irrelevant_lines() {
+        let dir = tempfile::tempdir().unwrap();
+        let log_path = dir.path().join("test.log");
+        {
+            let mut f = std::fs::File::create(&log_path).unwrap();
+            // Line without "received ABCI request"
+            writeln!(
+                f,
+                r#"{{"timestamp":"2024-01-01T00:00:00Z","fields":{{"message":"something else"}}}}"#
+            )
+            .unwrap();
+            // Empty line
+            writeln!(f).unwrap();
+            // Malformed JSON
+            writeln!(f, "not json at all").unwrap();
+            // Line without fields
+            writeln!(f, r#"{{"timestamp":"2024-01-01T00:00:00Z"}}"#).unwrap();
+            // Line with message but no request
+            writeln!(
+                f,
+                r#"{{"timestamp":"2024-01-01T00:00:00Z","fields":{{"message":"received ABCI request"}}}}"#
+            )
+            .unwrap();
+        }
+        let mut stream = LogRequestStream::open(&log_path).unwrap();
+        assert!(stream.next_item().unwrap().is_none());
+    }
+
+    #[test]
+    fn log_stream_peek_then_next() {
+        let dir = tempfile::tempdir().unwrap();
+        let log_path = dir.path().join("test.log");
+        {
+            let mut f = std::fs::File::create(&log_path).unwrap();
+            writeln!(
+                f,
+                r#"{{"timestamp":"2024-01-01T00:00:00Z","fields":{{"message":"received ABCI request","request":"Request {{ value: Some(Info(RequestInfo {{ version: \"1.0\", block_version: 14, p2p_version: 10, abci_version: \"1.0\" }})) }}"}},"span":{{"endpoint":"info"}}}}"#
+            )
+            .unwrap();
+        }
+        let mut stream = LogRequestStream::open(&log_path).unwrap();
+        // Peek should return a reference without consuming
+        assert!(stream.peek().unwrap().is_some());
+        // Peek again should return the same item
+        assert!(stream.peek().unwrap().is_some());
+        // next_item should consume the buffered item
+        let item = stream.next_item().unwrap().expect("expected an item");
+        assert!(matches!(item.request, LoadedRequest::Info(_)));
+        // Stream should now be empty
+        assert!(stream.next_item().unwrap().is_none());
+    }
+
+    #[test]
+    fn log_stream_skip_processed_entries() {
+        let dir = tempfile::tempdir().unwrap();
+        let log_path = dir.path().join("test.log");
+        {
+            let mut f = std::fs::File::create(&log_path).unwrap();
+            // ProcessProposal at height 1
+            writeln!(
+                f,
+                r#"{{"timestamp":"t1","fields":{{"message":"received ABCI request","request":"Request {{ value: Some(ProcessProposal(RequestProcessProposal {{ txs: [], proposed_last_commit: None, misbehavior: [], hash: [], height: 1, round: 0, time: None, next_validators_hash: [], core_chain_locked_height: 0, core_chain_lock_update: None, proposer_pro_tx_hash: [], proposed_app_version: 1, version: None, quorum_hash: [] }})) }}"}}}}"#
+            )
+            .unwrap();
+            // ProcessProposal at height 5
+            writeln!(
+                f,
+                r#"{{"timestamp":"t2","fields":{{"message":"received ABCI request","request":"Request {{ value: Some(ProcessProposal(RequestProcessProposal {{ txs: [], proposed_last_commit: None, misbehavior: [], hash: [], height: 5, round: 0, time: None, next_validators_hash: [], core_chain_locked_height: 0, core_chain_lock_update: None, proposer_pro_tx_hash: [], proposed_app_version: 1, version: None, quorum_hash: [] }})) }}"}}}}"#
+            )
+            .unwrap();
+        }
+        let mut stream = LogRequestStream::open(&log_path).unwrap();
+        let skipped = stream.skip_processed_entries(3).unwrap();
+        assert_eq!(skipped, 1);
+        // Remaining item should be height 5
+        let item = stream.next_item().unwrap().expect("expected height 5 item");
+        assert_eq!(item.request.block_height(), Some(5));
+    }
+
+    // ---- drain_skipped_entries ----
+
+    #[test]
+    fn drain_skipped_entries_empty_skip() {
+        let dir = tempfile::tempdir().unwrap();
+        let log_path = dir.path().join("test.log");
+        {
+            let mut f = std::fs::File::create(&log_path).unwrap();
+            writeln!(
+                f,
+                r#"{{"timestamp":"t1","fields":{{"message":"received ABCI request","request":"Request {{ value: Some(Info(RequestInfo {{ version: \"1.0\", block_version: 14, p2p_version: 10, abci_version: \"1.0\" }})) }}"}}}}"#
+            )
+            .unwrap();
+        }
+        let mut stream = LogRequestStream::open(&log_path).unwrap();
+        drain_skipped_entries(&mut stream, &[]).unwrap();
+        // Item should still be available
+        assert!(stream.next_item().unwrap().is_some());
+    }
+
+    #[test]
+    fn drain_skipped_entries_skips_matching_lines() {
+        let dir = tempfile::tempdir().unwrap();
+        let log_path = dir.path().join("test.log");
+        {
+            let mut f = std::fs::File::create(&log_path).unwrap();
+            // Line 1 - will be skipped
+            writeln!(
+                f,
+                r#"{{"timestamp":"t1","fields":{{"message":"received ABCI request","request":"Request {{ value: Some(Info(RequestInfo {{ version: \"1.0\", block_version: 14, p2p_version: 10, abci_version: \"1.0\" }})) }}"}}}}"#
+            )
+            .unwrap();
+            // Line 2 - not skipped
+            writeln!(
+                f,
+                r#"{{"timestamp":"t2","fields":{{"message":"received ABCI request","request":"Request {{ value: Some(Info(RequestInfo {{ version: \"2.0\", block_version: 14, p2p_version: 10, abci_version: \"1.0\" }})) }}"}}}}"#
+            )
+            .unwrap();
+        }
+        let mut stream = LogRequestStream::open(&log_path).unwrap();
+        let skip = vec![SkipSelector::Line(1)];
+        drain_skipped_entries(&mut stream, &skip).unwrap();
+        // The remaining item should be from line 2
+        let item = stream.next_item().unwrap().expect("expected an item");
+        assert_eq!(item.source.line(), 2);
+    }
+
+    // ---- advance_stream ----
+
+    #[test]
+    fn advance_stream_no_height_no_skip() {
+        let dir = tempfile::tempdir().unwrap();
+        let log_path = dir.path().join("test.log");
+        {
+            let mut f = std::fs::File::create(&log_path).unwrap();
+            writeln!(
+                f,
+                r#"{{"timestamp":"t1","fields":{{"message":"received ABCI request","request":"Request {{ value: Some(Info(RequestInfo {{ version: \"1.0\", block_version: 14, p2p_version: 10, abci_version: \"1.0\" }})) }}"}}}}"#
+            )
+            .unwrap();
+        }
+        let mut stream = LogRequestStream::open(&log_path).unwrap();
+        advance_stream(&mut stream, None, &[]).unwrap();
+        assert!(stream.next_item().unwrap().is_some());
+    }
+
+    // ---- Log stream with Flush (filtered out) ----
+
+    #[test]
+    fn log_stream_flush_request_filtered_out() {
+        let dir = tempfile::tempdir().unwrap();
+        let log_path = dir.path().join("test.log");
+        {
+            let mut f = std::fs::File::create(&log_path).unwrap();
+            writeln!(
+                f,
+                r#"{{"timestamp":"t1","fields":{{"message":"received ABCI request","request":"Request {{ value: Some(Flush(RequestFlush {{}})) }}"}}}}"#
+            )
+            .unwrap();
+        }
+        let mut stream = LogRequestStream::open(&log_path).unwrap();
+        // Flush is filtered to None by parse_request_variant
+        assert!(stream.next_item().unwrap().is_none());
+    }
+}

--- a/packages/rs-drive-abci/src/replay/runner.rs
+++ b/packages/rs-drive-abci/src/replay/runner.rs
@@ -550,3 +550,385 @@ fn format_height_round(height: Option<i64>, round: Option<i32>) -> String {
         format!(" ({})", parts.join(", "))
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tenderdash_abci::proto::abci::{
+        RequestExtendVote, RequestFinalizeBlock, RequestInfo, RequestInitChain,
+        RequestPrepareProposal, RequestProcessProposal, RequestVerifyVoteExtension,
+    };
+    use tenderdash_abci::proto::types::{Block, Header};
+
+    // ---- stop_height_reached ----
+
+    #[test]
+    fn stop_height_reached_no_limit() {
+        assert!(!stop_height_reached(None, Some(100)));
+    }
+
+    #[test]
+    fn stop_height_reached_no_known_height() {
+        assert!(!stop_height_reached(Some(100), None));
+    }
+
+    #[test]
+    fn stop_height_reached_both_none() {
+        assert!(!stop_height_reached(None, None));
+    }
+
+    #[test]
+    fn stop_height_reached_below_limit() {
+        assert!(!stop_height_reached(Some(100), Some(99)));
+    }
+
+    #[test]
+    fn stop_height_reached_at_limit() {
+        assert!(stop_height_reached(Some(100), Some(100)));
+    }
+
+    #[test]
+    fn stop_height_reached_above_limit() {
+        assert!(stop_height_reached(Some(100), Some(101)));
+    }
+
+    // ---- format_height_round ----
+
+    #[test]
+    fn format_height_round_both_present() {
+        let result = format_height_round(Some(42), Some(3));
+        assert_eq!(result, " (height=42, round=3)");
+    }
+
+    #[test]
+    fn format_height_round_height_only() {
+        let result = format_height_round(Some(42), None);
+        assert_eq!(result, " (height=42)");
+    }
+
+    #[test]
+    fn format_height_round_round_only() {
+        let result = format_height_round(None, Some(3));
+        assert_eq!(result, " (round=3)");
+    }
+
+    #[test]
+    fn format_height_round_neither() {
+        let result = format_height_round(None, None);
+        assert_eq!(result, "");
+    }
+
+    // ---- extract_expected_app_hash ----
+
+    #[test]
+    fn extract_expected_app_hash_with_block_and_header() {
+        let request = RequestFinalizeBlock {
+            block: Some(Block {
+                header: Some(Header {
+                    app_hash: vec![1, 2, 3, 4],
+                    ..Default::default()
+                }),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        let hash = extract_expected_app_hash(&request);
+        assert_eq!(hash, Some(vec![1, 2, 3, 4]));
+    }
+
+    #[test]
+    fn extract_expected_app_hash_no_block() {
+        let request = RequestFinalizeBlock {
+            block: None,
+            ..Default::default()
+        };
+        assert_eq!(extract_expected_app_hash(&request), None);
+    }
+
+    #[test]
+    fn extract_expected_app_hash_no_header() {
+        let request = RequestFinalizeBlock {
+            block: Some(Block {
+                header: None,
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        assert_eq!(extract_expected_app_hash(&request), None);
+    }
+
+    // ---- LoadedRequest::block_height ----
+
+    #[test]
+    fn loaded_request_block_height_init_chain() {
+        let request = LoadedRequest::InitChain(RequestInitChain::default());
+        assert_eq!(request.block_height(), Some(0));
+    }
+
+    #[test]
+    fn loaded_request_block_height_info() {
+        let request = LoadedRequest::Info(RequestInfo::default());
+        assert_eq!(request.block_height(), None);
+    }
+
+    #[test]
+    fn loaded_request_block_height_prepare() {
+        let request = LoadedRequest::Prepare(RequestPrepareProposal {
+            height: 42,
+            ..Default::default()
+        });
+        assert_eq!(request.block_height(), Some(42));
+    }
+
+    #[test]
+    fn loaded_request_block_height_process() {
+        let request = LoadedRequest::Process(RequestProcessProposal {
+            height: 100,
+            ..Default::default()
+        });
+        assert_eq!(request.block_height(), Some(100));
+    }
+
+    #[test]
+    fn loaded_request_block_height_finalize() {
+        let request = LoadedRequest::Finalize(RequestFinalizeBlock {
+            height: 200,
+            ..Default::default()
+        });
+        assert_eq!(request.block_height(), Some(200));
+    }
+
+    #[test]
+    fn loaded_request_block_height_extend_vote() {
+        let request = LoadedRequest::ExtendVote(RequestExtendVote {
+            height: 300,
+            ..Default::default()
+        });
+        assert_eq!(request.block_height(), Some(300));
+    }
+
+    #[test]
+    fn loaded_request_block_height_verify_vote_extension() {
+        let request = LoadedRequest::VerifyVoteExtension(RequestVerifyVoteExtension {
+            height: 400,
+            ..Default::default()
+        });
+        assert_eq!(request.block_height(), Some(400));
+    }
+
+    #[test]
+    fn loaded_request_block_height_negative() {
+        let request = LoadedRequest::Prepare(RequestPrepareProposal {
+            height: -1,
+            ..Default::default()
+        });
+        assert_eq!(request.block_height(), None);
+    }
+
+    // ---- ReplaySource::describe ----
+
+    #[test]
+    fn replay_source_describe_minimal() {
+        let source = ReplaySource {
+            path: PathBuf::from("/some/file.log"),
+            line: 42,
+            timestamp: None,
+            endpoint: None,
+        };
+        assert_eq!(source.describe(), "/some/file.log:42");
+    }
+
+    #[test]
+    fn replay_source_describe_with_endpoint() {
+        let source = ReplaySource {
+            path: PathBuf::from("/some/file.log"),
+            line: 42,
+            timestamp: None,
+            endpoint: Some("process_proposal".to_string()),
+        };
+        assert_eq!(source.describe(), "/some/file.log:42 process_proposal");
+    }
+
+    #[test]
+    fn replay_source_describe_with_timestamp() {
+        let source = ReplaySource {
+            path: PathBuf::from("/some/file.log"),
+            line: 42,
+            timestamp: Some("2024-01-01T00:00:00Z".to_string()),
+            endpoint: None,
+        };
+        assert_eq!(source.describe(), "/some/file.log:42 @2024-01-01T00:00:00Z");
+    }
+
+    #[test]
+    fn replay_source_describe_with_both() {
+        let source = ReplaySource {
+            path: PathBuf::from("/some/file.log"),
+            line: 42,
+            timestamp: Some("2024-01-01T00:00:00Z".to_string()),
+            endpoint: Some("finalize_block".to_string()),
+        };
+        assert_eq!(
+            source.describe(),
+            "/some/file.log:42 finalize_block @2024-01-01T00:00:00Z"
+        );
+    }
+
+    // ---- ReplayItem::from_log and describe ----
+
+    #[test]
+    fn replay_item_from_log_and_describe() {
+        let item = ReplayItem::from_log(
+            Path::new("/test/path.log"),
+            10,
+            Some("2024-01-01T00:00:00Z".to_string()),
+            Some("info".to_string()),
+            LoadedRequest::Info(RequestInfo::default()),
+        );
+        assert_eq!(
+            item.describe(),
+            "/test/path.log:10 info @2024-01-01T00:00:00Z"
+        );
+        assert_eq!(item.source.line(), 10);
+    }
+
+    // ---- ProgressReporter ----
+
+    #[test]
+    fn progress_reporter_format_rate_some() {
+        let formatted = ProgressReporter::format_rate(Some(12.345));
+        assert_eq!(formatted, "12.35 blk/min");
+    }
+
+    #[test]
+    fn progress_reporter_format_rate_none() {
+        let formatted = ProgressReporter::format_rate(None);
+        assert_eq!(formatted, "n/a");
+    }
+
+    #[test]
+    fn progress_reporter_format_eta_none() {
+        let formatted = ProgressReporter::format_eta(None);
+        assert_eq!(formatted, "n/a");
+    }
+
+    #[test]
+    fn progress_reporter_format_eta_zero() {
+        let formatted = ProgressReporter::format_eta(Some(Duration::from_secs(0)));
+        assert_eq!(formatted, "00s");
+    }
+
+    #[test]
+    fn progress_reporter_format_eta_seconds_only() {
+        let formatted = ProgressReporter::format_eta(Some(Duration::from_secs(45)));
+        assert_eq!(formatted, "45s");
+    }
+
+    #[test]
+    fn progress_reporter_format_eta_minutes_and_seconds() {
+        let formatted = ProgressReporter::format_eta(Some(Duration::from_secs(125)));
+        assert_eq!(formatted, "02m05s");
+    }
+
+    #[test]
+    fn progress_reporter_format_eta_hours() {
+        let formatted = ProgressReporter::format_eta(Some(Duration::from_secs(3723)));
+        assert_eq!(formatted, "01h02m03s");
+    }
+
+    #[test]
+    fn progress_reporter_short_hash_truncates() {
+        let hash = vec![0xAB, 0xCD, 0xEF, 0x01, 0x23, 0x45, 0x67, 0x89, 0xDE, 0xAD];
+        let short = ProgressReporter::short_hash(&hash);
+        assert_eq!(short.len(), 10);
+        assert_eq!(short, "abcdef0123");
+    }
+
+    #[test]
+    fn progress_reporter_short_hash_short_input() {
+        let hash = vec![0xAB, 0xCD];
+        let short = ProgressReporter::short_hash(&hash);
+        assert_eq!(short, "abcd");
+    }
+
+    #[test]
+    fn progress_reporter_eta_no_stop_height() {
+        let reporter = ProgressReporter::new(None);
+        assert_eq!(reporter.eta(Some(10.0), 50), None);
+    }
+
+    #[test]
+    fn progress_reporter_eta_already_reached() {
+        let reporter = ProgressReporter::new(Some(100));
+        assert_eq!(reporter.eta(Some(10.0), 100), Some(Duration::from_secs(0)));
+    }
+
+    #[test]
+    fn progress_reporter_eta_above_target() {
+        let reporter = ProgressReporter::new(Some(100));
+        assert_eq!(reporter.eta(Some(10.0), 200), Some(Duration::from_secs(0)));
+    }
+
+    #[test]
+    fn progress_reporter_eta_no_rate() {
+        let reporter = ProgressReporter::new(Some(100));
+        assert_eq!(reporter.eta(None, 50), None);
+    }
+
+    #[test]
+    fn progress_reporter_eta_zero_rate() {
+        let reporter = ProgressReporter::new(Some(100));
+        assert_eq!(reporter.eta(Some(0.0), 50), None);
+    }
+
+    #[test]
+    fn progress_reporter_eta_negative_rate() {
+        let reporter = ProgressReporter::new(Some(100));
+        assert_eq!(reporter.eta(Some(-5.0), 50), None);
+    }
+
+    #[test]
+    fn progress_reporter_eta_computes_remaining() {
+        let reporter = ProgressReporter::new(Some(100));
+        // 50 blocks remaining at 60 blocks/min = 50s
+        let eta = reporter.eta(Some(60.0), 50);
+        assert_eq!(eta, Some(Duration::from_secs(50)));
+    }
+
+    // ---- ensure_db_directory ----
+
+    #[test]
+    fn ensure_db_directory_creates_new() {
+        let dir = tempfile::tempdir().unwrap();
+        let new_path = dir.path().join("subdir").join("nested");
+        let created = ensure_db_directory(&new_path).unwrap();
+        assert!(created);
+        assert!(new_path.is_dir());
+    }
+
+    #[test]
+    fn ensure_db_directory_existing_dir() {
+        let dir = tempfile::tempdir().unwrap();
+        let created = ensure_db_directory(dir.path()).unwrap();
+        assert!(!created);
+    }
+
+    #[test]
+    fn ensure_db_directory_existing_file_error() {
+        let dir = tempfile::tempdir().unwrap();
+        let file_path = dir.path().join("not_a_dir");
+        fs::write(&file_path, "data").unwrap();
+        let result = ensure_db_directory(&file_path);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("not a directory"));
+    }
+
+    // ---- ProgressReporter rate_per_minute and trim_history ----
+
+    #[test]
+    fn progress_reporter_rate_per_minute_empty_history() {
+        let reporter = ProgressReporter::new(None);
+        let rate = reporter.rate_per_minute(Instant::now(), Duration::from_secs(60));
+        assert!(rate.is_none());
+    }
+}


### PR DESCRIPTION
## Issue being fixed or feature implemented

Improve test coverage for the `packages/rs-drive-abci/src/replay/` module, which previously had 0% coverage on cli.rs, mod.rs, and runner.rs, and ~47% on log_ingest.rs.

## What was done?

Added 179 unit tests across all four replay module files:

**cli.rs (13 tests):** `SkipSelector::matches` for exact line and range matching, `parse_skip_selector` for valid inputs (single line, range, whitespace) and error cases (empty, inverted range, non-numeric).

**log_ingest.rs (90 tests):** `DebugValueParser` for all value types (null, bool, numbers, strings with escape sequences, arrays, objects, tagged variants, Some/None wrapping), `ParsedValue` methods (`into_object`, `to_string_value`), helper functions (`normalize_type_tag`, `normalize_field_key`, `camel_to_upper_snake`, `is_enum_variant_identifier`, `normalize_identifier_value`), timestamp/duration formatting with error cases, `parse_number_field`/`parse_number_value` edge cases (bool coercion, tagged wrapping, wrong types), `array_to_hex`, `Deserializer` trait implementation (bool/i64/u64/f32/f64/string/option/unit/seq/map/enum/bytes), `convert_parsed_request` paths, `PrepareProposal` parsing, and `vote_extension_type_from_name`.

**mod.rs (30 tests):** `update_known_height` state transitions (from None, higher, lower, equal, None new), `should_skip_item` with various selectors, `RequestSequenceValidator` for valid sequences and all error paths (out-of-order heights, skipped heights, missing process/finalize pairs, incomplete sequences), `LogRequestStream` integration tests (read info request, skip irrelevant lines, peek/next buffering, skip_processed_entries, Flush filtering), `drain_skipped_entries`, and `advance_stream`.

**runner.rs (46 tests):** `stop_height_reached` all combinations, `format_height_round` formatting, `extract_expected_app_hash` with/without block and header, `LoadedRequest::block_height` for all 7 variants including negative values, `ReplaySource::describe` formatting with various optional fields, `ReplayItem::from_log`, `ProgressReporter` (format_rate, format_eta with hours/minutes/seconds, short_hash truncation, eta computation with edge cases, rate_per_minute with empty history), and `ensure_db_directory` (create new, existing dir, file-not-dir error).

## How Has This Been Tested?

All 179 tests pass locally:
```
cargo test -p drive-abci --lib --features replay -- replay::cli::tests       # 13 passed
cargo test -p drive-abci --lib --features replay -- replay::log_ingest::tests # 90 passed
cargo test -p drive-abci --lib --features replay -- replay::tests            # 30 passed
cargo test -p drive-abci --lib --features replay -- replay::runner::tests    # 46 passed
```

## Breaking Changes

None. This PR only adds test code.

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [x] I have made corresponding changes to the documentation if needed

Generated with [Claude Code](https://claude.com/claude-code)