### PR TITLE
test(drive-abci): assert check_tx never mutates committed grovedb state

### DIFF
--- a/packages/rs-drive-abci/src/execution/check_tx/mod.rs
+++ b/packages/rs-drive-abci/src/execution/check_tx/mod.rs
@@ -95,13 +95,41 @@ where
         platform_ref: &PlatformRef<C>,
         platform_version: &PlatformVersion,
     ) -> Result<ValidationResult<CheckTxResult, ConsensusError>, Error> {
-        match platform_version.drive_abci.methods.engine.check_tx {
+        // CheckTx runs OUTSIDE any block transaction, so it must NEVER mutate committed
+        // GroveDB state: an eager write here commits straight to disk, diverging the on-disk
+        // root from the signed app hash and deterministically halting the chain (devnet
+        // paloma, height 788 — see test::helpers::state_mutation_guard). In tests, EVERY
+        // check_tx call asserts the committed root hash is byte-identical around the call, so
+        // any state-transition fixture exercised through check_tx picks up the invariant
+        // automatically.
+        #[cfg(test)]
+        let committed_root_hash_before_check_tx =
+            crate::test::helpers::state_mutation_guard::committed_root_hash(
+                &self.drive,
+                platform_version,
+            );
+
+        let result = match platform_version.drive_abci.methods.engine.check_tx {
             0 => self.check_tx_v0(raw_tx, check_tx_level, platform_ref, platform_version),
             version => Err(Error::Execution(ExecutionError::UnknownVersionMismatch {
                 method: "check_tx".to_string(),
                 known_versions: vec![0],
                 received: version,
             })),
-        }
+        };
+
+        #[cfg(test)]
+        assert_eq!(
+            committed_root_hash_before_check_tx,
+            crate::test::helpers::state_mutation_guard::committed_root_hash(
+                &self.drive,
+                platform_version,
+            ),
+            "check_tx mutated committed grovedb state: it runs with transaction = None, so an \
+             eager write on this path commits straight to disk, diverging the root from the \
+             signed app hash and halting the chain (devnet paloma, height 788)"
+        );
+
+        result
     }
 }

--- a/packages/rs-drive-abci/src/execution/check_tx/v0/mod.rs
+++ b/packages/rs-drive-abci/src/execution/check_tx/v0/mod.rs
@@ -3820,4 +3820,298 @@ mod tests {
             ))
         ));
     }
+
+    /// CheckTx must NEVER mutate committed GroveDB state — the broad-sweep guard for the
+    /// 2026-06-10 devnet paloma chain halt (height 788).
+    ///
+    /// CheckTx fee estimation runs `validate_fees_of_event(..., transaction: None, ...)` (see
+    /// `check_tx_v0` above), so an eager GroveDB write anywhere on the CheckTx path (e.g. inside
+    /// a drive-op converter, as the pre-#3823 shielded `InsertNullifiers` arm did with
+    /// `store_nullifiers_for_block`) commits straight to disk on every node that validates the
+    /// gossiped transition. The on-disk root then diverges from the signed app hash and every
+    /// proposer panics with "drive and platform state app hash mismatch" — a chain halt that
+    /// restarts cannot heal because the write is durable. This test covers the identity-paid
+    /// (`ExecutionEvent::Paid`) estimation arm; the asset-lock arm is covered by
+    /// `check_tx_does_not_mutate_committed_state_identity_top_up` below, and the exact type-20
+    /// shape that halted paloma by `check_tx_fee_estimation_does_not_mutate_committed_state` in
+    /// `identity_create_from_shielded_pool/tests.rs`.
+    #[test]
+    fn check_tx_does_not_mutate_committed_state_data_contract_create() {
+        use crate::test::helpers::state_mutation_guard::assert_committed_root_hash_unchanged;
+
+        let platform_config = PlatformConfig {
+            testing_configs: PlatformTestConfig {
+                disable_instant_lock_signature_verification: true,
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+
+        let platform = TestPlatformBuilder::new()
+            .with_config(platform_config)
+            .build_with_mock_rpc();
+
+        let platform_state = platform.state.load();
+        let protocol_version = platform_state.current_protocol_version_in_consensus();
+        let platform_version = PlatformVersion::get(protocol_version).unwrap();
+
+        let (key, private_key) = IdentityPublicKey::random_ecdsa_critical_level_authentication_key(
+            1,
+            Some(1),
+            platform_version,
+        )
+        .expect("expected to get key pair");
+
+        platform
+            .drive
+            .create_initial_state_structure(None, platform_version)
+            .expect("expected to create state structure");
+        let identity: Identity = IdentityV0 {
+            id: Identifier::new([
+                158, 113, 180, 126, 91, 83, 62, 44, 83, 54, 97, 88, 240, 215, 84, 139, 167, 156,
+                166, 203, 222, 4, 64, 31, 215, 199, 149, 151, 190, 246, 251, 44,
+            ]),
+            public_keys: BTreeMap::from([(1, key.clone())]),
+            balance: 25_000_000_000, // 0.25 Dash
+            revision: 0,
+        }
+        .into();
+
+        let dashpay = get_dashpay_contract_fixture(Some(identity.id()), 1, protocol_version);
+        let mut create_contract_state_transition: StateTransition = dashpay
+            .try_into_platform_versioned(platform_version)
+            .expect("expected a state transition");
+        create_contract_state_transition
+            .sign(&key, private_key.as_slice(), &NativeBlsModule)
+            .expect("expected to sign transition");
+        let serialized = create_contract_state_transition
+            .serialize_to_bytes()
+            .expect("serialized state transition");
+        platform
+            .drive
+            .add_new_identity(
+                identity,
+                false,
+                &BlockInfo::default(),
+                true,
+                None,
+                platform_version,
+            )
+            .expect("expected to insert identity");
+
+        let platform_ref = PlatformRef {
+            drive: &platform.drive,
+            state: &platform_state,
+            config: &platform.config,
+            core_rpc: &platform.core_rpc,
+        };
+
+        let first_time_result = assert_committed_root_hash_unchanged(
+            &platform.drive,
+            platform_version,
+            "check_tx FirstTimeCheck (data contract create)",
+            || {
+                platform.check_tx(
+                    serialized.as_slice(),
+                    FirstTimeCheck,
+                    &platform_ref,
+                    platform_version,
+                )
+            },
+        )
+        .expect("expected to check tx");
+        // The fixture must stay a VALID transition: an early consensus rejection would skip the
+        // fee-estimation stage and the invariant would be checked against a no-op.
+        assert!(
+            first_time_result.is_valid(),
+            "fixture must remain valid so fee estimation actually runs: {:?}",
+            first_time_result.errors
+        );
+
+        let recheck_result = assert_committed_root_hash_unchanged(
+            &platform.drive,
+            platform_version,
+            "check_tx Recheck (data contract create)",
+            || {
+                platform.check_tx(
+                    serialized.as_slice(),
+                    Recheck,
+                    &platform_ref,
+                    platform_version,
+                )
+            },
+        )
+        .expect("expected to check tx");
+        assert!(recheck_result.is_valid());
+    }
+
+    /// CheckTx for an asset-lock-funded transition (identity top up) must not mutate committed
+    /// GroveDB state. Same invariant as
+    /// `check_tx_does_not_mutate_committed_state_data_contract_create` (see its docs for the
+    /// paloma height-788 halt), exercised through the `PaidFromAssetLock` fee-estimation arm and
+    /// the asset-lock Recheck path.
+    #[tokio::test]
+    async fn check_tx_does_not_mutate_committed_state_identity_top_up() {
+        use crate::test::helpers::state_mutation_guard::assert_committed_root_hash_unchanged;
+
+        let platform_config = PlatformConfig {
+            testing_configs: PlatformTestConfig {
+                disable_instant_lock_signature_verification: true,
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+
+        let platform = TestPlatformBuilder::new()
+            .with_config(platform_config)
+            .build_with_mock_rpc();
+
+        let platform_state = platform.state.load();
+        let platform_version = platform_state.current_platform_version().unwrap();
+
+        let platform_ref = PlatformRef {
+            drive: &platform.drive,
+            state: &platform_state,
+            config: &platform.config,
+            core_rpc: &platform.core_rpc,
+        };
+
+        let mut signer = SimpleSigner::default();
+
+        let mut rng = StdRng::seed_from_u64(567);
+
+        let (master_key, master_private_key) =
+            IdentityPublicKey::random_ecdsa_master_authentication_key(0, Some(3), platform_version)
+                .expect("expected to get key pair");
+
+        signer.add_identity_public_key(master_key.clone(), master_private_key);
+
+        let (key, private_key) = IdentityPublicKey::random_ecdsa_critical_level_authentication_key(
+            1,
+            Some(19),
+            platform_version,
+        )
+        .expect("expected to get key pair");
+
+        signer.add_identity_public_key(key.clone(), private_key);
+
+        let (_, pk) = ECDSA_SECP256K1
+            .random_public_and_private_key_data(&mut rng, platform_version)
+            .unwrap();
+
+        let asset_lock_proof = instant_asset_lock_proof_fixture(
+            Some(PrivateKey::from_byte_array(&pk, Network::Testnet).unwrap()),
+            None,
+        );
+
+        let identifier = asset_lock_proof
+            .create_identifier()
+            .expect("expected an identifier");
+
+        let identity: Identity = IdentityV0 {
+            id: identifier,
+            public_keys: BTreeMap::from([(0, master_key.clone()), (1, key.clone())]),
+            balance: 1000000000,
+            revision: 0,
+        }
+        .into();
+
+        let identity_create_transition: StateTransition =
+            IdentityCreateTransition::try_from_identity_with_signer_and_private_key(
+                &identity,
+                asset_lock_proof,
+                pk.as_slice(),
+                &signer,
+                &NativeBlsModule,
+                0,
+                platform_version,
+            )
+            .await
+            .expect("expected an identity create transition");
+
+        let identity_create_serialized_transition = identity_create_transition
+            .serialize_to_bytes()
+            .expect("serialized state transition");
+
+        platform
+            .drive
+            .create_initial_state_structure(None, platform_version)
+            .expect("expected to create state structure");
+
+        let transaction = platform.drive.grove.start_transaction();
+
+        let validation_result = platform
+            .execute_tx(identity_create_serialized_transition, &transaction)
+            .expect("expected to execute identity_create tx");
+        assert!(matches!(validation_result, SuccessfulPaidExecution(..)));
+
+        platform
+            .drive
+            .grove
+            .commit_transaction(transaction)
+            .unwrap()
+            .expect("expected to commit transaction");
+
+        let (_, pk) = ECDSA_SECP256K1
+            .random_public_and_private_key_data(&mut rng, platform_version)
+            .unwrap();
+
+        let asset_lock_proof_top_up = instant_asset_lock_proof_fixture(
+            Some(PrivateKey::from_byte_array(&pk, Network::Testnet).unwrap()),
+            None,
+        );
+
+        let identity_top_up_transition: StateTransition =
+            IdentityTopUpTransition::try_from_identity_with_private_key(
+                &identity,
+                asset_lock_proof_top_up,
+                pk.as_slice(),
+                0,
+                platform_version,
+                None,
+            )
+            .expect("expected an identity create transition");
+
+        let identity_top_up_serialized_transition = identity_top_up_transition
+            .serialize_to_bytes()
+            .expect("serialized state transition");
+
+        let first_time_result = assert_committed_root_hash_unchanged(
+            &platform.drive,
+            platform_version,
+            "check_tx FirstTimeCheck (identity top up)",
+            || {
+                platform.check_tx(
+                    identity_top_up_serialized_transition.as_slice(),
+                    FirstTimeCheck,
+                    &platform_ref,
+                    platform_version,
+                )
+            },
+        )
+        .expect("expected to check tx");
+        // The fixture must stay a VALID transition: an early consensus rejection would skip the
+        // fee-estimation stage and the invariant would be checked against a no-op.
+        assert!(
+            first_time_result.is_valid(),
+            "fixture must remain valid so fee estimation actually runs: {:?}",
+            first_time_result.errors
+        );
+
+        let recheck_result = assert_committed_root_hash_unchanged(
+            &platform.drive,
+            platform_version,
+            "check_tx Recheck (identity top up)",
+            || {
+                platform.check_tx(
+                    identity_top_up_serialized_transition.as_slice(),
+                    Recheck,
+                    &platform_ref,
+                    platform_version,
+                )
+            },
+        )
+        .expect("expected to check tx");
+        assert!(recheck_result.is_valid());
+    }
 }

--- a/packages/rs-drive-abci/src/execution/mod.rs
+++ b/packages/rs-drive-abci/src/execution/mod.rs
@@ -1,5 +1,5 @@
 /// Check tx module
-mod check_tx;
+pub(crate) mod check_tx;
 /// Engine module
 pub mod engine;
 /// platform execution events

--- a/packages/rs-drive-abci/src/execution/platform_events/state_transition_processing/validate_fees_of_event/mod.rs
+++ b/packages/rs-drive-abci/src/execution/platform_events/state_transition_processing/validate_fees_of_event/mod.rs
@@ -44,7 +44,22 @@ where
         platform_version: &PlatformVersion,
         previous_fee_versions: &CachedEpochIndexFeeVersions,
     ) -> Result<ConsensusValidationResult<FeeResult>, Error> {
-        match platform_version
+        // Fee validation with `transaction: None` is the CheckTx estimation mode: it runs
+        // OUTSIDE any block transaction, so it must NEVER mutate committed GroveDB state —
+        // an eager write inside an op converter here commits straight to disk and halts the
+        // chain (devnet paloma, height 788 — see test::helpers::state_mutation_guard). In
+        // tests, every transactionless call asserts the committed root hash is byte-identical
+        // around the call, so every event/op shape estimated in tests picks up the invariant
+        // automatically.
+        #[cfg(test)]
+        let committed_root_hash_before_estimation = transaction.is_none().then(|| {
+            crate::test::helpers::state_mutation_guard::committed_root_hash(
+                &self.drive,
+                platform_version,
+            )
+        });
+
+        let result = match platform_version
             .drive_abci
             .methods
             .state_transition_processing
@@ -62,6 +77,23 @@ where
                 known_versions: vec![0],
                 received: version,
             })),
+        };
+
+        #[cfg(test)]
+        if let Some(root_hash_before) = committed_root_hash_before_estimation {
+            assert_eq!(
+                root_hash_before,
+                crate::test::helpers::state_mutation_guard::committed_root_hash(
+                    &self.drive,
+                    platform_version,
+                ),
+                "validate_fees_of_event with transaction = None mutated committed grovedb \
+                 state: an eager write on the estimation path commits straight to disk, \
+                 diverging the root from the signed app hash and halting the chain (devnet \
+                 paloma, height 788)"
+            );
         }
+
+        result
     }
 }

--- a/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/address_credit_withdrawal/tests.rs
+++ b/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/address_credit_withdrawal/tests.rs
@@ -985,6 +985,21 @@ mod tests {
             let platform_state = platform.state.load();
             let transaction = platform.drive.grove.start_transaction();
 
+            // CheckTx root-invariance guard (devnet paloma h788): `check_tx` asserts under
+            // cfg(test) that it never mutates committed grovedb state, so running the
+            // canonical valid fixture through it pins the invariant for this transition type.
+            {
+                use dpp::serialization::PlatformSerializable;
+                let guard_serialized_transition = transition
+                    .serialize_to_bytes()
+                    .expect("expected to serialize transition for the check_tx guard");
+                crate::test::helpers::state_mutation_guard::assert_check_tx_valid_at_all_levels(
+                    &platform,
+                    &guard_serialized_transition,
+                    "address credit withdrawal",
+                );
+            }
+
             let processing_result = platform
                 .platform
                 .process_raw_state_transitions(

--- a/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/address_funding_from_asset_lock/tests.rs
+++ b/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/address_funding_from_asset_lock/tests.rs
@@ -1026,6 +1026,21 @@ mod tests {
             let platform_state = platform.state.load();
             let transaction = platform.drive.grove.start_transaction();
 
+            // CheckTx root-invariance guard (devnet paloma h788): `check_tx` asserts under
+            // cfg(test) that it never mutates committed grovedb state, so running the
+            // canonical valid fixture through it pins the invariant for this transition type.
+            {
+                use dpp::serialization::PlatformSerializable;
+                let guard_serialized_transition = transition
+                    .serialize_to_bytes()
+                    .expect("expected to serialize transition for the check_tx guard");
+                crate::test::helpers::state_mutation_guard::assert_check_tx_valid_at_all_levels(
+                    &platform,
+                    &guard_serialized_transition,
+                    "address funding from asset lock",
+                );
+            }
+
             let processing_result = platform
                 .platform
                 .process_raw_state_transitions(

--- a/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/address_funds_transfer/tests.rs
+++ b/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/address_funds_transfer/tests.rs
@@ -1425,6 +1425,21 @@ mod tests {
 
             let transaction = platform.drive.grove.start_transaction();
 
+            // CheckTx root-invariance guard (devnet paloma h788): `check_tx` asserts under
+            // cfg(test) that it never mutates committed grovedb state, so running the
+            // canonical valid fixture through it pins the invariant for this transition type.
+            {
+                use dpp::serialization::PlatformSerializable;
+                let guard_serialized_transition = transition
+                    .serialize_to_bytes()
+                    .expect("expected to serialize transition for the check_tx guard");
+                crate::test::helpers::state_mutation_guard::assert_check_tx_valid_at_all_levels(
+                    &platform,
+                    &guard_serialized_transition,
+                    "address funds transfer",
+                );
+            }
+
             let processing_result = platform
                 .platform
                 .process_raw_state_transitions(

--- a/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/identity_create_from_addresses/tests.rs
+++ b/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/identity_create_from_addresses/tests.rs
@@ -1037,6 +1037,21 @@ mod tests {
             let platform_state = platform.state.load();
             let transaction = platform.drive.grove.start_transaction();
 
+            // CheckTx root-invariance guard (devnet paloma h788): `check_tx` asserts under
+            // cfg(test) that it never mutates committed grovedb state, so running the
+            // canonical valid fixture through it pins the invariant for this transition type.
+            {
+                use dpp::serialization::PlatformSerializable;
+                let guard_serialized_transition = transition
+                    .serialize_to_bytes()
+                    .expect("expected to serialize transition for the check_tx guard");
+                crate::test::helpers::state_mutation_guard::assert_check_tx_valid_at_all_levels(
+                    &platform,
+                    &guard_serialized_transition,
+                    "identity create from addresses",
+                );
+            }
+
             let processing_result = platform
                 .platform
                 .process_raw_state_transitions(

--- a/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/identity_create_from_shielded_pool/tests.rs
+++ b/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/identity_create_from_shielded_pool/tests.rs
@@ -533,7 +533,23 @@ fn check_tx_fee_estimation_does_not_mutate_committed_state() {
         .minimum_pool_notes_for_outgoing;
     insert_dummy_encrypted_notes(&platform, min_notes.max(1));
 
-    let st = transition(vec![master_key()], vec![action(40), action(41)]);
+    // Unlike the validate_state tests above, fee estimation CONVERTS the `AddNewIdentity` op,
+    // which parses the key bytes — so the key must be a real secp256k1 point, not dummy zeros.
+    let (valid_master_key, _) =
+        IdentityPublicKey::random_ecdsa_master_authentication_key(0, Some(11), platform_version)
+            .expect("expected a valid master key");
+    let key_in_creation = IdentityPublicKeyInCreation::V0(IdentityPublicKeyInCreationV0 {
+        id: 0,
+        key_type: valid_master_key.key_type(),
+        purpose: valid_master_key.purpose(),
+        security_level: valid_master_key.security_level(),
+        contract_bounds: None,
+        read_only: false,
+        data: valid_master_key.data().clone(),
+        signature: BinaryData::default(),
+    });
+
+    let st = transition(vec![key_in_creation], vec![action(40), action(41)]);
     let mut execution_context =
         StateTransitionExecutionContext::default_for_platform_version(platform_version)
             .expect("execution context");

--- a/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/identity_create_from_shielded_pool/tests.rs
+++ b/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/identity_create_from_shielded_pool/tests.rs
@@ -497,6 +497,108 @@ fn failure_path_charge_executes_through_execute_event() {
     );
 }
 
+/// BLOCKING regression for the 2026-06-10 devnet paloma chain halt (height 788): CheckTx fee
+/// estimation must NEVER mutate committed GroveDB state.
+///
+/// `check_tx_v0` estimates fees via `validate_fees_of_event(event, last_block_info,
+/// transaction: None, ...)` -> `apply_drive_operations(ops, apply: false, ..., transaction: None)`.
+/// Pre-#3823, the `ShieldedPoolOperationType::InsertNullifiers` low-level converter arm eagerly
+/// called `drive.store_nullifiers_for_block(...)` — a direct write — with whatever
+/// `TransactionArg` it was handed, on the assumption it always ran under the block transaction.
+/// During CheckTx that argument is `None`, so the eager write committed DIRECTLY to disk on every
+/// node that validated the gossiped type-20 transition; the on-disk root diverged from the signed
+/// app hash and every proposer panicked ("drive and platform state app hash mismatch" in
+/// `prepare_proposal.rs`) — and restarts panic forever in `info.rs` because the write is durable.
+/// #3823 made the converter pure; this test pins the invariant for the exact event/op shape that
+/// halted paloma. No Halo 2 proving is needed — the event is built from a synthetic action.
+#[test]
+fn check_tx_fee_estimation_does_not_mutate_committed_state() {
+    use crate::execution::types::execution_event::ExecutionEvent;
+    use crate::platform_types::platform_state::PlatformStateV0Methods;
+    use crate::test::helpers::state_mutation_guard::assert_committed_root_hash_unchanged;
+    use dpp::block::epoch::Epoch;
+    use dpp::fee::default_costs::CachedEpochIndexFeeVersions;
+    use drive::util::batch::drive_op_batch::ShieldedPoolOperationType;
+    use drive::util::batch::DriveOperation;
+
+    let platform_version = PlatformVersion::latest();
+    let platform = setup_platform();
+
+    set_pool_total_balance(&platform, DENOMINATION * 10);
+    insert_anchor_into_state(&platform, &ANCHOR);
+    let min_notes = platform_version
+        .drive_abci
+        .validation_and_processing
+        .event_constants
+        .minimum_pool_notes_for_outgoing;
+    insert_dummy_encrypted_notes(&platform, min_notes.max(1));
+
+    let st = transition(vec![master_key()], vec![action(40), action(41)]);
+    let mut execution_context =
+        StateTransitionExecutionContext::default_for_platform_version(platform_version)
+            .expect("execution context");
+    let success_action =
+        build_success_action(&platform, &st, &mut execution_context, platform_version);
+
+    let event = ExecutionEvent::create_from_state_transition_action(
+        StateTransitionAction::IdentityCreateFromShieldedPoolAction(success_action),
+        None,
+        &Epoch::new(0).unwrap(),
+        execution_context,
+        platform_version,
+    )
+    .expect("create execution event");
+
+    // The event must carry ALL the shielded converter ops that ran on paloma — InsertNullifiers
+    // (the arm that held the eager write), InsertNote and UpdateTotalBalance — so estimation
+    // exercises every arm of the shielded low-level converter.
+    let ExecutionEvent::PaidFromShieldedPoolToNewIdentity { operations, .. } = &event else {
+        panic!("expected a PaidFromShieldedPoolToNewIdentity execution event");
+    };
+    let has_op = |pred: fn(&ShieldedPoolOperationType) -> bool| {
+        operations.iter().any(|op| match op {
+            DriveOperation::ShieldedPoolOperation(shielded_op) => pred(shielded_op),
+            _ => false,
+        })
+    };
+    assert!(
+        has_op(|op| matches!(op, ShieldedPoolOperationType::InsertNullifiers { .. })),
+        "event must carry InsertNullifiers (the arm that eagerly wrote pre-#3823)"
+    );
+    assert!(
+        has_op(|op| matches!(op, ShieldedPoolOperationType::InsertNote { .. })),
+        "event must carry InsertNote"
+    );
+    assert!(
+        has_op(|op| matches!(op, ShieldedPoolOperationType::UpdateTotalBalance { .. })),
+        "event must carry UpdateTotalBalance"
+    );
+
+    // Run the EXACT CheckTx estimation call (transaction = None, apply = false) and assert the
+    // committed root hash is byte-identical: a single eager write in any converter arm trips this.
+    let platform_state = platform.state.load();
+    let fee_versions = CachedEpochIndexFeeVersions::new();
+    let fee_result = assert_committed_root_hash_unchanged(
+        &platform.drive,
+        platform_version,
+        "validate_fees_of_event (type-20 pool->new-identity, CheckTx estimation mode)",
+        || {
+            platform.platform.validate_fees_of_event(
+                &event,
+                platform_state.last_block_info(),
+                None,
+                platform_version,
+                &fee_versions,
+            )
+        },
+    )
+    .expect("fee estimation must not error");
+    assert!(
+        fee_result.data.is_some(),
+        "estimation must produce a fee result"
+    );
+}
+
 /// Sum-tree credit-conservation regression for the pool->new-identity exit.
 ///
 /// Applies the converter's high-level drive operations through a REAL Drive and asserts the

--- a/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/identity_credit_transfer/mod.rs
+++ b/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/identity_credit_transfer/mod.rs
@@ -583,6 +583,15 @@ mod tests {
         )
         .await;
 
+        // CheckTx root-invariance guard (devnet paloma h788): `check_tx` asserts under
+        // cfg(test) that it never mutates committed grovedb state, so running the canonical
+        // valid fixture through it pins the invariant for this transition type.
+        crate::test::helpers::state_mutation_guard::assert_check_tx_valid_at_all_levels(
+            &platform,
+            &transfer_bytes,
+            "identity credit transfer",
+        );
+
         let transaction = platform.drive.grove.start_transaction();
 
         let processing_result = platform

--- a/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/identity_credit_transfer_to_addresses/tests.rs
+++ b/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/identity_credit_transfer_to_addresses/tests.rs
@@ -479,6 +479,21 @@ mod tests {
             let platform_state = platform.state.load();
             let transaction = platform.drive.grove.start_transaction();
 
+            // CheckTx root-invariance guard (devnet paloma h788): `check_tx` asserts under
+            // cfg(test) that it never mutates committed grovedb state, so running the
+            // canonical valid fixture through it pins the invariant for this transition type.
+            {
+                use dpp::serialization::PlatformSerializable;
+                let guard_serialized_transition = transition
+                    .serialize_to_bytes()
+                    .expect("expected to serialize transition for the check_tx guard");
+                crate::test::helpers::state_mutation_guard::assert_check_tx_valid_at_all_levels(
+                    &platform,
+                    &guard_serialized_transition,
+                    "identity credit transfer to addresses",
+                );
+            }
+
             let processing_result = platform
                 .platform
                 .process_raw_state_transitions(

--- a/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/identity_credit_withdrawal/mod.rs
+++ b/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/identity_credit_withdrawal/mod.rs
@@ -258,6 +258,15 @@ mod tests {
             .serialize_to_bytes()
             .expect("expected documents batch serialized state transition");
 
+        // CheckTx root-invariance guard (devnet paloma h788): `check_tx` asserts under
+        // cfg(test) that it never mutates committed grovedb state, so running the canonical
+        // valid fixture through it pins the invariant for this transition type.
+        crate::test::helpers::state_mutation_guard::assert_check_tx_valid_at_all_levels(
+            &platform,
+            &credit_withdrawal_transition_serialized_transition,
+            "identity credit withdrawal",
+        );
+
         let transaction = platform.drive.grove.start_transaction();
 
         let processing_result = platform

--- a/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/identity_top_up_from_addresses/tests.rs
+++ b/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/identity_top_up_from_addresses/tests.rs
@@ -1514,6 +1514,21 @@ mod tests {
             let platform_state = platform.state.load();
             let transaction = platform.drive.grove.start_transaction();
 
+            // CheckTx root-invariance guard (devnet paloma h788): `check_tx` asserts under
+            // cfg(test) that it never mutates committed grovedb state, so running the
+            // canonical valid fixture through it pins the invariant for this transition type.
+            {
+                use dpp::serialization::PlatformSerializable;
+                let guard_serialized_transition = transition
+                    .serialize_to_bytes()
+                    .expect("expected to serialize transition for the check_tx guard");
+                crate::test::helpers::state_mutation_guard::assert_check_tx_valid_at_all_levels(
+                    &platform,
+                    &guard_serialized_transition,
+                    "identity top up from addresses",
+                );
+            }
+
             let processing_result = platform
                 .platform
                 .process_raw_state_transitions(

--- a/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/mod.rs
+++ b/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/mod.rs
@@ -2143,6 +2143,17 @@ pub(in crate::execution) mod tests {
             .serialize_to_bytes()
             .expect("expected documents batch serialized state transition");
 
+        // CheckTx root-invariance guard (devnet paloma h788): `check_tx` asserts under
+        // cfg(test) that it never mutates committed grovedb state, so every valid vote
+        // fixture going through this shared helper pins the invariant for masternode votes.
+        if expect_error.is_none() {
+            crate::test::helpers::state_mutation_guard::assert_check_tx_valid_at_all_levels(
+                platform,
+                &masternode_vote_serialized_transition,
+                "masternode vote",
+            );
+        }
+
         let transaction = platform.drive.grove.start_transaction();
 
         let processing_result = platform

--- a/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/shield/tests.rs
+++ b/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/shield/tests.rs
@@ -857,6 +857,21 @@ mod tests {
                 v0.input_witnesses = witnesses;
             }
 
+            // CheckTx root-invariance guard (devnet paloma h788): `check_tx` asserts under
+            // cfg(test) that it never mutates committed grovedb state, so running the
+            // canonical valid fixture through it pins the invariant for this transition type.
+            {
+                use dpp::serialization::PlatformSerializable;
+                let guard_serialized_transition = st
+                    .serialize_to_bytes()
+                    .expect("expected to serialize transition for the check_tx guard");
+                crate::test::helpers::state_mutation_guard::assert_check_tx_valid_at_all_levels(
+                    &platform,
+                    &guard_serialized_transition,
+                    "shield",
+                );
+            }
+
             let processing_result = process_transition(&platform, st, platform_version);
 
             assert_matches!(

--- a/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/shield_from_asset_lock/tests.rs
+++ b/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/shield_from_asset_lock/tests.rs
@@ -547,6 +547,21 @@ mod tests {
                 binding_sig,
             );
 
+            // CheckTx root-invariance guard (devnet paloma h788): `check_tx` asserts under
+            // cfg(test) that it never mutates committed grovedb state, so running the
+            // canonical valid fixture through it pins the invariant for this transition type.
+            {
+                use dpp::serialization::PlatformSerializable;
+                let guard_serialized_transition = transition
+                    .serialize_to_bytes()
+                    .expect("expected to serialize transition for the check_tx guard");
+                crate::test::helpers::state_mutation_guard::assert_check_tx_valid_at_all_levels(
+                    &platform,
+                    &guard_serialized_transition,
+                    "shield from asset lock",
+                );
+            }
+
             let processing_result = process_transition(&platform, transition, platform_version);
 
             assert_matches!(

--- a/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/shielded_transfer/tests.rs
+++ b/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/shielded_transfer/tests.rs
@@ -372,6 +372,21 @@ mod tests {
                 binding_sig,
             );
 
+            // CheckTx root-invariance guard (devnet paloma h788): `check_tx` asserts under
+            // cfg(test) that it never mutates committed grovedb state, so running the
+            // canonical valid fixture through it pins the invariant for this transition type.
+            {
+                use dpp::serialization::PlatformSerializable;
+                let guard_serialized_transition = transition
+                    .serialize_to_bytes()
+                    .expect("expected to serialize transition for the check_tx guard");
+                crate::test::helpers::state_mutation_guard::assert_check_tx_valid_at_all_levels(
+                    &platform,
+                    &guard_serialized_transition,
+                    "shielded transfer",
+                );
+            }
+
             let processing_result = process_transition(&platform, transition, platform_version);
 
             assert_matches!(

--- a/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/shielded_withdrawal/tests.rs
+++ b/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/shielded_withdrawal/tests.rs
@@ -488,6 +488,21 @@ mod tests {
                 output_script,
             );
 
+            // CheckTx root-invariance guard (devnet paloma h788): `check_tx` asserts under
+            // cfg(test) that it never mutates committed grovedb state, so running the
+            // canonical valid fixture through it pins the invariant for this transition type.
+            {
+                use dpp::serialization::PlatformSerializable;
+                let guard_serialized_transition = transition
+                    .serialize_to_bytes()
+                    .expect("expected to serialize transition for the check_tx guard");
+                crate::test::helpers::state_mutation_guard::assert_check_tx_valid_at_all_levels(
+                    &platform,
+                    &guard_serialized_transition,
+                    "shielded withdrawal",
+                );
+            }
+
             let processing_result = process_transition(&platform, transition, platform_version);
 
             assert_matches!(

--- a/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/unshield/tests.rs
+++ b/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/unshield/tests.rs
@@ -522,6 +522,21 @@ mod tests {
                 binding_sig,
             );
 
+            // CheckTx root-invariance guard (devnet paloma h788): `check_tx` asserts under
+            // cfg(test) that it never mutates committed grovedb state, so running the
+            // canonical valid fixture through it pins the invariant for this transition type.
+            {
+                use dpp::serialization::PlatformSerializable;
+                let guard_serialized_transition = transition
+                    .serialize_to_bytes()
+                    .expect("expected to serialize transition for the check_tx guard");
+                crate::test::helpers::state_mutation_guard::assert_check_tx_valid_at_all_levels(
+                    &platform,
+                    &guard_serialized_transition,
+                    "unshield",
+                );
+            }
+
             let processing_result = process_transition(&platform, transition, platform_version);
 
             assert_matches!(

--- a/packages/rs-drive-abci/src/test/helpers/mod.rs
+++ b/packages/rs-drive-abci/src/test/helpers/mod.rs
@@ -3,6 +3,8 @@
 pub mod fast_forward_to_block;
 pub mod fee_pools;
 pub mod setup;
+#[cfg(test)]
+pub mod state_mutation_guard;
 // TODO: Move tests to appropriate place
 
 #[cfg(test)]

--- a/packages/rs-drive-abci/src/test/helpers/state_mutation_guard.rs
+++ b/packages/rs-drive-abci/src/test/helpers/state_mutation_guard.rs
@@ -1,0 +1,52 @@
+//! CheckTx committed-state mutation guard.
+//!
+//! CheckTx (mempool validation and fee estimation) runs OUTSIDE any block transaction:
+//! `check_tx_v0` calls `validate_fees_of_event(..., transaction: None, ...)`, which applies the
+//! event's drive operations in estimation mode (`apply: false`). Any code on that path that
+//! eagerly writes to GroveDB instead of returning operations therefore commits DIRECTLY to disk
+//! on every node that validates the gossiped transition. The on-disk root hash then diverges from
+//! the last signed app hash, every proposer panics with "drive and platform state app hash
+//! mismatch" (`abci/handler/prepare_proposal.rs`), and restarts panic forever in
+//! `abci/handler/info.rs` because the write is durable.
+//!
+//! This exact class halted devnet paloma at height 788 on 2026-06-10: pre-#3823, the
+//! `ShieldedPoolOperationType::InsertNullifiers` low-level converter arm eagerly called
+//! `drive.store_nullifiers_for_block(...)` with whatever `TransactionArg` it was handed (`None`
+//! during CheckTx fee estimation). #3823 made the converter pure; the helpers here guard the
+//! CLASS by asserting the committed root hash is byte-identical around CheckTx-path entry points.
+
+use dpp::version::PlatformVersion;
+use drive::drive::Drive;
+
+/// The committed (`transaction: None`, i.e. on-disk) GroveDB root hash.
+pub fn committed_root_hash(drive: &Drive, platform_version: &PlatformVersion) -> [u8; 32] {
+    drive
+        .grove
+        .root_hash(None, &platform_version.drive.grove_version)
+        .unwrap()
+        .expect("expected to fetch the committed grovedb root hash")
+}
+
+/// Runs `action` and asserts the committed GroveDB root hash is byte-identical before and after,
+/// returning `action`'s result.
+///
+/// Wrap CheckTx-path entry points (`check_tx`, `state_transition_to_execution_event_for_check_tx`,
+/// `validate_fees_of_event` with `transaction: None`) in this guard: CheckTx must NEVER mutate
+/// committed state (see the module docs for the paloma height-788 halt this guards against).
+pub fn assert_committed_root_hash_unchanged<R>(
+    drive: &Drive,
+    platform_version: &PlatformVersion,
+    context: &str,
+    action: impl FnOnce() -> R,
+) -> R {
+    let before = committed_root_hash(drive, platform_version);
+    let result = action();
+    let after = committed_root_hash(drive, platform_version);
+    assert_eq!(
+        before, after,
+        "{context} mutated committed grovedb state: CheckTx runs with transaction = None, so an \
+         eager write on this path commits straight to disk, diverging the root from the signed \
+         app hash and halting the chain (devnet paloma, height 788)"
+    );
+    result
+}

--- a/packages/rs-drive-abci/src/test/helpers/state_mutation_guard.rs
+++ b/packages/rs-drive-abci/src/test/helpers/state_mutation_guard.rs
@@ -15,6 +15,11 @@
 //! during CheckTx fee estimation). #3823 made the converter pure; the helpers here guard the
 //! CLASS by asserting the committed root hash is byte-identical around CheckTx-path entry points.
 
+use crate::execution::check_tx::CheckTxLevel;
+use crate::platform_types::platform::PlatformRef;
+use crate::platform_types::platform_state::PlatformStateV0Methods;
+use crate::rpc::core::MockCoreRPCLike;
+use crate::test::helpers::setup::TempPlatform;
 use dpp::version::PlatformVersion;
 use drive::drive::Drive;
 
@@ -49,4 +54,51 @@ pub fn assert_committed_root_hash_unchanged<R>(
          app hash and halting the chain (devnet paloma, height 788)"
     );
     result
+}
+
+/// Runs `check_tx` at BOTH levels (`FirstTimeCheck`, then `Recheck`) on a serialized state
+/// transition and asserts each returns a VALID result.
+///
+/// Call this from every state-transition type's canonical valid-fixture test, BEFORE the fixture
+/// is processed: it proves the type's full CheckTx pipeline (decode -> validation -> fee
+/// estimation) runs against committed state without errors, and — because `Platform::check_tx`
+/// itself asserts committed-root-hash invariance under `cfg(test)` — that nothing on the type's
+/// CheckTx path mutates committed GroveDB state (the devnet paloma height-788 halt class).
+///
+/// The validity assertions matter for the guard's strength: an early consensus rejection would
+/// skip fee estimation, leaving the type's drive-op converters unexercised in estimation mode.
+pub fn assert_check_tx_valid_at_all_levels(
+    platform: &TempPlatform<MockCoreRPCLike>,
+    serialized_transition: &[u8],
+    context: &str,
+) {
+    let platform_state = platform.state.load();
+    let platform_version = platform_state
+        .current_platform_version()
+        .expect("expected the current platform version");
+    let platform_ref = PlatformRef {
+        drive: &platform.drive,
+        state: &platform_state,
+        config: &platform.config,
+        core_rpc: &platform.core_rpc,
+    };
+
+    for level in [CheckTxLevel::FirstTimeCheck, CheckTxLevel::Recheck] {
+        let result = platform
+            .check_tx(
+                serialized_transition,
+                level,
+                &platform_ref,
+                platform_version,
+            )
+            .unwrap_or_else(|error| {
+                panic!("{context}: check_tx {level:?} must not error, got {error}")
+            });
+        assert!(
+            result.is_valid(),
+            "{context}: check_tx {level:?} must pass for the canonical valid fixture so fee \
+             estimation actually runs; got {:?}",
+            result.errors
+        );
+    }
 }


### PR DESCRIPTION
## Issue being fixed or feature implemented

On 2026-06-10 devnet paloma chain-halted at height 788. Root cause: in pre-#3823 builds, the `ShieldedPoolOperationType::InsertNullifiers` low-level converter arm eagerly called `drive.store_nullifiers_for_block(...)` — a direct write — with whatever `TransactionArg` it was handed. CheckTx fee estimation calls `validate_fees_of_event(..., transaction: None, ...)` (`check_tx_v0`), so the eager write committed DIRECTLY to GroveDB on every node that validated the gossiped type-20 transition. The on-disk root diverged from the signed app hash, every proposer panicked with "drive and platform state app hash mismatch" (`prepare_proposal.rs`), and restarts panic forever in `info.rs` because the write is durable.

#3823 removed that subsystem (the converter is now pure), but nothing guarded the CLASS: anyone reintroducing an eager write inside an op converter (or anywhere on the CheckTx path) would re-create the halt. This PR makes that class of bug unable to slip through tests for ANY state transition type.

## What was done?

Test-only change in `rs-drive-abci` (the only production-code touch is a `cfg(test)` block in two dispatchers and one `pub(crate)` visibility bump):

**1. Automatic invariant enforcement (`#[cfg(test)]`, zero production cost):**
- `Platform::check_tx` asserts the committed (`transaction: None`, on-disk) GroveDB root hash is byte-identical around every call.
- `validate_fees_of_event` asserts the same whenever called with `transaction: None` (the CheckTx estimation mode).
- Every present and FUTURE test that runs any transition through CheckTx or fee estimation now enforces the invariant automatically — a reintroduced eager write fails the suite immediately.

**2. Shared guard helpers** (`test/helpers/state_mutation_guard.rs`):
- `assert_committed_root_hash_unchanged(drive, version, context, closure)` — explicit wrapper used by the dedicated regression tests.
- `assert_check_tx_valid_at_all_levels(platform, serialized, context)` — runs `FirstTimeCheck` + `Recheck` and asserts BOTH return valid, so fee estimation genuinely executes (an early consensus rejection would leave the type's drive-op converters unexercised in estimation mode).
- Module docs document the invariant and the paloma halt.

**3. Coverage of all 21 `StateTransition` variants:**
- **Targeted regression (the exact paloma shape):** `check_tx_fee_estimation_does_not_mutate_committed_state` builds a synthetic `IdentityCreateFromShieldedPoolTransitionAction` (no Halo2 proving), asserts its event ops carry `InsertNullifiers` + `InsertNote` + `UpdateTotalBalance`, and drives `validate_fees_of_event(..., None, ...)` under the guard.
- **Dedicated check_tx tests:** data contract create and identity top-up wrapped in the explicit guard (`check_tx/v0/mod.rs`).
- **Canonical-fixture retrofits:** `assert_check_tx_valid_at_all_levels` wired into the canonical valid-fixture test of every type not already exercised through check_tx: identity credit transfer, identity credit withdrawal, masternode vote (inside the shared `perform_vote` helper, so every vote test inherits it), all six address-funded types (`IdentityCreditTransferToAddresses`, `IdentityCreateFromAddresses`, `IdentityTopUpFromAddresses`, `AddressFundsTransfer`, `AddressFundingFromAssetLock`, `AddressCreditWithdrawal`), and all five shielded types (`Shield`, `Unshield`, `ShieldedTransfer`, `ShieldedWithdrawal`, `ShieldFromAssetLock`) — the shielded fixtures carry real Halo2 proofs, so full check_tx passes proof validation and reaches estimation.
- The remaining types (contract create/update, documents, tokens, identity create/top-up/update) were already covered by existing check_tx tests, which the automatic guard now protects.

This covers all five fee-estimation arms that touch GroveDB (`Paid`, `PaidFromAssetLock`, `PaidFromAddressInputs`, `PaidFromAssetLockToPool`, `PaidFromShieldedPoolToNewIdentity`) and every drive-op converter family reachable from CheckTx.

## How Has This Been Tested?

- `cargo test -p drive-abci --lib` — full suite with the automatic guards firing in every check_tx/estimation call
- Targeted batch: the 16 guard/retrofit tests pass (including real Orchard proving for the five shielded types)
- Sensitivity check: temporarily reintroducing an eager GroveDB write into the `InsertNullifiers` converter arm makes the targeted test fail with the root-hash mismatch assertion, confirming the guard catches the paloma bug class (change reverted)
- `cargo fmt --all` and `cargo check --workspace --all-targets`

## Breaking Changes

None — test-only behavior; the dispatcher guards compile only under `cfg(test)`.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [ ] I have made corresponding changes to the documentation if needed

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone

🤖 Generated with [Claude Code](https://claude.com/claude-code)