### PR TITLE
test(wallet-storage): add missing wallet_group_id in test initializers

### DIFF
--- a/packages/rs-platform-wallet-storage/tests/sqlite_buffer_semantics.rs
+++ b/packages/rs-platform-wallet-storage/tests/sqlite_buffer_semantics.rs
@@ -311,6 +311,7 @@ fn tc023_one_flush_is_one_transaction() {
     cs.core = Some(core_with_height(7, 7));
     cs.wallet_metadata = Some(WalletMetadataEntry {
         network: Network::Testnet,
+        wallet_group_id: w,
         birth_height: 1,
     });
     let mut balances = BTreeMap::new();

--- a/packages/rs-platform-wallet-storage/tests/sqlite_delete_buffer_reconcile.rs
+++ b/packages/rs-platform-wallet-storage/tests/sqlite_delete_buffer_reconcile.rs
@@ -31,6 +31,7 @@ fn full_changeset(synced: u32) -> PlatformWalletChangeSet {
     let mut cs = PlatformWalletChangeSet::default();
     cs.wallet_metadata = Some(WalletMetadataEntry {
         network: Network::Testnet,
+        wallet_group_id: [0u8; 32],
         birth_height: 0,
     });
     cs.core = Some(CoreChangeSet {

--- a/packages/rs-platform-wallet-storage/tests/sqlite_persist_roundtrip.rs
+++ b/packages/rs-platform-wallet-storage/tests/sqlite_persist_roundtrip.rs
@@ -65,6 +65,7 @@ fn tc013_wallet_metadata_roundtrip() {
     let cs = PlatformWalletChangeSet {
         wallet_metadata: Some(WalletMetadataEntry {
             network: Network::Testnet,
+            wallet_group_id: w,
             birth_height: 12345,
         }),
         ..Default::default()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

#3772 added the `wallet_group_id` field to `WalletMetadataEntry` (`packages/rs-platform-wallet/src/changeset/changeset.rs`) but missed three test initializers in `platform-wallet-storage`, which only compile under `--all-features`. This breaks the "Rust workspace tests / Tests (macOS)" CI job on every PR with `error[E0063]: missing field wallet_group_id` (first observed on #3831, which doesn't touch this crate).

## What was done?
<!--- Describe your changes in detail -->

Added the missing `wallet_group_id` field to the three `WalletMetadataEntry` initializers:

- `packages/rs-platform-wallet-storage/tests/sqlite_persist_roundtrip.rs` — uses the wallet's own id (matching the documented group-of-one fallback)
- `packages/rs-platform-wallet-storage/tests/sqlite_buffer_semantics.rs` — same
- `packages/rs-platform-wallet-storage/tests/sqlite_delete_buffer_reconcile.rs` — zeroes (no wallet id in scope; the helper builds a synthetic changeset)

The sqlite persister doesn't persist this field yet, so no assertions change — the tests only need the struct to construct.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

- `cargo check -p platform-wallet-storage --all-features --all-targets` — the exact CI failure mode, now compiles clean.
- `cargo test -p platform-wallet-storage --all-features` — all tests pass (126 unit + integration suites, 0 failed).
- `cargo fmt --all` — no drift.

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->

None.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [x] I have made corresponding changes to the documentation if needed

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone

🤖 Generated with [Claude Code](https://claude.com/claude-code)