### PR TITLE
fix(swift-example-app): harden Withdraw Credits amount + address validation

### DIFF
--- a/packages/swift-sdk/SwiftExampleApp/SwiftExampleApp/Views/WithdrawCreditsView.swift
+++ b/packages/swift-sdk/SwiftExampleApp/SwiftExampleApp/Views/WithdrawCreditsView.swift
@@ -133,6 +133,11 @@ struct WithdrawCreditsView: View {
                     .textInputAutocapitalization(.never)
                     .autocorrectionDisabled(true)
                     .disabled(isSubmitting)
+                if !trimmedAddress.isEmpty && !isValidDestinationAddress {
+                    Text("Not a valid \(identity.network.displayName) Dash address.")
+                        .font(.caption)
+                        .foregroundColor(.red)
+                }
             } else {
                 Text("The wallet that owns this identity isn't loaded.")
                     .font(.subheadline)
@@ -255,7 +260,11 @@ struct WithdrawCreditsView: View {
             return nil
         }
         let credits = (dash * Double(Self.creditsPerDash)).rounded()
-        guard credits >= 1, credits <= Double(UInt64.max) else { return nil }
+        // Strict `<`: `Double(UInt64.max)` isn't exactly representable and
+        // rounds up to 2^64, so a `<=` bound would admit 2^64 and trap on
+        // the `UInt64(credits)` cast (this recomputes on every keystroke,
+        // before submit-time re-validation). `<` keeps it in range.
+        guard credits >= 1, credits < Double(UInt64.max) else { return nil }
         return UInt64(credits)
     }
 
@@ -265,8 +274,22 @@ struct WithdrawCreditsView: View {
         identity.balance < 0 ? 0 : UInt64(identity.balance)
     }
 
+    /// Local pre-validation of the destination so the submit button
+    /// doesn't light up for obviously malformed / wrong-network strings.
+    /// Uses the existing `DashAddress.parse` bridge (Base58Check + network
+    /// check in Rust); a `.core` result is a valid L1 address on this
+    /// identity's network. Authoritative validation still happens in Rust
+    /// on submit — this only tightens the UI.
+    private var isValidDestinationAddress: Bool {
+        guard !trimmedAddress.isEmpty else { return false }
+        if case .core = DashAddress.parse(trimmedAddress, network: identity.network).type {
+            return true
+        }
+        return false
+    }
+
     private var canSubmit: Bool {
-        !trimmedAddress.isEmpty
+        isValidDestinationAddress
             && managedWallet != nil
             && (parsedCredits.map { $0 > 0 && $0 <= senderBalanceCredits } ?? false)
     }
@@ -281,7 +304,7 @@ struct WithdrawCreditsView: View {
         let address = trimmedAddress
         guard
             let wallet = managedWallet,
-            !address.isEmpty,
+            isValidDestinationAddress,
             let credits = parsedCredits,
             credits > 0,
             credits <= senderBalanceCredits


### PR DESCRIPTION
## Issue being fixed or feature implemented

Follow-up to #3906 (Withdraw Credits production UI, ID-10), which merged before review feedback from `thepastaclaw` was addressed. Two issues in `WithdrawCreditsView`:

- 🔴 **Blocking — `parsedCredits` could crash on large input.** `Double(UInt64.max)` isn't exactly representable and rounds **up** to 2^64, so the `credits <= Double(UInt64.max)` guard admitted 2^64 and `UInt64(credits)` trapped. `parsedCredits` recomputes on every keystroke (before submit-time re-validation), so an amount scaling to ~2^64 credits would crash the sheet on input rather than show a friendly error. (Same shape exists in the merged `TransferCreditsView.parsedCredits` — flagged separately as a follow-up.)
- 🟡 **UX — submit enabled for any non-empty destination.** The button lit up for malformed / wrong-network addresses; the user only learned otherwise after the Rust round-trip.

## What was done?

- **`parsedCredits`:** switched the upper bound to strict `<` so 2^64 is rejected and the `UInt64` cast stays in range.
- **Destination validation:** added `isValidDestinationAddress`, which uses the existing `DashAddress.parse(_, network:)` bridge (Base58Check + network validation in Rust) and accepts a `.core` (L1) result. `canSubmit` and the `submit()` guard now require a valid address, and an inline "Not a valid <network> Dash address" hint explains the disabled state. No consensus logic added to Swift — authoritative validation still runs in Rust on submit, matching the file header.

## How Has This Been Tested?

`./build_ios.sh`-equivalent app build succeeds (0 errors, 0 code warnings). Driven on the simulator (devnet):
- Invalid destination → submit stays **disabled** + inline hint shown.
- Amount of 2×10⁸ DASH (huge) → sheet no longer crashes; button stays disabled.

## Breaking Changes

None. UI-only validation hardening in the example app.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any (n/a)
- [x] I have made corresponding changes to the documentation if needed (n/a)

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone

🤖 Generated with [Claude Code](https://claude.com/claude-code)