### PR TITLE
ci: cache yarn build-state and install-state

### DIFF
--- a/.github/actions/nodejs/action.yaml
+++ b/.github/actions/nodejs/action.yaml
@@ -26,8 +26,14 @@ runs:
     - name: Cache NPM build artifacts
       uses: actions/cache@v4
       with:
+        # Cache the unplugged packages (unpacked native builds), yarn's
+        # build-state (so postinstalls don't re-run) and install-state
+        # (cold-start avoidance). Missing paths are tolerated by the
+        # action, so first-run behavior is unaffected.
         path: |
           .yarn/unplugged
+          .yarn/build-state.yml
+          .yarn/install-state.gz
         key: ${{ runner.os }}/yarn/unplugged/${{ runner.arch }}/${{ hashFiles('yarn.lock') }}
         restore-keys: |
           ${{ runner.os }}/yarn/unplugged/${{ runner.arch }}/


### PR DESCRIPTION
## Issue being fixed or feature implemented

The Setup Node.JS composite action (`.github/actions/nodejs/action.yaml`) currently caches only `.yarn/unplugged`. On a cache hit, native-module packages already exist on disk — but yarn still re-runs every postinstall build script because it has no record of which ones previously succeeded. This is exactly the window where transient install failures (npm registry blips, `EBADF` races — see [#3519](https://github.com/dashpay/platform/pull/3519)) can bite.

## What was done?

Expanded the cache `path` to also include:

- **`.yarn/build-state.yml`** — yarn-berry tracks per-package postinstall success here. Caching it lets yarn skip re-running builds across runs with matching lockfiles.
- **`.yarn/install-state.gz`** — yarn's compressed resolution/link state. Caching it lets yarn skip cold-start hydration.

Both files are derived from `yarn.lock`, so the existing cache key (`hashFiles('yarn.lock')`) stays correct.

`actions/cache` tolerates missing paths at save time, so first-run behavior is unchanged and no explicit guards are needed.

## How Has This Been Tested?

Config-only change. Validation comes from observing on subsequent PRs that:
1. Cache-hit install runs are faster (fewer postinstall scripts executed).
2. `.yarn/build-state.yml` appears in the cached archive.

## Breaking Changes

None.

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [ ] I have made corresponding changes to the documentation if needed