### PR TITLE
test(drive): improve document module test coverage

### DIFF
--- a/packages/rs-drive/src/drive/document/delete/mod.rs
+++ b/packages/rs-drive/src/drive/document/delete/mod.rs
@@ -1021,4 +1021,274 @@ mod tests {
         assert_eq!(fee_result.storage_fee, 0);
         assert_eq!(fee_result.processing_fee, 71994700);
     }
+
+    #[test]
+    fn test_delete_document_for_contract_id() {
+        let drive = setup_drive_with_initial_state_structure(None);
+
+        let db_transaction = drive.grove.start_transaction();
+
+        let platform_version = PlatformVersion::latest();
+
+        let contract = setup_contract(
+            &drive,
+            "tests/supporting_files/contract/family/family-contract-reduced.json",
+            None,
+            None,
+            None::<fn(&mut DataContract)>,
+            Some(&db_transaction),
+            None,
+        );
+
+        let document_type = contract
+            .document_type_for_name("person")
+            .expect("expected to get document type");
+
+        let random_owner_id = rand::thread_rng().gen::<[u8; 32]>();
+
+        let person_document = json_document_to_document(
+            "tests/supporting_files/contract/family/person0.json",
+            Some(random_owner_id.into()),
+            document_type,
+            platform_version,
+        )
+        .expect("expected to get document");
+
+        let storage_flags = Some(Cow::Owned(StorageFlags::SingleEpoch(0)));
+
+        drive
+            .add_document_for_contract(
+                DocumentAndContractInfo {
+                    owned_document_info: OwnedDocumentInfo {
+                        document_info: DocumentRefInfo((&person_document, storage_flags)),
+                        owner_id: None,
+                    },
+                    contract: &contract,
+                    document_type,
+                },
+                false,
+                BlockInfo::default(),
+                true,
+                Some(&db_transaction),
+                platform_version,
+                None,
+            )
+            .expect("expected to insert a document successfully");
+
+        drive
+            .grove
+            .commit_transaction(db_transaction)
+            .unwrap()
+            .expect("unable to commit transaction");
+
+        // Verify the document exists
+        let sql_string =
+            "select * from person where firstName = 'Samuel' order by firstName asc limit 100";
+        let query =
+            DriveDocumentQuery::from_sql_expr(sql_string, &contract, Some(&DriveConfig::default()))
+                .expect("should build query");
+
+        let (results, _, _) = query
+            .execute_raw_results_no_proof(&drive, None, None, platform_version)
+            .expect("expected to execute query");
+        assert_eq!(results.len(), 1);
+
+        let document_id = bs58::decode("AYjYxDqLy2hvGQADqE6FAkBnQEpJSzNd3CRw1tpS6vZ7")
+            .into_vec()
+            .expect("should decode")
+            .as_slice()
+            .try_into()
+            .expect("this be 32 bytes");
+
+        // Delete using contract_id instead of contract reference
+        drive
+            .delete_document_for_contract_id(
+                document_id,
+                contract.id(),
+                "person",
+                BlockInfo::default(),
+                true,
+                None,
+                platform_version,
+                Some(&EPOCH_CHANGE_FEE_VERSION_TEST),
+            )
+            .expect("expected to be able to delete the document by contract id");
+
+        // Verify the document was deleted
+        let (results, _, _) = query
+            .execute_raw_results_no_proof(&drive, None, None, platform_version)
+            .expect("expected to execute query");
+        assert_eq!(results.len(), 0);
+    }
+
+    #[test]
+    fn test_delete_document_for_contract_id_estimated_costs() {
+        let drive = setup_drive_with_initial_state_structure(None);
+
+        let db_transaction = drive.grove.start_transaction();
+
+        let platform_version = PlatformVersion::latest();
+
+        let contract = setup_contract(
+            &drive,
+            "tests/supporting_files/contract/family/family-contract-reduced.json",
+            None,
+            None,
+            None::<fn(&mut DataContract)>,
+            Some(&db_transaction),
+            None,
+        );
+
+        let document_type = contract
+            .document_type_for_name("person")
+            .expect("expected to get document type");
+
+        let random_owner_id = rand::thread_rng().gen::<[u8; 32]>();
+
+        let person_document = json_document_to_document(
+            "tests/supporting_files/contract/family/person0.json",
+            Some(random_owner_id.into()),
+            document_type,
+            platform_version,
+        )
+        .expect("expected to get document");
+
+        let storage_flags = Some(Cow::Owned(StorageFlags::SingleEpoch(0)));
+
+        drive
+            .add_document_for_contract(
+                DocumentAndContractInfo {
+                    owned_document_info: OwnedDocumentInfo {
+                        document_info: DocumentRefInfo((&person_document, storage_flags)),
+                        owner_id: None,
+                    },
+                    contract: &contract,
+                    document_type,
+                },
+                false,
+                BlockInfo::default(),
+                true,
+                Some(&db_transaction),
+                platform_version,
+                None,
+            )
+            .expect("expected to insert a document successfully");
+
+        drive
+            .grove
+            .commit_transaction(db_transaction)
+            .unwrap()
+            .expect("unable to commit transaction");
+
+        let document_id = bs58::decode("AYjYxDqLy2hvGQADqE6FAkBnQEpJSzNd3CRw1tpS6vZ7")
+            .into_vec()
+            .expect("should decode")
+            .as_slice()
+            .try_into()
+            .expect("this be 32 bytes");
+
+        // Use apply=false to exercise the estimation costs path
+        let fee_result = drive
+            .delete_document_for_contract_id(
+                document_id,
+                contract.id(),
+                "person",
+                BlockInfo::default(),
+                false,
+                None,
+                platform_version,
+                Some(&EPOCH_CHANGE_FEE_VERSION_TEST),
+            )
+            .expect("expected to estimate delete costs");
+
+        // Should have processing fee but no storage fee for estimation
+        assert_eq!(fee_result.storage_fee, 0);
+        assert!(fee_result.processing_fee > 0);
+    }
+
+    #[test]
+    fn test_delete_document_keeps_history_returns_error() {
+        let drive = setup_drive_with_initial_state_structure(None);
+
+        let db_transaction = drive.grove.start_transaction();
+
+        let platform_version = PlatformVersion::latest();
+
+        let contract = setup_contract(
+            &drive,
+            "tests/supporting_files/contract/family/family-contract-with-history.json",
+            None,
+            None,
+            None::<fn(&mut DataContract)>,
+            Some(&db_transaction),
+            None,
+        );
+
+        let document_type = contract
+            .document_type_for_name("person")
+            .expect("expected to get document type");
+
+        let random_owner_id = rand::thread_rng().gen::<[u8; 32]>();
+
+        let person_document = json_document_to_document(
+            "tests/supporting_files/contract/family/person0.json",
+            Some(random_owner_id.into()),
+            document_type,
+            platform_version,
+        )
+        .expect("expected to get document");
+
+        let storage_flags = Some(Cow::Owned(StorageFlags::SingleEpoch(0)));
+
+        drive
+            .add_document_for_contract(
+                DocumentAndContractInfo {
+                    owned_document_info: OwnedDocumentInfo {
+                        document_info: DocumentRefInfo((&person_document, storage_flags)),
+                        owner_id: None,
+                    },
+                    contract: &contract,
+                    document_type,
+                },
+                false,
+                BlockInfo::default(),
+                true,
+                Some(&db_transaction),
+                platform_version,
+                None,
+            )
+            .expect("expected to insert a document successfully");
+
+        drive
+            .grove
+            .commit_transaction(db_transaction)
+            .unwrap()
+            .expect("unable to commit transaction");
+
+        let document_id = bs58::decode("AYjYxDqLy2hvGQADqE6FAkBnQEpJSzNd3CRw1tpS6vZ7")
+            .into_vec()
+            .expect("should decode")
+            .as_slice()
+            .try_into()
+            .expect("this be 32 bytes");
+
+        // Attempting to delete a document that keeps history should return an error
+        let err = drive
+            .delete_document_for_contract(
+                document_id,
+                &contract,
+                "person",
+                BlockInfo::default(),
+                true,
+                None,
+                platform_version,
+                Some(&EPOCH_CHANGE_FEE_VERSION_TEST),
+            )
+            .expect_err("expected deleting a history-keeping document to fail");
+
+        assert!(matches!(
+            err,
+            Error::Drive(DriveError::InvalidDeletionOfDocumentThatKeepsHistory(_))
+        ));
+    }
 }

--- a/packages/rs-drive/src/drive/document/delete/mod.rs
+++ b/packages/rs-drive/src/drive/document/delete/mod.rs
@@ -1204,6 +1204,23 @@ mod tests {
         // Should have processing fee but no storage fee for estimation
         assert_eq!(fee_result.storage_fee, 0);
         assert!(fee_result.processing_fee > 0);
+
+        // Verify the document still exists after dry-run delete (apply=false)
+        let sql_string =
+            "select * from person where firstName = 'Samuel' order by firstName asc limit 100";
+        let query =
+            DriveDocumentQuery::from_sql_expr(sql_string, &contract, Some(&DriveConfig::default()))
+                .expect("should build query");
+
+        let (results, _, _) = query
+            .execute_raw_results_no_proof(&drive, None, None, platform_version)
+            .expect("expected to execute query");
+
+        assert_eq!(
+            results.len(),
+            1,
+            "document should still exist after dry-run delete"
+        );
     }
 
     #[test]

--- a/packages/rs-drive/src/drive/document/insert/mod.rs
+++ b/packages/rs-drive/src/drive/document/insert/mod.rs
@@ -51,13 +51,17 @@ mod tests {
     use once_cell::sync::Lazy;
     use std::collections::BTreeMap;
 
+    use crate::config::DriveConfig;
     use crate::error::drive::DriveError;
     use crate::error::Error;
+    use crate::query::DriveDocumentQuery;
     use crate::util::object_size_info::DocumentInfo::DocumentRefInfo;
     use crate::util::test_helpers::setup::setup_drive_with_initial_state_structure;
     use dpp::block::epoch::Epoch;
     use dpp::data_contract::accessors::v0::DataContractV0Getters;
     use dpp::data_contract::DataContract;
+    use dpp::document::serialization_traits::DocumentPlatformConversionMethodsV0;
+    use dpp::document::{Document, DocumentV0Getters};
     use dpp::fee::default_costs::KnownCostItem::StorageDiskUsageCreditPerByte;
     use dpp::fee::default_costs::{CachedEpochIndexFeeVersions, EpochCosts};
     use dpp::fee::fee_result::FeeResult;
@@ -1005,6 +1009,33 @@ mod tests {
 
         assert!(fee_result.storage_fee > 0);
         assert!(fee_result.processing_fee > 0);
+
+        // Fetch the document back and verify content matches
+        let sql_string = "select * from profile";
+        let query =
+            DriveDocumentQuery::from_sql_expr(sql_string, &contract, Some(&DriveConfig::default()))
+                .expect("should build query");
+
+        let (results, _, _) = query
+            .execute_raw_results_no_proof(&drive, None, Some(&db_transaction), platform_version)
+            .expect("expected to execute query");
+
+        assert_eq!(results.len(), 1);
+
+        let document_type = contract
+            .document_type_for_name("profile")
+            .expect("expected profile document type");
+        let fetched_doc = Document::from_bytes(&results[0], document_type, platform_version)
+            .expect("expected to deserialize document");
+        assert_eq!(
+            fetched_doc
+                .get("displayName")
+                .expect("displayName should exist")
+                .as_text()
+                .expect("displayName should be text"),
+            "sam",
+            "displayName should match the original value from profile0.json"
+        );
     }
 
     #[test]
@@ -1097,6 +1128,43 @@ mod tests {
             .commit_transaction(db_transaction)
             .unwrap()
             .expect("unable to commit transaction");
+
+        // Fetch both documents back and verify they exist with correct content
+        let sql_string = "select * from person order by firstName asc limit 100";
+        let query =
+            DriveDocumentQuery::from_sql_expr(sql_string, &contract, Some(&DriveConfig::default()))
+                .expect("should build query");
+
+        let (results, _, _) = query
+            .execute_raw_results_no_proof(&drive, None, None, platform_version)
+            .expect("expected to execute query");
+
+        assert_eq!(
+            results.len(),
+            2,
+            "expected both history-keeping documents to be present"
+        );
+
+        let doc0 = Document::from_bytes(&results[0], document_type, platform_version)
+            .expect("expected to deserialize first document");
+        let doc1 = Document::from_bytes(&results[1], document_type, platform_version)
+            .expect("expected to deserialize second document");
+
+        // Results are ordered by firstName ascending: Samuel, Tom
+        assert_eq!(
+            doc0.get("firstName")
+                .expect("firstName should exist")
+                .as_text()
+                .expect("firstName should be text"),
+            "Samuel"
+        );
+        assert_eq!(
+            doc1.get("firstName")
+                .expect("firstName should exist")
+                .as_text()
+                .expect("firstName should be text"),
+            "Tom"
+        );
     }
 
     #[test]
@@ -1247,5 +1315,21 @@ mod tests {
                 platform_version,
             )
             .expect("expected second document insertion to succeed");
+
+        // Verify both documents were inserted by fetching them
+        let sql_string = "select * from contactRequest";
+        let query =
+            DriveDocumentQuery::from_sql_expr(sql_string, &contract, Some(&DriveConfig::default()))
+                .expect("should build query");
+
+        let (results, _, _) = query
+            .execute_raw_results_no_proof(&drive, None, Some(&db_transaction), platform_version)
+            .expect("expected to execute query");
+
+        assert_eq!(
+            results.len(),
+            2,
+            "expected both documents to be present after batch insertion"
+        );
     }
 }

--- a/packages/rs-drive/src/drive/document/insert/mod.rs
+++ b/packages/rs-drive/src/drive/document/insert/mod.rs
@@ -948,4 +948,304 @@ mod tests {
                 "expected not to be able to insert document with already existing unique index",
             );
     }
+
+    #[test]
+    fn test_add_document_by_contract_id() {
+        let drive = setup_drive_with_initial_state_structure(None);
+
+        let db_transaction = drive.grove.start_transaction();
+
+        let platform_version = PlatformVersion::latest();
+
+        let contract = setup_contract(
+            &drive,
+            "tests/supporting_files/contract/dashpay/dashpay-contract-all-mutable.json",
+            None,
+            None,
+            None::<fn(&mut DataContract)>,
+            Some(&db_transaction),
+            None,
+        );
+
+        let document_type = contract
+            .document_type_for_name("profile")
+            .expect("expected to get document type");
+
+        let random_owner_id = random::<[u8; 32]>();
+
+        let dashpay_profile_document = json_document_to_document(
+            "tests/supporting_files/contract/dashpay/profile0.json",
+            Some(random_owner_id.into()),
+            document_type,
+            platform_version,
+        )
+        .expect("expected to get document");
+
+        let owned_document_info = OwnedDocumentInfo {
+            document_info: DocumentRefInfo((
+                &dashpay_profile_document,
+                StorageFlags::optional_default_as_cow(),
+            )),
+            owner_id: Some(random_owner_id),
+        };
+
+        // Use the add_document API which takes contract_id instead of contract ref
+        let fee_result = drive
+            .add_document(
+                owned_document_info,
+                contract.id(),
+                "profile",
+                false,
+                &BlockInfo::default(),
+                true,
+                Some(&db_transaction),
+                platform_version,
+            )
+            .expect("expected to insert a document via add_document successfully");
+
+        assert!(fee_result.storage_fee > 0);
+        assert!(fee_result.processing_fee > 0);
+    }
+
+    #[test]
+    fn test_add_document_with_history() {
+        let drive = setup_drive_with_initial_state_structure(None);
+
+        let db_transaction = drive.grove.start_transaction();
+
+        let platform_version = PlatformVersion::latest();
+
+        let contract = setup_contract(
+            &drive,
+            "tests/supporting_files/contract/family/family-contract-with-history.json",
+            None,
+            None,
+            None::<fn(&mut DataContract)>,
+            Some(&db_transaction),
+            None,
+        );
+
+        let document_type = contract
+            .document_type_for_name("person")
+            .expect("expected to get document type");
+
+        let random_owner_id = random::<[u8; 32]>();
+
+        let person_document = json_document_to_document(
+            "tests/supporting_files/contract/family/person0.json",
+            Some(random_owner_id.into()),
+            document_type,
+            platform_version,
+        )
+        .expect("expected to get document");
+
+        let storage_flags = Some(Cow::Owned(StorageFlags::SingleEpoch(0)));
+
+        let fee_result = drive
+            .add_document_for_contract(
+                DocumentAndContractInfo {
+                    owned_document_info: OwnedDocumentInfo {
+                        document_info: DocumentRefInfo((&person_document, storage_flags)),
+                        owner_id: Some(random_owner_id),
+                    },
+                    contract: &contract,
+                    document_type,
+                },
+                false,
+                BlockInfo::default(),
+                true,
+                Some(&db_transaction),
+                platform_version,
+                None,
+            )
+            .expect("expected to insert a history-keeping document successfully");
+
+        assert!(fee_result.storage_fee > 0);
+
+        // Now add a second document with history
+        let person_document1 = json_document_to_document(
+            "tests/supporting_files/contract/family/person1.json",
+            Some(random_owner_id.into()),
+            document_type,
+            platform_version,
+        )
+        .expect("expected to get document");
+
+        let storage_flags = Some(Cow::Owned(StorageFlags::SingleEpoch(0)));
+
+        drive
+            .add_document_for_contract(
+                DocumentAndContractInfo {
+                    owned_document_info: OwnedDocumentInfo {
+                        document_info: DocumentRefInfo((&person_document1, storage_flags)),
+                        owner_id: Some(random_owner_id),
+                    },
+                    contract: &contract,
+                    document_type,
+                },
+                false,
+                BlockInfo::default(),
+                true,
+                Some(&db_transaction),
+                platform_version,
+                None,
+            )
+            .expect("expected to insert a second history-keeping document successfully");
+
+        drive
+            .grove
+            .commit_transaction(db_transaction)
+            .unwrap()
+            .expect("unable to commit transaction");
+    }
+
+    #[test]
+    fn test_add_document_with_history_estimated_costs() {
+        let drive = setup_drive_with_initial_state_structure(None);
+
+        let db_transaction = drive.grove.start_transaction();
+
+        let platform_version = PlatformVersion::latest();
+
+        let contract = setup_contract(
+            &drive,
+            "tests/supporting_files/contract/family/family-contract-with-history.json",
+            None,
+            None,
+            None::<fn(&mut DataContract)>,
+            Some(&db_transaction),
+            None,
+        );
+
+        let document_type = contract
+            .document_type_for_name("person")
+            .expect("expected to get document type");
+
+        let random_owner_id = random::<[u8; 32]>();
+
+        let person_document = json_document_to_document(
+            "tests/supporting_files/contract/family/person0.json",
+            Some(random_owner_id.into()),
+            document_type,
+            platform_version,
+        )
+        .expect("expected to get document");
+
+        let storage_flags = Some(Cow::Owned(StorageFlags::SingleEpoch(0)));
+
+        // apply=false for estimation path of history-keeping documents
+        let fee_result = drive
+            .add_document_for_contract(
+                DocumentAndContractInfo {
+                    owned_document_info: OwnedDocumentInfo {
+                        document_info: DocumentRefInfo((&person_document, storage_flags)),
+                        owner_id: Some(random_owner_id),
+                    },
+                    contract: &contract,
+                    document_type,
+                },
+                false,
+                BlockInfo::default(),
+                false,
+                Some(&db_transaction),
+                platform_version,
+                None,
+            )
+            .expect("expected to estimate insert of a history-keeping document");
+
+        // Estimation should have storage fee and processing fee
+        assert!(fee_result.storage_fee > 0);
+        assert!(fee_result.processing_fee > 0);
+    }
+
+    #[test]
+    fn test_add_document_for_contract_with_non_unique_batch() {
+        let drive = setup_drive_with_initial_state_structure(None);
+
+        let db_transaction = drive.grove.start_transaction();
+
+        let platform_version = PlatformVersion::latest();
+
+        let contract = setup_contract(
+            &drive,
+            "tests/supporting_files/contract/dashpay/dashpay-contract-all-mutable.json",
+            None,
+            None,
+            None::<fn(&mut DataContract)>,
+            Some(&db_transaction),
+            None,
+        );
+
+        let document_type = contract
+            .document_type_for_name("contactRequest")
+            .expect("expected to get document type");
+
+        let random_owner_id = random::<[u8; 32]>();
+
+        let document0 = json_document_to_document(
+            "tests/supporting_files/contract/dashpay/contact-request0.json",
+            Some(random_owner_id.into()),
+            document_type,
+            platform_version,
+        )
+        .expect("expected to get document");
+
+        let document1 = json_document_to_document(
+            "tests/supporting_files/contract/dashpay/contact-request1.json",
+            Some(random_owner_id.into()),
+            document_type,
+            platform_version,
+        )
+        .expect("expected to get document");
+
+        // Insert first document setting document_is_unique_for_document_type_in_batch=true
+        let mut drive_operations = vec![];
+        drive
+            .add_document_for_contract_apply_and_add_to_operations(
+                DocumentAndContractInfo {
+                    owned_document_info: OwnedDocumentInfo {
+                        document_info: DocumentRefInfo((
+                            &document0,
+                            StorageFlags::optional_default_as_cow(),
+                        )),
+                        owner_id: Some(random_owner_id),
+                    },
+                    contract: &contract,
+                    document_type,
+                },
+                false,
+                &BlockInfo::default(),
+                true, // unique in batch
+                true,
+                Some(&db_transaction),
+                &mut drive_operations,
+                platform_version,
+            )
+            .expect("expected first document insertion to succeed");
+
+        // Insert second document with document_is_unique_for_document_type_in_batch=false
+        // This exercises the else branch in apply_and_add_to_operations_v0
+        drive
+            .add_document_for_contract_apply_and_add_to_operations(
+                DocumentAndContractInfo {
+                    owned_document_info: OwnedDocumentInfo {
+                        document_info: DocumentRefInfo((
+                            &document1,
+                            StorageFlags::optional_default_as_cow(),
+                        )),
+                        owner_id: Some(random_owner_id),
+                    },
+                    contract: &contract,
+                    document_type,
+                },
+                false,
+                &BlockInfo::default(),
+                false, // not unique in batch - exercises else branch
+                true,
+                Some(&db_transaction),
+                &mut drive_operations,
+                platform_version,
+            )
+            .expect("expected second document insertion to succeed");
+    }
 }

--- a/packages/rs-drive/src/drive/document/query/mod.rs
+++ b/packages/rs-drive/src/drive/document/query/mod.rs
@@ -526,8 +526,6 @@ mod tests {
     fn test_query_documents_dry_run() {
         let (drive, contract) = setup_dashpay("query-dry-run", true);
 
-        let _platform_version = PlatformVersion::latest();
-
         let sql_string = "select * from contactRequest";
         let query =
             DriveDocumentQuery::from_sql_expr(sql_string, &contract, Some(&DriveConfig::default()))

--- a/packages/rs-drive/src/drive/document/query/mod.rs
+++ b/packages/rs-drive/src/drive/document/query/mod.rs
@@ -495,3 +495,337 @@ impl Drive {
     //     Ok((items, skipped, cost))
     // }
 }
+
+#[cfg(feature = "server")]
+#[cfg(test)]
+mod tests {
+    use std::borrow::Cow;
+    use std::option::Option::None;
+
+    use dpp::block::block_info::BlockInfo;
+    use dpp::block::epoch::Epoch;
+    use rand::random;
+
+    use crate::config::DriveConfig;
+    use crate::drive::document::query::{
+        QueryDocumentsOutcomeV0Methods, QueryDocumentsWithFlagsOutcomeV0Methods,
+    };
+    use crate::drive::document::tests::setup_dashpay;
+    use crate::query::DriveDocumentQuery;
+    use crate::util::object_size_info::DocumentInfo::DocumentRefInfo;
+    use crate::util::object_size_info::{DocumentAndContractInfo, OwnedDocumentInfo};
+    use crate::util::storage_flags::StorageFlags;
+    use crate::util::test_helpers::setup::setup_drive_with_initial_state_structure;
+    use crate::util::test_helpers::setup_contract;
+    use dpp::data_contract::accessors::v0::DataContractV0Getters;
+    use dpp::data_contract::DataContract;
+    use dpp::tests::json_document::json_document_to_document;
+    use dpp::version::PlatformVersion;
+
+    #[test]
+    fn test_query_documents_dry_run() {
+        let (drive, contract) = setup_dashpay("query-dry-run", true);
+
+        let _platform_version = PlatformVersion::latest();
+
+        let sql_string = "select * from contactRequest";
+        let query =
+            DriveDocumentQuery::from_sql_expr(sql_string, &contract, Some(&DriveConfig::default()))
+                .expect("should build query");
+
+        // Dry run should return empty results without touching storage
+        let outcome = drive
+            .query_documents(query, None, true, None, None)
+            .expect("expected dry run query to succeed");
+
+        assert_eq!(outcome.documents().len(), 0);
+        assert_eq!(outcome.skipped(), 0);
+        assert_eq!(outcome.cost(), 0);
+    }
+
+    #[test]
+    fn test_query_documents_with_epoch_fee() {
+        let (drive, contract) = setup_dashpay("query-epoch", true);
+
+        let platform_version = PlatformVersion::latest();
+
+        let document_type = contract
+            .document_type_for_name("contactRequest")
+            .expect("expected to get document type");
+
+        let random_owner_id = random::<[u8; 32]>();
+
+        let document = json_document_to_document(
+            "tests/supporting_files/contract/dashpay/contact-request0.json",
+            Some(random_owner_id.into()),
+            document_type,
+            platform_version,
+        )
+        .expect("expected to get document");
+
+        drive
+            .add_document_for_contract(
+                DocumentAndContractInfo {
+                    owned_document_info: OwnedDocumentInfo {
+                        document_info: DocumentRefInfo((
+                            &document,
+                            StorageFlags::optional_default_as_cow(),
+                        )),
+                        owner_id: Some(random_owner_id),
+                    },
+                    contract: &contract,
+                    document_type,
+                },
+                false,
+                BlockInfo::default(),
+                true,
+                None,
+                platform_version,
+                None,
+            )
+            .expect("expected to insert a document successfully");
+
+        let sql_string = "select * from contactRequest";
+        let query =
+            DriveDocumentQuery::from_sql_expr(sql_string, &contract, Some(&DriveConfig::default()))
+                .expect("should build query");
+
+        // Query with epoch to exercise the fee calculation path
+        let epoch = Epoch::new(0).unwrap();
+        let outcome = drive
+            .query_documents(query, Some(&epoch), false, None, None)
+            .expect("expected query with epoch to succeed");
+
+        assert_eq!(outcome.documents().len(), 1);
+        assert!(outcome.cost() > 0, "cost should be non-zero with epoch");
+    }
+
+    #[test]
+    fn test_query_documents_without_epoch_zero_cost() {
+        let (drive, contract) = setup_dashpay("query-no-epoch", true);
+
+        let platform_version = PlatformVersion::latest();
+
+        let document_type = contract
+            .document_type_for_name("contactRequest")
+            .expect("expected to get document type");
+
+        let random_owner_id = random::<[u8; 32]>();
+
+        let document = json_document_to_document(
+            "tests/supporting_files/contract/dashpay/contact-request0.json",
+            Some(random_owner_id.into()),
+            document_type,
+            platform_version,
+        )
+        .expect("expected to get document");
+
+        drive
+            .add_document_for_contract(
+                DocumentAndContractInfo {
+                    owned_document_info: OwnedDocumentInfo {
+                        document_info: DocumentRefInfo((
+                            &document,
+                            StorageFlags::optional_default_as_cow(),
+                        )),
+                        owner_id: Some(random_owner_id),
+                    },
+                    contract: &contract,
+                    document_type,
+                },
+                false,
+                BlockInfo::default(),
+                true,
+                None,
+                platform_version,
+                None,
+            )
+            .expect("expected to insert a document successfully");
+
+        let sql_string = "select * from contactRequest";
+        let query =
+            DriveDocumentQuery::from_sql_expr(sql_string, &contract, Some(&DriveConfig::default()))
+                .expect("should build query");
+
+        // Query without epoch, cost should be 0
+        let outcome = drive
+            .query_documents(query, None, false, None, None)
+            .expect("expected query without epoch to succeed");
+
+        assert_eq!(outcome.documents().len(), 1);
+        assert_eq!(outcome.cost(), 0, "cost should be zero without epoch");
+    }
+
+    #[test]
+    fn test_query_documents_with_flags() {
+        let drive = setup_drive_with_initial_state_structure(None);
+
+        let db_transaction = drive.grove.start_transaction();
+
+        let platform_version = PlatformVersion::latest();
+
+        let contract = setup_contract(
+            &drive,
+            "tests/supporting_files/contract/family/family-contract-reduced.json",
+            None,
+            None,
+            None::<fn(&mut DataContract)>,
+            Some(&db_transaction),
+            None,
+        );
+
+        let document_type = contract
+            .document_type_for_name("person")
+            .expect("expected to get document type");
+
+        let random_owner_id = random::<[u8; 32]>();
+
+        let person_document = json_document_to_document(
+            "tests/supporting_files/contract/family/person0.json",
+            Some(random_owner_id.into()),
+            document_type,
+            platform_version,
+        )
+        .expect("expected to get document");
+
+        let storage_flags = Some(Cow::Owned(StorageFlags::SingleEpoch(0)));
+
+        drive
+            .add_document_for_contract(
+                DocumentAndContractInfo {
+                    owned_document_info: OwnedDocumentInfo {
+                        document_info: DocumentRefInfo((&person_document, storage_flags)),
+                        owner_id: None,
+                    },
+                    contract: &contract,
+                    document_type,
+                },
+                false,
+                BlockInfo::default(),
+                true,
+                Some(&db_transaction),
+                platform_version,
+                None,
+            )
+            .expect("expected to insert a document successfully");
+
+        drive
+            .grove
+            .commit_transaction(db_transaction)
+            .unwrap()
+            .expect("unable to commit transaction");
+
+        let sql_string =
+            "select * from person where firstName = 'Samuel' order by firstName asc limit 100";
+        let query =
+            DriveDocumentQuery::from_sql_expr(sql_string, &contract, Some(&DriveConfig::default()))
+                .expect("should build query");
+
+        // Query documents with flags to cover the query_documents_with_flags path
+        let outcome = drive
+            .query_documents_with_flags(query, None, false, None, None)
+            .expect("expected query_documents_with_flags to succeed");
+
+        assert_eq!(outcome.documents().len(), 1);
+        assert_eq!(outcome.cost(), 0);
+        // Verify storage flags are returned
+        let (_, flags) = &outcome.documents()[0];
+        assert!(flags.is_some(), "storage flags should be present");
+    }
+
+    #[test]
+    fn test_query_documents_with_flags_dry_run() {
+        let (drive, contract) = setup_dashpay("query-flags-dry", true);
+
+        let sql_string = "select * from contactRequest";
+        let query =
+            DriveDocumentQuery::from_sql_expr(sql_string, &contract, Some(&DriveConfig::default()))
+                .expect("should build query");
+
+        // Dry run should return empty defaults
+        let outcome = drive
+            .query_documents_with_flags(query, None, true, None, None)
+            .expect("expected dry run query_documents_with_flags to succeed");
+
+        assert_eq!(outcome.documents().len(), 0);
+        assert_eq!(outcome.skipped(), 0);
+        assert_eq!(outcome.cost(), 0);
+    }
+
+    #[test]
+    fn test_query_documents_with_flags_with_epoch() {
+        let drive = setup_drive_with_initial_state_structure(None);
+
+        let db_transaction = drive.grove.start_transaction();
+
+        let platform_version = PlatformVersion::latest();
+
+        let contract = setup_contract(
+            &drive,
+            "tests/supporting_files/contract/family/family-contract-reduced.json",
+            None,
+            None,
+            None::<fn(&mut DataContract)>,
+            Some(&db_transaction),
+            None,
+        );
+
+        let document_type = contract
+            .document_type_for_name("person")
+            .expect("expected to get document type");
+
+        let random_owner_id = random::<[u8; 32]>();
+
+        let person_document = json_document_to_document(
+            "tests/supporting_files/contract/family/person0.json",
+            Some(random_owner_id.into()),
+            document_type,
+            platform_version,
+        )
+        .expect("expected to get document");
+
+        let storage_flags = Some(Cow::Owned(StorageFlags::SingleEpoch(0)));
+
+        drive
+            .add_document_for_contract(
+                DocumentAndContractInfo {
+                    owned_document_info: OwnedDocumentInfo {
+                        document_info: DocumentRefInfo((&person_document, storage_flags)),
+                        owner_id: None,
+                    },
+                    contract: &contract,
+                    document_type,
+                },
+                false,
+                BlockInfo::default(),
+                true,
+                Some(&db_transaction),
+                platform_version,
+                None,
+            )
+            .expect("expected to insert a document successfully");
+
+        drive
+            .grove
+            .commit_transaction(db_transaction)
+            .unwrap()
+            .expect("unable to commit transaction");
+
+        let sql_string =
+            "select * from person where firstName = 'Samuel' order by firstName asc limit 100";
+        let query =
+            DriveDocumentQuery::from_sql_expr(sql_string, &contract, Some(&DriveConfig::default()))
+                .expect("should build query");
+
+        let epoch = Epoch::new(0).unwrap();
+        let outcome = drive
+            .query_documents_with_flags(query, Some(&epoch), false, None, None)
+            .expect("expected query_documents_with_flags with epoch to succeed");
+
+        assert_eq!(outcome.documents().len(), 1);
+        assert!(
+            outcome.cost() > 0,
+            "cost should be non-zero when epoch is provided"
+        );
+    }
+}

--- a/packages/rs-drive/src/drive/document/update/mod.rs
+++ b/packages/rs-drive/src/drive/document/update/mod.rs
@@ -49,6 +49,7 @@ mod tests {
     use crate::util::object_size_info::{DocumentAndContractInfo, OwnedDocumentInfo};
     use crate::util::storage_flags::StorageFlags;
 
+    use crate::drive::document::query::QueryDocumentsOutcomeV0Methods;
     use crate::drive::document::tests::setup_dashpay;
     use crate::query::DriveDocumentQuery;
     use crate::util::test_helpers::setup::{setup_drive, setup_drive_with_initial_state_structure};
@@ -2053,6 +2054,51 @@ mod tests {
         )
         .expect("expected to get document");
 
+        // Insert documents first so update operations target existing documents
+        drive
+            .add_document_for_contract(
+                DocumentAndContractInfo {
+                    owned_document_info: OwnedDocumentInfo {
+                        document_info: DocumentRefInfo((
+                            &doc0,
+                            StorageFlags::optional_default_as_cow(),
+                        )),
+                        owner_id: Some(owner_id),
+                    },
+                    contract: &contract,
+                    document_type,
+                },
+                false,
+                BlockInfo::default(),
+                true,
+                None,
+                platform_version,
+                None,
+            )
+            .expect("expected to insert first document");
+
+        drive
+            .add_document_for_contract(
+                DocumentAndContractInfo {
+                    owned_document_info: OwnedDocumentInfo {
+                        document_info: DocumentRefInfo((
+                            &doc1,
+                            StorageFlags::optional_default_as_cow(),
+                        )),
+                        owner_id: Some(owner_id),
+                    },
+                    contract: &contract,
+                    document_type,
+                },
+                false,
+                BlockInfo::default(),
+                true,
+                None,
+                platform_version,
+                None,
+            )
+            .expect("expected to insert second document");
+
         let documents = vec![doc0, doc1];
 
         let mut drive_operations = vec![];
@@ -2205,7 +2251,9 @@ mod tests {
 
         // Update document
         document.set("displayName", "Bob".into());
-        document.increment_revision().unwrap();
+        document
+            .increment_revision()
+            .expect("document should have a revision to increment");
 
         let serialized = DocumentPlatformConversionMethodsV0::serialize(
             &document,
@@ -2232,6 +2280,28 @@ mod tests {
             .expect("expected to update document with serialization");
 
         assert!(fee_result.processing_fee > 0);
+
+        // Fetch the document back and verify the update took effect
+        let sql_string = "select * from profile";
+        let query =
+            DriveDocumentQuery::from_sql_expr(sql_string, &contract, Some(&DriveConfig::default()))
+                .expect("should build query");
+
+        let outcome = drive
+            .query_documents(query, None, false, None, None)
+            .expect("expected to query documents");
+
+        assert_eq!(outcome.documents().len(), 1);
+        let fetched_doc = &outcome.documents()[0];
+        assert_eq!(
+            fetched_doc
+                .get("displayName")
+                .expect("displayName should exist")
+                .as_text()
+                .expect("displayName should be text"),
+            "Bob",
+            "displayName should have been updated to Bob"
+        );
     }
 
     #[test]
@@ -2284,7 +2354,9 @@ mod tests {
 
         // Update document using contract_id API
         document.set("displayName", "Bob".into());
-        document.increment_revision().unwrap();
+        document
+            .increment_revision()
+            .expect("document should have a revision to increment");
 
         let serialized = DocumentPlatformConversionMethodsV0::serialize(
             &document,
@@ -2310,5 +2382,27 @@ mod tests {
             .expect("expected to update document for contract id");
 
         assert!(fee_result.processing_fee > 0);
+
+        // Fetch the document back and verify the update took effect
+        let sql_string = "select * from profile";
+        let query =
+            DriveDocumentQuery::from_sql_expr(sql_string, &contract, Some(&DriveConfig::default()))
+                .expect("should build query");
+
+        let outcome = drive
+            .query_documents(query, None, false, None, None)
+            .expect("expected to query documents");
+
+        assert_eq!(outcome.documents().len(), 1);
+        let fetched_doc = &outcome.documents()[0];
+        assert_eq!(
+            fetched_doc
+                .get("displayName")
+                .expect("displayName should exist")
+                .as_text()
+                .expect("displayName should be text"),
+            "Bob",
+            "displayName should have been updated to Bob"
+        );
     }
 }

--- a/packages/rs-drive/src/drive/document/update/mod.rs
+++ b/packages/rs-drive/src/drive/document/update/mod.rs
@@ -57,6 +57,7 @@ mod tests {
     use dpp::data_contract::accessors::v0::DataContractV0Getters;
     use dpp::data_contract::conversion::value::v0::DataContractValueConversionMethodsV0;
     use dpp::data_contract::document_type::methods::DocumentTypeV0Methods;
+    use dpp::document::document_methods::DocumentMethodsV0;
     use dpp::document::serialization_traits::{
         DocumentPlatformConversionMethodsV0, DocumentPlatformValueMethodsV0,
     };
@@ -2022,5 +2023,292 @@ mod tests {
             .expect("should update document");
 
         assert_ne!(update_fees.storage_fee, 0);
+    }
+
+    #[test]
+    fn test_add_update_multiple_documents_operations() {
+        let (drive, contract) = setup_dashpay("multi-update", true);
+
+        let platform_version = PlatformVersion::latest();
+
+        let document_type = contract
+            .document_type_for_name("contactRequest")
+            .expect("contactRequest document exists");
+
+        let owner_id = random::<[u8; 32]>();
+
+        let doc0 = json_document_to_document(
+            "tests/supporting_files/contract/dashpay/contact-request0.json",
+            Some(owner_id.into()),
+            document_type,
+            platform_version,
+        )
+        .expect("expected to get document");
+
+        let doc1 = json_document_to_document(
+            "tests/supporting_files/contract/dashpay/contact-request1.json",
+            Some(owner_id.into()),
+            document_type,
+            platform_version,
+        )
+        .expect("expected to get document");
+
+        let documents = vec![doc0, doc1];
+
+        let mut drive_operations = vec![];
+
+        drive
+            .add_update_multiple_documents_operations(
+                &documents,
+                &contract,
+                document_type,
+                &mut drive_operations,
+                &platform_version.drive,
+            )
+            .expect("expected to add update operations");
+
+        // Should have created one operation containing both documents
+        assert_eq!(drive_operations.len(), 1);
+    }
+
+    #[test]
+    fn test_add_update_multiple_documents_operations_empty() {
+        let (drive, contract) = setup_dashpay("multi-update-empty", true);
+
+        let platform_version = PlatformVersion::latest();
+
+        let document_type = contract
+            .document_type_for_name("contactRequest")
+            .expect("contactRequest document exists");
+
+        let documents: Vec<dpp::document::Document> = vec![];
+
+        let mut drive_operations = vec![];
+
+        drive
+            .add_update_multiple_documents_operations(
+                &documents,
+                &contract,
+                document_type,
+                &mut drive_operations,
+                &platform_version.drive,
+            )
+            .expect("expected empty documents to succeed");
+
+        // Empty documents should produce no operations
+        assert_eq!(drive_operations.len(), 0);
+    }
+
+    #[test]
+    fn test_update_document_for_contract_immutable_error() {
+        let drive = setup_drive_with_initial_state_structure(None);
+
+        let db_transaction = drive.grove.start_transaction();
+
+        let platform_version = PlatformVersion::latest();
+
+        // Use the non-mutable dashpay contract
+        let contract = setup_contract(
+            &drive,
+            "tests/supporting_files/contract/dashpay/dashpay-contract.json",
+            None,
+            None,
+            None::<fn(&mut DataContract)>,
+            Some(&db_transaction),
+            None,
+        );
+
+        // contactRequest is not mutable in this contract
+        let document_type = contract
+            .document_type_for_name("contactRequest")
+            .expect("contactRequest document exists");
+
+        let owner_id = random::<[u8; 32]>();
+
+        let document = json_document_to_document(
+            "tests/supporting_files/contract/dashpay/contact-request0.json",
+            Some(owner_id.into()),
+            document_type,
+            platform_version,
+        )
+        .expect("expected to get cbor document");
+
+        // Try to update an immutable document type
+        let err = drive
+            .update_document_for_contract(
+                &document,
+                &contract,
+                document_type,
+                Some(owner_id),
+                BlockInfo::default(),
+                true,
+                StorageFlags::optional_default_as_cow(),
+                Some(&db_transaction),
+                platform_version,
+                None,
+            )
+            .expect_err("expected updating an immutable document type to fail");
+
+        assert!(matches!(
+            err,
+            Error::Drive(DriveError::UpdatingReadOnlyImmutableDocument(_))
+        ));
+    }
+
+    #[test]
+    fn test_update_document_with_serialization_for_contract() {
+        let (drive, contract) = setup_dashpay("update-serialized", true);
+
+        let platform_version = PlatformVersion::latest();
+
+        let document_type = contract
+            .document_type_for_name("profile")
+            .expect("profile document exists");
+
+        let owner_id: Identifier = random::<[u8; 32]>().into();
+
+        let mut document = document_type
+            .create_document_from_data(
+                platform_value!({"displayName": "Alice"}),
+                owner_id,
+                random(),
+                random(),
+                random(),
+                platform_version,
+            )
+            .expect("should create document");
+
+        // First create the document
+        let info = DocumentAndContractInfo {
+            owned_document_info: OwnedDocumentInfo {
+                document_info: DocumentRefInfo((
+                    &document,
+                    StorageFlags::optional_default_as_cow(),
+                )),
+                owner_id: Some(owner_id.to_buffer()),
+            },
+            contract: &contract,
+            document_type,
+        };
+
+        drive
+            .add_document_for_contract(
+                info,
+                true,
+                BlockInfo::default(),
+                true,
+                None,
+                platform_version,
+                None,
+            )
+            .expect("should create profile");
+
+        // Update document
+        document.set("displayName", "Bob".into());
+        document.increment_revision().unwrap();
+
+        let serialized = DocumentPlatformConversionMethodsV0::serialize(
+            &document,
+            document_type,
+            &contract,
+            platform_version,
+        )
+        .expect("expected to serialize");
+
+        let fee_result = drive
+            .update_document_with_serialization_for_contract(
+                &document,
+                &serialized,
+                &contract,
+                "profile",
+                Some(owner_id.to_buffer()),
+                BlockInfo::default(),
+                true,
+                StorageFlags::optional_default_as_cow(),
+                None,
+                platform_version,
+                None,
+            )
+            .expect("expected to update document with serialization");
+
+        assert!(fee_result.processing_fee > 0);
+    }
+
+    #[test]
+    fn test_update_document_for_contract_id() {
+        let (drive, contract) = setup_dashpay("update-by-id", true);
+
+        let platform_version = PlatformVersion::latest();
+
+        let document_type = contract
+            .document_type_for_name("profile")
+            .expect("profile document exists");
+
+        let owner_id: Identifier = random::<[u8; 32]>().into();
+
+        let mut document = document_type
+            .create_document_from_data(
+                platform_value!({"displayName": "Alice"}),
+                owner_id,
+                random(),
+                random(),
+                random(),
+                platform_version,
+            )
+            .expect("should create document");
+
+        // First create the document
+        let info = DocumentAndContractInfo {
+            owned_document_info: OwnedDocumentInfo {
+                document_info: DocumentRefInfo((
+                    &document,
+                    StorageFlags::optional_default_as_cow(),
+                )),
+                owner_id: Some(owner_id.to_buffer()),
+            },
+            contract: &contract,
+            document_type,
+        };
+
+        drive
+            .add_document_for_contract(
+                info,
+                true,
+                BlockInfo::default(),
+                true,
+                None,
+                platform_version,
+                None,
+            )
+            .expect("should create profile");
+
+        // Update document using contract_id API
+        document.set("displayName", "Bob".into());
+        document.increment_revision().unwrap();
+
+        let serialized = DocumentPlatformConversionMethodsV0::serialize(
+            &document,
+            document_type,
+            &contract,
+            platform_version,
+        )
+        .expect("expected to serialize");
+
+        let fee_result = drive
+            .update_document_for_contract_id(
+                &serialized,
+                contract.id().to_buffer(),
+                "profile",
+                Some(owner_id.to_buffer()),
+                BlockInfo::default(),
+                true,
+                StorageFlags::optional_default_as_cow(),
+                None,
+                platform_version,
+                None,
+            )
+            .expect("expected to update document for contract id");
+
+        assert!(fee_result.processing_fee > 0);
     }
 }


### PR DESCRIPTION
## Issue being fixed or feature implemented

Improve test coverage for the `packages/rs-drive/src/drive/document/` module by targeting code paths with 0% coverage from drive-only tests.

## What was done?

Added 17 new unit tests targeting genuinely uncovered code paths in the drive document module. Coverage analysis was performed using `cargo llvm-cov` to identify specific files and functions with the lowest coverage.

**Delete module (3 tests):**
- `test_delete_document_for_contract_id` - exercises the `delete_document_for_contract_id` public API (was 0% covered)
- `test_delete_document_for_contract_id_estimated_costs` - exercises the estimation (apply=false) path
- `test_delete_document_keeps_history_returns_error` - covers the `InvalidDeletionOfDocumentThatKeepsHistory` error branch

**Insert module (4 tests):**
- `test_add_document_by_contract_id` - exercises the `add_document` public API (was 0% covered)
- `test_add_document_with_history` - covers the `documents_keep_history()` branch in `add_document_to_primary_storage` (was ~50% covered)
- `test_add_document_with_history_estimated_costs` - covers the estimation path for history-keeping documents
- `test_add_document_for_contract_with_non_unique_batch` - covers the `document_is_unique_for_document_type_in_batch=false` branch

**Query module (6 tests):**
- `test_query_documents_dry_run` - covers the dry_run early return path
- `test_query_documents_with_epoch_fee` - covers the epoch fee calculation branch
- `test_query_documents_without_epoch_zero_cost` - covers the no-epoch zero-cost path
- `test_query_documents_with_flags` - exercises `query_documents_with_flags` (was 0% covered)
- `test_query_documents_with_flags_dry_run` - dry_run path for flags query
- `test_query_documents_with_flags_with_epoch` - epoch fee calculation for flags query

**Update module (4 tests):**
- `test_add_update_multiple_documents_operations` - exercises batch update operations (was 0% covered)
- `test_add_update_multiple_documents_operations_empty` - covers empty documents guard
- `test_update_document_for_contract_immutable_error` - covers `UpdatingReadOnlyImmutableDocument` error
- `test_update_document_with_serialization_for_contract` - exercises the serialization update API (was 0% covered)
- `test_update_document_for_contract_id` - exercises the contract_id update API (was 0% covered)

## How Has This Been Tested?

All 17 new tests pass:
```
cargo test -p drive --features server
```

Full drive test suite passes with all existing tests (1374+ unit tests, 30 query tests, 3 history query tests).

## Breaking Changes

None. This PR adds tests only.

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [x] I have made corresponding changes to the documentation if needed