### PR TITLE
fix(swift-example-app): route orphan recovery to per-network managers

### DIFF
--- a/packages/swift-sdk/Sources/SwiftDashSDK/SDK.swift
+++ b/packages/swift-sdk/Sources/SwiftDashSDK/SDK.swift
@@ -159,9 +159,19 @@ public final class SDK: @unchecked Sendable {
     config.request_timeout_ms = 8000 // 8 seconds
 
     // Create SDK with trusted setup — Rust side auto-detects local/regtest
-    // and uses the quorum sidecar at localhost:22444 instead of remote endpoints
+    // and uses the quorum sidecar at localhost:22444 instead of remote endpoints.
+    //
+    // Regtest has no remote DAPI defaults on the Rust side, so it
+    // *must* be constructed with a local DAPI address regardless of
+    // the user-facing `useDockerSetup` toggle. Without this, building
+    // a regtest SDK from a context where the toggle has been
+    // auto-disabled (e.g. orphan-mnemonic recovery routing wallets to
+    // their original network from a non-regtest active state) fails
+    // with `DAPI addresses not available for network: Regtest` and
+    // the recovery loop stalls.
     let result: DashSDKResult
-    let forceLocal = UserDefaults.standard.bool(forKey: "useDockerSetup")
+    let forceLocal = network == .regtest
+        || UserDefaults.standard.bool(forKey: "useDockerSetup")
     if forceLocal {
       let localAddresses = Self.platformDAPIAddresses
       result = localAddresses.withCString { addressesCStr -> DashSDKResult in

--- a/packages/swift-sdk/SwiftExampleApp/SwiftExampleApp/ContentView.swift
+++ b/packages/swift-sdk/SwiftExampleApp/SwiftExampleApp/ContentView.swift
@@ -13,6 +13,7 @@ struct ContentView: View {
     let onRetry: () -> Void
 
     @EnvironmentObject var walletManager: PlatformWalletManager
+    @EnvironmentObject var walletManagerStore: WalletManagerStore
     @EnvironmentObject var appUIState: AppUIState
     @EnvironmentObject var platformState: AppState
     @Environment(\.modelContext) private var modelContext
@@ -427,8 +428,24 @@ struct ContentView: View {
             entry.network ?? metadata?.resolvedNetworks.first ?? platformState.currentNetwork
         let restoredBirthHeight = metadata?.birthHeight
 
+        // Route recovery to the manager for the wallet's original
+        // network — not the active manager. The Rust side stamps
+        // `wallet.network = self.sdk.network` at registration time,
+        // so creating a regtest wallet through the testnet manager
+        // would persist the row as testnet. `backgroundManager`
+        // lazy-builds the per-network manager (and its SDK) without
+        // changing the user's currently visible network.
+        let targetManager: PlatformWalletManager
         do {
-            let managed = try walletManager.createWallet(
+            targetManager = try walletManagerStore.backgroundManager(for: restoredNetwork)
+        } catch {
+            recoveryError = "Failed to prepare \(restoredNetwork.displayName) manager "
+                + "for \"\(entry.displayName)\": \(error.localizedDescription)"
+            return false
+        }
+
+        do {
+            let managed = try targetManager.createWallet(
                 mnemonic: mnemonic,
                 network: restoredNetwork,
                 name: restoredName
@@ -437,7 +454,32 @@ struct ContentView: View {
             let descriptor = FetchDescriptor<PersistentWallet>(
                 predicate: #Predicate { $0.walletId == walletIdMatch }
             )
-            if let row = try? modelContext.fetch(descriptor).first {
+
+            // Cross-context propagation: the row we just created
+            // landed in the target manager's background context,
+            // not in the main context that drives every `@Query`
+            // consumer in the UI. SwiftData merges sibling-context
+            // saves through `NSPersistentStoreRemoteChange`
+            // notifications, but that pipeline is asynchronous —
+            // an immediate `fetch` on the main context may still
+            // miss the row, in which case the post-recovery
+            // `isImported` / metadata flush is skipped *and* no
+            // main-context save fires, so `@Query` observers
+            // never re-evaluate. The wallet then "doesn't appear"
+            // until the next app launch when the main context is
+            // built fresh against disk. Retry a few times with a
+            // short yield between attempts so the merge has a
+            // chance to settle before we move on.
+            var row: PersistentWallet? = nil
+            for attempt in 0..<10 {
+                row = try? modelContext.fetch(descriptor).first
+                if row != nil { break }
+                if attempt < 9 {
+                    try? await Task.sleep(nanoseconds: 50_000_000)
+                }
+            }
+
+            if let row {
                 row.isImported = true
                 if row.walletDescription == nil {
                     row.walletDescription = restoredDescription

--- a/packages/swift-sdk/SwiftExampleApp/SwiftExampleApp/SwiftExampleAppApp.swift
+++ b/packages/swift-sdk/SwiftExampleApp/SwiftExampleApp/SwiftExampleAppApp.swift
@@ -107,6 +107,7 @@ struct SwiftExampleAppApp: App {
                 // PlatformWalletManager` consumers see the right
                 // network's manager without any view changes.
                 .environmentObject(walletManager)
+                .environmentObject(walletManagerStore)
                 .environmentObject(shieldedService)
                 .environmentObject(platformBalanceSyncService)
                 .environmentObject(transitionState)
@@ -264,6 +265,20 @@ struct SwiftExampleAppApp: App {
                     )
                 }
 
+                // Pre-warm per-network managers for any orphan
+                // mnemonic whose original network differs from
+                // the active one, so the orphan-recovery flow
+                // doesn't have to lazy-build them mid-session.
+                // SwiftData's @Query observers in the main
+                // context don't always reflect rows persisted
+                // through a `backgroundContext` that was
+                // created mid-session — pre-warming here means
+                // those backgrounds are wired up alongside the
+                // main context at launch and the recovered
+                // wallet appears in its correct tab on the same
+                // run instead of only after a relaunch.
+                preWarmOrphanNetworkManagers()
+
                 rebindWalletScopedServices()
             }
 
@@ -290,5 +305,44 @@ struct SwiftExampleAppApp: App {
             return csv.split(separator: ",").map { $0.trimmingCharacters(in: .whitespaces) }
         }
         return ["127.0.0.1"]
+    }
+
+    /// Materialize a `PlatformWalletManager` for every network that
+    /// has an orphan keychain mnemonic, except the already-active
+    /// one. Used during bootstrap so the orphan-recovery flow has
+    /// pre-warmed managers when the user authorizes recovery —
+    /// avoids a SwiftData edge case where a mid-session-created
+    /// background `ModelContext` doesn't propagate writes back to
+    /// the launch-time main context's `@Query` observers.
+    @MainActor
+    private func preWarmOrphanNetworkManagers() {
+        let storage = WalletStorage()
+        let keychainIds = (try? storage.listWalletIdsWithMnemonic()) ?? []
+        guard !keychainIds.isEmpty else { return }
+
+        var orphanNetworks: Set<Network> = []
+        for walletId in keychainIds {
+            guard let metadata = (try? storage.metadata(for: walletId)) ?? nil,
+                  let resolved = metadata.resolvedNetworks.first
+            else { continue }
+            orphanNetworks.insert(resolved)
+        }
+
+        let active = platformState.currentNetwork
+        for network in orphanNetworks where network != active {
+            do {
+                _ = try walletManagerStore.backgroundManager(for: network)
+                SDKLogger.log(
+                    "🔥 Pre-warmed wallet manager for \(network.displayName) "
+                        + "(orphan recovery target)",
+                    minimumLevel: .medium
+                )
+            } catch {
+                SDKLogger.error(
+                    "Failed to pre-warm \(network.displayName) manager: "
+                        + error.localizedDescription
+                )
+            }
+        }
     }
 }

--- a/packages/swift-sdk/SwiftExampleApp/SwiftExampleApp/WalletManagerStore.swift
+++ b/packages/swift-sdk/SwiftExampleApp/SwiftExampleApp/WalletManagerStore.swift
@@ -78,9 +78,15 @@ final class WalletManagerStore: ObservableObject {
     /// Failures during a fresh manager's `configure` /
     /// `loadFromPersistor` propagate to the caller — the cache
     /// stays untouched in that case so a later retry can succeed.
-    func activate(network: Network, sdk: SDK) throws {
+    ///
+    /// `makeActive == false` materializes the manager into the cache
+    /// without swapping `activeManager`. Used by background flows
+    /// (e.g. orphan recovery routing wallets to their original
+    /// network) that need a manager for a non-active network without
+    /// triggering a user-visible network switch.
+    func activate(network: Network, sdk: SDK, makeActive: Bool = true) throws {
         if let existing = managers[network] {
-            if existing !== activeManager {
+            if makeActive && existing !== activeManager {
                 activeManager = existing
             }
             return
@@ -102,7 +108,9 @@ final class WalletManagerStore: ObservableObject {
             )
         }
         managers[network] = manager
-        activeManager = manager
+        if makeActive {
+            activeManager = manager
+        }
     }
 
     /// Manager for `network` if one has been activated this session;
@@ -111,5 +119,31 @@ final class WalletManagerStore: ObservableObject {
     /// state without forcing it active.
     func manager(for network: Network) -> PlatformWalletManager? {
         managers[network]
+    }
+
+    /// Get-or-build the manager for `network` without changing the
+    /// currently active one. Builds a fresh `SDK` for that network
+    /// on demand the first time it's requested.
+    ///
+    /// Used by orphan-mnemonic recovery, which needs to route each
+    /// rebuilt wallet to the manager bound to the network the
+    /// wallet was originally created on — otherwise wallets bound
+    /// to non-active networks at creation time get re-derived and
+    /// persisted under the active network's manager (the Rust
+    /// manager stamps `wallet.network = self.sdk.network` at
+    /// registration time, so a regtest mnemonic recovered through
+    /// the testnet manager lands as a testnet row).
+    func backgroundManager(for network: Network) throws -> PlatformWalletManager {
+        if let existing = managers[network] {
+            return existing
+        }
+        let sdk = try SDK(network: network)
+        try activate(network: network, sdk: sdk, makeActive: false)
+        guard let manager = managers[network] else {
+            throw PlatformWalletError.invalidParameter(
+                "Failed to materialize manager for \(network.displayName)"
+            )
+        }
+        return manager
     }
 }


### PR DESCRIPTION
## Issue being fixed or feature implemented

When restoring orphan-mnemonic wallets after a reinstall, every recovered wallet was landing under the **active** network — so a regtest mnemonic recovered while the user was on Testnet ended up persisted with `networkRaw = testnet`, and the Local tab stayed stuck empty until the user manually switched networks and re-ran recovery.

Three issues stacked on top of each other to produce the observed UX:

1. **Wallet metadata stamped from the wrong manager.** The Rust `PlatformWalletManager` is network-locked and `register_wallet` records `wallet.network = self.sdk.network`. `ContentView.recoverWallet` always called `createWallet` on the env-injected active `walletManager`, so the persisted row's network reflected the active manager — not the original network read from keychain metadata.
2. **Regtest SDK construction failed mid-session.** `OptionsView` auto-disables `useDockerSetup` when leaving regtest. With the toggle off, `SDK(network: .regtest)` returned `DAPI addresses not available for network: Regtest` because regtest has no remote DAPI defaults on the Rust side — so even when recovery tried to route to the regtest manager, it couldn't build one.
3. **Cross-context propagation lag.** Even when recovery did succeed, the new row landed in the target manager's background `ModelContext` and the launch-time main context's `@Query` consumers didn't observe it in time for the post-recovery `isImported` flush. The wallet only appeared in the correct tab after the next app launch when the main context was rebuilt fresh from disk.

## What was done?

- **Per-network routing.** Added `WalletManagerStore.backgroundManager(for:)` and a `makeActive: Bool` overload on `activate(...)`. The recovery flow now resolves each orphan's original network from keychain metadata and calls `createWallet` on the manager for that network, lazy-building one (with its own SDK) without changing the user's currently visible network.
- **Regtest SDK construction.** `SDK(network:)` now forces local DAPI for regtest unconditionally — the `useDockerSetup` toggle still controls non-regtest networks, but for regtest local DAPI is the only valid option, so building it on demand from any context now succeeds.
- **Pre-warm + retry for cross-context propagation.** Bootstrap now scans keychain orphans, resolves their networks from metadata, and pre-builds per-network managers for any network whose target ≠ the active one. After `createWallet`, `recoverWallet` retries the `mainContext.fetch` up to 10× with a 50 ms yield between attempts so the cross-context merge has time to land before we move on; once the fetch finds the row, the existing `row.isImported = true; modelContext.save()` block fires and `@Query` re-evaluates immediately.

## How Has This Been Tested?

Manual end-to-end on iOS Simulator (iPhone 17, iOS 26.3):

- Reinstall scenario with 2 testnet + 2 regtest orphan mnemonics in keychain. Before the fix: all four landed under Testnet, Local tab stayed empty. After the fix: the testnet orphans appear under the Testnet tab and the regtest orphans appear under the Local tab on the same run, no app relaunch required.
- Verified that the regtest orphans still recover correctly when `useDockerSetup` is off at the time of recovery (the new SDK constructor branch covers this).
- `xcodebuild -project SwiftExampleApp/SwiftExampleApp.xcodeproj -scheme SwiftExampleApp -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 17,arch=arm64' build` → `BUILD SUCCEEDED`.

## Breaking Changes

None. New APIs are additive (`WalletManagerStore.backgroundManager(for:)`, `activate(...makeActive:)` overload with default-true preserves the existing call sites). The `SDK(network:)` change for regtest only affects a previously-failing path.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [ ] I have made corresponding changes to the documentation if needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed regtest network configuration to ensure proper setup
  * Improved orphan wallet recovery with enhanced data synchronization and retry logic

* **Improvements**
  * Enhanced wallet manager initialization to correctly handle multi-network wallet recovery
  * Optimized wallet environment handling for better data consistency across network switches

<!-- end of auto-generated comment: release notes by coderabbit.ai -->