### PR TITLE
docs(rs-sdk-ffi): document catch_unwind rationale at FFI boundaries

### DIFF
--- a/packages/rs-sdk-ffi/src/address/queries/balance_changes.rs
+++ b/packages/rs-sdk-ffi/src/address/queries/balance_changes.rs
@@ -34,7 +34,11 @@ pub unsafe extern "C" fn dash_sdk_address_fetch_recent_balance_changes(
     sdk_handle: *const SDKHandle,
     start_height: u64,
 ) -> DashSDKResult {
-    // Wrap the entire function in catch_unwind to prevent panics from crashing the app
+    // SAFETY: catch_unwind is kept intentionally despite `panic = "abort"` in the release profile.
+    // With panic=abort, catch_unwind is optimized away (zero cost). But keeping it:
+    // 1. Acts as a safety net if the panic strategy is ever changed (e.g., for debugging)
+    // 2. Documents the intent that panics must not cross this FFI boundary
+    // 3. Follows defense-in-depth for FFI safety
     let result = panic::catch_unwind(AssertUnwindSafe(|| {
         dash_sdk_address_fetch_recent_balance_changes_inner(sdk_handle, start_height)
     }));

--- a/packages/rs-sdk-ffi/src/address/queries/branch_state.rs
+++ b/packages/rs-sdk-ffi/src/address/queries/branch_state.rs
@@ -43,7 +43,11 @@ pub unsafe extern "C" fn dash_sdk_address_fetch_branch_state(
     expected_hash: *const u8,
     checkpoint_height: u64,
 ) -> DashSDKResult {
-    // Wrap the entire function in catch_unwind to prevent panics from crashing the app
+    // SAFETY: catch_unwind is kept intentionally despite `panic = "abort"` in the release profile.
+    // With panic=abort, catch_unwind is optimized away (zero cost). But keeping it:
+    // 1. Acts as a safety net if the panic strategy is ever changed (e.g., for debugging)
+    // 2. Documents the intent that panics must not cross this FFI boundary
+    // 3. Follows defense-in-depth for FFI safety
     let result = panic::catch_unwind(AssertUnwindSafe(|| {
         dash_sdk_address_fetch_branch_state_inner(
             sdk_handle,

--- a/packages/rs-sdk-ffi/src/address/queries/compacted_balance_changes.rs
+++ b/packages/rs-sdk-ffi/src/address/queries/compacted_balance_changes.rs
@@ -34,7 +34,11 @@ pub unsafe extern "C" fn dash_sdk_address_fetch_compacted_balance_changes(
     sdk_handle: *const SDKHandle,
     start_block_height: u64,
 ) -> DashSDKResult {
-    // Wrap the entire function in catch_unwind to prevent panics from crashing the app
+    // SAFETY: catch_unwind is kept intentionally despite `panic = "abort"` in the release profile.
+    // With panic=abort, catch_unwind is optimized away (zero cost). But keeping it:
+    // 1. Acts as a safety net if the panic strategy is ever changed (e.g., for debugging)
+    // 2. Documents the intent that panics must not cross this FFI boundary
+    // 3. Follows defense-in-depth for FFI safety
     let result = panic::catch_unwind(AssertUnwindSafe(|| {
         dash_sdk_address_fetch_compacted_balance_changes_inner(sdk_handle, start_block_height)
     }));

--- a/packages/rs-sdk-ffi/src/address/queries/info.rs
+++ b/packages/rs-sdk-ffi/src/address/queries/info.rs
@@ -29,7 +29,11 @@ pub unsafe extern "C" fn dash_sdk_address_fetch_info(
     address_bytes: *const u8,
     address_len: usize,
 ) -> DashSDKResult {
-    // Wrap the entire function in catch_unwind to prevent panics from crashing the app
+    // SAFETY: catch_unwind is kept intentionally despite `panic = "abort"` in the release profile.
+    // With panic=abort, catch_unwind is optimized away (zero cost). But keeping it:
+    // 1. Acts as a safety net if the panic strategy is ever changed (e.g., for debugging)
+    // 2. Documents the intent that panics must not cross this FFI boundary
+    // 3. Follows defense-in-depth for FFI safety
     let result = panic::catch_unwind(AssertUnwindSafe(|| {
         dash_sdk_address_fetch_info_inner(sdk_handle, address_bytes, address_len)
     }));

--- a/packages/rs-sdk-ffi/src/address/queries/infos.rs
+++ b/packages/rs-sdk-ffi/src/address/queries/infos.rs
@@ -35,7 +35,11 @@ pub unsafe extern "C" fn dash_sdk_addresses_fetch_infos(
     address_lengths: *const usize,
     addresses_count: usize,
 ) -> DashSDKResult {
-    // Wrap the entire function in catch_unwind to prevent panics from crashing the app
+    // SAFETY: catch_unwind is kept intentionally despite `panic = "abort"` in the release profile.
+    // With panic=abort, catch_unwind is optimized away (zero cost). But keeping it:
+    // 1. Acts as a safety net if the panic strategy is ever changed (e.g., for debugging)
+    // 2. Documents the intent that panics must not cross this FFI boundary
+    // 3. Follows defense-in-depth for FFI safety
     let result = panic::catch_unwind(AssertUnwindSafe(|| {
         dash_sdk_addresses_fetch_infos_inner(
             sdk_handle,

--- a/packages/rs-sdk-ffi/src/address/queries/trunk_state.rs
+++ b/packages/rs-sdk-ffi/src/address/queries/trunk_state.rs
@@ -27,7 +27,11 @@ use crate::{DashSDKError, DashSDKErrorCode, DashSDKResult, FFIError};
 pub unsafe extern "C" fn dash_sdk_address_fetch_trunk_state(
     sdk_handle: *const SDKHandle,
 ) -> DashSDKResult {
-    // Wrap the entire function in catch_unwind to prevent panics from crashing the app
+    // SAFETY: catch_unwind is kept intentionally despite `panic = "abort"` in the release profile.
+    // With panic=abort, catch_unwind is optimized away (zero cost). But keeping it:
+    // 1. Acts as a safety net if the panic strategy is ever changed (e.g., for debugging)
+    // 2. Documents the intent that panics must not cross this FFI boundary
+    // 3. Follows defense-in-depth for FFI safety
     let result = panic::catch_unwind(AssertUnwindSafe(|| {
         dash_sdk_address_fetch_trunk_state_inner(sdk_handle)
     }));

--- a/packages/rs-sdk-ffi/src/address/transitions/top_up_from_asset_lock.rs
+++ b/packages/rs-sdk-ffi/src/address/transitions/top_up_from_asset_lock.rs
@@ -73,7 +73,11 @@ pub unsafe extern "C" fn dash_sdk_address_top_up_from_asset_lock(
     fee_from_input_index: u16,
     put_settings: *const DashSDKPutSettings,
 ) -> DashSDKResult {
-    // Wrap in catch_unwind for panic safety
+    // SAFETY: catch_unwind is kept intentionally despite `panic = "abort"` in the release profile.
+    // With panic=abort, catch_unwind is optimized away (zero cost). But keeping it:
+    // 1. Acts as a safety net if the panic strategy is ever changed (e.g., for debugging)
+    // 2. Documents the intent that panics must not cross this FFI boundary
+    // 3. Follows defense-in-depth for FFI safety
     let result = panic::catch_unwind(AssertUnwindSafe(|| {
         dash_sdk_address_top_up_from_asset_lock_inner(
             sdk_handle,

--- a/packages/rs-sdk-ffi/src/address/transitions/transfer.rs
+++ b/packages/rs-sdk-ffi/src/address/transitions/transfer.rs
@@ -126,7 +126,11 @@ pub unsafe extern "C" fn dash_sdk_address_transfer_funds(
     outputs_count: usize,
     fee_from_input_index: u16,
 ) -> DashSDKResult {
-    // Wrap in catch_unwind for panic safety
+    // SAFETY: catch_unwind is kept intentionally despite `panic = "abort"` in the release profile.
+    // With panic=abort, catch_unwind is optimized away (zero cost). But keeping it:
+    // 1. Acts as a safety net if the panic strategy is ever changed (e.g., for debugging)
+    // 2. Documents the intent that panics must not cross this FFI boundary
+    // 3. Follows defense-in-depth for FFI safety
     let result = panic::catch_unwind(AssertUnwindSafe(|| {
         dash_sdk_address_transfer_funds_inner(
             sdk_handle,

--- a/packages/rs-sdk-ffi/src/address/transitions/withdraw.rs
+++ b/packages/rs-sdk-ffi/src/address/transitions/withdraw.rs
@@ -70,7 +70,11 @@ pub unsafe extern "C" fn dash_sdk_address_withdraw_funds(
     change_address: *const u8,
     change_address_len: usize,
 ) -> DashSDKResult {
-    // Wrap in catch_unwind for panic safety
+    // SAFETY: catch_unwind is kept intentionally despite `panic = "abort"` in the release profile.
+    // With panic=abort, catch_unwind is optimized away (zero cost). But keeping it:
+    // 1. Acts as a safety net if the panic strategy is ever changed (e.g., for debugging)
+    // 2. Documents the intent that panics must not cross this FFI boundary
+    // 3. Follows defense-in-depth for FFI safety
     let result = panic::catch_unwind(AssertUnwindSafe(|| {
         dash_sdk_address_withdraw_funds_inner(
             sdk_handle,

--- a/packages/rs-sdk-ffi/src/identity/create_from_addresses.rs
+++ b/packages/rs-sdk-ffi/src/identity/create_from_addresses.rs
@@ -57,7 +57,11 @@ pub unsafe extern "C" fn dash_sdk_identity_create_from_addresses(
     identity_signer_handle: *const crate::types::SignerHandle,
     put_settings: *const DashSDKPutSettings,
 ) -> DashSDKResult {
-    // Wrap in catch_unwind for panic safety
+    // SAFETY: catch_unwind is kept intentionally despite `panic = "abort"` in the release profile.
+    // With panic=abort, catch_unwind is optimized away (zero cost). But keeping it:
+    // 1. Acts as a safety net if the panic strategy is ever changed (e.g., for debugging)
+    // 2. Documents the intent that panics must not cross this FFI boundary
+    // 3. Follows defense-in-depth for FFI safety
     let result = panic::catch_unwind(AssertUnwindSafe(|| {
         dash_sdk_identity_create_from_addresses_inner(
             sdk_handle,

--- a/packages/rs-sdk-ffi/src/identity/top_up_from_addresses.rs
+++ b/packages/rs-sdk-ffi/src/identity/top_up_from_addresses.rs
@@ -51,7 +51,11 @@ pub unsafe extern "C" fn dash_sdk_identity_top_up_from_addresses(
     inputs_count: usize,
     put_settings: *const DashSDKPutSettings,
 ) -> DashSDKResult {
-    // Wrap in catch_unwind for panic safety
+    // SAFETY: catch_unwind is kept intentionally despite `panic = "abort"` in the release profile.
+    // With panic=abort, catch_unwind is optimized away (zero cost). But keeping it:
+    // 1. Acts as a safety net if the panic strategy is ever changed (e.g., for debugging)
+    // 2. Documents the intent that panics must not cross this FFI boundary
+    // 3. Follows defense-in-depth for FFI safety
     let result = panic::catch_unwind(AssertUnwindSafe(|| {
         dash_sdk_identity_top_up_from_addresses_inner(
             sdk_handle,

--- a/packages/rs-sdk-ffi/src/identity/transfer_to_addresses.rs
+++ b/packages/rs-sdk-ffi/src/identity/transfer_to_addresses.rs
@@ -52,7 +52,11 @@ pub unsafe extern "C" fn dash_sdk_identity_transfer_credits_to_addresses(
     signer_handle: *const crate::types::SignerHandle,
     put_settings: *const DashSDKPutSettings,
 ) -> DashSDKResult {
-    // Wrap in catch_unwind for panic safety
+    // SAFETY: catch_unwind is kept intentionally despite `panic = "abort"` in the release profile.
+    // With panic=abort, catch_unwind is optimized away (zero cost). But keeping it:
+    // 1. Acts as a safety net if the panic strategy is ever changed (e.g., for debugging)
+    // 2. Documents the intent that panics must not cross this FFI boundary
+    // 3. Follows defense-in-depth for FFI safety
     let result = panic::catch_unwind(AssertUnwindSafe(|| {
         dash_sdk_identity_transfer_credits_to_addresses_inner(
             sdk_handle,


### PR DESCRIPTION
## Summary
Add SAFETY comments to all `catch_unwind` usages in FFI entry points explaining why they are kept despite `panic = "abort"`:

1. **Safety net** — if panic strategy changes (e.g., for debugging), catch_unwind prevents UB at FFI boundary
2. **Documents intent** — clearly communicates panics must not cross FFI boundary
3. **Defense-in-depth** — redundant safety layers at FFI boundaries are a feature
4. **Zero cost** — compiler optimizes catch_unwind away with panic=abort

This prevents future audits from flagging these as dead code (see PR #3340).

## Test plan
- [x] No functional changes — comments only

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced internal safety documentation for FFI wrapper functions to clarify design rationale and defense-in-depth considerations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->