### PR TITLE
test(drive-abci): add happy path tests for token burn, freeze, emergency action, and destroy frozen funds

### DIFF
--- a/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/batch/tests/token/burn/mod.rs
+++ b/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/batch/tests/token/burn/mod.rs
@@ -91,6 +91,92 @@ mod token_burn_tests {
     }
 
     #[test]
+    fn test_token_burn_entire_balance() {
+        let platform_version = PlatformVersion::latest();
+        let mut platform = TestPlatformBuilder::new()
+            .with_latest_protocol_version()
+            .build_with_mock_rpc()
+            .set_genesis_state();
+
+        let mut rng = StdRng::seed_from_u64(49853);
+
+        let platform_state = platform.state.load();
+
+        let (identity, signer, key) =
+            setup_identity(&mut platform, rng.gen(), dash_to_credits!(0.5));
+
+        let (contract, token_id) = create_token_contract_with_owner_identity(
+            &mut platform,
+            identity.id(),
+            None::<fn(&mut TokenConfiguration)>,
+            None,
+            None,
+            None,
+            platform_version,
+        );
+
+        // Burn the entire balance of 100000 tokens
+        let burn_transition = BatchTransition::new_token_burn_transition(
+            token_id,
+            identity.id(),
+            contract.id(),
+            0,
+            100000,
+            None,
+            None,
+            &key,
+            2,
+            0,
+            &signer,
+            platform_version,
+            None,
+        )
+        .expect("expect to create documents batch transition");
+
+        let burn_serialized_transition = burn_transition
+            .serialize_to_bytes()
+            .expect("expected documents batch serialized state transition");
+
+        let transaction = platform.drive.grove.start_transaction();
+
+        let processing_result = platform
+            .platform
+            .process_raw_state_transitions(
+                &[burn_serialized_transition.clone()],
+                &platform_state,
+                &BlockInfo::default(),
+                &transaction,
+                platform_version,
+                false,
+                None,
+            )
+            .expect("expected to process state transition");
+
+        assert_matches!(
+            processing_result.execution_results().as_slice(),
+            [StateTransitionExecutionResult::SuccessfulExecution { .. }]
+        );
+
+        platform
+            .drive
+            .grove
+            .commit_transaction(transaction)
+            .unwrap()
+            .expect("expected to commit transaction");
+
+        let token_balance = platform
+            .drive
+            .fetch_identity_token_balance(
+                token_id.to_buffer(),
+                identity.id().to_buffer(),
+                None,
+                platform_version,
+            )
+            .expect("expected to fetch token balance");
+        assert_eq!(token_balance, Some(0));
+    }
+
+    #[test]
     fn test_token_burn_trying_to_burn_more_than_we_have() {
         let platform_version = PlatformVersion::latest();
         let mut platform = TestPlatformBuilder::new()

--- a/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/batch/tests/token/destroy_frozen_funds/mod.rs
+++ b/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/batch/tests/token/destroy_frozen_funds/mod.rs
@@ -2,6 +2,263 @@ use super::*;
 
 mod token_destroy_frozen_funds_tests {
     use super::*;
+    use dpp::tokens::info::v0::IdentityTokenInfoV0Accessors;
+
+    #[test]
+    fn test_token_destroy_frozen_funds_success() {
+        let platform_version = PlatformVersion::latest();
+        let mut platform = TestPlatformBuilder::new()
+            .with_latest_protocol_version()
+            .build_with_mock_rpc()
+            .set_genesis_state();
+
+        let mut rng = StdRng::seed_from_u64(49853);
+        let platform_state = platform.state.load();
+
+        let (identity, signer, key) =
+            setup_identity(&mut platform, rng.gen(), dash_to_credits!(0.5));
+
+        let (identity_2, _, _) = setup_identity(&mut platform, rng.gen(), dash_to_credits!(0.5));
+
+        let (contract, token_id) = create_token_contract_with_owner_identity(
+            &mut platform,
+            identity.id(),
+            Some(|token_configuration: &mut TokenConfiguration| {
+                token_configuration.set_destroy_frozen_funds_rules(ChangeControlRules::V0(
+                    ChangeControlRulesV0 {
+                        authorized_to_make_change: AuthorizedActionTakers::ContractOwner,
+                        admin_action_takers: AuthorizedActionTakers::NoOne,
+                        changing_authorized_action_takers_to_no_one_allowed: false,
+                        changing_admin_action_takers_to_no_one_allowed: false,
+                        self_changing_admin_action_takers_allowed: false,
+                    },
+                ));
+                token_configuration.set_freeze_rules(ChangeControlRules::V0(
+                    ChangeControlRulesV0 {
+                        authorized_to_make_change: AuthorizedActionTakers::ContractOwner,
+                        admin_action_takers: AuthorizedActionTakers::NoOne,
+                        changing_authorized_action_takers_to_no_one_allowed: false,
+                        changing_admin_action_takers_to_no_one_allowed: false,
+                        self_changing_admin_action_takers_allowed: false,
+                    },
+                ));
+                token_configuration.set_manual_minting_rules(ChangeControlRules::V0(
+                    ChangeControlRulesV0 {
+                        authorized_to_make_change: AuthorizedActionTakers::ContractOwner,
+                        admin_action_takers: AuthorizedActionTakers::NoOne,
+                        changing_authorized_action_takers_to_no_one_allowed: false,
+                        changing_admin_action_takers_to_no_one_allowed: false,
+                        self_changing_admin_action_takers_allowed: false,
+                    },
+                ));
+                token_configuration
+                    .distribution_rules_mut()
+                    .set_minting_allow_choosing_destination(true);
+            }),
+            None,
+            None,
+            None,
+            platform_version,
+        );
+
+        // Mint tokens to identity_2
+        let mint_transition = BatchTransition::new_token_mint_transition(
+            token_id,
+            identity.id(),
+            contract.id(),
+            0,
+            5000,
+            Some(identity_2.id()),
+            None,
+            None,
+            &key,
+            2,
+            0,
+            &signer,
+            platform_version,
+            None,
+        )
+        .expect("expected to create mint transition");
+
+        let serialized = mint_transition
+            .serialize_to_bytes()
+            .expect("expected to serialize");
+
+        let transaction = platform.drive.grove.start_transaction();
+
+        let processing_result = platform
+            .platform
+            .process_raw_state_transitions(
+                &[serialized],
+                &platform_state,
+                &BlockInfo::default(),
+                &transaction,
+                platform_version,
+                false,
+                None,
+            )
+            .expect("expected to process state transition");
+
+        assert_matches!(
+            processing_result.execution_results().as_slice(),
+            [StateTransitionExecutionResult::SuccessfulExecution { .. }]
+        );
+
+        platform
+            .drive
+            .grove
+            .commit_transaction(transaction)
+            .unwrap()
+            .expect("expected to commit transaction");
+
+        // Verify identity_2 has the minted tokens
+        let token_balance = platform
+            .drive
+            .fetch_identity_token_balance(
+                token_id.to_buffer(),
+                identity_2.id().to_buffer(),
+                None,
+                platform_version,
+            )
+            .expect("expected to fetch token balance");
+        assert_eq!(token_balance, Some(5000));
+
+        // Freeze identity_2's token account
+        let freeze_transition = BatchTransition::new_token_freeze_transition(
+            token_id,
+            identity.id(),
+            contract.id(),
+            0,
+            identity_2.id(),
+            None,
+            None,
+            &key,
+            3,
+            0,
+            &signer,
+            platform_version,
+            None,
+        )
+        .expect("expected to create freeze transition");
+
+        let serialized = freeze_transition
+            .serialize_to_bytes()
+            .expect("expected to serialize");
+
+        let transaction = platform.drive.grove.start_transaction();
+
+        let processing_result = platform
+            .platform
+            .process_raw_state_transitions(
+                &[serialized],
+                &platform_state,
+                &BlockInfo::default(),
+                &transaction,
+                platform_version,
+                false,
+                None,
+            )
+            .expect("expected to process state transition");
+
+        assert_matches!(
+            processing_result.execution_results().as_slice(),
+            [StateTransitionExecutionResult::SuccessfulExecution { .. }]
+        );
+
+        platform
+            .drive
+            .grove
+            .commit_transaction(transaction)
+            .unwrap()
+            .expect("expected to commit transaction");
+
+        // Verify identity_2 is frozen
+        let token_frozen = platform
+            .drive
+            .fetch_identity_token_info(
+                token_id.to_buffer(),
+                identity_2.id().to_buffer(),
+                None,
+                platform_version,
+            )
+            .expect("expected to fetch token info")
+            .map(|info| info.frozen());
+        assert_eq!(token_frozen, Some(true));
+
+        // Destroy the frozen funds
+        let destroy_transition = BatchTransition::new_token_destroy_frozen_funds_transition(
+            token_id,
+            identity.id(),
+            contract.id(),
+            0,
+            identity_2.id(),
+            None,
+            None,
+            &key,
+            4,
+            0,
+            &signer,
+            platform_version,
+            None,
+        )
+        .expect("expected to create destroy frozen funds transition");
+
+        let serialized = destroy_transition
+            .serialize_to_bytes()
+            .expect("expected to serialize");
+
+        let transaction = platform.drive.grove.start_transaction();
+
+        let processing_result = platform
+            .platform
+            .process_raw_state_transitions(
+                &[serialized],
+                &platform_state,
+                &BlockInfo::default(),
+                &transaction,
+                platform_version,
+                false,
+                None,
+            )
+            .expect("expected to process state transition");
+
+        assert_matches!(
+            processing_result.execution_results().as_slice(),
+            [StateTransitionExecutionResult::SuccessfulExecution { .. }]
+        );
+
+        platform
+            .drive
+            .grove
+            .commit_transaction(transaction)
+            .unwrap()
+            .expect("expected to commit transaction");
+
+        // Verify the frozen funds were destroyed (balance should be 0)
+        let token_balance = platform
+            .drive
+            .fetch_identity_token_balance(
+                token_id.to_buffer(),
+                identity_2.id().to_buffer(),
+                None,
+                platform_version,
+            )
+            .expect("expected to fetch token balance");
+        assert_eq!(token_balance, Some(0));
+
+        // Verify identity_2 is still frozen
+        let token_frozen = platform
+            .drive
+            .fetch_identity_token_info(
+                token_id.to_buffer(),
+                identity_2.id().to_buffer(),
+                None,
+                platform_version,
+            )
+            .expect("expected to fetch token info")
+            .map(|info| info.frozen());
+        assert_eq!(token_frozen, Some(true));
+    }
 
     #[test]
     fn test_token_destroy_frozen_funds_on_unfrozen_account_should_fail() {

--- a/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/batch/tests/token/emergency_action/mod.rs
+++ b/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/batch/tests/token/emergency_action/mod.rs
@@ -3,6 +3,255 @@ use super::*;
 mod token_emergency_action_tests {
     use super::*;
     use dpp::tokens::emergency_action::TokenEmergencyAction;
+    use dpp::tokens::status::v0::TokenStatusV0;
+    use dpp::tokens::status::TokenStatus;
+
+    #[test]
+    fn test_token_emergency_pause() {
+        let platform_version = PlatformVersion::latest();
+        let mut platform = TestPlatformBuilder::new()
+            .with_latest_protocol_version()
+            .build_with_mock_rpc()
+            .set_genesis_state();
+
+        let mut rng = StdRng::seed_from_u64(49853);
+        let platform_state = platform.state.load();
+
+        let (identity, signer, key) =
+            setup_identity(&mut platform, rng.gen(), dash_to_credits!(0.5));
+
+        let (contract, token_id) = create_token_contract_with_owner_identity(
+            &mut platform,
+            identity.id(),
+            Some(|token_configuration: &mut TokenConfiguration| {
+                token_configuration.set_emergency_action_rules(ChangeControlRules::V0(
+                    ChangeControlRulesV0 {
+                        authorized_to_make_change: AuthorizedActionTakers::ContractOwner,
+                        admin_action_takers: AuthorizedActionTakers::NoOne,
+                        changing_authorized_action_takers_to_no_one_allowed: false,
+                        changing_admin_action_takers_to_no_one_allowed: false,
+                        self_changing_admin_action_takers_allowed: false,
+                    },
+                ));
+            }),
+            None,
+            None,
+            None,
+            platform_version,
+        );
+
+        // Pause the token
+        let pause_transition = BatchTransition::new_token_emergency_action_transition(
+            token_id,
+            identity.id(),
+            contract.id(),
+            0,
+            TokenEmergencyAction::Pause,
+            None,
+            None,
+            &key,
+            2,
+            0,
+            &signer,
+            platform_version,
+            None,
+        )
+        .expect("expected to create emergency action transition");
+
+        let serialized = pause_transition
+            .serialize_to_bytes()
+            .expect("expected to serialize");
+
+        let transaction = platform.drive.grove.start_transaction();
+
+        let processing_result = platform
+            .platform
+            .process_raw_state_transitions(
+                &[serialized],
+                &platform_state,
+                &BlockInfo::default(),
+                &transaction,
+                platform_version,
+                false,
+                None,
+            )
+            .expect("expected to process state transition");
+
+        assert_matches!(
+            processing_result.execution_results().as_slice(),
+            [StateTransitionExecutionResult::SuccessfulExecution { .. }]
+        );
+
+        platform
+            .drive
+            .grove
+            .commit_transaction(transaction)
+            .unwrap()
+            .expect("expected to commit transaction");
+
+        // Verify that the token is now paused
+        let token_status = platform
+            .drive
+            .fetch_token_status(token_id.to_buffer(), None, platform_version)
+            .expect("expected to fetch token status");
+        assert_eq!(
+            token_status,
+            Some(TokenStatus::V0(TokenStatusV0 { paused: true }))
+        );
+    }
+
+    #[test]
+    fn test_token_emergency_resume() {
+        let platform_version = PlatformVersion::latest();
+        let mut platform = TestPlatformBuilder::new()
+            .with_latest_protocol_version()
+            .build_with_mock_rpc()
+            .set_genesis_state();
+
+        let mut rng = StdRng::seed_from_u64(49853);
+        let platform_state = platform.state.load();
+
+        let (identity, signer, key) =
+            setup_identity(&mut platform, rng.gen(), dash_to_credits!(0.5));
+
+        let (contract, token_id) = create_token_contract_with_owner_identity(
+            &mut platform,
+            identity.id(),
+            Some(|token_configuration: &mut TokenConfiguration| {
+                token_configuration.set_emergency_action_rules(ChangeControlRules::V0(
+                    ChangeControlRulesV0 {
+                        authorized_to_make_change: AuthorizedActionTakers::ContractOwner,
+                        admin_action_takers: AuthorizedActionTakers::NoOne,
+                        changing_authorized_action_takers_to_no_one_allowed: false,
+                        changing_admin_action_takers_to_no_one_allowed: false,
+                        self_changing_admin_action_takers_allowed: false,
+                    },
+                ));
+            }),
+            None,
+            None,
+            None,
+            platform_version,
+        );
+
+        // First pause the token
+        let pause_transition = BatchTransition::new_token_emergency_action_transition(
+            token_id,
+            identity.id(),
+            contract.id(),
+            0,
+            TokenEmergencyAction::Pause,
+            None,
+            None,
+            &key,
+            2,
+            0,
+            &signer,
+            platform_version,
+            None,
+        )
+        .expect("expected to create emergency action transition");
+
+        let serialized = pause_transition
+            .serialize_to_bytes()
+            .expect("expected to serialize");
+
+        let transaction = platform.drive.grove.start_transaction();
+
+        let processing_result = platform
+            .platform
+            .process_raw_state_transitions(
+                &[serialized],
+                &platform_state,
+                &BlockInfo::default(),
+                &transaction,
+                platform_version,
+                false,
+                None,
+            )
+            .expect("expected to process state transition");
+
+        assert_matches!(
+            processing_result.execution_results().as_slice(),
+            [StateTransitionExecutionResult::SuccessfulExecution { .. }]
+        );
+
+        platform
+            .drive
+            .grove
+            .commit_transaction(transaction)
+            .unwrap()
+            .expect("expected to commit transaction");
+
+        // Verify the token is paused
+        let token_status = platform
+            .drive
+            .fetch_token_status(token_id.to_buffer(), None, platform_version)
+            .expect("expected to fetch token status");
+        assert_eq!(
+            token_status,
+            Some(TokenStatus::V0(TokenStatusV0 { paused: true }))
+        );
+
+        // Now resume the token
+        let resume_transition = BatchTransition::new_token_emergency_action_transition(
+            token_id,
+            identity.id(),
+            contract.id(),
+            0,
+            TokenEmergencyAction::Resume,
+            None,
+            None,
+            &key,
+            3,
+            0,
+            &signer,
+            platform_version,
+            None,
+        )
+        .expect("expected to create emergency action transition");
+
+        let serialized = resume_transition
+            .serialize_to_bytes()
+            .expect("expected to serialize");
+
+        let transaction = platform.drive.grove.start_transaction();
+
+        let processing_result = platform
+            .platform
+            .process_raw_state_transitions(
+                &[serialized],
+                &platform_state,
+                &BlockInfo::default(),
+                &transaction,
+                platform_version,
+                false,
+                None,
+            )
+            .expect("expected to process state transition");
+
+        assert_matches!(
+            processing_result.execution_results().as_slice(),
+            [StateTransitionExecutionResult::SuccessfulExecution { .. }]
+        );
+
+        platform
+            .drive
+            .grove
+            .commit_transaction(transaction)
+            .unwrap()
+            .expect("expected to commit transaction");
+
+        // Verify the token is now resumed (not paused)
+        let token_status = platform
+            .drive
+            .fetch_token_status(token_id.to_buffer(), None, platform_version)
+            .expect("expected to fetch token status");
+        assert_eq!(
+            token_status,
+            Some(TokenStatus::V0(TokenStatusV0 { paused: false }))
+        );
+    }
 
     #[test]
     fn test_token_emergency_pause_already_paused_should_fail() {

--- a/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/batch/tests/token/freeze/mod.rs
+++ b/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/batch/tests/token/freeze/mod.rs
@@ -376,6 +376,359 @@ mod token_freeze_tests {
         }
 
         #[test]
+        fn test_token_unfreeze_success() {
+            let platform_version = PlatformVersion::latest();
+            let mut platform = TestPlatformBuilder::new()
+                .with_latest_protocol_version()
+                .build_with_mock_rpc()
+                .set_genesis_state();
+
+            let mut rng = StdRng::seed_from_u64(49853);
+
+            let platform_state = platform.state.load();
+
+            let (identity, signer, key) =
+                setup_identity(&mut platform, rng.gen(), dash_to_credits!(0.5));
+
+            let (identity_2, signer2, key2) =
+                setup_identity(&mut platform, rng.gen(), dash_to_credits!(0.5));
+
+            let (contract, token_id) = create_token_contract_with_owner_identity(
+                &mut platform,
+                identity.id(),
+                Some(|token_configuration: &mut TokenConfiguration| {
+                    token_configuration.set_freeze_rules(ChangeControlRules::V0(
+                        ChangeControlRulesV0 {
+                            authorized_to_make_change: AuthorizedActionTakers::ContractOwner,
+                            admin_action_takers: AuthorizedActionTakers::NoOne,
+                            changing_authorized_action_takers_to_no_one_allowed: false,
+                            changing_admin_action_takers_to_no_one_allowed: false,
+                            self_changing_admin_action_takers_allowed: false,
+                        },
+                    ));
+                    token_configuration.set_unfreeze_rules(ChangeControlRules::V0(
+                        ChangeControlRulesV0 {
+                            authorized_to_make_change: AuthorizedActionTakers::ContractOwner,
+                            admin_action_takers: AuthorizedActionTakers::NoOne,
+                            changing_authorized_action_takers_to_no_one_allowed: false,
+                            changing_admin_action_takers_to_no_one_allowed: false,
+                            self_changing_admin_action_takers_allowed: false,
+                        },
+                    ));
+                }),
+                None,
+                None,
+                None,
+                platform_version,
+            );
+
+            // Transfer some tokens to identity_2 first so they have a balance
+            let token_transfer_transition = BatchTransition::new_token_transfer_transition(
+                token_id,
+                identity.id(),
+                contract.id(),
+                0,
+                5000,
+                identity_2.id(),
+                None,
+                None,
+                None,
+                &key,
+                2,
+                0,
+                &signer,
+                platform_version,
+                None,
+            )
+            .expect("expect to create token transfer transition");
+
+            let transfer_serialized = token_transfer_transition
+                .serialize_to_bytes()
+                .expect("expected serialized state transition");
+
+            let transaction = platform.drive.grove.start_transaction();
+
+            let processing_result = platform
+                .platform
+                .process_raw_state_transitions(
+                    &[transfer_serialized],
+                    &platform_state,
+                    &BlockInfo::default(),
+                    &transaction,
+                    platform_version,
+                    false,
+                    None,
+                )
+                .expect("expected to process state transition");
+
+            assert_matches!(
+                processing_result.execution_results().as_slice(),
+                [StateTransitionExecutionResult::SuccessfulExecution { .. }]
+            );
+
+            platform
+                .drive
+                .grove
+                .commit_transaction(transaction)
+                .unwrap()
+                .expect("expected to commit transaction");
+
+            // Freeze identity_2
+            let freeze_transition = BatchTransition::new_token_freeze_transition(
+                token_id,
+                identity.id(),
+                contract.id(),
+                0,
+                identity_2.id(),
+                None,
+                None,
+                &key,
+                3,
+                0,
+                &signer,
+                platform_version,
+                None,
+            )
+            .expect("expect to create freeze transition");
+
+            let freeze_serialized = freeze_transition
+                .serialize_to_bytes()
+                .expect("expected serialized state transition");
+
+            let transaction = platform.drive.grove.start_transaction();
+
+            let processing_result = platform
+                .platform
+                .process_raw_state_transitions(
+                    &[freeze_serialized],
+                    &platform_state,
+                    &BlockInfo::default(),
+                    &transaction,
+                    platform_version,
+                    false,
+                    None,
+                )
+                .expect("expected to process state transition");
+
+            assert_matches!(
+                processing_result.execution_results().as_slice(),
+                [StateTransitionExecutionResult::SuccessfulExecution { .. }]
+            );
+
+            platform
+                .drive
+                .grove
+                .commit_transaction(transaction)
+                .unwrap()
+                .expect("expected to commit transaction");
+
+            // Verify identity_2 is frozen
+            let token_frozen = platform
+                .drive
+                .fetch_identity_token_info(
+                    token_id.to_buffer(),
+                    identity_2.id().to_buffer(),
+                    None,
+                    platform_version,
+                )
+                .expect("expected to fetch token info")
+                .map(|info| info.frozen());
+            assert_eq!(token_frozen, Some(true));
+
+            // Verify identity_2 cannot send tokens while frozen
+            let send_while_frozen = BatchTransition::new_token_transfer_transition(
+                token_id,
+                identity_2.id(),
+                contract.id(),
+                0,
+                100,
+                identity.id(),
+                None,
+                None,
+                None,
+                &key2,
+                2,
+                0,
+                &signer2,
+                platform_version,
+                None,
+            )
+            .expect("expect to create transfer transition");
+
+            let send_serialized = send_while_frozen
+                .serialize_to_bytes()
+                .expect("expected serialized state transition");
+
+            let transaction = platform.drive.grove.start_transaction();
+
+            let processing_result = platform
+                .platform
+                .process_raw_state_transitions(
+                    &[send_serialized],
+                    &platform_state,
+                    &BlockInfo::default(),
+                    &transaction,
+                    platform_version,
+                    false,
+                    None,
+                )
+                .expect("expected to process state transition");
+
+            assert_matches!(
+                processing_result.execution_results().as_slice(),
+                [PaidConsensusError {
+                    error: ConsensusError::StateError(StateError::IdentityTokenAccountFrozenError(
+                        _
+                    )),
+                    ..
+                }]
+            );
+
+            platform
+                .drive
+                .grove
+                .commit_transaction(transaction)
+                .unwrap()
+                .expect("expected to commit transaction");
+
+            // Now unfreeze identity_2
+            let unfreeze_transition = BatchTransition::new_token_unfreeze_transition(
+                token_id,
+                identity.id(),
+                contract.id(),
+                0,
+                identity_2.id(),
+                None,
+                None,
+                &key,
+                4,
+                0,
+                &signer,
+                platform_version,
+                None,
+            )
+            .expect("expect to create unfreeze transition");
+
+            let unfreeze_serialized = unfreeze_transition
+                .serialize_to_bytes()
+                .expect("expected serialized state transition");
+
+            let transaction = platform.drive.grove.start_transaction();
+
+            let processing_result = platform
+                .platform
+                .process_raw_state_transitions(
+                    &[unfreeze_serialized],
+                    &platform_state,
+                    &BlockInfo::default(),
+                    &transaction,
+                    platform_version,
+                    false,
+                    None,
+                )
+                .expect("expected to process state transition");
+
+            assert_matches!(
+                processing_result.execution_results().as_slice(),
+                [StateTransitionExecutionResult::SuccessfulExecution { .. }]
+            );
+
+            platform
+                .drive
+                .grove
+                .commit_transaction(transaction)
+                .unwrap()
+                .expect("expected to commit transaction");
+
+            // Verify identity_2 is no longer frozen
+            let token_frozen = platform
+                .drive
+                .fetch_identity_token_info(
+                    token_id.to_buffer(),
+                    identity_2.id().to_buffer(),
+                    None,
+                    platform_version,
+                )
+                .expect("expected to fetch token info")
+                .map(|info| info.frozen());
+            assert_eq!(token_frozen, Some(false));
+
+            // Verify identity_2 can now transact again after unfreezing
+            let send_after_unfreeze = BatchTransition::new_token_transfer_transition(
+                token_id,
+                identity_2.id(),
+                contract.id(),
+                0,
+                100,
+                identity.id(),
+                None,
+                None,
+                None,
+                &key2,
+                3,
+                0,
+                &signer2,
+                platform_version,
+                None,
+            )
+            .expect("expect to create transfer transition");
+
+            let send_serialized = send_after_unfreeze
+                .serialize_to_bytes()
+                .expect("expected serialized state transition");
+
+            let transaction = platform.drive.grove.start_transaction();
+
+            let processing_result = platform
+                .platform
+                .process_raw_state_transitions(
+                    &[send_serialized],
+                    &platform_state,
+                    &BlockInfo::default(),
+                    &transaction,
+                    platform_version,
+                    false,
+                    None,
+                )
+                .expect("expected to process state transition");
+
+            assert_matches!(
+                processing_result.execution_results().as_slice(),
+                [StateTransitionExecutionResult::SuccessfulExecution { .. }]
+            );
+
+            platform
+                .drive
+                .grove
+                .commit_transaction(transaction)
+                .unwrap()
+                .expect("expected to commit transaction");
+
+            // Verify balances after successful transfer
+            let balance_identity = platform
+                .drive
+                .fetch_identity_token_balance(
+                    token_id.to_buffer(),
+                    identity.id().to_buffer(),
+                    None,
+                    platform_version,
+                )
+                .expect("expected to fetch token balance");
+            assert_eq!(balance_identity, Some(100000 - 5000 + 100));
+
+            let balance_identity_2 = platform
+                .drive
+                .fetch_identity_token_balance(
+                    token_id.to_buffer(),
+                    identity_2.id().to_buffer(),
+                    None,
+                    platform_version,
+                )
+                .expect("expected to fetch token balance");
+            assert_eq!(balance_identity_2, Some(5000 - 100));
+        }
+
+        #[test]
         fn test_token_frozen_receive_balance_allowed_sending_not_allowed_till_unfrozen() {
             let platform_version = PlatformVersion::latest();
             let mut platform = TestPlatformBuilder::new()


### PR DESCRIPTION
## Summary

Adds 5 happy-path tests for token transition actions that previously only had error-path coverage.

| File | New Tests | What's covered |
|------|-----------|----------------|
| `emergency_action/mod.rs` | 2 | Pause token successfully, resume paused token |
| `destroy_frozen_funds/mod.rs` | 1 | Freeze + destroy frozen funds, verify balance = 0 |
| `burn/mod.rs` | 1 | Burn entire balance, verify balance = 0 |
| `freeze/mod.rs` | 1 | Freeze → verify transfer fails → unfreeze → verify transfer succeeds |

These tests exercise the full state transition pipeline including the transformer code in rs-drive, improving coverage for token_burn_transition_action, token_freeze/unfreeze_transition_action, token_emergency_action_transition_action, and token_destroy_frozen_funds_transition_action.

## Test plan
- [x] All 25 token tests pass (20 existing + 5 new)
- [x] `cargo fmt --all` clean
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Added test coverage for complete token burn scenarios, including burning entire account balance
  * Added test validation for frozen fund destruction operations
  * Added test cases for token emergency pause and resume functionality
  * Added test coverage for token account freezing and unfreezing with transaction validation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->