### PR TITLE
feat(drive): add paginated fetch_contract_ids and fetch_contracts

### DIFF
--- a/packages/rs-drive/src/drive/contract/get_fetch/fetch_contract_ids/mod.rs
+++ b/packages/rs-drive/src/drive/contract/get_fetch/fetch_contract_ids/mod.rs
@@ -1,0 +1,45 @@
+mod v0;
+
+use crate::drive::Drive;
+use crate::error::drive::DriveError;
+use crate::error::Error;
+use dpp::version::PlatformVersion;
+use grovedb::TransactionArg;
+
+impl Drive {
+    /// Fetches contract IDs from the DataContractDocuments root tree with pagination.
+    ///
+    /// # Arguments
+    ///
+    /// * `start_at` - Optional starting contract ID and whether it is included.
+    ///   `None` starts from the beginning.
+    /// * `limit` - Maximum number of contract IDs to return.
+    /// * `transaction` - The transaction argument.
+    /// * `platform_version` - The platform version for version dispatch.
+    ///
+    /// # Returns
+    ///
+    /// A `Vec<[u8; 32]>` of contract IDs in lexicographic order.
+    pub fn fetch_contract_ids(
+        &self,
+        start_at: Option<([u8; 32], bool)>,
+        limit: u16,
+        transaction: TransactionArg,
+        platform_version: &PlatformVersion,
+    ) -> Result<Vec<[u8; 32]>, Error> {
+        match platform_version
+            .drive
+            .methods
+            .contract
+            .get
+            .fetch_contract_ids
+        {
+            0 => self.fetch_contract_ids_v0(start_at, limit, transaction, &platform_version.drive),
+            version => Err(Error::Drive(DriveError::UnknownVersionMismatch {
+                method: "fetch_contract_ids".to_string(),
+                known_versions: vec![0],
+                received: version,
+            })),
+        }
+    }
+}

--- a/packages/rs-drive/src/drive/contract/get_fetch/fetch_contract_ids/v0/mod.rs
+++ b/packages/rs-drive/src/drive/contract/get_fetch/fetch_contract_ids/v0/mod.rs
@@ -1,0 +1,191 @@
+use crate::drive::{Drive, RootTree};
+use crate::error::Error;
+use crate::query::QueryResultType;
+use dpp::version::drive_versions::DriveVersion;
+use grovedb::{PathQuery, Query, QueryItem, SizedQuery, TransactionArg};
+use std::ops::RangeFull;
+
+impl Drive {
+    pub(crate) fn fetch_contract_ids_v0(
+        &self,
+        start_at: Option<([u8; 32], bool)>,
+        limit: u16,
+        transaction: TransactionArg,
+        drive_version: &DriveVersion,
+    ) -> Result<Vec<[u8; 32]>, Error> {
+        let contracts_root_path =
+            vec![Into::<&[u8; 1]>::into(RootTree::DataContractDocuments).to_vec()];
+
+        let mut query = Query::new();
+        if let Some((start_at_id, start_at_included)) = start_at {
+            if start_at_included {
+                query.insert_item(QueryItem::RangeFrom(start_at_id.to_vec()..));
+            } else {
+                query.insert_item(QueryItem::RangeAfter(start_at_id.to_vec()..));
+            }
+        } else {
+            query.insert_item(QueryItem::RangeFull(RangeFull));
+        }
+
+        let path_query = PathQuery::new(
+            contracts_root_path,
+            SizedQuery::new(query, Some(limit), None),
+        );
+
+        let (result_items, _) = self.grove_get_raw_path_query(
+            &path_query,
+            transaction,
+            QueryResultType::QueryKeyElementPairResultType,
+            &mut vec![],
+            drive_version,
+        )?;
+
+        result_items
+            .to_keys()
+            .into_iter()
+            .map(|key| {
+                let arr: [u8; 32] = key.try_into().map_err(|v: Vec<u8>| {
+                    Error::Drive(crate::error::drive::DriveError::CorruptedDriveState(
+                        format!(
+                            "Contract ID key has unexpected length {}, expected 32",
+                            v.len()
+                        ),
+                    ))
+                })?;
+                Ok(arr)
+            })
+            .collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::util::test_helpers::setup::setup_drive_with_initial_state_structure;
+    use dpp::block::block_info::BlockInfo;
+    use dpp::data_contract::accessors::v0::{DataContractV0Getters, DataContractV0Setters};
+    use dpp::tests::json_document::json_document_to_contract;
+    use dpp::version::PlatformVersion;
+    use grovedb_epoch_based_storage_flags::StorageFlags;
+
+    fn setup_contracts(count: usize) -> (crate::drive::Drive, Vec<[u8; 32]>) {
+        let drive = setup_drive_with_initial_state_structure(None);
+        let platform_version = PlatformVersion::latest();
+
+        let contract_path = "tests/supporting_files/contract/family/family-contract.json";
+
+        let mut ids = Vec::new();
+        for i in 0..count {
+            let mut contract = json_document_to_contract(contract_path, false, platform_version)
+                .expect("expected to get contract");
+            // Give each contract a unique ID
+            let mut id = [0u8; 32];
+            id[0] = (i + 1) as u8;
+            contract.set_id(id.into());
+            drive
+                .apply_contract(
+                    &contract,
+                    BlockInfo::default(),
+                    true,
+                    StorageFlags::optional_default_as_cow(),
+                    None,
+                    platform_version,
+                )
+                .expect("expected to apply contract");
+            ids.push(id);
+        }
+        ids.sort();
+        (drive, ids)
+    }
+
+    #[test]
+    fn fetch_all_contract_ids() {
+        let (drive, expected_ids) = setup_contracts(3);
+        let platform_version = PlatformVersion::latest();
+
+        let ids = drive
+            .fetch_contract_ids(None, 100, None, platform_version)
+            .expect("expected to fetch contract ids");
+
+        assert_eq!(ids, expected_ids);
+    }
+
+    #[test]
+    fn fetch_contract_ids_with_limit() {
+        let (drive, expected_ids) = setup_contracts(5);
+        let platform_version = PlatformVersion::latest();
+
+        let ids = drive
+            .fetch_contract_ids(None, 2, None, platform_version)
+            .expect("expected to fetch contract ids");
+
+        assert_eq!(ids.len(), 2);
+        assert_eq!(ids, &expected_ids[..2]);
+    }
+
+    #[test]
+    fn fetch_contract_ids_with_pagination() {
+        let (drive, expected_ids) = setup_contracts(5);
+        let platform_version = PlatformVersion::latest();
+
+        // First page
+        let page1 = drive
+            .fetch_contract_ids(None, 2, None, platform_version)
+            .expect("expected to fetch page 1");
+        assert_eq!(page1.len(), 2);
+
+        // Second page (start after last of page 1)
+        let page2 = drive
+            .fetch_contract_ids(Some((page1[1], false)), 2, None, platform_version)
+            .expect("expected to fetch page 2");
+        assert_eq!(page2.len(), 2);
+
+        // Third page
+        let page3 = drive
+            .fetch_contract_ids(Some((page2[1], false)), 2, None, platform_version)
+            .expect("expected to fetch page 3");
+        assert_eq!(page3.len(), 1);
+
+        // All pages combined should match the full set
+        let mut all: Vec<[u8; 32]> = Vec::new();
+        all.extend(&page1);
+        all.extend(&page2);
+        all.extend(&page3);
+        assert_eq!(all, expected_ids);
+    }
+
+    #[test]
+    fn fetch_contract_ids_start_at_included() {
+        let (drive, expected_ids) = setup_contracts(3);
+        let platform_version = PlatformVersion::latest();
+
+        let ids = drive
+            .fetch_contract_ids(Some((expected_ids[1], true)), 100, None, platform_version)
+            .expect("expected to fetch");
+
+        assert_eq!(ids, &expected_ids[1..]);
+    }
+
+    #[test]
+    fn fetch_contract_ids_start_at_excluded() {
+        let (drive, expected_ids) = setup_contracts(3);
+        let platform_version = PlatformVersion::latest();
+
+        let ids = drive
+            .fetch_contract_ids(Some((expected_ids[1], false)), 100, None, platform_version)
+            .expect("expected to fetch");
+
+        assert_eq!(ids, &expected_ids[2..]);
+    }
+
+    #[test]
+    fn fetch_contract_ids_empty_state() {
+        let drive = setup_drive_with_initial_state_structure(None);
+        let platform_version = PlatformVersion::latest();
+
+        let ids = drive
+            .fetch_contract_ids(None, 100, None, platform_version)
+            .expect("expected to fetch");
+
+        assert!(ids.is_empty());
+    }
+}

--- a/packages/rs-drive/src/drive/contract/get_fetch/fetch_contracts/mod.rs
+++ b/packages/rs-drive/src/drive/contract/get_fetch/fetch_contracts/mod.rs
@@ -1,0 +1,39 @@
+mod v0;
+
+use crate::drive::Drive;
+use crate::error::drive::DriveError;
+use crate::error::Error;
+use dpp::data_contract::DataContract;
+use dpp::version::PlatformVersion;
+use grovedb::TransactionArg;
+
+impl Drive {
+    /// Fetches data contracts from state with pagination.
+    ///
+    /// Returns deserialized `DataContract` objects in lexicographic order of their IDs.
+    /// Handles both non-historical and historical contract storage layouts.
+    ///
+    /// # Arguments
+    ///
+    /// * `start_at` - Optional starting contract ID and whether it is included.
+    ///   `None` starts from the beginning.
+    /// * `limit` - Maximum number of contracts to return.
+    /// * `transaction` - The transaction argument.
+    /// * `platform_version` - The platform version for version dispatch.
+    pub fn fetch_contracts(
+        &self,
+        start_at: Option<([u8; 32], bool)>,
+        limit: u16,
+        transaction: TransactionArg,
+        platform_version: &PlatformVersion,
+    ) -> Result<Vec<DataContract>, Error> {
+        match platform_version.drive.methods.contract.get.fetch_contracts {
+            0 => self.fetch_contracts_v0(start_at, limit, transaction, platform_version),
+            version => Err(Error::Drive(DriveError::UnknownVersionMismatch {
+                method: "fetch_contracts".to_string(),
+                known_versions: vec![0],
+                received: version,
+            })),
+        }
+    }
+}

--- a/packages/rs-drive/src/drive/contract/get_fetch/fetch_contracts/v0/mod.rs
+++ b/packages/rs-drive/src/drive/contract/get_fetch/fetch_contracts/v0/mod.rs
@@ -111,6 +111,7 @@ mod tests {
     use crate::util::test_helpers::setup::setup_drive_with_initial_state_structure;
     use dpp::block::block_info::BlockInfo;
     use dpp::data_contract::accessors::v0::{DataContractV0Getters, DataContractV0Setters};
+    use dpp::data_contract::config::v0::DataContractConfigSettersV0;
     use dpp::tests::json_document::json_document_to_contract;
     use dpp::version::PlatformVersion;
     use grovedb_epoch_based_storage_flags::StorageFlags;
@@ -222,5 +223,70 @@ mod tests {
             .expect("expected to fetch");
 
         assert!(contracts.is_empty());
+    }
+
+    #[test]
+    fn fetch_contracts_includes_historical_contract() {
+        let drive = setup_drive_with_initial_state_structure(None);
+        let platform_version = PlatformVersion::latest();
+
+        // Insert a normal (non-historical) contract
+        let contract_path = "tests/supporting_files/contract/family/family-contract.json";
+        let mut normal_contract = json_document_to_contract(contract_path, false, platform_version)
+            .expect("expected to get contract");
+        let normal_id = [1u8; 32];
+        normal_contract.set_id(normal_id.into());
+        drive
+            .apply_contract(
+                &normal_contract,
+                BlockInfo::default(),
+                true,
+                StorageFlags::optional_default_as_cow(),
+                None,
+                platform_version,
+            )
+            .expect("expected to apply normal contract");
+
+        // Insert a historical contract (keeps_history = true)
+        let history_path =
+            "tests/supporting_files/contract/references/references_with_contract_history.json";
+        let mut history_contract = json_document_to_contract(history_path, false, platform_version)
+            .expect("expected to get contract");
+        let history_id = [2u8; 32];
+        history_contract.set_id(history_id.into());
+        history_contract.config_mut().set_keeps_history(true);
+        history_contract.config_mut().set_readonly(false);
+        drive
+            .apply_contract(
+                &history_contract,
+                BlockInfo {
+                    time_ms: 1000,
+                    height: 100,
+                    core_height: 10,
+                    epoch: Default::default(),
+                },
+                true,
+                StorageFlags::optional_default_as_cow(),
+                None,
+                platform_version,
+            )
+            .expect("expected to apply historical contract");
+
+        // Fetch all contracts — should get both
+        let contracts = drive
+            .fetch_contracts(None, 100, None, platform_version)
+            .expect("expected to fetch contracts");
+
+        assert_eq!(contracts.len(), 2);
+        let fetched_ids: Vec<[u8; 32]> = contracts.iter().map(|c| c.id().to_buffer()).collect();
+        assert!(fetched_ids.contains(&normal_id));
+        assert!(fetched_ids.contains(&history_id));
+
+        // Verify the historical contract has the right document types
+        let hist = contracts
+            .iter()
+            .find(|c| c.id().to_buffer() == history_id)
+            .unwrap();
+        assert!(!hist.document_types().is_empty());
     }
 }

--- a/packages/rs-drive/src/drive/contract/get_fetch/fetch_contracts/v0/mod.rs
+++ b/packages/rs-drive/src/drive/contract/get_fetch/fetch_contracts/v0/mod.rs
@@ -1,0 +1,226 @@
+use crate::drive::contract::paths;
+use crate::drive::{Drive, RootTree};
+use crate::error::drive::DriveError;
+use crate::error::Error;
+use dpp::data_contract::DataContract;
+use dpp::serialization::PlatformDeserializableWithPotentialValidationFromVersionedStructure;
+use dpp::version::PlatformVersion;
+use grovedb::{Element, PathQuery, Query, QueryItem, SizedQuery, TransactionArg};
+use std::ops::RangeFull;
+
+impl Drive {
+    pub(super) fn fetch_contracts_v0(
+        &self,
+        start_at: Option<([u8; 32], bool)>,
+        limit: u16,
+        transaction: TransactionArg,
+        platform_version: &PlatformVersion,
+    ) -> Result<Vec<DataContract>, Error> {
+        let contracts_root_path =
+            vec![Into::<&[u8; 1]>::into(RootTree::DataContractDocuments).to_vec()];
+
+        let mut query = Query::new();
+        if let Some((start_at_id, start_at_included)) = start_at {
+            if start_at_included {
+                query.insert_item(QueryItem::RangeFrom(start_at_id.to_vec()..));
+            } else {
+                query.insert_item(QueryItem::RangeAfter(start_at_id.to_vec()..));
+            }
+        } else {
+            query.insert_item(QueryItem::RangeFull(RangeFull));
+        }
+        // Descend one level into each contract subtree to fetch key [0].
+        // For non-historical contracts this is the Item with the contract bytes.
+        // For historical contracts this is a Tree (the history subtree), which
+        // we handle with a follow-up read below.
+        query.set_subquery_key(vec![0]);
+
+        let path_query = PathQuery::new(
+            contracts_root_path,
+            SizedQuery::new(query, Some(limit), None),
+        );
+
+        let (result_items, _) = self.grove_get_raw_path_query(
+            &path_query,
+            transaction,
+            crate::query::QueryResultType::QueryPathKeyElementTrioResultType,
+            &mut vec![],
+            &platform_version.drive,
+        )?;
+
+        let mut contracts = Vec::new();
+
+        for (path, _key, element) in result_items.to_path_key_elements() {
+            let stored_bytes = match element {
+                Element::Item(bytes, _) => {
+                    // Non-historical contract — bytes are the serialized contract.
+                    bytes
+                }
+                Element::Tree(..) => {
+                    // Historical contract — the element at key [0] is the history
+                    // subtree. Read via get_caching_optional which follows the
+                    // reference at [root, id, 0, 0] to the latest revision.
+                    let contract_id_bytes =
+                        path.last()
+                            .ok_or(Error::Drive(DriveError::CorruptedDriveState(
+                                "Empty path in contract query result".to_string(),
+                            )))?;
+                    let history_path =
+                        paths::contract_keeping_history_root_path(contract_id_bytes.as_slice());
+                    let history_element = self
+                        .grove
+                        .get_caching_optional(
+                            (&history_path).into(),
+                            &[0],
+                            false,
+                            transaction,
+                            &platform_version.drive.grove_version,
+                        )
+                        .value
+                        .map_err(|e| Error::GroveDB(Box::new(e)))?;
+                    match history_element {
+                        Element::Item(bytes, _) => bytes,
+                        _ => {
+                            return Err(Error::Drive(DriveError::CorruptedDriveState(format!(
+                                "Could not resolve historical contract element for {}",
+                                hex::encode(contract_id_bytes)
+                            ))));
+                        }
+                    }
+                }
+                _ => {
+                    return Err(Error::Drive(DriveError::CorruptedDriveState(
+                        "Unexpected element type in contract query result".to_string(),
+                    )));
+                }
+            };
+
+            let contract =
+                DataContract::versioned_deserialize(&stored_bytes, false, platform_version)
+                    .map_err(Error::from)?;
+
+            contracts.push(contract);
+        }
+
+        Ok(contracts)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::util::test_helpers::setup::setup_drive_with_initial_state_structure;
+    use dpp::block::block_info::BlockInfo;
+    use dpp::data_contract::accessors::v0::{DataContractV0Getters, DataContractV0Setters};
+    use dpp::tests::json_document::json_document_to_contract;
+    use dpp::version::PlatformVersion;
+    use grovedb_epoch_based_storage_flags::StorageFlags;
+
+    fn setup_contracts(count: usize) -> (crate::drive::Drive, Vec<[u8; 32]>) {
+        let drive = setup_drive_with_initial_state_structure(None);
+        let platform_version = PlatformVersion::latest();
+
+        let contract_path = "tests/supporting_files/contract/family/family-contract.json";
+
+        let mut ids = Vec::new();
+        for i in 0..count {
+            let mut contract = json_document_to_contract(contract_path, false, platform_version)
+                .expect("expected to get contract");
+            let mut id = [0u8; 32];
+            id[0] = (i + 1) as u8;
+            contract.set_id(id.into());
+            drive
+                .apply_contract(
+                    &contract,
+                    BlockInfo::default(),
+                    true,
+                    StorageFlags::optional_default_as_cow(),
+                    None,
+                    platform_version,
+                )
+                .expect("expected to apply contract");
+            ids.push(id);
+        }
+        ids.sort();
+        (drive, ids)
+    }
+
+    #[test]
+    fn fetch_all_contracts() {
+        let (drive, expected_ids) = setup_contracts(3);
+        let platform_version = PlatformVersion::latest();
+
+        let contracts = drive
+            .fetch_contracts(None, 100, None, platform_version)
+            .expect("expected to fetch contracts");
+
+        assert_eq!(contracts.len(), 3);
+        let fetched_ids: Vec<[u8; 32]> = contracts.iter().map(|c| c.id().to_buffer()).collect();
+        assert_eq!(fetched_ids, expected_ids);
+    }
+
+    #[test]
+    fn fetch_contracts_with_limit() {
+        let (drive, expected_ids) = setup_contracts(5);
+        let platform_version = PlatformVersion::latest();
+
+        let contracts = drive
+            .fetch_contracts(None, 2, None, platform_version)
+            .expect("expected to fetch contracts");
+
+        assert_eq!(contracts.len(), 2);
+        let fetched_ids: Vec<[u8; 32]> = contracts.iter().map(|c| c.id().to_buffer()).collect();
+        assert_eq!(fetched_ids, &expected_ids[..2]);
+    }
+
+    #[test]
+    fn fetch_contracts_with_pagination() {
+        let (drive, expected_ids) = setup_contracts(4);
+        let platform_version = PlatformVersion::latest();
+
+        // First page
+        let page1 = drive
+            .fetch_contracts(None, 2, None, platform_version)
+            .expect("expected to fetch page 1");
+        assert_eq!(page1.len(), 2);
+
+        // Second page (start after last of page 1)
+        let last_id = page1.last().unwrap().id().to_buffer();
+        let page2 = drive
+            .fetch_contracts(Some((last_id, false)), 2, None, platform_version)
+            .expect("expected to fetch page 2");
+        assert_eq!(page2.len(), 2);
+
+        // All pages combined
+        let mut all_ids: Vec<[u8; 32]> = Vec::new();
+        all_ids.extend(page1.iter().map(|c| c.id().to_buffer()));
+        all_ids.extend(page2.iter().map(|c| c.id().to_buffer()));
+        assert_eq!(all_ids, expected_ids);
+    }
+
+    #[test]
+    fn fetch_contracts_returns_valid_data() {
+        let (drive, _) = setup_contracts(1);
+        let platform_version = PlatformVersion::latest();
+
+        let contracts = drive
+            .fetch_contracts(None, 100, None, platform_version)
+            .expect("expected to fetch contracts");
+
+        assert_eq!(contracts.len(), 1);
+        let contract = &contracts[0];
+        // The family contract should have document types
+        assert!(!contract.document_types().is_empty());
+    }
+
+    #[test]
+    fn fetch_contracts_empty_state() {
+        let drive = setup_drive_with_initial_state_structure(None);
+        let platform_version = PlatformVersion::latest();
+
+        let contracts = drive
+            .fetch_contracts(None, 100, None, platform_version)
+            .expect("expected to fetch");
+
+        assert!(contracts.is_empty());
+    }
+}

--- a/packages/rs-drive/src/drive/contract/get_fetch/mod.rs
+++ b/packages/rs-drive/src/drive/contract/get_fetch/mod.rs
@@ -1,5 +1,7 @@
 mod fetch_contract;
+mod fetch_contract_ids;
 mod fetch_contract_with_history;
+mod fetch_contracts;
 mod get_cached_contract_with_fetch_info;
 mod get_contract_with_fetch_info;
 mod get_contracts_with_fetch_info;

--- a/packages/rs-platform-version/src/version/drive_versions/drive_contract_method_versions/mod.rs
+++ b/packages/rs-platform-version/src/version/drive_versions/drive_contract_method_versions/mod.rs
@@ -44,6 +44,8 @@ pub struct DriveContractUpdateMethodVersions {
 #[derive(Clone, Debug, Default)]
 pub struct DriveContractGetMethodVersions {
     pub fetch_contract: FeatureVersion,
+    pub fetch_contract_ids: FeatureVersion,
+    pub fetch_contracts: FeatureVersion,
     pub fetch_contract_with_history: FeatureVersion,
     pub get_cached_contract_with_fetch_info: FeatureVersion,
     pub get_contract_with_fetch_info: FeatureVersion,

--- a/packages/rs-platform-version/src/version/drive_versions/drive_contract_method_versions/v1.rs
+++ b/packages/rs-platform-version/src/version/drive_versions/drive_contract_method_versions/v1.rs
@@ -31,6 +31,8 @@ pub const DRIVE_CONTRACT_METHOD_VERSIONS_V1: DriveContractMethodVersions =
         },
         get: DriveContractGetMethodVersions {
             fetch_contract: 0,
+            fetch_contract_ids: 0,
+            fetch_contracts: 0,
             fetch_contract_with_history: 0,
             get_cached_contract_with_fetch_info: 0,
             get_contract_with_fetch_info: 0,

--- a/packages/rs-platform-version/src/version/drive_versions/drive_contract_method_versions/v2.rs
+++ b/packages/rs-platform-version/src/version/drive_versions/drive_contract_method_versions/v2.rs
@@ -31,6 +31,8 @@ pub const DRIVE_CONTRACT_METHOD_VERSIONS_V2: DriveContractMethodVersions =
         },
         get: DriveContractGetMethodVersions {
             fetch_contract: 0,
+            fetch_contract_ids: 0,
+            fetch_contracts: 0,
             fetch_contract_with_history: 0,
             get_cached_contract_with_fetch_info: 0,
             get_contract_with_fetch_info: 0,


### PR DESCRIPTION
## Summary

- Add `Drive::fetch_contract_ids(start_at, limit)` — paginated query of contract IDs from the DataContractDocuments root tree
- Add `Drive::fetch_contracts(start_at, limit)` — paginated fetch of deserialized `DataContract` objects using `set_subquery_key([0])` for efficient single-query retrieval, with fallback reads for historical contracts
- Both follow the established `Option<([u8; 32], bool)>` pagination pattern (same as identity balance and vote queries)
- Version-dispatched via `DriveContractGetMethodVersions`

## Test plan

- [x] `fetch_all_contract_ids` — fetches all IDs from state
- [x] `fetch_contract_ids_with_limit` — respects limit parameter
- [x] `fetch_contract_ids_with_pagination` — multi-page traversal reconstructs full set
- [x] `fetch_contract_ids_start_at_included` — inclusive start boundary
- [x] `fetch_contract_ids_start_at_excluded` — exclusive start boundary
- [x] `fetch_contract_ids_empty_state` — empty state returns empty vec
- [x] `fetch_all_contracts` — fetches and deserializes all contracts
- [x] `fetch_contracts_with_limit` — respects limit
- [x] `fetch_contracts_with_pagination` — multi-page works correctly
- [x] `fetch_contracts_returns_valid_data` — deserialized contracts have document types
- [x] `fetch_contracts_empty_state` — empty state returns empty vec

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Paginated contract ID retrieval with optional cursors and limits for efficient browsing.
  * Paginated contract details retrieval with optional cursors and limits for accessing full contract data and metadata.

* **Tests**
  * Added unit tests covering full fetch, limits, pagination semantics (inclusive/exclusive), empty state, and historical contract handling.

* **Platform Versions**
  * Registered new method versions for fetch_contract_ids and fetch_contracts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->