### PR TITLE
fix(swift-sdk): scope UI by active network and add multi-wallet recovery sheet

### DIFF
--- a/packages/swift-sdk/Sources/SwiftDashSDK/Persistence/Models/PersistentDataContract.swift
+++ b/packages/swift-sdk/Sources/SwiftDashSDK/Persistence/Models/PersistentDataContract.swift
@@ -4,6 +4,11 @@ import SwiftData
 /// SwiftData model for persisting data contracts
 @Model
 public final class PersistentDataContract {
+    /// Index `networkRaw` so the static `predicate(networkRaw:)` and
+    /// `tokensPredicate(networkRaw:)` helpers — plus every per-network
+    /// list view — can index-scan instead of table-scan.
+    #Index<PersistentDataContract>([\.networkRaw])
+
     @Attribute(.unique) public var id: Data
     public var name: String
     public var serializedContract: Data

--- a/packages/swift-sdk/Sources/SwiftDashSDK/Persistence/Models/PersistentDocument.swift
+++ b/packages/swift-sdk/Sources/SwiftDashSDK/Persistence/Models/PersistentDocument.swift
@@ -4,6 +4,11 @@ import SwiftData
 /// SwiftData model for persisting documents
 @Model
 public final class PersistentDocument {
+    /// Index `networkRaw` to keep per-network document scans
+    /// index-served. The static `predicate(contractId:network:)` helper
+    /// and every UI list view filter by the active network.
+    #Index<PersistentDocument>([\.networkRaw])
+
     // Primary key
     @Attribute(.unique) public var documentId: String
 

--- a/packages/swift-sdk/Sources/SwiftDashSDK/Persistence/Models/PersistentIdentity.swift
+++ b/packages/swift-sdk/Sources/SwiftDashSDK/Persistence/Models/PersistentIdentity.swift
@@ -4,6 +4,11 @@ import SwiftData
 /// SwiftData model for persisting Identity data
 @Model
 public final class PersistentIdentity {
+    /// Index `networkRaw` so per-network scans (`#Predicate { $0.networkRaw == raw }`)
+    /// don't degrade to a table scan. Every UI surface that lists
+    /// identities filters by the active network.
+    #Index<PersistentIdentity>([\.networkRaw])
+
     // MARK: - Core Properties
     @Attribute(.unique) public var identityId: Data
     public var balance: Int64

--- a/packages/swift-sdk/Sources/SwiftDashSDK/Persistence/Models/PersistentPendingInput.swift
+++ b/packages/swift-sdk/Sources/SwiftDashSDK/Persistence/Models/PersistentPendingInput.swift
@@ -39,10 +39,17 @@ import SwiftData
 /// upsert outright.
 @Model
 public final class PersistentPendingInput {
-    /// 36-byte outpoint key (`PersistentTxo.makeOutpoint`). Indexed
-    /// for the per-outpoint reconciliation lookup that runs on every
-    /// `upsertUtxo`.
-    #Index<PersistentPendingInput>([\.outpoint])
+    /// Two single-column indexes:
+    ///   * `outpoint` — the per-outpoint reconciliation lookup that
+    ///     runs on every `upsertUtxo`.
+    ///   * `walletId` — per-wallet pending-input scans (cleanup when
+    ///     a wallet is removed, the storage explorer's network
+    ///     scope, "long-lived non-zero pending count" diagnostics).
+    ///
+    /// SwiftData allows only a single `#Index` macro per model;
+    /// passing multiple key-path arrays declares multiple separate
+    /// indexes from one macro call.
+    #Index<PersistentPendingInput>([\.outpoint], [\.walletId])
     public var outpoint: Data
 
     /// Position of this input in the spending transaction's input

--- a/packages/swift-sdk/Sources/SwiftDashSDK/Persistence/Models/PersistentPlatformAddress.swift
+++ b/packages/swift-sdk/Sources/SwiftDashSDK/Persistence/Models/PersistentPlatformAddress.swift
@@ -21,6 +21,12 @@ import SwiftData
 /// type tag 14).
 @Model
 public final class PersistentPlatformAddress {
+    /// Index `walletId` so per-wallet platform-address scans —
+    /// `predicate(walletId:)`, the storage explorer's network scope
+    /// fallback, BLAST-sync re-upsert paths — hit an index instead
+    /// of scanning the whole table.
+    #Index<PersistentPlatformAddress>([\.walletId])
+
     /// DIP-0018 bech32m-encoded address (`dash1…` / `tdash1…`). Unique
     /// across the SwiftData store — a collision would imply a wallet-
     /// id / derivation path collision.

--- a/packages/swift-sdk/Sources/SwiftDashSDK/Persistence/Models/PersistentTokenBalance.swift
+++ b/packages/swift-sdk/Sources/SwiftDashSDK/Persistence/Models/PersistentTokenBalance.swift
@@ -4,6 +4,11 @@ import SwiftData
 /// SwiftData model for persisting token balance data
 @Model
 public final class PersistentTokenBalance {
+    /// Index `networkRaw` for per-network balance scans. Token-balance
+    /// rows are aggregated per-identity per-token; UI surfaces always
+    /// scope to the active network.
+    #Index<PersistentTokenBalance>([\.networkRaw])
+
     // MARK: - Core Properties
     public var tokenId: String
     public var identityId: Data

--- a/packages/swift-sdk/Sources/SwiftDashSDK/Persistence/Models/PersistentTxo.swift
+++ b/packages/swift-sdk/Sources/SwiftDashSDK/Persistence/Models/PersistentTxo.swift
@@ -11,6 +11,15 @@ import SwiftData
 /// stays whole.
 @Model
 public final class PersistentTxo {
+    /// Index `walletId` so per-wallet TXO scans — the canonical
+    /// "show every TXO (and, by union of `transaction` +
+    /// `spendingTransaction`, every transaction) that touches wallet
+    /// W" path — hit an index instead of scanning the entire TXO
+    /// table. The denorm is what makes the predicate translatable
+    /// to SQL in the first place; this just makes the resulting
+    /// query fast at scale.
+    #Index<PersistentTxo>([\.walletId])
+
     /// Outpoint: 36 raw bytes (32-byte txid in wire orientation +
     /// 4-byte vout little-endian) — the standard Bitcoin outpoint
     /// serialization. Unique identifier stored explicitly so

--- a/packages/swift-sdk/Sources/SwiftDashSDK/Persistence/Models/PersistentWallet.swift
+++ b/packages/swift-sdk/Sources/SwiftDashSDK/Persistence/Models/PersistentWallet.swift
@@ -13,6 +13,12 @@ import SwiftData
 /// Per-account totals continue to live on `PersistentAccount`.
 @Model
 public final class PersistentWallet {
+    /// Index `networkRaw` so per-network wallet scans (used everywhere
+    /// from the network-scoped storage explorer to the per-network
+    /// "is there a wallet on this chain yet" lookups) don't degrade
+    /// to a table scan.
+    #Index<PersistentWallet>([\.networkRaw])
+
     /// 32-byte wallet ID (SHA256 of root public key).
     @Attribute(.unique) public var walletId: Data
     /// Network this wallet belongs to. `nil` means "not yet known" —

--- a/packages/swift-sdk/SwiftExampleApp/SwiftExampleApp/ContentView.swift
+++ b/packages/swift-sdk/SwiftExampleApp/SwiftExampleApp/ContentView.swift
@@ -300,6 +300,12 @@ struct ContentView: View {
             }
         }
 
+        // Per-wallet auth failures accumulate so the user sees every
+        // one when the loop ends rather than the last one clobbering
+        // earlier messages. Mirrors the same `[String]` pattern
+        // `deleteStoredMnemonics` uses for cross-wallet error
+        // aggregation.
+        var perWalletFailures: [String] = []
         for entry in separate {
             let reason = "Re-derive \"\(entry.displayName)\" from its stored recovery phrase."
             switch await runAuthPrompt(reason: reason) {
@@ -321,9 +327,17 @@ struct ContentView: View {
                 showDeletePrompt = true
                 return
             case .failed(let detail):
-                recoveryError = "Authorization failed: \(detail)"
+                perWalletFailures.append("\(entry.displayName): \(detail)")
                 continue
             }
+        }
+        if !perWalletFailures.isEmpty {
+            // One combined prompt at the end, joining every wallet's
+            // failure into one message so none get lost.
+            let prefix = perWalletFailures.count == 1
+                ? "Authorization failed: "
+                : "Authorization failed for \(perWalletFailures.count) wallets:\n"
+            recoveryError = prefix + perWalletFailures.joined(separator: "\n")
         }
 
         // Drop the entries we just recreated. If the user skipped

--- a/packages/swift-sdk/SwiftExampleApp/SwiftExampleApp/ContentView.swift
+++ b/packages/swift-sdk/SwiftExampleApp/SwiftExampleApp/ContentView.swift
@@ -312,7 +312,13 @@ struct ContentView: View {
                 // wallet — but keep going through the rest.
                 continue
             case .unavailable(let detail):
+                // Same shape as the shared-branch handler: surface
+                // the error AND route into the keep/delete prompt
+                // so the user has a path forward instead of being
+                // left with stale orphans queued internally with
+                // no UI to act on them.
                 recoveryError = "Authentication is unavailable on this device: \(detail)"
+                showDeletePrompt = true
                 return
             case .failed(let detail):
                 recoveryError = "Authorization failed: \(detail)"
@@ -397,9 +403,14 @@ struct ContentView: View {
         // `walletManager.createWallet` API still takes a single
         // network. Multi-network support is a TODO on the Rust side
         // — when it lands, `metadata?.resolvedNetworks` is already
-        // there to feed in directly.
+        // there to feed in directly. Final fallback is the user's
+        // active network rather than a hard-coded testnet — the
+        // only rows that hit the fallback are legacy / corrupted
+        // metadata blobs, and re-deriving them on whatever network
+        // the user is currently looking at matches their context
+        // far better than silently restoring on testnet.
         let restoredNetwork: Network =
-            entry.network ?? metadata?.resolvedNetworks.first ?? .testnet
+            entry.network ?? metadata?.resolvedNetworks.first ?? platformState.currentNetwork
         let restoredBirthHeight = metadata?.birthHeight
 
         do {

--- a/packages/swift-sdk/SwiftExampleApp/SwiftExampleApp/ContentView.swift
+++ b/packages/swift-sdk/SwiftExampleApp/SwiftExampleApp/ContentView.swift
@@ -26,12 +26,16 @@ struct ContentView: View {
 
     @State private var selectedTab: RootTab = .sync
 
-    // Orphan-mnemonic recovery flow. Prompts fire sequentially: one
-    // wallet at a time, starting with the head of `pendingOrphans`.
-    // `showRecoverAlert` drives the primary (Authorize / No) alert and
-    // `showDeletePrompt` drives the secondary (Recreate / Delete) one.
-    @State private var pendingOrphans: [Data] = []
+    // Orphan-mnemonic recovery flow. The whole batch surfaces in one
+    // alert + one sheet now: the primary "Recover Wallets?" alert
+    // gates the flow on user intent, the sheet collects per-wallet
+    // "Same pin code" choices, and a single auth covers every shared
+    // wallet (with separate auth prompts only for the rows the user
+    // unchecks). `showDeletePrompt` drives the "Keep these Wallets?"
+    // fallback when the user picks No.
+    @State private var orphanEntries: [OrphanWalletEntry] = []
     @State private var showRecoverAlert = false
+    @State private var showRecoverSheet = false
     @State private var showDeletePrompt = false
     @State private var recoveryInProgress = false
     @State private var recoveryError: String?
@@ -122,33 +126,39 @@ struct ContentView: View {
             .onChange(of: persistentWallets.count) { _, _ in
                 checkForOrphanMnemonic()
             }
-            .alert("Recover Wallet?", isPresented: $showRecoverAlert) {
+            .alert(recoverAlertTitle, isPresented: $showRecoverAlert) {
                 Button("Authorize") {
-                    Task { await authorizeAndRecover() }
+                    showRecoverSheet = true
                 }
                 Button("No", role: .cancel) {
                     showDeletePrompt = true
                 }
             } message: {
-                Text(
-                    "A wallet mnemonic is stored on this device, but no "
-                    + "wallet data was found. Authorize to re-derive the "
-                    + "wallet's public keys from the stored mnemonic."
+                Text(recoverAlertMessage)
+            }
+            .sheet(isPresented: $showRecoverSheet) {
+                RecoverWalletsSheet(
+                    entries: orphanEntries,
+                    onAuthorize: { choices in
+                        Task { await authorizeAndRecover(choices: choices) }
+                    },
+                    onCancel: {
+                        // Sheet cancel = "give me the keep/delete
+                        // path" so the user isn't trapped in a loop
+                        // between the alert and the sheet.
+                        showDeletePrompt = true
+                    }
                 )
             }
-            .alert("Keep this Wallet?", isPresented: $showDeletePrompt) {
+            .alert(deletePromptTitle, isPresented: $showDeletePrompt) {
                 Button("Recreate") {
                     showRecoverAlert = true
                 }
-                Button("Delete", role: .destructive) {
-                    deleteStoredMnemonic()
+                Button(deletePromptDestructiveLabel, role: .destructive) {
+                    deleteStoredMnemonics()
                 }
             } message: {
-                Text(
-                    "Recreate will re-derive the wallet from the stored "
-                    + "mnemonic. Delete will permanently remove the "
-                    + "mnemonic from this device."
-                )
+                Text(deletePromptMessage)
             }
             .alert(
                 "Recovery Failed",
@@ -167,54 +177,177 @@ struct ContentView: View {
 
     // MARK: - Orphan mnemonic recovery
 
+    private var recoverAlertTitle: String {
+        orphanEntries.count <= 1 ? "Recover Wallet?" : "Recover Wallets?"
+    }
+
+    private var recoverAlertMessage: String {
+        let count = orphanEntries.count
+        if count <= 1 {
+            return "A wallet mnemonic is stored on this device, but no "
+                + "wallet data was found. Authorize to re-derive the "
+                + "wallet's public keys from the stored mnemonic."
+        }
+        return "\(count) wallet mnemonics are stored on this device, but "
+            + "no matching wallet data was found. Authorize to re-derive "
+            + "their public keys from the stored mnemonics."
+    }
+
+    private var deletePromptTitle: String {
+        orphanEntries.count <= 1 ? "Keep this Wallet?" : "Keep these Wallets?"
+    }
+
+    private var deletePromptMessage: String {
+        if orphanEntries.count <= 1 {
+            return "Recreate will re-derive the wallet from the stored "
+                + "mnemonic. Delete will permanently remove the "
+                + "mnemonic from this device."
+        }
+        return "Recreate will re-derive every wallet from its stored "
+            + "mnemonic. Delete will permanently remove "
+            + "\(orphanEntries.count) mnemonics from this device."
+    }
+
+    private var deletePromptDestructiveLabel: String {
+        orphanEntries.count <= 1 ? "Delete" : "Delete All"
+    }
+
     /// Detect keychain mnemonics with no matching `PersistentWallet`
-    /// row and kick off the recovery alert for each in turn. Runs
-    /// once per launch after the first tab becomes visible.
-    /// Subsequent `persistentWallets` changes re-evaluate so
-    /// newly-recovered wallets drop out of the queue and we advance
-    /// to the next orphan.
+    /// row and prime the recovery flow. Runs once per launch after
+    /// the first tab becomes visible. Subsequent `persistentWallets`
+    /// changes re-evaluate so already-recovered wallets drop out of
+    /// the orphan set and the alert reflects the new count.
     @MainActor
     private func checkForOrphanMnemonic() {
         guard isInitialized, !orphanCheckDone else { return }
-        orphanCheckDone = true
 
         let storage = WalletStorage()
         let keychainIds = (try? storage.listWalletIdsWithMnemonic()) ?? []
         let localIds = Set(persistentWallets.map(\.walletId))
         let orphans = keychainIds.filter { !localIds.contains($0) }
 
-        guard !orphans.isEmpty else { return }
-        pendingOrphans = orphans
+        guard !orphans.isEmpty else {
+            // Nothing to do; mark the check done so we don't re-scan
+            // every time a wallet is added/removed mid-session.
+            orphanCheckDone = true
+            return
+        }
+
+        // Resolve display name + network for each orphan up-front so
+        // the alert + sheet render with stable, recognizable rows
+        // instead of bare 32-byte ids. Metadata reads are best-effort
+        // — older installs predate the metadata blob and just fall
+        // back to the generic placeholder name.
+        orphanEntries = orphans.map { walletId in
+            let metadata = (try? storage.metadata(for: walletId)) ?? nil
+            let displayName: String = {
+                guard let raw = metadata?.name else { return "Recovered Wallet" }
+                let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+                return trimmed.isEmpty ? "Recovered Wallet" : trimmed
+            }()
+            return OrphanWalletEntry(
+                walletId: walletId,
+                displayName: displayName,
+                network: metadata?.resolvedNetworks.first,
+                samePinCode: true
+            )
+        }
+        orphanCheckDone = true
         showRecoverAlert = true
     }
 
-    /// Drop the just-handled orphan from the queue and re-arm the
-    /// primary alert for the next one (if any).
+    /// Run the auth + re-derivation pipeline for the user's choices.
+    /// All wallets with `samePinCode == true` collapse into a single
+    /// `LAContext.evaluatePolicy` call; everything else gets its own
+    /// prompt. A cancel / policy failure on the shared prompt aborts
+    /// the shared group and bounces to the keep/delete decision; a
+    /// failure on a per-wallet prompt skips just that wallet.
     @MainActor
-    private func advanceToNextOrphan() {
-        if !pendingOrphans.isEmpty {
-            pendingOrphans.removeFirst()
+    private func authorizeAndRecover(choices: [OrphanWalletEntry]) async {
+        guard !recoveryInProgress else { return }
+        recoveryInProgress = true
+        defer { recoveryInProgress = false }
+
+        let shared = choices.filter(\.samePinCode)
+        let separate = choices.filter { !$0.samePinCode }
+        var recovered: Set<Data> = []
+
+        if !shared.isEmpty {
+            let reason = shared.count == 1
+                ? "Re-derive your wallet from the stored recovery phrase."
+                : "Re-derive \(shared.count) wallets from the stored recovery phrases."
+            switch await runAuthPrompt(reason: reason) {
+            case .authorized:
+                for entry in shared {
+                    if await recoverWallet(entry: entry) {
+                        recovered.insert(entry.walletId)
+                    }
+                }
+            case .denied:
+                // User actively bailed on the shared prompt —
+                // surface the keep/delete decision and let them
+                // pick again from there.
+                showDeletePrompt = true
+                return
+            case .unavailable(let detail):
+                recoveryError = "Authentication is unavailable on this device: \(detail)"
+                showDeletePrompt = true
+                return
+            case .failed(let detail):
+                recoveryError = "Authorization failed: \(detail)"
+                showDeletePrompt = true
+                return
+            }
         }
-        if !pendingOrphans.isEmpty {
-            // Small defer so SwiftUI has a chance to tear the
-            // previous alert down before presenting the next.
+
+        for entry in separate {
+            let reason = "Re-derive \"\(entry.displayName)\" from its stored recovery phrase."
+            switch await runAuthPrompt(reason: reason) {
+            case .authorized:
+                if await recoverWallet(entry: entry) {
+                    recovered.insert(entry.walletId)
+                }
+            case .denied:
+                // Skip this one — user said no to this specific
+                // wallet — but keep going through the rest.
+                continue
+            case .unavailable(let detail):
+                recoveryError = "Authentication is unavailable on this device: \(detail)"
+                return
+            case .failed(let detail):
+                recoveryError = "Authorization failed: \(detail)"
+                continue
+            }
+        }
+
+        // Drop the entries we just recreated. If the user skipped
+        // some (cancelled per-wallet auths) the remaining orphans
+        // stay queued — the next `checkForOrphanMnemonic()` (after
+        // `persistentWallets` reactivity fires) will re-arm the
+        // alert with the trimmed set.
+        orphanEntries.removeAll { recovered.contains($0.walletId) }
+        orphanCheckDone = false
+        if !orphanEntries.isEmpty {
+            // Small defer so the sheet dismiss has time to settle
+            // before the alert pops back up.
             Task { @MainActor in
-                try? await Task.sleep(nanoseconds: 200_000_000)
+                try? await Task.sleep(nanoseconds: 250_000_000)
                 showRecoverAlert = true
             }
         }
     }
 
-    /// Authorize via device passcode / biometrics, then fetch the
-    /// keychain-stored mnemonic for the current orphan and re-create
-    /// the wallet.
-    @MainActor
-    private func authorizeAndRecover() async {
-        guard !recoveryInProgress else { return }
-        guard let walletId = pendingOrphans.first else { return }
-        recoveryInProgress = true
-        defer { recoveryInProgress = false }
+    private enum AuthOutcome {
+        case authorized
+        case denied
+        case unavailable(String)
+        case failed(String)
+    }
 
+    /// Single LAContext-backed system prompt. Maps every cancel /
+    /// policy / error path to a typed outcome so callers can decide
+    /// whether to abort or skip.
+    private func runAuthPrompt(reason: String) async -> AuthOutcome {
         let context = LAContext()
         context.localizedCancelTitle = "Cancel"
         var policyError: NSError?
@@ -222,71 +355,54 @@ struct ContentView: View {
             .deviceOwnerAuthentication,
             error: &policyError
         ) else {
-            recoveryError =
-                "Authentication is unavailable on this device: "
-                + (policyError?.localizedDescription ?? "unknown")
-            showDeletePrompt = true
-            return
+            return .unavailable(policyError?.localizedDescription ?? "unknown")
         }
-
         do {
             let authorized = try await context.evaluatePolicy(
                 .deviceOwnerAuthentication,
-                localizedReason: "Re-derive your wallet from the stored recovery phrase."
+                localizedReason: reason
             )
-            guard authorized else {
-                showDeletePrompt = true
-                return
-            }
+            return authorized ? .authorized : .denied
         } catch {
-            // User cancel or policy failure — bounce to the
-            // Keep/Delete choice so they don't lose the path forward.
-            recoveryError = "Authorization failed: \(error.localizedDescription)"
-            showDeletePrompt = true
-            return
+            return .failed(error.localizedDescription)
         }
+    }
 
+    /// Read the keychain mnemonic + metadata for `entry`, then
+    /// re-create the wallet. Returns `true` on success so the caller
+    /// can drop the entry from the orphan set.
+    @MainActor
+    private func recoverWallet(entry: OrphanWalletEntry) async -> Bool {
         let storage = WalletStorage()
         let mnemonic: String
         do {
-            mnemonic = try storage.retrieveMnemonic(for: walletId)
+            mnemonic = try storage.retrieveMnemonic(for: entry.walletId)
         } catch {
             recoveryError = "Failed to read stored mnemonic: \(error.localizedDescription)"
-            return
+            return false
         }
 
-        // Pull the user-facing name + description + networks +
-        // birth height out of the keychain (written alongside the
-        // mnemonic at wallet creation time). If the metadata blob
-        // is missing — older installs that predate this feature —
-        // fall back to the generic "Recovered Wallet" placeholder
-        // and the previous testnet default so the row is still
-        // clickable.
-        let restoredMetadata: WalletKeychainMetadata? =
-            (try? storage.metadata(for: walletId)) ?? nil
+        // Re-fetch metadata at recovery time rather than relying on
+        // what the alert captured — ensures the description /
+        // birth-height carried over reflect the current state of the
+        // keychain blob rather than a possibly-stale snapshot.
+        let metadata = (try? storage.metadata(for: entry.walletId)) ?? nil
         let restoredName: String = {
-            guard let raw = restoredMetadata?.name else { return "Recovered Wallet" }
+            guard let raw = metadata?.name else { return entry.displayName }
             let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
-            return trimmed.isEmpty ? "Recovered Wallet" : trimmed
+            return trimmed.isEmpty ? entry.displayName : trimmed
         }()
-        let restoredDescription: String? = restoredMetadata?.walletDescription
+        let restoredDescription = metadata?.walletDescription
         // First valid stored network wins; the
         // `walletManager.createWallet` API still takes a single
-        // network. Multi-network support is a TODO on the Rust
-        // side (`WalletDetailView.swift:533`) — when it lands the
-        // full `restoredMetadata?.resolvedNetworks` list is
-        // already there to feed in.
+        // network. Multi-network support is a TODO on the Rust side
+        // — when it lands, `metadata?.resolvedNetworks` is already
+        // there to feed in directly.
         let restoredNetwork: Network =
-            restoredMetadata?.resolvedNetworks.first ?? .testnet
-        let restoredBirthHeight: UInt32? = restoredMetadata?.birthHeight
+            entry.network ?? metadata?.resolvedNetworks.first ?? .testnet
+        let restoredBirthHeight = metadata?.birthHeight
 
         do {
-            // The `PersistentWallet` row is created by the
-            // persister callback downstream of
-            // `walletManager.createWallet`; we only need to stamp
-            // the `isImported` flag and the carried-over
-            // description / birth height on top of what the
-            // persister wrote.
             let managed = try walletManager.createWallet(
                 mnemonic: mnemonic,
                 network: restoredNetwork,
@@ -304,38 +420,45 @@ struct ContentView: View {
                 // Persisted birth height wins over the synthetic
                 // value the persister stamped from the live SPV
                 // tip — otherwise a recovered wallet would scan
-                // forward from "now" and lose all transactions
-                // older than the recovery moment. Skip the
-                // override only if we have no record (`nil` →
-                // keep whatever the persister wrote).
+                // forward from "now" and lose every transaction
+                // older than the recovery moment.
                 if let stored = restoredBirthHeight {
                     row.birthHeight = stored
                 }
                 try? modelContext.save()
             }
-            advanceToNextOrphan()
+            return true
         } catch {
-            recoveryError = "Failed to recreate wallet: \(error.localizedDescription)"
+            recoveryError = "Failed to recreate \"\(entry.displayName)\": \(error.localizedDescription)"
+            return false
         }
     }
 
-    /// Remove the currently-selected orphan's mnemonic from the
-    /// keychain and advance to the next orphan in the queue. Also
-    /// drops any associated keychain metadata blob so the row is
-    /// fully cleared.
+    /// Drop every queued orphan's mnemonic + metadata from the
+    /// keychain. Best-effort: failures on individual rows surface
+    /// in `recoveryError` but the loop continues so a single bad
+    /// row can't block the rest of the cleanup.
     @MainActor
-    private func deleteStoredMnemonic() {
-        guard let walletId = pendingOrphans.first else { return }
-        do {
-            let storage = WalletStorage()
-            try storage.deleteMnemonic(for: walletId)
-            // Best-effort: metadata follows the mnemonic. If this
-            // fails the metadata row is harmless (it has no secret
-            // material and gets overwritten on the next setMetadata).
-            try? storage.deleteMetadata(for: walletId)
-            advanceToNextOrphan()
-        } catch {
-            recoveryError = "Failed to delete mnemonic: \(error.localizedDescription)"
+    private func deleteStoredMnemonics() {
+        let storage = WalletStorage()
+        var failures: [String] = []
+        for entry in orphanEntries {
+            do {
+                try storage.deleteMnemonic(for: entry.walletId)
+            } catch {
+                failures.append("\(entry.displayName): \(error.localizedDescription)")
+                continue
+            }
+            // Metadata follows the mnemonic. If this fails the row
+            // is harmless (no secret material) and gets overwritten
+            // on the next `setMetadata`.
+            try? storage.deleteMetadata(for: entry.walletId)
+        }
+        orphanEntries.removeAll()
+        if !failures.isEmpty {
+            recoveryError = "Failed to delete mnemonic"
+                + (failures.count == 1 ? "" : "s")
+                + ": " + failures.joined(separator: "; ")
         }
     }
 }

--- a/packages/swift-sdk/SwiftExampleApp/SwiftExampleApp/Core/Views/CoreContentView.swift
+++ b/packages/swift-sdk/SwiftExampleApp/SwiftExampleApp/Core/Views/CoreContentView.swift
@@ -19,14 +19,38 @@ struct CoreContentView: View {
     /// (which only reflects the currently-configured wallet).
     @Query private var platformAddresses: [PersistentPlatformAddress]
 
-    /// Aggregate platform credit balance across every wallet on disk.
-    private var aggregatePlatformBalance: UInt64 {
-        platformAddresses.reduce(0) { $0 + $1.balance }
+    /// All persisted wallets — used as the network-scoping pivot for
+    /// `platformAddresses`. `PersistentPlatformAddress` doesn't carry
+    /// a `networkRaw` column itself; the canonical join is through
+    /// `walletId` to the parent `PersistentWallet.networkRaw`. We
+    /// build a `Set<Data>` for the active network and filter the
+    /// address aggregate against it so switching to local doesn't
+    /// keep showing testnet sums.
+    @Query private var allWallets: [PersistentWallet]
+
+    private var walletIdsOnNetwork: Set<Data> {
+        let raw = platformState.currentNetwork.rawValue
+        return Set(allWallets.lazy
+            .filter { $0.networkRaw == raw }
+            .map(\.walletId))
     }
 
-    /// Addresses with a non-zero balance across every wallet.
+    /// Platform addresses scoped to the active network.
+    private var scopedPlatformAddresses: [PersistentPlatformAddress] {
+        let ids = walletIdsOnNetwork
+        return platformAddresses.filter { ids.contains($0.walletId) }
+    }
+
+    /// Aggregate platform credit balance across every wallet on the
+    /// active network.
+    private var aggregatePlatformBalance: UInt64 {
+        scopedPlatformAddresses.reduce(0) { $0 + $1.balance }
+    }
+
+    /// Addresses with a non-zero balance across every wallet on the
+    /// active network.
     private var aggregateActiveAddressCount: Int {
-        platformAddresses.reduce(0) { $1.balance > 0 ? $0 + 1 : $0 }
+        scopedPlatformAddresses.reduce(0) { $1.balance > 0 ? $0 + 1 : $0 }
     }
 
     // Display helpers

--- a/packages/swift-sdk/SwiftExampleApp/SwiftExampleApp/Core/Views/CreateWalletView.swift
+++ b/packages/swift-sdk/SwiftExampleApp/SwiftExampleApp/Core/Views/CreateWalletView.swift
@@ -251,7 +251,16 @@ struct CreateWalletView: View {
     }
 
     private var hasNetworkSelected: Bool {
-        createForMainnet || createForTestnet || createForDevnet || createForRegtest
+        // Mirror the same visibility gates used when building
+        // `selectedNetworks` below — without this, a stale
+        // `createForRegtest`/`createForDevnet` flag set by
+        // `setupInitialNetworkSelection()` could leave the Create
+        // button enabled while `selectedNetworks` ends up empty,
+        // surfacing a `"No network selected"` error after the tap.
+        createForMainnet ||
+        createForTestnet ||
+        (createForDevnet && shouldShowDevnet) ||
+        (createForRegtest && shouldShowRegtest)
     }
 
     private func setupInitialNetworkSelection() {

--- a/packages/swift-sdk/SwiftExampleApp/SwiftExampleApp/Core/Views/CreateWalletView.swift
+++ b/packages/swift-sdk/SwiftExampleApp/SwiftExampleApp/Core/Views/CreateWalletView.swift
@@ -44,6 +44,14 @@ struct CreateWalletView: View {
         currentNetwork == .devnet
     }
 
+    // Mirror of the devnet rule: regtest is a developer-only
+    // network and the toggle would clutter the create screen on
+    // mainnet/testnet. Showing it only when the active network is
+    // regtest also matches the wallet-info network picker pattern.
+    var shouldShowRegtest: Bool {
+        currentNetwork == .regtest
+    }
+
     var body: some View {
         Form {
             Section {
@@ -93,6 +101,23 @@ struct CreateWalletView: View {
                                 Image(systemName: "network")
                                     .foregroundColor(.green)
                                 Text("Devnet")
+                                    .font(.body)
+                            }
+                        }
+                        .toggleStyle(CheckboxToggleStyle())
+                    }
+
+                    // Mirror Devnet's gating: only render the local
+                    // (regtest) toggle when the user is actually on
+                    // regtest. Without this row there's no path to
+                    // create a regtest wallet from the active-network
+                    // creation flow.
+                    if shouldShowRegtest {
+                        Toggle(isOn: $createForRegtest) {
+                            HStack {
+                                Image(systemName: "network")
+                                    .foregroundColor(.purple)
+                                Text("Local (Regtest)")
                                     .font(.body)
                             }
                         }
@@ -226,7 +251,7 @@ struct CreateWalletView: View {
     }
 
     private var hasNetworkSelected: Bool {
-        createForMainnet || createForTestnet || createForDevnet
+        createForMainnet || createForTestnet || createForDevnet || createForRegtest
     }
 
     private func setupInitialNetworkSelection() {
@@ -284,6 +309,7 @@ struct CreateWalletView: View {
                     createForMainnet ? Network.mainnet : nil,
                     createForTestnet ? Network.testnet : nil,
                     (createForDevnet && shouldShowDevnet) ? Network.devnet : nil,
+                    (createForRegtest && shouldShowRegtest) ? Network.regtest : nil,
                 ].compactMap { $0 }
 
                 guard let platformNetwork = selectedNetworks.first else {

--- a/packages/swift-sdk/SwiftExampleApp/SwiftExampleApp/Core/Views/WalletDetailView.swift
+++ b/packages/swift-sdk/SwiftExampleApp/SwiftExampleApp/Core/Views/WalletDetailView.swift
@@ -202,6 +202,7 @@ struct WalletInfoView: View {
     @State private var mainnetAccountCount: Int? = nil
     @State private var testnetAccountCount: Int? = nil
     @State private var devnetAccountCount: Int? = nil
+    @State private var regtestAccountCount: Int? = nil
 
     // "View Seed Phrase" flow.
     @State private var isAuthorizingSeedPhrase = false
@@ -309,6 +310,25 @@ struct WalletInfoView: View {
                             .disabled(isUpdatingNetworks)
                         }
                     }
+
+                    HStack {
+                        Text("Local (Regtest)")
+                        Spacer()
+                        if regtestEnabled {
+                            Image(systemName: "checkmark.circle.fill")
+                                .foregroundColor(.green)
+                        } else {
+                            Button(action: {
+                                Task {
+                                    await enableNetwork(.regtest)
+                                }
+                            }) {
+                                Image(systemName: "plus.circle")
+                                    .foregroundColor(.blue)
+                            }
+                            .disabled(isUpdatingNetworks)
+                        }
+                    }
                 }
 
                 Section {
@@ -357,6 +377,14 @@ struct WalletInfoView: View {
                             Text("Devnet Accounts")
                             Spacer()
                             Text(devnetAccountCount.map(String.init) ?? "–")
+                                .foregroundColor(.secondary)
+                        }
+                    }
+                    if regtestEnabled {
+                        HStack {
+                            Text("Regtest Accounts")
+                            Spacer()
+                            Text(regtestAccountCount.map(String.init) ?? "–")
                                 .foregroundColor(.secondary)
                         }
                     }
@@ -510,6 +538,7 @@ struct WalletInfoView: View {
         mainnetAccountCount = mainnetEnabled ? count : nil
         testnetAccountCount = testnetEnabled ? count : nil
         devnetAccountCount = devnetEnabled ? count : nil
+        regtestAccountCount = regtestEnabled ? count : nil
     }
 
     private func saveWalletName() {

--- a/packages/swift-sdk/SwiftExampleApp/SwiftExampleApp/Core/Views/WalletsContentView.swift
+++ b/packages/swift-sdk/SwiftExampleApp/SwiftExampleApp/Core/Views/WalletsContentView.swift
@@ -17,10 +17,22 @@ struct WalletsContentView: View {
     @Query private var wallets: [PersistentWallet]
     @State private var showingCreateWallet = false
 
+    /// Wallets on the currently-selected network. The persistent
+    /// store keeps every network's rows so flipping back to testnet
+    /// re-surfaces what was synced there, but the tab only renders
+    /// the wallets tied to `platformState.currentNetwork`. Rows with
+    /// `networkRaw == nil` (legacy / not yet hydrated by the
+    /// persister) drop out — once the persister fills the column in,
+    /// they reappear under the matching network.
+    private var visibleWallets: [PersistentWallet] {
+        let raw = platformState.currentNetwork.rawValue
+        return wallets.filter { $0.networkRaw == raw }
+    }
+
     var body: some View {
         List {
             Section("Wallets (\(platformState.currentNetwork.displayName))") {
-                if wallets.isEmpty {
+                if visibleWallets.isEmpty {
                     VStack(spacing: 12) {
                         Image(systemName: "wallet.pass")
                             .font(.system(size: 40))
@@ -48,7 +60,7 @@ struct WalletsContentView: View {
                     .frame(maxWidth: .infinity)
                     .padding(.vertical, 20)
                 } else {
-                    ForEach(wallets) { wallet in
+                    ForEach(visibleWallets) { wallet in
                         NavigationLink(value: wallet) {
                             WalletRowView(wallet: wallet)
                         }

--- a/packages/swift-sdk/SwiftExampleApp/SwiftExampleApp/SwiftExampleAppApp.swift
+++ b/packages/swift-sdk/SwiftExampleApp/SwiftExampleApp/SwiftExampleAppApp.swift
@@ -92,19 +92,31 @@ struct SwiftExampleAppApp: App {
                 })) { _, _ in
                     rebindWalletScopedServices()
                 }
+                // Rebind on network switch as well — without this,
+                // the balance-sync service stays pinned to whatever
+                // wallet was picked at bootstrap, which leaks the
+                // previous network's Platform Balance / Active
+                // Addresses / Last Sync into the Sync Status tab
+                // for the new network.
+                .onChange(of: platformState.currentNetwork) { _, _ in
+                    rebindWalletScopedServices()
+                }
         }
     }
 
     /// Drive manager-wide BLAST sync state from the set of loaded
-    /// wallets. With no wallets present, sync is stopped and the
-    /// per-wallet `PlatformBalanceSyncService` UI surface is reset.
-    /// Otherwise, we ensure sync is running and bind the balance
-    /// service to `firstWallet` for the single-wallet UI surfaces
-    /// that still expect one focused wallet (detail views reconfigure
-    /// the service per-wallet themselves).
+    /// wallets. With no wallets present *on the active network*,
+    /// sync is stopped and the per-wallet `PlatformBalanceSyncService`
+    /// UI surface is reset — so the Sync Status tab shows zeros for
+    /// a network the user hasn't created a wallet on yet, instead
+    /// of leaking values from a wallet on a different network.
+    /// Otherwise, we bind the balance service to a deterministic
+    /// wallet on that network. (Detail views reconfigure the
+    /// service per-wallet themselves.)
     @MainActor
     private func rebindWalletScopedServices() {
-        guard let wallet = walletManager.firstWallet else {
+        let wallet = firstWalletOnActiveNetwork()
+        guard let wallet else {
             do {
                 try walletManager.stopPlatformAddressSync()
             } catch {
@@ -127,7 +139,7 @@ struct SwiftExampleAppApp: App {
                 try walletManager.startPlatformAddressSync()
             }
             SDKLogger.log(
-                "🔗 BLAST sync running; balance-sync UI bound to wallet \(wallet.walletId.prefix(4).map { String(format: "%02x", $0) }.joined())… (of \(walletManager.wallets.count) loaded)",
+                "🔗 BLAST sync running; balance-sync UI bound to wallet \(wallet.walletId.prefix(4).map { String(format: "%02x", $0) }.joined())… on \(platformState.currentNetwork.displayName) (of \(walletManager.wallets.count) loaded)",
                 minimumLevel: .medium
             )
         } catch {
@@ -135,6 +147,32 @@ struct SwiftExampleAppApp: App {
                 "Failed to bind platform address wallet: \(error.localizedDescription)"
             )
         }
+    }
+
+    /// Lowest-walletId managed wallet that's tagged to
+    /// `platformState.currentNetwork`. The Rust manager doesn't
+    /// track networks per wallet, so the source of truth is the
+    /// SwiftData `PersistentWallet.networkRaw` column — which the
+    /// persister fills in alongside the wallet creation that
+    /// populated `walletManager.wallets`. Returns `nil` when the
+    /// active network has no managed wallet (yet).
+    @MainActor
+    private func firstWalletOnActiveNetwork() -> ManagedPlatformWallet? {
+        let raw = platformState.currentNetwork.rawValue
+        let descriptor = FetchDescriptor<PersistentWallet>(
+            predicate: #Predicate { $0.networkRaw == raw }
+        )
+        let context = modelContainer.mainContext
+        let rows = (try? context.fetch(descriptor)) ?? []
+        // Sort by walletId so the choice is deterministic across
+        // launches — same shape as `PlatformWalletManager.firstWallet`.
+        let sortedIds = rows
+            .map(\.walletId)
+            .sorted { $0.lexicographicallyPrecedes($1) }
+        for id in sortedIds {
+            if let managed = walletManager.wallets[id] { return managed }
+        }
+        return nil
     }
 
     @MainActor

--- a/packages/swift-sdk/SwiftExampleApp/SwiftExampleApp/Views/RecoverWalletsSheet.swift
+++ b/packages/swift-sdk/SwiftExampleApp/SwiftExampleApp/Views/RecoverWalletsSheet.swift
@@ -19,9 +19,9 @@ struct OrphanWalletEntry: Identifiable, Hashable {
 }
 
 /// Sheet that consolidates orphan-mnemonic recovery into a single
-/// surface. Lists every orphan side-by-side with a `Same pin code`
-/// toggle so the user can authorize once for the wallets that share
-/// a passcode, and only get a separate prompt for the rows they
+/// surface. Lists every orphan side-by-side with a `Same PIN` toggle
+/// so the user can authorize once for the wallets that share a
+/// passcode, and only get a separate prompt for the rows they
 /// uncheck.
 ///
 /// All authentication and re-derivation logic lives on the parent
@@ -61,7 +61,7 @@ struct RecoverWalletsSheet: View {
         _localEntries = State(initialValue: entries)
     }
 
-    /// Hide the per-row "Same pin code" toggle when there's only one
+    /// Hide the per-row "Same PIN" toggle when there's only one
     /// orphan — the consolidation choice is meaningless for a single
     /// wallet and the toggle would just clutter the row.
     private var isMultiWallet: Bool { localEntries.count > 1 }
@@ -104,6 +104,7 @@ struct RecoverWalletsSheet: View {
                         onCancel()
                         dismiss()
                     }
+                    .accessibilityIdentifier("recoverWallets.cancelButton")
                 }
                 ToolbarItem(placement: .confirmationAction) {
                     Button("Authorize") {
@@ -111,6 +112,7 @@ struct RecoverWalletsSheet: View {
                         dismiss()
                     }
                     .fontWeight(.semibold)
+                    .accessibilityIdentifier("recoverWallets.authorizeButton")
                 }
             }
         }
@@ -140,7 +142,7 @@ struct RecoverWalletsSheet: View {
             }
             if isMultiWallet {
                 Toggle(isOn: entry.samePinCode) {
-                    Text("Same pin code")
+                    Text("Same PIN")
                         .font(.callout)
                 }
                 .toggleStyle(.switch)
@@ -164,7 +166,7 @@ struct RecoverWalletsSheet: View {
     private var footerHelp: String {
         if separateCount == 0 {
             return "All \(sharedCount) wallets will be authorized in one prompt. "
-                + "Uncheck \"Same pin code\" on any wallet that uses a different code."
+                + "Uncheck \"Same PIN\" on any wallet that uses a different code."
         }
         if sharedCount == 0 {
             return "Each wallet will prompt for its own authorization."

--- a/packages/swift-sdk/SwiftExampleApp/SwiftExampleApp/Views/RecoverWalletsSheet.swift
+++ b/packages/swift-sdk/SwiftExampleApp/SwiftExampleApp/Views/RecoverWalletsSheet.swift
@@ -1,0 +1,187 @@
+import SwiftUI
+import SwiftDashSDK
+
+/// One row in the multi-wallet recovery sheet: the orphan wallet's
+/// stable id, its display name (from keychain metadata), the network
+/// it was originally created on (best-effort), and the user's choice
+/// for whether it shares the primary auth prompt with its siblings.
+///
+/// `samePinCode == true` (default) means "fold this wallet into the
+/// shared authorization round"; `false` means "prompt separately
+/// for this one before re-deriving".
+struct OrphanWalletEntry: Identifiable, Hashable {
+    let walletId: Data
+    let displayName: String
+    let network: Network?
+    var samePinCode: Bool
+
+    var id: Data { walletId }
+}
+
+/// Sheet that consolidates orphan-mnemonic recovery into a single
+/// surface. Lists every orphan side-by-side with a `Same pin code`
+/// toggle so the user can authorize once for the wallets that share
+/// a passcode, and only get a separate prompt for the rows they
+/// uncheck.
+///
+/// All authentication and re-derivation logic lives on the parent
+/// (`ContentView`) — the sheet only collects the user's choices and
+/// hands them back through `onAuthorize`. That keeps `LAContext` /
+/// `WalletStorage` / `walletManager.createWallet` plumbing in one
+/// place and lets the sheet stay a pure SwiftUI struct.
+struct RecoverWalletsSheet: View {
+    @Environment(\.dismiss) private var dismiss
+
+    /// Initial set of orphans surfaced to the user. The sheet edits
+    /// the `samePinCode` flag locally on a copy so toggling rows
+    /// doesn't have to round-trip through the parent until Authorize
+    /// is tapped.
+    let entries: [OrphanWalletEntry]
+
+    /// Called with the user's per-wallet choices when they tap the
+    /// primary Authorize button. The sheet dismisses immediately and
+    /// the parent runs the auth + re-derivation pipeline.
+    let onAuthorize: ([OrphanWalletEntry]) -> Void
+
+    /// Called when the user taps Cancel. Parent decides whether to
+    /// route into the keep/delete prompt or just leave the orphans
+    /// pending.
+    let onCancel: () -> Void
+
+    @State private var localEntries: [OrphanWalletEntry]
+
+    init(
+        entries: [OrphanWalletEntry],
+        onAuthorize: @escaping ([OrphanWalletEntry]) -> Void,
+        onCancel: @escaping () -> Void
+    ) {
+        self.entries = entries
+        self.onAuthorize = onAuthorize
+        self.onCancel = onCancel
+        _localEntries = State(initialValue: entries)
+    }
+
+    /// Hide the per-row "Same pin code" toggle when there's only one
+    /// orphan — the consolidation choice is meaningless for a single
+    /// wallet and the toggle would just clutter the row.
+    private var isMultiWallet: Bool { localEntries.count > 1 }
+
+    private var sharedCount: Int {
+        localEntries.filter(\.samePinCode).count
+    }
+
+    private var separateCount: Int {
+        localEntries.count - sharedCount
+    }
+
+    var body: some View {
+        NavigationStack {
+            List {
+                Section {
+                    Text(headerMessage)
+                        .font(.callout)
+                } header: {
+                    Text("Wallets to Recover")
+                }
+
+                Section {
+                    ForEach($localEntries) { $entry in
+                        walletRow(entry: $entry)
+                    }
+                } footer: {
+                    if isMultiWallet {
+                        Text(footerHelp)
+                            .font(.caption)
+                            .foregroundColor(.secondary)
+                    }
+                }
+            }
+            .navigationTitle("Recover Wallets")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Cancel") {
+                        onCancel()
+                        dismiss()
+                    }
+                }
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("Authorize") {
+                        onAuthorize(localEntries)
+                        dismiss()
+                    }
+                    .fontWeight(.semibold)
+                }
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func walletRow(entry: Binding<OrphanWalletEntry>) -> some View {
+        VStack(alignment: .leading, spacing: 8) {
+            HStack(alignment: .center, spacing: 12) {
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(entry.wrappedValue.displayName)
+                        .font(.body)
+                        .lineLimit(1)
+                    HStack(spacing: 6) {
+                        Text(entry.wrappedValue.network?.displayName ?? "Unknown network")
+                            .font(.caption)
+                            .foregroundColor(.secondary)
+                        Text("·")
+                            .font(.caption)
+                            .foregroundColor(.secondary)
+                        Text(walletShortId(entry.wrappedValue.walletId))
+                            .font(.system(.caption, design: .monospaced))
+                            .foregroundColor(.secondary)
+                    }
+                }
+                Spacer()
+            }
+            if isMultiWallet {
+                Toggle(isOn: entry.samePinCode) {
+                    Text("Same pin code")
+                        .font(.callout)
+                }
+                .toggleStyle(.switch)
+            }
+        }
+        .padding(.vertical, 2)
+    }
+
+    private var headerMessage: String {
+        let count = localEntries.count
+        if count == 1 {
+            return "A wallet recovery phrase is stored on this device, "
+                + "but no matching wallet data was found. Authorize to "
+                + "re-derive its public keys from the stored phrase."
+        }
+        return "\(count) wallet recovery phrases are stored on this device, "
+            + "but no matching wallet data was found. Authorize to re-derive "
+            + "their public keys from the stored phrases."
+    }
+
+    private var footerHelp: String {
+        if separateCount == 0 {
+            return "All \(sharedCount) wallets will be authorized in one prompt. "
+                + "Uncheck \"Same pin code\" on any wallet that uses a different code."
+        }
+        if sharedCount == 0 {
+            return "Each wallet will prompt for its own authorization."
+        }
+        return "\(sharedCount) wallet\(sharedCount == 1 ? "" : "s") share a prompt; "
+            + "\(separateCount) will prompt separately."
+    }
+
+    /// 4-byte hex prefix of the 32-byte wallet id — short enough for a
+    /// caption row, distinguishable across the orphan set.
+    private func walletShortId(_ walletId: Data) -> String {
+        guard walletId.count >= 4 else {
+            return walletId.map { String(format: "%02x", $0) }.joined()
+        }
+        return walletId.prefix(4)
+            .map { String(format: "%02x", $0) }
+            .joined()
+            + "…"
+    }
+}

--- a/packages/swift-sdk/SwiftExampleApp/SwiftExampleApp/Views/StorageExplorerView.swift
+++ b/packages/swift-sdk/SwiftExampleApp/SwiftExampleApp/Views/StorageExplorerView.swift
@@ -3,99 +3,115 @@ import SwiftData
 import SwiftDashSDK
 
 struct StorageExplorerView: View {
+    @EnvironmentObject var appState: AppState
     @Environment(\.modelContext) private var modelContext
     @State private var counts: [String: Int] = [:]
 
+    /// Active network the explorer is filtering by. The storage layer
+    /// keeps every network's rows (so switching back to testnet
+    /// re-surfaces what was synced there), but the UI only shows the
+    /// rows tied to the network currently selected on `AppState`.
+    private var network: Network { appState.currentNetwork }
+
     var body: some View {
         List {
+            Section {
+                HStack {
+                    Label("Network", systemImage: "network")
+                    Spacer()
+                    Text(network.displayName)
+                        .foregroundColor(.secondary)
+                }
+                .font(.callout)
+            }
             modelRow("Identities", icon: "person.crop.circle", type: PersistentIdentity.self) {
-                IdentityStorageListView()
+                IdentityStorageListView(network: network)
             }
             // Identity-relationship caches: cascade-owned by
             // `PersistentIdentity`, surfaced as their own explorer
             // sections so the row counts and per-row drill-downs
             // are visible without going through the parent identity.
             modelRow("DPNS Names", icon: "at", type: PersistentDPNSName.self) {
-                DPNSNameStorageListView()
+                DPNSNameStorageListView(network: network)
             }
             modelRow(
                 "DashPay Profiles",
                 icon: "person.text.rectangle",
                 type: PersistentDashpayProfile.self
             ) {
-                DashpayProfileStorageListView()
+                DashpayProfileStorageListView(network: network)
             }
             modelRow(
                 "Contact Requests",
                 icon: "person.crop.circle.badge.plus",
                 type: PersistentDashpayContactRequest.self
             ) {
-                DashpayContactRequestStorageListView()
+                DashpayContactRequestStorageListView(network: network)
             }
             modelRow("Documents", icon: "doc.text", type: PersistentDocument.self) {
-                DocumentStorageListView()
+                DocumentStorageListView(network: network)
             }
             modelRow("Data Contracts", icon: "doc.plaintext", type: PersistentDataContract.self) {
-                DataContractStorageListView()
+                DataContractStorageListView(network: network)
             }
             modelRow("Public Keys", icon: "key", type: PersistentPublicKey.self) {
-                PublicKeyStorageListView()
+                PublicKeyStorageListView(network: network)
             }
             modelRow("Tokens", icon: "circle.hexagongrid", type: PersistentToken.self) {
-                TokenStorageListView()
+                TokenStorageListView(network: network)
             }
             modelRow("Token Balances", icon: "banknote", type: PersistentTokenBalance.self) {
-                TokenBalanceStorageListView()
+                TokenBalanceStorageListView(network: network)
             }
             modelRow("Token History", icon: "clock.arrow.circlepath", type: PersistentTokenHistoryEvent.self) {
-                TokenHistoryStorageListView()
+                TokenHistoryStorageListView(network: network)
             }
             modelRow("Document Types", icon: "list.bullet.rectangle", type: PersistentDocumentType.self) {
-                DocumentTypeStorageListView()
+                DocumentTypeStorageListView(network: network)
             }
             modelRow("Indices", icon: "tablecells", type: PersistentIndex.self) {
-                IndexStorageListView()
+                IndexStorageListView(network: network)
             }
             modelRow("Properties", icon: "slider.horizontal.3", type: PersistentProperty.self) {
-                PropertyStorageListView()
+                PropertyStorageListView(network: network)
             }
             modelRow("Keywords", icon: "tag", type: PersistentKeyword.self) {
-                KeywordStorageListView()
+                KeywordStorageListView(network: network)
             }
             modelCountRow(
                 "Platform Addresses",
                 icon: "creditcard",
                 countKey: platformAddressesCountKey
             ) {
-                PlatformAddressStorageListView()
+                PlatformAddressStorageListView(network: network)
             }
             modelRow("Platform Addresses Sync State", icon: "arrow.triangle.2.circlepath", type: PersistentPlatformAddressesSyncState.self) {
-                PlatformAddressesSyncStateStorageListView()
+                PlatformAddressesSyncStateStorageListView(network: network)
             }
             modelRow("Wallets", icon: "wallet.pass", type: PersistentWallet.self) {
-                WalletStorageListView()
+                WalletStorageListView(network: network)
             }
             modelRow("Accounts", icon: "person.2", type: PersistentAccount.self) {
-                AccountStorageListView()
+                AccountStorageListView(network: network)
             }
             modelCountRow(
                 "Core Addresses",
                 icon: "square.and.pencil",
                 countKey: coreAddressesCountKey
             ) {
-                CoreAddressStorageListView()
+                CoreAddressStorageListView(network: network)
             }
             modelRow("Transactions", icon: "arrow.left.arrow.right.circle", type: PersistentTransaction.self) {
-                TransactionStorageListView()
+                TransactionStorageListView(network: network)
             }
             modelRow("TXOs", icon: "bitcoinsign.circle", type: PersistentTxo.self) {
-                TxoStorageListView()
+                TxoStorageListView(network: network)
             }
             modelRow("Pending Inputs", icon: "hourglass", type: PersistentPendingInput.self) {
-                PendingInputStorageListView()
+                PendingInputStorageListView(network: network)
             }
             modelRow("Manager Metadata", icon: "gearshape.2", type: PersistentWalletManagerMetadata.self) {
-                WalletManagerMetadataStorageListView()
+                WalletManagerMetadataStorageListView(network: network)
             }
         }
         .navigationTitle("Storage Explorer")
@@ -107,6 +123,12 @@ struct StorageExplorerView: View {
             }
         }
         .onAppear { loadCounts() }
+        // Re-count whenever the user flips networks while the
+        // explorer is on screen. Without this the row counts would
+        // stay pinned to the network that was active on `onAppear`.
+        .onChange(of: appState.currentNetwork) { _, _ in
+            loadCounts()
+        }
     }
 
     private func modelRow<T: PersistentModel, D: View>(
@@ -151,37 +173,105 @@ struct StorageExplorerView: View {
     private var coreAddressesCountKey: String { "CoreAddresses" }
 
     private func loadCounts() {
-        func count<T: PersistentModel>(_ type: T.Type) {
+        let raw = network.rawValue
+
+        // Wallet-id set for the active network. Used to count
+        // transaction-side rows that don't carry a `networkRaw` field
+        // and instead trace back to a wallet via the
+        // `walletId`/`account` denorms.
+        let walletsOnNetwork: Set<Data> = {
+            let descriptor = FetchDescriptor<PersistentWallet>(
+                predicate: #Predicate { $0.networkRaw == raw }
+            )
+            let fetched = (try? modelContext.fetch(descriptor)) ?? []
+            return Set(fetched.map(\.walletId))
+        }()
+
+        func directCount<T: PersistentModel>(
+            _ type: T.Type,
+            predicate: Predicate<T>
+        ) {
             let key = String(describing: type)
-            counts[key] = (try? modelContext.fetchCount(FetchDescriptor<T>())) ?? 0
+            counts[key] = (try? modelContext.fetchCount(
+                FetchDescriptor<T>(predicate: predicate)
+            )) ?? 0
         }
-        count(PersistentIdentity.self)
-        count(PersistentDPNSName.self)
-        count(PersistentDashpayProfile.self)
-        count(PersistentDashpayContactRequest.self)
-        count(PersistentDocument.self)
-        count(PersistentDataContract.self)
-        count(PersistentPublicKey.self)
-        count(PersistentToken.self)
-        count(PersistentTokenBalance.self)
-        count(PersistentTokenHistoryEvent.self)
-        count(PersistentDocumentType.self)
-        count(PersistentIndex.self)
-        count(PersistentProperty.self)
-        count(PersistentKeyword.self)
-        count(PersistentPlatformAddressesSyncState.self)
-        count(PersistentWallet.self)
-        count(PersistentAccount.self)
-        count(PersistentTransaction.self)
-        count(PersistentTxo.self)
-        count(PersistentPendingInput.self)
-        count(PersistentWalletManagerMetadata.self)
-        // Core and Platform address rows live in separate models now
-        // (PersistentCoreAddress vs PersistentPlatformAddress), so
-        // counting them is a plain `fetchCount` per model.
-        counts[platformAddressesCountKey] =
-            (try? modelContext.fetchCount(FetchDescriptor<PersistentPlatformAddress>())) ?? 0
-        counts[coreAddressesCountKey] =
-            (try? modelContext.fetchCount(FetchDescriptor<PersistentCoreAddress>())) ?? 0
+
+        func filteredCount<T: PersistentModel>(
+            _ type: T.Type,
+            matches: (T) -> Bool
+        ) {
+            let key = String(describing: type)
+            let all = (try? modelContext.fetch(FetchDescriptor<T>())) ?? []
+            counts[key] = all.lazy.filter(matches).count
+        }
+
+        // Models with a direct `networkRaw` column — predicate-friendly,
+        // no in-memory pass needed.
+        directCount(PersistentIdentity.self, predicate: #Predicate { $0.networkRaw == raw })
+        directCount(PersistentDPNSName.self, predicate: #Predicate { $0.networkRaw == raw })
+        directCount(PersistentDashpayProfile.self, predicate: #Predicate { $0.networkRaw == raw })
+        directCount(PersistentDashpayContactRequest.self, predicate: #Predicate { $0.networkRaw == raw })
+        directCount(PersistentDocument.self, predicate: #Predicate { $0.networkRaw == raw })
+        directCount(PersistentDataContract.self, predicate: #Predicate { $0.networkRaw == raw })
+        directCount(PersistentTokenBalance.self, predicate: #Predicate { $0.networkRaw == raw })
+        directCount(PersistentPlatformAddressesSyncState.self, predicate: #Predicate { $0.networkRaw == raw })
+        directCount(PersistentWallet.self, predicate: #Predicate { $0.networkRaw == raw })
+        directCount(PersistentWalletManagerMetadata.self, predicate: #Predicate { $0.networkRaw == raw })
+
+        // Models that derive their network through a relationship —
+        // SwiftData's predicate compiler can't follow optional
+        // chains into these without crashing, so we count in memory.
+        filteredCount(PersistentToken.self) { $0.dataContract?.networkRaw == raw }
+        filteredCount(PersistentTokenHistoryEvent.self) {
+            $0.token?.dataContract?.networkRaw == raw
+        }
+        filteredCount(PersistentDocumentType.self) { $0.dataContract?.networkRaw == raw }
+        filteredCount(PersistentIndex.self) {
+            $0.documentType?.dataContract?.networkRaw == raw
+        }
+        filteredCount(PersistentProperty.self) {
+            $0.documentType?.dataContract?.networkRaw == raw
+        }
+        filteredCount(PersistentKeyword.self) { $0.dataContract?.networkRaw == raw }
+        filteredCount(PersistentPublicKey.self) { $0.identity?.networkRaw == raw }
+        filteredCount(PersistentAccount.self) { $0.wallet.networkRaw == raw }
+        filteredCount(PersistentTransaction.self) { tx in
+            for txo in tx.outputs where walletsOnNetwork.contains(txo.walletId) {
+                return true
+            }
+            for txo in tx.inputs where walletsOnNetwork.contains(txo.walletId) {
+                return true
+            }
+            return false
+        }
+        filteredCount(PersistentTxo.self) { walletsOnNetwork.contains($0.walletId) }
+        filteredCount(PersistentPendingInput.self) {
+            walletsOnNetwork.contains($0.walletId)
+        }
+
+        // Core / Platform addresses partition the same family of
+        // tables by account type, so they need their own counts.
+        let coreAddresses = (try? modelContext.fetch(
+            FetchDescriptor<PersistentCoreAddress>()
+        )) ?? []
+        counts[coreAddressesCountKey] = coreAddresses.lazy
+            .filter { $0.account?.wallet.networkRaw == raw }
+            .count
+
+        let platformAddresses = (try? modelContext.fetch(
+            FetchDescriptor<PersistentPlatformAddress>()
+        )) ?? []
+        counts[platformAddressesCountKey] = platformAddresses.lazy
+            .filter { entry in
+                if let raw2 = entry.account?.wallet.networkRaw {
+                    return raw2 == raw
+                }
+                // Fallback: address row was persisted before the
+                // account relationship caught up — match through the
+                // denormalized `walletId`.
+                return walletsOnNetwork.contains(entry.walletId)
+            }
+            .count
     }
 }

--- a/packages/swift-sdk/SwiftExampleApp/SwiftExampleApp/Views/StorageModelListViews.swift
+++ b/packages/swift-sdk/SwiftExampleApp/SwiftExampleApp/Views/StorageModelListViews.swift
@@ -111,16 +111,18 @@ struct PublicKeyStorageListView: View {
     }
 
     /// Keys whose owning identity is on the active network. Orphan
-    /// keys (no parent identity) get pulled in too — they have no
-    /// network discriminant of their own, so the explorer surfaces
-    /// them under the active network rather than hiding them across
-    /// every network. Wipes happen at the keychain layer, not here.
+    /// keys (no parent identity) drop out of the per-network view
+    /// entirely — duplicating them across mainnet / testnet / devnet
+    /// / regtest would re-introduce the cross-network leakage this
+    /// PR removes and would also disagree with
+    /// `StorageExplorerView.loadCounts()` (which evaluates
+    /// `$0.identity?.networkRaw == raw` and excludes nil identities
+    /// the same way). If global orphan-key diagnostics are needed
+    /// later they belong on a separate, network-agnostic surface.
     private var scopedKeys: [PersistentPublicKey] {
         allKeys.filter { key in
-            if let identity = key.identity {
-                return identity.networkRaw == network.rawValue
-            }
-            return true
+            guard let identity = key.identity else { return false }
+            return identity.networkRaw == network.rawValue
         }
     }
 
@@ -216,8 +218,11 @@ struct PublicKeyStorageListView: View {
 
     /// Keys whose `identity` relationship is nil — e.g. rows that
     /// predate the changeset wiring or belong to identities since
-    /// deleted. Orphan rows have no network discriminant; the
-    /// explorer shows them under whatever network is active.
+    /// deleted. `scopedKeys` already strips them from the
+    /// per-network view, so this collection is always empty in the
+    /// current explorer; the section render below short-circuits on
+    /// `isEmpty`. Kept as a one-liner so a future global
+    /// orphan-diagnostics surface can reuse it.
     private var orphanKeys: [PersistentPublicKey] {
         scopedKeys.filter { $0.identity == nil }
     }

--- a/packages/swift-sdk/SwiftExampleApp/SwiftExampleApp/Views/StorageModelListViews.swift
+++ b/packages/swift-sdk/SwiftExampleApp/SwiftExampleApp/Views/StorageModelListViews.swift
@@ -5,11 +5,17 @@ import SwiftDashSDK
 // MARK: - PersistentIdentity
 
 struct IdentityStorageListView: View {
+    let network: Network
     @Query(sort: \PersistentIdentity.lastUpdated, order: .reverse)
     private var records: [PersistentIdentity]
 
+    private var filtered: [PersistentIdentity] {
+        records.filter { $0.networkRaw == network.rawValue }
+    }
+
     var body: some View {
-        List(records) { record in
+        let visible = filtered
+        List(visible) { record in
             NavigationLink(destination: IdentityStorageDetailView(record: record)) {
                 VStack(alignment: .leading, spacing: 4) {
                     Text(record.dpnsName ?? record.alias ?? record.identityIdBase58)
@@ -19,19 +25,25 @@ struct IdentityStorageListView: View {
                 }
             }
         }
-        .navigationTitle("Identities (\(records.count))")
-        .overlay { if records.isEmpty { ContentUnavailableView("No Records", systemImage: "person.crop.circle") } }
+        .navigationTitle("Identities (\(visible.count))")
+        .overlay { if visible.isEmpty { ContentUnavailableView("No Records", systemImage: "person.crop.circle") } }
     }
 }
 
 // MARK: - PersistentDocument
 
 struct DocumentStorageListView: View {
+    let network: Network
     @Query(sort: \PersistentDocument.localUpdatedAt, order: .reverse)
     private var records: [PersistentDocument]
 
+    private var filtered: [PersistentDocument] {
+        records.filter { $0.networkRaw == network.rawValue }
+    }
+
     var body: some View {
-        List(records) { record in
+        let visible = filtered
+        List(visible) { record in
             NavigationLink(destination: DocumentStorageDetailView(record: record)) {
                 VStack(alignment: .leading, spacing: 4) {
                     Text(record.displayTitle).font(.body).lineLimit(1)
@@ -39,19 +51,25 @@ struct DocumentStorageListView: View {
                 }
             }
         }
-        .navigationTitle("Documents (\(records.count))")
-        .overlay { if records.isEmpty { ContentUnavailableView("No Records", systemImage: "doc.text") } }
+        .navigationTitle("Documents (\(visible.count))")
+        .overlay { if visible.isEmpty { ContentUnavailableView("No Records", systemImage: "doc.text") } }
     }
 }
 
 // MARK: - PersistentDataContract
 
 struct DataContractStorageListView: View {
+    let network: Network
     @Query(sort: \PersistentDataContract.lastAccessedAt, order: .reverse)
     private var records: [PersistentDataContract]
 
+    private var filtered: [PersistentDataContract] {
+        records.filter { $0.networkRaw == network.rawValue }
+    }
+
     var body: some View {
-        List(records) { record in
+        let visible = filtered
+        List(visible) { record in
             NavigationLink(destination: DataContractStorageDetailView(record: record)) {
                 VStack(alignment: .leading, spacing: 4) {
                     Text(record.name).font(.body).lineLimit(1)
@@ -59,8 +77,8 @@ struct DataContractStorageListView: View {
                 }
             }
         }
-        .navigationTitle("Data Contracts (\(records.count))")
-        .overlay { if records.isEmpty { ContentUnavailableView("No Records", systemImage: "doc.plaintext") } }
+        .navigationTitle("Data Contracts (\(visible.count))")
+        .overlay { if visible.isEmpty { ContentUnavailableView("No Records", systemImage: "doc.plaintext") } }
     }
 }
 
@@ -76,6 +94,7 @@ struct DataContractStorageListView: View {
 /// `(walletId, identityIndex)` — that way identity #0 of wallet A
 /// shows before identity #1, and unnamed wallets stay clustered.
 struct PublicKeyStorageListView: View {
+    let network: Network
     @Environment(\.modelContext) private var modelContext
     @Query(sort: \PersistentIdentity.identityIndex)
     private var identities: [PersistentIdentity]
@@ -85,12 +104,33 @@ struct PublicKeyStorageListView: View {
 
     @Query private var hdWallets: [PersistentWallet]
 
+    /// Identities scoped to the active network. The keys, wallet
+    /// labels, and orphan section all derive from this.
+    private var scopedIdentities: [PersistentIdentity] {
+        identities.filter { $0.networkRaw == network.rawValue }
+    }
+
+    /// Keys whose owning identity is on the active network. Orphan
+    /// keys (no parent identity) get pulled in too — they have no
+    /// network discriminant of their own, so the explorer surfaces
+    /// them under the active network rather than hiding them across
+    /// every network. Wipes happen at the keychain layer, not here.
+    private var scopedKeys: [PersistentPublicKey] {
+        allKeys.filter { key in
+            if let identity = key.identity {
+                return identity.networkRaw == network.rawValue
+            }
+            return true
+        }
+    }
+
     /// Key targeted by a pending Remove swipe. Non-nil presents the
     /// confirmation dialog; holding the reference lets the dialog
     /// show `Key N` without re-fetching.
     @State private var keyPendingRemoval: PersistentPublicKey?
 
     var body: some View {
+        let scoped = scopedKeys
         List {
             ForEach(walletGroups, id: \.walletId) { group in
                 walletSection(group)
@@ -105,9 +145,9 @@ struct PublicKeyStorageListView: View {
                 }
             }
         }
-        .navigationTitle("Public Keys (\(allKeys.count))")
+        .navigationTitle("Public Keys (\(scoped.count))")
         .overlay {
-            if allKeys.isEmpty {
+            if scoped.isEmpty {
                 ContentUnavailableView("No Records", systemImage: "key")
             }
         }
@@ -153,7 +193,7 @@ struct PublicKeyStorageListView: View {
     /// label (alphabetical, case-insensitive); no-wallet identities
     /// sort last so user-owned ones dominate the top of the screen.
     private var walletGroups: [WalletGroup] {
-        let grouped = Dictionary(grouping: identities) { $0.wallet?.walletId ?? Data() }
+        let grouped = Dictionary(grouping: scopedIdentities) { $0.wallet?.walletId ?? Data() }
         return grouped
             .map { (walletId, ids) -> WalletGroup in
                 WalletGroup(
@@ -176,9 +216,10 @@ struct PublicKeyStorageListView: View {
 
     /// Keys whose `identity` relationship is nil — e.g. rows that
     /// predate the changeset wiring or belong to identities since
-    /// deleted.
+    /// deleted. Orphan rows have no network discriminant; the
+    /// explorer shows them under whatever network is active.
     private var orphanKeys: [PersistentPublicKey] {
-        allKeys.filter { $0.identity == nil }
+        scopedKeys.filter { $0.identity == nil }
     }
 
     private func walletLabel(for walletId: Data) -> String? {
@@ -314,11 +355,17 @@ struct PublicKeyStorageListView: View {
 /// from `DpnsNameInfo.acquired_at` and zero-valued rows (legacy,
 /// un-timestamped) naturally fall to the bottom.
 struct DPNSNameStorageListView: View {
+    let network: Network
     @Query(sort: \PersistentDPNSName.acquiredAt, order: .reverse)
     private var records: [PersistentDPNSName]
 
+    private var filtered: [PersistentDPNSName] {
+        records.filter { $0.networkRaw == network.rawValue }
+    }
+
     var body: some View {
-        List(records) { record in
+        let visible = filtered
+        List(visible) { record in
             NavigationLink(destination: DPNSNameStorageDetailView(record: record)) {
                 VStack(alignment: .leading, spacing: 4) {
                     Text("\(record.label).\(record.parentDomainName)")
@@ -331,9 +378,9 @@ struct DPNSNameStorageListView: View {
                 }
             }
         }
-        .navigationTitle("DPNS Names (\(records.count))")
+        .navigationTitle("DPNS Names (\(visible.count))")
         .overlay {
-            if records.isEmpty {
+            if visible.isEmpty {
                 ContentUnavailableView("No Records", systemImage: "at")
             }
         }
@@ -345,11 +392,17 @@ struct DPNSNameStorageListView: View {
 /// Storage-explorer list of every cached DashPay profile. One row
 /// per (network, identity). Newest profile update first.
 struct DashpayProfileStorageListView: View {
+    let network: Network
     @Query(sort: \PersistentDashpayProfile.lastUpdated, order: .reverse)
     private var records: [PersistentDashpayProfile]
 
+    private var filtered: [PersistentDashpayProfile] {
+        records.filter { $0.networkRaw == network.rawValue }
+    }
+
     var body: some View {
-        List(records) { record in
+        let visible = filtered
+        List(visible) { record in
             NavigationLink(destination: DashpayProfileStorageDetailView(record: record)) {
                 VStack(alignment: .leading, spacing: 4) {
                     Text(record.displayName ?? "(no display name)")
@@ -362,9 +415,9 @@ struct DashpayProfileStorageListView: View {
                 }
             }
         }
-        .navigationTitle("DashPay Profiles (\(records.count))")
+        .navigationTitle("DashPay Profiles (\(visible.count))")
         .overlay {
-            if records.isEmpty {
+            if visible.isEmpty {
                 ContentUnavailableView("No Records", systemImage: "person.text.rectangle")
             }
         }
@@ -381,19 +434,25 @@ struct DashpayProfileStorageListView: View {
 /// (owner, contact) pair. Within each section, newest request first
 /// (`createdAtMillis` desc; `0` falls to the bottom).
 struct DashpayContactRequestStorageListView: View {
+    let network: Network
     @Query private var records: [PersistentDashpayContactRequest]
 
+    private var scoped: [PersistentDashpayContactRequest] {
+        records.filter { $0.networkRaw == network.rawValue }
+    }
+
     private var outgoing: [PersistentDashpayContactRequest] {
-        records.filter { $0.isOutgoing }
+        scoped.filter { $0.isOutgoing }
             .sorted { $0.createdAtMillis > $1.createdAtMillis }
     }
 
     private var incoming: [PersistentDashpayContactRequest] {
-        records.filter { !$0.isOutgoing }
+        scoped.filter { !$0.isOutgoing }
             .sorted { $0.createdAtMillis > $1.createdAtMillis }
     }
 
     var body: some View {
+        let visible = scoped
         List {
             if !outgoing.isEmpty {
                 Section("Outgoing (\(outgoing.count))") {
@@ -410,9 +469,9 @@ struct DashpayContactRequestStorageListView: View {
                 }
             }
         }
-        .navigationTitle("Contact Requests (\(records.count))")
+        .navigationTitle("Contact Requests (\(visible.count))")
         .overlay {
-            if records.isEmpty {
+            if visible.isEmpty {
                 ContentUnavailableView(
                     "No Records",
                     systemImage: "person.crop.circle.badge.plus"
@@ -456,11 +515,19 @@ struct DashpayContactRequestStorageListView: View {
 // MARK: - PersistentToken
 
 struct TokenStorageListView: View {
+    let network: Network
     @Query(sort: \PersistentToken.name)
     private var records: [PersistentToken]
 
+    /// Tokens trace their network through the parent contract; the
+    /// token row itself doesn't store a `networkRaw` column.
+    private var filtered: [PersistentToken] {
+        records.filter { $0.dataContract?.networkRaw == network.rawValue }
+    }
+
     var body: some View {
-        List(records) { record in
+        let visible = filtered
+        List(visible) { record in
             NavigationLink(destination: TokenStorageDetailView(record: record)) {
                 VStack(alignment: .leading, spacing: 4) {
                     Text(record.name).font(.body).lineLimit(1)
@@ -468,19 +535,25 @@ struct TokenStorageListView: View {
                 }
             }
         }
-        .navigationTitle("Tokens (\(records.count))")
-        .overlay { if records.isEmpty { ContentUnavailableView("No Records", systemImage: "circle.hexagongrid") } }
+        .navigationTitle("Tokens (\(visible.count))")
+        .overlay { if visible.isEmpty { ContentUnavailableView("No Records", systemImage: "circle.hexagongrid") } }
     }
 }
 
 // MARK: - PersistentTokenBalance
 
 struct TokenBalanceStorageListView: View {
+    let network: Network
     @Query(sort: \PersistentTokenBalance.lastUpdated, order: .reverse)
     private var records: [PersistentTokenBalance]
 
+    private var filtered: [PersistentTokenBalance] {
+        records.filter { $0.networkRaw == network.rawValue }
+    }
+
     var body: some View {
-        List(records) { record in
+        let visible = filtered
+        List(visible) { record in
             NavigationLink(destination: TokenBalanceStorageDetailView(record: record)) {
                 VStack(alignment: .leading, spacing: 4) {
                     Text(record.tokenName ?? record.tokenId).font(.body).lineLimit(1)
@@ -488,19 +561,28 @@ struct TokenBalanceStorageListView: View {
                 }
             }
         }
-        .navigationTitle("Token Balances (\(records.count))")
-        .overlay { if records.isEmpty { ContentUnavailableView("No Records", systemImage: "banknote") } }
+        .navigationTitle("Token Balances (\(visible.count))")
+        .overlay { if visible.isEmpty { ContentUnavailableView("No Records", systemImage: "banknote") } }
     }
 }
 
 // MARK: - PersistentTokenHistoryEvent
 
 struct TokenHistoryStorageListView: View {
+    let network: Network
     @Query(sort: \PersistentTokenHistoryEvent.createdAt, order: .reverse)
     private var records: [PersistentTokenHistoryEvent]
 
+    /// Token-history rows trace their network through `token →
+    /// dataContract.networkRaw`. Both relationships are optional so
+    /// any orphan row drops out of the explorer.
+    private var filtered: [PersistentTokenHistoryEvent] {
+        records.filter { $0.token?.dataContract?.networkRaw == network.rawValue }
+    }
+
     var body: some View {
-        List(records) { record in
+        let visible = filtered
+        List(visible) { record in
             NavigationLink(destination: TokenHistoryStorageDetailView(record: record)) {
                 VStack(alignment: .leading, spacing: 4) {
                     Text(record.displayTitle).font(.body).lineLimit(1)
@@ -509,19 +591,25 @@ struct TokenHistoryStorageListView: View {
                 }
             }
         }
-        .navigationTitle("Token History (\(records.count))")
-        .overlay { if records.isEmpty { ContentUnavailableView("No Records", systemImage: "clock.arrow.circlepath") } }
+        .navigationTitle("Token History (\(visible.count))")
+        .overlay { if visible.isEmpty { ContentUnavailableView("No Records", systemImage: "clock.arrow.circlepath") } }
     }
 }
 
 // MARK: - PersistentDocumentType
 
 struct DocumentTypeStorageListView: View {
+    let network: Network
     @Query(sort: \PersistentDocumentType.name)
     private var records: [PersistentDocumentType]
 
+    private var filtered: [PersistentDocumentType] {
+        records.filter { $0.dataContract?.networkRaw == network.rawValue }
+    }
+
     var body: some View {
-        List(records) { record in
+        let visible = filtered
+        List(visible) { record in
             NavigationLink(destination: DocumentTypeStorageDetailView(record: record)) {
                 VStack(alignment: .leading, spacing: 4) {
                     Text(record.name).font(.body).lineLimit(1)
@@ -529,19 +617,28 @@ struct DocumentTypeStorageListView: View {
                 }
             }
         }
-        .navigationTitle("Document Types (\(records.count))")
-        .overlay { if records.isEmpty { ContentUnavailableView("No Records", systemImage: "list.bullet.rectangle") } }
+        .navigationTitle("Document Types (\(visible.count))")
+        .overlay { if visible.isEmpty { ContentUnavailableView("No Records", systemImage: "list.bullet.rectangle") } }
     }
 }
 
 // MARK: - PersistentIndex
 
 struct IndexStorageListView: View {
+    let network: Network
     @Query(sort: \PersistentIndex.name)
     private var records: [PersistentIndex]
 
+    /// Indices live two relationships deep: documentType → dataContract.
+    /// Orphan rows (broken chain) drop out — they have no network to
+    /// attribute them to.
+    private var filtered: [PersistentIndex] {
+        records.filter { $0.documentType?.dataContract?.networkRaw == network.rawValue }
+    }
+
     var body: some View {
-        List(records) { record in
+        let visible = filtered
+        List(visible) { record in
             NavigationLink(destination: IndexStorageDetailView(record: record)) {
                 VStack(alignment: .leading, spacing: 4) {
                     Text(record.name).font(.body).lineLimit(1)
@@ -549,19 +646,25 @@ struct IndexStorageListView: View {
                 }
             }
         }
-        .navigationTitle("Indices (\(records.count))")
-        .overlay { if records.isEmpty { ContentUnavailableView("No Records", systemImage: "tablecells") } }
+        .navigationTitle("Indices (\(visible.count))")
+        .overlay { if visible.isEmpty { ContentUnavailableView("No Records", systemImage: "tablecells") } }
     }
 }
 
 // MARK: - PersistentProperty
 
 struct PropertyStorageListView: View {
+    let network: Network
     @Query(sort: \PersistentProperty.name)
     private var records: [PersistentProperty]
 
+    private var filtered: [PersistentProperty] {
+        records.filter { $0.documentType?.dataContract?.networkRaw == network.rawValue }
+    }
+
     var body: some View {
-        List(records) { record in
+        let visible = filtered
+        List(visible) { record in
             NavigationLink(destination: PropertyStorageDetailView(record: record)) {
                 VStack(alignment: .leading, spacing: 4) {
                     Text(record.name).font(.body).lineLimit(1)
@@ -569,36 +672,48 @@ struct PropertyStorageListView: View {
                 }
             }
         }
-        .navigationTitle("Properties (\(records.count))")
-        .overlay { if records.isEmpty { ContentUnavailableView("No Records", systemImage: "slider.horizontal.3") } }
+        .navigationTitle("Properties (\(visible.count))")
+        .overlay { if visible.isEmpty { ContentUnavailableView("No Records", systemImage: "slider.horizontal.3") } }
     }
 }
 
 // MARK: - PersistentKeyword
 
 struct KeywordStorageListView: View {
+    let network: Network
     @Query(sort: \PersistentKeyword.keyword)
     private var records: [PersistentKeyword]
 
+    private var filtered: [PersistentKeyword] {
+        records.filter { $0.dataContract?.networkRaw == network.rawValue }
+    }
+
     var body: some View {
-        List(records) { record in
+        let visible = filtered
+        List(visible) { record in
             NavigationLink(destination: KeywordStorageDetailView(record: record)) {
                 Text(record.keyword).font(.body)
             }
         }
-        .navigationTitle("Keywords (\(records.count))")
-        .overlay { if records.isEmpty { ContentUnavailableView("No Records", systemImage: "tag") } }
+        .navigationTitle("Keywords (\(visible.count))")
+        .overlay { if visible.isEmpty { ContentUnavailableView("No Records", systemImage: "tag") } }
     }
 }
 
 // MARK: - PersistentPlatformAddressesSyncState
 
 struct PlatformAddressesSyncStateStorageListView: View {
+    let network: Network
     @Query(sort: \PersistentPlatformAddressesSyncState.lastUpdated, order: .reverse)
     private var records: [PersistentPlatformAddressesSyncState]
 
+    private var filtered: [PersistentPlatformAddressesSyncState] {
+        records.filter { $0.networkRaw == network.rawValue }
+    }
+
     var body: some View {
-        List(records) { record in
+        let visible = filtered
+        List(visible) { record in
             NavigationLink(destination: PlatformAddressesSyncStateStorageDetailView(record: record)) {
                 VStack(alignment: .leading, spacing: 4) {
                     Text(record.network.displayName)
@@ -612,19 +727,29 @@ struct PlatformAddressesSyncStateStorageListView: View {
                 }
             }
         }
-        .navigationTitle("Platform Addresses Sync State (\(records.count))")
-        .overlay { if records.isEmpty { ContentUnavailableView("No Records", systemImage: "arrow.triangle.2.circlepath") } }
+        .navigationTitle("Platform Addresses Sync State (\(visible.count))")
+        .overlay { if visible.isEmpty { ContentUnavailableView("No Records", systemImage: "arrow.triangle.2.circlepath") } }
     }
 }
 
 // MARK: - PersistentWallet
 
 struct WalletStorageListView: View {
+    let network: Network
     @Query(sort: \PersistentWallet.lastUpdated, order: .reverse)
     private var records: [PersistentWallet]
 
+    /// `networkRaw` is optional on this model: a row can predate the
+    /// persister's network-fill step. Strict filter — `nil` rows
+    /// don't match any active network and are hidden until the
+    /// persister fills them in.
+    private var filtered: [PersistentWallet] {
+        records.filter { $0.networkRaw == network.rawValue }
+    }
+
     var body: some View {
-        List(records) { record in
+        let visible = filtered
+        List(visible) { record in
             NavigationLink(destination: WalletStorageDetailView(record: record)) {
                 VStack(alignment: .leading, spacing: 4) {
                     Text(record.name ?? record.walletId.map { String(format: "%02x", $0) }.prefix(16).joined())
@@ -634,27 +759,34 @@ struct WalletStorageListView: View {
                 }
             }
         }
-        .navigationTitle("Wallets (\(records.count))")
-        .overlay { if records.isEmpty { ContentUnavailableView("No Records", systemImage: "wallet.pass") } }
+        .navigationTitle("Wallets (\(visible.count))")
+        .overlay { if visible.isEmpty { ContentUnavailableView("No Records", systemImage: "wallet.pass") } }
     }
 }
 
 // MARK: - PersistentAccount
 
 struct AccountStorageListView: View {
+    let network: Network
     /// Query the wallet side of the `@Relationship` so the list groups
     /// by wallet. Accounts come through `wallet.accounts`, which
     /// updates reactively under SwiftData.
     @Query(sort: \PersistentWallet.createdAt, order: .reverse)
     private var wallets: [PersistentWallet]
 
+    /// Wallets on the active network. Accounts inherit the wallet's
+    /// network — there is no per-account `networkRaw` column.
+    private var scopedWallets: [PersistentWallet] {
+        wallets.filter { $0.networkRaw == network.rawValue }
+    }
+
     private var totalAccountCount: Int {
-        wallets.reduce(0) { $0 + $1.accounts.count }
+        scopedWallets.reduce(0) { $0 + $1.accounts.count }
     }
 
     var body: some View {
         List {
-            ForEach(wallets) { wallet in
+            ForEach(scopedWallets) { wallet in
                 Section(header: Text(walletHeader(for: wallet))) {
                     let sorted = sortedAccounts(wallet.accounts)
                     if sorted.isEmpty {
@@ -734,8 +866,21 @@ struct AccountStorageListView: View {
 // MARK: - PersistentTransaction
 
 struct TransactionStorageListView: View {
+    let network: Network
     @Query(sort: \PersistentTransaction.firstSeen, order: .reverse)
     private var records: [PersistentTransaction]
+
+    /// Wallets on the active network. Transactions don't carry a
+    /// `networkRaw` column; we match a tx to a network by checking
+    /// whether *any* of its TXOs (input or output) carry a
+    /// `walletId` that resolves to a wallet on this network.
+    @Query private var allWallets: [PersistentWallet]
+
+    private var walletIdsOnNetwork: Set<Data> {
+        Set(allWallets.lazy
+            .filter { $0.networkRaw == network.rawValue }
+            .map(\.walletId))
+    }
 
     /// Live-search needle — matches against the canonical block-explorer
     /// `txidHex` (byte-reversed) so a user can paste an explorer link's
@@ -774,10 +919,24 @@ struct TransactionStorageListView: View {
         "Asset Unlock Transaction",
     ]
 
+    /// Records whose at-least-one TXO points at a wallet on the
+    /// active network. The base set the search/direction/type
+    /// filters then narrow further. Counts on the title row are
+    /// against this set, not `records`, so they reflect the
+    /// network-scoped universe rather than the cross-network store.
+    private var networkScopedRecords: [PersistentTransaction] {
+        let ids = walletIdsOnNetwork
+        return records.filter { tx in
+            for txo in tx.outputs where ids.contains(txo.walletId) { return true }
+            for txo in tx.inputs where ids.contains(txo.walletId) { return true }
+            return false
+        }
+    }
+
     private var filteredRecords: [PersistentTransaction] {
         let trimmed = searchText.trimmingCharacters(in: .whitespacesAndNewlines)
         let needle = trimmed.lowercased()
-        return records.filter { record in
+        return networkScopedRecords.filter { record in
             // Direction.
             switch directionFilter {
             case .all: break
@@ -805,6 +964,7 @@ struct TransactionStorageListView: View {
     }
 
     var body: some View {
+        let scoped = networkScopedRecords
         let visible = filteredRecords
         List {
             Section {
@@ -844,7 +1004,7 @@ struct TransactionStorageListView: View {
             // direction / type / search to recover. As inline list
             // content, the message scrolls in below the filter row
             // and leaves the controls fully reachable.
-            if !records.isEmpty && visible.isEmpty {
+            if !scoped.isEmpty && visible.isEmpty {
                 Section {
                     ContentUnavailableView(
                         "No matching transactions",
@@ -888,8 +1048,8 @@ struct TransactionStorageListView: View {
         }
         .navigationTitle(
             (directionFilter == .all && typeFilter == nil && searchText.isEmpty)
-                ? "Transactions (\(records.count))"
-                : "Transactions (\(visible.count) / \(records.count))"
+                ? "Transactions (\(scoped.count))"
+                : "Transactions (\(visible.count) / \(scoped.count))"
         )
         .searchable(
             text: $searchText,
@@ -901,7 +1061,7 @@ struct TransactionStorageListView: View {
         // is fine. The filter-narrowed empty state is rendered as
         // list content above (see the inline Section).
         .overlay {
-            if records.isEmpty {
+            if scoped.isEmpty {
                 ContentUnavailableView(
                     "No Records",
                     systemImage: "arrow.left.arrow.right.circle"
@@ -945,11 +1105,21 @@ struct TransactionStorageListView: View {
 // MARK: - PersistentCoreAddress
 
 struct CoreAddressStorageListView: View {
+    let network: Network
     /// Every Core-chain address record. PlatformPayment (DIP-17)
     /// addresses now live in their own `PersistentPlatformAddress`
     /// store, so no filtering is needed here.
     @Query(sort: [SortDescriptor(\PersistentCoreAddress.addressIndex)])
     private var records: [PersistentCoreAddress]
+
+    /// Network filter. CoreAddress doesn't have a `networkRaw`
+    /// column; the network is owned by the parent wallet via
+    /// `account.wallet.networkRaw`. Rows whose `account` link is
+    /// nil have no resolvable network and drop out — they're
+    /// recovered by the persister on next sync.
+    private var scopedRecords: [PersistentCoreAddress] {
+        records.filter { $0.account?.wallet.networkRaw == network.rawValue }
+    }
 
     /// Live-search query. Matches case-insensitively against the
     /// Base58Check address, derivation path, and address index.
@@ -989,9 +1159,9 @@ struct CoreAddressStorageListView: View {
     /// sections drop out cleanly.
     private var filteredRecords: [PersistentCoreAddress] {
         let trimmed = searchText.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !trimmed.isEmpty else { return records }
+        guard !trimmed.isEmpty else { return scopedRecords }
         let needle = trimmed.lowercased()
-        return records.filter { record in
+        return scopedRecords.filter { record in
             if record.address.lowercased().contains(needle) { return true }
             if record.derivationPath.lowercased().contains(needle) { return true }
             if String(record.addressIndex).contains(needle) { return true }
@@ -1045,7 +1215,7 @@ struct CoreAddressStorageListView: View {
         .navigationTitle("Core Addresses (\(filteredRecords.count))")
         .searchable(text: $searchText, prompt: "Search address, path, or index")
         .overlay {
-            if records.isEmpty {
+            if scopedRecords.isEmpty {
                 ContentUnavailableView(
                     "No Records",
                     systemImage: "square.and.pencil"
@@ -1109,8 +1279,30 @@ struct CoreAddressStorageListView: View {
 /// address-emit path for type-14 accounts, refreshed by BLAST
 /// sync).
 struct PlatformAddressStorageListView: View {
+    let network: Network
     @Query(sort: [SortDescriptor(\PersistentPlatformAddress.addressIndex)])
     private var records: [PersistentPlatformAddress]
+
+    /// Wallet-id set used for the fallback path when a row's
+    /// `account` join hasn't been hydrated yet.
+    @Query private var allWallets: [PersistentWallet]
+
+    private var walletIdsOnNetwork: Set<Data> {
+        Set(allWallets.lazy
+            .filter { $0.networkRaw == network.rawValue }
+            .map(\.walletId))
+    }
+
+    private var scopedRecords: [PersistentPlatformAddress] {
+        let raw = network.rawValue
+        let ids = walletIdsOnNetwork
+        return records.filter { entry in
+            if let walletRaw = entry.account?.wallet.networkRaw {
+                return walletRaw == raw
+            }
+            return ids.contains(entry.walletId)
+        }
+    }
 
     private struct GroupKey: Hashable, Comparable {
         let walletId: Data
@@ -1129,7 +1321,7 @@ struct PlatformAddressStorageListView: View {
     }
 
     private var groups: [(GroupKey, [PersistentPlatformAddress])] {
-        let grouped = Dictionary(grouping: records) { record -> GroupKey in
+        let grouped = Dictionary(grouping: scopedRecords) { record -> GroupKey in
             let account = record.account
             let wallet = account?.wallet
             return GroupKey(
@@ -1146,6 +1338,7 @@ struct PlatformAddressStorageListView: View {
     }
 
     var body: some View {
+        let visible = scopedRecords
         List {
             ForEach(Array(groups.enumerated()), id: \.offset) { _, pair in
                 let (key, addresses) = pair
@@ -1158,9 +1351,9 @@ struct PlatformAddressStorageListView: View {
                 }
             }
         }
-        .navigationTitle("Platform Addresses (\(records.count))")
+        .navigationTitle("Platform Addresses (\(visible.count))")
         .overlay {
-            if records.isEmpty {
+            if visible.isEmpty {
                 ContentUnavailableView(
                     "No Records",
                     systemImage: "creditcard"
@@ -1209,6 +1402,7 @@ struct PlatformAddressStorageListView: View {
 // MARK: - PersistentTxo
 
 struct TxoStorageListView: View {
+    let network: Network
     /// Sort by block height descending — newest at the top, mempool
     /// (`height == 0`) ahead of confirmed entries. The previous
     /// `createdAt` sort meant rows were ordered by when they happened
@@ -1216,6 +1410,23 @@ struct TxoStorageListView: View {
     /// the mental model when scanning for a specific block range.
     @Query(sort: [SortDescriptor(\PersistentTxo.height, order: .reverse)])
     private var records: [PersistentTxo]
+
+    /// Wallets on the active network. Used to scope the TXO list by
+    /// the denormalized `walletId` column — every TXO carries one,
+    /// so this is a straight `Set` lookup rather than an optional
+    /// chain through the `account` relationship.
+    @Query private var allWallets: [PersistentWallet]
+
+    private var walletIdsOnNetwork: Set<Data> {
+        Set(allWallets.lazy
+            .filter { $0.networkRaw == network.rawValue }
+            .map(\.walletId))
+    }
+
+    private var scopedRecords: [PersistentTxo] {
+        let ids = walletIdsOnNetwork
+        return records.filter { ids.contains($0.walletId) }
+    }
 
     /// Spent / unspent filter. `.all` shows the full set (matches the
     /// previous behavior); `.unspent` and `.spent` narrow to the
@@ -1225,14 +1436,16 @@ struct TxoStorageListView: View {
     @State private var filter: SpentFilter = .all
 
     private var filteredRecords: [PersistentTxo] {
+        let scoped = scopedRecords
         switch filter {
-        case .all: return records
-        case .unspent: return records.filter { !$0.isSpent }
-        case .spent: return records.filter { $0.isSpent }
+        case .all: return scoped
+        case .unspent: return scoped.filter { !$0.isSpent }
+        case .spent: return scoped.filter { $0.isSpent }
         }
     }
 
     var body: some View {
+        let scoped = scopedRecords
         let visible = filteredRecords
         List {
             Section {
@@ -1248,7 +1461,7 @@ struct TxoStorageListView: View {
             // see the matching note in `TransactionStorageListView`.
             // Overlay would block the segmented Picker above and
             // dead-end the user.
-            if !records.isEmpty && visible.isEmpty {
+            if !scoped.isEmpty && visible.isEmpty {
                 Section {
                     ContentUnavailableView(
                         "No \(filter.title) TXOs",
@@ -1284,13 +1497,13 @@ struct TxoStorageListView: View {
             }
         }
         .navigationTitle(filter == .all
-            ? "TXOs (\(records.count))"
-            : "TXOs (\(visible.count) / \(records.count))")
+            ? "TXOs (\(scoped.count))"
+            : "TXOs (\(visible.count) / \(scoped.count))")
         // Overlay only the no-records-at-all case; the
         // filter-narrowed empty state lives inline above so the
         // Picker stays reachable.
         .overlay {
-            if records.isEmpty {
+            if scoped.isEmpty {
                 ContentUnavailableView("No Records", systemImage: "bitcoinsign.circle")
             }
         }
@@ -1322,11 +1535,26 @@ struct TxoStorageListView: View {
 /// that the wallet never derives, or input outpoints whose previous
 /// output isn't ours and will never resolve.
 struct PendingInputStorageListView: View {
+    let network: Network
     @Query(sort: [SortDescriptor(\PersistentPendingInput.createdAt, order: .reverse)])
     private var records: [PersistentPendingInput]
 
+    @Query private var allWallets: [PersistentWallet]
+
+    private var walletIdsOnNetwork: Set<Data> {
+        Set(allWallets.lazy
+            .filter { $0.networkRaw == network.rawValue }
+            .map(\.walletId))
+    }
+
+    private var scopedRecords: [PersistentPendingInput] {
+        let ids = walletIdsOnNetwork
+        return records.filter { ids.contains($0.walletId) }
+    }
+
     var body: some View {
-        List(records) { record in
+        let visible = scopedRecords
+        List(visible) { record in
             NavigationLink(destination: PendingInputStorageDetailView(record: record)) {
                 VStack(alignment: .leading, spacing: 4) {
                     Text(outpointHex(record.outpoint))
@@ -1344,9 +1572,9 @@ struct PendingInputStorageListView: View {
                 }
             }
         }
-        .navigationTitle("Pending Inputs (\(records.count))")
+        .navigationTitle("Pending Inputs (\(visible.count))")
         .overlay {
-            if records.isEmpty {
+            if visible.isEmpty {
                 ContentUnavailableView(
                     "No Pending Inputs",
                     systemImage: "hourglass"
@@ -1375,11 +1603,17 @@ struct PendingInputStorageListView: View {
 // MARK: - PersistentWalletManagerMetadata
 
 struct WalletManagerMetadataStorageListView: View {
+    let network: Network
     @Query(sort: \PersistentWalletManagerMetadata.lastUpdated, order: .reverse)
     private var records: [PersistentWalletManagerMetadata]
 
+    private var filtered: [PersistentWalletManagerMetadata] {
+        records.filter { $0.networkRaw == network.rawValue }
+    }
+
     var body: some View {
-        List(records) { record in
+        let visible = filtered
+        List(visible) { record in
             NavigationLink(destination: WalletManagerMetadataStorageDetailView(record: record)) {
                 VStack(alignment: .leading, spacing: 4) {
                     Text(record.network.displayName).font(.body)
@@ -1388,7 +1622,7 @@ struct WalletManagerMetadataStorageListView: View {
                 }
             }
         }
-        .navigationTitle("Manager Metadata (\(records.count))")
-        .overlay { if records.isEmpty { ContentUnavailableView("No Records", systemImage: "gearshape.2") } }
+        .navigationTitle("Manager Metadata (\(visible.count))")
+        .overlay { if visible.isEmpty { ContentUnavailableView("No Records", systemImage: "gearshape.2") } }
     }
 }

--- a/packages/swift-sdk/SwiftExampleApp/SwiftExampleAppUITests/SwiftExampleAppUITests.swift
+++ b/packages/swift-sdk/SwiftExampleApp/SwiftExampleAppUITests/SwiftExampleAppUITests.swift
@@ -191,8 +191,12 @@ final class SwiftExampleAppUITests: XCTestCase {
 
     @MainActor
     private func failIfRecoveryPromptVisible(in app: XCUIApplication, timeout: TimeInterval) {
-        let recoverWalletAlert = app.alerts["Recover Wallet?"]
-        if recoverWalletAlert.waitForExistence(timeout: timeout) {
+        // Title is plural for N>1 orphans, singular for one — guard
+        // both so a left-over one-wallet keychain mnemonic still
+        // trips this guard.
+        let plural = app.alerts["Recover Wallets?"]
+        let singular = app.alerts["Recover Wallet?"]
+        if plural.waitForExistence(timeout: timeout) || singular.waitForExistence(timeout: 0.5) {
             XCTFail(
                 "Pre-existing orphan-mnemonic recovery alert is blocking the UI test. "
                 + "Clean simulator state or resolve the alert manually before running this flow."

--- a/packages/swift-sdk/SwiftExampleApp/SwiftExampleAppUITests/SwiftExampleAppUITests.swift
+++ b/packages/swift-sdk/SwiftExampleApp/SwiftExampleAppUITests/SwiftExampleAppUITests.swift
@@ -191,12 +191,18 @@ final class SwiftExampleAppUITests: XCTestCase {
 
     @MainActor
     private func failIfRecoveryPromptVisible(in app: XCUIApplication, timeout: TimeInterval) {
-        // Title is plural for N>1 orphans, singular for one — guard
-        // both so a left-over one-wallet keychain mnemonic still
-        // trips this guard.
-        let plural = app.alerts["Recover Wallets?"]
-        let singular = app.alerts["Recover Wallet?"]
-        if plural.waitForExistence(timeout: timeout) || singular.waitForExistence(timeout: 0.5) {
+        // Title is plural for N>1 orphans, singular for one — match
+        // either label in a single predicate-based query so the
+        // total wait stays bounded by `timeout` and both variants
+        // are detected symmetrically.
+        let recoveryAlert = app.alerts.matching(
+            NSPredicate(
+                format: "label == %@ OR label == %@",
+                "Recover Wallets?",
+                "Recover Wallet?"
+            )
+        ).firstMatch
+        if recoveryAlert.waitForExistence(timeout: timeout) {
             XCTFail(
                 "Pre-existing orphan-mnemonic recovery alert is blocking the UI test. "
                 + "Clean simulator state or resolve the alert manually before running this flow."


### PR DESCRIPTION
## Issue being fixed or feature implemented

Two related sets of issues in the Swift example app:

**Network leakage across the UI.** Switching the active network (e.g. from Testnet to Local/Regtest) left every UI surface still showing the previous network's data:
- **Storage Explorer**: every list and per-row count was unfiltered.
- **Wallets** tab: showed wallets from all networks, with the empty-state hidden behind testnet rows.
- **Sync Status → Platform**: the aggregate Platform Balance / Active Addresses summed across every network's rows, and the BLAST sync service stayed pinned to whichever wallet was picked at bootstrap.
- **Create Wallet** + **Wallet Info**: had no entry for Local (Regtest), so wallets could not be created on regtest from the active-network flow.

**Orphan-mnemonic recovery fired one alert at a time.** With N stored mnemonics, the user got N "Recover Wallet?" alerts and N system passcode prompts — even when every wallet shared the same code.

## What was done?

### 1. Storage Explorer — network-scoped views and counts

`StorageExplorerView` now reads `appState.currentNetwork`, surfaces it as a header row, and threads it into every per-model list view. `StorageModelListViews.swift` was overhauled so each `*StorageListView` accepts `network: Network` and filters its rows:

- Direct `networkRaw == raw` for models with the column (Identity, Document, DataContract, TokenBalance, DPNSName, DashpayProfile/ContactRequest, PlatformAddressesSyncState, Wallet, WalletManagerMetadata).
- Relationship traversal for derived rows (`dataContract?.networkRaw`, `documentType?.dataContract?.networkRaw`, `identity?.networkRaw`, `account?.wallet.networkRaw`).
- A `Set<Data>` of wallet IDs on the active network for the wallet-id-keyed models (Transaction, Txo, PendingInput, PlatformAddress fallback) — those can't go through SwiftData predicates because the optional-chain doesn't translate to SQL.

`loadCounts()` mirrors the same split: predicate-based `fetchCount` for the direct columns, in-memory filtering for the rest. The counts re-evaluate on `appState.currentNetwork` change, not just on appear.

### 2. SwiftData indexes on heavily-queried columns

Pre-release, so no migration plan needed (DB rebuilds in dev). Added `#Index<>` declarations on the columns that are filter targets in production hot paths:
- `\.networkRaw` on `PersistentIdentity`, `PersistentDocument`, `PersistentDataContract`, `PersistentTokenBalance`, `PersistentWallet`.
- `\.walletId` on `PersistentTxo`, `PersistentPlatformAddress`.
- `PersistentPendingInput` already had `\.outpoint`; combined into one `#Index<>([\.outpoint], [\.walletId])` declaration since SwiftData allows only a single `#Index` macro per model.

Skipped where they wouldn't help: `PersistentCoreAddress` has no `networkRaw` / `walletId` column (resolves through `account?.wallet`), `PersistentPlatformAddressesSyncState` has one row per network, and `PersistentDPNSName`/`Profile`/`ContactRequest` already get implicit indexes from compound `#Unique` declarations leading on `networkRaw`.

### 3. Wallets tab + Sync Status — network-scoped

- `WalletsContentView` filters the `@Query` results by `platformState.currentNetwork.rawValue` so testnet wallets stop bleeding into the Local list, and the empty-state ("No Local Wallets") fires correctly.
- `CoreContentView` aggregates `PersistentPlatformAddress` rows scoped to wallets on the active network — the Platform Balance and Active Addresses zero out when the active network has no wallets.
- `SwiftExampleAppApp.rebindWalletScopedServices()` now picks a managed wallet on the active network (via a `PersistentWallet.networkRaw` lookup) instead of `walletManager.firstWallet`, and a new `.onChange(of: platformState.currentNetwork)` modifier triggers the rebind on network switch. When no wallet exists on the active network, BLAST sync is stopped and `PlatformBalanceSyncService.reset()` clears the UI surface.

### 4. Regtest exposed in the wallet-creation paths

- `CreateWalletView`: added a `shouldShowRegtest` toggle that mirrors `shouldShowDevnet` (only renders when the active network is regtest), wired `createForRegtest` (which had been a dead variable) into `hasNetworkSelected` and `selectedNetworks`. Without this, creating on Local silently failed with "No network selected".
- `WalletInfoView`: added the "Local (Regtest)" row in the Networks section with the same +/checkmark UX as the others, plus the matching "Regtest Accounts" line in the Information section. `regtestEnabled` was already declared and `loadNetworkStates()` already had the case — only the UI was missing.

### 5. Multi-wallet orphan-mnemonic recovery

`ContentView` now collects all orphan wallets up-front into `[OrphanWalletEntry]`, with name + network resolved from `WalletKeychainMetadata`, and shows one alert ("Recover Wallets?" / "Recover Wallet?") instead of looping per wallet. On Authorize, a new `RecoverWalletsSheet` lists every orphan with a "Same pin code" toggle (default on, hidden when N=1):
- All toggle-on wallets share a single `LAContext.evaluatePolicy` prompt (one passcode entry covers the group).
- Each toggle-off wallet gets its own prompt with a per-wallet `localizedReason`.
- A footer hint reflects the current grouping live ("2 wallets share a prompt; 1 will prompt separately").
- Cancel on the shared prompt routes to the keep/delete decision; cancel on a per-wallet prompt skips just that wallet.

The keep/delete fallback is also unified — "Keep these Wallets?" with Recreate or Delete All clears every queued mnemonic + metadata in one shot. `WalletStorage.retrieveMnemonic` doesn't gate on biometry (the keychain item is `kSecAttrAccessibleWhenUnlockedThisDeviceOnly` with no `SecAccessControl`), so a single successful auth is sufficient to read N mnemonics — no LAContext threading needed.

## How Has This Been Tested?

- `xcodebuild` passes for `SwiftExampleApp` against iPhone 16 simulator.
- Manually verified on the simulator: switched testnet ↔ regtest and confirmed Storage Explorer counts/lists, Wallets tab, and Sync Status all reflect only the active network's rows; created a wallet on Local via the Create flow; opened Wallet Info and added Local as an additional network on an existing wallet.
- Recovery flow exercised by clearing the SwiftData store while keeping keychain mnemonics around — confirmed the unified alert + sheet path with both shared and separated auth modes.
- Updated the `failIfRecoveryPromptVisible` UI-test helper to recognize either alert title (singular for one orphan, plural for many) so the existing pre-flight guard keeps working.

## Breaking Changes

None. All persistent-model changes are additive (new `#Index<>` declarations only — no column / relationship retypes); per memory the project is pre-release so the dev DB rebuild on the schema delta is fine.

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [x] I have made corresponding changes to the documentation if needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Batch recovery flow for multiple orphan wallets with flexible authentication options per wallet
  * Regtest network support in wallet creation and detail views
  * Network-scoped data filtering across app views (wallets, balances, addresses, transactions)

* **Performance**
  * Database query optimizations for network and wallet-scoped data retrieval

<!-- end of auto-generated comment: release notes by coderabbit.ai -->