### PR TITLE
fix(rs-scripts): remove redundant wildcard pattern blocking CI

### DIFF
--- a/packages/rs-scripts/src/bin/decode_document.rs
+++ b/packages/rs-scripts/src/bin/decode_document.rs
@@ -121,7 +121,7 @@ fn main() {
             eprintln!("Invalid hex: {e}");
             std::process::exit(1);
         }),
-        "auto" | _ => {
+        _ => {
             // Try base64 first (most common — gRPC responses are base64),
             // then hex. This avoids misinterpreting hex-only base64 strings.
             if let Ok(b) = base64::engine::general_purpose::STANDARD.decode(&args.doc_bytes) {


### PR DESCRIPTION
## Issue being fixed or feature implemented

Clippy rejects `"auto" | _` in the decode-document match arm (`wildcard_in_or_patterns`), causing CI failure on every PR that includes the rs-scripts workspace (#3428, #3429, etc.).

## What was done?

One-line fix: `"auto" | _` → `_`. The `_` wildcard already covers `"auto"` and everything else.

## How Has This Been Tested?

`cargo clippy -p rs-scripts -- -D warnings` passes.

## Breaking Changes

None.

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [ ] I have made corresponding changes to the documentation if needed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified internal command-line argument handling logic while preserving existing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->