### PR TITLE
fix(swift-sdk): stamp firstSeen at insert for unconfirmed transactions

### DIFF
--- a/packages/swift-sdk/Sources/SwiftDashSDK/PlatformWallet/PlatformWalletPersistenceHandler.swift
+++ b/packages/swift-sdk/Sources/SwiftDashSDK/PlatformWallet/PlatformWalletPersistenceHandler.swift
@@ -578,6 +578,14 @@ public class PlatformWalletPersistenceHandler {
             return Data(bytes: dataPtr, count: Int(tx.tx_data_len))
         }()
 
+        // The FFI only carries a real `first_seen` once the tx is in a
+        // block (it surfaces the block timestamp); mempool / instant-send
+        // sightings arrive with 0 and delegate the observation stamp to
+        // this side. Stamp the wall clock for those so a fresh send
+        // doesn't sit at the epoch until it's mined.
+        let firstSeen: UInt64 =
+            tx.first_seen != 0 ? tx.first_seen : UInt64(Date().timeIntervalSince1970)
+
         let record: PersistentTransaction
         if let existing = try? backgroundContext.fetch(descriptor).first {
             record = existing
@@ -590,7 +598,7 @@ public class PlatformWalletPersistenceHandler {
                 direction: tx.direction,
                 transactionType: tx.transaction_type.map { String(cString: $0) } ?? "Standard",
                 netAmount: tx.net_amount,
-                firstSeen: tx.first_seen
+                firstSeen: firstSeen
             )
             backgroundContext.insert(record)
         }
@@ -610,7 +618,14 @@ public class PlatformWalletPersistenceHandler {
         if let labelPtr = tx.label {
             record.label = String(cString: labelPtr)
         }
-        record.firstSeen = tx.first_seen
+        // Once mined, `tx.first_seen` carries the block timestamp —
+        // adopt it. While still unconfirmed it stays 0; keep whatever
+        // stamp the row already has rather than zeroing it, and stamp
+        // rows that never got one (placeholder rows from `upsertUtxo`,
+        // rows persisted before insert-time stamping existed).
+        if tx.first_seen != 0 || record.firstSeen == 0 {
+            record.firstSeen = firstSeen
+        }
         record.transactionData = transactionData
         record.lastUpdated = Date()
 


### PR DESCRIPTION
## Issue being fixed or feature implemented

A freshly sent core payment is persisted with `firstSeen` unset (`ZFIRSTSEEN=0` → 2001-01-01 reference date), so the Transactions list shows the pending send with an age of "56 yrs, 5 mths" until the tx is mined and the block timestamp backfills it. Reproduced on testnet 2026-06-12: send 0.01 DASH, open wallet → View All Transactions — the top row shows Pending with the bogus age.

Root cause: the FFI projection (`core_wallet_types.rs`) emits `first_seen = 0` for mempool/instant-send records — the block timestamp is only available once confirmed — and explicitly delegates the observation stamp to the persister. The Swift upsert in `PlatformWalletPersistenceHandler.upsertTransaction` copied the zero straight into `PersistentTransaction.firstSeen`.

## What was done?

In `upsertTransaction`:
- Resolve `firstSeen` once: the FFI value when non-zero (mined → block timestamp), otherwise the current wall clock.
- Insert path stamps a fresh mempool sighting with the wall clock instead of 0.
- Update path only writes when the FFI carries a real timestamp or the existing row has none — a mempool re-sighting can no longer zero an earlier stamp, the mined backfill still adopts the block timestamp as before, and rows that never got a stamp (`upsertUtxo` placeholder rows, rows persisted before this fix) are healed on their next callback.

## How Has This Been Tested?

- Full `xcodebuild` of SwiftExampleApp for the iPhone 16 simulator (clean build, exit 0).
- Manual repro on testnet: pending sends previously displayed "56 yrs, 5 mths"; with the stamp the row shows a real age at insert and the mined backfill path is unchanged.

## Breaking Changes

None.

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [ ] I have made corresponding changes to the documentation if needed

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved timestamp accuracy for unconfirmed wallet transactions by using the current time when the transaction timestamp is unavailable, ensuring more reliable transaction history records.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->