### PR TITLE
fix(dpp): correct misleading non-mainnet minimum-interval error message

### DIFF
--- a/packages/rs-dpp/src/errors/consensus/basic/token/invalid_token_distribution_block_interval_too_short_error.rs
+++ b/packages/rs-dpp/src/errors/consensus/basic/token/invalid_token_distribution_block_interval_too_short_error.rs
@@ -9,7 +9,7 @@ use thiserror::Error;
 #[derive(
     Error, Debug, Clone, PartialEq, Eq, Encode, Decode, PlatformSerialize, PlatformDeserialize,
 )]
-#[error("BlockBasedDistribution interval is too short: {interval}. Minimum allowed is 100.")]
+#[error("BlockBasedDistribution interval is too short: {interval}. It is below the network-required minimum.")]
 #[platform_serialize(unversioned)]
 pub struct InvalidTokenDistributionBlockIntervalTooShortError {
     interval: BlockHeightInterval,


### PR DESCRIPTION
## Issue

`InvalidTokenDistributionBlockIntervalTooShortError`'s `Display` literal asserted `Minimum allowed is 100.` That number is correct only on mainnet. The actual enforced floor is network-dependent (mainnet 100 / testnet 5 / devnet 2 / regtest 1), computed by the validator at `packages/rs-dpp/src/data_contract/associated_token/token_perpetual_distribution/reward_distribution_type/validation/v0/mod.rs`. On testnet/devnet/regtest the message lied — and it is surfaced verbatim to JS/wasm consumers via `generic_consensus_error!`.

## Fix (Option A — string-only `Display` reword)

Single line, single file: the `#[error(...)]` literal now reads

`BlockBasedDistribution interval is too short: {interval}. It is below the network-required minimum.`

No hardcoded number, no per-network table baked into the message — the validator stays the single source of truth.

## Why Option A, not Option B (carry the real minimum)

Option B requires adding a `minimum` field to the error struct. That struct is `bincode::Encode/Decode` + `PlatformSerialize/PlatformDeserialize`, `#[platform_serialize(unversioned)]`, wire-encoded inside `ConsensusError` (state-transition results / proofs). bincode encodes structs as ordered fieldless concatenation, so a field addition changes the byte layout and `Decode` shape with **no version discriminant to gate it** — a hard, ungated **breaking consensus-serialization change**, plus mandatory regen of every bincode/proof vector carrying this variant. Disproportionate for a cosmetic diagnostic-string bug.

The `#[error(...)]` literal is pure runtime `Display` — never serialized. Reword = zero wire impact: no struct/field/derive/serde change, error code 10272 unchanged, validator unchanged, wasm signature unchanged (JS message auto-fixed via passthrough), no vector regen. Non-breaking → plain `fix`, **no `!`, no `BREAKING CHANGE:` footer**.

## Scope / out of scope

- Touched: 1 file, 1 line. No test asserted the old `100` substring, so no test changed.
- **Sibling `InvalidTokenDistributionTimeIntervalTooShortError`** (`Minimum allowed is 3,600,000 ms (1 hour)`) is the **same network-dependent class** but is **intentionally out of scope** for this minimal fix — flagged here, not expanding scope.

## Validation

- `cargo check -p dpp` clean (only pre-existing unrelated baseline warnings).
- `cargo clippy -p dpp -- -D warnings`: no new findings — the failures are pre-existing baseline in `serialization_traits.rs`, proven identical on untouched `origin/v3.1-dev`.
- `cargo test -p dpp token_perpetual_distribution`: 405 passed, 0 failed.
- `cargo check -p wasm-dpp`: clean — message passthrough builds unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error messaging for token distribution block interval validation to dynamically report the network-required minimum value instead of a hardcoded threshold, providing clearer feedback to users when validation fails.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dashpay/platform/pull/3668?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->