### PR TITLE
fix(platform-wallet): add TRANSFER key to default identity registration key set

### DIFF
--- a/packages/rs-platform-wallet-ffi/src/identity_derive_and_persist.rs
+++ b/packages/rs-platform-wallet-ffi/src/identity_derive_and_persist.rs
@@ -47,7 +47,9 @@
 //! |--------|-----------------|----------------|----------------|
 //! | 0      | ECDSA_SECP256K1 | AUTHENTICATION | MASTER         |
 //! | 1      | ECDSA_SECP256K1 | AUTHENTICATION | CRITICAL       |
-//! | > 1    | ECDSA_SECP256K1 | AUTHENTICATION | HIGH           |
+//! | 2      | ECDSA_SECP256K1 | AUTHENTICATION | HIGH           |
+//! | 3      | ECDSA_SECP256K1 | TRANSFER       | CRITICAL       |
+//! | > 3    | ECDSA_SECP256K1 | AUTHENTICATION | HIGH           |
 //!
 //! Mirrors rs-dpp's canonical
 //! `main_keys_with_random_authentication_keys_*` layout (MASTER →
@@ -56,6 +58,19 @@
 //! `combined_security_level_requirement` collapses any batch
 //! containing a token transition to `[CRITICAL]` only, so without
 //! a CRITICAL key the identity cannot mint / burn / freeze tokens.
+//!
+//! Key id 3 is a `TRANSFER`/`CRITICAL` key. Dash Platform requires a
+//! `purpose=TRANSFER`, `security_level=CRITICAL`, ECDSA_SECP256K1 key
+//! to sign `IdentityCreditTransfer` (ID-04) and
+//! `IdentityCreditWithdrawal` (ID-10) state transitions; without it
+//! those broadcasts are rejected on-chain with
+//! `Protocol error: missing key: no transfer public key`. So the
+//! canonical default set provisions one. Slots 0/1/2 keep their
+//! pre-existing `(purpose, security_level)` bytes byte-for-byte, so a
+//! caller that still requests `key_count == 3` is completely
+//! unchanged. `TRANSFER` keys take no contract bounds (only
+//! ENCRYPTION/DECRYPTION require them), and this function never sets
+//! bounds anyway.
 //!
 //! If DPP renumbers any of those enum discriminants, this file is
 //! the single place that needs updating — the Swift caller just
@@ -100,6 +115,10 @@ use rs_sdk_ffi::{
 const KEY_TYPE_ECDSA_SECP256K1: u8 = 0;
 /// DPP `Purpose::AUTHENTICATION` discriminant byte.
 const PURPOSE_AUTHENTICATION: u8 = 0;
+/// DPP `Purpose::TRANSFER` discriminant byte. Required (with
+/// `SECURITY_LEVEL_CRITICAL`) to sign `IdentityCreditTransfer` /
+/// `IdentityCreditWithdrawal` state transitions.
+const PURPOSE_TRANSFER: u8 = 3;
 /// DPP `SecurityLevel::MASTER` discriminant byte.
 const SECURITY_LEVEL_MASTER: u8 = 0;
 /// DPP `SecurityLevel::CRITICAL` discriminant byte.
@@ -314,19 +333,30 @@ pub unsafe extern "C" fn dash_sdk_derive_and_persist_identity_keys(
             }
         };
 
-        // Per-key DPP metadata. Canonical 3-key identity layout per
-        // rs-dpp's `main_keys_with_random_authentication_keys_*`:
-        // MASTER at key_id 0 (signs IdentityUpdate / IdentityCreate),
-        // CRITICAL at key_id 1 (signs token state transitions —
-        // `combined_security_level_requirement` collapses any batch
-        // containing a token transition to `[CRITICAL]`), HIGH for
-        // any further keys (general document operations). Without
-        // a CRITICAL key the identity literally cannot sign token
-        // mints / burns / freezes.
-        let security_level = match key_index {
-            0 => SECURITY_LEVEL_MASTER,
-            1 => SECURITY_LEVEL_CRITICAL,
-            _ => SECURITY_LEVEL_HIGH,
+        // Per-key DPP metadata. Canonical default identity layout,
+        // extending rs-dpp's `main_keys_with_random_authentication_keys_*`
+        // (MASTER → CRITICAL → HIGH) with a dedicated TRANSFER key:
+        //   0 → AUTHENTICATION / MASTER   (signs IdentityUpdate / IdentityCreate)
+        //   1 → AUTHENTICATION / CRITICAL (signs token state transitions —
+        //       `combined_security_level_requirement` collapses any batch
+        //       containing a token transition to `[CRITICAL]`; without a
+        //       CRITICAL key the identity cannot mint / burn / freeze tokens)
+        //   2 → AUTHENTICATION / HIGH     (general document operations)
+        //   3 → TRANSFER / CRITICAL       (signs IdentityCreditTransfer /
+        //       IdentityCreditWithdrawal; without it those broadcasts fail
+        //       on-chain with "no transfer public key")
+        //   > 3 → AUTHENTICATION / HIGH   (any further keys)
+        //
+        // Slots 0/1/2 keep their pre-existing (purpose, security_level)
+        // bytes byte-for-byte, so a caller still passing key_count == 3
+        // is unchanged. TRANSFER keys take no contract bounds, and this
+        // function never sets bounds for any key.
+        let (purpose, security_level) = match key_index {
+            0 => (PURPOSE_AUTHENTICATION, SECURITY_LEVEL_MASTER),
+            1 => (PURPOSE_AUTHENTICATION, SECURITY_LEVEL_CRITICAL),
+            2 => (PURPOSE_AUTHENTICATION, SECURITY_LEVEL_HIGH),
+            3 => (PURPOSE_TRANSFER, SECURITY_LEVEL_CRITICAL),
+            _ => (PURPOSE_AUTHENTICATION, SECURITY_LEVEL_HIGH),
         };
         let args = PersistKeyArgs {
             wallet_id_bytes,
@@ -339,7 +369,7 @@ pub unsafe extern "C" fn dash_sdk_derive_and_persist_identity_keys(
             public_key_hash_bytes: pub_hash.as_ptr(),
             private_key_bytes: priv_scalar.as_ptr(),
             key_type: KEY_TYPE_ECDSA_SECP256K1,
-            purpose: PURPOSE_AUTHENTICATION,
+            purpose,
             security_level,
         };
         let persist_rc =
@@ -604,6 +634,68 @@ mod tests {
             dash_sdk_mnemonic_resolver_destroy(resolver);
             dash_sdk_identity_key_persister_destroy(persister);
             // Reclaim the per-test capture box.
+            let _ = Box::from_raw(capture);
+        }
+    }
+
+    #[test]
+    fn key_count_four_includes_transfer_critical_key() {
+        let (resolver, persister, capture) = make_capturing_handles();
+        let wallet_id = [42u8; 32];
+        let mut out = IdentityRegistrationKeyDerivationsFFI {
+            items: std::ptr::null_mut(),
+            count: 0,
+        };
+        let rc = unsafe {
+            dash_sdk_derive_and_persist_identity_keys(
+                FFINetwork::Testnet,
+                wallet_id.as_ptr(),
+                7, // identity_index
+                4, // key_count — now provisions the TRANSFER key at id 3
+                resolver,
+                persister,
+                &mut out,
+            )
+        };
+        assert_eq!(rc.code, PlatformWalletFFIResultCode::Success);
+        assert_eq!(out.count, 4);
+
+        let captured = unsafe { (*capture).rows.lock().unwrap().clone() };
+        assert_eq!(captured.len(), 4);
+
+        // Slots 0/1/2 are unchanged from the legacy 3-key layout:
+        // AUTHENTICATION with MASTER / CRITICAL / HIGH respectively.
+        for (i, expected_level) in [
+            SECURITY_LEVEL_MASTER,
+            SECURITY_LEVEL_CRITICAL,
+            SECURITY_LEVEL_HIGH,
+        ]
+        .iter()
+        .enumerate()
+        {
+            assert_eq!(captured[i].key_type, KEY_TYPE_ECDSA_SECP256K1);
+            assert_eq!(captured[i].purpose, PURPOSE_AUTHENTICATION);
+            assert_eq!(captured[i].security_level, *expected_level);
+        }
+
+        // Slot 3 is the new TRANSFER / CRITICAL key required to sign
+        // IdentityCreditTransfer (ID-04) / IdentityCreditWithdrawal
+        // (ID-10) — without it those broadcasts fail on-chain with
+        // "no transfer public key".
+        let transfer = &captured[3];
+        assert_eq!(transfer.key_id, 3);
+        assert_eq!(transfer.key_index, 3);
+        assert_eq!(transfer.key_type, KEY_TYPE_ECDSA_SECP256K1);
+        assert_eq!(transfer.purpose, PURPOSE_TRANSFER);
+        assert_eq!(transfer.security_level, SECURITY_LEVEL_CRITICAL);
+        assert_eq!(transfer.public_key.len(), 33);
+        assert_eq!(transfer.private_key.len(), 32);
+        assert_eq!(transfer.path, "m/9'/1'/5'/0'/0'/7'/3'");
+
+        unsafe {
+            crate::dash_sdk_derive_identity_keys_from_mnemonic_free(&mut out);
+            dash_sdk_mnemonic_resolver_destroy(resolver);
+            dash_sdk_identity_key_persister_destroy(persister);
             let _ = Box::from_raw(capture);
         }
     }

--- a/packages/swift-sdk/SwiftExampleApp/SwiftExampleApp/Views/CreateIdentityView.swift
+++ b/packages/swift-sdk/SwiftExampleApp/SwiftExampleApp/Views/CreateIdentityView.swift
@@ -58,11 +58,16 @@ struct CreateIdentityView: View {
     /// offered when its `boundWalletId` matches the selected wallet.
     @EnvironmentObject var shieldedService: ShieldedService
 
-    /// Default number of Platform identity authentication keys to
-    /// register in this first-pass flow. First key is MASTER, the
-    /// rest are HIGH. Advanced override is intentionally not exposed
-    /// here yet.
-    private static let defaultKeyCount: UInt32 = 3
+    /// Default number of Platform identity keys to register in this
+    /// first-pass flow. The Rust-owned per-slot policy
+    /// (`dash_sdk_derive_and_persist_identity_keys`) maps these to:
+    /// key 0 AUTHENTICATION/MASTER, key 1 AUTHENTICATION/CRITICAL,
+    /// key 2 AUTHENTICATION/HIGH, key 3 TRANSFER/CRITICAL. The
+    /// TRANSFER/CRITICAL key is required to sign IdentityCreditTransfer
+    /// (ID-04) and IdentityCreditWithdrawal (ID-10) — without it those
+    /// broadcasts are rejected on-chain with "no transfer public key".
+    /// Advanced override is intentionally not exposed here yet.
+    private static let defaultKeyCount: UInt32 = 4
 
     /// Number of extra keys added when `addDashPayKeys` is on
     /// (encryption + decryption).
@@ -124,8 +129,8 @@ struct CreateIdentityView: View {
     /// in `rs-platform-version`:
     ///   identity_create_base_cost (2_000_000 credits)
     ///   + asset_lock_base (200_000 duffs * 1000 credits/duff = 200_000_000)
-    ///   + identity_key_in_creation_cost (6_500_000) * defaultKeyCount (3)
-    ///   = 221_500_000 credits / 1000 = 221_500 duffs (0.002215 DASH).
+    ///   + identity_key_in_creation_cost (6_500_000) * defaultKeyCount (4)
+    ///   = 228_000_000 credits / 1000 = 228_000 duffs (0.002280 DASH).
     /// The v0 floor was 200_000 duffs but with key_in_creation_cost
     /// dynamic at v1, the per-key surcharge has to be added. Submitting
     /// below this gets rejected by Platform with
@@ -133,7 +138,7 @@ struct CreateIdentityView: View {
     /// `minFundingDuffs(forKeyCount:)` for the active per-flow value
     /// when extra keys (e.g. the DashPay encryption/decryption pair)
     /// bump the per-key surcharge.
-    private static let minIdentityFundingDuffsForDefaultKeys: UInt64 = 221_500
+    private static let minIdentityFundingDuffsForDefaultKeys: UInt64 = 228_000
 
     /// Recompute the minimum-funding floor for `keyCount` total
     /// identity keys. Formula above; result is in duffs (credits ÷ 1000).


### PR DESCRIPTION
## Issue being fixed or feature implemented

Identities created on-device by SwiftExampleApp were provisioned with only AUTHENTICATION keys (MASTER/CRITICAL/HIGH) plus the optional DashPay ENCRYPTION/DECRYPTION pair — but **no key with `purpose=TRANSFER` (purpose 3)**. Dash Platform requires a `purpose=TRANSFER`, `security_level=CRITICAL` key to sign `IdentityCreditTransfer` (ID-04) and `IdentityCreditWithdrawal` (ID-10) state transitions, so those broadcasts failed on-chain with `Protocol error: missing key: no transfer public key`. This blocked the Essential-tier ID-04 / ID-10 flows for every app-created identity, regardless of the (correct) Transfer Credits UI added in #3891.

## What was done?

The registration key-set policy is owned by Rust (per `packages/swift-sdk/CLAUDE.md`), in `dash_sdk_derive_and_persist_identity_keys`. The fix extends the per-slot policy table so the default registration set includes a TRANSFER key:

| keyId | key_type | purpose | security_level |
|-------|----------|---------|----------------|
| 0 | ECDSA_SECP256K1 | AUTHENTICATION | MASTER |
| 1 | ECDSA_SECP256K1 | AUTHENTICATION | CRITICAL |
| 2 | ECDSA_SECP256K1 | AUTHENTICATION | HIGH |
| **3** | **ECDSA_SECP256K1** | **TRANSFER** | **CRITICAL** |

- `packages/rs-platform-wallet-ffi/src/identity_derive_and_persist.rs`: add `PURPOSE_TRANSFER`; change the per-slot `match` to emit `(purpose, security_level)` instead of only `security_level`; slots 0/1/2 keep their previous bytes byte-for-byte (so any caller still passing `key_count = 3` is unchanged). TRANSFER keys carry no contract bounds (only ENC/DEC require them). Docs/table updated and a new unit test `key_count_four_includes_transfer_critical_key` added.
- `packages/swift-sdk/SwiftExampleApp/.../CreateIdentityView.swift`: bump `defaultKeyCount` 3 → 4 and the asset-lock funding floor `minIdentityFundingDuffsForDefaultKeys` 221_500 → 228_000 duffs. The optional DashPay enc/dec pair auto-shifts to keyId 4/5 via the symbolic `firstKeyId: Self.defaultKeyCount` (no Swift-side policy added).

## How Has This Been Tested?

- `cargo fmt --all`; `cargo test -p platform-wallet-ffi` (incl. the new test) and `cargo check -p platform-wallet-ffi --all-targets`/`--all-features --tests` pass. The pre-existing `key_count == 3` test is unchanged and still passes (slots 0/1/2 untouched).
- Built the unified iOS xcframework + SwiftExampleApp and ran on a booted testnet simulator. Created a fresh identity (index 3) via the new build; SwiftData ground-truth shows its keys `(keyId,purpose,secLvl)` = `(0,0,0)(1,0,1)(2,0,2)`**`(3,3,1)`**`(4,1,3)(5,2,3)` — the purpose-3 / CRITICAL / ECDSA TRANSFER key is present at keyId 3, with the DashPay enc/dec pair correctly at keyId 4/5. The three pre-existing identities have no purpose-3 key.
- Drove the Transfer Credits flow with the new identity as sender: the transition now **signs with the transfer key** and proceeds past the old `no transfer public key` rejection (build → sign → broadcast → proof verification). The original bug is fixed.

> Note: completing the transfer end-to-end in the app is currently blocked by a **separate, pre-existing** issue — the post-broadcast proof verification (`drive::verify::state_transition::verify_state_transition_was_executed_with_proof`) overflows the (small) client dispatch-worker stack in the debug build (the known latent recursive `Value::Decode`). That crash is unrelated to key derivation; this change merely unblocks reaching it. Tracked separately.

## Breaking Changes

None. This changes the default key set for newly created identities (SDK/example-app behavior); it is not consensus-breaking and does not alter any existing on-chain data. Pre-release, so no migration concerns.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [ ] I have made corresponding changes to the documentation if needed

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone