### PR TITLE
fix(ci): add rs-dash-async to Docker build context

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -381,6 +381,7 @@ COPY --parents \
     packages/rs-platform-wallet-ffi \
     packages/rs-drive-abci \
     packages/rs-dapi \
+    packages/rs-dash-async \
     packages/rs-dash-event-bus \
     packages/dashpay-contract \
     packages/withdrawals-contract \
@@ -472,6 +473,7 @@ COPY --parents \
     packages/dapi-grpc \
     packages/rs-dash-platform-macros \
     packages/rs-dapi \
+    packages/rs-dash-async \
     packages/rs-dash-event-bus \
     packages/rs-dpp \
     packages/rs-dpp-json-convertible-derive \
@@ -590,6 +592,7 @@ COPY --parents \
     rust-toolchain.toml \
     .cargo \
     packages/rs-dapi \
+    packages/rs-dash-async \
     packages/rs-dash-event-bus \
     packages/rs-dpp \
     packages/rs-dpp-json-convertible-derive \
@@ -832,6 +835,7 @@ COPY --parents \
     packages/rs-platform-wallet-ffi \
     packages/rs-drive-abci \
     packages/rs-dapi \
+    packages/rs-dash-async \
     packages/rs-dash-event-bus \
     packages/dashpay-contract \
     packages/wallet-utils-contract \


### PR DESCRIPTION
## Issue being fixed or feature implemented

The nightly Docker image builds (Drive, RS-DAPI, Dashmate helper) on `v3.1-dev` are failing with:

```
failed to load manifest for dependency `dash-async`
failed to read `/platform/packages/rs-dash-async/Cargo.toml`

Caused by:
  No such file or directory (os error 2)
```

Failing run: https://github.com/dashpay/platform/actions/runs/24942936277/job/73039526871

PR #3497 introduced `packages/rs-dash-async` as a workspace member (and as a path dependency of `rs-sdk`, `rs-context-provider`, and `rs-sdk-trusted-context-provider`) but did not update the `Dockerfile`. Cargo cannot resolve the workspace inside the build container because the manifest is missing, so every Rust image build aborts before compilation starts.

## What was done?

Added `packages/rs-dash-async` to all four `COPY --parents` blocks in the `Dockerfile`:

1. `build-planner` — sources used by `cargo chef prepare`
2. `build-drive-abci` — sources used to build `drive-abci`
3. `build-wasm-dpp` — sources used by the wasm-dpp / yarn build
4. `build-rs-dapi` — sources used to build `rs-dapi`

The crate is inserted next to `packages/rs-dash-event-bus` to keep the related `rs-dash-*` workspace members grouped.

## How Has This Been Tested?

- Verified the workspace `Cargo.toml` lists `packages/rs-dash-async` as a member.
- Verified `rs-sdk`, `rs-context-provider`, and `rs-sdk-trusted-context-provider` declare `dash-async = { path = "../rs-dash-async" }` — these crates are already in each affected COPY block.
- Verified all four COPY blocks now contain `packages/rs-dash-async \`.
- CI on the PR will exercise the actual Docker image builds.

## Breaking Changes

None.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [x] I have made corresponding changes to the documentation if needed