### PR TITLE
ci: exclude more non-unit-testable code from coverage

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -109,12 +109,27 @@ ignore:
   # Core chain type wrappers — masternode entry structs, deserialization
   # boilerplate, thin type aliases
   - "packages/rs-dpp/src/core_types/**"
-  # Infrastructure and glue code — binary entrypoints, query service dispatch,
-  # runtime context providers, and replay/debugging tooling
+  # Random data generators — test-only helpers, not production logic
+  - "packages/rs-dpp/src/**/random.rs"
+  - "packages/rs-dpp/src/**/random_*.rs"
+  # Batch transition resolvers — From/TryFrom conversion boilerplate
+  - "packages/rs-dpp/src/state_transition/state_transitions/document/batch_transition/batched_transition/resolvers.rs"
+  # Drive-ABCI infrastructure — binary entrypoints, query service dispatch,
+  # RPC wrappers, metrics, logging, runtime context providers, replay tooling
   - "packages/rs-drive-abci/src/main.rs"
   - "packages/rs-drive-abci/src/query/service.rs"
+  - "packages/rs-drive-abci/src/rpc/**"
+  - "packages/rs-drive-abci/src/metrics.rs"
+  - "packages/rs-drive-abci/src/logging/**"
+  - "packages/rs-drive-abci/src/mimic/**"
   - "packages/rs-sdk-trusted-context-provider/**"
   - "packages/rs-drive-abci/src/replay/**"
+  # DPP signing test module — integration tests, not unit-testable
+  - "packages/rs-dpp/src/state_transition/state_transitions/address_funds/**/signing_tests.rs"
+  # Drive extra tests — integration tests in production code tree
+  - "packages/rs-dpp/src/data_contract/extra/drive_api_tests.rs"
+  # Versioned dispatch methods — pure version routing with no logic
+  - "packages/rs-dpp/src/data_contract/document_type/methods/versioned_methods.rs"
   
 coverage:
   status:


### PR DESCRIPTION
## Summary

Additional `.codecov.yml` exclusions for code that is test-only infrastructure or pure boilerplate. Config-only change.

### New exclusions

| Pattern | Lines | Reason |
|---------|-------|--------|
| `**/random.rs`, `**/random_*.rs` (dpp) | ~2,500 | Test-only random data generators |
| `resolvers.rs` (batch transition) | ~250 | Pure From/TryFrom conversion boilerplate |
| `rpc/**`, `metrics.rs`, `logging/**` (drive-abci) | ~1,000 | Infrastructure code (RPC wrappers, metrics collection, log setup) |
| `mimic/**` (drive-abci) | ~300 | Test quorum simulation |
| `signing_tests.rs` (dpp) | ~1,200 | Integration tests in production code tree |
| `drive_api_tests.rs` (dpp) | ~350 | Integration tests in production code tree |
| `versioned_methods.rs` (dpp) | ~600 | Pure version dispatch routing with no logic |

### NOT excluded (kept in coverage)

- State transition action transformers — contain real transformation logic
- Proof verifier proof implementations — contain verification logic
- ABCI handlers — tested through strategy tests

## Test plan
- [x] Config only — no code changes
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)