### PR TITLE
chore: expand code ownership for SDK, wallet stack, proof verifier and wasm-dpp2

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,15 +1,21 @@
 * @QuantumExplorer
 
 # SDK packages
-/packages/rs-sdk/ @QuantumExplorer @shumkov
-/packages/rs-sdk-ffi/ @QuantumExplorer @shumkov
+/packages/rs-sdk/ @QuantumExplorer @shumkov @lklimek
+/packages/rs-sdk-ffi/ @QuantumExplorer @shumkov @lklimek
 /packages/rs-sdk-trusted-context-provider/ @QuantumExplorer @shumkov
 /packages/js-dash-sdk/ @QuantumExplorer @shumkov
 /packages/js-evo-sdk/ @QuantumExplorer @shumkov
 /packages/wasm-sdk/ @QuantumExplorer @shumkov
-/packages/swift-sdk/ @QuantumExplorer @shumkov @llbartekll
+/packages/swift-sdk/ @QuantumExplorer @shumkov @llbartekll @ZocoLini
 
 # Platform wallet stack
-/packages/rs-platform-wallet/ @QuantumExplorer @llbartekll
-/packages/rs-platform-wallet-ffi/ @QuantumExplorer @llbartekll
-/packages/rs-platform-wallet-storage/ @QuantumExplorer @llbartekll
+/packages/rs-platform-wallet/ @QuantumExplorer @shumkov @lklimek @llbartekll @ZocoLini
+/packages/rs-platform-wallet-ffi/ @QuantumExplorer @shumkov @lklimek @llbartekll @ZocoLini
+/packages/rs-platform-wallet-storage/ @QuantumExplorer @shumkov @lklimek @llbartekll @ZocoLini
+
+# Proof verification
+/packages/rs-drive-proof-verifier/ @QuantumExplorer @shumkov @lklimek
+
+# WASM DPP v2
+/packages/wasm-dpp2/ @QuantumExplorer @shumkov

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -7,4 +7,9 @@
 /packages/js-dash-sdk/ @QuantumExplorer @shumkov
 /packages/js-evo-sdk/ @QuantumExplorer @shumkov
 /packages/wasm-sdk/ @QuantumExplorer @shumkov
-/packages/swift-sdk/ @QuantumExplorer @shumkov
+/packages/swift-sdk/ @QuantumExplorer @shumkov @llbartekll
+
+# Platform wallet stack
+/packages/rs-platform-wallet/ @QuantumExplorer @llbartekll
+/packages/rs-platform-wallet-ffi/ @QuantumExplorer @llbartekll
+/packages/rs-platform-wallet-storage/ @QuantumExplorer @llbartekll


### PR DESCRIPTION
## Issue being fixed or feature implemented
Code-owner review is required on `v3.1-dev`, but ownership didn't reflect who actually works on each area, so PRs bottleneck on a single owner.

## What was done?
Updated CODEOWNERS:
- `packages/swift-sdk/`: added `@llbartekll` and `@ZocoLini`
- Platform wallet stack (`rs-platform-wallet`, `-ffi`, `-storage`): owned by `@QuantumExplorer` `@shumkov` `@lklimek` `@llbartekll` `@ZocoLini`
- `packages/rs-sdk/` and `packages/rs-sdk-ffi/`: added `@lklimek`
- `packages/rs-drive-proof-verifier/`: new entry — `@QuantumExplorer` `@shumkov` `@lklimek`
- `packages/wasm-dpp2/`: new entry — `@QuantumExplorer` `@shumkov`

Because CODEOWNERS is last-match-wins, anything outside these paths still falls back to `* @QuantumExplorer`.

## How Has This Been Tested?
N/A — CODEOWNERS-only change. Verified all added handles have write access (required for entries to take effect) and that branch protection on `v3.1-dev` enforces `require_code_owner_reviews`.

## Breaking Changes
None

## Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [ ] I have made corresponding changes to the documentation if needed

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated ownership for Rust SDK packages.
  * Expanded ownership for the Swift SDK.
  * Added ownership entries for a new Platform Wallet stack (core, FFI, and storage packages).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->