### PR TITLE
fix(rs-sdk): case-insensitive .dash suffix in DPNS name resolution

### DIFF
--- a/packages/rs-sdk/src/platform/dpns_usernames/mod.rs
+++ b/packages/rs-sdk/src/platform/dpns_usernames/mod.rs
@@ -35,6 +35,27 @@ pub fn convert_to_homograph_safe_chars(input: &str) -> String {
         .collect()
 }
 
+fn extract_dpns_label(name: &str) -> &str {
+    if let Some(dot_pos) = name.rfind('.') {
+        let (label_part, suffix) = name.split_at(dot_pos);
+        if suffix.eq_ignore_ascii_case(".dash") {
+            return label_part;
+        }
+    }
+    name
+}
+
+/// Strip an optional case-insensitive `.dash` suffix and apply DPNS
+/// homograph-safe normalization, producing a value suitable for matching
+/// against the `normalizedLabel` field of `domain` documents.
+///
+/// Accepts either a bare label (e.g. `"alice"`) or a full DPNS name
+/// (e.g. `"alice.dash"`, `"Alice.DASH"`) and returns the normalized label
+/// (e.g. `"a11ce"`).
+fn normalize_dpns_label(input: &str) -> String {
+    convert_to_homograph_safe_chars(extract_dpns_label(input))
+}
+
 /// Check if a username is valid according to DPNS rules
 ///
 /// A username is valid if:
@@ -365,19 +386,31 @@ impl Sdk {
     ///
     /// # Arguments
     ///
-    /// * `label` - The username label to check (e.g., "alice")
+    /// * `name` - The username label (e.g., "alice") or full DPNS name
+    ///   (e.g., "alice.dash"). The `.dash` suffix is matched
+    ///   case-insensitively and stripped before normalization, mirroring
+    ///   [`Sdk::resolve_dpns_name`].
     ///
     /// # Returns
     ///
     /// Returns `true` if the name is available, `false` if it's taken
-    pub async fn is_dpns_name_available(&self, label: &str) -> Result<bool, Error> {
+    pub async fn is_dpns_name_available(&self, name: &str) -> Result<bool, Error> {
         use crate::platform::documents::document_query::DocumentQuery;
         use drive::query::WhereClause;
         use drive::query::WhereOperator;
 
-        let dpns_contract = self.fetch_dpns_contract().await?;
+        let normalized_label = normalize_dpns_label(name);
 
-        let normalized_label = convert_to_homograph_safe_chars(label);
+        // An empty normalized label (e.g. `""`, `".dash"`, `".DASH"`) is not
+        // a registrable DPNS name, so report it as unavailable rather than
+        // doing a network round-trip that would query for
+        // `normalizedLabel == ""`. This mirrors the early-return guard in
+        // `resolve_dpns_name` so the two APIs agree on malformed input.
+        if normalized_label.is_empty() {
+            return Ok(false);
+        }
+
+        let dpns_contract = self.fetch_dpns_contract().await?;
 
         // Query for existing domain with this label
         let query = DocumentQuery {
@@ -427,30 +460,15 @@ impl Sdk {
         use drive::query::WhereClause;
         use drive::query::WhereOperator;
 
-        let dpns_contract = self.fetch_dpns_contract().await?;
+        let normalized_label = normalize_dpns_label(name);
 
-        // Extract label from full name if needed
-        // Handle both "alice" and "alice.dash" formats
-        let label = if let Some(dot_pos) = name.rfind('.') {
-            let (label_part, suffix) = name.split_at(dot_pos);
-            // Only strip the suffix if it's exactly ".dash"
-            if suffix == ".dash" {
-                label_part
-            } else {
-                // If it's not ".dash", treat the whole thing as the label
-                name
-            }
-        } else {
-            // No dot found, use the whole name as the label
-            name
-        };
-
-        // Validate the label before proceeding
-        if label.is_empty() {
+        // Empty normalized label (e.g. `""`, `".dash"`) can't resolve to an
+        // identity; bail before the contract fetch. Mirrors `is_dpns_name_available`.
+        if normalized_label.is_empty() {
             return Ok(None);
         }
 
-        let normalized_label = convert_to_homograph_safe_chars(label);
+        let dpns_contract = self.fetch_dpns_contract().await?;
 
         // Query for domain with this label
         let query = DocumentQuery {
@@ -507,6 +525,40 @@ mod tests {
         assert_eq!(convert_to_homograph_safe_chars("bob"), "b0b");
         assert_eq!(convert_to_homograph_safe_chars("COOL"), "c001");
         assert_eq!(convert_to_homograph_safe_chars("test123"), "test123");
+    }
+
+    #[test]
+    fn test_normalize_dpns_label_strips_dash_suffix_case_insensitively() {
+        // Bare label and full name normalize to the same value, regardless
+        // of the case of the .dash suffix. This is the contract that
+        // `is_dpns_name_available` and `resolve_dpns_name` share so that
+        // queries against `normalizedLabel` agree.
+        let expected = "a11ce";
+        assert_eq!(normalize_dpns_label("alice"), expected);
+        assert_eq!(normalize_dpns_label("alice.dash"), expected);
+        assert_eq!(normalize_dpns_label("alice.DASH"), expected);
+        assert_eq!(normalize_dpns_label("Alice.DaSh"), expected);
+        assert_eq!(normalize_dpns_label("ALICE.DASH"), expected);
+
+        // Non-.dash suffixes are not stripped (they are treated as part of
+        // the label and normalized whole).
+        assert_eq!(normalize_dpns_label("alice.eth"), "a11ce.eth");
+
+        // Empty / suffix-only inputs normalize to an empty label.
+        assert_eq!(normalize_dpns_label(""), "");
+        assert_eq!(normalize_dpns_label(".dash"), "");
+        assert_eq!(normalize_dpns_label(".DASH"), "");
+    }
+
+    #[test]
+    fn test_extract_dpns_label() {
+        assert_eq!(extract_dpns_label("alice.dash"), "alice");
+        assert_eq!(extract_dpns_label("alice.DASH"), "alice");
+        assert_eq!(extract_dpns_label("alice.DaSh"), "alice");
+        assert_eq!(extract_dpns_label("Alice.DASH"), "Alice");
+        assert_eq!(extract_dpns_label("alice"), "alice");
+        assert_eq!(extract_dpns_label("alice.eth"), "alice.eth");
+        assert_eq!(extract_dpns_label(".dash"), "");
     }
 
     #[test]


### PR DESCRIPTION
## Issue being fixed or feature implemented

- **Problem**: DPNS name resolution matched the `.dash` suffix **case-sensitively**. `resolve_dpns_name` stripped the suffix only when it was exactly `".dash"`, so a name like `"Alice.DASH"` or `"alice.Dash"` was treated as a bare label *including* the suffix and normalized whole — producing the wrong `normalizedLabel` and failing to resolve a name that does exist.
- **What breaks without it**: a user enters `"alice.DASH"` (or any mixed-case suffix) → the SDK queries `normalizedLabel == "a11ce.dash"` instead of `"a11ce"` → resolution returns "not found" for a registered name. Separately, empty/suffix-only input (`""`, `".dash"`) triggers a needless DPNS contract fetch + network round-trip before failing.

## What was done?

Scoped entirely to `packages/rs-sdk/src/platform/dpns_usernames/mod.rs`:

- Added `extract_dpns_label` — strips a trailing `.dash` suffix matched **case-insensitively** via `eq_ignore_ascii_case`, leaving non-`.dash` inputs untouched.
- Added `normalize_dpns_label` — combines suffix extraction with `convert_to_homograph_safe_chars`, giving a single value suitable for matching the `normalizedLabel` field of `domain` documents.
- `resolve_dpns_name` and `is_dpns_name_available` both route input through `normalize_dpns_label`, and both **short-circuit on an empty normalized label before fetching the DPNS contract** — no wasted network call for `""` / `".dash"`. The two APIs agree on malformed input.
- Unit tests `test_extract_dpns_label` and `test_normalize_dpns_label_strips_dash_suffix_case_insensitively` cover mixed-case suffixes, non-`.dash` suffixes, and empty/suffix-only inputs.

## How Has This Been Tested?

- `cargo build -p dash-sdk` — clean.
- `cargo test -p dash-sdk --lib -- platform::dpns_usernames::tests` — **5 passed, 0 failed** (2 new + 3 pre-existing, no regressions).
- `cargo fmt -p dash-sdk -- --check` — clean.
- `cargo clippy -p dash-sdk` — no new warnings.

## Breaking Changes

None. The public parameter of `is_dpns_name_available` is named `name` (it accepts both a bare label and a full `name.dash` form). Rust has no named arguments, so this is not an API/ABI break.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [ ] I have made corresponding changes to the documentation if needed

**For repository code-owners and collaborators only**

- [ ] I have assigned this pull request to a milestone

<sub>🤖 Co-authored by [Claudius the Magnificent](https://github.com/lklimek/claudius) AI Agent</sub>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved DPNS name availability validation to properly handle edge cases such as empty labels and inputs containing only the domain suffix.
  * Enhanced DPNS name resolution with better input validation before processing.

* **Tests**
  * Added comprehensive test coverage for DPNS name normalization and label extraction logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->