### PR TITLE
fix(platform-wallet): wallet_id gate on resolver-fed sign entrypoints

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4869,6 +4869,7 @@ dependencies = [
  "platform-wallet",
  "rs-sdk-ffi",
  "serde_json",
+ "subtle",
  "tempfile",
  "tokio",
  "tracing",

--- a/packages/rs-platform-wallet-ffi/Cargo.toml
+++ b/packages/rs-platform-wallet-ffi/Cargo.toml
@@ -54,6 +54,10 @@ bs58 = "0.5"
 # Zeroize intermediate key material crossing the FFI boundary.
 zeroize = { version = "1", features = ["derive"] }
 
+# Constant-time `wallet_id` compare in `sign_gate`, mirroring the
+# upstream gate previously in `manager::rehydrate`.
+subtle = "2"
+
 [dev-dependencies]
 tempfile = "3.8"
 dpp = { path = "../rs-dpp", features = ["fixtures-and-mocks"] }

--- a/packages/rs-platform-wallet-ffi/src/derive_identity_key_at_slot.rs
+++ b/packages/rs-platform-wallet-ffi/src/derive_identity_key_at_slot.rs
@@ -12,7 +12,10 @@ use zeroize::Zeroizing;
 use crate::error::*;
 use crate::identity_key_preview::IdentityKeyPreviewFFI;
 use crate::identity_keys_from_mnemonic::parse_mnemonic_any_language;
+use crate::sign_gate::verify_seed_matches_wallet_id;
 use crate::{check_ptr, unwrap_result_or_return};
+use dashcore::secp256k1::Secp256k1;
+use key_wallet::bip32::ExtendedPubKey;
 use rs_sdk_ffi::{
     mnemonic_resolver_result, MnemonicResolverHandle, MNEMONIC_RESOLVER_BUFFER_CAPACITY,
 };
@@ -182,6 +185,32 @@ pub unsafe extern "C" fn dash_sdk_derive_identity_key_at_slot_with_resolver(
 
     let mnemonic_str = unwrap_result_or_return!(std::str::from_utf8(&mnemonic_buf[..mnemonic_len]));
 
+    // Fail-closed wrong-seed gate before any signing-relevant material
+    // is materialized for the caller. Derive the root xpub from the
+    // resolver-supplied seed in its own scope so the master xpriv +
+    // its SecretKey are non-secure-erased before the inner derivation
+    // path runs (which re-derives from the seed via the shared helper).
+    {
+        let mnemonic = unwrap_result_or_return!(parse_mnemonic_any_language(mnemonic_str));
+        let seed: Zeroizing<[u8; 64]> = Zeroizing::new(mnemonic.to_seed(""));
+        drop(mnemonic);
+        let kw_network: Network = network.into();
+        let mut master =
+            unwrap_result_or_return!(ExtendedPrivKey::new_master(kw_network, seed.as_ref()));
+        let secp = Secp256k1::new();
+        let root_xpub = ExtendedPubKey::from_priv(&secp, &master);
+        let mut wallet_id_expected = [0u8; 32];
+        std::ptr::copy_nonoverlapping(wallet_id_bytes, wallet_id_expected.as_mut_ptr(), 32);
+        let gate_ok = verify_seed_matches_wallet_id(&root_xpub, &wallet_id_expected);
+        master.private_key.non_secure_erase();
+        if !gate_ok {
+            return PlatformWalletFFIResult::err(
+                PlatformWalletFFIResultCode::ErrorWrongSeedForWallet,
+                "wrong seed for wallet (derive_identity_key_at_slot_with_resolver gate)",
+            );
+        }
+    }
+
     derive_at_slot_inner(
         mnemonic_str,
         "",
@@ -225,4 +254,142 @@ pub unsafe extern "C" fn dash_sdk_derive_identity_key_at_slot_free(
         *byte = 0;
     }
     row.identity_index = 0;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use key_wallet::wallet::root_extended_keys::RootExtendedPubKey;
+    use key_wallet::wallet::Wallet;
+    use rs_sdk_ffi::{dash_sdk_mnemonic_resolver_create, dash_sdk_mnemonic_resolver_destroy};
+
+    /// English BIP-39 test vector (all-zero entropy). Matches the
+    /// fixture in the sibling resolver-fed entrypoints.
+    const ENGLISH_PHRASE: &str =
+        "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about";
+
+    /// Compute the `wallet_id` the gate will recompute from the
+    /// resolver-supplied seed. Tests must pass this id for happy-path
+    /// or short-circuit with `ErrorWrongSeedForWallet` on mismatch.
+    fn wallet_id_for_english_phrase() -> [u8; 32] {
+        let mnemonic = parse_mnemonic_any_language(ENGLISH_PHRASE).unwrap();
+        let seed: Zeroizing<[u8; 64]> = Zeroizing::new(mnemonic.to_seed(""));
+        let mut master =
+            ExtendedPrivKey::new_master(key_wallet::Network::Testnet, seed.as_ref()).unwrap();
+        let secp = Secp256k1::new();
+        let xpub = ExtendedPubKey::from_priv(&secp, &master);
+        let root = RootExtendedPubKey::from_extended_pub_key(&xpub);
+        let id = Wallet::compute_wallet_id_from_root_extended_pub_key(&root);
+        master.private_key.non_secure_erase();
+        id
+    }
+
+    unsafe extern "C" fn english_resolve(
+        _ctx: *const c_void,
+        _wallet_id_bytes: *const u8,
+        out_buf: *mut c_char,
+        out_capacity: usize,
+        out_len: *mut usize,
+    ) -> i32 {
+        let phrase = ENGLISH_PHRASE.as_bytes();
+        if phrase.len() + 1 > out_capacity {
+            return mnemonic_resolver_result::BUFFER_TOO_SMALL;
+        }
+        std::ptr::copy_nonoverlapping(phrase.as_ptr() as *const c_char, out_buf, phrase.len());
+        *out_buf.add(phrase.len()) = 0;
+        *out_len = phrase.len();
+        mnemonic_resolver_result::SUCCESS
+    }
+
+    unsafe extern "C" fn noop_destroy(_ctx: *mut c_void) {}
+
+    fn make_resolver() -> *mut MnemonicResolverHandle {
+        unsafe {
+            dash_sdk_mnemonic_resolver_create(std::ptr::null_mut(), english_resolve, noop_destroy)
+        }
+    }
+
+    /// Happy path: resolver yields a mnemonic whose derived wallet_id
+    /// matches the caller-supplied one; the gate passes and a non-empty
+    /// derived keypair is returned in `out_row`.
+    #[test]
+    fn matching_seed_returns_derived_key() {
+        let resolver = make_resolver();
+        let wallet_id = wallet_id_for_english_phrase();
+        let mut out_row = IdentityKeyPreviewFFI::empty();
+        let rc = unsafe {
+            dash_sdk_derive_identity_key_at_slot_with_resolver(
+                FFINetwork::Testnet,
+                wallet_id.as_ptr(),
+                resolver,
+                5, // identity_index
+                0, // key_index
+                &mut out_row,
+            )
+        };
+        assert_eq!(rc.code, PlatformWalletFFIResultCode::Success);
+        assert_eq!(out_row.identity_index, 5);
+        assert!(!out_row.derivation_path.is_null());
+        assert!(!out_row.public_key.is_null());
+        assert_eq!(out_row.public_key_len, 33, "compressed secp256k1 pubkey");
+        assert!(!out_row.private_key_wif.is_null());
+        // private_key_bytes must be populated (non-all-zero with
+        // overwhelming probability for a real derivation).
+        assert!(
+            out_row.private_key_bytes.iter().any(|b| *b != 0),
+            "derived private scalar should not be all zeros"
+        );
+
+        // Path shape: testnet coin = 1, identity_index = 5, key_index = 0.
+        let path = unsafe { std::ffi::CStr::from_ptr(out_row.derivation_path) }.to_string_lossy();
+        assert_eq!(path, "m/9'/1'/5'/0'/0'/5'/0'");
+
+        unsafe {
+            dash_sdk_derive_identity_key_at_slot_free(&mut out_row);
+            dash_sdk_mnemonic_resolver_destroy(resolver);
+        }
+    }
+
+    /// Wrong-seed gate fires: resolver yields a valid mnemonic but the
+    /// caller-supplied `wallet_id` doesn't match its derived id.
+    /// `out_row` must be left at its zeroed-empty state and no derived
+    /// key material may leak through it.
+    #[test]
+    fn wrong_wallet_id_fails_closed_with_wrong_seed_tag() {
+        let resolver = make_resolver();
+        // A wallet_id that cannot match the abandon-x12 derived id.
+        let wrong_wallet_id = [0xAAu8; 32];
+        let mut out_row = IdentityKeyPreviewFFI::empty();
+        let rc = unsafe {
+            dash_sdk_derive_identity_key_at_slot_with_resolver(
+                FFINetwork::Testnet,
+                wrong_wallet_id.as_ptr(),
+                resolver,
+                0,
+                0,
+                &mut out_row,
+            )
+        };
+        assert_eq!(
+            rc.code,
+            PlatformWalletFFIResultCode::ErrorWrongSeedForWallet,
+            "wrong-seed gate must fire with the dedicated structural tag"
+        );
+        // Caller-owned output struct must be the zero/empty state — no
+        // derivation_path, no pubkey, no WIF, no private scalar bytes.
+        assert!(out_row.derivation_path.is_null());
+        assert!(out_row.public_key.is_null());
+        assert_eq!(out_row.public_key_len, 0);
+        assert!(out_row.private_key_wif.is_null());
+        for b in out_row.private_key_bytes {
+            assert_eq!(b, 0, "private_key_bytes must be fully zeroed");
+        }
+        assert_eq!(out_row.identity_index, 0);
+
+        unsafe {
+            // Defensive: free is null-tolerant on the empty row.
+            dash_sdk_derive_identity_key_at_slot_free(&mut out_row);
+            dash_sdk_mnemonic_resolver_destroy(resolver);
+        }
+    }
 }

--- a/packages/rs-platform-wallet-ffi/src/error.rs
+++ b/packages/rs-platform-wallet-ffi/src/error.rs
@@ -89,6 +89,13 @@ pub enum PlatformWalletFFIResultCode {
     /// receive address, consolidate sub-min balances, or fall back to
     /// `InputSelection::Explicit`.
     ErrorNoSelectableInputs = 14,
+    /// Fail-closed wrong-seed gate hit: the seed yielded by the
+    /// `MnemonicResolverHandle` does not derive the `wallet_id` the
+    /// caller passed in. Surfaced by every resolver-fed sign / derive
+    /// entrypoint. Constant-time compared via
+    /// [`crate::sign_gate::verify_seed_matches_wallet_id`]; no key
+    /// material crosses this surface.
+    ErrorWrongSeedForWallet = 15,
 
     NotFound = 98, // Used exclusively for all the Option that are retuned as errors
     ErrorUnknown = 99,

--- a/packages/rs-platform-wallet-ffi/src/identity_derive_and_persist.rs
+++ b/packages/rs-platform-wallet-ffi/src/identity_derive_and_persist.rs
@@ -91,6 +91,7 @@ use crate::identity_keys_from_mnemonic::{
     identity_auth_derivation_path, parse_mnemonic_any_language,
 };
 use crate::identity_registration_with_signer::IdentityRegistrationKeyDerivationsFFI;
+use crate::sign_gate::verify_seed_matches_wallet_id;
 use crate::{check_ptr, unwrap_result_or_return};
 use rs_sdk_ffi::{
     mnemonic_resolver_result, MnemonicResolverHandle, MNEMONIC_RESOLVER_BUFFER_CAPACITY,
@@ -240,8 +241,22 @@ pub unsafe extern "C" fn dash_sdk_derive_and_persist_identity_keys(
     drop(mnemonic);
 
     let kw_network: Network = network.into();
-    let master = unwrap_result_or_return!(ExtendedPrivKey::new_master(kw_network, seed.as_ref()));
+    let mut master =
+        unwrap_result_or_return!(ExtendedPrivKey::new_master(kw_network, seed.as_ref()));
     let secp = Secp256k1::new();
+
+    // Fail-closed wrong-seed gate (constant-time compare). Zeroize the
+    // master xpriv's SecretKey before bailing on mismatch.
+    let root_xpub = ExtendedPubKey::from_priv(&secp, &master);
+    let mut wallet_id_expected = [0u8; 32];
+    std::ptr::copy_nonoverlapping(wallet_id_bytes, wallet_id_expected.as_mut_ptr(), 32);
+    if !verify_seed_matches_wallet_id(&root_xpub, &wallet_id_expected) {
+        master.private_key.non_secure_erase();
+        return PlatformWalletFFIResult::err(
+            PlatformWalletFFIResultCode::ErrorWrongSeedForWallet,
+            "wrong seed for wallet (derive_and_persist gate)",
+        );
+    }
 
     // ---- Walk derivation paths, persist, build pubkey-only rows --------------
     let persister = &*persister_handle;
@@ -416,6 +431,25 @@ mod tests {
     const ENGLISH_PHRASE: &str =
         "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about";
 
+    /// Compute the `wallet_id` the wrong-seed gate will recompute from
+    /// the resolver-supplied seed. Tests must pass this id (or another
+    /// that derives from the same phrase) — anything else short-circuits
+    /// before persistence with `ErrorWrongSeedForWallet`.
+    fn wallet_id_for_english_phrase() -> [u8; 32] {
+        use key_wallet::wallet::root_extended_keys::RootExtendedPubKey;
+        use key_wallet::wallet::Wallet;
+        let mnemonic = parse_mnemonic_any_language(ENGLISH_PHRASE).unwrap();
+        let seed: Zeroizing<[u8; 64]> = Zeroizing::new(mnemonic.to_seed(""));
+        let mut master =
+            ExtendedPrivKey::new_master(key_wallet::Network::Testnet, seed.as_ref()).unwrap();
+        let secp = Secp256k1::new();
+        let xpub = ExtendedPubKey::from_priv(&secp, &master);
+        let root = RootExtendedPubKey::from_extended_pub_key(&xpub);
+        let id = Wallet::compute_wallet_id_from_root_extended_pub_key(&root);
+        master.private_key.non_secure_erase();
+        id
+    }
+
     #[derive(Debug, Clone)]
     struct CapturedPersist {
         identity_index: u32,
@@ -547,7 +581,7 @@ mod tests {
     #[test]
     fn happy_path_persists_three_keys_and_returns_pubkeys() {
         let (resolver, persister, capture) = make_capturing_handles();
-        let wallet_id = [42u8; 32];
+        let wallet_id = wallet_id_for_english_phrase();
         let mut out = IdentityRegistrationKeyDerivationsFFI {
             items: std::ptr::null_mut(),
             count: 0,
@@ -611,7 +645,7 @@ mod tests {
     #[test]
     fn returning_false_from_persister_aborts_with_wallet_op_error() {
         let (resolver, persister) = make_failing_handles();
-        let wallet_id = [1u8; 32];
+        let wallet_id = wallet_id_for_english_phrase();
         let mut out = IdentityRegistrationKeyDerivationsFFI {
             items: std::ptr::null_mut(),
             count: 0,
@@ -671,6 +705,45 @@ mod tests {
             )
         };
         assert_eq!(rc.code, PlatformWalletFFIResultCode::ErrorNullPointer);
+        unsafe {
+            dash_sdk_mnemonic_resolver_destroy(resolver);
+            dash_sdk_identity_key_persister_destroy(persister);
+            let _ = Box::from_raw(capture);
+        }
+    }
+
+    #[test]
+    fn wrong_wallet_id_fails_closed_before_persisting_anything() {
+        let (resolver, persister, capture) = make_capturing_handles();
+        // A wallet_id that cannot match the abandon-x12 derived id.
+        let wrong_wallet_id = [0xAAu8; 32];
+        let mut out = IdentityRegistrationKeyDerivationsFFI {
+            items: std::ptr::null_mut(),
+            count: 0,
+        };
+        let rc = unsafe {
+            dash_sdk_derive_and_persist_identity_keys(
+                FFINetwork::Testnet,
+                wrong_wallet_id.as_ptr(),
+                0,
+                3,
+                resolver,
+                persister,
+                &mut out,
+            )
+        };
+        assert_eq!(
+            rc.code,
+            PlatformWalletFFIResultCode::ErrorWrongSeedForWallet
+        );
+        assert_eq!(out.count, 0);
+        assert!(out.items.is_null());
+        // The persister callback must NOT have been hit.
+        assert_eq!(
+            unsafe { (*capture).rows.lock().unwrap().len() },
+            0,
+            "wrong-seed gate must short-circuit before any key is persisted"
+        );
         unsafe {
             dash_sdk_mnemonic_resolver_destroy(resolver);
             dash_sdk_identity_key_persister_destroy(persister);

--- a/packages/rs-platform-wallet-ffi/src/lib.rs
+++ b/packages/rs-platform-wallet-ffi/src/lib.rs
@@ -59,6 +59,7 @@ pub mod shielded_send;
 #[cfg(feature = "shielded")]
 pub mod shielded_sync;
 pub mod shielded_types;
+pub mod sign_gate;
 pub mod sign_with_mnemonic_resolver;
 pub mod spv;
 pub mod token_persistence;

--- a/packages/rs-platform-wallet-ffi/src/shielded_sync.rs
+++ b/packages/rs-platform-wallet-ffi/src/shielded_sync.rs
@@ -22,7 +22,11 @@ use crate::handle::*;
 use crate::identity_keys_from_mnemonic::parse_mnemonic_any_language;
 use crate::runtime::runtime;
 use crate::shielded_types::ShieldedSyncWalletResultFFI;
+use crate::sign_gate::verify_seed_matches_wallet_id;
+use crate::types::Network;
 use crate::{check_ptr, unwrap_option_or_return};
+use dashcore::secp256k1::Secp256k1;
+use key_wallet::bip32::{ExtendedPrivKey, ExtendedPubKey};
 use rs_sdk_ffi::{
     mnemonic_resolver_result, MnemonicResolverHandle, MNEMONIC_RESOLVER_BUFFER_CAPACITY,
 };
@@ -302,6 +306,33 @@ pub unsafe extern "C" fn platform_wallet_manager_bind_shielded(
     let seed: Zeroizing<[u8; 64]> = Zeroizing::new(mnemonic.to_seed(""));
     drop(mnemonic);
 
+    // Fail-closed wrong-seed gate (constant-time compare). Runs before
+    // any signing material is materialized downstream. The wallet_id
+    // is independent of `kw_network` here (it hashes only pubkey +
+    // chain code), so any network is acceptable for the throwaway
+    // master used to project the root xpub.
+    {
+        let mut gate_master = match ExtendedPrivKey::new_master(Network::Testnet, seed.as_ref()) {
+            Ok(m) => m,
+            Err(e) => {
+                return PlatformWalletFFIResult::err(
+                    PlatformWalletFFIResultCode::ErrorWalletOperation,
+                    format!("derive gate-master failed: {e}"),
+                );
+            }
+        };
+        let secp = Secp256k1::new();
+        let root_xpub = ExtendedPubKey::from_priv(&secp, &gate_master);
+        let gate_ok = verify_seed_matches_wallet_id(&root_xpub, &wallet_id);
+        gate_master.private_key.non_secure_erase();
+        if !gate_ok {
+            return PlatformWalletFFIResult::err(
+                PlatformWalletFFIResultCode::ErrorWrongSeedForWallet,
+                "wrong seed for wallet (bind_shielded gate)",
+            );
+        }
+    }
+
     // Look up the wallet + the network-scoped shielded coordinator
     // on the manager. The coordinator owns the single SQLite handle
     // *and* the per-network sync-coordination registry; we hand it
@@ -546,5 +577,127 @@ pub unsafe extern "C" fn platform_wallet_manager_shielded_sync_wallet(
             PlatformWalletFFIResultCode::ErrorWalletOperation,
             format!("shielded sync failed: {e}"),
         ),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::handle::NULL_HANDLE;
+    use key_wallet::wallet::root_extended_keys::RootExtendedPubKey;
+    use key_wallet::wallet::Wallet;
+    use rs_sdk_ffi::{dash_sdk_mnemonic_resolver_create, dash_sdk_mnemonic_resolver_destroy};
+
+    /// English BIP-39 test vector (all-zero entropy). Matches the
+    /// sibling resolver-fed entrypoints' fixture.
+    const ENGLISH_PHRASE: &str =
+        "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about";
+
+    /// `wallet_id` the gate will recompute from the resolver-supplied
+    /// seed. Anything but this id short-circuits with
+    /// `ErrorWrongSeedForWallet` before any manager / coordinator
+    /// state is touched.
+    #[allow(dead_code)] // referenced by future happy-path coverage; see module note below.
+    fn wallet_id_for_english_phrase() -> [u8; 32] {
+        use crate::identity_keys_from_mnemonic::parse_mnemonic_any_language;
+        let mnemonic = parse_mnemonic_any_language(ENGLISH_PHRASE).unwrap();
+        let seed: Zeroizing<[u8; 64]> = Zeroizing::new(mnemonic.to_seed(""));
+        let mut master =
+            ExtendedPrivKey::new_master(key_wallet::Network::Testnet, seed.as_ref()).unwrap();
+        let secp = Secp256k1::new();
+        let xpub = ExtendedPubKey::from_priv(&secp, &master);
+        let root = RootExtendedPubKey::from_extended_pub_key(&xpub);
+        let id = Wallet::compute_wallet_id_from_root_extended_pub_key(&root);
+        master.private_key.non_secure_erase();
+        id
+    }
+
+    unsafe extern "C" fn english_resolve(
+        _ctx: *const std::os::raw::c_void,
+        _wallet_id_bytes: *const u8,
+        out_buf: *mut c_char,
+        out_capacity: usize,
+        out_len: *mut usize,
+    ) -> i32 {
+        let phrase = ENGLISH_PHRASE.as_bytes();
+        if phrase.len() + 1 > out_capacity {
+            return mnemonic_resolver_result::BUFFER_TOO_SMALL;
+        }
+        std::ptr::copy_nonoverlapping(phrase.as_ptr() as *const c_char, out_buf, phrase.len());
+        *out_buf.add(phrase.len()) = 0;
+        *out_len = phrase.len();
+        mnemonic_resolver_result::SUCCESS
+    }
+
+    unsafe extern "C" fn noop_destroy(_ctx: *mut std::os::raw::c_void) {}
+
+    fn make_resolver() -> *mut MnemonicResolverHandle {
+        unsafe {
+            dash_sdk_mnemonic_resolver_create(std::ptr::null_mut(), english_resolve, noop_destroy)
+        }
+    }
+
+    /// Wrong-seed gate fires before the manager handle is dereferenced.
+    /// The resolver yields a valid mnemonic but the caller-supplied
+    /// `wallet_id` doesn't match its derived id, so:
+    ///
+    /// (a) the FFI returns `ErrorWrongSeedForWallet`,
+    /// (b) `NULL_HANDLE` is never consulted on `PLATFORM_WALLET_MANAGER_STORAGE`
+    ///     — proves no shielded state can be bound on a mismatch,
+    /// (c) the `gate_master` xpriv inside the gate scope is
+    ///     `non_secure_erase`d before the early return (verified by the
+    ///     gate code path itself; this test exercises that path).
+    ///
+    /// **Happy path note**: `bind_shielded`'s happy path requires a
+    /// fully-constructed `PlatformWalletManager` (Sdk, persistence
+    /// vtable, event handler), a prior `configure_shielded` (SQLite
+    /// commitment-tree file open), and a registered wallet whose id
+    /// matches the gate. All three pieces are heavy infra to stand
+    /// up from a single unit test and would duplicate coverage that
+    /// already lives in `platform-wallet`'s shielded integration
+    /// suite. Per Marvin's directive (test the gate's effect in
+    /// isolation), we exercise the mismatch path only here — the
+    /// resolver-derived seed never reaches the coordinator, the
+    /// caller sees the canonical structural tag, and the manager
+    /// storage is never touched.
+    #[test]
+    fn wrong_wallet_id_fails_closed() {
+        let resolver = make_resolver();
+        let wrong_wallet_id = [0xAAu8; 32];
+        let accounts: [u32; 1] = [0];
+        let rc = unsafe {
+            platform_wallet_manager_bind_shielded(
+                NULL_HANDLE,
+                wrong_wallet_id.as_ptr(),
+                resolver,
+                accounts.as_ptr(),
+                accounts.len(),
+            )
+        };
+        assert_eq!(
+            rc.code,
+            PlatformWalletFFIResultCode::ErrorWrongSeedForWallet,
+            "wrong-seed gate must short-circuit before the manager lookup"
+        );
+        unsafe { dash_sdk_mnemonic_resolver_destroy(resolver) };
+    }
+
+    /// Defensive: a NULL resolver handle must be rejected before the
+    /// resolver callback is ever fired and before the gate runs.
+    /// Locks in `check_ptr!` ordering for the bind_shielded entrypoint.
+    #[test]
+    fn null_resolver_handle_rejected() {
+        let wallet_id = [0xAAu8; 32];
+        let accounts: [u32; 1] = [0];
+        let rc = unsafe {
+            platform_wallet_manager_bind_shielded(
+                NULL_HANDLE,
+                wallet_id.as_ptr(),
+                std::ptr::null_mut(),
+                accounts.as_ptr(),
+                accounts.len(),
+            )
+        };
+        assert_eq!(rc.code, PlatformWalletFFIResultCode::ErrorNullPointer);
     }
 }

--- a/packages/rs-platform-wallet-ffi/src/sign_gate.rs
+++ b/packages/rs-platform-wallet-ffi/src/sign_gate.rs
@@ -1,0 +1,75 @@
+//! Shared fail-closed `wallet_id` gate for resolver-fed sign entrypoints.
+//!
+//! Every FFI entrypoint that takes a `MnemonicResolverHandle` plus an
+//! `expected wallet_id` and derives signing keys from the resolved
+//! mnemonic MUST run the gate immediately after deriving the root
+//! extended public key, *before* it touches `derive_priv` (and well
+//! before any signature material is emitted).
+//!
+//! The gate constant-time compares the loaded `wallet_id` against the
+//! one recomputed from the resolver-supplied root extended public key.
+//! On mismatch it returns the structural failure tag the caller hands
+//! to its error path — no rendered hex, no key bytes.
+//!
+//! This is the fail-closed counterpart to the seedless load path:
+//! `load_from_persistor` reconstructs each persisted wallet
+//! **watch-only** (no derivation, no gate); wrong-seed detection moves
+//! here, where the gate is meaningful (the resolver actually produced
+//! signing material).
+
+use key_wallet::bip32::ExtendedPubKey;
+use key_wallet::wallet::root_extended_keys::RootExtendedPubKey;
+use key_wallet::wallet::Wallet;
+use subtle::ConstantTimeEq;
+
+/// Recompute `wallet_id` from the supplied root extended public key and
+/// constant-time compare against `expected_wallet_id`.
+///
+/// Returns `true` on match, `false` on mismatch. The boolean is
+/// intentionally information-free beyond the verdict: the caller maps
+/// `false` onto its own structural failure tag
+/// (`SIGN_WITH_RESOLVER_ERR_WRONG_SEED` and friends). No key material
+/// crosses this surface in either direction.
+#[inline]
+#[must_use]
+pub fn verify_seed_matches_wallet_id(
+    root_pub: &ExtendedPubKey,
+    expected_wallet_id: &[u8; 32],
+) -> bool {
+    let root_extended = RootExtendedPubKey::from_extended_pub_key(root_pub);
+    let derived = Wallet::compute_wallet_id_from_root_extended_pub_key(&root_extended);
+    bool::from(derived.ct_eq(expected_wallet_id))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use dashcore::secp256k1::Secp256k1;
+    use key_wallet::bip32::ExtendedPrivKey;
+
+    fn root_xpub_for_seed(seed: &[u8; 64]) -> (ExtendedPubKey, [u8; 32]) {
+        let master =
+            ExtendedPrivKey::new_master(key_wallet::Network::Testnet, seed.as_ref()).unwrap();
+        let secp = Secp256k1::new();
+        let xpub = ExtendedPubKey::from_priv(&secp, &master);
+        let root = RootExtendedPubKey::from_extended_pub_key(&xpub);
+        let wid = Wallet::compute_wallet_id_from_root_extended_pub_key(&root);
+        (xpub, wid)
+    }
+
+    #[test]
+    fn matching_seed_passes() {
+        let seed = [0x11; 64];
+        let (xpub, wid) = root_xpub_for_seed(&seed);
+        assert!(verify_seed_matches_wallet_id(&xpub, &wid));
+    }
+
+    #[test]
+    fn mismatched_seed_fails() {
+        let seed_a = [0x11; 64];
+        let seed_b = [0x22; 64];
+        let (xpub_a, _) = root_xpub_for_seed(&seed_a);
+        let (_, wid_b) = root_xpub_for_seed(&seed_b);
+        assert!(!verify_seed_matches_wallet_id(&xpub_a, &wid_b));
+    }
+}

--- a/packages/rs-platform-wallet-ffi/src/sign_with_mnemonic_resolver.rs
+++ b/packages/rs-platform-wallet-ffi/src/sign_with_mnemonic_resolver.rs
@@ -42,10 +42,11 @@ use std::str::FromStr;
 
 use crate::types::{FFINetwork, Network};
 use dashcore::secp256k1::Secp256k1;
-use key_wallet::bip32::{DerivationPath, ExtendedPrivKey};
+use key_wallet::bip32::{DerivationPath, ExtendedPrivKey, ExtendedPubKey};
 use zeroize::Zeroizing;
 
 use crate::identity_keys_from_mnemonic::parse_mnemonic_any_language;
+use crate::sign_gate::verify_seed_matches_wallet_id;
 use rs_sdk_ffi::{
     mnemonic_resolver_result, MnemonicResolverHandle, MNEMONIC_RESOLVER_BUFFER_CAPACITY,
 };
@@ -67,6 +68,10 @@ pub const SIGN_WITH_RESOLVER_ERR_UNSUPPORTED_KEY_TYPE: u8 = 8;
 pub const SIGN_WITH_RESOLVER_ERR_RESOLVER_NOT_FOUND: u8 = 9;
 /// Resolver callback returned `mnemonic_resolver_result::OTHER`.
 pub const SIGN_WITH_RESOLVER_ERR_RESOLVER_FAILED: u8 = 10;
+/// The seed yielded by the resolver does NOT derive the
+/// `wallet_id_bytes` passed by the caller. Fail-closed wrong-seed
+/// gate (constant-time compare). No key material crosses this surface.
+pub const SIGN_WITH_RESOLVER_ERR_WRONG_SEED: u8 = 11;
 
 /// Sign `data` with the ECDSA secp256k1 private key derived from
 /// `(mnemonic-via-resolver, derivation_path)`. Mnemonic, seed and
@@ -205,6 +210,19 @@ pub unsafe extern "C" fn dash_sdk_sign_with_mnemonic_resolver_and_path(
         Err(_) => return fail(SIGN_WITH_RESOLVER_ERR_DERIVATION),
     };
     let secp = Secp256k1::new();
+
+    // Fail-closed wrong-seed gate (constant-time compare). The seedless
+    // load path no longer runs this gate at load time; it lives here,
+    // on the first sign call that the resolver-supplied seed actually
+    // feeds into a derivation. Zeroize derived material before bailing.
+    let root_xpub = ExtendedPubKey::from_priv(&secp, &master);
+    let mut wallet_id_expected = [0u8; 32];
+    std::ptr::copy_nonoverlapping(wallet_id_bytes, wallet_id_expected.as_mut_ptr(), 32);
+    if !verify_seed_matches_wallet_id(&root_xpub, &wallet_id_expected) {
+        master.private_key.non_secure_erase();
+        return fail(SIGN_WITH_RESOLVER_ERR_WRONG_SEED);
+    }
+
     let mut derived = match master.derive_priv(&secp, &path) {
         Ok(d) => d,
         Err(_) => return fail(SIGN_WITH_RESOLVER_ERR_DERIVATION),
@@ -248,12 +266,29 @@ pub unsafe extern "C" fn dash_sdk_sign_with_mnemonic_resolver_and_path(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use key_wallet::wallet::root_extended_keys::RootExtendedPubKey;
+    use key_wallet::wallet::Wallet;
     use rs_sdk_ffi::{dash_sdk_mnemonic_resolver_create, dash_sdk_mnemonic_resolver_destroy};
     use std::ffi::CString;
 
     /// English BIP-39 test vector (all-zero entropy).
     const ENGLISH_PHRASE: &str =
         "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about";
+
+    /// Recompute the loaded `wallet_id` the resolver-derived seed will be
+    /// gated against in the happy-path test.
+    fn wallet_id_for_english_phrase() -> [u8; 32] {
+        let mnemonic = parse_mnemonic_any_language(ENGLISH_PHRASE).unwrap();
+        let seed: Zeroizing<[u8; 64]> = Zeroizing::new(mnemonic.to_seed(""));
+        let mut master =
+            ExtendedPrivKey::new_master(key_wallet::Network::Testnet, seed.as_ref()).unwrap();
+        let secp = Secp256k1::new();
+        let xpub = ExtendedPubKey::from_priv(&secp, &master);
+        let root = RootExtendedPubKey::from_extended_pub_key(&xpub);
+        let id = Wallet::compute_wallet_id_from_root_extended_pub_key(&root);
+        master.private_key.non_secure_erase();
+        id
+    }
 
     unsafe extern "C" fn english_resolve(
         _ctx: *const c_void,
@@ -292,7 +327,7 @@ mod tests {
     fn happy_path_signs_and_returns_signature() {
         let resolver = make_resolver(english_resolve);
         let path = CString::new("m/9'/1'/5'/0'/0'/0'/0'").unwrap();
-        let wallet_id = [0u8; 32];
+        let wallet_id = wallet_id_for_english_phrase();
         let data = b"hello";
         let mut sig_buf = [0u8; 128];
         let mut sig_len: usize = 0;
@@ -349,11 +384,49 @@ mod tests {
         unsafe { dash_sdk_mnemonic_resolver_destroy(resolver) };
     }
 
+    /// Resolver yields a valid mnemonic but the loaded `wallet_id`
+    /// doesn't match its derived id: the wrong-seed gate must fire,
+    /// `out_signature_len = 0`, no bytes in `out_signature`.
+    #[test]
+    fn wrong_wallet_id_fails_closed_with_wrong_seed_tag() {
+        let resolver = make_resolver(english_resolve);
+        let path = CString::new("m/9'/1'/5'/0'/0'/0'/0'").unwrap();
+        // A wallet_id derived from a different seed (here: just a
+        // sentinel that cannot equal the abandon-x12 wallet_id).
+        let wrong_wallet_id = [0xAAu8; 32];
+        let data = b"x";
+        let mut sig_buf = [0xFFu8; 128];
+        let mut sig_len: usize = 1;
+        let mut err: u8 = 0;
+        let rc = unsafe {
+            dash_sdk_sign_with_mnemonic_resolver_and_path(
+                resolver,
+                wrong_wallet_id.as_ptr(),
+                path.as_ptr(),
+                data.as_ptr(),
+                data.len(),
+                0,
+                FFINetwork::Testnet,
+                sig_buf.as_mut_ptr(),
+                sig_buf.len(),
+                &mut sig_len,
+                &mut err,
+            )
+        };
+        assert_eq!(rc, -1);
+        assert_eq!(err, SIGN_WITH_RESOLVER_ERR_WRONG_SEED);
+        assert_eq!(sig_len, 0, "no signature length must be reported");
+        for b in sig_buf {
+            assert_eq!(b, 0, "out_signature buffer must be fully zeroed");
+        }
+        unsafe { dash_sdk_mnemonic_resolver_destroy(resolver) };
+    }
+
     #[test]
     fn rejects_unsupported_key_type() {
         let resolver = make_resolver(english_resolve);
         let path = CString::new("m/9'/1'/5'/0'/0'/0'/0'").unwrap();
-        let wallet_id = [0u8; 32];
+        let wallet_id = wallet_id_for_english_phrase();
         let data = b"x";
         let mut sig_buf = [0u8; 128];
         let mut sig_len: usize = 0;


### PR DESCRIPTION

## Why this PR exists

**The gap:** Four FFI entrypoints in `rs-platform-wallet-ffi` accept a `MnemonicResolverHandle` plus a caller-supplied `wallet_id_bytes`. None of them verifies the resolver-returned mnemonic actually corresponds to that `wallet_id`. The resolver is host-controlled opaque state — there is no in-process cross-check.

**Threat scenario:** A host (Swift/iOS or any FFI consumer) calls one of these entrypoints with `wallet_id = W_A`, but the registered resolver — whether by host wiring bug, compromised resolver, or malicious resolver — returns the mnemonic for wallet `W_B`. Before this PR, all four entrypoints silently derive from W_B and proceed.

**Per-site impact (with the gate removed) — confirmed by code audit:**

| Entrypoint | Downstream detection | Worst-case state on wrong-seed | Test demonstrating the gate |
|---|---|---|---|
| `sign_with_mnemonic_resolver_and_path` | External only (Platform `InvalidSignature` on submit, or L1 mempool reject on asset-lock TX) | Wrong-key 65-byte sig returned with `rc = 0`; caller ships it to the network; failure surfaces only after round-trip | `sign_with_mnemonic_resolver::tests::wrong_wallet_id_fails_closed_with_wrong_seed_tag` |
| `derive_and_persist_identity_keys` | **NONE** | Persister callback writes Keychain rows tagged `wallet_id = W_A` but holding W_B's pubkey/privkey/path. Subsequent registration succeeds with internally-consistent W_B keys, creating an identity W_A's seed cannot sign for. **Irrecoverable without manual Keychain surgery.** | `identity_derive_and_persist::tests::wrong_wallet_id_fails_closed_before_persisting_anything` |
| `derive_identity_key_at_slot_with_resolver` | NONE inside FFI | 32-byte W_B private scalar + WIF crosses the FFI boundary with `rc = Success`; caller uses it freely | `derive_identity_key_at_slot::tests::wrong_wallet_id_fails_closed_with_wrong_seed_tag` |
| `platform_wallet_manager_bind_shielded` (shielded feature) | **NONE** — `PlatformWallet::bind_shielded` (`platform_wallet.rs:338-427`) uses `self.wallet_id` and the caller-supplied seed with zero cross-check | W_B's Orchard FVK/IVK/OVK durably installed under `SubwalletId { wallet_id: W_A }`. Sync flushes W_B's notes into W_A's persister rows; spend paths can authorize W_B's notes under W_A. **Cross-wallet fund visibility and spend leakage.** | `shielded_sync::tests::wrong_wallet_id_fails_closed` (requires `--features shielded`) |

Note that `rs-platform-wallet` itself does not catch this: pure-Rust callers instantiate `Wallet` objects whose `wallet_id` is derived from their own root — the mismatch is unreachable from Rust. The vulnerability is exclusively expressible across the FFI trust boundary, which is why the gate lives in `rs-platform-wallet-ffi`.

Each row's test fails on `v3.1-dev` without this PR's gate and passes once the gate is applied — verified locally against the rebased commit.

**Prerequisite/blocking relationship:** This PR is the logical prerequisite for PR #3692 (seedless watch-only rehydration), which removes the existing load-time wrong-seed gate in `rs-platform-wallet`. Without #3735 landing first, #3692 would briefly create a window where any seed could sign for any `wallet_id`. Decoupled here so the security fix ships to `v3.1-dev` on its own merits.

## Issue being fixed or feature implemented

Four FFI sign entrypoints in `rs-platform-wallet-ffi` take a `MnemonicResolverHandle` plus a `wallet_id_bytes` arg and derive signing material from the mnemonic the resolver returns. **None of them previously checked that the seed actually belongs to that wallet_id.** A host that called any of them with a mismatched `(wallet_id, mnemonic)` pair — whether by host bug or by a malicious resolver — would happily derive and sign with the wrong key.

This patch closes that gap.

It also unblocks the seedless-load model in PR #3692: that PR removes a load-time wrong-seed gate, so the sign-time gate has to exist before that change can land without regressing wrong-seed protection. Decoupled here so the security fix can ship to `v3.1-dev` on its own merits, ahead of the rehydration model rework.

## What was done?

### New helper: `crate::sign_gate::verify_seed_matches_wallet_id`

`packages/rs-platform-wallet-ffi/src/sign_gate.rs` (new):

```rust
#[inline]
#[must_use]
pub fn verify_seed_matches_wallet_id(
    root_pub: &ExtendedPubKey,
    expected_wallet_id: &[u8; 32],
) -> bool {
    let root_extended = RootExtendedPubKey::from_extended_pub_key(root_pub);
    let derived = Wallet::compute_wallet_id_from_root_extended_pub_key(&root_extended);
    bool::from(derived.ct_eq(expected_wallet_id))
}
```

- **Constant-time** comparison via `subtle::ConstantTimeEq` — no early-return on byte mismatch.
- **`#[must_use]`** so a caller can't silently drop the verdict.
- Operates on the public half of the root extended key — no private material flows into the comparator.
- New dep: `subtle = "2"` (well-known constant-time-comparison crate, single line added to `Cargo.lock`, no transitive bumps).

### New result code: `ErrorWrongSeedForWallet = 15`

`PlatformWalletFFIResultCode::ErrorWrongSeedForWallet = 15` in `error.rs`. Newly allocated slot 15. Slot 13 is taken by `ErrorArithmeticOverflow` (#3549), slot 14 by `ErrorNoSelectableInputs`; 15 was the smallest free integer.

For the byte-tagged `sign_with_mnemonic_resolver_and_path` path, a new u8 tag `SIGN_WITH_RESOLVER_ERR_WRONG_SEED = 11` is also added in that module.

### Gate wired into 4 entrypoints

| Entrypoint | File | Gate location |
|---|---|---|
| `dash_sdk_sign_with_mnemonic_resolver_and_path` | `sign_with_mnemonic_resolver.rs` | After master derivation, before `derive_priv` |
| `dash_sdk_derive_and_persist_identity_keys` | `identity_derive_and_persist.rs` | Before persister callback ever fires |
| `dash_sdk_derive_identity_key_at_slot_with_resolver` | `derive_identity_key_at_slot.rs` | Before `derive_at_slot_inner` |
| `platform_wallet_manager_bind_shielded` (`shielded` feature) | `shielded_sync.rs` | Before `PLATFORM_WALLET_MANAGER_STORAGE` touch |

At each site, on a mismatch:
- `master.private_key.non_secure_erase()` — derived master xpriv zeroed
- Caller-owned output buffer wiped (`sig_buf` zeroed via `ptr::write_bytes`; `out_row` left at `IdentityKeyPreviewFFI::empty()`; `*out_signature_len = 0`)
- Typed error returned (`ErrorWrongSeedForWallet` for structured paths, `SIGN_WITH_RESOLVER_ERR_WRONG_SEED` for the u8-tagged path)
- Persister callback / coordinator handoff never reached

Two of the four sites (`derive_identity_key_at_slot`, `shielded_sync`) `non_secure_erase` the gate-master unconditionally — defense in depth, since the gate-master is throwaway whether the verdict is true or false. The other two keep the master alive past the gate because the same master is then used for `derive_priv` and is erased downstream via the existing pattern.

## How Has This Been Tested?

```bash
cargo fmt --all -- --check
cargo clippy -p platform-wallet-ffi --all-targets -- -D warnings
cargo clippy -p platform-wallet-ffi --all-targets --features shielded -- -D warnings
cargo check --workspace
cargo test -p platform-wallet-ffi
cargo test -p platform-wallet-ffi --features shielded shielded_sync
cargo test -p platform-wallet           # workspace regression sanity
```

All green. **83 unit + 26 comprehensive + 5 integration tests pass**; 132 platform-wallet tests still pass; new gate tests included:

| Test | Asserts |
|---|---|
| `sign_gate::tests::matching_seed_passes` | CT comparator returns true on matching seed |
| `sign_gate::tests::mismatched_seed_fails` | CT comparator returns false on distinct seeds |
| `sign_with_mnemonic_resolver::tests::happy_path_signs_and_returns_signature` | `sig_len == 65` (compact-recoverable secp256k1) |
| `sign_with_mnemonic_resolver::tests::wrong_wallet_id_fails_closed_with_wrong_seed_tag` | rc=-1, tag=11, `sig_len==0`, every byte of 128-byte `sig_buf` is zero |
| `identity_derive_and_persist::tests::happy_path_persists_three_keys_and_returns_pubkeys` | gate doesn't false-positive on matching seed |
| `identity_derive_and_persist::tests::wrong_wallet_id_fails_closed_before_persisting_anything` | code=`ErrorWrongSeedForWallet`, `out.count==0`, `out.items.is_null()`, persister callback row count is zero |
| `derive_identity_key_at_slot::tests::matching_seed_returns_derived_key` | DIP-9 path, 33-byte pubkey, non-null WIF, non-zero private scalar |
| `derive_identity_key_at_slot::tests::wrong_wallet_id_fails_closed_with_wrong_seed_tag` | all output fields null/zero, every byte of `private_key_bytes` is zero |
| `shielded_sync::tests::wrong_wallet_id_fails_closed` | code=`ErrorWrongSeedForWallet` via `NULL_HANDLE` — gate short-circuits before manager-storage touch |
| `shielded_sync::tests::null_resolver_handle_rejected` | `check_ptr!` ordering locked in |

Every wrong-seed test asserts on **substance** — typed tag + output-buffer state + side-effect counters — not "did the function run".

## Breaking Changes

None for shipped consumers. The change is purely additive:
- New helper module (does not modify existing public APIs).
- New result code variant at a previously unoccupied enum slot.
- Gate insertions return new error tags only on the wrong-seed mismatch path — flows with correct `(wallet_id, mnemonic)` pairs behave identically to before.

No `!` in the title.

## Security note

This patch is logically the prerequisite for PR #3692 (seedless watch-only rehydration), which removes a load-time wrong-seed gate. Without this PR landed first, #3692 would briefly create a window where the same wallet_id could be signed by any seed. Once this lands, the merge-up cycle (`v3.1-dev → #3625 → #3672 → #3692`) will dedupe the duplicate sign-gate commits sitting on #3692 naturally — no force-push to that PR needed.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [x] I have made corresponding changes to the documentation if needed

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone

---

<sub>🤖 Co-authored by [Claudius the Magnificent](https://github.com/lklimek/claudius) AI Agent</sub>
