### PR TITLE
ci: exclude Drive state transition action boilerplate from coverage

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -139,6 +139,30 @@ ignore:
   - "packages/rs-dpp/src/data_contract/extra/drive_api_tests.rs"
   # Versioned dispatch methods — pure version routing with no logic
   - "packages/rs-dpp/src/data_contract/document_type/methods/versioned_methods.rs"
+  # Drive state transition action boilerplate — version dispatch enums with
+  # single-variant match arms, getters/setters, struct definitions, and top-level
+  # transformer delegation (v0/transformer.rs has real logic and is NOT excluded)
+  - "packages/rs-drive/src/state_transition_action/**/token_*_transition_action/mod.rs"
+  - "packages/rs-drive/src/state_transition_action/**/token_*_transition_action/v0/mod.rs"
+  - "packages/rs-drive/src/state_transition_action/**/token_*_transition_action/transformer.rs"
+  - "packages/rs-drive/src/state_transition_action/**/token_base_transition_action/mod.rs"
+  - "packages/rs-drive/src/state_transition_action/**/token_base_transition_action/v0/mod.rs"
+  - "packages/rs-drive/src/state_transition_action/**/token_transition_action_type.rs"
+  - "packages/rs-drive/src/state_transition_action/**/document_*_transition_action/mod.rs"
+  - "packages/rs-drive/src/state_transition_action/**/document_*_transition_action/v0/mod.rs"
+  - "packages/rs-drive/src/state_transition_action/**/document_*_transition_action/transformer.rs"
+  - "packages/rs-drive/src/state_transition_action/**/document_base_transition_action/mod.rs"
+  - "packages/rs-drive/src/state_transition_action/**/document_base_transition_action/v0/mod.rs"
+  - "packages/rs-drive/src/state_transition_action/**/document_transition_action_type.rs"
+  - "packages/rs-drive/src/state_transition_action/identity/*/mod.rs"
+  - "packages/rs-drive/src/state_transition_action/identity/*/v0/mod.rs"
+  - "packages/rs-drive/src/state_transition_action/identity/*/transformer.rs"
+  - "packages/rs-drive/src/state_transition_action/contract/*/mod.rs"
+  - "packages/rs-drive/src/state_transition_action/contract/*/v0/mod.rs"
+  - "packages/rs-drive/src/state_transition_action/contract/*/transformer.rs"
+  - "packages/rs-drive/src/state_transition_action/system/*/mod.rs"
+  - "packages/rs-drive/src/state_transition_action/system/*/v0/mod.rs"
+  - "packages/rs-drive/src/state_transition_action/system/*/transformer.rs"
   
 coverage:
   status:


### PR DESCRIPTION
## What was changed

Added codecov exclusions for Drive state transition action boilerplate files in `packages/rs-drive/src/state_transition_action/`.

These files contain:
- **`mod.rs`** — Version dispatch enums with single-variant match arms delegating to V0 (`match self { V0(v0) => v0.field }`)
- **`v0/mod.rs`** — Struct definitions + getter/setter trait impls (pure field accessors)
- **`transformer.rs`** (top-level) — Single-variant match delegating to `V0::try_from(...)`
- **`*_action_type.rs`** — Type enum definitions

**NOT excluded:** `v0/transformer.rs` files which contain real conversion logic (300-580 lines each).

## Affected paths

| Category | Files excluded |
|----------|---------------|
| Token actions | `token_burn`, `token_mint`, `token_transfer`, `token_freeze`, `token_unfreeze`, `token_claim`, `token_config_update`, `token_destroy_frozen_funds`, `token_emergency_action`, `token_direct_purchase`, `token_set_price_for_direct_purchase`, `token_base` |
| Document actions | `document_create`, `document_delete`, `document_replace`, `document_transfer`, `document_purchase`, `document_update_price`, `document_base` |
| Identity actions | `identity_create`, `identity_topup`, `identity_update`, `identity_credit_withdrawal`, `identity_credit_transfer`, etc. |
| Contract actions | `data_contract_create`, `data_contract_update` |
| System actions | `bump_identity_nonce_action`, `bump_address_input_nonces_action`, `partially_use_asset_lock_action`, etc. |

These are tested through drive-abci integration/strategy tests, not individually unit-testable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated code coverage tracking configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->