### PR TITLE
test(wasm-sdk): fix flaky tokenPaymentInfo document balance assertions

### DIFF
--- a/packages/wasm-sdk/tests/functional/transitions/documents.spec.ts
+++ b/packages/wasm-sdk/tests/functional/transitions/documents.spec.ts
@@ -30,6 +30,23 @@ describe('Document State Transitions', function describeDocumentStateTransitions
     const balances = await client.getIdentityTokenBalances(identityId, [tokenId]);
     return balances.get(tokenId);
   };
+  // Token balance proofs are served by nodes whose view can briefly lag the block
+  // that committed a state transition, so poll until the balance converges instead
+  // of asserting on a single immediate (and racy) read.
+  const expectTokenBalance = async (
+    identityId: string,
+    tokenId: string,
+    expected: bigint,
+    { timeoutMs = 30000, intervalMs = 500 } = {},
+  ) => {
+    const deadline = Date.now() + timeoutMs;
+    let actual = await getSingleTokenBalance(identityId, tokenId);
+    while (actual !== expected && Date.now() < deadline) {
+      await new Promise((resolve) => { setTimeout(resolve, intervalMs); });
+      actual = await getSingleTokenBalance(identityId, tokenId);
+    }
+    expect(actual).to.equal(expected);
+  };
   const buildSimpleTokenConfiguration = (baseSupply: bigint, newTokensDestinationIdentity: string) => {
     const contractOwner = sdk.AuthorizedActionTakers.ContractOwner();
     const contractOwnerChangeRules = new sdk.ChangeControlRules({
@@ -395,7 +412,7 @@ describe('Document State Transitions', function describeDocumentStateTransitions
 
       await waitForPlatform();
 
-      expect(await getSingleTokenBalance(testData.identityId, tokenPaidTokenId)).to.equal(1000n);
+      await expectTokenBalance(testData.identityId, tokenPaidTokenId, 1000n);
 
       await client.tokenTransfer({
         dataContractId: tokenPaidContractId,
@@ -419,9 +436,9 @@ describe('Document State Transitions', function describeDocumentStateTransitions
 
       await waitForPlatform();
 
-      expect(await getSingleTokenBalance(testData.identityId, tokenPaidTokenId)).to.equal(900n);
-      expect(await getSingleTokenBalance(testData.identityId2, tokenPaidTokenId)).to.equal(50n);
-      expect(await getSingleTokenBalance(testData.identityId3, tokenPaidTokenId)).to.equal(50n);
+      await expectTokenBalance(testData.identityId, tokenPaidTokenId, 900n);
+      await expectTokenBalance(testData.identityId2, tokenPaidTokenId, 50n);
+      await expectTokenBalance(testData.identityId3, tokenPaidTokenId, 50n);
     });
 
     it('should reject create when tokenPaymentInfo is omitted', async () => {
@@ -491,9 +508,9 @@ describe('Document State Transitions', function describeDocumentStateTransitions
 
       const { signer: sellerDocSigner, identityKey: sellerDocKey } = createTestSignerAndKey(sdk, 2, 2);
 
-      expect(await getSingleTokenBalance(testData.identityId, tokenPaidTokenId)).to.equal(900n);
-      expect(await getSingleTokenBalance(testData.identityId2, tokenPaidTokenId)).to.equal(50n);
-      expect(await getSingleTokenBalance(testData.identityId3, tokenPaidTokenId)).to.equal(50n);
+      await expectTokenBalance(testData.identityId, tokenPaidTokenId, 900n);
+      await expectTokenBalance(testData.identityId2, tokenPaidTokenId, 50n);
+      await expectTokenBalance(testData.identityId3, tokenPaidTokenId, 50n);
 
       const updatableTitle = `Token paid mutable listing ${Date.now()}`;
       const updatableDocument = new sdk.Document({
@@ -513,8 +530,8 @@ describe('Document State Transitions', function describeDocumentStateTransitions
         }),
       });
 
-      expect(await getSingleTokenBalance(testData.identityId2, tokenPaidTokenId)).to.equal(45n);
-      expect(await getSingleTokenBalance(testData.identityId, tokenPaidTokenId)).to.equal(905n);
+      await expectTokenBalance(testData.identityId2, tokenPaidTokenId, 45n);
+      await expectTokenBalance(testData.identityId, tokenPaidTokenId, 905n);
 
       await waitForPlatform();
 
@@ -536,8 +553,8 @@ describe('Document State Transitions', function describeDocumentStateTransitions
         }),
       });
 
-      expect(await getSingleTokenBalance(testData.identityId2, tokenPaidTokenId)).to.equal(41n);
-      expect(await getSingleTokenBalance(testData.identityId, tokenPaidTokenId)).to.equal(909n);
+      await expectTokenBalance(testData.identityId2, tokenPaidTokenId, 41n);
+      await expectTokenBalance(testData.identityId, tokenPaidTokenId, 909n);
 
       await waitForPlatform();
 
@@ -558,8 +575,8 @@ describe('Document State Transitions', function describeDocumentStateTransitions
         tokenPaymentInfo: makeTokenPaymentInfo(2n),
       });
 
-      expect(await getSingleTokenBalance(testData.identityId2, tokenPaidTokenId)).to.equal(39n);
-      expect(await getSingleTokenBalance(testData.identityId, tokenPaidTokenId)).to.equal(911n);
+      await expectTokenBalance(testData.identityId2, tokenPaidTokenId, 39n);
+      await expectTokenBalance(testData.identityId, tokenPaidTokenId, 911n);
 
       await waitForPlatform();
 
@@ -588,8 +605,8 @@ describe('Document State Transitions', function describeDocumentStateTransitions
         tokenPaymentInfo: makeTokenPaymentInfo(5n),
       });
 
-      expect(await getSingleTokenBalance(testData.identityId2, tokenPaidTokenId)).to.equal(34n);
-      expect(await getSingleTokenBalance(testData.identityId, tokenPaidTokenId)).to.equal(916n);
+      await expectTokenBalance(testData.identityId2, tokenPaidTokenId, 34n);
+      await expectTokenBalance(testData.identityId, tokenPaidTokenId, 916n);
 
       await waitForPlatform();
 
@@ -605,8 +622,8 @@ describe('Document State Transitions', function describeDocumentStateTransitions
         tokenPaymentInfo: makeTokenPaymentInfo(1n),
       });
 
-      expect(await getSingleTokenBalance(testData.identityId2, tokenPaidTokenId)).to.equal(33n);
-      expect(await getSingleTokenBalance(testData.identityId, tokenPaidTokenId)).to.equal(917n);
+      await expectTokenBalance(testData.identityId2, tokenPaidTokenId, 33n);
+      await expectTokenBalance(testData.identityId, tokenPaidTokenId, 917n);
     });
 
     it('should create, price, and purchase a document with tokenPaymentInfo', async () => {
@@ -616,9 +633,9 @@ describe('Document State Transitions', function describeDocumentStateTransitions
       const { signer: sellerDocSigner, identityKey: sellerDocKey } = createTestSignerAndKey(sdk, 2, 2);
       const { signer: buyerDocSigner, identityKey: buyerDocKey } = createTestSignerAndKey(sdk, 3, 2);
 
-      expect(await getSingleTokenBalance(testData.identityId, tokenPaidTokenId)).to.equal(917n);
-      expect(await getSingleTokenBalance(testData.identityId2, tokenPaidTokenId)).to.equal(33n);
-      expect(await getSingleTokenBalance(testData.identityId3, tokenPaidTokenId)).to.equal(50n);
+      await expectTokenBalance(testData.identityId, tokenPaidTokenId, 917n);
+      await expectTokenBalance(testData.identityId2, tokenPaidTokenId, 33n);
+      await expectTokenBalance(testData.identityId3, tokenPaidTokenId, 50n);
 
       const listingTitle = `Token paid listing ${Date.now()}`;
       const document = new sdk.Document({
@@ -638,8 +655,8 @@ describe('Document State Transitions', function describeDocumentStateTransitions
 
       tokenPaidDocumentId = document.id;
       expect(tokenPaidDocumentId).to.exist();
-      expect(await getSingleTokenBalance(testData.identityId2, tokenPaidTokenId)).to.equal(28n);
-      expect(await getSingleTokenBalance(testData.identityId, tokenPaidTokenId)).to.equal(922n);
+      await expectTokenBalance(testData.identityId2, tokenPaidTokenId, 28n);
+      await expectTokenBalance(testData.identityId, tokenPaidTokenId, 922n);
 
       await waitForPlatform();
 
@@ -660,8 +677,8 @@ describe('Document State Transitions', function describeDocumentStateTransitions
         tokenPaymentInfo: makeTokenPaymentInfo(2n),
       });
 
-      expect(await getSingleTokenBalance(testData.identityId2, tokenPaidTokenId)).to.equal(26n);
-      expect(await getSingleTokenBalance(testData.identityId, tokenPaidTokenId)).to.equal(924n);
+      await expectTokenBalance(testData.identityId2, tokenPaidTokenId, 26n);
+      await expectTokenBalance(testData.identityId, tokenPaidTokenId, 924n);
 
       await waitForPlatform();
 
@@ -691,9 +708,9 @@ describe('Document State Transitions', function describeDocumentStateTransitions
 
       expect(purchasedDocument).to.exist();
       expect(purchasedDocument.ownerId.toString()).to.equal(testData.identityId3);
-      expect(await getSingleTokenBalance(testData.identityId2, tokenPaidTokenId)).to.equal(26n);
-      expect(await getSingleTokenBalance(testData.identityId3, tokenPaidTokenId)).to.equal(47n);
-      expect(await getSingleTokenBalance(testData.identityId, tokenPaidTokenId)).to.equal(927n);
+      await expectTokenBalance(testData.identityId2, tokenPaidTokenId, 26n);
+      await expectTokenBalance(testData.identityId3, tokenPaidTokenId, 47n);
+      await expectTokenBalance(testData.identityId, tokenPaidTokenId, 927n);
     });
   });
 });

--- a/packages/wasm-sdk/tests/functional/transitions/documents.spec.ts
+++ b/packages/wasm-sdk/tests/functional/transitions/documents.spec.ts
@@ -39,13 +39,19 @@ describe('Document State Transitions', function describeDocumentStateTransitions
     expected: bigint,
     { timeoutMs = 30000, intervalMs = 500 } = {},
   ) => {
-    const deadline = Date.now() + timeoutMs;
+    const startedAt = Date.now();
+    const deadline = startedAt + timeoutMs;
     let actual = await getSingleTokenBalance(identityId, tokenId);
     while (actual !== expected && Date.now() < deadline) {
       await new Promise((resolve) => { setTimeout(resolve, intervalMs); });
       actual = await getSingleTokenBalance(identityId, tokenId);
     }
-    expect(actual).to.equal(expected);
+    // A timeout here is the most likely failure mode, so surface the triage data
+    // (which identity/token, what we waited for, how long, and the last read).
+    expect(actual).to.equal(
+      expected,
+      `token ${tokenId} balance for identity ${identityId} did not converge to ${expected} within ${Date.now() - startedAt}ms (last read: ${actual})`,
+    );
   };
   const buildSimpleTokenConfiguration = (baseSupply: bigint, newTokensDestinationIdentity: string) => {
     const contractOwner = sdk.AuthorizedActionTakers.ContractOwner();


### PR DESCRIPTION
## Issue being fixed or feature implemented
The nightly `Tests` workflow (`Packages functional tests / Run functional tests` → `Run WASM SDK functional tests`) has been failing intermittently for several scheduled runs, e.g. [run 26697658517](https://github.com/dashpay/platform/actions/runs/26697658517/job/78685260617).

The failures are in the `tokenPaymentInfo document flow` tests in `packages/wasm-sdk/tests/functional/transitions/documents.spec.ts`. They are flaky, not deterministic — different nightly runs fail on different lines with different stale values:

- 2026-05-30: line 592 `expected 911n to equal 916n`, line 619 `expected 916n to equal 917n`
- 2026-05-29: line 539 `expected 45n to equal 41n`, line 619 `expected 905n to equal 917n`

These tests pass on push-triggered runs only because the changed-package gating skips the WASM SDK functional suite there; the scheduled run exercises everything.

## What was done?
Root cause: each balance check was a single proof-verified `getIdentityTokenBalances` read taken **immediately** after a document state transition. That balance proof can be served by a node whose view briefly lags the block that committed the transition, so an immediate read intermittently returns a stale balance. The existing `waitForPlatform()` sleep sat *after* the assertions, so it never protected them.

Replaced the immediate `expect(await getSingleTokenBalance(...)).to.equal(x)` assertions with a new `expectTokenBalance(...)` helper that polls the balance until it converges to the expected value (500ms interval, 30s timeout) before asserting. On a clean read it returns immediately; under lag it waits instead of failing.

## How Has This Been Tested?
Change is test-only and mechanical (assertion sites rewritten to the polling helper; the expected values are unchanged). The expected balances were already correct — the suite passes on most runs — so converging on them removes the read-after-write race. Verified the full diff; no production code is touched.

## Breaking Changes
None.

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [ ] I have made corresponding changes to the documentation if needed

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved reliability of token-balance checks in document/payment-flow tests by switching to a polling-based verification to handle timing variations after state transitions.
  * Updated test assertions and expected post-transition token amounts for all involved parties (seller, buyer, third-party) to reflect finalized balances.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->