### PR TITLE
fix(swift-sdk): pending transaction display

### DIFF
--- a/packages/swift-sdk/SwiftExampleApp/SwiftExampleApp/Core/Views/TransactionDetailView.swift
+++ b/packages/swift-sdk/SwiftExampleApp/SwiftExampleApp/Core/Views/TransactionDetailView.swift
@@ -66,10 +66,12 @@ struct TransactionDetailView: View {
                             value: !transaction.isConfirmed ? "Pending" : "Confirmed"
                         )
 
-                        TransactionDetailRow(
-                            label: "Date",
-                            value: formatDate(transaction.date)
-                        )
+                        if transaction.isConfirmed {
+                            TransactionDetailRow(
+                                label: "Date",
+                                value: formatDate(transaction.date)
+                            )
+                        }
 
                         if transaction.height != 0 {
                             TransactionDetailRow(

--- a/packages/swift-sdk/SwiftExampleApp/SwiftExampleApp/Core/Views/TransactionListView.swift
+++ b/packages/swift-sdk/SwiftExampleApp/SwiftExampleApp/Core/Views/TransactionListView.swift
@@ -11,7 +11,12 @@ struct TransactionListView: View {
     @State private var selectedTransaction: WalletTransaction?
 
     private var sortedTransactions: [WalletTransaction] {
-        transactions.sorted { $0.timestamp > $1.timestamp }
+        transactions.sorted {
+            if $0.isConfirmed != $1.isConfirmed {
+                return !$0.isConfirmed
+            }
+            return $0.timestamp > $1.timestamp
+        }
     }
 
     var body: some View {
@@ -146,9 +151,11 @@ struct TransactionRowView: View {
 
                         Spacer()
 
-                    Text(transaction.date, style: .relative)
-                        .font(.caption)
-                        .foregroundColor(.secondary)
+                    if transaction.isConfirmed {
+                        Text(transaction.date, style: .relative)
+                            .font(.caption)
+                            .foregroundColor(.secondary)
+                    }
                 }
 
                 // confirmation and amount


### PR DESCRIPTION
I made the pending transaction show first in the list view in the example app. I also hide the date for them in the list and detailed views because they don't have one until they are confirmed


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [x] I have made corresponding changes to the documentation if needed

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone
