### PR TITLE
fix(platform): derive shielded identity-create id from the padded bundle's published nullifiers

### DIFF
--- a/packages/rs-dpp/src/address_funds/platform_address.rs
+++ b/packages/rs-dpp/src/address_funds/platform_address.rs
@@ -706,6 +706,24 @@ mod tests {
     use dashcore::PublicKey;
     use platform_value::BinaryData;
 
+    /// All non-mainnet networks share the `tdash` HRP (DIP-0018), so an address parsed from a
+    /// bech32m string can only ever report Mainnet or Testnet — never Devnet/Regtest. Network
+    /// checks against a parsed address MUST therefore compare HRPs, not raw `Network` values
+    /// (`PlatformWallet::shielded_unshield_to` relies on this; comparing raw networks made every
+    /// unshield fail on devnet wallets).
+    #[test]
+    fn hrp_is_shared_across_all_non_mainnet_networks() {
+        let testnet = PlatformAddress::hrp_for_network(Network::Testnet);
+        assert_eq!(testnet, PLATFORM_HRP_TESTNET);
+        assert_eq!(PlatformAddress::hrp_for_network(Network::Devnet), testnet);
+        assert_eq!(PlatformAddress::hrp_for_network(Network::Regtest), testnet);
+        assert_ne!(
+            PlatformAddress::hrp_for_network(Network::Mainnet),
+            testnet,
+            "mainnet must use a distinct HRP"
+        );
+    }
+
     /// Helper to create a keypair from a 32-byte seed
     fn create_keypair(seed: [u8; 32]) -> (RawSecretKey, PublicKey) {
         let secp = Secp256k1::new();

--- a/packages/rs-dpp/src/shielded/builder/identity_create_from_shielded_pool.rs
+++ b/packages/rs-dpp/src/shielded/builder/identity_create_from_shielded_pool.rs
@@ -21,7 +21,7 @@ use crate::ProtocolError;
 use platform_value::Identifier;
 use platform_version::version::PlatformVersion;
 
-use super::{build_spend_bundle, serialize_authorized_bundle, OrchardProver, SpendableNote};
+use super::{build_spend_bundle_with, serialize_authorized_bundle, OrchardProver, SpendableNote};
 
 /// Output of [`build_identity_create_from_shielded_pool_transition`]: everything the SDK's
 /// `IdentityCreateFromShieldedPool::identity_create_from_shielded_pool` broadcast helper needs.
@@ -62,9 +62,11 @@ pub struct IdentityCreateFromShieldedPoolBuildResult {
 /// 3. a per-key proof-of-possession signature over the transition's `signable_bytes`, proving the
 ///    creator holds every key being registered (mirrors `IdentityCreate`).
 ///
-/// The new identity id is derived from the SORTED spend nullifiers
-/// ([`derive_identity_id_from_actions`]) — fully determined by which notes are spent, so it is
-/// known before the bundle is built and the same value is re-derived and checked at consensus.
+/// The new identity id is derived from the SORTED **published** action nullifiers
+/// ([`derive_identity_id_from_actions`]) — including any padding action's dummy nullifier
+/// (`BundleType::DEFAULT` pads single-spend bundles to a 2-action minimum), so it is only known
+/// once the bundle's action set is fixed. It is derived inside the bundle-build hook, bound into
+/// the Orchard sighash there, and the same value is re-derived and checked at consensus.
 ///
 /// # Parameters
 /// - `public_keys` — the new identity's public keys, each paired with its
@@ -169,29 +171,18 @@ where
         )));
     }
 
-    // The id is derived from the SORTED spend nullifiers, which must be known BEFORE signing
-    // because the id is part of the Orchard sighash. The nullifier of a spend is
-    // `Note::nullifier(fvk)`, independent of bundle randomness, so compute them directly from the
-    // spent notes — the same values the bundle will publish and consensus will re-derive from.
-    let nullifiers: Vec<[u8; 32]> = spends
-        .iter()
-        .map(|s| s.note.nullifier(fvk).to_bytes())
-        .collect();
-    let identity_id = identity_id_from_nullifiers(&nullifiers);
-
-    // Build the in-creation key list (transition order) and bind it — together with the id and the
-    // denomination — into the Orchard sighash.
+    // Build the in-creation key list (transition order) up front — it is bound, together with the
+    // id and the denomination, into the Orchard sighash.
     let in_creation_keys: Vec<IdentityPublicKeyInCreation> =
         public_keys.iter().map(|(_, c)| c.clone()).collect();
-    let extra_sighash_data = crate::shielded::identity_create_from_shielded_extra_sighash_data(
-        &identity_id.to_buffer(),
-        denomination,
-        &send_to_address_on_creation_failure,
-        &in_creation_keys,
-        platform_version,
-    )?;
 
-    let bundle = build_spend_bundle(
+    // The id is `double_sha256(sorted PUBLISHED nullifiers)`. The published set is only known once
+    // the bundle is built: `BundleType::DEFAULT` pads a single-spend bundle with a dummy action
+    // whose random nullifier goes on the wire, and consensus re-derives the id over ALL action
+    // nullifiers (dummies are indistinguishable by design). So derive the id inside the
+    // post-build hook — after the action set is fixed, before the sighash is bound.
+    let mut bound_identity_id: Option<Identifier> = None;
+    let bundle = build_spend_bundle_with(
         spends,
         change_address,
         change_amount,
@@ -200,8 +191,24 @@ where
         ask,
         anchor,
         prover,
-        &extra_sighash_data,
+        |published_nullifiers| {
+            let id = identity_id_from_nullifiers(published_nullifiers);
+            let data = crate::shielded::identity_create_from_shielded_extra_sighash_data(
+                &id.to_buffer(),
+                denomination,
+                &send_to_address_on_creation_failure,
+                &in_creation_keys,
+                platform_version,
+            )?;
+            bound_identity_id = Some(id);
+            Ok(data)
+        },
     )?;
+    let identity_id = bound_identity_id.ok_or_else(|| {
+        ProtocolError::ShieldedBuildError(
+            "identity id was not derived during bundle build".to_string(),
+        )
+    })?;
 
     let sb = serialize_authorized_bundle(&bundle);
 
@@ -268,4 +275,227 @@ where
         identity_id,
         predicted_fee: fee,
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::address_funds::AddressWitness;
+    use crate::identity::identity_public_key::v0::IdentityPublicKeyV0;
+    use crate::identity::{KeyType, Purpose, SecurityLevel};
+    use crate::shielded::builder::test_helpers::{
+        test_orchard_address, test_spendable_note, TestProver,
+    };
+    use crate::state_transition::public_key_in_creation::v0::IdentityPublicKeyInCreationV0;
+    use grovedb_commitment_tree::{
+        ExtractedNoteCommitment, Hashable, MerkleHashOrchard, MerklePath, SpendingKey,
+        NOTE_COMMITMENT_TREE_DEPTH,
+    };
+    use platform_value::BinaryData;
+
+    /// A dummy PoP signer producing a fixed 65-byte signature. The builder fills (and does not
+    /// verify) the proof-of-possession signatures, so a stub is enough to exercise the pipeline.
+    #[derive(Debug)]
+    struct DummySigner;
+
+    #[async_trait::async_trait]
+    impl Signer<IdentityPublicKey> for DummySigner {
+        async fn sign(
+            &self,
+            _key: &IdentityPublicKey,
+            _data: &[u8],
+        ) -> Result<BinaryData, ProtocolError> {
+            Ok(BinaryData::new(vec![0u8; 65]))
+        }
+
+        async fn sign_create_witness(
+            &self,
+            _key: &IdentityPublicKey,
+            _data: &[u8],
+        ) -> Result<AddressWitness, ProtocolError> {
+            Err(ProtocolError::ShieldedBuildError(
+                "identity PoP signer never creates address witnesses".to_string(),
+            ))
+        }
+
+        fn can_sign_with(&self, _key: &IdentityPublicKey) -> bool {
+            true
+        }
+    }
+
+    /// One AUTHENTICATION/MASTER ECDSA key in both forms the builder takes.
+    fn key_pair(id: u32) -> (IdentityPublicKey, IdentityPublicKeyInCreation) {
+        let public = IdentityPublicKey::V0(IdentityPublicKeyV0 {
+            id,
+            purpose: Purpose::AUTHENTICATION,
+            security_level: SecurityLevel::MASTER,
+            contract_bounds: None,
+            key_type: KeyType::ECDSA_SECP256K1,
+            read_only: false,
+            data: BinaryData::new(vec![0xAB; 33]),
+            disabled_at: None,
+        });
+        let in_creation = IdentityPublicKeyInCreation::V0(IdentityPublicKeyInCreationV0 {
+            id,
+            key_type: KeyType::ECDSA_SECP256K1,
+            purpose: Purpose::AUTHENTICATION,
+            security_level: SecurityLevel::MASTER,
+            contract_bounds: None,
+            read_only: false,
+            data: BinaryData::new(vec![0xAB; 33]),
+            signature: BinaryData::new(vec![]),
+        });
+        (public, in_creation)
+    }
+
+    /// 0.1 DASH in credits — the smallest member of the versioned exit-denomination set.
+    const DENOMINATION: u64 = 10_000_000_000;
+
+    /// The padded-bundle regression test for the dummy-nullifier bug: a SINGLE-spend bundle is
+    /// padded by `BundleType::DEFAULT` to the 2-action minimum, and the padding action's random
+    /// dummy nullifier is published on the wire. The identity id MUST be derived from the FULL
+    /// published set (what consensus re-derives), not from the real spends alone — pre-fix this
+    /// build failed its own post-proving id-consistency check on every 1-note spend.
+    #[tokio::test]
+    async fn single_spend_padded_bundle_derives_id_from_published_nullifiers() {
+        let platform_version = PlatformVersion::latest();
+        let sk = SpendingKey::from_bytes([42u8; 32]).expect("valid spending key");
+        let fvk = FullViewingKey::from(&sk);
+        let ask = SpendAuthorizingKey::from(&sk);
+        let change_address = test_orchard_address();
+
+        // A valid (note, path, anchor) triple: the anchor is the root the witness computes over
+        // the note's commitment — the same trick `extract_spends_and_anchor` uses in production.
+        let spend = test_spendable_note(12_000_000_000);
+        let cmx = ExtractedNoteCommitment::from(spend.note.commitment());
+        let anchor = spend.merkle_path.root(cmx);
+        let real_nullifier = spend.note.nullifier(&fvk).to_bytes();
+
+        let result = build_identity_create_from_shielded_pool_transition(
+            vec![key_pair(0)],
+            DENOMINATION,
+            PlatformAddress::P2pkh([0u8; 20]),
+            vec![spend],
+            &change_address,
+            &fvk,
+            &ask,
+            anchor,
+            &TestProver,
+            &DummySigner,
+            [0u8; 36],
+            platform_version,
+        )
+        .await
+        .expect("a single-spend (padded) build must succeed");
+
+        assert_eq!(
+            result.bundle.actions.len(),
+            2,
+            "a single spend must be padded to the 2-action minimum"
+        );
+        assert!(
+            result
+                .bundle
+                .actions
+                .iter()
+                .any(|action| action.nullifier == real_nullifier),
+            "the real spend's nullifier must be among the published actions"
+        );
+        // The id must equal the consensus re-derivation over ALL published nullifiers…
+        assert_eq!(
+            result.identity_id,
+            derive_identity_id_from_actions(&result.bundle.actions),
+            "identity id must match the consensus derivation over the published actions"
+        );
+        // …and must NOT equal the real-spends-only derivation (the pre-fix behavior): the padding
+        // action's dummy nullifier participates.
+        assert_ne!(
+            result.identity_id,
+            identity_id_from_nullifiers(&[real_nullifier]),
+            "the padding action's dummy nullifier must participate in the id derivation"
+        );
+        assert!(
+            result.predicted_fee < DENOMINATION,
+            "predicted fee must leave the new identity a positive balance"
+        );
+    }
+
+    /// Complement: with two real spends (no padding needed), the published set IS the real set,
+    /// so the id equals the real-nullifiers-only derivation.
+    #[tokio::test]
+    async fn two_spend_unpadded_bundle_id_matches_real_nullifier_derivation() {
+        let platform_version = PlatformVersion::latest();
+        let sk = SpendingKey::from_bytes([42u8; 32]).expect("valid spending key");
+        let fvk = FullViewingKey::from(&sk);
+        let ask = SpendAuthorizingKey::from(&sk);
+        let change_address = test_orchard_address();
+
+        // Two distinct notes (different values → different commitments/nullifiers) witnessed in
+        // one two-leaf tree: each path's level-0 sibling is the other leaf, upper siblings shared,
+        // so both witnesses compute the SAME root — a consistent shared anchor.
+        let note_a = test_spendable_note(6_000_000_000).note;
+        let note_b = test_spendable_note(7_000_000_000).note;
+        let cmx_a = ExtractedNoteCommitment::from(note_a.commitment());
+        let cmx_b = ExtractedNoteCommitment::from(note_b.commitment());
+
+        let mut auth_path_a = [MerkleHashOrchard::empty_leaf(); NOTE_COMMITMENT_TREE_DEPTH];
+        auth_path_a[0] = MerkleHashOrchard::from_cmx(&cmx_b);
+        let mut auth_path_b = [MerkleHashOrchard::empty_leaf(); NOTE_COMMITMENT_TREE_DEPTH];
+        auth_path_b[0] = MerkleHashOrchard::from_cmx(&cmx_a);
+        let path_a = MerklePath::from_parts(0, auth_path_a);
+        let path_b = MerklePath::from_parts(1, auth_path_b);
+
+        let anchor = path_a.root(cmx_a);
+        assert_eq!(
+            anchor.to_bytes(),
+            path_b.root(cmx_b).to_bytes(),
+            "both witnesses must compute the same anchor"
+        );
+
+        let nf_a = note_a.nullifier(&fvk).to_bytes();
+        let nf_b = note_b.nullifier(&fvk).to_bytes();
+        let spends = vec![
+            SpendableNote {
+                note: note_a,
+                merkle_path: path_a,
+            },
+            SpendableNote {
+                note: note_b,
+                merkle_path: path_b,
+            },
+        ];
+
+        let result = build_identity_create_from_shielded_pool_transition(
+            vec![key_pair(0)],
+            DENOMINATION,
+            PlatformAddress::P2pkh([0u8; 20]),
+            spends,
+            &change_address,
+            &fvk,
+            &ask,
+            anchor,
+            &TestProver,
+            &DummySigner,
+            [0u8; 36],
+            platform_version,
+        )
+        .await
+        .expect("a two-spend build must succeed");
+
+        assert_eq!(
+            result.bundle.actions.len(),
+            2,
+            "two spends + one change output need no padding"
+        );
+        assert_eq!(
+            result.identity_id,
+            derive_identity_id_from_actions(&result.bundle.actions),
+            "identity id must match the consensus derivation over the published actions"
+        );
+        assert_eq!(
+            result.identity_id,
+            identity_id_from_nullifiers(&[nf_a, nf_b]),
+            "with no padding, the published set is exactly the real spends' nullifiers"
+        );
+    }
 }

--- a/packages/rs-dpp/src/shielded/builder/mod.rs
+++ b/packages/rs-dpp/src/shielded/builder/mod.rs
@@ -203,6 +203,44 @@ pub(crate) fn build_spend_bundle<P: OrchardProver>(
     prover: &P,
     extra_sighash_data: &[u8],
 ) -> Result<Bundle<Authorized, i64, DashMemo>, ProtocolError> {
+    let data = extra_sighash_data.to_vec();
+    build_spend_bundle_with(
+        spends,
+        recipient,
+        output_amount,
+        memo,
+        fvk,
+        ask,
+        anchor,
+        prover,
+        move |_| Ok(data),
+    )
+}
+
+/// Like [`build_spend_bundle`], but the extra sighash data is computed by a
+/// closure that receives the built bundle's published action nullifiers (in
+/// on-wire order, INCLUDING any padding actions' dummy nullifiers).
+///
+/// `IdentityCreateFromShieldedPool` needs this: its identity id is
+/// `double_sha256(sorted published nullifiers)`, and `BundleType::DEFAULT`
+/// pads single-spend bundles with a dummy action whose random nullifier only
+/// exists once the bundle is built — deriving the id from the real spends
+/// alone would diverge from the consensus re-derivation.
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn build_spend_bundle_with<P: OrchardProver, F>(
+    spends: Vec<SpendableNote>,
+    recipient: &OrchardAddress,
+    output_amount: u64,
+    memo: [u8; 36],
+    fvk: &FullViewingKey,
+    ask: &SpendAuthorizingKey,
+    anchor: Anchor,
+    prover: &P,
+    extra_sighash_data: F,
+) -> Result<Bundle<Authorized, i64, DashMemo>, ProtocolError>
+where
+    F: FnOnce(&[[u8; 32]]) -> Result<Vec<u8>, ProtocolError>,
+{
     let payment_address = PaymentAddress::from(recipient);
 
     let mut builder = Builder::<DashMemo>::new(BundleType::DEFAULT, anchor);
@@ -224,7 +262,7 @@ pub(crate) fn build_spend_bundle<P: OrchardProver>(
         )
         .map_err(|e| ProtocolError::ShieldedBuildError(format!("failed to add output: {:?}", e)))?;
 
-    prove_and_sign_bundle(
+    prove_and_sign_bundle_with(
         builder,
         prover,
         std::slice::from_ref(ask),
@@ -240,6 +278,23 @@ pub(crate) fn prove_and_sign_bundle<P: OrchardProver>(
     signing_keys: &[SpendAuthorizingKey],
     extra_sighash_data: &[u8],
 ) -> Result<Bundle<Authorized, i64, DashMemo>, ProtocolError> {
+    let data = extra_sighash_data.to_vec();
+    prove_and_sign_bundle_with(builder, prover, signing_keys, move |_| Ok(data))
+}
+
+/// Like [`prove_and_sign_bundle`], but the extra sighash data is computed by
+/// a closure receiving the built bundle's published action nullifiers (see
+/// [`build_spend_bundle_with`]). The closure runs after `Builder::build`
+/// fixes the action set (padding included) and before the sighash is bound.
+pub(crate) fn prove_and_sign_bundle_with<P: OrchardProver, F>(
+    builder: Builder<DashMemo>,
+    prover: &P,
+    signing_keys: &[SpendAuthorizingKey],
+    extra_sighash_data: F,
+) -> Result<Bundle<Authorized, i64, DashMemo>, ProtocolError>
+where
+    F: FnOnce(&[[u8; 32]]) -> Result<Vec<u8>, ProtocolError>,
+{
     let mut rng = OsRng;
 
     let (unauthorized, _) = builder
@@ -249,8 +304,15 @@ pub(crate) fn prove_and_sign_bundle<P: OrchardProver>(
             ProtocolError::ShieldedBuildError("bundle was empty after build".to_string())
         })?;
 
+    let nullifiers: Vec<[u8; 32]> = unauthorized
+        .actions()
+        .iter()
+        .map(|action| action.nullifier().to_bytes())
+        .collect();
+    let extra_sighash_data = extra_sighash_data(&nullifiers)?;
+
     let bundle_commitment: [u8; 32] = unauthorized.commitment().into();
-    let sighash = compute_platform_sighash(&bundle_commitment, extra_sighash_data);
+    let sighash = compute_platform_sighash(&bundle_commitment, &extra_sighash_data);
 
     let proven = unauthorized
         .create_proof(prover.proving_key(), &mut rng)
@@ -548,6 +610,92 @@ mod mod_tests {
             Ok(_) => {}
             Err(ProtocolError::ShieldedBuildError(_)) => {}
             Err(e) => panic!("unexpected error kind: {:?}", e),
+        }
+    }
+
+    /// Builds an output-only builder the way `build_output_only_bundle` does (no merkle
+    /// witness needed): a single output, padded by `BundleType` to the 2-action minimum.
+    fn output_only_builder(amount: u64) -> Builder<DashMemo> {
+        let recipient = test_orchard_address();
+        let payment_address = PaymentAddress::from(&recipient);
+        let mut builder = Builder::<DashMemo>::new(
+            BundleType::Transactional {
+                flags: OrchardFlags::SPENDS_DISABLED,
+                bundle_required: false,
+            },
+            Anchor::empty_tree(),
+        );
+        builder
+            .add_output(
+                None,
+                payment_address,
+                NoteValue::from_raw(amount),
+                [0u8; 36],
+            )
+            .expect("add output");
+        builder
+    }
+
+    // ------------------------------------------------------------------
+    // `prove_and_sign_bundle_with` — the closure contract. The closure MUST
+    // receive the BUILT bundle's published action nullifiers (padding
+    // actions' dummy nullifiers included), in on-wire order: this is what
+    // lets `IdentityCreateFromShieldedPool` derive its identity id from the
+    // same nullifier set consensus re-derives it from. Deriving from the
+    // requested spends alone would diverge whenever the bundle is padded.
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn prove_and_sign_bundle_with_closure_receives_published_nullifiers() {
+        let builder = output_only_builder(10_000);
+
+        let mut recorded: Option<Vec<[u8; 32]>> = None;
+        let bundle = prove_and_sign_bundle_with(builder, &TestProver, &[], |nullifiers| {
+            recorded = Some(nullifiers.to_vec());
+            Ok(vec![])
+        })
+        .expect("output-only bundle should prove");
+
+        let recorded = recorded.expect("the extra-sighash closure must run");
+        // A single output is padded to the 2-action minimum; every padded action
+        // publishes a (dummy) nullifier on the wire.
+        assert_eq!(
+            recorded.len(),
+            2,
+            "closure must see one nullifier per PUBLISHED action (incl. padding)"
+        );
+        assert_ne!(
+            recorded[0], recorded[1],
+            "padding dummy nullifiers are randomized per action"
+        );
+        // The recorded set must be exactly the authorized bundle's published
+        // nullifiers, in the same on-wire order.
+        let published: Vec<[u8; 32]> = bundle
+            .actions()
+            .iter()
+            .map(|action| action.nullifier().to_bytes())
+            .collect();
+        assert_eq!(
+            recorded, published,
+            "closure must receive the bundle's published nullifiers in on-wire order"
+        );
+    }
+
+    #[test]
+    fn prove_and_sign_bundle_with_closure_error_short_circuits_before_proving() {
+        let builder = output_only_builder(10_000);
+
+        let result = prove_and_sign_bundle_with(builder, &TestProver, &[], |_| {
+            Err(ProtocolError::ShieldedBuildError(
+                "closure rejected".to_string(),
+            ))
+        });
+
+        match result {
+            Err(ProtocolError::ShieldedBuildError(msg)) => {
+                assert_eq!(msg, "closure rejected", "closure error must pass through");
+            }
+            other => panic!("expected the closure's error to propagate, got {:?}", other),
         }
     }
 }

--- a/packages/rs-drive-abci/src/execution/validation/state_transition/processor/traits/state.rs
+++ b/packages/rs-drive-abci/src/execution/validation/state_transition/processor/traits/state.rs
@@ -209,18 +209,15 @@ impl StateTransitionStateValidation for StateTransition {
                 )))
             }
             StateTransition::IdentityCreateFromShieldedPool(st) => {
-                // Type 20 does NOT use `has_advanced_structure_validation_with_state` (the cheap
-                // PoP/key-structure checks stay in `validate_shielded_proof`, ahead of Halo 2), so
-                // the processor does not pre-build the action — it always arrives here as `None`.
-                // Build the optimistic SUCCESS action now (the stateless + pool/anchor/nullifier/
-                // balance checks). If that already rejects, forward the rejection; otherwise hand
-                // the success action to `validate_state`, which branches success-vs-Unshield-fallback
-                // on the identity-creation state checks.
-                // Type 20 keeps `has_advanced_structure_validation_with_state() == false`, so the
-                // processor never pre-builds the action — it always arrives `None`, and we build the
-                // optimistic success action here via `transform` (which runs the pool/anchor/
-                // nullifier/balance checks). Fail CLOSED at runtime if that invariant is ever broken:
-                // using a pre-built action would silently route around those checks.
+                // Type 20 keeps `has_advanced_structure_validation_with_state() == false` (the
+                // cheap PoP/key-structure checks stay in `validate_shielded_proof`, ahead of
+                // Halo 2), so the processor never pre-builds the action — it always arrives here
+                // as `None`. Build the optimistic SUCCESS action now via `transform` (the
+                // pool/anchor/nullifier/balance checks); if that already rejects, forward the
+                // rejection, otherwise hand the success action to `validate_state`, which branches
+                // success-vs-Unshield-fallback on the identity-creation state checks. Fail CLOSED
+                // at runtime if the no-pre-build invariant is ever broken: using a pre-built
+                // action would silently route around those checks.
                 let action = match action {
                     Some(_) => {
                         return Err(Error::Execution(ExecutionError::CorruptedCodeExecution(

--- a/packages/rs-platform-wallet/src/wallet/platform_wallet.rs
+++ b/packages/rs-platform-wallet/src/wallet/platform_wallet.rs
@@ -634,7 +634,11 @@ impl PlatformWallet {
                         "invalid platform address: {e}"
                     ))
                 })?;
-        if addr_network != self.sdk.network {
+        // Compare HRPs, not raw networks: testnet/devnet/regtest all share
+        // the "tdash" HRP, so a parsed address can never carry Devnet.
+        if dpp::address_funds::PlatformAddress::hrp_for_network(addr_network)
+            != dpp::address_funds::PlatformAddress::hrp_for_network(self.sdk.network)
+        {
             return Err(PlatformWalletError::ShieldedBuildError(format!(
                 "platform address network mismatch: address {addr_network:?}, wallet {:?}",
                 self.sdk.network


### PR DESCRIPTION
## Issue being fixed or feature implemented

Two client-side shielded bugs found during the paloma E2E run of the full shielded transition matrix (types 15–20), both blocking real-world flows:

1. **Type-20 (`IdentityCreateFromShieldedPool`) was broken for single-note spends.** The builder derived the new identity's id from the *requested spends'* nullifiers, but Orchard's `BundleType::DEFAULT` pads a single-spend bundle to the 2-action minimum — and the padding action's **random dummy nullifier is published on the wire**. Consensus re-derives the id over **all** published action nullifiers, so the builder's id (and the id bound into the Orchard `extra_sighash_data`) diverged from the consensus derivation whenever padding occurred. The builder's own post-proving id-consistency check caught the mismatch and failed the build — but only *after* paying the full Halo 2 proving cost, every time, making every 1-note identity creation unusable.

2. **Unshield was unusable on devnet/regtest.** `PlatformWallet::shielded_unshield_to` compared the parsed output address's network against the SDK network with raw `Network` equality — but bech32m parsing can only ever yield `Mainnet` or `Testnet` (testnet/devnet/regtest all share the `tdash` HRP per DIP-0018), so a `Devnet` wallet rejected every address, including its own.

## What was done?

**Commit 1 — type-20 id derivation from the padded bundle (`rs-dpp`):**
- New `build_spend_bundle_with` / `prove_and_sign_bundle_with` variants that take a closure `FnOnce(&[[u8; 32]]) -> Result<Vec<u8>, ProtocolError>` computing the extra sighash data from the **built** bundle's published action nullifiers — extracted after `Builder::build` fixes the action set (padding included) and before the sighash is bound / proof created. The existing fixed-data functions delegate to the `_with` variants.
- `build_identity_create_from_shielded_pool_transition` now derives the identity id **inside that hook** (`identity_id_from_nullifiers(published_nullifiers)`) and binds the extra sighash data there, so the bound id always equals the consensus re-derivation. The post-build id-consistency assert is kept as a true invariant guard.
- Doc comment corrected (the id is *not* known before the bundle is built when padding occurs) and a stale duplicated comment paragraph deduplicated in drive-abci's `state.rs` type-20 arm (comment-only).

**Commit 2 — unshield address network check by HRP (`rs-platform-wallet`):**
- `shielded_unshield_to` now compares `PlatformAddress::hrp_for_network(addr_network)` against `hrp_for_network(self.sdk.network)` instead of raw networks, matching what the bech32m encoding can actually represent.

## How Has This Been Tested?

New regression tests, all with **real Halo 2 proving** (the cached `TestProver` pattern):

- `single_spend_padded_bundle_derives_id_from_published_nullifiers` — the bug's exact shape: a 1-spend build (witnessed via the same `merkle_path.root(cmx)` anchor pattern production uses) must succeed, be padded to 2 actions, carry the real nullifier among the published set, and produce `identity_id == derive_identity_id_from_actions(actions)` while `!= identity_id_from_nullifiers([real_nullifier])` — proving the dummy participates. Pre-fix this failed the post-proving consistency check.
- `two_spend_unpadded_bundle_id_matches_real_nullifier_derivation` — no padding: the published set equals the real spends', and both derivations agree.
- `prove_and_sign_bundle_with_closure_receives_published_nullifiers` — the closure contract: it runs once and receives exactly the authorized bundle's published nullifiers (one per action, padding included, on-wire order).
- `prove_and_sign_bundle_with_closure_error_short_circuits_before_proving` — closure errors propagate before any proving work.
- `hrp_is_shared_across_all_non_mainnet_networks` — pins the DIP-0018 premise the wallet check now relies on (testnet/devnet/regtest share `tdash`; mainnet differs).

`cargo check --workspace --all-targets` green; `cargo check -p dpp / -p platform-wallet --all-features --tests` green; clippy clean on the touched crates; existing shielded builder suites still pass.

Both fixes were also exercised end-to-end on devnet paloma during the shielded matrix run: post-fix, unshield (type 17) completed pool → platform-address, and the type-20 built, proved, and broadcast successfully with a single-note spend.

## Breaking Changes

None. Client-side builder/wallet fixes only — no consensus, serialization, or protocol-version changes. `build_spend_bundle` / `prove_and_sign_bundle` keep their existing signatures (the `_with` variants are additive, crate-internal).

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [x] I have made corresponding changes to the documentation if needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed network address validation that was incorrectly rejecting valid testnet/devnet/regtest addresses due to HRP handling

* **Refactor**
  * Refactored shielded bundle builders for improved sighash computation
  * Updated identity derivation logic in shielded pool operations

* **Tests**
  * Added network address validation tests

<!-- end of auto-generated comment: release notes by coderabbit.ai -->