### PR TITLE
test(dpp): require shielded-client in shield-from-asset-lock signing tests

### DIFF
--- a/packages/rs-dpp/src/state_transition/state_transitions/shielded/shield_from_asset_lock_transition/mod.rs
+++ b/packages/rs-dpp/src/state_transition/state_transitions/shielded/shield_from_asset_lock_transition/mod.rs
@@ -4,7 +4,8 @@ mod proved;
 #[cfg(all(
     test,
     feature = "state-transition-signing",
-    feature = "core_key_wallet"
+    feature = "core_key_wallet",
+    feature = "shielded-client"
 ))]
 mod signing_tests;
 mod state_transition_estimated_fee_validation;

--- a/packages/rs-dpp/src/state_transition/state_transitions/shielded/shield_from_asset_lock_transition/signing_tests.rs
+++ b/packages/rs-dpp/src/state_transition/state_transitions/shielded/shield_from_asset_lock_transition/signing_tests.rs
@@ -10,10 +10,15 @@
 //! in `state_transition::mod` pins `sign_with_core_signer` against
 //! `sign_by_private_key` — we don't re-derive that contract here.
 
+// `crate::shielded::builder` (the high-level bundle builder these tests drive) only
+// exists under `shielded-client`, so this module must require it too — otherwise the
+// `--all-targets` feature-unified lib-test target (which enables `state-transition-signing`
+// + `core_key_wallet` without `shielded-client`) fails to resolve the builder import.
 #![cfg(all(
     test,
     feature = "state-transition-signing",
-    feature = "core_key_wallet"
+    feature = "core_key_wallet",
+    feature = "shielded-client"
 ))]
 
 use crate::identity::state_transition::asset_lock_proof::chain::ChainAssetLockProof;

--- a/packages/rs-platform-wallet-ffi/src/persistence.rs
+++ b/packages/rs-platform-wallet-ffi/src/persistence.rs
@@ -1430,10 +1430,10 @@ impl PlatformWalletPersistence for FFIPersister {
                     .on_load_shielded_outgoing_notes_free_fn
                     .is_some()
             {
-                return Err("on_load_shielded_outgoing_notes_fn and \
-                     on_load_shielded_outgoing_notes_free_fn must be provided together"
-                    .to_string()
-                    .into());
+                return Err(PersistenceError::backend(
+                    "on_load_shielded_outgoing_notes_fn and \
+                     on_load_shielded_outgoing_notes_free_fn must be provided together",
+                ));
             }
 
             // 1) notes
@@ -1508,11 +1508,10 @@ impl PlatformWalletPersistence for FFIPersister {
                 let rc =
                     unsafe { load_outgoing(self.callbacks.context, &mut out_ptr, &mut out_count) };
                 if rc != 0 {
-                    return Err(format!(
+                    return Err(PersistenceError::backend(format!(
                         "on_load_shielded_outgoing_notes_fn returned error code {}",
                         rc
-                    )
-                    .into());
+                    )));
                 }
                 struct OutgoingGuard {
                     context: *mut c_void,


### PR DESCRIPTION
## Issue being fixed or feature implemented

**Primary fix (dpp test-cfg):** `cargo check --workspace --all-targets` fails to compile the `dpp` lib-test target on a clean `v3.1-dev`-based tree:

```
error[E0433]: failed to resolve: could not find `builder` in `shielded`
error[E0432]: unresolved import `crate::shielded::builder`
```

The `signing_tests` module for `ShieldFromAssetLockTransition` imports `crate::shielded::builder::*`, but `pub mod builder;` in `shielded/mod.rs` is gated on the `shielded-client` feature (which pulls in `grovedb-commitment-tree` / Orchard). The test module was gated only on `state-transition-signing` + `core_key_wallet`. Under `--all-targets`/`--workspace` feature unification, the lib-test target gets those two features enabled **without** `shielded-client`, so `crate::shielded::builder` does not exist and compilation fails.

**Additional fix (platform-wallet, required to get CI green):** CI's `cargo clippy --workspace --all-features` was already broken on `v3.1-dev` — independently of this PR — by code merged in #3819:

```
error[E0277]: the trait bound `PersistenceError: From<String>` is not satisfied
error: could not compile `platform-wallet-ffi` (lib) due to 2 previous errors
```

`SledFfiPersister::load` returns `Result<_, PersistenceError>`, but the OVK outgoing-notes load path returned its errors via `.into()` on a `String`/`&str`, and `PersistenceError` has no `From<String>`. This fails the workspace clippy step that the "Tests (macOS)" check runs, so **every** open PR is red on it. Since this PR's CI runs the same workspace clippy, it cannot go green without this fix included.

## What was done?

1. **`test(dpp)`** — added `feature = "shielded-client"` to the `signing_tests` gate (both the `mod` declaration in `shield_from_asset_lock_transition/mod.rs` and the inner `#![cfg(all(...))]` of `signing_tests.rs`, with an explanatory comment). The test genuinely depends on `shielded-client`: it calls `build_shield_from_asset_lock_transition_with_signer`, which lives inside the builder module, whose body uses `grovedb_commitment_tree` (a dep pulled in only by `shielded-client`). Requiring it is the correct alignment, not a workaround — exposing `pub mod builder;` without `shielded-client` is not viable since the module would fail to compile for lack of that dep. The other in-module builder test references (`shield.rs`, `unshield.rs`, etc.) live *inside* the builder module, so they only compile when `shielded-client` is on and need no change.

2. **`fix(platform-wallet)`** — built both outgoing-notes load error sites in `persistence.rs` with `PersistenceError::backend(..)` (the same constructor the sibling incoming-notes / sync-state paths in the same `fn load` already use; `E: Into<Box<dyn StdError + Send + Sync>>`, which `String`/`&str` satisfy) instead of `.into()`. No behavior change beyond the errors being typed correctly. This is a drive-by fix for a pre-existing base-branch breakage; happy to split it into a standalone PR if maintainers prefer, but note it's needed for this PR's CI to pass.

## How Has This Been Tested?

- Reproduced the original dpp errors with `cargo check -p dpp --tests --no-default-features --features state-transition-signing,core_key_wallet` → after the fix, clean.
- `cargo check -p dpp --all-features --tests` — passes.
- `cargo check --workspace --all-targets` — passes (exit 0); the originally-failing command.
- Reproduced the platform-wallet-ffi clippy errors with `cargo clippy -p platform-wallet-ffi --all-features --locked -- --no-deps -D warnings` → after the fix, clean.
- `cargo clippy --workspace --all-features --locked -- --no-deps -D warnings` (the exact CI command) — passes with no errors or warnings.
- `cargo fmt` — clean on both crates.

## Breaking Changes

None. A test-only cfg-gate change plus an error-construction fix; no production behavior or consensus is affected.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [ ] I have made corresponding changes to the documentation if needed

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Tightened test compilation conditions so shielded state transition tests only run under the correct feature combinations, improving test reliability across build configurations.
* **Bug Fixes**
  * Improved error handling for shielded wallet restore paths so failures produce clearer, explicit error results instead of implicit string-based errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->