### PR TITLE
fix(sdk): call on_address_found for seeded balances in incremental-only sync

### DIFF
--- a/packages/rs-sdk/src/platform/address_sync/mod.rs
+++ b/packages/rs-sdk/src/platform/address_sync/mod.rs
@@ -341,7 +341,13 @@ pub async fn sync_address_balances<P: AddressProvider>(
             start_height
         );
         for (index, key, funds) in provider.current_balances() {
-            result.found.insert((index, key), funds);
+            result.found.insert((index, key.clone()), funds);
+            // Notify the provider so it can update its internal state
+            // (e.g., populate found_balances, extend gap limit). Without this,
+            // addresses discovered during a previous full scan are invisible to
+            // the consumer in incremental-only mode because on_address_found
+            // is the only path that populates the provider's found set.
+            provider.on_address_found(index, &key, funds);
         }
         start_height
     } else {


### PR DESCRIPTION
## Summary

Fixes a bug where newly funded platform addresses are never discovered during incremental-only address sync, making them permanently invisible to the wallet.

## Root Cause

In `sync_address_balances()` (incremental-only mode), `result.found` is seeded from `provider.current_balances()` but `on_address_found` is **not** called for those entries. This callback is the only mechanism that populates the provider's internal found set (e.g., `found_balances` in `WalletAddressProvider`).

### Failing Scenario

1. A platform address is funded via `top_up()` — state transition confirmed on Platform
2. Next `sync_address_balances()` call runs in incremental-only mode (`last_sync_timestamp > 0`)
3. `result.found` is seeded from `current_balances()` (the wallet's stored balances from previous sync)
4. `on_address_found` is NOT called for seeded entries
5. `found_balances` stays empty in the provider
6. `apply_results_to_wallet()` iterates over `found_balances` — finds nothing — wallet never updates
7. All subsequent polls repeat this — the address balance is permanently stale

### Why Full Scan Works

The full tree scan path (via `process_trunk_result` and `process_branch_result`) calls `on_address_found` for every discovered address (lines 155, 197). Incremental-only mode skips the tree scan entirely and only processes deltas, but the delta callbacks (`on_address_found` at lines 622, 683) only fire when `new_balance != current_balance` — if no delta exists in the incremental window, the address is never reported.

## Fix

Add `provider.on_address_found(index, &key, funds)` calls in the incremental-only seed loop, matching the full scan behavior. This ensures the provider's internal state is populated regardless of sync mode.

## Related Issue (not fixed here)

In `dash-evo-tool`, `src/backend_task/wallet/fetch_platform_address_balances.rs:116-120`: when incremental sync returns no data, `new_sync_timestamp = 0` is saved to DB, causing a destructive oscillation between full scan and incremental modes. This is a separate app-layer bug.

## Test Plan

- [ ] Verify compilation with `cargo build -p dash-sdk --all-features`
- [ ] Manual test: fund a platform address, confirm incremental sync discovers the balance
- [ ] Verify full scan path is unaffected (regression check)

<sub>🤖 Co-authored by [Claudius the Magnificent](https://github.com/lklimek/claudius) AI Agent</sub>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed address balance synchronization in incremental-only mode to properly track found addresses and update internal state during seeding.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->