### PR TITLE
feat(sdk): add address nonce caching and stale-marking on broadcast failure

### DIFF
--- a/packages/rs-sdk/src/internal_cache/mod.rs
+++ b/packages/rs-sdk/src/internal_cache/mod.rs
@@ -1,11 +1,15 @@
 use crate::error::Error;
 use crate::platform::transition::put_settings::PutSettings;
-use crate::platform::{Fetch, Identifier};
+use crate::platform::{Fetch, FetchMany, Identifier};
 use crate::Sdk;
+use dpp::address_funds::PlatformAddress;
 use dpp::identity::identity_nonce::{IDENTITY_NONCE_VALUE_FILTER, MAX_MISSING_IDENTITY_REVISIONS};
 use dpp::prelude::IdentityNonce;
-use drive_proof_verifier::types::{IdentityContractNonceFetcher, IdentityNonceFetcher};
+use drive_proof_verifier::types::{
+    AddressInfo, AddressInfos, IdentityContractNonceFetcher, IdentityNonceFetcher,
+};
 use lru::LruCache;
+use std::collections::BTreeSet;
 use std::fmt::Debug;
 use std::future::Future;
 use std::hash::Hash;
@@ -74,6 +78,7 @@ pub(crate) struct IdentityContractPair {
 pub(crate) struct NonceCache {
     identity_nonces: Mutex<LruCache<Identifier, NonceCacheEntry>>,
     contract_nonces: Mutex<LruCache<IdentityContractPair, NonceCacheEntry>>,
+    address_nonces: Mutex<LruCache<PlatformAddress, NonceCacheEntry>>,
     default_stale_time_s: u64,
 }
 
@@ -90,6 +95,7 @@ impl Default for NonceCache {
         Self {
             identity_nonces: Mutex::new(LruCache::new(DEFAULT_NONCE_CACHE_SIZE)),
             contract_nonces: Mutex::new(LruCache::new(DEFAULT_NONCE_CACHE_SIZE)),
+            address_nonces: Mutex::new(LruCache::new(DEFAULT_NONCE_CACHE_SIZE)),
             default_stale_time_s: DEFAULT_IDENTITY_NONCE_STALE_TIME_S,
         }
     }
@@ -202,6 +208,55 @@ impl NonceCache {
             },
         )
         .await
+    }
+
+    /// Get or fetch address nonce from cache, querying Platform via the SDK
+    /// when the cached value is stale or absent.
+    pub(crate) async fn get_address_nonce(
+        &self,
+        sdk: &Sdk,
+        address: PlatformAddress,
+        bump_first: bool,
+        settings: &PutSettings,
+    ) -> Result<IdentityNonce, Error> {
+        let request_settings = settings.request_settings;
+        Self::get_or_fetch_nonce(
+            &self.address_nonces,
+            address,
+            bump_first,
+            settings,
+            self.default_stale_time_s,
+            || async move {
+                let addresses = BTreeSet::from([address]);
+                let infos: AddressInfos =
+                    AddressInfo::fetch_many_with_metadata(sdk, addresses, Some(request_settings))
+                        .await
+                        .map(|(infos, _metadata)| infos)?;
+                let nonce = infos
+                    .get(&address)
+                    .and_then(|opt| opt.as_ref())
+                    .map(|info| info.nonce as u64)
+                    .unwrap_or_else(|| {
+                        tracing::debug!(
+                            address = ?address,
+                            "Platform returned no nonce for address; \
+                             defaulting to 0 (unknown address or first interaction)"
+                        );
+                        0
+                    });
+                Ok(nonce)
+            },
+        )
+        .await
+    }
+
+    /// Marks a single address nonce cache entry as stale, forcing a fresh
+    /// Platform fetch on the next access while preserving the cached value.
+    pub(crate) async fn refresh_address(&self, address: &PlatformAddress) {
+        let mut guard = self.address_nonces.lock().await;
+        if let Some(entry) = guard.get_mut(address) {
+            entry.last_fetch_timestamp = STALE_TIMESTAMP;
+        }
     }
 
     /// Marks all nonce cache entries for the given identity as stale,
@@ -998,5 +1053,183 @@ mod nonce_cache_tests {
         .await
         .unwrap();
         assert_eq!(nonce, 6);
+    }
+
+    // --- Address nonce cache tests ---
+
+    fn test_address() -> PlatformAddress {
+        PlatformAddress::P2pkh([0u8; 20])
+    }
+
+    fn test_address_2() -> PlatformAddress {
+        PlatformAddress::P2pkh([1u8; 20])
+    }
+
+    #[tokio::test]
+    async fn address_nonce_basic_fetch() {
+        let cache = NonceCache::default();
+        let address = test_address();
+
+        let result = NonceCache::get_or_fetch_nonce(
+            &cache.address_nonces,
+            address,
+            false,
+            &Default::default(),
+            DEFAULT_IDENTITY_NONCE_STALE_TIME_S,
+            || async { Ok(42u64) },
+        )
+        .await
+        .unwrap();
+        assert_eq!(result, 42);
+    }
+
+    #[tokio::test]
+    async fn address_nonce_cache_hit() {
+        let cache = NonceCache::default();
+        let address = test_address();
+        let settings = never_stale();
+
+        // Seed cache
+        NonceCache::get_or_fetch_nonce(
+            &cache.address_nonces,
+            address,
+            true,
+            &Default::default(),
+            DEFAULT_IDENTITY_NONCE_STALE_TIME_S,
+            || async { Ok(10u64) },
+        )
+        .await
+        .unwrap();
+
+        // Second access should serve from cache without Platform fetch
+        let result = NonceCache::get_or_fetch_nonce(
+            &cache.address_nonces,
+            address,
+            true,
+            &settings,
+            DEFAULT_IDENTITY_NONCE_STALE_TIME_S,
+            || async { panic!("should not fetch from platform") },
+        )
+        .await
+        .unwrap();
+        assert_eq!(result, 12, "first bump=11, second bump=12");
+    }
+
+    #[tokio::test]
+    async fn address_nonce_refresh_marks_stale() {
+        let cache = NonceCache::default();
+        let address = test_address();
+
+        // Seed cache
+        NonceCache::get_or_fetch_nonce(
+            &cache.address_nonces,
+            address,
+            true,
+            &Default::default(),
+            DEFAULT_IDENTITY_NONCE_STALE_TIME_S,
+            || async { Ok(5u64) },
+        )
+        .await
+        .unwrap();
+
+        // Mark stale
+        cache.refresh_address(&address).await;
+
+        // Verify timestamp is STALE_TIMESTAMP
+        let guard = cache.address_nonces.lock().await;
+        let entry = guard.peek(&address).unwrap();
+        assert_eq!(entry.last_fetch_timestamp, STALE_TIMESTAMP);
+    }
+
+    #[tokio::test]
+    async fn address_nonce_refresh_preserves_cached_value() {
+        let cache = NonceCache::default();
+        let address = test_address();
+
+        // Seed cache with bump: platform=5, cached=6
+        let nonce = NonceCache::get_or_fetch_nonce(
+            &cache.address_nonces,
+            address,
+            true,
+            &Default::default(),
+            DEFAULT_IDENTITY_NONCE_STALE_TIME_S,
+            || async { Ok(5u64) },
+        )
+        .await
+        .unwrap();
+        assert_eq!(nonce, 6);
+
+        // Bump again from cache: cached=7
+        let nonce = NonceCache::get_or_fetch_nonce(
+            &cache.address_nonces,
+            address,
+            true,
+            &never_stale(),
+            DEFAULT_IDENTITY_NONCE_STALE_TIME_S,
+            || async { panic!("should not fetch") },
+        )
+        .await
+        .unwrap();
+        assert_eq!(nonce, 7);
+
+        // Simulate broadcast failure: refresh marks stale
+        cache.refresh_address(&address).await;
+
+        // Re-fetch: platform still returns 5 (tx not confirmed yet).
+        // Phase 3 should use max(cached=7, platform=5) = 7, then bump to 8.
+        let nonce = NonceCache::get_or_fetch_nonce(
+            &cache.address_nonces,
+            address,
+            true,
+            &Default::default(),
+            DEFAULT_IDENTITY_NONCE_STALE_TIME_S,
+            || async { Ok(5u64) },
+        )
+        .await
+        .unwrap();
+        assert_eq!(nonce, 8, "should preserve cached nonce and bump past it");
+    }
+
+    #[tokio::test]
+    async fn address_nonce_different_addresses_isolated() {
+        let cache = NonceCache::default();
+        let addr1 = test_address();
+        let addr2 = test_address_2();
+
+        // Seed both addresses
+        NonceCache::get_or_fetch_nonce(
+            &cache.address_nonces,
+            addr1,
+            true,
+            &Default::default(),
+            DEFAULT_IDENTITY_NONCE_STALE_TIME_S,
+            || async { Ok(100u64) },
+        )
+        .await
+        .unwrap();
+        NonceCache::get_or_fetch_nonce(
+            &cache.address_nonces,
+            addr2,
+            true,
+            &Default::default(),
+            DEFAULT_IDENTITY_NONCE_STALE_TIME_S,
+            || async { Ok(200u64) },
+        )
+        .await
+        .unwrap();
+
+        // Refresh only addr1
+        cache.refresh_address(&addr1).await;
+
+        // addr1 should be stale, addr2 should be fresh
+        let guard = cache.address_nonces.lock().await;
+        assert_eq!(
+            guard.peek(&addr1).unwrap().last_fetch_timestamp,
+            STALE_TIMESTAMP
+        );
+        assert_ne!(
+            guard.peek(&addr2).unwrap().last_fetch_timestamp,
+            STALE_TIMESTAMP
+        );
     }
 }

--- a/packages/rs-sdk/src/platform/transition/address_credit_withdrawal.rs
+++ b/packages/rs-sdk/src/platform/transition/address_credit_withdrawal.rs
@@ -4,7 +4,6 @@ use super::address_inputs::{collect_address_infos_from_proof, fetch_inputs_with_
 use super::broadcast::BroadcastStateTransition;
 use super::put_settings::PutSettings;
 use super::validation::ensure_valid_state_transition_structure;
-use crate::platform::transition::address_inputs::nonce_inc;
 use crate::{Error, Sdk};
 use dpp::address_funds::{AddressFundsFeeStrategy, PlatformAddress};
 use dpp::fee::Credits;
@@ -64,7 +63,7 @@ impl<S: Signer<PlatformAddress>> WithdrawAddressFunds<S> for Sdk {
         signer: &S,
         settings: Option<PutSettings>,
     ) -> Result<AddressInfos, Error> {
-        let inputs_with_nonce = nonce_inc(fetch_inputs_with_nonce(self, &inputs).await?);
+        let inputs_with_nonce = fetch_inputs_with_nonce(self, &inputs).await?;
         self.withdraw_address_funds_with_nonce(
             inputs_with_nonce,
             change_output,

--- a/packages/rs-sdk/src/platform/transition/address_inputs.rs
+++ b/packages/rs-sdk/src/platform/transition/address_inputs.rs
@@ -24,19 +24,11 @@ pub(crate) async fn fetch_inputs_with_nonce(
     for (address, amount) in amounts {
         let info = ensure_address_exists(&address_infos, *address)?;
         ensure_address_balance(*address, info.balance, *amount)?;
-        inputs_with_nonce.insert(*address, (info.nonce, *amount));
+        let nonce = sdk.get_address_nonce(*address, true, None).await?;
+        inputs_with_nonce.insert(*address, (nonce, *amount));
     }
 
     Ok(inputs_with_nonce)
-}
-
-/// Increments the nonce for each address in the provided map.
-pub(crate) fn nonce_inc(
-    data: BTreeMap<PlatformAddress, (AddressNonce, Credits)>,
-) -> BTreeMap<PlatformAddress, (AddressNonce, Credits)> {
-    data.into_iter()
-        .map(|(address, (nonce, credits))| (address, (nonce + 1, credits)))
-        .collect()
 }
 
 /// Validates that the provided `address_infos_map` contains exactly the set of `expected_addresses`

--- a/packages/rs-sdk/src/platform/transition/broadcast.rs
+++ b/packages/rs-sdk/src/platform/transition/broadcast.rs
@@ -87,6 +87,11 @@ impl BroadcastStateTransition for StateTransition {
                 if let Some(owner_id) = self.owner_id() {
                     sdk.refresh_identity_nonce(&owner_id).await;
                 }
+                if let Some(inputs) = self.inputs() {
+                    for address in inputs.keys() {
+                        sdk.refresh_address_nonce(address).await;
+                    }
+                }
             }
         }
         result

--- a/packages/rs-sdk/src/platform/transition/shield.rs
+++ b/packages/rs-sdk/src/platform/transition/shield.rs
@@ -1,6 +1,6 @@
 use std::collections::BTreeMap;
 
-use super::address_inputs::{fetch_inputs_with_nonce, nonce_inc};
+use super::address_inputs::fetch_inputs_with_nonce;
 use super::broadcast::BroadcastStateTransition;
 use super::put_settings::PutSettings;
 use super::validation::ensure_valid_state_transition_structure;
@@ -51,7 +51,7 @@ impl<S: Signer<PlatformAddress>> ShieldFunds<S> for Sdk {
         signer: &S,
         settings: Option<PutSettings>,
     ) -> Result<(), Error> {
-        let inputs_with_nonce = nonce_inc(fetch_inputs_with_nonce(self, &inputs).await?);
+        let inputs_with_nonce = fetch_inputs_with_nonce(self, &inputs).await?;
         self.shield_funds_with_nonce(
             inputs_with_nonce,
             bundle,

--- a/packages/rs-sdk/src/platform/transition/top_up_identity_from_addresses.rs
+++ b/packages/rs-sdk/src/platform/transition/top_up_identity_from_addresses.rs
@@ -4,7 +4,7 @@ use super::address_inputs::fetch_inputs_with_nonce;
 use super::put_settings::PutSettings;
 use super::validation::ensure_valid_state_transition_structure;
 use super::waitable::Waitable;
-use crate::platform::transition::address_inputs::{collect_address_infos_from_proof, nonce_inc};
+use crate::platform::transition::address_inputs::collect_address_infos_from_proof;
 use crate::platform::transition::broadcast::BroadcastStateTransition;
 use crate::{Error, Sdk};
 use dpp::address_funds::PlatformAddress;
@@ -51,7 +51,7 @@ impl<S: Signer<PlatformAddress>> TopUpIdentityFromAddresses<S> for Identity {
         signer: &S,
         settings: Option<PutSettings>,
     ) -> Result<(AddressInfos, Credits), Error> {
-        let inputs_with_nonce = nonce_inc(fetch_inputs_with_nonce(sdk, &inputs).await?);
+        let inputs_with_nonce = fetch_inputs_with_nonce(sdk, &inputs).await?;
         self.top_up_from_addresses_with_nonce(sdk, inputs_with_nonce, signer, settings)
             .await
     }

--- a/packages/rs-sdk/src/platform/transition/transfer_address_funds.rs
+++ b/packages/rs-sdk/src/platform/transition/transfer_address_funds.rs
@@ -3,7 +3,6 @@ use std::collections::{BTreeMap, BTreeSet};
 use super::address_inputs::{collect_address_infos_from_proof, fetch_inputs_with_nonce};
 use super::put_settings::PutSettings;
 use super::validation::ensure_valid_state_transition_structure;
-use crate::platform::transition::address_inputs::nonce_inc;
 use crate::platform::transition::broadcast::BroadcastStateTransition;
 use crate::{Error, Sdk};
 use dpp::address_funds::{AddressFundsFeeStrategy, PlatformAddress};
@@ -52,7 +51,7 @@ impl<S: Signer<PlatformAddress>> TransferAddressFunds<S> for Sdk {
         signer: &S,
         settings: Option<PutSettings>,
     ) -> Result<AddressInfos, Error> {
-        let inputs_with_nonce = nonce_inc(fetch_inputs_with_nonce(self, &inputs).await?);
+        let inputs_with_nonce = fetch_inputs_with_nonce(self, &inputs).await?;
         self.transfer_address_funds_with_nonce(
             inputs_with_nonce,
             outputs,

--- a/packages/rs-sdk/src/sdk.rs
+++ b/packages/rs-sdk/src/sdk.rs
@@ -15,10 +15,11 @@ use dapi_grpc::tonic::transport::Certificate;
 use dash_context_provider::ContextProvider;
 #[cfg(feature = "mocks")]
 use dash_context_provider::MockContextProvider;
+use dpp::address_funds::PlatformAddress;
 use dpp::bincode;
 use dpp::bincode::error::DecodeError;
 use dpp::dashcore::Network;
-use dpp::prelude::IdentityNonce;
+use dpp::prelude::{AddressNonce, IdentityNonce};
 use dpp::version::{PlatformVersion, PlatformVersionCurrentVersion};
 use drive::grovedb::operations::proof::GroveDBProof;
 use drive_proof_verifier::FromProof;
@@ -378,6 +379,29 @@ impl Sdk {
     /// [`get_identity_contract_nonce`].
     pub async fn refresh_identity_nonce(&self, identity_id: &Identifier) {
         self.nonce_cache.refresh(identity_id).await;
+    }
+
+    /// Get or fetch address nonce, querying Platform when stale or absent.
+    /// Treats a missing nonce as `0` before applying the optional bump; on first
+    /// interaction this may return `0` or `1` depending on `bump_first`.
+    pub async fn get_address_nonce(
+        &self,
+        address: PlatformAddress,
+        bump_first: bool,
+        settings: Option<PutSettings>,
+    ) -> Result<AddressNonce, Error> {
+        let settings = settings.unwrap_or_default();
+        let nonce = self
+            .nonce_cache
+            .get_address_nonce(self, address, bump_first, &settings)
+            .await?;
+        Ok(nonce as AddressNonce)
+    }
+
+    /// Marks address nonce cache entry as stale so it is re-fetched from
+    /// Platform on the next call to [`get_address_nonce`].
+    pub async fn refresh_address_nonce(&self, address: &PlatformAddress) {
+        self.nonce_cache.refresh_address(address).await;
     }
 
     /// Return [Dash Platform version](PlatformVersion) information used by this SDK.


### PR DESCRIPTION
## Issue being fixed or feature implemented

Closes #3407

The SDK's `NonceCache` only tracks identity and identity-contract nonces. Address-based transitions (`Shield`, `AddressFundsTransfer`, `AddressCreditWithdrawal`, etc.) return `None` for `owner_id()`, so the broadcast failure path in `broadcast.rs` never triggers any nonce cleanup. Address nonces were fetched fresh from Platform every time with no caching and no stale-marking — meaning address-based transitions had zero parity with the existing identity nonce mechanism.

## What was done?

Added address nonce caching to the Rust SDK, achieving parity with the existing identity nonce cache:

1. **`NonceCache` (`internal_cache/mod.rs`)** — Added `address_nonces` LRU cache field. New `get_address_nonce()` method reuses the generic `get_or_fetch_nonce()` (same staleness, drift, and max-merge logic as identity nonces). New `refresh_address()` marks a single address entry as stale.

2. **`Sdk` (`sdk.rs`)** — Public `get_address_nonce(address, bump_first, settings)` (casts internal u64 → AddressNonce u32) and `refresh_address_nonce(address)` wrappers.

3. **Broadcast error handler (`broadcast.rs`)** — On broadcast failure, now iterates `self.inputs()` and calls `refresh_address_nonce()` for each address — parallel to the existing `refresh_identity_nonce()` path.

4. **`fetch_inputs_with_nonce()` (`address_inputs.rs`)** — Now uses the cached nonce via `sdk.get_address_nonce(*address, true, None)` with `bump_first=true`, matching the identity nonce pattern. Removed the separate `nonce_inc()` function (bump now happens inside the cache).

5. **Callers** — Updated 4 files (`shield.rs`, `transfer_address_funds.rs`, `address_credit_withdrawal.rs`, `top_up_identity_from_addresses.rs`) to remove the `nonce_inc()` wrapper.

## How Has This Been Tested?

5 new unit tests in `nonce_cache_tests`:
- `address_nonce_basic_fetch` — empty cache fetches from Platform, returns correct nonce
- `address_nonce_cache_hit` — fresh cached value served without Platform fetch
- `address_nonce_refresh_marks_stale` — refresh sets timestamp to `STALE_TIMESTAMP`
- `address_nonce_refresh_preserves_cached_value` — stale marking preserves cached nonce for `max()` merge (critical for preventing "tx already exists in cache" errors)
- `address_nonce_different_addresses_isolated` — refresh only affects the targeted address

**Build note:** The base branch (`v3.1-dev`) has a pre-existing dependency resolution failure (`key-wallet-manager` crate missing from `rust-dashcore` at rev `8cbae416`). This prevents `cargo check`/`cargo test` from running and is not caused by these changes.

## Breaking Changes

None. The public API is only extended (new `get_address_nonce` and `refresh_address_nonce` methods on `Sdk`). The internal `nonce_inc()` function was removed but was `pub(crate)` only.

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [ ] I have made corresponding changes to the documentation if needed

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone

<sub>🤖 Co-authored by [Claudius the Magnificent](https://github.com/lklimek/claudius) AI Agent</sub>