### PR TITLE
fix(drive): wire v1 dispatcher for deduct_from_prefunded_specialized_balance

### DIFF
--- a/packages/rs-drive/src/drive/prefunded_specialized_balances/deduct_from_prefunded_specialized_balance/mod.rs
+++ b/packages/rs-drive/src/drive/prefunded_specialized_balances/deduct_from_prefunded_specialized_balance/mod.rs
@@ -1,4 +1,5 @@
 mod v0;
+mod v1;
 
 use crate::drive::Drive;
 use crate::error::drive::DriveError;
@@ -43,9 +44,15 @@ impl Drive {
                 transaction,
                 platform_version,
             ),
+            1 => self.deduct_from_prefunded_specialized_balance_v1(
+                specialized_balance_id,
+                amount,
+                transaction,
+                platform_version,
+            ),
             version => Err(Error::Drive(DriveError::UnknownVersionMismatch {
                 method: "deduct_from_prefunded_specialized_balance".to_string(),
-                known_versions: vec![0],
+                known_versions: vec![0, 1],
                 received: version,
             })),
         }

--- a/packages/rs-drive/src/drive/prefunded_specialized_balances/deduct_from_prefunded_specialized_balance/v1/mod.rs
+++ b/packages/rs-drive/src/drive/prefunded_specialized_balances/deduct_from_prefunded_specialized_balance/v1/mod.rs
@@ -1,0 +1,54 @@
+use crate::drive::Drive;
+use crate::error::Error;
+use crate::fees::op::LowLevelDriveOperation;
+
+use dpp::identifier::Identifier;
+use dpp::version::PlatformVersion;
+use grovedb::TransactionArg;
+
+impl Drive {
+    /// Deducts from a prefunded specialized balance (v1).
+    ///
+    /// Functionally identical to `deduct_from_prefunded_specialized_balance_v0`:
+    /// version selection for the actual deduction logic happens inside the
+    /// `deduct_from_prefunded_specialized_balance_operations` dispatcher, which
+    /// routes to `_operations_v0` / `_operations_v1` based on the platform
+    /// version. This top-level wrapper just collects those operations and
+    /// applies the resulting grovedb batch.
+    ///
+    /// # Arguments
+    ///
+    /// * `amount` - The amount of credits to be removed from the prefunded balance.
+    /// * `transaction` - A `TransactionArg` object representing the transaction to be used.
+    /// * `platform_version` - A `PlatformVersion` object specifying the version of Platform.
+    ///
+    /// # Returns
+    ///
+    /// * `Result<(), Error>` - If successful, returns `Ok(())`. Otherwise, returns an `Error`.
+    #[inline(always)]
+    pub(super) fn deduct_from_prefunded_specialized_balance_v1(
+        &self,
+        specialized_balance_id: Identifier,
+        amount: u64,
+        transaction: TransactionArg,
+        platform_version: &PlatformVersion,
+    ) -> Result<(), Error> {
+        let mut drive_operations = vec![];
+        let batch_operations = self.deduct_from_prefunded_specialized_balance_operations(
+            specialized_balance_id,
+            amount,
+            &mut None,
+            transaction,
+            platform_version,
+        )?;
+        let grove_db_operations =
+            LowLevelDriveOperation::grovedb_operations_batch(&batch_operations);
+        self.grove_apply_batch_with_add_costs(
+            grove_db_operations,
+            false,
+            transaction,
+            &mut drive_operations,
+            &platform_version.drive,
+        )
+    }
+}

--- a/packages/rs-drive/src/drive/prefunded_specialized_balances/deduct_from_prefunded_specialized_balance_operations/mod.rs
+++ b/packages/rs-drive/src/drive/prefunded_specialized_balances/deduct_from_prefunded_specialized_balance_operations/mod.rs
@@ -60,7 +60,7 @@ impl Drive {
             ),
             version => Err(Error::Drive(DriveError::UnknownVersionMismatch {
                 method: "deduct_from_prefunded_specialized_balance_operations".to_string(),
-                known_versions: vec![0],
+                known_versions: vec![0, 1],
                 received: version,
             })),
         }


### PR DESCRIPTION
## Issue being fixed or feature implemented

The top-level \`Drive::deduct_from_prefunded_specialized_balance\` dispatcher in
[\`packages/rs-drive/src/drive/prefunded_specialized_balances/deduct_from_prefunded_specialized_balance/mod.rs\`](packages/rs-drive/src/drive/prefunded_specialized_balances/deduct_from_prefunded_specialized_balance/mod.rs) only matches
feature version \`0\`, but platform versions v3–v7 set
\`DrivePrefundedSpecializedMethodVersions::deduct_from_prefunded_specialized_balance\` to \`1\`
(see v3.rs:100, v4.rs:100, v5.rs:102, v6.rs:104, v7.rs:102). On any v3+ platform the helper
unconditionally returned:

\`\`\`
Error::Drive(DriveError::UnknownVersionMismatch {
    method: "deduct_from_prefunded_specialized_balance",
    known_versions: vec![0],
    received: 1,
})
\`\`\`

### Production impact

**None observed.** A grep of the workspace shows the helper has no production callers —
the real state-transition path is routed through
\`deduct_from_prefunded_specialized_balance_operations\` (from \`util/batch/drive_op_batch/prefunded_specialized_balance.rs:56\`),
which already handles both v0 and v1 and has been correct since #2422. However, the helper is
part of the public \`Drive\` API, so any external \`rs-drive\` consumer who did call it on v3+
would hit an \`UnknownVersionMismatch\` error.

### Adjacent latent issue (not fixed here)

While investigating, I noticed the \`_operations\` dispatcher reads the wrong platform-version field:

\`\`\`rust
// deduct_from_prefunded_specialized_balance_operations/mod.rs:41-45
match platform_version
    .drive
    .methods
    .prefunded_specialized_balances
    .deduct_from_prefunded_specialized_balance   // <-- the top-level field, not _operations
\`\`\`

Compare to the \`add\` sibling, which correctly reads \`.add_prefunded_specialized_balance_operations\`. This
misread is likely why v3+ bumped the top-level field to \`1\` rather than the \`_operations\` field —
it was the de facto control knob for \`_operations\` dispatch.

Fixing this properly requires swapping the \`1\` from the top-level to \`_operations\` across
v3–v7, which is consensus-adjacent (same observable \`_operations\` behavior — both read the
same value either way — but I did not want to bundle a platform-version edit into this PR).
**Happy to open a follow-up if reviewers agree it should be cleaned up.**

## What was done?

- Added [\`deduct_from_prefunded_specialized_balance/v1/mod.rs\`](packages/rs-drive/src/drive/prefunded_specialized_balances/deduct_from_prefunded_specialized_balance/v1/mod.rs) with a v1 impl. Its body is identical to v0 because the v0 impl
  is already version-agnostic: it delegates to \`deduct_from_prefunded_specialized_balance_operations\`,
  which dispatches to \`_operations_v0\` / \`_operations_v1\` based on the platform version. So v1 just
  collects those operations and applies the resulting grovedb batch.
- Registered the v1 module and added the match arm in the top-level dispatcher.
- Updated \`known_versions: vec![0]\` → \`vec![0, 1]\` in the \`_operations\` dispatcher error arm — it
  has handled both versions since #2422 and the error message was stale.

No platform-version files were touched, so there is no consensus risk.

## How Has This Been Tested?

- \`cargo build -p drive --lib\` — clean build.
- \`cargo clippy -p drive --lib --no-deps\` — no warnings.
- \`cargo fmt -p drive\`.

Did not add a unit test because the helper is not called from production or any existing test
harness; setting up a Drive fixture purely to round-trip the dispatcher would be out of proportion
to the fix. The match statement's compile-time coverage plus the existing \`_operations\` test
coverage (which the v0/v1 top-level bodies both delegate to) guard against regression.

## Breaking Changes

None. This restores previously expected behavior of a public method that was broken on v3+ and
keeps behavior identical on v0–v2.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [x] I have made corresponding changes to the documentation if needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Prefunded specialized balance deduction operations now support version 1 in addition to the existing version 0, expanding available options for users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->