### PR TITLE
docs(dpp): add safety comments for auditor false-positive patterns

### DIFF
--- a/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/shielded_common/mod.rs
+++ b/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/shielded_common/mod.rs
@@ -249,6 +249,14 @@ pub fn validate_nullifiers(
         }
     }
     // Phase 2: Check against state via Drive method
+    //
+    // SAFETY: No cross-transaction double-spend risk within a block. State
+    // transitions are processed sequentially: each transition's nullifier
+    // insertions are applied to the GroveDB transaction (via apply_batch)
+    // before the next transition's validation runs. GroveDB supports
+    // read-your-own-writes, so this lookup sees nullifiers from all prior
+    // transitions in the same block. The insert_only_known_to_not_already_exist_op
+    // provides an additional safety net at batch application time.
     for nullifier in nullifiers {
         let exists = drive
             .has_nullifier(nullifier, transaction, drive_operations, platform_version)

--- a/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/shielded_transfer/transform_into_action/v0/mod.rs
+++ b/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/shielded_transfer/transform_into_action/v0/mod.rs
@@ -54,6 +54,12 @@ impl ShieldedTransferStateTransitionTransformIntoActionValidationV0 for Shielded
         };
 
         // Read current shielded pool state from GroveDB
+        //
+        // SAFETY: No TOCTOU risk. State transitions within a block are processed
+        // sequentially: each transition's operations are applied to the GroveDB
+        // transaction (via apply_batch) before the next transition's validation
+        // reads the balance. GroveDB supports read-your-own-writes within an
+        // uncommitted transaction, so this read always sees the latest balance.
         let mut drive_operations = vec![];
         let current_total_balance =
             read_pool_total_balance(drive, transaction, &mut drive_operations, platform_version)?;

--- a/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/shielded_transfer/transform_into_action/v0/mod.rs
+++ b/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/shielded_transfer/transform_into_action/v0/mod.rs
@@ -55,11 +55,12 @@ impl ShieldedTransferStateTransitionTransformIntoActionValidationV0 for Shielded
 
         // Read current shielded pool state from GroveDB
         //
-        // SAFETY: No TOCTOU risk. State transitions within a block are processed
-        // sequentially: each transition's operations are applied to the GroveDB
-        // transaction (via apply_batch) before the next transition's validation
-        // reads the balance. GroveDB supports read-your-own-writes within an
-        // uncommitted transaction, so this read always sees the latest balance.
+        // SAFETY: No TOCTOU risk. Shielded transitions are processed sequentially
+        // against the same GroveDB transaction. Each transition's operations are
+        // applied (via apply_drive_operations) before the next transition's
+        // validation runs. GroveDB supports read-your-own-writes within that
+        // uncommitted transaction, so balance reads always see the latest state
+        // from prior transitions in the block.
         let mut drive_operations = vec![];
         let current_total_balance =
             read_pool_total_balance(drive, transaction, &mut drive_operations, platform_version)?;

--- a/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/shielded_withdrawal/transform_into_action/v0/mod.rs
+++ b/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/shielded_withdrawal/transform_into_action/v0/mod.rs
@@ -53,6 +53,12 @@ impl ShieldedWithdrawalStateTransitionTransformIntoActionValidationV0
         };
 
         // Read current shielded pool total balance from GroveDB
+        //
+        // SAFETY: No TOCTOU risk. State transitions within a block are processed
+        // sequentially: each transition's operations are applied to the GroveDB
+        // transaction (via apply_batch) before the next transition's validation
+        // reads the balance. GroveDB supports read-your-own-writes within an
+        // uncommitted transaction, so this read always sees the latest balance.
         let mut drive_operations = vec![];
         let current_total_balance =
             read_pool_total_balance(drive, transaction, &mut drive_operations, platform_version)?;

--- a/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/shielded_withdrawal/transform_into_action/v0/mod.rs
+++ b/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/shielded_withdrawal/transform_into_action/v0/mod.rs
@@ -54,11 +54,12 @@ impl ShieldedWithdrawalStateTransitionTransformIntoActionValidationV0
 
         // Read current shielded pool total balance from GroveDB
         //
-        // SAFETY: No TOCTOU risk. State transitions within a block are processed
-        // sequentially: each transition's operations are applied to the GroveDB
-        // transaction (via apply_batch) before the next transition's validation
-        // reads the balance. GroveDB supports read-your-own-writes within an
-        // uncommitted transaction, so this read always sees the latest balance.
+        // SAFETY: No TOCTOU risk. Shielded transitions are processed sequentially
+        // against the same GroveDB transaction. Each transition's operations are
+        // applied (via apply_drive_operations) before the next transition's
+        // validation runs. GroveDB supports read-your-own-writes within that
+        // uncommitted transaction, so balance reads always see the latest state
+        // from prior transitions in the block.
         let mut drive_operations = vec![];
         let current_total_balance =
             read_pool_total_balance(drive, transaction, &mut drive_operations, platform_version)?;

--- a/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/unshield/transform_into_action/v0/mod.rs
+++ b/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/unshield/transform_into_action/v0/mod.rs
@@ -48,6 +48,12 @@ impl UnshieldStateTransitionTransformIntoActionValidationV0 for UnshieldTransiti
         };
 
         // Read current shielded pool state from GroveDB
+        //
+        // SAFETY: No TOCTOU risk. State transitions within a block are processed
+        // sequentially: each transition's operations are applied to the GroveDB
+        // transaction (via apply_batch) before the next transition's validation
+        // reads the balance. GroveDB supports read-your-own-writes within an
+        // uncommitted transaction, so this read always sees the latest balance.
         let mut drive_operations = vec![];
         let current_total_balance =
             read_pool_total_balance(drive, transaction, &mut drive_operations, platform_version)?;

--- a/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/unshield/transform_into_action/v0/mod.rs
+++ b/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/unshield/transform_into_action/v0/mod.rs
@@ -49,11 +49,12 @@ impl UnshieldStateTransitionTransformIntoActionValidationV0 for UnshieldTransiti
 
         // Read current shielded pool state from GroveDB
         //
-        // SAFETY: No TOCTOU risk. State transitions within a block are processed
-        // sequentially: each transition's operations are applied to the GroveDB
-        // transaction (via apply_batch) before the next transition's validation
-        // reads the balance. GroveDB supports read-your-own-writes within an
-        // uncommitted transaction, so this read always sees the latest balance.
+        // SAFETY: No TOCTOU risk. Shielded transitions are processed sequentially
+        // against the same GroveDB transaction. Each transition's operations are
+        // applied (via apply_drive_operations) before the next transition's
+        // validation runs. GroveDB supports read-your-own-writes within that
+        // uncommitted transaction, so balance reads always see the latest state
+        // from prior transitions in the block.
         let mut drive_operations = vec![];
         let current_total_balance =
             read_pool_total_balance(drive, transaction, &mut drive_operations, platform_version)?;

--- a/packages/rs-drive/src/drive/shielded/insert_nullifiers/v0/mod.rs
+++ b/packages/rs-drive/src/drive/shielded/insert_nullifiers/v0/mod.rs
@@ -40,10 +40,9 @@ impl Drive {
 
         // Store to per-block sync storage for catch-up RPCs
         //
-        // SAFETY: Both the permanent nullifier ops (returned for batch application)
-        // and this sync storage write use the same GroveDB transaction. If the block
-        // is rolled back (transaction aborted), both are rolled back atomically.
-        // There is no inconsistency window because GroveDB transactions are atomic.
+        // SAFETY: `store_nullifiers_for_block` writes under the same GroveDB
+        // transaction that the caller later uses to apply the returned `ops`.
+        // If that transaction aborts, neither write persists (atomic commit/rollback).
         self.store_nullifiers_for_block(
             nullifiers,
             block_height,

--- a/packages/rs-drive/src/drive/shielded/insert_nullifiers/v0/mod.rs
+++ b/packages/rs-drive/src/drive/shielded/insert_nullifiers/v0/mod.rs
@@ -39,6 +39,11 @@ impl Drive {
             .collect();
 
         // Store to per-block sync storage for catch-up RPCs
+        //
+        // SAFETY: Both the permanent nullifier ops (returned for batch application)
+        // and this sync storage write use the same GroveDB transaction. If the block
+        // is rolled back (transaction aborted), both are rolled back atomically.
+        // There is no inconsistency window because GroveDB transactions are atomic.
         self.store_nullifiers_for_block(
             nullifiers,
             block_height,

--- a/packages/rs-drive/src/drive/shielded/prune_anchors/v0/mod.rs
+++ b/packages/rs-drive/src/drive/shielded/prune_anchors/v0/mod.rs
@@ -54,6 +54,8 @@ impl Drive {
             // Extract anchor_bytes from the element value
             if let Element::Item(anchor_bytes, _) = element {
                 // Delete from anchors tree (anchor_bytes -> block_height)
+                // NOTE: .unwrap() is CostContext::unwrap(), not Result::unwrap().
+                // It discards cost tracking info and never panics.
                 self.grove
                     .delete(
                         &anchors_path,

--- a/packages/rs-drive/src/drive/shielded/record_anchor_if_changed/v0/mod.rs
+++ b/packages/rs-drive/src/drive/shielded/record_anchor_if_changed/v0/mod.rs
@@ -27,6 +27,11 @@ impl Drive {
         let pool_path = shielded_credit_pool_path();
 
         // 1. Read current anchor from CommitmentTree
+        //
+        // NOTE: .unwrap() below is CostContext::unwrap(), NOT Result::unwrap().
+        // CostContext::unwrap() simply discards cost tracking info and never
+        // panics. This is the standard pattern for GroveDB operations throughout
+        // the Drive codebase when cost tracking is not needed.
         let current_anchor = self
             .grove
             .commitment_tree_anchor(


### PR DESCRIPTION
## Issue being fixed or feature implemented

Security auditors flagged several patterns in the shielded pool code as potential vulnerabilities (M1, M2, M4, M5). All were false positives. Adding inline comments so future auditors don't waste time re-investigating these patterns.

## What was done?

Added inline `// SAFETY:` and `// NOTE:` documentation comments to 7 files across `rs-drive-abci` and `rs-drive`, explaining why each flagged pattern is safe:

- **M1 (Pool balance TOCTOU)**: Added to `unshield`, `shielded_transfer`, and `shielded_withdrawal` `transform_into_action/v0/mod.rs` — explains that state transitions are processed sequentially within a block and GroveDB supports read-your-own-writes within an uncommitted transaction, so the balance read always reflects the latest state.
- **M2 (CostContext::unwrap())**: Added to `record_anchor_if_changed/v0/mod.rs` and `prune_anchors/v0/mod.rs` — clarifies that `.unwrap()` is `CostContext::unwrap()` (discards cost tracking info, never panics), not `Result::unwrap()`.
- **M4 (Non-atomic nullifier storage)**: Added to `insert_nullifiers/v0/mod.rs` — explains that both the permanent nullifier ops and the sync storage write use the same GroveDB transaction, so they are rolled back atomically if the block is aborted.
- **M5 (Cross-transaction nullifier dedup)**: Added to `shielded_common/mod.rs` — explains sequential processing + read-your-own-writes ensures nullifiers from prior transitions in the same block are visible, with `insert_only_known_to_not_already_exist_op` as an additional safety net.

No code logic was changed — only comments were added.

## How Has This Been Tested?

- `cargo fmt -p drive-abci -p drive` — no formatting changes needed
- Comment-only changes — no functional impact, no tests needed

## Breaking Changes

None.

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [ ] I have made corresponding changes to the documentation if needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive safety documentation comments throughout the codebase to clarify transaction behavior and concurrency guarantees for developers reviewing state transition validation logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->