### PR TITLE
fix(drive-abci): swap operands in core-sync chain lock height check

### DIFF
--- a/packages/rs-drive-abci/src/execution/platform_events/core_chain_lock/make_sure_core_is_synced_to_chain_lock/v0/mod.rs
+++ b/packages/rs-drive-abci/src/execution/platform_events/core_chain_lock/make_sure_core_is_synced_to_chain_lock/v0/mod.rs
@@ -23,7 +23,7 @@ where
         let best_chain_locked_height = self.core_rpc.submit_chain_lock(chain_lock)?;
         Ok(if best_chain_locked_height >= given_chain_lock_height {
             CoreSyncStatus::Done
-        } else if best_chain_locked_height - given_chain_lock_height
+        } else if given_chain_lock_height - best_chain_locked_height
             <= platform_version
                 .drive_abci
                 .methods
@@ -37,7 +37,57 @@ where
     }
 }
 
-// Tests removed: the production method `make_sure_core_is_synced_to_chain_lock_v0` requires
-// a Platform<C> whose `core_rpc` has mock expectations configured before construction.
-// The previous tests created mocks but never called the production method, only testing
-// inline if/else arithmetic. Real integration coverage belongs in higher-level tests.
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::rpc::core::MockCoreRPCLike;
+    use crate::test::helpers::setup::TestPlatformBuilder;
+    use dpp::dashcore::hashes::Hash;
+    use dpp::dashcore::{BlockHash, ChainLock};
+
+    fn chain_lock_at(height: u32) -> ChainLock {
+        ChainLock {
+            block_height: height,
+            block_hash: BlockHash::from_byte_array([0u8; 32]),
+            signature: [0u8; 96].into(),
+        }
+    }
+
+    fn run(best: u32, given: u32) -> CoreSyncStatus {
+        let mut platform = TestPlatformBuilder::new()
+            .with_latest_protocol_version()
+            .build_with_mock_rpc();
+        let mut mock_rpc = MockCoreRPCLike::new();
+        mock_rpc
+            .expect_submit_chain_lock()
+            .returning(move |_| Ok(best));
+        platform.core_rpc = mock_rpc;
+
+        let platform_version = PlatformVersion::latest();
+        platform
+            .platform
+            .make_sure_core_is_synced_to_chain_lock_v0(&chain_lock_at(given), platform_version)
+            .expect("should succeed")
+    }
+
+    #[test]
+    fn returns_done_when_core_caught_up() {
+        assert!(matches!(run(100, 100), CoreSyncStatus::Done));
+        assert!(matches!(run(101, 100), CoreSyncStatus::Done));
+    }
+
+    #[test]
+    fn returns_almost_when_core_is_slightly_behind() {
+        // recent_block_count_amount is 2 in the latest version.
+        // With the pre-fix code, `best - given` would underflow here:
+        // debug -> panic, release -> wraparound to near u32::MAX, falsely yielding `Not`.
+        assert!(matches!(run(99, 100), CoreSyncStatus::Almost));
+        assert!(matches!(run(98, 100), CoreSyncStatus::Almost));
+    }
+
+    #[test]
+    fn returns_not_when_core_is_far_behind() {
+        assert!(matches!(run(97, 100), CoreSyncStatus::Not));
+        assert!(matches!(run(0, 1000), CoreSyncStatus::Not));
+    }
+}

--- a/packages/rs-drive-abci/src/execution/platform_events/core_chain_lock/verify_chain_lock_through_core/v0/mod.rs
+++ b/packages/rs-drive-abci/src/execution/platform_events/core_chain_lock/verify_chain_lock_through_core/v0/mod.rs
@@ -25,7 +25,7 @@ where
             let best_chain_locked_height = self.core_rpc.submit_chain_lock(chain_lock)?;
             Ok(if best_chain_locked_height >= given_chain_lock_height {
                 (true, Some(CoreSyncStatus::Done))
-            } else if best_chain_locked_height - given_chain_lock_height
+            } else if given_chain_lock_height - best_chain_locked_height
                 <= platform_version
                     .drive_abci
                     .methods


### PR DESCRIPTION
## Issue being fixed or feature implemented

Production underflow bug in [`make_sure_core_is_synced_to_chain_lock_v0`](packages/rs-drive-abci/src/execution/platform_events/core_chain_lock/make_sure_core_is_synced_to_chain_lock/v0/mod.rs). The preceding branch gates on `best_chain_locked_height >= given_chain_lock_height`, so the `else if` branch only runs when `best < given`. The subtraction `best - given` therefore underflows: panic in debug, wrap-around to near `u32::MAX` in release (silently masking `CoreSyncStatus::Almost` as `::Not`).

The same bug existed in [`verify_chain_lock_through_core_v0`](packages/rs-drive-abci/src/execution/platform_events/core_chain_lock/verify_chain_lock_through_core/v0/mod.rs); both are fixed in this PR.

## What was done?

- Swapped the operands in both `else if` branches so the subtraction matches the intended "how far behind is core?" semantics: `given_chain_lock_height - best_chain_locked_height`.
- Added regression tests in [`make_sure_core_is_synced_to_chain_lock/v0/mod.rs`](packages/rs-drive-abci/src/execution/platform_events/core_chain_lock/make_sure_core_is_synced_to_chain_lock/v0/mod.rs) covering `Done`, `Almost`, and `Not`. The `Almost` cases (`best=99, given=100` and `best=98, given=100`) would have panicked under the old code in debug and wrapped to `Not` in release.

**Consensus safety:** not consensus-relevant. `CoreSyncStatus` only gates a local retry loop on the proposer. In release builds the wrap-around silently resolved to `CoreSyncStatus::Not`, which produces the same `core_is_synced: Some(false)` result as the intended `Almost` path after retries are exhausted — the only observable difference is that the proposer used to skip the short retry loop. No protocol version guard is needed; all registered method versions are `0`.

## How Has This Been Tested?

- `cargo test -p drive-abci make_sure_core_is_synced_to_chain_lock` — 3/3 pass.
- `cargo fmt -p drive-abci` — clean.

## Breaking Changes

None.

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [ ] I have made corresponding changes to the documentation if needed