### PR TITLE
fix(platform-wallet): wait for shield confirmations

### DIFF
--- a/packages/rs-platform-wallet/src/wallet/shielded/operations.rs
+++ b/packages/rs-platform-wallet/src/wallet/shielded/operations.rs
@@ -213,29 +213,32 @@ pub async fn shield<Sig: Signer<PlatformAddress>, P: OrchardProver>(
 
     trace!("Shield credits: state transition built, broadcasting...");
     let network = sdk.network;
-    state_transition.broadcast(sdk, None).await.map_err(|e| {
-        if let Some(rich) = addresses_not_enough_funds(&e) {
-            let claimed = claimed_inputs
-                .iter()
-                .map(|(addr, (nonce, credits))| {
-                    format!(
-                        "{}=(nonce {nonce}, {credits} credits)",
-                        addr.to_bech32m_string(network)
-                    )
-                })
-                .collect::<Vec<_>>()
-                .join(", ");
-            PlatformWalletError::ShieldedBroadcastFailed(format!(
-                "addresses not enough funds: required {} credits; \
+    state_transition
+        .broadcast_and_wait::<StateTransitionProofResult>(sdk, None)
+        .await
+        .map_err(|e| {
+            if let Some(rich) = addresses_not_enough_funds(&e) {
+                let claimed = claimed_inputs
+                    .iter()
+                    .map(|(addr, (nonce, credits))| {
+                        format!(
+                            "{}=(nonce {nonce}, {credits} credits)",
+                            addr.to_bech32m_string(network)
+                        )
+                    })
+                    .collect::<Vec<_>>()
+                    .join(", ");
+                PlatformWalletError::ShieldedBroadcastFailed(format!(
+                    "addresses not enough funds: required {} credits; \
                      claimed inputs [{}]; platform sees [{}]",
-                rich.required_balance(),
-                claimed,
-                format_addresses_with_info(rich.addresses_with_info(), network),
-            ))
-        } else {
-            PlatformWalletError::ShieldedBroadcastFailed(e.to_string())
-        }
-    })?;
+                    rich.required_balance(),
+                    claimed,
+                    format_addresses_with_info(rich.addresses_with_info(), network),
+                ))
+            } else {
+                PlatformWalletError::ShieldedBroadcastFailed(e.to_string())
+            }
+        })?;
 
     info!(account, credits = amount, "Shield broadcast succeeded");
     Ok(())
@@ -278,7 +281,7 @@ pub async fn shield_from_asset_lock<P: OrchardProver>(
 
     trace!("Shield from asset lock: state transition built, broadcasting...");
     state_transition
-        .broadcast(sdk, None)
+        .broadcast_and_wait::<StateTransitionProofResult>(sdk, None)
         .await
         .map_err(|e| PlatformWalletError::ShieldedBroadcastFailed(e.to_string()))?;
 

--- a/packages/swift-sdk/SwiftExampleApp/SwiftExampleApp/Core/Views/CoreContentView.swift
+++ b/packages/swift-sdk/SwiftExampleApp/SwiftExampleApp/Core/Views/CoreContentView.swift
@@ -9,12 +9,13 @@ struct CoreContentView: View {
     @EnvironmentObject var platformBalanceSyncService: PlatformBalanceSyncService
     @EnvironmentObject var shieldedService: ShieldedService
     /// Threaded into `ShieldedService.clearLocalState(modelContext:)`
-    /// so the Clear button can scope its delete-by-predicate to
-    /// the bound wallet's persisted rows.
+    /// so the global shielded Clear action can wipe persisted
+    /// rows across wallets on the active device.
     @Environment(\.modelContext) private var modelContext
     @State private var showProofDetail = false
     @State private var masternodesEnabled: Bool = true
     @State private var platformSyncExpanded: Bool = false
+    @State private var showShieldedClearConfirmation = false
     // Progress values come from PlatformWalletManager (polled from FFI each second)
 
     /// All persisted platform addresses across every wallet. Summed
@@ -539,26 +540,9 @@ var body: some View {
                         .disabled(shieldedService.isSyncing || !shieldedService.canResume)
 
                         Button {
-                            // Stop the manager-wide shielded sync
-                            // loop, then wipe every wallet's
-                            // persisted shielded rows (notes +
-                            // sync state). The Swift mirror zeros
-                            // out and the service goes unbound,
-                            // but the bind credentials are kept
-                            // so the user can tap Sync Now to
-                            // self-rebind from this screen — no
-                            // navigation detour required. The
-                            // on-disk SQLite tree is intentionally
-                            // NOT deleted (Rust still holds its
-                            // handle open via FileBackedShieldedStore;
-                            // see clearLocalState's doc).
-                            Task {
-                                await shieldedService.clearLocalState(
-                                    modelContext: modelContext
-                                )
-                            }
+                            showShieldedClearConfirmation = true
                         } label: {
-                            Text("Clear")
+                            Text("Clear Shielded Data")
                                 .font(.caption)
                                 .fontWeight(.medium)
                         }
@@ -595,6 +579,35 @@ var body: some View {
             NavigationStack {
                 ProofDetailView(proofData: platformBalanceSyncService.lastRecentProof)
             }
+        }
+        .confirmationDialog(
+            "Clear shielded sync data for every wallet on this device?",
+            isPresented: $showShieldedClearConfirmation,
+            titleVisibility: .visible
+        ) {
+            Button("Clear Shielded Data", role: .destructive) {
+                // Stop the manager-wide shielded sync loop, then
+                // wipe every wallet's persisted shielded rows
+                // (notes + sync state). The Swift mirror zeros
+                // out and the service goes unbound, but the bind
+                // credentials are kept so the user can tap
+                // Sync Now to self-rebind from this screen — no
+                // navigation detour required. The on-disk SQLite
+                // tree is intentionally NOT deleted (Rust still
+                // holds its handle open via
+                // FileBackedShieldedStore; see clearLocalState's
+                // doc).
+                Task {
+                    await shieldedService.clearLocalState(
+                        modelContext: modelContext
+                    )
+                }
+            }
+            Button("Cancel", role: .cancel) {}
+        } message: {
+            Text(
+                "This removes persisted shielded notes and sync state for all wallets on this device. Use Sync Now afterward to rebind and rescan."
+            )
         }
     }
 


### PR DESCRIPTION
## Issue being fixed or feature implemented

Follow-up for review-bot feedback on dashpay/platform#3603.

Shielding from transparent platform credits and asset locks previously returned after broadcast submission, while the other shielded operations waited for the state transition proof result before reporting success. The Swift Example App's global shielded Clear action also needed a stronger confirmation because it removes persisted shielded rows across every wallet on the device.

## What was done?

- Changed `shield` to use `broadcast_and_wait::<StateTransitionProofResult>(sdk, None)` while preserving the rich `addresses_not_enough_funds` diagnostic.
- Changed `shield_from_asset_lock` to wait for the proof result before returning success.
- Renamed the Swift Example App destructive button to `Clear Shielded Data`.
- Added a visible confirmation dialog explaining that the action clears persisted shielded notes and sync state for all wallets on the device.

## How Has This Been Tested?

- `git diff --check HEAD~1..HEAD`
- `cargo check -p platform-wallet`
- Code review gate: `ship`

## Breaking Changes

None.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [x] I have made corresponding changes to the documentation if needed

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added confirmation dialog before clearing shielded data to prevent accidental deletion

* **Improvements**
  * Shielded transactions now wait for proof confirmation before completion
  * Enhanced error messages for failed shielded operations with additional diagnostic information

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dashpay/platform/pull/3715?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->