### PR TITLE
fix(sdk): forward wasm grpc-web trailers to tonic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5095,8 +5095,8 @@ version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "343d3bd7056eda839b03204e68deff7d1b13aba7af2b2fd16890697274262ee7"
 dependencies = [
- "heck 0.4.1",
- "itertools 0.13.0",
+ "heck 0.5.0",
+ "itertools 0.14.0",
  "log",
  "multimap",
  "petgraph",
@@ -5117,7 +5117,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -5130,7 +5130,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
 dependencies = [
  "anyhow",
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -7481,9 +7481,9 @@ dependencies = [
 
 [[package]]
 name = "tonic-web-wasm-client"
-version = "0.8.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "898cd44be5e23e59d2956056538f1d6b3c5336629d384ffd2d92e76f87fb98ff"
+checksum = "3c0469c353de5f665c95f898074b5b004b500c6722214c3249f1dc79c0a2a3f6"
 dependencies = [
  "base64 0.22.1",
  "byteorder",
@@ -8235,9 +8235,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-streams"
-version = "0.4.2"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15053d8d85c7eccdbefef60f06769760a563c7f0a9d6902a13d35c7800b0ad65"
+checksum = "9d1ec4f6517c9e11ae630e200b2b65d193279042e28edd4a2cda233e46670bbb"
 dependencies = [
  "futures-util",
  "js-sys",

--- a/packages/rs-dapi-client/Cargo.toml
+++ b/packages/rs-dapi-client/Cargo.toml
@@ -29,7 +29,7 @@ tokio = { version = "1.40", features = ["time"] }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 gloo-timers = { version = "0.3.0", features = ["futures"] }
-tonic-web-wasm-client = { version = "0.8.0" }
+tonic-web-wasm-client = { version = "0.9.1" }
 wasm-bindgen-futures = { version = "0.4.58" }
 getrandom = { version = "0.2", features = ["js"] }
 chrono = { version = "0.4.38", features = ["serde", "wasmbind"] }


### PR DESCRIPTION
# Wasm gRPC-Web trailer forwarding

## Issue being fixed or feature implemented

Fixes #3719.

Browser SDK calls that use the Rust wasm DAPI client can fail when
`tonic-web-wasm-client` 0.8.0 does not surface parsed gRPC-Web trailers to
tonic as trailer frames.

The upstream `tonic-web-wasm-client` 0.9.1 release fixes that trailer
propagation path, which matches the missing `grpc-status` failure mode seen in
wasm/browser SDK calls.

## What was done

- Bumped `tonic-web-wasm-client` from 0.8.0 to 0.9.1 for the wasm
  `rs-dapi-client` transport.
- Refreshed `Cargo.lock`, including the expected `wasm-streams` 0.4.2 to 0.5.0
  transitive update.

## How Has This Been Tested

- `cargo check -p rs-dapi-client --target wasm32-unknown-unknown`
- Verified the locked wasm dependency graph includes:
  - `tonic-web-wasm-client v0.9.1`
  - `wasm-streams v0.5.0`
- Pre-PR review gate: `code-review` returned `ship`.

I also attempted `cargo check -p wasm-sdk --target wasm32-unknown-unknown`, but
local validation is blocked by the host clang toolchain failing to emit
`wasm32-unknown-unknown` C objects for `secp256k1-sys`. The earlier
`rs-dapi-client` wasm check validates the changed crate and dependency graph.

## Breaking Changes

None.

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have added "!" to the title and described breaking changes in the
  corresponding section if my code contains any
- [ ] I have made corresponding changes to the documentation if needed

### For repository code-owners and collaborators only

- [ ] I have assigned this pull request to a milestone

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated WebAssembly support dependencies to improve compatibility and stability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dashpay/platform/pull/3726?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
