### PR TITLE
fix(sdk): default to latest protocol version instead of pinning testnet to v1

### DIFF
--- a/packages/js-dash-sdk/src/SDK/Client/Platform/Platform.spec.ts
+++ b/packages/js-dash-sdk/src/SDK/Client/Platform/Platform.spec.ts
@@ -1,5 +1,5 @@
 import { expect } from 'chai';
-// import { getLatestProtocolVersion } from '@dashevo/wasm-dpp';
+import { getLatestProtocolVersion } from '@dashevo/wasm-dpp';
 import { Platform } from './index';
 import 'mocha';
 import Client from '../Client';
@@ -10,40 +10,30 @@ describe('Dash - Platform', () => {
     expect(Platform.constructor.name).to.be.equal('Function');
   });
 
-  // TODO(versioning): obsolete now?
-  it.skip('should set protocol version for DPP though options', async () => {
+  it('should use the protocol version passed through options', async () => {
     const platform = new Platform({
-      client: new Client(),
+      client: new Client({ network: 'testnet' }),
       network: 'testnet',
-      driveProtocolVersion: 42,
+      driveProtocolVersion: 1,
     });
 
     await platform.initialize();
-    // expect(platform.dpp.getProtocolVersion()).to.equal(42);
+
+    expect(platform.protocolVersion).to.equal(1);
   });
 
-  // TODO(versioning): obsolete now?
-  it.skip('should set protocol version for DPP using mapping', async () => {
+  it('should default to the latest protocol version on testnet', async () => {
+    // Regression: testnet must not be pinned to an old protocol version.
+    // wasm-dpp deserializes fetched contracts at this version, and an old
+    // version downgrades a V1 config (sized_integer_types) to V0, which the
+    // network rejects on contract update ("config version 0 is not supported").
     const platform = new Platform({
-      client: new Client(),
+      client: new Client({ network: 'testnet' }),
       network: 'testnet',
     });
 
-    // @ts-ignore
-    // const testnetProtocolVersion = Platform.networkToProtocolVersion.get('testnet');
-
     await platform.initialize();
-    // expect(platform.dpp.getProtocolVersion()).to.equal(testnetProtocolVersion);
-  });
 
-  // TODO(versioning): obsolete now?
-  it.skip('should set protocol version for DPP using latest version', async () => {
-    const platform = new Platform({
-      client: new Client(),
-      network: 'unknown',
-    });
-
-    await platform.initialize();
-    // expect(platform.dpp.getProtocolVersion()).to.equal(latestProtocolVersion);
+    expect(platform.protocolVersion).to.equal(getLatestProtocolVersion());
   });
 });

--- a/packages/js-dash-sdk/src/SDK/Client/Platform/Platform.ts
+++ b/packages/js-dash-sdk/src/SDK/Client/Platform/Platform.ts
@@ -148,10 +148,6 @@ export class Platform {
 
   client: Client;
 
-  private static readonly networkToProtocolVersion: Map<string, number> = new Map([
-    ['testnet', 1],
-  ]);
-
   protected fetcher: Fetcher;
 
   public nonceManager: NonceManager;
@@ -214,15 +210,11 @@ export class Platform {
       await Platform.initializeDppModule();
 
       if (this.protocolVersion === undefined) {
-        // use mapped protocol version otherwise
-        // fallback to one that set in dpp as the last option
-
-        const mappedProtocolVersion = Platform.networkToProtocolVersion.get(
-          this.client.network,
-        );
-
-        this.protocolVersion = mappedProtocolVersion !== undefined
-          ? mappedProtocolVersion : getLatestProtocolVersion();
+        // Default to the latest protocol version supported by the bundled DPP.
+        // This version also drives how fetched contracts are deserialized; an
+        // older version would downgrade a V1 config (sized_integer_types) to V0
+        // and make contract updates fail network validation.
+        this.protocolVersion = getLatestProtocolVersion();
       }
 
       // eslint-disable-next-line


### PR DESCRIPTION
## Issue being fixed or feature implemented

Updating an existing data contract through `js-dash-sdk` on testnet fails with:

> Can't update Data Contract `<id>` config: config version 0 is not supported, minimum version is 1

`js-dash-sdk` hardcoded `networkToProtocolVersion: testnet → 1`, so on testnet it built wasm-dpp at protocol version **1**. When it fetched the contract via `dataContract.createFromBuffer(...)`, wasm-dpp deserialized at v1 and **downgraded the contract's V1 config (`sized_integer_types`) to V0**. The update path (`contracts/update.ts`) only clones + `incrementVersion()` (the *contract* version, not the *config* version), so the resulting `DataContractUpdateTransition` carried a V0 config. Since protocol v12 the network enforces `config.min_version = 1` and rejects V0.

The contract itself is fine (V1 on-chain) — only the SDK was misreading it. Every non-testnet network already fell back to `getLatestProtocolVersion()`; only testnet was pinned to this stale value.

## What was done?

- Removed the stale `networkToProtocolVersion` map (its only entry was `testnet → 1`) and the now-dead lookup in `Platform.initialize()`.
- `initialize()` now falls back to `getLatestProtocolVersion()` for **all** networks when `driveProtocolVersion` isn't supplied via client options.
- Replaced the obsolete `it.skip` tests in `Platform.spec.ts` with two active ones: the protocol version is taken from options when provided, and defaults to the latest protocol version on testnet (the regression test).

Callers that need to pin a specific protocol version can still pass `driveProtocolVersion` in client options.

## How Has This Been Tested?

`Platform.spec.ts` (compiled via `tsconfig.mocha.json`, run with mocha):

- **Before the fix** (against `v3.1-dev`), the new test fails: `AssertionError: expected 1 to equal 12`.
- **After the fix**, all three Platform specs pass.

```
  Dash - Platform
    ✔ should provide expected class
    ✔ should use the protocol version passed through options
    ✔ should default to the latest protocol version on testnet
  3 passing
```

## Breaking Changes

None. Default protocol version on testnet changes from `1` to the latest supported by the bundled DPP; an explicit `driveProtocolVersion` option still overrides it.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [ ] I have made corresponding changes to the documentation if needed

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Platform SDK protocol version initialization enhanced to always default to the latest available protocol version when not explicitly specified by user configuration. This replaces the previous static network-to-version mapping with dynamic version detection, preventing potential protocol downgrades that could interrupt contract updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->