### PR TITLE
fix(swift-example-app): load document price on Purchase sheet appear

### DIFF
--- a/packages/swift-sdk/SwiftExampleApp/SwiftExampleApp/Views/DocumentWithPriceView.swift
+++ b/packages/swift-sdk/SwiftExampleApp/SwiftExampleApp/Views/DocumentWithPriceView.swift
@@ -117,6 +117,21 @@ struct DocumentWithPriceView: View {
                     .foregroundColor(.secondary)
             }
         }
+        .onAppear {
+            // `onChange(of: documentId)` does NOT fire when the id is
+            // established as the binding mounts — e.g. PurchaseDocumentView
+            // seeds `documentIdField` in its own `onAppear` and disables this
+            // view, so relying on onChange alone the price probe would never
+            // run and Purchase would stay gated off forever. Kick the fetch
+            // here so a pre-seeded id loads its price without a user edit.
+            // `.disabled(true)` only blocks hit-testing, not lifecycle events,
+            // so this still fires in the Purchase flow. When the field starts
+            // empty (the editable transition flow) this is a no-op and the
+            // existing onChange path continues to handle typing.
+            if !documentId.isEmpty {
+                handleDocumentIdChange(documentId)
+            }
+        }
     }
 
     private func handleDocumentIdChange(_ newValue: String) {

--- a/packages/swift-sdk/SwiftExampleApp/SwiftExampleApp/Views/DocumentsView.swift
+++ b/packages/swift-sdk/SwiftExampleApp/SwiftExampleApp/Views/DocumentsView.swift
@@ -275,6 +275,7 @@ struct DocumentDetailView: View {
     private var availableActions: [DocumentAction] {
         var actions: [DocumentAction] = []
         let docType = documentTypeRow
+        let tradeable = (docType?.tradeMode ?? 0) > 0
 
         if ownerIsControlled {
             actions.append(.replace)
@@ -282,12 +283,18 @@ struct DocumentDetailView: View {
             if docType?.documentsTransferable == true {
                 actions.append(.transfer)
             }
-            if (docType?.tradeMode ?? 0) > 0 {
+            if tradeable {
                 actions.append(.setPrice)
             }
-        } else if (docType?.tradeMode ?? 0) > 0 && !nonOwnerControlledIdentities.isEmpty {
-            // Not the owner, but the wallet holds another identity that
-            // could buy a for-sale, tradeable document.
+        }
+        // Surface Purchase whenever the doc type is tradeable and the wallet
+        // holds a controlled identity that isn't the owner (the buyer ≠
+        // owner, and the buyer signs). This intentionally also covers a doc
+        // owned by another *controlled* identity — the two-identities-in-one
+        // -app flow — not just externally-owned docs, matching the doc
+        // comment above. The Purchase sheet resolves the real on-chain price
+        // / for-sale state and disables the button when it isn't for sale.
+        if tradeable && !nonOwnerControlledIdentities.isEmpty {
             actions.append(.purchase)
         }
         return actions

--- a/packages/swift-sdk/SwiftExampleApp/SwiftExampleApp/Views/DocumentsView.swift
+++ b/packages/swift-sdk/SwiftExampleApp/SwiftExampleApp/Views/DocumentsView.swift
@@ -275,7 +275,10 @@ struct DocumentDetailView: View {
     private var availableActions: [DocumentAction] {
         var actions: [DocumentAction] = []
         let docType = documentTypeRow
-        let tradeable = (docType?.tradeMode ?? 0) > 0
+        // `tradeMode == 1` is DirectPurchase — the only mode that supports
+        // listing/buying — matching the marketplace gating in
+        // TransitionInputView (`$0.tradeMode == 1`).
+        let tradeable = (docType?.tradeMode ?? 0) == 1
 
         if ownerIsControlled {
             actions.append(.replace)


### PR DESCRIPTION
## Issue being fixed or feature implemented

The production document **Purchase** flow in SwiftExampleApp was blocked: the on-chain price never loaded, so the **Purchase / Broadcast** button stayed permanently disabled.

`DocumentWithPriceView` fetched the price **only** via the TextField's `onChange(of: documentId)`. `PurchaseDocumentView` seeds `documentIdField` as the binding mounts (and the field is `.disabled(true)`), so `onChange` never fires and the user can't trigger it by editing → `fetchDocument()` never ran, `transitionState.documentPrice` stayed `nil`, and submit was gated off forever. Confirmed via Rust logs that **zero** GetDocuments queries fired while the Purchase sheet was open.

This is a **merge regression**: the same bug (plus the Purchase gating and a submit-button gating fix) was already fixed on the #3945 branch in commit `588435aff4`, but the v3.1-dev merge (`96cba166ba`) dropped that commit, so it recurred.

## What was done?

- **`DocumentWithPriceView`**: added an `.onAppear` that triggers the fetch when the id is already populated at mount. `.disabled(true)` blocks hit-testing, not lifecycle events, so it fires in the Purchase flow. The editable `TransitionInputView` path starts empty → guarded no-op, and `onChange` still handles typing there.
- **`DocumentsView`**: restored the relaxed Purchase gating so the action surfaces for a for-sale, tradeable doc whenever the wallet holds a controlled identity other than the owner (buyer ≠ owner) — matching the file's own surviving doc-comment. Without this, the Purchase sheet is unreachable for the two-identities-in-one-wallet scenario.

## How Has This Been Tested?

Driven end-to-end on the iOS simulator (QA-iPhone16Pro, testnet), contract `Contract with card` (`5jpKat9U82PGcfmeYm8QZZWX6q7zDo2C32PZMxHpbiGB`):

| Step | Result |
|---|---|
| Create card doc (Identity 1 `J52PSRr4…`) | doc `GLXNTysahyLnUKPS1hzji…`, rev 1 |
| Set price 50000 credits | Broadcast confirmed, rev 2, `$price:50000` |
| Open Purchase → price loads | "Document found" + "50000 credits"; button **enabled** after selecting purchaser |
| Broadcast purchase (Identity 2 `envSngUJ…`) | Broadcast confirmed |
| `ZOWNERID` flip (SwiftData) | `J52PSRr4…` → `envSngUJ…`, rev 2→3, `$price` cleared |

The displayed price comes only from `fetchDocument`'s network read (`sdk.documentGet`), and `PurchaseDocumentView.onAppear` had just nil'd the shared price — so its appearance is direct proof the probe now fires on appear.

## Breaking Changes

None. Example-app UI only; no consensus, SDK, or FFI changes.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [x] I have made corresponding changes to the documentation if needed

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed document pricing and ownership details that were not loading when a document ID was pre-populated at view initialization.

* **New Features**
  * Expanded availability of the purchase action to appear when trading is enabled and the wallet controls additional identities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->