### PR TITLE
fix(swift-sdk): drop transitive keypath from PersistentTxo unspent prefetch

### DIFF
--- a/packages/swift-sdk/Sources/SwiftDashSDK/PlatformWallet/PlatformWalletPersistenceHandler.swift
+++ b/packages/swift-sdk/Sources/SwiftDashSDK/PlatformWallet/PlatformWalletPersistenceHandler.swift
@@ -2459,7 +2459,7 @@ public class PlatformWalletPersistenceHandler {
             var unspentDescriptor = FetchDescriptor<PersistentTxo>(
                 predicate: #Predicate { $0.isSpent == false }
             )
-            unspentDescriptor.relationshipKeyPathsForPrefetching = [\.account, \.account?.wallet]
+            unspentDescriptor.relationshipKeyPathsForPrefetching = [\.account]
             // Bail with `errored = true` on a SwiftData failure rather
             // than degrading to an empty bucket map. Without this, Rust
             // would see `entry.utxos_count == 0` for every wallet,


### PR DESCRIPTION
## Issue being fixed or feature implemented

`PlatformWalletPersistenceHandler.loadWalletList()` asserts inside SwiftData internals on the first run where the `restorable.isEmpty` gate opens — i.e. any wallet registration via the platform-wallet Rust crate after at least one wallet with populated accounts already exists on disk (app restart, second wallet import, key-migration flows, etc.). The full stack ends at the unspent `PersistentTxo` fetch:

```
SwiftData.ModelContext.fetch<PersistentTxo>(FetchDescriptor)
  ↑ PlatformWalletPersistenceHandler.loadWalletList() at line 2471
  ↑ FFIPersister::load (Rust)
  ↑ register_wallet (Rust)
  ↑ create_wallet_from_mnemonic / load_persisted_wallet
```

Reproducible by creating a wallet, force-quitting, relaunching — or by importing a second wallet into an app that already has one. Symptom is a Swift runtime fatal error with `"Couldn't find \PersistentTxo.<computed (Optional<PersistentAccount>)>?.<computed (PersistentWallet)>? on PersistentTxo with fields [outpoint, vout, ...]"`.

## What was done?

Dropped the chained second hop from the prefetch hint:

```diff
-unspentDescriptor.relationshipKeyPathsForPrefetching = [\.account, \.account?.wallet]
+unspentDescriptor.relationshipKeyPathsForPrefetching = [\.account]
```

SwiftData's prefetch resolver only supports direct, single-hop relationship keypaths — chained / transitive keypaths like `\.account?.wallet` trip an internal assertion in the schema walker even when both ends have proper relationship metadata. Adding `@Relationship` annotations to `PersistentTxo.account` / `PersistentAccount.wallet` does not fix it (verified by trying and watching the same crash recur with the annotations present).

The single-hop `\.account` prefetch is preserved, so the TXO → account bulk join still happens. The `account → wallet` hop now faults on demand inside the iteration loop — N+1 worst case, but `loadWalletList` runs at registration/restore time on a bounded set of TXOs and the cost is acceptable. If the chained prefetch is wanted back later it'd take a model-layer rework (e.g. denormalizing the wallet pointer onto TXO directly, or refactoring the loop to pre-fetch wallets via a `[walletId: PersistentWallet]` dictionary).

## How Has This Been Tested?

- dashwallet-ios, iOS Simulator (iPhone 17 Pro), wallet migrator flow that triggers `createOrImportWallet` against an existing on-disk wallet — reproduces the crash before the fix, completes cleanly after.
- Same simulator, fresh wallet creation in SwiftExampleApp — unaffected (early-return gate keeps it off the buggy path either way).

## Breaking Changes

None. Behavior change is purely the loss of one prefetch optimization; the relationship traversal at the use site still works, just fault-loaded.

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [ ] I have made corresponding changes to the documentation if needed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized wallet loading performance through improved relationship handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dashpay/platform/pull/3691?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->