### PR TITLE
feat(swift-example-app): collapse Platform Sync Status into compact view

### DIFF
--- a/packages/swift-sdk/SwiftExampleApp/SwiftExampleApp/Core/Views/CoreContentView.swift
+++ b/packages/swift-sdk/SwiftExampleApp/SwiftExampleApp/Core/Views/CoreContentView.swift
@@ -10,6 +10,7 @@ struct CoreContentView: View {
     @EnvironmentObject var shieldedService: ShieldedService
     @State private var showProofDetail = false
     @State private var masternodesEnabled: Bool = true
+    @State private var platformSyncExpanded: Bool = false
     // Progress values come from PlatformWalletManager (polled from FFI each second)
 
     /// All persisted platform addresses across every wallet. Summed
@@ -227,108 +228,122 @@ var body: some View {
                         }
                     }
 
-                    // Active addresses — count non-zero balance rows
-                    // across every wallet.
+                    // Chain tip height
                     HStack {
-                        Text("Active Addresses")
+                        Text("Chain Tip Height")
                             .font(.subheadline)
                             .foregroundColor(.secondary)
                         Spacer()
-                        Text("\(aggregateActiveAddressCount)")
-                            .font(.subheadline)
-                            .fontWeight(.medium)
-                    }
-
-                    // Chain tip height
-                    if platformBalanceSyncService.chainTipHeight > 0 {
-                        HStack {
-                            Text("Chain Tip Height")
-                                .font(.subheadline)
-                                .foregroundColor(.secondary)
-                            Spacer()
+                        if platformBalanceSyncService.chainTipHeight > 0 {
                             Text(formattedHeight(UInt32(platformBalanceSyncService.chainTipHeight)))
                                 .font(.subheadline)
                                 .fontWeight(.medium)
-                        }
-                    }
-
-                    // Sync checkpoint (from tree scan)
-                    if platformBalanceSyncService.checkpointHeight > 0 {
-                        HStack {
-                            Text("Sync Checkpoint")
-                                .font(.subheadline)
-                                .foregroundColor(.secondary)
-                            Spacer()
-                            Text(formattedHeight(UInt32(platformBalanceSyncService.checkpointHeight)))
-                                .font(.subheadline)
-                                .foregroundColor(.secondary)
-                        }
-                    }
-
-                    // Last known recent block (for compaction detection)
-                    HStack {
-                        Text("Last Recent Block")
-                            .font(.subheadline)
-                            .foregroundColor(.secondary)
-                        Spacer()
-                        if platformBalanceSyncService.lastKnownRecentBlock > 0 {
-                            Text(formattedHeight(UInt32(platformBalanceSyncService.lastKnownRecentBlock)))
-                                .font(.subheadline)
-                                .foregroundColor(.secondary)
                         } else {
-                            Text("None found")
+                            Text("—")
                                 .font(.subheadline)
-                                .foregroundColor(.blue)
-                                .onTapGesture {
-                                    showProofDetail = true
-                                }
-                        }
-                    }
-
-                    // Block time
-                    if let blockTime = platformBalanceSyncService.lastSyncBlockTime {
-                        HStack {
-                            Text("Block Time")
-                                .font(.subheadline)
-                                .foregroundColor(.secondary)
-                            Spacer()
-                            Text(AppDate.formatted(blockTime, dateStyle: .abbreviated, timeStyle: .omitted))
-                                .font(.caption)
-                                .foregroundColor(.secondary)
-                            Text(AppDate.formatted(blockTime, dateStyle: .omitted, timeStyle: .shortened))
-                                .font(.caption)
                                 .foregroundColor(.secondary)
                         }
                     }
 
-                    // Query counts since launch
-                    if platformBalanceSyncService.syncCountSinceLaunch > 0 {
-                        let svc = platformBalanceSyncService
-                        VStack(spacing: 4) {
+                    // Expandable details
+                    DisclosureGroup(isExpanded: $platformSyncExpanded) {
+                        VStack(spacing: 8) {
+                            // Active addresses — count non-zero balance rows
+                            // across every wallet.
                             HStack {
-                                Text("Queries Since Launch")
+                                Text("Active Addresses")
                                     .font(.subheadline)
                                     .foregroundColor(.secondary)
                                 Spacer()
-                                Text("\(svc.syncCountSinceLaunch) syncs")
-                                    .font(.caption)
-                                    .foregroundColor(.secondary)
+                                Text("\(aggregateActiveAddressCount)")
+                                    .font(.subheadline)
+                                    .fontWeight(.medium)
                             }
-                            HStack(spacing: 12) {
-                                QueryCountBadge(label: "Trunk", count: svc.totalTrunkQueries, color: .blue)
-                                QueryCountBadge(label: "Branch", count: svc.totalBranchQueries, color: .indigo)
-                                QueryCountBadge(label: "Compacted", count: svc.totalCompactedQueries, detail: svc.totalCompactedEntries, color: .orange)
-                                QueryCountBadge(label: "Recent", count: svc.totalRecentQueries, detail: svc.totalRecentEntries, color: .green)
+
+                            // Sync checkpoint (from tree scan)
+                            if platformBalanceSyncService.checkpointHeight > 0 {
+                                HStack {
+                                    Text("Sync Checkpoint")
+                                        .font(.subheadline)
+                                        .foregroundColor(.secondary)
+                                    Spacer()
+                                    Text(formattedHeight(UInt32(platformBalanceSyncService.checkpointHeight)))
+                                        .font(.subheadline)
+                                        .foregroundColor(.secondary)
+                                }
+                            }
+
+                            // Last known recent block (for compaction detection)
+                            HStack {
+                                Text("Last Recent Block")
+                                    .font(.subheadline)
+                                    .foregroundColor(.secondary)
+                                Spacer()
+                                if platformBalanceSyncService.lastKnownRecentBlock > 0 {
+                                    Text(formattedHeight(UInt32(platformBalanceSyncService.lastKnownRecentBlock)))
+                                        .font(.subheadline)
+                                        .foregroundColor(.secondary)
+                                } else {
+                                    Text("None found")
+                                        .font(.subheadline)
+                                        .foregroundColor(.blue)
+                                        .onTapGesture {
+                                            showProofDetail = true
+                                        }
+                                }
+                            }
+
+                            // Block time
+                            if let blockTime = platformBalanceSyncService.lastSyncBlockTime {
+                                HStack {
+                                    Text("Block Time")
+                                        .font(.subheadline)
+                                        .foregroundColor(.secondary)
+                                    Spacer()
+                                    Text(AppDate.formatted(blockTime, dateStyle: .abbreviated, timeStyle: .omitted))
+                                        .font(.caption)
+                                        .foregroundColor(.secondary)
+                                    Text(AppDate.formatted(blockTime, dateStyle: .omitted, timeStyle: .shortened))
+                                        .font(.caption)
+                                        .foregroundColor(.secondary)
+                                }
+                            }
+
+                            // Query counts since launch
+                            if platformBalanceSyncService.syncCountSinceLaunch > 0 {
+                                let svc = platformBalanceSyncService
+                                VStack(spacing: 4) {
+                                    HStack {
+                                        Text("Queries Since Launch")
+                                            .font(.subheadline)
+                                            .foregroundColor(.secondary)
+                                        Spacer()
+                                        Text("\(svc.syncCountSinceLaunch) syncs")
+                                            .font(.caption)
+                                            .foregroundColor(.secondary)
+                                    }
+                                    HStack(spacing: 12) {
+                                        QueryCountBadge(label: "Trunk", count: svc.totalTrunkQueries, color: .blue)
+                                        QueryCountBadge(label: "Branch", count: svc.totalBranchQueries, color: .indigo)
+                                        QueryCountBadge(label: "Compacted", count: svc.totalCompactedQueries, detail: svc.totalCompactedEntries, color: .orange)
+                                        QueryCountBadge(label: "Recent", count: svc.totalRecentQueries, detail: svc.totalRecentEntries, color: .green)
+                                    }
+                                }
+                            }
+
+                            // Error display
+                            if let error = platformBalanceSyncService.lastError {
+                                Text(error)
+                                    .font(.caption)
+                                    .foregroundColor(.red)
+                                    .lineLimit(2)
                             }
                         }
-                    }
-
-                    // Error display
-                    if let error = platformBalanceSyncService.lastError {
-                        Text(error)
+                        .padding(.top, 4)
+                    } label: {
+                        Text(platformSyncExpanded ? "Hide details" : "Show details")
                             .font(.caption)
-                            .foregroundColor(.red)
-                            .lineLimit(2)
+                            .foregroundColor(.blue)
                     }
 
                     // Action buttons


### PR DESCRIPTION
## Issue being fixed or feature implemented
The Platform Sync Status section in SwiftExampleApp's home view had grown to 7+ rows of detail (sync state, balance, active addresses, chain tip, checkpoint, last recent block, block time, query counters), pushing the rest of the screen below the fold. Most of those rows are diagnostic and only useful occasionally.

## What was done?
Restructured the section in [CoreContentView.swift](packages/swift-sdk/SwiftExampleApp/SwiftExampleApp/Core/Views/CoreContentView.swift) so it shows a compact summary by default and tucks the rest behind a `DisclosureGroup`:

**Always visible:**
- Sync state row (Syncing / Last sync / Not synced)
- Platform Balance
- Chain Tip Height (now always rendered, with `—` placeholder before the first sync)
- "Sync Now" / "Clear" action buttons

**Behind "Show details" / "Hide details":**
- Active Addresses
- Sync Checkpoint
- Last Recent Block (with the existing tap-to-show-proof affordance)
- Block Time
- Queries Since Launch + the four `QueryCountBadge`s (Trunk / Branch / Compacted / Recent)
- Error display

No behavior changes — same data, same data sources, same actions. Only the default visibility changed. State is held in a new `@State private var platformSyncExpanded: Bool = false`.

## How Has This Been Tested?
Manual review of the diff and surrounding context. I could not run `xcodebuild` to confirm because `DashSDKFFI.xcframework` is not present in this worktree (and `build_ios.sh` is a long, separate concern). The Swift change is self-contained — a reshuffle of an existing `VStack` into a `DisclosureGroup` plus one new `@State` flag — and uses only stock SwiftUI APIs already used elsewhere in the file.

Reviewers with a built framework can sanity-check by running the app and toggling the disclosure on the Core tab.

## Breaking Changes
None. UI-only change in the example app.

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [ ] I have made corresponding changes to the documentation if needed

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone