### PR TITLE
test(wasm-sdk): raise withdrawal test amount to the v12 minimum

### DIFF
--- a/packages/wasm-sdk/tests/functional/transitions/identity.spec.ts
+++ b/packages/wasm-sdk/tests/functional/transitions/identity.spec.ts
@@ -183,10 +183,11 @@ describe('Identity State Transitions', function describeIdentityStateTransitions
 
       // Withdraw credits - not specifying toAddress means withdrawal
       // will be to the identity's registered withdrawal address
-      // Minimum is 190000 credits, maximum is 50000000000000
+      // Minimum is 1000000 credits (raised from 190000 in protocol v12),
+      // maximum is 50000000000000
       const remainingBalance = await client.identityCreditWithdrawal({
         identity,
-        amount: 200000n, // Must be >= 190000
+        amount: 1000000n, // Must be >= 1000000
         coreFeePerByte: 1,
         signer,
       });


### PR DESCRIPTION
## Issue being fixed or feature implemented

The wasm-sdk functional test `Identity State Transitions > identityCreditWithdrawal() > should withdraw credits from platform` is failing on CI (e.g. observed on #3842, which is unrelated — it only touches BIP39 mnemonic FFI helpers):

```
Withdrawal failed: Protocol error: Credit withdrawal amount 200000 must be greater or equal to 1000000 and less than 50000000000000
```

Protocol **v12** raised `min_withdrawal_amount` from `190_000` to `1_000_000` (1000 duffs) in `SYSTEM_LIMITS_V2` (`packages/rs-platform-version/src/version/system_limits/v2.rs`). The functional test still withdrew `200000n` and carried stale `190000`-minimum comments, so it now fails validation in `identity_credit_withdrawal_transition`.

## What was done?

- Bumped the withdrawal amount in the test from `200000n` to `1000000n` (the new `>=` minimum).
- Updated the stale comments to reflect the v12 minimum of `1000000` credits.

Test identity 1 holds 100 DASH worth of credits, so the larger withdrawal stays well within balance.

## How Has This Been Tested?

This is a single-value change to bring a functional test in line with the current protocol limit. The amount now satisfies the on-chain validation (`withdrawal_amount >= platform_version.system_limits.min_withdrawal_amount`). Full verification runs via the wasm-sdk functional suite against a local platform seeded with `SDK_TEST_DATA=true`.

## Breaking Changes

None.

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [ ] I have made corresponding changes to the documentation if needed

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated identity credit withdrawal test expectations to reflect protocol changes.

* **Chores**
  * Updated minimum withdrawal amount requirements in test suite.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->