### PR TITLE
feat(rs-platform-wallet-ffi): expose devnet name and LLMQ_DEVNET override in spv_start

### DIFF
--- a/packages/rs-platform-wallet-ffi/src/spv.rs
+++ b/packages/rs-platform-wallet-ffi/src/spv.rs
@@ -3,6 +3,7 @@
 use std::ffi::CStr;
 use std::os::raw::c_char;
 
+use dashcore::sml::llmq_type::LlmqDevnetParams;
 use platform_wallet::spv::{ClientConfig, ProgressPercentage, SyncProgress, SyncState};
 
 use crate::error::*;
@@ -197,6 +198,17 @@ pub unsafe extern "C" fn platform_wallet_manager_spv_tip_unix_seconds(
 /// Hardcoded to `true` here; if a future caller has a real reason to
 /// run SPV without masternode sync, it can construct the wallet
 /// manager without the asset-lock path instead.
+///
+/// Devnet support:
+/// - `devnet_name` must be set (non-null) when `network == Devnet` and
+///   must be null on every other network. When set, the SPV user agent
+///   is rewritten to embed the `devnet.devnet-<name>` substring Dash
+///   Core peers gate inbound devnet handshakes on (matches the format
+///   the `dash-spv` binary uses).
+/// - `llmq_devnet_size` / `llmq_devnet_threshold` mirror Dash Core's
+///   `-llmqdevnetparams=<size>:<threshold>`. Both zero means "no
+///   override". Setting one without the other, or setting them on a
+///   non-devnet network, is rejected.
 #[no_mangle]
 #[allow(clippy::field_reassign_with_default)]
 pub unsafe extern "C" fn platform_wallet_manager_spv_start(
@@ -208,16 +220,62 @@ pub unsafe extern "C" fn platform_wallet_manager_spv_start(
     peer_count: usize,
     restrict_to_configured_peers: bool,
     start_from_height: u32,
+    devnet_name: *const c_char,
+    llmq_devnet_size: u32,
+    llmq_devnet_threshold: u32,
 ) -> PlatformWalletFFIResult {
     check_ptr!(data_dir);
     let data_dir_str = unwrap_result_or_return!(CStr::from_ptr(data_dir).to_str()).to_string();
-    let user_agent_str = if user_agent.is_null() {
+    let mut user_agent_str = if user_agent.is_null() {
         None
     } else {
         Some(unwrap_result_or_return!(CStr::from_ptr(user_agent).to_str()).to_string())
     };
 
     let net: crate::types::Network = network.into();
+
+    let devnet_name_str = if devnet_name.is_null() {
+        None
+    } else {
+        Some(unwrap_result_or_return!(CStr::from_ptr(devnet_name).to_str()).to_string())
+    };
+
+    if net == crate::types::Network::Devnet && devnet_name_str.is_none() {
+        return PlatformWalletFFIResult::err(
+            PlatformWalletFFIResultCode::ErrorInvalidParameter,
+            "devnet_name is required when network=Devnet",
+        );
+    }
+    if net != crate::types::Network::Devnet && devnet_name_str.is_some() {
+        return PlatformWalletFFIResult::err(
+            PlatformWalletFFIResultCode::ErrorInvalidParameter,
+            "devnet_name is only valid on devnet",
+        );
+    }
+    if (llmq_devnet_size > 0) ^ (llmq_devnet_threshold > 0) {
+        return PlatformWalletFFIResult::err(
+            PlatformWalletFFIResultCode::ErrorInvalidParameter,
+            "llmq_devnet_size and llmq_devnet_threshold must both be set or both zero",
+        );
+    }
+    if llmq_devnet_size > 0 && net != crate::types::Network::Devnet {
+        return PlatformWalletFFIResult::err(
+            PlatformWalletFFIResultCode::ErrorInvalidParameter,
+            "llmq_devnet_params is only valid on devnet",
+        );
+    }
+
+    // Dash Core devnet peers disconnect any inbound connection whose
+    // user agent doesn't contain `devnet.devnet-<name>`. Rebuild the
+    // user agent to embed the substring while keeping whatever base
+    // the caller (or our default) provided. Mirrors the dash-spv
+    // binary's `/rust-dash-spv:VERSION(devnet.devnet-NAME)/` format.
+    if let Some(name) = devnet_name_str.as_deref() {
+        let base = user_agent_str
+            .clone()
+            .unwrap_or_else(|| format!("platform-wallet-ffi:{}", env!("CARGO_PKG_VERSION")));
+        user_agent_str = Some(format!("/{base}(devnet.devnet-{name})/"));
+    }
 
     let mut peer_list: Vec<String> = Vec::new();
     if !peers.is_null() && peer_count > 0 {
@@ -255,6 +313,12 @@ pub unsafe extern "C" fn platform_wallet_manager_spv_start(
             if let Ok(addr) = p.parse() {
                 config.peers.push(addr);
             }
+        }
+        if llmq_devnet_size > 0 {
+            config.llmq_devnet_params = Some(LlmqDevnetParams {
+                size: llmq_devnet_size,
+                threshold: llmq_devnet_threshold,
+            });
         }
 
         let _guard = runtime().enter();

--- a/packages/swift-sdk/Sources/SwiftDashSDK/PlatformWallet/PlatformWalletManagerSPV.swift
+++ b/packages/swift-sdk/Sources/SwiftDashSDK/PlatformWallet/PlatformWalletManagerSPV.swift
@@ -112,6 +112,20 @@ public struct PlatformSpvStartConfig {
     public var peers: [String]
     public var restrictToConfiguredPeers: Bool
     public var startFromHeight: UInt32
+    /// Devnet name (e.g. `"333"` for `devnet-333`). Required when
+    /// `network == .devnet`, must be `nil` on every other network.
+    /// The FFI rebuilds the user agent to embed
+    /// `devnet.devnet-<name>` so Dash Core devnet peers accept the
+    /// handshake.
+    public var devnetName: String?
+    /// LLMQ_DEVNET quorum size override (matches Dash Core's
+    /// `-llmqdevnetparams=<size>:<threshold>`). `0` means "no
+    /// override". Must be paired with `llmqDevnetThreshold` and only
+    /// valid on devnet.
+    public var llmqDevnetSize: UInt32
+    /// LLMQ_DEVNET signing threshold override. See
+    /// `llmqDevnetSize`.
+    public var llmqDevnetThreshold: UInt32
 
     public init(
         dataDir: String,
@@ -119,7 +133,10 @@ public struct PlatformSpvStartConfig {
         userAgent: String? = nil,
         peers: [String] = [],
         restrictToConfiguredPeers: Bool = false,
-        startFromHeight: UInt32 = 0
+        startFromHeight: UInt32 = 0,
+        devnetName: String? = nil,
+        llmqDevnetSize: UInt32 = 0,
+        llmqDevnetThreshold: UInt32 = 0
     ) {
         self.dataDir = dataDir
         self.network = network
@@ -127,6 +144,9 @@ public struct PlatformSpvStartConfig {
         self.peers = peers
         self.restrictToConfiguredPeers = restrictToConfiguredPeers
         self.startFromHeight = startFromHeight
+        self.devnetName = devnetName
+        self.llmqDevnetSize = llmqDevnetSize
+        self.llmqDevnetThreshold = llmqDevnetThreshold
     }
 }
 
@@ -194,6 +214,9 @@ extension PlatformWalletManager {
             let userAgentPtr = config.userAgent.flatMap { strdup($0) }
             defer { if let p = userAgentPtr { free(p) } }
 
+            let devnetNamePtr = config.devnetName.flatMap { strdup($0) }
+            defer { if let p = devnetNamePtr { free(p) } }
+
             try peerCStrings.withUnsafeBufferPointer { peersBuf in
                 let peersPtr: UnsafePointer<UnsafePointer<CChar>?>? = peersBuf.baseAddress.map {
                     UnsafeRawPointer($0).assumingMemoryBound(to: UnsafePointer<CChar>?.self)
@@ -206,7 +229,10 @@ extension PlatformWalletManager {
                     peersPtr,
                     UInt(peerCStrings.count),
                     config.restrictToConfiguredPeers,
-                    config.startFromHeight
+                    config.startFromHeight,
+                    devnetNamePtr,
+                    config.llmqDevnetSize,
+                    config.llmqDevnetThreshold
                 ).check()
             }
         }


### PR DESCRIPTION
## Issue being fixed or feature implemented
SPV-syncing a Dash devnet from the platform wallet currently doesn't work — the FFI's `platform_wallet_manager_spv_start` has no way to pass the two devnet-specific knobs that rust-dashcore PR [dashpay/rust-dashcore#784](https://github.com/dashpay/rust-dashcore/pull/784) recently exposed on `ClientConfig` (already pinned at `58d61ea` in our `Cargo.toml`):

1. **Devnet user-agent substring.** Dash Core peers running a devnet gate inbound handshakes on a `devnet.devnet-<name>` substring in the peer's user agent (`net_processing.cpp:3957`). Without it, the SPV client cannot connect to any devnet peer.
2. **`LLMQ_DEVNET` size/threshold override.** Mirrors Dash Core's `-llmqdevnetparams=<size>:<threshold>`. Without matching params, the SPV client reconstructs the wrong quorum and ChainLock / legacy InstantSend signatures fail to verify.

This PR wires both through the FFI and the Swift wrapper as pure plumbing.

## What was done?

**Rust FFI (`rs-platform-wallet-ffi`)** — `platform_wallet_manager_spv_start` gains three trailing params:
- `devnet_name: *const c_char` — `NULL` means "not devnet".
- `llmq_devnet_size: u32`, `llmq_devnet_threshold: u32` — both `0` means "no override".

Validations (returned as `ErrorInvalidParameter`):
- `devnet_name` must be set iff `network == Devnet`.
- `llmq_devnet_size` and `llmq_devnet_threshold` must both be set or both zero.
- Non-zero LLMQ params are rejected on non-devnet networks (matches `ClientConfig::validate()` wording for consistency).

When `devnet_name` is supplied, the user agent is rebuilt as `/{base}(devnet.devnet-{name})/`, falling back to a `platform-wallet-ffi:<crate version>` base when the caller didn't pass one — mirrors the format the `dash-spv` binary constructs in `main.rs`. The LLMQ override is written into `ClientConfig.llmq_devnet_params`; `DashSpvClient::new` applies it via `apply_global_overrides` (idempotent for identical values).

**Swift wrapper (`SwiftDashSDK`)** — `PlatformSpvStartConfig` gains `devnetName: String?`, `llmqDevnetSize: UInt32`, `llmqDevnetThreshold: UInt32`, all defaulted so existing call sites (e.g. `CoreContentView.swift`) compile unchanged. `startSpv(config:)` marshals `devnetName` to a C string with the same `strdup`/`defer free` pattern as `userAgent`, then passes the new trailing args to the FFI. Pure marshalling — no decisions on the Swift side (complies with `packages/swift-sdk/CLAUDE.md`).

Diff stat: 2 files changed, +93 / -3.

## How Has This Been Tested?
- `cargo check -p platform-wallet-ffi` — clean.
- `cargo fmt --all -- --check` — clean.
- `cd packages/swift-sdk && ./build_ios.sh --target sim` — succeeded end-to-end (regenerated the C header inside `DashSDKFFI.xcframework`, then ran `xcodebuild build` on `SwiftExampleApp` with `-warnings-as-errors`; reports `Swift/Xcode build succeeded`).

The regenerated header inside the xcframework carries the new signature:
```c
struct PlatformWalletFFIResult platform_wallet_manager_spv_start(Handle handle, const char *data_dir, FFINetwork network, const char *user_agent, const char *const *peers, uintptr_t peer_count, bool restrict_to_configured_peers, uint32_t start_from_height, const char *devnet_name, uint32_t llmq_devnet_size, uint32_t llmq_devnet_threshold);
```

## Breaking Changes
None at the Swift level — every new field on `PlatformSpvStartConfig` is defaulted (`devnetName: nil`, `llmqDevnetSize: 0`, `llmqDevnetThreshold: 0`), so existing call sites compile unchanged.

The Rust `extern "C"` signature does gain three trailing params, which is a C-ABI source-level break for any out-of-tree caller calling `platform_wallet_manager_spv_start` directly. Per `feedback_breaking_change_scope`, `feat!:` is reserved for consensus-breaking changes in this repo, so this lands under plain `feat:`.

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [x] I have made corresponding changes to the documentation if needed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * SPV wallet manager now supports devnet network configuration with custom devnet naming capabilities
  * Added customizable LLMQ (Quorum) parameters for devnet environments, including size and threshold override options

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dashpay/platform/pull/3758?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->