### PR TITLE
fix(swift-example-app): expose Picker options to UI automation

### DIFF
--- a/packages/swift-sdk/SwiftExampleApp/SwiftExampleApp/Views/Components/AccessiblePicker.swift
+++ b/packages/swift-sdk/SwiftExampleApp/SwiftExampleApp/Views/Components/AccessiblePicker.swift
@@ -1,0 +1,73 @@
+// AccessiblePicker.swift
+// SwiftExampleApp
+//
+// TESTABILITY helper — NOT product logic. SwiftUI's default menu-style
+// `Picker` (the Form default, or an explicit `.pickerStyle(.menu)` /
+// `MenuPickerStyle()`) renders its option list as a UIKit context-menu
+// popover. idb's accessibility tree only sees that popover as a single
+// element labelled "Dismiss context menu" — the individual option rows
+// are NOT exposed, so UI automation can neither query nor tap a specific
+// option.
+//
+// These modifiers swap the presentation to a row-exposing style without
+// touching any selection / binding / onChange behaviour:
+//
+//   - `.accessibleFormPicker(_:)` — for pickers inside a `Form` / `List`.
+//     Applies `.pickerStyle(.navigationLink)`, which pushes a real
+//     `List` of selectable rows onto the navigation stack. idb traverses
+//     those rows directly.
+//   - `.accessibleInlinePicker(_:)` — for pickers NOT inside a Form
+//     (navigationLink renders poorly there). Applies
+//     `.pickerStyle(.inline)`, which lays the rows out in place as part
+//     of the view hierarchy idb can see.
+//
+// Both also stamp the picker container with an `accessibilityIdentifier`
+// so the picker element itself is addressable. Each *option row* should
+// also set its own `.accessibilityIdentifier(...)` at the call site —
+// but how that surfaces to idb differs by style (verified on-device):
+//
+//   - navigationLink: the pushed list renders each option as a distinct
+//     row and the per-row identifiers DO surface — e.g. an option row
+//     reports `id=topup.fundingSource.account.0`. Prefer this for the
+//     Form pickers; it gives stable, unique, tappable row ids.
+//   - inline: SwiftUI rebuilds the options as its own selection rows and
+//     does NOT surface their per-row identifiers — every row instead
+//     inherits the container identifier. So inline option rows are
+//     addressed by their visible label (`AXLabel`), not by a per-row id.
+//     The per-row `.accessibilityIdentifier(...)` calls are kept anyway:
+//     they document intent and take effect if the picker is ever moved
+//     into a Form/navigationLink context. Because inline rows share the
+//     container id, give each `.accessibleInlinePicker(_:)` a container
+//     id distinct from any sibling so a label+container query stays
+//     unambiguous.
+
+import SwiftUI
+
+extension View {
+    /// Form/List picker presentation that exposes option rows to the
+    /// accessibility tree. Use on a `Picker` that lives inside a `Form`
+    /// or `List`. Sets `.pickerStyle(.navigationLink)` and tags the
+    /// picker container with `identifier`.
+    ///
+    /// Does not alter selection, bindings, or `onChange` — purely a
+    /// presentation + accessibility change.
+    func accessibleFormPicker(_ identifier: String) -> some View {
+        self
+            .pickerStyle(.navigationLink)
+            .accessibilityIdentifier(identifier)
+    }
+
+    /// Inline picker presentation for pickers that are NOT inside a
+    /// `Form`/`List`, where `.navigationLink` renders poorly. Sets
+    /// `.pickerStyle(.inline)` so the rows are laid out in place (and
+    /// thus exposed to idb) and tags the picker container with
+    /// `identifier`.
+    ///
+    /// Does not alter selection, bindings, or `onChange` — purely a
+    /// presentation + accessibility change.
+    func accessibleInlinePicker(_ identifier: String) -> some View {
+        self
+            .pickerStyle(.inline)
+            .accessibilityIdentifier(identifier)
+    }
+}

--- a/packages/swift-sdk/SwiftExampleApp/SwiftExampleApp/Views/Components/RecipientPickerView.swift
+++ b/packages/swift-sdk/SwiftExampleApp/SwiftExampleApp/Views/Components/RecipientPickerView.swift
@@ -124,12 +124,16 @@ struct RecipientPickerView: View {
                 .foregroundColor(.secondary)
         } else {
             Picker("Identity", selection: localBinding) {
-                Text("Choose…").tag(Data?.none)
+                Text("Choose…")
+                    .tag(Data?.none)
+                    .accessibilityIdentifier("recipient.identity.none")
                 ForEach(candidates, id: \.identityId) { id in
-                    Text(id.displayName).tag(Optional(id.identityId))
+                    Text(id.displayName)
+                        .tag(Optional(id.identityId))
+                        .accessibilityIdentifier("recipient.identity.\(id.identityIdBase58)")
                 }
             }
-            .pickerStyle(.menu)
+            .accessibleInlinePicker("recipient.identityPicker")
         }
     }
 

--- a/packages/swift-sdk/SwiftExampleApp/SwiftExampleApp/Views/Components/RecipientPickerView.swift
+++ b/packages/swift-sdk/SwiftExampleApp/SwiftExampleApp/Views/Components/RecipientPickerView.swift
@@ -133,7 +133,12 @@ struct RecipientPickerView: View {
                         .accessibilityIdentifier("recipient.identity.\(id.identityIdBase58)")
                 }
             }
-            .accessibleInlinePicker("recipient.identityPicker")
+            // navigationLink (not inline): every call site embeds this
+            // view in a Form `Section`, so the picker pushes a real list
+            // whose rows expose the per-row `recipient.identity.<base58>`
+            // identifiers above (inline would drop them — see
+            // AccessiblePicker.swift).
+            .accessibleFormPicker("recipient.identityPicker")
         }
     }
 

--- a/packages/swift-sdk/SwiftExampleApp/SwiftExampleApp/Views/CreateIdentityView.swift
+++ b/packages/swift-sdk/SwiftExampleApp/SwiftExampleApp/Views/CreateIdentityView.swift
@@ -480,14 +480,18 @@ struct CreateIdentityView: View {
             Picker("Source Wallet", selection: $walletSelection) {
                 Text("Select…")
                     .tag(Optional<WalletSelection>.none)
+                    .accessibilityIdentifier("createIdentity.sourceWallet.none")
                 ForEach(wallets) { wallet in
                     Text(walletLabel(for: wallet))
                         .tag(Optional(WalletSelection.wallet(id: wallet.walletId)))
+                        .accessibilityIdentifier("createIdentity.sourceWallet.wallet.\(wallet.walletId.toHexString())")
                 }
                 Divider()
                 Text("Create without Wallet")
                     .tag(Optional(WalletSelection.walletless))
+                    .accessibilityIdentifier("createIdentity.sourceWallet.walletless")
             }
+            .accessibleFormPicker("createIdentity.sourceWalletPicker")
             .onChange(of: walletSelection) { _, newValue in
                 // Reset downstream selection whenever the wallet
                 // changes so a stale account / proof / denomination
@@ -607,9 +611,11 @@ struct CreateIdentityView: View {
             Picker("Funding Source", selection: $fundingSelection) {
                 Text("Select…")
                     .tag(Optional<FundingSelection>.none)
+                    .accessibilityIdentifier("createIdentity.fundingSource.none")
                 ForEach(options) { option in
                     Text("\(option.label) — \(option.balanceText)")
                         .tag(Optional(FundingSelection.account(id: option.persistentId)))
+                        .accessibilityIdentifier("createIdentity.fundingSource.account.\(option.accountType).\(option.accountIndex)")
                 }
                 if showShielded {
                     let shieldedText = Self.formatDash(
@@ -618,8 +624,10 @@ struct CreateIdentityView: View {
                     )
                     Text("Shielded Balance — \(shieldedText)")
                         .tag(Optional(FundingSelection.shieldedBalance))
+                        .accessibilityIdentifier("createIdentity.fundingSource.shielded")
                 }
             }
+            .accessibleFormPicker("createIdentity.fundingSourcePicker")
             .onChange(of: fundingSelection) { _, newValue in
                 // Pre-fill the amount with the full available balance
                 // of the selected Platform Payment account so the
@@ -732,14 +740,17 @@ struct CreateIdentityView: View {
                 Picker("Denomination", selection: $selectedDenomination) {
                     Text("Select…")
                         .tag(Optional<UInt64>.none)
+                        .accessibilityIdentifier("createIdentity.denomination.none")
                     ForEach(affordable, id: \.self) { denom in
                         Text(Self.formatDash(
                             raw: denom,
                             divisor: Double(Self.creditsPerDash)
                         ))
                         .tag(Optional(denom))
+                        .accessibilityIdentifier("createIdentity.denomination.\(denom)")
                     }
                 }
+                .accessibleFormPicker("createIdentity.denominationPicker")
                 .disabled(isCreating)
             }
         } header: {
@@ -1968,6 +1979,8 @@ struct CreateIdentityView: View {
                 )
                 return FundingAccountOption(
                     persistentId: account.persistentModelID,
+                    accountType: account.accountType,
+                    accountIndex: account.accountIndex,
                     label: Self.fundingLabel(for: account),
                     balanceText: balanceText
                 )
@@ -2182,6 +2195,17 @@ private enum FundingSelection: Hashable {
 
 private struct FundingAccountOption: Identifiable {
     let persistentId: PersistentIdentifier
+    /// HD account type tag (e.g. 0 = BIP44 standard, 14 = Platform
+    /// Payment). Paired with `accountIndex` in the row's accessibility
+    /// identifier because the index alone is NOT unique across account
+    /// types — this picker lists both Core and Platform Payment
+    /// accounts, so a bare `#0` would collide (BIP44 #0 vs Platform
+    /// Payment #0).
+    let accountType: UInt32
+    /// HD account index, carried only so the accessibility identifier
+    /// for this row can be stable across launches (the
+    /// `PersistentIdentifier` opaque id is not).
+    let accountIndex: UInt32
     let label: String
     /// Human-readable balance suffix (`"0.01 DASH"`). Zero-balance
     /// accounts are filtered out upstream so this is always a

--- a/packages/swift-sdk/SwiftExampleApp/SwiftExampleApp/Views/TopUpIdentityView.swift
+++ b/packages/swift-sdk/SwiftExampleApp/SwiftExampleApp/Views/TopUpIdentityView.swift
@@ -115,11 +115,14 @@ struct TopUpIdentityView: View {
                     Picker("Funding Source", selection: $fundingSelection) {
                         Text("Select…")
                             .tag(Optional<FundingSelection>.none)
+                            .accessibilityIdentifier("topup.fundingSource.none")
                         ForEach(options) { option in
                             Text("\(option.label) — \(option.balanceText)")
                                 .tag(Optional(FundingSelection.account(id: option.persistentId)))
+                                .accessibilityIdentifier("topup.fundingSource.account.\(option.accountIndex)")
                         }
                     }
+                    .accessibleFormPicker("topup.fundingSourcePicker")
                     .onChange(of: fundingSelection) { _, newValue in
                         amountDash = defaultAmountString(for: newValue)
                     }
@@ -382,6 +385,7 @@ struct TopUpIdentityView: View {
                 let balance = account.platformAddresses.reduce(0) { $0 + $1.balance }
                 return FundingAccountOption(
                     persistentId: account.persistentModelID,
+                    accountIndex: account.accountIndex,
                     label: "\(account.accountTypeName) #\(account.accountIndex)",
                     balanceText: Self.formatDash(
                         raw: balance,
@@ -411,6 +415,10 @@ private enum FundingSelection: Hashable {
 
 private struct FundingAccountOption: Identifiable {
     let persistentId: PersistentIdentifier
+    /// HD account index, carried only so the accessibility identifier
+    /// for this row can be stable across launches (the
+    /// `PersistentIdentifier` opaque id is not).
+    let accountIndex: UInt32
     let label: String
     let balanceText: String
     var id: PersistentIdentifier { persistentId }

--- a/packages/swift-sdk/SwiftExampleApp/SwiftExampleApp/Views/TransitionInputView.swift
+++ b/packages/swift-sdk/SwiftExampleApp/SwiftExampleApp/Views/TransitionInputView.swift
@@ -124,14 +124,14 @@ struct TransitionInputView: View {
                 Picker(input.label, selection: $value) {
                     Text("Select...")
                         .tag("")
-                        .accessibilityIdentifier("transition.select.none")
+                        .accessibilityIdentifier("transition.\(input.name).select.none")
                     ForEach(input.options ?? [], id: \.value) { option in
                         Text(option.label)
                             .tag(option.value)
-                            .accessibilityIdentifier("transition.select.\(option.value)")
+                            .accessibilityIdentifier("transition.\(input.name).select.\(option.value)")
                     }
                 }
-                .accessibleInlinePicker("transition.selectPicker")
+                .accessibleInlinePicker("transition.\(input.name).selectPicker")
 
             case "button":
                 Button(action: { onSpecialAction(input.action ?? "") }) {
@@ -211,16 +211,16 @@ struct TransitionInputView: View {
             Picker("Select Token", selection: $value) {
                 Text("Select a token...")
                     .tag("")
-                    .accessibilityIdentifier("transition.token.none")
+                    .accessibilityIdentifier("transition.\(input.name).token.none")
                 ForEach(tokens, id: \.token.id) { tokenData in
                     let displayName = tokenData.token.getSingularForm(languageCode: "en") ?? tokenData.token.displayName
                     let contractName = getContractDisplayName(tokenData.contract)
                     Text("\(displayName) (from \(contractName))")
                         .tag("\(tokenData.contract.idBase58):\(tokenData.token.position)")
-                        .accessibilityIdentifier("transition.token.\(tokenData.contract.idBase58).\(tokenData.token.position)")
+                        .accessibilityIdentifier("transition.\(input.name).token.\(tokenData.contract.idBase58).\(tokenData.token.position)")
                 }
             }
-            .accessibleInlinePicker("transition.tokenPicker")
+            .accessibleInlinePicker("transition.\(input.name).tokenPicker")
             .padding()
             .background(Color.gray.opacity(0.1))
             .cornerRadius(8)
@@ -336,14 +336,14 @@ struct TransitionInputView: View {
             Picker("Select Contract", selection: $value) {
                 Text("Select a contract...")
                     .tag("")
-                    .accessibilityIdentifier("transition.contract.none")
+                    .accessibilityIdentifier("transition.\(input.name).contract.none")
                 ForEach(availableContracts, id: \.idBase58) { contract in
                     Text(getContractDisplayName(contract))
                         .tag(contract.idBase58)
-                        .accessibilityIdentifier("transition.contract.\(contract.idBase58)")
+                        .accessibilityIdentifier("transition.\(input.name).contract.\(contract.idBase58)")
                 }
             }
-            .accessibleInlinePicker("transition.contractPicker")
+            .accessibleInlinePicker("transition.\(input.name).contractPicker")
             .padding()
             .frame(maxWidth: .infinity, alignment: .leading)
             .background(Color.gray.opacity(0.1))
@@ -429,14 +429,14 @@ struct TransitionInputView: View {
                     Picker("Select Document Type", selection: $value) {
                         Text("Select a type...")
                             .tag("")
-                            .accessibilityIdentifier("transition.documentType.none")
+                            .accessibilityIdentifier("transition.\(input.name).documentType.none")
                         ForEach(availableDocTypes, id: \.name) { docType in
                             Text(docType.name)
                                 .tag(docType.name)
-                                .accessibilityIdentifier("transition.documentType.\(docType.name)")
+                                .accessibilityIdentifier("transition.\(input.name).documentType.\(docType.name)")
                         }
                     }
-                    .accessibleInlinePicker("transition.documentTypePicker")
+                    .accessibleInlinePicker("transition.\(input.name).documentTypePicker")
                     .padding()
                     .frame(maxWidth: .infinity, alignment: .leading)
                     .background(Color.gray.opacity(0.1))
@@ -513,14 +513,14 @@ struct TransitionInputView: View {
             Picker("Select Identity", selection: $value) {
                 Text("Select an identity...")
                     .tag("")
-                    .accessibilityIdentifier("transition.identity.none")
+                    .accessibilityIdentifier("transition.\(input.name).identity.none")
                 ForEach(identities, id: \.identityIdBase58) { identity in
                     Text(identity.displayName)
                         .tag(identity.identityIdBase58)
-                        .accessibilityIdentifier("transition.identity.\(identity.identityIdBase58)")
+                        .accessibilityIdentifier("transition.\(input.name).identity.\(identity.identityIdBase58)")
                 }
             }
-            .accessibleInlinePicker("transition.identityPicker")
+            .accessibleInlinePicker("transition.\(input.name).identityPicker")
             .padding()
             .frame(maxWidth: .infinity, alignment: .leading)
             .background(Color.gray.opacity(0.1))
@@ -561,17 +561,17 @@ struct TransitionInputView: View {
                     Picker("Select Identity", selection: $value) {
                         Text("Select an identity...")
                             .tag("")
-                            .accessibilityIdentifier("transition.recipientIdentity.none")
+                            .accessibilityIdentifier("transition.\(input.name).recipientIdentity.none")
                         ForEach(identities, id: \.identityIdBase58) { identity in
                             Text(identity.displayName)
                                 .tag(identity.identityIdBase58)
-                                .accessibilityIdentifier("transition.recipientIdentity.\(identity.identityIdBase58)")
+                                .accessibilityIdentifier("transition.\(input.name).recipientIdentity.\(identity.identityIdBase58)")
                         }
                         Text("💳 Manually Enter Recipient")
                             .tag("__manual__")
-                            .accessibilityIdentifier("transition.recipientIdentity.manual")
+                            .accessibilityIdentifier("transition.\(input.name).recipientIdentity.manual")
                     }
-                    .accessibleInlinePicker("transition.recipientIdentityPicker")
+                    .accessibleInlinePicker("transition.\(input.name).recipientIdentityPicker")
                     .padding()
                     .frame(maxWidth: .infinity, alignment: .leading)
                     .background(Color.gray.opacity(0.1))

--- a/packages/swift-sdk/SwiftExampleApp/SwiftExampleApp/Views/TransitionInputView.swift
+++ b/packages/swift-sdk/SwiftExampleApp/SwiftExampleApp/Views/TransitionInputView.swift
@@ -122,12 +122,16 @@ struct TransitionInputView: View {
 
             case "select":
                 Picker(input.label, selection: $value) {
-                    Text("Select...").tag("")
+                    Text("Select...")
+                        .tag("")
+                        .accessibilityIdentifier("transition.select.none")
                     ForEach(input.options ?? [], id: \.value) { option in
-                        Text(option.label).tag(option.value)
+                        Text(option.label)
+                            .tag(option.value)
+                            .accessibilityIdentifier("transition.select.\(option.value)")
                     }
                 }
-                .pickerStyle(MenuPickerStyle())
+                .accessibleInlinePicker("transition.selectPicker")
 
             case "button":
                 Button(action: { onSpecialAction(input.action ?? "") }) {
@@ -205,15 +209,18 @@ struct TransitionInputView: View {
                 .cornerRadius(8)
         } else {
             Picker("Select Token", selection: $value) {
-                Text("Select a token...").tag("")
+                Text("Select a token...")
+                    .tag("")
+                    .accessibilityIdentifier("transition.token.none")
                 ForEach(tokens, id: \.token.id) { tokenData in
                     let displayName = tokenData.token.getSingularForm(languageCode: "en") ?? tokenData.token.displayName
                     let contractName = getContractDisplayName(tokenData.contract)
                     Text("\(displayName) (from \(contractName))")
                         .tag("\(tokenData.contract.idBase58):\(tokenData.token.position)")
+                        .accessibilityIdentifier("transition.token.\(tokenData.contract.idBase58).\(tokenData.token.position)")
                 }
             }
-            .pickerStyle(MenuPickerStyle())
+            .accessibleInlinePicker("transition.tokenPicker")
             .padding()
             .background(Color.gray.opacity(0.1))
             .cornerRadius(8)
@@ -327,13 +334,16 @@ struct TransitionInputView: View {
                 .cornerRadius(8)
         } else {
             Picker("Select Contract", selection: $value) {
-                Text("Select a contract...").tag("")
+                Text("Select a contract...")
+                    .tag("")
+                    .accessibilityIdentifier("transition.contract.none")
                 ForEach(availableContracts, id: \.idBase58) { contract in
                     Text(getContractDisplayName(contract))
                         .tag(contract.idBase58)
+                        .accessibilityIdentifier("transition.contract.\(contract.idBase58)")
                 }
             }
-            .pickerStyle(MenuPickerStyle())
+            .accessibleInlinePicker("transition.contractPicker")
             .padding()
             .frame(maxWidth: .infinity, alignment: .leading)
             .background(Color.gray.opacity(0.1))
@@ -417,12 +427,16 @@ struct TransitionInputView: View {
                         .cornerRadius(8)
                 } else {
                     Picker("Select Document Type", selection: $value) {
-                        Text("Select a type...").tag("")
+                        Text("Select a type...")
+                            .tag("")
+                            .accessibilityIdentifier("transition.documentType.none")
                         ForEach(availableDocTypes, id: \.name) { docType in
-                            Text(docType.name).tag(docType.name)
+                            Text(docType.name)
+                                .tag(docType.name)
+                                .accessibilityIdentifier("transition.documentType.\(docType.name)")
                         }
                     }
-                    .pickerStyle(MenuPickerStyle())
+                    .accessibleInlinePicker("transition.documentTypePicker")
                     .padding()
                     .frame(maxWidth: .infinity, alignment: .leading)
                     .background(Color.gray.opacity(0.1))
@@ -497,13 +511,16 @@ struct TransitionInputView: View {
                 .cornerRadius(8)
         } else {
             Picker("Select Identity", selection: $value) {
-                Text("Select an identity...").tag("")
+                Text("Select an identity...")
+                    .tag("")
+                    .accessibilityIdentifier("transition.identity.none")
                 ForEach(identities, id: \.identityIdBase58) { identity in
                     Text(identity.displayName)
                         .tag(identity.identityIdBase58)
+                        .accessibilityIdentifier("transition.identity.\(identity.identityIdBase58)")
                 }
             }
-            .pickerStyle(MenuPickerStyle())
+            .accessibleInlinePicker("transition.identityPicker")
             .padding()
             .frame(maxWidth: .infinity, alignment: .leading)
             .background(Color.gray.opacity(0.1))
@@ -542,14 +559,19 @@ struct TransitionInputView: View {
                     }
                 } else {
                     Picker("Select Identity", selection: $value) {
-                        Text("Select an identity...").tag("")
+                        Text("Select an identity...")
+                            .tag("")
+                            .accessibilityIdentifier("transition.recipientIdentity.none")
                         ForEach(identities, id: \.identityIdBase58) { identity in
                             Text(identity.displayName)
                                 .tag(identity.identityIdBase58)
+                                .accessibilityIdentifier("transition.recipientIdentity.\(identity.identityIdBase58)")
                         }
-                        Text("💳 Manually Enter Recipient").tag("__manual__")
+                        Text("💳 Manually Enter Recipient")
+                            .tag("__manual__")
+                            .accessibilityIdentifier("transition.recipientIdentity.manual")
                     }
-                    .pickerStyle(MenuPickerStyle())
+                    .accessibleInlinePicker("transition.recipientIdentityPicker")
                     .padding()
                     .frame(maxWidth: .infinity, alignment: .leading)
                     .background(Color.gray.opacity(0.1))


### PR DESCRIPTION
## Issue being fixed or feature implemented

Several SwiftExampleApp flows start with a SwiftUI `Picker` that renders as a menu popover (the `Form` default, or an explicit `.pickerStyle(.menu)` / `MenuPickerStyle()`). When opened, idb's accessibility tree shows **only** an element labeled "Dismiss context menu" — the actual option rows ("Platform Payment #0 — 0.0231 DASH", wallets, identities, etc.) are not exposed, so UI automation can neither query nor tap a specific option (a blind coordinate tap just dismisses the menu).

This blocked automated runs of the identity funding flows — **ID-05** (top up), **ID-06** (top up from Platform addresses), **ID-08** (create from Platform addresses) — and the token-register / builder identity pickers. The features work fine **manually**; this is a testability/accessibility fix, not a product-bug fix.

QA tracking: [#3897](https://github.com/dashpay/platform/issues/3897) (updated — the Picker-popover blocker is now marked RESOLVED).

## What was done?

Added a shared helper, `AccessiblePicker.swift`, with two presentation modifiers (no behaviour change — selection bindings / `onChange` untouched):

- `.accessibleFormPicker(_:)` → `.pickerStyle(.navigationLink)` for pickers inside a `Form`/`List`. Pushes a real `List`; **per-row `accessibilityIdentifier`s surface** as distinct, tappable rows.
- `.accessibleInlinePicker(_:)` → `.pickerStyle(.inline)` for pickers **not** in a Form (where `.navigationLink` renders poorly). Rows are laid out in place; addressable by `AXLabel`.

Applied them — with stable per-row identifiers — to:
- `TopUpIdentityView` — funding-source picker (`topup.fundingSource.*`)
- `CreateIdentityView` — source-wallet, funding-source, denomination pickers (`createIdentity.*`)
- `RecipientPickerView` — local-identity picker (`recipient.identity.*`)
- `TransitionInputView` — identity / recipient-identity / contract / document-type / token / generic-select pickers (`transition.*`)

The Create funding-source row id includes the account **type** (`…account.<accountType>.<accountIndex>`) because that picker lists both Core and Platform-Payment accounts, so a bare `#0` would collide (BIP44 #0 vs Platform Payment #0).

Pure SwiftUI / accessibility change in the example app — **no FFI, no Rust, no business logic** (per `packages/swift-sdk/CLAUDE.md`).

## How Has This Been Tested?

Built `packages/swift-sdk/build_ios.sh --target sim` (clean) and drove the booted iOS simulator (iPhone 17, fully-provisioned QA wallet) with `idb`:

- **ID-05 — end-to-end.** Opened the funding-source picker → `idb ui describe-all` listed `topup.fundingSource.account.0` ("Platform Payment #0 …") instead of "Dismiss context menu"; selected it (amount pre-filled, submit enabled), set a small amount, tapped **Top Up Balance**. Success banner showed the new balance, and **SwiftData ground truth confirmed** the identity balance increased to match. No errors/panics in the app log.
- **ID-08** — `CreateIdentityView` source-wallet picker exposed all rows; selecting a wallet revealed the funding-source picker, which exposed unique rows and propagated selection (verified the id-collision fix; drove to submit-ready, did not broadcast the create).
- **RecipientPickerView** — inline rows exposed; tapping one selected it.

Note: `.inline` pickers expose rows but SwiftUI does not surface their per-row ids (rows inherit the container id; address by `AXLabel`) — documented in the helper. `Menu { Button }` *navigation* menus (e.g. the Identities "+") were never affected — they already expose their children.

## Breaking Changes

None.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any (n/a — no breaking changes)
- [ ] I have made corresponding changes to the documentation if needed

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added SwiftUI picker accessibility helpers to standardize form and inline picker presentation.
* **Improvements**
  * Updated identity, recipient identity, funding source, wallet, token, contract, and document-type pickers to include stable accessibility identifiers for the “none/choose” option and each selectable row.
  * Switched some pickers to the new accessibility-friendly wrapper for clearer assistive-technology navigation.
  * Added per-option identifiers to picker-driven inputs, including manual-entry where applicable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->