### PR TITLE
fix(sdk): ban node and retry elsewhere on UNIMPLEMENTED responses

### DIFF
--- a/packages/rs-dapi-client/src/transport.rs
+++ b/packages/rs-dapi-client/src/transport.rs
@@ -166,6 +166,9 @@ mod tests {
             Code::Aborted,
             Code::Internal,
             Code::Unavailable,
+            // Retryable on another node: an old build in a mixed-version network
+            // returns Unimplemented for methods newer nodes already serve.
+            Code::Unimplemented,
         ];
 
         for code in retryable_codes {
@@ -187,7 +190,6 @@ mod tests {
             Code::PermissionDenied,
             Code::FailedPrecondition,
             Code::OutOfRange,
-            Code::Unimplemented,
             Code::Unauthenticated,
         ];
 

--- a/packages/rs-dapi-client/src/transport/grpc.rs
+++ b/packages/rs-dapi-client/src/transport/grpc.rs
@@ -114,6 +114,13 @@ impl CanRetry for dapi_grpc::tonic::Status {
                 | Aborted
                 | Internal
                 | Unavailable
+                // During a mixed-version network rollout, Unimplemented means this
+                // particular node runs an older build that doesn't expose the method
+                // yet; another node may serve it. Marking it retryable makes the
+                // executor ban the node and retry elsewhere. If no node implements
+                // the method, all addresses get exhausted and the error still
+                // surfaces as NoAvailableAddressesToRetry.
+                | Unimplemented
         )
     }
 }

--- a/packages/rs-dapi-client/src/transport/grpc.rs
+++ b/packages/rs-dapi-client/src/transport/grpc.rs
@@ -117,9 +117,32 @@ impl CanRetry for dapi_grpc::tonic::Status {
                 // During a mixed-version network rollout, Unimplemented means this
                 // particular node runs an older build that doesn't expose the method
                 // yet; another node may serve it. Marking it retryable makes the
-                // executor ban the node and retry elsewhere. If no node implements
-                // the method, all addresses get exhausted and the error still
-                // surfaces as NoAvailableAddressesToRetry.
+                // executor ban the node (see `update_address_ban_status`) and retry
+                // elsewhere.
+                //
+                // When NO node implements the method, how the failure surfaces depends
+                // on which of `DapiClient::execute`'s two caps trips first:
+                //   * `live_addresses <= settings.retries` — the address list is
+                //     exhausted before the retry budget, so the error surfaces as the
+                //     non-retryable `NoAvailableAddressesToRetry`.
+                //   * `live_addresses > settings.retries` — the per-call retry budget
+                //     trips first, banning `settings.retries + 1` nodes and surfacing
+                //     the raw (still-retryable) `Unimplemented`. A caller that honors
+                //     `CanRetry` then re-enters and bans more nodes each round,
+                //     converging on the exhausted-addresses case above; rs-sdk also
+                //     bounds this via its own `total_retries` cap (see
+                //     `rs-sdk/src/sync.rs`). Either way the loop is bounded — it never
+                //     retries the same node forever.
+                //
+                // Caveat: bans are address-scoped, not (address, method)-scoped, and
+                // Unimplemented is also returned deliberately for genuinely unsupported
+                // / feature-gated endpoints (e.g. rs-drive-abci's
+                // broadcast_state_transition / wait_for_state_transition_result /
+                // get_consensus_params, and any rs-dapi `MethodNotFound`). Calling such
+                // an endpoint bans an otherwise-healthy node across ALL methods for the
+                // ban window. Acceptable for the targeted rollout case; per-method ban
+                // granularity is left as a follow-up so optional endpoints can't poison
+                // the shared address list. TODO(per-method-ban).
                 | Unimplemented
         )
     }

--- a/packages/rs-dapi-client/tests/unimplemented_failover.rs
+++ b/packages/rs-dapi-client/tests/unimplemented_failover.rs
@@ -168,3 +168,55 @@ async fn unimplemented_on_all_nodes_still_surfaces_error() {
         other => panic!("expected NoAvailableAddressesToRetry, got: {other:?}"),
     }
 }
+
+#[tokio::test]
+async fn unimplemented_surfaces_retryable_when_pool_exceeds_retry_budget() {
+    // The non-retryable `NoAvailableAddressesToRetry` collapse (above) only holds
+    // when the live address list is exhausted before the retry budget, i.e.
+    // `live_addresses <= settings.retries`. When the pool is LARGER than the retry
+    // budget, the per-call retry cap trips first: the executor surfaces the raw
+    // (still-retryable) `Unimplemented` after banning `retries + 1` nodes, leaving
+    // the rest of the pool live. A caller honoring `CanRetry` re-enters and bans
+    // more nodes each round (rs-sdk additionally caps via `total_retries`), so
+    // termination is still bounded — this test pins the contract for that branch.
+    let settings = RequestSettings {
+        retries: Some(1),
+        ..Default::default()
+    };
+
+    // Three live nodes, retry budget of 1 → at most retries + 1 = 2 attempts, so
+    // the retry cap trips before all three addresses are banned.
+    let request = MixedVersionRequest::with_unimplemented_responses(usize::MAX);
+    let address_list: AddressList =
+        "http://127.0.0.1:10005,http://127.0.0.1:10006,http://127.0.0.1:10007"
+            .parse()
+            .expect("valid address list");
+    let client = DapiClient::new(address_list, settings);
+
+    let error = client
+        .execute(request.clone(), settings)
+        .await
+        .expect_err("request must fail when no node implements the method");
+
+    // retries + 1 = 2 nodes were tried (and banned) before the retry cap tripped;
+    // the third address is never reached.
+    assert_eq!(
+        request.state.lock().unwrap().unimplemented_uris.len(),
+        2,
+        "retry budget (1) caps attempts at 2 before the 3-node pool is exhausted"
+    );
+
+    // Because the retry cap — not address exhaustion — terminated the loop, the
+    // raw Unimplemented surfaces and is still retryable (unlike the exhausted-pool
+    // case, which collapses to the non-retryable NoAvailableAddressesToRetry).
+    assert!(
+        error.can_retry(),
+        "with more live nodes than retries, the surfaced Unimplemented stays retryable"
+    );
+    match error.inner {
+        DapiClientError::Transport(TransportError::Grpc(status)) => {
+            assert_eq!(status.code(), Code::Unimplemented)
+        }
+        other => panic!("expected raw Transport(Grpc(Unimplemented)), got: {other:?}"),
+    }
+}

--- a/packages/rs-dapi-client/tests/unimplemented_failover.rs
+++ b/packages/rs-dapi-client/tests/unimplemented_failover.rs
@@ -1,0 +1,170 @@
+//! Failover behavior for gRPC `Unimplemented` during a mixed-version network
+//! rollout: a node running an older build answers UNIMPLEMENTED for a method
+//! that upgraded nodes already serve. The executor must ban that node and
+//! retry the request on another address. If every node is unimplemented, the
+//! error must still surface instead of retrying forever.
+
+use std::sync::{Arc, Mutex};
+
+use dapi_grpc::mock::Mockable;
+use dapi_grpc::tonic::{Code, Status};
+use rs_dapi_client::transport::{
+    AppliedRequestSettings, BoxFuture, TransportClient, TransportError, TransportRequest,
+};
+use rs_dapi_client::{
+    Address, AddressList, CanRetry, ConnectionPool, DapiClient, DapiClientError,
+    DapiRequestExecutor, RequestSettings, Uri,
+};
+
+/// Transport client that only remembers which node it was created for.
+struct FakeClient {
+    uri: Uri,
+}
+
+impl TransportClient for FakeClient {
+    fn with_uri(uri: Uri, _pool: &ConnectionPool) -> Result<Self, TransportError> {
+        Ok(Self { uri })
+    }
+
+    fn with_uri_and_settings(
+        uri: Uri,
+        _settings: &AppliedRequestSettings,
+        _pool: &ConnectionPool,
+    ) -> Result<Self, TransportError> {
+        Ok(Self { uri })
+    }
+}
+
+#[derive(Debug)]
+struct FakeResponse;
+
+impl Mockable for FakeResponse {}
+
+#[derive(Debug, Default)]
+struct State {
+    /// How many more attempts should be answered with UNIMPLEMENTED,
+    /// simulating nodes that run an older build.
+    unimplemented_responses_left: usize,
+    /// Nodes that answered UNIMPLEMENTED, in order.
+    unimplemented_uris: Vec<Uri>,
+}
+
+/// Request that answers UNIMPLEMENTED for the first N attempts (each failing
+/// node gets banned by the executor, so each attempt hits a different node)
+/// and succeeds afterwards.
+#[derive(Clone, Debug)]
+struct MixedVersionRequest {
+    state: Arc<Mutex<State>>,
+}
+
+impl MixedVersionRequest {
+    fn with_unimplemented_responses(count: usize) -> Self {
+        Self {
+            state: Arc::new(Mutex::new(State {
+                unimplemented_responses_left: count,
+                unimplemented_uris: Vec::new(),
+            })),
+        }
+    }
+}
+
+impl Mockable for MixedVersionRequest {}
+
+impl TransportRequest for MixedVersionRequest {
+    type Client = FakeClient;
+    type Response = FakeResponse;
+
+    const SETTINGS_OVERRIDES: RequestSettings = RequestSettings::default();
+
+    fn method_name(&self) -> &'static str {
+        "fake_shielded_method"
+    }
+
+    fn execute_transport<'c>(
+        self,
+        client: &'c mut Self::Client,
+        _settings: &AppliedRequestSettings,
+    ) -> BoxFuture<'c, Result<Self::Response, TransportError>> {
+        let result = {
+            let mut state = self.state.lock().unwrap();
+            if state.unimplemented_responses_left > 0 {
+                state.unimplemented_responses_left -= 1;
+                state.unimplemented_uris.push(client.uri.clone());
+                Err(TransportError::Grpc(Status::unimplemented(
+                    "Operation is not implemented or not supported",
+                )))
+            } else {
+                Ok(FakeResponse)
+            }
+        };
+
+        Box::pin(async move { result })
+    }
+}
+
+#[tokio::test]
+async fn unimplemented_node_is_banned_and_request_retried_on_another() {
+    // One of the two nodes still runs an older build without the method.
+    let request = MixedVersionRequest::with_unimplemented_responses(1);
+    let address_list: AddressList = "http://127.0.0.1:10001,http://127.0.0.1:10002"
+        .parse()
+        .expect("valid address list");
+    let client = DapiClient::new(address_list, RequestSettings::default());
+
+    let response = client
+        .execute(request.clone(), RequestSettings::default())
+        .await
+        .expect("request should succeed on the upgraded node");
+
+    let old_node_uri = {
+        let state = request.state.lock().unwrap();
+        assert_eq!(
+            state.unimplemented_uris.len(),
+            1,
+            "exactly one node should have answered UNIMPLEMENTED"
+        );
+        state.unimplemented_uris[0].clone()
+    };
+
+    assert_eq!(response.retries, 1);
+    assert_ne!(
+        response.address.uri(),
+        &old_node_uri,
+        "retry must go to a different node"
+    );
+
+    let old_node = Address::try_from(old_node_uri).expect("valid address");
+    assert!(
+        client.address_list().is_banned(&old_node),
+        "the node that answered UNIMPLEMENTED must be banned"
+    );
+}
+
+#[tokio::test]
+async fn unimplemented_on_all_nodes_still_surfaces_error() {
+    // No node implements the method: every attempt answers UNIMPLEMENTED.
+    let request = MixedVersionRequest::with_unimplemented_responses(usize::MAX);
+    let address_list: AddressList = "http://127.0.0.1:10003,http://127.0.0.1:10004"
+        .parse()
+        .expect("valid address list");
+    let client = DapiClient::new(address_list, RequestSettings::default());
+
+    let error = client
+        .execute(request.clone(), RequestSettings::default())
+        .await
+        .expect_err("request must fail when no node implements the method");
+
+    // Both nodes were tried once each before the address list was exhausted.
+    assert_eq!(request.state.lock().unwrap().unimplemented_uris.len(), 2);
+    assert!(
+        !error.can_retry(),
+        "exhausted-addresses error must not be retried by callers"
+    );
+
+    match error.inner {
+        DapiClientError::NoAvailableAddressesToRetry(transport_error) => match *transport_error {
+            TransportError::Grpc(status) => assert_eq!(status.code(), Code::Unimplemented),
+        },
+        other => panic!("expected NoAvailableAddressesToRetry, got: {other:?}"),
+    }
+}


### PR DESCRIPTION
## Issue being fixed or feature implemented

rs-dapi-client classifies gRPC `Unimplemented` as non-retryable, so the error surfaces directly to the caller. For a stable network that's correct, but during a mixed-version rollout (e.g. shielded endpoints newly activated on testnet 4.0.0-rc.2) UNIMPLEMENTED actually means "this particular evonode runs an older build" — the same request succeeds on an upgraded node.

Observed 2026-06-12 on testnet: SwiftExampleApp's shielded sync failed with `Dapi client error: transport error: grpc error: 'Operation is not implemented or not supported'` from one rotation node, while `seed-1.testnet.networks.dash.org:1443` (and subsequent syncs) served all six `getShielded*` methods fine.

## What was done?

Reclassified `Code::Unimplemented` as retryable in `CanRetry for tonic::Status`. In the executor, ban-and-failover *is* the retryable path: `update_address_ban_status` bans the failed address only for retryable errors, and the retry loop then selects a fresh live address. So the stale node gets banned (60s base, exponential backoff on repeat) and the request transparently retries on another node.

This is bounded, not infinitely retryable. How an all-UNIMPLEMENTED network terminates depends on which of `DapiClient::execute`'s two caps trips first:

- `live_addresses <= settings.retries`: the address list is exhausted before the retry budget, so `get_live_address()` runs dry and the executor surfaces `NoAvailableAddressesToRetry` wrapping the last UNIMPLEMENTED status — itself non-retryable, so caller-level retry wrappers (e.g. rs-sdk's `retry`) won't loop on a genuinely unsupported network.
- `live_addresses > settings.retries`: the per-call retry budget (`settings.retries`, default 5) trips first, banning `settings.retries + 1` nodes and surfacing the raw (still-retryable) `Unimplemented`. A caller that honors `CanRetry` then re-enters and bans more nodes each round, converging on the exhausted-addresses case above; rs-sdk additionally bounds this with its own `total_retries` cap. Either way the loop is bounded — it never retries the same node forever.

Caveat (follow-up): bans are address-scoped, not `(address, method)`-scoped, and `Unimplemented` is also returned deliberately for genuinely unsupported / feature-gated endpoints (rs-drive-abci's `broadcast_state_transition` / `wait_for_state_transition_result` / `get_consensus_params`, and any rs-dapi `MethodNotFound`). Calling such an endpoint now bans an otherwise-healthy node across all methods for the ban window. Acceptable for the targeted mixed-version-rollout case; per-method ban granularity is left as a follow-up (documented inline as `TODO(per-method-ban)`).

Server-side uses of `Unimplemented` (rs-dapi error mapping, drive-abci handler codes) are unaffected; nothing else in the workspace relied on the old client-side classification.

## How Has This Been Tested?

- Updated the `can_retry()` classification unit tests in `transport.rs`.
- Integration tests in `tests/unimplemented_failover.rs` drive the real `DapiClient::execute` retry loop with a fake transport (the existing `MockDapiClient` bypasses the executor, so it can't cover this):
  - mixed-version: with two nodes where the first attempt answers UNIMPLEMENTED, the request succeeds with `retries == 1`, the response comes from a different address, and the stale node is banned in the `AddressList`;
  - all-nodes-stale, small pool (`live_addresses <= settings.retries`): both nodes are tried exactly once, the surfaced error is `NoAvailableAddressesToRetry(Unimplemented)` and reports non-retryable;
  - all-nodes-stale, pool larger than the retry budget (`live_addresses > settings.retries`): with 3 nodes and `retries = 1`, the retry cap trips first — exactly `retries + 1 = 2` nodes are banned and the surfaced raw `Unimplemented` is still retryable. This pins the branch where the all-stale collapse does *not* hold, so the inline comment and this description match the actual contract.
- `cargo test -p rs-dapi-client` (default and `--all-features`), `cargo clippy -p rs-dapi-client --all-features --tests`, `cargo fmt` — all clean.

## Breaking Changes

None.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [ ] I have made corresponding changes to the documentation if needed

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone

🤖 Generated with [Claude Code](https://claude.com/claude-code)
