### PR TITLE
test(drive): address review comments on document test coverage

### DIFF
--- a/packages/rs-drive-abci/src/abci/handler/extend_vote.rs
+++ b/packages/rs-drive-abci/src/abci/handler/extend_vote.rs
@@ -51,3 +51,176 @@ where
 
     Ok(proto::ResponseExtendVote { vote_extensions })
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::abci::app::FullAbciApplication;
+    use crate::execution::types::block_execution_context::v0::BlockExecutionContextV0;
+    use crate::execution::types::block_execution_context::BlockExecutionContext;
+    use crate::execution::types::block_state_info::v0::BlockStateInfoV0;
+    use crate::execution::types::block_state_info::BlockStateInfo;
+    use crate::platform_types::epoch_info::v0::EpochInfoV0;
+    use crate::platform_types::epoch_info::EpochInfo;
+    use crate::platform_types::platform_state::PlatformState;
+    use crate::platform_types::withdrawal::unsigned_withdrawal_txs::v0::UnsignedWithdrawalTxs;
+    use crate::rpc::core::MockCoreRPCLike;
+    use crate::test::helpers::setup::TestPlatformBuilder;
+    use dpp::version::PlatformVersion;
+    use std::collections::BTreeMap;
+
+    fn make_test_block_execution_context(
+        height: u64,
+        round: u32,
+        block_hash: Option<[u8; 32]>,
+        platform: &crate::platform_types::platform::Platform<MockCoreRPCLike>,
+    ) -> BlockExecutionContext {
+        let platform_version = PlatformVersion::latest();
+        BlockExecutionContext::V0(BlockExecutionContextV0 {
+            block_state_info: BlockStateInfo::V0(BlockStateInfoV0 {
+                height,
+                round,
+                block_time_ms: 1_000_000,
+                previous_block_time_ms: None,
+                proposer_pro_tx_hash: [0u8; 32],
+                core_chain_locked_height: 1,
+                block_hash,
+                app_hash: None,
+            }),
+            epoch_info: EpochInfo::V0(EpochInfoV0 {
+                current_epoch_index: 0,
+                previous_epoch_index: None,
+                is_epoch_change: false,
+            }),
+            unsigned_withdrawal_transactions: UnsignedWithdrawalTxs::default(),
+            block_address_balance_changes: BTreeMap::new(),
+            block_platform_state: PlatformState::default_with_protocol_versions(
+                platform_version.protocol_version,
+                platform_version.protocol_version,
+                &platform.config,
+            )
+            .expect("should create default platform state"),
+            proposer_results: None,
+        })
+    }
+
+    #[test]
+    fn extend_vote_fails_when_no_block_execution_context() {
+        let platform = TestPlatformBuilder::new()
+            .with_latest_protocol_version()
+            .build_with_mock_rpc();
+
+        let app = FullAbciApplication::<MockCoreRPCLike>::new(&platform.platform);
+
+        let request = proto::RequestExtendVote {
+            hash: vec![0u8; 32],
+            height: 10,
+            round: 0,
+        };
+
+        let result = extend_vote::<_, MockCoreRPCLike>(&app, request);
+        assert!(result.is_err());
+        let err_string = result.unwrap_err().to_string();
+        assert!(
+            err_string.contains("block execution context must be set"),
+            "Expected block execution context error, got: {}",
+            err_string
+        );
+    }
+
+    #[test]
+    fn extend_vote_fails_when_block_hash_does_not_match() {
+        let platform = TestPlatformBuilder::new()
+            .with_latest_protocol_version()
+            .build_with_mock_rpc();
+
+        let app = FullAbciApplication::<MockCoreRPCLike>::new(&platform.platform);
+
+        // Set block context at height 10, round 0 with specific hash
+        let context =
+            make_test_block_execution_context(10, 0, Some([0xAA; 32]), &platform.platform);
+        app.block_execution_context
+            .write()
+            .unwrap()
+            .replace(context);
+
+        // Request with a different hash
+        let request = proto::RequestExtendVote {
+            hash: vec![0xBB; 32],
+            height: 10,
+            round: 0,
+        };
+
+        let result = extend_vote::<_, MockCoreRPCLike>(&app, request);
+        assert!(result.is_err());
+        let err_string = result.unwrap_err().to_string();
+        assert!(
+            err_string.contains("request does not match current block"),
+            "Expected wrong block error, got: {}",
+            err_string
+        );
+    }
+
+    #[test]
+    fn extend_vote_fails_when_height_does_not_match() {
+        let platform = TestPlatformBuilder::new()
+            .with_latest_protocol_version()
+            .build_with_mock_rpc();
+
+        let app = FullAbciApplication::<MockCoreRPCLike>::new(&platform.platform);
+
+        // Set block context at height 10, round 0
+        let context =
+            make_test_block_execution_context(10, 0, Some([0xAA; 32]), &platform.platform);
+        app.block_execution_context
+            .write()
+            .unwrap()
+            .replace(context);
+
+        // Request for a different height
+        let request = proto::RequestExtendVote {
+            hash: vec![0xAA; 32],
+            height: 20,
+            round: 0,
+        };
+
+        let result = extend_vote::<_, MockCoreRPCLike>(&app, request);
+        assert!(result.is_err());
+        let err_string = result.unwrap_err().to_string();
+        assert!(
+            err_string.contains("request does not match current block"),
+            "Expected wrong block error, got: {}",
+            err_string
+        );
+    }
+
+    #[test]
+    fn extend_vote_succeeds_with_matching_block_and_empty_withdrawals() {
+        let platform = TestPlatformBuilder::new()
+            .with_latest_protocol_version()
+            .build_with_mock_rpc();
+
+        let app = FullAbciApplication::<MockCoreRPCLike>::new(&platform.platform);
+
+        // Set block context at height 10, round 0 with specific hash
+        let context =
+            make_test_block_execution_context(10, 0, Some([0xAA; 32]), &platform.platform);
+        app.block_execution_context
+            .write()
+            .unwrap()
+            .replace(context);
+
+        // Request with matching hash, height, round
+        let request = proto::RequestExtendVote {
+            hash: vec![0xAA; 32],
+            height: 10,
+            round: 0,
+        };
+
+        let response =
+            extend_vote::<_, MockCoreRPCLike>(&app, request).expect("extend_vote should succeed");
+
+        // No withdrawal transactions, so no vote extensions
+        assert!(response.vote_extensions.is_empty());
+    }
+}

--- a/packages/rs-drive-abci/src/abci/handler/finalize_block.rs
+++ b/packages/rs-drive-abci/src/abci/handler/finalize_block.rs
@@ -103,3 +103,65 @@ where
 
     Ok(proto::ResponseFinalizeBlock { retain_height: 0 })
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::abci::app::{FullAbciApplication, TransactionalApplication};
+    use crate::rpc::core::MockCoreRPCLike;
+    use crate::test::helpers::setup::TestPlatformBuilder;
+
+    #[test]
+    fn finalize_block_fails_when_no_transaction() {
+        let platform = TestPlatformBuilder::new()
+            .with_latest_protocol_version()
+            .build_with_mock_rpc();
+
+        let app = FullAbciApplication::<MockCoreRPCLike>::new(&platform.platform);
+
+        // No transaction started, no block execution context
+        let request = proto::RequestFinalizeBlock {
+            hash: vec![0u8; 32],
+            height: 1,
+            round: 0,
+            ..Default::default()
+        };
+
+        let result = finalize_block::<_, MockCoreRPCLike>(&app, request);
+        assert!(
+            matches!(
+                result,
+                Err(Error::Execution(ExecutionError::NotInTransaction(_)))
+            ),
+            "Expected NotInTransaction error, got: {result:?}"
+        );
+    }
+
+    #[test]
+    fn finalize_block_fails_when_no_block_execution_context() {
+        let platform = TestPlatformBuilder::new()
+            .with_latest_protocol_version()
+            .build_with_mock_rpc();
+
+        let app = FullAbciApplication::<MockCoreRPCLike>::new(&platform.platform);
+
+        // Start a transaction but do not set block execution context
+        app.start_transaction();
+
+        let request = proto::RequestFinalizeBlock {
+            hash: vec![0u8; 32],
+            height: 1,
+            round: 0,
+            ..Default::default()
+        };
+
+        let result = finalize_block::<_, MockCoreRPCLike>(&app, request);
+        assert!(
+            matches!(
+                result,
+                Err(Error::Execution(ExecutionError::CorruptedCodeExecution(_)))
+            ),
+            "Expected CorruptedCodeExecution error, got: {result:?}"
+        );
+    }
+}

--- a/packages/rs-drive-abci/src/abci/handler/info.rs
+++ b/packages/rs-drive-abci/src/abci/handler/info.rs
@@ -95,3 +95,66 @@ where
 
     Ok(response)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::abci::app::FullAbciApplication;
+    use crate::rpc::core::MockCoreRPCLike;
+    use crate::test::helpers::setup::TestPlatformBuilder;
+
+    #[test]
+    fn info_abci_version_mismatch_returns_error() {
+        let platform = TestPlatformBuilder::new()
+            .with_latest_protocol_version()
+            .build_with_mock_rpc();
+
+        let app = FullAbciApplication::new(&platform.platform);
+
+        // Use a valid semver but with a much higher minor version to guarantee mismatch.
+        // The check_version function panics on non-semver strings, so we must
+        // provide a valid semver that does not satisfy the compatibility requirement.
+        let request = proto::RequestInfo {
+            version: "test".to_string(),
+            block_version: 0,
+            p2p_version: 0,
+            abci_version: "999.999.999".to_string(),
+        };
+
+        let result = info::<_, MockCoreRPCLike>(&app, request);
+
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        let err_string = err.to_string();
+        assert!(
+            err_string.contains("ABCI version mismatch"),
+            "Expected ABCI version mismatch error, got: {}",
+            err_string
+        );
+    }
+
+    #[test]
+    fn info_successful_handshake_returns_response() {
+        let platform = TestPlatformBuilder::new()
+            .with_latest_protocol_version()
+            .build_with_mock_rpc();
+
+        let app = FullAbciApplication::new(&platform.platform);
+
+        let request = proto::RequestInfo {
+            version: "test".to_string(),
+            block_version: 0,
+            p2p_version: 0,
+            abci_version: tenderdash_abci::proto::ABCI_VERSION.to_string(),
+        };
+
+        let response = info::<_, MockCoreRPCLike>(&app, request).expect("info should succeed");
+
+        assert_eq!(response.last_block_height, 0);
+        assert_eq!(response.version, env!("CARGO_PKG_VERSION"));
+        assert_eq!(
+            response.app_version,
+            DESIRED_PLATFORM_VERSION.protocol_version as u64
+        );
+    }
+}

--- a/packages/rs-drive-abci/src/abci/handler/init_chain.rs
+++ b/packages/rs-drive-abci/src/abci/handler/init_chain.rs
@@ -40,3 +40,88 @@ where
 
     Ok(response)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::abci::app::FullAbciApplication;
+    use crate::execution::types::block_execution_context::v0::BlockExecutionContextV0;
+    use crate::execution::types::block_execution_context::BlockExecutionContext;
+    use crate::execution::types::block_state_info::v0::BlockStateInfoV0;
+    use crate::execution::types::block_state_info::BlockStateInfo;
+    use crate::platform_types::epoch_info::v0::EpochInfoV0;
+    use crate::platform_types::epoch_info::EpochInfo;
+    use crate::platform_types::platform_state::PlatformState;
+    use crate::platform_types::withdrawal::unsigned_withdrawal_txs::v0::UnsignedWithdrawalTxs;
+    use crate::rpc::core::MockCoreRPCLike;
+    use crate::test::helpers::setup::TestPlatformBuilder;
+    use dpp::version::PlatformVersion;
+    use std::collections::BTreeMap;
+
+    #[test]
+    fn init_chain_drops_existing_block_execution_context() {
+        let platform = TestPlatformBuilder::new()
+            .with_latest_protocol_version()
+            .build_with_mock_rpc();
+
+        let app = FullAbciApplication::<MockCoreRPCLike>::new(&platform.platform);
+        let platform_version = PlatformVersion::latest();
+
+        // Place an existing block execution context to exercise the "drop" branch
+        let existing_context = BlockExecutionContext::V0(BlockExecutionContextV0 {
+            block_state_info: BlockStateInfo::V0(BlockStateInfoV0 {
+                height: 5,
+                round: 0,
+                block_time_ms: 1_000_000,
+                previous_block_time_ms: None,
+                proposer_pro_tx_hash: [0u8; 32],
+                core_chain_locked_height: 1,
+                block_hash: None,
+                app_hash: None,
+            }),
+            epoch_info: EpochInfo::V0(EpochInfoV0 {
+                current_epoch_index: 0,
+                previous_epoch_index: None,
+                is_epoch_change: false,
+            }),
+            unsigned_withdrawal_transactions: UnsignedWithdrawalTxs::default(),
+            block_address_balance_changes: BTreeMap::new(),
+            block_platform_state: PlatformState::default_with_protocol_versions(
+                platform_version.protocol_version,
+                platform_version.protocol_version,
+                &platform.config,
+            )
+            .expect("should create default platform state"),
+            proposer_results: None,
+        });
+
+        app.block_execution_context
+            .write()
+            .unwrap()
+            .replace(existing_context);
+
+        // The block execution context is now present, init_chain should drop it
+        // and then attempt to initialize the chain
+        // We are not providing a valid genesis request, so this will likely fail
+        // after dropping the context, but that still exercises the drop path
+
+        let request = proto::RequestInitChain {
+            time: Some(tenderdash_abci::proto::google::protobuf::Timestamp {
+                seconds: 1700000000,
+                nanos: 0,
+            }),
+            chain_id: "test-chain".to_string(),
+            ..Default::default()
+        };
+
+        // The result will fail because init_chain requires valid genesis data,
+        // but the important thing is that the drop path was exercised.
+        // We just verify that block_execution_context was cleared.
+        let _ = init_chain::<_, MockCoreRPCLike>(&app, request);
+
+        assert!(
+            app.block_execution_context.read().unwrap().is_none(),
+            "expected init_chain to clear existing block execution context"
+        );
+    }
+}

--- a/packages/rs-drive-abci/src/abci/handler/verify_vote_extension.rs
+++ b/packages/rs-drive-abci/src/abci/handler/verify_vote_extension.rs
@@ -94,3 +94,208 @@ where
         status: VerifyStatus::Accept.into(),
     })
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::abci::app::FullAbciApplication;
+    use crate::execution::types::block_execution_context::v0::BlockExecutionContextV0;
+    use crate::execution::types::block_execution_context::BlockExecutionContext;
+    use crate::execution::types::block_state_info::v0::BlockStateInfoV0;
+    use crate::execution::types::block_state_info::BlockStateInfo;
+    use crate::platform_types::epoch_info::v0::EpochInfoV0;
+    use crate::platform_types::epoch_info::EpochInfo;
+    use crate::platform_types::platform_state::PlatformState;
+    use crate::platform_types::withdrawal::unsigned_withdrawal_txs::v0::UnsignedWithdrawalTxs;
+    use crate::rpc::core::MockCoreRPCLike;
+    use crate::test::helpers::setup::TestPlatformBuilder;
+    use dpp::version::PlatformVersion;
+    use std::collections::BTreeMap;
+
+    fn make_test_block_execution_context(
+        height: u64,
+        round: u32,
+        block_hash: Option<[u8; 32]>,
+        platform: &crate::platform_types::platform::Platform<MockCoreRPCLike>,
+    ) -> BlockExecutionContext {
+        let platform_version = PlatformVersion::latest();
+        BlockExecutionContext::V0(BlockExecutionContextV0 {
+            block_state_info: BlockStateInfo::V0(BlockStateInfoV0 {
+                height,
+                round,
+                block_time_ms: 1_000_000,
+                previous_block_time_ms: None,
+                proposer_pro_tx_hash: [0u8; 32],
+                core_chain_locked_height: 1,
+                block_hash,
+                app_hash: None,
+            }),
+            epoch_info: EpochInfo::V0(EpochInfoV0 {
+                current_epoch_index: 0,
+                previous_epoch_index: None,
+                is_epoch_change: false,
+            }),
+            unsigned_withdrawal_transactions: UnsignedWithdrawalTxs::default(),
+            block_address_balance_changes: BTreeMap::new(),
+            block_platform_state: PlatformState::default_with_protocol_versions(
+                platform_version.protocol_version,
+                platform_version.protocol_version,
+                &platform.config,
+            )
+            .expect("should create default platform state"),
+            proposer_results: None,
+        })
+    }
+
+    #[test]
+    fn verify_vote_extension_rejects_when_no_block_execution_context() {
+        let platform = TestPlatformBuilder::new()
+            .with_latest_protocol_version()
+            .build_with_mock_rpc();
+
+        let app = FullAbciApplication::<MockCoreRPCLike>::new(&platform.platform);
+
+        // No block execution context is set
+        let request = proto::RequestVerifyVoteExtension {
+            hash: vec![0u8; 32],
+            validator_pro_tx_hash: vec![0u8; 32],
+            height: 10,
+            round: 0,
+            vote_extensions: vec![],
+        };
+
+        let response = verify_vote_extension::<_, MockCoreRPCLike>(&app, request)
+            .expect("should return Ok with Reject status");
+
+        assert_eq!(response.status, VerifyStatus::Reject as i32);
+    }
+
+    #[test]
+    fn verify_vote_extension_rejects_when_height_mismatch() {
+        let platform = TestPlatformBuilder::new()
+            .with_latest_protocol_version()
+            .build_with_mock_rpc();
+
+        let app = FullAbciApplication::<MockCoreRPCLike>::new(&platform.platform);
+
+        // Set block execution context at height 10
+        let context =
+            make_test_block_execution_context(10, 0, Some([0xAA; 32]), &platform.platform);
+        app.block_execution_context
+            .write()
+            .unwrap()
+            .replace(context);
+
+        // Request verification for a different height (20)
+        let request = proto::RequestVerifyVoteExtension {
+            hash: vec![0u8; 32],
+            validator_pro_tx_hash: vec![0u8; 32],
+            height: 20,
+            round: 0,
+            vote_extensions: vec![],
+        };
+
+        let response = verify_vote_extension::<_, MockCoreRPCLike>(&app, request)
+            .expect("should return Ok with Reject status");
+
+        assert_eq!(response.status, VerifyStatus::Reject as i32);
+    }
+
+    #[test]
+    fn verify_vote_extension_accepts_matching_empty_withdrawals() {
+        let platform = TestPlatformBuilder::new()
+            .with_latest_protocol_version()
+            .build_with_mock_rpc();
+
+        let app = FullAbciApplication::<MockCoreRPCLike>::new(&platform.platform);
+
+        // Set block execution context at height 10, with empty withdrawal transactions
+        let context =
+            make_test_block_execution_context(10, 0, Some([0xAA; 32]), &platform.platform);
+        app.block_execution_context
+            .write()
+            .unwrap()
+            .replace(context);
+
+        // Request with matching empty vote extensions
+        let request = proto::RequestVerifyVoteExtension {
+            hash: vec![0u8; 32],
+            validator_pro_tx_hash: vec![0u8; 32],
+            height: 10,
+            round: 0,
+            vote_extensions: vec![],
+        };
+
+        let response = verify_vote_extension::<_, MockCoreRPCLike>(&app, request)
+            .expect("should return Ok with Accept status");
+
+        assert_eq!(response.status, VerifyStatus::Accept as i32);
+    }
+
+    #[test]
+    fn verify_vote_extension_rejects_mismatched_withdrawals() {
+        let platform = TestPlatformBuilder::new()
+            .with_latest_protocol_version()
+            .build_with_mock_rpc();
+
+        let app = FullAbciApplication::<MockCoreRPCLike>::new(&platform.platform);
+
+        // Set block execution context at height 10 with empty withdrawal transactions
+        let context =
+            make_test_block_execution_context(10, 0, Some([0xAA; 32]), &platform.platform);
+        app.block_execution_context
+            .write()
+            .unwrap()
+            .replace(context);
+
+        // Request with non-empty vote extensions (mismatch)
+        let request = proto::RequestVerifyVoteExtension {
+            hash: vec![0u8; 32],
+            validator_pro_tx_hash: vec![0u8; 32],
+            height: 10,
+            round: 0,
+            vote_extensions: vec![proto::ExtendVoteExtension {
+                r#type: 0,
+                extension: vec![1, 2, 3],
+                sign_request_id: None,
+            }],
+        };
+
+        let response = verify_vote_extension::<_, MockCoreRPCLike>(&app, request)
+            .expect("should return Ok with Reject status");
+
+        assert_eq!(response.status, VerifyStatus::Reject as i32);
+    }
+
+    #[test]
+    fn verify_vote_extension_accepts_different_round_same_height() {
+        let platform = TestPlatformBuilder::new()
+            .with_latest_protocol_version()
+            .build_with_mock_rpc();
+
+        let app = FullAbciApplication::<MockCoreRPCLike>::new(&platform.platform);
+
+        // Set block execution context at height 10, round 1
+        let context =
+            make_test_block_execution_context(10, 1, Some([0xAA; 32]), &platform.platform);
+        app.block_execution_context
+            .write()
+            .unwrap()
+            .replace(context);
+
+        // Request for same height but different round (round 5)
+        // This should still be accepted since only height needs to match
+        let request = proto::RequestVerifyVoteExtension {
+            hash: vec![0u8; 32],
+            validator_pro_tx_hash: vec![0u8; 32],
+            height: 10,
+            round: 5,
+            vote_extensions: vec![],
+        };
+
+        let response = verify_vote_extension::<_, MockCoreRPCLike>(&app, request)
+            .expect("should return Ok with Accept status");
+
+        assert_eq!(response.status, VerifyStatus::Accept as i32);
+    }
+}

--- a/packages/rs-drive/src/drive/contract/mod.rs
+++ b/packages/rs-drive/src/drive/contract/mod.rs
@@ -36,15 +36,20 @@ pub const MAX_CONTRACT_HISTORY_FETCH_LIMIT: u16 = 10;
 #[cfg(test)]
 mod tests {
     use dpp::block::block_info::BlockInfo;
+    use dpp::block::epoch::Epoch;
+    use dpp::data_contract::config::v0::DataContractConfigSettersV0;
     use rand::prelude::StdRng;
     use rand::{random, SeedableRng};
     use std::borrow::Cow;
     use std::option::Option::None;
 
+    use crate::drive::contract::paths::contract_root_path_vec;
     use crate::drive::Drive;
+    use crate::error::drive::DriveError;
+    use crate::error::Error;
     use crate::util::object_size_info::{DocumentAndContractInfo, DocumentInfo, OwnedDocumentInfo};
     use crate::util::storage_flags::StorageFlags;
-    use dpp::data_contract::accessors::v0::DataContractV0Getters;
+    use dpp::data_contract::accessors::v0::{DataContractV0Getters, DataContractV0Setters};
     use dpp::data_contract::document_type::random_document::CreateRandomDocument;
     use dpp::data_contract::schema::DataContractSchemaMethodsV0;
     use dpp::data_contract::DataContract;
@@ -169,6 +174,35 @@ mod tests {
             .apply_contract(
                 &contract,
                 BlockInfo::default(),
+                true,
+                StorageFlags::optional_default_as_cow(),
+                None,
+                platform_version,
+            )
+            .expect("expected to apply contract successfully");
+
+        (drive, contract)
+    }
+
+    /// Sets up a drive instance with a history-enabled contract applied at time_ms=1000.
+    pub(in crate::drive::contract) fn setup_history_contract() -> (Drive, DataContract) {
+        let drive = setup_drive_with_initial_state_structure(None);
+        let platform_version = PlatformVersion::latest();
+
+        let contract_path =
+            "tests/supporting_files/contract/references/references_with_contract_history.json";
+        let contract = json_document_to_contract(contract_path, false, platform_version)
+            .expect("expected to get contract");
+
+        drive
+            .apply_contract(
+                &contract,
+                BlockInfo {
+                    time_ms: 1000,
+                    height: 100,
+                    core_height: 10,
+                    epoch: Default::default(),
+                },
                 true,
                 StorageFlags::optional_default_as_cow(),
                 None,
@@ -351,7 +385,13 @@ mod tests {
             .fetch_identity_keys::<KeyIDIdentityPublicKeyPairVec>(request, None, platform_version)
             .expect("expected keys");
         assert_eq!(identity_keys.len(), 1);
-        assert_eq!(&identity_keys.first().unwrap().1, &encryption_key);
+        assert_eq!(
+            &identity_keys
+                .first()
+                .expect("expected at least one identity key")
+                .1,
+            &encryption_key
+        );
     }
 
     #[test]
@@ -414,7 +454,13 @@ mod tests {
             .fetch_identity_keys::<KeyIDIdentityPublicKeyPairVec>(request, None, platform_version)
             .expect("expected keys");
         assert_eq!(identity_keys.len(), 1);
-        assert_eq!(&identity_keys.first().unwrap().1, &encryption_key);
+        assert_eq!(
+            &identity_keys
+                .first()
+                .expect("expected at least one identity key")
+                .1,
+            &encryption_key
+        );
     }
 
     #[test]
@@ -427,7 +473,7 @@ mod tests {
         // let's construct the grovedb structure for the dashpay data contract
         let contract = json_document_to_contract(contract_path, false, platform_version)
             .expect("expected to get cbor document");
-        drive
+        let fee = drive
             .apply_contract(
                 &contract,
                 BlockInfo::default(),
@@ -437,6 +483,12 @@ mod tests {
                 platform_version,
             )
             .expect("expected to apply contract successfully");
+
+        // Estimation (apply=false) should produce non-zero processing fee
+        assert!(
+            fee.processing_fee > 0,
+            "estimation should produce non-zero processing fee"
+        );
     }
 
     #[test]
@@ -450,7 +502,7 @@ mod tests {
         // let's construct the grovedb structure for the dashpay data contract
         let contract = json_document_to_contract(contract_path, false, platform_version)
             .expect("expected to get contract");
-        drive
+        let fee = drive
             .apply_contract(
                 &contract,
                 BlockInfo::default(),
@@ -460,6 +512,12 @@ mod tests {
                 platform_version,
             )
             .expect("expected to apply contract successfully");
+
+        // Estimation (apply=false) for a history contract should produce non-zero processing fee
+        assert!(
+            fee.processing_fee > 0,
+            "history estimation should produce non-zero processing fee"
+        );
     }
 
     #[test]
@@ -496,5 +554,1188 @@ mod tests {
                 None,
             )
             .expect("expected to apply contract successfully");
+    }
+
+    #[test]
+    fn test_get_cached_contract_returns_none_when_not_cached() {
+        let drive = setup_drive_with_initial_state_structure(None);
+        let platform_version = PlatformVersion::latest();
+
+        let result = drive
+            .get_cached_contract_with_fetch_info([0u8; 32], None, &platform_version.drive)
+            .expect("should not error");
+
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn test_get_cached_contract_returns_some_after_fetch() {
+        let (drive, contract) = setup_reference_contract();
+        let platform_version = PlatformVersion::latest();
+
+        // First fetch to populate cache
+        let fetched = drive
+            .get_contract_with_fetch_info(contract.id().to_buffer(), true, None, platform_version)
+            .expect("should fetch contract");
+        assert!(fetched.is_some());
+
+        // Now check cache returns the contract
+        let cached = drive
+            .get_cached_contract_with_fetch_info(
+                contract.id().to_buffer(),
+                None,
+                &platform_version.drive,
+            )
+            .expect("should not error");
+        assert!(cached.is_some());
+        assert_eq!(
+            cached
+                .expect("cached contract should be present")
+                .contract
+                .id(),
+            contract.id()
+        );
+    }
+
+    #[test]
+    fn test_get_cached_contract_in_transaction_context() {
+        let (drive, contract) = setup_reference_contract();
+        let platform_version = PlatformVersion::latest();
+
+        // Populate the non-tx cache by fetching the contract outside any transaction
+        let fetched = drive
+            .get_contract_with_fetch_info(contract.id().to_buffer(), true, None, platform_version)
+            .expect("should fetch contract");
+        assert!(fetched.is_some(), "contract should be fetchable");
+        assert_eq!(
+            fetched
+                .expect("fetched contract should exist")
+                .contract
+                .version(),
+            1
+        );
+
+        let transaction = drive.grove.start_transaction();
+
+        // Insert a modified contract in transaction
+        let mut updated_contract = contract.clone();
+        updated_contract.increment_version();
+
+        drive
+            .update_contract(
+                &updated_contract,
+                BlockInfo::default(),
+                true,
+                Some(&transaction),
+                platform_version,
+                None,
+            )
+            .expect("should update contract");
+
+        // Cache in transaction context should have updated version
+        let cached_in_tx = drive
+            .get_cached_contract_with_fetch_info(
+                contract.id().to_buffer(),
+                Some(&transaction),
+                &platform_version.drive,
+            )
+            .expect("should not error");
+        assert!(cached_in_tx.is_some());
+        assert_eq!(
+            cached_in_tx
+                .expect("tx-cached contract should be present")
+                .contract
+                .version(),
+            2
+        );
+
+        // Non-transaction cache should still see the original version (v1)
+        let cached_outside_tx = drive
+            .get_cached_contract_with_fetch_info(
+                contract.id().to_buffer(),
+                None,
+                &platform_version.drive,
+            )
+            .expect("should not error");
+        assert!(
+            cached_outside_tx.is_some(),
+            "non-tx cache should still have the contract"
+        );
+        assert_eq!(
+            cached_outside_tx
+                .expect("non-tx cached contract should be present")
+                .contract
+                .version(),
+            1,
+            "non-tx cache should still see original v1 before commit"
+        );
+    }
+
+    #[test]
+    fn test_get_contracts_with_fetch_info_multiple() {
+        let drive = setup_drive_with_initial_state_structure(None);
+        let platform_version = PlatformVersion::latest();
+
+        // Create two contracts
+        let contract_path1 = "tests/supporting_files/contract/references/references.json";
+        let contract1 = json_document_to_contract(contract_path1, false, platform_version)
+            .expect("expected to get contract");
+        drive
+            .apply_contract(
+                &contract1,
+                BlockInfo::default(),
+                true,
+                StorageFlags::optional_default_as_cow(),
+                None,
+                platform_version,
+            )
+            .expect("expected to apply contract successfully");
+
+        let contract2 = get_dashpay_contract_fixture(None, 0, 1).data_contract_owned();
+        drive
+            .apply_contract(
+                &contract2,
+                BlockInfo::default(),
+                true,
+                StorageFlags::optional_default_as_cow(),
+                None,
+                platform_version,
+            )
+            .expect("expected to apply contract successfully");
+
+        let contract_ids = [contract1.id().to_buffer(), contract2.id().to_buffer()];
+        let result = drive
+            .get_contracts_with_fetch_info(&contract_ids, true, None, platform_version)
+            .expect("should get contracts");
+
+        assert_eq!(result.len(), 2);
+        assert!(result
+            .get(&contract1.id().to_buffer())
+            .expect("result should contain contract1 id")
+            .is_some());
+        assert!(result
+            .get(&contract2.id().to_buffer())
+            .expect("result should contain contract2 id")
+            .is_some());
+    }
+
+    #[test]
+    fn test_get_contracts_with_fetch_info_nonexistent() {
+        let drive = setup_drive_with_initial_state_structure(None);
+        let platform_version = PlatformVersion::latest();
+
+        let contract_ids = [[0u8; 32], [1u8; 32]];
+        let result = drive
+            .get_contracts_with_fetch_info(&contract_ids, true, None, platform_version)
+            .expect("should get contracts");
+
+        assert_eq!(result.len(), 2);
+        assert!(result
+            .get(&[0u8; 32])
+            .expect("result should contain zeroed id")
+            .is_none());
+        assert!(result
+            .get(&[1u8; 32])
+            .expect("result should contain ones id")
+            .is_none());
+    }
+
+    #[test]
+    fn test_prove_contracts_multiple() {
+        let drive = setup_drive_with_initial_state_structure(None);
+        let platform_version = PlatformVersion::latest();
+
+        let contract_path = "tests/supporting_files/contract/references/references.json";
+        let contract = json_document_to_contract(contract_path, false, platform_version)
+            .expect("expected to get contract");
+        drive
+            .apply_contract(
+                &contract,
+                BlockInfo::default(),
+                true,
+                StorageFlags::optional_default_as_cow(),
+                None,
+                platform_version,
+            )
+            .expect("expected to apply contract successfully");
+
+        let contract2 = get_dashpay_contract_fixture(None, 0, 1).data_contract_owned();
+        drive
+            .apply_contract(
+                &contract2,
+                BlockInfo::default(),
+                true,
+                StorageFlags::optional_default_as_cow(),
+                None,
+                platform_version,
+            )
+            .expect("expected to apply contract successfully");
+
+        let contract_ids = [contract.id().to_buffer(), contract2.id().to_buffer()];
+        let proof = drive
+            .prove_contracts(&contract_ids, None, platform_version)
+            .expect("should prove contracts");
+
+        // Verify proof against root hash using Drive::verify_contracts
+        let (_root_hash, verified) =
+            Drive::verify_contracts(&proof, false, &contract_ids, platform_version)
+                .expect("should verify contracts proof");
+        assert_eq!(verified.len(), 2);
+        assert!(
+            verified
+                .get(&contract.id().to_buffer())
+                .expect("should contain first contract id")
+                .is_some(),
+            "first contract should be present in proof"
+        );
+        assert!(
+            verified
+                .get(&contract2.id().to_buffer())
+                .expect("should contain second contract id")
+                .is_some(),
+            "second contract should be present in proof"
+        );
+    }
+
+    #[test]
+    fn test_prove_contracts_with_nonexistent() {
+        let drive = setup_drive_with_initial_state_structure(None);
+        let platform_version = PlatformVersion::latest();
+
+        // Prove a contract that does not exist
+        let contract_ids = [[42u8; 32]];
+        let proof = drive
+            .prove_contracts(&contract_ids, None, platform_version)
+            .expect("should prove contracts even if nonexistent");
+
+        // Verify proof proves non-existence using Drive::verify_contract
+        let (_root_hash, verified_contract) = Drive::verify_contract(
+            &proof,
+            Some(false),
+            false,
+            true,
+            [42u8; 32],
+            platform_version,
+        )
+        .expect("should verify absence proof for nonexistent contract");
+        assert!(
+            verified_contract.is_none(),
+            "nonexistent contract should verify as None"
+        );
+    }
+
+    #[test]
+    fn test_prove_single_contract() {
+        let (drive, contract) = setup_reference_contract();
+        let platform_version = PlatformVersion::latest();
+
+        let proof = drive
+            .prove_contract(contract.id().to_buffer(), None, platform_version)
+            .expect("should prove contract");
+
+        // Verify proof against root hash using Drive::verify_contract
+        let (_root_hash, verified_contract) = Drive::verify_contract(
+            &proof,
+            Some(false),
+            false,
+            false,
+            contract.id().to_buffer(),
+            platform_version,
+        )
+        .expect("should verify single contract proof");
+        assert!(verified_contract.is_some(), "contract should be in proof");
+        assert_eq!(
+            verified_contract
+                .expect("verified contract should exist")
+                .id(),
+            contract.id()
+        );
+    }
+
+    #[test]
+    fn test_prove_single_contract_nonexistent() {
+        let drive = setup_drive_with_initial_state_structure(None);
+        let platform_version = PlatformVersion::latest();
+
+        let proof = drive
+            .prove_contract([99u8; 32], None, platform_version)
+            .expect("should prove contract nonexistence");
+
+        // Verify proof proves non-existence using Drive::verify_contract
+        let (_root_hash, verified_contract) = Drive::verify_contract(
+            &proof,
+            Some(false),
+            false,
+            false,
+            [99u8; 32],
+            platform_version,
+        )
+        .expect("should verify nonexistent contract proof");
+        assert!(
+            verified_contract.is_none(),
+            "nonexistent contract should verify as None"
+        );
+    }
+
+    #[test]
+    fn test_prove_contract_history() {
+        use dpp::tests::fixtures::get_data_contract_fixture;
+
+        let drive = setup_drive_with_initial_state_structure(None);
+        let platform_version = PlatformVersion::latest();
+
+        let mut contract = get_data_contract_fixture(None, 0, platform_version.protocol_version)
+            .data_contract_owned();
+        contract.config_mut().set_keeps_history(true);
+        contract.config_mut().set_readonly(false);
+
+        drive
+            .apply_contract(
+                &contract,
+                BlockInfo {
+                    time_ms: 1000,
+                    height: 100,
+                    core_height: 10,
+                    epoch: Default::default(),
+                },
+                true,
+                None,
+                None,
+                platform_version,
+            )
+            .expect("expected to apply contract successfully");
+
+        let proof = drive
+            .prove_contract_history(
+                contract.id().to_buffer(),
+                None,
+                0,
+                Some(10),
+                None,
+                platform_version,
+            )
+            .expect("should prove contract history");
+
+        // Verify proof using Drive::verify_contract_history
+        let (_root_hash, verified_history) = Drive::verify_contract_history(
+            &proof,
+            contract.id().to_buffer(),
+            0,
+            Some(10),
+            None,
+            platform_version,
+        )
+        .expect("should verify contract history proof");
+        let history = verified_history.expect("history should be Some");
+        assert!(
+            history.contains_key(&1000),
+            "history should contain entry at time 1000"
+        );
+    }
+
+    #[test]
+    fn test_update_contract_errors_on_readonly() {
+        let drive = setup_drive_with_initial_state_structure(None);
+        let platform_version = PlatformVersion::latest();
+
+        // Create a mutable contract first, then make it readonly before inserting
+        let mut contract = get_dashpay_contract_fixture(None, 0, 1).data_contract_owned();
+        contract.config_mut().set_readonly(true);
+
+        drive
+            .apply_contract(
+                &contract,
+                BlockInfo::default(),
+                true,
+                StorageFlags::optional_default_as_cow(),
+                None,
+                platform_version,
+            )
+            .expect("expected to apply contract successfully");
+
+        // Attempting to update a readonly contract should fail
+        let result = drive.update_contract(
+            &contract,
+            BlockInfo::default(),
+            true,
+            None,
+            platform_version,
+            None,
+        );
+
+        assert!(
+            matches!(
+                result,
+                Err(Error::Drive(DriveError::UpdatingReadOnlyImmutableContract(
+                    _
+                )))
+            ),
+            "Expected UpdatingReadOnlyImmutableContract error, got: {:?}",
+            result
+        );
+    }
+
+    #[test]
+    fn test_update_contract_with_new_document_type() {
+        let (drive, mut contract) = setup_reference_contract();
+        let platform_version = PlatformVersion::latest();
+
+        // Add a new document type
+        let new_schema = platform_value!({
+            "type": "object",
+            "properties": {
+                "name": {
+                    "type": "string",
+                    "position": 0
+                }
+            },
+            "additionalProperties": false,
+        });
+
+        contract
+            .set_document_schema(
+                "brand_new_type",
+                new_schema,
+                true,
+                &mut vec![],
+                platform_version,
+            )
+            .expect("should set document schema");
+
+        contract.increment_version();
+
+        drive
+            .update_contract(
+                &contract,
+                BlockInfo::default(),
+                true,
+                None,
+                platform_version,
+                None,
+            )
+            .expect("should update contract with new document type");
+
+        // Verify the contract can be fetched with the new type
+        let fetched = drive
+            .get_contract_with_fetch_info(contract.id().to_buffer(), true, None, platform_version)
+            .expect("should fetch updated contract")
+            .expect("contract should exist");
+
+        assert!(fetched
+            .contract
+            .document_type_for_name("brand_new_type")
+            .is_ok());
+    }
+
+    #[test]
+    fn test_fetch_contract_with_epoch_calculates_fee() {
+        let (drive, contract) = setup_reference_contract();
+        let platform_version = PlatformVersion::latest();
+
+        let epoch = Epoch::new(0).expect("should create epoch");
+        let result = drive
+            .fetch_contract(
+                contract.id().to_buffer(),
+                Some(&epoch),
+                None,
+                None,
+                platform_version,
+            )
+            .unwrap_add_cost(&mut Default::default())
+            .expect("should fetch contract");
+
+        let fetch_info = result.expect("should have contract");
+        assert!(
+            fetch_info.fee.is_some(),
+            "should have fee when epoch is provided"
+        );
+    }
+
+    #[test]
+    fn test_fetch_contract_without_epoch_no_fee() {
+        let (drive, contract) = setup_reference_contract();
+        let platform_version = PlatformVersion::latest();
+
+        let result = drive
+            .fetch_contract(
+                contract.id().to_buffer(),
+                None,
+                None,
+                None,
+                platform_version,
+            )
+            .unwrap_add_cost(&mut Default::default())
+            .expect("should fetch contract");
+
+        let fetch_info = result.expect("should have contract");
+        assert!(
+            fetch_info.fee.is_none(),
+            "should have no fee when epoch is not provided"
+        );
+    }
+
+    #[test]
+    fn test_fetch_nonexistent_contract_returns_none() {
+        let drive = setup_drive_with_initial_state_structure(None);
+        let platform_version = PlatformVersion::latest();
+
+        let result = drive
+            .fetch_contract([0u8; 32], None, None, None, platform_version)
+            .unwrap_add_cost(&mut Default::default())
+            .expect("should not error");
+
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn test_fetch_contract_and_add_operations_with_epoch() {
+        let (drive, contract) = setup_reference_contract();
+        let platform_version = PlatformVersion::latest();
+
+        let epoch = Epoch::new(0).expect("should create epoch");
+        let mut operations = vec![];
+        let result = drive
+            .fetch_contract_and_add_operations(
+                contract.id().to_buffer(),
+                Some(&epoch),
+                None,
+                &mut operations,
+                platform_version,
+            )
+            .expect("should fetch contract and add operations");
+
+        assert!(result.is_some());
+        assert!(
+            !operations.is_empty(),
+            "should have operations when epoch is set"
+        );
+    }
+
+    #[test]
+    fn test_fetch_contract_and_add_operations_nonexistent_with_epoch() {
+        let drive = setup_drive_with_initial_state_structure(None);
+        let platform_version = PlatformVersion::latest();
+
+        let epoch = Epoch::new(0).expect("should create epoch");
+        let mut operations = vec![];
+        let result = drive
+            .fetch_contract_and_add_operations(
+                [0u8; 32],
+                Some(&epoch),
+                None,
+                &mut operations,
+                platform_version,
+            )
+            .expect("should not error for nonexistent contract");
+
+        assert!(result.is_none());
+        // Even for nonexistent contracts with an epoch, we should get a cost operation
+        assert!(
+            !operations.is_empty(),
+            "should have cost operation for nonexistent contract with epoch"
+        );
+    }
+
+    #[test]
+    fn test_contract_history_with_apply_and_updates() {
+        let drive = setup_drive_with_initial_state_structure(None);
+        let platform_version = PlatformVersion::latest();
+
+        let contract_path =
+            "tests/supporting_files/contract/references/references_with_contract_history.json";
+        let mut contract = json_document_to_contract(contract_path, false, platform_version)
+            .expect("expected to get contract");
+
+        // Make sure keeps_history is set and contract is mutable
+        contract.config_mut().set_keeps_history(true);
+        contract.config_mut().set_readonly(false);
+
+        // Initial insert with timestamp
+        drive
+            .apply_contract(
+                &contract,
+                BlockInfo {
+                    time_ms: 1000,
+                    height: 100,
+                    core_height: 10,
+                    epoch: Default::default(),
+                },
+                true,
+                StorageFlags::optional_default_as_cow(),
+                None,
+                platform_version,
+            )
+            .expect("expected to apply contract successfully");
+
+        // Add a new property and update the contract at a different time
+        let new_schema = platform_value!({
+            "type": "object",
+            "properties": {
+                "updated_field": {
+                    "type": "string",
+                    "position": 0
+                }
+            },
+            "additionalProperties": false,
+        });
+        contract
+            .set_document_schema("newDoc", new_schema, true, &mut vec![], platform_version)
+            .expect("should set schema");
+        contract.increment_version();
+
+        drive
+            .update_contract(
+                &contract,
+                BlockInfo {
+                    time_ms: 2000,
+                    height: 200,
+                    core_height: 20,
+                    epoch: Default::default(),
+                },
+                true,
+                None,
+                platform_version,
+                None,
+            )
+            .expect("should update contract with history");
+
+        // Fetch history
+        let history = drive
+            .fetch_contract_with_history(
+                contract.id().to_buffer(),
+                None,
+                0,
+                Some(10),
+                None,
+                platform_version,
+            )
+            .expect("should fetch history");
+
+        assert_eq!(history.len(), 2, "should have 2 history entries");
+        assert!(history.contains_key(&1000));
+        assert!(history.contains_key(&2000));
+    }
+
+    #[test]
+    fn test_paths_data_contract_paths_trait() {
+        use crate::drive::contract::paths::DataContractPaths;
+
+        let contract = get_dashpay_contract_fixture(None, 0, 1).data_contract_owned();
+
+        // Test root_path
+        let root = contract.root_path();
+        assert_eq!(root.len(), 2);
+
+        // Test documents_path
+        let docs_path = contract.documents_path();
+        assert_eq!(docs_path.len(), 3);
+        assert_eq!(docs_path[2], &[1u8]);
+
+        // Test document_type_path
+        let type_path = contract.document_type_path("contactRequest");
+        assert_eq!(type_path.len(), 4);
+        assert_eq!(type_path[3], "contactRequest".as_bytes());
+
+        // Test documents_primary_key_path
+        let pk_path = contract.documents_primary_key_path("contactRequest");
+        assert_eq!(pk_path.len(), 5);
+        assert_eq!(pk_path[4], &[0u8]);
+
+        // Test documents_with_history_primary_key_path
+        let history_pk_path =
+            contract.documents_with_history_primary_key_path("contactRequest", &[1, 2, 3]);
+        assert_eq!(history_pk_path.len(), 6);
+        assert_eq!(history_pk_path[5], &[1, 2, 3]);
+    }
+
+    #[test]
+    fn test_paths_free_functions() {
+        use crate::drive::contract::paths::*;
+
+        let contract_id = [42u8; 32];
+
+        // all_contracts_global_root_path
+        let root = all_contracts_global_root_path();
+        assert_eq!(root.len(), 1);
+
+        // contract_root_path
+        let root_path = contract_root_path(&contract_id);
+        assert_eq!(root_path.len(), 2);
+        assert_eq!(root_path[1], &contract_id);
+
+        // contract_root_path_vec
+        let root_path_vec = contract_root_path_vec(&contract_id);
+        assert_eq!(root_path_vec.len(), 2);
+        assert_eq!(root_path_vec[1], contract_id.to_vec());
+
+        // contract_storage_path_vec
+        let storage_path = contract_storage_path_vec(&contract_id);
+        assert_eq!(storage_path.len(), 3);
+        assert_eq!(storage_path[2], vec![0]);
+
+        // contract_keeping_history_root_path_vec
+        let history_root = contract_keeping_history_root_path_vec(&contract_id);
+        assert_eq!(history_root.len(), 3);
+
+        // contract_keeping_history_root_path
+        let history_root_ref = contract_keeping_history_root_path(&contract_id);
+        assert_eq!(history_root_ref.len(), 3);
+        assert_eq!(history_root_ref[1], &contract_id);
+
+        // contract_keeping_history_storage_time_reference_path
+        let time_path =
+            contract_keeping_history_storage_time_reference_path(&contract_id, vec![1, 2, 3, 4]);
+        assert_eq!(time_path.len(), 4);
+        assert_eq!(time_path[3], vec![1, 2, 3, 4]);
+    }
+
+    #[test]
+    fn test_queries_fetch_contract_query_with_and_without_limit() {
+        let contract_id = [42u8; 32];
+
+        let query_with_limit = Drive::fetch_contract_query(contract_id, true);
+        assert_eq!(query_with_limit.query.limit, Some(1));
+        assert_eq!(query_with_limit.path, contract_root_path_vec(&contract_id));
+
+        let query_without_limit = Drive::fetch_contract_query(contract_id, false);
+        assert!(query_without_limit.query.limit.is_none());
+        assert_eq!(
+            query_without_limit.path,
+            contract_root_path_vec(&contract_id)
+        );
+    }
+
+    #[test]
+    fn test_queries_fetch_contract_with_history_latest_query() {
+        use crate::drive::contract::paths::contract_keeping_history_root_path_vec;
+
+        let contract_id = [42u8; 32];
+
+        let query_with_limit = Drive::fetch_contract_with_history_latest_query(contract_id, true);
+        assert_eq!(query_with_limit.query.limit, Some(1));
+        assert_eq!(
+            query_with_limit.path,
+            contract_keeping_history_root_path_vec(&contract_id)
+        );
+
+        let query_without_limit =
+            Drive::fetch_contract_with_history_latest_query(contract_id, false);
+        assert!(query_without_limit.query.limit.is_none());
+        assert_eq!(
+            query_without_limit.path,
+            contract_keeping_history_root_path_vec(&contract_id)
+        );
+    }
+
+    #[test]
+    fn test_queries_fetch_non_historical_contracts_query() {
+        use crate::drive::RootTree;
+
+        let ids = [[1u8; 32], [2u8; 32], [3u8; 32]];
+        let query = Drive::fetch_non_historical_contracts_query(&ids);
+        assert_eq!(query.query.limit, Some(3));
+        assert_eq!(
+            query.path,
+            vec![Into::<&[u8; 1]>::into(RootTree::DataContractDocuments).to_vec()]
+        );
+    }
+
+    #[test]
+    fn test_queries_fetch_historical_contracts_query() {
+        use crate::drive::RootTree;
+
+        let ids = [[1u8; 32], [2u8; 32]];
+        let query = Drive::fetch_historical_contracts_query(&ids);
+        assert_eq!(query.query.limit, Some(2));
+        assert_eq!(
+            query.path,
+            vec![Into::<&[u8; 1]>::into(RootTree::DataContractDocuments).to_vec()]
+        );
+    }
+
+    #[test]
+    fn test_queries_fetch_contracts_query_non_historical_only() {
+        let platform_version = PlatformVersion::latest();
+        let non_hist = [[1u8; 32]];
+        let hist: &[[u8; 32]] = &[];
+        let query = Drive::fetch_contracts_query(&non_hist, hist, platform_version)
+            .expect("should create query");
+        assert_eq!(query.query.limit, Some(1));
+    }
+
+    #[test]
+    fn test_queries_fetch_contracts_query_historical_only() {
+        let platform_version = PlatformVersion::latest();
+        let non_hist: &[[u8; 32]] = &[];
+        let hist = [[2u8; 32]];
+        let query = Drive::fetch_contracts_query(non_hist, &hist, platform_version)
+            .expect("should create query");
+        assert_eq!(query.query.limit, Some(1));
+    }
+
+    #[test]
+    fn test_queries_fetch_contracts_query_mixed() {
+        let platform_version = PlatformVersion::latest();
+        let non_hist = [[1u8; 32]];
+        let hist = [[2u8; 32]];
+        let query = Drive::fetch_contracts_query(&non_hist, &hist, platform_version)
+            .expect("should create merged query");
+        // Merged query has no individual limit since it merges two sub-queries
+        assert!(
+            query.query.limit.is_none(),
+            "merged query should have no limit"
+        );
+    }
+
+    #[test]
+    fn test_queries_fetch_contract_history_query_valid_limits() {
+        use crate::drive::contract::paths::contract_keeping_history_root_path_vec;
+
+        let contract_id = [42u8; 32];
+
+        // Default limit (None -> 10)
+        let query = Drive::fetch_contract_history_query(contract_id, 0, None, None)
+            .expect("should create query");
+        assert_eq!(query.query.limit, Some(10));
+        assert_eq!(
+            query.path,
+            contract_keeping_history_root_path_vec(&contract_id)
+        );
+
+        // Explicit valid limit
+        let query = Drive::fetch_contract_history_query(contract_id, 0, Some(5), None)
+            .expect("should create query");
+        assert_eq!(query.query.limit, Some(5));
+
+        // With offset
+        let query = Drive::fetch_contract_history_query(contract_id, 0, Some(5), Some(3))
+            .expect("should create query");
+        assert_eq!(query.query.offset, Some(3));
+    }
+
+    #[test]
+    fn test_queries_fetch_contract_history_query_invalid_limits() {
+        let contract_id = [42u8; 32];
+
+        // Limit = 0 (below min)
+        let result = Drive::fetch_contract_history_query(contract_id, 0, Some(0), None);
+        assert!(result.is_err());
+
+        // Limit = 11 (above max)
+        let result = Drive::fetch_contract_history_query(contract_id, 0, Some(11), None);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_fetch_contract_with_known_keeps_history_true() {
+        let drive = setup_drive_with_initial_state_structure(None);
+        let platform_version = PlatformVersion::latest();
+
+        let contract_path =
+            "tests/supporting_files/contract/references/references_with_contract_history.json";
+        let mut contract = json_document_to_contract(contract_path, false, platform_version)
+            .expect("expected to get contract");
+        contract.config_mut().set_keeps_history(true);
+        contract.config_mut().set_readonly(false);
+
+        drive
+            .apply_contract(
+                &contract,
+                BlockInfo {
+                    time_ms: 1000,
+                    height: 100,
+                    core_height: 10,
+                    epoch: Default::default(),
+                },
+                true,
+                StorageFlags::optional_default_as_cow(),
+                None,
+                platform_version,
+            )
+            .expect("expected to apply contract successfully");
+
+        // Fetch with known_keeps_history = Some(true) - directly queries
+        // the contract_keeping_history_root_path
+        let result = drive
+            .fetch_contract(
+                contract.id().to_buffer(),
+                None,
+                Some(true),
+                None,
+                platform_version,
+            )
+            .unwrap_add_cost(&mut Default::default())
+            .expect("should fetch contract with history");
+
+        assert!(result.is_some());
+    }
+
+    #[test]
+    fn test_fetch_contract_with_known_keeps_history_false_discovers_tree() {
+        let drive = setup_drive_with_initial_state_structure(None);
+        let platform_version = PlatformVersion::latest();
+
+        let contract_path =
+            "tests/supporting_files/contract/references/references_with_contract_history.json";
+        let mut contract = json_document_to_contract(contract_path, false, platform_version)
+            .expect("expected to get contract");
+        contract.config_mut().set_keeps_history(true);
+        contract.config_mut().set_readonly(false);
+
+        drive
+            .apply_contract(
+                &contract,
+                BlockInfo {
+                    time_ms: 1000,
+                    height: 100,
+                    core_height: 10,
+                    epoch: Default::default(),
+                },
+                true,
+                StorageFlags::optional_default_as_cow(),
+                None,
+                platform_version,
+            )
+            .expect("expected to apply contract successfully");
+
+        // Fetch with known_keeps_history = Some(false) will get the raw element
+        // at contract_root_path, discover it's a Tree, and follow the history path.
+        // This exercises the Element::Tree(..) branch in fetch_contract_v0.
+        let result = drive
+            .fetch_contract(
+                contract.id().to_buffer(),
+                None,
+                Some(false),
+                None,
+                platform_version,
+            )
+            .unwrap_add_cost(&mut Default::default())
+            .expect("should fetch contract via tree branch");
+
+        assert!(result.is_some());
+    }
+
+    #[test]
+    fn test_contract_fetch_info_fixtures_can_be_applied_and_fetched() {
+        use crate::drive::contract::DataContractFetchInfo;
+
+        let drive = setup_drive_with_initial_state_structure(None);
+        let platform_version = PlatformVersion::latest();
+
+        // Build fixture contracts
+        let fixtures = [
+            DataContractFetchInfo::dpns_contract_fixture(platform_version.protocol_version),
+            DataContractFetchInfo::dashpay_contract_fixture(platform_version.protocol_version),
+            DataContractFetchInfo::masternode_rewards_contract_fixture(
+                platform_version.protocol_version,
+            ),
+            DataContractFetchInfo::withdrawals_contract_fixture(platform_version.protocol_version),
+        ];
+
+        // Apply each fixture to drive, then fetch it back and verify
+        for fixture in &fixtures {
+            assert!(fixture.fee.is_some(), "fixture should have a fee");
+
+            drive
+                .apply_contract(
+                    &fixture.contract,
+                    BlockInfo::default(),
+                    true,
+                    StorageFlags::optional_default_as_cow(),
+                    None,
+                    platform_version,
+                )
+                .expect("expected to apply fixture contract successfully");
+
+            let fetched = drive
+                .get_contract_with_fetch_info(
+                    fixture.contract.id().to_buffer(),
+                    true,
+                    None,
+                    platform_version,
+                )
+                .expect("should fetch contract")
+                .expect("contract should exist");
+
+            assert_eq!(
+                fetched.contract.id(),
+                fixture.contract.id(),
+                "fetched contract id should match fixture"
+            );
+        }
+    }
+
+    #[test]
+    fn test_apply_contract_with_history_keeps_history_insert_and_update() {
+        let drive = setup_drive_with_initial_state_structure(None);
+        let platform_version = PlatformVersion::latest();
+
+        let contract_path =
+            "tests/supporting_files/contract/references/references_with_contract_history.json";
+        let mut contract = json_document_to_contract(contract_path, false, platform_version)
+            .expect("expected to get contract");
+
+        // Apply initial contract (insert path with history)
+        let fee = drive
+            .apply_contract(
+                &contract,
+                BlockInfo {
+                    time_ms: 1000,
+                    height: 100,
+                    core_height: 10,
+                    epoch: Default::default(),
+                },
+                true,
+                StorageFlags::optional_default_as_cow(),
+                None,
+                platform_version,
+            )
+            .expect("expected to apply contract successfully");
+        assert!(fee.processing_fee > 0);
+
+        // Now update via apply_contract (update path with history)
+        let new_schema = platform_value!({
+            "type": "object",
+            "properties": {
+                "extra_field": {
+                    "type": "string",
+                    "position": 0
+                }
+            },
+            "additionalProperties": false,
+        });
+        contract
+            .set_document_schema("extraDoc", new_schema, true, &mut vec![], platform_version)
+            .expect("should set schema");
+        contract.increment_version();
+
+        let fee2 = drive
+            .apply_contract(
+                &contract,
+                BlockInfo {
+                    time_ms: 2000,
+                    height: 200,
+                    core_height: 20,
+                    epoch: Default::default(),
+                },
+                true,
+                StorageFlags::optional_default_as_cow(),
+                None,
+                platform_version,
+            )
+            .expect("expected to apply updated contract with history successfully");
+        assert!(fee2.processing_fee > 0);
+    }
+
+    #[test]
+    fn test_prove_contract_with_history() {
+        let (drive, contract) = setup_history_contract();
+        let platform_version = PlatformVersion::latest();
+
+        // Prove a contract that keeps history - exercises the Tree branch in prove_contract_v0
+        let proof = drive
+            .prove_contract(contract.id().to_buffer(), None, platform_version)
+            .expect("should prove history contract");
+
+        // Verify proof using Drive::verify_contract
+        let (_root_hash, verified_contract) = Drive::verify_contract(
+            &proof,
+            None,
+            false,
+            false,
+            contract.id().to_buffer(),
+            platform_version,
+        )
+        .expect("should verify history contract proof");
+        assert!(
+            verified_contract.is_some(),
+            "history contract should be present in proof"
+        );
+        assert_eq!(
+            verified_contract
+                .expect("verified contract should exist")
+                .id(),
+            contract.id()
+        );
+    }
+
+    #[test]
+    fn test_prove_contracts_with_mix_of_historical_and_non_historical() {
+        let drive = setup_drive_with_initial_state_structure(None);
+        let platform_version = PlatformVersion::latest();
+
+        // Create a non-historical contract
+        let contract_path = "tests/supporting_files/contract/references/references.json";
+        let non_hist_contract = json_document_to_contract(contract_path, false, platform_version)
+            .expect("expected to get contract");
+        drive
+            .apply_contract(
+                &non_hist_contract,
+                BlockInfo::default(),
+                true,
+                StorageFlags::optional_default_as_cow(),
+                None,
+                platform_version,
+            )
+            .expect("expected to apply contract");
+
+        // Create a historical contract
+        let hist_contract_path =
+            "tests/supporting_files/contract/references/references_with_contract_history.json";
+        let hist_contract = json_document_to_contract(hist_contract_path, false, platform_version)
+            .expect("expected to get contract");
+        drive
+            .apply_contract(
+                &hist_contract,
+                BlockInfo {
+                    time_ms: 1000,
+                    height: 100,
+                    core_height: 10,
+                    epoch: Default::default(),
+                },
+                true,
+                None,
+                None,
+                platform_version,
+            )
+            .expect("expected to apply contract");
+
+        // Prove both - exercises the mixed historical/non-historical path in prove_contracts_v0
+        let contract_ids = [
+            non_hist_contract.id().to_buffer(),
+            hist_contract.id().to_buffer(),
+        ];
+        let proof = drive
+            .prove_contracts(&contract_ids, None, platform_version)
+            .expect("should prove mixed contracts");
+
+        // Verify each contract individually as a subset of the proof
+        let (_root_hash_1, verified_non_hist) = Drive::verify_contract(
+            &proof,
+            Some(false),
+            true,
+            true,
+            non_hist_contract.id().to_buffer(),
+            platform_version,
+        )
+        .expect("should verify non-historical contract from mixed proof");
+        assert!(
+            verified_non_hist.is_some(),
+            "non-historical contract should be present in proof"
+        );
+
+        let (_root_hash_2, verified_hist) = Drive::verify_contract(
+            &proof,
+            None,
+            true,
+            true,
+            hist_contract.id().to_buffer(),
+            platform_version,
+        )
+        .expect("should verify historical contract from mixed proof");
+        assert!(
+            verified_hist.is_some(),
+            "historical contract should be present in proof"
+        );
     }
 }

--- a/packages/rs-drive/src/drive/document/delete/mod.rs
+++ b/packages/rs-drive/src/drive/document/delete/mod.rs
@@ -1021,4 +1021,274 @@ mod tests {
         assert_eq!(fee_result.storage_fee, 0);
         assert_eq!(fee_result.processing_fee, 71994700);
     }
+
+    #[test]
+    fn test_delete_document_for_contract_id() {
+        let drive = setup_drive_with_initial_state_structure(None);
+
+        let db_transaction = drive.grove.start_transaction();
+
+        let platform_version = PlatformVersion::latest();
+
+        let contract = setup_contract(
+            &drive,
+            "tests/supporting_files/contract/family/family-contract-reduced.json",
+            None,
+            None,
+            None::<fn(&mut DataContract)>,
+            Some(&db_transaction),
+            None,
+        );
+
+        let document_type = contract
+            .document_type_for_name("person")
+            .expect("expected to get document type");
+
+        let random_owner_id = rand::thread_rng().gen::<[u8; 32]>();
+
+        let person_document = json_document_to_document(
+            "tests/supporting_files/contract/family/person0.json",
+            Some(random_owner_id.into()),
+            document_type,
+            platform_version,
+        )
+        .expect("expected to get document");
+
+        let storage_flags = Some(Cow::Owned(StorageFlags::SingleEpoch(0)));
+
+        drive
+            .add_document_for_contract(
+                DocumentAndContractInfo {
+                    owned_document_info: OwnedDocumentInfo {
+                        document_info: DocumentRefInfo((&person_document, storage_flags)),
+                        owner_id: None,
+                    },
+                    contract: &contract,
+                    document_type,
+                },
+                false,
+                BlockInfo::default(),
+                true,
+                Some(&db_transaction),
+                platform_version,
+                None,
+            )
+            .expect("expected to insert a document successfully");
+
+        drive
+            .grove
+            .commit_transaction(db_transaction)
+            .unwrap()
+            .expect("unable to commit transaction");
+
+        // Verify the document exists
+        let sql_string =
+            "select * from person where firstName = 'Samuel' order by firstName asc limit 100";
+        let query =
+            DriveDocumentQuery::from_sql_expr(sql_string, &contract, Some(&DriveConfig::default()))
+                .expect("should build query");
+
+        let (results, _, _) = query
+            .execute_raw_results_no_proof(&drive, None, None, platform_version)
+            .expect("expected to execute query");
+        assert_eq!(results.len(), 1);
+
+        let document_id = bs58::decode("AYjYxDqLy2hvGQADqE6FAkBnQEpJSzNd3CRw1tpS6vZ7")
+            .into_vec()
+            .expect("should decode")
+            .as_slice()
+            .try_into()
+            .expect("this be 32 bytes");
+
+        // Delete using contract_id instead of contract reference
+        drive
+            .delete_document_for_contract_id(
+                document_id,
+                contract.id(),
+                "person",
+                BlockInfo::default(),
+                true,
+                None,
+                platform_version,
+                Some(&EPOCH_CHANGE_FEE_VERSION_TEST),
+            )
+            .expect("expected to be able to delete the document by contract id");
+
+        // Verify the document was deleted
+        let (results, _, _) = query
+            .execute_raw_results_no_proof(&drive, None, None, platform_version)
+            .expect("expected to execute query");
+        assert_eq!(results.len(), 0);
+    }
+
+    #[test]
+    fn test_delete_document_for_contract_id_estimated_costs() {
+        let drive = setup_drive_with_initial_state_structure(None);
+
+        let db_transaction = drive.grove.start_transaction();
+
+        let platform_version = PlatformVersion::latest();
+
+        let contract = setup_contract(
+            &drive,
+            "tests/supporting_files/contract/family/family-contract-reduced.json",
+            None,
+            None,
+            None::<fn(&mut DataContract)>,
+            Some(&db_transaction),
+            None,
+        );
+
+        let document_type = contract
+            .document_type_for_name("person")
+            .expect("expected to get document type");
+
+        let random_owner_id = rand::thread_rng().gen::<[u8; 32]>();
+
+        let person_document = json_document_to_document(
+            "tests/supporting_files/contract/family/person0.json",
+            Some(random_owner_id.into()),
+            document_type,
+            platform_version,
+        )
+        .expect("expected to get document");
+
+        let storage_flags = Some(Cow::Owned(StorageFlags::SingleEpoch(0)));
+
+        drive
+            .add_document_for_contract(
+                DocumentAndContractInfo {
+                    owned_document_info: OwnedDocumentInfo {
+                        document_info: DocumentRefInfo((&person_document, storage_flags)),
+                        owner_id: None,
+                    },
+                    contract: &contract,
+                    document_type,
+                },
+                false,
+                BlockInfo::default(),
+                true,
+                Some(&db_transaction),
+                platform_version,
+                None,
+            )
+            .expect("expected to insert a document successfully");
+
+        drive
+            .grove
+            .commit_transaction(db_transaction)
+            .unwrap()
+            .expect("unable to commit transaction");
+
+        let document_id = bs58::decode("AYjYxDqLy2hvGQADqE6FAkBnQEpJSzNd3CRw1tpS6vZ7")
+            .into_vec()
+            .expect("should decode")
+            .as_slice()
+            .try_into()
+            .expect("this be 32 bytes");
+
+        // Use apply=false to exercise the estimation costs path
+        let fee_result = drive
+            .delete_document_for_contract_id(
+                document_id,
+                contract.id(),
+                "person",
+                BlockInfo::default(),
+                false,
+                None,
+                platform_version,
+                Some(&EPOCH_CHANGE_FEE_VERSION_TEST),
+            )
+            .expect("expected to estimate delete costs");
+
+        // Should have processing fee but no storage fee for estimation
+        assert_eq!(fee_result.storage_fee, 0);
+        assert!(fee_result.processing_fee > 0);
+    }
+
+    #[test]
+    fn test_delete_document_keeps_history_returns_error() {
+        let drive = setup_drive_with_initial_state_structure(None);
+
+        let db_transaction = drive.grove.start_transaction();
+
+        let platform_version = PlatformVersion::latest();
+
+        let contract = setup_contract(
+            &drive,
+            "tests/supporting_files/contract/family/family-contract-with-history.json",
+            None,
+            None,
+            None::<fn(&mut DataContract)>,
+            Some(&db_transaction),
+            None,
+        );
+
+        let document_type = contract
+            .document_type_for_name("person")
+            .expect("expected to get document type");
+
+        let random_owner_id = rand::thread_rng().gen::<[u8; 32]>();
+
+        let person_document = json_document_to_document(
+            "tests/supporting_files/contract/family/person0.json",
+            Some(random_owner_id.into()),
+            document_type,
+            platform_version,
+        )
+        .expect("expected to get document");
+
+        let storage_flags = Some(Cow::Owned(StorageFlags::SingleEpoch(0)));
+
+        drive
+            .add_document_for_contract(
+                DocumentAndContractInfo {
+                    owned_document_info: OwnedDocumentInfo {
+                        document_info: DocumentRefInfo((&person_document, storage_flags)),
+                        owner_id: None,
+                    },
+                    contract: &contract,
+                    document_type,
+                },
+                false,
+                BlockInfo::default(),
+                true,
+                Some(&db_transaction),
+                platform_version,
+                None,
+            )
+            .expect("expected to insert a document successfully");
+
+        drive
+            .grove
+            .commit_transaction(db_transaction)
+            .unwrap()
+            .expect("unable to commit transaction");
+
+        let document_id = bs58::decode("AYjYxDqLy2hvGQADqE6FAkBnQEpJSzNd3CRw1tpS6vZ7")
+            .into_vec()
+            .expect("should decode")
+            .as_slice()
+            .try_into()
+            .expect("this be 32 bytes");
+
+        // Attempting to delete a document that keeps history should return an error
+        let err = drive
+            .delete_document_for_contract(
+                document_id,
+                &contract,
+                "person",
+                BlockInfo::default(),
+                true,
+                None,
+                platform_version,
+                Some(&EPOCH_CHANGE_FEE_VERSION_TEST),
+            )
+            .expect_err("expected deleting a history-keeping document to fail");
+
+        assert!(matches!(
+            err,
+            Error::Drive(DriveError::InvalidDeletionOfDocumentThatKeepsHistory(_))
+        ));
+    }
 }

--- a/packages/rs-drive/src/drive/document/delete/mod.rs
+++ b/packages/rs-drive/src/drive/document/delete/mod.rs
@@ -1204,6 +1204,23 @@ mod tests {
         // Should have processing fee but no storage fee for estimation
         assert_eq!(fee_result.storage_fee, 0);
         assert!(fee_result.processing_fee > 0);
+
+        // Verify the document still exists after dry-run delete (apply=false)
+        let sql_string =
+            "select * from person where firstName = 'Samuel' order by firstName asc limit 100";
+        let query =
+            DriveDocumentQuery::from_sql_expr(sql_string, &contract, Some(&DriveConfig::default()))
+                .expect("should build query");
+
+        let (results, _, _) = query
+            .execute_raw_results_no_proof(&drive, None, None, platform_version)
+            .expect("expected to execute query");
+
+        assert_eq!(
+            results.len(),
+            1,
+            "document should still exist after dry-run delete"
+        );
     }
 
     #[test]

--- a/packages/rs-drive/src/drive/document/insert/mod.rs
+++ b/packages/rs-drive/src/drive/document/insert/mod.rs
@@ -51,13 +51,17 @@ mod tests {
     use once_cell::sync::Lazy;
     use std::collections::BTreeMap;
 
+    use crate::config::DriveConfig;
     use crate::error::drive::DriveError;
     use crate::error::Error;
+    use crate::query::DriveDocumentQuery;
     use crate::util::object_size_info::DocumentInfo::DocumentRefInfo;
     use crate::util::test_helpers::setup::setup_drive_with_initial_state_structure;
     use dpp::block::epoch::Epoch;
     use dpp::data_contract::accessors::v0::DataContractV0Getters;
     use dpp::data_contract::DataContract;
+    use dpp::document::serialization_traits::DocumentPlatformConversionMethodsV0;
+    use dpp::document::{Document, DocumentV0Getters};
     use dpp::fee::default_costs::KnownCostItem::StorageDiskUsageCreditPerByte;
     use dpp::fee::default_costs::{CachedEpochIndexFeeVersions, EpochCosts};
     use dpp::fee::fee_result::FeeResult;
@@ -1005,6 +1009,33 @@ mod tests {
 
         assert!(fee_result.storage_fee > 0);
         assert!(fee_result.processing_fee > 0);
+
+        // Fetch the document back and verify content matches
+        let sql_string = "select * from profile";
+        let query =
+            DriveDocumentQuery::from_sql_expr(sql_string, &contract, Some(&DriveConfig::default()))
+                .expect("should build query");
+
+        let (results, _, _) = query
+            .execute_raw_results_no_proof(&drive, None, Some(&db_transaction), platform_version)
+            .expect("expected to execute query");
+
+        assert_eq!(results.len(), 1);
+
+        let document_type = contract
+            .document_type_for_name("profile")
+            .expect("expected profile document type");
+        let fetched_doc = Document::from_bytes(&results[0], document_type, platform_version)
+            .expect("expected to deserialize document");
+        assert_eq!(
+            fetched_doc
+                .get("displayName")
+                .expect("displayName should exist")
+                .as_text()
+                .expect("displayName should be text"),
+            "sam",
+            "displayName should match the original value from profile0.json"
+        );
     }
 
     #[test]
@@ -1097,6 +1128,43 @@ mod tests {
             .commit_transaction(db_transaction)
             .unwrap()
             .expect("unable to commit transaction");
+
+        // Fetch both documents back and verify they exist with correct content
+        let sql_string = "select * from person order by firstName asc limit 100";
+        let query =
+            DriveDocumentQuery::from_sql_expr(sql_string, &contract, Some(&DriveConfig::default()))
+                .expect("should build query");
+
+        let (results, _, _) = query
+            .execute_raw_results_no_proof(&drive, None, None, platform_version)
+            .expect("expected to execute query");
+
+        assert_eq!(
+            results.len(),
+            2,
+            "expected both history-keeping documents to be present"
+        );
+
+        let doc0 = Document::from_bytes(&results[0], document_type, platform_version)
+            .expect("expected to deserialize first document");
+        let doc1 = Document::from_bytes(&results[1], document_type, platform_version)
+            .expect("expected to deserialize second document");
+
+        // Results are ordered by firstName ascending: Samuel, Tom
+        assert_eq!(
+            doc0.get("firstName")
+                .expect("firstName should exist")
+                .as_text()
+                .expect("firstName should be text"),
+            "Samuel"
+        );
+        assert_eq!(
+            doc1.get("firstName")
+                .expect("firstName should exist")
+                .as_text()
+                .expect("firstName should be text"),
+            "Tom"
+        );
     }
 
     #[test]
@@ -1247,5 +1315,21 @@ mod tests {
                 platform_version,
             )
             .expect("expected second document insertion to succeed");
+
+        // Verify both documents were inserted by fetching them
+        let sql_string = "select * from contactRequest";
+        let query =
+            DriveDocumentQuery::from_sql_expr(sql_string, &contract, Some(&DriveConfig::default()))
+                .expect("should build query");
+
+        let (results, _, _) = query
+            .execute_raw_results_no_proof(&drive, None, Some(&db_transaction), platform_version)
+            .expect("expected to execute query");
+
+        assert_eq!(
+            results.len(),
+            2,
+            "expected both documents to be present after batch insertion"
+        );
     }
 }

--- a/packages/rs-drive/src/drive/document/insert/mod.rs
+++ b/packages/rs-drive/src/drive/document/insert/mod.rs
@@ -948,4 +948,304 @@ mod tests {
                 "expected not to be able to insert document with already existing unique index",
             );
     }
+
+    #[test]
+    fn test_add_document_by_contract_id() {
+        let drive = setup_drive_with_initial_state_structure(None);
+
+        let db_transaction = drive.grove.start_transaction();
+
+        let platform_version = PlatformVersion::latest();
+
+        let contract = setup_contract(
+            &drive,
+            "tests/supporting_files/contract/dashpay/dashpay-contract-all-mutable.json",
+            None,
+            None,
+            None::<fn(&mut DataContract)>,
+            Some(&db_transaction),
+            None,
+        );
+
+        let document_type = contract
+            .document_type_for_name("profile")
+            .expect("expected to get document type");
+
+        let random_owner_id = random::<[u8; 32]>();
+
+        let dashpay_profile_document = json_document_to_document(
+            "tests/supporting_files/contract/dashpay/profile0.json",
+            Some(random_owner_id.into()),
+            document_type,
+            platform_version,
+        )
+        .expect("expected to get document");
+
+        let owned_document_info = OwnedDocumentInfo {
+            document_info: DocumentRefInfo((
+                &dashpay_profile_document,
+                StorageFlags::optional_default_as_cow(),
+            )),
+            owner_id: Some(random_owner_id),
+        };
+
+        // Use the add_document API which takes contract_id instead of contract ref
+        let fee_result = drive
+            .add_document(
+                owned_document_info,
+                contract.id(),
+                "profile",
+                false,
+                &BlockInfo::default(),
+                true,
+                Some(&db_transaction),
+                platform_version,
+            )
+            .expect("expected to insert a document via add_document successfully");
+
+        assert!(fee_result.storage_fee > 0);
+        assert!(fee_result.processing_fee > 0);
+    }
+
+    #[test]
+    fn test_add_document_with_history() {
+        let drive = setup_drive_with_initial_state_structure(None);
+
+        let db_transaction = drive.grove.start_transaction();
+
+        let platform_version = PlatformVersion::latest();
+
+        let contract = setup_contract(
+            &drive,
+            "tests/supporting_files/contract/family/family-contract-with-history.json",
+            None,
+            None,
+            None::<fn(&mut DataContract)>,
+            Some(&db_transaction),
+            None,
+        );
+
+        let document_type = contract
+            .document_type_for_name("person")
+            .expect("expected to get document type");
+
+        let random_owner_id = random::<[u8; 32]>();
+
+        let person_document = json_document_to_document(
+            "tests/supporting_files/contract/family/person0.json",
+            Some(random_owner_id.into()),
+            document_type,
+            platform_version,
+        )
+        .expect("expected to get document");
+
+        let storage_flags = Some(Cow::Owned(StorageFlags::SingleEpoch(0)));
+
+        let fee_result = drive
+            .add_document_for_contract(
+                DocumentAndContractInfo {
+                    owned_document_info: OwnedDocumentInfo {
+                        document_info: DocumentRefInfo((&person_document, storage_flags)),
+                        owner_id: Some(random_owner_id),
+                    },
+                    contract: &contract,
+                    document_type,
+                },
+                false,
+                BlockInfo::default(),
+                true,
+                Some(&db_transaction),
+                platform_version,
+                None,
+            )
+            .expect("expected to insert a history-keeping document successfully");
+
+        assert!(fee_result.storage_fee > 0);
+
+        // Now add a second document with history
+        let person_document1 = json_document_to_document(
+            "tests/supporting_files/contract/family/person1.json",
+            Some(random_owner_id.into()),
+            document_type,
+            platform_version,
+        )
+        .expect("expected to get document");
+
+        let storage_flags = Some(Cow::Owned(StorageFlags::SingleEpoch(0)));
+
+        drive
+            .add_document_for_contract(
+                DocumentAndContractInfo {
+                    owned_document_info: OwnedDocumentInfo {
+                        document_info: DocumentRefInfo((&person_document1, storage_flags)),
+                        owner_id: Some(random_owner_id),
+                    },
+                    contract: &contract,
+                    document_type,
+                },
+                false,
+                BlockInfo::default(),
+                true,
+                Some(&db_transaction),
+                platform_version,
+                None,
+            )
+            .expect("expected to insert a second history-keeping document successfully");
+
+        drive
+            .grove
+            .commit_transaction(db_transaction)
+            .unwrap()
+            .expect("unable to commit transaction");
+    }
+
+    #[test]
+    fn test_add_document_with_history_estimated_costs() {
+        let drive = setup_drive_with_initial_state_structure(None);
+
+        let db_transaction = drive.grove.start_transaction();
+
+        let platform_version = PlatformVersion::latest();
+
+        let contract = setup_contract(
+            &drive,
+            "tests/supporting_files/contract/family/family-contract-with-history.json",
+            None,
+            None,
+            None::<fn(&mut DataContract)>,
+            Some(&db_transaction),
+            None,
+        );
+
+        let document_type = contract
+            .document_type_for_name("person")
+            .expect("expected to get document type");
+
+        let random_owner_id = random::<[u8; 32]>();
+
+        let person_document = json_document_to_document(
+            "tests/supporting_files/contract/family/person0.json",
+            Some(random_owner_id.into()),
+            document_type,
+            platform_version,
+        )
+        .expect("expected to get document");
+
+        let storage_flags = Some(Cow::Owned(StorageFlags::SingleEpoch(0)));
+
+        // apply=false for estimation path of history-keeping documents
+        let fee_result = drive
+            .add_document_for_contract(
+                DocumentAndContractInfo {
+                    owned_document_info: OwnedDocumentInfo {
+                        document_info: DocumentRefInfo((&person_document, storage_flags)),
+                        owner_id: Some(random_owner_id),
+                    },
+                    contract: &contract,
+                    document_type,
+                },
+                false,
+                BlockInfo::default(),
+                false,
+                Some(&db_transaction),
+                platform_version,
+                None,
+            )
+            .expect("expected to estimate insert of a history-keeping document");
+
+        // Estimation should have storage fee and processing fee
+        assert!(fee_result.storage_fee > 0);
+        assert!(fee_result.processing_fee > 0);
+    }
+
+    #[test]
+    fn test_add_document_for_contract_with_non_unique_batch() {
+        let drive = setup_drive_with_initial_state_structure(None);
+
+        let db_transaction = drive.grove.start_transaction();
+
+        let platform_version = PlatformVersion::latest();
+
+        let contract = setup_contract(
+            &drive,
+            "tests/supporting_files/contract/dashpay/dashpay-contract-all-mutable.json",
+            None,
+            None,
+            None::<fn(&mut DataContract)>,
+            Some(&db_transaction),
+            None,
+        );
+
+        let document_type = contract
+            .document_type_for_name("contactRequest")
+            .expect("expected to get document type");
+
+        let random_owner_id = random::<[u8; 32]>();
+
+        let document0 = json_document_to_document(
+            "tests/supporting_files/contract/dashpay/contact-request0.json",
+            Some(random_owner_id.into()),
+            document_type,
+            platform_version,
+        )
+        .expect("expected to get document");
+
+        let document1 = json_document_to_document(
+            "tests/supporting_files/contract/dashpay/contact-request1.json",
+            Some(random_owner_id.into()),
+            document_type,
+            platform_version,
+        )
+        .expect("expected to get document");
+
+        // Insert first document setting document_is_unique_for_document_type_in_batch=true
+        let mut drive_operations = vec![];
+        drive
+            .add_document_for_contract_apply_and_add_to_operations(
+                DocumentAndContractInfo {
+                    owned_document_info: OwnedDocumentInfo {
+                        document_info: DocumentRefInfo((
+                            &document0,
+                            StorageFlags::optional_default_as_cow(),
+                        )),
+                        owner_id: Some(random_owner_id),
+                    },
+                    contract: &contract,
+                    document_type,
+                },
+                false,
+                &BlockInfo::default(),
+                true, // unique in batch
+                true,
+                Some(&db_transaction),
+                &mut drive_operations,
+                platform_version,
+            )
+            .expect("expected first document insertion to succeed");
+
+        // Insert second document with document_is_unique_for_document_type_in_batch=false
+        // This exercises the else branch in apply_and_add_to_operations_v0
+        drive
+            .add_document_for_contract_apply_and_add_to_operations(
+                DocumentAndContractInfo {
+                    owned_document_info: OwnedDocumentInfo {
+                        document_info: DocumentRefInfo((
+                            &document1,
+                            StorageFlags::optional_default_as_cow(),
+                        )),
+                        owner_id: Some(random_owner_id),
+                    },
+                    contract: &contract,
+                    document_type,
+                },
+                false,
+                &BlockInfo::default(),
+                false, // not unique in batch - exercises else branch
+                true,
+                Some(&db_transaction),
+                &mut drive_operations,
+                platform_version,
+            )
+            .expect("expected second document insertion to succeed");
+    }
 }

--- a/packages/rs-drive/src/drive/document/query/mod.rs
+++ b/packages/rs-drive/src/drive/document/query/mod.rs
@@ -526,8 +526,6 @@ mod tests {
     fn test_query_documents_dry_run() {
         let (drive, contract) = setup_dashpay("query-dry-run", true);
 
-        let _platform_version = PlatformVersion::latest();
-
         let sql_string = "select * from contactRequest";
         let query =
             DriveDocumentQuery::from_sql_expr(sql_string, &contract, Some(&DriveConfig::default()))

--- a/packages/rs-drive/src/drive/document/query/mod.rs
+++ b/packages/rs-drive/src/drive/document/query/mod.rs
@@ -495,3 +495,337 @@ impl Drive {
     //     Ok((items, skipped, cost))
     // }
 }
+
+#[cfg(feature = "server")]
+#[cfg(test)]
+mod tests {
+    use std::borrow::Cow;
+    use std::option::Option::None;
+
+    use dpp::block::block_info::BlockInfo;
+    use dpp::block::epoch::Epoch;
+    use rand::random;
+
+    use crate::config::DriveConfig;
+    use crate::drive::document::query::{
+        QueryDocumentsOutcomeV0Methods, QueryDocumentsWithFlagsOutcomeV0Methods,
+    };
+    use crate::drive::document::tests::setup_dashpay;
+    use crate::query::DriveDocumentQuery;
+    use crate::util::object_size_info::DocumentInfo::DocumentRefInfo;
+    use crate::util::object_size_info::{DocumentAndContractInfo, OwnedDocumentInfo};
+    use crate::util::storage_flags::StorageFlags;
+    use crate::util::test_helpers::setup::setup_drive_with_initial_state_structure;
+    use crate::util::test_helpers::setup_contract;
+    use dpp::data_contract::accessors::v0::DataContractV0Getters;
+    use dpp::data_contract::DataContract;
+    use dpp::tests::json_document::json_document_to_document;
+    use dpp::version::PlatformVersion;
+
+    #[test]
+    fn test_query_documents_dry_run() {
+        let (drive, contract) = setup_dashpay("query-dry-run", true);
+
+        let _platform_version = PlatformVersion::latest();
+
+        let sql_string = "select * from contactRequest";
+        let query =
+            DriveDocumentQuery::from_sql_expr(sql_string, &contract, Some(&DriveConfig::default()))
+                .expect("should build query");
+
+        // Dry run should return empty results without touching storage
+        let outcome = drive
+            .query_documents(query, None, true, None, None)
+            .expect("expected dry run query to succeed");
+
+        assert_eq!(outcome.documents().len(), 0);
+        assert_eq!(outcome.skipped(), 0);
+        assert_eq!(outcome.cost(), 0);
+    }
+
+    #[test]
+    fn test_query_documents_with_epoch_fee() {
+        let (drive, contract) = setup_dashpay("query-epoch", true);
+
+        let platform_version = PlatformVersion::latest();
+
+        let document_type = contract
+            .document_type_for_name("contactRequest")
+            .expect("expected to get document type");
+
+        let random_owner_id = random::<[u8; 32]>();
+
+        let document = json_document_to_document(
+            "tests/supporting_files/contract/dashpay/contact-request0.json",
+            Some(random_owner_id.into()),
+            document_type,
+            platform_version,
+        )
+        .expect("expected to get document");
+
+        drive
+            .add_document_for_contract(
+                DocumentAndContractInfo {
+                    owned_document_info: OwnedDocumentInfo {
+                        document_info: DocumentRefInfo((
+                            &document,
+                            StorageFlags::optional_default_as_cow(),
+                        )),
+                        owner_id: Some(random_owner_id),
+                    },
+                    contract: &contract,
+                    document_type,
+                },
+                false,
+                BlockInfo::default(),
+                true,
+                None,
+                platform_version,
+                None,
+            )
+            .expect("expected to insert a document successfully");
+
+        let sql_string = "select * from contactRequest";
+        let query =
+            DriveDocumentQuery::from_sql_expr(sql_string, &contract, Some(&DriveConfig::default()))
+                .expect("should build query");
+
+        // Query with epoch to exercise the fee calculation path
+        let epoch = Epoch::new(0).unwrap();
+        let outcome = drive
+            .query_documents(query, Some(&epoch), false, None, None)
+            .expect("expected query with epoch to succeed");
+
+        assert_eq!(outcome.documents().len(), 1);
+        assert!(outcome.cost() > 0, "cost should be non-zero with epoch");
+    }
+
+    #[test]
+    fn test_query_documents_without_epoch_zero_cost() {
+        let (drive, contract) = setup_dashpay("query-no-epoch", true);
+
+        let platform_version = PlatformVersion::latest();
+
+        let document_type = contract
+            .document_type_for_name("contactRequest")
+            .expect("expected to get document type");
+
+        let random_owner_id = random::<[u8; 32]>();
+
+        let document = json_document_to_document(
+            "tests/supporting_files/contract/dashpay/contact-request0.json",
+            Some(random_owner_id.into()),
+            document_type,
+            platform_version,
+        )
+        .expect("expected to get document");
+
+        drive
+            .add_document_for_contract(
+                DocumentAndContractInfo {
+                    owned_document_info: OwnedDocumentInfo {
+                        document_info: DocumentRefInfo((
+                            &document,
+                            StorageFlags::optional_default_as_cow(),
+                        )),
+                        owner_id: Some(random_owner_id),
+                    },
+                    contract: &contract,
+                    document_type,
+                },
+                false,
+                BlockInfo::default(),
+                true,
+                None,
+                platform_version,
+                None,
+            )
+            .expect("expected to insert a document successfully");
+
+        let sql_string = "select * from contactRequest";
+        let query =
+            DriveDocumentQuery::from_sql_expr(sql_string, &contract, Some(&DriveConfig::default()))
+                .expect("should build query");
+
+        // Query without epoch, cost should be 0
+        let outcome = drive
+            .query_documents(query, None, false, None, None)
+            .expect("expected query without epoch to succeed");
+
+        assert_eq!(outcome.documents().len(), 1);
+        assert_eq!(outcome.cost(), 0, "cost should be zero without epoch");
+    }
+
+    #[test]
+    fn test_query_documents_with_flags() {
+        let drive = setup_drive_with_initial_state_structure(None);
+
+        let db_transaction = drive.grove.start_transaction();
+
+        let platform_version = PlatformVersion::latest();
+
+        let contract = setup_contract(
+            &drive,
+            "tests/supporting_files/contract/family/family-contract-reduced.json",
+            None,
+            None,
+            None::<fn(&mut DataContract)>,
+            Some(&db_transaction),
+            None,
+        );
+
+        let document_type = contract
+            .document_type_for_name("person")
+            .expect("expected to get document type");
+
+        let random_owner_id = random::<[u8; 32]>();
+
+        let person_document = json_document_to_document(
+            "tests/supporting_files/contract/family/person0.json",
+            Some(random_owner_id.into()),
+            document_type,
+            platform_version,
+        )
+        .expect("expected to get document");
+
+        let storage_flags = Some(Cow::Owned(StorageFlags::SingleEpoch(0)));
+
+        drive
+            .add_document_for_contract(
+                DocumentAndContractInfo {
+                    owned_document_info: OwnedDocumentInfo {
+                        document_info: DocumentRefInfo((&person_document, storage_flags)),
+                        owner_id: None,
+                    },
+                    contract: &contract,
+                    document_type,
+                },
+                false,
+                BlockInfo::default(),
+                true,
+                Some(&db_transaction),
+                platform_version,
+                None,
+            )
+            .expect("expected to insert a document successfully");
+
+        drive
+            .grove
+            .commit_transaction(db_transaction)
+            .unwrap()
+            .expect("unable to commit transaction");
+
+        let sql_string =
+            "select * from person where firstName = 'Samuel' order by firstName asc limit 100";
+        let query =
+            DriveDocumentQuery::from_sql_expr(sql_string, &contract, Some(&DriveConfig::default()))
+                .expect("should build query");
+
+        // Query documents with flags to cover the query_documents_with_flags path
+        let outcome = drive
+            .query_documents_with_flags(query, None, false, None, None)
+            .expect("expected query_documents_with_flags to succeed");
+
+        assert_eq!(outcome.documents().len(), 1);
+        assert_eq!(outcome.cost(), 0);
+        // Verify storage flags are returned
+        let (_, flags) = &outcome.documents()[0];
+        assert!(flags.is_some(), "storage flags should be present");
+    }
+
+    #[test]
+    fn test_query_documents_with_flags_dry_run() {
+        let (drive, contract) = setup_dashpay("query-flags-dry", true);
+
+        let sql_string = "select * from contactRequest";
+        let query =
+            DriveDocumentQuery::from_sql_expr(sql_string, &contract, Some(&DriveConfig::default()))
+                .expect("should build query");
+
+        // Dry run should return empty defaults
+        let outcome = drive
+            .query_documents_with_flags(query, None, true, None, None)
+            .expect("expected dry run query_documents_with_flags to succeed");
+
+        assert_eq!(outcome.documents().len(), 0);
+        assert_eq!(outcome.skipped(), 0);
+        assert_eq!(outcome.cost(), 0);
+    }
+
+    #[test]
+    fn test_query_documents_with_flags_with_epoch() {
+        let drive = setup_drive_with_initial_state_structure(None);
+
+        let db_transaction = drive.grove.start_transaction();
+
+        let platform_version = PlatformVersion::latest();
+
+        let contract = setup_contract(
+            &drive,
+            "tests/supporting_files/contract/family/family-contract-reduced.json",
+            None,
+            None,
+            None::<fn(&mut DataContract)>,
+            Some(&db_transaction),
+            None,
+        );
+
+        let document_type = contract
+            .document_type_for_name("person")
+            .expect("expected to get document type");
+
+        let random_owner_id = random::<[u8; 32]>();
+
+        let person_document = json_document_to_document(
+            "tests/supporting_files/contract/family/person0.json",
+            Some(random_owner_id.into()),
+            document_type,
+            platform_version,
+        )
+        .expect("expected to get document");
+
+        let storage_flags = Some(Cow::Owned(StorageFlags::SingleEpoch(0)));
+
+        drive
+            .add_document_for_contract(
+                DocumentAndContractInfo {
+                    owned_document_info: OwnedDocumentInfo {
+                        document_info: DocumentRefInfo((&person_document, storage_flags)),
+                        owner_id: None,
+                    },
+                    contract: &contract,
+                    document_type,
+                },
+                false,
+                BlockInfo::default(),
+                true,
+                Some(&db_transaction),
+                platform_version,
+                None,
+            )
+            .expect("expected to insert a document successfully");
+
+        drive
+            .grove
+            .commit_transaction(db_transaction)
+            .unwrap()
+            .expect("unable to commit transaction");
+
+        let sql_string =
+            "select * from person where firstName = 'Samuel' order by firstName asc limit 100";
+        let query =
+            DriveDocumentQuery::from_sql_expr(sql_string, &contract, Some(&DriveConfig::default()))
+                .expect("should build query");
+
+        let epoch = Epoch::new(0).unwrap();
+        let outcome = drive
+            .query_documents_with_flags(query, Some(&epoch), false, None, None)
+            .expect("expected query_documents_with_flags with epoch to succeed");
+
+        assert_eq!(outcome.documents().len(), 1);
+        assert!(
+            outcome.cost() > 0,
+            "cost should be non-zero when epoch is provided"
+        );
+    }
+}

--- a/packages/rs-drive/src/drive/document/update/mod.rs
+++ b/packages/rs-drive/src/drive/document/update/mod.rs
@@ -49,6 +49,7 @@ mod tests {
     use crate::util::object_size_info::{DocumentAndContractInfo, OwnedDocumentInfo};
     use crate::util::storage_flags::StorageFlags;
 
+    use crate::drive::document::query::QueryDocumentsOutcomeV0Methods;
     use crate::drive::document::tests::setup_dashpay;
     use crate::query::DriveDocumentQuery;
     use crate::util::test_helpers::setup::{setup_drive, setup_drive_with_initial_state_structure};
@@ -2053,6 +2054,51 @@ mod tests {
         )
         .expect("expected to get document");
 
+        // Insert documents first so update operations target existing documents
+        drive
+            .add_document_for_contract(
+                DocumentAndContractInfo {
+                    owned_document_info: OwnedDocumentInfo {
+                        document_info: DocumentRefInfo((
+                            &doc0,
+                            StorageFlags::optional_default_as_cow(),
+                        )),
+                        owner_id: Some(owner_id),
+                    },
+                    contract: &contract,
+                    document_type,
+                },
+                false,
+                BlockInfo::default(),
+                true,
+                None,
+                platform_version,
+                None,
+            )
+            .expect("expected to insert first document");
+
+        drive
+            .add_document_for_contract(
+                DocumentAndContractInfo {
+                    owned_document_info: OwnedDocumentInfo {
+                        document_info: DocumentRefInfo((
+                            &doc1,
+                            StorageFlags::optional_default_as_cow(),
+                        )),
+                        owner_id: Some(owner_id),
+                    },
+                    contract: &contract,
+                    document_type,
+                },
+                false,
+                BlockInfo::default(),
+                true,
+                None,
+                platform_version,
+                None,
+            )
+            .expect("expected to insert second document");
+
         let documents = vec![doc0, doc1];
 
         let mut drive_operations = vec![];
@@ -2205,7 +2251,9 @@ mod tests {
 
         // Update document
         document.set("displayName", "Bob".into());
-        document.increment_revision().unwrap();
+        document
+            .increment_revision()
+            .expect("document should have a revision to increment");
 
         let serialized = DocumentPlatformConversionMethodsV0::serialize(
             &document,
@@ -2232,6 +2280,28 @@ mod tests {
             .expect("expected to update document with serialization");
 
         assert!(fee_result.processing_fee > 0);
+
+        // Fetch the document back and verify the update took effect
+        let sql_string = "select * from profile";
+        let query =
+            DriveDocumentQuery::from_sql_expr(sql_string, &contract, Some(&DriveConfig::default()))
+                .expect("should build query");
+
+        let outcome = drive
+            .query_documents(query, None, false, None, None)
+            .expect("expected to query documents");
+
+        assert_eq!(outcome.documents().len(), 1);
+        let fetched_doc = &outcome.documents()[0];
+        assert_eq!(
+            fetched_doc
+                .get("displayName")
+                .expect("displayName should exist")
+                .as_text()
+                .expect("displayName should be text"),
+            "Bob",
+            "displayName should have been updated to Bob"
+        );
     }
 
     #[test]
@@ -2284,7 +2354,9 @@ mod tests {
 
         // Update document using contract_id API
         document.set("displayName", "Bob".into());
-        document.increment_revision().unwrap();
+        document
+            .increment_revision()
+            .expect("document should have a revision to increment");
 
         let serialized = DocumentPlatformConversionMethodsV0::serialize(
             &document,
@@ -2310,5 +2382,27 @@ mod tests {
             .expect("expected to update document for contract id");
 
         assert!(fee_result.processing_fee > 0);
+
+        // Fetch the document back and verify the update took effect
+        let sql_string = "select * from profile";
+        let query =
+            DriveDocumentQuery::from_sql_expr(sql_string, &contract, Some(&DriveConfig::default()))
+                .expect("should build query");
+
+        let outcome = drive
+            .query_documents(query, None, false, None, None)
+            .expect("expected to query documents");
+
+        assert_eq!(outcome.documents().len(), 1);
+        let fetched_doc = &outcome.documents()[0];
+        assert_eq!(
+            fetched_doc
+                .get("displayName")
+                .expect("displayName should exist")
+                .as_text()
+                .expect("displayName should be text"),
+            "Bob",
+            "displayName should have been updated to Bob"
+        );
     }
 }

--- a/packages/rs-drive/src/drive/document/update/mod.rs
+++ b/packages/rs-drive/src/drive/document/update/mod.rs
@@ -57,6 +57,7 @@ mod tests {
     use dpp::data_contract::accessors::v0::DataContractV0Getters;
     use dpp::data_contract::conversion::value::v0::DataContractValueConversionMethodsV0;
     use dpp::data_contract::document_type::methods::DocumentTypeV0Methods;
+    use dpp::document::document_methods::DocumentMethodsV0;
     use dpp::document::serialization_traits::{
         DocumentPlatformConversionMethodsV0, DocumentPlatformValueMethodsV0,
     };
@@ -2022,5 +2023,292 @@ mod tests {
             .expect("should update document");
 
         assert_ne!(update_fees.storage_fee, 0);
+    }
+
+    #[test]
+    fn test_add_update_multiple_documents_operations() {
+        let (drive, contract) = setup_dashpay("multi-update", true);
+
+        let platform_version = PlatformVersion::latest();
+
+        let document_type = contract
+            .document_type_for_name("contactRequest")
+            .expect("contactRequest document exists");
+
+        let owner_id = random::<[u8; 32]>();
+
+        let doc0 = json_document_to_document(
+            "tests/supporting_files/contract/dashpay/contact-request0.json",
+            Some(owner_id.into()),
+            document_type,
+            platform_version,
+        )
+        .expect("expected to get document");
+
+        let doc1 = json_document_to_document(
+            "tests/supporting_files/contract/dashpay/contact-request1.json",
+            Some(owner_id.into()),
+            document_type,
+            platform_version,
+        )
+        .expect("expected to get document");
+
+        let documents = vec![doc0, doc1];
+
+        let mut drive_operations = vec![];
+
+        drive
+            .add_update_multiple_documents_operations(
+                &documents,
+                &contract,
+                document_type,
+                &mut drive_operations,
+                &platform_version.drive,
+            )
+            .expect("expected to add update operations");
+
+        // Should have created one operation containing both documents
+        assert_eq!(drive_operations.len(), 1);
+    }
+
+    #[test]
+    fn test_add_update_multiple_documents_operations_empty() {
+        let (drive, contract) = setup_dashpay("multi-update-empty", true);
+
+        let platform_version = PlatformVersion::latest();
+
+        let document_type = contract
+            .document_type_for_name("contactRequest")
+            .expect("contactRequest document exists");
+
+        let documents: Vec<dpp::document::Document> = vec![];
+
+        let mut drive_operations = vec![];
+
+        drive
+            .add_update_multiple_documents_operations(
+                &documents,
+                &contract,
+                document_type,
+                &mut drive_operations,
+                &platform_version.drive,
+            )
+            .expect("expected empty documents to succeed");
+
+        // Empty documents should produce no operations
+        assert_eq!(drive_operations.len(), 0);
+    }
+
+    #[test]
+    fn test_update_document_for_contract_immutable_error() {
+        let drive = setup_drive_with_initial_state_structure(None);
+
+        let db_transaction = drive.grove.start_transaction();
+
+        let platform_version = PlatformVersion::latest();
+
+        // Use the non-mutable dashpay contract
+        let contract = setup_contract(
+            &drive,
+            "tests/supporting_files/contract/dashpay/dashpay-contract.json",
+            None,
+            None,
+            None::<fn(&mut DataContract)>,
+            Some(&db_transaction),
+            None,
+        );
+
+        // contactRequest is not mutable in this contract
+        let document_type = contract
+            .document_type_for_name("contactRequest")
+            .expect("contactRequest document exists");
+
+        let owner_id = random::<[u8; 32]>();
+
+        let document = json_document_to_document(
+            "tests/supporting_files/contract/dashpay/contact-request0.json",
+            Some(owner_id.into()),
+            document_type,
+            platform_version,
+        )
+        .expect("expected to get cbor document");
+
+        // Try to update an immutable document type
+        let err = drive
+            .update_document_for_contract(
+                &document,
+                &contract,
+                document_type,
+                Some(owner_id),
+                BlockInfo::default(),
+                true,
+                StorageFlags::optional_default_as_cow(),
+                Some(&db_transaction),
+                platform_version,
+                None,
+            )
+            .expect_err("expected updating an immutable document type to fail");
+
+        assert!(matches!(
+            err,
+            Error::Drive(DriveError::UpdatingReadOnlyImmutableDocument(_))
+        ));
+    }
+
+    #[test]
+    fn test_update_document_with_serialization_for_contract() {
+        let (drive, contract) = setup_dashpay("update-serialized", true);
+
+        let platform_version = PlatformVersion::latest();
+
+        let document_type = contract
+            .document_type_for_name("profile")
+            .expect("profile document exists");
+
+        let owner_id: Identifier = random::<[u8; 32]>().into();
+
+        let mut document = document_type
+            .create_document_from_data(
+                platform_value!({"displayName": "Alice"}),
+                owner_id,
+                random(),
+                random(),
+                random(),
+                platform_version,
+            )
+            .expect("should create document");
+
+        // First create the document
+        let info = DocumentAndContractInfo {
+            owned_document_info: OwnedDocumentInfo {
+                document_info: DocumentRefInfo((
+                    &document,
+                    StorageFlags::optional_default_as_cow(),
+                )),
+                owner_id: Some(owner_id.to_buffer()),
+            },
+            contract: &contract,
+            document_type,
+        };
+
+        drive
+            .add_document_for_contract(
+                info,
+                true,
+                BlockInfo::default(),
+                true,
+                None,
+                platform_version,
+                None,
+            )
+            .expect("should create profile");
+
+        // Update document
+        document.set("displayName", "Bob".into());
+        document.increment_revision().unwrap();
+
+        let serialized = DocumentPlatformConversionMethodsV0::serialize(
+            &document,
+            document_type,
+            &contract,
+            platform_version,
+        )
+        .expect("expected to serialize");
+
+        let fee_result = drive
+            .update_document_with_serialization_for_contract(
+                &document,
+                &serialized,
+                &contract,
+                "profile",
+                Some(owner_id.to_buffer()),
+                BlockInfo::default(),
+                true,
+                StorageFlags::optional_default_as_cow(),
+                None,
+                platform_version,
+                None,
+            )
+            .expect("expected to update document with serialization");
+
+        assert!(fee_result.processing_fee > 0);
+    }
+
+    #[test]
+    fn test_update_document_for_contract_id() {
+        let (drive, contract) = setup_dashpay("update-by-id", true);
+
+        let platform_version = PlatformVersion::latest();
+
+        let document_type = contract
+            .document_type_for_name("profile")
+            .expect("profile document exists");
+
+        let owner_id: Identifier = random::<[u8; 32]>().into();
+
+        let mut document = document_type
+            .create_document_from_data(
+                platform_value!({"displayName": "Alice"}),
+                owner_id,
+                random(),
+                random(),
+                random(),
+                platform_version,
+            )
+            .expect("should create document");
+
+        // First create the document
+        let info = DocumentAndContractInfo {
+            owned_document_info: OwnedDocumentInfo {
+                document_info: DocumentRefInfo((
+                    &document,
+                    StorageFlags::optional_default_as_cow(),
+                )),
+                owner_id: Some(owner_id.to_buffer()),
+            },
+            contract: &contract,
+            document_type,
+        };
+
+        drive
+            .add_document_for_contract(
+                info,
+                true,
+                BlockInfo::default(),
+                true,
+                None,
+                platform_version,
+                None,
+            )
+            .expect("should create profile");
+
+        // Update document using contract_id API
+        document.set("displayName", "Bob".into());
+        document.increment_revision().unwrap();
+
+        let serialized = DocumentPlatformConversionMethodsV0::serialize(
+            &document,
+            document_type,
+            &contract,
+            platform_version,
+        )
+        .expect("expected to serialize");
+
+        let fee_result = drive
+            .update_document_for_contract_id(
+                &serialized,
+                contract.id().to_buffer(),
+                "profile",
+                Some(owner_id.to_buffer()),
+                BlockInfo::default(),
+                true,
+                StorageFlags::optional_default_as_cow(),
+                None,
+                platform_version,
+                None,
+            )
+            .expect("expected to update document for contract id");
+
+        assert!(fee_result.processing_fee > 0);
     }
 }

--- a/packages/rs-drive/src/drive/identity/balance/update.rs
+++ b/packages/rs-drive/src/drive/identity/balance/update.rs
@@ -932,4 +932,74 @@ mod tests {
             ));
         }
     }
+
+    mod remove_from_identity_balance_errors {
+        use super::*;
+        use crate::error::identity::IdentityError;
+        use dpp::block::block_info::BlockInfo;
+        use dpp::version::PlatformVersion;
+
+        #[test]
+        fn should_fail_to_remove_more_than_balance() {
+            let drive = setup_drive_with_initial_state_structure(None);
+            let platform_version = PlatformVersion::latest();
+
+            let identity = create_test_identity(&drive, [0; 32], Some(15), None, platform_version)
+                .expect("expected to create an identity");
+
+            // Identity starts with balance from create_test_identity (which is 0 after creation
+            // since create_test_identity sets balance to 0). Let's add some balance first.
+            let added_balance = 100;
+
+            drive
+                .add_to_identity_balance(
+                    identity.id().to_buffer(),
+                    added_balance,
+                    &BlockInfo::default(),
+                    true,
+                    None,
+                    platform_version,
+                )
+                .expect("expected to add balance");
+
+            // Now try to remove more than available
+            let result = drive.remove_from_identity_balance(
+                identity.id().to_buffer(),
+                added_balance + 1,
+                &BlockInfo::default(),
+                true,
+                None,
+                platform_version,
+                None,
+            );
+
+            assert!(matches!(
+                result,
+                Err(Error::Identity(IdentityError::IdentityInsufficientBalance(
+                    _
+                )))
+            ));
+        }
+
+        #[test]
+        fn should_fail_to_remove_from_non_existent_identity() {
+            let drive = setup_drive_with_initial_state_structure(None);
+            let platform_version = PlatformVersion::latest();
+
+            let result = drive.remove_from_identity_balance(
+                [0; 32],
+                100,
+                &BlockInfo::default(),
+                true,
+                None,
+                platform_version,
+                None,
+            );
+
+            assert!(matches!(
+                result,
+                Err(Error::Drive(DriveError::CorruptedCodeExecution(_)))
+            ));
+        }
+    }
 }

--- a/packages/rs-drive/src/drive/identity/fetch/balance/mod.rs
+++ b/packages/rs-drive/src/drive/identity/fetch/balance/mod.rs
@@ -1,3 +1,237 @@
 mod fetch_identity_balance;
 mod fetch_identity_balance_include_debt;
 mod fetch_identity_negative_balance;
+
+#[cfg(feature = "server")]
+#[cfg(test)]
+mod tests {
+    use crate::util::test_helpers::setup::setup_drive_with_initial_state_structure;
+    use crate::util::test_helpers::test_utils::identities::create_test_identity;
+    use dpp::block::block_info::BlockInfo;
+    use dpp::identity::accessors::IdentityGettersV0;
+    use dpp::identity::Identity;
+    use dpp::version::PlatformVersion;
+
+    mod fetch_identity_balance {
+        use super::*;
+
+        #[test]
+        fn should_return_none_for_non_existent_identity() {
+            let drive = setup_drive_with_initial_state_structure(None);
+            let platform_version = PlatformVersion::latest();
+
+            let balance = drive
+                .fetch_identity_balance([0; 32], None, platform_version)
+                .expect("should not error");
+
+            assert!(balance.is_none());
+        }
+
+        #[test]
+        fn should_return_balance_for_existing_identity() {
+            let drive = setup_drive_with_initial_state_structure(None);
+            let platform_version = PlatformVersion::latest();
+
+            let identity = Identity::random_identity(3, Some(42), platform_version)
+                .expect("expected a random identity");
+
+            let expected_balance = identity.balance();
+
+            drive
+                .add_new_identity(
+                    identity.clone(),
+                    false,
+                    &BlockInfo::default(),
+                    true,
+                    None,
+                    platform_version,
+                )
+                .expect("expected to add identity");
+
+            let balance = drive
+                .fetch_identity_balance(identity.id().to_buffer(), None, platform_version)
+                .expect("should not error")
+                .expect("should have balance");
+
+            assert_eq!(balance, expected_balance);
+        }
+
+        #[test]
+        fn should_return_balance_with_costs_estimated() {
+            let drive = setup_drive_with_initial_state_structure(None);
+            let platform_version = PlatformVersion::latest();
+
+            let identity = Identity::random_identity(3, Some(42), platform_version)
+                .expect("expected a random identity");
+
+            drive
+                .add_new_identity(
+                    identity.clone(),
+                    false,
+                    &BlockInfo::default(),
+                    true,
+                    None,
+                    platform_version,
+                )
+                .expect("expected to add identity");
+
+            let block_info = BlockInfo::default();
+
+            // Estimated mode (apply=false)
+            let (balance, fee_result) = drive
+                .fetch_identity_balance_with_costs(
+                    identity.id().to_buffer(),
+                    &block_info,
+                    false,
+                    None,
+                    platform_version,
+                )
+                .expect("should return balance with costs");
+
+            // In estimated (stateless) mode, the balance query does not read
+            // from the database. It returns Some(0) as a placeholder value
+            // while computing estimated costs.
+            assert!(fee_result.processing_fee > 0);
+            assert_eq!(balance, Some(0));
+        }
+    }
+
+    mod fetch_identity_balance_include_debt {
+        use super::*;
+        use crate::fees::op::LowLevelDriveOperation;
+
+        #[test]
+        fn should_return_none_for_non_existent_identity() {
+            let drive = setup_drive_with_initial_state_structure(None);
+            let platform_version = PlatformVersion::latest();
+
+            let balance = drive
+                .fetch_identity_balance_include_debt([0; 32], None, platform_version)
+                .expect("should not error");
+
+            assert!(balance.is_none());
+        }
+
+        #[test]
+        fn should_return_positive_balance_for_identity_with_funds() {
+            let drive = setup_drive_with_initial_state_structure(None);
+            let platform_version = PlatformVersion::latest();
+
+            let identity = create_test_identity(&drive, [0; 32], Some(1), None, platform_version)
+                .expect("expected an identity");
+
+            let added_balance = 1000;
+
+            drive
+                .add_to_identity_balance(
+                    identity.id().to_buffer(),
+                    added_balance,
+                    &BlockInfo::default(),
+                    true,
+                    None,
+                    platform_version,
+                )
+                .expect("should add balance");
+
+            let balance = drive
+                .fetch_identity_balance_include_debt(
+                    identity.id().to_buffer(),
+                    None,
+                    platform_version,
+                )
+                .expect("should not error")
+                .expect("should have balance");
+
+            assert_eq!(balance, added_balance as i64);
+        }
+
+        #[test]
+        fn should_return_negative_balance_for_identity_with_debt() {
+            let drive = setup_drive_with_initial_state_structure(None);
+            let platform_version = PlatformVersion::latest();
+
+            let identity = create_test_identity(&drive, [0; 32], Some(1), None, platform_version)
+                .expect("expected an identity");
+
+            let negative_amount: u64 = 500;
+
+            // Set negative balance (debt)
+            let batch = vec![drive
+                .update_identity_negative_credit_operation(
+                    identity.id().to_buffer(),
+                    negative_amount,
+                    platform_version,
+                )
+                .expect("expected operation")];
+
+            let mut drive_operations: Vec<LowLevelDriveOperation> = vec![];
+            drive
+                .apply_batch_low_level_drive_operations(
+                    None,
+                    None,
+                    batch,
+                    &mut drive_operations,
+                    &platform_version.drive,
+                )
+                .expect("should apply batch");
+
+            let balance = drive
+                .fetch_identity_balance_include_debt(
+                    identity.id().to_buffer(),
+                    None,
+                    platform_version,
+                )
+                .expect("should not error")
+                .expect("should have balance");
+
+            assert_eq!(balance, -(negative_amount as i64));
+        }
+    }
+
+    mod fetch_identity_negative_balance {
+        use super::*;
+
+        #[test]
+        fn should_error_for_non_existent_identity() {
+            let drive = setup_drive_with_initial_state_structure(None);
+            let platform_version = PlatformVersion::latest();
+
+            let mut drive_operations = vec![];
+            // For a non-existent identity, the path doesn't exist, so grove_get_raw
+            // returns an error (PathParentLayerNotFound) since the identity subtree
+            // doesn't exist at all.
+            let result = drive.fetch_identity_negative_balance_operations(
+                [0; 32],
+                true,
+                None,
+                &mut drive_operations,
+                platform_version,
+            );
+
+            assert!(result.is_err());
+        }
+
+        #[test]
+        fn should_return_zero_negative_balance_for_new_identity() {
+            let drive = setup_drive_with_initial_state_structure(None);
+            let platform_version = PlatformVersion::latest();
+
+            let identity = create_test_identity(&drive, [0; 32], Some(1), None, platform_version)
+                .expect("expected an identity");
+
+            let mut drive_operations = vec![];
+            let negative_balance = drive
+                .fetch_identity_negative_balance_operations(
+                    identity.id().to_buffer(),
+                    true,
+                    None,
+                    &mut drive_operations,
+                    platform_version,
+                )
+                .expect("should not error")
+                .expect("should have negative balance");
+
+            assert_eq!(negative_balance, 0);
+        }
+    }
+}

--- a/packages/rs-drive/src/drive/identity/fetch/mod.rs
+++ b/packages/rs-drive/src/drive/identity/fetch/mod.rs
@@ -271,3 +271,234 @@ impl Drive {
             .collect()
     }
 }
+
+#[cfg(feature = "server")]
+#[cfg(test)]
+mod tests {
+    use crate::util::test_helpers::setup::setup_drive_with_initial_state_structure;
+    use dpp::block::block_info::BlockInfo;
+    use dpp::identity::accessors::IdentityGettersV0;
+    use dpp::identity::Identity;
+    use dpp::version::PlatformVersion;
+
+    mod verify_all_identities_exist {
+        use super::*;
+
+        #[test]
+        fn should_return_true_when_all_identities_exist() {
+            let drive = setup_drive_with_initial_state_structure(None);
+            let platform_version = PlatformVersion::latest();
+
+            let identities: Vec<Identity> =
+                Identity::random_identities(3, 3, Some(42), platform_version)
+                    .expect("expected random identities");
+
+            let ids: Vec<[u8; 32]> = identities.iter().map(|i| i.id().to_buffer()).collect();
+
+            for identity in &identities {
+                drive
+                    .add_new_identity(
+                        identity.clone(),
+                        false,
+                        &BlockInfo::default(),
+                        true,
+                        None,
+                        platform_version,
+                    )
+                    .expect("expected to add identity");
+            }
+
+            let result = drive
+                .verify_all_identities_exist(&ids, None, platform_version)
+                .expect("should not error");
+
+            assert!(result);
+        }
+
+        #[test]
+        fn should_return_false_when_some_identities_missing() {
+            let drive = setup_drive_with_initial_state_structure(None);
+            let platform_version = PlatformVersion::latest();
+
+            let identity = Identity::random_identity(3, Some(42), platform_version)
+                .expect("expected a random identity");
+
+            drive
+                .add_new_identity(
+                    identity.clone(),
+                    false,
+                    &BlockInfo::default(),
+                    true,
+                    None,
+                    platform_version,
+                )
+                .expect("expected to add identity");
+
+            // Include a nonexistent identity id
+            let ids = vec![identity.id().to_buffer(), [0xff; 32]];
+
+            let result = drive
+                .verify_all_identities_exist(&ids, None, platform_version)
+                .expect("should not error");
+
+            assert!(!result);
+        }
+    }
+
+    mod fetch_identities_balances {
+        use super::*;
+
+        #[test]
+        fn should_fetch_balances_for_existing_identities() {
+            let drive = setup_drive_with_initial_state_structure(None);
+            let platform_version = PlatformVersion::latest();
+
+            let identities: Vec<Identity> =
+                Identity::random_identities(3, 3, Some(42), platform_version)
+                    .expect("expected random identities");
+
+            for identity in &identities {
+                drive
+                    .add_new_identity(
+                        identity.clone(),
+                        false,
+                        &BlockInfo::default(),
+                        true,
+                        None,
+                        platform_version,
+                    )
+                    .expect("expected to add identity");
+            }
+
+            let ids: Vec<[u8; 32]> = identities.iter().map(|i| i.id().to_buffer()).collect();
+
+            let balances = drive
+                .fetch_identities_balances(&ids, None, platform_version)
+                .expect("should fetch balances");
+
+            assert_eq!(balances.len(), 3);
+            for identity in &identities {
+                let balance = balances
+                    .get(&identity.id().to_buffer())
+                    .expect("should have balance for identity");
+                assert_eq!(*balance, identity.balance());
+            }
+        }
+    }
+
+    mod fetch_optional_identities_balances {
+        use super::*;
+
+        #[test]
+        fn should_return_none_for_non_existent_identities() {
+            let drive = setup_drive_with_initial_state_structure(None);
+            let platform_version = PlatformVersion::latest();
+
+            let identity = Identity::random_identity(3, Some(42), platform_version)
+                .expect("expected a random identity");
+
+            drive
+                .add_new_identity(
+                    identity.clone(),
+                    false,
+                    &BlockInfo::default(),
+                    true,
+                    None,
+                    platform_version,
+                )
+                .expect("expected to add identity");
+
+            let ids = vec![identity.id().to_buffer(), [0xff; 32]];
+
+            let balances = drive
+                .fetch_optional_identities_balances(&ids, None, platform_version)
+                .expect("should fetch optional balances");
+
+            assert_eq!(balances.len(), 2);
+            assert_eq!(
+                *balances.get(&identity.id().to_buffer()).unwrap(),
+                Some(identity.balance())
+            );
+            assert_eq!(*balances.get(&[0xff; 32]).unwrap(), None);
+        }
+    }
+
+    mod fetch_many_identity_balances_by_range {
+        use super::*;
+        use std::collections::BTreeMap;
+
+        #[test]
+        fn should_fetch_balances_by_range_ascending() {
+            let drive = setup_drive_with_initial_state_structure(None);
+            let platform_version = PlatformVersion::latest();
+
+            let identities: Vec<Identity> =
+                Identity::random_identities(5, 3, Some(42), platform_version)
+                    .expect("expected random identities");
+
+            for identity in &identities {
+                drive
+                    .add_new_identity(
+                        identity.clone(),
+                        false,
+                        &BlockInfo::default(),
+                        true,
+                        None,
+                        platform_version,
+                    )
+                    .expect("expected to add identity");
+            }
+
+            let balances: BTreeMap<[u8; 32], u64> = drive
+                .fetch_many_identity_balances_by_range::<BTreeMap<[u8; 32], u64>>(
+                    None,
+                    true,
+                    10,
+                    None,
+                    platform_version,
+                )
+                .expect("should fetch balances by range");
+
+            assert_eq!(balances.len(), 5);
+
+            // BTreeMap keys are always sorted, confirming ascending order
+            let keys: Vec<[u8; 32]> = balances.keys().copied().collect();
+            assert!(keys.windows(2).all(|w| w[0] <= w[1]));
+        }
+
+        #[test]
+        fn should_respect_limit() {
+            let drive = setup_drive_with_initial_state_structure(None);
+            let platform_version = PlatformVersion::latest();
+
+            let identities: Vec<Identity> =
+                Identity::random_identities(5, 3, Some(42), platform_version)
+                    .expect("expected random identities");
+
+            for identity in &identities {
+                drive
+                    .add_new_identity(
+                        identity.clone(),
+                        false,
+                        &BlockInfo::default(),
+                        true,
+                        None,
+                        platform_version,
+                    )
+                    .expect("expected to add identity");
+            }
+
+            let balances: BTreeMap<[u8; 32], u64> = drive
+                .fetch_many_identity_balances_by_range::<BTreeMap<[u8; 32], u64>>(
+                    None,
+                    true,
+                    2,
+                    None,
+                    platform_version,
+                )
+                .expect("should fetch balances by range");
+
+            assert_eq!(balances.len(), 2);
+        }
+    }
+}

--- a/packages/rs-drive/src/drive/identity/fetch/nonce/mod.rs
+++ b/packages/rs-drive/src/drive/identity/fetch/nonce/mod.rs
@@ -1,2 +1,132 @@
 mod fetch_identity_nonce;
 mod prove_identity_nonce;
+
+#[cfg(feature = "server")]
+#[cfg(test)]
+mod tests {
+    use crate::util::test_helpers::setup::setup_drive_with_initial_state_structure;
+    use dpp::block::block_info::BlockInfo;
+    use dpp::identity::accessors::IdentityGettersV0;
+    use dpp::identity::Identity;
+    use dpp::version::PlatformVersion;
+
+    mod fetch_identity_nonce {
+        use super::*;
+
+        #[test]
+        fn should_return_none_for_non_existent_identity() {
+            let drive = setup_drive_with_initial_state_structure(None);
+            let platform_version = PlatformVersion::latest();
+
+            let nonce = drive
+                .fetch_identity_nonce([0; 32], true, None, platform_version)
+                .expect("should not error");
+
+            assert!(nonce.is_none());
+        }
+
+        #[test]
+        fn should_return_initial_nonce_for_new_identity() {
+            let drive = setup_drive_with_initial_state_structure(None);
+            let platform_version = PlatformVersion::latest();
+
+            let identity = Identity::random_identity(3, Some(42), platform_version)
+                .expect("expected a random identity");
+
+            drive
+                .add_new_identity(
+                    identity.clone(),
+                    false,
+                    &BlockInfo::default(),
+                    true,
+                    None,
+                    platform_version,
+                )
+                .expect("expected to add identity");
+
+            let nonce = drive
+                .fetch_identity_nonce(identity.id().to_buffer(), true, None, platform_version)
+                .expect("should not error")
+                .expect("should have nonce");
+
+            // New identity should have nonce 0
+            assert_eq!(nonce, 0);
+        }
+
+        #[test]
+        fn should_return_updated_nonce_after_merge() {
+            let drive = setup_drive_with_initial_state_structure(None);
+            let platform_version = PlatformVersion::latest();
+
+            let identity = Identity::random_identity(3, Some(42), platform_version)
+                .expect("expected a random identity");
+
+            drive
+                .add_new_identity(
+                    identity.clone(),
+                    false,
+                    &BlockInfo::default(),
+                    true,
+                    None,
+                    platform_version,
+                )
+                .expect("expected to add identity");
+
+            // Merge nonce to update it
+            drive
+                .merge_identity_nonce(
+                    identity.id().to_buffer(),
+                    1,
+                    &BlockInfo::default(),
+                    true,
+                    None,
+                    platform_version,
+                )
+                .expect("expected to merge nonce");
+
+            let nonce = drive
+                .fetch_identity_nonce(identity.id().to_buffer(), true, None, platform_version)
+                .expect("should not error")
+                .expect("should have nonce");
+
+            // After merging nonce 1, the nonce value should contain 1
+            // The nonce encoding includes missing revision bits, so just check it's nonzero
+            assert!(nonce > 0);
+        }
+
+        #[test]
+        fn should_return_nonce_with_fees() {
+            let drive = setup_drive_with_initial_state_structure(None);
+            let platform_version = PlatformVersion::latest();
+
+            let identity = Identity::random_identity(3, Some(42), platform_version)
+                .expect("expected a random identity");
+
+            drive
+                .add_new_identity(
+                    identity.clone(),
+                    false,
+                    &BlockInfo::default(),
+                    true,
+                    None,
+                    platform_version,
+                )
+                .expect("expected to add identity");
+
+            let block_info = BlockInfo::default();
+
+            let (nonce, fee_result) = drive
+                .fetch_identity_nonce_with_fees(
+                    identity.id().to_buffer(),
+                    &block_info,
+                    true,
+                    None,
+                    platform_version,
+                )
+                .expect("should not error");
+
+            assert_eq!(nonce, Some(0));
+            assert!(fee_result.processing_fee > 0);
+        }
+    }
+}

--- a/packages/rs-drive/src/drive/identity/fetch/partial_identity/mod.rs
+++ b/packages/rs-drive/src/drive/identity/fetch/partial_identity/mod.rs
@@ -3,3 +3,370 @@ mod fetch_identity_balance_with_keys_and_revision;
 mod fetch_identity_keys;
 mod fetch_identity_revision_with_keys;
 mod fetch_identity_with_balance;
+
+#[cfg(feature = "server")]
+#[cfg(test)]
+mod tests {
+    use crate::drive::identity::key::fetch::{IdentityKeysRequest, KeyRequestType};
+    use crate::util::test_helpers::setup::setup_drive_with_initial_state_structure;
+    use dpp::block::block_info::BlockInfo;
+    use dpp::identity::accessors::IdentityGettersV0;
+    use dpp::identity::Identity;
+    use dpp::version::PlatformVersion;
+
+    mod fetch_identity_with_balance {
+        use super::*;
+
+        #[test]
+        fn should_return_none_for_non_existent_identity() {
+            let drive = setup_drive_with_initial_state_structure(None);
+            let platform_version = PlatformVersion::latest();
+
+            let result = drive
+                .fetch_identity_with_balance([0; 32], None, platform_version)
+                .expect("should not error");
+
+            assert!(result.is_none());
+        }
+
+        #[test]
+        fn should_return_partial_identity_with_balance() {
+            let drive = setup_drive_with_initial_state_structure(None);
+            let platform_version = PlatformVersion::latest();
+
+            let identity = Identity::random_identity(3, Some(42), platform_version)
+                .expect("expected a random identity");
+
+            let expected_balance = identity.balance();
+
+            drive
+                .add_new_identity(
+                    identity.clone(),
+                    false,
+                    &BlockInfo::default(),
+                    true,
+                    None,
+                    platform_version,
+                )
+                .expect("expected to add identity");
+
+            let partial = drive
+                .fetch_identity_with_balance(identity.id().to_buffer(), None, platform_version)
+                .expect("should not error")
+                .expect("should have partial identity");
+
+            assert_eq!(partial.id, identity.id().clone());
+            assert_eq!(partial.balance, Some(expected_balance));
+            assert!(partial.loaded_public_keys.is_empty());
+            assert!(partial.revision.is_none());
+        }
+
+        #[test]
+        fn should_return_none_with_cost_when_not_applying() {
+            let drive = setup_drive_with_initial_state_structure(None);
+            let platform_version = PlatformVersion::latest();
+
+            let (partial, fee_result) = drive
+                .fetch_identity_with_balance_with_cost([0; 32], false, None, platform_version)
+                .expect("should not error");
+
+            assert!(partial.is_none());
+            assert!(fee_result.processing_fee > 0);
+        }
+    }
+
+    mod fetch_identity_balance_with_keys {
+        use super::*;
+
+        #[test]
+        fn should_return_none_for_non_existent_identity() {
+            let drive = setup_drive_with_initial_state_structure(None);
+            let platform_version = PlatformVersion::latest();
+
+            let key_request = IdentityKeysRequest {
+                identity_id: [0; 32],
+                request_type: KeyRequestType::AllKeys,
+                limit: None,
+                offset: None,
+            };
+
+            let result = drive
+                .fetch_identity_balance_with_keys(key_request, None, platform_version)
+                .expect("should not error");
+
+            assert!(result.is_none());
+        }
+
+        #[test]
+        fn should_return_partial_identity_with_balance_and_keys() {
+            let drive = setup_drive_with_initial_state_structure(None);
+            let platform_version = PlatformVersion::latest();
+
+            let identity = Identity::random_identity(3, Some(42), platform_version)
+                .expect("expected a random identity");
+
+            drive
+                .add_new_identity(
+                    identity.clone(),
+                    false,
+                    &BlockInfo::default(),
+                    true,
+                    None,
+                    platform_version,
+                )
+                .expect("expected to add identity");
+
+            let key_request = IdentityKeysRequest {
+                identity_id: identity.id().to_buffer(),
+                request_type: KeyRequestType::AllKeys,
+                limit: None,
+                offset: None,
+            };
+
+            let partial = drive
+                .fetch_identity_balance_with_keys(key_request, None, platform_version)
+                .expect("should not error")
+                .expect("should have partial identity");
+
+            assert_eq!(partial.id, identity.id().clone());
+            assert_eq!(partial.balance, Some(identity.balance()));
+            assert_eq!(partial.loaded_public_keys.len(), 3);
+            assert!(partial.revision.is_none());
+        }
+
+        #[test]
+        fn should_return_partial_identity_with_specific_keys() {
+            let drive = setup_drive_with_initial_state_structure(None);
+            let platform_version = PlatformVersion::latest();
+
+            let identity = Identity::random_identity(5, Some(42), platform_version)
+                .expect("expected a random identity");
+
+            drive
+                .add_new_identity(
+                    identity.clone(),
+                    false,
+                    &BlockInfo::default(),
+                    true,
+                    None,
+                    platform_version,
+                )
+                .expect("expected to add identity");
+
+            let key_request = IdentityKeysRequest {
+                identity_id: identity.id().to_buffer(),
+                request_type: KeyRequestType::SpecificKeys(vec![0, 1]),
+                limit: Some(2),
+                offset: None,
+            };
+
+            let partial = drive
+                .fetch_identity_balance_with_keys(key_request, None, platform_version)
+                .expect("should not error")
+                .expect("should have partial identity");
+
+            assert_eq!(partial.loaded_public_keys.len(), 2);
+            assert!(partial.loaded_public_keys.contains_key(&0));
+            assert!(partial.loaded_public_keys.contains_key(&1));
+        }
+
+        #[test]
+        fn should_track_not_found_keys() {
+            let drive = setup_drive_with_initial_state_structure(None);
+            let platform_version = PlatformVersion::latest();
+
+            let identity = Identity::random_identity(3, Some(42), platform_version)
+                .expect("expected a random identity");
+
+            drive
+                .add_new_identity(
+                    identity.clone(),
+                    false,
+                    &BlockInfo::default(),
+                    true,
+                    None,
+                    platform_version,
+                )
+                .expect("expected to add identity");
+
+            // Request key id 99 which does not exist
+            let key_request = IdentityKeysRequest {
+                identity_id: identity.id().to_buffer(),
+                request_type: KeyRequestType::SpecificKeys(vec![0, 99]),
+                limit: Some(2),
+                offset: None,
+            };
+
+            let partial = drive
+                .fetch_identity_balance_with_keys(key_request, None, platform_version)
+                .expect("should not error")
+                .expect("should have partial identity");
+
+            assert_eq!(partial.loaded_public_keys.len(), 1);
+            assert!(partial.loaded_public_keys.contains_key(&0));
+            assert_eq!(partial.not_found_public_keys.len(), 1);
+            assert!(partial.not_found_public_keys.contains(&99));
+        }
+    }
+
+    mod fetch_identity_balance_with_keys_and_revision {
+        use super::*;
+
+        #[test]
+        fn should_return_none_for_non_existent_identity() {
+            let drive = setup_drive_with_initial_state_structure(None);
+            let platform_version = PlatformVersion::latest();
+
+            let key_request = IdentityKeysRequest {
+                identity_id: [0; 32],
+                request_type: KeyRequestType::AllKeys,
+                limit: None,
+                offset: None,
+            };
+
+            let result = drive
+                .fetch_identity_balance_with_keys_and_revision(key_request, None, platform_version)
+                .expect("should not error");
+
+            assert!(result.is_none());
+        }
+
+        #[test]
+        fn should_return_partial_identity_with_balance_keys_and_revision() {
+            let drive = setup_drive_with_initial_state_structure(None);
+            let platform_version = PlatformVersion::latest();
+
+            let identity = Identity::random_identity(3, Some(42), platform_version)
+                .expect("expected a random identity");
+
+            drive
+                .add_new_identity(
+                    identity.clone(),
+                    false,
+                    &BlockInfo::default(),
+                    true,
+                    None,
+                    platform_version,
+                )
+                .expect("expected to add identity");
+
+            let key_request = IdentityKeysRequest {
+                identity_id: identity.id().to_buffer(),
+                request_type: KeyRequestType::AllKeys,
+                limit: None,
+                offset: None,
+            };
+
+            let partial = drive
+                .fetch_identity_balance_with_keys_and_revision(key_request, None, platform_version)
+                .expect("should not error")
+                .expect("should have partial identity");
+
+            assert_eq!(partial.id, identity.id().clone());
+            assert_eq!(partial.balance, Some(identity.balance()));
+            assert_eq!(partial.revision, Some(identity.revision()));
+            assert_eq!(partial.loaded_public_keys.len(), 3);
+        }
+    }
+
+    mod fetch_identity_revision_with_keys {
+        use super::*;
+
+        #[test]
+        fn should_return_none_for_non_existent_identity() {
+            let drive = setup_drive_with_initial_state_structure(None);
+            let platform_version = PlatformVersion::latest();
+
+            let key_request = IdentityKeysRequest {
+                identity_id: [0; 32],
+                request_type: KeyRequestType::AllKeys,
+                limit: None,
+                offset: None,
+            };
+
+            let result = drive
+                .fetch_identity_revision_with_keys(key_request, None, platform_version)
+                .expect("should not error");
+
+            assert!(result.is_none());
+        }
+
+        #[test]
+        fn should_return_partial_identity_with_revision_and_keys() {
+            let drive = setup_drive_with_initial_state_structure(None);
+            let platform_version = PlatformVersion::latest();
+
+            let identity = Identity::random_identity(3, Some(42), platform_version)
+                .expect("expected a random identity");
+
+            drive
+                .add_new_identity(
+                    identity.clone(),
+                    false,
+                    &BlockInfo::default(),
+                    true,
+                    None,
+                    platform_version,
+                )
+                .expect("expected to add identity");
+
+            let key_request = IdentityKeysRequest {
+                identity_id: identity.id().to_buffer(),
+                request_type: KeyRequestType::AllKeys,
+                limit: None,
+                offset: None,
+            };
+
+            let partial = drive
+                .fetch_identity_revision_with_keys(key_request, None, platform_version)
+                .expect("should not error")
+                .expect("should have partial identity");
+
+            assert_eq!(partial.id, identity.id().clone());
+            assert!(partial.balance.is_none());
+            assert_eq!(partial.revision, Some(identity.revision()));
+            assert_eq!(partial.loaded_public_keys.len(), 3);
+        }
+    }
+
+    mod fetch_identity_keys_as_partial_identity {
+        use super::*;
+
+        #[test]
+        fn should_return_partial_identity_with_only_keys() {
+            let drive = setup_drive_with_initial_state_structure(None);
+            let platform_version = PlatformVersion::latest();
+
+            let identity = Identity::random_identity(5, Some(42), platform_version)
+                .expect("expected a random identity");
+
+            drive
+                .add_new_identity(
+                    identity.clone(),
+                    false,
+                    &BlockInfo::default(),
+                    true,
+                    None,
+                    platform_version,
+                )
+                .expect("expected to add identity");
+
+            let key_request = IdentityKeysRequest {
+                identity_id: identity.id().to_buffer(),
+                request_type: KeyRequestType::AllKeys,
+                limit: None,
+                offset: None,
+            };
+
+            let partial = drive
+                .fetch_identity_keys_as_partial_identity(key_request, None, platform_version)
+                .expect("should not error")
+                .expect("should have partial identity");
+
+            assert_eq!(partial.id, identity.id().clone());
+            assert!(partial.balance.is_none());
+            assert!(partial.revision.is_none());
+            assert_eq!(partial.loaded_public_keys.len(), 5);
+        }
+    }
+}

--- a/packages/rs-drive/src/drive/identity/fetch/revision/mod.rs
+++ b/packages/rs-drive/src/drive/identity/fetch/revision/mod.rs
@@ -1,1 +1,133 @@
 mod fetch_identity_revision;
+
+#[cfg(feature = "server")]
+#[cfg(test)]
+mod tests {
+    use crate::util::test_helpers::setup::setup_drive_with_initial_state_structure;
+    use dpp::block::block_info::BlockInfo;
+    use dpp::identity::accessors::IdentityGettersV0;
+    use dpp::identity::Identity;
+    use dpp::version::PlatformVersion;
+
+    mod fetch_identity_revision {
+        use super::*;
+
+        #[test]
+        fn should_return_none_for_non_existent_identity() {
+            let drive = setup_drive_with_initial_state_structure(None);
+            let platform_version = PlatformVersion::latest();
+
+            let revision = drive
+                .fetch_identity_revision([0; 32], true, None, platform_version)
+                .expect("should not error");
+
+            assert!(revision.is_none());
+        }
+
+        #[test]
+        fn should_return_initial_revision_for_new_identity() {
+            let drive = setup_drive_with_initial_state_structure(None);
+            let platform_version = PlatformVersion::latest();
+
+            let identity = Identity::random_identity(3, Some(42), platform_version)
+                .expect("expected a random identity");
+
+            let expected_revision = identity.revision();
+
+            drive
+                .add_new_identity(
+                    identity.clone(),
+                    false,
+                    &BlockInfo::default(),
+                    true,
+                    None,
+                    platform_version,
+                )
+                .expect("expected to add identity");
+
+            let revision = drive
+                .fetch_identity_revision(identity.id().to_buffer(), true, None, platform_version)
+                .expect("should not error")
+                .expect("should have revision");
+
+            assert_eq!(revision, expected_revision);
+        }
+
+        #[test]
+        fn should_return_updated_revision_after_update() {
+            let drive = setup_drive_with_initial_state_structure(None);
+            let platform_version = PlatformVersion::latest();
+
+            let identity = Identity::random_identity(3, Some(42), platform_version)
+                .expect("expected a random identity");
+
+            drive
+                .add_new_identity(
+                    identity.clone(),
+                    false,
+                    &BlockInfo::default(),
+                    true,
+                    None,
+                    platform_version,
+                )
+                .expect("expected to add identity");
+
+            let new_revision = 5;
+            let block_info = BlockInfo::default();
+
+            drive
+                .update_identity_revision(
+                    identity.id().to_buffer(),
+                    new_revision,
+                    &block_info,
+                    true,
+                    None,
+                    platform_version,
+                    None,
+                )
+                .expect("expected to update revision");
+
+            let revision = drive
+                .fetch_identity_revision(identity.id().to_buffer(), true, None, platform_version)
+                .expect("should not error")
+                .expect("should have revision");
+
+            assert_eq!(revision, new_revision);
+        }
+
+        #[test]
+        fn should_return_revision_with_fees() {
+            let drive = setup_drive_with_initial_state_structure(None);
+            let platform_version = PlatformVersion::latest();
+
+            let identity = Identity::random_identity(3, Some(42), platform_version)
+                .expect("expected a random identity");
+
+            drive
+                .add_new_identity(
+                    identity.clone(),
+                    false,
+                    &BlockInfo::default(),
+                    true,
+                    None,
+                    platform_version,
+                )
+                .expect("expected to add identity");
+
+            let block_info = BlockInfo::default();
+
+            let (revision, fee_result) = drive
+                .fetch_identity_revision_with_fees(
+                    identity.id().to_buffer(),
+                    &block_info,
+                    true,
+                    None,
+                    platform_version,
+                )
+                .expect("should not error");
+
+            assert_eq!(revision, Some(identity.revision()));
+            assert!(fee_result.processing_fee > 0);
+        }
+    }
+}

--- a/packages/rs-drive/src/drive/identity/insert/add_new_identity/mod.rs
+++ b/packages/rs-drive/src/drive/identity/insert/add_new_identity/mod.rs
@@ -225,4 +225,99 @@ mod tests {
         }
         assert_eq!(fee_result, expected_fee_result);
     }
+
+    #[test]
+    fn should_fail_to_insert_duplicate_non_masternode_identity() {
+        use crate::error::identity::IdentityError;
+        use crate::error::Error;
+
+        let platform_version = PlatformVersion::latest();
+        let drive = setup_drive(None);
+
+        let transaction = drive.grove.start_transaction();
+
+        drive
+            .create_initial_state_structure(Some(&transaction), platform_version)
+            .expect("expected to create root tree successfully");
+
+        let identity = Identity::random_identity(5, Some(12345), platform_version)
+            .expect("expected a random identity");
+
+        // Insert the identity the first time
+        drive
+            .add_new_identity(
+                identity.clone(),
+                false,
+                &BlockInfo::default(),
+                true,
+                Some(&transaction),
+                platform_version,
+            )
+            .expect("expected to insert identity");
+
+        // Inserting the same non-masternode identity again should fail
+        let result = drive.add_new_identity(
+            identity,
+            false,
+            &BlockInfo::default(),
+            true,
+            Some(&transaction),
+            platform_version,
+        );
+
+        assert!(matches!(
+            result,
+            Err(Error::Identity(IdentityError::IdentityAlreadyExists(_)))
+        ));
+    }
+
+    #[test]
+    fn should_succeed_reinserting_masternode_identity() {
+        let platform_version = PlatformVersion::latest();
+        let drive = setup_drive(None);
+
+        let transaction = drive.grove.start_transaction();
+
+        drive
+            .create_initial_state_structure(Some(&transaction), platform_version)
+            .expect("expected to create root tree successfully");
+
+        let identity = Identity::random_identity(5, Some(12345), platform_version)
+            .expect("expected a random identity");
+
+        // Insert as masternode identity
+        drive
+            .add_new_identity(
+                identity.clone(),
+                true,
+                &BlockInfo::default(),
+                true,
+                Some(&transaction),
+                platform_version,
+            )
+            .expect("expected to insert identity");
+
+        // Reinserting the same masternode identity should succeed (re-enable keys)
+        let result = drive.add_new_identity(
+            identity.clone(),
+            true,
+            &BlockInfo::default(),
+            true,
+            Some(&transaction),
+            platform_version,
+        );
+
+        assert!(result.is_ok());
+
+        // Verify keys are still present after reinsertion
+        let fetched_keys = drive
+            .fetch_all_identity_keys(
+                identity.id().to_buffer(),
+                Some(&transaction),
+                platform_version,
+            )
+            .expect("expected to fetch keys");
+
+        assert_eq!(fetched_keys.len(), 5);
+    }
 }

--- a/packages/rs-drive/src/drive/identity/mod.rs
+++ b/packages/rs-drive/src/drive/identity/mod.rs
@@ -417,3 +417,161 @@ impl From<IdentityRootStructure> for &'static [u8; 1] {
         }
     }
 }
+
+#[cfg(all(test, any(feature = "server", feature = "verify")))]
+mod tests {
+    use super::*;
+
+    mod identity_root_structure {
+        use super::*;
+
+        #[test]
+        fn should_convert_from_valid_u8_values() {
+            assert!(matches!(
+                IdentityRootStructure::try_from(192u8),
+                Ok(IdentityRootStructure::IdentityTreeRevision)
+            ));
+            assert!(matches!(
+                IdentityRootStructure::try_from(64u8),
+                Ok(IdentityRootStructure::IdentityTreeNonce)
+            ));
+            assert!(matches!(
+                IdentityRootStructure::try_from(128u8),
+                Ok(IdentityRootStructure::IdentityTreeKeys)
+            ));
+            assert!(matches!(
+                IdentityRootStructure::try_from(160u8),
+                Ok(IdentityRootStructure::IdentityTreeKeyReferences)
+            ));
+            assert!(matches!(
+                IdentityRootStructure::try_from(96u8),
+                Ok(IdentityRootStructure::IdentityTreeNegativeCredit)
+            ));
+            assert!(matches!(
+                IdentityRootStructure::try_from(32u8),
+                Ok(IdentityRootStructure::IdentityContractInfo)
+            ));
+        }
+
+        #[test]
+        fn should_fail_for_invalid_u8_value() {
+            let result = IdentityRootStructure::try_from(0u8);
+            assert!(result.is_err());
+            let result = IdentityRootStructure::try_from(1u8);
+            assert!(result.is_err());
+            let result = IdentityRootStructure::try_from(255u8);
+            assert!(result.is_err());
+        }
+
+        #[test]
+        fn should_display_correct_names() {
+            assert_eq!(
+                format!("{}", IdentityRootStructure::IdentityTreeRevision),
+                "Revision"
+            );
+            assert_eq!(
+                format!("{}", IdentityRootStructure::IdentityTreeNonce),
+                "Nonce"
+            );
+            assert_eq!(
+                format!("{}", IdentityRootStructure::IdentityTreeKeys),
+                "IdentityKeys"
+            );
+            assert_eq!(
+                format!("{}", IdentityRootStructure::IdentityTreeKeyReferences),
+                "IdentityKeyReferences"
+            );
+            assert_eq!(
+                format!("{}", IdentityRootStructure::IdentityTreeNegativeCredit),
+                "NegativeCredit"
+            );
+            assert_eq!(
+                format!("{}", IdentityRootStructure::IdentityContractInfo),
+                "ContractInfo"
+            );
+        }
+
+        #[test]
+        fn should_convert_to_u8() {
+            let val: u8 = IdentityRootStructure::IdentityTreeRevision.into();
+            assert_eq!(val, 192);
+            let val: u8 = IdentityRootStructure::IdentityTreeNonce.into();
+            assert_eq!(val, 64);
+            let val: u8 = IdentityRootStructure::IdentityTreeKeys.into();
+            assert_eq!(val, 128);
+        }
+
+        #[test]
+        fn should_convert_to_u8_array() {
+            let val: [u8; 1] = IdentityRootStructure::IdentityTreeRevision.into();
+            assert_eq!(val, [192]);
+            let val: [u8; 1] = IdentityRootStructure::IdentityTreeNonce.into();
+            assert_eq!(val, [64]);
+        }
+
+        #[test]
+        fn should_convert_to_static_u8_array_ref() {
+            let val: &'static [u8; 1] = IdentityRootStructure::IdentityTreeRevision.into();
+            assert_eq!(val, &[192]);
+            let val: &'static [u8; 1] = IdentityRootStructure::IdentityContractInfo.into();
+            assert_eq!(val, &[32]);
+        }
+    }
+
+    mod identity_path_functions {
+        use super::*;
+
+        #[test]
+        fn should_create_correct_identity_path() {
+            let id = [1u8; 32];
+            let path = identity_path(&id);
+            assert_eq!(path.len(), 2);
+            assert_eq!(path[1], &id);
+        }
+
+        #[test]
+        fn should_create_correct_identity_path_vec() {
+            let id = [2u8; 32];
+            let path = identity_path_vec(&id);
+            assert_eq!(path.len(), 2);
+            assert_eq!(path[1], id.to_vec());
+        }
+
+        #[test]
+        fn should_create_correct_key_tree_path() {
+            let id = [3u8; 32];
+            let path = identity_key_tree_path(&id);
+            assert_eq!(path.len(), 3);
+            assert_eq!(path[1], &id);
+            assert_eq!(path[2], &[IdentityRootStructure::IdentityTreeKeys as u8]);
+        }
+
+        #[test]
+        fn should_create_correct_key_tree_path_vec() {
+            let id = [4u8; 32];
+            let path = identity_key_tree_path_vec(&id);
+            assert_eq!(path.len(), 3);
+            assert_eq!(path[1], id.to_vec());
+            assert_eq!(path[2], vec![IdentityRootStructure::IdentityTreeKeys as u8]);
+        }
+
+        #[cfg(feature = "server")]
+        #[test]
+        fn should_create_correct_contract_info_root_path() {
+            let id = [5u8; 32];
+            let path = identity_contract_info_root_path(&id);
+            assert_eq!(path.len(), 3);
+            assert_eq!(path[1], &id);
+        }
+
+        #[test]
+        fn should_create_correct_contract_info_group_path() {
+            let id = [6u8; 32];
+            let group_id = [7u8; 32];
+            let path = identity_contract_info_group_path(&id, &group_id);
+            assert_eq!(path.len(), 4);
+            assert_eq!(path[1], &id);
+            assert_eq!(path[3], &group_id);
+        }
+    }
+}


### PR DESCRIPTION
## Issue being fixed or feature implemented

Addresses review comments from PR #3333 (drive document tests) to improve assertion coverage and fix test correctness issues.

## What was done?

1. **HIGH: test_add_document_with_history** — Added fetch-back verification: both history-keeping documents are queried and their `firstName` values asserted ("Samuel", "Tom")
2. **HIGH: Update tests don't verify update took effect** — Both `test_update_document_with_serialization_for_contract` and `test_update_document_for_contract_id` now fetch the document after update and assert `displayName == "Bob"`
3. **MEDIUM: Estimated delete doesn't verify document survives** — `test_delete_document_for_contract_id_estimated_costs` now queries the document after the dry-run delete and asserts it still exists
4. **MEDIUM: No assertions on batch insertion** — `test_add_document_for_contract_with_non_unique_batch` now fetches both documents after insertion and asserts count == 2
5. **MEDIUM: Tests operations on non-existent documents** — `test_add_update_multiple_documents_operations` now inserts both documents before calling `add_update_multiple_documents_operations`
6. **LOW: Bare .unwrap() on increment_revision()** — Replaced with `.expect("document should have a revision to increment")` in both update tests
7. **NIT: Unused variable _platform_version** — Removed the unused binding in `test_query_documents_dry_run`
8. **LOW: test_add_document_by_contract_id doesn't verify content** — Added fetch-back and assertion that `displayName == "sam"` (matching profile0.json)

## How Has This Been Tested?

```
cargo fmt --package drive -- --check   # clean
cargo test --package drive -- drive::document   # 70 tests pass
```

## Breaking Changes

None.

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [x] I have made corresponding changes to the documentation if needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)