### PR TITLE
test(platform): improve platform-value coverage for inner_value, system_bytes, and serde

### DIFF
--- a/packages/rs-platform-value/src/inner_value.rs
+++ b/packages/rs-platform-value/src/inner_value.rs
@@ -970,3 +970,940 @@ impl Value {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Helper to build a Value::Map with string keys for testing
+    fn make_map(entries: Vec<(&str, Value)>) -> Value {
+        Value::Map(
+            entries
+                .into_iter()
+                .map(|(k, v)| (Value::Text(k.to_string()), v))
+                .collect(),
+        )
+    }
+
+    // ---------------------------------------------------------------
+    // has / get / get_mut
+    // ---------------------------------------------------------------
+
+    #[test]
+    fn has_returns_true_for_existing_key() {
+        let val = make_map(vec![("name", Value::Text("alice".into()))]);
+        assert!(val.has("name").unwrap());
+    }
+
+    #[test]
+    fn has_returns_false_for_missing_key() {
+        let val = make_map(vec![("name", Value::Text("alice".into()))]);
+        assert!(!val.has("age").unwrap());
+    }
+
+    #[test]
+    fn has_errors_on_non_map() {
+        let val = Value::U64(42);
+        assert!(val.has("key").is_err());
+    }
+
+    #[test]
+    fn get_returns_some_for_existing_key() {
+        let val = make_map(vec![("x", Value::U32(7))]);
+        let result = val.get("x").unwrap();
+        assert_eq!(result, Some(&Value::U32(7)));
+    }
+
+    #[test]
+    fn get_returns_none_for_missing_key() {
+        let val = make_map(vec![("x", Value::U32(7))]);
+        assert_eq!(val.get("y").unwrap(), None);
+    }
+
+    #[test]
+    fn get_mut_returns_mutable_ref() {
+        let mut val = make_map(vec![("x", Value::U32(7))]);
+        let inner = val.get_mut("x").unwrap().unwrap();
+        *inner = Value::U32(99);
+        assert_eq!(val.get("x").unwrap(), Some(&Value::U32(99)));
+    }
+
+    #[test]
+    fn get_value_returns_ref() {
+        let val = make_map(vec![("k", Value::Bool(true))]);
+        assert_eq!(val.get_value("k").unwrap(), &Value::Bool(true));
+    }
+
+    #[test]
+    fn get_value_errors_on_missing_key() {
+        let val = make_map(vec![("k", Value::Bool(true))]);
+        assert!(val.get_value("missing").is_err());
+    }
+
+    #[test]
+    fn get_value_mut_modifies_value() {
+        let mut val = make_map(vec![("k", Value::Bool(true))]);
+        let inner = val.get_value_mut("k").unwrap();
+        *inner = Value::Bool(false);
+        assert_eq!(val.get_value("k").unwrap(), &Value::Bool(false));
+    }
+
+    // ---------------------------------------------------------------
+    // set_into_value / set_value / insert / insert_at_end
+    // ---------------------------------------------------------------
+
+    #[test]
+    fn set_into_value_adds_new_key() {
+        let mut val = make_map(vec![]);
+        val.set_into_value("age", 42u64).unwrap();
+        let result: u64 = val.get_integer("age").unwrap();
+        assert_eq!(result, 42);
+    }
+
+    #[test]
+    fn set_into_value_replaces_existing() {
+        let mut val = make_map(vec![("age", Value::U64(10))]);
+        val.set_into_value("age", 42u64).unwrap();
+        let result: u64 = val.get_integer("age").unwrap();
+        assert_eq!(result, 42);
+    }
+
+    #[test]
+    fn set_into_binary_data_works() {
+        let mut val = make_map(vec![]);
+        val.set_into_binary_data("data", vec![1, 2, 3]).unwrap();
+        assert_eq!(val.get_value("data").unwrap(), &Value::Bytes(vec![1, 2, 3]));
+    }
+
+    #[test]
+    fn set_value_works() {
+        let mut val = make_map(vec![]);
+        val.set_value("flag", Value::Bool(true)).unwrap();
+        assert_eq!(val.get_value("flag").unwrap(), &Value::Bool(true));
+    }
+
+    #[test]
+    fn insert_sorted_position() {
+        let mut val = make_map(vec![("b", Value::U8(2))]);
+        val.insert("a".to_string(), Value::U8(1)).unwrap();
+        // After insert, "a" should exist
+        assert_eq!(val.get_value("a").unwrap(), &Value::U8(1));
+    }
+
+    #[test]
+    fn insert_at_end_appends() {
+        let mut val = make_map(vec![("a", Value::U8(1))]);
+        val.insert_at_end("z".to_string(), Value::U8(26)).unwrap();
+        assert_eq!(val.get_value("z").unwrap(), &Value::U8(26));
+    }
+
+    // ---------------------------------------------------------------
+    // remove / remove_many / remove_optional_value
+    // ---------------------------------------------------------------
+
+    #[test]
+    fn remove_existing_key() {
+        let mut val = make_map(vec![("k", Value::U64(1))]);
+        let removed = val.remove("k").unwrap();
+        assert_eq!(removed, Value::U64(1));
+        assert!(!val.has("k").unwrap());
+    }
+
+    #[test]
+    fn remove_missing_key_errors() {
+        let mut val = make_map(vec![("k", Value::U64(1))]);
+        assert!(val.remove("missing").is_err());
+    }
+
+    #[test]
+    fn remove_many_removes_all() {
+        let mut val = make_map(vec![
+            ("a", Value::U8(1)),
+            ("b", Value::U8(2)),
+            ("c", Value::U8(3)),
+        ]);
+        val.remove_many(&["a", "c"]).unwrap();
+        assert!(!val.has("a").unwrap());
+        assert!(val.has("b").unwrap());
+        assert!(!val.has("c").unwrap());
+    }
+
+    #[test]
+    fn remove_optional_value_returns_some() {
+        let mut val = make_map(vec![("k", Value::U64(1))]);
+        let result = val.remove_optional_value("k").unwrap();
+        assert_eq!(result, Some(Value::U64(1)));
+    }
+
+    #[test]
+    fn remove_optional_value_returns_none_for_missing() {
+        let mut val = make_map(vec![("k", Value::U64(1))]);
+        let result = val.remove_optional_value("missing").unwrap();
+        assert_eq!(result, None);
+    }
+
+    #[test]
+    fn remove_optional_value_if_null_removes_null() {
+        let mut val = make_map(vec![("k", Value::Null)]);
+        // Note: Null entries return None from get_optional_from_map, so we set directly
+        val.remove_optional_value_if_null("k").unwrap();
+    }
+
+    #[test]
+    fn remove_optional_value_if_empty_array_removes() {
+        let mut val = make_map(vec![("k", Value::Array(vec![]))]);
+        val.remove_optional_value_if_empty_array("k").unwrap();
+    }
+
+    // ---------------------------------------------------------------
+    // remove_integer / remove_optional_integer
+    // ---------------------------------------------------------------
+
+    #[test]
+    fn remove_integer_works() {
+        let mut val = make_map(vec![("n", Value::U64(42))]);
+        let result: u64 = val.remove_integer("n").unwrap();
+        assert_eq!(result, 42);
+    }
+
+    #[test]
+    fn remove_optional_integer_some() {
+        let mut val = make_map(vec![("n", Value::U32(99))]);
+        let result: Option<u32> = val.remove_optional_integer("n").unwrap();
+        assert_eq!(result, Some(99));
+    }
+
+    #[test]
+    fn remove_optional_integer_none_for_missing() {
+        let mut val = make_map(vec![("n", Value::U32(99))]);
+        let result: Option<u32> = val.remove_optional_integer("missing").unwrap();
+        assert_eq!(result, None);
+    }
+
+    // ---------------------------------------------------------------
+    // remove_identifier / remove_optional_identifier
+    // ---------------------------------------------------------------
+
+    #[test]
+    fn remove_identifier_works() {
+        let id_bytes = [7u8; 32];
+        let mut val = make_map(vec![("id", Value::Identifier(id_bytes))]);
+        let result = val.remove_identifier("id").unwrap();
+        assert_eq!(result, Identifier::new(id_bytes));
+    }
+
+    #[test]
+    fn remove_optional_identifier_some() {
+        let id_bytes = [8u8; 32];
+        let mut val = make_map(vec![("id", Value::Identifier(id_bytes))]);
+        let result = val.remove_optional_identifier("id").unwrap();
+        assert_eq!(result, Some(Identifier::new(id_bytes)));
+    }
+
+    #[test]
+    fn remove_optional_identifier_none_for_missing() {
+        let mut val = make_map(vec![("other", Value::U8(0))]);
+        let result = val.remove_optional_identifier("id").unwrap();
+        assert_eq!(result, None);
+    }
+
+    // ---------------------------------------------------------------
+    // remove_bytes_32 / remove_optional_bytes_32
+    // ---------------------------------------------------------------
+
+    #[test]
+    fn remove_bytes_32_works() {
+        let data = [3u8; 32];
+        let mut val = make_map(vec![("b", Value::Bytes32(data))]);
+        let result = val.remove_bytes_32("b").unwrap();
+        assert_eq!(result, Bytes32::new(data));
+    }
+
+    #[test]
+    fn remove_optional_bytes_32_returns_some() {
+        let data = [4u8; 32];
+        let mut val = make_map(vec![("b", Value::Bytes32(data))]);
+        let result = val.remove_optional_bytes_32("b").unwrap();
+        assert_eq!(result, Some(Bytes32::new(data)));
+    }
+
+    #[test]
+    fn remove_optional_bytes_32_returns_none_for_missing() {
+        let mut val = make_map(vec![]);
+        let result = val.remove_optional_bytes_32("b").unwrap();
+        assert_eq!(result, None);
+    }
+
+    // ---------------------------------------------------------------
+    // remove_hash256_bytes / remove_optional_hash256_bytes
+    // ---------------------------------------------------------------
+
+    #[test]
+    fn remove_hash256_bytes_works() {
+        let data = [9u8; 32];
+        let mut val = make_map(vec![("h", Value::Bytes32(data))]);
+        let result = val.remove_hash256_bytes("h").unwrap();
+        assert_eq!(result, data);
+    }
+
+    #[test]
+    fn remove_optional_hash256_bytes_some() {
+        let data = [10u8; 32];
+        let mut val = make_map(vec![("h", Value::Bytes32(data))]);
+        let result = val.remove_optional_hash256_bytes("h").unwrap();
+        assert_eq!(result, Some(data));
+    }
+
+    #[test]
+    fn remove_optional_hash256_bytes_none() {
+        let mut val = make_map(vec![]);
+        let result = val.remove_optional_hash256_bytes("h").unwrap();
+        assert_eq!(result, None);
+    }
+
+    // ---------------------------------------------------------------
+    // remove_bytes / remove_optional_bytes
+    // ---------------------------------------------------------------
+
+    #[test]
+    fn remove_bytes_works() {
+        let mut val = make_map(vec![("b", Value::Bytes(vec![1, 2, 3]))]);
+        let result = val.remove_bytes("b").unwrap();
+        assert_eq!(result, vec![1, 2, 3]);
+    }
+
+    #[test]
+    fn remove_optional_bytes_some() {
+        let mut val = make_map(vec![("b", Value::Bytes(vec![4, 5]))]);
+        let result = val.remove_optional_bytes("b").unwrap();
+        assert_eq!(result, Some(vec![4, 5]));
+    }
+
+    #[test]
+    fn remove_optional_bytes_none_for_missing() {
+        let mut val = make_map(vec![]);
+        let result = val.remove_optional_bytes("b").unwrap();
+        assert_eq!(result, None);
+    }
+
+    // ---------------------------------------------------------------
+    // remove_binary_data / remove_optional_binary_data
+    // ---------------------------------------------------------------
+
+    #[test]
+    fn remove_binary_data_works() {
+        let mut val = make_map(vec![("d", Value::Bytes(vec![10, 20]))]);
+        let result = val.remove_binary_data("d").unwrap();
+        assert_eq!(result, BinaryData::new(vec![10, 20]));
+    }
+
+    #[test]
+    fn remove_optional_binary_data_some() {
+        let mut val = make_map(vec![("d", Value::Bytes(vec![30]))]);
+        let result = val.remove_optional_binary_data("d").unwrap();
+        assert_eq!(result, Some(BinaryData::new(vec![30])));
+    }
+
+    #[test]
+    fn remove_optional_binary_data_none() {
+        let mut val = make_map(vec![]);
+        let result = val.remove_optional_binary_data("d").unwrap();
+        assert_eq!(result, None);
+    }
+
+    // ---------------------------------------------------------------
+    // remove_array / remove_optional_array
+    // ---------------------------------------------------------------
+
+    #[test]
+    fn remove_array_works() {
+        let mut val = make_map(vec![(
+            "arr",
+            Value::Array(vec![Value::U8(1), Value::U8(2)]),
+        )]);
+        let result = val.remove_array("arr").unwrap();
+        assert_eq!(result, vec![Value::U8(1), Value::U8(2)]);
+    }
+
+    #[test]
+    fn remove_optional_array_some() {
+        let mut val = make_map(vec![("arr", Value::Array(vec![Value::U8(3)]))]);
+        let result = val.remove_optional_array("arr").unwrap();
+        assert_eq!(result, Some(vec![Value::U8(3)]));
+    }
+
+    #[test]
+    fn remove_optional_array_none() {
+        let mut val = make_map(vec![]);
+        let result = val.remove_optional_array("arr").unwrap();
+        assert_eq!(result, None);
+    }
+
+    // ---------------------------------------------------------------
+    // get_integer / get_optional_integer
+    // ---------------------------------------------------------------
+
+    #[test]
+    fn get_integer_works() {
+        let val = make_map(vec![("n", Value::I64(-5))]);
+        let result: i64 = val.get_integer("n").unwrap();
+        assert_eq!(result, -5);
+    }
+
+    #[test]
+    fn get_integer_wrong_type() {
+        let val = make_map(vec![("n", Value::Text("hello".into()))]);
+        let result: Result<i64, Error> = val.get_integer("n");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn get_optional_integer_some() {
+        let val = make_map(vec![("n", Value::U16(100))]);
+        let result: Option<u16> = val.get_optional_integer("n").unwrap();
+        assert_eq!(result, Some(100));
+    }
+
+    #[test]
+    fn get_optional_integer_none_for_missing() {
+        let val = make_map(vec![]);
+        let result: Option<u16> = val.get_optional_integer("n").unwrap();
+        assert_eq!(result, None);
+    }
+
+    // ---------------------------------------------------------------
+    // get_str / get_optional_str
+    // ---------------------------------------------------------------
+
+    #[test]
+    fn get_str_works() {
+        let val = make_map(vec![("name", Value::Text("bob".into()))]);
+        assert_eq!(val.get_str("name").unwrap(), "bob");
+    }
+
+    #[test]
+    fn get_str_wrong_type() {
+        let val = make_map(vec![("name", Value::U64(5))]);
+        assert!(val.get_str("name").is_err());
+    }
+
+    #[test]
+    fn get_optional_str_some() {
+        let val = make_map(vec![("name", Value::Text("alice".into()))]);
+        assert_eq!(val.get_optional_str("name").unwrap(), Some("alice"));
+    }
+
+    #[test]
+    fn get_optional_str_none_for_missing() {
+        let val = make_map(vec![]);
+        assert_eq!(val.get_optional_str("name").unwrap(), None);
+    }
+
+    // ---------------------------------------------------------------
+    // get_bool / get_optional_bool
+    // ---------------------------------------------------------------
+
+    #[test]
+    fn get_bool_works() {
+        let val = make_map(vec![("flag", Value::Bool(true))]);
+        assert!(val.get_bool("flag").unwrap());
+    }
+
+    #[test]
+    fn get_bool_wrong_type() {
+        let val = make_map(vec![("flag", Value::U8(1))]);
+        assert!(val.get_bool("flag").is_err());
+    }
+
+    #[test]
+    fn get_optional_bool_some() {
+        let val = make_map(vec![("flag", Value::Bool(false))]);
+        assert_eq!(val.get_optional_bool("flag").unwrap(), Some(false));
+    }
+
+    #[test]
+    fn get_optional_bool_none_for_missing() {
+        let val = make_map(vec![]);
+        assert_eq!(val.get_optional_bool("flag").unwrap(), None);
+    }
+
+    // ---------------------------------------------------------------
+    // get_array / get_optional_array / get_array_ref / get_array_slice
+    // ---------------------------------------------------------------
+
+    #[test]
+    fn get_array_works() {
+        let val = make_map(vec![("a", Value::Array(vec![Value::U8(1)]))]);
+        let result = val.get_array("a").unwrap();
+        assert_eq!(result, vec![Value::U8(1)]);
+    }
+
+    #[test]
+    fn get_optional_array_some() {
+        let val = make_map(vec![("a", Value::Array(vec![Value::U8(2)]))]);
+        let result = val.get_optional_array("a").unwrap();
+        assert_eq!(result, Some(vec![Value::U8(2)]));
+    }
+
+    #[test]
+    fn get_optional_array_none() {
+        let val = make_map(vec![]);
+        let result = val.get_optional_array("a").unwrap();
+        assert_eq!(result, None);
+    }
+
+    #[test]
+    fn get_array_ref_works() {
+        let val = make_map(vec![("a", Value::Array(vec![Value::U8(3)]))]);
+        let result = val.get_array_ref("a").unwrap();
+        assert_eq!(result, &vec![Value::U8(3)]);
+    }
+
+    #[test]
+    fn get_array_slice_works() {
+        let val = make_map(vec![("a", Value::Array(vec![Value::U8(4)]))]);
+        let result = val.get_array_slice("a").unwrap();
+        assert_eq!(result, &[Value::U8(4)]);
+    }
+
+    #[test]
+    fn get_optional_array_slice_some() {
+        let val = make_map(vec![("a", Value::Array(vec![Value::U8(5)]))]);
+        let result = val.get_optional_array_slice("a").unwrap();
+        assert_eq!(result, Some([Value::U8(5)].as_slice()));
+    }
+
+    #[test]
+    fn get_optional_array_slice_none() {
+        let val = make_map(vec![]);
+        let result = val.get_optional_array_slice("a").unwrap();
+        assert_eq!(result, None);
+    }
+
+    #[test]
+    fn get_array_mut_ref_works() {
+        let mut val = make_map(vec![("a", Value::Array(vec![Value::U8(6)]))]);
+        let arr = val.get_array_mut_ref("a").unwrap();
+        arr.push(Value::U8(7));
+        assert_eq!(
+            val.get_array("a").unwrap(),
+            vec![Value::U8(6), Value::U8(7)]
+        );
+    }
+
+    #[test]
+    fn get_optional_array_mut_ref_some() {
+        let mut val = make_map(vec![("a", Value::Array(vec![Value::U8(8)]))]);
+        let result = val.get_optional_array_mut_ref("a").unwrap();
+        assert!(result.is_some());
+    }
+
+    #[test]
+    fn get_optional_array_mut_ref_none() {
+        let mut val = make_map(vec![]);
+        let result = val.get_optional_array_mut_ref("a").unwrap();
+        assert!(result.is_none());
+    }
+
+    // ---------------------------------------------------------------
+    // get_binary_data / get_optional_binary_data
+    // ---------------------------------------------------------------
+
+    #[test]
+    fn get_binary_data_works() {
+        let val = make_map(vec![("d", Value::Bytes(vec![1, 2]))]);
+        let result = val.get_binary_data("d").unwrap();
+        assert_eq!(result, BinaryData::new(vec![1, 2]));
+    }
+
+    #[test]
+    fn get_optional_binary_data_some() {
+        let val = make_map(vec![("d", Value::Bytes(vec![3]))]);
+        let result = val.get_optional_binary_data("d").unwrap();
+        assert_eq!(result, Some(BinaryData::new(vec![3])));
+    }
+
+    #[test]
+    fn get_optional_binary_data_none() {
+        let val = make_map(vec![]);
+        let result = val.get_optional_binary_data("d").unwrap();
+        assert_eq!(result, None);
+    }
+
+    // ---------------------------------------------------------------
+    // get_bytes / get_optional_bytes
+    // ---------------------------------------------------------------
+
+    #[test]
+    fn get_bytes_works() {
+        let val = make_map(vec![("b", Value::Bytes(vec![10, 11]))]);
+        let result = val.get_bytes("b").unwrap();
+        assert_eq!(result, vec![10, 11]);
+    }
+
+    #[test]
+    fn get_optional_bytes_some() {
+        let val = make_map(vec![("b", Value::Bytes(vec![12]))]);
+        let result = val.get_optional_bytes("b").unwrap();
+        assert_eq!(result, Some(vec![12]));
+    }
+
+    #[test]
+    fn get_optional_bytes_none() {
+        let val = make_map(vec![]);
+        let result = val.get_optional_bytes("b").unwrap();
+        assert_eq!(result, None);
+    }
+
+    // ---------------------------------------------------------------
+    // get_hash256 / get_optional_hash256 / get_identifier / get_optional_identifier
+    // ---------------------------------------------------------------
+
+    #[test]
+    fn get_hash256_works() {
+        let data = [5u8; 32];
+        let val = make_map(vec![("h", Value::Bytes32(data))]);
+        let result = val.get_hash256("h").unwrap();
+        assert_eq!(result, data);
+    }
+
+    #[test]
+    fn get_optional_hash256_some() {
+        let data = [6u8; 32];
+        let val = make_map(vec![("h", Value::Bytes32(data))]);
+        let result = val.get_optional_hash256("h").unwrap();
+        assert_eq!(result, Some(data));
+    }
+
+    #[test]
+    fn get_optional_hash256_none() {
+        let val = make_map(vec![]);
+        let result = val.get_optional_hash256("h").unwrap();
+        assert_eq!(result, None);
+    }
+
+    #[test]
+    fn get_identifier_works() {
+        let data = [11u8; 32];
+        let val = make_map(vec![("id", Value::Identifier(data))]);
+        let result = val.get_identifier("id").unwrap();
+        assert_eq!(result, Identifier::new(data));
+    }
+
+    #[test]
+    fn get_optional_identifier_some() {
+        let data = [12u8; 32];
+        let val = make_map(vec![("id", Value::Identifier(data))]);
+        let result = val.get_optional_identifier("id").unwrap();
+        assert_eq!(result, Some(Identifier::new(data)));
+    }
+
+    #[test]
+    fn get_optional_identifier_none() {
+        let val = make_map(vec![]);
+        let result = val.get_optional_identifier("id").unwrap();
+        assert_eq!(result, None);
+    }
+
+    #[test]
+    fn get_hash256_as_bs58_string_works() {
+        let data = [1u8; 32];
+        let val = make_map(vec![("h", Value::Bytes32(data))]);
+        let result = val.get_hash256_as_bs58_string("h").unwrap();
+        let expected = bs58::encode(data).into_string();
+        assert_eq!(result, expected);
+    }
+
+    // ---------------------------------------------------------------
+    // get_string_ref_map / get_optional_string_ref_map
+    // ---------------------------------------------------------------
+
+    #[test]
+    fn get_string_ref_map_works() {
+        let inner = Value::Map(vec![(Value::Text("nested_key".into()), Value::U8(42))]);
+        let val = make_map(vec![("m", inner)]);
+        let result: BTreeMap<String, &Value> = val.get_string_ref_map("m").unwrap();
+        assert_eq!(result.get("nested_key"), Some(&&Value::U8(42)));
+    }
+
+    #[test]
+    fn get_optional_string_ref_map_some() {
+        let inner = Value::Map(vec![(Value::Text("k".into()), Value::Bool(true))]);
+        let val = make_map(vec![("m", inner)]);
+        let result: Option<BTreeMap<String, &Value>> =
+            val.get_optional_string_ref_map("m").unwrap();
+        assert!(result.is_some());
+    }
+
+    #[test]
+    fn get_optional_string_ref_map_none_for_missing() {
+        let val = make_map(vec![]);
+        let result: Option<BTreeMap<String, &Value>> =
+            val.get_optional_string_ref_map("m").unwrap();
+        assert!(result.is_none());
+    }
+
+    // ---------------------------------------------------------------
+    // get_string_mut_ref_map / get_optional_string_mut_ref_map
+    // ---------------------------------------------------------------
+
+    #[test]
+    fn get_string_mut_ref_map_works() {
+        let inner = Value::Map(vec![(Value::Text("nested".into()), Value::U8(1))]);
+        let mut val = make_map(vec![("m", inner)]);
+        let result: BTreeMap<String, &mut Value> = val.get_string_mut_ref_map("m").unwrap();
+        assert!(result.contains_key("nested"));
+    }
+
+    #[test]
+    fn get_optional_string_mut_ref_map_some() {
+        let inner = Value::Map(vec![(Value::Text("k".into()), Value::Bool(true))]);
+        let mut val = make_map(vec![("m", inner)]);
+        let result: Option<BTreeMap<String, &mut Value>> =
+            val.get_optional_string_mut_ref_map("m").unwrap();
+        assert!(result.is_some());
+    }
+
+    #[test]
+    fn get_optional_string_mut_ref_map_none_for_missing() {
+        let mut val = make_map(vec![]);
+        let result: Option<BTreeMap<String, &mut Value>> =
+            val.get_optional_string_mut_ref_map("m").unwrap();
+        assert!(result.is_none());
+    }
+
+    // ---------------------------------------------------------------
+    // get_optional_bytes_into / get_bytes_into / get_optional_bytes_try_into / get_bytes_try_into
+    // ---------------------------------------------------------------
+
+    #[test]
+    fn get_optional_bytes_into_some() {
+        let val = make_map(vec![("b", Value::Bytes(vec![1, 2, 3]))]);
+        let result: Option<BinaryData> = val.get_optional_bytes_into("b").unwrap();
+        assert_eq!(result, Some(BinaryData::new(vec![1, 2, 3])));
+    }
+
+    #[test]
+    fn get_optional_bytes_into_none() {
+        let val = make_map(vec![]);
+        let result: Option<BinaryData> = val.get_optional_bytes_into("b").unwrap();
+        assert_eq!(result, None);
+    }
+
+    #[test]
+    fn get_bytes_into_works() {
+        let val = make_map(vec![("b", Value::Bytes(vec![4, 5]))]);
+        let result: BinaryData = val.get_bytes_into("b").unwrap();
+        assert_eq!(result, BinaryData::new(vec![4, 5]));
+    }
+
+    // ---------------------------------------------------------------
+    // inner_optional_array_of_strings
+    // ---------------------------------------------------------------
+
+    #[test]
+    fn inner_optional_array_of_strings_returns_some() {
+        let map: Vec<(Value, Value)> = vec![(
+            Value::Text("strs".into()),
+            Value::Array(vec![Value::Text("a".into()), Value::Text("b".into())]),
+        )];
+        let result: Option<Vec<String>> = Value::inner_optional_array_of_strings(&map, "strs");
+        assert_eq!(result, Some(vec!["a".to_string(), "b".to_string()]));
+    }
+
+    #[test]
+    fn inner_optional_array_of_strings_returns_none_for_missing() {
+        let map: Vec<(Value, Value)> = vec![];
+        let result: Option<Vec<String>> = Value::inner_optional_array_of_strings(&map, "strs");
+        assert_eq!(result, None);
+    }
+
+    #[test]
+    fn inner_optional_array_of_strings_returns_none_for_non_array() {
+        let map: Vec<(Value, Value)> = vec![(Value::Text("strs".into()), Value::U8(1))];
+        let result: Option<Vec<String>> = Value::inner_optional_array_of_strings(&map, "strs");
+        assert_eq!(result, None);
+    }
+
+    // ---------------------------------------------------------------
+    // inner_recursive_optional_array_of_strings
+    // ---------------------------------------------------------------
+
+    #[test]
+    fn inner_recursive_optional_array_of_strings_basic() {
+        let map: Vec<(Value, Value)> = vec![(
+            Value::Text("required".into()),
+            Value::Array(vec![Value::Text("field1".into())]),
+        )];
+        let result = Value::inner_recursive_optional_array_of_strings(
+            &map,
+            "".to_string(),
+            "properties",
+            "required",
+        );
+        assert!(result.contains("field1"));
+    }
+
+    #[test]
+    fn inner_recursive_optional_array_of_strings_recursive() {
+        let inner_map: Vec<(Value, Value)> = vec![(
+            Value::Text("required".into()),
+            Value::Array(vec![Value::Text("sub_field".into())]),
+        )];
+        let map: Vec<(Value, Value)> = vec![
+            (
+                Value::Text("required".into()),
+                Value::Array(vec![Value::Text("top_field".into())]),
+            ),
+            (
+                Value::Text("properties".into()),
+                Value::Map(vec![(Value::Text("nested".into()), Value::Map(inner_map))]),
+            ),
+        ];
+        let result = Value::inner_recursive_optional_array_of_strings(
+            &map,
+            "".to_string(),
+            "properties",
+            "required",
+        );
+        assert!(result.contains("top_field"));
+        assert!(result.contains("nested.sub_field"));
+    }
+
+    // ---------------------------------------------------------------
+    // get_from_map / get_optional_from_map / get_mut_from_map / get_optional_mut_from_map
+    // ---------------------------------------------------------------
+
+    #[test]
+    fn get_from_map_returns_value() {
+        let map: Vec<(Value, Value)> = vec![(Value::Text("k".into()), Value::U64(99))];
+        let result = Value::get_from_map(&map, "k").unwrap();
+        assert_eq!(result, &Value::U64(99));
+    }
+
+    #[test]
+    fn get_from_map_errors_for_missing() {
+        let map: Vec<(Value, Value)> = vec![];
+        assert!(Value::get_from_map(&map, "k").is_err());
+    }
+
+    #[test]
+    fn get_optional_from_map_returns_none_for_null() {
+        let map: Vec<(Value, Value)> = vec![(Value::Text("k".into()), Value::Null)];
+        let result = Value::get_optional_from_map(&map, "k");
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn get_optional_from_map_skips_non_text_keys() {
+        let map: Vec<(Value, Value)> = vec![(Value::U8(1), Value::U64(99))];
+        let result = Value::get_optional_from_map(&map, "1");
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn get_mut_from_map_works() {
+        let mut map: Vec<(Value, Value)> = vec![(Value::Text("k".into()), Value::U64(1))];
+        let result = Value::get_mut_from_map(&mut map, "k").unwrap();
+        *result = Value::U64(2);
+        assert_eq!(map[0].1, Value::U64(2));
+    }
+
+    #[test]
+    fn get_optional_mut_from_map_returns_none_for_null() {
+        let mut map: Vec<(Value, Value)> = vec![(Value::Text("k".into()), Value::Null)];
+        let result = Value::get_optional_mut_from_map(&mut map, "k");
+        assert!(result.is_none());
+    }
+
+    // ---------------------------------------------------------------
+    // insert_in_map / insert_in_map_string_value / push_to_map_string_value
+    // ---------------------------------------------------------------
+
+    #[test]
+    fn insert_in_map_adds_new_entry() {
+        let mut map: Vec<(Value, Value)> = vec![];
+        Value::insert_in_map(&mut map, "key", Value::U8(1));
+        assert_eq!(map.len(), 1);
+        assert_eq!(map[0].1, Value::U8(1));
+    }
+
+    #[test]
+    fn insert_in_map_replaces_existing() {
+        let mut map: Vec<(Value, Value)> = vec![(Value::Text("key".into()), Value::U8(1))];
+        Value::insert_in_map(&mut map, "key", Value::U8(2));
+        assert_eq!(map.len(), 1);
+        assert_eq!(map[0].1, Value::U8(2));
+    }
+
+    #[test]
+    fn insert_in_map_string_value_adds_new() {
+        let mut map: Vec<(Value, Value)> = vec![];
+        Value::insert_in_map_string_value(&mut map, "b".to_string(), Value::U8(2));
+        assert_eq!(map.len(), 1);
+    }
+
+    #[test]
+    fn insert_in_map_string_value_replaces_existing() {
+        let mut map: Vec<(Value, Value)> = vec![(Value::Text("b".into()), Value::U8(1))];
+        Value::insert_in_map_string_value(&mut map, "b".to_string(), Value::U8(99));
+        assert_eq!(map.len(), 1);
+        assert_eq!(map[0].1, Value::U8(99));
+    }
+
+    #[test]
+    fn push_to_map_string_value_adds_new() {
+        let mut map: Vec<(Value, Value)> = vec![];
+        Value::push_to_map_string_value(&mut map, "z".to_string(), Value::U8(26));
+        assert_eq!(map.len(), 1);
+        assert_eq!(map[0].1, Value::U8(26));
+    }
+
+    #[test]
+    fn push_to_map_string_value_replaces_existing() {
+        let mut map: Vec<(Value, Value)> = vec![(Value::Text("z".into()), Value::U8(1))];
+        Value::push_to_map_string_value(&mut map, "z".to_string(), Value::U8(100));
+        assert_eq!(map.len(), 1);
+        assert_eq!(map[0].1, Value::U8(100));
+    }
+
+    // ---------------------------------------------------------------
+    // Error cases: calling map methods on non-map values
+    // ---------------------------------------------------------------
+
+    #[test]
+    fn get_str_on_non_map_errors() {
+        let val = Value::U64(42);
+        assert!(val.get_str("key").is_err());
+    }
+
+    #[test]
+    fn get_bool_on_non_map_errors() {
+        let val = Value::U64(42);
+        assert!(val.get_bool("key").is_err());
+    }
+
+    #[test]
+    fn get_bytes_on_non_map_errors() {
+        let val = Value::U64(42);
+        assert!(val.get_bytes("key").is_err());
+    }
+
+    #[test]
+    fn remove_on_non_map_errors() {
+        let mut val = Value::U64(42);
+        assert!(val.remove("key").is_err());
+    }
+
+    #[test]
+    fn set_value_on_non_map_errors() {
+        let mut val = Value::U64(42);
+        assert!(val.set_value("key", Value::Bool(true)).is_err());
+    }
+
+    #[test]
+    fn insert_on_non_map_errors() {
+        let mut val = Value::U64(42);
+        assert!(val.insert("key".to_string(), Value::Bool(true)).is_err());
+    }
+}

--- a/packages/rs-platform-value/src/system_bytes.rs
+++ b/packages/rs-platform-value/src/system_bytes.rs
@@ -744,3 +744,728 @@ impl Value {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ---------------------------------------------------------------
+    // into_identifier_bytes / to_identifier_bytes  (base-58 encoding)
+    // ---------------------------------------------------------------
+
+    #[test]
+    fn into_identifier_bytes_from_bytes() {
+        let val = Value::Bytes(vec![1, 2, 3]);
+        assert_eq!(val.into_identifier_bytes().unwrap(), vec![1, 2, 3]);
+    }
+
+    #[test]
+    fn into_identifier_bytes_from_text_bs58() {
+        // "a811" is a valid base58 string
+        let val = Value::Text("a811".to_string());
+        let result = val.into_identifier_bytes().unwrap();
+        // Verify round-trip: encode back to base58
+        let encoded = bs58::encode(&result).into_string();
+        assert_eq!(encoded, "a811");
+    }
+
+    #[test]
+    fn into_identifier_bytes_from_array_of_u8() {
+        let val = Value::Array(vec![Value::U8(10), Value::U8(20), Value::U8(30)]);
+        assert_eq!(val.into_identifier_bytes().unwrap(), vec![10, 20, 30]);
+    }
+
+    #[test]
+    fn into_identifier_bytes_from_identifier() {
+        let id = [7u8; 32];
+        let val = Value::Identifier(id);
+        assert_eq!(val.into_identifier_bytes().unwrap(), id.to_vec());
+    }
+
+    #[test]
+    fn into_identifier_bytes_from_bytes32() {
+        let data = [3u8; 32];
+        let val = Value::Bytes32(data);
+        assert_eq!(val.into_identifier_bytes().unwrap(), data.to_vec());
+    }
+
+    #[test]
+    fn into_identifier_bytes_wrong_type_errors() {
+        let val = Value::Bool(true);
+        assert!(val.into_identifier_bytes().is_err());
+    }
+
+    #[test]
+    fn into_identifier_bytes_bad_array_element_errors() {
+        let val = Value::Array(vec![Value::Text("not_a_byte".into())]);
+        assert!(val.into_identifier_bytes().is_err());
+    }
+
+    #[test]
+    fn to_identifier_bytes_round_trip() {
+        let original = vec![50, 100, 150, 200];
+        let val = Value::Bytes(original.clone());
+        assert_eq!(val.to_identifier_bytes().unwrap(), original);
+    }
+
+    #[test]
+    fn to_identifier_bytes_from_text_bs58() {
+        let val = Value::Text("a811".to_string());
+        let result = val.to_identifier_bytes().unwrap();
+        let encoded = bs58::encode(&result).into_string();
+        assert_eq!(encoded, "a811");
+    }
+
+    #[test]
+    fn to_identifier_bytes_from_array() {
+        let val = Value::Array(vec![Value::U8(5), Value::U8(10)]);
+        assert_eq!(val.to_identifier_bytes().unwrap(), vec![5, 10]);
+    }
+
+    #[test]
+    fn to_identifier_bytes_from_bytes32() {
+        let data = [9u8; 32];
+        let val = Value::Bytes32(data);
+        assert_eq!(val.to_identifier_bytes().unwrap(), data.to_vec());
+    }
+
+    #[test]
+    fn to_identifier_bytes_from_identifier() {
+        let id = [11u8; 32];
+        let val = Value::Identifier(id);
+        assert_eq!(val.to_identifier_bytes().unwrap(), id.to_vec());
+    }
+
+    #[test]
+    fn to_identifier_bytes_wrong_type_errors() {
+        let val = Value::Float(1.0);
+        assert!(val.to_identifier_bytes().is_err());
+    }
+
+    // ---------------------------------------------------------------
+    // into_binary_bytes / to_binary_bytes  (base-64 encoding)
+    // ---------------------------------------------------------------
+
+    #[test]
+    fn into_binary_bytes_from_bytes() {
+        let val = Value::Bytes(vec![1, 2, 3]);
+        assert_eq!(val.into_binary_bytes().unwrap(), vec![1, 2, 3]);
+    }
+
+    #[test]
+    fn into_binary_bytes_from_text_b64() {
+        // base64 "AQID" = [1, 2, 3]
+        let val = Value::Text("AQID".to_string());
+        assert_eq!(val.into_binary_bytes().unwrap(), vec![1, 2, 3]);
+    }
+
+    #[test]
+    fn into_binary_bytes_from_array_of_u8() {
+        let val = Value::Array(vec![Value::U8(4), Value::U8(5)]);
+        assert_eq!(val.into_binary_bytes().unwrap(), vec![4, 5]);
+    }
+
+    #[test]
+    fn into_binary_bytes_from_identifier() {
+        let id = [2u8; 32];
+        let val = Value::Identifier(id);
+        assert_eq!(val.into_binary_bytes().unwrap(), id.to_vec());
+    }
+
+    #[test]
+    fn into_binary_bytes_from_bytes32() {
+        let data = [6u8; 32];
+        let val = Value::Bytes32(data);
+        assert_eq!(val.into_binary_bytes().unwrap(), data.to_vec());
+    }
+
+    #[test]
+    fn into_binary_bytes_wrong_type_errors() {
+        let val = Value::Bool(false);
+        assert!(val.into_binary_bytes().is_err());
+    }
+
+    #[test]
+    fn into_binary_bytes_bad_b64_errors() {
+        // "!!!!" is not valid base64
+        let val = Value::Text("!!!!".to_string());
+        assert!(val.into_binary_bytes().is_err());
+    }
+
+    #[test]
+    fn to_binary_bytes_round_trip() {
+        let original = vec![10, 20, 30, 40];
+        let val = Value::Bytes(original.clone());
+        assert_eq!(val.to_binary_bytes().unwrap(), original);
+    }
+
+    #[test]
+    fn to_binary_bytes_from_text_b64() {
+        let val = Value::Text("AQID".to_string());
+        assert_eq!(val.to_binary_bytes().unwrap(), vec![1, 2, 3]);
+    }
+
+    #[test]
+    fn to_binary_bytes_from_bytes20() {
+        let data = [8u8; 20];
+        let val = Value::Bytes20(data);
+        assert_eq!(val.to_binary_bytes().unwrap(), data.to_vec());
+    }
+
+    #[test]
+    fn to_binary_bytes_from_bytes32() {
+        let data = [9u8; 32];
+        let val = Value::Bytes32(data);
+        assert_eq!(val.to_binary_bytes().unwrap(), data.to_vec());
+    }
+
+    #[test]
+    fn to_binary_bytes_from_bytes36() {
+        let data = [10u8; 36];
+        let val = Value::Bytes36(data);
+        assert_eq!(val.to_binary_bytes().unwrap(), data.to_vec());
+    }
+
+    #[test]
+    fn to_binary_bytes_from_identifier() {
+        let id = [11u8; 32];
+        let val = Value::Identifier(id);
+        assert_eq!(val.to_binary_bytes().unwrap(), id.to_vec());
+    }
+
+    #[test]
+    fn to_binary_bytes_wrong_type_errors() {
+        let val = Value::Null;
+        assert!(val.to_binary_bytes().is_err());
+    }
+
+    // ---------------------------------------------------------------
+    // into_binary_data / to_binary_data (wraps binary_bytes)
+    // ---------------------------------------------------------------
+
+    #[test]
+    fn into_binary_data_from_bytes() {
+        let val = Value::Bytes(vec![1, 2, 3]);
+        assert_eq!(
+            val.into_binary_data().unwrap(),
+            BinaryData::new(vec![1, 2, 3])
+        );
+    }
+
+    #[test]
+    fn into_binary_data_from_identifier() {
+        let id = [5u8; 32];
+        let val = Value::Identifier(id);
+        assert_eq!(
+            val.into_binary_data().unwrap(),
+            BinaryData::new(id.to_vec())
+        );
+    }
+
+    #[test]
+    fn into_binary_data_wrong_type_errors() {
+        let val = Value::Bool(true);
+        assert!(val.into_binary_data().is_err());
+    }
+
+    // ---------------------------------------------------------------
+    // into_hash256 / to_hash256
+    // ---------------------------------------------------------------
+
+    #[test]
+    fn into_hash256_from_bytes32() {
+        let data = [4u8; 32];
+        let val = Value::Bytes32(data);
+        assert_eq!(val.into_hash256().unwrap(), data);
+    }
+
+    #[test]
+    fn into_hash256_from_identifier() {
+        let data = [5u8; 32];
+        let val = Value::Identifier(data);
+        assert_eq!(val.into_hash256().unwrap(), data);
+    }
+
+    #[test]
+    fn into_hash256_from_bytes_correct_length() {
+        let data = vec![6u8; 32];
+        let val = Value::Bytes(data.clone());
+        assert_eq!(
+            val.into_hash256().unwrap(),
+            <[u8; 32]>::try_from(data.as_slice()).unwrap()
+        );
+    }
+
+    #[test]
+    fn into_hash256_from_bytes_wrong_length_errors() {
+        let val = Value::Bytes(vec![1, 2, 3]);
+        assert!(val.into_hash256().is_err());
+    }
+
+    #[test]
+    fn into_hash256_from_text_bs58_valid() {
+        // Create a valid 32-byte bs58 string
+        let data = [7u8; 32];
+        let encoded = bs58::encode(data).into_string();
+        let val = Value::Text(encoded);
+        assert_eq!(val.into_hash256().unwrap(), data);
+    }
+
+    #[test]
+    fn into_hash256_from_text_bs58_wrong_length() {
+        // "a811" decodes to 3 bytes, not 32
+        let val = Value::Text("a811".to_string());
+        assert!(val.into_hash256().is_err());
+    }
+
+    #[test]
+    fn into_hash256_from_text_invalid_bs58() {
+        let val = Value::Text("a811Ii".to_string());
+        assert!(val.into_hash256().is_err());
+    }
+
+    #[test]
+    fn into_hash256_from_array_of_32_u8s() {
+        let arr: Vec<Value> = (0..32).map(|i| Value::U8(i as u8)).collect();
+        let val = Value::Array(arr);
+        let expected: [u8; 32] = core::array::from_fn(|i| i as u8);
+        assert_eq!(val.into_hash256().unwrap(), expected);
+    }
+
+    #[test]
+    fn into_hash256_from_array_wrong_length() {
+        let val = Value::Array(vec![Value::U8(1), Value::U8(2)]);
+        assert!(val.into_hash256().is_err());
+    }
+
+    #[test]
+    fn into_hash256_wrong_type_errors() {
+        let val = Value::Bool(true);
+        assert!(val.into_hash256().is_err());
+    }
+
+    #[test]
+    fn to_hash256_from_bytes32() {
+        let data = [8u8; 32];
+        let val = Value::Bytes32(data);
+        assert_eq!(val.to_hash256().unwrap(), data);
+    }
+
+    #[test]
+    fn to_hash256_from_identifier() {
+        let data = [9u8; 32];
+        let val = Value::Identifier(data);
+        assert_eq!(val.to_hash256().unwrap(), data);
+    }
+
+    #[test]
+    fn to_hash256_from_bytes_correct_length() {
+        let data = vec![10u8; 32];
+        let val = Value::Bytes(data.clone());
+        assert_eq!(
+            val.to_hash256().unwrap(),
+            <[u8; 32]>::try_from(data.as_slice()).unwrap()
+        );
+    }
+
+    #[test]
+    fn to_hash256_from_bytes_wrong_length_errors() {
+        let val = Value::Bytes(vec![1, 2]);
+        assert!(val.to_hash256().is_err());
+    }
+
+    #[test]
+    fn to_hash256_round_trip_with_bs58() {
+        let data = [11u8; 32];
+        let encoded = bs58::encode(data).into_string();
+        let val = Value::Text(encoded);
+        assert_eq!(val.to_hash256().unwrap(), data);
+    }
+
+    #[test]
+    fn to_hash256_wrong_type_errors() {
+        let val = Value::Float(1.0);
+        assert!(val.to_hash256().is_err());
+    }
+
+    // ---------------------------------------------------------------
+    // into_bytes_20 / to_bytes_20
+    // ---------------------------------------------------------------
+
+    #[test]
+    fn into_bytes_20_from_bytes20() {
+        let data = [1u8; 20];
+        let val = Value::Bytes20(data);
+        assert_eq!(val.into_bytes_20().unwrap(), Bytes20::new(data));
+    }
+
+    #[test]
+    fn into_bytes_20_from_bytes_correct_length() {
+        let data = vec![2u8; 20];
+        let val = Value::Bytes(data);
+        assert_eq!(val.into_bytes_20().unwrap(), Bytes20::new([2u8; 20]));
+    }
+
+    #[test]
+    fn into_bytes_20_from_bytes_wrong_length_errors() {
+        let val = Value::Bytes(vec![1, 2, 3]);
+        assert!(val.into_bytes_20().is_err());
+    }
+
+    #[test]
+    fn into_bytes_20_from_text_b64_round_trip() {
+        let data = [3u8; 20];
+        let encoded = base64::engine::general_purpose::STANDARD.encode(data);
+        let val = Value::Text(encoded);
+        assert_eq!(val.into_bytes_20().unwrap(), Bytes20::new(data));
+    }
+
+    #[test]
+    fn into_bytes_20_from_text_b64_wrong_length() {
+        // "AQID" = 3 bytes, not 20
+        let val = Value::Text("AQID".to_string());
+        assert!(val.into_bytes_20().is_err());
+    }
+
+    #[test]
+    fn into_bytes_20_from_array_of_20_u8s() {
+        let arr: Vec<Value> = (0..20).map(|i| Value::U8(i as u8)).collect();
+        let val = Value::Array(arr);
+        let expected: [u8; 20] = core::array::from_fn(|i| i as u8);
+        assert_eq!(val.into_bytes_20().unwrap(), Bytes20::new(expected));
+    }
+
+    #[test]
+    fn into_bytes_20_wrong_type_errors() {
+        let val = Value::Bool(true);
+        assert!(val.into_bytes_20().is_err());
+    }
+
+    #[test]
+    fn to_bytes_20_from_bytes20() {
+        let data = [4u8; 20];
+        let val = Value::Bytes20(data);
+        assert_eq!(val.to_bytes_20().unwrap(), Bytes20::new(data));
+    }
+
+    #[test]
+    fn to_bytes_20_from_bytes_correct_length() {
+        let data = vec![5u8; 20];
+        let val = Value::Bytes(data);
+        assert_eq!(val.to_bytes_20().unwrap(), Bytes20::new([5u8; 20]));
+    }
+
+    #[test]
+    fn to_bytes_20_from_text_b64_round_trip() {
+        let data = [6u8; 20];
+        let encoded = base64::engine::general_purpose::STANDARD.encode(data);
+        let val = Value::Text(encoded);
+        assert_eq!(val.to_bytes_20().unwrap(), Bytes20::new(data));
+    }
+
+    #[test]
+    fn to_bytes_20_wrong_type_errors() {
+        let val = Value::Null;
+        assert!(val.to_bytes_20().is_err());
+    }
+
+    // ---------------------------------------------------------------
+    // into_bytes_32 / to_bytes_32
+    // ---------------------------------------------------------------
+
+    #[test]
+    fn into_bytes_32_from_bytes32() {
+        let data = [1u8; 32];
+        let val = Value::Bytes32(data);
+        assert_eq!(val.into_bytes_32().unwrap(), Bytes32::new(data));
+    }
+
+    #[test]
+    fn into_bytes_32_from_bytes_correct_length() {
+        let data = vec![2u8; 32];
+        let val = Value::Bytes(data);
+        assert_eq!(val.into_bytes_32().unwrap(), Bytes32::new([2u8; 32]));
+    }
+
+    #[test]
+    fn into_bytes_32_from_bytes_wrong_length_errors() {
+        let val = Value::Bytes(vec![1, 2, 3]);
+        assert!(val.into_bytes_32().is_err());
+    }
+
+    #[test]
+    fn into_bytes_32_from_identifier() {
+        let data = [3u8; 32];
+        let val = Value::Identifier(data);
+        assert_eq!(val.into_bytes_32().unwrap(), Bytes32::new(data));
+    }
+
+    #[test]
+    fn into_bytes_32_from_text_b64_round_trip() {
+        let data = [4u8; 32];
+        let encoded = base64::engine::general_purpose::STANDARD.encode(data);
+        let val = Value::Text(encoded);
+        assert_eq!(val.into_bytes_32().unwrap(), Bytes32::new(data));
+    }
+
+    #[test]
+    fn into_bytes_32_from_text_b64_wrong_length() {
+        let val = Value::Text("AQID".to_string());
+        assert!(val.into_bytes_32().is_err());
+    }
+
+    #[test]
+    fn into_bytes_32_from_text_invalid_b64_errors() {
+        let val = Value::Text("a811Ii".to_string());
+        assert!(val.into_bytes_32().is_err());
+    }
+
+    #[test]
+    fn into_bytes_32_from_array_of_32_u8s() {
+        let arr: Vec<Value> = (0..32).map(|i| Value::U8(i as u8)).collect();
+        let val = Value::Array(arr);
+        let expected: [u8; 32] = core::array::from_fn(|i| i as u8);
+        assert_eq!(val.into_bytes_32().unwrap(), Bytes32::new(expected));
+    }
+
+    #[test]
+    fn into_bytes_32_wrong_type_errors() {
+        let val = Value::Bool(true);
+        assert!(val.into_bytes_32().is_err());
+    }
+
+    #[test]
+    fn to_bytes_32_from_bytes32() {
+        let data = [5u8; 32];
+        let val = Value::Bytes32(data);
+        assert_eq!(val.to_bytes_32().unwrap(), Bytes32::new(data));
+    }
+
+    #[test]
+    fn to_bytes_32_from_identifier() {
+        let data = [6u8; 32];
+        let val = Value::Identifier(data);
+        assert_eq!(val.to_bytes_32().unwrap(), Bytes32::new(data));
+    }
+
+    #[test]
+    fn to_bytes_32_from_bytes_correct_length() {
+        let data = vec![7u8; 32];
+        let val = Value::Bytes(data);
+        assert_eq!(val.to_bytes_32().unwrap(), Bytes32::new([7u8; 32]));
+    }
+
+    #[test]
+    fn to_bytes_32_from_text_b64_round_trip() {
+        let data = [8u8; 32];
+        let encoded = base64::engine::general_purpose::STANDARD.encode(data);
+        let val = Value::Text(encoded);
+        assert_eq!(val.to_bytes_32().unwrap(), Bytes32::new(data));
+    }
+
+    #[test]
+    fn to_bytes_32_wrong_type_errors() {
+        let val = Value::Float(1.0);
+        assert!(val.to_bytes_32().is_err());
+    }
+
+    // ---------------------------------------------------------------
+    // into_bytes_36 / to_bytes_36
+    // ---------------------------------------------------------------
+
+    #[test]
+    fn into_bytes_36_from_bytes36() {
+        let data = [1u8; 36];
+        let val = Value::Bytes36(data);
+        assert_eq!(val.into_bytes_36().unwrap(), Bytes36::new(data));
+    }
+
+    #[test]
+    fn into_bytes_36_from_bytes_correct_length() {
+        let data = vec![2u8; 36];
+        let val = Value::Bytes(data);
+        assert_eq!(val.into_bytes_36().unwrap(), Bytes36::new([2u8; 36]));
+    }
+
+    #[test]
+    fn into_bytes_36_from_bytes_wrong_length_errors() {
+        let val = Value::Bytes(vec![1, 2, 3]);
+        assert!(val.into_bytes_36().is_err());
+    }
+
+    #[test]
+    fn into_bytes_36_from_text_b64_round_trip() {
+        let data = [3u8; 36];
+        let encoded = base64::engine::general_purpose::STANDARD.encode(data);
+        let val = Value::Text(encoded);
+        assert_eq!(val.into_bytes_36().unwrap(), Bytes36::new(data));
+    }
+
+    #[test]
+    fn into_bytes_36_from_text_b64_wrong_length() {
+        let val = Value::Text("AQID".to_string());
+        assert!(val.into_bytes_36().is_err());
+    }
+
+    #[test]
+    fn into_bytes_36_from_text_invalid_b64_errors() {
+        let val = Value::Text("a811Ii".to_string());
+        assert!(val.into_bytes_36().is_err());
+    }
+
+    #[test]
+    fn into_bytes_36_from_array_of_36_u8s() {
+        let arr: Vec<Value> = (0..36).map(|i| Value::U8(i as u8)).collect();
+        let val = Value::Array(arr);
+        let expected: [u8; 36] = core::array::from_fn(|i| i as u8);
+        assert_eq!(val.into_bytes_36().unwrap(), Bytes36::new(expected));
+    }
+
+    #[test]
+    fn into_bytes_36_wrong_type_errors() {
+        let val = Value::Bool(true);
+        assert!(val.into_bytes_36().is_err());
+    }
+
+    #[test]
+    fn to_bytes_36_from_bytes36() {
+        let data = [4u8; 36];
+        let val = Value::Bytes36(data);
+        assert_eq!(val.to_bytes_36().unwrap(), Bytes36::new(data));
+    }
+
+    #[test]
+    fn to_bytes_36_from_bytes_correct_length() {
+        let data = vec![5u8; 36];
+        let val = Value::Bytes(data);
+        assert_eq!(val.to_bytes_36().unwrap(), Bytes36::new([5u8; 36]));
+    }
+
+    #[test]
+    fn to_bytes_36_from_text_b64_round_trip() {
+        let data = [6u8; 36];
+        let encoded = base64::engine::general_purpose::STANDARD.encode(data);
+        let val = Value::Text(encoded);
+        assert_eq!(val.to_bytes_36().unwrap(), Bytes36::new(data));
+    }
+
+    #[test]
+    fn to_bytes_36_wrong_type_errors() {
+        let val = Value::Null;
+        assert!(val.to_bytes_36().is_err());
+    }
+
+    // ---------------------------------------------------------------
+    // into_identifier / to_identifier
+    // ---------------------------------------------------------------
+
+    #[test]
+    fn into_identifier_from_identifier() {
+        let data = [1u8; 32];
+        let val = Value::Identifier(data);
+        assert_eq!(val.into_identifier().unwrap(), Identifier::new(data));
+    }
+
+    #[test]
+    fn into_identifier_from_bytes32() {
+        let data = [2u8; 32];
+        let val = Value::Bytes32(data);
+        assert_eq!(val.into_identifier().unwrap(), Identifier::new(data));
+    }
+
+    #[test]
+    fn into_identifier_from_bytes_correct_length() {
+        let data = vec![3u8; 32];
+        let val = Value::Bytes(data);
+        assert_eq!(val.into_identifier().unwrap(), Identifier::new([3u8; 32]));
+    }
+
+    #[test]
+    fn into_identifier_from_bytes_wrong_length_errors() {
+        let val = Value::Bytes(vec![1, 2, 3]);
+        assert!(val.into_identifier().is_err());
+    }
+
+    #[test]
+    fn into_identifier_from_text_bs58_round_trip() {
+        let data = [4u8; 32];
+        let encoded = bs58::encode(data).into_string();
+        let val = Value::Text(encoded);
+        assert_eq!(val.into_identifier().unwrap(), Identifier::new(data));
+    }
+
+    #[test]
+    fn into_identifier_from_text_bs58_wrong_length() {
+        let val = Value::Text("a811".to_string());
+        assert!(val.into_identifier().is_err());
+    }
+
+    #[test]
+    fn into_identifier_from_text_invalid_bs58() {
+        let val = Value::Text("a811Ii".to_string());
+        assert!(val.into_identifier().is_err());
+    }
+
+    #[test]
+    fn into_identifier_from_array_of_32_u8s() {
+        let arr: Vec<Value> = (0..32).map(|i| Value::U8(i as u8)).collect();
+        let val = Value::Array(arr);
+        let expected: [u8; 32] = core::array::from_fn(|i| i as u8);
+        assert_eq!(val.into_identifier().unwrap(), Identifier::new(expected));
+    }
+
+    #[test]
+    fn into_identifier_from_array_wrong_length() {
+        let val = Value::Array(vec![Value::U8(1), Value::U8(2)]);
+        assert!(val.into_identifier().is_err());
+    }
+
+    #[test]
+    fn into_identifier_wrong_type_errors() {
+        let val = Value::Bool(true);
+        assert!(val.into_identifier().is_err());
+    }
+
+    #[test]
+    fn to_identifier_from_identifier() {
+        let data = [5u8; 32];
+        let val = Value::Identifier(data);
+        assert_eq!(val.to_identifier().unwrap(), Identifier::new(data));
+    }
+
+    #[test]
+    fn to_identifier_from_bytes32() {
+        let data = [6u8; 32];
+        let val = Value::Bytes32(data);
+        assert_eq!(val.to_identifier().unwrap(), Identifier::new(data));
+    }
+
+    #[test]
+    fn to_identifier_from_bytes_correct_length() {
+        let data = vec![7u8; 32];
+        let val = Value::Bytes(data);
+        assert_eq!(val.to_identifier().unwrap(), Identifier::new([7u8; 32]));
+    }
+
+    #[test]
+    fn to_identifier_from_text_bs58_round_trip() {
+        let data = [8u8; 32];
+        let encoded = bs58::encode(data).into_string();
+        let val = Value::Text(encoded);
+        assert_eq!(val.to_identifier().unwrap(), Identifier::new(data));
+    }
+
+    #[test]
+    fn to_identifier_from_array_of_32_u8s() {
+        let arr: Vec<Value> = (0..32).map(|i| Value::U8(i as u8)).collect();
+        let val = Value::Array(arr.clone());
+        let expected: [u8; 32] = core::array::from_fn(|i| i as u8);
+        assert_eq!(val.to_identifier().unwrap(), Identifier::new(expected));
+    }
+
+    #[test]
+    fn to_identifier_wrong_type_errors() {
+        let val = Value::Float(1.0);
+        assert!(val.to_identifier().is_err());
+    }
+}

--- a/packages/rs-platform-value/src/value_serialization/de.rs
+++ b/packages/rs-platform-value/src/value_serialization/de.rs
@@ -656,3 +656,544 @@ impl<'de> de::VariantAccess<'de> for Deserializer<Value> {
         self.deserialize_map(visitor)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{from_value, to_value};
+    use serde::{Deserialize, Serialize};
+
+    // ---------------------------------------------------------------
+    // Deserialize Value via serde (Value -> Rust types)
+    // ---------------------------------------------------------------
+
+    #[test]
+    fn deserialize_bool() {
+        let val = Value::Bool(true);
+        let result: bool = from_value(val).unwrap();
+        assert!(result);
+    }
+
+    #[test]
+    fn deserialize_u8() {
+        let val = Value::U8(42);
+        let result: u8 = from_value(val).unwrap();
+        assert_eq!(result, 42);
+    }
+
+    #[test]
+    fn deserialize_u16() {
+        let val = Value::U16(1000);
+        let result: u16 = from_value(val).unwrap();
+        assert_eq!(result, 1000);
+    }
+
+    #[test]
+    fn deserialize_u32() {
+        let val = Value::U32(100_000);
+        let result: u32 = from_value(val).unwrap();
+        assert_eq!(result, 100_000);
+    }
+
+    #[test]
+    fn deserialize_u64() {
+        let val = Value::U64(10_000_000_000);
+        let result: u64 = from_value(val).unwrap();
+        assert_eq!(result, 10_000_000_000);
+    }
+
+    #[test]
+    fn deserialize_u128() {
+        let val = Value::U128(u128::MAX);
+        let result: u128 = from_value(val).unwrap();
+        assert_eq!(result, u128::MAX);
+    }
+
+    #[test]
+    fn deserialize_i8() {
+        let val = Value::I8(-42);
+        let result: i8 = from_value(val).unwrap();
+        assert_eq!(result, -42);
+    }
+
+    #[test]
+    fn deserialize_i16() {
+        let val = Value::I16(-1000);
+        let result: i16 = from_value(val).unwrap();
+        assert_eq!(result, -1000);
+    }
+
+    #[test]
+    fn deserialize_i32() {
+        let val = Value::I32(-100_000);
+        let result: i32 = from_value(val).unwrap();
+        assert_eq!(result, -100_000);
+    }
+
+    #[test]
+    fn deserialize_i64() {
+        let val = Value::I64(-10_000_000_000);
+        let result: i64 = from_value(val).unwrap();
+        assert_eq!(result, -10_000_000_000);
+    }
+
+    #[test]
+    fn deserialize_i128() {
+        let val = Value::I128(i128::MIN);
+        let result: i128 = from_value(val).unwrap();
+        assert_eq!(result, i128::MIN);
+    }
+
+    #[test]
+    fn deserialize_f64() {
+        let val = Value::Float(3.14);
+        let result: f64 = from_value(val).unwrap();
+        assert!((result - 3.14).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn deserialize_string() {
+        let val = Value::Text("hello".into());
+        let result: String = from_value(val).unwrap();
+        assert_eq!(result, "hello");
+    }
+
+    #[test]
+    fn deserialize_null_as_option_none() {
+        let val = Value::Null;
+        let result: Option<String> = from_value(val).unwrap();
+        assert_eq!(result, None);
+    }
+
+    #[test]
+    fn deserialize_some_as_option_some() {
+        let val = Value::Text("hi".into());
+        let result: Option<String> = from_value(val).unwrap();
+        assert_eq!(result, Some("hi".to_string()));
+    }
+
+    #[test]
+    fn deserialize_array_of_integers() {
+        let val = Value::Array(vec![Value::U32(1), Value::U32(2), Value::U32(3)]);
+        let result: Vec<u32> = from_value(val).unwrap();
+        assert_eq!(result, vec![1, 2, 3]);
+    }
+
+    #[test]
+    fn deserialize_unit_from_null() {
+        let val = Value::Null;
+        let result: () = from_value(val).unwrap();
+        assert_eq!(result, ());
+    }
+
+    #[test]
+    fn deserialize_unit_from_non_null_errors() {
+        let val = Value::U8(1);
+        let result: Result<(), Error> = from_value(val);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn deserialize_char_from_single_char_text() {
+        let val = Value::Text("A".into());
+        let result: char = from_value(val).unwrap();
+        assert_eq!(result, 'A');
+    }
+
+    #[test]
+    fn deserialize_char_from_multi_char_text_errors() {
+        let val = Value::Text("AB".into());
+        let result: Result<char, Error> = from_value(val);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn deserialize_struct_from_map() {
+        #[derive(Debug, PartialEq, Deserialize)]
+        struct Point {
+            x: i32,
+            y: i32,
+        }
+
+        let val = Value::Map(vec![
+            (Value::Text("x".into()), Value::I32(10)),
+            (Value::Text("y".into()), Value::I32(20)),
+        ]);
+        let result: Point = from_value(val).unwrap();
+        assert_eq!(result, Point { x: 10, y: 20 });
+    }
+
+    #[test]
+    fn deserialize_tuple_from_array() {
+        let val = Value::Array(vec![Value::U32(1), Value::U32(2)]);
+        let result: (u32, u32) = from_value(val).unwrap();
+        assert_eq!(result, (1, 2));
+    }
+
+    #[test]
+    fn deserialize_bool_type_mismatch_errors() {
+        let val = Value::U32(1);
+        let result: Result<bool, Error> = from_value(val);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn deserialize_f64_type_mismatch_errors() {
+        let val = Value::Text("not_a_float".into());
+        let result: Result<f64, Error> = from_value(val);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn deserialize_string_type_mismatch_errors() {
+        let val = Value::U32(42);
+        let result: Result<String, Error> = from_value(val);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn deserialize_seq_type_mismatch_errors() {
+        let val = Value::U32(42);
+        let result: Result<Vec<u32>, Error> = from_value(val);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn deserialize_map_type_mismatch_errors() {
+        let val = Value::U32(42);
+        let result: Result<std::collections::HashMap<String, u32>, Error> = from_value(val);
+        assert!(result.is_err());
+    }
+
+    // ---------------------------------------------------------------
+    // Round-trip serialization: Rust -> Value -> Rust
+    // ---------------------------------------------------------------
+
+    #[test]
+    fn round_trip_struct() {
+        #[derive(Debug, PartialEq, Serialize, Deserialize)]
+        struct Data {
+            name: String,
+            count: u64,
+            active: bool,
+        }
+
+        let original = Data {
+            name: "test".into(),
+            count: 42,
+            active: true,
+        };
+        let val = to_value(&original).unwrap();
+        let recovered: Data = from_value(val).unwrap();
+        assert_eq!(original, recovered);
+    }
+
+    #[test]
+    fn round_trip_vec() {
+        let original = vec![1u32, 2, 3, 4, 5];
+        let val = to_value(&original).unwrap();
+        let recovered: Vec<u32> = from_value(val).unwrap();
+        assert_eq!(original, recovered);
+    }
+
+    #[test]
+    fn round_trip_option_some() {
+        let original: Option<String> = Some("hello".into());
+        let val = to_value(&original).unwrap();
+        let recovered: Option<String> = from_value(val).unwrap();
+        assert_eq!(original, recovered);
+    }
+
+    #[test]
+    fn round_trip_option_none() {
+        let original: Option<String> = None;
+        let val = to_value(&original).unwrap();
+        let recovered: Option<String> = from_value(val).unwrap();
+        assert_eq!(original, recovered);
+    }
+
+    #[test]
+    fn round_trip_nested_struct() {
+        #[derive(Debug, PartialEq, Serialize, Deserialize)]
+        struct Inner {
+            value: i32,
+        }
+        #[derive(Debug, PartialEq, Serialize, Deserialize)]
+        struct Outer {
+            inner: Inner,
+            label: String,
+        }
+
+        let original = Outer {
+            inner: Inner { value: -5 },
+            label: "test".into(),
+        };
+        let val = to_value(&original).unwrap();
+        let recovered: Outer = from_value(val).unwrap();
+        assert_eq!(original, recovered);
+    }
+
+    #[test]
+    fn round_trip_hashmap() {
+        let mut original = std::collections::HashMap::new();
+        original.insert("a".to_string(), 1u32);
+        original.insert("b".to_string(), 2u32);
+        let val = to_value(&original).unwrap();
+        let recovered: std::collections::HashMap<String, u32> = from_value(val).unwrap();
+        assert_eq!(original, recovered);
+    }
+
+    // ---------------------------------------------------------------
+    // Value -> Value deserialization (Deserialize for Value)
+    // ---------------------------------------------------------------
+
+    #[test]
+    fn value_deserialize_preserves_bool() {
+        let val = Value::Bool(false);
+        let cloned = val.clone();
+        let result: Value = from_value(cloned).unwrap();
+        assert_eq!(result, val);
+    }
+
+    #[test]
+    fn value_deserialize_preserves_text() {
+        let val = Value::Text("test".into());
+        let cloned = val.clone();
+        let result: Value = from_value(cloned).unwrap();
+        assert_eq!(result, val);
+    }
+
+    #[test]
+    fn value_deserialize_preserves_integer_types() {
+        for val in [
+            Value::U8(1),
+            Value::I8(-1),
+            Value::U16(100),
+            Value::I16(-100),
+            Value::U32(1000),
+            Value::I32(-1000),
+            Value::U64(10000),
+            Value::I64(-10000),
+            Value::U128(100000),
+            Value::I128(-100000),
+        ] {
+            let cloned = val.clone();
+            let result: Value = from_value(cloned).unwrap();
+            assert_eq!(result, val);
+        }
+    }
+
+    #[test]
+    fn value_deserialize_preserves_float() {
+        let val = Value::Float(2.718);
+        let cloned = val.clone();
+        let result: Value = from_value(cloned).unwrap();
+        assert_eq!(result, val);
+    }
+
+    #[test]
+    fn value_deserialize_preserves_null() {
+        let val = Value::Null;
+        let cloned = val.clone();
+        let result: Value = from_value(cloned).unwrap();
+        assert_eq!(result, val);
+    }
+
+    #[test]
+    fn value_deserialize_preserves_array() {
+        let val = Value::Array(vec![Value::U8(1), Value::Text("hello".into())]);
+        let cloned = val.clone();
+        let result: Value = from_value(cloned).unwrap();
+        assert_eq!(result, val);
+    }
+
+    #[test]
+    fn value_deserialize_preserves_map() {
+        let val = Value::Map(vec![(Value::Text("key".into()), Value::U64(42))]);
+        let cloned = val.clone();
+        let result: Value = from_value(cloned).unwrap();
+        assert_eq!(result, val);
+    }
+
+    // ---------------------------------------------------------------
+    // Bytes deserialization (non-human-readable -> visit_bytes)
+    // ---------------------------------------------------------------
+
+    #[test]
+    fn value_deserialize_bytes_as_value() {
+        let val = Value::Bytes(vec![1, 2, 3]);
+        let cloned = val.clone();
+        let result: Value = from_value(cloned).unwrap();
+        assert_eq!(result, val);
+    }
+
+    #[test]
+    fn value_deserialize_bytes32_as_value() {
+        let val = Value::Bytes32([7u8; 32]);
+        let cloned = val.clone();
+        let result: Value = from_value(cloned).unwrap();
+        // Non-human-readable: Bytes32 goes through visit_bytes which produces Value::Bytes
+        assert_eq!(result, Value::Bytes(vec![7u8; 32]));
+    }
+
+    #[test]
+    fn value_deserialize_bytes20_as_value() {
+        let val = Value::Bytes20([8u8; 20]);
+        let cloned = val.clone();
+        let result: Value = from_value(cloned).unwrap();
+        // Non-human-readable: Bytes20 goes through visit_bytes which produces Value::Bytes
+        assert_eq!(result, Value::Bytes(vec![8u8; 20]));
+    }
+
+    #[test]
+    fn value_deserialize_bytes36_as_value() {
+        let val = Value::Bytes36([9u8; 36]);
+        let cloned = val.clone();
+        let result: Value = from_value(cloned).unwrap();
+        // Non-human-readable: Bytes36 goes through visit_bytes which produces Value::Bytes
+        assert_eq!(result, Value::Bytes(vec![9u8; 36]));
+    }
+
+    #[test]
+    fn value_deserialize_identifier_as_value() {
+        let val = Value::Identifier([10u8; 32]);
+        let cloned = val.clone();
+        let result: Value = from_value(cloned).unwrap();
+        // Non-human-readable: Identifier goes through visit_bytes which produces Value::Bytes
+        assert_eq!(result, Value::Bytes(vec![10u8; 32]));
+    }
+
+    // ---------------------------------------------------------------
+    // Newtype struct deserialization
+    // ---------------------------------------------------------------
+
+    #[test]
+    fn deserialize_newtype_struct() {
+        #[derive(Debug, PartialEq, Serialize, Deserialize)]
+        struct Wrapper(u32);
+
+        let val = Value::U32(42);
+        let result: Wrapper = from_value(val).unwrap();
+        assert_eq!(result, Wrapper(42));
+    }
+
+    // ---------------------------------------------------------------
+    // Unit struct deserialization
+    // ---------------------------------------------------------------
+
+    #[test]
+    fn deserialize_unit_struct_from_null() {
+        #[derive(Debug, PartialEq, Deserialize)]
+        struct Empty;
+
+        let val = Value::Null;
+        let result: Empty = from_value(val).unwrap();
+        assert_eq!(result, Empty);
+    }
+
+    // ---------------------------------------------------------------
+    // Bytes deserialization into byte buffers
+    // ---------------------------------------------------------------
+
+    #[test]
+    fn deserialize_bytes_from_bytes_value() {
+        let val = Value::Bytes(vec![1, 2, 3, 4]);
+        let result: Value = from_value(val.clone()).unwrap();
+        assert_eq!(result, val);
+    }
+
+    #[test]
+    fn deserialize_bytes_type_mismatch_errors() {
+        use serde::de::Deserializer as _;
+        struct BytesVisitor;
+        impl<'de> de::Visitor<'de> for BytesVisitor {
+            type Value = Vec<u8>;
+            fn expecting(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+                write!(f, "bytes")
+            }
+            fn visit_bytes<E: de::Error>(self, v: &[u8]) -> Result<Self::Value, E> {
+                Ok(v.to_vec())
+            }
+        }
+        let deser = Deserializer(Value::Bool(true));
+        let result = deser.deserialize_bytes(BytesVisitor);
+        assert!(result.is_err());
+    }
+
+    // ---------------------------------------------------------------
+    // Enum deserialization
+    // ---------------------------------------------------------------
+
+    #[test]
+    fn deserialize_unit_enum_from_text() {
+        #[derive(Debug, PartialEq, Deserialize)]
+        enum Color {
+            Red,
+            Green,
+            Blue,
+        }
+        let val = Value::Text("Red".into());
+        let result: Color = from_value(val).unwrap();
+        assert_eq!(result, Color::Red);
+    }
+
+    #[test]
+    fn deserialize_newtype_enum_from_map() {
+        #[derive(Debug, PartialEq, Serialize, Deserialize)]
+        enum Wrapper {
+            Count(u32),
+        }
+        let val = Value::Map(vec![(Value::Text("Count".into()), Value::U32(42))]);
+        let result: Wrapper = from_value(val).unwrap();
+        assert_eq!(result, Wrapper::Count(42));
+    }
+
+    #[test]
+    fn round_trip_unit_enum() {
+        #[derive(Debug, PartialEq, Serialize, Deserialize)]
+        enum Direction {
+            Up,
+            Down,
+        }
+        let original = Direction::Up;
+        let val = to_value(&original).unwrap();
+        let recovered: Direction = from_value(val).unwrap();
+        assert_eq!(original, recovered);
+    }
+
+    #[test]
+    fn round_trip_newtype_enum() {
+        #[derive(Debug, PartialEq, Serialize, Deserialize)]
+        enum Payload {
+            Message(String),
+        }
+        let original = Payload::Message("hello".into());
+        let val = to_value(&original).unwrap();
+        let recovered: Payload = from_value(val).unwrap();
+        assert_eq!(original, recovered);
+    }
+
+    #[test]
+    fn round_trip_struct_enum() {
+        #[derive(Debug, PartialEq, Serialize, Deserialize)]
+        enum Shape {
+            Circle { radius: u32 },
+        }
+        let original = Shape::Circle { radius: 5 };
+        let val = to_value(&original).unwrap();
+        let recovered: Shape = from_value(val).unwrap();
+        assert_eq!(original, recovered);
+    }
+
+    #[test]
+    fn round_trip_tuple_enum() {
+        #[derive(Debug, PartialEq, Serialize, Deserialize)]
+        enum Pair {
+            Coords(i32, i32),
+        }
+        let original = Pair::Coords(10, 20);
+        let val = to_value(&original).unwrap();
+        let recovered: Pair = from_value(val).unwrap();
+        assert_eq!(original, recovered);
+    }
+}

--- a/packages/rs-platform-value/src/value_serialization/ser.rs
+++ b/packages/rs-platform-value/src/value_serialization/ser.rs
@@ -720,3 +720,510 @@ impl serde::ser::SerializeStructVariant for SerializeStructVariant {
         )]))
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde::{Deserialize, Serialize};
+
+    // ---------------------------------------------------------------
+    // Serialize primitives
+    // ---------------------------------------------------------------
+
+    #[test]
+    fn serialize_bool() {
+        assert_eq!(to_value(true).unwrap(), Value::Bool(true));
+        assert_eq!(to_value(false).unwrap(), Value::Bool(false));
+    }
+
+    #[test]
+    fn serialize_i8() {
+        assert_eq!(to_value(-42i8).unwrap(), Value::I8(-42));
+    }
+
+    #[test]
+    fn serialize_i16() {
+        assert_eq!(to_value(-1000i16).unwrap(), Value::I16(-1000));
+    }
+
+    #[test]
+    fn serialize_i32() {
+        assert_eq!(to_value(-100_000i32).unwrap(), Value::I32(-100_000));
+    }
+
+    #[test]
+    fn serialize_i64() {
+        assert_eq!(
+            to_value(-10_000_000_000i64).unwrap(),
+            Value::I64(-10_000_000_000)
+        );
+    }
+
+    #[test]
+    fn serialize_i128() {
+        assert_eq!(to_value(i128::MIN).unwrap(), Value::I128(i128::MIN));
+    }
+
+    #[test]
+    fn serialize_u8() {
+        assert_eq!(to_value(42u8).unwrap(), Value::U8(42));
+    }
+
+    #[test]
+    fn serialize_u16() {
+        assert_eq!(to_value(1000u16).unwrap(), Value::U16(1000));
+    }
+
+    #[test]
+    fn serialize_u32() {
+        assert_eq!(to_value(100_000u32).unwrap(), Value::U32(100_000));
+    }
+
+    #[test]
+    fn serialize_u64() {
+        assert_eq!(
+            to_value(10_000_000_000u64).unwrap(),
+            Value::U64(10_000_000_000)
+        );
+    }
+
+    #[test]
+    fn serialize_u128() {
+        assert_eq!(to_value(u128::MAX).unwrap(), Value::U128(u128::MAX));
+    }
+
+    #[test]
+    fn serialize_f32() {
+        let val = to_value(3.14f32).unwrap();
+        match val {
+            Value::Float(f) => assert!((f - 3.14f32 as f64).abs() < 1e-6),
+            _ => panic!("expected Float"),
+        }
+    }
+
+    #[test]
+    fn serialize_f64() {
+        assert_eq!(to_value(2.718f64).unwrap(), Value::Float(2.718));
+    }
+
+    #[test]
+    fn serialize_char() {
+        let val = to_value('A').unwrap();
+        assert_eq!(val, Value::Text("A".to_string()));
+    }
+
+    #[test]
+    fn serialize_str() {
+        assert_eq!(to_value("hello").unwrap(), Value::Text("hello".to_string()));
+    }
+
+    #[test]
+    fn serialize_string() {
+        assert_eq!(
+            to_value("world".to_string()).unwrap(),
+            Value::Text("world".to_string())
+        );
+    }
+
+    // ---------------------------------------------------------------
+    // Serialize unit / None / Some
+    // ---------------------------------------------------------------
+
+    #[test]
+    fn serialize_unit() {
+        assert_eq!(to_value(()).unwrap(), Value::Null);
+    }
+
+    #[test]
+    fn serialize_none() {
+        let val: Option<u32> = None;
+        assert_eq!(to_value(val).unwrap(), Value::Null);
+    }
+
+    #[test]
+    fn serialize_some() {
+        let val: Option<u32> = Some(42);
+        assert_eq!(to_value(val).unwrap(), Value::U32(42));
+    }
+
+    // ---------------------------------------------------------------
+    // Serialize sequences and tuples
+    // ---------------------------------------------------------------
+
+    #[test]
+    fn serialize_vec() {
+        let val = to_value(vec![1u32, 2, 3]).unwrap();
+        assert_eq!(
+            val,
+            Value::Array(vec![Value::U32(1), Value::U32(2), Value::U32(3)])
+        );
+    }
+
+    #[test]
+    fn serialize_empty_vec() {
+        let val = to_value(Vec::<u32>::new()).unwrap();
+        assert_eq!(val, Value::Array(vec![]));
+    }
+
+    #[test]
+    fn serialize_tuple() {
+        let val = to_value((1u32, "hello")).unwrap();
+        assert_eq!(
+            val,
+            Value::Array(vec![Value::U32(1), Value::Text("hello".into())])
+        );
+    }
+
+    // ---------------------------------------------------------------
+    // Serialize maps
+    // ---------------------------------------------------------------
+
+    #[test]
+    fn serialize_hashmap() {
+        let mut map = std::collections::HashMap::new();
+        map.insert("key", 42u32);
+        let val = to_value(map).unwrap();
+        match val {
+            Value::Map(entries) => {
+                assert_eq!(entries.len(), 1);
+                assert_eq!(entries[0].0, Value::Text("key".into()));
+                assert_eq!(entries[0].1, Value::U32(42));
+            }
+            _ => panic!("expected Map"),
+        }
+    }
+
+    // ---------------------------------------------------------------
+    // Serialize structs
+    // ---------------------------------------------------------------
+
+    #[test]
+    fn serialize_struct() {
+        #[derive(Serialize)]
+        struct Point {
+            x: i32,
+            y: i32,
+        }
+        let val = to_value(Point { x: 10, y: 20 }).unwrap();
+        match val {
+            Value::Map(entries) => {
+                assert_eq!(entries.len(), 2);
+                assert_eq!(entries[0].0, Value::Text("x".into()));
+                assert_eq!(entries[0].1, Value::I32(10));
+                assert_eq!(entries[1].0, Value::Text("y".into()));
+                assert_eq!(entries[1].1, Value::I32(20));
+            }
+            _ => panic!("expected Map"),
+        }
+    }
+
+    #[test]
+    fn serialize_unit_struct() {
+        #[derive(Serialize)]
+        struct Empty;
+        assert_eq!(to_value(Empty).unwrap(), Value::Null);
+    }
+
+    #[test]
+    fn serialize_newtype_struct() {
+        #[derive(Serialize)]
+        struct Wrapper(u32);
+        assert_eq!(to_value(Wrapper(42)).unwrap(), Value::U32(42));
+    }
+
+    #[test]
+    fn serialize_tuple_struct() {
+        #[derive(Serialize)]
+        struct Pair(u32, String);
+        let val = to_value(Pair(1, "two".into())).unwrap();
+        assert_eq!(
+            val,
+            Value::Array(vec![Value::U32(1), Value::Text("two".into())])
+        );
+    }
+
+    // ---------------------------------------------------------------
+    // Serialize enums
+    // ---------------------------------------------------------------
+
+    #[test]
+    fn serialize_unit_variant() {
+        #[derive(Serialize)]
+        enum Color {
+            Red,
+        }
+        assert_eq!(
+            to_value(Color::Red).unwrap(),
+            Value::Text("Red".to_string())
+        );
+    }
+
+    #[test]
+    fn serialize_newtype_variant() {
+        #[derive(Serialize)]
+        enum Wrapper {
+            Count(u32),
+        }
+        let val = to_value(Wrapper::Count(42)).unwrap();
+        assert_eq!(
+            val,
+            Value::Map(vec![(Value::Text("Count".into()), Value::U32(42))])
+        );
+    }
+
+    #[test]
+    fn serialize_tuple_variant() {
+        #[derive(Serialize)]
+        enum Pair {
+            Coords(i32, i32),
+        }
+        let val = to_value(Pair::Coords(10, 20)).unwrap();
+        assert_eq!(
+            val,
+            Value::Map(vec![(
+                Value::Text("Coords".into()),
+                Value::Array(vec![Value::I32(10), Value::I32(20)])
+            )])
+        );
+    }
+
+    #[test]
+    fn serialize_struct_variant() {
+        #[derive(Serialize)]
+        enum Shape {
+            Circle { radius: u32 },
+        }
+        let val = to_value(Shape::Circle { radius: 5 }).unwrap();
+        assert_eq!(
+            val,
+            Value::Map(vec![(
+                Value::Text("Circle".into()),
+                Value::Map(vec![(Value::Text("radius".into()), Value::U32(5))])
+            )])
+        );
+    }
+
+    // ---------------------------------------------------------------
+    // Serialize bytes (non-human-readable mode)
+    // ---------------------------------------------------------------
+
+    #[test]
+    fn serialize_bytes_32_becomes_bytes32() {
+        // Exactly 32 bytes should become Bytes32
+        let data = [1u8; 32];
+        use serde::Serializer;
+        let val = Serializer.serialize_bytes(&data).unwrap();
+        assert_eq!(val, Value::Bytes32(data));
+    }
+
+    #[test]
+    fn serialize_bytes_20_becomes_bytes20() {
+        let data = [2u8; 20];
+        use serde::Serializer;
+        let val = Serializer.serialize_bytes(&data).unwrap();
+        assert_eq!(val, Value::Bytes20(data));
+    }
+
+    #[test]
+    fn serialize_bytes_36_becomes_bytes36() {
+        let data = [3u8; 36];
+        use serde::Serializer;
+        let val = Serializer.serialize_bytes(&data).unwrap();
+        assert_eq!(val, Value::Bytes36(data));
+    }
+
+    #[test]
+    fn serialize_bytes_other_len_becomes_bytes() {
+        let data = vec![4u8; 10];
+        use serde::Serializer;
+        let val = Serializer.serialize_bytes(&data).unwrap();
+        assert_eq!(val, Value::Bytes(data));
+    }
+
+    // ---------------------------------------------------------------
+    // Serialize Value (the Serialize impl for Value)
+    // ---------------------------------------------------------------
+
+    #[test]
+    fn serialize_value_null() {
+        let val = Value::Null;
+        let serialized = to_value(&val).unwrap();
+        assert_eq!(serialized, Value::Null);
+    }
+
+    #[test]
+    fn serialize_value_bool() {
+        let val = Value::Bool(true);
+        let serialized = to_value(&val).unwrap();
+        assert_eq!(serialized, Value::Bool(true));
+    }
+
+    #[test]
+    fn serialize_value_integer_types() {
+        let cases = vec![
+            Value::U8(1),
+            Value::I8(-1),
+            Value::U16(100),
+            Value::I16(-100),
+            Value::U32(1000),
+            Value::I32(-1000),
+            Value::U64(10000),
+            Value::I64(-10000),
+            Value::U128(100000),
+            Value::I128(-100000),
+        ];
+        for val in cases {
+            let serialized = to_value(&val).unwrap();
+            assert_eq!(serialized, val);
+        }
+    }
+
+    #[test]
+    fn serialize_value_float() {
+        let val = Value::Float(3.14);
+        let serialized = to_value(&val).unwrap();
+        assert_eq!(serialized, Value::Float(3.14));
+    }
+
+    #[test]
+    fn serialize_value_text() {
+        let val = Value::Text("hello".into());
+        let serialized = to_value(&val).unwrap();
+        assert_eq!(serialized, Value::Text("hello".into()));
+    }
+
+    #[test]
+    fn serialize_value_array() {
+        let val = Value::Array(vec![Value::U8(1), Value::U8(2)]);
+        let serialized = to_value(&val).unwrap();
+        assert_eq!(serialized, val);
+    }
+
+    #[test]
+    fn serialize_value_map() {
+        let val = Value::Map(vec![(Value::Text("k".into()), Value::U32(42))]);
+        let serialized = to_value(&val).unwrap();
+        assert_eq!(serialized, val);
+    }
+
+    #[test]
+    fn serialize_value_bytes() {
+        let val = Value::Bytes(vec![1, 2, 3, 4, 5]);
+        let serialized = to_value(&val).unwrap();
+        // Non-human-readable serializer: serialized as bytes
+        assert_eq!(serialized, val);
+    }
+
+    #[test]
+    fn serialize_value_bytes20() {
+        let val = Value::Bytes20([1u8; 20]);
+        let serialized = to_value(&val).unwrap();
+        // serialize_bytes with len=20 -> Bytes20
+        assert_eq!(serialized, val);
+    }
+
+    #[test]
+    fn serialize_value_bytes32() {
+        let val = Value::Bytes32([2u8; 32]);
+        let serialized = to_value(&val).unwrap();
+        assert_eq!(serialized, val);
+    }
+
+    #[test]
+    fn serialize_value_bytes36() {
+        let val = Value::Bytes36([3u8; 36]);
+        let serialized = to_value(&val).unwrap();
+        assert_eq!(serialized, val);
+    }
+
+    #[test]
+    fn serialize_value_identifier() {
+        let val = Value::Identifier([4u8; 32]);
+        let serialized = to_value(&val).unwrap();
+        // Non-human-readable: identifier serialized as bytes (32 bytes -> Bytes32)
+        assert_eq!(serialized, Value::Bytes32([4u8; 32]));
+    }
+
+    // ---------------------------------------------------------------
+    // MapKeySerializer error cases
+    // ---------------------------------------------------------------
+
+    #[test]
+    fn map_key_bool_errors() {
+        let mut map = std::collections::HashMap::new();
+        map.insert(true, "value");
+        let result = to_value(map);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn map_key_string_works() {
+        let mut map = std::collections::HashMap::new();
+        map.insert("key".to_string(), 42u32);
+        let result = to_value(map);
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn map_key_integer_works() {
+        let mut map = std::collections::HashMap::new();
+        map.insert(42u32, "value");
+        let result = to_value(map);
+        assert!(result.is_ok());
+    }
+
+    // ---------------------------------------------------------------
+    // Round-trip tests: Rust -> Value -> Rust
+    // ---------------------------------------------------------------
+
+    #[test]
+    fn round_trip_complex_struct() {
+        #[derive(Debug, PartialEq, Serialize, Deserialize)]
+        struct Complex {
+            name: String,
+            count: u64,
+            active: bool,
+            score: f64,
+            tags: Vec<String>,
+            metadata: Option<String>,
+        }
+
+        let original = Complex {
+            name: "test".into(),
+            count: 42,
+            active: true,
+            score: 3.14,
+            tags: vec!["a".into(), "b".into()],
+            metadata: Some("info".into()),
+        };
+        let val = to_value(&original).unwrap();
+        let recovered: Complex = crate::from_value(val).unwrap();
+        assert_eq!(original, recovered);
+    }
+
+    #[test]
+    fn round_trip_nested() {
+        #[derive(Debug, PartialEq, Serialize, Deserialize)]
+        struct Inner {
+            x: i32,
+        }
+        #[derive(Debug, PartialEq, Serialize, Deserialize)]
+        struct Outer {
+            inner: Inner,
+        }
+
+        let original = Outer {
+            inner: Inner { x: -5 },
+        };
+        let val = to_value(&original).unwrap();
+        let recovered: Outer = crate::from_value(val).unwrap();
+        assert_eq!(original, recovered);
+    }
+
+    #[test]
+    fn collect_str_produces_text() {
+        use serde::Serializer;
+        let val = Serializer.collect_str(&42).unwrap();
+        assert_eq!(val, Value::Text("42".to_string()));
+    }
+}


### PR DESCRIPTION
## Issue being fixed or feature implemented

Improves unit test coverage for `rs-platform-value` modules that had low coverage:
- `inner_value.rs` (65.8% -> improved)
- `system_bytes.rs` (32.2% -> improved)
- `value_serialization/de.rs` (54.6% -> improved)
- `value_serialization/ser.rs` (55.8% -> improved)

## What was done?

Added comprehensive `#[cfg(test)] mod tests` blocks to four files:

**`inner_value.rs`** (93 new tests):
- Map accessor methods: `get_str`, `get_integer`, `get_bool`, `get_bytes`, `get_array`, `get_hash256`, `get_identifier`, etc.
- Optional variants: `get_optional_*` for all types
- Mutator methods: `set_into_value`, `set_value`, `insert`, `insert_at_end`
- Remove methods: `remove`, `remove_many`, `remove_optional_value`, `remove_integer`, `remove_identifier`, `remove_bytes_32`, `remove_hash256_bytes`, `remove_bytes`, `remove_binary_data`, `remove_array`
- Map helpers: `get_from_map`, `get_optional_from_map`, `insert_in_map`, `push_to_map_string_value`
- Error cases: calling map methods on non-map values

**`system_bytes.rs`** (73 new tests):
- Identifier bytes: `into_identifier_bytes`/`to_identifier_bytes` from Bytes, Text (bs58), Array, Identifier, Bytes32
- Binary bytes: `into_binary_bytes`/`to_binary_bytes` from Bytes, Text (b64), Array, Bytes20/32/36, Identifier
- Hash256: `into_hash256`/`to_hash256` from Bytes32, Identifier, Bytes, Text (bs58), Array, with wrong-length errors
- Bytes20/32/36: `into_bytes_20`/`to_bytes_20`, `into_bytes_32`/`to_bytes_32`, `into_bytes_36`/`to_bytes_36` with round-trip b64 encoding
- Identifier: `into_identifier`/`to_identifier` from all source types with error cases

**`value_serialization/de.rs`** (56 new tests):
- Typed deserialization: all integer types, f64, bool, string, char, option, unit, arrays, maps, structs, tuples
- Type mismatch errors: bool, f64, string, seq, map
- Round-trip: struct, vec, option, nested struct, hashmap
- Value-to-Value preservation: all Value variants
- Bytes handling: Bytes, Bytes20, Bytes32, Bytes36, Identifier through visit_bytes
- Enum deserialization: unit, newtype, struct, and tuple variants

**`value_serialization/ser.rs`** (56 new tests):
- Primitive serialization: all integer types, f32/f64, bool, char, str, string
- Unit/None/Some serialization
- Sequences, tuples, maps, structs (regular, unit, newtype, tuple)
- Enum variants: unit, newtype, tuple, struct
- Bytes size dispatch: 20 -> Bytes20, 32 -> Bytes32, 36 -> Bytes36, other -> Bytes
- Value self-serialization for all variants
- MapKeySerializer error cases

## How Has This Been Tested?

```bash
cargo fmt -p platform-value   # formatting verified
cargo test -p platform-value --lib   # 347 tests pass (278 new)
```

## Breaking Changes

None. Only test code was added.

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [x] I have made corresponding changes to the documentation if needed

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded test coverage for Value operations, type conversions, and serialization/deserialization pathways across multiple modules to enhance code reliability and validation of existing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->