### PR TITLE
docs: trim batch transformer bump comment

### DIFF
--- a/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/batch/transformer/v0/mod.rs
+++ b/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/batch/transformer/v0/mod.rs
@@ -753,12 +753,9 @@ impl BatchTransitionInternalTransformerV0 for BatchTransition {
                     Self::find_replaced_document_v0(transition, replaced_documents);
 
                 if !validation_result.is_valid_with_data() {
-                    // Replace's missing-target-document path is the one
-                    // failure site that already emitted a bump action on
-                    // PROTOCOL_VERSION_11 (pre-PR), so it must continue to
-                    // do so regardless of `failed_per_transition_action`.
-                    // Routing it through the helper would drop the bump on
-                    // v0 and diverge v11 chain replay.
+                    // Keep this bump emission inline (not via Self::failed_per_transition_action):
+                    // it's the one legacy v0 bump site, and routing it through the helper would
+                    // drop the bump on PROTOCOL_VERSION_11 and diverge v11 chain replay (#2867).
                     let bump_action =
                         BumpIdentityDataContractNonceAction::from_borrowed_document_base_transition(
                             document_replace_transition.base(),


### PR DESCRIPTION
# PR 3616 comment trim

## Summary

- Trim the batch transformer v0 bump-emission comment to the wording
  QuantumExplorer approved on dashpay/platform#3616.
- Keep the safety note that routing this path through
  `Self::failed_per_transition_action` would diverge v11 replay behavior.

## Validation

- `cargo fmt --check -p drive-abci`
- Pre-commit Rust hook during commit:
  - `cargo fmt --all -- --check`
  - workspace `cargo check`
- Code review gate:
  - Base: `11c87bccbd93e871dd152679f4b333d098fa934b`
  - Head: `71b22ed4b4`
  - Intent: trim PR 3616 comment to reviewer-approved wording
  - Result: ship


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved internal code documentation for better maintainability.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dashpay/platform/pull/3628)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->