### PR TITLE
fix(swift-sdk): fix dash-spv sync (somehow)

### DIFF
--- a/packages/swift-sdk/Sources/SwiftDashSDK/Core/SPV/SPVClient.swift
+++ b/packages/swift-sdk/Sources/SwiftDashSDK/Core/SPV/SPVClient.swift
@@ -185,14 +185,14 @@ class SPVClient: @unchecked Sendable {
     func destroy() {
         dash_spv_ffi_client_destroy(client)
         dash_spv_ffi_config_destroy(config)
-        
+
         client = nil
         config = nil
     }
 
     // MARK: - Synchronization
 
-    func startSync() async throws {
+    func startSync() throws {
         let result = dash_spv_ffi_client_run(
             client
         )

--- a/packages/swift-sdk/Sources/SwiftDashSDK/Core/Services/WalletService.swift
+++ b/packages/swift-sdk/Sources/SwiftDashSDK/Core/Services/WalletService.swift
@@ -84,9 +84,9 @@ func print(_ items: Any..., separator: String = " ", terminator: String = "\n") 
     Swift.print(output, terminator: terminator)
 }
 
-// DESIGN NOTE: This class feels like something that should be in the example app, 
+// DESIGN NOTE: This class feels like something that should be in the example app,
 // we, as sdk developers, provide the tools and ffi wrappers, but how to
-// use them depends on the sdk user, for example, by implementing the SPV event 
+// use them depends on the sdk user, for example, by implementing the SPV event
 // handlers, the user can decide what to do with the events, but if we implement them in the sdk
 // we are taking that decision for them, and maybe not all users want the same thing
 @MainActor
@@ -96,10 +96,10 @@ public class WalletService: ObservableObject {
     @Published public var masternodesEnabled = true
     @Published public var lastSyncError: Error?
     @Published var network: AppNetwork
-    
+
     // Internal properties
     private var modelContainer: ModelContainer
-    
+
     // SPV Client and Wallet wrappers
     private var spvClient: SPVClient
     public private(set) var walletManager: CoreWalletManager
@@ -111,11 +111,6 @@ public class WalletService: ObservableObject {
         LoggingPreferences.configure()
 
         let dataDir = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first?.appendingPathComponent("SPV").appendingPathComponent(network.rawValue).path
-
-        // Ensure the data directory exists before initializing the SPV client
-        if let dataDir = dataDir {
-            try? FileManager.default.createDirectory(atPath: dataDir, withIntermediateDirectories: true)
-        }
 
         // Create SPV client first with dummy handlers to obtain the wallet manager,
         // then destroy and recreate with real handlers that reference self.
@@ -152,21 +147,16 @@ public class WalletService: ObservableObject {
         // Recreate the wallet manager with the new client
         self.walletManager = try! CoreWalletManager(spvClient: self.spvClient, modelContainer: modelContainer)
     }
-    
+
     deinit {
         spvClient.stopSync()
         spvClient.destroy()
     }
-    
+
     private func initializeNewSPVClient() {
       SDKLogger.log("Initializing SPV Client for \(self.self.network.rawValue)...", minimumLevel: .medium)
 
       let dataDir = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first?.appendingPathComponent("SPV").appendingPathComponent(self.network.rawValue).path
-
-      // Ensure the data directory exists before initializing the SPV client
-      if let dataDir = dataDir {
-          try? FileManager.default.createDirectory(atPath: dataDir, withIntermediateDirectories: true)
-      }
 
       // This ensures no memory leaks when creating a new client
       // and unlocks the storage in case we are about to use the same (we probably are)
@@ -200,7 +190,7 @@ public class WalletService: ObservableObject {
 
       SDKLogger.log("WalletManager wrapper initialized successfully", minimumLevel: .medium)
     }
-    
+
     // MARK: - Trusted Mode / Masternode Sync
     public func setMasternodesEnabled(_ enabled: Bool) {
         masternodesEnabled = enabled
@@ -217,11 +207,11 @@ public class WalletService: ObservableObject {
 
     // MARK: - Sync Management
 
-    public func startSync() async {
+    public func startSync() {
         lastSyncError = nil
 
         do {
-            try await spvClient.startSync()
+            try spvClient.startSync()
         } catch {
             self.lastSyncError = error
             print("❌ Sync failed: \(error)")
@@ -232,7 +222,7 @@ public class WalletService: ObservableObject {
       // pausing and resuming is not supported so, the trick is the following,
       // stop the old client and create a new one in its initial state xd
       spvClient.stopSync()
-      
+
       self.initializeNewSPVClient()
     }
 
@@ -265,17 +255,17 @@ public class WalletService: ObservableObject {
 
     public func switchNetwork(to network: AppNetwork) async {
         guard network != self.network else { return }
-        
+
         print("=== WalletService.switchNetwork START ===")
         print("Switching from \(self.network.rawValue) to \(network.rawValue)")
-        
+
         self.network = network
 
         self.stopSync()
-        
+
         print("=== WalletService.switchNetwork END ===")
     }
-    
+
     // MARK: - SPV Event Handlers implementations
 
     internal final class SPVProgressUpdateEventHandlerImpl: SPVProgressUpdateEventHandler, Sendable {

--- a/packages/swift-sdk/SwiftExampleApp/SwiftExampleApp/Core/Views/CoreContentView.swift
+++ b/packages/swift-sdk/SwiftExampleApp/SwiftExampleApp/Core/Views/CoreContentView.swift
@@ -325,9 +325,7 @@ var body: some View {
     }
 
     private func startSync() {
-        Task {
-            await walletService.startSync()
-        }
+        walletService.startSync()
     }
 
     private func pauseSync() {


### PR DESCRIPTION
Somehow this Pr makes dash-spv work in my machine after clearing the simulator with the changes this PR introduce, I didn't do a deep research on why, I will be investigating tomorrow, I have a little theory and has too do with file permissions and the way FileManager creates directories vs how Rust does. The reason I think thats the issue its bcs sync was working fine for me until I cleared the storage, then it got stuck until I removed the file creation and created a new simulator, letting dash-spv manage the directory creation


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Synchronization execution moved from asynchronous to synchronous across the SDK, changing how wallet initialization and data sync are started from apps and UI triggers. This adjusts the sync start call pattern without altering visible sync outcomes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->