### PR TITLE
fix(platform-version): gate shielded-pool block methods to protocol v12

### DIFF
--- a/packages/rs-platform-version/src/version/drive_abci_versions/drive_abci_method_versions/mod.rs
+++ b/packages/rs-platform-version/src/version/drive_abci_versions/drive_abci_method_versions/mod.rs
@@ -7,6 +7,7 @@ pub mod v4;
 pub mod v5;
 pub mod v6;
 pub mod v7;
+pub mod v8;
 
 #[derive(Clone, Debug, Default)]
 pub struct DriveAbciMethodVersions {

--- a/packages/rs-platform-version/src/version/drive_abci_versions/drive_abci_method_versions/v8.rs
+++ b/packages/rs-platform-version/src/version/drive_abci_versions/drive_abci_method_versions/v8.rs
@@ -12,18 +12,18 @@ use crate::version::drive_abci_versions::drive_abci_method_versions::{
     DriveAbciVotingMethodVersions,
 };
 
-// Introduced in Protocol version 11 (3.0.0) for checkpoints.
+// Introduced in Protocol version 12 for the shielded credit pool.
 //
-// The four shielded-pool block-processing methods
-// (`store_nullifiers_to_recent_block_storage`,
-// `cleanup_recent_block_storage_nullifiers`, `record_shielded_pool_anchor`,
-// `prune_shielded_pool_anchors`) are deliberately `None` here: they read the
-// shielded credit pool subtree `[ShieldedBalances (52), "M"]`, which is only
-// created from protocol v12 onward. Activating them on a v11 state opens a
-// subtree that does not exist and panics consensus with
-// "path parent layer not found: could not get key 4d for parent [52]".
-// The shielded activation lives in DRIVE_ABCI_METHOD_VERSIONS_V8 (protocol v12).
-pub const DRIVE_ABCI_METHOD_VERSIONS_V7: DriveAbciMethodVersions = DriveAbciMethodVersions {
+// Identical to DRIVE_ABCI_METHOD_VERSIONS_V7 (the protocol-v11 method set)
+// except the four shielded-pool block-processing methods are active here.
+// These read/write the shielded credit pool subtree
+// `[RootTree::ShieldedBalances (52), MAIN_SHIELDED_CREDIT_POOL_KEY ("M")]`,
+// which only exists from protocol v12 onward (created by the v12 upgrade
+// migration `transition_to_version_12` or a v12 genesis). They MUST stay
+// inactive on v11 (see DRIVE_ABCI_METHOD_VERSIONS_V7), so the shielded
+// activation lives in this dedicated v12 struct rather than being shared
+// with v11 via V7.
+pub const DRIVE_ABCI_METHOD_VERSIONS_V8: DriveAbciMethodVersions = DriveAbciMethodVersions {
     engine: DriveAbciEngineMethodVersions {
         init_chain: 0,
         check_tx: 0,
@@ -116,12 +116,10 @@ pub const DRIVE_ABCI_METHOD_VERSIONS_V7: DriveAbciMethodVersions = DriveAbciMeth
         process_raw_state_transitions: 0,
         decode_raw_state_transitions: 0,
         validate_fees_of_event: 0,
-        store_address_balances_to_recent_block_storage: Some(0), // changed
-        cleanup_recent_block_storage_address_balances: Some(0), // cleanup enabled when store is enabled
-        // Shielded-pool methods gated to v12 (DRIVE_ABCI_METHOD_VERSIONS_V8); the
-        // `[52, "M"]` subtree they touch does not exist on v11.
-        store_nullifiers_to_recent_block_storage: None,
-        cleanup_recent_block_storage_nullifiers: None,
+        store_address_balances_to_recent_block_storage: Some(0),
+        cleanup_recent_block_storage_address_balances: Some(0),
+        store_nullifiers_to_recent_block_storage: Some(0),
+        cleanup_recent_block_storage_nullifiers: Some(0),
     },
     epoch: DriveAbciEpochMethodVersions {
         gather_epoch_info: 0,
@@ -136,10 +134,8 @@ pub const DRIVE_ABCI_METHOD_VERSIONS_V7: DriveAbciMethodVersions = DriveAbciMeth
         validator_set_update: 2,
         should_checkpoint: Some(0),
         update_checkpoints: Some(0),
-        // Shielded-pool anchor methods gated to v12 (DRIVE_ABCI_METHOD_VERSIONS_V8);
-        // the `[52, "M"]` subtree they read does not exist on v11.
-        record_shielded_pool_anchor: None,
-        prune_shielded_pool_anchors: None,
+        record_shielded_pool_anchor: Some(0),
+        prune_shielded_pool_anchors: Some(0),
     },
     platform_state_storage: DriveAbciPlatformStateStorageMethodVersions {
         fetch_platform_state: 0,

--- a/packages/rs-platform-version/src/version/protocol_version.rs
+++ b/packages/rs-platform-version/src/version/protocol_version.rs
@@ -178,3 +178,64 @@ impl PlatformVersion {
             .expect("failed to set test versions")
     }
 }
+
+#[cfg(test)]
+mod shielded_pool_gating_tests {
+    use super::PlatformVersion;
+
+    // The shielded credit pool lives in GroveDB at
+    // `[RootTree::ShieldedBalances (52), MAIN_SHIELDED_CREDIT_POOL_KEY ("M" = 0x4d)]`.
+    // That subtree is created ONLY at the protocol v12 upgrade migration
+    // (`transition_to_version_12`) or on a v12 genesis (`create_initial_state_structure_v3`).
+    // It does not exist on a protocol-v11 state (v11 uses init structure v2).
+    //
+    // The block-end / recent-block-storage shielded methods below read that
+    // subtree unconditionally every block. If they are active before v12 they
+    // open `[52, "M"]` on a state where it was never created, producing the
+    // consensus-breaking GroveDB error
+    //   "path parent layer not found: could not get key 4d for parent [52]".
+    //
+    // These methods were inactive (`None`) through protocol v11 in the released
+    // 3.0.1 line, then accidentally turned on for v11 when the four fields were
+    // added as `Some(0)` to the SHARED `DRIVE_ABCI_METHOD_VERSIONS_V7` struct in
+    // the Medusa shielded-pool PR (#3177) — V7 is referenced by both v11.rs and
+    // v12.rs. These tests pin the invariant: shielded reads are gated to v12+.
+
+    #[test]
+    fn shielded_block_processing_methods_inactive_before_v12() {
+        let v11 = PlatformVersion::get(11).expect("protocol version 11 must exist");
+        let block_end = &v11.drive_abci.methods.block_end;
+        let st = &v11.drive_abci.methods.state_transition_processing;
+
+        assert_eq!(
+            block_end.record_shielded_pool_anchor, None,
+            "v11 must NOT record shielded pool anchors: the [52, \"M\"] subtree does not exist before v12"
+        );
+        assert_eq!(
+            block_end.prune_shielded_pool_anchors, None,
+            "v11 must NOT prune shielded pool anchors: the [52, \"M\"] subtree does not exist before v12"
+        );
+        assert_eq!(
+            st.store_nullifiers_to_recent_block_storage, None,
+            "v11 must NOT store shielded nullifiers: the [52, \"M\"] subtree does not exist before v12"
+        );
+        assert_eq!(
+            st.cleanup_recent_block_storage_nullifiers, None,
+            "v11 must NOT clean up shielded nullifiers: the [52, \"M\"] subtree does not exist before v12"
+        );
+    }
+
+    #[test]
+    fn shielded_block_processing_methods_active_at_v12() {
+        let v12 = PlatformVersion::get(12).expect("protocol version 12 must exist");
+        let block_end = &v12.drive_abci.methods.block_end;
+        let st = &v12.drive_abci.methods.state_transition_processing;
+
+        // At v12 the shielded pool subtree is created by the upgrade migration,
+        // so the same methods must be active.
+        assert_eq!(block_end.record_shielded_pool_anchor, Some(0));
+        assert_eq!(block_end.prune_shielded_pool_anchors, Some(0));
+        assert_eq!(st.store_nullifiers_to_recent_block_storage, Some(0));
+        assert_eq!(st.cleanup_recent_block_storage_nullifiers, Some(0));
+    }
+}

--- a/packages/rs-platform-version/src/version/v12.rs
+++ b/packages/rs-platform-version/src/version/v12.rs
@@ -15,7 +15,7 @@ use crate::version::dpp_versions::dpp_validation_versions::v3::DPP_VALIDATION_VE
 use crate::version::dpp_versions::dpp_voting_versions::v2::VOTING_VERSION_V2;
 use crate::version::dpp_versions::DPPVersion;
 use crate::version::drive_abci_versions::drive_abci_checkpoint_parameters::v1::DRIVE_ABCI_CHECKPOINT_PARAMETERS_V1;
-use crate::version::drive_abci_versions::drive_abci_method_versions::v7::DRIVE_ABCI_METHOD_VERSIONS_V7;
+use crate::version::drive_abci_versions::drive_abci_method_versions::v8::DRIVE_ABCI_METHOD_VERSIONS_V8;
 use crate::version::drive_abci_versions::drive_abci_query_versions::v1::DRIVE_ABCI_QUERY_VERSIONS_V1;
 use crate::version::drive_abci_versions::drive_abci_structure_versions::v1::DRIVE_ABCI_STRUCTURE_VERSIONS_V1;
 use crate::version::drive_abci_versions::drive_abci_validation_versions::v8::DRIVE_ABCI_VALIDATION_VERSIONS_V8;
@@ -36,7 +36,9 @@ pub const PLATFORM_V12: PlatformVersion = PlatformVersion {
     drive: DRIVE_VERSION_V7, // changed: shielded pool (commitment tree, nullifiers, anchors, address funds, sinsemilla hashing)
     drive_abci: DriveAbciVersion {
         structs: DRIVE_ABCI_STRUCTURE_VERSIONS_V1,
-        methods: DRIVE_ABCI_METHOD_VERSIONS_V7,
+        // V8 == V7 plus the four shielded-pool block-processing methods, which
+        // are valid only from v12 onward (the `[52, "M"]` subtree exists here).
+        methods: DRIVE_ABCI_METHOD_VERSIONS_V8,
         // enforce minimum config version check for contract create/update transitions
         validation_and_processing: DRIVE_ABCI_VALIDATION_VERSIONS_V8,
         withdrawal_constants: DRIVE_ABCI_WITHDRAWAL_CONSTANTS_V2,


### PR DESCRIPTION
## Issue being fixed or feature implemented

`drive 4.0.0-beta.1` cannot process **any** protocol-v11 block. A node syncing testnet on this build crash-loops in `ProcessProposal` with:

```
storage: grovedb: path parent layer not found: could not get key 4d for parent [ [hex: 34, str: 4],  ] of subtree: path key not found: key not found in Merk for get from storage: 4d
```

`0x34` = `RootTree::ShieldedBalances` (52); `0x4d` = `MAIN_SHIELDED_CREDIT_POOL_KEY` (`"M"`). The shielded credit pool subtree `[52, "M"]` is created only from protocol **v12** onward (`transition_to_version_12`, or a v12 genesis via init structure v3). On a protocol-v11 state it does not exist.

**Root cause:** protocol v11 and v12 both reference the shared `DRIVE_ABCI_METHOD_VERSIONS_V7`. The Medusa shielded-pool PR (#3177, `b33f8ec75b`) added four shielded block-processing methods to V7 as `Some(0)`:

- `store_nullifiers_to_recent_block_storage`
- `cleanup_recent_block_storage_nullifiers`
- `record_shielded_pool_anchor`
- `prune_shielded_pool_anchors`

Because V7 is shared, this silently turned them on for **v11** too. They run on every block (independent of transactions) and unconditionally read `[52, "M"]`, aborting consensus.

This was **not** introduced by #2920 (which switched v11 from V6→V7 for checkpoints): at release 3.0.1, V7 had no shielded fields, so v11 was fine. The rest of testnet runs `dashpay/drive:3.0.1` and is unaffected — only the lone `4.0.0-beta.1` node broke.

Observed on testnet `hp-masternode-7` at height **354892** — the first block the beta binary processed after it was deployed (the previous binary had committed cleanly up to 354891).

## What was done?

- Restored `DRIVE_ABCI_METHOD_VERSIONS_V7` (the protocol-v11 method set) to its 3.0.1 behavior: the four shielded methods are back to `None`.
- Added `DRIVE_ABCI_METHOD_VERSIONS_V8` (= V7 plus the four shielded methods `Some(0)`) and pointed `v12.rs` at it.
- `v11.rs` is unchanged (still references V7).

Net effect: shielded-pool block processing is gated to protocol **v12+**, where the `[52, "M"]` subtree is guaranteed to exist. The legitimately-v11 parts of V7 (checkpoints, address recent-block-storage from #2866) are untouched.

## How Has This Been Tested?

New unit test `platform-version::shielded_pool_gating_tests` pins the invariant with a red→green transition against this exact bug:

- ✖ **before fix:** `PlatformVersion::get(11).drive_abci.methods.block_end.record_shielded_pool_anchor == Some(0)` → test FAILS (`left: Some(0)`, `right: None`)
- ✔ **after fix:** v11 → `None` for all four methods; v12 → `Some(0)` → PASSES

```
cargo test -p platform-version --lib   # 7 passed, 0 failed
cargo fmt -p platform-version -- --check   # clean
```

Ground truth confirmed against the live network: every other testnet masternode runs `dashpay/drive:3.0.1`, whose `V7` has no shielded fields — this change restores exact v11 parity with them.

## Breaking Changes

None. This is a consensus-relevant version-map correction, but no chain state was ever produced under the buggy v11 rules (a v11 node with the bug crashes before it can commit), and the fix restores parity with the released 3.0.1 network. The shielded pool remains a v12 feature; the v12 upgrade migration (`transition_to_version_12`) is idempotent (`grove_insert_if_not_exists` per node) and creates `[52, "M"]` and its children when v12 activates.

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [ ] I have made corresponding changes to the documentation if needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added shielded pool block-processing functionality for Protocol v12.

* **Tests**
  * Added verification tests for shielded pool feature gating to Protocol v12.

* **Chores**
  * Updated version management configuration to support Protocol v12 requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->