### PR TITLE
fix(wasm-sdk): label getTokenContractInfo parameter as tokenId, not contractId

### DIFF
--- a/packages/js-evo-sdk/src/tokens/facade.ts
+++ b/packages/js-evo-sdk/src/tokens/facade.ts
@@ -119,18 +119,31 @@ export class TokensFacade {
     return w.getTokenDirectPurchasePricesWithProofInfo(tokenIds);
   }
 
-  async contractInfo(contractId: wasm.IdentifierLike): Promise<wasm.TokenContractInfo | undefined> {
+  /**
+   * Fetches a token's contract info (the data contract that defines it and the
+   * token's position within that contract).
+   *
+   * @param tokenId - The token ID, not a data contract ID. Derive one from a
+   *   contract ID and position with {@link TokensFacade.calculateId}.
+   */
+  async contractInfo(tokenId: wasm.IdentifierLike): Promise<wasm.TokenContractInfo | undefined> {
     const w = await this.sdk.getWasmSdkConnected();
-    return w.getTokenContractInfo(contractId);
+    return w.getTokenContractInfo(tokenId);
   }
 
+  /**
+   * Fetches a token's contract info with cryptographic proof.
+   *
+   * @param tokenId - The token ID, not a data contract ID. Derive one from a
+   *   contract ID and position with {@link TokensFacade.calculateId}.
+   */
   async contractInfoWithProof(
-    contractId: wasm.IdentifierLike,
+    tokenId: wasm.IdentifierLike,
   ): Promise<wasm.ProofMetadataResponseTyped<
     wasm.TokenContractInfo | undefined
   >> {
     const w = await this.sdk.getWasmSdkConnected();
-    return w.getTokenContractInfoWithProofInfo(contractId);
+    return w.getTokenContractInfoWithProofInfo(tokenId);
   }
 
   async perpetualDistributionLastClaim(

--- a/packages/js-evo-sdk/tests/unit/facades/tokens.spec.ts
+++ b/packages/js-evo-sdk/tests/unit/facades/tokens.spec.ts
@@ -315,17 +315,17 @@ describe('TokensFacade', () => {
 
   describe('contractInfo()', () => {
     it('should fetch token contract information', async () => {
-      await client.tokens.contractInfo(contractId);
+      await client.tokens.contractInfo(tokenId);
 
-      expect(getTokenContractInfoStub).to.be.calledOnceWithExactly(contractId);
+      expect(getTokenContractInfoStub).to.be.calledOnceWithExactly(tokenId);
     });
   });
 
   describe('contractInfoWithProof()', () => {
     it('should fetch contract info with proof', async () => {
-      await client.tokens.contractInfoWithProof(contractId);
+      await client.tokens.contractInfoWithProof(tokenId);
 
-      expect(getTokenContractInfoWithProofInfoStub).to.be.calledOnceWithExactly(contractId);
+      expect(getTokenContractInfoWithProofInfoStub).to.be.calledOnceWithExactly(tokenId);
     });
   });
 

--- a/packages/wasm-sdk/src/queries/token.rs
+++ b/packages/wasm-sdk/src/queries/token.rs
@@ -846,8 +846,7 @@ impl WasmSdk {
 
         // Fetch token contract info with proof
         let (info_result, metadata, proof) =
-            TokenContractInfo::fetch_with_metadata_and_proof(self.as_ref(), token_id, None)
-                .await?;
+            TokenContractInfo::fetch_with_metadata_and_proof(self.as_ref(), token_id, None).await?;
 
         let data = info_result
             .map(|info| JsValue::from(TokenContractInfoWasm::from(info)))

--- a/packages/wasm-sdk/src/queries/token.rs
+++ b/packages/wasm-sdk/src/queries/token.rs
@@ -457,21 +457,40 @@ impl WasmSdk {
         Ok(prices_map)
     }
 
+    /// Fetches the contract info for a token (the data contract that defines it
+    /// and the token's position within that contract).
+    ///
+    /// This query is keyed by **token ID**, not by data contract ID. A token ID
+    /// is derived from a data contract ID and the token's position via
+    /// `calculateTokenIdFromContract`. Passing a data contract ID here will not
+    /// match any record and resolves to `undefined`.
+    ///
+    /// # Arguments
+    /// * `token_id` - The token ID in base58 format
+    ///
+    /// # Returns
+    /// The token's contract info, or `undefined` if no token with that ID exists.
+    ///
+    /// # Example
+    /// ```javascript
+    /// const tokenId = sdk.calculateTokenIdFromContract("Hqyu8WcRwXCTwbNxdga4CN5gsVEGc67wng4TFzceyLUv", 0);
+    /// const info = await sdk.getTokenContractInfo(tokenId);
+    /// ```
     #[wasm_bindgen(js_name = "getTokenContractInfo")]
     pub async fn get_token_contract_info(
         &self,
-        #[wasm_bindgen(js_name = "dataContractId")] data_contract_id: IdentifierLikeJs,
+        #[wasm_bindgen(js_name = "tokenId")] token_id: IdentifierLikeJs,
     ) -> Result<Option<TokenContractInfoWasm>, WasmSdkError> {
         use dash_sdk::dpp::tokens::contract_info::TokenContractInfo;
         use dash_sdk::platform::Fetch;
 
-        // Parse contract ID
-        let contract_id: Identifier = data_contract_id.try_into().map_err(|err| {
-            WasmSdkError::invalid_argument(format!("Invalid contract ID: {}", err))
-        })?;
+        // Parse token ID
+        let token_id: Identifier = token_id
+            .try_into()
+            .map_err(|err| WasmSdkError::invalid_argument(format!("Invalid token ID: {}", err)))?;
 
         // Fetch token contract info
-        let info_result = TokenContractInfo::fetch(self.as_ref(), contract_id).await?;
+        let info_result = TokenContractInfo::fetch(self.as_ref(), token_id).await?;
 
         Ok(info_result.map(TokenContractInfoWasm::from))
     }
@@ -797,25 +816,37 @@ impl WasmSdk {
         ))
     }
 
+    /// Fetches the contract info for a token, with cryptographic proof.
+    ///
+    /// This query is keyed by **token ID**, not by data contract ID. A token ID
+    /// is derived from a data contract ID and the token's position via
+    /// `calculateTokenIdFromContract`. Passing a data contract ID here will not
+    /// match any record and resolves to `undefined`.
+    ///
+    /// # Arguments
+    /// * `token_id` - The token ID in base58 format
+    ///
+    /// # Returns
+    /// The token's contract info (or `undefined`) along with proof metadata.
     #[wasm_bindgen(
         js_name = "getTokenContractInfoWithProofInfo",
         unchecked_return_type = "ProofMetadataResponseTyped<TokenContractInfo | undefined>"
     )]
     pub async fn get_token_contract_info_with_proof_info(
         &self,
-        #[wasm_bindgen(js_name = "dataContractId")] data_contract_id: IdentifierLikeJs,
+        #[wasm_bindgen(js_name = "tokenId")] token_id: IdentifierLikeJs,
     ) -> Result<ProofMetadataResponseWasm, WasmSdkError> {
         use dash_sdk::dpp::tokens::contract_info::TokenContractInfo;
         use dash_sdk::platform::Fetch;
 
-        // Parse contract ID
-        let contract_id: Identifier = data_contract_id.try_into().map_err(|err| {
-            WasmSdkError::invalid_argument(format!("Invalid contract ID: {}", err))
-        })?;
+        // Parse token ID
+        let token_id: Identifier = token_id
+            .try_into()
+            .map_err(|err| WasmSdkError::invalid_argument(format!("Invalid token ID: {}", err)))?;
 
         // Fetch token contract info with proof
         let (info_result, metadata, proof) =
-            TokenContractInfo::fetch_with_metadata_and_proof(self.as_ref(), contract_id, None)
+            TokenContractInfo::fetch_with_metadata_and_proof(self.as_ref(), token_id, None)
                 .await?;
 
         let data = info_result

--- a/packages/wasm-sdk/src/queries/token.rs
+++ b/packages/wasm-sdk/src/queries/token.rs
@@ -473,7 +473,7 @@ impl WasmSdk {
     ///
     /// # Example
     /// ```javascript
-    /// const tokenId = sdk.calculateTokenIdFromContract("Hqyu8WcRwXCTwbNxdga4CN5gsVEGc67wng4TFzceyLUv", 0);
+    /// const tokenId = WasmSdk.calculateTokenIdFromContract("Hqyu8WcRwXCTwbNxdga4CN5gsVEGc67wng4TFzceyLUv", 0);
     /// const info = await sdk.getTokenContractInfo(tokenId);
     /// ```
     #[wasm_bindgen(js_name = "getTokenContractInfo")]

--- a/packages/wasm-sdk/tests/functional/tokens.spec.ts
+++ b/packages/wasm-sdk/tests/functional/tokens.spec.ts
@@ -10,7 +10,6 @@ describe('Tokens', function describeTokens() {
   const TEST_IDENTITY = req.identityId;
   const TOKEN_CONTRACT = req.tokenContracts[0].contractId;
   const TOKEN_CONTRACT_2 = TOKEN_CONTRACT;
-  const TOKEN_CONTRACT_3 = TOKEN_CONTRACT;
 
   let client: sdk.WasmSdk;
   let builder: sdk.WasmSdkBuilder;
@@ -48,14 +47,18 @@ describe('Tokens', function describeTokens() {
   });
 
   describe('getTokenContractInfo()', () => {
-    it('should return token contract info', async () => {
-      await client.getTokenContractInfo(TOKEN_CONTRACT_3);
+    it('should return token contract info for a valid token id', async () => {
+      const tokenId = sdk.WasmSdk.calculateTokenIdFromContract(TOKEN_CONTRACT, 0);
+      const info = await client.getTokenContractInfo(tokenId);
+      expect(info).to.exist();
+      expect(info.contractId.toBase58()).to.equal(TOKEN_CONTRACT);
+      expect(info.tokenContractPosition).to.equal(0);
     });
   });
 
   describe('getTokenPerpetualDistributionLastClaim()', () => {
     it('should return token perpetual distribution last claim', async () => {
-      const tokenId = sdk.WasmSdk.calculateTokenIdFromContract(TOKEN_CONTRACT_3, 0);
+      const tokenId = sdk.WasmSdk.calculateTokenIdFromContract(TOKEN_CONTRACT, 0);
       await client.getTokenPerpetualDistributionLastClaim(TEST_IDENTITY, tokenId);
     });
   });


### PR DESCRIPTION
## Issue being fixed or feature implemented

`getTokenContractInfo` / `getTokenContractInfoWithProofInfo` (wasm-sdk) and the `tokens.contractInfo` / `tokens.contractInfoWithProof` facade (js-evo-sdk) labeled their single parameter `dataContractId` / `contractId`. The query is actually keyed by **token ID**, which is a distinct value derived from a data contract ID and the token's position (`token_id = sha256d("dash_token" || contract_id || position)`).

Because the Drive query is a single-key GroveDB lookup keyed by `token_id`, passing a contract ID — as the parameter name invited — matched no record and silently resolved to `undefined` rather than erroring. Developers following the parameter name would conclude the token had no contract info.

The Rust SDK query type (`TokenContractInfoQuery { token_id }`), the gRPC proto field, and the Drive layer were already correctly named `token_id`; the mislabeling existed only at the WASM/JS surface.

## What was done?

- Renamed the parameter to `tokenId` on `getTokenContractInfo` and `getTokenContractInfoWithProofInfo`, corrected the error messages to "Invalid token ID", and added doc comments that state the argument is a token ID and point to `calculateTokenIdFromContract` for deriving one.
- Renamed the parameter to `tokenId` on the `tokens.contractInfo` / `tokens.contractInfoWithProof` facade methods with matching JSDoc.
- Fixed the wasm-sdk functional test, which previously passed a contract ID with no assertion (silently exercising the bug). It now derives a token ID via `calculateTokenIdFromContract` and asserts the returned `contractId` / `tokenContractPosition`.

The generated `dist/*.d.ts` regenerate from the wasm_bindgen `js_name` and TS source on build, so they were not hand-edited.

## How Has This Been Tested?

- `cargo build -p wasm-sdk` — compiles clean.
- `yarn workspace @dashevo/wasm-sdk test:functional` — the rewritten `getTokenContractInfo()` test now asserts the result, so it fails loudly if a contract ID (silent `None`) is ever passed again.
- `yarn workspace @dashevo/evo-sdk test:unit` — facade pass-through tests.

## Breaking Changes

None at runtime. wasm_bindgen generates positional JS arguments, so renaming the parameter does not change the call signature for existing callers — it only corrects the TypeScript parameter label and generated docs. The old `dataContractId` / `contractId` label was actively misleading and is the reason for this change.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [x] I have made corresponding changes to the documentation if needed

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **API Changes**
  * Methods returning token contract info now accept token IDs (parameter renamed) in both JS and WASM bindings, aligning public interfaces.
* **Documentation**
  * JSDoc/wasm-bindgen metadata updated to clarify token ID input and how to derive it.
* **Tests**
  * Unit and functional tests updated to use calculated token IDs and to assert behavior with the new parameter name.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->