### PR TITLE
fix(platform-wallet): spv error propagation

### DIFF
--- a/packages/rs-platform-wallet-ffi/src/spv.rs
+++ b/packages/rs-platform-wallet-ffi/src/spv.rs
@@ -10,7 +10,7 @@ use platform_wallet::spv::{
 
 use crate::error::*;
 use crate::handle::*;
-use crate::runtime::runtime;
+use crate::runtime::{block_on_worker, runtime};
 use crate::types::FFINetwork;
 use crate::{check_ptr, unwrap_option_or_return, unwrap_result_or_return};
 
@@ -358,10 +358,23 @@ pub unsafe extern "C" fn platform_wallet_manager_spv_start(
             config.devnet = Some(devnet);
         }
 
-        let _guard = runtime().enter();
-        manager.spv_arc().spawn_in_background(config);
+        let spv = manager.spv_arc();
+        let start_result = {
+            let spv = spv.clone();
+            block_on_worker(async move { spv.start(config).await })
+        };
+
+        if start_result.is_ok() {
+            let _guard = runtime().enter();
+            spv.spawn_run_loop();
+        }
+
+        start_result
     });
-    unwrap_option_or_return!(option);
+
+    let start_result = unwrap_option_or_return!(option);
+    unwrap_result_or_return!(start_result);
+
     PlatformWalletFFIResult::ok()
 }
 

--- a/packages/rs-platform-wallet/src/error.rs
+++ b/packages/rs-platform-wallet/src/error.rs
@@ -149,9 +149,6 @@ pub enum PlatformWalletError {
     #[error("No wallets configured — add a wallet before starting SPV")]
     NoWalletsConfigured,
 
-    #[error("SPV client is not running")]
-    SpvNotRunning,
-
     #[error("SPV error: {0}")]
     SpvError(String),
 

--- a/packages/rs-platform-wallet/src/manager/accessors.rs
+++ b/packages/rs-platform-wallet/src/manager/accessors.rs
@@ -256,7 +256,7 @@ impl<P: PlatformWalletPersistence + 'static> PlatformWalletManager<P> {
     }
 
     /// Clone the `Arc<SpvRuntime>` so callers (e.g. FFI) can invoke
-    /// [`SpvRuntime::spawn_in_background`] which takes `&Arc<Self>`.
+    /// [`SpvRuntime::spawn_run_loop`] which takes `&Arc<Self>`.
     pub fn spv_arc(&self) -> Arc<SpvRuntime> {
         Arc::clone(&self.spv_manager)
     }

--- a/packages/rs-platform-wallet/src/spv/runtime.rs
+++ b/packages/rs-platform-wallet/src/spv/runtime.rs
@@ -97,9 +97,9 @@ impl SpvRuntime {
         tx: &Transaction,
     ) -> Result<(), PlatformWalletError> {
         let client_guard = self.client.read().await;
-        let client = client_guard
-            .as_ref()
-            .ok_or(PlatformWalletError::SpvNotRunning)?;
+        let client = client_guard.as_ref().ok_or(PlatformWalletError::SpvError(
+            "SPV Client not started".to_string(),
+        ))?;
 
         client
             .broadcast_transaction(tx)
@@ -117,9 +117,9 @@ impl SpvRuntime {
         height: u32,
     ) -> Result<[u8; 48], PlatformWalletError> {
         let client_guard = self.client.read().await;
-        let client = client_guard
-            .as_ref()
-            .ok_or(PlatformWalletError::SpvNotRunning)?;
+        let client = client_guard.as_ref().ok_or(PlatformWalletError::SpvError(
+            "SPV Client not started".to_string(),
+        ))?;
 
         let llmq_type = LLMQType::from(quorum_type as u8);
         let qh = QuorumHash::from_byte_array(quorum_hash).reverse();
@@ -132,16 +132,15 @@ impl SpvRuntime {
         Ok(*quorum.quorum_entry.quorum_public_key.as_ref())
     }
 
-    /// Run the SPV sync loop until calling [`stop`]. This blocks the current thread.
-    pub async fn run(&self, config: ClientConfig) -> Result<(), PlatformWalletError> {
-        tracing::info!("SpvRuntime::run() starting client...");
-        self.start(config).await?;
-        tracing::info!("SpvRuntime::run() client started, entering sync loop");
-
+    /// Drive the sync loop of an already-[`start`]ed client until [`stop`]
+    /// is called
+    async fn run(&self) -> Result<(), PlatformWalletError> {
         let client_guard = self.client.read().await;
         let client = client_guard
             .as_ref()
-            .ok_or(PlatformWalletError::SpvNotRunning)?
+            .ok_or(PlatformWalletError::SpvError(
+                "SPV Client not started".to_string(),
+            ))?
             .clone();
         drop(client_guard);
 
@@ -189,10 +188,11 @@ impl SpvRuntime {
         stop_result
     }
 
-    /// Spawn `run()` on the current tokio runtime and return immediately.
+    /// Spawn the sync loop of an already-[`start`]ed client on the current
+    /// tokio runtime and return immediately.
     ///
     /// Call [`stop`] to stop it
-    pub fn spawn_in_background(self: &Arc<Self>, config: ClientConfig) {
+    pub fn spawn_run_loop(self: &Arc<Self>) {
         {
             let existing = self.task.lock().expect("spv task mutex poisoned");
             if existing.is_some() {
@@ -206,8 +206,8 @@ impl SpvRuntime {
         let this = Arc::clone(self);
 
         let handle = tokio::spawn(async move {
-            if let Err(e) = this.run(config).await {
-                tracing::warn!("SpvRuntime background run exited with error: {}", e);
+            if let Err(e) = this.run().await {
+                tracing::warn!("SpvRuntime background run loop exited with error: {}", e);
             }
         });
 
@@ -252,9 +252,10 @@ impl SpvRuntime {
     /// The SPV client must be running to perform this operation.
     pub async fn clear_storage(&self) -> Result<(), PlatformWalletError> {
         let client_guard = self.client.read().await;
-        let client = client_guard
-            .as_ref()
-            .ok_or(PlatformWalletError::SpvNotRunning)?;
+        let client = client_guard.as_ref().ok_or(PlatformWalletError::SpvError(
+            "SPV Client not started".to_string(),
+        ))?;
+
         client
             .clear_storage()
             .await
@@ -266,9 +267,10 @@ impl SpvRuntime {
     /// The network cannot be changed on a running client.
     pub async fn update_config(&self, config: ClientConfig) -> Result<(), PlatformWalletError> {
         let client_guard = self.client.read().await;
-        let client = client_guard
-            .as_ref()
-            .ok_or(PlatformWalletError::SpvNotRunning)?;
+        let client = client_guard.as_ref().ok_or(PlatformWalletError::SpvError(
+            "SPV Client not started".to_string(),
+        ))?;
+
         client
             .update_config(config)
             .await

--- a/packages/rs-platform-wallet/tests/spv_sync.rs
+++ b/packages/rs-platform-wallet/tests/spv_sync.rs
@@ -219,13 +219,9 @@ async fn test_spv_sync_and_balance() {
     }
 
     // --- Start SPV in background ---
-    let manager_for_spv = Arc::clone(&manager);
-    let spv_handle = tokio::spawn(async move {
-        if let Err(e) = manager_for_spv.spv().run(config).await {
-            eprintln!("SPV runtime error: {}", e);
-        }
-    });
-
+    let spv = manager.spv_arc();
+    spv.start(config).await.unwrap();
+    spv.spawn_run_loop();
     // --- Wait for confirmed balance ---
     // Cold start needs to sync full testnet chain headers (~1M+ blocks).
     // Second run with cached state is much faster (~20s).
@@ -241,7 +237,6 @@ async fn test_spv_sync_and_balance() {
     loop {
         if start.elapsed() > timeout {
             let _ = manager.spv().stop().await;
-            let _ = spv_handle.await;
             panic!("Timeout waiting for wallet balance after {:?}", timeout);
         }
 
@@ -266,7 +261,6 @@ async fn test_spv_sync_and_balance() {
         if confirmed > 0 {
             println!("SUCCESS: Wallet has confirmed balance: {} duffs", confirmed);
             let _ = manager.spv().stop().await;
-            let _ = spv_handle.await;
 
             // --- Verify persistence ---
             let core_stores = persister_for_check.core_store_count();


### PR DESCRIPTION
Because start was being called inside the run method, and spawn in background was calling this run method without returning any start error, the spv client could fail to start and nobody was reciting the error. With this PR I force the start method to be called independently, this way start errors are no longer discarded.

Regression tests in PR https://github.com/dashpay/platform/pull/3712


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [x] I have made corresponding changes to the documentation if needed

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved SPV startup so the run loop only begins after a successful initialization, with startup failures now correctly reported to the caller (including via FFI).
  * Refined SPV error handling: when SPV hasn’t been started, responses now consistently report “SPV Client not started” rather than a missing “SPV not running” case.

* **Refactor**
  * Restructured SPV background lifecycle to separate initialization from the background run loop, aligning runtime behavior with the manager’s SPV control flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->