### PR TITLE
fix(platform-wallet): build data contract config at the protocol-required version

### DIFF
--- a/packages/rs-platform-wallet/src/wallet/identity/network/contract.rs
+++ b/packages/rs-platform-wallet/src/wallet/identity/network/contract.rs
@@ -242,32 +242,12 @@ impl IdentityWallet {
                 serde_json::Value::String(s.to_string()),
             );
         }
-        // `DataContractConfig` is itself a `#[serde(tag =
-        // "$formatVersion")]` enum; the Swift form-builder shape sends
-        // a bare flags dict (or omits config entirely). Tag it with the
-        // protocol-required version so the tagged-enum dispatch picks a
-        // variant the network will accept. `DataContractConfigV1` is
-        // `#[serde(rename_all = "camelCase", default)]`, so a flags-only
-        // (or empty) dict deserializes into a valid V1 — every field,
-        // including `sized_integer_types: true`, has a serde default.
-        //
         // We always insert a `config` block (even when `config_json` is
         // None) so the version tag is explicit rather than relying on
         // the serialization format's `#[serde(default)]`; this keeps the
-        // emitted config aligned with the running protocol version.
-        let mut config_obj = match parse_optional_json("config_json", config_json)? {
-            Some(serde_json::Value::Object(map)) => map,
-            Some(other) => {
-                return Err(PlatformWalletError::InvalidIdentityData(format!(
-                    "config_json must be a JSON object, got: {other}"
-                )));
-            }
-            None => serde_json::Map::new(),
-        };
-        config_obj.insert(
-            "$formatVersion".to_string(),
-            serde_json::Value::String(config_format_version.to_string()),
-        );
+        // emitted config aligned with the running protocol version. See
+        // `build_config_object` for the full assembly contract.
+        let config_obj = build_config_object(config_json, config_format_version)?;
         format_value.insert("config".to_string(), serde_json::Value::Object(config_obj));
 
         // Round-trip through a string instead of `from_value` —
@@ -344,4 +324,212 @@ fn parse_optional_json(
     serde_json::from_str(s).map(Some).map_err(|e| {
         PlatformWalletError::InvalidIdentityData(format!("Invalid {field_name} JSON: {e}"))
     })
+}
+
+/// Assemble the `config` block for a data-contract serialization-format
+/// payload, tagged with the protocol-required `$formatVersion`.
+///
+/// `DataContractConfig` is itself a `#[serde(tag = "$formatVersion")]`
+/// enum; the Swift form-builder shape sends a bare flags dict (e.g.
+/// `{"canBeDeleted": true}`) or omits config entirely. We tag the dict
+/// with `config_format_version` so the tagged-enum dispatch picks a
+/// variant the network will accept — since protocol v12 the network
+/// rejects a V0 config, so the caller passes the running
+/// `PlatformVersion`'s `contract_versions.config.default_current_version`
+/// (1 on v12) rather than a hardcoded "0". `DataContractConfigV1` is
+/// `#[serde(rename_all = "camelCase", default)]`, so a flags-only (or
+/// empty) dict deserializes into a valid V1 — every field, including
+/// `sized_integer_types: true`, has a serde default.
+///
+/// The `$formatVersion` insert is an **unconditional overwrite**: any
+/// caller-supplied wire-level `$formatVersion` inside `config_json` is
+/// replaced. This is deliberate — the helper's contract is to always
+/// emit a network-acceptable version tag, no caller in this codebase
+/// sets the wire-level tag (the whole point of the helper is to abstract
+/// it), and honoring a caller-supplied "0" on v12+ would only earn a
+/// network rejection.
+///
+/// Inputs:
+///   - `None` / empty `config_json` -> empty map, then the version tag.
+///   - `Some(object)` -> that object's fields preserved, then the tag.
+///   - `Some(non-object)` (array / string / number) ->
+///     `PlatformWalletError::InvalidIdentityData`.
+fn build_config_object(
+    config_json: Option<&str>,
+    config_format_version: u16,
+) -> Result<serde_json::Map<String, serde_json::Value>, PlatformWalletError> {
+    let mut config_obj = match parse_optional_json("config_json", config_json)? {
+        Some(serde_json::Value::Object(map)) => map,
+        Some(other) => {
+            return Err(PlatformWalletError::InvalidIdentityData(format!(
+                "config_json must be a JSON object, got: {other}"
+            )));
+        }
+        None => serde_json::Map::new(),
+    };
+    config_obj.insert(
+        "$formatVersion".to_string(),
+        serde_json::Value::String(config_format_version.to_string()),
+    );
+    Ok(config_obj)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use dpp::version::PlatformVersion;
+
+    /// The current default config version for the latest protocol — 1 on
+    /// v12. Centralized so every assertion below tracks the real protocol
+    /// value rather than a hardcoded literal.
+    fn latest_config_version() -> u16 {
+        PlatformVersion::latest()
+            .dpp
+            .contract_versions
+            .config
+            .default_current_version
+    }
+
+    #[test]
+    fn build_config_object_none_emits_protocol_version_tag() {
+        let version = latest_config_version();
+        let obj = build_config_object(None, version).expect("None config builds");
+        assert_eq!(
+            obj.get("$formatVersion"),
+            Some(&serde_json::Value::String(version.to_string())),
+            "absent config must still carry the protocol-required version tag"
+        );
+        // Nothing else should have been invented.
+        assert_eq!(obj.len(), 1);
+    }
+
+    #[test]
+    fn build_config_object_empty_string_behaves_like_none() {
+        let version = latest_config_version();
+        let obj = build_config_object(Some(""), version).expect("empty config builds");
+        assert_eq!(
+            obj.get("$formatVersion"),
+            Some(&serde_json::Value::String(version.to_string()))
+        );
+        assert_eq!(obj.len(), 1);
+    }
+
+    #[test]
+    fn build_config_object_flags_object_preserves_caller_fields() {
+        let version = latest_config_version();
+        let obj = build_config_object(Some(r#"{"canBeDeleted":true}"#), version)
+            .expect("flags-only config builds");
+        // Caller field preserved verbatim ...
+        assert_eq!(
+            obj.get("canBeDeleted"),
+            Some(&serde_json::Value::Bool(true)),
+            "caller-supplied config flags must be preserved"
+        );
+        // ... alongside the protocol-required version tag.
+        assert_eq!(
+            obj.get("$formatVersion"),
+            Some(&serde_json::Value::String(version.to_string()))
+        );
+    }
+
+    #[test]
+    fn build_config_object_overwrites_caller_supplied_format_version() {
+        // The unconditional overwrite is deliberate (see helper docs):
+        // a caller-set wire-level tag is replaced with the protocol's
+        // required version so the emitted config is always acceptable.
+        let version = latest_config_version();
+        let obj = build_config_object(Some(r#"{"$formatVersion":"0"}"#), version)
+            .expect("config with caller tag builds");
+        assert_eq!(
+            obj.get("$formatVersion"),
+            Some(&serde_json::Value::String(version.to_string())),
+            "caller-supplied $formatVersion must be overwritten with the protocol version"
+        );
+    }
+
+    #[test]
+    fn build_config_object_rejects_non_object_json() {
+        let version = latest_config_version();
+        for bad in [r#"[]"#, r#""x""#, r#"5"#] {
+            let err = build_config_object(Some(bad), version)
+                .expect_err("non-object config_json must be rejected");
+            assert!(
+                matches!(err, PlatformWalletError::InvalidIdentityData(_)),
+                "expected InvalidIdentityData for {bad:?}, got {err:?}"
+            );
+        }
+    }
+
+    /// Round-trip: the bytes the helper feeds into the contract format
+    /// must actually validate as a `DataContract` at the latest protocol
+    /// version — this is the assertion that would have caught the original
+    /// hardcoded-"0" v12 rejection at unit-test time.
+    ///
+    /// A document type is included because `full_validation` rejects a
+    /// contract carrying neither document schemas nor tokens
+    /// (`DocumentTypesAreMissingError`); the config block is still the
+    /// subject under test — its version tag is what makes (or breaks)
+    /// validation at v12.
+    #[test]
+    fn build_config_object_output_validates_at_latest_version() {
+        let platform_version = PlatformVersion::latest();
+        let version = latest_config_version();
+
+        let config_obj = build_config_object(Some(r#"{"canBeDeleted":true}"#), version)
+            .expect("flags-only config builds");
+
+        // Minimal serialization-format payload: one trivial document type
+        // plus the assembled config block under test.
+        let mut document_schemas = serde_json::Map::new();
+        document_schemas.insert(
+            "note".to_string(),
+            serde_json::json!({
+                "type": "object",
+                "properties": {
+                    "message": {"type": "string", "position": 0, "maxLength": 63}
+                },
+                "additionalProperties": false
+            }),
+        );
+
+        let mut format_value = serde_json::Map::new();
+        format_value.insert(
+            "$formatVersion".to_string(),
+            serde_json::Value::String("1".to_string()),
+        );
+        format_value.insert(
+            "id".to_string(),
+            serde_json::Value::String(
+                bs58::encode(Identifier::default().to_buffer()).into_string(),
+            ),
+        );
+        format_value.insert(
+            "ownerId".to_string(),
+            serde_json::Value::String(
+                bs58::encode(Identifier::default().to_buffer()).into_string(),
+            ),
+        );
+        format_value.insert(
+            "version".to_string(),
+            serde_json::Value::Number(serde_json::Number::from(INITIAL_DATA_CONTRACT_VERSION)),
+        );
+        format_value.insert(
+            "documentSchemas".to_string(),
+            serde_json::Value::Object(document_schemas),
+        );
+        format_value.insert("config".to_string(), serde_json::Value::Object(config_obj));
+
+        let serialized = serde_json::to_string(&serde_json::Value::Object(format_value))
+            .expect("format value serializes");
+        let format: DataContractInSerializationFormat =
+            serde_json::from_str(&serialized).expect("format deserializes");
+
+        let mut errors = vec![];
+        let contract =
+            DataContract::try_from_platform_versioned(format, true, &mut errors, platform_version);
+        assert!(
+            contract.is_ok(),
+            "assembled config must validate at the latest version: {contract:?} (errors: {errors:?})"
+        );
+    }
 }

--- a/packages/rs-platform-wallet/src/wallet/identity/network/contract.rs
+++ b/packages/rs-platform-wallet/src/wallet/identity/network/contract.rs
@@ -116,10 +116,15 @@ impl IdentityWallet {
     ///   position, each value a `Group` JSON.
     /// - `keywords_json`: JSON array of strings.
     /// - `description`: plain (non-JSON) string.
-    /// - `config_json`: `DataContractConfig` JSON. The function
-    ///   injects `$formatVersion: "0"` if the caller-supplied
-    ///   config dict doesn't carry one (Swift form-builder shape
-    ///   doesn't know the tag).
+    /// - `config_json`: `DataContractConfig` JSON, or `None`. The
+    ///   function always tags the assembled config with the
+    ///   protocol-required `$formatVersion` (the running
+    ///   `PlatformVersion`'s `contract_versions.config
+    ///   .default_current_version`) — since protocol v12 the network
+    ///   rejects a V0 config, so a hardcoded "0" tag would fail. A
+    ///   flags-only or absent config deserializes into a valid V1
+    ///   because every `DataContractConfigV1` field has a serde
+    ///   default.
     #[allow(clippy::too_many_arguments)]
     pub async fn create_data_contract_with_signer<S>(
         &self,
@@ -169,6 +174,22 @@ impl IdentityWallet {
                 })?
                 .clone()
         };
+
+        // Protocol-required config version. Since protocol v12 the
+        // network rejects a V0 `DataContractConfig` (it lacks
+        // `sized_integer_types`): the data-contract-create basic-
+        // structure validator enforces
+        // `config().version() >= contract_versions.config.min_version`,
+        // and that minimum is 1 for v12+. We therefore tag every
+        // config we build with the protocol's
+        // `default_current_version` (which equals `min_version` here)
+        // rather than a hardcoded "0".
+        let platform_version = self.sdk.version();
+        let config_format_version = platform_version
+            .dpp
+            .contract_versions
+            .config
+            .default_current_version;
 
         // 2. Build the V1 serialization format with a placeholder id.
         //    The SDK's `DataContractCreateTransition::new_from_data_contract`
@@ -221,17 +242,33 @@ impl IdentityWallet {
                 serde_json::Value::String(s.to_string()),
             );
         }
-        if let Some(mut v) = parse_optional_json("config_json", config_json)? {
-            // `DataContractConfig` is itself a `#[serde(tag =
-            // "$formatVersion")]` enum; Swift form-builder shape
-            // sends a bare flags dict. Inject the V0 tag when
-            // missing so the tagged-enum dispatch picks a variant.
-            if let Some(obj) = v.as_object_mut() {
-                obj.entry("$formatVersion")
-                    .or_insert_with(|| serde_json::Value::String("0".to_string()));
+        // `DataContractConfig` is itself a `#[serde(tag =
+        // "$formatVersion")]` enum; the Swift form-builder shape sends
+        // a bare flags dict (or omits config entirely). Tag it with the
+        // protocol-required version so the tagged-enum dispatch picks a
+        // variant the network will accept. `DataContractConfigV1` is
+        // `#[serde(rename_all = "camelCase", default)]`, so a flags-only
+        // (or empty) dict deserializes into a valid V1 — every field,
+        // including `sized_integer_types: true`, has a serde default.
+        //
+        // We always insert a `config` block (even when `config_json` is
+        // None) so the version tag is explicit rather than relying on
+        // the serialization format's `#[serde(default)]`; this keeps the
+        // emitted config aligned with the running protocol version.
+        let mut config_obj = match parse_optional_json("config_json", config_json)? {
+            Some(serde_json::Value::Object(map)) => map,
+            Some(other) => {
+                return Err(PlatformWalletError::InvalidIdentityData(format!(
+                    "config_json must be a JSON object, got: {other}"
+                )));
             }
-            format_value.insert("config".to_string(), v);
-        }
+            None => serde_json::Map::new(),
+        };
+        config_obj.insert(
+            "$formatVersion".to_string(),
+            serde_json::Value::String(config_format_version.to_string()),
+        );
+        format_value.insert("config".to_string(), serde_json::Value::Object(config_obj));
 
         // Round-trip through a string instead of `from_value` —
         // serde's `#[serde(tag = "...")]` enum dispatch can drop /
@@ -252,7 +289,6 @@ impl IdentityWallet {
                 ))
             })?;
 
-        let platform_version = self.sdk.version();
         let mut errors = vec![];
         let data_contract =
             DataContract::try_from_platform_versioned(format, true, &mut errors, platform_version)


### PR DESCRIPTION
## Issue being fixed or feature implemented

Creating ANY data contract through the SwiftExampleApp (and any other client routing through `platform-wallet`) is rejected on protocol v12 (testnet) with:

> Protocol error: Can't update Data Contract <id> config: config version 0 is not supported, minimum version is 1

This blocks all contract creation — both token and document contracts.

**Root cause:** `packages/rs-platform-wallet/src/wallet/identity/network/contract.rs` (`create_data_contract_with_signer`) hardcoded `"$formatVersion": "0"` when tagging the assembled `DataContractConfig`. Since protocol v12, `DataContractConfig` V0 is no longer accepted — the data-contract-create basic-structure validator (`rs-drive-abci/.../data_contract_create/basic_structure/v1/mod.rs`) enforces `config().version() >= platform_version.dpp.contract_versions.config.min_version`, and that minimum is `1` for v12 (see `rs-platform-version/.../dpp_contract_versions/v3.rs` and `v4.rs`: `config.min_version = 1`, "V0 config no longer accepted — lacks sized_integer_types"). So every contract the wallet built carried a V0 config and was rejected.

## What was done?

- In `contract.rs`, the assembled config is now tagged with the running `PlatformVersion`'s `dpp.contract_versions.config.default_current_version` (which equals `min_version` on v12) instead of a hardcoded `"0"`.
- A `config` block is now always inserted — including when the caller passes no `config_json` — so the version tag is explicit rather than relying on the serialization format's `#[serde(default = "DataContractConfigV1::default_with_version")]`.
- A flags-only or empty config dict deserializes into a valid V1: `DataContractConfigV1` is `#[serde(rename_all = "camelCase", default)]`, so every field (including `sized_integer_types: true`) has a serde default. No extra field population is needed.
- Non-object `config_json` now returns a clear `InvalidIdentityData` error instead of being silently dropped.
- Removed the now-duplicate `let platform_version = self.sdk.version();` binding (hoisted earlier for the version lookup).

**Token schema left unchanged (investigated):** `QuickBasicTokenView.swift` emits `"$formatVersion": "0"` for the token schema. `TokenConfiguration` only has a `V0` variant and there is no token-config min-version gate on v12 (`token_versions` carries only `validate_structure_interval`), so V0 is still the only valid token-configuration version. Bumping it would break deserialization, so it was intentionally left alone.

## How Has This Been Tested?

- `cargo check -p platform-wallet` passes (compiles clean, including transitive `dpp`/`drive`/`dash-sdk`).
- `cargo fmt --all --check` passes.
- Full end-to-end iOS contract creation against a v12 testnet node is being verified separately by the orchestrator.

## Breaking Changes

None. This is a client-side fix in the `platform-wallet` crate; it changes the config version the wallet emits to match what the network already requires. No consensus or wire-format change.

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [ ] I have made corresponding changes to the documentation if needed

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed contract creation to properly validate and apply protocol-specified configuration format versions.

* **Tests**
  * Added validation tests for contract configuration handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->