### PR TITLE
fix(dashmate): bump Envoy gateway to 1.35.11 for HTTP/2 DoS (CVE-2026-47774)

### DIFF
--- a/packages/dashmate/configs/defaults/getBaseConfigFactory.js
+++ b/packages/dashmate/configs/defaults/getBaseConfigFactory.js
@@ -179,7 +179,7 @@ export default function getBaseConfigFactory() {
         },
         gateway: {
           docker: {
-            image: 'dashpay/envoy:1.30.2-impr.1',
+            image: 'dashpay/envoy:1.35.11-impr.1',
           },
           maxConnections: 1000,
           maxHeapSizeInBytes: 125000000, // 1 Gb

--- a/packages/dashmate/configs/getConfigFileMigrationsFactory.js
+++ b/packages/dashmate/configs/getConfigFileMigrationsFactory.js
@@ -1502,6 +1502,21 @@ export default function getConfigFileMigrationsFactory(homeDir, defaultConfigs) 
 
         return configFile;
       },
+      '4.0.0-beta.3': (configFile) => {
+        Object.entries(configFile.configs)
+          .forEach(([, options]) => {
+            // Patch the Platform Gateway (Envoy) image for CVE-2026-47774
+            // / GHSA-22m2-hvr2-xqc8: an unauthenticated HTTP/2 downstream
+            // memory-exhaustion DoS. Pre-fix configs pin the EOL
+            // `dashpay/envoy:1.30.2-impr.1` (Envoy 1.30.x); reset every
+            // config to the patched base default (Envoy 1.35.11).
+            if (options.platform?.gateway?.docker) {
+              options.platform.gateway.docker.image = base.get('platform.gateway.docker.image');
+            }
+          });
+
+        return configFile;
+      },
     };
   }
 

--- a/packages/dashmate/docs/config/gateway.md
+++ b/packages/dashmate/docs/config/gateway.md
@@ -6,7 +6,7 @@ The `platform.gateway` section configures the Dash Platform Gateway, which serve
 
 | Option | Description | Default | Example |
 |--------|-------------|---------|---------|
-| `platform.gateway.docker.image` | Docker image for Gateway | `dashpay/envoy:1.30.2-impr.1` | `dashpay/envoy:latest` |
+| `platform.gateway.docker.image` | Docker image for Gateway | `dashpay/envoy:1.35.11-impr.1` | `dashpay/envoy:latest` |
 
 ## Listeners
 

--- a/packages/dashmate/docs/update.md
+++ b/packages/dashmate/docs/update.md
@@ -78,7 +78,7 @@ $  dashmate update --format=json --config local_1 | jq
     "name": "gateway",
     "title": "Gateway",
     "updated": "up to date",
-    "image": "dashpay/envoy:1.30.2-impr.1"
+    "image": "dashpay/envoy:1.35.11-impr.1"
   }
 ]
 ```

--- a/packages/dashmate/templates/platform/gateway/envoy.yaml.dot
+++ b/packages/dashmate/templates/platform/gateway/envoy.yaml.dot
@@ -356,7 +356,6 @@ static_resources:
     - name: ratelimit_service
       type: STRICT_DNS
       connect_timeout: 1s
-      protocol_selection: USE_CONFIGURED_PROTOCOL
       typed_extension_protocol_options:
         envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
           "@type": type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
@@ -398,7 +397,7 @@ admin:
 
 # Dynamically adjust limits based on memory usage and number of active connections
 # TODO: We can use data provided by drive, tenderdash, or dapi to configure adaptive limits based on load
-# https://www.envoyproxy.io/docs/envoy/v1.30.1/api-v3/extensions/resource_monitors/injected_resource/v3/injected_resource.proto
+# https://www.envoyproxy.io/docs/envoy/v1.35.11/api-v3/extensions/resource_monitors/injected_resource/v3/injected_resource.proto
 overload_manager:
   refresh_interval: 0.25s
   resource_monitors:

--- a/packages/dashmate/test/unit/config/configFile/migrateConfigFileFactory.spec.js
+++ b/packages/dashmate/test/unit/config/configFile/migrateConfigFileFactory.spec.js
@@ -45,4 +45,40 @@ describe('migrateConfigFileFactory', () => {
 
     expect(migratedConfigFileData).to.be.deep.equal(currentConfigFileData);
   });
+
+  // Regression for CVE-2026-47774 / GHSA-22m2-hvr2-xqc8 (HTTP/2 DoS in Envoy).
+  // Configs created on 3.0.0..4.0.0-beta.2 pin the EOL, vulnerable
+  // `dashpay/envoy:1.30.2-impr.1`, and no migration above 3.0.0 touched the
+  // gateway image before the `4.0.0-beta.3` migration. This pins that the
+  // bump actually reaches that cohort — without the migration the image stays
+  // on the vulnerable 1.30 line and this fails.
+  it('should bump the vulnerable Platform Gateway (Envoy) image for configs from 4.0.0-beta.2', () => {
+    const base = container.resolve('defaultConfigs').get('base');
+    const patchedImage = base.get('platform.gateway.docker.image');
+
+    // The base default itself must be on a patched line (>= 1.35), never the
+    // vulnerable 1.30.x line — pins the security intent of the fix.
+    expect(patchedImage).to.match(/^dashpay\/envoy:1\.(3[5-9]|[4-9]\d)\./);
+
+    const rawConfigFile = {
+      configFormatVersion: '4.0.0-beta.2',
+      configs: {
+        testnet: {
+          platform: {
+            gateway: {
+              docker: {
+                image: 'dashpay/envoy:1.30.2-impr.1',
+              },
+            },
+          },
+        },
+      },
+    };
+
+    const migrated = migrateConfigFile(rawConfigFile, '4.0.0-beta.2', '4.0.0-beta.3');
+
+    const migratedImage = migrated.configs.testnet.platform.gateway.docker.image;
+    expect(migratedImage).to.equal(patchedImage);
+    expect(migratedImage).to.not.equal('dashpay/envoy:1.30.2-impr.1');
+  });
 });


### PR DESCRIPTION
## Issue being fixed or feature implemented

The Platform Gateway pins `dashpay/envoy:1.30.2-impr.1` (Envoy 1.30.x), affected by [GHSA-22m2-hvr2-xqc8](https://github.com/envoyproxy/envoy/security/advisories/GHSA-22m2-hvr2-xqc8) (**CVE-2026-47774**, CVSS 7.5 High) — an unauthenticated **HTTP/2 downstream memory-exhaustion DoS**: cookie header bytes bypass `max_request_headers_kb`, and HPACK decode amplification expands small encoded headers into large decoded ones. The 1.30 line is EOL (no backport).

## What was done?

Moved the gateway to the patched **`dashpay/envoy:1.35.11-impr.1`**. Of the advisory's fix versions (1.35.11 / 1.36.7 / 1.37.3 / 1.38.1), only **1.35.11** is published upstream so far, and it's the smallest jump from 1.30 (lowest config-deprecation risk).

- Bumped the base config default gateway image.
- Added a **`4.0.0-beta.3` config migration** resetting the gateway image to the patched default for existing nodes. The pre-existing reset (migration `1.0.0-dev.12`) only runs for `fromVersion < 3.0.0`, so configs created on **3.0.0 .. 4.0.0-beta.2** would otherwise stay on the vulnerable 1.30 image.
- Updated `docs/config/gateway.md` and `docs/update.md`.

> **Migration key note:** keyed `4.0.0-beta.3` (assumed next release). The semver gate covers everyone on ≤ `4.0.0-beta.2` regardless, but if the next release is named differently, retarget the key to match.

## ⚠️ Depends on the patched image being published first

This pin won't pull until `dashpay/docker-envoy` publishes `dashpay/envoy:1.35.11-impr.1`:
- Base-image bump: **dashpay/docker-envoy#3**
- After that merges, a maintainer must cut a release tagged **`v1.35.11-impr.1`** (or run the workflow_dispatch) to actually build & push the image.

**Do not merge this before `dashpay/envoy:1.35.11-impr.1` exists on Docker Hub.**

## How Has This Been Tested?

Added a regression test in `migrateConfigFileFactory.spec.js` pinning the migration for the 3.0.0..4.0.0-beta.2 cohort. Verified red→green (base bump in place, migration toggled):

```
✖ before migration: expected 'dashpay/envoy:1.30.2-impr.1' to equal 'dashpay/envoy:1.35.11-impr.1'
✔ after migration
```

Full `migrateConfigFileFactory` suite passes (existing full-migration test still green), eslint clean.

## Breaking Changes

None.

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [x] I have made corresponding changes to the documentation if needed

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated Platform Gateway Docker image to a newer version.
  * Added configuration migration for version 4.0.0-beta.3 to manage gateway component updates.
  * Updated documentation and added test coverage for the migration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->