### PR TITLE
fix(platform): tag restored wallet addresses with the wallet's network

### DIFF
--- a/packages/rs-platform-wallet-ffi/src/persistence.rs
+++ b/packages/rs-platform-wallet-ffi/src/persistence.rs
@@ -2123,11 +2123,30 @@ unsafe fn address_info_from_ffi(
     let address_str = CStr::from_ptr(entry.address_base58)
         .to_str()
         .map_err(|e| format!("address_base58 not UTF-8: {}", e))?;
-    let address = dashcore::Address::from_str(address_str)
+    let parsed = dashcore::Address::from_str(address_str)
         .map_err(|e| format!("failed to parse address '{}': {}", address_str, e))?
         .require_network(network)
         .map_err(|e| format!("address '{}' not on {:?}: {}", address_str, network, e))?;
-    let script_pubkey = address.script_pubkey();
+    let script_pubkey = parsed.script_pubkey();
+    // Re-tag with the wallet's exact network. Devnet (and regtest)
+    // share testnet's base58 prefixes, so `require_network` only
+    // VALIDATES the parse — the returned value keeps the as-parsed
+    // (Testnet) tag. `Address` equality and hashing include the
+    // network, and every runtime lookup key is built via
+    // `Address::from_script(script, wallet_network)`, so a
+    // Testnet-tagged restored key silently misses the pool's
+    // address-keyed maps (`get_address_info`) on a devnet wallet.
+    // The observable failure: outputs paying restored addresses are
+    // counted (`contains_script_pub_key` is script-keyed and hits)
+    // but never credited as UTXOs — a restored wallet permanently
+    // loses change returned by its own transactions. Rebuild from
+    // the script so the restored key is identical to runtime keys.
+    let address = dashcore::Address::from_script(&script_pubkey, network).map_err(|e| {
+        format!(
+            "failed to rebuild address '{}' from its script for {:?}: {}",
+            address_str, network, e
+        )
+    })?;
     let path_str = CStr::from_ptr(entry.derivation_path)
         .to_str()
         .map_err(|e| format!("derivation_path not UTF-8: {}", e))?;
@@ -3634,6 +3653,46 @@ mod tests {
     use key_wallet::managed_account::managed_account_trait::ManagedAccountTrait;
     use key_wallet::mnemonic::{Language, Mnemonic};
     use key_wallet::wallet::Wallet;
+
+    /// Regression: restored pool addresses must be tagged with the
+    /// WALLET's network, not the network the base58 string parses as.
+    /// Devnet shares testnet's base58 prefixes, so a devnet wallet's
+    /// persisted "y…" address parses as Testnet, and `require_network`
+    /// only validates — it keeps the as-parsed tag. `Address` equality
+    /// includes the network, so a Testnet-tagged restored key misses
+    /// every runtime lookup built via `Address::from_script(script,
+    /// Devnet)`: outputs paying restored addresses were matched
+    /// (script-keyed `contains_script_pub_key` hits) but never credited
+    /// as UTXOs (`get_address_info` missed) — a restored devnet wallet
+    /// permanently lost the change of its own transactions.
+    #[test]
+    fn restored_address_info_is_tagged_with_wallet_network() {
+        use std::ffi::CString;
+        // A valid testnet-prefixed (0x8C, "y…") P2PKH address, as a
+        // devnet wallet persists them.
+        let addr = "yMqShkrgjTRuReBGFpQr7FozEF1QcNBBYA";
+        let addr_c = CString::new(addr).unwrap();
+        let path_c = CString::new("m/44'/1'/0'/1/0").unwrap();
+        let entry = CoreAddressEntryFFI {
+            public_key: [0u8; 33],
+            has_public_key: false,
+            pool_type_tag: AddressPoolTypeTagFFI::Internal as u8,
+            address_index: 0,
+            is_used: false,
+            balance: 0,
+            address_base58: addr_c.as_ptr(),
+            derivation_path: path_c.as_ptr(),
+        };
+        let info = unsafe { address_info_from_ffi(&entry, Network::Devnet) }
+            .expect("restore must accept a testnet-prefixed string on devnet");
+        let runtime_key = dashcore::Address::from_script(&info.script_pubkey, Network::Devnet)
+            .expect("p2pkh script must convert back to an address");
+        assert_eq!(
+            info.address, runtime_key,
+            "restored address must be identical (network tag included) to the \
+             runtime `from_script` lookup key"
+        );
+    }
 
     /// Pins the contract that an `InBlock` unresolved-asset-lock row
     /// projects onto the matching BIP44 account's in-memory


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

On devnet (and regtest), a **restored** wallet permanently lost the change of its own transactions. Reproduced with the SwiftExampleApp Core→Shielded (Type 18) flow on paloma: the asset-lock tx was detected with the correct amounts (`key_wallet` logged `received=1.99999406 DASH sent=4.99999703 DASH`), the spent input was removed, but the change output was never credited — balance dropped to 0 and **two full Core rescans could not heal it**.

Root cause: devnet shares testnet's base58 prefixes, so a persisted "y…" address string parses as Testnet, and `Address::from_str(..).require_network(net)` only *validates* — it keeps the as-parsed tag. `Address` Eq/Hash include the network, and every runtime lookup key is built via `Address::from_script(script, wallet_network)` (Devnet-tagged). The restore path (`address_info_from_ffi`) therefore fed Testnet-tagged keys into the pool's address-keyed maps: the script-keyed `contains_script_pub_key` still hit (amounts counted), but `get_address_info` missed, `involved_addrs` came back empty, and `update_utxos` skipped the change-output insert. First-session wallets were unaffected (pool addresses derived in-process carry the wallet's tag) — the bug only surfaced after an app restart.

## What was done?
<!--- Describe your changes in detail -->

- `packages/rs-platform-wallet-ffi/src/persistence.rs` (`address_info_from_ffi`): after parsing + `require_network` validation, rebuild the restored address from its script with the wallet's exact network (`Address::from_script(&script_pubkey, network)`), so restored pool keys are byte-identical to runtime lookup keys. The UTXO restore path already used `from_script` and was unaffected.
- Added regression test `restored_address_info_is_tagged_with_wallet_network`: a testnet-prefixed address string restored onto a Devnet wallet must equal the runtime `from_script` key (network tag included).

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

- `cargo test -p platform-wallet-ffi --lib` — all 93 tests pass, including the new regression test.
- Bug mechanism proven in isolation: `Address::from_str("y…").require_network(Devnet) != Address::from_script(same_script, Devnet)` at the pinned rust-dashcore rev.
- End-to-end on the paloma devnet (iPhone 17 Pro simulator): with the pre-fix build, two full Core rescans over the affected block (28553) failed to credit a 1.99999406 DASH change output; with this fix installed, a rescan over the same block credited the TXO immediately (`ZPERSISTENTTXO` row written, Core balance healed to 1.99999406 DASH, full wallet conservation re-checked across Core/Platform/Shielded).
- Negative-control unit tests in key-wallet (fresh, non-restored wallet building an asset lock and processing it in a block — change credited) confirmed the processing pipeline itself is sound, isolating the bug to the restore boundary.

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->

None.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [ ] I have made corresponding changes to the documentation if needed

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed address restoration logic to ensure restored addresses are properly tagged with the wallet's configured network, preventing incorrect network identification.

* **Tests**
  * Added unit test coverage validating that address network tags are correctly assigned during wallet restoration across different network environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->