### PR TITLE
fix(swift-example-app): show real platform balance on Send screen

### DIFF
--- a/packages/swift-sdk/SwiftExampleApp/SwiftExampleApp/Core/Views/SendTransactionView.swift
+++ b/packages/swift-sdk/SwiftExampleApp/SwiftExampleApp/Core/Views/SendTransactionView.swift
@@ -13,9 +13,34 @@ struct SendTransactionView: View {
 
     @Environment(\.modelContext) private var modelContext
 
+    /// BLAST-synced platform-address balances for this wallet —
+    /// same source `WalletDetailView` reads to populate its
+    /// "Platform Balance" row. Without these the send screen used
+    /// to fall through to `wallet.identities.balance` only, which
+    /// is empty for wallets that hold credits at platform
+    /// addresses (e.g. faucet-funded Platform Payment accounts)
+    /// rather than at registered identities.
+    @Query private var addressBalances: [PersistentPlatformAddress]
+
+    /// Persisted BLAST sync watermarks — used to distinguish
+    /// "BLAST hasn't synced yet, fall back to identities" from
+    /// "BLAST synced and there genuinely are no platform-address
+    /// credits".
+    @Query private var syncStates: [PersistentPlatformAddressesSyncState]
+
     init(wallet: PersistentWallet) {
         self.wallet = wallet
         _viewModel = StateObject(wrappedValue: SendViewModel(network: wallet.network ?? .testnet))
+        let walletId = wallet.walletId
+        let walletNetworkRaw = (wallet.network ?? .testnet).rawValue
+        _addressBalances = Query(
+            filter: #Predicate<PersistentPlatformAddress> { $0.walletId == walletId }
+        )
+        _syncStates = Query(
+            filter: #Predicate<PersistentPlatformAddressesSyncState> {
+                $0.networkRaw == walletNetworkRaw
+            }
+        )
     }
 
     var body: some View {
@@ -185,8 +210,19 @@ struct SendTransactionView: View {
         shieldedService.shieldedBalance
     }
 
+    /// Mirrors `WalletDetailView.platformBalance`: BLAST-synced
+    /// address balances are the canonical source once a sync has
+    /// landed; before that, fall back to summing identity credits
+    /// so a freshly-restored wallet still shows something
+    /// approximate.
     private var platformBalance: UInt64 {
-        wallet.identities.reduce(UInt64(0)) { $0 + UInt64(bitPattern: $1.balance) }
+        let blastBalance = addressBalances.reduce(UInt64(0)) { $0 + $1.balance }
+        let hasSynced = syncStates.first.map { $0.syncHeight > 0 || $0.syncTimestamp > 0 }
+            ?? false
+        if blastBalance > 0 || hasSynced {
+            return blastBalance
+        }
+        return wallet.identities.reduce(UInt64(0)) { $0 + UInt64(bitPattern: $1.balance) }
     }
 
     private func availableSources(coreBalance: UInt64) -> [FundSource] {

--- a/packages/swift-sdk/SwiftExampleApp/SwiftExampleApp/Core/Views/SendTransactionView.swift
+++ b/packages/swift-sdk/SwiftExampleApp/SwiftExampleApp/Core/Views/SendTransactionView.swift
@@ -74,9 +74,24 @@ struct SendTransactionView: View {
                     }
 
                     VStack(alignment: .leading, spacing: 4) {
-                        BalanceInfoRow(label: "Core:", amount: coreBalance, color: .green)
-                        BalanceInfoRow(label: "Shielded:", amount: shieldedBalance, color: .purple)
-                        BalanceInfoRow(label: "Platform:", amount: platformBalance, color: .blue)
+                        BalanceInfoRow(
+                            label: "Core:",
+                            amount: coreBalance,
+                            unit: .duffs,
+                            color: .green
+                        )
+                        BalanceInfoRow(
+                            label: "Shielded:",
+                            amount: shieldedBalance,
+                            unit: .credits,
+                            color: .purple
+                        )
+                        BalanceInfoRow(
+                            label: "Platform:",
+                            amount: platformBalance,
+                            unit: .credits,
+                            color: .blue
+                        )
                     }
                 }
 
@@ -96,7 +111,8 @@ struct SendTransactionView: View {
                                         .foregroundColor(.primary)
                                     Spacer()
                                     Text(formatBalance(
-                                        balance(for: source, coreBalance: coreBalance)
+                                        balance(for: source, coreBalance: coreBalance),
+                                        unit: unit(for: source)
                                     ))
                                         .font(.caption)
                                         .foregroundColor(.secondary)
@@ -264,8 +280,13 @@ struct SendTransactionView: View {
         }
     }
 
-    private func formatBalance(_ amount: UInt64) -> String {
-        let dash = Double(amount) / 100_000_000.0
+    /// Format a `UInt64` balance for display.
+    ///
+    /// `unit` controls the divisor — Core/duffs are 1e8 per DASH,
+    /// Platform/shielded credits are 1e11 per DASH. Mixing the two
+    /// would over-report Platform balances by 1000×.
+    private func formatBalance(_ amount: UInt64, unit: SendBalanceUnit = .duffs) -> String {
+        let dash = Double(amount) / unit.dashDivisor
         let formatter = NumberFormatter()
         formatter.minimumFractionDigits = 0
         formatter.maximumFractionDigits = 8
@@ -276,6 +297,13 @@ struct SendTransactionView: View {
             return "\(formatted) DASH"
         }
         return String(format: "%.8f DASH", dash)
+    }
+
+    private func unit(for source: FundSource) -> SendBalanceUnit {
+        switch source {
+        case .core: return .duffs
+        case .platform, .shielded: return .credits
+        }
     }
 }
 
@@ -314,22 +342,39 @@ private struct AddressTypeBadge: View {
     }
 }
 
+/// Whether a `UInt64` balance reads as L1 duffs (1 DASH = 1e8) or
+/// Platform / shielded credits (1 DASH = 1e11). The two scales
+/// differ by 1000× — formatting Platform credits as duffs over-
+/// reports balances by exactly that factor.
+enum SendBalanceUnit {
+    case duffs
+    case credits
+
+    fileprivate var dashDivisor: Double {
+        switch self {
+        case .duffs: return 100_000_000.0
+        case .credits: return 100_000_000_000.0
+        }
+    }
+}
+
 private struct BalanceInfoRow: View {
     let label: String
     let amount: UInt64
+    var unit: SendBalanceUnit = .duffs
     var color: Color = .primary
 
     var body: some View {
         HStack {
             Text(label).font(.caption).foregroundColor(.secondary)
             Spacer()
-            Text(formatBalance(amount))
+            Text(formatBalance(amount, unit: unit))
                 .font(.caption).foregroundColor(amount > 0 ? color : .secondary)
         }
     }
 
-    private func formatBalance(_ amount: UInt64) -> String {
-        let dash = Double(amount) / 100_000_000.0
+    private func formatBalance(_ amount: UInt64, unit: SendBalanceUnit) -> String {
+        let dash = Double(amount) / unit.dashDivisor
         let formatter = NumberFormatter()
         formatter.minimumFractionDigits = 0
         formatter.maximumFractionDigits = 8


### PR DESCRIPTION
## Issue being fixed or feature implemented

The Send Dash sheet's \"Platform: 0 DASH\" row contradicted the
wallet detail's \"Platform Balance: 1.00572807 DASH\" for the
same wallet, and as a knock-on the FundSource picker never
offered Platform as an option for shielded sends — \`selectedSource\`
stayed pinned at the default Core, \`(.orchard, .core)\` doesn't
map to a flow, and the Send button stayed disabled.

## What was done?

Root cause: \`SendTransactionView.platformBalance\` summed only
\`wallet.identities.balance\`. BLAST-synced platform-address
credits (the Platform Payment accounts a faucet top-up lands
in) live in \`PersistentPlatformAddress\` rows under the wallet
id, not on the identity rows, so a wallet without a registered
identity always reported 0.

Mirror the same \`addressBalances + identity-fallback\` shape
\`WalletDetailView.platformBalance\` already uses: BLAST-synced
balance is canonical once \`syncHeight\`/\`syncTimestamp\` is set,
identity sum is the pre-sync fallback. Add the matching
\`@Query<PersistentPlatformAddress>\` and
\`@Query<PersistentPlatformAddressesSyncState>\` filters scoped
to the wallet id / network at init time.

After this the Send screen reports the same Platform balance
the wallet detail does, the FundSource picker offers Platform
for shielded destinations, and the flow detector resolves
\`(.orchard, .platform) → .platformToShielded\` so the user can
at least *select* the Platform→Shielded path. Actual send
execution still hits the \`\"Shielded sending is being rebuilt\"\`
placeholder until the spend signer pipeline lands.

## How Has This Been Tested?

- \`bash build_ios.sh --target sim --profile dev\` — green.
- Visually verified on the iPhone 17 Pro simulator: a wallet
  with 1.00572807 DASH in a Platform Payment account now shows
  that exact amount in the Send sheet's Platform row, the
  FundSource picker offers Platform when sending to a shielded
  address, and selecting it enables the Send button (which
  still produces the placeholder error on tap, as expected).

## Breaking Changes

None.

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have added \"!\" to the title and described breaking changes in the corresponding section if my code contains any
- [ ] I have made corresponding changes to the documentation if needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved balance calculation in transaction view to properly utilize BLAST address data when available, with appropriate fallback handling for synced and unavailable states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->