### PR TITLE
fix(swift-example-app): hold one PlatformWalletManager per network

### DIFF
--- a/packages/swift-sdk/Sources/SwiftDashSDK/PlatformWallet/PlatformWalletManager.swift
+++ b/packages/swift-sdk/Sources/SwiftDashSDK/PlatformWallet/PlatformWalletManager.swift
@@ -97,17 +97,33 @@ public class PlatformWalletManager: ObservableObject {
                 "dash_sdk_get_inner_sdk_ptr returned NULL for the supplied SDK"
             )
         }
-        try configure(sdkPointer: UnsafeRawPointer(innerSdkPtr), modelContainer: modelContainer)
+        // The Rust manager is network-locked at construction
+        // (`WalletManager::new(sdk.network)`); thread that same
+        // network through to the persistence handler so its
+        // `loadWalletList` only restores wallets bound to this
+        // network, matching the per-network manager design.
+        try configure(
+            sdkPointer: UnsafeRawPointer(innerSdkPtr),
+            modelContainer: modelContainer,
+            network: sdk.network
+        )
     }
 
     /// Configure with a raw Sdk pointer (advanced usage).
-    public func configure(sdkPointer: UnsafeRawPointer, modelContainer: ModelContainer? = nil) throws {
+    public func configure(
+        sdkPointer: UnsafeRawPointer,
+        modelContainer: ModelContainer? = nil,
+        network: Network? = nil
+    ) throws {
         var handle: Handle = NULL_HANDLE
 
         let handler: PlatformWalletPersistenceHandler?
         var persistence: PersistenceCallbacks
         if let container = modelContainer {
-            let h = PlatformWalletPersistenceHandler(modelContainer: container)
+            let h = PlatformWalletPersistenceHandler(
+                modelContainer: container,
+                network: network
+            )
             persistence = h.makeCallbacks()
             handler = h
         } else {

--- a/packages/swift-sdk/Sources/SwiftDashSDK/PlatformWallet/PlatformWalletPersistenceHandler.swift
+++ b/packages/swift-sdk/Sources/SwiftDashSDK/PlatformWallet/PlatformWalletPersistenceHandler.swift
@@ -10,6 +10,15 @@ import DashSDKFFI
 public class PlatformWalletPersistenceHandler {
     let modelContainer: ModelContainer
 
+    /// Network this handler's owning `PlatformWalletManager` is bound
+    /// to. When set, `loadWalletList` filters out persisted wallets
+    /// from other networks so a per-network manager only restores its
+    /// own wallets. `nil` keeps the legacy "load every wallet"
+    /// behavior for callers that don't yet thread network through —
+    /// once the example app's `WalletManagerStore` is the only
+    /// caller, the `nil` path can be retired.
+    let network: Network?
+
     /// Background context for writing from callback threads.
     ///
     /// `ModelContext` is not thread-safe — touching it from the
@@ -37,8 +46,9 @@ public class PlatformWalletPersistenceHandler {
     /// atomically.
     private var inChangeset = false
 
-    public init(modelContainer: ModelContainer) {
+    public init(modelContainer: ModelContainer, network: Network? = nil) {
         self.modelContainer = modelContainer
+        self.network = network
         self.backgroundContext = ModelContext(modelContainer)
         self.backgroundContext.autosaveEnabled = true
     }
@@ -2120,7 +2130,22 @@ public class PlatformWalletPersistenceHandler {
     /// Returns `(nil, 0)` if nothing is restorable.
     func loadWalletList() -> (entries: UnsafePointer<WalletRestoreEntryFFI>?, count: Int, errored: Bool) {
         onQueue {
-        let walletDescriptor = FetchDescriptor<PersistentWallet>()
+        // Scope the fetch to the handler's bound network so a
+        // per-network manager only sees its own wallets. If
+        // `network` is `nil` (legacy callers that haven't threaded
+        // network through yet) we fall back to the cross-network
+        // fetch — those callers were already fragile against
+        // cross-network data and the new path keeps them on the
+        // pre-refactor behavior until they migrate.
+        let walletDescriptor: FetchDescriptor<PersistentWallet>
+        if let network = self.network {
+            let raw = network.rawValue
+            walletDescriptor = FetchDescriptor<PersistentWallet>(
+                predicate: #Predicate { $0.networkRaw == raw }
+            )
+        } else {
+            walletDescriptor = FetchDescriptor<PersistentWallet>()
+        }
         let wallets: [PersistentWallet]
         do {
             wallets = try backgroundContext.fetch(walletDescriptor)

--- a/packages/swift-sdk/SwiftExampleApp/SwiftExampleApp/SwiftExampleAppApp.swift
+++ b/packages/swift-sdk/SwiftExampleApp/SwiftExampleApp/SwiftExampleAppApp.swift
@@ -27,14 +27,27 @@ struct SwiftExampleAppApp: App {
     // Platform identity / document / contract state.
     @StateObject private var platformState = AppState()
 
-    // The one wallet manager — drives SPV, BLAST sync, wallet creation, etc.
-    @StateObject private var walletManager = PlatformWalletManager()
+    // Per-network wallet managers. The Rust `PlatformWalletManager`
+    // is network-locked at `configure(...)` time, so swapping
+    // networks at runtime needs a different manager instance —
+    // not a reconfigured one. The store lazy-creates a manager per
+    // network and republishes the active one so the SwiftUI
+    // environment rebinds to the right instance on switch.
+    @StateObject private var walletManagerStore: WalletManagerStore
 
     // Remaining services.
     @StateObject private var shieldedService = ShieldedService()
     @StateObject private var platformBalanceSyncService = PlatformBalanceSyncService()
     @StateObject private var transitionState = TransitionState()
     @StateObject private var appUIState = AppUIState()
+
+    /// Current manager exposed to views via the env object pipeline.
+    /// Reads from the published `activeManager` on every body
+    /// invocation so the env object rebinds whenever
+    /// `walletManagerStore.activate(...)` swaps the active manager.
+    private var walletManager: PlatformWalletManager {
+        walletManagerStore.activeManager
+    }
 
     @State private var isInitialized = false
     @State private var bootstrapError: Error?
@@ -57,17 +70,35 @@ struct SwiftExampleAppApp: App {
         // `cleanupLegacyItems` itself.
         WalletStorage.cleanupLegacyItems()
 
+        let container: ModelContainer
         do {
-            self.modelContainer = try DashModelContainer.create()
+            container = try DashModelContainer.create()
         } catch {
             fatalError("Failed to create ModelContainer: \(error)")
         }
+        self.modelContainer = container
+        // Build the store eagerly so the autoclosure for
+        // `@StateObject` can capture the local `container`
+        // directly — referencing `self.modelContainer` here would
+        // make the autoclosure capture `self` mutating, which the
+        // compiler rejects. Same `container` is handed to every
+        // per-network manager the store lazy-creates.
+        _walletManagerStore = StateObject(
+            wrappedValue: WalletManagerStore(modelContainer: container)
+        )
     }
 
     var body: some Scene {
         WindowGroup {
             ContentView(isInitialized: isInitialized, bootstrapError: bootstrapError, onRetry: retryBootstrap)
                 .environmentObject(platformState)
+                // Re-injected on every body invocation. When the
+                // store swaps `activeManager` (network switch), the
+                // computed `walletManager` returns the new instance
+                // and SwiftUI rebinds the env object — the 40+
+                // `@EnvironmentObject var walletManager:
+                // PlatformWalletManager` consumers see the right
+                // network's manager without any view changes.
                 .environmentObject(walletManager)
                 .environmentObject(shieldedService)
                 .environmentObject(platformBalanceSyncService)
@@ -92,30 +123,60 @@ struct SwiftExampleAppApp: App {
                 })) { _, _ in
                     rebindWalletScopedServices()
                 }
-                // Rebind on network switch as well — without this,
-                // the balance-sync service stays pinned to whatever
-                // wallet was picked at bootstrap, which leaks the
-                // previous network's Platform Balance / Active
-                // Addresses / Last Sync into the Sync Status tab
-                // for the new network.
-                .onChange(of: platformState.currentNetwork) { _, _ in
+                // Network switch: activate the per-network manager
+                // first (the store lazy-creates one configured with
+                // a fresh SDK if this is the first time we see this
+                // network), then rebind the wallet-scoped services
+                // against it. Order matters — `rebindWalletScopedServices`
+                // reads `walletManager.firstWallet`, which has to
+                // resolve to the new network's manager before it
+                // runs.
+                .onChange(of: platformState.currentNetwork) { _, newNetwork in
+                    activateManager(for: newNetwork)
                     rebindWalletScopedServices()
                 }
         }
     }
 
+    /// Lazy-create + cache a `PlatformWalletManager` for `network`,
+    /// configured against `platformState.sdk`. No-ops on the
+    /// already-active network. Called from bootstrap and from
+    /// `currentNetwork.onChange`.
+    @MainActor
+    private func activateManager(for network: Network) {
+        guard let sdk = platformState.sdk else {
+            SDKLogger.error(
+                "Cannot activate wallet manager for \(network.displayName): "
+                    + "no SDK available (still bootstrapping?)"
+            )
+            return
+        }
+        do {
+            try walletManagerStore.activate(network: network, sdk: sdk)
+        } catch {
+            SDKLogger.error(
+                "Failed to activate wallet manager for "
+                    + "\(network.displayName): \(error.localizedDescription)"
+            )
+        }
+    }
+
     /// Drive manager-wide BLAST sync state from the set of loaded
-    /// wallets. With no wallets present *on the active network*,
-    /// sync is stopped and the per-wallet `PlatformBalanceSyncService`
+    /// wallets. With no wallets present on the active manager, sync
+    /// is stopped and the per-wallet `PlatformBalanceSyncService`
     /// UI surface is reset — so the Sync Status tab shows zeros for
     /// a network the user hasn't created a wallet on yet, instead
     /// of leaking values from a wallet on a different network.
     /// Otherwise, we bind the balance service to a deterministic
-    /// wallet on that network. (Detail views reconfigure the
+    /// wallet on the active manager. (Detail views reconfigure the
     /// service per-wallet themselves.)
+    ///
+    /// The active manager is per-network now, so its `firstWallet`
+    /// is already correctly scoped — no need for a separate
+    /// network-filtering pass at this layer.
     @MainActor
     private func rebindWalletScopedServices() {
-        let wallet = firstWalletOnActiveNetwork()
+        let wallet = walletManager.firstWallet
         guard let wallet else {
             do {
                 try walletManager.stopPlatformAddressSync()
@@ -149,32 +210,6 @@ struct SwiftExampleAppApp: App {
         }
     }
 
-    /// Lowest-walletId managed wallet that's tagged to
-    /// `platformState.currentNetwork`. The Rust manager doesn't
-    /// track networks per wallet, so the source of truth is the
-    /// SwiftData `PersistentWallet.networkRaw` column — which the
-    /// persister fills in alongside the wallet creation that
-    /// populated `walletManager.wallets`. Returns `nil` when the
-    /// active network has no managed wallet (yet).
-    @MainActor
-    private func firstWalletOnActiveNetwork() -> ManagedPlatformWallet? {
-        let raw = platformState.currentNetwork.rawValue
-        let descriptor = FetchDescriptor<PersistentWallet>(
-            predicate: #Predicate { $0.networkRaw == raw }
-        )
-        let context = modelContainer.mainContext
-        let rows = (try? context.fetch(descriptor)) ?? []
-        // Sort by walletId so the choice is deterministic across
-        // launches — same shape as `PlatformWalletManager.firstWallet`.
-        let sortedIds = rows
-            .map(\.walletId)
-            .sorted { $0.lexicographicallyPrecedes($1) }
-        for id in sortedIds {
-            if let managed = walletManager.wallets[id] { return managed }
-        }
-        return nil
-    }
-
     @MainActor
     private func bootstrap() async {
         do {
@@ -186,25 +221,22 @@ struct SwiftExampleAppApp: App {
             try? await Task.sleep(for: .milliseconds(500))
 
             if let sdk = platformState.sdk {
-                // Configure the wallet manager.
-                try walletManager.configure(sdk: sdk, modelContainer: modelContainer)
-
-                // Restore wallets from the persister (SwiftData). If
-                // no wallets have been persisted yet this is a no-op.
-                // Restored wallets come back watch-only; signing is
-                // deferred until the user unlocks via biometric +
-                // Keychain-stored mnemonic (future work).
-                do {
-                    let restored = try walletManager.loadFromPersistor()
-                    if !restored.isEmpty {
-                        SDKLogger.log(
-                            "🔓 Restored \(restored.count) wallet(s) from persister",
-                            minimumLevel: .medium
-                        )
-                    }
-                } catch {
-                    SDKLogger.error(
-                        "Failed to restore wallets from persister: \(error.localizedDescription)"
+                // Activate the per-network manager for the launch
+                // network. The store creates + configures the
+                // manager and runs `loadFromPersistor` against it
+                // (filtered to the launch network's wallets via
+                // the network-aware persistence handler), so no
+                // separate restore pass is needed here.
+                try walletManagerStore.activate(
+                    network: platformState.currentNetwork,
+                    sdk: sdk
+                )
+                let restoredCount = walletManager.wallets.count
+                if restoredCount > 0 {
+                    SDKLogger.log(
+                        "🔓 Restored \(restoredCount) wallet(s) from persister "
+                            + "for \(platformState.currentNetwork.displayName)",
+                        minimumLevel: .medium
                     )
                 }
 

--- a/packages/swift-sdk/SwiftExampleApp/SwiftExampleApp/WalletManagerStore.swift
+++ b/packages/swift-sdk/SwiftExampleApp/SwiftExampleApp/WalletManagerStore.swift
@@ -1,0 +1,115 @@
+import Foundation
+import SwiftData
+import SwiftUI
+import SwiftDashSDK
+
+/// Coordinator that holds one `PlatformWalletManager` per network.
+///
+/// The Rust `PlatformWalletManager` is intentionally network-locked
+/// — its inner `WalletManager` is constructed with `sdk.network` at
+/// `configure(...)` time and the SDK reference (plus the SPV
+/// runtime, BLAST sync coordinator, and persistence handler hung off
+/// it) all stay bound to that single network for the manager's
+/// lifetime. Switching networks at runtime therefore needs a
+/// **different manager**, not a reconfigured one.
+///
+/// `WalletManagerStore` materializes that design on the iOS side:
+///
+///   * Lazy-creates a `PlatformWalletManager` the first time a
+///     network is activated, keying on `Network` so subsequent
+///     activations of the same network return the warm manager.
+///   * Each manager's persistence handler is constructed with the
+///     same network (via `configure(sdk:modelContainer:)`), which
+///     scopes `loadWalletList` to that network's `PersistentWallet`
+///     rows — multiple managers writing into the shared SwiftData
+///     store don't trip over each other on hydration.
+///   * Publishes `activeManager` so the SwiftUI scene can re-inject
+///     it via `.environmentObject(...)` on every switch. Existing
+///     view consumers (`@EnvironmentObject var walletManager:
+///     PlatformWalletManager`) keep working unchanged — they just
+///     see the manager for the active network on each render after
+///     a switch.
+///
+/// Inactive managers stay alive in the background. SPV / BLAST sync
+/// continue running for them; the user can flip Testnet ↔ Local ↔
+/// ... and resume per-network state without losing in-flight sync
+/// progress. The cost is N×manager memory for N networks the user
+/// has touched this session — tractable for the 4-network upper
+/// bound the app supports today, and the right trade-off for a
+/// dev-focused example app where flipping is common.
+@MainActor
+final class WalletManagerStore: ObservableObject {
+    /// Currently-active manager. Reassigned when the user switches
+    /// networks; SwiftUI re-injects this into the env object so
+    /// every `@EnvironmentObject var walletManager:
+    /// PlatformWalletManager` consumer rebinds to the right
+    /// instance on each render.
+    ///
+    /// Starts as a placeholder, unconfigured `PlatformWalletManager`
+    /// — the bootstrap path replaces it via `activate(...)` once
+    /// the SDK for the initial network is ready, and views are
+    /// gated behind `isInitialized` until that happens (same
+    /// gating the pre-refactor single-manager flow used).
+    @Published private(set) var activeManager: PlatformWalletManager
+
+    /// Per-network managers. Lazily populated on first activation
+    /// of each network; lookup is O(1).
+    private var managers: [Network: PlatformWalletManager] = [:]
+
+    /// SwiftData container shared across every manager. Each
+    /// manager's persistence handler narrows its `loadWalletList`
+    /// fetch to its own network so the shared store doesn't cause
+    /// cross-network bleed at restore time.
+    private let modelContainer: ModelContainer
+
+    init(modelContainer: ModelContainer) {
+        self.modelContainer = modelContainer
+        // Placeholder. Held until the first `activate(...)` call
+        // replaces it with a configured manager. Views gate against
+        // bootstrap via `isInitialized` so they never see this
+        // intermediate value.
+        self.activeManager = PlatformWalletManager()
+    }
+
+    /// Activate the manager for `network`, lazily creating + caching
+    /// one configured against `sdk` if it's not already warm.
+    ///
+    /// Idempotent: re-activating the current network is a no-op.
+    /// Failures during a fresh manager's `configure` /
+    /// `loadFromPersistor` propagate to the caller — the cache
+    /// stays untouched in that case so a later retry can succeed.
+    func activate(network: Network, sdk: SDK) throws {
+        if let existing = managers[network] {
+            if existing !== activeManager {
+                activeManager = existing
+            }
+            return
+        }
+        let manager = PlatformWalletManager()
+        try manager.configure(sdk: sdk, modelContainer: modelContainer)
+        // Best-effort: a fresh manager comes up with no wallets in
+        // memory; restore from the network-scoped persistence
+        // handler so reopening the app on this network resurfaces
+        // the wallets the user already created here. Failures here
+        // are non-fatal — the user can still create / import
+        // wallets, the in-memory set just starts empty.
+        do {
+            _ = try manager.loadFromPersistor()
+        } catch {
+            SDKLogger.error(
+                "WalletManagerStore: load-from-persistor failed for "
+                    + "\(network.displayName): \(error.localizedDescription)"
+            )
+        }
+        managers[network] = manager
+        activeManager = manager
+    }
+
+    /// Manager for `network` if one has been activated this session;
+    /// otherwise `nil`. Used for diagnostics surfaces (e.g. Wallet
+    /// Memory Explorer) that want to inspect a specific network's
+    /// state without forcing it active.
+    func manager(for network: Network) -> PlatformWalletManager? {
+        managers[network]
+    }
+}


### PR DESCRIPTION
Replaces the closed #3588 — that PR papered over the symptom in the wrong layer; this one fixes the root cause.

The Rust `PlatformWalletManager` is intentionally network-locked: `WalletManager::new(sdk.network)` at [`packages/rs-platform-wallet/src/manager/mod.rs:70`](https://github.com/dashpay/platform/blob/v3.1-dev/packages/rs-platform-wallet/src/manager/mod.rs#L70) bakes the network in, and the SDK / SPV runtime / BLAST sync / persistence handler all stay bound to that single network. Switching networks at runtime needs a different manager instance, not a reconfigured one.

The example app previously held a single `PlatformWalletManager` for the whole app lifetime, so creating a regtest wallet after a runtime switch silently misattributed the wallet to the bootstrap-time network's manager.

## Changes

1. **Network-aware persistence handler** — `PlatformWalletPersistenceHandler` gains a `network: Network?` field; `loadWalletList` scopes its fetch to that network when set so multiple managers writing into the shared SwiftData store don't trip over each other on hydration.
2. **`PlatformWalletManager.configure` threads `sdk.network` through to the handler.**
3. **New `WalletManagerStore`** holds `[Network: PlatformWalletManager]`, lazy-creates per network on first activation, caches for fast switch-back, and publishes `activeManager` for re-injection into the SwiftUI environment.
4. **`SwiftExampleAppApp` rewired** around the store. A computed `walletManager: PlatformWalletManager { walletManagerStore.activeManager }` keeps every existing `@EnvironmentObject var walletManager: PlatformWalletManager` consumer working unchanged — they just see the right network's manager on each render after a switch.
5. **Removed `firstWalletOnActiveNetwork()` helper** — the active manager's own `firstWallet` is now correctly scoped.

Inactive managers stay alive; SPV / BLAST sync continues in the background so flipping networks resumes per-network state without losing in-flight progress. Pausing inactive managers can land as a follow-up.

## How Has This Been Tested?

- `xcodebuild -scheme SwiftExampleApp -sdk iphonesimulator` passes.
- Manually on the simulator: launched on Testnet, switched to Local, created a regtest wallet. Pre-fix the wallet vanished into the testnet partition with "No Local Wallets" stuck. Post-fix the wallet appears under Local with `networkRaw = 3`; flipping back to Testnet shows the testnet wallets unchanged.

## Breaking Changes

None on the public Swift SDK API. The new `network: Network? = nil` parameters default to `nil`, preserving every existing callsite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)