### PR TITLE
test(swift-sdk): first swift sdk integration tests with local network

### DIFF
--- a/packages/swift-sdk/Package.swift
+++ b/packages/swift-sdk/Package.swift
@@ -28,12 +28,21 @@ let package = Package(
             linkerSettings: [.linkedFramework("SystemConfiguration")]
         ),
 
-        // Tests
+        // Unit tests (offline, hermetic)
         .testTarget(
             name: "SwiftDashSDKTests",
             dependencies: ["SwiftDashSDK"],
             path: "SwiftTests/SwiftDashSDKTests"
-        )
+        ),
+
+        // Integration tests against a local dashmate devnet.
+        // Gated by env var `RUN_INTEGRATION_TESTS=1`
+        .testTarget(
+            name: "SwiftDashSDKIntegrationTests",
+            dependencies: ["SwiftDashSDK"],
+            path: "SwiftTests/SwiftDashSDKIntegrationTests",
+            swiftSettings: [.unsafeFlags(["-warnings-as-errors"])]
+        ),
     ],
     swiftLanguageModes: [.v6]
 )

--- a/packages/swift-sdk/Sources/SwiftDashSDK/Core/Wallet/WalletStorage.swift
+++ b/packages/swift-sdk/Sources/SwiftDashSDK/Core/Wallet/WalletStorage.swift
@@ -36,7 +36,9 @@ public class WalletStorage {
     /// this single service so the keychain explorer + future
     /// cross-item queries see one namespace. Legacy services are
     /// scrubbed on launch by `cleanupLegacyItems`.
-    public static let keychainService = "org.dashfoundation.wallet"
+    public static let keychainService =
+        ProcessInfo.processInfo.environment["DASH_KEYCHAIN_SERVICE"]
+        ?? "org.dashfoundation.wallet"
 
     /// Per-instance alias that lets the rest of this file stay
     /// short; the static constant is the one external callers

--- a/packages/swift-sdk/SwiftTests/SwiftDashSDKIntegrationTests/Core/CoreSendIntegrationTests.swift
+++ b/packages/swift-sdk/SwiftTests/SwiftDashSDKIntegrationTests/Core/CoreSendIntegrationTests.swift
@@ -1,0 +1,84 @@
+import XCTest
+import SwiftData
+@testable import SwiftDashSDK
+
+final class CoreSendIntegrationTests: IntegrationTestCase {
+    private let fundingDash: Double = 0.5
+    private var fundingDuffs: UInt64 {
+        UInt64(fundingDash * 1e8)
+    }
+
+    func testWalletToWalletViaSpv() async throws {
+        try await env.walletManager.startSpv(config: env.spvConfig)
+        let alice = try await env.makeTestWallet(name: "core-send-alice")
+        let bob = try await env.makeTestWallet(name: "core-send-bob")
+
+        let aliceAddress = try alice.getCoreWallet().nextReceiveAddress()
+        _ = try await env.fund(address: aliceAddress, dash: fundingDash)
+        let bobAddress = try bob.getCoreWallet().nextReceiveAddress()
+        _ = try await env.fund(address: bobAddress, dash: fundingDash)
+        try await alice.waitForSpendable(exactly: fundingDuffs, timeout: 90)
+        try await bob.waitForSpendable(exactly: fundingDuffs, timeout: 90)
+
+        let iterations = 5
+        let amount: UInt64 = 100_000 // 0.001 DASH per hop
+
+        for i in 0 ..< iterations {
+            let aliceSends = (i % 2 == 0)
+            let sender = aliceSends ? alice: bob
+            let receiver = aliceSends ? bob: alice
+
+            let receiverBalanceBefore = try receiver.getPlatformWallet().balance().spendable
+            let recipientAddress = try receiver.getCoreWallet().nextReceiveAddress()
+
+            let beforeTxids = try await readTxids()
+            _ = try sender.getCoreWallet().sendToAddresses(
+                recipients: [(address: recipientAddress, amountDuffs: amount)]
+            )
+            guard let sendTxid = try await waitForNewTxid(notIn: beforeTxids) else {
+                XCTFail("send PersistentTransaction row never appeared on iteration \(i)")
+                return
+            }
+            _ = try await env.mine(1, including: sendTxid)
+
+            try await Wait.until(
+                "receiver +\(amount) after iteration \(i)",
+                timeout: 60,
+                pollInterval: 0.01
+            ) {
+                try receiver.getPlatformWallet().balance().spendable
+                    == receiverBalanceBefore + amount
+            }
+        }
+
+        let aliceFinal = try alice.getPlatformWallet().balance().spendable
+        let bobFinal = try bob.getPlatformWallet().balance().spendable
+        XCTAssertLessThanOrEqual(aliceFinal + bobFinal, 2 * fundingDuffs)
+
+        // Validate via the SwiftData
+        let expectedTotalTxs = 2 + iterations
+        let aliceWalletId = alice.getPlatformWallet().walletId
+        let bobWalletId = bob.getPlatformWallet().walletId
+        let container = env.modelContainer
+
+        try await MainActor.run {
+            let context = ModelContext(container)
+            let allTxCount = try context.fetchCount(FetchDescriptor<PersistentTransaction>())
+            XCTAssertEqual(allTxCount, expectedTotalTxs)
+
+            let aliceTxoCount = try context.fetchCount(FetchDescriptor<PersistentTxo>(
+                predicate: #Predicate<PersistentTxo>{
+                    $0.walletId == aliceWalletId
+                }
+            ))
+            let bobTxoCount = try context.fetchCount(FetchDescriptor<PersistentTxo>(
+                predicate: #Predicate<PersistentTxo>{
+                    $0.walletId == bobWalletId
+                }
+            ))
+
+            XCTAssertEqual(aliceTxoCount, 1 + iterations)
+            XCTAssertEqual(bobTxoCount, 1 + iterations)
+        }
+    }
+}

--- a/packages/swift-sdk/SwiftTests/SwiftDashSDKIntegrationTests/Core/PersisterRestartClassificationIntegrationTests.swift
+++ b/packages/swift-sdk/SwiftTests/SwiftDashSDKIntegrationTests/Core/PersisterRestartClassificationIntegrationTests.swift
@@ -1,0 +1,97 @@
+import XCTest
+import SwiftData
+import CryptoKit
+@testable import SwiftDashSDK
+
+/// This test ensures that the classification of a self-send transaction
+/// as Internal / -fee survives a restart of the persister
+final class PersisterRestartClassificationIntegrationTests: IntegrationTestCase {
+    private let fundingDash: Double = 0.5
+    private var fundingDuffs: UInt64 { UInt64(fundingDash * 1e8) }
+    private let sendAmount: UInt64 = 10_000
+
+    func testSelfSendClassificationSurvivesRestart() async throws {
+        try await env.walletManager.startSpv(config: env.spvConfig)
+        let alice = try await env.makeTestWallet(name: "restart-class-alice")
+
+        let aliceFundingAddr = try alice.getCoreWallet().nextReceiveAddress()
+        _ = try await env.fund(address: aliceFundingAddr, dash: fundingDash)
+        try await alice.waitForSpendable(exactly: fundingDuffs, timeout: 90)
+
+        let aliceSecondAddr = try alice.getCoreWallet().nextReceiveAddress()
+        let sendTxData = try alice.getCoreWallet().sendToAddresses(
+            recipients: [(address: aliceSecondAddr, amountDuffs: sendAmount)]
+        )
+        let sendTxid = Self.txid(ofRawTx: sendTxData)
+        try await waitForTxRow(sendTxid)
+
+        // First sighting must already classify as Internal / -fee.
+        try await assertSelfSendRow(txid: sendTxid, phase: "first sighting")
+
+        try await env.restartWalletManager()
+        try await env.walletManager.startSpv(config: env.spvConfig)
+        try await env.walletManager.waitUntilUpToDate(height: try await env.coreRPC.getBlockCount())
+
+        // Regression: classification must survive the restart.
+        try await assertSelfSendRow(txid: sendTxid, phase: "post-restart catch-up")
+    }
+
+    // MARK: - Helpers
+
+    /// `sha256d(tx_bytes)` in internal byte order — the identity
+    /// `PersistentTransaction.txid` stores (the persister copies Rust's
+    /// `Txid` verbatim).
+    private static func txid(ofRawTx data: Data) -> Data {
+        let first = Data(SHA256.hash(data: data))
+        return Data(SHA256.hash(data: first))
+    }
+
+    private func waitForTxRow(_ txid: Data, timeout: TimeInterval = 60) async throws {
+        try await Wait.until(
+            "PersistentTransaction row for \(txid.toHexString())",
+            timeout: timeout
+        ) {
+            try await self.fetchTransaction(txid) != nil
+        }
+    }
+
+    private struct TxSnapshot: Sendable {
+        let direction: UInt32
+        let netAmount: Int64
+        let context: UInt32
+    }
+
+    private func fetchTransaction(_ txid: Data) async throws -> TxSnapshot? {
+        let container = env.modelContainer
+        return try await MainActor.run {
+            let ctx = ModelContext(container)
+            guard let row = try ctx.fetch(FetchDescriptor<PersistentTransaction>(
+                predicate: #Predicate { $0.txid == txid }
+            )).first else { return nil }
+            return TxSnapshot(
+                direction: row.direction,
+                netAmount: row.netAmount,
+                context: row.context
+            )
+        }
+    }
+
+    private func assertSelfSendRow(txid: Data, phase: String) async throws {
+        guard let row = try await fetchTransaction(txid) else {
+            XCTFail("\(phase): row missing for txid \(txid.toHexString())")
+            return
+        }
+
+        XCTAssertEqual(
+            row.direction, 2,
+            "\(phase): direction=\(row.direction) (expected 2=Internal). " +
+            "context=\(row.context), netAmount=\(row.netAmount). " +
+            "Positive netAmount with direction=0 is the phantom-incoming signature."
+        )
+
+        XCTAssertLessThan(
+            row.netAmount, 0,
+            "\(phase): netAmount=\(row.netAmount) (expected <0; self-send only leaves the fee)."
+        )
+    }
+}

--- a/packages/swift-sdk/SwiftTests/SwiftDashSDKIntegrationTests/Core/SpvRestartIntegrationTests.swift
+++ b/packages/swift-sdk/SwiftTests/SwiftDashSDKIntegrationTests/Core/SpvRestartIntegrationTests.swift
@@ -1,0 +1,85 @@
+import XCTest
+import SwiftData
+@testable import SwiftDashSDK
+
+/// Verifies that the persisted wallet state survives an SPV stop/start
+/// cycle
+final class SpvRestartIntegrationTests: IntegrationTestCase {
+    private let fundingDash: Double = 0.5
+    private var fundingDuffs: UInt64 { UInt64(fundingDash * 1e8) }
+    private let amount: UInt64 = 100_000
+
+    func testTxosSurviveSpvRestart() async throws {
+        try await env.walletManager.startSpv(config: env.spvConfig)
+        let alice = try await env.makeTestWallet(name: "spv-restart-alice")
+        let bob = try await env.makeTestWallet(name: "spv-restart-bob")
+
+        let aliceAddress = try alice.getCoreWallet().nextReceiveAddress()
+        _ = try await env.fund(address: aliceAddress, dash: fundingDash)
+
+        let bobAddress = try bob.getCoreWallet().nextReceiveAddress()
+        _ = try await env.fund(address: bobAddress, dash: fundingDash)
+
+        try await alice.waitForSpendable(exactly: fundingDuffs, timeout: 90)
+        try await bob.waitForSpendable(exactly: fundingDuffs, timeout: 90)
+
+        try await sendAndConfirm(from: alice, to: bob)
+
+        // Restart the SPV client with explicit stop + start directly on
+        // the wallet manager — the same API a real app drives — then
+        // wait for it to catch back up before the next send.
+        try await env.walletManager.stopSpv()
+        try await env.walletManager.startSpv(config: env.spvConfig)
+        try await env.walletManager.waitUntilUpToDate(
+            height: try await env.coreRPC.getBlockCount(),
+            timeout: 30
+        )
+
+        try await sendAndConfirm(from: alice, to: bob)
+
+        let aliceWalletId = alice.getPlatformWallet().walletId
+        let bobWalletId = bob.getPlatformWallet().walletId
+        let container = env.modelContainer
+
+        try await MainActor.run {
+            let context = ModelContext(container)
+
+            let aliceTxoCount = try context.fetchCount(FetchDescriptor<PersistentTxo>(
+                predicate: #Predicate<PersistentTxo> { $0.walletId == aliceWalletId }
+            ))
+            let bobTxoCount = try context.fetchCount(FetchDescriptor<PersistentTxo>(
+                predicate: #Predicate<PersistentTxo> { $0.walletId == bobWalletId }
+            ))
+
+            XCTAssertEqual(aliceTxoCount, 3)
+            XCTAssertEqual(bobTxoCount, 3)
+        }
+    }
+
+    private func sendAndConfirm(
+        from sender: TestWalletWrapper,
+        to receiver: TestWalletWrapper
+    ) async throws {
+        let receiverBalanceBefore = try receiver.getPlatformWallet().balance().spendable
+        let recipientAddress = try receiver.getCoreWallet().nextReceiveAddress()
+
+        let beforeTxids = try await readTxids()
+        _ = try sender.getCoreWallet().sendToAddresses(
+            recipients: [(address: recipientAddress, amountDuffs: amount)]
+        )
+        guard let sendTxid = try await waitForNewTxid(notIn: beforeTxids) else {
+            XCTFail("send PersistentTransaction row never appeared")
+            return
+        }
+        _ = try await env.mine(1, including: sendTxid)
+
+        try await Wait.until(
+            "receiver balance advances by \(amount)",
+            timeout: 60,
+            pollInterval: 0.01
+        ) {
+            try receiver.getPlatformWallet().balance().spendable
+                == receiverBalanceBefore + amount
+        }
+    }
+}

--- a/packages/swift-sdk/SwiftTests/SwiftDashSDKIntegrationTests/Core/SpvStartErrorIntegrationTests.swift
+++ b/packages/swift-sdk/SwiftTests/SwiftDashSDKIntegrationTests/Core/SpvStartErrorIntegrationTests.swift
@@ -1,0 +1,27 @@
+import XCTest
+import SwiftData
+@testable import SwiftDashSDK
+
+final class SpvStartErrorIntegrationTests: IntegrationTestCase {
+    func testStartSpvSurfacesLockedDataDir() async throws {
+        try await env.walletManager.startSpv(config: env.spvConfig)
+
+        let sdk = env.sdk
+        let container = env.modelContainer
+        let other = try await MainActor.run {
+            try PlatformWalletManager(sdk: sdk, modelContainer: container)
+        }
+
+        do {
+            try await other.startSpv(config: env.spvConfig)
+            XCTFail("startSpv should throw: data dir is locked by the first manager")
+        } catch {
+            let message = (error as? LocalizedError)?.errorDescription ?? "\(error)"
+            XCTAssertTrue(
+                message.localizedCaseInsensitiveContains("in use")
+                    || message.localizedCaseInsensitiveContains("lock"),
+                "expected a data-dir lock error, got: \(message)"
+            )
+        }
+    }
+}

--- a/packages/swift-sdk/SwiftTests/SwiftDashSDKIntegrationTests/Platform/CoreToPlatformIntegrationTests.swift
+++ b/packages/swift-sdk/SwiftTests/SwiftDashSDKIntegrationTests/Platform/CoreToPlatformIntegrationTests.swift
@@ -1,0 +1,140 @@
+import XCTest
+import SwiftData
+@testable import SwiftDashSDK
+
+final class CoreToPlatformIntegrationTests: IntegrationTestCase {
+    private let fundingDash: Double = 0.5
+    private var fundingDuffs: UInt64 { UInt64(fundingDash * 1e8) }
+
+    /// Fund a Platform address from Core: build an asset lock from the
+    /// Core wallet's UTXOs and credit one of the wallet's own platform
+    /// addresses, then assert its credit balance reflects the funding.
+    func testFundAddressReflectsInWallet() async throws {
+        try await env.walletManager.startSpv(config: env.spvConfig)
+        let alice = try await env.makeTestWallet(name: "c2p-fund-address")
+
+        // Core UTXOs to source the asset lock from.
+        let coreAddress = try alice.getCoreWallet().nextReceiveAddress()
+        _ = try await env.fund(address: coreAddress, dash: fundingDash)
+        try await alice.waitForSpendable(exactly: fundingDuffs, timeout: 90)
+
+        let recipient = try await firstPlatformAddress(
+            walletId: alice.getPlatformWallet().walletId
+        )
+
+        let signer = KeychainSigner(
+            modelContainer: env.modelContainer,
+            network: .regtest
+        )
+        let addressWallet = try alice.getPlatformWallet().platformAddressWallet()
+
+        let assetLockDuffs: UInt64 = 10_000_000
+        let updated = try await addressWallet.fundFromAssetLock(
+            amountDuffs: assetLockDuffs,
+            fundingAccountIndex: 0,
+            platformAccountIndex: 0,
+            recipients: [
+                .init(addressType: recipient.type, hash: recipient.hash, credits: nil)
+            ],
+            signer: signer
+        )
+
+        XCTAssertEqual(updated.count, 1)
+        XCTAssertGreaterThan(updated.first?.balance ?? 0, 0)
+        XCTAssertGreaterThan(try addressWallet.totalCredits(), 0)
+    }
+
+    /// Lowest-index platform address for `walletId`, polled because the
+    /// emit lands on the persister's background context.
+    private func firstPlatformAddress(
+        walletId: Data,
+        timeout: TimeInterval = 10
+    ) async throws -> (type: UInt8, hash: Data) {
+        let container = env.modelContainer
+        let deadline = Date().addingTimeInterval(timeout)
+
+        while Date() < deadline {
+            let found = try await MainActor.run { () -> (UInt8, Data)? in
+                let ctx = ModelContext(container)
+
+                let rows = try ctx.fetch(FetchDescriptor<PersistentPlatformAddress>(
+                    predicate: #Predicate<PersistentPlatformAddress> { $0.walletId == walletId }
+                ))
+
+                guard let row = rows.min(by: { $0.addressIndex < $1.addressIndex }) else {
+                    return nil
+                }
+
+                return (row.addressType, row.addressHash)
+            }
+
+            if let found { return (found.0, found.1) }
+
+            try await Task.sleep(nanoseconds: 100_000_000)
+        }
+
+        XCTFail("no PersistentPlatformAddress row for wallet within \(timeout)s")
+        throw SPVTestWaitError.timeout("no platform address emitted")
+    }
+
+    func testRegisterIdentityWithCoreFunding() async throws {
+        try await env.walletManager.startSpv(config: env.spvConfig)
+        let alice = try await env.makeTestWallet(name: "c2p-fund-identity")
+
+        let address = try alice.getCoreWallet().nextReceiveAddress()
+        _ = try await env.fund(address: address, dash: fundingDash)
+        try await alice.waitForSpendable(exactly: fundingDuffs, timeout: 90)
+
+        let wallet = alice.getPlatformWallet()
+        let identityIndex: UInt32 = 0
+        let keyCount: UInt32 = 3
+
+        let pubkeys = try wallet.prePersistIdentityKeysForRegistration(
+            identityIndex: identityIndex,
+            keyCount: keyCount,
+            network: .regtest
+        )
+        XCTAssertEqual(pubkeys.count, Int(keyCount))
+
+        let signer = KeychainSigner(
+            modelContainer: env.modelContainer,
+            network: .regtest
+        )
+
+        // 0.1 DASH of credits — comfortably above the ~221.5k-duff
+        // floor for three keys.
+        let assetLockDuffs: UInt64 = 10_000_000
+        let (identityId, identity) = try await wallet.registerIdentityWithFunding(
+            amountDuffs: assetLockDuffs,
+            accountIndex: 0,
+            identityIndex: identityIndex,
+            identityPubkeys: pubkeys,
+            signer: signer
+        )
+
+        XCTAssertEqual(identityId.count, 32)
+
+        // The registered identity carries the asset-lock credits
+        // (minus the registration cost).
+        let credits = try identity.getBalance()
+        XCTAssertGreaterThan(credits, 0)
+
+        // The identity persister writes the `PersistentIdentity` row on
+        // a background context, so poll rather than read once.
+        let container = env.modelContainer
+        try await Wait.until(
+            "PersistentIdentity row for the registered identity",
+            timeout: 30,
+            pollInterval: 0.1
+        ) {
+            try await MainActor.run {
+                let ctx = ModelContext(container)
+                let rows = try ctx.fetch(FetchDescriptor<PersistentIdentity>(
+                    predicate: #Predicate<PersistentIdentity> { $0.identityId == identityId }
+                ))
+                guard let row = rows.first else { return false }
+                return row.balance > 0
+            }
+        }
+    }
+}

--- a/packages/swift-sdk/SwiftTests/SwiftDashSDKIntegrationTests/Support/CoreRPCClient.swift
+++ b/packages/swift-sdk/SwiftTests/SwiftDashSDKIntegrationTests/Support/CoreRPCClient.swift
@@ -1,0 +1,177 @@
+import Foundation
+
+/// Minimal JSON-RPC client for dashd, covering only the calls the
+/// integration framework needs.
+struct CoreRPCClient {
+    private(set) var url: URL
+    let username: String
+    let password: String
+
+    init(port: Int, username: String, password: String) {
+        var components = URLComponents()
+        components.scheme = "http"
+        components.host = "127.0.0.1"
+        components.port = port
+        guard let url = components.url else {
+            preconditionFailure("Invalid Core RPC port: \(port)")
+        }
+        self.url = url
+        self.username = username
+        self.password = password
+    }
+
+    // MARK: - Typed methods
+
+    /// Throws RPC error -32601 if dashd was built without the miner.
+    @discardableResult
+    func generateToAddress(count: Int, address: String) async throws -> [String] {
+        try await call("generatetoaddress", params: [.int(count), .string(address)])
+    }
+
+    func getNewAddress(walletName: String = "main") async throws -> String {
+        try await wallet(walletName).call("getnewaddress")
+    }
+
+    /// `amount` is in DASH (not duffs). Returns the txid.
+    @discardableResult
+    func sendToAddress(amount: Double, address: String, walletName: String = "main") async throws -> String {
+        try await wallet(walletName).call(
+            "sendtoaddress",
+            params: [.string(address), .double(amount)]
+        )
+    }
+
+    /// Current best-known chain tip height.
+    func getBlockCount() async throws -> Int {
+        try await call("getblockcount")
+    }
+
+    func getRawTransaction(_ txid: String) async throws -> String {
+        try await call("getrawtransaction", params: [.string(txid)])
+    }
+
+    struct RawTxInfo: Decodable {
+        let instantlock: Bool
+    }
+
+    func getRawTransactionInfo(_ txid: String) async throws -> RawTxInfo {
+        try await call("getrawtransaction", params: [.string(txid), .int(1)])
+    }
+
+    @discardableResult
+    func sendRawTransaction(_ hex: String) async throws -> String {
+        try await call("sendrawtransaction", params: [.string(hex)])
+    }
+
+    private struct MasternodeEntry: Decodable {
+        let address: String
+    }
+
+    /// Masternode P2P endpoints as `127.0.0.1:<port>`
+    func masternodeP2PEndpoints() async throws -> [String] {
+        let list: [String: MasternodeEntry] = try await call(
+            "masternodelist", params: [.string("json")]
+        )
+
+        return list.values
+            .compactMap { $0.address.split(separator: ":").last.map { "127.0.0.1:\($0)" } }
+            .sorted()
+    }
+
+    /// Switches to the per-wallet RPC endpoint (`/wallet/<name>`).
+    func wallet(_ name: String) -> CoreRPCClient {
+        var copy = self
+        copy.url = url.appendingPathComponent("wallet").appendingPathComponent(name)
+        return copy
+    }
+
+    // MARK: - Generic JSON-RPC
+
+    enum Param: Sendable {
+        case string(String)
+        case int(Int)
+        case double(Double)
+    }
+
+    enum RPCError: Error, CustomStringConvertible {
+        case http(Int)
+        case rpc(code: Int, message: String)
+        case decode(String)
+
+        var description: String {
+            switch self {
+            case let .http(code): return "HTTP \(code)"
+            case let .rpc(code, msg): return "RPC error \(code): \(msg)"
+            case let .decode(msg): return "Decode error: \(msg)"
+            }
+        }
+    }
+
+    func call<T: Decodable>(_ method: String, params: [Param] = []) async throws -> T {
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+
+        let credentials = "\(username):\(password)".data(using: .utf8)!.base64EncodedString()
+        request.setValue("Basic \(credentials)", forHTTPHeaderField: "Authorization")
+
+        let body: [String: Any] = [
+            "jsonrpc": "1.0",
+            "id": "swift-integration",
+            "method": method,
+            "params": encodeParams(params),
+        ]
+        request.httpBody = try JSONSerialization.data(withJSONObject: body)
+
+        let (data, response) = try await URLSession.shared.data(for: request)
+        // dashd returns the RPC error in the body even on 500; only
+        // bail on HTTP errors if we can't parse the JSON-RPC body.
+        if let http = response as? HTTPURLResponse, !(200...299).contains(http.statusCode) {
+            if let decoded = try? decodeRPCResponse(data, T.self) {
+                return try unwrap(decoded)
+            }
+            throw RPCError.http(http.statusCode)
+        }
+        let decoded = try decodeRPCResponse(data, T.self)
+        return try unwrap(decoded)
+    }
+
+    private func decodeRPCResponse<T: Decodable>(_ data: Data, _: T.Type) throws -> RPCResponse<T> {
+        do {
+            return try JSONDecoder().decode(RPCResponse<T>.self, from: data)
+        } catch {
+            let raw = String(data: data, encoding: .utf8) ?? "<non-utf8>"
+            throw RPCError.decode("\(error) — body: \(raw)")
+        }
+    }
+
+    private func unwrap<T: Decodable>(_ response: RPCResponse<T>) throws -> T {
+        if let error = response.error {
+            throw RPCError.rpc(code: error.code, message: error.message)
+        }
+        guard let result = response.result else {
+            throw RPCError.decode("RPC response had neither `result` nor `error`")
+        }
+        return result
+    }
+
+    private func encodeParams(_ params: [Param]) -> [Any] {
+        params.map { param -> Any in
+            switch param {
+            case let .string(s): return s
+            case let .int(i): return i
+            case let .double(d): return d
+            }
+        }
+    }
+
+    private struct RPCResponse<T: Decodable>: Decodable {
+        let result: T?
+        let error: RPCErrorBody?
+    }
+
+    private struct RPCErrorBody: Decodable {
+        let code: Int
+        let message: String
+    }
+}

--- a/packages/swift-sdk/SwiftTests/SwiftDashSDKIntegrationTests/Support/IntegrationTestCase.swift
+++ b/packages/swift-sdk/SwiftTests/SwiftDashSDKIntegrationTests/Support/IntegrationTestCase.swift
@@ -1,0 +1,90 @@
+import Foundation
+import SwiftData
+import XCTest
+@testable import SwiftDashSDK
+
+open class IntegrationTestCase: XCTestCase {
+    private(set) var env: IntegrationTestEnv!
+    nonisolated(unsafe) private static var bootstrapResult: Result<IntegrationTestEnv, Error>?
+
+    open override func setUp() async throws {
+        try await super.setUp()
+        try skipIfDisabled()
+        env = try await Self.sharedEnv()
+        try await env.assertCleanState()
+    }
+
+    open override func tearDown() async throws {
+        if let env {
+            try? await env.resetState()
+        }
+
+        try await super.tearDown()
+    }
+
+    private func skipIfDisabled() throws {
+        let enabled = ProcessInfo.processInfo.environment["RUN_INTEGRATION_TESTS"] == "1"
+        try XCTSkipUnless(
+            enabled,
+            "Integration tests skipped — set RUN_INTEGRATION_TESTS=1 to enable"
+        )
+    }
+
+    private static func sharedEnv() async throws -> IntegrationTestEnv {
+        if let cached = bootstrapResult {
+            return try cached.get()
+        }
+
+        do {
+            let env = try await IntegrationTestEnv.bootstrap()
+            bootstrapResult = .success(env)
+
+            await MainActor.run {
+                SpvSuiteCleanupObserver.shared.env = env
+                XCTestObservationCenter.shared.addTestObserver(SpvSuiteCleanupObserver.shared)
+            }
+
+            return env
+        } catch {
+            bootstrapResult = .failure(error)
+            throw error
+        }
+    }
+
+    /// All txids currently in `PersistentTransaction`
+    func readTxids() async throws -> Set<Data> {
+        let container = env.modelContainer
+
+        return try await MainActor.run {
+            let ctx = ModelContext(container)
+            return Set(try ctx.fetch(FetchDescriptor<PersistentTransaction>()).map { $0.txid })
+        }
+    }
+
+    /// Polls `readTxids()` until a txid not in `before` shows up,
+    /// then returns it. Returns nil on timeout (60s).
+    func waitForNewTxid(notIn before: Set<Data>) async throws -> Data? {
+        let deadline = Date().addingTimeInterval(60)
+
+        while Date() < deadline {
+            let after = try await readTxids()
+
+            if let found = after.subtracting(before).first {
+                return found
+            }
+
+            try await Task.sleep(nanoseconds: 50_000_000)
+        }
+
+        return nil
+    }
+}
+
+private final class SpvSuiteCleanupObserver: NSObject, XCTestObservation {
+    nonisolated(unsafe) static let shared = SpvSuiteCleanupObserver()
+    nonisolated(unsafe) var env: IntegrationTestEnv?
+
+    func testBundleDidFinish(_ testBundle: Bundle) {
+        env?.cleanupSpvCache()
+    }
+}

--- a/packages/swift-sdk/SwiftTests/SwiftDashSDKIntegrationTests/Support/IntegrationTestEnv.swift
+++ b/packages/swift-sdk/SwiftTests/SwiftDashSDKIntegrationTests/Support/IntegrationTestEnv.swift
@@ -1,0 +1,451 @@
+import Foundation
+import XCTest
+import SwiftData
+import Security
+import SwiftDashSDK
+
+enum IntegrationTestEnvError: LocalizedError {
+    case timeout(String)
+
+    var errorDescription: String? {
+        switch self {
+        case .timeout(let msg): return msg
+        }
+    }
+}
+
+/// Suite-wide handle built once per process from
+/// `IntegrationTestCase.setUp` and reused across every test.
+final class IntegrationTestEnv: @unchecked Sendable {
+    let coreRPC: CoreRPCClient
+    let sdk: SDK
+    private(set) var modelContainer: ModelContainer
+
+    private(set) var walletManager: PlatformWalletManager
+    let spvDataDir: String
+    var spvCacheSnapshot: String { spvDataDir + "-snapshot" }
+
+    private let endpoints: LocalDevnet.Endpoints
+    private let mineRewardAddress: String
+    private let masternodePeers: [String]
+    private let masternodeRPCs: [CoreRPCClient]
+
+    var spvConfig: PlatformSpvStartConfig {
+        PlatformSpvStartConfig(
+            dataDir: spvDataDir,
+            network: .regtest,
+            userAgent: "swift-sdk-integration-tests/0.1",
+            peers: ["127.0.0.1:\(endpoints.coreP2P)"] + masternodePeers,
+            restrictToConfiguredPeers: true,
+            startFromHeight: 0
+        )
+    }
+
+    private static func makeSPVDataDir() -> String {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("swift-sdk-it-spv-\(UUID().uuidString.prefix(8))", isDirectory: true)
+        try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        return dir.path
+    }
+
+    /// Sync the SPV data dir up to the chain tip once, before any test
+    /// runs
+    func createSpvCache() async throws {
+        let tip = try await coreRPC.getBlockCount()
+        try await walletManager.startSpv(config: spvConfig)
+
+        do {
+            try await walletManager.waitUntilUpToDate(height: tip, timeout: 180)
+        } catch {
+            try? await walletManager.stopSpv()
+            throw error
+        }
+
+        try await walletManager.stopSpv()
+    }
+
+    /// Clone the freshly-synced SPV cache so every test can be handed a
+    /// pristine copy of it via `restoreSpvCacheFromSnapshot`.
+    func snapshotSpvCache() {
+        let fm = FileManager.default
+        try? fm.removeItem(atPath: spvCacheSnapshot)
+        try? fm.copyItem(atPath: spvDataDir, toPath: spvCacheSnapshot)
+    }
+
+    /// Replace the working SPV data dir with a fresh copy of the
+    /// snapshot, so each test starts from the same clean, pre-synced
+    /// cache instead of whatever the previous test left behind.
+    func restoreSpvCacheFromSnapshot() {
+        let fm = FileManager.default
+        try? fm.removeItem(atPath: spvDataDir)
+        try? fm.copyItem(atPath: spvCacheSnapshot, toPath: spvDataDir)
+    }
+
+    func cleanupSpvCache() {
+        try? FileManager.default.removeItem(atPath: spvDataDir)
+        try? FileManager.default.removeItem(atPath: spvCacheSnapshot)
+    }
+
+    private init(
+        endpoints: LocalDevnet.Endpoints,
+        coreRPC: CoreRPCClient,
+        sdk: SDK,
+        modelContainer: ModelContainer,
+        walletManager: PlatformWalletManager,
+        spvDataDir: String,
+        mineRewardAddress: String,
+        masternodePeers: [String],
+        masternodeRPCs: [CoreRPCClient]
+    ) {
+        self.endpoints = endpoints
+        self.coreRPC = coreRPC
+        self.sdk = sdk
+        self.modelContainer = modelContainer
+        self.walletManager = walletManager
+        self.spvDataDir = spvDataDir
+        self.mineRewardAddress = mineRewardAddress
+        self.masternodePeers = masternodePeers
+        self.masternodeRPCs = masternodeRPCs
+    }
+
+    /// Build the env. Assumes `run_integration_tests.sh` has already
+    /// brought dashmate online.
+    static func bootstrap() async throws -> IntegrationTestEnv {
+        cleanupLeftoverSpvDirs()
+        sweepKeychain()
+
+        let repoRoot = try locateRepoRoot()
+        let configName = ProcessInfo.processInfo.environment["DASHMATE_CONFIG"] ?? "local_seed"
+        let endpoints = try LocalDevnet(repoRoot: repoRoot, configName: configName)
+            .discoverEndpoints()
+
+        let coreRPC = CoreRPCClient(
+            port: endpoints.coreRPC,
+            username: endpoints.rpcUsername,
+            password: endpoints.rpcPassword
+        )
+
+        // The SDK reads `platformDAPIAddresses` from UserDefaults to
+        // override its built-in regtest default — matches SwiftExampleApp.
+        UserDefaults.standard.set(
+            "http://127.0.0.1:\(endpoints.platformDAPI)",
+            forKey: "platformDAPIAddresses"
+        )
+        let sdk = try SDK(network: .regtest)
+        let modelContainer = try DashModelContainer.createInMemory()
+        let walletManager = try await MainActor.run {
+            try PlatformWalletManager(sdk: sdk, modelContainer: modelContainer)
+        }
+
+        let masternodePeers = try await coreRPC.masternodeP2PEndpoints()
+        let groupPrefix = configName.replacingOccurrences(of: "_seed", with: "")
+
+        let masternodeRPCs = (try? discoverMasternodeRPCs(
+            repoRoot: repoRoot, groupPrefix: groupPrefix, p2pEndpoints: masternodePeers
+        )) ?? []
+
+        let env = IntegrationTestEnv(
+            endpoints: endpoints,
+            coreRPC: coreRPC,
+            sdk: sdk,
+            modelContainer: modelContainer,
+            walletManager: walletManager,
+            spvDataDir: makeSPVDataDir(),
+            mineRewardAddress: try await coreRPC.getNewAddress(),
+            masternodePeers: masternodePeers,
+            masternodeRPCs: masternodeRPCs
+        )
+
+        try await env.createSpvCache()
+        env.snapshotSpvCache()
+
+        try await env.assertCleanState()
+
+        return env
+    }
+
+    /// Build a `CoreRPCClient` per masternode. `masternodelist` gives the
+    /// P2P endpoints in port order (local_1, local_2, …); the RPC port is
+    /// the P2P port + 1 in the dashmate local layout, and the password is
+    /// read from each MN config. Reads are sequential (yarn's lock).
+    private static func discoverMasternodeRPCs(
+        repoRoot: URL, groupPrefix: String, p2pEndpoints: [String]
+    ) throws -> [CoreRPCClient] {
+        try p2pEndpoints.enumerated().compactMap { index, endpoint in
+            guard let p2pPort = Int(endpoint.split(separator: ":").last ?? "") else { return nil }
+
+            let password = try LocalDevnet(repoRoot: repoRoot, configName: "\(groupPrefix)_\(index + 1)")
+                .rpcPassword()
+
+            return CoreRPCClient(port: p2pPort + 1, username: "dashmate", password: password)
+        }
+    }
+
+    /// Remove SPV data dirs left behind by previous runs
+    private static func cleanupLeftoverSpvDirs() {
+        let tmp = FileManager.default.temporaryDirectory
+
+        guard let entries = try? FileManager.default.contentsOfDirectory(
+            at: tmp, includingPropertiesForKeys: nil
+        ) else { return }
+
+        for url in entries where url.lastPathComponent.hasPrefix("swift-sdk-it-spv-") {
+            try? FileManager.default.removeItem(at: url)
+        }
+    }
+
+    /// Mirror the app's cold-start sequence: stop SPV, drop the
+    /// current `PlatformWalletManager`, build a fresh one against the
+    /// same `modelContainer`, and re-hydrate it via `loadFromPersistor`.
+    /// SPV is left STOPPED so callers can drive state changes
+    func restartWalletManager() async throws {
+        let stopping = walletManager
+        try? await MainActor.run {
+            if try stopping.isSpvRunning() { try stopping.stopSpv() }
+        }
+
+        let sdk = self.sdk
+        let container = self.modelContainer
+
+        walletManager = try await MainActor.run { () -> PlatformWalletManager in
+            let mgr = try PlatformWalletManager(sdk: sdk, modelContainer: container)
+            _ = try mgr.loadFromPersistor()
+            return mgr
+        }
+    }
+
+    /// Reset the per-test mutable state
+    ///  - stop SPV
+    ///  - restore the SPV data dir from the pristine snapshot
+    ///  - swap in a fresh empty store
+    ///  - fresh wallet manager
+    ///  - wipe the Keychain.
+    func resetState() async throws {
+        let stopping = walletManager
+        try? await MainActor.run {
+            if try stopping.isSpvRunning() { try stopping.stopSpv() }
+        }
+
+        restoreSpvCacheFromSnapshot()
+
+        let sdk = self.sdk
+        let fresh = try DashModelContainer.createInMemory()
+        let mgr = try await MainActor.run { () -> PlatformWalletManager in
+            try PlatformWalletManager(sdk: sdk, modelContainer: fresh)
+        }
+
+        self.modelContainer = fresh
+        self.walletManager = mgr
+
+        Self.sweepKeychain()
+    }
+
+    func assertCleanState(file: StaticString = #filePath, line: UInt = #line) async throws {
+        let walletCount = await MainActor.run { walletManager.wallets.count }
+        XCTAssertEqual(
+            walletCount, 0,
+            "env not clean: wallet manager still holds \(walletCount) wallet(s)",
+            file: file, line: line
+        )
+
+        if ProcessInfo.processInfo.environment["DASH_KEYCHAIN_SERVICE"] != nil {
+            XCTAssertFalse(
+                Self.keychainHasItems(),
+                "env not clean: Keychain still holds wallet items",
+                file: file, line: line
+            )
+        }
+
+        XCTAssertEqual(
+            spvCacheSignature(spvDataDir), spvCacheSignature(spvCacheSnapshot),
+            "env not clean: SPV data dir diverges from the cloned cache",
+            file: file, line: line
+        )
+
+        let rows = try await MainActor.run { try totalPersistedRows() }
+        XCTAssertEqual(
+            rows, 0,
+            "env not clean: model container still holds \(rows) row(s)",
+            file: file, line: line
+        )
+    }
+
+    private static func sweepKeychain() {
+        guard ProcessInfo.processInfo.environment["DASH_KEYCHAIN_SERVICE"] != nil else { return }
+
+        // `SecItemDelete` fails inside the `xctest` runner: item ACLs are
+        // bound to the creating binary's code signature, which the runner
+        // doesn't satisfy, so deletes are silently denied (items pile up
+        // run after run). The Apple-signed `security` tool can delete
+        // them. It removes one match per call — loop until none remain.
+        let service = WalletStorage.keychainService
+        while runSecurityDelete(service: service) {}
+    }
+
+    private static func runSecurityDelete(service: String) -> Bool {
+        let proc = Process()
+        proc.executableURL = URL(fileURLWithPath: "/usr/bin/security")
+        proc.arguments = ["delete-generic-password", "-s", service]
+        proc.standardOutput = FileHandle.nullDevice
+        proc.standardError = FileHandle.nullDevice
+        do { try proc.run() } catch { return false }
+        proc.waitUntilExit()
+        return proc.terminationStatus == 0
+    }
+
+    private static func keychainHasItems() -> Bool {
+        let status = SecItemCopyMatching([
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: WalletStorage.keychainService,
+            kSecMatchLimit as String: kSecMatchLimitOne,
+        ] as CFDictionary, nil)
+        return status == errSecSuccess
+    }
+
+    /// Total rows across every persisted model type in the container.
+    private func totalPersistedRows() throws -> Int {
+        let ctx = ModelContext(modelContainer)
+        func count<T: PersistentModel>(_ type: T.Type) throws -> Int {
+            try ctx.fetchCount(FetchDescriptor<T>())
+        }
+        var total = 0
+        for type in DashModelContainer.modelTypes {
+            total += try count(type)
+        }
+        return total
+    }
+
+    /// Deterministic signature of a dir's regular files (relative path +
+    /// byte size) so two SPV caches can be compared for equality.
+    /// Paths are relativized via `pathComponents` after resolving
+    /// symlinks so the working dir and its `-snapshot` sibling produce
+    /// identical signatures — a plain string-prefix strip does not, since
+    /// the `/var`↔`/private` symlink and the suffix throw the offset off.
+    private func spvCacheSignature(_ path: String) -> String {
+        let fm = FileManager.default
+        let root = URL(fileURLWithPath: path).resolvingSymlinksInPath()
+        let rootCount = root.pathComponents.count
+
+        guard let walker = fm.enumerator(
+            at: root,
+            includingPropertiesForKeys: [.isRegularFileKey, .fileSizeKey]
+        ) else { return "" }
+
+        var entries: [String] = []
+        for case let url as URL in walker {
+            let values = try? url.resourceValues(forKeys: [.isRegularFileKey, .fileSizeKey])
+            guard values?.isRegularFile == true else { continue }
+
+            let rel = url.resolvingSymlinksInPath().pathComponents
+                .dropFirst(rootCount)
+                .joined(separator: "/")
+
+            entries.append("\(rel):\(values?.fileSize ?? 0)")
+        }
+
+        return entries.sorted().joined(separator: "\n")
+    }
+
+    /// Generates a fresh mnemonic each call and persists it to Keychain.
+    func makeTestWallet(name: String? = nil) async throws -> TestWalletWrapper {
+        let mnemonic = try Mnemonic.generate(wordCount: 24)
+
+        let wallet = try await MainActor.run {
+            try walletManager.createWallet(
+                mnemonic: mnemonic,
+                network: .regtest,
+                name: name,
+                createDefaultAccounts: true
+            )
+        }
+
+        try WalletStorage().storeMnemonic(mnemonic, for: wallet.walletId)
+
+        return TestWalletWrapper(wallet: wallet, core: try wallet.coreWallet())
+    }
+
+    /// Mine `count` blocks. When `including` is provided, block first
+    /// until dashd has the InstantSend lock for that txid
+    @discardableResult
+    func mine(_ count: Int, including txid: Data? = nil) async throws -> [String] {
+        if let txid {
+            let displayHex = Data(txid.reversed()).toHexString()
+            try await waitForInstantSendLock(txid: displayHex)
+        }
+
+        let preMineHeight = try await coreRPC.getBlockCount()
+        let addr = try await coreRPC.generateToAddress(count: count, address: mineRewardAddress)
+        let postMineHeight = try await coreRPC.getBlockCount()
+
+        XCTAssertEqual(
+            postMineHeight, preMineHeight + count,
+            "mine(\(count)) did not advance chain tip: \(preMineHeight) -> \(postMineHeight)"
+        )
+
+        return addr
+    }
+
+    /// `sendtoaddress` from the dashmate mining wallet, wait for the
+    /// InstantSend lock so the next mine actually includes the tx,
+    /// then mine 1 block. Returns the Core txid
+    @discardableResult
+    func fund(address: String, dash: Double) async throws -> String {
+        let txid = try await coreRPC.sendToAddress(amount: dash, address: address)
+        await broadcastToMasternodes(txid: txid)
+        try await waitForInstantSendLock(txid: txid)
+        _ = try await mine(1)
+        return txid
+    }
+
+    /// Hand a freshly-sent tx straight to the masternodes' mempools so the
+    /// InstantSend quorum signs it immediately
+    private func broadcastToMasternodes(txid: String) async {
+        guard !masternodeRPCs.isEmpty,
+              let hex = try? await coreRPC.getRawTransaction(txid)
+        else { return }
+        for mn in masternodeRPCs {
+            _ = try? await mn.sendRawTransaction(hex)
+        }
+    }
+
+    /// Block until dashd reports `instantlock=true` for the given tx
+    func waitForInstantSendLock(txid: String, timeout: TimeInterval = 30) async throws {
+        let deadline = Date().addingTimeInterval(timeout)
+        var lastError: Error?
+
+        while Date() < deadline {
+            do {
+                let info = try await coreRPC.getRawTransactionInfo(txid)
+                if info.instantlock { return }
+            } catch {
+                lastError = error
+            }
+            try await Task.sleep(nanoseconds: 50_000_000)
+        }
+
+        throw IntegrationTestEnvError.timeout(
+            "tx \(txid) did not reach instantlock=true within \(timeout)s" +
+            (lastError.map { " (last RPC error: \($0))" } ?? "")
+        )
+    }
+
+    private static func locateRepoRoot() throws -> URL {
+        if let override = ProcessInfo.processInfo.environment["PLATFORM_REPO_ROOT"] {
+            return URL(fileURLWithPath: override)
+        }
+
+        let fm = FileManager.default
+
+        var candidate = URL(fileURLWithPath: #filePath).deletingLastPathComponent()
+
+        for _ in 0..<8 {
+            if fm.fileExists(atPath: candidate.appendingPathComponent("package.json").path),
+               fm.fileExists(atPath: candidate.appendingPathComponent("packages/dashmate").path) {
+                return candidate
+            }
+            candidate.deleteLastPathComponent()
+        }
+
+        fatalError("Could not locate platform repo root. Set PLATFORM_REPO_ROOT to override.")
+    }
+}

--- a/packages/swift-sdk/SwiftTests/SwiftDashSDKIntegrationTests/Support/LocalDevnet.swift
+++ b/packages/swift-sdk/SwiftTests/SwiftDashSDKIntegrationTests/Support/LocalDevnet.swift
@@ -1,0 +1,92 @@
+import Foundation
+
+/// Reads port + credential info from a running dashmate devnet.
+/// Lifecycle (starting/stopping dashmate) is the script's job,
+/// `run_integration_tests.sh` brings it up before invoking the test
+/// binary. This type just reads config out of the running stack.
+struct LocalDevnet {
+    let repoRoot: URL
+    let configName: String
+
+    struct Endpoints {
+        let coreRPC: Int
+        let coreP2P: Int
+        let platformDAPI: Int
+        let rpcUsername: String
+        let rpcPassword: String
+    }
+
+    init(repoRoot: URL, configName: String) {
+        self.repoRoot = repoRoot
+        self.configName = configName
+    }
+
+    // MARK: - Endpoint discovery
+
+    /// Reads ports + RPC creds via `yarn dashmate config get`, which
+    /// returns the merged base/local/preset chain — pulling from
+    /// `~/.dashmate/config.json` directly would miss preset overrides.
+    func discoverEndpoints() throws -> Endpoints {
+        let coreRPC = try readConfigInt("core.rpc.port")
+        let coreP2P = try readConfigInt("core.p2p.port")
+        let platformDAPI = try readConfigInt("platform.gateway.listeners.dapiAndDrive.port")
+        let rpcUser = try readConfigString("core.rpc.users.dashmate.username", fallback: "dashmate")
+        let rpcPass = try readConfigString("core.rpc.users.dashmate.password", fallback: "rpcpassword")
+        return Endpoints(
+            coreRPC: coreRPC,
+            coreP2P: coreP2P,
+            platformDAPI: platformDAPI,
+            rpcUsername: rpcUser,
+            rpcPassword: rpcPass
+        )
+    }
+
+    func rpcPassword() throws -> String {
+        try readConfigString("core.rpc.users.dashmate.password", fallback: "rpcpassword")
+    }
+
+    private func readConfigInt(_ path: String) throws -> Int {
+        let raw = try readConfigRaw(path)
+        guard let value = Int(raw) else {
+            throw DevnetError.malformedConfig("Expected int at `\(path)`, got: \(raw)")
+        }
+        return value
+    }
+
+    private func readConfigString(_ path: String, fallback: String) throws -> String {
+        do {
+            return try readConfigRaw(path)
+        } catch {
+            return fallback
+        }
+    }
+
+    private func readConfigRaw(_ path: String) throws -> String {
+        let result = try Shell.runChecked(
+            "/usr/bin/env",
+            ["yarn", "dashmate", "config", "get", path, "--config=\(configName)"],
+            cwd: repoRoot,
+            timeout: 30
+        )
+        // yarn prepends its own banner lines; `dashmate config get`
+        // emits the value as the last non-empty line.
+        let lines = result.stdout
+            .split(separator: "\n", omittingEmptySubsequences: true)
+            .map { String($0).trimmingCharacters(in: .whitespaces) }
+            .filter { !$0.isEmpty }
+        guard let value = lines.last else {
+            throw DevnetError.malformedConfig("Empty `dashmate config get \(path)` output")
+        }
+        return value
+    }
+
+    enum DevnetError: Error, CustomStringConvertible {
+        case malformedConfig(String)
+
+        var description: String {
+            switch self {
+            case let .malformedConfig(msg): return "Devnet config malformed: \(msg)"
+            }
+        }
+    }
+}

--- a/packages/swift-sdk/SwiftTests/SwiftDashSDKIntegrationTests/Support/Shell.swift
+++ b/packages/swift-sdk/SwiftTests/SwiftDashSDKIntegrationTests/Support/Shell.swift
@@ -1,0 +1,105 @@
+import Foundation
+
+/// Subprocess wrapper used by the dashmate driver. Captures
+/// stdout / stderr and the exit code.
+enum Shell {
+    struct Result {
+        let exitCode: Int32
+        let stdout: String
+        let stderr: String
+
+        var ok: Bool { exitCode == 0 }
+    }
+
+    enum Error: Swift.Error, CustomStringConvertible {
+        case nonZeroExit(command: String, exitCode: Int32, stdout: String, stderr: String)
+        case spawnFailed(command: String, underlying: Swift.Error)
+
+        var description: String {
+            switch self {
+            case let .nonZeroExit(command, code, stdout, stderr):
+                // yarn often surfaces failure context on stdout; include
+                // both streams so the captured data isn't discarded.
+                return """
+                Shell command failed (exit \(code)): \(command)
+                stdout: \(stdout)
+                stderr: \(stderr)
+                """
+            case let .spawnFailed(command, err):
+                return "Failed to spawn `\(command)`: \(err)"
+            }
+        }
+    }
+
+    /// Run `command args...` in `cwd`, inheriting the parent
+    /// environment.
+    static func run(
+        _ command: String,
+        _ arguments: [String] = [],
+        cwd: URL? = nil,
+        timeout: TimeInterval? = nil
+    ) throws -> Result {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: command)
+        process.arguments = arguments
+        if let cwd { process.currentDirectoryURL = cwd }
+        process.environment = ProcessInfo.processInfo.environment
+
+        let stdoutPipe = Pipe()
+        let stderrPipe = Pipe()
+        process.standardOutput = stdoutPipe
+        process.standardError = stderrPipe
+
+        do {
+            try process.run()
+        } catch {
+            throw Error.spawnFailed(
+                command: "\(command) \(arguments.joined(separator: " "))",
+                underlying: error
+            )
+        }
+
+        if let timeout {
+            let deadline = Date().addingTimeInterval(timeout)
+            while process.isRunning && Date() < deadline {
+                Thread.sleep(forTimeInterval: 0.05)
+            }
+            if process.isRunning {
+                process.terminate()
+                Thread.sleep(forTimeInterval: 0.5)
+                if process.isRunning { kill(process.processIdentifier, SIGKILL) }
+            }
+        }
+
+        process.waitUntilExit()
+
+        let stdoutData = stdoutPipe.fileHandleForReading.readDataToEndOfFile()
+        let stderrData = stderrPipe.fileHandleForReading.readDataToEndOfFile()
+
+        return Result(
+            exitCode: process.terminationStatus,
+            stdout: String(data: stdoutData, encoding: .utf8) ?? "",
+            stderr: String(data: stderrData, encoding: .utf8) ?? ""
+        )
+    }
+
+    /// Like `run` but throws on non-zero exit.
+    @discardableResult
+    static func runChecked(
+        _ command: String,
+        _ arguments: [String] = [],
+        cwd: URL? = nil,
+        timeout: TimeInterval? = nil
+    ) throws -> Result {
+        let result = try run(command, arguments, cwd: cwd, timeout: timeout)
+        guard result.ok else {
+            throw Error.nonZeroExit(
+                command: "\(command) \(arguments.joined(separator: " "))",
+                exitCode: result.exitCode,
+                stdout: result.stdout,
+                stderr: result.stderr
+            )
+        }
+        return result
+    }
+}

--- a/packages/swift-sdk/SwiftTests/SwiftDashSDKIntegrationTests/Support/TestWallet.swift
+++ b/packages/swift-sdk/SwiftTests/SwiftDashSDKIntegrationTests/Support/TestWallet.swift
@@ -1,0 +1,86 @@
+import Foundation
+import SwiftDashSDK
+
+/// Wraps a `ManagedPlatformWallet` and a `ManagedCoreWallet`
+final class TestWalletWrapper {
+    private let core: ManagedCoreWallet
+    private let wallet: ManagedPlatformWallet
+
+    init(wallet: ManagedPlatformWallet, core: ManagedCoreWallet) {
+        self.wallet = wallet
+        self.core = core
+    }
+
+    func getCoreWallet() -> ManagedCoreWallet {
+        core
+    }
+
+    func getPlatformWallet() -> ManagedPlatformWallet {
+        wallet
+    }
+
+    func waitForSpendable(exactly duffs: UInt64, timeout: TimeInterval = 60) async throws {
+        try await Wait.until(
+            "wallet spendable == \(duffs) duffs",
+            timeout: timeout,
+            pollInterval: 0.01
+        ) {
+            try wallet.balance().spendable == duffs
+        }
+    }
+}
+
+enum Wait {
+    struct TimeoutError: Error, CustomStringConvertible {
+        let description: String
+    }
+
+    static func until(
+    _ message: @autoclosure () -> String,
+    timeout: TimeInterval = 60,
+    pollInterval: TimeInterval = 0.5,
+    _ condition: () async throws -> Bool
+    ) async throws {
+        let deadline = Date().addingTimeInterval(timeout)
+        while Date() < deadline {
+            if try await condition() { return }
+            try await Task.sleep(nanoseconds: UInt64(pollInterval * 1_000_000_000))
+        }
+        throw TimeoutError(description: "Timed out after \(timeout)s waiting for: \(message())")
+    }
+}
+
+@MainActor
+extension PlatformWalletManager {
+    func waitUntilUpToDate(height: Int, timeout: TimeInterval = 10) async throws {
+        let target = UInt32(max(0, height))
+        let deadline = Date().addingTimeInterval(timeout)
+        var lastHeaders: UInt32 = 0
+        var lastFilters: UInt32 = 0
+
+        while Date() < deadline {
+            let progress = try syncProgress()
+            lastHeaders = progress.headers?.currentHeight ?? 0
+            lastFilters = progress.filters?.currentHeight ?? 0
+
+            if lastHeaders >= target && lastFilters >= target { return }
+
+            try await Task.sleep(nanoseconds: 100_000_000)
+        }
+
+        throw SPVTestWaitError.timeout(
+            "SPV did not reach height \(target) within \(timeout)s — " +
+            "headers=\(lastHeaders), filters=\(lastFilters)"
+        )
+    }
+}
+
+enum SPVTestWaitError: LocalizedError {
+    case timeout(String)
+
+    var errorDescription: String? {
+        switch self {
+        case .timeout(let msg): return msg
+        }
+    }
+}

--- a/packages/swift-sdk/build_ios.sh
+++ b/packages/swift-sdk/build_ios.sh
@@ -257,7 +257,9 @@ OTHER_SWIFT_FLAGS="-warnings-as-errors"
 SWIFT_TREAT_WARNINGS_AS_ERRORS=YES
 SWIFT_SUPPRESS_WARNINGS=NO
 
-if command -v xcodebuild >/dev/null 2>&1; then
+if [ "${SKIP_EXAMPLE_APP_BUILD:-0}" = "1" ]; then
+    log_info "SKIP_EXAMPLE_APP_BUILD=1 — skipping SwiftExampleApp verification build"
+elif command -v xcodebuild >/dev/null 2>&1; then
     set +e
     xcodebuild -project "$SWIFT_PROJECT" \
                -scheme "$SWIFT_SCHEME" \

--- a/packages/swift-sdk/run_integration_tests.sh
+++ b/packages/swift-sdk/run_integration_tests.sh
@@ -1,0 +1,62 @@
+#!/bin/bash
+set -euo pipefail
+
+# Run the Swift SDK integration tests against a local dashmate devnet.
+# Restarts dashmate fresh every run, builds the FFI, runs the tests with
+# Address Sanitizer, always tears the devnet down afterwards, and exits
+# with the test runner's status so CI fails on a test failure.
+#
+# One-time setup: `yarn dashmate setup --preset local`.
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+REPO_ROOT="$( cd "$SCRIPT_DIR/../.." && pwd )"
+
+cd "$SCRIPT_DIR"
+
+# dashmate pins Node 20–22; bail early instead of failing several
+# minutes into the dashmate startup with a cryptic error.
+node_major=$(node -p "process.versions.node.split('.')[0]" 2>/dev/null || echo 0)
+if [ "$node_major" -gt 22 ] || [ "$node_major" -lt 20 ]; then
+  echo "Node $(node --version 2>/dev/null || echo '<missing>') is not supported by dashmate."
+  echo "Use Node 20–22 (e.g. \`nvm use 22\`) and re-run."
+  exit 1
+fi
+
+# Bootstrap JS workspace once. Both are idempotent skip-fast paths.
+[ -d "$REPO_ROOT/.yarn/unplugged" ] || (cd "$REPO_ROOT" && yarn install)
+[ -f "$REPO_ROOT/packages/wasm-dpp/dist/index.js" ] || (cd "$REPO_ROOT" && yarn build)
+
+cleanup() {
+  trap - EXIT INT TERM  # disarm so a second signal / the EXIT can't re-enter
+
+  for pid in "${devnet_pid:-}" "${build_pid:-}"; do
+    [ -n "$pid" ] && kill "$pid" 2>/dev/null || true
+  done
+
+  echo "tearing down dashmate devnet group…"
+  (cd "$REPO_ROOT" && yarn dashmate group stop --group=local --force 2>/dev/null || true)
+}
+
+trap cleanup EXIT
+trap 'cleanup; exit 130' INT TERM
+
+# Always start from a FRESH devnet
+(
+echo "restarting dashmate devnet group (fresh, ~1-2 min)…"
+(cd "$REPO_ROOT" && yarn dashmate group stop --group=local --force 2>/dev/null || true)
+(cd "$REPO_ROOT" && yarn dashmate group start --group=local --wait-for-readiness)
+) &
+devnet_pid=$!
+
+SKIP_EXAMPLE_APP_BUILD=1 bash build_ios.sh --target mac --profile dev &
+build_pid=$!
+
+devnet_rc=0; wait "$devnet_pid" || devnet_rc=$?
+build_rc=0;  wait "$build_pid"  || build_rc=$?
+
+if [ "$devnet_rc" -ne 0 ]; then echo "dashmate devnet failed (rc=$devnet_rc)" >&2; exit "$devnet_rc"; fi
+if [ "$build_rc" -ne 0 ]; then echo "FFI build failed (rc=$build_rc)" >&2; exit "$build_rc"; fi
+
+DASH_KEYCHAIN_SERVICE="org.dashfoundation.wallet.itest.$(uuidgen)"
+
+RUN_INTEGRATION_TESTS=1 DASH_KEYCHAIN_SERVICE="$DASH_KEYCHAIN_SERVICE" swift test --sanitize=address --filter SwiftDashSDKIntegrationTests "$@"


### PR DESCRIPTION
What

Adds a Swift SDK integration-test suite that runs against a local dashmate devnet (Core in regtest), exercising the Core (SPV/wallet) and Platform layers end-to-end. Includes a run_integration_tests.sh runner that spins up a fresh
devnet, builds the FFI, runs the tests under ASan, and tears the devnet down afterward. Gated by RUN_INTEGRATION_TESTS=1, so normal CI/builds are unaffected.

Coverage  
  - Wallet-to-wallet sends over SPV
  - TXO / tx-classification survival across SPV and persistor restarts
  - Locked-data-dir error surfacing
  - Core-funding → Platform identity registration

Each test runs against a shared, expensive env (devnet endpoints, RPC clients, pre-synced SPV cache) but with per-test state isolation (fresh in-memory ModelContainer, restored SPV-cache clone, swept keychain), asserted before every test.
  
Note: WalletStorage.keychainService is now overridable via DASH_KEYCHAIN_SERVICE for test isolation; no behavior change in production (defaults unchanged).


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [ ] I have made corresponding changes to the documentation if needed

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added end-to-end integration tests for wallet send flows, SDK bootstrap and initialization, plus supporting test harness and RPC/devnet helpers.
  * Introduced utilities for subprocess/shell runs, test wallets, and shared integration environment to run suites against a local devnet.

* **Chores**
  * Reorganized and removed legacy unit test suites and example artifacts.
  * Updated CI/workflow and local test runner scripts to streamline integration test execution and devnet lifecycle; extended build script deployment target exports.

* **Documentation**
  * Fixed relative links in a PlatformWallet README.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dashpay/platform/pull/3712?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->