### PR TITLE
fix(swift-sdk): drop legacy headers pre-processing in build_ios.sh

### DIFF
--- a/packages/swift-sdk/Sources/SwiftDashSDK/Address/AddressSyncService.swift
+++ b/packages/swift-sdk/Sources/SwiftDashSDK/Address/AddressSyncService.swift
@@ -119,7 +119,7 @@ extension SDK {
                             if var cfg = ffiConfig {
                                 return withUnsafePointer(to: &cfg) { cfgPtr in
                                     dash_sdk_sync_addresses_batch_with_result(
-                                        UnsafePointer(sdkPtr.ptr),
+                                        sdkPtr.ptr,
                                         keysBase, indicesBase, count, keySizeU32, gapLimit,
                                         kbKeysPtr, kbIndPtr, kbNonPtr, kbAmtPtr, kbCount,
                                         cfgPtr, syncHeight, syncTimestamp, recentBlock
@@ -127,7 +127,7 @@ extension SDK {
                                 }
                             } else {
                                 return dash_sdk_sync_addresses_batch_with_result(
-                                    UnsafePointer(sdkPtr.ptr),
+                                    sdkPtr.ptr,
                                     keysBase, indicesBase, count, keySizeU32, gapLimit,
                                     kbKeysPtr, kbIndPtr, kbNonPtr, kbAmtPtr, kbCount,
                                     nil, syncHeight, syncTimestamp, recentBlock
@@ -182,6 +182,6 @@ extension SDK {
 // MARK: - Private Sendable Wrapper
 
 private final class AddressSyncSendableSdkPtr: @unchecked Sendable {
-    let ptr: UnsafeMutablePointer<SDKHandle>
-    init(_ p: UnsafeMutablePointer<SDKHandle>) { self.ptr = p }
+    let ptr: OpaquePointer
+    init(_ p: OpaquePointer) { self.ptr = p }
 }

--- a/packages/swift-sdk/Sources/SwiftDashSDK/Address/Addresses.swift
+++ b/packages/swift-sdk/Sources/SwiftDashSDK/Address/Addresses.swift
@@ -1294,7 +1294,7 @@ public class Addresses: @unchecked Sendable {
             throw SDKError.internalError("Failed to parse identity")
         }
 
-        let identityHandle = identityHandlePtr.assumingMemoryBound(to: IdentityHandle.self)
+        let identityHandle = OpaquePointer(identityHandlePtr)
         defer { dash_sdk_identity_destroy(identityHandle) }
 
         // Prepare FFI inputs
@@ -1333,7 +1333,7 @@ public class Addresses: @unchecked Sendable {
         let result = ffiInputs.withUnsafeMutableBufferPointer { inputsBuffer -> DashSDKResult in
             dash_sdk_identity_top_up_from_addresses(
                 handle,
-                UnsafePointer(identityHandle),
+                identityHandle,
                 inputsBuffer.baseAddress,
                 UInt(inputs.count),
                 nil // put_settings
@@ -1434,7 +1434,7 @@ public class Addresses: @unchecked Sendable {
             throw SDKError.internalError("Failed to parse identity")
         }
 
-        let identityHandle = identityHandlePtr.assumingMemoryBound(to: IdentityHandle.self)
+        let identityHandle = OpaquePointer(identityHandlePtr)
         defer { dash_sdk_identity_destroy(identityHandle) }
 
         // Create signer from private key
@@ -1457,7 +1457,7 @@ public class Addresses: @unchecked Sendable {
         }
 
         defer {
-            dash_sdk_signer_destroy(signer.assumingMemoryBound(to: SignerHandle.self))
+            dash_sdk_signer_destroy(OpaquePointer(signer))
         }
 
         // Prepare FFI outputs
@@ -1484,11 +1484,11 @@ public class Addresses: @unchecked Sendable {
         let result = ffiOutputs.withUnsafeMutableBufferPointer { outputsBuffer -> DashSDKResult in
             dash_sdk_identity_transfer_credits_to_addresses(
                 handle,
-                UnsafePointer(identityHandle),
+                identityHandle,
                 outputsBuffer.baseAddress,
                 UInt(outputs.count),
                 publicKeyId,
-                signer.assumingMemoryBound(to: SignerHandle.self),
+                OpaquePointer(signer),
                 nil // put_settings
             )
         }
@@ -1588,7 +1588,7 @@ public class Addresses: @unchecked Sendable {
             throw SDKError.internalError("Failed to parse identity")
         }
 
-        let identityHandle = identityHandlePtr.assumingMemoryBound(to: IdentityHandle.self)
+        let identityHandle = OpaquePointer(identityHandlePtr)
         // Note: We don't destroy this handle here because it will be replaced by the created identity
 
         // Create signer from private key
@@ -1612,7 +1612,7 @@ public class Addresses: @unchecked Sendable {
         }
 
         defer {
-            dash_sdk_signer_destroy(signer.assumingMemoryBound(to: SignerHandle.self))
+            dash_sdk_signer_destroy(OpaquePointer(signer))
         }
 
         // Prepare FFI inputs
@@ -1670,11 +1670,11 @@ public class Addresses: @unchecked Sendable {
         let result = ffiInputs.withUnsafeMutableBufferPointer { inputsBuffer -> DashSDKResult in
             dash_sdk_identity_create_from_addresses(
                 handle,
-                UnsafePointer(identityHandle),
+                identityHandle,
                 inputsBuffer.baseAddress,
                 UInt(inputs.count),
                 ffiOutput,
-                signer.assumingMemoryBound(to: SignerHandle.self),
+                OpaquePointer(signer),
                 nil // put_settings
             )
         }
@@ -1729,10 +1729,6 @@ public class Addresses: @unchecked Sendable {
         // Free the result (but keep the identity handle - caller must free it)
         dash_sdk_identity_create_from_addresses_result_free(resultPtr)
 
-        // Convert UnsafeMutablePointer<IdentityHandle> to OpaquePointer
-        // OpaquePointer initializer returns optional, so we force unwrap since we know it's valid
-        let createdIdentityHandle = OpaquePointer(UnsafeRawPointer(identityHandlePtr))!
-
-        return (createdIdentityHandle, PlatformAddressInfosResult(infos: infos))
+        return (identityHandlePtr, PlatformAddressInfosResult(infos: infos))
     }
 }

--- a/packages/swift-sdk/Sources/SwiftDashSDK/FFI/KeychainSigner.swift
+++ b/packages/swift-sdk/Sources/SwiftDashSDK/FFI/KeychainSigner.swift
@@ -88,13 +88,13 @@ public final class KeychainSigner: Signer, @unchecked Sendable {
 
     /// FFI signer handle. Pass to any `*_with_signer` entry point;
     /// the underlying pointer is the C-imported
-    /// `UnsafeMutablePointer<SignerHandle>` from `platform-wallet-ffi.h`
+    /// `OpaquePointer` from `platform-wallet-ffi.h`
     /// (and equivalently `rs-sdk-ffi.h`). Owned by this object —
     /// freed in `deinit` via `dash_sdk_signer_destroy`. Caller must
     /// keep the `KeychainSigner` alive for the duration of any FFI
     /// call that captured this pointer (see the keepalive contract
     /// above).
-    public var handle: UnsafeMutablePointer<SignerHandle> {
+    public var handle: OpaquePointer {
         handlePtr
     }
 
@@ -182,7 +182,7 @@ public final class KeychainSigner: Signer, @unchecked Sendable {
 
     /// Raw pointer to the FFI signer handle. Boxed by Rust and freed
     /// in `deinit`.
-    private var handlePtr: UnsafeMutablePointer<SignerHandle>!
+    private var handlePtr: OpaquePointer!
 
     // MARK: Init
 
@@ -747,7 +747,7 @@ public final class KeychainSigner: Signer, @unchecked Sendable {
         guard let rawSigner = signerResult.data else {
             return .failure(.ffiSignerCreationFailed(message: "null handle"))
         }
-        let signerHandle = rawSigner.assumingMemoryBound(to: SignerHandle.self)
+        let signerHandle = OpaquePointer(rawSigner)
         defer { dash_sdk_signer_destroy(signerHandle) }
 
         let signResult = data.withUnsafeBytes { dataBuf -> DashSDKResult in

--- a/packages/swift-sdk/Sources/SwiftDashSDK/FFI/PlatformQueryExtensions.swift
+++ b/packages/swift-sdk/Sources/SwiftDashSDK/FFI/PlatformQueryExtensions.swift
@@ -499,7 +499,7 @@ extension SDK {
 
         defer {
             // Clean up contract handle when done
-            let contractPtr = contractHandle.assumingMemoryBound(to: DataContractHandle.self)
+            let contractPtr = OpaquePointer(contractHandle)
             dash_sdk_data_contract_destroy(contractPtr)
         }
 
@@ -514,7 +514,7 @@ extension SDK {
                     if let orderByClause = orderByClauseCString {
                         return orderByClause.withUnsafeBufferPointer { orderByPtr in
                             var searchParams = DashSDKDocumentSearchParams()
-                            searchParams.data_contract_handle = UnsafePointer(contractHandle.assumingMemoryBound(to: DataContractHandle.self))
+                            searchParams.data_contract_handle = OpaquePointer(contractHandle)
                             searchParams.document_type = documentTypePtr.baseAddress
                             searchParams.where_json = wherePtr.baseAddress
                             searchParams.order_by_json = orderByPtr.baseAddress
@@ -534,7 +534,7 @@ extension SDK {
                         }
                     } else {
                         var searchParams = DashSDKDocumentSearchParams()
-                        searchParams.data_contract_handle = UnsafePointer(contractHandle.assumingMemoryBound(to: DataContractHandle.self))
+                        searchParams.data_contract_handle = OpaquePointer(contractHandle)
                         searchParams.document_type = documentTypePtr.baseAddress
                         searchParams.where_json = wherePtr.baseAddress
                         searchParams.order_by_json = nil
@@ -555,7 +555,7 @@ extension SDK {
                 }
             } else {
                 var searchParams = DashSDKDocumentSearchParams()
-                searchParams.data_contract_handle = UnsafePointer(contractHandle.assumingMemoryBound(to: DataContractHandle.self))
+                searchParams.data_contract_handle = OpaquePointer(contractHandle)
                 searchParams.document_type = documentTypePtr.baseAddress
                 searchParams.where_json = nil
                 searchParams.order_by_json = nil
@@ -590,12 +590,12 @@ extension SDK {
 
         defer {
             // Clean up contract handle when done
-            let contractPtr = contractHandle.assumingMemoryBound(to: DataContractHandle.self)
+            let contractPtr = OpaquePointer(contractHandle)
             dash_sdk_data_contract_destroy(contractPtr)
         }
 
         // Now fetch the document
-        let documentResult = dash_sdk_document_fetch(handle, contractHandle.assumingMemoryBound(to: DataContractHandle.self), documentType, documentId)
+        let documentResult = dash_sdk_document_fetch(handle, OpaquePointer(contractHandle), documentType, documentId)
 
         if let error = documentResult.error {
             let errorMessage = error.pointee.message != nil ? String(cString: error.pointee.message!) : "Unknown error"
@@ -609,11 +609,11 @@ extension SDK {
 
         defer {
             // Clean up document handle
-            dash_sdk_document_destroy(handle, documentHandle.assumingMemoryBound(to: DocumentHandle.self))
+            dash_sdk_document_destroy(handle, OpaquePointer(documentHandle))
         }
 
         // Get document info to convert to JSON
-        let info = dash_sdk_document_get_info(documentHandle.assumingMemoryBound(to: DocumentHandle.self))
+        let info = dash_sdk_document_get_info(OpaquePointer(documentHandle))
         defer {
             if let info = info {
                 dash_sdk_document_info_free(info)
@@ -733,7 +733,7 @@ extension SDK {
             throw SDKError.notFound("Data contract not found")
         }
         defer {
-            dash_sdk_data_contract_destroy(contractHandle.assumingMemoryBound(to: DataContractHandle.self))
+            dash_sdk_data_contract_destroy(OpaquePointer(contractHandle))
         }
 
         // Marshal the optional JSON strings in. nil → null pointer = "none".
@@ -743,7 +743,7 @@ extension SDK {
                     withOptionalCString(groupByJSON) { groupPtr in
                         dash_sdk_document_count(
                             handle,
-                            contractHandle.assumingMemoryBound(to: DataContractHandle.self),
+                            OpaquePointer(contractHandle),
                             typePtr,
                             wherePtr,
                             orderPtr,
@@ -835,7 +835,7 @@ extension SDK {
             throw SDKError.notFound("Data contract not found")
         }
         defer {
-            dash_sdk_data_contract_destroy(contractHandle.assumingMemoryBound(to: DataContractHandle.self))
+            dash_sdk_data_contract_destroy(OpaquePointer(contractHandle))
         }
 
         // Marshal the strings in. sumProperty is required (non-null);
@@ -847,7 +847,7 @@ extension SDK {
                         withOptionalCString(groupByJSON) { groupPtr in
                             dash_sdk_document_sum(
                                 handle,
-                                contractHandle.assumingMemoryBound(to: DataContractHandle.self),
+                                OpaquePointer(contractHandle),
                                 typePtr,
                                 sumPropPtr,
                                 wherePtr,
@@ -944,7 +944,7 @@ extension SDK {
             throw SDKError.notFound("Data contract not found")
         }
         defer {
-            dash_sdk_data_contract_destroy(contractHandle.assumingMemoryBound(to: DataContractHandle.self))
+            dash_sdk_data_contract_destroy(OpaquePointer(contractHandle))
         }
 
         // Marshal the strings in. sumProperty is required (non-null);
@@ -956,7 +956,7 @@ extension SDK {
                         withOptionalCString(groupByJSON) { groupPtr in
                             dash_sdk_document_average(
                                 handle,
-                                contractHandle.assumingMemoryBound(to: DataContractHandle.self),
+                                OpaquePointer(contractHandle),
                                 typePtr,
                                 sumPropPtr,
                                 wherePtr,

--- a/packages/swift-sdk/Sources/SwiftDashSDK/FFI/StateTransitionExtensions.swift
+++ b/packages/swift-sdk/Sources/SwiftDashSDK/FFI/StateTransitionExtensions.swift
@@ -1,17 +1,6 @@
 import Foundation
 import DashSDKFFI
 
-// MARK: - OpaquePointer -> typed FFI helpers
-@inline(__always) private func idConst(_ p: OpaquePointer) -> UnsafePointer<IdentityHandle> { UnsafePointer(p) }
-@inline(__always) private func idMut(_ p: OpaquePointer) -> UnsafeMutablePointer<IdentityHandle> { UnsafeMutablePointer(p) }
-@inline(__always) private func signerConst(_ p: OpaquePointer) -> UnsafePointer<SignerHandle> { UnsafePointer(p) }
-@inline(__always) private func signerMut(_ p: OpaquePointer) -> UnsafeMutablePointer<SignerHandle> { UnsafeMutablePointer(p) }
-@inline(__always) private func idPubKeyConst(_ p: OpaquePointer) -> UnsafePointer<IdentityPublicKeyHandle> { UnsafePointer(p) }
-@inline(__always) private func dataContractConst(_ p: OpaquePointer) -> UnsafePointer<DataContractHandle> { UnsafePointer(p) }
-@inline(__always) private func dataContractMut(_ p: OpaquePointer) -> UnsafeMutablePointer<DataContractHandle> { UnsafeMutablePointer(p) }
-@inline(__always) private func documentConst(_ p: OpaquePointer) -> UnsafePointer<DocumentHandle> { UnsafePointer(p) }
-@inline(__always) private func documentMut(_ p: OpaquePointer) -> UnsafeMutablePointer<DocumentHandle> { UnsafeMutablePointer(p) }
-
 // MARK: - Sendable wrappers
 private final class SendableOpaque: @unchecked Sendable { let p: OpaquePointer; init(_ p: OpaquePointer) { self.p = p } }
 
@@ -29,7 +18,7 @@ private final class SendableOpaque: @unchecked Sendable { let p: OpaquePointer; 
 private func signerCanSign(_ signer: OpaquePointer, _ key: IdentityPublicKey) -> Bool {
     key.data.withUnsafeBytes { (raw: UnsafeRawBufferPointer) -> Bool in
         dash_sdk_signer_can_sign(
-            signerConst(signer),
+            signer,
             raw.bindMemory(to: UInt8.self).baseAddress,
             UInt(key.data.count),
             key.keyType.rawValue
@@ -119,7 +108,7 @@ private func selectSigningKey(
 }
 
 /// Helper to create a public key handle from an IdentityPublicKey
-private func createPublicKeyHandle(from key: IdentityPublicKey, operation: String) -> UnsafeMutablePointer<IdentityPublicKeyHandle>? {
+private func createPublicKeyHandle(from key: IdentityPublicKey, operation: String) -> OpaquePointer? {
     let keyData = key.data
     let keyType = key.keyType.ffiValue
     let purpose = key.purpose.ffiValue
@@ -152,7 +141,7 @@ private func createPublicKeyHandle(from key: IdentityPublicKey, operation: Strin
     }
 
     print("✅ [\(operation)] Public key handle created from local data")
-    return keyHandle.assumingMemoryBound(to: IdentityPublicKeyHandle.self)
+    return OpaquePointer(keyHandle)
 }
 
 // MARK: - State Transition Extensions
@@ -295,8 +284,8 @@ extension SDK {
                     if result.data_type.rawValue == 3, // ResultIdentityHandle
                        let identityHandle = result.data {
                         // Get identity info from the handle
-                        let idPtr = identityHandle.assumingMemoryBound(to: IdentityHandle.self)
-                        let infoPtr = dash_sdk_identity_get_info(UnsafePointer(idPtr))
+                        let idPtr = OpaquePointer(identityHandle)
+                        let infoPtr = dash_sdk_identity_get_info(idPtr)
 
                         if let info = infoPtr {
                             // Convert the C struct to a Swift dictionary
@@ -362,7 +351,7 @@ extension SDK {
                         privateKey.withUnsafeBytes { keyBytes in
                             dash_sdk_identity_topup_with_instant_lock(
                                 handle,
-                                idConst(idBox.p),
+                                idBox.p,
                                 instantLockBytes.bindMemory(to: UInt8.self).baseAddress!,
                                 UInt(instantLock.count),
                                 txBytes.bindMemory(to: UInt8.self).baseAddress!,
@@ -380,8 +369,8 @@ extension SDK {
                     if result.data_type.rawValue == 3, // ResultIdentityHandle
                        let toppedUpIdentityHandle = result.data {
                         // Get identity info from the handle to retrieve the new balance
-                        let idPtr = toppedUpIdentityHandle.assumingMemoryBound(to: IdentityHandle.self)
-                        let infoPtr = dash_sdk_identity_get_info(UnsafePointer(idPtr))
+                        let idPtr = OpaquePointer(toppedUpIdentityHandle)
+                        let infoPtr = dash_sdk_identity_get_info(idPtr)
 
                         if let info = infoPtr {
                             let balance = info.pointee.balance
@@ -431,11 +420,11 @@ extension SDK {
                 let result = toIdentityId.withCString { toIdCStr in
                     dash_sdk_identity_transfer_credits(
                         handle,
-                        idConst(fromBox.p),
+                        fromBox.p,
                         toIdCStr,
                         amount,
                         publicKeyId,
-                        signerConst(signerBox.p),
+                        signerBox.p,
                         nil  // Default put settings
                     )
                 }
@@ -484,12 +473,12 @@ extension SDK {
                 let result = toAddress.withCString { addressCStr in
                     dash_sdk_identity_withdraw(
                         handle,
-                        idConst(idBox.p),
+                        idBox.p,
                         addressCStr,
                         amount,
                         coreFeePerByte,
                         publicKeyId,
-                        signerConst(signerBox.p),
+                        signerBox.p,
                         nil  // Default put settings
                     )
                 }
@@ -658,7 +647,7 @@ extension SDK {
                                 docTypeCStr,
                                 entropyPtr,
                                 keyHandle,
-                                signerConst(signerBox.p),
+                                signerBox.p,
                                 tokenPaymentInfo,
                                 putSettings,
                                 stateTransitionOptions
@@ -759,7 +748,7 @@ extension SDK {
                 }
 
                 defer {
-                    let dcPtr = contractHandle.assumingMemoryBound(to: DataContractHandle.self)
+                    let dcPtr = OpaquePointer(contractHandle)
                     dash_sdk_data_contract_destroy(dcPtr)
                 }
 
@@ -768,7 +757,7 @@ extension SDK {
                     documentId.withCString { docIdCStr in
                         dash_sdk_document_fetch(
                             handle,
-                            UnsafePointer(contractHandle.assumingMemoryBound(to: DataContractHandle.self)),
+                            OpaquePointer(contractHandle),
                             docTypeCStr,
                             docIdCStr
                         )
@@ -794,7 +783,7 @@ extension SDK {
                 }
 
                 defer {
-                    dash_sdk_document_free(documentHandle.assumingMemoryBound(to: DocumentHandle.self))
+                    dash_sdk_document_free(OpaquePointer(documentHandle))
                 }
 
                 print("✅ [DOCUMENT REPLACE] Document fetched successfully")
@@ -803,7 +792,7 @@ extension SDK {
                 // Use pre-serialized JSON to avoid capturing non-Sendable value types
                 let propertiesJson = propertiesJsonPre
                 _ = propertiesJson.withCString { propsCStr in
-                    dash_sdk_document_set_properties(documentHandle.assumingMemoryBound(to: DocumentHandle.self), propsCStr)
+                    dash_sdk_document_set_properties(OpaquePointer(documentHandle), propsCStr)
                 }
 
                 // 3. Get appropriate key for signing
@@ -830,11 +819,11 @@ extension SDK {
                     documentType.withCString { docTypeCStr in
                             dash_sdk_document_replace_on_platform_and_wait(
                                 handle,
-                                UnsafePointer(documentHandle.assumingMemoryBound(to: DocumentHandle.self)),
+                                OpaquePointer(documentHandle),
                                 contractIdCStr,
                                 docTypeCStr,
                                 keyHandle,
-                                signerConst(signerBox.p),
+                                signerBox.p,
                                 nil, // token payment info
                                 nil, // put settings
                                 nil  // state transition options
@@ -853,7 +842,7 @@ extension SDK {
                 } else if replaceResult.data_type == DashSDKFFI.ResultDocumentHandle,
                           let resultHandle = replaceResult.data {
                     // Document was successfully replaced
-                    dash_sdk_document_free(resultHandle.assumingMemoryBound(to: DocumentHandle.self))
+                    dash_sdk_document_free(OpaquePointer(resultHandle))
 
                     let totalTime = Date().timeIntervalSince(startTime)
                     print("✅ [DOCUMENT REPLACE] Document replaced successfully")
@@ -929,7 +918,7 @@ extension SDK {
                         contractIdCString,
                         documentTypeCString,
                         keyHandle,
-                        signerConst(signerBox.p),
+                        signerBox.p,
                         nil,  // token_payment_info
                         nil,  // put_settings
                         nil   // state_transition_creation_options
@@ -1026,7 +1015,7 @@ extension SDK {
                 }
 
                 defer {
-                    let dcPtr2 = contractHandle.assumingMemoryBound(to: DataContractHandle.self)
+                    let dcPtr2 = OpaquePointer(contractHandle)
                     dash_sdk_data_contract_destroy(dcPtr2)
                 }
 
@@ -1039,7 +1028,7 @@ extension SDK {
                 // Now fetch the document using the contract handle
                 let fetchResult = dash_sdk_document_fetch(
                     handle,
-                    UnsafePointer(contractHandle.assumingMemoryBound(to: DataContractHandle.self)),
+                    OpaquePointer(contractHandle),
                     documentTypeCString,
                     documentIdCString
                 )
@@ -1057,7 +1046,7 @@ extension SDK {
                 }
 
                 defer {
-                    dash_sdk_document_destroy(handle, documentHandle.assumingMemoryBound(to: DocumentHandle.self))
+                    dash_sdk_document_destroy(handle, OpaquePointer(documentHandle))
                 }
 
                 print("✅ [DOCUMENT TRANSFER] Document fetched successfully")
@@ -1069,12 +1058,12 @@ extension SDK {
                 print("🔄 [DOCUMENT TRANSFER] Creating state transition...")
                 let transitionResult = dash_sdk_document_transfer_to_identity(
                     handle,
-                    UnsafePointer(documentHandle.assumingMemoryBound(to: DocumentHandle.self)),
+                    OpaquePointer(documentHandle),
                     toIdentityCString,
                     contractIdCString,
                     documentTypeCString,
                     keyHandle,
-                    signerConst(signerBox.p),
+                    signerBox.p,
                     nil,  // token_payment_info
                     nil,  // put_settings
                     nil   // state_transition_creation_options
@@ -1093,12 +1082,12 @@ extension SDK {
                 print("🔄 [DOCUMENT TRANSFER] Broadcasting and waiting for confirmation...")
                 let result = dash_sdk_document_transfer_to_identity_and_wait(
                     handle,
-                    UnsafePointer(documentHandle.assumingMemoryBound(to: DocumentHandle.self)),
+                    OpaquePointer(documentHandle),
                     toIdentityCString,
                     contractIdCString,
                     documentTypeCString,
                     keyHandle,
-                    signerConst(signerBox.p),
+                    signerBox.p,
                     nil,  // token_payment_info
                     nil,  // put_settings
                     nil   // state_transition_creation_options
@@ -1195,7 +1184,7 @@ extension SDK {
                 }
 
                 defer {
-                    let dcPtr3 = contractHandle.assumingMemoryBound(to: DataContractHandle.self)
+                    let dcPtr3 = OpaquePointer(contractHandle)
                     dash_sdk_data_contract_destroy(dcPtr3)
                 }
 
@@ -1205,7 +1194,7 @@ extension SDK {
                     documentId.withCString { docIdCStr in
                         dash_sdk_document_fetch(
                             handle,
-                            UnsafePointer(contractHandle.assumingMemoryBound(to: DataContractHandle.self)),
+                            OpaquePointer(contractHandle),
                             docTypeCStr,
                             docIdCStr
                         )
@@ -1227,7 +1216,7 @@ extension SDK {
                 }
 
                 defer {
-                    dash_sdk_document_destroy(handle, documentHandle.assumingMemoryBound(to: DocumentHandle.self))
+                    dash_sdk_document_destroy(handle, OpaquePointer(documentHandle))
                 }
 
                 print("✅ [DOCUMENT UPDATE PRICE] Document fetched successfully")
@@ -1250,12 +1239,12 @@ extension SDK {
                     documentType.withCString { documentTypeCStr in
                         dash_sdk_document_update_price_of_document_and_wait(
                             handle,
-                            UnsafePointer(documentHandle.assumingMemoryBound(to: DocumentHandle.self)),
+                            OpaquePointer(documentHandle),
                             contractIdCStr,
                             documentTypeCStr,
                             newPrice,
                             keyHandle,
-                            signerConst(signerBox.p),
+                            signerBox.p,
                             nil,  // token_payment_info
                             nil,  // put_settings
                             nil   // state_transition_creation_options
@@ -1351,7 +1340,7 @@ extension SDK {
                 }
 
                 defer {
-                    dash_sdk_data_contract_destroy(contractHandle.assumingMemoryBound(to: DataContractHandle.self))
+                    dash_sdk_data_contract_destroy(OpaquePointer(contractHandle))
                 }
 
                 print("📝 [DOCUMENT PURCHASE] Contract fetched in \(Date().timeIntervalSince(contractFetchStartTime)) seconds")
@@ -1360,7 +1349,7 @@ extension SDK {
                 print("📝 [DOCUMENT PURCHASE] Step 2: Fetching document...")
                 let documentFetchStart = Date()
 
-                let documentResult = dash_sdk_document_fetch(handle, UnsafePointer(contractHandle.assumingMemoryBound(to: DataContractHandle.self)), documentTypeCString, documentIdCString)
+                let documentResult = dash_sdk_document_fetch(handle, OpaquePointer(contractHandle), documentTypeCString, documentIdCString)
 
                 if let error = documentResult.error {
                     let errorMessage = error.pointee.message != nil ? String(cString: error.pointee.message!) : "Unknown error"
@@ -1375,7 +1364,7 @@ extension SDK {
                 }
 
                 defer {
-                    dash_sdk_document_destroy(handle, documentHandle.assumingMemoryBound(to: DocumentHandle.self))
+                    dash_sdk_document_destroy(handle, OpaquePointer(documentHandle))
                 }
 
                 print("📝 [DOCUMENT PURCHASE] Document fetched in \(Date().timeIntervalSince(documentFetchStart)) seconds")
@@ -1387,13 +1376,13 @@ extension SDK {
 
                 let result = dash_sdk_document_purchase_and_wait(
                     handle,
-                    UnsafePointer(documentHandle.assumingMemoryBound(to: DocumentHandle.self)),
+                    OpaquePointer(documentHandle),
                     contractIdCString,
                     documentTypeCString,
                     price,
                     purchaserIdCString,
                     keyHandle,
-                    signerConst(signerBox.p),
+                    signerBox.p,
                     nil,  // token_payment_info - null for now
                     nil,  // put_settings - null for now
                     nil   // state_transition_creation_options - null for now
@@ -1417,7 +1406,7 @@ extension SDK {
                 // The result should contain the purchased document
                 if let documentData = result.data {
                     // We received the purchased document back
-                    let purchasedDocHandle = documentData.assumingMemoryBound(to: DocumentHandle.self)
+                    let purchasedDocHandle = OpaquePointer(documentData)
 
                     // Get info about the purchased document (extract Sendable primitives)
                     var purchasedId: String? = nil
@@ -1519,7 +1508,7 @@ extension SDK {
                 defer {
                     print("🟦 TOKEN MINT: Cleaning up identity handle")
                     // Clean up the identity handle when done
-                    dash_sdk_identity_destroy(idMut(ownerIdentityHandle))
+                    dash_sdk_identity_destroy(ownerIdentityHandle)
                 }
 
                 // Get the owner ID from the identity
@@ -1555,7 +1544,7 @@ extension SDK {
                 // Get the public key handle for the minting key
                 print("🟦 TOKEN MINT: Getting public key handle for key ID: \(keyId)")
                 let keyHandleResult = dash_sdk_identity_get_public_key_by_id(
-                    idConst(ownerIdentityHandle),
+                    ownerIdentityHandle,
                     UInt8(keyId)
                 )
 
@@ -1569,7 +1558,7 @@ extension SDK {
                     return
                 }
 
-                let publicKeyHandle = keyHandleData.assumingMemoryBound(to: IdentityPublicKeyHandle.self)
+                let publicKeyHandle = OpaquePointer(keyHandleData)
                 print("✅ TOKEN MINT: Successfully got public key handle")
                 defer {
                     print("🟦 TOKEN MINT: Cleaning up public key handle")
@@ -1611,7 +1600,7 @@ extension SDK {
                                         ownerIdBytes.bindMemory(to: UInt8.self).baseAddress!,
                                         &params,
                                         publicKeyHandle,
-                                        signerConst(signerBox.p),
+                                        signerBox.p,
                                         nil,  // Default put settings
                                         nil   // Default state transition options
                                     )
@@ -1629,7 +1618,7 @@ extension SDK {
                                     ownerIdBytes.bindMemory(to: UInt8.self).baseAddress!,
                                     &params,
                                     publicKeyHandle,
-                                    signerConst(signerBox.p),
+                                    signerBox.p,
                                     nil,  // Default put settings
                                     nil   // Default state transition options
                                 )
@@ -1687,7 +1676,7 @@ extension SDK {
 
                 defer {
                     // Clean up the identity handle when done
-                    dash_sdk_identity_destroy(idMut(ownerIdentityHandle))
+                    dash_sdk_identity_destroy(ownerIdentityHandle)
                 }
 
                 // Get the owner ID from the identity
@@ -1712,7 +1701,7 @@ extension SDK {
 
                 // Get the public key handle for the freezing key
                 let keyHandleResult = dash_sdk_identity_get_public_key_by_id(
-                    idConst(ownerIdentityHandle),
+                    ownerIdentityHandle,
                     UInt8(freezingKey.id)
                 )
 
@@ -1725,7 +1714,7 @@ extension SDK {
                     return
                 }
 
-                let publicKeyHandle = keyHandleData.assumingMemoryBound(to: IdentityPublicKeyHandle.self)
+                let publicKeyHandle = OpaquePointer(keyHandleData)
                 defer {
                     // Clean up the public key handle when done
                     dash_sdk_identity_public_key_destroy(publicKeyHandle)
@@ -1752,7 +1741,7 @@ extension SDK {
                                         ownerIdBytes.bindMemory(to: UInt8.self).baseAddress!,
                                         &params,
                                         publicKeyHandle,
-                                        signerConst(signerBox.p),
+                                        signerBox.p,
                                         nil,  // Default put settings
                                         nil   // Default state transition options
                                     )
@@ -1765,7 +1754,7 @@ extension SDK {
                                     ownerIdBytes.bindMemory(to: UInt8.self).baseAddress!,
                                     &params,
                                     publicKeyHandle,
-                                    signerConst(signerBox.p),
+                                    signerBox.p,
                                     nil,  // Default put settings
                                     nil   // Default state transition options
                                 )
@@ -1819,7 +1808,7 @@ extension SDK {
 
                 defer {
                     // Clean up the identity handle when done
-                    dash_sdk_identity_destroy(idMut(ownerIdentityHandle))
+                    dash_sdk_identity_destroy(ownerIdentityHandle)
                 }
 
                 // Get the owner ID from the identity
@@ -1844,7 +1833,7 @@ extension SDK {
 
                 // Get the public key handle for the unfreezing key
                 let keyHandleResult = dash_sdk_identity_get_public_key_by_id(
-                    idConst(ownerIdentityHandle),
+                    ownerIdentityHandle,
                     UInt8(unfreezingKey.id)
                 )
 
@@ -1857,7 +1846,7 @@ extension SDK {
                     return
                 }
 
-                let publicKeyHandle = keyHandleData.assumingMemoryBound(to: IdentityPublicKeyHandle.self)
+                let publicKeyHandle = OpaquePointer(keyHandleData)
                 defer {
                     // Clean up the public key handle when done
                     dash_sdk_identity_public_key_destroy(publicKeyHandle)
@@ -1884,7 +1873,7 @@ extension SDK {
                                         ownerIdBytes.bindMemory(to: UInt8.self).baseAddress!,
                                         &params,
                                         publicKeyHandle,
-                                        signerConst(signerBox.p),
+                                        signerBox.p,
                                         nil,  // Default put settings
                                         nil   // Default state transition options
                                     )
@@ -1897,7 +1886,7 @@ extension SDK {
                                     ownerIdBytes.bindMemory(to: UInt8.self).baseAddress!,
                                     &params,
                                     publicKeyHandle,
-                                    signerConst(signerBox.p),
+                                    signerBox.p,
                                     nil,  // Default put settings
                                     nil   // Default state transition options
                                 )
@@ -1951,7 +1940,7 @@ extension SDK {
 
                 defer {
                     // Clean up the identity handle when done
-                    dash_sdk_identity_destroy(idMut(ownerIdentityHandle))
+                    dash_sdk_identity_destroy(ownerIdentityHandle)
                 }
 
                 // Get the owner ID from the identity
@@ -1966,7 +1955,7 @@ extension SDK {
 
                 // Get the public key handle for the burning key
                 let keyHandleResult = dash_sdk_identity_get_public_key_by_id(
-                    idConst(ownerIdentityHandle),
+                    ownerIdentityHandle,
                     UInt8(burningKey.id)
                 )
 
@@ -1979,7 +1968,7 @@ extension SDK {
                     return
                 }
 
-                let publicKeyHandle = keyHandleData.assumingMemoryBound(to: IdentityPublicKeyHandle.self)
+                let publicKeyHandle = OpaquePointer(keyHandleData)
                 defer {
                     // Clean up the public key handle when done
                     dash_sdk_identity_public_key_destroy(publicKeyHandle)
@@ -2005,7 +1994,7 @@ extension SDK {
                                     ownerIdBytes.bindMemory(to: UInt8.self).baseAddress!,
                                     &params,
                                     publicKeyHandle,
-                                    signerConst(signerBox.p),
+                                    signerBox.p,
                                     nil,  // Default put settings
                                     nil   // Default state transition options
                                 )
@@ -2018,7 +2007,7 @@ extension SDK {
                                 ownerIdBytes.bindMemory(to: UInt8.self).baseAddress!,
                                 &params,
                                 publicKeyHandle,
-                                signerConst(signerBox.p),
+                                signerBox.p,
                                 nil,  // Default put settings
                                 nil   // Default state transition options
                             )
@@ -2071,7 +2060,7 @@ extension SDK {
 
                 defer {
                     // Clean up the identity handle when done
-                    dash_sdk_identity_destroy(idMut(ownerIdentityHandle))
+                    dash_sdk_identity_destroy(ownerIdentityHandle)
                 }
 
                 // Get the owner ID from the identity
@@ -2096,7 +2085,7 @@ extension SDK {
 
                 // Get the public key handle for the destroy key
                 let keyHandleResult = dash_sdk_identity_get_public_key_by_id(
-                    idConst(ownerIdentityHandle),
+                    ownerIdentityHandle,
                     UInt8(destroyKey.id)
                 )
 
@@ -2109,7 +2098,7 @@ extension SDK {
                     return
                 }
 
-                let publicKeyHandle = keyHandleData.assumingMemoryBound(to: IdentityPublicKeyHandle.self)
+                let publicKeyHandle = OpaquePointer(keyHandleData)
                 defer {
                     // Clean up the public key handle when done
                     dash_sdk_identity_public_key_destroy(publicKeyHandle)
@@ -2136,7 +2125,7 @@ extension SDK {
                                         ownerIdBytes.bindMemory(to: UInt8.self).baseAddress!,
                                         &params,
                                         publicKeyHandle,
-                                        signerConst(signerBox.p),
+                                        signerBox.p,
                                         nil,  // Default put settings
                                         nil   // Default state transition options
                                     )
@@ -2149,7 +2138,7 @@ extension SDK {
                                     ownerIdBytes.bindMemory(to: UInt8.self).baseAddress!,
                                     &params,
                                     publicKeyHandle,
-                                    signerConst(signerBox.p),
+                                    signerBox.p,
                                     nil,  // Default put settings
                                     nil   // Default state transition options
                                 )
@@ -2203,7 +2192,7 @@ extension SDK {
 
                 defer {
                     // Clean up the identity handle when done
-                    dash_sdk_identity_destroy(idMut(ownerIdentityHandle))
+                    dash_sdk_identity_destroy(ownerIdentityHandle)
                 }
 
                 // Get the owner ID from the identity
@@ -2211,7 +2200,7 @@ extension SDK {
 
                 // Get the public key handle for the claiming key
                 let keyHandleResult = dash_sdk_identity_get_public_key_by_id(
-                    idConst(ownerIdentityHandle),
+                    ownerIdentityHandle,
                     UInt8(keyId)
                 )
 
@@ -2224,7 +2213,7 @@ extension SDK {
                     return
                 }
 
-                let publicKeyHandle = keyHandleData.assumingMemoryBound(to: IdentityPublicKeyHandle.self)
+                let publicKeyHandle = OpaquePointer(keyHandleData)
                 defer {
                     // Clean up the public key handle when done
                     dash_sdk_identity_public_key_destroy(publicKeyHandle)
@@ -2262,7 +2251,7 @@ extension SDK {
                                     ownerIdBytes.bindMemory(to: UInt8.self).baseAddress!,
                                     &params,
                                     publicKeyHandle,
-                                    signerConst(signerBox.p),
+                                    signerBox.p,
                                     nil,  // Default put settings
                                     nil   // Default state transition options
                                 )
@@ -2275,7 +2264,7 @@ extension SDK {
                                 ownerIdBytes.bindMemory(to: UInt8.self).baseAddress!,
                                 &params,
                                 publicKeyHandle,
-                                signerConst(signerBox.p),
+                                signerBox.p,
                                 nil,  // Default put settings
                                 nil   // Default state transition options
                             )
@@ -2329,7 +2318,7 @@ extension SDK {
 
                 defer {
                     // Clean up the identity handle when done
-                    dash_sdk_identity_destroy(idMut(ownerIdentityHandle))
+                    dash_sdk_identity_destroy(ownerIdentityHandle)
                 }
 
                 // Get the owner ID from the identity
@@ -2347,7 +2336,7 @@ extension SDK {
 
                 // Get the public key handle for the transfer key
                 let keyHandleResult = dash_sdk_identity_get_public_key_by_id(
-                    idConst(ownerIdentityHandle),
+                    ownerIdentityHandle,
                     UInt8(keyId)
                 )
 
@@ -2360,7 +2349,7 @@ extension SDK {
                     return
                 }
 
-                let publicKeyHandle = keyHandleData.assumingMemoryBound(to: IdentityPublicKeyHandle.self)
+                let publicKeyHandle = OpaquePointer(keyHandleData)
                 defer {
                     // Clean up the public key handle when done
                     dash_sdk_identity_public_key_destroy(publicKeyHandle)
@@ -2390,7 +2379,7 @@ extension SDK {
                                         ownerIdBytes.bindMemory(to: UInt8.self).baseAddress!,
                                         &params,
                                         publicKeyHandle,
-                                        signerConst(signerBox.p),
+                                        signerBox.p,
                                         nil,  // Default put settings
                                         nil   // Default state transition options
                                     )
@@ -2403,7 +2392,7 @@ extension SDK {
                                     ownerIdBytes.bindMemory(to: UInt8.self).baseAddress!,
                                     &params,
                                     publicKeyHandle,
-                                    signerConst(signerBox.p),
+                                    signerBox.p,
                                     nil,  // Default put settings
                                     nil   // Default state transition options
                                 )
@@ -2458,7 +2447,7 @@ extension SDK {
 
                 defer {
                     // Clean up the identity handle when done
-                    dash_sdk_identity_destroy(idMut(ownerIdentityHandle))
+                    dash_sdk_identity_destroy(ownerIdentityHandle)
                 }
 
                 // Get the owner ID from the identity
@@ -2466,7 +2455,7 @@ extension SDK {
 
                 // Get the public key handle for the pricing key
                 let keyHandleResult = dash_sdk_identity_get_public_key_by_id(
-                    idConst(ownerIdentityHandle),
+                    ownerIdentityHandle,
                     UInt8(keyId)
                 )
 
@@ -2479,7 +2468,7 @@ extension SDK {
                     return
                 }
 
-                let publicKeyHandle = keyHandleData.assumingMemoryBound(to: IdentityPublicKeyHandle.self)
+                let publicKeyHandle = OpaquePointer(keyHandleData)
                 defer {
                     // Clean up the public key handle when done
                     dash_sdk_identity_public_key_destroy(publicKeyHandle)
@@ -2531,7 +2520,7 @@ extension SDK {
                                     ownerIdBytes.bindMemory(to: UInt8.self).baseAddress!,
                                     &params,
                                     publicKeyHandle,
-                                    signerConst(signerBox.p),
+                                    signerBox.p,
                                     nil,  // Default put settings
                                     nil   // Default state transition options
                                 )
@@ -2544,7 +2533,7 @@ extension SDK {
                                 ownerIdBytes.bindMemory(to: UInt8.self).baseAddress!,
                                 &params,
                                 publicKeyHandle,
-                                signerConst(signerBox.p),
+                                signerBox.p,
                                 nil,  // Default put settings
                                 nil   // Default state transition options
                             )
@@ -2590,7 +2579,7 @@ extension SDK {
         let identityHandle = try identityToHandle(identity)
         defer {
             // Clean up the handle when done
-            dash_sdk_identity_destroy(idMut(identityHandle))
+            dash_sdk_identity_destroy(identityHandle)
         }
 
         // Call the lower-level method
@@ -2615,7 +2604,7 @@ extension SDK {
         let identityHandle = try identityToHandle(identity)
         defer {
             // Clean up the handle when done
-            dash_sdk_identity_destroy(idMut(identityHandle))
+            dash_sdk_identity_destroy(identityHandle)
         }
 
         // Call the lower-level method
@@ -2640,7 +2629,7 @@ extension SDK {
         let identityHandle = try identityToHandle(identity)
         defer {
             // Clean up the handle when done
-            dash_sdk_identity_destroy(idMut(identityHandle))
+            dash_sdk_identity_destroy(identityHandle)
         }
 
         // Call the lower-level method

--- a/packages/swift-sdk/Sources/SwiftDashSDK/KeyWallet/Account.swift
+++ b/packages/swift-sdk/Sources/SwiftDashSDK/KeyWallet/Account.swift
@@ -3,10 +3,10 @@ import DashSDKFFI
 
 /// Swift wrapper for a wallet account
 public class Account {
-    private let handle: UnsafeMutablePointer<FFIAccount>
+    private let handle: OpaquePointer
     private weak var wallet: Wallet?
 
-    internal init(handle: UnsafeMutablePointer<FFIAccount>, wallet: Wallet) {
+    internal init(handle: OpaquePointer, wallet: Wallet) {
         self.handle = handle
         self.wallet = wallet
     }

--- a/packages/swift-sdk/Sources/SwiftDashSDK/KeyWallet/AccountCollection.swift
+++ b/packages/swift-sdk/Sources/SwiftDashSDK/KeyWallet/AccountCollection.swift
@@ -3,10 +3,10 @@ import DashSDKFFI
 
 /// Swift wrapper for a collection of accounts
 public class AccountCollection {
-    private let handle: UnsafeMutablePointer<FFIAccountCollection>
+    private let handle: OpaquePointer
     private weak var wallet: Wallet?
 
-    internal init(handle: UnsafeMutablePointer<FFIAccountCollection>, wallet: Wallet) {
+    internal init(handle: OpaquePointer, wallet: Wallet) {
         self.handle = handle
         self.wallet = wallet
     }
@@ -22,7 +22,7 @@ public class AccountCollection {
         guard let rawPointer = account_collection_get_provider_operator_keys(handle) else {
             return nil
         }
-        let accountHandle = rawPointer.assumingMemoryBound(to: FFIBLSAccount.self)
+        let accountHandle = OpaquePointer(rawPointer)
         return BLSAccount(handle: accountHandle, wallet: wallet)
     }
 
@@ -33,7 +33,7 @@ public class AccountCollection {
         guard let rawPointer = account_collection_get_provider_platform_keys(handle) else {
             return nil
         }
-        let accountHandle = rawPointer.assumingMemoryBound(to: FFIEdDSAAccount.self)
+        let accountHandle = OpaquePointer(rawPointer)
         return EdDSAAccount(handle: accountHandle, wallet: wallet)
     }
 

--- a/packages/swift-sdk/Sources/SwiftDashSDK/KeyWallet/AddressPool.swift
+++ b/packages/swift-sdk/Sources/SwiftDashSDK/KeyWallet/AddressPool.swift
@@ -3,9 +3,9 @@ import DashSDKFFI
 
 /// Swift wrapper for an address pool from a managed account
 public class AddressPool {
-    private let handle: UnsafeMutablePointer<FFIAddressPool>
+    private let handle: OpaquePointer
 
-    internal init(handle: UnsafeMutablePointer<FFIAddressPool>) {
+    internal init(handle: OpaquePointer) {
         self.handle = handle
     }
 

--- a/packages/swift-sdk/Sources/SwiftDashSDK/KeyWallet/BLSAccount.swift
+++ b/packages/swift-sdk/Sources/SwiftDashSDK/KeyWallet/BLSAccount.swift
@@ -3,10 +3,10 @@ import DashSDKFFI
 
 /// Swift wrapper for a BLS account (used for provider keys)
 public class BLSAccount {
-    internal let handle: UnsafeMutablePointer<FFIBLSAccount>
+    internal let handle: OpaquePointer
     private weak var wallet: Wallet?
 
-    internal init(handle: UnsafeMutablePointer<FFIBLSAccount>, wallet: Wallet?) {
+    internal init(handle: OpaquePointer, wallet: Wallet?) {
         self.handle = handle
         self.wallet = wallet
     }

--- a/packages/swift-sdk/Sources/SwiftDashSDK/KeyWallet/EdDSAAccount.swift
+++ b/packages/swift-sdk/Sources/SwiftDashSDK/KeyWallet/EdDSAAccount.swift
@@ -3,10 +3,10 @@ import DashSDKFFI
 
 /// Swift wrapper for an EdDSA account (used for platform P2P keys)
 public class EdDSAAccount {
-    internal let handle: UnsafeMutablePointer<FFIEdDSAAccount>
+    internal let handle: OpaquePointer
     private weak var wallet: Wallet?
 
-    internal init(handle: UnsafeMutablePointer<FFIEdDSAAccount>, wallet: Wallet?) {
+    internal init(handle: OpaquePointer, wallet: Wallet?) {
         self.handle = handle
         self.wallet = wallet
     }

--- a/packages/swift-sdk/Sources/SwiftDashSDK/KeyWallet/KeyDerivation.swift
+++ b/packages/swift-sdk/Sources/SwiftDashSDK/KeyWallet/KeyDerivation.swift
@@ -262,9 +262,9 @@ public class KeyDerivation {
 
 /// Extended private key handle
 public class ExtendedPrivateKey {
-    private let handle: UnsafeMutablePointer<FFIExtendedPrivKey>
+    private let handle: OpaquePointer
 
-    internal init(handle: UnsafeMutablePointer<FFIExtendedPrivKey>) {
+    internal init(handle: OpaquePointer) {
         self.handle = handle
     }
 
@@ -307,9 +307,9 @@ public class ExtendedPrivateKey {
 
 /// Extended public key handle
 public class ExtendedPublicKey {
-    private let handle: UnsafeMutablePointer<FFIExtendedPubKey>
+    private let handle: OpaquePointer
 
-    internal init(handle: UnsafeMutablePointer<FFIExtendedPubKey>) {
+    internal init(handle: OpaquePointer) {
         self.handle = handle
     }
 

--- a/packages/swift-sdk/Sources/SwiftDashSDK/KeyWallet/KeyManager.swift
+++ b/packages/swift-sdk/Sources/SwiftDashSDK/KeyWallet/KeyManager.swift
@@ -348,8 +348,7 @@ public final class KeyManager: Sendable {
   /// Destroy a signer handle
   /// - Parameter signer: The signer handle to destroy
   public func destroySigner(_ signer: OpaquePointer) {
-    let signerPtr = UnsafeMutablePointer<SignerHandle>(signer)
-    dash_sdk_signer_destroy(signerPtr)
+    dash_sdk_signer_destroy(signer)
   }
 
   // MARK: - Key Validation

--- a/packages/swift-sdk/Sources/SwiftDashSDK/KeyWallet/ManagedAccount.swift
+++ b/packages/swift-sdk/Sources/SwiftDashSDK/KeyWallet/ManagedAccount.swift
@@ -3,10 +3,10 @@ import DashSDKFFI
 
 /// Swift wrapper for a managed account with address pool management
 public class ManagedAccount {
-    internal let handle: UnsafeMutablePointer<FFIManagedCoreAccount>
+    internal let handle: OpaquePointer
     private let manager: WalletManager
 
-    internal init(handle: UnsafeMutablePointer<FFIManagedCoreAccount>, manager: WalletManager) {
+    internal init(handle: OpaquePointer, manager: WalletManager) {
         self.handle = handle
         self.manager = manager
     }

--- a/packages/swift-sdk/Sources/SwiftDashSDK/KeyWallet/ManagedAccountCollection.swift
+++ b/packages/swift-sdk/Sources/SwiftDashSDK/KeyWallet/ManagedAccountCollection.swift
@@ -3,10 +3,10 @@ import DashSDKFFI
 
 /// Swift wrapper for a collection of managed accounts
 public class ManagedAccountCollection {
-    private let handle: UnsafeMutablePointer<FFIManagedCoreAccountCollection>
+    private let handle: OpaquePointer
     private let manager: WalletManager
 
-    internal init(handle: UnsafeMutablePointer<FFIManagedCoreAccountCollection>, manager: WalletManager) {
+    internal init(handle: OpaquePointer, manager: WalletManager) {
         self.handle = handle
         self.manager = manager
     }
@@ -211,7 +211,7 @@ public class ManagedAccountCollection {
         guard let rawPointer = managed_account_collection_get_provider_operator_keys(handle) else {
             return nil
         }
-        let accountHandle = rawPointer.assumingMemoryBound(to: FFIManagedCoreAccount.self)
+        let accountHandle = OpaquePointer(rawPointer)
         return ManagedAccount(handle: accountHandle, manager: manager)
     }
 
@@ -225,7 +225,7 @@ public class ManagedAccountCollection {
         guard let rawPointer = managed_account_collection_get_provider_platform_keys(handle) else {
             return nil
         }
-        let accountHandle = rawPointer.assumingMemoryBound(to: FFIManagedCoreAccount.self)
+        let accountHandle = OpaquePointer(rawPointer)
         return ManagedAccount(handle: accountHandle, manager: manager)
     }
 

--- a/packages/swift-sdk/Sources/SwiftDashSDK/KeyWallet/ManagedPlatformAccount.swift
+++ b/packages/swift-sdk/Sources/SwiftDashSDK/KeyWallet/ManagedPlatformAccount.swift
@@ -4,9 +4,6 @@
 // Swift wrapper for a managed platform payment account (DIP-17).
 // Platform payment accounts are identified by (account_index, key_class)
 // and hold credit/duff balances with their own address pool.
-//
-// FFIManagedPlatformAccount is an opaque C type with a minimal body so Swift
-// can use typed pointers (UnsafeMutablePointer<FFIManagedPlatformAccount>).
 
 import Foundation
 import DashSDKFFI
@@ -33,9 +30,9 @@ public struct PlatformPaymentAccountKey: Sendable, Equatable {
 /// Provides access to credit/duff balances, address counts, and the
 /// account's address pool. The underlying FFI handle is freed on deinit.
 public class ManagedPlatformAccount {
-    private let handle: UnsafeMutablePointer<FFIManagedPlatformAccount>
+    private let handle: OpaquePointer
 
-    internal init(handle: UnsafeMutablePointer<FFIManagedPlatformAccount>) {
+    internal init(handle: OpaquePointer) {
         self.handle = handle
     }
 

--- a/packages/swift-sdk/Sources/SwiftDashSDK/KeyWallet/Wallet.swift
+++ b/packages/swift-sdk/Sources/SwiftDashSDK/KeyWallet/Wallet.swift
@@ -3,7 +3,7 @@ import DashSDKFFI
 
 /// Swift wrapper for a Dash wallet with HD key derivation
 public class Wallet {
-    internal let handle: UnsafeMutablePointer<FFIWallet>
+    internal let handle: OpaquePointer
     private let ownsHandle: Bool
 
     // MARK: - Static Methods
@@ -33,7 +33,7 @@ public class Wallet {
                 accountOptions: AccountCreationOption = .default) throws {
 
         var error = FFIError()
-        let walletPtr: UnsafeMutablePointer<FFIWallet>?
+        let walletPtr: OpaquePointer?
 
         if case .specificAccounts = accountOptions {
             // Use the with_options variant for specific accounts
@@ -84,7 +84,7 @@ public class Wallet {
         self.ownsHandle = true
 
         var error = FFIError()
-        let walletPtr: UnsafeMutablePointer<FFIWallet>? = seed.withUnsafeBytes { seedBytes in
+        let walletPtr: OpaquePointer? = seed.withUnsafeBytes { seedBytes in
             let seedPtr = seedBytes.bindMemory(to: UInt8.self).baseAddress
 
             if case .specificAccounts = accountOptions {
@@ -161,7 +161,7 @@ public class Wallet {
     public static func createRandom(network: Network = .mainnet,
                                    accountOptions: AccountCreationOption = .default) throws -> Wallet {
         var error = FFIError()
-        let walletPtr: UnsafeMutablePointer<FFIWallet>?
+        let walletPtr: OpaquePointer?
 
         if case .specificAccounts = accountOptions {
             var options = accountOptions.toFFIOptions()
@@ -186,7 +186,7 @@ public class Wallet {
     }
 
     /// Private initializer for internal use (takes ownership)
-    private init(handle: UnsafeMutablePointer<FFIWallet>, network: Network) {
+    private init(handle: OpaquePointer, network: Network) {
         self.handle = handle
         self.ownsHandle = true
     }
@@ -510,11 +510,11 @@ public class Wallet {
         return AccountCollection(handle: collectionHandle, wallet: self)
     }
 
-    internal var ffiHandle: UnsafeMutablePointer<FFIWallet> { handle }
+    internal var ffiHandle: OpaquePointer { handle }
 
     // Non-owning initializer for wallets obtained from WalletManager
     public init(nonOwningHandle handle: UnsafeRawPointer) {
-        self.handle = UnsafeMutablePointer<FFIWallet>(mutating: handle.bindMemory(to: FFIWallet.self, capacity: 1))
+        self.handle = OpaquePointer(handle)
         self.ownsHandle = false
     }
 

--- a/packages/swift-sdk/Sources/SwiftDashSDK/KeyWallet/WalletManager.swift
+++ b/packages/swift-sdk/Sources/SwiftDashSDK/KeyWallet/WalletManager.swift
@@ -3,7 +3,7 @@ import DashSDKFFI
 
 /// Swift wrapper for wallet manager that manages multiple wallets
 public class WalletManager {
-    private let handle: UnsafeMutablePointer<FFIWalletManager>
+    private let handle: OpaquePointer
     internal let network: Network
     private let ownsHandle: Bool
 
@@ -27,7 +27,7 @@ public class WalletManager {
 
     /// Create a wallet manager wrapper from an existing handle (does not own the handle)
     /// - Parameter handle: The FFI wallet manager handle
-    internal init(handle: UnsafeMutablePointer<FFIWalletManager>) throws {
+    internal init(handle: OpaquePointer) throws {
         var error = FFIError()
         let network = wallet_manager_network(handle, &error)
 
@@ -578,7 +578,7 @@ public class WalletManager {
         }
     }
 
-    internal var ffiHandle: UnsafeMutablePointer<FFIWalletManager> { handle }
+    internal var ffiHandle: OpaquePointer { handle }
 
     // MARK: - Serialization
 

--- a/packages/swift-sdk/Sources/SwiftDashSDK/SDK.swift
+++ b/packages/swift-sdk/Sources/SwiftDashSDK/SDK.swift
@@ -49,7 +49,7 @@ extension Data {
 
 /// Swift wrapper for the Dash Platform SDK
 public final class SDK: @unchecked Sendable {
-  public private(set) var handle: UnsafeMutablePointer<SDKHandle>?
+  public private(set) var handle: OpaquePointer?
 
   /// The network this SDK instance is connected to
   public private(set) var network: Network = .testnet
@@ -363,7 +363,7 @@ public final class SDK: @unchecked Sendable {
     }
 
     // Store the handle and network
-    handle = result.data?.assumingMemoryBound(to: SDKHandle.self)
+    handle = OpaquePointer(result.data)
     self.network = network
   }
 

--- a/packages/swift-sdk/SwiftExampleApp/SwiftExampleApp/Views/TransitionDetailView.swift
+++ b/packages/swift-sdk/SwiftExampleApp/SwiftExampleApp/Views/TransitionDetailView.swift
@@ -847,7 +847,7 @@ struct TransitionDetailView: View {
       from: dppIdentity,
       toIdentityId: normalizedToIdentityId,
       amount: amount,
-      signer: OpaquePointer(signer.handle)
+      signer: signer.handle
     )
     _ = signer  // keepalive
 
@@ -901,7 +901,7 @@ struct TransitionDetailView: View {
       amount: amount,
       toAddress: toAddress,
       coreFeePerByte: coreFeePerByte,
-      signer: OpaquePointer(signer.handle)
+      signer: signer.handle
     )
     _ = signer  // keepalive
 
@@ -998,7 +998,7 @@ struct TransitionDetailView: View {
       documentType: documentType,
       ownerIdentity: dppIdentity,
       properties: properties,
-      signer: OpaquePointer(signer.handle)
+      signer: signer.handle
     )
     _ = signer  // keepalive
 
@@ -1042,7 +1042,7 @@ struct TransitionDetailView: View {
       documentType: documentType,
       documentId: documentId,
       ownerIdentity: dppIdentity,
-      signer: OpaquePointer(signer.handle)
+      signer: signer.handle
     )
     _ = signer  // keepalive across the await — see KeychainSigner lifetime contract
 
@@ -1098,7 +1098,7 @@ struct TransitionDetailView: View {
       documentId: documentId,
       fromIdentity: fromIdentity,
       toIdentityId: recipientId,
-      signer: OpaquePointer(signer.handle)
+      signer: signer.handle
     )
     _ = signer  // keepalive
 
@@ -1153,7 +1153,7 @@ struct TransitionDetailView: View {
       documentId: documentId,
       newPrice: newPrice,
       ownerIdentity: ownerDPPIdentity,
-      signer: OpaquePointer(signer.handle)
+      signer: signer.handle
     )
     _ = signer  // keepalive
 
@@ -1211,7 +1211,7 @@ struct TransitionDetailView: View {
       documentId: documentId,
       purchaserIdentity: fromIdentity,
       price: price,
-      signer: OpaquePointer(signer.handle)
+      signer: signer.handle
     )
     _ = signer  // keepalive
 
@@ -1304,7 +1304,7 @@ struct TransitionDetailView: View {
       documentId: documentId,
       ownerIdentity: dppIdentity,
       properties: properties,
-      signer: OpaquePointer(signer.handle)
+      signer: signer.handle
     )
     _ = signer  // keepalive
 
@@ -1401,7 +1401,7 @@ struct TransitionDetailView: View {
       amount: amount,
       ownerIdentity: dppIdentity,
       keyId: mintingKey.id,
-      signer: OpaquePointer(signer.handle),
+      signer: signer.handle,
       note: note
     )
     _ = signer  // keepalive
@@ -1489,7 +1489,7 @@ struct TransitionDetailView: View {
       amount: amount,
       ownerIdentity: dppIdentity,
       keyId: burningKey.id,
-      signer: OpaquePointer(signer.handle),
+      signer: signer.handle,
       note: note
     )
     _ = signer  // keepalive
@@ -1542,7 +1542,7 @@ struct TransitionDetailView: View {
       targetIdentityId: targetIdentityId,
       ownerIdentity: dppIdentity,
       keyId: freezingKey.id,
-      signer: OpaquePointer(signer.handle),
+      signer: signer.handle,
       note: note
     )
     _ = signer  // keepalive
@@ -1590,7 +1590,7 @@ struct TransitionDetailView: View {
       targetIdentityId: targetIdentityId,
       ownerIdentity: dppIdentity,
       keyId: unfreezingKey.id,
-      signer: OpaquePointer(signer.handle),
+      signer: signer.handle,
       note: formInputs["note"]
     )
     _ = signer  // keepalive
@@ -1638,7 +1638,7 @@ struct TransitionDetailView: View {
       frozenIdentityId: frozenIdentityId,
       ownerIdentity: dppIdentity,
       keyId: destroyKey.id,
-      signer: OpaquePointer(signer.handle),
+      signer: signer.handle,
       note: formInputs["note"]
     )
     _ = signer  // keepalive
@@ -1688,7 +1688,7 @@ struct TransitionDetailView: View {
       distributionType: distributionType,
       ownerIdentity: dppIdentity,
       keyId: claimingKey.id,
-      signer: OpaquePointer(signer.handle),
+      signer: signer.handle,
       note: note
     )
     _ = signer  // keepalive
@@ -1760,7 +1760,7 @@ struct TransitionDetailView: View {
       amount: amount,
       ownerIdentity: dppIdentity,
       keyId: transferKey.id,
-      signer: OpaquePointer(signer.handle),
+      signer: signer.handle,
       note: note
     )
     _ = signer  // keepalive
@@ -1814,7 +1814,7 @@ struct TransitionDetailView: View {
       priceData: priceData,
       ownerIdentity: dppIdentity,
       keyId: pricingKey.id,
-      signer: OpaquePointer(signer.handle),
+      signer: signer.handle,
       note: note
     )
     _ = signer  // keepalive

--- a/packages/swift-sdk/SwiftExampleApp/SwiftExampleApp/WalletManagerStore.swift
+++ b/packages/swift-sdk/SwiftExampleApp/SwiftExampleApp/WalletManagerStore.swift
@@ -64,7 +64,7 @@ final class WalletManagerStore: ObservableObject {
     /// otherwise the cached manager keeps using its own Sdk clone
     /// with stale DAPI / quorum endpoints, and proof verification
     /// fails forever ("no available addresses to use").
-    private var managerSdkHandles: [Network: UnsafeMutablePointer<SDKHandle>] = [:]
+    private var managerSdkHandles: [Network: OpaquePointer] = [:]
 
     /// SwiftData container shared across every manager. Each
     /// manager's persistence handler narrows its `loadWalletList`

--- a/packages/swift-sdk/SwiftExampleApp/SwiftExampleAppTests/SimpleTransitionTests.swift
+++ b/packages/swift-sdk/SwiftExampleApp/SwiftExampleAppTests/SimpleTransitionTests.swift
@@ -75,7 +75,7 @@ final class SimpleTransitionTests: XCTestCase {
       }
 
       defer {
-        dash_sdk_identity_destroy(identityHandle.assumingMemoryBound(to: IdentityHandle.self))
+        dash_sdk_identity_destroy(OpaquePointer(identityHandle))
       }
 
       // Use key ID 3 (transfer key) directly
@@ -97,7 +97,7 @@ final class SimpleTransitionTests: XCTestCase {
       }
 
       defer {
-        dash_sdk_signer_destroy(signer.assumingMemoryBound(to: SignerHandle.self))
+        dash_sdk_signer_destroy(OpaquePointer(signer))
       }
 
       // `OpaquePointer` lost its retroactive `Sendable` conformance

--- a/packages/swift-sdk/SwiftExampleApp/SwiftExampleAppTests/StateTransitionTests.swift
+++ b/packages/swift-sdk/SwiftExampleApp/SwiftExampleAppTests/StateTransitionTests.swift
@@ -116,7 +116,7 @@ final class StateTransitionTests: XCTestCase {
       }
 
       defer {
-        dash_sdk_identity_destroy(identityHandle.assumingMemoryBound(to: IdentityHandle.self))
+        dash_sdk_identity_destroy(OpaquePointer(identityHandle))
       }
 
       // Use key ID 3 (transfer key) directly
@@ -137,7 +137,7 @@ final class StateTransitionTests: XCTestCase {
       }
 
       defer {
-        dash_sdk_signer_destroy(signer.assumingMemoryBound(to: SignerHandle.self))
+        dash_sdk_signer_destroy(OpaquePointer(signer))
       }
 
       // `OpaquePointer` lost its retroactive `Sendable` conformance
@@ -286,7 +286,7 @@ final class StateTransitionTests: XCTestCase {
         }
 
         defer {
-          dash_sdk_signer_destroy(signer.assumingMemoryBound(to: SignerHandle.self))
+          dash_sdk_signer_destroy(OpaquePointer(signer))
         }
 
         print("   Calling transferCredits...")
@@ -380,7 +380,7 @@ final class StateTransitionTests: XCTestCase {
     }
 
     defer {
-      dash_sdk_signer_destroy(signer.assumingMemoryBound(to: SignerHandle.self))
+      dash_sdk_signer_destroy(OpaquePointer(signer))
     }
 
     nonisolated(unsafe) let signerPtr = OpaquePointer(signer)
@@ -475,7 +475,7 @@ final class StateTransitionTests: XCTestCase {
     }
 
     defer {
-      dash_sdk_signer_destroy(signer.assumingMemoryBound(to: SignerHandle.self))
+      dash_sdk_signer_destroy(OpaquePointer(signer))
     }
 
     print("✅ Signer created successfully")
@@ -492,7 +492,7 @@ final class StateTransitionTests: XCTestCase {
     // Try to sign the data
     let signResult = testData.withUnsafeBytes { dataBytes in
       dash_sdk_signer_sign(
-        signer.assumingMemoryBound(to: SignerHandle.self),
+        OpaquePointer(signer),
         dataBytes.bindMemory(to: UInt8.self).baseAddress!,
         UInt(testData.count)
       )
@@ -546,7 +546,7 @@ final class StateTransitionTests: XCTestCase {
     }
 
     defer {
-      dash_sdk_signer_destroy(signer.assumingMemoryBound(to: SignerHandle.self))
+      dash_sdk_signer_destroy(OpaquePointer(signer))
     }
 
     print("✅ Signer created")
@@ -568,7 +568,7 @@ final class StateTransitionTests: XCTestCase {
     }
 
     defer {
-      dash_sdk_identity_destroy(identityHandle.assumingMemoryBound(to: IdentityHandle.self))
+      dash_sdk_identity_destroy(OpaquePointer(identityHandle))
     }
 
     print("✅ Identity handle fetched")
@@ -586,11 +586,11 @@ final class StateTransitionTests: XCTestCase {
     let result = recipientId.withCString { toIdCStr in
       dash_sdk_identity_transfer_credits(
         sdk.handle,
-        identityHandle.assumingMemoryBound(to: IdentityHandle.self),
+        OpaquePointer(identityHandle),
         toIdCStr,
         amount,
         0,  // Auto-select key
-        signer.assumingMemoryBound(to: SignerHandle.self),
+        OpaquePointer(signer),
         nil  // Default put settings
       )
     }

--- a/packages/swift-sdk/SwiftTests/SwiftDashSDKTests/SDKMethodTests.swift
+++ b/packages/swift-sdk/SwiftTests/SwiftDashSDKTests/SDKMethodTests.swift
@@ -71,7 +71,7 @@ final class SDKMethodTests: XCTestCase {
       }
 
       defer {
-        dash_sdk_signer_destroy(signer.assumingMemoryBound(to: SignerHandle.self))
+        dash_sdk_signer_destroy(OpaquePointer(signer))
       }
 
       nonisolated(unsafe) let signerPtr = OpaquePointer(signer)

--- a/packages/swift-sdk/build_ios.sh
+++ b/packages/swift-sdk/build_ios.sh
@@ -126,6 +126,29 @@ log_info "Package: $PACKAGE"
 log_info "Profile: $PROFILE"
 
 # -------------------------------
+# Force header regeneration
+# -------------------------------
+# TODO: this is a temporal fix. Because this script
+# was modifying the headers in place, this PR, that removes
+# that weird behaviour, hits an issue, cargo doesnt re-run
+# the build.rs scripts, leaving the old modified headers,
+# so I have to force the headers generation for this PR
+#
+# Once this change is in the dev branch a new PR will be open
+# removing this step
+log_info "Forcing cbindgen header regeneration: ${INCLUDED_CRATES[*]}"
+TRIPLES=()
+if $BUILD_IOS; then TRIPLES+=("aarch64-apple-ios"); fi
+if $BUILD_SIM; then TRIPLES+=("aarch64-apple-ios-sim"); fi
+if $BUILD_MAC; then TRIPLES+=("aarch64-apple-darwin"); fi
+for triple in "${TRIPLES[@]}"; do
+  for c in "${INCLUDED_CRATES[@]}"; do
+    cargo clean -p "$c" --profile "$PROFILE" --target "$triple"
+  done
+  rm -rf "$TARGET_DIR/$triple/$OUTPUT_DIR/include"
+done
+
+# -------------------------------
 # Build commands
 # -------------------------------
 
@@ -173,20 +196,6 @@ module DashSDKFFI {
 }
 EOF
   log_info "  → module.modulemap + umbrella header injected in $HEADERS_DIR"
-
-  # Give opaque struct forward declarations a body so Swift can use UnsafeMutablePointer<T>.
-  # Skip types that already have a full definition in another header to avoid redefinition.
-  local defined
-  defined=$(grep -oh 'typedef struct [A-Za-z_][A-Za-z_0-9]* {' "$HEADERS_DIR"/*/*.h 2>/dev/null \
-    | sed 's/typedef struct \([^ ]*\) {/\1/' | sort -u | paste -sd'|' - || true)
-  for h in "$HEADERS_DIR"/*/*.h; do
-    if [ -n "$defined" ]; then
-      perl -i -pe "s/^typedef struct (\w+) \1;\$/
-        my \$n=\$1; \$n=~m{^($defined)\$} ? \$_ : \"typedef struct \$n { uint8_t _opaque; } \$n;\n\"/e" "$h"
-    else
-      perl -i -pe 's/^typedef struct (\w+) \1;$/typedef struct $1 { uint8_t _opaque; } $1;/' "$h"
-    fi
-  done
 }
 
 # Shielded (Orchard / ZK) support is compiled in by default. The


### PR DESCRIPTION
The build_ios.sh script was modifying the headers in place for compatibility after the rewrite I made months ago, with this PR I remove that logic to use the generated headers the way they were generated


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [x] I have made corresponding changes to the documentation if needed

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Internal improvements to pointer handling across the Swift SDK for enhanced compatibility with FFI (Foreign Function Interface) layer.
  * Optimized code structure in SDK components without affecting visible functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->