### PR TITLE
fix(sdk):  implementation of `std::marker::Send` is not general enough

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -94,3 +94,4 @@ __pycache__/
 
 # Security audit reports (local-only, not committed)
 audits/
+.serena/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1628,6 +1628,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "dash-sdk-macros"
+version = "3.1.0-dev.1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "dash-spv"
 version = "0.42.0"
 source = "git+https://github.com/dashpay/rust-dashcore?rev=f92f114b83f6e442af8290611a10f2246ee58d3a#f92f114b83f6e442af8290611a10f2246ee58d3a"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,7 @@ members = [
     "packages/rs-platform-wallet-ffi",
     "packages/rs-platform-encryption",
     "packages/wasm-sdk",
+    "packages/rs-sdk-macros",
 ]
 
 [workspace.dependencies]

--- a/packages/rs-sdk-macros/Cargo.toml
+++ b/packages/rs-sdk-macros/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "dash-sdk-macros"
+version.workspace = true
+edition = "2021"
+description = "Proc macros for dash-sdk — provides #[box_async] to replace #[async_trait]"
+license = "MIT"
+
+[lib]
+proc-macro = true
+
+[dependencies]
+proc-macro2 = "1"
+quote = "1"
+syn = { version = "2", features = ["full", "visit-mut"] }

--- a/packages/rs-sdk-macros/src/lib.rs
+++ b/packages/rs-sdk-macros/src/lib.rs
@@ -1,0 +1,204 @@
+//! Proc macros for dash-sdk.
+//!
+//! Provides `#[box_async]` — a drop-in replacement for `#[async_trait]` that avoids
+//! the HRTB Send inference bug ([rust-lang/rust#96865]).
+//!
+//! # Why not `#[async_trait]`?
+//!
+//! `async_trait` introduces a unified `'async_trait` lifetime with complex `where`
+//! clauses that trigger a Rust compiler bug when many generic trait implementations
+//! exist (e.g. 28+ `impl Fetch` types). The compiler fails to prove the resulting
+//! future is `Send`.
+//!
+//! `#[box_async]` performs the same transformation — boxing the return into
+//! `Pin<Box<dyn Future + Send>>` — but uses explicit per-reference lifetimes,
+//! avoiding the problematic HRTB inference path.
+//!
+//! # Usage
+//!
+//! ```ignore
+//! use dash_sdk_macros::box_async;
+//!
+//! #[box_async]
+//! pub trait MyTrait {
+//!     async fn do_work(&self, sdk: &Sdk) -> Result<(), Error> {
+//!         sdk.call().await
+//!     }
+//! }
+//!
+//! #[box_async]
+//! impl MyTrait for MyStruct {
+//!     async fn do_work(&self, sdk: &Sdk) -> Result<(), Error> {
+//!         sdk.other_call().await
+//!     }
+//! }
+//! ```
+//!
+//! [rust-lang/rust#96865]: https://github.com/rust-lang/rust/issues/96865
+
+use proc_macro::TokenStream;
+use proc_macro2::Span;
+use quote::quote;
+use syn::{
+    parse_macro_input, parse_quote, FnArg, GenericParam, ImplItem, Lifetime, LifetimeParam,
+    ReturnType, Signature, TraitItem, Type,
+};
+
+/// Transform `async fn` methods to return boxed futures.
+///
+/// Apply to a trait definition or an `impl` block. Each `async fn` is converted to
+/// a regular `fn` returning `Pin<Box<dyn Future<Output = T> + Send + 'a>>`, where
+/// `'a` captures all reference parameter lifetimes.
+///
+/// The method body is wrapped in `Box::pin(async move { ... })`.
+#[proc_macro_attribute]
+pub fn box_async(_attr: TokenStream, item: TokenStream) -> TokenStream {
+    let item_clone = item.clone();
+
+    // Try parsing as trait first, then as impl
+    if let Ok(mut trait_item) = syn::parse::<syn::ItemTrait>(item_clone) {
+        // Add Send as a supertrait bound (async_trait does this implicitly)
+        let has_send = trait_item.supertraits.iter().any(|bound| {
+            if let syn::TypeParamBound::Trait(t) = bound {
+                t.path.is_ident("Send")
+            } else {
+                false
+            }
+        });
+        if !has_send {
+            trait_item
+                .supertraits
+                .push(parse_quote!(Send));
+        }
+
+        for item in &mut trait_item.items {
+            if let TraitItem::Fn(method) = item {
+                if method.sig.asyncness.is_some() {
+                    transform_signature(&mut method.sig);
+                    if let Some(body) = &method.default {
+                        let stmts = &body.stmts;
+                        method.default = Some(parse_quote!({
+                            Box::pin(async move { #(#stmts)* })
+                        }));
+                    }
+                }
+            }
+        }
+        return TokenStream::from(quote! { #trait_item });
+    }
+
+    let mut impl_item = parse_macro_input!(item as syn::ItemImpl);
+    for item in &mut impl_item.items {
+        if let ImplItem::Fn(method) = item {
+            if method.sig.asyncness.is_some() {
+                transform_signature(&mut method.sig);
+                let stmts = &method.block.stmts;
+                method.block = parse_quote!({
+                    Box::pin(async move { #(#stmts)* })
+                });
+            }
+        }
+    }
+    TokenStream::from(quote! { #impl_item })
+}
+
+/// Transform an async fn signature to return a boxed future.
+///
+/// - Removes `async`
+/// - Adds lifetime `'__boxfut` to all unnamed reference params
+/// - Adds `'__boxfut` bound to all generic type params
+/// - Changes return type to `Pin<Box<dyn Future<Output = T> + Send + '__boxfut>>`
+fn transform_signature(sig: &mut Signature) {
+    sig.asyncness = None;
+
+    let output_ty = match &sig.output {
+        ReturnType::Default => quote! { () },
+        ReturnType::Type(_, ty) => quote! { #ty },
+    };
+
+    // Check if any parameters are references (need lifetime)
+    let has_references = sig.inputs.iter().any(|arg| match arg {
+        FnArg::Receiver(r) => r.reference.is_some(),
+        FnArg::Typed(t) => matches!(*t.ty, Type::Reference(_)),
+    });
+
+    if !has_references {
+        // No references — return 'static future
+        sig.output = parse_quote! {
+            -> ::std::pin::Pin<Box<
+                dyn ::std::future::Future<Output = #output_ty> + Send
+            >>
+        };
+        return;
+    }
+
+    let lifetime = Lifetime::new("'__boxfut", Span::call_site());
+
+    // Add lifetime parameter at position 0
+    sig.generics.params.insert(
+        0,
+        GenericParam::Lifetime(LifetimeParam::new(lifetime.clone())),
+    );
+
+    // Apply lifetime to all reference params (including nested, e.g. Option<&T>).
+    // All references captured by the async block must share the same lifetime.
+    for arg in &mut sig.inputs {
+        match arg {
+            FnArg::Receiver(r) => {
+                if let Some((_, ref mut lt)) = r.reference {
+                    if lt.is_none() {
+                        *lt = Some(lifetime.clone());
+                    }
+                }
+            }
+            FnArg::Typed(t) => {
+                apply_lifetime_to_refs(&mut t.ty, &lifetime);
+            }
+        }
+    }
+
+    // Add lifetime bound to all generic type params
+    for param in &mut sig.generics.params {
+        if let GenericParam::Type(type_param) = param {
+            type_param.bounds.push(parse_quote! { #lifetime });
+        }
+    }
+
+    // Transform return type
+    sig.output = parse_quote! {
+        -> ::std::pin::Pin<Box<
+            dyn ::std::future::Future<Output = #output_ty> + Send + #lifetime
+        >>
+    };
+}
+
+/// Recursively apply a lifetime to all anonymous references in a type,
+/// including references nested inside generic types like `Option<&T>`.
+fn apply_lifetime_to_refs(ty: &mut Type, lifetime: &Lifetime) {
+    match ty {
+        Type::Reference(type_ref) => {
+            if type_ref.lifetime.is_none() {
+                type_ref.lifetime = Some(lifetime.clone());
+            }
+            apply_lifetime_to_refs(&mut type_ref.elem, lifetime);
+        }
+        Type::Path(type_path) => {
+            // Recurse into generic arguments: Option<&T>, Vec<&T>, BTreeMap<K, &V>, etc.
+            for segment in &mut type_path.path.segments {
+                if let syn::PathArguments::AngleBracketed(args) = &mut segment.arguments {
+                    for arg in &mut args.args {
+                        if let syn::GenericArgument::Type(inner_ty) = arg {
+                            apply_lifetime_to_refs(inner_ty, lifetime);
+                        }
+                    }
+                }
+            }
+        }
+        Type::Tuple(type_tuple) => {
+            for elem in &mut type_tuple.elems {
+                apply_lifetime_to_refs(elem, lifetime);
+            }
+        }
+        _ => {}
+    }
+}

--- a/packages/rs-sdk/src/platform/fetch.rs
+++ b/packages/rs-sdk/src/platform/fetch.rs
@@ -23,6 +23,8 @@ use drive_proof_verifier::FromProof;
 use rs_dapi_client::{transport::TransportRequest, DapiRequest, RequestSettings};
 use rs_dapi_client::{ExecutionError, ExecutionResponse, InnerInto, IntoInner};
 use std::fmt::Debug;
+use std::future::Future;
+use std::pin::Pin;
 
 use super::types::identity::IdentityRequest;
 use super::DocumentQuery;
@@ -52,10 +54,10 @@ use super::DocumentQuery;
 ///
 /// let identity = Identity::fetch(&sdk, query);
 /// ```
-#[async_trait::async_trait]
 pub trait Fetch
 where
     Self: Sized
+        + Send
         + Debug
         + MockResponse
         + FromProof<
@@ -91,11 +93,13 @@ where
     /// ## Error Handling
     ///
     /// Any errors encountered during the execution are returned as [Error] instances.
-    async fn fetch<Q: Query<<Self as Fetch>::Request>>(
-        sdk: &Sdk,
+    fn fetch<'a, Q: Query<<Self as Fetch>::Request> + Send + 'a>(
+        sdk: &'a Sdk,
         query: Q,
-    ) -> Result<Option<Self>, Error> {
-        Self::fetch_with_settings(sdk, query, RequestSettings::default()).await
+    ) -> Pin<Box<dyn Future<Output = Result<Option<Self>, Error>> + Send + 'a>> {
+        Box::pin(
+            async move { Self::fetch_with_settings(sdk, query, RequestSettings::default()).await },
+        )
     }
 
     /// Fetch single object from Platform with metadata.
@@ -119,14 +123,17 @@ where
     /// ## Error Handling
     ///
     /// Any errors encountered during the execution are returned as [Error] instances.
-    async fn fetch_with_metadata<Q: Query<<Self as Fetch>::Request>>(
-        sdk: &Sdk,
+    fn fetch_with_metadata<'a, Q: Query<<Self as Fetch>::Request> + Send + 'a>(
+        sdk: &'a Sdk,
         query: Q,
         settings: Option<RequestSettings>,
-    ) -> Result<(Option<Self>, ResponseMetadata), Error> {
-        Self::fetch_with_metadata_and_proof(sdk, query, settings)
-            .await
-            .map(|(object, metadata, _)| (object, metadata))
+    ) -> Pin<Box<dyn Future<Output = Result<(Option<Self>, ResponseMetadata), Error>> + Send + 'a>>
+    {
+        Box::pin(async move {
+            Self::fetch_with_metadata_and_proof(sdk, query, settings)
+                .await
+                .map(|(object, metadata, _)| (object, metadata))
+        })
     }
 
     /// Fetch single object from Platform with metadata and underlying proof.
@@ -153,52 +160,58 @@ where
     /// ## Error Handling
     ///
     /// Any errors encountered during the execution are returned as [Error] instances.
-    async fn fetch_with_metadata_and_proof<Q: Query<<Self as Fetch>::Request>>(
-        sdk: &Sdk,
+    fn fetch_with_metadata_and_proof<'a, Q: Query<<Self as Fetch>::Request> + Send + 'a>(
+        sdk: &'a Sdk,
         query: Q,
         settings: Option<RequestSettings>,
-    ) -> Result<(Option<Self>, ResponseMetadata, Proof), Error> {
-        let request: &<Self as Fetch>::Request = &query.query(sdk.prove())?;
+    ) -> Pin<
+        Box<
+            dyn Future<Output = Result<(Option<Self>, ResponseMetadata, Proof), Error>> + Send + 'a,
+        >,
+    > {
+        Box::pin(async move {
+            let request: &<Self as Fetch>::Request = &query.query(sdk.prove())?;
 
-        let fut = |settings: RequestSettings| async move {
-            let ExecutionResponse {
-                address,
-                retries,
-                inner: response,
-            } = request
-                .clone()
-                .execute(sdk, settings)
-                .await
-                .map_err(|execution_error| execution_error.inner_into())?;
-
-            let object_type = std::any::type_name::<Self>().to_string();
-            tracing::trace!(request = ?request, response = ?response, ?address, retries, object_type, "fetched object from platform");
-
-            let (object, response_metadata, proof): (Option<Self>, ResponseMetadata, Proof) = sdk
-                .parse_proof_with_metadata_and_proof(request.clone(), response)
-                .await
-                .map_err(|e| ExecutionError {
-                    inner: e,
-                    address: Some(address.clone()),
+            let fut = |settings: RequestSettings| async move {
+                let ExecutionResponse {
+                    address,
                     retries,
-                })?;
+                    inner: response,
+                } = request
+                    .clone()
+                    .execute(sdk, settings)
+                    .await
+                    .map_err(|execution_error| execution_error.inner_into())?;
 
-            match object {
-                Some(item) => Ok((item.into(), response_metadata, proof)),
-                None => Ok((None, response_metadata, proof)),
-            }
-            .map(|x| ExecutionResponse {
-                inner: x,
-                address,
-                retries,
-            })
-        };
+                let object_type = std::any::type_name::<Self>().to_string();
+                tracing::trace!(request = ?request, response = ?response, ?address, retries, object_type, "fetched object from platform");
 
-        let settings = sdk
-            .dapi_client_settings
-            .override_by(settings.unwrap_or_default());
+                let (object, response_metadata, proof): (Option<Self>, ResponseMetadata, Proof) =
+                    sdk.parse_proof_with_metadata_and_proof(request.clone(), response)
+                        .await
+                        .map_err(|e| ExecutionError {
+                            inner: e,
+                            address: Some(address.clone()),
+                            retries,
+                        })?;
 
-        retry(sdk.address_list(), settings, fut).await.into_inner()
+                match object {
+                    Some(item) => Ok((item.into(), response_metadata, proof)),
+                    None => Ok((None, response_metadata, proof)),
+                }
+                .map(|x| ExecutionResponse {
+                    inner: x,
+                    address,
+                    retries,
+                })
+            };
+
+            let settings = sdk
+                .dapi_client_settings
+                .override_by(settings.unwrap_or_default());
+
+            retry(sdk.address_list(), settings, fut).await.into_inner()
+        })
     }
 
     /// Fetch single object from Platform.
@@ -222,13 +235,15 @@ where
     /// ## Error Handling
     ///
     /// Any errors encountered during the execution are returned as [Error] instances.
-    async fn fetch_with_settings<Q: Query<<Self as Fetch>::Request>>(
-        sdk: &Sdk,
+    fn fetch_with_settings<'a, Q: Query<<Self as Fetch>::Request> + Send + 'a>(
+        sdk: &'a Sdk,
         query: Q,
         settings: RequestSettings,
-    ) -> Result<Option<Self>, Error> {
-        let (object, _) = Self::fetch_with_metadata(sdk, query, Some(settings)).await?;
-        Ok(object)
+    ) -> Pin<Box<dyn Future<Output = Result<Option<Self>, Error>> + Send + 'a>> {
+        Box::pin(async move {
+            let (object, _) = Self::fetch_with_metadata(sdk, query, Some(settings)).await?;
+            Ok(object)
+        })
     }
 
     /// Fetch single object from Platform by identifier.
@@ -241,11 +256,14 @@ where
     ///
     /// - `sdk`: An instance of [Sdk].
     /// - `id`: An [Identifier] of the object to be fetched.
-    async fn fetch_by_identifier(sdk: &Sdk, id: Identifier) -> Result<Option<Self>, Error>
+    fn fetch_by_identifier<'a>(
+        sdk: &'a Sdk,
+        id: Identifier,
+    ) -> Pin<Box<dyn Future<Output = Result<Option<Self>, Error>> + Send + 'a>>
     where
         Identifier: Query<<Self as Fetch>::Request>,
     {
-        Self::fetch(sdk, id).await
+        Box::pin(async move { Self::fetch(sdk, id).await })
     }
 }
 

--- a/packages/rs-sdk/src/platform/fetch_many.rs
+++ b/packages/rs-sdk/src/platform/fetch_many.rs
@@ -45,6 +45,8 @@ use rs_dapi_client::{
     transport::TransportRequest, DapiRequest, ExecutionError, ExecutionResponse, InnerInto,
     IntoInner, RequestSettings,
 };
+use std::future::Future;
+use std::pin::Pin;
 
 /// Fetch multiple objects from Platform.
 ///
@@ -83,10 +85,9 @@ use rs_dapi_client::{
 ///
 /// let data_contract = DataContract::fetch_many(&sdk, query);
 /// ```
-#[async_trait::async_trait]
 pub trait FetchMany<K: Ord, O: FromIterator<(K, Option<Self>)>>
 where
-    Self: Sized,
+    Self: Sized + Send,
     O: MockResponse
         + FromProof<
             Self::Request,
@@ -141,13 +142,15 @@ where
     /// ## Error Handling
     ///
     /// Any errors encountered during the execution are returned as [`Error`](crate::error::Error) instances.
-    async fn fetch_many<Q: Query<<Self as FetchMany<K, O>>::Request>>(
-        sdk: &Sdk,
+    fn fetch_many<'a, Q: Query<<Self as FetchMany<K, O>>::Request> + Send + 'a>(
+        sdk: &'a Sdk,
         query: Q,
-    ) -> Result<O, Error> {
-        Self::fetch_many_with_metadata_and_proof(sdk, query, None)
-            .await
-            .map(|(objects, _, _)| objects)
+    ) -> Pin<Box<dyn Future<Output = Result<O, Error>> + Send + 'a>> {
+        Box::pin(async move {
+            Self::fetch_many_with_metadata_and_proof(sdk, query, None)
+                .await
+                .map(|(objects, _, _)| objects)
+        })
     }
 
     /// Fetch multiple objects from Platform with metadata.
@@ -171,14 +174,16 @@ where
     /// ## Error Handling
     ///
     /// Any errors encountered during the execution are returned as [Error] instances.
-    async fn fetch_many_with_metadata<Q: Query<<Self as FetchMany<K, O>>::Request>>(
-        sdk: &Sdk,
+    fn fetch_many_with_metadata<'a, Q: Query<<Self as FetchMany<K, O>>::Request> + Send + 'a>(
+        sdk: &'a Sdk,
         query: Q,
         settings: Option<RequestSettings>,
-    ) -> Result<(O, ResponseMetadata), Error> {
-        Self::fetch_many_with_metadata_and_proof(sdk, query, settings)
-            .await
-            .map(|(objects, metadata, _)| (objects, metadata))
+    ) -> Pin<Box<dyn Future<Output = Result<(O, ResponseMetadata), Error>> + Send + 'a>> {
+        Box::pin(async move {
+            Self::fetch_many_with_metadata_and_proof(sdk, query, settings)
+                .await
+                .map(|(objects, metadata, _)| (objects, metadata))
+        })
     }
 
     /// Fetch multiple objects from Platform with metadata and underlying proof.
@@ -202,56 +207,62 @@ where
     /// ## Error Handling
     ///
     /// Any errors encountered during the execution are returned as [Error] instances.
-    async fn fetch_many_with_metadata_and_proof<Q: Query<<Self as FetchMany<K, O>>::Request>>(
-        sdk: &Sdk,
+    fn fetch_many_with_metadata_and_proof<
+        'a,
+        Q: Query<<Self as FetchMany<K, O>>::Request> + Send + 'a,
+    >(
+        sdk: &'a Sdk,
         query: Q,
         settings: Option<RequestSettings>,
-    ) -> Result<(O, ResponseMetadata, Proof), Error> {
-        let request = &query.query(sdk.prove())?;
+    ) -> Pin<Box<dyn Future<Output = Result<(O, ResponseMetadata, Proof), Error>> + Send + 'a>>
+    {
+        Box::pin(async move {
+            let request = &query.query(sdk.prove())?;
 
-        let fut = |settings: RequestSettings| async move {
-            let ExecutionResponse {
-                address,
-                retries,
-                inner: response,
-            } = request
-                .clone()
-                .execute(sdk, settings)
+            let fut = |settings: RequestSettings| async move {
+                let ExecutionResponse {
+                    address,
+                    retries,
+                    inner: response,
+                } = request
+                    .clone()
+                    .execute(sdk, settings)
+                    .await
+                    .map_err(|e| e.inner_into())?;
+
+                let object_type = std::any::type_name::<Self>().to_string();
+                tracing::trace!(
+                    request = ?request,
+                    response = ?response,
+                    ?address,
+                    retries,
+                    object_type,
+                    "fetched objects from platform"
+                );
+
+                sdk.parse_proof_with_metadata_and_proof::<<Self as FetchMany<K, O>>::Request, O>(
+                    request.clone(),
+                    response,
+                )
                 .await
-                .map_err(|e| e.inner_into())?;
+                .map_err(|e| ExecutionError {
+                    inner: e,
+                    address: Some(address.clone()),
+                    retries,
+                })
+                .map(|(o, metadata, proof)| ExecutionResponse {
+                    inner: (o.unwrap_or_default(), metadata, proof),
+                    retries,
+                    address: address.clone(),
+                })
+            };
 
-            let object_type = std::any::type_name::<Self>().to_string();
-            tracing::trace!(
-                request = ?request,
-                response = ?response,
-                ?address,
-                retries,
-                object_type,
-                "fetched objects from platform"
-            );
+            let settings = sdk
+                .dapi_client_settings
+                .override_by(settings.unwrap_or_default());
 
-            sdk.parse_proof_with_metadata_and_proof::<<Self as FetchMany<K, O>>::Request, O>(
-                request.clone(),
-                response,
-            )
-            .await
-            .map_err(|e| ExecutionError {
-                inner: e,
-                address: Some(address.clone()),
-                retries,
-            })
-            .map(|(o, metadata, proof)| ExecutionResponse {
-                inner: (o.unwrap_or_default(), metadata, proof),
-                retries,
-                address: address.clone(),
-            })
-        };
-
-        let settings = sdk
-            .dapi_client_settings
-            .override_by(settings.unwrap_or_default());
-
-        retry(sdk.address_list(), settings, fut).await.into_inner()
+            retry(sdk.address_list(), settings, fut).await.into_inner()
+        })
     }
 
     /// Fetch multiple objects from Platform by their identifiers.
@@ -267,15 +278,17 @@ where
     /// ## Requirements
     ///
     /// `Vec<Identifier>` must implement [Query] for [Self::Request].
-    async fn fetch_by_identifiers<I: IntoIterator<Item = Identifier> + Send>(
-        sdk: &Sdk,
+    fn fetch_by_identifiers<'a, I: IntoIterator<Item = Identifier> + Send + 'a>(
+        sdk: &'a Sdk,
         identifiers: I,
-    ) -> Result<O, Error>
+    ) -> Pin<Box<dyn Future<Output = Result<O, Error>> + Send + 'a>>
     where
         Vec<Identifier>: Query<<Self as FetchMany<K, O>>::Request>,
     {
-        let ids = identifiers.into_iter().collect::<Vec<Identifier>>();
-        Self::fetch_many(sdk, ids).await
+        Box::pin(async move {
+            let ids = identifiers.into_iter().collect::<Vec<Identifier>>();
+            Self::fetch_many(sdk, ids).await
+        })
     }
 
     /// Fetch multiple objects from Platform with limit.
@@ -288,21 +301,23 @@ where
     /// - `sdk`: An instance of [Sdk].
     /// - `query`: A query parameter implementing [`Query`](crate::platform::query::Query) to specify the data to be retrieved.
     /// - `limit`: Maximum number of objects to fetch.
-    async fn fetch_many_with_limit<Q: Query<<Self as FetchMany<K, O>>::Request>>(
-        sdk: &Sdk,
+    fn fetch_many_with_limit<'a, Q: Query<<Self as FetchMany<K, O>>::Request> + Send + 'a>(
+        sdk: &'a Sdk,
         query: Q,
         limit: u32,
-    ) -> Result<O, Error>
+    ) -> Pin<Box<dyn Future<Output = Result<O, Error>> + Send + 'a>>
     where
         LimitQuery<Q>: Query<<Self as FetchMany<K, O>>::Request>,
     {
-        let limit_query = LimitQuery {
-            limit: Some(limit),
-            query,
-            start_info: None,
-        };
+        Box::pin(async move {
+            let limit_query = LimitQuery {
+                limit: Some(limit),
+                query,
+                start_info: None,
+            };
 
-        Self::fetch_many(sdk, limit_query).await
+            Self::fetch_many(sdk, limit_query).await
+        })
     }
 }
 
@@ -462,7 +477,6 @@ impl FetchMany<Identifier, ContestedResources> for ContestedResource {
 /// ## Supported query types
 ///
 /// * [`ContestedDocumentVotePollDriveQuery`](drive::query::vote_poll_vote_state_query::ContestedDocumentVotePollDriveQuery)
-#[async_trait::async_trait]
 impl FetchMany<Identifier, Contenders> for ContenderWithSerializedDocument {
     type Request = GetContestedResourceVoteStateRequest;
 }

--- a/packages/rs-sdk/src/platform/fetch_unproved.rs
+++ b/packages/rs-sdk/src/platform/fetch_unproved.rs
@@ -11,11 +11,12 @@ use drive_proof_verifier::unproved::FromUnproved;
 use rs_dapi_client::{transport::TransportRequest, DapiRequest, RequestSettings};
 use rs_dapi_client::{ExecutionError, ExecutionResponse, InnerInto, IntoInner};
 use std::fmt::Debug;
+use std::future::Future;
+use std::pin::Pin;
 
-#[async_trait::async_trait]
 pub trait FetchUnproved
 where
-    Self: Sized + Debug + MockResponse,
+    Self: Sized + Send + Debug + MockResponse,
 {
     /// Type of request used to fetch data from Platform.
     type Request: TransportRequest;
@@ -31,10 +32,10 @@ where
     /// * `Ok(Some(Self))` when object is found.
     /// * `Ok(None)` when object is not found.
     /// * [`Err(Error)`](Error) when an error occurs.
-    async fn fetch_unproved<Q: Query<<Self as FetchUnproved>::Request>>(
-        sdk: &Sdk,
+    fn fetch_unproved<'a, Q: Query<<Self as FetchUnproved>::Request> + Send + 'a>(
+        sdk: &'a Sdk,
         query: Q,
-    ) -> Result<Option<Self>, Error>
+    ) -> Pin<Box<dyn Future<Output = Result<Option<Self>, Error>> + Send + 'a>>
     where
         Self: FromUnproved<
             <Self as FetchUnproved>::Request,
@@ -42,9 +43,11 @@ where
             Response = <<Self as FetchUnproved>::Request as TransportRequest>::Response,
         >,
     {
-        let (obj, _mtd) =
-            Self::fetch_unproved_with_settings(sdk, query, RequestSettings::default()).await?;
-        Ok(obj)
+        Box::pin(async move {
+            let (obj, _mtd) =
+                Self::fetch_unproved_with_settings(sdk, query, RequestSettings::default()).await?;
+            Ok(obj)
+        })
     }
 
     /// Fetch unproved data from the Platform with custom settings.
@@ -58,11 +61,11 @@ where
     /// * `Ok(Some(Self))` when object is found.
     /// * `Ok(None)` when object is not found.
     /// * [`Err(Error)`](Error) when an error occurs.
-    async fn fetch_unproved_with_settings<Q: Query<<Self as FetchUnproved>::Request>>(
-        sdk: &Sdk,
+    fn fetch_unproved_with_settings<'a, Q: Query<<Self as FetchUnproved>::Request> + Send + 'a>(
+        sdk: &'a Sdk,
         query: Q,
         settings: RequestSettings,
-    ) -> Result<(Option<Self>, ResponseMetadata), Error>
+    ) -> Pin<Box<dyn Future<Output = Result<(Option<Self>, ResponseMetadata), Error>> + Send + 'a>>
     where
         Self: FromUnproved<
             <Self as FetchUnproved>::Request,
@@ -70,45 +73,47 @@ where
             Response = <<Self as FetchUnproved>::Request as TransportRequest>::Response,
         >,
     {
-        // Default implementation
-        let request: &<Self as FetchUnproved>::Request = &query.query(false)?;
-        let closure = move |local_settings: RequestSettings| async move {
-            // Execute the request using the Sdk instance
-            let ExecutionResponse {
-                inner: response,
-                address,
-                retries,
-            } = request
-                .clone()
-                .execute(sdk, local_settings)
-                .await
-                .map_err(|e| e.inner_into())?;
-
-            // Parse the response into the appropriate type along with metadata
-            let (object, metadata): (Option<Self>, platform_proto::ResponseMetadata) =
-                Self::maybe_from_unproved_with_metadata(
-                    request.clone(),
-                    response,
-                    sdk.network,
-                    sdk.version(),
-                )
-                .map_err(|e| ExecutionError {
-                    inner: e.into(),
-                    address: Some(address.clone()),
+        Box::pin(async move {
+            // Default implementation
+            let request: &<Self as FetchUnproved>::Request = &query.query(false)?;
+            let closure = move |local_settings: RequestSettings| async move {
+                // Execute the request using the Sdk instance
+                let ExecutionResponse {
+                    inner: response,
+                    address,
                     retries,
-                })?;
+                } = request
+                    .clone()
+                    .execute(sdk, local_settings)
+                    .await
+                    .map_err(|e| e.inner_into())?;
 
-            Ok(ExecutionResponse {
-                inner: (object, metadata),
-                address,
-                retries,
-            })
-        };
+                // Parse the response into the appropriate type along with metadata
+                let (object, metadata): (Option<Self>, platform_proto::ResponseMetadata) =
+                    Self::maybe_from_unproved_with_metadata(
+                        request.clone(),
+                        response,
+                        sdk.network,
+                        sdk.version(),
+                    )
+                    .map_err(|e| ExecutionError {
+                        inner: e.into(),
+                        address: Some(address.clone()),
+                        retries,
+                    })?;
 
-        let settings = sdk.dapi_client_settings.override_by(settings);
-        retry(sdk.address_list(), settings, closure)
-            .await
-            .into_inner()
+                Ok(ExecutionResponse {
+                    inner: (object, metadata),
+                    address,
+                    retries,
+                })
+            };
+
+            let settings = sdk.dapi_client_settings.override_by(settings);
+            retry(sdk.address_list(), settings, closure)
+                .await
+                .into_inner()
+        })
     }
 }
 

--- a/packages/rs-sdk/src/platform/transition/address_credit_withdrawal.rs
+++ b/packages/rs-sdk/src/platform/transition/address_credit_withdrawal.rs
@@ -1,4 +1,6 @@
 use std::collections::{BTreeMap, BTreeSet};
+use std::future::Future;
+use std::pin::Pin;
 
 use super::address_inputs::{collect_address_infos_from_proof, fetch_inputs_with_nonce};
 use super::broadcast::BroadcastStateTransition;
@@ -18,112 +20,114 @@ use dpp::withdrawal::Pooling;
 use drive_proof_verifier::types::AddressInfos;
 
 /// Helper trait to withdraw credits from Platform addresses into a Core script.
-#[async_trait::async_trait]
 pub trait WithdrawAddressFunds<S: Signer<PlatformAddress>> {
     /// Withdraws address balances (nonces fetched automatically).
     #[allow(clippy::too_many_arguments)]
-    async fn withdraw_address_funds(
-        &self,
+    fn withdraw_address_funds<'a>(
+        &'a self,
         inputs: BTreeMap<PlatformAddress, Credits>,
         change_output: Option<(PlatformAddress, Credits)>,
         fee_strategy: AddressFundsFeeStrategy,
         core_fee_per_byte: u32,
         pooling: Pooling,
         output_script: CoreScript,
-        signer: &S,
+        signer: &'a S,
         settings: Option<PutSettings>,
-    ) -> Result<AddressInfos, Error>;
+    ) -> Pin<Box<dyn Future<Output = Result<AddressInfos, Error>> + Send + 'a>>;
 
     /// Withdraws address balances with explicitly provided nonces.
     ///
     /// Inputs are not pre-validated client-side beyond signature preparation.
     #[allow(clippy::too_many_arguments)]
-    async fn withdraw_address_funds_with_nonce(
-        &self,
+    fn withdraw_address_funds_with_nonce<'a>(
+        &'a self,
         inputs: BTreeMap<PlatformAddress, (AddressNonce, Credits)>,
         change_output: Option<(PlatformAddress, Credits)>,
         fee_strategy: AddressFundsFeeStrategy,
         core_fee_per_byte: u32,
         pooling: Pooling,
         output_script: CoreScript,
-        signer: &S,
+        signer: &'a S,
         settings: Option<PutSettings>,
-    ) -> Result<AddressInfos, Error>;
+    ) -> Pin<Box<dyn Future<Output = Result<AddressInfos, Error>> + Send + 'a>>;
 }
 
-#[async_trait::async_trait]
 impl<S: Signer<PlatformAddress>> WithdrawAddressFunds<S> for Sdk {
-    async fn withdraw_address_funds(
-        &self,
+    fn withdraw_address_funds<'a>(
+        &'a self,
         inputs: BTreeMap<PlatformAddress, Credits>,
         change_output: Option<(PlatformAddress, Credits)>,
         fee_strategy: AddressFundsFeeStrategy,
         core_fee_per_byte: u32,
         pooling: Pooling,
         output_script: CoreScript,
-        signer: &S,
+        signer: &'a S,
         settings: Option<PutSettings>,
-    ) -> Result<AddressInfos, Error> {
-        let inputs_with_nonce = nonce_inc(fetch_inputs_with_nonce(self, &inputs).await?);
-        self.withdraw_address_funds_with_nonce(
-            inputs_with_nonce,
-            change_output,
-            fee_strategy,
-            core_fee_per_byte,
-            pooling,
-            output_script,
-            signer,
-            settings,
-        )
-        .await
+    ) -> Pin<Box<dyn Future<Output = Result<AddressInfos, Error>> + Send + 'a>> {
+        Box::pin(async move {
+            let inputs_with_nonce = nonce_inc(fetch_inputs_with_nonce(self, &inputs).await?);
+            self.withdraw_address_funds_with_nonce(
+                inputs_with_nonce,
+                change_output,
+                fee_strategy,
+                core_fee_per_byte,
+                pooling,
+                output_script,
+                signer,
+                settings,
+            )
+            .await
+        })
     }
 
-    async fn withdraw_address_funds_with_nonce(
-        &self,
+    fn withdraw_address_funds_with_nonce<'a>(
+        &'a self,
         inputs: BTreeMap<PlatformAddress, (AddressNonce, Credits)>,
         change_output: Option<(PlatformAddress, Credits)>,
         fee_strategy: AddressFundsFeeStrategy,
         core_fee_per_byte: u32,
         pooling: Pooling,
         output_script: CoreScript,
-        signer: &S,
+        signer: &'a S,
         settings: Option<PutSettings>,
-    ) -> Result<AddressInfos, Error> {
-        let user_fee_increase = settings
-            .as_ref()
-            .and_then(|settings| settings.user_fee_increase)
-            .unwrap_or_default();
+    ) -> Pin<Box<dyn Future<Output = Result<AddressInfos, Error>> + Send + 'a>> {
+        Box::pin(async move {
+            let user_fee_increase = settings
+                .as_ref()
+                .and_then(|settings| settings.user_fee_increase)
+                .unwrap_or_default();
 
-        let state_transition = AddressCreditWithdrawalTransition::try_from_inputs_with_signer(
-            inputs.clone(),
-            change_output,
-            fee_strategy,
-            core_fee_per_byte,
-            pooling,
-            output_script,
-            signer,
-            user_fee_increase,
-            self.version(),
-        )?;
-        ensure_valid_state_transition_structure(&state_transition, self.version())?;
+            let state_transition = AddressCreditWithdrawalTransition::try_from_inputs_with_signer(
+                inputs.clone(),
+                change_output,
+                fee_strategy,
+                core_fee_per_byte,
+                pooling,
+                output_script,
+                signer,
+                user_fee_increase,
+                self.version(),
+            )?;
+            ensure_valid_state_transition_structure(&state_transition, self.version())?;
 
-        match state_transition
-            .broadcast_and_wait::<StateTransitionProofResult>(self, settings)
-            .await?
-        {
-            StateTransitionProofResult::VerifiedAddressInfos(address_infos_map) => {
-                let mut expected_addresses: BTreeSet<PlatformAddress> =
-                    inputs.keys().copied().collect();
-                if let Some((change_address, _)) = change_output {
-                    expected_addresses.insert(change_address);
+            match state_transition
+                .broadcast_and_wait::<StateTransitionProofResult>(self, settings)
+                .await?
+            {
+                StateTransitionProofResult::VerifiedAddressInfos(address_infos_map) => {
+                    let mut expected_addresses: BTreeSet<PlatformAddress> =
+                        inputs.keys().copied().collect();
+                    if let Some((change_address, _)) = change_output {
+                        expected_addresses.insert(change_address);
+                    }
+
+                    collect_address_infos_from_proof(address_infos_map, &expected_addresses)
                 }
-
-                collect_address_infos_from_proof(address_infos_map, &expected_addresses)
+                other => Err(Error::InvalidProvedResponse(format!(
+                    "unexpected proof result for address withdrawal: {:?}",
+                    other
+                ))),
             }
-            other => Err(Error::InvalidProvedResponse(format!(
-                "unexpected proof result for address withdrawal: {:?}",
-                other
-            ))),
-        }
+        })
     }
 }

--- a/packages/rs-sdk/src/platform/transition/broadcast.rs
+++ b/packages/rs-sdk/src/platform/transition/broadcast.rs
@@ -16,264 +16,278 @@ use drive::drive::Drive;
 use drive_proof_verifier::DataContractProvider;
 use rs_dapi_client::{DapiRequest, ExecutionError, InnerInto, IntoInner, RequestSettings};
 use rs_dapi_client::{ExecutionResponse, WrapToExecutionResult};
+use std::future::Future;
+use std::pin::Pin;
 use tracing::{trace, warn};
 
-#[async_trait::async_trait]
 pub trait BroadcastStateTransition {
-    async fn broadcast(&self, sdk: &Sdk, settings: Option<PutSettings>) -> Result<(), Error>;
-    async fn wait_for_response<T: TryFrom<StateTransitionProofResult> + Send>(
-        &self,
-        sdk: &Sdk,
+    fn broadcast<'a>(
+        &'a self,
+        sdk: &'a Sdk,
         settings: Option<PutSettings>,
-    ) -> Result<T, Error>;
-    async fn broadcast_and_wait<T: TryFrom<StateTransitionProofResult> + Send>(
-        &self,
-        sdk: &Sdk,
+    ) -> Pin<Box<dyn Future<Output = Result<(), Error>> + Send + 'a>>;
+    fn wait_for_response<'a, T: TryFrom<StateTransitionProofResult> + Send>(
+        &'a self,
+        sdk: &'a Sdk,
         settings: Option<PutSettings>,
-    ) -> Result<T, Error>;
+    ) -> Pin<Box<dyn Future<Output = Result<T, Error>> + Send + 'a>>;
+    fn broadcast_and_wait<'a, T: TryFrom<StateTransitionProofResult> + Send>(
+        &'a self,
+        sdk: &'a Sdk,
+        settings: Option<PutSettings>,
+    ) -> Pin<Box<dyn Future<Output = Result<T, Error>> + Send + 'a>>;
 }
 
-#[async_trait::async_trait]
 impl BroadcastStateTransition for StateTransition {
-    async fn broadcast(&self, sdk: &Sdk, settings: Option<PutSettings>) -> Result<(), Error> {
-        trace!(
-            state_transition = %self.name(),
-            transaction_id = %self
-                .transaction_id()
-                .map(hex::encode)
-                .unwrap_or("UNKNOWN".to_string()),
-            "broadcast: start"
-        );
+    fn broadcast<'a>(
+        &'a self,
+        sdk: &'a Sdk,
+        settings: Option<PutSettings>,
+    ) -> Pin<Box<dyn Future<Output = Result<(), Error>> + Send + 'a>> {
+        Box::pin(async move {
+            trace!(
+                state_transition = %self.name(),
+                transaction_id = %self
+                    .transaction_id()
+                    .map(hex::encode)
+                    .unwrap_or("UNKNOWN".to_string()),
+                "broadcast: start"
+            );
 
-        let retry_settings = match settings {
-            Some(s) => sdk.dapi_client_settings.override_by(s.request_settings),
-            None => sdk.dapi_client_settings,
-        };
+            let retry_settings = match settings {
+                Some(s) => sdk.dapi_client_settings.override_by(s.request_settings),
+                None => sdk.dapi_client_settings,
+            };
 
-        // async fn retry_test_function(settings: RequestSettings) -> ExecutionResult<(), dash_sdk::Error>
-        let factory = |request_settings: RequestSettings| async move {
-            trace!("broadcast: creating request");
-            let request =
-                self.broadcast_request_for_state_transition()
+            // async fn retry_test_function(settings: RequestSettings) -> ExecutionResult<(), dash_sdk::Error>
+            let factory = |request_settings: RequestSettings| async move {
+                trace!("broadcast: creating request");
+                let request =
+                    self.broadcast_request_for_state_transition()
+                        .map_err(|e| ExecutionError {
+                            inner: e,
+                            address: None,
+                            retries: 0,
+                        })?;
+                trace!("broadcast: executing request");
+                let result = request
+                    .execute(sdk, request_settings)
+                    .await
+                    .map_err(|e| e.inner_into());
+
+                match &result {
+                    Ok(_) => trace!("broadcast: request succeeded"),
+                    Err(e) => warn!(error = ?e, "broadcast: request failed"),
+                }
+                result
+            };
+
+            // response is empty for a broadcast, result comes from the stream wait for state transition result
+            trace!("broadcast: starting retry mechanism");
+            let result = retry(sdk.address_list(), retry_settings, factory)
+                .await
+                .into_inner()
+                .map(|_| ());
+
+            match &result {
+                Ok(_) => trace!("broadcast: completed successfully"),
+                Err(e) => {
+                    warn!(error = ?e, "broadcast: failed after retries");
+                    if let Some(owner_id) = self.owner_id() {
+                        sdk.refresh_identity_nonce(&owner_id).await;
+                    }
+                }
+            }
+            result
+        })
+    }
+    fn wait_for_response<'a, T: TryFrom<StateTransitionProofResult> + Send>(
+        &'a self,
+        sdk: &'a Sdk,
+        settings: Option<PutSettings>,
+    ) -> Pin<Box<dyn Future<Output = Result<T, Error>> + Send + 'a>> {
+        Box::pin(async move {
+            trace!(
+                transaction_id = %self
+                    .transaction_id()
+                    .map(hex::encode)
+                    .unwrap_or("UNKNOWN".to_string()),
+                "wait: start"
+            );
+
+            let retry_settings = match settings {
+                Some(s) => sdk.dapi_client_settings.override_by(s.request_settings),
+                None => sdk.dapi_client_settings,
+            };
+
+            // prepare a factory that will generate closure which executes actual code
+            let factory = |request_settings: RequestSettings| async move {
+                trace!("wait: creating request");
+                let request = self
+                    .wait_for_state_transition_result_request()
                     .map_err(|e| ExecutionError {
                         inner: e,
                         address: None,
                         retries: 0,
                     })?;
-            trace!("broadcast: executing request");
-            let result = request
-                .execute(sdk, request_settings)
-                .await
-                .map_err(|e| e.inner_into());
 
-            match &result {
-                Ok(_) => trace!("broadcast: request succeeded"),
-                Err(e) => warn!(error = ?e, "broadcast: request failed"),
-            }
-            result
-        };
+                trace!("wait: executing request");
+                let response = request.execute(sdk, request_settings).await.inner_into()?;
+                trace!("wait: received response");
 
-        // response is empty for a broadcast, result comes from the stream wait for state transition result
-        trace!("broadcast: starting retry mechanism");
-        let result = retry(sdk.address_list(), retry_settings, factory)
-            .await
-            .into_inner()
-            .map(|_| ());
+                let grpc_response: &WaitForStateTransitionResultResponse = &response.inner;
 
-        match &result {
-            Ok(_) => trace!("broadcast: completed successfully"),
-            Err(e) => {
-                warn!(error = ?e, "broadcast: failed after retries");
-                if let Some(owner_id) = self.owner_id() {
-                    sdk.refresh_identity_nonce(&owner_id).await;
+                // We use match here to have a compilation error if a new version of the response is introduced
+                let state_transition_broadcast_error = match &grpc_response.version {
+                    Some(wait_for_state_transition_result_response::Version::V0(result)) => {
+                        match &result.result {
+                            Some(wait_for_state_transition_result_response_v0::Result::Error(
+                                e,
+                            )) => Some(e),
+                            _ => None,
+                        }
+                    }
+                    None => None,
+                };
+
+                if let Some(e) = state_transition_broadcast_error {
+                    warn!(error=?e, "wait: state transition broadcast error detected");
+                    let state_transition_broadcast_error: StateTransitionBroadcastError =
+                        StateTransitionBroadcastError::try_from(e.clone())
+                            .wrap_to_execution_result(&response)?
+                            .inner;
+
+                    return Err(Error::from(state_transition_broadcast_error))
+                        .wrap_to_execution_result(&response);
                 }
-            }
-        }
-        result
-    }
-    async fn wait_for_response<T: TryFrom<StateTransitionProofResult> + Send>(
-        &self,
-        sdk: &Sdk,
-        settings: Option<PutSettings>,
-    ) -> Result<T, Error> {
-        trace!(
-            transaction_id = %self
-                .transaction_id()
-                .map(hex::encode)
-                .unwrap_or("UNKNOWN".to_string()),
-            "wait: start"
-        );
 
-        let retry_settings = match settings {
-            Some(s) => sdk.dapi_client_settings.override_by(s.request_settings),
-            None => sdk.dapi_client_settings,
-        };
+                trace!("wait: extracting metadata");
+                let metadata = grpc_response
+                    .metadata()
+                    .wrap_to_execution_result(&response)?
+                    .inner;
+                let block_info = block_info_from_metadata(metadata)
+                    .wrap_to_execution_result(&response)?
+                    .inner;
+                trace!(block_info = ?block_info, "wait: block info extracted");
 
-        // prepare a factory that will generate closure which executes actual code
-        let factory = |request_settings: RequestSettings| async move {
-            trace!("wait: creating request");
-            let request = self
-                .wait_for_state_transition_result_request()
-                .map_err(|e| ExecutionError {
-                    inner: e,
-                    address: None,
-                    retries: 0,
+                trace!("wait: extracting proof");
+                let proof: &Proof = (*grpc_response)
+                    .proof()
+                    .wrap_to_execution_result(&response)?
+                    .inner;
+                trace!(
+                    proof_size = proof.grovedb_proof.len(),
+                    "wait: proof extracted"
+                );
+
+                let context_provider = sdk.context_provider().ok_or(ExecutionError {
+                    inner: Error::from(ContextProviderError::Config(
+                        "Context provider not initialized".to_string(),
+                    )),
+                    address: Some(response.address.clone()),
+                    retries: response.retries,
                 })?;
 
-            trace!("wait: executing request");
-            let response = request.execute(sdk, request_settings).await.inner_into()?;
-            trace!("wait: received response");
+                trace!("wait: verifying proof");
+                let (_, result) = match Drive::verify_state_transition_was_executed_with_proof(
+                    self,
+                    &block_info,
+                    proof.grovedb_proof.as_slice(),
+                    &context_provider.as_contract_lookup_fn(sdk.version()),
+                    sdk.version(),
+                ) {
+                    Ok(r) => Ok(ExecutionResponse {
+                        inner: r,
+                        retries: response.retries,
+                        address: response.address.clone(),
+                    }),
+                    Err(drive::error::Error::Proof(proof_error)) => Err(ExecutionError {
+                        inner: Error::DriveProofError(
+                            proof_error,
+                            proof.grovedb_proof.clone(),
+                            block_info,
+                        ),
+                        retries: response.retries,
+                        address: Some(response.address.clone()),
+                    }),
+                    Err(e) => Err(ExecutionError {
+                        inner: e.into(),
+                        retries: response.retries,
+                        address: Some(response.address.clone()),
+                    }),
+                }?
+                .inner;
 
-            let grpc_response: &WaitForStateTransitionResultResponse = &response.inner;
+                trace!("wait: proof verification successful");
+                trace!(result_variant = %result.to_string(), "wait: result variant");
 
-            // We use match here to have a compilation error if a new version of the response is introduced
-            let state_transition_broadcast_error = match &grpc_response.version {
-                Some(wait_for_state_transition_result_response::Version::V0(result)) => {
-                    match &result.result {
-                        Some(wait_for_state_transition_result_response_v0::Result::Error(e)) => {
-                            Some(e)
-                        }
-                        _ => None,
-                    }
+                let variant_name = result.to_string();
+                let conversion_result = T::try_from(result)
+                    .map_err(|_| {
+                        Error::InvalidProvedResponse(format!(
+                            "invalid proved response: cannot convert from {} to {}",
+                            variant_name,
+                            std::any::type_name::<T>(),
+                        ))
+                    })
+                    .wrap_to_execution_result(&response);
+
+                match &conversion_result {
+                    Ok(_) => trace!("wait: converted result to expected type"),
+                    Err(e) => warn!(error = ?e, "wait: failed to convert result"),
                 }
-                None => None,
+                conversion_result
             };
 
-            if let Some(e) = state_transition_broadcast_error {
-                warn!(error=?e, "wait: state transition broadcast error detected");
-                let state_transition_broadcast_error: StateTransitionBroadcastError =
-                    StateTransitionBroadcastError::try_from(e.clone())
-                        .wrap_to_execution_result(&response)?
-                        .inner;
+            let future = retry(sdk.address_list(), retry_settings, factory);
+            // run the future with or without timeout, depending on the settings
+            let wait_timeout = settings.and_then(|s| s.wait_timeout);
 
-                return Err(Error::from(state_transition_broadcast_error))
-                    .wrap_to_execution_result(&response);
+            trace!(timeout = ?wait_timeout, "wait: starting retry mechanism");
+
+            match wait_timeout {
+                Some(timeout) => {
+                    trace!(?timeout, "wait: waiting with timeout");
+                    tokio::time::timeout(timeout, future)
+                        .await
+                        .map_err(|e| {
+                            warn!(?timeout, "wait: timeout reached");
+                            Error::TimeoutReached(
+                                timeout,
+                                format!("Timeout waiting for result of {} (tx id: {}) affecting object {}: {:?}",
+                                self.name(),
+                                self.transaction_id().map(hex::encode).unwrap_or("UNKNOWN".to_string()),
+                                self.unique_identifiers().join(","),
+                                 e),
+                            )
+                        })?
+                        .into_inner()
+                }
+                None => {
+                    trace!("wait: waiting without timeout");
+                    future.await.into_inner()
+                }
             }
-
-            trace!("wait: extracting metadata");
-            let metadata = grpc_response
-                .metadata()
-                .wrap_to_execution_result(&response)?
-                .inner;
-            let block_info = block_info_from_metadata(metadata)
-                .wrap_to_execution_result(&response)?
-                .inner;
-            trace!(block_info = ?block_info, "wait: block info extracted");
-
-            trace!("wait: extracting proof");
-            let proof: &Proof = (*grpc_response)
-                .proof()
-                .wrap_to_execution_result(&response)?
-                .inner;
-            trace!(
-                proof_size = proof.grovedb_proof.len(),
-                "wait: proof extracted"
-            );
-
-            let context_provider = sdk.context_provider().ok_or(ExecutionError {
-                inner: Error::from(ContextProviderError::Config(
-                    "Context provider not initialized".to_string(),
-                )),
-                address: Some(response.address.clone()),
-                retries: response.retries,
-            })?;
-
-            trace!("wait: verifying proof");
-            let (_, result) = match Drive::verify_state_transition_was_executed_with_proof(
-                self,
-                &block_info,
-                proof.grovedb_proof.as_slice(),
-                &context_provider.as_contract_lookup_fn(sdk.version()),
-                sdk.version(),
-            ) {
-                Ok(r) => Ok(ExecutionResponse {
-                    inner: r,
-                    retries: response.retries,
-                    address: response.address.clone(),
-                }),
-                Err(drive::error::Error::Proof(proof_error)) => Err(ExecutionError {
-                    inner: Error::DriveProofError(
-                        proof_error,
-                        proof.grovedb_proof.clone(),
-                        block_info,
-                    ),
-                    retries: response.retries,
-                    address: Some(response.address.clone()),
-                }),
-                Err(e) => Err(ExecutionError {
-                    inner: e.into(),
-                    retries: response.retries,
-                    address: Some(response.address.clone()),
-                }),
-            }?
-            .inner;
-
-            trace!("wait: proof verification successful");
-            trace!(result_variant = %result.to_string(), "wait: result variant");
-
-            let variant_name = result.to_string();
-            let conversion_result = T::try_from(result)
-                .map_err(|_| {
-                    Error::InvalidProvedResponse(format!(
-                        "invalid proved response: cannot convert from {} to {}",
-                        variant_name,
-                        std::any::type_name::<T>(),
-                    ))
-                })
-                .wrap_to_execution_result(&response);
-
-            match &conversion_result {
-                Ok(_) => trace!("wait: converted result to expected type"),
-                Err(e) => warn!(error = ?e, "wait: failed to convert result"),
-            }
-            conversion_result
-        };
-
-        let future = retry(sdk.address_list(), retry_settings, factory);
-        // run the future with or without timeout, depending on the settings
-        let wait_timeout = settings.and_then(|s| s.wait_timeout);
-
-        trace!(timeout = ?wait_timeout, "wait: starting retry mechanism");
-
-        match wait_timeout {
-            Some(timeout) => {
-                trace!(?timeout, "wait: waiting with timeout");
-                tokio::time::timeout(timeout, future)
-                    .await
-                    .map_err(|e| {
-                        warn!(?timeout, "wait: timeout reached");
-                        Error::TimeoutReached(
-                            timeout,
-                            format!("Timeout waiting for result of {} (tx id: {}) affecting object {}: {:?}",
-                            self.name(),
-                            self.transaction_id().map(hex::encode).unwrap_or("UNKNOWN".to_string()),
-                            self.unique_identifiers().join(","),
-                             e),
-                        )
-                    })?
-                    .into_inner()
-            }
-            None => {
-                trace!("wait: waiting without timeout");
-                future.await.into_inner()
-            }
-        }
+        })
     }
 
-    async fn broadcast_and_wait<T: TryFrom<StateTransitionProofResult> + Send>(
-        &self,
-        sdk: &Sdk,
+    fn broadcast_and_wait<'a, T: TryFrom<StateTransitionProofResult> + Send>(
+        &'a self,
+        sdk: &'a Sdk,
         settings: Option<PutSettings>,
-    ) -> Result<T, Error> {
-        trace!(state_transition = %self.name(), "broadcast_and_wait: start");
-        trace!("broadcast_and_wait: step 1 - broadcasting");
-        self.broadcast(sdk, settings).await?;
-        trace!("broadcast_and_wait: step 2 - waiting for response");
-        let result = self.wait_for_response::<T>(sdk, settings).await;
-        match &result {
-            Ok(_) => trace!("broadcast_and_wait: complete success"),
-            Err(e) => warn!(error = ?e, "broadcast_and_wait: failed"),
-        }
-        result
+    ) -> Pin<Box<dyn Future<Output = Result<T, Error>> + Send + 'a>> {
+        Box::pin(async move {
+            trace!(state_transition = %self.name(), "broadcast_and_wait: start");
+            trace!("broadcast_and_wait: step 1 - broadcasting");
+            self.broadcast(sdk, settings).await?;
+            trace!("broadcast_and_wait: step 2 - waiting for response");
+            let result = self.wait_for_response::<T>(sdk, settings).await;
+            match &result {
+                Ok(_) => trace!("broadcast_and_wait: complete success"),
+                Err(e) => warn!(error = ?e, "broadcast_and_wait: failed"),
+            }
+            result
+        })
     }
 }

--- a/packages/rs-sdk/src/platform/transition/purchase_document.rs
+++ b/packages/rs-sdk/src/platform/transition/purchase_document.rs
@@ -14,108 +14,112 @@ use dpp::state_transition::batch_transition::methods::v0::DocumentsBatchTransiti
 use dpp::state_transition::batch_transition::BatchTransition;
 use dpp::state_transition::StateTransition;
 use dpp::tokens::token_payment_info::TokenPaymentInfo;
+use std::future::Future;
+use std::pin::Pin;
 
-#[async_trait::async_trait]
 /// A trait for purchasing a document on Platform
 pub trait PurchaseDocument<S: Signer<IdentityPublicKey>>: Waitable {
     /// Tries to purchase a document on platform
     /// Setting settings to `None` sets default connection behavior
     #[allow(clippy::too_many_arguments)]
-    async fn purchase_document(
-        &self,
+    fn purchase_document<'a>(
+        &'a self,
         price: Credits,
-        sdk: &Sdk,
+        sdk: &'a Sdk,
         document_type: DocumentType,
         purchaser_id: Identifier,
         identity_public_key: IdentityPublicKey,
         token_payment_info: Option<TokenPaymentInfo>,
-        signer: &S,
+        signer: &'a S,
         settings: Option<PutSettings>,
-    ) -> Result<StateTransition, Error>;
+    ) -> Pin<Box<dyn Future<Output = Result<StateTransition, Error>> + Send + 'a>>;
 
     /// Tries to purchase a document on platform and waits for the response
     #[allow(clippy::too_many_arguments)]
-    async fn purchase_document_and_wait_for_response(
-        &self,
+    fn purchase_document_and_wait_for_response<'a>(
+        &'a self,
         price: Credits,
-        sdk: &Sdk,
+        sdk: &'a Sdk,
         document_type: DocumentType,
         purchaser_id: Identifier,
         identity_public_key: IdentityPublicKey,
         token_payment_info: Option<TokenPaymentInfo>,
-        signer: &S,
+        signer: &'a S,
         settings: Option<PutSettings>,
-    ) -> Result<Document, Error>;
+    ) -> Pin<Box<dyn Future<Output = Result<Document, Error>> + Send + 'a>>;
 }
 
-#[async_trait::async_trait]
 impl<S: Signer<IdentityPublicKey>> PurchaseDocument<S> for Document {
-    async fn purchase_document(
-        &self,
+    fn purchase_document<'a>(
+        &'a self,
         price: Credits,
-        sdk: &Sdk,
+        sdk: &'a Sdk,
         document_type: DocumentType,
         purchaser_id: Identifier,
         identity_public_key: IdentityPublicKey,
         token_payment_info: Option<TokenPaymentInfo>,
-        signer: &S,
+        signer: &'a S,
         settings: Option<PutSettings>,
-    ) -> Result<StateTransition, Error> {
-        let new_identity_contract_nonce = sdk
-            .get_identity_contract_nonce(
+    ) -> Pin<Box<dyn Future<Output = Result<StateTransition, Error>> + Send + 'a>> {
+        Box::pin(async move {
+            let new_identity_contract_nonce = sdk
+                .get_identity_contract_nonce(
+                    purchaser_id,
+                    document_type.data_contract_id(),
+                    true,
+                    settings,
+                )
+                .await?;
+
+            let settings = settings.unwrap_or_default();
+
+            let transition = BatchTransition::new_document_purchase_transition_from_document(
+                self.clone(),
+                document_type.as_ref(),
                 purchaser_id,
-                document_type.data_contract_id(),
-                true,
-                settings,
-            )
-            .await?;
-
-        let settings = settings.unwrap_or_default();
-
-        let transition = BatchTransition::new_document_purchase_transition_from_document(
-            self.clone(),
-            document_type.as_ref(),
-            purchaser_id,
-            price,
-            &identity_public_key,
-            new_identity_contract_nonce,
-            settings.user_fee_increase.unwrap_or_default(),
-            token_payment_info,
-            signer,
-            sdk.version(),
-            settings.state_transition_creation_options,
-        )?;
-        ensure_valid_state_transition_structure(&transition, sdk.version())?;
-
-        transition.broadcast(sdk, Some(settings)).await?;
-        // response is empty for a broadcast, result comes from the stream wait for state transition result
-        Ok(transition)
-    }
-
-    async fn purchase_document_and_wait_for_response(
-        &self,
-        price: Credits,
-        sdk: &Sdk,
-        document_type: DocumentType,
-        purchaser_id: Identifier,
-        identity_public_key: IdentityPublicKey,
-        token_payment_info: Option<TokenPaymentInfo>,
-        signer: &S,
-        settings: Option<PutSettings>,
-    ) -> Result<Document, Error> {
-        let state_transition = self
-            .purchase_document(
                 price,
-                sdk,
-                document_type,
-                purchaser_id,
-                identity_public_key,
+                &identity_public_key,
+                new_identity_contract_nonce,
+                settings.user_fee_increase.unwrap_or_default(),
                 token_payment_info,
                 signer,
-                settings,
-            )
-            .await?;
+                sdk.version(),
+                settings.state_transition_creation_options,
+            )?;
+            ensure_valid_state_transition_structure(&transition, sdk.version())?;
 
-        Self::wait_for_response(sdk, state_transition, settings).await
+            transition.broadcast(sdk, Some(settings)).await?;
+            // response is empty for a broadcast, result comes from the stream wait for state transition result
+            Ok(transition)
+        })
+    }
+
+    fn purchase_document_and_wait_for_response<'a>(
+        &'a self,
+        price: Credits,
+        sdk: &'a Sdk,
+        document_type: DocumentType,
+        purchaser_id: Identifier,
+        identity_public_key: IdentityPublicKey,
+        token_payment_info: Option<TokenPaymentInfo>,
+        signer: &'a S,
+        settings: Option<PutSettings>,
+    ) -> Pin<Box<dyn Future<Output = Result<Document, Error>> + Send + 'a>> {
+        Box::pin(async move {
+            let state_transition = self
+                .purchase_document(
+                    price,
+                    sdk,
+                    document_type,
+                    purchaser_id,
+                    identity_public_key,
+                    token_payment_info,
+                    signer,
+                    settings,
+                )
+                .await?;
+
+            Self::wait_for_response(sdk, state_transition, settings).await
+        })
     }
 }

--- a/packages/rs-sdk/src/platform/transition/put_contract.rs
+++ b/packages/rs-sdk/src/platform/transition/put_contract.rs
@@ -1,4 +1,6 @@
 use std::collections::BTreeMap;
+use std::future::Future;
+use std::pin::Pin;
 
 use crate::{Error, Sdk};
 
@@ -16,79 +18,81 @@ use super::broadcast::BroadcastStateTransition;
 use super::validation::ensure_valid_state_transition_structure;
 use super::waitable::Waitable;
 
-#[async_trait::async_trait]
 /// A trait for putting a contract to platform
 pub trait PutContract<S: Signer<IdentityPublicKey>>: Waitable {
     /// Puts a contract on platform
     /// Setting settings to `None` sets default connection behavior
-    async fn put_to_platform(
-        &self,
-        sdk: &Sdk,
+    fn put_to_platform<'a>(
+        &'a self,
+        sdk: &'a Sdk,
         identity_public_key: IdentityPublicKey,
-        signer: &S,
+        signer: &'a S,
         settings: Option<PutSettings>,
-    ) -> Result<StateTransition, Error>;
+    ) -> Pin<Box<dyn Future<Output = Result<StateTransition, Error>> + Send + 'a>>;
 
     /// Puts a contract on platform and waits for the confirmation proof
-    async fn put_to_platform_and_wait_for_response(
-        &self,
-        sdk: &Sdk,
+    fn put_to_platform_and_wait_for_response<'a>(
+        &'a self,
+        sdk: &'a Sdk,
         identity_public_key: IdentityPublicKey,
-        signer: &S,
+        signer: &'a S,
         settings: Option<PutSettings>,
-    ) -> Result<DataContract, Error>;
+    ) -> Pin<Box<dyn Future<Output = Result<DataContract, Error>> + Send + 'a>>;
 }
 
-#[async_trait::async_trait]
 impl<S: Signer<IdentityPublicKey>> PutContract<S> for DataContract {
-    async fn put_to_platform(
-        &self,
-        sdk: &Sdk,
+    fn put_to_platform<'a>(
+        &'a self,
+        sdk: &'a Sdk,
         identity_public_key: IdentityPublicKey,
-        signer: &S,
+        signer: &'a S,
         settings: Option<PutSettings>,
-    ) -> Result<StateTransition, Error> {
-        let new_identity_nonce = sdk
-            .get_identity_nonce(self.owner_id(), true, settings)
-            .await?;
+    ) -> Pin<Box<dyn Future<Output = Result<StateTransition, Error>> + Send + 'a>> {
+        Box::pin(async move {
+            let new_identity_nonce = sdk
+                .get_identity_nonce(self.owner_id(), true, settings)
+                .await?;
 
-        let key_id = identity_public_key.id();
+            let key_id = identity_public_key.id();
 
-        let partial_identity = PartialIdentity {
-            id: self.owner_id(),
-            loaded_public_keys: BTreeMap::from([(key_id, identity_public_key)]),
-            balance: None,
-            revision: None,
-            not_found_public_keys: Default::default(),
-        };
-        let transition = DataContractCreateTransition::new_from_data_contract(
-            self.clone(),
-            new_identity_nonce,
-            &partial_identity,
-            key_id,
-            signer,
-            sdk.version(),
-            None,
-        )?;
-        ensure_valid_state_transition_structure(&transition, sdk.version())?;
+            let partial_identity = PartialIdentity {
+                id: self.owner_id(),
+                loaded_public_keys: BTreeMap::from([(key_id, identity_public_key)]),
+                balance: None,
+                revision: None,
+                not_found_public_keys: Default::default(),
+            };
+            let transition = DataContractCreateTransition::new_from_data_contract(
+                self.clone(),
+                new_identity_nonce,
+                &partial_identity,
+                key_id,
+                signer,
+                sdk.version(),
+                None,
+            )?;
+            ensure_valid_state_transition_structure(&transition, sdk.version())?;
 
-        transition.broadcast(sdk, settings).await?;
-        // response is empty for a broadcast, result comes from the stream wait for state transition result
+            transition.broadcast(sdk, settings).await?;
+            // response is empty for a broadcast, result comes from the stream wait for state transition result
 
-        Ok(transition)
+            Ok(transition)
+        })
     }
 
-    async fn put_to_platform_and_wait_for_response(
-        &self,
-        sdk: &Sdk,
+    fn put_to_platform_and_wait_for_response<'a>(
+        &'a self,
+        sdk: &'a Sdk,
         identity_public_key: IdentityPublicKey,
-        signer: &S,
+        signer: &'a S,
         settings: Option<PutSettings>,
-    ) -> Result<DataContract, Error> {
-        let state_transition = self
-            .put_to_platform(sdk, identity_public_key, signer, settings)
-            .await?;
+    ) -> Pin<Box<dyn Future<Output = Result<DataContract, Error>> + Send + 'a>> {
+        Box::pin(async move {
+            let state_transition = self
+                .put_to_platform(sdk, identity_public_key, signer, settings)
+                .await?;
 
-        Self::wait_for_response(sdk, state_transition, settings).await
+            Self::wait_for_response(sdk, state_transition, settings).await
+        })
     }
 }

--- a/packages/rs-sdk/src/platform/transition/put_document.rs
+++ b/packages/rs-sdk/src/platform/transition/put_document.rs
@@ -14,131 +14,135 @@ use dpp::state_transition::batch_transition::methods::v0::DocumentsBatchTransiti
 use dpp::state_transition::batch_transition::BatchTransition;
 use dpp::state_transition::StateTransition;
 use dpp::tokens::token_payment_info::TokenPaymentInfo;
+use std::future::Future;
+use std::pin::Pin;
 
-#[async_trait::async_trait]
 /// A trait for putting a document to platform
 pub trait PutDocument<S: Signer<IdentityPublicKey>>: Waitable {
     /// Puts a document on platform
     /// setting settings to `None` sets default connection behavior
     #[allow(clippy::too_many_arguments)]
-    async fn put_to_platform(
-        &self,
-        sdk: &Sdk,
+    fn put_to_platform<'a>(
+        &'a self,
+        sdk: &'a Sdk,
         document_type: DocumentType,
         document_state_transition_entropy: Option<[u8; 32]>,
         identity_public_key: IdentityPublicKey,
         token_payment_info: Option<TokenPaymentInfo>,
-        signer: &S,
+        signer: &'a S,
         settings: Option<PutSettings>,
-    ) -> Result<StateTransition, Error>;
+    ) -> Pin<Box<dyn Future<Output = Result<StateTransition, Error>> + Send + 'a>>;
 
     /// Puts a document on platform and waits for the confirmation proof
     #[allow(clippy::too_many_arguments)]
-    async fn put_to_platform_and_wait_for_response(
-        &self,
-        sdk: &Sdk,
+    fn put_to_platform_and_wait_for_response<'a>(
+        &'a self,
+        sdk: &'a Sdk,
         document_type: DocumentType,
         document_state_transition_entropy: Option<[u8; 32]>,
         identity_public_key: IdentityPublicKey,
         token_payment_info: Option<TokenPaymentInfo>,
-        signer: &S,
+        signer: &'a S,
         settings: Option<PutSettings>,
-    ) -> Result<Document, Error>;
+    ) -> Pin<Box<dyn Future<Output = Result<Document, Error>> + Send + 'a>>;
 }
 
-#[async_trait::async_trait]
 impl<S: Signer<IdentityPublicKey>> PutDocument<S> for Document {
-    async fn put_to_platform(
-        &self,
-        sdk: &Sdk,
+    fn put_to_platform<'a>(
+        &'a self,
+        sdk: &'a Sdk,
         document_type: DocumentType,
         document_state_transition_entropy: Option<[u8; 32]>,
         identity_public_key: IdentityPublicKey,
         token_payment_info: Option<TokenPaymentInfo>,
-        signer: &S,
+        signer: &'a S,
         settings: Option<PutSettings>,
-    ) -> Result<StateTransition, Error> {
-        let new_identity_contract_nonce = sdk
-            .get_identity_contract_nonce(
-                self.owner_id(),
-                document_type.data_contract_id(),
-                true,
-                settings,
-            )
-            .await?;
+    ) -> Pin<Box<dyn Future<Output = Result<StateTransition, Error>> + Send + 'a>> {
+        Box::pin(async move {
+            let new_identity_contract_nonce = sdk
+                .get_identity_contract_nonce(
+                    self.owner_id(),
+                    document_type.data_contract_id(),
+                    true,
+                    settings,
+                )
+                .await?;
 
-        let settings = settings.unwrap_or_default();
-        let transition = if self.revision().is_some()
-            && self.revision().unwrap() != INITIAL_REVISION
-        {
-            BatchTransition::new_document_replacement_transition_from_document(
-                self.clone(),
-                document_type.as_ref(),
-                &identity_public_key,
-                new_identity_contract_nonce,
-                settings.user_fee_increase.unwrap_or_default(),
-                token_payment_info,
-                signer,
-                sdk.version(),
-                settings.state_transition_creation_options,
-            )
-        } else {
-            let (document, document_state_transition_entropy) = document_state_transition_entropy
-                .map(|entropy| (self.clone(), entropy))
-                .unwrap_or_else(|| {
-                    let mut rng = StdRng::from_entropy();
-                    let mut document = self.clone();
-                    let entropy = rng.gen::<[u8; 32]>();
-                    document.set_id(Document::generate_document_id_v0(
-                        &document_type.data_contract_id(),
-                        &document.owner_id(),
-                        document_type.name(),
-                        entropy.as_slice(),
-                    ));
-                    (document, entropy)
-                });
-            BatchTransition::new_document_creation_transition_from_document(
-                document,
-                document_type.as_ref(),
-                document_state_transition_entropy,
-                &identity_public_key,
-                new_identity_contract_nonce,
-                settings.user_fee_increase.unwrap_or_default(),
-                token_payment_info,
-                signer,
-                sdk.version(),
-                settings.state_transition_creation_options,
-            )
-        }?;
-        ensure_valid_state_transition_structure(&transition, sdk.version())?;
+            let settings = settings.unwrap_or_default();
+            let transition =
+                if self.revision().is_some() && self.revision().unwrap() != INITIAL_REVISION {
+                    BatchTransition::new_document_replacement_transition_from_document(
+                        self.clone(),
+                        document_type.as_ref(),
+                        &identity_public_key,
+                        new_identity_contract_nonce,
+                        settings.user_fee_increase.unwrap_or_default(),
+                        token_payment_info,
+                        signer,
+                        sdk.version(),
+                        settings.state_transition_creation_options,
+                    )
+                } else {
+                    let (document, document_state_transition_entropy) =
+                        document_state_transition_entropy
+                            .map(|entropy| (self.clone(), entropy))
+                            .unwrap_or_else(|| {
+                                let mut rng = StdRng::from_entropy();
+                                let mut document = self.clone();
+                                let entropy = rng.gen::<[u8; 32]>();
+                                document.set_id(Document::generate_document_id_v0(
+                                    &document_type.data_contract_id(),
+                                    &document.owner_id(),
+                                    document_type.name(),
+                                    entropy.as_slice(),
+                                ));
+                                (document, entropy)
+                            });
+                    BatchTransition::new_document_creation_transition_from_document(
+                        document,
+                        document_type.as_ref(),
+                        document_state_transition_entropy,
+                        &identity_public_key,
+                        new_identity_contract_nonce,
+                        settings.user_fee_increase.unwrap_or_default(),
+                        token_payment_info,
+                        signer,
+                        sdk.version(),
+                        settings.state_transition_creation_options,
+                    )
+                }?;
+            ensure_valid_state_transition_structure(&transition, sdk.version())?;
 
-        // response is empty for a broadcast, result comes from the stream wait for state transition result
-        transition.broadcast(sdk, Some(settings)).await?;
-        Ok(transition)
+            // response is empty for a broadcast, result comes from the stream wait for state transition result
+            transition.broadcast(sdk, Some(settings)).await?;
+            Ok(transition)
+        })
     }
 
-    async fn put_to_platform_and_wait_for_response(
-        &self,
-        sdk: &Sdk,
+    fn put_to_platform_and_wait_for_response<'a>(
+        &'a self,
+        sdk: &'a Sdk,
         document_type: DocumentType,
         document_state_transition_entropy: Option<[u8; 32]>,
         identity_public_key: IdentityPublicKey,
         token_payment_info: Option<TokenPaymentInfo>,
-        signer: &S,
+        signer: &'a S,
         settings: Option<PutSettings>,
-    ) -> Result<Document, Error> {
-        let state_transition = self
-            .put_to_platform(
-                sdk,
-                document_type,
-                document_state_transition_entropy,
-                identity_public_key,
-                token_payment_info,
-                signer,
-                settings,
-            )
-            .await?;
+    ) -> Pin<Box<dyn Future<Output = Result<Document, Error>> + Send + 'a>> {
+        Box::pin(async move {
+            let state_transition = self
+                .put_to_platform(
+                    sdk,
+                    document_type,
+                    document_state_transition_entropy,
+                    identity_public_key,
+                    token_payment_info,
+                    signer,
+                    settings,
+                )
+                .await?;
 
-        Self::wait_for_response(sdk, state_transition, settings).await
+            Self::wait_for_response(sdk, state_transition, settings).await
+        })
     }
 }

--- a/packages/rs-sdk/src/platform/transition/put_identity.rs
+++ b/packages/rs-sdk/src/platform/transition/put_identity.rs
@@ -21,29 +21,30 @@ use dpp::state_transition::proof_result::StateTransitionProofResult;
 use dpp::state_transition::StateTransition;
 use drive_proof_verifier::types::AddressInfos;
 use std::collections::{BTreeMap, BTreeSet};
+use std::future::Future;
+use std::pin::Pin;
 
 /// Trait for creating identities on the platform.
-#[async_trait::async_trait]
 pub trait PutIdentity<IS: Signer<IdentityPublicKey>>: Waitable {
     /// Creates an identity using an asset lock proof.
-    async fn put_to_platform(
-        &self,
-        sdk: &Sdk,
+    fn put_to_platform<'a>(
+        &'a self,
+        sdk: &'a Sdk,
         asset_lock_proof: AssetLockProof,
-        asset_lock_proof_private_key: &PrivateKey,
-        signer: &IS,
+        asset_lock_proof_private_key: &'a PrivateKey,
+        signer: &'a IS,
         settings: Option<PutSettings>,
-    ) -> Result<StateTransition, Error>;
+    ) -> Pin<Box<dyn Future<Output = Result<StateTransition, Error>> + Send + 'a>>;
 
     /// Creates an identity using an asset lock and waits for confirmation.
-    async fn put_to_platform_and_wait_for_response(
-        &self,
-        sdk: &Sdk,
+    fn put_to_platform_and_wait_for_response<'a>(
+        &'a self,
+        sdk: &'a Sdk,
         asset_lock_proof: AssetLockProof,
-        asset_lock_proof_private_key: &PrivateKey,
-        signer: &IS,
+        asset_lock_proof_private_key: &'a PrivateKey,
+        signer: &'a IS,
         settings: Option<PutSettings>,
-    ) -> Result<Self, Error>
+    ) -> Pin<Box<dyn Future<Output = Result<Self, Error>> + Send + 'a>>
     where
         Self: Sized;
 
@@ -53,78 +54,83 @@ pub trait PutIdentity<IS: Signer<IdentityPublicKey>>: Waitable {
     /// to create an identity. Then use this method to put it to the platform.
     ///
     /// This is a preferred method, as you need to use the same nonces when creating the identity.
-    async fn put_with_address_funding<AS: Signer<PlatformAddress> + Send + Sync>(
-        &self,
-        sdk: &Sdk,
+    fn put_with_address_funding<'a, AS: Signer<PlatformAddress> + Send + Sync + 'a>(
+        &'a self,
+        sdk: &'a Sdk,
         inputs_with_nonce: BTreeMap<PlatformAddress, (AddressNonce, Credits)>,
         output: Option<(PlatformAddress, Credits)>,
-        identity_signer: &IS,
-        input_address_signer: &AS,
+        identity_signer: &'a IS,
+        input_address_signer: &'a AS,
         settings: Option<PutSettings>,
-    ) -> Result<(Identity, AddressInfos), Error>;
+    ) -> Pin<Box<dyn Future<Output = Result<(Identity, AddressInfos), Error>> + Send + 'a>>;
 }
 
-#[async_trait::async_trait]
 impl<IS: Signer<IdentityPublicKey>> PutIdentity<IS> for Identity {
-    async fn put_to_platform(
-        &self,
-        sdk: &Sdk,
+    fn put_to_platform<'a>(
+        &'a self,
+        sdk: &'a Sdk,
         asset_lock_proof: AssetLockProof,
-        asset_lock_proof_private_key: &PrivateKey,
-        signer: &IS,
+        asset_lock_proof_private_key: &'a PrivateKey,
+        signer: &'a IS,
         settings: Option<PutSettings>,
-    ) -> Result<StateTransition, Error> {
-        put_identity_with_asset_lock(
-            self,
-            sdk,
-            asset_lock_proof,
-            asset_lock_proof_private_key,
-            signer,
-            settings,
-        )
-        .await
-    }
-
-    async fn put_to_platform_and_wait_for_response(
-        &self,
-        sdk: &Sdk,
-        asset_lock_proof: AssetLockProof,
-        asset_lock_proof_private_key: &PrivateKey,
-        signer: &IS,
-        settings: Option<PutSettings>,
-    ) -> Result<Identity, Error> {
-        let state_transition = self
-            .put_to_platform(
+    ) -> Pin<Box<dyn Future<Output = Result<StateTransition, Error>> + Send + 'a>> {
+        Box::pin(async move {
+            put_identity_with_asset_lock(
+                self,
                 sdk,
                 asset_lock_proof,
                 asset_lock_proof_private_key,
                 signer,
                 settings,
             )
-            .await?;
-
-        Self::wait_for_response(sdk, state_transition, settings).await
+            .await
+        })
     }
 
-    async fn put_with_address_funding<AS: Signer<PlatformAddress> + Send + Sync>(
-        &self,
-        sdk: &Sdk,
+    fn put_to_platform_and_wait_for_response<'a>(
+        &'a self,
+        sdk: &'a Sdk,
+        asset_lock_proof: AssetLockProof,
+        asset_lock_proof_private_key: &'a PrivateKey,
+        signer: &'a IS,
+        settings: Option<PutSettings>,
+    ) -> Pin<Box<dyn Future<Output = Result<Identity, Error>> + Send + 'a>> {
+        Box::pin(async move {
+            let state_transition = self
+                .put_to_platform(
+                    sdk,
+                    asset_lock_proof,
+                    asset_lock_proof_private_key,
+                    signer,
+                    settings,
+                )
+                .await?;
+
+            Self::wait_for_response(sdk, state_transition, settings).await
+        })
+    }
+
+    fn put_with_address_funding<'a, AS: Signer<PlatformAddress> + Send + Sync + 'a>(
+        &'a self,
+        sdk: &'a Sdk,
         inputs: BTreeMap<PlatformAddress, (AddressNonce, Credits)>,
         output: Option<(PlatformAddress, Credits)>,
-        identity_signer: &IS,
-        input_address_signer: &AS,
+        identity_signer: &'a IS,
+        input_address_signer: &'a AS,
         settings: Option<PutSettings>,
-    ) -> Result<(Identity, AddressInfos), Error> {
-        put_identity_with_address_funding::<IS, AS>(
-            self,
-            sdk,
-            inputs,
-            output,
-            identity_signer,
-            input_address_signer,
-            settings,
-        )
-        .await
+    ) -> Pin<Box<dyn Future<Output = Result<(Identity, AddressInfos), Error>> + Send + 'a>> {
+        Box::pin(async move {
+            put_identity_with_address_funding::<IS, AS>(
+                self,
+                sdk,
+                inputs,
+                output,
+                identity_signer,
+                input_address_signer,
+                settings,
+            )
+            .await
+        })
     }
 }
 

--- a/packages/rs-sdk/src/platform/transition/shield.rs
+++ b/packages/rs-sdk/src/platform/transition/shield.rs
@@ -1,4 +1,6 @@
 use std::collections::BTreeMap;
+use std::future::Future;
+use std::pin::Pin;
 
 use super::address_inputs::{fetch_inputs_with_nonce, nonce_inc};
 use super::broadcast::BroadcastStateTransition;
@@ -14,91 +16,93 @@ use dpp::state_transition::shield_transition::methods::ShieldTransitionMethodsV0
 use dpp::state_transition::shield_transition::ShieldTransition;
 
 /// Helper trait to shield platform credits into the shielded pool.
-#[async_trait::async_trait]
 pub trait ShieldFunds<S: Signer<PlatformAddress>> {
     /// Shield funds from platform addresses into the shielded pool.
     /// Address nonces are fetched automatically.
-    async fn shield_funds(
-        &self,
+    fn shield_funds<'a>(
+        &'a self,
         inputs: BTreeMap<PlatformAddress, Credits>,
         bundle: OrchardBundleParams,
         amount: u64,
         fee_strategy: AddressFundsFeeStrategy,
-        signer: &S,
+        signer: &'a S,
         settings: Option<PutSettings>,
-    ) -> Result<(), Error>;
+    ) -> Pin<Box<dyn Future<Output = Result<(), Error>> + Send + 'a>>;
 
     /// Shield funds with explicitly provided address nonces.
-    async fn shield_funds_with_nonce(
-        &self,
+    fn shield_funds_with_nonce<'a>(
+        &'a self,
         inputs: BTreeMap<PlatformAddress, (AddressNonce, Credits)>,
         bundle: OrchardBundleParams,
         amount: u64,
         fee_strategy: AddressFundsFeeStrategy,
-        signer: &S,
+        signer: &'a S,
         settings: Option<PutSettings>,
-    ) -> Result<(), Error>;
+    ) -> Pin<Box<dyn Future<Output = Result<(), Error>> + Send + 'a>>;
 }
 
-#[async_trait::async_trait]
 impl<S: Signer<PlatformAddress>> ShieldFunds<S> for Sdk {
-    async fn shield_funds(
-        &self,
+    fn shield_funds<'a>(
+        &'a self,
         inputs: BTreeMap<PlatformAddress, Credits>,
         bundle: OrchardBundleParams,
         amount: u64,
         fee_strategy: AddressFundsFeeStrategy,
-        signer: &S,
+        signer: &'a S,
         settings: Option<PutSettings>,
-    ) -> Result<(), Error> {
-        let inputs_with_nonce = nonce_inc(fetch_inputs_with_nonce(self, &inputs).await?);
-        self.shield_funds_with_nonce(
-            inputs_with_nonce,
-            bundle,
-            amount,
-            fee_strategy,
-            signer,
-            settings,
-        )
-        .await
+    ) -> Pin<Box<dyn Future<Output = Result<(), Error>> + Send + 'a>> {
+        Box::pin(async move {
+            let inputs_with_nonce = nonce_inc(fetch_inputs_with_nonce(self, &inputs).await?);
+            self.shield_funds_with_nonce(
+                inputs_with_nonce,
+                bundle,
+                amount,
+                fee_strategy,
+                signer,
+                settings,
+            )
+            .await
+        })
     }
 
-    async fn shield_funds_with_nonce(
-        &self,
+    fn shield_funds_with_nonce<'a>(
+        &'a self,
         inputs: BTreeMap<PlatformAddress, (AddressNonce, Credits)>,
         bundle: OrchardBundleParams,
         amount: u64,
         fee_strategy: AddressFundsFeeStrategy,
-        signer: &S,
+        signer: &'a S,
         settings: Option<PutSettings>,
-    ) -> Result<(), Error> {
-        let user_fee_increase = settings
-            .as_ref()
-            .and_then(|s| s.user_fee_increase)
-            .unwrap_or_default();
+    ) -> Pin<Box<dyn Future<Output = Result<(), Error>> + Send + 'a>> {
+        Box::pin(async move {
+            let user_fee_increase = settings
+                .as_ref()
+                .and_then(|s| s.user_fee_increase)
+                .unwrap_or_default();
 
-        let OrchardBundleParams {
-            actions,
-            anchor,
-            proof,
-            binding_signature,
-        } = bundle;
+            let OrchardBundleParams {
+                actions,
+                anchor,
+                proof,
+                binding_signature,
+            } = bundle;
 
-        let state_transition = ShieldTransition::try_from_bundle_with_signer(
-            inputs,
-            actions,
-            amount,
-            anchor,
-            proof,
-            binding_signature,
-            fee_strategy,
-            signer,
-            user_fee_increase,
-            self.version(),
-        )?;
-        ensure_valid_state_transition_structure(&state_transition, self.version())?;
+            let state_transition = ShieldTransition::try_from_bundle_with_signer(
+                inputs,
+                actions,
+                amount,
+                anchor,
+                proof,
+                binding_signature,
+                fee_strategy,
+                signer,
+                user_fee_increase,
+                self.version(),
+            )?;
+            ensure_valid_state_transition_structure(&state_transition, self.version())?;
 
-        state_transition.broadcast(self, settings).await?;
-        Ok(())
+            state_transition.broadcast(self, settings).await?;
+            Ok(())
+        })
     }
 }

--- a/packages/rs-sdk/src/platform/transition/shield_from_asset_lock.rs
+++ b/packages/rs-sdk/src/platform/transition/shield_from_asset_lock.rs
@@ -6,53 +6,55 @@ use dpp::prelude::AssetLockProof;
 use dpp::shielded::OrchardBundleParams;
 use dpp::state_transition::shield_from_asset_lock_transition::methods::ShieldFromAssetLockTransitionMethodsV0;
 use dpp::state_transition::shield_from_asset_lock_transition::ShieldFromAssetLockTransition;
+use std::future::Future;
+use std::pin::Pin;
 
 /// Helper trait to shield funds from an L1 asset lock into the shielded pool.
-#[async_trait::async_trait]
 pub trait ShieldFromAssetLock {
     /// Shield funds from an L1 asset lock into the shielded pool.
     /// The asset lock proof proves ownership of L1 funds, and the ECDSA signature
     /// binds those funds to this specific Orchard bundle.
-    async fn shield_from_asset_lock(
-        &self,
+    fn shield_from_asset_lock<'a>(
+        &'a self,
         asset_lock_proof: AssetLockProof,
-        asset_lock_proof_private_key: &[u8],
+        asset_lock_proof_private_key: &'a [u8],
         bundle: OrchardBundleParams,
         value_balance: u64,
         settings: Option<PutSettings>,
-    ) -> Result<(), Error>;
+    ) -> Pin<Box<dyn Future<Output = Result<(), Error>> + Send + 'a>>;
 }
 
-#[async_trait::async_trait]
 impl ShieldFromAssetLock for Sdk {
-    async fn shield_from_asset_lock(
-        &self,
+    fn shield_from_asset_lock<'a>(
+        &'a self,
         asset_lock_proof: AssetLockProof,
-        asset_lock_proof_private_key: &[u8],
+        asset_lock_proof_private_key: &'a [u8],
         bundle: OrchardBundleParams,
         value_balance: u64,
         settings: Option<PutSettings>,
-    ) -> Result<(), Error> {
-        let OrchardBundleParams {
-            actions,
-            anchor,
-            proof,
-            binding_signature,
-        } = bundle;
+    ) -> Pin<Box<dyn Future<Output = Result<(), Error>> + Send + 'a>> {
+        Box::pin(async move {
+            let OrchardBundleParams {
+                actions,
+                anchor,
+                proof,
+                binding_signature,
+            } = bundle;
 
-        let state_transition = ShieldFromAssetLockTransition::try_from_asset_lock_with_bundle(
-            asset_lock_proof,
-            asset_lock_proof_private_key,
-            actions,
-            value_balance,
-            anchor,
-            proof,
-            binding_signature,
-            self.version(),
-        )?;
-        ensure_valid_state_transition_structure(&state_transition, self.version())?;
+            let state_transition = ShieldFromAssetLockTransition::try_from_asset_lock_with_bundle(
+                asset_lock_proof,
+                asset_lock_proof_private_key,
+                actions,
+                value_balance,
+                anchor,
+                proof,
+                binding_signature,
+                self.version(),
+            )?;
+            ensure_valid_state_transition_structure(&state_transition, self.version())?;
 
-        state_transition.broadcast(self, settings).await?;
-        Ok(())
+            state_transition.broadcast(self, settings).await?;
+            Ok(())
+        })
     }
 }

--- a/packages/rs-sdk/src/platform/transition/shielded_transfer.rs
+++ b/packages/rs-sdk/src/platform/transition/shielded_transfer.rs
@@ -5,46 +5,48 @@ use crate::{Error, Sdk};
 use dpp::shielded::OrchardBundleParams;
 use dpp::state_transition::shielded_transfer_transition::methods::ShieldedTransferTransitionMethodsV0;
 use dpp::state_transition::shielded_transfer_transition::ShieldedTransferTransition;
+use std::future::Future;
+use std::pin::Pin;
 
 /// Helper trait to transfer funds within the shielded pool.
-#[async_trait::async_trait]
 pub trait TransferShielded {
     /// Transfer funds within the shielded pool.
     /// Authentication is via Orchard spend authorization signatures in the bundle actions.
-    async fn transfer_shielded(
-        &self,
+    fn transfer_shielded<'a>(
+        &'a self,
         bundle: OrchardBundleParams,
         value_balance: u64,
         settings: Option<PutSettings>,
-    ) -> Result<(), Error>;
+    ) -> Pin<Box<dyn Future<Output = Result<(), Error>> + Send + 'a>>;
 }
 
-#[async_trait::async_trait]
 impl TransferShielded for Sdk {
-    async fn transfer_shielded(
-        &self,
+    fn transfer_shielded<'a>(
+        &'a self,
         bundle: OrchardBundleParams,
         value_balance: u64,
         settings: Option<PutSettings>,
-    ) -> Result<(), Error> {
-        let OrchardBundleParams {
-            actions,
-            anchor,
-            proof,
-            binding_signature,
-        } = bundle;
+    ) -> Pin<Box<dyn Future<Output = Result<(), Error>> + Send + 'a>> {
+        Box::pin(async move {
+            let OrchardBundleParams {
+                actions,
+                anchor,
+                proof,
+                binding_signature,
+            } = bundle;
 
-        let state_transition = ShieldedTransferTransition::try_from_bundle(
-            actions,
-            value_balance,
-            anchor,
-            proof,
-            binding_signature,
-            self.version(),
-        )?;
-        ensure_valid_state_transition_structure(&state_transition, self.version())?;
+            let state_transition = ShieldedTransferTransition::try_from_bundle(
+                actions,
+                value_balance,
+                anchor,
+                proof,
+                binding_signature,
+                self.version(),
+            )?;
+            ensure_valid_state_transition_structure(&state_transition, self.version())?;
 
-        state_transition.broadcast(self, settings).await?;
-        Ok(())
+            state_transition.broadcast(self, settings).await?;
+            Ok(())
+        })
     }
 }

--- a/packages/rs-sdk/src/platform/transition/shielded_withdrawal.rs
+++ b/packages/rs-sdk/src/platform/transition/shielded_withdrawal.rs
@@ -7,57 +7,59 @@ use dpp::shielded::OrchardBundleParams;
 use dpp::state_transition::shielded_withdrawal_transition::methods::ShieldedWithdrawalTransitionMethodsV0;
 use dpp::state_transition::shielded_withdrawal_transition::ShieldedWithdrawalTransition;
 use dpp::withdrawal::Pooling;
+use std::future::Future;
+use std::pin::Pin;
 
 /// Helper trait to withdraw funds from the shielded pool to L1.
-#[async_trait::async_trait]
 pub trait WithdrawShielded {
     /// Withdraw funds from the shielded pool to a Core address.
     /// Authentication is via Orchard spend authorization signatures in the bundle actions.
     #[allow(clippy::too_many_arguments)]
-    async fn withdraw_shielded(
-        &self,
+    fn withdraw_shielded<'a>(
+        &'a self,
         unshielding_amount: u64,
         bundle: OrchardBundleParams,
         core_fee_per_byte: u32,
         pooling: Pooling,
         output_script: CoreScript,
         settings: Option<PutSettings>,
-    ) -> Result<(), Error>;
+    ) -> Pin<Box<dyn Future<Output = Result<(), Error>> + Send + 'a>>;
 }
 
-#[async_trait::async_trait]
 impl WithdrawShielded for Sdk {
     #[allow(clippy::too_many_arguments)]
-    async fn withdraw_shielded(
-        &self,
+    fn withdraw_shielded<'a>(
+        &'a self,
         unshielding_amount: u64,
         bundle: OrchardBundleParams,
         core_fee_per_byte: u32,
         pooling: Pooling,
         output_script: CoreScript,
         settings: Option<PutSettings>,
-    ) -> Result<(), Error> {
-        let OrchardBundleParams {
-            actions,
-            anchor,
-            proof,
-            binding_signature,
-        } = bundle;
+    ) -> Pin<Box<dyn Future<Output = Result<(), Error>> + Send + 'a>> {
+        Box::pin(async move {
+            let OrchardBundleParams {
+                actions,
+                anchor,
+                proof,
+                binding_signature,
+            } = bundle;
 
-        let state_transition = ShieldedWithdrawalTransition::try_from_bundle(
-            actions,
-            unshielding_amount,
-            anchor,
-            proof,
-            binding_signature,
-            core_fee_per_byte,
-            pooling,
-            output_script,
-            self.version(),
-        )?;
-        ensure_valid_state_transition_structure(&state_transition, self.version())?;
+            let state_transition = ShieldedWithdrawalTransition::try_from_bundle(
+                actions,
+                unshielding_amount,
+                anchor,
+                proof,
+                binding_signature,
+                core_fee_per_byte,
+                pooling,
+                output_script,
+                self.version(),
+            )?;
+            ensure_valid_state_transition_structure(&state_transition, self.version())?;
 
-        state_transition.broadcast(self, settings).await?;
-        Ok(())
+            state_transition.broadcast(self, settings).await?;
+            Ok(())
+        })
     }
 }

--- a/packages/rs-sdk/src/platform/transition/top_up_address.rs
+++ b/packages/rs-sdk/src/platform/transition/top_up_address.rs
@@ -1,4 +1,6 @@
 use std::collections::{BTreeMap, BTreeSet};
+use std::future::Future;
+use std::pin::Pin;
 
 use super::address_inputs::collect_address_infos_from_proof;
 use super::broadcast::BroadcastStateTransition;
@@ -19,98 +21,99 @@ use dpp::ProtocolError;
 use drive_proof_verifier::types::AddressInfos;
 
 /// Trait for topping up Platform addresses using various funding sources.
-#[async_trait::async_trait]
 pub trait TopUpAddress<S: Signer<PlatformAddress>> {
     /// Tops up addresses using the provided funding source and fee strategy.
     ///
     /// Returns proof-backed [`AddressInfos`] for the funded addresses.
-    async fn top_up(
-        &self,
-        sdk: &Sdk,
+    fn top_up<'a>(
+        &'a self,
+        sdk: &'a Sdk,
         asset_lock_proof: AssetLockProof,
         asset_lock_private_key: PrivateKey,
         fee_strategy: AddressFundsFeeStrategy,
-        signer: &S,
+        signer: &'a S,
         settings: Option<PutSettings>,
-    ) -> Result<AddressInfos, Error>;
+    ) -> Pin<Box<dyn Future<Output = Result<AddressInfos, Error>> + Send + 'a>>;
 }
 
 pub type AddressWithBalance = (PlatformAddress, Option<Credits>);
 pub type AddressesWithBalances = BTreeMap<PlatformAddress, Option<Credits>>;
 
-#[async_trait::async_trait]
 impl<S: Signer<PlatformAddress>> TopUpAddress<S> for AddressWithBalance
 where
     BTreeMap<PlatformAddress, Option<Credits>>: TopUpAddress<S>,
 {
-    async fn top_up(
-        &self,
-        sdk: &Sdk,
+    fn top_up<'a>(
+        &'a self,
+        sdk: &'a Sdk,
         asset_lock_proof: AssetLockProof,
         asset_lock_private_key: PrivateKey,
         fee_strategy: AddressFundsFeeStrategy,
-        signer: &S,
+        signer: &'a S,
         settings: Option<PutSettings>,
-    ) -> Result<AddressInfos, Error> {
-        BTreeMap::from([(self.0, self.1)])
-            .top_up(
-                sdk,
-                asset_lock_proof,
-                asset_lock_private_key,
-                fee_strategy,
-                signer,
-                settings,
-            )
-            .await
+    ) -> Pin<Box<dyn Future<Output = Result<AddressInfos, Error>> + Send + 'a>> {
+        Box::pin(async move {
+            BTreeMap::from([(self.0, self.1)])
+                .top_up(
+                    sdk,
+                    asset_lock_proof,
+                    asset_lock_private_key,
+                    fee_strategy,
+                    signer,
+                    settings,
+                )
+                .await
+        })
     }
 }
 
-#[async_trait::async_trait]
 impl<S: Signer<PlatformAddress>> TopUpAddress<S> for AddressesWithBalances {
-    async fn top_up(
-        &self,
-        sdk: &Sdk,
+    fn top_up<'a>(
+        &'a self,
+        sdk: &'a Sdk,
         asset_lock_proof: AssetLockProof,
         asset_lock_private_key: PrivateKey,
         fee_strategy: AddressFundsFeeStrategy,
-        signer: &S,
+        signer: &'a S,
         settings: Option<PutSettings>,
-    ) -> Result<AddressInfos, Error> {
-        if self.is_empty() {
-            return Err(Error::from(TransitionNoOutputsError::new()));
-        }
-
-        let user_fee_increase = settings
-            .as_ref()
-            .and_then(|settings| settings.user_fee_increase)
-            .unwrap_or_default();
-
-        let state_transition = create_address_funding_from_asset_lock_transition(
-            asset_lock_proof,
-            asset_lock_private_key.inner.as_ref(),
-            BTreeMap::new(),
-            self.clone(),
-            fee_strategy,
-            signer,
-            user_fee_increase,
-            sdk,
-        )?;
-
-        ensure_valid_state_transition_structure(&state_transition, sdk.version())?;
-        let st_result = state_transition
-            .broadcast_and_wait::<StateTransitionProofResult>(sdk, settings)
-            .await?;
-        match st_result {
-            StateTransitionProofResult::VerifiedAddressInfos(address_infos) => {
-                let expected_addresses =
-                    self.keys().copied().collect::<BTreeSet<PlatformAddress>>();
-                collect_address_infos_from_proof(address_infos, &expected_addresses)
+    ) -> Pin<Box<dyn Future<Output = Result<AddressInfos, Error>> + Send + 'a>> {
+        Box::pin(async move {
+            if self.is_empty() {
+                return Err(Error::from(TransitionNoOutputsError::new()));
             }
-            other => Err(Error::InvalidProvedResponse(format!(
-                "address info proof was expected for {:?}, but received {:?}",
-                state_transition, other
-            ))),
-        }
+
+            let user_fee_increase = settings
+                .as_ref()
+                .and_then(|settings| settings.user_fee_increase)
+                .unwrap_or_default();
+
+            let state_transition = create_address_funding_from_asset_lock_transition(
+                asset_lock_proof,
+                asset_lock_private_key.inner.as_ref(),
+                BTreeMap::new(),
+                self.clone(),
+                fee_strategy,
+                signer,
+                user_fee_increase,
+                sdk,
+            )?;
+
+            ensure_valid_state_transition_structure(&state_transition, sdk.version())?;
+            let st_result = state_transition
+                .broadcast_and_wait::<StateTransitionProofResult>(sdk, settings)
+                .await?;
+            match st_result {
+                StateTransitionProofResult::VerifiedAddressInfos(address_infos) => {
+                    let expected_addresses =
+                        self.keys().copied().collect::<BTreeSet<PlatformAddress>>();
+                    collect_address_infos_from_proof(address_infos, &expected_addresses)
+                }
+                other => Err(Error::InvalidProvedResponse(format!(
+                    "address info proof was expected for {:?}, but received {:?}",
+                    state_transition, other
+                ))),
+            }
+        })
     }
 }
 

--- a/packages/rs-sdk/src/platform/transition/top_up_identity.rs
+++ b/packages/rs-sdk/src/platform/transition/top_up_identity.rs
@@ -8,42 +8,45 @@ use dpp::identity::{Identity, PartialIdentity};
 use dpp::prelude::{AssetLockProof, UserFeeIncrease};
 use dpp::state_transition::identity_topup_transition::methods::IdentityTopUpTransitionMethodsV0;
 use dpp::state_transition::identity_topup_transition::IdentityTopUpTransition;
+use std::future::Future;
+use std::pin::Pin;
 
-#[async_trait::async_trait]
 pub trait TopUpIdentity: Waitable {
-    async fn top_up_identity(
-        &self,
-        sdk: &Sdk,
+    fn top_up_identity<'a>(
+        &'a self,
+        sdk: &'a Sdk,
         asset_lock_proof: AssetLockProof,
-        asset_lock_proof_private_key: &PrivateKey,
+        asset_lock_proof_private_key: &'a PrivateKey,
         user_fee_increase: Option<UserFeeIncrease>,
         settings: Option<PutSettings>,
-    ) -> Result<u64, Error>;
+    ) -> Pin<Box<dyn Future<Output = Result<u64, Error>> + Send + 'a>>;
 }
 
-#[async_trait::async_trait]
 impl TopUpIdentity for Identity {
-    async fn top_up_identity(
-        &self,
-        sdk: &Sdk,
+    fn top_up_identity<'a>(
+        &'a self,
+        sdk: &'a Sdk,
         asset_lock_proof: AssetLockProof,
-        asset_lock_proof_private_key: &PrivateKey,
+        asset_lock_proof_private_key: &'a PrivateKey,
         user_fee_increase: Option<UserFeeIncrease>,
         settings: Option<PutSettings>,
-    ) -> Result<u64, Error> {
-        let state_transition = IdentityTopUpTransition::try_from_identity(
-            self,
-            asset_lock_proof,
-            asset_lock_proof_private_key.inner.as_ref(),
-            user_fee_increase.unwrap_or_default(),
-            sdk.version(),
-            None,
-        )?;
-        ensure_valid_state_transition_structure(&state_transition, sdk.version())?;
-        let identity: PartialIdentity = state_transition.broadcast_and_wait(sdk, settings).await?;
+    ) -> Pin<Box<dyn Future<Output = Result<u64, Error>> + Send + 'a>> {
+        Box::pin(async move {
+            let state_transition = IdentityTopUpTransition::try_from_identity(
+                self,
+                asset_lock_proof,
+                asset_lock_proof_private_key.inner.as_ref(),
+                user_fee_increase.unwrap_or_default(),
+                sdk.version(),
+                None,
+            )?;
+            ensure_valid_state_transition_structure(&state_transition, sdk.version())?;
+            let identity: PartialIdentity =
+                state_transition.broadcast_and_wait(sdk, settings).await?;
 
-        identity
-            .balance
-            .ok_or(Error::Generic("expected an identity balance".to_string()))
+            identity
+                .balance
+                .ok_or(Error::Generic("expected an identity balance".to_string()))
+        })
     }
 }

--- a/packages/rs-sdk/src/platform/transition/top_up_identity_from_addresses.rs
+++ b/packages/rs-sdk/src/platform/transition/top_up_identity_from_addresses.rs
@@ -1,4 +1,6 @@
 use std::collections::{BTreeMap, BTreeSet};
+use std::future::Future;
+use std::pin::Pin;
 
 use super::address_inputs::fetch_inputs_with_nonce;
 use super::put_settings::PutSettings;
@@ -19,99 +21,102 @@ use dpp::state_transition::proof_result::StateTransitionProofResult;
 use drive_proof_verifier::types::AddressInfos;
 
 /// Helper trait to top up an identity using balances from Platform addresses.
-#[async_trait::async_trait]
 pub trait TopUpIdentityFromAddresses<S: Signer<PlatformAddress>>: Waitable {
     /// Top up an identity by spending address balances (nonces looked up automatically).
-    async fn top_up_from_addresses(
-        &self,
-        sdk: &Sdk,
+    fn top_up_from_addresses<'a>(
+        &'a self,
+        sdk: &'a Sdk,
         inputs: BTreeMap<PlatformAddress, Credits>,
-        signer: &S,
+        signer: &'a S,
         settings: Option<PutSettings>,
-    ) -> Result<(AddressInfos, Credits), Error>;
+    ) -> Pin<Box<dyn Future<Output = Result<(AddressInfos, Credits), Error>> + Send + 'a>>;
 
     /// Top up identity providing explicit address nonces.
     ///
     /// Inputs are not pre-validated client-side (Drive enforces authoritative checks).
-    async fn top_up_from_addresses_with_nonce(
-        &self,
-        sdk: &Sdk,
+    fn top_up_from_addresses_with_nonce<'a>(
+        &'a self,
+        sdk: &'a Sdk,
         inputs: BTreeMap<PlatformAddress, (AddressNonce, Credits)>,
-        signer: &S,
+        signer: &'a S,
         settings: Option<PutSettings>,
-    ) -> Result<(AddressInfos, Credits), Error>;
+    ) -> Pin<Box<dyn Future<Output = Result<(AddressInfos, Credits), Error>> + Send + 'a>>;
 }
 
-#[async_trait::async_trait]
 impl<S: Signer<PlatformAddress>> TopUpIdentityFromAddresses<S> for Identity {
-    async fn top_up_from_addresses(
-        &self,
-        sdk: &Sdk,
+    fn top_up_from_addresses<'a>(
+        &'a self,
+        sdk: &'a Sdk,
         inputs: BTreeMap<PlatformAddress, Credits>,
-        signer: &S,
+        signer: &'a S,
         settings: Option<PutSettings>,
-    ) -> Result<(AddressInfos, Credits), Error> {
-        let inputs_with_nonce = nonce_inc(fetch_inputs_with_nonce(sdk, &inputs).await?);
-        self.top_up_from_addresses_with_nonce(sdk, inputs_with_nonce, signer, settings)
-            .await
+    ) -> Pin<Box<dyn Future<Output = Result<(AddressInfos, Credits), Error>> + Send + 'a>> {
+        Box::pin(async move {
+            let inputs_with_nonce = nonce_inc(fetch_inputs_with_nonce(sdk, &inputs).await?);
+            self.top_up_from_addresses_with_nonce(sdk, inputs_with_nonce, signer, settings)
+                .await
+        })
     }
 
-    async fn top_up_from_addresses_with_nonce(
-        &self,
-        sdk: &Sdk,
+    fn top_up_from_addresses_with_nonce<'a>(
+        &'a self,
+        sdk: &'a Sdk,
         inputs: BTreeMap<PlatformAddress, (AddressNonce, Credits)>,
-        signer: &S,
+        signer: &'a S,
         settings: Option<PutSettings>,
-    ) -> Result<(AddressInfos, Credits), Error> {
-        let user_fee_increase = settings
-            .as_ref()
-            .and_then(|settings| settings.user_fee_increase)
-            .unwrap_or_default();
+    ) -> Pin<Box<dyn Future<Output = Result<(AddressInfos, Credits), Error>> + Send + 'a>> {
+        Box::pin(async move {
+            let user_fee_increase = settings
+                .as_ref()
+                .and_then(|settings| settings.user_fee_increase)
+                .unwrap_or_default();
 
-        let expected_addresses: BTreeSet<PlatformAddress> =
-            inputs.keys().copied().collect::<BTreeSet<_>>();
+            let expected_addresses: BTreeSet<PlatformAddress> =
+                inputs.keys().copied().collect::<BTreeSet<_>>();
 
-        let state_transition = IdentityTopUpFromAddressesTransition::try_from_inputs_with_signer(
-            self,
-            inputs,
-            signer,
-            user_fee_increase,
-            sdk.version(),
-            None,
-        )?;
-        ensure_valid_state_transition_structure(&state_transition, sdk.version())?;
+            let state_transition =
+                IdentityTopUpFromAddressesTransition::try_from_inputs_with_signer(
+                    self,
+                    inputs,
+                    signer,
+                    user_fee_increase,
+                    sdk.version(),
+                    None,
+                )?;
+            ensure_valid_state_transition_structure(&state_transition, sdk.version())?;
 
-        match state_transition
-            .broadcast_and_wait::<StateTransitionProofResult>(sdk, settings)
-            .await?
-        {
-            StateTransitionProofResult::VerifiedIdentityWithAddressInfos(
-                identity,
-                address_infos_map,
-            ) => {
-                if identity.id != self.id() {
-                    return Err(Error::InvalidProvedResponse(format!(
-                        "proof returned identity {} but {} was topped up",
-                        identity.id,
-                        self.id()
-                    )));
+            match state_transition
+                .broadcast_and_wait::<StateTransitionProofResult>(sdk, settings)
+                .await?
+            {
+                StateTransitionProofResult::VerifiedIdentityWithAddressInfos(
+                    identity,
+                    address_infos_map,
+                ) => {
+                    if identity.id != self.id() {
+                        return Err(Error::InvalidProvedResponse(format!(
+                            "proof returned identity {} but {} was topped up",
+                            identity.id,
+                            self.id()
+                        )));
+                    }
+
+                    let address_infos =
+                        collect_address_infos_from_proof(address_infos_map, &expected_addresses)?;
+
+                    let balance = identity.balance.ok_or_else(|| {
+                        Error::InvalidProvedResponse(
+                            "identity proof did not include updated balance".to_string(),
+                        )
+                    })?;
+
+                    Ok((address_infos, balance))
                 }
-
-                let address_infos =
-                    collect_address_infos_from_proof(address_infos_map, &expected_addresses)?;
-
-                let balance = identity.balance.ok_or_else(|| {
-                    Error::InvalidProvedResponse(
-                        "identity proof did not include updated balance".to_string(),
-                    )
-                })?;
-
-                Ok((address_infos, balance))
+                other => Err(Error::InvalidProvedResponse(format!(
+                    "identity proof was expected for {:?}, but received {:?}",
+                    state_transition, other
+                ))),
             }
-            other => Err(Error::InvalidProvedResponse(format!(
-                "identity proof was expected for {:?}, but received {:?}",
-                state_transition, other
-            ))),
-        }
+        })
     }
 }

--- a/packages/rs-sdk/src/platform/transition/transfer.rs
+++ b/packages/rs-sdk/src/platform/transition/transfer.rs
@@ -9,10 +9,11 @@ use dpp::identity::signer::Signer;
 use dpp::identity::{Identity, IdentityPublicKey, PartialIdentity};
 use dpp::state_transition::identity_credit_transfer_transition::methods::IdentityCreditTransferTransitionMethodsV0;
 use dpp::state_transition::identity_credit_transfer_transition::IdentityCreditTransferTransition;
+use std::future::Future;
+use std::pin::Pin;
 
 use super::waitable::Waitable;
 
-#[async_trait::async_trait]
 pub trait TransferToIdentity: Waitable {
     /// Transfers credits from an identity to another identity.
     ///
@@ -24,54 +25,55 @@ pub trait TransferToIdentity: Waitable {
     /// ## Returns
     ///
     /// A tuple of `(sender_balance, receiver_balance)` after the transfer.
-    async fn transfer_credits<S: Signer<IdentityPublicKey> + Send>(
-        &self,
-        sdk: &Sdk,
+    fn transfer_credits<'a, S: Signer<IdentityPublicKey> + Send + 'a>(
+        &'a self,
+        sdk: &'a Sdk,
         to_identity_id: Identifier,
         amount: u64,
-        signing_transfer_key_to_use: Option<&IdentityPublicKey>,
+        signing_transfer_key_to_use: Option<&'a IdentityPublicKey>,
         signer: S,
         settings: Option<PutSettings>,
-    ) -> Result<(u64, u64), Error>;
+    ) -> Pin<Box<dyn Future<Output = Result<(u64, u64), Error>> + Send + 'a>>;
 }
 
-#[async_trait::async_trait]
 impl TransferToIdentity for Identity {
-    async fn transfer_credits<S: Signer<IdentityPublicKey> + Send>(
-        &self,
-        sdk: &Sdk,
+    fn transfer_credits<'a, S: Signer<IdentityPublicKey> + Send + 'a>(
+        &'a self,
+        sdk: &'a Sdk,
         to_identity_id: Identifier,
         amount: u64,
-        signing_transfer_key_to_use: Option<&IdentityPublicKey>,
+        signing_transfer_key_to_use: Option<&'a IdentityPublicKey>,
         signer: S,
         settings: Option<PutSettings>,
-    ) -> Result<(u64, u64), Error> {
-        let new_identity_nonce = sdk.get_identity_nonce(self.id(), true, settings).await?;
-        let user_fee_increase = settings.and_then(|settings| settings.user_fee_increase);
-        let state_transition = IdentityCreditTransferTransition::try_from_identity(
-            self,
-            to_identity_id,
-            amount,
-            user_fee_increase.unwrap_or_default(),
-            signer,
-            signing_transfer_key_to_use,
-            new_identity_nonce,
-            sdk.version(),
-            None,
-        )?;
-        ensure_valid_state_transition_structure(&state_transition, sdk.version())?;
+    ) -> Pin<Box<dyn Future<Output = Result<(u64, u64), Error>> + Send + 'a>> {
+        Box::pin(async move {
+            let new_identity_nonce = sdk.get_identity_nonce(self.id(), true, settings).await?;
+            let user_fee_increase = settings.and_then(|settings| settings.user_fee_increase);
+            let state_transition = IdentityCreditTransferTransition::try_from_identity(
+                self,
+                to_identity_id,
+                amount,
+                user_fee_increase.unwrap_or_default(),
+                signer,
+                signing_transfer_key_to_use,
+                new_identity_nonce,
+                sdk.version(),
+                None,
+            )?;
+            ensure_valid_state_transition_structure(&state_transition, sdk.version())?;
 
-        let (sender, receiver): (PartialIdentity, PartialIdentity) =
-            state_transition.broadcast_and_wait(sdk, settings).await?;
+            let (sender, receiver): (PartialIdentity, PartialIdentity) =
+                state_transition.broadcast_and_wait(sdk, settings).await?;
 
-        let sender_balance = sender.balance.ok_or_else(|| {
-            Error::Generic("expected an identity balance after transfer (sender)".to_string())
-        })?;
+            let sender_balance = sender.balance.ok_or_else(|| {
+                Error::Generic("expected an identity balance after transfer (sender)".to_string())
+            })?;
 
-        let receiver_balance = receiver.balance.ok_or_else(|| {
-            Error::Generic("expected an identity balance after transfer (receiver)".to_string())
-        })?;
+            let receiver_balance = receiver.balance.ok_or_else(|| {
+                Error::Generic("expected an identity balance after transfer (receiver)".to_string())
+            })?;
 
-        Ok((sender_balance, receiver_balance))
+            Ok((sender_balance, receiver_balance))
+        })
     }
 }

--- a/packages/rs-sdk/src/platform/transition/transfer_address_funds.rs
+++ b/packages/rs-sdk/src/platform/transition/transfer_address_funds.rs
@@ -1,4 +1,6 @@
 use std::collections::{BTreeMap, BTreeSet};
+use std::future::Future;
+use std::pin::Pin;
 
 use super::address_inputs::{collect_address_infos_from_proof, fetch_inputs_with_nonce};
 use super::put_settings::PutSettings;
@@ -17,93 +19,95 @@ use dpp::state_transition::proof_result::StateTransitionProofResult;
 use drive_proof_verifier::types::AddressInfos;
 
 /// Helper trait to transfer funds directly between Platform addresses.
-#[async_trait::async_trait]
 pub trait TransferAddressFunds<S: Signer<PlatformAddress>> {
     /// Broadcast address funds transfer (nonces looked up automatically) and return refreshed balances.
-    async fn transfer_address_funds(
-        &self,
+    fn transfer_address_funds<'a>(
+        &'a self,
         inputs: BTreeMap<PlatformAddress, Credits>,
         outputs: BTreeMap<PlatformAddress, Credits>,
         fee_strategy: AddressFundsFeeStrategy,
-        signer: &S,
+        signer: &'a S,
         settings: Option<PutSettings>,
-    ) -> Result<AddressInfos, Error>;
+    ) -> Pin<Box<dyn Future<Output = Result<AddressInfos, Error>> + Send + 'a>>;
 
     /// Broadcast address funds transfer with explicitly provided address nonces.
     ///
     /// Inputs are not pre-validated client-side (Drive will perform authoritative checks).
-    async fn transfer_address_funds_with_nonce(
-        &self,
+    fn transfer_address_funds_with_nonce<'a>(
+        &'a self,
         inputs: BTreeMap<PlatformAddress, (AddressNonce, Credits)>,
         outputs: BTreeMap<PlatformAddress, Credits>,
         fee_strategy: AddressFundsFeeStrategy,
-        signer: &S,
+        signer: &'a S,
         settings: Option<PutSettings>,
-    ) -> Result<AddressInfos, Error>;
+    ) -> Pin<Box<dyn Future<Output = Result<AddressInfos, Error>> + Send + 'a>>;
 }
 
-#[async_trait::async_trait]
 impl<S: Signer<PlatformAddress>> TransferAddressFunds<S> for Sdk {
-    async fn transfer_address_funds(
-        &self,
+    fn transfer_address_funds<'a>(
+        &'a self,
         inputs: BTreeMap<PlatformAddress, Credits>,
         outputs: BTreeMap<PlatformAddress, Credits>,
         fee_strategy: AddressFundsFeeStrategy,
-        signer: &S,
+        signer: &'a S,
         settings: Option<PutSettings>,
-    ) -> Result<AddressInfos, Error> {
-        let inputs_with_nonce = nonce_inc(fetch_inputs_with_nonce(self, &inputs).await?);
-        self.transfer_address_funds_with_nonce(
-            inputs_with_nonce,
-            outputs,
-            fee_strategy,
-            signer,
-            settings,
-        )
-        .await
+    ) -> Pin<Box<dyn Future<Output = Result<AddressInfos, Error>> + Send + 'a>> {
+        Box::pin(async move {
+            let inputs_with_nonce = nonce_inc(fetch_inputs_with_nonce(self, &inputs).await?);
+            self.transfer_address_funds_with_nonce(
+                inputs_with_nonce,
+                outputs,
+                fee_strategy,
+                signer,
+                settings,
+            )
+            .await
+        })
     }
 
-    async fn transfer_address_funds_with_nonce(
-        &self,
+    fn transfer_address_funds_with_nonce<'a>(
+        &'a self,
         inputs: BTreeMap<PlatformAddress, (AddressNonce, Credits)>,
         outputs: BTreeMap<PlatformAddress, Credits>,
         fee_strategy: AddressFundsFeeStrategy,
-        signer: &S,
+        signer: &'a S,
         settings: Option<PutSettings>,
-    ) -> Result<AddressInfos, Error> {
-        if outputs.is_empty() {
-            return Err(Error::from(TransitionNoOutputsError::new()));
-        }
-
-        let user_fee_increase = settings
-            .as_ref()
-            .and_then(|settings| settings.user_fee_increase)
-            .unwrap_or_default();
-
-        let state_transition = AddressFundsTransferTransition::try_from_inputs_with_signer(
-            inputs.clone(),
-            outputs.clone(),
-            fee_strategy,
-            signer,
-            user_fee_increase,
-            self.version(),
-        )?;
-        ensure_valid_state_transition_structure(&state_transition, self.version())?;
-
-        let expected_addresses: BTreeSet<PlatformAddress> =
-            inputs.keys().chain(outputs.keys()).copied().collect();
-
-        match state_transition
-            .broadcast_and_wait::<StateTransitionProofResult>(self, settings)
-            .await?
-        {
-            StateTransitionProofResult::VerifiedAddressInfos(address_infos_map) => {
-                collect_address_infos_from_proof(address_infos_map, &expected_addresses)
+    ) -> Pin<Box<dyn Future<Output = Result<AddressInfos, Error>> + Send + 'a>> {
+        Box::pin(async move {
+            if outputs.is_empty() {
+                return Err(Error::from(TransitionNoOutputsError::new()));
             }
-            other => Err(Error::InvalidProvedResponse(format!(
-                "address info proof was expected for {:?}, but received {:?}",
-                state_transition, other
-            ))),
-        }
+
+            let user_fee_increase = settings
+                .as_ref()
+                .and_then(|settings| settings.user_fee_increase)
+                .unwrap_or_default();
+
+            let state_transition = AddressFundsTransferTransition::try_from_inputs_with_signer(
+                inputs.clone(),
+                outputs.clone(),
+                fee_strategy,
+                signer,
+                user_fee_increase,
+                self.version(),
+            )?;
+            ensure_valid_state_transition_structure(&state_transition, self.version())?;
+
+            let expected_addresses: BTreeSet<PlatformAddress> =
+                inputs.keys().chain(outputs.keys()).copied().collect();
+
+            match state_transition
+                .broadcast_and_wait::<StateTransitionProofResult>(self, settings)
+                .await?
+            {
+                StateTransitionProofResult::VerifiedAddressInfos(address_infos_map) => {
+                    collect_address_infos_from_proof(address_infos_map, &expected_addresses)
+                }
+                other => Err(Error::InvalidProvedResponse(format!(
+                    "address info proof was expected for {:?}, but received {:?}",
+                    state_transition, other
+                ))),
+            }
+        })
     }
 }

--- a/packages/rs-sdk/src/platform/transition/transfer_document.rs
+++ b/packages/rs-sdk/src/platform/transition/transfer_document.rs
@@ -14,110 +14,114 @@ use dpp::state_transition::batch_transition::BatchTransition;
 use dpp::state_transition::StateTransition;
 use dpp::tokens::token_payment_info::TokenPaymentInfo;
 use rs_dapi_client::{DapiRequest, IntoInner};
+use std::future::Future;
+use std::pin::Pin;
 
-#[async_trait::async_trait]
 /// A trait for transferring a document on Platform
 pub trait TransferDocument<S: Signer<IdentityPublicKey>>: Waitable {
     /// Transfers a document on platform
     /// Setting settings to `None` sets default connection behavior
     #[allow(clippy::too_many_arguments)]
-    async fn transfer_document_to_identity(
-        &self,
+    fn transfer_document_to_identity<'a>(
+        &'a self,
         recipient_id: Identifier,
-        sdk: &Sdk,
+        sdk: &'a Sdk,
         document_type: DocumentType,
         identity_public_key: IdentityPublicKey,
         token_payment_info: Option<TokenPaymentInfo>,
-        signer: &S,
+        signer: &'a S,
         settings: Option<PutSettings>,
-    ) -> Result<StateTransition, Error>;
+    ) -> Pin<Box<dyn Future<Output = Result<StateTransition, Error>> + Send + 'a>>;
 
     /// Transfers a document on platform and waits for the response
     #[allow(clippy::too_many_arguments)]
-    async fn transfer_document_to_identity_and_wait_for_response(
-        &self,
+    fn transfer_document_to_identity_and_wait_for_response<'a>(
+        &'a self,
         recipient_id: Identifier,
-        sdk: &Sdk,
+        sdk: &'a Sdk,
         document_type: DocumentType,
         identity_public_key: IdentityPublicKey,
         token_payment_info: Option<TokenPaymentInfo>,
-        signer: &S,
+        signer: &'a S,
         settings: Option<PutSettings>,
-    ) -> Result<Document, Error>;
+    ) -> Pin<Box<dyn Future<Output = Result<Document, Error>> + Send + 'a>>;
 }
 
-#[async_trait::async_trait]
 impl<S: Signer<IdentityPublicKey>> TransferDocument<S> for Document {
-    async fn transfer_document_to_identity(
-        &self,
+    fn transfer_document_to_identity<'a>(
+        &'a self,
         recipient_id: Identifier,
-        sdk: &Sdk,
+        sdk: &'a Sdk,
         document_type: DocumentType,
         identity_public_key: IdentityPublicKey,
         token_payment_info: Option<TokenPaymentInfo>,
-        signer: &S,
+        signer: &'a S,
         settings: Option<PutSettings>,
-    ) -> Result<StateTransition, Error> {
-        let new_identity_contract_nonce = sdk
-            .get_identity_contract_nonce(
-                self.owner_id(),
-                document_type.data_contract_id(),
-                true,
-                settings,
-            )
-            .await?;
+    ) -> Pin<Box<dyn Future<Output = Result<StateTransition, Error>> + Send + 'a>> {
+        Box::pin(async move {
+            let new_identity_contract_nonce = sdk
+                .get_identity_contract_nonce(
+                    self.owner_id(),
+                    document_type.data_contract_id(),
+                    true,
+                    settings,
+                )
+                .await?;
 
-        let settings = settings.unwrap_or_default();
+            let settings = settings.unwrap_or_default();
 
-        let transition = BatchTransition::new_document_transfer_transition_from_document(
-            self.clone(),
-            document_type.as_ref(),
-            recipient_id,
-            &identity_public_key,
-            new_identity_contract_nonce,
-            settings.user_fee_increase.unwrap_or_default(),
-            token_payment_info,
-            signer,
-            sdk.version(),
-            settings.state_transition_creation_options,
-        )?;
-        ensure_valid_state_transition_structure(&transition, sdk.version())?;
-
-        let request = transition.broadcast_request_for_state_transition()?;
-
-        request
-            .clone()
-            .execute(sdk, settings.request_settings)
-            .await // TODO: We need better way to handle execution errors
-            .into_inner()?;
-
-        // response is empty for a broadcast, result comes from the stream wait for state transition result
-
-        Ok(transition)
-    }
-
-    async fn transfer_document_to_identity_and_wait_for_response(
-        &self,
-        recipient_id: Identifier,
-        sdk: &Sdk,
-        document_type: DocumentType,
-        identity_public_key: IdentityPublicKey,
-        token_payment_info: Option<TokenPaymentInfo>,
-        signer: &S,
-        settings: Option<PutSettings>,
-    ) -> Result<Document, Error> {
-        let state_transition = self
-            .transfer_document_to_identity(
+            let transition = BatchTransition::new_document_transfer_transition_from_document(
+                self.clone(),
+                document_type.as_ref(),
                 recipient_id,
-                sdk,
-                document_type,
-                identity_public_key,
+                &identity_public_key,
+                new_identity_contract_nonce,
+                settings.user_fee_increase.unwrap_or_default(),
                 token_payment_info,
                 signer,
-                settings,
-            )
-            .await?;
+                sdk.version(),
+                settings.state_transition_creation_options,
+            )?;
+            ensure_valid_state_transition_structure(&transition, sdk.version())?;
 
-        Self::wait_for_response(sdk, state_transition, settings).await
+            let request = transition.broadcast_request_for_state_transition()?;
+
+            request
+                .clone()
+                .execute(sdk, settings.request_settings)
+                .await // TODO: We need better way to handle execution errors
+                .into_inner()?;
+
+            // response is empty for a broadcast, result comes from the stream wait for state transition result
+
+            Ok(transition)
+        })
+    }
+
+    fn transfer_document_to_identity_and_wait_for_response<'a>(
+        &'a self,
+        recipient_id: Identifier,
+        sdk: &'a Sdk,
+        document_type: DocumentType,
+        identity_public_key: IdentityPublicKey,
+        token_payment_info: Option<TokenPaymentInfo>,
+        signer: &'a S,
+        settings: Option<PutSettings>,
+    ) -> Pin<Box<dyn Future<Output = Result<Document, Error>> + Send + 'a>> {
+        Box::pin(async move {
+            let state_transition = self
+                .transfer_document_to_identity(
+                    recipient_id,
+                    sdk,
+                    document_type,
+                    identity_public_key,
+                    token_payment_info,
+                    signer,
+                    settings,
+                )
+                .await?;
+
+            Self::wait_for_response(sdk, state_transition, settings).await
+        })
     }
 }

--- a/packages/rs-sdk/src/platform/transition/transfer_to_addresses.rs
+++ b/packages/rs-sdk/src/platform/transition/transfer_to_addresses.rs
@@ -1,4 +1,6 @@
 use std::collections::{BTreeMap, BTreeSet};
+use std::future::Future;
+use std::pin::Pin;
 
 use super::address_inputs::collect_address_infos_from_proof;
 use super::broadcast::BroadcastStateTransition;
@@ -16,7 +18,6 @@ use dpp::state_transition::identity_credit_transfer_to_addresses_transition::Ide
 use dpp::state_transition::proof_result::StateTransitionProofResult;
 use drive_proof_verifier::types::AddressInfos;
 
-#[async_trait::async_trait]
 pub trait TransferToAddresses: Waitable {
     /// Transfer credits from an identity to multiple Platform addresses.
     ///
@@ -25,84 +26,85 @@ pub trait TransferToAddresses: Waitable {
     /// * Updated identity balance
     /// * Proof-backed address infos for provided recipients
     #[allow(clippy::too_many_arguments)]
-    async fn transfer_credits_to_addresses<S: Signer<IdentityPublicKey> + Send>(
-        &self,
-        sdk: &Sdk,
+    fn transfer_credits_to_addresses<'a, S: Signer<IdentityPublicKey> + Send + 'a>(
+        &'a self,
+        sdk: &'a Sdk,
         recipient_addresses: BTreeMap<PlatformAddress, Credits>,
-        signing_transfer_key_to_use: Option<&IdentityPublicKey>,
-        signer: &S,
+        signing_transfer_key_to_use: Option<&'a IdentityPublicKey>,
+        signer: &'a S,
         settings: Option<PutSettings>,
-    ) -> Result<(AddressInfos, Credits), Error>;
+    ) -> Pin<Box<dyn Future<Output = Result<(AddressInfos, Credits), Error>> + Send + 'a>>;
 }
 
-#[async_trait::async_trait]
 impl TransferToAddresses for Identity {
-    async fn transfer_credits_to_addresses<S: Signer<IdentityPublicKey> + Send>(
-        &self,
-        sdk: &Sdk,
+    fn transfer_credits_to_addresses<'a, S: Signer<IdentityPublicKey> + Send + 'a>(
+        &'a self,
+        sdk: &'a Sdk,
         recipient_addresses: BTreeMap<PlatformAddress, Credits>,
-        signing_transfer_key_to_use: Option<&IdentityPublicKey>,
-        signer: &S,
+        signing_transfer_key_to_use: Option<&'a IdentityPublicKey>,
+        signer: &'a S,
         settings: Option<PutSettings>,
-    ) -> Result<(AddressInfos, Credits), Error> {
-        if recipient_addresses.is_empty() {
-            return Err(Error::Generic(
-                "recipient_addresses must contain at least one address".to_string(),
-            ));
-        }
-
-        let new_identity_nonce = sdk.get_identity_nonce(self.id(), true, settings).await?;
-        let user_fee_increase = settings
-            .as_ref()
-            .and_then(|settings| settings.user_fee_increase)
-            .unwrap_or_default();
-
-        let state_transition = IdentityCreditTransferToAddressesTransition::try_from_identity(
-            self,
-            recipient_addresses.clone(),
-            user_fee_increase,
-            signer,
-            signing_transfer_key_to_use,
-            new_identity_nonce,
-            sdk.version(),
-            None,
-        )?;
-        ensure_valid_state_transition_structure(&state_transition, sdk.version())?;
-
-        let expected_addresses: BTreeSet<PlatformAddress> =
-            recipient_addresses.keys().copied().collect();
-
-        match state_transition
-            .broadcast_and_wait::<StateTransitionProofResult>(sdk, settings)
-            .await?
-        {
-            StateTransitionProofResult::VerifiedIdentityWithAddressInfos(
-                identity,
-                address_infos_map,
-            ) => {
-                if identity.id != self.id() {
-                    return Err(Error::InvalidProvedResponse(format!(
-                        "proof returned identity {} but {} initiated transfer",
-                        identity.id,
-                        self.id()
-                    )));
-                }
-
-                let address_infos =
-                    collect_address_infos_from_proof(address_infos_map, &expected_addresses)?;
-
-                let balance = identity.balance.ok_or_else(|| {
-                    Error::InvalidProvedResponse(
-                        "identity proof did not include updated balance".to_string(),
-                    )
-                })?;
-
-                Ok((address_infos, balance))
+    ) -> Pin<Box<dyn Future<Output = Result<(AddressInfos, Credits), Error>> + Send + 'a>> {
+        Box::pin(async move {
+            if recipient_addresses.is_empty() {
+                return Err(Error::Generic(
+                    "recipient_addresses must contain at least one address".to_string(),
+                ));
             }
-            other => Err(Error::InvalidProvedResponse(format!(
-                "identity proof was expected for {:?}, but received {:?}",
-                state_transition, other
-            ))),
-        }
+
+            let new_identity_nonce = sdk.get_identity_nonce(self.id(), true, settings).await?;
+            let user_fee_increase = settings
+                .as_ref()
+                .and_then(|settings| settings.user_fee_increase)
+                .unwrap_or_default();
+
+            let state_transition = IdentityCreditTransferToAddressesTransition::try_from_identity(
+                self,
+                recipient_addresses.clone(),
+                user_fee_increase,
+                signer,
+                signing_transfer_key_to_use,
+                new_identity_nonce,
+                sdk.version(),
+                None,
+            )?;
+            ensure_valid_state_transition_structure(&state_transition, sdk.version())?;
+
+            let expected_addresses: BTreeSet<PlatformAddress> =
+                recipient_addresses.keys().copied().collect();
+
+            match state_transition
+                .broadcast_and_wait::<StateTransitionProofResult>(sdk, settings)
+                .await?
+            {
+                StateTransitionProofResult::VerifiedIdentityWithAddressInfos(
+                    identity,
+                    address_infos_map,
+                ) => {
+                    if identity.id != self.id() {
+                        return Err(Error::InvalidProvedResponse(format!(
+                            "proof returned identity {} but {} initiated transfer",
+                            identity.id,
+                            self.id()
+                        )));
+                    }
+
+                    let address_infos =
+                        collect_address_infos_from_proof(address_infos_map, &expected_addresses)?;
+
+                    let balance = identity.balance.ok_or_else(|| {
+                        Error::InvalidProvedResponse(
+                            "identity proof did not include updated balance".to_string(),
+                        )
+                    })?;
+
+                    Ok((address_infos, balance))
+                }
+                other => Err(Error::InvalidProvedResponse(format!(
+                    "identity proof was expected for {:?}, but received {:?}",
+                    state_transition, other
+                ))),
+            }
+        })
     }
 }

--- a/packages/rs-sdk/src/platform/transition/unshield.rs
+++ b/packages/rs-sdk/src/platform/transition/unshield.rs
@@ -6,49 +6,51 @@ use dpp::address_funds::PlatformAddress;
 use dpp::shielded::OrchardBundleParams;
 use dpp::state_transition::unshield_transition::methods::UnshieldTransitionMethodsV0;
 use dpp::state_transition::unshield_transition::UnshieldTransition;
+use std::future::Future;
+use std::pin::Pin;
 
 /// Helper trait to unshield funds from the shielded pool to a platform address.
-#[async_trait::async_trait]
 pub trait UnshieldFunds {
     /// Unshield funds from the shielded pool to a platform address.
     /// Authentication is via Orchard spend authorization signatures in the bundle actions.
-    async fn unshield_funds(
-        &self,
+    fn unshield_funds<'a>(
+        &'a self,
         output_address: PlatformAddress,
         unshielding_amount: u64,
         bundle: OrchardBundleParams,
         settings: Option<PutSettings>,
-    ) -> Result<(), Error>;
+    ) -> Pin<Box<dyn Future<Output = Result<(), Error>> + Send + 'a>>;
 }
 
-#[async_trait::async_trait]
 impl UnshieldFunds for Sdk {
-    async fn unshield_funds(
-        &self,
+    fn unshield_funds<'a>(
+        &'a self,
         output_address: PlatformAddress,
         unshielding_amount: u64,
         bundle: OrchardBundleParams,
         settings: Option<PutSettings>,
-    ) -> Result<(), Error> {
-        let OrchardBundleParams {
-            actions,
-            anchor,
-            proof,
-            binding_signature,
-        } = bundle;
+    ) -> Pin<Box<dyn Future<Output = Result<(), Error>> + Send + 'a>> {
+        Box::pin(async move {
+            let OrchardBundleParams {
+                actions,
+                anchor,
+                proof,
+                binding_signature,
+            } = bundle;
 
-        let state_transition = UnshieldTransition::try_from_bundle(
-            output_address,
-            actions,
-            unshielding_amount,
-            anchor,
-            proof,
-            binding_signature,
-            self.version(),
-        )?;
-        ensure_valid_state_transition_structure(&state_transition, self.version())?;
+            let state_transition = UnshieldTransition::try_from_bundle(
+                output_address,
+                actions,
+                unshielding_amount,
+                anchor,
+                proof,
+                binding_signature,
+                self.version(),
+            )?;
+            ensure_valid_state_transition_structure(&state_transition, self.version())?;
 
-        state_transition.broadcast(self, settings).await?;
-        Ok(())
+            state_transition.broadcast(self, settings).await?;
+            Ok(())
+        })
     }
 }

--- a/packages/rs-sdk/src/platform/transition/update_price_of_document.rs
+++ b/packages/rs-sdk/src/platform/transition/update_price_of_document.rs
@@ -14,102 +14,106 @@ use dpp::state_transition::batch_transition::methods::v0::DocumentsBatchTransiti
 use dpp::state_transition::batch_transition::BatchTransition;
 use dpp::state_transition::StateTransition;
 use dpp::tokens::token_payment_info::TokenPaymentInfo;
+use std::future::Future;
+use std::pin::Pin;
 
-#[async_trait::async_trait]
 /// A trait for updating the price of a document on Platform
 pub trait UpdatePriceOfDocument<S: Signer<IdentityPublicKey>>: Waitable {
     /// Updates the price of a document on platform
     /// Setting settings to `None` sets default connection behavior
     #[allow(clippy::too_many_arguments)]
-    async fn update_price_of_document(
-        &self,
+    fn update_price_of_document<'a>(
+        &'a self,
         price: Credits,
-        sdk: &Sdk,
+        sdk: &'a Sdk,
         document_type: DocumentType,
         identity_public_key: IdentityPublicKey,
         token_payment_info: Option<TokenPaymentInfo>,
-        signer: &S,
+        signer: &'a S,
         settings: Option<PutSettings>,
-    ) -> Result<StateTransition, Error>;
+    ) -> Pin<Box<dyn Future<Output = Result<StateTransition, Error>> + Send + 'a>>;
 
     /// Updates the price of a document on platform and waits for the response
     #[allow(clippy::too_many_arguments)]
-    async fn update_price_of_document_and_wait_for_response(
-        &self,
+    fn update_price_of_document_and_wait_for_response<'a>(
+        &'a self,
         price: Credits,
-        sdk: &Sdk,
+        sdk: &'a Sdk,
         document_type: DocumentType,
         identity_public_key: IdentityPublicKey,
         token_payment_info: Option<TokenPaymentInfo>,
-        signer: &S,
+        signer: &'a S,
         settings: Option<PutSettings>,
-    ) -> Result<Document, Error>;
+    ) -> Pin<Box<dyn Future<Output = Result<Document, Error>> + Send + 'a>>;
 }
 
-#[async_trait::async_trait]
 impl<S: Signer<IdentityPublicKey>> UpdatePriceOfDocument<S> for Document {
-    async fn update_price_of_document(
-        &self,
+    fn update_price_of_document<'a>(
+        &'a self,
         price: Credits,
-        sdk: &Sdk,
+        sdk: &'a Sdk,
         document_type: DocumentType,
         identity_public_key: IdentityPublicKey,
         token_payment_info: Option<TokenPaymentInfo>,
-        signer: &S,
+        signer: &'a S,
         settings: Option<PutSettings>,
-    ) -> Result<StateTransition, Error> {
-        let new_identity_contract_nonce = sdk
-            .get_identity_contract_nonce(
-                self.owner_id(),
-                document_type.data_contract_id(),
-                true,
-                settings,
-            )
-            .await?;
+    ) -> Pin<Box<dyn Future<Output = Result<StateTransition, Error>> + Send + 'a>> {
+        Box::pin(async move {
+            let new_identity_contract_nonce = sdk
+                .get_identity_contract_nonce(
+                    self.owner_id(),
+                    document_type.data_contract_id(),
+                    true,
+                    settings,
+                )
+                .await?;
 
-        let settings = settings.unwrap_or_default();
+            let settings = settings.unwrap_or_default();
 
-        let transition = BatchTransition::new_document_update_price_transition_from_document(
-            self.clone(),
-            document_type.as_ref(),
-            price,
-            &identity_public_key,
-            new_identity_contract_nonce,
-            settings.user_fee_increase.unwrap_or_default(),
-            token_payment_info,
-            signer,
-            sdk.version(),
-            settings.state_transition_creation_options,
-        )?;
-        ensure_valid_state_transition_structure(&transition, sdk.version())?;
-
-        // response is empty for a broadcast, result comes from the stream wait for state transition result
-        transition.broadcast(sdk, Some(settings)).await?;
-        Ok(transition)
-    }
-
-    async fn update_price_of_document_and_wait_for_response(
-        &self,
-        price: Credits,
-        sdk: &Sdk,
-        document_type: DocumentType,
-        identity_public_key: IdentityPublicKey,
-        token_payment_info: Option<TokenPaymentInfo>,
-        signer: &S,
-        settings: Option<PutSettings>,
-    ) -> Result<Document, Error> {
-        let state_transition = self
-            .update_price_of_document(
+            let transition = BatchTransition::new_document_update_price_transition_from_document(
+                self.clone(),
+                document_type.as_ref(),
                 price,
-                sdk,
-                document_type,
-                identity_public_key,
+                &identity_public_key,
+                new_identity_contract_nonce,
+                settings.user_fee_increase.unwrap_or_default(),
                 token_payment_info,
                 signer,
-                None,
-            )
-            .await?;
+                sdk.version(),
+                settings.state_transition_creation_options,
+            )?;
+            ensure_valid_state_transition_structure(&transition, sdk.version())?;
 
-        Self::wait_for_response(sdk, state_transition, settings).await
+            // response is empty for a broadcast, result comes from the stream wait for state transition result
+            transition.broadcast(sdk, Some(settings)).await?;
+            Ok(transition)
+        })
+    }
+
+    fn update_price_of_document_and_wait_for_response<'a>(
+        &'a self,
+        price: Credits,
+        sdk: &'a Sdk,
+        document_type: DocumentType,
+        identity_public_key: IdentityPublicKey,
+        token_payment_info: Option<TokenPaymentInfo>,
+        signer: &'a S,
+        settings: Option<PutSettings>,
+    ) -> Pin<Box<dyn Future<Output = Result<Document, Error>> + Send + 'a>> {
+        Box::pin(async move {
+            let state_transition = self
+                .update_price_of_document(
+                    price,
+                    sdk,
+                    document_type,
+                    identity_public_key,
+                    token_payment_info,
+                    signer,
+                    None,
+                )
+                .await?;
+
+            Self::wait_for_response(sdk, state_transition, settings).await
+        })
     }
 }

--- a/packages/rs-sdk/src/platform/transition/vote.rs
+++ b/packages/rs-sdk/src/platform/transition/vote.rs
@@ -14,122 +14,127 @@ use dpp::state_transition::masternode_vote_transition::MasternodeVoteTransition;
 use dpp::voting::votes::resource_vote::accessors::v0::ResourceVoteGettersV0;
 use dpp::voting::votes::Vote;
 use rs_dapi_client::{DapiRequest, IntoInner};
+use std::future::Future;
+use std::pin::Pin;
 
 use super::waitable::Waitable;
 
-#[async_trait::async_trait]
 /// A trait for putting a vote on platform
 pub trait PutVote<S: Signer<IdentityPublicKey>>: Waitable {
     /// Puts a vote on platform
-    async fn put_to_platform(
-        &self,
+    fn put_to_platform<'a>(
+        &'a self,
         voter_pro_tx_hash: Identifier,
-        voting_public_key: &IdentityPublicKey,
-        sdk: &Sdk,
-        signer: &S,
+        voting_public_key: &'a IdentityPublicKey,
+        sdk: &'a Sdk,
+        signer: &'a S,
         settings: Option<PutSettings>,
-    ) -> Result<(), Error>;
+    ) -> Pin<Box<dyn Future<Output = Result<(), Error>> + Send + 'a>>;
     /// Puts a vote on platform and waits for the confirmation proof
-    async fn put_to_platform_and_wait_for_response(
-        &self,
+    fn put_to_platform_and_wait_for_response<'a>(
+        &'a self,
         voter_pro_tx_hash: Identifier,
-        voting_public_key: &IdentityPublicKey,
-        sdk: &Sdk,
-        signer: &S,
+        voting_public_key: &'a IdentityPublicKey,
+        sdk: &'a Sdk,
+        signer: &'a S,
         settings: Option<PutSettings>,
-    ) -> Result<Vote, Error>;
+    ) -> Pin<Box<dyn Future<Output = Result<Vote, Error>> + Send + 'a>>;
 }
 
-#[async_trait::async_trait]
 impl<S: Signer<IdentityPublicKey>> PutVote<S> for Vote {
-    async fn put_to_platform(
-        &self,
+    fn put_to_platform<'a>(
+        &'a self,
         voter_pro_tx_hash: Identifier,
-        voting_public_key: &IdentityPublicKey,
-        sdk: &Sdk,
-        signer: &S,
+        voting_public_key: &'a IdentityPublicKey,
+        sdk: &'a Sdk,
+        signer: &'a S,
         settings: Option<PutSettings>,
-    ) -> Result<(), Error> {
-        let voting_identity_id = get_voting_identity_id(voter_pro_tx_hash, voting_public_key)?;
+    ) -> Pin<Box<dyn Future<Output = Result<(), Error>> + Send + 'a>> {
+        Box::pin(async move {
+            let voting_identity_id = get_voting_identity_id(voter_pro_tx_hash, voting_public_key)?;
 
-        let new_masternode_voting_nonce = sdk
-            .get_identity_nonce(voting_identity_id, true, settings)
-            .await?;
+            let new_masternode_voting_nonce = sdk
+                .get_identity_nonce(voting_identity_id, true, settings)
+                .await?;
 
-        let settings = settings.unwrap_or_default();
+            let settings = settings.unwrap_or_default();
 
-        let masternode_vote_transition = MasternodeVoteTransition::try_from_vote_with_signer(
-            self.clone(),
-            signer,
-            voter_pro_tx_hash,
-            voting_public_key,
-            new_masternode_voting_nonce,
-            sdk.version(),
-            None,
-        )?;
-        ensure_valid_state_transition_structure(&masternode_vote_transition, sdk.version())?;
-        let request = masternode_vote_transition.broadcast_request_for_state_transition()?;
+            let masternode_vote_transition = MasternodeVoteTransition::try_from_vote_with_signer(
+                self.clone(),
+                signer,
+                voter_pro_tx_hash,
+                voting_public_key,
+                new_masternode_voting_nonce,
+                sdk.version(),
+                None,
+            )?;
+            ensure_valid_state_transition_structure(&masternode_vote_transition, sdk.version())?;
+            let request = masternode_vote_transition.broadcast_request_for_state_transition()?;
 
-        request
-            .execute(sdk, settings.request_settings)
-            .await // TODO: We need better way to handle execution errors
-            .into_inner()?;
+            request
+                .execute(sdk, settings.request_settings)
+                .await // TODO: We need better way to handle execution errors
+                .into_inner()?;
 
-        Ok(())
+            Ok(())
+        })
     }
 
-    async fn put_to_platform_and_wait_for_response(
-        &self,
+    fn put_to_platform_and_wait_for_response<'a>(
+        &'a self,
         voter_pro_tx_hash: Identifier,
-        voting_public_key: &IdentityPublicKey,
-        sdk: &Sdk,
-        signer: &S,
+        voting_public_key: &'a IdentityPublicKey,
+        sdk: &'a Sdk,
+        signer: &'a S,
         settings: Option<PutSettings>,
-    ) -> Result<Vote, Error> {
-        let voting_identity_id = get_voting_identity_id(voter_pro_tx_hash, voting_public_key)?;
+    ) -> Pin<Box<dyn Future<Output = Result<Vote, Error>> + Send + 'a>> {
+        Box::pin(async move {
+            let voting_identity_id = get_voting_identity_id(voter_pro_tx_hash, voting_public_key)?;
 
-        let new_masternode_voting_nonce = sdk
-            .get_identity_nonce(voting_identity_id, true, settings)
-            .await?;
+            let new_masternode_voting_nonce = sdk
+                .get_identity_nonce(voting_identity_id, true, settings)
+                .await?;
 
-        let settings = settings.unwrap_or_default();
+            let settings = settings.unwrap_or_default();
 
-        let Vote::ResourceVote(resource_vote) = self;
-        let vote_poll_id = resource_vote.vote_poll().unique_id()?;
+            let Vote::ResourceVote(resource_vote) = self;
+            let vote_poll_id = resource_vote.vote_poll().unique_id()?;
 
-        let masternode_vote_transition = MasternodeVoteTransition::try_from_vote_with_signer(
-            self.clone(),
-            signer,
-            voter_pro_tx_hash,
-            voting_public_key,
-            new_masternode_voting_nonce,
-            sdk.version(),
-            None,
-        )?;
-        ensure_valid_state_transition_structure(&masternode_vote_transition, sdk.version())?;
-        let request = masternode_vote_transition.broadcast_request_for_state_transition()?;
-        // TODO: Implement retry logic
-        let response_result = request
-            .execute(sdk, settings.request_settings)
-            .await
-            .into_inner();
+            let masternode_vote_transition = MasternodeVoteTransition::try_from_vote_with_signer(
+                self.clone(),
+                signer,
+                voter_pro_tx_hash,
+                voting_public_key,
+                new_masternode_voting_nonce,
+                sdk.version(),
+                None,
+            )?;
+            ensure_valid_state_transition_structure(&masternode_vote_transition, sdk.version())?;
+            let request = masternode_vote_transition.broadcast_request_for_state_transition()?;
+            // TODO: Implement retry logic
+            let response_result = request
+                .execute(sdk, settings.request_settings)
+                .await
+                .into_inner();
 
-        match response_result {
-            Ok(_) => {}
-            //todo make this more reliable
-            Err(e) => {
-                return if e.to_string().contains("already exists") {
-                    let vote =
-                        Vote::fetch(sdk, VoteQuery::new(voter_pro_tx_hash, vote_poll_id)).await?;
-                    vote.ok_or(Error::Generic(
-                        "vote was proved to not exist but was said to exist".to_string(),
-                    ))
-                } else {
-                    Err(e.into())
+            match response_result {
+                Ok(_) => {}
+                //todo make this more reliable
+                Err(e) => {
+                    return if e.to_string().contains("already exists") {
+                        let vote =
+                            Vote::fetch(sdk, VoteQuery::new(voter_pro_tx_hash, vote_poll_id))
+                                .await?;
+                        vote.ok_or(Error::Generic(
+                            "vote was proved to not exist but was said to exist".to_string(),
+                        ))
+                    } else {
+                        Err(e.into())
+                    }
                 }
             }
-        }
-        Self::wait_for_response(sdk, masternode_vote_transition, Some(settings)).await
+            Self::wait_for_response(sdk, masternode_vote_transition, Some(settings)).await
+        })
     }
 }
 

--- a/packages/rs-sdk/src/platform/transition/waitable.rs
+++ b/packages/rs-sdk/src/platform/transition/waitable.rs
@@ -1,4 +1,6 @@
 use std::collections::BTreeMap;
+use std::future::Future;
+use std::pin::Pin;
 
 use super::broadcast::BroadcastStateTransition;
 use super::put_settings::PutSettings;
@@ -17,115 +19,118 @@ use dpp::ProtocolError;
 /// receive altered objects.
 ///
 /// This is a simple convenience trait wrapping the [`BroadcastStateTransition::wait_for_response`] method.
-#[async_trait::async_trait]
 pub trait Waitable: Sized {
-    async fn wait_for_response(
-        sdk: &Sdk,
+    fn wait_for_response<'a>(
+        sdk: &'a Sdk,
         state_transition: StateTransition,
         settings: Option<PutSettings>,
-    ) -> Result<Self, Error>;
+    ) -> Pin<Box<dyn Future<Output = Result<Self, Error>> + Send + 'a>>;
 }
-#[async_trait::async_trait]
+
 impl Waitable for DataContract {
-    async fn wait_for_response(
-        sdk: &Sdk,
+    fn wait_for_response<'a>(
+        sdk: &'a Sdk,
         state_transition: StateTransition,
         settings: Option<PutSettings>,
-    ) -> Result<DataContract, Error> {
-        state_transition.wait_for_response(sdk, settings).await
+    ) -> Pin<Box<dyn Future<Output = Result<DataContract, Error>> + Send + 'a>> {
+        Box::pin(async move { state_transition.wait_for_response(sdk, settings).await })
     }
 }
 
-#[async_trait::async_trait]
 impl Waitable for Document {
-    async fn wait_for_response(
-        sdk: &Sdk,
+    fn wait_for_response<'a>(
+        sdk: &'a Sdk,
         state_transition: StateTransition,
         settings: Option<PutSettings>,
-    ) -> Result<Self, Error> {
-        let doc_id = if let StateTransition::Batch(transition) = &state_transition {
-            let ids = transition.modified_data_ids();
-            if ids.len() != 1 {
-                return Err(Error::Protocol(
-                    dpp::ProtocolError::InvalidStateTransitionType(format!(
-                        "expected state transition with exactly one document, got {}",
-                        ids.into_iter()
-                            .map(|id| id
-                                .to_string(dpp::platform_value::string_encoding::Encoding::Base58))
-                            .collect::<Vec<_>>()
-                            .join(", ")
-                    )),
-                ));
-            }
-            ids[0]
-        } else {
-            return Err(Error::Protocol(ProtocolError::InvalidStateTransitionType(
-                format!(
-                    "expected state transition to be a DocumentsBatchTransition, got {}",
-                    state_transition.name()
-                ),
-            )));
-        };
-
-        let mut documents: BTreeMap<Identifier, Option<Document>> =
-            state_transition.wait_for_response(sdk, settings).await?;
-
-        let document: Document = documents
-            .remove(&doc_id)
-            .ok_or(Error::InvalidProvedResponse(
-                "did not prove the sent document".to_string(),
-            ))?
-            .ok_or(Error::InvalidProvedResponse(
-                "expected there to actually be a document".to_string(),
-            ))?;
-
-        Ok(document)
-    }
-}
-
-#[async_trait::async_trait]
-impl Waitable for Identity {
-    async fn wait_for_response(
-        sdk: &Sdk,
-        state_transition: StateTransition,
-        settings: Option<PutSettings>,
-    ) -> Result<Self, Error> {
-        let result: Result<Self, Error> = state_transition.wait_for_response(sdk, settings).await;
-
-        match result {
-            Ok(identity) => Ok(identity),
-            // TODO: We need to refactor sdk Error to be able to retrieve gRPC error code and identify conflicts
-            Err(Error::AlreadyExists(_)) => {
-                let identity_id = if let StateTransition::IdentityCreate(st) = state_transition {
-                    st.identity_id()
-                } else {
-                    return Err(Error::Generic(format!(
-                        "expected identity create state transition, got {:?}",
+    ) -> Pin<Box<dyn Future<Output = Result<Self, Error>> + Send + 'a>> {
+        Box::pin(async move {
+            let doc_id = if let StateTransition::Batch(transition) = &state_transition {
+                let ids = transition.modified_data_ids();
+                if ids.len() != 1 {
+                    return Err(Error::Protocol(
+                        dpp::ProtocolError::InvalidStateTransitionType(format!(
+                            "expected state transition with exactly one document, got {}",
+                            ids.into_iter()
+                                .map(|id| id.to_string(
+                                    dpp::platform_value::string_encoding::Encoding::Base58
+                                ))
+                                .collect::<Vec<_>>()
+                                .join(", ")
+                        )),
+                    ));
+                }
+                ids[0]
+            } else {
+                return Err(Error::Protocol(ProtocolError::InvalidStateTransitionType(
+                    format!(
+                        "expected state transition to be a DocumentsBatchTransition, got {}",
                         state_transition.name()
-                    )));
-                };
+                    ),
+                )));
+            };
 
-                tracing::debug!(
-                    ?identity_id,
-                    "attempt to create identity that already exists"
-                );
-                let identity = Identity::fetch(sdk, identity_id).await?;
-                identity.ok_or(Error::Generic(
-                    "identity was proved to not exist but was said to exist".to_string(),
-                ))
-            }
-            Err(e) => Err(e),
-        }
+            let mut documents: BTreeMap<Identifier, Option<Document>> =
+                state_transition.wait_for_response(sdk, settings).await?;
+
+            let document: Document = documents
+                .remove(&doc_id)
+                .ok_or(Error::InvalidProvedResponse(
+                    "did not prove the sent document".to_string(),
+                ))?
+                .ok_or(Error::InvalidProvedResponse(
+                    "expected there to actually be a document".to_string(),
+                ))?;
+
+            Ok(document)
+        })
     }
 }
 
-#[async_trait::async_trait]
-impl Waitable for Vote {
-    async fn wait_for_response(
-        sdk: &Sdk,
+impl Waitable for Identity {
+    fn wait_for_response<'a>(
+        sdk: &'a Sdk,
         state_transition: StateTransition,
         settings: Option<PutSettings>,
-    ) -> Result<Self, Error> {
-        state_transition.wait_for_response(sdk, settings).await
+    ) -> Pin<Box<dyn Future<Output = Result<Self, Error>> + Send + 'a>> {
+        Box::pin(async move {
+            let result: Result<Self, Error> =
+                state_transition.wait_for_response(sdk, settings).await;
+
+            match result {
+                Ok(identity) => Ok(identity),
+                // TODO: We need to refactor sdk Error to be able to retrieve gRPC error code and identify conflicts
+                Err(Error::AlreadyExists(_)) => {
+                    let identity_id = if let StateTransition::IdentityCreate(st) = state_transition
+                    {
+                        st.identity_id()
+                    } else {
+                        return Err(Error::Generic(format!(
+                            "expected identity create state transition, got {:?}",
+                            state_transition.name()
+                        )));
+                    };
+
+                    tracing::debug!(
+                        ?identity_id,
+                        "attempt to create identity that already exists"
+                    );
+                    let identity = Identity::fetch(sdk, identity_id).await?;
+                    identity.ok_or(Error::Generic(
+                        "identity was proved to not exist but was said to exist".to_string(),
+                    ))
+                }
+                Err(e) => Err(e),
+            }
+        })
+    }
+}
+
+impl Waitable for Vote {
+    fn wait_for_response<'a>(
+        sdk: &'a Sdk,
+        state_transition: StateTransition,
+        settings: Option<PutSettings>,
+    ) -> Pin<Box<dyn Future<Output = Result<Self, Error>> + Send + 'a>> {
+        Box::pin(async move { state_transition.wait_for_response(sdk, settings).await })
     }
 }

--- a/packages/rs-sdk/src/platform/transition/withdraw_from_identity.rs
+++ b/packages/rs-sdk/src/platform/transition/withdraw_from_identity.rs
@@ -15,65 +15,67 @@ use dpp::state_transition::identity_credit_withdrawal_transition::methods::{
 use dpp::state_transition::identity_credit_withdrawal_transition::IdentityCreditWithdrawalTransition;
 use dpp::state_transition::proof_result::StateTransitionProofResult;
 use dpp::withdrawal::Pooling;
+use std::future::Future;
+use std::pin::Pin;
 
-#[async_trait::async_trait]
 pub trait WithdrawFromIdentity {
     /// Function to withdraw credits from an identity. Returns the final identity balance.
     /// If signing_withdrawal_key_to_use is not set, we will try to use one in the signer that is
     /// available for withdrawal
     #[allow(clippy::too_many_arguments)]
-    async fn withdraw<S: Signer<IdentityPublicKey> + Send>(
-        &self,
-        sdk: &Sdk,
+    fn withdraw<'a, S: Signer<IdentityPublicKey> + Send + 'a>(
+        &'a self,
+        sdk: &'a Sdk,
         address: Option<Address>,
         amount: u64,
         core_fee_per_byte: Option<u32>,
-        signing_withdrawal_key_to_use: Option<&IdentityPublicKey>,
+        signing_withdrawal_key_to_use: Option<&'a IdentityPublicKey>,
         signer: S,
         settings: Option<PutSettings>,
-    ) -> Result<u64, Error>;
+    ) -> Pin<Box<dyn Future<Output = Result<u64, Error>> + Send + 'a>>;
 }
 
-#[async_trait::async_trait]
 impl WithdrawFromIdentity for Identity {
-    async fn withdraw<S: Signer<IdentityPublicKey> + Send>(
-        &self,
-        sdk: &Sdk,
+    fn withdraw<'a, S: Signer<IdentityPublicKey> + Send + 'a>(
+        &'a self,
+        sdk: &'a Sdk,
         address: Option<Address>,
         amount: u64,
         core_fee_per_byte: Option<u32>,
-        signing_withdrawal_key_to_use: Option<&IdentityPublicKey>,
+        signing_withdrawal_key_to_use: Option<&'a IdentityPublicKey>,
         signer: S,
         settings: Option<PutSettings>,
-    ) -> Result<u64, Error> {
-        let new_identity_nonce = sdk.get_identity_nonce(self.id(), true, settings).await?;
-        let script = address.map(|address| CoreScript::new(address.script_pubkey()));
-        let user_fee_increase = settings.and_then(|settings| settings.user_fee_increase);
-        let state_transition = IdentityCreditWithdrawalTransition::try_from_identity(
-            self,
-            script,
-            amount,
-            Pooling::Never,
-            core_fee_per_byte.unwrap_or(1),
-            user_fee_increase.unwrap_or_default(),
-            signer,
-            signing_withdrawal_key_to_use,
-            PreferredKeyPurposeForSigningWithdrawal::TransferPreferred,
-            new_identity_nonce,
-            sdk.version(),
-            None,
-        )?;
-        ensure_valid_state_transition_structure(&state_transition, sdk.version())?;
+    ) -> Pin<Box<dyn Future<Output = Result<u64, Error>> + Send + 'a>> {
+        Box::pin(async move {
+            let new_identity_nonce = sdk.get_identity_nonce(self.id(), true, settings).await?;
+            let script = address.map(|address| CoreScript::new(address.script_pubkey()));
+            let user_fee_increase = settings.and_then(|settings| settings.user_fee_increase);
+            let state_transition = IdentityCreditWithdrawalTransition::try_from_identity(
+                self,
+                script,
+                amount,
+                Pooling::Never,
+                core_fee_per_byte.unwrap_or(1),
+                user_fee_increase.unwrap_or_default(),
+                signer,
+                signing_withdrawal_key_to_use,
+                PreferredKeyPurposeForSigningWithdrawal::TransferPreferred,
+                new_identity_nonce,
+                sdk.version(),
+                None,
+            )?;
+            ensure_valid_state_transition_structure(&state_transition, sdk.version())?;
 
-        let result = state_transition.broadcast_and_wait(sdk, settings).await?;
+            let result = state_transition.broadcast_and_wait(sdk, settings).await?;
 
-        match result {
-            StateTransitionProofResult::VerifiedPartialIdentity(identity) => {
-                identity.balance.ok_or(Error::Generic(
-                    "expected an identity balance after withdrawal".to_string(),
-                ))
+            match result {
+                StateTransitionProofResult::VerifiedPartialIdentity(identity) => {
+                    identity.balance.ok_or(Error::Generic(
+                        "expected an identity balance after withdrawal".to_string(),
+                    ))
+                }
+                _ => Err(Error::Generic("proved a non identity".to_string())),
             }
-            _ => Err(Error::Generic("proved a non identity".to_string())),
-        }
+        })
     }
 }


### PR DESCRIPTION
## Issue being fixed or feature implemented

Fixes the HRTB Send inference failure ([rust-lang/rust#96865](https://github.com/rust-lang/rust/issues/96865)) that prevents SDK consumers from using `tokio::spawn` with SDK operations when 28+ `Fetch` impl types exist.

This issue was introduced when shielded pool support added 8 new `Fetch` impls (20 -> 28), pushing the Rust compiler's type inference past its limit. The same bug affects other projects like [tonic](https://github.com/hyperium/tonic/issues/2012).

## What was done?

Replaced `#[async_trait]` with explicit `Pin<Box<dyn Future<Output = ...> + Send + 'a>>` returns on:

- **Fetch** trait (5 methods) — `fetch.rs`
- **FetchMany** trait (5 methods) — `fetch_many.rs`
- **FetchUnproved** trait (2 methods) — `fetch_unproved.rs`
- **BroadcastStateTransition** trait (3 methods) — `broadcast.rs`
- **21 transition traits** (PutDocument, PutIdentity, TransferAddressFunds, ShieldFunds, WithdrawFromIdentity, etc.)

### Why this works

With `#[async_trait]`, the compiler still analyzes the trait method bodies to prove Send when monomorphizing across all impl types. With explicit `BoxFuture`, the compiler sees `Box<dyn Future + Send>` at the trait boundary and stops — Send is proven by construction via the boxed trait object.

### No performance regression

`#[async_trait]` already performed the exact same boxing (`Pin<Box<dyn Future + Send>>`). We just make it explicit instead of macro-generated, removing the macro's involvement in the compiler's inference chain.

## How Has This Been Tested?

- `cargo check -p dash-sdk` — passes
- `cargo check -p dpp --all-features -p drive-abci -p platform-wallet -p platform-wallet-ffi` — passes
- `cargo check -p wasm-sdk --target wasm32-unknown-unknown` — passes (WASM unaffected)
- **dash-evo-tool compiles with `tokio::spawn`** (no `spawn_blocking` workaround) against this branch — verified locally

## Breaking Changes
None