### PR TITLE
fix(dashmate): bump Envoy gateway to 1.35.11 for HTTP/2 DoS (CVE-2026-47774)

### DIFF
--- a/packages/dashmate/configs/defaults/getBaseConfigFactory.js
+++ b/packages/dashmate/configs/defaults/getBaseConfigFactory.js
@@ -172,7 +172,7 @@ export default function getBaseConfigFactory() {
         },
         gateway: {
           docker: {
-            image: 'dashpay/envoy:1.30.2-impr.1',
+            image: 'dashpay/envoy:1.35.11-impr.1',
           },
           maxConnections: 1000,
           maxHeapSizeInBytes: 125000000, // 1 Gb

--- a/packages/dashmate/configs/getConfigFileMigrationsFactory.js
+++ b/packages/dashmate/configs/getConfigFileMigrationsFactory.js
@@ -1398,6 +1398,24 @@ export default function getConfigFileMigrationsFactory(homeDir, defaultConfigs) 
 
         return configFile;
       },
+      '3.0.2': (configFile) => {
+        // Patch the Platform Gateway (Envoy) image for CVE-2026-47774 /
+        // GHSA-22m2-hvr2-xqc8: an unauthenticated HTTP/2 downstream
+        // memory-exhaustion DoS. Only configs still on the EOL,
+        // dashmate-shipped 1.30.x Envoy image are bumped to the patched base
+        // default (Envoy 1.35.11); a deliberately customised image (private
+        // fork, vendor-patched build, `:latest`, etc.) is left untouched.
+        const patchedImage = base.get('platform.gateway.docker.image');
+        Object.entries(configFile.configs)
+          .forEach(([, options]) => {
+            const docker = options.platform?.gateway?.docker;
+            if (docker && /^dashpay\/envoy:1\.30\./.test(docker.image)) {
+              docker.image = patchedImage;
+            }
+          });
+
+        return configFile;
+      },
     };
   }
 

--- a/packages/dashmate/docs/config/gateway.md
+++ b/packages/dashmate/docs/config/gateway.md
@@ -6,7 +6,7 @@ The `platform.gateway` section configures the Dash Platform Gateway, which serve
 
 | Option | Description | Default | Example |
 |--------|-------------|---------|---------|
-| `platform.gateway.docker.image` | Docker image for Gateway | `dashpay/envoy:1.30.2-impr.1` | `dashpay/envoy:latest` |
+| `platform.gateway.docker.image` | Docker image for Gateway | `dashpay/envoy:1.35.11-impr.1` | `dashpay/envoy:latest` |
 
 ## Listeners
 

--- a/packages/dashmate/docs/update.md
+++ b/packages/dashmate/docs/update.md
@@ -78,7 +78,7 @@ $  dashmate update --format=json --config local_1 | jq
     "name": "gateway",
     "title": "Gateway",
     "updated": "up to date",
-    "image": "dashpay/envoy:1.30.2-impr.1"
+    "image": "dashpay/envoy:1.35.11-impr.1"
   }
 ]
 ```


### PR DESCRIPTION
## Issue being fixed or feature implemented

**v3 hotfix.** The Platform Gateway pins `dashpay/envoy:1.30.2-impr.1` (Envoy 1.30.x), affected by [GHSA-22m2-hvr2-xqc8](https://github.com/envoyproxy/envoy/security/advisories/GHSA-22m2-hvr2-xqc8) (**CVE-2026-47774**, CVSS 7.5 High) — an unauthenticated **HTTP/2 downstream memory-exhaustion DoS**: cookie header bytes bypass `max_request_headers_kb`, and HPACK decode amplification expands small encoded headers into large decoded ones. The 1.30 line is EOL (no backport).

## What was done?

Moved the gateway to the patched **`dashpay/envoy:1.35.11-impr.1`** — the only patched Envoy line published upstream so far, and the smallest jump from 1.30.

- Bumped the base config default gateway image.
- Added a **`3.0.2` config migration** resetting the gateway image to the patched default for existing nodes. No migration above `3.0.0` touched the gateway image, so v3 configs (`3.0.0` .. `3.0.1-hotfix.4`) would otherwise stay on the vulnerable 1.30 image.
- Updated `docs/config/gateway.md` and `docs/update.md`.

The image is **already built, published, and verified** (multi-arch amd64/arm64, contains Envoy `1.35.11`): built from [dashpay/docker-envoy#3](https://github.com/dashpay/docker-envoy/pull/3) via release [`v1.35.11-impr.1`](https://github.com/dashpay/docker-envoy/releases/tag/v1.35.11-impr.1). So this PR is **not blocked** on image availability.

> **Migration key note:** keyed `3.0.2` (the next v3 release, per the `release_3.0.2` branch). Semver-safe: it runs for every config on `< 3.0.2`, i.e. `3.0.0`, `3.0.1`, and all `3.0.1-hotfix.*` prereleases. If the hotfix ships under a different version, retarget the key to match.

## How Has This Been Tested?

Added a regression test in `migrateConfigFileFactory.spec.js` for the v3 cohort. Red→green verified via the real `migrateConfigFile` dispatch + real base config:

```
RED  (no migration):    dashpay/envoy:1.30.2-impr.1   (still vulnerable)
GREEN (with migration): dashpay/envoy:1.35.11-impr.1
```

Separately, the rendered gateway config was validated against Envoy 1.35.11 (`envoy --mode validate`, all conditional branches) — loads clean, zero deprecation warnings.

## Breaking Changes

None.

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [x] I have made corresponding changes to the documentation if needed

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone