### PR TITLE
fix(drive-abci): make shielded snapshot ingest idempotent across InitChain retries

### DIFF
--- a/packages/rs-drive-abci/src/execution/platform_events/initialization/create_genesis_state/test/shielded.rs
+++ b/packages/rs-drive-abci/src/execution/platform_events/initialization/create_genesis_state/test/shielded.rs
@@ -1136,6 +1136,124 @@ mod platform_tests {
         );
     }
 
+    /// Reproduces the production devnet InitChain failure:
+    ///   `DRIVE_SHIELDED_SNAPSHOT apply failed: grovedb: ingest_subtree_sst:
+    ///    ... ingest_subtree_sst(default, /tmp/drv-shielded-snapshot-*.sst)
+    ///    failed: Invalid argument: Global seqno is required, but disabled`
+    ///
+    /// Root cause: `apply_shielded_snapshot`'s SST ingest commits DIRECTLY to
+    /// the underlying RocksDB (`ingest_external_file_cf`), bypassing the
+    /// InitChain GroveDB transaction — and nothing wipes the DB on InitChain.
+    /// The genesis transaction is committed only at the end of finalizing
+    /// block 1, so if InitChain never reaches that commit (any genesis/block-1
+    /// failure, a drive-abci restart, or a Tenderdash InitChain retry) the
+    /// transaction rolls back but the **already-ingested SST keys persist** in
+    /// the committed `default` CF. The next InitChain attempt re-runs the
+    /// ingest over the now-committed keys; the SST's key range overlaps
+    /// existing committed keys, so RocksDB needs to assign a global sequence
+    /// number, which grovedb's `ingest_subtree_sst` forbids
+    /// (`allow_global_seqno=false`) → "Global seqno is required, but disabled",
+    /// and the devnet can never initialize.
+    ///
+    /// Applying a deterministic genesis snapshot must therefore be IDEMPOTENT:
+    /// after a failed attempt's transaction rolls back, the next attempt must
+    /// succeed even though the orphaned ingest survived the rollback.
+    ///
+    /// This test models the production scenario exactly:
+    ///   1. apply the snapshot WITH a transaction (`Some(tx1)`) — the ingest
+    ///      writes straight to RocksDB, the parent-leaf patch goes into `tx1`;
+    ///   2. DROP `tx1` without committing — the InitChain failure path. This
+    ///      rolls back the parent-leaf patch (and, in production, all genesis
+    ///      writes) but NOT the ingest, which never went through `tx1`;
+    ///   3. apply again WITH a fresh transaction (`Some(tx2)`) — the retry.
+    ///
+    /// The key point (and the answer to "shouldn't rollback restore an empty
+    /// DB?"): rollback would restore an empty DB only if the ingest were
+    /// transactional. It is not — so after step 2 the `default` CF still holds
+    /// the orphaned SST keys, and step 3's re-ingest overlaps them.
+    ///
+    /// Would have caught the production failure in CI:
+    ///   ✖ step 3 errors with "Global seqno is required, but disabled" before
+    ///     the fix,
+    ///   ✔ step 3 succeeds (safe no-op) after.
+    #[test]
+    fn snapshot_reapply_is_idempotent_under_initchain_retry() {
+        let platform_version = PlatformVersion::latest();
+
+        // --- A: seed a small pool and dump it to a snapshot file ---
+        let platform_a = build_regtest_platform();
+        let cfg = ShieldedSeedConfig {
+            total_notes: 5_000,
+            rng_seed: 0xDEAD_BEEF,
+        };
+        let tx_a = platform_a.drive.grove.start_transaction();
+        platform_a
+            .seed_shielded_pool_with_config(
+                &cfg,
+                &BlockInfo::default(),
+                Some(&tx_a),
+                platform_version,
+            )
+            .expect("seed A");
+        tx_a.commit().expect("commit A");
+        let anchor_a = read_current_anchor(&platform_a, None, platform_version);
+        assert_ne!(anchor_a, EMPTY_SINSEMILLA_ROOT);
+
+        let dump_dir = tempfile::tempdir().expect("tempdir");
+        let snapshot_path = dump_dir.path().join("shielded-pool.snap");
+        crate::shielded_snapshot::dump_shielded_subtree(
+            &platform_a.drive.grove,
+            None,
+            &snapshot_path,
+            platform_version,
+        )
+        .expect("dump");
+
+        // --- B, attempt 1: apply inside a transaction, then ROLL BACK ---
+        // Models an InitChain that ingests the snapshot but never reaches the
+        // block-1 commit (a later genesis/block failure, a restart, or a
+        // Tenderdash InitChain retry).
+        let platform_b = build_regtest_platform();
+        {
+            let tx1 = platform_b.drive.grove.start_transaction();
+            crate::shielded_snapshot::apply_shielded_snapshot(
+                &platform_b.drive.grove,
+                Some(&tx1),
+                &snapshot_path,
+                platform_version,
+            )
+            .expect("first apply (inside tx1) must succeed");
+            // Drop tx1 WITHOUT committing — the failure/rollback path. The
+            // parent-leaf patch (in tx1) is discarded; the ingest is NOT.
+            drop(tx1);
+        }
+
+        // --- B, attempt 2: the retry, in a fresh transaction ---
+        // The orphaned ingest from attempt 1 is still committed in the
+        // `default` CF, so this re-ingest overlaps it — the exact production
+        // failure ("Global seqno is required, but disabled").
+        let tx2 = platform_b.drive.grove.start_transaction();
+        let retry = crate::shielded_snapshot::apply_shielded_snapshot(
+            &platform_b.drive.grove,
+            Some(&tx2),
+            &snapshot_path,
+            platform_version,
+        );
+        assert!(
+            retry.is_ok(),
+            "re-applying a deterministic genesis snapshot after a rolled-back \
+             attempt must be idempotent (InitChain retry path), but it failed: \
+             {retry:?}"
+        );
+        tx2.commit().expect("commit retry tx");
+
+        let anchor_b = read_current_anchor(&platform_b, None, platform_version);
+        assert_eq!(
+            anchor_b, anchor_a,
+            "anchor must match after an idempotent re-apply"
+        );
+    }
+
     // Real InitChain hook coverage happens via the dashmate devnet flow
     // (see docs/genesis-snapshot-design.md §13 e2e). An in-process equivalent
     // would need `std::env::set_var`, which this crate's

--- a/packages/rs-drive-abci/src/shielded_snapshot/mod.rs
+++ b/packages/rs-drive-abci/src/shielded_snapshot/mod.rs
@@ -510,16 +510,40 @@ pub fn apply_shielded_snapshot(
     std::fs::write(&sst_tmp, sst_slice)?;
     let _cleanup = SstTmpGuard(sst_tmp.clone());
 
-    // 4. Bulk-ingest. Bypasses any open transaction; OK at InitChain time
-    //    (txn abort = wipe-and-restart, so orphan data is unreachable).
-    grove
-        .ingest_subtree_sst(SUBTREE_CF, &sst_tmp)
-        .map_err(|e| ShieldedSnapshotError::GroveDb(format!("ingest_subtree_sst: {e}")))?;
-
-    // 5. Cross-validate: reload CommitmentTree from the just-ingested data
-    //    and check recomputed combined_root matches header. Drift surfaces
-    //    BEFORE we touch the parent Merk.
+    // 4. Bulk-ingest the SST — UNLESS a prior attempt already ingested it.
+    //
+    //    The ingest writes straight to RocksDB (`ingest_external_file_cf`),
+    //    bypassing `transaction`, and nothing wipes the DB on InitChain. The
+    //    genesis transaction is committed only at the END of block 1, so if
+    //    InitChain never reaches that commit (a later genesis/block-1 failure,
+    //    a drive-abci restart, or a Tenderdash InitChain retry) the transaction
+    //    rolls back but these directly-committed keys SURVIVE — the rollback
+    //    restores an empty DB for everything except this non-transactional
+    //    ingest. A naive re-ingest on the next attempt overlaps the orphaned
+    //    keys, and RocksDB rejects the overlapping ingest with "Global seqno is
+    //    required, but disabled" (grovedb ingests with `allow_global_seqno =
+    //    false`), wedging the chain permanently.
+    //
+    //    The snapshot is deterministic, so an already-populated subtree holds
+    //    exactly the keys we'd write. Detect that committed state and skip the
+    //    re-ingest; the combined_root cross-validation in step 5 still verifies
+    //    the data (and fails loudly if a stale/foreign subtree is present).
     let subtree_segments = shielded_subtree_segments();
+    if shielded_subtree_has_committed_keys(grove, &subtree_segments) {
+        tracing::info!(
+            "apply_shielded_snapshot: shielded subtree already populated (a prior \
+             InitChain attempt's ingest survived a rolled-back transaction); \
+             skipping re-ingest and re-validating the existing data"
+        );
+    } else {
+        grove
+            .ingest_subtree_sst(SUBTREE_CF, &sst_tmp)
+            .map_err(|e| ShieldedSnapshotError::GroveDb(format!("ingest_subtree_sst: {e}")))?;
+    }
+
+    // 5. Cross-validate: reload CommitmentTree from the ingested (or
+    //    already-present) data and check recomputed combined_root matches
+    //    header. Drift surfaces BEFORE we touch the parent Merk.
     let subtree_path = SubtreePath::from(subtree_segments.as_slice());
 
     let local_tx;
@@ -585,6 +609,28 @@ impl Drop for SstTmpGuard {
     fn drop(&mut self) {
         let _ = std::fs::remove_file(&self.0);
     }
+}
+
+/// Returns `true` if the shielded commitment-tree subtree already has at least
+/// one key committed to the underlying RocksDB.
+///
+/// Read through a fresh, throwaway transaction (rolled back on drop), which
+/// sees the latest committed state — exactly the state the SST ingest's
+/// overlap check compares against. This is the idempotency probe for
+/// [`apply_shielded_snapshot`]: the ingest bypasses the caller's transaction,
+/// so a prior InitChain attempt's keys survive a rolled-back genesis and must
+/// not be re-ingested (RocksDB would reject the overlapping ingest with
+/// "Global seqno is required, but disabled").
+fn shielded_subtree_has_committed_keys(grove: &GroveDb, subtree_segments: &[Vec<u8>]) -> bool {
+    let probe_tx = grove.start_transaction();
+    let path = SubtreePath::from(subtree_segments);
+    let ctx = grove
+        .raw_storage()
+        .get_transactional_storage_context(path, None, &probe_tx)
+        .unwrap();
+    let mut iter = ctx.raw_iter();
+    iter.seek_to_first().unwrap();
+    iter.valid().unwrap()
 }
 
 #[cfg(test)]

--- a/packages/rs-platform-wallet-ffi/src/persistence.rs
+++ b/packages/rs-platform-wallet-ffi/src/persistence.rs
@@ -1430,10 +1430,10 @@ impl PlatformWalletPersistence for FFIPersister {
                     .on_load_shielded_outgoing_notes_free_fn
                     .is_some()
             {
-                return Err("on_load_shielded_outgoing_notes_fn and \
-                     on_load_shielded_outgoing_notes_free_fn must be provided together"
-                    .to_string()
-                    .into());
+                return Err(PersistenceError::backend(
+                    "on_load_shielded_outgoing_notes_fn and \
+                     on_load_shielded_outgoing_notes_free_fn must be provided together",
+                ));
             }
 
             // 1) notes
@@ -1508,11 +1508,10 @@ impl PlatformWalletPersistence for FFIPersister {
                 let rc =
                     unsafe { load_outgoing(self.callbacks.context, &mut out_ptr, &mut out_count) };
                 if rc != 0 {
-                    return Err(format!(
+                    return Err(PersistenceError::backend(format!(
                         "on_load_shielded_outgoing_notes_fn returned error code {}",
                         rc
-                    )
-                    .into());
+                    )));
                 }
                 struct OutgoingGuard {
                     context: *mut c_void,


### PR DESCRIPTION
## Issue being fixed or feature implemented

The shielded-pool genesis snapshot apply (`apply_shielded_snapshot`) is **not idempotent across InitChain retries**, which permanently wedges a chain in a Tenderdash crash-restart loop.

The SST ingest writes straight to RocksDB (`ingest_external_file_cf`), **bypassing the InitChain GroveDB transaction**, and nothing wipes the DB on InitChain. The genesis transaction is committed only at the end of block 1, so if InitChain never reaches that commit — a genesis/block-1 failure, a drive-abci restart, or a Tenderdash InitChain retry — the transaction rolls back but the directly-committed SST keys **survive**. The next InitChain attempt re-ingests the same SST over the orphaned keys; the overlapping ingest needs a global sequence number, which grovedb forbids (`allow_global_seqno = false`), so RocksDB rejects it with:

```
DRIVE_SHIELDED_SNAPSHOT apply failed: grovedb: ingest_subtree_sst: ...
ingest_subtree_sst(default, /tmp/drv-shielded-snapshot-*.sst) failed:
Invalid argument: Global seqno is required, but disabled
```

Observed in production on `devnet-paloma`: InitChain succeeded once (snapshot applied, `app_hash 79fd0a…`), block 1 was never produced (so nothing committed), a `SIGTERM`/restart discarded the transaction but not the ingest, and every subsequent InitChain replay then crash-looped on the global-seqno error — Tenderdash `failed to start node` → restart → repeat every ~15s.

## What was done?

`apply_shielded_snapshot` now probes the **committed** DB for keys under the shielded subtree prefix before ingesting. If the subtree is already populated (orphaned from a prior attempt), the re-ingest is skipped. The snapshot is deterministic, so an already-populated subtree holds exactly the keys we would write, and the existing `combined_root` cross-validation still runs against the present data — failing loudly if a stale or foreign subtree is found.

- `packages/rs-drive-abci/src/shielded_snapshot/mod.rs`
  - Guard the ingest with a `shielded_subtree_has_committed_keys(...)` probe; skip + log when already present.
  - New helper reads the latest committed state through a throwaway transaction (the same state the RocksDB ingest overlap-checks against).
  - Corrected the now-false comment that claimed "txn abort = wipe-and-restart, so orphan data is unreachable".

## How Has This Been Tested?

New regression test `snapshot_reapply_is_idempotent_under_initchain_retry` models the exact production path: apply inside `tx1` → drop `tx1` **uncommitted** (the rollback) → apply inside a fresh `tx2` (the retry).

- ✖ **Before the fix:** the second apply fails with `Invalid argument: Global seqno is required, but disabled` — byte-for-byte the devnet error.
- ✔ **After the fix:** the second apply is a safe no-op and the anchor matches.

```
cargo test -p drive-abci --features shielded_test_data snapshot_ -- --nocapture
# snapshot_reapply_is_idempotent_under_initchain_retry ... ok
# snapshot_dump_apply_preserves_anchor ... ok   (existing roundtrip, no regression)
```

## Breaking Changes

None.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [ ] I have made corresponding changes to the documentation if needed

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Snapshot application now detects and skips already-applied shielded data to avoid ingest conflicts during genesis retry/rollback.
  * Improved error wrapping for shielded outgoing-notes restore to produce clearer backend persistence errors.

* **Tests**
  * New integration test verifying snapshot re-apply is idempotent after a rollback/retry scenario.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->