### PR TITLE
docs(drive): document trusted-state rationale for bincode NoLimit

### DIFF
--- a/packages/rs-drive/src/drive/shielded/nullifiers/types.rs
+++ b/packages/rs-drive/src/drive/shielded/nullifiers/types.rs
@@ -15,6 +15,12 @@ impl CompactedNullifiers {
     }
 
     /// Returns the bincode configuration used for nullifier serialization.
+    ///
+    /// SAFETY: `with_no_limit()` is intentional. This data is deserialized from
+    /// GroveDB state which is always trusted. If state-level corruption occurs,
+    /// the problem is at the storage layer, not the deserialization layer.
+    /// Adding artificial limits here would mask real issues without providing
+    /// meaningful protection.
     fn bincode_config() -> bincode::config::Configuration<
         bincode::config::BigEndian,
         bincode::config::Varint,
@@ -75,6 +81,8 @@ impl NullifierExpirationRanges {
     }
 
     /// Returns the bincode configuration used for expiration range serialization.
+    ///
+    /// SAFETY: `with_no_limit()` is intentional — see `CompactedNullifiers::bincode_config`.
     fn bincode_config() -> bincode::config::Configuration<
         bincode::config::BigEndian,
         bincode::config::Varint,


### PR DESCRIPTION
## Summary
- Adds SAFETY comments to `CompactedNullifiers::bincode_config()` and `NullifierExpirationRanges::bincode_config()` explaining why `with_no_limit()` is intentional
- GroveDB state is trusted — if storage-level corruption occurs, artificial deserialization limits would mask the real problem rather than providing meaningful protection

## Context
Security audit flagged `with_no_limit()` as a potential DoS vector (L7). After review, this was determined to be a false positive: this data is only deserialized from GroveDB's own trusted state, never from untrusted external input. Adding this comment to prevent future auditors from re-investigating.

## Test plan
- [x] Documentation-only change, no logic changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added clarifying documentation comments to explain internal configuration settings and their rationale.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->