### PR TITLE
fix(swift-sdk): crash when switching to devnet in settings

### DIFF
--- a/packages/swift-sdk/Sources/SwiftDashSDK/Core/Services/WalletService.swift
+++ b/packages/swift-sdk/Sources/SwiftDashSDK/Core/Services/WalletService.swift
@@ -111,9 +111,14 @@ public class WalletService: ObservableObject {
         LoggingPreferences.configure()
         
         let dataDir = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first?.appendingPathComponent("SPV").appendingPathComponent(network.rawValue).path
-        
+
+        // Ensure the data directory exists before initializing the SPV client
+        if let dataDir = dataDir {
+            try? FileManager.default.createDirectory(atPath: dataDir, withIntermediateDirectories: true)
+        }
+
         // For simplicity, lets unwrap the error. This can only fail due to
-        // IO errors when working with the internal storage system, I don't 
+        // IO errors when working with the internal storage system, I don't
         // see how we can recover from that right now easily
         let spvClient = try! SPVClient(
             network: network.sdkNetwork,
@@ -142,13 +147,18 @@ public class WalletService: ObservableObject {
       SDKLogger.log("Initializing SPV Client for \(self.self.network.rawValue)...", minimumLevel: .medium)
       
       let dataDir = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first?.appendingPathComponent("SPV").appendingPathComponent(self.network.rawValue).path
-      
+
+      // Ensure the data directory exists before initializing the SPV client
+      if let dataDir = dataDir {
+          try? FileManager.default.createDirectory(atPath: dataDir, withIntermediateDirectories: true)
+      }
+
       // This ensures no memory leaks when creating a new client
       // and unlocks the storage in case we are about to use the same (we probably are)
       self.spvClient.destroy()
-      
+
       // For simplicity, lets unwrap the error. This can only fail due to
-      // IO errors when working with the internal storage system, I don't 
+      // IO errors when working with the internal storage system, I don't
       // see how we can recover from that right now easily
       self.spvClient = try! SPVClient(
           network: self.self.network.sdkNetwork,

--- a/packages/swift-sdk/Sources/SwiftDashSDK/Models/Network.swift
+++ b/packages/swift-sdk/Sources/SwiftDashSDK/Models/Network.swift
@@ -4,8 +4,8 @@ import Foundation
 public enum AppNetwork: String, CaseIterable, Codable, Sendable {
     case mainnet = "mainnet"
     case testnet = "testnet"
-    case regtest = "regtest"
     case devnet = "devnet"
+    case regtest = "regtest"
 
     init(network: KeyWalletNetwork) {
         switch network {
@@ -23,7 +23,7 @@ public enum AppNetwork: String, CaseIterable, Codable, Sendable {
         case .testnet:
             return "Testnet"
         case .regtest:
-            return "Regtest"
+            return "Local"
         case .devnet:
             return "Devnet"
         }


### PR DESCRIPTION
## Summary

- Fixes crash in `WalletService.initializeNewSPVClient()` when switching networks — the SPV data directory for the target network didn't exist yet, causing `SPVClient` init to throw (force-unwrapped by `try!`)
- Adds `FileManager.createDirectory(withIntermediateDirectories: true)` before `SPVClient` initialization in both `init()` and `initializeNewSPVClient()`
- Reorders network picker segments to: Mainnet | Testnet | Devnet | Local
- Renames "Regtest" display name to "Local"

## Test plan

- [ ] Switch to Devnet in settings — should no longer crash
- [ ] Switch between all networks — verify SPV client initializes correctly
- [ ] Verify network picker shows correct order: Mainnet, Testnet, Devnet, Local

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved wallet service initialization with enhanced data directory handling.

* **UI Updates**
  * Updated test network display name from "Regtest" to "Local."

<!-- end of auto-generated comment: release notes by coderabbit.ai -->