### PR TITLE
fix(dpp): add upper fee bound to unshield and withdrawal builders

### DIFF
--- a/packages/rs-dpp/src/shielded/builder/shielded_withdrawal.rs
+++ b/packages/rs-dpp/src/shielded/builder/shielded_withdrawal.rs
@@ -70,6 +70,12 @@ pub fn build_shielded_withdrawal_transition<P: OrchardProver>(
                 f, min_fee
             )));
         }
+        Some(f) if f > min_fee.saturating_mul(1000) => {
+            return Err(ProtocolError::ShieldedBuildError(format!(
+                "fee {} exceeds 1000x the minimum fee {}",
+                f, min_fee
+            )));
+        }
         Some(f) => f,
         None => min_fee,
     };
@@ -158,6 +164,49 @@ mod tests {
         let err = result.unwrap_err().to_string();
         assert!(
             err.contains("below minimum required fee"),
+            "unexpected error: {}",
+            err
+        );
+    }
+
+    #[test]
+    fn test_shielded_withdrawal_fee_above_upper_bound() {
+        let platform_version = PlatformVersion::latest();
+        let change_address = test_orchard_address();
+
+        let note = test_spendable_note(u64::MAX);
+        let spends = vec![note];
+
+        let sk = grovedb_commitment_tree::SpendingKey::from_bytes([42u8; 32])
+            .expect("valid spending key bytes");
+        let fvk = FullViewingKey::from(&sk);
+        let ask = SpendAuthorizingKey::from(&sk);
+
+        // Compute the minimum fee so we can exceed the 1000x bound
+        let num_actions = 1usize;
+        let min_fee = crate::shielded::compute_minimum_shielded_fee(num_actions, platform_version);
+        let excessive_fee = min_fee.saturating_mul(1000) + 1;
+
+        let result = build_shielded_withdrawal_transition(
+            spends,
+            100,
+            CoreScript::new_p2pkh([1u8; 20]),
+            1,
+            Pooling::Never,
+            &change_address,
+            &fvk,
+            &ask,
+            Anchor::empty_tree(),
+            &TestProver,
+            [0u8; 36],
+            Some(excessive_fee),
+            platform_version,
+        );
+
+        assert!(result.is_err());
+        let err = result.unwrap_err().to_string();
+        assert!(
+            err.contains("exceeds 1000x the minimum fee"),
             "unexpected error: {}",
             err
         );

--- a/packages/rs-dpp/src/shielded/builder/unshield.rs
+++ b/packages/rs-dpp/src/shielded/builder/unshield.rs
@@ -64,6 +64,12 @@ pub fn build_unshield_transition<P: OrchardProver>(
                 f, min_fee
             )));
         }
+        Some(f) if f > min_fee.saturating_mul(1000) => {
+            return Err(ProtocolError::ShieldedBuildError(format!(
+                "fee {} exceeds 1000x the minimum fee {}",
+                f, min_fee
+            )));
+        }
         Some(f) => f,
         None => min_fee,
     };
@@ -147,6 +153,48 @@ mod tests {
         let err = result.unwrap_err().to_string();
         assert!(
             err.contains("below minimum required fee"),
+            "unexpected error: {}",
+            err
+        );
+    }
+
+    #[test]
+    fn test_unshield_fee_above_upper_bound() {
+        let platform_version = PlatformVersion::latest();
+        let change_address = test_orchard_address();
+        let output_address = PlatformAddress::P2pkh([1u8; 20]);
+
+        let note = test_spendable_note(u64::MAX);
+        let spends = vec![note];
+
+        let sk = grovedb_commitment_tree::SpendingKey::from_bytes([42u8; 32])
+            .expect("valid spending key bytes");
+        let fvk = FullViewingKey::from(&sk);
+        let ask = SpendAuthorizingKey::from(&sk);
+
+        // Compute the minimum fee so we can exceed the 1000x bound
+        let num_actions = 1usize;
+        let min_fee = crate::shielded::compute_minimum_shielded_fee(num_actions, platform_version);
+        let excessive_fee = min_fee.saturating_mul(1000) + 1;
+
+        let result = build_unshield_transition(
+            spends,
+            output_address,
+            100,
+            &change_address,
+            &fvk,
+            &ask,
+            Anchor::empty_tree(),
+            &TestProver,
+            [0u8; 36],
+            Some(excessive_fee),
+            platform_version,
+        );
+
+        assert!(result.is_err());
+        let err = result.unwrap_err().to_string();
+        assert!(
+            err.contains("exceeds 1000x the minimum fee"),
             "unexpected error: {}",
             err
         );


### PR DESCRIPTION
## Issue being fixed or feature implemented

The `ShieldedTransfer` builder already validates that a user-provided fee does not exceed 1000x the minimum fee, preventing accidental fund burning. However, the `Unshield` and `ShieldedWithdrawal` builders were missing this upper-bound check, meaning a user who accidentally provides an enormous fee value would silently burn their funds.

## What was done?

- Added the `f > min_fee.saturating_mul(1000)` guard to the fee match in `build_unshield_transition` (`packages/rs-dpp/src/shielded/builder/unshield.rs`)
- Added the same guard to `build_shielded_withdrawal_transition` (`packages/rs-dpp/src/shielded/builder/shielded_withdrawal.rs`)
- Match arms are ordered consistently with the existing `shielded_transfer.rs` pattern: too-low, too-high, valid `Some(f)`, `None`
- Added unit tests (`test_unshield_fee_above_upper_bound` and `test_shielded_withdrawal_fee_above_upper_bound`) covering the new validation

## How Has This Been Tested?

- `cargo check -p dpp --features shielded-client` passes
- `cargo fmt -p dpp` produces no changes
- New unit tests verify the error message and that the builder returns `Err` for excessive fees

## Breaking Changes

None. This is a purely additive validation that rejects fees that were previously silently accepted but would have burned user funds.

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [x] I have made corresponding changes to the documentation if needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)