### PR TITLE
ci: preserve Swift SDK Rust build cache

### DIFF
--- a/.github/workflows/swift-sdk-build.yml
+++ b/.github/workflows/swift-sdk-build.yml
@@ -13,12 +13,14 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          clean: true
+          clean: false
 
-      - name: Force clean working directory
+      - name: Clean working directory while preserving Rust build cache
         run: |
-          git clean -ffdx
           git reset --hard HEAD
+          git clean -ffdx \
+            -e target/ \
+            -e target/**
 
       - name: Debug - Show BaseViewModel.swift content
         run: |
@@ -42,17 +44,18 @@ jobs:
           xcodebuild -version
           swift --version
 
-      # Rust + Cargo cache to speed up FFI build
       - name: Set up Rust toolchain (stable)
         uses: dtolnay/rust-toolchain@stable
 
-      - name: Cache cargo registry
-        uses: actions/cache@v5
+      - name: Restore cargo registry cache
+        uses: actions/cache/restore@v5
         with:
           path: |
             ~/.cargo/registry
             ~/.cargo/git
           key: cargo-registry-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            cargo-registry-
 
       - name: Add iOS Rust targets
         run: |


### PR DESCRIPTION
## Summary
- preserve the Rust `target/` directory during the Swift SDK workspace cleanup so Apple target artifacts can be reused on self-hosted runners
- switch the cargo registry/git cache step to restore-only with a broad restore key to avoid the long post-job cache save

## Validation
- `git diff --check -- .github/workflows/swift-sdk-build.yml`
- `python3 -c 'import pathlib, yaml; yaml.safe_load(pathlib.Path(".github/workflows/swift-sdk-build.yml").read_text()); print("yaml ok")'`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build workflow configuration to improve checkout and cache handling for the Swift SDK build process.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dashpay/platform/pull/3632)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->