### PR TITLE
feat(swift-sdk): add identityUpdate handler to the generic transition builder

### DIFF
--- a/packages/swift-sdk/SwiftExampleApp/SwiftExampleApp/Views/IdentityKeyAddition.swift
+++ b/packages/swift-sdk/SwiftExampleApp/SwiftExampleApp/Views/IdentityKeyAddition.swift
@@ -1,0 +1,235 @@
+import Foundation
+import SwiftData
+import SwiftDashSDK
+
+/// Shared "add a key to an existing identity" plumbing.
+///
+/// This is the exact derive → validate → persist → build-`IdentityPubkey`
+/// sequence `AddIdentityKeyView.submit()` runs, lifted into a reusable
+/// helper so the generic transition builder
+/// (`TransitionDetailView.executeIdentityUpdate`) can drive the same
+/// IdentityUpdate flow without duplicating the crypto / Keychain steps.
+///
+/// Per `swift-sdk/CLAUDE.md`, all derivation policy lives in
+/// `rs-platform-wallet`; this helper only marshals choices into the
+/// `wallet.deriveIdentityAuthKeyAtSlot(...)` /
+/// `wallet.updateIdentity(...)` FFI calls and owns the iOS-Keychain
+/// persist step (the one operation Rust can't perform from its side).
+enum IdentityKeyAddition {
+    /// A single key the caller wants to add, described by its DPP
+    /// attributes. The keypair itself is derived Rust-side from the
+    /// owning wallet's mnemonic — the caller never supplies private
+    /// material, because a key the app can't sign with later would be
+    /// useless on the identity.
+    struct KeySpec {
+        let keyType: KeyType
+        let purpose: KeyPurpose
+        let securityLevel: SecurityLevel
+        let contractBounds: ManagedPlatformWallet.ContractBounds?
+
+        init(
+            keyType: KeyType,
+            purpose: KeyPurpose,
+            securityLevel: SecurityLevel,
+            contractBounds: ManagedPlatformWallet.ContractBounds? = nil
+        ) {
+            self.keyType = keyType
+            self.purpose = purpose
+            self.securityLevel = securityLevel
+            self.contractBounds = contractBounds
+        }
+    }
+
+    enum KeyAdditionError: LocalizedError {
+        case derivationMismatch
+        case keychainWriteFailed
+        case hash160ComputationFailed
+        case blsUnsupported
+
+        var errorDescription: String? {
+            switch self {
+            case .derivationMismatch:
+                return "Derived key didn't match its public key — refusing to broadcast."
+            case .keychainWriteFailed:
+                return "Could not persist new key to the iOS Keychain — aborted before broadcast."
+            case .hash160ComputationFailed:
+                return "Could not compute HASH160 of derived pubkey — aborted before broadcast."
+            case .blsUnsupported:
+                return "BLS derivation is not yet wired through the FFI for this flow. Use ECDSA secp256k1 or ECDSA Hash160."
+            }
+        }
+    }
+
+    /// Derive each requested key against the wallet, pre-persist its
+    /// private scalar to the iOS Keychain, and build the matching
+    /// `IdentityPubkey` row — without broadcasting. Returns the rows in
+    /// the same order as `specs`, with `keyId` slots auto-assigned as
+    /// `max(existingKeyIds) + 1`, `+2`, ... so they never collide with
+    /// an existing slot.
+    ///
+    /// Runs on the main actor because `deriveIdentityAuthKeyAtSlot` and
+    /// the Keychain writes are main-actor-bound in this app.
+    @MainActor
+    static func prepareKeys(
+        specs: [KeySpec],
+        identity: PersistentIdentity,
+        wallet: ManagedPlatformWallet,
+        walletId: Data,
+        network: Network
+    ) throws -> [ManagedPlatformWallet.IdentityPubkey] {
+        var firstFreeKeyId = (identity.identityPublicKeys.map { $0.id }.max() ?? 0) + 1
+        var rows: [ManagedPlatformWallet.IdentityPubkey] = []
+        rows.reserveCapacity(specs.count)
+
+        for spec in specs {
+            // ECDSA only for the moment — BLS derivation still needs
+            // Rust work (mirrors AddIdentityKeyView's gating).
+            guard spec.keyType != .bls12_381 else {
+                throw KeyAdditionError.blsUnsupported
+            }
+
+            let chosenKeyId = firstFreeKeyId
+            firstFreeKeyId += 1
+
+            // 1. Derive the keypair via the FFI. The library does the
+            //    path build + secp256k1 derive; we get the public bytes
+            //    + the 32-byte private scalar back.
+            let preview = try wallet.deriveIdentityAuthKeyAtSlot(
+                identityIndex: identity.identityIndex,
+                keyId: chosenKeyId,
+                network: network
+            )
+
+            // 2. Verify the derived scalar matches the returned public
+            //    key — cheap defence against derivation drift. Validation
+            //    goes against the compressed pubkey (33 bytes) regardless
+            //    of keyType; the HASH160 variant just stores a different
+            //    on-chain payload.
+            guard
+                KeyValidation.validatePrivateKeyForPublicKey(
+                    privateKeyHex: preview.privateKeyData.toHexString(),
+                    publicKeyHex: preview.publicKeyHex,
+                    keyType: .ecdsaSecp256k1,
+                    network: network
+                )
+            else {
+                throw KeyAdditionError.derivationMismatch
+            }
+
+            // 3. Pre-persist private bytes to Keychain so the
+            //    KeychainSigner trampoline can sign the resulting
+            //    updateIdentity transition. The trampoline matches on
+            //    metadata.publicKey: for ECDSA_HASH160 that's the
+            //    20-byte HASH160 hex, otherwise the 33-byte compressed
+            //    pubkey hex.
+            let pubKeyHashHex =
+                SwiftDashSDK.KeychainManager.computePublicKeyHashHex(preview.publicKeyData)
+            let metadataPublicKeyHex: String =
+                spec.keyType == .ecdsaHash160 ? pubKeyHashHex : preview.publicKeyHex
+            let metadata = IdentityPrivateKeyMetadata(
+                identityId: identity.identityIdString,
+                keyId: chosenKeyId,
+                walletId: walletId.toHexString(),
+                identityIndex: identity.identityIndex,
+                keyIndex: chosenKeyId,
+                derivationPath: preview.derivationPath,
+                publicKey: metadataPublicKeyHex,
+                publicKeyHash: pubKeyHashHex,
+                keyType: spec.keyType.rawValue,
+                purpose: spec.purpose.rawValue,
+                securityLevel: spec.securityLevel.rawValue
+            )
+            guard
+                KeychainManager.shared.storeIdentityPrivateKey(
+                    preview.privateKeyData,
+                    derivationPath: preview.derivationPath,
+                    metadata: metadata
+                ) != nil
+            else {
+                throw KeyAdditionError.keychainWriteFailed
+            }
+
+            // 4. Build the IdentityPubkey. For ECDSA_HASH160 the
+            //    on-chain payload is the 20-byte HASH160 of the
+            //    compressed pubkey, not the pubkey itself.
+            let pubkeyBytesForFFI: Data
+            if spec.keyType == .ecdsaHash160 {
+                guard let hashBytes = Data(hexString: pubKeyHashHex), hashBytes.count == 20 else {
+                    throw KeyAdditionError.hash160ComputationFailed
+                }
+                pubkeyBytesForFFI = hashBytes
+            } else {
+                pubkeyBytesForFFI = preview.publicKeyData
+            }
+
+            rows.append(
+                ManagedPlatformWallet.IdentityPubkey(
+                    keyId: chosenKeyId,
+                    keyType: spec.keyType,
+                    purpose: spec.purpose,
+                    securityLevel: spec.securityLevel,
+                    pubkeyBytes: pubkeyBytesForFFI,
+                    contractBounds: spec.contractBounds
+                )
+            )
+        }
+
+        return rows
+    }
+}
+
+// MARK: - DPP string parsing
+
+/// Parse the canonical DPP enum token strings the generic transition
+/// builder's `addPublicKeys` JSON uses (e.g. `"ECDSA_HASH160"`,
+/// `"AUTHENTICATION"`, `"MEDIUM"`). Case-insensitive; tolerant of
+/// hyphen/space separators so `"ecdsa-secp256k1"` also resolves.
+
+/// Upper-case and strip `_`, `-`, and space so the switch arms below
+/// can match a single canonical form regardless of input punctuation.
+private func normalizeDPPToken(_ raw: String) -> String {
+    raw.uppercased()
+        .replacingOccurrences(of: "_", with: "")
+        .replacingOccurrences(of: "-", with: "")
+        .replacingOccurrences(of: " ", with: "")
+}
+
+extension KeyType {
+    init?(dppToken raw: String) {
+        switch normalizeDPPToken(raw) {
+        case "ECDSASECP256K1", "ECDSA", "SECP256K1": self = .ecdsaSecp256k1
+        case "BLS12381", "BLS": self = .bls12_381
+        case "ECDSAHASH160", "HASH160": self = .ecdsaHash160
+        case "BIP13SCRIPTHASH", "BIP13": self = .bip13ScriptHash
+        case "EDDSA25519HASH160", "EDDSA": self = .eddsa25519Hash160
+        default: return nil
+        }
+    }
+}
+
+extension KeyPurpose {
+    init?(dppToken raw: String) {
+        switch normalizeDPPToken(raw) {
+        case "AUTHENTICATION", "AUTH": self = .authentication
+        case "ENCRYPTION": self = .encryption
+        case "DECRYPTION": self = .decryption
+        case "TRANSFER": self = .transfer
+        case "SYSTEM": self = .system
+        case "VOTING": self = .voting
+        case "OWNER": self = .owner
+        default: return nil
+        }
+    }
+}
+
+extension SecurityLevel {
+    init?(dppToken raw: String) {
+        switch normalizeDPPToken(raw) {
+        case "MASTER": self = .master
+        case "CRITICAL": self = .critical
+        case "HIGH": self = .high
+        case "MEDIUM": self = .medium
+        default: return nil
+        }
+    }
+}

--- a/packages/swift-sdk/SwiftExampleApp/SwiftExampleApp/Views/TransitionDetailView.swift
+++ b/packages/swift-sdk/SwiftExampleApp/SwiftExampleApp/Views/TransitionDetailView.swift
@@ -481,6 +481,9 @@ struct TransitionDetailView: View {
     case "identityTopUp":
       return try await executeIdentityTopUp(sdk: sdk)
 
+    case "identityUpdate":
+      return try await executeIdentityUpdate(sdk: sdk)
+
     case "identityCreditTransfer":
       return try await executeIdentityCreditTransfer(sdk: sdk)
 
@@ -600,6 +603,156 @@ struct TransitionDetailView: View {
     }
 
     throw SDKError.notImplemented("Identity top-up requires proper Identity handle conversion")
+  }
+
+  /// Generic-builder IdentityUpdate handler.
+  ///
+  /// Mirrors `AddIdentityKeyView`: the keys-to-add are *derived*
+  /// against the owning wallet (the app never accepts raw key bytes
+  /// from the form, because a key whose private scalar the app
+  /// doesn't hold couldn't be signed with later), pre-persisted to
+  /// the iOS Keychain, then submitted via the same
+  /// `wallet.updateIdentity(...)` entry point — which also carries
+  /// the key IDs to disable. The shared derive → validate → persist →
+  /// build-`IdentityPubkey` plumbing lives in
+  /// `IdentityKeyAddition.prepareKeys(...)`.
+  ///
+  /// Form inputs (`identityUpdate` in StateTransitionDefinitions):
+  ///   - `addPublicKeys`: JSON array of `{ keyType, purpose,
+  ///     securityLevel? }` rows (DPP token strings such as
+  ///     `"ECDSA_HASH160"` / `"AUTHENTICATION"`). Any `data` field is
+  ///     ignored — the keypair is derived Rust-side. `keyId` slots are
+  ///     auto-assigned as `max(existing) + 1`.
+  ///   - `disablePublicKeys`: comma-separated existing key IDs.
+  ///
+  /// `@MainActor` because the derive + Keychain-persist step
+  /// (`IdentityKeyAddition.prepareKeys`) is main-actor-bound, matching
+  /// `AddIdentityKeyView.submit()`.
+  @MainActor
+  private func executeIdentityUpdate(sdk: SDK) async throws -> Any {
+    guard !selectedIdentityId.isEmpty,
+          let ownerIdentity = identities.first(where: { $0.identityIdBase58 == selectedIdentityId }) else {
+      throw SDKError.invalidParameter("No identity selected")
+    }
+
+    // Resolve the wallet that owns this identity — same lookup as
+    // executeDataContractCreate. IdentityUpdate routes through
+    // platform-wallet's updateIdentity(...) so derivation + signing
+    // + broadcast all happen Rust-side.
+    guard let walletId = ownerIdentity.wallet?.walletId,
+          let wallet = walletManager.wallet(for: walletId) else {
+      throw SDKError.invalidParameter(
+        "Identity has no wallet linkage; cannot derive keys or sign the update"
+      )
+    }
+
+    // Parse the keys-to-add JSON array (optional).
+    var keySpecs: [IdentityKeyAddition.KeySpec] = []
+    if let addJson = formInputs["addPublicKeys"],
+       !addJson.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+      guard let data = addJson.data(using: .utf8),
+            let rows = try? JSONSerialization.jsonObject(with: data) as? [[String: Any]] else {
+        throw SDKError.serializationError(
+          "Keys to add must be a JSON array of objects"
+        )
+      }
+      keySpecs = try rows.map { row in
+        guard let keyTypeStr = row["keyType"] as? String,
+              let keyType = KeyType(dppToken: keyTypeStr) else {
+          throw SDKError.invalidParameter(
+            "Each key needs a valid `keyType` (e.g. ECDSA_SECP256K1, ECDSA_HASH160)"
+          )
+        }
+        guard let purposeStr = row["purpose"] as? String,
+              let purpose = KeyPurpose(dppToken: purposeStr) else {
+          throw SDKError.invalidParameter(
+            "Each key needs a valid `purpose` (e.g. AUTHENTICATION, TRANSFER)"
+          )
+        }
+        // securityLevel is optional in the form JSON; derive a sane
+        // protocol-locked default per purpose when absent, matching
+        // AddIdentityKeyView's effectiveSecurityLevel.
+        let securityLevel: SecurityLevel
+        if let secStr = row["securityLevel"] as? String {
+          guard let parsed = SecurityLevel(dppToken: secStr) else {
+            throw SDKError.invalidParameter(
+              "Invalid `securityLevel` (use MASTER, CRITICAL, HIGH, or MEDIUM)"
+            )
+          }
+          securityLevel = parsed
+        } else {
+          switch purpose {
+          case .transfer: securityLevel = .critical
+          case .encryption, .decryption: securityLevel = .medium
+          default: securityLevel = .high
+          }
+        }
+        return IdentityKeyAddition.KeySpec(
+          keyType: keyType,
+          purpose: purpose,
+          securityLevel: securityLevel
+        )
+      }
+    }
+
+    // Parse the comma-separated key IDs to disable (optional).
+    var disableIds: [UInt32] = []
+    if let disableStr = formInputs["disablePublicKeys"],
+       !disableStr.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+      disableIds = try disableStr
+        .split(separator: ",")
+        .map { $0.trimmingCharacters(in: .whitespaces) }
+        .filter { !$0.isEmpty }
+        .map { token in
+          guard let id = UInt32(token) else {
+            throw SDKError.invalidParameter(
+              "Invalid key ID to disable: '\(token)'"
+            )
+          }
+          return id
+        }
+    }
+
+    guard !keySpecs.isEmpty || !disableIds.isEmpty else {
+      throw SDKError.invalidParameter(
+        "Provide at least one key to add or one key ID to disable"
+      )
+    }
+
+    let network = appState.sdk?.network ?? appState.currentNetwork
+
+    // Derive + validate + Keychain-persist the new keys, then build
+    // their IdentityPubkey rows (no broadcast yet). Mirrors the exact
+    // sequence AddIdentityKeyView runs. Runs inline on the main actor
+    // (this handler is @MainActor).
+    let addPublicKeys = try IdentityKeyAddition.prepareKeys(
+      specs: keySpecs,
+      identity: ownerIdentity,
+      wallet: wallet,
+      walletId: walletId,
+      network: network
+    )
+
+    // Submit the IdentityUpdate. Rust signs with the identity's
+    // MASTER auth key via the trampoline and broadcasts; the
+    // persister callback writes the new PersistentPublicKey rows when
+    // the transition lands on-chain.
+    let signer = KeychainSigner(modelContainer: modelContext.container)
+    try await wallet.updateIdentity(
+      identityId: ownerIdentity.identityId,
+      addPublicKeys: addPublicKeys,
+      disablePublicKeyIds: disableIds,
+      signer: signer
+    )
+    _ = signer  // keepalive: see KeychainSigner lifetime contract.
+
+    return [
+      "success": true,
+      "identityId": ownerIdentity.identityIdBase58,
+      "addedKeyIds": addPublicKeys.map { $0.keyId },
+      "disabledKeyIds": disableIds,
+      "message": "Identity update broadcast successfully",
+    ]
   }
 
   private func executeIdentityCreditTransfer(sdk: SDK) async throws -> Any {

--- a/packages/swift-sdk/SwiftExampleApp/SwiftExampleApp/Views/TransitionDetailView.swift
+++ b/packages/swift-sdk/SwiftExampleApp/SwiftExampleApp/Views/TransitionDetailView.swift
@@ -669,6 +669,38 @@ struct TransitionDetailView: View {
             "Each key needs a valid `purpose` (e.g. AUTHENTICATION, TRANSFER)"
           )
         }
+        // Fail fast — BEFORE any derivation or Keychain write — on key
+        // types / purposes this generic path can't safely add. Mirrors
+        // AddIdentityKeyView's gating so we never derive a secp256k1
+        // pubkey for a BIP13/EdDSA hash payload, never orphan key
+        // material in the Keychain for an ENCRYPTION/DECRYPTION key the
+        // JSON parser can't attach contractBounds to, and never submit a
+        // SYSTEM/VOTING/OWNER purpose DPP forbids on externally-added
+        // keys. prepareKeys derives + writes the Keychain per spec, so
+        // the guard has to sit here, ahead of it.
+        switch keyType {
+        case .ecdsaSecp256k1, .ecdsaHash160:
+          break
+        case .bls12_381, .bip13ScriptHash, .eddsa25519Hash160:
+          throw SDKError.invalidParameter(
+            "Key type \(keyTypeStr) is not supported by this flow; "
+              + "use ECDSA_SECP256K1 or ECDSA_HASH160"
+          )
+        }
+        switch purpose {
+        case .authentication, .transfer:
+          break
+        case .encryption, .decryption:
+          throw SDKError.invalidParameter(
+            "Purpose \(purposeStr) requires contract bounds, which this "
+              + "generic builder can't supply; use AUTHENTICATION or TRANSFER"
+          )
+        case .system, .voting, .owner:
+          throw SDKError.invalidParameter(
+            "Purpose \(purposeStr) cannot be added to an identity here; "
+              + "use AUTHENTICATION or TRANSFER"
+          )
+        }
         // securityLevel is optional in the form JSON; derive a sane
         // protocol-locked default per purpose when absent, matching
         // AddIdentityKeyView's effectiveSecurityLevel.


### PR DESCRIPTION
## Issue being fixed or feature implemented

The SwiftExampleApp generic transition builder
(`TransitionDetailView.executeStateTransition()`) had no case for
`identityUpdate`, even though `StateTransitionDefinitions.swift` defines an
`identityUpdate` form (keys to add + key IDs to disable). Selecting that
transition always fell through to the `notImplemented` default arm, so the
form was dead. An IdentityUpdate transition adds and/or disables identity
public keys.

## What was done?

Added an `identityUpdate` case to the `executeStateTransition()` switch and
implemented `executeIdentityUpdate(sdk:)`, modeled on the existing add-key
path in `AddIdentityKeyView` and reusing the same Rust entry points:

- Resolves the selected identity and its owning wallet (same lookup pattern
  as `executeDataContractCreate`).
- Parses the form's `addPublicKeys` JSON array (`keyType` / `purpose` /
  optional `securityLevel` as DPP token strings such as `ECDSA_HASH160`,
  `AUTHENTICATION`) and the comma-separated `disablePublicKeys` key IDs.
- Derives each new keypair Rust-side via
  `wallet.deriveIdentityAuthKeyAtSlot(...)`, validates the scalar against
  its public key, pre-persists the private scalar to the iOS Keychain, and
  builds the matching `IdentityPubkey` — auto-assigning `keyId` slots as
  `max(existingKeyIds) + 1`.
- Submits through the same `wallet.updateIdentity(addPublicKeys:
  disablePublicKeyIds:signer:)` entry point, signed by `KeychainSigner` and
  broadcast Rust-side.

The shared derive -> validate -> Keychain-persist -> build-`IdentityPubkey`
sequence was lifted into a new helper `IdentityKeyAddition.prepareKeys(...)`
so the generic builder and `AddIdentityKeyView` describe the same flow
without copy-paste drift.

Per `swift-sdk/CLAUDE.md`: no raw key bytes are accepted from the form (the
app must hold the private scalar to sign with the key later), all derivation
runs in `rs-platform-wallet`, and no mnemonic crosses the FFI — Swift only
marshals choices into the existing FFI calls and owns the Keychain persist
step.

Reused method: `ManagedPlatformWallet.updateIdentity(identityId:
addPublicKeys:disablePublicKeyIds:signer:)` (the same call
`AddIdentityKeyView.submit()` already uses).

## How Has This Been Tested?

No Rust was touched, so no `cargo` checks were required. The Swift handler
was written for self-consistency against the existing add-key plumbing; the
iOS app build / combined end-to-end testing is handled separately by the
orchestrator.

## Breaking Changes

None. This only adds a previously-missing handler in the example app; no
consensus-affecting or public-API changes.

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [ ] I have made corresponding changes to the documentation if needed

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added identity key management capabilities supporting key addition and key disabling
  * Implemented secure key storage for identity keys
  * Enhanced identity update functionality in the example app

<!-- end of auto-generated comment: release notes by coderabbit.ai -->