### PR TITLE
docs(swift-example-app): link on-chain QA status dashboard from TEST_PLAN

### DIFF
--- a/packages/swift-sdk/SwiftExampleApp/TEST_PLAN.md
+++ b/packages/swift-sdk/SwiftExampleApp/TEST_PLAN.md
@@ -4,6 +4,8 @@ A catalog of **every action theoretically possible** on Dash via the Platform gR
 
 This file is meant to be read by an automated QA agent. A human or agent can say *"test the Essential, Platform-only actions"* and the agent filters the tables below by `Tier = Essential` and `Layer = Platform`, then drives each action in the booted simulator (see the `simulator-control` skill) and reports pass/fail.
 
+> **📊 Live QA status dashboard.** A read-only web dashboard visualises these tests' on-chain results — the `dash-qa` data contract seeded from this plan: **<https://dashpay.github.io/qa-dashboard-site/>**. It renders a tier × category status matrix, per-test latest result + run history, summary counts, and filters (network / build / tier / category / result). Source: [`dashpay/qa-dashboard-site`](https://github.com/dashpay/qa-dashboard-site).
+
 > **Provenance & maintenance.** Generated from a full source scan of the `v3.1-dev` line (proto, `rs-dpp`, `rs-sdk`, `rs-sdk-ffi`, `rs-platform-wallet[-ffi]`, `swift-sdk`, `SwiftExampleApp`). It is a snapshot — when features land or move, update the affected rows (status, entry point) and re-tier if behavior changes. Treat the codebase as the source of truth if a row looks stale.
 
 ---


### PR DESCRIPTION
## Issue being fixed or feature implemented
The iOS TEST_PLAN (`packages/swift-sdk/SwiftExampleApp/TEST_PLAN.md`) is now backed by an on-chain QA framework: a `dash-qa` data contract (`testCase` / `testRun` document types) seeded from this plan, plus a read-only web dashboard that visualises run status. This adds a discoverable link from the plan to that dashboard.

Relates to #3897.

## What was done?
- Added a short "Live QA status dashboard" note near the top of `TEST_PLAN.md` linking to:
  - the live dashboard: https://dashpay.github.io/qa-dashboard-site/
  - its source repo: https://github.com/dashpay/qa-dashboard-site

The dashboard is read-only (no wallet/signing). It reads the on-chain `dash-qa` contract via the Evo SDK with proof verification and renders a tier × category status matrix, per-test latest result + run-history drill-in, summary counts, and filters.

## How Has This Been Tested?
Docs-only change. The linked dashboard was verified separately against the live testnet contract (`2qEVUbg4znNgNRs3FJQ4kof4NKpB8q4fGtYa7qBouLzw`): its Evo SDK query path loads all 126 seeded `testCase` docs plus the seeded `testRun`, and the matrix/list/filters/history render in-browser.

## Breaking Changes
None.

## Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [x] I have made corresponding changes to the documentation if needed