### PR TITLE
test(wasm-sdk): fix flaky functional tests during local network warmup

### DIFF
--- a/packages/wasm-sdk/tests/functional/addresses.spec.ts
+++ b/packages/wasm-sdk/tests/functional/addresses.spec.ts
@@ -1,5 +1,6 @@
 import { expect } from './helpers/chai.ts';
 import init, * as sdk from '../../dist/sdk.compressed.js';
+import { prefetchLocalReady } from './helpers/trustedContext.ts';
 import { wasmFunctionalTestRequirements } from './fixtures/requiredTestData.ts';
 
 describe('Platform Address Queries', function describePlatformAddressQueries() {
@@ -13,7 +14,7 @@ describe('Platform Address Queries', function describePlatformAddressQueries() {
 
   before(async () => {
     await init();
-    const context = await sdk.WasmTrustedContext.prefetchLocal();
+    const context = await prefetchLocalReady();
     const builder = sdk.WasmSdkBuilder.local().withTrustedContext(context);
     client = await builder.build();
 

--- a/packages/wasm-sdk/tests/functional/contracts.spec.ts
+++ b/packages/wasm-sdk/tests/functional/contracts.spec.ts
@@ -1,5 +1,6 @@
 import { expect } from './helpers/chai.ts';
 import init, * as sdk from '../../dist/sdk.compressed.js';
+import { prefetchLocalReady } from './helpers/trustedContext.ts';
 import { wasmFunctionalTestRequirements } from './fixtures/requiredTestData.ts';
 
 describe('Data Contract Queries', function describeDataContractQueries() {
@@ -11,7 +12,7 @@ describe('Data Contract Queries', function describeDataContractQueries() {
 
   before(async () => {
     await init();
-    const context = await sdk.WasmTrustedContext.prefetchLocal();
+    const context = await prefetchLocalReady();
     const builder = sdk.WasmSdkBuilder.local().withTrustedContext(context);
     client = await builder.build();
   });

--- a/packages/wasm-sdk/tests/functional/dpns.spec.ts
+++ b/packages/wasm-sdk/tests/functional/dpns.spec.ts
@@ -1,5 +1,6 @@
 import { expect } from './helpers/chai.ts';
 import init, * as sdk from '../../dist/sdk.compressed.js';
+import { prefetchLocalReady } from './helpers/trustedContext.ts';
 import { wasmFunctionalTestRequirements } from './fixtures/requiredTestData.ts';
 
 describe('Document Queries', function describeDocumentQueries() {
@@ -12,7 +13,7 @@ describe('Document Queries', function describeDocumentQueries() {
 
   before(async () => {
     await init();
-    const context = await sdk.WasmTrustedContext.prefetchLocal();
+    const context = await prefetchLocalReady();
     builder = sdk.WasmSdkBuilder.local().withTrustedContext(context);
     client = await builder.build();
   });

--- a/packages/wasm-sdk/tests/functional/epochs-blocks.spec.ts
+++ b/packages/wasm-sdk/tests/functional/epochs-blocks.spec.ts
@@ -1,5 +1,6 @@
 import { expect } from './helpers/chai.ts';
 import init, * as sdk from '../../dist/sdk.compressed.js';
+import { prefetchLocalReady } from './helpers/trustedContext.ts';
 
 describe('Epochs and Evonode Blocks', function describeEpochs() {
   this.timeout(60000);
@@ -9,7 +10,7 @@ describe('Epochs and Evonode Blocks', function describeEpochs() {
 
   before(async () => {
     await init();
-    const context = await sdk.WasmTrustedContext.prefetchLocal();
+    const context = await prefetchLocalReady();
     const builder = sdk.WasmSdkBuilder.local().withTrustedContext(context);
     client = await builder.build();
 

--- a/packages/wasm-sdk/tests/functional/groups.spec.ts
+++ b/packages/wasm-sdk/tests/functional/groups.spec.ts
@@ -1,4 +1,5 @@
 import init, * as sdk from '../../dist/sdk.compressed.js';
+import { prefetchLocalReady } from './helpers/trustedContext.ts';
 import { wasmFunctionalTestRequirements } from './fixtures/requiredTestData.ts';
 
 describe('Groups', function describeGroups() {
@@ -9,7 +10,7 @@ describe('Groups', function describeGroups() {
 
   before(async () => {
     await init();
-    const context = await sdk.WasmTrustedContext.prefetchLocal();
+    const context = await prefetchLocalReady();
     builder = sdk.WasmSdkBuilder.local().withTrustedContext(context);
     client = await builder.build();
   });

--- a/packages/wasm-sdk/tests/functional/helpers/trustedContext.ts
+++ b/packages/wasm-sdk/tests/functional/helpers/trustedContext.ts
@@ -1,6 +1,6 @@
 import * as sdk from '../../../dist/sdk.compressed.js';
 
-const DEFAULT_TIMEOUT_MS = 120_000;
+const DEFAULT_TIMEOUT_MS = 60_000;
 const DEFAULT_INTERVAL_MS = 2_000;
 
 export interface PrefetchLocalReadyOptions {
@@ -28,12 +28,11 @@ export async function prefetchLocalReady(
     } catch (error) {
       lastError = error;
       const remaining = deadline - Date.now();
-      if (remaining <= intervalMs) {
-        break;
+      if (remaining > intervalMs) {
+        await new Promise((resolve) => {
+          setTimeout(resolve, intervalMs);
+        });
       }
-      await new Promise((resolve) => {
-        setTimeout(resolve, intervalMs);
-      });
     }
   }
 

--- a/packages/wasm-sdk/tests/functional/helpers/trustedContext.ts
+++ b/packages/wasm-sdk/tests/functional/helpers/trustedContext.ts
@@ -28,8 +28,12 @@ export async function prefetchLocalReady(
     } catch (error) {
       lastError = error;
       const remaining = deadline - Date.now();
-      if (remaining <= intervalMs) break;
-      await new Promise((resolve) => setTimeout(resolve, intervalMs));
+      if (remaining <= intervalMs) {
+        break;
+      }
+      await new Promise((resolve) => {
+        setTimeout(resolve, intervalMs);
+      });
     }
   }
 

--- a/packages/wasm-sdk/tests/functional/helpers/trustedContext.ts
+++ b/packages/wasm-sdk/tests/functional/helpers/trustedContext.ts
@@ -1,0 +1,40 @@
+import * as sdk from '../../../dist/sdk.compressed.js';
+
+const DEFAULT_TIMEOUT_MS = 120_000;
+const DEFAULT_INTERVAL_MS = 2_000;
+
+export interface PrefetchLocalReadyOptions {
+  timeoutMs?: number;
+  intervalMs?: number;
+}
+
+// Wait for the local dashmate network to be ready, then return a prefetched
+// WasmTrustedContext. Retries on any error from prefetchLocal() until the
+// timeout — masternodes can take time to reach status=ENABLED + versionCheck=success
+// after `yarn start`, and a single failed attempt would otherwise abort the suite.
+export async function prefetchLocalReady(
+  options: PrefetchLocalReadyOptions = {},
+): Promise<sdk.WasmTrustedContext> {
+  const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  const intervalMs = options.intervalMs ?? DEFAULT_INTERVAL_MS;
+  const deadline = Date.now() + timeoutMs;
+  let lastError: unknown;
+  let attempts = 0;
+
+  while (Date.now() < deadline) {
+    attempts += 1;
+    try {
+      return await sdk.WasmTrustedContext.prefetchLocal();
+    } catch (error) {
+      lastError = error;
+      const remaining = deadline - Date.now();
+      if (remaining <= intervalMs) break;
+      await new Promise((resolve) => setTimeout(resolve, intervalMs));
+    }
+  }
+
+  const message = lastError instanceof Error ? lastError.message : String(lastError);
+  throw new Error(
+    `prefetchLocalReady: local network not ready after ${timeoutMs}ms (${attempts} attempts); last error: ${message}`,
+  );
+}

--- a/packages/wasm-sdk/tests/functional/identities.spec.ts
+++ b/packages/wasm-sdk/tests/functional/identities.spec.ts
@@ -1,6 +1,7 @@
 import { expect } from './helpers/chai.ts';
 import init, * as sdk from '../../dist/sdk.compressed.js';
 import { wasmFunctionalTestRequirements } from './fixtures/requiredTestData.ts';
+import { prefetchLocalReady } from './helpers/trustedContext.ts';
 
 describe('Identities', function describeIdentities() {
   this.timeout(90000);
@@ -16,7 +17,7 @@ describe('Identities', function describeIdentities() {
 
   before(async () => {
     await init();
-    const context = await sdk.WasmTrustedContext.prefetchLocal();
+    const context = await prefetchLocalReady();
     builder = sdk.WasmSdkBuilder.local().withTrustedContext(context);
     client = await builder.build();
   });

--- a/packages/wasm-sdk/tests/functional/protocol.spec.ts
+++ b/packages/wasm-sdk/tests/functional/protocol.spec.ts
@@ -1,5 +1,6 @@
 import { expect } from './helpers/chai.ts';
 import init, * as sdk from '../../dist/sdk.compressed.js';
+import { prefetchLocalReady } from './helpers/trustedContext.ts';
 
 describe('Protocol', function describeProtocol() {
   this.timeout(60000);
@@ -9,7 +10,7 @@ describe('Protocol', function describeProtocol() {
 
   before(async () => {
     await init();
-    const context = await sdk.WasmTrustedContext.prefetchLocal();
+    const context = await prefetchLocalReady();
     const builder = sdk.WasmSdkBuilder.local().withTrustedContext(context);
     client = await builder.build();
 

--- a/packages/wasm-sdk/tests/functional/shielded.spec.ts
+++ b/packages/wasm-sdk/tests/functional/shielded.spec.ts
@@ -1,5 +1,6 @@
 import { expect } from './helpers/chai.ts';
 import init, * as sdk from '../../dist/sdk.compressed.js';
+import { prefetchLocalReady } from './helpers/trustedContext.ts';
 
 // These tests run against a local dashmate node and verify only the
 // SHAPE of each shielded query response, not its contents — the local
@@ -13,7 +14,7 @@ describe('Shielded queries', function describeShielded() {
 
   before(async () => {
     await init();
-    const context = await sdk.WasmTrustedContext.prefetchLocal();
+    const context = await prefetchLocalReady();
     const builder = sdk.WasmSdkBuilder.local().withTrustedContext(context);
     client = await builder.build();
   });

--- a/packages/wasm-sdk/tests/functional/status.spec.ts
+++ b/packages/wasm-sdk/tests/functional/status.spec.ts
@@ -3,7 +3,7 @@ import init, * as sdk from '../../dist/sdk.compressed.js';
 import { prefetchLocalReady } from './helpers/trustedContext.ts';
 
 describe('Status', function describeStatus() {
-  this.timeout(30000);
+  this.timeout(60000);
 
   let client: sdk.WasmSdk;
   let builder: sdk.WasmSdkBuilder;

--- a/packages/wasm-sdk/tests/functional/status.spec.ts
+++ b/packages/wasm-sdk/tests/functional/status.spec.ts
@@ -1,5 +1,6 @@
 import { expect } from './helpers/chai.ts';
 import init, * as sdk from '../../dist/sdk.compressed.js';
+import { prefetchLocalReady } from './helpers/trustedContext.ts';
 
 describe('Status', function describeStatus() {
   this.timeout(30000);
@@ -9,7 +10,7 @@ describe('Status', function describeStatus() {
 
   before(async () => {
     await init();
-    const context = await sdk.WasmTrustedContext.prefetchLocal();
+    const context = await prefetchLocalReady();
     builder = sdk.WasmSdkBuilder.local().withTrustedContext(context);
     client = await builder.build();
   });

--- a/packages/wasm-sdk/tests/functional/system.spec.ts
+++ b/packages/wasm-sdk/tests/functional/system.spec.ts
@@ -1,5 +1,6 @@
 import { expect } from './helpers/chai.ts';
 import init, * as sdk from '../../dist/sdk.compressed.js';
+import { prefetchLocalReady } from './helpers/trustedContext.ts';
 
 describe('System', function describeSystem() {
   this.timeout(60000);
@@ -9,7 +10,7 @@ describe('System', function describeSystem() {
 
   before(async () => {
     await init();
-    const context = await sdk.WasmTrustedContext.prefetchLocal();
+    const context = await prefetchLocalReady();
     builder = sdk.WasmSdkBuilder.local().withTrustedContext(context);
     client = await builder.build();
   });

--- a/packages/wasm-sdk/tests/functional/token-pricing.spec.ts
+++ b/packages/wasm-sdk/tests/functional/token-pricing.spec.ts
@@ -1,5 +1,6 @@
 import { expect } from './helpers/chai.ts';
 import init, * as sdk from '../../dist/sdk.compressed.js';
+import { prefetchLocalReady } from './helpers/trustedContext.ts';
 import { wasmFunctionalTestRequirements } from './fixtures/requiredTestData.ts';
 
 describe('TokenPricing', function describeTokenPricing() {
@@ -10,7 +11,7 @@ describe('TokenPricing', function describeTokenPricing() {
 
   before(async () => {
     await init();
-    const context = await sdk.WasmTrustedContext.prefetchLocal();
+    const context = await prefetchLocalReady();
     builder = sdk.WasmSdkBuilder.local().withTrustedContext(context);
     client = await builder.build();
   });

--- a/packages/wasm-sdk/tests/functional/tokens.spec.ts
+++ b/packages/wasm-sdk/tests/functional/tokens.spec.ts
@@ -1,5 +1,6 @@
 import { expect } from './helpers/chai.ts';
 import init, * as sdk from '../../dist/sdk.compressed.js';
+import { prefetchLocalReady } from './helpers/trustedContext.ts';
 import { wasmFunctionalTestRequirements } from './fixtures/requiredTestData.ts';
 
 describe('Tokens', function describeTokens() {
@@ -16,7 +17,7 @@ describe('Tokens', function describeTokens() {
 
   before(async () => {
     await init();
-    const context = await sdk.WasmTrustedContext.prefetchLocal();
+    const context = await prefetchLocalReady();
     builder = sdk.WasmSdkBuilder.local().withTrustedContext(context);
     client = await builder.build();
   });

--- a/packages/wasm-sdk/tests/functional/transitions/contracts.spec.ts
+++ b/packages/wasm-sdk/tests/functional/transitions/contracts.spec.ts
@@ -1,5 +1,6 @@
 import { expect } from '../helpers/chai.ts';
 import init, * as sdk from '../../../dist/sdk.compressed.js';
+import { prefetchLocalReady } from '../helpers/trustedContext.ts';
 import { wasmFunctionalTestRequirements, createTestSignerAndKey } from '../fixtures/requiredTestData.ts';
 
 /**
@@ -25,7 +26,7 @@ describe('Contract State Transitions', function describeContractStateTransitions
 
   before(async () => {
     await init();
-    const context = await sdk.WasmTrustedContext.prefetchLocal();
+    const context = await prefetchLocalReady();
     const builder = sdk.WasmSdkBuilder.local().withTrustedContext(context);
     client = await builder.build();
   });

--- a/packages/wasm-sdk/tests/functional/transitions/documents.spec.ts
+++ b/packages/wasm-sdk/tests/functional/transitions/documents.spec.ts
@@ -1,5 +1,6 @@
 import { expect } from '../helpers/chai.ts';
 import init, * as sdk from '../../../dist/sdk.compressed.js';
+import { prefetchLocalReady } from '../helpers/trustedContext.ts';
 import { wasmFunctionalTestRequirements, createTestSignerAndKey } from '../fixtures/requiredTestData.ts';
 
 /**
@@ -32,7 +33,7 @@ describe('Document State Transitions', function describeDocumentStateTransitions
 
   before(async () => {
     await init();
-    const context = await sdk.WasmTrustedContext.prefetchLocal();
+    const context = await prefetchLocalReady();
     const builder = sdk.WasmSdkBuilder.local().withTrustedContext(context);
     client = await builder.build();
   });

--- a/packages/wasm-sdk/tests/functional/transitions/dpns.spec.ts
+++ b/packages/wasm-sdk/tests/functional/transitions/dpns.spec.ts
@@ -1,5 +1,6 @@
 import { expect } from '../helpers/chai.ts';
 import init, * as sdk from '../../../dist/sdk.compressed.js';
+import { prefetchLocalReady } from '../helpers/trustedContext.ts';
 import { wasmFunctionalTestRequirements, createTestSignerAndKey } from '../fixtures/requiredTestData.ts';
 
 /**
@@ -30,7 +31,7 @@ describe('DPNS State Transitions', function describeDpnsStateTransitions() {
 
   before(async () => {
     await init();
-    const context = await sdk.WasmTrustedContext.prefetchLocal();
+    const context = await prefetchLocalReady();
     const builder = sdk.WasmSdkBuilder.local().withTrustedContext(context);
     client = await builder.build();
   });

--- a/packages/wasm-sdk/tests/functional/transitions/identity.spec.ts
+++ b/packages/wasm-sdk/tests/functional/transitions/identity.spec.ts
@@ -1,5 +1,6 @@
 import { expect } from '../helpers/chai.ts';
 import init, * as sdk from '../../../dist/sdk.compressed.js';
+import { prefetchLocalReady } from '../helpers/trustedContext.ts';
 import { wasmFunctionalTestRequirements, createTestSignerAndKey } from '../fixtures/requiredTestData.ts';
 
 /**
@@ -28,7 +29,7 @@ describe('Identity State Transitions', function describeIdentityStateTransitions
 
   before(async () => {
     await init();
-    const context = await sdk.WasmTrustedContext.prefetchLocal();
+    const context = await prefetchLocalReady();
     const builder = sdk.WasmSdkBuilder.local().withTrustedContext(context);
     client = await builder.build();
   });

--- a/packages/wasm-sdk/tests/functional/transitions/tokens.spec.ts
+++ b/packages/wasm-sdk/tests/functional/transitions/tokens.spec.ts
@@ -1,5 +1,6 @@
 import { expect } from '../helpers/chai.ts';
 import init, * as sdk from '../../../dist/sdk.compressed.js';
+import { prefetchLocalReady } from '../helpers/trustedContext.ts';
 import { wasmFunctionalTestRequirements, createTestSignerAndKey } from '../fixtures/requiredTestData.ts';
 
 /**
@@ -32,7 +33,7 @@ describe('Token State Transitions', function describeTokenStateTransitions() {
 
   before(async () => {
     await init();
-    const context = await sdk.WasmTrustedContext.prefetchLocal();
+    const context = await prefetchLocalReady();
     const builder = sdk.WasmSdkBuilder.local().withTrustedContext(context);
     client = await builder.build();
   });

--- a/packages/wasm-sdk/tests/functional/utilities.spec.ts
+++ b/packages/wasm-sdk/tests/functional/utilities.spec.ts
@@ -1,5 +1,6 @@
 import { expect } from './helpers/chai.ts';
 import init, * as sdk from '../../dist/sdk.compressed.js';
+import { prefetchLocalReady } from './helpers/trustedContext.ts';
 
 describe('Utilities', function describeUtilities() {
   this.timeout(60000);
@@ -8,7 +9,7 @@ describe('Utilities', function describeUtilities() {
 
   describe('WasmTrustedContext.prefetchLocal()', () => {
     it('should prefetch trusted quorums for local', async () => {
-      await sdk.WasmTrustedContext.prefetchLocal();
+      await prefetchLocalReady();
     });
   });
 

--- a/packages/wasm-sdk/tests/functional/voting.spec.ts
+++ b/packages/wasm-sdk/tests/functional/voting.spec.ts
@@ -1,4 +1,5 @@
 import init, * as sdk from '../../dist/sdk.compressed.js';
+import { prefetchLocalReady } from './helpers/trustedContext.ts';
 import { wasmFunctionalTestRequirements } from './fixtures/requiredTestData.ts';
 
 describe('Voting', function describeVoting() {
@@ -10,7 +11,7 @@ describe('Voting', function describeVoting() {
 
   before(async () => {
     await init();
-    const context = await sdk.WasmTrustedContext.prefetchLocal();
+    const context = await prefetchLocalReady();
     builder = sdk.WasmSdkBuilder.local().withTrustedContext(context);
     client = await builder.build();
   });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

The nightly scheduled `Tests` workflow on `v3.1-dev` fails 100% of the time on the `Packages functional tests / Run functional tests` step (5/5 over the past week, e.g. [run 25082687549](https://github.com/dashpay/platform/actions/runs/25082687549/job/73492606393)). Push-triggered runs on the same SHAs pass — same code, different result by trigger — pointing at a startup race rather than a code bug.

Root cause: every wasm-sdk functional spec calls `WasmTrustedContext.prefetchLocal()` exactly once in its `before all` hook. When the local dashmate network has not yet promoted all masternodes to `status=ENABLED` + `versionCheck=success`, `TrustedHttpContextProvider::fetch_masternode_addresses` ([`packages/rs-sdk-trusted-context-provider/src/provider.rs:340`](https://github.com/dashpay/platform/blob/v3.1-dev/packages/rs-sdk-trusted-context-provider/src/provider.rs#L340)) raises `"No eligible masternode addresses discovered"` and every suite aborts in `before all`.

## What was done?
<!--- Describe your changes in detail -->

- New `packages/wasm-sdk/tests/functional/helpers/trustedContext.ts` exporting `prefetchLocalReady({ timeoutMs = 120_000, intervalMs = 2_000 })`. It polls `WasmTrustedContext.prefetchLocal()` until it returns, swallowing transient errors during the local-network warmup window. On timeout it throws with the last underlying error.
- Replaced the single `await sdk.WasmTrustedContext.prefetchLocal()` call in all 19 functional spec files with `await prefetchLocalReady()`.
- **Production `WasmTrustedContext.prefetchLocal()` is unchanged** — the retry is scoped to tests so real bugs in user code still surface immediately.
- Lint fixes in the helper (`no-promise-executor-return`, `curly`).

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

**Local:** `yarn workspace @dashevo/wasm-sdk lint` passes.

**CI A/B experiment to confirm the fix and the flake.** Re-running the original failed run (`gh run rerun 25082687549`) wasn't viable — its build artifact had already been garbage-collected. Instead I produced fresh control samples by:

1. Pushing a sibling branch `test/wasm-sdk-flake-baseline-no-retry` with `prefetchLocalReady()` reverted to a single attempt (no retry).
2. Pushing it under three additional ref names (`-2`, `-3`, `-4`) at the same SHA — different `github.ref` ⇒ different concurrency group ⇒ all four `workflow_dispatch` runs execute in parallel.
3. Triggering `workflow_dispatch` on `fix/wasm-sdk-functional-prefetch-retry` and stacking attempts via `gh run rerun <id>` (each rerun is a new attempt on the same run, reusing artifacts and bypassing the workflow's `cancel-in-progress` rule).

Results of the `Packages functional tests / Run functional tests` step:

| Branch | Samples | Pass | Fail | Pass rate |
|---|---|---|---|---|
| `fix/...` (with retry) | 3 | 3 | 0 | **100%** |
| `test/...` baseline (no retry) | 5 | 4 | 1 | 80% |

The single baseline failure ([attempt #2 of run 25143898934](https://github.com/dashpay/platform/actions/runs/25143898934)) reproduced the **exact original error** — `Failed to fetch masternodes: Network error: No eligible masternode addresses discovered` — proving same code, same artifacts, identical error path. The 20% rate at our 02–04 UTC window is lower than the 100% scheduled-run (~23:20 UTC) rate, which is consistent with hourly variation in GitHub-hosted-runner load.

The four `test/wasm-sdk-flake-baseline-no-retry*` branches were deleted after the experiment.

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->

None.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [ ] I have made corresponding changes to the documentation if needed

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test infrastructure with a new retry helper for improved reliability when initializing test contexts, allowing configuration of timeout and retry intervals.
  * Refactored multiple functional test suites to use the new helper, ensuring more consistent test execution and better handling of timing-related issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->