### PR TITLE
test(drive): improve group module test coverage

### DIFF
--- a/packages/rs-drive/src/drive/group/fetch/fetch_group_infos/v0/mod.rs
+++ b/packages/rs-drive/src/drive/group/fetch/fetch_group_infos/v0/mod.rs
@@ -50,20 +50,31 @@ impl Drive {
         self.grove_get_raw_path_query(
             &path_query,
             transaction,
-            QueryResultType::QueryKeyElementPairResultType,
+            QueryResultType::QueryPathKeyElementTrioResultType,
             drive_operations,
             &platform_version.drive,
         )?
         .0
-        .to_key_elements_btree_map()
+        .to_path_key_elements()
         .into_iter()
-        .map(|(key, element)| {
+        .map(|(path, _key, element)| {
+            // The query uses a subquery key (GROUP_INFO_KEY), so the returned key is the
+            // subquery key, not the group contract position. The group contract position is
+            // the last component of the path (the parent key that matched the range query).
+            let Some(group_position_bytes) = path.last() else {
+                return Err(Error::Drive(DriveError::CorruptedDriveState(
+                    "expected path to not be empty when fetching group infos".to_string(),
+                )));
+            };
             let group_contract_position: GroupContractPosition =
-                GroupContractPosition::from_be_bytes(key.try_into().map_err(|_| {
-                    Error::Drive(DriveError::CorruptedDriveState(
-                        "group contract position not encoded on 2 bytes as expected".to_string(),
-                    ))
-                })?);
+                GroupContractPosition::from_be_bytes(
+                    group_position_bytes.clone().try_into().map_err(|_| {
+                        Error::Drive(DriveError::CorruptedDriveState(
+                            "group contract position not encoded on 2 bytes as expected"
+                                .to_string(),
+                        ))
+                    })?,
+                );
             match element {
                 Item(value, ..) => Ok((
                     group_contract_position,

--- a/packages/rs-drive/src/drive/group/fetch/fetch_group_infos/v0/mod.rs
+++ b/packages/rs-drive/src/drive/group/fetch/fetch_group_infos/v0/mod.rs
@@ -68,7 +68,7 @@ impl Drive {
             };
             let group_contract_position: GroupContractPosition =
                 GroupContractPosition::from_be_bytes(
-                    group_position_bytes.clone().try_into().map_err(|_| {
+                    group_position_bytes.as_slice().try_into().map_err(|_| {
                         Error::Drive(DriveError::CorruptedDriveState(
                             "group contract position not encoded on 2 bytes as expected"
                                 .to_string(),

--- a/packages/rs-drive/src/drive/group/mod.rs
+++ b/packages/rs-drive/src/drive/group/mod.rs
@@ -245,6 +245,8 @@ mod tests {
             updated_at_block_height: None,
             created_at_epoch: None,
             updated_at_epoch: None,
+            // Use a position above 255 to exercise the 2-byte big-endian encoding,
+            // which is the exact scenario the fetch_group_infos bug would have broken.
             groups: BTreeMap::from([
                 (
                     0,
@@ -254,7 +256,7 @@ mod tests {
                     }),
                 ),
                 (
-                    1,
+                    300,
                     Group::V0(GroupV0 {
                         members: [(identity_1_id, 3)].into(),
                         required_power: 3,
@@ -287,7 +289,10 @@ mod tests {
 
         assert_eq!(groups.len(), 2);
         assert!(groups.contains_key(&0));
-        assert!(groups.contains_key(&1));
+        assert!(
+            groups.contains_key(&300),
+            "position 300 (above 255) should be correctly decoded from 2 bytes"
+        );
     }
 
     #[test]
@@ -609,6 +614,27 @@ mod tests {
         assert!(
             closed_signers.contains_key(&identity_2_id),
             "identity_2 should be in closed signers"
+        );
+
+        // Verify signers were REMOVED from the active state (moved, not copied)
+        let active_signers = drive
+            .fetch_action_signers(
+                contract_id,
+                0,
+                GroupActionStatus::ActionActive,
+                action_id,
+                None,
+                platform_version,
+            )
+            .expect("expected to fetch active signers");
+
+        assert!(
+            !active_signers.contains_key(&identity_1_id),
+            "identity_1 should not remain in active signers after closing"
+        );
+        assert!(
+            !active_signers.contains_key(&identity_2_id),
+            "identity_2 should not remain in active signers after closing"
         );
     }
 

--- a/packages/rs-drive/src/drive/group/mod.rs
+++ b/packages/rs-drive/src/drive/group/mod.rs
@@ -32,6 +32,7 @@ mod tests {
     use dpp::identifier::Identifier;
     use dpp::identity::accessors::IdentityGettersV0;
     use dpp::identity::Identity;
+    use dpp::serialization::PlatformDeserializable;
     use dpp::tokens::token_event::TokenEvent;
     use dpp::version::PlatformVersion;
     use std::collections::BTreeMap;
@@ -165,8 +166,7 @@ mod tests {
             .fetch_group_info(contract_id, 0, None, platform_version)
             .expect("expected to fetch group info");
 
-        assert!(group.is_some(), "group should exist");
-        let group = group.unwrap();
+        let group = group.expect("group should exist");
         assert_eq!(
             group,
             Group::V0(GroupV0 {
@@ -514,16 +514,27 @@ mod tests {
 
     #[test]
     fn should_fetch_serialized_action_info() {
-        let (drive, contract_id, _, _, action_id) = setup_drive_with_contract_and_action();
+        let (drive, contract_id, identity_1_id, _, action_id) =
+            setup_drive_with_contract_and_action();
         let platform_version = PlatformVersion::latest();
 
         let serialized = drive
             .fetch_action_id_info_keep_serialized(contract_id, 0, action_id, None, platform_version)
             .expect("expected to fetch serialized action info");
 
-        assert!(
-            !serialized.is_empty(),
-            "serialized data should not be empty"
+        let deserialized = GroupAction::deserialize_from_bytes(&serialized)
+            .expect("expected to deserialize action info");
+
+        let expected = GroupAction::V0(GroupActionV0 {
+            contract_id,
+            proposer_id: identity_1_id,
+            token_contract_position: 0,
+            event: GroupActionEvent::TokenEvent(TokenEvent::Mint(100, identity_1_id, None)),
+        });
+
+        assert_eq!(
+            deserialized, expected,
+            "deserialized action info should match the originally inserted action"
         );
     }
 
@@ -635,6 +646,35 @@ mod tests {
         assert!(
             !active_signers.contains_key(&identity_2_id),
             "identity_2 should not remain in active signers after closing"
+        );
+
+        // Verify action info was moved to the closed subtree
+        let closed_actions = drive
+            .fetch_action_infos(
+                contract_id,
+                0,
+                GroupActionStatus::ActionClosed,
+                None,
+                Some(10),
+                None,
+                platform_version,
+            )
+            .expect("expected to fetch closed action infos");
+
+        let closed_action = closed_actions
+            .get(&action_id)
+            .expect("action info should exist in closed subtree");
+
+        let expected_action = GroupAction::V0(GroupActionV0 {
+            contract_id,
+            proposer_id: identity_1_id,
+            token_contract_position: 0,
+            event: GroupActionEvent::TokenEvent(TokenEvent::Mint(100, identity_1_id, None)),
+        });
+
+        assert_eq!(
+            *closed_action, expected_action,
+            "closed action info should match the originally inserted action"
         );
     }
 
@@ -983,7 +1023,15 @@ mod tests {
                 .expect("expected proof verification to succeed");
 
         assert!(!root_hash.is_empty());
-        assert!(group.is_some());
+        let group = group.expect("group should exist in proof");
+        assert_eq!(
+            group,
+            Group::V0(GroupV0 {
+                members: [(identity_1.id(), 1), (identity_2.id(), 2)].into(),
+                required_power: 3,
+            }),
+            "proved group should match the inserted group"
+        );
     }
 
     #[test]

--- a/packages/rs-drive/src/drive/group/mod.rs
+++ b/packages/rs-drive/src/drive/group/mod.rs
@@ -9,3 +9,1172 @@ pub mod paths;
 #[cfg(feature = "server")]
 mod prove;
 mod queries;
+
+#[cfg(test)]
+#[cfg(feature = "server")]
+mod tests {
+    use crate::drive::Drive;
+    use crate::util::test_helpers::setup::setup_drive_with_initial_state_structure;
+    use dpp::block::block_info::BlockInfo;
+    use dpp::data_contract::accessors::v0::DataContractV0Getters;
+    use dpp::data_contract::associated_token::token_configuration::v0::TokenConfigurationV0;
+    use dpp::data_contract::associated_token::token_configuration::TokenConfiguration;
+    use dpp::data_contract::config::v0::DataContractConfigV0;
+    use dpp::data_contract::config::DataContractConfig;
+    use dpp::data_contract::group::v0::GroupV0;
+    use dpp::data_contract::group::Group;
+    use dpp::data_contract::v1::DataContractV1;
+    use dpp::data_contract::DataContract;
+    use dpp::group::action_event::GroupActionEvent;
+    use dpp::group::group_action::v0::GroupActionV0;
+    use dpp::group::group_action::GroupAction;
+    use dpp::group::group_action_status::GroupActionStatus;
+    use dpp::identifier::Identifier;
+    use dpp::identity::accessors::IdentityGettersV0;
+    use dpp::identity::Identity;
+    use dpp::tokens::token_event::TokenEvent;
+    use dpp::version::PlatformVersion;
+    use std::collections::BTreeMap;
+
+    /// Helper to create a standard test contract with groups and tokens.
+    fn create_test_contract_with_groups(
+        identity_1_id: Identifier,
+        identity_2_id: Identifier,
+    ) -> DataContract {
+        DataContract::V1(DataContractV1 {
+            id: Default::default(),
+            version: 0,
+            owner_id: Default::default(),
+            document_types: Default::default(),
+            config: DataContractConfig::V0(DataContractConfigV0 {
+                can_be_deleted: false,
+                readonly: false,
+                keeps_history: false,
+                documents_keep_history_contract_default: false,
+                documents_mutable_contract_default: false,
+                documents_can_be_deleted_contract_default: false,
+                requires_identity_encryption_bounded_key: None,
+                requires_identity_decryption_bounded_key: None,
+            }),
+            schema_defs: None,
+            created_at: None,
+            updated_at: None,
+            created_at_block_height: None,
+            updated_at_block_height: None,
+            created_at_epoch: None,
+            updated_at_epoch: None,
+            groups: BTreeMap::from([(
+                0,
+                Group::V0(GroupV0 {
+                    members: [(identity_1_id, 1), (identity_2_id, 2)].into(),
+                    required_power: 3,
+                }),
+            )]),
+            tokens: BTreeMap::from([(
+                0,
+                TokenConfiguration::V0(TokenConfigurationV0::default_most_restrictive()),
+            )]),
+            keywords: Vec::new(),
+            description: None,
+        })
+    }
+
+    /// Helper to insert a contract and add an action, returning IDs.
+    fn setup_drive_with_contract_and_action(
+    ) -> (Drive, Identifier, Identifier, Identifier, Identifier) {
+        let drive = setup_drive_with_initial_state_structure(None);
+        let platform_version = PlatformVersion::latest();
+
+        let identity_1 = Identity::random_identity(3, Some(14), platform_version)
+            .expect("expected a platform identity");
+        let identity_2 = Identity::random_identity(3, Some(506), platform_version)
+            .expect("expected a platform identity");
+        let identity_1_id = identity_1.id();
+        let identity_2_id = identity_2.id();
+
+        let contract = create_test_contract_with_groups(identity_1_id, identity_2_id);
+        let contract_id = contract.id();
+
+        drive
+            .insert_contract(
+                &contract,
+                BlockInfo::default(),
+                true,
+                None,
+                platform_version,
+            )
+            .expect("expected to insert contract");
+
+        let action_id = Identifier::random();
+        let action = GroupAction::V0(GroupActionV0 {
+            contract_id,
+            proposer_id: identity_1_id,
+            token_contract_position: 0,
+            event: GroupActionEvent::TokenEvent(TokenEvent::Mint(100, identity_1_id, None)),
+        });
+
+        drive
+            .add_group_action(
+                contract_id,
+                0,
+                Some(action),
+                false,
+                action_id,
+                identity_1_id,
+                1,
+                &BlockInfo::default(),
+                true,
+                None,
+                platform_version,
+            )
+            .expect("expected to add group action");
+
+        (drive, contract_id, identity_1_id, identity_2_id, action_id)
+    }
+
+    // ========================================================================
+    // fetch_group_info tests (covers fetch_group_info mod.rs + v0/mod.rs)
+    // ========================================================================
+
+    #[test]
+    fn should_fetch_group_info_for_existing_group() {
+        let drive = setup_drive_with_initial_state_structure(None);
+        let platform_version = PlatformVersion::latest();
+
+        let identity_1 = Identity::random_identity(3, Some(14), platform_version)
+            .expect("expected a platform identity");
+        let identity_2 = Identity::random_identity(3, Some(506), platform_version)
+            .expect("expected a platform identity");
+        let identity_1_id = identity_1.id();
+        let identity_2_id = identity_2.id();
+
+        let contract = create_test_contract_with_groups(identity_1_id, identity_2_id);
+        let contract_id = contract.id();
+
+        drive
+            .insert_contract(
+                &contract,
+                BlockInfo::default(),
+                true,
+                None,
+                platform_version,
+            )
+            .expect("expected to insert contract");
+
+        let group = drive
+            .fetch_group_info(contract_id, 0, None, platform_version)
+            .expect("expected to fetch group info");
+
+        assert!(group.is_some(), "group should exist");
+        let group = group.unwrap();
+        assert_eq!(
+            group,
+            Group::V0(GroupV0 {
+                members: [(identity_1_id, 1), (identity_2_id, 2)].into(),
+                required_power: 3,
+            })
+        );
+    }
+
+    #[test]
+    fn should_return_none_for_nonexistent_group_position() {
+        let drive = setup_drive_with_initial_state_structure(None);
+        let platform_version = PlatformVersion::latest();
+
+        let identity_1 = Identity::random_identity(3, Some(14), platform_version)
+            .expect("expected a platform identity");
+        let identity_2 = Identity::random_identity(3, Some(506), platform_version)
+            .expect("expected a platform identity");
+
+        let contract = create_test_contract_with_groups(identity_1.id(), identity_2.id());
+        let contract_id = contract.id();
+
+        drive
+            .insert_contract(
+                &contract,
+                BlockInfo::default(),
+                true,
+                None,
+                platform_version,
+            )
+            .expect("expected to insert contract");
+
+        // Position 99 does not exist
+        let group = drive
+            .fetch_group_info(contract_id, 99, None, platform_version)
+            .expect("expected to fetch group info");
+
+        assert!(group.is_none(), "group should not exist at position 99");
+    }
+
+    // ========================================================================
+    // fetch_group_infos tests (covers fetch_group_infos mod.rs + v0/mod.rs)
+    // ========================================================================
+
+    #[test]
+    fn should_fetch_multiple_group_infos() {
+        let drive = setup_drive_with_initial_state_structure(None);
+        let platform_version = PlatformVersion::latest();
+
+        let identity_1 = Identity::random_identity(3, Some(14), platform_version)
+            .expect("expected a platform identity");
+        let identity_2 = Identity::random_identity(3, Some(506), platform_version)
+            .expect("expected a platform identity");
+        let identity_1_id = identity_1.id();
+        let identity_2_id = identity_2.id();
+
+        let contract = DataContract::V1(DataContractV1 {
+            id: Default::default(),
+            version: 0,
+            owner_id: Default::default(),
+            document_types: Default::default(),
+            config: DataContractConfig::V0(DataContractConfigV0 {
+                can_be_deleted: false,
+                readonly: false,
+                keeps_history: false,
+                documents_keep_history_contract_default: false,
+                documents_mutable_contract_default: false,
+                documents_can_be_deleted_contract_default: false,
+                requires_identity_encryption_bounded_key: None,
+                requires_identity_decryption_bounded_key: None,
+            }),
+            schema_defs: None,
+            created_at: None,
+            updated_at: None,
+            created_at_block_height: None,
+            updated_at_block_height: None,
+            created_at_epoch: None,
+            updated_at_epoch: None,
+            groups: BTreeMap::from([
+                (
+                    0,
+                    Group::V0(GroupV0 {
+                        members: [(identity_1_id, 1), (identity_2_id, 2)].into(),
+                        required_power: 3,
+                    }),
+                ),
+                (
+                    1,
+                    Group::V0(GroupV0 {
+                        members: [(identity_1_id, 3)].into(),
+                        required_power: 3,
+                    }),
+                ),
+            ]),
+            tokens: BTreeMap::from([(
+                0,
+                TokenConfiguration::V0(TokenConfigurationV0::default_most_restrictive()),
+            )]),
+            keywords: Vec::new(),
+            description: None,
+        });
+
+        let contract_id = contract.id();
+
+        drive
+            .insert_contract(
+                &contract,
+                BlockInfo::default(),
+                true,
+                None,
+                platform_version,
+            )
+            .expect("expected to insert contract");
+
+        let groups = drive
+            .fetch_group_infos(contract_id, None, Some(10), None, platform_version)
+            .expect("expected to fetch group infos");
+
+        assert_eq!(groups.len(), 2);
+        assert!(groups.contains_key(&0));
+        assert!(groups.contains_key(&1));
+    }
+
+    #[test]
+    fn should_fetch_group_infos_with_start_position() {
+        let drive = setup_drive_with_initial_state_structure(None);
+        let platform_version = PlatformVersion::latest();
+
+        let identity_1 = Identity::random_identity(3, Some(14), platform_version)
+            .expect("expected a platform identity");
+        let identity_2 = Identity::random_identity(3, Some(506), platform_version)
+            .expect("expected a platform identity");
+        let identity_1_id = identity_1.id();
+        let identity_2_id = identity_2.id();
+
+        let contract = DataContract::V1(DataContractV1 {
+            id: Default::default(),
+            version: 0,
+            owner_id: Default::default(),
+            document_types: Default::default(),
+            config: DataContractConfig::V0(DataContractConfigV0 {
+                can_be_deleted: false,
+                readonly: false,
+                keeps_history: false,
+                documents_keep_history_contract_default: false,
+                documents_mutable_contract_default: false,
+                documents_can_be_deleted_contract_default: false,
+                requires_identity_encryption_bounded_key: None,
+                requires_identity_decryption_bounded_key: None,
+            }),
+            schema_defs: None,
+            created_at: None,
+            updated_at: None,
+            created_at_block_height: None,
+            updated_at_block_height: None,
+            created_at_epoch: None,
+            updated_at_epoch: None,
+            groups: BTreeMap::from([
+                (
+                    0,
+                    Group::V0(GroupV0 {
+                        members: [(identity_1_id, 1)].into(),
+                        required_power: 1,
+                    }),
+                ),
+                (
+                    1,
+                    Group::V0(GroupV0 {
+                        members: [(identity_2_id, 2)].into(),
+                        required_power: 2,
+                    }),
+                ),
+                (
+                    2,
+                    Group::V0(GroupV0 {
+                        members: [(identity_1_id, 1), (identity_2_id, 2)].into(),
+                        required_power: 3,
+                    }),
+                ),
+            ]),
+            tokens: BTreeMap::from([(
+                0,
+                TokenConfiguration::V0(TokenConfigurationV0::default_most_restrictive()),
+            )]),
+            keywords: Vec::new(),
+            description: None,
+        });
+
+        let contract_id = contract.id();
+
+        drive
+            .insert_contract(
+                &contract,
+                BlockInfo::default(),
+                true,
+                None,
+                platform_version,
+            )
+            .expect("expected to insert contract");
+
+        // Start at position 1 (exclusive), should return positions 2
+        let groups = drive
+            .fetch_group_infos(
+                contract_id,
+                Some((1, false)),
+                Some(10),
+                None,
+                platform_version,
+            )
+            .expect("expected to fetch group infos");
+
+        assert_eq!(groups.len(), 1);
+        assert!(groups.contains_key(&2));
+    }
+
+    // ========================================================================
+    // fetch_active_action_info tests
+    // ========================================================================
+
+    #[test]
+    fn should_fetch_active_action_info() {
+        let (drive, contract_id, identity_1_id, _, action_id) =
+            setup_drive_with_contract_and_action();
+        let platform_version = PlatformVersion::latest();
+
+        let action = drive
+            .fetch_active_action_info(contract_id, 0, action_id, None, platform_version)
+            .expect("expected to fetch action info");
+
+        match action {
+            GroupAction::V0(ref action_v0) => {
+                assert_eq!(action_v0.contract_id, contract_id);
+                assert_eq!(action_v0.proposer_id, identity_1_id);
+                assert_eq!(action_v0.token_contract_position, 0);
+            }
+        }
+    }
+
+    // ========================================================================
+    // fetch_action_id_signers_power tests
+    // ========================================================================
+
+    #[test]
+    fn should_fetch_action_signers_power() {
+        let (drive, contract_id, _, _, action_id) = setup_drive_with_contract_and_action();
+        let platform_version = PlatformVersion::latest();
+
+        let power = drive
+            .fetch_action_id_signers_power(contract_id, 0, action_id, None, platform_version)
+            .expect("expected to fetch signers power");
+
+        assert!(power.is_some(), "signers power should exist");
+        assert_eq!(power.unwrap(), 1, "signer power should be 1");
+    }
+
+    #[test]
+    fn should_return_none_signers_power_for_nonexistent_action() {
+        let drive = setup_drive_with_initial_state_structure(None);
+        let platform_version = PlatformVersion::latest();
+
+        let identity_1 = Identity::random_identity(3, Some(14), platform_version)
+            .expect("expected a platform identity");
+        let identity_2 = Identity::random_identity(3, Some(506), platform_version)
+            .expect("expected a platform identity");
+
+        let contract = create_test_contract_with_groups(identity_1.id(), identity_2.id());
+        let contract_id = contract.id();
+
+        drive
+            .insert_contract(
+                &contract,
+                BlockInfo::default(),
+                true,
+                None,
+                platform_version,
+            )
+            .expect("expected to insert contract");
+
+        let power = drive
+            .fetch_action_id_signers_power(
+                contract_id,
+                0,
+                Identifier::random(),
+                None,
+                platform_version,
+            )
+            .expect("expected to fetch signers power");
+
+        assert!(power.is_none(), "no power for nonexistent action");
+    }
+
+    // ========================================================================
+    // fetch_action_id_has_signer tests
+    // ========================================================================
+
+    #[test]
+    fn should_detect_existing_signer() {
+        let (drive, contract_id, identity_1_id, _, action_id) =
+            setup_drive_with_contract_and_action();
+        let platform_version = PlatformVersion::latest();
+
+        let has_signer = drive
+            .fetch_action_id_has_signer(
+                contract_id,
+                0,
+                action_id,
+                identity_1_id,
+                None,
+                platform_version,
+            )
+            .expect("expected to check signer");
+
+        assert!(has_signer, "identity_1 should be a signer");
+    }
+
+    #[test]
+    fn should_detect_missing_signer() {
+        let (drive, contract_id, _, identity_2_id, action_id) =
+            setup_drive_with_contract_and_action();
+        let platform_version = PlatformVersion::latest();
+
+        // identity_2 has NOT signed
+        let has_signer = drive
+            .fetch_action_id_has_signer(
+                contract_id,
+                0,
+                action_id,
+                identity_2_id,
+                None,
+                platform_version,
+            )
+            .expect("expected to check signer");
+
+        assert!(!has_signer, "identity_2 should not be a signer");
+    }
+
+    // ========================================================================
+    // fetch_action_id_info_keep_serialized tests
+    // ========================================================================
+
+    #[test]
+    fn should_fetch_serialized_action_info() {
+        let (drive, contract_id, _, _, action_id) = setup_drive_with_contract_and_action();
+        let platform_version = PlatformVersion::latest();
+
+        let serialized = drive
+            .fetch_action_id_info_keep_serialized(contract_id, 0, action_id, None, platform_version)
+            .expect("expected to fetch serialized action info");
+
+        assert!(
+            !serialized.is_empty(),
+            "serialized data should not be empty"
+        );
+    }
+
+    // ========================================================================
+    // fetch_action_is_closed tests
+    // ========================================================================
+
+    #[test]
+    fn active_action_should_not_be_closed() {
+        let (drive, contract_id, _, _, action_id) = setup_drive_with_contract_and_action();
+        let platform_version = PlatformVersion::latest();
+
+        let is_closed = drive
+            .fetch_action_is_closed(
+                contract_id,
+                0,
+                action_id,
+                true,
+                None,
+                &mut vec![],
+                platform_version,
+            )
+            .expect("expected to check if action is closed");
+
+        assert!(!is_closed, "active action should not be closed");
+    }
+
+    // ========================================================================
+    // add_group_action with closing (covers the closing branch in v0)
+    // ========================================================================
+
+    #[test]
+    fn should_close_group_action_and_move_signers() {
+        let (drive, contract_id, identity_1_id, identity_2_id, action_id) =
+            setup_drive_with_contract_and_action();
+        let platform_version = PlatformVersion::latest();
+
+        // Add second signer to bring total power to 3 (meets required_power)
+        // and close the action
+        drive
+            .add_group_action(
+                contract_id,
+                0,
+                None, // no new action info, existing one will be moved
+                true, // closes_group_action
+                action_id,
+                identity_2_id,
+                2,
+                &BlockInfo::default(),
+                true,
+                None,
+                platform_version,
+            )
+            .expect("expected to close group action");
+
+        // Verify the action is now closed
+        let is_closed = drive
+            .fetch_action_is_closed(
+                contract_id,
+                0,
+                action_id,
+                true,
+                None,
+                &mut vec![],
+                platform_version,
+            )
+            .expect("expected to check if action is closed");
+
+        assert!(is_closed, "action should now be closed");
+
+        // Verify signers were moved to closed
+        let closed_signers = drive
+            .fetch_action_signers(
+                contract_id,
+                0,
+                GroupActionStatus::ActionClosed,
+                action_id,
+                None,
+                platform_version,
+            )
+            .expect("expected to fetch closed signers");
+
+        // Should have both signers in the closed state
+        assert!(
+            closed_signers.contains_key(&identity_1_id),
+            "identity_1 should be in closed signers"
+        );
+        assert!(
+            closed_signers.contains_key(&identity_2_id),
+            "identity_2 should be in closed signers"
+        );
+    }
+
+    #[test]
+    fn should_close_group_action_with_new_action_info() {
+        let drive = setup_drive_with_initial_state_structure(None);
+        let platform_version = PlatformVersion::latest();
+
+        let identity_1 = Identity::random_identity(3, Some(14), platform_version)
+            .expect("expected a platform identity");
+        let identity_2 = Identity::random_identity(3, Some(506), platform_version)
+            .expect("expected a platform identity");
+        let identity_1_id = identity_1.id();
+        let identity_2_id = identity_2.id();
+
+        // Contract with required_power = 1 so single signer can close
+        let contract = DataContract::V1(DataContractV1 {
+            id: Default::default(),
+            version: 0,
+            owner_id: Default::default(),
+            document_types: Default::default(),
+            config: DataContractConfig::V0(DataContractConfigV0 {
+                can_be_deleted: false,
+                readonly: false,
+                keeps_history: false,
+                documents_keep_history_contract_default: false,
+                documents_mutable_contract_default: false,
+                documents_can_be_deleted_contract_default: false,
+                requires_identity_encryption_bounded_key: None,
+                requires_identity_decryption_bounded_key: None,
+            }),
+            schema_defs: None,
+            created_at: None,
+            updated_at: None,
+            created_at_block_height: None,
+            updated_at_block_height: None,
+            created_at_epoch: None,
+            updated_at_epoch: None,
+            groups: BTreeMap::from([(
+                0,
+                Group::V0(GroupV0 {
+                    members: [(identity_1_id, 5), (identity_2_id, 5)].into(),
+                    required_power: 5,
+                }),
+            )]),
+            tokens: BTreeMap::from([(
+                0,
+                TokenConfiguration::V0(TokenConfigurationV0::default_most_restrictive()),
+            )]),
+            keywords: Vec::new(),
+            description: None,
+        });
+
+        let contract_id = contract.id();
+
+        drive
+            .insert_contract(
+                &contract,
+                BlockInfo::default(),
+                true,
+                None,
+                platform_version,
+            )
+            .expect("expected to insert contract");
+
+        let action_id = Identifier::random();
+        let action = GroupAction::V0(GroupActionV0 {
+            contract_id,
+            proposer_id: identity_1_id,
+            token_contract_position: 0,
+            event: GroupActionEvent::TokenEvent(TokenEvent::Mint(500, identity_1_id, None)),
+        });
+
+        // Close immediately with action info provided
+        drive
+            .add_group_action(
+                contract_id,
+                0,
+                Some(action.clone()),
+                true, // close immediately
+                action_id,
+                identity_1_id,
+                5,
+                &BlockInfo::default(),
+                true,
+                None,
+                platform_version,
+            )
+            .expect("expected to close group action immediately");
+
+        let is_closed = drive
+            .fetch_action_is_closed(
+                contract_id,
+                0,
+                action_id,
+                true,
+                None,
+                &mut vec![],
+                platform_version,
+            )
+            .expect("expected to check if action is closed");
+
+        assert!(is_closed, "action should be closed");
+    }
+
+    // ========================================================================
+    // add_new_groups with existing contract (covers the "not inserted" branch)
+    // ========================================================================
+
+    #[test]
+    fn should_add_groups_to_existing_contract_tree() {
+        let drive = setup_drive_with_initial_state_structure(None);
+        let platform_version = PlatformVersion::latest();
+
+        let identity_1 = Identity::random_identity(3, Some(14), platform_version)
+            .expect("expected a platform identity");
+        let identity_2 = Identity::random_identity(3, Some(506), platform_version)
+            .expect("expected a platform identity");
+        let identity_1_id = identity_1.id();
+        let identity_2_id = identity_2.id();
+
+        let contract = create_test_contract_with_groups(identity_1_id, identity_2_id);
+        let contract_id = contract.id();
+
+        drive
+            .insert_contract(
+                &contract,
+                BlockInfo::default(),
+                true,
+                None,
+                platform_version,
+            )
+            .expect("expected to insert contract");
+
+        // Now add a second group to the same contract
+        let new_groups = BTreeMap::from([(
+            1u16,
+            Group::V0(GroupV0 {
+                members: [(identity_1_id, 2)].into(),
+                required_power: 2,
+            }),
+        )]);
+
+        drive
+            .add_new_groups(
+                contract_id,
+                &new_groups,
+                &BlockInfo::default(),
+                true,
+                None,
+                platform_version,
+            )
+            .expect("expected to add new groups to existing contract");
+
+        // Verify both groups exist
+        let fetched = drive
+            .fetch_group_infos(contract_id, None, Some(10), None, platform_version)
+            .expect("expected to fetch group infos");
+
+        assert_eq!(fetched.len(), 2);
+        assert!(fetched.contains_key(&0));
+        assert!(fetched.contains_key(&1));
+    }
+
+    // ========================================================================
+    // Cost estimation tests (apply=false covers estimated_costs modules)
+    // ========================================================================
+
+    #[test]
+    fn should_estimate_costs_for_add_group_action() {
+        let drive = setup_drive_with_initial_state_structure(None);
+        let platform_version = PlatformVersion::latest();
+
+        let identity_1 = Identity::random_identity(3, Some(14), platform_version)
+            .expect("expected a platform identity");
+        let identity_2 = Identity::random_identity(3, Some(506), platform_version)
+            .expect("expected a platform identity");
+
+        let contract = create_test_contract_with_groups(identity_1.id(), identity_2.id());
+        let contract_id = contract.id();
+
+        drive
+            .insert_contract(
+                &contract,
+                BlockInfo::default(),
+                true,
+                None,
+                platform_version,
+            )
+            .expect("expected to insert contract");
+
+        let action_id = Identifier::random();
+        let action = GroupAction::V0(GroupActionV0 {
+            contract_id,
+            proposer_id: identity_1.id(),
+            token_contract_position: 0,
+            event: GroupActionEvent::TokenEvent(TokenEvent::Mint(100, identity_1.id(), None)),
+        });
+
+        // apply=false triggers cost estimation
+        let fee_result = drive
+            .add_group_action(
+                contract_id,
+                0,
+                Some(action),
+                false, // not closing
+                action_id,
+                identity_1.id(),
+                1,
+                &BlockInfo::default(),
+                false, // apply=false = cost estimation only
+                None,
+                platform_version,
+            )
+            .expect("expected cost estimation to succeed");
+
+        assert!(
+            fee_result.storage_fee > 0 || fee_result.processing_fee > 0,
+            "fee result should contain fees"
+        );
+    }
+
+    #[test]
+    fn should_estimate_costs_for_add_new_groups() {
+        let drive = setup_drive_with_initial_state_structure(None);
+        let platform_version = PlatformVersion::latest();
+
+        let identity_1 = Identity::random_identity(3, Some(14), platform_version)
+            .expect("expected a platform identity");
+        let identity_1_id = identity_1.id();
+
+        let groups = BTreeMap::from([(
+            0u16,
+            Group::V0(GroupV0 {
+                members: [(identity_1_id, 1)].into(),
+                required_power: 1,
+            }),
+        )]);
+
+        let contract_id = Identifier::random();
+
+        let fee_result = drive
+            .add_new_groups(
+                contract_id,
+                &groups,
+                &BlockInfo::default(),
+                false, // apply=false = cost estimation
+                None,
+                platform_version,
+            )
+            .expect("expected cost estimation to succeed");
+
+        assert!(
+            fee_result.storage_fee > 0 || fee_result.processing_fee > 0,
+            "fee result should contain fees"
+        );
+    }
+
+    #[test]
+    fn should_estimate_costs_for_closing_group_action() {
+        let drive = setup_drive_with_initial_state_structure(None);
+        let platform_version = PlatformVersion::latest();
+
+        let identity_1 = Identity::random_identity(3, Some(14), platform_version)
+            .expect("expected a platform identity");
+        let identity_2 = Identity::random_identity(3, Some(506), platform_version)
+            .expect("expected a platform identity");
+
+        let contract = create_test_contract_with_groups(identity_1.id(), identity_2.id());
+        let contract_id = contract.id();
+
+        drive
+            .insert_contract(
+                &contract,
+                BlockInfo::default(),
+                true,
+                None,
+                platform_version,
+            )
+            .expect("expected to insert contract");
+
+        let action_id = Identifier::random();
+        let action = GroupAction::V0(GroupActionV0 {
+            contract_id,
+            proposer_id: identity_1.id(),
+            token_contract_position: 0,
+            event: GroupActionEvent::TokenEvent(TokenEvent::Mint(100, identity_1.id(), None)),
+        });
+
+        // Estimate costs for closing action (apply=false, closes_group_action=true)
+        let fee_result = drive
+            .add_group_action(
+                contract_id,
+                0,
+                Some(action),
+                true, // closing
+                action_id,
+                identity_1.id(),
+                3,
+                &BlockInfo::default(),
+                false, // apply=false = cost estimation only
+                None,
+                platform_version,
+            )
+            .expect("expected cost estimation to succeed");
+
+        assert!(
+            fee_result.storage_fee > 0 || fee_result.processing_fee > 0,
+            "fee result should contain fees for closing"
+        );
+    }
+
+    // ========================================================================
+    // prove through public API (covers prove mod.rs version dispatch)
+    // ========================================================================
+
+    #[test]
+    fn should_prove_group_info_through_public_api() {
+        let drive = setup_drive_with_initial_state_structure(None);
+        let platform_version = PlatformVersion::latest();
+
+        let identity_1 = Identity::random_identity(3, Some(14), platform_version)
+            .expect("expected a platform identity");
+        let identity_2 = Identity::random_identity(3, Some(506), platform_version)
+            .expect("expected a platform identity");
+
+        let contract = create_test_contract_with_groups(identity_1.id(), identity_2.id());
+        let contract_id = contract.id();
+
+        drive
+            .insert_contract(
+                &contract,
+                BlockInfo::default(),
+                true,
+                None,
+                platform_version,
+            )
+            .expect("expected to insert contract");
+
+        let proof = drive
+            .prove_group_info(contract_id, 0, None, platform_version)
+            .expect("should prove group info through public API");
+
+        let (root_hash, group) =
+            Drive::verify_group_info(proof.as_slice(), contract_id, 0, false, platform_version)
+                .expect("expected proof verification to succeed");
+
+        assert!(!root_hash.is_empty());
+        assert!(group.is_some());
+    }
+
+    #[test]
+    fn should_prove_group_infos_through_public_api() {
+        let drive = setup_drive_with_initial_state_structure(None);
+        let platform_version = PlatformVersion::latest();
+
+        let identity_1 = Identity::random_identity(3, Some(14), platform_version)
+            .expect("expected a platform identity");
+        let identity_2 = Identity::random_identity(3, Some(506), platform_version)
+            .expect("expected a platform identity");
+
+        let contract = create_test_contract_with_groups(identity_1.id(), identity_2.id());
+        let contract_id = contract.id();
+
+        drive
+            .insert_contract(
+                &contract,
+                BlockInfo::default(),
+                true,
+                None,
+                platform_version,
+            )
+            .expect("expected to insert contract");
+
+        let proof = drive
+            .prove_group_infos(contract_id, None, Some(10), None, platform_version)
+            .expect("should prove group infos through public API");
+
+        let (_, groups): (
+            _,
+            BTreeMap<dpp::data_contract::GroupContractPosition, Group>,
+        ) = Drive::verify_group_infos_in_contract(
+            proof.as_slice(),
+            contract_id,
+            None,
+            Some(10),
+            false,
+            platform_version,
+        )
+        .expect("expected proof verification to succeed");
+
+        assert_eq!(groups.len(), 1);
+    }
+
+    #[test]
+    fn should_prove_action_signers_through_public_api() {
+        let (drive, contract_id, identity_1_id, _, action_id) =
+            setup_drive_with_contract_and_action();
+        let platform_version = PlatformVersion::latest();
+
+        let proof = drive
+            .prove_action_signers(
+                contract_id,
+                0,
+                GroupActionStatus::ActionActive,
+                action_id,
+                None,
+                platform_version,
+            )
+            .expect("should prove action signers through public API");
+
+        let (_, signers): (
+            _,
+            BTreeMap<Identifier, dpp::data_contract::group::GroupMemberPower>,
+        ) = Drive::verify_action_signers(
+            proof.as_slice(),
+            contract_id,
+            0,
+            GroupActionStatus::ActionActive,
+            action_id,
+            false,
+            platform_version,
+        )
+        .expect("expected proof verification to succeed");
+
+        assert_eq!(signers.len(), 1);
+        assert!(signers.contains_key(&identity_1_id));
+    }
+
+    // ========================================================================
+    // Second signer addition (non-initialization, existing action)
+    // ========================================================================
+
+    #[test]
+    fn should_add_second_signer_to_existing_action() {
+        let (drive, contract_id, identity_1_id, identity_2_id, action_id) =
+            setup_drive_with_contract_and_action();
+        let platform_version = PlatformVersion::latest();
+
+        // Add second signer without closing
+        drive
+            .add_group_action(
+                contract_id,
+                0,
+                None,  // action already exists
+                false, // not closing
+                action_id,
+                identity_2_id,
+                2,
+                &BlockInfo::default(),
+                true,
+                None,
+                platform_version,
+            )
+            .expect("expected to add second signer");
+
+        let signers = drive
+            .fetch_action_signers(
+                contract_id,
+                0,
+                GroupActionStatus::ActionActive,
+                action_id,
+                None,
+                platform_version,
+            )
+            .expect("expected to fetch signers");
+
+        assert_eq!(signers.len(), 2);
+        assert_eq!(signers[&identity_1_id], 1);
+        assert_eq!(signers[&identity_2_id], 2);
+
+        // Verify total power
+        let power = drive
+            .fetch_action_id_signers_power(contract_id, 0, action_id, None, platform_version)
+            .expect("expected to fetch signers power");
+
+        assert_eq!(power.unwrap(), 3);
+    }
+
+    // ========================================================================
+    // fetch_action_id_has_signer_with_costs
+    // ========================================================================
+
+    #[test]
+    fn should_fetch_has_signer_with_costs() {
+        let (drive, contract_id, identity_1_id, _, action_id) =
+            setup_drive_with_contract_and_action();
+        let platform_version = PlatformVersion::latest();
+
+        let (has_signer, fee_result) = drive
+            .fetch_action_id_has_signer_with_costs(
+                contract_id,
+                0,
+                action_id,
+                identity_1_id,
+                &BlockInfo::default(),
+                None,
+                platform_version,
+            )
+            .expect("expected to check signer with costs");
+
+        assert!(has_signer, "identity_1 should be a signer");
+        // Fee result should be computed
+        assert!(fee_result.processing_fee > 0);
+    }
+
+    // ========================================================================
+    // fetch_action_is_closed with apply=false (stateless)
+    // ========================================================================
+
+    #[test]
+    fn should_check_action_is_closed_stateless() {
+        let (drive, contract_id, _, _, action_id) = setup_drive_with_contract_and_action();
+        let platform_version = PlatformVersion::latest();
+
+        let is_closed = drive
+            .fetch_action_is_closed(
+                contract_id,
+                0,
+                action_id,
+                false, // stateless
+                None,
+                &mut vec![],
+                platform_version,
+            )
+            .expect("expected to check if action is closed");
+
+        // Stateless mode returns false since we don't check active state
+        assert!(!is_closed);
+    }
+
+    // ========================================================================
+    // prove_action_infos through public API
+    // ========================================================================
+
+    #[test]
+    fn should_prove_action_infos_through_public_api() {
+        let (drive, contract_id, _, _, action_id) = setup_drive_with_contract_and_action();
+        let platform_version = PlatformVersion::latest();
+
+        let proof = drive
+            .prove_action_infos(
+                contract_id,
+                0,
+                GroupActionStatus::ActionActive,
+                None,
+                Some(10),
+                None,
+                platform_version,
+            )
+            .expect("should prove action infos through public API");
+
+        let (_, actions): (_, BTreeMap<Identifier, GroupAction>) =
+            Drive::verify_action_infos_in_contract(
+                proof.as_slice(),
+                contract_id,
+                0,
+                GroupActionStatus::ActionActive,
+                None,
+                Some(10),
+                false,
+                platform_version,
+            )
+            .expect("expected proof verification to succeed");
+
+        assert_eq!(actions.len(), 1);
+        assert!(actions.contains_key(&action_id));
+    }
+}

--- a/packages/rs-drive/src/drive/group/paths.rs
+++ b/packages/rs-drive/src/drive/group/paths.rs
@@ -236,3 +236,171 @@ pub fn group_closed_action_signers_path_vec(
         ACTION_SIGNERS_KEY.to_vec(),
     ]
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const FAKE_CONTRACT_ID: [u8; 32] = [0xAA; 32];
+    const FAKE_ACTION_ID: [u8; 32] = [0xBB; 32];
+    const GROUP_POS: GroupContractPosition = 5u16;
+
+    fn root_byte() -> u8 {
+        RootTree::GroupActions as u8
+    }
+
+    #[test]
+    fn group_root_path_returns_single_element() {
+        let path = group_root_path();
+        assert_eq!(path.len(), 1);
+        assert_eq!(path[0], &[root_byte()]);
+    }
+
+    #[test]
+    fn group_root_path_vec_returns_single_element() {
+        let path = group_root_path_vec();
+        assert_eq!(path.len(), 1);
+        assert_eq!(path[0], vec![root_byte()]);
+    }
+
+    #[test]
+    fn group_contract_path_includes_contract_id() {
+        let path = group_contract_path(&FAKE_CONTRACT_ID);
+        assert_eq!(path.len(), 2);
+        assert_eq!(path[0], &[root_byte()]);
+        assert_eq!(path[1], &FAKE_CONTRACT_ID);
+    }
+
+    #[test]
+    fn group_contract_path_vec_includes_contract_id() {
+        let path = group_contract_path_vec(&FAKE_CONTRACT_ID);
+        assert_eq!(path.len(), 2);
+        assert_eq!(path[0], vec![root_byte()]);
+        assert_eq!(path[1], FAKE_CONTRACT_ID.to_vec());
+    }
+
+    #[test]
+    fn group_path_includes_position_bytes() {
+        let pos_bytes = GROUP_POS.to_be_bytes();
+        let path = group_path(&FAKE_CONTRACT_ID, &pos_bytes);
+        assert_eq!(path.len(), 3);
+        assert_eq!(path[2], &pos_bytes);
+    }
+
+    #[test]
+    fn group_path_vec_includes_position_bytes() {
+        let path = group_path_vec(&FAKE_CONTRACT_ID, GROUP_POS);
+        assert_eq!(path.len(), 3);
+        assert_eq!(path[2], GROUP_POS.to_be_bytes().to_vec());
+    }
+
+    #[test]
+    fn group_active_action_root_path_has_active_key() {
+        let pos_bytes = GROUP_POS.to_be_bytes();
+        let path = group_active_action_root_path(&FAKE_CONTRACT_ID, &pos_bytes);
+        assert_eq!(path.len(), 4);
+        assert_eq!(path[3], GROUP_ACTIVE_ACTIONS_KEY);
+    }
+
+    #[test]
+    fn group_active_action_root_path_vec_has_active_key() {
+        let path = group_active_action_root_path_vec(&FAKE_CONTRACT_ID, GROUP_POS);
+        assert_eq!(path.len(), 4);
+        assert_eq!(path[3], GROUP_ACTIVE_ACTIONS_KEY.to_vec());
+    }
+
+    #[test]
+    fn group_active_action_path_has_action_id() {
+        let pos_bytes = GROUP_POS.to_be_bytes();
+        let path = group_active_action_path(&FAKE_CONTRACT_ID, &pos_bytes, &FAKE_ACTION_ID);
+        assert_eq!(path.len(), 5);
+        assert_eq!(path[3], GROUP_ACTIVE_ACTIONS_KEY);
+        assert_eq!(path[4], &FAKE_ACTION_ID);
+    }
+
+    #[test]
+    fn group_active_action_path_vec_has_action_id() {
+        let path = group_active_action_path_vec(&FAKE_CONTRACT_ID, GROUP_POS, &FAKE_ACTION_ID);
+        assert_eq!(path.len(), 5);
+        assert_eq!(path[4], FAKE_ACTION_ID.to_vec());
+    }
+
+    #[test]
+    fn group_action_signers_path_has_signers_key() {
+        let pos_bytes = GROUP_POS.to_be_bytes();
+        let path = group_action_signers_path(&FAKE_CONTRACT_ID, &pos_bytes, &FAKE_ACTION_ID);
+        assert_eq!(path.len(), 6);
+        assert_eq!(path[5], ACTION_SIGNERS_KEY);
+    }
+
+    #[test]
+    fn group_action_signers_path_vec_has_signers_key() {
+        let path = group_action_signers_path_vec(&FAKE_CONTRACT_ID, GROUP_POS, &FAKE_ACTION_ID);
+        assert_eq!(path.len(), 6);
+        assert_eq!(path[5], ACTION_SIGNERS_KEY.to_vec());
+    }
+
+    #[test]
+    fn group_closed_action_root_path_has_closed_key() {
+        let pos_bytes = GROUP_POS.to_be_bytes();
+        let path = group_closed_action_root_path(&FAKE_CONTRACT_ID, &pos_bytes);
+        assert_eq!(path.len(), 4);
+        assert_eq!(path[3], GROUP_CLOSED_ACTIONS_KEY);
+    }
+
+    #[test]
+    fn group_closed_action_root_path_vec_has_closed_key() {
+        let path = group_closed_action_root_path_vec(&FAKE_CONTRACT_ID, GROUP_POS);
+        assert_eq!(path.len(), 4);
+        assert_eq!(path[3], GROUP_CLOSED_ACTIONS_KEY.to_vec());
+    }
+
+    #[test]
+    fn group_closed_action_path_has_action_id() {
+        let pos_bytes = GROUP_POS.to_be_bytes();
+        let path = group_closed_action_path(&FAKE_CONTRACT_ID, &pos_bytes, &FAKE_ACTION_ID);
+        assert_eq!(path.len(), 5);
+        assert_eq!(path[3], GROUP_CLOSED_ACTIONS_KEY);
+        assert_eq!(path[4], &FAKE_ACTION_ID);
+    }
+
+    #[test]
+    fn group_closed_action_path_vec_has_action_id() {
+        let path = group_closed_action_path_vec(&FAKE_CONTRACT_ID, GROUP_POS, &FAKE_ACTION_ID);
+        assert_eq!(path.len(), 5);
+        assert_eq!(path[3], GROUP_CLOSED_ACTIONS_KEY.to_vec());
+        assert_eq!(path[4], FAKE_ACTION_ID.to_vec());
+    }
+
+    #[test]
+    fn group_closed_action_signers_path_has_signers_key() {
+        let pos_bytes = GROUP_POS.to_be_bytes();
+        let path = group_closed_action_signers_path(&FAKE_CONTRACT_ID, &pos_bytes, &FAKE_ACTION_ID);
+        assert_eq!(path.len(), 6);
+        assert_eq!(path[4], &FAKE_ACTION_ID);
+        assert_eq!(path[5], ACTION_SIGNERS_KEY);
+    }
+
+    #[test]
+    fn group_closed_action_signers_path_vec_has_signers_key() {
+        let path =
+            group_closed_action_signers_path_vec(&FAKE_CONTRACT_ID, GROUP_POS, &FAKE_ACTION_ID);
+        assert_eq!(path.len(), 6);
+        assert_eq!(path[4], FAKE_ACTION_ID.to_vec());
+        assert_eq!(path[5], ACTION_SIGNERS_KEY.to_vec());
+    }
+
+    #[test]
+    fn active_and_closed_paths_differ_only_by_key() {
+        let pos_bytes = GROUP_POS.to_be_bytes();
+        let active = group_active_action_root_path(&FAKE_CONTRACT_ID, &pos_bytes);
+        let closed = group_closed_action_root_path(&FAKE_CONTRACT_ID, &pos_bytes);
+
+        // First 3 components are the same
+        assert_eq!(active[..3], closed[..3]);
+        // 4th differs
+        assert_ne!(active[3], closed[3]);
+        assert_eq!(active[3], GROUP_ACTIVE_ACTIONS_KEY);
+        assert_eq!(closed[3], GROUP_CLOSED_ACTIONS_KEY);
+    }
+}

--- a/packages/rs-drive/src/drive/group/queries.rs
+++ b/packages/rs-drive/src/drive/group/queries.rs
@@ -274,3 +274,216 @@ impl Drive {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const CONTRACT_ID: [u8; 32] = [1u8; 32];
+    const ACTION_ID: [u8; 32] = [2u8; 32];
+    const IDENTITY_ID: [u8; 32] = [3u8; 32];
+    const GROUP_POS: GroupContractPosition = 0;
+
+    #[test]
+    fn group_info_query_has_limit_of_one() {
+        let pq = Drive::group_info_for_contract_id_and_group_contract_position_query(
+            CONTRACT_ID,
+            GROUP_POS,
+        );
+        assert_eq!(pq.query.limit, Some(1));
+        assert_eq!(pq.path, group_path_vec(&CONTRACT_ID, GROUP_POS));
+    }
+
+    #[test]
+    fn group_infos_query_with_no_start_returns_range_full() {
+        let pq = Drive::group_infos_for_contract_id_query(CONTRACT_ID, None, Some(10));
+        assert_eq!(pq.query.limit, Some(10));
+        assert_eq!(pq.path, group_contract_path_vec(&CONTRACT_ID));
+    }
+
+    #[test]
+    fn group_infos_query_with_start_included() {
+        let pq = Drive::group_infos_for_contract_id_query(CONTRACT_ID, Some((5, true)), Some(10));
+        assert_eq!(pq.query.limit, Some(10));
+    }
+
+    #[test]
+    fn group_infos_query_with_start_excluded() {
+        let pq = Drive::group_infos_for_contract_id_query(CONTRACT_ID, Some((5, false)), Some(10));
+        assert_eq!(pq.query.limit, Some(10));
+    }
+
+    #[test]
+    fn action_infos_query_active_status() {
+        let pq = Drive::group_action_infos_query(
+            CONTRACT_ID,
+            GROUP_POS,
+            GroupActionStatus::ActionActive,
+            None,
+            Some(5),
+        );
+        assert_eq!(pq.query.limit, Some(5));
+        // Path should end with the active actions key
+        assert_eq!(pq.path.last().unwrap(), &GROUP_ACTIVE_ACTIONS_KEY.to_vec());
+    }
+
+    #[test]
+    fn action_infos_query_closed_status() {
+        let pq = Drive::group_action_infos_query(
+            CONTRACT_ID,
+            GROUP_POS,
+            GroupActionStatus::ActionClosed,
+            None,
+            Some(5),
+        );
+        assert_eq!(pq.path.last().unwrap(), &GROUP_CLOSED_ACTIONS_KEY.to_vec());
+    }
+
+    #[test]
+    fn action_infos_query_with_start_at_included() {
+        let pq = Drive::group_action_infos_query(
+            CONTRACT_ID,
+            GROUP_POS,
+            GroupActionStatus::ActionActive,
+            Some((ACTION_ID, true)),
+            Some(5),
+        );
+        assert_eq!(pq.query.limit, Some(5));
+    }
+
+    #[test]
+    fn action_infos_query_with_start_at_excluded() {
+        let pq = Drive::group_action_infos_query(
+            CONTRACT_ID,
+            GROUP_POS,
+            GroupActionStatus::ActionActive,
+            Some((ACTION_ID, false)),
+            Some(5),
+        );
+        assert_eq!(pq.query.limit, Some(5));
+    }
+
+    #[test]
+    fn group_action_query_active() {
+        let pq = Drive::group_action_query(
+            CONTRACT_ID,
+            GROUP_POS,
+            GroupActionStatus::ActionActive,
+            ACTION_ID,
+        );
+        assert!(pq.query.limit.is_none());
+        // Path includes the action_id
+        assert_eq!(pq.path.last().unwrap(), &ACTION_ID.to_vec());
+    }
+
+    #[test]
+    fn group_action_query_closed() {
+        let pq = Drive::group_action_query(
+            CONTRACT_ID,
+            GROUP_POS,
+            GroupActionStatus::ActionClosed,
+            ACTION_ID,
+        );
+        // The 4th element should be the closed actions key
+        assert_eq!(pq.path[3], GROUP_CLOSED_ACTIONS_KEY.to_vec());
+    }
+
+    #[test]
+    fn group_action_signers_query_active() {
+        let pq = Drive::group_action_signers_query(
+            CONTRACT_ID,
+            GROUP_POS,
+            GroupActionStatus::ActionActive,
+            ACTION_ID,
+        );
+        assert!(pq.query.limit.is_none());
+        assert_eq!(pq.path.last().unwrap(), &ACTION_SIGNERS_KEY.to_vec());
+    }
+
+    #[test]
+    fn group_action_signers_query_closed() {
+        let pq = Drive::group_action_signers_query(
+            CONTRACT_ID,
+            GROUP_POS,
+            GroupActionStatus::ActionClosed,
+            ACTION_ID,
+        );
+        assert_eq!(pq.path[3], GROUP_CLOSED_ACTIONS_KEY.to_vec());
+        assert_eq!(pq.path.last().unwrap(), &ACTION_SIGNERS_KEY.to_vec());
+    }
+
+    #[test]
+    fn active_action_single_signer_query_path() {
+        let pq = Drive::group_active_action_single_signer_query(
+            CONTRACT_ID,
+            GROUP_POS,
+            ACTION_ID,
+            IDENTITY_ID,
+        );
+        assert!(pq.query.limit.is_none());
+        // Path should be the active signers path
+        assert_eq!(
+            pq.path,
+            group_action_signers_path_vec(&CONTRACT_ID, GROUP_POS, &ACTION_ID)
+        );
+    }
+
+    #[test]
+    fn closed_action_single_signer_query_path() {
+        let pq = Drive::group_closed_action_single_signer_query(
+            CONTRACT_ID,
+            GROUP_POS,
+            ACTION_ID,
+            IDENTITY_ID,
+        );
+        assert!(pq.query.limit.is_none());
+        assert_eq!(
+            pq.path,
+            group_closed_action_signers_path_vec(&CONTRACT_ID, GROUP_POS, &ACTION_ID)
+        );
+    }
+
+    #[test]
+    fn active_or_closed_single_signer_query_active() {
+        let pq = Drive::group_active_or_closed_action_single_signer_query(
+            CONTRACT_ID,
+            GROUP_POS,
+            ACTION_ID,
+            GroupActionStatus::ActionActive,
+            IDENTITY_ID,
+        );
+        assert_eq!(pq.path[3], GROUP_ACTIVE_ACTIONS_KEY.to_vec());
+        assert_eq!(pq.path.last().unwrap(), &ACTION_SIGNERS_KEY.to_vec());
+    }
+
+    #[test]
+    fn active_or_closed_single_signer_query_closed() {
+        let pq = Drive::group_active_or_closed_action_single_signer_query(
+            CONTRACT_ID,
+            GROUP_POS,
+            ACTION_ID,
+            GroupActionStatus::ActionClosed,
+            IDENTITY_ID,
+        );
+        assert_eq!(pq.path[3], GROUP_CLOSED_ACTIONS_KEY.to_vec());
+    }
+
+    #[test]
+    fn active_or_closed_action_query_has_both_keys() {
+        let pq = Drive::group_active_or_closed_action_query(CONTRACT_ID, GROUP_POS);
+        assert!(pq.query.limit.is_none());
+        assert_eq!(pq.path, group_path_vec(&CONTRACT_ID, GROUP_POS));
+    }
+
+    #[test]
+    fn active_and_closed_single_signer_query_has_subquery_path() {
+        let pq = Drive::group_active_and_closed_action_single_signer_query(
+            CONTRACT_ID,
+            GROUP_POS,
+            ACTION_ID,
+            IDENTITY_ID,
+        );
+        assert!(pq.query.limit.is_none());
+        assert_eq!(pq.path, group_path_vec(&CONTRACT_ID, GROUP_POS));
+    }
+}

--- a/packages/rs-drive/src/drive/group/queries.rs
+++ b/packages/rs-drive/src/drive/group/queries.rs
@@ -306,15 +306,17 @@ mod tests {
             "expected RangeFull query item"
         );
         // Should have the subquery key set to GROUP_INFO_KEY
-        let subquery = pq
+        let subquery_path = pq
             .query
             .query
             .default_subquery_branch
             .subquery_path
-            .as_ref();
-        assert!(
-            subquery.is_some(),
-            "expected a subquery path for GROUP_INFO_KEY"
+            .as_ref()
+            .expect("expected a subquery path for GROUP_INFO_KEY");
+        assert_eq!(
+            *subquery_path,
+            vec![GROUP_INFO_KEY.to_vec()],
+            "subquery path should contain GROUP_INFO_KEY"
         );
     }
 
@@ -356,13 +358,17 @@ mod tests {
         assert_eq!(pq.query.query.items.len(), 1);
         assert!(matches!(pq.query.query.items[0], QueryItem::RangeFull(..)));
         // Should have subquery key for ACTION_INFO_KEY
-        assert!(
-            pq.query
-                .query
-                .default_subquery_branch
-                .subquery_path
-                .is_some(),
-            "expected a subquery path for ACTION_INFO_KEY"
+        let subquery_path = pq
+            .query
+            .query
+            .default_subquery_branch
+            .subquery_path
+            .as_ref()
+            .expect("expected a subquery path for ACTION_INFO_KEY");
+        assert_eq!(
+            *subquery_path,
+            vec![ACTION_INFO_KEY.to_vec()],
+            "subquery path should contain ACTION_INFO_KEY"
         );
     }
 

--- a/packages/rs-drive/src/drive/group/queries.rs
+++ b/packages/rs-drive/src/drive/group/queries.rs
@@ -299,18 +299,45 @@ mod tests {
         let pq = Drive::group_infos_for_contract_id_query(CONTRACT_ID, None, Some(10));
         assert_eq!(pq.query.limit, Some(10));
         assert_eq!(pq.path, group_contract_path_vec(&CONTRACT_ID));
+        // Should have a RangeFull query item
+        assert_eq!(pq.query.query.items.len(), 1);
+        assert!(
+            matches!(pq.query.query.items[0], QueryItem::RangeFull(..)),
+            "expected RangeFull query item"
+        );
+        // Should have the subquery key set to GROUP_INFO_KEY
+        let subquery = pq
+            .query
+            .query
+            .default_subquery_branch
+            .subquery_path
+            .as_ref();
+        assert!(
+            subquery.is_some(),
+            "expected a subquery path for GROUP_INFO_KEY"
+        );
     }
 
     #[test]
     fn group_infos_query_with_start_included() {
         let pq = Drive::group_infos_for_contract_id_query(CONTRACT_ID, Some((5, true)), Some(10));
         assert_eq!(pq.query.limit, Some(10));
+        assert_eq!(pq.query.query.items.len(), 1);
+        assert!(
+            matches!(pq.query.query.items[0], QueryItem::RangeFrom(..)),
+            "expected RangeFrom for included start"
+        );
     }
 
     #[test]
     fn group_infos_query_with_start_excluded() {
         let pq = Drive::group_infos_for_contract_id_query(CONTRACT_ID, Some((5, false)), Some(10));
         assert_eq!(pq.query.limit, Some(10));
+        assert_eq!(pq.query.query.items.len(), 1);
+        assert!(
+            matches!(pq.query.query.items[0], QueryItem::RangeAfter(..)),
+            "expected RangeAfter for excluded start"
+        );
     }
 
     #[test]
@@ -325,6 +352,18 @@ mod tests {
         assert_eq!(pq.query.limit, Some(5));
         // Path should end with the active actions key
         assert_eq!(pq.path.last().unwrap(), &GROUP_ACTIVE_ACTIONS_KEY.to_vec());
+        // Should be a RangeFull query item when no start_at
+        assert_eq!(pq.query.query.items.len(), 1);
+        assert!(matches!(pq.query.query.items[0], QueryItem::RangeFull(..)));
+        // Should have subquery key for ACTION_INFO_KEY
+        assert!(
+            pq.query
+                .query
+                .default_subquery_branch
+                .subquery_path
+                .is_some(),
+            "expected a subquery path for ACTION_INFO_KEY"
+        );
     }
 
     #[test]
@@ -349,6 +388,11 @@ mod tests {
             Some(5),
         );
         assert_eq!(pq.query.limit, Some(5));
+        assert_eq!(pq.query.query.items.len(), 1);
+        assert!(
+            matches!(pq.query.query.items[0], QueryItem::RangeFrom(..)),
+            "expected RangeFrom for included start_at"
+        );
     }
 
     #[test]
@@ -361,6 +405,11 @@ mod tests {
             Some(5),
         );
         assert_eq!(pq.query.limit, Some(5));
+        assert_eq!(pq.query.query.items.len(), 1);
+        assert!(
+            matches!(pq.query.query.items[0], QueryItem::RangeAfter(..)),
+            "expected RangeAfter for excluded start_at"
+        );
     }
 
     #[test]
@@ -374,6 +423,12 @@ mod tests {
         assert!(pq.query.limit.is_none());
         // Path includes the action_id
         assert_eq!(pq.path.last().unwrap(), &ACTION_ID.to_vec());
+        // Query should contain ACTION_SIGNERS_KEY as a single key
+        assert_eq!(pq.query.query.items.len(), 1);
+        assert_eq!(
+            pq.query.query.items[0],
+            QueryItem::Key(ACTION_SIGNERS_KEY.to_vec())
+        );
     }
 
     #[test]
@@ -386,6 +441,12 @@ mod tests {
         );
         // The 4th element should be the closed actions key
         assert_eq!(pq.path[3], GROUP_CLOSED_ACTIONS_KEY.to_vec());
+        // Query should contain ACTION_SIGNERS_KEY as a single key
+        assert_eq!(pq.query.query.items.len(), 1);
+        assert_eq!(
+            pq.query.query.items[0],
+            QueryItem::Key(ACTION_SIGNERS_KEY.to_vec())
+        );
     }
 
     #[test]
@@ -398,6 +459,9 @@ mod tests {
         );
         assert!(pq.query.limit.is_none());
         assert_eq!(pq.path.last().unwrap(), &ACTION_SIGNERS_KEY.to_vec());
+        // Should be a full range query
+        assert_eq!(pq.query.query.items.len(), 1);
+        assert!(matches!(pq.query.query.items[0], QueryItem::RangeFull(..)));
     }
 
     #[test]
@@ -410,6 +474,8 @@ mod tests {
         );
         assert_eq!(pq.path[3], GROUP_CLOSED_ACTIONS_KEY.to_vec());
         assert_eq!(pq.path.last().unwrap(), &ACTION_SIGNERS_KEY.to_vec());
+        // Should be a full range query
+        assert!(matches!(pq.query.query.items[0], QueryItem::RangeFull(..)));
     }
 
     #[test]
@@ -426,6 +492,12 @@ mod tests {
             pq.path,
             group_action_signers_path_vec(&CONTRACT_ID, GROUP_POS, &ACTION_ID)
         );
+        // Query should have a single key for the identity
+        assert_eq!(pq.query.query.items.len(), 1);
+        assert_eq!(
+            pq.query.query.items[0],
+            QueryItem::Key(IDENTITY_ID.to_vec())
+        );
     }
 
     #[test]
@@ -441,6 +513,12 @@ mod tests {
             pq.path,
             group_closed_action_signers_path_vec(&CONTRACT_ID, GROUP_POS, &ACTION_ID)
         );
+        // Query should have a single key for the identity
+        assert_eq!(pq.query.query.items.len(), 1);
+        assert_eq!(
+            pq.query.query.items[0],
+            QueryItem::Key(IDENTITY_ID.to_vec())
+        );
     }
 
     #[test]
@@ -454,6 +532,12 @@ mod tests {
         );
         assert_eq!(pq.path[3], GROUP_ACTIVE_ACTIONS_KEY.to_vec());
         assert_eq!(pq.path.last().unwrap(), &ACTION_SIGNERS_KEY.to_vec());
+        // Query should have a single key for the identity
+        assert_eq!(pq.query.query.items.len(), 1);
+        assert_eq!(
+            pq.query.query.items[0],
+            QueryItem::Key(IDENTITY_ID.to_vec())
+        );
     }
 
     #[test]
@@ -466,6 +550,12 @@ mod tests {
             IDENTITY_ID,
         );
         assert_eq!(pq.path[3], GROUP_CLOSED_ACTIONS_KEY.to_vec());
+        // Query should have a single key for the identity
+        assert_eq!(pq.query.query.items.len(), 1);
+        assert_eq!(
+            pq.query.query.items[0],
+            QueryItem::Key(IDENTITY_ID.to_vec())
+        );
     }
 
     #[test]
@@ -473,6 +563,16 @@ mod tests {
         let pq = Drive::group_active_or_closed_action_query(CONTRACT_ID, GROUP_POS);
         assert!(pq.query.limit.is_none());
         assert_eq!(pq.path, group_path_vec(&CONTRACT_ID, GROUP_POS));
+        // Should have two keys: active and closed
+        assert_eq!(pq.query.query.items.len(), 2);
+        assert_eq!(
+            pq.query.query.items[0],
+            QueryItem::Key(GROUP_ACTIVE_ACTIONS_KEY.to_vec())
+        );
+        assert_eq!(
+            pq.query.query.items[1],
+            QueryItem::Key(GROUP_CLOSED_ACTIONS_KEY.to_vec())
+        );
     }
 
     #[test]
@@ -485,5 +585,27 @@ mod tests {
         );
         assert!(pq.query.limit.is_none());
         assert_eq!(pq.path, group_path_vec(&CONTRACT_ID, GROUP_POS));
+        // Should have two keys: active and closed
+        assert_eq!(pq.query.query.items.len(), 2);
+        assert_eq!(
+            pq.query.query.items[0],
+            QueryItem::Key(GROUP_ACTIVE_ACTIONS_KEY.to_vec())
+        );
+        assert_eq!(
+            pq.query.query.items[1],
+            QueryItem::Key(GROUP_CLOSED_ACTIONS_KEY.to_vec())
+        );
+        // Should have a subquery path with action_id, signers key, and identity_id
+        let subquery_path = pq
+            .query
+            .query
+            .default_subquery_branch
+            .subquery_path
+            .as_ref()
+            .expect("expected a subquery path");
+        assert_eq!(subquery_path.len(), 3);
+        assert_eq!(subquery_path[0], ACTION_ID.to_vec());
+        assert_eq!(subquery_path[1], ACTION_SIGNERS_KEY.to_vec());
+        assert_eq!(subquery_path[2], IDENTITY_ID.to_vec());
     }
 }


### PR DESCRIPTION
## Issue being fixed or feature implemented

Improve test coverage for the `packages/rs-drive/src/drive/group/` module and fix a production bug discovered during testing.

## What was done?

### Bug Fix
Fixed a production bug in `fetch_group_infos_operations_v0` where `QueryKeyElementPairResultType` was used with a subquery key (`GROUP_INFO_KEY`). This caused the returned key to be the subquery key (`b"I"`, 1 byte) instead of the group contract position (2 bytes), resulting in a `CorruptedDriveState` error every time `fetch_group_infos` was called. Changed to `QueryPathKeyElementTrioResultType` and extract the group contract position from the last path component instead.

This bug affects the DAPI group infos query endpoint (`rs-drive-abci/src/query/group_queries/group_infos/v0/mod.rs`).

### Test Coverage (53 new tests)

**`paths.rs` (19 tests)** -- Coverage: 35.86% -> 100%
- Tests all path construction functions (root, contract, group, active/closed action, signers)
- Validates path lengths, component values, and key placement
- Verifies active vs. closed paths differ only by the action key

**`queries.rs` (19 tests)** -- Coverage: 51.71% -> 100%
- Tests all query builder functions including limits, start positions, and status filters
- Covers `group_info_query`, `group_infos_query` (with/without start, included/excluded)
- Covers `action_infos_query` (active/closed, with/without start_at)
- Covers `group_action_query`, `group_action_signers_query`
- Covers single signer queries (active, closed, active_or_closed, active_and_closed)

**`mod.rs` integration tests (24 tests)** -- Covers fetch, insert, prove, and cost estimation:
- `fetch_group_info` and `fetch_group_infos` through public API (0% -> ~85%)
- `fetch_active_action_info` (0% -> ~41%)
- `fetch_action_id_signers_power` (0% -> ~44%)
- `fetch_action_id_has_signer` and `_with_costs` (0% -> ~93%)
- `fetch_action_id_info_keep_serialized` (0% -> ~43%)
- `fetch_action_is_closed` with both stateful and stateless modes (0% -> ~97%)
- Group action closing with signer migration (covers the `closes_group_action=true` branch)
- Adding groups to existing contract trees (covers the "not inserted" branch in `add_new_groups`)
- Cost estimation for add_group_action, add_new_groups, and closing actions
- Prove functions through public API version dispatch (prove_group_info, prove_group_infos, prove_action_signers, prove_action_infos)

### Key v0 coverage improvements:
| File | Before | After |
|------|--------|-------|
| `estimated_costs/for_add_group_action/v0` | 0% | 98% |
| `estimated_costs/for_add_groups/v0` | 0% | 100% |
| `fetch/fetch_action_id_has_signer/v0` | 0% | 93% |
| `fetch/fetch_action_is_closed/v0` | 0% | 97% |
| `fetch/fetch_group_infos/v0` | 0% | 85% |
| `insert/add_group_action/v0` | 47% | 93% |
| `insert/add_new_groups/v0` | 38% | 92% |
| `paths.rs` | 36% | 100% |
| `queries.rs` | 52% | 100% |

## How Has This Been Tested?

All 72 group tests pass:
```
cargo test --package drive --all-features -- drive::group
test result: ok. 72 passed; 0 failed; 0 ignored
```

Coverage verified with `cargo llvm-cov`.

## Breaking Changes

None. The bug fix changes the query result type in `fetch_group_infos_operations_v0` from `QueryKeyElementPairResultType` to `QueryPathKeyElementTrioResultType`, which is a behavioral fix -- the previous code would always fail with a `CorruptedDriveState` error.

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [x] I have made corresponding changes to the documentation if needed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Extensive new test coverage for group functionality, including comprehensive scenarios for information retrieval, path construction validation, query operations, and edge case handling across multiple configurations.

* **Chores**
  * Internal improvements to group data extraction and handling mechanisms to enhance overall reliability and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->