### PR TITLE
test(rs-drive-proof-verifier): improve test coverage

### DIFF
--- a/packages/rs-drive-proof-verifier/src/error.rs
+++ b/packages/rs-drive-proof-verifier/src/error.rs
@@ -142,3 +142,180 @@ impl<O> MapGroveDbError<O> for Result<O, drive::error::Error> {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use drive::grovedb::{Error as GroveError, Query, SizedQuery};
+
+    /// Helper: build a minimal `Proof` with the given grovedb_proof bytes.
+    fn test_proof(grovedb_proof: Vec<u8>) -> Proof {
+        Proof {
+            grovedb_proof,
+            quorum_hash: vec![0u8; 32],
+            signature: vec![0u8; 96],
+            round: 1,
+            block_id_hash: vec![0u8; 32],
+            quorum_type: 1,
+        }
+    }
+
+    /// Helper: build a minimal `ResponseMetadata`.
+    fn test_metadata(height: u64, time_ms: u64) -> ResponseMetadata {
+        ResponseMetadata {
+            height,
+            core_chain_locked_height: 1,
+            epoch: 0,
+            time_ms,
+            protocol_version: 1,
+            chain_id: "test-chain".to_string(),
+        }
+    }
+
+    /// Helper: build a simple `PathQuery`.
+    fn test_path_query() -> PathQuery {
+        let query = Query::new();
+        let sized = SizedQuery::new(query, Some(10), None);
+        PathQuery::new(vec![vec![1, 2, 3]], sized)
+    }
+
+    #[test]
+    fn test_map_drive_error_ok_passes_through() {
+        let result: Result<u64, drive::error::Error> = Ok(42u64);
+        let proof = test_proof(vec![0xAA, 0xBB]);
+        let metadata = test_metadata(100, 5000);
+
+        let mapped = result.map_drive_error(&proof, &metadata);
+        assert_eq!(mapped.unwrap(), 42u64);
+    }
+
+    #[test]
+    fn test_map_drive_error_grovedb_invalid_proof() {
+        let pq = test_path_query();
+        let grove_err = GroveError::InvalidProof(pq.clone(), "bad proof data".to_string());
+        let drive_err = drive::error::Error::GroveDB(Box::new(grove_err));
+        let result: Result<u64, drive::error::Error> = Err(drive_err);
+
+        let proof_bytes = vec![0xDE, 0xAD];
+        let proof = test_proof(proof_bytes.clone());
+        let metadata = test_metadata(42, 9999);
+
+        let mapped = result.map_drive_error(&proof, &metadata);
+        let err = mapped.unwrap_err();
+
+        match err {
+            Error::GroveDBError {
+                proof_bytes: pb,
+                path_query: maybe_pq,
+                height,
+                time_ms,
+                error,
+            } => {
+                assert_eq!(pb, proof_bytes, "proof_bytes should match the input proof");
+                assert!(
+                    maybe_pq.is_some(),
+                    "path_query should be Some for InvalidProof"
+                );
+                assert_eq!(
+                    maybe_pq.unwrap(),
+                    pq,
+                    "path_query should match the original"
+                );
+                assert_eq!(height, 42);
+                assert_eq!(time_ms, 9999);
+                assert!(
+                    error.contains("bad proof data"),
+                    "error message should contain the original message, got: {error}"
+                );
+            }
+            other => panic!("expected GroveDBError, got: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_map_drive_error_grovedb_other() {
+        let grove_err = GroveError::InternalError("something broke".to_string());
+        let drive_err = drive::error::Error::GroveDB(Box::new(grove_err));
+        let result: Result<u64, drive::error::Error> = Err(drive_err);
+
+        let proof = test_proof(vec![0x01]);
+        let metadata = test_metadata(10, 2000);
+
+        let mapped = result.map_drive_error(&proof, &metadata);
+        let err = mapped.unwrap_err();
+
+        match err {
+            Error::GroveDBError {
+                path_query, error, ..
+            } => {
+                assert!(
+                    path_query.is_none(),
+                    "path_query should be None for non-InvalidProof GroveDB errors"
+                );
+                assert!(
+                    error.contains("something broke"),
+                    "error message should be preserved, got: {error}"
+                );
+            }
+            other => panic!("expected GroveDBError, got: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_map_drive_error_non_grovedb() {
+        let drive_err = drive::error::Error::Drive(
+            drive::error::drive::DriveError::CorruptedCodeExecution("test drive error"),
+        );
+        let result: Result<u64, drive::error::Error> = Err(drive_err);
+
+        let proof = test_proof(vec![]);
+        let metadata = test_metadata(1, 1);
+
+        let mapped = result.map_drive_error(&proof, &metadata);
+        let err = mapped.unwrap_err();
+
+        match err {
+            Error::DriveError { error } => {
+                assert!(
+                    error.contains("test drive error"),
+                    "error message should contain the original text, got: {error}"
+                );
+            }
+            other => panic!("expected DriveError, got: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_from_protocol_error() {
+        let protocol_err = ProtocolError::IdentifierError("bad id".to_string());
+        let err: Error = protocol_err.into();
+
+        match err {
+            Error::ProtocolError { error } => {
+                assert!(
+                    error.contains("bad id"),
+                    "error message should contain the original text, got: {error}"
+                );
+            }
+            other => panic!("expected ProtocolError, got: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_from_drive_error() {
+        let drive_err = drive::error::Error::Drive(
+            drive::error::drive::DriveError::CorruptedCodeExecution("from conversion test"),
+        );
+        let err: Error = drive_err.into();
+
+        match err {
+            Error::DriveError { error } => {
+                assert!(
+                    error.contains("from conversion test"),
+                    "error message should contain the original text, got: {error}"
+                );
+            }
+            other => panic!("expected DriveError, got: {other:?}"),
+        }
+    }
+}

--- a/packages/rs-drive-proof-verifier/src/from_request.rs
+++ b/packages/rs-drive-proof-verifier/src/from_request.rs
@@ -465,3 +465,232 @@ fn bincode_encode_values<'a, T: IntoIterator<Item = &'a Value>>(
         })
         .collect::<Result<Vec<_>, _>>()
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use dpp::identifier::Identifier;
+    use dpp::platform_value::Value;
+
+    // ---------------------------------------------------------------
+    // Helper: to_bytes32
+    // ---------------------------------------------------------------
+
+    #[test]
+    fn test_to_bytes32_valid() {
+        let input = [0xABu8; 32];
+        let result = to_bytes32(&input).expect("should convert 32-byte slice");
+        assert_eq!(result, input);
+    }
+
+    #[test]
+    fn test_to_bytes32_invalid_length() {
+        // Too short
+        let short = [0u8; 16];
+        assert!(to_bytes32(&short).is_err());
+
+        // Too long
+        let long = [0u8; 33];
+        assert!(to_bytes32(&long).is_err());
+
+        // Empty
+        assert!(to_bytes32(&[]).is_err());
+    }
+
+    // ---------------------------------------------------------------
+    // Helper: bincode encode/decode roundtrip
+    // ---------------------------------------------------------------
+
+    #[test]
+    fn test_bincode_encode_decode_roundtrip() {
+        let values = vec![
+            Value::Text("hello".to_string()),
+            Value::U64(42),
+            Value::Bool(true),
+        ];
+        let encoded = bincode_encode_values(&values).expect("encoding should succeed");
+        assert_eq!(encoded.len(), 3);
+
+        let decoded = bincode_decode_values(encoded.iter()).expect("decoding should succeed");
+        assert_eq!(decoded, values);
+    }
+
+    #[test]
+    fn test_bincode_decode_empty() {
+        let empty: Vec<Vec<u8>> = vec![];
+        let result = bincode_decode_values(empty.iter()).expect("empty input should succeed");
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn test_bincode_decode_invalid() {
+        let garbage = vec![vec![0xFF, 0xFE, 0xFD, 0xFC, 0xFB]];
+        let result = bincode_decode_values(garbage.iter());
+        assert!(
+            result.is_err(),
+            "invalid bincode bytes should produce an error"
+        );
+    }
+
+    // ---------------------------------------------------------------
+    // TryFromRequest roundtrip: ContestedDocumentVotePollDriveQueryResultType
+    // ---------------------------------------------------------------
+
+    #[test]
+    fn test_contested_document_vote_poll_result_type_roundtrip() {
+        use get_contested_resource_vote_state_request_v0::ResultType as GrpcResultType;
+
+        let cases = vec![
+            (
+                GrpcResultType::Documents,
+                ContestedDocumentVotePollDriveQueryResultType::Documents,
+            ),
+            (
+                GrpcResultType::VoteTally,
+                ContestedDocumentVotePollDriveQueryResultType::VoteTally,
+            ),
+            (
+                GrpcResultType::DocumentsAndVoteTally,
+                ContestedDocumentVotePollDriveQueryResultType::DocumentsAndVoteTally,
+            ),
+        ];
+
+        for (grpc_val, expected_drive) in cases {
+            // grpc -> drive
+            let drive_val =
+                ContestedDocumentVotePollDriveQueryResultType::try_from_request(grpc_val)
+                    .expect("try_from_request should succeed");
+            assert_eq!(drive_val, expected_drive);
+
+            // drive -> grpc
+            let back = drive_val
+                .try_to_request()
+                .expect("try_to_request should succeed");
+            assert_eq!(back, grpc_val);
+        }
+    }
+
+    // ---------------------------------------------------------------
+    // TryFromRequest roundtrip: ContestedDocumentVotePollDriveQuery
+    // ---------------------------------------------------------------
+
+    #[test]
+    fn test_contested_document_vote_poll_query_roundtrip() {
+        let contract_id = Identifier::from_bytes(&[1u8; 32]).unwrap();
+        let index_values = vec![Value::Text("dash".to_string())];
+
+        let query = ContestedDocumentVotePollDriveQuery {
+            vote_poll: ContestedDocumentResourceVotePoll {
+                contract_id,
+                document_type_name: "domain".to_string(),
+                index_name: "parentNameAndLabel".to_string(),
+                index_values: index_values.clone(),
+            },
+            result_type: ContestedDocumentVotePollDriveQueryResultType::DocumentsAndVoteTally,
+            offset: None,
+            limit: Some(10),
+            start_at: None,
+            allow_include_locked_and_abstaining_vote_tally: true,
+        };
+
+        let grpc_request = query
+            .try_to_request()
+            .expect("try_to_request should succeed");
+
+        let roundtripped = ContestedDocumentVotePollDriveQuery::try_from_request(grpc_request)
+            .expect("try_from_request should succeed");
+
+        assert_eq!(
+            roundtripped.vote_poll.contract_id,
+            query.vote_poll.contract_id
+        );
+        assert_eq!(
+            roundtripped.vote_poll.document_type_name,
+            query.vote_poll.document_type_name
+        );
+        assert_eq!(
+            roundtripped.vote_poll.index_name,
+            query.vote_poll.index_name
+        );
+        assert_eq!(
+            roundtripped.vote_poll.index_values,
+            query.vote_poll.index_values
+        );
+        assert_eq!(roundtripped.result_type, query.result_type);
+        assert_eq!(roundtripped.limit, query.limit);
+        assert_eq!(roundtripped.start_at, query.start_at);
+        assert_eq!(
+            roundtripped.allow_include_locked_and_abstaining_vote_tally,
+            query.allow_include_locked_and_abstaining_vote_tally
+        );
+    }
+
+    // ---------------------------------------------------------------
+    // TryFromRequest roundtrip: Identifier <-> GetPrefundedSpecializedBalanceRequest
+    // ---------------------------------------------------------------
+
+    #[test]
+    fn test_identifier_prefunded_balance_roundtrip() {
+        let id = Identifier::from_bytes(&[7u8; 32]).unwrap();
+
+        let grpc_request: GetPrefundedSpecializedBalanceRequest =
+            id.try_to_request().expect("try_to_request should succeed");
+
+        let roundtripped =
+            Identifier::try_from_request(grpc_request).expect("try_from_request should succeed");
+
+        assert_eq!(roundtripped, id);
+    }
+
+    // ---------------------------------------------------------------
+    // Error path: SingleDocumentByContender is rejected in try_to_request
+    // ---------------------------------------------------------------
+
+    #[test]
+    fn test_contested_result_type_rejects_single_document_by_contender() {
+        let contender_id = Identifier::from_bytes(&[0xCC; 32]).unwrap();
+        let result_type =
+            ContestedDocumentVotePollDriveQueryResultType::SingleDocumentByContender(contender_id);
+
+        let result = result_type.try_to_request();
+        assert!(
+            result.is_err(),
+            "SingleDocumentByContender should not be convertible to a gRPC request"
+        );
+
+        let err_msg = format!("{}", result.unwrap_err());
+        assert!(
+            err_msg.contains("single document by contender"),
+            "error message should mention 'single document by contender', got: {}",
+            err_msg
+        );
+    }
+
+    // ---------------------------------------------------------------
+    // Error path: VotePollsByEndDateDriveQuery rejects offset in try_to_request
+    // ---------------------------------------------------------------
+
+    #[test]
+    fn test_vote_polls_by_end_date_rejects_offset() {
+        let query = VotePollsByEndDateDriveQuery {
+            start_time: Some((1000, true)),
+            end_time: Some((2000, false)),
+            limit: Some(5),
+            offset: Some(10), // This should cause an error
+            order_ascending: true,
+        };
+
+        let result = query.try_to_request();
+        assert!(
+            result.is_err(),
+            "offset must be None for try_to_request to succeed"
+        );
+
+        let err_msg = format!("{}", result.unwrap_err());
+        assert!(
+            err_msg.contains("offset"),
+            "error message should mention 'offset', got: {}",
+            err_msg
+        );
+    }
+}

--- a/packages/rs-drive-proof-verifier/src/types/evonode_status.rs
+++ b/packages/rs-drive-proof-verifier/src/types/evonode_status.rs
@@ -378,3 +378,200 @@ impl TryFrom<&GetStatusResponse> for Time {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use dapi_grpc::platform::v0::get_status_response::get_status_response_v0;
+
+    /// Build a fully populated GetStatusResponse V0 for test reuse.
+    fn build_full_status_response() -> GetStatusResponse {
+        let software = get_status_response_v0::version::Software {
+            dapi: "1.2.3".to_string(),
+            drive: Some("4.5.6".to_string()),
+            tenderdash: Some("0.14.0-dev.1".to_string()),
+        };
+
+        let tenderdash_protocol =
+            get_status_response_v0::version::protocol::Tenderdash { p2p: 9, block: 12 };
+
+        let drive_protocol = get_status_response_v0::version::protocol::Drive {
+            latest: 7,
+            current: 6,
+            next_epoch: 7,
+        };
+
+        let protocol = get_status_response_v0::version::Protocol {
+            tenderdash: Some(tenderdash_protocol),
+            drive: Some(drive_protocol),
+        };
+
+        let version = get_status_response_v0::Version {
+            software: Some(software),
+            protocol: Some(protocol),
+        };
+
+        let time = get_status_response_v0::Time {
+            local: 1700000000,
+            block: Some(1699999900),
+            genesis: Some(1690000000),
+            epoch: Some(42),
+        };
+
+        let node = get_status_response_v0::Node {
+            id: vec![0xAA; 20],
+            pro_tx_hash: Some(vec![0xBB; 32]),
+        };
+
+        let chain = get_status_response_v0::Chain {
+            catching_up: true,
+            latest_block_hash: vec![0x11; 32],
+            latest_app_hash: vec![0x22; 32],
+            latest_block_height: 5000,
+            earliest_block_hash: vec![0x33; 32],
+            earliest_app_hash: vec![0x44; 32],
+            earliest_block_height: 10,
+            max_peer_block_height: 5001,
+            core_chain_locked_height: Some(750),
+        };
+
+        let network = get_status_response_v0::Network {
+            chain_id: "dash-mainnet".to_string(),
+            peers_count: 50,
+            listening: true,
+        };
+
+        let state_sync = get_status_response_v0::StateSync {
+            total_synced_time: 7200,
+            remaining_time: 60,
+            total_snapshots: 3,
+            chunk_process_avg_time: 25,
+            snapshot_height: 4500,
+            snapshot_chunks_count: 200,
+            backfilled_blocks: 1000,
+            backfill_blocks_total: 2000,
+        };
+
+        let v0 = get_status_response::GetStatusResponseV0 {
+            version: Some(version),
+            node: Some(node),
+            chain: Some(chain),
+            network: Some(network),
+            state_sync: Some(state_sync),
+            time: Some(time),
+        };
+
+        GetStatusResponse {
+            version: Some(get_status_response::Version::V0(v0)),
+        }
+    }
+
+    #[test]
+    fn test_try_from_status_response_all_fields() {
+        let response = build_full_status_response();
+        let status = EvoNodeStatus::try_from(response).expect("should convert valid response");
+
+        // Version / Software
+        let sw = status.version.software.as_ref().unwrap();
+        assert_eq!(sw.dapi, "1.2.3");
+        assert_eq!(sw.drive.as_deref(), Some("4.5.6"));
+        assert_eq!(sw.tenderdash.as_deref(), Some("0.14.0-dev.1"));
+
+        // Version / Protocol
+        let proto = status.version.protocol.as_ref().unwrap();
+        let td_proto = proto.tenderdash.as_ref().unwrap();
+        assert_eq!(td_proto.p2p, 9);
+        assert_eq!(td_proto.block, 12);
+        let drv_proto = proto.drive.as_ref().unwrap();
+        assert_eq!(drv_proto.latest, 7);
+        assert_eq!(drv_proto.current, 6);
+        assert_eq!(drv_proto.next_epoch, 7);
+
+        // Node
+        assert_eq!(status.node.id, vec![0xAA; 20]);
+        assert_eq!(status.node.pro_tx_hash, Some(vec![0xBB; 32]));
+
+        // Chain
+        assert!(status.chain.catching_up);
+        assert_eq!(status.chain.latest_block_hash, vec![0x11; 32]);
+        assert_eq!(status.chain.latest_app_hash, vec![0x22; 32]);
+        assert_eq!(status.chain.latest_block_height, 5000);
+        assert_eq!(status.chain.earliest_block_hash, vec![0x33; 32]);
+        assert_eq!(status.chain.earliest_app_hash, vec![0x44; 32]);
+        assert_eq!(status.chain.earliest_block_height, 10);
+        assert_eq!(status.chain.max_peer_block_height, 5001);
+        assert_eq!(status.chain.core_chain_locked_height, Some(750));
+
+        // Network
+        assert_eq!(status.network.chain_id, "dash-mainnet");
+        assert_eq!(status.network.peers_count, 50);
+        assert!(status.network.listening);
+
+        // StateSync
+        assert_eq!(status.state_sync.total_synced_time, 7200);
+        assert_eq!(status.state_sync.remaining_time, 60);
+        assert_eq!(status.state_sync.total_snapshots, 3);
+        assert_eq!(status.state_sync.chunk_process_avg_time, 25);
+        assert_eq!(status.state_sync.snapshot_height, 4500);
+        assert_eq!(status.state_sync.snapshot_chunks_count, 200);
+        assert_eq!(status.state_sync.backfilled_blocks, 1000);
+        assert_eq!(status.state_sync.backfill_blocks_total, 2000);
+
+        // Time
+        assert_eq!(status.time.local, 1700000000);
+        assert_eq!(status.time.block, Some(1699999900));
+        assert_eq!(status.time.genesis, Some(1690000000));
+        assert_eq!(status.time.epoch, Some(42));
+    }
+
+    #[test]
+    fn test_try_from_status_response_empty_version() {
+        let response = GetStatusResponse { version: None };
+        let err = EvoNodeStatus::try_from(response).expect_err("should fail when version is None");
+        let err_string = err.to_string();
+        assert!(
+            err_string.contains("empty version"),
+            "unexpected error: {err_string}"
+        );
+    }
+
+    #[test]
+    fn test_version_conversion() {
+        let response = build_full_status_response();
+        let version = Version::try_from(&response).expect("should convert Version");
+
+        // Software components
+        let sw = version.software.as_ref().unwrap();
+        assert_eq!(sw.dapi, "1.2.3");
+        assert_eq!(sw.drive.as_deref(), Some("4.5.6"));
+        assert_eq!(sw.tenderdash.as_deref(), Some("0.14.0-dev.1"));
+
+        // Protocol versions
+        let proto = version.protocol.as_ref().unwrap();
+
+        let td = proto.tenderdash.as_ref().unwrap();
+        assert_eq!(td.p2p, 9);
+        assert_eq!(td.block, 12);
+
+        let drv = proto.drive.as_ref().unwrap();
+        assert_eq!(drv.latest, 7);
+        assert_eq!(drv.current, 6);
+        assert_eq!(drv.next_epoch, 7);
+    }
+
+    #[test]
+    fn test_chain_conversion() {
+        let response = build_full_status_response();
+        let chain = Chain::try_from(&response).expect("should convert Chain");
+
+        assert!(chain.catching_up);
+        assert_eq!(chain.latest_block_hash, vec![0x11; 32]);
+        assert_eq!(chain.latest_app_hash, vec![0x22; 32]);
+        assert_eq!(chain.latest_block_height, 5000);
+        assert_eq!(chain.earliest_block_hash, vec![0x33; 32]);
+        assert_eq!(chain.earliest_app_hash, vec![0x44; 32]);
+        assert_eq!(chain.earliest_block_height, 10);
+        assert_eq!(chain.max_peer_block_height, 5001);
+        assert_eq!(chain.core_chain_locked_height, Some(750));
+    }
+}

--- a/packages/rs-drive-proof-verifier/src/unproved.rs
+++ b/packages/rs-drive-proof-verifier/src/unproved.rs
@@ -295,3 +295,337 @@ impl FromUnproved<platform::GetStatusRequest> for EvoNodeStatus {
         Ok((Some(status), Default::default()))
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use dapi_grpc::platform::v0::{
+        get_current_quorums_info_response, get_status_response, ResponseMetadata,
+    };
+    use dpp::bls_signatures::{Bls12381G2Impl, SecretKey};
+    use dpp::version::PlatformVersion;
+
+    /// Generate a valid BLS public key as compressed bytes (48 bytes) from a
+    /// deterministic secret key derived from the given seed byte.
+    fn generate_valid_bls_public_key_bytes(seed: u8) -> Vec<u8> {
+        let mut secret_bytes = [0u8; 32];
+        secret_bytes[31] = seed.max(1); // ensure nonzero
+        let sk: SecretKey<Bls12381G2Impl> =
+            SecretKey::<Bls12381G2Impl>::from_be_bytes(&secret_bytes)
+                .into_option()
+                .expect("valid secret key");
+        sk.public_key().0.to_compressed().to_vec()
+    }
+
+    /// Helper: build a valid GetCurrentQuorumsInfoResponse with one quorum hash,
+    /// one validator set with one member, and metadata.
+    fn build_valid_quorums_info_response() -> platform::GetCurrentQuorumsInfoResponse {
+        let quorum_hash = vec![1u8; 32];
+        let current_quorum_hash = vec![2u8; 32];
+        let last_block_proposer = vec![3u8; 32];
+        let pro_tx_hash = vec![4u8; 32];
+        let threshold_public_key = generate_valid_bls_public_key_bytes(42);
+
+        let member = get_current_quorums_info_response::ValidatorV0 {
+            pro_tx_hash: pro_tx_hash.clone(),
+            node_ip: "127.0.0.1".to_string(),
+            is_banned: false,
+        };
+
+        let validator_set = get_current_quorums_info_response::ValidatorSetV0 {
+            quorum_hash: quorum_hash.clone(),
+            core_height: 100,
+            members: vec![member],
+            threshold_public_key,
+        };
+
+        let v0 = get_current_quorums_info_response::GetCurrentQuorumsInfoResponseV0 {
+            quorum_hashes: vec![quorum_hash],
+            current_quorum_hash,
+            validator_sets: vec![validator_set],
+            last_block_proposer,
+            metadata: Some(ResponseMetadata {
+                height: 500,
+                core_chain_locked_height: 200,
+                epoch: 10,
+                time_ms: 1234567890,
+                protocol_version: 1,
+                chain_id: "dash-testnet-1".to_string(),
+            }),
+        };
+
+        platform::GetCurrentQuorumsInfoResponse {
+            version: Some(get_current_quorums_info_response::Version::V0(v0)),
+        }
+    }
+
+    /// Helper: build a valid GetStatusResponse V0 with all inner fields populated.
+    fn build_valid_status_response() -> platform::GetStatusResponse {
+        use dapi_grpc::platform::v0::get_status_response::get_status_response_v0;
+
+        let software = get_status_response_v0::version::Software {
+            dapi: "1.0.0".to_string(),
+            drive: Some("2.0.0".to_string()),
+            tenderdash: Some("0.14.0".to_string()),
+        };
+
+        let tenderdash_protocol =
+            get_status_response_v0::version::protocol::Tenderdash { p2p: 8, block: 11 };
+
+        let drive_protocol = get_status_response_v0::version::protocol::Drive {
+            latest: 5,
+            current: 4,
+            next_epoch: 5,
+        };
+
+        let protocol = get_status_response_v0::version::Protocol {
+            tenderdash: Some(tenderdash_protocol),
+            drive: Some(drive_protocol),
+        };
+
+        let version = get_status_response_v0::Version {
+            software: Some(software),
+            protocol: Some(protocol),
+        };
+
+        let time = get_status_response_v0::Time {
+            local: 1700000000,
+            block: Some(1699999900),
+            genesis: Some(1690000000),
+            epoch: Some(42),
+        };
+
+        let node = get_status_response_v0::Node {
+            id: vec![10u8; 20],
+            pro_tx_hash: Some(vec![11u8; 32]),
+        };
+
+        let chain = get_status_response_v0::Chain {
+            catching_up: false,
+            latest_block_hash: vec![20u8; 32],
+            latest_app_hash: vec![21u8; 32],
+            latest_block_height: 1000,
+            earliest_block_hash: vec![22u8; 32],
+            earliest_app_hash: vec![23u8; 32],
+            earliest_block_height: 1,
+            max_peer_block_height: 1001,
+            core_chain_locked_height: Some(500),
+        };
+
+        let network = get_status_response_v0::Network {
+            chain_id: "dash-testnet-1".to_string(),
+            peers_count: 25,
+            listening: true,
+        };
+
+        let state_sync = get_status_response_v0::StateSync {
+            total_synced_time: 3600,
+            remaining_time: 120,
+            total_snapshots: 5,
+            chunk_process_avg_time: 50,
+            snapshot_height: 900,
+            snapshot_chunks_count: 100,
+            backfilled_blocks: 800,
+            backfill_blocks_total: 1000,
+        };
+
+        let v0 = get_status_response::GetStatusResponseV0 {
+            version: Some(version),
+            node: Some(node),
+            chain: Some(chain),
+            network: Some(network),
+            state_sync: Some(state_sync),
+            time: Some(time),
+        };
+
+        platform::GetStatusResponse {
+            version: Some(get_status_response::Version::V0(v0)),
+        }
+    }
+
+    #[test]
+    fn test_current_quorums_info_valid_response() {
+        let request = platform::GetCurrentQuorumsInfoRequest { version: None };
+        let response = build_valid_quorums_info_response();
+        let platform_version = PlatformVersion::latest();
+
+        let result = CurrentQuorumsInfo::maybe_from_unproved_with_metadata(
+            request,
+            response,
+            Network::Testnet,
+            platform_version,
+        );
+
+        let (maybe_info, metadata) = result.expect("should parse valid response");
+        let info = maybe_info.expect("should contain CurrentQuorumsInfo");
+
+        assert_eq!(info.quorum_hashes.len(), 1);
+        assert_eq!(info.quorum_hashes[0], [1u8; 32]);
+        assert_eq!(info.current_quorum_hash, [2u8; 32]);
+        assert_eq!(info.last_block_proposer, [3u8; 32]);
+        assert_eq!(info.validator_sets.len(), 1);
+        assert_eq!(info.last_platform_block_height, 500);
+        assert_eq!(info.last_core_block_height, 200);
+        assert_eq!(metadata.height, 500);
+        assert_eq!(metadata.core_chain_locked_height, 200);
+    }
+
+    #[test]
+    fn test_current_quorums_info_invalid_quorum_hash_length() {
+        let mut response = build_valid_quorums_info_response();
+
+        // Inject an invalid quorum_hash that is not 32 bytes
+        if let Some(get_current_quorums_info_response::Version::V0(ref mut v0)) = response.version {
+            v0.quorum_hashes = vec![vec![0u8; 16]]; // 16 bytes instead of 32
+        }
+
+        let request = platform::GetCurrentQuorumsInfoRequest { version: None };
+        let platform_version = PlatformVersion::latest();
+
+        let result = CurrentQuorumsInfo::maybe_from_unproved_with_metadata(
+            request,
+            response,
+            Network::Testnet,
+            platform_version,
+        );
+
+        let err = result.expect_err("should fail for invalid quorum_hash length");
+        let err_string = err.to_string();
+        assert!(
+            err_string.contains("Invalid quorum_hash length"),
+            "unexpected error: {err_string}"
+        );
+    }
+
+    #[test]
+    fn test_current_quorums_info_invalid_current_quorum_hash_length() {
+        let mut response = build_valid_quorums_info_response();
+
+        // Inject an invalid current_quorum_hash that is not 32 bytes
+        if let Some(get_current_quorums_info_response::Version::V0(ref mut v0)) = response.version {
+            v0.current_quorum_hash = vec![0u8; 10]; // 10 bytes instead of 32
+        }
+
+        let request = platform::GetCurrentQuorumsInfoRequest { version: None };
+        let platform_version = PlatformVersion::latest();
+
+        let result = CurrentQuorumsInfo::maybe_from_unproved_with_metadata(
+            request,
+            response,
+            Network::Testnet,
+            platform_version,
+        );
+
+        let err = result.expect_err("should fail for invalid current_quorum_hash length");
+        let err_string = err.to_string();
+        assert!(
+            err_string.contains("Invalid current_quorum_hash length"),
+            "unexpected error: {err_string}"
+        );
+    }
+
+    #[test]
+    fn test_current_quorums_info_invalid_last_block_proposer() {
+        let mut response = build_valid_quorums_info_response();
+
+        // Inject an invalid last_block_proposer that is not 32 bytes
+        if let Some(get_current_quorums_info_response::Version::V0(ref mut v0)) = response.version {
+            v0.last_block_proposer = vec![0u8; 5]; // 5 bytes instead of 32
+        }
+
+        let request = platform::GetCurrentQuorumsInfoRequest { version: None };
+        let platform_version = PlatformVersion::latest();
+
+        let result = CurrentQuorumsInfo::maybe_from_unproved_with_metadata(
+            request,
+            response,
+            Network::Testnet,
+            platform_version,
+        );
+
+        let err = result.expect_err("should fail for invalid last_block_proposer length");
+        let err_string = err.to_string();
+        assert!(
+            err_string.contains("Invalid last_block_proposer length"),
+            "unexpected error: {err_string}"
+        );
+    }
+
+    #[test]
+    fn test_current_quorums_info_none_metadata() {
+        let mut response = build_valid_quorums_info_response();
+
+        // Remove metadata from the response
+        if let Some(get_current_quorums_info_response::Version::V0(ref mut v0)) = response.version {
+            v0.metadata = None;
+        }
+
+        let request = platform::GetCurrentQuorumsInfoRequest { version: None };
+        let platform_version = PlatformVersion::latest();
+
+        let result = CurrentQuorumsInfo::maybe_from_unproved_with_metadata(
+            request,
+            response,
+            Network::Testnet,
+            platform_version,
+        );
+
+        let err = result.expect_err("should fail when metadata is missing");
+        let err_string = err.to_string();
+        assert!(
+            err_string.contains("empty response metadata"),
+            "unexpected error: {err_string}"
+        );
+    }
+
+    #[test]
+    fn test_evo_node_status_valid_response() {
+        let request = platform::GetStatusRequest { version: None };
+        let response = build_valid_status_response();
+        let platform_version = PlatformVersion::latest();
+
+        let result = EvoNodeStatus::maybe_from_unproved_with_metadata(
+            request,
+            response,
+            Network::Testnet,
+            platform_version,
+        );
+
+        let (maybe_status, _metadata) = result.expect("should parse valid status response");
+        let status = maybe_status.expect("should contain EvoNodeStatus");
+
+        // Verify version fields
+        let software = status.version.software.as_ref().unwrap();
+        assert_eq!(software.dapi, "1.0.0");
+        assert_eq!(software.drive.as_deref(), Some("2.0.0"));
+        assert_eq!(software.tenderdash.as_deref(), Some("0.14.0"));
+
+        let protocol = status.version.protocol.as_ref().unwrap();
+        let td = protocol.tenderdash.as_ref().unwrap();
+        assert_eq!(td.p2p, 8);
+        assert_eq!(td.block, 11);
+        let drv = protocol.drive.as_ref().unwrap();
+        assert_eq!(drv.latest, 5);
+        assert_eq!(drv.current, 4);
+        assert_eq!(drv.next_epoch, 5);
+
+        // Verify node fields
+        assert_eq!(status.node.id, vec![10u8; 20]);
+        assert_eq!(status.node.pro_tx_hash, Some(vec![11u8; 32]));
+
+        // Verify chain fields
+        assert!(!status.chain.catching_up);
+        assert_eq!(status.chain.latest_block_height, 1000);
+        assert_eq!(status.chain.core_chain_locked_height, Some(500));
+
+        // Verify network fields
+        assert_eq!(status.network.chain_id, "dash-testnet-1");
+        assert_eq!(status.network.peers_count, 25);
+        assert!(status.network.listening);
+
+        // Verify time fields
+        assert_eq!(status.time.local, 1700000000);
+        assert_eq!(status.time.block, Some(1699999900));
+        assert_eq!(status.time.epoch, Some(42));
+    }
+}

--- a/packages/rs-drive-proof-verifier/src/verify.rs
+++ b/packages/rs-drive-proof-verifier/src/verify.rs
@@ -230,4 +230,193 @@ mod tests {
             "error message should mention quorum type out of range, got: {err_msg}"
         );
     }
+
+    /// Helper: create a deterministic BLS key pair for testing.
+    fn test_keypair() -> (
+        bls_signatures::SecretKey<Bls12381G2Impl>,
+        bls_signatures::PublicKey<Bls12381G2Impl>,
+    ) {
+        let sk = bls_signatures::SecretKey::<Bls12381G2Impl>::from_hash(b"test-key-seed");
+        let pk = sk.public_key();
+        (sk, pk)
+    }
+
+    /// A ContextProvider that returns a cryptographically valid public key
+    /// so that tests can progress past the public-key parsing step and
+    /// reach deeper code paths (e.g. signature verification).
+    struct ValidKeyContextProvider {
+        pubkey_bytes: [u8; 48],
+    }
+
+    impl ValidKeyContextProvider {
+        fn new() -> Self {
+            let (_, pk) = test_keypair();
+            let pk_vec: Vec<u8> = (&pk).into();
+            let mut pubkey_bytes = [0u8; 48];
+            pubkey_bytes.copy_from_slice(&pk_vec);
+            Self { pubkey_bytes }
+        }
+    }
+
+    impl ContextProvider for ValidKeyContextProvider {
+        fn get_data_contract(
+            &self,
+            _id: &Identifier,
+            _platform_version: &PlatformVersion,
+        ) -> Result<Option<Arc<DataContract>>, ContextProviderError> {
+            Ok(None)
+        }
+
+        fn get_token_configuration(
+            &self,
+            _token_id: &Identifier,
+        ) -> Result<Option<TokenConfiguration>, ContextProviderError> {
+            Ok(None)
+        }
+
+        fn get_quorum_public_key(
+            &self,
+            _quorum_type: u32,
+            _quorum_hash: [u8; 32],
+            _core_chain_locked_height: u32,
+        ) -> Result<[u8; 48], ContextProviderError> {
+            Ok(self.pubkey_bytes)
+        }
+
+        fn get_platform_activation_height(&self) -> Result<CoreBlockHeight, ContextProviderError> {
+            Ok(1)
+        }
+    }
+
+    /// Helper to build default test metadata.
+    fn test_metadata() -> ResponseMetadata {
+        ResponseMetadata {
+            height: 100,
+            core_chain_locked_height: 1,
+            epoch: 0,
+            time_ms: 1_000_000,
+            protocol_version: 1,
+            chain_id: "test-chain".to_string(),
+        }
+    }
+
+    /// An all-zeros 96-byte signature must be rejected early by
+    /// `verify_signature_digest` with a `SignatureVerificationError`
+    /// containing "empty signature".
+    #[test]
+    fn test_verify_signature_digest_all_zeros() {
+        let (_, pk) = test_keypair();
+        let sign_digest = b"some-digest-data";
+        let signature = [0u8; 96];
+
+        let result = verify_signature_digest(sign_digest, &signature, &pk);
+        let err = result.expect_err("expected error for all-zero signature");
+        let err_msg = err.to_string();
+        assert!(
+            err_msg.contains("empty signature"),
+            "error should mention empty signature, got: {err_msg}"
+        );
+    }
+
+    /// Random non-zero 96 bytes that do not form a valid compressed BLS
+    /// signature must cause `verify_signature_digest` to return
+    /// `SignatureVerificationError`.
+    #[test]
+    fn test_verify_signature_digest_invalid_compressed() {
+        let (_, pk) = test_keypair();
+        let sign_digest = b"some-digest-data";
+
+        // Construct 96 non-zero bytes that are not a valid BLS signature.
+        // We use a simple pattern that is extremely unlikely to be a valid
+        // compressed G2 point.
+        let mut signature = [0xFFu8; 96];
+        signature[0] = 0x01; // ensure it is not all-0xFF either
+
+        let result = verify_signature_digest(sign_digest, &signature, &pk);
+        let err = result.expect_err("expected error for invalid compressed signature");
+        let err_msg = err.to_string();
+        assert!(
+            err_msg.contains("Could not verify signature digest"),
+            "error should mention failed verification, got: {err_msg}"
+        );
+    }
+
+    /// A `Proof` whose `quorum_hash` is not exactly 32 bytes must
+    /// produce a `ResponseDecodeError` mentioning "invalid quorum hash
+    /// size".
+    #[test]
+    fn test_verify_tenderdash_proof_invalid_quorum_hash_size() {
+        let proof = Proof {
+            grovedb_proof: vec![],
+            quorum_hash: vec![0u8; 16], // too short — not 32 bytes
+            signature: vec![0u8; 96],
+            round: 1,
+            block_id_hash: vec![0u8; 32],
+            quorum_type: 1,
+        };
+
+        let metadata = test_metadata();
+        let provider = StubContextProvider;
+
+        let result = verify_tenderdash_proof(&proof, &metadata, &[0u8; 32], &provider);
+        let err = result.expect_err("expected error for invalid quorum hash size");
+        let err_msg = err.to_string();
+        assert!(
+            err_msg.contains("invalid quorum hash size"),
+            "error should mention invalid quorum hash size, got: {err_msg}"
+        );
+    }
+
+    /// A `Proof` with a valid 32-byte `quorum_hash` but a signature
+    /// that is not exactly 96 bytes must produce an
+    /// `InvalidSignatureFormat` error mentioning "invalid signature
+    /// size".
+    #[test]
+    fn test_verify_tenderdash_proof_invalid_signature_size() {
+        let proof = Proof {
+            grovedb_proof: vec![],
+            quorum_hash: vec![0u8; 32],
+            signature: vec![0u8; 50], // wrong size — not 96 bytes
+            round: 1,
+            block_id_hash: vec![0u8; 32],
+            quorum_type: 1,
+        };
+
+        let metadata = test_metadata();
+        let provider = ValidKeyContextProvider::new();
+
+        let result = verify_tenderdash_proof(&proof, &metadata, &[0u8; 32], &provider);
+        let err = result.expect_err("expected error for invalid signature size");
+        let err_msg = err.to_string();
+        assert!(
+            err_msg.contains("invalid signature size"),
+            "error should mention invalid signature size, got: {err_msg}"
+        );
+    }
+
+    /// A `Proof` with 96 zero-byte signature that reaches
+    /// `verify_signature_digest` through `verify_tenderdash_proof` must
+    /// trigger the "empty signature" early-return error.
+    #[test]
+    fn test_verify_tenderdash_proof_empty_signature() {
+        let proof = Proof {
+            grovedb_proof: vec![],
+            quorum_hash: vec![0u8; 32],
+            signature: vec![0u8; 96], // all zeros — "empty signature"
+            round: 1,
+            block_id_hash: vec![0u8; 32],
+            quorum_type: 1,
+        };
+
+        let metadata = test_metadata();
+        let provider = ValidKeyContextProvider::new();
+
+        let result = verify_tenderdash_proof(&proof, &metadata, &[0u8; 32], &provider);
+        let err = result.expect_err("expected error for empty signature");
+        let err_msg = err.to_string();
+        assert!(
+            err_msg.contains("empty signature"),
+            "error should mention empty signature, got: {err_msg}"
+        );
+    }
 }


### PR DESCRIPTION
## Summary
- Add 31 new unit tests across 5 files in `rs-drive-proof-verifier`, bringing total from 5 to 36
- **error.rs**: 6 tests for `MapGroveDbError` trait (`map_drive_error` with GroveDB/InvalidProof/non-GroveDB errors) and `From` impls
- **from_request.rs**: 10 tests covering `TryFromRequest` roundtrips, `to_bytes32`, `bincode_encode/decode`, and error paths (SingleDocumentByContender rejection, offset-not-None)
- **verify.rs**: 5 tests for `verify_signature_digest` (all-zeros, invalid compressed) and `verify_tenderdash_proof` error paths (invalid quorum hash size, invalid signature size, empty signature)
- **unproved.rs**: 6 tests for `CurrentQuorumsInfo` parsing (valid, invalid hash lengths, missing metadata) and `EvoNodeStatus`
- **types/evonode_status.rs**: 4 tests for `TryFrom<GetStatusResponse>` (all fields, empty version, version/chain conversion)

## Test plan
- [x] `cargo test -p drive-proof-verifier --lib` passes all 36 tests
- [x] `cargo fmt -p drive-proof-verifier` clean
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Expanded test coverage for error handling, response parsing, and cryptographic verification workflows.
  * Added comprehensive unit tests validating serialization/deserialization and edge case handling.
  * No changes to user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->