### PR TITLE
docs(book): fix drifted source links in the count group-by chapters

### DIFF
--- a/book/src/drive/count-index-group-by-examples.md
+++ b/book/src/drive/count-index-group-by-examples.md
@@ -35,7 +35,7 @@ Range queries are different. `AggregateCountOnRange` (chapter 29's Q7) walks the
 
 ## Queries in this Chapter
 
-All proof-size and behaviour numbers below come from the same bench helper (`report_group_by_matrix`) as chapter 29's. The dispatcher's group_by surface validation lives in [`validate_count_query_groupby_against_index`](https://github.com/dashpay/platform/blob/v4.0-dev/packages/rs-drive/src/query/drive_document_count_query/validate.rs); the per-mode path-query builders sit in [`packages/rs-drive/src/query/drive_document_count_query/path_query.rs`](https://github.com/dashpay/platform/blob/v4.0-dev/packages/rs-drive/src/query/drive_document_count_query/path_query.rs)'s `group_by_*` family.
+All proof-size and behaviour numbers below come from the same bench helper (`report_group_by_matrix`) as chapter 29's. The dispatcher's group_by surface validation lives in [`DriveDocumentCountQuery::detect_mode`](https://github.com/dashpay/platform/blob/v4.0-dev/packages/rs-drive/src/query/drive_document_count_query/mode_detection.rs); the per-mode path-query builders sit in [`packages/rs-drive/src/query/drive_document_count_query/path_query.rs`](https://github.com/dashpay/platform/blob/v4.0-dev/packages/rs-drive/src/query/drive_document_count_query/path_query.rs) (the group-by modes route to `distinct_count_path_query` and `carrier_aggregate_count_path_query`).
 
 | # | Query | Filter + group_by | Complexity | Avg time | Proof size | Verified shape | Notes |
 |---|-------|-------------------|------------|----------|------------|----------------|-------|
@@ -1721,7 +1721,7 @@ This chapter now mirrors chapter 29's per-query structure: every section above c
 
 Two pieces of infrastructure made this possible:
 
-- `query_g1_*` … `query_g6_*` criterion `bench_function` calls in [`document_count_worst_case.rs`](https://github.com/dashpay/platform/blob/v4.0-dev/packages/rs-drive/benches/document_count_worst_case.rs) — produce the **Avg time** column in [Queries in this Chapter](#queries-in-this-chapter).
+- `query_g1_*` … `query_g8_*` criterion `bench_function` calls (the series skips `g6`) in [`document_count_worst_case.rs`](https://github.com/dashpay/platform/blob/v4.0-dev/packages/rs-drive/benches/document_count_worst_case.rs) — produce the **Avg time** column in [Queries in this Chapter](#queries-in-this-chapter).
 - `display_group_by_proofs` (a sibling of `display_proofs` in the same bench file) — emits each `group_by` shape's verbatim merk-proof structure via bincode decode + `GroveDBProof::Display`. Tagged with `[gproof]` prefix in stderr so reviewers can grep deterministically.
 
 Open follow-ups:
@@ -1738,4 +1738,4 @@ For background on the building blocks every query in this chapter uses:
 - [Count Index Examples § How To Read The Proofs](./count-index-examples.md#how-to-read-the-proofs) — the four-section per-query template plus the `LayerProof` / `Merk` / `Push` / `Parent` / `Child` op grammar.
 - [Count Index Examples § Worked Example: How `node_hash_with_count` Rebuilds the Merk Root](./count-index-examples.md#worked-example-how-node_hash_with_count-rebuilds-the-merk-root) — exact Blake3 formulas underpinning every count proof in either chapter.
 
-The path-query builder (`packages/rs-drive/src/query/drive_document_count_query/path_query.rs`) and verifier mirror (`packages/rs-drive/src/verify/document_count/`) live in the same modules for both chapters' queries — the only difference is which `point_lookup_*` / `aggregate_*` / `group_by_*` function the dispatcher calls based on the `CountMode` carried in the request.
+The path-query builder (`packages/rs-drive/src/query/drive_document_count_query/path_query.rs`) and verifier mirror (`packages/rs-drive/src/verify/document_count/`) live in the same modules for both chapters' queries — the only difference is which `point_lookup_*` / `aggregate_*` / `distinct_count_*` / `carrier_aggregate_*` function the dispatcher calls based on the `CountMode` carried in the request.

--- a/book/src/drive/document-count-trees.md
+++ b/book/src/drive/document-count-trees.md
@@ -124,7 +124,7 @@ A single unified gRPC endpoint exposes the feature: `GetDocumentsCount`. The res
 
 When `prove=false`, drive-abci calls into `DriveDocumentCountQuery` (in [`packages/rs-drive/src/query/drive_document_count_query/mod.rs`](https://github.com/dashpay/platform/blob/v4.0-dev/packages/rs-drive/src/query/drive_document_count_query/mod.rs)). The handler picks a path based on the where clauses:
 
-**Unfiltered total (no where clauses) on a `documentsCountable: true` document type** ([`Drive::read_primary_key_count_tree`](https://github.com/dashpay/platform/blob/v4.0-dev/packages/rs-drive/src/query/drive_document_count_query/drive_dispatcher.rs)):
+**Unfiltered total (no where clauses) on a `documentsCountable: true` document type** ([`read_primary_key_count_tree`](https://github.com/dashpay/platform/blob/v4.0-dev/packages/rs-drive/src/query/drive_document_count_query/executors/total.rs)):
 
 The doctype's primary-key tree at `[contract_doc, contract_id, 1, doctype, 0]` is itself a `CountTree`. One grovedb read gives `count_value` — the total document count. O(1).
 


### PR DESCRIPTION
## Issue being fixed or feature implemented

Follow-up to #3972 (the merged `v3.1-dev → v4.0-dev` branch retarget). That PR faithfully swapped the branch name in every `book/` source link, but reviewers (`thepastaclaw`, `Claudius-Maginificent`) noticed a few of those links had **drifted before the rename** — they point at code that has since moved or been renamed (one link 404s). Keeping #3972 a clean mechanical rename, the content fixes land here.

## What was done?

All targets verified against the current `v4.0-dev` tree:

- **`count-index-group-by-examples.md`**
  - group_by surface-validation link → `drive_document_count_query/validate.rs` **no longer exists**; validation now lives in `DriveDocumentCountQuery::detect_mode` (`mode_detection.rs`).
  - There is no `group_by_*` builder family — the group-by modes route to `distinct_count_path_query` / `carrier_aggregate_count_path_query`. Corrected on the "Queries in this Chapter" line **and** in the closing prose.
  - Bench series is `query_g1_* … query_g8_*` (it skips `g6`), not `… query_g6_*`.
- **`document-count-trees.md`**
  - `read_primary_key_count_tree` moved from `drive_dispatcher.rs` to `executors/total.rs`; also dropped the inaccurate `Drive::` qualifier.

Out of scope (per the reviewer discussion on #3972): converting branch links to commit-ID permalinks — that's a broader docs-link policy question, not this focused fix.

## How Has This Been Tested?

- Verified each replacement symbol/path exists at the branch tip: `detect_mode` (`mode_detection.rs:85`), `distinct_count_path_query` / `carrier_aggregate_count_path_query` (`path_query.rs`), `read_primary_key_count_tree` (`executors/total.rs:89`), and that the bench defines `query_g1..g8` with no `g6`.
- Docs-only change; no code paths affected, no automated tests applicable.

## Breaking Changes

None.

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [x] I have made corresponding changes to the documentation if needed

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified query-routing notes to better reflect the current count and group-by flow.
  * Updated benchmark references in the examples guide to match the actual set of contributing benchmark cases.
  * Refined wording in the document-count guide to point directly to the relevant count-tree lookup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->