### PR TITLE
refactor(rs-sdk): async AddressProvider callbacks

### DIFF
--- a/packages/rs-platform-wallet/src/wallet/platform_addresses/provider.rs
+++ b/packages/rs-platform-wallet/src/wallet/platform_addresses/provider.rs
@@ -201,12 +201,16 @@ impl PlatformPaymentAddressAccountProvider {
 
     /// Update the account for a found address: set its balance, mark it used
     /// in the pool, and generate new addresses to maintain the gap limit.
-    fn on_address_found_in_pool(
+    ///
+    /// Asynchronous because it acquires the wallet manager's async write lock,
+    /// so it must never be called from a `blocking_*` context on a tokio
+    /// worker thread.
+    async fn on_address_found_in_pool(
         &mut self,
         p2pkh: &PlatformP2PKHAddress,
         funds: AddressFunds,
     ) -> Result<(), PlatformWalletError> {
-        let mut wm = self.wallet_manager.blocking_write();
+        let mut wm = self.wallet_manager.write().await;
         let info = wm.get_wallet_info_mut(&self.wallet_id).ok_or_else(|| {
             PlatformWalletError::WalletNotFound(format!(
                 "Wallet {:?} not found in wallet manager",
@@ -252,7 +256,7 @@ impl AddressProvider for PlatformPaymentAddressAccountProvider {
             .collect()
     }
 
-    fn on_address_found(
+    async fn on_address_found(
         &mut self,
         index: AddressIndex,
         address: &PlatformAddress,
@@ -267,12 +271,12 @@ impl AddressProvider for PlatformPaymentAddressAccountProvider {
         self.found.insert((index, p2pkh), funds);
         self.highest_found = Some(self.highest_found.map_or(index, |v| v.max(index)));
 
-        if let Err(e) = self.on_address_found_in_pool(&p2pkh, funds) {
+        if let Err(e) = self.on_address_found_in_pool(&p2pkh, funds).await {
             tracing::warn!("Failed to update pool for found address: {}", e);
         }
     }
 
-    fn on_address_absent(&mut self, index: AddressIndex, address: &PlatformAddress) {
+    async fn on_address_absent(&mut self, index: AddressIndex, address: &PlatformAddress) {
         let PlatformAddress::P2pkh(hash) = address else {
             return;
         };

--- a/packages/rs-sdk-ffi/src/address_sync/mod.rs
+++ b/packages/rs-sdk-ffi/src/address_sync/mod.rs
@@ -221,7 +221,7 @@ impl AddressProvider for BatchAddressProvider {
         self.pending.iter().map(|(i, a)| (*i, *a)).collect()
     }
 
-    fn on_address_found(
+    async fn on_address_found(
         &mut self,
         index: AddressIndex,
         address: &PlatformAddress,
@@ -232,7 +232,7 @@ impl AddressProvider for BatchAddressProvider {
         self.highest_found = Some(self.highest_found.map_or(index, |v| v.max(index)));
     }
 
-    fn on_address_absent(&mut self, index: AddressIndex, address: &PlatformAddress) {
+    async fn on_address_absent(&mut self, index: AddressIndex, address: &PlatformAddress) {
         self.pending.remove(&index);
         self.absent.insert((index, *address));
     }

--- a/packages/rs-sdk-ffi/src/address_sync/provider.rs
+++ b/packages/rs-sdk-ffi/src/address_sync/provider.rs
@@ -136,12 +136,15 @@ impl<'a> AddressProvider for CallbackAddressProvider<'a> {
         }
     }
 
-    fn on_address_found(
+    async fn on_address_found(
         &mut self,
         index: AddressIndex,
         address: &PlatformAddress,
         funds: AddressFunds,
     ) {
+        // The C callback is synchronous — the FFI layer already runs this
+        // entire sync loop inside `runtime.block_on(...)`, so invoking the
+        // callback directly on the current thread is correct.
         unsafe {
             let vtable = &*self.ffi.vtable;
             let key_bytes = address.to_bytes();
@@ -156,7 +159,8 @@ impl<'a> AddressProvider for CallbackAddressProvider<'a> {
         }
     }
 
-    fn on_address_absent(&mut self, index: AddressIndex, address: &PlatformAddress) {
+    async fn on_address_absent(&mut self, index: AddressIndex, address: &PlatformAddress) {
+        // The C callback is synchronous — see `on_address_found` above.
         unsafe {
             let vtable = &*self.ffi.vtable;
             let key_bytes = address.to_bytes();

--- a/packages/rs-sdk/src/platform/address_sync/mod.rs
+++ b/packages/rs-sdk/src/platform/address_sync/mod.rs
@@ -142,7 +142,7 @@ impl<P: AddressProvider> TrunkBranchSyncOps for AddressOps<P> {
         })
     }
 
-    fn process_trunk_result(
+    async fn process_trunk_result(
         trunk_result: &GroveTrunkQueryResult,
         context: &mut Self::Context<'_>,
         tracker: &mut KeyLeafTracker,
@@ -154,13 +154,13 @@ impl<P: AddressProvider> TrunkBranchSyncOps for AddressOps<P> {
             if let Some(element) = trunk_result.elements.get(&key_bytes) {
                 let funds = AddressFunds::try_from(element)?;
                 context.result.found.insert((index, address), funds);
-                context.provider.on_address_found(index, &address, funds);
+                context.provider.on_address_found(index, &address, funds).await;
             } else if let Some((leaf_key, info)) = trunk_result.trace_key_to_leaf(&key_bytes) {
                 tracker.add_key(key_bytes, leaf_key, info);
             } else {
                 // Key is proven absent
                 context.result.absent.insert((index, address));
-                context.provider.on_address_absent(index, &address);
+                context.provider.on_address_absent(index, &address).await;
             }
         }
 
@@ -179,7 +179,7 @@ impl<P: AddressProvider> TrunkBranchSyncOps for AddressOps<P> {
         execute_address_branch_query(sdk, params, settings, platform_version).await
     }
 
-    fn process_branch_result(
+    async fn process_branch_result(
         branch_result: &GroveBranchQueryResult,
         queried_leaf_key: &[u8],
         context: &mut Self::Context<'_>,
@@ -197,7 +197,7 @@ impl<P: AddressProvider> TrunkBranchSyncOps for AddressOps<P> {
             if let Some(element) = branch_result.elements.get(&target_key) {
                 let funds = AddressFunds::try_from(element)?;
                 context.result.found.insert((index, address), funds);
-                context.provider.on_address_found(index, &address, funds);
+                context.provider.on_address_found(index, &address, funds).await;
                 tracker.key_found(&target_key);
             } else if let Some((new_leaf_key, info)) = branch_result.trace_key_to_leaf(&target_key)
             {
@@ -205,7 +205,7 @@ impl<P: AddressProvider> TrunkBranchSyncOps for AddressOps<P> {
             } else {
                 // Key is proven absent
                 context.result.absent.insert((index, address));
-                context.provider.on_address_absent(index, &address);
+                context.provider.on_address_absent(index, &address).await;
                 tracker.key_found(&target_key); // Remove from tracking
             }
         }
@@ -227,7 +227,7 @@ impl<P: AddressProvider> TrunkBranchSyncOps for AddressOps<P> {
         )
     }
 
-    fn after_branch_iteration(
+    async fn after_branch_iteration(
         trunk_result: &GroveTrunkQueryResult,
         context: &mut Self::Context<'_>,
         tracker: &mut KeyLeafTracker,
@@ -620,7 +620,7 @@ async fn incremental_catch_up<P: AddressProvider>(
                                 balance: new_balance,
                             };
                             result.found.insert(result_key, funds);
-                            provider.on_address_found(index, &address, funds);
+                            provider.on_address_found(index, &address, funds).await;
                         }
                     }
                 }
@@ -678,7 +678,7 @@ async fn incremental_catch_up<P: AddressProvider>(
                             balance: new_balance,
                         };
                         result.found.insert(result_key, funds);
-                        provider.on_address_found(index, &address, funds);
+                        provider.on_address_found(index, &address, funds).await;
                     }
                 }
             }

--- a/packages/rs-sdk/src/platform/address_sync/provider.rs
+++ b/packages/rs-sdk/src/platform/address_sync/provider.rs
@@ -18,6 +18,15 @@ use dpp::address_funds::PlatformAddress;
 /// 2. The provider can extend [`pending_addresses`](AddressProvider::pending_addresses)
 ///    to include more addresses
 /// 3. Sync continues until all pending addresses are resolved
+///
+/// # Async mutation callbacks
+///
+/// [`on_address_found`](AddressProvider::on_address_found) and
+/// [`on_address_absent`](AddressProvider::on_address_absent) are `async fn`
+/// so implementations can perform asynchronous I/O (acquiring async locks,
+/// writing to async stores, etc.) without blocking tokio workers. All other
+/// methods are pure getters over local state and remain synchronous.
+#[allow(async_fn_in_trait)]
 pub trait AddressProvider: Send {
     /// Get the gap limit for this provider.
     ///
@@ -47,7 +56,7 @@ pub trait AddressProvider: Send {
     /// - `index`: The address index that was found
     /// - `address`: The platform address that was found
     /// - `funds`: The nonce and credits balance at this address
-    fn on_address_found(
+    async fn on_address_found(
         &mut self,
         index: AddressIndex,
         address: &PlatformAddress,
@@ -63,7 +72,7 @@ pub trait AddressProvider: Send {
     /// # Arguments
     /// - `index`: The address index proven absent
     /// - `address`: The platform address proven absent
-    fn on_address_absent(&mut self, index: AddressIndex, address: &PlatformAddress);
+    async fn on_address_absent(&mut self, index: AddressIndex, address: &PlatformAddress);
 
     /// Check if there are still pending addresses to synchronize.
     ///

--- a/packages/rs-sdk/src/platform/shielded/nullifier_sync/mod.rs
+++ b/packages/rs-sdk/src/platform/shielded/nullifier_sync/mod.rs
@@ -138,7 +138,7 @@ impl TrunkBranchSyncOps for NullifierOps {
         })
     }
 
-    fn process_trunk_result(
+    async fn process_trunk_result(
         trunk_result: &GroveTrunkQueryResult,
         context: &mut Self::Context<'_>,
         tracker: &mut KeyLeafTracker,
@@ -177,7 +177,7 @@ impl TrunkBranchSyncOps for NullifierOps {
         execute_nullifier_branch_query(sdk, config, params, settings, platform_version).await
     }
 
-    fn process_branch_result(
+    async fn process_branch_result(
         branch_result: &GroveBranchQueryResult,
         queried_leaf_key: &[u8],
         context: &mut Self::Context<'_>,

--- a/packages/rs-sdk/src/platform/trunk_branch_sync/mod.rs
+++ b/packages/rs-sdk/src/platform/trunk_branch_sync/mod.rs
@@ -107,7 +107,10 @@ pub trait TrunkBranchSyncOps {
     ///
     /// Implementations iterate over their target keys and call the
     /// appropriate methods on `tracker` for keys that trace to leaf subtrees.
-    fn process_trunk_result(
+    ///
+    /// Asynchronous so implementations may invoke provider callbacks that
+    /// perform async I/O (e.g. acquiring `tokio::sync::RwLock` writers).
+    async fn process_trunk_result(
         trunk_result: &GroveTrunkQueryResult,
         context: &mut Self::Context<'_>,
         tracker: &mut KeyLeafTracker,
@@ -139,7 +142,10 @@ pub trait TrunkBranchSyncOps {
 
     /// Process a branch query result: for each target key in the queried
     /// leaf, classify it as found, absent, or needing a deeper query.
-    fn process_branch_result(
+    ///
+    /// Asynchronous so implementations may invoke provider callbacks that
+    /// perform async I/O (e.g. acquiring `tokio::sync::RwLock` writers).
+    async fn process_branch_result(
         branch_result: &GroveBranchQueryResult,
         queried_leaf_key: &[u8],
         context: &mut Self::Context<'_>,
@@ -158,7 +164,10 @@ pub trait TrunkBranchSyncOps {
     /// This allows the address sync module to extend pending addresses
     /// (gap-limit behavior) and add newly pending keys to the tracker.
     /// The default implementation does nothing.
-    fn after_branch_iteration(
+    ///
+    /// Asynchronous so implementations may invoke provider callbacks that
+    /// perform async I/O.
+    async fn after_branch_iteration(
         _trunk_result: &GroveTrunkQueryResult,
         _context: &mut Self::Context<'_>,
         _tracker: &mut KeyLeafTracker,
@@ -212,7 +221,7 @@ pub async fn run_full_tree_scan<Ops: TrunkBranchSyncOps>(
 
     // Step 2: Process trunk result
     let mut tracker = KeyLeafTracker::new();
-    Ops::process_trunk_result(&trunk_result, context, &mut tracker)?;
+    Ops::process_trunk_result(&trunk_result, context, &mut tracker).await?;
 
     // Step 3: Iterative branch queries
     let (min_query_depth, max_query_depth) = Ops::depth_limits(platform_version);
@@ -255,12 +264,12 @@ pub async fn run_full_tree_scan<Ops: TrunkBranchSyncOps>(
         .await?;
 
         for (leaf_key, branch_result) in branch_results {
-            Ops::process_branch_result(&branch_result, &leaf_key, context, &mut tracker)?;
+            Ops::process_branch_result(&branch_result, &leaf_key, context, &mut tracker).await?;
             Ops::on_elements_seen(context, branch_result.elements.len());
         }
 
         // Post-iteration hook (gap-limit extension for addresses)
-        Ops::after_branch_iteration(&trunk_result, context, &mut tracker);
+        Ops::after_branch_iteration(&trunk_result, context, &mut tracker).await;
     }
 
     if iterations >= max_iterations {

--- a/packages/rs-sdk/tests/fetch/address_sync.rs
+++ b/packages/rs-sdk/tests/fetch/address_sync.rs
@@ -1,5 +1,6 @@
+use dash_sdk::dpp::address_funds::PlatformAddress;
 use dash_sdk::platform::address_sync::{
-    sync_address_balances, AddressFunds, AddressIndex, AddressKey, AddressProvider,
+    sync_address_balances, AddressFunds, AddressIndex, AddressProvider,
 };
 use std::collections::{BTreeMap, BTreeSet};
 
@@ -12,16 +13,18 @@ use super::{
     },
 };
 
+const EMPTY_BALANCES: &[(AddressIndex, PlatformAddress, AddressFunds)] = &[];
+
 struct TestAddressProvider {
     gap_limit: AddressIndex,
-    pending: BTreeMap<AddressIndex, AddressKey>,
-    found: BTreeMap<(AddressIndex, AddressKey), AddressFunds>,
-    absent: BTreeSet<(AddressIndex, AddressKey)>,
+    pending: BTreeMap<AddressIndex, PlatformAddress>,
+    found: BTreeMap<(AddressIndex, PlatformAddress), AddressFunds>,
+    absent: BTreeSet<(AddressIndex, PlatformAddress)>,
     highest_found_index: Option<AddressIndex>,
 }
 
 impl TestAddressProvider {
-    fn new(pending: Vec<(AddressIndex, AddressKey)>) -> Self {
+    fn new(pending: Vec<(AddressIndex, PlatformAddress)>) -> Self {
         Self {
             gap_limit: 0,
             pending: pending.into_iter().collect(),
@@ -37,26 +40,32 @@ impl AddressProvider for TestAddressProvider {
         self.gap_limit
     }
 
-    fn pending_addresses(&self) -> Vec<(AddressIndex, AddressKey)> {
-        self.pending
-            .iter()
-            .map(|(index, key)| (*index, key.clone()))
-            .collect()
+    fn pending_addresses(&self) -> Vec<(AddressIndex, PlatformAddress)> {
+        self.pending.iter().map(|(index, key)| (*index, *key)).collect()
     }
 
-    fn on_address_found(&mut self, index: AddressIndex, key: &[u8], funds: AddressFunds) {
-        self.found.insert((index, key.to_vec()), funds);
+    async fn on_address_found(
+        &mut self,
+        index: AddressIndex,
+        address: &PlatformAddress,
+        funds: AddressFunds,
+    ) {
+        self.found.insert((index, *address), funds);
         self.pending.remove(&index);
         self.highest_found_index = Some(self.highest_found_index.map_or(index, |v| v.max(index)));
     }
 
-    fn on_address_absent(&mut self, index: AddressIndex, key: &[u8]) {
-        self.absent.insert((index, key.to_vec()));
+    async fn on_address_absent(&mut self, index: AddressIndex, address: &PlatformAddress) {
+        self.absent.insert((index, *address));
         self.pending.remove(&index);
     }
 
     fn highest_found_index(&self) -> Option<AddressIndex> {
         self.highest_found_index
+    }
+
+    fn current_balances(&self) -> &[(AddressIndex, PlatformAddress, AddressFunds)] {
+        EMPTY_BALANCES
     }
 }
 
@@ -68,15 +77,12 @@ async fn test_sync_address_balances() {
     let cfg = Config::new();
     let sdk = cfg.setup_api("test_sync_address_balances").await;
 
-    let key_1 = PLATFORM_ADDRESS_1.to_bytes();
-    let key_2 = PLATFORM_ADDRESS_2.to_bytes();
-    let key_unknown = UNKNOWN_PLATFORM_ADDRESS.to_bytes();
+    let key_1 = PLATFORM_ADDRESS_1;
+    let key_2 = PLATFORM_ADDRESS_2;
+    let key_unknown = UNKNOWN_PLATFORM_ADDRESS;
 
-    let mut provider = TestAddressProvider::new(vec![
-        (0, key_1.clone()),
-        (1, key_2.clone()),
-        (2, key_unknown.clone()),
-    ]);
+    let mut provider =
+        TestAddressProvider::new(vec![(0, key_1), (1, key_2), (2, key_unknown)]);
 
     let result = sync_address_balances(&sdk, &mut provider, None, None)
         .await
@@ -88,7 +94,7 @@ async fn test_sync_address_balances() {
     assert_eq!(
         result
             .found
-            .get(&(0, key_1.clone()))
+            .get(&(0, key_1))
             .expect("found address 0")
             .balance,
         PLATFORM_ADDRESS_1_BALANCE
@@ -96,12 +102,12 @@ async fn test_sync_address_balances() {
     assert_eq!(
         result
             .found
-            .get(&(1, key_2.clone()))
+            .get(&(1, key_2))
             .expect("found address 1")
             .balance,
         PLATFORM_ADDRESS_2_BALANCE
     );
-    assert!(result.absent.contains(&(2, key_unknown.clone())));
+    assert!(result.absent.contains(&(2, key_unknown)));
 
     assert_eq!(
         result.total_balance(),


### PR DESCRIPTION
## Summary

Convert `AddressProvider::on_address_found` and `on_address_absent` to `async fn` so implementations can `.await` on internal state writes (e.g. `wallet_manager.write().await` in platform-wallet's provider) without panicking on tokio workers from sync trait bodies.

This **supersedes the `block_in_place + Handle::block_on` workaround** added for the `AddressProvider` impl path in feat/platform-wallet2 (\`b9ce0eaae\`). Once this PR lands, the runtime-coupled bridge can be removed in favor of a plain \`.await\`.

## Changes

- **Trait** (\`rs-sdk/.../address_sync/provider.rs\`): \`on_address_found\` / \`on_address_absent\` become \`async fn\`. Native async-fn-in-trait (same style as \`TrunkBranchSyncOps\`, which also carries \`#[allow(async_fn_in_trait)]\`). Searched for \`dyn AddressProvider\` — none exists in the repo; all usages are \`P: AddressProvider\` generic.
- **TrunkBranchSyncOps ripple**: \`process_trunk_result\` / \`process_branch_result\` / \`after_branch_iteration\` become async to propagate the callback boundary up to \`run_full_tree_scan\`.
- **shielded::nullifier_sync**: trivial async adapters for conformance (no callback use).
- **Impls updated**: \`BatchAddressProvider\`, \`CallbackAddressProvider\`, \`TestAddressProvider\`, \`PlatformPaymentAddressAccountProvider\`.
- **\`PlatformPaymentAddressAccountProvider::on_address_found_in_pool\`** now uses \`wallet_manager.write().await\` — eliminates the \`blocking_write\` panic inside tokio context.
- **\`TestAddressProvider\`**: also fixes pre-existing baseline staleness (removed \`AddressKey\` type, missing \`current_balances\`) to restore build/test.

## Test plan
- [x] \`cargo build --workspace\`
- [x] \`cargo test -p dash-sdk --test fetch -- fetch::address_sync\` — \`test_sync_address_balances\` passes
- [x] \`cargo clippy --workspace\` — no new warnings introduced
- [ ] CI on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)