### PR TITLE
fix(swift-sdk): persist addresses derived by gap-limit extension

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1568,7 +1568,7 @@ dependencies = [
 [[package]]
 name = "dash-network"
 version = "0.42.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=c6cbe78e8194020dcab30d8886e5425a24cc8ef2#c6cbe78e8194020dcab30d8886e5425a24cc8ef2"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=fe2476611fcf72d6f36f1154a39a2f9af3b6a248#fe2476611fcf72d6f36f1154a39a2f9af3b6a248"
 dependencies = [
  "bincode",
  "bincode_derive",
@@ -1579,7 +1579,7 @@ dependencies = [
 [[package]]
 name = "dash-network-seeds"
 version = "0.42.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=c6cbe78e8194020dcab30d8886e5425a24cc8ef2#c6cbe78e8194020dcab30d8886e5425a24cc8ef2"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=fe2476611fcf72d6f36f1154a39a2f9af3b6a248#fe2476611fcf72d6f36f1154a39a2f9af3b6a248"
 dependencies = [
  "dash-network",
 ]
@@ -1656,7 +1656,7 @@ dependencies = [
 [[package]]
 name = "dash-spv"
 version = "0.42.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=c6cbe78e8194020dcab30d8886e5425a24cc8ef2#c6cbe78e8194020dcab30d8886e5425a24cc8ef2"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=fe2476611fcf72d6f36f1154a39a2f9af3b6a248#fe2476611fcf72d6f36f1154a39a2f9af3b6a248"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1684,7 +1684,7 @@ dependencies = [
 [[package]]
 name = "dash-spv-ffi"
 version = "0.42.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=c6cbe78e8194020dcab30d8886e5425a24cc8ef2#c6cbe78e8194020dcab30d8886e5425a24cc8ef2"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=fe2476611fcf72d6f36f1154a39a2f9af3b6a248#fe2476611fcf72d6f36f1154a39a2f9af3b6a248"
 dependencies = [
  "cbindgen 0.29.2",
  "clap",
@@ -1703,7 +1703,7 @@ dependencies = [
 [[package]]
 name = "dashcore"
 version = "0.42.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=c6cbe78e8194020dcab30d8886e5425a24cc8ef2#c6cbe78e8194020dcab30d8886e5425a24cc8ef2"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=fe2476611fcf72d6f36f1154a39a2f9af3b6a248#fe2476611fcf72d6f36f1154a39a2f9af3b6a248"
 dependencies = [
  "anyhow",
  "base64-compat",
@@ -1729,12 +1729,12 @@ dependencies = [
 [[package]]
 name = "dashcore-private"
 version = "0.42.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=c6cbe78e8194020dcab30d8886e5425a24cc8ef2#c6cbe78e8194020dcab30d8886e5425a24cc8ef2"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=fe2476611fcf72d6f36f1154a39a2f9af3b6a248#fe2476611fcf72d6f36f1154a39a2f9af3b6a248"
 
 [[package]]
 name = "dashcore-rpc"
 version = "0.42.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=c6cbe78e8194020dcab30d8886e5425a24cc8ef2#c6cbe78e8194020dcab30d8886e5425a24cc8ef2"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=fe2476611fcf72d6f36f1154a39a2f9af3b6a248#fe2476611fcf72d6f36f1154a39a2f9af3b6a248"
 dependencies = [
  "dashcore-rpc-json",
  "hex",
@@ -1747,7 +1747,7 @@ dependencies = [
 [[package]]
 name = "dashcore-rpc-json"
 version = "0.42.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=c6cbe78e8194020dcab30d8886e5425a24cc8ef2#c6cbe78e8194020dcab30d8886e5425a24cc8ef2"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=fe2476611fcf72d6f36f1154a39a2f9af3b6a248#fe2476611fcf72d6f36f1154a39a2f9af3b6a248"
 dependencies = [
  "bincode",
  "dashcore",
@@ -1762,7 +1762,7 @@ dependencies = [
 [[package]]
 name = "dashcore_hashes"
 version = "0.42.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=c6cbe78e8194020dcab30d8886e5425a24cc8ef2#c6cbe78e8194020dcab30d8886e5425a24cc8ef2"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=fe2476611fcf72d6f36f1154a39a2f9af3b6a248#fe2476611fcf72d6f36f1154a39a2f9af3b6a248"
 dependencies = [
  "bincode",
  "dashcore-private",
@@ -3811,7 +3811,7 @@ dependencies = [
 [[package]]
 name = "key-wallet"
 version = "0.42.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=c6cbe78e8194020dcab30d8886e5425a24cc8ef2#c6cbe78e8194020dcab30d8886e5425a24cc8ef2"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=fe2476611fcf72d6f36f1154a39a2f9af3b6a248#fe2476611fcf72d6f36f1154a39a2f9af3b6a248"
 dependencies = [
  "aes",
  "async-trait",
@@ -3839,7 +3839,7 @@ dependencies = [
 [[package]]
 name = "key-wallet-ffi"
 version = "0.42.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=c6cbe78e8194020dcab30d8886e5425a24cc8ef2#c6cbe78e8194020dcab30d8886e5425a24cc8ef2"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=fe2476611fcf72d6f36f1154a39a2f9af3b6a248#fe2476611fcf72d6f36f1154a39a2f9af3b6a248"
 dependencies = [
  "cbindgen 0.29.2",
  "dash-network",
@@ -3855,7 +3855,7 @@ dependencies = [
 [[package]]
 name = "key-wallet-manager"
 version = "0.42.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=c6cbe78e8194020dcab30d8886e5425a24cc8ef2#c6cbe78e8194020dcab30d8886e5425a24cc8ef2"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=fe2476611fcf72d6f36f1154a39a2f9af3b6a248#fe2476611fcf72d6f36f1154a39a2f9af3b6a248"
 dependencies = [
  "async-trait",
  "bincode",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,15 +49,15 @@ members = [
 ]
 
 [workspace.dependencies]
-dashcore = { git = "https://github.com/dashpay/rust-dashcore", rev = "c6cbe78e8194020dcab30d8886e5425a24cc8ef2" }
-dash-network-seeds = { git = "https://github.com/dashpay/rust-dashcore", rev = "c6cbe78e8194020dcab30d8886e5425a24cc8ef2" }
-dash-spv = { git = "https://github.com/dashpay/rust-dashcore", rev = "c6cbe78e8194020dcab30d8886e5425a24cc8ef2" }
-dash-spv-ffi = { git = "https://github.com/dashpay/rust-dashcore", rev = "c6cbe78e8194020dcab30d8886e5425a24cc8ef2" }
-key-wallet = { git = "https://github.com/dashpay/rust-dashcore", rev = "c6cbe78e8194020dcab30d8886e5425a24cc8ef2" }
-key-wallet-ffi = { git = "https://github.com/dashpay/rust-dashcore", rev = "c6cbe78e8194020dcab30d8886e5425a24cc8ef2" }
-key-wallet-manager = { git = "https://github.com/dashpay/rust-dashcore", rev = "c6cbe78e8194020dcab30d8886e5425a24cc8ef2" }
-dash-network = { git = "https://github.com/dashpay/rust-dashcore", rev = "c6cbe78e8194020dcab30d8886e5425a24cc8ef2" }
-dashcore-rpc = { git = "https://github.com/dashpay/rust-dashcore", rev = "c6cbe78e8194020dcab30d8886e5425a24cc8ef2" }
+dashcore = { git = "https://github.com/dashpay/rust-dashcore", rev = "fe2476611fcf72d6f36f1154a39a2f9af3b6a248" }
+dash-network-seeds = { git = "https://github.com/dashpay/rust-dashcore", rev = "fe2476611fcf72d6f36f1154a39a2f9af3b6a248" }
+dash-spv = { git = "https://github.com/dashpay/rust-dashcore", rev = "fe2476611fcf72d6f36f1154a39a2f9af3b6a248" }
+dash-spv-ffi = { git = "https://github.com/dashpay/rust-dashcore", rev = "fe2476611fcf72d6f36f1154a39a2f9af3b6a248" }
+key-wallet = { git = "https://github.com/dashpay/rust-dashcore", rev = "fe2476611fcf72d6f36f1154a39a2f9af3b6a248" }
+key-wallet-ffi = { git = "https://github.com/dashpay/rust-dashcore", rev = "fe2476611fcf72d6f36f1154a39a2f9af3b6a248" }
+key-wallet-manager = { git = "https://github.com/dashpay/rust-dashcore", rev = "fe2476611fcf72d6f36f1154a39a2f9af3b6a248" }
+dash-network = { git = "https://github.com/dashpay/rust-dashcore", rev = "fe2476611fcf72d6f36f1154a39a2f9af3b6a248" }
+dashcore-rpc = { git = "https://github.com/dashpay/rust-dashcore", rev = "fe2476611fcf72d6f36f1154a39a2f9af3b6a248" }
 
 # Optimize heavy crypto crates even in dev/test builds so that
 # Halo 2 proof generation and verification run at near-release speed.

--- a/packages/rs-platform-wallet-ffi/src/persistence.rs
+++ b/packages/rs-platform-wallet-ffi/src/persistence.rs
@@ -466,6 +466,49 @@ impl PlatformWalletPersistence for FFIPersister {
 
         // Send core wallet changeset (accounts, transactions, UTXOs).
         if let Some(ref core_cs) = changeset.core {
+            // Fan out gap-limit-extension addresses BEFORE the wallet
+            // changeset itself: the changeset's UTXOs reference these
+            // addresses, and the Swift-side `upsertUtxo`'s
+            // `coreAddress` link lookup is keyed on the address row
+            // existing. Emitting the pool snapshot first means a
+            // brand-new TXO landing on a freshly-derived address
+            // finds the matching `PersistentCoreAddress` in the same
+            // changeset round and the cascade-delete chain stays
+            // intact. Reuses `on_persist_account_address_pools_fn`
+            // so the Swift side handles both registration-time emit
+            // and event-time emit through `persistAccountAddresses`
+            // — single Swift code path covers both.
+            if !core_cs.addresses_derived.is_empty() {
+                if let Some(cb) = self.callbacks.on_persist_account_address_pools_fn {
+                    match build_address_pools_from_derived(&core_cs.addresses_derived) {
+                        Ok((pools, _address_storage, _string_storage)) => {
+                            let result = unsafe {
+                                cb(
+                                    self.callbacks.context,
+                                    wallet_id.as_ptr(),
+                                    pools.as_ptr(),
+                                    pools.len(),
+                                )
+                            };
+                            drop(pools);
+                            drop(_address_storage);
+                            drop(_string_storage);
+                            if result != 0 {
+                                eprintln!(
+                                    "Derived-address persistence callback returned error code {}",
+                                    result
+                                );
+                                round_success = false;
+                            }
+                        }
+                        Err(e) => {
+                            eprintln!("Failed to encode derived address pool entries: {}", e);
+                            round_success = false;
+                        }
+                    }
+                }
+            }
+
             if let Some(cb) = self.callbacks.on_persist_wallet_changeset_fn {
                 let ffi_cs = WalletChangeSetFFI::from_changeset(core_cs);
                 let result = unsafe { cb(self.callbacks.context, wallet_id.as_ptr(), &ffi_cs) };
@@ -1130,6 +1173,147 @@ fn build_core_address_entry_ffi(
         address_base58: address_ptr,
         derivation_path: path_ptr,
     })
+}
+
+/// Bucket a slice of upstream-emitted `DerivedAddress` entries into the
+/// same `AccountAddressPoolFFI` shape `build_address_pools_for_callback`
+/// produces, so the event-driven gap-limit-extension flow can fan out
+/// through the existing `on_persist_account_address_pools_fn` pipeline
+/// rather than introducing a parallel callback.
+///
+/// Each upstream entry already carries `(account_type, pool_type,
+/// derivation_index, address, public_key)`; we group on
+/// `(account_type, pool_type)` so a single block that pushed the
+/// gap-limit boundary on multiple pools (e.g. an internal change
+/// receive that extends Internal AND a separate external receive that
+/// extends External) emits one pool snapshot per pool variant.
+///
+/// `derivation_path` is intentionally empty on this path —
+/// `key_wallet_manager::DerivedAddress` deliberately omits it ("consumers
+/// can recompute deterministically from `(account_type, pool_type,
+/// derivation_index)` rather than shipping a redundant string"). The
+/// next full pool snapshot (registration-time emit, or a follow-up
+/// path that has access to the wallet manager) overwrites with the
+/// canonical BIP32 string. Empty is safe: `PersistentCoreAddress.address`
+/// stays the authoritative join key, and the storage explorer just
+/// renders an empty derivation-path field for these rows until the
+/// follow-up emit lands.
+#[allow(clippy::type_complexity)]
+fn build_address_pools_from_derived(
+    derived: &[platform_wallet::DerivedAddress],
+) -> Result<
+    (
+        Vec<AccountAddressPoolFFI>,
+        Vec<Vec<CoreAddressEntryFFI>>,
+        Vec<CString>,
+    ),
+    String,
+> {
+    use std::collections::BTreeMap;
+    if derived.is_empty() {
+        return Ok((Vec::new(), Vec::new(), Vec::new()));
+    }
+
+    // Bucket key: (account_type, pool_type). Preserve arrival order
+    // within a bucket — the upstream `project_derived_addresses`
+    // already deduped by `(account_type, pool_type, derivation_index)`,
+    // so two entries in the same bucket here always have distinct
+    // indices.
+    let mut buckets: BTreeMap<(usize, AddressPoolType), Vec<&platform_wallet::DerivedAddress>> =
+        BTreeMap::new();
+    // We can't use AccountType as the BTreeMap key directly (no `Ord`
+    // upstream), so keep an account-type index per bucket and look it
+    // up by the discriminant order entries arrive in.
+    let mut account_types: Vec<AccountType> = Vec::new();
+    let mut account_type_to_idx: Vec<(AccountType, usize)> = Vec::new();
+    for d in derived {
+        let idx = account_type_to_idx
+            .iter()
+            .find(|(at, _)| *at == d.account_type)
+            .map(|(_, i)| *i)
+            .unwrap_or_else(|| {
+                let i = account_types.len();
+                account_types.push(d.account_type);
+                account_type_to_idx.push((d.account_type, i));
+                i
+            });
+        buckets.entry((idx, d.pool_type)).or_default().push(d);
+    }
+
+    let mut owned_strings: Vec<CString> = Vec::new();
+    let mut address_storage: Vec<Vec<CoreAddressEntryFFI>> = Vec::with_capacity(buckets.len());
+    let mut pools: Vec<AccountAddressPoolFFI> = Vec::with_capacity(buckets.len());
+
+    for ((account_idx, pool_type), bucket) in buckets {
+        let account_type = account_types[account_idx];
+        let pool_tag = match pool_type {
+            AddressPoolType::External => AddressPoolTypeTagFFI::External,
+            AddressPoolType::Internal => AddressPoolTypeTagFFI::Internal,
+            AddressPoolType::Absent => AddressPoolTypeTagFFI::Absent,
+            AddressPoolType::AbsentHardened => AddressPoolTypeTagFFI::AbsentHardened,
+        } as u8;
+        let is_platform_payment = matches!(account_type, AccountType::PlatformPayment { .. });
+
+        let mut pool_entries: Vec<CoreAddressEntryFFI> = Vec::with_capacity(bucket.len());
+        for d in bucket {
+            // Re-render the address. PlatformPayment uses DIP-0018
+            // bech32m; everything else base58check (matching
+            // `build_core_address_entry_ffi`'s logic).
+            let rendered_address = if is_platform_payment {
+                let network = *d.address.network();
+                let converted: Result<PlatformAddress, _> =
+                    PlatformAddress::try_from(d.address.clone());
+                converted
+                    .map(|p| p.to_bech32m_string(network))
+                    .unwrap_or_else(|_| d.address.to_string())
+            } else {
+                d.address.to_string()
+            };
+            let address_c = CString::new(rendered_address)
+                .map_err(|e| format!("derived address contained NUL byte: {}", e))?;
+            // Empty derivation_path placeholder — see fn doc-comment
+            // for rationale.
+            let path_c = CString::new("").expect("empty CString construction cannot fail");
+            let address_ptr = address_c.as_ptr();
+            let path_ptr = path_c.as_ptr();
+            owned_strings.push(address_c);
+            owned_strings.push(path_c);
+
+            pool_entries.push(CoreAddressEntryFFI {
+                public_key: d.public_key,
+                has_public_key: true,
+                pool_type_tag: pool_tag,
+                address_index: d.derivation_index,
+                // Newly-derived addresses haven't been seen in any
+                // tx yet (they came from gap-limit extension,
+                // not from observing the address as used). The
+                // upstream `mark_address_used` flow that triggered
+                // this derivation marks the OLD address that got
+                // matched, not these new ones; their `is_used`
+                // stays false until SPV later observes a tx paying
+                // to one of them.
+                is_used: false,
+                balance: 0,
+                address_base58: address_ptr,
+                derivation_path: path_ptr,
+            });
+        }
+
+        let empty_xpub: &[u8] = &[];
+        let spec = build_account_spec_ffi(&account_type, empty_xpub);
+        let addresses_ptr = pool_entries.as_ptr();
+        let addresses_count = pool_entries.len();
+        address_storage.push(pool_entries);
+
+        pools.push(AccountAddressPoolFFI {
+            account: spec,
+            pool_type_tag: pool_tag,
+            addresses_ptr,
+            addresses_count,
+        });
+    }
+
+    Ok((pools, address_storage, owned_strings))
 }
 
 /// RAII drop-guard that invokes the paired free callback on exit, so

--- a/packages/rs-platform-wallet-ffi/src/persistence.rs
+++ b/packages/rs-platform-wallet-ffi/src/persistence.rs
@@ -1175,51 +1175,6 @@ fn build_core_address_entry_ffi(
     })
 }
 
-/// Render the BIP32 derivation path string for a derived address from
-/// the structured triple `(account_type, pool_type, derivation_index)`
-/// + the network the address lives on. Mirrors what the address pool
-/// itself does at derive time: take the account-level prefix from
-/// [`AccountType::derivation_path`], append the pool's chain
-/// segment (External → `/0`, Internal → `/1`, Absent → no chain
-/// segment, AbsentHardened → no chain segment), then append the
-/// leaf index (hardened only for AbsentHardened pools).
-///
-/// Returns `None` when the account-level path can't be resolved
-/// (the typed `derivation_path` returns an `Error` for some account
-/// variants). Callers fall back to an empty path string in that
-/// case — `PersistentCoreAddress.address` stays the authoritative
-/// join key, so an empty path is purely a display-side
-/// degradation.
-fn derivation_path_for_derived_address(
-    derived: &platform_wallet::DerivedAddress,
-) -> Option<String> {
-    use key_wallet::bip32::{ChildNumber, DerivationPath};
-    let network: dash_network::Network = (*derived.address.network()).into();
-    let mut path: DerivationPath = derived.account_type.derivation_path(network).ok()?;
-    let leaf = match derived.pool_type {
-        AddressPoolType::External => {
-            // m/.../0/<index>
-            path = path.child(ChildNumber::from_normal_idx(0).ok()?);
-            ChildNumber::from_normal_idx(derived.derivation_index).ok()?
-        }
-        AddressPoolType::Internal => {
-            // m/.../1/<index>
-            path = path.child(ChildNumber::from_normal_idx(1).ok()?);
-            ChildNumber::from_normal_idx(derived.derivation_index).ok()?
-        }
-        AddressPoolType::Absent => {
-            // m/.../<index>
-            ChildNumber::from_normal_idx(derived.derivation_index).ok()?
-        }
-        AddressPoolType::AbsentHardened => {
-            // m/.../<index'>
-            ChildNumber::from_hardened_idx(derived.derivation_index).ok()?
-        }
-    };
-    path = path.child(leaf);
-    Some(path.to_string())
-}
-
 /// Bucket a slice of upstream-emitted `DerivedAddress` entries into the
 /// same `AccountAddressPoolFFI` shape `build_address_pools_for_callback`
 /// produces, so the event-driven gap-limit-extension flow can fan out
@@ -1234,12 +1189,12 @@ fn derivation_path_for_derived_address(
 /// extends External) emits one pool snapshot per pool variant.
 ///
 /// `derivation_path` is computed deterministically per-entry by
-/// [`derivation_path_for_derived_address`] from the same
-/// `(account_type, pool_type, derivation_index)` triple the pool
-/// itself uses at derive time. Falls back to an empty string only
-/// when the account-level path can't be resolved (`AccountType`
-/// variants whose `derivation_path` errors); the address string
-/// remains the authoritative join key in that case.
+/// [`platform_wallet::derivation_path_string_for_derived_address`]
+/// from the same `(account_type, pool_type, derivation_index)`
+/// triple the pool itself uses at derive time. Falls back to an
+/// empty string only when the account-level path can't be resolved
+/// (`AccountType` variants whose `derivation_path` errors); the
+/// address string remains the authoritative join key in that case.
 #[allow(clippy::type_complexity)]
 fn build_address_pools_from_derived(
     derived: &[platform_wallet::DerivedAddress],
@@ -1313,14 +1268,17 @@ fn build_address_pools_from_derived(
             };
             let address_c = CString::new(rendered_address)
                 .map_err(|e| format!("derived address contained NUL byte: {}", e))?;
-            // Compute the BIP32 derivation path deterministically
-            // from `(account_type, pool_type, derivation_index)` —
-            // mirrors what the address pool itself does at derive
-            // time. Falls back to an empty string only when the
-            // account-level path can't be resolved (some non-Standard
-            // variants); the address string remains the authoritative
-            // join key on the persister side either way.
-            let path_str = derivation_path_for_derived_address(d).unwrap_or_default();
+            // Render the BIP32 derivation path via the
+            // platform-wallet helper. Path-shape decisions are
+            // protocol-aware and live next to other key-derivation
+            // logic in the non-FFI crate; the FFI shim's job is
+            // only to marshal the resulting string into the C ABI.
+            // Falls back to an empty string for non-Standard
+            // variants whose account-level path doesn't render —
+            // the address string remains the authoritative join
+            // key on the persister side regardless.
+            let path_str =
+                platform_wallet::derivation_path_string_for_derived_address(d).unwrap_or_default();
             let path_c = CString::new(path_str)
                 .map_err(|e| format!("derivation path contained NUL byte: {}", e))?;
             let address_ptr = address_c.as_ptr();

--- a/packages/rs-platform-wallet-ffi/src/persistence.rs
+++ b/packages/rs-platform-wallet-ffi/src/persistence.rs
@@ -1175,6 +1175,51 @@ fn build_core_address_entry_ffi(
     })
 }
 
+/// Render the BIP32 derivation path string for a derived address from
+/// the structured triple `(account_type, pool_type, derivation_index)`
+/// + the network the address lives on. Mirrors what the address pool
+/// itself does at derive time: take the account-level prefix from
+/// [`AccountType::derivation_path`], append the pool's chain
+/// segment (External → `/0`, Internal → `/1`, Absent → no chain
+/// segment, AbsentHardened → no chain segment), then append the
+/// leaf index (hardened only for AbsentHardened pools).
+///
+/// Returns `None` when the account-level path can't be resolved
+/// (the typed `derivation_path` returns an `Error` for some account
+/// variants). Callers fall back to an empty path string in that
+/// case — `PersistentCoreAddress.address` stays the authoritative
+/// join key, so an empty path is purely a display-side
+/// degradation.
+fn derivation_path_for_derived_address(
+    derived: &platform_wallet::DerivedAddress,
+) -> Option<String> {
+    use key_wallet::bip32::{ChildNumber, DerivationPath};
+    let network: dash_network::Network = (*derived.address.network()).into();
+    let mut path: DerivationPath = derived.account_type.derivation_path(network).ok()?;
+    let leaf = match derived.pool_type {
+        AddressPoolType::External => {
+            // m/.../0/<index>
+            path = path.child(ChildNumber::from_normal_idx(0).ok()?);
+            ChildNumber::from_normal_idx(derived.derivation_index).ok()?
+        }
+        AddressPoolType::Internal => {
+            // m/.../1/<index>
+            path = path.child(ChildNumber::from_normal_idx(1).ok()?);
+            ChildNumber::from_normal_idx(derived.derivation_index).ok()?
+        }
+        AddressPoolType::Absent => {
+            // m/.../<index>
+            ChildNumber::from_normal_idx(derived.derivation_index).ok()?
+        }
+        AddressPoolType::AbsentHardened => {
+            // m/.../<index'>
+            ChildNumber::from_hardened_idx(derived.derivation_index).ok()?
+        }
+    };
+    path = path.child(leaf);
+    Some(path.to_string())
+}
+
 /// Bucket a slice of upstream-emitted `DerivedAddress` entries into the
 /// same `AccountAddressPoolFFI` shape `build_address_pools_for_callback`
 /// produces, so the event-driven gap-limit-extension flow can fan out
@@ -1188,16 +1233,13 @@ fn build_core_address_entry_ffi(
 /// receive that extends Internal AND a separate external receive that
 /// extends External) emits one pool snapshot per pool variant.
 ///
-/// `derivation_path` is intentionally empty on this path —
-/// `key_wallet_manager::DerivedAddress` deliberately omits it ("consumers
-/// can recompute deterministically from `(account_type, pool_type,
-/// derivation_index)` rather than shipping a redundant string"). The
-/// next full pool snapshot (registration-time emit, or a follow-up
-/// path that has access to the wallet manager) overwrites with the
-/// canonical BIP32 string. Empty is safe: `PersistentCoreAddress.address`
-/// stays the authoritative join key, and the storage explorer just
-/// renders an empty derivation-path field for these rows until the
-/// follow-up emit lands.
+/// `derivation_path` is computed deterministically per-entry by
+/// [`derivation_path_for_derived_address`] from the same
+/// `(account_type, pool_type, derivation_index)` triple the pool
+/// itself uses at derive time. Falls back to an empty string only
+/// when the account-level path can't be resolved (`AccountType`
+/// variants whose `derivation_path` errors); the address string
+/// remains the authoritative join key in that case.
 #[allow(clippy::type_complexity)]
 fn build_address_pools_from_derived(
     derived: &[platform_wallet::DerivedAddress],
@@ -1271,9 +1313,16 @@ fn build_address_pools_from_derived(
             };
             let address_c = CString::new(rendered_address)
                 .map_err(|e| format!("derived address contained NUL byte: {}", e))?;
-            // Empty derivation_path placeholder — see fn doc-comment
-            // for rationale.
-            let path_c = CString::new("").expect("empty CString construction cannot fail");
+            // Compute the BIP32 derivation path deterministically
+            // from `(account_type, pool_type, derivation_index)` —
+            // mirrors what the address pool itself does at derive
+            // time. Falls back to an empty string only when the
+            // account-level path can't be resolved (some non-Standard
+            // variants); the address string remains the authoritative
+            // join key on the persister side either way.
+            let path_str = derivation_path_for_derived_address(d).unwrap_or_default();
+            let path_c = CString::new(path_str)
+                .map_err(|e| format!("derivation path contained NUL byte: {}", e))?;
             let address_ptr = address_c.as_ptr();
             let path_ptr = path_c.as_ptr();
             owned_strings.push(address_c);

--- a/packages/rs-platform-wallet/src/address_paths.rs
+++ b/packages/rs-platform-wallet/src/address_paths.rs
@@ -1,0 +1,73 @@
+//! BIP32 path rendering for upstream-emitted [`DerivedAddress`]
+//! event payloads.
+//!
+//! The upstream `key_wallet_manager::DerivedAddress` event payload
+//! deliberately omits the rendered derivation-path string —
+//! consumers that need one are expected to recompute it
+//! deterministically from `(account_type, pool_type,
+//! derivation_index)`. This module is the canonical recomputation
+//! site so the path-shape rules live next to other protocol-aware
+//! address logic in `platform-wallet`, NOT in the FFI shim. The FFI
+//! crates' job is marshaling C ABI shapes; deciding what a path
+//! looks like is a `key-wallet`/`platform-wallet`-level concern.
+//!
+//! The layout mirrors what
+//! `AddressPool::generate_address_at_index` produces internally:
+//!
+//! | Pool             | Path layout                  |
+//! |------------------|------------------------------|
+//! | `External`       | `<account-prefix>/0/<index>` |
+//! | `Internal`       | `<account-prefix>/1/<index>` |
+//! | `Absent`         | `<account-prefix>/<index>`   |
+//! | `AbsentHardened` | `<account-prefix>/<index>'`  |
+//!
+//! `<account-prefix>` comes from
+//! [`AccountType::derivation_path`](key_wallet::account::AccountType::derivation_path).
+//! Network is read directly off `DerivedAddress.address.network()`
+//! so callers don't have to thread it.
+//!
+//! Returns `None` only for account variants whose
+//! `derivation_path()` returns `Err` (some non-Standard variants
+//! that have no enumerable BIP32 prefix). Callers that just want a
+//! display string fall back to the empty string in that case;
+//! correctness is unaffected because the address itself is the
+//! authoritative join key downstream.
+
+use key_wallet::bip32::{ChildNumber, DerivationPath};
+use key_wallet::managed_account::address_pool::AddressPoolType;
+use key_wallet::Network;
+
+use crate::DerivedAddress;
+
+/// Render the BIP32 derivation path for a `DerivedAddress` event
+/// payload. See module-level docs for the path layout rules.
+pub fn derivation_path_for_derived_address(derived: &DerivedAddress) -> Option<DerivationPath> {
+    // `dashcore::Address::network()` returns `&Network` and
+    // `key_wallet::Network` is a re-export of `dashcore::Network`,
+    // so this is a single deref — no conversion needed.
+    let network: Network = *derived.address.network();
+    let mut path: DerivationPath = derived.account_type.derivation_path(network).ok()?;
+    let leaf = match derived.pool_type {
+        AddressPoolType::External => {
+            path = path.child(ChildNumber::from_normal_idx(0).ok()?);
+            ChildNumber::from_normal_idx(derived.derivation_index).ok()?
+        }
+        AddressPoolType::Internal => {
+            path = path.child(ChildNumber::from_normal_idx(1).ok()?);
+            ChildNumber::from_normal_idx(derived.derivation_index).ok()?
+        }
+        AddressPoolType::Absent => ChildNumber::from_normal_idx(derived.derivation_index).ok()?,
+        AddressPoolType::AbsentHardened => {
+            ChildNumber::from_hardened_idx(derived.derivation_index).ok()?
+        }
+    };
+    path = path.child(leaf);
+    Some(path)
+}
+
+/// Display-string variant of
+/// [`derivation_path_for_derived_address`]. Returns `None` for the
+/// same cases.
+pub fn derivation_path_string_for_derived_address(derived: &DerivedAddress) -> Option<String> {
+    derivation_path_for_derived_address(derived).map(|p| p.to_string())
+}

--- a/packages/rs-platform-wallet/src/changeset/changeset.rs
+++ b/packages/rs-platform-wallet/src/changeset/changeset.rs
@@ -121,6 +121,20 @@ pub struct CoreChangeSet {
     /// durable filter-batch sync checkpoint to this value. Monotonic-max
     /// on merge.
     pub synced_height: Option<u32>,
+
+    /// Addresses freshly derived as a side effect of processing the
+    /// records in this batch — i.e. `WalletEvent::TransactionDetected.
+    /// addresses_derived` and `WalletEvent::BlockProcessed.
+    /// addresses_derived`. The persister mirrors these into its
+    /// address-pool table (e.g. `PersistentCoreAddress` on the Swift
+    /// side) so UTXOs landing on freshly-derived addresses can be
+    /// linked back to the canonical pool row instead of being
+    /// orphaned at the `coreAddress` link. De-duplicated on merge by
+    /// `(account_type, pool_type, derivation_index)` — same key the
+    /// upstream `project_derived_addresses` uses, so two records in
+    /// the same flush both pushing the same gap-limit boundary
+    /// collapse to one entry.
+    pub addresses_derived: Vec<key_wallet_manager::DerivedAddress>,
 }
 
 impl Merge for CoreChangeSet {
@@ -152,6 +166,34 @@ impl Merge for CoreChangeSet {
         if let Some(h) = other.synced_height {
             self.synced_height = Some(self.synced_height.map_or(h, |existing| existing.max(h)));
         }
+
+        // Derived-address dedup. Within a single `WalletEvent` the
+        // upstream `project_derived_addresses` already deduped on
+        // `(account_type, pool_type, derivation_index)`, but a flush
+        // can fold multiple events together (TransactionDetected +
+        // BlockProcessed for the same wallet over a sync round), and
+        // a tx in one event can push the same boundary as a tx in
+        // another. Build a fast-lookup set from current entries, then
+        // append only entries we haven't seen yet — preserves arrival
+        // order so the persister's writes line up with the same
+        // derivation order the wallet's pool sees.
+        if !other.addresses_derived.is_empty() {
+            let mut seen: std::collections::HashSet<(
+                key_wallet::account::AccountType,
+                key_wallet::managed_account::address_pool::AddressPoolType,
+                u32,
+            )> = self
+                .addresses_derived
+                .iter()
+                .map(|d| (d.account_type, d.pool_type, d.derivation_index))
+                .collect();
+            for d in other.addresses_derived {
+                let key = (d.account_type, d.pool_type, d.derivation_index);
+                if seen.insert(key) {
+                    self.addresses_derived.push(d);
+                }
+            }
+        }
     }
 
     fn is_empty(&self) -> bool {
@@ -161,6 +203,7 @@ impl Merge for CoreChangeSet {
             && self.instant_locks_for_non_final_records.is_empty()
             && self.last_processed_height.is_none()
             && self.synced_height.is_none()
+            && self.addresses_derived.is_empty()
     }
 }
 

--- a/packages/rs-platform-wallet/src/changeset/core_bridge.rs
+++ b/packages/rs-platform-wallet/src/changeset/core_bridge.rs
@@ -124,13 +124,24 @@ async fn build_core_changeset(
     event: &WalletEvent,
 ) -> CoreChangeSet {
     match event {
-        WalletEvent::TransactionDetected { record, .. } => {
+        WalletEvent::TransactionDetected {
+            record,
+            addresses_derived,
+            ..
+        } => {
             // Derive UTXO deltas BEFORE moving the record into `records`
             // so we still have the per-record borrows.
             CoreChangeSet {
                 new_utxos: derive_new_utxos(record),
                 spent_utxos: derive_spent_utxos(record),
                 records: vec![(**record).clone()],
+                // Mirror the upstream-emitted derived addresses
+                // through to the persister so newly-extended pool
+                // rows are written transactionally with the tx that
+                // triggered the extension. See
+                // `CoreChangeSet.addresses_derived` for the cascade-
+                // link rationale.
+                addresses_derived: addresses_derived.clone(),
                 ..CoreChangeSet::default()
             }
         }
@@ -156,6 +167,7 @@ async fn build_core_changeset(
             inserted,
             updated,
             matured,
+            addresses_derived,
             ..
         } => {
             let mut cs = CoreChangeSet::default();
@@ -173,6 +185,10 @@ async fn build_core_changeset(
             cs.records.extend(updated.iter().cloned());
             cs.records.extend(matured.iter().cloned());
             cs.last_processed_height = Some(*height);
+            // Pool extensions triggered by any record in this block.
+            // Already deduped upstream by `project_derived_addresses`;
+            // `Merge` re-dedupes if multiple events fold together.
+            cs.addresses_derived = addresses_derived.clone();
             cs
         }
         WalletEvent::SyncHeightAdvanced { height, .. } => CoreChangeSet {

--- a/packages/rs-platform-wallet/src/lib.rs
+++ b/packages/rs-platform-wallet/src/lib.rs
@@ -12,6 +12,7 @@
 #![allow(clippy::doc_lazy_continuation)]
 #![allow(clippy::doc_overindented_list_items)]
 
+pub mod address_paths;
 pub mod broadcaster;
 pub mod changeset;
 pub mod error;
@@ -28,6 +29,12 @@ pub use key_wallet::wallet::managed_wallet_info::asset_lock_builder::AssetLockFu
 // project `CoreChangeSet.addresses_derived` without taking an extra
 // direct dependency on `key-wallet-manager`.
 pub use key_wallet_manager::DerivedAddress;
+// Re-export the path-rendering helpers so FFI shims and other
+// consumers can render `DerivedAddress.derivation_path` without
+// reimplementing the layout rules.
+pub use address_paths::{
+    derivation_path_for_derived_address, derivation_path_string_for_derived_address,
+};
 pub use manager::identity_sync::{
     IdentitySyncManager, IdentityTokenSyncInfo, IdentityTokenSyncState,
     DEFAULT_SYNC_INTERVAL_SECS as IDENTITY_SYNC_DEFAULT_INTERVAL_SECS,

--- a/packages/rs-platform-wallet/src/lib.rs
+++ b/packages/rs-platform-wallet/src/lib.rs
@@ -23,6 +23,11 @@ pub mod wallet;
 pub use error::PlatformWalletError;
 pub use events::{PlatformEventHandler, PlatformEventManager};
 pub use key_wallet::wallet::managed_wallet_info::asset_lock_builder::AssetLockFundingType;
+// Surface the upstream `DerivedAddress` event payload through this
+// crate so downstream FFI consumers (rs-platform-wallet-ffi) can
+// project `CoreChangeSet.addresses_derived` without taking an extra
+// direct dependency on `key-wallet-manager`.
+pub use key_wallet_manager::DerivedAddress;
 pub use manager::identity_sync::{
     IdentitySyncManager, IdentityTokenSyncInfo, IdentityTokenSyncState,
     DEFAULT_SYNC_INTERVAL_SECS as IDENTITY_SYNC_DEFAULT_INTERVAL_SECS,


### PR DESCRIPTION
## Issue being fixed or feature implemented

Wallets accumulated `PersistentTxo` rows whose `coreAddress` link was nil for every UTXO landing on an address that was added to the in-memory pool by gap-limit maintenance after a tx match. The cascade-delete chain `Wallet → Account → CoreAddress → Txo` runs through `coreAddress`, so a nil link orphaned those TXOs against any future `delete wallet` and made the storage explorer flag every row of an active account with `no coreAddress link`.

Root cause was upstream: `WalletEvent` had no slot for "addresses just derived as a side effect of processing this tx," so the platform-wallet event adapter and downstream Swift persister never learned about freshly-derived addresses, and `PersistentCoreAddress` rows for them were never written.

The upstream half landed in rust-dashcore tip `fe247661` — `WalletEvent::TransactionDetected` and `WalletEvent::BlockProcessed` now carry an `addresses_derived: Vec<DerivedAddress>` slice deduped on `(account_type, pool_type, derivation_index)`. This PR is the downstream half: bumping the pin and wiring the new field through `CoreChangeSet` → FFI → Swift.

## What was done?

### 1. rust-dashcore bump (`Cargo.toml`, `Cargo.lock`)

Workspace deps move from `c6cbe78e8…` to `fe2476611…` (tip of `v0.42-platform-nightly`). Seven commits in the bump window, headline ones:

- `2ceea91f` `feat(dash-spv-ffi): expose addresses_derived on Wallet event callbacks`
- `4e6ee4bf` `review(key-wallet-manager): per-record derivations, observability, real dedup test`
- `ee0adcd5` `refactor(key-wallet-manager): drop redundant derivation_path from DerivedAddress`
- `507cff26` `feat(key-wallet-manager): carry addresses_derived on TransactionDetected / BlockProcessed`
- `a9fb28f3` `refactor(key-wallet): drop unused first_loaded_at and total_transactions from WalletMetadata`

### 2. Plumb `addresses_derived` through `CoreChangeSet` (`changeset.rs`, `core_bridge.rs`, `lib.rs`)

- `CoreChangeSet` gains `addresses_derived: Vec<DerivedAddress>`. `Merge::merge` re-dedupes on `(account_type, pool_type, derivation_index)` so multiple events folding into one flush collapse correctly. `is_empty` covers the new field.
- `build_core_changeset` reads the slice off `WalletEvent::TransactionDetected` and `WalletEvent::BlockProcessed`. `TransactionInstantLocked` and `SyncHeightAdvanced` don't trigger derivation upstream and stay unchanged.
- `key_wallet_manager::DerivedAddress` re-exported from `platform-wallet` so downstream FFI consumers don't need a direct `key-wallet-manager` dep.

### 3. Project through the FFI persister (`persistence.rs`)

- `FFIPersister::store` fires `on_persist_account_address_pools_fn` for `core_cs.addresses_derived` BEFORE the wallet-changeset emit. TXOs in the same flush reference these addresses, and Swift's `upsertUtxo` keys its `coreAddress` link lookup on the address row already existing, so emitting addresses first keeps the cascade-delete chain intact.
- `build_address_pools_from_derived` buckets entries by `(account_type, pool_type)` and produces the same `AccountAddressPoolFFI` / `CoreAddressEntryFFI` shape the existing registration-time emit produces. **No new FFI surface or Swift handler** — both registration-time and event-time emits drain through `persistAccountAddresses`.
- `derivation_path_for_derived_address` recomputes the BIP32 path string deterministically from `(account_type, pool_type, derivation_index)`, mirroring what `AddressPool::generate_address_at_index` does. Account-level prefix from `AccountType::derivation_path(network)`; pool segment is `/0` (External), `/1` (Internal), or absent (Absent / AbsentHardened); leaf hardened only on AbsentHardened. Network is read off `DerivedAddress.address.network()`.

### Result

For a wallet processing a tx that pushes the gap-limit boundary: the address pool extends in Rust, an event fires, the platform-wallet adapter projects, the FFI persister fans out one `AccountAddressPoolFFI` per `(account, pool)`, Swift's `persistAccountAddresses` upserts `PersistentCoreAddress` rows AND backfills the `coreAddress` link on any TXOs at that address — atomically with the tx record that triggered the derivation.

## How Has This Been Tested?

- `cargo check -p platform-wallet -p platform-wallet-ffi` → clean
- `cargo fmt --all`
- `./build_ios.sh --target sim` → BUILD SUCCEEDED

Manual end-to-end on a recovered wallet that previously showed `no coreAddress link` on every UTXO is the next verification step (tracked separately).

## Breaking Changes

None.

- `CoreChangeSet` gained a new field with `Default::default() = Vec::new()`; existing code that constructs it via struct-update syntax or `..CoreChangeSet::default()` continues to compile.
- No FFI shape changes — reuses the existing `AccountAddressPoolFFI` / `on_persist_account_address_pools_fn` callback.
- The cargo update reaches a new tip on the same `v0.42-platform-nightly` tracking branch we already pin to.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [ ] I have made corresponding changes to the documentation if needed

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced address pool management: Wallet now automatically captures and persists snapshots of newly derived addresses when processing transactions and blocks, improving state tracking consistency and address management reliability.

* **Chores**
  * Updated core workspace dependencies to the latest revision.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->