### PR TITLE
build: add rs-unified-sdk-ffi to Dockerfile COPY blocks

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -405,6 +405,7 @@ COPY --parents \
     packages/rs-dapi-client \
     packages/rs-sdk \
     packages/rs-sdk-ffi \
+    packages/rs-unified-sdk-ffi \
     packages/check-features \
     packages/dash-platform-balance-checker \
     packages/wasm-sdk \
@@ -509,6 +510,7 @@ COPY --parents \
     packages/rs-dapi-client \
     packages/rs-sdk \
     packages/rs-sdk-ffi \
+    packages/rs-unified-sdk-ffi \
     packages/check-features \
     packages/dash-platform-balance-checker \
     packages/wasm-sdk \
@@ -599,6 +601,7 @@ COPY --parents \
     packages/rs-platform-versioning \
     packages/rs-platform-value-convertible \
     packages/rs-platform-wallet-ffi \
+    packages/rs-unified-sdk-ffi \
     packages/rs-json-schema-compatibility-validator \
     # Common
     packages/wasm-dpp \
@@ -854,6 +857,7 @@ COPY --parents \
     packages/rs-dapi-client \
     packages/rs-sdk \
     packages/rs-sdk-ffi \
+    packages/rs-unified-sdk-ffi \
     packages/rs-platform-wallet \
     packages/check-features \
     packages/dash-platform-balance-checker \


### PR DESCRIPTION
## Issue being fixed or feature implemented

Docker build fails with `Cannot extract Cargo metadata` because `rs-unified-sdk-ffi` was added as a workspace member in `Cargo.toml` but not included in the Dockerfile's `COPY --parents` blocks.

## What was done?

Added `packages/rs-unified-sdk-ffi` to all four Dockerfile COPY blocks that enumerate workspace members:

1. **build-planner** — `cargo chef prepare` needs all workspace members to extract metadata
2. **build-drive-abci** — source COPY for drive-abci build
3. **build-js** — source COPY for JS/WASM build
4. **build-rs-dapi** — source COPY for rs-dapi build

## How Has This Been Tested?

- Verified `rs-unified-sdk-ffi` directory and `Cargo.toml` exist in the workspace
- Confirmed the crate is listed in workspace `Cargo.toml` members
- Confirmed all four COPY blocks that list workspace members now include the new crate

## Breaking Changes

None.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [ ] I have made corresponding changes to the documentation if needed

<sub>🤖 Co-authored by [Claudius the Magnificent](https://github.com/lklimek/claudius) AI Agent</sub>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized Docker build configuration to improve package handling across multiple build stages for enhanced build efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->