### PR TITLE
ci(release): fix dashmate deb pack by configuring oclif targets

### DIFF
--- a/packages/dashmate/package.json
+++ b/packages/dashmate/package.json
@@ -128,6 +128,17 @@
     ],
     "commands": "./src/commands",
     "bin": "dashmate",
+    "update": {
+      "node": {
+        "targets": [
+          "linux-x64",
+          "linux-arm64",
+          "win32-x64",
+          "darwin-x64",
+          "darwin-arm64"
+        ]
+      }
+    },
     "macos": {
       "identifier": "org.dash.dashmate",
       "sign": "'Developer ID Installer: The Dash Foundation, Inc.'"

--- a/scripts/pack_dashmate.sh
+++ b/scripts/pack_dashmate.sh
@@ -21,18 +21,14 @@ fi
 FLAGS=""
 
 # Node 24+ does not publish 32-bit binaries (linux-armv7l, win-x86), so we
-# must explicitly drop those targets from oclif's default lists; otherwise
-# `oclif pack` 404s while downloading the embedded Node runtime.
-#   - tarballs default: oclif builds whatever we pass; we previously passed
-#     `linux-arm` (= armv7l). Replace with linux-arm64.
-#   - deb default targets: linux-x64, linux-arm (armv7l), linux-arm64 — drop arm.
-#   - win default targets: win32-x64, win32-x86 — drop x86.
+# must drop those targets from oclif's defaults; otherwise `oclif pack` 404s
+# while downloading the embedded Node runtime.
+#   - `tarballs` and `win` accept `--targets`, so we override on the command line.
+#   - `oclif pack deb` has no `--targets` flag; its linux targets come from
+#     `oclif.update.node.targets` in packages/dashmate/package.json.
 case "$COMMAND" in
   tarballs)
     FLAGS="--no-xz --targets=linux-arm64,linux-x64"
-    ;;
-  deb)
-    FLAGS="--targets=linux-x64,linux-arm64"
     ;;
   win)
     FLAGS="--targets=win32-x64"


### PR DESCRIPTION
## Issue being fixed or feature implemented

The `Release Dashmate packages (deb, ubuntu-24.04)` job fails at the **Create package** step with:

```
› Error: Nonexistent flag: --targets=linux-x64,linux-arm64
```

PR #3709 added a `deb` case to `scripts/pack_dashmate.sh` that passes `--targets=linux-x64,linux-arm64` to `oclif pack deb`. Unlike `pack tarballs` and `pack win`, the `oclif pack deb` command (oclif@4.0.3) has **no `--targets` flag**, so the command aborts and the deb release artifact is never produced. (The tarballs/win/macos jobs in the same run passed.)

Example failing run: https://github.com/dashpay/platform/actions/runs/26183903035/job/77044083874

## What was done?

- Removed the `--targets` flag from the `deb` case in `scripts/pack_dashmate.sh`.
- Configured the build targets via `oclif.update.node.targets` in `packages/dashmate/package.json`, which `pack deb` (and `pack macos`) read. The list is `linux-x64`, `linux-arm64`, `win32-x64`, `darwin-x64`, `darwin-arm64` — i.e. the 32-bit `linux-armv7l` and `win32-x86` targets stay dropped (the goal of #3709, since Node 24+ does not publish 32-bit binaries and `oclif pack` 404s on them).
- `tarballs` and `win` keep their command-line `--targets` overrides since those commands support the flag.

## How Has This Been Tested?

- Validated `package.json` is still valid JSON and `pack_dashmate.sh` passes `bash -n`.
- Logic verified against the failing run: only the `deb` matrix job (which uniquely received `--targets`) failed; `deb` derives its linux targets from `oclif.update.node.targets`, and `macos` derives darwin targets from the same config (unchanged behavior).

## Breaking Changes

None.

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [ ] I have made corresponding changes to the documentation if needed

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated platform support configuration to ensure dashmate distribution compatibility across Linux, Windows, and macOS.
  * Enhanced packaging script for improved Node 24+ compatibility.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dashpay/platform/pull/3713?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->