### PR TITLE
ci: exclude DPP state transition boilerplate from coverage

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -19,11 +19,22 @@ ignore:
   - "packages/wasm-sdk/**"
   - "**/block_end/validator_set_update/v0/**"
   - "**/block_end/validator_set_update/v1/**"
-  # Error type definitions — these are enum/struct declarations with Display/thiserror
+  # Error type definitions — enum/struct declarations with Display/thiserror
   # derives, not logic that needs test coverage
   - "packages/rs-drive/src/error/**"
   - "packages/rs-drive-abci/src/error/**"
   - "packages/rs-dpp/src/errors/**"
+  - "packages/rs-dpp/src/state_transition/errors/**"
+  # State transition boilerplate — trait interfaces, accessors, field constants,
+  # type metadata, version dispatch, and factory patterns
+  - "packages/rs-dpp/src/state_transition/traits/**"
+  - "packages/rs-dpp/src/state_transition/state_transitions/**/accessors/**"
+  - "packages/rs-dpp/src/state_transition/state_transitions/**/fields.rs"
+  - "packages/rs-dpp/src/state_transition/state_transitions/**/common_fields.rs"
+  - "packages/rs-dpp/src/state_transition/state_transitions/**/types.rs"
+  - "packages/rs-dpp/src/state_transition/state_transitions/**/version.rs"
+  - "packages/rs-dpp/src/state_transition/state_transition_types.rs"
+  - "packages/rs-dpp/src/state_transition/state_transition_factory.rs"
 
 coverage:
   status:


### PR DESCRIPTION
## Summary
- Exclude ~3,900 lines of pure boilerplate from Codecov tracking in `rs-dpp/src/state_transition/`
- **Errors**: thiserror enum definitions with no logic
- **Traits**: interface definitions with no default implementations
- **Accessors**: thin field getter/setter trait impls
- **Field constants**: `fields.rs`, `common_fields.rs` — pure `const` definitions
- **Type metadata**: `types.rs` — `signature_property_paths()`, `identifiers_property_paths()`, etc.
- **Version dispatch**: `version.rs` — single-arm match statements
- **Factory/types**: enum definitions with derives only

Business logic files (v0_methods, validation, serialization, signing, state_transition_like) remain tracked.

## Test plan
- [ ] Codecov config is valid (CI will validate on upload)
- [ ] Coverage numbers should tick up slightly as denominator shrinks

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated code coverage reporting configuration to refine which files are excluded from coverage metrics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->