### PR TITLE
refactor(rs-sdk): async AddressProvider callbacks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5862,6 +5862,7 @@ dependencies = [
 name = "rs-sdk-ffi"
 version = "3.1.0-dev.1"
 dependencies = [
+ "async-trait",
  "bincode",
  "bs58",
  "cbindgen 0.27.0",

--- a/packages/rs-sdk-ffi/Cargo.toml
+++ b/packages/rs-sdk-ffi/Cargo.toml
@@ -21,6 +21,7 @@ rs-sdk-trusted-context-provider = { path = "../rs-sdk-trusted-context-provider",
     "dpns-contract",
 ] }
 simple-signer = { path = "../simple-signer" }
+async-trait = { version = "0.1.83" }
 
 # Platform Wallet integration for DashPay support
 platform-wallet-ffi = { path = "../rs-platform-wallet-ffi" }

--- a/packages/rs-sdk-ffi/src/address_sync/mod.rs
+++ b/packages/rs-sdk-ffi/src/address_sync/mod.rs
@@ -220,13 +220,13 @@ impl AddressProvider for BatchAddressProvider {
         self.pending.iter().map(|(i, k)| (*i, k.clone())).collect()
     }
 
-    fn on_address_found(&mut self, index: AddressIndex, key: &[u8], funds: AddressFunds) {
+    async fn on_address_found(&mut self, index: AddressIndex, key: &[u8], funds: AddressFunds) {
         self.pending.remove(&index);
         self.found.insert((index, key.to_vec()), funds);
         self.highest_found = Some(self.highest_found.map_or(index, |v| v.max(index)));
     }
 
-    fn on_address_absent(&mut self, index: AddressIndex, key: &[u8]) {
+    async fn on_address_absent(&mut self, index: AddressIndex, key: &[u8]) {
         self.pending.remove(&index);
         self.absent.insert((index, key.to_vec()));
     }

--- a/packages/rs-sdk-ffi/src/address_sync/mod.rs
+++ b/packages/rs-sdk-ffi/src/address_sync/mod.rs
@@ -13,6 +13,7 @@ pub use types::*;
 use crate::sdk::SDKWrapper;
 use crate::types::SDKHandle;
 use crate::{DashSDKError, DashSDKErrorCode, DashSDKResult, FFIError};
+use async_trait::async_trait;
 use dash_sdk::platform::address_sync::{
     AddressFunds, AddressIndex, AddressKey, AddressProvider, AddressSyncConfig, AddressSyncResult,
 };
@@ -211,6 +212,7 @@ struct BatchAddressProvider {
     last_known_recent_block: u64,
 }
 
+#[async_trait]
 impl AddressProvider for BatchAddressProvider {
     fn gap_limit(&self) -> AddressIndex {
         self.gap_limit

--- a/packages/rs-sdk-ffi/src/address_sync/provider.rs
+++ b/packages/rs-sdk-ffi/src/address_sync/provider.rs
@@ -130,7 +130,7 @@ impl<'a> AddressProvider for CallbackAddressProvider<'a> {
         }
     }
 
-    fn on_address_found(&mut self, index: AddressIndex, key: &[u8], funds: AddressFunds) {
+    async fn on_address_found(&mut self, index: AddressIndex, key: &[u8], funds: AddressFunds) {
         unsafe {
             let vtable = &*self.ffi.vtable;
             (vtable.on_address_found)(
@@ -144,7 +144,7 @@ impl<'a> AddressProvider for CallbackAddressProvider<'a> {
         }
     }
 
-    fn on_address_absent(&mut self, index: AddressIndex, key: &[u8]) {
+    async fn on_address_absent(&mut self, index: AddressIndex, key: &[u8]) {
         unsafe {
             let vtable = &*self.ffi.vtable;
             (vtable.on_address_absent)(self.ffi.context, index, key.as_ptr(), key.len());

--- a/packages/rs-sdk-ffi/src/address_sync/provider.rs
+++ b/packages/rs-sdk-ffi/src/address_sync/provider.rs
@@ -1,6 +1,7 @@
 //! FFI-compatible address provider implementation using callbacks
 
 use super::types::DashSDKPendingAddressList;
+use async_trait::async_trait;
 use dash_sdk::platform::address_sync::{AddressFunds, AddressIndex, AddressKey, AddressProvider};
 use std::os::raw::c_void;
 
@@ -99,6 +100,7 @@ impl<'a> CallbackAddressProvider<'a> {
     }
 }
 
+#[async_trait]
 impl<'a> AddressProvider for CallbackAddressProvider<'a> {
     fn gap_limit(&self) -> AddressIndex {
         unsafe {

--- a/packages/rs-sdk/src/platform/address_sync/mod.rs
+++ b/packages/rs-sdk/src/platform/address_sync/mod.rs
@@ -205,10 +205,7 @@ impl<P: AddressProvider> TrunkBranchSyncOps for AddressOps<P> {
             } else {
                 // Key is proven absent
                 context.result.absent.insert((index, target_key.clone()));
-                context
-                    .provider
-                    .on_address_absent(index, &target_key)
-                    .await;
+                context.provider.on_address_absent(index, &target_key).await;
                 tracker.key_found(&target_key); // Remove from tracking
             }
         }

--- a/packages/rs-sdk/src/platform/address_sync/mod.rs
+++ b/packages/rs-sdk/src/platform/address_sync/mod.rs
@@ -141,7 +141,7 @@ impl<P: AddressProvider> TrunkBranchSyncOps for AddressOps<P> {
         })
     }
 
-    fn process_trunk_result(
+    async fn process_trunk_result(
         trunk_result: &GroveTrunkQueryResult,
         context: &mut Self::Context<'_>,
         tracker: &mut KeyLeafTracker,
@@ -152,13 +152,13 @@ impl<P: AddressProvider> TrunkBranchSyncOps for AddressOps<P> {
             if let Some(element) = trunk_result.elements.get(&key) {
                 let funds = AddressFunds::try_from(element)?;
                 context.result.found.insert((index, key.clone()), funds);
-                context.provider.on_address_found(index, &key, funds);
+                context.provider.on_address_found(index, &key, funds).await;
             } else if let Some((leaf_key, info)) = trunk_result.trace_key_to_leaf(&key) {
                 tracker.add_key(key, leaf_key, info);
             } else {
                 // Key is proven absent
                 context.result.absent.insert((index, key.clone()));
-                context.provider.on_address_absent(index, &key);
+                context.provider.on_address_absent(index, &key).await;
             }
         }
 
@@ -177,7 +177,7 @@ impl<P: AddressProvider> TrunkBranchSyncOps for AddressOps<P> {
         execute_address_branch_query(sdk, params, settings, platform_version).await
     }
 
-    fn process_branch_result(
+    async fn process_branch_result(
         branch_result: &GroveBranchQueryResult,
         queried_leaf_key: &[u8],
         context: &mut Self::Context<'_>,
@@ -194,7 +194,10 @@ impl<P: AddressProvider> TrunkBranchSyncOps for AddressOps<P> {
                     .result
                     .found
                     .insert((index, target_key.clone()), funds);
-                context.provider.on_address_found(index, &target_key, funds);
+                context
+                    .provider
+                    .on_address_found(index, &target_key, funds)
+                    .await;
                 tracker.key_found(&target_key);
             } else if let Some((new_leaf_key, info)) = branch_result.trace_key_to_leaf(&target_key)
             {
@@ -202,7 +205,10 @@ impl<P: AddressProvider> TrunkBranchSyncOps for AddressOps<P> {
             } else {
                 // Key is proven absent
                 context.result.absent.insert((index, target_key.clone()));
-                context.provider.on_address_absent(index, &target_key);
+                context
+                    .provider
+                    .on_address_absent(index, &target_key)
+                    .await;
                 tracker.key_found(&target_key); // Remove from tracking
             }
         }
@@ -224,7 +230,7 @@ impl<P: AddressProvider> TrunkBranchSyncOps for AddressOps<P> {
         )
     }
 
-    fn after_branch_iteration(
+    async fn after_branch_iteration(
         trunk_result: &GroveTrunkQueryResult,
         context: &mut Self::Context<'_>,
         tracker: &mut KeyLeafTracker,
@@ -619,7 +625,7 @@ async fn incremental_catch_up<P: AddressProvider>(
                                 balance: new_balance,
                             };
                             result.found.insert((*index, key.clone()), funds);
-                            provider.on_address_found(*index, key, funds);
+                            provider.on_address_found(*index, key, funds).await;
                         }
                     }
                 }
@@ -680,7 +686,7 @@ async fn incremental_catch_up<P: AddressProvider>(
                             balance: new_balance,
                         };
                         result.found.insert((*index, key.clone()), funds);
-                        provider.on_address_found(*index, key, funds);
+                        provider.on_address_found(*index, key, funds).await;
                     }
                 }
             }

--- a/packages/rs-sdk/src/platform/address_sync/provider.rs
+++ b/packages/rs-sdk/src/platform/address_sync/provider.rs
@@ -1,6 +1,7 @@
 //! Address provider trait for address synchronization.
 
 use super::types::{AddressFunds, AddressIndex, AddressKey};
+use async_trait::async_trait;
 
 /// Trait for providing addresses to be synchronized.
 ///
@@ -58,7 +59,7 @@ use super::types::{AddressFunds, AddressIndex, AddressKey};
 /// the caller's task; do not spawn detached tasks that outlive the returned
 /// future, as the engine relies on the mutation having been applied before
 /// the next iteration observes the updated pending set.
-#[allow(async_fn_in_trait)]
+#[async_trait]
 pub trait AddressProvider: Send {
     /// Get the gap limit for this provider.
     ///

--- a/packages/rs-sdk/src/platform/address_sync/provider.rs
+++ b/packages/rs-sdk/src/platform/address_sync/provider.rs
@@ -47,6 +47,18 @@ use super::types::{AddressFunds, AddressIndex, AddressKey};
 ///     // ... other methods
 /// }
 /// ```
+///
+/// # Async mutation contract
+///
+/// [`on_address_found`](Self::on_address_found) and
+/// [`on_address_absent`](Self::on_address_absent) are `async` so implementations
+/// can `.await` on internal state writes (for example, acquiring an async lock
+/// or persisting to an async store) without having to `block_on` a runtime
+/// from a sync trait body.  The sync engine awaits each callback in-order on
+/// the caller's task; do not spawn detached tasks that outlive the returned
+/// future, as the engine relies on the mutation having been applied before
+/// the next iteration observes the updated pending set.
+#[allow(async_fn_in_trait)]
 pub trait AddressProvider: Send {
     /// Get the gap limit for this provider.
     ///
@@ -76,7 +88,7 @@ pub trait AddressProvider: Send {
     /// - `index`: The address index that was found
     /// - `key`: The address key bytes
     /// - `funds`: The nonce and credits balance at this address
-    fn on_address_found(&mut self, index: AddressIndex, key: &[u8], funds: AddressFunds);
+    async fn on_address_found(&mut self, index: AddressIndex, key: &[u8], funds: AddressFunds);
 
     /// Called when an address is proven absent from the tree.
     ///
@@ -87,7 +99,7 @@ pub trait AddressProvider: Send {
     /// # Arguments
     /// - `index`: The address index proven absent
     /// - `key`: The address key bytes
-    fn on_address_absent(&mut self, index: AddressIndex, key: &[u8]);
+    async fn on_address_absent(&mut self, index: AddressIndex, key: &[u8]);
 
     /// Check if there are still pending addresses to synchronize.
     ///

--- a/packages/rs-sdk/src/platform/shielded/nullifier_sync/mod.rs
+++ b/packages/rs-sdk/src/platform/shielded/nullifier_sync/mod.rs
@@ -138,7 +138,7 @@ impl TrunkBranchSyncOps for NullifierOps {
         })
     }
 
-    fn process_trunk_result(
+    async fn process_trunk_result(
         trunk_result: &GroveTrunkQueryResult,
         context: &mut Self::Context<'_>,
         tracker: &mut KeyLeafTracker,
@@ -177,7 +177,7 @@ impl TrunkBranchSyncOps for NullifierOps {
         execute_nullifier_branch_query(sdk, config, params, settings, platform_version).await
     }
 
-    fn process_branch_result(
+    async fn process_branch_result(
         branch_result: &GroveBranchQueryResult,
         queried_leaf_key: &[u8],
         context: &mut Self::Context<'_>,

--- a/packages/rs-sdk/src/platform/trunk_branch_sync/mod.rs
+++ b/packages/rs-sdk/src/platform/trunk_branch_sync/mod.rs
@@ -107,7 +107,10 @@ pub trait TrunkBranchSyncOps {
     ///
     /// Implementations iterate over their target keys and call the
     /// appropriate methods on `tracker` for keys that trace to leaf subtrees.
-    fn process_trunk_result(
+    ///
+    /// Async so implementations can await `AddressProvider` callbacks that
+    /// mutate internal state (e.g. acquiring async locks).
+    async fn process_trunk_result(
         trunk_result: &GroveTrunkQueryResult,
         context: &mut Self::Context<'_>,
         tracker: &mut KeyLeafTracker,
@@ -139,7 +142,10 @@ pub trait TrunkBranchSyncOps {
 
     /// Process a branch query result: for each target key in the queried
     /// leaf, classify it as found, absent, or needing a deeper query.
-    fn process_branch_result(
+    ///
+    /// Async so implementations can await `AddressProvider` callbacks that
+    /// mutate internal state (e.g. acquiring async locks).
+    async fn process_branch_result(
         branch_result: &GroveBranchQueryResult,
         queried_leaf_key: &[u8],
         context: &mut Self::Context<'_>,
@@ -158,7 +164,10 @@ pub trait TrunkBranchSyncOps {
     /// This allows the address sync module to extend pending addresses
     /// (gap-limit behavior) and add newly pending keys to the tracker.
     /// The default implementation does nothing.
-    fn after_branch_iteration(
+    ///
+    /// Async so implementations can await provider queries that resolve from
+    /// an async store (though the default provided here is a no-op).
+    async fn after_branch_iteration(
         _trunk_result: &GroveTrunkQueryResult,
         _context: &mut Self::Context<'_>,
         _tracker: &mut KeyLeafTracker,
@@ -212,7 +221,7 @@ pub async fn run_full_tree_scan<Ops: TrunkBranchSyncOps>(
 
     // Step 2: Process trunk result
     let mut tracker = KeyLeafTracker::new();
-    Ops::process_trunk_result(&trunk_result, context, &mut tracker)?;
+    Ops::process_trunk_result(&trunk_result, context, &mut tracker).await?;
 
     // Step 3: Iterative branch queries
     let (min_query_depth, max_query_depth) = Ops::depth_limits(platform_version);
@@ -255,12 +264,12 @@ pub async fn run_full_tree_scan<Ops: TrunkBranchSyncOps>(
         .await?;
 
         for (leaf_key, branch_result) in branch_results {
-            Ops::process_branch_result(&branch_result, &leaf_key, context, &mut tracker)?;
+            Ops::process_branch_result(&branch_result, &leaf_key, context, &mut tracker).await?;
             Ops::on_elements_seen(context, branch_result.elements.len());
         }
 
         // Post-iteration hook (gap-limit extension for addresses)
-        Ops::after_branch_iteration(&trunk_result, context, &mut tracker);
+        Ops::after_branch_iteration(&trunk_result, context, &mut tracker).await;
     }
 
     if iterations >= max_iterations {

--- a/packages/rs-sdk/tests/fetch/address_sync.rs
+++ b/packages/rs-sdk/tests/fetch/address_sync.rs
@@ -1,3 +1,4 @@
+use async_trait::async_trait;
 use dash_sdk::platform::address_sync::{
     sync_address_balances, AddressFunds, AddressIndex, AddressKey, AddressProvider,
 };
@@ -32,6 +33,7 @@ impl TestAddressProvider {
     }
 }
 
+#[async_trait]
 impl AddressProvider for TestAddressProvider {
     fn gap_limit(&self) -> AddressIndex {
         self.gap_limit

--- a/packages/rs-sdk/tests/fetch/address_sync.rs
+++ b/packages/rs-sdk/tests/fetch/address_sync.rs
@@ -44,13 +44,13 @@ impl AddressProvider for TestAddressProvider {
             .collect()
     }
 
-    fn on_address_found(&mut self, index: AddressIndex, key: &[u8], funds: AddressFunds) {
+    async fn on_address_found(&mut self, index: AddressIndex, key: &[u8], funds: AddressFunds) {
         self.found.insert((index, key.to_vec()), funds);
         self.pending.remove(&index);
         self.highest_found_index = Some(self.highest_found_index.map_or(index, |v| v.max(index)));
     }
 
-    fn on_address_absent(&mut self, index: AddressIndex, key: &[u8]) {
+    async fn on_address_absent(&mut self, index: AddressIndex, key: &[u8]) {
         self.absent.insert((index, key.to_vec()));
         self.pending.remove(&index);
     }


### PR DESCRIPTION
## Summary

Promote \`AddressProvider::on_address_found\` and \`on_address_absent\` to \`async fn\` so implementations can \`.await\` on internal state writes (async lock acquisition, async persistence) without panicking on tokio workers from sync trait bodies.

Downstream, this lets \`feat/platform-wallet2\` drop its \`block_in_place + Handle::block_on\` bridge in the \`AddressProvider\` impl on \`PlatformPaymentAddressAccountProvider\` — but that cleanup belongs on that branch, not here. This PR is purely a trait + call-site change.

## Why

The two callbacks are mutating and real impls increasingly need to write back to async-locked state (e.g. a tokio \`RwLock\` over wallet state) or persist via async DB handles. Today the only way to do that from a sync trait body is \`blocking_write\` (panics on tokio workers) or \`block_in_place\`+\`Handle::block_on\` (runtime-coupled, wrong layer for a library). Async fn in trait is the correct answer.

## Changes

- **Trait** (\`rs-sdk/.../address_sync/provider.rs\`): \`on_address_found\` / \`on_address_absent\` become \`async fn\`. \`#[allow(async_fn_in_trait)]\` at the trait level (same pattern the repo already uses on \`TrunkBranchSyncOps\`). Native async fn — verified no \`dyn AddressProvider\` usages; all call sites are generic \`P: AddressProvider\`.
- **\`TrunkBranchSyncOps\` ripple**: \`process_trunk_result\`, \`process_branch_result\`, \`after_branch_iteration\` become async to propagate the callback boundary up to \`run_full_tree_scan\`. Fine because the trait already uses \`async fn in trait\` for its query methods.
- **\`AddressOps\` impl** (\`rs-sdk/.../address_sync/mod.rs\`): 6 provider-callback sites now \`.await\`.
- **\`shielded::nullifier_sync\`**: trivial \`async\` on \`process_trunk_result\` / \`process_branch_result\` to conform to the updated trait. No callback use, bodies unchanged.
- **Impls**: \`BatchAddressProvider\` / \`CallbackAddressProvider\` (\`rs-sdk-ffi\`) and \`TestAddressProvider\` (\`rs-sdk/tests/fetch/address_sync.rs\`) get \`async\` on the two callbacks. FFI entry points already run the sync loop under \`runtime.block_on\`, so no new bridge was added.

## Test plan

- [x] \`cargo build --workspace\`
- [x] \`cargo test -p dash-sdk --test main -- fetch::address_sync --nocapture\` → \`test_sync_address_balances\` passes
- [x] \`cargo clippy -p dash-sdk -p rs-sdk-ffi --all-targets\` — no new warnings from this change
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced address and nullifier synchronization operations to use asynchronous callbacks, improving responsiveness during sync processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->