### PR TITLE
fix: case-insensitive .dash suffix and UTXO double-spend prevention (backport from DET)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,13 +47,13 @@ members = [
 ]
 
 [workspace.dependencies]
-dashcore = { path = "../rust-dashcore/dash" }
-dash-spv = { path = "../rust-dashcore/dash-spv" }
-dash-spv-ffi = { path = "../rust-dashcore/dash-spv-ffi" }
-key-wallet = { path = "../rust-dashcore/key-wallet" }
-key-wallet-ffi = { path = "../rust-dashcore/key-wallet-ffi" }
-key-wallet-manager = { path = "../rust-dashcore/key-wallet-manager" }
-dashcore-rpc = { path = "../rust-dashcore/rpc-client" }
+dashcore = { git = "https://github.com/dashpay/rust-dashcore", branch = "feat/blockchain-identities-account-type" }
+dash-spv = { git = "https://github.com/dashpay/rust-dashcore", branch = "feat/blockchain-identities-account-type" }
+dash-spv-ffi = { git = "https://github.com/dashpay/rust-dashcore", branch = "feat/blockchain-identities-account-type" }
+key-wallet = { git = "https://github.com/dashpay/rust-dashcore", branch = "feat/blockchain-identities-account-type" }
+key-wallet-ffi = { git = "https://github.com/dashpay/rust-dashcore", branch = "feat/blockchain-identities-account-type" }
+key-wallet-manager = { git = "https://github.com/dashpay/rust-dashcore", branch = "feat/blockchain-identities-account-type" }
+dashcore-rpc = { git = "https://github.com/dashpay/rust-dashcore", branch = "feat/blockchain-identities-account-type" }
 
 # Optimize heavy crypto crates even in dev/test builds so that
 # Halo 2 proof generation and verification run at near-release speed.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,13 +47,13 @@ members = [
 ]
 
 [workspace.dependencies]
-dashcore = { git = "https://github.com/dashpay/rust-dashcore", branch = "feat/blockchain-identities-account-type" }
-dash-spv = { git = "https://github.com/dashpay/rust-dashcore", branch = "feat/blockchain-identities-account-type" }
-dash-spv-ffi = { git = "https://github.com/dashpay/rust-dashcore", branch = "feat/blockchain-identities-account-type" }
-key-wallet = { git = "https://github.com/dashpay/rust-dashcore", branch = "feat/blockchain-identities-account-type" }
-key-wallet-ffi = { git = "https://github.com/dashpay/rust-dashcore", branch = "feat/blockchain-identities-account-type" }
-key-wallet-manager = { git = "https://github.com/dashpay/rust-dashcore", branch = "feat/blockchain-identities-account-type" }
-dashcore-rpc = { git = "https://github.com/dashpay/rust-dashcore", branch = "feat/blockchain-identities-account-type" }
+dashcore = { path = "../rust-dashcore/dash" }
+dash-spv = { path = "../rust-dashcore/dash-spv" }
+dash-spv-ffi = { path = "../rust-dashcore/dash-spv-ffi" }
+key-wallet = { path = "../rust-dashcore/key-wallet" }
+key-wallet-ffi = { path = "../rust-dashcore/key-wallet-ffi" }
+key-wallet-manager = { path = "../rust-dashcore/key-wallet-manager" }
+dashcore-rpc = { path = "../rust-dashcore/rpc-client" }
 
 # Optimize heavy crypto crates even in dev/test builds so that
 # Halo 2 proof generation and verification run at near-release speed.

--- a/packages/rs-platform-wallet/src/wallet/core/wallet.rs
+++ b/packages/rs-platform-wallet/src/wallet/core/wallet.rs
@@ -4,9 +4,9 @@ use std::sync::Arc;
 
 use super::balance::WalletBalance;
 
+use dashcore::Address as DashAddress;
 use dashcore::secp256k1::{Message, Secp256k1};
 use dashcore::sighash::SighashCache;
-use dashcore::Address as DashAddress;
 use dashcore::{OutPoint, ScriptBuf, Transaction, TxIn, TxOut};
 use key_wallet::Utxo;
 use tokio::sync::RwLock;
@@ -316,6 +316,38 @@ impl CoreWallet {
         self.sign_transaction_inputs(&secp, &mut tx, &selected_utxos)
             .await?;
 
+        // 5b. Validate-and-mark under write lock: verify that the UTXOs we
+        // selected (under a read lock earlier) haven't been claimed by a
+        // concurrent caller. If they have, fail fast with a clear error
+        // instead of broadcasting a transaction the network will reject.
+        {
+            use crate::wallet::platform_wallet_traits::WalletTransactionChecker;
+            use key_wallet::transaction_checking::TransactionContext;
+            let mut state = self.state.write().await;
+
+            // Re-check that our selected outpoints are still spendable.
+            let current_spendable: std::collections::BTreeSet<OutPoint> = state
+                .managed_state
+                .wallet_info()
+                .get_spendable_utxos()
+                .iter()
+                .map(|u| u.outpoint)
+                .collect();
+
+            for (outpoint, _, _) in &selected_utxos {
+                if !current_spendable.contains(outpoint) {
+                    return Err(PlatformWalletError::TransactionBuild(
+                        "Selected UTXOs are no longer available (concurrent transaction). Please retry.".to_string(),
+                    ));
+                }
+            }
+
+            // All UTXOs still available — mark them as spent atomically.
+            state
+                .check_core_transaction(&tx, TransactionContext::Mempool, true, true)
+                .await;
+        }
+
         // 6. Broadcast.
         self.broadcast_transaction(&tx).await?;
 
@@ -479,12 +511,16 @@ impl CoreWallet {
         // Derive private keys and sign.
         for (i, (input, sighash)) in tx.input.iter_mut().zip(sighashes).enumerate() {
             let path = &derivation_paths[i];
-            let extended_key = info.managed_state.wallet().derive_extended_private_key(path).map_err(|e| {
-                PlatformWalletError::TransactionBuild(format!(
-                    "Failed to derive key for input {}: {}",
-                    i, e
-                ))
-            })?;
+            let extended_key = info
+                .managed_state
+                .wallet()
+                .derive_extended_private_key(path)
+                .map_err(|e| {
+                    PlatformWalletError::TransactionBuild(format!(
+                        "Failed to derive key for input {}: {}",
+                        i, e
+                    ))
+                })?;
             let input_private_key = extended_key.to_priv();
 
             let message = Message::from_digest(sighash.into());

--- a/packages/rs-sdk/src/platform/dpns_usernames/mod.rs
+++ b/packages/rs-sdk/src/platform/dpns_usernames/mod.rs
@@ -427,7 +427,7 @@ impl Sdk {
         let label = if let Some(dot_pos) = name.rfind('.') {
             let (label_part, suffix) = name.split_at(dot_pos);
             // Only strip the suffix if it's exactly ".dash"
-            if suffix == ".dash" {
+            if suffix.eq_ignore_ascii_case(".dash") {
                 label_part
             } else {
                 // If it's not ".dash", treat the whole thing as the label


### PR DESCRIPTION
## Summary

Two targeted fixes backported from dash-evo-tool into the platform wallet codebase. No upstream merge — just the fixes on top of `feat/platform-wallet`.

## Context: what moved from dash-evo-tool to platform

The `feat/platform-wallet` refactor extracted wallet logic from dash-evo-tool into `packages/rs-platform-wallet/`:

| From dash-evo-tool | Now in platform |
|---|---|
| `src/spv/manager.rs` — SPV lifecycle, broadcast | `rs-platform-wallet/src/spv/` — rewritten around `WalletManager` |
| `src/backend_task/dashpay/dip14_derivation.rs` | `rs-platform-wallet/src/wallet/dashpay/dip14.rs` |
| `src/model/wallet/asset_lock_transaction.rs` | `rs-platform-wallet/src/wallet/asset_lock/` |
| Wallet state, UTXO management (scattered) | `rs-platform-wallet/src/wallet/core/wallet.rs` — unified `CoreWallet` |

These fixes address bugs discovered in dash-evo-tool (PRs #810 and #815) that also exist in the platform-side code after the split.

## Fix 1: Case-insensitive `.dash` suffix (SDK)

**File:** `packages/rs-sdk/src/platform/dpns_usernames/mod.rs`

`resolve_dpns_name()` stripped the `.dash` suffix using exact match (`suffix == ".dash"`). Inputs like `"Alice.DASH"` or `"alice.Dash"` would not match — the full string including `.dash` would be normalized as the label → DPNS lookup miss.

```diff
-            if suffix == ".dash" {
+            if suffix.eq_ignore_ascii_case(".dash") {
```

*Backported from dash-evo-tool PR #810 which fixed the equivalent bug in DET's DPNS helpers.*

## Fix 2: UTXO double-spend prevention (platform-wallet)

**File:** `packages/rs-platform-wallet/src/wallet/core/wallet.rs`

`CoreWallet::send_transaction()` had a TOCTOU race between reading spendable UTXOs and broadcasting:

1. Read UTXOs (acquires read lock, **drops it**)
2. Select, build, sign (no lock held)
3. Broadcast (no lock held)

Concurrent callers could both select the same UTXOs between steps 1–3. The second broadcast would be rejected by the network (no IS lock issued for the conflicting tx), but the user sees a failed payment with no clear cause.

**Fix — optimistic validation pattern:**

After signing, acquire the write lock and **re-validate** that the selected outpoints are still in the spendable UTXO set. If a concurrent caller already claimed them via `check_core_transaction`, return a clear error instead of broadcasting a doomed transaction. If all UTXOs are still available, mark them atomically before dropping the lock:

```
1. Read UTXOs (read lock, drop)         ← optimistic read
2. Select, build, sign (no lock)        ← optimistic work
3. Acquire WRITE lock                   ← validation gate
4. Re-check selected outpoints          ← reject if stale
5. check_core_transaction (Mempool)     ← mark spent atomically
6. Drop write lock
7. Broadcast
```

This eliminates the race: the second concurrent caller gets `"Selected UTXOs are no longer available (concurrent transaction). Please retry."` instead of a network rejection.

*Backported from dash-evo-tool v1.0-dev commit `f4d3b3b3` which fixed the same race in the old SPV manager, adapted to the platform-wallet's `RwLock<PlatformWalletInfo>` architecture.*

## Companion PR

- **dash-evo-tool**: dashpay/dash-evo-tool#821 — backports v1.0-dev into feat/platform-wallet (lazy contexts, DB migrations, DPNS fixes)

<sub>🤖 Co-authored by [Claudius the Magnificent](https://github.com/lklimek/claudius) AI Agent</sub>