### PR TITLE
feat(swift-example-app): GroveDB path elements diagnostic view (SYS-06)

### DIFF
--- a/packages/swift-sdk/Sources/SwiftDashSDK/FFI/PlatformQueryExtensions.swift
+++ b/packages/swift-sdk/Sources/SwiftDashSDK/FFI/PlatformQueryExtensions.swift
@@ -27,6 +27,27 @@ public struct DocumentCountResult: Sendable {
     }
 }
 
+/// One element returned by ``SDK/systemPathElements(path:keys:)``.
+///
+/// Mirrors a single object in the FFI's JSON array payload
+/// (`[{"key":"<hex>","element":"<formatted>","type":"<grovedb-variant>"}]`).
+public struct PathElement: Sendable {
+    /// Hex-encoded GroveDB key.
+    public let key: String
+    /// The formatted element value (e.g. a hex item, `sum_item:<n>`, or
+    /// `tree`), exactly as rendered by the Rust side.
+    public let element: String
+    /// The GroveDB element variant (e.g. `tree`, `item`, `sum_item`,
+    /// `sum_tree`).
+    public let type: String
+
+    public init(key: String, element: String, type: String) {
+        self.key = key
+        self.element = element
+        self.type = type
+    }
+}
+
 // MARK: - Platform Query Extensions for SDK
 @MainActor
 extension SDK {
@@ -1634,5 +1655,74 @@ extension SDK {
 
         let result = dash_sdk_system_get_prefunded_specialized_balance(handle, id)
         return try processUInt64Result(result)
+    }
+
+    /// Fetch the raw GroveDB elements stored under `keys` within `path`.
+    ///
+    /// Thin bridge over `dash_sdk_system_get_path_elements`: it serializes
+    /// the `path` / `keys` string arrays to JSON, passes them to the FFI,
+    /// and marshals the
+    /// `[{"key":"<hex>","element":"<formatted>","type":"<variant>"}]`
+    /// payload out into ``PathElement`` rows. The FFI accepts each string as
+    /// either hex-encoded bytes (preferred) or plain UTF-8 (hex-decode is
+    /// tried first, with a raw-bytes fallback). All of the GroveDB traversal
+    /// + formatting happens on the Rust side; nothing is decided here.
+    ///
+    /// - Parameters:
+    ///   - path: GroveDB path segments. `[]` is the root. Each segment is
+    ///     hex bytes or a plain string (e.g. `["60"]` for the Balances
+    ///     subtree).
+    ///   - keys: Keys to fetch within `path`, same hex-or-plain rule
+    ///     (e.g. `["20","40","10","60"]` for the top-level RootTree subtrees).
+    /// - Returns: The matching ``PathElement`` rows. Empty when the FFI
+    ///   returns no elements (`NoData`).
+    @MainActor
+    public func systemPathElements(path: [String], keys: [String]) async throws -> [PathElement] {
+        guard let handle = handle else {
+            throw SDKError.invalidState("SDK not initialized")
+        }
+
+        // Serialize the path/keys string arrays to JSON for the FFI.
+        let pathData = try JSONSerialization.data(withJSONObject: path)
+        let keysData = try JSONSerialization.data(withJSONObject: keys)
+        guard let pathJSON = String(data: pathData, encoding: .utf8),
+              let keysJSON = String(data: keysData, encoding: .utf8) else {
+            throw SDKError.serializationError("Failed to encode path/keys JSON")
+        }
+
+        let result = pathJSON.withCString { pathPtr in
+            keysJSON.withCString { keysPtr in
+                dash_sdk_system_get_path_elements(handle, pathPtr, keysPtr)
+            }
+        }
+
+        // Surface FFI errors with their original code (network/timeout/etc.).
+        if let error = result.error {
+            let sdkError = SDKError.fromDashSDKError(error.pointee)
+            dash_sdk_error_free(error)
+            throw sdkError
+        }
+
+        // NoData (null payload, no error) means no elements were found —
+        // treat it as an empty array rather than an error.
+        guard let dataPtr = result.data else {
+            return []
+        }
+
+        let jsonString = String(cString: dataPtr.assumingMemoryBound(to: CChar.self))
+        dash_sdk_string_free(dataPtr)
+
+        guard let data = jsonString.data(using: .utf8),
+              let array = try? JSONSerialization.jsonObject(with: data) as? [[String: Any]] else {
+            throw SDKError.serializationError("Failed to parse path elements JSON array")
+        }
+
+        return array.map { entry in
+            PathElement(
+                key: entry["key"] as? String ?? "",
+                element: entry["element"] as? String ?? "",
+                type: entry["type"] as? String ?? ""
+            )
+        }
     }
 }

--- a/packages/swift-sdk/SwiftExampleApp/SwiftExampleApp/Views/GroveDBPathElementsView.swift
+++ b/packages/swift-sdk/SwiftExampleApp/SwiftExampleApp/Views/GroveDBPathElementsView.swift
@@ -1,0 +1,233 @@
+import SwiftUI
+import SwiftDashSDK
+
+/// READ-only diagnostic view that drives the raw GroveDB path-elements FFI
+/// (`dash_sdk_system_get_path_elements` via `SDK.systemPathElements`). Covers
+/// QA test SYS-06.
+///
+/// This is a low-level query view, not a state-transition builder — nothing
+/// is signed or broadcast. It takes a `path` (JSON array of strings) and a
+/// `keys` (JSON array of strings), passes them to the wrapper, and renders
+/// the returned elements (`type` / `key` / `element`) or the decode / FFI
+/// error.
+///
+/// The "DPNS contract example" preset fills the fields with a bounded query
+/// (the DPNS system contract under the `DataContractDocuments` root) so the
+/// query can be run without typing JSON (the simulator's smart-punctuation
+/// mangles typed quotes).
+struct GroveDBPathElementsView: View {
+    @EnvironmentObject var appState: AppState
+
+    /// JSON array string of GroveDB path segments, e.g. `["40"]` or `["60"]`.
+    @State private var pathText = ""
+    /// JSON array string of keys to fetch within the path.
+    @State private var keysText = ""
+
+    @State private var isRunning = false
+    /// Set once a run completes (success or failure) so the result section
+    /// appears.
+    @State private var didRun = false
+    @State private var elements: [PathElement] = []
+    @State private var errorMessage: String?
+
+    var body: some View {
+        Form {
+            inputSection
+            runSection
+            if didRun {
+                resultSection
+            }
+        }
+        .navigationTitle("GroveDB Path Elements")
+        .navigationBarTitleDisplayMode(.inline)
+    }
+
+    // MARK: - Sections
+
+    private var inputSection: some View {
+        Section {
+            TextField("[] or [\"60\"]", text: $pathText)
+                .textInputAutocapitalization(.never)
+                .disableAutocorrection(true)
+                .font(.system(.footnote, design: .monospaced))
+                .accessibilityLabel("Path JSON array")
+                .accessibilityIdentifier("sysPathElements.pathField")
+                .disabled(isRunning)
+
+            TextField("[\"20\",\"40\",\"10\",\"60\"]", text: $keysText)
+                .textInputAutocapitalization(.never)
+                .disableAutocorrection(true)
+                .font(.system(.footnote, design: .monospaced))
+                .accessibilityLabel("Keys JSON array")
+                .accessibilityIdentifier("sysPathElements.keysField")
+                .disabled(isRunning)
+
+            Button(action: applyExamplePreset) {
+                Label("DPNS contract example", systemImage: "tray.2")
+            }
+            .accessibilityLabel("Fill DPNS contract example preset")
+            .accessibilityIdentifier("sysPathElements.presetButton")
+            .disabled(isRunning)
+        } header: {
+            Text("Query")
+        } footer: {
+            Text("`path` and `keys` are JSON arrays of strings. Each string is hex bytes (preferred) or plain text. \"DPNS contract example\" fills path = [\"40\"] (the DataContractDocuments root, byte 0x40) and keys = [the DPNS system contract id], returning that contract's GroveDB subtree. Use a bounded (non-empty) path: root-level queries (path = []) currently fail GroveDB proof verification.")
+        }
+    }
+
+    private var runSection: some View {
+        Section {
+            Button(action: runQuery) {
+                HStack {
+                    if isRunning {
+                        ProgressView()
+                            .progressViewStyle(.circular)
+                    } else {
+                        Image(systemName: "magnifyingglass")
+                    }
+                    Text(isRunning ? "Running…" : "Run")
+                        .fontWeight(.semibold)
+                }
+                .frame(maxWidth: .infinity)
+            }
+            .disabled(isRunning || appState.sdk == nil)
+            .accessibilityIdentifier("sysPathElements.runButton")
+        }
+    }
+
+    @ViewBuilder
+    private var resultSection: some View {
+        if let errorMessage = errorMessage {
+            Section("Error") {
+                Text(errorMessage)
+                    .foregroundColor(.red)
+                    .font(.callout)
+                    .textSelection(.enabled)
+                    .accessibilityIdentifier("sysPathElements.errorText")
+            }
+        } else {
+            Section("Elements (\(elements.count))") {
+                if elements.isEmpty {
+                    Text("No elements found")
+                        .foregroundColor(.secondary)
+                        .accessibilityIdentifier("sysPathElements.emptyText")
+                } else {
+                    ForEach(elements, id: \.key) { element in
+                        VStack(alignment: .leading, spacing: 4) {
+                            Text(element.type)
+                                .font(.subheadline)
+                                .fontWeight(.semibold)
+                                .foregroundColor(.blue)
+                            Text(element.key)
+                                .font(.system(.footnote, design: .monospaced))
+                                .lineLimit(1)
+                                .truncationMode(.middle)
+                                .textSelection(.enabled)
+                            Text(element.element)
+                                .font(.system(.caption, design: .monospaced))
+                                .foregroundColor(.secondary)
+                                .textSelection(.enabled)
+                        }
+                        .padding(.vertical, 2)
+                        .accessibilityElement(children: .combine)
+                        .accessibilityIdentifier("sysPathElements.resultRow.\(element.key)")
+                    }
+                }
+            }
+        }
+    }
+
+    // MARK: - Actions
+
+    /// Fill the fields with a bounded example query: the DPNS system data
+    /// contract under the `DataContractDocuments` root (RootTree byte `0x40`).
+    /// Sets the @State strings directly so no JSON has to be typed (the
+    /// simulator's smart-punctuation mangles typed quotes). A *bounded* path
+    /// is used on purpose — empty-path (root-level) queries currently fail
+    /// GroveDB proof verification ("Cannot verify lower bound").
+    private func applyExamplePreset() {
+        pathText = "[\"40\"]"
+        keysText = "[\"e668c659af66aee1e72c186dde7b5b7e0a1d712a09c40d5721f622bf53c53155\"]"
+        resetResult()
+    }
+
+    private func resetResult() {
+        didRun = false
+        elements = []
+        errorMessage = nil
+    }
+
+    private func runQuery() {
+        guard let sdk = appState.sdk else {
+            errorMessage = "SDK not initialized"
+            didRun = true
+            return
+        }
+
+        // Decode the two text fields from JSON arrays of strings.
+        let path: [String]
+        let keys: [String]
+        do {
+            path = try decodeStringArray(pathText, field: "path")
+            keys = try decodeStringArray(keysText, field: "keys")
+        } catch {
+            errorMessage = error.localizedDescription
+            didRun = true
+            return
+        }
+
+        isRunning = true
+        errorMessage = nil
+        elements = []
+
+        Task {
+            do {
+                let fetched = try await sdk.systemPathElements(path: path, keys: keys)
+                await MainActor.run {
+                    self.elements = fetched
+                    self.didRun = true
+                    self.isRunning = false
+                }
+            } catch {
+                await MainActor.run {
+                    self.errorMessage = error.localizedDescription
+                    self.didRun = true
+                    self.isRunning = false
+                }
+            }
+        }
+    }
+
+    /// Parse a JSON array-of-strings text field, surfacing a clear error when
+    /// it isn't valid JSON or isn't an array of strings.
+    private func decodeStringArray(_ text: String, field: String) throws -> [String] {
+        let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard let data = trimmed.data(using: .utf8) else {
+            throw PathElementsInputError.invalid("Could not encode \(field) field")
+        }
+        guard let array = try? JSONSerialization.jsonObject(with: data) as? [String] else {
+            throw PathElementsInputError.invalid("\(field) must be a JSON array of strings, e.g. [\"60\"]")
+        }
+        return array
+    }
+
+    private enum PathElementsInputError: LocalizedError {
+        case invalid(String)
+
+        var errorDescription: String? {
+            switch self {
+            case .invalid(let message):
+                return message
+            }
+        }
+    }
+}
+
+struct GroveDBPathElementsView_Previews: PreviewProvider {
+    static var previews: some View {
+        NavigationView {
+            GroveDBPathElementsView()
+                .environmentObject(AppState())
+        }
+    }
+}

--- a/packages/swift-sdk/SwiftExampleApp/SwiftExampleApp/Views/PlatformQueriesView.swift
+++ b/packages/swift-sdk/SwiftExampleApp/SwiftExampleApp/Views/PlatformQueriesView.swift
@@ -103,6 +103,19 @@ struct QueryCategoryDetailView: View {
                             }
                             .padding(.vertical, 4)
                         }
+                    } else if query.name == "getPathElements" {
+                        NavigationLink(destination: GroveDBPathElementsView()) {
+                            VStack(alignment: .leading, spacing: 4) {
+                                Text(query.label)
+                                    .font(.headline)
+                                Text(query.description)
+                                    .font(.caption)
+                                    .foregroundColor(.secondary)
+                                    .lineLimit(2)
+                            }
+                            .padding(.vertical, 4)
+                        }
+                        .accessibilityIdentifier("systemQueries.getPathElementsLink")
                     } else if query.name == "testDPNSQueries" {
                         NavigationLink(destination: DPNSTestView()) {
                             VStack(alignment: .leading, spacing: 4) {
@@ -228,7 +241,8 @@ struct QueryCategoryDetailView: View {
                 QueryDefinition(name: "getStatus", label: "Get Status", description: "Get system status"),
                 QueryDefinition(name: "getTotalCreditsInPlatform", label: "Get Total Credits in Platform", description: "Get total credits in the platform"),
                 QueryDefinition(name: "getCurrentQuorumsInfo", label: "Get Current Quorums Info", description: "Get information about current validator quorums"),
-                QueryDefinition(name: "getPrefundedSpecializedBalance", label: "Get Prefunded Specialized Balance", description: "Get balance of a prefunded specialized account")
+                QueryDefinition(name: "getPrefundedSpecializedBalance", label: "Get Prefunded Specialized Balance", description: "Get balance of a prefunded specialized account"),
+                QueryDefinition(name: "getPathElements", label: "Get GroveDB Path Elements", description: "Fetch raw GroveDB elements by path and keys (diagnostic)")
             ]
 
         case .addresses:

--- a/packages/swift-sdk/SwiftExampleApp/TEST_PLAN.md
+++ b/packages/swift-sdk/SwiftExampleApp/TEST_PLAN.md
@@ -290,7 +290,7 @@ Shielded notes/balance/activity have **no read-side FFI** by design — Rust pus
 | SYS-03 | Protocol-version upgrade state / vote status | Platform | Uncommon | ✅ | `PlatformQueriesView` protocol category. |
 | SYS-04 | Run-all-queries / DPNS test harness | Platform | Thorough | ✅ | `PlatformQueriesView` diagnostics (`runAllQueries`, `testDPNSQueries`), `DiagnosticsView`. |
 | SYS-05 | Storage / Keychain / Wallet-memory explorers | — | Thorough | ✅ | `StorageExplorerView`, `KeychainExplorerView`, `WalletMemoryExplorerView` (Settings; debug tooling). |
-| SYS-06 | Path elements (raw GroveDB) | Platform | Uncommon | 🔌 | FFI `dash_sdk_system_get_path_elements`; no UI. |
+| SYS-06 | Path elements (raw GroveDB) | Platform | Uncommon | 🧪 | **Get GroveDB Path Elements** read view (Platform Queries → System & Utility) → Swift wrapper over FFI `dash_sdk_system_get_path_elements` (proof-verified `Element::fetch_many` over `KeysInPath`). Enter a `path` + `keys` JSON array (hex bytes); returns `[{key, element, type}]`. Use a **bounded** path — root-level queries (`path=[]`) fail GroveDB proof verification ("Cannot verify lower bound"). The "DPNS contract example" preset fills `path=["40"]` (DataContractDocuments root) + the DPNS contract id → its subtree `tree` element. |
 
 ### 4.13 Multi-wallet on-device Platform scenarios (same network) — `Domain=MultiWallet`
 
@@ -444,7 +444,7 @@ The complete Platform read surface, mapped to where each RPC is exercised in the
 | getPrefundedSpecializedBalance | Thorough | ✅ | catalog |
 | waitForStateTransitionResult | Essential | ✅ | implicit in every write round-trip |
 | broadcastStateTransition | Essential | ✅ | implicit in every write (`@sdk-ignore` RPC) |
-| getPathElements | Uncommon | 🔌 | FFI only (`SYS-06`) |
+| getPathElements | Uncommon | 🧪 | "Get GroveDB Path Elements" read view (`SYS-06`) |
 | getConsensusParams | Uncommon | 🚫 | `@sdk-ignore` (served via Tenderdash RPC) |
 
 ### Address Sync (DIP-17)
@@ -476,7 +476,6 @@ For completeness (the "everything gRPC + Core can do" requirement), these exist 
 **🔌 SDK-only (FFI/wrapper exists, no UI):**
 - `ADDR-05` address balance-change history (recent / compacted / branch / trunk)
 - `SH-11` create identity from shielded pool (Type 20)
-- `SYS-06` raw GroveDB path elements
 
 **🚫 Not implemented anywhere:**
 - `DOC-13` document SUM aggregation — FFI stub returns `NotImplemented` (blocked on grovedb PR 670)


### PR DESCRIPTION
## Issue being fixed or feature implemented

`SYS-06` (raw GroveDB path elements) was marked 🔌 *SDK-only, no UI* — the FFI `dash_sdk_system_get_path_elements` is fully implemented and proof-verified, but nothing in SwiftExampleApp surfaced it, so it could only ever be skipped in app QA. This adds the missing diagnostic surface.

## What was done?

- **SwiftDashSDK** (`PlatformQueryExtensions.swift`): added a thin read-only bridge `systemPathElements(path:keys:) -> [PathElement]` over the already-exported FFI `dash_sdk_system_get_path_elements` (call → marshal → parse the `{key, element, type}` JSON array → return; `NoData` → `[]`). Mirrors the existing `documentCount` wrapper — no business logic.
- **SwiftExampleApp** (`GroveDBPathElementsView.swift`, new; `PlatformQueriesView.swift`): a "Get GroveDB Path Elements" read view reachable via **Platform Queries → System & Utility → Get GroveDB Path Elements**. `path` + `keys` JSON fields, a Run button, a results list (type / key / element), an error section, and a **"DPNS contract example" preset** that fills the fields directly (no typed JSON → avoids the simulator's smart-punctuation mangling of quotes).
- The preset uses a **bounded** path on purpose: empty/root-level queries (`path=[]`) fail GroveDB proof verification ("Cannot verify lower bound"); bounded path queries verify cleanly. The footer documents this.
- **TEST_PLAN.md**: flipped `SYS-06` from 🔌 to 🧪, updated the Appendix A read-query row and the SDK-only completeness list.

No Rust / xcframework change — `dash_sdk_system_get_path_elements` was already implemented and exported; this is Swift-only.

## How Has This Been Tested?

Driven end-to-end on testnet (iPhone 16 Pro sim) via the new view: `path=["40"]` (the `DataContractDocuments` root, byte `0x40`), `keys=[DPNS system contract id]` → **1 element returned, type `tree`** (the DPNS contract's GroveDB subtree), proof-verified. Recorded `pass` for SYS-06 to the QA contract; it renders on the [live QA dashboard](https://dashpay.github.io/qa-dashboard-site/). Also confirmed the empty-path preset path errors with a proof-verification failure, which is why the shipped preset is bounded.

## Breaking Changes

None.

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [x] I have made corresponding changes to the documentation if needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a GroveDB path elements query interface to the example app, providing a diagnostic UI with preset DPNS contract examples for querying raw elements.
  * SDK now exposes a new method for querying GroveDB path elements with customizable path and key parameters.

* **Documentation**
  * Updated test plan to reflect new diagnostic UI capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->