### PR TITLE
chore: bump rust-dashcore to commit 383b306e4438e21852aea5762f4aedda9549acd4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1607,12 +1607,9 @@ dependencies = [
 [[package]]
 name = "dash-spv"
 version = "0.42.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=88e8a9aa1eadce79c8177f757f6741f8a55a83f5#88e8a9aa1eadce79c8177f757f6741f8a55a83f5"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=383b306e4438e21852aea5762f4aedda9549acd4#383b306e4438e21852aea5762f4aedda9549acd4"
 dependencies = [
- "anyhow",
  "async-trait",
- "bincode",
- "blsful",
  "chrono",
  "clap",
  "dashcore",
@@ -1620,10 +1617,8 @@ dependencies = [
  "futures",
  "hex",
  "hickory-resolver",
- "indexmap 2.13.1",
  "key-wallet",
  "key-wallet-manager",
- "log",
  "rand 0.8.5",
  "rayon",
  "serde",
@@ -1640,23 +1635,16 @@ dependencies = [
 [[package]]
 name = "dash-spv-ffi"
 version = "0.42.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=88e8a9aa1eadce79c8177f757f6741f8a55a83f5#88e8a9aa1eadce79c8177f757f6741f8a55a83f5"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=383b306e4438e21852aea5762f4aedda9549acd4#383b306e4438e21852aea5762f4aedda9549acd4"
 dependencies = [
  "cbindgen 0.29.2",
  "clap",
  "dash-spv",
  "dashcore",
- "env_logger 0.10.2",
  "hex",
  "key-wallet",
  "key-wallet-ffi",
  "key-wallet-manager",
- "libc",
- "log",
- "once_cell",
- "rand 0.8.5",
- "serde",
- "serde_json",
  "tokio",
  "tokio-util",
  "tracing",
@@ -1665,7 +1653,7 @@ dependencies = [
 [[package]]
 name = "dashcore"
 version = "0.42.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=88e8a9aa1eadce79c8177f757f6741f8a55a83f5#88e8a9aa1eadce79c8177f757f6741f8a55a83f5"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=383b306e4438e21852aea5762f4aedda9549acd4#383b306e4438e21852aea5762f4aedda9549acd4"
 dependencies = [
  "anyhow",
  "base64-compat",
@@ -1680,35 +1668,35 @@ dependencies = [
  "ed25519-dalek",
  "hex",
  "hex_lit",
- "log",
  "rustversion",
  "secp256k1",
  "serde",
  "thiserror 2.0.18",
+ "tracing",
 ]
 
 [[package]]
 name = "dashcore-private"
 version = "0.42.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=88e8a9aa1eadce79c8177f757f6741f8a55a83f5#88e8a9aa1eadce79c8177f757f6741f8a55a83f5"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=383b306e4438e21852aea5762f4aedda9549acd4#383b306e4438e21852aea5762f4aedda9549acd4"
 
 [[package]]
 name = "dashcore-rpc"
 version = "0.42.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=88e8a9aa1eadce79c8177f757f6741f8a55a83f5#88e8a9aa1eadce79c8177f757f6741f8a55a83f5"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=383b306e4438e21852aea5762f4aedda9549acd4#383b306e4438e21852aea5762f4aedda9549acd4"
 dependencies = [
  "dashcore-rpc-json",
  "hex",
  "jsonrpc",
- "log",
  "serde",
  "serde_json",
+ "tracing",
 ]
 
 [[package]]
 name = "dashcore-rpc-json"
 version = "0.42.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=88e8a9aa1eadce79c8177f757f6741f8a55a83f5#88e8a9aa1eadce79c8177f757f6741f8a55a83f5"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=383b306e4438e21852aea5762f4aedda9549acd4#383b306e4438e21852aea5762f4aedda9549acd4"
 dependencies = [
  "bincode",
  "dashcore",
@@ -1723,12 +1711,11 @@ dependencies = [
 [[package]]
 name = "dashcore_hashes"
 version = "0.42.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=88e8a9aa1eadce79c8177f757f6741f8a55a83f5#88e8a9aa1eadce79c8177f757f6741f8a55a83f5"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=383b306e4438e21852aea5762f4aedda9549acd4#383b306e4438e21852aea5762f4aedda9549acd4"
 dependencies = [
  "bincode",
  "dashcore-private",
  "rs-x11-hash",
- "secp256k1",
  "serde",
 ]
 
@@ -1923,7 +1910,7 @@ dependencies = [
  "derive_more 1.0.0",
  "dpp",
  "dpp-json-convertible-derive",
- "env_logger 0.11.10",
+ "env_logger",
  "getrandom 0.2.17",
  "grovedb-commitment-tree",
  "hex",
@@ -2235,19 +2222,6 @@ checksum = "32e90c2accc4b07a8456ea0debdc2e7587bdd890680d71173a15d4ae604f6eef"
 dependencies = [
  "log",
  "regex",
-]
-
-[[package]]
-name = "env_logger"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cd405aab171cb85d6735e5c8d9db038c17d3ca007a4d2c25f337935c3d90580"
-dependencies = [
- "humantime",
- "is-terminal",
- "log",
- "regex",
- "termcolor",
 ]
 
 [[package]]
@@ -3832,7 +3806,7 @@ dependencies = [
 [[package]]
 name = "key-wallet"
 version = "0.42.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=88e8a9aa1eadce79c8177f757f6741f8a55a83f5#88e8a9aa1eadce79c8177f757f6741f8a55a83f5"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=383b306e4438e21852aea5762f4aedda9549acd4#383b306e4438e21852aea5762f4aedda9549acd4"
 dependencies = [
  "aes",
  "async-trait",
@@ -3860,7 +3834,7 @@ dependencies = [
 [[package]]
 name = "key-wallet-ffi"
 version = "0.42.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=88e8a9aa1eadce79c8177f757f6741f8a55a83f5#88e8a9aa1eadce79c8177f757f6741f8a55a83f5"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=383b306e4438e21852aea5762f4aedda9549acd4#383b306e4438e21852aea5762f4aedda9549acd4"
 dependencies = [
  "cbindgen 0.29.2",
  "dashcore",
@@ -3875,7 +3849,7 @@ dependencies = [
 [[package]]
 name = "key-wallet-manager"
 version = "0.42.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=88e8a9aa1eadce79c8177f757f6741f8a55a83f5#88e8a9aa1eadce79c8177f757f6741f8a55a83f5"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=383b306e4438e21852aea5762f4aedda9549acd4#383b306e4438e21852aea5762f4aedda9549acd4"
 dependencies = [
  "async-trait",
  "bincode",
@@ -5868,7 +5842,7 @@ dependencies = [
  "dash-sdk",
  "dotenvy",
  "drive-proof-verifier",
- "env_logger 0.11.10",
+ "env_logger",
  "envy",
  "getrandom 0.2.17",
  "hex",
@@ -6971,15 +6945,6 @@ dependencies = [
  "ureq",
  "walkdir",
  "zip 7.2.0",
-]
-
-[[package]]
-name = "termcolor"
-version = "1.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
-dependencies = [
- "winapi-util",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,13 +49,13 @@ members = [
 ]
 
 [workspace.dependencies]
-dashcore = { git = "https://github.com/dashpay/rust-dashcore", rev = "88e8a9aa1eadce79c8177f757f6741f8a55a83f5" }
-dash-spv = { git = "https://github.com/dashpay/rust-dashcore", rev = "88e8a9aa1eadce79c8177f757f6741f8a55a83f5" }
-dash-spv-ffi = { git = "https://github.com/dashpay/rust-dashcore", rev = "88e8a9aa1eadce79c8177f757f6741f8a55a83f5" }
-key-wallet = { git = "https://github.com/dashpay/rust-dashcore", rev = "88e8a9aa1eadce79c8177f757f6741f8a55a83f5" }
-key-wallet-ffi = { git = "https://github.com/dashpay/rust-dashcore", rev = "88e8a9aa1eadce79c8177f757f6741f8a55a83f5" }
-key-wallet-manager = { git = "https://github.com/dashpay/rust-dashcore", rev = "88e8a9aa1eadce79c8177f757f6741f8a55a83f5" }
-dashcore-rpc = { git = "https://github.com/dashpay/rust-dashcore", rev = "88e8a9aa1eadce79c8177f757f6741f8a55a83f5" }
+dashcore = { git = "https://github.com/dashpay/rust-dashcore", rev = "383b306e4438e21852aea5762f4aedda9549acd4" }
+dash-spv = { git = "https://github.com/dashpay/rust-dashcore", rev = "383b306e4438e21852aea5762f4aedda9549acd4" }
+dash-spv-ffi = { git = "https://github.com/dashpay/rust-dashcore", rev = "383b306e4438e21852aea5762f4aedda9549acd4" }
+key-wallet = { git = "https://github.com/dashpay/rust-dashcore", rev = "383b306e4438e21852aea5762f4aedda9549acd4" }
+key-wallet-ffi = { git = "https://github.com/dashpay/rust-dashcore", rev = "383b306e4438e21852aea5762f4aedda9549acd4" }
+key-wallet-manager = { git = "https://github.com/dashpay/rust-dashcore", rev = "383b306e4438e21852aea5762f4aedda9549acd4" }
+dashcore-rpc = { git = "https://github.com/dashpay/rust-dashcore", rev = "383b306e4438e21852aea5762f4aedda9549acd4" }
 
 # Optimize heavy crypto crates even in dev/test builds so that
 # Halo 2 proof generation and verification run at near-release speed.


### PR DESCRIPTION
Some changes in the FFI are coming soon so I would like to bump the version before those changes with the latest changes available. With this version bump we are getting:

 - fix: SPVClient stalling issues
 - chore: Reduced static library size used in rust-dashcore by 4MB aprox. (not a lot but looks like removing unused dependencies had some impact)
 - fix: SPVClient announcing tip to new peers when synced
 - fix: suscribe to SPVClient event monitors before startup


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [ ] I have made corresponding changes to the documentation if needed

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated multiple workspace dependencies to their latest versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->