### PR TITLE
fix(swift-sdk): example app ask if the spv is running directly instead of using the sync state

### DIFF
--- a/packages/swift-sdk/Sources/SwiftDashSDK/PlatformWallet/PlatformWalletManager.swift
+++ b/packages/swift-sdk/Sources/SwiftDashSDK/PlatformWallet/PlatformWalletManager.swift
@@ -39,6 +39,8 @@ public class PlatformWalletManager: ObservableObject {
     /// started in [`configure`].
     @Published public private(set) var spvProgress: PlatformSpvSyncProgress = .empty
 
+    @Published public private(set) var spvIsRunning: Bool = false
+
     /// Block time of the SPV header storage's current tip (if any).
     /// `nil` while SPV isn't running or hasn't stored a header yet.
     /// Useful as a "is core producing blocks?" indicator — when this
@@ -810,6 +812,9 @@ public class PlatformWalletManager: ObservableObject {
                 guard let self = self else { return }
                 if let progress = try? self.syncProgress(), progress != self.spvProgress {
                     self.spvProgress = progress
+                }
+                if let running = try? self.isSpvRunning(), running != self.spvIsRunning {
+                    self.spvIsRunning = running
                 }
                 if let isSyncing = try? self.isPlatformAddressSyncing(),
                    isSyncing != self.platformAddressSyncIsSyncing {

--- a/packages/swift-sdk/Sources/SwiftDashSDK/PlatformWallet/PlatformWalletManagerSPV.swift
+++ b/packages/swift-sdk/Sources/SwiftDashSDK/PlatformWallet/PlatformWalletManagerSPV.swift
@@ -8,13 +8,6 @@ public enum PlatformSpvSyncState: UInt32, Sendable {
     case syncing = 2
     case synced = 3
     case error = 4
-
-    public var isRunning: Bool {
-        switch self {
-        case .waitingForConnections, .syncing: return true
-        case .waitForEvents, .synced, .error: return false
-        }
-    }
 }
 
 /// Progress for one of the SPV sub-managers (headers, filters, masternodes, etc.).

--- a/packages/swift-sdk/SwiftExampleApp/SwiftExampleApp/Core/Views/CoreContentView.swift
+++ b/packages/swift-sdk/SwiftExampleApp/SwiftExampleApp/Core/Views/CoreContentView.swift
@@ -89,7 +89,7 @@ struct CoreContentView: View {
     }
 
     private var isSpvRunning: Bool {
-        walletManager.spvProgress.overallState.isRunning
+        walletManager.spvIsRunning
     }
 
     private func heightDisplay(numerator: UInt32, denominator: UInt32) -> String {


### PR DESCRIPTION
Before the arquitectural change the example app was checking if the spv client was running  using the sync progress state, in this PR we are replacing that logic with directly calls to the exposed spv client methods that correctly return if the spv client is running or not


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [x] I have made corresponding changes to the documentation if needed

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * SPV running status handling was redesigned and is now exposed as a stable read-only indicator.
  * The UI now reads this indicator to drive Start/Pause and Clear button enabled/disabled states, improving reliability of those controls.
  * SPV polling was adjusted to update the indicator only when the running state changes, reducing unnecessary UI updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->