### PR TITLE
fix(swift-sdk): wrapper for FFITxOutput that correctly handles alloc memory

### DIFF
--- a/packages/swift-sdk/Sources/SwiftDashSDK/Core/Wallet/CoreWalletManager.swift
+++ b/packages/swift-sdk/Sources/SwiftDashSDK/Core/Wallet/CoreWalletManager.swift
@@ -317,7 +317,7 @@ public class CoreWalletManager: ObservableObject {
     ///   - accountIndex: The account index to use
     ///   - outputs: The transaction outputs
     /// - Returns: The signed transaction bytes
-    public func buildSignedTransaction(for wallet: HDWallet, accIndex: UInt32, outputs: [Transaction.Output]) throws -> (Data, UInt64) {
+    public func buildSignedTransaction(for wallet: HDWallet, accIndex: UInt32, outputs: [TxOutput]) throws -> (Data, UInt64) {
         try sdkWalletManager.buildSignedTransaction(for: wallet, accIndex: accIndex, outputs: outputs)
     }
 

--- a/packages/swift-sdk/Sources/SwiftDashSDK/KeyWallet/Transaction.swift
+++ b/packages/swift-sdk/Sources/SwiftDashSDK/KeyWallet/Transaction.swift
@@ -4,25 +4,6 @@ import DashSDKFFI
 /// Transaction utilities for wallet operations
 public class Transaction {
 
-    /// Transaction output for building transactions
-    public struct Output {
-        public let address: String
-        public let amount: UInt64
-
-        public init(address: String, amount: UInt64) {
-            self.address = address
-            self.amount = amount
-        }
-
-        func toFFI() -> FFITxOutput {
-            // TODO: This memory is not being freed, FFI must free FFITxOutput
-            // or expose a method to do it
-            let cString = strdup(address)
-
-            return FFITxOutput(address: cString, amount: amount)
-        }
-    }
-
     /// Classify a transaction for routing
     /// - Parameter transactionData: The transaction bytes
     /// - Returns: A string describing the transaction type

--- a/packages/swift-sdk/Sources/SwiftDashSDK/KeyWallet/TxOutput.swift
+++ b/packages/swift-sdk/Sources/SwiftDashSDK/KeyWallet/TxOutput.swift
@@ -1,0 +1,21 @@
+import Foundation
+import DashSDKFFI
+
+public class TxOutput {
+    let address: UnsafeMutablePointer<CChar>
+    let amount: UInt64
+
+    public init(address: String, amount: UInt64) {
+        let address = address.trimmingCharacters(in: .whitespacesAndNewlines)
+        self.address = strdup(address)
+        self.amount = amount
+    }
+
+    deinit {
+        free(address)
+    }
+
+    func toFFI() -> FFITxOutput {
+        return FFITxOutput(address: address, amount: amount)
+    }
+}

--- a/packages/swift-sdk/Sources/SwiftDashSDK/KeyWallet/WalletManager.swift
+++ b/packages/swift-sdk/Sources/SwiftDashSDK/KeyWallet/WalletManager.swift
@@ -356,7 +356,7 @@ public class WalletManager {
     ///   - accIndex: The account index to use
     ///   - outputs: The transaction outputs
     /// - Returns: The signed transaction bytes and the fee
-    public func buildSignedTransaction(for wallet: HDWallet, accIndex: UInt32, outputs: [Transaction.Output]) throws -> (Data, UInt64) {
+    public func buildSignedTransaction(for wallet: HDWallet, accIndex: UInt32, outputs: [TxOutput]) throws -> (Data, UInt64) {
         guard !outputs.isEmpty else {
             throw KeyWalletError.invalidInput("Transaction must have at least one output")
         }
@@ -390,9 +390,6 @@ public class WalletManager {
         defer {
             if error.message != nil {
                 error_message_free(error.message)
-            }
-            for _ in ffiOutputs {
-              // TODO: Memory leak, FFI doesnt expose a way to free the address
             }
             if let ptr = txBytesPtr {
                 transaction_bytes_free(ptr)

--- a/packages/swift-sdk/SwiftExampleApp/SwiftExampleApp/Core/ViewModels/SendViewModel.swift
+++ b/packages/swift-sdk/SwiftExampleApp/SwiftExampleApp/Core/ViewModels/SendViewModel.swift
@@ -271,7 +271,7 @@ class SendViewModel: ObservableObject {
 
             case .coreToCore:
                 let outputs = [
-                    Transaction.Output(address: recipientAddress, amount: amount)
+                    TxOutput(address: recipientAddress, amount: amount)
                 ]
 
                 // TODO: The model is using hardoced estimated fees


### PR DESCRIPTION



## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [x] I have made corresponding changes to the documentation if needed

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Updated the transaction output model used by wallet signing. The public signing API signature changed, so callers must construct and pass outputs using the new output type.
  * Example app updated to use the new output construction when creating and signing transactions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->