### PR TITLE
fix(wasm-sdk): protocol upgrade state misreported vote count as activation height

### DIFF
--- a/packages/wasm-sdk/src/queries/protocol.rs
+++ b/packages/wasm-sdk/src/queries/protocol.rs
@@ -72,6 +72,52 @@ fn next_version_upgrade(
         })
 }
 
+#[cfg(test)]
+mod tests {
+    use super::next_version_upgrade;
+    use drive_proof_verifier::types::ProtocolVersionUpgrades;
+
+    #[test]
+    fn empty_upgrades_yield_no_candidate() {
+        let upgrades = ProtocolVersionUpgrades::new();
+
+        assert_eq!(next_version_upgrade(&upgrades, 12), (None, None));
+    }
+
+    #[test]
+    fn none_vote_counts_are_skipped() {
+        let upgrades = ProtocolVersionUpgrades::from_iter([(13, None), (14, None)]);
+
+        assert_eq!(next_version_upgrade(&upgrades, 12), (None, None));
+    }
+
+    #[test]
+    fn versions_at_or_below_current_are_excluded() {
+        let upgrades = ProtocolVersionUpgrades::from_iter([(11, Some(50)), (12, Some(80))]);
+
+        assert_eq!(next_version_upgrade(&upgrades, 12), (None, None));
+    }
+
+    #[test]
+    fn picks_future_version_with_most_votes() {
+        let upgrades = ProtocolVersionUpgrades::from_iter([
+            (11, Some(200)),
+            (13, Some(7)),
+            (14, Some(132)),
+            (15, Some(3)),
+        ]);
+
+        assert_eq!(next_version_upgrade(&upgrades, 12), (Some(14), Some(132)));
+    }
+
+    #[test]
+    fn equal_votes_resolve_to_highest_version() {
+        let upgrades = ProtocolVersionUpgrades::from_iter([(13, Some(9)), (14, Some(9))]);
+
+        assert_eq!(next_version_upgrade(&upgrades, 12), (Some(14), Some(9)));
+    }
+}
+
 #[wasm_bindgen(js_name = "ProtocolVersionUpgradeVoteStatus")]
 #[derive(Clone)]
 pub struct ProtocolVersionUpgradeVoteStatusWasm {

--- a/packages/wasm-sdk/src/queries/protocol.rs
+++ b/packages/wasm-sdk/src/queries/protocol.rs
@@ -56,7 +56,8 @@ impl ProtocolVersionUpgradeStateWasm {
 }
 
 /// Pick the candidate upgrade version from the vote counts: among versions
-/// newer than `current_version`, the one with the most votes.
+/// newer than `current_version`, the one with the most votes; equal vote
+/// counts resolve to the highest version.
 fn next_version_upgrade(
     upgrades: &drive_proof_verifier::types::ProtocolVersionUpgrades,
     current_version: u32,
@@ -65,7 +66,7 @@ fn next_version_upgrade(
         .iter()
         .filter_map(|(version, votes)| votes.map(|votes| (*version, votes)))
         .filter(|(version, _)| *version > current_version)
-        .max_by_key(|(_, votes)| *votes)
+        .max_by_key(|&(version, votes)| (votes, version))
         .map_or((None, None), |(version, votes)| {
             (Some(version), Some(votes))
         })

--- a/packages/wasm-sdk/src/queries/protocol.rs
+++ b/packages/wasm-sdk/src/queries/protocol.rs
@@ -16,56 +16,59 @@ use wasm_dpp2::{ProTxHashLikeNullableJs, ProTxHashWasm};
 pub struct ProtocolVersionUpgradeStateWasm {
     current_protocol_version: u32,
     next_protocol_version: Option<u32>,
-    activation_height: Option<u64>,
-    vote_count: Option<u32>,
-    #[serde(rename = "thresholdReached")]
-    is_threshold_reached: bool,
+    vote_count: Option<u64>,
 }
 
 impl ProtocolVersionUpgradeStateWasm {
     fn new(
         current_protocol_version: u32,
         next_protocol_version: Option<u32>,
-        activation_height: Option<u64>,
-        vote_count: Option<u32>,
-        is_threshold_reached: bool,
+        vote_count: Option<u64>,
     ) -> Self {
         Self {
             current_protocol_version,
             next_protocol_version,
-            activation_height,
             vote_count,
-            is_threshold_reached,
         }
     }
 }
 
 #[wasm_bindgen(js_class = ProtocolVersionUpgradeState)]
 impl ProtocolVersionUpgradeStateWasm {
+    /// Protocol version the chain was running when this response was produced.
     #[wasm_bindgen(getter = "currentProtocolVersion")]
     pub fn current_protocol_version(&self) -> u32 {
         self.current_protocol_version
     }
 
+    /// Candidate upgrade version: the version above the current one with the
+    /// most evonode votes, if any votes exist.
     #[wasm_bindgen(getter = "nextProtocolVersion")]
     pub fn next_protocol_version(&self) -> Option<u32> {
         self.next_protocol_version
     }
 
-    #[wasm_bindgen(getter = "activationHeight")]
-    pub fn activation_height(&self) -> Option<u64> {
-        self.activation_height
-    }
-
+    /// Number of evonode votes cast for `nextProtocolVersion`.
     #[wasm_bindgen(getter = "voteCount")]
-    pub fn vote_count(&self) -> Option<u32> {
+    pub fn vote_count(&self) -> Option<u64> {
         self.vote_count
     }
+}
 
-    #[wasm_bindgen(getter = "isThresholdReached")]
-    pub fn is_threshold_reached(&self) -> bool {
-        self.is_threshold_reached
-    }
+/// Pick the candidate upgrade version from the vote counts: among versions
+/// newer than `current_version`, the one with the most votes.
+fn next_version_upgrade(
+    upgrades: &drive_proof_verifier::types::ProtocolVersionUpgrades,
+    current_version: u32,
+) -> (Option<u32>, Option<u64>) {
+    upgrades
+        .iter()
+        .filter_map(|(version, votes)| votes.map(|votes| (*version, votes)))
+        .filter(|(version, _)| *version > current_version)
+        .max_by_key(|(_, votes)| *votes)
+        .map_or((None, None), |(version, votes)| {
+            (Some(version), Some(votes))
+        })
 }
 
 #[wasm_bindgen(js_name = "ProtocolVersionUpgradeVoteStatus")]
@@ -108,36 +111,18 @@ impl WasmSdk {
         use dash_sdk::platform::FetchMany;
         use drive_proof_verifier::types::ProtocolVersionVoteCount;
 
-        let upgrade_result: drive_proof_verifier::types::ProtocolVersionUpgrades =
-            ProtocolVersionVoteCount::fetch_many(self.as_ref(), ()).await?;
+        let (upgrade_result, metadata): (drive_proof_verifier::types::ProtocolVersionUpgrades, _) =
+            ProtocolVersionVoteCount::fetch_many_with_metadata(self.as_ref(), (), None).await?;
 
-        // Get the current protocol version from the SDK
-        let current_version = self.version();
+        // The chain's protocol version at the time of the response
+        let current_version = metadata.protocol_version;
 
-        // Find the next version with votes
-        let mut next_version = None;
-        let mut activation_height = None;
-        let mut vote_count = None;
-        let mut threshold_reached = false;
-
-        // The result is an IndexMap<u32, Option<u64>> where u32 is version and Option<u64> is activation height
-        for (version, height_opt) in upgrade_result.iter() {
-            if *version > current_version {
-                next_version = Some(*version);
-                activation_height = *height_opt;
-                // TODO: Get actual vote count and threshold from platform
-                vote_count = None;
-                threshold_reached = height_opt.is_some();
-                break;
-            }
-        }
+        let (next_version, vote_count) = next_version_upgrade(&upgrade_result, current_version);
 
         Ok(ProtocolVersionUpgradeStateWasm::new(
             current_version,
             next_version,
-            activation_height,
             vote_count,
-            threshold_reached,
         ))
     }
 
@@ -194,32 +179,12 @@ impl WasmSdk {
         ) = ProtocolVersionVoteCount::fetch_many_with_metadata_and_proof(self.as_ref(), (), None)
             .await?;
 
-        // Get the current protocol version from the SDK
-        let current_version = self.version();
+        // The chain's protocol version at the time of the response
+        let current_version = metadata.protocol_version;
 
-        // Find the next version with votes
-        let mut next_version = None;
-        let mut activation_height = None;
-        let mut vote_count = None;
-        let mut threshold_reached = false;
+        let (next_version, vote_count) = next_version_upgrade(&upgrade_result, current_version);
 
-        for (version, height_opt) in upgrade_result.iter() {
-            if *version > current_version {
-                next_version = Some(*version);
-                activation_height = *height_opt;
-                vote_count = None;
-                threshold_reached = height_opt.is_some();
-                break;
-            }
-        }
-
-        let state = ProtocolVersionUpgradeStateWasm::new(
-            current_version,
-            next_version,
-            activation_height,
-            vote_count,
-            threshold_reached,
-        );
+        let state = ProtocolVersionUpgradeStateWasm::new(current_version, next_version, vote_count);
 
         Ok(ProofMetadataResponseWasm::from_sdk_parts(
             state, metadata, proof,

--- a/packages/wasm-sdk/tests/unit/conversion-simple-types.spec.ts
+++ b/packages/wasm-sdk/tests/unit/conversion-simple-types.spec.ts
@@ -52,17 +52,13 @@ describe('Simple Type Conversions', () => {
     const jsonFixture = {
       currentProtocolVersion: 7,
       nextProtocolVersion: 8,
-      activationHeight: 50000,
       voteCount: 100,
-      thresholdReached: false,
     };
 
     const objectFixture = {
       currentProtocolVersion: 7,
       nextProtocolVersion: 8,
-      activationHeight: 50000n,
-      voteCount: 100,
-      thresholdReached: false,
+      voteCount: 100n,
     };
 
     describe('toJSON()', () => {
@@ -84,8 +80,7 @@ describe('Simple Type Conversions', () => {
         const result = sdk.ProtocolVersionUpgradeState.fromJSON(jsonFixture);
         expect(result.currentProtocolVersion).to.equal(7);
         expect(result.nextProtocolVersion).to.equal(8);
-        expect(result.voteCount).to.equal(100);
-        expect(result.isThresholdReached).to.equal(false);
+        expect(result.voteCount).to.equal(100n);
       });
     });
 
@@ -94,17 +89,13 @@ describe('Simple Type Conversions', () => {
         const fixture = {
           currentProtocolVersion: 7,
           nextProtocolVersion: null,
-          activationHeight: null,
           voteCount: null,
-          thresholdReached: true,
         };
 
         const result = sdk.ProtocolVersionUpgradeState.fromJSON(fixture);
         expect(result.currentProtocolVersion).to.equal(7);
         expect(result.nextProtocolVersion).to.be.undefined();
-        expect(result.activationHeight).to.be.undefined();
         expect(result.voteCount).to.be.undefined();
-        expect(result.isThresholdReached).to.equal(true);
       });
     });
   });


### PR DESCRIPTION
## Issue being fixed or feature implemented

`getProtocolVersionUpgradeState` (and its `WithProofInfo` variant) misinterpreted the result of `ProtocolVersionVoteCount::fetch_many`. The returned `IndexMap<u32, u64>` maps protocol version → **vote count** (`pub type ProtocolVersionVoteCount = u64`), but the binding assigned the count to `activationHeight`, left `voteCount` as a `None` TODO, and set `isThresholdReached` whenever any vote existed. Verified live on mainnet: `activationHeight` returned 132 — exactly the number of PV12 votes — with `thresholdReached: true` from a single vote onward.

`currentProtocolVersion` was also taken from the SDK's own configured version (`self.version()`), which can be pinned or stale, rather than from chain state.

## What was done?

- Populate `voteCount` (now `Option<u64>`) from the fetched map.
- Remove `activationHeight` and `isThresholdReached` from `ProtocolVersionUpgradeState`: the activation height is not present in this response, and the vote threshold cannot be derived without the active evonode count, for which the WASM SDK has no proven query. Reporting nothing is better than reporting wrong data.
- Take `currentProtocolVersion` from the response metadata's `protocol_version` (chain state at response time); the plain variant switched to `fetch_many_with_metadata`, which costs no extra network round trip.
- Pick `nextProtocolVersion` as the future version with the **most** votes (shared helper for both variants) instead of the first map entry.
- Update unit-test fixtures for the new shape.

Not affected: `rs-sdk-ffi`'s equivalent binding already interprets the map correctly as vote counts, and the `js-evo-sdk` protocol facade is a pass-through whose types come from the generated `.d.ts`.

## How Has This Been Tested?

- `cargo check`/`cargo clippy -p wasm-sdk --target wasm32-unknown-unknown` clean.
- Full wasm-sdk unit suite (mocha + karma, 397 tests) passes against the rebuilt bundle.

## Breaking Changes

None consensus-wise. SDK API surface: `ProtocolVersionUpgradeState.activationHeight` and `.isThresholdReached` are removed, and `voteCount` changes from always-`null` to a populated `bigint` — pre-release v4.0 API cleanup. Consumers reading the removed fields now get `undefined` instead of a wrong number.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [ ] I have made corresponding changes to the documentation if needed

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated protocol upgrade state responses to return a simpler set of fields, removing unsupported activation-status details.
  * Improved vote count handling so large values are preserved accurately.
  * Refined upgrade-state selection to better identify the next available protocol version and its vote count.
* **Tests**
  * Adjusted unit coverage to match the updated response shape and optional-value behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->