### PR TITLE
test(rs-sdk): expect network floor in mock sdk seed test

### DIFF
--- a/packages/rs-sdk/tests/fetch/document_query_v0_v1.rs
+++ b/packages/rs-sdk/tests/fetch/document_query_v0_v1.rs
@@ -30,7 +30,8 @@ use dapi_grpc::platform::v0::GetDocumentsRequest;
 use dash_sdk::{platform::documents::document_query::DocumentQuery, Error as SdkError, SdkBuilder};
 use dpp::data_contract::document_type::accessors::DocumentTypeV0Getters;
 use dpp::platform_value::Value;
-use dpp::version::PlatformVersion;
+use dpp::version::v11::PROTOCOL_VERSION_11;
+use dpp::version::{PlatformVersion, INITIAL_PROTOCOL_VERSION};
 use drive::query::conditions::{WhereClause, WhereOperator};
 use drive::query::ordering::OrderClause;
 use drive::query::SelectProjection;
@@ -219,15 +220,12 @@ fn encoder_dispatches_v0_via_query_settings_without_sdk() {
 
 #[test]
 fn sdk_builder_default_seeds_atomic_to_floor() {
-    // Auto-detect default uses mainnet, so the atomic seeds to the mainnet
-    // `min_protocol_version` floor, which `version()` returns until the first
-    // response ratchets it upward. Mainnet's floor is PV_11 in
-    // `Sdk::min_protocol_version`.
+    // Auto-detect default: the atomic seeds to the effective floor,
+    // max(INITIAL_PROTOCOL_VERSION, mainnet network floor), which
+    // `version()` returns until the first response ratchets it upward.
     let sdk_default = SdkBuilder::new_mock().build().expect("mock sdk");
-    assert_eq!(
-        sdk_default.version().protocol_version,
-        dpp::version::v11::PROTOCOL_VERSION_11
-    );
+    let expected_floor = INITIAL_PROTOCOL_VERSION.max(PROTOCOL_VERSION_11);
+    assert_eq!(sdk_default.version().protocol_version, expected_floor);
 }
 
 /// PROTOCOL_VERSION_11 corresponds to Dash Platform v3.0 (testnet at the


### PR DESCRIPTION
## Issue being fixed or feature implemented

Fixes dashpay/platform#3933.

The `sdk_builder_default_seeds_atomic_to_floor` rs-sdk integration test
still expected the raw `DEFAULT_INITIAL_PROTOCOL_VERSION`, but mock SDK
construction defaults to mainnet and seeds the effective protocol floor as
`max(DEFAULT_INITIAL_PROTOCOL_VERSION, mainnet network floor)`.

## What was done?

- Updated the test expectation to use
  `DEFAULT_INITIAL_PROTOCOL_VERSION.max(PROTOCOL_VERSION_11)`.
- Adjusted the nearby comment to describe the effective floor rather than only
  the initial floor.
- Left production SDK behavior unchanged.

## How Has This Been Tested?

- `cargo fmt --all`
- `cargo test -p dash-sdk --all-features --test main fetch::document_query_v0_v1::sdk_builder_default_seeds_atomic_to_floor -- --exact --nocapture`
- Pre-PR code review gate: `ship`

## Breaking Changes

None.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have added "!" to the title and described breaking changes in the
  corresponding section if my code contains any
- [ ] I have made corresponding changes to the documentation if needed

## For repository code-owners and collaborators only

- [ ] I have assigned this pull request to a milestone


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Updated protocol version handling assertions to match the SDK’s new “effective floor” behavior (using the higher of the initial version and the minimum supported version).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->