### PR TITLE
test(dpp): improve coverage for cbor canonical, json utils, and document accessors

### DIFF
--- a/packages/rs-dpp/src/data_contract/document_type/accessors/mod.rs
+++ b/packages/rs-dpp/src/data_contract/document_type/accessors/mod.rs
@@ -763,3 +763,449 @@ impl DocumentTypeV1Getters for DocumentTypeMutRef<'_> {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::data_contract::accessors::v0::DataContractV0Getters;
+    use crate::data_contract::document_type::restricted_creation::CreationRestrictionMode;
+    use crate::data_contract::storage_requirements::keys_for_document_type::StorageKeyRequirements;
+    use crate::document::transfer::Transferable;
+    use crate::nft::TradeMode;
+    use crate::tests::fixtures::get_data_contract_fixture;
+    use platform_version::version::PlatformVersion;
+
+    fn get_test_document_type() -> DocumentType {
+        let platform_version = PlatformVersion::latest();
+        let created = get_data_contract_fixture(None, 0, platform_version.protocol_version);
+        let data_contract = created.data_contract_owned();
+        let doc_types = data_contract.document_types();
+        // Use "indexedDocument" because it has the most properties and indices
+        doc_types
+            .get("indexedDocument")
+            .expect("indexedDocument should exist")
+            .clone()
+    }
+
+    // DocumentTypeV0Getters on DocumentType
+
+    #[test]
+    fn name_returns_document_type_name() {
+        let doc_type = get_test_document_type();
+        assert_eq!(doc_type.name(), "indexedDocument");
+    }
+
+    #[test]
+    fn schema_returns_value() {
+        let doc_type = get_test_document_type();
+        let schema = doc_type.schema();
+        // Schema should be a non-null Value
+        assert!(!schema.is_null());
+    }
+
+    #[test]
+    fn schema_owned_returns_value() {
+        let doc_type = get_test_document_type();
+        let schema = doc_type.schema_owned();
+        assert!(!schema.is_null());
+    }
+
+    #[test]
+    fn indexes_returns_indices() {
+        let doc_type = get_test_document_type();
+        let indexes = doc_type.indexes();
+        // indexedDocument has 6 indices defined in the fixture
+        assert_eq!(indexes.len(), 6);
+        assert!(indexes.contains_key("index1"));
+        assert!(indexes.contains_key("index2"));
+    }
+
+    #[test]
+    fn find_contested_index_returns_none_for_normal_type() {
+        let doc_type = get_test_document_type();
+        // The fixture's indexedDocument has no contested index
+        assert!(doc_type.find_contested_index().is_none());
+    }
+
+    #[test]
+    fn index_structure_returns_index_level() {
+        let doc_type = get_test_document_type();
+        let _structure = doc_type.index_structure();
+        // Just ensure it does not panic
+    }
+
+    #[test]
+    fn flattened_properties_contains_expected_fields() {
+        let doc_type = get_test_document_type();
+        let props = doc_type.flattened_properties();
+        assert!(props.contains_key("firstName"));
+        assert!(props.contains_key("lastName"));
+    }
+
+    #[test]
+    fn properties_contains_expected_fields() {
+        let doc_type = get_test_document_type();
+        let props = doc_type.properties();
+        assert!(props.contains_key("firstName"));
+        assert!(props.contains_key("lastName"));
+    }
+
+    #[test]
+    fn required_fields_contains_expected_fields() {
+        let doc_type = get_test_document_type();
+        let required = doc_type.required_fields();
+        assert!(required.contains("firstName"));
+        assert!(required.contains("lastName"));
+    }
+
+    #[test]
+    fn transient_fields_returns_set() {
+        let doc_type = get_test_document_type();
+        let _transient = doc_type.transient_fields();
+        // The fixture does not define transient fields, so it should be empty
+        assert!(doc_type.transient_fields().is_empty());
+    }
+
+    #[test]
+    fn identifier_paths_returns_set() {
+        let doc_type = get_test_document_type();
+        let _paths = doc_type.identifier_paths();
+        // Should not panic
+    }
+
+    #[test]
+    fn binary_paths_returns_set() {
+        let doc_type = get_test_document_type();
+        let _paths = doc_type.binary_paths();
+        // Should not panic
+    }
+
+    #[test]
+    fn documents_keep_history_returns_bool() {
+        let doc_type = get_test_document_type();
+        // Default is false for the fixture
+        let _keep = doc_type.documents_keep_history();
+    }
+
+    #[test]
+    fn documents_mutable_returns_bool() {
+        let doc_type = get_test_document_type();
+        // Default is true for the fixture
+        assert!(doc_type.documents_mutable());
+    }
+
+    #[test]
+    fn documents_can_be_deleted_returns_bool() {
+        let doc_type = get_test_document_type();
+        assert!(doc_type.documents_can_be_deleted());
+    }
+
+    #[test]
+    fn documents_transferable_returns_value() {
+        let doc_type = get_test_document_type();
+        assert_eq!(doc_type.documents_transferable(), Transferable::Never);
+    }
+
+    #[test]
+    fn trade_mode_returns_value() {
+        let doc_type = get_test_document_type();
+        assert_eq!(doc_type.trade_mode(), TradeMode::None);
+    }
+
+    #[test]
+    fn creation_restriction_mode_returns_value() {
+        let doc_type = get_test_document_type();
+        assert_eq!(
+            doc_type.creation_restriction_mode(),
+            CreationRestrictionMode::NoRestrictions
+        );
+    }
+
+    #[test]
+    fn data_contract_id_returns_identifier() {
+        let doc_type = get_test_document_type();
+        let id = doc_type.data_contract_id();
+        // Should be a valid non-zero identifier set by the fixture
+        assert_ne!(id, Identifier::default());
+    }
+
+    #[test]
+    fn requires_identity_encryption_bounded_key_returns_option() {
+        let doc_type = get_test_document_type();
+        // The fixture's indexedDocument does not require encryption key
+        assert_eq!(
+            doc_type.requires_identity_encryption_bounded_key(),
+            None::<StorageKeyRequirements>
+        );
+    }
+
+    #[test]
+    fn requires_identity_decryption_bounded_key_returns_option() {
+        let doc_type = get_test_document_type();
+        assert_eq!(
+            doc_type.requires_identity_decryption_bounded_key(),
+            None::<StorageKeyRequirements>
+        );
+    }
+
+    #[test]
+    fn security_level_requirement_returns_level() {
+        let doc_type = get_test_document_type();
+        let _level = doc_type.security_level_requirement();
+        // Should not panic; default is HIGH
+    }
+
+    // DocumentTypeV0Setters on DocumentType
+
+    #[test]
+    fn set_data_contract_id_updates_id() {
+        let mut doc_type = get_test_document_type();
+        let new_id = Identifier::from([42u8; 32]);
+        doc_type.set_data_contract_id(new_id);
+        assert_eq!(doc_type.data_contract_id(), new_id);
+    }
+
+    // DocumentTypeV0Getters on DocumentTypeRef
+
+    #[test]
+    fn document_type_ref_getters_work() {
+        let doc_type = get_test_document_type();
+        let doc_ref = doc_type.as_ref();
+
+        assert_eq!(doc_ref.name(), "indexedDocument");
+        assert!(!doc_ref.schema().is_null());
+        assert!(!doc_ref.indexes().is_empty());
+        assert!(doc_ref.find_contested_index().is_none());
+        let _structure = doc_ref.index_structure();
+        assert!(!doc_ref.flattened_properties().is_empty());
+        assert!(!doc_ref.properties().is_empty());
+        let _id_paths = doc_ref.identifier_paths();
+        let _bin_paths = doc_ref.binary_paths();
+        assert!(!doc_ref.required_fields().is_empty());
+        assert!(doc_ref.transient_fields().is_empty());
+        assert!(doc_ref.documents_mutable());
+        assert!(doc_ref.documents_can_be_deleted());
+        assert_eq!(doc_ref.documents_transferable(), Transferable::Never);
+        assert_eq!(doc_ref.trade_mode(), TradeMode::None);
+        assert_eq!(
+            doc_ref.creation_restriction_mode(),
+            CreationRestrictionMode::NoRestrictions
+        );
+        assert_ne!(doc_ref.data_contract_id(), Identifier::default());
+        assert_eq!(
+            doc_ref.requires_identity_encryption_bounded_key(),
+            None::<StorageKeyRequirements>
+        );
+        assert_eq!(
+            doc_ref.requires_identity_decryption_bounded_key(),
+            None::<StorageKeyRequirements>
+        );
+        let _sec_level = doc_ref.security_level_requirement();
+    }
+
+    #[test]
+    fn document_type_ref_schema_owned() {
+        let doc_type = get_test_document_type();
+        let doc_ref = doc_type.as_ref();
+        let schema = doc_ref.schema_owned();
+        assert!(!schema.is_null());
+    }
+
+    // DocumentTypeV0MutGetters on DocumentType
+
+    #[test]
+    fn schema_mut_allows_modification() {
+        let mut doc_type = get_test_document_type();
+        let schema = doc_type.schema_mut();
+        // Just verify it returns a mutable reference without panicking
+        assert!(!schema.is_null());
+    }
+
+    // DocumentTypeV0Getters on DocumentTypeMutRef
+
+    #[test]
+    fn document_type_mut_ref_getters_work() {
+        let mut doc_type = get_test_document_type();
+        let doc_mut_ref = doc_type.as_mut_ref();
+
+        assert_eq!(doc_mut_ref.name(), "indexedDocument");
+        assert!(!doc_mut_ref.schema().is_null());
+        assert!(!doc_mut_ref.indexes().is_empty());
+        assert!(doc_mut_ref.find_contested_index().is_none());
+        let _structure = doc_mut_ref.index_structure();
+        assert!(!doc_mut_ref.flattened_properties().is_empty());
+        assert!(!doc_mut_ref.properties().is_empty());
+        let _id_paths = doc_mut_ref.identifier_paths();
+        let _bin_paths = doc_mut_ref.binary_paths();
+        assert!(!doc_mut_ref.required_fields().is_empty());
+        assert!(doc_mut_ref.transient_fields().is_empty());
+        assert!(doc_mut_ref.documents_mutable());
+        assert!(doc_mut_ref.documents_can_be_deleted());
+        assert_eq!(doc_mut_ref.documents_transferable(), Transferable::Never);
+        assert_eq!(doc_mut_ref.trade_mode(), TradeMode::None);
+        assert_eq!(
+            doc_mut_ref.creation_restriction_mode(),
+            CreationRestrictionMode::NoRestrictions
+        );
+        assert_ne!(doc_mut_ref.data_contract_id(), Identifier::default());
+        assert_eq!(
+            doc_mut_ref.requires_identity_encryption_bounded_key(),
+            None::<StorageKeyRequirements>
+        );
+        assert_eq!(
+            doc_mut_ref.requires_identity_decryption_bounded_key(),
+            None::<StorageKeyRequirements>
+        );
+        let _sec_level = doc_mut_ref.security_level_requirement();
+    }
+
+    #[test]
+    fn document_type_mut_ref_schema_owned() {
+        let mut doc_type = get_test_document_type();
+        let doc_mut_ref = doc_type.as_mut_ref();
+        let schema = doc_mut_ref.schema_owned();
+        assert!(!schema.is_null());
+    }
+
+    // DocumentTypeV0Setters on DocumentTypeMutRef
+
+    #[test]
+    fn document_type_mut_ref_set_data_contract_id() {
+        let mut doc_type = get_test_document_type();
+        let mut doc_mut_ref = doc_type.as_mut_ref();
+        let new_id = Identifier::from([99u8; 32]);
+        doc_mut_ref.set_data_contract_id(new_id);
+        assert_eq!(doc_mut_ref.data_contract_id(), new_id);
+    }
+
+    // DocumentTypeV1Getters on DocumentType (V0 variant returns None/defaults)
+
+    #[test]
+    fn v1_getters_on_v0_document_type_return_none() {
+        let doc_type = get_test_document_type();
+        // The fixture creates V0 document types
+        assert!(doc_type.document_creation_token_cost().is_none());
+        assert!(doc_type.document_replacement_token_cost().is_none());
+        assert!(doc_type.document_deletion_token_cost().is_none());
+        assert!(doc_type.document_transfer_token_cost().is_none());
+        assert!(doc_type.document_update_price_token_cost().is_none());
+        assert!(doc_type.document_purchase_token_cost().is_none());
+        assert!(doc_type.all_document_token_costs().is_empty());
+        assert!(doc_type
+            .all_external_token_costs_contract_tokens()
+            .is_empty());
+    }
+
+    // DocumentTypeV1Getters on DocumentTypeRef (V0 variant returns None/defaults)
+
+    #[test]
+    fn v1_getters_on_v0_document_type_ref_return_none() {
+        let doc_type = get_test_document_type();
+        let doc_ref = doc_type.as_ref();
+
+        assert!(doc_ref.document_creation_token_cost().is_none());
+        assert!(doc_ref.document_replacement_token_cost().is_none());
+        assert!(doc_ref.document_deletion_token_cost().is_none());
+        assert!(doc_ref.document_transfer_token_cost().is_none());
+        assert!(doc_ref.document_update_price_token_cost().is_none());
+        assert!(doc_ref.document_purchase_token_cost().is_none());
+        assert!(doc_ref.all_document_token_costs().is_empty());
+        assert!(doc_ref
+            .all_external_token_costs_contract_tokens()
+            .is_empty());
+    }
+
+    // DocumentTypeV1Getters on DocumentTypeMutRef (V0 variant returns None/defaults)
+
+    #[test]
+    fn v1_getters_on_v0_document_type_mut_ref_return_none() {
+        let mut doc_type = get_test_document_type();
+        let doc_mut_ref = doc_type.as_mut_ref();
+
+        assert!(doc_mut_ref.document_creation_token_cost().is_none());
+        assert!(doc_mut_ref.document_replacement_token_cost().is_none());
+        assert!(doc_mut_ref.document_deletion_token_cost().is_none());
+        assert!(doc_mut_ref.document_transfer_token_cost().is_none());
+        assert!(doc_mut_ref.document_update_price_token_cost().is_none());
+        assert!(doc_mut_ref.document_purchase_token_cost().is_none());
+        assert!(doc_mut_ref.all_document_token_costs().is_empty());
+        assert!(doc_mut_ref
+            .all_external_token_costs_contract_tokens()
+            .is_empty());
+    }
+
+    // DocumentTypeV1Setters on DocumentType (V0 variant is no-op)
+
+    #[test]
+    fn v1_setters_on_v0_document_type_are_noop() {
+        let mut doc_type = get_test_document_type();
+        // These should not panic on V0 variants
+        doc_type.set_document_creation_token_cost(None);
+        doc_type.set_document_replacement_token_cost(None);
+        doc_type.set_document_deletion_token_cost(None);
+        doc_type.set_document_transfer_token_cost(None);
+        doc_type.set_document_price_update_token_cost(None);
+        doc_type.set_document_purchase_token_cost(None);
+    }
+
+    // Test with different document types from the fixture
+
+    #[test]
+    fn no_time_document_type_getters() {
+        let platform_version = PlatformVersion::latest();
+        let created = get_data_contract_fixture(None, 0, platform_version.protocol_version);
+        let data_contract = created.data_contract_owned();
+        let doc_types = data_contract.document_types();
+
+        let no_time = doc_types
+            .get("noTimeDocument")
+            .expect("noTimeDocument should exist");
+
+        assert_eq!(no_time.name(), "noTimeDocument");
+        assert!(no_time.indexes().is_empty());
+        assert!(no_time.documents_mutable());
+    }
+
+    #[test]
+    fn with_byte_arrays_document_type_has_binary_paths() {
+        let platform_version = PlatformVersion::latest();
+        let created = get_data_contract_fixture(None, 0, platform_version.protocol_version);
+        let data_contract = created.data_contract_owned();
+        let doc_types = data_contract.document_types();
+
+        let byte_doc = doc_types
+            .get("withByteArrays")
+            .expect("withByteArrays should exist");
+
+        assert_eq!(byte_doc.name(), "withByteArrays");
+        // This document type has byte array fields
+        assert!(!byte_doc.binary_paths().is_empty() || !byte_doc.identifier_paths().is_empty());
+        assert!(!byte_doc.indexes().is_empty());
+    }
+
+    #[test]
+    fn nice_document_type_required_fields() {
+        let platform_version = PlatformVersion::latest();
+        let created = get_data_contract_fixture(None, 0, platform_version.protocol_version);
+        let data_contract = created.data_contract_owned();
+        let doc_types = data_contract.document_types();
+
+        let nice = doc_types
+            .get("niceDocument")
+            .expect("niceDocument should exist");
+
+        assert_eq!(nice.name(), "niceDocument");
+        // niceDocument requires $createdAt
+        assert!(nice.required_fields().contains("$createdAt"));
+    }
+
+    #[test]
+    fn to_owned_document_type_from_ref() {
+        let doc_type = get_test_document_type();
+        let doc_ref = doc_type.as_ref();
+
+        let owned = doc_ref.to_owned_document_type();
+        assert_eq!(owned.name(), doc_type.name());
+        assert_eq!(owned.data_contract_id(), doc_type.data_contract_id());
+    }
+}

--- a/packages/rs-dpp/src/document/specialized_document_factory/v0/mod.rs
+++ b/packages/rs-dpp/src/document/specialized_document_factory/v0/mod.rs
@@ -549,3 +549,176 @@ impl SpecializedDocumentFactoryV0 {
         ids.into_iter().all_equal()
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::document::DocumentV0Getters;
+    use crate::tests::fixtures::get_data_contract_fixture;
+    use crate::util::entropy_generator::EntropyGenerator;
+    use platform_value::platform_value;
+
+    /// A deterministic entropy generator for tests
+    struct TestEntropyGenerator;
+
+    impl EntropyGenerator for TestEntropyGenerator {
+        fn generate(&self) -> anyhow::Result<[u8; 32]> {
+            Ok([1u8; 32])
+        }
+    }
+
+    fn setup_factory() -> (SpecializedDocumentFactoryV0, DataContract) {
+        let platform_version = PlatformVersion::latest();
+        let created = get_data_contract_fixture(None, 0, platform_version.protocol_version);
+        let data_contract = created.data_contract_owned();
+        let factory = SpecializedDocumentFactoryV0::new_with_entropy_generator(
+            platform_version.protocol_version,
+            data_contract.clone(),
+            Box::new(TestEntropyGenerator),
+        );
+        (factory, data_contract)
+    }
+
+    #[test]
+    fn new_creates_factory_with_default_entropy() {
+        let platform_version = PlatformVersion::latest();
+        let created = get_data_contract_fixture(None, 0, platform_version.protocol_version);
+        let data_contract = created.data_contract_owned();
+        let factory =
+            SpecializedDocumentFactoryV0::new(platform_version.protocol_version, data_contract);
+        // Just verify it was created without panic
+        assert_eq!(factory.protocol_version, platform_version.protocol_version);
+    }
+
+    #[test]
+    fn create_document_with_valid_type_succeeds() {
+        let (factory, data_contract) = setup_factory();
+        let owner_id = Identifier::from([10u8; 32]);
+
+        let data = platform_value!({
+            "firstName": "John",
+            "lastName": "Doe",
+        });
+
+        let result = factory.create_document(
+            &data_contract,
+            owner_id,
+            100,
+            50,
+            "indexedDocument".to_string(),
+            data,
+        );
+
+        let doc = result.expect("should create document");
+        assert_eq!(doc.owner_id(), owner_id);
+    }
+
+    #[test]
+    fn create_document_with_invalid_type_fails() {
+        let (factory, data_contract) = setup_factory();
+        let owner_id = Identifier::from([10u8; 32]);
+
+        let result = factory.create_document(
+            &data_contract,
+            owner_id,
+            100,
+            50,
+            "nonExistentDocType".to_string(),
+            Value::Null,
+        );
+
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn create_document_without_time_based_properties_succeeds() {
+        let (factory, _) = setup_factory();
+        let owner_id = Identifier::from([20u8; 32]);
+
+        let data = platform_value!({
+            "name": "test",
+        });
+
+        let result = factory.create_document_without_time_based_properties(
+            owner_id,
+            "noTimeDocument".to_string(),
+            data,
+        );
+
+        let doc = result.expect("should create document without time properties");
+        assert_eq!(doc.owner_id(), owner_id);
+    }
+
+    #[test]
+    fn create_document_without_time_based_properties_invalid_type_fails() {
+        let (factory, _) = setup_factory();
+        let owner_id = Identifier::from([20u8; 32]);
+
+        let result = factory.create_document_without_time_based_properties(
+            owner_id,
+            "nonExistentDocType".to_string(),
+            Value::Null,
+        );
+
+        assert!(result.is_err());
+    }
+
+    #[cfg(feature = "extended-document")]
+    #[test]
+    fn create_extended_document_succeeds() {
+        let (factory, _) = setup_factory();
+        let owner_id = Identifier::from([30u8; 32]);
+
+        let data = platform_value!({
+            "name": "test",
+        });
+
+        let result = factory.create_extended_document(owner_id, "noTimeDocument".to_string(), data);
+
+        assert!(result.is_ok());
+    }
+
+    #[cfg(feature = "extended-document")]
+    #[test]
+    fn create_extended_document_invalid_type_fails() {
+        let (factory, _) = setup_factory();
+        let owner_id = Identifier::from([30u8; 32]);
+
+        let result = factory.create_extended_document(
+            owner_id,
+            "nonExistentDocType".to_string(),
+            Value::Null,
+        );
+
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn is_ownership_the_same_with_same_ids() {
+        let id = Identifier::from([1u8; 32]);
+        assert!(SpecializedDocumentFactoryV0::is_ownership_the_same([
+            &id, &id, &id
+        ]));
+    }
+
+    #[test]
+    fn is_ownership_the_same_with_different_ids() {
+        let id1 = Identifier::from([1u8; 32]);
+        let id2 = Identifier::from([2u8; 32]);
+        assert!(!SpecializedDocumentFactoryV0::is_ownership_the_same([
+            &id1, &id2
+        ]));
+    }
+
+    #[test]
+    fn is_ownership_the_same_with_single_id() {
+        let id = Identifier::from([1u8; 32]);
+        assert!(SpecializedDocumentFactoryV0::is_ownership_the_same([&id]));
+    }
+
+    #[test]
+    fn is_ownership_the_same_with_empty_iter() {
+        let ids: Vec<&Identifier> = vec![];
+        assert!(SpecializedDocumentFactoryV0::is_ownership_the_same(ids));
+    }
+}

--- a/packages/rs-dpp/src/util/cbor_value/canonical.rs
+++ b/packages/rs-dpp/src/util/cbor_value/canonical.rs
@@ -361,14 +361,16 @@ pub fn value_to_hash(value: &CborValue) -> Result<[u8; 32], ProtocolError> {
 
 #[cfg(test)]
 mod test {
+    use std::collections::BTreeMap;
+    use std::convert::TryFrom;
     use std::convert::TryInto;
 
-    use crate::util::cbor_value::ReplacePaths;
+    use crate::util::cbor_value::{ReplacePaths, ValuesCollection};
 
-    use super::{CborValue, FieldType};
+    use super::{value_to_bytes, value_to_hash, CborCanonicalMap, CborValue, FieldType};
     use ciborium::cbor;
 
-    use super::CborCanonicalMap;
+    // ------- Existing tests -------
 
     #[test]
     fn should_get_path_to_property_from_cbor() {
@@ -440,5 +442,714 @@ mod test {
             &mut CborValue::Text(bs58::encode(vec![0_u8; 32]).into_string()),
             replaced
         );
+    }
+
+    // ------- New coverage tests -------
+
+    // CborCanonicalMap construction and basic operations
+
+    #[test]
+    fn new_creates_empty_map() {
+        let map = CborCanonicalMap::new();
+        let value = map.to_value_unsorted();
+        assert_eq!(value, CborValue::Map(vec![]));
+    }
+
+    #[test]
+    fn default_creates_empty_map() {
+        let map = CborCanonicalMap::default();
+        let value = map.to_value_unsorted();
+        assert_eq!(value, CborValue::Map(vec![]));
+    }
+
+    #[test]
+    fn insert_adds_key_value_pair() {
+        let mut map = CborCanonicalMap::new();
+        map.insert("hello", CborValue::Text("world".to_string()));
+
+        let val = ValuesCollection::get(&map, &CborValue::Text("hello".to_string()));
+        assert_eq!(val, Some(&CborValue::Text("world".to_string())));
+    }
+
+    #[test]
+    fn insert_multiple_keys() {
+        let mut map = CborCanonicalMap::new();
+        map.insert("a", CborValue::Integer(1.into()));
+        map.insert("b", CborValue::Integer(2.into()));
+        map.insert("c", CborValue::Integer(3.into()));
+
+        assert_eq!(
+            ValuesCollection::get(&map, &CborValue::Text("a".to_string())),
+            Some(&CborValue::Integer(1.into()))
+        );
+        assert_eq!(
+            ValuesCollection::get(&map, &CborValue::Text("b".to_string())),
+            Some(&CborValue::Integer(2.into()))
+        );
+        assert_eq!(
+            ValuesCollection::get(&map, &CborValue::Text("c".to_string())),
+            Some(&CborValue::Integer(3.into()))
+        );
+    }
+
+    #[test]
+    fn remove_existing_key() {
+        let mut map = CborCanonicalMap::new();
+        map.insert("key1", CborValue::Bool(true));
+        map.insert("key2", CborValue::Bool(false));
+
+        map.remove("key1");
+
+        assert!(ValuesCollection::get(&map, &CborValue::Text("key1".to_string())).is_none());
+        assert_eq!(
+            ValuesCollection::get(&map, &CborValue::Text("key2".to_string())),
+            Some(&CborValue::Bool(false))
+        );
+    }
+
+    #[test]
+    fn remove_nonexistent_key_is_noop() {
+        let mut map = CborCanonicalMap::new();
+        map.insert("key1", CborValue::Bool(true));
+
+        // Should not panic or change anything
+        map.remove("nonexistent");
+
+        assert_eq!(
+            ValuesCollection::get(&map, &CborValue::Text("key1".to_string())),
+            Some(&CborValue::Bool(true))
+        );
+    }
+
+    #[test]
+    fn get_mut_returns_mutable_reference() {
+        let mut map = CborCanonicalMap::new();
+        map.insert("key", CborValue::Integer(10.into()));
+
+        let val = map.get_mut(&CborValue::Text("key".to_string()));
+        assert!(val.is_some());
+        *val.unwrap() = CborValue::Integer(20.into());
+
+        assert_eq!(
+            ValuesCollection::get(&map, &CborValue::Text("key".to_string())),
+            Some(&CborValue::Integer(20.into()))
+        );
+    }
+
+    #[test]
+    fn get_mut_returns_none_for_missing_key() {
+        let mut map = CborCanonicalMap::new();
+        assert!(map
+            .get_mut(&CborValue::Text("missing".to_string()))
+            .is_none());
+    }
+
+    #[test]
+    fn set_replaces_existing_value() {
+        let mut map = CborCanonicalMap::new();
+        map.insert("key", CborValue::Integer(1.into()));
+
+        let result = map.set(
+            &CborValue::Text("key".to_string()),
+            CborValue::Integer(99.into()),
+        );
+        assert!(result.is_some());
+
+        assert_eq!(
+            ValuesCollection::get(&map, &CborValue::Text("key".to_string())),
+            Some(&CborValue::Integer(99.into()))
+        );
+    }
+
+    #[test]
+    fn set_returns_none_for_missing_key() {
+        let mut map = CborCanonicalMap::new();
+
+        let result = map.set(
+            &CborValue::Text("missing".to_string()),
+            CborValue::Integer(1.into()),
+        );
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn from_vector_creates_map() {
+        let vec = vec![
+            (
+                CborValue::Text("a".to_string()),
+                CborValue::Integer(1.into()),
+            ),
+            (
+                CborValue::Text("b".to_string()),
+                CborValue::Integer(2.into()),
+            ),
+        ];
+
+        let map = CborCanonicalMap::from_vector(vec);
+
+        assert_eq!(
+            ValuesCollection::get(&map, &CborValue::Text("a".to_string())),
+            Some(&CborValue::Integer(1.into()))
+        );
+        assert_eq!(
+            ValuesCollection::get(&map, &CborValue::Text("b".to_string())),
+            Some(&CborValue::Integer(2.into()))
+        );
+    }
+
+    #[test]
+    fn from_serializable_with_btreemap() {
+        let mut btree = BTreeMap::new();
+        btree.insert("name".to_string(), "test".to_string());
+
+        let map =
+            CborCanonicalMap::from_serializable(&btree).expect("should serialize from BTreeMap");
+
+        assert!(ValuesCollection::get(&map, &CborValue::Text("name".to_string())).is_some());
+    }
+
+    #[test]
+    fn from_serializable_with_non_map_value_fails() {
+        // A plain string serializes as CborValue::Text, not a Map
+        let result = CborCanonicalMap::from_serializable(&"just a string");
+        assert!(result.is_err());
+    }
+
+    // Canonical sorting
+
+    #[test]
+    fn sort_canonical_orders_by_key_length_then_lexicographic() {
+        let mut map = CborCanonicalMap::new();
+        // Longer key first
+        map.insert("beta", CborValue::Integer(2.into()));
+        map.insert("a", CborValue::Integer(1.into()));
+        map.insert("cc", CborValue::Integer(3.into()));
+        map.insert("bb", CborValue::Integer(4.into()));
+
+        map.sort_canonical();
+
+        let sorted = map.to_value_unsorted();
+        if let CborValue::Map(pairs) = sorted {
+            let keys: Vec<&str> = pairs.iter().map(|(k, _)| k.as_text().unwrap()).collect();
+            // "a" (len 1) < "bb" (len 2) < "cc" (len 2, but bb < cc) < "beta" (len 4)
+            assert_eq!(keys, vec!["a", "bb", "cc", "beta"]);
+        } else {
+            panic!("Expected map");
+        }
+    }
+
+    #[test]
+    fn sort_canonical_recursively_sorts_nested_maps() {
+        let mut map = CborCanonicalMap::new();
+        // Create a nested map with unsorted keys
+        let nested = CborValue::Map(vec![
+            (
+                CborValue::Text("zz".to_string()),
+                CborValue::Integer(1.into()),
+            ),
+            (
+                CborValue::Text("a".to_string()),
+                CborValue::Integer(2.into()),
+            ),
+        ]);
+        map.insert("outer", nested);
+
+        map.sort_canonical();
+
+        let sorted = map.to_value_unsorted();
+        if let CborValue::Map(pairs) = sorted {
+            if let CborValue::Map(inner_pairs) = &pairs[0].1 {
+                let keys: Vec<&str> = inner_pairs
+                    .iter()
+                    .map(|(k, _)| k.as_text().unwrap())
+                    .collect();
+                // "a" (len 1) should come before "zz" (len 2)
+                assert_eq!(keys, vec!["a", "zz"]);
+            } else {
+                panic!("Expected nested map");
+            }
+        }
+    }
+
+    #[test]
+    fn sort_canonical_recursively_sorts_maps_inside_arrays() {
+        let mut map = CborCanonicalMap::new();
+        let nested_map_in_array = CborValue::Array(vec![CborValue::Map(vec![
+            (
+                CborValue::Text("zz".to_string()),
+                CborValue::Integer(1.into()),
+            ),
+            (
+                CborValue::Text("a".to_string()),
+                CborValue::Integer(2.into()),
+            ),
+        ])]);
+        map.insert("items", nested_map_in_array);
+
+        map.sort_canonical();
+
+        let sorted = map.to_value_unsorted();
+        if let CborValue::Map(pairs) = sorted {
+            if let CborValue::Array(arr) = &pairs[0].1 {
+                if let CborValue::Map(inner_pairs) = &arr[0] {
+                    let keys: Vec<&str> = inner_pairs
+                        .iter()
+                        .map(|(k, _)| k.as_text().unwrap())
+                        .collect();
+                    assert_eq!(keys, vec!["a", "zz"]);
+                } else {
+                    panic!("Expected map inside array");
+                }
+            } else {
+                panic!("Expected array");
+            }
+        }
+    }
+
+    // Serialization and value conversion
+
+    #[test]
+    fn to_bytes_produces_valid_cbor() {
+        let mut map = CborCanonicalMap::new();
+        map.insert("key", CborValue::Text("value".to_string()));
+
+        let bytes = map.to_bytes().expect("should serialize to bytes");
+        assert!(!bytes.is_empty());
+
+        // Deserialize back
+        let deserialized: CborValue =
+            ciborium::de::from_reader(&bytes[..]).expect("should deserialize");
+        if let CborValue::Map(pairs) = deserialized {
+            assert_eq!(pairs.len(), 1);
+            assert_eq!(
+                pairs[0],
+                (
+                    CborValue::Text("key".to_string()),
+                    CborValue::Text("value".to_string())
+                )
+            );
+        } else {
+            panic!("Expected map after deserialization");
+        }
+    }
+
+    #[test]
+    fn to_bytes_sorts_before_serializing() {
+        let mut map = CborCanonicalMap::new();
+        map.insert("beta", CborValue::Integer(2.into()));
+        map.insert("a", CborValue::Integer(1.into()));
+
+        let bytes = map.to_bytes().expect("should serialize");
+        let deserialized: CborValue =
+            ciborium::de::from_reader(&bytes[..]).expect("should deserialize");
+
+        if let CborValue::Map(pairs) = deserialized {
+            let keys: Vec<&str> = pairs.iter().map(|(k, _)| k.as_text().unwrap()).collect();
+            assert_eq!(keys, vec!["a", "beta"]);
+        }
+    }
+
+    #[test]
+    fn to_value_unsorted_preserves_insertion_order() {
+        let mut map = CborCanonicalMap::new();
+        map.insert("z", CborValue::Integer(1.into()));
+        map.insert("a", CborValue::Integer(2.into()));
+
+        let value = map.to_value_unsorted();
+        if let CborValue::Map(pairs) = value {
+            assert_eq!(pairs[0].0, CborValue::Text("z".to_string()));
+            assert_eq!(pairs[1].0, CborValue::Text("a".to_string()));
+        }
+    }
+
+    #[test]
+    fn to_value_sorted_returns_sorted_map() {
+        let mut map = CborCanonicalMap::new();
+        map.insert("beta", CborValue::Integer(2.into()));
+        map.insert("a", CborValue::Integer(1.into()));
+
+        let value = map.to_value_sorted();
+        if let CborValue::Map(pairs) = value {
+            assert_eq!(pairs[0].0, CborValue::Text("a".to_string()));
+            assert_eq!(pairs[1].0, CborValue::Text("beta".to_string()));
+        }
+    }
+
+    #[test]
+    fn to_value_clone_returns_sorted_clone() {
+        let mut map = CborCanonicalMap::new();
+        map.insert("beta", CborValue::Integer(2.into()));
+        map.insert("a", CborValue::Integer(1.into()));
+
+        let value = map.to_value_clone();
+        if let CborValue::Map(pairs) = value {
+            assert_eq!(pairs[0].0, CborValue::Text("a".to_string()));
+            assert_eq!(pairs[1].0, CborValue::Text("beta".to_string()));
+        }
+
+        // Original map should still be accessible (it was sorted in place but not consumed)
+        let val = ValuesCollection::get(&map, &CborValue::Text("a".to_string()));
+        assert!(val.is_some());
+    }
+
+    // TryFrom and From impls
+
+    #[test]
+    fn try_from_cbor_map_succeeds() {
+        let cbor = CborValue::Map(vec![(
+            CborValue::Text("k".to_string()),
+            CborValue::Bool(true),
+        )]);
+
+        let map = CborCanonicalMap::try_from(cbor).expect("should convert from map");
+        assert_eq!(
+            ValuesCollection::get(&map, &CborValue::Text("k".to_string())),
+            Some(&CborValue::Bool(true))
+        );
+    }
+
+    #[test]
+    fn try_from_non_map_fails() {
+        let cbor = CborValue::Text("not a map".to_string());
+        let result = CborCanonicalMap::try_from(cbor);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn from_vec_creates_canonical_map() {
+        let vec = vec![(
+            CborValue::Text("x".to_string()),
+            CborValue::Integer(42.into()),
+        )];
+
+        let map: CborCanonicalMap = vec.into();
+        assert_eq!(
+            ValuesCollection::get(&map, &CborValue::Text("x".to_string())),
+            Some(&CborValue::Integer(42.into()))
+        );
+    }
+
+    #[test]
+    fn from_ref_vec_creates_canonical_map() {
+        let vec = vec![(
+            CborValue::Text("y".to_string()),
+            CborValue::Integer(7.into()),
+        )];
+
+        let map: CborCanonicalMap = (&vec).into();
+        assert_eq!(
+            ValuesCollection::get(&map, &CborValue::Text("y".to_string())),
+            Some(&CborValue::Integer(7.into()))
+        );
+    }
+
+    #[test]
+    fn from_btreemap_string_creates_canonical_map() {
+        let mut btree = BTreeMap::new();
+        btree.insert("alpha".to_string(), CborValue::Integer(1.into()));
+        btree.insert("beta".to_string(), CborValue::Integer(2.into()));
+
+        let map: CborCanonicalMap = (&btree).into();
+        assert_eq!(
+            ValuesCollection::get(&map, &CborValue::Text("alpha".to_string())),
+            Some(&CborValue::Integer(1.into()))
+        );
+        assert_eq!(
+            ValuesCollection::get(&map, &CborValue::Text("beta".to_string())),
+            Some(&CborValue::Integer(2.into()))
+        );
+    }
+
+    // ValuesCollection trait impl
+
+    #[test]
+    fn values_collection_get_returns_value() {
+        let map = CborCanonicalMap::from_vector(vec![(
+            CborValue::Text("k".to_string()),
+            CborValue::Text("v".to_string()),
+        )]);
+
+        let result = ValuesCollection::get(&map, &CborValue::Text("k".to_string()));
+        assert_eq!(result, Some(&CborValue::Text("v".to_string())));
+    }
+
+    #[test]
+    fn values_collection_get_returns_none_for_missing() {
+        let map = CborCanonicalMap::new();
+        let result = ValuesCollection::get(&map, &CborValue::Text("missing".to_string()));
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn values_collection_remove_returns_removed_value() {
+        let mut map = CborCanonicalMap::from_vector(vec![
+            (
+                CborValue::Text("a".to_string()),
+                CborValue::Integer(1.into()),
+            ),
+            (
+                CborValue::Text("b".to_string()),
+                CborValue::Integer(2.into()),
+            ),
+        ]);
+
+        let removed = ValuesCollection::remove(&mut map, "a");
+        assert_eq!(removed, Some(CborValue::Integer(1.into())));
+        assert!(ValuesCollection::get(&map, &CborValue::Text("a".to_string())).is_none());
+    }
+
+    #[test]
+    fn values_collection_remove_returns_none_for_missing() {
+        let mut map = CborCanonicalMap::new();
+        let removed = ValuesCollection::remove(&mut map, "nonexistent");
+        assert!(removed.is_none());
+    }
+
+    // replace_paths (ReplacePaths trait)
+
+    #[test]
+    fn replace_paths_converts_multiple_paths() {
+        let cbor_value = cbor!({
+            "field1" => vec![0_u8; 32],
+            "field2" => vec![1_u8; 32]
+        })
+        .expect("valid cbor");
+
+        let mut canonical: CborCanonicalMap = cbor_value.try_into().expect("valid canonical");
+        ReplacePaths::replace_paths(
+            &mut canonical,
+            vec!["field1", "field2"],
+            FieldType::ArrayInt,
+            FieldType::Bytes,
+        );
+
+        let v1 = ValuesCollection::get(&canonical, &CborValue::Text("field1".to_string()));
+        assert!(matches!(v1, Some(CborValue::Bytes(_))));
+        let v2 = ValuesCollection::get(&canonical, &CborValue::Text("field2".to_string()));
+        assert!(matches!(v2, Some(CborValue::Bytes(_))));
+    }
+
+    #[test]
+    fn replace_path_returns_none_for_nonexistent_path() {
+        let mut map = CborCanonicalMap::new();
+        map.insert("exists", CborValue::Text("value".to_string()));
+
+        let result =
+            ReplacePaths::replace_path(&mut map, "nonexistent", FieldType::Bytes, FieldType::Bytes);
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn get_path_mut_with_empty_path_returns_none() {
+        let mut map = CborCanonicalMap::new();
+        map.insert("key", CborValue::Integer(1.into()));
+
+        // Empty string results in a path with a single empty-string key
+        // which won't match any real keys typically
+        let result = ReplacePaths::get_path_mut(&mut map, "");
+        // An empty path string still produces a single Key("") step,
+        // which won't match any inserted key
+        assert!(result.is_none());
+    }
+
+    // value_to_bytes tests
+
+    #[test]
+    fn value_to_bytes_from_bytes() {
+        let val = CborValue::Bytes(vec![1, 2, 3, 4]);
+        let result = value_to_bytes(&val).expect("should succeed");
+        assert_eq!(result, Some(vec![1, 2, 3, 4]));
+    }
+
+    #[test]
+    fn value_to_bytes_from_valid_base58_text() {
+        let original = vec![1, 2, 3, 4, 5];
+        let encoded = bs58::encode(&original).into_string();
+        let val = CborValue::Text(encoded);
+
+        let result = value_to_bytes(&val).expect("should succeed");
+        assert_eq!(result, Some(original));
+    }
+
+    #[test]
+    fn value_to_bytes_from_invalid_base58_text_returns_none() {
+        // "0OIl" contains characters invalid in base58
+        let val = CborValue::Text("0OIl!!!".to_string());
+        let result = value_to_bytes(&val).expect("should succeed");
+        assert_eq!(result, None);
+    }
+
+    #[test]
+    fn value_to_bytes_from_integer_array() {
+        let val = CborValue::Array(vec![
+            CborValue::Integer(10.into()),
+            CborValue::Integer(20.into()),
+            CborValue::Integer(30.into()),
+        ]);
+
+        let result = value_to_bytes(&val).expect("should succeed");
+        assert_eq!(result, Some(vec![10, 20, 30]));
+    }
+
+    #[test]
+    fn value_to_bytes_from_array_with_non_integer_fails() {
+        let val = CborValue::Array(vec![
+            CborValue::Integer(1.into()),
+            CborValue::Text("not an int".to_string()),
+        ]);
+
+        let result = value_to_bytes(&val);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn value_to_bytes_from_bool_fails() {
+        let val = CborValue::Bool(true);
+        let result = value_to_bytes(&val);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn value_to_bytes_from_null_fails() {
+        let val = CborValue::Null;
+        let result = value_to_bytes(&val);
+        assert!(result.is_err());
+    }
+
+    // value_to_hash tests
+
+    #[test]
+    fn value_to_hash_from_32_bytes() {
+        let bytes = vec![42u8; 32];
+        let val = CborValue::Bytes(bytes.clone());
+
+        let result = value_to_hash(&val).expect("should succeed");
+        assert_eq!(result, [42u8; 32]);
+    }
+
+    #[test]
+    fn value_to_hash_from_wrong_length_bytes_fails() {
+        let val = CborValue::Bytes(vec![1u8; 16]);
+        let result = value_to_hash(&val);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn value_to_hash_from_valid_base58_text_32_bytes() {
+        let original = [7u8; 32];
+        let encoded = bs58::encode(&original).into_string();
+        let val = CborValue::Text(encoded);
+
+        let result = value_to_hash(&val).expect("should succeed");
+        assert_eq!(result, original);
+    }
+
+    #[test]
+    fn value_to_hash_from_invalid_base58_text_fails() {
+        let val = CborValue::Text("!!!invalid!!!".to_string());
+        let result = value_to_hash(&val);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn value_to_hash_from_base58_text_wrong_length_fails() {
+        // Valid base58 but only 4 bytes
+        let encoded = bs58::encode(&[1u8; 4]).into_string();
+        let val = CborValue::Text(encoded);
+        let result = value_to_hash(&val);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn value_to_hash_from_integer_array_32_bytes() {
+        let val = CborValue::Array((0..32).map(|i| CborValue::Integer(i.into())).collect());
+
+        let result = value_to_hash(&val).expect("should succeed");
+        let expected: [u8; 32] = (0u8..32).collect::<Vec<u8>>().try_into().unwrap();
+        assert_eq!(result, expected);
+    }
+
+    #[test]
+    fn value_to_hash_from_integer_array_wrong_length_fails() {
+        let val = CborValue::Array(vec![CborValue::Integer(1.into()); 10]);
+        let result = value_to_hash(&val);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn value_to_hash_from_array_with_non_integer_fails() {
+        let mut arr: Vec<CborValue> = (0..31).map(|i| CborValue::Integer(i.into())).collect();
+        arr.push(CborValue::Text("not_int".to_string()));
+        let val = CborValue::Array(arr);
+
+        let result = value_to_hash(&val);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn value_to_hash_from_bool_fails() {
+        let val = CborValue::Bool(false);
+        let result = value_to_hash(&val);
+        assert!(result.is_err());
+    }
+
+    // Round-trip: to_bytes and back
+
+    #[test]
+    fn round_trip_canonical_map_through_bytes() {
+        let mut map = CborCanonicalMap::new();
+        map.insert("name", CborValue::Text("Alice".to_string()));
+        map.insert("age", CborValue::Integer(30.into()));
+        map.insert("active", CborValue::Bool(true));
+
+        let bytes = map.to_bytes().expect("should serialize");
+
+        let decoded: CborValue = ciborium::de::from_reader(&bytes[..]).expect("should deserialize");
+        let decoded_map = CborCanonicalMap::try_from(decoded).expect("should convert to map");
+
+        assert_eq!(
+            ValuesCollection::get(&decoded_map, &CborValue::Text("name".to_string())),
+            Some(&CborValue::Text("Alice".to_string()))
+        );
+        assert_eq!(
+            ValuesCollection::get(&decoded_map, &CborValue::Text("age".to_string())),
+            Some(&CborValue::Integer(30.into()))
+        );
+        assert_eq!(
+            ValuesCollection::get(&decoded_map, &CborValue::Text("active".to_string())),
+            Some(&CborValue::Bool(true))
+        );
+    }
+
+    #[test]
+    fn canonical_sort_with_same_length_keys_uses_lexicographic_order() {
+        let mut map = CborCanonicalMap::new();
+        map.insert("cc", CborValue::Integer(1.into()));
+        map.insert("bb", CborValue::Integer(2.into()));
+        map.insert("aa", CborValue::Integer(3.into()));
+
+        map.sort_canonical();
+
+        let value = map.to_value_unsorted();
+        if let CborValue::Map(pairs) = value {
+            let keys: Vec<&str> = pairs.iter().map(|(k, _)| k.as_text().unwrap()).collect();
+            assert_eq!(keys, vec!["aa", "bb", "cc"]);
+        }
+    }
+
+    #[test]
+    fn canonical_sort_shorter_keys_come_first() {
+        let mut map = CborCanonicalMap::new();
+        map.insert("zzz", CborValue::Integer(1.into()));
+        map.insert("a", CborValue::Integer(2.into()));
+        map.insert("bb", CborValue::Integer(3.into()));
+
+        map.sort_canonical();
+
+        let value = map.to_value_unsorted();
+        if let CborValue::Map(pairs) = value {
+            let keys: Vec<&str> = pairs.iter().map(|(k, _)| k.as_text().unwrap()).collect();
+            assert_eq!(keys, vec!["a", "bb", "zzz"]);
+        }
     }
 }

--- a/packages/rs-dpp/src/util/json_value/mod.rs
+++ b/packages/rs-dpp/src/util/json_value/mod.rs
@@ -469,4 +469,512 @@ mod test {
             json!("new_value")
         );
     }
+
+    // ------- New coverage tests -------
+
+    // push
+
+    #[test]
+    fn push_adds_to_array() {
+        let mut arr = json!([1, 2, 3]);
+        arr.push(json!(4)).expect("should push");
+        assert_eq!(arr, json!([1, 2, 3, 4]));
+    }
+
+    #[test]
+    fn push_on_non_array_fails() {
+        let mut obj = json!({"a": 1});
+        assert!(obj.push(json!(1)).is_err());
+    }
+
+    // insert
+
+    #[test]
+    fn insert_adds_key_to_object() {
+        let mut obj = json!({"existing": 1});
+        JsonValueExt::insert(&mut obj, "new_key".to_string(), json!("new_value"))
+            .expect("should insert");
+        assert_eq!(obj["new_key"], json!("new_value"));
+        assert_eq!(obj["existing"], json!(1));
+    }
+
+    #[test]
+    fn insert_on_non_object_fails() {
+        let mut arr = json!([1, 2]);
+        assert!(JsonValueExt::insert(&mut arr, "key".to_string(), json!(1)).is_err());
+    }
+
+    // remove
+
+    #[test]
+    fn remove_existing_property() {
+        let mut obj = json!({"a": 1, "b": 2});
+        let removed = JsonValueExt::remove(&mut obj, "a").expect("should remove");
+        assert_eq!(removed, json!(1));
+        assert!(obj.get("a").is_none());
+    }
+
+    #[test]
+    fn remove_nonexistent_property_fails() {
+        let mut obj = json!({"a": 1});
+        assert!(JsonValueExt::remove(&mut obj, "missing").is_err());
+    }
+
+    #[test]
+    fn remove_on_non_object_fails() {
+        let mut val = json!("string");
+        assert!(JsonValueExt::remove(&mut val, "key").is_err());
+    }
+
+    // remove_into
+
+    #[test]
+    fn remove_into_deserializes_value() {
+        let mut obj = json!({"count": 42});
+        let count: u64 = obj
+            .remove_into("count")
+            .expect("should remove and deserialize");
+        assert_eq!(count, 42);
+    }
+
+    #[test]
+    fn remove_into_missing_property_fails() {
+        let mut obj = json!({"a": 1});
+        let result: Result<u64, _> = obj.remove_into("missing");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn remove_into_on_non_object_fails() {
+        let mut val = json!(123);
+        let result: Result<u64, _> = val.remove_into("key");
+        assert!(result.is_err());
+    }
+
+    // get_string
+
+    #[test]
+    fn get_string_returns_string_value() {
+        let obj = json!({"name": "Alice"});
+        let result = obj.get_string("name").expect("should get string");
+        assert_eq!(result, "Alice");
+    }
+
+    #[test]
+    fn get_string_missing_property_fails() {
+        let obj = json!({"a": 1});
+        assert!(obj.get_string("missing").is_err());
+    }
+
+    #[test]
+    fn get_string_non_string_value_fails() {
+        let obj = json!({"num": 42});
+        assert!(obj.get_string("num").is_err());
+    }
+
+    // get_u8
+
+    #[test]
+    fn get_u8_returns_u8_value() {
+        let obj = json!({"val": 200});
+        let result = obj.get_u8("val").expect("should get u8");
+        assert_eq!(result, 200);
+    }
+
+    #[test]
+    fn get_u8_too_large_fails() {
+        let obj = json!({"val": 300});
+        assert!(obj.get_u8("val").is_err());
+    }
+
+    #[test]
+    fn get_u8_missing_property_fails() {
+        let obj = json!({});
+        assert!(obj.get_u8("val").is_err());
+    }
+
+    #[test]
+    fn get_u8_non_number_fails() {
+        let obj = json!({"val": "text"});
+        assert!(obj.get_u8("val").is_err());
+    }
+
+    // get_u32
+
+    #[test]
+    fn get_u32_returns_u32_value() {
+        let obj = json!({"val": 100000});
+        let result = obj.get_u32("val").expect("should get u32");
+        assert_eq!(result, 100_000);
+    }
+
+    #[test]
+    fn get_u32_missing_property_fails() {
+        let obj = json!({});
+        assert!(obj.get_u32("val").is_err());
+    }
+
+    #[test]
+    fn get_u32_non_number_fails() {
+        let obj = json!({"val": true});
+        assert!(obj.get_u32("val").is_err());
+    }
+
+    // get_u64
+
+    #[test]
+    fn get_u64_returns_u64_value() {
+        let obj = json!({"val": 9999999999u64});
+        let result = obj.get_u64("val").expect("should get u64");
+        assert_eq!(result, 9_999_999_999);
+    }
+
+    #[test]
+    fn get_u64_missing_property_fails() {
+        let obj = json!({});
+        assert!(obj.get_u64("val").is_err());
+    }
+
+    #[test]
+    fn get_u64_non_number_fails() {
+        let obj = json!({"val": "text"});
+        assert!(obj.get_u64("val").is_err());
+    }
+
+    // get_i64
+
+    #[test]
+    fn get_i64_returns_i64_value() {
+        let obj = json!({"val": -42});
+        let result = obj.get_i64("val").expect("should get i64");
+        assert_eq!(result, -42);
+    }
+
+    #[test]
+    fn get_i64_positive_value() {
+        let obj = json!({"val": 100});
+        let result = obj.get_i64("val").expect("should get i64");
+        assert_eq!(result, 100);
+    }
+
+    #[test]
+    fn get_i64_missing_property_fails() {
+        let obj = json!({});
+        assert!(obj.get_i64("val").is_err());
+    }
+
+    #[test]
+    fn get_i64_non_number_fails() {
+        let obj = json!({"val": "text"});
+        assert!(obj.get_i64("val").is_err());
+    }
+
+    // get_f64
+
+    #[test]
+    fn get_f64_returns_f64_value() {
+        let obj = json!({"val": 3.14});
+        let result = obj.get_f64("val").expect("should get f64");
+        assert!((result - 3.14).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn get_f64_integer_value() {
+        let obj = json!({"val": 42});
+        let result = obj.get_f64("val").expect("should get f64 from integer");
+        assert!((result - 42.0).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn get_f64_missing_property_fails() {
+        let obj = json!({});
+        assert!(obj.get_f64("val").is_err());
+    }
+
+    #[test]
+    fn get_f64_non_number_fails() {
+        let obj = json!({"val": "text"});
+        assert!(obj.get_f64("val").is_err());
+    }
+
+    // get_bytes
+
+    #[test]
+    fn get_bytes_from_array() {
+        let obj = json!({"data": [1, 2, 3, 4, 5]});
+        let result = obj.get_bytes("data").expect("should get bytes");
+        assert_eq!(result, vec![1, 2, 3, 4, 5]);
+    }
+
+    #[test]
+    fn get_bytes_missing_property_fails() {
+        let obj = json!({});
+        assert!(obj.get_bytes("data").is_err());
+    }
+
+    // get_bool
+
+    #[test]
+    fn get_bool_true() {
+        let obj = json!({"flag": true});
+        let result = obj.get_bool("flag").expect("should get bool");
+        assert!(result);
+    }
+
+    #[test]
+    fn get_bool_false() {
+        let obj = json!({"flag": false});
+        let result = obj.get_bool("flag").expect("should get bool");
+        assert!(!result);
+    }
+
+    #[test]
+    fn get_bool_missing_property_fails() {
+        let obj = json!({});
+        assert!(obj.get_bool("flag").is_err());
+    }
+
+    #[test]
+    fn get_bool_non_bool_fails() {
+        let obj = json!({"flag": 1});
+        assert!(obj.get_bool("flag").is_err());
+    }
+
+    // get_value and get_value_mut
+
+    #[test]
+    fn get_value_navigates_nested_path() {
+        let obj = json!({
+            "a": {
+                "b": {
+                    "c": "deep_value"
+                }
+            }
+        });
+
+        let result = obj.get_value("a.b.c").expect("should find nested value");
+        assert_eq!(result, &json!("deep_value"));
+    }
+
+    #[test]
+    fn get_value_with_array_index() {
+        let obj = json!({
+            "items": [10, 20, 30]
+        });
+
+        let result = obj
+            .get_value("items[1]")
+            .expect("should find array element");
+        assert_eq!(result, &json!(20));
+    }
+
+    #[test]
+    fn get_value_missing_path_fails() {
+        let obj = json!({"a": 1});
+        assert!(obj.get_value("a.b.c").is_err());
+    }
+
+    #[test]
+    fn get_value_mut_modifies_nested_value() {
+        let mut obj = json!({
+            "a": {
+                "b": "old"
+            }
+        });
+
+        let val = obj.get_value_mut("a.b").expect("should find value");
+        *val = json!("new");
+
+        assert_eq!(obj["a"]["b"], json!("new"));
+    }
+
+    // get_value_by_path and get_value_by_path_mut
+
+    #[test]
+    fn get_value_by_path_with_steps() {
+        let obj = json!({
+            "root": {
+                "items": [1, 2, 3]
+            }
+        });
+
+        let path = vec![
+            JsonPathStep::Key("root".to_string()),
+            JsonPathStep::Key("items".to_string()),
+            JsonPathStep::Index(2),
+        ];
+
+        let result = obj.get_value_by_path(&path).expect("should find value");
+        assert_eq!(result, &json!(3));
+    }
+
+    #[test]
+    fn get_value_by_path_missing_fails() {
+        let obj = json!({"a": 1});
+        let path = vec![JsonPathStep::Key("nonexistent".to_string())];
+        assert!(obj.get_value_by_path(&path).is_err());
+    }
+
+    #[test]
+    fn get_value_by_path_mut_modifies_value() {
+        let mut obj = json!({
+            "list": ["a", "b", "c"]
+        });
+
+        let path = vec![
+            JsonPathStep::Key("list".to_string()),
+            JsonPathStep::Index(1),
+        ];
+
+        let val = obj.get_value_by_path_mut(&path).expect("should find value");
+        *val = json!("modified");
+
+        assert_eq!(obj["list"][1], json!("modified"));
+    }
+
+    // remove_u32
+
+    #[test]
+    fn remove_u32_removes_and_returns_value() {
+        let mut obj = json!({"version": 42});
+        let result = obj.remove_u32("version").expect("should remove u32");
+        assert_eq!(result, 42);
+        assert!(obj.get("version").is_none());
+    }
+
+    #[test]
+    fn remove_u32_missing_property_fails() {
+        let mut obj = json!({"a": 1});
+        assert!(obj.remove_u32("missing").is_err());
+    }
+
+    #[test]
+    fn remove_u32_non_number_fails() {
+        let mut obj = json!({"val": "text"});
+        assert!(obj.remove_u32("val").is_err());
+    }
+
+    #[test]
+    fn remove_u32_on_non_object_fails() {
+        let mut val = json!([1, 2, 3]);
+        assert!(val.remove_u32("key").is_err());
+    }
+
+    // add_protocol_version
+
+    #[test]
+    fn add_protocol_version_inserts_number() {
+        let mut obj = json!({});
+        obj.add_protocol_version("protocolVersion", 5)
+            .expect("should add protocol version");
+
+        assert_eq!(obj["protocolVersion"], json!(5));
+    }
+
+    #[test]
+    fn add_protocol_version_on_non_object_fails() {
+        let mut val = json!([1, 2]);
+        assert!(val.add_protocol_version("protocolVersion", 1).is_err());
+    }
+
+    // remove_value_at_path_into
+
+    #[test]
+    fn remove_value_at_path_into_removes_and_deserializes() {
+        let mut obj = json!({
+            "config": {
+                "timeout": 30
+            }
+        });
+
+        let timeout: u64 = obj
+            .remove_value_at_path_into("config.timeout")
+            .expect("should remove and deserialize");
+        assert_eq!(timeout, 30);
+        assert!(obj["config"].get("timeout").is_none());
+    }
+
+    #[test]
+    fn remove_value_at_path_into_missing_path_fails() {
+        let mut obj = json!({"a": 1});
+        let result: Result<u64, _> = obj.remove_value_at_path_into("a.b.c");
+        assert!(result.is_err());
+    }
+
+    // Free functions: get_value_mut, get_value_from_json_path, get_value_from_json_path_mut
+
+    #[test]
+    fn free_get_value_mut_works() {
+        let mut obj = json!({"x": {"y": 10}});
+        let val = get_value_mut("x.y", &mut obj).expect("should find value");
+        *val = json!(20);
+        assert_eq!(obj["x"]["y"], json!(20));
+    }
+
+    #[test]
+    fn get_value_from_json_path_navigates_keys_and_indices() {
+        let obj = json!({
+            "data": [
+                {"id": "first"},
+                {"id": "second"}
+            ]
+        });
+
+        let path = vec![
+            JsonPathStep::Key("data".to_string()),
+            JsonPathStep::Index(1),
+            JsonPathStep::Key("id".to_string()),
+        ];
+
+        let result = get_value_from_json_path(&path, &obj).expect("should find");
+        assert_eq!(result, &json!("second"));
+    }
+
+    #[test]
+    fn get_value_from_json_path_returns_none_for_missing() {
+        let obj = json!({"a": 1});
+        let path = vec![JsonPathStep::Key("nonexistent".to_string())];
+        assert!(get_value_from_json_path(&path, &obj).is_none());
+    }
+
+    #[test]
+    fn get_value_from_json_path_mut_modifies_value() {
+        let mut obj = json!({"items": [100, 200, 300]});
+
+        let path = vec![
+            JsonPathStep::Key("items".to_string()),
+            JsonPathStep::Index(0),
+        ];
+
+        let val = get_value_from_json_path_mut(&path, &mut obj).expect("should find");
+        *val = json!(999);
+        assert_eq!(obj["items"][0], json!(999));
+    }
+
+    #[test]
+    fn get_value_from_json_path_empty_path_returns_root() {
+        let obj = json!({"a": 1});
+        let path: Vec<JsonPathStep> = vec![];
+        let result = get_value_from_json_path(&path, &obj).expect("should return root");
+        assert_eq!(result, &json!({"a": 1}));
+    }
+
+    // insert_with_path via trait
+
+    #[test]
+    fn insert_with_path_creates_deeply_nested_structure() {
+        let mut obj = json!({});
+        obj.insert_with_path("a.b.c", json!("deep"))
+            .expect("should insert");
+        assert_eq!(obj["a"]["b"]["c"], json!("deep"));
+    }
+
+    #[test]
+    fn insert_with_path_into_existing_structure() {
+        let mut obj = json!({"a": {"b": 1}});
+        obj.insert_with_path("a.c", json!(2))
+            .expect("should insert sibling");
+        assert_eq!(obj["a"]["c"], json!(2));
+        assert_eq!(obj["a"]["b"], json!(1));
+    }
 }


### PR DESCRIPTION
## Issue being fixed or feature implemented

Improves unit test coverage for four DPP utility modules that had low coverage:
- `util/cbor_value/canonical.rs` (28.8% -> improved)
- `util/json_value/mod.rs` (22.8% -> improved)
- `document/specialized_document_factory/v0/mod.rs` (8.2% -> improved)
- `data_contract/document_type/accessors/mod.rs` (42.6% -> improved)

## What was done?

Added 160 new unit tests across four files:

**`canonical.rs` (55 new tests):**
- `CborCanonicalMap` construction (`new`, `default`, `from_vector`, `from_serializable`)
- Insert, remove, get, get_mut, set operations
- Canonical sorting per RFC 7049 (shorter keys first, then lexicographic)
- Recursive sorting of nested maps and maps inside arrays
- Serialization to bytes and round-trip deserialization
- `to_value_unsorted`, `to_value_sorted`, `to_value_clone`
- `TryFrom<CborValue>` and `From` impls for Vec and BTreeMap
- `ValuesCollection` trait (`get`, `get_mut`, `remove`)
- `ReplacePaths` trait (`replace_paths`, `replace_path`, `get_path_mut`)
- `value_to_bytes` with Bytes, Text (base58), Array, and error cases
- `value_to_hash` with Bytes, Text (base58), Array, and error cases

**`json_value/mod.rs` (52 new tests):**
- All `JsonValueExt` trait methods: `push`, `insert`, `remove`, `remove_into`
- Numeric getters: `get_u8`, `get_u32`, `get_u64`, `get_i64`, `get_f64`
- Other getters: `get_string`, `get_bytes`, `get_bool`
- Path navigation: `get_value`, `get_value_mut`, `get_value_by_path`, `get_value_by_path_mut`
- Mutation: `remove_u32`, `add_protocol_version`, `remove_value_at_path_into`
- Free functions: `get_value_mut`, `get_value_from_json_path`, `get_value_from_json_path_mut`
- `insert_with_path` for deeply nested structure creation
- Error cases for all methods (missing property, wrong type, non-object/array)

**`document_type/accessors/mod.rs` (37 new tests):**
- All `DocumentTypeV0Getters` methods on `DocumentType`, `DocumentTypeRef`, `DocumentTypeMutRef`
- `DocumentTypeV0Setters` (`set_data_contract_id`) on `DocumentType` and `DocumentTypeMutRef`
- `DocumentTypeV0MutGetters` (`schema_mut`)
- `DocumentTypeV1Getters` on V0 variants (verify None/empty defaults)
- `DocumentTypeV1Setters` on V0 variants (verify no-op behavior)
- Tests with multiple fixture document types (indexedDocument, noTimeDocument, withByteArrays, niceDocument)
- `to_owned_document_type` from ref

**`specialized_document_factory/v0/mod.rs` (10 new tests):**
- Factory construction with default and custom entropy generators
- Document creation with valid and invalid document type names
- Document creation without time-based properties
- Extended document creation (valid and invalid)
- `is_ownership_the_same` helper with same, different, single, and empty ID sets

## How Has This Been Tested?

All 164 tests pass with `cargo test -p dpp`:
```
test result: ok. 164 passed; 0 failed; 0 ignored; 0 measured; 904 filtered out
```

Code was formatted with `cargo fmt -p dpp` and compiles without warnings.

## Breaking Changes

None. This PR only adds tests.

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [x] I have made corresponding changes to the documentation if needed