### PR TITLE
fix(drive-abci): use checked arithmetic in shielded fee calculation

### DIFF
--- a/packages/rs-drive-abci/src/execution/validation/state_transition/processor/traits/shielded_proof.rs
+++ b/packages/rs-drive-abci/src/execution/validation/state_transition/processor/traits/shielded_proof.rs
@@ -129,15 +129,31 @@ impl StateTransitionShieldedMinimumFeeValidationV0 for StateTransition {
                 // Storage fee per action: 312 bytes (280 BulkAppendTree + 32 nullifier)
                 // × (storage_disk_usage_credit_per_byte + storage_processing_credit_per_byte)
                 let storage_costs = &platform_version.fee_version.storage;
-                let storage_fee_per_action = SHIELDED_STORAGE_BYTES_PER_ACTION
-                    * (storage_costs.storage_disk_usage_credit_per_byte
-                        + storage_costs.storage_processing_credit_per_byte);
+                let storage_fee_per_action = storage_costs
+                    .storage_disk_usage_credit_per_byte
+                    .checked_add(storage_costs.storage_processing_credit_per_byte)
+                    .and_then(|sum| SHIELDED_STORAGE_BYTES_PER_ACTION.checked_mul(sum))
+                    .ok_or(Error::Execution(ExecutionError::Overflow(
+                        "storage fee per action overflow in shielded fee calculation",
+                    )))?;
 
                 // min_fee = proof_verification_fee + num_actions × (processing_fee + storage_fee)
-                let per_action_fee =
-                    constants.shielded_per_action_processing_fee + storage_fee_per_action;
-                let minimum_shielded_fee =
-                    constants.shielded_proof_verification_fee + num_actions as u64 * per_action_fee;
+                let per_action_fee = constants
+                    .shielded_per_action_processing_fee
+                    .checked_add(storage_fee_per_action)
+                    .ok_or(Error::Execution(ExecutionError::Overflow(
+                        "per-action fee overflow in shielded fee calculation",
+                    )))?;
+                let minimum_shielded_fee = (num_actions as u64)
+                    .checked_mul(per_action_fee)
+                    .and_then(|actions_fee| {
+                        constants
+                            .shielded_proof_verification_fee
+                            .checked_add(actions_fee)
+                    })
+                    .ok_or(Error::Execution(ExecutionError::Overflow(
+                        "minimum shielded fee overflow in shielded fee calculation",
+                    )))?;
 
                 if (fee as u64) < minimum_shielded_fee {
                     Ok(SimpleConsensusValidationResult::new_with_error(


### PR DESCRIPTION
## Issue being fixed or feature implemented

The `validate_minimum_shielded_fee` function in the shielded proof validation
uses unchecked multiplication and addition to compute the minimum fee. While
current protocol constants make overflow impossible, future protocol version
changes could introduce values that overflow `u64` arithmetic, leading to
silent wraparound and incorrect fee validation.

## What was done?

Replaced all unchecked arithmetic operators (`*`, `+`) in the minimum shielded
fee calculation with their checked counterparts (`checked_mul`, `checked_add`).
On overflow, the function now returns `ExecutionError::Overflow` with a
descriptive message instead of silently wrapping around.

Specifically, three arithmetic expressions were hardened:
1. `storage_fee_per_action` — addition of per-byte costs then multiplication by bytes-per-action
2. `per_action_fee` — addition of processing fee and storage fee
3. `minimum_shielded_fee` — multiplication by action count then addition of proof verification fee

## How Has This Been Tested?

- `cargo check -p drive-abci --lib` passes with no errors
- `cargo fmt -p drive-abci` confirms formatting is correct
- Existing tests (`validate_minimum_shielded_fee` module) continue to pass since current constants do not overflow

## Breaking Changes

None. This is a purely defensive change — behavior is identical for all non-overflowing inputs.

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [x] I have made corresponding changes to the documentation if needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)