### PR TITLE
fix(platform-wallet): free SPV data dir on stop

### DIFF
--- a/packages/rs-platform-wallet/src/spv/runtime.rs
+++ b/packages/rs-platform-wallet/src/spv/runtime.rs
@@ -1,8 +1,9 @@
 //! SPV client runtime — manages the DashSpvClient lifecycle.
 
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 
 use tokio::sync::RwLock;
+use tokio::task::JoinHandle;
 
 use dashcore::sml::llmq_type::LLMQType;
 use dashcore::{QuorumHash, Transaction};
@@ -29,6 +30,7 @@ pub struct SpvRuntime {
     event_manager: Arc<PlatformEventManager>,
     wallet_manager: Arc<RwLock<WalletManager<PlatformWalletInfo>>>,
     client: RwLock<Option<SpvClient>>,
+    task: Mutex<Option<JoinHandle<()>>>,
 }
 // TODO: We want it better
 impl SpvRuntime {
@@ -41,6 +43,7 @@ impl SpvRuntime {
             event_manager,
             wallet_manager,
             client: RwLock::new(None),
+            task: Mutex::new(None),
         }
     }
 
@@ -153,27 +156,62 @@ impl SpvRuntime {
         result
     }
 
-    /// Stop SPV sync gracefully.
+    /// Stop SPV sync gracefully. Unlocks the data dir safely
     pub async fn stop(&self) -> Result<(), PlatformWalletError> {
-        let mut client = self.client.write().await;
-        if let Some(c) = client.take() {
-            c.stop()
+        let taken = {
+            let mut client = self.client.write().await;
+            client.take()
+        };
+
+        let stop_result = match taken {
+            Some(c) => c
+                .stop()
                 .await
-                .map_err(|e| PlatformWalletError::SpvError(e.to_string()))?;
+                .map_err(|e| PlatformWalletError::SpvError(e.to_string())),
+            None => Ok(()),
+        };
+
+        let handle = self.task.lock().expect("spv task mutex poisoned").take();
+        if let Some(handle) = handle {
+            let abort = handle.abort_handle();
+            if tokio::time::timeout(std::time::Duration::from_secs(15), handle)
+                .await
+                .is_err()
+            {
+                tracing::warn!(
+                    "SPV stop: background run loop did not unwind within 15s; aborting it"
+                );
+
+                abort.abort();
+            }
         }
-        Ok(())
+
+        stop_result
     }
 
     /// Spawn `run()` on the current tokio runtime and return immediately.
     ///
     /// Call [`stop`] to stop it
     pub fn spawn_in_background(self: &Arc<Self>, config: ClientConfig) {
+        {
+            let existing = self.task.lock().expect("spv task mutex poisoned");
+            if existing.is_some() {
+                tracing::warn!(
+                    "spawn_in_background called while a task is already running; ignoring"
+                );
+                return;
+            }
+        }
+
         let this = Arc::clone(self);
-        tokio::spawn(async move {
+
+        let handle = tokio::spawn(async move {
             if let Err(e) = this.run(config).await {
                 tracing::warn!("SpvRuntime background run exited with error: {}", e);
             }
         });
+
+        *self.task.lock().expect("spv task mutex poisoned") = Some(handle);
     }
 
     /// Get the current sync progress.


### PR DESCRIPTION
The spv client wrapper stop method wasn't waiting for the spv task to stop, making run calls made right after it fail due to a locked storage dir. With this PR the stop method waits for the run method to finish by waiting for the JoinHandle


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [ ] I have made corresponding changes to the documentation if needed

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved graceful shutdown of background sync with a bounded wait and clearer warnings when shutdown times out.
  * Prevented duplicate background sync tasks from being spawned; attempts to start an already-running background process now emit a warning and return early.
  * Safer tracking and cleanup of background work to reduce resource leaks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->