### PR TITLE
fix(swift-sdk): sort transfer outputs lexicographically before ReduceOutput

### DIFF
--- a/packages/swift-sdk/Sources/SwiftDashSDK/PlatformWallet/ManagedPlatformAddressWallet.swift
+++ b/packages/swift-sdk/Sources/SwiftDashSDK/PlatformWallet/ManagedPlatformAddressWallet.swift
@@ -262,40 +262,15 @@ public final class ManagedPlatformAddressWallet: @unchecked Sendable {
             )
         }
 
-        // Marshal recipient outputs.
-        var ffiOutputs: [AddressBalanceEntryFFI] = []
-        ffiOutputs.reserveCapacity(outputs.count + 1)
-        for out in outputs {
-            let outTuple = Self.hashTuple(from: out.hash)
-            ffiOutputs.append(
-                AddressBalanceEntryFFI(
-                    address: PlatformAddressFFI(address_type: out.addressType, hash: outTuple),
-                    balance: out.credits,
-                    nonce: 0,
-                    account_index: 0,
-                    address_index: 0
-                )
-            )
-        }
-
-        // Append the change output to the resolved change address —
-        // guaranteed to be distinct from every input and recipient
-        // (the protocol rejects outputs that also appear as inputs).
+        // Build the FFI output list in the same lexicographic order Rust's
+        // BTreeMap<PlatformAddress, _> canonicalizes to, so the fee-reduction
+        // index we hand it lines up with the row Rust will actually decrement.
         let changeAmount = totalInputs - totalRecipientCredits
-        let changeTuple = Self.hashTuple(from: resolvedChange.hash)
-        ffiOutputs.append(
-            AddressBalanceEntryFFI(
-                address: PlatformAddressFFI(address_type: resolvedChange.addressType, hash: changeTuple),
-                balance: changeAmount,
-                nonce: 0,
-                account_index: 0,
-                address_index: 0
-            )
+        let (ffiOutputs, changeIndex) = Self.buildSortedFFIOutputs(
+            recipients: outputs,
+            change: (resolvedChange.addressType, resolvedChange.hash, changeAmount)
         )
 
-        // Fee strategy: take the fee out of the change output (last index)
-        // so recipients get their requested amounts unchanged.
-        let changeIndex = UInt16(ffiOutputs.count - 1)
         let feeStrategy: [FeeStrategyStepFFI] = [
             FeeStrategyStepFFI(step_type: 1, index: changeIndex)  // 1 = ReduceOutput
         ]
@@ -351,6 +326,46 @@ public final class ManagedPlatformAddressWallet: @unchecked Sendable {
                 )
             }
         }.value
+    }
+
+    /// Build the FFI output array (recipients + change) in the same
+    /// lexicographic order Rust's `BTreeMap<PlatformAddress, _>` uses, and
+    /// return the change row's index in that sorted list.
+    ///
+    /// Mirrors `derive(Ord)` on
+    /// `enum PlatformAddress { P2pkh([u8;20]), P2sh([u8;20]) }`: variant
+    /// discriminant first (`P2pkh = 0 < P2sh = 1`), then 20-byte hash
+    /// compared lexicographically. Load-bearing because
+    /// `FeeStrategyStep::ReduceOutput(N)` on the Rust side indexes the
+    /// post-canonicalization output list — not Swift's insertion order.
+    /// See https://github.com/dashpay/platform/issues/3738.
+    internal static func buildSortedFFIOutputs(
+        recipients: [TransferOutput],
+        change: (addressType: UInt8, hash: Data, balance: UInt64)
+    ) -> (rows: [AddressBalanceEntryFFI], changeIndex: UInt16) {
+        var rows: [(addressType: UInt8, hash: Data, balance: UInt64)] =
+            recipients.map { (addressType: $0.addressType, hash: $0.hash, balance: $0.credits) }
+        rows.append(change)
+        rows.sort { a, b in
+            if a.addressType != b.addressType { return a.addressType < b.addressType }
+            return a.hash.lexicographicallyPrecedes(b.hash)
+        }
+        let changeIdx = UInt16(rows.firstIndex {
+            $0.addressType == change.addressType && $0.hash == change.hash
+        }!)
+        let ffiRows = rows.map { row in
+            AddressBalanceEntryFFI(
+                address: PlatformAddressFFI(
+                    address_type: row.addressType,
+                    hash: hashTuple(from: row.hash)
+                ),
+                balance: row.balance,
+                nonce: 0,
+                account_index: 0,
+                address_index: 0
+            )
+        }
+        return (ffiRows, changeIdx)
     }
 
     /// Copy a 20-byte `Data` into the fixed-size tuple shape the FFI expects.

--- a/packages/swift-sdk/SwiftExampleApp/SwiftExampleAppTests/ManagedPlatformAddressWalletTests.swift
+++ b/packages/swift-sdk/SwiftExampleApp/SwiftExampleAppTests/ManagedPlatformAddressWalletTests.swift
@@ -1,0 +1,82 @@
+import XCTest
+@testable import SwiftDashSDK
+
+final class ManagedPlatformAddressWalletTests: XCTestCase {
+
+    /// Convert the FFI's 20-byte tuple back to Data for assertion.
+    private func hashData(_ entry: AddressBalanceEntryFFI) -> Data {
+        withUnsafeBytes(of: entry.address.hash) { Data($0) }
+    }
+
+    // Pre-fix this returned changeIndex == 1 (insertion order, change was
+    // last). Rust then indexed sorted row 1 (the recipient) and carved the
+    // fee out of them. Regression scenario from issue #3738.
+    func test_buildSortedFFIOutputs_changeSortsBeforeRecipient_indexIsZero() {
+        let recipientHash = Data(repeating: 0xFF, count: 20)
+        let changeHash = Data(repeating: 0x00, count: 20)
+        let recipient = ManagedPlatformAddressWallet.TransferOutput(
+            addressType: 0,
+            hash: recipientHash,
+            credits: 100
+        )
+        let change = (
+            addressType: UInt8(0),
+            hash: changeHash,
+            balance: UInt64(50)
+        )
+
+        let (rows, changeIndex) = ManagedPlatformAddressWallet.buildSortedFFIOutputs(
+            recipients: [recipient],
+            change: change
+        )
+
+        XCTAssertEqual(changeIndex, 0)
+        XCTAssertEqual(rows.count, 2)
+        XCTAssertEqual(hashData(rows[0]), changeHash, "row 0 = change address (0x00…)")
+        XCTAssertEqual(rows[0].balance, 50)
+        XCTAssertEqual(hashData(rows[1]), recipientHash, "row 1 = recipient address (0xFF…)")
+        XCTAssertEqual(rows[1].balance, 100)
+    }
+
+    // Multi-recipient: change address sorts into the MIDDLE of the
+    // output list. Defends against an off-by-one or
+    // last-position-assumption regression in the helper, and crosses
+    // the 0x7F/0x80 byte boundary so that any accidental signed-byte
+    // comparison would flip the order and fail the test.
+    func test_buildSortedFFIOutputs_multipleRecipients_changeInMiddle() {
+        let lowRecipientHash = Data(repeating: 0x10, count: 20)
+        let changeHash = Data(repeating: 0x80, count: 20)
+        let highRecipientHash = Data(repeating: 0xF0, count: 20)
+        let recipients = [
+            ManagedPlatformAddressWallet.TransferOutput(
+                addressType: 0,
+                hash: lowRecipientHash,
+                credits: 100
+            ),
+            ManagedPlatformAddressWallet.TransferOutput(
+                addressType: 0,
+                hash: highRecipientHash,
+                credits: 200
+            ),
+        ]
+        let change = (
+            addressType: UInt8(0),
+            hash: changeHash,
+            balance: UInt64(75)
+        )
+
+        let (rows, changeIndex) = ManagedPlatformAddressWallet.buildSortedFFIOutputs(
+            recipients: recipients,
+            change: change
+        )
+
+        XCTAssertEqual(rows.count, 3)
+        XCTAssertEqual(changeIndex, 1, "change at 0x80… sorts between 0x10… and 0xF0…")
+        XCTAssertEqual(hashData(rows[0]), lowRecipientHash)
+        XCTAssertEqual(rows[0].balance, 100)
+        XCTAssertEqual(hashData(rows[1]), changeHash)
+        XCTAssertEqual(rows[1].balance, 75)
+        XCTAssertEqual(hashData(rows[2]), highRecipientHash)
+        XCTAssertEqual(rows[2].balance, 200)
+    }
+}


### PR DESCRIPTION
## Issue being fixed or feature implemented

Fixes #3738 — `ManagedPlatformAddressWallet.transfer()` was underpaying recipients whenever the resolved change address sorted lexicographically before any recipient address. HIGH severity, silent fund misdirection.

## What was done?

The Swift wrapper was targeting the fee-reduction step by **insertion index**:

```swift
ffiOutputs = [...recipients, change]
let changeIndex = UInt16(ffiOutputs.count - 1)   // ⚠ insertion order
feeStrategy = [FeeStrategyStepFFI(step_type: 1, index: changeIndex)]
```

But the Rust side collects outputs into `BTreeMap<PlatformAddress, Credits>`, which canonicalizes them **lexicographically by address** — variant byte first (`P2pkh = 0 < P2sh = 1`), then the 20-byte hash. DPP's fee-deduction layer (`rs-dpp/src/address_funds/fee_strategy/v0.rs`) resolves `ReduceOutput(N)` against that canonicalized list, not Swift's insertion order. When the change address sorted before any recipient, the wrong row got decremented: the recipient was underpaid by the fee amount, and the change came back full. The bug hit randomly based on which address got generated as change, so it bypassed integration tests most runs.

Fix: mirror the Rust ordering in Swift via a new `buildSortedFFIOutputs` helper.

- Build `(addressType, hash, balance)` rows for all outputs + change.
- Sort by `(addressType, hash)` — `addressType` ascending first, then `hash` via `Data.lexicographicallyPrecedes` (unsigned byte-by-byte).
- Look up the change row's actual position in the sorted list.
- Only then marshal into `AddressBalanceEntryFFI`.

The helper is `internal static` so the unit tests can hit it directly without spinning up FFI handles.

Per discussion in #3738, this is the structurally complete fix for the Swift side. No additional FFI consumers are planned, so a Rust-side `transfer_with_change_address` bridge is out of scope.

## How Has This Been Tested?

Two regression tests on the pure helper (in `SwiftExampleApp/SwiftExampleAppTests/ManagedPlatformAddressWalletTests.swift`, auto-discovered via the existing `PBXFileSystemSynchronizedRootGroup`):

1. **`test_buildSortedFFIOutputs_changeSortsBeforeRecipient_indexIsZero`** — exact #3738 scenario. Recipient hash `0xFF…`, change hash `0x00…`. Asserts `changeIndex == 0` and both rows land in the correct sorted positions with balances preserved. Pre-fix this returned `changeIndex == 1` and Rust would have decremented the recipient.

2. **`test_buildSortedFFIOutputs_multipleRecipients_changeInMiddle`** — three outputs, change sorts into the middle position. Recipients at `0x10…` / `0xF0…`, change at `0x80…`. Asserts `changeIndex == 1` and all three rows in the correct sorted positions. The `0x80` midpoint deliberately crosses the signed-byte boundary — if the comparator ever degrades to signed-byte semantics, this test fails immediately. Also defends against any off-by-one or last-position assumption regression.

End-to-end build verification was blocked locally by a stale `DashSDKFFI.xcframework` (recent FFI constants from PR #3651 aren't in the framework I had built on May 25) — unrelated to this change. The two pre-existing errors are in `PlatformWalletResult.swift`, not in the file modified here. swift-frontend reported **zero errors in `ManagedPlatformAddressWallet.swift`** during the failed build, confirming my changes parse and type-check cleanly. Will need `./build_ios.sh` to refresh the framework before CI/test run.

## Breaking Changes

None. The FFI ABI is unchanged; only the values Swift puts into the existing slots change.

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [ ] I have made corresponding changes to the documentation if needed

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a critical issue in wallet transfer operations where transaction outputs were not being sorted in the correct canonical order. The change amount is now properly computed and aligned with expected output ordering before processing. This ensures accurate transaction construction, reliable fee calculations, and proper handling of change outputs in wallet transfers.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dashpay/platform/pull/3752?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->