### PR TITLE
ci: exclude additional boilerplate from code coverage

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -52,6 +52,21 @@ ignore:
   - "packages/rs-platform-version/**"
   # Simple signer — thin test-only wrapper
   - "packages/simple-signer/src/**"
+  # gRPC service handler wrapping Core RPC calls — requires a running Dash
+  # Core node, not unit-testable
+  - "packages/rs-dapi/src/services/core_service.rs"
+  # Proof-verifier boilerplate — response type constructors, conversion impls,
+  # and unproved response handling
+  - "packages/rs-drive-proof-verifier/src/types.rs"
+  - "packages/rs-drive-proof-verifier/src/unproved.rs"
+  # SDK mock infrastructure — test-only scaffolding, not production logic
+  - "packages/rs-sdk/src/mock/**"
+  # Document-type property accessors — pure getter/setter trait implementations,
+  # same category as the state-transition accessors excluded above
+  - "packages/rs-dpp/src/data_contract/document_type/accessors/**"
+  # Core chain type wrappers — masternode entry structs, deserialization
+  # boilerplate, thin type aliases
+  - "packages/rs-dpp/src/core_types/**"
 
 coverage:
   status:


### PR DESCRIPTION
## Issue being fixed or feature implemented

Code coverage metrics are skewed by untestable infrastructure, pure accessor boilerplate, and test-only scaffolding that cannot or should not carry meaningful test coverage.

## What was done?

Added the following paths to the `.codecov.yml` ignore list:

- **`packages/rs-dapi/src/services/core_service.rs`** — gRPC service handler that wraps Core RPC calls; requires a running Dash Core node, so it cannot be unit-tested (0% coverage, 265 lines)
- **`packages/rs-drive-proof-verifier/src/types.rs`** — Response type constructors and conversion boilerplate for proof verification results (13.8% coverage, 193 lines)
- **`packages/rs-drive-proof-verifier/src/unproved.rs`** — Unproved response handling boilerplate (0% coverage, 141 lines)
- **`packages/rs-sdk/src/mock/**`** — Mock infrastructure for SDK testing, not production logic
- **`packages/rs-dpp/src/data_contract/document_type/accessors/**`** — Pure getter/setter trait implementations, same category as the already-excluded state transition accessors (42.6% coverage, 296 lines)
- **`packages/rs-dpp/src/core_types/**`** — Core chain type wrappers (masternode entries etc.) that are mostly deserialization boilerplate (42.6% coverage, 255 lines)

## How Has This Been Tested?

This is a configuration-only change to `.codecov.yml`. The excluded paths were verified to exist in the repository and to match the rationale (boilerplate, untestable infrastructure, or test-only code).

## Breaking Changes

None. This only affects coverage reporting, not any build or runtime behavior.

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [ ] I have made corresponding changes to the documentation if needed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated code coverage configuration to properly track test scaffolding and non-production files. No impact to product functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->