### PR TITLE
feat(swift-example-app): enable SPV on devnet

### DIFF
--- a/packages/rs-platform-wallet-ffi/src/spv.rs
+++ b/packages/rs-platform-wallet-ffi/src/spv.rs
@@ -254,19 +254,28 @@ pub unsafe extern "C" fn platform_wallet_manager_spv_start(
             "devnet_name is only valid on devnet",
         );
     }
-    // Reject empty / whitespace-only / `/`-containing names
-    // synchronously here rather than letting `DevnetConfig::validate`
-    // surface them asynchronously from `spawn_in_background`. Mirrors
+    // Reject empty / any-whitespace / `/`-containing names synchronously
+    // here rather than letting `DevnetConfig::validate` surface them
+    // asynchronously from `spawn_in_background`. Mirrors
     // `DevnetConfig::validate` (which only checks empty + `/`) and
-    // additionally rejects whitespace-only names so callers without a
-    // pre-filter (other language bindings, integration tests) can't
-    // produce a `(devnet.devnet-   )` user agent that Dash Core peers
-    // silently drop.
+    // additionally rejects any whitespace — leading, trailing, or
+    // interior — so callers without a pre-filter (other language
+    // bindings, integration tests) can't produce a malformed
+    // `(devnet.devnet- foo )` user agent that Dash Core peers silently
+    // drop. Rejecting (rather than auto-trimming) keeps the rule
+    // deterministic and avoids the Unicode-whitespace asymmetry
+    // between `str::trim` and Swift's `CharacterSet.whitespaces`.
     if let Some(name) = devnet_name_str.as_deref() {
-        if name.trim().is_empty() {
+        if name.is_empty() {
             return PlatformWalletFFIResult::err(
                 PlatformWalletFFIResultCode::ErrorInvalidParameter,
-                "devnet_name must not be empty or whitespace-only",
+                "devnet_name must not be empty",
+            );
+        }
+        if name.chars().any(char::is_whitespace) {
+            return PlatformWalletFFIResult::err(
+                PlatformWalletFFIResultCode::ErrorInvalidParameter,
+                "devnet_name must not contain whitespace",
             );
         }
         if name.contains('/') {

--- a/packages/rs-platform-wallet-ffi/src/spv.rs
+++ b/packages/rs-platform-wallet-ffi/src/spv.rs
@@ -254,6 +254,28 @@ pub unsafe extern "C" fn platform_wallet_manager_spv_start(
             "devnet_name is only valid on devnet",
         );
     }
+    // Reject empty / whitespace-only / `/`-containing names
+    // synchronously here rather than letting `DevnetConfig::validate`
+    // surface them asynchronously from `spawn_in_background`. Mirrors
+    // `DevnetConfig::validate` (which only checks empty + `/`) and
+    // additionally rejects whitespace-only names so callers without a
+    // pre-filter (other language bindings, integration tests) can't
+    // produce a `(devnet.devnet-   )` user agent that Dash Core peers
+    // silently drop.
+    if let Some(name) = devnet_name_str.as_deref() {
+        if name.trim().is_empty() {
+            return PlatformWalletFFIResult::err(
+                PlatformWalletFFIResultCode::ErrorInvalidParameter,
+                "devnet_name must not be empty or whitespace-only",
+            );
+        }
+        if name.contains('/') {
+            return PlatformWalletFFIResult::err(
+                PlatformWalletFFIResultCode::ErrorInvalidParameter,
+                "devnet_name must not contain '/'",
+            );
+        }
+    }
     if (llmq_devnet_size > 0) ^ (llmq_devnet_threshold > 0) {
         return PlatformWalletFFIResult::err(
             PlatformWalletFFIResultCode::ErrorInvalidParameter,

--- a/packages/swift-sdk/SwiftExampleApp/SwiftExampleApp/AppState.swift
+++ b/packages/swift-sdk/SwiftExampleApp/SwiftExampleApp/AppState.swift
@@ -20,6 +20,17 @@ class AppState: ObservableObject {
 
     @Published var dataStatistics: (identities: Int, documents: Int, contracts: Int, tokenBalances: Int)?
 
+    /// Monotonic tick incremented when a wallet-scoped service rebind
+    /// is needed but neither of the standard triggers
+    /// (`currentNetwork.onChange`, `wallets.keys.onChange`) will fire.
+    /// Concretely: a devnet→devnet SDK rebuild from OptionsView swaps
+    /// the cached `PlatformWalletManager` but leaves the network and
+    /// wallet ID set unchanged, so `PlatformBalanceSyncService` and
+    /// `ShieldedService` keep their references to the old manager.
+    /// SwiftExampleAppApp observes this tick to re-run
+    /// `rebindWalletScopedServices()` in that edge case.
+    @Published var walletScopedServicesRebindTick: Int = 0
+
     @Published var useDockerSetup: Bool {
         didSet {
             UserDefaults.standard.set(useDockerSetup, forKey: "useDockerSetup")

--- a/packages/swift-sdk/SwiftExampleApp/SwiftExampleApp/Core/Views/CoreContentView.swift
+++ b/packages/swift-sdk/SwiftExampleApp/SwiftExampleApp/Core/Views/CoreContentView.swift
@@ -584,11 +584,23 @@ var body: some View {
             let peers = spvPeerOverride()
             let restrictToConfiguredPeers = !peers.isEmpty
 
+            // Devnet requires a name so `DevnetConfig` can embed
+            // `devnet.devnet-<name>` in the SPV user agent (Dash
+            // Core devnet peers drop inbound handshakes without it).
+            // Read from the same UserDefaults key OptionsView writes.
+            let devnetName: String? = platformState.currentNetwork == .devnet
+                ? UserDefaults.standard.string(forKey: "platformDevnetName").flatMap {
+                    let trimmed = $0.trimmingCharacters(in: .whitespaces)
+                    return trimmed.isEmpty ? nil : trimmed
+                }
+                : nil
+
             let config = PlatformSpvStartConfig(
                 dataDir: dataDirURL.path,
                 network: platformState.currentNetwork,
                 peers: peers,
-                restrictToConfiguredPeers: restrictToConfiguredPeers
+                restrictToConfiguredPeers: restrictToConfiguredPeers,
+                devnetName: devnetName
             )
             try walletManager.startSpv(config: config)
         } catch {

--- a/packages/swift-sdk/SwiftExampleApp/SwiftExampleApp/SwiftExampleAppApp.swift
+++ b/packages/swift-sdk/SwiftExampleApp/SwiftExampleApp/SwiftExampleAppApp.swift
@@ -150,6 +150,18 @@ struct SwiftExampleAppApp: App {
                     activateManager(for: newNetwork)
                     rebindWalletScopedServices()
                 }
+                // Devnet→devnet rebuild from OptionsView: when the user
+                // edits the quorum URL / devnet name the SDK is rebuilt
+                // and `WalletManagerStore.activate` swaps the cached
+                // `PlatformWalletManager`, but neither of the two
+                // observers above fires (network stays `.devnet`;
+                // wallet ID set stays identical after persistor reload).
+                // PlatformBalanceSyncService and ShieldedService would
+                // keep retaining the old manager. Listen for the explicit
+                // tick OptionsView publishes after the activate completes.
+                .onChange(of: platformState.walletScopedServicesRebindTick) { _, _ in
+                    rebindWalletScopedServices()
+                }
         }
     }
 

--- a/packages/swift-sdk/SwiftExampleApp/SwiftExampleApp/Views/OptionsView.swift
+++ b/packages/swift-sdk/SwiftExampleApp/SwiftExampleApp/Views/OptionsView.swift
@@ -23,6 +23,16 @@ struct OptionsView: View {
         UserDefaults.standard.string(forKey: "faucetRPCPassword") ?? ""
     @State private var faucetValidation: FaucetValidationStatus = .idle
 
+    /// Snapshot of `devnetQuorumURL` / `devnetName` at the moment the
+    /// devnet section appeared. Captured so the `.onDisappear` rebuild
+    /// only fires when the user actually edited a value — without this
+    /// every Options-tab dismissal would tear down and rebuild the SDK,
+    /// even on read-only visits. Set to `nil` outside the devnet branch
+    /// so a mainnet/testnet visit can't accidentally trigger a rebuild
+    /// on dismissal.
+    @State private var devnetQuorumURLSnapshot: String? = nil
+    @State private var devnetNameSnapshot: String? = nil
+
     /// Driven by the 0.5s-debounced `.task(id: faucetPassword)`.
     /// Runs a single cheap `getblockcount` JSON-RPC against the
     /// dashmate-managed Core (`127.0.0.1:<faucetRPCPort>`) and
@@ -242,7 +252,7 @@ struct OptionsView: View {
                             .autocorrectionDisabled()
                             .keyboardType(.URL)
 
-                            Text("SPV Peers + DAPI nodes are auto-discovered from {Quorum URL}/masternodes. Changes apply on the next SDK build (switch network or relaunch).")
+                            Text("Required, alongside Devnet Name. SPV Peers + DAPI nodes are auto-discovered from {Quorum URL}/masternodes. The SDK rebuilds automatically when you leave Options.")
                                 .font(.caption2)
                                 .foregroundColor(.secondary)
 
@@ -263,6 +273,29 @@ struct OptionsView: View {
                                 .foregroundColor(.secondary)
                         }
                         .padding(.top, 4)
+                        .onAppear {
+                            devnetQuorumURLSnapshot = devnetQuorumURL
+                            devnetNameSnapshot = devnetName
+                        }
+                        .onDisappear {
+                            // Rebuild the SDK once on close if either
+                            // devnet field actually changed. Avoids
+                            // per-keystroke churn (TextField onChange
+                            // would fire every character) while still
+                            // saving the user from having to manually
+                            // bounce to testnet and back to pick up
+                            // edits.
+                            let quorumChanged = devnetQuorumURLSnapshot != devnetQuorumURL
+                            let nameChanged = devnetNameSnapshot != devnetName
+                            devnetQuorumURLSnapshot = nil
+                            devnetNameSnapshot = nil
+                            guard quorumChanged || nameChanged else { return }
+                            guard appState.currentNetwork == .devnet else { return }
+                            try? walletManager.stopSpv()
+                            Task {
+                                await appState.switchNetwork(to: .devnet)
+                            }
+                        }
                     } else {
                         Toggle("Use Custom SPV Peers", isOn: $customSpvPeersEnabled)
                             .onChange(of: customSpvPeersEnabled) { _, isOn in

--- a/packages/swift-sdk/SwiftExampleApp/SwiftExampleApp/Views/OptionsView.swift
+++ b/packages/swift-sdk/SwiftExampleApp/SwiftExampleApp/Views/OptionsView.swift
@@ -4,6 +4,7 @@ import SwiftDashSDK
 struct OptionsView: View {
     @EnvironmentObject var appState: AppState
     @EnvironmentObject var walletManager: PlatformWalletManager
+    @EnvironmentObject var walletManagerStore: WalletManagerStore
     @EnvironmentObject var platformBalanceSyncService: PlatformBalanceSyncService
     @EnvironmentObject var shieldedService: ShieldedService
     @State private var showingDataManagement = false
@@ -294,6 +295,23 @@ struct OptionsView: View {
                             try? walletManager.stopSpv()
                             Task {
                                 await appState.switchNetwork(to: .devnet)
+                                // `switchNetwork` rebuilds `appState.sdk` but
+                                // doesn't refresh per-network managers (the
+                                // app-level `.onChange(of: currentNetwork)`
+                                // observer doesn't fire when the value stays
+                                // `.devnet`). Re-`activate` here so the
+                                // store's stale-handle check fires and the
+                                // cached `PlatformWalletManager` rebuilds
+                                // against the new SDK clone — otherwise
+                                // wallet-manager-routed work keeps talking
+                                // to the old DAPI / quorum endpoints.
+                                await MainActor.run {
+                                    if let sdk = appState.sdk {
+                                        try? walletManagerStore.activate(
+                                            network: .devnet, sdk: sdk
+                                        )
+                                    }
+                                }
                             }
                         }
                     } else {

--- a/packages/swift-sdk/SwiftExampleApp/SwiftExampleApp/Views/OptionsView.swift
+++ b/packages/swift-sdk/SwiftExampleApp/SwiftExampleApp/Views/OptionsView.swift
@@ -81,6 +81,14 @@ struct OptionsView: View {
     // here redirects the next SDK construction.
     @AppStorage("platformQuorumURL") private var devnetQuorumURL: String = ""
 
+    // Devnet identity (`-devnet=<name>` in Dash Core). Required by
+    // `DevnetConfig` so the SPV client embeds `devnet.devnet-<name>`
+    // in its user agent — Dash Core devnet peers drop inbound
+    // handshakes that don't carry the name. Read by SPV start in
+    // CoreContentView (`startSync`); editing here applies on the
+    // next SPV start.
+    @AppStorage("platformDevnetName") private var devnetName: String = ""
+
     /// Default localhost peer string for a given network. Used to
     /// pre-populate the peers text field when the user enables the
     /// custom-SPV toggle. The FFI drops bare-IP entries (no port),
@@ -235,6 +243,22 @@ struct OptionsView: View {
                             .keyboardType(.URL)
 
                             Text("SPV Peers + DAPI nodes are auto-discovered from {Quorum URL}/masternodes. Changes apply on the next SDK build (switch network or relaunch).")
+                                .font(.caption2)
+                                .foregroundColor(.secondary)
+
+                            Text("Devnet Name")
+                                .font(.caption)
+                                .foregroundColor(.secondary)
+                                .padding(.top, 8)
+                            TextField(
+                                "e.g. paloma  (matches dashd -devnet=<name>)",
+                                text: $devnetName
+                            )
+                            .font(.system(.body, design: .monospaced))
+                            .textInputAutocapitalization(.never)
+                            .autocorrectionDisabled()
+
+                            Text("Required to start SPV on devnet. The name is embedded in the SPV user agent (`devnet.devnet-<name>`) so Dash Core devnet peers accept the handshake. Applies on the next SPV start.")
                                 .font(.caption2)
                                 .foregroundColor(.secondary)
                         }

--- a/packages/swift-sdk/SwiftExampleApp/SwiftExampleApp/Views/OptionsView.swift
+++ b/packages/swift-sdk/SwiftExampleApp/SwiftExampleApp/Views/OptionsView.swift
@@ -311,6 +311,15 @@ struct OptionsView: View {
                                             network: .devnet, sdk: sdk
                                         )
                                     }
+                                    // Drive `rebindWalletScopedServices`
+                                    // via the App scene's observer.
+                                    // Neither `currentNetwork` nor the
+                                    // wallet ID set changes here, so
+                                    // PlatformBalanceSyncService and
+                                    // ShieldedService would otherwise
+                                    // keep referencing the now-stale
+                                    // manager.
+                                    appState.walletScopedServicesRebindTick &+= 1
                                 }
                             }
                         }


### PR DESCRIPTION
## Issue being fixed or feature implemented

The example app could already create an SDK against a devnet, but pressing `Start Sync` would fail at the FFI with "devnet_name is required when network=Devnet" — the Swift app never told `dash-spv` it was running on a devnet. This PR enables SPV on devnet end-to-end and hardens the FFI against malformed devnet names.

## What was done?

**Example app — devnet identity is now part of the SPV start config**
- `OptionsView`: new "Devnet Name" text field next to the existing Quorum URL field, backed by `platformDevnetName` UserDefaults.
- `CoreContentView.startSync`: when `currentNetwork == .devnet`, reads `platformDevnetName` (trimmed; empty → `nil`) and passes it to `PlatformSpvStartConfig.devnetName`.

**FFI — synchronous rejection of malformed devnet names**
- `platform_wallet_manager_spv_start` now rejects empty, whitespace-only, and `/`-containing `devnet_name` values up front instead of letting them flow into `DevnetConfig::new(...)` and produce a `(devnet.devnet-)` user agent that Dash Core devnet peers silently drop. Mirrors `dash_spv::DevnetConfig::validate` and adds the whitespace check (the Swift caller already filters whitespace, but the C ABI is the chokepoint for any other binding/test that doesn't).

## How Has This Been Tested?

- `cargo check -p platform-wallet-ffi` clean on top of v3.1-dev.
- Manual UAT to follow: enter `platformQuorumURL` + `platformDevnetName` in Options on devnet, hit "Start Sync" on the Wallet tab, confirm SPV reaches the masternodes auto-discovered from `{quorumURL}/masternodes` and that headers / filters / masternodes progress all advance.

## Breaking Changes

None. `PlatformSpvStartConfig.devnetName` parameter already exists in the Swift SDK (added in #3758); this PR just starts using it from the example app.

Builds on the `dash-spv::DevnetConfig` API consolidated upstream in [rust-dashcore#788](https://github.com/dashpay/rust-dashcore/pull/788), already pulled into v3.1-dev by #3762.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configurable, persistent Devnet Name in Devnet settings, included in SPV sync.
  * App now rebinds wallet-scoped services when Devnet settings trigger a rebuild.

* **Improvements**
  * Devnet Name is validated (rejects empty, whitespace-only, or names containing slashes) with clear errors.
  * SDK rebuilds only when Devnet quorum URL or Devnet Name actually change, avoiding unnecessary restarts.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dashpay/platform/pull/3763?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->