### PR TITLE
feat(swift-sdk): wire data contract update through the platform-wallet path

### DIFF
--- a/packages/rs-platform-wallet-ffi/src/data_contract.rs
+++ b/packages/rs-platform-wallet-ffi/src/data_contract.rs
@@ -76,6 +76,73 @@ pub unsafe extern "C" fn platform_wallet_create_data_contract_with_signer(
     PlatformWalletFFIResult::ok()
 }
 
+/// Update + broadcast an existing data contract owned by
+/// `owner_identity_id`. The new schemas / config replace the live
+/// definition at the next contract version (the wallet reads the
+/// current version from Platform and bumps it).
+#[no_mangle]
+#[allow(clippy::too_many_arguments)]
+pub unsafe extern "C" fn platform_wallet_update_data_contract_with_signer(
+    wallet_handle: Handle,
+    owner_identity_id: *const u8,
+    contract_id: *const u8,
+    documents_schema_json: *const c_char,
+    tokens_schema_json: *const c_char,
+    groups_schema_json: *const c_char,
+    keywords_json: *const c_char,
+    description: *const c_char,
+    config_json: *const c_char,
+    signer_handle: *mut SignerHandle,
+    out_contract_id: *mut u8,
+) -> PlatformWalletFFIResult {
+    check_ptr!(signer_handle);
+    check_ptr!(documents_schema_json);
+    check_ptr!(out_contract_id);
+
+    let owner_id = unwrap_result_or_return!(read_identifier(owner_identity_id));
+    let contract_id_value = unwrap_result_or_return!(read_identifier(contract_id));
+
+    let documents_str = unwrap_result_or_return!(CStr::from_ptr(documents_schema_json).to_str());
+
+    let tokens_str = unwrap_result_or_return!(read_optional_str(tokens_schema_json));
+    let groups_str = unwrap_result_or_return!(read_optional_str(groups_schema_json));
+    let keywords_str = unwrap_result_or_return!(read_optional_str(keywords_json));
+    let description_str = unwrap_result_or_return!(read_optional_str(description));
+    let config_str = unwrap_result_or_return!(read_optional_str(config_json));
+
+    let signer_addr = signer_handle as usize;
+    let owner_id_for_async = owner_id;
+    let contract_id_for_async = contract_id_value;
+
+    let option = PLATFORM_WALLET_STORAGE.with_item(wallet_handle, |wallet| {
+        let identity_wallet = wallet.identity().clone();
+        let result: Result<Identifier, _> = block_on_worker(async move {
+            let signer: &VTableSigner = &*(signer_addr as *const VTableSigner);
+            identity_wallet
+                .update_data_contract_with_signer(
+                    &owner_id_for_async,
+                    &contract_id_for_async,
+                    documents_str,
+                    tokens_str,
+                    groups_str,
+                    keywords_str,
+                    description_str,
+                    config_str,
+                    signer,
+                )
+                .await
+                .map(|contract| contract.id())
+        });
+        result
+    });
+    let result = unwrap_option_or_return!(option);
+    let contract_id = unwrap_result_or_return!(result);
+    let bytes = contract_id.to_buffer();
+    let dst = slice::from_raw_parts_mut(out_contract_id, 32);
+    dst.copy_from_slice(&bytes);
+    PlatformWalletFFIResult::ok()
+}
+
 /// Decode an optional NUL-terminated UTF-8 C string.
 unsafe fn read_optional_str<'a>(
     ptr: *const c_char,

--- a/packages/rs-platform-wallet-ffi/src/data_contract.rs
+++ b/packages/rs-platform-wallet-ffi/src/data_contract.rs
@@ -77,9 +77,14 @@ pub unsafe extern "C" fn platform_wallet_create_data_contract_with_signer(
 }
 
 /// Update + broadcast an existing data contract owned by
-/// `owner_identity_id`. The new schemas / config replace the live
-/// definition at the next contract version (the wallet reads the
-/// current version from Platform and bumps it).
+/// `owner_identity_id`. The wallet fetches the live contract, validates
+/// the owner, and *merges* the supplied sections onto it at the next
+/// contract version (it reads the current version from Platform and
+/// bumps it). The JSON args are additive overlays: `documents_schema`
+/// / `tokens_schema` / `groups_schema` entries are added or replaced
+/// key-by-key (omitted keys keep their on-chain definition), and
+/// `keywords` / `description` / `config` override only when supplied —
+/// so a single-section update never wipes the rest of the contract.
 #[no_mangle]
 #[allow(clippy::too_many_arguments)]
 pub unsafe extern "C" fn platform_wallet_update_data_contract_with_signer(

--- a/packages/rs-platform-wallet/src/wallet/identity/network/contract.rs
+++ b/packages/rs-platform-wallet/src/wallet/identity/network/contract.rs
@@ -29,15 +29,21 @@
 use async_trait::async_trait;
 
 use dpp::address_funds::AddressWitness;
+use dpp::data_contract::accessors::v0::DataContractV0Getters;
 use dpp::data_contract::serialized_version::DataContractInSerializationFormat;
 use dpp::data_contract::INITIAL_DATA_CONTRACT_VERSION;
 use dpp::identity::signer::Signer;
-use dpp::identity::{IdentityPublicKey, KeyType, Purpose, SecurityLevel};
+use dpp::identity::{IdentityPublicKey, KeyType, PartialIdentity, Purpose, SecurityLevel};
 use dpp::platform_value::BinaryData;
 use dpp::prelude::{DataContract, Identifier};
+use dpp::state_transition::data_contract_update_transition::methods::DataContractUpdateTransitionMethodsV0;
+use dpp::state_transition::data_contract_update_transition::DataContractUpdateTransition;
 use dpp::ProtocolError;
 
+use dash_sdk::platform::transition::broadcast::BroadcastStateTransition;
 use dash_sdk::platform::transition::put_contract::PutContract;
+use dash_sdk::platform::transition::waitable::Waitable;
+use dash_sdk::platform::Fetch;
 
 use crate::error::PlatformWalletError;
 
@@ -278,6 +284,252 @@ impl IdentityWallet {
                     "Failed to put data contract to platform: {e}"
                 ))
             })?;
+
+        Ok(confirmed)
+    }
+
+    /// Update an existing data contract owned by `owner_identity_id`
+    /// and broadcast the change to Platform.
+    ///
+    /// Mirrors `create_data_contract_with_signer` but targets an
+    /// already-registered contract. The new schemas / config arrive
+    /// as JSON strings; the function:
+    ///   1. Looks up `owner_identity_id` in the in-memory wallet
+    ///      manager and picks the CRITICAL + AUTHENTICATION + ECDSA
+    ///      key (same triple a contract-create signature requires).
+    ///   2. Fetches the *current* contract from Platform to read its
+    ///      live version — the new contract definition must carry
+    ///      `current_version + 1` (DPP rejects an update that doesn't
+    ///      strictly increment the version), and the caller doesn't
+    ///      have to track local version state.
+    ///   3. Assembles a serialization-format payload reusing the
+    ///      existing contract id + owner, the bumped version, and the
+    ///      supplied schemas / config, deserializes it via the public
+    ///      `DataContractInSerializationFormat` enum entry point, and
+    ///      validates through `try_from_platform_versioned`.
+    ///   4. Fetches + bumps the identity-contract nonce, builds a
+    ///      `DataContractUpdateTransition`, signs it via the external
+    ///      signer, broadcasts, and waits for the confirmed contract.
+    ///
+    /// # JSON shapes
+    ///
+    /// Identical to `create_data_contract_with_signer`. The config
+    /// `$formatVersion` is selected from the platform version's
+    /// `contract_versions.config.default_current_version` (V1 under
+    /// v12) rather than hardcoded to "0" — v12 rejects a V0 config
+    /// on both registration and update.
+    #[allow(clippy::too_many_arguments)]
+    pub async fn update_data_contract_with_signer<S>(
+        &self,
+        owner_identity_id: &Identifier,
+        contract_id: &Identifier,
+        documents_schema_json: &str,
+        tokens_schema_json: Option<&str>,
+        groups_schema_json: Option<&str>,
+        keywords_json: Option<&str>,
+        description: Option<&str>,
+        config_json: Option<&str>,
+        signer: &S,
+    ) -> Result<DataContract, PlatformWalletError>
+    where
+        S: Signer<IdentityPublicKey> + Send + Sync,
+    {
+        // 1. Owner identity + signing key from the wallet manager.
+        use dpp::identity::accessors::IdentityGettersV0;
+        let signing_key = {
+            let wm = self.wallet_manager.read().await;
+            let info = wm.get_wallet_info(&self.wallet_id).ok_or_else(|| {
+                PlatformWalletError::WalletNotFound(
+                    "Wallet info not found in wallet manager".to_string(),
+                )
+            })?;
+            let manager = &info.identity_manager;
+            let identity = manager
+                .identity(owner_identity_id)
+                .map(|m| m.identity.clone())
+                .ok_or(PlatformWalletError::IdentityNotFound(*owner_identity_id))?;
+            // Contract update requires the same CRITICAL +
+            // AUTHENTICATION + ECDSA_SECP256K1 key as create — DPP
+            // rejects HIGH / MEDIUM / non-ECDSA keys on this
+            // state-transition shape.
+            identity
+                .get_first_public_key_matching(
+                    Purpose::AUTHENTICATION,
+                    [SecurityLevel::CRITICAL].into(),
+                    [KeyType::ECDSA_SECP256K1].into(),
+                    false,
+                )
+                .ok_or_else(|| {
+                    PlatformWalletError::InvalidIdentityData(
+                        "No CRITICAL authentication key found on owner identity \
+                         (required to sign a contract-update state transition)"
+                            .to_string(),
+                    )
+                })?
+                .clone()
+        };
+
+        // 2. Fetch the live contract to read its current version. The
+        //    update must strictly increment the version, so we bump
+        //    the on-chain value by one rather than trusting a
+        //    caller-supplied number.
+        let existing = DataContract::fetch(&self.sdk, *contract_id)
+            .await
+            .map_err(|e| {
+                PlatformWalletError::InvalidIdentityData(format!(
+                    "Failed to fetch contract {contract_id} for update: {e}"
+                ))
+            })?
+            .ok_or_else(|| {
+                PlatformWalletError::InvalidIdentityData(format!(
+                    "Data contract {contract_id} not found on Platform; cannot update"
+                ))
+            })?;
+        let new_version = existing.version().checked_add(1).ok_or_else(|| {
+            PlatformWalletError::InvalidIdentityData(
+                "Contract version overflow; cannot update".to_string(),
+            )
+        })?;
+
+        // 3. Assemble the updated serialization-format payload. Unlike
+        //    create, the id is the *existing* contract id (the update
+        //    transition keys off it) and the version is the bumped
+        //    value above.
+        let platform_version = self.sdk.version();
+        // Config `$formatVersion` follows the platform's current
+        // default (V1 under v12). Hardcoding "0" would build a V0
+        // config that v12 rejects on update.
+        let config_format_version = platform_version
+            .dpp
+            .contract_versions
+            .config
+            .default_current_version;
+
+        let mut format_value = serde_json::Map::new();
+        format_value.insert(
+            "$formatVersion".to_string(),
+            serde_json::Value::String("1".to_string()),
+        );
+        format_value.insert(
+            "id".to_string(),
+            serde_json::Value::String(bs58::encode(contract_id.to_buffer()).into_string()),
+        );
+        format_value.insert(
+            "ownerId".to_string(),
+            serde_json::Value::String(bs58::encode(owner_identity_id.to_buffer()).into_string()),
+        );
+        format_value.insert(
+            "version".to_string(),
+            serde_json::Value::Number(serde_json::Number::from(new_version)),
+        );
+
+        format_value.insert(
+            "documentSchemas".to_string(),
+            parse_required_json("documents_schema_json", documents_schema_json)?,
+        );
+        if let Some(v) = parse_optional_json("tokens_schema_json", tokens_schema_json)? {
+            format_value.insert("tokens".to_string(), v);
+        }
+        if let Some(v) = parse_optional_json("groups_schema_json", groups_schema_json)? {
+            format_value.insert("groups".to_string(), v);
+        }
+        if let Some(v) = parse_optional_json("keywords_json", keywords_json)? {
+            format_value.insert("keywords".to_string(), v);
+        }
+        if let Some(s) = description.filter(|s| !s.is_empty()) {
+            format_value.insert(
+                "description".to_string(),
+                serde_json::Value::String(s.to_string()),
+            );
+        }
+        if let Some(mut v) = parse_optional_json("config_json", config_json)? {
+            // `DataContractConfig` is a `#[serde(tag =
+            // "$formatVersion")]` enum; the Swift form-builder sends a
+            // bare flags dict. Inject the platform-selected config
+            // version (V1 under v12) when missing so the tagged-enum
+            // dispatch picks the variant the network accepts.
+            if let Some(obj) = v.as_object_mut() {
+                obj.entry("$formatVersion").or_insert_with(|| {
+                    serde_json::Value::String(config_format_version.to_string())
+                });
+            }
+            format_value.insert("config".to_string(), v);
+        }
+
+        // Round-trip through a string instead of `from_value` — see
+        // `create_data_contract_with_signer` for why the tagged-enum
+        // dispatch needs `to_string` + `from_str`.
+        let serialized = serde_json::to_string_pretty(&serde_json::Value::Object(format_value))
+            .map_err(|e| {
+                PlatformWalletError::InvalidIdentityData(format!(
+                    "Failed to serialize updated contract format: {e}"
+                ))
+            })?;
+        let format: DataContractInSerializationFormat =
+            serde_json::from_str(&serialized).map_err(|e| {
+                PlatformWalletError::InvalidIdentityData(format!(
+                    "Failed to assemble updated contract format: {e}\n\nAssembled JSON:\n{serialized}"
+                ))
+            })?;
+
+        let mut errors = vec![];
+        let updated_contract =
+            DataContract::try_from_platform_versioned(format, true, &mut errors, platform_version)
+                .map_err(|e| {
+                    PlatformWalletError::InvalidIdentityData(format!(
+                        "Failed to build updated contract: {e}\n\nAssembled JSON:\n{serialized}"
+                    ))
+                })?;
+
+        // 4. Build + broadcast the update transition. There's no
+        //    `UpdateContract` SDK extension mirroring `PutContract`,
+        //    so assemble the `DataContractUpdateTransition` directly:
+        //    fetch+bump the identity-contract nonce, sign via the
+        //    external signer, broadcast on the platform-wallet 8 MB
+        //    worker stack, and wait for the confirmed contract.
+        let new_identity_contract_nonce = self
+            .sdk
+            .get_identity_contract_nonce(*owner_identity_id, *contract_id, true, None)
+            .await
+            .map_err(PlatformWalletError::Sdk)?;
+
+        let key_id = {
+            use dpp::identity::identity_public_key::accessors::v0::IdentityPublicKeyGettersV0;
+            signing_key.id()
+        };
+        let partial_identity = PartialIdentity {
+            id: *owner_identity_id,
+            loaded_public_keys: [(key_id, signing_key.clone())].into_iter().collect(),
+            balance: None,
+            revision: None,
+            not_found_public_keys: Default::default(),
+        };
+
+        let transition = DataContractUpdateTransition::new_from_data_contract(
+            updated_contract,
+            &partial_identity,
+            key_id,
+            new_identity_contract_nonce,
+            0,
+            &SignerRef(signer),
+            platform_version,
+            None,
+        )
+        .await
+        .map_err(|e| {
+            PlatformWalletError::InvalidIdentityData(format!(
+                "Failed to build contract-update transition: {e}"
+            ))
+        })?;
+
+        transition
+            .broadcast(&self.sdk, None)
+            .await
+            .map_err(PlatformWalletError::Sdk)?;
+
+        let confirmed = DataContract::wait_for_response(&self.sdk, transition, None)
+            .await
+            .map_err(PlatformWalletError::Sdk)?;
 
         Ok(confirmed)
     }

--- a/packages/rs-platform-wallet/src/wallet/identity/network/contract.rs
+++ b/packages/rs-platform-wallet/src/wallet/identity/network/contract.rs
@@ -38,6 +38,7 @@ use dpp::platform_value::BinaryData;
 use dpp::prelude::{DataContract, Identifier};
 use dpp::state_transition::data_contract_update_transition::methods::DataContractUpdateTransitionMethodsV0;
 use dpp::state_transition::data_contract_update_transition::DataContractUpdateTransition;
+use dpp::version::TryFromPlatformVersioned;
 use dpp::ProtocolError;
 
 use dash_sdk::platform::transition::broadcast::BroadcastStateTransition;
@@ -292,32 +293,52 @@ impl IdentityWallet {
     /// and broadcast the change to Platform.
     ///
     /// Mirrors `create_data_contract_with_signer` but targets an
-    /// already-registered contract. The new schemas / config arrive
-    /// as JSON strings; the function:
+    /// already-registered contract. Unlike create, the caller-supplied
+    /// JSON sections are *merged onto the fetched on-chain contract*
+    /// rather than used to build the payload from scratch. A
+    /// `DataContractUpdateTransition` broadcasts a complete contract
+    /// definition (not a diff), so anything the caller omits would
+    /// otherwise be reset to serde defaults — wiping live keywords /
+    /// description / config and, worse, dropping document-type / token /
+    /// group entries (which DPP rejects as illegal removals). Seeding
+    /// from `existing` keeps every untouched section intact. The
+    /// function:
     ///   1. Looks up `owner_identity_id` in the in-memory wallet
     ///      manager and picks the CRITICAL + AUTHENTICATION + ECDSA
     ///      key (same triple a contract-create signature requires).
-    ///   2. Fetches the *current* contract from Platform to read its
-    ///      live version — the new contract definition must carry
-    ///      `current_version + 1` (DPP rejects an update that doesn't
-    ///      strictly increment the version), and the caller doesn't
-    ///      have to track local version state.
-    ///   3. Assembles a serialization-format payload reusing the
-    ///      existing contract id + owner, the bumped version, and the
-    ///      supplied schemas / config, deserializes it via the public
-    ///      `DataContractInSerializationFormat` enum entry point, and
-    ///      validates through `try_from_platform_versioned`.
+    ///   2. Fetches the *current* contract from Platform and validates
+    ///      that it is actually owned by `owner_identity_id` — this
+    ///      runs *before* any nonce fetch/bump so a bad (owner,
+    ///      contract) pair fails as a local validation error instead of
+    ///      consuming nonce state. The bumped version is
+    ///      `existing.version() + 1` (DPP rejects an update that doesn't
+    ///      strictly increment the version), so the caller doesn't have
+    ///      to track local version state.
+    ///   3. Serializes `existing` into its canonical
+    ///      `DataContractInSerializationFormat` JSON (already a valid V1
+    ///      on-chain contract, so the config version is preserved with
+    ///      no manual tagging), then overlays the caller's sections:
+    ///      `documentSchemas` / `tokens` / `groups` are merged key-by-
+    ///      key (add or replace an entry; never drop an existing one),
+    ///      and `keywords` / `description` / `config` are overridden
+    ///      only when the caller supplies them. The id + owner stay as
+    ///      `existing`'s and the version is the bumped value. The merged
+    ///      Value is deserialized via the public
+    ///      `DataContractInSerializationFormat` enum entry point and
+    ///      validated through `try_from_platform_versioned`.
     ///   4. Fetches + bumps the identity-contract nonce, builds a
     ///      `DataContractUpdateTransition`, signs it via the external
     ///      signer, broadcasts, and waits for the confirmed contract.
     ///
     /// # JSON shapes
     ///
-    /// Identical to `create_data_contract_with_signer`. The config
-    /// `$formatVersion` is selected from the platform version's
-    /// `contract_versions.config.default_current_version` (V1 under
-    /// v12) rather than hardcoded to "0" — v12 rejects a V0 config
-    /// on both registration and update.
+    /// Identical to `create_data_contract_with_signer`, but every
+    /// section is *additive / overlay*: an empty `documents_schema_json`
+    /// (`"{}"`) or a `None` for an optional section preserves whatever
+    /// is already on-chain rather than clearing it. Because the payload
+    /// is seeded from the fetched V1 contract, the config keeps its
+    /// on-chain `$formatVersion` automatically; a caller-supplied
+    /// `config_json` is only used to override it.
     #[allow(clippy::too_many_arguments)]
     pub async fn update_data_contract_with_signer<S>(
         &self,
@@ -369,10 +390,9 @@ impl IdentityWallet {
                 .clone()
         };
 
-        // 2. Fetch the live contract to read its current version. The
-        //    update must strictly increment the version, so we bump
-        //    the on-chain value by one rather than trusting a
-        //    caller-supplied number.
+        // 2. Fetch the live contract. We seed the update payload from
+        //    it (so omitted sections are preserved) and read its
+        //    current version to bump.
         let existing = DataContract::fetch(&self.sdk, *contract_id)
             .await
             .map_err(|e| {
@@ -385,86 +405,69 @@ impl IdentityWallet {
                     "Data contract {contract_id} not found on Platform; cannot update"
                 ))
             })?;
+
+        // Reject an owner/contract mismatch *before* touching nonce
+        // state. If `contract_id` belongs to a different owner, the
+        // network would reject the transition anyway — but only after
+        // we'd fetched+bumped the identity-contract nonce for the
+        // supplied pair, turning a bad request into stateful nonce
+        // consumption. Fail it as a local validation error instead.
+        if existing.owner_id() != *owner_identity_id {
+            return Err(PlatformWalletError::InvalidIdentityData(format!(
+                "Data contract {contract_id} is owned by {}, not {owner_identity_id}; \
+                 cannot update with this identity",
+                existing.owner_id()
+            )));
+        }
+
         let new_version = existing.version().checked_add(1).ok_or_else(|| {
             PlatformWalletError::InvalidIdentityData(
                 "Contract version overflow; cannot update".to_string(),
             )
         })?;
 
-        // 3. Assemble the updated serialization-format payload. Unlike
-        //    create, the id is the *existing* contract id (the update
-        //    transition keys off it) and the version is the bumped
-        //    value above.
+        // 3. Build the updated serialization-format payload by merging
+        //    the caller's sections onto the fetched contract. `existing`
+        //    is already a valid V1 on-chain contract, so serializing it
+        //    to the canonical `DataContractInSerializationFormat` JSON
+        //    gives us a base that carries every live field (config keeps
+        //    its on-chain version, document/token/group sets are
+        //    complete). We then overlay only what the caller supplied.
         let platform_version = self.sdk.version();
-        // Config `$formatVersion` follows the platform's current
-        // default (V1 under v12). Hardcoding "0" would build a V0
-        // config that v12 rejects on update.
-        let config_format_version = platform_version
-            .dpp
-            .contract_versions
-            .config
-            .default_current_version;
+        let base_format = DataContractInSerializationFormat::try_from_platform_versioned(
+            &existing,
+            platform_version,
+        )
+        .map_err(|e| {
+            PlatformWalletError::InvalidIdentityData(format!(
+                "Failed to convert existing contract to serialization format: {e}"
+            ))
+        })?;
+        let base_value = serde_json::to_value(&base_format).map_err(|e| {
+            PlatformWalletError::InvalidIdentityData(format!(
+                "Failed to serialize existing contract format: {e}"
+            ))
+        })?;
 
-        let mut format_value = serde_json::Map::new();
-        format_value.insert(
-            "$formatVersion".to_string(),
-            serde_json::Value::String("1".to_string()),
-        );
-        format_value.insert(
-            "id".to_string(),
-            serde_json::Value::String(bs58::encode(contract_id.to_buffer()).into_string()),
-        );
-        format_value.insert(
-            "ownerId".to_string(),
-            serde_json::Value::String(bs58::encode(owner_identity_id.to_buffer()).into_string()),
-        );
-        format_value.insert(
-            "version".to_string(),
-            serde_json::Value::Number(serde_json::Number::from(new_version)),
-        );
-
-        format_value.insert(
-            "documentSchemas".to_string(),
+        let merged_value = merge_contract_update_payload(
+            base_value,
+            new_version,
             parse_required_json("documents_schema_json", documents_schema_json)?,
-        );
-        if let Some(v) = parse_optional_json("tokens_schema_json", tokens_schema_json)? {
-            format_value.insert("tokens".to_string(), v);
-        }
-        if let Some(v) = parse_optional_json("groups_schema_json", groups_schema_json)? {
-            format_value.insert("groups".to_string(), v);
-        }
-        if let Some(v) = parse_optional_json("keywords_json", keywords_json)? {
-            format_value.insert("keywords".to_string(), v);
-        }
-        if let Some(s) = description.filter(|s| !s.is_empty()) {
-            format_value.insert(
-                "description".to_string(),
-                serde_json::Value::String(s.to_string()),
-            );
-        }
-        if let Some(mut v) = parse_optional_json("config_json", config_json)? {
-            // `DataContractConfig` is a `#[serde(tag =
-            // "$formatVersion")]` enum; the Swift form-builder sends a
-            // bare flags dict. Inject the platform-selected config
-            // version (V1 under v12) when missing so the tagged-enum
-            // dispatch picks the variant the network accepts.
-            if let Some(obj) = v.as_object_mut() {
-                obj.entry("$formatVersion").or_insert_with(|| {
-                    serde_json::Value::String(config_format_version.to_string())
-                });
-            }
-            format_value.insert("config".to_string(), v);
-        }
+            parse_optional_json("tokens_schema_json", tokens_schema_json)?,
+            parse_optional_json("groups_schema_json", groups_schema_json)?,
+            parse_optional_json("keywords_json", keywords_json)?,
+            description.filter(|s| !s.is_empty()),
+            parse_optional_json("config_json", config_json)?,
+        )?;
 
         // Round-trip through a string instead of `from_value` — see
         // `create_data_contract_with_signer` for why the tagged-enum
         // dispatch needs `to_string` + `from_str`.
-        let serialized = serde_json::to_string_pretty(&serde_json::Value::Object(format_value))
-            .map_err(|e| {
-                PlatformWalletError::InvalidIdentityData(format!(
-                    "Failed to serialize updated contract format: {e}"
-                ))
-            })?;
+        let serialized = serde_json::to_string_pretty(&merged_value).map_err(|e| {
+            PlatformWalletError::InvalidIdentityData(format!(
+                "Failed to serialize updated contract format: {e}"
+            ))
+        })?;
         let format: DataContractInSerializationFormat =
             serde_json::from_str(&serialized).map_err(|e| {
                 PlatformWalletError::InvalidIdentityData(format!(
@@ -560,4 +563,254 @@ fn parse_optional_json(
     serde_json::from_str(s).map(Some).map_err(|e| {
         PlatformWalletError::InvalidIdentityData(format!("Invalid {field_name} JSON: {e}"))
     })
+}
+
+/// Overlay the caller-supplied update sections onto `base` — the
+/// serialization-format JSON of the *fetched* on-chain contract.
+///
+/// `base` must be a JSON object (the serialized
+/// `DataContractInSerializationFormat`), already carrying the live
+/// `documentSchemas` / `tokens` / `groups` / `keywords` / `description`
+/// / `config`. The merge is deliberately *additive* so an update that
+/// only touches one section never resets the others to serde defaults:
+///
+/// - `version` is set to `new_version` (the bumped value).
+/// - `documents` / `tokens` / `groups`: each supplied map is merged
+///   key-by-key into the existing map — an entry is added or replaced,
+///   but existing keys the caller didn't mention are kept. (DPP rejects
+///   document-type / token / group *removals* on update, so dropping
+///   the untouched ones would fail the transition.)
+/// - `keywords` / `description` / `config`: overridden wholesale, but
+///   only when the caller actually supplied them. A supplied `config`
+///   that lacks the `$formatVersion` tag inherits the base contract's
+///   on-chain config version so the tagged-enum dispatch still resolves.
+///
+/// The id + owner stay as whatever `base` carries (the fetched
+/// contract's), so the caller cannot retarget the update.
+#[allow(clippy::too_many_arguments)]
+fn merge_contract_update_payload(
+    mut base: serde_json::Value,
+    new_version: u32,
+    documents: serde_json::Value,
+    tokens: Option<serde_json::Value>,
+    groups: Option<serde_json::Value>,
+    keywords: Option<serde_json::Value>,
+    description: Option<&str>,
+    config: Option<serde_json::Value>,
+) -> Result<serde_json::Value, PlatformWalletError> {
+    let obj = base.as_object_mut().ok_or_else(|| {
+        PlatformWalletError::InvalidIdentityData(
+            "Existing contract did not serialize to a JSON object".to_string(),
+        )
+    })?;
+
+    obj.insert(
+        "version".to_string(),
+        serde_json::Value::Number(serde_json::Number::from(new_version)),
+    );
+
+    merge_map_section(obj, "documentSchemas", documents)?;
+    if let Some(v) = tokens {
+        merge_map_section(obj, "tokens", v)?;
+    }
+    if let Some(v) = groups {
+        merge_map_section(obj, "groups", v)?;
+    }
+
+    if let Some(v) = keywords {
+        obj.insert("keywords".to_string(), v);
+    }
+    if let Some(s) = description {
+        obj.insert(
+            "description".to_string(),
+            serde_json::Value::String(s.to_string()),
+        );
+    }
+    if let Some(mut v) = config {
+        // `DataContractConfig` is a `#[serde(tag = "$formatVersion")]`
+        // enum and the Swift form-builder sends a bare flags dict. When
+        // the caller omits the tag, inherit the base contract's
+        // on-chain config version so the tagged-enum dispatch resolves
+        // to the variant the network already accepts.
+        if let Some(supplied) = v.as_object_mut() {
+            if !supplied.contains_key("$formatVersion") {
+                if let Some(existing_tag) = obj
+                    .get("config")
+                    .and_then(|c| c.get("$formatVersion"))
+                    .cloned()
+                {
+                    supplied.insert("$formatVersion".to_string(), existing_tag);
+                }
+            }
+        }
+        obj.insert("config".to_string(), v);
+    }
+
+    Ok(base)
+}
+
+/// Merge a caller-supplied keyed map (`addition`, e.g. document
+/// schemas keyed by type name, or tokens keyed by stringified slot)
+/// into the same section already present in `base`. Adds or replaces
+/// each key; never drops an existing one. Inserts the section if the
+/// base didn't carry it. `addition` must be a JSON object.
+fn merge_map_section(
+    base: &mut serde_json::Map<String, serde_json::Value>,
+    section: &str,
+    addition: serde_json::Value,
+) -> Result<(), PlatformWalletError> {
+    let addition = match addition {
+        serde_json::Value::Object(map) => map,
+        // An empty / absent section is a no-op overlay (preserve base).
+        serde_json::Value::Null => return Ok(()),
+        _ => {
+            return Err(PlatformWalletError::InvalidIdentityData(format!(
+                "{section} update payload must be a JSON object keyed by entry name"
+            )))
+        }
+    };
+
+    match base.get_mut(section) {
+        Some(serde_json::Value::Object(existing)) => {
+            for (k, v) in addition {
+                existing.insert(k, v);
+            }
+        }
+        _ => {
+            base.insert(section.to_string(), serde_json::Value::Object(addition));
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    /// A minimal serialized-V1-contract base value, shaped like the
+    /// output of `serde_json::to_value(&DataContractInSerializationFormat)`.
+    fn base_contract() -> serde_json::Value {
+        json!({
+            "$formatVersion": "1",
+            "id": "11111111111111111111111111111111",
+            "ownerId": "22222222222222222222222222222222",
+            "version": 1,
+            "documentSchemas": {
+                "note": { "type": "object" }
+            },
+            "tokens": {
+                "0": { "conventions": {} }
+            },
+            "groups": {},
+            "keywords": ["alpha", "beta"],
+            "description": "original description",
+            "config": { "$formatVersion": "1", "canBeDeleted": false }
+        })
+    }
+
+    #[test]
+    fn merge_preserves_omitted_sections_and_adds_supplied_document() {
+        // Caller adds one new document type and supplies nothing else.
+        let merged = merge_contract_update_payload(
+            base_contract(),
+            2,
+            json!({ "comment": { "type": "object" } }),
+            None,
+            None,
+            None,
+            None,
+            None,
+        )
+        .expect("merge");
+
+        // Version bumped.
+        assert_eq!(merged["version"], json!(2));
+
+        // New document type added; existing one preserved (not dropped).
+        let docs = merged["documentSchemas"].as_object().unwrap();
+        assert!(docs.contains_key("note"), "existing doc type preserved");
+        assert!(docs.contains_key("comment"), "new doc type added");
+        assert_eq!(docs.len(), 2);
+
+        // Omitted sections kept verbatim from the fetched contract.
+        assert_eq!(merged["keywords"], json!(["alpha", "beta"]));
+        assert_eq!(merged["description"], json!("original description"));
+        assert_eq!(merged["tokens"], json!({ "0": { "conventions": {} } }));
+        assert_eq!(
+            merged["config"],
+            json!({ "$formatVersion": "1", "canBeDeleted": false })
+        );
+
+        // Id + owner unchanged.
+        assert_eq!(merged["id"], json!("11111111111111111111111111111111"));
+        assert_eq!(merged["ownerId"], json!("22222222222222222222222222222222"));
+    }
+
+    #[test]
+    fn merge_replaces_existing_document_entry_by_key() {
+        let merged = merge_contract_update_payload(
+            base_contract(),
+            2,
+            json!({ "note": { "type": "object", "revised": true } }),
+            None,
+            None,
+            None,
+            None,
+            None,
+        )
+        .expect("merge");
+
+        let docs = merged["documentSchemas"].as_object().unwrap();
+        assert_eq!(docs.len(), 1, "no extra key added");
+        assert_eq!(docs["note"], json!({ "type": "object", "revised": true }));
+    }
+
+    #[test]
+    fn merge_empty_documents_is_a_noop_overlay() {
+        // Token-only update path passes "{}" for documents.
+        let merged = merge_contract_update_payload(
+            base_contract(),
+            2,
+            json!({}),
+            Some(json!({ "1": { "conventions": {} } })),
+            None,
+            None,
+            None,
+            None,
+        )
+        .expect("merge");
+
+        // Existing document type still present.
+        assert!(merged["documentSchemas"]
+            .as_object()
+            .unwrap()
+            .contains_key("note"));
+        // New token slot merged alongside the existing one.
+        let tokens = merged["tokens"].as_object().unwrap();
+        assert!(tokens.contains_key("0"), "existing token slot preserved");
+        assert!(tokens.contains_key("1"), "new token slot added");
+    }
+
+    #[test]
+    fn merge_overrides_keywords_description_and_config_only_when_supplied() {
+        let merged = merge_contract_update_payload(
+            base_contract(),
+            2,
+            json!({}),
+            None,
+            None,
+            Some(json!(["gamma"])),
+            Some("new description"),
+            // Caller supplies a config without the format tag — should
+            // inherit the base contract's on-chain version.
+            Some(json!({ "canBeDeleted": true })),
+        )
+        .expect("merge");
+
+        assert_eq!(merged["keywords"], json!(["gamma"]));
+        assert_eq!(merged["description"], json!("new description"));
+        assert_eq!(merged["config"]["$formatVersion"], json!("1"));
+        assert_eq!(merged["config"]["canBeDeleted"], json!(true));
+    }
 }

--- a/packages/swift-sdk/Sources/SwiftDashSDK/PlatformWallet/ManagedPlatformWallet.swift
+++ b/packages/swift-sdk/Sources/SwiftDashSDK/PlatformWallet/ManagedPlatformWallet.swift
@@ -2475,6 +2475,90 @@ extension ManagedPlatformWallet {
         }.value
     }
 
+    /// Update an existing data contract owned by `ownerIdentityId`
+    /// and broadcast the change to Platform.
+    ///
+    /// Companion to `createDataContract`. The wallet fetches the
+    /// live contract from Platform, bumps its version, and applies
+    /// the supplied schemas / config at the next version — the
+    /// caller does NOT track contract version state. Every JSON
+    /// input has the same shape as `createDataContract`.
+    ///
+    /// `contractId` is the id of the existing contract to update.
+    /// Returns the (unchanged) contract id of the updated contract.
+    ///
+    /// Lifetime contract: the `signer` instance MUST stay alive for
+    /// the duration of the `await` (Rust holds a `passUnretained`
+    /// ctx pointer to the underlying `KeychainSigner`). A
+    /// `_ = signer` keepalive at the call site is the canonical way
+    /// to pin it.
+    public func updateDataContract(
+        ownerIdentityId: Identifier,
+        contractId: Identifier,
+        documentSchemasJSON: String,
+        tokenSchemasJSON: String? = nil,
+        groupsJSON: String? = nil,
+        keywordsJSON: String? = nil,
+        description: String? = nil,
+        contractConfigJSON: String? = nil,
+        signer: KeychainSigner
+    ) async throws -> Identifier {
+        let handle = self.handle
+        let signerHandle = signer.handle
+        let ownerBytes: [UInt8] = ownerIdentityId.withFFIBytes { ptr in
+            Array(UnsafeBufferPointer(start: ptr, count: 32))
+        }
+        let contractBytes: [UInt8] = contractId.withFFIBytes { ptr in
+            Array(UnsafeBufferPointer(start: ptr, count: 32))
+        }
+        return try await Task.detached(priority: .userInitiated) {
+            // Pin every borrowed payload across the FFI call: the
+            // owner-id + contract-id bytes, the required documents
+            // string, and each optional JSON / description string.
+            // Rust dereferences the C-string pointers synchronously
+            // inside `block_on_worker`, so the `withCString` scopes
+            // here are sufficient — the pointers don't need to
+            // outlive the call.
+            _ = signer
+            var contractIdBytes = [UInt8](repeating: 0, count: 32)
+
+            let result = ownerBytes.withUnsafeBufferPointer { ownerBp -> PlatformWalletFFIResult in
+                contractBytes.withUnsafeBufferPointer { contractBp -> PlatformWalletFFIResult in
+                    documentSchemasJSON.withCString { docsPtr in
+                        Self.withOptionalCString(tokenSchemasJSON) { tokensPtr in
+                            Self.withOptionalCString(groupsJSON) { groupsPtr in
+                                Self.withOptionalCString(keywordsJSON) { keywordsPtr in
+                                    Self.withOptionalCString(description) { descriptionPtr in
+                                        Self.withOptionalCString(contractConfigJSON) { configPtr in
+                                            contractIdBytes.withUnsafeMutableBufferPointer { outBp in
+                                                platform_wallet_update_data_contract_with_signer(
+                                                    handle,
+                                                    ownerBp.baseAddress!,
+                                                    contractBp.baseAddress!,
+                                                    docsPtr,
+                                                    tokensPtr,
+                                                    groupsPtr,
+                                                    keywordsPtr,
+                                                    descriptionPtr,
+                                                    configPtr,
+                                                    signerHandle,
+                                                    outBp.baseAddress!
+                                                )
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+
+            try result.check()
+            return Data(contractIdBytes)
+        }.value
+    }
+
     /// Run `body` with a NUL-terminated C string for `value`, or
     /// `nil` when `value` is nil. Mirrors the `withCString`
     /// pattern but terminates the chain when the optional is

--- a/packages/swift-sdk/SwiftExampleApp/SwiftExampleApp/Views/TransitionDetailView.swift
+++ b/packages/swift-sdk/SwiftExampleApp/SwiftExampleApp/Views/TransitionDetailView.swift
@@ -1916,10 +1916,16 @@ struct TransitionDetailView: View {
     // Resolve the wallet that owns this identity — contract update
     // mirrors contract create and goes through `platform-wallet`'s
     // `updateDataContract(...)`. The wallet fetches the live
-    // contract, bumps its version, applies the new schemas at the
-    // next version, builds a `DataContractUpdateTransition`, signs
-    // via the external `KeychainSigner`, and broadcasts on the
-    // 8 MB-stack worker (same rationale as create).
+    // contract, validates the owner, bumps its version, and *merges*
+    // the supplied sections onto the fetched definition at the next
+    // version (omitted sections — and any document/token/group entry
+    // we don't pass — are preserved), then builds a
+    // `DataContractUpdateTransition`, signs via the external
+    // `KeychainSigner`, and broadcasts on the 8 MB-stack worker (same
+    // rationale as create). Because the merge happens Rust-side, this
+    // form only needs to forward the sections the user actually
+    // changed; keywords / description / config are left to the
+    // on-chain values.
     guard let walletId = ownerIdentity.wallet?.walletId,
           let wallet = walletManager.wallet(for: walletId) else {
       throw SDKError.invalidParameter(
@@ -1927,9 +1933,10 @@ struct TransitionDetailView: View {
       )
     }
 
-    // The update transition replaces the full document-schema set
-    // at the next version, so an empty `{}` is the token-only
-    // baseline (matches the create path's required-documents arg).
+    // Document schemas are merged onto the fetched contract Rust-side
+    // (add or replace by type name; existing types are kept), so an
+    // empty `{}` is a no-op overlay — the right default for a token- or
+    // group-only update that touches no document types.
     let documentSchemasJSON = try toJSONString(
       newDocumentSchemas as Any?,
       fieldName: "newDocumentSchemas",

--- a/packages/swift-sdk/SwiftExampleApp/SwiftExampleApp/Views/TransitionDetailView.swift
+++ b/packages/swift-sdk/SwiftExampleApp/SwiftExampleApp/Views/TransitionDetailView.swift
@@ -1869,14 +1869,43 @@ struct TransitionDetailView: View {
       newTokenSchemas = parsed
     }
 
-    // Parse new groups if provided
-    var newGroups: [[String: Any]]? = nil
+    // Parse new groups if provided. As with contract create,
+    // `RegisterContractSourceView` flattens the chain-shape
+    // `{ "<position>": { ... } }` map into an array with an
+    // injected `id`. The V1 contract format wants a position-keyed
+    // map, so re-key the array back before crossing the FFI.
+    var newGroups: [String: Any]? = nil
     if let groupsJson = formInputs["newGroups"], !groupsJson.isEmpty {
-      guard let data = groupsJson.data(using: .utf8),
-            let parsed = try? JSONSerialization.jsonObject(with: data) as? [[String: Any]] else {
+      guard let data = groupsJson.data(using: .utf8) else {
         throw SDKError.serializationError("Invalid groups JSON")
       }
-      newGroups = parsed
+      let parsed = try JSONSerialization.jsonObject(with: data)
+      switch parsed {
+      case let byPosition as [String: Any]:
+        newGroups = byPosition
+      case let entries as [[String: Any]]:
+        var byPosition: [String: Any] = [:]
+        for var entry in entries {
+          guard let rawId = entry.removeValue(forKey: "id") else {
+            throw SDKError.serializationError("Group entry is missing an `id` field")
+          }
+          let key: String
+          if let intId = rawId as? Int {
+            key = String(intId)
+          } else if let strId = rawId as? String {
+            key = strId
+          } else {
+            throw SDKError.serializationError("Group entry has unsupported `id` type — expected Int or String")
+          }
+          guard byPosition[key] == nil else {
+            throw SDKError.serializationError("Duplicate group position `\(key)` in groups payload")
+          }
+          byPosition[key] = entry
+        }
+        newGroups = byPosition
+      default:
+        throw SDKError.serializationError("Invalid groups JSON")
+      }
     }
 
     // Validate that at least one update is provided
@@ -1884,25 +1913,58 @@ struct TransitionDetailView: View {
       throw SDKError.invalidParameter("At least one update (document schemas, token schemas, or groups) must be provided")
     }
 
-    // Use the DPPIdentity for contract update
-    let dppIdentity = DPPIdentity(
-      id: ownerIdentity.identityId,
-      publicKeys: Dictionary(uniqueKeysWithValues: ownerIdentity.identityPublicKeys.map { ($0.id, $0) }),
-      balance: UInt64(bitPattern: ownerIdentity.balance),
-      revision: 0
-    )
+    // Resolve the wallet that owns this identity — contract update
+    // mirrors contract create and goes through `platform-wallet`'s
+    // `updateDataContract(...)`. The wallet fetches the live
+    // contract, bumps its version, applies the new schemas at the
+    // next version, builds a `DataContractUpdateTransition`, signs
+    // via the external `KeychainSigner`, and broadcasts on the
+    // 8 MB-stack worker (same rationale as create).
+    guard let walletId = ownerIdentity.wallet?.walletId,
+          let wallet = walletManager.wallet(for: walletId) else {
+      throw SDKError.invalidParameter(
+        "Identity has no wallet linkage; cannot sign contract update"
+      )
+    }
 
-    // Contract update via the new platform-wallet path isn't
-    // wired through yet — the previous `sdk.dataContractUpdate(...)`
-    // call always threw `notImplemented` and is now deleted along
-    // with the other legacy rs-sdk-ffi contract surface. Surface
-    // the same error here until a `wallet.updateDataContract(...)`
-    // sibling lands.
-    _ = (contractId, dppIdentity, newDocumentSchemas, newTokenSchemas, newGroups)
-    throw SDKError.notImplemented(
-      "Data contract update is not yet wired through the platform-wallet path. " +
-      "Create a fresh contract for now."
+    // The update transition replaces the full document-schema set
+    // at the next version, so an empty `{}` is the token-only
+    // baseline (matches the create path's required-documents arg).
+    let documentSchemasJSON = try toJSONString(
+      newDocumentSchemas as Any?,
+      fieldName: "newDocumentSchemas",
+      defaultIfNil: "{}"
+    ) ?? "{}"
+    let tokenSchemasJSON = try toJSONString(newTokenSchemas as Any?, fieldName: "newTokenSchemas")
+    let groupsJSON = try toJSONString(newGroups as Any?, fieldName: "newGroups")
+
+    // Decode the base58 contract id the form provided.
+    guard let contractIdData = Data.identifier(fromBase58: contractId),
+          contractIdData.count == 32 else {
+      throw SDKError.invalidParameter("Invalid data contract ID (expected 32-byte base58)")
+    }
+
+    // External-signer pattern (matches contract create): Rust calls
+    // back into Swift over the `KeychainSigner` trampoline whenever
+    // it needs a signature.
+    let signer = KeychainSigner(modelContainer: modelContext.container)
+
+    let updatedContractId = try await wallet.updateDataContract(
+      ownerIdentityId: ownerIdentity.identityId,
+      contractId: contractIdData,
+      documentSchemasJSON: documentSchemasJSON,
+      tokenSchemasJSON: tokenSchemasJSON,
+      groupsJSON: groupsJSON,
+      signer: signer
     )
+    // Keepalive: see KeychainSigner lifetime contract.
+    _ = signer
+
+    return [
+      "success": true,
+      "contractId": updatedContractId.toBase58String(),
+      "message": "Data contract updated and broadcast successfully",
+    ]
   }
 
   // MARK: - Helper Functions


### PR DESCRIPTION
## Issue being fixed or feature implemented

The SwiftExampleApp's generic transition builder defines a `dataContractUpdate`
transition form, but its execution handler
(`TransitionDetailView.executeDataContractUpdate`) was stubbed to throw
*"Data contract update is not yet wired through the platform-wallet path"*.
As a result, contract updates could not be broadcast from the app — only fresh
contract creates worked.

## What was done?

Wired `executeDataContractUpdate` end-to-end through the `platform-wallet`
path, mirroring the existing `createDataContract` flow. A **new** wallet-side
method was added (no existing update path existed):

- **`platform-wallet`** — `IdentityWallet::update_data_contract_with_signer`
  (`packages/rs-platform-wallet/src/wallet/identity/network/contract.rs`).
  It picks the owner identity's CRITICAL + AUTHENTICATION + ECDSA key, fetches
  the live contract from Platform to read its current version, assembles the
  new serialization-format payload at `current_version + 1` (DPP requires a
  strictly incremented version), deserializes/validates it via
  `DataContractInSerializationFormat` + `try_from_platform_versioned`, then
  fetches+bumps the identity-contract nonce, builds a
  `DataContractUpdateTransition`, signs via the external signer, broadcasts on
  the 8 MB-stack worker, and waits for the confirmed contract. There is no
  `UpdateContract` SDK extension mirroring `PutContract`, so the transition is
  assembled directly here.

- **Config version fix (cross-cutting)** — the config `$formatVersion` is
  selected from `platform_version.dpp.contract_versions.config.default_current_version`
  (which is `1`/V1 under v12) rather than the hardcoded `"0"` the create path
  still uses. v12 rejects a V0 config on update. The create-path V0 build is
  fixed separately by `fix/data-contract-config-v1`; this change deliberately
  does **not** touch the create path and does not reintroduce V0.

- **`rs-platform-wallet-ffi`** — exposed
  `platform_wallet_update_data_contract_with_signer`
  (`packages/rs-platform-wallet-ffi/src/data_contract.rs`), adding a
  `contract_id` input over the create binding. The C header is regenerated by
  cbindgen at build time, so no manual header edit is needed.

- **`swift-sdk`** — added the thin `ManagedPlatformWallet.updateDataContract(...)`
  wrapper (`packages/swift-sdk/Sources/SwiftDashSDK/PlatformWallet/ManagedPlatformWallet.swift`)
  and called it from `executeDataContractUpdate`
  (`packages/swift-sdk/SwiftExampleApp/SwiftExampleApp/Views/TransitionDetailView.swift`),
  re-keying the form-flattened `newGroups` array back into the position-keyed
  map the V1 format expects. All orchestration stays in Rust per
  `swift-sdk/CLAUDE.md`; Swift only marshals.

## How Has This Been Tested?

- `cargo fmt --all`
- `cargo check -p platform-wallet` — clean
- `cargo check -p platform-wallet-ffi` — clean
- `cargo clippy -p platform-wallet -p platform-wallet-ffi` — clean (no findings)

iOS build + combined end-to-end testing is handled separately by the
orchestrator and was intentionally not run here.

## Breaking Changes

None. This is SDK/app surface (a new wallet method + FFI binding + Swift
wrapper), not a consensus change.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [ ] I have made corresponding changes to the documentation if needed

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Update existing data contracts from the wallet with custom document/token schemas, groups, keywords, description, and config; changes are signed and broadcasted, returning the confirmed contract ID.
  * Swift SDK: new async API to invoke data-contract updates using a keychain-backed signer.
  * UI: Example app now supports submitting data-contract updates from the Transition view with input parsing and validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->