### PR TITLE
fix(swift-sdk): handle ErrorShutdownIncomplete on PR #3954

### DIFF
--- a/packages/swift-sdk/Sources/SwiftDashSDK/PlatformWallet/PlatformWalletManager.swift
+++ b/packages/swift-sdk/Sources/SwiftDashSDK/PlatformWallet/PlatformWalletManager.swift
@@ -155,9 +155,46 @@ public class PlatformWalletManager: ObservableObject {
         if handle != NULL_HANDLE {
             platform_wallet_manager_platform_address_sync_stop(handle).discard()
             platform_wallet_manager_shielded_sync_stop(handle).discard()
-            platform_wallet_manager_destroy(handle).discard()
+            // `destroy` joins every coordinator OS thread with a 30 s
+            // deadline. On `errorShutdownIncomplete` one or more
+            // coordinators are still alive and still hold the
+            // `Arc<FFIPersister>` / `Arc<FFIEventHandler>` whose context
+            // pointer is `Unmanaged.passUnretained(handler).toOpaque()`
+            // for the Swift handler objects below — freeing those Swift
+            // objects now would dangle that pointer and the next
+            // callback would be a use-after-free. Stash them in a
+            // process-global leak slot so any final callback still
+            // sees valid memory. We accept the bounded leak (two small
+            // objects per non-clean shutdown); a clean shutdown returns
+            // success and the handlers are released as usual.
+            let destroyResult = PlatformWalletResult(
+                platform_wallet_manager_destroy(handle)
+            )
+            if destroyResult.code == .errorShutdownIncomplete {
+                PlatformWalletManager._leakedContextLock.lock()
+                if let h = persistenceHandler {
+                    PlatformWalletManager._leakedContext.append(h)
+                }
+                if let h = eventHandler {
+                    PlatformWalletManager._leakedContext.append(h)
+                }
+                PlatformWalletManager._leakedContextLock.unlock()
+            }
         }
     }
+
+    /// Lock guarding `_leakedContext`. Both are `nonisolated` so the
+    /// (implicitly nonisolated) `deinit` can append to the leak slot
+    /// without an isolation hop.
+    nonisolated static let _leakedContextLock = NSLock()
+    /// Process-global retention list for persister / event-handler
+    /// objects we cannot release at `deinit` because a lingering Rust
+    /// coordinator thread (`errorShutdownIncomplete` from `destroy`)
+    /// may still callback through their `Unmanaged.passUnretained`
+    /// context pointer. `AnyObject` keeps the existential opaque so
+    /// `PlatformWalletPersistenceHandler` / `PlatformWalletEventHandler`
+    /// don't need to be `Sendable` to be retained here.
+    nonisolated(unsafe) static var _leakedContext: [AnyObject] = []
 
     // MARK: - Configuration
 

--- a/packages/swift-sdk/Sources/SwiftDashSDK/PlatformWallet/PlatformWalletResult.swift
+++ b/packages/swift-sdk/Sources/SwiftDashSDK/PlatformWallet/PlatformWalletResult.swift
@@ -39,6 +39,15 @@ public enum PlatformWalletResultCode: Int32, Sendable {
     /// outcome. Do NOT auto-retry — a retry would rebuild the bundle and
     /// could double-execute if the original landed.
     case errorShieldedSpendUnconfirmed = 18
+    /// One or more background coordinator threads did not exit cleanly
+    /// before the FFI's 30 s join deadline. The host MUST keep its
+    /// callback context (the persister + event-handler Swift objects whose
+    /// `Unmanaged.passUnretained` opaque pointers were handed to Rust)
+    /// alive past `platform_wallet_manager_destroy` — a lingering
+    /// coordinator thread still holds an `Arc<FFIPersister>` /
+    /// `Arc<FFIEventHandler>` and may fire one final callback through
+    /// that context. The manager IS torn down; do NOT retry `destroy`.
+    case errorShutdownIncomplete = 19
     case notFound = 98
     case errorUnknown = 99
 
@@ -82,6 +91,8 @@ public enum PlatformWalletResultCode: Int32, Sendable {
             self = .errorShieldedBroadcastUnconfirmed
         case PLATFORM_WALLET_FFI_RESULT_CODE_ERROR_SHIELDED_SPEND_UNCONFIRMED:
             self = .errorShieldedSpendUnconfirmed
+        case PLATFORM_WALLET_FFI_RESULT_CODE_ERROR_SHUTDOWN_INCOMPLETE:
+            self = .errorShutdownIncomplete
         case PLATFORM_WALLET_FFI_RESULT_CODE_NOT_FOUND:
             self = .notFound
         case PLATFORM_WALLET_FFI_RESULT_CODE_ERROR_UNKNOWN:
@@ -177,6 +188,14 @@ public enum PlatformWalletError: LocalizedError {
     /// notes reserved wallet-side (a shield reserves nothing) until the
     /// next sync reconciles the outcome. Do NOT auto-retry.
     case shieldedSpendUnconfirmed(String)
+    /// `platform_wallet_manager_destroy` returned without proving that
+    /// every background coordinator OS thread had exited. The manager is
+    /// torn down, but the host must not free the Swift-side persister /
+    /// event-handler context until that thread has had a chance to wind
+    /// down — `PlatformWalletManager.deinit` retains those handlers in a
+    /// process-global leak slot on this code so a final, lingering Rust
+    /// callback finds valid memory.
+    case shutdownIncomplete(String)
     case notFound(String)
     case unknown(String)
 
@@ -192,6 +211,7 @@ public enum PlatformWalletError: LocalizedError {
              .arithmeticOverflow(let m), .noSelectableInputs(let m),
              .walletAlreadyExists(let m), .shieldedBroadcastFailed(let m),
              .shieldedBroadcastUnconfirmed(let m), .shieldedSpendUnconfirmed(let m),
+             .shutdownIncomplete(let m),
              .notFound(let m), .unknown(let m):
             return m
         }
@@ -222,6 +242,7 @@ public enum PlatformWalletError: LocalizedError {
         case .errorShieldedBroadcastFailed: self = .shieldedBroadcastFailed(detail)
         case .errorShieldedBroadcastUnconfirmed: self = .shieldedBroadcastUnconfirmed(detail)
         case .errorShieldedSpendUnconfirmed: self = .shieldedSpendUnconfirmed(detail)
+        case .errorShutdownIncomplete: self = .shutdownIncomplete(detail)
         case .notFound:               self = .notFound(detail)
         case .errorUnknown:           self = .unknown(detail)
         }


### PR DESCRIPTION
## Issue being fixed or feature implemented

Fixes the two CodeRabbit findings on #3954 head `2bd9501a0e`:

1. **Inline (`packages/rs-platform-wallet-ffi/src/error.rs` 128–135)** — the Swift mirror `PlatformWalletResultCode` enum was missing the new `errorShutdownIncomplete = 19` variant, so `init(ffi:)` fell through to `errorUnknown` for `PLATFORM_WALLET_FFI_RESULT_CODE_ERROR_SHUTDOWN_INCOMPLETE`. Swift callers had no way to distinguish a lifecycle-specific shutdown-incomplete from a generic unknown failure.
2. **Outside-diff (`packages/rs-platform-wallet-ffi/src/manager.rs` 366–385, critical)** — the Rust FFI added `ErrorShutdownIncomplete` so the host could keep its callback context alive when a coordinator OS thread did not exit before the 30 s join deadline. But the Swift `deinit` at `PlatformWalletManager.swift:158` calls `platform_wallet_manager_destroy(handle).discard()` and unconditionally proceeds to release `persistenceHandler` / `eventHandler` — whose `Unmanaged.passUnretained(...).toOpaque()` pointers a lingering coordinator's `Arc<FFIPersister>` / `Arc<FFIEventHandler>` still holds. Releasing them would dangle that pointer; the next callback would be a use-after-free — exactly the hazard the new result code was added to prevent.

## What was done?

* `PlatformWalletResultCode.errorShutdownIncomplete = 19` and the matching `init(ffi:)` arm, plus a `PlatformWalletError.shutdownIncomplete(String)` payload so the error sums round-trip cleanly.
* In `PlatformWalletManager.deinit`, capture the destroy result. On `errorShutdownIncomplete`, move the handler references into a process-global retention slot (`_leakedContext` guarded by `_leakedContextLock`) so any final coordinator callback resolves to live Swift memory. The clean path is unchanged.

The two changes are split into separate commits so the enum mirror can land independently of the host-side safety fix if needed.

## How Has This Been Tested?

* `cargo check -p platform-wallet-ffi` — clean.
* `swiftc -parse -swift-version 6` on both modified Swift files — parses clean.
* Full Swift package build is not feasible in this temp clone: `DashSDKFFI.xcframework` is not checked in (built by `packages/swift-sdk/build_ios.sh` from Rust artifacts), and the only pre-built xcframework available on this machine predates the platform-wallet FFI. The `PLATFORM_WALLET_FFI_RESULT_CODE_ERROR_SHUTDOWN_INCOMPLETE` symbol added in this PR follows `cbindgen`'s `ErrorShutdownIncomplete` → `PLATFORM_WALLET_FFI_RESULT_CODE_ERROR_SHUTDOWN_INCOMPLETE` rule used by every other variant in the file.

## Breaking Changes

None — `errorShutdownIncomplete` only fires when the new Rust `ErrorShutdownIncomplete` result code is returned, which is itself new in PR #3954.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I have not provided a default value for specific properties without consultation

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)