### PR TITLE
feat(swift-example-app): rebrand to "Dash Developer Pro" for TestFlight

### DIFF
--- a/.claude/skills/simulator-control/SKILL.md
+++ b/.claude/skills/simulator-control/SKILL.md
@@ -26,7 +26,7 @@ Without `idb` the inspection workflows (screenshot + SwiftData + logs) still wor
 export PATH="$HOME/.local/bin:$PATH"
 UDID=$(xcrun simctl list devices booted | awk -F'[()]' '/Booted/ {print $2}')
 idb connect $UDID    # starts idb_companion alongside the running sim
-BUNDLE=org.dashfoundation.SwiftExampleApp
+BUNDLE=org.dashfoundation.DashDeveloperPro
 
 # === INSPECT ===
 xcrun simctl io booted screenshot /tmp/sim.png             # screenshot
@@ -278,8 +278,10 @@ If `idb connect` succeeds but `idb ui describe-all` returns a single root elemen
 The skill assumes the binary on the simulator is current. It's not, if you've built but forgotten to install. After every `./build_ios.sh --target sim` (or any code change), push the fresh artifact:
 
 ```bash
-BUNDLE=org.dashfoundation.SwiftExampleApp
-APP=$(find ~/Library/Developer/Xcode/DerivedData -name "${BUNDLE##*.}.app" -path "*Debug-iphonesimulator*" -not -path "*Index.noindex*" 2>/dev/null | head -1)
+BUNDLE=org.dashfoundation.DashDeveloperPro
+# The .app on disk is named after PRODUCT_NAME (still "SwiftExampleApp"), which
+# differs from the bundle id — find by the product name, launch by the bundle id.
+APP=$(find ~/Library/Developer/Xcode/DerivedData -name "SwiftExampleApp.app" -path "*Debug-iphonesimulator*" -not -path "*Index.noindex*" 2>/dev/null | head -1)
 xcrun simctl install booted "$APP"
 xcrun simctl launch booted "$BUNDLE"  # or terminate-then-launch to force a fresh process
 ```

--- a/.claude/skills/simulator-control/SKILL.md
+++ b/.claude/skills/simulator-control/SKILL.md
@@ -26,7 +26,7 @@ Without `idb` the inspection workflows (screenshot + SwiftData + logs) still wor
 export PATH="$HOME/.local/bin:$PATH"
 UDID=$(xcrun simctl list devices booted | awk -F'[()]' '/Booted/ {print $2}')
 idb connect $UDID    # starts idb_companion alongside the running sim
-BUNDLE=org.dashfoundation.DashDeveloperPro
+BUNDLE=org.dashfoundation.SwiftExampleApp
 
 # === INSPECT ===
 xcrun simctl io booted screenshot /tmp/sim.png             # screenshot
@@ -278,10 +278,8 @@ If `idb connect` succeeds but `idb ui describe-all` returns a single root elemen
 The skill assumes the binary on the simulator is current. It's not, if you've built but forgotten to install. After every `./build_ios.sh --target sim` (or any code change), push the fresh artifact:
 
 ```bash
-BUNDLE=org.dashfoundation.DashDeveloperPro
-# The .app on disk is named after PRODUCT_NAME (still "SwiftExampleApp"), which
-# differs from the bundle id — find by the product name, launch by the bundle id.
-APP=$(find ~/Library/Developer/Xcode/DerivedData -name "SwiftExampleApp.app" -path "*Debug-iphonesimulator*" -not -path "*Index.noindex*" 2>/dev/null | head -1)
+BUNDLE=org.dashfoundation.SwiftExampleApp
+APP=$(find ~/Library/Developer/Xcode/DerivedData -name "${BUNDLE##*.}.app" -path "*Debug-iphonesimulator*" -not -path "*Index.noindex*" 2>/dev/null | head -1)
 xcrun simctl install booted "$APP"
 xcrun simctl launch booted "$BUNDLE"  # or terminate-then-launch to force a fresh process
 ```

--- a/packages/swift-sdk/SwiftExampleApp/Info.plist
+++ b/packages/swift-sdk/SwiftExampleApp/Info.plist
@@ -13,6 +13,8 @@
 	<string>6.0</string>
 	<key>CFBundleName</key>
 	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundleDisplayName</key>
+	<string>Dash Developer Pro</string>
 	<key>CFBundlePackageType</key>
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>

--- a/packages/swift-sdk/SwiftExampleApp/SwiftExampleApp.xcodeproj/project.pbxproj
+++ b/packages/swift-sdk/SwiftExampleApp/SwiftExampleApp.xcodeproj/project.pbxproj
@@ -444,7 +444,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = org.dashfoundation.SwiftExampleApp;
+				PRODUCT_BUNDLE_IDENTIFIER = org.dashfoundation.DashDeveloperPro;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 6.0;
@@ -473,7 +473,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = org.dashfoundation.SwiftExampleApp;
+				PRODUCT_BUNDLE_IDENTIFIER = org.dashfoundation.DashDeveloperPro;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 6.0;

--- a/packages/swift-sdk/get_logs.sh
+++ b/packages/swift-sdk/get_logs.sh
@@ -23,12 +23,12 @@ set -euo pipefail
 #                               [--session <ts|latest>]
 #
 # Defaults:
-#   bundle-id: org.dashfoundation.SwiftExampleApp
+#   bundle-id: org.dashfoundation.DashDeveloperPro
 #   out:       ./logs-<device-name>-<session-ts>
 #   device:    interactive picker when more than one is available
 #   session:   interactive picker when more than one is available
 
-BUNDLE_ID="org.dashfoundation.SwiftExampleApp"
+BUNDLE_ID="org.dashfoundation.DashDeveloperPro"
 OUT_DIR=""
 DEVICE=""
 SESSION=""


### PR DESCRIPTION
## Issue being fixed or feature implemented

We want to ship the iOS example app to TestFlight as a standalone product, **Dash Developer Pro**, rather than the internal-looking "SwiftExampleApp". This requires a user-visible app name and a distinct bundle identifier so Xcode can register it as its own app record in App Store Connect.

## What was done?

- Added `CFBundleDisplayName = "Dash Developer Pro"` to `Info.plist` so the home-screen / TestFlight name is the product name (previously the label fell through to `PRODUCT_NAME` → "SwiftExampleApp").
- Changed the app target's `PRODUCT_BUNDLE_IDENTIFIER` from `org.dashfoundation.SwiftExampleApp` to `org.dashfoundation.DashDeveloperPro` (both Debug and Release configurations). Test target bundle identifiers are intentionally left unchanged — they reference the host app by product name, not bundle ID, so tests still build.
- Updated local dev tooling that hardcoded the old bundle ID so it keeps working after the rename:
  - `packages/swift-sdk/get_logs.sh` (default `BUNDLE_ID` + usage comment) — used via `simctl get_app_container`, straight swap.
  - `.claude/skills/simulator-control/SKILL.md` setup `BUNDLE`. The install/launch block previously derived the `.app` filename from the bundle ID (`${BUNDLE##*.}.app`); since only the bundle ID changed (not `PRODUCT_NAME`), it now finds the artifact by the literal `SwiftExampleApp.app` and launches by the new bundle ID.

Note: this is scoped to branding only. ATS hardening (the `NSAllowsArbitraryLoads` flag, tracked in #3714) and network-default cleanup are out of scope here — fine for TestFlight, but should be addressed before any public App Store review.

## How Has This Been Tested?

- Archived the app in Xcode for a physical device and confirmed the App Store Connect upload dialog picks up bundle id `org.dashfoundation.DashDeveloperPro`.
- Verified the rebuilt `DashSDKFFI.xcframework` includes the `ios-arm64` device slice so the archive links (previously simulator-only).
- Verified the uploaded archive embeds the app icon (`CFBundleIconName = AppIcon`, compiled rendition present in `Assets.car`).
- Confirmed no remaining references to the old bundle id across `*.sh` / `*.md` / `*.swift` / `*.yml` / `*.json`.

## Breaking Changes

None for the SDK. The bundle identifier change means the app installs as a **new** app rather than upgrading an existing `org.dashfoundation.SwiftExampleApp` install.

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [ ] I have made corresponding changes to the documentation if needed

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Swift example application branding, renaming the display name to `Dash Developer Pro` and refreshing associated identifiers throughout the project.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->