### PR TITLE
test: cover drive/document, votes, queries, object_size_info, and lowcov

### DIFF
--- a/packages/rs-dpp/src/data_contract/config/mod.rs
+++ b/packages/rs-dpp/src/data_contract/config/mod.rs
@@ -583,4 +583,120 @@ mod tests {
             }
         }
     }
+
+    mod bincode_roundtrip {
+        use super::*;
+        use bincode::config;
+
+        #[test]
+        fn v0_bincode_roundtrip_preserves_fields() {
+            let cfg = config::standard();
+            let original = DataContractConfig::V0(DataContractConfigV0 {
+                can_be_deleted: true,
+                readonly: true,
+                keeps_history: true,
+                documents_keep_history_contract_default: true,
+                documents_mutable_contract_default: false,
+                documents_can_be_deleted_contract_default: false,
+                requires_identity_encryption_bounded_key: Some(StorageKeyRequirements::Unique),
+                requires_identity_decryption_bounded_key: None,
+            });
+            let bytes = bincode::encode_to_vec(original, cfg).expect("encode");
+            let (decoded, _): (DataContractConfig, _) =
+                bincode::decode_from_slice(&bytes, cfg).expect("decode");
+            assert_eq!(decoded, original);
+        }
+
+        #[test]
+        fn v1_bincode_roundtrip_preserves_sized_integer_types() {
+            let cfg = config::standard();
+            let original = DataContractConfig::V1(DataContractConfigV1 {
+                can_be_deleted: false,
+                readonly: false,
+                keeps_history: false,
+                documents_keep_history_contract_default: false,
+                documents_mutable_contract_default: true,
+                documents_can_be_deleted_contract_default: true,
+                requires_identity_encryption_bounded_key: None,
+                requires_identity_decryption_bounded_key: None,
+                sized_integer_types: false,
+            });
+            let bytes = bincode::encode_to_vec(original, cfg).expect("encode");
+            let (decoded, _): (DataContractConfig, _) =
+                bincode::decode_from_slice(&bytes, cfg).expect("decode");
+            assert_eq!(decoded, original);
+            // And sized_integer_types is correctly false on the decoded copy
+            assert!(!decoded.sized_integer_types());
+        }
+    }
+
+    mod from_value_tests {
+        use super::*;
+        use platform_value::platform_value;
+
+        #[test]
+        fn from_value_yields_default_for_empty_object() {
+            // Empty object -> defaults; succeeds on the latest platform version
+            let value = platform_value!({});
+            let platform_version = PlatformVersion::latest();
+            let cfg = DataContractConfig::from_value(value, platform_version)
+                .expect("empty object should deserialize to defaults");
+            // All booleans should match defaults
+            assert_eq!(cfg.can_be_deleted(), DEFAULT_CONTRACT_CAN_BE_DELETED);
+        }
+    }
+
+    mod get_contract_configuration_properties_tests {
+        use super::*;
+        use platform_value::Value;
+        use std::collections::BTreeMap;
+
+        fn make_contract_map(can_be_deleted: bool, readonly: bool) -> BTreeMap<String, Value> {
+            let mut m = BTreeMap::new();
+            m.insert(
+                property::CAN_BE_DELETED.to_string(),
+                Value::Bool(can_be_deleted),
+            );
+            m.insert(property::READONLY.to_string(), Value::Bool(readonly));
+            m
+        }
+
+        #[test]
+        fn reads_booleans_from_map() {
+            let platform_version = PlatformVersion::latest();
+            let contract = make_contract_map(true, true);
+            let cfg = DataContractConfig::get_contract_configuration_properties(
+                &contract,
+                platform_version,
+            )
+            .expect("should parse config from map");
+            assert!(cfg.can_be_deleted());
+            assert!(cfg.readonly());
+        }
+
+        #[test]
+        fn missing_keys_fall_back_to_defaults() {
+            let platform_version = PlatformVersion::latest();
+            let empty: BTreeMap<String, Value> = BTreeMap::new();
+            let cfg =
+                DataContractConfig::get_contract_configuration_properties(&empty, platform_version)
+                    .expect("should parse empty contract map");
+            // Defaults preserved
+            assert_eq!(cfg.can_be_deleted(), DEFAULT_CONTRACT_CAN_BE_DELETED);
+            assert_eq!(cfg.keeps_history(), DEFAULT_CONTRACT_KEEPS_HISTORY);
+        }
+
+        #[test]
+        fn non_bool_value_errors() {
+            let platform_version = PlatformVersion::latest();
+            let mut m: BTreeMap<String, Value> = BTreeMap::new();
+            m.insert(
+                property::CAN_BE_DELETED.to_string(),
+                Value::Text("not-a-bool".to_string()),
+            );
+            let result =
+                DataContractConfig::get_contract_configuration_properties(&m, platform_version);
+            assert!(result.is_err());
+        }
+    }
 }

--- a/packages/rs-dpp/src/data_contract/config/mod.rs
+++ b/packages/rs-dpp/src/data_contract/config/mod.rs
@@ -664,14 +664,18 @@ mod tests {
         #[test]
         fn reads_booleans_from_map() {
             let platform_version = PlatformVersion::latest();
-            let contract = make_contract_map(true, true);
-            let cfg = DataContractConfig::get_contract_configuration_properties(
-                &contract,
-                platform_version,
-            )
-            .expect("should parse config from map");
-            assert!(cfg.can_be_deleted());
-            assert!(cfg.readonly());
+            // Use distinct values for both fields so a key mix-up (reading
+            // one field from the other's key) would fail the assertion.
+            for (can_be_deleted, readonly) in [(true, false), (false, true)] {
+                let contract = make_contract_map(can_be_deleted, readonly);
+                let cfg = DataContractConfig::get_contract_configuration_properties(
+                    &contract,
+                    platform_version,
+                )
+                .expect("should parse config from map");
+                assert_eq!(cfg.can_be_deleted(), can_be_deleted);
+                assert_eq!(cfg.readonly(), readonly);
+            }
         }
 
         #[test]

--- a/packages/rs-dpp/src/voting/contender_structs/mod.rs
+++ b/packages/rs-dpp/src/voting/contender_structs/mod.rs
@@ -121,3 +121,162 @@ impl TryFrom<ContenderWithSerializedDocument> for FinalizedContenderWithSerializ
         })
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::voting::contender_structs::contender::v0::ContenderWithSerializedDocumentV0;
+    use platform_value::Identifier;
+
+    mod finalized_resource_vote_choices_display {
+        use super::*;
+
+        #[test]
+        fn display_with_no_voters() {
+            let item = FinalizedResourceVoteChoicesWithVoterInfo {
+                resource_vote_choice: ResourceVoteChoice::Abstain,
+                voters: vec![],
+            };
+            let s = item.to_string();
+            assert!(s.contains("resource_vote_choice"));
+            assert!(s.contains("voters: []"));
+        }
+
+        #[test]
+        fn display_with_multiple_voters() {
+            let id1 = Identifier::new([1u8; 32]);
+            let id2 = Identifier::new([2u8; 32]);
+            let item = FinalizedResourceVoteChoicesWithVoterInfo {
+                resource_vote_choice: ResourceVoteChoice::Lock,
+                voters: vec![(id1, 1), (id2, 4)],
+            };
+            let s = item.to_string();
+            // Each voter rendered as id:strength and comma separated
+            assert!(s.contains(&format!("{}:1", id1)));
+            assert!(s.contains(&format!("{}:4", id2)));
+            assert!(s.contains(", "));
+        }
+    }
+
+    mod finalized_resource_vote_choices_encoding {
+        use super::*;
+        use bincode::config;
+
+        #[test]
+        fn roundtrip_preserves_data() {
+            let id = Identifier::new([7u8; 32]);
+            let original = FinalizedResourceVoteChoicesWithVoterInfo {
+                resource_vote_choice: ResourceVoteChoice::TowardsIdentity(id),
+                voters: vec![(id, 3)],
+            };
+            let cfg = config::standard();
+            let bytes = bincode::encode_to_vec(&original, cfg).expect("encode");
+            let (decoded, _): (FinalizedResourceVoteChoicesWithVoterInfo, _) =
+                bincode::decode_from_slice(&bytes, cfg).expect("decode");
+            assert_eq!(decoded, original);
+        }
+    }
+
+    mod finalized_contender_with_serialized_document_default {
+        use super::*;
+
+        #[test]
+        fn default_has_zero_fields() {
+            let fc = FinalizedContenderWithSerializedDocument::default();
+            assert_eq!(fc.identity_id, Identifier::default());
+            assert!(fc.serialized_document.is_empty());
+            assert_eq!(fc.final_vote_tally, 0);
+        }
+    }
+
+    mod try_from_contender_with_serialized_document {
+        use super::*;
+
+        #[test]
+        fn err_when_serialized_document_missing() {
+            let csd = ContenderWithSerializedDocument::V0(ContenderWithSerializedDocumentV0 {
+                identity_id: Identifier::new([1u8; 32]),
+                serialized_document: None,
+                vote_tally: Some(10),
+            });
+            let result = FinalizedContenderWithSerializedDocument::try_from(csd);
+            match result {
+                Err(ProtocolError::CorruptedCodeExecution(msg)) => {
+                    assert!(msg.contains("expected serialized document"));
+                }
+                _ => panic!("expected CorruptedCodeExecution error for missing document"),
+            }
+        }
+
+        #[test]
+        fn err_when_vote_tally_missing() {
+            let csd = ContenderWithSerializedDocument::V0(ContenderWithSerializedDocumentV0 {
+                identity_id: Identifier::new([1u8; 32]),
+                serialized_document: Some(vec![1, 2, 3]),
+                vote_tally: None,
+            });
+            let result = FinalizedContenderWithSerializedDocument::try_from(csd);
+            match result {
+                Err(ProtocolError::CorruptedCodeExecution(msg)) => {
+                    assert!(msg.contains("expected vote tally"));
+                }
+                _ => panic!("expected CorruptedCodeExecution error for missing vote tally"),
+            }
+        }
+
+        #[test]
+        fn ok_when_all_fields_present() {
+            let id = Identifier::new([9u8; 32]);
+            let doc = vec![0xAA, 0xBB, 0xCC];
+            let csd = ContenderWithSerializedDocument::V0(ContenderWithSerializedDocumentV0 {
+                identity_id: id,
+                serialized_document: Some(doc.clone()),
+                vote_tally: Some(42),
+            });
+            let finalized =
+                FinalizedContenderWithSerializedDocument::try_from(csd).expect("should succeed");
+            assert_eq!(finalized.identity_id, id);
+            assert_eq!(finalized.serialized_document, doc);
+            assert_eq!(finalized.final_vote_tally, 42);
+        }
+    }
+
+    mod finalized_contender_with_serialized_document_equality {
+        use super::*;
+
+        #[test]
+        fn equal_structs_compare_equal() {
+            let id = Identifier::new([3u8; 32]);
+            let a = FinalizedContenderWithSerializedDocument {
+                identity_id: id,
+                serialized_document: vec![1, 2, 3],
+                final_vote_tally: 100,
+            };
+            let b = FinalizedContenderWithSerializedDocument {
+                identity_id: id,
+                serialized_document: vec![1, 2, 3],
+                final_vote_tally: 100,
+            };
+            assert_eq!(a, b);
+            // Clone preserves fields
+            let c = a.clone();
+            assert_eq!(a, c);
+        }
+
+        #[test]
+        fn different_tally_not_equal() {
+            let id = Identifier::new([3u8; 32]);
+            let a = FinalizedContenderWithSerializedDocument {
+                identity_id: id,
+                serialized_document: vec![1, 2, 3],
+                final_vote_tally: 100,
+            };
+            let b = FinalizedContenderWithSerializedDocument {
+                identity_id: id,
+                serialized_document: vec![1, 2, 3],
+                final_vote_tally: 101,
+            };
+            assert_ne!(a, b);
+        }
+    }
+}

--- a/packages/rs-dpp/src/voting/vote_info_storage/contested_document_vote_poll_stored_info/mod.rs
+++ b/packages/rs-dpp/src/voting/vote_info_storage/contested_document_vote_poll_stored_info/mod.rs
@@ -206,3 +206,117 @@ impl ContestedDocumentVotePollStoredInfoV0Getters for ContestedDocumentVotePollS
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::serialization::{PlatformDeserializable, PlatformSerializable};
+
+    fn sb(time: u64, height: u64) -> BlockInfo {
+        BlockInfo {
+            time_ms: time,
+            height,
+            ..BlockInfo::default()
+        }
+    }
+
+    #[test]
+    fn new_uses_latest_supported_version() {
+        let pv = PlatformVersion::latest();
+        let info = ContestedDocumentVotePollStoredInfo::new(sb(1, 1), pv)
+            .expect("should construct for latest version");
+        // At present only V0 exists
+        match info {
+            ContestedDocumentVotePollStoredInfo::V0(v0) => {
+                matches!(
+                    v0.vote_poll_status,
+                    ContestedDocumentVotePollStatus::Started(_)
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn update_to_latest_version_is_idempotent_for_v0() {
+        let pv = PlatformVersion::latest();
+        let info = ContestedDocumentVotePollStoredInfo::new(sb(1, 1), pv).unwrap();
+        let updated = info
+            .clone()
+            .update_to_latest_version(pv)
+            .expect("should be ok");
+        assert_eq!(info, updated);
+    }
+
+    #[test]
+    fn finalize_routes_through_wrapper() {
+        let pv = PlatformVersion::latest();
+        let mut info = ContestedDocumentVotePollStoredInfo::new(sb(1, 1), pv).unwrap();
+        info.finalize_vote_poll(
+            vec![],
+            sb(2, 2),
+            ContestedDocumentVotePollWinnerInfo::Locked,
+        )
+        .expect("should finalize");
+        // After locked winner, status should be Locked.
+        assert!(matches!(
+            info.vote_poll_status(),
+            ContestedDocumentVotePollStatus::Locked
+        ));
+    }
+
+    #[test]
+    fn display_contains_wrapper_name() {
+        let pv = PlatformVersion::latest();
+        let info = ContestedDocumentVotePollStoredInfo::new(sb(1, 1), pv).unwrap();
+        let rendered = info.to_string();
+        assert!(rendered.starts_with("V0("));
+    }
+
+    #[test]
+    fn serialization_roundtrip() {
+        let pv = PlatformVersion::latest();
+        let info = ContestedDocumentVotePollStoredInfo::new(sb(1, 1), pv).unwrap();
+        let bytes = info.serialize_to_bytes().expect("serialize");
+        let restored = ContestedDocumentVotePollStoredInfo::deserialize_from_bytes(&bytes)
+            .expect("deserialize");
+        assert_eq!(info, restored);
+    }
+
+    #[test]
+    fn getters_proxy_to_inner_v0() {
+        let pv = PlatformVersion::latest();
+        let mut info = ContestedDocumentVotePollStoredInfo::new(sb(1, 1), pv).unwrap();
+        // Before any finalize, many getters return None or defaults
+        assert!(info.last_resource_vote_choices().is_none());
+        assert!(info.awarded_block().is_none());
+        assert_eq!(info.current_start_block(), Some(sb(1, 1)));
+        assert!(info.last_finalization_block().is_none());
+        assert_eq!(info.winner(), ContestedDocumentVotePollWinnerInfo::NoWinner);
+        assert!(info.last_locked_votes().is_none());
+        assert!(info.last_locked_voters().is_none());
+        assert!(info.last_abstain_votes().is_none());
+        assert!(info.last_abstain_voters().is_none());
+        assert!(info
+            .contender_votes_in_vec_of_contender_with_serialized_document()
+            .is_none());
+        matches!(
+            info.vote_poll_status_ref(),
+            ContestedDocumentVotePollStatus::Started(_)
+        );
+
+        // After an identity-winning finalize, awarded_block / winner populated.
+        let id = Identifier::new([7u8; 32]);
+        info.finalize_vote_poll(
+            vec![],
+            sb(2, 2),
+            ContestedDocumentVotePollWinnerInfo::WonByIdentity(id),
+        )
+        .unwrap();
+        assert_eq!(info.awarded_block(), Some(sb(2, 2)));
+        assert_eq!(
+            info.winner(),
+            ContestedDocumentVotePollWinnerInfo::WonByIdentity(id)
+        );
+        assert_eq!(info.last_finalization_block(), Some(sb(2, 2)));
+    }
+}

--- a/packages/rs-dpp/src/voting/vote_info_storage/contested_document_vote_poll_stored_info/mod.rs
+++ b/packages/rs-dpp/src/voting/vote_info_storage/contested_document_vote_poll_stored_info/mod.rs
@@ -228,10 +228,10 @@ mod tests {
         // At present only V0 exists
         match info {
             ContestedDocumentVotePollStoredInfo::V0(v0) => {
-                matches!(
+                assert!(matches!(
                     v0.vote_poll_status,
                     ContestedDocumentVotePollStatus::Started(_)
-                );
+                ));
             }
         }
     }
@@ -299,10 +299,10 @@ mod tests {
         assert!(info
             .contender_votes_in_vec_of_contender_with_serialized_document()
             .is_none());
-        matches!(
+        assert!(matches!(
             info.vote_poll_status_ref(),
             ContestedDocumentVotePollStatus::Started(_)
-        );
+        ));
 
         // After an identity-winning finalize, awarded_block / winner populated.
         let id = Identifier::new([7u8; 32]);

--- a/packages/rs-dpp/src/voting/vote_info_storage/contested_document_vote_poll_stored_info/v0/mod.rs
+++ b/packages/rs-dpp/src/voting/vote_info_storage/contested_document_vote_poll_stored_info/v0/mod.rs
@@ -377,7 +377,7 @@ mod tests {
                 ContestedDocumentVotePollWinnerInfo::NoWinner,
             )
             .expect_err("should fail when locked");
-        matches!(err, ProtocolError::CorruptedCodeExecution(_));
+        assert!(matches!(err, ProtocolError::CorruptedCodeExecution(_)));
     }
 
     #[test]

--- a/packages/rs-dpp/src/voting/vote_info_storage/contested_document_vote_poll_stored_info/v0/mod.rs
+++ b/packages/rs-dpp/src/voting/vote_info_storage/contested_document_vote_poll_stored_info/v0/mod.rs
@@ -316,3 +316,342 @@ impl ContestedDocumentVotePollStoredInfoV0Getters for ContestedDocumentVotePollS
         &self.vote_poll_status
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn start_block(time: u64, height: u64) -> BlockInfo {
+        BlockInfo {
+            time_ms: time,
+            height,
+            ..BlockInfo::default()
+        }
+    }
+
+    #[test]
+    fn new_sets_status_to_started() {
+        let sb = start_block(1, 1);
+        let info = ContestedDocumentVotePollStoredInfoV0::new(sb);
+        assert!(info.finalized_events.is_empty());
+        assert_eq!(info.locked_count, 0);
+        match info.vote_poll_status {
+            ContestedDocumentVotePollStatus::Started(b) => assert_eq!(b, sb),
+            other => panic!("expected Started, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn finalize_errors_when_not_started() {
+        let mut info = ContestedDocumentVotePollStoredInfoV0 {
+            finalized_events: vec![],
+            vote_poll_status: ContestedDocumentVotePollStatus::NotStarted,
+            locked_count: 0,
+        };
+        let err = info
+            .finalize_vote_poll(
+                vec![],
+                start_block(2, 2),
+                ContestedDocumentVotePollWinnerInfo::NoWinner,
+            )
+            .expect_err("should fail when not started");
+        match err {
+            ProtocolError::CorruptedCodeExecution(msg) => {
+                assert!(msg.contains("hasn't started"));
+            }
+            _ => panic!("expected CorruptedCodeExecution"),
+        }
+    }
+
+    #[test]
+    fn finalize_errors_when_locked() {
+        let mut info = ContestedDocumentVotePollStoredInfoV0 {
+            finalized_events: vec![],
+            vote_poll_status: ContestedDocumentVotePollStatus::Locked,
+            locked_count: 1,
+        };
+        let err = info
+            .finalize_vote_poll(
+                vec![],
+                start_block(2, 2),
+                ContestedDocumentVotePollWinnerInfo::NoWinner,
+            )
+            .expect_err("should fail when locked");
+        matches!(err, ProtocolError::CorruptedCodeExecution(_));
+    }
+
+    #[test]
+    fn finalize_no_winner_from_started_without_prior_locks_returns_not_started() {
+        let sb = start_block(1, 1);
+        let mut info = ContestedDocumentVotePollStoredInfoV0::new(sb);
+        info.finalize_vote_poll(
+            vec![],
+            start_block(2, 2),
+            ContestedDocumentVotePollWinnerInfo::NoWinner,
+        )
+        .expect("should finalize");
+        assert_eq!(info.finalized_events.len(), 1);
+        assert!(matches!(
+            info.vote_poll_status,
+            ContestedDocumentVotePollStatus::NotStarted
+        ));
+    }
+
+    #[test]
+    fn finalize_no_winner_with_prior_locks_returns_locked() {
+        let sb = start_block(1, 1);
+        let mut info = ContestedDocumentVotePollStoredInfoV0::new(sb);
+        info.locked_count = 2;
+        info.finalize_vote_poll(
+            vec![],
+            start_block(2, 2),
+            ContestedDocumentVotePollWinnerInfo::NoWinner,
+        )
+        .expect("should finalize");
+        assert!(matches!(
+            info.vote_poll_status,
+            ContestedDocumentVotePollStatus::Locked
+        ));
+        // locked_count is preserved (not incremented for NoWinner)
+        assert_eq!(info.locked_count, 2);
+    }
+
+    #[test]
+    fn finalize_with_identity_winner_returns_awarded() {
+        let sb = start_block(1, 1);
+        let mut info = ContestedDocumentVotePollStoredInfoV0::new(sb);
+        let winner_id = Identifier::new([7u8; 32]);
+        info.finalize_vote_poll(
+            vec![],
+            start_block(2, 2),
+            ContestedDocumentVotePollWinnerInfo::WonByIdentity(winner_id),
+        )
+        .expect("should finalize");
+        match info.vote_poll_status {
+            ContestedDocumentVotePollStatus::Awarded(id) => assert_eq!(id, winner_id),
+            other => panic!("expected Awarded, got {:?}", other),
+        }
+        // awarded_block should now return the finalization block
+        assert_eq!(info.awarded_block(), Some(start_block(2, 2)));
+    }
+
+    #[test]
+    fn finalize_with_locked_winner_increments_lock_count() {
+        let sb = start_block(1, 1);
+        let mut info = ContestedDocumentVotePollStoredInfoV0::new(sb);
+        assert_eq!(info.locked_count, 0);
+        info.finalize_vote_poll(
+            vec![],
+            start_block(2, 2),
+            ContestedDocumentVotePollWinnerInfo::Locked,
+        )
+        .expect("should finalize");
+        assert_eq!(info.locked_count, 1);
+        assert!(matches!(
+            info.vote_poll_status,
+            ContestedDocumentVotePollStatus::Locked
+        ));
+    }
+
+    #[test]
+    fn status_awarded_or_locked_helper() {
+        assert!(ContestedDocumentVotePollStatus::Locked.awarded_or_locked());
+        assert!(
+            ContestedDocumentVotePollStatus::Awarded(Identifier::default()).awarded_or_locked()
+        );
+        assert!(!ContestedDocumentVotePollStatus::NotStarted.awarded_or_locked());
+        assert!(
+            !ContestedDocumentVotePollStatus::Started(BlockInfo::default()).awarded_or_locked()
+        );
+    }
+
+    #[test]
+    fn current_start_block_only_when_started() {
+        let sb = start_block(1, 1);
+        let info = ContestedDocumentVotePollStoredInfoV0::new(sb);
+        assert_eq!(info.current_start_block(), Some(sb));
+
+        let awarded = ContestedDocumentVotePollStoredInfoV0 {
+            finalized_events: vec![],
+            vote_poll_status: ContestedDocumentVotePollStatus::Awarded(Identifier::default()),
+            locked_count: 0,
+        };
+        assert_eq!(awarded.current_start_block(), None);
+
+        let locked = ContestedDocumentVotePollStoredInfoV0 {
+            finalized_events: vec![],
+            vote_poll_status: ContestedDocumentVotePollStatus::Locked,
+            locked_count: 1,
+        };
+        assert_eq!(locked.current_start_block(), None);
+    }
+
+    #[test]
+    fn awarded_block_none_when_not_awarded() {
+        let info = ContestedDocumentVotePollStoredInfoV0::new(start_block(1, 1));
+        assert_eq!(info.awarded_block(), None);
+    }
+
+    #[test]
+    fn winner_getter_maps_statuses() {
+        // NotStarted -> NoWinner
+        let not_started = ContestedDocumentVotePollStoredInfoV0 {
+            finalized_events: vec![],
+            vote_poll_status: ContestedDocumentVotePollStatus::NotStarted,
+            locked_count: 0,
+        };
+        assert_eq!(
+            not_started.winner(),
+            ContestedDocumentVotePollWinnerInfo::NoWinner
+        );
+        // Locked -> Locked
+        let locked = ContestedDocumentVotePollStoredInfoV0 {
+            finalized_events: vec![],
+            vote_poll_status: ContestedDocumentVotePollStatus::Locked,
+            locked_count: 1,
+        };
+        assert_eq!(locked.winner(), ContestedDocumentVotePollWinnerInfo::Locked);
+        // Started -> NoWinner
+        let started = ContestedDocumentVotePollStoredInfoV0::new(start_block(1, 1));
+        assert_eq!(
+            started.winner(),
+            ContestedDocumentVotePollWinnerInfo::NoWinner
+        );
+        // Awarded -> WonByIdentity
+        let wid = Identifier::new([8u8; 32]);
+        let awarded = ContestedDocumentVotePollStoredInfoV0 {
+            finalized_events: vec![],
+            vote_poll_status: ContestedDocumentVotePollStatus::Awarded(wid),
+            locked_count: 0,
+        };
+        assert_eq!(
+            awarded.winner(),
+            ContestedDocumentVotePollWinnerInfo::WonByIdentity(wid)
+        );
+    }
+
+    #[test]
+    fn last_locked_and_abstain_aggregations() {
+        let sb = start_block(1, 1);
+        let mut info = ContestedDocumentVotePollStoredInfoV0::new(sb);
+        let v1 = Identifier::new([1u8; 32]);
+        let v2 = Identifier::new([2u8; 32]);
+        let v3 = Identifier::new([3u8; 32]);
+        // Two lock voters (strength 1 and 4), one abstain voter (strength 2)
+        let choices = vec![
+            FinalizedResourceVoteChoicesWithVoterInfo {
+                resource_vote_choice: ResourceVoteChoice::Lock,
+                voters: vec![(v1, 1), (v2, 4)],
+            },
+            FinalizedResourceVoteChoicesWithVoterInfo {
+                resource_vote_choice: ResourceVoteChoice::Abstain,
+                voters: vec![(v3, 2)],
+            },
+            FinalizedResourceVoteChoicesWithVoterInfo {
+                resource_vote_choice: ResourceVoteChoice::TowardsIdentity(Identifier::new(
+                    [9u8; 32],
+                )),
+                voters: vec![(v1, 3)],
+            },
+        ];
+        info.finalize_vote_poll(
+            choices,
+            start_block(2, 2),
+            ContestedDocumentVotePollWinnerInfo::NoWinner,
+        )
+        .expect("should finalize");
+
+        assert_eq!(info.last_locked_votes(), Some(5));
+        assert_eq!(info.last_abstain_votes(), Some(2));
+        let locked_voters = info.last_locked_voters().expect("some");
+        assert!(locked_voters.contains(&(v1, 1)));
+        assert!(locked_voters.contains(&(v2, 4)));
+        let abstain_voters = info.last_abstain_voters().expect("some");
+        assert_eq!(abstain_voters, vec![(v3, 2)]);
+
+        let towards_only = info
+            .contender_votes_in_vec_of_contender_with_serialized_document()
+            .expect("some");
+        assert_eq!(towards_only.len(), 1);
+        let first = &towards_only[0];
+        assert_eq!(first.identity_id(), Identifier::new([9u8; 32]));
+        assert_eq!(first.vote_tally(), Some(3));
+    }
+
+    #[test]
+    fn last_accessors_none_when_no_finalized_events() {
+        let info = ContestedDocumentVotePollStoredInfoV0::new(start_block(1, 1));
+        assert!(info.last_resource_vote_choices().is_none());
+        assert!(info.last_locked_votes().is_none());
+        assert!(info.last_abstain_votes().is_none());
+        assert!(info.last_finalization_block().is_none());
+        assert!(info
+            .contender_votes_in_vec_of_contender_with_serialized_document()
+            .is_none());
+    }
+
+    #[test]
+    fn display_contains_key_fields() {
+        let info = ContestedDocumentVotePollStoredInfoV0::new(start_block(10, 5));
+        let rendered = info.to_string();
+        assert!(rendered.contains("finalized_events"));
+        assert!(rendered.contains("vote_poll_status"));
+        assert!(rendered.contains("locked_count: 0"));
+
+        let status_str = ContestedDocumentVotePollStatus::NotStarted.to_string();
+        assert_eq!(status_str, "NotStarted");
+
+        let locked_str = ContestedDocumentVotePollStatus::Locked.to_string();
+        assert_eq!(locked_str, "Locked");
+
+        let awarded_str =
+            ContestedDocumentVotePollStatus::Awarded(Identifier::new([1u8; 32])).to_string();
+        assert!(awarded_str.starts_with("Awarded("));
+        let started_str =
+            ContestedDocumentVotePollStatus::Started(BlockInfo::default()).to_string();
+        assert!(started_str.starts_with("Started("));
+    }
+
+    #[test]
+    fn status_encode_decode_roundtrip() {
+        use bincode::config;
+        let cfg = config::standard();
+        for status in [
+            ContestedDocumentVotePollStatus::NotStarted,
+            ContestedDocumentVotePollStatus::Locked,
+            ContestedDocumentVotePollStatus::Awarded(Identifier::new([5u8; 32])),
+            ContestedDocumentVotePollStatus::Started(BlockInfo::default()),
+        ] {
+            let bytes = bincode::encode_to_vec(status, cfg).expect("encode");
+            let (decoded, _): (ContestedDocumentVotePollStatus, _) =
+                bincode::decode_from_slice(&bytes, cfg).expect("decode");
+            assert_eq!(decoded, status);
+        }
+    }
+
+    #[test]
+    fn vote_event_new_preserves_fields() {
+        let sb = start_block(1, 1);
+        let fb = start_block(2, 2);
+        let winner = ContestedDocumentVotePollWinnerInfo::Locked;
+        let event = ContestedDocumentVotePollStoredInfoVoteEventV0::new(vec![], sb, fb, winner);
+        assert!(event.resource_vote_choices.is_empty());
+        assert_eq!(event.start_block, sb);
+        assert_eq!(event.finalization_block, fb);
+        assert_eq!(event.winner, winner);
+    }
+
+    #[test]
+    fn vote_event_display_contains_winner() {
+        let sb = start_block(1, 1);
+        let fb = start_block(2, 2);
+        let event = ContestedDocumentVotePollStoredInfoVoteEventV0::new(
+            vec![],
+            sb,
+            fb,
+            ContestedDocumentVotePollWinnerInfo::Locked,
+        );
+        let rendered = event.to_string();
+        assert!(rendered.contains("winner: Locked"));
+    }
+}

--- a/packages/rs-dpp/src/voting/vote_info_storage/contested_document_vote_poll_winner_info/mod.rs
+++ b/packages/rs-dpp/src/voting/vote_info_storage/contested_document_vote_poll_winner_info/mod.rs
@@ -33,3 +33,78 @@ impl fmt::Display for ContestedDocumentVotePollWinnerInfo {
 // (not versioned V0/V1).
 #[cfg(feature = "json-conversion")]
 impl JsonConvertible for ContestedDocumentVotePollWinnerInfo {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_is_no_winner() {
+        let default: ContestedDocumentVotePollWinnerInfo = Default::default();
+        assert_eq!(default, ContestedDocumentVotePollWinnerInfo::NoWinner);
+    }
+
+    #[test]
+    fn display_no_winner() {
+        let s = ContestedDocumentVotePollWinnerInfo::NoWinner.to_string();
+        assert_eq!(s, "NoWinner");
+    }
+
+    #[test]
+    fn display_locked() {
+        let s = ContestedDocumentVotePollWinnerInfo::Locked.to_string();
+        assert_eq!(s, "Locked");
+    }
+
+    #[test]
+    fn display_won_by_identity() {
+        let id = Identifier::new([5u8; 32]);
+        let s = ContestedDocumentVotePollWinnerInfo::WonByIdentity(id).to_string();
+        assert!(s.starts_with("WonByIdentity("));
+        assert!(s.contains(&format!("{}", id)));
+    }
+
+    #[test]
+    fn equality_and_copy() {
+        let a = ContestedDocumentVotePollWinnerInfo::Locked;
+        let b = a; // Copy
+        assert_eq!(a, b);
+
+        let id1 = Identifier::new([1u8; 32]);
+        let id2 = Identifier::new([2u8; 32]);
+        assert_ne!(
+            ContestedDocumentVotePollWinnerInfo::WonByIdentity(id1),
+            ContestedDocumentVotePollWinnerInfo::WonByIdentity(id2)
+        );
+        assert_ne!(
+            ContestedDocumentVotePollWinnerInfo::NoWinner,
+            ContestedDocumentVotePollWinnerInfo::Locked
+        );
+    }
+
+    #[test]
+    fn bincode_roundtrip() {
+        use bincode::config;
+        let cfg = config::standard();
+        for v in [
+            ContestedDocumentVotePollWinnerInfo::NoWinner,
+            ContestedDocumentVotePollWinnerInfo::Locked,
+            ContestedDocumentVotePollWinnerInfo::WonByIdentity(Identifier::new([9u8; 32])),
+        ] {
+            let bytes = bincode::encode_to_vec(v, cfg).expect("encode");
+            let (decoded, _): (ContestedDocumentVotePollWinnerInfo, _) =
+                bincode::decode_from_slice(&bytes, cfg).expect("decode");
+            assert_eq!(v, decoded);
+        }
+    }
+
+    #[test]
+    fn serde_roundtrip_won_by_identity() {
+        let id = Identifier::new([3u8; 32]);
+        let value = ContestedDocumentVotePollWinnerInfo::WonByIdentity(id);
+        let json = serde_json::to_string(&value).expect("serialize");
+        let back: ContestedDocumentVotePollWinnerInfo =
+            serde_json::from_str(&json).expect("deserialize");
+        assert_eq!(back, value);
+    }
+}

--- a/packages/rs-drive-abci/src/platform_types/platform/mod.rs
+++ b/packages/rs-drive-abci/src/platform_types/platform/mod.rs
@@ -299,3 +299,80 @@ impl<C> Drop for Platform<C> {
         tracing::debug!("platform shutdown complete");
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test::helpers::setup::TestPlatformBuilder;
+
+    #[test]
+    fn debug_platform_state_ref_contains_state_and_config() {
+        let platform = TestPlatformBuilder::new().build_with_mock_rpc();
+        let state = platform.state.load();
+        let psr = PlatformStateRef {
+            drive: &platform.drive,
+            state: &state,
+            config: &platform.config,
+        };
+        let s = format!("{:?}", psr);
+        assert!(s.contains("state"));
+        assert!(s.contains("config"));
+    }
+
+    #[test]
+    fn debug_platform_is_minimal() {
+        let platform = TestPlatformBuilder::new().build_with_mock_rpc();
+        let s = format!("{:?}", platform.platform);
+        // The Debug impl intentionally outputs just "Platform"
+        assert_eq!(s, "Platform");
+    }
+
+    #[test]
+    fn platform_state_ref_from_platform_ref_forwards_fields() {
+        let platform = TestPlatformBuilder::new().build_with_mock_rpc();
+        let state = platform.state.load();
+        let pref = PlatformRef {
+            drive: &platform.drive,
+            state: &state,
+            config: &platform.config,
+            core_rpc: &platform.core_rpc,
+        };
+        let psr: PlatformStateRef = (&pref).into();
+        // Both references should point at the same config and state
+        assert!(std::ptr::eq(psr.config, pref.config));
+        assert!(std::ptr::eq(psr.state, pref.state));
+        assert!(std::ptr::eq(psr.drive, pref.drive));
+    }
+
+    #[test]
+    fn open_with_latest_protocol_version_succeeds() {
+        let tp = TestPlatformBuilder::new()
+            .with_latest_protocol_version()
+            .build_with_mock_rpc();
+        // Protocol version set correctly
+        let state = tp.state.load();
+        assert_eq!(
+            state.current_protocol_version_in_consensus(),
+            PlatformVersion::latest().protocol_version
+        );
+        // No checkpoint states on fresh DB
+        assert!(tp.checkpoint_platform_states.load().is_empty());
+    }
+
+    #[test]
+    fn open_with_initial_protocol_version_first_succeeds() {
+        let first = PlatformVersion::first().protocol_version;
+        let tp = TestPlatformBuilder::new()
+            .with_initial_protocol_version(first)
+            .build_with_mock_rpc();
+        let state = tp.state.load();
+        assert_eq!(state.current_protocol_version_in_consensus(), first);
+    }
+
+    #[test]
+    fn committed_block_height_guard_initialized_to_zero_on_fresh_db() {
+        let tp = TestPlatformBuilder::new().build_with_mock_rpc();
+        use std::sync::atomic::Ordering;
+        assert_eq!(tp.committed_block_height_guard.load(Ordering::Relaxed), 0);
+    }
+}

--- a/packages/rs-drive-abci/src/query/system/finalized_epoch_infos/v0/mod.rs
+++ b/packages/rs-drive-abci/src/query/system/finalized_epoch_infos/v0/mod.rs
@@ -267,4 +267,65 @@ mod tests {
             })
         ));
     }
+
+    #[test]
+    fn test_query_finalized_epoch_infos_equal_indexes_both_included() {
+        // When start == end and both boundaries are included, the range
+        // validation passes; the response should be an empty epoch list
+        // on an uninitialised platform with no finalized epochs yet.
+        let (platform, state, version) = setup_platform(None, Network::Testnet, None);
+
+        let request = GetFinalizedEpochInfosRequestV0 {
+            start_epoch_index: 3,
+            start_epoch_index_included: true,
+            end_epoch_index: 3,
+            end_epoch_index_included: true,
+            prove: false,
+        };
+
+        let result = platform
+            .query_finalized_epoch_infos_v0(request, &state, version)
+            .expect("expected query to succeed");
+
+        assert!(matches!(
+            result.data,
+            Some(GetFinalizedEpochInfosResponseV0 {
+                result: Some(get_finalized_epoch_infos_response_v0::Result::Epochs(FinalizedEpochInfos { finalized_epoch_infos })),
+                metadata: Some(_),
+            }) if finalized_epoch_infos.is_empty()
+        ));
+    }
+
+    #[test]
+    fn test_query_finalized_epoch_infos_start_at_max_does_not_trigger_range_guard() {
+        // start_epoch_index exactly at u16::MAX must not trip the
+        // `> u16::MAX` guard. Downstream layers may still reject it, but
+        // not with the InvalidArgument("start_epoch_index ... exceeds
+        // maximum") message this query is responsible for.
+        let (platform, state, version) = setup_platform(None, Network::Testnet, None);
+
+        let request = GetFinalizedEpochInfosRequestV0 {
+            start_epoch_index: u16::MAX as u32,
+            start_epoch_index_included: true,
+            end_epoch_index: u16::MAX as u32,
+            end_epoch_index_included: true,
+            prove: false,
+        };
+
+        let result = platform
+            .query_finalized_epoch_infos_v0(request, &state, version)
+            .expect("expected query to succeed");
+
+        // No "start_epoch_index ... exceeds maximum" InvalidArgument: any
+        // other error (or success) is acceptable, since the range guard is
+        // what this test covers.
+        for err in &result.errors {
+            if let QueryError::InvalidArgument(msg) = err {
+                assert!(
+                    !msg.contains("start_epoch_index") || !msg.contains("exceeds maximum"),
+                    "range guard fired at u16::MAX boundary: {msg}"
+                );
+            }
+        }
+    }
 }

--- a/packages/rs-drive-abci/src/query/system/path_elements/v0/mod.rs
+++ b/packages/rs-drive-abci/src/query/system/path_elements/v0/mod.rs
@@ -195,4 +195,59 @@ mod tests {
             })
         ));
     }
+
+    #[test]
+    fn test_query_path_elements_missing_key_returns_no_entries() {
+        // An existing path with a key that is not present should produce a
+        // valid Elements response. The fetch skips absent keys, so the
+        // returned list is empty.
+        let (platform, state, version) = setup_platform(None, Network::Testnet, None);
+
+        let request = GetPathElementsRequestV0 {
+            path: vec![vec![RootTree::Misc as u8]],
+            keys: vec![b"nonexistent-key".to_vec()],
+            prove: false,
+        };
+
+        let response = platform
+            .query_path_elements_v0(request, &state, version)
+            .expect("expected query to succeed");
+
+        let response_data = response.into_data().expect("expected data");
+
+        let get_path_elements_response_v0::Result::Elements(elements) =
+            response_data.result.expect("expected a result")
+        else {
+            panic!("expected elements")
+        };
+
+        // Missing keys produce no entries.
+        assert!(elements.elements.is_empty());
+    }
+
+    #[test]
+    fn test_query_path_elements_empty_keys() {
+        // Passing an empty `keys` vec must succeed with an empty Elements list.
+        let (platform, state, version) = setup_platform(None, Network::Testnet, None);
+
+        let request = GetPathElementsRequestV0 {
+            path: vec![vec![RootTree::Misc as u8]],
+            keys: vec![],
+            prove: false,
+        };
+
+        let response = platform
+            .query_path_elements_v0(request, &state, version)
+            .expect("expected query to succeed");
+
+        let response_data = response.into_data().expect("expected data");
+
+        let get_path_elements_response_v0::Result::Elements(elements) =
+            response_data.result.expect("expected a result")
+        else {
+            panic!("expected elements")
+        };
+
+        assert!(elements.elements.is_empty());
+    }
 }

--- a/packages/rs-drive-abci/src/query/token_queries/token_pre_programmed_distributions/v0/mod.rs
+++ b/packages/rs-drive-abci/src/query/token_queries/token_pre_programmed_distributions/v0/mod.rs
@@ -411,4 +411,53 @@ mod tests {
             })
         ));
     }
+
+    #[test]
+    fn test_query_limit_zero_is_rejected_as_error() {
+        // limit == 0 routes through the `.ok_or(...)?` path, which propagates
+        // a Drive(Query(InvalidLimit(...))) error via `Err(...)`, not as a
+        // validation error inside the response.
+        let (platform, state, version) = setup_platform(None, Network::Testnet, None);
+
+        let request = GetTokenPreProgrammedDistributionsRequestV0 {
+            token_id: vec![0; 32],
+            start_at_info: None,
+            limit: Some(0),
+            prove: false,
+        };
+
+        let err = platform
+            .query_token_pre_programmed_distributions_v0(request, &state, version)
+            .expect_err("limit=0 should propagate an Err");
+
+        // Accept any Drive/Query related error; we just want to verify the
+        // `.ok_or(...)?` path is exercised.
+        let msg = format!("{:?}", err);
+        assert!(
+            msg.contains("InvalidLimit") || msg.contains("limit"),
+            "unexpected error: {msg}"
+        );
+    }
+
+    #[test]
+    fn test_query_limit_above_max_is_rejected_as_error() {
+        let (platform, state, version) = setup_platform(None, Network::Testnet, None);
+
+        let request = GetTokenPreProgrammedDistributionsRequestV0 {
+            token_id: vec![0; 32],
+            start_at_info: None,
+            limit: Some((u16::MAX as u32) + 1),
+            prove: false,
+        };
+
+        let err = platform
+            .query_token_pre_programmed_distributions_v0(request, &state, version)
+            .expect_err("oversized limit should propagate an Err");
+
+        let msg = format!("{:?}", err);
+        assert!(
+            msg.contains("InvalidLimit") || msg.contains("limit"),
+            "unexpected error: {msg}"
+        );
+    }
 }

--- a/packages/rs-drive-abci/src/query/voting/contested_resource_identity_votes/v0/mod.rs
+++ b/packages/rs-drive-abci/src/query/voting/contested_resource_identity_votes/v0/mod.rs
@@ -286,4 +286,116 @@ mod tests {
             }) if contested_resource_identity_votes.is_empty() && finished_results
         ));
     }
+
+    #[test]
+    fn test_query_contested_resource_identity_votes_empty_prove() {
+        let (platform, state, version) = setup_platform(None, Network::Testnet, None);
+
+        let request = GetContestedResourceIdentityVotesRequestV0 {
+            identity_id: vec![0; 32],
+            limit: None,
+            offset: None,
+            order_ascending: true,
+            start_at_vote_poll_id_info: None,
+            prove: true,
+        };
+
+        let result = platform
+            .query_contested_resource_identity_votes_v0(request, &state, version)
+            .expect("expected query to succeed");
+
+        assert!(matches!(
+            result.data,
+            Some(GetContestedResourceIdentityVotesResponseV0 {
+                result: Some(get_contested_resource_identity_votes_response_v0::Result::Proof(_),),
+                metadata: Some(_),
+            })
+        ));
+    }
+
+    #[test]
+    fn test_query_contested_resource_identity_votes_limit_above_max_is_error() {
+        // `limit` that overflows u16 takes the `.ok_or(...)?` path and surfaces
+        // a Drive(Query(InvalidLimit)) error via `Err(_)` rather than as a
+        // validation error in the response.
+        let (platform, state, version) = setup_platform(None, Network::Testnet, None);
+
+        let request = GetContestedResourceIdentityVotesRequestV0 {
+            identity_id: vec![0; 32],
+            limit: Some((u16::MAX as u32) + 1),
+            offset: None,
+            order_ascending: true,
+            start_at_vote_poll_id_info: None,
+            prove: false,
+        };
+
+        let err = platform
+            .query_contested_resource_identity_votes_v0(request, &state, version)
+            .expect_err("oversized limit should propagate an Err");
+
+        let msg = format!("{:?}", err);
+        assert!(
+            msg.contains("InvalidLimit") || msg.contains("limit"),
+            "unexpected error: {msg}"
+        );
+    }
+
+    #[test]
+    fn test_query_contested_resource_identity_votes_limit_zero_is_error() {
+        let (platform, state, version) = setup_platform(None, Network::Testnet, None);
+
+        let request = GetContestedResourceIdentityVotesRequestV0 {
+            identity_id: vec![0; 32],
+            limit: Some(0),
+            offset: None,
+            order_ascending: true,
+            start_at_vote_poll_id_info: None,
+            prove: false,
+        };
+
+        let err = platform
+            .query_contested_resource_identity_votes_v0(request, &state, version)
+            .expect_err("limit=0 should propagate an Err");
+
+        let msg = format!("{:?}", err);
+        assert!(
+            msg.contains("InvalidLimit") || msg.contains("limit"),
+            "unexpected error: {msg}"
+        );
+    }
+
+    #[test]
+    fn test_query_contested_resource_identity_votes_descending_empty() {
+        // Exercise the descending branch of the `start_at` computation and the
+        // no-data path where `finished_results` short-circuits to true.
+        let (platform, state, version) = setup_platform(None, Network::Testnet, None);
+
+        let request = GetContestedResourceIdentityVotesRequestV0 {
+            identity_id: vec![0; 32],
+            limit: Some(1),
+            offset: None,
+            order_ascending: false,
+            start_at_vote_poll_id_info: None,
+            prove: false,
+        };
+
+        let result = platform
+            .query_contested_resource_identity_votes_v0(request, &state, version)
+            .expect("expected query to succeed");
+
+        assert!(matches!(
+            result.data,
+            Some(GetContestedResourceIdentityVotesResponseV0 {
+                result: Some(
+                    get_contested_resource_identity_votes_response_v0::Result::Votes(
+                        get_contested_resource_identity_votes_response_v0::ContestedResourceIdentityVotes {
+                            contested_resource_identity_votes,
+                            finished_results,
+                        },
+                    ),
+                ),
+                metadata: Some(_),
+            }) if contested_resource_identity_votes.is_empty() && finished_results
+        ));
+    }
 }

--- a/packages/rs-drive-abci/src/query/voting/contested_resource_vote_state/v0/mod.rs
+++ b/packages/rs-drive-abci/src/query/voting/contested_resource_vote_state/v0/mod.rs
@@ -315,4 +315,87 @@ mod tests {
             [QueryError::Query(QuerySyntaxError::DataContractNotFound(_))]
         ));
     }
+
+    #[test]
+    fn test_query_contested_resource_vote_state_contract_not_found_prove() {
+        // Exercises the prove branch dispatch when the contract is missing.
+        let (platform, state, version) = setup_platform(None, Network::Testnet, None);
+
+        let request = GetContestedResourceVoteStateRequestV0 {
+            contract_id: vec![0; 32],
+            document_type_name: "x".to_string(),
+            index_name: "x".to_string(),
+            index_values: vec![],
+            result_type: 0,
+            allow_include_locked_and_abstaining_vote_tally: false,
+            start_at_identifier_info: None,
+            count: None,
+            prove: true,
+        };
+
+        let result = platform
+            .query_contested_resource_vote_state_v0(request, &state, version)
+            .expect("expected query to succeed");
+
+        // The contract-not-found check fires before the prove split, so this
+        // still returns a DataContractNotFound error.
+        assert!(matches!(
+            result.errors.as_slice(),
+            [QueryError::Query(QuerySyntaxError::DataContractNotFound(_))]
+        ));
+    }
+
+    #[test]
+    fn test_query_contested_resource_vote_state_count_zero_rejected() {
+        // count = 0 must be rejected as out-of-bounds.
+        let (platform, state, version) = setup_platform(None, Network::Testnet, None);
+
+        let request = GetContestedResourceVoteStateRequestV0 {
+            contract_id: vec![0; 8], // fail before the contract is needed
+            document_type_name: "x".to_string(),
+            index_name: "x".to_string(),
+            index_values: vec![],
+            result_type: 0,
+            allow_include_locked_and_abstaining_vote_tally: false,
+            start_at_identifier_info: None,
+            count: Some(0),
+            prove: false,
+        };
+
+        let result = platform
+            .query_contested_resource_vote_state_v0(request, &state, version)
+            .expect("expected query to succeed");
+
+        // The contract_id check runs first; contract_id (vec![0; 8]) is invalid.
+        assert!(matches!(
+            result.errors.as_slice(),
+            [QueryError::InvalidArgument(msg)] if msg.contains("contract_id must be a valid identifier")
+        ));
+    }
+
+    #[test]
+    fn test_query_contested_resource_vote_state_count_out_of_bounds_u16() {
+        // count overflowing u16 should flag "limit out of bounds" - but
+        // contract_id validation runs first, so this primarily guards against
+        // changes that reorder validation.
+        let (platform, state, version) = setup_platform(None, Network::Testnet, None);
+
+        let request = GetContestedResourceVoteStateRequestV0 {
+            contract_id: vec![0; 8],
+            document_type_name: "x".to_string(),
+            index_name: "x".to_string(),
+            index_values: vec![],
+            result_type: 0,
+            allow_include_locked_and_abstaining_vote_tally: false,
+            start_at_identifier_info: None,
+            count: Some((u16::MAX as u32) + 1),
+            prove: false,
+        };
+
+        let result = platform
+            .query_contested_resource_vote_state_v0(request, &state, version)
+            .expect("expected query to succeed");
+
+        assert!(!result.errors.is_empty());
+    }
 }

--- a/packages/rs-drive-abci/src/query/voting/contested_resource_vote_state/v0/mod.rs
+++ b/packages/rs-drive-abci/src/query/voting/contested_resource_vote_state/v0/mod.rs
@@ -345,13 +345,17 @@ mod tests {
         ));
     }
 
+    /// NOTE: the `count` guards on lines 132-142 are not reachable here
+    /// without a valid 32-byte `contract_id` + an existing contract, so
+    /// these two tests deliberately pin validation **ordering** — i.e.
+    /// that `contract_id.try_into()` fires before the count checks. They
+    /// both assert the same `InvalidArgument("contract_id …")` message.
     #[test]
-    fn test_query_contested_resource_vote_state_count_zero_rejected() {
-        // count = 0 must be rejected as out-of-bounds.
+    fn test_query_contested_resource_vote_state_invalid_contract_id_runs_before_count_zero() {
         let (platform, state, version) = setup_platform(None, Network::Testnet, None);
 
         let request = GetContestedResourceVoteStateRequestV0 {
-            contract_id: vec![0; 8], // fail before the contract is needed
+            contract_id: vec![0; 8],
             document_type_name: "x".to_string(),
             index_name: "x".to_string(),
             index_values: vec![],
@@ -366,7 +370,6 @@ mod tests {
             .query_contested_resource_vote_state_v0(request, &state, version)
             .expect("expected query to succeed");
 
-        // The contract_id check runs first; contract_id (vec![0; 8]) is invalid.
         assert!(matches!(
             result.errors.as_slice(),
             [QueryError::InvalidArgument(msg)] if msg.contains("contract_id must be a valid identifier")
@@ -374,10 +377,7 @@ mod tests {
     }
 
     #[test]
-    fn test_query_contested_resource_vote_state_count_out_of_bounds_u16() {
-        // count overflowing u16 should flag "limit out of bounds" - but
-        // contract_id validation runs first, so this primarily guards against
-        // changes that reorder validation.
+    fn test_query_contested_resource_vote_state_invalid_contract_id_runs_before_count_over_u16() {
         let (platform, state, version) = setup_platform(None, Network::Testnet, None);
 
         let request = GetContestedResourceVoteStateRequestV0 {
@@ -396,6 +396,10 @@ mod tests {
             .query_contested_resource_vote_state_v0(request, &state, version)
             .expect("expected query to succeed");
 
-        assert!(!result.errors.is_empty());
+        // Same `contract_id` error as above — confirms validation ordering.
+        assert!(matches!(
+            result.errors.as_slice(),
+            [QueryError::InvalidArgument(msg)] if msg.contains("contract_id must be a valid identifier")
+        ));
     }
 }

--- a/packages/rs-drive-abci/src/query/voting/contested_resource_voters_for_identity/v0/mod.rs
+++ b/packages/rs-drive-abci/src/query/voting/contested_resource_voters_for_identity/v0/mod.rs
@@ -333,4 +333,62 @@ mod tests {
             [QueryError::Query(QuerySyntaxError::DataContractNotFound(_))]
         ));
     }
+
+    #[test]
+    fn test_query_voters_contract_not_found_prove() {
+        // Dispatch reaches the fetch_contract step, so prove=true still
+        // reports DataContractNotFound before the prove branch runs.
+        let (platform, state, version) = setup_platform(None, Network::Testnet, None);
+
+        let request = GetContestedResourceVotersForIdentityRequestV0 {
+            contract_id: vec![0; 32],
+            document_type_name: "x".to_string(),
+            index_name: "x".to_string(),
+            index_values: vec![],
+            contestant_id: vec![0; 32],
+            start_at_identifier_info: None,
+            count: None,
+            order_ascending: true,
+            prove: true,
+        };
+
+        let result = platform
+            .query_contested_resource_voters_for_identity_v0(request, &state, version)
+            .expect("expected query to succeed");
+
+        assert!(matches!(
+            result.errors.as_slice(),
+            [QueryError::Query(QuerySyntaxError::DataContractNotFound(_))]
+        ));
+    }
+
+    #[test]
+    fn test_query_voters_count_zero_rejected() {
+        // count = 0 must be rejected as out-of-bounds; but contract_id is
+        // validated first, so this also verifies that validation order.
+        let (platform, state, version) = setup_platform(None, Network::Testnet, None);
+
+        let request = GetContestedResourceVotersForIdentityRequestV0 {
+            contract_id: vec![0; 32],
+            document_type_name: "x".to_string(),
+            index_name: "x".to_string(),
+            index_values: vec![],
+            contestant_id: vec![0; 32],
+            start_at_identifier_info: None,
+            count: Some(0),
+            order_ascending: true,
+            prove: false,
+        };
+
+        let result = platform
+            .query_contested_resource_voters_for_identity_v0(request, &state, version)
+            .expect("expected query to succeed");
+
+        // Contract lookup fires before `count` validation, so we see the
+        // DataContractNotFound error here.
+        assert!(matches!(
+            result.errors.as_slice(),
+            [QueryError::Query(QuerySyntaxError::DataContractNotFound(_))]
+        ));
+    }
 }

--- a/packages/rs-drive-abci/src/query/voting/contested_resources/v0/mod.rs
+++ b/packages/rs-drive-abci/src/query/voting/contested_resources/v0/mod.rs
@@ -294,4 +294,62 @@ mod tests {
             [QueryError::Query(QuerySyntaxError::DataContractNotFound(_))]
         ));
     }
+
+    #[test]
+    fn test_query_contested_resources_contract_not_found_prove() {
+        let (platform, state, version) = setup_platform(None, Network::Testnet, None);
+
+        let request = GetContestedResourcesRequestV0 {
+            contract_id: vec![0; 32],
+            document_type_name: "x".to_string(),
+            index_name: "x".to_string(),
+            start_index_values: vec![],
+            end_index_values: vec![],
+            start_at_value_info: None,
+            count: None,
+            order_ascending: true,
+            prove: true,
+        };
+
+        let result = platform
+            .query_contested_resources_v0(request, &state, version)
+            .expect("expected query to succeed");
+
+        // Contract lookup runs before the prove/no-prove split.
+        assert!(matches!(
+            result.errors.as_slice(),
+            [QueryError::Query(QuerySyntaxError::DataContractNotFound(_))]
+        ));
+    }
+
+    #[test]
+    fn test_query_contested_resources_short_contract_id_rejected() {
+        // Verify the InvalidArgument message for a too-short contract_id
+        // includes the "contested resources query" suffix specific to this
+        // endpoint.
+        let (platform, state, version) = setup_platform(None, Network::Testnet, None);
+
+        let request = GetContestedResourcesRequestV0 {
+            contract_id: vec![0; 31], // off-by-one short
+            document_type_name: "x".to_string(),
+            index_name: "x".to_string(),
+            start_index_values: vec![],
+            end_index_values: vec![],
+            start_at_value_info: None,
+            count: None,
+            order_ascending: true,
+            prove: false,
+        };
+
+        let result = platform
+            .query_contested_resources_v0(request, &state, version)
+            .expect("expected query to succeed");
+
+        assert!(matches!(
+            result.errors.as_slice(),
+            [QueryError::InvalidArgument(msg)]
+                if msg.contains("contract_id must be a valid identifier")
+                    && msg.contains("contested resources query")
+        ));
+    }
 }

--- a/packages/rs-drive-abci/src/query/voting/vote_polls_by_end_date_query/v0/mod.rs
+++ b/packages/rs-drive-abci/src/query/voting/vote_polls_by_end_date_query/v0/mod.rs
@@ -388,4 +388,83 @@ mod tests {
             }) if vote_polls_by_timestamps.is_empty() && finished_results
         ));
     }
+
+    #[test]
+    fn test_query_vote_polls_by_end_date_limit_out_of_u16_range() {
+        // limit > u16::MAX triggers the u16::try_from failure path.
+        let (platform, state, version) = setup_platform(None, Network::Testnet, None);
+
+        let request = GetVotePollsByEndDateRequestV0 {
+            start_time_info: None,
+            end_time_info: None,
+            limit: Some((u16::MAX as u32) + 1),
+            offset: None,
+            ascending: true,
+            prove: false,
+        };
+
+        let result = platform
+            .query_vote_polls_by_end_date_query_v0(request, &state, version)
+            .expect("expected query to succeed");
+
+        assert!(matches!(
+            result.errors.as_slice(),
+            [QueryError::InvalidArgument(msg)] if msg.contains("limit out of bounds")
+        ));
+    }
+
+    #[test]
+    fn test_query_vote_polls_by_end_date_limit_above_default_but_within_u16() {
+        // A limit that fits in u16 but exceeds default_query_limit should be
+        // rejected with the "out of bounds of [1, <default>]" message.
+        let (platform, state, version) = setup_platform(None, Network::Testnet, None);
+
+        let over_default = (platform.config.drive.default_query_limit as u32).saturating_add(1);
+
+        let request = GetVotePollsByEndDateRequestV0 {
+            start_time_info: None,
+            end_time_info: None,
+            limit: Some(over_default),
+            offset: None,
+            ascending: true,
+            prove: false,
+        };
+
+        let result = platform
+            .query_vote_polls_by_end_date_query_v0(request, &state, version)
+            .expect("expected query to succeed");
+
+        assert!(matches!(
+            result.errors.as_slice(),
+            [QueryError::InvalidArgument(msg)] if msg.contains("out of bounds of")
+        ));
+    }
+
+    #[test]
+    fn test_query_vote_polls_by_end_date_empty_prove() {
+        // Exercise the prove=true branch with offset=None so the
+        // RequestingProofWithOffset guard is skipped.
+        let (platform, state, version) = setup_platform(None, Network::Testnet, None);
+
+        let request = GetVotePollsByEndDateRequestV0 {
+            start_time_info: None,
+            end_time_info: None,
+            limit: None,
+            offset: None,
+            ascending: true,
+            prove: true,
+        };
+
+        let result = platform
+            .query_vote_polls_by_end_date_query_v0(request, &state, version)
+            .expect("expected query to succeed");
+
+        assert!(matches!(
+            result.data,
+            Some(GetVotePollsByEndDateResponseV0 {
+                result: Some(get_vote_polls_by_end_date_response_v0::Result::Proof(_)),
+                metadata: Some(_),
+            })
+        ));
+    }
 }

--- a/packages/rs-drive/src/drive/balances/mod.rs
+++ b/packages/rs-drive/src/drive/balances/mod.rs
@@ -130,6 +130,7 @@ pub(crate) fn balance_path_vec() -> Vec<Vec<u8>> {
 #[cfg(feature = "server")]
 #[cfg(test)]
 mod tests {
+    use super::*;
     use crate::drive::Drive;
 
     use crate::util::test_helpers::setup::setup_drive_with_initial_state_structure;
@@ -146,5 +147,143 @@ mod tests {
             .calculate_total_credits_balance(Some(&db_transaction), &platform_version.drive)
             .expect("expected to get the result of the verification");
         assert!(credits_match_expected.ok().expect("no overflow"));
+    }
+
+    mod path_helpers {
+        use super::*;
+
+        #[test]
+        fn total_credits_path_is_two_elements() {
+            let p = total_credits_path();
+            assert_eq!(p.len(), 2);
+            assert_eq!(p[1], TOTAL_SYSTEM_CREDITS_STORAGE_KEY);
+        }
+
+        #[test]
+        fn total_credits_path_vec_matches_array_form() {
+            let arr = total_credits_path();
+            let v = total_credits_path_vec();
+            assert_eq!(v.len(), arr.len());
+            for (a, b) in arr.iter().zip(v.iter()) {
+                assert_eq!(*a, b.as_slice());
+            }
+        }
+
+        #[test]
+        fn total_credits_on_platform_path_query_single_key() {
+            let q = total_credits_on_platform_path_query();
+            assert_eq!(q.path.len(), 1);
+            assert_eq!(q.query.limit, Some(1));
+            assert!(q.query.offset.is_none());
+        }
+
+        #[test]
+        fn total_tokens_root_supply_path_is_two_elements() {
+            let p = total_tokens_root_supply_path();
+            assert_eq!(p.len(), 2);
+            assert_eq!(p[1], TOTAL_TOKEN_SUPPLIES_STORAGE_KEY);
+        }
+
+        #[test]
+        fn total_tokens_root_supply_path_vec_matches_array() {
+            let arr = total_tokens_root_supply_path();
+            let v = total_tokens_root_supply_path_vec();
+            assert_eq!(v.len(), arr.len());
+            for (a, b) in arr.iter().zip(v.iter()) {
+                assert_eq!(*a, b.as_slice());
+            }
+        }
+
+        #[test]
+        fn total_token_supply_paths_include_token_id() {
+            let token_id = [7u8; 32];
+            let p = total_token_supply_path(&token_id);
+            assert_eq!(p.len(), 3);
+            assert_eq!(p[2], &token_id);
+
+            let v = total_token_supply_path_vec(token_id);
+            assert_eq!(v.len(), 3);
+            assert_eq!(v[2], token_id.to_vec());
+        }
+
+        #[test]
+        fn total_supply_for_token_path_query_uses_token_id() {
+            let token_id = [0xAAu8; 32];
+            let q = total_supply_for_token_on_platform_path_query(token_id);
+            assert_eq!(q.path.len(), 2);
+            assert_eq!(q.query.limit, Some(1));
+        }
+
+        #[test]
+        fn balance_path_has_single_segment() {
+            let bp = balance_path();
+            assert_eq!(bp.len(), 1);
+            let bpv = balance_path_vec();
+            assert_eq!(bpv.len(), 1);
+            assert_eq!(bp[0], bpv[0].as_slice());
+        }
+    }
+
+    mod add_remove_credits {
+        use super::*;
+
+        #[test]
+        fn add_then_remove_roundtrip() {
+            let drive: Drive = setup_drive_with_initial_state_structure(None);
+            let tx = drive.grove.start_transaction();
+            let pv = PlatformVersion::latest();
+
+            // Snapshot before
+            let before = drive
+                .calculate_total_credits_balance(Some(&tx), &pv.drive)
+                .expect("calc before");
+            let before_total = before.total_credits_in_platform;
+
+            // Add 1_000_000 credits
+            drive
+                .add_to_system_credits(1_000_000, Some(&tx), pv)
+                .expect("add credits");
+
+            let after_add = drive
+                .calculate_total_credits_balance(Some(&tx), &pv.drive)
+                .expect("calc after add");
+            assert_eq!(
+                after_add.total_credits_in_platform,
+                before_total + 1_000_000
+            );
+
+            // Remove them again
+            drive
+                .remove_from_system_credits(1_000_000, Some(&tx), pv)
+                .expect("remove credits");
+
+            let after_remove = drive
+                .calculate_total_credits_balance(Some(&tx), &pv.drive)
+                .expect("calc after remove");
+            assert_eq!(after_remove.total_credits_in_platform, before_total);
+        }
+
+        #[test]
+        fn add_zero_credits_is_noop() {
+            let drive: Drive = setup_drive_with_initial_state_structure(None);
+            let tx = drive.grove.start_transaction();
+            let pv = PlatformVersion::latest();
+
+            let before = drive
+                .calculate_total_credits_balance(Some(&tx), &pv.drive)
+                .expect("before");
+
+            drive
+                .add_to_system_credits(0, Some(&tx), pv)
+                .expect("add zero");
+
+            let after = drive
+                .calculate_total_credits_balance(Some(&tx), &pv.drive)
+                .expect("after");
+            assert_eq!(
+                before.total_credits_in_platform,
+                after.total_credits_in_platform
+            );
+        }
     }
 }

--- a/packages/rs-drive/src/drive/document/delete/mod.rs
+++ b/packages/rs-drive/src/drive/document/delete/mod.rs
@@ -1443,8 +1443,14 @@ mod tests {
             Some(&EPOCH_CHANGE_FEE_VERSION_TEST),
         );
 
-        // Either succeeds (estimation path can be more permissive) or errors;
-        // whichever happens, it exercises the previously-uncovered branch.
-        let _ = result;
+        // The estimation-costs branch (apply=false) uses fake cost estimates
+        // instead of real grove operations, so it succeeds whether or not
+        // the document actually exists — what matters is that the branch is
+        // exercised end-to-end and produces a non-zero fee estimate.
+        let fees = result.expect("estimation path should succeed for nonexistent document");
+        assert!(
+            fees.processing_fee > 0 || fees.storage_fee > 0,
+            "expected non-zero fee estimate from estimation path, got {fees:?}"
+        );
     }
 }

--- a/packages/rs-drive/src/drive/document/delete/mod.rs
+++ b/packages/rs-drive/src/drive/document/delete/mod.rs
@@ -1308,4 +1308,143 @@ mod tests {
             Error::Drive(DriveError::InvalidDeletionOfDocumentThatKeepsHistory(_))
         ));
     }
+
+    // ---------- Error-path tests (added for coverage) ----------
+
+    #[test]
+    fn test_delete_document_for_contract_id_nonexistent_contract_returns_error() {
+        // `delete_document_for_contract_id` resolves the contract by id. A random
+        // id that does not exist in the drive must surface as
+        // DocumentError::DataContractNotFound.
+        use crate::error::document::DocumentError;
+
+        let drive = setup_drive_with_initial_state_structure(None);
+        let platform_version = PlatformVersion::latest();
+
+        let nonexistent_contract_id = Identifier::from(rand::thread_rng().gen::<[u8; 32]>());
+        let random_document_id = Identifier::random();
+
+        let err = drive
+            .delete_document_for_contract_id(
+                random_document_id,
+                nonexistent_contract_id,
+                "person",
+                BlockInfo::default(),
+                true,
+                None,
+                platform_version,
+                Some(&EPOCH_CHANGE_FEE_VERSION_TEST),
+            )
+            .expect_err("expected delete_document_for_contract_id with bad contract id to fail");
+
+        assert!(
+            matches!(err, Error::Document(DocumentError::DataContractNotFound)),
+            "expected DataContractNotFound, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn test_delete_document_for_contract_nonexistent_document_type_returns_error() {
+        // `delete_document_for_contract` must surface an error if the document
+        // type name is not present on the contract (hits
+        // DataContract::document_type_for_name `?` error branch).
+        let (drive, contract) = setup_dashpay("delete-bad-doc-type", true);
+        let platform_version = PlatformVersion::latest();
+
+        let random_document_id = Identifier::random();
+
+        let err = drive
+            .delete_document_for_contract(
+                random_document_id,
+                &contract,
+                "not_a_real_document_type",
+                BlockInfo::default(),
+                true,
+                None,
+                platform_version,
+                Some(&EPOCH_CHANGE_FEE_VERSION_TEST),
+            )
+            .expect_err("expected delete_document_for_contract with bad type to fail");
+
+        // Should NOT be a "contract not found" error — the contract exists.
+        assert!(
+            !matches!(
+                err,
+                Error::Document(crate::error::document::DocumentError::DataContractNotFound)
+            ),
+            "expected a document-type error, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn test_delete_document_for_contract_id_with_named_type_operations_bad_contract() {
+        // Exercises the pub-facing
+        // `delete_document_for_contract_id_with_named_type_operations` variant
+        // which has its own DataContractNotFound error branch (via the
+        // `let Some(...) = ... else { return Err(...); }` pattern).
+        use crate::error::document::DocumentError;
+        use grovedb::batch::KeyInfoPath;
+        use grovedb::EstimatedLayerInformation;
+        use std::collections::HashMap;
+
+        let drive = setup_drive_with_initial_state_structure(None);
+        let platform_version = PlatformVersion::latest();
+        let epoch = Epoch::new(0).unwrap();
+
+        let nonexistent_contract_id = Identifier::from(rand::thread_rng().gen::<[u8; 32]>());
+        let random_document_id = Identifier::random();
+
+        let mut estimated_costs_only_with_layer_info: Option<
+            HashMap<KeyInfoPath, EstimatedLayerInformation>,
+        > = None;
+
+        let err = drive
+            .delete_document_for_contract_id_with_named_type_operations(
+                random_document_id,
+                nonexistent_contract_id,
+                "profile",
+                &epoch,
+                None,
+                &mut estimated_costs_only_with_layer_info,
+                None,
+                platform_version,
+            )
+            .expect_err(
+                "expected delete_document_for_contract_id_with_named_type_operations to fail",
+            );
+
+        assert!(
+            matches!(err, Error::Document(DocumentError::DataContractNotFound)),
+            "expected DataContractNotFound, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn test_delete_nonexistent_document_without_apply_estimation_costs() {
+        // Delete a nonexistent document with apply=false to exercise the
+        // estimation-costs branch (different control flow than the apply=true
+        // branch already covered).
+        let (drive, contract) = setup_dashpay("delete-nonexist-estimate", true);
+        let platform_version = PlatformVersion::latest();
+
+        let document_id = Identifier::random();
+
+        // With apply=false the code takes the estimated_costs_only_with_layer_info
+        // = Some(HashMap::new()) branch. The document does not exist, so we
+        // expect an error, but a different one than the stateful path.
+        let result = drive.delete_document_for_contract(
+            document_id,
+            &contract,
+            "profile",
+            BlockInfo::default(),
+            false,
+            None,
+            platform_version,
+            Some(&EPOCH_CHANGE_FEE_VERSION_TEST),
+        );
+
+        // Either succeeds (estimation path can be more permissive) or errors;
+        // whichever happens, it exercises the previously-uncovered branch.
+        let _ = result;
+    }
 }

--- a/packages/rs-drive/src/drive/document/insert/mod.rs
+++ b/packages/rs-drive/src/drive/document/insert/mod.rs
@@ -1332,4 +1332,113 @@ mod tests {
             "expected both documents to be present after batch insertion"
         );
     }
+
+    // ---------- Error-path tests (added for coverage) ----------
+
+    #[test]
+    fn test_add_document_with_nonexistent_contract_id_returns_data_contract_not_found() {
+        // `add_document` takes a contract_id and must resolve it internally.
+        // Supplying a random id that does not exist should fail with
+        // DocumentError::DataContractNotFound (instead of, e.g., a panic or
+        // lower-level grovedb error).
+        use crate::error::document::DocumentError;
+
+        let (drive, contract) = setup_dashpay("add-doc-nonexistent-contract", true);
+
+        let platform_version = PlatformVersion::latest();
+
+        let document_type = contract
+            .document_type_for_name("profile")
+            .expect("profile document exists");
+
+        let random_owner_id = random::<[u8; 32]>();
+
+        let document = json_document_to_document(
+            "tests/supporting_files/contract/dashpay/profile0.json",
+            Some(random_owner_id.into()),
+            document_type,
+            platform_version,
+        )
+        .expect("expected to get document");
+
+        let nonexistent_contract_id: [u8; 32] = random();
+
+        let err = drive
+            .add_document(
+                OwnedDocumentInfo {
+                    document_info: DocumentRefInfo((
+                        &document,
+                        StorageFlags::optional_default_as_cow(),
+                    )),
+                    owner_id: Some(random_owner_id),
+                },
+                nonexistent_contract_id.into(),
+                "profile",
+                false,
+                &BlockInfo::default(),
+                true,
+                None,
+                platform_version,
+            )
+            .expect_err("expected add_document with nonexistent contract id to fail");
+
+        assert!(
+            matches!(err, Error::Document(DocumentError::DataContractNotFound)),
+            "expected DataContractNotFound, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn test_add_document_with_invalid_document_type_name_returns_error() {
+        // `add_document` should fail when given a document type name that does
+        // not exist in the contract (contract.document_type_for_name(...) ?).
+        let (drive, contract) = setup_dashpay("add-doc-bad-type", true);
+
+        let platform_version = PlatformVersion::latest();
+
+        let document_type = contract
+            .document_type_for_name("profile")
+            .expect("profile document exists");
+
+        let random_owner_id = random::<[u8; 32]>();
+
+        let document = json_document_to_document(
+            "tests/supporting_files/contract/dashpay/profile0.json",
+            Some(random_owner_id.into()),
+            document_type,
+            platform_version,
+        )
+        .expect("expected to get document");
+
+        let err = drive
+            .add_document(
+                OwnedDocumentInfo {
+                    document_info: DocumentRefInfo((
+                        &document,
+                        StorageFlags::optional_default_as_cow(),
+                    )),
+                    owner_id: Some(random_owner_id),
+                },
+                contract.id(),
+                "not_a_real_document_type",
+                false,
+                &BlockInfo::default(),
+                true,
+                None,
+                platform_version,
+            )
+            .expect_err("expected add_document with bad document type to fail");
+
+        // The error originates from DataContract::document_type_for_name, which
+        // maps through the `?` into an Error. We don't match a specific variant
+        // because that depends on dpp's mapping, but we verify it's not a
+        // contract-not-found error (which would be the other likely branch).
+        assert!(
+            !matches!(
+                err,
+                Error::Document(crate::error::document::DocumentError::DataContractNotFound)
+            ),
+            "expected a document-type error, not DataContractNotFound: {err:?}"
+        );
+    }
 }

--- a/packages/rs-drive/src/drive/document/update/mod.rs
+++ b/packages/rs-drive/src/drive/document/update/mod.rs
@@ -2405,4 +2405,209 @@ mod tests {
             "displayName should have been updated to Bob"
         );
     }
+
+    // ---------- Error-path tests (added for coverage) ----------
+
+    #[test]
+    fn test_update_document_for_contract_id_nonexistent_contract_returns_error() {
+        // `update_document_for_contract_id` resolves the contract by id.
+        // A nonexistent id must yield DocumentError::DataContractNotFound.
+        use crate::error::document::DocumentError;
+
+        let drive = setup_drive_with_initial_state_structure(None);
+        let platform_version = PlatformVersion::latest();
+
+        // Arbitrary serialized bytes - we never reach the deserialize step
+        // because the contract lookup fails first.
+        let dummy_serialized = vec![0u8; 32];
+        let nonexistent_contract_id: [u8; 32] = random();
+
+        let err = drive
+            .update_document_for_contract_id(
+                &dummy_serialized,
+                nonexistent_contract_id,
+                "profile",
+                None,
+                BlockInfo::default(),
+                true,
+                StorageFlags::optional_default_as_cow(),
+                None,
+                platform_version,
+                Some(&EPOCH_CHANGE_FEE_VERSION_TEST),
+            )
+            .expect_err("expected update_document_for_contract_id to fail");
+
+        assert!(
+            matches!(err, Error::Document(DocumentError::DataContractNotFound)),
+            "expected DataContractNotFound, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn test_update_document_for_contract_id_invalid_document_type_returns_error() {
+        // The contract exists, but the document_type_name does not. This
+        // exercises the `contract.document_type_for_name(...)?` error branch
+        // in update_document_for_contract_id_v0.
+        let (drive, contract) = setup_dashpay("update-by-id-bad-type", true);
+        let platform_version = PlatformVersion::latest();
+
+        let dummy_serialized = vec![0u8; 32];
+
+        let err = drive
+            .update_document_for_contract_id(
+                &dummy_serialized,
+                contract.id().to_buffer(),
+                "not_a_real_document_type",
+                None,
+                BlockInfo::default(),
+                true,
+                StorageFlags::optional_default_as_cow(),
+                None,
+                platform_version,
+                Some(&EPOCH_CHANGE_FEE_VERSION_TEST),
+            )
+            .expect_err("expected update_document_for_contract_id with bad type to fail");
+
+        assert!(
+            !matches!(
+                err,
+                Error::Document(crate::error::document::DocumentError::DataContractNotFound)
+            ),
+            "expected a document-type error, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn test_update_document_for_contract_id_malformed_serialized_returns_error() {
+        // Contract & document type exist, but the serialized bytes are not a
+        // valid document. This exercises the `Document::from_bytes(...)?`
+        // error branch in update_document_for_contract_id_v0.
+        let (drive, contract) = setup_dashpay("update-by-id-bad-bytes", true);
+        let platform_version = PlatformVersion::latest();
+
+        // Definitively malformed: all zeros won't be a valid serialized doc.
+        let malformed = vec![0xFFu8; 8];
+
+        let err = drive
+            .update_document_for_contract_id(
+                &malformed,
+                contract.id().to_buffer(),
+                "profile",
+                None,
+                BlockInfo::default(),
+                true,
+                StorageFlags::optional_default_as_cow(),
+                None,
+                platform_version,
+                Some(&EPOCH_CHANGE_FEE_VERSION_TEST),
+            )
+            .expect_err("expected update_document_for_contract_id with malformed bytes to fail");
+
+        // Should NOT be a contract-not-found error - the contract is valid.
+        assert!(
+            !matches!(
+                err,
+                Error::Document(crate::error::document::DocumentError::DataContractNotFound)
+            ),
+            "expected a deserialization error, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn test_update_document_with_serialization_for_contract_invalid_document_type() {
+        // Exercises the `contract.document_type_for_name(...)?` error branch in
+        // update_document_with_serialization_for_contract_v0.
+        let (drive, contract) = setup_dashpay("update-ser-bad-type", true);
+        let platform_version = PlatformVersion::latest();
+
+        // Build a valid document & serialization against the real profile type
+        // so that we reach `document_type_for_name` with a bad name, not fail
+        // earlier elsewhere.
+        let document_type = contract
+            .document_type_for_name("profile")
+            .expect("profile document exists");
+
+        let owner_id: Identifier = random::<[u8; 32]>().into();
+
+        let document = document_type
+            .create_document_from_data(
+                platform_value!({"displayName": "Alice"}),
+                owner_id,
+                random(),
+                random(),
+                random(),
+                platform_version,
+            )
+            .expect("should create document");
+
+        let serialized = DocumentPlatformConversionMethodsV0::serialize(
+            &document,
+            document_type,
+            &contract,
+            platform_version,
+        )
+        .expect("expected to serialize");
+
+        let err = drive
+            .update_document_with_serialization_for_contract(
+                &document,
+                &serialized,
+                &contract,
+                "not_a_real_document_type",
+                Some(owner_id.to_buffer()),
+                BlockInfo::default(),
+                true,
+                StorageFlags::optional_default_as_cow(),
+                None,
+                platform_version,
+                None,
+            )
+            .expect_err(
+                "expected update_document_with_serialization_for_contract with bad type to fail",
+            );
+
+        // Make sure this is not a DataContractNotFound - the contract is valid.
+        assert!(
+            !matches!(
+                err,
+                Error::Document(crate::error::document::DocumentError::DataContractNotFound)
+            ),
+            "expected a document-type error, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn test_update_document_for_contract_id_v0_without_apply_dry_run_nonexistent_contract() {
+        // Exercises the estimation-costs branch (apply=false) combined with a
+        // nonexistent contract to verify the branch ordering: contract lookup
+        // occurs before estimation path setup matters, so we still get
+        // DataContractNotFound even with apply=false.
+        use crate::error::document::DocumentError;
+
+        let drive = setup_drive_with_initial_state_structure(None);
+        let platform_version = PlatformVersion::latest();
+
+        let dummy_serialized = vec![0u8; 32];
+        let nonexistent_contract_id: [u8; 32] = random();
+
+        let err = drive
+            .update_document_for_contract_id(
+                &dummy_serialized,
+                nonexistent_contract_id,
+                "profile",
+                None,
+                BlockInfo::default(),
+                false, // apply=false ⇒ estimated costs path
+                StorageFlags::optional_default_as_cow(),
+                None,
+                platform_version,
+                Some(&EPOCH_CHANGE_FEE_VERSION_TEST),
+            )
+            .expect_err("expected update_document_for_contract_id (dry run) to fail");
+
+        assert!(
+            matches!(err, Error::Document(DocumentError::DataContractNotFound)),
+            "expected DataContractNotFound, got {err:?}"
+        );
+    }
 }

--- a/packages/rs-drive/src/drive/votes/mod.rs
+++ b/packages/rs-drive/src/drive/votes/mod.rs
@@ -111,3 +111,158 @@ impl ResourceVoteChoiceToKeyTrait for ResourceVoteChoice {
         }
     }
 }
+
+#[cfg(test)]
+#[cfg(feature = "server")]
+mod tests {
+    use super::*;
+    use dpp::identifier::Identifier;
+    use dpp::platform_value::Value;
+    use dpp::tests::fixtures::get_dpns_data_contract_fixture;
+    use dpp::voting::vote_polls::contested_document_resource_vote_poll::ContestedDocumentResourceVotePoll;
+    use dpp::voting::votes::resource_vote::v0::ResourceVoteV0;
+    use platform_version::version::PlatformVersion;
+
+    /// Helper: construct a ResourceVote referencing a given contract id / document type
+    /// / index name.
+    fn make_resource_vote(
+        contract_id: Identifier,
+        document_type_name: &str,
+        index_name: &str,
+    ) -> ResourceVote {
+        ResourceVote::V0(ResourceVoteV0 {
+            vote_poll: VotePoll::ContestedDocumentResourceVotePoll(
+                ContestedDocumentResourceVotePoll {
+                    contract_id,
+                    document_type_name: document_type_name.to_string(),
+                    index_name: index_name.to_string(),
+                    index_values: vec![
+                        Value::Text("dash".to_string()),
+                        Value::Text("label".to_string()),
+                    ],
+                },
+            ),
+            resource_vote_choice: ResourceVoteChoice::Abstain,
+        })
+    }
+
+    #[test]
+    fn resource_vote_choice_to_key_towards_identity_returns_identity_bytes() {
+        let id_bytes = [0xAAu8; 32];
+        let choice = ResourceVoteChoice::TowardsIdentity(Identifier::from(id_bytes));
+        let key = choice.to_key();
+        assert_eq!(key, id_bytes.to_vec());
+    }
+
+    #[test]
+    fn resource_vote_choice_to_key_abstain_matches_constant() {
+        assert_eq!(
+            ResourceVoteChoice::Abstain.to_key(),
+            RESOURCE_ABSTAIN_VOTE_TREE_KEY_U8_32.to_vec()
+        );
+    }
+
+    #[test]
+    fn resource_vote_choice_to_key_lock_matches_constant() {
+        assert_eq!(
+            ResourceVoteChoice::Lock.to_key(),
+            RESOURCE_LOCK_VOTE_TREE_KEY_U8_32.to_vec()
+        );
+    }
+
+    #[test]
+    fn resource_vote_choice_to_key_abstain_and_lock_differ() {
+        assert_ne!(
+            ResourceVoteChoice::Abstain.to_key(),
+            ResourceVoteChoice::Lock.to_key()
+        );
+    }
+
+    #[test]
+    fn tree_path_resource_vote_errors_on_contract_id_mismatch() {
+        let pv = PlatformVersion::latest();
+        let contract =
+            get_dpns_data_contract_fixture(None, 0, pv.protocol_version).data_contract_owned();
+
+        // Use a deliberately *wrong* contract id in the vote poll.
+        let wrong_contract_id = Identifier::from([0xEEu8; 32]);
+        assert_ne!(wrong_contract_id, contract.id());
+        let vote = make_resource_vote(wrong_contract_id, "domain", "parentNameAndLabel");
+
+        let err = vote.tree_path(&contract).expect_err("expected VoteError");
+        match err {
+            ProtocolError::VoteError(msg) => {
+                assert!(
+                    msg.contains("does not match supplied contract"),
+                    "msg: {msg}"
+                );
+            }
+            other => panic!("expected VoteError, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn tree_path_resource_vote_errors_on_unknown_document_type() {
+        let pv = PlatformVersion::latest();
+        let contract =
+            get_dpns_data_contract_fixture(None, 0, pv.protocol_version).data_contract_owned();
+
+        let vote = make_resource_vote(contract.id(), "not_a_real_type", "parentNameAndLabel");
+
+        let err = vote.tree_path(&contract).expect_err("expected error");
+        // Unknown document type surfaces as a DataContractError wrapped in ProtocolError.
+        // Accept any ProtocolError variant -- the important property is that it fails
+        // *before* reaching the indexes.get step.
+        assert!(
+            !matches!(err, ProtocolError::UnknownContestedIndexResolution(_)),
+            "should fail on doc_type, not on index lookup: {err:?}"
+        );
+    }
+
+    #[test]
+    fn tree_path_resource_vote_errors_on_unknown_index_name() {
+        let pv = PlatformVersion::latest();
+        let contract =
+            get_dpns_data_contract_fixture(None, 0, pv.protocol_version).data_contract_owned();
+
+        // Valid document type but bogus index name.
+        let vote = make_resource_vote(contract.id(), "domain", "no_such_index");
+
+        let err = vote.tree_path(&contract).expect_err("expected error");
+        match err {
+            ProtocolError::UnknownContestedIndexResolution(msg) => {
+                assert!(msg.contains("no index named no_such_index"), "msg: {msg}");
+            }
+            other => panic!("expected UnknownContestedIndexResolution, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn tree_path_resource_vote_ok_for_dpns_parent_name_and_label() {
+        let pv = PlatformVersion::latest();
+        let contract =
+            get_dpns_data_contract_fixture(None, 0, pv.protocol_version).data_contract_owned();
+
+        let vote = make_resource_vote(contract.id(), "domain", "parentNameAndLabel");
+
+        let path = vote.tree_path(&contract).expect("tree_path should succeed");
+        // The path must be non-empty; we don't hard-code its exact contents so the
+        // test doesn't need to be updated whenever dpns changes its contract layout.
+        assert!(!path.is_empty());
+    }
+
+    #[test]
+    fn tree_path_vote_dispatches_to_resource_vote() {
+        let pv = PlatformVersion::latest();
+        let contract =
+            get_dpns_data_contract_fixture(None, 0, pv.protocol_version).data_contract_owned();
+
+        let vote = Vote::ResourceVote(make_resource_vote(
+            contract.id(),
+            "domain",
+            "parentNameAndLabel",
+        ));
+        let path = vote.tree_path(&contract).expect("tree_path should succeed");
+        assert!(!path.is_empty());
+    }
+}

--- a/packages/rs-drive/src/drive/votes/resolved/vote_polls/contested_document_resource_vote_poll/mod.rs
+++ b/packages/rs-drive/src/drive/votes/resolved/vote_polls/contested_document_resource_vote_poll/mod.rs
@@ -342,3 +342,145 @@ impl ContestedDocumentResourceVotePollWithContractInfoAllowBorrowed<'_> {
             .map_err(|e| Error::Protocol(Box::new(ProtocolError::DataContractError(e))))
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::util::object_size_info::DataContractOwnedResolvedInfo;
+    use dpp::tests::fixtures::get_dpns_data_contract_fixture;
+    use platform_version::version::PlatformVersion;
+
+    fn make_info_with(
+        document_type_name: &str,
+        index_name: &str,
+    ) -> ContestedDocumentResourceVotePollWithContractInfo {
+        let pv = PlatformVersion::latest();
+        let data_contract =
+            get_dpns_data_contract_fixture(None, 0, pv.protocol_version).data_contract_owned();
+        ContestedDocumentResourceVotePollWithContractInfo {
+            contract: DataContractOwnedResolvedInfo::OwnedDataContract(data_contract),
+            document_type_name: document_type_name.to_string(),
+            index_name: index_name.to_string(),
+            index_values: vec![],
+        }
+    }
+
+    #[test]
+    fn owned_index_errors_when_index_not_found() {
+        let info = make_info_with("domain", "no_such_index");
+        let err = info.index().expect_err("should fail");
+        match err {
+            Error::Drive(DriveError::ContestedIndexNotFound(_)) => {}
+            other => panic!("expected ContestedIndexNotFound, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn owned_index_errors_when_document_type_missing() {
+        let info = make_info_with("no_such_doc_type", "parentNameAndLabel");
+        let _ = info.index().expect_err("should fail");
+    }
+
+    #[test]
+    fn owned_document_type_errors_when_missing() {
+        let info = make_info_with("no_such_doc_type", "parentNameAndLabel");
+        let err = info.document_type().expect_err("should fail");
+        match err {
+            Error::Protocol(boxed) => match *boxed {
+                ProtocolError::DataContractError(_) => {}
+                other => panic!("expected DataContractError, got {other:?}"),
+            },
+            other => panic!("expected Error::Protocol, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn owned_document_type_borrowed_errors_when_missing() {
+        let info = make_info_with("no_such_doc_type", "parentNameAndLabel");
+        let err = info.document_type_borrowed().expect_err("should fail");
+        match err {
+            Error::Protocol(boxed) => match *boxed {
+                ProtocolError::DataContractError(_) => {}
+                other => panic!("expected DataContractError, got {other:?}"),
+            },
+            other => panic!("expected Error::Protocol, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn owned_index_succeeds_for_valid_dpns_index() {
+        let info = make_info_with("domain", "parentNameAndLabel");
+        let idx = info.index().expect("index should resolve for dpns");
+        assert_eq!(idx.name, "parentNameAndLabel");
+    }
+
+    #[test]
+    fn owned_document_type_succeeds_for_dpns_domain() {
+        let info = make_info_with("domain", "parentNameAndLabel");
+        let doc_type = info.document_type().expect("domain should resolve");
+        assert_eq!(doc_type.name(), "domain");
+    }
+
+    #[test]
+    fn serialize_to_bytes_and_sha256_2_hash_are_deterministic() {
+        let info = make_info_with("domain", "parentNameAndLabel");
+        let bytes_a = info.serialize_to_bytes().expect("ser ok");
+        let bytes_b = info.serialize_to_bytes().expect("ser ok");
+        assert_eq!(bytes_a, bytes_b);
+        let hash_a = info.sha256_2_hash().expect("hash ok");
+        let hash_b = info.sha256_2_hash().expect("hash ok");
+        assert_eq!(hash_a, hash_b);
+        let unique = info.unique_id().expect("unique_id ok");
+        let balance = info.specialized_balance_id().expect("balance_id ok");
+        assert_eq!(unique, balance);
+        assert_eq!(unique.to_buffer(), hash_a);
+    }
+
+    #[test]
+    fn borrowed_variant_parity_with_owned_variant() {
+        let info = make_info_with("domain", "parentNameAndLabel");
+        let borrowed: ContestedDocumentResourceVotePollWithContractInfoAllowBorrowed<'_> =
+            (&info).into();
+        let owned_hash = info.sha256_2_hash().expect("owned hash ok");
+        let borrowed_hash = borrowed.sha256_2_hash().expect("borrowed hash ok");
+        assert_eq!(owned_hash, borrowed_hash);
+
+        assert_eq!(
+            borrowed.index().expect("borrowed idx").name,
+            info.index().expect("owned idx").name
+        );
+        assert_eq!(
+            borrowed.document_type().expect("borrowed dt").name(),
+            info.document_type().expect("owned dt").name()
+        );
+    }
+
+    #[test]
+    fn borrowed_index_errors_when_index_not_found() {
+        let info = make_info_with("domain", "nope");
+        let borrowed: ContestedDocumentResourceVotePollWithContractInfoAllowBorrowed<'_> =
+            (&info).into();
+        let err = borrowed.index().expect_err("should fail");
+        match err {
+            Error::Drive(DriveError::ContestedIndexNotFound(_)) => {}
+            other => panic!("expected ContestedIndexNotFound, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn borrowed_document_type_errors_when_missing() {
+        let info = make_info_with("no_such_doc_type", "parentNameAndLabel");
+        let borrowed: ContestedDocumentResourceVotePollWithContractInfoAllowBorrowed<'_> =
+            (&info).into();
+        let err = borrowed.document_type().expect_err("should fail");
+        match err {
+            Error::Protocol(_) => {}
+            other => panic!("expected Error::Protocol, got {other:?}"),
+        }
+        let err2 = borrowed.document_type_borrowed().expect_err("should fail");
+        match err2 {
+            Error::Protocol(_) => {}
+            other => panic!("expected Error::Protocol, got {other:?}"),
+        }
+    }
+}

--- a/packages/rs-drive/src/drive/votes/storage_form/contested_document_resource_storage_form/mod.rs
+++ b/packages/rs-drive/src/drive/votes/storage_form/contested_document_resource_storage_form/mod.rs
@@ -185,3 +185,225 @@ impl TreePathStorageForm for ContestedDocumentResourceVoteStorageForm {
         })
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::drive::votes::paths::ACTIVE_POLLS_TREE_KEY;
+
+    /// Build a valid 10-element path whose third element is ACTIVE_POLLS_TREE_KEY,
+    /// contract id is 32 bytes, document type name is valid UTF-8, and the
+    /// 3-before-last element is a 32-byte identity-style choice.
+    ///
+    /// Layout indices (len == 10):
+    ///   0: root (unused by this parser but required by preceding caller)
+    ///   1: (unused here)
+    ///   2: active_polls_key
+    ///   3: contract_id (32 bytes)
+    ///   4: document_type_name utf-8
+    ///   5: first "real" index value that will be captured in index_values
+    ///   6..len-3 : index values
+    ///   len-3   : vote choice (key_vote_choice, 32 bytes)
+    ///   len-2, len-1: tail (ignored by this parser)
+    fn make_valid_path(choice: [u8; 32], first_index_byte: u8) -> Vec<Vec<u8>> {
+        vec![
+            vec![0u8],                         // 0: root placeholder
+            vec![0u8],                         // 1: placeholder
+            vec![ACTIVE_POLLS_TREE_KEY as u8], // 2: active polls
+            vec![7u8; 32],                     // 3: contract_id (32 bytes)
+            b"mytype".to_vec(),                // 4: document type name
+            vec![first_index_byte],            // 5: leading byte
+            vec![9u8],                         // 6: index value captured
+            choice.to_vec(),                   // 7: vote choice (len-3)
+            vec![0u8],                         // 8: tail
+            vec![0u8],                         // 9: tail
+        ]
+    }
+
+    #[test]
+    fn try_from_tree_path_errors_when_too_short() {
+        let path: Vec<Vec<u8>> = vec![vec![0u8]; 9];
+        let err = match ContestedDocumentResourceVoteStorageForm::try_from_tree_path(path) {
+            Ok(_) => panic!("expected error, got Ok"),
+            Err(e) => e,
+        };
+        match err {
+            ProtocolError::VoteError(msg) => assert!(msg.contains("is not long enough"), "{msg}"),
+            other => panic!("expected VoteError, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn try_from_tree_path_errors_when_third_element_empty() {
+        let mut path = make_valid_path([0xAB; 32], 8);
+        path[2] = vec![];
+        let err = match ContestedDocumentResourceVoteStorageForm::try_from_tree_path(path) {
+            Ok(_) => panic!("expected error, got Ok"),
+            Err(e) => e,
+        };
+        match err {
+            ProtocolError::VoteError(msg) => {
+                assert!(msg.contains("third element must be a byte"), "{msg}")
+            }
+            other => panic!("expected VoteError, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn try_from_tree_path_errors_when_third_element_is_not_active_polls() {
+        let mut path = make_valid_path([0xAB; 32], 8);
+        path[2] = vec![(ACTIVE_POLLS_TREE_KEY as u8).wrapping_add(1)];
+        let err = match ContestedDocumentResourceVoteStorageForm::try_from_tree_path(path) {
+            Ok(_) => panic!("expected error, got Ok"),
+            Err(e) => e,
+        };
+        match err {
+            ProtocolError::VoteError(msg) => assert!(
+                msg.contains("third element must be a byte for ACTIVE_POLLS_TREE_KEY"),
+                "{msg}"
+            ),
+            other => panic!("expected VoteError, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn try_from_tree_path_errors_when_contract_id_wrong_length() {
+        let mut path = make_valid_path([0xAB; 32], 8);
+        path[3] = vec![1, 2, 3]; // not 32 bytes
+        let err = match ContestedDocumentResourceVoteStorageForm::try_from_tree_path(path) {
+            Ok(_) => panic!("expected error, got Ok"),
+            Err(e) => e,
+        };
+        match err {
+            ProtocolError::VoteError(msg) => {
+                assert!(msg.contains("32 bytes long"), "{msg}")
+            }
+            other => panic!("expected VoteError, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn try_from_tree_path_errors_when_document_type_name_not_utf8() {
+        let mut path = make_valid_path([0xAB; 32], 8);
+        // 0x80 on its own is not valid UTF-8
+        path[4] = vec![0x80, 0xFF];
+        let err = match ContestedDocumentResourceVoteStorageForm::try_from_tree_path(path) {
+            Ok(_) => panic!("expected error, got Ok"),
+            Err(e) => e,
+        };
+        match err {
+            ProtocolError::VoteError(msg) => {
+                assert!(msg.contains("document type name"), "{msg}")
+            }
+            other => panic!("expected VoteError, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn try_from_tree_path_errors_when_vote_choice_not_32_bytes() {
+        let mut path = make_valid_path([0xAB; 32], 8);
+        let len = path.len();
+        path[len - 3] = vec![1, 2, 3]; // non-32-byte choice
+        let err = match ContestedDocumentResourceVoteStorageForm::try_from_tree_path(path) {
+            Ok(_) => panic!("expected error, got Ok"),
+            Err(e) => e,
+        };
+        match err {
+            ProtocolError::VoteError(msg) => {
+                assert!(
+                    msg.contains("identifier or RESOURCE_ABSTAIN_VOTE_TREE_KEY")
+                        || msg.contains("2 before last element"),
+                    "{msg}"
+                )
+            }
+            other => panic!("expected VoteError, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn try_from_tree_path_parses_towards_identity_choice() {
+        let identity_choice_bytes = [0x42u8; 32];
+        let path = make_valid_path(identity_choice_bytes, 8);
+        let form = ContestedDocumentResourceVoteStorageForm::try_from_tree_path(path)
+            .expect("should parse");
+        assert_eq!(form.contract_id, Identifier::from([7u8; 32]));
+        assert_eq!(form.document_type_name, "mytype");
+        assert!(matches!(
+            form.resource_vote_choice,
+            ResourceVoteChoice::TowardsIdentity(id) if id == Identifier::from(identity_choice_bytes)
+        ));
+        // index_values spans indices 6..len-3 which is just [vec![9u8]]
+        assert_eq!(form.index_values, vec![vec![9u8]]);
+    }
+
+    #[test]
+    fn try_from_tree_path_parses_lock_choice() {
+        let path = make_valid_path(RESOURCE_LOCK_VOTE_TREE_KEY_U8_32, 8);
+        let form = ContestedDocumentResourceVoteStorageForm::try_from_tree_path(path)
+            .expect("should parse");
+        assert_eq!(form.resource_vote_choice, ResourceVoteChoice::Lock);
+    }
+
+    #[test]
+    fn try_from_tree_path_parses_abstain_choice() {
+        let path = make_valid_path(RESOURCE_ABSTAIN_VOTE_TREE_KEY_U8_32, 8);
+        let form = ContestedDocumentResourceVoteStorageForm::try_from_tree_path(path)
+            .expect("should parse");
+        assert_eq!(form.resource_vote_choice, ResourceVoteChoice::Abstain);
+    }
+
+    #[test]
+    fn resolve_with_contract_unknown_version_returns_drive_error() {
+        // Directly set an unsupported version into the platform version clone
+        let mut pv = PlatformVersion::latest().clone();
+        pv.drive.methods.vote.storage_form.resolve_with_contract = 99;
+
+        let form = ContestedDocumentResourceVoteStorageForm {
+            contract_id: Identifier::from([1u8; 32]),
+            document_type_name: "ignored".to_string(),
+            index_values: vec![],
+            resource_vote_choice: ResourceVoteChoice::Abstain,
+        };
+
+        // We don't need a real contract; the version dispatch happens before any
+        // contract-level work.
+        let dummy_contract: DataContract =
+            dpp::tests::fixtures::get_dpns_data_contract_fixture(None, 0, pv.protocol_version)
+                .data_contract_owned();
+
+        let err = form
+            .resolve_with_contract(&dummy_contract, &pv)
+            .expect_err("expected unknown version error");
+        match err {
+            Error::Drive(DriveError::UnknownVersionMismatch {
+                method, received, ..
+            }) => {
+                assert!(method.contains("resolve_with_contract"), "method: {method}");
+                assert_eq!(received, 99);
+            }
+            other => panic!("expected UnknownVersionMismatch, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn resolve_with_contract_v0_errors_when_document_type_missing() {
+        let pv = PlatformVersion::latest();
+        let data_contract =
+            dpp::tests::fixtures::get_dpns_data_contract_fixture(None, 0, pv.protocol_version)
+                .data_contract_owned();
+
+        let form = ContestedDocumentResourceVoteStorageForm {
+            contract_id: data_contract.id(),
+            document_type_name: "nonexistent_doc_type".to_string(),
+            index_values: vec![],
+            resource_vote_choice: ResourceVoteChoice::Abstain,
+        };
+
+        let err = form
+            .resolve_with_contract(&data_contract, pv)
+            .expect_err("expected error for missing document type");
+        // We simply assert that it errors out; the exact error variant is the
+        // contract's own "document type not found" error, surfaced as Error.
+        let _ = err; // discarded on purpose -- any error is fine here
+    }
+}

--- a/packages/rs-drive/src/drive/votes/storage_form/vote_storage_form/mod.rs
+++ b/packages/rs-drive/src/drive/votes/storage_form/vote_storage_form/mod.rs
@@ -72,3 +72,152 @@ impl TreePathStorageForm for VoteStorageForm {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::drive::votes::paths::{
+        ACTIVE_POLLS_TREE_KEY, CONTESTED_RESOURCE_TREE_KEY, VOTE_DECISIONS_TREE_KEY,
+    };
+
+    /// Returns a minimally valid path that reaches the ContestedDocumentResource
+    /// dispatch branch, but still fails inside the inner try_from_tree_path (length
+    /// check) -- sufficient to exercise this router's happy dispatch.
+    fn path_with_prefix(second_byte: u8) -> Vec<Vec<u8>> {
+        vec![
+            vec![Votes as u8],
+            vec![second_byte],
+            vec![ACTIVE_POLLS_TREE_KEY as u8],
+        ]
+    }
+
+    #[test]
+    fn try_from_tree_path_errors_when_path_too_short() {
+        // path.len() < 3 -> error
+        let path = vec![vec![Votes as u8], vec![CONTESTED_RESOURCE_TREE_KEY as u8]];
+        let err = match VoteStorageForm::try_from_tree_path(path) {
+            Ok(_) => panic!("expected error, got Ok"),
+            Err(e) => e,
+        };
+        match err {
+            ProtocolError::VoteError(msg) => {
+                assert!(msg.contains("is not long enough"), "msg: {msg}");
+            }
+            other => panic!("expected VoteError, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn try_from_tree_path_errors_when_first_element_empty() {
+        // first_element empty -> "first element must be a byte"
+        let path = vec![
+            vec![],
+            vec![CONTESTED_RESOURCE_TREE_KEY as u8],
+            vec![ACTIVE_POLLS_TREE_KEY as u8],
+        ];
+        let err = match VoteStorageForm::try_from_tree_path(path) {
+            Ok(_) => panic!("expected error, got Ok"),
+            Err(e) => e,
+        };
+        match err {
+            ProtocolError::VoteError(msg) => {
+                assert!(msg.contains("first element must be a byte"), "msg: {msg}");
+            }
+            other => panic!("expected VoteError, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn try_from_tree_path_errors_when_root_key_not_votes() {
+        // Wrong root byte (not Votes root tree) -> error
+        let wrong_root: u8 = (Votes as u8).wrapping_add(1);
+        let path = vec![
+            vec![wrong_root],
+            vec![CONTESTED_RESOURCE_TREE_KEY as u8],
+            vec![ACTIVE_POLLS_TREE_KEY as u8],
+        ];
+        let err = match VoteStorageForm::try_from_tree_path(path) {
+            Ok(_) => panic!("expected error, got Ok"),
+            Err(e) => e,
+        };
+        match err {
+            ProtocolError::VoteError(msg) => {
+                assert!(
+                    msg.contains("first element must be a byte for voting"),
+                    "msg: {msg}"
+                );
+            }
+            other => panic!("expected VoteError, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn try_from_tree_path_errors_when_second_element_empty() {
+        let path = vec![vec![Votes as u8], vec![], vec![ACTIVE_POLLS_TREE_KEY as u8]];
+        let err = match VoteStorageForm::try_from_tree_path(path) {
+            Ok(_) => panic!("expected error, got Ok"),
+            Err(e) => e,
+        };
+        match err {
+            ProtocolError::VoteError(msg) => {
+                assert!(msg.contains("second element must be a byte"), "msg: {msg}");
+            }
+            other => panic!("expected VoteError, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn try_from_tree_path_returns_not_supported_for_decision_votes() {
+        let path = path_with_prefix(VOTE_DECISIONS_TREE_KEY as u8);
+        let err = match VoteStorageForm::try_from_tree_path(path) {
+            Ok(_) => panic!("expected error, got Ok"),
+            Err(e) => e,
+        };
+        match err {
+            ProtocolError::NotSupported(msg) => {
+                assert!(msg.contains("decision votes"), "msg: {msg}");
+            }
+            other => panic!("expected NotSupported, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn try_from_tree_path_errors_for_unknown_second_byte() {
+        // Pick a byte that is neither CONTESTED_RESOURCE_TREE_KEY nor VOTE_DECISIONS_TREE_KEY
+        let unknown_byte = b'Z';
+        assert_ne!(unknown_byte, CONTESTED_RESOURCE_TREE_KEY as u8);
+        assert_ne!(unknown_byte, VOTE_DECISIONS_TREE_KEY as u8);
+        let path = path_with_prefix(unknown_byte);
+        let err = match VoteStorageForm::try_from_tree_path(path) {
+            Ok(_) => panic!("expected error, got Ok"),
+            Err(e) => e,
+        };
+        match err {
+            ProtocolError::VoteError(msg) => {
+                assert!(
+                    msg.contains("second element must be a byte for CONTESTED_RESOURCE_TREE_KEY"),
+                    "msg: {msg}"
+                );
+            }
+            other => panic!("expected VoteError, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn try_from_tree_path_dispatches_to_contested_document_inner() {
+        // For the CONTESTED_RESOURCE_TREE_KEY branch, dispatch reaches
+        // ContestedDocumentResourceVoteStorageForm::try_from_tree_path, which requires
+        // path.len() >= 10. With len == 3 the inner code errors "not long enough".
+        let path = path_with_prefix(CONTESTED_RESOURCE_TREE_KEY as u8);
+        let err = match VoteStorageForm::try_from_tree_path(path) {
+            Ok(_) => panic!("expected error, got Ok"),
+            Err(e) => e,
+        };
+        match err {
+            ProtocolError::VoteError(msg) => {
+                assert!(msg.contains("is not long enough"), "msg: {msg}");
+            }
+            other => panic!("expected VoteError from inner, got {other:?}"),
+        }
+    }
+}

--- a/packages/rs-drive/src/state_transition_action/identity/identity_create_from_addresses/v0/transformer.rs
+++ b/packages/rs-drive/src/state_transition_action/identity/identity_create_from_addresses/v0/transformer.rs
@@ -79,3 +79,141 @@ impl IdentityCreateFromAddressesTransitionActionV0 {
         })
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use dpp::address_funds::PlatformAddress;
+    use dpp::consensus::basic::BasicError;
+    use dpp::consensus::ConsensusError;
+
+    /// Build a minimal V0 transition. `inputs` is always set empty so
+    /// `identity_id_from_inputs` would fail; callers override as needed.
+    fn base_transition_v0() -> IdentityCreateFromAddressesTransitionV0 {
+        IdentityCreateFromAddressesTransitionV0::default()
+    }
+
+    #[test]
+    fn empty_inputs_produce_identity_id_derivation_error() {
+        // Per dpp: `identity_id_from_input_addresses` returns ParsingError when
+        // inputs is empty. The transformer wraps this as ValueError.
+        let value = base_transition_v0();
+        let result = IdentityCreateFromAddressesTransitionActionV0::try_from_transition(
+            &value,
+            BTreeMap::new(),
+        );
+        assert!(!result.is_valid());
+        let errors = result.errors;
+        assert!(!errors.is_empty());
+        // Any ValueError variant is acceptable -- specific wording tested in fmt
+        match &errors[0] {
+            ConsensusError::BasicError(BasicError::ValueError(e)) => {
+                assert!(
+                    e.to_string().contains("Failed to calculate identity id"),
+                    "unexpected ValueError message: {}",
+                    e
+                );
+            }
+            other => panic!("expected ValueError, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn overflowing_input_sum_produces_overflow_error() {
+        // Two inputs whose balances summed overflow u64
+        let mut v0 = base_transition_v0();
+        let addr_a = PlatformAddress::P2pkh([1u8; 20]);
+        let addr_b = PlatformAddress::P2pkh([2u8; 20]);
+        // Each ~= 2/3 of u64::MAX, summed they overflow
+        let almost_max = u64::MAX - 10;
+        v0.inputs.insert(addr_a, (0u32, almost_max));
+        v0.inputs.insert(addr_b, (0u32, almost_max));
+        // Provide non-empty balance map to pass identity_id derivation.
+        let inputs_remaining: BTreeMap<PlatformAddress, (AddressNonce, Credits)> =
+            v0.inputs.iter().map(|(k, v)| (*k, *v)).collect();
+
+        let result = IdentityCreateFromAddressesTransitionActionV0::try_from_transition(
+            &v0,
+            inputs_remaining,
+        );
+        assert!(!result.is_valid());
+        let errors = result.errors;
+        assert!(!errors.is_empty());
+        let msg = format!("{:?}", errors[0]);
+        assert!(
+            msg.to_lowercase().contains("overflow"),
+            "expected overflow error, got {msg}"
+        );
+    }
+
+    #[test]
+    fn output_exceeding_inputs_produces_overflow_error() {
+        // inputs sum to 100 but output is 1000 -- must error in checked_sub branch
+        let mut v0 = base_transition_v0();
+        let addr = PlatformAddress::P2pkh([7u8; 20]);
+        v0.inputs.insert(addr, (0u32, 100));
+        v0.output = Some((PlatformAddress::P2sh([9u8; 20]), 1000));
+
+        let inputs_remaining: BTreeMap<PlatformAddress, (AddressNonce, Credits)> =
+            v0.inputs.iter().map(|(k, v)| (*k, *v)).collect();
+
+        let result = IdentityCreateFromAddressesTransitionActionV0::try_from_transition(
+            &v0,
+            inputs_remaining,
+        );
+        assert!(!result.is_valid());
+        let errors = result.errors;
+        assert!(!errors.is_empty());
+        let msg = format!("{:?}", errors[0]);
+        assert!(
+            msg.to_lowercase().contains("output exceeds")
+                || msg.to_lowercase().contains("overflow"),
+            "expected output-exceeds-input error, got {msg}"
+        );
+    }
+
+    #[test]
+    fn valid_inputs_without_output_succeed_and_fund_equals_sum() {
+        let mut v0 = base_transition_v0();
+        let addr_a = PlatformAddress::P2pkh([4u8; 20]);
+        let addr_b = PlatformAddress::P2pkh([5u8; 20]);
+        v0.inputs.insert(addr_a, (1u32, 300));
+        v0.inputs.insert(addr_b, (2u32, 200));
+        v0.output = None;
+
+        let inputs_remaining: BTreeMap<PlatformAddress, (AddressNonce, Credits)> =
+            v0.inputs.iter().map(|(k, v)| (*k, *v)).collect();
+
+        let result = IdentityCreateFromAddressesTransitionActionV0::try_from_transition(
+            &v0,
+            inputs_remaining,
+        );
+        assert!(result.is_valid(), "errors: {:?}", result.errors);
+        let action = result.into_data().expect("action");
+        assert_eq!(action.fund_identity_amount, 500);
+        assert!(action.output.is_none());
+    }
+
+    #[test]
+    fn valid_inputs_with_output_subtract_from_fund_amount() {
+        let mut v0 = base_transition_v0();
+        let addr = PlatformAddress::P2pkh([8u8; 20]);
+        v0.inputs.insert(addr, (1u32, 1_000));
+        v0.output = Some((PlatformAddress::P2sh([0xAA; 20]), 250));
+
+        let inputs_remaining: BTreeMap<PlatformAddress, (AddressNonce, Credits)> =
+            v0.inputs.iter().map(|(k, v)| (*k, *v)).collect();
+
+        let result = IdentityCreateFromAddressesTransitionActionV0::try_from_transition(
+            &v0,
+            inputs_remaining,
+        );
+        assert!(result.is_valid(), "errors: {:?}", result.errors);
+        let action = result.into_data().expect("action");
+        assert_eq!(action.fund_identity_amount, 750);
+        assert_eq!(
+            action.output,
+            Some((PlatformAddress::P2sh([0xAA; 20]), 250))
+        );
+    }
+}

--- a/packages/rs-drive/src/state_transition_action/identity/identity_topup_from_addresses/v0/transformer.rs
+++ b/packages/rs-drive/src/state_transition_action/identity/identity_topup_from_addresses/v0/transformer.rs
@@ -63,3 +63,116 @@ impl IdentityTopUpFromAddressesTransitionActionV0 {
         })
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use dpp::address_funds::PlatformAddress;
+
+    fn base_transition_v0() -> IdentityTopUpFromAddressesTransitionV0 {
+        IdentityTopUpFromAddressesTransitionV0::default()
+    }
+
+    #[test]
+    fn overflowing_input_sum_produces_overflow_error() {
+        let mut v0 = base_transition_v0();
+        v0.inputs
+            .insert(PlatformAddress::P2pkh([1u8; 20]), (0u32, u64::MAX - 5));
+        v0.inputs
+            .insert(PlatformAddress::P2pkh([2u8; 20]), (0u32, u64::MAX - 5));
+
+        let inputs_remaining: BTreeMap<PlatformAddress, (AddressNonce, Credits)> =
+            v0.inputs.iter().map(|(k, v)| (*k, *v)).collect();
+
+        let result = IdentityTopUpFromAddressesTransitionActionV0::try_from_transition(
+            &v0,
+            inputs_remaining,
+        );
+        assert!(!result.is_valid());
+        let errors = result.errors;
+        assert!(!errors.is_empty());
+        let msg = format!("{:?}", errors[0]);
+        assert!(
+            msg.to_lowercase().contains("overflow"),
+            "expected overflow error, got {msg}"
+        );
+    }
+
+    #[test]
+    fn output_exceeding_inputs_produces_overflow_error() {
+        let mut v0 = base_transition_v0();
+        v0.inputs
+            .insert(PlatformAddress::P2pkh([3u8; 20]), (0u32, 50));
+        v0.output = Some((PlatformAddress::P2sh([9u8; 20]), 200));
+
+        let inputs_remaining: BTreeMap<PlatformAddress, (AddressNonce, Credits)> =
+            v0.inputs.iter().map(|(k, v)| (*k, *v)).collect();
+
+        let result = IdentityTopUpFromAddressesTransitionActionV0::try_from_transition(
+            &v0,
+            inputs_remaining,
+        );
+        assert!(!result.is_valid());
+        let errors = result.errors;
+        assert!(!errors.is_empty());
+        let msg = format!("{:?}", errors[0]);
+        assert!(
+            msg.to_lowercase().contains("output exceeds")
+                || msg.to_lowercase().contains("overflow"),
+            "expected output-exceeds-input error, got {msg}"
+        );
+    }
+
+    #[test]
+    fn valid_inputs_without_output_succeed_and_topup_equals_sum() {
+        let mut v0 = base_transition_v0();
+        v0.inputs
+            .insert(PlatformAddress::P2pkh([4u8; 20]), (1u32, 400));
+        v0.inputs
+            .insert(PlatformAddress::P2pkh([5u8; 20]), (2u32, 100));
+        v0.output = None;
+
+        let inputs_remaining: BTreeMap<PlatformAddress, (AddressNonce, Credits)> =
+            v0.inputs.iter().map(|(k, v)| (*k, *v)).collect();
+
+        let result = IdentityTopUpFromAddressesTransitionActionV0::try_from_transition(
+            &v0,
+            inputs_remaining,
+        );
+        assert!(result.is_valid(), "errors: {:?}", result.errors);
+        let action = result.into_data().expect("action");
+        assert_eq!(action.topup_amount, 500);
+        assert!(action.output.is_none());
+    }
+
+    #[test]
+    fn valid_inputs_with_output_subtract_from_topup() {
+        let mut v0 = base_transition_v0();
+        v0.inputs
+            .insert(PlatformAddress::P2pkh([8u8; 20]), (1u32, 1_000));
+        v0.output = Some((PlatformAddress::P2sh([0xAA; 20]), 700));
+
+        let inputs_remaining: BTreeMap<PlatformAddress, (AddressNonce, Credits)> =
+            v0.inputs.iter().map(|(k, v)| (*k, *v)).collect();
+
+        let result = IdentityTopUpFromAddressesTransitionActionV0::try_from_transition(
+            &v0,
+            inputs_remaining,
+        );
+        assert!(result.is_valid(), "errors: {:?}", result.errors);
+        let action = result.into_data().expect("action");
+        assert_eq!(action.topup_amount, 300);
+    }
+
+    #[test]
+    fn empty_inputs_produce_topup_of_zero_when_no_output() {
+        // Edge case: zero inputs and no output should produce topup = 0.
+        // This covers the "None" branch of the output match with 0-sum inputs.
+        let v0 = base_transition_v0();
+        let result =
+            IdentityTopUpFromAddressesTransitionActionV0::try_from_transition(&v0, BTreeMap::new());
+        assert!(result.is_valid(), "errors: {:?}", result.errors);
+        let action = result.into_data().expect("action");
+        assert_eq!(action.topup_amount, 0);
+    }
+}

--- a/packages/rs-drive/src/util/object_size_info/contract_info.rs
+++ b/packages/rs-drive/src/util/object_size_info/contract_info.rs
@@ -241,3 +241,87 @@ impl<'a> DocumentTypeInfo<'a> {
         }
     }
 }
+
+#[cfg(all(feature = "server", test))]
+mod tests {
+    use super::*;
+    use dpp::tests::fixtures::get_data_contract_fixture;
+    use dpp::version::PlatformVersion;
+
+    fn sample_contract() -> DataContract {
+        let platform_version = PlatformVersion::latest();
+        get_data_contract_fixture(None, 0, platform_version.protocol_version).data_contract_owned()
+    }
+
+    #[test]
+    fn owned_resolved_info_id_and_as_ref() {
+        let contract = sample_contract();
+        let expected_id = contract.id();
+        let owned = DataContractOwnedResolvedInfo::OwnedDataContract(contract);
+        assert_eq!(owned.id(), expected_id);
+        let as_ref: &DataContract = owned.as_ref();
+        assert_eq!(as_ref.id(), expected_id);
+    }
+
+    #[test]
+    fn owned_resolved_info_into_owned_returns_inner() {
+        let contract = sample_contract();
+        let expected_id = contract.id();
+        let owned = DataContractOwnedResolvedInfo::OwnedDataContract(contract);
+        let unwrapped = owned.into_owned();
+        assert_eq!(unwrapped.id(), expected_id);
+    }
+
+    #[test]
+    fn resolved_info_borrowed_and_owned() {
+        let contract = sample_contract();
+        let id = contract.id();
+
+        let borrowed: DataContractResolvedInfo =
+            DataContractResolvedInfo::BorrowedDataContract(&contract);
+        assert_eq!(borrowed.id(), id);
+        let as_ref: &DataContract = borrowed.as_ref();
+        assert_eq!(as_ref.id(), id);
+
+        let owned_wrapper = DataContractResolvedInfo::OwnedDataContract(contract);
+        assert_eq!(owned_wrapper.id(), id);
+        let as_ref2: &DataContract = owned_wrapper.as_ref();
+        assert_eq!(as_ref2.id(), id);
+    }
+
+    #[test]
+    fn resolved_info_arc_contract() {
+        use std::sync::Arc;
+        let contract = sample_contract();
+        let id = contract.id();
+        let arc = Arc::new(contract);
+        let info: DataContractResolvedInfo = DataContractResolvedInfo::ArcDataContract(arc);
+        assert_eq!(info.id(), id);
+        let as_ref: &DataContract = info.as_ref();
+        assert_eq!(as_ref.id(), id);
+    }
+
+    #[test]
+    fn from_owned_resolved_info_produces_borrowed_variant() {
+        let contract = sample_contract();
+        let id = contract.id();
+        let owned = DataContractOwnedResolvedInfo::OwnedDataContract(contract);
+        let borrowed: DataContractResolvedInfo = (&owned).into();
+        match borrowed {
+            DataContractResolvedInfo::BorrowedDataContract(b) => {
+                assert_eq!(b.id(), id);
+            }
+            _ => panic!("expected BorrowedDataContract"),
+        }
+    }
+
+    #[test]
+    fn document_type_info_resolve_errors_for_missing_type() {
+        let contract = sample_contract();
+        let info = DocumentTypeInfo::DocumentTypeName("missing".to_string());
+        assert!(info.resolve(&contract).is_err());
+
+        let info = DocumentTypeInfo::DocumentTypeNameAsStr("nope_at_all");
+        assert!(info.resolve(&contract).is_err());
+    }
+}

--- a/packages/rs-drive/src/util/object_size_info/drive_key_info.rs
+++ b/packages/rs-drive/src/util/object_size_info/drive_key_info.rs
@@ -107,3 +107,158 @@ impl<'a> DriveKeyInfo<'a> {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use grovedb::batch::key_info::KeyInfo::MaxKeySize;
+
+    #[test]
+    fn default_is_empty_key() {
+        let d = DriveKeyInfo::default();
+        assert!(d.is_empty());
+        assert_eq!(d.len(), 0);
+    }
+
+    #[test]
+    fn key_len_and_is_empty() {
+        let k = DriveKeyInfo::Key(vec![1, 2, 3]);
+        assert_eq!(k.len(), 3);
+        assert!(!k.is_empty());
+
+        let empty = DriveKeyInfo::Key(vec![]);
+        assert!(empty.is_empty());
+    }
+
+    #[test]
+    fn key_ref_len_and_is_empty() {
+        let bytes = [1u8, 2, 3, 4];
+        let k = DriveKeyInfo::KeyRef(&bytes);
+        assert_eq!(k.len(), 4);
+        assert!(!k.is_empty());
+
+        let empty: &[u8] = &[];
+        let k = DriveKeyInfo::KeyRef(empty);
+        assert!(k.is_empty());
+    }
+
+    #[test]
+    fn key_size_len_and_is_empty() {
+        let info = KeyInfo::MaxKeySize {
+            unique_id: vec![0xAB],
+            max_size: 10,
+        };
+        let k = DriveKeyInfo::KeySize(info);
+        assert_eq!(k.len(), 10);
+        assert!(!k.is_empty());
+
+        let zero_size = KeyInfo::MaxKeySize {
+            unique_id: vec![],
+            max_size: 0,
+        };
+        let k = DriveKeyInfo::KeySize(zero_size);
+        assert!(k.is_empty());
+    }
+
+    #[test]
+    fn to_owned_key_info_from_key() {
+        let k = DriveKeyInfo::Key(vec![9, 8, 7]);
+        match k.to_owned_key_info() {
+            KnownKey(v) => assert_eq!(v, vec![9, 8, 7]),
+            _ => panic!("expected KnownKey"),
+        }
+    }
+
+    #[test]
+    fn to_owned_key_info_from_key_ref() {
+        let bytes = [4u8, 5, 6];
+        let k = DriveKeyInfo::KeyRef(&bytes);
+        match k.to_owned_key_info() {
+            KnownKey(v) => assert_eq!(v, vec![4, 5, 6]),
+            _ => panic!("expected KnownKey"),
+        }
+    }
+
+    #[test]
+    fn to_owned_key_info_preserves_key_size() {
+        let info = KeyInfo::MaxKeySize {
+            unique_id: vec![0x11],
+            max_size: 5,
+        };
+        let k = DriveKeyInfo::KeySize(info.clone());
+        assert_eq!(k.to_owned_key_info(), info);
+    }
+
+    #[test]
+    fn to_key_info_borrows_and_clones() {
+        let k = DriveKeyInfo::Key(vec![1, 2]);
+        let info_a = k.to_key_info();
+        // k is still usable (not consumed)
+        let info_b = k.to_key_info();
+        assert_eq!(info_a, info_b);
+        match info_a {
+            KnownKey(v) => assert_eq!(v, vec![1, 2]),
+            _ => panic!("expected KnownKey"),
+        }
+    }
+
+    #[test]
+    fn add_fixed_size_path_variants() {
+        // Key -> PathFixedSizeKey
+        let k = DriveKeyInfo::Key(vec![1]);
+        let path: [&[u8]; 2] = [&[0u8, 1], &[2u8, 3]];
+        let pk = k.add_fixed_size_path(path);
+        match pk {
+            PathKeyInfo::PathFixedSizeKey((p, key)) => {
+                assert_eq!(p.len(), 2);
+                assert_eq!(key, vec![1]);
+            }
+            _ => panic!("expected PathFixedSizeKey"),
+        }
+
+        // KeyRef -> PathFixedSizeKeyRef
+        let bytes = [5u8];
+        let k = DriveKeyInfo::KeyRef(&bytes);
+        let pk = k.add_fixed_size_path(path);
+        matches!(pk, PathKeyInfo::PathFixedSizeKeyRef(_));
+
+        // KeySize -> PathKeySize
+        let k = DriveKeyInfo::KeySize(MaxKeySize {
+            unique_id: vec![],
+            max_size: 8,
+        });
+        let pk = k.add_fixed_size_path(path);
+        matches!(pk, PathKeyInfo::PathKeySize(..));
+    }
+
+    #[test]
+    fn add_path_variants_for_vec_path() {
+        let path = vec![vec![0u8], vec![1u8, 2u8]];
+
+        // Key
+        let k = DriveKeyInfo::Key(vec![9]);
+        let pk: PathKeyInfo<0> = k.add_path(path.clone());
+        matches!(pk, PathKeyInfo::PathKey(_));
+
+        // KeyRef
+        let bytes = [7u8];
+        let k = DriveKeyInfo::KeyRef(&bytes);
+        let pk: PathKeyInfo<0> = k.add_path(path.clone());
+        matches!(pk, PathKeyInfo::PathKeyRef(_));
+
+        // KeySize
+        let k = DriveKeyInfo::KeySize(MaxKeySize {
+            unique_id: vec![],
+            max_size: 3,
+        });
+        let pk: PathKeyInfo<0> = k.add_path(path);
+        matches!(pk, PathKeyInfo::PathKeySize(..));
+    }
+
+    #[test]
+    fn clone_preserves_variant() {
+        let k = DriveKeyInfo::Key(vec![1, 2, 3]);
+        let cloned = k.clone();
+        assert_eq!(k.len(), cloned.len());
+    }
+}

--- a/packages/rs-drive/src/util/object_size_info/drive_key_info.rs
+++ b/packages/rs-drive/src/util/object_size_info/drive_key_info.rs
@@ -220,7 +220,7 @@ mod tests {
         let bytes = [5u8];
         let k = DriveKeyInfo::KeyRef(&bytes);
         let pk = k.add_fixed_size_path(path);
-        matches!(pk, PathKeyInfo::PathFixedSizeKeyRef(_));
+        assert!(matches!(pk, PathKeyInfo::PathFixedSizeKeyRef(_)));
 
         // KeySize -> PathKeySize
         let k = DriveKeyInfo::KeySize(MaxKeySize {
@@ -228,7 +228,7 @@ mod tests {
             max_size: 8,
         });
         let pk = k.add_fixed_size_path(path);
-        matches!(pk, PathKeyInfo::PathKeySize(..));
+        assert!(matches!(pk, PathKeyInfo::PathKeySize(..)));
     }
 
     #[test]
@@ -238,13 +238,13 @@ mod tests {
         // Key
         let k = DriveKeyInfo::Key(vec![9]);
         let pk: PathKeyInfo<0> = k.add_path(path.clone());
-        matches!(pk, PathKeyInfo::PathKey(_));
+        assert!(matches!(pk, PathKeyInfo::PathKey(_)));
 
         // KeyRef
         let bytes = [7u8];
         let k = DriveKeyInfo::KeyRef(&bytes);
         let pk: PathKeyInfo<0> = k.add_path(path.clone());
-        matches!(pk, PathKeyInfo::PathKeyRef(_));
+        assert!(matches!(pk, PathKeyInfo::PathKeyRef(_)));
 
         // KeySize
         let k = DriveKeyInfo::KeySize(MaxKeySize {
@@ -252,7 +252,7 @@ mod tests {
             max_size: 3,
         });
         let pk: PathKeyInfo<0> = k.add_path(path);
-        matches!(pk, PathKeyInfo::PathKeySize(..));
+        assert!(matches!(pk, PathKeyInfo::PathKeySize(..)));
     }
 
     #[test]

--- a/packages/rs-drive/src/util/object_size_info/key_value_info.rs
+++ b/packages/rs-drive/src/util/object_size_info/key_value_info.rs
@@ -30,3 +30,49 @@ impl<'a> KeyValueInfo<'a> {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn as_key_ref_request_ok_for_key_ref() {
+        let bytes = [1u8, 2, 3];
+        let info = KeyValueInfo::KeyRefRequest(&bytes);
+        let got = info.as_key_ref_request().expect("should succeed");
+        assert_eq!(got, &[1, 2, 3]);
+    }
+
+    #[test]
+    fn as_key_ref_request_errors_for_max_size() {
+        let info = KeyValueInfo::KeyValueMaxSize((32, 128));
+        let err = info.as_key_ref_request().expect_err("should err");
+        match err {
+            Error::Drive(DriveError::CorruptedCodeExecution(msg)) => {
+                assert!(msg.contains("key ref request"));
+            }
+            _ => panic!("expected CorruptedCodeExecution"),
+        }
+    }
+
+    #[test]
+    fn key_len_for_key_ref() {
+        let bytes = [1u8; 7];
+        let info = KeyValueInfo::KeyRefRequest(&bytes);
+        assert_eq!(info.key_len(), 7);
+    }
+
+    #[test]
+    fn key_len_for_max_size_uses_first_tuple_element() {
+        let info = KeyValueInfo::KeyValueMaxSize((32, 1024));
+        assert_eq!(info.key_len(), 32);
+    }
+
+    #[test]
+    fn clone_preserves_ref_variant() {
+        let bytes = [4u8, 5];
+        let info = KeyValueInfo::KeyRefRequest(&bytes);
+        let cloned = info.clone();
+        assert_eq!(info.key_len(), cloned.key_len());
+    }
+}

--- a/packages/rs-drive/src/util/object_size_info/path_info.rs
+++ b/packages/rs-drive/src/util/object_size_info/path_info.rs
@@ -79,3 +79,134 @@ impl<'a, const N: usize> PathInfo<'a, N> {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use grovedb::batch::key_info::KeyInfo::MaxKeySize;
+
+    #[test]
+    fn fixed_size_array_len_sums_elements() {
+        let arr: [&[u8]; 3] = [&[1u8], &[2u8, 3u8], &[4u8, 5u8, 6u8]];
+        let p: PathInfo<3> = PathInfo::PathFixedSizeArray(arr);
+        assert_eq!(p.len(), 6);
+        assert!(!p.is_empty());
+    }
+
+    #[test]
+    fn fixed_size_empty_array_reports_zero_len() {
+        let arr: [&[u8]; 0] = [];
+        let p: PathInfo<0> = PathInfo::PathFixedSizeArray(arr);
+        assert_eq!(p.len(), 0);
+        assert!(p.is_empty());
+    }
+
+    #[test]
+    fn as_vec_len_and_empty() {
+        let p: PathInfo<0> = PathInfo::PathAsVec(vec![vec![1u8, 2], vec![3u8]]);
+        assert_eq!(p.len(), 3);
+        assert!(!p.is_empty());
+
+        let p: PathInfo<0> = PathInfo::PathAsVec(vec![]);
+        assert!(p.is_empty());
+        assert_eq!(p.len(), 0);
+    }
+
+    #[test]
+    fn with_sizes_len_uses_max_length() {
+        let path = KeyInfoPath::from_known_path([b"abc".as_ref(), b"defg".as_ref()]);
+        let p: PathInfo<0> = PathInfo::PathWithSizes(path);
+        assert_eq!(p.len(), 7);
+        assert!(!p.is_empty());
+    }
+
+    #[test]
+    fn push_to_fixed_size_errors() {
+        let arr: [&[u8]; 1] = [&[1u8]];
+        let mut p: PathInfo<1> = PathInfo::PathFixedSizeArray(arr);
+        let err = p.push(DriveKeyInfo::Key(vec![9])).expect_err("err");
+        match err {
+            Error::Drive(DriveError::CorruptedCodeExecution(msg)) => {
+                assert!(msg.contains("fixed size"));
+            }
+            _ => panic!("expected CorruptedCodeExecution"),
+        }
+    }
+
+    #[test]
+    fn push_key_to_vec_appends_vec() {
+        let mut p: PathInfo<0> = PathInfo::PathAsVec(vec![]);
+        p.push(DriveKeyInfo::Key(vec![1, 2])).expect("push");
+        let bytes: [u8; 1] = [3];
+        p.push(DriveKeyInfo::KeyRef(&bytes)).expect("push ref");
+        match p {
+            PathInfo::PathAsVec(v) => {
+                assert_eq!(v, vec![vec![1u8, 2], vec![3u8]]);
+            }
+            _ => panic!("expected vec"),
+        }
+    }
+
+    #[test]
+    fn push_key_size_to_vec_errors() {
+        let mut p: PathInfo<0> = PathInfo::PathAsVec(vec![]);
+        let err = p
+            .push(DriveKeyInfo::KeySize(MaxKeySize {
+                unique_id: vec![],
+                max_size: 4,
+            }))
+            .expect_err("should err");
+        match err {
+            Error::Drive(DriveError::CorruptedCodeExecution(msg)) => {
+                assert!(msg.contains("key size"));
+            }
+            _ => panic!("expected CorruptedCodeExecution"),
+        }
+    }
+
+    #[test]
+    fn push_all_variants_to_path_with_sizes() {
+        let mut p: PathInfo<0> =
+            PathInfo::PathWithSizes(KeyInfoPath::from_known_owned_path(vec![]));
+
+        // Key
+        p.push(DriveKeyInfo::Key(vec![1])).expect("push key");
+        // KeyRef
+        let bytes = [2u8];
+        p.push(DriveKeyInfo::KeyRef(&bytes)).expect("push ref");
+        // KeySize
+        p.push(DriveKeyInfo::KeySize(MaxKeySize {
+            unique_id: vec![0xA],
+            max_size: 3,
+        }))
+        .expect("push size");
+
+        match p {
+            PathInfo::PathWithSizes(kip) => assert_eq!(kip.len(), 3),
+            _ => panic!("expected PathWithSizes"),
+        }
+    }
+
+    #[test]
+    fn convert_to_key_info_path_fixed_size_array() {
+        let arr: [&[u8]; 2] = [&[1u8], &[2u8, 3u8]];
+        let p: PathInfo<2> = PathInfo::PathFixedSizeArray(arr);
+        let kip = p.convert_to_key_info_path();
+        assert_eq!(kip.len(), 2);
+    }
+
+    #[test]
+    fn convert_to_key_info_path_as_vec() {
+        let p: PathInfo<0> = PathInfo::PathAsVec(vec![vec![1], vec![2, 3]]);
+        let kip = p.convert_to_key_info_path();
+        assert_eq!(kip.len(), 2);
+    }
+
+    #[test]
+    fn convert_to_key_info_path_passthrough() {
+        let orig = KeyInfoPath::from_known_path([b"x".as_ref()]);
+        let p: PathInfo<0> = PathInfo::PathWithSizes(orig);
+        let kip = p.convert_to_key_info_path();
+        assert_eq!(kip.len(), 1);
+    }
+}

--- a/packages/rs-drive/src/util/object_size_info/path_key_element_info.rs
+++ b/packages/rs-drive/src/util/object_size_info/path_key_element_info.rs
@@ -115,3 +115,180 @@ impl<'a, const N: usize> PathKeyElementInfo<'a, N> {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use grovedb::batch::key_info::KeyInfo::MaxKeySize;
+
+    fn item_element() -> Element {
+        Element::new_item(vec![1, 2, 3])
+    }
+
+    #[test]
+    fn from_path_info_vec_with_key_element_produces_ref_element() {
+        let path = PathInfo::<0>::PathAsVec(vec![vec![1u8]]);
+        let key: &[u8] = &[9u8];
+        let res = PathKeyElementInfo::from_path_info_and_key_element(
+            path,
+            KeyElementInfo::KeyElement((key, item_element())),
+        )
+        .expect("ok");
+        matches!(res, PathKeyRefElement(_));
+    }
+
+    #[test]
+    fn from_path_info_vec_with_unknown_element_size_errors() {
+        let path = PathInfo::<0>::PathAsVec(vec![vec![1u8]]);
+        let err = PathKeyElementInfo::from_path_info_and_key_element(
+            path,
+            KeyElementInfo::KeyUnknownElementSize((KnownKey(vec![9]), 16)),
+        )
+        .expect_err("should err");
+        match err {
+            Error::Drive(DriveError::NotSupportedPrivate(msg)) => {
+                assert!(msg.contains("key element size"));
+            }
+            _ => panic!("expected NotSupportedPrivate"),
+        }
+    }
+
+    #[test]
+    fn from_path_info_fixed_size_with_unknown_element_size_errors() {
+        let path: [&[u8]; 1] = [&[1u8]];
+        let res = PathKeyElementInfo::<1>::from_path_info_and_key_element(
+            PathInfo::PathFixedSizeArray(path),
+            KeyElementInfo::KeyUnknownElementSize((KnownKey(vec![9]), 10)),
+        );
+        match res {
+            Err(Error::Drive(DriveError::NotSupportedPrivate(_))) => {}
+            _ => panic!("expected error for unknown element size on fixed-size path"),
+        }
+    }
+
+    #[test]
+    fn from_path_info_fixed_size_with_key_element_produces_ref_element() {
+        let path: [&[u8]; 1] = [&[1u8]];
+        let key: &[u8] = &[9u8];
+        let res = PathKeyElementInfo::<1>::from_path_info_and_key_element(
+            PathInfo::PathFixedSizeArray(path),
+            KeyElementInfo::KeyElement((key, item_element())),
+        )
+        .expect("ok");
+        matches!(res, PathFixedSizeKeyRefElement(_));
+    }
+
+    #[test]
+    fn from_path_info_with_sizes_supports_unknown_element_size() {
+        let path = PathInfo::<0>::PathWithSizes(KeyInfoPath::from_known_owned_path(vec![vec![1]]));
+        let res = PathKeyElementInfo::from_path_info_and_key_element(
+            path,
+            KeyElementInfo::KeyUnknownElementSize((KnownKey(vec![9]), 100)),
+        )
+        .expect("path-with-sizes supports unknown element size");
+        matches!(res, PathKeyUnknownElementSize(_));
+    }
+
+    #[test]
+    fn from_path_info_with_sizes_key_element_wraps_with_known_key() {
+        let path = PathInfo::<0>::PathWithSizes(KeyInfoPath::from_known_owned_path(vec![vec![1]]));
+        let key: &[u8] = &[9u8];
+        let res = PathKeyElementInfo::from_path_info_and_key_element(
+            path,
+            KeyElementInfo::KeyElement((key, item_element())),
+        )
+        .expect("ok");
+        matches!(res, PathKeyElementSize(_));
+    }
+
+    #[test]
+    fn from_path_info_with_sizes_element_size_roundtrips() {
+        let path = PathInfo::<0>::PathWithSizes(KeyInfoPath::from_known_owned_path(vec![vec![1]]));
+        let res = PathKeyElementInfo::from_path_info_and_key_element(
+            path,
+            KeyElementInfo::KeyElementSize((
+                MaxKeySize {
+                    unique_id: vec![0xA],
+                    max_size: 4,
+                },
+                item_element(),
+            )),
+        )
+        .expect("ok");
+        matches!(res, PathKeyElementSize(_));
+    }
+
+    #[test]
+    fn from_fixed_size_path_and_key_element_happy_path() {
+        let path: [&[u8]; 2] = [&[1u8], &[2u8]];
+        let key: &[u8] = &[9u8];
+        let res = PathKeyElementInfo::<2>::from_fixed_size_path_and_key_element(
+            path,
+            KeyElementInfo::KeyElement((key, item_element())),
+        )
+        .expect("ok");
+        matches!(res, PathFixedSizeKeyRefElement(_));
+    }
+
+    #[test]
+    fn from_fixed_size_path_and_key_unknown_size_errors() {
+        let path: [&[u8]; 1] = [&[1u8]];
+        let res = PathKeyElementInfo::<1>::from_fixed_size_path_and_key_element(
+            path,
+            KeyElementInfo::KeyUnknownElementSize((KnownKey(vec![]), 16)),
+        );
+        match res {
+            Err(Error::Drive(DriveError::NotSupportedPrivate(_))) => {}
+            _ => panic!("expected NotSupportedPrivate"),
+        }
+    }
+
+    #[test]
+    fn from_fixed_size_path_and_key_element_size_ok() {
+        let path: [&[u8]; 1] = [&[1u8]];
+        let res = PathKeyElementInfo::<1>::from_fixed_size_path_and_key_element(
+            path,
+            KeyElementInfo::KeyElementSize((
+                MaxKeySize {
+                    unique_id: vec![0xA],
+                    max_size: 8,
+                },
+                item_element(),
+            )),
+        )
+        .expect("ok");
+        matches!(res, PathKeyElementSize(_));
+    }
+
+    #[test]
+    fn from_path_and_key_element_variants() {
+        let path = vec![vec![1u8]];
+        let key: &[u8] = &[9u8];
+        let res = PathKeyElementInfo::<0>::from_path_and_key_element(
+            path.clone(),
+            KeyElementInfo::KeyElement((key, item_element())),
+        )
+        .expect("ok");
+        matches!(res, PathKeyRefElement(_));
+
+        let res = PathKeyElementInfo::<0>::from_path_and_key_element(
+            path.clone(),
+            KeyElementInfo::KeyElementSize((
+                MaxKeySize {
+                    unique_id: vec![],
+                    max_size: 8,
+                },
+                item_element(),
+            )),
+        )
+        .expect("ok");
+        matches!(res, PathKeyElementSize(_));
+
+        let err = PathKeyElementInfo::<0>::from_path_and_key_element(
+            path,
+            KeyElementInfo::KeyUnknownElementSize((KnownKey(vec![]), 8)),
+        )
+        .expect_err("err");
+        matches!(err, Error::Drive(DriveError::NotSupportedPrivate(_)));
+    }
+}

--- a/packages/rs-drive/src/util/object_size_info/path_key_element_info.rs
+++ b/packages/rs-drive/src/util/object_size_info/path_key_element_info.rs
@@ -134,7 +134,7 @@ mod tests {
             KeyElementInfo::KeyElement((key, item_element())),
         )
         .expect("ok");
-        matches!(res, PathKeyRefElement(_));
+        assert!(matches!(res, PathKeyRefElement(_)));
     }
 
     #[test]
@@ -175,7 +175,7 @@ mod tests {
             KeyElementInfo::KeyElement((key, item_element())),
         )
         .expect("ok");
-        matches!(res, PathFixedSizeKeyRefElement(_));
+        assert!(matches!(res, PathFixedSizeKeyRefElement(_)));
     }
 
     #[test]
@@ -186,7 +186,7 @@ mod tests {
             KeyElementInfo::KeyUnknownElementSize((KnownKey(vec![9]), 100)),
         )
         .expect("path-with-sizes supports unknown element size");
-        matches!(res, PathKeyUnknownElementSize(_));
+        assert!(matches!(res, PathKeyUnknownElementSize(_)));
     }
 
     #[test]
@@ -198,7 +198,7 @@ mod tests {
             KeyElementInfo::KeyElement((key, item_element())),
         )
         .expect("ok");
-        matches!(res, PathKeyElementSize(_));
+        assert!(matches!(res, PathKeyElementSize(_)));
     }
 
     #[test]
@@ -215,7 +215,7 @@ mod tests {
             )),
         )
         .expect("ok");
-        matches!(res, PathKeyElementSize(_));
+        assert!(matches!(res, PathKeyElementSize(_)));
     }
 
     #[test]
@@ -227,7 +227,7 @@ mod tests {
             KeyElementInfo::KeyElement((key, item_element())),
         )
         .expect("ok");
-        matches!(res, PathFixedSizeKeyRefElement(_));
+        assert!(matches!(res, PathFixedSizeKeyRefElement(_)));
     }
 
     #[test]
@@ -257,7 +257,7 @@ mod tests {
             )),
         )
         .expect("ok");
-        matches!(res, PathKeyElementSize(_));
+        assert!(matches!(res, PathKeyElementSize(_)));
     }
 
     #[test]
@@ -269,7 +269,7 @@ mod tests {
             KeyElementInfo::KeyElement((key, item_element())),
         )
         .expect("ok");
-        matches!(res, PathKeyRefElement(_));
+        assert!(matches!(res, PathKeyRefElement(_)));
 
         let res = PathKeyElementInfo::<0>::from_path_and_key_element(
             path.clone(),
@@ -282,13 +282,16 @@ mod tests {
             )),
         )
         .expect("ok");
-        matches!(res, PathKeyElementSize(_));
+        assert!(matches!(res, PathKeyElementSize(_)));
 
         let err = PathKeyElementInfo::<0>::from_path_and_key_element(
             path,
             KeyElementInfo::KeyUnknownElementSize((KnownKey(vec![]), 8)),
         )
         .expect_err("err");
-        matches!(err, Error::Drive(DriveError::NotSupportedPrivate(_)));
+        assert!(matches!(
+            err,
+            Error::Drive(DriveError::NotSupportedPrivate(_))
+        ));
     }
 }

--- a/packages/rs-drive/src/util/object_size_info/path_key_info.rs
+++ b/packages/rs-drive/src/util/object_size_info/path_key_info.rs
@@ -250,3 +250,193 @@ impl<'a, const N: usize> PathKeyInfo<'a, N> {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use grovedb::batch::key_info::KeyInfo::MaxKeySize;
+
+    #[test]
+    fn try_from_empty_vec_errors() {
+        let v: Vec<Vec<u8>> = vec![];
+        let result: Result<PathKeyInfo<'static, 0>, Error> = v.try_into();
+        let err = result.expect_err("empty vec should fail");
+        match err {
+            Error::Drive(DriveError::InvalidPath(msg)) => {
+                assert!(msg.contains("must not be none"));
+            }
+            _ => panic!("expected InvalidPath"),
+        }
+    }
+
+    #[test]
+    fn try_from_non_empty_vec_splits_last() {
+        let v: Vec<Vec<u8>> = vec![vec![1u8], vec![2u8, 3u8], vec![4u8]];
+        let pk: PathKeyInfo<0> = v.try_into().expect("should convert");
+        match pk {
+            PathKey((path, key)) => {
+                assert_eq!(path, vec![vec![1u8], vec![2u8, 3u8]]);
+                assert_eq!(key, vec![4u8]);
+            }
+            _ => panic!("expected PathKey"),
+        }
+    }
+
+    #[test]
+    fn try_from_single_element_vec() {
+        let v: Vec<Vec<u8>> = vec![vec![9u8]];
+        let pk: PathKeyInfo<0> = v.try_into().expect("single element should work");
+        match pk {
+            PathKey((path, key)) => {
+                assert!(path.is_empty());
+                assert_eq!(key, vec![9u8]);
+            }
+            _ => panic!("expected PathKey"),
+        }
+    }
+
+    #[test]
+    fn len_path_key() {
+        let pk: PathKeyInfo<0> = PathKey((vec![vec![1u8, 2], vec![3]], vec![4, 5, 6]));
+        assert_eq!(pk.len(), 6);
+    }
+
+    #[test]
+    fn len_path_key_ref() {
+        let key: &[u8] = &[10u8, 11];
+        let pk: PathKeyInfo<0> = PathKeyRef((vec![vec![1u8]], key));
+        assert_eq!(pk.len(), 3);
+    }
+
+    #[test]
+    fn len_fixed_size_variants() {
+        let path: [&[u8]; 2] = [&[1, 2], &[3]];
+        let pk: PathKeyInfo<2> = PathFixedSizeKey((path, vec![9, 8]));
+        assert_eq!(pk.len(), 5);
+
+        let key: &[u8] = &[7];
+        let pk: PathKeyInfo<2> = PathFixedSizeKeyRef((path, key));
+        assert_eq!(pk.len(), 4);
+    }
+
+    #[test]
+    fn len_path_key_size_uses_max_length() {
+        let kip = KeyInfoPath::from_known_path([b"ab".as_ref()]);
+        let pk: PathKeyInfo<0> = PathKeySize(
+            kip,
+            MaxKeySize {
+                unique_id: vec![],
+                max_size: 5,
+            },
+        );
+        assert_eq!(pk.len(), 7);
+    }
+
+    #[test]
+    fn is_empty_detects_empty_paths_and_keys() {
+        let pk: PathKeyInfo<0> = PathKey((vec![], vec![]));
+        assert!(pk.is_empty());
+
+        let pk: PathKeyInfo<0> = PathKey((vec![vec![1u8]], vec![]));
+        assert!(!pk.is_empty());
+    }
+
+    #[test]
+    fn is_contained_in_cache_path_key() {
+        let mut cache: std::collections::HashSet<Vec<Vec<u8>>> = std::collections::HashSet::new();
+        let path = vec![vec![1u8], vec![2u8]];
+        let key = vec![3u8];
+        let mut expected = path.clone();
+        expected.push(key.clone());
+        cache.insert(expected);
+
+        let pk: PathKeyInfo<0> = PathKey((path, key));
+        assert!(pk.is_contained_in_cache(&cache));
+    }
+
+    #[test]
+    fn add_to_cache_inserts_once() {
+        let mut cache: std::collections::HashSet<Vec<Vec<u8>>> = std::collections::HashSet::new();
+        let path: [&[u8]; 2] = [&[1u8], &[2u8]];
+        let key: &[u8] = &[3u8];
+        let pk: PathKeyInfo<2> = PathFixedSizeKeyRef((path, key));
+        assert!(pk.add_to_cache(&mut cache));
+        assert_eq!(cache.len(), 1);
+        // Inserting the same one again returns false
+        assert!(!pk.add_to_cache(&mut cache));
+    }
+
+    #[test]
+    fn convert_to_key_info_path_all_variants() {
+        // PathKey
+        let pk: PathKeyInfo<0> = PathKey((vec![vec![1u8]], vec![9u8]));
+        let kip = pk.convert_to_key_info_path().expect("ok");
+        assert_eq!(kip.len(), 2);
+
+        // PathKeyRef
+        let key: &[u8] = &[8u8];
+        let pk: PathKeyInfo<0> = PathKeyRef((vec![vec![1u8]], key));
+        let kip = pk.convert_to_key_info_path().expect("ok");
+        assert_eq!(kip.len(), 2);
+
+        // PathFixedSizeKey
+        let path: [&[u8]; 1] = [&[1u8]];
+        let pk: PathKeyInfo<1> = PathFixedSizeKey((path, vec![9u8]));
+        let kip = pk.convert_to_key_info_path().expect("ok");
+        assert_eq!(kip.len(), 2);
+
+        // PathFixedSizeKeyRef
+        let key: &[u8] = &[8u8];
+        let pk: PathKeyInfo<1> = PathFixedSizeKeyRef((path, key));
+        let kip = pk.convert_to_key_info_path().expect("ok");
+        assert_eq!(kip.len(), 2);
+
+        // PathKeySize
+        let pk: PathKeyInfo<0> = PathKeySize(
+            KeyInfoPath::from_known_owned_path(vec![vec![1u8]]),
+            KnownKey(vec![9u8]),
+        );
+        let kip = pk.convert_to_key_info_path().expect("ok");
+        assert_eq!(kip.len(), 2);
+    }
+
+    #[test]
+    fn display_renders_variants() {
+        let pk: PathKeyInfo<0> = PathKey((vec![vec![b'a']], vec![b'b']));
+        let s = format!("{}", pk);
+        assert!(s.starts_with("PathKey(path:"));
+
+        let key: &[u8] = &[b'c'];
+        let pk: PathKeyInfo<0> = PathKeyRef((vec![vec![b'd']], key));
+        let s = format!("{}", pk);
+        assert!(s.starts_with("PathKeyRef(path:"));
+
+        let path: [&[u8]; 1] = [b"a"];
+        let pk: PathKeyInfo<1> = PathFixedSizeKey((path, vec![b'x']));
+        let s = format!("{}", pk);
+        assert!(s.starts_with("PathFixedSizeKey(path:"));
+
+        let key_ref: &[u8] = &[b'y'];
+        let pk: PathKeyInfo<1> = PathFixedSizeKeyRef((path, key_ref));
+        let s = format!("{}", pk);
+        assert!(s.starts_with("PathFixedSizeKeyRef(path:"));
+
+        let pk: PathKeyInfo<0> = PathKeySize(
+            KeyInfoPath::from_known_owned_path(vec![vec![b'p']]),
+            KnownKey(vec![b'k']),
+        );
+        let s = format!("{}", pk);
+        assert!(s.starts_with("PathKeySize(path_info:"));
+
+        // Max size variant path rendering
+        let pk: PathKeyInfo<0> = PathKeySize(
+            KeyInfoPath::from_known_owned_path(vec![vec![b'p']]),
+            MaxKeySize {
+                unique_id: vec![b'z'],
+                max_size: 7,
+            },
+        );
+        let s = format!("{}", pk);
+        assert!(s.contains("MaxKeySize"));
+    }
+}


### PR DESCRIPTION
## Issue being fixed or feature implemented

Seventh PR in the push toward 90% global coverage. After [#3503](https://github.com/dashpay/platform/pull/3503)–[#3512](https://github.com/dashpay/platform/pull/3512) we were at **86.77%**. This PR targets ~4,000 missed lines across 4 focus areas and brings the project to **87.04%**.

## What was done?

**181 new unit tests** across 30 files.

| Target | Prev cov | Missed | Tests added |
|---|---|---|---|
| rs-drive/drive/document (error paths only) | 83% | 1572 | 11 |
| rs-drive/drive/votes | 81% | 517 | 37 |
| rs-drive/state_transition_action/identity | 82% | 294 | 10 |
| rs-drive-abci/query/token_queries + system + voting | 81–83% | 1000 | 21 |
| rs-dpp/data_contract/config | 76% | 169 | 11 |
| rs-drive/util/object_size_info | 76% | 160 | 50+ |
| rs-dpp/voting/contender_structs | **68%** | 135 | 4 |
| rs-drive/drive/balances | 73% | 110 | 10 |
| rs-dpp/voting/vote_info_storage | **69%** | 100 | 26 |
| rs-drive-abci/platform_types/platform | **46%** | 119 | 5 |

### Highlighted coverage wins

**drive/document** — error-path focus: `DataContractNotFound` + unknown-document-type + malformed-bytes rejection paths in `add_document_v0` / `delete_document_for_contract_id_*` / `update_document_for_contract_id_*` / `update_document_with_serialization_for_contract_v0`, plus `apply=false` estimation-costs branches.

**drive/votes** — `ResourceVoteChoice::to_key` all 3 variants; `TreePath for ResourceVote` error branches (contract-id mismatch, unknown doc type, unknown index name); `TreePathStorageForm::try_from_tree_path` exhaustive error matrix across two impls; `resolve_with_contract` `UnknownVersionMismatch` dispatch error; `ContestedDocumentResourceVotePoll` index/document_type accessor errors + owned/borrowed parity.

**state_transition_action/identity** — `identity_create_from_addresses` + `identity_topup_from_addresses` transformers: empty-inputs `ValueError`, input-sum overflow, `output > inputs` overflow, success with and without output.

**query modules** — `prove: true` paths (previously untested in 5 voting modules), `InvalidLimit` propagation for token_pre_programmed_distributions, `u16::MAX` range guard in finalized_epoch_infos, limit-rejection in contested_resource_identity_votes and vote_polls_by_end_date_query. Fixed two mis-named `count_*` tests in `contested_resource_vote_state` to reflect that they pin validation **ordering** (contract_id check runs before count), not the count branch itself.

**voting/vote_info_storage** — `finalize_vote_poll` guards (NotStarted/Locked), all three `ContestedDocumentVotePollWinnerInfo` branches, `last_locked_votes` + `last_abstain_votes` aggregation, bincode roundtrip, all `ContestedDocumentVotePollStoredInfoV0Getters` proxies.

**util/object_size_info** (50+ tests across 6 files) — `drive_key_info`/`key_value_info`/`path_info`/`path_key_info`/`path_key_element_info`/`contract_info` len/is_empty/convert branches, `push` error paths (fixed-size, KeySize-into-Vec), `KeyUnknownElementSize` rejection, `DocumentTypeInfo::resolve` missing-type errors.

**drive/balances** — path-helper consistency (array form matches vec form); `add_to_system_credits` + `remove_from_system_credits` roundtrip under a real Drive; zero-amount no-op.

**platform_types/platform** — Debug impls, `From<&PlatformRef> for PlatformStateRef` pointer-equality forwarding, open-with-latest-protocol success, `committed_block_height_guard` init.

### CodeRabbit review addressed

8 review comments handled in the follow-up commit, all test-quality tightenings:
- `data_contract/config` `reads_booleans_from_map`: use distinct `(true, false)` / `(false, true)` pairs so a key mix-up would fail.
- `voting/vote_info_storage` (3 sites) + `util/object_size_info` (~13 sites): wrap bare `matches!(...)` in `assert!(matches!(...))` — the bare form returns a discarded bool, making the tests no-ops.
- `drive/document/delete` `test_delete_nonexistent_document_without_apply_estimation_costs`: the estimation branch actually succeeds (fake cost estimates, not real grove ops). Assert success + non-zero fee estimate instead of dropping the result.
- `query/voting/contested_resource_vote_state` `count_*` tests: renamed to reflect they pin validation ordering, and tightened the second assertion to match the same `InvalidArgument("contract_id …")` as the first.

## Follow-up observations

Two things surfaced during coverage work that deserve visibility but are **out of scope** for this PR:

### V0 config parser quirk — consensus-frozen, NOT a bug

`get_contract_configuration_properties_v0` at [packages/rs-dpp/src/data_contract/config/v0/mod.rs:177-185](packages/rs-dpp/src/data_contract/config/v0/mod.rs#L177-L185) reads the decryption bounded-key field from `REQUIRES_IDENTITY_ENCRYPTION_BOUNDED_KEY` (V1 at [v1/mod.rs:140](packages/rs-dpp/src/data_contract/config/v1/mod.rs#L140) reads from the correct key).

Originally flagged in the commit message as a potential bug. **That characterization was wrong** — this is consensus-frozen V0 parser behavior. Changing it would risk a fork on any node replaying historical V0 contracts. [#3514](https://github.com/dashpay/platform/pull/3514) pins the current behavior in place with lock-in tests and an in-code `CONSENSUS-FROZEN BUG` comment so it doesn't get "fixed" later.

### `InvalidLimit` error surface in query modules (minor design observation)

Multiple query modules propagate `InvalidLimit` via a top-level `Err(Error::Drive(Query(InvalidLimit)))` instead of wrapping it in a `QueryValidationResult::new_with_error(...)`. This is inconsistent with sibling validators in the same files, and means gRPC clients see a transport-level error for `limit=0` / `limit>max` rather than a structured validation response. Not incorrect — just inconsistent. Worth a small unifying PR but not required here.

## How Has This Been Tested?

- `cargo check --tests -p dpp -p drive -p drive-abci` — clean
- `cargo fmt -p dpp -p drive -p drive-abci` — clean
- Per-target test runs (all pass): `drive::document`, `drive::votes`, `state_transition_action::identity`, `query::token_queries`, `query::system`, `query::voting`, `data_contract::config`, `voting::contender_structs`, `voting::vote_info_storage`, `util::object_size_info`, `drive::balances`, `platform_types::platform`.
- Codecov: project `86.77% → 87.04%` (+0.27%), patch 98%+.

## Breaking Changes

None. Tests only.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [x] I have made corresponding changes to the documentation if needed

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone