### PR TITLE
fix(swift-sdk): reconcile spending tx <-> spent TXO + tx-detail UX + dashcore bump

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1568,7 +1568,7 @@ dependencies = [
 [[package]]
 name = "dash-network"
 version = "0.42.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=e2e8fcf852130383b5922d3c2d907dda334296ee#e2e8fcf852130383b5922d3c2d907dda334296ee"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=c6cbe78e8194020dcab30d8886e5425a24cc8ef2#c6cbe78e8194020dcab30d8886e5425a24cc8ef2"
 dependencies = [
  "bincode",
  "bincode_derive",
@@ -1579,7 +1579,7 @@ dependencies = [
 [[package]]
 name = "dash-network-seeds"
 version = "0.42.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=e2e8fcf852130383b5922d3c2d907dda334296ee#e2e8fcf852130383b5922d3c2d907dda334296ee"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=c6cbe78e8194020dcab30d8886e5425a24cc8ef2#c6cbe78e8194020dcab30d8886e5425a24cc8ef2"
 dependencies = [
  "dash-network",
 ]
@@ -1656,7 +1656,7 @@ dependencies = [
 [[package]]
 name = "dash-spv"
 version = "0.42.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=e2e8fcf852130383b5922d3c2d907dda334296ee#e2e8fcf852130383b5922d3c2d907dda334296ee"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=c6cbe78e8194020dcab30d8886e5425a24cc8ef2#c6cbe78e8194020dcab30d8886e5425a24cc8ef2"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1684,7 +1684,7 @@ dependencies = [
 [[package]]
 name = "dash-spv-ffi"
 version = "0.42.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=e2e8fcf852130383b5922d3c2d907dda334296ee#e2e8fcf852130383b5922d3c2d907dda334296ee"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=c6cbe78e8194020dcab30d8886e5425a24cc8ef2#c6cbe78e8194020dcab30d8886e5425a24cc8ef2"
 dependencies = [
  "cbindgen 0.29.2",
  "clap",
@@ -1703,7 +1703,7 @@ dependencies = [
 [[package]]
 name = "dashcore"
 version = "0.42.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=e2e8fcf852130383b5922d3c2d907dda334296ee#e2e8fcf852130383b5922d3c2d907dda334296ee"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=c6cbe78e8194020dcab30d8886e5425a24cc8ef2#c6cbe78e8194020dcab30d8886e5425a24cc8ef2"
 dependencies = [
  "anyhow",
  "base64-compat",
@@ -1729,12 +1729,12 @@ dependencies = [
 [[package]]
 name = "dashcore-private"
 version = "0.42.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=e2e8fcf852130383b5922d3c2d907dda334296ee#e2e8fcf852130383b5922d3c2d907dda334296ee"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=c6cbe78e8194020dcab30d8886e5425a24cc8ef2#c6cbe78e8194020dcab30d8886e5425a24cc8ef2"
 
 [[package]]
 name = "dashcore-rpc"
 version = "0.42.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=e2e8fcf852130383b5922d3c2d907dda334296ee#e2e8fcf852130383b5922d3c2d907dda334296ee"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=c6cbe78e8194020dcab30d8886e5425a24cc8ef2#c6cbe78e8194020dcab30d8886e5425a24cc8ef2"
 dependencies = [
  "dashcore-rpc-json",
  "hex",
@@ -1747,7 +1747,7 @@ dependencies = [
 [[package]]
 name = "dashcore-rpc-json"
 version = "0.42.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=e2e8fcf852130383b5922d3c2d907dda334296ee#e2e8fcf852130383b5922d3c2d907dda334296ee"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=c6cbe78e8194020dcab30d8886e5425a24cc8ef2#c6cbe78e8194020dcab30d8886e5425a24cc8ef2"
 dependencies = [
  "bincode",
  "dashcore",
@@ -1762,7 +1762,7 @@ dependencies = [
 [[package]]
 name = "dashcore_hashes"
 version = "0.42.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=e2e8fcf852130383b5922d3c2d907dda334296ee#e2e8fcf852130383b5922d3c2d907dda334296ee"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=c6cbe78e8194020dcab30d8886e5425a24cc8ef2#c6cbe78e8194020dcab30d8886e5425a24cc8ef2"
 dependencies = [
  "bincode",
  "dashcore-private",
@@ -3811,7 +3811,7 @@ dependencies = [
 [[package]]
 name = "key-wallet"
 version = "0.42.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=e2e8fcf852130383b5922d3c2d907dda334296ee#e2e8fcf852130383b5922d3c2d907dda334296ee"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=c6cbe78e8194020dcab30d8886e5425a24cc8ef2#c6cbe78e8194020dcab30d8886e5425a24cc8ef2"
 dependencies = [
  "aes",
  "async-trait",
@@ -3839,7 +3839,7 @@ dependencies = [
 [[package]]
 name = "key-wallet-ffi"
 version = "0.42.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=e2e8fcf852130383b5922d3c2d907dda334296ee#e2e8fcf852130383b5922d3c2d907dda334296ee"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=c6cbe78e8194020dcab30d8886e5425a24cc8ef2#c6cbe78e8194020dcab30d8886e5425a24cc8ef2"
 dependencies = [
  "cbindgen 0.29.2",
  "dash-network",
@@ -3855,7 +3855,7 @@ dependencies = [
 [[package]]
 name = "key-wallet-manager"
 version = "0.42.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=e2e8fcf852130383b5922d3c2d907dda334296ee#e2e8fcf852130383b5922d3c2d907dda334296ee"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=c6cbe78e8194020dcab30d8886e5425a24cc8ef2#c6cbe78e8194020dcab30d8886e5425a24cc8ef2"
 dependencies = [
  "async-trait",
  "bincode",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,15 +49,15 @@ members = [
 ]
 
 [workspace.dependencies]
-dashcore = { git = "https://github.com/dashpay/rust-dashcore", rev = "e2e8fcf852130383b5922d3c2d907dda334296ee" }
-dash-network-seeds = { git = "https://github.com/dashpay/rust-dashcore", rev = "e2e8fcf852130383b5922d3c2d907dda334296ee" }
-dash-spv = { git = "https://github.com/dashpay/rust-dashcore", rev = "e2e8fcf852130383b5922d3c2d907dda334296ee" }
-dash-spv-ffi = { git = "https://github.com/dashpay/rust-dashcore", rev = "e2e8fcf852130383b5922d3c2d907dda334296ee" }
-key-wallet = { git = "https://github.com/dashpay/rust-dashcore", rev = "e2e8fcf852130383b5922d3c2d907dda334296ee" }
-key-wallet-ffi = { git = "https://github.com/dashpay/rust-dashcore", rev = "e2e8fcf852130383b5922d3c2d907dda334296ee" }
-key-wallet-manager = { git = "https://github.com/dashpay/rust-dashcore", rev = "e2e8fcf852130383b5922d3c2d907dda334296ee" }
-dash-network = { git = "https://github.com/dashpay/rust-dashcore", rev = "e2e8fcf852130383b5922d3c2d907dda334296ee" }
-dashcore-rpc = { git = "https://github.com/dashpay/rust-dashcore", rev = "e2e8fcf852130383b5922d3c2d907dda334296ee" }
+dashcore = { git = "https://github.com/dashpay/rust-dashcore", rev = "c6cbe78e8194020dcab30d8886e5425a24cc8ef2" }
+dash-network-seeds = { git = "https://github.com/dashpay/rust-dashcore", rev = "c6cbe78e8194020dcab30d8886e5425a24cc8ef2" }
+dash-spv = { git = "https://github.com/dashpay/rust-dashcore", rev = "c6cbe78e8194020dcab30d8886e5425a24cc8ef2" }
+dash-spv-ffi = { git = "https://github.com/dashpay/rust-dashcore", rev = "c6cbe78e8194020dcab30d8886e5425a24cc8ef2" }
+key-wallet = { git = "https://github.com/dashpay/rust-dashcore", rev = "c6cbe78e8194020dcab30d8886e5425a24cc8ef2" }
+key-wallet-ffi = { git = "https://github.com/dashpay/rust-dashcore", rev = "c6cbe78e8194020dcab30d8886e5425a24cc8ef2" }
+key-wallet-manager = { git = "https://github.com/dashpay/rust-dashcore", rev = "c6cbe78e8194020dcab30d8886e5425a24cc8ef2" }
+dash-network = { git = "https://github.com/dashpay/rust-dashcore", rev = "c6cbe78e8194020dcab30d8886e5425a24cc8ef2" }
+dashcore-rpc = { git = "https://github.com/dashpay/rust-dashcore", rev = "c6cbe78e8194020dcab30d8886e5425a24cc8ef2" }
 
 # Optimize heavy crypto crates even in dev/test builds so that
 # Halo 2 proof generation and verification run at near-release speed.

--- a/packages/rs-platform-wallet-ffi/src/core_wallet_types.rs
+++ b/packages/rs-platform-wallet-ffi/src/core_wallet_types.rs
@@ -91,6 +91,20 @@ pub struct TransactionRecordFFI {
     pub has_fee: bool,
     pub label: *mut c_char,
     pub first_seen: u64,
+    /// Outpoints of every input in this transaction, in input index
+    /// order. Always populated from `tx.input.iter()` directly so the
+    /// list survives even when the wallet's in-memory `self.utxos`
+    /// map didn't classify the input as "ours" at processing time.
+    /// Required so the Swift persister can reconcile `(spending tx)
+    /// ↔ (spent TXO)` even when the funding tx is processed after
+    /// the spending tx (in-Swift out-of-order arrival), or when the
+    /// funding output was persisted but never re-loaded into
+    /// `self.utxos`. Iterating `input_details` (which only has
+    /// entries for inputs that hit `self.utxos`) was the silent-drop
+    /// path that left `PersistentTxo.isSpent` stuck at false. Empty
+    /// for coinbase transactions.
+    pub input_outpoints: *mut OutPointFFI,
+    pub input_outpoints_count: usize,
 }
 
 // ---------------------------------------------------------------------------
@@ -778,6 +792,38 @@ fn tx_record_to_ffi(
         .unwrap_or_else(|_| CString::new("Unknown").unwrap());
     let label_str = CString::new(tr.label.clone()).unwrap_or_else(|_| CString::new("").unwrap());
 
+    // Build the input-outpoint slice from `tx.input` directly. NOT from
+    // `input_details` — that field only carries entries the wallet
+    // recognized as "ours" at processing time (i.e., entries whose
+    // `previous_output` was already in `self.utxos`), so it silently
+    // drops the spent-outpoint signal whenever the funding tx hadn't
+    // populated the UTXO map yet (in-Swift out-of-order arrival, or
+    // a load_from_persistor that didn't fully repopulate). The Swift
+    // persister reconciles this list against its own `PersistentTxo`
+    // table to mark the spend, so emitting every input — even ones
+    // we don't currently classify as ours — is correct: outpoint is
+    // a globally-unique key and Swift's lookup is a no-op when no
+    // matching row exists. Coinbase inputs are skipped (the previous
+    // output of the synthetic coinbase outpoint is never one of ours).
+    let input_outpoints_vec: Vec<OutPointFFI> = if tr.transaction.is_coin_base() {
+        Vec::new()
+    } else {
+        tr.transaction
+            .input
+            .iter()
+            .map(|input| {
+                let mut prev_txid = [0u8; 32];
+                prev_txid.copy_from_slice(input.previous_output.txid.as_ref());
+                OutPointFFI {
+                    txid: prev_txid,
+                    vout: input.previous_output.vout,
+                }
+            })
+            .collect()
+    };
+    let input_outpoints_count = input_outpoints_vec.len();
+    let input_outpoints = vec_to_ptr(input_outpoints_vec);
+
     TransactionRecordFFI {
         txid,
         tx_data: tx_ptr,
@@ -801,6 +847,8 @@ fn tx_record_to_ffi(
         // refresh from `Date.now()` on insert if it needs a real
         // observation timestamp.
         first_seen: blk_ts as u64,
+        input_outpoints,
+        input_outpoints_count,
     }
 }
 
@@ -890,6 +938,13 @@ pub unsafe fn free_wallet_changeset_ffi(cs: &WalletChangeSetFFI) {
                 }
                 if !tx.label.is_null() {
                     let _ = CString::from_raw(tx.label);
+                }
+                if !tx.input_outpoints.is_null() && tx.input_outpoints_count > 0 {
+                    drop(Vec::from_raw_parts(
+                        tx.input_outpoints,
+                        tx.input_outpoints_count,
+                        tx.input_outpoints_count,
+                    ));
                 }
             }
             drop(Vec::from_raw_parts(

--- a/packages/swift-sdk/Sources/SwiftDashSDK/Persistence/DashModelContainer.swift
+++ b/packages/swift-sdk/Sources/SwiftDashSDK/Persistence/DashModelContainer.swift
@@ -27,6 +27,7 @@ public enum DashModelContainer {
             PersistentCoreAddress.self,
             PersistentTransaction.self,
             PersistentTxo.self,
+            PersistentPendingInput.self,
             PersistentWalletManagerMetadata.self
         ]
     }

--- a/packages/swift-sdk/Sources/SwiftDashSDK/Persistence/Models/PersistentPendingInput.swift
+++ b/packages/swift-sdk/Sources/SwiftDashSDK/Persistence/Models/PersistentPendingInput.swift
@@ -1,0 +1,88 @@
+import Foundation
+import SwiftData
+
+/// Side-table row tracking a transaction input whose previous-output
+/// `PersistentTxo` hasn't landed in SwiftData yet.
+///
+/// The persistence pipeline can deliver a spending transaction
+/// before its funding transaction in two distinct ways:
+///
+/// 1. **In-Swift out-of-order**: the FFI flushes the spending tx's
+///    record to `upsertTransaction(...)` ahead of the funding tx's
+///    output to `upsertUtxo(...)`. By the time we walk the spending
+///    tx's inputs, no `PersistentTxo` exists yet for the previous
+///    output, so a naive "fetch and mark spent" pass silently drops
+///    the linkage.
+/// 2. **Mid-sync restart**: a previous session persisted the
+///    funding TXO but the live sync's `self.utxos` map didn't get
+///    repopulated by `load_from_persistor`, so the Rust side never
+///    classifies the input as "ours" and the FFI's
+///    `utxos_spent` slice is empty for that outpoint. The funding
+///    `PersistentTxo` exists on disk but never gets marked.
+///
+/// To handle both, every spending tx that arrives writes a
+/// `PersistentPendingInput` row for each of its inputs whose
+/// previous-output we don't yet have a `PersistentTxo` for. When a
+/// later `upsertUtxo` creates the matching row, it consults this
+/// table; finding a hit lets it set `isSpent = true`, link
+/// `spendingTransaction = pending.spendingTransaction`, and delete
+/// the pending row in one pass. The mechanism is order-symmetric:
+/// the spend signal travels through the side table when arrival
+/// order doesn't match dependency order.
+///
+/// The 36-byte `outpoint` (32-byte txid + 4-byte LE u32 vout —
+/// composed via [`PersistentTxo.makeOutpoint(txid:vout:)`]) is the
+/// join key between this table and `PersistentTxo`. We index it but
+/// don't mark it `unique` — a re-org or double-spend scenario could
+/// in principle produce two pending rows for the same outpoint,
+/// and we'd rather both resolve naturally than reject the second
+/// upsert outright.
+@Model
+public final class PersistentPendingInput {
+    /// 36-byte outpoint key (`PersistentTxo.makeOutpoint`). Indexed
+    /// for the per-outpoint reconciliation lookup that runs on every
+    /// `upsertUtxo`.
+    #Index<PersistentPendingInput>([\.outpoint])
+    public var outpoint: Data
+
+    /// Position of this input in the spending transaction's input
+    /// list. Carried so a future UI surface can render the input
+    /// index correctly without re-deriving from the raw tx bytes;
+    /// the resolution flow itself only uses `outpoint`.
+    public var inputIndex: UInt32
+
+    /// 32-byte canonical txid of the spending transaction. Stored
+    /// in addition to the relationship below so the entry remains
+    /// usable if the parent `PersistentTransaction` isn't yet in the
+    /// background context (re-upsert ordering, fault-in lag, …).
+    public var spendingTxid: Data
+
+    /// The transaction this input belongs to. Cascade-deleted from
+    /// the parent side via `PersistentTransaction.pendingInputs` so
+    /// removing a tx doesn't leave dangling pending rows.
+    public var spendingTransaction: PersistentTransaction?
+
+    /// Wallet id (`PersistentTxo.walletId` denorm) so cleanup /
+    /// per-wallet diagnostics can scope without joining through the
+    /// transaction relationship.
+    public var walletId: Data
+
+    /// Insertion timestamp — useful for spotting stale entries that
+    /// never resolved (orphans whose previous output isn't ours).
+    public var createdAt: Date
+
+    public init(
+        outpoint: Data,
+        inputIndex: UInt32,
+        spendingTxid: Data,
+        spendingTransaction: PersistentTransaction?,
+        walletId: Data
+    ) {
+        self.outpoint = outpoint
+        self.inputIndex = inputIndex
+        self.spendingTxid = spendingTxid
+        self.spendingTransaction = spendingTransaction
+        self.walletId = walletId
+        self.createdAt = Date()
+    }
+}

--- a/packages/swift-sdk/Sources/SwiftDashSDK/Persistence/Models/PersistentTransaction.swift
+++ b/packages/swift-sdk/Sources/SwiftDashSDK/Persistence/Models/PersistentTransaction.swift
@@ -76,6 +76,18 @@ public final class PersistentTransaction {
     @Relationship(inverse: \PersistentTxo.spendingTransaction)
     public var inputs: [PersistentTxo] = []
 
+    /// Pending input outpoints — entries this transaction's input
+    /// list references but for which no `PersistentTxo` has been
+    /// upserted yet. Filled by `PlatformWalletPersistenceHandler.
+    /// upsertTransaction` via the FFI's `input_outpoints` slice;
+    /// each entry is consumed (deleted) by `upsertUtxo` when the
+    /// matching previous-output finally arrives. See
+    /// `PersistentPendingInput` for the full reconciliation flow.
+    /// Cascade-delete: removing the spending tx drops every pending
+    /// row that hasn't resolved yet.
+    @Relationship(deleteRule: .cascade, inverse: \PersistentPendingInput.spendingTransaction)
+    public var pendingInputs: [PersistentPendingInput] = []
+
     public init(
         txid: Data,
         context: UInt32 = 0,

--- a/packages/swift-sdk/Sources/SwiftDashSDK/Persistence/Models/PersistentTxo.swift
+++ b/packages/swift-sdk/Sources/SwiftDashSDK/Persistence/Models/PersistentTxo.swift
@@ -77,6 +77,20 @@ public final class PersistentTxo {
     /// the spending tx must not cascade-delete this row.
     public var spendingTransaction: PersistentTransaction?
 
+    /// Position of this output within `spendingTransaction.input`
+    /// (i.e. the canonical "vin index"). Captured at the moment the
+    /// spend is reconciled — sourced from
+    /// `TransactionRecordFFI.input_outpoints` index, which itself
+    /// comes from `tx.input.iter()` on the Rust side, so the value
+    /// matches the serialized transaction's input ordering exactly.
+    /// `nil` when the TXO is unspent (no spending tx, no vin index)
+    /// or when migrated from an older row that predates the column.
+    /// Surfaced by `TransactionStorageDetailView` so input rows
+    /// render in serialized vin order with their real positions
+    /// rather than being re-sorted by outpoint hex (which loses
+    /// the relationship between row and serialized index).
+    public var spendingInputIndex: UInt32? = nil
+
     /// Parent account. No longer paired with an inverse on the
     /// account side — the canonical account path is
     /// `coreAddress?.account`. This field is the fallback when the

--- a/packages/swift-sdk/Sources/SwiftDashSDK/PlatformWallet/PlatformWalletPersistenceHandler.swift
+++ b/packages/swift-sdk/Sources/SwiftDashSDK/PlatformWallet/PlatformWalletPersistenceHandler.swift
@@ -483,11 +483,18 @@ public class PlatformWalletPersistenceHandler {
             // an idempotent re-upsert of the same tx must not
             // gratuitously bump `lastUpdated` and trigger a follow-on
             // changeset emit.
-            if !txo.isSpent || txo.spendingTransaction?.txid != spendingTxid {
+            let linkageChanged =
+                !txo.isSpent
+                || txo.spendingTransaction?.txid != spendingTxid
+                || txo.spendingInputIndex != inputIndex
+            if linkageChanged {
                 txo.isSpent = true
                 if txo.spendingTransaction?.txid != spendingTxid {
                     txo.spendingTransaction = spendingTransaction
                 }
+                // Capture the canonical vin index so the detail
+                // view can render inputs in serialized order.
+                txo.spendingInputIndex = inputIndex
                 txo.lastUpdated = Date()
             }
             // A pending entry from an earlier write is now stale —
@@ -644,6 +651,13 @@ public class PlatformWalletPersistenceHandler {
             // observation; the rest are dropped.
             let chosen = pendingRows.max(by: { $0.createdAt < $1.createdAt }) ?? pendingRows[0]
             record.isSpent = true
+            // Carry the vin index forward so the spending tx's
+            // detail view can render its inputs in the canonical
+            // serialized order. Same source as the linkage write
+            // in `resolveInputOutpoint` — the only path that creates
+            // pending rows captures the index from FFI's
+            // `input_outpoints` slice, which mirrors `tx.input.iter()`.
+            record.spendingInputIndex = chosen.inputIndex
             if let spending = chosen.spendingTransaction {
                 if record.spendingTransaction?.txid != spending.txid {
                     record.spendingTransaction = spending

--- a/packages/swift-sdk/Sources/SwiftDashSDK/PlatformWallet/PlatformWalletPersistenceHandler.swift
+++ b/packages/swift-sdk/Sources/SwiftDashSDK/PlatformWallet/PlatformWalletPersistenceHandler.swift
@@ -385,13 +385,13 @@ public class PlatformWalletPersistenceHandler {
     }
 
     private func upsertTransaction(account: PersistentAccount, tx: TransactionRecordFFI) {
-        // `account` is intentionally consumed only by the TXO upsert
-        // pass that follows this method's call site. The transaction
-        // row itself is account-agnostic — a single tx can land in
-        // multiple accounts (or wallets), and per-wallet membership
-        // is recovered through the TXO graph (`outputs` / `inputs`)
-        // rather than a denormalized column on the transaction.
-        _ = account
+        // The `account` parameter scopes the wallet-id used for the
+        // input-reconciliation pass at the bottom of this method.
+        // The transaction row itself stays account-agnostic — a
+        // single tx can land in multiple accounts (or wallets), and
+        // per-wallet membership is recovered through the TXO graph
+        // (`outputs` / `inputs`) rather than a denormalized column.
+        let resolvedWalletId: Data = account.wallet.walletId
         let txidData = hashData(tx.txid)
         let descriptor = FetchDescriptor<PersistentTransaction>(
             predicate: #Predicate { $0.txid == txidData }
@@ -432,6 +432,110 @@ public class PlatformWalletPersistenceHandler {
             record.transactionData = Data(bytes: dataPtr, count: Int(tx.tx_data_len))
         }
         record.lastUpdated = Date()
+
+        // Walk every input in this transaction and reconcile it
+        // against the `PersistentTxo` table. The FFI populates
+        // `input_outpoints` from `tx.input.iter()` directly, so the
+        // list survives even when the wallet's in-memory `self.utxos`
+        // didn't classify the input as ours at processing time —
+        // that gap was the silent-drop path that left
+        // `PersistentTxo.isSpent` stuck at false on out-of-order
+        // arrival. For each input outpoint:
+        //   1. Look up the matching `PersistentTxo`.
+        //   2. If found → set `isSpent` and link `spendingTransaction`.
+        //   3. If not found → write a `PersistentPendingInput` row;
+        //      the matching `upsertUtxo` will pick it up later and
+        //      delete the pending row in the same pass.
+        if let inPtr = tx.input_outpoints, tx.input_outpoints_count > 0 {
+            for i in 0..<Int(tx.input_outpoints_count) {
+                let entry = inPtr[i]
+                let prevTxid = withUnsafeBytes(of: entry.txid) { Data($0) }
+                let outpoint = PersistentTxo.makeOutpoint(txid: prevTxid, vout: entry.vout)
+                resolveInputOutpoint(
+                    outpoint: outpoint,
+                    inputIndex: UInt32(i),
+                    spendingTransaction: record,
+                    spendingTxid: txidData,
+                    walletId: resolvedWalletId
+                )
+            }
+        }
+    }
+
+    /// Mark the `PersistentTxo` whose 36-byte `outpoint` matches the
+    /// given input as spent and link it to `spendingTransaction`.
+    /// If no matching TXO exists yet (in-Swift out-of-order, or
+    /// load_from_persistor missed it), write a
+    /// `PersistentPendingInput` row so the next `upsertUtxo` for
+    /// that outpoint can resolve the linkage.
+    private func resolveInputOutpoint(
+        outpoint: Data,
+        inputIndex: UInt32,
+        spendingTransaction: PersistentTransaction,
+        spendingTxid: Data,
+        walletId: Data
+    ) {
+        let txoDescriptor = FetchDescriptor<PersistentTxo>(
+            predicate: #Predicate { $0.outpoint == outpoint }
+        )
+        if let txo = try? backgroundContext.fetch(txoDescriptor).first {
+            // Only touch the row if the linkage actually changes —
+            // an idempotent re-upsert of the same tx must not
+            // gratuitously bump `lastUpdated` and trigger a follow-on
+            // changeset emit.
+            if !txo.isSpent || txo.spendingTransaction?.txid != spendingTxid {
+                txo.isSpent = true
+                if txo.spendingTransaction?.txid != spendingTxid {
+                    txo.spendingTransaction = spendingTransaction
+                }
+                txo.lastUpdated = Date()
+            }
+            // A pending entry from an earlier write is now stale —
+            // resolved by this fetch. Drop it.
+            removePendingInputs(for: outpoint)
+        } else {
+            // Defer: record a pending row so a future `upsertUtxo`
+            // can complete the link. Writing one row per input is
+            // cheap; the cascade-delete relationship + the resolve
+            // path in `upsertUtxo` keep the table from growing
+            // unbounded.
+            //
+            // Skip the write if a pending row for this exact
+            // (outpoint, spending-tx) pair already exists — re-upserts
+            // of the same transaction would otherwise produce
+            // duplicate pending rows that all resolve to the same
+            // TXO, wasting fetch work on the resolve side.
+            let pendingDescriptor = FetchDescriptor<PersistentPendingInput>(
+                predicate: #Predicate { $0.outpoint == outpoint && $0.spendingTxid == spendingTxid }
+            )
+            if (try? backgroundContext.fetch(pendingDescriptor).first) == nil {
+                let pending = PersistentPendingInput(
+                    outpoint: outpoint,
+                    inputIndex: inputIndex,
+                    spendingTxid: spendingTxid,
+                    spendingTransaction: spendingTransaction,
+                    walletId: walletId
+                )
+                backgroundContext.insert(pending)
+            }
+        }
+    }
+
+    /// Drop every `PersistentPendingInput` row keyed on `outpoint`.
+    /// Called after a successful `PersistentTxo` mark-spent so the
+    /// pending entries don't linger as orphans, and from
+    /// `upsertUtxo`'s resolve path so a freshly-arrived TXO doesn't
+    /// keep its corresponding pending row alive.
+    private func removePendingInputs(for outpoint: Data) {
+        let descriptor = FetchDescriptor<PersistentPendingInput>(
+            predicate: #Predicate { $0.outpoint == outpoint }
+        )
+        guard let rows = try? backgroundContext.fetch(descriptor), !rows.isEmpty else {
+            return
+        }
+        for row in rows {
+            backgroundContext.delete(row)
+        }
     }
 
     private func upsertUtxo(account: PersistentAccount, utxo: UtxoEntryFFI) {
@@ -517,6 +621,50 @@ public class PlatformWalletPersistenceHandler {
                 record.coreAddress = coreAddr
             }
         }
+
+        // Resolve any deferred spend signal that landed before this
+        // TXO existed. `upsertTransaction` writes a
+        // `PersistentPendingInput` row for every input outpoint
+        // whose previous-output isn't in SwiftData yet; the matching
+        // upsert here drains those rows and stamps `isSpent` on the
+        // TXO. Symmetric with the resolve path in
+        // `upsertTransaction`, so the spend signal is order-
+        // independent at this layer regardless of which side arrives
+        // first.
+        let outpointKey = record.outpoint
+        let pendingDescriptor = FetchDescriptor<PersistentPendingInput>(
+            predicate: #Predicate { $0.outpoint == outpointKey }
+        )
+        if let pendingRows = try? backgroundContext.fetch(pendingDescriptor),
+           !pendingRows.isEmpty {
+            // Pick the freshest pending entry — under normal sync
+            // there's only one, but a chain reorg or double-spend
+            // observation could leave multiple. Newest wins so the
+            // visible spendingTransaction matches the most recent
+            // observation; the rest are dropped.
+            let chosen = pendingRows.max(by: { $0.createdAt < $1.createdAt }) ?? pendingRows[0]
+            record.isSpent = true
+            if let spending = chosen.spendingTransaction {
+                if record.spendingTransaction?.txid != spending.txid {
+                    record.spendingTransaction = spending
+                }
+            } else {
+                // Pending row's parent tx wasn't faulted in; fall
+                // back to a txid lookup so the linkage still lands.
+                let spendingTxid = chosen.spendingTxid
+                let txDescriptor = FetchDescriptor<PersistentTransaction>(
+                    predicate: #Predicate { $0.txid == spendingTxid }
+                )
+                if let spending = try? backgroundContext.fetch(txDescriptor).first,
+                   record.spendingTransaction?.txid != spending.txid {
+                    record.spendingTransaction = spending
+                }
+            }
+            record.lastUpdated = Date()
+            for row in pendingRows {
+                backgroundContext.delete(row)
+            }
+        }
     }
 
     private func markUtxoSpent(_ entry: SpentOutPointFFI) {
@@ -552,6 +700,15 @@ public class PlatformWalletPersistenceHandler {
             }
         }
         txo.lastUpdated = Date()
+        // The spend signal landed both via the legacy
+        // `utxos_spent` slice (this path) and — assuming the
+        // spending tx's record was emitted in the same flush —
+        // through `upsertTransaction`'s reconciliation pass. Both
+        // resolve to the same TXO row, but the latter may have
+        // written a `PersistentPendingInput` row when the TXO
+        // didn't yet exist. Drain any leftover pending rows for
+        // this outpoint so they don't linger as orphans.
+        removePendingInputs(for: outpoint)
     }
 
     private func markUtxoInstantLocked(_ op: OutPointFFI) {

--- a/packages/swift-sdk/SwiftExampleApp/SwiftExampleApp/Views/StorageExplorerView.swift
+++ b/packages/swift-sdk/SwiftExampleApp/SwiftExampleApp/Views/StorageExplorerView.swift
@@ -91,6 +91,9 @@ struct StorageExplorerView: View {
             modelRow("TXOs", icon: "bitcoinsign.circle", type: PersistentTxo.self) {
                 TxoStorageListView()
             }
+            modelRow("Pending Inputs", icon: "hourglass", type: PersistentPendingInput.self) {
+                PendingInputStorageListView()
+            }
             modelRow("Manager Metadata", icon: "gearshape.2", type: PersistentWalletManagerMetadata.self) {
                 WalletManagerMetadataStorageListView()
             }
@@ -171,6 +174,7 @@ struct StorageExplorerView: View {
         count(PersistentAccount.self)
         count(PersistentTransaction.self)
         count(PersistentTxo.self)
+        count(PersistentPendingInput.self)
         count(PersistentWalletManagerMetadata.self)
         // Core and Platform address rows live in separate models now
         // (PersistentCoreAddress vs PersistentPlatformAddress), so

--- a/packages/swift-sdk/SwiftExampleApp/SwiftExampleApp/Views/StorageModelListViews.swift
+++ b/packages/swift-sdk/SwiftExampleApp/SwiftExampleApp/Views/StorageModelListViews.swift
@@ -1285,6 +1285,67 @@ struct TxoStorageListView: View {
     }
 }
 
+// MARK: - PersistentPendingInput
+
+/// Diagnostic list of every `PersistentPendingInput` row — one per
+/// transaction-input outpoint whose previous-output `PersistentTxo`
+/// hasn't landed in SwiftData yet. A non-empty list is informational
+/// rather than alarming on its own (entries resolve and self-delete
+/// when the matching `upsertUtxo` arrives), but a *long-lived*
+/// non-zero count points at a real reconciliation gap — addresses
+/// that the wallet never derives, or input outpoints whose previous
+/// output isn't ours and will never resolve.
+struct PendingInputStorageListView: View {
+    @Query(sort: [SortDescriptor(\PersistentPendingInput.createdAt, order: .reverse)])
+    private var records: [PersistentPendingInput]
+
+    var body: some View {
+        List(records) { record in
+            NavigationLink(destination: PendingInputStorageDetailView(record: record)) {
+                VStack(alignment: .leading, spacing: 4) {
+                    Text(outpointHex(record.outpoint))
+                        .font(.system(.caption, design: .monospaced))
+                        .lineLimit(1).truncationMode(.middle)
+                    HStack(spacing: 8) {
+                        Text("input \(record.inputIndex)")
+                            .font(.caption2)
+                            .foregroundColor(.secondary)
+                        Spacer()
+                        Text(record.createdAt, style: .relative)
+                            .font(.caption2)
+                            .foregroundColor(.secondary)
+                    }
+                }
+            }
+        }
+        .navigationTitle("Pending Inputs (\(records.count))")
+        .overlay {
+            if records.isEmpty {
+                ContentUnavailableView(
+                    "No Pending Inputs",
+                    systemImage: "hourglass"
+                )
+            }
+        }
+    }
+
+    /// 36-byte outpoint as `<txid hex (display order)>:<vout>`. Mirrors
+    /// `PersistentTxo.outpointHex` so the same row is identifiable
+    /// across both surfaces.
+    private func outpointHex(_ outpoint: Data) -> String {
+        guard outpoint.count == 36 else {
+            return outpoint.map { String(format: "%02x", $0) }.joined()
+        }
+        let txid = outpoint.prefix(32)
+        let voutBytes = outpoint.suffix(4)
+        let vout = voutBytes.withUnsafeBytes { raw in
+            raw.load(as: UInt32.self).littleEndian
+        }
+        let txidHex = txid.reversed().map { String(format: "%02x", $0) }.joined()
+        return "\(txidHex):\(vout)"
+    }
+}
+
 // MARK: - PersistentWalletManagerMetadata
 
 struct WalletManagerMetadataStorageListView: View {

--- a/packages/swift-sdk/SwiftExampleApp/SwiftExampleApp/Views/StorageModelListViews.swift
+++ b/packages/swift-sdk/SwiftExampleApp/SwiftExampleApp/Views/StorageModelListViews.swift
@@ -836,6 +836,23 @@ struct TransactionStorageListView: View {
                     }
                 }
             }
+            // Render the filter-narrowed empty state INSIDE the List
+            // (not as an `.overlay`) so the filter Section above
+            // remains tappable. Overlaying ContentUnavailableView on
+            // top of the same List that hosts the filter controls
+            // makes "no matches" a dead-end — the user can't change
+            // direction / type / search to recover. As inline list
+            // content, the message scrolls in below the filter row
+            // and leaves the controls fully reachable.
+            if !records.isEmpty && visible.isEmpty {
+                Section {
+                    ContentUnavailableView(
+                        "No matching transactions",
+                        systemImage: "magnifyingglass",
+                        description: Text("Adjust the search / direction / type filters")
+                    )
+                }
+            }
             ForEach(visible) { record in
                 NavigationLink(destination: TransactionStorageDetailView(record: record)) {
                     VStack(alignment: .leading, spacing: 4) {
@@ -879,17 +896,15 @@ struct TransactionStorageListView: View {
             placement: .navigationBarDrawer(displayMode: .always),
             prompt: "Search by tx id (hex)"
         )
+        // Only the "no records at all" state uses an overlay — there's
+        // nothing to interact with in that case, so blocking the List
+        // is fine. The filter-narrowed empty state is rendered as
+        // list content above (see the inline Section).
         .overlay {
             if records.isEmpty {
                 ContentUnavailableView(
                     "No Records",
                     systemImage: "arrow.left.arrow.right.circle"
-                )
-            } else if visible.isEmpty {
-                ContentUnavailableView(
-                    "No matching transactions",
-                    systemImage: "magnifyingglass",
-                    description: Text("Adjust the search / direction / type filters")
                 )
             }
         }
@@ -1228,6 +1243,19 @@ struct TxoStorageListView: View {
                 }
                 .pickerStyle(.segmented)
             }
+            // Render the filter-narrowed empty state as inline list
+            // content rather than as an `.overlay` over the List —
+            // see the matching note in `TransactionStorageListView`.
+            // Overlay would block the segmented Picker above and
+            // dead-end the user.
+            if !records.isEmpty && visible.isEmpty {
+                Section {
+                    ContentUnavailableView(
+                        "No \(filter.title) TXOs",
+                        systemImage: "bitcoinsign.circle"
+                    )
+                }
+            }
             ForEach(visible) { record in
                 NavigationLink(destination: TxoStorageDetailView(record: record)) {
                     VStack(alignment: .leading, spacing: 4) {
@@ -1258,14 +1286,12 @@ struct TxoStorageListView: View {
         .navigationTitle(filter == .all
             ? "TXOs (\(records.count))"
             : "TXOs (\(visible.count) / \(records.count))")
+        // Overlay only the no-records-at-all case; the
+        // filter-narrowed empty state lives inline above so the
+        // Picker stays reachable.
         .overlay {
             if records.isEmpty {
                 ContentUnavailableView("No Records", systemImage: "bitcoinsign.circle")
-            } else if visible.isEmpty {
-                ContentUnavailableView(
-                    "No \(filter.title) TXOs",
-                    systemImage: "bitcoinsign.circle"
-                )
             }
         }
     }

--- a/packages/swift-sdk/SwiftExampleApp/SwiftExampleApp/Views/StorageModelListViews.swift
+++ b/packages/swift-sdk/SwiftExampleApp/SwiftExampleApp/Views/StorageModelListViews.swift
@@ -737,24 +737,193 @@ struct TransactionStorageListView: View {
     @Query(sort: \PersistentTransaction.firstSeen, order: .reverse)
     private var records: [PersistentTransaction]
 
+    /// Live-search needle — matches against the canonical block-explorer
+    /// `txidHex` (byte-reversed) so a user can paste an explorer link's
+    /// id directly. Case-insensitive substring; empty disables the
+    /// filter entirely.
+    @State private var searchText: String = ""
+    /// Direction filter. `PersistentTransaction.direction` carries the
+    /// four values exposed by `TransactionDirection` on the Rust side
+    /// (`Incoming`/`Outgoing`/`Internal`/`CoinJoin`); `.all` keeps
+    /// everything.
+    @State private var directionFilter: DirectionFilter = .all
+    /// Transaction-type filter. Keyed on `transactionType` strings the
+    /// Rust FFI emits via `format!("{:?}", …)` on
+    /// `dashcore::TransactionType` (e.g. `"Classic Transaction"`,
+    /// `"Asset Lock Transaction"`). The legacy default placeholder
+    /// `"Standard"` is also tolerated so older rows still match
+    /// "Classic". `nil` means "any type".
+    @State private var typeFilter: String? = nil
+
+    /// Pre-defined list of every type the data model exposes. Not
+    /// derived from the live record set so that the picker shape stays
+    /// stable as the user changes filters and so reviewers can spot a
+    /// type that has zero rows (data exists / not exists is itself a
+    /// signal). Strings match the FFI-emitted Debug form on
+    /// `TransactionType`.
+    private static let knownTypes: [String] = [
+        "Classic Transaction",
+        "Provider Registration Transaction",
+        "Provider Update Service Transaction",
+        "Provider Update Registrar Transaction",
+        "Provider Update Revocation Transaction",
+        "Coinbase Transaction",
+        "Quorum Commitment Transaction",
+        "MNHF Signal Transaction",
+        "Asset Lock Transaction",
+        "Asset Unlock Transaction",
+    ]
+
+    private var filteredRecords: [PersistentTransaction] {
+        let trimmed = searchText.trimmingCharacters(in: .whitespacesAndNewlines)
+        let needle = trimmed.lowercased()
+        return records.filter { record in
+            // Direction.
+            switch directionFilter {
+            case .all: break
+            case .incoming where record.direction != 0: return false
+            case .outgoing where record.direction != 1: return false
+            case .internalTx where record.direction != 2: return false
+            case .coinjoin where record.direction != 3: return false
+            default: break
+            }
+            // Type. Treat the legacy `"Standard"` placeholder (the
+            // default the persister uses when the FFI column is nil)
+            // as equivalent to `"Classic Transaction"` so users
+            // searching for classic txs still see those rows.
+            if let want = typeFilter {
+                let actual = record.transactionType
+                let normalized = actual == "Standard" ? "Classic Transaction" : actual
+                if normalized != want { return false }
+            }
+            // Search needle.
+            if !needle.isEmpty {
+                if !record.txidHex.lowercased().contains(needle) { return false }
+            }
+            return true
+        }
+    }
+
     var body: some View {
-        List(records) { record in
-            NavigationLink(destination: TransactionStorageDetailView(record: record)) {
-                VStack(alignment: .leading, spacing: 4) {
-                    Text(record.txidHex)
-                        .font(.system(.caption, design: .monospaced))
-                        .lineLimit(1).truncationMode(.middle)
+        let visible = filteredRecords
+        List {
+            Section {
+                Picker("Direction", selection: $directionFilter) {
+                    ForEach(DirectionFilter.allCases, id: \.self) { d in
+                        Text(d.title).tag(d)
+                    }
+                }
+                .pickerStyle(.segmented)
+
+                // Type selection. 10+ options doesn't fit a segmented
+                // picker — use a `Menu` so the row stays single-line.
+                Menu {
+                    Button("All Types") { typeFilter = nil }
+                    Divider()
+                    ForEach(Self.knownTypes, id: \.self) { t in
+                        Button(displayName(forType: t)) { typeFilter = t }
+                    }
+                } label: {
                     HStack {
-                        Text(record.directionName).font(.caption)
+                        Text("Type")
+                            .foregroundColor(.primary)
                         Spacer()
-                        Text(record.formattedAmount)
-                            .font(.caption).foregroundColor(record.netAmount >= 0 ? .green : .red)
+                        Text(typeFilter.map(displayName(forType:)) ?? "All")
+                            .foregroundColor(.secondary)
+                        Image(systemName: "chevron.up.chevron.down")
+                            .font(.caption2)
+                            .foregroundColor(.secondary)
+                    }
+                }
+            }
+            ForEach(visible) { record in
+                NavigationLink(destination: TransactionStorageDetailView(record: record)) {
+                    VStack(alignment: .leading, spacing: 4) {
+                        Text(record.txidHex)
+                            .font(.system(.caption, design: .monospaced))
+                            .lineLimit(1).truncationMode(.middle)
+                        HStack(spacing: 8) {
+                            Text(record.directionName).font(.caption)
+                            // Only surface the type label when it
+                            // isn't the default Classic — saves a
+                            // line on the most-common row shape.
+                            let normalizedType =
+                                record.transactionType == "Standard"
+                                    ? "Classic Transaction"
+                                    : record.transactionType
+                            if normalizedType != "Classic Transaction" {
+                                Text(displayName(forType: normalizedType))
+                                    .font(.caption2)
+                                    .padding(.horizontal, 6)
+                                    .padding(.vertical, 2)
+                                    .background(Color.purple.opacity(0.15))
+                                    .foregroundColor(.purple)
+                                    .clipShape(Capsule())
+                            }
+                            Spacer()
+                            Text(record.formattedAmount)
+                                .font(.caption)
+                                .foregroundColor(record.netAmount >= 0 ? .green : .red)
+                        }
                     }
                 }
             }
         }
-        .navigationTitle("Transactions (\(records.count))")
-        .overlay { if records.isEmpty { ContentUnavailableView("No Records", systemImage: "arrow.left.arrow.right.circle") } }
+        .navigationTitle(
+            (directionFilter == .all && typeFilter == nil && searchText.isEmpty)
+                ? "Transactions (\(records.count))"
+                : "Transactions (\(visible.count) / \(records.count))"
+        )
+        .searchable(
+            text: $searchText,
+            placement: .navigationBarDrawer(displayMode: .always),
+            prompt: "Search by tx id (hex)"
+        )
+        .overlay {
+            if records.isEmpty {
+                ContentUnavailableView(
+                    "No Records",
+                    systemImage: "arrow.left.arrow.right.circle"
+                )
+            } else if visible.isEmpty {
+                ContentUnavailableView(
+                    "No matching transactions",
+                    systemImage: "magnifyingglass",
+                    description: Text("Adjust the search / direction / type filters")
+                )
+            }
+        }
+    }
+
+    /// Drop the redundant trailing "Transaction" word so the
+    /// segmented row + picker stay readable. `"Asset Lock
+    /// Transaction"` → `"Asset Lock"`, etc. The full string is what
+    /// gets compared against `record.transactionType` — only the
+    /// label is shortened.
+    private func displayName(forType raw: String) -> String {
+        let suffix = " Transaction"
+        if raw.hasSuffix(suffix) {
+            return String(raw.dropLast(suffix.count))
+        }
+        return raw
+    }
+
+    private enum DirectionFilter: CaseIterable, Hashable {
+        case all
+        case incoming
+        case outgoing
+        case internalTx
+        case coinjoin
+
+        var title: String {
+            switch self {
+            case .all: return "All"
+            case .incoming: return "In"
+            case .outgoing: return "Out"
+            case .internalTx: return "Internal"
+            case .coinjoin: return "CoinJoin"
+            }
+        }
     }
 }
 

--- a/packages/swift-sdk/SwiftExampleApp/SwiftExampleApp/Views/StorageRecordDetailViews.swift
+++ b/packages/swift-sdk/SwiftExampleApp/SwiftExampleApp/Views/StorageRecordDetailViews.swift
@@ -1660,6 +1660,78 @@ struct TxoStorageDetailView: View {
     }
 }
 
+// MARK: - PersistentPendingInput
+
+struct PendingInputStorageDetailView: View {
+    let record: PersistentPendingInput
+
+    var body: some View {
+        Form {
+            Section("Core") {
+                FieldRow(label: "Outpoint", value: outpointHex(record.outpoint))
+                FieldRow(label: "Input Index", value: "\(record.inputIndex)")
+                // Display order matches the canonical block-explorer
+                // form (byte-reversed from on-disk wire order) — same
+                // convention `PersistentTransaction.txidHex` uses.
+                FieldRow(
+                    label: "Spending TXID",
+                    value: record.spendingTxid.reversed()
+                        .map { String(format: "%02x", $0) }
+                        .joined()
+                )
+                FieldRow(label: "Wallet ID", value: record.walletId.isEmpty ? "—" : hexString(record.walletId))
+            }
+            Section("Relationships") {
+                if let spending = record.spendingTransaction {
+                    NavigationLink(destination: TransactionStorageDetailView(record: spending)) {
+                        FieldRow(label: "Spending Transaction", value: spending.txidHex)
+                    }
+                } else {
+                    // The pending row's parent transaction may not have
+                    // faulted in (rare — the cascade-delete relationship
+                    // keeps them in lockstep, but the field is optional
+                    // for SwiftData's brief-window tolerance). Surface
+                    // explicitly so reviewers can spot the orphan.
+                    FieldRow(label: "Spending Transaction", value: "— (unlinked)")
+                }
+            }
+            Section("Timestamps") {
+                FieldRow(label: "Created", value: dateString(record.createdAt))
+            }
+            Section {
+                Text(
+                    "A pending input lives here until its previous-output "
+                    + "PersistentTxo arrives. On `upsertUtxo`, the matching "
+                    + "row is consumed: the new TXO is marked spent, "
+                    + "linked to this row's spendingTransaction, and the "
+                    + "pending entry is deleted in one pass."
+                )
+                .font(.caption2)
+                .foregroundColor(.secondary)
+            }
+        }
+        .navigationTitle("Pending Input")
+        .navigationBarTitleDisplayMode(.inline)
+    }
+
+    /// 36-byte outpoint as `<txid hex (display order)>:<vout>`.
+    /// Duplicates the helper in the list view rather than threading
+    /// it through a shared file — the function is small and the two
+    /// surfaces don't otherwise collaborate.
+    private func outpointHex(_ outpoint: Data) -> String {
+        guard outpoint.count == 36 else {
+            return outpoint.map { String(format: "%02x", $0) }.joined()
+        }
+        let txid = outpoint.prefix(32)
+        let voutBytes = outpoint.suffix(4)
+        let vout = voutBytes.withUnsafeBytes { raw in
+            raw.load(as: UInt32.self).littleEndian
+        }
+        let txidHex = txid.reversed().map { String(format: "%02x", $0) }.joined()
+        return "\(txidHex):\(vout)"
+    }
+}
+
 // MARK: - PersistentWalletManagerMetadata
 
 struct WalletManagerMetadataStorageDetailView: View {

--- a/packages/swift-sdk/SwiftExampleApp/SwiftExampleApp/Views/StorageRecordDetailViews.swift
+++ b/packages/swift-sdk/SwiftExampleApp/SwiftExampleApp/Views/StorageRecordDetailViews.swift
@@ -1506,19 +1506,35 @@ struct TransactionStorageDetailView: View {
             // Per-input drill-downs. Each input is the
             // `PersistentTxo` of the *previous* output that this tx
             // consumed — tapping it surfaces where the funds came
-            // from (address, originating tx, amount). No stable
-            // input index column lives on `PersistentTxo`, so rows
-            // are ordered by their canonical outpoint string for
-            // determinism.
+            // from (address, originating tx, amount). Rows are
+            // ordered by `spendingInputIndex` (the canonical vin
+            // position captured when the spend was reconciled), so
+            // row N matches input N in the serialized transaction.
+            // The fallback ordering (`outpointHex`) only kicks in
+            // for legacy rows that predate the column or for rows
+            // whose pending-input resolution didn't run with an
+            // index — both rare edge cases that drop to the bottom
+            // of the list with a sentinel "prev" label.
             Section {
                 if record.inputs.isEmpty {
                     Text("None")
                         .font(.caption)
                         .foregroundColor(.secondary)
                 } else {
-                    ForEach(record.inputs.sorted { $0.outpointHex < $1.outpointHex }) { txo in
+                    let orderedInputs = record.inputs.sorted { lhs, rhs in
+                        switch (lhs.spendingInputIndex, rhs.spendingInputIndex) {
+                        case let (.some(l), .some(r)): return l < r
+                        case (.some, .none): return true
+                        case (.none, .some): return false
+                        case (.none, .none): return lhs.outpointHex < rhs.outpointHex
+                        }
+                    }
+                    ForEach(orderedInputs) { txo in
                         NavigationLink(destination: TxoStorageDetailView(record: txo)) {
-                            txoRowLabel(txo, indexLabel: "prev")
+                            txoRowLabel(
+                                txo,
+                                indexLabel: txo.spendingInputIndex.map { "vin \($0)" } ?? "prev"
+                            )
                         }
                     }
                 }
@@ -1536,10 +1552,14 @@ struct TransactionStorageDetailView: View {
 
     /// Two-line row label for an input / output cell. Top line:
     /// `<vout-or-prev>  <amount>  <spent-pill>`. Bottom line: the
-    /// 36-byte outpoint hex (so user can copy to a block explorer)
+    /// canonical block-explorer outpoint string —
+    /// `<display-order txid hex>:<vout>` via `PersistentTxo.outpointHex`,
+    /// which is what users paste into DashScan / mempool explorers —
     /// followed by the address when present. Address line stays
     /// truncated-middle so a long Base58 doesn't push the right edge
-    /// off the screen.
+    /// off the screen. (If you ever need the raw 36-byte outpoint
+    /// hex instead, use `hexString(txo.outpoint)` — the
+    /// `outpointHex` accessor flips byte order on the txid half.)
     @ViewBuilder
     private func txoRowLabel(
         _ txo: PersistentTxo,

--- a/packages/swift-sdk/SwiftExampleApp/SwiftExampleApp/Views/StorageRecordDetailViews.swift
+++ b/packages/swift-sdk/SwiftExampleApp/SwiftExampleApp/Views/StorageRecordDetailViews.swift
@@ -1481,12 +1481,49 @@ struct TransactionStorageDetailView: View {
                     FieldRow(label: "TX Size", value: "\(size) bytes")
                 }
             }
-            Section("Relationships") {
-                // Transactions are no longer account-scoped. We
-                // surface the participating accounts (if any)
-                // indirectly via the output / input TXOs.
-                FieldRow(label: "Outputs", value: "\(record.outputs.count)")
-                FieldRow(label: "Inputs", value: "\(record.inputs.count)")
+            // Per-output drill-downs. Each row navigates to the
+            // owning `PersistentTxo` so the address / spent state /
+            // wallet linkage of that single output is one tap away.
+            // Sorted by `vout` so the order matches the on-chain
+            // serialization. The vout column is left-aligned and
+            // monospaced so columns line up across rows.
+            Section {
+                if record.outputs.isEmpty {
+                    Text("None")
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                } else {
+                    ForEach(record.outputs.sorted { $0.vout < $1.vout }) { txo in
+                        NavigationLink(destination: TxoStorageDetailView(record: txo)) {
+                            txoRowLabel(txo, indexLabel: "vout \(txo.vout)")
+                        }
+                    }
+                }
+            } header: {
+                Text("Outputs (\(record.outputs.count))")
+            }
+
+            // Per-input drill-downs. Each input is the
+            // `PersistentTxo` of the *previous* output that this tx
+            // consumed — tapping it surfaces where the funds came
+            // from (address, originating tx, amount). No stable
+            // input index column lives on `PersistentTxo`, so rows
+            // are ordered by their canonical outpoint string for
+            // determinism.
+            Section {
+                if record.inputs.isEmpty {
+                    Text("None")
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                } else {
+                    ForEach(record.inputs.sorted { $0.outpointHex < $1.outpointHex }) { txo in
+                        NavigationLink(destination: TxoStorageDetailView(record: txo)) {
+                            txoRowLabel(txo, indexLabel: "prev")
+                        }
+                    }
+                }
+            } header: {
+                Text("Inputs (\(record.inputs.count))")
             }
             Section("Timestamps") {
                 FieldRow(label: "Created", value: dateString(record.createdAt))
@@ -1495,6 +1532,69 @@ struct TransactionStorageDetailView: View {
         }
         .navigationTitle("Transaction")
         .navigationBarTitleDisplayMode(.inline)
+    }
+
+    /// Two-line row label for an input / output cell. Top line:
+    /// `<vout-or-prev>  <amount>  <spent-pill>`. Bottom line: the
+    /// 36-byte outpoint hex (so user can copy to a block explorer)
+    /// followed by the address when present. Address line stays
+    /// truncated-middle so a long Base58 doesn't push the right edge
+    /// off the screen.
+    @ViewBuilder
+    private func txoRowLabel(
+        _ txo: PersistentTxo,
+        indexLabel: String
+    ) -> some View {
+        VStack(alignment: .leading, spacing: 2) {
+            HStack(spacing: 6) {
+                Text(indexLabel)
+                    .font(.caption2.monospaced())
+                    .foregroundColor(.secondary)
+                Text(txo.formattedAmount)
+                    .font(.caption)
+                if txo.isSpent {
+                    Text("spent")
+                        .font(.caption2)
+                        .padding(.horizontal, 5)
+                        .padding(.vertical, 1)
+                        .background(Color.red.opacity(0.15))
+                        .foregroundColor(.red)
+                        .clipShape(Capsule())
+                }
+                if txo.isCoinbase {
+                    Text("coinbase")
+                        .font(.caption2)
+                        .padding(.horizontal, 5)
+                        .padding(.vertical, 1)
+                        .background(Color.orange.opacity(0.15))
+                        .foregroundColor(.orange)
+                        .clipShape(Capsule())
+                }
+                if txo.isInstantLocked {
+                    Text("IS")
+                        .font(.caption2)
+                        .padding(.horizontal, 5)
+                        .padding(.vertical, 1)
+                        .background(Color.green.opacity(0.15))
+                        .foregroundColor(.green)
+                        .clipShape(Capsule())
+                }
+                Spacer()
+            }
+            Text(txo.outpointHex)
+                .font(.caption2.monospaced())
+                .foregroundColor(.secondary)
+                .lineLimit(1)
+                .truncationMode(.middle)
+            if !txo.address.isEmpty {
+                Text(txo.address)
+                    .font(.caption2.monospaced())
+                    .foregroundColor(.secondary)
+                    .lineLimit(1)
+                    .truncationMode(.middle)
+            }
+        }
+        .padding(.vertical, 2)
     }
 }
 


### PR DESCRIPTION
## Issue being fixed or feature implemented

**Three loosely-related improvements bundled on this branch.** Stack as you read:

1. **rust-dashcore bump** to `c6cbe78e`. Picks up two upstream commits, both about preserving SPV's buffered headers across peer disconnects so we don't lose the in-flight header batch on every reconnect.

2. **Transactions list UX** — the SwiftData Transactions explorer was previously a 1,484-row dump with no way to find anything. Adds search by txid (canonical block-explorer hex), direction filter (All / In / Out / Internal / CoinJoin), and a type filter that surfaces every special-tx variant the FFI ships (Classic / providers / asset lock / asset unlock / coinbase / quorum commitment / mnhf signal). Non-classic txs get a small purple pill on the row so they stand out at a glance. Companion change on the per-tx detail screen: the two count-only "Outputs/Inputs" rows expand into per-TXO drill-downs that link to `TxoStorageDetailView`, with status pills (`spent` / `coinbase` / `IS`) and amount surfaced inline.

3. **Spending-tx ↔ spent-TXO reconciliation fix.** Diagnosed during a regression where a wallet's `PersistentTxo` would stay `isSpent = false` even though a known `PersistentTransaction` had spent it. Root cause is in `key_wallet::record_transaction`: `input_details` only includes inputs whose previous output is in `self.utxos` at processing time, so an out-of-order arrival (or a mid-sync restart that didn't repopulate the in-memory utxo map) drops the spent-outpoint signal silently and `markUtxoSpent` is never called Swift-side.

## What was done?

### Bump (`Cargo.toml`, `Cargo.lock`)

Workspace deps moved from `e2e8fcf85…` to `c6cbe78e8…`. Two upstream commits in the bump:
- `c6cbe78e` — merge of `fix/preserve-buffered-headers-on-disconnect` into `v0.42-platform-nightly`
- `6ae8662b` — `fix(dash-spv): preserve buffered block headers across disconnect`

### Transactions list filters (`StorageModelListViews.swift`)

- `.searchable(...)` bar matching against `txidHex` (byte-reversed canonical form).
- Segmented direction picker: `All / In / Out / Internal / CoinJoin`. The model carries all four variants of `TransactionDirection`; previously only `Incoming` / `Outgoing` were addressable.
- `Menu` type picker listing the ten Debug-formatted strings the FFI ships (`Classic Transaction`, `Asset Lock Transaction`, etc.). The legacy `\"Standard\"` placeholder rows are normalised to `Classic Transaction` for matching so older rows don't get filtered out by the Classic option.
- Header shows `(visible / total)` whenever any filter is active; empty result hits a `ContentUnavailableView` with hint copy.

### Transaction detail input/output drill-downs (`StorageRecordDetailViews.swift`)

`TransactionStorageDetailView` previously rendered `Outputs N` / `Inputs N` count rows with no further detail. Now:

- Outputs rendered per-row, sorted by vout, each row a `NavigationLink` to `TxoStorageDetailView`.
- Inputs rendered per-row, sorted by outpoint hex (no input-index column on `PersistentTxo`), each likewise a NavigationLink.
- Per-row label is two/three lines: index label (`vout N` for outputs, `prev` for inputs), amount, status pills (`spent`/`coinbase`/`IS`), 36-byte outpoint hex, and address when present.

### Spending-tx ↔ spent-TXO reconciliation (`core_wallet_types.rs`, `PersistentPendingInput.swift`, `PlatformWalletPersistenceHandler.swift`)

**Rust side** (`core_wallet_types.rs`):
- `TransactionRecordFFI` gains `input_outpoints: *mut OutPointFFI` + `input_outpoints_count: usize`. Populated from `tr.transaction.input.iter()` directly, so the slice survives even when the wallet's in-memory `self.utxos` didn't classify the input as ours at processing time. Coinbase txs emit empty.
- Free path drops the new array.

**Swift side** — new SwiftData model `PersistentPendingInput` (indexed on `outpoint`, cascade-deleted from `PersistentTransaction.pendingInputs`) carries the deferred spend signal when the matching TXO hasn't been upserted yet. Stores `spendingTxid` alongside the relationship so the entry stays usable if the parent tx hasn't faulted in.

Reconciliation flow:

- `upsertTransaction` walks the new `input_outpoints` slice. For each input outpoint: if a matching `PersistentTxo` exists, set `isSpent = true` and link `spendingTransaction`; else write a `PersistentPendingInput` row.
- `upsertUtxo`, after creating/updating the row, drains any `PersistentPendingInput` rows keyed on its outpoint, stamping `isSpent` + `spendingTransaction` in the same pass.
- Legacy `markUtxoSpent` (the original `utxos_spent` slice path) also clears matching pending rows so they don't linger.
- Container schema + `DashSchemaV1` register the new model.

The mechanism is order-symmetric: spend signals route through the side table whenever arrival order doesn't match dependency order, so the linkage lands regardless of which side comes first.

## How Has This Been Tested?

- `./build_ios.sh --target sim` → BUILD SUCCEEDED
- `cargo check -p platform-wallet -p platform-wallet-ffi` → clean
- `cargo fmt --all`
- Manual smoke: opened the Transactions list on a wallet with ~1,500 records and verified the search/filter/picker all narrow correctly; tapped through the per-tx detail to confirm input/output rows drill into the matching `TxoStorageDetailView`.

**Not yet covered:**
- The reconciliation fix is forward-only; existing already-broken linkage in a long-running wallet won't auto-repair until the next sync touches the affected tx. A backfill (probably an FFI helper that returns input outpoints for a raw tx blob, then a one-shot pass over `PersistentTransaction`) is a follow-up.
- Address-pool gap-limit extension events still don't fire from rust-dashcore — separate upstream PR queued.

## Breaking Changes

None. `TransactionRecordFFI` is an additive C-ABI extension (new trailing fields); existing callers will get the array as null/zero-count. New SwiftData model is additive — older stores upgrade via the lightweight migration path.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [ ] I have made corresponding changes to the documentation if needed

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved handling of transaction inputs when referenced outputs are pending
  * Added searchable and filterable transaction list view with direction and type filters
  * Enhanced transaction detail view with inputs and outputs sections displaying spending status and amount information

<!-- end of auto-generated comment: release notes by coderabbit.ai -->