### PR TITLE
fix(platform-wallet): poll platform-address transfer FFI on the big-stack worker

### DIFF
--- a/packages/rs-platform-wallet-ffi/src/platform_addresses/transfer.rs
+++ b/packages/rs-platform-wallet-ffi/src/platform_addresses/transfer.rs
@@ -7,7 +7,8 @@ use crate::platform_address_types::*;
 use crate::{unwrap_option_or_return, unwrap_result_or_return};
 use rs_sdk_ffi::{SignerHandle, VTableSigner};
 
-use super::{parse_input_selection, runtime};
+use super::parse_input_selection;
+use crate::runtime::block_on_worker;
 
 /// Transfer credits between platform addresses.
 ///
@@ -50,21 +51,31 @@ pub unsafe extern "C" fn platform_address_wallet_transfer(
 
     let fee = parse_fee_strategy(fee_strategy, fee_strategy_count);
 
-    // SAFETY: caller guarantees `signer_address_handle` is a valid,
-    // non-destroyed handle that outlives this call.
-    let address_signer: &VTableSigner = &*(signer_address_handle as *const VTableSigner);
-
-    let option = PLATFORM_ADDRESS_WALLET_STORAGE.with_item(handle, |wallet| {
-        runtime().block_on(wallet.transfer(
-            account_index,
-            input_selection,
-            output_map,
-            fee,
-            None, // platform_version = latest
-            address_signer,
-        ))
+    // Clone the wallet out of handle storage so the read lock is released
+    // before the long-running transfer, then poll on a worker thread
+    // (8 MB stack): the transfer future verifies the execution proof, and
+    // GroveDB proof verification recurses past the ~512 KB stacks of iOS
+    // dispatch / Swift-concurrency threads (see runtime.rs) — polling it
+    // on the calling thread crashes with EXC_BAD_ACCESS after the funds
+    // already moved on-chain. Round-trip the signer pointer through
+    // `usize` so the future's capture is `Send + 'static`; the caller
+    // guarantees the handle outlives this synchronously-awaited call.
+    let option = PLATFORM_ADDRESS_WALLET_STORAGE.with_item(handle, |wallet| wallet.clone());
+    let wallet = unwrap_option_or_return!(option);
+    let signer_addr = signer_address_handle as usize;
+    let result = block_on_worker(async move {
+        let address_signer: &VTableSigner = unsafe { &*(signer_addr as *const VTableSigner) };
+        wallet
+            .transfer(
+                account_index,
+                input_selection,
+                output_map,
+                fee,
+                None, // platform_version -> wallet SDK version
+                address_signer,
+            )
+            .await
     });
-    let result = unwrap_option_or_return!(option);
     let changeset = unwrap_result_or_return!(result);
     *out_changeset = PlatformAddressChangeSetFFI::from(&changeset);
     PlatformWalletFFIResult::ok()


### PR DESCRIPTION
## Issue being fixed or feature implemented

`platform_address_wallet_transfer` polls its proof-verifying future with `runtime().block_on` on the caller's thread. The transfer future verifies the execution proof, and GroveDB proof verification recurses past the ~512 KB stacks of iOS dispatch / Swift-concurrency threads — the exact `EXC_BAD_ACCESS` class `runtime.rs` documents — crashing **after** the funds moved on-chain but **before** the changeset reached the caller. The sibling withdraw entry points get the same fix in #3923; this covers the last platform-address spend path.

## What was done?

Mirror the established pattern (`fund_from_asset_lock`, `identity_top_up`, the #3923 withdraw fix): clone the wallet out of handle storage (releasing the storage read lock before network work), round-trip the signer pointer through `usize` so the future is `Send + 'static`, and poll via `block_on_worker` on the 8 MB-stack worker.

## How Has This Been Tested?

`cargo check -p platform-wallet-ffi` and `cargo fmt --all -- --check` clean. No signature changes — no header regen or Swift-side changes needed. The identical pattern is exercised by the sibling flows' existing coverage.

## Breaking Changes

None.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [x] I have made corresponding changes to the documentation if needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)