### PR TITLE
ci: allow Swift SDK build to run when Rust tests are skipped

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -201,7 +201,7 @@ jobs:
     needs:
       - changes
       - rs-workspace-tests
-    if: ${{ needs.changes.outputs.swift-sdk-changed == 'true' }}
+    if: ${{ always() && needs.changes.outputs.swift-sdk-changed == 'true' && needs.changes.result != 'failure' && needs.rs-workspace-tests.result != 'failure' }}
     secrets: inherit
     uses: ./.github/workflows/swift-sdk-build.yml
 


### PR DESCRIPTION
## Summary

- Fix Swift SDK build job being skipped when PRs only change Swift files (no Rust changes)

## Details

The `swift-sdk-build` job depends on `rs-workspace-tests`. When a PR only changes Swift files, `rs-workspace-tests` skips (no Rust changes detected). GitHub Actions propagates the skip to all downstream `needs` jobs, so Swift build never runs — even though `swift-sdk-changed` is `true`.

**Before**: Swift-only PRs like #3079 skip the Swift build entirely
**After**: Swift build runs when Rust tests skip or pass, blocks only on Rust test failure

The fix uses `always()` with explicit failure guards:
```yaml
if: >-
  always()
  && needs.changes.outputs.swift-sdk-changed == 'true'
  && needs.changes.result != 'failure'
  && needs.rs-workspace-tests.result != 'failure'
```

## Test plan
- [ ] Verify Swift-only PR triggers Swift SDK build
- [ ] Verify Rust+Swift PR still runs both jobs in order
- [ ] Verify Rust test failure still blocks Swift build

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test workflow gating conditions to improve build reliability. Updated logic to prevent unnecessary Swift SDK builds from executing when prior validation steps fail, resulting in more efficient pipeline execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->