### PR TITLE
fix(rs-sdk-ffi): classify DAPI transport and timeout errors instead of internalError

### DIFF
--- a/packages/rs-sdk-ffi/src/error.rs
+++ b/packages/rs-sdk-ffi/src/error.rs
@@ -118,7 +118,25 @@ impl From<FFIError> for DashSDKError {
                     // emit only the inner Drive message so downstream FFI consumers
                     // don't double-render the "Drive internal error: " prefix.
                     (DashSDKErrorCode::DriveInternalError, inner.clone())
-                } else if error_str.contains("timeout") || error_str.contains("Timeout") {
+                } else if matches!(
+                    sdk_err,
+                    dash_sdk::Error::DapiClientError(_)
+                        | dash_sdk::Error::NoAvailableAddressesToRetry(_)
+                ) {
+                    // Transport / connectivity failure (e.g. all DAPI nodes
+                    // unreachable or serving expired TLS certificates). Match the
+                    // typed variant rather than the Display string: the message
+                    // ("Dapi client error: transport error: ...") matches none of
+                    // the substrings below, so it would otherwise fall through to
+                    // InternalError and surface in the UI as a misleading
+                    // "Internal Error" for what is really a network problem.
+                    (DashSDKErrorCode::NetworkError, error_str)
+                } else if matches!(sdk_err, dash_sdk::Error::TimeoutReached(_, _))
+                    || error_str.contains("timeout")
+                    || error_str.contains("Timeout")
+                {
+                    // Typed SDK timeout, plus a substring fallback for timeouts
+                    // surfaced inside other error types' Display strings.
                     (DashSDKErrorCode::Timeout, error_str)
                 } else if error_str.contains("I/O error") || error_str.contains("connection") {
                     (
@@ -254,6 +272,28 @@ mod tests {
     fn generic_not_found_still_maps_to_not_found() {
         let err = dash_sdk::Error::Generic("identity not found".to_string());
         assert_eq!(classify(err), DashSDKErrorCode::NotFound);
+    }
+
+    #[test]
+    fn dapi_client_error_maps_to_network_error() {
+        // The Display form is "Dapi client error: …", which matches none of the
+        // substring heuristics ("DAPI"/"dapi"/"connection"/…). It must be
+        // classified as NetworkError via the typed variant so a transient
+        // transport failure (e.g. an evonode serving an expired TLS cert) does
+        // not surface in the UI as a misleading "Internal Error".
+        let err = dash_sdk::Error::DapiClientError(
+            dash_sdk::dapi_client::DapiClientError::NoAvailableAddresses,
+        );
+        assert_eq!(classify(err), DashSDKErrorCode::NetworkError);
+    }
+
+    #[test]
+    fn timeout_reached_maps_to_timeout() {
+        let err = dash_sdk::Error::TimeoutReached(
+            std::time::Duration::from_secs(8),
+            "fetch protocol version upgrade state".to_string(),
+        );
+        assert_eq!(classify(err), DashSDKErrorCode::Timeout);
     }
 
     #[test]

--- a/packages/rs-sdk-ffi/src/protocol_version/queries/upgrade_state.rs
+++ b/packages/rs-sdk-ffi/src/protocol_version/queries/upgrade_state.rs
@@ -1,5 +1,5 @@
 use crate::types::SDKHandle;
-use crate::{DashSDKError, DashSDKErrorCode, DashSDKResult, DashSDKResultDataType};
+use crate::{DashSDKError, DashSDKErrorCode, DashSDKResult, DashSDKResultDataType, FFIError};
 use dash_sdk::dpp::version::ProtocolVersionVoteCount;
 use dash_sdk::platform::FetchMany;
 use std::ffi::CString;
@@ -50,57 +50,56 @@ pub unsafe extern "C" fn dash_sdk_protocol_version_get_upgrade_state(
             data: std::ptr::null_mut(),
             error: std::ptr::null_mut(),
         },
+        // Preserve the typed `dash_sdk::Error` classification (network /
+        // timeout / etc.) instead of flattening everything to InternalError.
+        // A transient DAPI transport failure (e.g. an evonode serving an
+        // expired TLS certificate) is a NetworkError, not an internal bug, and
+        // the UI should label it as such rather than "Internal Error".
         Err(e) => DashSDKResult {
             data_type: DashSDKResultDataType::NoData,
             data: std::ptr::null_mut(),
-            error: Box::into_raw(Box::new(DashSDKError::new(
-                DashSDKErrorCode::InternalError,
-                e,
-            ))),
+            error: Box::into_raw(Box::new(DashSDKError::from(e))),
         },
     }
 }
 
 fn get_protocol_version_upgrade_state(
     sdk_handle: *const SDKHandle,
-) -> Result<Option<String>, String> {
+) -> Result<Option<String>, FFIError> {
     if sdk_handle.is_null() {
-        return Err("SDK handle is null".to_string());
+        return Err(FFIError::InvalidState("SDK handle is null".to_string()));
     }
 
     let rt = crate::runtime::BigStackRuntime::new_isolated()
-        .map_err(|e| format!("Failed to create Tokio runtime: {}", e))?;
+        .map_err(|e| FFIError::InternalError(format!("Failed to create Tokio runtime: {}", e)))?;
 
     let wrapper = unsafe { &*(sdk_handle as *const crate::sdk::SDKWrapper) };
     let sdk = wrapper.sdk.clone();
 
     rt.block_on(async move {
-        match ProtocolVersionVoteCount::fetch_many(&sdk, ()).await {
-            Ok(upgrades) => {
-                let upgrades: dash_sdk::query_types::ProtocolVersionUpgrades = upgrades;
-                if upgrades.is_empty() {
-                    return Ok(None);
-                }
+        // Propagate the `dash_sdk::Error` unchanged via `?` so the FFI error
+        // converter classifies it (NetworkError, Timeout, ...). Returning a
+        // pre-formatted String here would erase that classification.
+        let upgrades: dash_sdk::query_types::ProtocolVersionUpgrades =
+            ProtocolVersionVoteCount::fetch_many(&sdk, ()).await?;
 
-                let upgrades_json: Vec<String> = upgrades
-                    .iter()
-                    .filter_map(|(version, vote_count_opt)| {
-                        vote_count_opt.as_ref().map(|vote_count| {
-                            format!(
-                                r#"{{"version_number":{},"vote_count":{}}}"#,
-                                version, vote_count
-                            )
-                        })
-                    })
-                    .collect();
-
-                Ok(Some(format!("[{}]", upgrades_json.join(","))))
-            }
-            Err(e) => Err(format!(
-                "Failed to fetch protocol version upgrade state: {}",
-                e
-            )),
+        if upgrades.is_empty() {
+            return Ok(None);
         }
+
+        let upgrades_json: Vec<String> = upgrades
+            .iter()
+            .filter_map(|(version, vote_count_opt)| {
+                vote_count_opt.as_ref().map(|vote_count| {
+                    format!(
+                        r#"{{"version_number":{},"vote_count":{}}}"#,
+                        version, vote_count
+                    )
+                })
+            })
+            .collect();
+
+        Ok(Some(format!("[{}]", upgrades_json.join(","))))
     })
 }
 

--- a/packages/rs-sdk-ffi/src/protocol_version/queries/upgrade_vote_status.rs
+++ b/packages/rs-sdk-ffi/src/protocol_version/queries/upgrade_vote_status.rs
@@ -1,5 +1,5 @@
 use crate::types::SDKHandle;
-use crate::{DashSDKError, DashSDKErrorCode, DashSDKResult, DashSDKResultDataType};
+use crate::{DashSDKError, DashSDKErrorCode, DashSDKResult, DashSDKResultDataType, FFIError};
 use dash_sdk::dpp::dashcore::ProTxHash;
 use dash_sdk::platform::FetchMany;
 use dash_sdk::query_types::MasternodeProtocolVote;
@@ -56,13 +56,15 @@ pub unsafe extern "C" fn dash_sdk_protocol_version_get_upgrade_vote_status(
             data: std::ptr::null_mut(),
             error: std::ptr::null_mut(),
         },
+        // Preserve the typed `dash_sdk::Error` classification (network /
+        // timeout / etc.) instead of flattening everything to InternalError.
+        // A transient DAPI transport failure (e.g. an evonode serving an
+        // expired TLS certificate) is a NetworkError, not an internal bug, and
+        // the UI should label it as such rather than "Internal Error".
         Err(e) => DashSDKResult {
             data_type: DashSDKResultDataType::NoData,
             data: std::ptr::null_mut(),
-            error: Box::into_raw(Box::new(DashSDKError::new(
-                DashSDKErrorCode::InternalError,
-                e,
-            ))),
+            error: Box::into_raw(Box::new(DashSDKError::from(e))),
         },
     }
 }
@@ -71,14 +73,14 @@ fn get_protocol_version_upgrade_vote_status(
     sdk_handle: *const SDKHandle,
     start_pro_tx_hash: *const c_char,
     count: u32,
-) -> Result<Option<String>, String> {
+) -> Result<Option<String>, FFIError> {
     // Check for null pointer
     if sdk_handle.is_null() {
-        return Err("SDK handle is null".to_string());
+        return Err(FFIError::InvalidState("SDK handle is null".to_string()));
     }
 
     let rt = crate::runtime::BigStackRuntime::new_isolated()
-        .map_err(|e| format!("Failed to create Tokio runtime: {}", e))?;
+        .map_err(|e| FFIError::InternalError(format!("Failed to create Tokio runtime: {}", e)))?;
 
     let wrapper = unsafe { &*(sdk_handle as *const crate::sdk::SDKWrapper) };
     let sdk = wrapper.sdk.clone();
@@ -88,15 +90,16 @@ fn get_protocol_version_upgrade_vote_status(
             None
         } else {
             let start_hash_str = unsafe {
-                CStr::from_ptr(start_pro_tx_hash)
-                    .to_str()
-                    .map_err(|e| format!("Invalid UTF-8 in start pro_tx_hash: {}", e))?
+                CStr::from_ptr(start_pro_tx_hash).to_str().map_err(|e| {
+                    FFIError::InvalidParameter(format!("Invalid UTF-8 in start pro_tx_hash: {}", e))
+                })?
             };
-            let bytes = hex::decode(start_hash_str)
-                .map_err(|e| format!("Failed to decode start pro_tx_hash: {}", e))?;
-            let hash_bytes: [u8; 32] = bytes
-                .try_into()
-                .map_err(|_| "start_pro_tx_hash must be exactly 32 bytes".to_string())?;
+            let bytes = hex::decode(start_hash_str).map_err(|e| {
+                FFIError::InvalidParameter(format!("Failed to decode start pro_tx_hash: {}", e))
+            })?;
+            let hash_bytes: [u8; 32] = bytes.try_into().map_err(|_| {
+                FFIError::InvalidParameter("start_pro_tx_hash must be exactly 32 bytes".to_string())
+            })?;
             Some(ProTxHash::from(hash_bytes))
         };
 
@@ -106,32 +109,29 @@ fn get_protocol_version_upgrade_vote_status(
             start_info: None,
         };
 
-        match MasternodeProtocolVote::fetch_many(&sdk, query).await {
-            Ok(votes) => {
-                if votes.is_empty() {
-                    return Ok(None);
-                }
+        // Propagate the `dash_sdk::Error` unchanged via `?` so the FFI error
+        // converter classifies it (NetworkError, Timeout, ...). Returning a
+        // pre-formatted String here would erase that classification.
+        let votes = MasternodeProtocolVote::fetch_many(&sdk, query).await?;
 
-                let votes_json: Vec<String> = votes
-                    .iter()
-                    .filter_map(|(pro_tx_hash, vote_opt)| {
-                        vote_opt.as_ref().map(|vote| {
-                            format!(
-                                r#"{{"pro_tx_hash":"{}","version":{}}}"#,
-                                hex::encode(pro_tx_hash),
-                                vote.voted_version
-                            )
-                        })
-                    })
-                    .collect();
-
-                Ok(Some(format!("[{}]", votes_json.join(","))))
-            }
-            Err(e) => Err(format!(
-                "Failed to fetch protocol version upgrade vote status: {}",
-                e
-            )),
+        if votes.is_empty() {
+            return Ok(None);
         }
+
+        let votes_json: Vec<String> = votes
+            .iter()
+            .filter_map(|(pro_tx_hash, vote_opt)| {
+                vote_opt.as_ref().map(|vote| {
+                    format!(
+                        r#"{{"pro_tx_hash":"{}","version":{}}}"#,
+                        hex::encode(pro_tx_hash),
+                        vote.voted_version
+                    )
+                })
+            })
+            .collect();
+
+        Ok(Some(format!("[{}]", votes_json.join(","))))
     })
 }
 

--- a/packages/swift-sdk/Sources/SwiftDashSDK/FFI/PlatformQueryExtensions.swift
+++ b/packages/swift-sdk/Sources/SwiftDashSDK/FFI/PlatformQueryExtensions.swift
@@ -19,8 +19,11 @@ extension SDK {
         if let error = result.error {
             let errorMessage = error.pointee.message != nil ? String(cString: error.pointee.message!) : "Unknown error"
             print("❌ processJSONResult: FFI returned error: \(errorMessage)")
+            // Preserve the FFI error code so transport failures surface as
+            // .networkError / .timeout rather than a misleading .internalError.
+            let sdkError = SDKError.fromDashSDKError(error.pointee)
             dash_sdk_error_free(error)
-            throw SDKError.internalError(errorMessage)
+            throw sdkError
         }
 
         guard let dataPtr = result.data else {
@@ -51,9 +54,11 @@ extension SDK {
     /// Process DashSDKResult and extract JSON array
     private func processJSONArrayResult(_ result: DashSDKResult) throws -> [[String: Any]] {
         if let error = result.error {
-            let errorMessage = error.pointee.message != nil ? String(cString: error.pointee.message!) : "Unknown error"
+            // Preserve the FFI error code so transport failures surface as
+            // .networkError / .timeout rather than a misleading .internalError.
+            let sdkError = SDKError.fromDashSDKError(error.pointee)
             dash_sdk_error_free(error)
-            throw SDKError.internalError(errorMessage)
+            throw sdkError
         }
 
         guard let dataPtr = result.data else {
@@ -74,9 +79,11 @@ extension SDK {
     /// Process DashSDKResult and extract string
     private func processStringResult(_ result: DashSDKResult) throws -> String {
         if let error = result.error {
-            let errorMessage = error.pointee.message != nil ? String(cString: error.pointee.message!) : "Unknown error"
+            // Preserve the FFI error code so transport failures surface as
+            // .networkError / .timeout rather than a misleading .internalError.
+            let sdkError = SDKError.fromDashSDKError(error.pointee)
             dash_sdk_error_free(error)
-            throw SDKError.internalError(errorMessage)
+            throw sdkError
         }
 
         guard let dataPtr = result.data else {
@@ -1078,9 +1085,12 @@ extension SDK {
 
         // Special handling for protocol version upgrade state which returns an array
         if let error = result.error {
-            let errorMessage = error.pointee.message != nil ? String(cString: error.pointee.message!) : "Unknown error"
+            // Preserve the FFI error code so transport failures (e.g. an evonode
+            // serving an expired TLS certificate) surface as .networkError
+            // rather than a misleading .internalError.
+            let sdkError = SDKError.fromDashSDKError(error.pointee)
             dash_sdk_error_free(error)
-            throw SDKError.internalError(errorMessage)
+            throw sdkError
         }
 
         // If no data, return empty result


### PR DESCRIPTION
## Issue being fixed or feature implemented

Surfaced via QA test **ID-SYS-03**: in SwiftExampleApp's Platform Queries catalog, both *Get Protocol Version Upgrade State* and *Get Protocol Version Upgrade Vote Status* intermittently returned a misleading **"Internal Error: Failed to fetch protocol version upgrade…"** on testnet (proof-verified / TRUSTED mode).

Root-causing it revealed the query path was **never broken**. The raw error was:

```
Dapi client error: transport error: grpc error: 'service currently unavailable',
invalid peer certificate: certificate expired
```

A cluster of testnet evonodes was serving **expired TLS certs** (25/30 ENABLED nodes at one point). That is an ops issue, since resolved by cert renewal — there is nothing to fix in this repo for the outage itself.

The one genuine defect in this codebase is that this transient **network/transport** failure was classified and displayed as an **"Internal Error"**, which masked the real, retryable cause and actively misdirected diagnosis toward a phantom proof-verification bug. This PR fixes that classification.

## What was done?

- **`packages/rs-sdk-ffi/src/error.rs`** — `FFIError::from` now classifies by the typed `dash_sdk::Error` variant *first*, before the substring fallbacks:
  - `DapiClientError(_)` / `NoAvailableAddressesToRetry(_)` → `NetworkError`
  - `TimeoutReached(..)` → `Timeout`
  
  (Previously these fell through to `InternalError`: `DapiClientError`'s `Display` starts with `"Dapi client error:"`, which matched none of the old `"DAPI"`/`"dapi"`/`"connection"` heuristics.) Single source-of-truth classifier, so **every** platform query benefits — not just the protocol-version ones.
- **`packages/rs-sdk-ffi/src/protocol_version/queries/upgrade_state.rs`** and **`upgrade_vote_status.rs`** — the inner helpers now propagate the typed `dash_sdk::Error` via `?` instead of hand-rolling a `format!(…)` string that bypassed the classifier and forced `InternalError`. Pure bridging; no business logic added.
- **`packages/swift-sdk/Sources/SwiftDashSDK/FFI/PlatformQueryExtensions.swift`** — the JSON / array / string result helpers and the inline state-query error block call the existing `SDKError.fromDashSDKError(_:)` mapper instead of unconditionally throwing `.internalError`, so a transport failure renders as **"Network Error" / "Timeout"** in `QueryDetailView`.

## How Has This Been Tested?

- `cargo fmt --all -- --check`: clean.
- `cargo clippy -p rs-sdk-ffi --lib`: clean.
- `cargo check -p rs-sdk-ffi --all-targets`: clean.
- `cargo test -p rs-sdk-ffi --lib`: **282 passed**, including new `dapi_client_error_maps_to_network_error` and `timeout_reached_maps_to_timeout`.
- `./build_ios.sh --target sim`: BUILD SUCCEEDED (xcframework + SwiftExampleApp).
- **Simulator** (QA-iPhone16Pro, testnet, TRUSTED/proof-verified mode): both queries return valid live results once node rotation lands on a healthy node:
  - *Upgrade State* → `{ "upgrades": [{ "version_number": 12, "vote_count": 15 }] }`
  - *Vote Status* → array of `{ "pro_tx_hash": "05b687…", "version": 12 }`
  
  When a transport failure does occur it now surfaces as a "Network Error" rather than "Internal Error" (covered by the new unit tests).

## Breaking Changes

None. This only changes how existing transport/timeout errors are *classified and labeled* across the FFI boundary; no public API signatures or consensus behavior change.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [ ] I have made corresponding changes to the documentation if needed

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved error classification and reporting across SDK boundaries to provide more specific error details (network, timeout, invalid input) instead of generic internal errors.
  * Enhanced error handling in protocol version queries to preserve underlying error types when communicating between components.
  * Refined input validation with clearer error categorization for protocol queries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->