### PR TITLE
chore(deps): bump rust-dashcore to ca507a9 (v0.42-dev)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1568,7 +1568,7 @@ dependencies = [
 [[package]]
 name = "dash-network"
 version = "0.42.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=8fe9ea394306e5f9282505b24d09092ab9a33738#8fe9ea394306e5f9282505b24d09092ab9a33738"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=ca507a92967ab4ab60dd681de1f736f8cc1d129f#ca507a92967ab4ab60dd681de1f736f8cc1d129f"
 dependencies = [
  "bincode",
  "bincode_derive",
@@ -1579,7 +1579,7 @@ dependencies = [
 [[package]]
 name = "dash-network-seeds"
 version = "0.42.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=8fe9ea394306e5f9282505b24d09092ab9a33738#8fe9ea394306e5f9282505b24d09092ab9a33738"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=ca507a92967ab4ab60dd681de1f736f8cc1d129f#ca507a92967ab4ab60dd681de1f736f8cc1d129f"
 dependencies = [
  "dash-network",
 ]
@@ -1656,7 +1656,7 @@ dependencies = [
 [[package]]
 name = "dash-spv"
 version = "0.42.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=8fe9ea394306e5f9282505b24d09092ab9a33738#8fe9ea394306e5f9282505b24d09092ab9a33738"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=ca507a92967ab4ab60dd681de1f736f8cc1d129f#ca507a92967ab4ab60dd681de1f736f8cc1d129f"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1684,7 +1684,7 @@ dependencies = [
 [[package]]
 name = "dash-spv-ffi"
 version = "0.42.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=8fe9ea394306e5f9282505b24d09092ab9a33738#8fe9ea394306e5f9282505b24d09092ab9a33738"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=ca507a92967ab4ab60dd681de1f736f8cc1d129f#ca507a92967ab4ab60dd681de1f736f8cc1d129f"
 dependencies = [
  "cbindgen 0.29.2",
  "clap",
@@ -1703,7 +1703,7 @@ dependencies = [
 [[package]]
 name = "dashcore"
 version = "0.42.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=8fe9ea394306e5f9282505b24d09092ab9a33738#8fe9ea394306e5f9282505b24d09092ab9a33738"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=ca507a92967ab4ab60dd681de1f736f8cc1d129f#ca507a92967ab4ab60dd681de1f736f8cc1d129f"
 dependencies = [
  "anyhow",
  "base64-compat",
@@ -1729,12 +1729,12 @@ dependencies = [
 [[package]]
 name = "dashcore-private"
 version = "0.42.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=8fe9ea394306e5f9282505b24d09092ab9a33738#8fe9ea394306e5f9282505b24d09092ab9a33738"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=ca507a92967ab4ab60dd681de1f736f8cc1d129f#ca507a92967ab4ab60dd681de1f736f8cc1d129f"
 
 [[package]]
 name = "dashcore-rpc"
 version = "0.42.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=8fe9ea394306e5f9282505b24d09092ab9a33738#8fe9ea394306e5f9282505b24d09092ab9a33738"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=ca507a92967ab4ab60dd681de1f736f8cc1d129f#ca507a92967ab4ab60dd681de1f736f8cc1d129f"
 dependencies = [
  "dashcore-rpc-json",
  "hex",
@@ -1747,7 +1747,7 @@ dependencies = [
 [[package]]
 name = "dashcore-rpc-json"
 version = "0.42.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=8fe9ea394306e5f9282505b24d09092ab9a33738#8fe9ea394306e5f9282505b24d09092ab9a33738"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=ca507a92967ab4ab60dd681de1f736f8cc1d129f#ca507a92967ab4ab60dd681de1f736f8cc1d129f"
 dependencies = [
  "bincode",
  "dashcore",
@@ -1762,7 +1762,7 @@ dependencies = [
 [[package]]
 name = "dashcore_hashes"
 version = "0.42.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=8fe9ea394306e5f9282505b24d09092ab9a33738#8fe9ea394306e5f9282505b24d09092ab9a33738"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=ca507a92967ab4ab60dd681de1f736f8cc1d129f#ca507a92967ab4ab60dd681de1f736f8cc1d129f"
 dependencies = [
  "bincode",
  "dashcore-private",
@@ -3811,7 +3811,7 @@ dependencies = [
 [[package]]
 name = "key-wallet"
 version = "0.42.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=8fe9ea394306e5f9282505b24d09092ab9a33738#8fe9ea394306e5f9282505b24d09092ab9a33738"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=ca507a92967ab4ab60dd681de1f736f8cc1d129f#ca507a92967ab4ab60dd681de1f736f8cc1d129f"
 dependencies = [
  "aes",
  "async-trait",
@@ -3839,7 +3839,7 @@ dependencies = [
 [[package]]
 name = "key-wallet-ffi"
 version = "0.42.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=8fe9ea394306e5f9282505b24d09092ab9a33738#8fe9ea394306e5f9282505b24d09092ab9a33738"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=ca507a92967ab4ab60dd681de1f736f8cc1d129f#ca507a92967ab4ab60dd681de1f736f8cc1d129f"
 dependencies = [
  "cbindgen 0.29.2",
  "dash-network",
@@ -3855,7 +3855,7 @@ dependencies = [
 [[package]]
 name = "key-wallet-manager"
 version = "0.42.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=8fe9ea394306e5f9282505b24d09092ab9a33738#8fe9ea394306e5f9282505b24d09092ab9a33738"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=ca507a92967ab4ab60dd681de1f736f8cc1d129f#ca507a92967ab4ab60dd681de1f736f8cc1d129f"
 dependencies = [
  "async-trait",
  "bincode",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,15 +49,15 @@ members = [
 ]
 
 [workspace.dependencies]
-dashcore = { git = "https://github.com/dashpay/rust-dashcore", rev = "8fe9ea394306e5f9282505b24d09092ab9a33738" }
-dash-network-seeds = { git = "https://github.com/dashpay/rust-dashcore", rev = "8fe9ea394306e5f9282505b24d09092ab9a33738" }
-dash-spv = { git = "https://github.com/dashpay/rust-dashcore", rev = "8fe9ea394306e5f9282505b24d09092ab9a33738" }
-dash-spv-ffi = { git = "https://github.com/dashpay/rust-dashcore", rev = "8fe9ea394306e5f9282505b24d09092ab9a33738" }
-key-wallet = { git = "https://github.com/dashpay/rust-dashcore", rev = "8fe9ea394306e5f9282505b24d09092ab9a33738" }
-key-wallet-ffi = { git = "https://github.com/dashpay/rust-dashcore", rev = "8fe9ea394306e5f9282505b24d09092ab9a33738" }
-key-wallet-manager = { git = "https://github.com/dashpay/rust-dashcore", rev = "8fe9ea394306e5f9282505b24d09092ab9a33738" }
-dash-network = { git = "https://github.com/dashpay/rust-dashcore", rev = "8fe9ea394306e5f9282505b24d09092ab9a33738" }
-dashcore-rpc = { git = "https://github.com/dashpay/rust-dashcore", rev = "8fe9ea394306e5f9282505b24d09092ab9a33738" }
+dashcore = { git = "https://github.com/dashpay/rust-dashcore", rev = "ca507a92967ab4ab60dd681de1f736f8cc1d129f" }
+dash-network-seeds = { git = "https://github.com/dashpay/rust-dashcore", rev = "ca507a92967ab4ab60dd681de1f736f8cc1d129f" }
+dash-spv = { git = "https://github.com/dashpay/rust-dashcore", rev = "ca507a92967ab4ab60dd681de1f736f8cc1d129f" }
+dash-spv-ffi = { git = "https://github.com/dashpay/rust-dashcore", rev = "ca507a92967ab4ab60dd681de1f736f8cc1d129f" }
+key-wallet = { git = "https://github.com/dashpay/rust-dashcore", rev = "ca507a92967ab4ab60dd681de1f736f8cc1d129f" }
+key-wallet-ffi = { git = "https://github.com/dashpay/rust-dashcore", rev = "ca507a92967ab4ab60dd681de1f736f8cc1d129f" }
+key-wallet-manager = { git = "https://github.com/dashpay/rust-dashcore", rev = "ca507a92967ab4ab60dd681de1f736f8cc1d129f" }
+dash-network = { git = "https://github.com/dashpay/rust-dashcore", rev = "ca507a92967ab4ab60dd681de1f736f8cc1d129f" }
+dashcore-rpc = { git = "https://github.com/dashpay/rust-dashcore", rev = "ca507a92967ab4ab60dd681de1f736f8cc1d129f" }
 
 # Optimize heavy crypto crates even in dev/test builds so that
 # Halo 2 proof generation and verification run at near-release speed.

--- a/packages/rs-platform-wallet/src/changeset/core_bridge.rs
+++ b/packages/rs-platform-wallet/src/changeset/core_bridge.rs
@@ -214,6 +214,9 @@ fn derive_new_utxos(record: &TransactionRecord) -> Vec<Utxo> {
     );
     let is_instant = matches!(record.context, TransactionContext::InstantSend(_));
     let is_coinbase = record.transaction.is_coin_base();
+    // We own at least one input iff the wallet recorded any input details
+    // (those entries are keyed to inputs that spent our outpoints).
+    let owns_any_input = !record.input_details.is_empty();
 
     record
         .output_details
@@ -228,6 +231,9 @@ fn derive_new_utxos(record: &TransactionRecord) -> Vec<Utxo> {
                 .get(detail.index as usize)?
                 .clone();
             let address = detail.address.clone()?;
+            // Mirror key-wallet's "trusted change" rule: change output of a
+            // transaction we authored (so it's our funds returning).
+            let is_trusted = matches!(detail.role, OutputRole::Change) && owns_any_input;
             Some(Utxo {
                 outpoint: OutPoint {
                     txid: record.txid,
@@ -240,6 +246,7 @@ fn derive_new_utxos(record: &TransactionRecord) -> Vec<Utxo> {
                 is_confirmed,
                 is_instantlocked: is_instant,
                 is_locked: false,
+                is_trusted,
             })
         })
         .collect()
@@ -275,6 +282,7 @@ fn derive_spent_utxos(record: &TransactionRecord) -> Vec<Utxo> {
                 is_confirmed: false,
                 is_instantlocked: false,
                 is_locked: false,
+                is_trusted: false,
             })
         })
         .collect()


### PR DESCRIPTION
## Issue being fixed or feature implemented

Pulls in the latest commits on the upstream `v0.42-dev` branch of [rust-dashcore](https://github.com/dashpay/rust-dashcore):

- [#706](https://github.com/dashpay/rust-dashcore/pull/706) — `feat(key-wallet-manager)`: carry per-account balance diff on `WalletEvent`
- [#707](https://github.com/dashpay/rust-dashcore/pull/707) — `fix(key-wallet)`: track self-send change in confirmed balance via new `Utxo::is_trusted` flag

Bumps the workspace pin from `8fe9ea3` to `ca507a9` for all 9 rust-dashcore crates.

## What was done?

- `Cargo.toml`: bumped the shared `rev` for `dashcore`, `dash-network-seeds`, `dash-spv`, `dash-spv-ffi`, `key-wallet`, `key-wallet-ffi`, `key-wallet-manager`, `dash-network`, `dashcore-rpc`.
- `Cargo.lock`: regenerated.
- `packages/rs-platform-wallet/src/changeset/core_bridge.rs`: added the new `is_trusted` field to the two `Utxo` struct literals (this is the only place in the platform repo that builds `Utxo` by-field).
  - `derive_new_utxos` — sets `is_trusted = true` on `OutputRole::Change` outputs when the wallet also owns at least one input on the same transaction (`!record.input_details.is_empty()`). That matches key-wallet's "this is the change of a tx we authored, so it's our funds returning" rule.
  - `derive_spent_utxos` — sets `is_trusted = false`. Per the existing comment, the synthetic UTXOs in the spent set are deleted by outpoint and the other flag fields are informational only.

## How Has This Been Tested?

- `cargo check --workspace` — clean
- `cargo check --workspace --tests` — clean
- `cargo clippy -p platform-wallet --tests` — no warnings
- `cargo test -p platform-wallet --lib` — 115/115 passing
- `cargo fmt --all` — no diffs

## Breaking Changes

None for this repo's public API. The upstream `Utxo` struct gained a new field, which is an additive change to the persisted/serialized form (deserializes to `false` by default).

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [ ] I have made corresponding changes to the documentation if needed

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Refined wallet UTXO handling: change outputs are now marked as trusted only when the wallet has authored at least one transaction input. Spent UTXOs are consistently marked as untrusted.

* **Chores**
  * Updated internal dependencies including dashcore, dash-network, dashcore-rpc, and related Dash packages to latest versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->