### PR TITLE
fix(platform-wallet): fix failing CI

### DIFF
--- a/packages/rs-platform-wallet-ffi/src/tokens/group_info.rs
+++ b/packages/rs-platform-wallet-ffi/src/tokens/group_info.rs
@@ -94,7 +94,7 @@ mod tests {
     fn test_decode_other_signer_null_action_id() {
         unsafe {
             let result = decode_group_info(2, 0, std::ptr::null(), false);
-            assert!(matches!(result, Err(_)), "expected Err(NullPointer)");
+            assert!(result.is_err(), "expected Err(NullPointer)");
         }
     }
 
@@ -120,7 +120,7 @@ mod tests {
     fn test_decode_invalid_kind() {
         unsafe {
             let result = decode_group_info(99, 0, std::ptr::null(), false);
-            assert!(matches!(result, Err(_)), "expected Err(InvalidParameter)");
+            assert!(result.is_err(), "expected Err(InvalidParameter)");
         }
     }
 }

--- a/packages/rs-platform-wallet-ffi/tests/integration_tests.rs
+++ b/packages/rs-platform-wallet-ffi/tests/integration_tests.rs
@@ -50,7 +50,6 @@ fn test_wallet_from_mnemonic() {
         let result = platform_wallet_info_create_from_mnemonic(
             Network::Testnet.into(),
             mnemonic.as_ptr(),
-            std::ptr::null(),
             &mut handle,
         );
 
@@ -266,7 +265,6 @@ fn test_full_workflow() {
         let result = platform_wallet_info_create_from_mnemonic(
             Network::Testnet.into(),
             mnemonic.as_ptr(),
-            std::ptr::null(),
             &mut wallet_handle,
         );
         assert_eq!(result.code, PlatformWalletFFIResultCode::Success);


### PR DESCRIPTION
## Issue being fixed or feature implemented

Two latent CI failures on `v3.1-dev` for `rs-platform-wallet-ffi`:

1. **Test compile error** — `packages/rs-platform-wallet-ffi/tests/integration_tests.rs:50,266` calls `platform_wallet_info_create_from_mnemonic` with 4 arguments. PR #3627 dropped the `passphrase` parameter to 3 args but missed the test callers. Any workspace test build fails with `error[E0061]: this function takes 3 arguments but 4 arguments were supplied`.

2. **Clippy `-D warnings` failure** — `packages/rs-platform-wallet-ffi/src/tokens/group_info.rs:97,123` has `redundant_pattern_matching` lints (`matches!(x, Err(_))` should be `.is_err()`). The workspace's `-D warnings` gate fails on it.

## What was done?

Cherry-picked two existing fixes from PR #3554 (`fix/rs-platform-wallet-auto-select-inputs`):

- `ab6eb41738` (originally `50f7607868`) — `fix(rs-platform-wallet-ffi): drop stale ptr arg from integration_tests`
- `b8dae71fad` (originally `f19a9fe718`) — `chore(rs-platform-wallet-ffi): use Result::is_err in group_info tests`

Both are minimal, single-file mechanical fixes (2 sites + 2 sites respectively). Authorship preserved (Lukasz Klimek).

## Why a separate PR?

The fixes already ride inside PR #3554. They've also been cherry-picked separately into PR #3585 (`ff56c56979` — clippy only) and PR #3637 (`6c11ecefb6` + `f23183c778`). Landing both at the v3.1-dev root means:

- v3.1-dev's own CI goes green
- The cherry-picks in #3554 / #3585 / #3637 become duplicate-by-content and git drops them on rebase
- Future branches forking from v3.1-dev no longer inherit the bugs

This PR is the minimal, focused fix and should be a clean fast-merge.

## Breaking Changes

None — only fixes test callers and clippy style.

## How Has This Been Tested?

- `cargo check -p platform-wallet-ffi --tests` — clean
- `cargo clippy -p platform-wallet-ffi --tests --no-deps -- -D warnings` — clean
- `cargo test -p platform-wallet-ffi --no-run` — test binaries build successfully
- `cargo check --workspace` — no wider workspace breakage

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests *(fixing existing tests; no new tests needed)*
- [x] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any *(no breaking changes)*
- [x] I have made corresponding changes to the documentation if needed *(none)*

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone

<sub>🤖 Co-authored by [Claudius the Magnificent](https://github.com/lklimek/claudius) AI Agent</sub>
