### PR TITLE
chore: bump rust-dashcore to eb889af

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1550,7 +1550,7 @@ dependencies = [
 [[package]]
 name = "dash-network"
 version = "0.43.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=58d61ea50ac4c217c8e1350b57363b351a0b99d4#58d61ea50ac4c217c8e1350b57363b351a0b99d4"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=eb889af13f667ed39c35e8e8a0830eeedf523476#eb889af13f667ed39c35e8e8a0830eeedf523476"
 dependencies = [
  "bincode",
  "bincode_derive",
@@ -1561,7 +1561,7 @@ dependencies = [
 [[package]]
 name = "dash-network-seeds"
 version = "0.43.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=58d61ea50ac4c217c8e1350b57363b351a0b99d4#58d61ea50ac4c217c8e1350b57363b351a0b99d4"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=eb889af13f667ed39c35e8e8a0830eeedf523476#eb889af13f667ed39c35e8e8a0830eeedf523476"
 dependencies = [
  "dash-network",
 ]
@@ -1638,7 +1638,7 @@ dependencies = [
 [[package]]
 name = "dash-spv"
 version = "0.43.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=58d61ea50ac4c217c8e1350b57363b351a0b99d4#58d61ea50ac4c217c8e1350b57363b351a0b99d4"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=eb889af13f667ed39c35e8e8a0830eeedf523476#eb889af13f667ed39c35e8e8a0830eeedf523476"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1667,7 +1667,7 @@ dependencies = [
 [[package]]
 name = "dashcore"
 version = "0.43.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=58d61ea50ac4c217c8e1350b57363b351a0b99d4#58d61ea50ac4c217c8e1350b57363b351a0b99d4"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=eb889af13f667ed39c35e8e8a0830eeedf523476#eb889af13f667ed39c35e8e8a0830eeedf523476"
 dependencies = [
  "anyhow",
  "base64-compat",
@@ -1693,12 +1693,12 @@ dependencies = [
 [[package]]
 name = "dashcore-private"
 version = "0.43.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=58d61ea50ac4c217c8e1350b57363b351a0b99d4#58d61ea50ac4c217c8e1350b57363b351a0b99d4"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=eb889af13f667ed39c35e8e8a0830eeedf523476#eb889af13f667ed39c35e8e8a0830eeedf523476"
 
 [[package]]
 name = "dashcore-rpc"
 version = "0.43.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=58d61ea50ac4c217c8e1350b57363b351a0b99d4#58d61ea50ac4c217c8e1350b57363b351a0b99d4"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=eb889af13f667ed39c35e8e8a0830eeedf523476#eb889af13f667ed39c35e8e8a0830eeedf523476"
 dependencies = [
  "dashcore-rpc-json",
  "hex",
@@ -1711,7 +1711,7 @@ dependencies = [
 [[package]]
 name = "dashcore-rpc-json"
 version = "0.43.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=58d61ea50ac4c217c8e1350b57363b351a0b99d4#58d61ea50ac4c217c8e1350b57363b351a0b99d4"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=eb889af13f667ed39c35e8e8a0830eeedf523476#eb889af13f667ed39c35e8e8a0830eeedf523476"
 dependencies = [
  "bincode",
  "dashcore",
@@ -1726,7 +1726,7 @@ dependencies = [
 [[package]]
 name = "dashcore_hashes"
 version = "0.43.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=58d61ea50ac4c217c8e1350b57363b351a0b99d4#58d61ea50ac4c217c8e1350b57363b351a0b99d4"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=eb889af13f667ed39c35e8e8a0830eeedf523476#eb889af13f667ed39c35e8e8a0830eeedf523476"
 dependencies = [
  "bincode",
  "dashcore-private",
@@ -2636,7 +2636,7 @@ dependencies = [
 [[package]]
 name = "git-state"
 version = "0.43.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=58d61ea50ac4c217c8e1350b57363b351a0b99d4#58d61ea50ac4c217c8e1350b57363b351a0b99d4"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=eb889af13f667ed39c35e8e8a0830eeedf523476#eb889af13f667ed39c35e8e8a0830eeedf523476"
 
 [[package]]
 name = "glob"
@@ -3780,7 +3780,7 @@ dependencies = [
 [[package]]
 name = "key-wallet"
 version = "0.43.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=58d61ea50ac4c217c8e1350b57363b351a0b99d4#58d61ea50ac4c217c8e1350b57363b351a0b99d4"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=eb889af13f667ed39c35e8e8a0830eeedf523476#eb889af13f667ed39c35e8e8a0830eeedf523476"
 dependencies = [
  "aes",
  "async-trait",
@@ -3808,7 +3808,7 @@ dependencies = [
 [[package]]
 name = "key-wallet-ffi"
 version = "0.43.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=58d61ea50ac4c217c8e1350b57363b351a0b99d4#58d61ea50ac4c217c8e1350b57363b351a0b99d4"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=eb889af13f667ed39c35e8e8a0830eeedf523476#eb889af13f667ed39c35e8e8a0830eeedf523476"
 dependencies = [
  "cbindgen 0.29.2",
  "dash-network",
@@ -3824,7 +3824,7 @@ dependencies = [
 [[package]]
 name = "key-wallet-manager"
 version = "0.43.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=58d61ea50ac4c217c8e1350b57363b351a0b99d4#58d61ea50ac4c217c8e1350b57363b351a0b99d4"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=eb889af13f667ed39c35e8e8a0830eeedf523476#eb889af13f667ed39c35e8e8a0830eeedf523476"
 dependencies = [
  "async-trait",
  "bincode",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,14 +49,14 @@ members = [
 ]
 
 [workspace.dependencies]
-dashcore = { git = "https://github.com/dashpay/rust-dashcore", rev = "58d61ea50ac4c217c8e1350b57363b351a0b99d4" }
-dash-network-seeds = { git = "https://github.com/dashpay/rust-dashcore", rev = "58d61ea50ac4c217c8e1350b57363b351a0b99d4" }
-dash-spv = { git = "https://github.com/dashpay/rust-dashcore", rev = "58d61ea50ac4c217c8e1350b57363b351a0b99d4" }
-key-wallet = { git = "https://github.com/dashpay/rust-dashcore", rev = "58d61ea50ac4c217c8e1350b57363b351a0b99d4" }
-key-wallet-ffi = { git = "https://github.com/dashpay/rust-dashcore", rev = "58d61ea50ac4c217c8e1350b57363b351a0b99d4" }
-key-wallet-manager = { git = "https://github.com/dashpay/rust-dashcore", rev = "58d61ea50ac4c217c8e1350b57363b351a0b99d4" }
-dash-network = { git = "https://github.com/dashpay/rust-dashcore", rev = "58d61ea50ac4c217c8e1350b57363b351a0b99d4" }
-dashcore-rpc = { git = "https://github.com/dashpay/rust-dashcore", rev = "58d61ea50ac4c217c8e1350b57363b351a0b99d4" }
+dashcore = { git = "https://github.com/dashpay/rust-dashcore", rev = "eb889af13f667ed39c35e8e8a0830eeedf523476" }
+dash-network-seeds = { git = "https://github.com/dashpay/rust-dashcore", rev = "eb889af13f667ed39c35e8e8a0830eeedf523476" }
+dash-spv = { git = "https://github.com/dashpay/rust-dashcore", rev = "eb889af13f667ed39c35e8e8a0830eeedf523476" }
+key-wallet = { git = "https://github.com/dashpay/rust-dashcore", rev = "eb889af13f667ed39c35e8e8a0830eeedf523476" }
+key-wallet-ffi = { git = "https://github.com/dashpay/rust-dashcore", rev = "eb889af13f667ed39c35e8e8a0830eeedf523476" }
+key-wallet-manager = { git = "https://github.com/dashpay/rust-dashcore", rev = "eb889af13f667ed39c35e8e8a0830eeedf523476" }
+dash-network = { git = "https://github.com/dashpay/rust-dashcore", rev = "eb889af13f667ed39c35e8e8a0830eeedf523476" }
+dashcore-rpc = { git = "https://github.com/dashpay/rust-dashcore", rev = "eb889af13f667ed39c35e8e8a0830eeedf523476" }
 
 # Optimize heavy crypto crates even in dev/test builds so that
 # Halo 2 proof generation and verification run at near-release speed.

--- a/packages/rs-platform-wallet-ffi/src/spv.rs
+++ b/packages/rs-platform-wallet-ffi/src/spv.rs
@@ -4,7 +4,9 @@ use std::ffi::CStr;
 use std::os::raw::c_char;
 
 use dashcore::sml::llmq_type::LlmqDevnetParams;
-use platform_wallet::spv::{ClientConfig, ProgressPercentage, SyncProgress, SyncState};
+use platform_wallet::spv::{
+    ClientConfig, DevnetConfig, ProgressPercentage, SyncProgress, SyncState,
+};
 
 use crate::error::*;
 use crate::handle::*;
@@ -314,11 +316,15 @@ pub unsafe extern "C" fn platform_wallet_manager_spv_start(
                 config.peers.push(addr);
             }
         }
-        if llmq_devnet_size > 0 {
-            config.llmq_devnet_params = Some(LlmqDevnetParams {
-                size: llmq_devnet_size,
-                threshold: llmq_devnet_threshold,
-            });
+        if let Some(name) = devnet_name_str.as_deref() {
+            let mut devnet = DevnetConfig::new(name);
+            if llmq_devnet_size > 0 {
+                devnet.llmq_params = Some(LlmqDevnetParams {
+                    size: llmq_devnet_size,
+                    threshold: llmq_devnet_threshold,
+                });
+            }
+            config.devnet = Some(devnet);
         }
 
         let _guard = runtime().enter();

--- a/packages/rs-platform-wallet/src/spv/mod.rs
+++ b/packages/rs-platform-wallet/src/spv/mod.rs
@@ -8,5 +8,5 @@ pub use dash_spv::sync::{
     BlockHeadersProgress, FilterHeadersProgress, FiltersProgress, MasternodesProgress,
     ProgressPercentage, SyncProgress, SyncState,
 };
-pub use dash_spv::ClientConfig;
+pub use dash_spv::{ClientConfig, DevnetConfig};
 pub use tokio_util::sync::CancellationToken;

--- a/packages/rs-platform-wallet/src/wallet/platform_wallet_traits.rs
+++ b/packages/rs-platform-wallet/src/wallet/platform_wallet_traits.rs
@@ -9,7 +9,7 @@ use async_trait::async_trait;
 use dashcore::ephemerealdata::chain_lock::ChainLock;
 use dashcore::ephemerealdata::instant_lock::InstantLock;
 use dashcore::prelude::CoreBlockHeight;
-use dashcore::{Address as DashAddress, Transaction, Txid};
+use dashcore::{Address as DashAddress, ScriptBuf, Transaction, Txid};
 
 use key_wallet::account::AccountType;
 use key_wallet::bip32::ExtendedPubKey;
@@ -95,6 +95,10 @@ impl WalletInfoInterface for PlatformWalletInfo {
 
     fn monitored_addresses(&self) -> Vec<DashAddress> {
         self.core_wallet.monitored_addresses()
+    }
+
+    fn monitored_script_pubkeys(&self) -> Vec<ScriptBuf> {
+        self.core_wallet.monitored_script_pubkeys()
     }
 
     fn utxos(&self) -> BTreeSet<&Utxo> {


### PR DESCRIPTION
## Issue being fixed or feature implemented

Picks up two upstream rust-dashcore changes on top of `58d61ea`:

- [dashpay/rust-dashcore#781](https://github.com/dashpay/rust-dashcore/pull/781) — `refactor: avoid rebuilding script_pubkey`s for BIP158 filter matching`. Adds `monitored_script_pubkeys` to `WalletInfoInterface` and threads cached `ScriptBuf`s through the rescan path so a full testnet sync no longer rebuilds ~7M P2PKH `ScriptBuf`s.
- [dashpay/rust-dashcore#788](https://github.com/dashpay/rust-dashcore/pull/788) — `feat(dash-spv): consolidate devnet config into DevnetConfig struct`. Replaces `ClientConfig.llmq_devnet_params` with `ClientConfig.devnet: Option<DevnetConfig>`, which also holds the `-llmq{chainlocks,instantsenddip0024,platform}` routing overrides. `ClientConfig::validate` now enforces `devnet.is_some() == (network == Network::Devnet)`.

## What was done?

- `Cargo.toml` / `Cargo.lock`: bump all rust-dashcore git deps from `58d61ea` → `eb889af`.
- `packages/rs-platform-wallet/src/wallet/platform_wallet_traits.rs`: implement the new `monitored_script_pubkeys` trait method by delegating to the inner `ManagedWalletInfo`, and import `ScriptBuf`.
- `packages/rs-platform-wallet-ffi/src/spv.rs`: in `platform_wallet_manager_spv_start`, build a `DevnetConfig` whenever `devnet_name` is non-null and hang the optional `LlmqDevnetParams` off it, replacing the removed `ClientConfig.llmq_devnet_params` write. The FFI signature is unchanged.
- `packages/rs-platform-wallet/src/spv/mod.rs`: re-export `DevnetConfig` alongside `ClientConfig` so the FFI doesn't reach into `dash_spv` directly.

## How Has This Been Tested?

- `cargo check --workspace --tests` — clean.
- `cargo clippy -p platform-wallet -p platform-wallet-ffi --all-targets` — clean.
- `cargo fmt --all -- --check` — clean.

## Breaking Changes

None for consensus or external API. The `platform_wallet_manager_spv_start` FFI signature is unchanged; the existing `devnet_name` + `llmq_devnet_size`/`threshold` arguments still drive the same behavior, just routed through `DevnetConfig` instead of `ClientConfig.llmq_devnet_params`.

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [x] I have made corresponding changes to the documentation if needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved wallet information interface by exposing script pubkey monitoring capabilities for enhanced wallet transparency
  * Restructured devnet configuration initialization to provide more flexible network-specific parameter handling

* **Chores**
  * Updated core workspace dependencies to latest git revision for rust-dashcore family packages

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dashpay/platform/pull/3762?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->