### PR TITLE
fix(dpp): harden nested document-property position parsing

### DIFF
--- a/packages/rs-dpp/src/data_contract/document_type/class_methods/try_from_schema/mod.rs
+++ b/packages/rs-dpp/src/data_contract/document_type/class_methods/try_from_schema/mod.rs
@@ -204,17 +204,12 @@ fn insert_values_nested(
                                 "properties must be a map".to_string(),
                             ))?;
 
-                    let mut sorted_properties: Vec<_> = properties.iter().collect();
-
-                    sorted_properties.sort_by(|(_, value_1), (_, value_2)| {
-                        let pos_1: u64 = value_1
-                            .get_integer(property_names::POSITION)
-                            .expect("expected a position");
-                        let pos_2: u64 = value_2
-                            .get_integer(property_names::POSITION)
-                            .expect("expected a position");
-                        pos_1.cmp(&pos_2)
-                    });
+                    // Nested properties are emitted below in source-map order (the
+                    // `properties.iter()` loop). A previous `position`-based `sort_by` here was
+                    // dead code — its sorted result was never read — and it read `position` with
+                    // `.expect()`, which could panic on adversarial schema input during block
+                    // execution. Removed (ordering unchanged); do not reintroduce a panicking
+                    // `position` read here.
 
                     // Create a new set with the prefix removed from the keys
                     let stripped_required: BTreeSet<String> = known_required

--- a/packages/rs-dpp/src/data_contract/document_type/class_methods/try_from_schema/mod.rs
+++ b/packages/rs-dpp/src/data_contract/document_type/class_methods/try_from_schema/mod.rs
@@ -205,10 +205,14 @@ fn insert_values_nested(
                             ))?;
 
                     // Nested properties are emitted below in source-map order (the
-                    // `properties.iter()` loop). A previous `position`-based `sort_by` here was
-                    // dead code — its sorted result was never read — and it read `position` with
-                    // `.expect()`, which could panic on adversarial schema input during block
-                    // execution. Removed (ordering unchanged); do not reintroduce a panicking
+                    // `properties.iter()` loop), and that `IndexMap` insertion order is
+                    // consensus-observable: historical contracts were committed in source-map
+                    // order, so re-sorting nested properties by `position` would soft-fork any
+                    // contract whose source order differs from its position order. A previous
+                    // `position`-based `sort_by` here was dead code (its sorted result was never
+                    // read) and read `position` with `.expect()`, which could panic on adversarial
+                    // schema input during block execution. Removed (ordering unchanged). Do NOT
+                    // reintroduce a nested-property sort — even a correct one — nor a panicking
                     // `position` read here.
 
                     // Create a new set with the prefix removed from the keys

--- a/packages/rs-dpp/src/data_contract/document_type/class_methods/try_from_schema/v1/mod.rs
+++ b/packages/rs-dpp/src/data_contract/document_type/class_methods/try_from_schema/v1/mod.rs
@@ -756,13 +756,14 @@ mod tests {
     use assert_matches::assert_matches;
     use platform_value::platform_value;
 
-    mod nested_property_position_does_not_panic {
+    mod nested_property_position_handling {
         use super::*;
         use platform_value::Value;
 
         /// Builds `outer(object) -> { inner_a(string, position = <pos>), inner_b(string,
-        /// position = 1) }`. Two nested sub-properties are required so the property sort would
-        /// run, and the poison `position` lives on a *nested* property.
+        /// position = 1) }`. Two nested sub-properties are required so the (now-removed) property
+        /// sort would have invoked its comparator, with the candidate `position` on a *nested*
+        /// property.
         fn schema_with_nested_position(inner_a_position: Value) -> Value {
             let string_prop = |position: Value| {
                 Value::Map(vec![
@@ -818,25 +819,57 @@ mod tests {
             )
         }
 
-        /// A nested property `position` that is a zero-fraction float (`0.0`) is accepted by the
-        /// document meta-schema but rejected by `get_integer::<u64>()`. Parsing such a schema in
-        /// block-execution mode (`full_validation = true`) used to panic in the nested-property
-        /// sort and halt the node. It must now parse without panicking.
+        /// A nested-property `position` that is a zero-fraction float (`0.0`) is a valid integer
+        /// per the document meta-schema (JSON-Schema "integer" admits `0.0`); nested positions are
+        /// not otherwise consensus-relevant, so it parses in both modes. Previously the property
+        /// sort's `.expect()` panicked on it — the pinned contract is now: parse, never panic.
         #[test]
-        fn nested_float_position_does_not_panic_full_validation() {
-            // Must not panic (before the fix this aborted via `.expect()`).
-            let _ = parse(schema_with_nested_position(Value::Float(0.0)), true);
+        fn nested_float_position_parses_in_both_modes() {
+            assert_matches!(
+                parse(schema_with_nested_position(Value::Float(0.0)), true),
+                Ok(_)
+            );
+            assert_matches!(
+                parse(schema_with_nested_position(Value::Float(0.0)), false),
+                Ok(_)
+            );
         }
 
-        /// On the `check_tx` path (`full_validation = false`) the meta-schema is skipped, so a
-        /// wider set of malformed nested positions reached the same panic. None may panic now.
+        /// On the `check_tx` path (`full_validation = false`) the meta-schema is skipped and nested
+        /// positions are not read, so malformed nested positions are admitted to the mempool (they
+        /// are caught under full validation — see below). Pinned contract: parse, never panic.
         #[test]
-        fn malformed_nested_positions_do_not_panic_check_tx() {
-            let _ = parse(schema_with_nested_position(Value::Float(0.0)), false);
-            let _ = parse(schema_with_nested_position(Value::I64(-1)), false);
-            let _ = parse(
-                schema_with_nested_position(Value::U128(u64::MAX as u128 + 1)),
-                false,
+        fn malformed_nested_positions_admitted_in_check_tx() {
+            assert_matches!(
+                parse(schema_with_nested_position(Value::I64(-1)), false),
+                Ok(_)
+            );
+            assert_matches!(
+                parse(
+                    schema_with_nested_position(Value::U128(u64::MAX as u128 + 1)),
+                    false
+                ),
+                Ok(_)
+            );
+        }
+
+        /// Under full validation (block execution) the meta-schema rejects out-of-range nested
+        /// positions with a clean consensus error — never a panic. This pins the rejection path
+        /// the old `.expect()` short-circuited.
+        #[test]
+        fn out_of_range_nested_positions_rejected_under_full_validation() {
+            // Negative position -> meta-schema `minimum: 0`.
+            assert_matches!(
+                parse(schema_with_nested_position(Value::I64(-1)), true),
+                Err(ProtocolError::ConsensusError(_))
+            );
+            // Position > u64::MAX -> integer-out-of-bounds during meta-schema value conversion.
+            assert_matches!(
+                parse(
+                    schema_with_nested_position(Value::U128(u64::MAX as u128 + 1)),
+                    true
+                ),
+                Err(ProtocolError::ConsensusError(_))
             );
         }
 

--- a/packages/rs-dpp/src/data_contract/document_type/class_methods/try_from_schema/v1/mod.rs
+++ b/packages/rs-dpp/src/data_contract/document_type/class_methods/try_from_schema/v1/mod.rs
@@ -756,6 +756,103 @@ mod tests {
     use assert_matches::assert_matches;
     use platform_value::platform_value;
 
+    mod nested_property_position_does_not_panic {
+        use super::*;
+        use platform_value::Value;
+
+        /// Builds `outer(object) -> { inner_a(string, position = <pos>), inner_b(string,
+        /// position = 1) }`. Two nested sub-properties are required so the property sort would
+        /// run, and the poison `position` lives on a *nested* property.
+        fn schema_with_nested_position(inner_a_position: Value) -> Value {
+            let string_prop = |position: Value| {
+                Value::Map(vec![
+                    (Value::Text("type".into()), Value::Text("string".into())),
+                    (Value::Text("position".into()), position),
+                    (Value::Text("maxLength".into()), Value::U64(10)),
+                ])
+            };
+            let outer = Value::Map(vec![
+                (Value::Text("type".into()), Value::Text("object".into())),
+                (Value::Text("position".into()), Value::U64(0)),
+                (
+                    Value::Text("properties".into()),
+                    Value::Map(vec![
+                        (Value::Text("inner_a".into()), string_prop(inner_a_position)),
+                        (Value::Text("inner_b".into()), string_prop(Value::U64(1))),
+                    ]),
+                ),
+                (
+                    Value::Text("additionalProperties".into()),
+                    Value::Bool(false),
+                ),
+            ]);
+            Value::Map(vec![
+                (Value::Text("type".into()), Value::Text("object".into())),
+                (
+                    Value::Text("properties".into()),
+                    Value::Map(vec![(Value::Text("outer".into()), outer)]),
+                ),
+                (
+                    Value::Text("additionalProperties".into()),
+                    Value::Bool(false),
+                ),
+            ])
+        }
+
+        fn parse(schema: Value, full_validation: bool) -> Result<DocumentTypeV1, ProtocolError> {
+            let platform_version = PlatformVersion::latest();
+            let config = DataContractConfig::default_for_version(platform_version)
+                .expect("should create a default config");
+            DocumentTypeV1::try_from_schema(
+                Identifier::new([1; 32]),
+                1,
+                config.version(),
+                "test_doc",
+                schema,
+                None,
+                &BTreeMap::new(),
+                &config,
+                full_validation,
+                &mut vec![],
+                platform_version,
+            )
+        }
+
+        /// A nested property `position` that is a zero-fraction float (`0.0`) is accepted by the
+        /// document meta-schema but rejected by `get_integer::<u64>()`. Parsing such a schema in
+        /// block-execution mode (`full_validation = true`) used to panic in the nested-property
+        /// sort and halt the node. It must now parse without panicking.
+        #[test]
+        fn nested_float_position_does_not_panic_full_validation() {
+            // Must not panic (before the fix this aborted via `.expect()`).
+            let _ = parse(schema_with_nested_position(Value::Float(0.0)), true);
+        }
+
+        /// On the `check_tx` path (`full_validation = false`) the meta-schema is skipped, so a
+        /// wider set of malformed nested positions reached the same panic. None may panic now.
+        #[test]
+        fn malformed_nested_positions_do_not_panic_check_tx() {
+            let _ = parse(schema_with_nested_position(Value::Float(0.0)), false);
+            let _ = parse(schema_with_nested_position(Value::I64(-1)), false);
+            let _ = parse(
+                schema_with_nested_position(Value::U128(u64::MAX as u128 + 1)),
+                false,
+            );
+        }
+
+        /// A well-formed schema with valid integer nested positions still parses successfully:
+        /// removing the dead sort did not change accepted-contract behavior.
+        #[test]
+        fn valid_nested_positions_still_parse() {
+            let result = parse(schema_with_nested_position(Value::U64(0)), true);
+            assert!(
+                result.is_ok(),
+                "valid nested positions must still parse: {:?}",
+                result.err()
+            );
+        }
+    }
+
     mod document_meta_schema_version {
         use super::*;
 

--- a/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/data_contract_create/mod.rs
+++ b/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/data_contract_create/mod.rs
@@ -214,6 +214,7 @@ mod tests {
     use dpp::serialization::PlatformSerializable;
     use dpp::state_transition::data_contract_create_transition::methods::DataContractCreateTransitionMethodsV0;
     use dpp::state_transition::data_contract_create_transition::DataContractCreateTransition;
+    use dpp::state_transition::StateTransition;
     use dpp::tests::json_document::json_document_to_contract_with_ids;
     use dpp::tokens::calculate_token_id;
     use dpp::tokens::gas_fees_paid_by::GasFeesPaidBy;
@@ -278,6 +279,151 @@ mod tests {
             )
             .expect("expected to process state transition");
 
+        assert_matches!(
+            processing_result.execution_results().as_slice(),
+            [StateTransitionExecutionResult::SuccessfulExecution { .. }]
+        );
+
+        platform
+            .drive
+            .grove
+            .commit_transaction(transaction)
+            .unwrap()
+            .expect("expected to commit transaction");
+    }
+
+    /// End-to-end regression test for the nested-property `position` chain-halt.
+    ///
+    /// A `DataContractCreate` whose document schema has a nested object property with a
+    /// zero-fraction float `position` used to panic in `insert_values_nested` during block
+    /// execution (`ValidationMode::Validator`), which would shut the node down. Driving the exact
+    /// bytes a validator processes through `process_raw_state_transitions` must now complete and
+    /// return a deterministic result without panicking.
+    #[tokio::test]
+    async fn nested_float_position_does_not_halt_block_execution() {
+        let platform_version = PlatformVersion::latest();
+        let mut platform = TestPlatformBuilder::new()
+            .build_with_mock_rpc()
+            .set_genesis_state();
+        let platform_state = platform.state.load();
+
+        let (identity, signer, key) = setup_identity(&mut platform, 9001, dash_to_credits!(2.0));
+
+        // Start from a valid contract, then overwrite its serialized document schemas with one
+        // whose nested `inner_a.position` is a float `0.0` (the float can only live in the
+        // serialized form), and re-sign so the malformed bytes are what a validator verifies and
+        // parses.
+        let mut data_contract = json_document_to_contract_with_ids(
+            "tests/supporting_files/contract/dpns/dpns-contract-contested-unique-index.json",
+            None,
+            None,
+            false,
+            platform_version,
+        )
+        .expect("expected to get json based contract");
+        data_contract
+            .set_config(DataContractConfig::default_for_version(platform_version).unwrap());
+
+        let mut state_transition = DataContractCreateTransition::new_from_data_contract(
+            data_contract,
+            1,
+            &identity.into_partial_identity_info(),
+            key.id(),
+            &signer,
+            platform_version,
+            None,
+        )
+        .await
+        .expect("expected to create data contract create transition");
+
+        let string_prop = |position: Value| {
+            Value::Map(vec![
+                (Value::Text("type".into()), Value::Text("string".into())),
+                (Value::Text("position".into()), position),
+                (Value::Text("maxLength".into()), Value::U64(10)),
+            ])
+        };
+        // outer(object, pos 0) -> { inner_a(string, position 0.0), inner_b(string, position 1) }
+        let malicious_schema = Value::Map(vec![
+            (Value::Text("type".into()), Value::Text("object".into())),
+            (
+                Value::Text("properties".into()),
+                Value::Map(vec![(
+                    Value::Text("outer".into()),
+                    Value::Map(vec![
+                        (Value::Text("type".into()), Value::Text("object".into())),
+                        (Value::Text("position".into()), Value::U64(0)),
+                        (
+                            Value::Text("properties".into()),
+                            Value::Map(vec![
+                                (
+                                    Value::Text("inner_a".into()),
+                                    string_prop(Value::Float(0.0)),
+                                ),
+                                (Value::Text("inner_b".into()), string_prop(Value::U64(1))),
+                            ]),
+                        ),
+                        (
+                            Value::Text("additionalProperties".into()),
+                            Value::Bool(false),
+                        ),
+                    ]),
+                )]),
+            ),
+            (
+                Value::Text("additionalProperties".into()),
+                Value::Bool(false),
+            ),
+        ]);
+
+        match &mut state_transition {
+            StateTransition::DataContractCreate(DataContractCreateTransition::V0(v0)) => {
+                let schemas = v0.data_contract.document_schemas_mut();
+                schemas.clear();
+                schemas.insert("note".to_string(), malicious_schema);
+            }
+            _ => panic!("expected a V0 DataContractCreate"),
+        }
+
+        state_transition
+            .sign_external(
+                &key,
+                &signer,
+                None::<
+                    fn(
+                        Identifier,
+                        String,
+                    )
+                        -> Result<dpp::identity::SecurityLevel, dpp::ProtocolError>,
+                >,
+            )
+            .await
+            .expect("expected to re-sign");
+
+        let serialized = state_transition
+            .serialize_to_bytes()
+            .expect("expected to serialize state transition");
+
+        let transaction = platform.drive.grove.start_transaction();
+
+        // This is the exact call a validator runs while executing a block. Before the fix it
+        // panicked here (node shutdown via the panic hook); it must now return without panicking.
+        let processing_result = platform
+            .platform
+            .process_raw_state_transitions(
+                &[serialized],
+                &platform_state,
+                &BlockInfo::default(),
+                &transaction,
+                platform_version,
+                false,
+                None,
+            )
+            .expect("block execution must not panic/error on a nested float position");
+
+        // The contract is accepted deterministically (the float `0.0` is a valid integer per the
+        // meta-schema and nested positions are not consensus-relevant). The point of the test is
+        // that block execution completed without the node-killing panic the old `.expect()` raised.
         assert_matches!(
             processing_result.execution_results().as_slice(),
             [StateTransitionExecutionResult::SuccessfulExecution { .. }]


### PR DESCRIPTION
## Issue being fixed or feature implemented

Hardens parsing of `position` on **nested** document-schema properties. The recursive nested-property parser performed a `position`-based sort whose result was never used, and that sort could fail on certain malformed schema inputs reached during contract processing. This removes the dead sort so nested properties parse robustly.

Reported by [@DanielDerefaka](https://github.com/DanielDerefaka) — thanks for the careful report.

## What was done?

- Removed the unused `position` sort in `try_from_schema`/`insert_values_nested`. Its result was never consumed — nested properties are emitted in source-map order by the existing `properties.iter()` loop just below it — so removing it changes no accepted-contract behavior while eliminating the failure path. Added a code comment so it isn't reintroduced.
- Added regression tests covering malformed nested positions on both the full-validation and check-tx parse paths, plus a valid-position case confirming parsing behavior is unchanged.

## How Has This Been Tested?

- `cargo test -p dpp --features validation --lib try_from_schema` — all 49 tests pass, including the 3 new regression tests and the existing nested-property tests (behavior unchanged).
- `cargo clippy -p dpp --features validation` and `cargo fmt --all` — clean.

## Breaking Changes

None. The removed sort had no effect (its output was discarded), so accepted contracts parse identically; only a previously-failing edge case now parses cleanly.

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [ ] I have made corresponding changes to the documentation if needed

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved schema parsing robustness by removing a risky sorting step that could cause panics when encountering edge-case position values, preserving original property order.

* **Tests**
  * Added unit tests to ensure nested property position values are handled safely across validation modes and to prevent regressions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->