### PR TITLE
feat(platform-wallet): external signable wallets

### DIFF
--- a/packages/rs-platform-wallet/src/manager/wallet_lifecycle.rs
+++ b/packages/rs-platform-wallet/src/manager/wallet_lifecycle.rs
@@ -125,7 +125,7 @@ impl<P: PlatformWalletPersistence + 'static> PlatformWalletManager<P> {
     #[allow(clippy::type_complexity)]
     async fn register_wallet(
         &self,
-        wallet: Wallet,
+        mut wallet: Wallet,
         birth_height_override: Option<u32>,
     ) -> Result<Arc<PlatformWallet>, PlatformWalletError> {
         // NOTE: the wallet id is NETWORK-SCOPED by construction.
@@ -240,6 +240,8 @@ impl<P: PlatformWalletPersistence + 'static> PlatformWalletManager<P> {
             identity_manager: crate::wallet::identity::IdentityManager::new(),
             tracked_asset_locks: std::collections::BTreeMap::new(),
         };
+
+        wallet.downgrade_to_external_signable();
 
         // Insert into WalletManager. A duplicate (same network-scoped
         // wallet id already registered) surfaces as the typed


### PR DESCRIPTION
After Wallet::from_mnemonic and Wallet::from_seed I do a wallet downgrade into ExternableSignable, forcing every transaction to be signed externally 

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [ ] I have made corresponding changes to the documentation if needed

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Internal Improvements**
  * Improved wallet registration process to ensure proper configuration handling during setup.

---

*Note: This release includes internal enhancements with no changes to user-facing functionality or public APIs.*
<!-- end of auto-generated comment: release notes by coderabbit.ai -->