### PR TITLE
docs: add nightly test status page and badge

### DIFF
--- a/NIGHTLY_STATUS.md
+++ b/NIGHTLY_STATUS.md
@@ -2,45 +2,50 @@
 
 [![Nightly Tests](https://github.com/dashpay/platform/actions/workflows/tests.yml/badge.svg?event=schedule)](https://github.com/dashpay/platform/actions/workflows/tests.yml?query=event%3Aschedule)
 
+> **Note:** This page is manually maintained. For live results, check the [latest nightly run](https://github.com/dashpay/platform/actions/workflows/tests.yml?query=event%3Aschedule+branch%3Av3.1-dev) directly.
+
 Nightly tests run every day at **23:00 UTC** on the `v3.1-dev` branch via the [Tests workflow](https://github.com/dashpay/platform/actions/workflows/tests.yml?query=event%3Aschedule). They exercise the full CI pipeline including Docker image builds, E2E tests, and the platform test suite.
 
-## Current Status (as of 2026-03-21)
+## Nightly Jobs
 
-### Passing
+### Always run on schedule
+
+These jobs have `github.event_name == 'schedule'` in their conditions and run every night.
 
 | Job | Status | Notes |
 |-----|--------|-------|
 | [Build JS packages](https://github.com/dashpay/platform/actions/workflows/tests-build-js.yml) | Passing | |
 | [Build Docker images](https://github.com/dashpay/platform/actions/workflows/tests-build-image.yml) (Drive, RS-DAPI, Dashmate helper) | Passing | All 3 images build successfully |
-| [Rust workspace tests](https://github.com/dashpay/platform/actions/workflows/tests-rs-workspace.yml) (macOS) | Passing | |
-| [Swift SDK build](https://github.com/dashpay/platform/actions/workflows/swift-sdk-build.yml) | Passing | |
-| [JS package tests](https://github.com/dashpay/platform/actions/workflows/tests-js-package.yml) | Passing | dapi, dapi-client, evo-sdk, wallet-lib, wasm-dpp, wasm-dpp2, wasm-sdk, dash, dashmate |
 | [JS dependency versions](https://github.com/dashpay/platform/actions/workflows/tests.yml) | Passing | `yarn constraints` check |
 | [Dashmate E2E tests](https://github.com/dashpay/platform/actions/workflows/tests-dashmate.yml) | Passing | Local network, Testnet fullnode, Testnet Evonode |
-| Test Suite in browser (batch 2) | Passing | |
+| [Test Suite](https://github.com/dashpay/platform/actions/workflows/tests-test-suite.yml) (`test:suite`) | **Failing** | 2 of 65 tests fail with `bad-txns-inputs-missingorspent`. See [known issues](#test-suite-bad-txns-inputs-missingorspent-since-mar-16). |
+| [Test Suite in browser (1)](https://github.com/dashpay/platform/actions/workflows/tests-test-suite.yml) | **Cancelled** | Cancelled due to 15-minute timeout. |
+| [Test Suite in browser (2)](https://github.com/dashpay/platform/actions/workflows/tests-test-suite.yml) | Passing | |
+| [Packages functional tests](https://github.com/dashpay/platform/actions/workflows/tests-packges-functional.yml) | **Failing** | Long-standing flaky failure. See [known issues](#functional-tests-long-standing-flakiness). |
 
-### Failing
+### Conditional (run when changes detected)
 
-| Job | Status | Known Issue |
-|-----|--------|-------------|
-| [Test Suite](https://github.com/dashpay/platform/actions/workflows/tests-test-suite.yml) (`test:suite`) | **Failing** | 2 of 65 tests fail with `bad-txns-inputs-missingorspent` -- a Core-level UTXO rejection during withdrawal tests. Failing since ~Mar 16. |
-| [Packages functional tests](https://github.com/dashpay/platform/actions/workflows/tests-packges-functional.yml) | **Failing** | Long-standing flaky failure unrelated to recent code changes. |
-| Test Suite in browser (batch 1) | **Cancelled** | Cancelled due to 15-minute timeout. |
+These jobs only run on nightly if relevant files changed in the latest commit. They may be skipped entirely on a given night.
 
-### Known Issues
+| Job | Status | Condition |
+|-----|--------|-----------|
+| [Rust workspace tests](https://github.com/dashpay/platform/actions/workflows/tests-rs-workspace.yml) (macOS) | Passing (when run) | Rust package changes |
+| [Swift SDK build](https://github.com/dashpay/platform/actions/workflows/swift-sdk-build.yml) | Passing (when run) | swift-sdk, rs-sdk, or rs-sdk-ffi changes |
+| [JS package tests](https://github.com/dashpay/platform/actions/workflows/tests-js-package.yml) | Passing (when run) | JS package changes |
 
-#### Test Suite: `bad-txns-inputs-missingorspent` (since ~Mar 16)
+## Known Issues
+
+### Test Suite: `bad-txns-inputs-missingorspent` (since ~Mar 16)
 
 Two withdrawal-related tests fail because Core rejects a transaction whose inputs are missing or already spent. The local network starts and processes blocks normally -- the failure is specific to the withdrawal test scenario.
 
 - **63 tests pass**, 2 fail
 - Error: `InvalidRequestError: Transaction is rejected: bad-txns-inputs-missingorspent`
 - **Not caused by** the `ssh2`/`nan` compilation warnings (those are non-fatal)
-- The failing tests worked on Mar 15 and broke on Mar 16
 
-#### Functional tests: long-standing flakiness
+### Functional tests: long-standing flakiness
 
-The functional tests (`test/functional`) have been intermittently failing for months. This is a known pre-existing issue unrelated to recent code changes.
+The functional tests have been intermittently failing for months. This is a known pre-existing issue unrelated to recent code changes.
 
 ## Links
 

--- a/NIGHTLY_STATUS.md
+++ b/NIGHTLY_STATUS.md
@@ -1,0 +1,52 @@
+# Nightly Test Status
+
+[![Nightly Tests](https://github.com/dashpay/platform/actions/workflows/tests.yml/badge.svg?event=schedule)](https://github.com/dashpay/platform/actions/workflows/tests.yml?query=event%3Aschedule)
+
+Nightly tests run every day at **23:00 UTC** on the `v3.1-dev` branch via the [Tests workflow](https://github.com/dashpay/platform/actions/workflows/tests.yml?query=event%3Aschedule). They exercise the full CI pipeline including Docker image builds, E2E tests, and the platform test suite.
+
+## Current Status (as of 2026-03-21)
+
+### Passing
+
+| Job | Status | Notes |
+|-----|--------|-------|
+| [Build JS packages](https://github.com/dashpay/platform/actions/workflows/tests-build-js.yml) | Passing | |
+| [Build Docker images](https://github.com/dashpay/platform/actions/workflows/tests-build-image.yml) (Drive, RS-DAPI, Dashmate helper) | Passing | All 3 images build successfully |
+| [Rust workspace tests](https://github.com/dashpay/platform/actions/workflows/tests-rs-workspace.yml) (macOS) | Passing | |
+| [Swift SDK build](https://github.com/dashpay/platform/actions/workflows/swift-sdk-build.yml) | Passing | |
+| [JS package tests](https://github.com/dashpay/platform/actions/workflows/tests-js-package.yml) | Passing | dapi, dapi-client, evo-sdk, wallet-lib, wasm-dpp, wasm-dpp2, wasm-sdk, dash, dashmate |
+| [JS dependency versions](https://github.com/dashpay/platform/actions/workflows/tests.yml) | Passing | `yarn constraints` check |
+| [Dashmate E2E tests](https://github.com/dashpay/platform/actions/workflows/tests-dashmate.yml) | Passing | Local network, Testnet fullnode, Testnet Evonode |
+| Test Suite in browser (batch 2) | Passing | |
+
+### Failing
+
+| Job | Status | Known Issue |
+|-----|--------|-------------|
+| [Test Suite](https://github.com/dashpay/platform/actions/workflows/tests-test-suite.yml) (`test:suite`) | **Failing** | 2 of 65 tests fail with `bad-txns-inputs-missingorspent` -- a Core-level UTXO rejection during withdrawal tests. Failing since ~Mar 16. |
+| [Packages functional tests](https://github.com/dashpay/platform/actions/workflows/tests-packges-functional.yml) | **Failing** | Long-standing flaky failure unrelated to recent code changes. |
+| Test Suite in browser (batch 1) | **Cancelled** | Cancelled due to 15-minute timeout. |
+
+### Known Issues
+
+#### Test Suite: `bad-txns-inputs-missingorspent` (since ~Mar 16)
+
+Two withdrawal-related tests fail because Core rejects a transaction whose inputs are missing or already spent. The local network starts and processes blocks normally -- the failure is specific to the withdrawal test scenario.
+
+- **63 tests pass**, 2 fail
+- Error: `InvalidRequestError: Transaction is rejected: bad-txns-inputs-missingorspent`
+- **Not caused by** the `ssh2`/`nan` compilation warnings (those are non-fatal)
+- The failing tests worked on Mar 15 and broke on Mar 16
+
+#### Functional tests: long-standing flakiness
+
+The functional tests (`test/functional`) have been intermittently failing for months. This is a known pre-existing issue unrelated to recent code changes.
+
+## Links
+
+- [All nightly runs](https://github.com/dashpay/platform/actions/workflows/tests.yml?query=event%3Aschedule)
+- [Latest nightly run](https://github.com/dashpay/platform/actions/workflows/tests.yml?query=event%3Aschedule+branch%3Av3.1-dev)
+- [Long-running Rust nightly](https://github.com/dashpay/platform/actions/workflows/tests-rs-nightly-long-running.yml)
+- [Security audits (Rust)](https://github.com/dashpay/platform/actions/workflows/security-audit-rust.yml)
+- [Security audits (JS - npm)](https://github.com/dashpay/platform/actions/workflows/security-audit-js-npm.yml)
+- [Security audits (JS - CodeQL)](https://github.com/dashpay/platform/actions/workflows/security-audit-js-codeql.yml)

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 </p>
 
 <p align="center">
-  <a href="https://github.com/dashpay/platform/actions/workflows/tests.yml"><img alt="GitHub CI Status" src="https://github.com/dashpay/platform/actions/workflows/tests.yml/badge.svg"></a>
+  <a href="https://github.com/dashpay/platform/actions/workflows/tests.yml"><img alt="CI" src="https://github.com/dashpay/platform/actions/workflows/tests.yml/badge.svg"></a>
   <a href="NIGHTLY_STATUS.md"><img alt="Nightly Tests" src="https://github.com/dashpay/platform/actions/workflows/tests.yml/badge.svg?event=schedule" title="Nightly test status"></a>
   <a href="https://codecov.io/gh/dashpay/platform"><img alt="codecov" src="https://codecov.io/gh/dashpay/platform/branch/v3.1-dev/graph/badge.svg"></a>
   <a href="https://github.com/dashpay/platform/graphs/commit-activity"><img alt="commit activity" src="https://img.shields.io/github/commit-activity/m/dashpay/platform"></a>

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 
 <p align="center">
   <a href="https://github.com/dashpay/platform/actions/workflows/tests.yml"><img alt="CI" src="https://github.com/dashpay/platform/actions/workflows/tests.yml/badge.svg"></a>
-  <a href="NIGHTLY_STATUS.md"><img alt="Nightly Tests" src="https://github.com/dashpay/platform/actions/workflows/tests.yml/badge.svg?event=schedule" title="Nightly test status"></a>
+  <a href="NIGHTLY_STATUS.md"><img alt="Nightly Tests" src="https://img.shields.io/github/actions/workflow/status/dashpay/platform/tests.yml?event=schedule&label=Nightly%20Tests" title="Nightly test status"></a>
   <a href="https://codecov.io/gh/dashpay/platform"><img alt="codecov" src="https://codecov.io/gh/dashpay/platform/branch/v3.1-dev/graph/badge.svg"></a>
   <a href="https://github.com/dashpay/platform/graphs/commit-activity"><img alt="commit activity" src="https://img.shields.io/github/commit-activity/m/dashpay/platform"></a>
   <a href="https://github.com/dashpay/platform/commits"><img alt="last commit" src="https://img.shields.io/github/last-commit/dashpay/platform"></a>

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@
 
 <p align="center">
   <a href="https://github.com/dashpay/platform/actions/workflows/tests.yml"><img alt="GitHub CI Status" src="https://github.com/dashpay/platform/actions/workflows/tests.yml/badge.svg"></a>
+  <a href="NIGHTLY_STATUS.md"><img alt="Nightly Tests" src="https://github.com/dashpay/platform/actions/workflows/tests.yml/badge.svg?event=schedule" title="Nightly test status"></a>
   <a href="https://codecov.io/gh/dashpay/platform"><img alt="codecov" src="https://codecov.io/gh/dashpay/platform/branch/v3.1-dev/graph/badge.svg"></a>
   <a href="https://github.com/dashpay/platform/graphs/commit-activity"><img alt="commit activity" src="https://img.shields.io/github/commit-activity/m/dashpay/platform"></a>
   <a href="https://github.com/dashpay/platform/commits"><img alt="last commit" src="https://img.shields.io/github/last-commit/dashpay/platform"></a>

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 
 <p align="center">
   <a href="https://github.com/dashpay/platform/actions/workflows/tests.yml"><img alt="CI" src="https://github.com/dashpay/platform/actions/workflows/tests.yml/badge.svg"></a>
-  <a href="NIGHTLY_STATUS.md"><img alt="Nightly Tests" src="https://img.shields.io/github/actions/workflow/status/dashpay/platform/tests.yml?event=schedule&label=Nightly%20Tests" title="Nightly test status"></a>
+  <a href="https://github.com/dashpay/platform/blob/v3.1-dev/NIGHTLY_STATUS.md"><img alt="Nightly Tests" src="https://img.shields.io/github/actions/workflow/status/dashpay/platform/tests.yml?event=schedule&label=Nightly%20Tests" title="Nightly test status"></a>
   <a href="https://codecov.io/gh/dashpay/platform"><img alt="codecov" src="https://codecov.io/gh/dashpay/platform/branch/v3.1-dev/graph/badge.svg"></a>
   <a href="https://github.com/dashpay/platform/graphs/commit-activity"><img alt="commit activity" src="https://img.shields.io/github/commit-activity/m/dashpay/platform"></a>
   <a href="https://github.com/dashpay/platform/commits"><img alt="last commit" src="https://img.shields.io/github/last-commit/dashpay/platform"></a>


### PR DESCRIPTION
## Summary

- Adds `NIGHTLY_STATUS.md` documenting the current state of nightly CI: what's passing, what's failing, known issues, and links to all relevant GitHub Actions workflows
- Adds a nightly test badge to `README.md` linking to the status page

Currently 2 of 65 test suite tests are failing (`bad-txns-inputs-missingorspent`) since ~Mar 16. All Docker builds, JS tests, Rust tests, Dashmate E2E, and Swift SDK builds pass.

## Test plan

- [x] Verify badge renders correctly in README
- [ ] Review status page accuracy

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a nightly testing status dashboard with daily summaries, CI job results, timestamps, and links to recent runs.
  * Dashboard lists current status, per-job outcomes, and known issues (including two recurring withdrawal-related test failures and long‑running flakiness in package tests).
  * Added a README badge linking to the nightly status dashboard.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->