### PR TITLE
ci: skip ssh2 optional crypto native build

### DIFF
--- a/package.json
+++ b/package.json
@@ -128,5 +128,13 @@
   "dependencies": {
     "dompurify": "^3.3.2",
     "node-gyp": "^10.0.1"
+  },
+  "dependenciesMeta": {
+    "ssh2@1.11.0": {
+      "built": false
+    },
+    "ssh2@1.16.0": {
+      "built": false
+    }
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1940,6 +1940,11 @@ __metadata:
     typedoc: "npm:^0.28.17"
     typescript: "npm:^5.7.3"
     ultra-runner: "npm:^3.10.5"
+  dependenciesMeta:
+    ssh2@1.11.0:
+      built: false
+    ssh2@1.16.0:
+      built: false
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
## Issue being fixed or feature implemented

`ssh2` — pulled in transitively via `docker-modem` — ships an optional "sshcrypto" native binding built via `node-gyp` + `nan`. On Node 24 the vendored `nan` versions (2.17 / 2.22) don't compile against V8's newer `Intercepted` / `ScriptOriginOptions` API, producing a wall of C++ errors during `yarn install --inline-builds`.

Example log (from a CI run on [#3516](https://github.com/dashpay/platform/pull/3516)):

```
ssh2@npm:1.11.0 STDERR ../../../../../../../nan-npm-2.17.0-.../nan.h:2546:8: error: 'class v8::ObjectTemplate' has no member named 'SetAccessor'
...
ssh2@npm:1.11.0 STDOUT Failed to build optional crypto binding
```

The failure is **cosmetic** — ssh2 catches it and falls back to pure-JS crypto. But the noise makes real install failures (e.g. the EBADF race addressed separately in [#3519](https://github.com/dashpay/platform/pull/3519)) much harder to spot.

## What was done?

Added `dependenciesMeta` in the root `package.json` to set `built: false` on both resolved `ssh2` versions (1.11.0 and 1.16.0). yarn skips the postinstall build script entirely, so the native compile never runs.

## How Has This Been Tested?

- Ran `yarn install --mode=skip-build` locally — config accepted, no warnings beyond pre-existing peer-dep messages.
- Updated `yarn.lock` reflects the metadata in the workspace root entry.

Functional verification: ssh2 itself already runs in a "build failed, fall back" mode in production CI today, so disabling the build is strictly a superset of the current behavior.

## Breaking Changes

None. ssh2 already operates without the optional native binding in all CI runs; this just avoids attempting the build.

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [ ] I have made corresponding changes to the documentation if needed