### PR TITLE
feat(swift-example-app): enable SPV on devnet

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1132,7 +1132,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1550,7 +1550,7 @@ dependencies = [
 [[package]]
 name = "dash-network"
 version = "0.43.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=58d61ea50ac4c217c8e1350b57363b351a0b99d4#58d61ea50ac4c217c8e1350b57363b351a0b99d4"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=eb889af13f667ed39c35e8e8a0830eeedf523476#eb889af13f667ed39c35e8e8a0830eeedf523476"
 dependencies = [
  "bincode",
  "bincode_derive",
@@ -1561,7 +1561,7 @@ dependencies = [
 [[package]]
 name = "dash-network-seeds"
 version = "0.43.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=58d61ea50ac4c217c8e1350b57363b351a0b99d4#58d61ea50ac4c217c8e1350b57363b351a0b99d4"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=eb889af13f667ed39c35e8e8a0830eeedf523476#eb889af13f667ed39c35e8e8a0830eeedf523476"
 dependencies = [
  "dash-network",
 ]
@@ -1638,7 +1638,7 @@ dependencies = [
 [[package]]
 name = "dash-spv"
 version = "0.43.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=58d61ea50ac4c217c8e1350b57363b351a0b99d4#58d61ea50ac4c217c8e1350b57363b351a0b99d4"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=eb889af13f667ed39c35e8e8a0830eeedf523476#eb889af13f667ed39c35e8e8a0830eeedf523476"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1667,7 +1667,7 @@ dependencies = [
 [[package]]
 name = "dashcore"
 version = "0.43.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=58d61ea50ac4c217c8e1350b57363b351a0b99d4#58d61ea50ac4c217c8e1350b57363b351a0b99d4"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=eb889af13f667ed39c35e8e8a0830eeedf523476#eb889af13f667ed39c35e8e8a0830eeedf523476"
 dependencies = [
  "anyhow",
  "base64-compat",
@@ -1693,12 +1693,12 @@ dependencies = [
 [[package]]
 name = "dashcore-private"
 version = "0.43.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=58d61ea50ac4c217c8e1350b57363b351a0b99d4#58d61ea50ac4c217c8e1350b57363b351a0b99d4"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=eb889af13f667ed39c35e8e8a0830eeedf523476#eb889af13f667ed39c35e8e8a0830eeedf523476"
 
 [[package]]
 name = "dashcore-rpc"
 version = "0.43.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=58d61ea50ac4c217c8e1350b57363b351a0b99d4#58d61ea50ac4c217c8e1350b57363b351a0b99d4"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=eb889af13f667ed39c35e8e8a0830eeedf523476#eb889af13f667ed39c35e8e8a0830eeedf523476"
 dependencies = [
  "dashcore-rpc-json",
  "hex",
@@ -1711,7 +1711,7 @@ dependencies = [
 [[package]]
 name = "dashcore-rpc-json"
 version = "0.43.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=58d61ea50ac4c217c8e1350b57363b351a0b99d4#58d61ea50ac4c217c8e1350b57363b351a0b99d4"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=eb889af13f667ed39c35e8e8a0830eeedf523476#eb889af13f667ed39c35e8e8a0830eeedf523476"
 dependencies = [
  "bincode",
  "dashcore",
@@ -1726,7 +1726,7 @@ dependencies = [
 [[package]]
 name = "dashcore_hashes"
 version = "0.43.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=58d61ea50ac4c217c8e1350b57363b351a0b99d4#58d61ea50ac4c217c8e1350b57363b351a0b99d4"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=eb889af13f667ed39c35e8e8a0830eeedf523476#eb889af13f667ed39c35e8e8a0830eeedf523476"
 dependencies = [
  "bincode",
  "dashcore-private",
@@ -2261,7 +2261,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2636,7 +2636,7 @@ dependencies = [
 [[package]]
 name = "git-state"
 version = "0.43.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=58d61ea50ac4c217c8e1350b57363b351a0b99d4#58d61ea50ac4c217c8e1350b57363b351a0b99d4"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=eb889af13f667ed39c35e8e8a0830eeedf523476#eb889af13f667ed39c35e8e8a0830eeedf523476"
 
 [[package]]
 name = "glob"
@@ -3549,7 +3549,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3780,7 +3780,7 @@ dependencies = [
 [[package]]
 name = "key-wallet"
 version = "0.43.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=58d61ea50ac4c217c8e1350b57363b351a0b99d4#58d61ea50ac4c217c8e1350b57363b351a0b99d4"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=eb889af13f667ed39c35e8e8a0830eeedf523476#eb889af13f667ed39c35e8e8a0830eeedf523476"
 dependencies = [
  "aes",
  "async-trait",
@@ -3808,7 +3808,7 @@ dependencies = [
 [[package]]
 name = "key-wallet-ffi"
 version = "0.43.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=58d61ea50ac4c217c8e1350b57363b351a0b99d4#58d61ea50ac4c217c8e1350b57363b351a0b99d4"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=eb889af13f667ed39c35e8e8a0830eeedf523476#eb889af13f667ed39c35e8e8a0830eeedf523476"
 dependencies = [
  "cbindgen 0.29.2",
  "dash-network",
@@ -3824,7 +3824,7 @@ dependencies = [
 [[package]]
 name = "key-wallet-manager"
 version = "0.43.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=58d61ea50ac4c217c8e1350b57363b351a0b99d4#58d61ea50ac4c217c8e1350b57363b351a0b99d4"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=eb889af13f667ed39c35e8e8a0830eeedf523476#eb889af13f667ed39c35e8e8a0830eeedf523476"
 dependencies = [
  "async-trait",
  "bincode",
@@ -4301,7 +4301,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5308,7 +5308,7 @@ dependencies = [
  "once_cell",
  "socket2 0.5.10",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6030,7 +6030,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6043,7 +6043,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6102,7 +6102,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6942,7 +6942,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -8344,7 +8344,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,14 +49,14 @@ members = [
 ]
 
 [workspace.dependencies]
-dashcore = { git = "https://github.com/dashpay/rust-dashcore", rev = "58d61ea50ac4c217c8e1350b57363b351a0b99d4" }
-dash-network-seeds = { git = "https://github.com/dashpay/rust-dashcore", rev = "58d61ea50ac4c217c8e1350b57363b351a0b99d4" }
-dash-spv = { git = "https://github.com/dashpay/rust-dashcore", rev = "58d61ea50ac4c217c8e1350b57363b351a0b99d4" }
-key-wallet = { git = "https://github.com/dashpay/rust-dashcore", rev = "58d61ea50ac4c217c8e1350b57363b351a0b99d4" }
-key-wallet-ffi = { git = "https://github.com/dashpay/rust-dashcore", rev = "58d61ea50ac4c217c8e1350b57363b351a0b99d4" }
-key-wallet-manager = { git = "https://github.com/dashpay/rust-dashcore", rev = "58d61ea50ac4c217c8e1350b57363b351a0b99d4" }
-dash-network = { git = "https://github.com/dashpay/rust-dashcore", rev = "58d61ea50ac4c217c8e1350b57363b351a0b99d4" }
-dashcore-rpc = { git = "https://github.com/dashpay/rust-dashcore", rev = "58d61ea50ac4c217c8e1350b57363b351a0b99d4" }
+dashcore = { git = "https://github.com/dashpay/rust-dashcore", rev = "eb889af13f667ed39c35e8e8a0830eeedf523476" }
+dash-network-seeds = { git = "https://github.com/dashpay/rust-dashcore", rev = "eb889af13f667ed39c35e8e8a0830eeedf523476" }
+dash-spv = { git = "https://github.com/dashpay/rust-dashcore", rev = "eb889af13f667ed39c35e8e8a0830eeedf523476" }
+key-wallet = { git = "https://github.com/dashpay/rust-dashcore", rev = "eb889af13f667ed39c35e8e8a0830eeedf523476" }
+key-wallet-ffi = { git = "https://github.com/dashpay/rust-dashcore", rev = "eb889af13f667ed39c35e8e8a0830eeedf523476" }
+key-wallet-manager = { git = "https://github.com/dashpay/rust-dashcore", rev = "eb889af13f667ed39c35e8e8a0830eeedf523476" }
+dash-network = { git = "https://github.com/dashpay/rust-dashcore", rev = "eb889af13f667ed39c35e8e8a0830eeedf523476" }
+dashcore-rpc = { git = "https://github.com/dashpay/rust-dashcore", rev = "eb889af13f667ed39c35e8e8a0830eeedf523476" }
 
 # Optimize heavy crypto crates even in dev/test builds so that
 # Halo 2 proof generation and verification run at near-release speed.

--- a/packages/rs-platform-wallet-ffi/src/spv.rs
+++ b/packages/rs-platform-wallet-ffi/src/spv.rs
@@ -254,6 +254,26 @@ pub unsafe extern "C" fn platform_wallet_manager_spv_start(
             "devnet_name is only valid on devnet",
         );
     }
+    // Reject empty or `/`-containing names synchronously here rather
+    // than letting `DevnetConfig::validate` surface them asynchronously
+    // from `spawn_in_background`. Mirrors `DevnetConfig::validate` and
+    // saves callers without a pre-filter (other language bindings,
+    // integration tests) from a `(devnet.devnet-)` user agent that
+    // Dash Core peers silently drop.
+    if let Some(name) = devnet_name_str.as_deref() {
+        if name.is_empty() {
+            return PlatformWalletFFIResult::err(
+                PlatformWalletFFIResultCode::ErrorInvalidParameter,
+                "devnet_name must not be empty",
+            );
+        }
+        if name.contains('/') {
+            return PlatformWalletFFIResult::err(
+                PlatformWalletFFIResultCode::ErrorInvalidParameter,
+                "devnet_name must not contain '/'",
+            );
+        }
+    }
     if (llmq_devnet_size > 0) ^ (llmq_devnet_threshold > 0) {
         return PlatformWalletFFIResult::err(
             PlatformWalletFFIResultCode::ErrorInvalidParameter,

--- a/packages/rs-platform-wallet-ffi/src/spv.rs
+++ b/packages/rs-platform-wallet-ffi/src/spv.rs
@@ -4,7 +4,9 @@ use std::ffi::CStr;
 use std::os::raw::c_char;
 
 use dashcore::sml::llmq_type::LlmqDevnetParams;
-use platform_wallet::spv::{ClientConfig, ProgressPercentage, SyncProgress, SyncState};
+use platform_wallet::spv::{
+    ClientConfig, DevnetConfig, ProgressPercentage, SyncProgress, SyncState,
+};
 
 use crate::error::*;
 use crate::handle::*;
@@ -314,11 +316,15 @@ pub unsafe extern "C" fn platform_wallet_manager_spv_start(
                 config.peers.push(addr);
             }
         }
-        if llmq_devnet_size > 0 {
-            config.llmq_devnet_params = Some(LlmqDevnetParams {
-                size: llmq_devnet_size,
-                threshold: llmq_devnet_threshold,
-            });
+        if let Some(name) = devnet_name_str.as_deref() {
+            let mut devnet = DevnetConfig::new(name);
+            if llmq_devnet_size > 0 {
+                devnet = devnet.with_llmq_params(LlmqDevnetParams {
+                    size: llmq_devnet_size,
+                    threshold: llmq_devnet_threshold,
+                });
+            }
+            config.devnet = Some(devnet);
         }
 
         let _guard = runtime().enter();

--- a/packages/rs-platform-wallet/src/spv/mod.rs
+++ b/packages/rs-platform-wallet/src/spv/mod.rs
@@ -8,5 +8,5 @@ pub use dash_spv::sync::{
     BlockHeadersProgress, FilterHeadersProgress, FiltersProgress, MasternodesProgress,
     ProgressPercentage, SyncProgress, SyncState,
 };
-pub use dash_spv::ClientConfig;
+pub use dash_spv::{ClientConfig, DevnetConfig};
 pub use tokio_util::sync::CancellationToken;

--- a/packages/rs-platform-wallet/src/wallet/platform_wallet_traits.rs
+++ b/packages/rs-platform-wallet/src/wallet/platform_wallet_traits.rs
@@ -9,7 +9,7 @@ use async_trait::async_trait;
 use dashcore::ephemerealdata::chain_lock::ChainLock;
 use dashcore::ephemerealdata::instant_lock::InstantLock;
 use dashcore::prelude::CoreBlockHeight;
-use dashcore::{Address as DashAddress, Transaction, Txid};
+use dashcore::{Address as DashAddress, ScriptBuf, Transaction, Txid};
 
 use key_wallet::account::AccountType;
 use key_wallet::bip32::ExtendedPubKey;
@@ -95,6 +95,10 @@ impl WalletInfoInterface for PlatformWalletInfo {
 
     fn monitored_addresses(&self) -> Vec<DashAddress> {
         self.core_wallet.monitored_addresses()
+    }
+
+    fn monitored_script_pubkeys(&self) -> Vec<ScriptBuf> {
+        self.core_wallet.monitored_script_pubkeys()
     }
 
     fn utxos(&self) -> BTreeSet<&Utxo> {

--- a/packages/swift-sdk/SwiftExampleApp/SwiftExampleApp/Core/Views/CoreContentView.swift
+++ b/packages/swift-sdk/SwiftExampleApp/SwiftExampleApp/Core/Views/CoreContentView.swift
@@ -584,11 +584,23 @@ var body: some View {
             let peers = spvPeerOverride()
             let restrictToConfiguredPeers = !peers.isEmpty
 
+            // Devnet requires a name so `DevnetConfig` can embed
+            // `devnet.devnet-<name>` in the SPV user agent (Dash
+            // Core devnet peers drop inbound handshakes without it).
+            // Read from the same UserDefaults key OptionsView writes.
+            let devnetName: String? = platformState.currentNetwork == .devnet
+                ? UserDefaults.standard.string(forKey: "platformDevnetName").flatMap {
+                    let trimmed = $0.trimmingCharacters(in: .whitespaces)
+                    return trimmed.isEmpty ? nil : trimmed
+                }
+                : nil
+
             let config = PlatformSpvStartConfig(
                 dataDir: dataDirURL.path,
                 network: platformState.currentNetwork,
                 peers: peers,
-                restrictToConfiguredPeers: restrictToConfiguredPeers
+                restrictToConfiguredPeers: restrictToConfiguredPeers,
+                devnetName: devnetName
             )
             try walletManager.startSpv(config: config)
         } catch {

--- a/packages/swift-sdk/SwiftExampleApp/SwiftExampleApp/Views/OptionsView.swift
+++ b/packages/swift-sdk/SwiftExampleApp/SwiftExampleApp/Views/OptionsView.swift
@@ -81,6 +81,14 @@ struct OptionsView: View {
     // here redirects the next SDK construction.
     @AppStorage("platformQuorumURL") private var devnetQuorumURL: String = ""
 
+    // Devnet identity (`-devnet=<name>` in Dash Core). Required by
+    // `DevnetConfig` so the SPV client embeds `devnet.devnet-<name>`
+    // in its user agent — Dash Core devnet peers drop inbound
+    // handshakes that don't carry the name. Read by SPV start in
+    // CoreContentView (`startSync`); editing here applies on the
+    // next SPV start.
+    @AppStorage("platformDevnetName") private var devnetName: String = ""
+
     /// Default localhost peer string for a given network. Used to
     /// pre-populate the peers text field when the user enables the
     /// custom-SPV toggle. The FFI drops bare-IP entries (no port),
@@ -235,6 +243,22 @@ struct OptionsView: View {
                             .keyboardType(.URL)
 
                             Text("SPV Peers + DAPI nodes are auto-discovered from {Quorum URL}/masternodes. Changes apply on the next SDK build (switch network or relaunch).")
+                                .font(.caption2)
+                                .foregroundColor(.secondary)
+
+                            Text("Devnet Name")
+                                .font(.caption)
+                                .foregroundColor(.secondary)
+                                .padding(.top, 8)
+                            TextField(
+                                "e.g. paloma  (matches dashd -devnet=<name>)",
+                                text: $devnetName
+                            )
+                            .font(.system(.body, design: .monospaced))
+                            .textInputAutocapitalization(.never)
+                            .autocorrectionDisabled()
+
+                            Text("Required to start SPV on devnet. The name is embedded in the SPV user agent (`devnet.devnet-<name>`) so Dash Core devnet peers accept the handshake. Applies on the next SPV start.")
                                 .font(.caption2)
                                 .foregroundColor(.secondary)
                         }


### PR DESCRIPTION
## Issue being fixed or feature implemented

The example app could already create an SDK against a devnet, but `Start Sync` would either fail or connect to the wrong peers because the SPV start path never told `dash-spv` it was running against a devnet. This PR enables SPV on devnet end-to-end.

## What was done?

**Example app — devnet identity is now part of the SPV start config**
- `OptionsView`: new \"Devnet Name\" text field next to the existing Quorum URL field, backed by `platformDevnetName` UserDefaults.
- `CoreContentView.startSync`: when `currentNetwork == .devnet`, reads `platformDevnetName` and passes it to `PlatformSpvStartConfig.devnetName`. Without this the FFI rejects the start with \"devnet_name is required when network=Devnet\".

**FFI — migrated to the new `dash-spv::DevnetConfig` surface**
- `packages/rs-platform-wallet-ffi/src/spv.rs`: replaced the removed `ClientConfig::llmq_devnet_params` field with `ClientConfig.devnet = Some(DevnetConfig::new(name).with_llmq_params(...))`.
- `packages/rs-platform-wallet/src/wallet/platform_wallet_traits.rs`: implemented the new `WalletInfoInterface::monitored_script_pubkeys` required method by delegating to the inner `ManagedWalletInfo`.
- `packages/rs-platform-wallet/src/spv/mod.rs`: re-exported `DevnetConfig` from `dash_spv` so the FFI layer can build it without depending on `dash-spv` directly.

**Dependency bump (the enabler)**
- Bumped `rust-dashcore` pin `58d61ea5` → `eb889af1` (current dev HEAD), picking up:
  - [`eb889af1`](https://github.com/dashpay/rust-dashcore/commit/eb889af13f667ed39c35e8e8a0830eeedf523476) feat(dash-spv): consolidate devnet config into `DevnetConfig` struct (#788)
  - [`9655ea38`](https://github.com/dashpay/rust-dashcore/commit/9655ea38) refactor: avoid rebuilding `script_pubkey`s for BIP158 filter matching (#781)

## How Has This Been Tested?

- `cargo check -p platform-wallet -p platform-wallet-ffi` against the bumped revision is clean.
- Manual UAT to follow: enter `platformQuorumURL` + `platformDevnetName` in Options on devnet, hit \"Start Sync\" on the Wallet tab, confirm SPV reaches the masternodes auto-discovered from `{quorumURL}/masternodes` and that headers / filters / masternodes progress all advance.

## Breaking Changes

None for downstream consumers. The Swift `PlatformSpvStartConfig.devnetName` parameter was already public (added in #3758); this PR just starts using it.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a persistent "Devnet Name" setting and UI field for configuring devnet identity.
  * SPV startup now accepts and validates an optional devnet name, enabling devnet-specific behavior and user-agent embedding on next sync.

* **Bug Fixes**
  * Wallet info now exposes monitored script pubkeys for improved wallet visibility.

* **Chores**
  * Updated internal dependency revisions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dashpay/platform/pull/3761?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->