### PR TITLE
chore: update rust-dashcore PR #579

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,12 +47,12 @@ members = [
 ]
 
 [workspace.dependencies]
-dashcore = { git = "https://github.com/dashpay/rust-dashcore", rev = "42eb1d698d4f178d3a8a80c72c9c0f9bbeddcc3e" }
-dash-spv = { git = "https://github.com/dashpay/rust-dashcore", rev = "42eb1d698d4f178d3a8a80c72c9c0f9bbeddcc3e" }
-dash-spv-ffi = { git = "https://github.com/dashpay/rust-dashcore", rev = "42eb1d698d4f178d3a8a80c72c9c0f9bbeddcc3e" }
-key-wallet = { git = "https://github.com/dashpay/rust-dashcore", rev = "42eb1d698d4f178d3a8a80c72c9c0f9bbeddcc3e" }
-key-wallet-manager = { git = "https://github.com/dashpay/rust-dashcore", rev = "42eb1d698d4f178d3a8a80c72c9c0f9bbeddcc3e" }
-dashcore-rpc = { git = "https://github.com/dashpay/rust-dashcore", rev = "42eb1d698d4f178d3a8a80c72c9c0f9bbeddcc3e" }
+dashcore = { git = "https://github.com/dashpay/rust-dashcore", rev = "8cbae416458565faac21d3452fbc6d80b324f6d3" }
+dash-spv = { git = "https://github.com/dashpay/rust-dashcore", rev = "8cbae416458565faac21d3452fbc6d80b324f6d3" }
+dash-spv-ffi = { git = "https://github.com/dashpay/rust-dashcore", rev = "8cbae416458565faac21d3452fbc6d80b324f6d3" }
+key-wallet = { git = "https://github.com/dashpay/rust-dashcore", rev = "8cbae416458565faac21d3452fbc6d80b324f6d3" }
+key-wallet-manager = { git = "https://github.com/dashpay/rust-dashcore", rev = "8cbae416458565faac21d3452fbc6d80b324f6d3" }
+dashcore-rpc = { git = "https://github.com/dashpay/rust-dashcore", rev = "8cbae416458565faac21d3452fbc6d80b324f6d3" }
 
 # Optimize heavy crypto crates even in dev/test builds so that
 # Halo 2 proof generation and verification run at near-release speed.


### PR DESCRIPTION
Automated integration test for [dashpay/rust-dashcore#579](https://github.com/dashpay/rust-dashcore/pull/579).

This PR updates the rust-dashcore dependency to commit `8cbae416458565faac21d3452fbc6d80b324f6d3` to verify downstream compatibility.

**This PR will be automatically closed after CI results are collected.**

---
_Triggered by @ktechmidas via `@dashinfraclaw fulltest`_