### PR TITLE
test(dpp): pin V0 config parser consensus-frozen quirk

### DIFF
--- a/packages/rs-dpp/src/data_contract/config/mod.rs
+++ b/packages/rs-dpp/src/data_contract/config/mod.rs
@@ -583,4 +583,69 @@ mod tests {
             }
         }
     }
+
+    mod get_contract_configuration_properties {
+        use super::*;
+        use crate::data_contract::config::property::{
+            REQUIRES_IDENTITY_DECRYPTION_BOUNDED_KEY, REQUIRES_IDENTITY_ENCRYPTION_BOUNDED_KEY,
+        };
+        use platform_value::Value;
+        use std::collections::BTreeMap;
+
+        /// Regression test for a copy-paste bug where V0 parsing read both
+        /// encryption and decryption bounded-key fields from the same map key
+        /// (`requiresIdentityEncryptionBoundedKey`), making it impossible to
+        /// set them to different values via the map-based parser.
+        #[test]
+        fn v0_parses_encryption_and_decryption_keys_from_distinct_properties() {
+            let mut map: BTreeMap<String, Value> = BTreeMap::new();
+            map.insert(
+                REQUIRES_IDENTITY_ENCRYPTION_BOUNDED_KEY.to_string(),
+                Value::U8(StorageKeyRequirements::Unique as u8),
+            );
+            map.insert(
+                REQUIRES_IDENTITY_DECRYPTION_BOUNDED_KEY.to_string(),
+                Value::U8(StorageKeyRequirements::Multiple as u8),
+            );
+
+            let config = DataContractConfigV0::get_contract_configuration_properties_v0(&map)
+                .expect("should parse V0 config");
+
+            assert_eq!(
+                config.requires_identity_encryption_bounded_key,
+                Some(StorageKeyRequirements::Unique)
+            );
+            assert_eq!(
+                config.requires_identity_decryption_bounded_key,
+                Some(StorageKeyRequirements::Multiple)
+            );
+        }
+
+        #[test]
+        fn v0_leaves_bounded_key_fields_none_when_absent() {
+            let map: BTreeMap<String, Value> = BTreeMap::new();
+            let config = DataContractConfigV0::get_contract_configuration_properties_v0(&map)
+                .expect("should parse V0 config with defaults");
+            assert!(config.requires_identity_encryption_bounded_key.is_none());
+            assert!(config.requires_identity_decryption_bounded_key.is_none());
+        }
+
+        #[test]
+        fn v0_parses_only_decryption_when_encryption_absent() {
+            let mut map: BTreeMap<String, Value> = BTreeMap::new();
+            map.insert(
+                REQUIRES_IDENTITY_DECRYPTION_BOUNDED_KEY.to_string(),
+                Value::U8(StorageKeyRequirements::MultipleReferenceToLatest as u8),
+            );
+
+            let config = DataContractConfigV0::get_contract_configuration_properties_v0(&map)
+                .expect("should parse V0 config");
+
+            assert!(config.requires_identity_encryption_bounded_key.is_none());
+            assert_eq!(
+                config.requires_identity_decryption_bounded_key,
+                Some(StorageKeyRequirements::MultipleReferenceToLatest)
+            );
+        }
+    }
 }

--- a/packages/rs-dpp/src/data_contract/config/mod.rs
+++ b/packages/rs-dpp/src/data_contract/config/mod.rs
@@ -584,7 +584,14 @@ mod tests {
         }
     }
 
-    mod get_contract_configuration_properties {
+    /// V0's `get_contract_configuration_properties_v0` has a historical
+    /// copy-paste quirk: the decryption bounded-key field is parsed from
+    /// the `requiresIdentityEncryptionBoundedKey` property (not the matching
+    /// DECRYPTION one). This is part of V0 protocol behavior and MUST NOT be
+    /// changed — altering it would fork the chain. V1 parses correctly; see
+    /// `v1/mod.rs`. These tests lock the V0 behavior in place so the quirk
+    /// is not silently "fixed" by a future well-intentioned refactor.
+    mod get_contract_configuration_properties_v0_consensus_lock {
         use super::*;
         use crate::data_contract::config::property::{
             REQUIRES_IDENTITY_DECRYPTION_BOUNDED_KEY, REQUIRES_IDENTITY_ENCRYPTION_BOUNDED_KEY,
@@ -592,12 +599,59 @@ mod tests {
         use platform_value::Value;
         use std::collections::BTreeMap;
 
-        /// Regression test for a copy-paste bug where V0 parsing read both
-        /// encryption and decryption bounded-key fields from the same map key
-        /// (`requiresIdentityEncryptionBoundedKey`), making it impossible to
-        /// set them to different values via the map-based parser.
+        /// When the ENCRYPTION property is set, V0 applies that value to
+        /// BOTH the encryption and decryption fields — because the parser
+        /// reads both from the same key.
         #[test]
-        fn v0_parses_encryption_and_decryption_keys_from_distinct_properties() {
+        fn encryption_property_populates_both_fields() {
+            let mut map: BTreeMap<String, Value> = BTreeMap::new();
+            map.insert(
+                REQUIRES_IDENTITY_ENCRYPTION_BOUNDED_KEY.to_string(),
+                Value::U8(StorageKeyRequirements::Unique as u8),
+            );
+
+            let config = DataContractConfigV0::get_contract_configuration_properties_v0(&map)
+                .expect("should parse V0 config");
+
+            assert_eq!(
+                config.requires_identity_encryption_bounded_key,
+                Some(StorageKeyRequirements::Unique)
+            );
+            assert_eq!(
+                config.requires_identity_decryption_bounded_key,
+                Some(StorageKeyRequirements::Unique),
+                "V0 consensus quirk: decryption field is read from the ENCRYPTION key"
+            );
+        }
+
+        /// When ONLY the DECRYPTION property is set, V0 ignores it entirely
+        /// — neither field is populated, because V0 never reads the
+        /// DECRYPTION key.
+        #[test]
+        fn decryption_property_is_ignored_by_v0() {
+            let mut map: BTreeMap<String, Value> = BTreeMap::new();
+            map.insert(
+                REQUIRES_IDENTITY_DECRYPTION_BOUNDED_KEY.to_string(),
+                Value::U8(StorageKeyRequirements::MultipleReferenceToLatest as u8),
+            );
+
+            let config = DataContractConfigV0::get_contract_configuration_properties_v0(&map)
+                .expect("should parse V0 config");
+
+            assert!(
+                config.requires_identity_encryption_bounded_key.is_none(),
+                "V0 does not read the DECRYPTION property at all"
+            );
+            assert!(
+                config.requires_identity_decryption_bounded_key.is_none(),
+                "V0 consensus quirk: decryption field is NOT sourced from the DECRYPTION key"
+            );
+        }
+
+        /// When BOTH properties are set, the ENCRYPTION value wins for both
+        /// fields; the DECRYPTION property is ignored.
+        #[test]
+        fn encryption_wins_when_both_properties_set() {
             let mut map: BTreeMap<String, Value> = BTreeMap::new();
             map.insert(
                 REQUIRES_IDENTITY_ENCRYPTION_BOUNDED_KEY.to_string(),
@@ -617,35 +671,19 @@ mod tests {
             );
             assert_eq!(
                 config.requires_identity_decryption_bounded_key,
-                Some(StorageKeyRequirements::Multiple)
+                Some(StorageKeyRequirements::Unique),
+                "V0 consensus quirk: the DECRYPTION property is ignored"
             );
         }
 
+        /// Sanity check: with neither property set, both fields stay `None`.
         #[test]
-        fn v0_leaves_bounded_key_fields_none_when_absent() {
+        fn neither_property_set_leaves_both_none() {
             let map: BTreeMap<String, Value> = BTreeMap::new();
             let config = DataContractConfigV0::get_contract_configuration_properties_v0(&map)
                 .expect("should parse V0 config with defaults");
             assert!(config.requires_identity_encryption_bounded_key.is_none());
             assert!(config.requires_identity_decryption_bounded_key.is_none());
-        }
-
-        #[test]
-        fn v0_parses_only_decryption_when_encryption_absent() {
-            let mut map: BTreeMap<String, Value> = BTreeMap::new();
-            map.insert(
-                REQUIRES_IDENTITY_DECRYPTION_BOUNDED_KEY.to_string(),
-                Value::U8(StorageKeyRequirements::MultipleReferenceToLatest as u8),
-            );
-
-            let config = DataContractConfigV0::get_contract_configuration_properties_v0(&map)
-                .expect("should parse V0 config");
-
-            assert!(config.requires_identity_encryption_bounded_key.is_none());
-            assert_eq!(
-                config.requires_identity_decryption_bounded_key,
-                Some(StorageKeyRequirements::MultipleReferenceToLatest)
-            );
         }
     }
 }

--- a/packages/rs-dpp/src/data_contract/config/v0/mod.rs
+++ b/packages/rs-dpp/src/data_contract/config/v0/mod.rs
@@ -179,8 +179,14 @@ impl DataContractConfigV0 {
             .map(|int| int.try_into())
             .transpose()?;
 
+        // CONSENSUS-FROZEN BUG: this intentionally reads from
+        // `REQUIRES_IDENTITY_ENCRYPTION_BOUNDED_KEY` (not the matching
+        // DECRYPTION constant). The V0 parser shipped this way and its output
+        // is part of V0 protocol behavior, so it must not be changed even
+        // though it looks like a copy-paste typo. V1 reads from the correct
+        // DECRYPTION key — see v1/mod.rs. Do not "fix" this line.
         let requires_identity_decryption_bounded_key = contract
-            .get_optional_integer::<u8>(config::property::REQUIRES_IDENTITY_DECRYPTION_BOUNDED_KEY)?
+            .get_optional_integer::<u8>(config::property::REQUIRES_IDENTITY_ENCRYPTION_BOUNDED_KEY)?
             .map(|int| int.try_into())
             .transpose()?;
 

--- a/packages/rs-dpp/src/data_contract/config/v0/mod.rs
+++ b/packages/rs-dpp/src/data_contract/config/v0/mod.rs
@@ -180,7 +180,7 @@ impl DataContractConfigV0 {
             .transpose()?;
 
         let requires_identity_decryption_bounded_key = contract
-            .get_optional_integer::<u8>(config::property::REQUIRES_IDENTITY_ENCRYPTION_BOUNDED_KEY)?
+            .get_optional_integer::<u8>(config::property::REQUIRES_IDENTITY_DECRYPTION_BOUNDED_KEY)?
             .map(|int| int.try_into())
             .transpose()?;
 


### PR DESCRIPTION
## Issue being fixed or feature implemented

While investigating [packages/rs-dpp/src/data_contract/config/v0/mod.rs:177-185](packages/rs-dpp/src/data_contract/config/v0/mod.rs#L177-L185), I noticed that `get_contract_configuration_properties_v0` reads the decryption bounded-key field from `REQUIRES_IDENTITY_ENCRYPTION_BOUNDED_KEY` (not the matching DECRYPTION constant). V1 at [packages/rs-dpp/src/data_contract/config/v1/mod.rs:140](packages/rs-dpp/src/data_contract/config/v1/mod.rs#L140) reads from the correct key.

It looks like a copy-paste typo from [#1358](https://github.com/dashpay/platform/pull/1358) (2023-09), but **it is part of V0 protocol behavior and must not be changed**: altering the V0 parser's output would risk a fork on any node replaying historical V0 contracts, even if the function appears dead today.

So this PR **does not fix the bug**. Instead it locks the existing V0 behavior in place so nobody accidentally "fixes" it later.

## What was done?

- Added a `CONSENSUS-FROZEN BUG` comment directly at the offending line in V0, pointing at V1 as the correct reference.
- Added a `get_contract_configuration_properties_v0_consensus_lock` test module asserting the current V0 behavior:
  - Setting only the ENCRYPTION property populates **both** encryption and decryption fields (the quirk).
  - Setting only the DECRYPTION property is ignored entirely by V0.
  - When both are set, the ENCRYPTION value wins for both fields; DECRYPTION is ignored.
  - When neither is set, both fields stay `None`.

No functional code change — V0 parsing behavior is unchanged. V1 is untouched.

### Commit history

This branch has two commits on it. The first commit (`fix(dpp): ...`) was an incorrect attempt to patch the typo before I realized the consensus implications. The second commit (`test(dpp): ...`) reverts that change and replaces the regression tests with lock-in tests. Both kept for transparency; happy to squash before merge.

## How Has This Been Tested?

```
cargo test -p dpp -- data_contract::config
# 34 passed; 0 failed (4 new lock-in tests)
cargo fmt -p dpp
```

## Breaking Changes

None. Behavior of the V0 parser is preserved exactly.

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [ ] I have made corresponding changes to the documentation if needed

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added unit tests for contract configuration property behavior validation.

* **Documentation**
  * Added clarifying in-code comments for configuration parsing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->