### PR TITLE
feat(drive): bump grovedb and expose key_exists_as_boundary for pagination

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -116,9 +116,9 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.13"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5192cca8006f1fd4f7237516f40fa183bb07f8fbdfedaa0036de5ea9b0b45e78"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
 
 [[package]]
 name = "anstyle-parse"
@@ -912,9 +912,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.56"
+version = "1.2.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aebf35691d1bfb0ac386a69bac2fde4dd276fb618cf8bf4f5318fe285e821bb2"
+checksum = "7a0dd1ca384932ff3641c8718a02769f1698e7563dc6974ffd03346116310423"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -1127,9 +1127,9 @@ dependencies = [
 
 [[package]]
 name = "colorchoice"
-version = "1.0.4"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
+checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "colored"
@@ -1492,12 +1492,12 @@ dependencies = [
 
 [[package]]
 name = "darling"
-version = "0.21.3"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cdf337090841a411e2a7f3deb9187445851f91b309c0c0a29e05f74a00a48c0"
+checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
 dependencies = [
- "darling_core 0.21.3",
- "darling_macro 0.21.3",
+ "darling_core 0.23.0",
+ "darling_macro 0.23.0",
 ]
 
 [[package]]
@@ -1516,11 +1516,10 @@ dependencies = [
 
 [[package]]
 name = "darling_core"
-version = "0.21.3"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1247195ecd7e3c85f83c8d2a366e4210d588e802133e1e355180a9870b517ea4"
+checksum = "9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0"
 dependencies = [
- "fnv",
  "ident_case",
  "proc-macro2",
  "quote",
@@ -1541,11 +1540,11 @@ dependencies = [
 
 [[package]]
 name = "darling_macro"
-version = "0.21.3"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d38308df82d1080de0afee5d069fa14b0326a88c14f15c5ccda35b4a6c414c81"
+checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
 dependencies = [
- "darling_core 0.21.3",
+ "darling_core 0.23.0",
  "quote",
  "syn 2.0.117",
 ]
@@ -1607,7 +1606,7 @@ dependencies = [
  "drive-proof-verifier",
  "envy",
  "futures",
- "grovedb-commitment-tree 4.0.0 (git+https://github.com/dashpay/grovedb?rev=7ecb8465fad750c7cddd5332adb6f97fcceb498b)",
+ "grovedb-commitment-tree",
  "hex",
  "http",
  "js-sys",
@@ -1949,7 +1948,7 @@ dependencies = [
  "dpp-json-convertible-derive",
  "env_logger 0.11.9",
  "getrandom 0.2.17",
- "grovedb-commitment-tree 4.0.0 (git+https://github.com/dashpay/grovedb?rev=dd99ed1db0350e5f39127573808dd172c6bc2346)",
+ "grovedb-commitment-tree",
  "hex",
  "indexmap 2.13.0",
  "integer-encoding",
@@ -1961,7 +1960,7 @@ dependencies = [
  "lazy_static",
  "log",
  "nohash-hasher",
- "num_enum 0.7.5",
+ "num_enum 0.7.6",
  "once_cell",
  "platform-serialization",
  "platform-serialization-derive",
@@ -2009,7 +2008,7 @@ dependencies = [
  "dpp",
  "enum-map",
  "grovedb",
- "grovedb-costs 4.0.0 (git+https://github.com/dashpay/grovedb?rev=dd99ed1db0350e5f39127573808dd172c6bc2346)",
+ "grovedb-costs",
  "grovedb-epoch-based-storage-flags",
  "grovedb-path",
  "grovedb-storage",
@@ -2057,7 +2056,7 @@ dependencies = [
  "drive-proof-verifier",
  "envy",
  "file-rotate",
- "grovedb-commitment-tree 4.0.0 (git+https://github.com/dashpay/grovedb?rev=dd99ed1db0350e5f39127573808dd172c6bc2346)",
+ "grovedb-commitment-tree",
  "hex",
  "indexmap 2.13.0",
  "integer-encoding",
@@ -2717,15 +2716,15 @@ dependencies = [
 [[package]]
 name = "grovedb"
 version = "4.0.0"
-source = "git+https://github.com/dashpay/grovedb?rev=dd99ed1db0350e5f39127573808dd172c6bc2346#dd99ed1db0350e5f39127573808dd172c6bc2346"
+source = "git+https://github.com/dashpay/grovedb?rev=80f009386570cd8d92c989d55d48dbe84596e34c#80f009386570cd8d92c989d55d48dbe84596e34c"
 dependencies = [
  "axum 0.8.8",
  "bincode",
  "bincode_derive",
  "blake3",
  "grovedb-bulk-append-tree",
- "grovedb-commitment-tree 4.0.0 (git+https://github.com/dashpay/grovedb?rev=dd99ed1db0350e5f39127573808dd172c6bc2346)",
- "grovedb-costs 4.0.0 (git+https://github.com/dashpay/grovedb?rev=dd99ed1db0350e5f39127573808dd172c6bc2346)",
+ "grovedb-commitment-tree",
+ "grovedb-costs",
  "grovedb-dense-fixed-sized-merkle-tree",
  "grovedb-element",
  "grovedb-merk",
@@ -2755,11 +2754,11 @@ dependencies = [
 [[package]]
 name = "grovedb-bulk-append-tree"
 version = "4.0.0"
-source = "git+https://github.com/dashpay/grovedb?rev=dd99ed1db0350e5f39127573808dd172c6bc2346#dd99ed1db0350e5f39127573808dd172c6bc2346"
+source = "git+https://github.com/dashpay/grovedb?rev=80f009386570cd8d92c989d55d48dbe84596e34c#80f009386570cd8d92c989d55d48dbe84596e34c"
 dependencies = [
  "bincode",
  "blake3",
- "grovedb-costs 4.0.0 (git+https://github.com/dashpay/grovedb?rev=dd99ed1db0350e5f39127573808dd172c6bc2346)",
+ "grovedb-costs",
  "grovedb-dense-fixed-sized-merkle-tree",
  "grovedb-merkle-mountain-range",
  "grovedb-query",
@@ -2771,10 +2770,12 @@ dependencies = [
 [[package]]
 name = "grovedb-commitment-tree"
 version = "4.0.0"
-source = "git+https://github.com/dashpay/grovedb?rev=7ecb8465fad750c7cddd5332adb6f97fcceb498b#7ecb8465fad750c7cddd5332adb6f97fcceb498b"
+source = "git+https://github.com/dashpay/grovedb?rev=80f009386570cd8d92c989d55d48dbe84596e34c#80f009386570cd8d92c989d55d48dbe84596e34c"
 dependencies = [
  "blake3",
- "grovedb-costs 4.0.0 (git+https://github.com/dashpay/grovedb?rev=7ecb8465fad750c7cddd5332adb6f97fcceb498b)",
+ "grovedb-bulk-append-tree",
+ "grovedb-costs",
+ "grovedb-storage",
  "incrementalmerkletree",
  "orchard",
  "rusqlite",
@@ -2783,34 +2784,9 @@ dependencies = [
 ]
 
 [[package]]
-name = "grovedb-commitment-tree"
-version = "4.0.0"
-source = "git+https://github.com/dashpay/grovedb?rev=dd99ed1db0350e5f39127573808dd172c6bc2346#dd99ed1db0350e5f39127573808dd172c6bc2346"
-dependencies = [
- "blake3",
- "grovedb-bulk-append-tree",
- "grovedb-costs 4.0.0 (git+https://github.com/dashpay/grovedb?rev=dd99ed1db0350e5f39127573808dd172c6bc2346)",
- "grovedb-storage",
- "incrementalmerkletree",
- "orchard",
- "shardtree",
- "thiserror 2.0.18",
-]
-
-[[package]]
 name = "grovedb-costs"
 version = "4.0.0"
-source = "git+https://github.com/dashpay/grovedb?rev=7ecb8465fad750c7cddd5332adb6f97fcceb498b#7ecb8465fad750c7cddd5332adb6f97fcceb498b"
-dependencies = [
- "integer-encoding",
- "intmap",
- "thiserror 2.0.18",
-]
-
-[[package]]
-name = "grovedb-costs"
-version = "4.0.0"
-source = "git+https://github.com/dashpay/grovedb?rev=dd99ed1db0350e5f39127573808dd172c6bc2346#dd99ed1db0350e5f39127573808dd172c6bc2346"
+source = "git+https://github.com/dashpay/grovedb?rev=80f009386570cd8d92c989d55d48dbe84596e34c#80f009386570cd8d92c989d55d48dbe84596e34c"
 dependencies = [
  "integer-encoding",
  "intmap",
@@ -2820,11 +2796,11 @@ dependencies = [
 [[package]]
 name = "grovedb-dense-fixed-sized-merkle-tree"
 version = "4.0.0"
-source = "git+https://github.com/dashpay/grovedb?rev=dd99ed1db0350e5f39127573808dd172c6bc2346#dd99ed1db0350e5f39127573808dd172c6bc2346"
+source = "git+https://github.com/dashpay/grovedb?rev=80f009386570cd8d92c989d55d48dbe84596e34c#80f009386570cd8d92c989d55d48dbe84596e34c"
 dependencies = [
  "bincode",
  "blake3",
- "grovedb-costs 4.0.0 (git+https://github.com/dashpay/grovedb?rev=dd99ed1db0350e5f39127573808dd172c6bc2346)",
+ "grovedb-costs",
  "grovedb-query",
  "grovedb-storage",
  "thiserror 2.0.18",
@@ -2833,7 +2809,7 @@ dependencies = [
 [[package]]
 name = "grovedb-element"
 version = "4.0.0"
-source = "git+https://github.com/dashpay/grovedb?rev=dd99ed1db0350e5f39127573808dd172c6bc2346#dd99ed1db0350e5f39127573808dd172c6bc2346"
+source = "git+https://github.com/dashpay/grovedb?rev=80f009386570cd8d92c989d55d48dbe84596e34c#80f009386570cd8d92c989d55d48dbe84596e34c"
 dependencies = [
  "bincode",
  "bincode_derive",
@@ -2848,9 +2824,9 @@ dependencies = [
 [[package]]
 name = "grovedb-epoch-based-storage-flags"
 version = "4.0.0"
-source = "git+https://github.com/dashpay/grovedb?rev=dd99ed1db0350e5f39127573808dd172c6bc2346#dd99ed1db0350e5f39127573808dd172c6bc2346"
+source = "git+https://github.com/dashpay/grovedb?rev=80f009386570cd8d92c989d55d48dbe84596e34c#80f009386570cd8d92c989d55d48dbe84596e34c"
 dependencies = [
- "grovedb-costs 4.0.0 (git+https://github.com/dashpay/grovedb?rev=dd99ed1db0350e5f39127573808dd172c6bc2346)",
+ "grovedb-costs",
  "hex",
  "integer-encoding",
  "intmap",
@@ -2860,7 +2836,7 @@ dependencies = [
 [[package]]
 name = "grovedb-merk"
 version = "4.0.0"
-source = "git+https://github.com/dashpay/grovedb?rev=dd99ed1db0350e5f39127573808dd172c6bc2346#dd99ed1db0350e5f39127573808dd172c6bc2346"
+source = "git+https://github.com/dashpay/grovedb?rev=80f009386570cd8d92c989d55d48dbe84596e34c#80f009386570cd8d92c989d55d48dbe84596e34c"
 dependencies = [
  "bincode",
  "bincode_derive",
@@ -2868,7 +2844,7 @@ dependencies = [
  "byteorder",
  "colored",
  "ed",
- "grovedb-costs 4.0.0 (git+https://github.com/dashpay/grovedb?rev=dd99ed1db0350e5f39127573808dd172c6bc2346)",
+ "grovedb-costs",
  "grovedb-element",
  "grovedb-path",
  "grovedb-query",
@@ -2886,18 +2862,18 @@ dependencies = [
 [[package]]
 name = "grovedb-merkle-mountain-range"
 version = "4.0.0"
-source = "git+https://github.com/dashpay/grovedb?rev=dd99ed1db0350e5f39127573808dd172c6bc2346#dd99ed1db0350e5f39127573808dd172c6bc2346"
+source = "git+https://github.com/dashpay/grovedb?rev=80f009386570cd8d92c989d55d48dbe84596e34c#80f009386570cd8d92c989d55d48dbe84596e34c"
 dependencies = [
  "bincode",
  "blake3",
- "grovedb-costs 4.0.0 (git+https://github.com/dashpay/grovedb?rev=dd99ed1db0350e5f39127573808dd172c6bc2346)",
+ "grovedb-costs",
  "grovedb-storage",
 ]
 
 [[package]]
 name = "grovedb-path"
 version = "4.0.0"
-source = "git+https://github.com/dashpay/grovedb?rev=dd99ed1db0350e5f39127573808dd172c6bc2346#dd99ed1db0350e5f39127573808dd172c6bc2346"
+source = "git+https://github.com/dashpay/grovedb?rev=80f009386570cd8d92c989d55d48dbe84596e34c#80f009386570cd8d92c989d55d48dbe84596e34c"
 dependencies = [
  "hex",
 ]
@@ -2905,12 +2881,12 @@ dependencies = [
 [[package]]
 name = "grovedb-query"
 version = "4.0.0"
-source = "git+https://github.com/dashpay/grovedb?rev=dd99ed1db0350e5f39127573808dd172c6bc2346#dd99ed1db0350e5f39127573808dd172c6bc2346"
+source = "git+https://github.com/dashpay/grovedb?rev=80f009386570cd8d92c989d55d48dbe84596e34c#80f009386570cd8d92c989d55d48dbe84596e34c"
 dependencies = [
  "bincode",
  "byteorder",
  "ed",
- "grovedb-costs 4.0.0 (git+https://github.com/dashpay/grovedb?rev=dd99ed1db0350e5f39127573808dd172c6bc2346)",
+ "grovedb-costs",
  "grovedb-storage",
  "hex",
  "indexmap 2.13.0",
@@ -2921,10 +2897,10 @@ dependencies = [
 [[package]]
 name = "grovedb-storage"
 version = "4.0.0"
-source = "git+https://github.com/dashpay/grovedb?rev=dd99ed1db0350e5f39127573808dd172c6bc2346#dd99ed1db0350e5f39127573808dd172c6bc2346"
+source = "git+https://github.com/dashpay/grovedb?rev=80f009386570cd8d92c989d55d48dbe84596e34c#80f009386570cd8d92c989d55d48dbe84596e34c"
 dependencies = [
  "blake3",
- "grovedb-costs 4.0.0 (git+https://github.com/dashpay/grovedb?rev=dd99ed1db0350e5f39127573808dd172c6bc2346)",
+ "grovedb-costs",
  "grovedb-path",
  "grovedb-visualize",
  "hex",
@@ -2940,7 +2916,7 @@ dependencies = [
 [[package]]
 name = "grovedb-version"
 version = "4.0.0"
-source = "git+https://github.com/dashpay/grovedb?rev=dd99ed1db0350e5f39127573808dd172c6bc2346#dd99ed1db0350e5f39127573808dd172c6bc2346"
+source = "git+https://github.com/dashpay/grovedb?rev=80f009386570cd8d92c989d55d48dbe84596e34c#80f009386570cd8d92c989d55d48dbe84596e34c"
 dependencies = [
  "thiserror 2.0.18",
  "versioned-feature-core 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2949,7 +2925,7 @@ dependencies = [
 [[package]]
 name = "grovedb-visualize"
 version = "4.0.0"
-source = "git+https://github.com/dashpay/grovedb?rev=dd99ed1db0350e5f39127573808dd172c6bc2346#dd99ed1db0350e5f39127573808dd172c6bc2346"
+source = "git+https://github.com/dashpay/grovedb?rev=80f009386570cd8d92c989d55d48dbe84596e34c#80f009386570cd8d92c989d55d48dbe84596e34c"
 dependencies = [
  "hex",
  "itertools 0.14.0",
@@ -2958,10 +2934,10 @@ dependencies = [
 [[package]]
 name = "grovedbg-types"
 version = "4.0.0"
-source = "git+https://github.com/dashpay/grovedb?rev=dd99ed1db0350e5f39127573808dd172c6bc2346#dd99ed1db0350e5f39127573808dd172c6bc2346"
+source = "git+https://github.com/dashpay/grovedb?rev=80f009386570cd8d92c989d55d48dbe84596e34c#80f009386570cd8d92c989d55d48dbe84596e34c"
 dependencies = [
  "serde",
- "serde_with 3.17.0",
+ "serde_with 3.18.0",
 ]
 
 [[package]]
@@ -4489,11 +4465,11 @@ dependencies = [
 
 [[package]]
 name = "num_enum"
-version = "0.7.5"
+version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1207a7e20ad57b847bbddc6776b968420d38292bbfe2089accff5e19e82454c"
+checksum = "5d0bca838442ec211fa11de3a8b0e0e8f3a4522575b5c4c06ed722e005036f26"
 dependencies = [
- "num_enum_derive 0.7.5",
+ "num_enum_derive 0.7.6",
  "rustversion",
 ]
 
@@ -4511,9 +4487,9 @@ dependencies = [
 
 [[package]]
 name = "num_enum_derive"
-version = "0.7.5"
+version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff32365de1b6743cb203b710788263c44a03de03802daf96092f2da4fe6ba4d7"
+checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
 dependencies = [
  "proc-macro-crate 3.5.0",
  "proc-macro2",
@@ -4967,9 +4943,9 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portable-atomic-util"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a9db96d7fa8782dd8c15ce32ffe8680bbd1e978a43bf51a34d39483540495f5"
+checksum = "091397be61a01d4be58e7841595bd4bfedb15f1cd54977d79b8271e94ed799a3"
 dependencies = [
  "portable-atomic",
 ]
@@ -6452,9 +6428,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "3.17.0"
+version = "3.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "381b283ce7bc6b476d903296fb59d0d36633652b633b27f64db4fb46dcbfc3b9"
+checksum = "dd5414fad8e6907dbdd5bc441a50ae8d6e26151a03b1de04d89a5576de61d01f"
 dependencies = [
  "base64 0.22.1",
  "chrono",
@@ -6465,7 +6441,7 @@ dependencies = [
  "schemars 1.2.1",
  "serde_core",
  "serde_json",
- "serde_with_macros 3.17.0",
+ "serde_with_macros 3.18.0",
  "time",
 ]
 
@@ -6483,11 +6459,11 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "3.17.0"
+version = "3.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6d4e30573c8cb306ed6ab1dca8423eec9a463ea0e155f45399455e0368b27e0"
+checksum = "d3db8978e608f1fe7357e211969fd9abdcae80bac1ba7a3369bb7eb6b404eb65"
 dependencies = [
- "darling 0.21.3",
+ "darling 0.23.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -7132,9 +7108,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.10.0"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfa5fdc3bce6191a1dbc8c02d5c8bffcf557bafa17c124c5264a458f1b0613fa"
+checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -7640,9 +7616,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.3.22"
+version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f30143827ddab0d256fd843b7a66d164e9f271cfa0dde49142c5ca0ca291f1e"
+checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
 dependencies = [
  "matchers",
  "nu-ansi-term",
@@ -8096,7 +8072,7 @@ dependencies = [
  "itertools 0.13.0",
  "js-sys",
  "log",
- "num_enum 0.7.5",
+ "num_enum 0.7.6",
  "pastey",
  "serde",
  "serde-wasm-bindgen 0.5.0 (git+https://github.com/QuantumExplorer/serde-wasm-bindgen?branch=feat%2Fnot_human_readable)",

--- a/packages/rs-dpp/Cargo.toml
+++ b/packages/rs-dpp/Cargo.toml
@@ -72,7 +72,7 @@ strum = { version = "0.26", features = ["derive"] }
 json-schema-compatibility-validator = { path = '../rs-json-schema-compatibility-validator', optional = true }
 once_cell = "1.19.0"
 tracing = { version = "0.1.41" }
-grovedb-commitment-tree = { git = "https://github.com/dashpay/grovedb", rev = "dd99ed1db0350e5f39127573808dd172c6bc2346", optional = true }
+grovedb-commitment-tree = { git = "https://github.com/dashpay/grovedb", rev = "80f009386570cd8d92c989d55d48dbe84596e34c", optional = true }
 
 [dev-dependencies]
 tokio = { version = "1.40", features = ["full"] }

--- a/packages/rs-drive-abci/Cargo.toml
+++ b/packages/rs-drive-abci/Cargo.toml
@@ -82,7 +82,7 @@ derive_more = { version = "1.0", features = ["from", "deref", "deref_mut"] }
 async-trait = "0.1.77"
 console-subscriber = { version = "0.4", optional = true }
 bls-signatures = { git = "https://github.com/dashpay/bls-signatures", rev = "0842b17583888e8f46c252a4ee84cdfd58e0546f", optional = true }
-grovedb-commitment-tree = { git = "https://github.com/dashpay/grovedb", rev = "dd99ed1db0350e5f39127573808dd172c6bc2346" }
+grovedb-commitment-tree = { git = "https://github.com/dashpay/grovedb", rev = "80f009386570cd8d92c989d55d48dbe84596e34c" }
 nonempty = "0.11"
 
 [dev-dependencies]
@@ -103,7 +103,7 @@ dpp = { path = "../rs-dpp", default-features = false, features = [
 drive = { path = "../rs-drive", features = ["fixtures-and-mocks"] }
 drive-proof-verifier = { path = "../rs-drive-proof-verifier" }
 strategy-tests = { path = "../strategy-tests" }
-grovedb-commitment-tree = { git = "https://github.com/dashpay/grovedb", rev = "dd99ed1db0350e5f39127573808dd172c6bc2346", features = ["client"] }
+grovedb-commitment-tree = { git = "https://github.com/dashpay/grovedb", rev = "80f009386570cd8d92c989d55d48dbe84596e34c", features = ["client"] }
 assert_matches = "1.5.0"
 drive-abci = { path = ".", features = ["testing-config", "mocks"] }
 bls-signatures = { git = "https://github.com/dashpay/bls-signatures", rev = "0842b17583888e8f46c252a4ee84cdfd58e0546f" }

--- a/packages/rs-drive/Cargo.toml
+++ b/packages/rs-drive/Cargo.toml
@@ -52,12 +52,12 @@ enum-map = { version = "2.0.3", optional = true }
 intmap = { version = "3.0.1", features = ["serde"], optional = true }
 chrono = { version = "0.4.35", optional = true }
 itertools = { version = "0.13", optional = true }
-grovedb = { git = "https://github.com/dashpay/grovedb", rev = "dd99ed1db0350e5f39127573808dd172c6bc2346", optional = true, default-features = false }
-grovedb-costs = { git = "https://github.com/dashpay/grovedb", rev = "dd99ed1db0350e5f39127573808dd172c6bc2346", optional = true }
-grovedb-path = { git = "https://github.com/dashpay/grovedb", rev = "dd99ed1db0350e5f39127573808dd172c6bc2346" }
-grovedb-storage = { git = "https://github.com/dashpay/grovedb", rev = "dd99ed1db0350e5f39127573808dd172c6bc2346", optional = true }
-grovedb-version = { git = "https://github.com/dashpay/grovedb", rev = "dd99ed1db0350e5f39127573808dd172c6bc2346" }
-grovedb-epoch-based-storage-flags = { git = "https://github.com/dashpay/grovedb", rev = "dd99ed1db0350e5f39127573808dd172c6bc2346" }
+grovedb = { git = "https://github.com/dashpay/grovedb", rev = "80f009386570cd8d92c989d55d48dbe84596e34c", optional = true, default-features = false }
+grovedb-costs = { git = "https://github.com/dashpay/grovedb", rev = "80f009386570cd8d92c989d55d48dbe84596e34c", optional = true }
+grovedb-path = { git = "https://github.com/dashpay/grovedb", rev = "80f009386570cd8d92c989d55d48dbe84596e34c" }
+grovedb-storage = { git = "https://github.com/dashpay/grovedb", rev = "80f009386570cd8d92c989d55d48dbe84596e34c", optional = true }
+grovedb-version = { git = "https://github.com/dashpay/grovedb", rev = "80f009386570cd8d92c989d55d48dbe84596e34c" }
+grovedb-epoch-based-storage-flags = { git = "https://github.com/dashpay/grovedb", rev = "80f009386570cd8d92c989d55d48dbe84596e34c" }
 
 [dev-dependencies]
 criterion = "0.5"

--- a/packages/rs-drive/src/drive/initialization/v0/mod.rs
+++ b/packages/rs-drive/src/drive/initialization/v0/mod.rs
@@ -1295,7 +1295,7 @@ mod tests {
                 drive_version,
             )
             .expect("expected to get root elements");
-        assert_eq!(proof.len(), 113); //it + left + right
+        assert_eq!(proof.len(), 112); //it + left + right
 
         // Merk Level 1
         let mut query = Query::new();
@@ -1317,7 +1317,7 @@ mod tests {
                 drive_version,
             )
             .expect("expected to get root elements");
-        assert_eq!(proof.len(), 181); //it + left + right + parent + parent other
+        assert_eq!(proof.len(), 180); //it + left + right + parent + parent other
 
         let mut query = Query::new();
         query.insert_key(vec![RootTree::Balances as u8]);
@@ -1338,7 +1338,7 @@ mod tests {
                 drive_version,
             )
             .expect("expected to get root elements");
-        assert_eq!(proof.len(), 182); //it + left + right + parent + parent other
+        assert_eq!(proof.len(), 181); //it + left + right + parent + parent other
 
         // Merk Level 2
         let mut query = Query::new();
@@ -1360,7 +1360,7 @@ mod tests {
                 drive_version,
             )
             .expect("expected to get root elements");
-        assert_eq!(proof.len(), 286); //it + left + right + parent + sibling + parent sibling + grandparent (was 251, +35 from KVValueHashFeatureTypeWithChildHash)
+        assert_eq!(proof.len(), 285); //it + left + right + parent + sibling + parent sibling + grandparent (was 251, +35 from KVValueHashFeatureTypeWithChildHash)
 
         let mut query = Query::new();
         query.insert_key(vec![RootTree::Pools as u8]);
@@ -1381,7 +1381,7 @@ mod tests {
                 drive_version,
             )
             .expect("expected to get root elements");
-        assert_eq!(proof.len(), 288); //it + left + parent + sibling + parent sibling + grandparent (was 253, +35 from KVValueHashFeatureTypeWithChildHash)
+        assert_eq!(proof.len(), 287); //it + left + parent + sibling + parent sibling + grandparent (was 253, +35 from KVValueHashFeatureTypeWithChildHash)
 
         let mut query = Query::new();
         query.insert_key(vec![RootTree::WithdrawalTransactions as u8]);
@@ -1402,7 +1402,7 @@ mod tests {
                 drive_version,
             )
             .expect("expected to get root elements");
-        assert_eq!(proof.len(), 286); //it + left + right + parent + sibling + parent sibling + grandparent (was 251, +35 from KVValueHashFeatureTypeWithChildHash)
+        assert_eq!(proof.len(), 285); //it + left + right + parent + sibling + parent sibling + grandparent (was 251, +35 from KVValueHashFeatureTypeWithChildHash)
 
         let mut query = Query::new();
         query.insert_key(vec![RootTree::Votes as u8]);
@@ -1423,7 +1423,7 @@ mod tests {
                 drive_version,
             )
             .expect("expected to get root elements");
-        assert_eq!(proof.len(), 286); //it + left + right + parent + sibling + parent sibling + grandparent (was 251, +35 from KVValueHashFeatureTypeWithChildHash)
+        assert_eq!(proof.len(), 285); //it + left + right + parent + sibling + parent sibling + grandparent (was 251, +35 from KVValueHashFeatureTypeWithChildHash)
 
         // Merk Level 3
 
@@ -1446,7 +1446,7 @@ mod tests {
                 drive_version,
             )
             .expect("expected to get root elements");
-        assert_eq!(proof.len(), 249); //it + parent + sibling + parent sibling + grandparent + grandparent sibling + great-grandparent
+        assert_eq!(proof.len(), 248); //it + parent + sibling + parent sibling + grandparent + grandparent sibling + great-grandparent
 
         let mut query = Query::new();
         query.insert_key(vec![
@@ -1469,7 +1469,7 @@ mod tests {
                 drive_version,
             )
             .expect("expected to get root elements");
-        assert_eq!(proof.len(), 249); //it + parent + sibling + parent sibling + grandparent + grandparent sibling + great-grandparent
+        assert_eq!(proof.len(), 248); //it + parent + sibling + parent sibling + grandparent + grandparent sibling + great-grandparent
 
         let mut query = Query::new();
         query.insert_key(vec![RootTree::PreFundedSpecializedBalances as u8]);
@@ -1490,7 +1490,7 @@ mod tests {
                 drive_version,
             )
             .expect("expected to get root elements");
-        assert_eq!(proof.len(), 321); //it + parent + sibling + parent sibling + grandparent + grandparent sibling + great-grandparent (was 288, +33 from KVValueHashFeatureTypeWithChildHash)
+        assert_eq!(proof.len(), 320); //it + parent + sibling + parent sibling + grandparent + grandparent sibling + great-grandparent (was 288, +33 from KVValueHashFeatureTypeWithChildHash)
 
         let mut query = Query::new();
         query.insert_key(vec![RootTree::AddressBalances as u8]);
@@ -1511,7 +1511,7 @@ mod tests {
                 drive_version,
             )
             .expect("expected to get root elements");
-        assert_eq!(proof.len(), 287); //it + parent + sibling + parent sibling + grandparent + grandparent sibling + great-grandparent (was 252, +35 from KVValueHashFeatureTypeWithChildHash)
+        assert_eq!(proof.len(), 286); //it + parent + sibling + parent sibling + grandparent + grandparent sibling + great-grandparent (was 252, +35 from KVValueHashFeatureTypeWithChildHash)
 
         let mut query = Query::new();
         query.insert_key(vec![RootTree::SpentAssetLockTransactions as u8]);
@@ -1532,7 +1532,7 @@ mod tests {
                 drive_version,
             )
             .expect("expected to get root elements");
-        assert_eq!(proof.len(), 249); //it + parent + sibling + parent sibling + grandparent + grandparent sibling + great-grandparent
+        assert_eq!(proof.len(), 248); //it + parent + sibling + parent sibling + grandparent + grandparent sibling + great-grandparent
 
         let mut query = Query::new();
         query.insert_key(vec![RootTree::GroupActions as u8]);
@@ -1553,7 +1553,7 @@ mod tests {
                 drive_version,
             )
             .expect("expected to get root elements");
-        assert_eq!(proof.len(), 249); //it + parent + sibling + parent sibling + grandparent + grandparent sibling + great-grandparent
+        assert_eq!(proof.len(), 248); //it + parent + sibling + parent sibling + grandparent + grandparent sibling + great-grandparent
 
         let mut query = Query::new();
         query.insert_key(vec![RootTree::Misc as u8]);
@@ -1574,7 +1574,7 @@ mod tests {
                 drive_version,
             )
             .expect("expected to get root elements");
-        assert_eq!(proof.len(), 286); //it + parent + sibling + parent sibling + grandparent + grandparent sibling + great-grandparent (was 251, +35 from KVValueHashFeatureTypeWithChildHash)
+        assert_eq!(proof.len(), 285); //it + parent + sibling + parent sibling + grandparent + grandparent sibling + great-grandparent (was 251, +35 from KVValueHashFeatureTypeWithChildHash)
 
         let mut query = Query::new();
         query.insert_key(vec![RootTree::Versions as u8]);
@@ -1595,7 +1595,7 @@ mod tests {
                 drive_version,
             )
             .expect("expected to get root elements");
-        assert_eq!(proof.len(), 286); //it + parent + sibling + parent sibling + grandparent + grandparent sibling + great-grandparent (was 251, +35 from KVValueHashFeatureTypeWithChildHash)
+        assert_eq!(proof.len(), 285); //it + parent + sibling + parent sibling + grandparent + grandparent sibling + great-grandparent (was 251, +35 from KVValueHashFeatureTypeWithChildHash)
 
         // Merk Level 4
 
@@ -1618,6 +1618,6 @@ mod tests {
                 drive_version,
             )
             .expect("expected to get root elements");
-        assert_eq!(proof.len(), 320); //it + parent + parent sibling + grandparent + grandparent sibling + great-grandparent + great-grandparent sibling + great-great-grandparent (was 287, +33 from KVValueHashFeatureTypeWithChildHash)
+        assert_eq!(proof.len(), 319); //it + parent + parent sibling + grandparent + grandparent sibling + great-grandparent + great-grandparent sibling + great-great-grandparent (was 287, +33 from KVValueHashFeatureTypeWithChildHash)
     }
 }

--- a/packages/rs-drive/src/drive/initialization/v0/mod.rs
+++ b/packages/rs-drive/src/drive/initialization/v0/mod.rs
@@ -1269,6 +1269,8 @@ mod tests {
     }
 
     #[test]
+    /// Proof sizes differ from v11 by +33/+35 bytes on nodes touching the
+    /// shielded pool subtree, which uses `KVValueHashFeatureTypeWithChildHash`.
     fn test_initial_state_structure_proper_heights_in_latest_protocol_version() {
         let drive = setup_drive_with_initial_state_structure(None);
 
@@ -1360,7 +1362,7 @@ mod tests {
                 drive_version,
             )
             .expect("expected to get root elements");
-        assert_eq!(proof.len(), 285); //it + left + right + parent + sibling + parent sibling + grandparent (was 251, +35 from KVValueHashFeatureTypeWithChildHash)
+        assert_eq!(proof.len(), 285); //it + left + right + parent + sibling + parent sibling + grandparent
 
         let mut query = Query::new();
         query.insert_key(vec![RootTree::Pools as u8]);
@@ -1381,7 +1383,7 @@ mod tests {
                 drive_version,
             )
             .expect("expected to get root elements");
-        assert_eq!(proof.len(), 287); //it + left + parent + sibling + parent sibling + grandparent (was 253, +35 from KVValueHashFeatureTypeWithChildHash)
+        assert_eq!(proof.len(), 287); //it + left + parent + sibling + parent sibling + grandparent
 
         let mut query = Query::new();
         query.insert_key(vec![RootTree::WithdrawalTransactions as u8]);
@@ -1402,7 +1404,7 @@ mod tests {
                 drive_version,
             )
             .expect("expected to get root elements");
-        assert_eq!(proof.len(), 285); //it + left + right + parent + sibling + parent sibling + grandparent (was 251, +35 from KVValueHashFeatureTypeWithChildHash)
+        assert_eq!(proof.len(), 285); //it + left + right + parent + sibling + parent sibling + grandparent
 
         let mut query = Query::new();
         query.insert_key(vec![RootTree::Votes as u8]);
@@ -1423,7 +1425,7 @@ mod tests {
                 drive_version,
             )
             .expect("expected to get root elements");
-        assert_eq!(proof.len(), 285); //it + left + right + parent + sibling + parent sibling + grandparent (was 251, +35 from KVValueHashFeatureTypeWithChildHash)
+        assert_eq!(proof.len(), 285); //it + left + right + parent + sibling + parent sibling + grandparent
 
         // Merk Level 3
 
@@ -1490,7 +1492,7 @@ mod tests {
                 drive_version,
             )
             .expect("expected to get root elements");
-        assert_eq!(proof.len(), 320); //it + parent + sibling + parent sibling + grandparent + grandparent sibling + great-grandparent (was 288, +33 from KVValueHashFeatureTypeWithChildHash)
+        assert_eq!(proof.len(), 320); //it + parent + sibling + parent sibling + grandparent + grandparent sibling + great-grandparent
 
         let mut query = Query::new();
         query.insert_key(vec![RootTree::AddressBalances as u8]);
@@ -1511,7 +1513,7 @@ mod tests {
                 drive_version,
             )
             .expect("expected to get root elements");
-        assert_eq!(proof.len(), 286); //it + parent + sibling + parent sibling + grandparent + grandparent sibling + great-grandparent (was 252, +35 from KVValueHashFeatureTypeWithChildHash)
+        assert_eq!(proof.len(), 286); //it + parent + sibling + parent sibling + grandparent + grandparent sibling + great-grandparent
 
         let mut query = Query::new();
         query.insert_key(vec![RootTree::SpentAssetLockTransactions as u8]);
@@ -1574,7 +1576,7 @@ mod tests {
                 drive_version,
             )
             .expect("expected to get root elements");
-        assert_eq!(proof.len(), 285); //it + parent + sibling + parent sibling + grandparent + grandparent sibling + great-grandparent (was 251, +35 from KVValueHashFeatureTypeWithChildHash)
+        assert_eq!(proof.len(), 285); //it + parent + sibling + parent sibling + grandparent + grandparent sibling + great-grandparent
 
         let mut query = Query::new();
         query.insert_key(vec![RootTree::Versions as u8]);
@@ -1595,7 +1597,7 @@ mod tests {
                 drive_version,
             )
             .expect("expected to get root elements");
-        assert_eq!(proof.len(), 285); //it + parent + sibling + parent sibling + grandparent + grandparent sibling + great-grandparent (was 251, +35 from KVValueHashFeatureTypeWithChildHash)
+        assert_eq!(proof.len(), 285); //it + parent + sibling + parent sibling + grandparent + grandparent sibling + great-grandparent
 
         // Merk Level 4
 
@@ -1618,6 +1620,6 @@ mod tests {
                 drive_version,
             )
             .expect("expected to get root elements");
-        assert_eq!(proof.len(), 319); //it + parent + parent sibling + grandparent + grandparent sibling + great-grandparent + great-grandparent sibling + great-great-grandparent (was 287, +33 from KVValueHashFeatureTypeWithChildHash)
+        assert_eq!(proof.len(), 319); //it + parent + parent sibling + grandparent + grandparent sibling + great-grandparent + great-grandparent sibling + great-great-grandparent
     }
 }

--- a/packages/rs-drive/src/drive/initialization/v0/mod.rs
+++ b/packages/rs-drive/src/drive/initialization/v0/mod.rs
@@ -1362,7 +1362,7 @@ mod tests {
                 drive_version,
             )
             .expect("expected to get root elements");
-        assert_eq!(proof.len(), 285); //it + left + right + parent + sibling + parent sibling + grandparent
+        assert_eq!(proof.len(), 285); //it + left + right + parent + sibling + parent sibling + grandparent (v11: 250, +35 from KVValueHashFeatureTypeWithChildHash)
 
         let mut query = Query::new();
         query.insert_key(vec![RootTree::Pools as u8]);
@@ -1383,7 +1383,7 @@ mod tests {
                 drive_version,
             )
             .expect("expected to get root elements");
-        assert_eq!(proof.len(), 287); //it + left + parent + sibling + parent sibling + grandparent
+        assert_eq!(proof.len(), 287); //it + left + parent + sibling + parent sibling + grandparent (v11: 252, +35 from KVValueHashFeatureTypeWithChildHash)
 
         let mut query = Query::new();
         query.insert_key(vec![RootTree::WithdrawalTransactions as u8]);
@@ -1404,7 +1404,7 @@ mod tests {
                 drive_version,
             )
             .expect("expected to get root elements");
-        assert_eq!(proof.len(), 285); //it + left + right + parent + sibling + parent sibling + grandparent
+        assert_eq!(proof.len(), 285); //it + left + right + parent + sibling + parent sibling + grandparent (v11: 250, +35 from KVValueHashFeatureTypeWithChildHash)
 
         let mut query = Query::new();
         query.insert_key(vec![RootTree::Votes as u8]);
@@ -1425,7 +1425,7 @@ mod tests {
                 drive_version,
             )
             .expect("expected to get root elements");
-        assert_eq!(proof.len(), 285); //it + left + right + parent + sibling + parent sibling + grandparent
+        assert_eq!(proof.len(), 285); //it + left + right + parent + sibling + parent sibling + grandparent (v11: 250, +35 from KVValueHashFeatureTypeWithChildHash)
 
         // Merk Level 3
 
@@ -1492,7 +1492,7 @@ mod tests {
                 drive_version,
             )
             .expect("expected to get root elements");
-        assert_eq!(proof.len(), 320); //it + parent + sibling + parent sibling + grandparent + grandparent sibling + great-grandparent
+        assert_eq!(proof.len(), 320); //it + parent + sibling + parent sibling + grandparent + grandparent sibling + great-grandparent (v11: 287, +33 from KVValueHashFeatureTypeWithChildHash)
 
         let mut query = Query::new();
         query.insert_key(vec![RootTree::AddressBalances as u8]);
@@ -1513,7 +1513,7 @@ mod tests {
                 drive_version,
             )
             .expect("expected to get root elements");
-        assert_eq!(proof.len(), 286); //it + parent + sibling + parent sibling + grandparent + grandparent sibling + great-grandparent
+        assert_eq!(proof.len(), 286); //it + parent + sibling + parent sibling + grandparent + grandparent sibling + great-grandparent (v11: 251, +35 from KVValueHashFeatureTypeWithChildHash)
 
         let mut query = Query::new();
         query.insert_key(vec![RootTree::SpentAssetLockTransactions as u8]);
@@ -1576,7 +1576,7 @@ mod tests {
                 drive_version,
             )
             .expect("expected to get root elements");
-        assert_eq!(proof.len(), 285); //it + parent + sibling + parent sibling + grandparent + grandparent sibling + great-grandparent
+        assert_eq!(proof.len(), 285); //it + parent + sibling + parent sibling + grandparent + grandparent sibling + great-grandparent (v11: 250, +35 from KVValueHashFeatureTypeWithChildHash)
 
         let mut query = Query::new();
         query.insert_key(vec![RootTree::Versions as u8]);
@@ -1597,7 +1597,7 @@ mod tests {
                 drive_version,
             )
             .expect("expected to get root elements");
-        assert_eq!(proof.len(), 285); //it + parent + sibling + parent sibling + grandparent + grandparent sibling + great-grandparent
+        assert_eq!(proof.len(), 285); //it + parent + sibling + parent sibling + grandparent + grandparent sibling + great-grandparent (v11: 250, +35 from KVValueHashFeatureTypeWithChildHash)
 
         // Merk Level 4
 
@@ -1620,6 +1620,6 @@ mod tests {
                 drive_version,
             )
             .expect("expected to get root elements");
-        assert_eq!(proof.len(), 319); //it + parent + parent sibling + grandparent + grandparent sibling + great-grandparent + great-grandparent sibling + great-great-grandparent
+        assert_eq!(proof.len(), 319); //it + parent + parent sibling + grandparent + grandparent sibling + great-grandparent + great-grandparent sibling + great-great-grandparent (v11: 286, +33 from KVValueHashFeatureTypeWithChildHash)
     }
 }

--- a/packages/rs-drive/src/verify/boundary/mod.rs
+++ b/packages/rs-drive/src/verify/boundary/mod.rs
@@ -1,0 +1,1 @@
+mod verify_key_exists_as_boundary;

--- a/packages/rs-drive/src/verify/boundary/verify_key_exists_as_boundary/mod.rs
+++ b/packages/rs-drive/src/verify/boundary/verify_key_exists_as_boundary/mod.rs
@@ -1,0 +1,43 @@
+mod v0;
+
+use crate::drive::Drive;
+use crate::error::drive::DriveError;
+use crate::error::Error;
+use dpp::version::PlatformVersion;
+
+impl Drive {
+    /// Checks whether a key exists as a boundary element in a GroveDB proof.
+    ///
+    /// Boundary elements appear in proofs for exclusive range queries (e.g.,
+    /// `RangeAfter(cursor_key)`) where the boundary key anchors the range
+    /// but is not part of the result set.
+    ///
+    /// This is useful for **pagination verification**: after verifying a proof
+    /// for "next N documents after cursor X", the client can check that cursor X
+    /// still exists in the tree by calling this function.
+    ///
+    /// # Parameters
+    /// - `proof` - Raw proof bytes (serialized `GroveDBProof`)
+    /// - `path` - GroveDB path to the subtree where the range query was executed
+    /// - `key` - The boundary key to check for (e.g., the pagination cursor)
+    /// - `platform_version` - Protocol version for dispatch
+    ///
+    /// # Returns
+    /// `true` if the key exists as a KVDigest or KVDigestCount boundary in the
+    /// proof at the given path, `false` otherwise.
+    pub fn verify_key_exists_as_boundary(
+        proof: &[u8],
+        path: &[&[u8]],
+        key: &[u8],
+        platform_version: &PlatformVersion,
+    ) -> Result<bool, Error> {
+        match platform_version.drive.methods.verify.document.verify_proof {
+            0 => Self::verify_key_exists_as_boundary_v0(proof, path, key),
+            version => Err(Error::Drive(DriveError::UnknownVersionMismatch {
+                method: "verify_key_exists_as_boundary".to_string(),
+                known_versions: vec![0],
+                received: version,
+            })),
+        }
+    }
+}

--- a/packages/rs-drive/src/verify/boundary/verify_key_exists_as_boundary/mod.rs
+++ b/packages/rs-drive/src/verify/boundary/verify_key_exists_as_boundary/mod.rs
@@ -31,7 +31,13 @@ impl Drive {
         key: &[u8],
         platform_version: &PlatformVersion,
     ) -> Result<bool, Error> {
-        match platform_version.drive.methods.verify.document.verify_proof {
+        match platform_version
+            .drive
+            .methods
+            .verify
+            .boundary
+            .verify_key_exists_as_boundary
+        {
             0 => Self::verify_key_exists_as_boundary_v0(proof, path, key),
             version => Err(Error::Drive(DriveError::UnknownVersionMismatch {
                 method: "verify_key_exists_as_boundary".to_string(),

--- a/packages/rs-drive/src/verify/boundary/verify_key_exists_as_boundary/v0/mod.rs
+++ b/packages/rs-drive/src/verify/boundary/verify_key_exists_as_boundary/v0/mod.rs
@@ -32,3 +32,182 @@ impl Drive {
             })
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::util::test_helpers::setup::setup_drive_with_initial_state_structure;
+    use grovedb::batch::QualifiedGroveDbOp;
+    use grovedb::{Element, PathQuery, Query, QueryItem, SizedQuery};
+    use platform_version::version::PlatformVersion;
+
+    /// Helper: insert items with keys [1..=count] under a test subtree within
+    /// the existing Drive tree structure. Uses DataContractDocuments root tree
+    /// as the parent and creates a subtree "test" beneath it.
+    fn insert_test_items(drive: &Drive, count: u8, platform_version: &PlatformVersion) {
+        use crate::drive::RootTree;
+        use crate::util::batch::grovedb_op_batch::GroveDbOpBatchV0Methods;
+        use crate::util::batch::GroveDbOpBatch;
+
+        // Create the test subtree under DataContractDocuments
+        let parent_path = vec![vec![RootTree::DataContractDocuments as u8]];
+        let subtree_op = QualifiedGroveDbOp::insert_or_replace_op(
+            parent_path.clone(),
+            b"test".to_vec(),
+            Element::empty_tree(),
+        );
+        drive
+            .grove_apply_batch(
+                GroveDbOpBatch::from_operations(vec![subtree_op]),
+                false,
+                None,
+                &platform_version.drive,
+            )
+            .expect("should create test subtree");
+
+        // Insert items
+        let test_path = vec![
+            vec![RootTree::DataContractDocuments as u8],
+            b"test".to_vec(),
+        ];
+        let ops: Vec<_> = (1..=count)
+            .map(|i| {
+                QualifiedGroveDbOp::insert_or_replace_op(
+                    test_path.clone(),
+                    vec![i],
+                    Element::new_item(vec![i; 4]),
+                )
+            })
+            .collect();
+        drive
+            .grove_apply_batch(
+                GroveDbOpBatch::from_operations(ops),
+                false,
+                None,
+                &platform_version.drive,
+            )
+            .expect("should insert items");
+    }
+
+    fn test_path_refs() -> Vec<Vec<u8>> {
+        use crate::drive::RootTree;
+        vec![
+            vec![RootTree::DataContractDocuments as u8],
+            b"test".to_vec(),
+        ]
+    }
+
+    #[test]
+    fn should_detect_boundary_key_in_range_after_proof() {
+        let drive = setup_drive_with_initial_state_structure(None);
+        let platform_version = PlatformVersion::latest();
+
+        // Insert keys [1, 2, 3, 4, 5]
+        insert_test_items(&drive, 5, platform_version);
+
+        // Query: RangeAfter(key=3) — key 3 is the boundary, results are [4, 5]
+        let path_vecs = test_path_refs();
+        let mut query = Query::new();
+        query.insert_item(QueryItem::RangeAfter(vec![3u8]..));
+        let path_query = PathQuery::new(
+            path_vecs.clone(),
+            SizedQuery {
+                query,
+                limit: Some(10),
+                offset: None,
+            },
+        );
+
+        let proof = drive
+            .grove_get_proved_path_query(&path_query, None, &mut vec![], &platform_version.drive)
+            .expect("should produce proof");
+
+        // Key 3 should exist as a boundary
+        let path_refs: Vec<&[u8]> = path_vecs.iter().map(|v| v.as_slice()).collect();
+        let exists =
+            Drive::verify_key_exists_as_boundary(&proof, &path_refs, &[3u8], platform_version)
+                .expect("should verify");
+        assert!(exists, "key 3 should exist as boundary in RangeAfter proof");
+    }
+
+    #[test]
+    fn should_not_detect_non_existent_key_as_boundary() {
+        let drive = setup_drive_with_initial_state_structure(None);
+        let platform_version = PlatformVersion::latest();
+
+        insert_test_items(&drive, 5, platform_version);
+
+        let path_vecs = test_path_refs();
+        let mut query = Query::new();
+        query.insert_item(QueryItem::RangeAfter(vec![3u8]..));
+        let path_query = PathQuery::new(
+            path_vecs.clone(),
+            SizedQuery {
+                query,
+                limit: Some(10),
+                offset: None,
+            },
+        );
+
+        let proof = drive
+            .grove_get_proved_path_query(&path_query, None, &mut vec![], &platform_version.drive)
+            .expect("should produce proof");
+
+        // Key 99 was never inserted — should not be a boundary
+        let path_refs: Vec<&[u8]> = path_vecs.iter().map(|v| v.as_slice()).collect();
+        let exists =
+            Drive::verify_key_exists_as_boundary(&proof, &path_refs, &[99u8], platform_version)
+                .expect("should verify");
+        assert!(
+            !exists,
+            "non-existent key should not be detected as boundary"
+        );
+    }
+
+    #[test]
+    fn should_not_detect_result_key_as_boundary() {
+        let drive = setup_drive_with_initial_state_structure(None);
+        let platform_version = PlatformVersion::latest();
+
+        insert_test_items(&drive, 5, platform_version);
+
+        let path_vecs = test_path_refs();
+        let mut query = Query::new();
+        // RangeFrom is inclusive — key 3 is a result, not a boundary
+        query.insert_item(QueryItem::RangeFrom(vec![3u8]..));
+        let path_query = PathQuery::new(
+            path_vecs.clone(),
+            SizedQuery {
+                query,
+                limit: Some(10),
+                offset: None,
+            },
+        );
+
+        let proof = drive
+            .grove_get_proved_path_query(&path_query, None, &mut vec![], &platform_version.drive)
+            .expect("should produce proof");
+
+        // Key 3 is a result in RangeFrom (inclusive), not a boundary
+        let path_refs: Vec<&[u8]> = path_vecs.iter().map(|v| v.as_slice()).collect();
+        let exists =
+            Drive::verify_key_exists_as_boundary(&proof, &path_refs, &[3u8], platform_version)
+                .expect("should verify");
+        assert!(
+            !exists,
+            "inclusive range start key is a result, not a boundary"
+        );
+    }
+
+    #[test]
+    fn should_reject_invalid_proof_bytes() {
+        let platform_version = PlatformVersion::latest();
+        let result = Drive::verify_key_exists_as_boundary(
+            &[0xff, 0xfe],
+            &[b"test"],
+            &[1u8],
+            platform_version,
+        );
+        assert!(result.is_err(), "garbage proof bytes should return error");
+    }
+}

--- a/packages/rs-drive/src/verify/boundary/verify_key_exists_as_boundary/v0/mod.rs
+++ b/packages/rs-drive/src/verify/boundary/verify_key_exists_as_boundary/v0/mod.rs
@@ -1,0 +1,34 @@
+use crate::drive::Drive;
+use crate::error::proof::ProofError;
+use crate::error::Error;
+use grovedb::operations::proof::GroveDBProof;
+
+impl Drive {
+    pub(super) fn verify_key_exists_as_boundary_v0(
+        proof: &[u8],
+        path: &[&[u8]],
+        key: &[u8],
+    ) -> Result<bool, Error> {
+        let bincode_config = bincode::config::standard()
+            .with_big_endian()
+            .with_no_limit();
+
+        let grovedb_proof: GroveDBProof = bincode::decode_from_slice(proof, bincode_config)
+            .map(|(p, _)| p)
+            .map_err(|e| {
+                Error::Proof(ProofError::CorruptedProof(format!(
+                    "cannot decode GroveDBProof: {}",
+                    e
+                )))
+            })?;
+
+        grovedb_proof
+            .key_exists_as_boundary(path, key)
+            .map_err(|e| {
+                Error::Proof(ProofError::CorruptedProof(format!(
+                    "error checking boundary key: {}",
+                    e
+                )))
+            })
+    }
+}

--- a/packages/rs-drive/src/verify/mod.rs
+++ b/packages/rs-drive/src/verify/mod.rs
@@ -14,6 +14,8 @@ pub mod system;
 
 /// Address funds proof verification module
 pub mod address_funds;
+/// Boundary key existence verification in proofs (pagination cursor checks)
+pub mod boundary;
 /// Group proof verification module
 pub mod group;
 /// Shielded pool proof verification module

--- a/packages/rs-platform-version/Cargo.toml
+++ b/packages/rs-platform-version/Cargo.toml
@@ -11,7 +11,7 @@ license = "MIT"
 thiserror = { version = "2.0.12" }
 bincode = { version = "=2.0.1" }
 versioned-feature-core = { git = "https://github.com/dashpay/versioned-feature-core", version = "1.0.0" }
-grovedb-version = { git = "https://github.com/dashpay/grovedb", rev = "dd99ed1db0350e5f39127573808dd172c6bc2346" }
+grovedb-version = { git = "https://github.com/dashpay/grovedb", rev = "80f009386570cd8d92c989d55d48dbe84596e34c" }
 
 [features]
 mock-versions = []

--- a/packages/rs-platform-version/src/version/drive_versions/drive_verify_method_versions/mod.rs
+++ b/packages/rs-platform-version/src/version/drive_versions/drive_verify_method_versions/mod.rs
@@ -15,6 +15,12 @@ pub struct DriveVerifyMethodVersions {
     pub address_funds: DriveVerifyAddressFundsMethodVersions,
     pub state_transition: DriveVerifyStateTransitionMethodVersions,
     pub shielded: DriveVerifyShieldedMethodVersions,
+    pub boundary: DriveVerifyBoundaryMethodVersions,
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct DriveVerifyBoundaryMethodVersions {
+    pub verify_key_exists_as_boundary: FeatureVersion,
 }
 
 #[derive(Clone, Debug, Default)]

--- a/packages/rs-platform-version/src/version/drive_versions/drive_verify_method_versions/v1.rs
+++ b/packages/rs-platform-version/src/version/drive_versions/drive_verify_method_versions/v1.rs
@@ -1,7 +1,7 @@
 use crate::version::drive_versions::drive_verify_method_versions::{
-    DriveVerifyAddressFundsMethodVersions, DriveVerifyContractMethodVersions,
-    DriveVerifyDocumentMethodVersions, DriveVerifyGroupMethodVersions,
-    DriveVerifyIdentityMethodVersions, DriveVerifyMethodVersions,
+    DriveVerifyAddressFundsMethodVersions, DriveVerifyBoundaryMethodVersions,
+    DriveVerifyContractMethodVersions, DriveVerifyDocumentMethodVersions,
+    DriveVerifyGroupMethodVersions, DriveVerifyIdentityMethodVersions, DriveVerifyMethodVersions,
     DriveVerifyShieldedMethodVersions, DriveVerifySingleDocumentMethodVersions,
     DriveVerifyStateTransitionMethodVersions, DriveVerifySystemMethodVersions,
     DriveVerifyTokenMethodVersions, DriveVerifyVoteMethodVersions,
@@ -101,5 +101,8 @@ pub const DRIVE_VERIFY_METHOD_VERSIONS_V1: DriveVerifyMethodVersions = DriveVeri
         verify_nullifiers_branch_query: 0,
         verify_recent_nullifier_changes: 0,
         verify_compacted_nullifier_changes: 0,
+    },
+    boundary: DriveVerifyBoundaryMethodVersions {
+        verify_key_exists_as_boundary: 0,
     },
 };

--- a/packages/rs-sdk/Cargo.toml
+++ b/packages/rs-sdk/Cargo.toml
@@ -17,7 +17,7 @@ drive = { path = "../rs-drive", default-features = false, features = [
 ] }
 
 drive-proof-verifier = { path = "../rs-drive-proof-verifier", default-features = false }
-grovedb-commitment-tree = { git = "https://github.com/dashpay/grovedb", rev = "7ecb8465fad750c7cddd5332adb6f97fcceb498b", features = ["client", "sqlite"], optional = true }
+grovedb-commitment-tree = { git = "https://github.com/dashpay/grovedb", rev = "80f009386570cd8d92c989d55d48dbe84596e34c", features = ["client", "sqlite"], optional = true }
 dash-context-provider = { path = "../rs-context-provider", default-features = false }
 dash-platform-macros = { path = "../rs-dash-platform-macros" }
 platform-encryption = { path = "../rs-platform-encryption" }


### PR DESCRIPTION
## Summary
- Bumps all grovedb dependencies to [`80f0093`](https://github.com/dashpay/grovedb/commit/80f009386570cd8d92c989d55d48dbe84596e34c) (grovedb PR [#649](https://github.com/dashpay/grovedb/pull/649))
- Exposes `Drive::verify_key_exists_as_boundary(proof, path, key, platform_version)` in the Drive verify module

## What this enables

**Pagination cursor verification.** When a client paginates documents using `RangeAfter(cursor_key)`, the proof contains documents 101-200 but the client also needs to verify that the cursor (document X) still exists in the tree. Without this, the pagination anchor could be invalid (e.g., document was deleted between pages).

```rust
// After verifying the proof normally:
let (root_hash, documents) = Drive::verify_documents(...)?;

// Check that the pagination cursor still exists as a boundary:
let cursor_exists = Drive::verify_key_exists_as_boundary(
    proof,
    &[b"dpcontract", contract_id, b"documents", doc_type],
    cursor_document_id,
    platform_version,
)?;

if !cursor_exists {
    // Cursor was deleted — restart pagination from beginning
}
```

## Test plan
- [x] `cargo check -p drive --features verify` — clean compile
- [x] `cargo check -p dpp -p drive-abci -p dash-sdk` — all crates compile with bumped grovedb
- [ ] Integration test with prove → verify → check boundary round-trip

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added boundary key existence verification capability for proof validation, enabling verification of whether a key exists as a boundary element in GroveDB proofs (useful for pagination cursor checks).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->