### PR TITLE
fix(swift-sdk): show combined wallet balance on Wallets list

### DIFF
--- a/packages/swift-sdk/SwiftExampleApp/SwiftExampleApp/Core/Views/CoreContentView.swift
+++ b/packages/swift-sdk/SwiftExampleApp/SwiftExampleApp/Core/Views/CoreContentView.swift
@@ -644,6 +644,21 @@ struct WalletRowView: View {
     let wallet: PersistentWallet
     @EnvironmentObject var platformState: AppState
 
+    /// Per-wallet BLAST-synced platform-address balances. Mirrors
+    /// `BalanceCardView` so the summary row sees the same balance as
+    /// the detail view — previously the row only summed identity
+    /// credits, so a wallet funded purely via Platform Payment
+    /// addresses (no identities) showed "Empty".
+    @Query private var addressBalances: [PersistentPlatformAddress]
+
+    init(wallet: PersistentWallet) {
+        self.wallet = wallet
+        let walletId = wallet.walletId
+        _addressBalances = Query(
+            filter: #Predicate<PersistentPlatformAddress> { $0.walletId == walletId }
+        )
+    }
+
     /// Identities on this wallet — via the SwiftData relationship.
     /// The wallet↔identity relationship is the canonical source
     /// now; no need to filter `appState.identities` by walletId.
@@ -651,13 +666,31 @@ struct WalletRowView: View {
         wallet.identities
     }
 
+    /// Platform balance in credits: prefer BLAST address sync, fall
+    /// back to summing identity credits when no addresses have been
+    /// synced yet.
     private var platformBalance: UInt64 {
-        identitiesForWallet.reduce(0) { $0 + UInt64(bitPattern: $1.balance) }
+        let blastBalance = addressBalances.reduce(UInt64(0)) { $0 + $1.balance }
+        if blastBalance > 0 { return blastBalance }
+        return identitiesForWallet.reduce(UInt64(0)) {
+            $0 + UInt64(bitPattern: $1.balance)
+        }
     }
 
     private var totalCoreBalance: UInt64 {
         wallet.balanceConfirmed + wallet.balanceUnconfirmed
             + wallet.balanceImmature + wallet.balanceLocked
+    }
+
+    /// Combined wallet balance expressed in DASH. Core uses 1e8
+    /// duffs/DASH; Platform uses 1e11 credits/DASH.
+    private var combinedDashAmount: Double {
+        Double(totalCoreBalance) / 100_000_000.0
+            + Double(platformBalance) / 100_000_000_000.0
+    }
+
+    private var hasAnyBalance: Bool {
+        totalCoreBalance > 0 || platformBalance > 0
     }
 
     private var walletIdShort: String {
@@ -680,7 +713,10 @@ struct WalletRowView: View {
     }
 
     private func formatBalance(_ amount: UInt64) -> String {
-        let dash = Double(amount) / 100_000_000.0
+        formatDash(Double(amount) / 100_000_000.0)
+    }
+
+    private func formatDash(_ dash: Double) -> String {
         let formatter = NumberFormatter()
         formatter.numberStyle = .decimal
         formatter.minimumFractionDigits = 0
@@ -748,10 +784,10 @@ struct WalletRowView: View {
                     }
                 }
                 Spacer()
-                Text(totalCoreBalance == 0 ? "Empty" : formatBalance(totalCoreBalance))
+                Text(hasAnyBalance ? formatDash(combinedDashAmount) : "Empty")
                     .font(.subheadline)
                     .fontWeight(.medium)
-                    .foregroundColor(totalCoreBalance == 0 ? .secondary : .primary)
+                    .foregroundColor(hasAnyBalance ? .primary : .secondary)
             }
 
             // Row 1: network + created date.


### PR DESCRIPTION
## Issue being fixed or feature implemented

On the Wallets tab the wallet row showed "Empty" and "No Core balance" even when the wallet had a non-zero Platform balance (visible in `BalanceCardView` on the wallet detail screen). The summary row was inconsistent with the detail card and hid funds from users.

## What was done?

Updated `WalletRowView` in [CoreContentView.swift](packages/swift-sdk/SwiftExampleApp/SwiftExampleApp/Core/Views/CoreContentView.swift) to mirror `BalanceCardView`'s balance logic:

- Added a `@Query` for `PersistentPlatformAddress` filtered by `walletId` so the row picks up BLAST-synced address credits (with the existing identity-credit sum kept as a fallback for the pre-sync state).
- Replaced the `totalCoreBalance == 0 ? "Empty"` check at the top-right with a combined Core + Platform balance rendered in DASH. "Empty" is only shown when both Core and Platform balances are zero.
- Extracted a `formatDash(_:)` helper so duff- and credit-derived amounts share the same formatter (Core uses 1e8 duffs/DASH; Platform uses 1e11 credits/DASH).

Row 5 ("Platform: X DASH • walletId") now also picks up BLAST-synced balances via the same `platformBalance` computation.

## How Has This Been Tested?

- `xcodebuild -project SwiftExampleApp/SwiftExampleApp.xcodeproj -scheme SwiftExampleApp -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 17 Pro,arch=arm64' build` succeeds.
- Manually verified against a testnet wallet (`Wallet1`, ID `73c5dc…98c4e2`) that previously showed "Empty" / "No Core balance" despite holding `0.24581622 DASH` on the Platform side; the row now shows the combined DASH total at the top-right.

## Breaking Changes

None — UI-only change in the example app.

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [ ] I have made corresponding changes to the documentation if needed

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved wallet balance display to accurately show combined values from multiple sources.
  * Enhanced balance calculation and formatting for better accuracy.
  * Refined empty wallet state display and visual styling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->