### PR TITLE
fix(swift-sdk): load address pools into the wallet after restart

### DIFF
--- a/packages/rs-platform-wallet-ffi/src/persistence.rs
+++ b/packages/rs-platform-wallet-ffi/src/persistence.rs
@@ -8,13 +8,15 @@
 use bincode::config;
 use key_wallet::account::account_collection::AccountCollection;
 use key_wallet::account::{Account, AccountType, StandardAccountType};
+use key_wallet::bip32::DerivationPath;
 use key_wallet::bip32::ExtendedPubKey;
-use key_wallet::managed_account::address_pool::{AddressPoolType, PublicKeyType};
+use key_wallet::managed_account::address_pool::{AddressPool, AddressPoolType, PublicKeyType};
 use key_wallet::wallet::managed_wallet_info::wallet_info_interface::WalletInfoInterface;
 use key_wallet::wallet::managed_wallet_info::ManagedWalletInfo;
 use key_wallet::wallet::Wallet;
 use key_wallet::AddressInfo;
 use parking_lot::RwLock;
+use std::str::FromStr;
 
 use crate::types::{FFINetwork, Network};
 use platform_wallet::changeset::{
@@ -1541,6 +1543,80 @@ fn build_core_address_entry_ffi(
     })
 }
 
+/// Reverse of [`build_core_address_entry_ffi`]: rebuild an
+/// `AddressInfo` from a Swift-supplied `CoreAddressEntryFFI` on the
+/// wallet-load path.
+///
+/// # Safety
+/// `entry.address_base58` / `entry.derivation_path` must be valid
+/// NUL-terminated C strings for the duration of the call.
+unsafe fn address_info_from_ffi(
+    entry: &CoreAddressEntryFFI,
+    network: Network,
+) -> Result<AddressInfo, String> {
+    if entry.address_base58.is_null() {
+        return Err("CoreAddressEntryFFI.address_base58 is null".to_string());
+    }
+    if entry.derivation_path.is_null() {
+        return Err("CoreAddressEntryFFI.derivation_path is null".to_string());
+    }
+    let address_str = CStr::from_ptr(entry.address_base58)
+        .to_str()
+        .map_err(|e| format!("address_base58 not UTF-8: {}", e))?;
+    let address = dashcore::Address::from_str(address_str)
+        .map_err(|e| format!("failed to parse address '{}': {}", address_str, e))?
+        .require_network(network)
+        .map_err(|e| format!("address '{}' not on {:?}: {}", address_str, network, e))?;
+    let script_pubkey = address.script_pubkey();
+    let path_str = CStr::from_ptr(entry.derivation_path)
+        .to_str()
+        .map_err(|e| format!("derivation_path not UTF-8: {}", e))?;
+    let path = DerivationPath::from_str(path_str)
+        .map_err(|e| format!("failed to parse derivation path '{}': {}", path_str, e))?;
+    let public_key = if entry.has_public_key {
+        Some(PublicKeyType::ECDSA(entry.public_key.to_vec()))
+    } else {
+        None
+    };
+    Ok(AddressInfo {
+        address,
+        script_pubkey,
+        public_key,
+        index: entry.address_index,
+        path,
+        used: entry.is_used,
+        generated_at: 0,
+        used_at: if entry.is_used { Some(0) } else { None },
+        tx_count: 0,
+        total_received: 0,
+        total_sent: 0,
+        balance: entry.balance,
+        label: None,
+        metadata: std::collections::BTreeMap::new(),
+    })
+}
+
+/// Merge persisted `AddressInfo` rows into a managed account's
+/// `AddressPool`. Upsert semantics: a persisted row overwrites the
+/// gap-limit default `ManagedWalletInfo::from_wallet` pre-derived at
+/// the same index, and the reverse-lookup maps + `highest_*`
+/// watermarks are extended to cover indices past that default
+/// gap window.
+fn restore_address_pool(pool: &mut AddressPool, infos: Vec<AddressInfo>) {
+    for info in infos {
+        let idx = info.index;
+        pool.address_index.insert(info.address.clone(), idx);
+        pool.script_pubkey_index
+            .insert(info.script_pubkey.clone(), idx);
+        pool.highest_generated = Some(pool.highest_generated.map_or(idx, |h| h.max(idx)));
+        if info.used {
+            pool.used_indices.insert(idx);
+            pool.highest_used = Some(pool.highest_used.map_or(idx, |h| h.max(idx)));
+        }
+        pool.addresses.insert(idx, info);
+    }
+}
+
 /// Bucket a slice of upstream-emitted `DerivedAddress` entries into the
 /// same `AccountAddressPoolFFI` shape `build_address_pools_for_callback`
 /// produces, so the event-driven gap-limit-extension flow can fan out
@@ -1845,6 +1921,142 @@ fn build_wallet_start_state(
                      next fresh CLSig will repopulate"
                 );
             }
+        }
+    }
+
+    // Persisted core address pools → funds-bearing managed accounts.
+    // `ManagedWalletInfo::from_wallet` only pre-derives the gap-limit
+    // window from each account xpub; addresses past that window — and
+    // every `used` flag — come from this snapshot. Without it a
+    // restored wallet can hold a UTXO whose address the signer can't
+    // map back to a derivation path, breaking core-to-core spends.
+    {
+        use key_wallet::managed_account::managed_account_trait::ManagedAccountTrait;
+        let pool_entries: &[AccountAddressPoolFFI] =
+            if entry.core_address_pools.is_null() || entry.core_address_pools_count == 0 {
+                &[]
+            } else {
+                unsafe {
+                    slice::from_raw_parts(entry.core_address_pools, entry.core_address_pools_count)
+                }
+            };
+        let mut pools_routed = 0usize;
+        let mut pools_dropped = 0usize;
+        for pool_ffi in pool_entries {
+            let account_type = match account_type_from_spec(&pool_ffi.account) {
+                Ok(t) => t,
+                Err(e) => {
+                    if is_legacy_removed_account_tag(pool_ffi.account.type_tag) {
+                        pools_dropped += 1;
+                        continue;
+                    }
+                    return Err(e);
+                }
+            };
+            let pool_type = match pool_ffi.pool_type_tag {
+                0 => AddressPoolType::External,
+                1 => AddressPoolType::Internal,
+                2 => AddressPoolType::Absent,
+                3 => AddressPoolType::AbsentHardened,
+                other => {
+                    pools_dropped += 1;
+                    tracing::warn!(
+                        wallet_id = %hex::encode(entry.wallet_id),
+                        pool_type_tag = other,
+                        "load: skipping persisted address pool with invalid pool_type_tag"
+                    );
+                    continue;
+                }
+            };
+            let funds = match account_type {
+                AccountType::Standard {
+                    index,
+                    standard_account_type: StandardAccountType::BIP44Account,
+                } => wallet_info.accounts.standard_bip44_accounts.get_mut(&index),
+                AccountType::Standard {
+                    index,
+                    standard_account_type: StandardAccountType::BIP32Account,
+                } => wallet_info.accounts.standard_bip32_accounts.get_mut(&index),
+                AccountType::CoinJoin { index } => {
+                    wallet_info.accounts.coinjoin_accounts.get_mut(&index)
+                }
+                AccountType::DashpayReceivingFunds {
+                    index,
+                    user_identity_id,
+                    friend_identity_id,
+                } => wallet_info.accounts.dashpay_receival_accounts.get_mut(
+                    &key_wallet::account::account_collection::DashpayAccountKey {
+                        index,
+                        user_identity_id,
+                        friend_identity_id,
+                    },
+                ),
+                AccountType::DashpayExternalAccount {
+                    index,
+                    user_identity_id,
+                    friend_identity_id,
+                } => wallet_info.accounts.dashpay_external_accounts.get_mut(
+                    &key_wallet::account::account_collection::DashpayAccountKey {
+                        index,
+                        user_identity_id,
+                        friend_identity_id,
+                    },
+                ),
+                _ => None,
+            };
+            let Some(funds_account) = funds else {
+                pools_dropped += 1;
+                tracing::warn!(
+                    wallet_id = %hex::encode(entry.wallet_id),
+                    ?account_type,
+                    "load: skipping persisted address pool with no matching funds account"
+                );
+                continue;
+            };
+            let rows: &[CoreAddressEntryFFI] = if pool_ffi.addresses_ptr.is_null()
+                || pool_ffi.addresses_count == 0
+            {
+                &[]
+            } else {
+                unsafe { slice::from_raw_parts(pool_ffi.addresses_ptr, pool_ffi.addresses_count) }
+            };
+            let mut infos: Vec<AddressInfo> = Vec::with_capacity(rows.len());
+            for row in rows {
+                match unsafe { address_info_from_ffi(row, network) } {
+                    Ok(info) => infos.push(info),
+                    Err(e) => {
+                        pools_dropped += 1;
+                        tracing::warn!(
+                            wallet_id = %hex::encode(entry.wallet_id),
+                            error = %e,
+                            "load: skipping un-decodable persisted address row"
+                        );
+                    }
+                }
+            }
+            let mut managed_pools = funds_account.managed_account_type_mut().address_pools_mut();
+            match managed_pools.iter_mut().find(|p| p.pool_type == pool_type) {
+                Some(pool) => {
+                    pools_routed += infos.len();
+                    restore_address_pool(pool, infos);
+                }
+                None => {
+                    pools_dropped += 1;
+                    tracing::warn!(
+                        wallet_id = %hex::encode(entry.wallet_id),
+                        ?pool_type,
+                        "load: persisted address pool has no matching managed pool"
+                    );
+                }
+            }
+        }
+        if pools_dropped > 0 {
+            tracing::warn!(
+                wallet_id = %hex::encode(entry.wallet_id),
+                pools_routed,
+                pools_dropped,
+                "load: persisted address-pool restore completed with skipped rows"
+            );
         }
     }
 

--- a/packages/rs-platform-wallet-ffi/src/wallet_restore_types.rs
+++ b/packages/rs-platform-wallet-ffi/src/wallet_restore_types.rs
@@ -29,6 +29,7 @@ use std::os::raw::{c_char, c_void};
 use crate::asset_lock_persistence::AssetLockEntryFFI;
 use crate::platform_address_types::AddressBalanceEntryFFI;
 use crate::types::FFINetwork;
+use crate::wallet_registration_persistence::AccountAddressPoolFFI;
 
 /// Discriminant for [`key_wallet::account::AccountType`].
 ///
@@ -435,6 +436,9 @@ pub struct WalletRestoreEntryFFI {
     /// unresolved asset locks.
     pub unresolved_asset_lock_tx_records: *const UnresolvedAssetLockTxRecordFFI,
     pub unresolved_asset_lock_tx_records_count: usize,
+    /// Persisted core address pools for this wallet
+    pub core_address_pools: *const AccountAddressPoolFFI,
+    pub core_address_pools_count: usize,
     /// Bincode-serialised
     /// `dashcore::ephemerealdata::chain_lock::ChainLock`
     /// (`bincode::config::standard()`) carrying the persisted
@@ -471,8 +475,9 @@ unsafe impl Sync for UtxoRestoreEntryFFI {}
 /// accounts arrays, the optional per-wallet platform-address balance
 /// arrays, every xpub byte buffer, the per-wallet identity arrays,
 /// every nested c-string + c-string pointer array carried by the
-/// identity entries, and every per-identity `IdentityKeyRestoreFFI`
+/// identity entries, every per-identity `IdentityKeyRestoreFFI`
 /// array together with the public-key byte buffers each row points
-/// at. Called exactly once after a successful load.
+/// at, and every per-wallet core-address-pool. Called exactly once
+/// after a successful load.
 pub type LoadWalletListFreeFn =
     unsafe extern "C" fn(context: *mut c_void, entries: *const WalletRestoreEntryFFI, count: usize);

--- a/packages/swift-sdk/Sources/SwiftDashSDK/PlatformWallet/PlatformWalletPersistenceHandler.swift
+++ b/packages/swift-sdk/Sources/SwiftDashSDK/PlatformWallet/PlatformWalletPersistenceHandler.swift
@@ -2717,6 +2717,17 @@ public class PlatformWalletPersistenceHandler {
             entry.utxos = utxoBuf.map { UnsafePointer($0) }
             entry.utxos_count = UInt(utxoCount)
 
+            let (poolBuf, poolCount, poolErrored) = buildCoreAddressPoolBuffer(
+                accounts: sortedAccounts,
+                allocation: allocation
+            )
+            if poolErrored {
+                allocation.release()
+                return (nil, 0, true)
+            }
+            entry.core_address_pools = poolBuf.map { UnsafePointer($0) }
+            entry.core_address_pools_count = UInt(poolCount)
+
             // Tracked asset-lock rows. The Rust side rehydrates these
             // into `unused_asset_locks` so an in-flight registration
             // that was killed mid-flight can resume from the latest
@@ -2904,6 +2915,85 @@ public class PlatformWalletPersistenceHandler {
             return (nil, 0, false)
         }
         allocation.utxoArrays.append((buf, written))
+        return (buf, written, false)
+    }
+
+    /// Build a contiguous `[AccountAddressPoolFFI]` buffer for one
+    /// wallet's persisted core address pools
+    private func buildCoreAddressPoolBuffer(
+        accounts: [PersistentAccount],
+        allocation: LoadAllocation
+    ) -> (UnsafeMutablePointer<AccountAddressPoolFFI>?, Int, Bool) {
+        var groups: [(account: PersistentAccount, poolTypeTag: UInt8, rows: [PersistentCoreAddress])] = []
+        for account in accounts {
+            if account.coreAddresses.isEmpty { continue }
+            var byPool: [UInt8: [PersistentCoreAddress]] = [:]
+            for addr in account.coreAddresses {
+                byPool[addr.poolTypeTag, default: []].append(addr)
+            }
+            for (tag, rows) in byPool.sorted(by: { $0.key < $1.key }) {
+                groups.append((account, tag, rows))
+            }
+        }
+        if groups.isEmpty {
+            return (nil, 0, false)
+        }
+
+        let buf = UnsafeMutablePointer<AccountAddressPoolFFI>.allocate(capacity: groups.count)
+        var written = 0
+        for group in groups {
+            let account = group.account
+            guard let typeTagByte = UInt8(exactly: account.accountType) else {
+                NSLog(
+                    "[persistor-load:swift] aborting load: address-pool account row has accountType %u out of UInt8 range",
+                    account.accountType
+                )
+                buf.deallocate()
+                return (nil, 0, true)
+            }
+
+            // Inner CoreAddressEntryFFI array — one row per address.
+            let rowBuf = UnsafeMutablePointer<CoreAddressEntryFFI>.allocate(
+                capacity: group.rows.count
+            )
+            for (j, row) in group.rows.enumerated() {
+                var e = CoreAddressEntryFFI()
+                copyBytes(row.publicKey, into: &e.public_key)
+                e.has_public_key = (row.publicKey.count == 33)
+                e.pool_type_tag = group.poolTypeTag
+                e.address_index = row.addressIndex
+                e.is_used = row.isUsed
+                e.balance = row.balance
+                e.address_base58 = UnsafePointer(
+                    duplicateCString(row.address, allocation: allocation)
+                )
+                e.derivation_path = UnsafePointer(
+                    duplicateCString(row.derivationPath, allocation: allocation)
+                )
+                rowBuf[j] = e
+            }
+            allocation.coreAddressEntryArrays.append((rowBuf, group.rows.count))
+
+            var spec = AccountSpecFFI()
+            spec.type_tag = typeTagByte
+            spec.standard_tag = account.standardTag
+            spec.index = account.accountIndex
+            spec.registration_index = account.registrationIndex
+            spec.key_class = account.keyClass
+            copyBytes(account.userIdentityId, into: &spec.user_identity_id)
+            copyBytes(account.friendIdentityId, into: &spec.friend_identity_id)
+            spec.account_xpub_bytes = nil
+            spec.account_xpub_bytes_len = 0
+
+            var pool = AccountAddressPoolFFI()
+            pool.account = spec
+            pool.pool_type_tag = group.poolTypeTag
+            pool.addresses_ptr = UnsafePointer(rowBuf)
+            pool.addresses_count = UInt(group.rows.count)
+            buf[written] = pool
+            written += 1
+        }
+        allocation.coreAddressPoolArrays.append((buf, written))
         return (buf, written, false)
     }
 
@@ -3516,6 +3606,11 @@ private final class LoadAllocation {
     /// so the next chain-lock event can cascade-promote them. The
     /// `tx_bytes` buffer each row references lives in `scalarBuffers`.
     var unresolvedAssetLockTxRecordArrays: [(UnsafeMutablePointer<UnresolvedAssetLockTxRecordFFI>, Int)] = []
+    /// Per-wallet `AccountAddressPoolFFI` arrays, the persisted core
+    /// address pools
+    var coreAddressPoolArrays: [(UnsafeMutablePointer<AccountAddressPoolFFI>, Int)] = []
+    /// Inner `CoreAddressEntryFFI` arrays, one per pool entry above.
+    var coreAddressEntryArrays: [(UnsafeMutablePointer<CoreAddressEntryFFI>, Int)] = []
 
     func release() {
         if let entries = entries {
@@ -3564,6 +3659,14 @@ private final class LoadAllocation {
             ptr.deallocate()
         }
         for (ptr, count) in unresolvedAssetLockTxRecordArrays {
+            ptr.deinitialize(count: count)
+            ptr.deallocate()
+        }
+        for (ptr, count) in coreAddressEntryArrays {
+            ptr.deinitialize(count: count)
+            ptr.deallocate()
+        }
+        for (ptr, count) in coreAddressPoolArrays {
             ptr.deinitialize(count: count)
             ptr.deallocate()
         }


### PR DESCRIPTION
AddressPools where being persisted but never loaded into memory after a restart


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [ ] I have made corresponding changes to the documentation if needed

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone
