### PR TITLE
chore: ignore .codex/ directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -92,6 +92,7 @@ grpc-coverage-report.txt
 __pycache__/
 .claude/worktrees/
 .claude/scheduled_tasks.lock
+.codex/
 
 # Security audit reports (local-only, not committed)
 audits/


### PR DESCRIPTION
## Issue being fixed or feature implemented
The Codex CLI stores per-user state (credentials in `auth.json`, session history, logs, lockfiles) under `.codex/`. None of that should ever land in the repo, but there's currently no `.gitignore` rule preventing accidental commits — making it too easy to leak credentials or noise into a PR.

## What was done?
Added `.codex/` to `.gitignore`, placed alongside the existing `.claude/` entries so all AI-tool config dirs sit together. Mirrors the same "exclude by default, un-ignore shared content later" pattern the repo already uses for `.claude/` (e.g. `.claude/skills/pr-description/SKILL.md` is checked in while transient subpaths are ignored).

## How Has This Been Tested?
- `git status` no longer surfaces `.codex/` paths when present locally.
- Diff is a single line in `.gitignore`; no code paths affected.

## Breaking Changes
None.

## Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [ ] I have made corresponding changes to the documentation if needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)