### PR TITLE
chore(swift-sdk): define missing spv client event OnTransactionStatusChanged

### DIFF
--- a/packages/swift-sdk/Sources/SwiftDashSDK/Core/SPV/SPVEventHandler.swift
+++ b/packages/swift-sdk/Sources/SwiftDashSDK/Core/SPV/SPVEventHandler.swift
@@ -488,6 +488,12 @@ public protocol SPVWalletEventsHandler: AnyObject {
         _ record: NotOwnedTransactionRecord
     )
 
+    func onTransactionStatusChanged(
+        _ walletId: String,
+        _ txId: Data,
+        _ status: TransactionContext
+    )
+
     func onBalanceUpdated(
         _ walletId: String,
         _ spendable: UInt64,
@@ -503,7 +509,7 @@ extension SPVWalletEventsHandler {
     public func intoFFIWalletEventCallbacks() -> FFIWalletEventCallbacks {
         FFIWalletEventCallbacks(
             on_transaction_received: onSpvTransactionReceivedCallbackC,
-            on_transaction_status_changed: nil,
+            on_transaction_status_changed: onSpvTransactionStatusChangedCallbackC,
             on_balance_updated: onSpvBalanceUpdatedCallbackC,
             user_data: Unmanaged.passUnretained(self).toOpaque()
         )
@@ -535,6 +541,30 @@ private func onSpvTransactionReceivedCallbackC(
         walletId,
         accountIndex,
         record
+    )
+}
+
+private func onSpvTransactionStatusChangedCallbackC(
+    walletIdPtr: UnsafePointer<CChar>?,
+    txIdPtr: UnsafePointer<Byte32>?,
+    status: FFITransactionContext,
+    userData: UnsafeMutableRawPointer?
+) {
+    let handler = rawPtrIntoSpvWalletEventsHandler(userData)
+
+    guard let walletIdPtr else {
+        assertionFailure("TransactionStatusChanged walletId pointer is nil")
+        return
+    }
+
+    let txId = bytePtrIntoData(txIdPtr, 32)
+    let walletId = String(cString: walletIdPtr)
+    let status = TransactionContext(ffi: status)
+
+    handler.onTransactionStatusChanged(
+        walletId,
+        txId,
+        status
     )
 }
 
@@ -582,6 +612,12 @@ private final class DummySPVWalletEventsHandler: SPVWalletEventsHandler {
         _: String,
         _: UInt32,
         _: NotOwnedTransactionRecord,
+    ) {}
+
+    func onTransactionStatusChanged(
+        _ walletId: String,
+        _ txId: Data,
+        _ status: TransactionContext
     ) {}
 
     func onBalanceUpdated(

--- a/packages/swift-sdk/Sources/SwiftDashSDK/Core/Services/WalletService.swift
+++ b/packages/swift-sdk/Sources/SwiftDashSDK/Core/Services/WalletService.swift
@@ -375,6 +375,12 @@ public class WalletService: ObservableObject {
             _ record: NotOwnedTransactionRecord
         ) {}
 
+        func onTransactionStatusChanged(
+            _ walletId: String,
+            _ txId: Data,
+            _ status: TransactionContext
+        ) {}
+
         func onBalanceUpdated(
             _ walletId: String,
             _ spendable: UInt64,


### PR DESCRIPTION
In this PR I am implementing a missing wrapper for the OnTransactionStatusChanged event in the SPVClient that was missing after PR https://github.com/dashpay/platform/pull/3414


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [x] I have made corresponding changes to the documentation if needed

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added transaction status monitoring to wallet event handling, enabling the SDK to detect and respond to transaction status updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->