### PR TITLE
fix(dpp): guard index property parsing against empty/oversized maps to prevent check_tx panic

### DIFF
--- a/packages/rs-dpp/src/data_contract/document_type/index/mod.rs
+++ b/packages/rs-dpp/src/data_contract/document_type/index/mod.rs
@@ -1016,6 +1016,16 @@ impl IndexProperty {
     pub fn from_platform_value(
         index_property_map: &[(Value, Value)],
     ) -> Result<Self, DataContractError> {
+        // The document meta-schema enforces `minProperties: 1` /
+        // `maxProperties: 1` on each index property object, but that
+        // validation is skipped in check_tx (full_validation=false), so a
+        // crafted contract can reach this point with an empty or oversized
+        // map. Guard explicitly to avoid panicking on an out-of-bounds index.
+        if index_property_map.len() != 1 {
+            return Err(DataContractError::InvalidContractStructure(
+                "index property entry must contain exactly one key/value".to_string(),
+            ));
+        }
         let property = &index_property_map[0];
 
         let key = property
@@ -1487,6 +1497,33 @@ mod tests {
         let map = vec![(Value::Text("field".to_string()), Value::U64(1))];
         let result = IndexProperty::from_platform_value(&map);
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_index_property_from_platform_value_empty_map_returns_err() {
+        // An empty index property object `{}` must not panic with an
+        // out-of-bounds index. This is reachable in check_tx, where the
+        // document meta-schema (minProperties: 1) is not enforced.
+        let result = IndexProperty::from_platform_value(&[]);
+        assert!(matches!(
+            result,
+            Err(DataContractError::InvalidContractStructure(_))
+        ));
+    }
+
+    #[test]
+    fn test_index_property_from_platform_value_multiple_entries_returns_err() {
+        // More than one key/value violates the meta-schema `maxProperties: 1`,
+        // which is also skipped in check_tx.
+        let map = vec![
+            (Value::Text("a".to_string()), Value::Text("asc".to_string())),
+            (Value::Text("b".to_string()), Value::Text("asc".to_string())),
+        ];
+        let result = IndexProperty::from_platform_value(&map);
+        assert!(matches!(
+            result,
+            Err(DataContractError::InvalidContractStructure(_))
+        ));
     }
 
     // -----------------------------------------------------------------------


### PR DESCRIPTION
## Issue being fixed or feature implemented

`IndexProperty::from_platform_value` (in `packages/rs-dpp/src/data_contract/document_type/index/mod.rs`) indexed the input slice with `&index_property_map[0]` without first checking that the slice is non-empty. It is called from `Index::try_from(&[(Value, Value)])` (the `"properties"` arm) for each index-property object in a contract's document-type schema.

When a contract's document schema contains an index whose property entry is an empty object `{}`, `property.as_map()` yields an empty slice and `from_platform_value` panics with index-out-of-bounds.

In block execution (Validator mode, `full_validation=true`) this is shadowed by the document meta-schema, which enforces `minProperties: 1` / `maxProperties: 1` on index property objects. But in `check_tx` (`full_validation=false`) the meta-schema is skipped, so a crafted `DataContractCreate`/`Update` reaches `from_platform_value` with an empty slice and panics — a **mempool/check_tx node DoS** (the panic hook cancels the node).

## What was done?

- Replaced the unchecked `[0]` index in `IndexProperty::from_platform_value` with a `len() != 1` guard that returns `DataContractError::InvalidContractStructure` on an empty slice.
- The guard uses `!= 1` rather than only rejecting empty, so it also rejects oversized slices — the meta-schema enforces `maxProperties: 1`, but `check_tx` skips that too.
- The error propagates through the existing `?` in `Index::try_from`, producing a clean validation error instead of a panic in both `check_tx` and block execution.
- Added unit tests for the empty-slice and multiple-entry error paths (`test_index_property_from_platform_value_empty_map_returns_err`, `test_index_property_from_platform_value_multiple_entries_returns_err`).

## How Has This Been Tested?

- `cargo test -p dpp index_property` — all 16 tests pass, including the two new error-path tests.
- `cargo fmt --all` — clean.

## Breaking Changes

None. This change is **not consensus-breaking**. In full validation (block execution) the document meta-schema already rejected an empty/oversized index property object before reaching this code, so such a contract was never accepted. The fix only converts the `check_tx` panic into the same `DataContractError` that full validation would have produced.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [ ] I have made corresponding changes to the documentation if needed

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced validation to prevent crashes when processing malformed data structures. The system now returns a proper error message instead of potentially panicking on invalid inputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->