### PR TITLE
fix: add rs-scripts to Docker build context

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -409,6 +409,7 @@ COPY --parents \
     packages/check-features \
     packages/dash-platform-balance-checker \
     packages/wasm-sdk \
+    packages/rs-scripts \
     /platform/
 
 RUN --mount=type=secret,id=AWS \
@@ -514,6 +515,7 @@ COPY --parents \
     packages/check-features \
     packages/dash-platform-balance-checker \
     packages/wasm-sdk \
+    packages/rs-scripts \
     /platform/
 
 RUN mkdir /artifacts
@@ -862,6 +864,7 @@ COPY --parents \
     packages/check-features \
     packages/dash-platform-balance-checker \
     packages/wasm-sdk \
+    packages/rs-scripts \
     /platform/
 
 RUN mkdir /artifacts


### PR DESCRIPTION
## Issue Being Fixed

Docker builds fail at the `build-planner` stage with:

```
Cannot extract Cargo metadata
`cargo metadata` exited with an error: error: failed to load manifest for workspace member `/platform/packages/rs-scripts`
Caused by: No such file or directory (os error 2)
```

## Root Cause

`packages/rs-scripts` was added as a workspace member in `Cargo.toml` (PR #3391) but was not included in the Dockerfile's `COPY --parents` directives. The three Rust build stages (build-planner, build-drive-abci, build-rs-dapi) all copy the workspace `Cargo.toml` which references `rs-scripts`, but the package directory itself was missing from the Docker context.

## What was changed

Added `packages/rs-scripts \` to all three `COPY --parents` blocks in the Dockerfile (lines ~411, ~517, ~866).

## Breaking Changes

None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build infrastructure configuration to optimize monorepo build processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->