### PR TITLE
fix(platform-wallet): satisfy accessors clippy lints

### DIFF
--- a/packages/rs-platform-wallet/src/manager/accessors.rs
+++ b/packages/rs-platform-wallet/src/manager/accessors.rs
@@ -347,10 +347,10 @@ impl<P: PlatformWalletPersistence + 'static> PlatformWalletManager<P> {
         // through a helper on the manager — since the registry itself
         // isn't exposed, fall back to "0" until a sync getter is
         // added. This is intentionally a TODO surface, not a guess.
-        let queue_depth = match self.identity_sync_manager.try_queue_depth() {
-            Some(n) => n,
-            None => 0,
-        };
+        let queue_depth = self
+            .identity_sync_manager
+            .try_queue_depth()
+            .unwrap_or_default();
         IdentitySyncConfigSnapshot {
             interval_seconds: interval.as_secs().max(1),
             queue_depth,
@@ -702,7 +702,7 @@ impl<P: PlatformWalletPersistence + 'static> PlatformWalletManager<P> {
             .map(|(reg_idx, managed)| {
                 use dpp::identity::accessors::IdentityGettersV0;
                 WalletIdentityRowSnapshot {
-                    registration_index: *reg_idx as u32,
+                    registration_index: *reg_idx,
                     identity_id: managed.identity.id().to_buffer(),
                 }
             })
@@ -739,11 +739,7 @@ fn pool_snapshot(pool: &AddressPool) -> AccountAddressPoolSnapshot {
         AddressPoolType::AbsentHardened => 3,
     };
     let last_used_index: i64 = pool.highest_used.map(|i| i as i64).unwrap_or(-1);
-    let addresses = pool
-        .addresses
-        .values()
-        .map(|info| addr_info_snapshot(info))
-        .collect();
+    let addresses = pool.addresses.values().map(addr_info_snapshot).collect();
     AccountAddressPoolSnapshot {
         pool_type,
         gap_limit: pool.gap_limit,


### PR DESCRIPTION
# fix(platform-wallet): satisfy accessors clippy lints

## Issue being fixed or feature implemented

Fixes `cargo clippy -p platform-wallet --all-targets -- -D warnings` failures
on `v3.1-dev` caused by newly-denied clippy lints in
`PlatformWalletManager` accessors.

## What was done?

- Replaced a manual `Option` fallback with `.unwrap_or_default()`.
- Removed an unnecessary `u32 -> u32` cast from wallet identity row snapshots.
- Replaced a redundant closure with the helper function directly.

## How Has This Been Tested?

- `cargo fmt --all`
- `cargo clippy -p platform-wallet --all-targets -- -D warnings`
- Pre-PR code review gate: `ship`

## Breaking Changes

None.

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have added "!" to the title and described breaking changes in the
  corresponding section if my code contains any
- [ ] I have made corresponding changes to the documentation if needed

## For repository code-owners and collaborators only

- [ ] I have assigned this pull request to a milestone


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified internal code patterns for improved maintainability and consistency. No user-facing changes or API modifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->