### PR TITLE
test(drive-abci): fix direct-selling tests broken by empty-schedule validation

### DIFF
--- a/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/batch/tests/token/direct_selling/mod.rs
+++ b/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/batch/tests/token/direct_selling/mod.rs
@@ -3,6 +3,7 @@ use super::*;
 mod token_selling_tests {
     use std::collections::BTreeMap;
 
+    use crate::platform_types::state_transitions_processing_result::StateTransitionsProcessingResult;
     use crate::{rpc::core::MockCoreRPCLike, test::helpers::setup::TempPlatform};
 
     use super::*;
@@ -547,7 +548,7 @@ mod token_selling_tests {
                 (100, dash_to_credits!(10)),
                 (500, dash_to_credits!(5)),
             ])),
-            TokenPricingSchedule::SetPrices(BTreeMap::new()),
+            TokenPricingSchedule::SetPrices(BTreeMap::from([(1, dash_to_credits!(2))])),
         ];
 
         // Setup the test
@@ -832,6 +833,35 @@ mod token_selling_tests {
         pricing: Option<TokenPricingSchedule>,
         identity_contract_nonce: &mut u64,
     ) -> (DataContract, Identifier) {
+        let (contract, token_id, processing_result) = create_token_with_pricing_result(
+            platform_version,
+            platform,
+            seller,
+            seller_signer,
+            seller_key,
+            pricing,
+            identity_contract_nonce,
+        )
+        .await;
+
+        assert_matches!(
+            processing_result.execution_results().as_slice(),
+            [StateTransitionExecutionResult::SuccessfulExecution { .. }]
+        );
+        (contract, token_id)
+    }
+
+    /// Same as [`create_token_with_pricing`], but returns the set-price processing
+    /// result instead of asserting it succeeded, for tests that expect rejection.
+    async fn create_token_with_pricing_result(
+        platform_version: &PlatformVersion,
+        platform: &mut TempPlatform<MockCoreRPCLike>,
+        seller: &Identity,
+        seller_signer: &SimpleSigner,
+        seller_key: &IdentityPublicKey,
+        pricing: Option<TokenPricingSchedule>,
+        identity_contract_nonce: &mut u64,
+    ) -> (DataContract, Identifier, StateTransitionsProcessingResult) {
         let (contract, token_id) = create_token_contract_with_owner_identity(
             platform,
             seller.id(),
@@ -884,22 +914,21 @@ mod token_selling_tests {
             platform_version,
         );
 
-        assert_matches!(
-            processing_result.execution_results().as_slice(),
-            [StateTransitionExecutionResult::SuccessfulExecution { .. }]
-        );
-        (contract, token_id)
+        (contract, token_id, processing_result)
     }
 
     /// Regression test for the chain-halt where an empty `SetPrices` schedule
     /// caused a `.expect("Map is not empty")` panic in the direct-purchase
     /// transformer.
     ///
-    /// An empty `SetPrices` schedule passes structure validation (which
-    /// explicitly skips the price) and state validation (auth-only), and is
-    /// stored verbatim. The transformer runs on every validator during block
-    /// execution, so a panic there would crash all validators and halt the
-    /// chain. With the fix, a purchase against an empty schedule must instead be
+    /// An empty `SetPrices` schedule is now rejected at structure validation
+    /// with `TokenPricingScheduleEmptyError`, so it can no longer reach state
+    /// through a state transition — asserted first. The transformer must still
+    /// handle an empty schedule defensively (defense in depth, e.g. state
+    /// written before the structure check existed): the transformer runs on
+    /// every validator during block execution, so a panic there would crash
+    /// all validators and halt the chain. The schedule is therefore planted
+    /// directly through the drive API, and a purchase against it must be
     /// rejected gracefully as `TokenNotForDirectSale` — no panic.
     #[tokio::test]
     async fn test_direct_purchase_empty_set_prices_does_not_panic() {
@@ -915,22 +944,43 @@ mod token_selling_tests {
         let (buyer, buyer_signer, buyer_key) =
             setup_identity(&mut platform, rng.gen(), dash_to_credits!(10.0));
 
-        // Plant: set an EMPTY tiered pricing schedule. This is accepted and
-        // stored (structure validation skips the price; state validation is
-        // auth-only), as asserted inside `create_token_with_pricing`.
         let empty_set_prices = TokenPricingSchedule::SetPrices(BTreeMap::new());
 
+        // Setting an EMPTY tiered pricing schedule via a state transition must
+        // be rejected at structure validation.
         let mut identity_contract_nonce: u64 = 2;
-        let (contract, token_id) = create_token_with_pricing(
+        let (contract, token_id, processing_result) = create_token_with_pricing_result(
             platform_version,
             &mut platform,
             &seller,
             &seller_signer,
             &seller_key,
-            Some(empty_set_prices),
+            Some(empty_set_prices.clone()),
             &mut identity_contract_nonce,
         )
         .await;
+
+        assert_matches!(
+            processing_result.execution_results().as_slice(),
+            [StateTransitionExecutionResult::UnpaidConsensusError(
+                ConsensusError::BasicError(BasicError::TokenPricingScheduleEmptyError(_))
+            )]
+        );
+
+        // Plant: write the empty schedule straight into state through the
+        // drive API, bypassing state transition validation — simulating state
+        // written before the structure check existed.
+        platform
+            .drive
+            .token_set_direct_purchase_price(
+                token_id.to_buffer(),
+                Some(empty_set_prices),
+                &BlockInfo::default(),
+                true,
+                None,
+                platform_version,
+            )
+            .expect("expected to set empty pricing schedule directly");
 
         // Detonate: any direct purchase used to panic at
         // `set_prices.keys().next().expect("Map is not empty")`.


### PR DESCRIPTION
## Issue being fixed or feature implemented

CI on `v3.1-dev` is red: two drive-abci direct-selling tests fail with `TokenPricingScheduleEmptyError` where they expect `SuccessfulExecution` (e.g. [this run](https://github.com/dashpay/platform/actions/runs/27403371763/job/80986515270?pr=3866)).

This is a semantic conflict between two independently merged PRs:

- #3856 added tests that plant an empty `SetPrices` pricing schedule **via a state transition**, asserting it is accepted and stored (regression coverage for the direct-purchase transformer panic).
- #3865 added structure validation that now rejects exactly that transition with `TokenPricingScheduleEmptyError`.

Each PR was green on its own; together the #3856 tests can no longer plant their fixture.

## What was done?

Test-only changes in `batch/tests/token/direct_selling/mod.rs` — no production code touched:

- Split the `create_token_with_pricing` helper: a new `create_token_with_pricing_result` returns the set-price processing result, while the existing helper keeps asserting success on top of it.
- `test_direct_purchase_empty_set_prices_does_not_panic` now covers both layers of the defense:
  1. asserts that setting an empty `SetPrices` schedule via a state transition is rejected with `UnpaidConsensusError(TokenPricingScheduleEmptyError)` (the #3865 check, end-to-end);
  2. plants the empty schedule directly through `Drive::token_set_direct_purchase_price` (bypassing validation, simulating state written before the check existed) and asserts a purchase is still rejected gracefully as `TokenNotForDirectSale` with no panic and no token credited (the #3856 transformer fix).
- `test_successful_direct_purchase_multiple_tokens` uses a non-empty single-tier `SetPrices` schedule for its third token instead of the no-longer-storable empty one, keeping three distinct schedule shapes for the price fetch/proof round-trip.

## How Has This Been Tested?

`cargo test -p drive-abci --all-features token_selling_tests` — all 10 tests pass, including the two that were failing in CI. Also verified these are the only two places in the workspace (outside the #3865 validator's own unit tests) that construct an empty `SetPrices` schedule.

## Breaking Changes

None.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [ ] I have made corresponding changes to the documentation if needed

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation and error handling for empty token pricing schedules to prevent system crashes when processing invalid pricing configurations.

* **Tests**
  * Enhanced regression tests to verify graceful handling of malformed pricing data and ensure proper error rejection during token transactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->