### PR TITLE
feat(rs-sdk-ffi): expose dash_sdk_signer_can_sign for signer-delegated key preflight

### DIFF
--- a/packages/rs-sdk-ffi/src/signer.rs
+++ b/packages/rs-sdk-ffi/src/signer.rs
@@ -819,6 +819,102 @@ pub unsafe extern "C" fn dash_sdk_signer_destroy(handle: *mut SignerHandle) {
     let _ = Box::from_raw(handle as *mut VTableSigner);
 }
 
+/// Query whether the supplied signer can sign for a given identity public
+/// key, WITHOUT pulling any private-key material across the FFI.
+///
+/// This exists so the Swift SDK can keep its key-selection *policy* (ranking
+/// candidates by purpose / security level) in Swift while delegating the
+/// *availability* decision — "does this exact signer hold private material
+/// for this key?" — to the signer that will actually be used at sign time.
+/// Before this export existed, the only way to learn availability was to let
+/// Rust invoke the vtable's `can_sign_with` slot internally during signing,
+/// which forced Swift to preflight against a *separate* store
+/// (`KeychainManager.shared`). That coupling silently mis-judged any signer
+/// not backed by the shared Keychain (a raw-key `createSigner`, a
+/// hardware-backed callback signer, or a `KeychainSigner` bound to a
+/// different `KeychainManager`). This export removes that coupling: the
+/// preflight asks the supplied signer directly.
+///
+/// The verdict naturally covers BOTH inner `VTableSigner` variants:
+/// - `Inner::Callback` forwards `(pubkey_bytes, key_type)` through the
+///   vtable's `can_sign_with` slot, identical to the wire encoding used by
+///   `sign_async` (raw pubkey bytes + `KeyType` discriminant byte).
+/// - `Inner::Native` delegates to the wrapped Rust `Signer`, which compares
+///   the key material it holds.
+///
+/// `key_type` is the `dpp::identity::KeyType` discriminant byte (0–4). This
+/// FFI is for *identity* public keys only; the `0xFF` platform-address tag
+/// (and any other out-of-range byte) returns `false`.
+///
+/// Returns `false` (never aborts) on any of: null `signer`, an out-of-range
+/// `key_type`, or a signer that reports it cannot sign.
+///
+/// # Safety
+/// - `signer` must be a valid `*const SignerHandle` previously returned by
+///   this SDK (e.g. `dash_sdk_signer_create*` /
+///   `dash_sdk_signer_create_from_private_key`) and not yet destroyed. It may
+///   be null, in which case this returns `false`.
+/// - `pubkey_bytes` must point to at least `pubkey_len` readable bytes, OR be
+///   null with `pubkey_len == 0`. The bytes are only read for the duration of
+///   this call and are not retained.
+#[no_mangle]
+pub unsafe extern "C" fn dash_sdk_signer_can_sign(
+    signer: *const SignerHandle,
+    pubkey_bytes: *const u8,
+    pubkey_len: usize,
+    key_type: u8,
+) -> bool {
+    if signer.is_null() {
+        return false;
+    }
+
+    // This FFI is for identity public keys only. `KeyType::try_from` rejects
+    // anything outside 0–4 (including the 0xFF platform-address tag), so an
+    // out-of-range byte fails closed.
+    let key_type = match dash_sdk::dpp::identity::KeyType::try_from(key_type) {
+        Ok(kt) => kt,
+        Err(_) => return false,
+    };
+
+    let bytes = if pubkey_bytes.is_null() {
+        Vec::new()
+    } else {
+        // SAFETY: caller guarantees `pubkey_bytes` is valid for `pubkey_len`
+        // readable bytes (documented contract above).
+        std::slice::from_raw_parts(pubkey_bytes, pubkey_len).to_vec()
+    };
+
+    // A `*const SignerHandle` is really a `*const VTableSigner` (see
+    // `dash_sdk_signer_destroy`, which `Box::from_raw`s it as `*mut
+    // VTableSigner`). SAFETY: caller guarantees the handle is valid and not
+    // destroyed; we only borrow it, we do not take ownership.
+    let vtable_signer = &*(signer as *const VTableSigner);
+
+    // Reconstruct a minimal IdentityPublicKey. Only `data` + `key_type` are
+    // load-bearing: the Callback variant reads exactly those two via the
+    // vtable slot, and the Native variant compares the key material. The
+    // id / purpose / security_level are irrelevant to `can_sign_with` — same
+    // shape as `make_dummy_key()` in the tests below.
+    let ipk = {
+        use dash_sdk::dpp::identity::identity_public_key::v0::IdentityPublicKeyV0;
+        use dash_sdk::dpp::identity::{Purpose, SecurityLevel};
+        use dash_sdk::dpp::platform_value::BinaryData;
+
+        IdentityPublicKey::V0(IdentityPublicKeyV0 {
+            id: 0,
+            purpose: Purpose::AUTHENTICATION,
+            security_level: SecurityLevel::HIGH,
+            key_type,
+            read_only: false,
+            data: BinaryData::new(bytes),
+            disabled_at: None,
+            contract_bounds: None,
+        })
+    };
+
+    <VTableSigner as Signer<IdentityPublicKey>>::can_sign_with(vtable_signer, &ipk)
+}
+
 /// Free bytes that were allocated with `malloc`/`calloc`.
 ///
 /// Kept for backwards compatibility with older FFI code that exchanges
@@ -850,6 +946,7 @@ pub fn signer_handle_from_single_key(signer: SingleKeySigner) -> *mut SignerHand
 #[cfg(test)]
 mod tests {
     use super::*;
+    use dash_sdk::dpp::identity::KeyType;
     use std::sync::atomic::{AtomicBool, Ordering};
 
     /// Global flag set by the completion invocation during tests so we can
@@ -929,6 +1026,16 @@ mod tests {
         true
     }
 
+    /// Test can-sign callback that always reports the key is NOT available.
+    unsafe extern "C" fn test_cannot_sign(
+        _signer: *const c_void,
+        _pubkey_bytes: *const u8,
+        _pubkey_len: usize,
+        _key_type: u8,
+    ) -> bool {
+        false
+    }
+
     /// Test destroy callback (no-op).
     unsafe extern "C" fn test_destroy(_signer: *mut c_void) {}
 
@@ -959,6 +1066,98 @@ mod tests {
         // SAFETY: we just produced the vtable with Box::into_raw and we take
         // ownership of it here (owns_vtable = true) so it will be freed on drop.
         unsafe { VTableSigner::from_callback(std::ptr::null_mut(), vtable_ptr, true) }
+    }
+
+    /// Build a callback-backed signer with a specific `can_sign_with` slot,
+    /// so the `dash_sdk_signer_can_sign` tests can pin the vtable verdict.
+    fn make_signer_with_can_sign(can_sign_with: CanSignCallback) -> VTableSigner {
+        let vtable = Box::new(SignerVTable {
+            sign_async: test_sign_async_sync,
+            can_sign_with,
+            destroy: test_destroy,
+        });
+        let vtable_ptr = Box::into_raw(vtable);
+        // SAFETY: vtable just produced via Box::into_raw; owns_vtable = true
+        // frees it on drop.
+        unsafe { VTableSigner::from_callback(std::ptr::null_mut(), vtable_ptr, true) }
+    }
+
+    #[test]
+    fn can_sign_ffi_round_trips_vtable_true_verdict() {
+        let signer = make_signer_with_can_sign(test_can_sign);
+        let handle = Box::into_raw(Box::new(signer)) as *const SignerHandle;
+        let pubkey = [0u8; 33];
+        // SAFETY: handle is a freshly-boxed VTableSigner; pubkey is 33 bytes.
+        let verdict = unsafe {
+            dash_sdk_signer_can_sign(
+                handle,
+                pubkey.as_ptr(),
+                pubkey.len(),
+                KeyType::ECDSA_SECP256K1 as u8,
+            )
+        };
+        assert!(verdict, "true vtable verdict must round-trip as true");
+        // SAFETY: reclaim the boxed signer.
+        unsafe { dash_sdk_signer_destroy(handle as *mut SignerHandle) };
+    }
+
+    #[test]
+    fn can_sign_ffi_round_trips_vtable_false_verdict() {
+        let signer = make_signer_with_can_sign(test_cannot_sign);
+        let handle = Box::into_raw(Box::new(signer)) as *const SignerHandle;
+        let pubkey = [0u8; 33];
+        // SAFETY: handle is a freshly-boxed VTableSigner; pubkey is 33 bytes.
+        let verdict = unsafe {
+            dash_sdk_signer_can_sign(
+                handle,
+                pubkey.as_ptr(),
+                pubkey.len(),
+                KeyType::ECDSA_SECP256K1 as u8,
+            )
+        };
+        assert!(!verdict, "false vtable verdict must round-trip as false");
+        // SAFETY: reclaim the boxed signer.
+        unsafe { dash_sdk_signer_destroy(handle as *mut SignerHandle) };
+    }
+
+    #[test]
+    fn can_sign_ffi_null_signer_is_false() {
+        let pubkey = [0u8; 33];
+        // SAFETY: null signer is an explicitly-documented input; returns false.
+        let verdict = unsafe {
+            dash_sdk_signer_can_sign(
+                std::ptr::null(),
+                pubkey.as_ptr(),
+                pubkey.len(),
+                KeyType::ECDSA_SECP256K1 as u8,
+            )
+        };
+        assert!(!verdict, "null signer must yield false");
+    }
+
+    #[test]
+    fn can_sign_ffi_out_of_range_key_type_is_false() {
+        // A `true`-returning vtable would say yes — but an out-of-range
+        // key_type (e.g. the 0xFF platform-address tag) must fail closed
+        // BEFORE the vtable is ever consulted.
+        let signer = make_signer_with_can_sign(test_can_sign);
+        let handle = Box::into_raw(Box::new(signer)) as *const SignerHandle;
+        let pubkey = [0u8; 20];
+        // SAFETY: handle valid; pubkey is 20 bytes.
+        let verdict = unsafe {
+            dash_sdk_signer_can_sign(
+                handle,
+                pubkey.as_ptr(),
+                pubkey.len(),
+                SIGNER_KEY_TYPE_PLATFORM_ADDRESS_HASH,
+            )
+        };
+        assert!(
+            !verdict,
+            "out-of-range key_type must yield false even with a true-returning vtable"
+        );
+        // SAFETY: reclaim the boxed signer.
+        unsafe { dash_sdk_signer_destroy(handle as *mut SignerHandle) };
     }
 
     #[tokio::test]

--- a/packages/swift-sdk/Sources/SwiftDashSDK/FFI/StateTransitionExtensions.swift
+++ b/packages/swift-sdk/Sources/SwiftDashSDK/FFI/StateTransitionExtensions.swift
@@ -17,52 +17,104 @@ private final class SendableOpaque: @unchecked Sendable { let p: OpaquePointer; 
 
 // MARK: - Key Selection Helpers
 
-/// Helper to select the appropriate key for signing operations.
-/// Picks a key whose purpose matches the state-transition requirement
-/// AND whose private material is actually available in the Keychain
-/// (delegating to KeyManager.findSigningKey, which mirrors how the
-/// KeychainSigner trampoline resolves the key at sign time).
+/// Ask the SUPPLIED signer — not `KeychainManager.shared` — whether it holds
+/// signable private material for `key`. Pure marshalling: it ships the key's
+/// raw public-key bytes + `KeyType` discriminant byte across the FFI and
+/// returns the signer's own verdict via `dash_sdk_signer_can_sign`. The
+/// availability *decision* lives entirely in Rust / the signer; Swift only
+/// converts the bytes. Never pulls private-key material across the boundary.
 ///
-/// **Caller contract / known coupling:** availability is checked against
-/// `KeychainManager.shared`, so the `signer` handed to the document ops
-/// below must be backed by the shared Keychain. Every current caller
-/// passes a `KeychainSigner`, which defaults to `KeychainManager.shared`,
-/// so the store queried here is exactly the one the signer will use at
-/// sign time. A signer bound to a different `KeychainManager`, a raw
-/// private-key signer (`KeyManager.createSigner(from:)`), or a
-/// hardware-backed callback signer is NOT consulted here — this preflight
-/// could then reject a key that signer can actually sign. Removing the
-/// coupling would mean ranking candidates by purpose/security in Swift
-/// and delegating the availability check to the supplied signer (which
-/// needs a `dash_sdk_signer_can_sign`-style FFI that does not yet exist;
-/// the `can_sign` vtable slot is only invoked internally by Rust during
-/// signing).
+/// `key.keyType.rawValue` is the dpp `KeyType` discriminant (0–4) the Rust
+/// side expects; identity keys only.
+private func signerCanSign(_ signer: OpaquePointer, _ key: IdentityPublicKey) -> Bool {
+    key.data.withUnsafeBytes { (raw: UnsafeRawBufferPointer) -> Bool in
+        dash_sdk_signer_can_sign(
+            signerConst(signer),
+            raw.bindMemory(to: UInt8.self).baseAddress,
+            UInt(key.data.count),
+            key.keyType.rawValue
+        )
+    }
+}
+
+/// Helper to select the appropriate key for signing operations.
+///
+/// Key-selection *policy* (rank candidates by purpose / security level) runs
+/// in Swift via `KeyManager.rankSigningCandidates`; the *availability* check
+/// ("does this signer actually hold the private material?") is delegated to
+/// the SUPPLIED `signer` through `dash_sdk_signer_can_sign`. This removes the
+/// old coupling to `KeychainManager.shared`: a signer bound to a different
+/// `KeychainManager`, a raw private-key signer (`KeyManager.createSigner`),
+/// or a hardware-backed callback signer is now consulted directly, so the
+/// preflight matches exactly what will happen at sign time.
+///
+/// When `signer == nil` (no signer available to ask) this falls back to the
+/// shared-Keychain `KeyManager.findSigningKey` path — same behavior as before
+/// the FFI delegation existed.
 @MainActor
-private func selectSigningKey(from identity: DPPIdentity, operation: String) -> IdentityPublicKey? {
+private func selectSigningKey(
+    from identity: DPPIdentity,
+    operation: String,
+    signer: OpaquePointer?
+) -> IdentityPublicKey? {
     print("🔑 [\(operation)] Selecting public key for identity \(identity.id.toBase58String())")
+
+    // Contract create/update require a CRITICAL + AUTHENTICATION key;
+    // document ops require any AUTHENTICATION key (prefer CRITICAL).
+    let isContractOp = operation == "CONTRACT CREATE" || operation == "CONTRACT UPDATE"
+    let minimumSecurityLevel: SecurityLevel? = isContractOp ? .critical : nil
 
     let km = KeyManager.withSharedKeychain()
 
-    // Contract create/update require a CRITICAL + AUTHENTICATION key.
-    if operation == "CONTRACT CREATE" || operation == "CONTRACT UPDATE" {
-        if let k = km.findSigningKey(for: identity, purpose: .authentication, minimumSecurityLevel: .critical, preferCritical: true) {
-            print("📝 [\(operation)] Selected CRITICAL AUTHENTICATION key #\(k.id)")
+    // No signer to ask → fall back to the shared-Keychain availability check.
+    guard let signer = signer else {
+        if let k = km.findSigningKey(
+            for: identity,
+            purpose: .authentication,
+            minimumSecurityLevel: minimumSecurityLevel,
+            preferCritical: true
+        ) {
+            if isContractOp {
+                print("📝 [\(operation)] Selected CRITICAL AUTHENTICATION key #\(k.id)")
+            } else {
+                print("📝 [\(operation)] Selected AUTHENTICATION key #\(k.id) (security \(k.securityLevel.name))")
+            }
             return k
         }
-        print("❌ [\(operation)] No CRITICAL AUTHENTICATION key with available private material")
+        if isContractOp {
+            print("❌ [\(operation)] No CRITICAL AUTHENTICATION key with available private material")
+        } else {
+            print("❌ [\(operation)] No AUTHENTICATION key with available private material")
+        }
         return nil
     }
 
-    // Document state transitions require an AUTHENTICATION-purpose key.
-    // Prefer a CRITICAL auth key, but findSigningKey skips any candidate
-    // whose private key is not in the Keychain, so an identity whose only
-    // CRITICAL key is a TRANSFER key (or a CRITICAL auth key with no stored
-    // private material) correctly falls through to its HIGH auth key.
-    if let k = km.findSigningKey(for: identity, purpose: .authentication, minimumSecurityLevel: nil, preferCritical: true) {
-        print("📝 [\(operation)] Selected AUTHENTICATION key #\(k.id) (security \(k.securityLevel.name))")
+    // Rank candidates by purpose/security in Swift, then delegate the
+    // availability decision to the supplied signer. Prefer a CRITICAL auth
+    // key, but skip any candidate the signer can't actually sign with, so an
+    // identity whose only CRITICAL key is a TRANSFER key (or a CRITICAL auth
+    // key with no stored private material) correctly falls through to its
+    // HIGH auth key.
+    let candidates = km.rankSigningCandidates(
+        for: identity,
+        purpose: .authentication,
+        minimumSecurityLevel: minimumSecurityLevel,
+        preferCritical: true
+    )
+    for k in candidates where signerCanSign(signer, k) {
+        if isContractOp {
+            print("📝 [\(operation)] Selected CRITICAL AUTHENTICATION key #\(k.id)")
+        } else {
+            print("📝 [\(operation)] Selected AUTHENTICATION key #\(k.id) (security \(k.securityLevel.name))")
+        }
         return k
     }
-    print("❌ [\(operation)] No AUTHENTICATION key with available private material")
+
+    if isContractOp {
+        print("❌ [\(operation)] No CRITICAL AUTHENTICATION key with available private material")
+    } else {
+        print("❌ [\(operation)] No AUTHENTICATION key with available private material")
+    }
     return nil
 }
 
@@ -491,7 +543,7 @@ extension SDK {
 
         // Select the signing key on the MainActor (KeyManager is @MainActor)
         // before dispatching the FFI work off-actor.
-        guard let signingKey = selectSigningKey(from: ownerIdentity, operation: "DOCUMENT CREATE") else {
+        guard let signingKey = selectSigningKey(from: ownerIdentity, operation: "DOCUMENT CREATE", signer: signer) else {
             throw SDKError.invalidParameter("No public key found for identity")
         }
 
@@ -670,7 +722,7 @@ extension SDK {
 
         // Select the signing key on the MainActor (KeyManager is @MainActor)
         // before dispatching the FFI work off-actor.
-        guard let signingKey = selectSigningKey(from: ownerIdentity, operation: "DOCUMENT REPLACE") else {
+        guard let signingKey = selectSigningKey(from: ownerIdentity, operation: "DOCUMENT REPLACE", signer: signer) else {
             throw SDKError.invalidParameter("No public key found")
         }
 
@@ -832,7 +884,7 @@ extension SDK {
 
         // Select the signing key on the MainActor (KeyManager is @MainActor)
         // before dispatching the FFI work off-actor.
-        guard let signingKey = selectSigningKey(from: ownerIdentity, operation: "DOCUMENT DELETE") else {
+        guard let signingKey = selectSigningKey(from: ownerIdentity, operation: "DOCUMENT DELETE", signer: signer) else {
             throw SDKError.protocolError("No suitable key found for signing")
         }
 
@@ -922,7 +974,7 @@ extension SDK {
 
         // Select the signing key on the MainActor (KeyManager is @MainActor)
         // before dispatching the FFI work off-actor.
-        guard let signingKey = selectSigningKey(from: fromIdentity, operation: "DOCUMENT TRANSFER") else {
+        guard let signingKey = selectSigningKey(from: fromIdentity, operation: "DOCUMENT TRANSFER", signer: signer) else {
             throw SDKError.invalidParameter("No suitable key found for signing")
         }
 
@@ -1111,7 +1163,7 @@ extension SDK {
 
         // Select the signing key on the MainActor (KeyManager is @MainActor)
         // before dispatching the FFI work off-actor.
-        guard let signingKey = selectSigningKey(from: ownerIdentity, operation: "UPDATE_PRICE") else {
+        guard let signingKey = selectSigningKey(from: ownerIdentity, operation: "UPDATE_PRICE", signer: signer) else {
             throw SDKError.invalidParameter("No suitable signing key found")
         }
 
@@ -1253,7 +1305,7 @@ extension SDK {
 
         // Select the signing key on the MainActor (KeyManager is @MainActor)
         // before entering the continuation, for consistency with the other ops.
-        guard let signingKey = selectSigningKey(from: purchaserIdentity, operation: "DOCUMENT PURCHASE") else {
+        guard let signingKey = selectSigningKey(from: purchaserIdentity, operation: "DOCUMENT PURCHASE", signer: signer) else {
             throw SDKError.invalidParameter("No suitable key found for signing")
         }
 

--- a/packages/swift-sdk/Sources/SwiftDashSDK/KeyWallet/KeyManager.swift
+++ b/packages/swift-sdk/Sources/SwiftDashSDK/KeyWallet/KeyManager.swift
@@ -280,6 +280,27 @@ public final class KeyManager: Sendable {
     return bySecurity
   }
 
+  /// Public ranking entry point. Returns the same purpose/security-ordered
+  /// candidate list `findSigningKey` walks, but WITHOUT any private-material
+  /// availability check — pure key-selection *policy*. Callers that want to
+  /// delegate the availability decision to a specific signer (rather than to
+  /// `KeychainManager.shared`) rank candidates here and then ask that signer
+  /// directly. This is a read-only filter over `identity.publicKeys`; it does
+  /// not touch the Keychain, so it stays out of the `@MainActor` Keychain path.
+  public func rankSigningCandidates(
+    for identity: DPPIdentity,
+    purpose: KeyPurpose? = nil,
+    minimumSecurityLevel: SecurityLevel? = nil,
+    preferCritical: Bool = true
+  ) -> [IdentityPublicKey] {
+    rankKeys(
+      for: identity,
+      purpose: purpose,
+      minimumSecurityLevel: minimumSecurityLevel,
+      preferCritical: preferCritical
+    )
+  }
+
   // MARK: - Signer Creation
 
   /// Create a signer from private key data


### PR DESCRIPTION
## Issue being fixed or feature implemented

Follow-up to #3922 (review thread https://github.com/dashpay/platform/pull/3922#discussion_r3423222271).

`selectSigningKey(from:operation:)` in `StateTransitionExtensions.swift` picks the public key for a document state transition by ranking candidates by purpose/security, then checking private-material availability against `KeychainManager.shared` (via `KeyManager.withSharedKeychain().findSigningKey(...)`). The six document SDK ops (documentCreate / Replace / Delete / Transfer / UpdatePrice / Purchase) each accept a generic `signer: OpaquePointer`, so a caller passing a signer **not** backed by the shared Keychain — a raw-key `KeyManager.createSigner(from:)` signer, a hardware-backed callback signer, or a `KeychainSigner` bound to a different `KeychainManager` — would have its key availability mis-judged, and the preflight could reject a key that signer can actually sign with.

It's a latent design coupling, not an active bug: every current caller passes a `KeychainSigner` defaulting to `KeychainManager.shared`. But it's exactly the coupling #3922's own doc-comment flagged for removal.

## What was done?

Removed the coupling by delegating the **availability** decision to the *supplied* signer, while keeping key-selection **policy** (ranking by purpose/security) in Swift.

**`rs-sdk-ffi` (`signer.rs`)** — new export:

```rust
pub unsafe extern "C" fn dash_sdk_signer_can_sign(
    signer: *const SignerHandle,
    pubkey_bytes: *const u8,
    pubkey_len: usize,
    key_type: u8,
) -> bool
```

It reconstructs a minimal `IdentityPublicKey` from `(pubkey_bytes, key_type)` and calls the existing `VTableSigner::can_sign_with` (previously only invoked internally by Rust during signing). This naturally covers both inner variants: `Inner::Callback` forwards `(pubkey_bytes, key_type)` through the vtable's `can_sign_with` slot (same wire encoding as `sign_async`), and `Inner::Native` delegates to the wrapped Rust signer. `KeyType::try_from(key_type)` fails closed on any out-of-range byte (including the `0xFF` platform-address tag); a null `signer` returns `false`. No private-key material crosses the boundary.

**`swift-sdk`**:
- `selectSigningKey` now takes `signer: OpaquePointer?`. It ranks candidates via the new public `KeyManager.rankSigningCandidates(...)` and returns the first key the **supplied** signer reports it can sign with through a thin `signerCanSign(_:_:)` marshalling wrapper over `dash_sdk_signer_can_sign`.
- The shared-Keychain `findSigningKey` path is retained as the **fallback used only when no signer is available** (`signer == nil`).
- All six document ops pass their in-scope `signer` to `selectSigningKey`.
- `KeyManager.rankSigningCandidates(...)` is a public, read-only ranking entry point delegating to the existing private `rankKeys(...)` (no duplication; stays off the `@MainActor` Keychain path).

The same purpose/security policy as before is preserved: contract create/update → AUTHENTICATION + minimum CRITICAL; document ops → AUTHENTICATION, prefer CRITICAL. Existing log markers are unchanged.

## How Has This Been Tested?

- `cargo fmt --all` clean; `cargo check -p rs-sdk-ffi` (incl. `--all-targets`) clean.
- 4 new unit tests in `signer.rs` (`can_sign_ffi_*`): true/false vtable verdict round-trip, null signer → false, out-of-range key_type fails closed before the vtable is consulted. `cargo test -p rs-sdk-ffi can_sign_ffi` → **4 passed**; full `signer` suite → **39 passed**.
- `packages/swift-sdk/build_ios.sh` succeeded; the new `dash_sdk_signer_can_sign` symbol is present in the generated `rs-sdk-ffi.h`. **SwiftExampleApp built to `BUILD SUCCEEDED`**, confirming the Swift wrapper, `rankSigningCandidates`, and rewired `selectSigningKey` compile against the regenerated header.

## Breaking Changes

None. This adds a new FFI export and an additional `signer:` parameter on a `private` Swift helper (all in-tree call sites updated). Not consensus-breaking.

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [ ] I have made corresponding changes to the documentation if needed

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone

🤖 Generated with [Claude Code](https://claude.com/claude-code)