### PR TITLE
fix(swift-sdk): seed testnet at the per-network protocol-version floor instead of pinning PV11

### DIFF
--- a/packages/swift-sdk/Sources/SwiftDashSDK/SDK.swift
+++ b/packages/swift-sdk/Sources/SwiftDashSDK/SDK.swift
@@ -247,14 +247,13 @@ public final class SDK: @unchecked Sendable {
   /// This is suitable for mobile applications where proof verification would be resource-intensive.
   ///
   /// `platformVersion`:
-  /// - `0` (default) — pick a network-appropriate version: PV 11 for the
-  ///   public networks still on pre-v3.1 drive-abci (mainnet, testnet),
-  ///   PV 12 (latest) for the leading-edge networks (devnet, regtest).
-  ///   This avoids the V0/V1 `getDocuments` wire-format mismatch that
-  ///   would otherwise make Platform queries fail with
-  ///   `"decoding error: could not decode data contracts query"` on the
-  ///   public networks until they roll forward. Override by passing an
-  ///   explicit non-zero value.
+  /// - `0` (default) — let the Rust SDK seed at the per-network minimum
+  ///   protocol version (mainnet 11, testnet/devnet/regtest 12) with
+  ///   auto-detect on, ratcheting up as the network reports newer
+  ///   versions. The per-network floor encodes the V0/V1 `getDocuments`
+  ///   wire format (mainnet floor 11 = V0 until mainnet upgrades;
+  ///   testnet floor 12 = V1), so this picks the right wire without a
+  ///   Swift-side network→version map.
   /// - non-zero — pin the SDK to this exact `PlatformVersion`.
   public init(network: Network, platformVersion: UInt32 = 0) throws {
     var config = DashSDKConfig()
@@ -264,26 +263,12 @@ public final class SDK: @unchecked Sendable {
     config.skip_asset_lock_proof_verification = false
     config.request_retry_count = 1
     config.request_timeout_ms = 8000 // 8 seconds
-    let resolvedPlatformVersion: UInt32
-    if platformVersion != 0 {
-      resolvedPlatformVersion = platformVersion
-    } else {
-      switch network {
-      case .mainnet, .testnet:
-        // TODO(platform-version-bump): bump mainnet/testnet to 12
-        // (or whatever PV is current) once drive-abci 3.1+ has
-        // rolled out on those networks and the new
-        // `getDocuments` V1 wire format is on by default. The
-        // trigger is: a HardFork shipping the V1 wire format
-        // becomes active on mainnet/testnet. Until then, pinning
-        // 11 keeps the SDK speaking the V0 protocol the active
-        // tenderdash quorums understand.
-        resolvedPlatformVersion = 11
-      case .devnet, .regtest:
-        resolvedPlatformVersion = 12
-      }
-    }
-    config.platform_version = resolvedPlatformVersion
+    // `0` is passed straight through: the FFI `apply_version(builder, 0)`
+    // returns the builder unchanged, so `SdkBuilder::build()` seeds at the
+    // per-network `min_protocol_version` floor with auto-detect on
+    // (version_pinned=false) and ratchets up as the network reports newer
+    // versions. A non-zero value is an explicit pin via `with_version`.
+    config.platform_version = platformVersion
 
     // Create SDK with trusted setup. DAPI / quorum-URL overrides come from
     // UserDefaults and apply on:


### PR DESCRIPTION
## Issue being fixed or feature implemented

`SDK.init(network:platformVersion:)` in `SwiftDashSDK` hardcoded `platformVersion = 11` for `.mainnet`/`.testnet` when the caller passed `0` (the default). That pinned the SDK via `SdkBuilder::with_version(11)`, which disables auto-detect, so the SDK kept speaking the **V0 `getDocuments` wire** even though testnet has rolled forward to **Platform v3.1 (protocol version 12)**.

The visible symptom: V1-only features — document **sum/average aggregation** (QA tests DOC-13/14, added in #3942) — were rejected client-side with:

> `SDK misconfigured: select=Sum requires Platform v3.1+ (V1 documents wire); pin/upgrade to a v3.1+ network`

The `11` pin was a deliberate workaround (with a `TODO(platform-version-bump)`) from when the public networks were on pre-v3.1 drive-abci. Previously a construction-time floor clamp in `rs-sdk` (`initial = self.version.protocol_version.max(min_protocol_version(network))`, "applies to pinned and auto-detect SDKs alike") silently raised the sub-floor pin up to the network floor (testnet 12), so the app actually spoke V1. #3900 ("per-network protocol-version floor + version_pinned unification") changed the floor into a **seed-only default** for the unpinned case (its doc now reads "Not a runtime clamp"), so the stale `11` pin now sticks → V0 → V1 features break.

## What was done?

In the `platformVersion == 0` (default) path, stop mapping to a Swift-side per-network constant and pass `0` straight through to `config.platform_version`. The FFI `apply_version(builder, 0)` returns the builder unpinned, so `rs-sdk` seeds at the per-network `min_protocol_version` floor — **mainnet 11, testnet/devnet/regtest 12** — with **auto-detect on**, and ratchets upward as the network reports newer versions. The network→version decision now lives entirely in `rs-sdk`.

A non-zero `platformVersion` still pins via `with_version`, unchanged.

Net effect:
- **testnet** → PV12 (V1 wire) — sum/avg and other V1 features work, matching the live network.
- **mainnet** → PV11 (V0 wire) — correct until mainnet upgrades, then auto-detect ratchets up on its own.

13 insertions / 28 deletions in one file (`SDK.swift`); the deleted block is the hardcoded `switch network` version map and its stale rationale comment.

## How Has This Been Tested?

Rebuilt the iOS xcframework + app (`./build_ios.sh --target sim --profile dev`) and re-ran the SwiftExampleApp **Sum / Average Documents** view on testnet against a summable fixture contract (`metric` doc type, `documentsSummable: "value"`, seeded values 10/20/40/50):

- **Before** the change: both ops failed with the `requires Platform v3.1+ (V1 documents wire)` error.
- **After**: **sum = 120**, **average = 30.0000** — proof-verified, matching the seeded data (DOC-13/DOC-14 green).

Regular identity/contract/document reads continued to work on testnet after the change (the app is now on the V1 wire the live network expects).

## Breaking Changes

None. No public API signature change — same initializer, different default-version resolution. Not consensus-affecting.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [x] I have made corresponding changes to the documentation if needed

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone