### PR TITLE
fix(sdk): add Regtest support to trusted context provider activation height

### DIFF
--- a/packages/rs-sdk-trusted-context-provider/src/provider.rs
+++ b/packages/rs-sdk-trusted-context-provider/src/provider.rs
@@ -804,7 +804,7 @@ impl ContextProvider for TrustedHttpContextProvider {
         match self.network {
             Network::Mainnet => Ok(2132092), // Mainnet L1 locked height
             Network::Testnet => Ok(1090319), // Testnet L1 locked height
-            Network::Devnet => Ok(1),        // Devnet activation height
+            Network::Devnet | Network::Regtest => Ok(1), // Devnet/Regtest activation height
             _ => Err(ContextProviderError::Generic(
                 "Unsupported network".to_string(),
             )),


### PR DESCRIPTION
## Issue Being Fixed

Nightly "Packages functional tests" fail with:

```
Proof verification error: Context provider error: Unsupported network
```

## Root Cause

`get_platform_activation_height()` in `rs-sdk-trusted-context-provider/src/provider.rs` only handles `Mainnet`, `Testnet`, and `Devnet`. The functional tests run on a **local regtest network**, which hits the `_` wildcard and returns an error.

## What was changed

Added `Network::Regtest` to the `Devnet` match arm with activation height `1` (same as Devnet — platform activates at genesis on local/test networks).

```diff
- Network::Devnet => Ok(1),        // Devnet activation height
+ Network::Devnet | Network::Regtest => Ok(1), // Devnet/Regtest activation height
```

## Breaking Changes

None. Previously Regtest always errored; now it works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed support for Regtest network in the SDK, which previously resulted in an error. Regtest now properly uses the same activation height as the development network.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->