### PR TITLE
chore: ignore project-local .mcp.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -97,6 +97,7 @@ __pycache__/
 .claude/settings.local.json
 .claude/worktrees/
 .claude/scheduled_tasks.lock
+.mcp.json
 .codex/
 
 # Security audit reports (local-only, not committed)


### PR DESCRIPTION
## Issue being fixed or feature implemented
Claude Code's project-scoped MCP config (`.mcp.json`) was untracked but not ignored, so it would show up in `git status` and risk being committed. The choice of MCP servers (XcodeBuildMCP, ios-simulator-mcp, etc.) is a per-developer tooling preference and shouldn't be imposed on the team.

## What was done?
Added `.mcp.json` to `.gitignore`, placed alongside the existing personal-Claude-config ignores (`.claude/settings.local.json`, `.claude/scheduled_tasks.lock`) and `.codex/`.

```
 .claude/settings.local.json
 .claude/worktrees/
 .claude/scheduled_tasks.lock
+.mcp.json
 .codex/
```

If a future change calls for a *team-wide* MCP config (e.g. shipping a standard XcodeBuildMCP setup for everyone), that's a separate decision and would be done by either removing this entry or committing a tracked file with `git add -f`.

## How Has This Been Tested?
- Created a local `.mcp.json` in the repo root and confirmed `git status` no longer reports it.
- `.gitignore` change is the only file in the diff.

## Breaking Changes
None.

## Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [ ] I have made corresponding changes to the documentation if needed

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone