### PR TITLE
fix(drive): correct fee/credit accounting on the address-funding asset-lock penalty path

### DIFF
--- a/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/address_funding_from_asset_lock/advanced_structure/v0/mod.rs
+++ b/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/address_funding_from_asset_lock/advanced_structure/v0/mod.rs
@@ -59,6 +59,12 @@ impl AddressFundingFromAssetLockStateTransitionAdvancedStructureValidationV0
                 .checked_add(execution_context.fee_cost(platform_version)?.processing_fee)
                 .ok_or(ProtocolError::Overflow("processing fee overflow error"))?;
 
+            // The transition failed, so no outputs are created and the inputs' intended spend is
+            // never transferred. Charge only the penalty fee, not the spend: restore each input to
+            // its full balance before the fee is deducted, so the address keeps its funds aside from
+            // the fee instead of the spend being removed without being credited anywhere.
+            action.restore_input_spends_for_failed_transition(self.inputs());
+
             // Create a PartiallyUseAssetLockAction to deduct fees from inputs first, then asset lock
             let bump_action = StateTransitionAction::PartiallyUseAssetLockAction(
                 PartiallyUseAssetLockAction::from_address_funding_from_asset_lock_transition_action(

--- a/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/address_funding_from_asset_lock/tests.rs
+++ b/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/address_funding_from_asset_lock/tests.rs
@@ -8698,12 +8698,11 @@ mod tests {
         async fn test_invalid_paid_fee_from_input_only() {
             // Scenario: Input has enough balance to cover the entire penalty + processing fee.
             // Fee strategy specifies DeductFromInput first.
-            // Expected: Input balance is reduced, asset lock remains untouched.
+            // Expected: Input balance is reduced by ONLY the fee, asset lock remains untouched.
             //
-            // Note: When a transition fails in advanced_structure validation, the action still has
-            // the "remaining balance" which is (actual_balance - input_spend_amount). The fee is
-            // then deducted from this remaining balance. So the final balance is:
-            // actual_balance - input_spend_amount - fee_from_remaining
+            // Note: When a transition fails in advanced_structure validation, no outputs are created,
+            // so the intended spend is NOT consumed -- only the penalty fee is charged. The final
+            // balance is: actual_balance - fee (the spend is preserved).
             let platform_version = PlatformVersion::latest();
             let platform_config = PlatformConfig {
                 testing_configs: PlatformTestConfig {
@@ -8795,29 +8794,35 @@ mod tests {
                 .penalties
                 .address_funds_insufficient_balance;
 
-            // Verify input balance was reduced
+            // Verify input balance was reduced by ONLY the fee (the intended spend is preserved
+            // because the transition failed and no outputs were created).
             let input_balance_after = get_address_balance(&platform, input_address, &transaction);
 
-            // The remaining_balance in action = initial_input_balance - input_spend_amount
-            let remaining_balance_in_action = initial_input_balance - input_spend_amount;
+            // Amount actually charged to the input address.
+            let fee_from_input = initial_input_balance - input_balance_after;
 
-            // Fee deducted from input = remaining_balance - balance_after
-            let fee_from_input = remaining_balance_in_action - input_balance_after;
-
-            // Verify that input was charged (balance reduced)
+            // Verify that the input was charged (balance reduced).
             assert!(
-                input_balance_after < remaining_balance_in_action,
-                "Input balance {} should be less than remaining {} (some fee was taken)",
+                input_balance_after < initial_input_balance,
+                "Input balance {} should be less than the initial {} (the fee was taken)",
                 input_balance_after,
-                remaining_balance_in_action
+                initial_input_balance
             );
 
-            // Verify at least the penalty was taken from input
+            // Verify at least the penalty was taken from the input.
             assert!(
                 fee_from_input >= penalty,
                 "Fee from input {} should be at least the penalty {}",
                 fee_from_input,
                 penalty
+            );
+
+            // Verify the intended spend was NOT confiscated -- only the fee should be charged.
+            assert!(
+                fee_from_input < input_spend_amount,
+                "Only the fee ({}) should be charged to the input, not the intended spend ({})",
+                fee_from_input,
+                input_spend_amount
             );
 
             // Verify asset lock is untouched (full value remains)
@@ -8845,13 +8850,204 @@ mod tests {
         }
 
         #[tokio::test]
-        async fn test_invalid_paid_fee_from_input_then_asset_lock() {
-            // Scenario: Input has some balance but not enough for the full fee (penalty + processing).
-            // Fee strategy specifies DeductFromInput first.
-            // Expected: Input contributes what it can, remainder comes from asset lock.
+        async fn test_address_funding_penalty_charges_only_fee_and_conserves_credits() {
+            // Credit-accounting test for the AddressFundingFromAssetLock penalty path (the branch
+            // taken when a transition can't be fully applied):
             //
-            // Note: The action's inputs_with_remaining_balance contains (actual_balance - input_spend_amount).
-            // Fee is deducted from this remaining balance, not the original balance.
+            //   - When the penalty fee is (partly) covered by an address input, only the
+            //     asset-lock-sourced portion of the fee should be reflected in the system credit
+            //     total; the input-covered portion already lives in the address balances.
+            //
+            //   - The failed transition creates no outputs, so the inputs' intended "spend" should
+            //     not be consumed -- only the penalty fee is charged (the address ends at
+            //     actual - fee), so an address keeps its funds aside from the fee.
+            //
+            // This checks that, after processing, the system credit total and the balance trees
+            // reconcile: the asset lock is untouched (no asset-lock-sourced credits), the address is
+            // charged only the penalty fee (its spend preserved), the system credit total does not
+            // grow (scalar_delta == 0), and the totals line up (accounting_gap == 0).
+            let platform_version = PlatformVersion::latest();
+            let platform_config = PlatformConfig {
+                testing_configs: PlatformTestConfig {
+                    disable_instant_lock_signature_verification: true,
+                    ..Default::default()
+                },
+                ..Default::default()
+            };
+
+            let mut platform = TestPlatformBuilder::new()
+                .with_config(platform_config)
+                .with_latest_protocol_version()
+                .build_with_mock_rpc()
+                .set_genesis_state();
+
+            let mut signer = TestAddressSigner::new();
+            let input_address = signer.add_p2pkh([200u8; 32]);
+
+            // Seed the address with plenty of balance to cover penalty + processing fee.
+            let initial_input_balance = dash_to_credits!(0.5);
+            let input_spend_amount = dash_to_credits!(0.1);
+            setup_address_with_balance(&mut platform, input_address, 0, initial_input_balance);
+
+            let mut rng = StdRng::seed_from_u64(2002);
+            let (asset_lock_proof, asset_lock_pk) = create_asset_lock_proof_with_key(&mut rng);
+            let asset_lock_outpoint = asset_lock_proof.out_point().expect("should have outpoint");
+            let initial_asset_lock_value = dash_to_credits!(1.0); // From fixture
+
+            let mut inputs = BTreeMap::new();
+            inputs.insert(input_address, (1 as AddressNonce, input_spend_amount));
+
+            let mut outputs = BTreeMap::new();
+            // Outputs (3 DASH) exceed asset_lock (1) + input spend (0.1) -> insufficient-funds
+            // penalty path, with the fee deducted from the input address first.
+            outputs.insert(create_platform_address(1), Some(dash_to_credits!(3.0)));
+            outputs.insert(create_platform_address(2), None); // Remainder recipient
+
+            let transition = create_signed_address_funding_from_asset_lock_transition(
+                asset_lock_proof,
+                &asset_lock_pk,
+                &signer,
+                inputs,
+                outputs,
+                vec![
+                    AddressFundsFeeStrategyStep::DeductFromInput(0),
+                    AddressFundsFeeStrategyStep::ReduceOutput(0),
+                ],
+            )
+            .await;
+
+            let result = transition.serialize_to_bytes().expect("should serialize");
+
+            let platform_state = platform.state.load();
+            let transaction = platform.drive.grove.start_transaction();
+
+            // --- Capture conservation state before processing (delta approach) ---
+            let before = platform
+                .drive
+                .calculate_total_credits_balance(Some(&transaction), &platform_version.drive)
+                .expect("should calculate total credits balance before");
+            let scalar_before = before.total_credits_in_platform as i128;
+            let trees_before = before.total_in_trees().expect("trees before") as i128;
+
+            let processing_result = platform
+                .platform
+                .process_raw_state_transitions(
+                    &[result],
+                    &platform_state,
+                    &BlockInfo::default(),
+                    &transaction,
+                    platform_version,
+                    false,
+                    None,
+                )
+                .expect("expected to process state transition");
+
+            // Confirm we hit the invalid_paid (penalty) path.
+            assert_eq!(processing_result.invalid_paid_count(), 1);
+            assert_eq!(processing_result.valid_count(), 0);
+
+            // The asset lock must be left UNTOUCHED: the fee came from the address, so 0 credits
+            // entered the platform from L1.
+            let asset_lock_consumed =
+                match get_asset_lock_info(&platform, &asset_lock_outpoint, &transaction) {
+                    StoredAssetLockInfo::PartiallyConsumed(value) => {
+                        initial_asset_lock_value as i128 - value.remaining_credit_value() as i128
+                    }
+                    StoredAssetLockInfo::FullyConsumed => {
+                        panic!("asset lock should not be fully consumed")
+                    }
+                    StoredAssetLockInfo::NotPresent => {
+                        panic!("asset lock should be present after processing")
+                    }
+                };
+            assert_eq!(
+                asset_lock_consumed, 0,
+                "asset lock should be untouched (fee paid from address), so 0 new money entered from L1"
+            );
+
+            // 2b: the address must be charged ONLY the penalty fee -- its intended spend is preserved.
+            let penalty = platform_version
+                .drive_abci
+                .validation_and_processing
+                .penalties
+                .address_funds_insufficient_balance;
+            let address_after = get_address_balance(&platform, input_address, &transaction);
+            let charged_from_address = initial_input_balance as i128 - address_after as i128;
+            assert!(
+                charged_from_address >= penalty as i128,
+                "the penalty ({}) should have been charged to the address (charged {})",
+                penalty,
+                charged_from_address
+            );
+            assert!(
+                charged_from_address < input_spend_amount as i128,
+                "only the fee should be charged, not the intended spend ({}); charged {} -- the \
+                 spend must be preserved on a failed transition",
+                input_spend_amount,
+                charged_from_address
+            );
+
+            // Fees the engine books into the Pools sum tree at block end.
+            let fees = processing_result.aggregated_fees();
+            let fees_to_pools = fees.storage_fee as i128 + fees.processing_fee as i128;
+
+            let after = platform
+                .drive
+                .calculate_total_credits_balance(Some(&transaction), &platform_version.drive)
+                .expect("should calculate total credits balance after");
+            let scalar_after = after.total_credits_in_platform as i128;
+            let trees_after = after.total_in_trees().expect("trees after") as i128;
+
+            let scalar_delta = scalar_after - scalar_before;
+            let trees_delta = trees_after - trees_before;
+
+            // After the block's fees are booked into the pools, the system credit total should equal
+            // the sum of the balance trees, i.e. scalar_delta == trees_delta + fees_to_pools.
+            let accounting_gap = scalar_delta - (trees_delta + fees_to_pools);
+
+            println!(
+                "address-funding penalty credit-accounting check:\n  \
+                 asset_lock_consumed   = {}\n  \
+                 charged_from_address  = {}\n  \
+                 scalar_delta          = {}\n  \
+                 trees_delta           = {}\n  \
+                 fees_to_pools         = {}\n  \
+                 accounting_gap        = {}",
+                asset_lock_consumed,
+                charged_from_address,
+                scalar_delta,
+                trees_delta,
+                fees_to_pools,
+                accounting_gap,
+            );
+
+            // The asset lock contributed nothing and the entire fee was paid from the pre-existing
+            // address balance, so the system credit total must not grow.
+            assert_eq!(
+                scalar_delta, 0,
+                "the system credit total must not grow when the fee is paid from an existing \
+                 address balance and nothing came from the asset lock (scalar_delta {})",
+                scalar_delta,
+            );
+
+            // The system credit total reconciles with the balance trees on this path.
+            assert_eq!(
+                accounting_gap, 0,
+                "the system credit total must reconcile with the balance trees on the penalty path \
+                 (gap {})",
+                accounting_gap,
+            );
+        }
+
+        #[tokio::test]
+        async fn test_invalid_paid_fee_from_input_then_asset_lock() {
+            // Scenario: Input's full balance is not enough for the full fee (penalty + processing).
+            // Fee strategy specifies DeductFromInput first.
+            // Expected: Input contributes everything it has, remainder comes from asset lock.
+            //
+            // Note: on the failed-transition penalty path the fee is charged from the input's full
+            // ACTUAL balance (the intended spend is no longer destroyed). Here the fee exceeds the
+            // balance, so the input is fully drained and the asset lock covers the remainder.
             let platform_version = PlatformVersion::latest();
             let platform_config = PlatformConfig {
                 testing_configs: PlatformTestConfig {
@@ -8870,13 +9066,10 @@ mod tests {
             let mut signer = TestAddressSigner::new();
             let input_address = signer.add_p2pkh([201u8; 32]);
 
-            // Set up input such that remaining_balance < total_fee
-            // remaining_balance = initial_input_balance - input_spend_amount
-            // We want: remaining_balance < penalty (~10M) + processing (~10M)
-            // But remaining_balance > 0 so both input and asset lock contribute
-            let initial_input_balance = 15_000_000u64; // 15M credits
-            let input_spend_amount = 10_000_000u64; // 10M credits
-                                                    // remaining_balance_in_action = 15M - 10M = 5M (less than ~20M total fee)
+            // Set up the input so its FULL actual balance is less than the total fee (penalty +
+            // processing, ~10M), so the input is fully drained and the asset lock covers the rest.
+            let initial_input_balance = 5_000_000u64; // 5M credits (< ~10M total fee)
+            let input_spend_amount = 2_000_000u64; // 2M credits
             setup_address_with_balance(&mut platform, input_address, 0, initial_input_balance);
 
             let mut rng = StdRng::seed_from_u64(2003);
@@ -8944,23 +9137,16 @@ mod tests {
                 .penalties
                 .address_funds_insufficient_balance;
 
-            // Verify input balance after processing
+            // The fee exceeds the input's full balance, so the input is fully drained.
             let input_balance_after = get_address_balance(&platform, input_address, &transaction);
-
-            // The remaining_balance in action = initial_input_balance - input_spend_amount
-            let remaining_balance_in_action = initial_input_balance - input_spend_amount;
-
-            // Input balance should be 0 or reduced significantly (fee deducted from remaining)
-            // Final balance = remaining_balance - min(fee, remaining_balance) = 0 (if remaining < fee)
-            assert!(
-                input_balance_after < remaining_balance_in_action,
-                "Input balance after {} should be less than remaining {} (some fee was taken)",
-                input_balance_after,
-                remaining_balance_in_action
+            assert_eq!(
+                input_balance_after, 0,
+                "Input balance after {} should be 0 (fully drained by the fee)",
+                input_balance_after
             );
 
-            // Fee deducted from input = remaining_balance_in_action - input_balance_after
-            let fee_from_input = remaining_balance_in_action - input_balance_after;
+            // Fee charged to the input = everything it had.
+            let fee_from_input = initial_input_balance - input_balance_after;
 
             // Verify asset lock was partially consumed
             let asset_lock_info =

--- a/packages/rs-drive/src/state_transition_action/action_convert_to_operations/system/partially_use_asset_lock.rs
+++ b/packages/rs-drive/src/state_transition_action/action_convert_to_operations/system/partially_use_asset_lock.rs
@@ -59,13 +59,17 @@ impl DriveHighLevelOperationConverter for PartiallyUseAssetLockAction {
 
                 let mut drive_operations = Vec::new();
 
+                // Tracks how much of `used_credits` was paid from existing address balances. Those
+                // credits already count toward total_credits_in_platform, so they must NOT be added
+                // again via AddToSystemCredits (only asset-lock-sourced credits are new money).
+                let mut total_deducted_from_inputs = 0u64;
+
                 // If we have inputs and a fee strategy, deduct fees from inputs first
                 // Note: remaining_credit_value was already pre-computed to deduct ALL used_credits
                 // from the asset lock. Here we restore the portion that's covered by inputs.
                 if let Some((inputs, fee_strategy)) = inputs_and_strategy {
                     let inputs_ordered: Vec<_> = inputs.iter().collect();
                     let mut remaining_fee = used_credits;
-                    let mut total_deducted_from_inputs = 0u64;
 
                     // Process fee strategy steps in order
                     for step in &fee_strategy {
@@ -111,9 +115,14 @@ impl DriveHighLevelOperationConverter for PartiallyUseAssetLockAction {
                         remaining_credit_value.saturating_add(total_deducted_from_inputs);
                 }
 
+                // Only the portion of the fee sourced from the asset lock is new money entering the
+                // platform. The portion paid from existing address balances is already counted in
+                // the system credit total, so adding the full `used_credits` would count it twice.
+                let new_system_credits = used_credits.saturating_sub(total_deducted_from_inputs);
+
                 // Add system credits operation
                 drive_operations.push(SystemOperation(SystemOperationType::AddToSystemCredits {
-                    amount: used_credits,
+                    amount: new_system_credits,
                 }));
 
                 // Add used asset lock operation
@@ -242,10 +251,12 @@ mod tests {
             other => panic!("expected SetBalanceToAddress, got {:?}", other),
         }
 
-        // Second should be AddToSystemCredits
+        // Second should be AddToSystemCredits. The entire fee (3000) was covered by the input
+        // address (existing credits already counted in total_credits_in_platform), so NO new money
+        // entered from the asset lock -> AddToSystemCredits must be 0 (credit-conservation fix).
         match &ops[1] {
             SystemOperation(SystemOperationType::AddToSystemCredits { amount }) => {
-                assert_eq!(*amount, 3000);
+                assert_eq!(*amount, 0);
             }
             other => panic!("expected AddToSystemCredits, got {:?}", other),
         }

--- a/packages/rs-drive/src/state_transition_action/action_convert_to_operations/system/partially_use_asset_lock.rs
+++ b/packages/rs-drive/src/state_transition_action/action_convert_to_operations/system/partially_use_asset_lock.rs
@@ -32,14 +32,15 @@ impl DriveHighLevelOperationConverter for PartiallyUseAssetLockAction {
                 let used_credits = self.used_credits();
                 let asset_lock_outpoint = self.asset_lock_outpoint();
 
-                let previous_transaction_hashes = if self.previous_transaction_hashes_ref().len()
+                let max_usage_attempts_reached = self.previous_transaction_hashes_ref().len()
                     as u16
                     >= platform_version
                         .drive_abci
                         .validation_and_processing
                         .state_transitions
-                        .max_asset_lock_usage_attempts
-                {
+                        .max_asset_lock_usage_attempts;
+
+                let previous_transaction_hashes = if max_usage_attempts_reached {
                     // There have been 16 failed attempts at using the asset lock
                     // In this case the remaining credit value is burned and there is no need to keep around previous
                     // transaction hashes
@@ -113,6 +114,13 @@ impl DriveHighLevelOperationConverter for PartiallyUseAssetLockAction {
                     // asset lock. Restore the portion that was covered by inputs.
                     remaining_credit_value =
                         remaining_credit_value.saturating_add(total_deducted_from_inputs);
+                }
+
+                // The input-fee restoration above must not revive a burned remainder: once the max
+                // usage attempts are reached the asset lock is fully consumed regardless of who paid
+                // the fee, so keep the remainder at 0.
+                if max_usage_attempts_reached {
+                    remaining_credit_value = 0;
                 }
 
                 // Only the portion of the fee sourced from the asset lock is new money entering the
@@ -378,6 +386,69 @@ mod tests {
             }) => {
                 // Still burned even when well above max
                 assert_eq!(asset_lock_value.remaining_credit_value(), 0);
+                assert!(asset_lock_value.used_tags_ref().is_empty());
+            }
+            other => panic!("expected AddUsedAssetLock, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_action_max_usage_attempts_with_inputs_still_burns_remainder() {
+        // When the max usage attempts have been reached, the asset-lock remainder must be burned to
+        // 0 (fully consumed) even if the fee is paid from address inputs. The input-fee restoration
+        // must not revive the burned remainder.
+        let platform_version = PlatformVersion::latest();
+        let max_attempts = platform_version
+            .drive_abci
+            .validation_and_processing
+            .state_transitions
+            .max_asset_lock_usage_attempts;
+
+        let previous_hashes: Vec<Bytes32> =
+            (0..max_attempts).map(|i| Bytes32([i as u8; 32])).collect();
+
+        let mut inputs = BTreeMap::new();
+        // Input fully covers the fee (used_credits).
+        inputs.insert(PlatformAddress::P2pkh([0xBB; 20]), (7_u32, 10000_u64));
+
+        let action = PartiallyUseAssetLockAction::V0(PartiallyUseAssetLockActionV0 {
+            asset_lock_outpoint: Bytes36::new([0xCC; 36]),
+            initial_credit_value: 50000,
+            previous_transaction_hashes: previous_hashes,
+            asset_lock_script: vec![0x76, 0xA9, 0x14],
+            remaining_credit_value: 40000,
+            used_credits: 10000,
+            user_fee_increase: 0,
+            inputs_with_remaining_balance: Some(inputs),
+            fee_strategy: Some(vec![AddressFundsFeeStrategyStep::DeductFromInput(0)]),
+        });
+        let epoch = Epoch::new(0).unwrap();
+
+        let ops = action
+            .into_high_level_drive_operations(&epoch, platform_version)
+            .expect("expected operations");
+
+        // SetBalanceToAddress, AddToSystemCredits, AddUsedAssetLock
+        assert_eq!(ops.len(), 3);
+
+        // The whole fee was covered by the input, so no new system credits are added.
+        match &ops[1] {
+            SystemOperation(SystemOperationType::AddToSystemCredits { amount }) => {
+                assert_eq!(*amount, 0);
+            }
+            other => panic!("expected AddToSystemCredits, got {:?}", other),
+        }
+
+        // The remainder must stay burned (0) -> fully consumed, despite the input paying the fee.
+        match &ops[2] {
+            SystemOperation(SystemOperationType::AddUsedAssetLock {
+                asset_lock_value, ..
+            }) => {
+                assert_eq!(
+                    asset_lock_value.remaining_credit_value(),
+                    0,
+                    "max-attempt burn must not be revived by the input-fee restoration"
+                );
                 assert!(asset_lock_value.used_tags_ref().is_empty());
             }
             other => panic!("expected AddUsedAssetLock, got {:?}", other),

--- a/packages/rs-drive/src/state_transition_action/address_funds/address_funding_from_asset_lock/mod.rs
+++ b/packages/rs-drive/src/state_transition_action/address_funds/address_funding_from_asset_lock/mod.rs
@@ -140,6 +140,32 @@ impl AddressFundingFromAssetLockTransitionAction {
             }
         }
     }
+
+    /// Restores each input's full balance ahead of the insufficient-funds penalty path.
+    ///
+    /// `inputs_with_remaining_balance` stores each input's balance *after* its intended spend
+    /// (`actual - requested`), which is correct on the success path because the spend funds the
+    /// outputs. On the penalty path the transition failed and no outputs are created, so the spend
+    /// must not be consumed — only the penalty fee should be charged. This adds each input's
+    /// requested spend back so the downstream `PartiallyUseAssetLockAction` deducts the fee from the
+    /// full balance, leaving the user with `actual - fee`. Without this, the spend would be removed
+    /// from the address without being credited anywhere.
+    pub fn restore_input_spends_for_failed_transition(
+        &mut self,
+        requested_inputs: &BTreeMap<PlatformAddress, (AddressNonce, Credits)>,
+    ) {
+        match self {
+            AddressFundingFromAssetLockTransitionAction::V0(transition) => {
+                for (address, (_nonce, balance)) in
+                    transition.inputs_with_remaining_balance.iter_mut()
+                {
+                    if let Some((_, requested_spend)) = requested_inputs.get(address) {
+                        *balance = balance.saturating_add(*requested_spend);
+                    }
+                }
+            }
+        }
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Issue being fixed or feature implemented

Tidies up credit accounting on the `AddressFundingFromAssetLock` penalty path — the branch taken when a transition can't be fully applied. A couple of edge cases in how the penalty fee interacts with address inputs and the asset lock weren't being accounted consistently.

## What was done?

- When the penalty fee is (partly) covered by an address input, only the asset-lock-sourced portion of the fee is reflected in the system credit total. The input-covered portion already lives in the address balances, so it shouldn't be added again.
- On this path the inputs' intended spend is no longer consumed — only the penalty fee is charged — so an address keeps its funds aside from the fee.
- Added a credit-accounting test and updated the unit/integration tests that encoded the previous behavior.

Touched files:
- `rs-drive/.../action_convert_to_operations/system/partially_use_asset_lock.rs`
- `rs-drive/.../address_funds/address_funding_from_asset_lock/mod.rs`
- `rs-drive-abci/.../address_funding_from_asset_lock/advanced_structure/v0/mod.rs`
- `rs-drive-abci/.../address_funding_from_asset_lock/tests.rs`

## How Has This Been Tested?

New and updated tests in the `address_funding_from_asset_lock` suite, plus the `partially_use_asset_lock` converter unit tests.

```bash
cargo test -p drive --lib partially_use_asset_lock
cargo test -p drive-abci --lib address_funding_from_asset_lock
```

## Breaking Changes

Minor change to the on-state effect of a *failed* `AddressFundingFromAssetLock` transition (penalty fee only; successful transitions are unaffected). Pre-release beta.

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [ ] I have made corresponding changes to the documentation if needed

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added detailed explanation of penalty fee behavior when address funding transitions fail due to insufficient funds.

* **Bug Fixes**
  * Fixed credit conservation logic to properly distinguish between input-funded and asset-lock-funded fees.
  * Corrected penalty fee charging to ensure only penalties are deducted on failed transitions.

* **Tests**
  * Enhanced address-funding validation tests with refined fee-charging assertions.
  * Added comprehensive regression test for penalty-charging scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->