### PR TITLE
chore: gitignore .claude/scheduled_tasks.lock

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -91,6 +91,7 @@ grpc-coverage-report.txt
 
 __pycache__/
 .claude/worktrees/
+.claude/scheduled_tasks.lock
 
 # Security audit reports (local-only, not committed)
 audits/


### PR DESCRIPTION
## Summary

Add \`.claude/scheduled_tasks.lock\` to \`.gitignore\`. The file is a runtime lock written by the Claude Code harness when a task is scheduled via its wake-up mechanism; it carries no useful state for anyone other than the local session and has accidentally leaked into diffs a couple of times already.

## Test plan
- [ ] \`git status\` no longer shows \`.claude/scheduled_tasks.lock\` as untracked after Claude Code runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated version control configuration to exclude additional temporary files from tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->