### PR TITLE
fix(drive,drive-abci): post-merge follow-ups for shielded anchor refactor

### DIFF
--- a/packages/rs-drive-abci/src/query/shielded/most_recent_anchor/v0/mod.rs
+++ b/packages/rs-drive-abci/src/query/shielded/most_recent_anchor/v0/mod.rs
@@ -11,6 +11,7 @@ use dpp::check_validation_result_with_data;
 use dpp::validation::ValidationResult;
 use dpp::version::PlatformVersion;
 use drive::drive::shielded::paths::shielded_latest_recorded_anchor_path_query;
+use drive::error::drive::DriveError;
 use drive::grovedb::query_result_type::QueryResultType;
 use drive::grovedb::Element;
 use drive::util::grove_operations::GroveDBToUse;
@@ -81,9 +82,23 @@ impl<C> Platform<C> {
             // with an explicit absent variant, drop the
             // `vec![0u8; 32]` sentinel here in lock-step with both
             // the verifier and the SDK decoder.
+            // Split the three states explicitly. A non-`Item`
+            // element under `SHIELDED_ANCHORS_BY_HEIGHT_KEY` is a
+            // state-corruption signal — the prove-mode verifier
+            // (`verify_most_recent_shielded_anchor_v0`) and the
+            // raw-read helper
+            // (`Drive::read_latest_recorded_shielded_anchor_v0`)
+            // both surface this as `CorruptedProof` /
+            // `CorruptedElementType`, so the non-prove path must
+            // not silently fold it into the empty-index sentinel.
             let anchor_bytes = match entries.into_iter().next() {
                 Some((_height_key, Element::Item(bytes, _))) => bytes,
-                _ => vec![0u8; 32],
+                Some(_) => {
+                    return Err(Error::Drive(drive::error::Error::Drive(
+                        DriveError::CorruptedElementType("anchors-by-height entry is not an Item"),
+                    )));
+                }
+                None => vec![0u8; 32],
             };
 
             GetMostRecentShieldedAnchorResponseV0 {

--- a/packages/rs-drive-abci/src/query/shielded/most_recent_anchor/v0/mod.rs
+++ b/packages/rs-drive-abci/src/query/shielded/most_recent_anchor/v0/mod.rs
@@ -59,13 +59,30 @@ impl<C> Platform<C> {
             )?;
 
             let entries = results.to_key_elements();
+            // EMPTY-INDEX CONVENTION (see also
+            // `Drive::verify_most_recent_shielded_anchor_v0`):
+            //
+            // The `Anchor`/`Proof` `oneof` in the gRPC response has
+            // no third "absent" variant, so the proven and non-proven
+            // branches encode "no anchor recorded yet" differently:
+            //
+            //   * Non-proven (this branch) — return
+            //     `Anchor(vec![0u8; 32])`. Callers treat the all-zero
+            //     anchor as "absent." Carries over from the
+            //     pre-`[7]`-removal behaviour where the slot was
+            //     initialised to `[0; 32]`; kept for wire-format
+            //     compatibility.
+            //   * Proven — return the GroveDB proof. The SDK runs
+            //     `verify_most_recent_shielded_anchor_v0` against
+            //     the same `limit 1` reverse `PathQuery`, which
+            //     returns `Ok(None)` when the index is empty.
+            //
+            // If a future protocol revision extends the response
+            // with an explicit absent variant, drop the
+            // `vec![0u8; 32]` sentinel here in lock-step with both
+            // the verifier and the SDK decoder.
             let anchor_bytes = match entries.into_iter().next() {
                 Some((_height_key, Element::Item(bytes, _))) => bytes,
-                // Empty index, or the entry isn't an Item (which
-                // would be a state-corruption bug elsewhere). Either
-                // way, return the zero-anchor sentinel — same shape
-                // the previous `[7]`-backed implementation used when
-                // the slot was uninitialised.
                 _ => vec![0u8; 32],
             };
 

--- a/packages/rs-drive-abci/tests/strategy_tests/test_cases/shielded_tests.rs
+++ b/packages/rs-drive-abci/tests/strategy_tests/test_cases/shielded_tests.rs
@@ -534,20 +534,48 @@ mod tests {
         // 3. Verify the derived "most recent anchor" — i.e. the
         //    highest-block-height entry in the anchors-by-height
         //    index — exists and matches one of the recorded anchors.
-        //    There is no longer a separate "most recent anchor" slot;
-        //    the index is the canonical source.
-        let most_recent_anchor = drive
-            .read_latest_recorded_shielded_anchor_v0(None, &platform_version.drive)
-            .expect("read latest recorded anchor")
+        //    There is no longer a separate "most recent anchor"
+        //    slot; the index is the canonical source.
+        //
+        //    Read directly via the same path query the production
+        //    handler uses, rather than reaching across crates for
+        //    the internal `read_latest_recorded_shielded_anchor_v0`
+        //    helper — its visibility is `pub(in crate::drive)` and
+        //    a strategy test has no reason to push that to the
+        //    public Drive surface.
+        use drive::drive::shielded::paths::shielded_latest_recorded_anchor_path_query;
+        let path_query = shielded_latest_recorded_anchor_path_query();
+        let (results, _) = drive
+            .grove_get_raw_path_query(
+                &path_query,
+                None,
+                QueryResultType::QueryKeyElementPairResultType,
+                &mut vec![],
+                &platform_version.drive,
+            )
+            .expect("query latest recorded shielded anchor");
+        let mut entries = results.to_key_elements();
+        let (_, most_recent_element) = entries
+            .pop()
             .expect("most recent anchor must exist after successful shields");
+        let most_recent_anchor = if let Element::Item(bytes, _) = most_recent_element {
+            bytes
+        } else {
+            panic!("expected Item element in anchors-by-height tree");
+        };
+        assert_eq!(
+            most_recent_anchor.len(),
+            32,
+            "most recent anchor must be 32 bytes"
+        );
         assert_ne!(
-            most_recent_anchor.to_vec(),
+            most_recent_anchor,
             vec![0u8; 32],
             "most recent anchor must not be all zeros after successful shields"
         );
         let is_known = anchor_to_height
             .iter()
-            .any(|(a, _)| *a == most_recent_anchor.to_vec());
+            .any(|(a, _)| *a == most_recent_anchor);
         assert!(
             is_known,
             "most recent anchor must match one of the recorded anchors"

--- a/packages/rs-drive/src/drive/shielded/estimated_costs.rs
+++ b/packages/rs-drive/src/drive/shielded/estimated_costs.rs
@@ -79,13 +79,19 @@ impl Drive {
         // SumTree containing: notes (CommitmentTree), permanent nullifiers (ProvableCountTree),
         // total balance (SumItem), anchors (NormalTree), anchors-by-height (NormalTree),
         // recent nullifiers (CountSumTree), compacted nullifiers (NormalTree),
-        // expiration time (NormalTree), most recent anchor (Item)
-        // 9 elements total (7 subtrees + 2 items) → balanced Merk depth = ceil(log2(9)) = 4
+        // expiration time (NormalTree).
+        // 8 elements total (7 subtrees + 1 item) → balanced Merk depth = ceil(log2(8)) = 3.
+        //
+        // The retired `SHIELDED_MOST_RECENT_ANCHOR_KEY = 7` slot used
+        // to add a second `Item` entry; the most-recent anchor is
+        // now derived from the highest-block-height entry in the
+        // anchors-by-height subtree, so the pool layer is one item
+        // smaller than before.
         estimated_costs_only_with_layer_info.insert(
             KeyInfoPath::from_known_path(shielded_credit_pool_path()),
             EstimatedLayerInformation {
                 tree_type: TreeType::SumTree,
-                estimated_layer_count: EstimatedLevel(4, false),
+                estimated_layer_count: EstimatedLevel(3, false),
                 estimated_layer_sizes: Mix {
                     subtrees_size: Some((
                         1,
@@ -99,7 +105,7 @@ impl Drive {
                         None,
                         7, // 7 subtrees: notes, permanent nullifiers, anchors, anchors-by-height, recent nullifiers, compacted nullifiers, expiration time
                     )),
-                    items_size: Some((1, 32, None, 2)), // 2 items: total balance (SumItem), most recent anchor (Item)
+                    items_size: Some((1, 8, None, 1)), // 1 item: total balance (SumItem, i64 = 8 bytes)
                     references_size: None,
                 },
             },

--- a/packages/rs-drive/src/drive/shielded/prune_anchors/v0/mod.rs
+++ b/packages/rs-drive/src/drive/shielded/prune_anchors/v0/mod.rs
@@ -96,17 +96,19 @@ impl Drive {
             entries_below
         } else {
             // Exclude the entry with the highest block_height key.
-            // Keys are big-endian u64 → lexicographic comparison
-            // matches numeric comparison.
-            let max_key = entries_below
-                .iter()
-                .map(|(k, _)| k.clone())
-                .max()
+            // `entries_below` came from a `Query::new()` (default
+            // `left_to_right = true`) over a `RangeTo` against
+            // `SHIELDED_ANCHORS_BY_HEIGHT_KEY`, whose keys are
+            // big-endian u64 — so GroveDB returns the entries in
+            // ascending numeric order and the live anchor is
+            // always the last element. Pop it off and discard;
+            // the remaining vec is exactly the prunable set, no
+            // extra scan or per-key clone.
+            let mut candidates = entries_below;
+            candidates
+                .pop()
                 .expect("entries_below non-empty (guarded above)");
-            entries_below
-                .into_iter()
-                .filter(|(k, _)| k != &max_key)
-                .collect()
+            candidates
         };
 
         // 3. Delete from both trees. Order doesn't matter for

--- a/packages/rs-drive/src/drive/shielded/record_anchor_if_changed/v0/mod.rs
+++ b/packages/rs-drive/src/drive/shielded/record_anchor_if_changed/v0/mod.rs
@@ -115,19 +115,14 @@ impl Drive {
     /// (pool has never recorded an anchor — chain is at genesis or
     /// no shielded ops yet).
     ///
-    /// Single source of truth for "what's the most-recent anchor on
-    /// this chain right now":
-    ///
-    /// - `record_shielded_pool_anchor_if_changed_v0` calls this to
-    ///   decide whether the anchor changed this block.
-    /// - `Platform::query_most_recent_shielded_anchor_v0` builds the
-    ///   same path query against `grove_get_proved_path_query` so
-    ///   the SDK's verifier can replay it byte-for-byte.
-    /// Public so drive-abci's strategy tests + the
-    /// `getMostRecentShieldedAnchor` non-proven query path can reach
-    /// it; both are inside the workspace and would otherwise have to
-    /// duplicate the path-query construction.
-    pub fn read_latest_recorded_shielded_anchor_v0(
+    /// Used by `record_shielded_pool_anchor_if_changed_v0` to decide
+    /// whether the anchor changed this block. The drive-abci handler
+    /// (`Platform::query_most_recent_shielded_anchor_v0`) and SDK
+    /// verifier (`Drive::verify_most_recent_shielded_anchor_v0`)
+    /// share the same `PathQuery` shape via
+    /// `shielded_latest_recorded_anchor_path_query`, but operate on
+    /// proofs rather than this raw helper.
+    pub(in crate::drive) fn read_latest_recorded_shielded_anchor_v0(
         &self,
         transaction: grovedb::TransactionArg,
         drive_version: &dpp::version::drive_versions::DriveVersion,


### PR DESCRIPTION
## Issue being fixed or feature implemented

Follow-up review of [#3605](https://github.com/dashpay/platform/pull/3605) (retire `SHIELDED_MOST_RECENT_ANCHOR_KEY`, derive most-recent from `[8]`, never empty the index under prune). Four findings from the automated review, all verified valid against the merged v3.1-dev code.

## What was done?

### 1. [BLOCKING] `estimated_costs.rs`: layout was still pre-PR

`add_estimation_costs_for_shielded_pool_operations` registered the shielded credit pool with the **old** shape — `EstimatedLevel(4, false)`, `items_size: Some((1, 32, None, 2))`, comment claiming "9 elements (7 subtrees + 2 items)" — even though `[7]` is gone. The pool now holds 7 subtrees + 1 item (the `SHIELDED_TOTAL_BALANCE_KEY` `SumItem`):

- `EstimatedLevel(4, false)` → `EstimatedLevel(3, false)` (`ceil(log2(8)) = 3`)
- `items_size: Some((1, 32, None, 2))` → `Some((1, 8, None, 1))` (one i64 SumItem, 8 bytes)
- Comment updated to match.

This metadata feeds `ShieldedPoolOperationType::into_low_level_drive_operations()` whenever shielded ops are costed in estimation mode (`apply=false`), so without this fix every shielded note/nullifier/balance fee estimate would have over-reported pool depth + item count by one each.

### 2. `prune_anchors_v0`: use `.pop()` instead of recomputing `max_key`

`entries_below` comes from `grove_get_raw_path_query` over a `Query::new()` (default `left_to_right = true`) with `RangeTo` against `SHIELDED_ANCHORS_BY_HEIGHT_KEY`, whose keys are big-endian u64 — so GroveDB returns the entries in ascending numeric order. The previous code cloned every key into a new `Vec<u8>` to find the maximum, then walked the vec again to filter that key out — O(N) extra work plus per-entry allocation on a path that runs every block. `.pop()` on the already-sorted result accomplishes the same thing with zero scans or allocations.

### 3. `query_most_recent_shielded_anchor_v0`: document the empty-index convention

The non-proven branch returns `Anchor(vec![0u8; 32])` when `[8]` is empty; the proven branch returns a proof that `verify_most_recent_shielded_anchor_v0` decodes to `Ok(None)`. Asymmetric handling that only stays coherent if the SDK's response decoder keeps treating the all-zeros anchor as "absent." The right long-term fix is a third \"absent\" variant on the gRPC `oneof`, but that's a wire-format change. For now, added a comment block at the sentinel-emitting site cross-referencing the verifier and flagging the lock-step requirement, so the implicit convention isn't invisible to future maintainers.

### 4. `read_latest_recorded_shielded_anchor_v0`: revert to crate-local

The helper was bumped to `pub` purely so the drive-abci strategy test could reach across crates. The doc justified that visibility with a caller (the non-proven `getMostRecentShieldedAnchor` path) that doesn't actually use it — that path calls `grove_get_raw_path_query` directly on `shielded_latest_recorded_anchor_path_query()` and parses the result inline. Reverted to `pub(in crate::drive)` matching `record_shielded_pool_anchor_if_changed_v0`, fixed the doc, and inlined the strategy test's read against the same shared `PathQuery` the production handler uses. Internal storage helpers don't need to bleed onto the public Drive surface for test convenience.

## How Has This Been Tested?

- `cargo test -p drive --lib drive::shielded` → 60 passed
- `cargo test -p drive --lib verify::shielded` → 22 passed
- `cargo test -p drive-abci --lib query::shielded` → 54 passed
- `cargo clippy -p drive -p drive-abci --all-targets` clean
- `cargo fmt --all` clean

## Breaking Changes

None. The estimated-costs fix changes fee-estimation outputs by one Merk depth level + one item slot for shielded pool root-layer operations — small, in the direction of \"now correct\" — but doesn't affect on-chain state shape or RPC wire format. v3.1-dev hasn't shipped, so the v0 method bodies are amended in place.

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have added \"!\" to the title and described breaking changes in the corresponding section if my code contains any
- [ ] I have made corresponding changes to the documentation if needed

## Related

Follows up [#3605](https://github.com/dashpay/platform/pull/3605); unblocks the spend rows of [#3603](https://github.com/dashpay/platform/pull/3603) once the regtest restarts past the prune fix landing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Optimized shielded pool storage layout for fewer elements and reduced tree depth.
  * Updated pruning to rely on ascending key order when excluding the live anchor.
  * Narrowed visibility of an internal anchor helper and updated tests to use the canonical index approach.

* **Bug Fixes**
  * Corrupted/non-item entries in anchor queries now surface an explicit error instead of treating them as empty.

* **Documentation**
  * Added explanatory comments on anchor conventions and structural simplifications.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->