### PR TITLE
test(platform): improve btreemap extensions test coverage

### DIFF
--- a/packages/rs-platform-value/src/btreemap_extensions/btreemap_path_extensions.rs
+++ b/packages/rs-platform-value/src/btreemap_extensions/btreemap_path_extensions.rs
@@ -582,3 +582,844 @@ where
             .ok_or_else(|| Error::StructureError(format!("unable to get float property {path}")))
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{Identifier, Value};
+    use std::collections::BTreeMap;
+
+    // -----------------------------------------------------------------------
+    // Helper: build a BTreeMap<String, Value> from tuples
+    // -----------------------------------------------------------------------
+
+    fn map_with(entries: Vec<(&str, Value)>) -> BTreeMap<String, Value> {
+        entries
+            .into_iter()
+            .map(|(k, v)| (k.to_string(), v))
+            .collect()
+    }
+
+    /// Build a nested Value::Map from a BTreeMap-like structure
+    fn nested_value_map(entries: Vec<(&str, Value)>) -> Value {
+        Value::Map(
+            entries
+                .into_iter()
+                .map(|(k, v)| (Value::Text(k.to_string()), v))
+                .collect(),
+        )
+    }
+
+    // -----------------------------------------------------------------------
+    // get_at_path / get_optional_at_path
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn get_at_path_single_level() {
+        let map = map_with(vec![("name", Value::Text("alice".to_string()))]);
+        let result = map.get_at_path("name").unwrap();
+        assert_eq!(result, &Value::Text("alice".to_string()));
+    }
+
+    #[test]
+    fn get_at_path_nested() {
+        let inner = nested_value_map(vec![("city", Value::Text("NYC".to_string()))]);
+        let map = map_with(vec![("address", inner)]);
+        let result = map.get_at_path("address.city").unwrap();
+        assert_eq!(result, &Value::Text("NYC".to_string()));
+    }
+
+    #[test]
+    fn get_at_path_deeply_nested() {
+        let deep = nested_value_map(vec![("z", Value::U64(42))]);
+        let mid = nested_value_map(vec![("y", deep)]);
+        let map = map_with(vec![("x", mid)]);
+        let result = map.get_at_path("x.y.z").unwrap();
+        assert_eq!(result, &Value::U64(42));
+    }
+
+    #[test]
+    fn get_at_path_missing_top_level_errors() {
+        let map: BTreeMap<String, Value> = BTreeMap::new();
+        assert!(map.get_at_path("missing").is_err());
+    }
+
+    #[test]
+    fn get_at_path_missing_nested_key_errors() {
+        let inner = nested_value_map(vec![("a", Value::U64(1))]);
+        let map = map_with(vec![("top", inner)]);
+        assert!(map.get_at_path("top.nonexistent").is_err());
+    }
+
+    #[test]
+    fn get_at_path_empty_path_errors() {
+        let map = map_with(vec![("a", Value::U64(1))]);
+        // Empty string splits into one element "", which won't match anything
+        // The actual implementation: split("").next() returns Some("")
+        // but get("") returns None => StructureError
+        assert!(map.get_at_path("").is_err());
+    }
+
+    #[test]
+    fn get_optional_at_path_returns_some() {
+        let map = map_with(vec![("key", Value::Bool(true))]);
+        let result = map.get_optional_at_path("key").unwrap();
+        assert_eq!(result, Some(&Value::Bool(true)));
+    }
+
+    #[test]
+    fn get_optional_at_path_returns_none_for_missing_top_level() {
+        let map: BTreeMap<String, Value> = BTreeMap::new();
+        let result = map.get_optional_at_path("missing").unwrap();
+        assert_eq!(result, None);
+    }
+
+    #[test]
+    fn get_optional_at_path_returns_none_for_missing_nested() {
+        let inner = nested_value_map(vec![("a", Value::U64(1))]);
+        let map = map_with(vec![("top", inner)]);
+        let result = map.get_optional_at_path("top.missing").unwrap();
+        assert_eq!(result, None);
+    }
+
+    #[test]
+    fn get_optional_at_path_nested_returns_some() {
+        let inner = nested_value_map(vec![("val", Value::Float(9.9))]);
+        let map = map_with(vec![("nested", inner)]);
+        let result = map.get_optional_at_path("nested.val").unwrap();
+        assert_eq!(result, Some(&Value::Float(9.9)));
+    }
+
+    // -----------------------------------------------------------------------
+    // get_identifier_at_path / get_optional_identifier_at_path
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn get_identifier_at_path_success() {
+        let id = [1u8; 32];
+        let map = map_with(vec![("id", Value::Bytes32(id))]);
+        let result = map.get_identifier_at_path("id").unwrap();
+        assert_eq!(result, id);
+    }
+
+    #[test]
+    fn get_identifier_at_path_missing_errors() {
+        let map: BTreeMap<String, Value> = BTreeMap::new();
+        assert!(map.get_identifier_at_path("id").is_err());
+    }
+
+    #[test]
+    fn get_optional_identifier_at_path_returns_some() {
+        let id = [2u8; 32];
+        let map = map_with(vec![("id", Value::Bytes32(id))]);
+        let result = map.get_optional_identifier_at_path("id").unwrap();
+        assert_eq!(result, Some(id));
+    }
+
+    #[test]
+    fn get_optional_identifier_at_path_returns_none_for_missing() {
+        let map: BTreeMap<String, Value> = BTreeMap::new();
+        let result = map.get_optional_identifier_at_path("id").unwrap();
+        assert_eq!(result, None);
+    }
+
+    // -----------------------------------------------------------------------
+    // get_string_at_path / get_optional_string_at_path
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn get_string_at_path_success() {
+        let map = map_with(vec![("s", Value::Text("hello".to_string()))]);
+        let result = map.get_string_at_path("s").unwrap();
+        assert_eq!(result, "hello");
+    }
+
+    #[test]
+    fn get_string_at_path_missing_errors() {
+        let map: BTreeMap<String, Value> = BTreeMap::new();
+        assert!(map.get_string_at_path("s").is_err());
+    }
+
+    #[test]
+    fn get_optional_string_at_path_returns_some() {
+        let map = map_with(vec![("s", Value::Text("world".to_string()))]);
+        let result = map.get_optional_string_at_path("s").unwrap();
+        assert_eq!(result, Some("world".to_string()));
+    }
+
+    #[test]
+    fn get_optional_string_at_path_returns_none() {
+        let map: BTreeMap<String, Value> = BTreeMap::new();
+        let result = map.get_optional_string_at_path("s").unwrap();
+        assert_eq!(result, None);
+    }
+
+    #[test]
+    fn get_optional_string_at_path_wrong_type_errors() {
+        let map = map_with(vec![("s", Value::U64(42))]);
+        assert!(map.get_optional_string_at_path("s").is_err());
+    }
+
+    // -----------------------------------------------------------------------
+    // get_str_at_path / get_optional_str_at_path
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn get_str_at_path_success() {
+        let map = map_with(vec![("s", Value::Text("borrow_me".to_string()))]);
+        let result = map.get_str_at_path("s").unwrap();
+        assert_eq!(result, "borrow_me");
+    }
+
+    #[test]
+    fn get_str_at_path_missing_errors() {
+        let map: BTreeMap<String, Value> = BTreeMap::new();
+        assert!(map.get_str_at_path("s").is_err());
+    }
+
+    #[test]
+    fn get_optional_str_at_path_returns_some() {
+        let map = map_with(vec![("s", Value::Text("ref".to_string()))]);
+        let result = map.get_optional_str_at_path("s").unwrap();
+        assert_eq!(result, Some("ref"));
+    }
+
+    #[test]
+    fn get_optional_str_at_path_returns_none() {
+        let map: BTreeMap<String, Value> = BTreeMap::new();
+        let result = map.get_optional_str_at_path("s").unwrap();
+        assert_eq!(result, None);
+    }
+
+    // -----------------------------------------------------------------------
+    // get_integer_at_path / get_optional_integer_at_path
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn get_integer_at_path_success() {
+        let map = map_with(vec![("num", Value::U64(100))]);
+        let result: u64 = map.get_integer_at_path("num").unwrap();
+        assert_eq!(result, 100);
+    }
+
+    #[test]
+    fn get_integer_at_path_nested() {
+        let inner = nested_value_map(vec![("val", Value::I32(-5))]);
+        let map = map_with(vec![("data", inner)]);
+        let result: i32 = map.get_integer_at_path("data.val").unwrap();
+        assert_eq!(result, -5);
+    }
+
+    #[test]
+    fn get_integer_at_path_missing_errors() {
+        let map: BTreeMap<String, Value> = BTreeMap::new();
+        let result: Result<u64, Error> = map.get_integer_at_path("num");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn get_optional_integer_at_path_returns_some() {
+        let map = map_with(vec![("n", Value::U32(7))]);
+        let result: Option<u32> = map.get_optional_integer_at_path("n").unwrap();
+        assert_eq!(result, Some(7));
+    }
+
+    #[test]
+    fn get_optional_integer_at_path_returns_none_for_missing() {
+        let map: BTreeMap<String, Value> = BTreeMap::new();
+        let result: Option<u32> = map.get_optional_integer_at_path("n").unwrap();
+        assert_eq!(result, None);
+    }
+
+    #[test]
+    fn get_optional_integer_at_path_returns_none_for_null() {
+        let map = map_with(vec![("n", Value::Null)]);
+        let result: Option<u32> = map.get_optional_integer_at_path("n").unwrap();
+        assert_eq!(result, None);
+    }
+
+    // -----------------------------------------------------------------------
+    // get_float_at_path / get_optional_float_at_path
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn get_float_at_path_success() {
+        let map = map_with(vec![("f", Value::Float(1.23))]);
+        let result = map.get_float_at_path("f").unwrap();
+        assert!((result - 1.23).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn get_float_at_path_missing_errors() {
+        let map: BTreeMap<String, Value> = BTreeMap::new();
+        assert!(map.get_float_at_path("f").is_err());
+    }
+
+    #[test]
+    fn get_optional_float_at_path_returns_some() {
+        let map = map_with(vec![("f", Value::Float(2.72))]);
+        let result = map.get_optional_float_at_path("f").unwrap();
+        assert_eq!(result, Some(2.72));
+    }
+
+    #[test]
+    fn get_optional_float_at_path_returns_none_for_missing() {
+        let map: BTreeMap<String, Value> = BTreeMap::new();
+        let result = map.get_optional_float_at_path("f").unwrap();
+        assert_eq!(result, None);
+    }
+
+    #[test]
+    fn get_optional_float_at_path_returns_none_for_null() {
+        let map = map_with(vec![("f", Value::Null)]);
+        let result = map.get_optional_float_at_path("f").unwrap();
+        assert_eq!(result, None);
+    }
+
+    // -----------------------------------------------------------------------
+    // get_bool_at_path / get_optional_bool_at_path
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn get_bool_at_path_success() {
+        let map = map_with(vec![("flag", Value::Bool(true))]);
+        let result = map.get_bool_at_path("flag").unwrap();
+        assert!(result);
+    }
+
+    #[test]
+    fn get_bool_at_path_missing_errors() {
+        let map: BTreeMap<String, Value> = BTreeMap::new();
+        assert!(map.get_bool_at_path("flag").is_err());
+    }
+
+    #[test]
+    fn get_optional_bool_at_path_returns_some() {
+        let map = map_with(vec![("b", Value::Bool(false))]);
+        let result = map.get_optional_bool_at_path("b").unwrap();
+        assert_eq!(result, Some(false));
+    }
+
+    #[test]
+    fn get_optional_bool_at_path_returns_none_for_missing() {
+        let map: BTreeMap<String, Value> = BTreeMap::new();
+        let result = map.get_optional_bool_at_path("b").unwrap();
+        assert_eq!(result, None);
+    }
+
+    #[test]
+    fn get_optional_bool_at_path_returns_none_for_null() {
+        let map = map_with(vec![("b", Value::Null)]);
+        let result = map.get_optional_bool_at_path("b").unwrap();
+        assert_eq!(result, None);
+    }
+
+    // -----------------------------------------------------------------------
+    // get_inner_value_array_at_path / get_optional_inner_value_array_at_path
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn get_inner_value_array_at_path_success() {
+        let arr = Value::Array(vec![Value::U64(1), Value::U64(2), Value::U64(3)]);
+        let map = map_with(vec![("arr", arr)]);
+        let result: Vec<&Value> = map.get_inner_value_array_at_path("arr").unwrap();
+        assert_eq!(result.len(), 3);
+        assert_eq!(result[0], &Value::U64(1));
+    }
+
+    #[test]
+    fn get_inner_value_array_at_path_missing_errors() {
+        let map: BTreeMap<String, Value> = BTreeMap::new();
+        let result: Result<Vec<&Value>, Error> = map.get_inner_value_array_at_path("arr");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn get_optional_inner_value_array_returns_some() {
+        let arr = Value::Array(vec![Value::Bool(true)]);
+        let map = map_with(vec![("arr", arr)]);
+        let result: Option<Vec<&Value>> =
+            map.get_optional_inner_value_array_at_path("arr").unwrap();
+        assert!(result.is_some());
+        assert_eq!(result.unwrap().len(), 1);
+    }
+
+    #[test]
+    fn get_optional_inner_value_array_returns_none_for_missing() {
+        let map: BTreeMap<String, Value> = BTreeMap::new();
+        let result: Option<Vec<&Value>> =
+            map.get_optional_inner_value_array_at_path("arr").unwrap();
+        assert_eq!(result, None);
+    }
+
+    // -----------------------------------------------------------------------
+    // get_inner_string_array_at_path / get_optional_inner_string_array_at_path
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn get_inner_string_array_at_path_success() {
+        let arr = Value::Array(vec![
+            Value::Text("a".to_string()),
+            Value::Text("b".to_string()),
+        ]);
+        let map = map_with(vec![("names", arr)]);
+        let result: Vec<String> = map.get_inner_string_array_at_path("names").unwrap();
+        assert_eq!(result, vec!["a".to_string(), "b".to_string()]);
+    }
+
+    #[test]
+    fn get_inner_string_array_at_path_missing_errors() {
+        let map: BTreeMap<String, Value> = BTreeMap::new();
+        let result: Result<Vec<String>, Error> = map.get_inner_string_array_at_path("names");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn get_optional_inner_string_array_returns_some() {
+        let arr = Value::Array(vec![Value::Text("x".to_string())]);
+        let map = map_with(vec![("names", arr)]);
+        let result: Option<Vec<String>> = map
+            .get_optional_inner_string_array_at_path("names")
+            .unwrap();
+        assert_eq!(result, Some(vec!["x".to_string()]));
+    }
+
+    #[test]
+    fn get_optional_inner_string_array_returns_none_for_missing() {
+        let map: BTreeMap<String, Value> = BTreeMap::new();
+        let result: Option<Vec<String>> = map
+            .get_optional_inner_string_array_at_path("names")
+            .unwrap();
+        assert_eq!(result, None);
+    }
+
+    #[test]
+    fn get_optional_inner_string_array_errors_on_non_string_elements() {
+        let arr = Value::Array(vec![Value::U64(42)]);
+        let map = map_with(vec![("names", arr)]);
+        let result: Result<Option<Vec<String>>, Error> =
+            map.get_optional_inner_string_array_at_path("names");
+        assert!(result.is_err());
+    }
+
+    // -----------------------------------------------------------------------
+    // get_optional_inner_borrowed_map_at_path
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn get_optional_inner_borrowed_map_at_path_returns_some() {
+        let inner = nested_value_map(vec![("k", Value::U64(1))]);
+        let map = map_with(vec![("m", inner)]);
+        let result = map.get_optional_inner_borrowed_map_at_path("m").unwrap();
+        assert!(result.is_some());
+    }
+
+    #[test]
+    fn get_optional_inner_borrowed_map_at_path_returns_none_for_missing() {
+        let map: BTreeMap<String, Value> = BTreeMap::new();
+        let result = map.get_optional_inner_borrowed_map_at_path("m").unwrap();
+        assert_eq!(result, None);
+    }
+
+    #[test]
+    fn get_optional_inner_borrowed_map_at_path_errors_on_non_map() {
+        let map = map_with(vec![("m", Value::U64(42))]);
+        assert!(map.get_optional_inner_borrowed_map_at_path("m").is_err());
+    }
+
+    // -----------------------------------------------------------------------
+    // get_inner_borrowed_str_value_map_at_path /
+    // get_optional_inner_borrowed_str_value_map_at_path
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn get_inner_borrowed_str_value_map_at_path_success() {
+        let inner = nested_value_map(vec![("k", Value::Text("v".to_string()))]);
+        let map = map_with(vec![("m", inner)]);
+        let result: BTreeMap<String, &Value> =
+            map.get_inner_borrowed_str_value_map_at_path("m").unwrap();
+        assert_eq!(result.get("k"), Some(&&Value::Text("v".to_string())));
+    }
+
+    #[test]
+    fn get_inner_borrowed_str_value_map_at_path_missing_errors() {
+        let map: BTreeMap<String, Value> = BTreeMap::new();
+        let result: Result<BTreeMap<String, &Value>, Error> =
+            map.get_inner_borrowed_str_value_map_at_path("m");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn get_optional_inner_borrowed_str_value_map_returns_some() {
+        let inner = nested_value_map(vec![("a", Value::Bool(true))]);
+        let map = map_with(vec![("m", inner)]);
+        let result: Option<BTreeMap<String, &Value>> = map
+            .get_optional_inner_borrowed_str_value_map_at_path("m")
+            .unwrap();
+        assert!(result.is_some());
+    }
+
+    #[test]
+    fn get_optional_inner_borrowed_str_value_map_returns_none_for_missing() {
+        let map: BTreeMap<String, Value> = BTreeMap::new();
+        let result: Option<BTreeMap<String, &Value>> = map
+            .get_optional_inner_borrowed_str_value_map_at_path("m")
+            .unwrap();
+        assert_eq!(result, None);
+    }
+
+    // -----------------------------------------------------------------------
+    // get_hash256_bytes_at_path / get_optional_hash256_bytes_at_path
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn get_hash256_bytes_at_path_success() {
+        let hash = [5u8; 32];
+        let map = map_with(vec![("h", Value::Bytes32(hash))]);
+        let result = map.get_hash256_bytes_at_path("h").unwrap();
+        assert_eq!(result, hash);
+    }
+
+    #[test]
+    fn get_hash256_bytes_at_path_missing_errors() {
+        let map: BTreeMap<String, Value> = BTreeMap::new();
+        assert!(map.get_hash256_bytes_at_path("h").is_err());
+    }
+
+    #[test]
+    fn get_optional_hash256_bytes_at_path_returns_some() {
+        let hash = [6u8; 32];
+        let map = map_with(vec![("h", Value::Bytes32(hash))]);
+        let result = map.get_optional_hash256_bytes_at_path("h").unwrap();
+        assert_eq!(result, Some(hash));
+    }
+
+    #[test]
+    fn get_optional_hash256_bytes_at_path_returns_none() {
+        let map: BTreeMap<String, Value> = BTreeMap::new();
+        let result = map.get_optional_hash256_bytes_at_path("h").unwrap();
+        assert_eq!(result, None);
+    }
+
+    // -----------------------------------------------------------------------
+    // get_bytes_at_path / get_optional_bytes_at_path
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn get_bytes_at_path_success() {
+        let bytes = vec![1, 2, 3];
+        let map = map_with(vec![("b", Value::Bytes(bytes.clone()))]);
+        let result = map.get_bytes_at_path("b").unwrap();
+        assert_eq!(result, bytes);
+    }
+
+    #[test]
+    fn get_bytes_at_path_missing_errors() {
+        let map: BTreeMap<String, Value> = BTreeMap::new();
+        assert!(map.get_bytes_at_path("b").is_err());
+    }
+
+    #[test]
+    fn get_optional_bytes_at_path_returns_some() {
+        let bytes = vec![4, 5];
+        let map = map_with(vec![("b", Value::Bytes(bytes.clone()))]);
+        let result = map.get_optional_bytes_at_path("b").unwrap();
+        assert_eq!(result, Some(bytes));
+    }
+
+    #[test]
+    fn get_optional_bytes_at_path_returns_none() {
+        let map: BTreeMap<String, Value> = BTreeMap::new();
+        let result = map.get_optional_bytes_at_path("b").unwrap();
+        assert_eq!(result, None);
+    }
+
+    // -----------------------------------------------------------------------
+    // get_identifier_bytes_at_path / get_optional_identifier_bytes_at_path
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn get_identifier_bytes_at_path_success() {
+        let id = [7u8; 32];
+        let map = map_with(vec![("id", Value::Identifier(id))]);
+        let result = map.get_identifier_bytes_at_path("id").unwrap();
+        assert_eq!(result, id.to_vec());
+    }
+
+    #[test]
+    fn get_identifier_bytes_at_path_missing_errors() {
+        let map: BTreeMap<String, Value> = BTreeMap::new();
+        assert!(map.get_identifier_bytes_at_path("id").is_err());
+    }
+
+    #[test]
+    fn get_optional_identifier_bytes_at_path_returns_some() {
+        let id = [8u8; 32];
+        let map = map_with(vec![("id", Value::Identifier(id))]);
+        let result = map.get_optional_identifier_bytes_at_path("id").unwrap();
+        assert_eq!(result, Some(id.to_vec()));
+    }
+
+    #[test]
+    fn get_optional_identifier_bytes_at_path_returns_none() {
+        let map: BTreeMap<String, Value> = BTreeMap::new();
+        let result = map.get_optional_identifier_bytes_at_path("id").unwrap();
+        assert_eq!(result, None);
+    }
+
+    // -----------------------------------------------------------------------
+    // get_binary_bytes_at_path / get_optional_binary_bytes_at_path
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn get_binary_bytes_at_path_success() {
+        let bytes = vec![10, 20, 30];
+        let map = map_with(vec![("bin", Value::Bytes(bytes.clone()))]);
+        let result = map.get_binary_bytes_at_path("bin").unwrap();
+        assert_eq!(result, bytes);
+    }
+
+    #[test]
+    fn get_binary_bytes_at_path_missing_errors() {
+        let map: BTreeMap<String, Value> = BTreeMap::new();
+        assert!(map.get_binary_bytes_at_path("bin").is_err());
+    }
+
+    #[test]
+    fn get_optional_binary_bytes_at_path_returns_some() {
+        let bytes = vec![40, 50];
+        let map = map_with(vec![("bin", Value::Bytes(bytes.clone()))]);
+        let result = map.get_optional_binary_bytes_at_path("bin").unwrap();
+        assert_eq!(result, Some(bytes));
+    }
+
+    #[test]
+    fn get_optional_binary_bytes_at_path_returns_none() {
+        let map: BTreeMap<String, Value> = BTreeMap::new();
+        let result = map.get_optional_binary_bytes_at_path("bin").unwrap();
+        assert_eq!(result, None);
+    }
+
+    // -----------------------------------------------------------------------
+    // remove_string_at_path / remove_optional_string_at_path
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn remove_string_at_path_success() {
+        let mut map = map_with(vec![("name", Value::Text("test".to_string()))]);
+        let result = map.remove_string_at_path("name").unwrap();
+        assert_eq!(result, "test");
+        assert!(map.is_empty());
+    }
+
+    #[test]
+    fn remove_string_at_path_missing_errors() {
+        let mut map: BTreeMap<String, Value> = BTreeMap::new();
+        assert!(map.remove_string_at_path("name").is_err());
+    }
+
+    #[test]
+    fn remove_optional_string_at_path_returns_some() {
+        let mut map = map_with(vec![("s", Value::Text("hi".to_string()))]);
+        let result = map.remove_optional_string_at_path("s").unwrap();
+        assert_eq!(result, Some("hi".to_string()));
+    }
+
+    #[test]
+    fn remove_optional_string_at_path_returns_none() {
+        let mut map: BTreeMap<String, Value> = BTreeMap::new();
+        let result = map.remove_optional_string_at_path("s").unwrap();
+        assert_eq!(result, None);
+    }
+
+    // -----------------------------------------------------------------------
+    // remove_float_at_path / remove_optional_float_at_path
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn remove_float_at_path_success() {
+        let mut map = map_with(vec![("f", Value::Float(1.5))]);
+        let result = map.remove_float_at_path("f").unwrap();
+        assert!((result - 1.5).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn remove_float_at_path_missing_errors() {
+        let mut map: BTreeMap<String, Value> = BTreeMap::new();
+        assert!(map.remove_float_at_path("f").is_err());
+    }
+
+    #[test]
+    fn remove_optional_float_at_path_returns_some() {
+        let mut map = map_with(vec![("f", Value::Float(0.5))]);
+        let result = map.remove_optional_float_at_path("f").unwrap();
+        assert_eq!(result, Some(0.5));
+    }
+
+    #[test]
+    fn remove_optional_float_at_path_returns_none_for_missing() {
+        let mut map: BTreeMap<String, Value> = BTreeMap::new();
+        let result = map.remove_optional_float_at_path("f").unwrap();
+        assert_eq!(result, None);
+    }
+
+    #[test]
+    fn remove_optional_float_at_path_returns_none_for_null() {
+        let mut map = map_with(vec![("f", Value::Null)]);
+        let result = map.remove_optional_float_at_path("f").unwrap();
+        assert_eq!(result, None);
+    }
+
+    // -----------------------------------------------------------------------
+    // remove_integer_at_path / remove_optional_integer_at_path
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn remove_integer_at_path_success() {
+        let mut map = map_with(vec![("n", Value::U64(99))]);
+        let result: u64 = map.remove_integer_at_path("n").unwrap();
+        assert_eq!(result, 99);
+    }
+
+    #[test]
+    fn remove_integer_at_path_missing_errors() {
+        let mut map: BTreeMap<String, Value> = BTreeMap::new();
+        let result: Result<u64, Error> = map.remove_integer_at_path("n");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn remove_optional_integer_at_path_returns_some() {
+        let mut map = map_with(vec![("n", Value::I32(-3))]);
+        let result: Option<i32> = map.remove_optional_integer_at_path("n").unwrap();
+        assert_eq!(result, Some(-3));
+    }
+
+    #[test]
+    fn remove_optional_integer_at_path_returns_none_for_missing() {
+        let mut map: BTreeMap<String, Value> = BTreeMap::new();
+        let result: Option<i32> = map.remove_optional_integer_at_path("n").unwrap();
+        assert_eq!(result, None);
+    }
+
+    #[test]
+    fn remove_optional_integer_at_path_returns_none_for_null() {
+        let mut map = map_with(vec![("n", Value::Null)]);
+        let result: Option<i32> = map.remove_optional_integer_at_path("n").unwrap();
+        assert_eq!(result, None);
+    }
+
+    // -----------------------------------------------------------------------
+    // remove_hash256_bytes_at_path / remove_optional_hash256_bytes_at_path
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn remove_hash256_bytes_at_path_success() {
+        let hash = [9u8; 32];
+        let mut map = map_with(vec![("h", Value::Bytes32(hash))]);
+        let result = map.remove_hash256_bytes_at_path("h").unwrap();
+        assert_eq!(result, hash);
+        assert!(map.is_empty());
+    }
+
+    #[test]
+    fn remove_hash256_bytes_at_path_missing_errors() {
+        let mut map: BTreeMap<String, Value> = BTreeMap::new();
+        assert!(map.remove_hash256_bytes_at_path("h").is_err());
+    }
+
+    #[test]
+    fn remove_optional_hash256_bytes_at_path_returns_some() {
+        let hash = [10u8; 32];
+        let mut map = map_with(vec![("h", Value::Bytes32(hash))]);
+        let result = map.remove_optional_hash256_bytes_at_path("h").unwrap();
+        assert_eq!(result, Some(hash));
+    }
+
+    #[test]
+    fn remove_optional_hash256_bytes_at_path_returns_none() {
+        let mut map: BTreeMap<String, Value> = BTreeMap::new();
+        let result = map.remove_optional_hash256_bytes_at_path("h").unwrap();
+        assert_eq!(result, None);
+    }
+
+    // -----------------------------------------------------------------------
+    // remove_identifier_at_path / remove_optional_identifier_at_path
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn remove_identifier_at_path_success() {
+        let id = [11u8; 32];
+        let mut map = map_with(vec![("id", Value::Identifier(id))]);
+        let result = map.remove_identifier_at_path("id").unwrap();
+        assert_eq!(result, Identifier::from(id));
+        assert!(map.is_empty());
+    }
+
+    #[test]
+    fn remove_identifier_at_path_missing_errors() {
+        let mut map: BTreeMap<String, Value> = BTreeMap::new();
+        assert!(map.remove_identifier_at_path("id").is_err());
+    }
+
+    #[test]
+    fn remove_optional_identifier_at_path_returns_some() {
+        let id = [12u8; 32];
+        let mut map = map_with(vec![("id", Value::Identifier(id))]);
+        let result = map.remove_optional_identifier_at_path("id").unwrap();
+        assert_eq!(result, Some(Identifier::from(id)));
+    }
+
+    #[test]
+    fn remove_optional_identifier_at_path_returns_none() {
+        let mut map: BTreeMap<String, Value> = BTreeMap::new();
+        let result = map.remove_optional_identifier_at_path("id").unwrap();
+        assert_eq!(result, None);
+    }
+
+    // -----------------------------------------------------------------------
+    // Nested path traversal edge cases
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn get_at_path_works_with_ref_values() {
+        // Test that the impl works for BTreeMap<String, &Value> via the generic impl
+        let source: BTreeMap<String, Value> =
+            map_with(vec![("key", Value::Text("val".to_string()))]);
+        let ref_map: BTreeMap<String, &Value> =
+            source.iter().map(|(k, v)| (k.clone(), v)).collect();
+        let result = ref_map.get_at_path("key").unwrap();
+        assert_eq!(result, &Value::Text("val".to_string()));
+    }
+
+    #[test]
+    fn get_at_path_ref_map_nested() {
+        let inner = nested_value_map(vec![("deep", Value::Bool(true))]);
+        let source = map_with(vec![("top", inner)]);
+        let ref_map: BTreeMap<String, &Value> =
+            source.iter().map(|(k, v)| (k.clone(), v)).collect();
+        let result = ref_map.get_at_path("top.deep").unwrap();
+        assert_eq!(result, &Value::Bool(true));
+    }
+
+    // -----------------------------------------------------------------------
+    // Nested path: multi-level structure tests
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn get_string_at_nested_path() {
+        let level2 = nested_value_map(vec![("name", Value::Text("deep".to_string()))]);
+        let level1 = nested_value_map(vec![("child", level2)]);
+        let map = map_with(vec![("parent", level1)]);
+        let result = map.get_string_at_path("parent.child.name").unwrap();
+        assert_eq!(result, "deep");
+    }
+
+    #[test]
+    fn get_bool_at_nested_path() {
+        let inner = nested_value_map(vec![("enabled", Value::Bool(false))]);
+        let map = map_with(vec![("config", inner)]);
+        let result = map.get_bool_at_path("config.enabled").unwrap();
+        assert!(!result);
+    }
+}

--- a/packages/rs-platform-value/src/btreemap_extensions/btreemap_removal_extensions.rs
+++ b/packages/rs-platform-value/src/btreemap_extensions/btreemap_removal_extensions.rs
@@ -732,7 +732,8 @@ impl BTreeValueRemoveTupleFromMapHelper for BTreeMap<String, Value> {
                             Ok(key_value) => key_value,
                             Err(e) => return Some(Err(e)),
                         };
-                        let value_value: V = match arr.remove(1).try_into() {
+                        // After removing index 0 above, the second element is now at index 0
+                        let value_value: V = match arr.remove(0).try_into() {
                             Ok(key_value) => key_value,
                             Err(e) => return Some(Err(e)),
                         };
@@ -749,5 +750,1065 @@ impl BTreeValueRemoveTupleFromMapHelper for BTreeMap<String, Value> {
                 }
             })
             .transpose()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{BinaryData, Bytes20, Bytes32, Identifier, Value};
+    use std::collections::BTreeMap;
+
+    // -----------------------------------------------------------------------
+    // Helper functions
+    // -----------------------------------------------------------------------
+
+    fn owned_map_with(entries: Vec<(&str, Value)>) -> BTreeMap<String, Value> {
+        entries
+            .into_iter()
+            .map(|(k, v)| (k.to_string(), v))
+            .collect()
+    }
+
+    fn ref_map_from(map: &BTreeMap<String, Value>) -> BTreeMap<String, &Value> {
+        map.iter().map(|(k, v)| (k.clone(), v)).collect()
+    }
+
+    // -----------------------------------------------------------------------
+    // Tests for BTreeMap<String, Value> (owned impl)
+    // -----------------------------------------------------------------------
+
+    mod owned_map {
+        use super::*;
+
+        // -- String tests --
+
+        #[test]
+        fn remove_string_success() {
+            let mut map = owned_map_with(vec![("name", Value::Text("alice".to_string()))]);
+            let result = map.remove_string("name").unwrap();
+            assert_eq!(result, "alice");
+            assert!(map.is_empty());
+        }
+
+        #[test]
+        fn remove_string_missing_key_errors() {
+            let mut map: BTreeMap<String, Value> = BTreeMap::new();
+            assert!(map.remove_string("name").is_err());
+        }
+
+        #[test]
+        fn remove_optional_string_returns_some() {
+            let mut map = owned_map_with(vec![("name", Value::Text("bob".to_string()))]);
+            let result = map.remove_optional_string("name").unwrap();
+            assert_eq!(result, Some("bob".to_string()));
+        }
+
+        #[test]
+        fn remove_optional_string_returns_none_for_missing() {
+            let mut map: BTreeMap<String, Value> = BTreeMap::new();
+            let result = map.remove_optional_string("name").unwrap();
+            assert_eq!(result, None);
+        }
+
+        #[test]
+        fn remove_optional_string_returns_none_for_null() {
+            let mut map = owned_map_with(vec![("name", Value::Null)]);
+            let result = map.remove_optional_string("name").unwrap();
+            assert_eq!(result, None);
+        }
+
+        // -- Float tests --
+
+        #[test]
+        fn remove_float_success() {
+            let mut map = owned_map_with(vec![("score", Value::Float(1.23))]);
+            let result = map.remove_float("score").unwrap();
+            assert!((result - 1.23).abs() < f64::EPSILON);
+        }
+
+        #[test]
+        fn remove_float_missing_key_errors() {
+            let mut map: BTreeMap<String, Value> = BTreeMap::new();
+            assert!(map.remove_float("score").is_err());
+        }
+
+        #[test]
+        fn remove_optional_float_returns_some() {
+            let mut map = owned_map_with(vec![("score", Value::Float(2.72))]);
+            let result = map.remove_optional_float("score").unwrap();
+            assert_eq!(result, Some(2.72));
+        }
+
+        #[test]
+        fn remove_optional_float_returns_none_for_missing() {
+            let mut map: BTreeMap<String, Value> = BTreeMap::new();
+            let result = map.remove_optional_float("score").unwrap();
+            assert_eq!(result, None);
+        }
+
+        #[test]
+        fn remove_optional_float_returns_none_for_null() {
+            let mut map = owned_map_with(vec![("score", Value::Null)]);
+            let result = map.remove_optional_float("score").unwrap();
+            assert_eq!(result, None);
+        }
+
+        // -- Integer tests --
+
+        #[test]
+        fn remove_integer_u64_success() {
+            let mut map = owned_map_with(vec![("age", Value::U64(42))]);
+            let result: u64 = map.remove_integer("age").unwrap();
+            assert_eq!(result, 42);
+        }
+
+        #[test]
+        fn remove_integer_i32_success() {
+            let mut map = owned_map_with(vec![("temp", Value::I32(-10))]);
+            let result: i32 = map.remove_integer("temp").unwrap();
+            assert_eq!(result, -10);
+        }
+
+        #[test]
+        fn remove_integer_missing_key_errors() {
+            let mut map: BTreeMap<String, Value> = BTreeMap::new();
+            let result: Result<u64, Error> = map.remove_integer("age");
+            assert!(result.is_err());
+        }
+
+        #[test]
+        fn remove_optional_integer_returns_some() {
+            let mut map = owned_map_with(vec![("count", Value::U32(7))]);
+            let result: Option<u32> = map.remove_optional_integer("count").unwrap();
+            assert_eq!(result, Some(7));
+        }
+
+        #[test]
+        fn remove_optional_integer_returns_none_for_missing() {
+            let mut map: BTreeMap<String, Value> = BTreeMap::new();
+            let result: Option<u32> = map.remove_optional_integer("count").unwrap();
+            assert_eq!(result, None);
+        }
+
+        #[test]
+        fn remove_optional_integer_returns_none_for_null() {
+            let mut map = owned_map_with(vec![("count", Value::Null)]);
+            let result: Option<u32> = map.remove_optional_integer("count").unwrap();
+            assert_eq!(result, None);
+        }
+
+        // -- Bool tests --
+
+        #[test]
+        fn remove_bool_success() {
+            let mut map = owned_map_with(vec![("active", Value::Bool(true))]);
+            let result = map.remove_bool("active").unwrap();
+            assert!(result);
+        }
+
+        #[test]
+        fn remove_bool_missing_key_errors() {
+            let mut map: BTreeMap<String, Value> = BTreeMap::new();
+            assert!(map.remove_bool("active").is_err());
+        }
+
+        #[test]
+        fn remove_optional_bool_returns_some() {
+            let mut map = owned_map_with(vec![("flag", Value::Bool(false))]);
+            let result = map.remove_optional_bool("flag").unwrap();
+            assert_eq!(result, Some(false));
+        }
+
+        #[test]
+        fn remove_optional_bool_returns_none_for_missing() {
+            let mut map: BTreeMap<String, Value> = BTreeMap::new();
+            let result = map.remove_optional_bool("flag").unwrap();
+            assert_eq!(result, None);
+        }
+
+        #[test]
+        fn remove_optional_bool_returns_none_for_null() {
+            let mut map = owned_map_with(vec![("flag", Value::Null)]);
+            let result = map.remove_optional_bool("flag").unwrap();
+            assert_eq!(result, None);
+        }
+
+        // -- Hash256 bytes tests --
+
+        #[test]
+        fn remove_hash256_bytes_success() {
+            let hash = [1u8; 32];
+            let mut map = owned_map_with(vec![("hash", Value::Bytes32(hash))]);
+            let result = map.remove_hash256_bytes("hash").unwrap();
+            assert_eq!(result, hash);
+        }
+
+        #[test]
+        fn remove_hash256_bytes_missing_key_errors() {
+            let mut map: BTreeMap<String, Value> = BTreeMap::new();
+            assert!(map.remove_hash256_bytes("hash").is_err());
+        }
+
+        #[test]
+        fn remove_optional_hash256_bytes_returns_some() {
+            let hash = [2u8; 32];
+            let mut map = owned_map_with(vec![("hash", Value::Bytes32(hash))]);
+            let result = map.remove_optional_hash256_bytes("hash").unwrap();
+            assert_eq!(result, Some(hash));
+        }
+
+        #[test]
+        fn remove_optional_hash256_bytes_returns_none_for_missing() {
+            let mut map: BTreeMap<String, Value> = BTreeMap::new();
+            let result = map.remove_optional_hash256_bytes("hash").unwrap();
+            assert_eq!(result, None);
+        }
+
+        #[test]
+        fn remove_optional_hash256_bytes_returns_none_for_null() {
+            let mut map = owned_map_with(vec![("hash", Value::Null)]);
+            let result = map.remove_optional_hash256_bytes("hash").unwrap();
+            assert_eq!(result, None);
+        }
+
+        // -- Bytes tests --
+
+        #[test]
+        fn remove_bytes_success() {
+            let bytes = vec![1, 2, 3, 4];
+            let mut map = owned_map_with(vec![("data", Value::Bytes(bytes.clone()))]);
+            let result = map.remove_bytes("data").unwrap();
+            assert_eq!(result, bytes);
+        }
+
+        #[test]
+        fn remove_bytes_missing_key_errors() {
+            let mut map: BTreeMap<String, Value> = BTreeMap::new();
+            assert!(map.remove_bytes("data").is_err());
+        }
+
+        #[test]
+        fn remove_optional_bytes_returns_some() {
+            let bytes = vec![5, 6, 7];
+            let mut map = owned_map_with(vec![("data", Value::Bytes(bytes.clone()))]);
+            let result = map.remove_optional_bytes("data").unwrap();
+            assert_eq!(result, Some(bytes));
+        }
+
+        #[test]
+        fn remove_optional_bytes_returns_none_for_missing() {
+            let mut map: BTreeMap<String, Value> = BTreeMap::new();
+            let result = map.remove_optional_bytes("data").unwrap();
+            assert_eq!(result, None);
+        }
+
+        #[test]
+        fn remove_optional_bytes_returns_none_for_null() {
+            let mut map = owned_map_with(vec![("data", Value::Null)]);
+            let result = map.remove_optional_bytes("data").unwrap();
+            assert_eq!(result, None);
+        }
+
+        // -- Identifier tests --
+
+        #[test]
+        fn remove_identifier_success() {
+            let id_bytes = [3u8; 32];
+            let mut map = owned_map_with(vec![("id", Value::Identifier(id_bytes))]);
+            let result = map.remove_identifier("id").unwrap();
+            assert_eq!(result, Identifier::from(id_bytes));
+        }
+
+        #[test]
+        fn remove_identifier_missing_key_errors() {
+            let mut map: BTreeMap<String, Value> = BTreeMap::new();
+            assert!(map.remove_identifier("id").is_err());
+        }
+
+        #[test]
+        fn remove_optional_identifier_returns_some() {
+            let id_bytes = [4u8; 32];
+            let mut map = owned_map_with(vec![("id", Value::Identifier(id_bytes))]);
+            let result = map.remove_optional_identifier("id").unwrap();
+            assert_eq!(result, Some(Identifier::from(id_bytes)));
+        }
+
+        #[test]
+        fn remove_optional_identifier_returns_none_for_missing() {
+            let mut map: BTreeMap<String, Value> = BTreeMap::new();
+            let result = map.remove_optional_identifier("id").unwrap();
+            assert_eq!(result, None);
+        }
+
+        #[test]
+        fn remove_optional_identifier_returns_none_for_null() {
+            let mut map = owned_map_with(vec![("id", Value::Null)]);
+            let result = map.remove_optional_identifier("id").unwrap();
+            assert_eq!(result, None);
+        }
+
+        // -- BinaryData tests --
+
+        #[test]
+        fn remove_binary_data_success() {
+            let bytes = vec![10, 20, 30];
+            let mut map = owned_map_with(vec![("bin", Value::Bytes(bytes.clone()))]);
+            let result = map.remove_binary_data("bin").unwrap();
+            assert_eq!(result, BinaryData(bytes));
+        }
+
+        #[test]
+        fn remove_binary_data_missing_key_errors() {
+            let mut map: BTreeMap<String, Value> = BTreeMap::new();
+            assert!(map.remove_binary_data("bin").is_err());
+        }
+
+        #[test]
+        fn remove_optional_binary_data_returns_some() {
+            let bytes = vec![40, 50];
+            let mut map = owned_map_with(vec![("bin", Value::Bytes(bytes.clone()))]);
+            let result = map.remove_optional_binary_data("bin").unwrap();
+            assert_eq!(result, Some(BinaryData(bytes)));
+        }
+
+        #[test]
+        fn remove_optional_binary_data_returns_none_for_missing() {
+            let mut map: BTreeMap<String, Value> = BTreeMap::new();
+            let result = map.remove_optional_binary_data("bin").unwrap();
+            assert_eq!(result, None);
+        }
+
+        #[test]
+        fn remove_optional_binary_data_returns_none_for_null() {
+            let mut map = owned_map_with(vec![("bin", Value::Null)]);
+            let result = map.remove_optional_binary_data("bin").unwrap();
+            assert_eq!(result, None);
+        }
+
+        // -- Bytes32 tests --
+
+        #[test]
+        fn remove_bytes_32_success() {
+            let b32 = [5u8; 32];
+            let mut map = owned_map_with(vec![("b32", Value::Bytes32(b32))]);
+            let result = map.remove_bytes_32("b32").unwrap();
+            assert_eq!(result, Bytes32(b32));
+        }
+
+        #[test]
+        fn remove_bytes_32_missing_key_errors() {
+            let mut map: BTreeMap<String, Value> = BTreeMap::new();
+            assert!(map.remove_bytes_32("b32").is_err());
+        }
+
+        #[test]
+        fn remove_optional_bytes_32_returns_some() {
+            let b32 = [6u8; 32];
+            let mut map = owned_map_with(vec![("b32", Value::Bytes32(b32))]);
+            let result = map.remove_optional_bytes_32("b32").unwrap();
+            assert_eq!(result, Some(Bytes32(b32)));
+        }
+
+        #[test]
+        fn remove_optional_bytes_32_returns_none_for_missing() {
+            let mut map: BTreeMap<String, Value> = BTreeMap::new();
+            let result = map.remove_optional_bytes_32("b32").unwrap();
+            assert_eq!(result, None);
+        }
+
+        #[test]
+        fn remove_optional_bytes_32_returns_none_for_null() {
+            let mut map = owned_map_with(vec![("b32", Value::Null)]);
+            let result = map.remove_optional_bytes_32("b32").unwrap();
+            assert_eq!(result, None);
+        }
+
+        // -- Bytes20 tests --
+
+        #[test]
+        fn remove_bytes_20_success() {
+            let b20 = [7u8; 20];
+            let mut map = owned_map_with(vec![("b20", Value::Bytes20(b20))]);
+            let result = map.remove_bytes_20("b20").unwrap();
+            assert_eq!(result, Bytes20(b20));
+        }
+
+        #[test]
+        fn remove_bytes_20_missing_key_errors() {
+            let mut map: BTreeMap<String, Value> = BTreeMap::new();
+            assert!(map.remove_bytes_20("b20").is_err());
+        }
+
+        #[test]
+        fn remove_optional_bytes_20_returns_some() {
+            let b20 = [8u8; 20];
+            let mut map = owned_map_with(vec![("b20", Value::Bytes20(b20))]);
+            let result = map.remove_optional_bytes_20("b20").unwrap();
+            assert_eq!(result, Some(Bytes20(b20)));
+        }
+
+        #[test]
+        fn remove_optional_bytes_20_returns_none_for_missing() {
+            let mut map: BTreeMap<String, Value> = BTreeMap::new();
+            let result = map.remove_optional_bytes_20("b20").unwrap();
+            assert_eq!(result, None);
+        }
+
+        #[test]
+        fn remove_optional_bytes_20_returns_none_for_null() {
+            let mut map = owned_map_with(vec![("b20", Value::Null)]);
+            let result = map.remove_optional_bytes_20("b20").unwrap();
+            assert_eq!(result, None);
+        }
+
+        // -- Hash256s (array of hashes) tests --
+
+        #[test]
+        fn remove_hash256s_success() {
+            let h1 = [1u8; 32];
+            let h2 = [2u8; 32];
+            let mut map = owned_map_with(vec![(
+                "hashes",
+                Value::Array(vec![Value::Bytes32(h1), Value::Bytes32(h2)]),
+            )]);
+            let result = map.remove_hash256s("hashes").unwrap();
+            assert_eq!(result, vec![h1, h2]);
+        }
+
+        #[test]
+        fn remove_hash256s_missing_key_errors() {
+            let mut map: BTreeMap<String, Value> = BTreeMap::new();
+            assert!(map.remove_hash256s("hashes").is_err());
+        }
+
+        #[test]
+        fn remove_optional_hash256s_returns_some() {
+            let h1 = [3u8; 32];
+            let mut map = owned_map_with(vec![("hashes", Value::Array(vec![Value::Bytes32(h1)]))]);
+            let result = map.remove_optional_hash256s("hashes").unwrap();
+            assert_eq!(result, Some(vec![h1]));
+        }
+
+        #[test]
+        fn remove_optional_hash256s_returns_none_for_missing() {
+            let mut map: BTreeMap<String, Value> = BTreeMap::new();
+            let result = map.remove_optional_hash256s("hashes").unwrap();
+            assert_eq!(result, None);
+        }
+
+        #[test]
+        fn remove_optional_hash256s_returns_none_for_null() {
+            let mut map = owned_map_with(vec![("hashes", Value::Null)]);
+            let result = map.remove_optional_hash256s("hashes").unwrap();
+            assert_eq!(result, None);
+        }
+
+        #[test]
+        fn remove_optional_hash256s_returns_none_for_non_array() {
+            let mut map = owned_map_with(vec![("hashes", Value::Text("not_array".to_string()))]);
+            let result = map.remove_optional_hash256s("hashes").unwrap();
+            assert_eq!(result, None);
+        }
+
+        // -- Identifiers (array) tests --
+
+        #[test]
+        fn remove_identifiers_success() {
+            let id1 = [10u8; 32];
+            let id2 = [20u8; 32];
+            let mut map = owned_map_with(vec![(
+                "ids",
+                Value::Array(vec![Value::Identifier(id1), Value::Identifier(id2)]),
+            )]);
+            let result = map.remove_identifiers("ids").unwrap();
+            assert_eq!(result, vec![Identifier::from(id1), Identifier::from(id2)]);
+        }
+
+        #[test]
+        fn remove_identifiers_missing_key_errors() {
+            let mut map: BTreeMap<String, Value> = BTreeMap::new();
+            assert!(map.remove_identifiers("ids").is_err());
+        }
+
+        #[test]
+        fn remove_optional_identifiers_returns_some() {
+            let id = [30u8; 32];
+            let mut map = owned_map_with(vec![("ids", Value::Array(vec![Value::Identifier(id)]))]);
+            let result = map.remove_optional_identifiers("ids").unwrap();
+            assert_eq!(result, Some(vec![Identifier::from(id)]));
+        }
+
+        #[test]
+        fn remove_optional_identifiers_returns_none_for_missing() {
+            let mut map: BTreeMap<String, Value> = BTreeMap::new();
+            let result = map.remove_optional_identifiers("ids").unwrap();
+            assert_eq!(result, None);
+        }
+
+        #[test]
+        fn remove_optional_identifiers_returns_none_for_null() {
+            let mut map = owned_map_with(vec![("ids", Value::Null)]);
+            let result = map.remove_optional_identifiers("ids").unwrap();
+            assert_eq!(result, None);
+        }
+
+        #[test]
+        fn remove_optional_identifiers_returns_none_for_non_array() {
+            let mut map = owned_map_with(vec![("ids", Value::U64(999))]);
+            let result = map.remove_optional_identifiers("ids").unwrap();
+            assert_eq!(result, None);
+        }
+
+        // -- Map as BTreeMap tests --
+
+        #[test]
+        fn remove_map_as_btree_map_success() {
+            let inner_map = vec![
+                (Value::Text("a".to_string()), Value::U64(1)),
+                (Value::Text("b".to_string()), Value::U64(2)),
+            ];
+            let mut map = owned_map_with(vec![("m", Value::Map(inner_map))]);
+            let result: BTreeMap<String, u64> = map.remove_map_as_btree_map("m").unwrap();
+            assert_eq!(result.get("a"), Some(&1u64));
+            assert_eq!(result.get("b"), Some(&2u64));
+        }
+
+        #[test]
+        fn remove_map_as_btree_map_missing_key_errors() {
+            let mut map: BTreeMap<String, Value> = BTreeMap::new();
+            let result: Result<BTreeMap<String, String>, Error> = map.remove_map_as_btree_map("m");
+            assert!(result.is_err());
+        }
+
+        #[test]
+        fn remove_optional_map_as_btree_map_returns_some() {
+            let inner_map = vec![(Value::Text("x".to_string()), Value::Text("y".to_string()))];
+            let mut map = owned_map_with(vec![("m", Value::Map(inner_map))]);
+            let result: Option<BTreeMap<String, String>> =
+                map.remove_optional_map_as_btree_map("m").unwrap();
+            assert!(result.is_some());
+            let inner = result.unwrap();
+            assert_eq!(inner.get("x"), Some(&"y".to_string()));
+        }
+
+        #[test]
+        fn remove_optional_map_as_btree_map_returns_none_for_missing() {
+            let mut map: BTreeMap<String, Value> = BTreeMap::new();
+            let result: Option<BTreeMap<String, String>> =
+                map.remove_optional_map_as_btree_map("m").unwrap();
+            assert_eq!(result, None);
+        }
+
+        #[test]
+        fn remove_optional_map_as_btree_map_returns_none_for_null() {
+            let mut map = owned_map_with(vec![("m", Value::Null)]);
+            let result: Option<BTreeMap<String, String>> =
+                map.remove_optional_map_as_btree_map("m").unwrap();
+            assert_eq!(result, None);
+        }
+
+        // -- Map keep values as platform value tests --
+
+        #[test]
+        fn remove_map_as_btree_map_keep_values_success() {
+            let inner_map = vec![
+                (Value::Text("k1".to_string()), Value::Bool(true)),
+                (Value::Text("k2".to_string()), Value::Float(1.5)),
+            ];
+            let mut map = owned_map_with(vec![("m", Value::Map(inner_map))]);
+            let result: BTreeMap<String, Value> = map
+                .remove_map_as_btree_map_keep_values_as_platform_value::<String, Value>("m")
+                .unwrap();
+            assert_eq!(result.get("k1"), Some(&Value::Bool(true)));
+            assert_eq!(result.get("k2"), Some(&Value::Float(1.5)));
+        }
+
+        #[test]
+        fn remove_map_as_btree_map_keep_values_missing_key_errors() {
+            let mut map: BTreeMap<String, Value> = BTreeMap::new();
+            let result: Result<BTreeMap<String, Value>, Error> =
+                map.remove_map_as_btree_map_keep_values_as_platform_value::<String, Value>("m");
+            assert!(result.is_err());
+        }
+
+        #[test]
+        fn remove_optional_map_keep_values_returns_none_for_null() {
+            let mut map = owned_map_with(vec![("m", Value::Null)]);
+            let result: Option<BTreeMap<String, Value>> = map
+                .remove_optional_map_as_btree_map_keep_values_as_platform_value("m")
+                .unwrap();
+            assert_eq!(result, None);
+        }
+
+        #[test]
+        fn remove_optional_map_keep_values_returns_none_for_missing() {
+            let mut map: BTreeMap<String, Value> = BTreeMap::new();
+            let result: Option<BTreeMap<String, Value>> = map
+                .remove_optional_map_as_btree_map_keep_values_as_platform_value("m")
+                .unwrap();
+            assert_eq!(result, None);
+        }
+
+        // -- Removal actually removes the key from the map --
+
+        #[test]
+        fn removal_removes_key_from_map() {
+            let mut map = owned_map_with(vec![
+                ("a", Value::Text("hello".to_string())),
+                ("b", Value::U64(42)),
+            ]);
+            assert_eq!(map.len(), 2);
+            let _ = map.remove_string("a");
+            assert_eq!(map.len(), 1);
+            assert!(!map.contains_key("a"));
+            assert!(map.contains_key("b"));
+        }
+
+        // -- Integer type edge cases --
+
+        #[test]
+        fn remove_integer_u8() {
+            let mut map = owned_map_with(vec![("x", Value::U8(255))]);
+            let result: u8 = map.remove_integer("x").unwrap();
+            assert_eq!(result, 255);
+        }
+
+        #[test]
+        fn remove_integer_i16() {
+            let mut map = owned_map_with(vec![("x", Value::I16(-100))]);
+            let result: i16 = map.remove_integer("x").unwrap();
+            assert_eq!(result, -100);
+        }
+
+        #[test]
+        fn remove_integer_u128() {
+            let mut map = owned_map_with(vec![("x", Value::U128(u128::MAX))]);
+            let result: u128 = map.remove_integer("x").unwrap();
+            assert_eq!(result, u128::MAX);
+        }
+
+        #[test]
+        fn remove_integer_i128() {
+            let mut map = owned_map_with(vec![("x", Value::I128(i128::MIN))]);
+            let result: i128 = map.remove_integer("x").unwrap();
+            assert_eq!(result, i128::MIN);
+        }
+
+        // -- Tuple tests --
+
+        #[test]
+        fn remove_tuple_success() {
+            let mut map = owned_map_with(vec![(
+                "pair",
+                Value::Array(vec![
+                    Value::Text("key".to_string()),
+                    Value::Text("value".to_string()),
+                ]),
+            )]);
+            let result: (String, String) = map.remove_tuple("pair").unwrap();
+            assert_eq!(result, ("key".to_string(), "value".to_string()));
+        }
+
+        #[test]
+        fn remove_tuple_missing_key_errors() {
+            let mut map: BTreeMap<String, Value> = BTreeMap::new();
+            let result: Result<(String, String), Error> = map.remove_tuple("pair");
+            assert!(result.is_err());
+        }
+
+        #[test]
+        fn remove_optional_tuple_returns_some() {
+            let mut map = owned_map_with(vec![(
+                "pair",
+                Value::Array(vec![
+                    Value::Text("a".to_string()),
+                    Value::Text("b".to_string()),
+                ]),
+            )]);
+            let result: Option<(String, String)> = map.remove_optional_tuple("pair").unwrap();
+            assert_eq!(result, Some(("a".to_string(), "b".to_string())));
+        }
+
+        #[test]
+        fn remove_optional_tuple_returns_none_for_missing() {
+            let mut map: BTreeMap<String, Value> = BTreeMap::new();
+            let result: Option<(String, String)> = map.remove_optional_tuple("pair").unwrap();
+            assert_eq!(result, None);
+        }
+
+        #[test]
+        fn remove_optional_tuple_returns_none_for_null() {
+            let mut map = owned_map_with(vec![("pair", Value::Null)]);
+            let result: Option<(String, String)> = map.remove_optional_tuple("pair").unwrap();
+            assert_eq!(result, None);
+        }
+
+        #[test]
+        fn remove_optional_tuple_wrong_length_errors() {
+            let mut map = owned_map_with(vec![(
+                "pair",
+                Value::Array(vec![Value::Text("only_one".to_string())]),
+            )]);
+            let result: Result<Option<(String, String)>, Error> = map.remove_optional_tuple("pair");
+            assert!(result.is_err());
+        }
+
+        #[test]
+        fn remove_optional_tuple_non_array_errors() {
+            let mut map = owned_map_with(vec![("pair", Value::Text("not_an_array".to_string()))]);
+            let result: Result<Option<(String, String)>, Error> = map.remove_optional_tuple("pair");
+            assert!(result.is_err());
+        }
+
+        #[test]
+        fn remove_optional_tuple_three_elements_errors() {
+            let mut map = owned_map_with(vec![(
+                "pair",
+                Value::Array(vec![
+                    Value::Text("a".to_string()),
+                    Value::Text("b".to_string()),
+                    Value::Text("c".to_string()),
+                ]),
+            )]);
+            let result: Result<Option<(String, String)>, Error> = map.remove_optional_tuple("pair");
+            assert!(result.is_err());
+        }
+
+        #[test]
+        fn remove_optional_tuple_empty_array_errors() {
+            let mut map = owned_map_with(vec![("pair", Value::Array(vec![]))]);
+            let result: Result<Option<(String, String)>, Error> = map.remove_optional_tuple("pair");
+            assert!(result.is_err());
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // Tests for BTreeMap<String, &Value> (ref impl)
+    // -----------------------------------------------------------------------
+
+    mod ref_map {
+        use super::*;
+
+        // -- String tests --
+
+        #[test]
+        fn remove_string_success() {
+            let source = owned_map_with(vec![("name", Value::Text("alice".to_string()))]);
+            let mut map = ref_map_from(&source);
+            let result = map.remove_string("name").unwrap();
+            assert_eq!(result, "alice");
+        }
+
+        #[test]
+        fn remove_string_missing_key_errors() {
+            let mut map: BTreeMap<String, &Value> = BTreeMap::new();
+            assert!(map.remove_string("name").is_err());
+        }
+
+        #[test]
+        fn remove_optional_string_returns_some() {
+            let source = owned_map_with(vec![("name", Value::Text("bob".to_string()))]);
+            let mut map = ref_map_from(&source);
+            let result = map.remove_optional_string("name").unwrap();
+            assert_eq!(result, Some("bob".to_string()));
+        }
+
+        #[test]
+        fn remove_optional_string_returns_none_for_missing() {
+            let mut map: BTreeMap<String, &Value> = BTreeMap::new();
+            let result = map.remove_optional_string("name").unwrap();
+            assert_eq!(result, None);
+        }
+
+        #[test]
+        fn remove_optional_string_returns_none_for_null() {
+            let source = owned_map_with(vec![("name", Value::Null)]);
+            let mut map = ref_map_from(&source);
+            let result = map.remove_optional_string("name").unwrap();
+            assert_eq!(result, None);
+        }
+
+        // -- Float tests --
+
+        #[test]
+        fn remove_float_success() {
+            let source = owned_map_with(vec![("f", Value::Float(2.5))]);
+            let mut map = ref_map_from(&source);
+            let result = map.remove_float("f").unwrap();
+            assert!((result - 2.5).abs() < f64::EPSILON);
+        }
+
+        #[test]
+        fn remove_float_missing_key_errors() {
+            let mut map: BTreeMap<String, &Value> = BTreeMap::new();
+            assert!(map.remove_float("f").is_err());
+        }
+
+        #[test]
+        fn remove_optional_float_returns_none_for_null() {
+            let source = owned_map_with(vec![("f", Value::Null)]);
+            let mut map = ref_map_from(&source);
+            let result = map.remove_optional_float("f").unwrap();
+            assert_eq!(result, None);
+        }
+
+        // -- Integer tests --
+
+        #[test]
+        fn remove_integer_success() {
+            let source = owned_map_with(vec![("num", Value::U64(99))]);
+            let mut map = ref_map_from(&source);
+            let result: u64 = map.remove_integer("num").unwrap();
+            assert_eq!(result, 99);
+        }
+
+        #[test]
+        fn remove_integer_missing_key_errors() {
+            let mut map: BTreeMap<String, &Value> = BTreeMap::new();
+            let result: Result<u64, Error> = map.remove_integer("num");
+            assert!(result.is_err());
+        }
+
+        #[test]
+        fn remove_optional_integer_returns_none_for_null() {
+            let source = owned_map_with(vec![("num", Value::Null)]);
+            let mut map = ref_map_from(&source);
+            let result: Option<u64> = map.remove_optional_integer("num").unwrap();
+            assert_eq!(result, None);
+        }
+
+        // -- Bool tests --
+
+        #[test]
+        fn remove_bool_success() {
+            let source = owned_map_with(vec![("flag", Value::Bool(true))]);
+            let mut map = ref_map_from(&source);
+            let result = map.remove_bool("flag").unwrap();
+            assert!(result);
+        }
+
+        #[test]
+        fn remove_optional_bool_returns_none_for_null() {
+            let source = owned_map_with(vec![("flag", Value::Null)]);
+            let mut map = ref_map_from(&source);
+            let result = map.remove_optional_bool("flag").unwrap();
+            assert_eq!(result, None);
+        }
+
+        // -- Hash256 tests --
+
+        #[test]
+        fn remove_hash256_bytes_success() {
+            let hash = [9u8; 32];
+            let source = owned_map_with(vec![("h", Value::Bytes32(hash))]);
+            let mut map = ref_map_from(&source);
+            let result = map.remove_hash256_bytes("h").unwrap();
+            assert_eq!(result, hash);
+        }
+
+        #[test]
+        fn remove_optional_hash256_bytes_returns_none_for_null() {
+            let source = owned_map_with(vec![("h", Value::Null)]);
+            let mut map = ref_map_from(&source);
+            let result = map.remove_optional_hash256_bytes("h").unwrap();
+            assert_eq!(result, None);
+        }
+
+        // -- Bytes tests --
+
+        #[test]
+        fn remove_bytes_success() {
+            let bytes = vec![1, 2, 3];
+            let source = owned_map_with(vec![("b", Value::Bytes(bytes.clone()))]);
+            let mut map = ref_map_from(&source);
+            let result = map.remove_bytes("b").unwrap();
+            assert_eq!(result, bytes);
+        }
+
+        #[test]
+        fn remove_optional_bytes_returns_none_for_null() {
+            let source = owned_map_with(vec![("b", Value::Null)]);
+            let mut map = ref_map_from(&source);
+            let result = map.remove_optional_bytes("b").unwrap();
+            assert_eq!(result, None);
+        }
+
+        // -- Identifier tests --
+
+        #[test]
+        fn remove_identifier_success() {
+            let id_bytes = [11u8; 32];
+            let source = owned_map_with(vec![("id", Value::Identifier(id_bytes))]);
+            let mut map = ref_map_from(&source);
+            let result = map.remove_identifier("id").unwrap();
+            assert_eq!(result, Identifier::from(id_bytes));
+        }
+
+        #[test]
+        fn remove_optional_identifier_returns_none_for_null() {
+            let source = owned_map_with(vec![("id", Value::Null)]);
+            let mut map = ref_map_from(&source);
+            let result = map.remove_optional_identifier("id").unwrap();
+            assert_eq!(result, None);
+        }
+
+        // -- BinaryData tests --
+
+        #[test]
+        fn remove_binary_data_success() {
+            let bytes = vec![100, 200];
+            let source = owned_map_with(vec![("bd", Value::Bytes(bytes.clone()))]);
+            let mut map = ref_map_from(&source);
+            let result = map.remove_binary_data("bd").unwrap();
+            assert_eq!(result, BinaryData(bytes));
+        }
+
+        #[test]
+        fn remove_optional_binary_data_returns_none_for_null() {
+            let source = owned_map_with(vec![("bd", Value::Null)]);
+            let mut map = ref_map_from(&source);
+            let result = map.remove_optional_binary_data("bd").unwrap();
+            assert_eq!(result, None);
+        }
+
+        // -- Bytes32 tests --
+
+        #[test]
+        fn remove_bytes_32_success() {
+            let b32 = [12u8; 32];
+            let source = owned_map_with(vec![("b32", Value::Bytes32(b32))]);
+            let mut map = ref_map_from(&source);
+            let result = map.remove_bytes_32("b32").unwrap();
+            assert_eq!(result, Bytes32(b32));
+        }
+
+        #[test]
+        fn remove_optional_bytes_32_returns_none_for_null() {
+            let source = owned_map_with(vec![("b32", Value::Null)]);
+            let mut map = ref_map_from(&source);
+            let result = map.remove_optional_bytes_32("b32").unwrap();
+            assert_eq!(result, None);
+        }
+
+        // -- Bytes20 tests --
+
+        #[test]
+        fn remove_bytes_20_success() {
+            let b20 = [13u8; 20];
+            let source = owned_map_with(vec![("b20", Value::Bytes20(b20))]);
+            let mut map = ref_map_from(&source);
+            let result = map.remove_bytes_20("b20").unwrap();
+            assert_eq!(result, Bytes20(b20));
+        }
+
+        #[test]
+        fn remove_optional_bytes_20_returns_none_for_null() {
+            let source = owned_map_with(vec![("b20", Value::Null)]);
+            let mut map = ref_map_from(&source);
+            let result = map.remove_optional_bytes_20("b20").unwrap();
+            assert_eq!(result, None);
+        }
+
+        // -- Hash256s (array of hashes) tests --
+
+        #[test]
+        fn remove_hash256s_success() {
+            let h1 = [14u8; 32];
+            let h2 = [15u8; 32];
+            let source = owned_map_with(vec![(
+                "hashes",
+                Value::Array(vec![Value::Bytes32(h1), Value::Bytes32(h2)]),
+            )]);
+            let mut map = ref_map_from(&source);
+            let result = map.remove_hash256s("hashes").unwrap();
+            assert_eq!(result, vec![h1, h2]);
+        }
+
+        #[test]
+        fn remove_optional_hash256s_returns_none_for_null() {
+            let source = owned_map_with(vec![("hashes", Value::Null)]);
+            let mut map = ref_map_from(&source);
+            let result = map.remove_optional_hash256s("hashes").unwrap();
+            assert_eq!(result, None);
+        }
+
+        #[test]
+        fn remove_optional_hash256s_returns_none_for_non_array() {
+            let source = owned_map_with(vec![("hashes", Value::U64(42))]);
+            let mut map = ref_map_from(&source);
+            let result = map.remove_optional_hash256s("hashes").unwrap();
+            assert_eq!(result, None);
+        }
+
+        // -- Identifiers (array) tests --
+
+        #[test]
+        fn remove_identifiers_success() {
+            let id1 = [16u8; 32];
+            let source = owned_map_with(vec![("ids", Value::Array(vec![Value::Identifier(id1)]))]);
+            let mut map = ref_map_from(&source);
+            let result = map.remove_identifiers("ids").unwrap();
+            assert_eq!(result, vec![Identifier::from(id1)]);
+        }
+
+        #[test]
+        fn remove_optional_identifiers_returns_none_for_null() {
+            let source = owned_map_with(vec![("ids", Value::Null)]);
+            let mut map = ref_map_from(&source);
+            let result = map.remove_optional_identifiers("ids").unwrap();
+            assert_eq!(result, None);
+        }
+
+        #[test]
+        fn remove_optional_identifiers_returns_none_for_non_array() {
+            let source = owned_map_with(vec![("ids", Value::Bool(false))]);
+            let mut map = ref_map_from(&source);
+            let result = map.remove_optional_identifiers("ids").unwrap();
+            assert_eq!(result, None);
+        }
+
+        // -- Map as BTreeMap tests --
+
+        #[test]
+        fn remove_optional_map_as_btree_map_returns_none_for_null() {
+            let source = owned_map_with(vec![("m", Value::Null)]);
+            let mut map = ref_map_from(&source);
+            let result: Option<BTreeMap<String, String>> =
+                map.remove_optional_map_as_btree_map("m").unwrap();
+            assert_eq!(result, None);
+        }
+
+        #[test]
+        fn remove_optional_map_as_btree_map_returns_none_for_missing() {
+            let mut map: BTreeMap<String, &Value> = BTreeMap::new();
+            let result: Option<BTreeMap<String, String>> =
+                map.remove_optional_map_as_btree_map("m").unwrap();
+            assert_eq!(result, None);
+        }
+
+        // -- Map keep values tests --
+
+        #[test]
+        fn remove_optional_map_keep_values_returns_none_for_null() {
+            let source = owned_map_with(vec![("m", Value::Null)]);
+            let mut map = ref_map_from(&source);
+            let result: Option<BTreeMap<String, Value>> = map
+                .remove_optional_map_as_btree_map_keep_values_as_platform_value("m")
+                .unwrap();
+            assert_eq!(result, None);
+        }
+
+        // -- Ref map removal semantics --
+
+        #[test]
+        fn ref_removal_removes_key_from_map() {
+            let source = owned_map_with(vec![("a", Value::Bool(true)), ("b", Value::Bool(false))]);
+            let mut map = ref_map_from(&source);
+            assert_eq!(map.len(), 2);
+            let _ = map.remove_bool("a");
+            assert_eq!(map.len(), 1);
+            assert!(!map.contains_key("a"));
+        }
     }
 }


### PR DESCRIPTION
## Issue being fixed or feature implemented

Improve test coverage for `rs-platform-value` btreemap extension modules which had very low coverage:
- `btreemap_removal_extensions.rs`: 20.1% coverage (414 uncovered lines)
- `btreemap_path_extensions.rs`: 9.2% coverage (347 uncovered lines)

## What was done?

Added comprehensive `#[cfg(test)] mod tests` to both files:

**btreemap_removal_extensions.rs** (~130 tests):
- Tests for both `BTreeMap<String, Value>` (owned) and `BTreeMap<String, &Value>` (ref) impls
- Covers all public methods: `remove_string`, `remove_float`, `remove_integer`, `remove_bool`, `remove_hash256_bytes`, `remove_bytes`, `remove_identifier`, `remove_binary_data`, `remove_bytes_32`, `remove_bytes_20`, `remove_hash256s`, `remove_identifiers`, `remove_map_as_btree_map`, `remove_map_as_btree_map_keep_values_as_platform_value`, and `remove_tuple`
- Each method tested with: happy path, missing key error, null value handling, and type-specific edge cases
- Tests tuple operations with wrong length arrays, non-array values, and empty arrays
- Fixes off-by-one bug in `remove_optional_tuple` (`arr.remove(1)` after `arr.remove(0)` shifted the array)

**btreemap_path_extensions.rs** (~80 tests):
- Tests `get_at_path`, `get_optional_at_path` with single-level, nested, and deeply nested paths
- Covers all typed getters: string, str, float, integer, bool, identifier, hash256, bytes, identifier_bytes, binary_bytes
- Covers all typed removers: string, float, integer, hash256, identifier
- Tests array and map path accessors: `get_inner_value_array_at_path`, `get_inner_string_array_at_path`, `get_inner_borrowed_str_value_map_at_path`
- Edge cases: empty paths, missing keys at various nesting levels, null values, wrong types
- Tests generic impl works for both `BTreeMap<String, Value>` and `BTreeMap<String, &Value>`

## How Has This Been Tested?

- `cargo fmt -p platform-value` -- passes
- `cargo test -p platform-value` -- all 248 tests pass
- `cargo clippy -p platform-value` -- no warnings in modified files

## Breaking Changes

None.

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [x] I have made corresponding changes to the documentation if needed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed tuple removal logic in map operations to correctly account for index shifts when removing multiple elements sequentially.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->