### PR TITLE
feat(swift-sdk): core to platform asset-lock funding from Send screen

### DIFF
--- a/packages/rs-dpp/src/state_transition/state_transitions/address_funds/address_funding_from_asset_lock_transition/methods/mod.rs
+++ b/packages/rs-dpp/src/state_transition/state_transitions/address_funds/address_funding_from_asset_lock_transition/methods/mod.rs
@@ -63,4 +63,49 @@ impl AddressFundingFromAssetLockTransitionMethodsV0 for AddressFundingFromAssetL
             }),
         }
     }
+
+    #[cfg(all(feature = "state-transition-signing", feature = "core_key_wallet"))]
+    async fn try_from_asset_lock_with_external_signer<AS, S>(
+        asset_lock_proof: AssetLockProof,
+        asset_lock_proof_path: &::key_wallet::bip32::DerivationPath,
+        asset_lock_signer: &AS,
+        inputs: BTreeMap<PlatformAddress, (AddressNonce, Credits)>,
+        outputs: BTreeMap<PlatformAddress, Option<Credits>>,
+        fee_strategy: AddressFundsFeeStrategy,
+        signer: &S,
+        user_fee_increase: UserFeeIncrease,
+        platform_version: &PlatformVersion,
+    ) -> Result<StateTransition, ProtocolError>
+    where
+        AS: ::key_wallet::signer::Signer,
+        S: Signer<PlatformAddress>,
+    {
+        match platform_version
+            .dpp
+            .state_transition_conversion_versions
+            .address_funding_from_asset_lock_transition
+        {
+            0 => Ok(
+                AddressFundingFromAssetLockTransitionV0::try_from_asset_lock_with_external_signer::<AS, S>(
+                    asset_lock_proof,
+                    asset_lock_proof_path,
+                    asset_lock_signer,
+                    inputs,
+                    outputs,
+                    fee_strategy,
+                    signer,
+                    user_fee_increase,
+                    platform_version,
+                )
+                .await?,
+            ),
+            version => Err(ProtocolError::UnknownVersionMismatch {
+                method:
+                    "AddressFundingFromAssetLockTransition::try_from_asset_lock_with_external_signer"
+                        .to_string(),
+                known_versions: vec![0],
+                received: version,
+            }),
+        }
+    }
 }

--- a/packages/rs-dpp/src/state_transition/state_transitions/address_funds/address_funding_from_asset_lock_transition/methods/v0/mod.rs
+++ b/packages/rs-dpp/src/state_transition/state_transitions/address_funds/address_funding_from_asset_lock_transition/methods/v0/mod.rs
@@ -29,6 +29,26 @@ pub trait AddressFundingFromAssetLockTransitionMethodsV0 {
         platform_version: &PlatformVersion,
     ) -> Result<StateTransition, ProtocolError>;
 
+    /// Signer-driven counterpart to [`Self::try_from_asset_lock_with_signer`]:
+    /// signs the asset-lock proof via `asset_lock_signer` at
+    /// `asset_lock_proof_path` instead of a raw private key.
+    #[cfg(all(feature = "state-transition-signing", feature = "core_key_wallet"))]
+    #[allow(clippy::too_many_arguments)]
+    async fn try_from_asset_lock_with_external_signer<AS, S>(
+        asset_lock_proof: AssetLockProof,
+        asset_lock_proof_path: &::key_wallet::bip32::DerivationPath,
+        asset_lock_signer: &AS,
+        inputs: BTreeMap<PlatformAddress, (AddressNonce, Credits)>,
+        outputs: BTreeMap<PlatformAddress, Option<Credits>>,
+        fee_strategy: AddressFundsFeeStrategy,
+        signer: &S,
+        user_fee_increase: UserFeeIncrease,
+        platform_version: &PlatformVersion,
+    ) -> Result<StateTransition, ProtocolError>
+    where
+        AS: ::key_wallet::signer::Signer,
+        S: Signer<PlatformAddress>;
+
     /// Get State Transition Type
     fn get_type() -> StateTransitionType {
         StateTransitionType::AddressFundingFromAssetLock

--- a/packages/rs-dpp/src/state_transition/state_transitions/address_funds/address_funding_from_asset_lock_transition/v0/v0_methods.rs
+++ b/packages/rs-dpp/src/state_transition/state_transitions/address_funds/address_funding_from_asset_lock_transition/v0/v0_methods.rs
@@ -68,4 +68,67 @@ impl AddressFundingFromAssetLockTransitionMethodsV0 for AddressFundingFromAssetL
         tracing::debug!("try_from_asset_lock_with_signer: Successfully created transition");
         Ok(address_funding_transition.into())
     }
+
+    #[cfg(all(feature = "state-transition-signing", feature = "core_key_wallet"))]
+    async fn try_from_asset_lock_with_external_signer<AS, S>(
+        asset_lock_proof: AssetLockProof,
+        asset_lock_proof_path: &::key_wallet::bip32::DerivationPath,
+        asset_lock_signer: &AS,
+        inputs: BTreeMap<PlatformAddress, (AddressNonce, Credits)>,
+        outputs: BTreeMap<PlatformAddress, Option<Credits>>,
+        fee_strategy: AddressFundsFeeStrategy,
+        signer: &S,
+        user_fee_increase: UserFeeIncrease,
+        _platform_version: &PlatformVersion,
+    ) -> Result<StateTransition, ProtocolError>
+    where
+        AS: ::key_wallet::signer::Signer,
+        S: Signer<PlatformAddress>,
+    {
+        tracing::debug!(
+            input_count = inputs.len(),
+            output_count = outputs.len(),
+            "try_from_asset_lock_with_external_signer"
+        );
+
+        let address_funding_transition = AddressFundingFromAssetLockTransitionV0 {
+            asset_lock_proof,
+            inputs: inputs.clone(),
+            outputs,
+            fee_strategy,
+            user_fee_increase,
+            signature: Default::default(),
+            input_witnesses: Vec::new(),
+        };
+
+        let mut state_transition: StateTransition = address_funding_transition.into();
+
+        state_transition
+            .sign_with_core_signer(asset_lock_proof_path, asset_lock_signer)
+            .await?;
+
+        let signable_bytes = state_transition.signable_bytes()?;
+
+        let mut input_witnesses: Vec<AddressWitness> = Vec::with_capacity(inputs.len());
+        for address in inputs.keys() {
+            input_witnesses.push(signer.sign_create_witness(address, &signable_bytes).await?);
+        }
+
+        // `input_witnesses` is a v0-only field — reach into the variant.
+        match &mut state_transition {
+            StateTransition::AddressFundingFromAssetLock(
+                crate::state_transition::AddressFundingFromAssetLockTransition::V0(v0),
+            ) => {
+                v0.input_witnesses = input_witnesses;
+            }
+            other => {
+                return Err(ProtocolError::Generic(format!(
+                    "Expected AddressFundingFromAssetLock state transition after sign_with_core_signer, got {:?}",
+                    other.name()
+                )));
+            }
+        }
+
+        Ok(state_transition)
+    }
 }

--- a/packages/rs-platform-wallet-ffi/src/platform_addresses/fund_from_core.rs
+++ b/packages/rs-platform-wallet-ffi/src/platform_addresses/fund_from_core.rs
@@ -1,0 +1,74 @@
+use dashcore::hashes::Hash;
+use dpp::address_funds::PlatformAddress;
+use rs_sdk_ffi::{MnemonicResolverCoreSigner, MnemonicResolverHandle, SignerHandle, VTableSigner};
+
+use crate::check_ptr;
+use crate::error::*;
+use crate::handle::*;
+use crate::platform_address_types::*;
+use crate::runtime::block_on_worker;
+use crate::{unwrap_option_or_return, unwrap_result_or_return};
+
+/// Fund one of the wallet's own platform addresses by locking
+/// `amount_duffs` of Core L1 funds. On success writes the asset-lock
+/// outpoint to `out_asset_lock_txid` / `out_asset_lock_vout`.
+///
+/// # Safety
+/// - `mnemonic_resolver_handle` and `signer_address_handle` must be
+///   pinned alive for the duration of the call.
+/// - `out_*` pointers must reference writable memory.
+#[no_mangle]
+pub unsafe extern "C" fn platform_wallet_fund_platform_address_from_core(
+    wallet_handle: Handle,
+    mnemonic_resolver_handle: *mut MnemonicResolverHandle,
+    amount_duffs: u64,
+    core_account_index: u32,
+    platform_account_index: u32,
+    target_address: PlatformAddressFFI,
+    signer_address_handle: *mut SignerHandle,
+    out_asset_lock_txid: *mut [u8; 32],
+    out_asset_lock_vout: *mut u32,
+) -> PlatformWalletFFIResult {
+    check_ptr!(mnemonic_resolver_handle);
+    check_ptr!(signer_address_handle);
+    check_ptr!(out_asset_lock_txid);
+    check_ptr!(out_asset_lock_vout);
+
+    let target = unwrap_result_or_return!(PlatformAddress::try_from(target_address));
+
+    // Pointers → usize so the spawned future is `Send + 'static`.
+    let signer_addr = signer_address_handle as usize;
+    let resolver_addr = mnemonic_resolver_handle as usize;
+
+    let option = PLATFORM_WALLET_STORAGE.with_item(wallet_handle, |wallet| {
+        let wallet = wallet.clone();
+        let wallet_id = wallet.wallet_id();
+        let network = wallet.sdk().network;
+        block_on_worker(async move {
+            let address_signer: &VTableSigner = unsafe { &*(signer_addr as *const VTableSigner) };
+            let asset_lock_signer = unsafe {
+                MnemonicResolverCoreSigner::new(
+                    resolver_addr as *mut MnemonicResolverHandle,
+                    wallet_id,
+                    network,
+                )
+            };
+            wallet
+                .fund_platform_address_from_core(
+                    amount_duffs,
+                    core_account_index,
+                    platform_account_index,
+                    target,
+                    &asset_lock_signer,
+                    address_signer,
+                )
+                .await
+        })
+    });
+    let result = unwrap_option_or_return!(option);
+    let outcome = unwrap_result_or_return!(result);
+
+    *out_asset_lock_txid = outcome.asset_lock_txid.to_byte_array();
+    *out_asset_lock_vout = outcome.asset_lock_vout;
+    PlatformWalletFFIResult::ok()
+}

--- a/packages/rs-platform-wallet-ffi/src/platform_addresses/mod.rs
+++ b/packages/rs-platform-wallet-ffi/src/platform_addresses/mod.rs
@@ -3,6 +3,7 @@
 //! Mirrors the structure of `platform_wallet::wallet::platform_addresses`.
 
 mod fund_from_asset_lock;
+mod fund_from_core;
 mod sync;
 mod transfer;
 mod wallet;
@@ -10,6 +11,7 @@ mod withdrawal;
 
 // Re-export all FFI types and functions.
 pub use fund_from_asset_lock::*;
+pub use fund_from_core::*;
 pub use sync::*;
 pub use transfer::*;
 pub use wallet::*;

--- a/packages/rs-platform-wallet/src/wallet/platform_addresses/fund_from_asset_lock.rs
+++ b/packages/rs-platform-wallet/src/wallet/platform_addresses/fund_from_asset_lock.rs
@@ -1,11 +1,13 @@
 use crate::wallet::PlatformAddressWallet;
 use crate::{PlatformAddressChangeSet, PlatformWalletError};
-use dash_sdk::platform::transition::top_up_address::TopUpAddress;
+use dash_sdk::platform::transition::top_up_address::{TopUpAddress, TopUpAddressWithSigner};
+use dash_sdk::query_types::AddressInfos;
 use dashcore::PrivateKey;
 use dpp::address_funds::{AddressFundsFeeStrategy, PlatformAddress};
 use dpp::fee::Credits;
 use dpp::identity::signer::Signer;
 use dpp::prelude::AssetLockProof;
+use key_wallet::bip32::DerivationPath;
 use key_wallet::PlatformP2PKHAddress;
 use std::collections::BTreeMap;
 
@@ -150,5 +152,144 @@ impl PlatformAddressWallet {
         }
 
         Ok(cs)
+    }
+
+    /// Signer-driven counterpart to [`Self::fund_from_asset_lock`]: signs
+    /// the asset-lock proof via `asset_lock_signer` at
+    /// `asset_lock_proof_path` instead of a raw `PrivateKey`.
+    #[allow(clippy::too_many_arguments)]
+    pub async fn fund_from_asset_lock_with_signer<AS, S>(
+        &self,
+        account_index: u32,
+        addresses: BTreeMap<PlatformAddress, Option<Credits>>,
+        asset_lock_proof: AssetLockProof,
+        asset_lock_proof_path: &DerivationPath,
+        asset_lock_signer: &AS,
+        fee_strategy: AddressFundsFeeStrategy,
+        address_signer: &S,
+    ) -> Result<PlatformAddressChangeSet, PlatformWalletError>
+    where
+        AS: ::key_wallet::signer::Signer + Send + Sync,
+        S: Signer<PlatformAddress> + Send + Sync,
+    {
+        if addresses.is_empty() {
+            return Err(PlatformWalletError::AddressOperation(
+                "fund_from_asset_lock_with_signer requires at least one address".to_string(),
+            ));
+        }
+        let none_count = addresses.values().filter(|v| v.is_none()).count();
+        if none_count != 1 {
+            return Err(PlatformWalletError::AddressOperation(format!(
+                "Exactly one address must have None balance (the funding recipient), found {}",
+                none_count
+            )));
+        }
+        {
+            let wm = self.wallet_manager.read().await;
+            let info = wm.get_wallet_info(&self.wallet_id).ok_or_else(|| {
+                PlatformWalletError::WalletNotFound(format!(
+                    "Wallet {:?} not found in wallet manager",
+                    hex::encode(self.wallet_id)
+                ))
+            })?;
+            let account = info
+                .core_wallet
+                .platform_payment_managed_account_at_index(account_index)
+                .ok_or_else(|| {
+                    PlatformWalletError::AddressSync(format!(
+                        "No platform payment account at index {}",
+                        account_index
+                    ))
+                })?;
+            for addr in addresses.keys() {
+                let PlatformAddress::P2pkh(hash) = addr else {
+                    return Err(PlatformWalletError::AddressOperation(
+                        "Only P2PKH addresses are supported".to_string(),
+                    ));
+                };
+                let p2pkh = PlatformP2PKHAddress::new(*hash);
+                if !account.contains_platform_address(&p2pkh) {
+                    return Err(PlatformWalletError::AddressNotFound(format!(
+                        "Address {} does not belong to account index {}",
+                        p2pkh, account_index
+                    )));
+                }
+            }
+        }
+
+        let address_infos = addresses
+            .top_up_with_signer(
+                &self.sdk,
+                asset_lock_proof,
+                asset_lock_proof_path,
+                asset_lock_signer,
+                fee_strategy,
+                address_signer,
+                None,
+            )
+            .await?;
+
+        Ok(self
+            .apply_address_top_up_results(account_index, &address_infos)
+            .await)
+    }
+
+    async fn apply_address_top_up_results(
+        &self,
+        account_index: u32,
+        address_infos: &AddressInfos,
+    ) -> PlatformAddressChangeSet {
+        let key_source = {
+            let guard = self.provider.read().await;
+            guard
+                .as_ref()
+                .and_then(|p| p.key_source(&self.wallet_id, account_index))
+        };
+
+        let mut wm = self.wallet_manager.write().await;
+        let mut cs = PlatformAddressChangeSet::default();
+        if let Some(info) = wm.get_wallet_info_mut(&self.wallet_id) {
+            if let Some(account) = info
+                .core_wallet
+                .platform_payment_managed_account_at_index_mut(account_index)
+            {
+                for (addr, maybe_info) in address_infos.iter() {
+                    let PlatformAddress::P2pkh(hash) = *addr else {
+                        continue;
+                    };
+                    let p2pkh = PlatformP2PKHAddress::new(hash);
+                    let funds = match maybe_info {
+                        Some(ai) => dash_sdk::platform::address_sync::AddressFunds {
+                            balance: ai.balance,
+                            nonce: ai.nonce,
+                        },
+                        None => dash_sdk::platform::address_sync::AddressFunds {
+                            balance: 0,
+                            nonce: 0,
+                        },
+                    };
+                    account.set_address_credit_balance(p2pkh, funds.balance, key_source.as_ref());
+                    let address_index = account
+                        .addresses
+                        .addresses
+                        .iter()
+                        .find_map(|(&idx, info)| {
+                            PlatformP2PKHAddress::from_address(&info.address)
+                                .ok()
+                                .filter(|found| *found == p2pkh)
+                                .map(|_| idx)
+                        })
+                        .unwrap_or(0);
+                    cs.addresses.push(crate::PlatformAddressBalanceEntry {
+                        wallet_id: self.wallet_id,
+                        account_index,
+                        address_index,
+                        address: p2pkh,
+                        funds,
+                    });
+                }
+            }
+        }
+        cs
     }
 }

--- a/packages/rs-platform-wallet/src/wallet/platform_addresses/fund_from_core.rs
+++ b/packages/rs-platform-wallet/src/wallet/platform_addresses/fund_from_core.rs
@@ -1,0 +1,71 @@
+use std::collections::BTreeMap;
+
+use dpp::address_funds::{AddressFundsFeeStrategyStep, PlatformAddress};
+use dpp::fee::Credits;
+use dpp::identity::signer::Signer;
+use key_wallet::wallet::managed_wallet_info::asset_lock_builder::AssetLockFundingType;
+
+use crate::wallet::PlatformWallet;
+use crate::{PlatformAddressChangeSet, PlatformWalletError};
+
+#[derive(Debug)]
+pub struct FundPlatformAddressFromCoreResult {
+    pub asset_lock_txid: dashcore::Txid,
+    pub asset_lock_vout: u32,
+    pub address_changeset: PlatformAddressChangeSet,
+}
+
+impl PlatformWallet {
+    /// Mint platform credits on `target_address` by locking
+    /// `amount_duffs` of Core L1 funds.
+    pub async fn fund_platform_address_from_core<AS, S>(
+        &self,
+        amount_duffs: u64,
+        core_account_index: u32,
+        platform_account_index: u32,
+        target_address: PlatformAddress,
+        asset_lock_signer: &AS,
+        address_signer: &S,
+    ) -> Result<FundPlatformAddressFromCoreResult, PlatformWalletError>
+    where
+        AS: ::key_wallet::signer::Signer + Send + Sync,
+        S: Signer<PlatformAddress> + Send + Sync,
+    {
+        let (proof, asset_lock_proof_path, out_point) = self
+            .asset_locks
+            .create_funded_asset_lock_proof(
+                amount_duffs,
+                core_account_index,
+                AssetLockFundingType::AssetLockAddressTopUp,
+                0,
+                asset_lock_signer,
+            )
+            .await?;
+
+        // With zero inputs the fee MUST come from the only output;
+        // `DeductFromInput(0)` would surface as "index 0 out of bounds
+        // (count: 0)" from the DPP layer.
+        let mut addresses: BTreeMap<PlatformAddress, Option<Credits>> = BTreeMap::new();
+        addresses.insert(target_address, None);
+        let fee_strategy = vec![AddressFundsFeeStrategyStep::ReduceOutput(0)];
+
+        let address_changeset = self
+            .platform
+            .fund_from_asset_lock_with_signer(
+                platform_account_index,
+                addresses,
+                proof,
+                &asset_lock_proof_path,
+                asset_lock_signer,
+                fee_strategy,
+                address_signer,
+            )
+            .await?;
+
+        Ok(FundPlatformAddressFromCoreResult {
+            asset_lock_txid: out_point.txid,
+            asset_lock_vout: out_point.vout,
+            address_changeset,
+        })
+    }
+}

--- a/packages/rs-platform-wallet/src/wallet/platform_addresses/mod.rs
+++ b/packages/rs-platform-wallet/src/wallet/platform_addresses/mod.rs
@@ -7,12 +7,14 @@ use dpp::fee::Credits;
 pub use dpp::prelude::AddressNonce;
 
 mod fund_from_asset_lock;
+mod fund_from_core;
 pub(crate) mod provider;
 mod sync;
 mod transfer;
 mod wallet;
 mod withdrawal;
 
+pub use fund_from_core::FundPlatformAddressFromCoreResult;
 pub use provider::{
     PerAccountPlatformAddressState, PerWalletPlatformAddressState, PlatformAddressTag,
 };

--- a/packages/rs-sdk/src/platform/transition/top_up_address.rs
+++ b/packages/rs-sdk/src/platform/transition/top_up_address.rs
@@ -35,6 +35,27 @@ pub trait TopUpAddress<S: Signer<PlatformAddress>> {
     ) -> Result<AddressInfos, Error>;
 }
 
+/// Signer-driven counterpart to [`TopUpAddress`]: signs the asset-lock
+/// proof via `asset_lock_signer` at `asset_lock_proof_path` instead of
+/// a raw private key.
+#[cfg(feature = "core_key_wallet")]
+#[async_trait::async_trait]
+pub trait TopUpAddressWithSigner<S: Signer<PlatformAddress>> {
+    #[allow(clippy::too_many_arguments)]
+    async fn top_up_with_signer<AS>(
+        &self,
+        sdk: &Sdk,
+        asset_lock_proof: AssetLockProof,
+        asset_lock_proof_path: &dpp::key_wallet::bip32::DerivationPath,
+        asset_lock_signer: &AS,
+        fee_strategy: AddressFundsFeeStrategy,
+        signer: &S,
+        settings: Option<PutSettings>,
+    ) -> Result<AddressInfos, Error>
+    where
+        AS: dpp::key_wallet::signer::Signer + Send + Sync;
+}
+
 pub type AddressWithBalance = (PlatformAddress, Option<Credits>);
 pub type AddressesWithBalances = BTreeMap<PlatformAddress, Option<Credits>>;
 
@@ -137,4 +158,61 @@ async fn create_address_funding_from_asset_lock_transition<S: Signer<PlatformAdd
         sdk.version(),
     )
     .await
+}
+
+#[cfg(feature = "core_key_wallet")]
+#[async_trait::async_trait]
+impl<S: Signer<PlatformAddress>> TopUpAddressWithSigner<S> for AddressesWithBalances {
+    async fn top_up_with_signer<AS>(
+        &self,
+        sdk: &Sdk,
+        asset_lock_proof: AssetLockProof,
+        asset_lock_proof_path: &dpp::key_wallet::bip32::DerivationPath,
+        asset_lock_signer: &AS,
+        fee_strategy: AddressFundsFeeStrategy,
+        signer: &S,
+        settings: Option<PutSettings>,
+    ) -> Result<AddressInfos, Error>
+    where
+        AS: dpp::key_wallet::signer::Signer + Send + Sync,
+    {
+        if self.is_empty() {
+            return Err(Error::from(TransitionNoOutputsError::new()));
+        }
+
+        let user_fee_increase = settings
+            .as_ref()
+            .and_then(|settings| settings.user_fee_increase)
+            .unwrap_or_default();
+
+        let state_transition =
+            AddressFundingFromAssetLockTransition::try_from_asset_lock_with_external_signer(
+                asset_lock_proof,
+                asset_lock_proof_path,
+                asset_lock_signer,
+                BTreeMap::new(),
+                self.clone(),
+                fee_strategy,
+                signer,
+                user_fee_increase,
+                sdk.version(),
+            )
+            .await?;
+
+        ensure_valid_state_transition_structure(&state_transition, sdk.version())?;
+        let st_result = state_transition
+            .broadcast_and_wait::<StateTransitionProofResult>(sdk, settings)
+            .await?;
+        match st_result {
+            StateTransitionProofResult::VerifiedAddressInfos(address_infos) => {
+                let expected_addresses =
+                    self.keys().copied().collect::<BTreeSet<PlatformAddress>>();
+                collect_address_infos_from_proof(address_infos, &expected_addresses)
+            }
+            other => Err(Error::InvalidProvedResponse(format!(
+                "address info proof was expected for {:?}, but received {:?}",
+                state_transition, other
+            ))),
+        }
+    }
 }

--- a/packages/swift-sdk/Sources/SwiftDashSDK/PlatformWallet/ManagedPlatformWallet.swift
+++ b/packages/swift-sdk/Sources/SwiftDashSDK/PlatformWallet/ManagedPlatformWallet.swift
@@ -552,6 +552,90 @@ public final class ManagedPlatformWallet: @unchecked Sendable {
         }.value
     }
 
+    // MARK: - Core → Platform address funding
+
+    public struct FundPlatformAddressFromCoreResult: Sendable {
+        public let assetLockTxid: Data
+        public let assetLockVout: UInt32
+
+        public init(assetLockTxid: Data, assetLockVout: UInt32) {
+            self.assetLockTxid = assetLockTxid
+            self.assetLockVout = assetLockVout
+        }
+    }
+
+    /// Mint platform credits on one of the wallet's own addresses by
+    /// locking Core L1 funds. `targetAddressHash` is the 20-byte P2PKH
+    /// hash of an address owned by the wallet.
+    public func fundPlatformAddressFromCore(
+        amountDuffs: UInt64,
+        coreAccountIndex: UInt32 = 0,
+        platformAccountIndex: UInt32 = 0,
+        targetAddressType: UInt8 = 0,
+        targetAddressHash: Data,
+        signer: KeychainSigner
+    ) async throws -> FundPlatformAddressFromCoreResult {
+        guard targetAddressHash.count == 20 else {
+            throw PlatformWalletError.invalidParameter(
+                "targetAddressHash must be 20 bytes, got \(targetAddressHash.count)"
+            )
+        }
+
+        let mnemonicResolver = MnemonicResolver()
+        guard let resolverHandle = mnemonicResolver.handle else {
+            throw PlatformWalletError.invalidParameter(
+                "MnemonicResolver has no handle"
+            )
+        }
+
+        let handle = self.handle
+        let addressSignerHandle = signer.handle
+
+        return try await Task.detached(priority: .userInitiated) {
+            () -> FundPlatformAddressFromCoreResult in
+            var hashTuple = hashTupleInit()
+            withUnsafeMutableBytes(of: &hashTuple) { raw in
+                for (i, byte) in targetAddressHash.prefix(20).enumerated() {
+                    raw[i] = byte
+                }
+            }
+            let target = PlatformAddressFFI(
+                address_type: targetAddressType,
+                hash: hashTuple
+            )
+
+            var txidTuple: FFIByteTuple32 =
+                (0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0)
+            var vout: UInt32 = 0
+
+            // Pin signer + resolver across the FFI call so Rust still
+            // sees the vtable ctx valid.
+            let result = withExtendedLifetime((signer, mnemonicResolver)) {
+                withUnsafeMutablePointer(to: &txidTuple) { txidPtr in
+                    platform_wallet_fund_platform_address_from_core(
+                        handle,
+                        resolverHandle,
+                        amountDuffs,
+                        coreAccountIndex,
+                        platformAccountIndex,
+                        target,
+                        addressSignerHandle,
+                        txidPtr,
+                        &vout
+                    )
+                }
+            }
+            try result.check()
+
+            let txidData = withUnsafeBytes(of: txidTuple) { Data($0) }
+            return FundPlatformAddressFromCoreResult(
+                assetLockTxid: txidData,
+                assetLockVout: vout
+            )
+        }.value
+    }
+
     /// Pin every pubkey buffer simultaneously and call `body` with a
     /// freshly-built `[IdentityPubkeyFFI]` whose `pubkey_bytes`
     /// pointers all reference the pinned bytes. Recursive shape

--- a/packages/swift-sdk/SwiftExampleApp/SwiftExampleApp/Core/ViewModels/SendViewModel.swift
+++ b/packages/swift-sdk/SwiftExampleApp/SwiftExampleApp/Core/ViewModels/SendViewModel.swift
@@ -5,6 +5,7 @@ import SwiftDashSDK
 /// Available send flow types based on source and destination.
 enum SendFlow: Equatable {
     case coreToCore              // Standard L1 payment
+    case coreToPlatform          // Asset lock — fund own platform address
     case platformToPlatform      // Platform-address → platform-address transfer
     case platformToShielded      // Shield credits
     case shieldedToShielded      // Private transfer
@@ -14,6 +15,7 @@ enum SendFlow: Equatable {
     var displayName: String {
         switch self {
         case .coreToCore: return "Core Payment"
+        case .coreToPlatform: return "Fund Platform Address"
         case .platformToPlatform: return "Platform Transfer"
         case .platformToShielded: return "Shield Credits"
         case .shieldedToShielded: return "Shielded Transfer"
@@ -25,6 +27,7 @@ enum SendFlow: Equatable {
     var iconName: String {
         switch self {
         case .coreToCore: return "arrow.right"
+        case .coreToPlatform: return "arrow.up.forward.square"
         case .platformToPlatform: return "arrow.right"
         case .platformToShielded: return "lock.shield"
         case .shieldedToShielded: return "arrow.left.arrow.right"
@@ -36,6 +39,7 @@ enum SendFlow: Equatable {
     var estimatedFee: UInt64 {
         switch self {
         case .coreToCore: return 500_000             // ~0.005 DASH
+        case .coreToPlatform: return 700_000         // asset-lock tx + state transition
         case .platformToPlatform: return 100_000_000 // ~0.001 DASH in credits
         case .platformToShielded: return 200_000
         case .shieldedToShielded: return 300_000
@@ -127,6 +131,7 @@ class SendViewModel: ObservableObject {
             if shieldedBalance > 0 { sources.append(.shielded) }
             if platformBalance > 0 { sources.append(.platform) }
         case .platform:
+            if coreBalance > 0 { sources.append(.core) }
             if platformBalance > 0 { sources.append(.platform) }
             if shieldedBalance > 0 { sources.append(.shielded) }
         case .unknown:
@@ -157,6 +162,8 @@ class SendViewModel: ObservableObject {
             detectedFlow = .coreToCore
         case (.core, .shielded):
             detectedFlow = .shieldedToCore
+        case (.platform, .core):
+            detectedFlow = .coreToPlatform
         case (.orchard, .shielded):
             detectedFlow = .shieldedToShielded
         case (.orchard, .platform):
@@ -180,6 +187,7 @@ class SendViewModel: ObservableObject {
         wallet: PersistentWallet,
         coreWallet: ManagedCoreWallet?,
         platformAddressWallet: ManagedPlatformAddressWallet?,
+        managedWallet: ManagedPlatformWallet?,
         signer: KeychainSigner?,
         senderAccountIndex: UInt32,
         changeAddressRow: PersistentPlatformAddress?,
@@ -306,6 +314,42 @@ class SendViewModel: ObservableObject {
                 }
 
                 successMessage = "Platform transfer sent"
+
+            case .coreToPlatform:
+                guard let managedWallet else {
+                    error = "Platform wallet not available"
+                    return
+                }
+                guard let signer = signer else {
+                    error = "Signer not available"
+                    return
+                }
+                guard let amount = amount else { return }
+                guard case .platform(let payload) = detectedAddressType,
+                      payload.count == 21 else {
+                    error = "Recipient is not a platform address"
+                    return
+                }
+                // DIP-0018 bech32m type byte → FFI `address_type` (0/1).
+                let targetAddressType: UInt8
+                switch payload[0] {
+                case 0xb0: targetAddressType = 0
+                case 0x80: targetAddressType = 1
+                default:
+                    error = "Unsupported platform address variant (type byte 0x\(String(payload[0], radix: 16)))"
+                    return
+                }
+                let targetAddressHash = payload.subdata(in: 1..<21)
+
+                let result = try await managedWallet.fundPlatformAddressFromCore(
+                    amountDuffs: amount,
+                    coreAccountIndex: senderAccountIndex,
+                    platformAccountIndex: 0,
+                    targetAddressType: targetAddressType,
+                    targetAddressHash: targetAddressHash,
+                    signer: signer
+                )
+                successMessage = "Funded platform address (asset lock tx \(result.assetLockTxid.prefix(4).map { String(format: "%02x", $0) }.joined())…)"
 
             case .platformToShielded,
                  .shieldedToShielded,

--- a/packages/swift-sdk/SwiftExampleApp/SwiftExampleApp/Core/Views/SendTransactionView.swift
+++ b/packages/swift-sdk/SwiftExampleApp/SwiftExampleApp/Core/Views/SendTransactionView.swift
@@ -164,9 +164,9 @@ struct SendTransactionView: View {
                             // the Rust manager holds all wallets
                             // and this view's `wallet` may not
                             // be the one that was last created.
-                            let managed = walletManager.wallet(for: wallet.walletId)
-                            let coreWallet = try? managed?.coreWallet()
-                            let platformAddressWallet = try? managed?.platformAddressWallet()
+                            let managedWallet = walletManager.wallet(for: wallet.walletId)
+                            let coreWallet = try? managedWallet?.coreWallet()
+                            let platformAddressWallet = try? managedWallet?.platformAddressWallet()
                             // Pick the account holding the platform
                             // balance. Most wallets have a single
                             // PlatformPayment account (index 0);
@@ -199,6 +199,7 @@ struct SendTransactionView: View {
                                 wallet: wallet,
                                 coreWallet: coreWallet,
                                 platformAddressWallet: platformAddressWallet,
+                                managedWallet: managedWallet,
                                 signer: signer,
                                 senderAccountIndex: senderAccountIndex,
                                 changeAddressRow: changeAddressRow,
@@ -302,6 +303,7 @@ struct SendTransactionView: View {
     private func flowColor(for flow: SendFlow) -> Color {
         switch flow {
         case .coreToCore: return .green
+        case .coreToPlatform: return .blue
         case .platformToPlatform: return .blue
         case .platformToShielded: return .purple
         case .shieldedToShielded: return .purple


### PR DESCRIPTION
Basically what the title says. There is a lot of logic copy pasted inside methods that already exist but refactoring them to reduce the amount of logic I introduce in this PR would add unnecessary noise, I will be opening a PR refactoring that logic once this PR get merged


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [ ] I have made corresponding changes to the documentation if needed

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added direct Core-to-Platform address funding capability, allowing users to transfer funds from Core L1 wallets to Platform addresses in a single operation.
  * Introduced external signer support for address funding transitions, enabling more flexible wallet integrations and improved key management workflows.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dashpay/platform/pull/3688?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->