### PR TITLE
fix(dpp): populate transferred_at in random_document_with_params when required

### DIFF
--- a/packages/rs-dpp/src/data_contract/document_type/random_document.rs
+++ b/packages/rs-dpp/src/data_contract/document_type/random_document.rs
@@ -5,7 +5,8 @@ use crate::data_contract::document_type::accessors::DocumentTypeV0Getters;
 use crate::data_contract::document_type::methods::DocumentTypeV0Methods;
 use crate::data_contract::document_type::{DocumentType, DocumentTypeRef};
 use crate::document::property_names::{
-    CREATED_AT, CREATED_AT_BLOCK_HEIGHT, CREATED_AT_CORE_BLOCK_HEIGHT, UPDATED_AT,
+    CREATED_AT, CREATED_AT_BLOCK_HEIGHT, CREATED_AT_CORE_BLOCK_HEIGHT, TRANSFERRED_AT,
+    TRANSFERRED_AT_BLOCK_HEIGHT, TRANSFERRED_AT_CORE_BLOCK_HEIGHT, UPDATED_AT,
     UPDATED_AT_BLOCK_HEIGHT, UPDATED_AT_CORE_BLOCK_HEIGHT,
 };
 use crate::document::{Document, DocumentV0, INITIAL_REVISION};
@@ -329,6 +330,46 @@ pub trait CreateRandomDocument: DocumentTypeV0Getters + DocumentTypeV0Methods {
             None
         };
 
+        let transferred_at = if self.required_fields().contains(TRANSFERRED_AT) {
+            if time_ms.is_some() {
+                time_ms
+            } else if created_at.is_some() {
+                created_at
+            } else {
+                let now = SystemTime::now();
+                let duration_since_epoch =
+                    now.duration_since(UNIX_EPOCH).expect("Time went backwards");
+                let milliseconds = duration_since_epoch.as_millis() as u64;
+                Some(milliseconds)
+            }
+        } else {
+            None
+        };
+
+        let transferred_at_block_height =
+            if self.required_fields().contains(TRANSFERRED_AT_BLOCK_HEIGHT) {
+                if block_height.is_some() {
+                    block_height
+                } else {
+                    Some(0)
+                }
+            } else {
+                None
+            };
+
+        let transferred_at_core_block_height = if self
+            .required_fields()
+            .contains(TRANSFERRED_AT_CORE_BLOCK_HEIGHT)
+        {
+            if core_block_height.is_some() {
+                core_block_height
+            } else {
+                Some(0)
+            }
+        } else {
+            None
+        };
+
         match platform_version
             .dpp
             .document_versions
@@ -341,13 +382,13 @@ pub trait CreateRandomDocument: DocumentTypeV0Getters + DocumentTypeV0Methods {
                 revision,
                 created_at,
                 updated_at,
-                transferred_at: None,
+                transferred_at,
                 created_at_block_height,
                 updated_at_block_height,
-                transferred_at_block_height: None,
+                transferred_at_block_height,
                 created_at_core_block_height,
                 updated_at_core_block_height,
-                transferred_at_core_block_height: None,
+                transferred_at_core_block_height,
                 creator_id: None,
             }
             .into()),
@@ -424,3 +465,124 @@ pub trait CreateRandomDocument: DocumentTypeV0Getters + DocumentTypeV0Methods {
 impl CreateRandomDocument for DocumentType {}
 
 impl CreateRandomDocument for DocumentTypeRef<'_> {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::data_contract::accessors::v0::DataContractV0Getters;
+    use crate::document::DocumentV0Getters;
+    use crate::system_data_contracts::{load_system_data_contract, SystemDataContract};
+
+    /// Regression test for a bug where `random_document_with_params`
+    /// unconditionally set `transferred_at` / `transferred_at_block_height`
+    /// / `transferred_at_core_block_height` to `None`, even when the
+    /// document type listed those fields in `required_fields`. Callers then
+    /// hit `MissingRequiredKey("transferred at field is not present")` on
+    /// later serialize.
+    ///
+    /// DPNS `domain` lists `$transferredAt` in its required fields, so the
+    /// generated document's `transferred_at` must be `Some(_)`.
+    #[test]
+    fn random_document_populates_transferred_at_when_required() {
+        let platform_version = PlatformVersion::latest();
+        let dpns = load_system_data_contract(SystemDataContract::DPNS, platform_version)
+            .expect("load DPNS");
+        let domain = dpns
+            .document_type_for_name("domain")
+            .expect("domain document type");
+
+        assert!(
+            domain
+                .required_fields()
+                .contains(crate::document::property_names::TRANSFERRED_AT),
+            "precondition: DPNS domain requires $transferredAt"
+        );
+
+        let mut rng = StdRng::seed_from_u64(42);
+        let doc = domain
+            .random_document_with_params(
+                Identifier::random_with_rng(&mut rng),
+                Bytes32::random_with_rng(&mut rng),
+                Some(1_700_000_000_000),
+                Some(10),
+                Some(1),
+                DocumentFieldFillType::FillIfNotRequired,
+                DocumentFieldFillSize::AnyDocumentFillSize,
+                &mut rng,
+                platform_version,
+            )
+            .expect("generate random DPNS domain");
+
+        assert_eq!(
+            doc.transferred_at(),
+            Some(1_700_000_000_000),
+            "transferred_at should be populated from time_ms when required"
+        );
+    }
+
+    /// When `$transferredAt` is NOT in the required fields, the generated
+    /// document must keep `transferred_at` as `None`. DPNS `preorder` has
+    /// no `$transferredAt*` requirements, so all three must be `None`.
+    #[test]
+    fn random_document_leaves_transferred_at_none_when_not_required() {
+        let platform_version = PlatformVersion::latest();
+        let dpns = load_system_data_contract(SystemDataContract::DPNS, platform_version)
+            .expect("load DPNS");
+        let preorder = dpns
+            .document_type_for_name("preorder")
+            .expect("preorder document type");
+
+        let mut rng = StdRng::seed_from_u64(7);
+        let doc = preorder
+            .random_document_with_params(
+                Identifier::random_with_rng(&mut rng),
+                Bytes32::random_with_rng(&mut rng),
+                Some(1_700_000_000_000),
+                Some(10),
+                Some(1),
+                DocumentFieldFillType::FillIfNotRequired,
+                DocumentFieldFillSize::AnyDocumentFillSize,
+                &mut rng,
+                platform_version,
+            )
+            .expect("generate random DPNS preorder");
+
+        assert_eq!(doc.transferred_at(), None);
+        assert_eq!(doc.transferred_at_block_height(), None);
+        assert_eq!(doc.transferred_at_core_block_height(), None);
+    }
+
+    /// When `time_ms` / `block_height` / `core_block_height` are not
+    /// provided but the fields are required, the function should fall
+    /// back to `created_at` for `transferred_at`, and `Some(0)` for the
+    /// block-height fields — mirroring the existing CREATED_AT behavior.
+    #[test]
+    fn transferred_at_falls_back_to_created_at_when_no_time_provided() {
+        let platform_version = PlatformVersion::latest();
+        let dpns = load_system_data_contract(SystemDataContract::DPNS, platform_version)
+            .expect("load DPNS");
+        let domain = dpns
+            .document_type_for_name("domain")
+            .expect("domain document type");
+
+        let mut rng = StdRng::seed_from_u64(13);
+        let doc = domain
+            .random_document_with_params(
+                Identifier::random_with_rng(&mut rng),
+                Bytes32::random_with_rng(&mut rng),
+                None,
+                None,
+                None,
+                DocumentFieldFillType::FillIfNotRequired,
+                DocumentFieldFillSize::AnyDocumentFillSize,
+                &mut rng,
+                platform_version,
+            )
+            .expect("generate random DPNS domain");
+
+        // When time_ms is None and $createdAt is also required (DPNS
+        // domain requires both), transferred_at should equal created_at.
+        assert!(doc.created_at().is_some());
+        assert_eq!(doc.transferred_at(), doc.created_at());
+    }
+}


### PR DESCRIPTION
## Issue being fixed or feature implemented

[packages/rs-dpp/src/data_contract/document_type/random_document.rs:206](packages/rs-dpp/src/data_contract/document_type/random_document.rs#L206) `DocumentType::random_document_with_params` unconditionally set `transferred_at`, `transferred_at_block_height`, and `transferred_at_core_block_height` to `None` — even when those fields were listed in the document type's `required_fields`.

Callers that subsequently serialized the returned `Document` (e.g. any test that writes it to grove) hit:

```
DataContractError(MissingRequiredKey("transferred at field is not present"))
```

This was surfaced while writing uniqueness-violation tests against DPNS `domain` in [#3516](https://github.com/dashpay/platform/pull/3516).

All other `random_*` methods delegate to `random_document_with_params`, so the bug affected every random-document helper in the `CreateRandomDocument` trait.

## What was done?

Mirror the existing `$createdAt` / `$createdAtBlockHeight` / `$createdAtCoreBlockHeight` logic for the three `$transferredAt` fields:

- **`transferred_at`** — use `time_ms` if provided, else `created_at`, else wall clock. Matches the `updated_at` fallback chain.
- **`transferred_at_block_height`** — use `block_height` if provided, else `Some(0)`. Matches `updated_at_block_height`.
- **`transferred_at_core_block_height`** — use `core_block_height` if provided, else `Some(0)`. Matches `updated_at_core_block_height`.

Added three regression tests using DPNS as fixture data:

1. **`random_document_populates_transferred_at_when_required`** — DPNS `domain` requires `$transferredAt`, so the generated doc must have it populated from `time_ms`.
2. **`random_document_leaves_transferred_at_none_when_not_required`** — DPNS `preorder` requires none of the three `$transferredAt*` fields, so all three must be `None`.
3. **`transferred_at_falls_back_to_created_at_when_no_time_provided`** — when `time_ms` is not provided, `transferred_at` should fall back to `created_at`.

## How Has This Been Tested?

- `cargo test -p dpp --lib 'data_contract::document_type::random_document'` — 3/3 pass
- `cargo check --tests -p dpp` — clean
- `cargo fmt -p dpp` — clean

## Breaking Changes

None. The fix only changes behavior when the document type lists a `$transferredAt*` field as required — the old code produced a `Document` that would fail serialization in that case. Callers that were relying on the old behavior for non-required cases see no change.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [x] I have made corresponding changes to the documentation if needed

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone