### PR TITLE
fix(swift-sdk): keychain privk storage

### DIFF
--- a/packages/swift-sdk/Sources/SwiftDashSDK/Security/KeychainManager.swift
+++ b/packages/swift-sdk/Sources/SwiftDashSDK/Security/KeychainManager.swift
@@ -649,6 +649,7 @@ extension KeychainManager {
             kSecValueData as String: privateKey,
             kSecAttrAccessible as String: kSecAttrAccessibleWhenUnlockedThisDeviceOnly,
             kSecAttrSynchronizable as String: false,
+            kSecAttrLabel as String: metadata.publicKey.lowercased(),
         ]
 
         if let accessGroup = accessGroup {
@@ -710,8 +711,8 @@ extension KeychainManager {
         var query: [String: Any] = [
             kSecClass as String: kSecClassGenericPassword,
             kSecAttrService as String: serviceName,
-            kSecMatchLimit as String: kSecMatchLimitAll,
-            kSecReturnAttributes as String: true,
+            kSecAttrLabel as String: publicKeyHex.lowercased(),
+            kSecMatchLimit as String: kSecMatchLimitOne,
             kSecReturnData as String: true,
         ]
         if let accessGroup = accessGroup {
@@ -720,29 +721,8 @@ extension KeychainManager {
 
         var result: AnyObject?
         let status = SecItemCopyMatching(query as CFDictionary, &result)
-        guard status == errSecSuccess, let items = result as? [[String: Any]] else {
-            return nil
-        }
-
-        let decoder = JSONDecoder()
-        for item in items {
-            guard let account = item[kSecAttrAccount as String] as? String,
-                account.hasPrefix("identity_privkey.")
-            else {
-                continue
-            }
-            guard let metadataData = item[kSecAttrGeneric as String] as? Data,
-                let metadata = try? decoder.decode(IdentityPrivateKeyMetadata.self, from: metadataData)
-            else {
-                continue
-            }
-            // Case-insensitive hex compare — both producers downcase
-            // their hex but be defensive against future writers.
-            if metadata.publicKey.caseInsensitiveCompare(publicKeyHex) == .orderedSame {
-                return item[kSecValueData as String] as? Data
-            }
-        }
-        return nil
+        guard status == errSecSuccess else { return nil }
+        return result as? Data
     }
 
     /// Existence check for the wallet-derived identity-private-key


### PR DESCRIPTION
How Private keys were been stored didn't work well with the legacy keyring the swift tests where using without signing the app, what I do with this PR is updated the store/load logic to use the public key as the keyring entry label, being able to query for a single priv key instead of requesting a bunch oof items to later iterate over them, what doesn't work well in macOS file based keyring  


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [ ] I have made corresponding changes to the documentation if needed

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved the speed and efficiency of private-key retrieval by switching to a direct lookup keyed by the corresponding public key.
  * Updated how private keys are stored to associate them with the public key label for faster matching.
  * Retrieval now more reliably returns results (or nil) based on that direct match, without scanning unrelated stored items.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->