### PR TITLE
fix(rs-sdk-ffi): run blocking FFI calls on a large stack to prevent proof-verification stack overflow

### DIFF
--- a/packages/rs-sdk-ffi/src/contested_resource/queries/identity_votes.rs
+++ b/packages/rs-sdk-ffi/src/contested_resource/queries/identity_votes.rs
@@ -92,7 +92,7 @@ fn get_contested_resource_identity_votes(
         return Err("Identity ID is null".to_string());
     }
 
-    let rt = tokio::runtime::Runtime::new()
+    let rt = crate::runtime::BigStackRuntime::new_isolated()
         .map_err(|e| format!("Failed to create Tokio runtime: {}", e))?;
 
     let identity_id_str = unsafe {

--- a/packages/rs-sdk-ffi/src/contested_resource/queries/resources.rs
+++ b/packages/rs-sdk-ffi/src/contested_resource/queries/resources.rs
@@ -118,7 +118,7 @@ fn get_contested_resources(
         return Err("Index name is null".to_string());
     }
 
-    let rt = tokio::runtime::Runtime::new()
+    let rt = crate::runtime::BigStackRuntime::new_isolated()
         .map_err(|e| format!("Failed to create Tokio runtime: {}", e))?;
 
     let contract_id_str = unsafe {

--- a/packages/rs-sdk-ffi/src/contested_resource/queries/vote_state.rs
+++ b/packages/rs-sdk-ffi/src/contested_resource/queries/vote_state.rs
@@ -123,7 +123,7 @@ fn get_contested_resource_vote_state(
         return Err("Index values JSON is null".to_string());
     }
 
-    let rt = tokio::runtime::Runtime::new()
+    let rt = crate::runtime::BigStackRuntime::new_isolated()
         .map_err(|e| format!("Failed to create Tokio runtime: {}", e))?;
 
     let contract_id_str = unsafe {

--- a/packages/rs-sdk-ffi/src/contested_resource/queries/voters_for_identity.rs
+++ b/packages/rs-sdk-ffi/src/contested_resource/queries/voters_for_identity.rs
@@ -125,7 +125,7 @@ fn get_contested_resource_voters_for_identity(
         return Err("Contestant ID is null".to_string());
     }
 
-    let rt = tokio::runtime::Runtime::new()
+    let rt = crate::runtime::BigStackRuntime::new_isolated()
         .map_err(|e| format!("Failed to create Tokio runtime: {}", e))?;
 
     let contract_id_str = unsafe {

--- a/packages/rs-sdk-ffi/src/evonode/queries/proposed_epoch_blocks_by_ids.rs
+++ b/packages/rs-sdk-ffi/src/evonode/queries/proposed_epoch_blocks_by_ids.rs
@@ -76,7 +76,7 @@ fn get_evonodes_proposed_epoch_blocks_by_ids(
         return Err("IDs JSON is null".to_string());
     }
 
-    let rt = tokio::runtime::Runtime::new()
+    let rt = crate::runtime::BigStackRuntime::new_isolated()
         .map_err(|e| format!("Failed to create Tokio runtime: {}", e))?;
 
     let ids_str = unsafe {

--- a/packages/rs-sdk-ffi/src/evonode/queries/proposed_epoch_blocks_by_range.rs
+++ b/packages/rs-sdk-ffi/src/evonode/queries/proposed_epoch_blocks_by_range.rs
@@ -85,7 +85,7 @@ fn get_evonodes_proposed_epoch_blocks_by_range(
         return Err("SDK handle is null".to_string());
     }
 
-    let rt = tokio::runtime::Runtime::new()
+    let rt = crate::runtime::BigStackRuntime::new_isolated()
         .map_err(|e| format!("Failed to create Tokio runtime: {}", e))?;
 
     let wrapper = unsafe { &*(sdk_handle as *const crate::sdk::SDKWrapper) };

--- a/packages/rs-sdk-ffi/src/group/queries/action_signers.rs
+++ b/packages/rs-sdk-ffi/src/group/queries/action_signers.rs
@@ -91,7 +91,7 @@ fn get_group_action_signers(
         return Err("Action ID is null".to_string());
     }
 
-    let rt = tokio::runtime::Runtime::new()
+    let rt = crate::runtime::BigStackRuntime::new_isolated()
         .map_err(|e| format!("Failed to create Tokio runtime: {}", e))?;
 
     let contract_id_str = unsafe {

--- a/packages/rs-sdk-ffi/src/group/queries/actions.rs
+++ b/packages/rs-sdk-ffi/src/group/queries/actions.rs
@@ -92,7 +92,7 @@ fn get_group_actions(
         return Err("Contract ID is null".to_string());
     }
 
-    let rt = tokio::runtime::Runtime::new()
+    let rt = crate::runtime::BigStackRuntime::new_isolated()
         .map_err(|e| format!("Failed to create Tokio runtime: {}", e))?;
 
     let contract_id_str = unsafe {

--- a/packages/rs-sdk-ffi/src/group/queries/info.rs
+++ b/packages/rs-sdk-ffi/src/group/queries/info.rs
@@ -75,7 +75,7 @@ fn get_group_info(
         return Err("Contract ID is null".to_string());
     }
 
-    let rt = tokio::runtime::Runtime::new()
+    let rt = crate::runtime::BigStackRuntime::new_isolated()
         .map_err(|e| format!("Failed to create Tokio runtime: {}", e))?;
 
     let contract_id_str = unsafe {

--- a/packages/rs-sdk-ffi/src/group/queries/infos.rs
+++ b/packages/rs-sdk-ffi/src/group/queries/infos.rs
@@ -71,7 +71,7 @@ fn get_group_infos(
         return Err("SDK handle is null".to_string());
     }
 
-    let rt = tokio::runtime::Runtime::new()
+    let rt = crate::runtime::BigStackRuntime::new_isolated()
         .map_err(|e| format!("Failed to create Tokio runtime: {}", e))?;
 
     let wrapper = unsafe { &*(sdk_handle as *const crate::sdk::SDKWrapper) };

--- a/packages/rs-sdk-ffi/src/lib.rs
+++ b/packages/rs-sdk-ffi/src/lib.rs
@@ -22,6 +22,7 @@ mod identity;
 mod mnemonic_resolver;
 mod mnemonic_resolver_core_signer;
 mod protocol_version;
+mod runtime;
 mod sdk;
 mod signer;
 mod signer_simple;

--- a/packages/rs-sdk-ffi/src/protocol_version/queries/upgrade_state.rs
+++ b/packages/rs-sdk-ffi/src/protocol_version/queries/upgrade_state.rs
@@ -68,7 +68,7 @@ fn get_protocol_version_upgrade_state(
         return Err("SDK handle is null".to_string());
     }
 
-    let rt = tokio::runtime::Runtime::new()
+    let rt = crate::runtime::BigStackRuntime::new_isolated()
         .map_err(|e| format!("Failed to create Tokio runtime: {}", e))?;
 
     let wrapper = unsafe { &*(sdk_handle as *const crate::sdk::SDKWrapper) };

--- a/packages/rs-sdk-ffi/src/protocol_version/queries/upgrade_vote_status.rs
+++ b/packages/rs-sdk-ffi/src/protocol_version/queries/upgrade_vote_status.rs
@@ -77,7 +77,7 @@ fn get_protocol_version_upgrade_vote_status(
         return Err("SDK handle is null".to_string());
     }
 
-    let rt = tokio::runtime::Runtime::new()
+    let rt = crate::runtime::BigStackRuntime::new_isolated()
         .map_err(|e| format!("Failed to create Tokio runtime: {}", e))?;
 
     let wrapper = unsafe { &*(sdk_handle as *const crate::sdk::SDKWrapper) };

--- a/packages/rs-sdk-ffi/src/runtime.rs
+++ b/packages/rs-sdk-ffi/src/runtime.rs
@@ -1,0 +1,194 @@
+//! A Tokio runtime wrapper that drives blocking FFI calls on an OS thread with
+//! a large stack.
+//!
+//! ## Why this exists
+//!
+//! [`Runtime::block_on`] polls the root future on the *calling* thread. On iOS
+//! the SDK's synchronous FFI entry points are invoked from libdispatch QoS
+//! worker threads whose stacks are tiny (~512 KiB). Post-broadcast proof
+//! verification (`Drive::verify_state_transition_was_executed_with_proof`) drives
+//! deep recursion through grovedb proof verification and `platform_value::Value`
+//! decoding; on a 512 KiB stack this overflows and the app crashes with
+//! `EXC_BAD_ACCESS` / SIGBUS ("Thread stack size exceeded") *after* the
+//! transition has already been signed and broadcast (e.g. Identity Transfer
+//! Credits / Withdraw).
+//!
+//! `drive-abci` runs all consensus ABCI work on a Tokio runtime configured with
+//! an 8 MiB `thread_stack_size` for exactly this reason. This wrapper gives the
+//! client the same budget: [`block_on`](BigStackRuntime::block_on) runs the
+//! future on a dedicated scoped OS thread with a large stack, while transparently
+//! delegating every other [`Runtime`] method (`spawn`, `handle`, `enter`, …) to
+//! the inner runtime via [`Deref`].
+
+use std::future::Future;
+use std::ops::Deref;
+use tokio::runtime::{Builder, Runtime};
+
+/// Stack size for the OS thread that drives blocking FFI calls.
+///
+/// Set to twice `drive-abci`'s 8 MiB consensus runtime stack so that client-side
+/// proof verification has at least the same recursion budget as the nodes that
+/// produced the proof, with headroom for the larger frames of unoptimized debug
+/// builds. Thread stacks are reserved lazily by the OS, so this costs negligible
+/// physical memory until it is actually touched.
+const FFI_BLOCKING_STACK_SIZE: usize = 16 * 1024 * 1024;
+
+/// Worker-thread stack size for tasks spawned onto the runtime with
+/// [`Runtime::spawn`]. Matches the consensus runtime so spawned work has the same
+/// budget as [`BigStackRuntime::block_on`].
+const WORKER_STACK_SIZE: usize = 8 * 1024 * 1024;
+
+/// A [`Runtime`] whose [`block_on`](BigStackRuntime::block_on) drives the future
+/// on an OS thread with a large stack. See the module docs for the rationale.
+pub(crate) struct BigStackRuntime(Runtime);
+
+impl BigStackRuntime {
+    /// Wrap an already-built runtime (used for the mock/test runtimes).
+    pub(crate) fn new(runtime: Runtime) -> Self {
+        BigStackRuntime(runtime)
+    }
+
+    /// Build the shared multi-threaded runtime used by the FFI.
+    ///
+    /// Mirrors the previous inline builder (single worker thread for mobile, all
+    /// drivers enabled) and additionally gives worker threads a large stack so
+    /// that work spawned with [`Runtime::spawn`] has the same budget as
+    /// [`block_on`](Self::block_on).
+    pub(crate) fn build_shared() -> std::io::Result<Self> {
+        let runtime = Builder::new_multi_thread()
+            .thread_name("dash-sdk-worker")
+            .worker_threads(1) // Reduce threads for mobile
+            .thread_stack_size(WORKER_STACK_SIZE)
+            .enable_all()
+            .build()?;
+        Ok(BigStackRuntime(runtime))
+    }
+
+    /// Build an isolated multi-threaded runtime (the `Runtime::new()` equivalent
+    /// used by the standalone-runtime query helpers), with large worker stacks.
+    pub(crate) fn new_isolated() -> std::io::Result<Self> {
+        let runtime = Builder::new_multi_thread()
+            .thread_stack_size(WORKER_STACK_SIZE)
+            .enable_all()
+            .build()?;
+        Ok(BigStackRuntime(runtime))
+    }
+
+    /// Run `future` to completion, driving it on a dedicated OS thread with a
+    /// large stack (see [`FFI_BLOCKING_STACK_SIZE`]).
+    ///
+    /// This is the drop-in replacement for `Runtime::block_on` on the FFI hot
+    /// path: it accepts the same (possibly non-`Send`) futures the FFI builds —
+    /// many capture `&` references to `#[repr(C)]` parameter structs holding raw
+    /// pointers, which are `!Sync` and hence `!Send` — yet still drives them on a
+    /// large stack.
+    pub(crate) fn block_on<F>(&self, future: F) -> F::Output
+    where
+        F: Future,
+    {
+        // `std::thread::Builder::spawn_scoped` is the only API that both (a) lets
+        // the worker borrow non-`'static` data — the FFI call's references — and
+        // (b) lets us set the stack size. It requires the moved-in closure (and
+        // its return value) to be `Send`, so we wrap the future and its output in
+        // `AssertSend`.
+        //
+        // SAFETY: asserting `Send` here is sound because execution is strictly
+        // sequential, never concurrent:
+        //   * `spawn_scoped` starts the worker, then this thread immediately
+        //     blocks in `join()` until the worker has fully finished. While the
+        //     worker runs the future, this thread touches neither the future nor
+        //     any data it captured, so there is no simultaneous access (the usual
+        //     reason `Send` is required) and thus no data race.
+        //   * `thread::scope` additionally guarantees the worker cannot outlive
+        //     this call, so any borrowed FFI pointers/references — valid for the
+        //     duration of the FFI call, which has not yet returned — stay valid.
+        // The future is created on this thread, run and dropped on the worker, and
+        // only its output crosses back, all without overlap.
+        struct AssertSend<T>(T);
+        // SAFETY: see the explanation above the use of `AssertSend`.
+        unsafe impl<T> Send for AssertSend<T> {}
+        impl<T> AssertSend<T> {
+            // Consuming `self` (rather than pattern-matching `self.0`) forces the
+            // worker closure to capture the whole `AssertSend` value: under the
+            // 2021 disjoint-closure-capture rules a `let AssertSend(x) = wrapper`
+            // pattern would capture the inner `T` field directly and bypass the
+            // `unsafe impl Send`.
+            fn into_inner(self) -> T {
+                self.0
+            }
+        }
+
+        let future = AssertSend(future);
+        std::thread::scope(|scope| {
+            let output = std::thread::Builder::new()
+                .name("dash-sdk-ffi-block-on".to_string())
+                .stack_size(FFI_BLOCKING_STACK_SIZE)
+                .spawn_scoped(scope, move || {
+                    AssertSend(self.0.block_on(future.into_inner()))
+                })
+                .expect("failed to spawn FFI block-on thread")
+                .join()
+                // Preserve `block_on`'s panic behaviour: re-raise on the caller's
+                // thread (a no-op under `panic = "abort"`, which aborts first).
+                .unwrap_or_else(|payload| std::panic::resume_unwind(payload));
+            output.into_inner()
+        })
+    }
+}
+
+impl Deref for BigStackRuntime {
+    type Target = Runtime;
+
+    fn deref(&self) -> &Runtime {
+        &self.0
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Recurses `depth` levels, holding a large, un-elidable frame at each level
+    /// so total stack use is roughly `depth * 8 KiB` regardless of optimization.
+    fn deep_recurse(depth: usize) -> usize {
+        let mut buf = [0u8; 8192];
+        let last = buf.len() - 1;
+        buf[0] = (depth & 0xff) as u8;
+        buf[last] = buf[0];
+        // `black_box(&buf)` forces the 8 KiB frame to be materialized so it can't
+        // be optimized away regardless of profile.
+        std::hint::black_box(&buf);
+        if depth == 0 {
+            0
+        } else {
+            1 + deep_recurse(depth - 1)
+        }
+    }
+
+    /// Regression guard for the iOS proof-verification stack overflow.
+    ///
+    /// The recursion below needs ~8 MiB of stack — far more than the ~2 MiB
+    /// default thread stack the test harness (and the libdispatch QoS workers
+    /// that crashed in the field) provide. It completes only because
+    /// [`BigStackRuntime::block_on`] drives the future on its dedicated
+    /// large-stack thread rather than on the calling thread. If that behaviour
+    /// regresses, this test overflows and aborts instead of passing.
+    #[test]
+    fn block_on_drives_future_on_large_stack() {
+        let runtime = BigStackRuntime::new_isolated().expect("build runtime");
+        let result = runtime.block_on(async { deep_recurse(1000) });
+        assert_eq!(result, 1000);
+    }
+
+    /// A value returned from a non-`Send`-friendly closure still comes back
+    /// correctly across the worker-thread hand-off.
+    #[test]
+    fn block_on_returns_future_output() {
+        let runtime = BigStackRuntime::new_isolated().expect("build runtime");
+        let value = runtime.block_on(async {
+            tokio::task::yield_now().await;
+            21 * 2
+        });
+        assert_eq!(value, 42);
+    }
+}

--- a/packages/rs-sdk-ffi/src/sdk.rs
+++ b/packages/rs-sdk-ffi/src/sdk.rs
@@ -11,6 +11,7 @@ use std::ffi::CStr;
 use std::str::FromStr;
 
 use crate::context_provider::{ContextProviderHandle, ContextProviderWrapper, CoreSDKHandle};
+use crate::runtime::BigStackRuntime;
 use crate::types::{DashSDKConfig, FFINetwork, Network, SDKHandle};
 use crate::{DashSDKError, DashSDKErrorCode, DashSDKResult, FFIError};
 
@@ -41,7 +42,7 @@ fn apply_version(builder: SdkBuilder, platform_version: u32) -> Result<SdkBuilde
 /// Internal SDK wrapper
 pub(crate) struct SDKWrapper {
     pub sdk: Sdk,
-    pub runtime: Arc<Runtime>,
+    pub runtime: Arc<BigStackRuntime>,
     pub trusted_provider: Option<Arc<rs_sdk_trusted_context_provider::TrustedHttpContextProvider>>,
 }
 
@@ -49,7 +50,7 @@ impl SDKWrapper {
     fn new(sdk: Sdk, runtime: Runtime) -> Self {
         SDKWrapper {
             sdk,
-            runtime: Arc::new(runtime),
+            runtime: Arc::new(BigStackRuntime::new(runtime)),
             trusted_provider: None,
         }
     }
@@ -62,7 +63,7 @@ impl SDKWrapper {
     ) -> Self {
         SDKWrapper {
             sdk,
-            runtime: Arc::new(runtime),
+            runtime: Arc::new(BigStackRuntime::new(runtime)),
             trusted_provider: Some(provider),
         }
     }
@@ -83,19 +84,14 @@ impl SDKWrapper {
 }
 
 // Shared Tokio runtime to avoid exhausting file descriptors when creating many SDK instances
-static RUNTIME: OnceLock<Arc<Runtime>> = OnceLock::new();
+static RUNTIME: OnceLock<Arc<BigStackRuntime>> = OnceLock::new();
 
-fn init_or_get_runtime() -> Result<Arc<Runtime>, String> {
+fn init_or_get_runtime() -> Result<Arc<BigStackRuntime>, String> {
     if let Some(rt) = RUNTIME.get() {
         return Ok(rt.clone());
     }
-    let mut builder = tokio::runtime::Builder::new_multi_thread();
-    builder.thread_name("dash-sdk-worker");
-    builder.worker_threads(1); // Reduce threads for mobile
-    builder.enable_all();
-    let rt = builder
-        .build()
-        .map_err(|e| format!("Failed to create runtime: {}", e))?;
+    let rt =
+        BigStackRuntime::build_shared().map_err(|e| format!("Failed to create runtime: {}", e))?;
     let arc = Arc::new(rt);
     let _ = RUNTIME.set(arc.clone());
     Ok(arc)

--- a/packages/rs-sdk-ffi/src/system/queries/current_quorums_info.rs
+++ b/packages/rs-sdk-ffi/src/system/queries/current_quorums_info.rs
@@ -66,7 +66,7 @@ fn get_current_quorums_info(sdk_handle: *const SDKHandle) -> Result<Option<Strin
         return Err("SDK handle is null".to_string());
     }
 
-    let rt = tokio::runtime::Runtime::new()
+    let rt = crate::runtime::BigStackRuntime::new_isolated()
         .map_err(|e| format!("Failed to create Tokio runtime: {}", e))?;
 
     let wrapper = unsafe { &*(sdk_handle as *const crate::sdk::SDKWrapper) };

--- a/packages/rs-sdk-ffi/src/system/queries/epochs_info.rs
+++ b/packages/rs-sdk-ffi/src/system/queries/epochs_info.rs
@@ -76,7 +76,7 @@ fn get_epochs_info(
         return Err("SDK handle is null".to_string());
     }
 
-    let rt = tokio::runtime::Runtime::new()
+    let rt = crate::runtime::BigStackRuntime::new_isolated()
         .map_err(|e| format!("Failed to create Tokio runtime: {}", e))?;
 
     let wrapper = unsafe { &*(sdk_handle as *const crate::sdk::SDKWrapper) };

--- a/packages/rs-sdk-ffi/src/system/queries/path_elements.rs
+++ b/packages/rs-sdk-ffi/src/system/queries/path_elements.rs
@@ -79,7 +79,7 @@ fn get_path_elements(
         return Err("Keys JSON is null".to_string());
     }
 
-    let rt = tokio::runtime::Runtime::new()
+    let rt = crate::runtime::BigStackRuntime::new_isolated()
         .map_err(|e| format!("Failed to create Tokio runtime: {}", e))?;
 
     let path_str = unsafe {

--- a/packages/rs-sdk-ffi/src/system/queries/platform_status.rs
+++ b/packages/rs-sdk-ffi/src/system/queries/platform_status.rs
@@ -54,7 +54,7 @@ fn get_platform_status(sdk_handle: *const SDKHandle) -> Result<String, String> {
         return Err("SDK handle is null".to_string());
     }
 
-    let rt = tokio::runtime::Runtime::new()
+    let rt = crate::runtime::BigStackRuntime::new_isolated()
         .map_err(|e| format!("Failed to create Tokio runtime: {}", e))?;
 
     let wrapper = unsafe { &*(sdk_handle as *const crate::sdk::SDKWrapper) };

--- a/packages/rs-sdk-ffi/src/system/queries/prefunded_specialized_balance.rs
+++ b/packages/rs-sdk-ffi/src/system/queries/prefunded_specialized_balance.rs
@@ -72,7 +72,7 @@ fn get_prefunded_specialized_balance(
         return Err("ID is null".to_string());
     }
 
-    let rt = tokio::runtime::Runtime::new()
+    let rt = crate::runtime::BigStackRuntime::new_isolated()
         .map_err(|e| format!("Failed to create Tokio runtime: {}", e))?;
 
     let id_str = unsafe {

--- a/packages/rs-sdk-ffi/src/system/queries/total_credits_in_platform.rs
+++ b/packages/rs-sdk-ffi/src/system/queries/total_credits_in_platform.rs
@@ -64,7 +64,7 @@ fn get_total_credits_in_platform(sdk_handle: *const SDKHandle) -> Result<Option<
         return Err("SDK handle is null".to_string());
     }
 
-    let rt = tokio::runtime::Runtime::new()
+    let rt = crate::runtime::BigStackRuntime::new_isolated()
         .map_err(|e| format!("Failed to create Tokio runtime: {}", e))?;
 
     let wrapper = unsafe { &*(sdk_handle as *const crate::sdk::SDKWrapper) };

--- a/packages/rs-sdk-ffi/src/token/queries/total_supply.rs
+++ b/packages/rs-sdk-ffi/src/token/queries/total_supply.rs
@@ -70,7 +70,7 @@ fn get_token_total_supply(
         return Err("Token ID is null".to_string());
     }
 
-    let rt = tokio::runtime::Runtime::new()
+    let rt = crate::runtime::BigStackRuntime::new_isolated()
         .map_err(|e| format!("Failed to create Tokio runtime: {}", e))?;
 
     let token_id_str = unsafe {

--- a/packages/rs-sdk-ffi/src/voting/queries/vote_polls_by_end_date.rs
+++ b/packages/rs-sdk-ffi/src/voting/queries/vote_polls_by_end_date.rs
@@ -95,7 +95,7 @@ fn get_vote_polls_by_end_date(
         return Err("SDK handle is null".to_string());
     }
 
-    let rt = tokio::runtime::Runtime::new()
+    let rt = crate::runtime::BigStackRuntime::new_isolated()
         .map_err(|e| format!("Failed to create Tokio runtime: {}", e))?;
 
     let wrapper = unsafe { &*(sdk_handle as *const crate::sdk::SDKWrapper) };


### PR DESCRIPTION
## Issue being fixed or feature implemented

`IdentityCreditTransfer` (State Transitions → Identity → Transfer Credits), and any state transition that waits for a result proof, reproducibly crashed **SwiftExampleApp** with `EXC_BAD_ACCESS` / SIGBUS **"Thread stack size exceeded"** in the **post-broadcast proof-verification** step — i.e. *after* the transition was signed and broadcast. This blocked Essential-tier ID-04 (identity→identity credit transfer) and ID-10 (withdrawal) from landing in the app.

Crash backtrace (from `~/Library/Logs/DiagnosticReports/SwiftExampleApp-*.ips`):

```
Runtime::block_on
  → dash_sdk_identity_transfer_credits::{{closure}}
    → <Identity as TransferToIdentity>::transfer_credits::{{closure}}
      → drive::verify::state_transition::verify_state_transition_was_executed_with_proof   ← overflow
```

**Root cause:** tokio's `Runtime::block_on` polls its root future on the **calling** thread. On iOS the SDK's synchronous FFI entry points are invoked from libdispatch QoS worker threads whose stacks are tiny (~512 KiB). The synchronous proof verification driven inside that future recurses deeply through grovedb proof-tree verification and overflows that stack. `drive-abci` runs all consensus ABCI work on a runtime configured with an **8 MiB** `thread_stack_size` for exactly this reason — the client had no equivalent budget, so a proof the nodes verify fine overflows on-device.

## What was done?

Fix is confined to `rs-sdk-ffi`. **No FFI signature / C-header change**, so the Swift layer is unaffected.

- **New `BigStackRuntime`** (`packages/rs-sdk-ffi/src/runtime.rs`): wraps the tokio `Runtime`, `Deref`s to it for `spawn`/`handle`/`enter`, and overrides `block_on` to drive the future on a **dedicated 16 MiB scoped OS thread** (`std::thread::Builder::stack_size` + `spawn_scoped`).
  - A documented `unsafe impl Send` (`AssertSend`) lets the (often non-`Send`) FFI futures cross to the worker thread. It is sound because the calling thread blocks in `join()` for the entire run, so execution is strictly **sequential, never concurrent** — no data race, and `thread::scope` guarantees the worker can't outlive the FFI call so any borrowed pointers stay valid.
- **Routed through it:** the shared `RUNTIME` static, `SDKWrapper.runtime`, and the ~20 standalone `Runtime::new()` query helpers. This is **zero call-site churn** for the ~70 `wrapper.runtime.block_on(...)` callers (same method name resolves to the wrapper's inherent `block_on`).
- Worker threads also bumped to an 8 MiB stack, matching the consensus runtime.

**Not done — `Value::decode` depth cap:** the alternative suggestion was a recursion depth cap in `platform_value::Value` decoding. Deliberately omitted: a credit-transfer proof reconstructs only `u64` balances (shallow `Value`), so the crashing recursion is grovedb's proof tree (a pinned git dependency), not `Value::Decode`; and a decode cap on the consensus-critical `Value` risks halting on legitimately-deep on-chain state. The stack fix is the correct and sufficient fix; a depth cap is a separate consensus-sensitive change.

## How Has This Been Tested?

- `cargo check -p rs-sdk-ffi --all-targets` ✅ and `cargo clippy -p rs-sdk-ffi --all-targets` ✅ (clean).
- **New regression test** `runtime::tests::block_on_drives_future_on_large_stack`: drives ~8 MiB of recursion (which overflows the default ~2 MiB thread stack) through `BigStackRuntime::block_on` and asserts it completes — directly proving the blocking path now executes on the large stack rather than the small calling-thread stack. Passes.
- `packages/swift-sdk/build_ios.sh --target sim --profile dev` ✅ — `rs-sdk-ffi` cross-compiles + links for `aarch64-apple-ios-sim`, and the SwiftExampleApp Debug bundle builds/signs.
- **Live on-device run** (iPhone 17 Pro simulator, fixed build): a Transfer Credits attempt no longer crashes (process stable, no new crash report). Note: the only locally-available identities predate the transfer-key fix (no TRANSFER key), so the transfer fails gracefully at *signing* before reaching the verify step — the deep post-broadcast recursion itself is covered by the regression test + crash-path analysis above.

## Breaking Changes

None. This is a client-side (iOS/FFI) reliability fix with no public API, FFI signature, or consensus change.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [ ] I have made corresponding changes to the documentation if needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)