### PR TITLE
chore: add audits/ to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -91,3 +91,6 @@ grpc-coverage-report.txt
 
 __pycache__/
 .claude/worktrees/
+
+# Security audit reports (local-only, not committed)
+audits/


### PR DESCRIPTION
## Summary
- Adds `audits/` directory to `.gitignore` so security audit reports can be stored locally without being accidentally committed

## Test plan
- [x] `git status` confirms `audits/` directory is ignored

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated version control configuration to exclude security audit reports from the repository.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->