### PR TITLE
ci(swift-sdk): prune orphaned FFI header subdirs in build_ios.sh

### DIFF
--- a/packages/swift-sdk/build_ios.sh
+++ b/packages/swift-sdk/build_ios.sh
@@ -23,6 +23,15 @@ PACKAGE="rs-unified-sdk-ffi"
 XCFRAMEWORK="$SCRIPT_DIR/DashSDKFFI.xcframework"
 PROFILE="dev" # Rust doesn't allow us to use "debug" for some reason, the profile name internally is dev
 
+# Crates whose cbindgen-generated headers ship in the unified framework.
+# Order matters: earlier headers define types referenced by later ones.
+INCLUDED_CRATES=(
+  dash-network
+  key-wallet-ffi
+  rs-sdk-ffi
+  platform-wallet-ffi
+)
+
 # -------------------------------
 # Flags
 # -------------------------------
@@ -122,19 +131,40 @@ fi
 
 inject_modulemap() {
   local HEADERS_DIR="$1"
+  local dir name keep c
 
-  # Create umbrella header that includes all FFI headers in dependency order
-  cat > "$HEADERS_DIR/DashSDKFFI.h" << 'EOF'
-#ifndef DASHSDKFFI_H
-#define DASHSDKFFI_H
+  for dir in "$HEADERS_DIR"/*/; do
+    [[ -d "$dir" ]] || continue
+    name=$(basename "$dir")
+    keep=0
+    for c in "${INCLUDED_CRATES[@]}"; do
+      if [[ "$c" == "$name" ]]; then
+        keep=1
+        break
+      fi
+    done
+    if (( ! keep )); then
+      rm -rf "$dir"
+      log_info "  → pruned orphan header dir: $name"
+    fi
+  done
 
-#include "dash-network/dash-network.h"
-#include "key-wallet-ffi/key-wallet-ffi.h"
-#include "rs-sdk-ffi/rs-sdk-ffi.h"
-#include "platform-wallet-ffi/platform-wallet-ffi.h"
+  for c in "${INCLUDED_CRATES[@]}"; do
+    if [[ ! -f "$HEADERS_DIR/$c/$c.h" ]]; then
+      log_error "Missing header: $HEADERS_DIR/$c/$c.h"
+      log_error "  → ensure '$c' is a dependency of $PACKAGE"
+      exit 1
+    fi
+  done
 
-#endif
-EOF
+  {
+    printf '#ifndef DASHSDKFFI_H\n'
+    printf '#define DASHSDKFFI_H\n\n'
+    for c in "${INCLUDED_CRATES[@]}"; do
+      printf '#include "%s/%s.h"\n' "$c" "$c"
+    done
+    printf '\n#endif\n'
+  } > "$HEADERS_DIR/DashSDKFFI.h"
 
   cat > "$HEADERS_DIR/module.modulemap" << 'EOF'
 module DashSDKFFI {


### PR DESCRIPTION
## Issue being fixed or feature implemented

The Swift SDK CI job (`.github/workflows/swift-sdk-build.yml`, job `Swift SDK and Example build (warnings as errors)`) has been failing on PRs that merge `v3.1-dev` with:

```
DashSDKFFI.h:10:1: error: umbrella header for module 'DashSDKFFI'
does not include header '/dash-spv-ffi/dash-spv-ffi.h'
```

The self-hosted macOS ARM64 runner preserves `target/` across CI runs (introduced by [#3632](https://github.com/dashpay/platform/pull/3632), `git clean -ffdx -e target/ -e target/**`). Recently [#3644](https://github.com/dashpay/platform/pull/3644) removed the `dash-spv-ffi` crate from the unified FFI build and dropped its `#include` from the umbrella header. `cargo` never reclaims `target/<triple>/<profile>/include/<crate>/` when a crate leaves the dependency tree, so the orphan `dash-spv-ffi/dash-spv-ffi.h` sits in the cached include directory, `xcodebuild -create-xcframework -headers` bundles it into the framework, and Clang's `umbrella header` check fails.

## What was done?

Made `packages/swift-sdk/build_ios.sh` self-correcting against this class of stale-state failure.

- Introduced a single ordered `INCLUDED_CRATES` list at the top of the script — the canonical set of FFI crates whose cbindgen output ships in `DashSDKFFI.xcframework`. Ordering matters because earlier headers define types referenced by later ones.
- `inject_modulemap` now:
  1. **Prunes** any immediate subdirectory of the include dir whose name is not in `INCLUDED_CRATES` (catches orphans from removed/renamed crates), with safe quoting and a `[[ -d "$dir" ]] || continue` guard.
  2. **Asserts** that every crate in `INCLUDED_CRATES` has its expected header on disk — converts the silent drift case ("array references a crate Cargo.toml doesn't pull in") into a clear script-level error before Clang sees it.
  3. **Generates** the umbrella `DashSDKFFI.h` from the same list via a `printf` loop, replacing the previous hardcoded heredoc.
- `module.modulemap` heredoc and the opaque-struct rewrite loop are untouched.

The list is the one source of truth: a future crate removal becomes a one-line edit, and the script self-heals the runner's cache on the next run.

## How Has This Been Tested?

Validated locally before pushing.

- `bash -n packages/swift-sdk/build_ios.sh` clean.
- Sourced `inject_modulemap` against the real stale `target/aarch64-apple-ios-sim/release/include/` on this workstation (which contained the same `dash-spv-ffi/` orphan the runner has): the orphan was pruned, generated `DashSDKFFI.h` came out byte-identical to the post-`#3644` heredoc shape, `module.modulemap` unchanged.
- Hid one of the surviving include dirs (`dash-network/`) to simulate a `Cargo.toml`/array drift: existence assertion fired with `Missing header: …` and `exit 1`. No silent failure path into Clang.

On CI (this PR): the first run will exercise the bug — the runner's cached `target/` still contains the `dash-spv-ffi/` subdir from prior builds, the prune step will remove it (look for `→ pruned orphan header dir: dash-spv-ffi` in the logs), the umbrella check passes, and the runner's cache is permanently repaired for every subsequent PR. Re-runs on the same SHA will be a no-op for the prune step.

Out-of-scope: not switching the modulemap from `umbrella header "X.h"` to `umbrella .` — that would mask the orphan rather than fix it, and would lose the explicit `#include` order the framework relies on for transitive type visibility.

## Breaking Changes

None. The generated umbrella header is byte-identical to the previous hardcoded heredoc on the no-orphan path, and the script is invoked the same way.

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [x] I have made corresponding changes to the documentation if needed

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved iOS SDK build system with enhanced header organization, validation, and error handling to ensure more reliable builds.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dashpay/platform/pull/3666?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->