### PR TITLE
fix(platform-wallet): keep sync watermark monotonic

### DIFF
--- a/packages/rs-platform-wallet/src/wallet/platform_addresses/provider.rs
+++ b/packages/rs-platform-wallet/src/wallet/platform_addresses/provider.rs
@@ -425,9 +425,11 @@ impl PlatformPaymentAddressProvider {
         &mut self,
         result: &AddressSyncResult<PlatformAddressTag, PlatformP2PKHAddress>,
     ) {
-        self.sync_height = result.new_sync_height;
-        self.sync_timestamp = result.new_sync_timestamp;
-        self.last_known_recent_block = result.last_known_recent_block;
+        self.sync_height = self.sync_height.max(result.new_sync_height);
+        self.sync_timestamp = self.sync_timestamp.max(result.new_sync_timestamp);
+        self.last_known_recent_block = self
+            .last_known_recent_block
+            .max(result.last_known_recent_block);
     }
 
     /// Current `last_known_recent_block` watermark.


### PR DESCRIPTION
# fix(platform-wallet): keep sync watermark monotonic

## Summary

Fixes the CodeRabbit feedback on dashpay/platform#3723 by keeping
`PlatformPaymentAddressProvider::update_sync_state` monotonic.

An out-of-order sync result can no longer move `sync_height`, `sync_timestamp`,
or `last_known_recent_block` backward after a newer result has already advanced
them.

## Validation

- `cargo fmt -p platform-wallet --check`
- `cargo test -p platform-wallet platform_addresses`
- Pre-commit hook: `cargo fmt --all -- --check`
- Pre-commit hook: workspace `cargo check`
- Code review gate against
  `origin/feat/platform-wallet-sync-watermark-getter...fix-3723-monotonic-sync-watermark`
  — Recommendation: ship


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved wallet synchronization state tracking to ensure previously observed sync progress markers are preserved across updates, preventing potential regression in sync state management.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dashpay/platform/pull/3724?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->