### PR TITLE
chore: remove ignored cargo build config

### DIFF
--- a/packages/rs-sdk-ffi/Cargo.toml
+++ b/packages/rs-sdk-ffi/Cargo.toml
@@ -74,13 +74,6 @@ reqwest = { version = "0.12", features = ["json", "rustls-tls-native-roots"] }
 [build-dependencies]
 cbindgen = "0.27"
 
-[profile.release]
-lto = "fat"       # Enable cross-crate optimization
-codegen-units = 1 # Single codegen unit for better optimization
-strip = "symbols" # Strip debug symbols for smaller size
-opt-level = "z"   # Optimize for size
-panic = "abort"   # Required for iOS
-
 [dev-dependencies]
 hex = "0.4"
 env_logger = "0.11"

--- a/packages/wasm-dpp/Cargo.toml
+++ b/packages/wasm-dpp/Cargo.toml
@@ -50,9 +50,5 @@ wasm-bindgen-futures = "0.4.58"
 async-trait = "0.1.59"
 bincode = { version = "=2.0.1" }
 
-[profile.release]
-lto = true
-opt-level = 'z'
-
 [package.metadata.cargo-machete]
 ignored = ["wasm-bindgen-futures"]

--- a/packages/wasm-sdk/Cargo.toml
+++ b/packages/wasm-sdk/Cargo.toml
@@ -96,12 +96,6 @@ wasm-dpp2 = { path = "../wasm-dpp2" }
 wasm-sdk = { path = ".", features = ["mocks", "all-system-contracts"] }
 tokio = { version = "1.40", features = ["macros", "rt-multi-thread"] }
 
-[profile.release]
-opt-level = "z"
-panic = "abort"
-debug = false
-lto = "fat"
-
 [package.metadata.wasm-pack]
 wasm-opt = false
 


### PR DESCRIPTION
In this PR I remove the profile.release sections in the crates Cargo.toml. They were not being applied bcs they need to be specified at the workspace level. I didn't write a replacement because the workspace already provides optimized profiles for the swift sdk builds


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [ ] I have made corresponding changes to the documentation if needed

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Removed custom release build profile configurations from multiple packages, standardizing release build settings across the project.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->