### PR TITLE
fix(ci): remove stale feature-flags-contract references breaking Docker build

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -42,7 +42,6 @@ ignore:
   - "packages/dashpay-contract/src/**"
   - "packages/data-contracts/src/**"
   - "packages/dpns-contract/src/**"
-  - "packages/feature-flags-contract/src/**"
   - "packages/keyword-search-contract/src/**"
   - "packages/masternode-reward-shares-contract/src/**"
   - "packages/token-history-contract/src/**"

--- a/.pnp.cjs
+++ b/.pnp.cjs
@@ -43,10 +43,6 @@ const RAW_RUNTIME_STATE =
       "reference": "workspace:packages/dpns-contract"\
     },\
     {\
-      "name": "@dashevo/feature-flags-contract",\
-      "reference": "workspace:packages/feature-flags-contract"\
-    },\
-    {\
       "name": "@dashevo/dapi-client",\
       "reference": "workspace:packages/js-dapi-client"\
     },\
@@ -119,7 +115,6 @@ const RAW_RUNTIME_STATE =
     ["@dashevo/dashpay-contract", ["workspace:packages/dashpay-contract"]],\
     ["@dashevo/dpns-contract", ["workspace:packages/dpns-contract"]],\
     ["@dashevo/evo-sdk", ["workspace:packages/js-evo-sdk"]],\
-    ["@dashevo/feature-flags-contract", ["workspace:packages/feature-flags-contract"]],\
     ["@dashevo/grpc-common", ["workspace:packages/js-grpc-common"]],\
     ["@dashevo/keyword-search-contract", ["workspace:packages/keyword-search-contract"]],\
     ["@dashevo/masternode-reward-shares-contract", ["workspace:packages/masternode-reward-shares-contract"]],\
@@ -2826,22 +2821,6 @@ const RAW_RUNTIME_STATE =
         "linkType": "SOFT"\
       }]\
     ]],\
-    ["@dashevo/feature-flags-contract", [\
-      ["workspace:packages/feature-flags-contract", {\
-        "packageLocation": "./packages/feature-flags-contract/",\
-        "packageDependencies": [\
-          ["@dashevo/feature-flags-contract", "workspace:packages/feature-flags-contract"],\
-          ["@dashevo/wasm-dpp", "workspace:packages/wasm-dpp"],\
-          ["chai", "npm:4.3.10"],\
-          ["dirty-chai", "virtual:e2d057e7cc143d3cb9bec864f4a2d862441b5a09f81f8e6c46e7a098cbc89e4d07017cc6e2e2142d5704bb55da853cbec2d025ebc0b30e8696c31380c00f2c7d#npm:2.0.1"],\
-          ["eslint", "virtual:de32c10d523830f1843784ae863166d6ef2e074b6da9615f2b3296a1f90385ed3f59e274e3957326ba7cf3442d82470d9e1ec01e6720989a570c075c95d90dbc#npm:9.39.2"],\
-          ["mocha", "npm:11.1.0"],\
-          ["sinon", "npm:18.0.1"],\
-          ["sinon-chai", "virtual:e2d057e7cc143d3cb9bec864f4a2d862441b5a09f81f8e6c46e7a098cbc89e4d07017cc6e2e2142d5704bb55da853cbec2d025ebc0b30e8696c31380c00f2c7d#npm:3.7.0"]\
-        ],\
-        "linkType": "SOFT"\
-      }]\
-    ]],\
     ["@dashevo/grpc-common", [\
       ["workspace:packages/js-grpc-common", {\
         "packageLocation": "./packages/js-grpc-common/",\
@@ -2931,7 +2910,6 @@ const RAW_RUNTIME_STATE =
           ["@dashevo/dapi-client", "workspace:packages/js-dapi-client"],\
           ["@dashevo/dashcore-lib", "npm:0.22.0"],\
           ["@dashevo/dpns-contract", "workspace:packages/dpns-contract"],\
-          ["@dashevo/feature-flags-contract", "workspace:packages/feature-flags-contract"],\
           ["@dashevo/grpc-common", "workspace:packages/js-grpc-common"],\
           ["@dashevo/masternode-reward-shares-contract", "workspace:packages/masternode-reward-shares-contract"],\
           ["@dashevo/platform-test-suite", "workspace:packages/platform-test-suite"],\

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -121,7 +121,6 @@ yarn configure:tests:network
 Platform uses data contracts to define application data schemas:
 - `dpns-contract`: Dash Platform Naming Service
 - `dashpay-contract`: Social payments functionality
-- `feature-flags-contract`: System feature toggles
 - `masternode-reward-shares-contract`: Masternode reward distribution
 - `withdrawals-contract`: Platform credit withdrawals
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -385,7 +385,6 @@ COPY --parents \
     packages/dashpay-contract \
     packages/withdrawals-contract \
     packages/masternode-reward-shares-contract \
-    packages/feature-flags-contract \
     packages/dpns-contract \
     packages/wallet-utils-contract \
     packages/token-history-contract \
@@ -492,7 +491,6 @@ COPY --parents \
     packages/keyword-search-contract \
     packages/withdrawals-contract \
     packages/masternode-reward-shares-contract \
-    packages/feature-flags-contract \
     packages/dpns-contract \
     packages/data-contracts \
     packages/strategy-tests \
@@ -614,7 +612,6 @@ COPY --parents \
     packages/token-history-contract \
     packages/keyword-search-contract \
     packages/masternode-reward-shares-contract \
-    packages/feature-flags-contract \
     packages/dpns-contract \
     packages/data-contracts \
     packages/dapi-grpc \
@@ -740,7 +737,6 @@ COPY --from=build-dashmate-helper /platform/packages/token-history-contract pack
 COPY --from=build-dashmate-helper /platform/packages/keyword-search-contract packages/keyword-search-contract
 COPY --from=build-dashmate-helper /platform/packages/withdrawals-contract packages/withdrawals-contract
 COPY --from=build-dashmate-helper /platform/packages/masternode-reward-shares-contract packages/masternode-reward-shares-contract
-COPY --from=build-dashmate-helper /platform/packages/feature-flags-contract packages/feature-flags-contract
 COPY --from=build-dashmate-helper /platform/packages/dpns-contract packages/dpns-contract
 COPY --from=build-dashmate-helper /platform/packages/data-contracts packages/data-contracts
 COPY --from=build-dashmate-helper /platform/packages/wasm-dpp packages/wasm-dpp
@@ -843,7 +839,6 @@ COPY --parents \
     packages/keyword-search-contract \
     packages/withdrawals-contract \
     packages/masternode-reward-shares-contract \
-    packages/feature-flags-contract \
     packages/dpns-contract \
     packages/data-contracts \
     packages/strategy-tests \

--- a/book/src/architecture/overview.md
+++ b/book/src/architecture/overview.md
@@ -281,7 +281,7 @@ Here is a simplified view of every Rust workspace member, grouped by role:
 | **gRPC definitions** | `dapi-grpc` |
 | **WASM bindings** | `wasm-dpp`, `wasm-dpp2`, `wasm-sdk`, `wasm-drive-verify` |
 | **iOS/FFI** | `rs-sdk-ffi` |
-| **System contracts** | `dpns-contract`, `dashpay-contract`, `withdrawals-contract`, `masternode-reward-shares-contract`, `feature-flags-contract`, `wallet-utils-contract`, `token-history-contract`, `keyword-search-contract`, `data-contracts` |
+| **System contracts** | `dpns-contract`, `dashpay-contract`, `withdrawals-contract`, `masternode-reward-shares-contract`, `wallet-utils-contract`, `token-history-contract`, `keyword-search-contract`, `data-contracts` |
 | **Tooling** | `dashmate` (JS), `strategy-tests`, `simple-signer`, `check-features`, `json-schema-compatibility-validator` |
 | **Other** | `dash-platform-macros`, `rs-dash-event-bus`, `rs-platform-wallet`, `dash-platform-balance-checker`, `rs-dapi` |
 

--- a/packages/README.md
+++ b/packages/README.md
@@ -5,7 +5,6 @@
 | [`@dashevo/wasm-dpp`](/packages/wasm-dpp)                             |  | JS implementation of Dash Platform Protocol, the core data structures used by the Platform |
 | [`@dashevo/dpns-contract`](/packages/dpns-contract)                   | [![npm](https://img.shields.io/npm/v/@dashevo/dpns-contract.svg?maxAge=3600)](https://www.npmjs.com/package/@dashevo/dpns-contract) | Data Contract for DashPay Naming Service |
 | [`@dashevo/grpc-common`](/packages/js-grpc-common)                    | [![npm](https://img.shields.io/npm/v/@dashevo/grpc-common.svg?maxAge=3600)](https://www.npmjs.com/package/@dashevo/grpc-common) | Common gRPC packages |
-| [`@dashevo/feature-flags-contract`](/packages/feature-flags-contract) | [![npm](https://img.shields.io/npm/v/@dashevo/feature-flags-contract.svg?maxAge=3600)](https://www.npmjs.com/package/@dashevo/feature-flags-contract) | System data contract to enable feature flags |
 
 ### Fullnode & Masternode tools
 

--- a/packages/dapi/Cargo.toml.template
+++ b/packages/dapi/Cargo.toml.template
@@ -6,7 +6,6 @@ members = [
     "packages/dashpay-contract",
     "packages/withdrawals-contract",
     "packages/masternode-reward-shares-contract",
-    "packages/feature-flags-contract",
     "packages/dpns-contract",
     "packages/data-contracts",
     "packages/rs-platform-version",

--- a/packages/dashmate/Cargo.toml.template
+++ b/packages/dashmate/Cargo.toml.template
@@ -6,7 +6,6 @@ members = [
     "packages/dashpay-contract",
     "packages/withdrawals-contract",
     "packages/masternode-reward-shares-contract",
-    "packages/feature-flags-contract",
     "packages/dpns-contract",
     "packages/data-contracts",
     "packages/rs-platform-version",

--- a/packages/platform-test-suite/Cargo.toml.template
+++ b/packages/platform-test-suite/Cargo.toml.template
@@ -6,7 +6,6 @@ members = [
     "packages/dashpay-contract",
     "packages/withdrawals-contract",
     "packages/masternode-reward-shares-contract",
-    "packages/feature-flags-contract",
     "packages/dpns-contract",
     "packages/data-contracts",
     "packages/rs-platform-version",

--- a/packages/platform-test-suite/README.md
+++ b/packages/platform-test-suite/README.md
@@ -49,8 +49,6 @@ Usage: test <seed> [options]
               --dpns-tld-identity-private-key=private_key   - top level identity private key
               --dpns-tld-identity-id=tld_identity_id        - top level identity id
               --dpns-contract-id=tld_contract_id            - dpns contract id
-              --feature-flags-identity-id=ff_identity_id    - feature-flags contract id
-              --feature-flags-contract-id=ff_contract_id    - feature-flags contract id
               --faucet-wallet-use-storage=true              - use persistent wallet storage for faucet
               --faucet-wallet-storage-dir=absolute_dir      - specify directory where faucet wallet persistent storage will be stored
   -t          --timeout                                     - test timeout in milliseconds
@@ -89,8 +87,6 @@ Usage: test <seed> [options]
               --dpns-tld-identity-private-key=private_key   - top level identity private key
               --dpns-tld-identity-id=tld_identity_id        - top level identity id
               --dpns-contract-id=tld_contract_id            - dpns contract id
-              --feature-flags-identity-id=ff_identity_id    - feature-flags contract id
-              --feature-flags-contract-id=ff_contract_id    - feature-flags contract id
               --faucet-wallet-use-storage=true              - use persistent wallet storage for faucet
               --faucet-wallet-storage-dir=absolute_dir      - specify directory where faucet wallet persistent storage will be stored
   -t          --timeout                                     - test timeout in milliseconds


### PR DESCRIPTION
## Issue being fixed or feature implemented

The removal of the `feature-flags-contract` crate in #3522 left behind stale
references that break the Docker image builds. The [v3.1-dev Tests run](https://github.com/dashpay/platform/actions/runs/24826576190)
fails three jobs with:

```
failed to compute cache key: failed to calculate checksum of ref ...
"/packages/feature-flags-contract": not found
```

Affected builds: **RS-DAPI image**, **Dashmate helper image**, **Drive image**.

## What was done?

Removed every remaining reference to `packages/feature-flags-contract`:

- `Dockerfile`: dropped the crate from 4 COPY filter lists and the
  dashmate-helper `COPY` line (root cause of the failing builds).
- `packages/{dapi,dashmate,platform-test-suite}/Cargo.toml.template`:
  dropped the crate from the workspace member lists used during the
  Docker build.
- `.codecov.yml`: dropped the now-nonexistent ignore path.
- `.pnp.cjs`: regenerated via `yarn install` (the removal commit
  updated `yarn.lock` but not the PnP manifest).
- `CLAUDE.md`, `packages/README.md`, `book/src/architecture/overview.md`,
  `packages/platform-test-suite/README.md`: dropped mentions of the
  removed contract and its CLI flags.

`packages/wasm-drive-verify/Cargo.lock` still references the crate, but
that lockfile is orphaned cruft (wasm-drive-verify is a workspace
member; no CI job uses this separate lockfile) — left untouched to keep
this PR focused.

## How Has This Been Tested?

Verified no remaining non-generated references:

```
$ grep -r feature-flags-contract .  # only CHANGELOG.md and the
                                    # orphaned wasm-drive-verify/Cargo.lock
```

Docker build + full CI will run on this PR.

## Breaking Changes

None. The crate was already removed in #3522; this only cleans up
orphaned references.

## Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have added \"!\" to the title and described breaking changes in the corresponding section if my code contains any
- [x] I have made corresponding changes to the documentation if needed