### PR TITLE
ci: prune macOS coverage artifacts

### DIFF
--- a/.github/workflows/tests-rs-workspace.yml
+++ b/.github/workflows/tests-rs-workspace.yml
@@ -21,14 +21,27 @@ jobs:
         with:
           clean: false
 
-      - name: Clean target if too large
+      - name: Prune macOS runner disk before tests
         run: |
-          SIZE=$(du -sm target 2>/dev/null | cut -f1 || true)
+          for path in ../target-backup-before-*-clean-* target/llvm-cov-target; do
+            if [ -e "$path" ]; then
+              echo "Removing stale runner artifact: $path"
+              rm -rf "$path"
+            fi
+          done
+
+          TARGET_MAX_MB=120000
+          MIN_FREE_MB=60000
+          SIZE=$(du -sm target 2>/dev/null | awk '{print $1}' || echo 0)
+          FREE=$(df -m . | awk 'NR == 2 {print $4}')
           SIZE=${SIZE:-0}
+          FREE=${FREE:-0}
+
           echo "target/ size: ${SIZE}MB"
-          if [ "$SIZE" -gt 200000 ]; then
-            echo "target/ exceeds 200GB — cleaning"
-            cargo clean
+          echo "available disk: ${FREE}MB"
+          if [ "$SIZE" -gt "$TARGET_MAX_MB" ] || [ "$FREE" -lt "$MIN_FREE_MB" ]; then
+            echo "target/ exceeds ${TARGET_MAX_MB}MB or disk is below ${MIN_FREE_MB}MB free; removing target/"
+            rm -rf target
           fi
 
       - name: Install build dependencies
@@ -211,6 +224,15 @@ jobs:
           flags: rust
           token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: false
+
+      - name: Remove cargo-llvm-cov build artifacts
+        if: always()
+        run: |
+          if [ -d target/llvm-cov-target ]; then
+            du -sh target/llvm-cov-target || true
+            rm -rf target/llvm-cov-target
+          fi
+          du -sh target 2>/dev/null || true
 
       - name: Run doctests
         if: ${{ inputs.doctests-changed }}
@@ -530,4 +552,3 @@ jobs:
             fi
           done
           echo "No immutable/append_only structure violations found"
-


### PR DESCRIPTION
## Summary
- prune stale macOS runner artifacts before Rust tests, including `target/llvm-cov-target` and old `target-backup-before-*-clean-*` folders
- lower the emergency `target/` cleanup threshold and also clean when free disk drops below 60GB
- remove `cargo llvm-cov` build artifacts after coverage upload so they do not accumulate between self-hosted runner jobs

## Validation
- `git diff --check -- .github/workflows/tests-rs-workspace.yml`
- `python3 -c 'import pathlib, yaml; yaml.safe_load(pathlib.Path(".github/workflows/tests-rs-workspace.yml").read_text()); print("yaml ok")'`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Improved CI workflow disk management with enhanced artifact pruning and conditional cleanup of build artifacts on macOS test runners based on disk thresholds
  * Optimized build pipeline reliability through better storage handling

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dashpay/platform/pull/3667?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->