### PR TITLE
test(platform-wallet): fix stale balance assertion in paloma shielded sync example

### DIFF
--- a/packages/rs-platform-wallet/examples/shielded_sync_paloma.rs
+++ b/packages/rs-platform-wallet/examples/shielded_sync_paloma.rs
@@ -1,7 +1,7 @@
 //! Remote-devnet variant of the `shielded_sync` example. Binds wallet A
 //! (raw ZIP-32 seed `[0x73; 32]`) against a live devnet that's been
 //! deployed from a `SDK_TEST_DATA=true` image, drives one shielded sync
-//! pass, and asserts the recovered balance.
+//! pass, and asserts the pass walks the seeded note pool cleanly.
 //!
 //! This is an opt-in example (NOT a test) because it performs real network
 //! I/O against a live devnet; cargo examples are compiled but never run by
@@ -46,14 +46,22 @@
 //!
 //! # What this proves
 //!
-//! Green: ZIP-32 derivation + bind + decryption + persistence work
-//! end-to-end against paloma. If the iOS SwiftExampleApp shows balance
-//! = 0 against the same devnet, the bug is iOS-side (persister
-//! callback, SwiftData write, UI aggregation).
+//! Green: ZIP-32 derivation + bind + chunked note fetch + trial
+//! decryption + persistence work end-to-end against paloma — the pass
+//! finishes with no per-wallet errors and a non-zero scan count. If the
+//! iOS SwiftExampleApp can't sync against the same devnet, the bug is
+//! iOS-side (persister callback, SwiftData write, UI aggregation).
 //!
-//! Red on "decrypted 0 notes": paloma was built without
+//! No balance is expected: paloma's seeded notes are filler-only. The
+//! genesis test-wallet note seeding was removed (see
+//! `packages/rs-drive-abci/.../create_genesis_state/test/shielded.rs::
+//! sdk_test_data`), so wallet A decrypts nothing and a 0 balance is
+//! correct. The balance is printed for information only; decryptable
+//! balances need real shielded-fund transitions post-genesis.
+//!
+//! Red on "scanned 0 notes": paloma was built without
 //! `SDK_TEST_DATA=true`, or from a commit predating the snapshot
-//! machinery — its 1M notes are filler-only.
+//! machinery — there's no seeded pool to walk.
 //!
 //! Red on proof / network errors: quorum URL or DAPI addresses are
 //! wrong or unreachable.
@@ -70,18 +78,16 @@ use platform_wallet::changeset::{
     ClientStartState, PlatformWalletChangeSet, PlatformWalletPersistence,
 };
 use platform_wallet::events::{EventHandler, PlatformEventHandler};
+use platform_wallet::manager::shielded_sync::WalletShieldedOutcome;
 use platform_wallet::wallet::platform_wallet::WalletId;
 use platform_wallet::PlatformWalletManager;
 use rs_sdk_trusted_context_provider::TrustedHttpContextProvider;
 
-/// Wallet A seed — must stay byte-identical to
-/// `packages/rs-drive-abci/.../shielded_test_wallets.rs::SEED_A`.
+/// Wallet A seed — the historical SDK test-wallet seed. The genesis
+/// test-wallet note seeding was removed, so no seeded note decrypts to
+/// this (or any) seed; any fixed seed would do. Kept byte-identical to
+/// the `shielded_sync` example so runs stay comparable.
 const SEED_A: [u8; 32] = [0x73; 32];
-
-/// Per-wallet bake config (mirror of `ShieldedSeedConfig::sdk_test_data`).
-const COUNT_A: u32 = 4;
-const OWNED_VALUE: u64 = 100_000;
-const EXPECTED_BALANCE_A: u64 = COUNT_A as u64 * OWNED_VALUE; // 400_000
 
 /// Default quorum-list service URL for paloma. Override with
 /// `PALOMA_QUORUM_URL`.
@@ -178,8 +184,8 @@ async fn main() {
     let quorum = quorum_url();
     let live_count = addresses.get_live_addresses().len();
     eprintln!(
-        "paloma config: quorum_url={} dapi_node_count={} expected_balance={}",
-        quorum, live_count, EXPECTED_BALANCE_A,
+        "paloma config: quorum_url={} dapi_node_count={}",
+        quorum, live_count,
     );
 
     // --- 1. Build SDK pointing at all paloma masternodes, with the
@@ -256,21 +262,38 @@ async fn main() {
     let summary = coordinator.sync(true).await;
     eprintln!("sync summary: {:?}", summary);
 
-    // --- 6. Read the per-account balance + assert. ---
+    // --- 6. Assert the pass ran cleanly and actually walked the
+    //        seeded pool. Paloma's notes are filler-only (the genesis
+    //        test-wallet seeding was removed), so balance is printed
+    //        for information, not asserted. ---
+    assert_eq!(
+        summary.error_count(),
+        0,
+        "shielded sync pass reported per-wallet errors: {:?}",
+        summary.wallet_results,
+    );
+    let wallet_summary = match summary.wallet_results.get(&platform_wallet.wallet_id()) {
+        Some(WalletShieldedOutcome::Ok(s)) => s,
+        other => panic!("expected a successful sync outcome for wallet A, got {other:?}"),
+    };
+    assert!(
+        !wallet_summary.is_cooldown_skip,
+        "sync(force = true) must not be short-circuited by the caught-up cooldown",
+    );
+    assert!(
+        wallet_summary.notes_result.total_scanned > 0,
+        "scanned 0 notes — paloma built without SDK_TEST_DATA=true, or \
+         from a commit predating the snapshot machinery?",
+    );
+
     let balances = platform_wallet
         .shielded_balances(&coordinator)
         .await
         .expect("shielded_balances");
     let total_balance: u64 = balances.values().sum();
     eprintln!(
-        "paloma wallet A balances = {:?} (total {})",
-        balances, total_balance,
-    );
-
-    assert_eq!(
-        total_balance, EXPECTED_BALANCE_A,
-        "wallet A balance mismatch on paloma (expected {} = {} × {}, got {})",
-        EXPECTED_BALANCE_A, COUNT_A, OWNED_VALUE, total_balance,
+        "paloma wallet A: scanned {} notes, balances = {:?} (total {}, informational)",
+        wallet_summary.notes_result.total_scanned, balances, total_balance,
     );
 
     let _ = std::fs::remove_dir_all(&shielded_db_dir);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

The `shielded_sync_paloma` example asserted wallet A (seed `[0x73; 32]`) recovers a 400000-credit balance (4 × 100000) from paloma's genesis-seeded shielded notes. That expectation is stale: the genesis test-wallet note seeding was removed (see `ShieldedSeedConfig::sdk_test_data` in `packages/rs-drive-abci/src/execution/platform_events/initialization/create_genesis_state/test/shielded.rs` — wallet-balance UX no longer comes from seeded notes), so the devnet's 1M notes are filler-only and the example always panicked with balance 0 even when sync worked perfectly.

## What was done?
<!--- Describe your changes in detail -->

- Replaced the balance assertion in `packages/rs-platform-wallet/examples/shielded_sync_paloma.rs` with what current `SDK_TEST_DATA=true` deployments actually guarantee:
  - the sync pass reports no per-wallet errors (`ShieldedSyncPassSummary::error_count() == 0`),
  - wallet A's outcome is `WalletShieldedOutcome::Ok` and not a cooldown skip (the example forces the pass),
  - `notes_result.total_scanned > 0`, proving the pass walked the seeded pool.
- Balances are now printed informationally instead of asserted (0 is the correct value).
- Updated the "What this proves" doc section to explain that no balance is expected and that decryptable-balance flows need real shielded-fund transitions post-genesis.
- Removed the now-unused `COUNT_A` / `OWNED_VALUE` / `EXPECTED_BALANCE_A` constants and the stale `SEED_A` cross-reference to the deleted `shielded_test_wallets.rs`.
- Still an opt-in network example: compiled but never run by `cargo test`.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

- `cargo check -p platform-wallet --example shielded_sync_paloma --features shielded` — compiles clean.
- `cargo fmt --all` — no formatting drift.
- The example itself requires a live paloma devnet, so it remains opt-in (`cargo run -p platform-wallet --example shielded_sync_paloma --features shielded`).

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->

None.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [x] I have made corresponding changes to the documentation if needed

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated example documentation and comments to accurately reflect Paloma's shielded note pool behavior and improve clarity.

* **Tests**
  * Enhanced validation assertions to verify zero sync errors, successful wallet outcomes, and non-zero note scanning, removing incorrect balance expectations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->