### PR TITLE
fix(drive): error on unexpected element type in anchor retrieval

### DIFF
--- a/packages/rs-drive/src/drive/shielded/record_anchor_if_changed/v0/mod.rs
+++ b/packages/rs-drive/src/drive/shielded/record_anchor_if_changed/v0/mod.rs
@@ -59,7 +59,9 @@ impl Drive {
                         ))
                     })
                 } else {
-                    Ok([0u8; 32])
+                    Err(Error::Drive(DriveError::CorruptedElementType(
+                        "most recent anchor element is not an Item",
+                    )))
                 }
             })?;
 


### PR DESCRIPTION
## Issue being fixed or feature implemented

When the most recent anchor element stored in GroveDB is not an `Element::Item` (e.g., due to corruption), the code silently treats it as a zero anchor (`[0u8; 32]`) instead of flagging the corruption. This masks potential state corruption issues.

## What was done?

Changed the `else` branch in `record_shielded_pool_anchor_if_changed_v0` to return a `CorruptedElementType` error instead of silently defaulting to `[0u8; 32]`. This ensures that if the most recent anchor element has an unexpected type, the corruption is surfaced immediately rather than masked.

**File changed:** `packages/rs-drive/src/drive/shielded/record_anchor_if_changed/v0/mod.rs`

Before:
```rust
} else {
    Ok([0u8; 32])
}
```

After:
```rust
} else {
    Err(Error::Drive(DriveError::CorruptedElementType(
        "most recent anchor element is not an Item",
    )))
}
```

## How Has This Been Tested?

- `cargo fmt -p drive` -- passes
- `cargo check -p drive --features server` -- passes

## Breaking Changes

None. This only changes behavior in a corruption scenario that was previously silently ignored.

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [x] I have made corresponding changes to the documentation if needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)