### PR TITLE
fix(drive): return empty history for contracts that don't keep history

### DIFF
--- a/packages/rs-drive/src/verify/contract/verify_contract_history/v0/mod.rs
+++ b/packages/rs-drive/src/verify/contract/verify_contract_history/v0/mod.rs
@@ -1,4 +1,4 @@
-use crate::drive::contract::paths::contract_storage_path_vec;
+use crate::drive::contract::paths::{contract_root_path_vec, contract_storage_path_vec};
 use crate::drive::Drive;
 use crate::error::proof::ProofError;
 use crate::error::Error;
@@ -50,6 +50,29 @@ impl Drive {
 
         let (root_hash, mut proved_key_values) =
             GroveDb::verify_query(proof, &path_query, &platform_version.drive.grove_version)?;
+
+        // A contract that does NOT keep history stores its single current version as an
+        // Item at the contract root path (key [0]), one level above the history subtree.
+        // Querying history for such a contract proves THAT single Item instead of the
+        // (non-existent) history subtree. Treat it as a valid empty history rather than a
+        // corrupted proof. Require exactly one proved element that is a present item, so any
+        // other shape at this path still fails as corrupted (mirroring the strict path
+        // discrimination applied to the history entries below).
+        if proved_key_values.len() == 1 {
+            let (path, key, maybe_element) = &proved_key_values[0];
+            if path == &contract_root_path_vec(&contract_id) && key == &vec![0u8] {
+                let is_item = maybe_element
+                    .as_ref()
+                    .map(|element| element.is_any_item())
+                    .unwrap_or(false);
+                if !is_item {
+                    return Err(Error::Proof(ProofError::CorruptedProof(
+                        "expected a contract item at the contract root path".to_string(),
+                    )));
+                }
+                return Ok((root_hash, Some(BTreeMap::new())));
+            }
+        }
 
         let mut contracts: BTreeMap<u64, DataContract> = BTreeMap::new();
         for (path, key, maybe_element) in proved_key_values.drain(..) {
@@ -236,6 +259,101 @@ mod tests {
             history.len(),
             2,
             "should have 2 history entries with limit=2"
+        );
+    }
+
+    #[test]
+    fn should_return_empty_history_for_non_history_contract() {
+        let drive = setup_drive_with_initial_state_structure(None);
+        let platform_version = PlatformVersion::latest();
+
+        let mut contract = get_data_contract_fixture(None, 0, platform_version.protocol_version)
+            .data_contract_owned();
+        // The contract does NOT keep history (the default, but make it explicit).
+        contract.config_mut().set_keeps_history(false);
+        contract.config_mut().set_readonly(false);
+
+        let contract_id = contract.id().to_buffer();
+
+        // Apply the contract once at time 1000
+        apply_contract(
+            &drive,
+            &contract,
+            BlockInfo {
+                time_ms: 1000,
+                height: 100,
+                core_height: 10,
+                epoch: Default::default(),
+            },
+        );
+
+        // Prove history starting from time 0
+        let proof = drive
+            .prove_contract_history(contract_id, None, 0, Some(10), None, platform_version)
+            .expect("should prove contract history for a non-history contract");
+
+        let (_root_hash, verified_history) = Drive::verify_contract_history(
+            &proof,
+            contract_id,
+            0,
+            Some(10),
+            None,
+            platform_version,
+        )
+        .expect("should verify contract history for a non-history contract");
+
+        let history = verified_history.expect("history should be Some (an empty map)");
+        assert!(
+            history.is_empty(),
+            "a contract that does not keep history should return an empty history map"
+        );
+    }
+
+    #[test]
+    fn should_return_empty_history_for_non_history_contract_with_params() {
+        let drive = setup_drive_with_initial_state_structure(None);
+        let platform_version = PlatformVersion::latest();
+
+        let mut contract = get_data_contract_fixture(None, 0, platform_version.protocol_version)
+            .data_contract_owned();
+        contract.config_mut().set_keeps_history(false);
+        contract.config_mut().set_readonly(false);
+
+        let contract_id = contract.id().to_buffer();
+
+        apply_contract(
+            &drive,
+            &contract,
+            BlockInfo {
+                time_ms: 1000,
+                height: 100,
+                core_height: 10,
+                epoch: Default::default(),
+            },
+        );
+
+        // A non-default limit and start_at_ms must not change the empty result.
+        // (offset is intentionally not exercised here: count-offset pagination is a
+        // prove-side limitation that errors against a non-history contract's item path,
+        // and the FFI never sends a non-zero offset for the no-history case anyway.)
+        let proof = drive
+            .prove_contract_history(contract_id, None, 500, Some(5), None, platform_version)
+            .expect("should prove contract history for a non-history contract");
+
+        let (_root_hash, verified_history) = Drive::verify_contract_history(
+            &proof,
+            contract_id,
+            500,
+            Some(5),
+            None,
+            platform_version,
+        )
+        .expect("should verify contract history for a non-history contract");
+
+        let history = verified_history.expect("history should be Some (an empty map)");
+        assert!(
+            history.is_empty(),
+            "a non-history contract should return empty regardless of limit/start_at_ms"
         );
     }
 }


### PR DESCRIPTION
## Issue being fixed or feature implemented

`getDataContractHistory` against a contract with `keepsHistory=false` (e.g. the testnet DPNS contract `GWRSAVFMjXx8HpQFaNJMqBV7MBgMK4br5UESsB4S31Ec`) failed with a proof-verification error instead of returning an empty result:

> `Proof verification error: dash drive: proof: corrupted error: we did not get back an element for the correct path for the historical contract`

A contract that doesn't keep history simply has no history — that should be a graceful empty result, not an error. This also matches a long-standing `it.skip` in `packages/wasm-sdk/tests/functional/contracts.spec.ts`.

## What was done?

**Root cause.** `verify_contract_history_v0` always assumes the queried contract keeps history. It expects every proved key-value at the 3-segment history path `[DataContractDocuments, contract_id, 0]`. But a contract with `keepsHistory=false` stores its single current version as an `Item` at the 2-segment contract **root** path (key `[0]`), one level up. GroveDB therefore proves *that* element, the path is length 2 (not 3), and the verifier rejected a perfectly valid proof as `CorruptedProof`.

**Fix** (`packages/rs-drive/src/verify/contract/verify_contract_history/v0/mod.rs`): detect the non-history shape — *exactly one* proved element at `contract_root_path_vec(id)` (key `[0]`) that is a present item (`is_any_item()`) — and return an empty history map. Any other shape at that path still fails as `CorruptedProof`, mirroring the strict discrimination applied to the history-path entries. Returning `Some(empty)` (not `None`) flows cleanly through `FromProof for DataContractHistory` and the FFI.

**Soundness:** no regression. The proof remains cryptographically bound to the state root (merk hash checks) and the signed block (tenderdash); a server cannot forge an `Item` where a real history `Tree` exists.

> Note: the misleading `"Failed to fetch balances:"` FFI error prefix that compounded this message was a separate issue, already fixed and merged in #3878. This PR was rebased onto current `v3.1-dev` (which already includes both #3878 and the shielded-activity feature), so it now contains only the verifier fix.

## How Has This Been Tested?

- `cargo test -p drive --lib verify_contract_history` — **5 passing**, including two new regression tests (`should_return_empty_history_for_non_history_contract` and a non-default `limit`/`start_at_ms` variant). Existing `keepsHistory=true` tests still pass.
- `cargo check -p drive --no-default-features --features verify` — clean (the verifier builds under the `verify` feature only; confirms `contract_root_path_vec`/`is_any_item` are available there).

**Manual / live testnet** (read-only, no funded identity needed; rebuild the xcframework first):
- No-history: query DPNS `GWRSAVFMjXx8HpQFaNJMqBV7MBgMK4br5UESsB4S31Ec` (limit 10) → graceful empty result, no error.
- Happy path: query `HLY575cNazmc5824FxqaEMEBuzFeE4a98GDRNKbyJqCM` (the known history-keeping testnet contract used by the app's `DiagnosticsView`) → ≥1 entry.

## Breaking Changes

None. Client-side proof-verification bug fix; no consensus or wire-format change. Behavior changes only from "error" to "empty result" for the no-history case.

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any (no breaking changes)
- [ ] I have made corresponding changes to the documentation if needed

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone
