### PR TITLE
fix(rs-sdk-ffi): don't export ContestedResourceVoteChoiceFFI to the C header

### DIFF
--- a/packages/rs-sdk-ffi/cbindgen.toml
+++ b/packages/rs-sdk-ffi/cbindgen.toml
@@ -15,7 +15,7 @@ documentation_style = "c99"
 [defines]
 
 [export]
-include = ["dash_sdk_*", "dash_core_*", "dash_unified_sdk_*", "ContestedResourceVoteChoiceFFI"]
+include = ["dash_sdk_*", "dash_core_*", "dash_unified_sdk_*"]
 # Exclude types that come from key-wallet-ffi to avoid duplication
 exclude = ["FFIAccountType", "FFIAccountTypePreference", "FFIAccountTypeUsed", "FFIAccountCreationOptionType"]
 prefix = ""

--- a/packages/rs-sdk-ffi/src/contested_resource/transitions/cast_vote.rs
+++ b/packages/rs-sdk-ffi/src/contested_resource/transitions/cast_vote.rs
@@ -58,10 +58,12 @@ use zeroize::Zeroizing;
 /// `0` = TowardsIdentity (requires `contender_identity_id`), `1` = Abstain,
 /// `2` = Lock.
 ///
-/// This `#[repr(u8)]` enum exists so cbindgen emits the discriminant values
-/// into the generated C header (a bare `pub const u8` is not exported),
-/// giving Swift a single source of truth instead of hand-mirroring `0/1/2`.
-/// It is force-emitted via the `[export] include` list in `cbindgen.toml`.
+/// This `#[repr(u8)]` enum is the Rust-internal single source of truth for the
+/// `vote_choice` discriminants used by [`cast_vote_inner`] (its `as u8`
+/// discriminants drive the value validation / comparison). It is intentionally
+/// **not** exported to the generated C header: the FFI parameter is a plain
+/// `u8`, and the Swift side mirrors the discriminants in
+/// `packages/swift-sdk/Sources/SwiftDashSDK/PlatformWallet/ContestVoteState.swift`.
 ///
 /// The `vote_choice` FFI parameter is deliberately a plain `u8`, **not** this
 /// enum: a C/Swift caller can pass any byte, and materializing an

--- a/packages/swift-sdk/Sources/SwiftDashSDK/PlatformWallet/ContestVoteState.swift
+++ b/packages/swift-sdk/Sources/SwiftDashSDK/PlatformWallet/ContestVoteState.swift
@@ -63,19 +63,17 @@ public enum ContestedResourceVoteChoice: Sendable, Equatable {
     /// Lock — vote that nobody should win the contested resource.
     case lock
 
-    /// The `vote_choice` value passed across the FFI, typed as the
-    /// cbindgen-generated `ContestedResourceVoteChoiceFFI` rather than a bare
-    /// `UInt8`. `rs-sdk-ffi` emits that `#[repr(u8)]` enum into the C header
-    /// (a u8 typedef) as the single source of truth for the discriminants, so
-    /// binding the bridge to the generated symbol keeps Swift from drifting
-    /// from the Rust values. The FFI function takes a `u8`, which this maps
-    /// to cleanly. The raw values mirror the Rust variants:
+    /// The `vote_choice` discriminant byte passed across the FFI. The
+    /// `dash_sdk_contested_resource_cast_vote` parameter is a plain `u8`, so
+    /// this is a `UInt8`. The values must agree with the
+    /// `ContestedResourceVoteChoiceFFI` enum in
+    /// `packages/rs-sdk-ffi/src/contested_resource/transitions/cast_vote.rs`:
     /// `TowardsIdentity = 0`, `Abstain = 1`, `Lock = 2`.
-    var ffiTag: ContestedResourceVoteChoiceFFI {
+    var ffiTag: UInt8 {
         switch self {
-        case .towardsIdentity: return ContestedResourceVoteChoiceFFI(0)
-        case .abstain: return ContestedResourceVoteChoiceFFI(1)
-        case .lock: return ContestedResourceVoteChoiceFFI(2)
+        case .towardsIdentity: return 0
+        case .abstain: return 1
+        case .lock: return 2
         }
     }
 }


### PR DESCRIPTION
## Issue being fixed or feature implemented

Rebuilding the iOS xcframework from this branch (`packages/swift-sdk/build_ios.sh --target sim`) produced an `rs-sdk-ffi.h` in which cbindgen emitted `ContestedResourceVoteChoiceFFI` **twice**: once as `enum ContestedResourceVoteChoiceFFI { ... }` and once as `typedef uint8_t ContestedResourceVoteChoiceFFI;` (under `#ifndef __cplusplus`, an artifact of `cpp_compat = true`). When the Swift SDK imports the header the name is ambiguous, so [`ContestVoteState.swift`](https://github.com/dashpay/platform/blob/claude/friendly-swirles-b9eb8e/packages/swift-sdk/Sources/SwiftDashSDK/PlatformWallet/ContestVoteState.swift)'s `var ffiTag: ContestedResourceVoteChoiceFFI` fails to compile:

```
error: 'ContestedResourceVoteChoiceFFI' is ambiguous for type lookup in this context
```

This blocks **both** the `SwiftDashSDK` target and any `SwiftExampleApp` build from this branch.

It was introduced by #3883 (`feat(rs-sdk-ffi): add masternode contested-resource vote broadcast`), which force-exported the enum to the header via cbindgen's `[export] include` list. It stayed latent because the committed xcframework predated #3883 and hadn't been rebuilt.

The enum is **not used in any FFI signature** — `dash_sdk_contested_resource_cast_vote` takes a plain `u8` (`vote_choice`) — and the Swift side already hardcoded `0/1/2`, so the intended "single source of truth in the header" never actually paid off while it broke the build.

## What was done?

Removed the header export and aligned the Swift bridge with the existing `TokenConfigChange.ffiTag` precedent (a sibling enum that maps to a plain `u8` FFI param the same way):

- **`packages/rs-sdk-ffi/cbindgen.toml`** — dropped `"ContestedResourceVoteChoiceFFI"` from `[export] include`. It was only emitted because it was force-listed there; nothing references it in a signature, so cbindgen now emits neither the enum nor the typedef. The enum stays in Rust as the internal source of truth, still used by `cast_vote_inner` (`... as u8`).
- **`packages/swift-sdk/.../ContestVoteState.swift`** — changed `ffiTag` from `ContestedResourceVoteChoiceFFI` to a plain `UInt8` (returning `0/1/2`), matching `TokenConfigChange.ffiTag`. Transparent at the call site, which feeds the value straight into the `u8` FFI param.
- Updated the now-stale doc comments in both `cast_vote.rs` and `ContestVoteState.swift`.

## How Has This Been Tested?

- `cargo fmt --all` — no changes.
- `cargo check -p rs-sdk-ffi` — clean, no warnings (the enum is still referenced internally, so it is not flagged unused).
- `cd packages/swift-sdk && ./build_ios.sh --target sim` — **`** BUILD SUCCEEDED **`** (compiles Swift with `-warnings-as-errors`).
- Verified the regenerated `rs-sdk-ffi.h` no longer contains the `enum` declaration or the `typedef uint8_t` for `ContestedResourceVoteChoiceFFI` (only a prose doc-comment mention remains, which cannot cause type-lookup ambiguity).

## Breaking Changes

None in the consensus sense. This removes a brand-new (#3883, unreleased) symbol from the generated C header that was never usable from Swift anyway and is not part of any FFI function signature.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [x] I have made corresponding changes to the documentation if needed

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone
