### PR TITLE
feat(swift-example-app): multi-recipient Core L1 send (CORE-10)

### DIFF
--- a/packages/swift-sdk/SwiftExampleApp/SwiftExampleApp/Core/ViewModels/SendViewModel.swift
+++ b/packages/swift-sdk/SwiftExampleApp/SwiftExampleApp/Core/ViewModels/SendViewModel.swift
@@ -170,29 +170,54 @@ class SendViewModel: ObservableObject {
         parseTokenAmount(amountString, decimals: 8)
     }
 
-    /// The full, ordered Core output list for the `coreToCore` flow:
-    /// the PRIMARY row (`recipientAddress` + `amountDuffs`) followed by
-    /// each `additionalCoreRecipients` row, in display order. Returns
-    /// `nil` if ANY row is invalid so callers (gating + send) treat the
-    /// batch atomically — a single bad extra row blocks the whole send
-    /// rather than silently dropping that output.
+    /// The validated Core batch for the `coreToCore` flow, built once: the
+    /// ordered output list (primary + extras) AND its running duffs total.
+    /// `coreRecipients` and `coreSendTotalDuffs` both derive from this so
+    /// the gated/sent list and the displayed "Total" can never disagree —
+    /// they come from a single iteration over the same rows.
+    ///
+    /// Returns `nil` (whole batch invalid) when ANY row is invalid OR the
+    /// running total would overflow `UInt64`, so callers (gating + send)
+    /// treat the batch atomically — a single bad extra row, or an
+    /// aggregate that exceeds the duffs range, blocks the whole send
+    /// rather than silently dropping an output or wrapping the total.
     ///
     /// "Valid" per row = the address parses as a `.core` address on
     /// `self.network` (same `DashAddress.parse` the primary row's
     /// detection uses, so a Platform/Orchard string in an extra row is
     /// rejected here) AND its duffs amount is `> 0` (a sub-unit amount
     /// scales to 0 and would reach Rust as a zero-value output).
-    var coreRecipients: [(address: String, amountDuffs: UInt64)]? {
+    ///
+    /// Overflow rationale: each row's amount is independently a valid
+    /// `UInt64`, but two valid amounts can still sum past `UInt64.max`.
+    /// Dash's total supply is far below that, so this is only reachable
+    /// from raw user input, but a bare `+` would trap in debug / wrap in
+    /// release the moment the summary renders. Accumulating with
+    /// `addingReportingOverflow` and treating overflow as "batch invalid"
+    /// keeps the failure mode identical to a bad address or zero amount.
+    private var coreRecipientPlan:
+        (outputs: [(address: String, amountDuffs: UInt64)], total: UInt64)? {
         var outputs: [(address: String, amountDuffs: UInt64)] = []
+        var total: UInt64 = 0
+
+        // Accumulate `duffs` into `total`, rejecting the whole batch on
+        // overflow (see the property's overflow rationale).
+        func add(_ address: String, _ duffs: UInt64) -> Bool {
+            let (sum, overflow) = total.addingReportingOverflow(duffs)
+            if overflow { return false }
+            total = sum
+            outputs.append((address: address, amountDuffs: duffs))
+            return true
+        }
 
         // Primary row. The trim mirrors the existing `.coreToCore` send
         // case so the marshalled address matches what the badge validated.
         let primaryAddress = recipientAddress
             .trimmingCharacters(in: .whitespacesAndNewlines)
         guard isCoreAddress(primaryAddress),
-              let primaryDuffs = amountDuffs, primaryDuffs > 0
+              let primaryDuffs = amountDuffs, primaryDuffs > 0,
+              add(primaryAddress, primaryDuffs)
         else { return nil }
-        outputs.append((address: primaryAddress, amountDuffs: primaryDuffs))
 
         // Extra rows, in order.
         for row in additionalCoreRecipients {
@@ -200,21 +225,30 @@ class SendViewModel: ObservableObject {
                 .trimmingCharacters(in: .whitespacesAndNewlines)
             guard isCoreAddress(address),
                   let rowDuffs = duffs(forRecipientAmount: row.amountString),
-                  rowDuffs > 0
+                  rowDuffs > 0,
+                  add(address, rowDuffs)
             else { return nil }
-            outputs.append((address: address, amountDuffs: rowDuffs))
         }
 
-        return outputs
+        return (outputs, total)
+    }
+
+    /// The full, ordered Core output list for the `coreToCore` flow:
+    /// the PRIMARY row (`recipientAddress` + `amountDuffs`) followed by
+    /// each `additionalCoreRecipients` row, in display order. `nil` when
+    /// the batch isn't fully valid — see `coreRecipientPlan`.
+    var coreRecipients: [(address: String, amountDuffs: UInt64)]? {
+        coreRecipientPlan?.outputs
     }
 
     /// Sum of every valid Core output (primary + additional), in duffs —
     /// the "Total" shown in the multi-output summary. Returns 0 when the
-    /// batch isn't fully valid (`coreRecipients` is `nil`), matching the
-    /// disabled-Send state so the summary never shows a total for a batch
-    /// that can't be sent.
+    /// batch isn't fully valid (`coreRecipientPlan` is `nil`, including the
+    /// overflow case), matching the disabled-Send state so the summary
+    /// never shows a total for a batch that can't be sent. Computed with
+    /// checked addition (no bare `+`) in `coreRecipientPlan`.
     var coreSendTotalDuffs: UInt64 {
-        coreRecipients?.reduce(0) { $0 + $1.amountDuffs } ?? 0
+        coreRecipientPlan?.total ?? 0
     }
 
     /// Whether a trimmed string parses as a `.core` address on this

--- a/packages/swift-sdk/SwiftExampleApp/SwiftExampleApp/Core/ViewModels/SendViewModel.swift
+++ b/packages/swift-sdk/SwiftExampleApp/SwiftExampleApp/Core/ViewModels/SendViewModel.swift
@@ -81,6 +81,19 @@ enum FundSource: String, CaseIterable, Identifiable {
 
 import SwiftUI
 
+/// One *extra* Core output row beyond the primary recipient. The
+/// primary recipient stays on `recipientAddress` / `amountString` (it
+/// drives `detectAddressType()` → `detectedFlow`, i.e. the Core /
+/// Platform / Shielded routing); these are the additional outputs that
+/// only the multi-recipient `coreToCore` flow appends. `id` is a stable
+/// identity for `ForEach`/`@Published` diffing; `Equatable` keeps the
+/// array cheap to diff.
+struct CoreRecipient: Identifiable, Equatable {
+    let id = UUID()
+    var address: String = ""
+    var amountString: String = ""
+}
+
 /// ViewModel for the Send Transaction screen.
 @MainActor
 class SendViewModel: ObservableObject {
@@ -88,6 +101,11 @@ class SendViewModel: ObservableObject {
         didSet { detectAddressType() }
     }
     @Published var amountString = ""
+    /// Extra Core outputs beyond the primary recipient. Only populated
+    /// (and only consulted) on the `coreToCore` flow — every other flow
+    /// ignores it. Empty by default so the screen looks identical to the
+    /// single-recipient form until the user taps "Add recipient".
+    @Published var additionalCoreRecipients: [CoreRecipient] = []
     /// Optional UTF-8 memo for a shielded → shielded transfer. Only
     /// surfaced when the recipient is an Orchard address; Rust caps it
     /// at 32 UTF-8 bytes and does the 36-byte encoding.
@@ -129,6 +147,88 @@ class SendViewModel: ObservableObject {
     /// (Core uses duffs; Platform / shielded use credits).
     var amountDuffs: UInt64? { amount }
 
+    // MARK: - Multi-recipient (coreToCore only)
+
+    /// Append an empty extra Core output. The Rust coin-selector handles
+    /// however many outputs we hand it, so there's no UI-side cap.
+    func addCoreRecipient() {
+        additionalCoreRecipients.append(CoreRecipient())
+    }
+
+    /// Remove the extra output with the given identity. No-op if it was
+    /// already removed (e.g. a double-tap on the delete control).
+    func removeCoreRecipient(_ id: CoreRecipient.ID) {
+        additionalCoreRecipients.removeAll { $0.id == id }
+    }
+
+    /// Parse one extra row's amount to duffs through the same
+    /// `Decimal`-backed path as the primary `amount` (1 DASH = 1e8). Kept
+    /// as a single helper so every Core output — primary and extra — is
+    /// scaled identically; reinventing the decimal parse per row would
+    /// risk a row that rounds differently than the summary total.
+    func duffs(forRecipientAmount amountString: String) -> UInt64? {
+        parseTokenAmount(amountString, decimals: 8)
+    }
+
+    /// The full, ordered Core output list for the `coreToCore` flow:
+    /// the PRIMARY row (`recipientAddress` + `amountDuffs`) followed by
+    /// each `additionalCoreRecipients` row, in display order. Returns
+    /// `nil` if ANY row is invalid so callers (gating + send) treat the
+    /// batch atomically — a single bad extra row blocks the whole send
+    /// rather than silently dropping that output.
+    ///
+    /// "Valid" per row = the address parses as a `.core` address on
+    /// `self.network` (same `DashAddress.parse` the primary row's
+    /// detection uses, so a Platform/Orchard string in an extra row is
+    /// rejected here) AND its duffs amount is `> 0` (a sub-unit amount
+    /// scales to 0 and would reach Rust as a zero-value output).
+    var coreRecipients: [(address: String, amountDuffs: UInt64)]? {
+        var outputs: [(address: String, amountDuffs: UInt64)] = []
+
+        // Primary row. The trim mirrors the existing `.coreToCore` send
+        // case so the marshalled address matches what the badge validated.
+        let primaryAddress = recipientAddress
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        guard isCoreAddress(primaryAddress),
+              let primaryDuffs = amountDuffs, primaryDuffs > 0
+        else { return nil }
+        outputs.append((address: primaryAddress, amountDuffs: primaryDuffs))
+
+        // Extra rows, in order.
+        for row in additionalCoreRecipients {
+            let address = row.address
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+            guard isCoreAddress(address),
+                  let rowDuffs = duffs(forRecipientAmount: row.amountString),
+                  rowDuffs > 0
+            else { return nil }
+            outputs.append((address: address, amountDuffs: rowDuffs))
+        }
+
+        return outputs
+    }
+
+    /// Sum of every valid Core output (primary + additional), in duffs —
+    /// the "Total" shown in the multi-output summary. Returns 0 when the
+    /// batch isn't fully valid (`coreRecipients` is `nil`), matching the
+    /// disabled-Send state so the summary never shows a total for a batch
+    /// that can't be sent.
+    var coreSendTotalDuffs: UInt64 {
+        coreRecipients?.reduce(0) { $0 + $1.amountDuffs } ?? 0
+    }
+
+    /// Whether a trimmed string parses as a `.core` address on this
+    /// view model's network. Wraps the same `DashAddress.parse` the
+    /// primary-row detection uses so Core-address validity is judged
+    /// identically for every output.
+    private func isCoreAddress(_ trimmed: String) -> Bool {
+        guard !trimmed.isEmpty else { return false }
+        if case .core = DashAddress.parse(trimmed, network: network).type {
+            return true
+        }
+        return false
+    }
+
     /// Minimum L1 lock size (in duffs) for a `coreToShielded` send.
     /// Mirrors `ShieldedFundFromAssetLockView.minDuffs` (1 mDASH): an
     /// asset lock smaller than the Platform pool fee would build a lock
@@ -167,7 +267,14 @@ class SendViewModel: ObservableObject {
         // credits-ledger flow settles in credits (1e11).
         switch flow {
         case .coreToCore:
-            return (amountDuffs ?? 0) > 0
+            // Gate on the *whole* batch, not just the primary row: the
+            // multi-output send is atomic (one tx), so every extra row's
+            // address must be a Core address on-network and every extra
+            // amount > 0. `coreRecipients` already encodes "all rows
+            // valid (incl. the primary's amountDuffs > 0), else nil", so a
+            // non-nil list means the batch is sendable. With zero extra
+            // rows this reduces to the prior primary-only check.
+            return coreRecipients != nil
         case .coreToShielded:
             // Funded by an L1 asset lock denominated in duffs; gate on
             // the lock floor so a doomed (sub-fee) amount can't kick off
@@ -302,19 +409,26 @@ class SendViewModel: ObservableObject {
         do {
             switch flow {
             case .coreToCore:
-                guard let amountDuffs else {
-                    error = "Invalid amount"
-                    return
-                }
                 guard let core = coreWallet else {
                     error = "Core wallet not available"
                     return
                 }
-                let address = recipientAddress.trimmingCharacters(in: .whitespacesAndNewlines)
-                let _ = try core.sendToAddresses(
-                    recipients: [(address: address, amountDuffs: amountDuffs)]
-                )
-                successMessage = "Payment sent"
+                // Build the ordered output list (primary + any extra
+                // rows). `coreRecipients` is nil unless every row is a
+                // valid on-network Core address with a > 0 duffs amount —
+                // the same condition `canSend` gates on, re-checked here
+                // so a stale enabled-Send tap can't slip an invalid batch
+                // through. Coin selection + multi-output tx building are
+                // entirely Rust-side; we only marshal the parallel
+                // address/amount arrays into `sendToAddresses`.
+                guard let recipients = coreRecipients else {
+                    error = "Invalid recipient or amount"
+                    return
+                }
+                let _ = try core.sendToAddresses(recipients: recipients)
+                successMessage = recipients.count > 1
+                    ? "Payment sent to \(recipients.count) recipients"
+                    : "Payment sent"
 
             case .platformToPlatform:
                 guard let addressWallet = platformAddressWallet else {

--- a/packages/swift-sdk/SwiftExampleApp/SwiftExampleApp/Core/Views/SendTransactionView.swift
+++ b/packages/swift-sdk/SwiftExampleApp/SwiftExampleApp/Core/Views/SendTransactionView.swift
@@ -112,6 +112,18 @@ struct SendTransactionView: View {
                     }
                 }
 
+                // Additional recipients (Core → Core only). A standard
+                // L1 tx can pay any number of outputs in one transaction;
+                // the Rust coin-selector builds the multi-output tx, so
+                // this is purely extra address/amount input rows. Hidden
+                // for every other flow — shield / platform / unshield all
+                // remain single-recipient. The primary row above still
+                // drives `detectedFlow`, so this section only appears once
+                // that row resolves to a Core address with a Core source.
+                if viewModel.detectedFlow == .coreToCore {
+                    additionalRecipientsSection
+                }
+
                 // Memo (shielded → shielded only). The on-chain note
                 // carries an optional 32-byte UTF-8 memo. Gate on the
                 // flow, not the recipient type: an Orchard recipient
@@ -183,6 +195,17 @@ struct SendTransactionView: View {
                             }
                         }
                     }
+                }
+
+                // Per-output summary (Core → Core, multi-output only).
+                // `coreRecipients` is the same ordered, fully-validated
+                // list `executeSend` marshals, so the summary can't show
+                // a row the send wouldn't include. Only rendered with >1
+                // output — the single-output case is already covered by
+                // the "Transaction Type" / "Estimated Fee" section above.
+                if viewModel.detectedFlow == .coreToCore,
+                   let outputs = viewModel.coreRecipients, outputs.count > 1 {
+                    coreOutputsSummarySection(outputs: outputs)
                 }
 
             }
@@ -289,6 +312,90 @@ struct SendTransactionView: View {
                 }
             }
         }
+    }
+
+    // MARK: - Multi-recipient sections (Core → Core)
+
+    /// The extra-output input rows plus the "Add recipient" button.
+    /// Split out of `body` so the type-checker doesn't have to solve the
+    /// whole Form in one pass — the per-row editor is a separate
+    /// `CoreRecipientRow` subview for the same reason. Iterates over a
+    /// `$`-binding so each row's edits flow straight back into
+    /// `viewModel.additionalCoreRecipients`.
+    @ViewBuilder
+    private var additionalRecipientsSection: some View {
+        Section("Additional Recipients") {
+            ForEach($viewModel.additionalCoreRecipients) { $recipient in
+                CoreRecipientRow(
+                    recipient: $recipient,
+                    network: wallet.network ?? .testnet,
+                    onRemove: { viewModel.removeCoreRecipient(recipient.id) }
+                )
+            }
+
+            Button {
+                viewModel.addCoreRecipient()
+            } label: {
+                Label("Add recipient", systemImage: "plus.circle.fill")
+            }
+            // `.borderless` so only the label is the tap target inside the
+            // Form row, matching the QR button on the primary recipient.
+            .buttonStyle(.borderless)
+        }
+    }
+
+    /// Per-output breakdown + Total + Fee for a multi-output Core send.
+    /// `outputs` is the already-validated `coreRecipients` list, so each
+    /// row's amount is a real duffs value. Total is the sum of outputs;
+    /// the fee reuses `viewModel.estimatedFee` rendered in the
+    /// `.coreToCore` fee unit (duffs per `feeUnit(for:)`).
+    @ViewBuilder
+    private func coreOutputsSummarySection(
+        outputs: [(address: String, amountDuffs: UInt64)]
+    ) -> some View {
+        Section("Outputs") {
+            ForEach(Array(outputs.enumerated()), id: \.offset) { _, output in
+                HStack {
+                    Text(abbreviatedAddress(output.address))
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                        .lineLimit(1)
+                        .truncationMode(.middle)
+                    Spacer()
+                    Text(formatBalance(output.amountDuffs, unit: .duffs))
+                        .font(.caption)
+                }
+            }
+
+            HStack {
+                Text("Total:")
+                    .fontWeight(.medium)
+                Spacer()
+                Text(formatBalance(viewModel.coreSendTotalDuffs, unit: .duffs))
+                    .fontWeight(.medium)
+            }
+
+            if let fee = viewModel.estimatedFee {
+                HStack {
+                    Text("Estimated Fee:")
+                    Spacer()
+                    // coreToCore fee is denominated in duffs (see
+                    // feeUnit(for:)); reuse the same formatter as the
+                    // single-output fee row.
+                    Text("~\(formatBalance(fee, unit: .duffs))")
+                        .foregroundColor(.secondary)
+                }
+            }
+        }
+    }
+
+    /// Middle-truncate a Core address for the compact summary rows so a
+    /// long base58 string doesn't blow out the row width. Short addresses
+    /// (shouldn't happen for valid Core addresses, but be safe) are shown
+    /// whole.
+    private func abbreviatedAddress(_ address: String) -> String {
+        guard address.count > 16 else { return address }
+        return "\(address.prefix(8))…\(address.suffix(6))"
     }
 
     // MARK: - Computed
@@ -407,6 +514,74 @@ struct SendTransactionView: View {
 }
 
 // MARK: - Subviews
+
+/// One extra Core output editor: an address field + amount field +
+/// remove control, with a per-row Core badge / inline invalid hint that
+/// mirrors the primary recipient's `AddressTypeBadge`. Factored out of
+/// `SendTransactionView.body` to keep the Form's type-check tractable
+/// (the surrounding view already drives the compiler hard). Holds no
+/// state of its own — the `recipient` binding writes straight back into
+/// the view model's `additionalCoreRecipients` array, and validity is
+/// re-parsed here only for the inline hint (the authoritative gate is
+/// the view model's `coreRecipients`).
+private struct CoreRecipientRow: View {
+    @Binding var recipient: CoreRecipient
+    let network: Network
+    let onRemove: () -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            HStack(spacing: 8) {
+                TextField("Recipient Address", text: $recipient.address)
+                    .textInputAutocapitalization(.never)
+                    .autocorrectionDisabled()
+                Button(role: .destructive, action: onRemove) {
+                    Image(systemName: "minus.circle.fill")
+                        .foregroundColor(.red)
+                }
+                // `.borderless` so the delete control doesn't make the
+                // whole row tappable and swallow text-field taps — same
+                // reason the primary row's QR button uses it.
+                .buttonStyle(.borderless)
+                .accessibilityLabel("Remove recipient")
+            }
+
+            HStack {
+                TextField("0.00000000", text: $recipient.amountString)
+                    .keyboardType(.decimalPad)
+                Text("DASH")
+                    .foregroundColor(.secondary)
+            }
+
+            // Inline validity hint: show the Core badge once the address
+            // resolves on this network, otherwise a red hint so the user
+            // sees *which* extra row is blocking Send. Empty address shows
+            // nothing (the row is simply incomplete, not wrong).
+            if !recipient.address.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                if isCoreAddress {
+                    AddressTypeBadge(type: .core(Data()))
+                } else {
+                    Text("Not a Core address on this network")
+                        .font(.caption)
+                        .foregroundColor(.red)
+                }
+            }
+        }
+    }
+
+    /// Whether this row's trimmed address parses as a `.core` address on
+    /// `network` — same `DashAddress.parse` the view model gates on, so
+    /// the hint can't disagree with the Send button.
+    private var isCoreAddress: Bool {
+        let trimmed = recipient.address
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return false }
+        if case .core = DashAddress.parse(trimmed, network: network).type {
+            return true
+        }
+        return false
+    }
+}
 
 private struct AddressTypeBadge: View {
     let type: DashAddressType

--- a/packages/swift-sdk/SwiftExampleApp/SwiftExampleAppTests/SendViewModelCoreRecipientsTests.swift
+++ b/packages/swift-sdk/SwiftExampleApp/SwiftExampleAppTests/SendViewModelCoreRecipientsTests.swift
@@ -1,0 +1,189 @@
+import XCTest
+import SwiftDashSDK
+@testable import SwiftExampleApp
+
+/// Behavioral tests for `SendViewModel`'s multi-recipient Core batch —
+/// the pure view-model logic behind the `coreToCore` send screen
+/// (`coreRecipients`, `coreSendTotalDuffs`, `canSend`, and the add/remove
+/// of extra output rows).
+///
+/// These are pure view-model tests: no network, no FFI send. Address
+/// validity runs through `DashAddress.parse` → `Address.validate` (Rust
+/// FFI), which is pure/offline and links fine in the test bundle (other
+/// suites already exercise the SDK). Everything uses `Network.testnet`.
+///
+/// `SendViewModel` is `@MainActor`, so the suite is too.
+@MainActor
+final class SendViewModelCoreRecipientsTests: XCTestCase {
+
+    // Two verified testnet P2PKH (base58check) Core addresses.
+    private let primaryAddress = "yX6nLg4fVSdkecziwJmkeLrVLqDUivHmnh"
+    private let extraAddress = "yW2nW3XsoYRfcJV6QgcAXvdWTUorkjgsNQ"
+    private let network: Network = .testnet
+
+    /// Build a view model already routed onto the `coreToCore` flow with
+    /// `primaryAddress` as the primary recipient. Mirrors how the app
+    /// drives it: set the recipient (which runs `detectAddressType`) and
+    /// the source, then `updateFlow()`.
+    private func makeCoreToCoreViewModel(
+        primaryAmount: String
+    ) -> SendViewModel {
+        let vm = SendViewModel(network: network)
+        vm.recipientAddress = primaryAddress
+        vm.amountString = primaryAmount
+        vm.selectedSource = .core
+        vm.updateFlow()
+        return vm
+    }
+
+    // MARK: - Sanity: the fixtures really are Core addresses on testnet
+
+    func test_fixtureAddresses_areTestnetCore() {
+        if case .core = DashAddress.parse(primaryAddress, network: network).type {} else {
+            XCTFail("primary fixture should be a testnet Core address")
+        }
+        if case .core = DashAddress.parse(extraAddress, network: network).type {} else {
+            XCTFail("extra fixture should be a testnet Core address")
+        }
+    }
+
+    func test_makeViewModel_routesToCoreToCore() {
+        // If the flow isn't `.coreToCore`, every gating assertion below is
+        // meaningless (the multi-recipient list is only consulted there).
+        let vm = makeCoreToCoreViewModel(primaryAmount: "0.001")
+        XCTAssertEqual(vm.detectedFlow, .coreToCore)
+    }
+
+    // MARK: - 1. Primary-only (no extra rows)
+
+    func test_primaryOnly_singleOutputAndTotal() {
+        let vm = makeCoreToCoreViewModel(primaryAmount: "0.001")
+
+        let recipients = vm.coreRecipients
+        XCTAssertEqual(recipients?.count, 1)
+        XCTAssertEqual(recipients?.first?.address, primaryAddress)
+        XCTAssertEqual(recipients?.first?.amountDuffs, 100_000) // 0.001 * 1e8
+
+        // Total equals the single output; Send is enabled.
+        XCTAssertEqual(vm.coreSendTotalDuffs, 100_000)
+        XCTAssertTrue(vm.canSend)
+    }
+
+    // MARK: - 2. Primary + extras ordering
+
+    func test_primaryPlusExtras_orderedOutputsAndSummedTotal() {
+        let vm = makeCoreToCoreViewModel(primaryAmount: "0.001") // 100_000
+
+        vm.addCoreRecipient()
+        vm.additionalCoreRecipients[0].address = extraAddress
+        vm.additionalCoreRecipients[0].amountString = "0.002" // 200_000
+
+        vm.addCoreRecipient()
+        vm.additionalCoreRecipients[1].address = primaryAddress
+        vm.additionalCoreRecipients[1].amountString = "0.003" // 300_000
+
+        let recipients = vm.coreRecipients
+        XCTAssertEqual(recipients?.count, 3)
+        // Display order: primary first, then extras in row order.
+        XCTAssertEqual(recipients?[0].address, primaryAddress)
+        XCTAssertEqual(recipients?[0].amountDuffs, 100_000)
+        XCTAssertEqual(recipients?[1].address, extraAddress)
+        XCTAssertEqual(recipients?[1].amountDuffs, 200_000)
+        XCTAssertEqual(recipients?[2].address, primaryAddress)
+        XCTAssertEqual(recipients?[2].amountDuffs, 300_000)
+
+        XCTAssertEqual(vm.coreSendTotalDuffs, 600_000)
+        XCTAssertTrue(vm.canSend)
+    }
+
+    // MARK: - 3. Invalid extra address → whole batch invalid
+
+    func test_invalidExtraAddress_invalidatesBatch() {
+        let vm = makeCoreToCoreViewModel(primaryAmount: "0.001")
+
+        vm.addCoreRecipient()
+        // Not a Core address (garbage / wrong type).
+        vm.additionalCoreRecipients[0].address = "not-a-real-address"
+        vm.additionalCoreRecipients[0].amountString = "0.002"
+
+        XCTAssertNil(vm.coreRecipients)
+        XCTAssertFalse(vm.canSend)
+        // A nil batch shows no total, matching the disabled-Send state.
+        XCTAssertEqual(vm.coreSendTotalDuffs, 0)
+    }
+
+    // MARK: - 4. Sub-unit / zero amount in a row → batch invalid
+
+    func test_subUnitExtraAmount_invalidatesBatch() {
+        let vm = makeCoreToCoreViewModel(primaryAmount: "0.001")
+
+        vm.addCoreRecipient()
+        vm.additionalCoreRecipients[0].address = extraAddress
+        // 0.000000001 DASH * 1e8 = 0.1 → truncates to 0 duffs.
+        vm.additionalCoreRecipients[0].amountString = "0.000000001"
+
+        XCTAssertNil(vm.coreRecipients)
+        XCTAssertFalse(vm.canSend)
+        XCTAssertEqual(vm.coreSendTotalDuffs, 0)
+    }
+
+    func test_emptyExtraAmount_invalidatesBatch() {
+        let vm = makeCoreToCoreViewModel(primaryAmount: "0.001")
+
+        vm.addCoreRecipient()
+        vm.additionalCoreRecipients[0].address = extraAddress
+        vm.additionalCoreRecipients[0].amountString = "" // unparseable → nil duffs
+
+        XCTAssertNil(vm.coreRecipients)
+        XCTAssertFalse(vm.canSend)
+        XCTAssertEqual(vm.coreSendTotalDuffs, 0)
+    }
+
+    // MARK: - 5. Aggregate overflow → batch invalid (never traps)
+
+    func test_aggregateOverflow_invalidatesBatchWithoutTrapping() {
+        // Each row scales to 1e11 DASH * 1e8 = 1e19 duffs, which is below
+        // UInt64.max (~1.8446744e19) so each parses to a valid UInt64 on
+        // its own. Two of them sum to 2e19, which overflows UInt64 — the
+        // batch must be rejected (nil), and the total must be 0 rather
+        // than trapping/wrapping when the summary renders.
+        let huge = "100000000000" // 1e11 DASH
+
+        // Pre-flight: a single huge row is individually valid (it does NOT
+        // already overflow on its own), so the rejection below is genuinely
+        // the *aggregate* overflow path, not a per-row range failure.
+        let single = makeCoreToCoreViewModel(primaryAmount: huge)
+        XCTAssertEqual(single.coreRecipients?.count, 1)
+        XCTAssertEqual(single.coreSendTotalDuffs, 10_000_000_000_000_000_000) // 1e19
+
+        let vm = makeCoreToCoreViewModel(primaryAmount: huge)
+        vm.addCoreRecipient()
+        vm.additionalCoreRecipients[0].address = extraAddress
+        vm.additionalCoreRecipients[0].amountString = huge
+
+        XCTAssertNil(vm.coreRecipients)
+        XCTAssertEqual(vm.coreSendTotalDuffs, 0)
+        XCTAssertFalse(vm.canSend)
+    }
+
+    // MARK: - 6. Removal returns to the primary-only list
+
+    func test_removeExtra_returnsToPrimaryOnly() {
+        let vm = makeCoreToCoreViewModel(primaryAmount: "0.001")
+
+        vm.addCoreRecipient()
+        vm.additionalCoreRecipients[0].address = extraAddress
+        vm.additionalCoreRecipients[0].amountString = "0.002"
+        XCTAssertEqual(vm.coreRecipients?.count, 2)
+        XCTAssertEqual(vm.coreSendTotalDuffs, 300_000)
+
+        let id = vm.additionalCoreRecipients[0].id
+        vm.removeCoreRecipient(id)
+
+        XCTAssertTrue(vm.additionalCoreRecipients.isEmpty)
+        XCTAssertEqual(vm.coreRecipients?.count, 1)
+        XCTAssertEqual(vm.coreRecipients?.first?.address, primaryAddress)
+        XCTAssertEqual(vm.coreSendTotalDuffs, 100_000)
+        XCTAssertTrue(vm.canSend)
+    }
+}

--- a/packages/swift-sdk/SwiftExampleApp/TEST_PLAN.md
+++ b/packages/swift-sdk/SwiftExampleApp/TEST_PLAN.md
@@ -115,7 +115,7 @@ Most Platform actions have hard preconditions. Establish these fixtures before s
 | CORE-07 | SPV sync (start / stop / progress) | Core | Essential | ✅ | Global sync indicator (`ContentView`) → `platform_wallet_manager_spv_*`. Headers/filters/masternodes advance to tip. |
 | CORE-08 | QR scan recipient | Core | Manual | ✅ | `QRScannerView`, reachable in the Send flow — but scanning needs a real camera the simulator doesn't have, so it can't be automated (`Tier=Manual`). On a device: Send → QR-scan button → point at a Dash address QR → recipient field populates. |
 | CORE-09 | Multiple HD accounts (within one wallet) | Core | Common | ✅ | Account selection / `AccountDetailView`; balances per `account_index`. Distinct from holding multiple *wallets* — see CORE-14+. |
-| CORE-10 | Multi-recipient Core send | Core | Common | 🔌 | FFI `core_wallet_send_to_addresses` takes parallel address/amount arrays; UI is single-recipient — verify before claiming. |
+| CORE-10 | Multi-recipient Core send | Core | Common | ✅ | Send flow (`SendTransactionView`, Core→Core) → "Add recipient" appends extra address/amount rows → `SendViewModel.coreRecipients` → `core_wallet_send_to_addresses` (parallel arrays; Rust coin-selects + builds the multi-output tx). One tx with N outputs; balance drops by sum+fee. Verified: 2-output testnet send (txid `30010050…17f840fc`, txlock, 3 vouts) credited both recipients. |
 | CORE-11 | Custom fee on transparent send | Core | Uncommon | 🚫 | Not exposed on the transparent send path (custom Core fee only on shielded withdraw `SH-08` and platform-address funding). |
 | CORE-12 | CoinJoin / mixing | Core | Uncommon | 🚫 | Not implemented anywhere (SPV crate or FFI). |
 | CORE-13 | Send explicitly via InstantSend | Core | Uncommon | 🚫 | IS is observe-only (used to obtain asset-lock proofs); no user-facing send toggle. |
@@ -470,7 +470,6 @@ The complete Platform read surface, mapped to where each RPC is exercised in the
 For completeness (the "everything gRPC + Core can do" requirement), these exist at the protocol/FFI level but have **no app entry point** today:
 
 **🔌 SDK-only (FFI/wrapper exists, no UI):**
-- `CORE-10` multi-recipient Core send (FFI supports arrays; UI single-recipient)
 - `ADDR-05` address balance-change history (recent / compacted / branch / trunk)
 - `DOC-08` document count / sum / average aggregation
 - `TOK-17` calculate token ID


### PR DESCRIPTION
## Issue being fixed or feature implemented

Test-plan item **CORE-10 (Multi-recipient Core send)** — tracked in #3897 — was marked 🔌 *"SDK-only, no UI"*. The Core→Core send flow only let you pay a **single** recipient, even though the FFI `core_wallet_send_to_addresses` (via the `ManagedCoreWallet.sendToAddresses(recipients:)` wrapper) already takes **parallel address/amount arrays**, and coin selection + multi-output tx construction already happen entirely on the Rust side. This surfaces that capability in the UI.

## What was done?

A **UI + marshalling-only** change — no new FFI, no logic moved into Swift (per `packages/swift-sdk/CLAUDE.md`). Swift just collects N `(address, amount)` pairs and passes them through the existing wrapper.

**`SendViewModel`**
- Added a `CoreRecipient` row value type + `@Published additionalCoreRecipients`, with `addCoreRecipient` / `removeCoreRecipient`.
- `coreRecipients` builds the ordered `[(address, amountDuffs)]` list (primary row + extras) and returns `nil` unless **every** row is a valid on-network Core address with amount > 0 — so the batch is validated atomically. `coreSendTotalDuffs` sums it for the summary.
- `canSend` (`.coreToCore`) and the `.coreToCore` branch of `executeSend` now build from `coreRecipients` and pass the array straight to `sendToAddresses(recipients:)`. The success message reflects the output count (`"Payment sent to N recipients"`). Every other flow (shielded / platform / coreToShielded …) is byte-for-byte unchanged.

**`SendTransactionView`**
- An "Additional Recipients" section with an **"Add recipient"** button, shown only for the `coreToCore` flow; each extra row has its own address + amount fields, a remove control, and a per-row Core-address badge / inline "Not a Core address on this network" hint.
- An **"Outputs"** summary (each output + **Total** + **Fee**) rendered when there is more than one recipient. The single-recipient case is unchanged and remains the simple default.

**`TEST_PLAN.md`**
- CORE-10 flipped 🔌 → ✅ with the entry point; removed from the Appendix B "SDK-only, no UI" list.

## How Has This Been Tested?

Built with `packages/swift-sdk/build_ios.sh --target sim` + `xcodebuild` (BUILD SUCCEEDED), then driven end-to-end on a booted **iPhone 17 / testnet** simulator (`simulator-control` skill / `idb`):

- Sent **0.001 + 0.002 DASH** from `TestnetWallet` to two external addresses (a second on-device wallet) in **one** transaction. Success alert read *"Payment sent to 2 recipients"*.
- On-chain ([`insight.testnet`](https://insight.testnet.networks.dash.org/insight-api/tx/30010050ce9f4f96b6a05ad8d7ab6bacde26b95cacdb98d9e0b0a72c17f840fc)): txid `30010050…17f840fc`, block **1,495,895**, `txlock: true`, **3 vouts** — `0.001 → recipient A`, `0.002 → recipient B`, `0.811… → change`. One input → one tx.
- Sender confirmed balance dropped `1.81473134 → 1.81172874 DASH` = **sum (300,000) + fee (260 duffs)**.
- Both recipients credited after sync (recipient wallet: **2 UTXOs = 300,000 duffs**).
- Incidental: per-row validation correctly flagged a malformed address and disabled Send; Remove recipient works.

Full write-up posted to #3897.

## Breaking Changes

None. UI-only addition; the FFI/wrapper signature was already array-based and is unchanged.

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [x] I have made corresponding changes to the documentation if needed

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enabled multi-recipient “Core to Core” sends in a single transaction.
  * Added an “Additional Recipients” section to add/remove extra recipients.
  * Added an “Outputs” summary showing each address/amount, plus total and estimated fee when available.

* **Bug Fixes**
  * Improved send eligibility for multi-recipient batches to require all entries be valid.

* **Tests**
  * Added offline test coverage for multi-recipient validation, ordering, overflow handling, and removal behavior.

* **Documentation**
  * Updated the Core/Wallet catalog and action availability notes to reflect the new multi-recipient send.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->