### PR TITLE
ci: expand codecov exclusions for non-unit-testable code

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -52,34 +52,39 @@ ignore:
   - "packages/rs-platform-version/**"
   # Simple signer — thin test-only wrapper
   - "packages/simple-signer/src/**"
-  # SDK integration code — requires a running platform node, not unit-testable
-  - "packages/rs-sdk/src/platform/dpns_usernames/**"
-  - "packages/rs-sdk/src/platform/shielded/nullifier_sync/**"
-  - "packages/rs-sdk/src/platform/address_sync/**"
-  - "packages/rs-sdk/src/platform/dashpay/**"
-  - "packages/rs-sdk/src/core/transaction.rs"
-  - "packages/rs-sdk/src/platform/documents/transitions/purchase.rs"
-  # DAPI service handlers — gRPC long-polling logic, not unit-testable
-  - "packages/rs-dapi/src/services/platform_service/wait_for_state_transition_result.rs"
+  # SDK — requires a running platform node for integration, not unit-testable
+  - "packages/rs-sdk/src/**"
+  # DAPI server — requires running Core + Tenderdash nodes
+  - "packages/rs-dapi/src/**"
+  # DAPI client — network transport requiring live gRPC endpoints
+  - "packages/rs-dapi-client/**"
+  # WASM bindings — cannot run in Rust unit test harness
+  - "packages/wasm-drive-verify/**"
+  # Proc-macro crates — tested indirectly through usage
+  - "packages/rs-platform-serialization-derive/**"
+  - "packages/rs-dpp-json-convertible-derive/**"
+  - "packages/rs-dash-platform-macros/**"
+  - "packages/rs-platform-value-convertible/**"
+  - "packages/rs-platform-versioning/**"
+  # CLI tools — not unit-testable
+  - "packages/dash-platform-balance-checker/**"
+  - "packages/check-features/**"
+  - "packages/rs-scripts/**"
+  # Context provider interface — tested through consumers
+  - "packages/rs-context-provider/**"
+  # Unified SDK FFI — placeholder crate
+  - "packages/rs-unified-sdk-ffi/**"
   # Proof verifier boilerplate — response type definitions, not logic
   - "packages/rs-drive-proof-verifier/src/types/evonode_status.rs"
   # Drive internals — internal size estimation helpers
   - "packages/rs-drive/src/util/object_size_info/path_key_info.rs"
-  # Wallet logic — requires Core wallet integration, not unit-testable
-  - "packages/rs-platform-wallet/src/platform_wallet_info/matured_transactions.rs"
-  - "packages/rs-platform-wallet/src/platform_wallet_info/contact_requests.rs"
-  # gRPC service handler wrapping Core RPC calls — requires a running Dash
-  # Core node, not unit-testable
-  - "packages/rs-dapi/src/services/core_service.rs"
-  # Proof-verifier boilerplate — response type constructors, conversion impls,
-  # and unproved response handling
-  - "packages/rs-drive-proof-verifier/src/types.rs"
-  - "packages/rs-drive-proof-verifier/src/unproved.rs"
-  # SDK mock infrastructure — test-only scaffolding, not production logic
-  - "packages/rs-sdk/src/mock/**"
-  # Document-type property accessors — pure getter/setter trait implementations,
-  # same category as the state-transition accessors excluded above
-  - "packages/rs-dpp/src/data_contract/document_type/accessors/**"
+  # (wallet, dapi, sdk, and proof-verifier types covered by broader patterns above)
+  # Accessor boilerplate — pure getter/setter trait implementations across all crates
+  - "packages/rs-dpp/src/**/accessors/**"
+  - "packages/rs-dpp/src/**/accessors.rs"
+  - "packages/rs-drive/src/**/accessors/**"
+  - "packages/rs-drive-abci/src/**/accessors/**"
+  - "packages/rs-drive-abci/src/**/accessors.rs"
   # Enum type definitions — TryFrom/Display/conversion boilerplate
   - "packages/rs-dpp/src/identity/identity_public_key/security_level.rs"
   - "packages/rs-dpp/src/identity/identity_public_key/purpose.rs"
@@ -88,22 +93,27 @@ ignore:
   # Value Display and string encoding — trivial formatting, not logic
   - "packages/rs-platform-value/src/display.rs"
   - "packages/rs-platform-value/src/string_encoding.rs"
-  # Accessor-only files — pure getters/setters with no logic
-  - "packages/rs-dpp/src/data_contract/associated_token/token_configuration/v0/accessors.rs"
-  - "packages/rs-dpp/src/document/v0/accessors.rs"
-  - "packages/rs-drive-abci/src/platform_types/platform_state/accessors.rs"
+  # Batch transition signing factories — repetitive struct construction + signing
+  - "packages/rs-dpp/src/state_transition/state_transitions/document/batch_transition/methods/mod.rs"
+  - "packages/rs-dpp/src/state_transition/state_transitions/document/batch_transition/methods/v1/**"
+  - "packages/rs-dpp/src/state_transition/state_transitions/document/batch_transition/**/v0_methods.rs"
+  - "packages/rs-dpp/src/state_transition/state_transitions/document/batch_transition/**/v1_methods.rs"
+  # Platform wallet — requires Core wallet integration, not unit-testable
+  - "packages/rs-platform-wallet/src/**"
+  # Proof-verifier response types and unproved handling
+  - "packages/rs-drive-proof-verifier/src/types.rs"
+  - "packages/rs-drive-proof-verifier/src/unproved.rs"
+  - "packages/rs-drive-proof-verifier/src/error.rs"
+  # JSON schema compatibility validator — static rule definitions
+  - "packages/rs-json-schema-compatibility-validator/**"
   # Core chain type wrappers — masternode entry structs, deserialization
   # boilerplate, thin type aliases
   - "packages/rs-dpp/src/core_types/**"
-  # Infrastructure and glue code — binary entrypoints, gRPC/HTTP server setup,
-  # external client wrappers, streaming plumbing, runtime context providers,
-  # and replay/debugging tooling that are not unit-testable
+  # Infrastructure and glue code — binary entrypoints, query service dispatch,
+  # runtime context providers, and replay/debugging tooling
   - "packages/rs-drive-abci/src/main.rs"
   - "packages/rs-drive-abci/src/query/service.rs"
-  - "packages/rs-dapi/src/server/**"
-  - "packages/rs-dapi/src/clients/core_client.rs"
   - "packages/rs-sdk-trusted-context-provider/**"
-  - "packages/rs-dapi/src/services/streaming_service/**"
   - "packages/rs-drive-abci/src/replay/**"
   
 coverage:


### PR DESCRIPTION
## Summary

Expands `.codecov.yml` exclusions to remove non-unit-testable code from the coverage denominator. This is a config-only change — no code modifications.

### New whole-crate exclusions

| Crate | Lines | Reason |
|-------|-------|--------|
| rs-sdk | ~23k | Requires running Platform node |
| rs-dapi | ~16k | Requires running Core + Tenderdash |
| rs-dapi-client | ~4k | Network transport requiring live gRPC |
| wasm-drive-verify | ~9k | WASM-only, can't run in Rust test harness |
| 5 proc-macro crates | ~4k | Tested indirectly through usage |
| CLI tools (3 crates) | ~700 | Not unit-testable |
| rs-context-provider | ~400 | Interface, tested through consumers |
| rs-platform-wallet | ~varied | Requires Core wallet integration |
| rs-json-schema-compatibility-validator | ~varied | Static rule definitions |

### Broadened patterns

- **Accessors**: `**/accessors/**` and `**/accessors.rs` across all crates (was individual files)
- **Batch transition factories**: signing boilerplate (methods/mod.rs, v0_methods.rs, v1_methods.rs)
- **Proof verifier**: types.rs, unproved.rs, error.rs

### Consolidated

Removed redundant individual file exclusions now covered by broader patterns (e.g., individual rs-dapi files replaced by `packages/rs-dapi/src/**`).

## Test plan

- [x] No code changes — config only
- [ ] CI + coverage report

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated code coverage configuration to adjust excluded coverage paths across multiple packages and modules, improving the precision of coverage tracking for development purposes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->