### PR TITLE
ci: exclude error type definitions from code coverage

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -19,6 +19,11 @@ ignore:
   - "packages/wasm-sdk/**"
   - "**/block_end/validator_set_update/v0/**"
   - "**/block_end/validator_set_update/v1/**"
+  # Error type definitions — these are enum/struct declarations with Display/thiserror
+  # derives, not logic that needs test coverage
+  - "packages/rs-drive/src/error/**"
+  - "packages/rs-drive-abci/src/error/**"
+  - "packages/rs-dpp/src/errors/**"
 
 coverage:
   status:


### PR DESCRIPTION
## Summary
- Exclude error modules from Codecov tracking — they contain enum/struct declarations with `Display`/`thiserror` derives, not business logic
- Gives a more accurate picture of actual logic coverage

Excluded:
- `packages/rs-drive/src/error/**`
- `packages/rs-drive-abci/src/error/**`
- `packages/rs-dpp/src/errors/**`

## Test plan
- [ ] Verify overall coverage % increases after merge (fewer tracked lines, same hits)

🤖 Generated with [Claude Code](https://claude.com/claude-code)