### PR TITLE
fix(rs-sdk-ffi): shrink signature allocation to len before leaking (capacity UB)

### DIFF
--- a/packages/rs-sdk-ffi/src/signer_simple.rs
+++ b/packages/rs-sdk-ffi/src/signer_simple.rs
@@ -111,6 +111,31 @@ pub struct DashSDKSignature {
     pub signature_len: usize,
 }
 
+/// Leak `bytes` into a raw `(ptr, len)` pair suitable for handing across
+/// the FFI boundary inside [`DashSDKSignature`], to be reclaimed by
+/// [`dash_sdk_signature_free`].
+///
+/// This mirrors the fix applied to [`crate::types::DashSDKResult::success_binary`]:
+/// the source `Vec` may have `capacity > len` (e.g. it came from a
+/// `BinaryData` whose inner buffer was over-allocated), but the free path
+/// reconstructs with `Vec::from_raw_parts(ptr, len, len)`. Reconstructing
+/// with `cap == len` is only sound when the *original* allocation also had
+/// `cap == len`; otherwise the global allocator receives a `Layout` that
+/// does not match the real allocation on dealloc — undefined behavior /
+/// heap corruption.
+///
+/// `into_boxed_slice()` shrinks the allocation so that its capacity equals
+/// its length before we leak it, making the `cap == len` free path sound.
+/// A `Box<[u8]>` of length `len` owns an allocation of exactly `len` bytes
+/// with the same layout `Vec<u8>` would use, so `Vec::from_raw_parts(ptr,
+/// len, len)` reclaims it correctly.
+fn leak_binary_to_ptr(bytes: Vec<u8>) -> (*mut u8, usize) {
+    let boxed: Box<[u8]> = bytes.into_boxed_slice();
+    let len = boxed.len();
+    let ptr = Box::into_raw(boxed) as *mut u8;
+    (ptr, len)
+}
+
 /// Sign data with a signer.
 ///
 /// # Safety
@@ -170,9 +195,11 @@ pub unsafe extern "C" fn dash_sdk_signer_sign(
 
     match result {
         Ok(Ok(signature)) => {
-            let sig_vec = signature.to_vec();
-            let sig_len = sig_vec.len();
-            let sig_ptr = sig_vec.leak().as_mut_ptr();
+            // Shrink the allocation so capacity == len before leaking, so
+            // that `dash_sdk_signature_free`'s `Vec::from_raw_parts(ptr, len,
+            // len)` reconstruction matches the real allocation layout. See
+            // `leak_binary_to_ptr` for why this is required for soundness.
+            let (sig_ptr, sig_len) = leak_binary_to_ptr(signature.to_vec());
 
             let boxed = Box::new(DashSDKSignature {
                 signature: sig_ptr,
@@ -459,5 +486,87 @@ mod tests {
         // attempt in the loop must fail and the helper must surface
         // the catch-all error.
         assert!(parse_mnemonic_any_language("not a real bip39 phrase at all here").is_err());
+    }
+
+    /// Regression test for the signature alloc/free round-trip.
+    ///
+    /// Mirrors `types::tests::test_success_binary_preserves_capacity_via_shrink`.
+    /// The signing path used to do `signature.to_vec().leak()`, which keeps
+    /// the source `Vec`'s *actual capacity*, while `dash_sdk_signature_free`
+    /// reconstructs with `Vec::from_raw_parts(ptr, len, len)`. When the
+    /// source capacity exceeded its length (as `BinaryData`'s inner `Vec`
+    /// can), the allocator received a wrong `Layout` on dealloc — undefined
+    /// behavior / heap corruption.
+    ///
+    /// `leak_binary_to_ptr` now shrinks capacity to len via
+    /// `into_boxed_slice()` before leaking, so the `cap == len` free path is
+    /// sound. This test drives a `capacity > len` buffer through the exact
+    /// alloc + free code the FFI uses and asserts the bytes survive the
+    /// round-trip and the free does not corrupt the heap.
+    #[test]
+    fn test_leak_binary_to_ptr_preserves_capacity_via_shrink() {
+        // A 65-byte compact-recoverable ECDSA signature living in a buffer
+        // with far more capacity than length — the exact mismatch the old
+        // `.leak()` path mishandled.
+        let signature_bytes: Vec<u8> = (0u8..65).collect();
+        let mut over_allocated: Vec<u8> = Vec::with_capacity(128);
+        over_allocated.extend_from_slice(&signature_bytes);
+
+        assert_eq!(over_allocated.len(), 65);
+        assert!(
+            over_allocated.capacity() > over_allocated.len(),
+            "capacity ({}) must exceed len ({}) for this test to exercise the bug",
+            over_allocated.capacity(),
+            over_allocated.len(),
+        );
+
+        // Alloc side: exactly what the `Ok(Ok(signature))` arm now does.
+        let (sig_ptr, sig_len) = leak_binary_to_ptr(over_allocated);
+        assert!(!sig_ptr.is_null());
+        assert_eq!(sig_len, 65);
+
+        // The bytes must survive the leak unchanged.
+        let round_tripped = unsafe { std::slice::from_raw_parts(sig_ptr, sig_len) };
+        assert_eq!(round_tripped, &signature_bytes[..]);
+
+        // Wrap exactly as the sign arm does, then free via the real FFI
+        // free function. Under the previous code this `Vec::from_raw_parts(
+        // ptr, len, len)` would hit the global allocator with a `Layout`
+        // whose size (len) disagreed with the real allocation (cap == 128),
+        // which is UB and would trip the allocator's debug checks / a
+        // sanitizer. With the `into_boxed_slice()` shrink it is sound.
+        let signature = Box::new(DashSDKSignature {
+            signature: sig_ptr,
+            signature_len: sig_len,
+        });
+        unsafe {
+            dash_sdk_signature_free(Box::into_raw(signature));
+        }
+    }
+
+    /// Empty-signature edge case: a zero-length leak must produce a
+    /// non-dangling, freeable allocation (the free path guards on
+    /// `signature_len`/null, and `into_boxed_slice` on an empty `Vec`
+    /// yields a dangling-but-valid `Box<[u8]>`).
+    #[test]
+    fn test_leak_binary_to_ptr_empty() {
+        let (sig_ptr, sig_len) = leak_binary_to_ptr(Vec::new());
+        assert_eq!(sig_len, 0);
+
+        let signature = Box::new(DashSDKSignature {
+            signature: sig_ptr,
+            signature_len: sig_len,
+        });
+        unsafe {
+            dash_sdk_signature_free(Box::into_raw(signature));
+        }
+    }
+
+    /// `dash_sdk_signature_free(null)` must be a no-op, not a crash.
+    #[test]
+    fn test_dash_sdk_signature_free_null() {
+        unsafe {
+            dash_sdk_signature_free(std::ptr::null_mut());
+        }
     }
 }


### PR DESCRIPTION
## Issue being fixed or feature implemented

**Latent heap-corruption UB on the native signer's sign → free path.**

`dash_sdk_signer_sign` (`signer_simple.rs`) returned the signature via:
```rust
let sig_vec = signature.to_vec();
let sig_ptr = sig_vec.leak().as_mut_ptr();   // leaks the source Vec's *capacity*
```
while `dash_sdk_signature_free` reclaims it with `Vec::from_raw_parts(sig.signature, sig.signature_len, sig.signature_len)`. `Vec::from_raw_parts(ptr, len, cap)` requires `cap` to **exactly** equal the original allocation capacity. `signature.to_vec()` clones a `BinaryData`'s inner `Vec`, whose capacity is not guaranteed to equal its length — when `capacity > len`, the global allocator is handed a wrong `Layout` on dealloc → undefined behavior / heap corruption.

This is the same bug class already fixed in `DashSDKResult::success_binary` (`types.rs`) via `into_boxed_slice()`, with a regression test noting it "was previously UB when capacity != len". The signer path never got the fix.

## What was done?

The signing arm now routes through a small private helper that shrinks capacity to len before leaking:
```rust
fn leak_binary_to_ptr(bytes: Vec<u8>) -> (*mut u8, usize) {
    let boxed: Box<[u8]> = bytes.into_boxed_slice(); // shrinks cap to len
    let len = boxed.len();
    (Box::into_raw(boxed) as *mut u8, len)
}
```
A `Box<[u8]>` of length `len` owns an allocation of exactly `len` bytes with a `Vec`-compatible layout, so the existing `Vec::from_raw_parts(ptr, len, len)` free is now sound. The free fn and the `#[repr(C)] DashSDKSignature` struct are unchanged.

I also audited the rest of `rs-sdk-ffi`: this was the **only** `.leak()` in the crate, and every other `Vec::from_raw_parts(ptr, len, len)` site already consumes an exact-capacity allocation, so no other instances of this bug exist.

## How Has This Been Tested?

`cargo test -p rs-sdk-ffi --lib signer_simple` — **6 passed, 0 failed**, including the new `test_leak_binary_to_ptr_preserves_capacity_via_shrink`, which builds a 65-byte signature inside a `Vec::with_capacity(128)` (capacity 128 > len 65 — the exact mismatch the old `.leak()` mishandled), runs it through `leak_binary_to_ptr` + the real `dash_sdk_signature_free`, and asserts the bytes round-trip without corrupting the heap. The existing `test_success_binary_preserves_capacity_via_shrink` still passes. `cargo fmt --all` clean.

## Breaking Changes

None. Internal allocation-layout correctness fix; `extern "C"` ABI unchanged.

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [ ] I have made corresponding changes to the documentation if needed

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced signature memory management to prevent allocation mismatches and improve reliability.

* **Tests**
  * Added edge-case tests for signature handling to validate stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->