### PR TITLE
fix(drive): return error instead of panicking on empty SetPrices direct purchase

### DIFF
--- a/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/batch/tests/token/direct_selling/mod.rs
+++ b/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/batch/tests/token/direct_selling/mod.rs
@@ -980,4 +980,88 @@ mod token_selling_tests {
             .expect("expected to fetch token balance");
         assert_eq!(token_balance, None);
     }
+
+    /// Companion to the empty-`SetPrices` regression test: a NON-empty tiered
+    /// schedule whose smallest tier is above the requested amount must be
+    /// rejected as below the minimum sale amount (the `Some` arm of the same
+    /// no-matching-tier branch), not panic.
+    #[tokio::test]
+    async fn test_direct_purchase_below_minimum_sale_amount() {
+        let platform_version = PlatformVersion::latest();
+        let mut platform = TestPlatformBuilder::new()
+            .with_latest_protocol_version()
+            .build_with_mock_rpc()
+            .set_genesis_state();
+
+        let mut rng = StdRng::seed_from_u64(12345);
+        let (seller, seller_signer, seller_key) =
+            setup_identity(&mut platform, rng.gen(), dash_to_credits!(1.0));
+        let (buyer, buyer_signer, buyer_key) =
+            setup_identity(&mut platform, rng.gen(), dash_to_credits!(10.0));
+
+        // Tiered schedule whose smallest tier requires at least 100 tokens.
+        let tiered = TokenPricingSchedule::SetPrices(BTreeMap::from([
+            (100, dash_to_credits!(10)),
+            (500, dash_to_credits!(5)),
+        ]));
+
+        let mut identity_contract_nonce: u64 = 2;
+        let (contract, token_id) = create_token_with_pricing(
+            platform_version,
+            &mut platform,
+            &seller,
+            &seller_signer,
+            &seller_key,
+            Some(tiered),
+            &mut identity_contract_nonce,
+        )
+        .await;
+
+        // Buyer asks for 3 tokens — below the smallest (100-token) tier, so
+        // `range(..=3).next_back()` is `None` and the smallest defined tier (100)
+        // is reported as the minimum sale amount.
+        let platform_state = platform.state.load();
+        let purchase_transition = BatchTransition::new_token_direct_purchase_transition(
+            token_id,
+            buyer.id(),
+            contract.id(),
+            0,
+            3,
+            dash_to_credits!(3),
+            &buyer_key,
+            2,
+            0,
+            &buyer_signer,
+            platform_version,
+            None,
+        )
+        .await
+        .unwrap();
+
+        let processing_result = process_test_state_transition(
+            &mut platform,
+            purchase_transition,
+            &platform_state,
+            platform_version,
+        );
+
+        assert_matches!(
+            processing_result.execution_results().as_slice(),
+            [PaidConsensusError {
+                error: ConsensusError::StateError(StateError::TokenAmountUnderMinimumSaleAmount(_)),
+                ..
+            }]
+        );
+
+        let token_balance = platform
+            .drive
+            .fetch_identity_token_balance(
+                token_id.to_buffer(),
+                buyer.id().to_buffer(),
+                None,
+                platform_version,
+            )
+            .expect("expected to fetch token balance");
+        assert_eq!(token_balance, None);
+    }
 }

--- a/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/batch/tests/token/direct_selling/mod.rs
+++ b/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/batch/tests/token/direct_selling/mod.rs
@@ -890,4 +890,94 @@ mod token_selling_tests {
         );
         (contract, token_id)
     }
+
+    /// Regression test for the chain-halt where an empty `SetPrices` schedule
+    /// caused a `.expect("Map is not empty")` panic in the direct-purchase
+    /// transformer.
+    ///
+    /// An empty `SetPrices` schedule passes structure validation (which
+    /// explicitly skips the price) and state validation (auth-only), and is
+    /// stored verbatim. The transformer runs on every validator during block
+    /// execution, so a panic there would crash all validators and halt the
+    /// chain. With the fix, a purchase against an empty schedule must instead be
+    /// rejected gracefully as `TokenNotForDirectSale` — no panic.
+    #[tokio::test]
+    async fn test_direct_purchase_empty_set_prices_does_not_panic() {
+        let platform_version = PlatformVersion::latest();
+        let mut platform = TestPlatformBuilder::new()
+            .with_latest_protocol_version()
+            .build_with_mock_rpc()
+            .set_genesis_state();
+
+        let mut rng = StdRng::seed_from_u64(12345);
+        let (seller, seller_signer, seller_key) =
+            setup_identity(&mut platform, rng.gen(), dash_to_credits!(1.0));
+        let (buyer, buyer_signer, buyer_key) =
+            setup_identity(&mut platform, rng.gen(), dash_to_credits!(10.0));
+
+        // Plant: set an EMPTY tiered pricing schedule. This is accepted and
+        // stored (structure validation skips the price; state validation is
+        // auth-only), as asserted inside `create_token_with_pricing`.
+        let empty_set_prices = TokenPricingSchedule::SetPrices(BTreeMap::new());
+
+        let mut identity_contract_nonce: u64 = 2;
+        let (contract, token_id) = create_token_with_pricing(
+            platform_version,
+            &mut platform,
+            &seller,
+            &seller_signer,
+            &seller_key,
+            Some(empty_set_prices),
+            &mut identity_contract_nonce,
+        )
+        .await;
+
+        // Detonate: any direct purchase used to panic at
+        // `set_prices.keys().next().expect("Map is not empty")`.
+        let platform_state = platform.state.load();
+        let purchase_transition = BatchTransition::new_token_direct_purchase_transition(
+            token_id,
+            buyer.id(),
+            contract.id(),
+            0,
+            3, // Buying 3 tokens
+            dash_to_credits!(3),
+            &buyer_key,
+            2,
+            0,
+            &buyer_signer,
+            platform_version,
+            None,
+        )
+        .await
+        .unwrap();
+
+        let processing_result = process_test_state_transition(
+            &mut platform,
+            purchase_transition,
+            &platform_state,
+            platform_version,
+        );
+
+        // Must be rejected gracefully (the node did not panic to get here).
+        assert_matches!(
+            processing_result.execution_results().as_slice(),
+            [PaidConsensusError {
+                error: ConsensusError::StateError(StateError::TokenNotForDirectSale(_)),
+                ..
+            }]
+        );
+
+        // The buyer must not have received any tokens.
+        let token_balance = platform
+            .drive
+            .fetch_identity_token_balance(
+                token_id.to_buffer(),
+                buyer.id().to_buffer(),
+                None,
+                platform_version,
+            )
+            .expect("expected to fetch token balance");
+        assert_eq!(token_balance, None);
+    }
 }

--- a/packages/rs-drive/src/state_transition_action/batch/batched_transition/token_transition/token_direct_purchase_transition_action/v0/transformer.rs
+++ b/packages/rs-drive/src/state_transition_action/batch/batched_transition/token_transition/token_direct_purchase_transition_action/v0/transformer.rs
@@ -251,7 +251,14 @@ impl TokenDirectPurchaseTransitionActionV0 {
                         required_total
                     }
                     None => {
-                        // Token count is below all defined thresholds — this is an invalid purchase
+                        // `range(..=token_count).next_back()` returns `None` in two situations:
+                        //   1. the schedule has tiers but the smallest one is above `token_count`
+                        //      (the buyer is under the minimum sale amount), or
+                        //   2. the schedule is empty — the token has no usable direct-sale price.
+                        // Both are invalid purchases. We must NOT assume the map is non-empty here:
+                        // an empty `SetPrices` schedule can be set and stored (its structure/state
+                        // validation does not reject the price), so `.expect()`-ing a key would panic
+                        // during block execution on every validator and halt the chain.
                         let bump_action =
                             BumpIdentityDataContractNonceAction::from_borrowed_token_base_transition(
                                 base,
@@ -261,18 +268,27 @@ impl TokenDirectPurchaseTransitionActionV0 {
                         let batched_action =
                             BatchedTransitionAction::BumpIdentityDataContractNonce(bump_action);
 
+                        let error = match set_prices.keys().next() {
+                            // At least one tier exists: the buyer is below the minimum sale amount.
+                            Some(minimum_sale_amount) => ConsensusError::StateError(
+                                StateError::TokenAmountUnderMinimumSaleAmount(
+                                    TokenAmountUnderMinimumSaleAmount::new(
+                                        base.token_id(),
+                                        *token_count,
+                                        *minimum_sale_amount,
+                                    ),
+                                ),
+                            ),
+                            // Empty schedule: the token has no direct-sale price at all.
+                            None => ConsensusError::StateError(StateError::TokenNotForDirectSale(
+                                TokenNotForDirectSale::new(base.token_id()),
+                            )),
+                        };
+
                         return Ok((
                             ConsensusValidationResult::new_with_data_and_errors(
                                 batched_action,
-                                vec![ConsensusError::StateError(
-                                    StateError::TokenAmountUnderMinimumSaleAmount(
-                                        TokenAmountUnderMinimumSaleAmount::new(
-                                            base.token_id(),
-                                            *token_count,
-                                            *set_prices.keys().next().expect("Map is not empty"),
-                                        ),
-                                    ),
-                                )],
+                                vec![error],
                             ),
                             fee_result,
                         ));


### PR DESCRIPTION
## Issue being fixed or feature implemented

Hardens the token direct-purchase transition against an edge case in tiered (`SetPrices`) pricing schedules. In an unusual schedule configuration the transformer could fail ungracefully instead of returning a clean validation error.

## What was done?

Reworked the no-matching-tier branch of the direct-purchase transformer so it no longer makes an assumption about the schedule's contents. When no applicable price tier is found, the transition is rejected with an appropriate consensus error in all cases. Added a regression test covering the edge case.

## How Has This Been Tested?

- `cargo test -p drive-abci --lib direct_selling` — all tests pass, including the new regression test and the existing version-pinned baselines (existing behaviour unchanged).
- `cargo check -p drive`, `cargo clippy -p drive`, `cargo fmt --all` — clean.

## Breaking Changes

None.

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [ ] I have made corresponding changes to the documentation if needed

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Direct token purchases with empty pricing schedules now fail gracefully with a clear "not for direct sale" error instead of causing a panic.
  * Purchases below the minimum tier are rejected with a specific "amount under minimum" error.

* **Tests**
  * Added regression tests covering empty pricing schedules and below-minimum direct purchase attempts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->