### PR TITLE
feat(wasm-sdk): expose tiered token pricing in setPrice

### DIFF
--- a/packages/js-evo-sdk/package.json
+++ b/packages/js-evo-sdk/package.json
@@ -28,7 +28,7 @@
     "build": "rm -rf dist && tsc -p tsconfig.json && webpack --config webpack.config.cjs",
     "lint": "eslint \"src/**/*.ts\" \"tests/**/*.ts\"",
     "test": "yarn run test:unit",
-    "test:unit": "mocha --import ts-node/esm --require tests/bootstrap.cjs tests/unit/**/*.spec.ts && karma start ./tests/karma/karma.conf.cjs --single-run"
+    "test:unit": "TS_NODE_TRANSPILE_ONLY=true TS_NODE_PROJECT=tests/tsconfig.json TS_NODE_FILES=true mocha --node-option loader=ts-node/esm --require tests/bootstrap.cjs tests/unit/**/*.spec.ts && karma start ./tests/karma/karma.conf.cjs --single-run"
   },
   "devDependencies": {
     "@types/chai": "^4.3.11",

--- a/packages/js-evo-sdk/tests/unit/facades/tokens.spec.ts
+++ b/packages/js-evo-sdk/tests/unit/facades/tokens.spec.ts
@@ -476,12 +476,26 @@ describe('TokensFacade', () => {
   });
 
   describe('setPrice()', () => {
-    it('should set direct purchase price for tokens', async () => {
+    it('should set a flat direct purchase price for tokens', async () => {
       const options = {
         tokenId,
-        price: {
-          type: 'fixed',
-          value: BigInt(1000000), // 1M credits per token
+        price: BigInt(1000000), // 1M credits per token
+        identityKey,
+        signer,
+      };
+
+      const result = await client.tokens.setPrice(options);
+
+      expect(tokenSetPriceStub).to.be.calledOnceWithExactly(options);
+      expect(result.tokenId).to.equal(tokenId);
+    });
+
+    it('should forward a tiered direct purchase price schedule unchanged', async () => {
+      const options = {
+        tokenId,
+        priceTiers: {
+          '100': BigInt(1000),
+          '1000': BigInt(900),
         },
         identityKey,
         signer,

--- a/packages/wasm-sdk/src/state_transitions/token.rs
+++ b/packages/wasm-sdk/src/state_transitions/token.rs
@@ -8,6 +8,7 @@ use crate::sdk::WasmSdk;
 use crate::settings::{get_user_fee_increase, PutSettingsInput};
 use dash_sdk::dpp::balances::credits::TokenAmount;
 use dash_sdk::dpp::document::Document;
+use dash_sdk::dpp::fee::Credits;
 use dash_sdk::dpp::identity::IdentityPublicKey;
 use dash_sdk::dpp::platform_value::Identifier;
 use dash_sdk::platform::tokens::builders::{
@@ -27,6 +28,7 @@ use dash_sdk::platform::tokens::transitions::{
 use dash_sdk::platform::transition::put_settings::PutSettings;
 use js_sys::BigInt;
 use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
 use std::sync::Arc;
 use wasm_bindgen::prelude::*;
 use wasm_dpp2::data_contract::document::DocumentWasm;
@@ -35,7 +37,7 @@ use wasm_dpp2::identity::IdentityPublicKeyWasm;
 use wasm_dpp2::state_transitions::base::GroupStateTransitionInfoStatusWasm;
 use wasm_dpp2::state_transitions::batch::token_pricing_schedule::TokenPricingScheduleWasm;
 use wasm_dpp2::tokens::configuration_change_item::TokenConfigurationChangeItemWasm;
-use wasm_dpp2::utils::{try_from_options, try_from_options_optional};
+use wasm_dpp2::utils::{try_from_options, try_from_options_optional, try_to_u64};
 use wasm_dpp2::version::PlatformVersionLikeJs;
 use wasm_dpp2::IdentitySignerWasm;
 
@@ -1942,10 +1944,26 @@ export interface TokenSetPriceOptions {
   authorityId: Identifier;
 
   /**
-   * The price in credits for one token.
+   * The flat price in credits for one token (SinglePrice schedule).
    * Set to null to disable direct purchases.
+   * Mutually exclusive with `priceTiers`.
    */
-  price: bigint | null;
+  price?: bigint | null;
+
+  /**
+   * Tiered direct-purchase pricing (SetPrices schedule).
+   *
+   * Maps the minimum bulk-buy amount (token amount, as a string key)
+   * to the per-token price in credits for that tier. Keys are unsigned
+   * integers encoded as strings; values are credit amounts as bigint.
+   *
+   * Example: `{ "1": 1_000n, "100": 900n, "1000": 800n }` charges 1000
+   * credits/token for purchases of 1+, 900 for purchases of 100+, and
+   * 800 for purchases of 1000+.
+   *
+   * Mutually exclusive with `price`. Must contain at least one entry.
+   */
+  priceTiers?: Record<string, bigint>;
 
   /**
    * Optional public note for the price change.
@@ -1985,6 +2003,10 @@ extern "C" {
 }
 
 /// Main input struct for token set price options (primitives only).
+///
+/// Tiered pricing (`priceTiers`) is extracted separately via `extract_price_tiers`
+/// because serde-wasm-bindgen does not deserialize JS bigints inside a generic
+/// `Record<string, bigint>` reliably.
 #[derive(Deserialize)]
 #[serde(rename_all = "camelCase")]
 struct TokenSetPriceOptionsInput {
@@ -2003,6 +2025,89 @@ fn deserialize_token_set_price_options(
         "Options object is required",
         "token set price options",
     )
+}
+
+/// Validate a constructed `priceTiers` map.
+///
+/// Rejects:
+/// - empty maps (caller must specify at least one tier)
+/// - a `0` minimum bulk-buy amount (use the flat `price` field for that)
+/// - a `0` credits value (use `price: null` to disable direct purchases)
+///
+/// Pure function so it can be unit-tested without a JS runtime.
+fn validate_price_tiers(tiers: &BTreeMap<TokenAmount, Credits>) -> Result<(), WasmSdkError> {
+    if tiers.is_empty() {
+        return Err(WasmSdkError::invalid_argument(
+            "'priceTiers' must contain at least one entry",
+        ));
+    }
+    for (amount, credits) in tiers {
+        if *amount == 0 {
+            return Err(WasmSdkError::invalid_argument(
+                "'priceTiers' minimum bulk-buy amount must be > 0; use 'price' for a flat single-token price",
+            ));
+        }
+        if *credits == 0 {
+            return Err(WasmSdkError::invalid_argument(format!(
+                "'priceTiers' price for amount {} must be > 0; set 'price: null' to disable direct purchases",
+                amount
+            )));
+        }
+    }
+    Ok(())
+}
+
+/// Extract the optional `priceTiers` field from the raw JS options object.
+///
+/// Returns `Ok(None)` when the field is absent, null, or undefined.
+/// Returns `Err` when the field is present but malformed (wrong type,
+/// empty, non-numeric keys, non-bigint/integer values, zero amount/price, etc.).
+fn extract_price_tiers(
+    options: &JsValue,
+) -> Result<Option<BTreeMap<TokenAmount, Credits>>, WasmSdkError> {
+    let value = js_sys::Reflect::get(options, &JsValue::from_str("priceTiers"))
+        .map_err(|_| WasmSdkError::invalid_argument("failed to read 'priceTiers' from options"))?;
+
+    if value.is_undefined() || value.is_null() {
+        return Ok(None);
+    }
+
+    if !value.is_object() || js_sys::Array::is_array(&value) {
+        return Err(WasmSdkError::invalid_argument(
+            "'priceTiers' must be an object mapping token amount keys to bigint credit prices",
+        ));
+    }
+
+    let obj = js_sys::Object::from(value);
+    let entries = js_sys::Object::entries(&obj);
+    let mut tiers: BTreeMap<TokenAmount, Credits> = BTreeMap::new();
+
+    for entry in entries.iter() {
+        let entry_arr = js_sys::Array::from(&entry);
+        let key = entry_arr.get(0);
+        let val = entry_arr.get(1);
+
+        let key_str = key.as_string().ok_or_else(|| {
+            WasmSdkError::invalid_argument(
+                "'priceTiers' keys must be strings encoding token amounts",
+            )
+        })?;
+
+        let amount: TokenAmount = key_str.parse().map_err(|err| {
+            WasmSdkError::invalid_argument(format!(
+                "Invalid token amount key '{}' in priceTiers: {}",
+                key_str, err
+            ))
+        })?;
+
+        let credits = try_to_u64(&val, &format!("priceTiers['{}']", key_str))?;
+
+        tiers.insert(amount, credits);
+    }
+
+    validate_price_tiers(&tiers)?;
+
+    Ok(Some(tiers))
 }
 
 /// Result of setting the token price.
@@ -2103,11 +2208,36 @@ impl WasmSdk {
         let authority_id: Identifier =
             try_from_options::<IdentifierWasm>(&options, "authorityId")?.into();
 
-        // Deserialize primitive fields last (consumes options)
-        let parsed = deserialize_token_set_price_options(options.into())?;
+        // Extract optional tiered pricing map before consuming options.
+        let raw_options_js: JsValue = options.into();
+        let price_tiers = extract_price_tiers(&raw_options_js)?;
 
-        // Convert price to pricing schedule
-        let pricing_schedule = parsed.price.map(TokenPricingSchedule::SinglePrice);
+        // Reject ambiguous state: caller specified both flat price and tiers.
+        // We detect a present `price` key (including explicit `null` for "disable")
+        // via Reflect to distinguish "key absent" from "price: null".
+        let price_field_present =
+            js_sys::Reflect::get(&raw_options_js, &JsValue::from_str("price"))
+                .map(|v| !v.is_undefined())
+                .unwrap_or(false);
+
+        if price_tiers.is_some() && price_field_present {
+            return Err(WasmSdkError::invalid_argument(
+                "Specify either 'price' (flat or null) or 'priceTiers' (tiered), not both",
+            ));
+        }
+
+        // Deserialize primitive fields last (consumes options)
+        let parsed = deserialize_token_set_price_options(raw_options_js)?;
+
+        // Build the pricing schedule:
+        // - priceTiers present → SetPrices
+        // - price = Some(n)    → SinglePrice(n)
+        // - price = None / absent → no schedule set (disables direct purchases)
+        let pricing_schedule = if let Some(tiers) = price_tiers {
+            Some(TokenPricingSchedule::SetPrices(tiers))
+        } else {
+            parsed.price.map(TokenPricingSchedule::SinglePrice)
+        };
 
         // Fetch and cache the data contract
         let data_contract = self.get_or_fetch_contract(contract_id).await?;
@@ -2571,5 +2701,63 @@ impl WasmSdk {
             result,
             contract_id,
         ))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A single non-zero tier passes validation.
+    #[test]
+    fn validate_price_tiers_accepts_single_tier() {
+        let tiers: BTreeMap<TokenAmount, Credits> = BTreeMap::from([(1u64, 1_000u64)]);
+        validate_price_tiers(&tiers).expect("single non-zero tier should validate");
+    }
+
+    /// Multiple non-zero tiers pass validation.
+    #[test]
+    fn validate_price_tiers_accepts_multiple_tiers() {
+        let tiers: BTreeMap<TokenAmount, Credits> =
+            BTreeMap::from([(1u64, 1_000u64), (100u64, 900u64), (1000u64, 800u64)]);
+        validate_price_tiers(&tiers).expect("multi-tier schedule should validate");
+    }
+
+    /// An empty tier map is rejected — the caller must specify at least one tier.
+    #[test]
+    fn validate_price_tiers_rejects_empty() {
+        let tiers: BTreeMap<TokenAmount, Credits> = BTreeMap::new();
+        let err = validate_price_tiers(&tiers).expect_err("empty tiers should be rejected");
+        assert!(
+            err.message().contains("at least one entry"),
+            "unexpected error message: {}",
+            err.message()
+        );
+    }
+
+    /// A `0` minimum bulk-buy amount is rejected — direct callers should use `price`.
+    #[test]
+    fn validate_price_tiers_rejects_zero_amount_key() {
+        let tiers: BTreeMap<TokenAmount, Credits> = BTreeMap::from([(0u64, 1_000u64)]);
+        let err = validate_price_tiers(&tiers).expect_err("zero amount key should be rejected");
+        assert!(
+            err.message().contains("amount must be > 0"),
+            "unexpected error message: {}",
+            err.message()
+        );
+    }
+
+    /// A `0` per-token price is rejected — callers should use `price: null` to disable.
+    #[test]
+    fn validate_price_tiers_rejects_zero_credits() {
+        let tiers: BTreeMap<TokenAmount, Credits> =
+            BTreeMap::from([(1u64, 1_000u64), (100u64, 0u64)]);
+        let err = validate_price_tiers(&tiers).expect_err("zero credits should be rejected");
+        let msg = err.message();
+        assert!(
+            msg.contains("amount 100") && msg.contains("must be > 0"),
+            "unexpected error message: {}",
+            msg
+        );
     }
 }

--- a/packages/wasm-sdk/src/state_transitions/token.rs
+++ b/packages/wasm-sdk/src/state_transitions/token.rs
@@ -2032,7 +2032,10 @@ fn deserialize_token_set_price_options(
 /// Rejects:
 /// - empty maps (caller must specify at least one tier)
 /// - a `0` minimum bulk-buy amount (use the flat `price` field for that)
-/// - a `0` credits value (use `price: null` to disable direct purchases)
+///
+/// A `0` credits value is permitted — it mirrors the lower/consensus
+/// `SetPrices` schedule, which allows zero-credit tiers for free
+/// direct purchases at that bulk amount.
 ///
 /// Pure function so it can be unit-tested without a JS runtime.
 fn validate_price_tiers(tiers: &BTreeMap<TokenAmount, Credits>) -> Result<(), WasmSdkError> {
@@ -2041,17 +2044,11 @@ fn validate_price_tiers(tiers: &BTreeMap<TokenAmount, Credits>) -> Result<(), Wa
             "'priceTiers' must contain at least one entry",
         ));
     }
-    for (amount, credits) in tiers {
+    for amount in tiers.keys() {
         if *amount == 0 {
             return Err(WasmSdkError::invalid_argument(
                 "'priceTiers' minimum bulk-buy amount must be > 0; use 'price' for a flat single-token price",
             ));
-        }
-        if *credits == 0 {
-            return Err(WasmSdkError::invalid_argument(format!(
-                "'priceTiers' price for amount {} must be > 0; set 'price: null' to disable direct purchases",
-                amount
-            )));
         }
     }
     Ok(())
@@ -2061,7 +2058,7 @@ fn validate_price_tiers(tiers: &BTreeMap<TokenAmount, Credits>) -> Result<(), Wa
 ///
 /// Returns `Ok(None)` when the field is absent, null, or undefined.
 /// Returns `Err` when the field is present but malformed (wrong type,
-/// empty, non-numeric keys, non-bigint/integer values, zero amount/price, etc.).
+/// empty, non-numeric keys, non-bigint/integer values, zero amount key, etc.).
 fn extract_price_tiers(
     options: &JsValue,
 ) -> Result<Option<BTreeMap<TokenAmount, Credits>>, WasmSdkError> {
@@ -2747,17 +2744,12 @@ mod tests {
         );
     }
 
-    /// A `0` per-token price is rejected — callers should use `price: null` to disable.
+    /// A `0` per-token price is accepted — mirrors lower/consensus `SetPrices`,
+    /// which permits zero-credit tiers for free direct purchases.
     #[test]
-    fn validate_price_tiers_rejects_zero_credits() {
+    fn validate_price_tiers_accepts_zero_credits() {
         let tiers: BTreeMap<TokenAmount, Credits> =
             BTreeMap::from([(1u64, 1_000u64), (100u64, 0u64)]);
-        let err = validate_price_tiers(&tiers).expect_err("zero credits should be rejected");
-        let msg = err.message();
-        assert!(
-            msg.contains("amount 100") && msg.contains("must be > 0"),
-            "unexpected error message: {}",
-            msg
-        );
+        validate_price_tiers(&tiers).expect("zero credits tier should validate");
     }
 }

--- a/packages/wasm-sdk/src/state_transitions/token.rs
+++ b/packages/wasm-sdk/src/state_transitions/token.rs
@@ -2054,6 +2054,55 @@ fn validate_price_tiers(tiers: &BTreeMap<TokenAmount, Credits>) -> Result<(), Wa
     Ok(())
 }
 
+/// Build a `priceTiers` map from already-parsed `(originalKey, amount, credits)` entries.
+///
+/// Detects keys that parse to the same `TokenAmount` (e.g. `"1"` and `"01"`) and rejects
+/// them with a message naming both the original and duplicate string keys, instead of
+/// silently overwriting one with the other via `BTreeMap::insert`.
+///
+/// Pure function so it can be unit-tested without a JS runtime.
+fn build_price_tiers(
+    entries: Vec<(String, TokenAmount, Credits)>,
+) -> Result<BTreeMap<TokenAmount, Credits>, WasmSdkError> {
+    let mut tiers: BTreeMap<TokenAmount, Credits> = BTreeMap::new();
+    let mut original_keys: BTreeMap<TokenAmount, String> = BTreeMap::new();
+    for (key_str, amount, credits) in entries {
+        if let Some(prev_key) = original_keys.get(&amount) {
+            return Err(WasmSdkError::invalid_argument(format!(
+                "Duplicate priceTiers tier amount {}: keys '{}' and '{}' both parse to the same token amount",
+                amount, prev_key, key_str
+            )));
+        }
+        original_keys.insert(amount, key_str);
+        tiers.insert(amount, credits);
+    }
+    validate_price_tiers(&tiers)?;
+    Ok(tiers)
+}
+
+/// Decide which pricing mode the caller specified for `tokenSetPrice`.
+///
+/// Exactly one of `price` (flat, including explicit `null` for disable) or
+/// `priceTiers` (tiered) must be provided. Both omitted is rejected so that
+/// a missing field is not silently treated like an explicit `price: null`.
+/// Both present is rejected as ambiguous.
+///
+/// Pure function so it can be unit-tested without a JS runtime.
+fn validate_pricing_mode_selection(
+    price_present: bool,
+    price_tiers_present: bool,
+) -> Result<(), WasmSdkError> {
+    match (price_present, price_tiers_present) {
+        (true, true) => Err(WasmSdkError::invalid_argument(
+            "Specify either 'price' (flat or null) or 'priceTiers' (tiered), not both",
+        )),
+        (false, false) => Err(WasmSdkError::invalid_argument(
+            "Must specify exactly one of 'price' (flat or null to disable) or 'priceTiers' (tiered)",
+        )),
+        _ => Ok(()),
+    }
+}
+
 /// Extract the optional `priceTiers` field from the raw JS options object.
 ///
 /// Returns `Ok(None)` when the field is absent, null, or undefined.
@@ -2077,7 +2126,8 @@ fn extract_price_tiers(
 
     let obj = js_sys::Object::from(value);
     let entries = js_sys::Object::entries(&obj);
-    let mut tiers: BTreeMap<TokenAmount, Credits> = BTreeMap::new();
+    let mut parsed_entries: Vec<(String, TokenAmount, Credits)> =
+        Vec::with_capacity(entries.length() as usize);
 
     for entry in entries.iter() {
         let entry_arr = js_sys::Array::from(&entry);
@@ -2099,12 +2149,10 @@ fn extract_price_tiers(
 
         let credits = try_to_u64(&val, &format!("priceTiers['{}']", key_str))?;
 
-        tiers.insert(amount, credits);
+        parsed_entries.push((key_str, amount, credits));
     }
 
-    validate_price_tiers(&tiers)?;
-
-    Ok(Some(tiers))
+    Ok(Some(build_price_tiers(parsed_entries)?))
 }
 
 /// Result of setting the token price.
@@ -2209,19 +2257,17 @@ impl WasmSdk {
         let raw_options_js: JsValue = options.into();
         let price_tiers = extract_price_tiers(&raw_options_js)?;
 
-        // Reject ambiguous state: caller specified both flat price and tiers.
-        // We detect a present `price` key (including explicit `null` for "disable")
-        // via Reflect to distinguish "key absent" from "price: null".
+        // Determine which pricing mode the caller selected. We must distinguish
+        // "field absent" from "field explicitly null" so that `price: null` can
+        // explicitly disable direct purchases while `{}` is rejected as ambiguous
+        // rather than silently treated like `price: null`.
         let price_field_present =
             js_sys::Reflect::get(&raw_options_js, &JsValue::from_str("price"))
                 .map(|v| !v.is_undefined())
                 .unwrap_or(false);
+        let price_tiers_field_present = price_tiers.is_some();
 
-        if price_tiers.is_some() && price_field_present {
-            return Err(WasmSdkError::invalid_argument(
-                "Specify either 'price' (flat or null) or 'priceTiers' (tiered), not both",
-            ));
-        }
+        validate_pricing_mode_selection(price_field_present, price_tiers_field_present)?;
 
         // Deserialize primitive fields last (consumes options)
         let parsed = deserialize_token_set_price_options(raw_options_js)?;
@@ -2751,5 +2797,106 @@ mod tests {
         let tiers: BTreeMap<TokenAmount, Credits> =
             BTreeMap::from([(1u64, 1_000u64), (100u64, 0u64)]);
         validate_price_tiers(&tiers).expect("zero credits tier should validate");
+    }
+
+    /// Distinct token amount keys build a tier map preserving all entries.
+    #[test]
+    fn build_price_tiers_accepts_distinct_keys() {
+        let entries = vec![
+            ("1".to_string(), 1u64, 1_000u64),
+            ("100".to_string(), 100u64, 800u64),
+        ];
+        let tiers = build_price_tiers(entries).expect("distinct keys should build successfully");
+        assert_eq!(tiers.len(), 2);
+        assert_eq!(tiers.get(&1u64), Some(&1_000u64));
+        assert_eq!(tiers.get(&100u64), Some(&800u64));
+    }
+
+    /// Two string keys that parse to the same `TokenAmount` (e.g. "1" and "01")
+    /// are rejected instead of silently overwriting one entry with the other.
+    #[test]
+    fn build_price_tiers_rejects_duplicate_parsed_keys() {
+        let entries = vec![
+            ("1".to_string(), 1u64, 1_000u64),
+            ("01".to_string(), 1u64, 2_000u64),
+        ];
+        let err = build_price_tiers(entries)
+            .expect_err("duplicate parsed tier amount should be rejected");
+        let msg = err.message();
+        assert!(
+            msg.contains("Duplicate"),
+            "unexpected error message: {}",
+            msg
+        );
+        assert!(
+            msg.contains("'1'"),
+            "error should mention original key: {}",
+            msg
+        );
+        assert!(
+            msg.contains("'01'"),
+            "error should mention duplicate key: {}",
+            msg
+        );
+    }
+
+    /// Even with three keys colliding, the error names the first-seen and the
+    /// next colliding key so the user can locate the offending pair.
+    #[test]
+    fn build_price_tiers_reports_first_collision() {
+        let entries = vec![
+            ("10".to_string(), 10u64, 1u64),
+            ("010".to_string(), 10u64, 2u64),
+            ("0010".to_string(), 10u64, 3u64),
+        ];
+        let err = build_price_tiers(entries).expect_err("collision should be rejected");
+        let msg = err.message();
+        assert!(
+            msg.contains("'10'"),
+            "error should mention first key: {}",
+            msg
+        );
+        assert!(
+            msg.contains("'010'"),
+            "error should mention second key: {}",
+            msg
+        );
+    }
+
+    /// Empty selection (neither `price` nor `priceTiers`) is rejected so that a
+    /// missing field is not silently treated like an explicit `price: null`.
+    #[test]
+    fn validate_pricing_mode_selection_rejects_neither() {
+        let err = validate_pricing_mode_selection(false, false)
+            .expect_err("neither field present should be rejected");
+        assert!(
+            err.message().contains("exactly one"),
+            "unexpected error message: {}",
+            err.message()
+        );
+    }
+
+    /// Specifying both `price` and `priceTiers` is rejected as ambiguous.
+    #[test]
+    fn validate_pricing_mode_selection_rejects_both() {
+        let err = validate_pricing_mode_selection(true, true)
+            .expect_err("both fields present should be rejected");
+        assert!(
+            err.message().contains("not both"),
+            "unexpected error message: {}",
+            err.message()
+        );
+    }
+
+    /// Only `price` present (including `price: null` for disable) is accepted.
+    #[test]
+    fn validate_pricing_mode_selection_accepts_price_only() {
+        validate_pricing_mode_selection(true, false).expect("price-only selection should validate");
+    }
+
+    /// Only `priceTiers` present is accepted.
+    #[test]
+    fn validate_pricing_mode_selection_accepts_tiers_only() {
+        validate_pricing_mode_selection(false, true).expect("tiers-only selection should validate");
     }
 }


### PR DESCRIPTION
# Tiered Token Direct-Purchase Pricing

## Issue being fixed or feature implemented

The protocol supports consensus-enforced minimum direct-purchase amounts through
`TokenPricingSchedule::SetPrices`: the lowest tier key is the minimum purchasable
token amount. Rust SDK, FFI, and lower-level wasm-dpp2 paths can represent tiered
schedules, but the high-level JavaScript path could only call `tokenSetPrice`
with a flat `price: bigint | null`.

That meant JS users of `@dashevo/evo-sdk` / `@dashevo/wasm-sdk` could
UI-enforce "buy at least 100", but could not set the consensus-enforced tier
schedule through the normal SDK API.

## What was done?

- Extended wasm-sdk `TokenSetPriceOptions` with
  `priceTiers?: Record<string, bigint>`.
- Mapped `priceTiers` to `TokenPricingSchedule::SetPrices` while keeping
  `price` mapped to `SinglePrice` and `null` mapped to disabling direct
  purchases.
- Rejected ambiguous calls that pass both `price` and `priceTiers`.
- Validated tier maps before building the transition:
  - at least one tier is required
  - tier amounts must be unsigned integer string keys greater than zero
  - zero-credit tier prices are allowed, matching lower SDK/protocol behavior
- Updated evo-sdk facade tests so `tokens.setPrice()` covers both flat prices
  and tiered schedules forwarded unchanged to wasm-sdk.
- Fixed the evo-sdk Mocha unit-test loader invocation to use Mocha's
  `--node-option loader=ts-node/esm` path with ts-node transpile-only runtime
  execution.

## How Has This Been Tested?

Validation performed locally on macOS arm64:

- `cargo fmt --all -- --check`
- `cargo check -p wasm-sdk --tests`
- `cargo test -p wasm-sdk --lib state_transitions::token::tests::`
- `cargo clippy -p wasm-sdk --lib --tests`
- `yarn workspace @dashevo/wasm-sdk lint`
  - Passed with one existing unrelated warning in
    `packages/wasm-sdk/tests/functional/shielded.spec.ts` about `_e` being
    unused.
- `yarn workspace @dashevo/evo-sdk lint`
- `yarn workspace @dashevo/wasm-sdk build`
  - Built with local Node 20.18.1 and Zig 0.13.0 wrapper for the wasm target.
  - `wasm-opt` was not installed locally, so wasm-pack skipped optimization
    after producing the build.
- `yarn workspace @dashevo/evo-sdk build`
- `YARN_NODE_LINKER=node-modules yarn install --immutable`
  - Used only to create a temporary ignored `node_modules` install for local
    package test execution in this worktree.
- `YARN_NODE_LINKER=node-modules yarn workspace @dashevo/evo-sdk test:unit`
  - Ran through an SSH login session so ChromeHeadless can start on macOS.
  - Mocha: 212 passing.
  - Karma/ChromeHeadless: 212 completed.
- Focused runtime forwarding check against built packages:
  - imported built `@dashevo/wasm-sdk` and `@dashevo/evo-sdk`
  - monkeypatched `wasmSdk.tokenSetPrice`
  - called:

    ```ts
    client.tokens.setPrice({
      priceTiers: { "100": 1000n, "1000": 900n },
      ...options,
    });
    ```

  - asserted evo-sdk forwards the `priceTiers` object unchanged
- Pre-PR `code-review` gate returned `ship` before opening the PR.
- Post-test-run `code-review` gate returned `ship` again after adding the
  evo-sdk test-script fix.

## Breaking Changes

None. Existing `price: bigint | null` callers continue to work. `priceTiers` is
additive, and passing both fields is rejected as invalid input.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have added "!" to the title and described breaking changes in the
  corresponding section if my code contains any
- [x] I have made corresponding changes to the documentation if needed

### For repository code-owners and collaborators only

- [ ] I have assigned this pull request to a milestone


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for tiered direct-purchase pricing via `priceTiers`, alongside existing fixed `price`.
  * Pricing options now support explicit disabling of direct purchases when no price is provided.

* **Bug Fixes**
  * Enforced mutual exclusivity between fixed pricing (`price`) and tiered pricing (`priceTiers`).
  * Added stricter validation for tier contents and detected duplicate tier keys.

* **Tests**
  * Updated unit tests for the new `setPrice` options shape and added coverage for tier forwarding and validation rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->