### PR TITLE
ci: bump actions/cache to v5 and codecov/codecov-action to v6

### DIFF
--- a/.github/actions/docker/action.yaml
+++ b/.github/actions/docker/action.yaml
@@ -109,7 +109,7 @@ runs:
       run: echo "HOME=$HOME" >> $GITHUB_ENV
 
     - name: Cargo cache for Docker
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       id: cargo-cache
       with:
         path: |
@@ -141,7 +141,7 @@ runs:
         skip-extraction: ${{ steps.cargo-cache.outputs.cache-hit }}
 
     - name: Yarn unplugged cache for Docker
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       id: yarn-cache
       with:
         path: ${{ env.HOME }}/yarn-unplugged-cache

--- a/.github/actions/docker/action.yaml
+++ b/.github/actions/docker/action.yaml
@@ -151,7 +151,7 @@ runs:
 
     - name: Set arch
       id: arch
-      uses: actions/github-script@v6
+      uses: actions/github-script@v8
       with:
         result-encoding: "string"
         script: return '${{ inputs.platform }}'.replace('linux/', '');

--- a/.github/actions/librocksdb/action.yaml
+++ b/.github/actions/librocksdb/action.yaml
@@ -18,7 +18,7 @@ runs:
   using: composite
   steps:
     - name: Cache librocksdb
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       id: librocksdb-cache
       with:
         key: librocksdb/${{ inputs.version }}/${{ runner.os }}/${{ runner.arch }}

--- a/.github/actions/local-network/action.yaml
+++ b/.github/actions/local-network/action.yaml
@@ -28,7 +28,7 @@ runs:
 
     - name: Restore local network data
       id: local-network-data
-      uses: actions/cache/restore@v4
+      uses: actions/cache/restore@v5
       with:
         path: |
           ${{ env.HOME }}/.dashmate
@@ -63,7 +63,7 @@ runs:
       if: steps.local-network-data.outputs.cache-hit != 'true'
 
     - name: Save local network data
-      uses: actions/cache/save@v4
+      uses: actions/cache/save@v5
       with:
         path: |
           ${{ env.HOME }}/.dashmate

--- a/.github/actions/nodejs/action.yaml
+++ b/.github/actions/nodejs/action.yaml
@@ -29,7 +29,7 @@ runs:
       run: npm config set audit false
 
     - name: Cache NPM build artifacts
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         # Cache the unplugged packages (unpacked native builds), yarn's
         # build-state (so postinstalls don't re-run) and install-state

--- a/.github/actions/rust/action.yaml
+++ b/.github/actions/rust/action.yaml
@@ -69,7 +69,7 @@ runs:
     - name: Restore cached protoc (v32.0)
       if: runner.os == 'Linux'
       id: cache-protoc
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: |
           ${{ steps.resolved_home.outputs.home }}/.local/protoc-32.0/bin
@@ -94,7 +94,7 @@ runs:
 
     - name: Save cached protoc (v32.0)
       if: runner.os == 'Linux' && steps.cache-protoc.outputs.cache-hit != 'true'
-      uses: actions/cache/save@v4
+      uses: actions/cache/save@v5
       with:
         path: |
           ${{ steps.resolved_home.outputs.home }}/.local/protoc-32.0/bin
@@ -106,7 +106,7 @@ runs:
       run: echo "HOME=$HOME" >> $GITHUB_ENV
 
     - name: Cache cargo registry
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       if: inputs.cache == 'true'
       with:
         path: |

--- a/.github/workflows/swift-example-app-ui-smoke.yml
+++ b/.github/workflows/swift-example-app-ui-smoke.yml
@@ -31,7 +31,7 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
 
       - name: Cache cargo registry
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.cargo/registry
@@ -50,7 +50,7 @@ jobs:
 
       - name: Restore cached Protobuf
         id: cache-protoc
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.local/protoc-32.0/bin

--- a/.github/workflows/swift-sdk-build.yml
+++ b/.github/workflows/swift-sdk-build.yml
@@ -47,7 +47,7 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
 
       - name: Cache cargo registry
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.cargo/registry
@@ -64,7 +64,7 @@ jobs:
 
       - name: Restore cached Protobuf (protoc)
         id: cache-protoc
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ${{ env.HOME }}/.local/protoc-32.0/bin
@@ -88,7 +88,7 @@ jobs:
 
       - name: Save cached Protobuf (protoc)
         if: steps.cache-protoc.outputs.cache-hit != 'true'
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@v5
         with:
           path: |
             ${{ env.HOME }}/.local/protoc-32.0/bin

--- a/.github/workflows/swift-sdk-build.yml
+++ b/.github/workflows/swift-sdk-build.yml
@@ -130,7 +130,7 @@ jobs:
 
       - name: Comment/update PR with artifact link and usage guide (skip if unchanged)
         if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const runUrl = `https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;

--- a/.github/workflows/swift-sdk-release.yml
+++ b/.github/workflows/swift-sdk-release.yml
@@ -81,7 +81,7 @@ jobs:
 
       - name: Check existing release for changes
         id: check
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         env:
           NAME: ${{ steps.tag.outputs.name }}
         with:

--- a/.github/workflows/swift-sdk-release.yml
+++ b/.github/workflows/swift-sdk-release.yml
@@ -37,7 +37,7 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
 
       - name: Cache cargo registry
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.cargo/registry

--- a/.github/workflows/tests-build-js.yml
+++ b/.github/workflows/tests-build-js.yml
@@ -39,7 +39,7 @@ jobs:
 
       - name: Cache protoc Docker image
         id: cache-protoc
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: /tmp/protoc-image.tar
           key: docker-rvolosatovs-protoc-4.0.0

--- a/.github/workflows/tests-dashmate.yml
+++ b/.github/workflows/tests-dashmate.yml
@@ -84,7 +84,7 @@ jobs:
 
       - name: Restore test suite local network data to speed up dashmate local network tests
         id: local-network-data
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v5
         with:
           path: |
             ${{ env.HOME }}/.dashmate

--- a/.github/workflows/tests-rs-workspace.yml
+++ b/.github/workflows/tests-rs-workspace.yml
@@ -205,7 +205,7 @@ jobs:
 
       - name: Upload coverage
         if: always()
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v6
         with:
           files: lcov.info
           flags: rust


### PR DESCRIPTION
## Issue being fixed or feature implemented
GitHub Actions emits Node.js 20 deprecation warnings on every CI run because we still pin `actions/cache@v4` (Node 20) and `codecov/codecov-action@v5` (also pulls in `actions/github-script@v7`/Node 20). Mirrors [dashpay/rust-dashcore#741](https://github.com/dashpay/rust-dashcore/pull/741).

## What was done?
- Bumped every reference of `actions/cache@v4` (and the `/save`, `/restore` subpaths) to `@v5` across the workflows in `.github/workflows/` and the composite actions in `.github/actions/`.
- Bumped `codecov/codecov-action@v5` to `@v6` in `.github/workflows/tests-rs-workspace.yml`. v6 also brings in `actions/github-script@v8`, removing the second deprecation notice surfaced via the codecov step.

Both actions now run on Node.js 24.

## How Has This Been Tested?
CI on this PR exercises every touched workflow / composite action.

## Breaking Changes
None — caches keys are unchanged, so existing cache entries remain reusable.

## Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [ ] I have made corresponding changes to the documentation if needed

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated GitHub Actions infrastructure dependencies to latest versions for improved caching and code coverage integration. No user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->