### PR TITLE
test(swift-sdk): add wallet UI smoke flow

### DIFF
--- a/.github/workflows/swift-example-app-ui-smoke.yml
+++ b/.github/workflows/swift-example-app-ui-smoke.yml
@@ -1,0 +1,195 @@
+name: Swift Example App UI Smoke
+
+'on':
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  wallet-flow:
+    name: Wallet flow XCUITest
+    runs-on: [self-hosted, macOS, ARM64]
+    timeout-minutes: 90
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          clean: true
+
+      - name: Force clean working directory
+        run: |
+          git clean -ffdx
+          git reset --hard HEAD
+
+      - name: Show Xcode and Swift versions
+        run: |
+          xcodebuild -version
+          swift --version
+
+      - name: Set up Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache cargo registry
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+          key: cargo-registry-${{ hashFiles('**/Cargo.lock') }}
+
+      - name: Add iOS simulator Rust target
+        run: |
+          rustup target add aarch64-apple-ios-sim
+
+      - name: Install cbindgen
+        run: |
+          brew install cbindgen || true
+
+      - name: Restore cached Protobuf
+        id: cache-protoc
+        uses: actions/cache@v4
+        with:
+          path: |
+            ${{ env.HOME }}/.local/protoc-32.0/bin
+            ${{ env.HOME }}/.local/protoc-32.0/include
+          key: protoc/32.0/${{ runner.os }}/universal
+
+      - name: Install Protobuf if cache miss
+        if: steps.cache-protoc.outputs.cache-hit != 'true'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euxo pipefail
+          VERSION=32.0
+          OS=osx-universal_binary
+          PROTOC_DIR="$HOME/.local/protoc-${VERSION}"
+          mkdir -p "$PROTOC_DIR"
+          curl -fsSL -H "Authorization: token ${GITHUB_TOKEN}" \
+            -o /tmp/protoc.zip \
+            "https://github.com/protocolbuffers/protobuf/releases/download/v${VERSION}/protoc-${VERSION}-${OS}.zip"
+          unzip -o /tmp/protoc.zip -d "$PROTOC_DIR"
+
+      - name: Save cached Protobuf
+        if: steps.cache-protoc.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v4
+        with:
+          path: |
+            ${{ env.HOME }}/.local/protoc-32.0/bin
+            ${{ env.HOME }}/.local/protoc-32.0/include
+          key: protoc/32.0/${{ runner.os }}/universal
+
+      - name: Verify protoc and export env
+        run: |
+          set -euxo pipefail
+          echo "$HOME/.local/protoc-32.0/bin" >> "$GITHUB_PATH"
+          echo "PROTOC=$HOME/.local/protoc-32.0/bin/protoc" >> "$GITHUB_ENV"
+          "$HOME/.local/protoc-32.0/bin/protoc" --version
+
+      - name: Clean Xcode derived data and Swift package caches
+        run: |
+          rm -rf ~/Library/Developer/Xcode/DerivedData/* || true
+          rm -rf packages/swift-sdk/.build || true
+          rm -rf packages/swift-sdk/SwiftExampleApp/.build || true
+
+      - name: Build simulator DashSDKFFI.xcframework
+        run: |
+          bash packages/swift-sdk/build_ios.sh --target sim --profile dev
+
+      - name: Create disposable iOS simulator
+        id: simulator
+        env:
+          SIM_NAME: SwiftExampleApp-UI-${{ github.run_id }}-${{ github.run_attempt }}
+        run: |
+          set -euo pipefail
+          ruby <<'RUBY'
+          require "json"
+          require "open3"
+          require "rubygems"
+
+          def simctl_json(*args)
+            stdout, stderr, status = Open3.capture3("xcrun", "simctl", "list", *args, "--json")
+            abort stderr unless status.success?
+            JSON.parse(stdout)
+          end
+
+          device_types = simctl_json("devicetypes").fetch("devicetypes")
+          runtimes = simctl_json("runtimes").fetch("runtimes")
+
+          runtime = runtimes
+            .select { |item| item["platform"] == "iOS" && item["isAvailable"] }
+            .max_by { |item| Gem::Version.new(item.fetch("version", "0")) }
+          abort "No available iOS simulator runtime found" unless runtime
+
+          preferred_names = ["iPhone 16", "iPhone 16e"]
+          device = preferred_names
+            .map { |name| device_types.find { |item| item["name"] == name } }
+            .compact
+            .first
+          device ||= device_types.find { |item| item["name"].start_with?("iPhone") && !item["name"].include?("SE") }
+          device ||= device_types.find { |item| item["name"].start_with?("iPhone") }
+          abort "No iPhone simulator device type found" unless device
+
+          name = ENV.fetch("SIM_NAME")
+          stdout, stderr, status = Open3.capture3(
+            "xcrun",
+            "simctl",
+            "create",
+            name,
+            device.fetch("identifier"),
+            runtime.fetch("identifier")
+          )
+          abort stderr unless status.success?
+
+          udid = stdout.strip
+          File.open(ENV.fetch("GITHUB_OUTPUT"), "a") do |file|
+            file.puts "udid=#{udid}"
+            file.puts "name=#{name}"
+            file.puts "device=#{device.fetch("name")}"
+            file.puts "runtime=#{runtime.fetch("name")}"
+          end
+
+          puts "Created #{name} (#{udid}) using #{device.fetch("name")} on #{runtime.fetch("name")}"
+          RUBY
+
+      - name: Boot disposable simulator
+        env:
+          SIM_UDID: ${{ steps.simulator.outputs.udid }}
+        run: |
+          set -euo pipefail
+          xcrun simctl boot "$SIM_UDID"
+          xcrun simctl bootstatus "$SIM_UDID" -b
+
+      - name: Run wallet flow XCUITest
+        working-directory: packages/swift-sdk
+        env:
+          SIM_UDID: ${{ steps.simulator.outputs.udid }}
+          RESULT_BUNDLE_PATH: ${{ runner.temp }}/SwiftExampleAppUITests.xcresult
+        run: |
+          set -euo pipefail
+          xcodebuild test \
+            -project SwiftExampleApp/SwiftExampleApp.xcodeproj \
+            -scheme SwiftExampleApp \
+            -destination "platform=iOS Simulator,id=$SIM_UDID" \
+            -only-testing:SwiftExampleAppUITests/SwiftExampleAppUITests/testCreateGeneratedWalletFlow \
+            -parallel-testing-enabled NO \
+            -maximum-concurrent-test-simulator-destinations 1 \
+            -resultBundlePath "$RESULT_BUNDLE_PATH"
+
+      - name: Upload XCUITest result bundle
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: SwiftExampleAppUITests-xcresult
+          path: ${{ runner.temp }}/SwiftExampleAppUITests.xcresult
+          if-no-files-found: ignore
+          retention-days: 14
+
+      - name: Delete disposable simulator
+        if: always() && steps.simulator.outputs.udid != ''
+        env:
+          SIM_UDID: ${{ steps.simulator.outputs.udid }}
+        run: |
+          xcrun simctl shutdown "$SIM_UDID" || true
+          xcrun simctl delete "$SIM_UDID" || true

--- a/.github/workflows/swift-example-app-ui-smoke.yml
+++ b/.github/workflows/swift-example-app-ui-smoke.yml
@@ -18,9 +18,8 @@ jobs:
         with:
           clean: true
 
-      - name: Force clean working directory
+      - name: Reset checked-out worktree
         run: |
-          git clean -ffdx
           git reset --hard HEAD
 
       - name: Show Xcode and Swift versions
@@ -38,6 +37,8 @@ jobs:
             ~/.cargo/registry
             ~/.cargo/git
           key: cargo-registry-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            cargo-registry-
 
       - name: Add iOS simulator Rust target
         run: |
@@ -52,33 +53,23 @@ jobs:
         uses: actions/cache@v4
         with:
           path: |
-            ${{ env.HOME }}/.local/protoc-32.0/bin
-            ${{ env.HOME }}/.local/protoc-32.0/include
+            ~/.local/protoc-32.0/bin
+            ~/.local/protoc-32.0/include
           key: protoc/32.0/${{ runner.os }}/universal
+          restore-keys: |
+            protoc/32.0/${{ runner.os }}/
 
       - name: Install Protobuf if cache miss
         if: steps.cache-protoc.outputs.cache-hit != 'true'
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euxo pipefail
           VERSION=32.0
           OS=osx-universal_binary
           PROTOC_DIR="$HOME/.local/protoc-${VERSION}"
           mkdir -p "$PROTOC_DIR"
-          curl -fsSL -H "Authorization: token ${GITHUB_TOKEN}" \
-            -o /tmp/protoc.zip \
+          curl -fsSL -o /tmp/protoc.zip \
             "https://github.com/protocolbuffers/protobuf/releases/download/v${VERSION}/protoc-${VERSION}-${OS}.zip"
           unzip -o /tmp/protoc.zip -d "$PROTOC_DIR"
-
-      - name: Save cached Protobuf
-        if: steps.cache-protoc.outputs.cache-hit != 'true'
-        uses: actions/cache/save@v4
-        with:
-          path: |
-            ${{ env.HOME }}/.local/protoc-32.0/bin
-            ${{ env.HOME }}/.local/protoc-32.0/include
-          key: protoc/32.0/${{ runner.os }}/universal
 
       - name: Verify protoc and export env
         run: |
@@ -123,13 +114,17 @@ jobs:
           abort "No available iOS simulator runtime found" unless runtime
 
           preferred_names = ["iPhone 16", "iPhone 16e"]
+          supported_ids = runtime.fetch("supportedDeviceTypes", []).map { |item| item["identifier"] }
+          candidates = device_types.select do |item|
+            supported_ids.empty? || supported_ids.include?(item["identifier"])
+          end
           device = preferred_names
-            .map { |name| device_types.find { |item| item["name"] == name } }
+            .map { |name| candidates.find { |item| item["name"] == name } }
             .compact
             .first
-          device ||= device_types.find { |item| item["name"].start_with?("iPhone") && !item["name"].include?("SE") }
-          device ||= device_types.find { |item| item["name"].start_with?("iPhone") }
-          abort "No iPhone simulator device type found" unless device
+          device ||= candidates.find { |item| item["name"].start_with?("iPhone") && !item["name"].include?("SE") }
+          device ||= candidates.find { |item| item["name"].start_with?("iPhone") }
+          abort "No compatible iPhone simulator device type found for runtime #{runtime.fetch("name")}" unless device
 
           name = ENV.fetch("SIM_NAME")
           stdout, stderr, status = Open3.capture3(

--- a/packages/swift-sdk/SwiftExampleApp/SwiftExampleApp.xcodeproj/xcshareddata/xcschemes/SwiftExampleApp.xcscheme
+++ b/packages/swift-sdk/SwiftExampleApp/SwiftExampleApp.xcodeproj/xcshareddata/xcschemes/SwiftExampleApp.xcscheme
@@ -42,8 +42,7 @@
             </BuildableReference>
          </TestableReference>
          <TestableReference
-            skipped = "NO"
-            parallelizable = "YES">
+            skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "FB6D4D182DF53B40000F3FE1"

--- a/packages/swift-sdk/SwiftExampleApp/SwiftExampleApp/ContentView.swift
+++ b/packages/swift-sdk/SwiftExampleApp/SwiftExampleApp/ContentView.swift
@@ -80,6 +80,7 @@ struct ContentView: View {
                 WalletsTabView()
                     .tabItem {
                         Label("Wallets", systemImage: "wallet.pass")
+                            .accessibilityIdentifier("rootTab.wallets")
                     }
                     .tag(RootTab.wallets)
 

--- a/packages/swift-sdk/SwiftExampleApp/SwiftExampleApp/ContentView.swift
+++ b/packages/swift-sdk/SwiftExampleApp/SwiftExampleApp/ContentView.swift
@@ -78,9 +78,9 @@ struct ContentView: View {
 
                 // Tab 2: Wallets
                 WalletsTabView()
+                    .accessibilityIdentifier("rootTab.wallets")
                     .tabItem {
                         Label("Wallets", systemImage: "wallet.pass")
-                            .accessibilityIdentifier("rootTab.wallets")
                     }
                     .tag(RootTab.wallets)
 

--- a/packages/swift-sdk/SwiftExampleApp/SwiftExampleApp/Core/Views/CreateWalletView.swift
+++ b/packages/swift-sdk/SwiftExampleApp/SwiftExampleApp/Core/Views/CreateWalletView.swift
@@ -51,6 +51,7 @@ struct CreateWalletView: View {
                     .textInputAutocapitalization(.words)
                     .focused($focusedField, equals: .walletName)
                     .submitLabel(.next)
+                    .accessibilityIdentifier("createWallet.walletNameField")
                     .onSubmit {
                         focusedField = .pin
                     }
@@ -114,6 +115,7 @@ struct CreateWalletView: View {
                         .textContentType(.oneTimeCode)
                         .autocorrectionDisabled()
                         .focused($focusedField, equals: .pin)
+                        .accessibilityIdentifier("createWallet.pinField")
                 }
 
                 HStack {
@@ -124,6 +126,7 @@ struct CreateWalletView: View {
                         .textContentType(.oneTimeCode)
                         .autocorrectionDisabled()
                         .focused($focusedField, equals: .confirmPin)
+                        .accessibilityIdentifier("createWallet.confirmPinField")
                 }
             } header: {
                 Text("Security")
@@ -182,6 +185,7 @@ struct CreateWalletView: View {
                     onCreateTapped()
                 }
                 .disabled(!canCreateWallet)
+                .accessibilityIdentifier("createWallet.createButton")
             }
         }
         .disabled(isCreating)

--- a/packages/swift-sdk/SwiftExampleApp/SwiftExampleApp/Core/Views/SeedBackupView.swift
+++ b/packages/swift-sdk/SwiftExampleApp/SwiftExampleApp/Core/Views/SeedBackupView.swift
@@ -46,6 +46,7 @@ struct SeedBackupView: View {
                 Text("I wrote it down")
                     .font(.body)
             }
+            .accessibilityIdentifier("seedBackup.wroteItDownToggle")
             .padding(.top, 8)
 
             Spacer()
@@ -70,6 +71,7 @@ struct SeedBackupView: View {
                 .foregroundColor(.white)
                 .cornerRadius(10)
                 .disabled(!wroteItDown || isSubmitting)
+                .accessibilityIdentifier("seedBackup.createWalletButton")
             }
         }
         .padding()

--- a/packages/swift-sdk/SwiftExampleApp/SwiftExampleApp/Core/Views/WalletDetailView.swift
+++ b/packages/swift-sdk/SwiftExampleApp/SwiftExampleApp/Core/Views/WalletDetailView.swift
@@ -532,23 +532,31 @@ struct WalletInfoView: View {
     private func deleteWallet() async {
         let walletId = wallet.walletId
 
-        // Dismiss views FIRST to prevent UI from accessing deleted
-        // relationships, then delete the `PersistentWallet` row.
+        await MainActor.run { isDeleting = true }
+
         // Cascade-delete rules on `accounts` / `identities` null out
         // or cascade the children automatically.
-        await MainActor.run {
-            dismiss()
-            onWalletDeleted()
-        }
-
         modelContext.delete(wallet)
-        try? modelContext.save()
         do {
+            try modelContext.save()
             try WalletStorage().deleteMnemonic(for: walletId)
         } catch {
+            modelContext.rollback()
             SDKLogger.error(
-                "Failed to delete wallet mnemonic from keychain: \(error.localizedDescription)"
+                "Failed to fully delete wallet: \(error.localizedDescription)"
             )
+            await MainActor.run {
+                errorMessage = "Failed to delete wallet: \(error.localizedDescription)"
+                showError = true
+                isDeleting = false
+            }
+            return
+        }
+
+        await MainActor.run {
+            isDeleting = false
+            dismiss()
+            onWalletDeleted()
         }
         // TODO(platform-wallet): expose wallet removal on PlatformWalletManager
         // so the Rust side also drops the in-memory handle.

--- a/packages/swift-sdk/SwiftExampleApp/SwiftExampleApp/Core/Views/WalletDetailView.swift
+++ b/packages/swift-sdk/SwiftExampleApp/SwiftExampleApp/Core/Views/WalletDetailView.swift
@@ -147,6 +147,7 @@ struct WalletDetailView: View {
                 } label: {
                     Image(systemName: "info.circle")
                 }
+                .accessibilityIdentifier("walletDetail.infoButton")
             }
         }
         .sheet(isPresented: $showReceiveAddress) {
@@ -386,6 +387,7 @@ struct WalletInfoView: View {
                         }
                     }
                     .disabled(isDeleting)
+                    .accessibilityIdentifier("walletInfo.deleteWalletButton")
                     .listRowBackground(Color.red)
                 }
             }
@@ -528,6 +530,8 @@ struct WalletInfoView: View {
     }
 
     private func deleteWallet() async {
+        let walletId = wallet.walletId
+
         // Dismiss views FIRST to prevent UI from accessing deleted
         // relationships, then delete the `PersistentWallet` row.
         // Cascade-delete rules on `accounts` / `identities` null out
@@ -539,6 +543,13 @@ struct WalletInfoView: View {
 
         modelContext.delete(wallet)
         try? modelContext.save()
+        do {
+            try WalletStorage().deleteMnemonic(for: walletId)
+        } catch {
+            SDKLogger.error(
+                "Failed to delete wallet mnemonic from keychain: \(error.localizedDescription)"
+            )
+        }
         // TODO(platform-wallet): expose wallet removal on PlatformWalletManager
         // so the Rust side also drops the in-memory handle.
     }

--- a/packages/swift-sdk/SwiftExampleApp/SwiftExampleApp/Core/Views/WalletsContentView.swift
+++ b/packages/swift-sdk/SwiftExampleApp/SwiftExampleApp/Core/Views/WalletsContentView.swift
@@ -54,7 +54,8 @@ struct WalletsContentView: View {
                         } label: {
                             WalletRowView(wallet: wallet)
                         }
-                        .accessibilityIdentifier("wallets.walletRow.\(wallet.label)")
+                        .accessibilityIdentifier("wallets.walletRow.\(wallet.walletId.toHexString())")
+                        .accessibilityLabel(wallet.label)
                     }
                 }
             }

--- a/packages/swift-sdk/SwiftExampleApp/SwiftExampleApp/Core/Views/WalletsContentView.swift
+++ b/packages/swift-sdk/SwiftExampleApp/SwiftExampleApp/Core/Views/WalletsContentView.swift
@@ -43,6 +43,7 @@ struct WalletsContentView: View {
                                 .background(Color.blue)
                                 .cornerRadius(8)
                         }
+                        .accessibilityIdentifier("wallets.empty.createWalletButton")
                     }
                     .frame(maxWidth: .infinity)
                     .padding(.vertical, 20)
@@ -53,10 +54,12 @@ struct WalletsContentView: View {
                         } label: {
                             WalletRowView(wallet: wallet)
                         }
+                        .accessibilityIdentifier("wallets.walletRow.\(wallet.label)")
                     }
                 }
             }
         }
+        .accessibilityIdentifier("wallets.screen")
         .navigationTitle("Wallets")
         .toolbar {
             ToolbarItem(placement: .navigationBarTrailing) {
@@ -65,6 +68,7 @@ struct WalletsContentView: View {
                 } label: {
                     Image(systemName: "plus")
                 }
+                .accessibilityIdentifier("wallets.addWalletButton")
             }
         }
         .sheet(isPresented: $showingCreateWallet) {

--- a/packages/swift-sdk/SwiftExampleApp/SwiftExampleAppUITests/SwiftExampleAppUITests.swift
+++ b/packages/swift-sdk/SwiftExampleApp/SwiftExampleAppUITests/SwiftExampleAppUITests.swift
@@ -8,34 +8,296 @@
 import XCTest
 
 final class SwiftExampleAppUITests: XCTestCase {
+    private enum Identifier {
+        static let walletsTab = "rootTab.wallets"
+        static let walletsScreen = "wallets.screen"
+        static let addWalletButton = "wallets.addWalletButton"
+        static let emptyCreateWalletButton = "wallets.empty.createWalletButton"
+        static let walletNameField = "createWallet.walletNameField"
+        static let pinField = "createWallet.pinField"
+        static let confirmPinField = "createWallet.confirmPinField"
+        static let createWalletButton = "createWallet.createButton"
+        static let wroteItDownToggle = "seedBackup.wroteItDownToggle"
+        static let confirmSeedCreateWalletButton = "seedBackup.createWalletButton"
+        static let walletInfoButton = "walletDetail.infoButton"
+        static let deleteWalletButton = "walletInfo.deleteWalletButton"
 
-    override func setUpWithError() throws {
-        // Put setup code here. This method is called before the invocation of each test method in the class.
-
-        // In UI tests it is usually best to stop immediately when a failure occurs.
-        continueAfterFailure = false
-
-        // In UI tests it’s important to set the initial state - such as interface orientation - required for your tests before they run. The setUp method is a good place to do this.
+        static func walletRow(named name: String) -> String {
+            "wallets.walletRow.\(name)"
+        }
     }
 
-    override func tearDownWithError() throws {
-        // Put teardown code here. This method is called after the invocation of each test method in the class.
+    override func setUpWithError() throws {
+        continueAfterFailure = false
     }
 
     @MainActor
-    func testExample() throws {
-        // UI tests must launch the application that they test.
+    func testCreateGeneratedWalletFlow() throws {
         let app = XCUIApplication()
         app.launch()
 
-        // Use XCTAssert and related functions to verify your tests produce the correct results.
+        failIfRecoveryPromptVisible(in: app, timeout: 2)
+        openWalletsTab(in: app)
+
+        let walletName = "UITest Wallet \(UUID().uuidString.prefix(8))"
+        createGeneratedWallet(named: walletName, in: app)
+
+        let createdWalletRow = scrollToWalletRow(named: walletName, in: app)
+        XCTAssertTrue(
+            createdWalletRow.waitForExistence(timeout: 20),
+            "Expected created wallet row named \(walletName) to appear."
+        )
+
+        deleteWallet(named: walletName, in: app)
     }
 
     @MainActor
-    func testLaunchPerformance() throws {
-        // This measures how long it takes to launch your application.
-        measure(metrics: [XCTApplicationLaunchMetric()]) {
-            XCUIApplication().launch()
+    private func openWalletsTab(in app: XCUIApplication) {
+        let walletsScreen = element(Identifier.walletsScreen, in: app)
+        if walletsScreen.exists {
+            return
         }
+
+        let tabBar = app.tabBars.firstMatch
+        XCTAssertTrue(
+            tabBar.waitForExistence(timeout: 60),
+            "Expected root tab bar to appear after app initialization."
+        )
+        failIfRecoveryPromptVisible(in: app, timeout: 0)
+
+        let walletsTab = button(Identifier.walletsTab, in: app)
+        if walletsTab.exists && walletsTab.isHittable {
+            walletsTab.tap()
+        } else {
+            let labeledWalletsTab = app.tabBars.buttons["Wallets"]
+            if labeledWalletsTab.exists && labeledWalletsTab.isHittable {
+                labeledWalletsTab.tap()
+            } else {
+                tapTabBarItem(index: 1, itemCount: 5, in: app)
+            }
+        }
+
+        XCTAssertTrue(
+            walletsScreen.waitForExistence(timeout: 10)
+                || app.navigationBars["Wallets"].waitForExistence(timeout: 1),
+            "Expected Wallets screen after selecting Wallets tab."
+        )
+    }
+
+    @MainActor
+    private func createGeneratedWallet(named walletName: String, in app: XCUIApplication) {
+        let addWalletButton = button(Identifier.addWalletButton, in: app)
+        if addWalletButton.waitForExistence(timeout: 5) {
+            addWalletButton.tap()
+        } else {
+            let emptyCreateButton = button(Identifier.emptyCreateWalletButton, in: app)
+            XCTAssertTrue(
+                emptyCreateButton.waitForExistence(timeout: 5),
+                "Expected either the toolbar add button or empty-state create wallet button."
+            )
+            emptyCreateButton.tap()
+        }
+
+        XCTAssertTrue(
+            app.navigationBars["Create Wallet"].waitForExistence(timeout: 10),
+            "Expected Create Wallet sheet to open."
+        )
+
+        let walletNameField = textField(Identifier.walletNameField, in: app)
+        XCTAssertTrue(walletNameField.waitForExistence(timeout: 5))
+        walletNameField.tap()
+        walletNameField.typeText(walletName)
+
+        let pinField = secureTextField(Identifier.pinField, in: app)
+        XCTAssertTrue(pinField.waitForExistence(timeout: 5))
+        pinField.tap()
+        pinField.typeText("1234")
+
+        let confirmPinField = secureTextField(Identifier.confirmPinField, in: app)
+        XCTAssertTrue(confirmPinField.waitForExistence(timeout: 5))
+        confirmPinField.tap()
+        confirmPinField.typeText("1234")
+
+        let createButton = button(Identifier.createWalletButton, in: app)
+        XCTAssertTrue(
+            waitForElementToBeEnabled(createButton, timeout: 5),
+            "Expected Create button to become enabled after valid wallet form input."
+        )
+        createButton.tap()
+
+        XCTAssertTrue(
+            app.navigationBars["Backup Seed"].waitForExistence(timeout: 10),
+            "Expected Backup Seed screen after creating a generated recovery phrase."
+        )
+
+        let wroteItDownToggle = switchControl(Identifier.wroteItDownToggle, in: app)
+        XCTAssertTrue(wroteItDownToggle.waitForExistence(timeout: 5))
+        scrollUntilHittable(wroteItDownToggle, in: app)
+        XCTAssertTrue(
+            wroteItDownToggle.isHittable,
+            "Expected seed backup confirmation switch to be hittable."
+        )
+        if !isSwitchOn(wroteItDownToggle) {
+            wroteItDownToggle
+                .coordinate(withNormalizedOffset: CGVector(dx: 0.9, dy: 0.5))
+                .tap()
+        }
+        XCTAssertTrue(
+            wait(timeout: 5) { isSwitchOn(wroteItDownToggle) },
+            "Expected seed backup confirmation switch to turn on."
+        )
+
+        let confirmCreateButton = button(Identifier.confirmSeedCreateWalletButton, in: app)
+        XCTAssertTrue(
+            waitForElementToBeEnabled(confirmCreateButton, timeout: 5),
+            "Expected final Create Wallet button to enable after confirming seed backup."
+        )
+        confirmCreateButton.tap()
+    }
+
+    @MainActor
+    private func deleteWallet(named walletName: String, in app: XCUIApplication) {
+        let walletRow = scrollToWalletRow(named: walletName, in: app)
+        XCTAssertTrue(
+            walletRow.waitForExistence(timeout: 10),
+            "Expected wallet row named \(walletName) before cleanup."
+        )
+        walletRow.tap()
+
+        let infoButton = button(Identifier.walletInfoButton, in: app)
+        XCTAssertTrue(infoButton.waitForExistence(timeout: 10))
+        infoButton.tap()
+
+        let deleteButton = button(Identifier.deleteWalletButton, in: app)
+        scrollUntilHittable(deleteButton, in: app)
+        XCTAssertTrue(
+            deleteButton.exists && deleteButton.isHittable,
+            "Expected Delete Wallet button to be reachable in Wallet Info."
+        )
+        deleteButton.tap()
+
+        let deleteAlert = app.alerts["Delete Wallet"]
+        XCTAssertTrue(deleteAlert.waitForExistence(timeout: 5))
+        deleteAlert.buttons["Delete"].tap()
+
+        XCTAssertTrue(
+            waitForNonExistence(walletRow, timeout: 10),
+            "Expected created wallet row named \(walletName) to disappear after cleanup."
+        )
+    }
+
+    @MainActor
+    private func failIfRecoveryPromptVisible(in app: XCUIApplication, timeout: TimeInterval) {
+        let recoverWalletAlert = app.alerts["Recover Wallet?"]
+        if recoverWalletAlert.waitForExistence(timeout: timeout) {
+            XCTFail(
+                "Pre-existing orphan-mnemonic recovery alert is blocking the UI test. "
+                + "Clean simulator state or resolve the alert manually before running this flow."
+            )
+        }
+    }
+
+    @MainActor
+    private func scrollToWalletRow(named walletName: String, in app: XCUIApplication) -> XCUIElement {
+        let row = element(Identifier.walletRow(named: walletName), in: app)
+        for _ in 0..<8 where !row.exists {
+            app.swipeUp()
+        }
+        return row
+    }
+
+    @MainActor
+    private func scrollUntilHittable(_ element: XCUIElement, in app: XCUIApplication) {
+        for _ in 0..<6 where !(element.exists && element.isHittable) {
+            app.swipeUp()
+        }
+    }
+
+    @MainActor
+    private func tapTabBarItem(index: Int, itemCount: Int, in app: XCUIApplication) {
+        let tabBar = app.tabBars.firstMatch
+        XCTAssertTrue(tabBar.waitForExistence(timeout: 10), "Expected tab bar to be present.")
+
+        let itemWidth = tabBar.frame.width / CGFloat(itemCount)
+        let x = tabBar.frame.minX + itemWidth * (CGFloat(index) + 0.5)
+        let y = tabBar.frame.midY
+        app.coordinate(withNormalizedOffset: .zero)
+            .withOffset(CGVector(dx: x, dy: y))
+            .tap()
+    }
+
+    @MainActor
+    private func element(_ identifier: String, in app: XCUIApplication) -> XCUIElement {
+        app.descendants(matching: .any)
+            .matching(identifier: identifier)
+            .firstMatch
+    }
+
+    @MainActor
+    private func button(_ identifier: String, in app: XCUIApplication) -> XCUIElement {
+        app.buttons
+            .matching(identifier: identifier)
+            .firstMatch
+    }
+
+    @MainActor
+    private func textField(_ identifier: String, in app: XCUIApplication) -> XCUIElement {
+        app.textFields
+            .matching(identifier: identifier)
+            .firstMatch
+    }
+
+    @MainActor
+    private func secureTextField(_ identifier: String, in app: XCUIApplication) -> XCUIElement {
+        app.secureTextFields
+            .matching(identifier: identifier)
+            .firstMatch
+    }
+
+    @MainActor
+    private func switchControl(_ identifier: String, in app: XCUIApplication) -> XCUIElement {
+        app.switches
+            .matching(identifier: identifier)
+            .firstMatch
+    }
+
+    @MainActor
+    private func waitForElementToBeEnabled(
+        _ element: XCUIElement,
+        timeout: TimeInterval
+    ) -> Bool {
+        wait(timeout: timeout) {
+            element.exists && element.isEnabled
+        }
+    }
+
+    @MainActor
+    private func waitForNonExistence(
+        _ element: XCUIElement,
+        timeout: TimeInterval
+    ) -> Bool {
+        wait(timeout: timeout) {
+            !element.exists
+        }
+    }
+
+    @MainActor
+    private func isSwitchOn(_ element: XCUIElement) -> Bool {
+        guard let value = element.value as? String else {
+            return false
+        }
+        return value == "1" || value.lowercased() == "true"
+    }
+
+    @MainActor
+    private func wait(timeout: TimeInterval, until condition: () -> Bool) -> Bool {
+        let deadline = Date().addingTimeInterval(timeout)
+        while Date() < deadline {
+            if condition() {
+                return true
+            }
+            RunLoop.current.run(until: Date().addingTimeInterval(0.1))
+        }
+        return condition()
     }
 }

--- a/packages/swift-sdk/SwiftExampleApp/SwiftExampleAppUITests/SwiftExampleAppUITests.swift
+++ b/packages/swift-sdk/SwiftExampleApp/SwiftExampleAppUITests/SwiftExampleAppUITests.swift
@@ -21,10 +21,6 @@ final class SwiftExampleAppUITests: XCTestCase {
         static let confirmSeedCreateWalletButton = "seedBackup.createWalletButton"
         static let walletInfoButton = "walletDetail.infoButton"
         static let deleteWalletButton = "walletInfo.deleteWalletButton"
-
-        static func walletRow(named name: String) -> String {
-            "wallets.walletRow.\(name)"
-        }
     }
 
     override func setUpWithError() throws {
@@ -65,15 +61,22 @@ final class SwiftExampleAppUITests: XCTestCase {
         )
         failIfRecoveryPromptVisible(in: app, timeout: 0)
 
-        let walletsTab = button(Identifier.walletsTab, in: app)
-        if walletsTab.exists && walletsTab.isHittable {
+        let walletsTab = app.tabBars.buttons
+            .matching(identifier: Identifier.walletsTab)
+            .firstMatch
+        if walletsTab.waitForExistence(timeout: 2) {
             walletsTab.tap()
         } else {
             let labeledWalletsTab = app.tabBars.buttons["Wallets"]
-            if labeledWalletsTab.exists && labeledWalletsTab.isHittable {
+            if labeledWalletsTab.waitForExistence(timeout: 2) {
                 labeledWalletsTab.tap()
             } else {
-                tapTabBarItem(index: 1, itemCount: 5, in: app)
+                let indexedWalletsTab = app.tabBars.buttons.element(boundBy: 1)
+                XCTAssertTrue(
+                    indexedWalletsTab.waitForExistence(timeout: 5),
+                    "Expected Wallets tab button to exist."
+                )
+                indexedWalletsTab.tap()
             }
         }
 
@@ -143,7 +146,7 @@ final class SwiftExampleAppUITests: XCTestCase {
                 .tap()
         }
         XCTAssertTrue(
-            wait(timeout: 5) { isSwitchOn(wroteItDownToggle) },
+            waitForSwitchToTurnOn(wroteItDownToggle, timeout: 5),
             "Expected seed backup confirmation switch to turn on."
         )
 
@@ -199,11 +202,23 @@ final class SwiftExampleAppUITests: XCTestCase {
 
     @MainActor
     private func scrollToWalletRow(named walletName: String, in app: XCUIApplication) -> XCUIElement {
-        let row = element(Identifier.walletRow(named: walletName), in: app)
+        let row = app.buttons
+            .matching(NSPredicate(format: "label == %@", walletName))
+            .firstMatch
         for _ in 0..<8 where !row.exists {
             app.swipeUp()
         }
-        return row
+        if row.exists {
+            return row
+        }
+
+        let label = app.staticTexts
+            .matching(NSPredicate(format: "label == %@", walletName))
+            .firstMatch
+        for _ in 0..<8 where !label.exists {
+            app.swipeUp()
+        }
+        return label
     }
 
     @MainActor
@@ -211,19 +226,6 @@ final class SwiftExampleAppUITests: XCTestCase {
         for _ in 0..<6 where !(element.exists && element.isHittable) {
             app.swipeUp()
         }
-    }
-
-    @MainActor
-    private func tapTabBarItem(index: Int, itemCount: Int, in app: XCUIApplication) {
-        let tabBar = app.tabBars.firstMatch
-        XCTAssertTrue(tabBar.waitForExistence(timeout: 10), "Expected tab bar to be present.")
-
-        let itemWidth = tabBar.frame.width / CGFloat(itemCount)
-        let x = tabBar.frame.minX + itemWidth * (CGFloat(index) + 0.5)
-        let y = tabBar.frame.midY
-        app.coordinate(withNormalizedOffset: .zero)
-            .withOffset(CGVector(dx: x, dy: y))
-            .tap()
     }
 
     @MainActor
@@ -266,9 +268,12 @@ final class SwiftExampleAppUITests: XCTestCase {
         _ element: XCUIElement,
         timeout: TimeInterval
     ) -> Bool {
-        wait(timeout: timeout) {
-            element.exists && element.isEnabled
+        let predicate = NSPredicate { object, _ in
+            guard let element = object as? XCUIElement else { return false }
+            return element.exists && element.isEnabled
         }
+        let expectation = XCTNSPredicateExpectation(predicate: predicate, object: element)
+        return XCTWaiter.wait(for: [expectation], timeout: timeout) == .completed
     }
 
     @MainActor
@@ -276,9 +281,26 @@ final class SwiftExampleAppUITests: XCTestCase {
         _ element: XCUIElement,
         timeout: TimeInterval
     ) -> Bool {
-        wait(timeout: timeout) {
-            !element.exists
+        let predicate = NSPredicate { object, _ in
+            guard let element = object as? XCUIElement else { return false }
+            return !element.exists
         }
+        let expectation = XCTNSPredicateExpectation(predicate: predicate, object: element)
+        return XCTWaiter.wait(for: [expectation], timeout: timeout) == .completed
+    }
+
+    @MainActor
+    private func waitForSwitchToTurnOn(
+        _ element: XCUIElement,
+        timeout: TimeInterval
+    ) -> Bool {
+        let predicate = NSPredicate { object, _ in
+            guard let element = object as? XCUIElement else { return false }
+            guard let value = element.value as? String else { return false }
+            return value == "1" || value.lowercased() == "true"
+        }
+        let expectation = XCTNSPredicateExpectation(predicate: predicate, object: element)
+        return XCTWaiter.wait(for: [expectation], timeout: timeout) == .completed
     }
 
     @MainActor
@@ -289,15 +311,4 @@ final class SwiftExampleAppUITests: XCTestCase {
         return value == "1" || value.lowercased() == "true"
     }
 
-    @MainActor
-    private func wait(timeout: TimeInterval, until condition: () -> Bool) -> Bool {
-        let deadline = Date().addingTimeInterval(timeout)
-        while Date() < deadline {
-            if condition() {
-                return true
-            }
-            RunLoop.current.run(until: Date().addingTimeInterval(0.1))
-        }
-        return condition()
-    }
 }


### PR DESCRIPTION
## Summary
- add stable SwiftExampleApp accessibility identifiers for wallet creation and cleanup controls
- add an XCUITest smoke flow that creates a generated wallet, verifies it appears, then deletes it
- clean up wallet mnemonics when deleting wallets and add a manual-only UI smoke workflow

## Validation
- xcodebuild test -project packages/swift-sdk/SwiftExampleApp/SwiftExampleApp.xcodeproj -scheme SwiftExampleApp -destination 'platform=iOS Simulator,id=00FBEE82-B611-45D2-AD31-C454A9502D33' -only-testing:SwiftExampleAppUITests/SwiftExampleAppUITests/testCreateGeneratedWalletFlow -parallel-testing-enabled NO -maximum-concurrent-test-simulator-destinations 1
- git diff --check
- parsed .github/workflows/swift-example-app-ui-smoke.yml with Ruby Psych

## Notes
- iPhone 16 was unavailable locally, so validation used iPhone 16e
- the new workflow is workflow_dispatch only and is not wired into PR CI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Testing**
  * Added automated UI testing workflow for iOS simulator validation.
  * Implemented comprehensive wallet creation and deletion test flow.

* **Bug Fixes**
  * Enhanced wallet deletion to properly clean up keychain storage, preventing data remnants.

* **Accessibility**
  * Added accessibility identifiers across UI elements to improve automation support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->