### PR TITLE
fix(swift-example-app): fix compile timeout on on newest xcode versions

### DIFF
--- a/packages/swift-sdk/SwiftExampleApp/SwiftExampleApp/Views/CreateIdentityView.swift
+++ b/packages/swift-sdk/SwiftExampleApp/SwiftExampleApp/Views/CreateIdentityView.swift
@@ -633,19 +633,20 @@ struct CreateIdentityView: View {
         } header: {
             Text("Funding Source")
         } footer: {
-            Text(
-                "Any account on the selected wallet with a balance can fund "
-                + "the identity — Core or Platform Payment. Empty accounts "
-                + "are hidden. "
-                + (showShielded
-                    ? "Shielded Balance funds the identity directly from this "
-                      + "wallet's shielded (Orchard) pool by spending a fixed "
-                      + "denomination. "
-                    : "")
-                + "To resume a prior in-flight registration, "
-                + "use the Resumable Registrations section on the Identities tab."
-            )
+            Text(Self.fundingSourceFooterText(showShielded: showShielded))
         }
+    }
+
+    private static func fundingSourceFooterText(showShielded: Bool) -> String {
+        var text = "Any account on the selected wallet with a balance can fund "
+            + "the identity — Core or Platform Payment. Empty accounts are hidden. "
+        if showShielded {
+            text += "Shielded Balance funds the identity directly from this "
+                + "wallet's shielded (Orchard) pool by spending a fixed denomination. "
+        }
+        text += "To resume a prior in-flight registration, "
+            + "use the Resumable Registrations section on the Identities tab."
+        return text
     }
 
     /// Amount (in DASH) to fund the new identity with. Shown for


### PR DESCRIPTION
The newest version of the compiler can't analyze the String concatenation without timing out


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [ ] I have made corresponding changes to the documentation if needed

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved code organization in the identity creation form by simplifying the funding source section.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->