### PR TITLE
chore(swift-sdk): remove dash-spv-ffi crate usage, spv is wrapped by platform-wallet

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1664,25 +1664,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "dash-spv-ffi"
-version = "0.42.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=53130869e5b9343ae59016323e5e5269e717a8fd#53130869e5b9343ae59016323e5e5269e717a8fd"
-dependencies = [
- "cbindgen 0.29.2",
- "clap",
- "dash-network",
- "dash-spv",
- "dashcore",
- "hex",
- "key-wallet",
- "key-wallet-ffi",
- "key-wallet-manager",
- "tokio",
- "tokio-util",
- "tracing",
-]
-
-[[package]]
 name = "dashcore"
 version = "0.42.0"
 source = "git+https://github.com/dashpay/rust-dashcore?rev=53130869e5b9343ae59016323e5e5269e717a8fd#53130869e5b9343ae59016323e5e5269e717a8fd"
@@ -5932,7 +5913,6 @@ name = "rs-unified-sdk-ffi"
 version = "3.1.0-dev.1"
 dependencies = [
  "dash-network",
- "dash-spv-ffi",
  "key-wallet-ffi",
  "platform-wallet-ffi",
  "rs-sdk-ffi",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,7 +52,6 @@ members = [
 dashcore = { git = "https://github.com/dashpay/rust-dashcore", rev = "53130869e5b9343ae59016323e5e5269e717a8fd" }
 dash-network-seeds = { git = "https://github.com/dashpay/rust-dashcore", rev = "53130869e5b9343ae59016323e5e5269e717a8fd" }
 dash-spv = { git = "https://github.com/dashpay/rust-dashcore", rev = "53130869e5b9343ae59016323e5e5269e717a8fd" }
-dash-spv-ffi = { git = "https://github.com/dashpay/rust-dashcore", rev = "53130869e5b9343ae59016323e5e5269e717a8fd" }
 key-wallet = { git = "https://github.com/dashpay/rust-dashcore", rev = "53130869e5b9343ae59016323e5e5269e717a8fd" }
 key-wallet-ffi = { git = "https://github.com/dashpay/rust-dashcore", rev = "53130869e5b9343ae59016323e5e5269e717a8fd" }
 key-wallet-manager = { git = "https://github.com/dashpay/rust-dashcore", rev = "53130869e5b9343ae59016323e5e5269e717a8fd" }

--- a/packages/rs-platform-wallet/src/wallet/platform_addresses/wallet.rs
+++ b/packages/rs-platform-wallet/src/wallet/platform_addresses/wallet.rs
@@ -117,11 +117,7 @@ impl PlatformAddressWallet {
                         .platform_payment_managed_account_at_index_mut(*account_index)
                     {
                         for (p2pkh, funds) in account_state.found() {
-                            account.set_address_credit_balance(
-                                *p2pkh,
-                                funds.balance,
-                                None,
-                            );
+                            account.set_address_credit_balance(*p2pkh, funds.balance, None);
                         }
                     }
                 }

--- a/packages/rs-sdk-ffi/cbindgen.toml
+++ b/packages/rs-sdk-ffi/cbindgen.toml
@@ -15,8 +15,8 @@ documentation_style = "c99"
 [defines]
 
 [export]
-include = ["dash_sdk_*", "dash_core_*", "dash_unified_sdk_*", "dash_spv_ffi_*"]
-# Exclude types that come from key-wallet-ffi or dash-spv-ffi to avoid duplication
+include = ["dash_sdk_*", "dash_core_*", "dash_unified_sdk_*"]
+# Exclude types that come from key-wallet-ffi to avoid duplication
 exclude = ["FFIAccountType", "FFIAccountTypePreference", "FFIAccountTypeUsed", "FFIAccountCreationOptionType"]
 prefix = ""
 item_types = ["enums", "structs", "unions", "typedefs", "opaque", "functions"]

--- a/packages/rs-unified-sdk-ffi/Cargo.toml
+++ b/packages/rs-unified-sdk-ffi/Cargo.toml
@@ -8,7 +8,6 @@ rust-version.workspace = true
 crate-type = ["staticlib", "cdylib"]
 
 [dependencies]
-dash-spv-ffi = { workspace = true }
 key-wallet-ffi = { workspace = true }
 platform-wallet-ffi = { path = "../rs-platform-wallet-ffi" }
 rs-sdk-ffi = { path = "../rs-sdk-ffi" }

--- a/packages/rs-unified-sdk-ffi/src/lib.rs
+++ b/packages/rs-unified-sdk-ffi/src/lib.rs
@@ -1,5 +1,4 @@
 pub use dash_network;
-pub use dash_spv_ffi;
 pub use key_wallet_ffi;
 pub use platform_wallet_ffi;
 pub use rs_sdk_ffi;

--- a/packages/swift-sdk/Sources/SwiftDashSDK/Core/Services/SDKLogger.swift
+++ b/packages/swift-sdk/Sources/SwiftDashSDK/Core/Services/SDKLogger.swift
@@ -29,7 +29,7 @@ public enum LoggingPreferences {
         let preset = loadPreset()
         let enableSwiftVerbose: Bool
 
-        SDK.initializeSPVLogging(level: SDK.LogLevel.info, enableConsole: true, maxFiles: 5)
+        SDK.enableLogging(level: .info)
 
         switch preset {
         case .high:

--- a/packages/swift-sdk/Sources/SwiftDashSDK/KeyWallet/WalletManager.swift
+++ b/packages/swift-sdk/Sources/SwiftDashSDK/KeyWallet/WalletManager.swift
@@ -49,7 +49,7 @@ public class WalletManager {
 
     deinit {
         if ownsHandle {
-            dash_spv_ffi_wallet_manager_free(handle)
+            wallet_manager_free(handle)
         }
     }
 

--- a/packages/swift-sdk/Sources/SwiftDashSDK/SDK.swift
+++ b/packages/swift-sdk/Sources/SwiftDashSDK/SDK.swift
@@ -81,62 +81,6 @@ public final class SDK: @unchecked Sendable {
     print("🔵 SDK: Logging enabled at level: \(level)")
   }
 
-  /// Initialize SPV logging with configurable output options
-  /// - Parameters:
-  ///   - level: Log level (defaults to .info if nil)
-  ///   - enableConsole: Whether to output logs to console/stderr
-  ///   - logDirectory: Directory for log files (nil to disable file logging)
-  ///   - maxFiles: Maximum archived log files to retain (ignored if logDirectory is nil)
-  /// - Returns: true if logging was initialized successfully
-  @discardableResult
-  public static func initializeSPVLogging(
-    level: LogLevel? = nil,
-    enableConsole: Bool = true,
-    logDirectory: String? = nil,
-    maxFiles: UInt = 5
-  ) -> Bool {
-    let levelString: String? = level.map { lvl in
-      switch lvl {
-      case .error: return "error"
-      case .warn: return "warn"
-      case .info: return "info"
-      case .debug: return "debug"
-      case .trace: return "trace"
-      }
-    }
-
-    let result: Int32
-    if let levelStr = levelString {
-      if let logDir = logDirectory {
-        result = levelStr.withCString { levelCStr in
-          logDir.withCString { dirCStr in
-            dash_spv_ffi_init_logging(levelCStr, enableConsole, dirCStr, maxFiles)
-          }
-        }
-      } else {
-        result = levelStr.withCString { levelCStr in
-          dash_spv_ffi_init_logging(levelCStr, enableConsole, nil, maxFiles)
-        }
-      }
-    } else {
-      if let logDir = logDirectory {
-        result = logDir.withCString { dirCStr in
-          dash_spv_ffi_init_logging(nil, enableConsole, dirCStr, maxFiles)
-        }
-      } else {
-        result = dash_spv_ffi_init_logging(nil, enableConsole, nil, maxFiles)
-      }
-    }
-
-    let success = result == 0
-    if success {
-      print("🔵 SDK: SPV logging initialized (level: \(levelString ?? "default"), console: \(enableConsole))")
-    } else {
-      print("⚠️ SDK: SPV logging initialization returned code \(result)")
-    }
-    return success
-  }
-
   /// Local Platform DAPI addresses; override via UserDefaults key "platformDAPIAddresses"
   private static var platformDAPIAddresses: String {
     if let override = UserDefaults.standard.string(forKey: "platformDAPIAddresses"), !override.isEmpty {

--- a/packages/swift-sdk/build_ios.sh
+++ b/packages/swift-sdk/build_ios.sh
@@ -130,7 +130,6 @@ inject_modulemap() {
 
 #include "dash-network/dash-network.h"
 #include "key-wallet-ffi/key-wallet-ffi.h"
-#include "dash-spv-ffi/dash-spv-ffi.h"
 #include "rs-sdk-ffi/rs-sdk-ffi.h"
 #include "platform-wallet-ffi/platform-wallet-ffi.h"
 


### PR DESCRIPTION
If we are planning to wrap all dash-spv logic in platform-wallet and platform-wallet-ffi, it makes more sense to remove this symbols from the final binary so nobody can use them


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [ ] I have made corresponding changes to the documentation if needed

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Breaking Changes**
  * Removed `initializeSPVLogging()` public method from Swift SDK. Migrate code to use `enableLogging(level:)` for logging initialization instead.

* **Refactor**
  * Updated internal FFI layer and dependency architecture to streamline SDK components.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dashpay/platform/pull/3644)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->