### PR TITLE
chore: bump rust-dashcore to 58d61ea

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1132,7 +1132,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1550,7 +1550,7 @@ dependencies = [
 [[package]]
 name = "dash-network"
 version = "0.43.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=f569e7b7b99dfe589c41f9ba7d36fbbe6805acdc#f569e7b7b99dfe589c41f9ba7d36fbbe6805acdc"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=58d61ea50ac4c217c8e1350b57363b351a0b99d4#58d61ea50ac4c217c8e1350b57363b351a0b99d4"
 dependencies = [
  "bincode",
  "bincode_derive",
@@ -1561,7 +1561,7 @@ dependencies = [
 [[package]]
 name = "dash-network-seeds"
 version = "0.43.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=f569e7b7b99dfe589c41f9ba7d36fbbe6805acdc#f569e7b7b99dfe589c41f9ba7d36fbbe6805acdc"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=58d61ea50ac4c217c8e1350b57363b351a0b99d4#58d61ea50ac4c217c8e1350b57363b351a0b99d4"
 dependencies = [
  "dash-network",
 ]
@@ -1638,7 +1638,7 @@ dependencies = [
 [[package]]
 name = "dash-spv"
 version = "0.43.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=f569e7b7b99dfe589c41f9ba7d36fbbe6805acdc#f569e7b7b99dfe589c41f9ba7d36fbbe6805acdc"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=58d61ea50ac4c217c8e1350b57363b351a0b99d4#58d61ea50ac4c217c8e1350b57363b351a0b99d4"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1667,7 +1667,7 @@ dependencies = [
 [[package]]
 name = "dashcore"
 version = "0.43.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=f569e7b7b99dfe589c41f9ba7d36fbbe6805acdc#f569e7b7b99dfe589c41f9ba7d36fbbe6805acdc"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=58d61ea50ac4c217c8e1350b57363b351a0b99d4#58d61ea50ac4c217c8e1350b57363b351a0b99d4"
 dependencies = [
  "anyhow",
  "base64-compat",
@@ -1693,12 +1693,12 @@ dependencies = [
 [[package]]
 name = "dashcore-private"
 version = "0.43.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=f569e7b7b99dfe589c41f9ba7d36fbbe6805acdc#f569e7b7b99dfe589c41f9ba7d36fbbe6805acdc"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=58d61ea50ac4c217c8e1350b57363b351a0b99d4#58d61ea50ac4c217c8e1350b57363b351a0b99d4"
 
 [[package]]
 name = "dashcore-rpc"
 version = "0.43.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=f569e7b7b99dfe589c41f9ba7d36fbbe6805acdc#f569e7b7b99dfe589c41f9ba7d36fbbe6805acdc"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=58d61ea50ac4c217c8e1350b57363b351a0b99d4#58d61ea50ac4c217c8e1350b57363b351a0b99d4"
 dependencies = [
  "dashcore-rpc-json",
  "hex",
@@ -1711,7 +1711,7 @@ dependencies = [
 [[package]]
 name = "dashcore-rpc-json"
 version = "0.43.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=f569e7b7b99dfe589c41f9ba7d36fbbe6805acdc#f569e7b7b99dfe589c41f9ba7d36fbbe6805acdc"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=58d61ea50ac4c217c8e1350b57363b351a0b99d4#58d61ea50ac4c217c8e1350b57363b351a0b99d4"
 dependencies = [
  "bincode",
  "dashcore",
@@ -1726,7 +1726,7 @@ dependencies = [
 [[package]]
 name = "dashcore_hashes"
 version = "0.43.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=f569e7b7b99dfe589c41f9ba7d36fbbe6805acdc#f569e7b7b99dfe589c41f9ba7d36fbbe6805acdc"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=58d61ea50ac4c217c8e1350b57363b351a0b99d4#58d61ea50ac4c217c8e1350b57363b351a0b99d4"
 dependencies = [
  "bincode",
  "dashcore-private",
@@ -2261,7 +2261,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2636,7 +2636,7 @@ dependencies = [
 [[package]]
 name = "git-state"
 version = "0.43.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=f569e7b7b99dfe589c41f9ba7d36fbbe6805acdc#f569e7b7b99dfe589c41f9ba7d36fbbe6805acdc"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=58d61ea50ac4c217c8e1350b57363b351a0b99d4#58d61ea50ac4c217c8e1350b57363b351a0b99d4"
 
 [[package]]
 name = "glob"
@@ -3298,7 +3298,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -3549,7 +3549,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3780,7 +3780,7 @@ dependencies = [
 [[package]]
 name = "key-wallet"
 version = "0.43.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=f569e7b7b99dfe589c41f9ba7d36fbbe6805acdc#f569e7b7b99dfe589c41f9ba7d36fbbe6805acdc"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=58d61ea50ac4c217c8e1350b57363b351a0b99d4#58d61ea50ac4c217c8e1350b57363b351a0b99d4"
 dependencies = [
  "aes",
  "async-trait",
@@ -3808,7 +3808,7 @@ dependencies = [
 [[package]]
 name = "key-wallet-ffi"
 version = "0.43.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=f569e7b7b99dfe589c41f9ba7d36fbbe6805acdc#f569e7b7b99dfe589c41f9ba7d36fbbe6805acdc"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=58d61ea50ac4c217c8e1350b57363b351a0b99d4#58d61ea50ac4c217c8e1350b57363b351a0b99d4"
 dependencies = [
  "cbindgen 0.29.2",
  "dash-network",
@@ -3824,7 +3824,7 @@ dependencies = [
 [[package]]
 name = "key-wallet-manager"
 version = "0.43.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=f569e7b7b99dfe589c41f9ba7d36fbbe6805acdc#f569e7b7b99dfe589c41f9ba7d36fbbe6805acdc"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=58d61ea50ac4c217c8e1350b57363b351a0b99d4#58d61ea50ac4c217c8e1350b57363b351a0b99d4"
 dependencies = [
  "async-trait",
  "bincode",
@@ -5103,7 +5103,7 @@ version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "343d3bd7056eda839b03204e68deff7d1b13aba7af2b2fd16890697274262ee7"
 dependencies = [
- "heck 0.5.0",
+ "heck 0.4.1",
  "itertools 0.14.0",
  "log",
  "multimap",
@@ -5268,7 +5268,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash 2.1.2",
  "rustls",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -5306,9 +5306,9 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6030,7 +6030,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6043,7 +6043,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6102,7 +6102,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6942,7 +6942,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -8344,7 +8344,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,14 +49,14 @@ members = [
 ]
 
 [workspace.dependencies]
-dashcore = { git = "https://github.com/dashpay/rust-dashcore", rev = "f569e7b7b99dfe589c41f9ba7d36fbbe6805acdc" }
-dash-network-seeds = { git = "https://github.com/dashpay/rust-dashcore", rev = "f569e7b7b99dfe589c41f9ba7d36fbbe6805acdc" }
-dash-spv = { git = "https://github.com/dashpay/rust-dashcore", rev = "f569e7b7b99dfe589c41f9ba7d36fbbe6805acdc" }
-key-wallet = { git = "https://github.com/dashpay/rust-dashcore", rev = "f569e7b7b99dfe589c41f9ba7d36fbbe6805acdc" }
-key-wallet-ffi = { git = "https://github.com/dashpay/rust-dashcore", rev = "f569e7b7b99dfe589c41f9ba7d36fbbe6805acdc" }
-key-wallet-manager = { git = "https://github.com/dashpay/rust-dashcore", rev = "f569e7b7b99dfe589c41f9ba7d36fbbe6805acdc" }
-dash-network = { git = "https://github.com/dashpay/rust-dashcore", rev = "f569e7b7b99dfe589c41f9ba7d36fbbe6805acdc" }
-dashcore-rpc = { git = "https://github.com/dashpay/rust-dashcore", rev = "f569e7b7b99dfe589c41f9ba7d36fbbe6805acdc" }
+dashcore = { git = "https://github.com/dashpay/rust-dashcore", rev = "58d61ea50ac4c217c8e1350b57363b351a0b99d4" }
+dash-network-seeds = { git = "https://github.com/dashpay/rust-dashcore", rev = "58d61ea50ac4c217c8e1350b57363b351a0b99d4" }
+dash-spv = { git = "https://github.com/dashpay/rust-dashcore", rev = "58d61ea50ac4c217c8e1350b57363b351a0b99d4" }
+key-wallet = { git = "https://github.com/dashpay/rust-dashcore", rev = "58d61ea50ac4c217c8e1350b57363b351a0b99d4" }
+key-wallet-ffi = { git = "https://github.com/dashpay/rust-dashcore", rev = "58d61ea50ac4c217c8e1350b57363b351a0b99d4" }
+key-wallet-manager = { git = "https://github.com/dashpay/rust-dashcore", rev = "58d61ea50ac4c217c8e1350b57363b351a0b99d4" }
+dash-network = { git = "https://github.com/dashpay/rust-dashcore", rev = "58d61ea50ac4c217c8e1350b57363b351a0b99d4" }
+dashcore-rpc = { git = "https://github.com/dashpay/rust-dashcore", rev = "58d61ea50ac4c217c8e1350b57363b351a0b99d4" }
 
 # Optimize heavy crypto crates even in dev/test builds so that
 # Halo 2 proof generation and verification run at near-release speed.


### PR DESCRIPTION
## Issue being fixed or feature implemented
Bumps the `rust-dashcore` workspace dependency revision from `f569e7b7` to `58d61ea5` (current `dev` HEAD).

## What was done?
Updated the `rev` of all 8 `rust-dashcore` workspace dependencies in `Cargo.toml` (`dashcore`, `dash-network-seeds`, `dash-spv`, `key-wallet`, `key-wallet-ffi`, `key-wallet-manager`, `dash-network`, `dashcore-rpc`) and regenerated `Cargo.lock`.

Picks up two upstream commits:
- [dashpay/rust-dashcore#782](https://github.com/dashpay/rust-dashcore/pull/782) — add `downgrade_to_external_signable` method to wallets
- [dashpay/rust-dashcore#784](https://github.com/dashpay/rust-dashcore/pull/784) — devnet support for `dash-spv`

## How Has This Been Tested?
- `cargo update -p dashcore -p dash-network-seeds -p dash-spv -p key-wallet -p key-wallet-ffi -p key-wallet-manager -p dash-network -p dashcore-rpc`
- `cargo check --workspace --tests --all-features` — finishes with no errors

## Breaking Changes
None.

## Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [ ] I have made corresponding changes to the documentation if needed

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated core dependencies to the latest versions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dashpay/platform/pull/3757?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->