### PR TITLE
feat(swift-sdk): scan recipient address QR codes on the Send screen

### DIFF
--- a/packages/swift-sdk/SwiftExampleApp/Info.plist
+++ b/packages/swift-sdk/SwiftExampleApp/Info.plist
@@ -22,6 +22,12 @@
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 
+	<!-- Camera permission — the Send screen's QR scanner reads Dash
+	     address QR codes. Without this key the app crashes the moment
+	     it touches the camera. -->
+	<key>NSCameraUsageDescription</key>
+	<string>The camera is used to scan Dash address QR codes.</string>
+
 	<!-- UIKit / Scene config (auto-generated equivalents). -->
 	<key>UIApplicationSceneManifest</key>
 	<dict>

--- a/packages/swift-sdk/SwiftExampleApp/SwiftExampleApp/Core/Views/QRScannerView.swift
+++ b/packages/swift-sdk/SwiftExampleApp/SwiftExampleApp/Core/Views/QRScannerView.swift
@@ -1,0 +1,680 @@
+// QRScannerView.swift
+// SwiftExampleApp
+//
+// A self-contained camera QR scanner sheet for the Send screen, plus a
+// pure (UIKit-free) payload parser that decodes what a scanned/pasted
+// string actually means.
+//
+// What it does:
+//   * Presents a live camera viewfinder, reads `.qr` metadata, and calls
+//     `onScan(ScannedPayment)` with a validated Dash address (and an
+//     optional BIP21-style `amount=`) the moment a good code is seen.
+//   * Validation is NOT re-implemented here — `QRPayloadParser` defers to
+//     `DashAddress.parse(_:network:)`, which routes Core addresses through
+//     the Rust FFI (`Address.validate`) and decodes Platform/Orchard
+//     bech32m locally. The scanner only marshals strings in and out.
+//
+// States the sheet can be in (every state keeps a "Paste from Clipboard"
+// affordance pinned near the bottom, so the screen is useful even with no
+// camera):
+//   * .scanning      — authorized + a capture device exists: live preview
+//                      with a cut-out viewfinder, optional torch toggle,
+//                      and transient valid/invalid feedback.
+//   * .denied        — permission denied/restricted: an explanatory state
+//                      with an "Open Settings" button.
+//   * .noDevice      — authorized but no camera (the simulator case):
+//                      an intentional "Camera not available" state that
+//                      nudges the user to paste instead.
+//   * .checking      — the brief window while we resolve authorization.
+//
+// All UI state is `@MainActor`. The capture session is configured and
+// torn down on a background queue; the metadata delegate hops to the main
+// actor before touching any state.
+
+import SwiftUI
+@preconcurrency import AVFoundation
+import UIKit
+import SwiftDashSDK
+
+// MARK: - Pure payload parsing (no UIKit — keep this test-light)
+
+/// The meaningful result of decoding a scanned/pasted string: a validated
+/// address plus an optional amount lifted from a BIP21-style URI.
+struct ScannedPayment: Equatable {
+    let address: String
+    /// Decimal DASH string from a BIP21-style `amount=` query param, if
+    /// present and positive. `nil` when absent or unparseable.
+    let amount: String?
+}
+
+/// Decodes the strings that show up in Dash payment QR codes into a
+/// `ScannedPayment`, or `nil` if the embedded address isn't a recognized
+/// Dash address on `network`.
+///
+/// Accepts:
+///   * a bare address (`yMq…`, `tdash1…`, …)
+///   * `dash:ADDRESS`
+///   * `dash://ADDRESS`
+///   * `dash:ADDRESS?amount=1.23&label=Coffee` (params after the address)
+///
+/// The `dash:` scheme match is case-insensitive, but the address itself is
+/// kept verbatim — base58check and bech32m payloads are case-sensitive, so
+/// lowercasing them would corrupt valid addresses.
+enum QRPayloadParser {
+    static func parse(_ raw: String, network: Network) -> ScannedPayment? {
+        let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return nil }
+
+        // Strip an optional, case-insensitive `dash:` scheme (then an
+        // optional `//`) without touching the casing of the remainder.
+        var remainder = trimmed
+        let schemePrefix = "dash:"
+        if remainder.count >= schemePrefix.count,
+           remainder.prefix(schemePrefix.count).lowercased() == schemePrefix {
+            remainder = String(remainder.dropFirst(schemePrefix.count))
+            if remainder.hasPrefix("//") {
+                remainder = String(remainder.dropFirst(2))
+            }
+        }
+
+        // The address is everything up to the query string; params follow.
+        let parts = remainder.split(separator: "?", maxSplits: 1,
+                                    omittingEmptySubsequences: false)
+        let candidate = String(parts.first ?? "")
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !candidate.isEmpty else { return nil }
+
+        // Only accept a candidate that resolves to a known address type.
+        guard DashAddress.parse(candidate, network: network).type != .unknown else {
+            return nil
+        }
+
+        let amount = parts.count > 1
+            ? positiveAmount(fromQuery: String(parts[1]))
+            : nil
+
+        return ScannedPayment(address: candidate, amount: amount)
+    }
+
+    /// Extract a positive `amount` value from a `key=value&key=value` query
+    /// string. Returns the original (un-reformatted) string so the field is
+    /// filled with exactly what the QR author intended, but only if it
+    /// parses as a strictly-positive `Double`.
+    private static func positiveAmount(fromQuery query: String) -> String? {
+        for pair in query.split(separator: "&") {
+            let kv = pair.split(separator: "=", maxSplits: 1,
+                                omittingEmptySubsequences: false)
+            guard kv.count == 2, kv[0].lowercased() == "amount" else { continue }
+            let rawValue = String(kv[1])
+            // Percent-decode in case the URI encoded the value; fall back
+            // to the raw text when it wasn't encoded.
+            let value = rawValue.removingPercentEncoding ?? rawValue
+            if let parsed = Double(value), parsed > 0 {
+                return value
+            }
+            return nil
+        }
+        return nil
+    }
+}
+
+// MARK: - Scanner sheet
+
+/// Camera QR scanner presented as a sheet. Calls `onScan` exactly once on a
+/// successful read (or paste) and then dismisses itself.
+struct QRScannerView: View {
+    /// The states the sheet resolves into after checking permissions and
+    /// hardware availability.
+    private enum ScanState: Equatable {
+        case checking
+        case scanning
+        case denied
+        case noDevice
+    }
+
+    let network: Network
+    let onScan: @MainActor (ScannedPayment) -> Void
+
+    @Environment(\.dismiss) private var dismiss
+
+    /// Owns the `AVCaptureSession`. The view drives it (stop on match,
+    /// torch toggle) without the representable having to expose AVFoundation
+    /// state back up the tree.
+    @StateObject private var camera = CameraSessionController()
+
+    @State private var state: ScanState = .checking
+    @State private var isTorchOn = false
+    /// Transient banner shown over the viewfinder when a code (or paste)
+    /// doesn't validate.
+    @State private var invalidMessage: String?
+    /// Drives the green "matched!" flash before we dismiss.
+    @State private var didMatch = false
+    /// The most recent payload we rejected, with the time we rejected it —
+    /// used to de-dupe a hovering invalid code so it doesn't machine-gun
+    /// haptics.
+    @State private var lastRejected: (payload: String, at: Date)?
+
+    var body: some View {
+        NavigationStack {
+            ZStack {
+                Color.black.ignoresSafeArea()
+
+                switch state {
+                case .checking:
+                    ProgressView()
+                        .progressViewStyle(.circular)
+                        .tint(.white)
+                case .scanning:
+                    scanningContent
+                case .denied:
+                    deniedContent
+                case .noDevice:
+                    noDeviceContent
+                }
+
+                // Paste affordance is available in EVERY state.
+                VStack {
+                    Spacer()
+                    pasteButton
+                        .padding(.horizontal, 24)
+                        .padding(.bottom, 28)
+                }
+            }
+            .navigationTitle("Scan QR Code")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .navigationBarLeading) {
+                    Button("Cancel") { dismiss() }
+                }
+            }
+            .toolbarBackground(.visible, for: .navigationBar)
+            .toolbarColorScheme(.dark, for: .navigationBar)
+        }
+        .onAppear(perform: resolveInitialState)
+    }
+
+    // MARK: Scanning state
+
+    private var scanningContent: some View {
+        GeometryReader { proxy in
+            let cutout = viewfinderRect(in: proxy.size)
+            ZStack {
+                CameraPreview(
+                    controller: camera,
+                    rectOfInterest: cutout,
+                    onResult: handleScan
+                )
+                .ignoresSafeArea()
+
+                ViewfinderOverlay(cutout: cutout, matched: didMatch)
+                    .ignoresSafeArea()
+
+                // Hint + transient invalid banner, anchored to the cutout.
+                VStack(spacing: 0) {
+                    Spacer()
+                        .frame(height: cutout.maxY + 16)
+                    if let invalidMessage {
+                        Text(invalidMessage)
+                            .font(.footnote.weight(.semibold))
+                            .foregroundColor(.white)
+                            .padding(.horizontal, 14)
+                            .padding(.vertical, 8)
+                            .background(
+                                Capsule().fill(Color.red.opacity(0.9))
+                            )
+                            .transition(.opacity.combined(with: .scale))
+                    } else {
+                        Text("Point the camera at a Dash address QR code")
+                            .font(.footnote)
+                            .foregroundColor(.white)
+                            .multilineTextAlignment(.center)
+                            .padding(.horizontal, 32)
+                    }
+                    Spacer()
+                }
+                .frame(maxWidth: .infinity)
+
+                // Torch toggle, bottom-trailing, only when supported.
+                if CameraSessionController.hasTorch {
+                    VStack {
+                        Spacer()
+                        HStack {
+                            Spacer()
+                            torchButton
+                                .padding(.trailing, 24)
+                                // Sit above the paste button.
+                                .padding(.bottom, 96)
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    private var torchButton: some View {
+        Button {
+            isTorchOn.toggle()
+            camera.setTorch(on: isTorchOn)
+        } label: {
+            Image(systemName: isTorchOn ? "flashlight.on.fill" : "flashlight.off.fill")
+                .font(.title3)
+                .foregroundColor(.white)
+                .frame(width: 48, height: 48)
+                .background(.ultraThinMaterial, in: Circle())
+        }
+        .accessibilityLabel(isTorchOn ? "Turn off torch" : "Turn on torch")
+    }
+
+    // MARK: Denied state
+
+    private var deniedContent: some View {
+        VStack(spacing: 16) {
+            Image(systemName: "camera.fill")
+                .font(.system(size: 56))
+                .foregroundColor(.white.opacity(0.85))
+            Text("Camera access is off")
+                .font(.title3.weight(.semibold))
+                .foregroundColor(.white)
+            Text("Allow camera access in Settings to scan a Dash address QR code. You can still paste an address below.")
+                .font(.callout)
+                .foregroundColor(.white.opacity(0.7))
+                .multilineTextAlignment(.center)
+                .padding(.horizontal, 40)
+            Button {
+                openSettings()
+            } label: {
+                Text("Open Settings")
+            }
+            .buttonStyle(.bordered)
+            .tint(.white)
+        }
+        .padding(.bottom, 80)
+    }
+
+    // MARK: No-device state (simulator)
+
+    private var noDeviceContent: some View {
+        VStack(spacing: 16) {
+            Image(systemName: "camera.on.rectangle")
+                .font(.system(size: 56))
+                .foregroundColor(.white.opacity(0.85))
+            Text("Camera not available")
+                .font(.title3.weight(.semibold))
+                .foregroundColor(.white)
+            Text("Paste an address instead.")
+                .font(.callout)
+                .foregroundColor(.white.opacity(0.7))
+                .multilineTextAlignment(.center)
+                .padding(.horizontal, 40)
+        }
+        .padding(.bottom, 80)
+    }
+
+    // MARK: Paste affordance
+
+    private var pasteButton: some View {
+        Button {
+            handlePaste()
+        } label: {
+            Label("Paste from Clipboard", systemImage: "doc.on.clipboard")
+                .frame(maxWidth: .infinity)
+        }
+        .buttonStyle(.borderedProminent)
+        .controlSize(.large)
+    }
+
+    // MARK: - Geometry
+
+    /// A centered rounded square ~65% of the width, used both as the visual
+    /// viewfinder and as the camera's region of interest.
+    private func viewfinderRect(in size: CGSize) -> CGRect {
+        let side = min(size.width, size.height) * 0.65
+        let originX = (size.width - side) / 2
+        let originY = (size.height - side) / 2
+        return CGRect(x: originX, y: originY, width: side, height: side)
+    }
+
+    // MARK: - Permission / availability resolution
+
+    private func resolveInitialState() {
+        switch AVCaptureDevice.authorizationStatus(for: .video) {
+        case .authorized:
+            state = CameraSessionController.hasCaptureDevice ? .scanning : .noDevice
+        case .notDetermined:
+            AVCaptureDevice.requestAccess(for: .video) { granted in
+                Task { @MainActor in
+                    if granted {
+                        state = CameraSessionController.hasCaptureDevice ? .scanning : .noDevice
+                    } else {
+                        state = .denied
+                    }
+                }
+            }
+        case .denied, .restricted:
+            state = .denied
+        @unknown default:
+            state = .denied
+        }
+    }
+
+    // MARK: - Result handling
+
+    /// Called by the camera delegate (already on the main actor) with the
+    /// raw string of a decoded QR code.
+    @MainActor
+    private func handleScan(_ raw: String) {
+        // Ignore further reads once we've matched and are animating out.
+        guard !didMatch else { return }
+
+        if let payment = QRPayloadParser.parse(raw, network: network) {
+            acceptMatch(payment)
+        } else {
+            rejectPayload(raw, message: "Not a Dash address")
+        }
+    }
+
+    @MainActor
+    private func handlePaste() {
+        let clipboard = UIPasteboard.general.string ?? ""
+        if let payment = QRPayloadParser.parse(clipboard, network: network) {
+            acceptMatch(payment)
+        } else {
+            showInvalid("Clipboard doesn't contain a valid address")
+        }
+    }
+
+    /// Common success path for both scan and paste.
+    @MainActor
+    private func acceptMatch(_ payment: ScannedPayment) {
+        guard !didMatch else { return }
+        didMatch = true
+        invalidMessage = nil
+        camera.stop()
+        UINotificationFeedbackGenerator().notificationOccurred(.success)
+        withAnimation(.spring(response: 0.3, dampingFraction: 0.6)) {
+            // `didMatch` flips the viewfinder border green via the overlay.
+        }
+        // Give the green flash a beat to register, then hand off & dismiss.
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.35) {
+            onScan(payment)
+            dismiss()
+        }
+    }
+
+    /// Reject a scanned payload, de-duped so a hovering invalid code emits
+    /// at most one error haptic per distinct string within ~1.5s.
+    @MainActor
+    private func rejectPayload(_ raw: String, message: String) {
+        let now = Date()
+        if let last = lastRejected,
+           last.payload == raw,
+           now.timeIntervalSince(last.at) < 1.5 {
+            // Same code still hovering — refresh the timestamp, stay quiet.
+            lastRejected = (raw, now)
+            return
+        }
+        lastRejected = (raw, now)
+        UINotificationFeedbackGenerator().notificationOccurred(.error)
+        showInvalid(message)
+    }
+
+    /// Flash a transient invalid banner that auto-hides after ~1.5s.
+    @MainActor
+    private func showInvalid(_ message: String) {
+        withAnimation(.easeInOut(duration: 0.2)) {
+            invalidMessage = message
+        }
+        let shown = message
+        DispatchQueue.main.asyncAfter(deadline: .now() + 1.5) {
+            // Only clear if this same banner is still up.
+            if invalidMessage == shown {
+                withAnimation(.easeInOut(duration: 0.2)) {
+                    invalidMessage = nil
+                }
+            }
+        }
+    }
+
+    private func openSettings() {
+        guard let url = URL(string: UIApplication.openSettingsURLString) else { return }
+        UIApplication.shared.open(url)
+    }
+}
+
+// MARK: - Viewfinder overlay
+
+/// Dims the screen and punches a rounded-square hole over the live preview,
+/// stroking the cutout (green once a match lands).
+private struct ViewfinderOverlay: View {
+    let cutout: CGRect
+    let matched: Bool
+
+    private let cornerRadius: CGFloat = 20
+
+    var body: some View {
+        ZStack {
+            // Dim everything, then cut out the viewfinder with an even-odd
+            // fill so the camera shows through the hole.
+            Path { path in
+                path.addRect(CGRect(origin: .zero, size: UIScreen.main.bounds.size))
+                path.addRoundedRect(in: cutout, cornerSize: CGSize(width: cornerRadius,
+                                                                   height: cornerRadius))
+            }
+            .fill(Color.black.opacity(0.55), style: FillStyle(eoFill: true))
+
+            RoundedRectangle(cornerRadius: cornerRadius)
+                .stroke(matched ? Color.green : Color.white,
+                        style: StrokeStyle(lineWidth: 2, lineCap: .round, lineJoin: .round))
+                .frame(width: cutout.width, height: cutout.height)
+                .position(x: cutout.midX, y: cutout.midY)
+                .animation(.spring(response: 0.3, dampingFraction: 0.6), value: matched)
+        }
+        .allowsHitTesting(false)
+    }
+}
+
+// MARK: - Camera preview (AVFoundation bridge)
+
+/// `UIViewRepresentable` that hosts an `AVCaptureVideoPreviewLayer` over the
+/// `.qr`-only `AVCaptureSession` owned by `CameraSessionController`. Metadata
+/// results are delivered on the main actor via `onResult`.
+///
+/// The representable is intentionally thin: it forwards the preview layer and
+/// region of interest to the controller, which the parent view also holds so
+/// it can stop the session (`controller.stop()`) and toggle the torch
+/// (`controller.setTorch`) without reaching back through the representable.
+private struct CameraPreview: UIViewRepresentable {
+    let controller: CameraSessionController
+    let rectOfInterest: CGRect
+    let onResult: @MainActor @Sendable (String) -> Void
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator(controller: controller, onResult: onResult)
+    }
+
+    func makeUIView(context: Context) -> PreviewContainerView {
+        let view = PreviewContainerView()
+        view.previewLayer.videoGravity = .resizeAspectFill
+        controller.start(previewLayer: view.previewLayer,
+                         rectOfInterest: rectOfInterest,
+                         delegate: context.coordinator)
+        return view
+    }
+
+    func updateUIView(_ uiView: PreviewContainerView, context: Context) {
+        controller.updateRectOfInterest(rectOfInterest,
+                                        previewLayer: uiView.previewLayer)
+    }
+
+    static func dismantleUIView(_ uiView: PreviewContainerView, coordinator: Coordinator) {
+        coordinator.controller.stop()
+    }
+
+    // MARK: Container view whose backing layer is the preview layer
+
+    /// A `UIView` whose layer class is `AVCaptureVideoPreviewLayer`, so the
+    /// preview always tracks the view's bounds without manual frame syncing.
+    final class PreviewContainerView: UIView {
+        override class var layerClass: AnyClass { AVCaptureVideoPreviewLayer.self }
+
+        var previewLayer: AVCaptureVideoPreviewLayer {
+            guard let layer = layer as? AVCaptureVideoPreviewLayer else {
+                // Unreachable: `layerClass` guarantees this type. Returning a
+                // detached layer keeps the API non-optional without a crash.
+                return AVCaptureVideoPreviewLayer()
+            }
+            return layer
+        }
+    }
+
+    // MARK: Coordinator — the metadata delegate
+
+    /// Bridges `AVCaptureMetadataOutput` callbacks (which fire on the
+    /// session's background queue) to the main-actor `onResult` closure.
+    final class Coordinator: NSObject, AVCaptureMetadataOutputObjectsDelegate {
+        let controller: CameraSessionController
+        private let onResult: @MainActor @Sendable (String) -> Void
+
+        init(controller: CameraSessionController,
+             onResult: @escaping @MainActor @Sendable (String) -> Void) {
+            self.controller = controller
+            self.onResult = onResult
+        }
+
+        func metadataOutput(_ output: AVCaptureMetadataOutput,
+                            didOutput metadataObjects: [AVMetadataObject],
+                            from connection: AVCaptureConnection) {
+            guard
+                let object = metadataObjects.first as? AVMetadataMachineReadableCodeObject,
+                object.type == .qr,
+                let value = object.stringValue
+            else { return }
+
+            // Delegate fires on the session queue — hop to the main actor
+            // before touching any SwiftUI state.
+            let handler = onResult
+            Task { @MainActor in
+                handler(value)
+            }
+        }
+    }
+}
+
+// MARK: - Camera session controller
+
+/// Owns the scanner's `AVCaptureSession` and serializes every access to it
+/// onto a private background queue.
+///
+/// Marked `@unchecked Sendable` deliberately: the only non-`Sendable` state
+/// (`session`, its inputs/outputs) is touched exclusively on `queue`, and the
+/// preview-layer wiring (`previewLayer.session = session`) happens on the
+/// main thread before any concurrent work begins. The `ObservableObject`
+/// surface is intentionally empty today — the controller exists so the view
+/// can drive start/stop/torch without leaking AVFoundation upward — but
+/// conforming keeps it usable as a `@StateObject`.
+private final class CameraSessionController: ObservableObject, @unchecked Sendable {
+    private let session = AVCaptureSession()
+    private let queue = DispatchQueue(label: "qrscanner.session")
+    private var isConfigured = false
+
+    // MARK: Static hardware queries
+
+    /// A capture device exists — used to choose `.scanning` vs `.noDevice`
+    /// before any session is built (the simulator has none).
+    static var hasCaptureDevice: Bool {
+        AVCaptureDevice.default(for: .video) != nil
+    }
+
+    static var hasTorch: Bool {
+        AVCaptureDevice.default(for: .video)?.hasTorch ?? false
+    }
+
+    // MARK: Lifecycle
+
+    /// Configure (once) and start the session, wiring `delegate` to a fresh
+    /// metadata output limited to `.qr`. Safe to call repeatedly — it only
+    /// builds inputs/outputs the first time and restarts thereafter.
+    func start(previewLayer: AVCaptureVideoPreviewLayer,
+               rectOfInterest: CGRect,
+               delegate: AVCaptureMetadataOutputObjectsDelegate) {
+        // Layer/session wiring stays on the main thread; the heavy session
+        // work is dispatched to `queue`.
+        previewLayer.session = session
+        let converted = previewLayer.metadataOutputRectConverted(fromLayerRect: rectOfInterest)
+        queue.async { [self] in
+            if !isConfigured {
+                configure(delegate: delegate)
+            }
+            applyRectOfInterest(converted)
+            if !session.isRunning {
+                session.startRunning()
+            }
+        }
+    }
+
+    private func configure(delegate: AVCaptureMetadataOutputObjectsDelegate) {
+        session.beginConfiguration()
+        defer { session.commitConfiguration() }
+
+        guard
+            let device = AVCaptureDevice.default(for: .video),
+            let input = try? AVCaptureDeviceInput(device: device),
+            session.canAddInput(input)
+        else {
+            return
+        }
+        session.addInput(input)
+
+        let output = AVCaptureMetadataOutput()
+        guard session.canAddOutput(output) else { return }
+        session.addOutput(output)
+        output.setMetadataObjectsDelegate(delegate, queue: queue)
+        if output.availableMetadataObjectTypes.contains(.qr) {
+            output.metadataObjectTypes = [.qr]
+        }
+
+        isConfigured = true
+    }
+
+    /// Re-derive and apply the region of interest after a layout change. The
+    /// layer→metadata conversion needs the preview layer's geometry, so it
+    /// happens on the main thread; the assignment is dispatched to `queue`.
+    func updateRectOfInterest(_ rect: CGRect, previewLayer: AVCaptureVideoPreviewLayer) {
+        let converted = previewLayer.metadataOutputRectConverted(fromLayerRect: rect)
+        queue.async { [self] in
+            applyRectOfInterest(converted)
+        }
+    }
+
+    /// Must be called on `queue`. Pushes the normalized rect to the metadata
+    /// output, ignoring degenerate rects (zero-size during first layout).
+    private func applyRectOfInterest(_ converted: CGRect) {
+        guard converted.width > 0, converted.height > 0 else { return }
+        for output in session.outputs {
+            if let metadataOutput = output as? AVCaptureMetadataOutput {
+                metadataOutput.rectOfInterest = converted
+            }
+        }
+    }
+
+    func stop() {
+        queue.async { [self] in
+            if session.isRunning {
+                session.stopRunning()
+            }
+        }
+    }
+
+    func setTorch(on: Bool) {
+        queue.async {
+            guard let device = AVCaptureDevice.default(for: .video), device.hasTorch else { return }
+            do {
+                try device.lockForConfiguration()
+                device.torchMode = on ? .on : .off
+                device.unlockForConfiguration()
+            } catch {
+                // Non-fatal: torch just stays in its prior state.
+            }
+        }
+    }
+}

--- a/packages/swift-sdk/SwiftExampleApp/SwiftExampleApp/Core/Views/SendTransactionView.swift
+++ b/packages/swift-sdk/SwiftExampleApp/SwiftExampleApp/Core/Views/SendTransactionView.swift
@@ -11,6 +11,9 @@ struct SendTransactionView: View {
 
     @StateObject private var viewModel: SendViewModel
 
+    /// Drives the camera QR scanner sheet launched from the recipient row.
+    @State private var showQRScanner = false
+
     @Environment(\.modelContext) private var modelContext
 
     /// BLAST-synced platform-address balances for this wallet —
@@ -55,9 +58,23 @@ struct SendTransactionView: View {
             Form {
                 // Recipient
                 Section("Recipient") {
-                    TextField("Recipient Address", text: $viewModel.recipientAddress)
-                        .textInputAutocapitalization(.never)
-                        .autocorrectionDisabled()
+                    HStack(spacing: 8) {
+                        TextField("Recipient Address", text: $viewModel.recipientAddress)
+                            .textInputAutocapitalization(.never)
+                            .autocorrectionDisabled()
+                        Button {
+                            showQRScanner = true
+                        } label: {
+                            Image(systemName: "qrcode.viewfinder")
+                                .font(.title3)
+                                .foregroundColor(.accentColor)
+                        }
+                        // `.borderless` is REQUIRED: the default button
+                        // style inside a Form makes the whole row tappable,
+                        // which would swallow taps on the text field.
+                        .buttonStyle(.borderless)
+                        .accessibilityLabel("Scan recipient address QR code")
+                    }
 
                     if !viewModel.recipientAddress.isEmpty {
                         AddressTypeBadge(type: viewModel.detectedAddressType)
@@ -235,6 +252,20 @@ struct SendTransactionView: View {
             }
             .onChange(of: viewModel.detectedAddressType) { _, _ in
                 autoSelectSource()
+            }
+            .sheet(isPresented: $showQRScanner) {
+                // Same network the view model was built with
+                // (`wallet.network ?? .testnet`) so the scanner validates
+                // against the wallet's chain. Assigning `recipientAddress`
+                // triggers the view model's `didSet` address-type
+                // detection; the amount is only adopted when the user
+                // hasn't already typed one.
+                QRScannerView(network: wallet.network ?? .testnet) { payment in
+                    viewModel.recipientAddress = payment.address
+                    if let amount = payment.amount, viewModel.amountString.isEmpty {
+                        viewModel.amountString = amount
+                    }
+                }
             }
         }
     }

--- a/packages/swift-sdk/SwiftExampleApp/SwiftExampleAppTests/QRPayloadParserTests.swift
+++ b/packages/swift-sdk/SwiftExampleApp/SwiftExampleAppTests/QRPayloadParserTests.swift
@@ -1,0 +1,141 @@
+import XCTest
+import SwiftDashSDK
+@testable import SwiftExampleApp
+
+/// Behavioral tests for `QRPayloadParser.parse` — the pure decoder behind
+/// the Send screen's QR scanner.
+///
+/// The scanner UI (camera session, overlays, haptics) isn't unit-testable,
+/// but the parser is: it's the piece that decides what a scanned/pasted
+/// string actually means. It accepts bare addresses and BIP21-style
+/// `dash:` URIs, lifts an optional `amount`, and rejects anything that
+/// doesn't resolve to a known `DashAddress` on the given network.
+///
+/// Address validation is NOT mocked: the Core path runs through
+/// `DashAddress.parse` → `Address.validate` (Rust FFI), which links fine in
+/// the test bundle (other suites already exercise the SDK). All cases use
+/// `Network.testnet`.
+final class QRPayloadParserTests: XCTestCase {
+
+    /// Known-valid testnet P2PKH (base58check) Core address.
+    private let validCoreAddress = "yMqShkrgjTRuReBGFpQr7FozEF1QcNBBYA"
+    private let network: Network = .testnet
+
+    // MARK: - Sanity: the fixture really is valid on testnet
+
+    func test_fixtureAddress_isRecognizedByDashAddress() {
+        // If this fails, every other case below is meaningless — the
+        // fixture or the FFI link is the problem, not the parser.
+        XCTAssertNotEqual(
+            DashAddress.parse(validCoreAddress, network: network).type,
+            .unknown,
+            "Fixture testnet address should validate via the FFI"
+        )
+    }
+
+    // MARK: - Bare address
+
+    func test_bareCoreAddress_isAccepted() {
+        let result = QRPayloadParser.parse(validCoreAddress, network: network)
+        XCTAssertEqual(result, ScannedPayment(address: validCoreAddress, amount: nil))
+    }
+
+    // MARK: - Scheme stripping
+
+    func test_dashSchemePrefix_isStripped() {
+        let result = QRPayloadParser.parse("dash:\(validCoreAddress)", network: network)
+        XCTAssertEqual(result?.address, validCoreAddress)
+        XCTAssertNil(result?.amount)
+    }
+
+    func test_dashSchemeIsCaseInsensitive() {
+        let result = QRPayloadParser.parse("DASH:\(validCoreAddress)", network: network)
+        XCTAssertEqual(result?.address, validCoreAddress)
+    }
+
+    func test_dashSchemeWithDoubleSlash_isStripped() {
+        let result = QRPayloadParser.parse("dash://\(validCoreAddress)", network: network)
+        XCTAssertEqual(result?.address, validCoreAddress)
+    }
+
+    // MARK: - Amount parsing
+
+    func test_amountQueryParam_isExtracted() {
+        let result = QRPayloadParser.parse(
+            "dash:\(validCoreAddress)?amount=0.5&label=x",
+            network: network
+        )
+        XCTAssertEqual(result?.address, validCoreAddress)
+        XCTAssertEqual(result?.amount, "0.5")
+    }
+
+    func test_amountBeforeLabelOrder_isIrrelevant() {
+        let result = QRPayloadParser.parse(
+            "dash:\(validCoreAddress)?label=Coffee&amount=1.23",
+            network: network
+        )
+        XCTAssertEqual(result?.amount, "1.23")
+    }
+
+    func test_nonNumericAmount_isDroppedButAddressKept() {
+        let result = QRPayloadParser.parse(
+            "dash:\(validCoreAddress)?amount=abc",
+            network: network
+        )
+        XCTAssertEqual(result?.address, validCoreAddress)
+        XCTAssertNil(result?.amount)
+    }
+
+    func test_negativeAmount_isDroppedButAddressKept() {
+        let result = QRPayloadParser.parse(
+            "dash:\(validCoreAddress)?amount=-1.0",
+            network: network
+        )
+        XCTAssertEqual(result?.address, validCoreAddress)
+        XCTAssertNil(result?.amount)
+    }
+
+    func test_zeroAmount_isDropped() {
+        // Zero is not a positive amount.
+        let result = QRPayloadParser.parse(
+            "dash:\(validCoreAddress)?amount=0",
+            network: network
+        )
+        XCTAssertEqual(result?.address, validCoreAddress)
+        XCTAssertNil(result?.amount)
+    }
+
+    // MARK: - Whitespace handling
+
+    func test_whitespaceWrappedAddress_isTrimmedAndValid() {
+        let result = QRPayloadParser.parse("  \n\(validCoreAddress)\t \n", network: network)
+        XCTAssertEqual(result?.address, validCoreAddress)
+    }
+
+    // MARK: - Rejections
+
+    func test_garbageString_isRejected() {
+        XCTAssertNil(QRPayloadParser.parse("not-an-address-at-all", network: network))
+    }
+
+    func test_emptyString_isRejected() {
+        XCTAssertNil(QRPayloadParser.parse("", network: network))
+    }
+
+    func test_whitespaceOnly_isRejected() {
+        XCTAssertNil(QRPayloadParser.parse("   \n\t  ", network: network))
+    }
+
+    func test_schemeWithNoAddress_isRejected() {
+        XCTAssertNil(QRPayloadParser.parse("dash:", network: network))
+    }
+
+    func test_addressCasingIsPreserved_notLowercased() {
+        // The parser must not lowercase the candidate — base58check is
+        // case-sensitive, so a mangled-case address must be rejected
+        // rather than "fixed" into a different (or invalid) address.
+        let mangled = validCoreAddress.lowercased()
+        XCTAssertNotEqual(mangled, validCoreAddress)
+        XCTAssertNil(QRPayloadParser.parse(mangled, network: network))
+    }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

The Send Dash screen only accepted typed/pasted recipient addresses. Long base58/bech32m strings are error-prone to enter by hand; scanning a QR code is the expected wallet UX.

## What was done?
<!--- Describe your changes in detail -->

- **`Core/Views/QRScannerView.swift` (new)** — a self-contained scanner sheet:
  - Live AVFoundation capture (`.qr` metadata only) with a dimmed even-odd viewfinder cutout, detection limited to the viewfinder region (`rectOfInterest`), instruction caption, and a torch toggle when the device has one.
  - Pure, UIKit-free `QRPayloadParser`: accepts bare addresses and BIP21-style URIs (`dash:ADDR`, `dash://ADDR`, `dash:ADDR?amount=…&label=…`); case-insensitive scheme, case-preserving address; positive `amount=` extracted, anything else dropped. Validation defers to the existing `DashAddress.parse` (Core base58 via Rust FFI, Platform/Orchard bech32m) so every address type the Send flow understands scans in.
  - Scan feedback: success haptic + green viewfinder flash + auto-dismiss; invalid codes get one error haptic per distinct payload (deduped, ~1.5s) and a transient "Not a Dash address" capsule while scanning continues.
  - Permission/capability states: `.notDetermined` requests inline; denied/restricted shows an "Open Settings" deep link; simulators/camera-less devices get an intentional "Camera not available — paste an address instead" state. A **Paste from Clipboard** button is present in every state and routes through the same parser.
  - Swift 6 strict concurrency: capture-session work is serialized on a private queue in a view-owned `CameraSessionController`; delegate→UI hops are `@MainActor`.
- **`Core/Views/SendTransactionView.swift`** — `qrcode.viewfinder` button (`.borderless`, accessibility-labeled) trailing the Recipient text field; on scan, fills `recipientAddress` (existing `didSet` detection/flow routing fires) and prefills the Amount field from a BIP21 `amount=` only when it's still empty.
- **`Info.plist`** — `NSCameraUsageDescription`.
- **`SwiftExampleAppTests/QRPayloadParserTests.swift` (new)** — 16 unit tests for the parser.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

- `xcodebuild build` (iPhone 16 simulator) — clean.
- `xcodebuild -only-testing:SwiftExampleAppTests/QRPayloadParserTests test` — 16/16 pass (scheme stripping, `dash://`, case-insensitive scheme, amount extraction, zero/negative/non-numeric amount rejection, whitespace trimming, base58 case preservation, FFI-backed fixture validation, garbage/empty rejection).
- Manual UI pass on the iPhone 17 Pro simulator: camera button renders in the Recipient row; the sheet shows the system permission prompt with the new usage string; after Allow, the simulator's no-camera fallback state renders as designed; "Paste from Clipboard" with `dash:yMqShkr…?amount=0.25` on the pasteboard dismissed the sheet, filled the recipient (Core Address badge detected), and prefilled Amount to 0.25 with the Core source auto-selected.
- Live camera capture itself isn't exercisable in the simulator; the capture pipeline is standard `AVCaptureMetadataOutput` wiring.

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->

None.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [ ] I have made corresponding changes to the documentation if needed

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added QR code scanner to quickly populate recipient address field
  * Supports scanning payment QR codes with automatic amount pre-filling when available
  * Includes "Paste from Clipboard" option for QR payloads in all device states
  * Handles camera permission requests gracefully with appropriate user feedback

* **Tests**
  * Added comprehensive QR payload parsing test suite

<!-- end of auto-generated comment: release notes by coderabbit.ai -->