### PR TITLE
fix(swift-example-app): prevent UInt64.max overflow crash in TransferCreditsView amount parsing

### DIFF
--- a/packages/swift-sdk/SwiftExampleApp/SwiftExampleApp/Views/TransferCreditsView.swift
+++ b/packages/swift-sdk/SwiftExampleApp/SwiftExampleApp/Views/TransferCreditsView.swift
@@ -224,7 +224,11 @@ struct TransferCreditsView: View {
             return nil
         }
         let credits = (dash * Double(Self.creditsPerDash)).rounded()
-        guard credits >= 1, credits <= Double(UInt64.max) else { return nil }
+        // Strict `<`: `Double(UInt64.max)` isn't exactly representable and
+        // rounds up to 2^64, so a `<=` bound would admit 2^64 and trap on
+        // the `UInt64(credits)` cast (this recomputes on every keystroke,
+        // before submit-time re-validation). `<` keeps it in range.
+        guard credits >= 1, credits < Double(UInt64.max) else { return nil }
         return UInt64(credits)
     }
 


### PR DESCRIPTION
## Issue being fixed or feature implemented

`TransferCreditsView.parsedCredits` had a crash-class bug identical to the one fixed in `WithdrawCreditsView` ([#3907](https://github.com/dashpay/platform/pull/3907)).

It guarded the scaled credit amount with:

```swift
let credits = (dash * Double(Self.creditsPerDash)).rounded()
guard credits >= 1, credits <= Double(UInt64.max) else { return nil }
return UInt64(credits)
```

`Double(UInt64.max)` is not exactly representable and rounds **up** to 2^64, so the `<=` guard admitted a value (2^64) one above `UInt64`'s representable range, and `UInt64(credits)` then trapped. Because `parsedCredits` recomputes on every keystroke (before any submit-time re-validation), a user typing a DASH amount that scales to ~2^64 credits (input around 1.844e8 DASH) crashed the Transfer Credits sheet on input instead of producing a friendly disabled-button state.

## What was done?

Changed the upper bound to a strict `<` so 2^64 is rejected and the `UInt64(credits)` cast stays in range, with a comment explaining why. This mirrors the exact fix applied to `WithdrawCreditsView` in [#3907](https://github.com/dashpay/platform/pull/3907).

```swift
// Strict `<`: `Double(UInt64.max)` isn't exactly representable and
// rounds up to 2^64, so a `<=` bound would admit 2^64 and trap on
// the `UInt64(credits)` cast (this recomputes on every keystroke,
// before submit-time re-validation). `<` keeps it in range.
guard credits >= 1, credits < Double(UInt64.max) else { return nil }
```

## How Has This Been Tested?

Built the app for the iOS simulator from `packages/swift-sdk`:

```
xcodebuild -project SwiftExampleApp/SwiftExampleApp.xcodeproj -scheme SwiftExampleApp \
  -sdk iphonesimulator -destination 'platform=iOS Simulator,id=<booted-udid>' \
  EXCLUDED_ARCHS=x86_64 build
```

→ **BUILD SUCCEEDED**.

## Breaking Changes

None.

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [ ] I have made corresponding changes to the documentation if needed

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a validation issue in credit transfers that could cause an overflow when processing maximum credit amounts. Credit validation now more strictly enforces upper boundary limits to prevent edge case errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->