### PR TITLE
fix(swift-example-app): receive address always picks BIP44 account over BIP32

### DIFF
--- a/packages/swift-sdk/SwiftExampleApp/SwiftExampleApp/Core/Views/ReceiveAddressView.swift
+++ b/packages/swift-sdk/SwiftExampleApp/SwiftExampleApp/Core/Views/ReceiveAddressView.swift
@@ -16,16 +16,26 @@ struct ReceiveAddressView: View {
     @EnvironmentObject var shieldedService: ShieldedService
     let wallet: PersistentWallet
 
-    /// BIP44 accounts only (accountType == 0, standardTag == 0,
-    /// accountIndex == 0). Scalar-only predicate avoids the
-    /// type-checker budget issue that relationship-based filters hit.
-    /// The wallet-id check is the only remaining Swift-side filter.
-    @Query(filter: #Predicate<PersistentAccount> {
-        $0.accountType == 0 && $0.standardTag == 0 && $0.accountIndex == 0
-    }) private var bip44Accounts: [PersistentAccount]
-    /// All PlatformPayment (DIP-17) addresses. Filtered down to this
-    /// wallet in `nextPlatformReceiveAddress`.
+    /// The single primary BIP44 account for this wallet.
+    /// Predicate uses a single-hop relationship traversal for the
+    /// wallet id; single-hop is well within the type-checker budget
+    /// unlike the multi-condition relationship predicates that
+    /// previously caused compiler timeouts.
+    @Query private var bip44Accounts: [PersistentAccount]
+    /// PlatformPayment (DIP-17) addresses for this wallet.
     @Query private var platformAddresses: [PersistentPlatformAddress]
+
+    init(wallet: PersistentWallet) {
+        self.wallet = wallet
+        let walletId = wallet.walletId
+        _bip44Accounts = Query(filter: #Predicate<PersistentAccount> {
+            $0.wallet.walletId == walletId &&
+            $0.accountType == 0 &&
+            $0.standardTag == 0 &&
+            $0.accountIndex == 0
+        })
+        _platformAddresses = Query(filter: PersistentPlatformAddress.predicate(walletId: walletId))
+    }
 
     @State private var selectedTab: ReceiveAddressTab = .core
     @State private var copiedToClipboard = false
@@ -51,25 +61,15 @@ struct ReceiveAddressView: View {
     /// is unnecessary now that Platform addresses have their own
     /// model.
     private var nextPlatformReceiveAddress: PersistentPlatformAddress? {
-        let walletId = wallet.walletId
-        var best: PersistentPlatformAddress? = nil
-        for addr in platformAddresses {
-            if addr.walletId != walletId { continue }
-            if addr.isUsed { continue }
-            if let current = best, current.addressIndex <= addr.addressIndex {
-                continue
-            }
-            best = addr
-        }
-        return best
+        platformAddresses
+            .filter { !$0.isUsed }
+            .min(by: { $0.addressIndex < $1.addressIndex })
     }
 
-    /// Primary BIP44 account for the active wallet, or nil if not yet
-    /// persisted. Type/tag/index are pre-filtered by the @Query above;
-    /// the only remaining check is wallet identity.
+    /// Primary BIP44 account for this wallet. All filters applied in the
+    /// @Query; this is always at most one element.
     private var primaryBip44Account: PersistentAccount? {
-        let walletId = wallet.walletId
-        return bip44Accounts.first { $0.wallet.walletId == walletId }
+        bip44Accounts.first
     }
 
     /// Lowest-indexed address in the given pool on the given account

--- a/packages/swift-sdk/SwiftExampleApp/SwiftExampleApp/Core/Views/ReceiveAddressView.swift
+++ b/packages/swift-sdk/SwiftExampleApp/SwiftExampleApp/Core/Views/ReceiveAddressView.swift
@@ -16,13 +16,13 @@ struct ReceiveAddressView: View {
     @EnvironmentObject var shieldedService: ShieldedService
     let wallet: PersistentWallet
 
-    /// All persisted accounts across wallets. Filtered down to this
-    /// view's wallet + primary BIP44 account inside
-    /// `nextCoreReceiveAddress`. A `Query(filter:)` with the natural
-    /// predicate exceeded Swift's type-checker budget, so filtering in
-    /// Swift keeps compile times reasonable at negligible runtime
-    /// cost (tens of accounts per store, not thousands).
-    @Query private var allAccounts: [PersistentAccount]
+    /// BIP44 accounts only (accountType == 0, standardTag == 0,
+    /// accountIndex == 0). Scalar-only predicate avoids the
+    /// type-checker budget issue that relationship-based filters hit.
+    /// The wallet-id check is the only remaining Swift-side filter.
+    @Query(filter: #Predicate<PersistentAccount> {
+        $0.accountType == 0 && $0.standardTag == 0 && $0.accountIndex == 0
+    }) private var bip44Accounts: [PersistentAccount]
     /// All PlatformPayment (DIP-17) addresses. Filtered down to this
     /// wallet in `nextPlatformReceiveAddress`.
     @Query private var platformAddresses: [PersistentPlatformAddress]
@@ -64,22 +64,12 @@ struct ReceiveAddressView: View {
         return best
     }
 
-    /// Primary BIP44 account (standardTag == 0) for the active wallet,
-    /// or nil if it hasn't been persisted yet.
+    /// Primary BIP44 account for the active wallet, or nil if not yet
+    /// persisted. Type/tag/index are pre-filtered by the @Query above;
+    /// the only remaining check is wallet identity.
     private var primaryBip44Account: PersistentAccount? {
-        findAccount(accountType: 0, accountIndex: 0, standardTag: 0)
-    }
-
-    private func findAccount(accountType: UInt32, accountIndex: UInt32, standardTag: UInt8? = nil) -> PersistentAccount? {
         let walletId = wallet.walletId
-        for account in allAccounts {
-            if account.wallet.walletId != walletId { continue }
-            if account.accountType != accountType { continue }
-            if account.accountIndex != accountIndex { continue }
-            if let tag = standardTag, account.standardTag != tag { continue }
-            return account
-        }
-        return nil
+        return bip44Accounts.first { $0.wallet.walletId == walletId }
     }
 
     /// Lowest-indexed address in the given pool on the given account

--- a/packages/swift-sdk/SwiftExampleApp/SwiftExampleApp/Core/Views/ReceiveAddressView.swift
+++ b/packages/swift-sdk/SwiftExampleApp/SwiftExampleApp/Core/Views/ReceiveAddressView.swift
@@ -64,21 +64,19 @@ struct ReceiveAddressView: View {
         return best
     }
 
-    /// Primary Standard account (BIP44 or BIP32) for the active wallet,
-    /// or nil if it hasn't been persisted yet. `standardTag` is not
-    /// required to match — a wallet only ever has one `(accountType=0,
-    /// accountIndex=0)` account, so the uniqueness already follows
-    /// from the two upstream fields.
+    /// Primary BIP44 account (standardTag == 0) for the active wallet,
+    /// or nil if it hasn't been persisted yet.
     private var primaryBip44Account: PersistentAccount? {
-        findAccount(accountType: 0, accountIndex: 0)
+        findAccount(accountType: 0, accountIndex: 0, standardTag: 0)
     }
 
-    private func findAccount(accountType: UInt32, accountIndex: UInt32) -> PersistentAccount? {
+    private func findAccount(accountType: UInt32, accountIndex: UInt32, standardTag: UInt8? = nil) -> PersistentAccount? {
         let walletId = wallet.walletId
         for account in allAccounts {
             if account.wallet.walletId != walletId { continue }
             if account.accountType != accountType { continue }
             if account.accountIndex != accountIndex { continue }
+            if let tag = standardTag, account.standardTag != tag { continue }
             return account
         }
         return nil

--- a/packages/swift-sdk/SwiftExampleApp/SwiftExampleApp/Core/Views/ReceiveAddressView.swift
+++ b/packages/swift-sdk/SwiftExampleApp/SwiftExampleApp/Core/Views/ReceiveAddressView.swift
@@ -28,16 +28,19 @@ struct ReceiveAddressView: View {
     init(wallet: PersistentWallet) {
         self.wallet = wallet
         let walletId = wallet.walletId
-        _bip44Accounts = Query(filter: #Predicate<PersistentAccount> {
-            $0.wallet.walletId == walletId &&
-            $0.accountType == 0 &&
-            $0.standardTag == 0 &&
-            $0.accountIndex == 0
-        })
+        _bip44Accounts = Query(
+            filter: #Predicate<PersistentAccount> {
+                $0.wallet.walletId == walletId &&
+                $0.accountType == 0 &&
+                $0.standardTag == 0
+            },
+            sort: \.accountIndex
+        )
         _platformAddresses = Query(filter: PersistentPlatformAddress.predicate(walletId: walletId))
     }
 
     @State private var selectedTab: ReceiveAddressTab = .core
+    @State private var selectedAccountIndex: UInt32 = 0
     @State private var copiedToClipboard = false
     @State private var faucetStatus: String?
     @State private var isFaucetLoading = false
@@ -66,10 +69,9 @@ struct ReceiveAddressView: View {
             .min(by: { $0.addressIndex < $1.addressIndex })
     }
 
-    /// Primary BIP44 account for this wallet. All filters applied in the
-    /// @Query; this is always at most one element.
     private var primaryBip44Account: PersistentAccount? {
-        bip44Accounts.first
+        bip44Accounts.first { $0.accountIndex == selectedAccountIndex }
+            ?? bip44Accounts.first
     }
 
     /// Lowest-indexed address in the given pool on the given account
@@ -154,6 +156,26 @@ struct ReceiveAddressView: View {
                 }
                 .pickerStyle(.segmented)
                 .padding(.horizontal)
+
+                if selectedTab == .core && bip44Accounts.count > 1 {
+                    if bip44Accounts.count <= 4 {
+                        Picker("Account", selection: $selectedAccountIndex) {
+                            ForEach(bip44Accounts, id: \.accountIndex) { account in
+                                Text("Account \(account.accountIndex)").tag(account.accountIndex)
+                            }
+                        }
+                        .pickerStyle(.segmented)
+                        .padding(.horizontal)
+                    } else {
+                        Picker("Account", selection: $selectedAccountIndex) {
+                            ForEach(bip44Accounts, id: \.accountIndex) { account in
+                                Text("Account \(account.accountIndex)").tag(account.accountIndex)
+                            }
+                        }
+                        .pickerStyle(.menu)
+                        .padding(.horizontal)
+                    }
+                }
 
                 if hasValidAddress {
                     if let qrImage = generateQRCode(from: currentAddress) {
@@ -264,6 +286,9 @@ struct ReceiveAddressView: View {
                 }
             }
             .onChange(of: selectedTab) { _, _ in
+                copiedToClipboard = false
+            }
+            .onChange(of: selectedAccountIndex) { _, _ in
                 copiedToClipboard = false
             }
         }


### PR DESCRIPTION
## Issue being fixed or feature implemented

The **Receive Dash** screen showed a BIP32 derivation path (`m/0'/0/n`) instead of the expected BIP44 path (`m/44'/5'/0'/0/n`). The wallet was receiving on the BIP32 account rather than the BIP44 account.

## What was done?

`findAccount(accountType:accountIndex:)` in `ReceiveAddressView` never checked the `standardTag` field of `PersistentAccount`. Both BIP32 and BIP44 accounts share `(accountType=0, accountIndex=0)` — they're distinguished only by `standardTag` (0 = BIP44, 1 = BIP32, matching `StandardAccountTypeTagFFI`). Without the guard, whichever account appeared first in the `@Query` result set was returned — in practice the BIP32 account.

Fix: added an optional `standardTag` parameter to `findAccount` and pass `standardTag: 0` (BIP44) when resolving the primary Core receive account.

## How Has This Been Tested?

Verified visually in the iOS Simulator — the Receive Dash screen now shows a BIP44 derivation path.

## Breaking Changes

None.

## Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [ ] I have made corresponding changes to the documentation if needed