### PR TITLE
fix(dpp): block pre-programmed distribution changes on token update

### DIFF
--- a/packages/rs-dpp/src/data_contract/associated_token/token_configuration/methods/validate_token_configuration_update/v0/mod.rs
+++ b/packages/rs-dpp/src/data_contract/associated_token/token_configuration/methods/validate_token_configuration_update/v0/mod.rs
@@ -256,6 +256,21 @@ impl TokenConfiguration {
             }
         }
 
+        // Check immutable fields: pre_programmed_distribution
+        if old.distribution_rules.pre_programmed_distribution()
+            != new.distribution_rules.pre_programmed_distribution()
+        {
+            return SimpleConsensusValidationResult::new_with_error(
+                DataContractTokenConfigurationUpdateError::new(
+                    "update".to_string(),
+                    "preProgrammedDistribution".to_string(),
+                    self.clone(),
+                    new_config.clone(),
+                )
+                .into(),
+            );
+        }
+
         // Check changes to manual_minting_rules
         #[allow(clippy::collapsible_if)]
         if old.manual_minting_rules != new.manual_minting_rules {


### PR DESCRIPTION
### Motivation
- `pre_programmed_distribution` was added to `TokenDistributionRulesV0` but was not checked during token configuration updates, ~allowing updates to modify emission schedules without any change-control enforcement.~

Note: this was identified as a security issue by codex. In my investigation, I found that this is NOT a security issue. None of the exposed update methods are able to update `pre_programmed_distribution` however; in my view, it is best to explicitly check in validation that these do not change. 

### Description
- Added a guard in `validate_token_config_update_v0` that rejects any update which changes `pre_programmed_distribution` by returning a `DataContractTokenConfigurationUpdateError` for `preProgrammedDistribution`.

### Testing
- Ran `cargo test -p rs-dpp --lib --no-run`, which failed because the package is named `dpp` (package name mismatch), not due to the code change.
- Ran `cargo test -p dpp --lib --no-run`, which compiled the package and built the test binary successfully (test profile finished).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b05d9f2d708326aefc40abe791499a)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Token configuration pre-programmed distribution is now enforced as immutable. Attempts to modify this field during configuration updates are rejected with a validation error.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->