### PR TITLE
ci(release): drop 32-bit dashmate pack targets unsupported by Node 24

### DIFF
--- a/scripts/pack_dashmate.sh
+++ b/scripts/pack_dashmate.sh
@@ -20,10 +20,24 @@ fi
 
 FLAGS=""
 
-if [[ "$COMMAND" == "tarballs" ]]
-then
-  FLAGS="--no-xz --targets=linux-arm,linux-x64"
-fi
+# Node 24+ does not publish 32-bit binaries (linux-armv7l, win-x86), so we
+# must explicitly drop those targets from oclif's default lists; otherwise
+# `oclif pack` 404s while downloading the embedded Node runtime.
+#   - tarballs default: oclif builds whatever we pass; we previously passed
+#     `linux-arm` (= armv7l). Replace with linux-arm64.
+#   - deb default targets: linux-x64, linux-arm (armv7l), linux-arm64 — drop arm.
+#   - win default targets: win32-x64, win32-x86 — drop x86.
+case "$COMMAND" in
+  tarballs)
+    FLAGS="--no-xz --targets=linux-arm64,linux-x64"
+    ;;
+  deb)
+    FLAGS="--targets=linux-x64,linux-arm64"
+    ;;
+  win)
+    FLAGS="--targets=win32-x64"
+    ;;
+esac
 
 FULL_PATH=$(realpath "$0")
 DIR_PATH=$(dirname "$FULL_PATH")


### PR DESCRIPTION
## Summary

- Restrict `oclif pack` targets in `scripts/pack_dashmate.sh` to architectures Node 24 still publishes binaries for.
- Drops 32-bit Linux ARM (`linux-armv7l`) and 32-bit Windows (`win-x86`) from the dashmate release matrix.

## Background

The `Release Dashmate packages` matrix (`deb`, `tarballs`, `win`) has been failing on every release run since `v3.1.0-dev.1` (2026-02-18). Logs from today's `v3.1.0-dev.3` run ([26180129457](https://github.com/dashpay/platform/actions/runs/26180129457)):

```
oclif: building target dashmate-v3.1.0-dev.3-39f2e29c9-linux-arm.tar.gz
oclif: downloading node-v24.14.1-linux-armv7l
oclif: retrying node download (attempt 1)
oclif: retrying node download (attempt 2)
oclif: retrying node download (attempt 3)
HTTPError: Response code 404 (Not Found)
```

**Node 24 dropped 32-bit binaries.** [`SHASUMS256.txt` for v24.14.1](https://nodejs.org/dist/v24.14.1/SHASUMS256.txt) publishes only:

- linux: `x64`, `arm64`, `ppc64le`, `s390x`
- win: `x64`, `arm64`
- darwin: `x64`, `arm64`

When `oclif pack` bundles a Node runtime for an embedded target, it downloads the matching nodejs.org tarball. `linux-armv7l` and `win-x86` 404 → all three jobs die at "Create package".

## Why it surfaced now

- Composite `Setup Node.JS` default bumped 20 → 24 in commit `ec4665bb2a` on 2026-01-27, before `v3.1.0-dev.1`.
- Same failure on `v3.1.0-dev.1` ([22144450177](https://github.com/dashpay/platform/actions/runs/22144450177)) — same three jobs ✗, `macos` ✓.
- Masked on `v3.1.0-dev.2` because release-npm itself failed and `needs: release-npm` blocked the matrix from running.
- With release-npm fixed in #3702, the latent dashmate-pack failure is now visible.

## Trade-off

`v3.0.1` (last successful Node-20-era release) shipped three artifacts this PR removes:

- `dashmate-...-linux-arm.tar.gz` (32-bit ARM)
- `dashmate_..._armel.deb`
- `dashmate-...-x86.exe`

Modern hardware on those platforms is essentially extinct (Raspberry Pi 4+ is 64-bit, current Windows is x64/arm64), and Node 24+ cannot package against them anyway. The alternative — embedding a separate older Node for the pack step — splits Node versions across release stages and conflicts with the trusted-publishers Node 24+ requirement at the publish step. Dropping the dead platforms is simpler.

## Test plan

- [ ] CI green on this PR
- [ ] After merge, the next release run (`v3.1.0-dev.4` or whatever follows) shows `Release Dashmate packages (deb|tarballs|win|macos)` all ✓.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build infrastructure to support 64-bit platforms exclusively. 32-bit build variants for ARM and Windows are no longer produced.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dashpay/platform/pull/3709?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->