### PR TITLE
fix(dashmate): ssl obtain --force populates context before CSR generation (fixes #3803)

### DIFF
--- a/packages/dashmate/src/listr/tasks/ssl/zerossl/obtainZeroSSLCertificateTaskFactory.js
+++ b/packages/dashmate/src/listr/tasks/ssl/zerossl/obtainZeroSSLCertificateTaskFactory.js
@@ -46,8 +46,6 @@ export default function obtainZeroSSLCertificateTaskFactory(
     const tasks = new Listr([
       {
         title: 'Check if certificate already exists and not expiring soon',
-        // Skips the check if force flag is set
-        skip: (ctx) => ctx.force,
         task: async (ctx, task) => {
           const { error, data } = await validateZeroSslCertificate(config, ctx.expirationDays);
 
@@ -55,6 +53,28 @@ export default function obtainZeroSSLCertificateTaskFactory(
 
           // Ensure we have config dir created
           fs.mkdirSync(ctx.sslConfigDir, { recursive: true });
+
+          // With --force we always (re)create the certificate. We must still run
+          // validateZeroSslCertificate above so the context (externalIp, apiKey, file
+          // paths) is populated for the keypair/CSR/creation steps below — otherwise
+          // generateCsr() is called with an undefined externalIp and fails with
+          // "Attribute value not specified". Only genuine prerequisite configuration
+          // errors should still abort under --force.
+          if (ctx.force) {
+            if (error === ERRORS.API_KEY_IS_NOT_SET) {
+              throw new Error('ZeroSSL API key is not set. Please set it in the config file');
+            }
+
+            if (error === ERRORS.EXTERNAL_IP_IS_NOT_SET) {
+              throw new Error('External IP is not set. Please set it in the config file');
+            }
+
+            // Force full regeneration of keypair, CSR and certificate
+            ctx.isCsrFilePresent = false;
+            ctx.certificate = null;
+
+            return;
+          }
 
           switch (error) {
             case undefined:


### PR DESCRIPTION
## What

Fixes #3803 — `dashmate ssl obtain --provider zerossl --force` always fails with `[FAILED] Attribute value not specified.` at the *Generate certificate request* step, which makes the `--force` flag unusable for ZeroSSL.

## Root cause

In `packages/dashmate/src/listr/tasks/ssl/zerossl/obtainZeroSSLCertificateTaskFactory.js`, the first subtask *"Check if certificate already exists and not expiring soon"* was skipped entirely under `--force`:

```js
skip: (ctx) => ctx.force,
```

But that subtask is the **only** place the obtain context is populated:

```js
const { error, data } = await validateZeroSslCertificate(config, ctx.expirationDays);
lodash.merge(ctx, data); // sets ctx.externalIp, ctx.apiKey, ctx.isCsrFilePresent, ...
```

So under `--force`, `ctx.externalIp` is `undefined`, and the later CSR subtask calls `generateCsr(ctx.keyPair, ctx.externalIp)` → node-forge `csr.setSubject([{ name: 'commonName', value: undefined }])` → throws **`Attribute value not specified`**.

## Fix

Run `validateZeroSslCertificate` + `lodash.merge(ctx, data)` **unconditionally** so the context is always populated, then handle `--force` explicitly *after* the merge:

- still abort on genuine prerequisites (`API_KEY_IS_NOT_SET`, `EXTERNAL_IP_IS_NOT_SET`);
- otherwise force full regeneration (`ctx.isCsrFilePresent = false; ctx.certificate = null`), which preserves the original intent of `--force` (a brand-new keypair, CSR and certificate).

The non-`--force` `switch (error)` path is left **unchanged**, so normal issuance and the scheduled auto-renewal behavior are untouched.

## Testing

- Reproduced on a real node (dashmate `3.0.1`): `ssl obtain --provider zerossl --force` → `Attribute value not specified`; the same node with `ssl obtain --provider zerossl --expiration-days N` succeeds — which is the clue, since `--expiration-days` keeps the context-loading subtask while `--force` skipped it.
- Verified the code paths against the current `v3.1-dev` source.
- `node --check` passes on the patched file.
- I was **not** able to run the full dashmate test suite in my environment. Happy to add/adjust unit tests for the `--force` path per your preference.

---

*Root-caused and fixed by **Claude** (Anthropic's Claude Code agent) while performing SSL certificate maintenance on a dashmate node, submitted on behalf of the node operator. Full investigation in #3803.*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved SSL certificate validation and force renewal to ensure comprehensive validation occurs before regeneration while protecting against configuration errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->