### PR TITLE
test(swift-example-app): cover KeyDisableGate and correct consensus-framing comments

### DIFF
--- a/packages/swift-sdk/SwiftExampleApp/SwiftExampleApp/Services/KeyDisableGate.swift
+++ b/packages/swift-sdk/SwiftExampleApp/SwiftExampleApp/Services/KeyDisableGate.swift
@@ -3,17 +3,25 @@ import SwiftDashSDK
 
 /// Client-side safety gate for the **Disable Key** action.
 ///
-/// Mirrors the consensus rules Drive enforces on an
-/// `IdentityUpdateTransition` that disables a key, so the app never
-/// broadcasts a transition that's doomed to be rejected. This is a
-/// pre-flight UI guard, not protocol logic — the authoritative checks
-/// still run in `rs-drive-abci`; we just refuse to spend fees on a
-/// transition we already know fails.
+/// This is a pre-flight UI guard, not protocol logic. It mixes two
+/// kinds of refusal:
+///
+/// - **Master key (consensus):** disabling a lone master key really is
+///   rejected by consensus (`validate_master_key_uniqueness_v0`), so
+///   refusing it here just avoids spending fees on a transition we
+///   already know `rs-drive-abci` will reject.
+/// - **Last auth / last transfer (client-side self-brick guards):**
+///   these are *not* protocol invariants. The drive-abci
+///   identity_update state validator only checks that every disabled
+///   key id exists in state and that master-key uniqueness holds — it
+///   would happily accept disabling the last enabled authentication or
+///   transfer key. We refuse those locally purely as a UX safeguard so
+///   the user can't strand (brick) their own identity.
 ///
 /// The gate is computed against the identity's full enabled key set
-/// (a disable is only valid relative to what else remains enabled),
-/// so callers pass `allKeys` (the identity's `identityPublicKeys`)
-/// alongside the `target` key being disabled.
+/// (these guards are only meaningful relative to what else remains
+/// enabled), so callers pass `allKeys` (the identity's
+/// `identityPublicKeys`) alongside the `target` key being disabled.
 enum KeyDisableGate {
     /// Result of evaluating whether `target` may be disabled.
     enum Evaluation: Equatable {
@@ -47,9 +55,12 @@ enum KeyDisableGate {
             )
         }
 
-        // Disabling the last enabled AUTHENTICATION key would leave
-        // the identity unable to authenticate / sign future
-        // transitions — consensus requires at least one.
+        // Client-side self-brick guard (not a consensus rule):
+        // drive-abci would accept this transition, but disabling the
+        // last enabled AUTHENTICATION key would leave the identity
+        // unable to authenticate / sign future transitions, so we
+        // refuse it locally to keep the user from stranding the
+        // identity.
         if target.purpose == .authentication
             && enabledCount(of: .authentication, in: allKeys) <= 1 {
             return .forbidden(
@@ -57,9 +68,12 @@ enum KeyDisableGate {
             )
         }
 
-        // Disabling the last enabled TRANSFER key breaks credit
-        // withdrawals / transfers (ID-10). Re-adding a transfer key
-        // currently requires the Add Key flow (ID-07).
+        // Client-side self-brick guard (not a consensus rule):
+        // drive-abci would accept this too, but disabling the last
+        // enabled TRANSFER key would break credit withdrawals /
+        // transfers (ID-10), and re-adding a transfer key currently
+        // requires the Add Key flow (ID-07). We refuse it locally as a
+        // UX safeguard.
         if target.purpose == .transfer
             && enabledCount(of: .transfer, in: allKeys) <= 1 {
             return .forbidden(

--- a/packages/swift-sdk/SwiftExampleApp/SwiftExampleAppTests/KeyDisableGateTests.swift
+++ b/packages/swift-sdk/SwiftExampleApp/SwiftExampleAppTests/KeyDisableGateTests.swift
@@ -1,0 +1,204 @@
+//
+//  KeyDisableGateTests.swift
+//  SwiftExampleAppTests
+//
+//  Unit coverage for `KeyDisableGate.evaluate` — the pure, single
+//  source of truth for whether a Disable Key submit is attempted
+//  (used in KeyDetailView, KeysListView, and the pre-submit re-check).
+//
+
+import XCTest
+import SwiftDashSDK
+@testable import SwiftExampleApp
+
+final class KeyDisableGateTests: XCTestCase {
+
+    // MARK: - Fixtures
+
+    /// Build an `IdentityPublicKey` test value with the fields the gate
+    /// actually reads (`id`, `purpose`, `securityLevel`, `disabledAt`).
+    /// `keyType`/`data`/`readOnly` are irrelevant to the gate, so they
+    /// get trivial defaults.
+    private func makeKey(
+        id: KeyID,
+        purpose: KeyPurpose,
+        securityLevel: SecurityLevel = .high,
+        disabledAt: TimestampMillis? = nil
+    ) -> IdentityPublicKey {
+        IdentityPublicKey(
+            id: id,
+            purpose: purpose,
+            securityLevel: securityLevel,
+            contractBounds: nil,
+            keyType: .ecdsaSecp256k1,
+            readOnly: false,
+            data: BinaryData(),
+            disabledAt: disabledAt
+        )
+    }
+
+    /// A fixed, non-nil disabled timestamp for "already disabled" keys.
+    private let disabledTimestamp: TimestampMillis = 1_700_000_000_000
+
+    // MARK: - 1. Already disabled
+
+    func testAlreadyDisabledTarget_returnsAlreadyDisabled() {
+        let target = makeKey(id: 5, purpose: .authentication, disabledAt: disabledTimestamp)
+        // Include a second enabled auth key so the result can only be
+        // `.alreadyDisabled` (and not, e.g., a last-auth refusal).
+        let other = makeKey(id: 6, purpose: .authentication)
+
+        let result = KeyDisableGate.evaluate(target: target, allKeys: [target, other])
+
+        XCTAssertEqual(result, .alreadyDisabled)
+    }
+
+    // MARK: - 2. Master key
+
+    func testMasterKey_isForbidden() {
+        // A master key is also an authentication key in practice; the
+        // master check runs before the auth check, so this must be
+        // `.forbidden` regardless of how many other auth keys exist.
+        let target = makeKey(id: 0, purpose: .authentication, securityLevel: .master)
+        let other = makeKey(id: 1, purpose: .authentication)
+
+        let result = KeyDisableGate.evaluate(target: target, allKeys: [target, other])
+
+        guard case .forbidden = result else {
+            return XCTFail("expected .forbidden for a master key, got \(result)")
+        }
+    }
+
+    // MARK: - 3. Last authentication key
+
+    func testLastEnabledAuthenticationKey_isForbidden() {
+        let target = makeKey(id: 1, purpose: .authentication)
+
+        let result = KeyDisableGate.evaluate(target: target, allKeys: [target])
+
+        guard case .forbidden = result else {
+            return XCTFail("expected .forbidden for the only auth key, got \(result)")
+        }
+    }
+
+    func testAuthenticationKey_withSecondEnabledAuth_isAllowed() {
+        let target = makeKey(id: 1, purpose: .authentication)
+        let second = makeKey(id: 2, purpose: .authentication)
+
+        let result = KeyDisableGate.evaluate(target: target, allKeys: [target, second])
+
+        XCTAssertEqual(result, .allowed)
+    }
+
+    // MARK: - 4. Last transfer key
+
+    func testLastEnabledTransferKey_isForbidden() {
+        // Pair with an auth key so the auth rail can't trip first and
+        // the transfer rail is the one under test.
+        let target = makeKey(id: 3, purpose: .transfer)
+        let auth = makeKey(id: 1, purpose: .authentication)
+
+        let result = KeyDisableGate.evaluate(target: target, allKeys: [target, auth])
+
+        guard case .forbidden = result else {
+            return XCTFail("expected .forbidden for the only transfer key, got \(result)")
+        }
+    }
+
+    func testTransferKey_withSecondEnabledTransfer_isAllowed() {
+        let target = makeKey(id: 3, purpose: .transfer)
+        let secondTransfer = makeKey(id: 4, purpose: .transfer)
+        let auth = makeKey(id: 1, purpose: .authentication)
+
+        let result = KeyDisableGate.evaluate(
+            target: target,
+            allKeys: [target, secondTransfer, auth]
+        )
+
+        XCTAssertEqual(result, .allowed)
+    }
+
+    // MARK: - 5. Normal non-last key
+
+    func testNormalNonLastKey_isAllowed() {
+        // A non-auth / non-transfer purpose with no special rails.
+        let target = makeKey(id: 7, purpose: .encryption)
+        // Keep an auth key around so the identity stays signable; this
+        // shouldn't matter for an encryption-key disable, but it makes
+        // the scenario realistic.
+        let auth = makeKey(id: 1, purpose: .authentication)
+
+        let result = KeyDisableGate.evaluate(target: target, allKeys: [target, auth])
+
+        XCTAssertEqual(result, .allowed)
+    }
+
+    // MARK: - 6. enabledCount edge cases (exercised through evaluate)
+
+    /// Keys of a *different* purpose must not count toward the auth
+    /// limit: disabling the only auth key is forbidden even when other
+    /// purposes have many enabled keys.
+    func testOtherPurposeKeysDoNotCountTowardAuthLimit() {
+        let target = makeKey(id: 1, purpose: .authentication)
+        let encryption = makeKey(id: 2, purpose: .encryption)
+        let transferA = makeKey(id: 3, purpose: .transfer)
+        let transferB = makeKey(id: 4, purpose: .transfer)
+
+        let result = KeyDisableGate.evaluate(
+            target: target,
+            allKeys: [target, encryption, transferA, transferB]
+        )
+
+        guard case .forbidden = result else {
+            return XCTFail(
+                "expected .forbidden — other-purpose keys must not satisfy the auth requirement, got \(result)"
+            )
+        }
+    }
+
+    /// Already-disabled keys of the same purpose are excluded from the
+    /// count: two auth keys where one is already disabled still forbids
+    /// disabling the remaining enabled one.
+    func testAlreadyDisabledSamePurposeKeyExcludedFromCount() {
+        let target = makeKey(id: 1, purpose: .authentication)
+        let disabledAuth = makeKey(
+            id: 2,
+            purpose: .authentication,
+            disabledAt: disabledTimestamp
+        )
+
+        let result = KeyDisableGate.evaluate(
+            target: target,
+            allKeys: [target, disabledAuth]
+        )
+
+        guard case .forbidden = result else {
+            return XCTFail(
+                "expected .forbidden — a disabled sibling auth key is not an enabled fallback, got \(result)"
+            )
+        }
+    }
+
+    /// Symmetric transfer-side check: a disabled sibling transfer key
+    /// doesn't keep the last enabled transfer key disableable.
+    func testAlreadyDisabledSiblingTransferKeyExcludedFromCount() {
+        let target = makeKey(id: 3, purpose: .transfer)
+        let disabledTransfer = makeKey(
+            id: 4,
+            purpose: .transfer,
+            disabledAt: disabledTimestamp
+        )
+        let auth = makeKey(id: 1, purpose: .authentication)
+
+        let result = KeyDisableGate.evaluate(
+            target: target,
+            allKeys: [target, disabledTransfer, auth]
+        )
+
+        guard case .forbidden = result else {
+            return XCTFail(
+                "expected .forbidden — a disabled sibling transfer key is not an enabled fallback, got \(result)"
+            )
+        }
+    }
+}


### PR DESCRIPTION
## Issue being fixed or feature implemented
Follow-up to #3918 (ID-12 production Disable Key), addressing the two non-blocking review findings from `thepastaclaw`:
- 💬 Nitpick: the doc comments overstated "mirrors consensus" for the last-auth / last-transfer rails.
- 🟡 Suggestion: `KeyDisableGate.evaluate` is pure and trivially testable but had no unit tests.

## What was done?
- **Corrected the doc comments** in `KeyDisableGate.swift`. Verified against the drive-abci identity_update state validator (`packages/rs-drive-abci/.../identity_update/state/v0/mod.rs`): it enforces only that disabled key ids exist in state **and** master-key uniqueness (`validate_not_disabling_last_master_key` → `validate_master_key_uniqueness_v0`). It does **not** reject disabling the last enabled authentication or transfer key. So only the **master** refusal is consensus-enforced; the last-auth / last-transfer refusals are now correctly described as **client-side self-brick guards** (drive-abci would accept those transitions — we refuse them locally so a user can't strand their identity). **No logic changed** — comments only.
- **Added `KeyDisableGateTests.swift`** (new, in `SwiftExampleAppTests`) — 10 cases covering every branch of `evaluate(target:allKeys:)` (alreadyDisabled, master forbidden, last-auth forbidden + allowed-with-second-key, last-transfer forbidden + allowed-with-second-key, normal allowed) plus the `enabledCount` edge cases (other-purpose keys don't count toward a limit; already-disabled same-purpose siblings are excluded). `evaluate` is the single source of truth for whether a disable submit is attempted (KeyDetailView + KeysListView + pre-submit re-check), so this guards it against a future key-rotation refactor.

## How Has This Been Tested?
- `xcodebuild test ... -only-testing:SwiftExampleAppTests/KeyDisableGateTests` on the iPhone 16 simulator (iOS 26.3.1): **TEST SUCCEEDED**, all 10 pass.
- Whole-app build: **BUILD SUCCEEDED**. Test fixtures use `IdentityPublicKey`'s existing public init via a small private `makeKey(...)` helper in the test file — no production types changed.

## Breaking Changes
None. Comments + new tests only; no production code or API changes.

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any (n/a — no breaking changes)
- [x] I have made corresponding changes to the documentation if needed (corrected the gate's doc comments)

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone

🤖 Generated with [Claude Code](https://claude.com/claude-code)
