### PR TITLE
fix(swift-sdk): parse getIdentitiesTokenBalances NSNumber result

### DIFF
--- a/packages/swift-sdk/Sources/SwiftDashSDK/FFI/PlatformQueryExtensions.swift
+++ b/packages/swift-sdk/Sources/SwiftDashSDK/FFI/PlatformQueryExtensions.swift
@@ -1375,11 +1375,16 @@ extension SDK {
         let result = dash_sdk_identities_fetch_token_balances(handle, identityIdsStr, tokenId)
         let json = try processJSONResult(result)
 
-        // Convert the result to [String: UInt64]
+        // Convert the result to [String: UInt64].
+        // JSONSerialization decodes numbers as NSNumber, so read .uint64Value
+        // (matching getIdentityTokenBalances above). The Rust FFI emits `null`
+        // for identities that have never held the token; those decode to NSNull
+        // and are skipped, mirroring how the single-identity query omits
+        // never-held tokens.
         var balances: [String: UInt64] = [:]
         for (key, value) in json {
-            if let balance = value as? UInt64 {
-                balances[key] = balance
+            if let balance = value as? NSNumber {
+                balances[key] = balance.uint64Value
             }
         }
 


### PR DESCRIPTION
## Issue being fixed or feature implemented

`SDK.getIdentitiesTokenBalances(identityIds:tokenId:)` almost always returned an empty `[String: UInt64]`.

The result from the FFI is decoded with `JSONSerialization`, which boxes numeric JSON values as `NSNumber`. The method cast each value with `value as? UInt64`, which never succeeds for an `NSNumber`, so every entry was silently dropped and callers saw an empty dictionary regardless of the actual on-chain balances.

The sibling method `getIdentityTokenBalances(identityId:tokenIds:)` already handles this correctly via `NSNumber.uint64Value`.

## What was done?

In `packages/swift-sdk/Sources/SwiftDashSDK/FFI/PlatformQueryExtensions.swift`, fixed the parse loop in `getIdentitiesTokenBalances` to read `.uint64Value` off `NSNumber`, matching the sibling method:

```swift
for (key, value) in json {
    if let balance = value as? NSNumber {
        balances[key] = balance.uint64Value
    }
}
```

The Rust FFI (`packages/rs-sdk-ffi/src/token/queries/identities_balances.rs`) emits `null` for identities that have never held the token. `JSONSerialization` decodes that as `NSNull`, which fails the `as? NSNumber` cast and is therefore skipped — mirroring how the single-identity query omits never-held tokens (no balance row). This is safe: the cast simply doesn't match, so there is no crash.

## How Has This Been Tested?

- Reviewed the three callers (`QueryDetailView`, `DiagnosticsView`) — all consume the dictionary only for display and none depend on the previous (empty) behavior, so the now-populated result is strictly an improvement.
- A full iOS xcframework build was intentionally **not** run because a parallel `build_ios.sh` was in flight at the time. The change is a localized, type-only fix identical in shape to the already-compiling sibling method, and `import Foundation` (providing `NSNumber`/`NSNull`) is already present in the file.

## Breaking Changes

None. Public API signature is unchanged; only the parsing behavior is corrected.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [ ] I have made corresponding changes to the documentation if needed

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of null values in token balance retrieval, ensuring missing balance data is properly managed without errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->