### PR TITLE
ci: retry docker metadata step on transient github api failures

### DIFF
--- a/.github/actions/docker/action.yaml
+++ b/.github/actions/docker/action.yaml
@@ -82,8 +82,27 @@ runs:
           [worker.oci]
             gc = false
 
+    # metadata-action fetches repo data from the GitHub API without retries, so a
+    # transient API failure kills the whole build ("Unexpected end of JSON input").
+    # Retry once before giving up.
     - name: Set Docker tags and labels from image tag
       id: docker_meta
+      uses: docker/metadata-action@v5
+      continue-on-error: true
+      with:
+        images: ${{ inputs.image_org }}/${{ inputs.image_name }}
+        tags: |
+          type=semver,pattern={{version}},value=${{inputs.image_version}},enable=${{ inputs.image_version != '' }}
+          type=sha,format=long,enable=${{ inputs.image_version == '' }}
+
+    - name: Wait before retrying Docker meta
+      if: ${{ steps.docker_meta.outcome == 'failure' }}
+      shell: bash
+      run: sleep 10
+
+    - name: Set Docker tags and labels from image tag (retry)
+      id: docker_meta_retry
+      if: ${{ steps.docker_meta.outcome == 'failure' }}
       uses: docker/metadata-action@v5
       with:
         images: ${{ inputs.image_org }}/${{ inputs.image_name }}
@@ -190,9 +209,9 @@ runs:
         context: .
         builder: ${{ steps.buildx.outputs.name }}
         target: ${{ inputs.target }}
-        labels: ${{ steps.docker_meta.outputs.labels }}
+        labels: ${{ steps.docker_meta.outcome == 'success' && steps.docker_meta.outputs.labels || steps.docker_meta_retry.outputs.labels }}
         push: ${{ inputs.push_tags }}
-        tags: ${{ inputs.push_tags == 'true' && steps.docker_meta.outputs.tags || '' }}
+        tags: ${{ inputs.push_tags == 'true' && (steps.docker_meta.outcome == 'success' && steps.docker_meta.outputs.tags || steps.docker_meta_retry.outputs.tags) || '' }}
         platforms: ${{ inputs.platform }}
         secret-files: |
           AWS=${{ env.HOME }}/.aws/credentials

--- a/.github/workflows/release-docker-image.yml
+++ b/.github/workflows/release-docker-image.yml
@@ -124,8 +124,31 @@ jobs:
               return '';
             }
 
+      # metadata-action fetches repo data from the GitHub API without retries, so a
+      # transient API failure kills the whole job ("Unexpected end of JSON input").
+      # Retry once before giving up.
       - name: Set Docker tags and labels from image
         id: docker_meta
+        uses: docker/metadata-action@v5
+        continue-on-error: true
+        with:
+          images: ${{ inputs.image_org }}/${{ inputs.image_name }}
+          tags: |
+            type=match,pattern=v(.*),group=1,value=${{ inputs.tag }},priority=910,suffix=
+            type=match,pattern=v(\d+),group=1,value=${{ inputs.tag }}
+            type=match,pattern=v(\d+.\d+),group=1,value=${{ inputs.tag }}
+            type=match,pattern=v(\d+.\d+.\d+),group=1,value=${{ inputs.tag }}
+          flavor: |
+            suffix=${{ steps.suffix.outputs.result }},onlatest=true
+            latest=${{ github.event_name == 'release' }}
+
+      - name: Wait before retrying Docker meta
+        if: ${{ steps.docker_meta.outcome == 'failure' }}
+        run: sleep 10
+
+      - name: Set Docker tags and labels from image (retry)
+        id: docker_meta_retry
+        if: ${{ steps.docker_meta.outcome == 'failure' }}
         uses: docker/metadata-action@v5
         with:
           images: ${{ inputs.image_org }}/${{ inputs.image_name }}
@@ -153,4 +176,4 @@ jobs:
 
       - name: Inspect image
         run: |
-          docker buildx imagetools inspect ${{ inputs.image_org }}/${{ inputs.image_name }}:${{ steps.docker_meta.outputs.version }}
+          docker buildx imagetools inspect ${{ inputs.image_org }}/${{ inputs.image_name }}:${{ steps.docker_meta.outcome == 'success' && steps.docker_meta.outputs.version || steps.docker_meta_retry.outputs.version }}


### PR DESCRIPTION
## Issue being fixed or feature implemented

The v4.0.0-rc.1 release run failed building the Test Suite linux/arm64 image: [run 27288770906](https://github.com/dashpay/platform/actions/runs/27288770906/job/80603258288). The `docker/metadata-action@v5` step died 3 seconds in with `Unexpected end of JSON input`, before printing its "Context info" group.

The only unguarded JSON-parsing call on that early code path is `toolkit.github.repoData()` ([main.ts:16](https://github.com/docker/metadata-action/blob/v5.10.0/src/main.ts#L16)) — a `GET /repos/{owner}/{repo}` GitHub API request with **no retry logic** (the toolkit uses plain octokit without the retry plugin, including in the latest v6). A transient empty/truncated API response fails the step and kills the whole image build. The event payload itself was intact — the earlier `setup-buildx` step successfully re-serialized it into the provenance context.

## What was done?

Added a single gated retry around both `docker/metadata-action` call sites, using the standard `continue-on-error` + `if: outcome == 'failure'` pattern (GitHub Actions has no native retry for `uses:` steps):

- `.github/actions/docker/action.yaml` — the composite action used by all image builds (this is where the release failed)
- `.github/workflows/release-docker-image.yml` — the `publish-manifest` job, which has the same unprotected call

Downstream consumers (`labels`, `tags`, `version`) now coalesce outputs from whichever attempt succeeded. The `DOCKER_METADATA_OUTPUT_JSON` env var used by the manifest-push step needs no change: a failed first attempt dies before exporting anything, and a successful retry exports the same variables.

If both attempts fail, the job still fails as before.

## How Has This Been Tested?

Validated YAML syntax locally. The retry path only triggers on a metadata-action failure, so the happy path is unchanged; behavior is verified by the existing build workflows running on this PR.

## Breaking Changes

None.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [ ] I have made corresponding changes to the documentation if needed

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced Docker image release workflow reliability by implementing automatic retry logic for metadata generation to gracefully handle transient failures during the build process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->