### PR TITLE
fix(platform-wallet): fix spv client deadlocking himself when trying to stop

### DIFF
--- a/packages/rs-platform-wallet/src/spv/runtime.rs
+++ b/packages/rs-platform-wallet/src/spv/runtime.rs
@@ -138,14 +138,15 @@ impl SpvRuntime {
         let client_guard = self.client.read().await;
         let client = client_guard
             .as_ref()
-            .ok_or(PlatformWalletError::SpvNotRunning)?;
+            .ok_or(PlatformWalletError::SpvNotRunning)?
+            .clone();
+        drop(client_guard);
 
         let result = client
             .run()
             .await
             .map_err(|e| PlatformWalletError::SpvError(e.to_string()));
 
-        drop(client_guard);
         let mut client = self.client.write().await;
         let _ = client.take();
 


### PR DESCRIPTION
The run method in the spa client wrapper was holding a read() lock over the inner spv client while the client was running, and stop tried to take a write() lock, what I do in this PR is clonning the Client, Client fields are Arc so we preserve reference to the same memory space.

Other way to solve the issue would be to take a read() lock on stop, and stop the client, then run() would continue and take a write() lock to replace de Some with a None, maybe it sounds like Chinese without having the code in front but yeah, two ways to solve it and I went with the one its the easiest to read and understand. Anyway, I am trying to refactor the SpvClient usage in platform wallet but first I need my integrations tests to get in so I can make sure I don't make any regression

Closes https://github.com/dashpay/platform/issues/3741

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [ ] I have made corresponding changes to the documentation if needed

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved SPV wallet runtime client handling to enhance resource management efficiency.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dashpay/platform/pull/3742?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->