### PR TITLE
feat: record DAPI address ban reason and expose via platform-wallet FFI

### DIFF
--- a/packages/rs-dapi-client/src/address_ban_info.rs
+++ b/packages/rs-dapi-client/src/address_ban_info.rs
@@ -1,0 +1,29 @@
+//! An owned snapshot of an address' ban state, decoupled from the
+//! lock-guarded [`crate::AddressList`] internals so it can cross crate
+//! and FFI boundaries.
+
+use chrono::{DateTime, Utc};
+
+/// An owned, cloned snapshot of a single address' ban state, returned
+/// from [`crate::AddressList::ban_info`].
+///
+/// This is a plain-data mirror of [`crate::AddressStatus`] (plus the
+/// address URI) so it can be handed across crate / FFI boundaries
+/// without holding the [`crate::AddressList`] lock.
+#[derive(Debug, Clone)]
+pub struct AddressBanInfo {
+    /// The address URI as a string.
+    pub uri: String,
+    /// Whether the address is *currently effectively* banned, i.e. it
+    /// has been banned at least once and the ban period has not yet
+    /// expired. Consistent with the filtering used by
+    /// [`crate::AddressList::get_live_address`].
+    pub banned: bool,
+    /// Total number of times the address has been banned (drives the
+    /// exponential backoff).
+    pub ban_count: usize,
+    /// The timestamp until which the address remains banned, if any.
+    pub banned_until: Option<DateTime<Utc>>,
+    /// Human-readable reason for the most recent ban, if recorded.
+    pub reason: Option<String>,
+}

--- a/packages/rs-dapi-client/src/address_list.rs
+++ b/packages/rs-dapi-client/src/address_list.rs
@@ -73,16 +73,33 @@ impl Address {
 pub struct AddressStatus {
     ban_count: usize,
     banned_until: Option<chrono::DateTime<Utc>>,
+    /// Human-readable reason for the most recent ban, if any. Cleared
+    /// on [`AddressStatus::unban`]. Sourced from the error that caused
+    /// the ban (see `update_address_ban_status`).
+    ban_reason: Option<String>,
 }
 
 impl AddressStatus {
     /// Ban the [Address] so it won't be available through [AddressList::get_live_address] for some time.
+    ///
+    /// Back-compat shim for [`AddressStatus::ban_with_reason`] with no reason.
     pub fn ban(&mut self, base_ban_period: &Duration) {
+        self.ban_with_reason(base_ban_period, None);
+    }
+
+    /// Ban the [Address] and record the `reason` for the ban.
+    ///
+    /// Applies the same exponential backoff as [`AddressStatus::ban`];
+    /// the only difference is that `ban_reason` is stored so callers
+    /// (diagnostics, the iOS explorer) can surface why a node was
+    /// banned.
+    pub fn ban_with_reason(&mut self, base_ban_period: &Duration, reason: Option<String>) {
         let coefficient = (self.ban_count as f64).exp();
         let ban_period = Duration::from_secs_f64(base_ban_period.as_secs_f64() * coefficient);
 
         self.banned_until = Some(chrono::Utc::now() + ban_period);
         self.ban_count += 1;
+        self.ban_reason = reason;
     }
 
     /// Check if [Address] is banned.
@@ -94,7 +111,32 @@ impl AddressStatus {
     pub fn unban(&mut self) {
         self.ban_count = 0;
         self.banned_until = None;
+        self.ban_reason = None;
     }
+}
+
+/// An owned, cloned snapshot of a single address' ban state, returned
+/// from [`AddressList::ban_info`].
+///
+/// This is a plain-data mirror of [`AddressStatus`] (plus the address
+/// URI) so it can be handed across crate / FFI boundaries without
+/// holding the [`AddressList`] lock.
+#[derive(Debug, Clone)]
+pub struct AddressBanInfo {
+    /// The address URI as a string.
+    pub uri: String,
+    /// Whether the address is *currently effectively* banned, i.e. it
+    /// has been banned at least once and the ban period has not yet
+    /// expired. Consistent with the filtering used by
+    /// [`AddressList::get_live_address`].
+    pub banned: bool,
+    /// Total number of times the address has been banned (drives the
+    /// exponential backoff).
+    pub ban_count: usize,
+    /// The timestamp until which the address remains banned, if any.
+    pub banned_until: Option<chrono::DateTime<Utc>>,
+    /// Human-readable reason for the most recent ban, if recorded.
+    pub reason: Option<String>,
 }
 
 /// [AddressList] errors
@@ -143,14 +185,22 @@ impl AddressList {
 
     /// Bans address
     /// Returns false if the address is not in the list.
+    ///
+    /// Back-compat shim for [`AddressList::ban_with_reason`] with no reason.
     pub fn ban(&self, address: &Address) -> bool {
+        self.ban_with_reason(address, None)
+    }
+
+    /// Bans address, recording the `reason` for the ban.
+    /// Returns false if the address is not in the list.
+    pub fn ban_with_reason(&self, address: &Address, reason: Option<String>) -> bool {
         let mut guard = self.addresses.write().unwrap();
 
         let Some(status) = guard.get_mut(address) else {
             return false;
         };
 
-        status.ban(&self.base_ban_period);
+        status.ban_with_reason(&self.base_ban_period, reason);
 
         true
     }
@@ -263,6 +313,38 @@ impl AddressList {
                     .unwrap_or(true)
             })
             .map(|(addr, _)| addr.clone())
+            .collect()
+    }
+
+    /// Get an owned snapshot of every address' ban state.
+    ///
+    /// Clones the current state into an owned `Vec<AddressBanInfo>` so
+    /// it can be inspected without holding the internal lock. The
+    /// `banned` flag reflects the *currently effectively banned*
+    /// semantics used by [`AddressList::get_live_address`]: the address
+    /// has been banned at least once (`ban_count > 0`) and its ban
+    /// period has not yet expired (`banned_until` is in the future).
+    pub fn ban_info(&self) -> Vec<AddressBanInfo> {
+        let guard = self.addresses.read().unwrap();
+
+        let now = chrono::Utc::now();
+
+        guard
+            .iter()
+            .map(|(addr, status)| {
+                let banned = status.ban_count > 0
+                    && status
+                        .banned_until
+                        .map(|banned_until| banned_until >= now)
+                        .unwrap_or(false);
+                AddressBanInfo {
+                    uri: addr.to_string(),
+                    banned,
+                    ban_count: status.ban_count,
+                    banned_until: status.banned_until,
+                    reason: status.ban_reason.clone(),
+                }
+            })
             .collect()
     }
 
@@ -591,5 +673,109 @@ mod tests {
     fn test_address_list_default() {
         let list = AddressList::default();
         assert!(list.is_empty());
+    }
+
+    #[test]
+    fn test_address_status_ban_with_reason_stores_reason() {
+        let mut status = AddressStatus::default();
+        assert!(status.ban_reason.is_none());
+
+        status.ban_with_reason(
+            &Duration::from_secs(60),
+            Some("transport error".to_string()),
+        );
+        assert_eq!(status.ban_reason.as_deref(), Some("transport error"));
+        assert!(status.is_banned());
+    }
+
+    #[test]
+    fn test_address_status_ban_without_reason_is_none() {
+        let mut status = AddressStatus::default();
+        status.ban(&Duration::from_secs(60));
+        assert!(status.ban_reason.is_none());
+        assert!(status.is_banned());
+    }
+
+    #[test]
+    fn test_address_status_unban_clears_reason() {
+        let mut status = AddressStatus::default();
+        status.ban_with_reason(&Duration::from_secs(60), Some("boom".to_string()));
+        assert_eq!(status.ban_reason.as_deref(), Some("boom"));
+
+        status.unban();
+        assert!(status.ban_reason.is_none());
+        assert!(!status.is_banned());
+    }
+
+    #[test]
+    fn test_address_list_ban_with_reason_records_reason() {
+        let mut list = AddressList::new();
+        let addr: Address = "http://127.0.0.1:3000".parse().unwrap();
+        list.add(addr.clone());
+
+        assert!(list.ban_with_reason(&addr, Some("node down".to_string())));
+
+        let info = list.ban_info();
+        assert_eq!(info.len(), 1);
+        let entry = &info[0];
+        assert_eq!(entry.reason.as_deref(), Some("node down"));
+        assert!(entry.banned);
+        assert_eq!(entry.ban_count, 1);
+        assert!(entry.banned_until.is_some());
+    }
+
+    #[test]
+    fn test_address_list_ban_without_reason_records_none() {
+        let mut list = AddressList::new();
+        let addr: Address = "http://127.0.0.1:3000".parse().unwrap();
+        list.add(addr.clone());
+
+        assert!(list.ban(&addr));
+
+        let info = list.ban_info();
+        assert_eq!(info.len(), 1);
+        assert!(info[0].reason.is_none());
+        assert!(info[0].banned);
+    }
+
+    #[test]
+    fn test_address_list_unban_clears_reason_in_ban_info() {
+        let mut list = AddressList::new();
+        let addr: Address = "http://127.0.0.1:3000".parse().unwrap();
+        list.add(addr.clone());
+
+        list.ban_with_reason(&addr, Some("oops".to_string()));
+        assert!(list.unban(&addr));
+
+        let info = list.ban_info();
+        assert_eq!(info.len(), 1);
+        let entry = &info[0];
+        assert!(entry.reason.is_none());
+        assert!(!entry.banned);
+        assert_eq!(entry.ban_count, 0);
+        assert!(entry.banned_until.is_none());
+    }
+
+    #[test]
+    fn test_ban_info_reflects_unbanned_address() {
+        let mut list = AddressList::new();
+        let addr: Address = "http://127.0.0.1:3000".parse().unwrap();
+        list.add(addr.clone());
+
+        // Never banned: banned == false, no reason, ban_count == 0.
+        let info = list.ban_info();
+        assert_eq!(info.len(), 1);
+        let entry = &info[0];
+        assert!(!entry.banned);
+        assert_eq!(entry.ban_count, 0);
+        assert!(entry.banned_until.is_none());
+        assert!(entry.reason.is_none());
+        assert!(entry.uri.contains("127.0.0.1"));
+    }
+
+    #[test]
+    fn test_ban_info_empty_list() {
+        let list = AddressList::new();
+        assert!(list.ban_info().is_empty());
     }
 }

--- a/packages/rs-dapi-client/src/address_list.rs
+++ b/packages/rs-dapi-client/src/address_list.rs
@@ -1,5 +1,6 @@
 //! Subsystem to manage DAPI nodes.
 
+use crate::address_ban_info::AddressBanInfo;
 use crate::Uri;
 use chrono::Utc;
 use rand::{rngs::SmallRng, seq::IteratorRandom, SeedableRng};
@@ -113,30 +114,6 @@ impl AddressStatus {
         self.banned_until = None;
         self.ban_reason = None;
     }
-}
-
-/// An owned, cloned snapshot of a single address' ban state, returned
-/// from [`AddressList::ban_info`].
-///
-/// This is a plain-data mirror of [`AddressStatus`] (plus the address
-/// URI) so it can be handed across crate / FFI boundaries without
-/// holding the [`AddressList`] lock.
-#[derive(Debug, Clone)]
-pub struct AddressBanInfo {
-    /// The address URI as a string.
-    pub uri: String,
-    /// Whether the address is *currently effectively* banned, i.e. it
-    /// has been banned at least once and the ban period has not yet
-    /// expired. Consistent with the filtering used by
-    /// [`AddressList::get_live_address`].
-    pub banned: bool,
-    /// Total number of times the address has been banned (drives the
-    /// exponential backoff).
-    pub ban_count: usize,
-    /// The timestamp until which the address remains banned, if any.
-    pub banned_until: Option<chrono::DateTime<Utc>>,
-    /// Human-readable reason for the most recent ban, if recorded.
-    pub reason: Option<String>,
 }
 
 /// [AddressList] errors
@@ -283,7 +260,7 @@ impl AddressList {
     /// Get all not banned addresses.
     ///
     /// Returns a vector of addresses that are not currently banned or whose ban period has expired.
-    /// The returned addresses use the same filtering logic as [get_live_address], checking if the
+    /// The returned addresses use the same filtering logic as [`Self::get_live_address`], checking if the
     /// ban period has expired based on the current time.
     ///
     /// # Examples

--- a/packages/rs-dapi-client/src/dapi_client.rs
+++ b/packages/rs-dapi-client/src/dapi_client.rs
@@ -352,6 +352,16 @@ mod tests {
 
         update_address_ban_status(&address_list, &result, &make_applied_settings(true));
         assert!(address_list.is_banned(&addr));
+
+        // The ban reason must be propagated from the error via this call path,
+        // not just the ban itself.
+        let info = address_list.ban_info();
+        assert_eq!(info.len(), 1);
+        let reason = info[0].reason.as_deref().expect("ban reason recorded");
+        assert!(
+            reason.contains("temporary"),
+            "ban reason should carry the underlying error, got: {reason}"
+        );
     }
 
     #[test]

--- a/packages/rs-dapi-client/src/dapi_client.rs
+++ b/packages/rs-dapi-client/src/dapi_client.rs
@@ -187,7 +187,7 @@ pub fn update_address_ban_status<R, E>(
             if error.can_retry() {
                 if let Some(address) = error.address.as_ref() {
                     if applied_settings.ban_failed_address {
-                        if address_list.ban(address) {
+                        if address_list.ban_with_reason(address, Some(error.to_string())) {
                             tracing::warn!(
                                 ?address,
                                 ?error,

--- a/packages/rs-dapi-client/src/lib.rs
+++ b/packages/rs-dapi-client/src/lib.rs
@@ -2,6 +2,7 @@
 
 #![deny(missing_docs)]
 
+mod address_ban_info;
 mod address_list;
 mod connection_pool;
 mod dapi_client;
@@ -13,8 +14,8 @@ pub mod mock;
 mod request_settings;
 pub mod transport;
 
+pub use address_ban_info::AddressBanInfo;
 pub use address_list::Address;
-pub use address_list::AddressBanInfo;
 pub use address_list::AddressList;
 pub use address_list::AddressListError;
 pub use address_list::AddressStatus;

--- a/packages/rs-dapi-client/src/lib.rs
+++ b/packages/rs-dapi-client/src/lib.rs
@@ -14,6 +14,7 @@ mod request_settings;
 pub mod transport;
 
 pub use address_list::Address;
+pub use address_list::AddressBanInfo;
 pub use address_list::AddressList;
 pub use address_list::AddressListError;
 pub use address_list::AddressStatus;

--- a/packages/rs-platform-wallet-ffi/src/core_wallet_types.rs
+++ b/packages/rs-platform-wallet-ffi/src/core_wallet_types.rs
@@ -615,6 +615,29 @@ pub struct WalletIdentityRowFFI {
     pub identity_id: [u8; 32],
 }
 
+/// One row of the DAPI address ban-list snapshot.
+///
+/// `address` is a heap-owned NUL-terminated UTF-8 string (the node
+/// URI); `reason` is a heap-owned NUL-terminated UTF-8 string or
+/// `null` when no ban reason was recorded. Both are freed by the
+/// paired `platform_wallet_manager_address_ban_info_free`.
+#[repr(C)]
+#[derive(Debug, Clone, Copy)]
+pub struct AddressBanInfoFFI {
+    /// Heap-owned node URI string. Always non-null on a successful row.
+    pub address: *mut c_char,
+    /// Whether the address is currently effectively banned.
+    pub banned: bool,
+    /// Total number of times the address has been banned.
+    pub ban_count: u32,
+    /// Unix-epoch millisecond timestamp until which the address is
+    /// banned; `0` when there is no active ban window.
+    pub banned_until_ms: i64,
+    /// Heap-owned human-readable ban reason, or `null` when none was
+    /// recorded.
+    pub reason: *mut c_char,
+}
+
 /// Subset of [`crate::wallet_restore_types::AccountSpecFFI`] carrying
 /// only the tag/discriminator fields — no xpub. Used by the
 /// changeset emit path to populate

--- a/packages/rs-platform-wallet-ffi/src/manager_diagnostics.rs
+++ b/packages/rs-platform-wallet-ffi/src/manager_diagnostics.rs
@@ -820,7 +820,7 @@ pub unsafe extern "C" fn platform_wallet_manager_address_ban_info(
         .map(|s| AddressBanInfoFFI {
             address: optional_into_raw(Some(s.uri)),
             banned: s.banned,
-            ban_count: s.ban_count as u32,
+            ban_count: u32::try_from(s.ban_count).unwrap_or(u32::MAX),
             banned_until_ms: s.banned_until_ms.unwrap_or(0),
             reason: optional_into_raw(s.reason),
         })

--- a/packages/rs-platform-wallet-ffi/src/manager_diagnostics.rs
+++ b/packages/rs-platform-wallet-ffi/src/manager_diagnostics.rs
@@ -18,17 +18,18 @@ use std::os::raw::c_char;
 
 use platform_wallet::manager::accessors::{
     AccountAddressInfoSnapshot, AccountAddressPoolSnapshot, AccountMetadataSnapshot,
-    AccountTransactionSnapshot, AccountUtxoSnapshot, CoreWalletStateSnapshot,
-    IdentitySyncConfigSnapshot, IdentityWalletStateSnapshot, PlatformAddressProviderStateSnapshot,
-    PlatformAddressSyncConfigSnapshot, TrackedAssetLockSnapshot, WalletIdentityRowSnapshot,
+    AccountTransactionSnapshot, AccountUtxoSnapshot, AddressBanInfoSnapshot,
+    CoreWalletStateSnapshot, IdentitySyncConfigSnapshot, IdentityWalletStateSnapshot,
+    PlatformAddressProviderStateSnapshot, PlatformAddressSyncConfigSnapshot,
+    TrackedAssetLockSnapshot, WalletIdentityRowSnapshot,
 };
 
 use crate::check_ptr;
 use crate::core_wallet_types::{
     AccountAddressPoolEntryFFI, AccountMetadataFFI, AccountTransactionEntryFFI,
-    AccountUtxoEntryFFI, AddressInfoFFI, CoreWalletStateFFI, IdentitySyncConfigFFI,
-    IdentityWalletStateFFI, PlatformAddressProviderStateFFI, PlatformAddressSyncConfigFFI,
-    TrackedAssetLockEntryFFI, WalletIdentityRowFFI,
+    AccountUtxoEntryFFI, AddressBanInfoFFI, AddressInfoFFI, CoreWalletStateFFI,
+    IdentitySyncConfigFFI, IdentityWalletStateFFI, PlatformAddressProviderStateFFI,
+    PlatformAddressSyncConfigFFI, TrackedAssetLockEntryFFI, WalletIdentityRowFFI,
 };
 use crate::error::{PlatformWalletFFIResult, PlatformWalletFFIResultCode};
 use crate::handle::{Handle, PLATFORM_WALLET_MANAGER_STORAGE};
@@ -780,6 +781,77 @@ pub unsafe extern "C" fn platform_wallet_identity_manager_wallet_identities_free
     if !rows.is_null() && count > 0 {
         let _ = Box::from_raw(std::ptr::slice_from_raw_parts_mut(rows, count));
     }
+}
+
+// ---------------------------------------------------------------------------
+// Phase 8 — DAPI address ban list
+// ---------------------------------------------------------------------------
+
+/// Snapshot of every DAPI address' ban state, including the reason
+/// each address was banned (when recorded).
+///
+/// On success `*out_entries` points at a heap-owned `[AddressBanInfoFFI]`
+/// of length `*out_count`; the caller must release it via
+/// [`platform_wallet_manager_address_ban_info_free`]. An empty list
+/// returns `ok()` with `*out_entries = null`, `*out_count = 0`.
+#[no_mangle]
+pub unsafe extern "C" fn platform_wallet_manager_address_ban_info(
+    manager_handle: Handle,
+    out_entries: *mut *const AddressBanInfoFFI,
+    out_count: *mut usize,
+) -> PlatformWalletFFIResult {
+    check_ptr!(out_entries);
+    check_ptr!(out_count);
+    *out_entries = std::ptr::null();
+    *out_count = 0;
+    let Some(rows): Option<Vec<AddressBanInfoSnapshot>> = PLATFORM_WALLET_MANAGER_STORAGE
+        .with_item(manager_handle, |m| m.address_ban_info_blocking())
+    else {
+        return PlatformWalletFFIResult::err(
+            PlatformWalletFFIResultCode::ErrorInvalidHandle,
+            "Manager handle invalid".to_string(),
+        );
+    };
+    if rows.is_empty() {
+        return PlatformWalletFFIResult::ok();
+    }
+    let entries: Vec<AddressBanInfoFFI> = rows
+        .into_iter()
+        .map(|s| AddressBanInfoFFI {
+            address: optional_into_raw(Some(s.uri)),
+            banned: s.banned,
+            ban_count: s.ban_count as u32,
+            banned_until_ms: s.banned_until_ms.unwrap_or(0),
+            reason: optional_into_raw(s.reason),
+        })
+        .collect();
+    let count = entries.len();
+    let boxed = entries.into_boxed_slice();
+    *out_entries = Box::into_raw(boxed) as *const _;
+    *out_count = count;
+    PlatformWalletFFIResult::ok()
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn platform_wallet_manager_address_ban_info_free(
+    entries: *mut AddressBanInfoFFI,
+    count: usize,
+) {
+    if entries.is_null() || count == 0 {
+        return;
+    }
+    // Walk every row first to release its heap-owned `address` and
+    // optional `reason` C strings before reclaiming the parent slice.
+    let slice = std::slice::from_raw_parts(entries, count);
+    for entry in slice {
+        if !entry.address.is_null() {
+            let _ = CString::from_raw(entry.address);
+        }
+        if !entry.reason.is_null() {
+            let _ = CString::from_raw(entry.reason);
+        }
+    }
+    let _ = Box::from_raw(std::ptr::slice_from_raw_parts_mut(entries, count));
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/rs-platform-wallet/src/manager/accessors.rs
+++ b/packages/rs-platform-wallet/src/manager/accessors.rs
@@ -201,10 +201,53 @@ pub struct WalletIdentityRowSnapshot {
     pub identity_id: [u8; 32],
 }
 
+/// One row of the DAPI address ban-list snapshot, returned from
+/// [`PlatformWalletManager::address_ban_info_blocking`].
+///
+/// A platform-wallet-owned mirror of the SDK's `AddressBanInfo` with
+/// `banned_until` already projected to a millisecond Unix timestamp so
+/// the FFI layer can marshal it without depending on `chrono`.
+#[derive(Debug, Clone)]
+pub struct AddressBanInfoSnapshot {
+    /// The DAPI node URI.
+    pub uri: String,
+    /// Whether the address is currently effectively banned (banned at
+    /// least once and the ban period has not yet expired).
+    pub banned: bool,
+    /// Total number of times the address has been banned.
+    pub ban_count: usize,
+    /// Unix-epoch millisecond timestamp until which the address is
+    /// banned, or `None` if there is no active ban window.
+    pub banned_until_ms: Option<i64>,
+    /// Human-readable reason for the most recent ban, if recorded.
+    pub reason: Option<String>,
+}
+
 impl<P: PlatformWalletPersistence + 'static> PlatformWalletManager<P> {
     /// The SDK instance.
     pub fn sdk(&self) -> &dash_sdk::Sdk {
         &self.sdk
+    }
+
+    /// Snapshot of every DAPI address' ban state, including the reason
+    /// each address was banned (when recorded).
+    ///
+    /// Delegates to the SDK's `address_ban_info`, projecting the
+    /// `chrono` timestamp into a Unix-epoch millisecond `i64` so the
+    /// FFI layer can marshal it without a `chrono` dependency. This is
+    /// a pure read — no async, no lock contention on the wallet manager.
+    pub fn address_ban_info_blocking(&self) -> Vec<AddressBanInfoSnapshot> {
+        self.sdk
+            .address_ban_info()
+            .into_iter()
+            .map(|info| AddressBanInfoSnapshot {
+                uri: info.uri,
+                banned: info.banned,
+                ban_count: info.ban_count,
+                banned_until_ms: info.banned_until.map(|t| t.timestamp_millis()),
+                reason: info.reason,
+            })
+            .collect()
     }
 
     /// Access the SPV runtime for sync control.

--- a/packages/rs-sdk/src/sdk.rs
+++ b/packages/rs-sdk/src/sdk.rs
@@ -26,6 +26,7 @@ pub use http::Uri;
 #[cfg(feature = "mocks")]
 use rs_dapi_client::mock::MockDapiClient;
 pub use rs_dapi_client::Address;
+pub use rs_dapi_client::AddressBanInfo;
 pub use rs_dapi_client::AddressList;
 pub use rs_dapi_client::RequestSettings;
 use rs_dapi_client::{
@@ -618,6 +619,16 @@ impl Sdk {
             #[cfg(feature = "mocks")]
             SdkInstance::Mock { address_list, .. } => address_list,
         }
+    }
+
+    /// Return an owned snapshot of every DAPI address' ban state,
+    /// including the reason the address was banned (when recorded).
+    ///
+    /// Delegates to [`AddressList::ban_info`]. Useful for diagnostics
+    /// and surfacing ban state up through the platform-wallet FFI to
+    /// the iOS example app.
+    pub fn address_ban_info(&self) -> Vec<AddressBanInfo> {
+        self.address_list().ban_info()
     }
 }
 

--- a/packages/swift-sdk/Sources/SwiftDashSDK/PlatformWallet/PlatformWalletManagerDiagnostics.swift
+++ b/packages/swift-sdk/Sources/SwiftDashSDK/PlatformWallet/PlatformWalletManagerDiagnostics.swift
@@ -510,9 +510,12 @@ extension PlatformWalletManager {
         let res = platform_wallet_manager_address_ban_info(handle, &outEntries, &outCount)
         guard PlatformWalletResult(res).isSuccess, let ptr = outEntries, outCount > 0 else { return [] }
         defer { platform_wallet_manager_address_ban_info_free(UnsafeMutablePointer(mutating: ptr), outCount) }
-        return (0..<Int(outCount)).map { i in
+        return (0..<Int(outCount)).compactMap { i -> AddressBanInfo? in
             let entry = ptr[i]
-            let address: String = entry.address.map { String(cString: $0) } ?? ""
+            // The address is the key identifier; skip any (defensive) NULL
+            // entry rather than surfacing a non-actionable blank row.
+            guard let addressPtr = entry.address else { return nil }
+            let address = String(cString: addressPtr)
             let reason: String? = entry.reason.map { String(cString: $0) }
             let bannedUntil: Date? = entry.banned_until_ms == 0
                 ? nil

--- a/packages/swift-sdk/Sources/SwiftDashSDK/PlatformWallet/PlatformWalletManagerDiagnostics.swift
+++ b/packages/swift-sdk/Sources/SwiftDashSDK/PlatformWallet/PlatformWalletManagerDiagnostics.swift
@@ -482,6 +482,50 @@ extension PlatformWalletManager {
             )
         }
     }
+
+    // MARK: - Phase 8 — DAPI address ban list
+
+    /// One row of the DAPI address ban-list snapshot.
+    public struct AddressBanInfo {
+        /// The DAPI node URI.
+        public let address: String
+        /// Whether the address is currently effectively banned.
+        public let banned: Bool
+        /// Total number of times the address has been banned.
+        public let banCount: Int
+        /// The instant until which the address remains banned, or `nil`
+        /// when there is no active ban window.
+        public let bannedUntil: Date?
+        /// Human-readable reason for the most recent ban, or `nil` when
+        /// none was recorded.
+        public let reason: String?
+    }
+
+    /// Snapshot of every DAPI address' ban state, including the reason
+    /// each address was banned (when recorded).
+    public func addressBanInfo() -> [AddressBanInfo] {
+        guard isConfigured, handle != NULL_HANDLE else { return [] }
+        var outEntries: UnsafePointer<AddressBanInfoFFI>? = nil
+        var outCount: UInt = 0
+        let res = platform_wallet_manager_address_ban_info(handle, &outEntries, &outCount)
+        guard PlatformWalletResult(res).isSuccess, let ptr = outEntries, outCount > 0 else { return [] }
+        defer { platform_wallet_manager_address_ban_info_free(UnsafeMutablePointer(mutating: ptr), outCount) }
+        return (0..<Int(outCount)).map { i in
+            let entry = ptr[i]
+            let address: String = entry.address.map { String(cString: $0) } ?? ""
+            let reason: String? = entry.reason.map { String(cString: $0) }
+            let bannedUntil: Date? = entry.banned_until_ms == 0
+                ? nil
+                : Date(timeIntervalSince1970: Double(entry.banned_until_ms) / 1000.0)
+            return AddressBanInfo(
+                address: address,
+                banned: entry.banned,
+                banCount: Int(entry.ban_count),
+                bannedUntil: bannedUntil,
+                reason: reason
+            )
+        }
+    }
 }
 
 // MARK: - Helpers

--- a/packages/swift-sdk/SwiftExampleApp/SwiftExampleApp/Views/BannedAddressesView.swift
+++ b/packages/swift-sdk/SwiftExampleApp/SwiftExampleApp/Views/BannedAddressesView.swift
@@ -1,0 +1,181 @@
+// BannedAddressesView.swift
+// SwiftExampleApp
+//
+// Read-only diagnostic surface for the DAPI address ban list. Renders
+// the synchronous snapshot returned by
+// `PlatformWalletManager.addressBanInfo()` — the Rust-side DAPI client's
+// per-address ban state, including the reason each address was banned
+// (when recorded).
+//
+// Complements the other Data-section explorers (Storage / Keychain /
+// Wallet Memory). Like those, this view only READS via the existing FFI
+// wrapper and renders; it makes no policy decisions, performs no
+// iteration logic, and writes nothing back.
+
+import SwiftUI
+import SwiftDashSDK
+
+struct BannedAddressesView: View {
+    @EnvironmentObject var walletManager: PlatformWalletManager
+
+    /// Snapshot loaded imperatively from `addressBanInfo()`. The wrapper
+    /// is a synchronous one-shot read (not a SwiftData `@Query`), so the
+    /// view loads it on appear and re-loads on manual refresh rather
+    /// than observing reactively.
+    @State private var entries: [PlatformWalletManager.AddressBanInfo] = []
+    @State private var hasLoaded = false
+
+    /// Stable formatter for the `bannedUntil` instant. Built once so we
+    /// don't allocate a `DateFormatter` per row.
+    private static let dateFormatter: DateFormatter = {
+        let f = DateFormatter()
+        f.dateStyle = .short
+        f.timeStyle = .medium
+        return f
+    }()
+
+    var body: some View {
+        Group {
+            if entries.isEmpty {
+                emptyState
+            } else {
+                List {
+                    Section {
+                        ForEach(Array(entries.enumerated()), id: \.offset) { _, entry in
+                            BanRow(entry: entry, dateFormatter: Self.dateFormatter)
+                        }
+                    } header: {
+                        Text("Addresses (\(entries.count))")
+                    } footer: {
+                        sessionCaption
+                    }
+                }
+            }
+        }
+        .navigationTitle("Banned Addresses")
+        .navigationBarTitleDisplayMode(.inline)
+        .toolbar {
+            ToolbarItem(placement: .navigationBarTrailing) {
+                Button {
+                    load()
+                } label: {
+                    Image(systemName: "arrow.clockwise")
+                }
+                .accessibilityLabel("Refresh")
+            }
+        }
+        .refreshable { load() }
+        .onAppear {
+            // Load once on first appearance; pull-to-refresh and the
+            // toolbar button drive subsequent reloads.
+            guard !hasLoaded else { return }
+            load()
+        }
+    }
+
+    // MARK: - Empty state
+
+    @ViewBuilder
+    private var emptyState: some View {
+        ContentUnavailableView {
+            Label("No Banned Addresses", systemImage: "nosign")
+        } description: {
+            Text(emptyStateMessage)
+        } actions: {
+            Button("Refresh") { load() }
+        }
+    }
+
+    private var emptyStateMessage: String {
+        "This list reflects the current SDK session. An empty list can "
+        + "mean either that no DAPI addresses have been banned, or that "
+        + "the address pool has not yet been seeded."
+    }
+
+    private var sessionCaption: some View {
+        Text(
+            "Reflects the current SDK session. An empty list can mean "
+            + "either no bans or an unseeded address pool."
+        )
+        .font(.caption)
+        .foregroundColor(.secondary)
+    }
+
+    // MARK: - Load
+
+    private func load() {
+        entries = walletManager.addressBanInfo()
+        hasLoaded = true
+    }
+}
+
+// MARK: - Row
+
+private struct BanRow: View {
+    let entry: PlatformWalletManager.AddressBanInfo
+    let dateFormatter: DateFormatter
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            HStack(alignment: .firstTextBaseline, spacing: 8) {
+                Text(entry.address)
+                    .font(.system(.body, design: .monospaced))
+                    .lineLimit(1)
+                    .truncationMode(.middle)
+                    .textSelection(.enabled)
+                Spacer(minLength: 8)
+                BanStatusBadge(banned: entry.banned)
+            }
+
+            KVLine(label: "Ban Count", value: "\(entry.banCount)")
+            KVLine(
+                label: "Banned Until",
+                value: entry.bannedUntil.map { dateFormatter.string(from: $0) } ?? "—"
+            )
+
+            VStack(alignment: .leading, spacing: 2) {
+                Text("Reason")
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+                Text(entry.reason ?? "—")
+                    .font(.callout)
+                    .fixedSize(horizontal: false, vertical: true)
+                    .textSelection(.enabled)
+            }
+        }
+        .padding(.vertical, 2)
+    }
+}
+
+/// A label/value line where the value is monospaced and trailing-aligned.
+private struct KVLine: View {
+    let label: String
+    let value: String
+
+    var body: some View {
+        HStack(alignment: .firstTextBaseline) {
+            Text(label)
+                .font(.caption)
+                .foregroundColor(.secondary)
+            Spacer()
+            Text(value)
+                .font(.system(.caption, design: .monospaced))
+        }
+    }
+}
+
+/// Red "Banned" capsule vs green "Live" capsule, mirroring the badge
+/// style used by `AccountVariantBadge` in the Wallet Memory explorer.
+private struct BanStatusBadge: View {
+    let banned: Bool
+
+    var body: some View {
+        Text(banned ? "Banned" : "Live")
+            .font(.caption2.weight(.semibold))
+            .padding(.horizontal, 6)
+            .padding(.vertical, 1)
+            .background((banned ? Color.red : Color.green).opacity(0.18))
+            .foregroundColor(banned ? .red : .green)
+            .clipShape(Capsule())
+    }
+}

--- a/packages/swift-sdk/SwiftExampleApp/SwiftExampleApp/Views/OptionsView.swift
+++ b/packages/swift-sdk/SwiftExampleApp/SwiftExampleApp/Views/OptionsView.swift
@@ -385,6 +385,10 @@ struct OptionsView: View {
                         Label("Wallet Memory Explorer", systemImage: "memorychip")
                     }
 
+                    NavigationLink(destination: BannedAddressesView()) {
+                        Label("Banned Addresses", systemImage: "nosign")
+                    }
+
                     Button(action: { showingDataManagement = true }) {
                         Label("Manage Local Data", systemImage: "internaldrive")
                     }


### PR DESCRIPTION
## Issue being fixed or feature implemented
When the DAPI client bans an address, it tracked only `ban_count` and `banned_until` — the underlying error (the *reason*) was logged at `tracing::warn!` and then discarded. This surfaced during iOS QA: a shielded operation failed with `Dapi client error: no available addresses to use`, and there was no way for the app to show *why* the nodes were banned. This change records the ban reason and exposes the ban list (with reasons) up through `platform-wallet` and its FFI so clients like the iOS app can read it.

## What was done?
Threaded a ban reason through the stack (additive, non-breaking):

- **rs-dapi-client** (`address_list.rs`): added `AddressStatus.ban_reason: Option<String>`; new `ban_with_reason()` stores it (`ban()` preserved as a `None`-reason shim); `unban()` clears it. Added public `AddressBanInfo { uri, banned, ban_count, banned_until, reason }` and `AddressList::ban_info() -> Vec<AddressBanInfo>` snapshot getter (exported from the crate root). The runtime ban site in `update_address_ban_status` (`dapi_client.rs`) now passes `error.to_string()`.
- **dash-sdk**: `Sdk::address_ban_info()` delegating to `address_list().ban_info()`.
- **platform-wallet**: `PlatformWalletManager::address_ban_info_blocking() -> Vec<AddressBanInfoSnapshot>` from its `Arc<Sdk>` (`banned_until` projected to epoch-ms so the FFI stays chrono-free).
- **platform-wallet-ffi**: `platform_wallet_manager_address_ban_info(...)` + `_free`, struct `AddressBanInfoFFI { address, banned, ban_count, banned_until_ms, reason }`, following the existing `platform_wallet_tracked_asset_locks_list`/`_free` array convention.
- **swift-sdk**: `PlatformWalletManager.addressBanInfo() -> [AddressBanInfo]` — a thin bridge (no logic), per the swift-sdk architecture rules.

## How Has This Been Tested?
- `cargo fmt --all --check` clean.
- `cargo check --all-targets` + `cargo clippy --all-targets` clean on `rs-dapi-client`, `dash-sdk`, `platform-wallet`, `platform-wallet-ffi`.
- `cargo test -p rs-dapi-client` → 94 pass, including 8 new tests (ban stores reason / ban-without-reason is `None` / `unban` clears it at both `AddressStatus` and `AddressList` levels / `ban_info` reflects banned/unbanned/empty).
- FFI header regenerated (host + `aarch64-apple-ios-sim`); unified xcframework assembled; the Swift wrapper matches the regenerated header.

> **Note:** the full iOS *app* build currently fails at `EmitSwiftModule` due to a **pre-existing, unrelated** duplicate `ContestedResourceVoteChoiceFFI` emission in `rs-sdk-ffi.h` (from #3883) — being fixed in a separate change. It does not touch any code in this PR; the Swift wrapper here is a mechanical bridge over the regenerated header.

## Breaking Changes
None. `ban()` keeps its signature; the new `AddressStatus` field is private; all additions are new public items.

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [ ] I have made corresponding changes to the documentation if needed

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Addresses can now be banned with an optional human-readable reason.
  * Added address ban-list inspection APIs that return a snapshot including effective ban status, ban count, optional expiration, and the recorded reason.
  * Exposed the ban-list snapshot through SDK/FFI and Swift for diagnostics.

* **Bug Fixes**
  * When retry-based bans occur, the stored ban reason now includes the underlying error text.

* **Tests**
  * Extended coverage for reason-aware banning, unbanning, and snapshot behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->