### PR TITLE
fix(swift-example-app): show success title on DPNS registration alert

### DIFF
--- a/packages/swift-sdk/SwiftExampleApp/SwiftExampleApp/Views/RegisterNameView.swift
+++ b/packages/swift-sdk/SwiftExampleApp/SwiftExampleApp/Views/RegisterNameView.swift
@@ -325,7 +325,7 @@ struct RegisterNameView: View {
           }
         }
       }
-      .alert("Error", isPresented: $showingError) {
+      .alert(registrationSuccess ? "Success" : "Error", isPresented: $showingError) {
         Button("OK") { }
       } message: {
         Text(errorMessage)


### PR DESCRIPTION
## Issue being fixed or feature implemented

In SwiftExampleApp, registering a DPNS name (Identity Details → Register a name) shows the success message under an alert titled "Error" — e.g. title "Error", body "Successfully registered qa3870-1206x.dash!". Reproduced on testnet 2026-06-12. The view routed both success and failure messages through the same error-alert binding.

## What was done?

`RegisterNameView` already tracks a `registrationSuccess` flag that is set only on the success paths (registration succeeded / contest started). The alert title is now derived from it ("Success" vs "Error") instead of being hardcoded to "Error". The existing auto-dismiss-after-2s behavior on success is unchanged; failures and the availability-check error path still show "Error".

Audited all other alert-bearing views in SwiftExampleApp (token actions, identity create/load/top-up, asset-lock and shielded funding, send transaction, co-sign proposal, contracts, wallet/key detail, etc.) — no other view routes a success message into an error-titled alert.

## How Has This Been Tested?

Built SwiftExampleApp for the iPhone 16 simulator with `xcodebuild` — succeeds with no warnings or errors. UI-only one-line change.

## Breaking Changes

None.

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [ ] I have made corresponding changes to the documentation if needed

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Registration alert now displays appropriate titles based on outcome: "Success" for successful registrations and "Error" for failed attempts, improving user feedback clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->