### PR TITLE
test(dpp,drive-abci): cover transfer-key signing rules for token transfers

### DIFF
--- a/packages/rs-dpp/src/state_transition/state_transitions/document/batch_transition/tests.rs
+++ b/packages/rs-dpp/src/state_transition/state_transitions/document/batch_transition/tests.rs
@@ -1,6 +1,10 @@
 #[cfg(test)]
 mod batch_transition_tests {
+    use crate::address_funds::AddressWitness;
+    use crate::identity::identity_public_key::accessors::v0::IdentityPublicKeyGettersV0;
+    use crate::identity::signer::Signer;
     use crate::identity::SecurityLevel;
+    use crate::identity::{IdentityPublicKey, KeyType, Purpose};
     use crate::state_transition::batch_transition::batched_transition::document_base_transition::v0::DocumentBaseTransitionV0;
     use crate::state_transition::batch_transition::batched_transition::document_base_transition::DocumentBaseTransition;
     use crate::state_transition::batch_transition::batched_transition::document_create_transition::v0::DocumentCreateTransitionV0;
@@ -35,8 +39,13 @@ mod batch_transition_tests {
         BatchTransitionV0, BatchTransitionV1,
     };
     use crate::state_transition::StateTransitionLike;
+    use crate::state_transition::StateTransition;
+    use crate::ProtocolError;
     use crate::data_contract::associated_token::token_distribution_key::TokenDistributionType;
+    use async_trait::async_trait;
     use platform_value::{BinaryData, Identifier};
+    use platform_version::version::PlatformVersion;
+    use rand::SeedableRng;
     use std::collections::BTreeMap;
 
     // -----------------------------------------------------------------------
@@ -135,6 +144,79 @@ mod batch_transition_tests {
             signature_public_key_id: 0,
             signature: BinaryData::default(),
         }
+    }
+
+    #[derive(Debug)]
+    struct TestSigner;
+
+    #[async_trait]
+    impl Signer<IdentityPublicKey> for TestSigner {
+        async fn sign(
+            &self,
+            _key: &IdentityPublicKey,
+            _data: &[u8],
+        ) -> Result<BinaryData, ProtocolError> {
+            Ok(vec![1, 2, 3].into())
+        }
+
+        async fn sign_create_witness(
+            &self,
+            _key: &IdentityPublicKey,
+            _data: &[u8],
+        ) -> Result<AddressWitness, ProtocolError> {
+            Err(ProtocolError::Generic(
+                "test signer does not create address witnesses".to_string(),
+            ))
+        }
+
+        fn can_sign_with(&self, _key: &IdentityPublicKey) -> bool {
+            true
+        }
+    }
+
+    fn critical_authentication_key(platform_version: &PlatformVersion) -> IdentityPublicKey {
+        IdentityPublicKey::random_ecdsa_critical_level_authentication_key(
+            1,
+            Some(1),
+            platform_version,
+        )
+        .expect("expected critical authentication key")
+        .0
+    }
+
+    fn high_authentication_key(platform_version: &PlatformVersion) -> IdentityPublicKey {
+        IdentityPublicKey::random_ecdsa_high_level_authentication_key(2, Some(2), platform_version)
+            .expect("expected high authentication key")
+            .0
+    }
+
+    fn critical_transfer_key(platform_version: &PlatformVersion) -> IdentityPublicKey {
+        IdentityPublicKey::random_key_with_known_attributes(
+            3,
+            &mut rand::prelude::StdRng::seed_from_u64(3),
+            Purpose::TRANSFER,
+            SecurityLevel::CRITICAL,
+            KeyType::ECDSA_HASH160,
+            None,
+            platform_version,
+        )
+        .expect("expected critical transfer key")
+        .0
+    }
+
+    async fn sign_token_transfer_batch_with_key(
+        key: &IdentityPublicKey,
+        transitions: Vec<BatchedTransition>,
+    ) -> Result<StateTransition, ProtocolError> {
+        let mut state_transition: StateTransition = make_batch_v1(transitions).into();
+        state_transition
+            .sign_external(
+                key,
+                &TestSigner,
+                None::<crate::state_transition::GetDataContractSecurityLevelRequirementFn>,
+            )
+            .await?;
+        Ok(state_transition)
     }
 
     // -----------------------------------------------------------------------
@@ -552,6 +634,72 @@ mod batch_transition_tests {
         let purposes = batch.purpose_requirement();
         // With more than 1 transition, purpose_requirement returns AUTHENTICATION only
         assert_eq!(purposes, vec![Purpose::AUTHENTICATION]);
+    }
+
+    #[tokio::test]
+    async fn signing_single_token_transfer_accepts_critical_authentication_key() {
+        let platform_version = PlatformVersion::latest();
+        let key = critical_authentication_key(platform_version);
+
+        let signed = sign_token_transfer_batch_with_key(
+            &key,
+            vec![BatchedTransition::Token(make_token_transfer_transition(1))],
+        )
+        .await
+        .expect("single token transfer should accept critical authentication key");
+
+        assert_eq!(signed.signature_public_key_id(), Some(key.id()));
+    }
+
+    #[tokio::test]
+    async fn signing_single_token_transfer_accepts_critical_transfer_key() {
+        let platform_version = PlatformVersion::latest();
+        let key = critical_transfer_key(platform_version);
+
+        let signed = sign_token_transfer_batch_with_key(
+            &key,
+            vec![BatchedTransition::Token(make_token_transfer_transition(1))],
+        )
+        .await
+        .expect("single token transfer should accept critical transfer key");
+
+        assert_eq!(signed.signature_public_key_id(), Some(key.id()));
+    }
+
+    #[tokio::test]
+    async fn signing_single_token_transfer_rejects_high_authentication_key() {
+        let platform_version = PlatformVersion::latest();
+        let key = high_authentication_key(platform_version);
+
+        let err = sign_token_transfer_batch_with_key(
+            &key,
+            vec![BatchedTransition::Token(make_token_transfer_transition(1))],
+        )
+        .await
+        .expect_err("token transitions require critical security");
+
+        assert!(matches!(
+            err,
+            ProtocolError::InvalidSignaturePublicKeySecurityLevelError(_)
+        ));
+    }
+
+    #[tokio::test]
+    async fn signing_multi_transition_batch_rejects_transfer_key() {
+        let platform_version = PlatformVersion::latest();
+        let key = critical_transfer_key(platform_version);
+
+        let err = sign_token_transfer_batch_with_key(
+            &key,
+            vec![
+                BatchedTransition::Token(make_token_transfer_transition(1)),
+                BatchedTransition::Token(make_token_burn_transition(2, 100)),
+            ],
+        )
+        .await
+        .expect_err("transfer keys are only allowed for single transfer or claim batches");
+
+        assert!(matches!(err, ProtocolError::WrongPublicKeyPurposeError(_)));
     }
 
     #[test]

--- a/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/batch/tests/token/transfer/mod.rs
+++ b/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/batch/tests/token/transfer/mod.rs
@@ -1,5 +1,6 @@
 use super::*;
 mod token_transfer_tests {
+    use crate::execution::validation::state_transition::tests::setup_identity_with_withdrawal_key_and_system_credits;
     use dpp::data_contract::change_control_rules::authorized_action_takers::AuthorizedActionTakers;
     use dpp::data_contract::change_control_rules::ChangeControlRules;
     use dpp::data_contract::change_control_rules::v0::ChangeControlRulesV0;
@@ -13,6 +14,7 @@ mod token_transfer_tests {
     use dpp::state_transition::batch_transition::batched_transition::BatchedTransitionMutRef;
     use dpp::state_transition::batch_transition::token_base_transition::token_base_transition_accessors::TokenBaseTransitionAccessors;
     use dpp::state_transition::batch_transition::token_base_transition::v0::v0_methods::TokenBaseTransitionV0Methods;
+    use dpp::identity::KeyType;
     use dpp::tokens::emergency_action::TokenEmergencyAction;
     use dpp::tokens::status::TokenStatus;
     use dpp::tokens::status::v0::TokenStatusV0;
@@ -119,6 +121,112 @@ mod token_transfer_tests {
             .expect("expected to fetch token balance");
         let expected_amount = 1337;
         assert_eq!(token_balance, Some(expected_amount));
+    }
+
+    #[tokio::test]
+    async fn test_token_transfer_signed_with_transfer_key() {
+        let platform_version = PlatformVersion::latest();
+        let mut platform = TestPlatformBuilder::new()
+            .with_latest_protocol_version()
+            .build_with_mock_rpc()
+            .set_genesis_state();
+
+        let mut rng = StdRng::seed_from_u64(49854);
+
+        let platform_state = platform.state.load();
+
+        let (identity, signer, _, transfer_key) =
+            setup_identity_with_withdrawal_key_and_system_credits(
+                &mut platform,
+                rng.gen(),
+                KeyType::ECDSA_HASH160,
+                dash_to_credits!(0.5),
+            );
+
+        let (recipient, _, _) = setup_identity(&mut platform, rng.gen(), dash_to_credits!(0.5));
+
+        let (contract, token_id) = create_token_contract_with_owner_identity(
+            &mut platform,
+            identity.id(),
+            None::<fn(&mut TokenConfiguration)>,
+            None,
+            None,
+            None,
+            platform_version,
+        );
+
+        let token_transfer_transition = BatchTransition::new_token_transfer_transition(
+            token_id,
+            identity.id(),
+            contract.id(),
+            0,
+            1337,
+            recipient.id(),
+            None,
+            None,
+            None,
+            &transfer_key,
+            2,
+            0,
+            &signer,
+            platform_version,
+            None,
+        )
+        .await
+        .expect("expect to create documents batch transition signed with transfer key");
+
+        let token_transfer_serialized_transition = token_transfer_transition
+            .serialize_to_bytes()
+            .expect("expected documents batch serialized state transition");
+
+        let transaction = platform.drive.grove.start_transaction();
+
+        let processing_result = platform
+            .platform
+            .process_raw_state_transitions(
+                &[token_transfer_serialized_transition.clone()],
+                &platform_state,
+                &BlockInfo::default(),
+                &transaction,
+                platform_version,
+                false,
+                None,
+            )
+            .expect("expected to process state transition");
+
+        assert_matches!(
+            processing_result.execution_results().as_slice(),
+            [StateTransitionExecutionResult::SuccessfulExecution { .. }]
+        );
+
+        platform
+            .drive
+            .grove
+            .commit_transaction(transaction)
+            .unwrap()
+            .expect("expected to commit transaction");
+
+        let token_balance = platform
+            .drive
+            .fetch_identity_token_balance(
+                token_id.to_buffer(),
+                identity.id().to_buffer(),
+                None,
+                platform_version,
+            )
+            .expect("expected to fetch token balance");
+        assert_eq!(token_balance, Some(100000 - 1337));
+
+        let token_balance = platform
+            .drive
+            .fetch_identity_token_balance(
+                token_id.to_buffer(),
+                recipient.id().to_buffer(),
+                None,
+                platform_version,
+            )
+            .expect("expected to fetch token balance");
+        assert_eq!(token_balance, Some(1337));
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Issue being fixed or feature implemented

Token-transfer signing has a split validation path: `sign_external` enforces token-batch security up front, while Drive's signature validation and the batch's advanced structure validation re-derive purpose/security from the batched transitions. The declared rule — a standalone token transfer accepts `AUTHENTICATION` or `TRANSFER` (CRITICAL), while multi-transition batches require `AUTHENTICATION` (CRITICAL) — was only thinly exercised:

- DPP signing tests didn't cover transfer-key acceptance, the high-authentication rejection, or the single-vs-multi transfer-key boundary.
- Drive token-transfer tests only used the default setup identity, which signs with its critical authentication key — no end-to-end coverage that a `CRITICAL TRANSFER` key actually clears advanced structure validation.

Without these, a manually signed transition could plausibly pass one validation layer and fail another, and we'd have no regression net for the boundary.

## What was done?

DPP unit tests in `batch_transition/tests.rs`:
- `signing_single_token_transfer_accepts_critical_authentication_key`
- `signing_single_token_transfer_accepts_critical_transfer_key`
- `signing_single_token_transfer_rejects_high_authentication_key` — expects `InvalidSignaturePublicKeySecurityLevelError`
- `signing_multi_transition_batch_rejects_transfer_key` — expects `WrongPublicKeyPurposeError`

Drive-abci end-to-end test in `batch/tests/token/transfer/mod.rs`:
- `test_token_transfer_signed_with_transfer_key` — signs a standalone token transfer with an `ECDSA_HASH160` CRITICAL TRANSFER key, processes the state transition, and asserts both sender and recipient balances post-execution.

These nail down the declared rule at both layers and prove the transfer-key path actually clears advanced structure validation, not just `sign_external`.

## How Has This Been Tested?

- `cargo test -p dash-sdk-dpp --lib state_transition::state_transitions::document::batch_transition::tests`
- `cargo test -p drive-abci --lib execution::validation::state_transition::state_transitions::batch::tests::token::transfer`

## Breaking Changes

None. Tests only.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Added test cases validating token transfer batch signing with authentication and transfer keys
  * Implemented validation for security level requirements in signing operations
  * Expanded test infrastructure for multi-transition batch signing scenarios
  * New tests verify token balance updates following transfer operations
  * Enhanced helper functions for test key generation and signing workflows

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dashpay/platform/pull/3766?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->