### PR TITLE
ci: auto-close stale AI-agent draft PRs

### DIFF
--- a/.github/workflows/close-stale-ai-draft-prs.yml
+++ b/.github/workflows/close-stale-ai-draft-prs.yml
@@ -1,0 +1,271 @@
+name: "Close Stale AI Draft PRs"
+
+# Daily housekeeping job that warns about, and eventually closes, draft PRs
+# opened by automated agents once they go quiet. A draft is "stale" after a
+# week with no activity; it is then closed after an additional grace period
+# unless someone touches it again.
+
+on:
+  schedule:
+    - cron: "0 7 * * *" # Daily 07:00 UTC
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "Log the actions that would be taken without applying them"
+        type: boolean
+        default: false
+
+permissions:
+  pull-requests: write
+  issues: write
+
+concurrency:
+  group: close-stale-ai-draft-prs
+  cancel-in-progress: false
+
+jobs:
+  close-stale-ai-draft-prs:
+    name: Close stale AI draft PRs
+    runs-on: ubuntu-24.04
+    if: github.repository == 'dashpay/platform'
+    steps:
+      - name: Warn and close stale AI-authored draft PRs
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
+        env:
+          # Comma / space / newline separated GitHub logins treated as AI agents.
+          # Override without editing this file by setting the `AI_AGENT_AUTHORS`
+          # repository variable (Settings → Secrets and variables → Actions → Variables).
+          AGENT_AUTHORS: ${{ vars.AI_AGENT_AUTHORS }}
+          # Days of inactivity before a draft is marked stale and warned.
+          DAYS_BEFORE_STALE: "7"
+          # Additional days after the warning before the draft is closed.
+          DAYS_BEFORE_CLOSE: "3"
+          STALE_LABEL: "stale"
+          # "true" on a manual run with the dry_run input checked; otherwise "false".
+          DRY_RUN: ${{ github.event_name == 'workflow_dispatch' && inputs.dry_run || 'false' }}
+        with:
+          script: |
+            const DAY_MS = 24 * 60 * 60 * 1000;
+            const now = Date.now();
+
+            const daysBeforeStale = Number(process.env.DAYS_BEFORE_STALE || '7');
+            const daysBeforeClose = Number(process.env.DAYS_BEFORE_CLOSE || '3');
+            const staleLabel = (process.env.STALE_LABEL || 'stale').trim();
+            const dryRun = String(process.env.DRY_RUN || 'false') === 'true';
+
+            // Actors whose activity is this workflow's own bookkeeping and must NOT
+            // count as "the author or a maintainer touched the PR".
+            const botActors = new Set(['github-actions[bot]', 'github-actions']);
+
+            // Default agent allowlist, used when AI_AGENT_AUTHORS is not configured.
+            const defaultAgents = ['Claudius-Maginificent', 'thepastaclaw'];
+            const configured = (process.env.AGENT_AUTHORS || '')
+              .split(/[\s,]+/)
+              .map((s) => s.trim())
+              .filter(Boolean);
+            const agentLogins = new Set(
+              (configured.length ? configured : defaultAgents).map((s) => s.toLowerCase())
+            );
+
+            core.info(`AI agent authors: ${[...agentLogins].join(', ')}`);
+            core.info(
+              `Thresholds: warn after ${daysBeforeStale}d idle, close ${daysBeforeClose}d after the warning`
+            );
+            if (dryRun) core.info('DRY RUN — no changes will be made');
+
+            const { owner, repo } = context.repo;
+
+            const allOpen = await github.paginate(github.rest.pulls.list, {
+              owner,
+              repo,
+              state: 'open',
+              per_page: 100,
+            });
+
+            const targets = allOpen.filter(
+              (pr) => pr.draft && pr.user && agentLogins.has(pr.user.login.toLowerCase())
+            );
+
+            core.info(`Found ${targets.length} open draft PR(s) authored by AI agents`);
+            if (targets.length === 0) return;
+
+            // Most recent activity (ms) that is NOT this workflow's own stale-label
+            // bookkeeping or comments. Used to decide idleness and to reset the clock
+            // when a human/agent resumes work on a stale PR.
+            async function lastActivityMs(pr) {
+              const events = await github.paginate(github.rest.issues.listEventsForTimeline, {
+                owner,
+                repo,
+                issue_number: pr.number,
+                per_page: 100,
+              });
+
+              let last = new Date(pr.created_at).getTime();
+
+              for (const e of events) {
+                // Ignore the stale label being added/removed — it is our own bookkeeping.
+                if (
+                  (e.event === 'labeled' || e.event === 'unlabeled') &&
+                  e.label &&
+                  e.label.name === staleLabel
+                ) {
+                  continue;
+                }
+
+                const actor = (e.actor && e.actor.login) || (e.user && e.user.login) || null;
+                if (actor && botActors.has(actor)) continue;
+
+                const ts =
+                  e.created_at ||
+                  e.submitted_at ||
+                  (e.committer && e.committer.date) ||
+                  (e.author && e.author.date) ||
+                  null;
+                if (!ts) continue;
+
+                const t = new Date(ts).getTime();
+                if (!Number.isNaN(t) && t > last) last = t;
+              }
+
+              return last;
+            }
+
+            // When (ms) the stale label was most recently applied, or null if not found.
+            async function staleSinceMs(pr) {
+              const evs = await github.paginate(github.rest.issues.listEvents, {
+                owner,
+                repo,
+                issue_number: pr.number,
+                per_page: 100,
+              });
+              let when = null;
+              for (const e of evs) {
+                if (e.event === 'labeled' && e.label && e.label.name === staleLabel) {
+                  const t = new Date(e.created_at).getTime();
+                  if (when === null || t > when) when = t;
+                }
+              }
+              return when;
+            }
+
+            // Make sure the stale label exists before we try to apply it.
+            async function ensureLabel(name) {
+              try {
+                await github.rest.issues.getLabel({ owner, repo, name });
+              } catch (err) {
+                if (err.status !== 404) throw err;
+                core.info(`Creating missing label "${name}"`);
+                if (!dryRun) {
+                  await github.rest.issues.createLabel({
+                    owner,
+                    repo,
+                    name,
+                    color: 'ededed',
+                    description: 'No recent activity; scheduled for automatic close',
+                  });
+                }
+              }
+            }
+
+            let labelEnsured = false;
+
+            for (const pr of targets) {
+              const hasStale = (pr.labels || []).some((l) => (l.name || l) === staleLabel);
+              const lastMs = await lastActivityMs(pr);
+              const idleDays = (now - lastMs) / DAY_MS;
+
+              core.info(
+                `#${pr.number} "${pr.title}" by @${pr.user.login} — idle ${idleDays.toFixed(
+                  1
+                )}d, stale=${hasStale}`
+              );
+
+              // Not yet warned: mark stale once it crosses the inactivity threshold.
+              if (!hasStale) {
+                if (idleDays < daysBeforeStale) continue;
+
+                core.info(`  → marking stale (idle ${idleDays.toFixed(1)}d ≥ ${daysBeforeStale}d)`);
+                if (dryRun) continue;
+
+                if (!labelEnsured) {
+                  await ensureLabel(staleLabel);
+                  labelEnsured = true;
+                }
+
+                await github.rest.issues.addLabels({
+                  owner,
+                  repo,
+                  issue_number: pr.number,
+                  labels: [staleLabel],
+                });
+                await github.rest.issues.createComment({
+                  owner,
+                  repo,
+                  issue_number: pr.number,
+                  body: [
+                    `👋 This draft PR has had no activity for **${Math.floor(idleDays)} days**.`,
+                    ``,
+                    `It was opened by an automated agent, so it has been marked **\`${staleLabel}\`** and will be **closed in ${daysBeforeClose} days** unless there is new activity.`,
+                    ``,
+                    `To keep it open, just push a commit, leave a comment, or remove the \`${staleLabel}\` label. Closed PRs can be reopened at any time.`,
+                  ].join('\n'),
+                });
+                continue;
+              }
+
+              // Already warned but active again: clear the label and reset the clock.
+              if (idleDays < daysBeforeStale) {
+                core.info(
+                  `  → activity resumed (idle ${idleDays.toFixed(1)}d) — removing \`${staleLabel}\` label`
+                );
+                if (dryRun) continue;
+                await github.rest.issues
+                  .removeLabel({ owner, repo, issue_number: pr.number, name: staleLabel })
+                  .catch((err) =>
+                    core.warning(`Could not remove label from #${pr.number}: ${err.message}`)
+                  );
+                continue;
+              }
+
+              // Still stale: close only after the grace period has elapsed since the warning.
+              const warnedAt = await staleSinceMs(pr);
+              if (warnedAt === null) {
+                core.warning(
+                  `  #${pr.number} is labeled \`${staleLabel}\` but no labeling event was found; skipping`
+                );
+                continue;
+              }
+              const daysSinceWarning = (now - warnedAt) / DAY_MS;
+              if (daysSinceWarning < daysBeforeClose) {
+                core.info(
+                  `  → in grace period (${daysSinceWarning.toFixed(1)}d / ${daysBeforeClose}d since warning)`
+                );
+                continue;
+              }
+
+              core.info(
+                `  → closing (idle ${idleDays.toFixed(1)}d, ${daysSinceWarning.toFixed(
+                  1
+                )}d since warning)`
+              );
+              if (dryRun) continue;
+
+              await github.rest.issues.createComment({
+                owner,
+                repo,
+                issue_number: pr.number,
+                body: [
+                  `🤖 Closing this draft PR after **${Math.floor(
+                    idleDays
+                  )} days** without activity (warned ${Math.floor(daysSinceWarning)} days ago).`,
+                  ``,
+                  `Feel free to reopen it if work continues.`,
+                ].join('\n'),
+              });
+              await github.rest.pulls.update({
+                owner,
+                repo,
+                pull_number: pr.number,
+                state: 'closed',
+              });
+            }

--- a/.github/workflows/close-stale-ai-draft-prs.yml
+++ b/.github/workflows/close-stale-ai-draft-prs.yml
@@ -40,7 +40,11 @@ jobs:
           DAYS_BEFORE_STALE: "7"
           # Additional days after the warning before the draft is closed.
           DAYS_BEFORE_CLOSE: "3"
-          STALE_LABEL: "stale"
+          # Workflow-private label. Do NOT use a generic name like "stale": this
+          # label is the state for the warn → close machine, and an unrelated
+          # actor applying a generic label must not be able to drive or
+          # short-circuit it.
+          STALE_LABEL: "ai-agent-stale"
           # "true" on a manual run with the dry_run input checked; otherwise "false".
           DRY_RUN: ${{ github.event_name == 'workflow_dispatch' && inputs.dry_run || 'false' }}
         with:
@@ -50,12 +54,48 @@ jobs:
 
             const daysBeforeStale = Number(process.env.DAYS_BEFORE_STALE || '7');
             const daysBeforeClose = Number(process.env.DAYS_BEFORE_CLOSE || '3');
-            const staleLabel = (process.env.STALE_LABEL || 'stale').trim();
+            const staleLabel = (process.env.STALE_LABEL || 'ai-agent-stale').trim();
             const dryRun = String(process.env.DRY_RUN || 'false') === 'true';
 
-            // Actors whose activity is this workflow's own bookkeeping and must NOT
-            // count as "the author or a maintainer touched the PR".
+            // Exact bot logins always treated as automation, plus the general
+            // rule below (any login ending in "[bot]") that covers GitHub Apps
+            // such as coderabbitai[bot], dependabot[bot], codecov[bot], etc.
             const botActors = new Set(['github-actions[bot]', 'github-actions']);
+            const isBotLogin = (login) =>
+              !!login && (botActors.has(login) || /\[bot\]$/i.test(login));
+
+            // A commit's timeline entry carries no GitHub user object — identity
+            // lives in author/committer name+email. Treat "[bot]" markers there
+            // (e.g. github-actions[bot], release scripts) as automation so a
+            // bot-driven rebase/force-push cannot keep an abandoned draft alive.
+            const isBotCommit = (e) =>
+              /\[bot\]/i.test(
+                [
+                  e.author && e.author.name,
+                  e.author && e.author.email,
+                  e.committer && e.committer.name,
+                  e.committer && e.committer.email,
+                ]
+                  .filter(Boolean)
+                  .join(' ')
+              );
+
+            // Only these timeline events reset the inactivity clock. Bookkeeping
+            // events (subscribed/mentioned/assigned/…) are intentionally ignored.
+            // `labeled`/`unlabeled` are included so a human removing the stale
+            // label counts as a deliberate "keep this open" signal; this
+            // workflow's own label changes are filtered out via isBotLogin.
+            const activityEvents = new Set([
+              'committed',
+              'head_ref_force_pushed',
+              'commented',
+              'reviewed',
+              'review_requested',
+              'ready_for_review',
+              'renamed',
+              'labeled',
+              'unlabeled',
+            ]);
 
             // Default agent allowlist, used when AI_AGENT_AUTHORS is not configured.
             const defaultAgents = ['Claudius-Maginificent', 'thepastaclaw'];
@@ -89,9 +129,10 @@ jobs:
             core.info(`Found ${targets.length} open draft PR(s) authored by AI agents`);
             if (targets.length === 0) return;
 
-            // Most recent activity (ms) that is NOT this workflow's own stale-label
-            // bookkeeping or comments. Used to decide idleness and to reset the clock
-            // when a human/agent resumes work on a stale PR.
+            // Most recent genuine activity (ms). Automation — this workflow's own
+            // label/comment bookkeeping and any other bot — is excluded so it can
+            // never reset the clock, while real human/agent work (commits,
+            // comments, reviews, deliberate label changes) does.
             async function lastActivityMs(pr) {
               const events = await github.paginate(github.rest.issues.listEventsForTimeline, {
                 owner,
@@ -103,17 +144,14 @@ jobs:
               let last = new Date(pr.created_at).getTime();
 
               for (const e of events) {
-                // Ignore the stale label being added/removed — it is our own bookkeeping.
-                if (
-                  (e.event === 'labeled' || e.event === 'unlabeled') &&
-                  e.label &&
-                  e.label.name === staleLabel
-                ) {
-                  continue;
-                }
+                if (!activityEvents.has(e.event)) continue;
 
-                const actor = (e.actor && e.actor.login) || (e.user && e.user.login) || null;
-                if (actor && botActors.has(actor)) continue;
+                if (e.event === 'committed') {
+                  if (isBotCommit(e)) continue;
+                } else {
+                  const actor = (e.actor && e.actor.login) || (e.user && e.user.login) || null;
+                  if (isBotLogin(actor)) continue;
+                }
 
                 const ts =
                   e.created_at ||
@@ -130,7 +168,9 @@ jobs:
               return last;
             }
 
-            // When (ms) the stale label was most recently applied, or null if not found.
+            // When (ms) this workflow most recently applied the stale label, or
+            // null if it never did. Only bot-applied labels count so the grace
+            // period is measured from our own warning, not a manual label.
             async function staleSinceMs(pr) {
               const evs = await github.paginate(github.rest.issues.listEvents, {
                 owner,
@@ -140,7 +180,12 @@ jobs:
               });
               let when = null;
               for (const e of evs) {
-                if (e.event === 'labeled' && e.label && e.label.name === staleLabel) {
+                if (
+                  e.event === 'labeled' &&
+                  e.label &&
+                  e.label.name === staleLabel &&
+                  isBotLogin(e.actor && e.actor.login)
+                ) {
                   const t = new Date(e.created_at).getTime();
                   if (when === null || t > when) when = t;
                 }
@@ -161,7 +206,7 @@ jobs:
                     repo,
                     name,
                     color: 'ededed',
-                    description: 'No recent activity; scheduled for automatic close',
+                    description: 'Idle AI-agent draft PR scheduled for automatic close',
                   });
                 }
               }
@@ -169,7 +214,9 @@ jobs:
 
             let labelEnsured = false;
 
-            for (const pr of targets) {
+            // Process a single PR. Returns once it has taken (or skipped) its
+            // action; the caller isolates failures so one PR cannot abort the run.
+            async function processPr(pr) {
               const hasStale = (pr.labels || []).some((l) => (l.name || l) === staleLabel);
               const lastMs = await lastActivityMs(pr);
               const idleDays = (now - lastMs) / DAY_MS;
@@ -182,10 +229,10 @@ jobs:
 
               // Not yet warned: mark stale once it crosses the inactivity threshold.
               if (!hasStale) {
-                if (idleDays < daysBeforeStale) continue;
+                if (idleDays < daysBeforeStale) return;
 
                 core.info(`  → marking stale (idle ${idleDays.toFixed(1)}d ≥ ${daysBeforeStale}d)`);
-                if (dryRun) continue;
+                if (dryRun) return;
 
                 if (!labelEnsured) {
                   await ensureLabel(staleLabel);
@@ -210,7 +257,7 @@ jobs:
                     `To keep it open, just push a commit, leave a comment, or remove the \`${staleLabel}\` label. Closed PRs can be reopened at any time.`,
                   ].join('\n'),
                 });
-                continue;
+                return;
               }
 
               // Already warned but active again: clear the label and reset the clock.
@@ -218,29 +265,29 @@ jobs:
                 core.info(
                   `  → activity resumed (idle ${idleDays.toFixed(1)}d) — removing \`${staleLabel}\` label`
                 );
-                if (dryRun) continue;
+                if (dryRun) return;
                 await github.rest.issues
                   .removeLabel({ owner, repo, issue_number: pr.number, name: staleLabel })
                   .catch((err) =>
                     core.warning(`Could not remove label from #${pr.number}: ${err.message}`)
                   );
-                continue;
+                return;
               }
 
               // Still stale: close only after the grace period has elapsed since the warning.
               const warnedAt = await staleSinceMs(pr);
               if (warnedAt === null) {
                 core.warning(
-                  `  #${pr.number} is labeled \`${staleLabel}\` but no labeling event was found; skipping`
+                  `  #${pr.number} has \`${staleLabel}\` but this workflow never applied it; skipping`
                 );
-                continue;
+                return;
               }
               const daysSinceWarning = (now - warnedAt) / DAY_MS;
               if (daysSinceWarning < daysBeforeClose) {
                 core.info(
                   `  → in grace period (${daysSinceWarning.toFixed(1)}d / ${daysBeforeClose}d since warning)`
                 );
-                continue;
+                return;
               }
 
               core.info(
@@ -248,7 +295,7 @@ jobs:
                   1
                 )}d since warning)`
               );
-              if (dryRun) continue;
+              if (dryRun) return;
 
               await github.rest.issues.createComment({
                 owner,
@@ -268,4 +315,12 @@ jobs:
                 pull_number: pr.number,
                 state: 'closed',
               });
+            }
+
+            for (const pr of targets) {
+              try {
+                await processPr(pr);
+              } catch (err) {
+                core.warning(`Failed to process #${pr.number}: ${err.message}`);
+              }
             }


### PR DESCRIPTION
## Issue being fixed or feature implemented
Draft PRs opened by automated agents tend to accumulate and go stale, cluttering the open-PR list with abandoned work. There is no automated housekeeping to retire them.

This adds a daily CI job that warns about, and eventually closes, agent-authored draft PRs once they go quiet — while leaving an audit trail and an easy way to keep a PR open.

## What was done?
Added `.github/workflows/close-stale-ai-draft-prs.yml`, a scheduled (`cron: "0 7 * * *"`, daily 07:00 UTC) workflow using `actions/github-script`.

Behavior, per **open draft PR authored by an allowlisted agent account**:

- **Warn (7 days idle):** mark the PR `stale` and post a comment explaining it will be closed in 3 days unless there is new activity. The `stale` label is auto-created if the repo doesn't have it.
- **Close (3 days after the warning, still idle):** comment and close the PR. Effective close happens ~10 days after the last activity.
- **Reset:** if the author or anyone resumes work (commit, comment, review, non-bookkeeping label change), the clock resets and the `stale` label is removed.

Design notes:
- **Agent detection is by author allowlist.** Defaults to the known agent accounts (`Claudius-Maginificent`, `thepastaclaw`) and can be overridden — without editing the workflow — via the `AI_AGENT_AUTHORS` repository variable (comma/space/newline separated logins).
- **The workflow's own actions never reset the clock.** Last-activity is computed from the issue timeline excluding `github-actions[bot]` comments and the `stale` label add/remove, so the warning comment itself doesn't keep a PR alive.
- **Grace window is measured from the actual `stale`-labeling event** (issue events API), not from `updated_at`.
- **Safety:** scoped to `dashpay/platform` via `if:`, least-privilege `pull-requests: write` / `issues: write` permissions, a `concurrency` group, and a `workflow_dispatch` `dry_run` input for a no-op trial run. Untrusted PR content is passed via `env`, never interpolated into the script.

Thresholds (`DAYS_BEFORE_STALE=7`, `DAYS_BEFORE_CLOSE=3`, `STALE_LABEL=stale`) are env vars at the top of the step for easy tuning.

## How Has This Been Tested?
- `python3 yaml.safe_load` — workflow parses; triggers `schedule` + `workflow_dispatch` confirmed.
- `node --check` on the embedded script (wrapped in an async fn as `github-script` does) — syntax OK.
- A standalone Node simulation drove the script against a mocked Octokit across 13 scenarios: warn at 7d, skip when <7d idle (via real comment/commit events), skip non-agent authors, skip non-drafts, grace-period hold, close after grace, reset/un-stale on resumed activity, dry-run no-ops, allowlist override, and missing-label auto-create. All produced the expected actions.

## Breaking Changes
None. New CI workflow only; no code or consensus changes.

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [ ] I have made corresponding changes to the documentation if needed

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added an automated workflow to manage idle AI-generated draft pull requests.
  * Draft PRs are detected and labeled as stale after a configurable period of inactivity.
  * Stale draft PRs are closed automatically after a subsequent configurable grace period, with warning and closing comments posted.
  * Supports a manual dry-run mode that logs intended actions without modifying PRs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->