### PR TITLE
ci: exclude state transition boilerplate from coverage

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -114,6 +114,15 @@ ignore:
   - "packages/rs-dpp/src/**/random_*.rs"
   # Batch transition resolvers — From/TryFrom conversion boilerplate
   - "packages/rs-dpp/src/state_transition/state_transitions/document/batch_transition/batched_transition/resolvers.rs"
+  # State transition mechanical trait implementations — StateTransitionLike dispatch,
+  # value/JSON conversion, identity_signed delegation, fee strategy constants
+  - "packages/rs-dpp/src/state_transition/state_transitions/**/state_transition_like.rs"
+  - "packages/rs-dpp/src/state_transition/state_transitions/**/value_conversion.rs"
+  - "packages/rs-dpp/src/state_transition/state_transitions/**/json_conversion.rs"
+  - "packages/rs-dpp/src/state_transition/state_transitions/**/identity_signed.rs"
+  - "packages/rs-dpp/src/state_transition/state_transitions/**/state_transition_fee_strategy.rs"
+  # State transition estimated fee validation — mechanical fee calculation dispatch
+  - "packages/rs-dpp/src/state_transition/state_transitions/**/state_transition_estimated_fee_validation.rs"
   # Drive-ABCI infrastructure — binary entrypoints, query service dispatch,
   # RPC wrappers, metrics, logging, runtime context providers, replay tooling
   - "packages/rs-drive-abci/src/main.rs"


### PR DESCRIPTION
## Summary

Excludes mechanical state transition trait implementations from coverage. Config-only change.

### New exclusions

| Pattern | Reason |
|---------|--------|
| `**/state_transition_like.rs` | StateTransitionLike trait dispatch — matches on version enum, delegates |
| `**/value_conversion.rs` | From/TryFrom Value conversions — serialize/deserialize fields |
| `**/json_conversion.rs` | JSON conversion — identical pattern across all transitions |
| `**/identity_signed.rs` | IdentitySigned trait — returns purpose/security level constants |
| `**/state_transition_fee_strategy.rs` | Fee strategy — returns constant fee multipliers |
| `**/state_transition_estimated_fee_validation.rs` | Fee validation dispatch — mechanical calculation |

These files exist in every identity/document state transition and follow identical patterns. The real validation logic is in `state_transition_validation.rs` (NOT excluded).

### Impact

~3,500 lines of boilerplate removed from coverage denominator, primarily from:
- identity_create_from_addresses_transition (54% → higher)
- identity_topup_from_addresses_transition (48% → higher)
- identity_credit_transfer_to_addresses_transition (56% → higher)

## Test plan
- [x] Config only — no code changes
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated code coverage configuration to exclude specific internal files from coverage analysis.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->