### PR TITLE
docs(swift-example-app): add MANUAL tier to iOS test plan

### DIFF
--- a/packages/swift-sdk/SwiftExampleApp/TEST_PLAN.md
+++ b/packages/swift-sdk/SwiftExampleApp/TEST_PLAN.md
@@ -14,12 +14,12 @@ Every catalog row carries four orthogonal, machine-filterable fields. Select tes
 
 **Selection grammar** — canonical tokens (case-insensitive):
 
-- **Tier** ∈ `Essential` · `Common` · `Thorough` · `Uncommon`
+- **Tier** ∈ `Essential` · `Common` · `Thorough` · `Uncommon` · `Manual`
 - **Layer** ∈ `Core` · `Platform` · `Cross` · `Shielded`
-- **Status** ∈ `✅` · `🧪` · `🔌` · `⚠️` · `🚫`
+- **Status** ∈ `✅` · `🧪` · `⚠️` · `🔌` · `🚫`
 - **Category** ∈ `Core` · `Identity` · `Address` · `DPNS` · `Voting` · `Contract` · `Document` · `Token` · `Shielded` · `DashPay` · `Group` · `System` · `MultiWallet` (the feature area; shown as `Domain=…` on each §4 section header — "Category" and "Domain" are the same axis)
 
-A test is **runnable now** only if Status is `✅`, `🧪`, or `⚠️` (reachable in the app). `🔌`/`🚫` rows are listed for completeness — skip them unless asked to confirm absence.
+A test is **automatable now** only if Status is `✅`, `🧪`, or `⚠️` (reachable and drivable in the simulator) **and** `Tier ≠ Manual`. `Tier=Manual` marks implemented features that need a human on a physical device (e.g. a camera) — the automated QA agent must **skip and flag them for manual testing**, never mark them failed. `🔌`/`🚫` rows are listed for completeness — skip them unless asked to confirm absence.
 
 A row's **primary** category is the §4 section it lives in. Some tests are **cross-cutting** — e.g. `MW-02` (token transfer between two wallets) lives in the MultiWallet section but is also a **Token** test, and `CORE-21` is also **Shielded**. Resolve any `Category=…` selection through **§6 Category index**, which lists every member ID per category (primary + cross-cutting), so "run all Token tests" catches `MW-02` and `GRP-03` too. This is the axis behind requests like *"run all non-Uncommon Token tests."*
 
@@ -28,7 +28,8 @@ A row's **primary** category is the §4 section it lives in. Some tests are **cr
 | Request | Filter | Resolves to |
 |---|---|---|
 | "test Essential, Platform-only" | `Tier=Essential AND Layer=Platform` | `ID-02, ID-03, ID-04, DPNS-01, DPNS-02, DPNS-03, DPNS-04` |
-| "test all Essential" | `Tier=Essential` | the core experience: `CORE-01..08`, `ID-01/02/03/04`, `DPNS-01/02/03/04`, `SH-01..06` |
+| "test all Essential" | `Tier=Essential` | the core experience: `CORE-01..07`, `ID-01/02/03/04`, `DPNS-01/02/03/04`, `SH-01..06` |
+| "list the manual tests" | `Tier=Manual` | `CORE-08` (skip in automation; run on a physical device) |
 | "smoke test the wallet" | `Category=Core AND Status=✅` | `CORE-01..CORE-09` |
 | "test all non-Uncommon Token tests" | `Category=Token AND Tier≠Uncommon` | `TOK-01..07`, `MW-02` (via §6 index) |
 | "exercise every token admin action" | `Category=Token AND Tier=Uncommon` | `TOK-08..TOK-16` |
@@ -74,6 +75,7 @@ Most Platform actions have hard preconditions. Establish these fixtures before s
 | **Common** | Frequent actions beyond the core experience — identity top-ups, contested usernames, identity key management, platform-address credit ops, contracts, token transfer/view, DashPay, secondary shielded flows (asset-lock shield, withdraw, prover warm-up). |
 | **Thorough** | Occasional, or tied to a specialized role (contract author, voter, contact-graph user, multi-wallet power user) — voting, contract update, document edit/delete, mint/burn/claim, group reads, multi-wallet management. |
 | **Uncommon** | Rare / exotic / administrative edge cases (most token governance, marketplace, emergency, group, raw-protocol). |
+| **Manual** | Not a frequency — a special bucket for implemented features that **can't be driven in the simulator** and need a human on a physical device (e.g. camera, biometrics, NFC). The automated agent **skips and flags** these for a person; it never fails them. Select with `Tier=Manual`. |
 
 **Layers** (for the "X-only" filter):
 
@@ -111,7 +113,7 @@ Most Platform actions have hard preconditions. Establish these fixtures before s
 | CORE-05 | Send Core L1 transaction | Core | Essential | ✅ | Send flow (`SendTransactionView`, mode Core→Core) → `core_wallet_send_to_addresses`. Tx broadcasts; balance drops; appears in history. *Anchor: the canonical Essential action.* |
 | CORE-06 | View balance / tx history / UTXOs | Core | Essential | ✅ | `WalletDetailView`, `TransactionListView`, `AccountDetailView` (SwiftData). |
 | CORE-07 | SPV sync (start / stop / progress) | Core | Essential | ✅ | Global sync indicator (`ContentView`) → `platform_wallet_manager_spv_*`. Headers/filters/masternodes advance to tip. |
-| CORE-08 | QR scan recipient | Core | Essential | ✅ | `QRScannerView`. Scanned address fills the send field. |
+| CORE-08 | QR scan recipient | Core | Manual | ✅ | `QRScannerView`, reachable in the Send flow — but scanning needs a real camera the simulator doesn't have, so it can't be automated (`Tier=Manual`). On a device: Send → QR-scan button → point at a Dash address QR → recipient field populates. |
 | CORE-09 | Multiple HD accounts (within one wallet) | Core | Common | ✅ | Account selection / `AccountDetailView`; balances per `account_index`. Distinct from holding multiple *wallets* — see CORE-14+. |
 | CORE-10 | Multi-recipient Core send | Core | Common | 🔌 | FFI `core_wallet_send_to_addresses` takes parallel address/amount arrays; UI is single-recipient — verify before claiming. |
 | CORE-11 | Custom fee on transparent send | Core | Uncommon | 🚫 | Not exposed on the transparent send path (custom Core fee only on shielded withdraw `SH-08` and platform-address funding). |
@@ -310,22 +312,23 @@ Together with the wallet-lifecycle rows in §4.1 (`CORE-14..23`), these form the
 
 ## 5. Summary matrix
 
-Counts are of **runnable** rows (`✅`/`🧪`/`⚠️`); `🔌`/`🚫`/stub rows are excluded. Each catalog row carries its own `Tier` + `Layer`, so any intersection (e.g. *Essential ∩ Platform*) is derivable directly from §4.
+Counts are of rows reachable in the app (Status `✅`/`🧪`/`⚠️`); `🔌`/`🚫`/stub rows are excluded. `Tier=Manual` rows are reachable but **not automatable** (need a physical device) — counted on their own row below, excluded from the by-layer automatable totals. Each catalog row carries its own `Tier` + `Layer`, so any intersection (e.g. *Essential ∩ Platform*) is derivable directly from §4.
 
-**By tier (runnable):**
+**By tier:**
 
-| Tier | Count (approx.) |
-|---|---|
-| Essential | 22 |
-| Common | 31 |
-| Thorough | 35 |
-| Uncommon | 25 |
+| Tier | Count (approx.) | Automatable? |
+|---|---|---|
+| Essential | 21 | yes |
+| Common | 31 | yes |
+| Thorough | 35 | yes |
+| Uncommon | 25 | yes |
+| Manual | 1 (`CORE-08`) | no — physical device |
 
-**By layer (runnable):**
+**By layer (automatable only):**
 
 | Layer | Count (approx.) |
 |---|---|
-| Core | 18 |
+| Core | 17 |
 | Platform | ~72 |
 | Cross | 7 |
 | Shielded | 16 |


### PR DESCRIPTION
## Issue being fixed or feature implemented
`CORE-08` (QR scan recipient) is implemented and reachable in the app UI, but it **cannot be exercised in the iOS simulator** (no camera). It was previously tiered **Essential** and counted as an automatable pass/fail, which is misleading — an automated QA run can neither drive it nor should it fail it. "Can't be automated" is a *selection* concern, so it belongs on the **Tier** axis.

## What was done?
Added **`Manual`** as a **Tier** value (peer of Essential / Common / Thorough / Uncommon) in `packages/swift-sdk/SwiftExampleApp/TEST_PLAN.md`:
- **Tier grammar + legend**: `Manual` = not a frequency, a special bucket for implemented features that can't be driven in the simulator and need a human on a physical device (camera, biometrics, NFC). The automated agent **skips and flags** them, never fails them. Select with `Tier=Manual`.
- The automatable-now rule now requires `Tier ≠ Manual` (in addition to Status `✅`/`🧪`/`⚠️`).
- **`CORE-08` set to `Tier=Manual`** (Status stays `✅` — the scanner *is* in the UI), staying in its §4.1 Core home.
- **Summary matrix**: Essential 22→**21**, Core layer 18→**17**, and a `Manual` tier row (`1 — CORE-08`, marked not-automatable).
- Added a "list the manual tests" worked example (`Tier=Manual` → `CORE-08`).

No new status symbol and no separate section — `Manual` is just another tier, so it filters and reports like the others.

## How Has This Been Tested?
Documentation only. Verified `CORE-08` is a single `Tier=Manual` row in §4.1, `Manual` appears in the tier grammar/legend/matrix, the automatable counts exclude it, and no stray status symbol or orphan section remains.

## Breaking Changes
None. Documentation only.

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [x] I have made corresponding changes to the documentation if needed

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the iOS test plan to introduce a new **Tier=Manual** category.
  * Clarified how “automatable” tests are determined, and that **manual-only** coverage requires a physical device.
  * Updated the legend and worked examples, including adjusting the **CORE-08** QR scan recipient scenario to **manual** testing.
  * Recalculated summary counts to reflect the new manual classification and updated automation/skip behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->