### PR TITLE
fix(wallet-lib): fix broadcast retry not matching DAPI error message

### DIFF
--- a/NIGHTLY_STATUS.md
+++ b/NIGHTLY_STATUS.md
@@ -37,11 +37,13 @@ These jobs only run on nightly if relevant files changed in the latest commit. T
 
 ### Test Suite: `bad-txns-inputs-missingorspent` (since ~Mar 16)
 
-Two withdrawal-related tests fail because Core rejects a transaction whose inputs are missing or already spent. The local network starts and processes blocks normally -- the failure is specific to the withdrawal test scenario.
+Seven tests fail because Core rejects faucet wallet funding transactions whose inputs are already in the mempool. The failures are in the Data Contract and Contacts test groups -- 1 `before all` hook failure cascades into 6 dependent Contacts tests.
 
-- **63 tests pass**, 2 fail
+- **65 tests pass**, 7 fail (1 Data Contract funding + 6 Contacts cascade)
 - Error: `InvalidRequestError: Transaction is rejected: bad-txns-inputs-missingorspent`
+- **Root cause:** The wallet-lib retry logic at `broadcastTransaction.js:181` checks for `'invalid transaction: bad-txns-inputs-missingorspent'` but DAPI returns `'Transaction is rejected: bad-txns-inputs-missingorspent'` -- the retry never matches, so UTXO conflicts are not retried.
 - **Not caused by** the `ssh2`/`nan` compilation warnings (those are non-fatal)
+- **Fix:** PR #3434 updates the check to use `.includes('bad-txns-inputs-missingorspent')`
 
 ### Functional tests: long-standing flakiness
 

--- a/packages/wallet-lib/src/types/Account/methods/broadcastTransaction.js
+++ b/packages/wallet-lib/src/types/Account/methods/broadcastTransaction.js
@@ -178,7 +178,7 @@ async function broadcastTransaction(transaction, options = {
   } catch (error) {
     cancelMempoolSubscription();
 
-    if (error.message === 'invalid transaction: bad-txns-inputs-missingorspent') {
+    if (error.message && error.message.includes('bad-txns-inputs-missingorspent')) {
       if (this.broadcastRetryAttempts === MAX_RETRY_ATTEMPTS) {
         throw error;
       }


### PR DESCRIPTION
## Issue Being Fixed

Since ~March 16, **7 nightly test suite tests fail consistently** with `bad-txns-inputs-missingorspent`. This has been tracked in [NIGHTLY_STATUS.md](https://github.com/dashpay/platform/blob/v3.1-dev/NIGHTLY_STATUS.md#test-suite-bad-txns-inputs-missingorspent-since-mar-16).

### Root cause

The wallet-lib has retry logic for UTXO conflicts in `broadcastTransaction.js:181`, but the error message check was wrong:

```javascript
// What wallet-lib checked for:
error.message === 'invalid transaction: bad-txns-inputs-missingorspent'

// What DAPI actually returns (both JS and Rust DAPI):
'Transaction is rejected: bad-txns-inputs-missingorspent'
```

The retry **never triggered**. When the faucet wallet tried to fund multiple test wallets in quick succession, the second transaction would reference UTXOs still in the mempool from the first — Core rejects with `bad-txns-inputs-missingorspent`, and without the retry, the test fails immediately.

### Failing tests (7 total, from 2 broadcastTransaction failures)

1. `Platform > Data Contract > "before all" hook` — faucet funding fails
2-7. `e2e > Contacts > Alice/Bob` — cascade from Alice's wallet funding failure

### Investigation timeline

- **Last passing nightly:** March 15 (run 23121472332)
- **First failing nightly:** March 16 (run 23170189658)
- The UTXO race condition was always latent; timing changes from commits landing March 15-16 made it consistently reproducible
- The retry logic message mismatch predates the failure — it was never matching against the DAPI error format

## What was changed

**`packages/wallet-lib/src/types/Account/methods/broadcastTransaction.js`**

```diff
- if (error.message === 'invalid transaction: bad-txns-inputs-missingorspent') {
+ if (error.message && error.message.includes('bad-txns-inputs-missingorspent')) {
```

Using `.includes()` matches regardless of the message prefix (`"invalid transaction:"`, `"Transaction is rejected:"`, or any future format). The `error.message &&` guard prevents TypeError on errors without a message property.

**`NIGHTLY_STATUS.md`** — Updated the known issue section with correct failure count (7, not 2), correct root cause (faucet funding, not withdrawals), and a link to this PR.

## Breaking Changes

None. The retry behavior is strictly more permissive (matches errors it previously missed).

## Tests

The fix should resolve the 7 nightly test failures. The retry logic itself doesn't have a unit test in `broadcastTransaction.spec.js`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved transaction retry logic to more reliably detect and handle certain broadcast failures, enabling proper retry behavior for transaction conflicts that previously failed to retry.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->