### PR TITLE
fix(platform-wallet): apply disabled-key flags to local cache after identity update

### DIFF
--- a/packages/rs-platform-wallet/src/wallet/identity/network/update.rs
+++ b/packages/rs-platform-wallet/src/wallet/identity/network/update.rs
@@ -233,20 +233,24 @@ impl IdentityWallet {
                 }
 
                 if !disabled_ids_for_local_apply.is_empty() {
-                    // TODO(disable-keys): wire a
-                    // `ManagedIdentity::disable_keys` counterpart to
-                    // `add_key` so the disable side of an update
-                    // transition stamps a `disabled_at` on the
-                    // matching `IdentityKeyEntry` rows. For now we
-                    // log + leave the cache stale on the disable
-                    // path; callers that need it should refresh
-                    // from Platform after the broadcast.
-                    tracing::warn!(
-                        identity = %identity_id,
-                        disabled_count = disabled_ids_for_local_apply.len(),
-                        "Disable-keys post-broadcast apply not yet implemented; \
-                         in-memory cache will not reflect disabled key flags \
-                         until the next refresh"
+                    // Disable-side counterpart to the `add_key` loop
+                    // above: stamp `disabled_at` on the matching cached
+                    // keys and fire the persister so the Swift
+                    // `PersistentPublicKey.disabledAt` rows flip without
+                    // a network re-fetch. The local wall-clock timestamp
+                    // is a placeholder — the next Platform refresh
+                    // reconciles it to the authoritative on-chain block
+                    // time. `disable_keys` reuses the same derivation
+                    // breadcrumb `add_key` carries, so the disabled key
+                    // keeps its private-key linkage.
+                    let disabled_at = std::time::SystemTime::now()
+                        .duration_since(std::time::UNIX_EPOCH)
+                        .map(|d| d.as_millis() as u64)
+                        .unwrap_or_default();
+                    managed.disable_keys(
+                        &disabled_ids_for_local_apply,
+                        disabled_at,
+                        &self.persister,
                     );
                 }
             }

--- a/packages/rs-platform-wallet/src/wallet/identity/state/managed_identity/identity_ops.rs
+++ b/packages/rs-platform-wallet/src/wallet/identity/state/managed_identity/identity_ops.rs
@@ -7,6 +7,7 @@ use crate::wallet::persister::WalletPersister;
 use dpp::identity::accessors::IdentityGettersV0;
 use dpp::identity::identity_public_key::accessors::v0::IdentityPublicKeyGettersV0;
 use dpp::identity::Identity;
+use dpp::identity::{KeyID, TimestampMillis};
 use dpp::prelude::Identifier;
 use dpp::util::hash::ripemd160_sha256;
 use std::collections::BTreeMap;
@@ -285,6 +286,111 @@ impl ManagedIdentity {
                 derivation_indices,
             },
         );
+        let cs = crate::changeset::PlatformWalletChangeSet {
+            identities: Some(self.snapshot_changeset()),
+            identity_keys: Some(keys_cs),
+            ..Default::default()
+        };
+        if let Err(e) = persister.store(cs) {
+            tracing::error!("Failed to persist changeset: {}", e);
+        }
+    }
+
+    /// Stamp `disabled_at` on the public keys named by `key_ids` and
+    /// emit a single-key [`IdentityKeysChangeSet`] upsert per affected
+    /// key — the disable-side counterpart to [`Self::add_key`].
+    ///
+    /// Mirrors `add_key`'s persistence shape: the matching
+    /// `IdentityPublicKey` records are mutated in place on the DPP
+    /// `Identity` (so every signing / introspection path sees the
+    /// disabled flag immediately) and a combined changeset is persisted
+    /// so the client's `PersistentPublicKey.disabledAt` rows flip
+    /// without a network re-fetch. Each emitted entry reuses the same
+    /// `(wallet_id, identity_index, key_index)` derivation breadcrumb
+    /// `add_key` carries, so the client re-derives idempotently and
+    /// keeps the key's existing private-key linkage rather than
+    /// dropping it on the upsert. Out-of-wallet identities (no
+    /// derivation context) emit a breadcrumb-less entry, matching
+    /// their watch-only state.
+    ///
+    /// `key_ids` not present on the identity are skipped (logged) and
+    /// no changeset is emitted when nothing matched. `disabled_at` is
+    /// the timestamp stamped on every matching key — callers pass the
+    /// local broadcast time; the next Platform refresh reconciles it to
+    /// the authoritative on-chain block time.
+    ///
+    /// Does **not** touch the identity revision — the caller bumps it
+    /// alongside the update transition.
+    pub fn disable_keys(
+        &mut self,
+        key_ids: &[KeyID],
+        disabled_at: TimestampMillis,
+        persister: &WalletPersister,
+    ) {
+        use dpp::identity::accessors::IdentitySettersV0;
+        use dpp::identity::identity_public_key::accessors::v0::IdentityPublicKeySettersV0;
+
+        let identity_id = self.id();
+
+        // Reconstruct the derivation breadcrumb from the cached
+        // wallet/identity slot. Wallet-owned identities carry both
+        // halves; out-of-wallet ones have neither (and no private key
+        // to preserve), so they fall through to a watch-only entry.
+        let breadcrumb = match (self.wallet_id, self.identity_index) {
+            (Some(wallet_id), Some(identity_index)) => Some((wallet_id, identity_index)),
+            _ => None,
+        };
+
+        // Operate on a clone of the key map, mirroring `add_key`, then
+        // write it back once all matching keys have been stamped.
+        let mut keys = self.identity.public_keys().clone();
+        let mut keys_cs = IdentityKeysChangeSet::default();
+
+        for &key_id in key_ids {
+            let Some(public_key) = keys.get_mut(&key_id) else {
+                tracing::warn!(
+                    identity = %identity_id,
+                    key_id,
+                    "disable_keys: key id not present on identity; skipping",
+                );
+                continue;
+            };
+
+            public_key.set_disabled_at(disabled_at);
+            let public_key_hash = pubkey_hash_of(public_key);
+
+            let (wallet_id, derivation_indices) = match breadcrumb {
+                Some((wallet_id, identity_index)) => (
+                    Some(wallet_id),
+                    Some(crate::changeset::IdentityKeyDerivationIndices {
+                        identity_index,
+                        key_index: key_id,
+                    }),
+                ),
+                None => (None, None),
+            };
+
+            keys_cs.upserts.insert(
+                (identity_id, key_id),
+                IdentityKeyEntry {
+                    identity_id,
+                    key_id,
+                    public_key: public_key.clone(),
+                    public_key_hash,
+                    wallet_id,
+                    derivation_indices,
+                },
+            );
+        }
+
+        // Nothing matched — leave state untouched rather than churning a
+        // no-op changeset.
+        if keys_cs.upserts.is_empty() {
+            return;
+        }
+
+        self.identity.set_public_keys(keys);
+
         let cs = crate::changeset::PlatformWalletChangeSet {
             identities: Some(self.snapshot_changeset()),
             identity_keys: Some(keys_cs),

--- a/packages/rs-platform-wallet/src/wallet/identity/state/managed_identity/mod.rs
+++ b/packages/rs-platform-wallet/src/wallet/identity/state/managed_identity/mod.rs
@@ -356,4 +356,52 @@ mod tests {
         assert_eq!(managed.incoming_contact_requests.len(), 1);
         assert_eq!(managed.established_contacts.len(), 0);
     }
+
+    #[test]
+    fn test_disable_keys_stamps_disabled_at() {
+        use dpp::identity::accessors::{IdentityGettersV0, IdentitySettersV0};
+        use dpp::identity::identity_public_key::accessors::v0::IdentityPublicKeyGettersV0;
+        use dpp::identity::identity_public_key::v0::IdentityPublicKeyV0;
+        use dpp::identity::{IdentityPublicKey, KeyType, Purpose, SecurityLevel};
+        use dpp::platform_value::BinaryData;
+
+        let make_key = |id: u32| {
+            IdentityPublicKey::V0(IdentityPublicKeyV0 {
+                id,
+                key_type: KeyType::ECDSA_SECP256K1,
+                purpose: Purpose::AUTHENTICATION,
+                security_level: SecurityLevel::HIGH,
+                contract_bounds: None,
+                read_only: false,
+                data: BinaryData::new(vec![0x02; 33]),
+                disabled_at: None,
+            })
+        };
+
+        let mut identity = create_test_identity();
+        let mut keys = BTreeMap::new();
+        keys.insert(0, make_key(0));
+        keys.insert(1, make_key(1));
+        identity.set_public_keys(keys);
+
+        let mut managed = ManagedIdentity::new(identity, 0);
+        let p = noop_persister();
+
+        // Disable key 1 plus a non-existent key 9 (must be skipped).
+        managed.disable_keys(&[1, 9], 1_700_000_000, &p);
+
+        let pk0 = managed.identity.get_public_key_by_id(0).unwrap();
+        let pk1 = managed.identity.get_public_key_by_id(1).unwrap();
+        assert_eq!(pk0.disabled_at(), None, "untouched key must stay enabled");
+        assert_eq!(
+            pk1.disabled_at(),
+            Some(1_700_000_000),
+            "targeted key must be stamped disabled"
+        );
+        // The skipped key id must not have materialized a phantom row.
+        assert!(
+            managed.identity.get_public_key_by_id(9).is_none(),
+            "non-existent key id must not be created"
+        );
+    }
 }


### PR DESCRIPTION
## Issue being fixed or feature implemented

The post-broadcast local-cache apply for the **disable-key** side of an identity update was an unimplemented TODO in `update_identity_with_external_signer`: it logged a warning and left the in-memory `ManagedIdentity` cache stale. As a result, a disabled key's `disabled_at` flag only flipped in SwiftData after a full network re-fetch (via `IdentityDetailView.refreshIdentityData()`).

This blocks promoting test case **ID-12 (disable identity key)** to a production UI action, where the Identity Keys list needs to reflect the disabled flag immediately.

## What was done?

Added `ManagedIdentity::disable_keys`, the disable-side counterpart to the existing `add_key`:

- Stamps `disabled_at` on the matching `IdentityPublicKey` records in the cached DPP `Identity`, so every signing / introspection path sees the disabled flag immediately.
- Fires the persister with the same combined changeset shape `add_key` uses (scalar identity snapshot + `IdentityKeysChangeSet` upserts), so the client's `PersistentPublicKey.disabledAt` rows update without a network re-fetch. The FFI derives the Swift `disabledAt` from `entry.public_key.disabled_at()`.
- Each emitted key entry **reuses the `(wallet_id, identity_index, key_index)` derivation breadcrumb** that `add_key` carries — reconstructed from the managed identity's own slot. This matters because the Swift upsert wipes `privateKeyKeychainIdentifier` when `derivationIndices` is absent; carrying the breadcrumb makes the client re-derive idempotently and keep the key's private-key linkage instead of dropping it.
- Skips (with a warning) key ids not present on the identity and emits no changeset when nothing matched.
- Does **not** touch the identity revision — the revision bump is already handled by the caller alongside the update transition.

Wired it into the call site in `update.rs`, replacing the TODO/`tracing::warn!` block. The local wall-clock time is passed as a placeholder `disabled_at`; the next Platform refresh reconciles it to the authoritative on-chain block time.

## How Has This Been Tested?

- `cargo check -p platform-wallet` — passes.
- `cargo test -p platform-wallet --lib managed_identity` — **21 passed, 0 failed**, including the new `test_disable_keys_stamps_disabled_at` (asserts the targeted key is stamped, an untouched key stays enabled, and a non-existent key id is skipped without creating a phantom row).
- `cargo fmt --all` — clean.

## Breaking Changes

None. Adds a new public method to `platform-wallet`; no consensus or wire-format changes.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [ ] I have made corresponding changes to the documentation if needed

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone

🤖 Generated with [Claude Code](https://claude.com/claude-code)