### PR TITLE
ci: exclude infrastructure files from code coverage

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -52,6 +52,16 @@ ignore:
   - "packages/rs-platform-version/**"
   # Simple signer — thin test-only wrapper
   - "packages/simple-signer/src/**"
+  # Infrastructure and glue code — binary entrypoints, gRPC/HTTP server setup,
+  # external client wrappers, streaming plumbing, runtime context providers,
+  # and replay/debugging tooling that are not unit-testable
+  - "packages/rs-drive-abci/src/main.rs"
+  - "packages/rs-drive-abci/src/query/service.rs"
+  - "packages/rs-dapi/src/server/**"
+  - "packages/rs-dapi/src/clients/core_client.rs"
+  - "packages/rs-sdk-trusted-context-provider/**"
+  - "packages/rs-dapi/src/services/streaming_service/**"
+  - "packages/rs-drive-abci/src/replay/**"
 
 coverage:
   status:


### PR DESCRIPTION
## Issue being fixed or feature implemented

Infrastructure and glue files (binary entrypoints, server setup, external client wrappers, streaming plumbing, context providers, replay tooling) inflate uncovered line counts by ~3,500 lines. These files are not unit-testable by nature and should not count toward coverage metrics.

## What was done?

Added 7 new entries to the `ignore:` section in `.codecov.yml`:

| Path | Rationale |
|------|-----------|
| `packages/rs-drive-abci/src/main.rs` | Binary entrypoint, not unit-testable (201 uncovered lines) |
| `packages/rs-drive-abci/src/query/service.rs` | gRPC service router/glue (229 uncovered lines) |
| `packages/rs-dapi/src/server/**` | HTTP/gRPC server setup, metrics, jsonrpc handler (439 uncovered lines) |
| `packages/rs-dapi/src/clients/core_client.rs` | External HTTP client wrapper for Core RPC (345 uncovered lines) |
| `packages/rs-sdk-trusted-context-provider/**` | Runtime context provider glue (480 uncovered lines) |
| `packages/rs-dapi/src/services/streaming_service/**` | WebSocket/ZMQ streaming infrastructure (~1,300 uncovered lines) |
| `packages/rs-drive-abci/src/replay/**` | Replay/debugging infrastructure (534 uncovered lines) |

## How Has This Been Tested?

Configuration-only change. Codecov will apply the updated ignore rules on the next coverage upload.

## Breaking Changes

None.

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [ ] I have made corresponding changes to the documentation if needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated code coverage configuration to exclude additional infrastructure and internal tooling paths from coverage metrics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->