### PR TITLE
fix(swift-sdk): update ReceiveAddressView to correctly show BIP44 and BIP32 addresses

### DIFF
--- a/packages/swift-sdk/SwiftExampleApp/SwiftExampleApp/Core/Views/ReceiveAddressView.swift
+++ b/packages/swift-sdk/SwiftExampleApp/SwiftExampleApp/Core/Views/ReceiveAddressView.swift
@@ -9,6 +9,27 @@ enum ReceiveAddressTab: String, CaseIterable {
     case shielded = "Shielded"
 }
 
+/// Sub-selector for the Core tab: a wallet created with the default
+/// account-creation options carries both a BIP44 and a BIP32
+/// "Standard" account at index 0 (different `standardTag`s — see
+/// `key-wallet` `WalletAccountCreationOptions::Default`). This lets
+/// the user pick which one to derive the receive address from.
+enum CoreReceiveAccountKind: String, CaseIterable {
+    case bip44 = "BIP44"
+    case bip32 = "BIP32"
+
+    /// The `standardTag` value the persistence layer assigns to this
+    /// account kind (0 = BIP44, 1 = BIP32). Used to disambiguate
+    /// rows in `PersistentAccount` — `(accountType=0, accountIndex=0)`
+    /// alone is not unique once both kinds are present.
+    var standardTag: UInt8 {
+        switch self {
+        case .bip44: return 0
+        case .bip32: return 1
+        }
+    }
+}
+
 struct ReceiveAddressView: View {
     @Environment(\.dismiss) private var dismiss
     @EnvironmentObject var walletManager: PlatformWalletManager
@@ -28,18 +49,19 @@ struct ReceiveAddressView: View {
     @Query private var platformAddresses: [PersistentPlatformAddress]
 
     @State private var selectedTab: ReceiveAddressTab = .core
+    @State private var coreAccountKind: CoreReceiveAccountKind = .bip44
     @State private var copiedToClipboard = false
     @State private var faucetStatus: String?
     @State private var isFaucetLoading = false
 
-    /// Lowest-indexed external address on the primary BIP44 account
-    /// that has never received an inbound transaction.
-    /// `PersistentCoreAddress` rows are populated by the Rust
-    /// `on_persist_account_address_pools_fn` callback at wallet creation
-    /// (initial gap-limit fill), so they're available without a
-    /// runtime FFI hop.
+    /// Lowest-indexed external address on the selected Standard
+    /// account (`coreAccountKind` picks BIP44 or BIP32) that has never
+    /// received an inbound transaction. `PersistentCoreAddress` rows
+    /// are populated by the Rust `on_persist_account_address_pools_fn`
+    /// callback at wallet creation (initial gap-limit fill), so
+    /// they're available without a runtime FFI hop.
     private var nextCoreReceiveAddress: PersistentCoreAddress? {
-        guard let account = primaryBip44Account else { return nil }
+        guard let account = primaryStandardAccount else { return nil }
         return firstUnreceivedAddress(in: account, poolTag: 0)
     }
 
@@ -64,20 +86,32 @@ struct ReceiveAddressView: View {
         return best
     }
 
-    /// Primary Standard account (BIP44 or BIP32) for the active wallet,
-    /// or nil if it hasn't been persisted yet. `standardTag` is not
-    /// required to match — a wallet only ever has one `(accountType=0,
-    /// accountIndex=0)` account, so the uniqueness already follows
-    /// from the two upstream fields.
-    private var primaryBip44Account: PersistentAccount? {
-        findAccount(accountType: 0, accountIndex: 0)
+    /// Primary Standard account at index 0 for the active wallet,
+    /// disambiguated by `coreAccountKind` (BIP44 / BIP32). A wallet
+    /// created with `WalletAccountCreationOptions::Default` carries
+    /// both — `(accountType=0, accountIndex=0)` is **not** unique, the
+    /// `standardTag` distinguishes them (0 = BIP44, 1 = BIP32). Earlier
+    /// versions of this view filtered without `standardTag` and
+    /// silently picked whichever the SwiftData iterator returned
+    /// first.
+    private var primaryStandardAccount: PersistentAccount? {
+        findAccount(
+            accountType: 0,
+            standardTag: coreAccountKind.standardTag,
+            accountIndex: 0
+        )
     }
 
-    private func findAccount(accountType: UInt32, accountIndex: UInt32) -> PersistentAccount? {
+    private func findAccount(
+        accountType: UInt32,
+        standardTag: UInt8,
+        accountIndex: UInt32
+    ) -> PersistentAccount? {
         let walletId = wallet.walletId
         for account in allAccounts {
             if account.wallet.walletId != walletId { continue }
             if account.accountType != accountType { continue }
+            if account.standardTag != standardTag { continue }
             if account.accountIndex != accountIndex { continue }
             return account
         }
@@ -166,6 +200,16 @@ struct ReceiveAddressView: View {
                 }
                 .pickerStyle(.segmented)
                 .padding(.horizontal)
+
+                if selectedTab == .core {
+                    Picker("Account Kind", selection: $coreAccountKind) {
+                        ForEach(CoreReceiveAccountKind.allCases, id: \.self) { kind in
+                            Text(kind.rawValue).tag(kind)
+                        }
+                    }
+                    .pickerStyle(.segmented)
+                    .padding(.horizontal)
+                }
 
                 if hasValidAddress {
                     if let qrImage = generateQRCode(from: currentAddress) {
@@ -278,12 +322,15 @@ struct ReceiveAddressView: View {
             .onChange(of: selectedTab) { _, _ in
                 copiedToClipboard = false
             }
+            .onChange(of: coreAccountKind) { _, _ in
+                copiedToClipboard = false
+            }
         }
     }
 
     private var addressLabel: String {
         switch selectedTab {
-        case .core: return "Your Core Address"
+        case .core: return "Your Core \(coreAccountKind.rawValue) Address"
         case .platform: return "Your Platform Address"
         case .shielded: return "Your Shielded Address"
         }


### PR DESCRIPTION
the view now lets you chose between accounts instead of randomly picking one of them (it was matching against the first one in the list because we were not taking in consideration the standardTag field, see line 114)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [ ] I have made corresponding changes to the documentation if needed

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features

* Added the ability to select between BIP44 and BIP32 Core address formats when receiving funds
* Users can now switch between account standards in the Core tab to match their wallet configuration
* The Core address display clearly indicates which account standard is currently active
* Clipboard state resets when switching between different address formats

<!-- end of auto-generated comment: release notes by coderabbit.ai -->