### PR TITLE
fix(drive-abci): use checked_sub for ShieldFromAssetLock fee computation

### DIFF
--- a/packages/rs-drive-abci/src/execution/types/execution_event/mod.rs
+++ b/packages/rs-drive-abci/src/execution/types/execution_event/mod.rs
@@ -500,7 +500,12 @@ impl ExecutionEvent<'_> {
                 // Fee = asset_lock_value - shield_amount (excess from asset lock)
                 let fee_amount = shield_from_asset_lock_action
                     .asset_lock_value_to_be_consumed()
-                    .saturating_sub(shield_from_asset_lock_action.shield_amount());
+                    .checked_sub(shield_from_asset_lock_action.shield_amount())
+                    .ok_or(Error::Execution(
+                        ExecutionError::CorruptedCodeExecution(
+                            "shield amount exceeds asset lock value to be consumed in ShieldFromAssetLock fee computation",
+                        ),
+                    ))?;
                 let operations =
                     action.into_high_level_drive_operations(epoch, platform_version)?;
                 Ok(ExecutionEvent::PaidFromAssetLockToPool {


### PR DESCRIPTION
## Issue being fixed or feature implemented

The `ShieldFromAssetLock` fee computation uses `saturating_sub` to calculate `asset_lock_value - shield_amount`. If `shield_amount` ever exceeds `asset_lock_value_to_be_consumed` (which should be impossible but would indicate a bug), the fee silently becomes 0 instead of flagging the invariant violation. This could mask bugs in upstream validation logic.

## What was done?

- Replaced `saturating_sub` with `checked_sub` and `.ok_or(...)` error handling in the `ShieldFromAssetLock` fee computation
- If the subtraction underflows, a `CorruptedCodeExecution` error is returned with a descriptive message, consistent with how other invariant violations are handled in the same function

## How Has This Been Tested?

- `cargo check -p drive-abci` passes successfully
- `cargo fmt -p drive-abci` confirms formatting is correct
- The change is a defensive coding improvement; the underflow condition should never occur in practice but will now produce a clear error if it does

## Breaking Changes

None. This only changes error handling for a condition that should never occur.

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [ ] I have made corresponding changes to the documentation if needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)