### PR TITLE
build: bump rust-dashcore to v0.42-dev 0093278

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1605,6 +1605,7 @@ dependencies = [
  "dapi-grpc",
  "dash-async",
  "dash-context-provider",
+ "dash-network-seeds",
  "dash-platform-macros",
  "derive_more 1.0.0",
  "dotenvy",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -120,7 +120,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -131,7 +131,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1114,7 +1114,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1548,6 +1548,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "dash-network"
+version = "0.42.0"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=0093278609a22fc53086bfef569b74bf10544982#0093278609a22fc53086bfef569b74bf10544982"
+dependencies = [
+ "bincode",
+ "bincode_derive",
+ "cbindgen 0.29.2",
+ "serde",
+]
+
+[[package]]
+name = "dash-network-seeds"
+version = "0.42.0"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=0093278609a22fc53086bfef569b74bf10544982#0093278609a22fc53086bfef569b74bf10544982"
+dependencies = [
+ "dash-network",
+]
+
+[[package]]
 name = "dash-platform-balance-checker"
 version = "3.1.0-dev.1"
 dependencies = [
@@ -1618,23 +1637,19 @@ dependencies = [
 [[package]]
 name = "dash-spv"
 version = "0.42.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=88e8a9aa1eadce79c8177f757f6741f8a55a83f5#88e8a9aa1eadce79c8177f757f6741f8a55a83f5"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=0093278609a22fc53086bfef569b74bf10544982#0093278609a22fc53086bfef569b74bf10544982"
 dependencies = [
- "anyhow",
  "async-trait",
- "bincode",
- "blsful",
  "chrono",
  "clap",
+ "dash-network-seeds",
  "dashcore",
  "dashcore_hashes",
  "futures",
  "hex",
  "hickory-resolver",
- "indexmap 2.13.1",
  "key-wallet",
  "key-wallet-manager",
- "log",
  "rand 0.8.5",
  "rayon",
  "serde",
@@ -1651,23 +1666,17 @@ dependencies = [
 [[package]]
 name = "dash-spv-ffi"
 version = "0.42.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=88e8a9aa1eadce79c8177f757f6741f8a55a83f5#88e8a9aa1eadce79c8177f757f6741f8a55a83f5"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=0093278609a22fc53086bfef569b74bf10544982#0093278609a22fc53086bfef569b74bf10544982"
 dependencies = [
  "cbindgen 0.29.2",
  "clap",
+ "dash-network",
  "dash-spv",
  "dashcore",
- "env_logger 0.10.2",
  "hex",
  "key-wallet",
  "key-wallet-ffi",
  "key-wallet-manager",
- "libc",
- "log",
- "once_cell",
- "rand 0.8.5",
- "serde",
- "serde_json",
  "tokio",
  "tokio-util",
  "tracing",
@@ -1676,7 +1685,7 @@ dependencies = [
 [[package]]
 name = "dashcore"
 version = "0.42.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=88e8a9aa1eadce79c8177f757f6741f8a55a83f5#88e8a9aa1eadce79c8177f757f6741f8a55a83f5"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=0093278609a22fc53086bfef569b74bf10544982#0093278609a22fc53086bfef569b74bf10544982"
 dependencies = [
  "anyhow",
  "base64-compat",
@@ -1686,40 +1695,41 @@ dependencies = [
  "bitvec",
  "blake3",
  "blsful",
+ "dash-network",
  "dashcore-private",
  "dashcore_hashes",
  "ed25519-dalek",
  "hex",
  "hex_lit",
- "log",
  "rustversion",
  "secp256k1",
  "serde",
  "thiserror 2.0.18",
+ "tracing",
 ]
 
 [[package]]
 name = "dashcore-private"
 version = "0.42.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=88e8a9aa1eadce79c8177f757f6741f8a55a83f5#88e8a9aa1eadce79c8177f757f6741f8a55a83f5"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=0093278609a22fc53086bfef569b74bf10544982#0093278609a22fc53086bfef569b74bf10544982"
 
 [[package]]
 name = "dashcore-rpc"
 version = "0.42.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=88e8a9aa1eadce79c8177f757f6741f8a55a83f5#88e8a9aa1eadce79c8177f757f6741f8a55a83f5"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=0093278609a22fc53086bfef569b74bf10544982#0093278609a22fc53086bfef569b74bf10544982"
 dependencies = [
  "dashcore-rpc-json",
  "hex",
  "jsonrpc",
- "log",
  "serde",
  "serde_json",
+ "tracing",
 ]
 
 [[package]]
 name = "dashcore-rpc-json"
 version = "0.42.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=88e8a9aa1eadce79c8177f757f6741f8a55a83f5#88e8a9aa1eadce79c8177f757f6741f8a55a83f5"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=0093278609a22fc53086bfef569b74bf10544982#0093278609a22fc53086bfef569b74bf10544982"
 dependencies = [
  "bincode",
  "dashcore",
@@ -1734,12 +1744,11 @@ dependencies = [
 [[package]]
 name = "dashcore_hashes"
 version = "0.42.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=88e8a9aa1eadce79c8177f757f6741f8a55a83f5#88e8a9aa1eadce79c8177f757f6741f8a55a83f5"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=0093278609a22fc53086bfef569b74bf10544982#0093278609a22fc53086bfef569b74bf10544982"
 dependencies = [
  "bincode",
  "dashcore-private",
  "rs-x11-hash",
- "secp256k1",
  "serde",
 ]
 
@@ -1933,7 +1942,7 @@ dependencies = [
  "derive_more 1.0.0",
  "dpp",
  "dpp-json-convertible-derive",
- "env_logger 0.11.10",
+ "env_logger",
  "getrandom 0.2.17",
  "grovedb-commitment-tree",
  "hex",
@@ -2249,19 +2258,6 @@ dependencies = [
 
 [[package]]
 name = "env_logger"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cd405aab171cb85d6735e5c8d9db038c17d3ca007a4d2c25f337935c3d90580"
-dependencies = [
- "humantime",
- "is-terminal",
- "log",
- "regex",
- "termcolor",
-]
-
-[[package]]
-name = "env_logger"
 version = "0.11.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0621c04f2196ac3f488dd583365b9c09be011a4ab8b9f37248ffcc8f6198b56a"
@@ -2295,7 +2291,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3349,7 +3345,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -3606,7 +3602,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3832,7 +3828,7 @@ dependencies = [
 [[package]]
 name = "key-wallet"
 version = "0.42.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=88e8a9aa1eadce79c8177f757f6741f8a55a83f5#88e8a9aa1eadce79c8177f757f6741f8a55a83f5"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=0093278609a22fc53086bfef569b74bf10544982#0093278609a22fc53086bfef569b74bf10544982"
 dependencies = [
  "aes",
  "async-trait",
@@ -3860,9 +3856,10 @@ dependencies = [
 [[package]]
 name = "key-wallet-ffi"
 version = "0.42.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=88e8a9aa1eadce79c8177f757f6741f8a55a83f5#88e8a9aa1eadce79c8177f757f6741f8a55a83f5"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=0093278609a22fc53086bfef569b74bf10544982#0093278609a22fc53086bfef569b74bf10544982"
 dependencies = [
  "cbindgen 0.29.2",
+ "dash-network",
  "dashcore",
  "hex",
  "key-wallet",
@@ -3875,7 +3872,7 @@ dependencies = [
 [[package]]
 name = "key-wallet-manager"
 version = "0.42.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=88e8a9aa1eadce79c8177f757f6741f8a55a83f5#88e8a9aa1eadce79c8177f757f6741f8a55a83f5"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=0093278609a22fc53086bfef569b74bf10544982#0093278609a22fc53086bfef569b74bf10544982"
 dependencies = [
  "async-trait",
  "bincode",
@@ -4340,7 +4337,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4882,6 +4879,7 @@ name = "platform-wallet-ffi"
 version = "2.1.1"
 dependencies = [
  "cbindgen 0.27.0",
+ "dash-network",
  "dpp",
  "key-wallet",
  "key-wallet-ffi",
@@ -5107,7 +5105,7 @@ version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "343d3bd7056eda839b03204e68deff7d1b13aba7af2b2fd16890697274262ee7"
 dependencies = [
- "heck 0.5.0",
+ "heck 0.4.1",
  "itertools 0.14.0",
  "log",
  "multimap",
@@ -5266,7 +5264,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash 2.1.2",
  "rustls",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -5304,7 +5302,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -5870,7 +5868,7 @@ dependencies = [
  "dash-sdk",
  "dotenvy",
  "drive-proof-verifier",
- "env_logger 0.11.10",
+ "env_logger",
  "envy",
  "getrandom 0.2.17",
  "hex",
@@ -6036,7 +6034,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -6095,7 +6093,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -6684,7 +6682,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -6916,7 +6914,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -6973,15 +6971,6 @@ dependencies = [
  "ureq",
  "walkdir",
  "zip 7.2.0",
-]
-
-[[package]]
-name = "termcolor"
-version = "1.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
-dependencies = [
- "winapi-util",
 ]
 
 [[package]]
@@ -8328,7 +8317,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,6 +51,7 @@ members = [
 [workspace.dependencies]
 dashcore = { git = "https://github.com/dashpay/rust-dashcore", rev = "0093278609a22fc53086bfef569b74bf10544982" }
 dash-network = { git = "https://github.com/dashpay/rust-dashcore", rev = "0093278609a22fc53086bfef569b74bf10544982" }
+dash-network-seeds = { git = "https://github.com/dashpay/rust-dashcore", rev = "0093278609a22fc53086bfef569b74bf10544982" }
 dash-spv = { git = "https://github.com/dashpay/rust-dashcore", rev = "0093278609a22fc53086bfef569b74bf10544982" }
 dash-spv-ffi = { git = "https://github.com/dashpay/rust-dashcore", rev = "0093278609a22fc53086bfef569b74bf10544982" }
 key-wallet = { git = "https://github.com/dashpay/rust-dashcore", rev = "0093278609a22fc53086bfef569b74bf10544982" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,13 +49,14 @@ members = [
 ]
 
 [workspace.dependencies]
-dashcore = { git = "https://github.com/dashpay/rust-dashcore", rev = "88e8a9aa1eadce79c8177f757f6741f8a55a83f5" }
-dash-spv = { git = "https://github.com/dashpay/rust-dashcore", rev = "88e8a9aa1eadce79c8177f757f6741f8a55a83f5" }
-dash-spv-ffi = { git = "https://github.com/dashpay/rust-dashcore", rev = "88e8a9aa1eadce79c8177f757f6741f8a55a83f5" }
-key-wallet = { git = "https://github.com/dashpay/rust-dashcore", rev = "88e8a9aa1eadce79c8177f757f6741f8a55a83f5" }
-key-wallet-ffi = { git = "https://github.com/dashpay/rust-dashcore", rev = "88e8a9aa1eadce79c8177f757f6741f8a55a83f5" }
-key-wallet-manager = { git = "https://github.com/dashpay/rust-dashcore", rev = "88e8a9aa1eadce79c8177f757f6741f8a55a83f5" }
-dashcore-rpc = { git = "https://github.com/dashpay/rust-dashcore", rev = "88e8a9aa1eadce79c8177f757f6741f8a55a83f5" }
+dashcore = { git = "https://github.com/dashpay/rust-dashcore", rev = "0093278609a22fc53086bfef569b74bf10544982" }
+dash-network = { git = "https://github.com/dashpay/rust-dashcore", rev = "0093278609a22fc53086bfef569b74bf10544982" }
+dash-spv = { git = "https://github.com/dashpay/rust-dashcore", rev = "0093278609a22fc53086bfef569b74bf10544982" }
+dash-spv-ffi = { git = "https://github.com/dashpay/rust-dashcore", rev = "0093278609a22fc53086bfef569b74bf10544982" }
+key-wallet = { git = "https://github.com/dashpay/rust-dashcore", rev = "0093278609a22fc53086bfef569b74bf10544982" }
+key-wallet-ffi = { git = "https://github.com/dashpay/rust-dashcore", rev = "0093278609a22fc53086bfef569b74bf10544982" }
+key-wallet-manager = { git = "https://github.com/dashpay/rust-dashcore", rev = "0093278609a22fc53086bfef569b74bf10544982" }
+dashcore-rpc = { git = "https://github.com/dashpay/rust-dashcore", rev = "0093278609a22fc53086bfef569b74bf10544982" }
 
 # Optimize heavy crypto crates even in dev/test builds so that
 # Halo 2 proof generation and verification run at near-release speed.

--- a/packages/rs-platform-wallet-ffi/Cargo.toml
+++ b/packages/rs-platform-wallet-ffi/Cargo.toml
@@ -20,6 +20,7 @@ lazy_static = "1.4"
 
 key-wallet = { workspace = true }
 key-wallet-ffi = { workspace = true }
+dash-network = { workspace = true, features = ["ffi"] }
 
 [dev-dependencies]
 tempfile = "3.8"

--- a/packages/rs-platform-wallet-ffi/src/platform_wallet_info.rs
+++ b/packages/rs-platform-wallet-ffi/src/platform_wallet_info.rs
@@ -1,8 +1,8 @@
 use crate::error::*;
 use crate::handle::*;
+use dash_network::ffi::FFINetwork;
 use key_wallet::wallet::initialization::WalletAccountCreationOptions;
 use key_wallet::wallet::managed_wallet_info::wallet_info_interface::WalletInfoInterface;
-use key_wallet_ffi::FFINetwork;
 use platform_wallet::platform_wallet_info::PlatformWalletInfo;
 use std::os::raw::{c_char, c_uchar};
 

--- a/packages/rs-platform-wallet-ffi/tests/integration_tests.rs
+++ b/packages/rs-platform-wallet-ffi/tests/integration_tests.rs
@@ -1,5 +1,5 @@
+use dash_network::ffi::FFINetwork;
 use dpp::identity::accessors::IdentityGettersV0;
-use key_wallet_ffi::FFINetwork;
 use platform_wallet_ffi::*;
 use std::ffi::CString;
 

--- a/packages/rs-platform-wallet/src/platform_wallet_info/contact_requests.rs
+++ b/packages/rs-platform-wallet/src/platform_wallet_info/contact_requests.rs
@@ -483,8 +483,6 @@ mod tests {
     use std::collections::BTreeMap;
 
     fn create_dummy_wallet() -> Wallet {
-        // WatchOnly is now a unit variant (rust-dashcore PR #654) — no key
-        // material is embedded in the wallet type.
         Wallet::from_wallet_type(Network::Testnet, key_wallet::wallet::WalletType::WatchOnly)
     }
 

--- a/packages/rs-platform-wallet/src/platform_wallet_info/contact_requests.rs
+++ b/packages/rs-platform-wallet/src/platform_wallet_info/contact_requests.rs
@@ -479,20 +479,13 @@ mod tests {
     use dpp::identity::v0::IdentityV0;
     use dpp::identity::Identity;
     use dpp::prelude::Identifier;
-    use key_wallet::bip32::ExtendedPubKey;
     use key_wallet::Network;
     use std::collections::BTreeMap;
 
     fn create_dummy_wallet() -> Wallet {
-        // Create a dummy extended public key for testing
-        use key_wallet::wallet::root_extended_keys::RootExtendedPubKey;
-        let xpub_str = "xpub6ASuArnXKPbfEwhqN6e3mwBcDTgzisQN1wXN9BJcM47sSikHjJf3UFHKkNAWbWMiGj7Wf5uMash7SyYq527Hqck2AxYysAA7xmALppuCkwQ";
-        let xpub = xpub_str.parse::<ExtendedPubKey>().unwrap();
-        let root_xpub = RootExtendedPubKey::from_extended_pub_key(&xpub);
-        Wallet::from_wallet_type(
-            Network::Testnet,
-            key_wallet::wallet::WalletType::WatchOnly(root_xpub),
-        )
+        // WatchOnly is now a unit variant (rust-dashcore PR #654) — no key
+        // material is embedded in the wallet type.
+        Wallet::from_wallet_type(Network::Testnet, key_wallet::wallet::WalletType::WatchOnly)
     }
 
     fn create_test_identity(id_bytes: [u8; 32]) -> Identity {

--- a/packages/rs-platform-wallet/src/platform_wallet_info/wallet_info_interface.rs
+++ b/packages/rs-platform-wallet/src/platform_wallet_info/wallet_info_interface.rs
@@ -80,10 +80,6 @@ impl WalletInfoInterface for PlatformWalletInfo {
         self.wallet_info.utxos()
     }
 
-    fn get_spendable_utxos(&self) -> BTreeSet<&Utxo> {
-        self.wallet_info.get_spendable_utxos()
-    }
-
     fn balance(&self) -> WalletCoreBalance {
         self.wallet_info.balance()
     }

--- a/packages/rs-sdk-ffi/src/sdk.rs
+++ b/packages/rs-sdk-ffi/src/sdk.rs
@@ -380,62 +380,8 @@ pub unsafe extern "C" fn dash_sdk_create_trusted(config: *const DashSDKConfig) -
         info!("dash_sdk_create_trusted: no DAPI addresses provided, using defaults for network");
         // Use default addresses for the network
         match network {
-            Network::Testnet => {
-                // Use testnet addresses from WASM SDK
-                let default_addresses = [
-                    "https://52.12.176.90:1443",
-                    "https://35.82.197.197:1443",
-                    "https://44.240.98.102:1443",
-                    "https://52.34.144.50:1443",
-                    "https://44.239.39.153:1443",
-                    "https://35.164.23.245:1443",
-                    "https://54.149.33.167:1443",
-                ]
-                .join(",");
-
-                info!(
-                    addresses = default_addresses.as_str(),
-                    "dash_sdk_create_trusted: using default testnet addresses"
-                );
-                let address_list = match AddressList::from_str(&default_addresses) {
-                    Ok(list) => list,
-                    Err(e) => {
-                        error!(error = %e, "dash_sdk_create_trusted: failed to parse default addresses");
-                        return DashSDKResult::error(DashSDKError::new(
-                            DashSDKErrorCode::InternalError,
-                            format!("Failed to parse default addresses: {}", e),
-                        ));
-                    }
-                };
-                SdkBuilder::new(address_list).with_network(network)
-            }
-            Network::Mainnet => {
-                // Use mainnet addresses from WASM SDK
-                let default_addresses = [
-                    "https://149.28.241.190:443",
-                    "https://198.7.115.48:443",
-                    "https://134.255.182.186:443",
-                    "https://93.115.172.39:443",
-                    "https://5.189.164.253:443",
-                    "https://178.215.237.134:443",
-                    "https://157.66.81.162:443",
-                    "https://173.212.232.90:443",
-                ]
-                .join(",");
-
-                info!("dash_sdk_create_trusted: using default mainnet addresses");
-                let address_list = match AddressList::from_str(&default_addresses) {
-                    Ok(list) => list,
-                    Err(e) => {
-                        error!(error = %e, "dash_sdk_create_trusted: failed to parse default addresses");
-                        return DashSDKResult::error(DashSDKError::new(
-                            DashSDKErrorCode::InternalError,
-                            format!("Failed to parse default addresses: {}", e),
-                        ));
-                    }
-                };
-                SdkBuilder::new(address_list).with_network(network)
-            }
+            Network::Testnet => SdkBuilder::new_testnet(),
+            Network::Mainnet => SdkBuilder::new_mainnet(),
             _ => {
                 error!(
                     ?network,

--- a/packages/rs-sdk/Cargo.toml
+++ b/packages/rs-sdk/Cargo.toml
@@ -12,6 +12,7 @@ dpp = { path = "../rs-dpp", default-features = false, features = [
 ] }
 dapi-grpc = { path = "../dapi-grpc", default-features = false }
 rs-dapi-client = { path = "../rs-dapi-client", default-features = false }
+dash-network-seeds = { workspace = true }
 drive = { path = "../rs-drive", default-features = false, features = [
   "verify",
 ] }

--- a/packages/rs-sdk/src/sdk.rs
+++ b/packages/rs-sdk/src/sdk.rs
@@ -25,6 +25,7 @@ use drive_proof_verifier::FromProof;
 pub use http::Uri;
 #[cfg(feature = "mocks")]
 use rs_dapi_client::mock::MockDapiClient;
+use rs_dapi_client::Address;
 pub use rs_dapi_client::AddressList;
 pub use rs_dapi_client::RequestSettings;
 use rs_dapi_client::{
@@ -62,6 +63,41 @@ const DEFAULT_REQUEST_SETTINGS: RequestSettings = RequestSettings {
     connect_timeout: None,
     max_decoding_message_size: None,
 };
+
+/// Build the default DAPI bootstrap address list for `network` from
+/// [`dash_network_seeds`].
+///
+/// The seed lists are single-source-of-truth, weekly-refreshed upstream in
+/// `rust-dashcore`. We filter to Evo (HPMN) masternodes — the only ones that
+/// run Dash Platform — and build `https://<ip>:<platform_http_port>` URIs.
+/// The Core port on `seed.address` is intentionally discarded: DAPI clients
+/// need the platform HTTP port, not the Core P2P port.
+///
+/// Malformed upstream entries are silently skipped rather than panicking;
+/// the DAPI client handles retry/rotation across the remaining addresses.
+///
+/// ## Panics
+///
+/// Panics on networks other than `Mainnet` and `Testnet` — no upstream
+/// seed list exists for devnet/regtest.
+fn default_address_list_for_network(network: Network) -> AddressList {
+    if !matches!(network, Network::Mainnet | Network::Testnet) {
+        panic!("default address list is only available for mainnet and testnet");
+    }
+    let mut list = AddressList::new();
+    for seed in dash_network_seeds::evo_seeds(network) {
+        let Some(port) = seed.platform_http_port else {
+            continue;
+        };
+        let url = format!("https://{}:{}", seed.address.ip(), port);
+        if let Ok(uri) = url.parse::<Uri>() {
+            if let Ok(address) = Address::try_from(uri) {
+                list.add(address);
+            }
+        }
+    }
+    list
+}
 
 /// Dash Platform SDK
 ///
@@ -747,18 +783,18 @@ impl SdkBuilder {
         Self::default()
     }
 
-    /// Create a new SdkBuilder instance preconfigured for testnet. NOT IMPLEMENTED YET.
+    /// Create a new SdkBuilder instance preconfigured for testnet.
     ///
     /// This is a helper method that preconfigures [SdkBuilder] for testnet use.
     /// Use this method if you want to connect to Dash Platform testnet during development and testing
     /// of your solution.
     pub fn new_testnet() -> Self {
-        unimplemented!(
-            "Testnet address list not implemented yet. Use new() and provide address list."
-        )
+        let address_list = default_address_list_for_network(Network::Testnet);
+
+        Self::new(address_list).with_network(Network::Testnet)
     }
 
-    /// Create a new SdkBuilder instance preconfigured for mainnet (production network). NOT IMPLEMENTED YET.
+    /// Create a new SdkBuilder instance preconfigured for mainnet (production network).
     ///
     /// This is a helper method that preconfigures [SdkBuilder] for production use.
     /// Use this method if you want to connect to Dash Platform mainnet with production-ready product.
@@ -771,9 +807,9 @@ impl SdkBuilder {
     ///
     /// This method is unstable and can be changed in the future.
     pub fn new_mainnet() -> Self {
-        unimplemented!(
-            "Mainnet address list not implemented yet. Use new() and provide address list."
-        )
+        let address_list = default_address_list_for_network(Network::Mainnet);
+
+        Self::new(address_list).with_network(Network::Mainnet)
     }
 
     /// Configure network type.
@@ -1101,6 +1137,80 @@ mod test {
     use test_case::test_matrix;
 
     use crate::SdkBuilder;
+
+    use super::Network;
+
+    /// Mainnet Evo masternodes expose the Platform HTTP endpoint on 443.
+    const MAINNET_PLATFORM_HTTP_PORT: u16 = 443;
+    /// Testnet Evo masternodes expose the Platform HTTP endpoint on 1443.
+    const TESTNET_PLATFORM_HTTP_PORT: u16 = 1443;
+
+    #[test]
+    fn new_testnet_sources_bootstrap_from_seeds() {
+        let builder = SdkBuilder::new_testnet();
+        let address_list = builder
+            .addresses
+            .as_ref()
+            .expect("testnet builder should configure default addresses");
+
+        assert_eq!(builder.network, Network::Testnet);
+        assert!(
+            !address_list.is_empty(),
+            "testnet must have at least one bootstrap address"
+        );
+        for address in address_list.get_live_addresses() {
+            assert_eq!(
+                address.uri().port_u16(),
+                Some(TESTNET_PLATFORM_HTTP_PORT),
+                "testnet bootstrap address must use the platform HTTP port",
+            );
+        }
+    }
+
+    #[test]
+    fn new_mainnet_sources_bootstrap_from_seeds() {
+        let builder = SdkBuilder::new_mainnet();
+        let address_list = builder
+            .addresses
+            .as_ref()
+            .expect("mainnet builder should configure default addresses");
+
+        assert_eq!(builder.network, Network::Mainnet);
+        assert!(
+            !address_list.is_empty(),
+            "mainnet must have at least one bootstrap address"
+        );
+        for address in address_list.get_live_addresses() {
+            assert_eq!(
+                address.uri().port_u16(),
+                Some(MAINNET_PLATFORM_HTTP_PORT),
+                "mainnet bootstrap address must use the platform HTTP port",
+            );
+        }
+    }
+
+    /// Smoke signal: the upstream seed lists are far larger than 10 entries on
+    /// both networks. If parsing drops most of them we want a loud test
+    /// failure rather than silently shipping a near-empty bootstrap list.
+    #[test]
+    fn bootstrap_counts_reasonable() {
+        let mainnet = SdkBuilder::new_mainnet()
+            .addresses
+            .expect("mainnet builder should configure default addresses");
+        let testnet = SdkBuilder::new_testnet()
+            .addresses
+            .expect("testnet builder should configure default addresses");
+        assert!(
+            mainnet.len() >= 10,
+            "expected >=10 mainnet bootstrap addresses, got {}",
+            mainnet.len()
+        );
+        assert!(
+            testnet.len() >= 10,
+            "expected >=10 testnet bootstrap addresses, got {}",
+            testnet.len()
+        );
+    }
 
     #[test_matrix(97..102, 100, 2, false; "valid height")]
     #[test_case(103, 100, 2, true; "invalid height")]

--- a/packages/wasm-sdk/src/sdk.rs
+++ b/packages/wasm-sdk/src/sdk.rs
@@ -18,29 +18,7 @@ fn parse_addresses(addresses: &'static [&str]) -> Vec<Address> {
         })
         .collect()
 }
-// Mainnet addresses from mnowatch.org
-fn default_mainnet_addresses() -> Vec<Address> {
-    parse_addresses(&[
-        "https://149.28.241.190:443",
-        "https://198.7.115.48:443",
-        "https://134.255.182.186:443",
-        "https://93.115.172.39:443",
-        "https://5.189.164.253:443",
-    ])
-}
-// Testnet addresses from https://quorums.testnet.networks.dash.org/masternodes
-fn default_testnet_addresses() -> Vec<Address> {
-    parse_addresses(&[
-        "https://52.12.176.90:1443",
-        "https://35.82.197.197:1443",
-        "https://44.240.98.102:1443",
-        "https://52.34.144.50:1443",
-        "https://44.239.39.153:1443",
-        "https://34.214.48.68:1443",
-        "https://54.149.33.167:1443",
-        "https://52.24.124.162:1443",
-    ])
-}
+
 fn default_local_addresses() -> Vec<Address> {
     parse_addresses(&["https://127.0.0.1:2443"])
 }
@@ -249,10 +227,7 @@ impl WasmSdkBuilder {
 
     #[wasm_bindgen(js_name = "mainnet")]
     pub fn new_mainnet() -> Self {
-        let address_list = dash_sdk::sdk::AddressList::from_iter(default_mainnet_addresses());
-        let sdk_builder = SdkBuilder::new(address_list)
-            .with_network(dash_sdk::dpp::dashcore::Network::Mainnet)
-            .with_context_provider(WasmContext {});
+        let sdk_builder = SdkBuilder::new_mainnet().with_context_provider(WasmContext {});
 
         Self {
             inner: sdk_builder,
@@ -262,10 +237,7 @@ impl WasmSdkBuilder {
 
     #[wasm_bindgen(js_name = "testnet")]
     pub fn new_testnet() -> Self {
-        let address_list = dash_sdk::sdk::AddressList::from_iter(default_testnet_addresses());
-        let sdk_builder = SdkBuilder::new(address_list)
-            .with_network(dash_sdk::dpp::dashcore::Network::Testnet)
-            .with_context_provider(WasmContext {});
+        let sdk_builder = SdkBuilder::new_testnet().with_context_provider(WasmContext {});
 
         Self {
             inner: sdk_builder,


### PR DESCRIPTION
## Issue being fixed or feature implemented

Refresh our `dashpay/rust-dashcore` pin to the latest `v0.42-dev` HEAD (37 commits ahead of the previous pin, `88e8a9aa`). Keeps platform aligned with ongoing key-wallet / dash-spv work and picks up several SPV, key-wallet, and FFI fixes that other clients are already consuming.

## What was done?

Workspace bump from `rev = 88e8a9aa1eadce79c8177f757f6741f8a55a83f5` to `rev = 0093278609a22fc53086bfef569b74bf10544982` for:

- `dashcore`, `dash-spv`, `dash-spv-ffi`
- `key-wallet`, `key-wallet-ffi`, `key-wallet-manager`
- `dashcore-rpc`

Added `dash-network` (new standalone crate extracted from `dashcore` upstream in PR dashpay/rust-dashcore#679) to `[workspace.dependencies]`, pinned to the same rev and required by `rs-platform-wallet-ffi` for `FFINetwork` (now behind the `ffi` feature of `dash-network` rather than re-exported from `key-wallet-ffi`).

Breaking changes from upstream that actually hit this codebase:

- **`WalletType::WatchOnly` is now a unit variant** (dashpay/rust-dashcore#654). Updated the `create_dummy_wallet` test helper in `rs-platform-wallet/src/platform_wallet_info/contact_requests.rs` — dropped the xpub payload and removed the now-unused `ExtendedPubKey` import.
- **`WalletInfoInterface::get_spendable_utxos` removed** (dashpay/rust-dashcore#643, moved to account level). Dropped the matching impl stub on `PlatformWalletInfo` — no other platform callers.
- **`FFINetwork` relocated** (dashpay/rust-dashcore#642, #679). Added `dash-network` as a workspace dep with `features = ["ffi"]` in `rs-platform-wallet-ffi` and repointed two imports to `dash_network::ffi::FFINetwork`.

Other upstream refactors (`FFIExtendedPriv/PubKey` renames, new `FFIError`, AssetLockTx DIP-00X fix, `Address<NetworkChecked>` serde fix) did not surface in the platform build — those APIs aren't referenced here.

## How Has This Been Tested?

- `cargo check --workspace --all-targets` — pass
- `cargo test --workspace --no-run` — all test binaries compile
- `cargo fmt --all --check` — clean
- `cargo clippy --workspace --all-targets -- -D warnings` — same pre-existing warnings as `v3.1-dev` HEAD in `rs-platform-value` / `rs-platform-serialization`; not introduced by this bump

The full runtime test suite (`yarn test`) needs a running local node and was not executed. Recommend running it before merge.

## Breaking Changes

None for platform consumers. All API shifts are internal (workspace-local dependency rev + the three call-site adjustments listed above).

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests — not applicable; pure dependency bump
- [x] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any — no platform-facing breaking changes
- [ ] I have made corresponding changes to the documentation if needed

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone

<sub>🤖 Co-authored by [Claudius the Magnificent](https://github.com/lklimek/claudius) AI Agent</sub>