### PR TITLE
perf(swift-sdk): gate SPV progress polling on inequality

### DIFF
--- a/packages/swift-sdk/Sources/SwiftDashSDK/PlatformWallet/PlatformWalletManager.swift
+++ b/packages/swift-sdk/Sources/SwiftDashSDK/PlatformWallet/PlatformWalletManager.swift
@@ -379,15 +379,22 @@ public class PlatformWalletManager: ObservableObject {
     }
 
     /// Starts the SPV progress polling loop. Cancelled on deinit.
+    ///
+    /// `@Published` assignments are gated on inequality so that identical
+    /// snapshots don't trigger SwiftUI re-evaluation. A naive 1 Hz reassignment
+    /// of a non-Equatable struct caused every observer (sync screens, memory
+    /// explorer, global indicator) to re-evaluate every second, accreting
+    /// SwiftUI attribute-graph state and burning CPU long after sync settled.
     private func startProgressPolling() {
         progressPollTask?.cancel()
         progressPollTask = Task { [weak self] in
             while !Task.isCancelled {
                 guard let self = self else { return }
-                if let progress = try? self.syncProgress() {
+                if let progress = try? self.syncProgress(), progress != self.spvProgress {
                     self.spvProgress = progress
                 }
-                if let isSyncing = try? self.isPlatformAddressSyncing() {
+                if let isSyncing = try? self.isPlatformAddressSyncing(),
+                   isSyncing != self.platformAddressSyncIsSyncing {
                     self.platformAddressSyncIsSyncing = isSyncing
                 }
                 try? await Task.sleep(for: .seconds(1))

--- a/packages/swift-sdk/Sources/SwiftDashSDK/PlatformWallet/PlatformWalletManagerSPV.swift
+++ b/packages/swift-sdk/Sources/SwiftDashSDK/PlatformWallet/PlatformWalletManagerSPV.swift
@@ -17,7 +17,7 @@ public enum PlatformSpvSyncState: UInt32, Sendable {
 }
 
 /// Progress for one of the SPV sub-managers (headers, filters, masternodes, etc.).
-public struct PlatformSpvSubProgress: Sendable {
+public struct PlatformSpvSubProgress: Sendable, Equatable {
     public let state: PlatformSpvSyncState
     public let currentHeight: UInt32
     public let targetHeight: UInt32
@@ -25,7 +25,7 @@ public struct PlatformSpvSubProgress: Sendable {
 }
 
 /// Aggregate SPV sync progress snapshot.
-public struct PlatformSpvSyncProgress: Sendable {
+public struct PlatformSpvSyncProgress: Sendable, Equatable {
     public let overallState: PlatformSpvSyncState
     public let overallPercentage: Double
 


### PR DESCRIPTION
## Issue being fixed or feature implemented

After leaving `SwiftExampleApp` running overnight the user observed it sitting at **729 MB memory and 98% CPU**. Investigation traced the runaway to the 1 Hz SPV-progress polling task in `PlatformWalletManager`.

The poller reassigned `@Published spvProgress` and `@Published platformAddressSyncIsSyncing` on every tick regardless of whether the values had actually changed. Because `PlatformSpvSyncProgress` and `PlatformSpvSubProgress` were `Sendable` but **not `Equatable`**, each assignment unconditionally fired `objectWillChange` — forcing every observing view (the sync screens, the memory explorer, `GlobalSyncIndicator`) to re-evaluate `body` once per second forever. Over ~12 hours that's ~43,200 SwiftUI invalidations; the attribute graph and diffing caches accreted, and the loop re-emitted onto the main thread every second forever, even after sync had long settled.

## What was done?

- Added `Equatable` conformance to `PlatformSpvSubProgress` and `PlatformSpvSyncProgress` (all members were already `Equatable` — just synthesised conformance).
- Gated the two `@Published` assignments in `startProgressPolling()` on inequality so identical snapshots no longer republish.
- Added a comment on the polling function explaining why the gate exists, so a future hand doesn't accidentally undo it.

The polling loop itself, its cancellation in `deinit`, and the FFI calls are unchanged.

## How Has This Been Tested?

- `xcodebuild -project SwiftExampleApp/SwiftExampleApp.xcodeproj -scheme SwiftExampleApp -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 16,OS=18.6,arch=arm64' build` succeeds.
- Manual verification of the regression itself (run overnight, watch CPU/memory) is suggested as a follow-up — the static read is already pretty conclusive but a confirmation trace would be worth banking. Instruments → Time Profiler should show the `platform_wallet_manager_sync_progress` stack drop out of the hot path once sync settles.

## Breaking Changes

None. `Equatable` is an additive conformance on public types; existing call sites that didn't compare these structs continue to compile unchanged.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [ ] I have made corresponding changes to the documentation if needed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Optimized wallet synchronization polling to reduce redundant property updates and minimize unnecessary UI refresh cycles, improving overall app responsiveness during sync operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->