### PR TITLE
feat(sdk): source mainnet/testnet bootstrap from dash-network-seeds (backport #3533)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1623,6 +1623,7 @@ dependencies = [
  "dapi-grpc",
  "dash-async",
  "dash-context-provider",
+ "dash-network-seeds",
  "dash-platform-macros",
  "derive_more 1.0.0",
  "dotenvy",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,6 +50,7 @@ members = [
 
 [workspace.dependencies]
 dashcore = { git = "https://github.com/dashpay/rust-dashcore", rev = "ea33cbc84179666c25515dfc817ce32210953037" }
+dash-network-seeds = { git = "https://github.com/dashpay/rust-dashcore", rev = "ea33cbc84179666c25515dfc817ce32210953037" }
 dash-spv = { git = "https://github.com/dashpay/rust-dashcore", rev = "ea33cbc84179666c25515dfc817ce32210953037" }
 dash-spv-ffi = { git = "https://github.com/dashpay/rust-dashcore", rev = "ea33cbc84179666c25515dfc817ce32210953037" }
 key-wallet = { git = "https://github.com/dashpay/rust-dashcore", rev = "ea33cbc84179666c25515dfc817ce32210953037" }

--- a/packages/rs-sdk-ffi/src/sdk.rs
+++ b/packages/rs-sdk-ffi/src/sdk.rs
@@ -380,84 +380,8 @@ pub unsafe extern "C" fn dash_sdk_create_trusted(config: *const DashSDKConfig) -
         info!("dash_sdk_create_trusted: no DAPI addresses provided, using defaults for network");
         // Use default addresses for the network
         match network {
-            Network::Testnet => {
-                // Fixed testnet DAPI addresses (hp-masternodes 1-29)
-                let default_addresses = [
-                    "https://68.67.122.1:1443",
-                    "https://68.67.122.2:1443",
-                    "https://68.67.122.3:1443",
-                    "https://68.67.122.4:1443",
-                    "https://68.67.122.5:1443",
-                    "https://68.67.122.6:1443",
-                    "https://68.67.122.7:1443",
-                    "https://68.67.122.8:1443",
-                    "https://68.67.122.9:1443",
-                    "https://68.67.122.10:1443",
-                    "https://68.67.122.11:1443",
-                    "https://68.67.122.12:1443",
-                    "https://68.67.122.13:1443",
-                    "https://68.67.122.14:1443",
-                    "https://68.67.122.15:1443",
-                    "https://68.67.122.16:1443",
-                    "https://68.67.122.17:1443",
-                    "https://68.67.122.18:1443",
-                    "https://68.67.122.19:1443",
-                    "https://68.67.122.20:1443",
-                    "https://68.67.122.21:1443",
-                    "https://68.67.122.22:1443",
-                    "https://68.67.122.23:1443",
-                    "https://68.67.122.24:1443",
-                    "https://68.67.122.25:1443",
-                    "https://68.67.122.26:1443",
-                    "https://68.67.122.27:1443",
-                    "https://68.67.122.28:1443",
-                    "https://68.67.122.29:1443",
-                ]
-                .join(",");
-
-                info!(
-                    addresses = default_addresses.as_str(),
-                    "dash_sdk_create_trusted: using default testnet addresses"
-                );
-                let address_list = match AddressList::from_str(&default_addresses) {
-                    Ok(list) => list,
-                    Err(e) => {
-                        error!(error = %e, "dash_sdk_create_trusted: failed to parse default addresses");
-                        return DashSDKResult::error(DashSDKError::new(
-                            DashSDKErrorCode::InternalError,
-                            format!("Failed to parse default addresses: {}", e),
-                        ));
-                    }
-                };
-                SdkBuilder::new(address_list).with_network(network)
-            }
-            Network::Mainnet => {
-                // Use mainnet addresses from WASM SDK
-                let default_addresses = [
-                    "https://149.28.241.190:443",
-                    "https://198.7.115.48:443",
-                    "https://134.255.182.186:443",
-                    "https://93.115.172.39:443",
-                    "https://5.189.164.253:443",
-                    "https://178.215.237.134:443",
-                    "https://157.66.81.162:443",
-                    "https://173.212.232.90:443",
-                ]
-                .join(",");
-
-                info!("dash_sdk_create_trusted: using default mainnet addresses");
-                let address_list = match AddressList::from_str(&default_addresses) {
-                    Ok(list) => list,
-                    Err(e) => {
-                        error!(error = %e, "dash_sdk_create_trusted: failed to parse default addresses");
-                        return DashSDKResult::error(DashSDKError::new(
-                            DashSDKErrorCode::InternalError,
-                            format!("Failed to parse default addresses: {}", e),
-                        ));
-                    }
-                };
-                SdkBuilder::new(address_list).with_network(network)
-            }
+            Network::Testnet => SdkBuilder::new_testnet(),
+            Network::Mainnet => SdkBuilder::new_mainnet(),
             _ => {
                 error!(
                     ?network,

--- a/packages/rs-sdk/Cargo.toml
+++ b/packages/rs-sdk/Cargo.toml
@@ -12,6 +12,7 @@ dpp = { path = "../rs-dpp", default-features = false, features = [
 ] }
 dapi-grpc = { path = "../dapi-grpc", default-features = false }
 rs-dapi-client = { path = "../rs-dapi-client", default-features = false }
+dash-network-seeds = { workspace = true }
 drive = { path = "../rs-drive", default-features = false, features = [
   "verify",
 ] }

--- a/packages/rs-sdk/src/sdk.rs
+++ b/packages/rs-sdk/src/sdk.rs
@@ -64,46 +64,39 @@ const DEFAULT_REQUEST_SETTINGS: RequestSettings = RequestSettings {
     max_decoding_message_size: None,
 };
 
-const DEFAULT_MAINNET_ADDRESSES: &[&str] = &[
-    "https://149.28.241.190:443",
-    "https://198.7.115.48:443",
-    "https://134.255.182.186:443",
-    "https://93.115.172.39:443",
-    "https://5.189.164.253:443",
-    "https://178.215.237.134:443",
-    "https://157.66.81.162:443",
-    "https://173.212.232.90:443",
-];
-
-const DEFAULT_TESTNET_ADDRESSES: &[&str] = &[
-    "https://52.12.176.90:1443",
-    "https://35.82.197.197:1443",
-    "https://44.240.98.102:1443",
-    "https://52.34.144.50:1443",
-    "https://44.239.39.153:1443",
-    "https://34.214.48.68:1443",
-    "https://35.164.23.245:1443",
-    "https://54.149.33.167:1443",
-    "https://52.24.124.162:1443",
-];
-
-fn parse_address_list(addresses: &[&str]) -> AddressList {
-    AddressList::from_iter(addresses.iter().map(|address| {
-        let uri = address
-            .parse::<Uri>()
-            .unwrap_or_else(|_| panic!("default SDK address must be a valid URI: {address}"));
-        Address::try_from(uri).unwrap_or_else(|_| {
-            panic!("default SDK address must be a valid DAPI address: {address}")
-        })
-    }))
-}
-
+/// Build the default DAPI bootstrap address list for `network` from
+/// [`dash_network_seeds`].
+///
+/// The seed lists are single-source-of-truth, weekly-refreshed upstream in
+/// `rust-dashcore`. We filter to Evo (HPMN) masternodes — the only ones that
+/// run Dash Platform — and build `https://<ip>:<platform_http_port>` URIs.
+/// The Core port on `seed.address` is intentionally discarded: DAPI clients
+/// need the platform HTTP port, not the Core P2P port.
+///
+/// Malformed upstream entries are silently skipped rather than panicking;
+/// the DAPI client handles retry/rotation across the remaining addresses.
+///
+/// ## Panics
+///
+/// Panics on networks other than `Mainnet` and `Testnet` — no upstream
+/// seed list exists for devnet/regtest.
 fn default_address_list_for_network(network: Network) -> AddressList {
-    match network {
-        Network::Mainnet => parse_address_list(DEFAULT_MAINNET_ADDRESSES),
-        Network::Testnet => parse_address_list(DEFAULT_TESTNET_ADDRESSES),
-        _ => panic!("default address list is only available for mainnet and testnet"),
+    if !matches!(network, Network::Mainnet | Network::Testnet) {
+        panic!("default address list is only available for mainnet and testnet");
     }
+    let mut list = AddressList::new();
+    for seed in dash_network_seeds::evo_seeds(network) {
+        let Some(port) = seed.platform_http_port else {
+            continue;
+        };
+        let url = format!("https://{}:{}", seed.address.ip(), port);
+        if let Ok(uri) = url.parse::<Uri>() {
+            if let Ok(address) = Address::try_from(uri) {
+                list.add(address);
+            }
+        }
+    }
+    list
 }
 
 /// Dash Platform SDK
@@ -1137,7 +1130,6 @@ pub fn prettify_proof(proof: &Proof) -> String {
 
 #[cfg(test)]
 mod test {
-    use std::collections::BTreeSet;
     use std::sync::Arc;
 
     use dapi_grpc::platform::v0::{GetIdentityRequest, ResponseMetadata};
@@ -1146,26 +1138,15 @@ mod test {
 
     use crate::SdkBuilder;
 
-    use super::{AddressList, Network, DEFAULT_MAINNET_ADDRESSES, DEFAULT_TESTNET_ADDRESSES};
+    use super::Network;
 
-    fn live_address_set(address_list: &AddressList) -> BTreeSet<String> {
-        address_list
-            .get_live_addresses()
-            .into_iter()
-            .map(|address| address.to_string())
-            .collect()
-    }
-
-    fn expected_address_set(addresses: &[&str]) -> BTreeSet<String> {
-        super::parse_address_list(addresses)
-            .get_live_addresses()
-            .into_iter()
-            .map(|address| address.to_string())
-            .collect()
-    }
+    /// Mainnet Evo masternodes expose the Platform HTTP endpoint on 443.
+    const MAINNET_PLATFORM_HTTP_PORT: u16 = 443;
+    /// Testnet Evo masternodes expose the Platform HTTP endpoint on 1443.
+    const TESTNET_PLATFORM_HTTP_PORT: u16 = 1443;
 
     #[test]
-    fn new_testnet_uses_default_testnet_addresses() {
+    fn new_testnet_sources_bootstrap_from_seeds() {
         let builder = SdkBuilder::new_testnet();
         let address_list = builder
             .addresses
@@ -1173,15 +1154,21 @@ mod test {
             .expect("testnet builder should configure default addresses");
 
         assert_eq!(builder.network, Network::Testnet);
-        assert_eq!(address_list.len(), DEFAULT_TESTNET_ADDRESSES.len());
-        assert_eq!(
-            live_address_set(address_list),
-            expected_address_set(DEFAULT_TESTNET_ADDRESSES)
+        assert!(
+            !address_list.is_empty(),
+            "testnet must have at least one bootstrap address"
         );
+        for address in address_list.get_live_addresses() {
+            assert_eq!(
+                address.uri().port_u16(),
+                Some(TESTNET_PLATFORM_HTTP_PORT),
+                "testnet bootstrap address must use the platform HTTP port",
+            );
+        }
     }
 
     #[test]
-    fn new_mainnet_uses_default_mainnet_addresses() {
+    fn new_mainnet_sources_bootstrap_from_seeds() {
         let builder = SdkBuilder::new_mainnet();
         let address_list = builder
             .addresses
@@ -1189,10 +1176,39 @@ mod test {
             .expect("mainnet builder should configure default addresses");
 
         assert_eq!(builder.network, Network::Mainnet);
-        assert_eq!(address_list.len(), DEFAULT_MAINNET_ADDRESSES.len());
-        assert_eq!(
-            live_address_set(address_list),
-            expected_address_set(DEFAULT_MAINNET_ADDRESSES)
+        assert!(
+            !address_list.is_empty(),
+            "mainnet must have at least one bootstrap address"
+        );
+        for address in address_list.get_live_addresses() {
+            assert_eq!(
+                address.uri().port_u16(),
+                Some(MAINNET_PLATFORM_HTTP_PORT),
+                "mainnet bootstrap address must use the platform HTTP port",
+            );
+        }
+    }
+
+    /// Smoke signal: the upstream seed lists are far larger than 10 entries on
+    /// both networks. If parsing drops most of them we want a loud test
+    /// failure rather than silently shipping a near-empty bootstrap list.
+    #[test]
+    fn bootstrap_counts_reasonable() {
+        let mainnet = SdkBuilder::new_mainnet()
+            .addresses
+            .expect("mainnet builder should configure default addresses");
+        let testnet = SdkBuilder::new_testnet()
+            .addresses
+            .expect("testnet builder should configure default addresses");
+        assert!(
+            mainnet.len() >= 10,
+            "expected >=10 mainnet bootstrap addresses, got {}",
+            mainnet.len()
+        );
+        assert!(
+            testnet.len() >= 10,
+            "expected >=10 testnet bootstrap addresses, got {}",
+            testnet.len()
         );
     }
 

--- a/packages/rs-sdk/src/sdk.rs
+++ b/packages/rs-sdk/src/sdk.rs
@@ -25,6 +25,7 @@ use drive_proof_verifier::FromProof;
 pub use http::Uri;
 #[cfg(feature = "mocks")]
 use rs_dapi_client::mock::MockDapiClient;
+use rs_dapi_client::Address;
 pub use rs_dapi_client::AddressList;
 pub use rs_dapi_client::RequestSettings;
 use rs_dapi_client::{
@@ -62,6 +63,46 @@ const DEFAULT_REQUEST_SETTINGS: RequestSettings = RequestSettings {
     connect_timeout: None,
     max_decoding_message_size: None,
 };
+
+const DEFAULT_MAINNET_ADDRESSES: &[&str] = &[
+    "https://149.28.241.190:443",
+    "https://198.7.115.48:443",
+    "https://134.255.182.186:443",
+    "https://93.115.172.39:443",
+    "https://5.189.164.253:443",
+    "https://178.215.237.134:443",
+    "https://157.66.81.162:443",
+    "https://173.212.232.90:443",
+];
+
+const DEFAULT_TESTNET_ADDRESSES: &[&str] = &[
+    "https://52.12.176.90:1443",
+    "https://35.82.197.197:1443",
+    "https://44.240.98.102:1443",
+    "https://52.34.144.50:1443",
+    "https://44.239.39.153:1443",
+    "https://34.214.48.68:1443",
+    "https://35.164.23.245:1443",
+    "https://54.149.33.167:1443",
+    "https://52.24.124.162:1443",
+];
+
+fn parse_address_list(addresses: &[&str]) -> AddressList {
+    AddressList::from_iter(addresses.iter().map(|address| {
+        let uri = address
+            .parse::<Uri>()
+            .expect("default SDK address must be a valid URI");
+        Address::try_from(uri).expect("default SDK address must be a valid DAPI address")
+    }))
+}
+
+fn default_address_list_for_network(network: Network) -> Option<AddressList> {
+    match network {
+        Network::Mainnet => Some(parse_address_list(DEFAULT_MAINNET_ADDRESSES)),
+        Network::Testnet => Some(parse_address_list(DEFAULT_TESTNET_ADDRESSES)),
+        _ => None,
+    }
+}
 
 /// Dash Platform SDK
 ///
@@ -747,18 +788,19 @@ impl SdkBuilder {
         Self::default()
     }
 
-    /// Create a new SdkBuilder instance preconfigured for testnet. NOT IMPLEMENTED YET.
+    /// Create a new SdkBuilder instance preconfigured for testnet.
     ///
     /// This is a helper method that preconfigures [SdkBuilder] for testnet use.
     /// Use this method if you want to connect to Dash Platform testnet during development and testing
     /// of your solution.
     pub fn new_testnet() -> Self {
-        unimplemented!(
-            "Testnet address list not implemented yet. Use new() and provide address list."
-        )
+        let address_list = default_address_list_for_network(Network::Testnet)
+            .expect("testnet default address list must be available");
+
+        Self::new(address_list).with_network(Network::Testnet)
     }
 
-    /// Create a new SdkBuilder instance preconfigured for mainnet (production network). NOT IMPLEMENTED YET.
+    /// Create a new SdkBuilder instance preconfigured for mainnet (production network).
     ///
     /// This is a helper method that preconfigures [SdkBuilder] for production use.
     /// Use this method if you want to connect to Dash Platform mainnet with production-ready product.
@@ -771,9 +813,10 @@ impl SdkBuilder {
     ///
     /// This method is unstable and can be changed in the future.
     pub fn new_mainnet() -> Self {
-        unimplemented!(
-            "Mainnet address list not implemented yet. Use new() and provide address list."
-        )
+        let address_list = default_address_list_for_network(Network::Mainnet)
+            .expect("mainnet default address list must be available");
+
+        Self::new(address_list).with_network(Network::Mainnet)
     }
 
     /// Configure network type.
@@ -1094,6 +1137,7 @@ pub fn prettify_proof(proof: &Proof) -> String {
 
 #[cfg(test)]
 mod test {
+    use std::collections::BTreeSet;
     use std::sync::Arc;
 
     use dapi_grpc::platform::v0::{GetIdentityRequest, ResponseMetadata};
@@ -1101,6 +1145,56 @@ mod test {
     use test_case::test_matrix;
 
     use crate::SdkBuilder;
+
+    use super::{AddressList, Network, DEFAULT_MAINNET_ADDRESSES, DEFAULT_TESTNET_ADDRESSES};
+
+    fn live_address_set(address_list: &AddressList) -> BTreeSet<String> {
+        address_list
+            .get_live_addresses()
+            .into_iter()
+            .map(|address| address.to_string())
+            .collect()
+    }
+
+    fn expected_address_set(addresses: &[&str]) -> BTreeSet<String> {
+        super::parse_address_list(addresses)
+            .get_live_addresses()
+            .into_iter()
+            .map(|address| address.to_string())
+            .collect()
+    }
+
+    #[test]
+    fn new_testnet_uses_default_testnet_addresses() {
+        let builder = SdkBuilder::new_testnet();
+        let address_list = builder
+            .addresses
+            .as_ref()
+            .expect("testnet builder should configure default addresses");
+
+        assert_eq!(builder.network, Network::Testnet);
+        assert_eq!(address_list.len(), DEFAULT_TESTNET_ADDRESSES.len());
+        assert_eq!(
+            live_address_set(address_list),
+            expected_address_set(DEFAULT_TESTNET_ADDRESSES)
+        );
+    }
+
+    #[test]
+    fn new_mainnet_uses_default_mainnet_addresses() {
+        let builder = SdkBuilder::new_mainnet();
+        let address_list = builder
+            .addresses
+            .as_ref()
+            .expect("mainnet builder should configure default addresses");
+
+        assert_eq!(builder.network, Network::Mainnet);
+        assert_eq!(address_list.len(), DEFAULT_MAINNET_ADDRESSES.len());
+        assert_eq!(
+            live_address_set(address_list),
+            expected_address_set(DEFAULT_MAINNET_ADDRESSES)
+        );
+    }
 
     #[test_matrix(97..102, 100, 2, false; "valid height")]
     #[test_case(103, 100, 2, true; "invalid height")]

--- a/packages/rs-sdk/src/sdk.rs
+++ b/packages/rs-sdk/src/sdk.rs
@@ -91,16 +91,18 @@ fn parse_address_list(addresses: &[&str]) -> AddressList {
     AddressList::from_iter(addresses.iter().map(|address| {
         let uri = address
             .parse::<Uri>()
-            .expect("default SDK address must be a valid URI");
-        Address::try_from(uri).expect("default SDK address must be a valid DAPI address")
+            .unwrap_or_else(|_| panic!("default SDK address must be a valid URI: {address}"));
+        Address::try_from(uri).unwrap_or_else(|_| {
+            panic!("default SDK address must be a valid DAPI address: {address}")
+        })
     }))
 }
 
-fn default_address_list_for_network(network: Network) -> Option<AddressList> {
+fn default_address_list_for_network(network: Network) -> AddressList {
     match network {
-        Network::Mainnet => Some(parse_address_list(DEFAULT_MAINNET_ADDRESSES)),
-        Network::Testnet => Some(parse_address_list(DEFAULT_TESTNET_ADDRESSES)),
-        _ => None,
+        Network::Mainnet => parse_address_list(DEFAULT_MAINNET_ADDRESSES),
+        Network::Testnet => parse_address_list(DEFAULT_TESTNET_ADDRESSES),
+        _ => panic!("default address list is only available for mainnet and testnet"),
     }
 }
 
@@ -794,8 +796,7 @@ impl SdkBuilder {
     /// Use this method if you want to connect to Dash Platform testnet during development and testing
     /// of your solution.
     pub fn new_testnet() -> Self {
-        let address_list = default_address_list_for_network(Network::Testnet)
-            .expect("testnet default address list must be available");
+        let address_list = default_address_list_for_network(Network::Testnet);
 
         Self::new(address_list).with_network(Network::Testnet)
     }
@@ -813,8 +814,7 @@ impl SdkBuilder {
     ///
     /// This method is unstable and can be changed in the future.
     pub fn new_mainnet() -> Self {
-        let address_list = default_address_list_for_network(Network::Mainnet)
-            .expect("mainnet default address list must be available");
+        let address_list = default_address_list_for_network(Network::Mainnet);
 
         Self::new(address_list).with_network(Network::Mainnet)
     }

--- a/packages/wasm-sdk/src/sdk.rs
+++ b/packages/wasm-sdk/src/sdk.rs
@@ -18,29 +18,7 @@ fn parse_addresses(addresses: &'static [&str]) -> Vec<Address> {
         })
         .collect()
 }
-// Mainnet addresses from mnowatch.org
-fn default_mainnet_addresses() -> Vec<Address> {
-    parse_addresses(&[
-        "https://149.28.241.190:443",
-        "https://198.7.115.48:443",
-        "https://134.255.182.186:443",
-        "https://93.115.172.39:443",
-        "https://5.189.164.253:443",
-    ])
-}
-// Testnet addresses from https://quorums.testnet.networks.dash.org/masternodes
-fn default_testnet_addresses() -> Vec<Address> {
-    parse_addresses(&[
-        "https://52.12.176.90:1443",
-        "https://35.82.197.197:1443",
-        "https://44.240.98.102:1443",
-        "https://52.34.144.50:1443",
-        "https://44.239.39.153:1443",
-        "https://34.214.48.68:1443",
-        "https://54.149.33.167:1443",
-        "https://52.24.124.162:1443",
-    ])
-}
+
 fn default_local_addresses() -> Vec<Address> {
     parse_addresses(&["https://127.0.0.1:2443"])
 }
@@ -249,10 +227,7 @@ impl WasmSdkBuilder {
 
     #[wasm_bindgen(js_name = "mainnet")]
     pub fn new_mainnet() -> Self {
-        let address_list = dash_sdk::sdk::AddressList::from_iter(default_mainnet_addresses());
-        let sdk_builder = SdkBuilder::new(address_list)
-            .with_network(dash_sdk::dpp::dashcore::Network::Mainnet)
-            .with_context_provider(WasmContext {});
+        let sdk_builder = SdkBuilder::new_mainnet().with_context_provider(WasmContext {});
 
         Self {
             inner: sdk_builder,
@@ -262,10 +237,7 @@ impl WasmSdkBuilder {
 
     #[wasm_bindgen(js_name = "testnet")]
     pub fn new_testnet() -> Self {
-        let address_list = dash_sdk::sdk::AddressList::from_iter(default_testnet_addresses());
-        let sdk_builder = SdkBuilder::new(address_list)
-            .with_network(dash_sdk::dpp::dashcore::Network::Testnet)
-            .with_context_provider(WasmContext {});
+        let sdk_builder = SdkBuilder::new_testnet().with_context_provider(WasmContext {});
 
         Self {
             inner: sdk_builder,


### PR DESCRIPTION
## Issue being fixed or feature implemented

Backports PR #3533 (`feat(sdk): source mainnet/testnet bootstrap from dash-network-seeds`) onto `v3.1-dev`. PR #3533 was merged into `feat/bump-rust-dashcore-v0.42-dev` on 2026-04-25 and hasn't been promoted to `v3.1-dev` yet — meanwhile `SdkBuilder::new_testnet()` / `new_mainnet()` are still `unimplemented!()` stubs on this base, blocking downstream callers (e.g. PR #3549's e2e harness) from using the upstream helpers.

## What was done?

Cherry-picked PR #3533's three commits onto `v3.1-dev`:

- **`fix(sdk): centralize mainnet and testnet builders`** — collapses the per-frontend hardcoded address lists in `rs-sdk-ffi/src/sdk.rs` and `wasm-sdk/src/sdk.rs` into delegations to `SdkBuilder::new_testnet()` / `new_mainnet()`. `wasm-sdk::new_local` left intact.
- **`fix(sdk): harden default network address parsing`** — unchanged from PR #3533.
- **`feat(sdk): source mainnet/testnet bootstrap from dash-network-seeds`** — replaces the hardcoded `DEFAULT_*_ADDRESSES` in `rs-sdk` with `dash_network_seeds::evo_seeds(network)` filtered by `platform_http_port`. Adds `dash-network-seeds` to workspace `Cargo.toml` and `rs-sdk/Cargo.toml`.

### Backport-specific resolutions

- Workspace `Cargo.toml` conflict: PR #3533's branch had pinned every rust-dashcore-sourced dep to `0093278609a22fc53086bfef569b74bf10544982`. Kept `v3.1-dev`'s existing rev `ea33cbc84179666c25515dfc817ce32210953037` for every pre-existing dep; added only the new `dash-network-seeds` line at that same rev. Verified `dash-network-seeds::evo_seeds` is callable at this rev — the function is the same as on PR #3533's branch.
- `rs-sdk-ffi/src/sdk.rs` had diverged on `v3.1-dev` (extra hardcoded testnet block lines 383-465); kept the divergence's surrounding code and applied PR #3533's intent — the `Network::Testnet => SdkBuilder::new_testnet()` delegation — over the conflicted block.
- `dash-network` workspace dep (added by PR #3533 alongside `dash-network-seeds`) was **not** added because `v3.1-dev` doesn't carry it as an explicit workspace dep and no caller breaks without it. Can be added in a follow-up if needed.
- `Cargo.lock` regenerated by `cargo check`.

## How Has This Been Tested?

| Step | Result |
|---|---|
| `cargo check -p dash-sdk --tests` | PASS |
| `cargo check -p platform-wallet --tests` | PASS |
| `cargo check -p rs-sdk-ffi --tests` | PASS |
| `cargo check -p wasm-sdk --tests` | PASS |
| `cargo clippy -p dash-sdk --tests --all-features -- -D warnings` | PASS |
| `cargo fmt --check -p dash-sdk` | PASS |
| `cargo test -p dash-sdk --lib` | PASS — 117 passed, 6 ignored, 0 failed; new tests `new_testnet_sources_bootstrap_from_seeds`, `new_mainnet_sources_bootstrap_from_seeds`, and `bootstrap_counts_reasonable` all green |

## Breaking Changes

None for `v3.1-dev` consumers. The `SdkBuilder::new_testnet()` / `new_mainnet()` surface goes from `unimplemented!()` to a working implementation.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation if needed

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone

<sub>🤖 Co-authored by [Claudius the Magnificent](https://github.com/lklimek/claudius) AI Agent</sub>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * SDK testnet and mainnet initialization now automatically configures with proper default bootstrap addresses, enabling reliable out-of-the-box network connectivity.

* **Refactor**
  * Simplified default network endpoint configuration by consolidating setup logic and removing hardcoded address values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->