### PR TITLE
docs(dashpay): expand DashPay QA test cases for DIP-15/16 (DP-07..10)

### DIFF
--- a/docs/dashpay/QA_TESTCASES_SPEC.md
+++ b/docs/dashpay/QA_TESTCASES_SPEC.md
@@ -1,0 +1,212 @@
+# DashPay (DIP-15 / DIP-16) QA test-case expansion — SPEC
+
+**Status:** reviewed (4-lens multi-agent pass folded in)
+**Target file:** `packages/swift-sdk/SwiftExampleApp/TEST_PLAN.md` §4.10 (+ §5, §6, §1)
+**Base:** branched off `feat/dashpay-m1-sync-correctness` (PR #3841,
+"fix(platform-wallet)!: complete dashpay") — the DashPay views, `docs/dashpay/`,
+and the features these rows describe live there, not yet in `v3.1-dev`.
+**PR target:** `v3.1-dev`, to merge **after** #3841 lands (pure-docs diff;
+rebased so it shows only the TEST_PLAN.md / spec changes).
+**Renders in:** [`dashpay/qa-dashboard-site`](https://github.com/dashpay/qa-dashboard-site)
+once the sibling seed task re-seeds the `dash-qa` contract from the updated plan.
+
+---
+
+## 1. Problem
+
+`TEST_PLAN.md` §4.10 (DashPay) had **6 coarse rows** (`DP-01..06` + cross-ref
+`MW-03`) at "feature exists" granularity, and their entry points were **stale**:
+they cited `FriendsView` / `AddFriendView`, which #3841 replaced with a dedicated
+DashPay tab (`DashPayTabView`, `AddContactView`, `ContactsView`,
+`ContactRequestsView`, `ContactDetailView`, `DashPayProfileView`,
+`IgnoredContactsView`, `SendDashPayPaymentSheet`).
+
+#3841 implements substantial **DIP-15** surface the catalog did not exercise
+(per the branch's audit `docs/dashpay/DIP_CONFORMANCE_GAPS.md`):
+`encryptedAccountLabel` send+receive, QR auto-accept (build + paste-to-add),
+on-chain `contactInfo` publish, and the §12.6 incoming-payment backfill rescan.
+**DIP-16** is the SPV sync layer underneath (covered by `CORE-07`; its
+DashPay-specific facet is the single backfill row `DP-10`).
+
+## 2. Goal & non-goals
+
+**Goal:** correct the stale `DP-01..06` entry points and add rows for the
+**user-observable, simulator-drivable** DIP-15/16 DashPay flows #3841 ships.
+
+**Non-goals (out of scope):**
+- **DIP-15 crypto internals** (ECDH, 69-byte compact xpub, `accountReference`
+  masking, avatar hash/dHash) — already Rust known-answer tests; not app rows.
+- **Gap / absence rows** (`🚫`/`➖`) for unimplemented features (multi-account
+  `Account≠0`, `acceptedAccounts` flood mitigation, invitations). Drivable only.
+- **A DIP-16 section.** SPV sync is `CORE-07`; the DashPay facet is `DP-10`.
+- **New table columns.** Keep the uniform 6-col `ID | Action | Layer | Tier |
+  Status | Entry point & test notes`; cite DIP §s inline. (The dashboard
+  normaliser reads no section field; a 7th column is dropped on seed.)
+- **A `tags` column.** Tag assignment for the v5 contract is the seed tool's job
+  (not in these repos). Open question §7.
+
+## 3. Corrections to existing rows (`DP-01..06`)
+
+Entry points updated to the #3841 DashPay tab; FFI-symbol naming (matches the
+existing §4.10 convention). Merged sub-flows folded in as notes:
+- **DPNS-add path** → a note on `DP-01` (precedent: `ID-04`/`MW-01` list input
+  methods in one row; DPNS resolution itself is `DPNS-03`/`DPNS-07`).
+- **Payment-channel-broken** state → a note on `DP-03` (precedent: `ID-12`/`DOC-07`
+  attach gating state to the action row).
+- **Avatar** (url + Rust-computed hash/fingerprint) → a note on `DP-04`.
+- `DP-06` **Reject → Ignore** rename (the branch made reject a reversible local mute).
+
+## 4. New rows (drivable DIP-15/16 flows)
+
+| ID | Tier | DIP-15 § | Behavior |
+|---|---|---|---|
+| DP-07 | Common | §8.5 | Attach `encryptedAccountLabel` on send; counterparty sees "Their account" (decrypted, incoming-row only). |
+| DP-08 | Thorough | §8.13 | QR auto-accept: build "Add me" QR; add via pasted URI → auto-accepted without manual accept. Paste-drivable; camera = Manual variant. |
+| DP-09 | Thorough | §10 | Publish encrypted on-chain `contactInfo`; ≥2-contact gate → `.published` / `.deferredUntilTwoContacts` / `.skippedWatchOnly`. |
+| DP-10 | Manual | §8.7/§12.6 | Incoming-payment backfill rescan (no UI trigger; `reconcile_dashpay_rescan` rewinds SPV `synced_height`). Env-limited; the §12.6 payment-loss regression pin. |
+
+`DP-10` note: the branch's `DIP_CONFORMANCE_GAPS.md` §1.1 still marks this MISSING,
+but that audit predates the implementing commit `18483e4232`
+(`reconcile_dashpay_rescan`, wired in `manager/dashpay_sync.rs`, 4 unit tests) —
+so Status=✅ is correct.
+
+## 5. Cross-cutting edits (applied)
+
+- **§6 index** — DashPay: `DP-01..06, MW-03` → `DP-01..10, MW-03`.
+- **§5 by-tier** — Common `31→32`, Thorough `35→37`, Manual `1→2` (`CORE-08, DP-10`).
+- **§5 by-layer (automatable; Manual EXCLUDED)** — Platform `~72→~75`; **Cross
+  unchanged** (DP-10 is Manual).
+- **§1 worked example** — "list the manual tests" → `CORE-08, DP-10`.
+
+## 6. Final row set
+
+6 corrections (`DP-01..06`) **+ 4 new** (`DP-07` account label, `DP-08` QR
+auto-accept, `DP-09` on-chain `contactInfo`, `DP-10` backfill rescan).
+
+## 7. Open questions
+
+1. **Tags** — does the seed tool assign v5 tags (e.g. `dip15`, `sync`) from
+   Domain/§6, or should the plan encode them? Needs the seed tool (not in repos).
+2. **DP-07 a11y id** — the "Their account" block in `ContactDetailView` has no
+   `accessibilityIdentifier`, so DP-07 asserts on visible text. A 1-line app
+   change would make it cleanly automatable — a trivial follow-up, deliberately
+   kept out of this docs-only PR.
+
+## 8. Verification plan
+
+1. **Render check** — IDs match `^DP-\d+$`; tier/category present so the dashboard
+   matrix charts them (the normaliser only hard-requires `testId`).
+2. **Drive each new row** with the `simulator-control` skill on a booted sim; two
+   on-device wallets where a counterparty is needed (`DP-07`/`DP-08`, cf. `MW-03`).
+   Verify against **persisted SwiftData state**, not UI alone (§1 pass criteria).
+   `DP-10` is Manual → skip-and-flag in automation.
+3. **No code change** — pure TEST_PLAN.md edit. The seed task re-seeds `dash-qa`;
+   the dashboard renders.
+
+## 9. Review provenance
+
+Four independent review lenses (DIP domain-fit, scope/simplicity, automatability/
+entry-point accuracy, catalog conventions) ran against the draft. Key folds:
+- Added `DP-09` (on-chain `contactInfo`) — the draft wrongly excluded it as
+  "local-only / no UI"; it is a drivable DIP-15 §10 publish.
+- Merged the draft's separate DPNS / avatar / channel-broken rows into notes on
+  `DP-01` / `DP-04` / `DP-03` (catalog precedent; lean set).
+- Dropped a 7th `DIP-15 §` column (normaliser ignores it; breaks the 6-col shape).
+- Confirmed `DP-10`'s rescan is implemented + wired; corrected the `wallet.pass`
+  SF-symbol-vs-a11y-id confusion in `DP-07`.
+
+## 10. Runtime verification (simulator)
+
+Driven on a booted iOS simulator (iPhone 17) against a live devnet build with real
+DashPay fixtures (wallet "SimB", 1 identity, 2 contacts, 5 requests), via the
+`simulator-control` skill. Read-only structural pass — navigated to each row's
+entry point and confirmed the cited screens/controls exist; **no broadcasts fired**.
+
+Confirmed live:
+- `DP-01` — `AddContactView` mode picker + resolved-recipient preview + **Send Request**.
+- `DP-03` — `ContactDetailView` `dashpay.detail.sendDash`.
+- `DP-04` — `DashPayProfileView` **Edit** (→ editor) + avatar.
+- `DP-05` — DashPay tab: `ContactsView` (search, contacts, segment, profile header).
+- `DP-07` (send) — `dashpay.addContact.accountLabel` renders once a recipient resolves.
+- `DP-08` — build: `dashpay.profile.qrURI` emits a real `dash:?du=…&dapk=…` URI + QR
+  image; add: `AddViaQRSheet` `dashpay.qr.uriField`.
+- `DP-09` — the **Alias / Note / Hide** editor calls `saveContactInfo` →
+  `setDashPayContactInfo`; the in-app footer confirms the ≥2-contact encrypted-publish
+  gate. **Refined the row** accordingly — the original "distinct from a local note"
+  wording was wrong (the same editor caches locally *and* publishes on-chain).
+
+Code-confirmed but not rendered this pass (no fixture): `DP-02` / `DP-06`
+(`dashpay.request.accept` / `.ignore` — need an *incoming* pending request);
+`DP-07` receive-side "Their account" (only shows when a contact sent a label);
+`DP-10` (no UI by design — automatic in DashPay sync). Live broadcast execution and
+the two-wallet loops (`DP-07`/`DP-08`) are the next step, gated on credits + a
+counterparty identity.
+
+A full code re-audit of every row (4 parallel passes) confirmed 8/10 rows + all the
+§5/§6/§1 count edits accurate, and corrected 5 row-wording inaccuracies: DP-01 (open
+button id `dashpay.addContact` vs the in-sheet mode toggle), DP-02/DP-05
+(`EstablishedContact` is a Rust/FFI handle, **not** a SwiftData model — the tab views
+are backed by `PersistentDashpayContactRequest`), DP-03 (channel-broken is any
+permanent channel failure, not only key rotation), and DP-08 (TTL is exactly 3600s).
+
+## 11. Implementation observations (for #3841 — surfaced during verification, NOT addressed here)
+
+These are defects/smells in the DashPay *implementation* found while auditing the
+plan. They are out of scope for this docs PR; recorded for the #3841 author.
+
+1. **Stale doc-comment** — `ContactRequestsView.swift:5-8` says incoming rows carry
+   "**Accept / Reject**", but the button is **Ignore** (reject was replaced by the
+   reversible local mute). Same file `:35-37` carries an internal `§6.4` spec-gate
+   ref (rots; against the timeless-comment convention).
+2. **Multi-wallet mis-attribution risk** — `DashPayProfileEditorView` falls back to
+   `walletManager.firstWallet` when `walletId` is nil (`IdentityDetailView.swift:1316`);
+   in a multi-wallet setup a profile update could submit under the wrong identity.
+   Already acknowledged in an in-code comment as needing tightening.
+3. **Handle-leak smell** — `acceptContactRequest`'s returned `EstablishedContact`
+   (FFI handle wrapper) is discarded with `_ =` at both call sites
+   (`ContactRequestsView.swift:228`, `AddContactView.swift:487`); leaks per accept
+   unless the wrapper frees the handle in `deinit` (worth confirming a `deinit`).
+4. **QR clock edge** — `build_auto_accept_qr` derives expiry from
+   `SystemTime::now()…unwrap_or(0)`; a pre-1970 / badly-skewed clock yields an
+   already-expired QR. Harmless on a real device.
+5. **No collision handling in `AddViaQRSheet`** — pasting a URI from someone who
+   already sent *you* a request broadcasts a duplicate outgoing request rather than
+   offering "Accept instead" (`AddContactView` handles this; the QR path does not).
+
+By-design / cosmetic (no action expected): avatar hash does not change if the image
+bytes are swapped behind the same URL; a corrupt/hostile incoming account label
+unpads to garbage and is coerced to `None` (shows no "Their account" — relevant to
+DP-07 negative testing); `setDashPayContactInfo` maps unknown future outcome bytes to
+`.published` on the Swift side; a stale memo doc-comment in `SendDashPayPaymentSheet`
+(DashPay payments always pass `memo: nil`); a dead `_ = bytes` local + a redundant
+`?? nil` duplicated across four profile-cache reads.
+
+## 12. Live end-to-end run (freshly-built binary)
+
+Built `build_ios.sh --target sim` from `feat/dashpay-m1-sync-correctness` HEAD
+(`47d9044b5a`), installed on two iOS simulators, and drove the flows on-chain
+against devnet (two funded identities per side): **Eve** (SimB) ↔ **Alice / Bob /
+Dolly(7A8E)** (SimA), each ~25–30B credits. Verified against SwiftData ground
+truth (and on-chain for the payment).
+
+| Row | Result (fresh build) | Evidence |
+|---|---|---|
+| DP-01 send | ✅ | labeled contact request broadcast (sheet dismissed, no error); also the DP-02 reciprocal send |
+| DP-02 accept | ✅ | 7A8E accepted Eve → reciprocal `7A8E→Eve` row created (established) |
+| DP-03 payment | ✅ | Eve→Alice **0.001 DASH** real L1 tx (input spent, change `74,899,477`, fee `226` duffs, txid `850433507c88…560e`) — **after starting Core SPV** |
+| DP-04 profile | ✅ | publicMessage updated on-chain → SwiftData (`QA fresh-build 16:10`) |
+| DP-05 view | ✅ | contacts / requests / profile rendered throughout |
+| DP-06 ignore | ⚪ proven on prior build | not re-runnable on the saturated graph (no pending incoming); local-only (`ignoreContactSender`, no broadcast), code unchanged |
+| DP-07 label | ✅ send; receive timing confirmed | label attached + broadcast; **decrypts on accept** (ingest carries encrypted bytes, plaintext appears once established) |
+| DP-08 QR | ✅ | Eve built `dash:?du=…&dapk=…`; SimA pasted + `sendContactRequestFromQR` broadcast |
+| DP-09 contactInfo | ✅ | Eve alias "QA Bestie" on Alice persisted; footer confirms ≥2-contact encrypted publish |
+| DP-10 backfill rescan | ⚪ Manual | no UI trigger; needs a restore-from-seed / pre-watch skew window — not auto-runnable (impl code-confirmed) |
+
+**8/10 flows confirmed live on the fresh build**; `DP-06` and `DP-10` not
+re-runnable for environmental reasons (graph saturation / Manual-tier), both
+proven/confirmed by other means.
+
+Two plan corrections came out of the run: **DP-03** now records the Core-SPV
+precondition (a DashPay payment is an L1 broadcast — fails "SPV Client not started"
+if SPV is stopped); **DP-07** now states the label decrypts **on accept**, not on
+ingest.

--- a/packages/swift-sdk/SwiftExampleApp/TEST_PLAN.md
+++ b/packages/swift-sdk/SwiftExampleApp/TEST_PLAN.md
@@ -31,7 +31,7 @@ A row's **primary** category is the §4 section it lives in. Some tests are **cr
 |---|---|---|
 | "test Essential, Platform-only" | `Tier=Essential AND Layer=Platform` | `ID-02, ID-03, ID-04, DPNS-01, DPNS-02, DPNS-03, DPNS-04` |
 | "test all Essential" | `Tier=Essential` | the core experience: `CORE-01..07`, `ID-01/02/03/04`, `DPNS-01/02/03/04`, `SH-01..06` |
-| "list the manual tests" | `Tier=Manual` | `CORE-08` (skip in automation; run on a physical device) |
+| "list the manual tests" | `Tier=Manual` | `CORE-08`, `DP-10` (skip in automation; run on a physical device) |
 | "smoke test the wallet" | `Category=Core AND Status=✅` | `CORE-01..CORE-09` |
 | "test all non-Uncommon Token tests" | `Category=Token AND Tier≠Uncommon` | `TOK-01..07`, `MW-02` (via §6 index) |
 | "exercise every token admin action" | `Category=Token AND Tier=Uncommon` | `TOK-08..TOK-16` |
@@ -265,12 +265,16 @@ Shielded notes/balance/activity have **no read-side FFI** by design — Rust pus
 
 | ID | Action | Layer | Tier | Status | Entry point & test notes |
 |---|---|---|---|---|---|
-| DP-01 | Send contact request | Platform | Common | ✅ | `FriendsView` (AddFriendView) → `platform_wallet_send_contact_request_with_signer`. |
-| DP-02 | Accept contact request | Platform | Common | ✅ | `FriendsView` → `platform_wallet_accept_contact_request_with_signer`. |
-| DP-03 | Send DashPay payment to a contact | Platform | Common | ✅ | `FriendsView` → `platform_wallet_send_dashpay_payment`. |
-| DP-04 | Create / update DashPay profile | Platform | Common | ✅ | `IdentityDetailView` profile editor → `platform_wallet_create_or_update_dashpay_profile_with_signer`. |
-| DP-05 | View profile / contacts / requests | Platform | Common | ✅ | `FriendsView`, `EstablishedContact` (SwiftData). |
-| DP-06 | Reject contact request | Platform | Thorough | ✅ | `FriendsView` → `wallet.rejectContactRequest`. |
+| DP-01 | Send contact request | Platform | Common | ✅ | DashPay tab → **Add Contact** (toolbar button `dashpay.addContact`) → `AddContactView` (mode toggle `dashpay.addContact.mode`): by Identity ID (base58, 32-byte gated) or DPNS username (≥2-char live prefix search; not-found offers clear-and-retry `dashpay.addContact.retry`) → `platform_wallet_send_contact_request_with_signer`. Optimistic-send overlay until the request appears. |
+| DP-02 | Accept contact request | Platform | Common | ✅ | `ContactRequestsView` (Incoming) → **Accept** (`dashpay.request.accept`) → `platform_wallet_accept_contact_request_with_signer`. Contact moves to `ContactsView`; the bidirectional contact persists (both request-direction rows present for the pair). |
+| DP-03 | Send DashPay payment to a contact | Platform | Common | ✅ | `ContactDetailView` → **Send Dash** (`dashpay.detail.sendDash`) → `SendDashPayPaymentSheet` → `platform_wallet_send_dashpay_payment`. A DashPay payment is an **L1 transaction**, so it requires the **Core SPV client running** (`CORE-07`) — with SPV stopped the broadcast fails with "SPV error: SPV Client not started". Payment appears in the contact's Payments (txid). Send is disabled while the payment channel is broken — flagged on a permanent channel failure (e.g. the contact rotated their payment keys/addresses, or a request decrypt/validation failure) — showing "ask the contact to send a new request"; it re-enables when a fresh request arrives. |
+| DP-04 | Create / update DashPay profile | Platform | Common | ✅ | `DashPayProfileView` → **Edit** (`dashpay.profile.edit`) → `DashPayProfileEditorView` (`dashpay.profile.displayName` / `.publicMessage` / `.avatarUrl`) → `platform_wallet_create_or_update_dashpay_profile_with_signer`. Non-destructive update; avatar renders via `DashPayAvatarView` and the re-fetched profile carries the computed `avatarHash` + 8-byte dHash `avatarFingerprint`. |
+| DP-05 | View profile / contacts / requests | Platform | Common | ✅ | DashPay tab: `ContactsView` (established + search `dashpay.search`), `ContactRequestsView` (incoming/outgoing), `ContactDetailView`, `DashPayProfileView` — backed by `PersistentDashpayContactRequest` (SwiftData); established contacts are derived in-memory by joining each pair's incoming + outgoing request rows. |
+| DP-06 | Ignore a contact request (reversible local mute) | Platform | Thorough | ✅ | `ContactRequestsView` → **Ignore** (`dashpay.request.ignore`) → `wallet.ignoreContactSender`. The sender leaves the requests list and appears in `IgnoredContactsView` (un-ignore `dashpay.ignored.unignore` reverses it). Local-only, no on-chain artifact (R1 privacy); persists across relaunch. |
+| DP-07 | Attach `encryptedAccountLabel`; see contact's "Their account" on receive | Platform | Common | ✅ | DIP-15 §8.5. Send: `AddContactView` → **Account label** (`dashpay.addContact.accountLabel`) carried into `sendContactRequest(…accountLabel:)`. Receive: the counterparty's `ContactDetailView` shows a read-only **"Their account"** block (assert on visible text — no a11y id yet). Verify on a two-wallet loop (cf. `MW-03`): the ingested request carries the encrypted bytes, but the plaintext is decrypted **on accept** (the signer-bearing register step) and shown on the **incoming row only** (direction-specific). |
+| DP-08 | QR auto-accept (build "Add me" QR + add via pasted URI) | Platform | Thorough | ✅ | DIP-15 §8.13. Build: `DashPayProfileView` → **Add me (DIP-15 QR)** (`dashpay.profile.qrURI`, `du=…&dapk=…`, 1h validity — `AUTO_ACCEPT_TTL_SECS=3600`) via `buildAutoAcceptQR`. Add: DashPay tab → **Add via QR** (`dashpay.addViaQR`) → `AddViaQRSheet` (`dashpay.qr.uriField` / `dashpay.qr.send`) → `sendContactRequestFromQR`. Two-wallet: A builds the QR, B pastes the URI → the request is auto-accepted by A without A manually accepting (a distinct acceptance path from `DP-02`). The paste path is simulator-drivable; a camera scan yields the same string (Manual variant). |
+| DP-09 | Publish encrypted on-chain `contactInfo` (private contact metadata) | Platform | Thorough | ✅ | DIP-15 §10. `ContactDetailView` → edit **Alias** / **Note** / **Hide contact** (`dashpay.detail.aliasEdit` / `dashpay.detail.noteEdit` / `dashpay.detail.hideToggle`) → `saveContactInfo` → `platform_wallet_set_dashpay_contact_info_with_signer` (ECB `encToUserId` + CBC `privateData`). These fields are locally cached **and** published encrypted to Platform once the identity has **≥2 established contacts** (stated in the in-app footer) → outcomes `.published` / `.deferredUntilTwoContacts` / `.skippedWatchOnly`. |
+| DP-10 | Incoming-payment backfill rescan (restore-from-seed / pre-watch window) | Cross | Manual | ✅ | DIP-15 §8.7 / §12.6 (on the DIP-16 SPV base). No UI trigger — automatic in DashPay sync: `reconcile_dashpay_rescan` lowers SPV `synced_height` to `min($coreHeightCreatedAt)` across new receival contacts so the filter manager backfills. Pass: a DashPay payment that landed on a contact's address **before** it was watched (restore-from-seed / second device / the offline-accept→pay window) appears after restore + SPV sync. Environment-limited (must construct the skew window); the regression pin for the §12.6 payment-loss gap. |
 
 ### 4.11 Group — `Domain=Group`
 
@@ -323,17 +327,17 @@ Counts are of rows reachable in the app (Status `✅`/`🧪`/`⚠️`); `🔌`/`
 | Tier | Count (approx.) | Automatable? |
 |---|---|---|
 | Essential | 21 | yes |
-| Common | 31 | yes |
-| Thorough | 35 | yes |
+| Common | 32 | yes |
+| Thorough | 37 | yes |
 | Uncommon | 25 | yes |
-| Manual | 1 (`CORE-08`) | no — physical device |
+| Manual | 2 (`CORE-08`, `DP-10`) | no — physical device |
 
 **By layer (automatable only):**
 
 | Layer | Count (approx.) |
 |---|---|
 | Core | 17 |
-| Platform | ~72 |
+| Platform | ~75 |
 | Cross | 7 |
 | Shielded | 16 |
 
@@ -355,7 +359,7 @@ Membership of each feature category across **all** sections (primary section mem
 - **Document** — `DOC-01..14`, `MW-04`
 - **Token** — `TOK-01..16`, `MW-02`, `GRP-03`
 - **Shielded** — `SH-01..13`, `CORE-21`, `MW-06`, `MW-07`, `MW-11`
-- **DashPay** — `DP-01..06`, `MW-03`
+- **DashPay** — `DP-01..10`, `MW-03`
 - **Group** — `GRP-01..04`, `TOK-15`, `TOK-16`
 - **System / Diagnostics** — `SYS-01..06`
 


### PR DESCRIPTION
## Issue being fixed or feature implemented

The DashPay section (§4.10) of `packages/swift-sdk/SwiftExampleApp/TEST_PLAN.md`
was thin (6 "feature exists" rows) and **stale** — the rows cited `FriendsView`,
which #3841 ("fix(platform-wallet)!: complete dashpay") replaced with a dedicated
DashPay tab. It also didn't exercise the DIP-15 / DIP-16 surface #3841 implements.

This is the QA-catalog companion to #3841: `TEST_PLAN.md` is the source the
on-chain `dash-qa` contract — and the read-only QA dashboard
([`dashpay/qa-dashboard-site`](https://github.com/dashpay/qa-dashboard-site)) — is
seeded from.

> **Draft — pairs with #3841.** The new rows describe screens/features that land
> with #3841, so this should merge after it. `TEST_PLAN.md` is identical on
> `v3.1-dev` and the #3841 branch, so this diff is clean against `v3.1-dev`.

## What was done?

Docs-only edit to `TEST_PLAN.md` §4.10 (+ §5 summary matrix, §6 index, §1 example):

- **Corrected `DP-01..06`** entry points to the new DashPay tab views
  (`AddContactView`, `ContactRequestsView`, `ContactDetailView`,
  `DashPayProfileView`, `IgnoredContactsView`, `SendDashPayPaymentSheet`); renamed
  **`DP-06` "Reject" → "Ignore"** (reversible local mute).
- **Added 4 drivable DIP-15/16 rows:**
  - `DP-07` — `encryptedAccountLabel` send + "Their account" on receive (DIP-15 §8.5)
  - `DP-08` — QR auto-accept: build "Add me" QR + paste-to-add (§8.13)
  - `DP-09` — publish encrypted on-chain `contactInfo`, ≥2-contact gate (§10)
  - `DP-10` — incoming-payment backfill rescan, `Tier=Manual` (§8.7/§12.6 — the
    payment-loss regression pin)
- Folded the DPNS-add / payment-channel-broken / avatar sub-flows into notes on
  `DP-01`/`DP-03`/`DP-04` (catalog convention); updated counts (Common 32,
  Thorough 37, Manual 2) and the category index (`DP-01..10`).
- Added `docs/dashpay/QA_TESTCASES_SPEC.md` — rationale + a 4-lens review summary.

**Out of scope:** crypto known-answer tests (already Rust-tested), unimplemented
gaps (multi-account `Account≠0`, `acceptedAccounts` flood mitigation, invitations),
and a 1-line accessibility-id follow-up for the `DP-07` "Their account" label.

## How Has This Been Tested?

- **Static checks (done):** all 10 `DP-*` rows are well-formed (6 columns); every
  accessibility id cited in the new rows exists in the app on the #3841 branch
  (`dashpay.addContact.mode`, `dashpay.request.accept`, `dashpay.detail.sendDash`,
  `dashpay.profile.qrURI`, `dashpay.addViaQR`, `dashpay.qr.send`,
  `dashpay.ignored.unignore`, `dashpay.search`); summary-matrix/category-index
  counts reconciled.
- **Runtime (pending on a booted sim + #3841 app build):** drive each new row with
  the `simulator-control` skill, two on-device wallets for the counterparty flows
  (`DP-07`/`DP-08`, cf. `MW-03`), verifying against persisted SwiftData state, not
  UI alone (§1 pass criteria). `DP-10` is `Manual` → skip-and-flag in automation.

## Breaking Changes

None — documentation only.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests <!-- N/A: these rows *are* the test definitions; runtime drive pending -->
- [ ] I have added "!" to the title and described breaking changes <!-- N/A: no breaking change -->
- [x] I have made corresponding changes to the documentation if needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
