### PR TITLE
test(wasm-sdk): remove invalid `position` from document-type root in fixtures

### DIFF
--- a/packages/wasm-sdk/tests/functional/transitions/contracts.spec.ts
+++ b/packages/wasm-sdk/tests/functional/transitions/contracts.spec.ts
@@ -39,12 +39,14 @@ describe('Contract State Transitions', function describeContractStateTransitions
       // Contract operations require at least HIGH security level (key index 2)
       const { signer, identityKey } = createTestSignerAndKey(sdk, 1, 2);
 
-      // Create a simple test schema with a "note" document type
-      // Position property is required for document types and their properties
+      // Create a simple test schema with a "note" document type.
+      // `position` is required on each *property* (to order fields in the
+      // document row) — it is NOT a valid key on the document-type root.
+      // Under protocol v12 the document meta-schema is strict
+      // (`additionalProperties: false`) and rejects stray root-level keys.
       const schema = {
         note: {
           type: 'object',
-          position: 0,
           properties: {
             message: {
               type: 'string',
@@ -114,7 +116,6 @@ describe('Contract State Transitions', function describeContractStateTransitions
         ...existingSchemas,
         task: {
           type: 'object',
-          position: 1,
           properties: {
             title: {
               type: 'string',

--- a/packages/wasm-sdk/tests/functional/transitions/documents.spec.ts
+++ b/packages/wasm-sdk/tests/functional/transitions/documents.spec.ts
@@ -78,13 +78,15 @@ describe('Document State Transitions', function describeDocumentStateTransitions
       // Contract operations require at least HIGH security level (key index 2)
       const { signer, identityKey } = createTestSignerAndKey(sdk, 1, 2);
 
-      // Create a schema with mutable, deletable, and transferable document types
-      // Position property is required for document types and properties
+      // Create a schema with mutable, deletable, and transferable document types.
+      // `position` is required on each *property* (to order fields in the
+      // document row) — it is NOT a valid key on the document-type root.
+      // Under protocol v12 the document meta-schema is strict
+      // (`additionalProperties: false`) and rejects stray root-level keys.
       const schema = {
         // Mutable document type - can be updated
         mutableNote: {
           type: 'object',
-          position: 0,
           documentsMutable: true,
           canBeDeleted: true,
           properties: {
@@ -101,7 +103,6 @@ describe('Document State Transitions', function describeDocumentStateTransitions
         // transferable: 1 = Always transferable (see Transferable enum in DPP)
         transferableItem: {
           type: 'object',
-          position: 1,
           transferable: 1,
           documentsMutable: false,
           canBeDeleted: false,


### PR DESCRIPTION
## Issue being fixed or feature implemented

The scheduled `v3.1-dev Tests` job has been failing the `Run WASM SDK functional tests` step: [run 24641468414, job 72046508655](https://github.com/dashpay/platform/actions/runs/24641468414/job/72046508655) — 6 failures / 82 passing.

## What was done?

Removed four stray `position: N` entries placed at the **document-type root** of the test fixture schemas in `contracts.spec.ts` and `documents.spec.ts`. `position` is only meaningful *inside* a property definition (to order fields in the serialized document row); it is not a valid document-type-level config key.

Also replaced the misleading comment (*"Position property is required for document types and their properties"*) with an accurate note about where `position` belongs.

### Root cause

The v0 document meta-schema silently accepted unknown root-level keys because `additionalProperties` was unconstrained. #3475 (merged 2026-04-12, gated on protocol v12, closing #2703) added `additionalProperties: false` to the v1 meta-schema. With v12 live, these stray keys are correctly rejected and fail the test fixtures:

```
state transition broadcast error: JsonSchemaError:
  Additional properties are not allowed ('position' was unexpected), path:
```

Four of the six failures were cascading `expected null to exist` assertions in tests (`contractUpdate`, `documentReplace`, `documentDelete`, `documentTransfer`) that all depend on the contract publish succeeding first.

## How Has This Been Tested?

- Verified all remaining `position:` lines in the changed files are at the property level (14-space indent), not the document-type root (10-space indent).
- Unit fixtures at `packages/wasm-sdk/tests/unit/fixtures/*.ts` were audited and already place `position` correctly inside `properties.*`.

## Breaking Changes

None — test-only change.

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [ ] I have made corresponding changes to the documentation if needed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated contract and document test schemas to comply with protocol v12's strict meta-schema validation
  * Repositioned position field from document-type root to property level for field ordering
  * Enhanced documentation clarifying validation rules and schema structure requirements

<!-- end of auto-generated comment: release notes by coderabbit.ai -->