### PR TITLE
ci(release): configure oclif update targets in package.json, drop --targets for deb

### DIFF
--- a/packages/dashmate/package.json
+++ b/packages/dashmate/package.json
@@ -132,6 +132,17 @@
       "identifier": "org.dash.dashmate",
       "sign": "'Developer ID Installer: The Dash Foundation, Inc.'"
     },
+    "update": {
+      "node": {
+        "targets": [
+          "linux-x64",
+          "linux-arm64",
+          "win32-x64",
+          "darwin-x64",
+          "darwin-arm64"
+        ]
+      }
+    },
     "plugins": [
       "@oclif/plugin-help"
     ],

--- a/scripts/pack_dashmate.sh
+++ b/scripts/pack_dashmate.sh
@@ -20,10 +20,24 @@ fi
 
 FLAGS=""
 
-if [[ "$COMMAND" == "tarballs" ]]
-then
-  FLAGS="--no-xz --targets=linux-arm,linux-x64"
-fi
+# Node 24+ does not publish 32-bit binaries (linux-armv7l, win-x86), so we
+# must explicitly drop those targets from oclif's default lists; otherwise
+# `oclif pack` 404s while downloading the embedded Node runtime.
+#   - tarballs default: oclif builds whatever we pass; we previously passed
+#     `linux-arm` (= armv7l). Replace with linux-arm64.
+#   - deb default targets: linux-x64, linux-arm (armv7l), linux-arm64 — drop arm.
+#   - win default targets: win32-x64, win32-x86 — drop x86.
+case "$COMMAND" in
+  tarballs)
+    FLAGS="--no-xz --targets=linux-arm64,linux-x64"
+    ;;
+  deb)
+    FLAGS="--targets=linux-x64,linux-arm64"
+    ;;
+  win)
+    FLAGS="--targets=win32-x64"
+    ;;
+esac
 
 FULL_PATH=$(realpath "$0")
 DIR_PATH=$(dirname "$FULL_PATH")

--- a/scripts/pack_dashmate.sh
+++ b/scripts/pack_dashmate.sh
@@ -20,24 +20,18 @@ fi
 
 FLAGS=""
 
-# Node 24+ does not publish 32-bit binaries (linux-armv7l, win-x86), so we
-# must explicitly drop those targets from oclif's default lists; otherwise
-# `oclif pack` 404s while downloading the embedded Node runtime.
-#   - tarballs default: oclif builds whatever we pass; we previously passed
-#     `linux-arm` (= armv7l). Replace with linux-arm64.
-#   - deb default targets: linux-x64, linux-arm (armv7l), linux-arm64 — drop arm.
-#   - win default targets: win32-x64, win32-x86 — drop x86.
-case "$COMMAND" in
-  tarballs)
-    FLAGS="--no-xz --targets=linux-arm64,linux-x64"
-    ;;
-  deb)
-    FLAGS="--targets=linux-x64,linux-arm64"
-    ;;
-  win)
-    FLAGS="--targets=win32-x64"
-    ;;
-esac
+# Limit `oclif pack tarballs` to the linux subset of `oclif.update.node.targets`
+# in packages/dashmate/package.json — without this it would emit tarballs for
+# every configured target (linux + win + darwin), and we only ship linux
+# tarballs as release artifacts.
+#
+# `pack deb`, `pack win`, and `pack macos` read `oclif.update.node.targets`
+# directly and filter to their own platform; no per-command flag needed.
+# Note: `pack deb` in oclif 4.0.3 rejects `--targets` as an unknown flag.
+if [[ "$COMMAND" == "tarballs" ]]
+then
+  FLAGS="--no-xz --targets=linux-arm64,linux-x64"
+fi
 
 FULL_PATH=$(realpath "$0")
 DIR_PATH=$(dirname "$FULL_PATH")


### PR DESCRIPTION
## Summary

- Move the dashmate pack target list from script flags to `oclif.update.node.targets` in `packages/dashmate/package.json`.
- Revert `scripts/pack_dashmate.sh` to only set `--targets` for the `tarballs` subcommand.

## Background

[#3709](https://github.com/dashpay/platform/pull/3709) tried to restrict dashmate pack targets by passing `--targets=linux-x64,linux-arm64` to `oclif pack deb`. That fixed `tarballs` and `win`, but `deb` still failed on [v3.1.0-dev.4](https://github.com/dashpay/platform/actions/runs/26183903035):

```
Error: Nonexistent flag: --targets=linux-x64,linux-arm64
Process completed with exit code 2
```

In oclif 4.0.3, `--targets` is accepted by `pack tarballs` and `pack win` but **not** `pack deb`. Inconsistent CLI surface.

The portable way to restrict targets across all `pack` subcommands is the `oclif.update.node.targets` field in `package.json`. Each subcommand filters that list to its own platform prefix (`linux-*` for deb, `win32-*` for win, `darwin-*` for macos). `pack tarballs` builds for every configured target, which is why it still needs a `--targets` override to stay linux-only.

## Test plan

- [ ] CI green on this PR.
- [ ] Next release run shows all four `Release Dashmate packages` jobs ✓.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced multi-platform support for node updates across Windows, macOS, and Linux.
  * Improved release build process to support both x64 and ARM64 architectures on all platforms.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dashpay/platform/pull/3717?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->