### PR TITLE
docs(swift-example-app): retire GRP-04 from the QA catalog

### DIFF
--- a/packages/swift-sdk/SwiftExampleApp/TEST_PLAN.md
+++ b/packages/swift-sdk/SwiftExampleApp/TEST_PLAN.md
@@ -279,7 +279,7 @@ Shielded notes/balance/activity have **no read-side FFI** by design — Rust pus
 | GRP-01 | View group info / members | Platform | Thorough | ✅ | `GroupDetailView` (drill into member identities). |
 | GRP-02 | Group queries (info / infos / actions / signers) | Platform | Thorough | ✅ | `PlatformQueriesView` group category → `dash_sdk_group_get_*`. |
 | GRP-03 | Token group action — propose / co-sign | Platform | Uncommon | ✅ | Same as `TOK-15` / `TOK-16`. |
-| GRP-04 | Standalone group lifecycle management | Platform | Uncommon | 🚫 | Not implemented — groups exist only as a token access-control construct + read queries. There is no group-create/membership transition. |
+| GRP-04 | Standalone group lifecycle management | Platform | — | ➖ | Retired from the catalog — not implemented anywhere and never will be a standalone test: there is no group-create/membership transition; groups exist only as a token access-control construct (read queries `GRP-01`/`GRP-02`; actions `GRP-03` ≡ `TOK-15`/`TOK-16`). Kept here to document the absence; not seeded to the QA catalog. |
 
 ### 4.12 System / Protocol / Diagnostics — `Domain=System`
 


### PR DESCRIPTION
## Issue being fixed or feature implemented
`GRP-04` ("standalone group lifecycle management") was marked `🚫`, but it isn't a pending feature — it's an **architectural absence**: there is **no group-create / membership transition** on the protocol. Groups exist only as a token access-control construct (read queries `GRP-01`/`GRP-02`; group actions `GRP-03` ≡ `TOK-15`/`TOK-16`). As a seeded catalog row it produced a confusing "not implemented, no runs" tile on the QA dashboard for something that will never be a standalone test.

Follow-up to #3929 (which retired the `VOTE-07`/`ID-13` builder stubs the same way).

## What was done?
- Reclassified `GRP-04` `🚫 → ➖` ("retired — folded/absent", per the legend) with a note recording *why* it's absent.
- `seed.mjs` already skips **and deletes** `➖` rows, so `GRP-04` drops out of the on-chain catalog on the next seed; the row stays here to document the absence.
- The on-chain `testCase` for `GRP-04` was deleted to match (dashboard already updated).
- **`DOC-13`/`DOC-14`** (the other `🚫` rows — sum/avg aggregation, blocked on grovedb) are intentionally **left as-is**: they're pending a dependency and worth tracking as blocked, and will seed normally once reclassified `✅`/`🔌`.

## How Has This Been Tested?
- Confirmed `GRP-04`'s on-chain `testCase` now queries to count 0.
- Verified the `➖`-skip path in `seed.mjs` drops the row (same guard exercised for `DOC-09`/`VOTE-07`/`ID-13`).

## Breaking Changes
None — documentation/catalog only.

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [x] I have made corresponding changes to the documentation if needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)