### PR TITLE
chore: bump rust-dashcore rev to 95a3c8ff04d75d7abe324db4af01e8521092aff9

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1637,7 +1637,7 @@ dependencies = [
 [[package]]
 name = "dash-network"
 version = "0.43.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=5c0113e7901551450f6063023eec4be95beeb6b9#5c0113e7901551450f6063023eec4be95beeb6b9"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=95a3c8ff04d75d7abe324db4af01e8521092aff9#95a3c8ff04d75d7abe324db4af01e8521092aff9"
 dependencies = [
  "bincode",
  "bincode_derive",
@@ -1648,7 +1648,7 @@ dependencies = [
 [[package]]
 name = "dash-network-seeds"
 version = "0.43.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=5c0113e7901551450f6063023eec4be95beeb6b9#5c0113e7901551450f6063023eec4be95beeb6b9"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=95a3c8ff04d75d7abe324db4af01e8521092aff9#95a3c8ff04d75d7abe324db4af01e8521092aff9"
 dependencies = [
  "dash-network",
 ]
@@ -1725,7 +1725,7 @@ dependencies = [
 [[package]]
 name = "dash-spv"
 version = "0.43.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=5c0113e7901551450f6063023eec4be95beeb6b9#5c0113e7901551450f6063023eec4be95beeb6b9"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=95a3c8ff04d75d7abe324db4af01e8521092aff9#95a3c8ff04d75d7abe324db4af01e8521092aff9"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1754,7 +1754,7 @@ dependencies = [
 [[package]]
 name = "dashcore"
 version = "0.43.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=5c0113e7901551450f6063023eec4be95beeb6b9#5c0113e7901551450f6063023eec4be95beeb6b9"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=95a3c8ff04d75d7abe324db4af01e8521092aff9#95a3c8ff04d75d7abe324db4af01e8521092aff9"
 dependencies = [
  "anyhow",
  "base64-compat",
@@ -1780,12 +1780,12 @@ dependencies = [
 [[package]]
 name = "dashcore-private"
 version = "0.43.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=5c0113e7901551450f6063023eec4be95beeb6b9#5c0113e7901551450f6063023eec4be95beeb6b9"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=95a3c8ff04d75d7abe324db4af01e8521092aff9#95a3c8ff04d75d7abe324db4af01e8521092aff9"
 
 [[package]]
 name = "dashcore-rpc"
 version = "0.43.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=5c0113e7901551450f6063023eec4be95beeb6b9#5c0113e7901551450f6063023eec4be95beeb6b9"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=95a3c8ff04d75d7abe324db4af01e8521092aff9#95a3c8ff04d75d7abe324db4af01e8521092aff9"
 dependencies = [
  "dashcore-rpc-json",
  "hex",
@@ -1798,7 +1798,7 @@ dependencies = [
 [[package]]
 name = "dashcore-rpc-json"
 version = "0.43.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=5c0113e7901551450f6063023eec4be95beeb6b9#5c0113e7901551450f6063023eec4be95beeb6b9"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=95a3c8ff04d75d7abe324db4af01e8521092aff9#95a3c8ff04d75d7abe324db4af01e8521092aff9"
 dependencies = [
  "bincode",
  "dashcore",
@@ -1813,7 +1813,7 @@ dependencies = [
 [[package]]
 name = "dashcore_hashes"
 version = "0.43.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=5c0113e7901551450f6063023eec4be95beeb6b9#5c0113e7901551450f6063023eec4be95beeb6b9"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=95a3c8ff04d75d7abe324db4af01e8521092aff9#95a3c8ff04d75d7abe324db4af01e8521092aff9"
 dependencies = [
  "bincode",
  "dashcore-private",
@@ -2867,7 +2867,7 @@ dependencies = [
 [[package]]
 name = "git-state"
 version = "0.43.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=5c0113e7901551450f6063023eec4be95beeb6b9#5c0113e7901551450f6063023eec4be95beeb6b9"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=95a3c8ff04d75d7abe324db4af01e8521092aff9#95a3c8ff04d75d7abe324db4af01e8521092aff9"
 
 [[package]]
 name = "glob"
@@ -4034,7 +4034,7 @@ dependencies = [
 [[package]]
 name = "key-wallet"
 version = "0.43.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=5c0113e7901551450f6063023eec4be95beeb6b9#5c0113e7901551450f6063023eec4be95beeb6b9"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=95a3c8ff04d75d7abe324db4af01e8521092aff9#95a3c8ff04d75d7abe324db4af01e8521092aff9"
 dependencies = [
  "aes",
  "async-trait",
@@ -4063,7 +4063,7 @@ dependencies = [
 [[package]]
 name = "key-wallet-ffi"
 version = "0.43.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=5c0113e7901551450f6063023eec4be95beeb6b9#5c0113e7901551450f6063023eec4be95beeb6b9"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=95a3c8ff04d75d7abe324db4af01e8521092aff9#95a3c8ff04d75d7abe324db4af01e8521092aff9"
 dependencies = [
  "cbindgen 0.29.4",
  "dash-network",
@@ -4079,7 +4079,7 @@ dependencies = [
 [[package]]
 name = "key-wallet-manager"
 version = "0.43.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=5c0113e7901551450f6063023eec4be95beeb6b9#5c0113e7901551450f6063023eec4be95beeb6b9"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=95a3c8ff04d75d7abe324db4af01e8521092aff9#95a3c8ff04d75d7abe324db4af01e8521092aff9"
 dependencies = [
  "async-trait",
  "bincode",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,14 +50,14 @@ members = [
 ]
 
 [workspace.dependencies]
-dashcore = { git = "https://github.com/dashpay/rust-dashcore", rev = "5c0113e7901551450f6063023eec4be95beeb6b9" }
-dash-network-seeds = { git = "https://github.com/dashpay/rust-dashcore", rev = "5c0113e7901551450f6063023eec4be95beeb6b9" }
-dash-spv = { git = "https://github.com/dashpay/rust-dashcore", rev = "5c0113e7901551450f6063023eec4be95beeb6b9" }
-key-wallet = { git = "https://github.com/dashpay/rust-dashcore", rev = "5c0113e7901551450f6063023eec4be95beeb6b9" }
-key-wallet-ffi = { git = "https://github.com/dashpay/rust-dashcore", rev = "5c0113e7901551450f6063023eec4be95beeb6b9" }
-key-wallet-manager = { git = "https://github.com/dashpay/rust-dashcore", rev = "5c0113e7901551450f6063023eec4be95beeb6b9" }
-dash-network = { git = "https://github.com/dashpay/rust-dashcore", rev = "5c0113e7901551450f6063023eec4be95beeb6b9" }
-dashcore-rpc = { git = "https://github.com/dashpay/rust-dashcore", rev = "5c0113e7901551450f6063023eec4be95beeb6b9" }
+dashcore = { git = "https://github.com/dashpay/rust-dashcore", rev = "95a3c8ff04d75d7abe324db4af01e8521092aff9" }
+dash-network-seeds = { git = "https://github.com/dashpay/rust-dashcore", rev = "95a3c8ff04d75d7abe324db4af01e8521092aff9" }
+dash-spv = { git = "https://github.com/dashpay/rust-dashcore", rev = "95a3c8ff04d75d7abe324db4af01e8521092aff9" }
+key-wallet = { git = "https://github.com/dashpay/rust-dashcore", rev = "95a3c8ff04d75d7abe324db4af01e8521092aff9" }
+key-wallet-ffi = { git = "https://github.com/dashpay/rust-dashcore", rev = "95a3c8ff04d75d7abe324db4af01e8521092aff9" }
+key-wallet-manager = { git = "https://github.com/dashpay/rust-dashcore", rev = "95a3c8ff04d75d7abe324db4af01e8521092aff9" }
+dash-network = { git = "https://github.com/dashpay/rust-dashcore", rev = "95a3c8ff04d75d7abe324db4af01e8521092aff9" }
+dashcore-rpc = { git = "https://github.com/dashpay/rust-dashcore", rev = "95a3c8ff04d75d7abe324db4af01e8521092aff9" }
 
 tokio-metrics = "0.5"
 


### PR DESCRIPTION
With this rust-dashcore bump we introduce a fix for some swift sdk panics under specific conditions


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [ ] I have made corresponding changes to the documentation if needed

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated dashcore ecosystem package dependencies to their latest revisions, including dashcore, dash-network-seeds, dash-spv, key-wallet, key-wallet-ffi, key-wallet-manager, dash-network, and dashcore-rpc.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->