### PR TITLE
test(sdk): match ban info entry by exact URI

### DIFF
--- a/packages/rs-dapi-client/src/dapi_client.rs
+++ b/packages/rs-dapi-client/src/dapi_client.rs
@@ -468,9 +468,10 @@ mod tests {
             let after = chrono::Utc::now();
 
             let info = address_list.ban_info();
+            let addr_uri = addr.to_string();
             let entry = info
                 .iter()
-                .find(|i| i.uri.contains("3000"))
+                .find(|i| i.uri == addr_uri)
                 .expect("address present in ban info");
 
             assert!(entry.banned, "genuine failure must ban the node");


### PR DESCRIPTION
Fixes the Copilot review note on dashpay/platform#3951 by matching the ban-info entry using the exact address URI instead of a substring search for the port.

Validation:
- `CARGO_INCREMENTAL=0 git commit ...` pre-commit hook passed `cargo fmt --all -- --check` and workspace `cargo check`
- `CARGO_INCREMENTAL=0 cargo test -p rs-dapi-client test_invariant_genuine_failure_still_bans_with_unchanged_ladder`
