### PR TITLE
chore(swift-sdk): correctly refer to the swift sdk as swift in the build script and cargo profiles

### DIFF
--- a/.claude/skills/simulator-control/SKILL.md
+++ b/.claude/skills/simulator-control/SKILL.md
@@ -275,7 +275,7 @@ If `idb connect` succeeds but `idb ui describe-all` returns a single root elemen
 
 ### Install the latest build before driving the UI
 
-The skill assumes the binary on the simulator is current. It's not, if you've built but forgotten to install. After every `./build_ios.sh --target sim` (or any code change), push the fresh artifact:
+The skill assumes the binary on the simulator is current. It's not, if you've built but forgotten to install. After every `./build_swift.sh --target sim` (or any code change), push the fresh artifact:
 
 ```bash
 BUNDLE=org.dashfoundation.SwiftExampleApp

--- a/.github/workflows/swift-example-app-ui-smoke.yml
+++ b/.github/workflows/swift-example-app-ui-smoke.yml
@@ -86,7 +86,7 @@ jobs:
 
       - name: Build simulator DashSDKFFI.xcframework
         run: |
-          bash packages/swift-sdk/build_ios.sh --target sim --profile dev
+          bash packages/swift-sdk/build_swift.sh --target sim --profile dev
 
       - name: Create disposable iOS simulator
         id: simulator

--- a/.github/workflows/swift-sdk-release.yml
+++ b/.github/workflows/swift-sdk-release.yml
@@ -59,7 +59,7 @@ jobs:
 
       - name: Build DashSDKFFI.xcframework and install into Swift package
         run: |
-          bash packages/swift-sdk/build_ios.sh --target all --profile release
+          bash packages/swift-sdk/build_swift.sh --target all --profile release
 
       - name: Zip XCFramework and compute checksum
         id: zip

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,10 +61,10 @@ dashcore-rpc = { git = "https://github.com/dashpay/rust-dashcore", rev = "5c0113
 
 tokio-metrics = "0.5"
 
-# Size-tuned profile for the iOS `rs-unified-sdk-ffi` staticlib, which
-# otherwise ships huge. Inherits `release` and is ONLY used by the iOS
-# build (`build_ios.sh --profile release`)
-[profile.release-ios]
+# Size-tuned profile for the iOS `rs-unified-sdk-ffi` staticlibs, which
+# otherwise ships huge. Inherits `release` and is ONLY used by the Swift
+# build (`build_swift.sh --profile release`)
+[profile.release-swift]
 inherits = "release"
 panic = "abort"
 strip = "symbols"
@@ -72,9 +72,9 @@ lto = "fat"
 codegen-units = 1
 opt-level = 3
 
-# Debug counterpart for smaller iOS dev builds. Inherits the standard `dev`
-# profile (and is ONLY used by the iOS build (`build_ios.sh --profile dev`)
-[profile.dev-ios]
+# Debug counterpart for smaller Swift dev builds. Inherits the standard `dev`
+# profile (and is ONLY used by the Swift build (`build_swift.sh --profile dev`)
+[profile.dev-swift]
 inherits = "dev"
 panic = "abort"
 lto = "thin"

--- a/packages/rs-platform-wallet-ffi/IMPLEMENTATION_SUMMARY.md
+++ b/packages/rs-platform-wallet-ffi/IMPLEMENTATION_SUMMARY.md
@@ -110,7 +110,7 @@ All Week 1-8 tasks have been completed without stubs.
 - Core types: Handle, IdentifierBytes, NetworkType, BlockTime, etc.
 
 **Build System:**
-- Integrated into existing `swift-sdk/build_ios.sh`
+- Integrated into existing `swift-sdk/build_swift.sh`
 - No standalone build script needed
 - Compiles cleanly with unified xcframework
 

--- a/packages/swift-sdk/build_swift.sh
+++ b/packages/swift-sdk/build_swift.sh
@@ -117,9 +117,9 @@ if ! $BUILD_IOS && ! $BUILD_SIM && ! $BUILD_MAC && ! $BUILD_INTEL_MAC; then
   show_help
 fi
 
-# Map the requested base profile (dev|release) onto its iOS-tuned custom
-# profile by appending "-ios" (dev-ios / release-ios)
-PROFILE="${PROFILE}-ios"
+# Map the requested base profile (dev|release) onto its swift-tuned custom
+# profile by appending "-swift" (dev-swift / release-swift)
+PROFILE="${PROFILE}-swift"
 OUTPUT_DIR="$PROFILE"
 
 log_info "Package: $PACKAGE"
@@ -196,7 +196,7 @@ EOF
 # the bundled SDK exposes the platform-wallet shielded FFI.
 CARGO_FEATURES="shielded"
 
-if [ "$PROFILE" = "dev-ios" ]; then
+if [ "$PROFILE" = "dev-swift" ]; then
   CARGO_FEATURES="$CARGO_FEATURES tokio-metrics"
   log_info "  → tokio-metrics enabled (dev profile)"
 fi

--- a/packages/swift-sdk/run_tests.sh
+++ b/packages/swift-sdk/run_tests.sh
@@ -20,7 +20,7 @@ if [ -z "$SIM_NAME" ]; then
   exit 1
 fi
 
-bash build_ios.sh --target all --profile dev
+bash build_swift.sh --target all --profile dev
 
 swift package clean
 swift build


### PR DESCRIPTION
This PR renames build_ios.sh to build_swift.sh and the dev-ios and profile-its profiles to *-swift. I think this better reflects what we are truly building, a swift-sdk. Everything still works the same. This change is just for consistency


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [ ] I have made corresponding changes to the documentation if needed

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated Swift SDK build, test, and release automation to use Swift-specific build scripts and profiles (instead of iOS-named ones).
  * Adjusted simulator and CI smoke-test flows to build the correct Swift-tuned artifacts before running tests.
* **Documentation**
  * Revised internal setup/integration notes to reference the updated Swift build script for simulator installs and Platform Wallet FFI integration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->