### PR TITLE
fix(platform-wallet): spv client deadlocking when sending a tx

### DIFF
--- a/packages/rs-platform-wallet/src/spv/runtime.rs
+++ b/packages/rs-platform-wallet/src/spv/runtime.rs
@@ -103,9 +103,6 @@ impl SpvRuntime {
             .await
             .map_err(|e| PlatformWalletError::SpvError(e.to_string()))?;
 
-        let mut client = self.client.write().await;
-        let _ = client.take();
-
         Ok(())
     }
 
@@ -143,10 +140,16 @@ impl SpvRuntime {
             .as_ref()
             .ok_or(PlatformWalletError::SpvNotRunning)?;
 
-        client
+        let result = client
             .run()
             .await
-            .map_err(|e| PlatformWalletError::SpvError(e.to_string()))
+            .map_err(|e| PlatformWalletError::SpvError(e.to_string()));
+
+        drop(client_guard);
+        let mut client = self.client.write().await;
+        let _ = client.take();
+
+        result
     }
 
     /// Stop SPV sync gracefully.


### PR DESCRIPTION
I misplaced two lines of code in PR https://github.com/dashpay/platform/pull/3729 blocking the spa client when sending a tx, this fixes that


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [ ] I have made corresponding changes to the documentation if needed

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * SPV client now remains available after broadcasting a transaction, allowing continued use without interruption.
  * Runtime shutdown now performs improved cleanup and returns final sync status reliably.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dashpay/platform/pull/3730?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->