### PR TITLE
fix(platform-wallet): zeroize private keys when freeing preview rows

### DIFF
--- a/packages/rs-platform-wallet-ffi/src/derive_identity_key_at_slot.rs
+++ b/packages/rs-platform-wallet-ffi/src/derive_identity_key_at_slot.rs
@@ -11,7 +11,7 @@ use zeroize::Zeroizing;
 
 use crate::error::*;
 use crate::identity_key_preview::IdentityKeyPreviewFFI;
-use crate::identity_keys_from_mnemonic::parse_mnemonic_any_language;
+use crate::identity_keys_from_mnemonic::{parse_mnemonic_any_language, zeroize_and_free_row};
 use crate::{check_ptr, unwrap_result_or_return};
 use rs_sdk_ffi::{
     mnemonic_resolver_result, MnemonicResolverHandle, MNEMONIC_RESOLVER_BUFFER_CAPACITY,
@@ -193,6 +193,15 @@ pub unsafe extern "C" fn dash_sdk_derive_identity_key_at_slot_with_resolver(
 }
 
 /// Free a row populated by [`dash_sdk_derive_identity_key_at_slot`].
+///
+/// Routes through the shared
+/// [`crate::identity_keys_from_mnemonic::zeroize_and_free_row`] helper
+/// so the WIF backing bytes and the inline 32-byte ECDSA scalar are
+/// scrubbed with `zeroize::Zeroize::zeroize` (a volatile write the
+/// optimizer cannot elide). The previous hand-rolled
+/// `std::ptr::write_bytes` / `*byte = 0` scrubs were *non-volatile* and
+/// could be dropped as dead stores. Owned pointers are nulled so a
+/// second free no-ops (double-free idempotency).
 #[no_mangle]
 pub unsafe extern "C" fn dash_sdk_derive_identity_key_at_slot_free(
     out_row: *mut IdentityKeyPreviewFFI,
@@ -200,29 +209,73 @@ pub unsafe extern "C" fn dash_sdk_derive_identity_key_at_slot_free(
     if out_row.is_null() {
         return;
     }
-    let row = &mut *out_row;
+    zeroize_and_free_row(&mut *out_row);
+}
 
-    if !row.derivation_path.is_null() {
-        let _ = CString::from_raw(row.derivation_path);
-        row.derivation_path = std::ptr::null_mut();
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Build a single heap-detached row the way `derive_at_slot_inner`
+    /// does (CString::into_raw for path + WIF, a leaked `Box<[u8]>`
+    /// pubkey via `into_boxed_slice`, a real secret scalar inline) so
+    /// `_free` is exercised on genuinely-owned allocations.
+    fn make_owned_row(secret: [u8; 32]) -> IdentityKeyPreviewFFI {
+        let path = CString::new("m/9'/1'/5'/0'/0'/0'/0'").unwrap();
+        let wif = CString::new("cQ_fake_wif_for_test_only_not_a_real_key").unwrap();
+        // Mirror the producer: `Vec` -> `into_boxed_slice()` (so the
+        // backing allocation has capacity == len, matching the
+        // `Vec::from_raw_parts(ptr, len, len)` reclaim in the shared
+        // helper).
+        let mut pub_box: Box<[u8]> = vec![0x02u8; 33].into_boxed_slice();
+        let pub_ptr = pub_box.as_mut_ptr();
+        let pub_len = pub_box.len();
+        std::mem::forget(pub_box);
+
+        IdentityKeyPreviewFFI {
+            identity_index: 9,
+            derivation_path: path.into_raw(),
+            public_key: pub_ptr,
+            public_key_len: pub_len,
+            private_key_wif: wif.into_raw(),
+            private_key_bytes: secret,
+        }
     }
-    if !row.public_key.is_null() && row.public_key_len > 0 {
-        let _ = Box::from_raw(std::ptr::slice_from_raw_parts_mut(
-            row.public_key,
-            row.public_key_len,
-        ));
-        row.public_key = std::ptr::null_mut();
-        row.public_key_len = 0;
+
+    /// `dash_sdk_derive_identity_key_at_slot_free` now routes through
+    /// the shared `zeroize_and_free_row` helper, replacing the
+    /// non-volatile `write_bytes` / `*byte = 0` scrubs (which the
+    /// optimizer may elide as dead stores). This asserts the inline
+    /// 32-byte scalar is wiped, every owned pointer is nulled, and a
+    /// second free no-ops (double-free idempotency).
+    #[test]
+    fn free_zeroizes_secret_and_is_idempotent() {
+        let secret = [0xC7u8; 32];
+        let mut row = make_owned_row(secret);
+
+        assert_eq!(row.private_key_bytes, secret);
+        assert!(!row.derivation_path.is_null());
+        assert!(!row.private_key_wif.is_null());
+        assert!(!row.public_key.is_null());
+
+        // SAFETY: `row` owns freshly-detached allocations and has not
+        // crossed the FFI boundary, so this is the sole release.
+        unsafe { dash_sdk_derive_identity_key_at_slot_free(&mut row) };
+
+        assert_eq!(
+            row.private_key_bytes, [0u8; 32],
+            "private_key_bytes must be zeroized after _free"
+        );
+        assert!(row.derivation_path.is_null());
+        assert!(row.private_key_wif.is_null());
+        assert!(row.public_key.is_null());
+        assert_eq!(row.public_key_len, 0);
+
+        // Second free on the reset row must not double-free or panic.
+        unsafe { dash_sdk_derive_identity_key_at_slot_free(&mut row) };
+        assert_eq!(row.private_key_bytes, [0u8; 32]);
+
+        // Null outer pointer is a safe no-op.
+        unsafe { dash_sdk_derive_identity_key_at_slot_free(std::ptr::null_mut()) };
     }
-    if !row.private_key_wif.is_null() {
-        let cstring = CString::from_raw(row.private_key_wif);
-        let bytes_len = cstring.as_bytes().len();
-        std::ptr::write_bytes(cstring.as_ptr() as *mut u8, 0, bytes_len);
-        drop(cstring);
-        row.private_key_wif = std::ptr::null_mut();
-    }
-    for byte in row.private_key_bytes.iter_mut() {
-        *byte = 0;
-    }
-    row.identity_index = 0;
 }

--- a/packages/rs-platform-wallet-ffi/src/identity_key_preview.rs
+++ b/packages/rs-platform-wallet-ffi/src/identity_key_preview.rs
@@ -280,12 +280,12 @@ pub unsafe extern "C" fn platform_wallet_preview_identity_registration_keys_free
     }
     unsafe {
         let slice = std::slice::from_raw_parts_mut(previews.items, previews.count);
-        let boxed: Box<[IdentityKeyPreviewFFI]> = Box::from_raw(slice);
+        let mut boxed: Box<[IdentityKeyPreviewFFI]> = Box::from_raw(slice);
         // Reclaim each row's owned allocations before the rows
         // themselves get dropped (which by itself wouldn't free
         // them — they're raw pointers from `into_raw` /
         // `forget(Box::...)`).
-        for row in boxed.iter() {
+        for row in boxed.iter_mut() {
             release_row(row);
         }
         drop(boxed);
@@ -294,20 +294,35 @@ pub unsafe extern "C" fn platform_wallet_preview_identity_registration_keys_free
     previews.count = 0;
 }
 
-/// Reclaim the heap allocations owned by a single preview row.
-/// Used by both the public free function (post-success path) and
-/// the internal cleanup helper that drops successfully-built rows
-/// when a later derivation fails mid-loop.
-unsafe fn release_row(row: &IdentityKeyPreviewFFI) {
+/// Reclaim the heap allocations owned by a single preview row and
+/// zeroize the sensitive private-key material it carried.
+///
+/// Takes `&mut` so it can both scrub the inline `private_key_bytes`
+/// scalar in place and null `private_key_wif`/`derivation_path`/
+/// `public_key` after reclaiming them — preserving double-free
+/// idempotency. Used by both the public free function (post-success
+/// path) and the internal cleanup helper that drops
+/// successfully-built rows when a later derivation fails mid-loop.
+///
+/// Mirrors the zeroization performed by
+/// [`crate::identity_keys_from_mnemonic::dash_sdk_derive_identity_keys_from_mnemonic_free`]:
+/// the WIF string holds the same private key in human-readable form,
+/// so its backing bytes are scrubbed before the allocation is
+/// released, and the raw 32-byte scalar is zeroized in place.
+unsafe fn release_row(row: &mut IdentityKeyPreviewFFI) {
     if !row.derivation_path.is_null() {
         unsafe {
             drop(CString::from_raw(row.derivation_path));
         }
+        row.derivation_path = ptr::null_mut();
     }
     if !row.private_key_wif.is_null() {
-        unsafe {
-            drop(CString::from_raw(row.private_key_wif));
-        }
+        // WIF carries the private key in clear text — scrub the
+        // CString's backing bytes (including the trailing NUL slot)
+        // before the allocation is handed back to the allocator.
+        let mut wif = unsafe { CString::from_raw(row.private_key_wif) }.into_bytes_with_nul();
+        zeroize::Zeroize::zeroize(&mut wif);
+        row.private_key_wif = ptr::null_mut();
     }
     if !row.public_key.is_null() && row.public_key_len > 0 {
         unsafe {
@@ -317,13 +332,17 @@ unsafe fn release_row(row: &IdentityKeyPreviewFFI) {
                 row.public_key_len,
             ));
         }
+        row.public_key = ptr::null_mut();
+        row.public_key_len = 0;
     }
+    // Scrub the raw 32-byte ECDSA scalar held inline in the row.
+    zeroize::Zeroize::zeroize(&mut row.private_key_bytes);
 }
 
 /// Release every row in a partially-built preview list and consume
 /// the vec. Used by the build-loop cleanup branch.
-fn free_rows(rows: Vec<IdentityKeyPreviewFFI>) {
-    for row in &rows {
+fn free_rows(mut rows: Vec<IdentityKeyPreviewFFI>) {
+    for row in &mut rows {
         // SAFETY: each row was just appended by the build loop
         // (CString::into_raw + Vec::into_raw). They have not been
         // exposed across the FFI boundary yet, so this is the
@@ -331,4 +350,108 @@ fn free_rows(rows: Vec<IdentityKeyPreviewFFI>) {
         unsafe { release_row(row) };
     }
     drop(rows);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Build a heap-detached row the same way the production build
+    /// loop does (CString::into_raw + Vec leak), so `release_row` is
+    /// exercised on genuinely-owned allocations rather than borrowed
+    /// stack data.
+    fn make_owned_row(secret: [u8; 32]) -> IdentityKeyPreviewFFI {
+        let path = CString::new("m/9'/1'/5'/0'/0'/0'/0'").unwrap();
+        let wif = CString::new("cQ_fake_wif_for_test_only_not_a_real_key").unwrap();
+        let mut pub_box: Box<[u8]> = vec![0x02u8; 33].into_boxed_slice();
+        let pub_ptr = pub_box.as_mut_ptr();
+        let pub_len = pub_box.len();
+        std::mem::forget(pub_box);
+
+        IdentityKeyPreviewFFI {
+            identity_index: 0,
+            derivation_path: path.into_raw(),
+            public_key: pub_ptr,
+            public_key_len: pub_len,
+            private_key_wif: wif.into_raw(),
+            private_key_bytes: secret,
+        }
+    }
+
+    /// `release_row` scrubs the inline 32-byte scalar in place and
+    /// nulls every owned pointer, leaving the row safe to release a
+    /// second time (double-free idempotency).
+    #[test]
+    fn release_row_zeroizes_secret_and_is_idempotent() {
+        let secret = [0xABu8; 32];
+        let mut row = make_owned_row(secret);
+
+        // Sanity: the row starts out carrying the real secret and
+        // owns its allocations.
+        assert_eq!(row.private_key_bytes, secret);
+        assert!(!row.derivation_path.is_null());
+        assert!(!row.private_key_wif.is_null());
+        assert!(!row.public_key.is_null());
+
+        // SAFETY: `row` owns freshly-detached allocations and has not
+        // crossed the FFI boundary, so this is the sole release.
+        unsafe { release_row(&mut row) };
+
+        // The raw scalar is wiped in place.
+        assert_eq!(
+            row.private_key_bytes, [0u8; 32],
+            "private_key_bytes must be zeroized after release_row"
+        );
+        // Every owned pointer is nulled so a second release no-ops.
+        assert!(row.derivation_path.is_null());
+        assert!(row.private_key_wif.is_null());
+        assert!(row.public_key.is_null());
+        assert_eq!(row.public_key_len, 0);
+
+        // Second release must not double-free or panic.
+        unsafe { release_row(&mut row) };
+        assert_eq!(row.private_key_bytes, [0u8; 32]);
+    }
+
+    /// The public preview → free round-trip wipes secrets and resets
+    /// the outer struct so a second free is a no-op. We build the
+    /// rows directly (the public derive path needs a live wallet
+    /// handle) and drive them through the real `_free` entry point.
+    #[test]
+    fn public_free_zeroizes_and_resets() {
+        let secret = [0x5Au8; 32];
+        let rows = vec![make_owned_row(secret), make_owned_row(secret)];
+        let mut boxed = rows.into_boxed_slice();
+        let items_ptr = boxed.as_mut_ptr();
+        let items_count = boxed.len();
+        std::mem::forget(boxed);
+
+        let mut previews = IdentityKeyPreviewsFFI {
+            items: items_ptr,
+            count: items_count,
+        };
+
+        // SAFETY: `previews.items` was detached above exactly as the
+        // production derive path does; this is the sole free.
+        unsafe { platform_wallet_preview_identity_registration_keys_free(&mut previews) };
+
+        assert!(previews.items.is_null());
+        assert_eq!(previews.count, 0);
+
+        // Idempotent: a second free on the reset struct no-ops.
+        unsafe { platform_wallet_preview_identity_registration_keys_free(&mut previews) };
+        assert!(previews.items.is_null());
+        assert_eq!(previews.count, 0);
+    }
+
+    /// `free_rows` (the mid-loop cleanup path) zeroizes secrets and
+    /// must not panic on a partially-built list.
+    #[test]
+    fn free_rows_zeroizes_partial_list() {
+        let rows = vec![make_owned_row([0x11u8; 32]), make_owned_row([0x22u8; 32])];
+        // No assertion on the scalar after the fact — `free_rows`
+        // consumes the vec — but it must release every owned
+        // allocation without panicking or double-freeing.
+        free_rows(rows);
+    }
 }

--- a/packages/rs-platform-wallet-ffi/src/identity_key_preview.rs
+++ b/packages/rs-platform-wallet-ffi/src/identity_key_preview.rs
@@ -35,6 +35,7 @@ use platform_wallet::{derive_identity_auth_keypair, IDENTITY_GAP_LIMIT, MASTER_K
 
 use crate::error::*;
 use crate::handle::*;
+use crate::identity_keys_from_mnemonic::zeroize_and_free_row;
 use crate::{check_ptr, unwrap_option_or_return, unwrap_result_or_return};
 
 /// One identity-registration-key preview row.
@@ -294,49 +295,19 @@ pub unsafe extern "C" fn platform_wallet_preview_identity_registration_keys_free
     previews.count = 0;
 }
 
-/// Reclaim the heap allocations owned by a single preview row and
-/// zeroize the sensitive private-key material it carried.
+/// Reclaim the heap allocations owned by a single preview row and zeroize the
+/// sensitive private-key material it carried.
 ///
-/// Takes `&mut` so it can both scrub the inline `private_key_bytes`
-/// scalar in place and null `private_key_wif`/`derivation_path`/
-/// `public_key` after reclaiming them — preserving double-free
-/// idempotency. Used by both the public free function (post-success
-/// path) and the internal cleanup helper that drops
-/// successfully-built rows when a later derivation fails mid-loop.
-///
-/// Mirrors the zeroization performed by
-/// [`crate::identity_keys_from_mnemonic::dash_sdk_derive_identity_keys_from_mnemonic_free`]:
-/// the WIF string holds the same private key in human-readable form,
-/// so its backing bytes are scrubbed before the allocation is
-/// released, and the raw 32-byte scalar is zeroized in place.
+/// This is a thin delegation to [`zeroize_and_free_row`], the single canonical
+/// zeroize-and-free implementation for [`IdentityKeyPreviewFFI`]. Keeping the
+/// logic in exactly one place is the whole point of this change: a future change
+/// to the row (a new sensitive `*mut c_char` field, moving `private_key_bytes`
+/// behind a `Zeroizing` wrapper, etc.) then cannot silently leave one free path
+/// scrubbing while another leaks. The longer-term endpoint noted at the
+/// build-loop `TODO` is a `Drop` impl on the struct itself, which would make the
+/// single zeroization site enforced by construction.
 unsafe fn release_row(row: &mut IdentityKeyPreviewFFI) {
-    if !row.derivation_path.is_null() {
-        unsafe {
-            drop(CString::from_raw(row.derivation_path));
-        }
-        row.derivation_path = ptr::null_mut();
-    }
-    if !row.private_key_wif.is_null() {
-        // WIF carries the private key in clear text — scrub the
-        // CString's backing bytes (including the trailing NUL slot)
-        // before the allocation is handed back to the allocator.
-        let mut wif = unsafe { CString::from_raw(row.private_key_wif) }.into_bytes_with_nul();
-        zeroize::Zeroize::zeroize(&mut wif);
-        row.private_key_wif = ptr::null_mut();
-    }
-    if !row.public_key.is_null() && row.public_key_len > 0 {
-        unsafe {
-            drop(Vec::from_raw_parts(
-                row.public_key,
-                row.public_key_len,
-                row.public_key_len,
-            ));
-        }
-        row.public_key = ptr::null_mut();
-        row.public_key_len = 0;
-    }
-    // Scrub the raw 32-byte ECDSA scalar held inline in the row.
-    zeroize::Zeroize::zeroize(&mut row.private_key_bytes);
+    unsafe { zeroize_and_free_row(row) }
 }
 
 /// Release every row in a partially-built preview list and consume

--- a/packages/rs-platform-wallet-ffi/src/identity_keys_from_mnemonic.rs
+++ b/packages/rs-platform-wallet-ffi/src/identity_keys_from_mnemonic.rs
@@ -17,6 +17,42 @@ use crate::identity_registration_with_signer::IdentityRegistrationKeyDerivations
 use crate::types::{FFINetwork, Network};
 use crate::{check_ptr, unwrap_result_or_return};
 
+/// Reclaim a single derived row's heap allocations and scrub the
+/// sensitive private-key material it carried.
+///
+/// Shared by both the mid-loop cleanup closure (when a later
+/// derivation fails and the partially-built rows must be released)
+/// and the public
+/// [`dash_sdk_derive_identity_keys_from_mnemonic_free`] entry point,
+/// so neither path can drift from the other. The WIF string holds
+/// the private key in human-readable form, so its backing bytes are
+/// zeroized before the allocation is released; the inline 32-byte
+/// ECDSA scalar is zeroized in place. Owned pointers are nulled so a
+/// second release no-ops (double-free idempotency).
+///
+/// # Safety
+/// `row`'s `derivation_path` / `private_key_wif` (if non-null) must
+/// have come from `CString::into_raw`, and `public_key` (if non-null,
+/// with `public_key_len > 0`) from a leaked `Box<[u8]>`/`Vec<u8>`.
+/// Must be the sole release of these allocations.
+pub(crate) unsafe fn zeroize_and_free_row(row: &mut IdentityKeyPreviewFFI) {
+    if !row.derivation_path.is_null() {
+        let _ = CString::from_raw(row.derivation_path);
+        row.derivation_path = std::ptr::null_mut();
+    }
+    if !row.public_key.is_null() && row.public_key_len > 0 {
+        let _ = Vec::from_raw_parts(row.public_key, row.public_key_len, row.public_key_len);
+        row.public_key = std::ptr::null_mut();
+        row.public_key_len = 0;
+    }
+    if !row.private_key_wif.is_null() {
+        let mut wif = CString::from_raw(row.private_key_wif).into_bytes_with_nul();
+        zeroize::Zeroize::zeroize(&mut wif);
+        row.private_key_wif = std::ptr::null_mut();
+    }
+    zeroize::Zeroize::zeroize(&mut row.private_key_bytes);
+}
+
 /// Parse a BIP-39 mnemonic against every supported wordlist.
 pub(crate) fn parse_mnemonic_any_language(phrase: &str) -> Result<Mnemonic, &'static str> {
     const LANGUAGES: [Language; 10] = [
@@ -104,17 +140,12 @@ pub unsafe extern "C" fn dash_sdk_derive_identity_keys_from_mnemonic(
 
     let mut rows: Vec<IdentityKeyPreviewFFI> = Vec::with_capacity(key_count as usize);
 
-    let cleanup = |rows: Vec<IdentityKeyPreviewFFI>| {
-        for row in rows {
-            if !row.derivation_path.is_null() {
-                let _ = CString::from_raw(row.derivation_path);
-            }
-            if !row.public_key.is_null() && row.public_key_len > 0 {
-                let _ = Vec::from_raw_parts(row.public_key, row.public_key_len, row.public_key_len);
-            }
-            if !row.private_key_wif.is_null() {
-                let _ = CString::from_raw(row.private_key_wif);
-            }
+    let cleanup = |mut rows: Vec<IdentityKeyPreviewFFI>| {
+        for row in &mut rows {
+            // Route through the shared helper so the cleanup path
+            // scrubs the WIF + raw scalar exactly like the public
+            // `_free` entry point does — no divergence.
+            zeroize_and_free_row(row);
         }
     };
 
@@ -227,18 +258,7 @@ pub unsafe extern "C" fn dash_sdk_derive_identity_keys_from_mnemonic_free(
     }
     let slice = std::slice::from_raw_parts_mut(owned.items, owned.count);
     for row in slice.iter_mut() {
-        if !row.derivation_path.is_null() {
-            let _ = CString::from_raw(row.derivation_path);
-        }
-        if !row.public_key.is_null() && row.public_key_len > 0 {
-            let _ = Vec::from_raw_parts(row.public_key, row.public_key_len, row.public_key_len);
-        }
-        if !row.private_key_wif.is_null() {
-            let mut wif = CString::from_raw(row.private_key_wif).into_bytes_with_nul();
-            zeroize::Zeroize::zeroize(&mut wif);
-            row.private_key_wif = std::ptr::null_mut();
-        }
-        zeroize::Zeroize::zeroize(&mut row.private_key_bytes);
+        zeroize_and_free_row(row);
     }
     let _ = Box::from_raw(slice as *mut [IdentityKeyPreviewFFI]);
 }

--- a/packages/rs-platform-wallet-ffi/src/identity_registration_with_signer.rs
+++ b/packages/rs-platform-wallet-ffi/src/identity_registration_with_signer.rs
@@ -69,12 +69,12 @@ use std::convert::TryFrom;
 use std::ffi::{CStr, CString};
 use std::ptr;
 use std::slice;
-use zeroize::Zeroize;
 
 use crate::check_ptr;
 use crate::error::*;
 use crate::handle::*;
 use crate::identity_key_preview::IdentityKeyPreviewFFI;
+use crate::identity_keys_from_mnemonic::zeroize_and_free_row;
 use crate::identity_registration::{IdentityFundingInputFFI, IdentityFundingOutputFFI};
 use crate::runtime::block_on_worker;
 use crate::{unwrap_option_or_return, unwrap_result_or_return};
@@ -564,19 +564,16 @@ pub unsafe extern "C" fn platform_wallet_derive_identity_keys_for_index(
 
         let mut rows: Vec<IdentityKeyPreviewFFI> = Vec::with_capacity(key_count as usize);
 
-        let cleanup = |rows: Vec<IdentityKeyPreviewFFI>| {
-            for row in rows {
-                if !row.derivation_path.is_null() {
-                    let _ = unsafe { CString::from_raw(row.derivation_path) };
-                }
-                if !row.public_key.is_null() {
-                    let _ = unsafe {
-                        Vec::from_raw_parts(row.public_key, row.public_key_len, row.public_key_len)
-                    };
-                }
-                if !row.private_key_wif.is_null() {
-                    let _ = unsafe { CString::from_raw(row.private_key_wif) };
-                }
+        let cleanup = |mut rows: Vec<IdentityKeyPreviewFFI>| {
+            for row in &mut rows {
+                // Route through the shared helper so this error-path
+                // cleanup scrubs the WIF backing bytes + raw scalar
+                // exactly like the public
+                // `platform_wallet_derive_identity_keys_for_index_free`
+                // entry point does — keys for rows 0..N already built
+                // when a later derivation fails must not be left in
+                // freed heap. See the public `_free` below.
+                unsafe { zeroize_and_free_row(row) };
             }
         };
 
@@ -680,18 +677,9 @@ pub unsafe extern "C" fn platform_wallet_derive_identity_keys_for_index_free(
     }
     let slice = std::slice::from_raw_parts_mut(owned.items, owned.count);
     for row in slice.iter_mut() {
-        if !row.derivation_path.is_null() {
-            let _ = CString::from_raw(row.derivation_path);
-        }
-        if !row.public_key.is_null() {
-            let _ = Vec::from_raw_parts(row.public_key, row.public_key_len, row.public_key_len);
-        }
-        if !row.private_key_wif.is_null() {
-            let mut wif = CString::from_raw(row.private_key_wif).into_bytes_with_nul();
-            wif.zeroize();
-            row.private_key_wif = ptr::null_mut();
-        }
-        row.private_key_bytes.zeroize();
+        // Same shared helper the mid-loop cleanup closure uses, so the
+        // success-path release and the error-path release can't drift.
+        zeroize_and_free_row(row);
     }
     let _ = Box::from_raw(slice as *mut [IdentityKeyPreviewFFI]);
 }
@@ -714,3 +702,113 @@ pub unsafe extern "C" fn platform_wallet_derive_identity_keys_for_index_free(
 // SwiftData row, and calls that one-shot FFI to produce a signature.
 // The derived key never leaves Rust, never crosses the FFI as bytes,
 // and never lands in the Keychain.
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Build a heap-detached `IdentityKeyPreviewFFI` exactly the way
+    /// the `platform_wallet_derive_identity_keys_for_index` build loop
+    /// does (CString::into_raw for path + WIF, a leaked
+    /// `Box<[u8]>` pubkey, a real secret scalar inline) so the
+    /// cleanup / free paths are exercised on genuinely-owned
+    /// allocations rather than borrowed stack data.
+    fn make_owned_row(secret: [u8; 32]) -> IdentityKeyPreviewFFI {
+        let path = CString::new("m/9'/1'/5'/0'/0'/0'/0'").unwrap();
+        let wif = CString::new("cQ_fake_wif_for_test_only_not_a_real_key").unwrap();
+        let mut pub_box: Box<[u8]> = vec![0x02u8; 33].into_boxed_slice();
+        let pub_ptr = pub_box.as_mut_ptr();
+        let pub_len = pub_box.len();
+        std::mem::forget(pub_box);
+
+        IdentityKeyPreviewFFI {
+            identity_index: 3,
+            derivation_path: path.into_raw(),
+            public_key: pub_ptr,
+            public_key_len: pub_len,
+            private_key_wif: wif.into_raw(),
+            private_key_bytes: secret,
+        }
+    }
+
+    /// The mid-loop error-path `cleanup` closure now routes every
+    /// partially-built row through `zeroize_and_free_row`. This
+    /// asserts that path scrubs the inline 32-byte scalar in place and
+    /// nulls every owned pointer, leaving each row safe to release a
+    /// second time (double-free idempotency) — the regression the
+    /// adversarial review caught (rows 0..N's WIF + scalar were
+    /// previously freed without scrubbing when a later derivation
+    /// failed).
+    #[test]
+    fn cleanup_path_zeroizes_secret_and_is_idempotent() {
+        let secret = [0xABu8; 32];
+        // Two rows, mirroring `key_count > 1` where a later index
+        // fails after earlier rows were already built and pushed.
+        let mut rows = vec![make_owned_row(secret), make_owned_row(secret)];
+
+        for row in &rows {
+            assert_eq!(row.private_key_bytes, secret);
+            assert!(!row.derivation_path.is_null());
+            assert!(!row.private_key_wif.is_null());
+            assert!(!row.public_key.is_null());
+        }
+
+        // Exactly what the `cleanup` closure body does.
+        for row in &mut rows {
+            // SAFETY: rows own freshly-detached allocations and have
+            // not crossed the FFI boundary, so this is the sole
+            // release.
+            unsafe { zeroize_and_free_row(row) };
+        }
+
+        for row in &rows {
+            assert_eq!(
+                row.private_key_bytes, [0u8; 32],
+                "private_key_bytes must be zeroized by the cleanup path"
+            );
+            assert!(row.derivation_path.is_null());
+            assert!(row.private_key_wif.is_null());
+            assert!(row.public_key.is_null());
+            assert_eq!(row.public_key_len, 0);
+        }
+
+        // Second release must not double-free or panic.
+        for row in &mut rows {
+            unsafe { zeroize_and_free_row(row) };
+            assert_eq!(row.private_key_bytes, [0u8; 32]);
+        }
+    }
+
+    /// The public `platform_wallet_derive_identity_keys_for_index_free`
+    /// round-trip wipes secrets and resets the outer struct so a
+    /// second free is a no-op. We build the rows directly (the public
+    /// derive path needs a live wallet handle) and drive them through
+    /// the real `_free` entry point — the same helper the cleanup
+    /// path uses, so success-path and error-path releases can't drift.
+    #[test]
+    fn derive_keys_for_index_free_zeroizes_and_resets() {
+        let secret = [0x5Au8; 32];
+        let rows = vec![make_owned_row(secret), make_owned_row(secret)];
+        let mut boxed = rows.into_boxed_slice();
+        let items_ptr = boxed.as_mut_ptr();
+        let items_count = boxed.len();
+        std::mem::forget(boxed);
+
+        let mut out = IdentityRegistrationKeyDerivationsFFI {
+            items: items_ptr,
+            count: items_count,
+        };
+
+        // SAFETY: `out.items` was detached above exactly as the
+        // production derive path does; this is the sole free.
+        unsafe { platform_wallet_derive_identity_keys_for_index_free(&mut out) };
+
+        assert!(out.items.is_null());
+        assert_eq!(out.count, 0);
+
+        // Idempotent: a second free on the reset struct no-ops.
+        unsafe { platform_wallet_derive_identity_keys_for_index_free(&mut out) };
+        assert!(out.items.is_null());
+        assert_eq!(out.count, 0);
+    }
+}


### PR DESCRIPTION
## Issue being fixed or feature implemented

**Private-key material left un-zeroized in freed heap memory (mobile wallet).**

`release_row` in `identity_key_preview.rs` freed `private_key_wif` (a `*mut c_char` holding the **WIF private key** in clear text) and dropped the row's inline `private_key_bytes: [u8; 32]` (the raw ECDSA scalar) **without zeroizing either**, returning freed pages that still contain real private keys to the allocator. This runs on every `platform_wallet_preview_identity_registration_keys` → `_free` round-trip (the "scan/preview identity registration keys" UI path). The mid-loop error `cleanup` closure in `identity_keys_from_mnemonic.rs` had the same gap.

The structurally identical sibling `dash_sdk_derive_identity_keys_from_mnemonic_free` already zeroizes both correctly — this aligns the lagging paths with it.

## What was done?

- `release_row` now takes `&mut IdentityKeyPreviewFFI`, scrubs the WIF backing bytes (`CString::into_bytes_with_nul()` + `zeroize::Zeroize::zeroize`), zeroizes `private_key_bytes` in place, and nulls every owned pointer after reclaiming it (preserving double-free idempotency). Call sites (`platform_wallet_preview_identity_registration_keys_free`, `free_rows`) updated to `iter_mut`/`&mut`.
- A shared `zeroize_and_free_row(&mut IdentityKeyPreviewFFI)` helper is factored out in `identity_keys_from_mnemonic.rs` and used by **both** the mid-loop cleanup closure and the public `dash_sdk_derive_identity_keys_from_mnemonic_free`, so the two paths can't drift.
- Public `extern "C"` ABI is unchanged — only internal helpers changed.

## How Has This Been Tested?

`cargo test -p platform-wallet-ffi identity_key_preview` — **3 passed, 0 failed**:
- `release_row_zeroizes_secret_and_is_idempotent`: asserts the inline scalar is wiped to all-zero, every owned pointer is nulled, and a second `release_row` is a safe no-op.
- `public_free_zeroizes_and_resets`: drives rows through the real `_free` entry point; asserts the outer struct is reset and a second free no-ops.
- `free_rows_zeroizes_partial_list`: mid-loop cleanup path releases a partial list without panicking/double-freeing.

Crate builds clean; `cargo fmt --all` applied.

## Breaking Changes

None. Internal helper signatures only; the `extern "C"` FFI surface is unchanged.

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [ ] I have made corresponding changes to the documentation if needed

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cleanup of sensitive cryptographic material to ensure secrets are securely erased and released, preventing leaks and making release operations safe to repeat.
  * Ensured consistent, safe cleanup path for partly-constructed key data to avoid panics on error paths.

* **Tests**
  * Added unit tests verifying secure zeroization, pointer/reset idempotency, and robust free behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->