### PR TITLE
chore: sync v4.1-dev with v4.0-dev

### DIFF
--- a/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/shielded_withdrawal/tests.rs
+++ b/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/shielded_withdrawal/tests.rs
@@ -511,6 +511,234 @@ mod tests {
             );
         }
 
+        /// Gold-standard reproduction of TestFlight report B ("shielded→Core
+        /// withdrawal never lands"). Identical to
+        /// `test_valid_shielded_withdrawal_proof_succeeds` — a **real** Orchard
+        /// proof, correct value balance, sufficient pool balance — EXCEPT the
+        /// anchor is **not** recorded in state (`insert_anchor_into_state` is
+        /// omitted). A legitimate spend is then refused with `InvalidAnchorError`
+        /// purely because its anchor isn't in the recorded set.
+        ///
+        /// This is exactly the wallet's failure mode: it builds the proof
+        /// against its depth-0 tree root, but the index-chunk sync leaves that
+        /// root mid-block, so Platform (which records one anchor per block) never
+        /// recorded it. See `platform-wallet`'s
+        /// `depth0_spend_anchor_mid_block_is_not_a_recorded_block_boundary_anchor`,
+        /// which proves the wallet produces such a non-recorded anchor.
+        #[test]
+        fn test_valid_proof_with_unrecorded_anchor_returns_invalid_anchor_error() {
+            let platform_version = PlatformVersion::latest();
+            let platform = setup_platform();
+            insert_dummy_encrypted_notes(&platform, 250);
+            let mut rng = StdRng::seed_from_u64(0);
+            let pk = get_proving_key();
+
+            // --- Create keys ---
+            let sk = SpendingKey::from_bytes([0u8; 32]).unwrap();
+            let fvk = FullViewingKey::from(&sk);
+            let recipient = fvk.address_at(0u32, Scope::External);
+            let ask = SpendAuthorizingKey::from(&sk);
+
+            // --- Create a spendable note with value 500M ---
+            let rho_bytes: [u8; 32] = {
+                let mut b = [0u8; 32];
+                b[0] = 1;
+                b
+            };
+            let rho = Rho::from_bytes(&rho_bytes).unwrap();
+            let rseed = RandomSeed::from_bytes([42u8; 32], &rho).unwrap();
+            let note =
+                Note::from_parts(recipient, NoteValue::from_raw(500_000_000), rho, rseed).unwrap();
+
+            // --- Build commitment tree and get anchor + merkle path ---
+            let cmx = ExtractedNoteCommitment::from(note.commitment());
+            let mut tree = ClientMemoryCommitmentTree::new(100);
+            tree.append(cmx.to_bytes(), Retention::Marked).unwrap();
+            tree.checkpoint(0u32).unwrap();
+            let anchor = tree.anchor().unwrap();
+            let merkle_path = tree.witness(Position::from(0u64), 0).unwrap().unwrap();
+
+            // --- Build bundle: spend 500M -> output 5K ---
+            let mut builder = Builder::<DashMemo>::new(BundleType::DEFAULT, anchor);
+            builder.add_spend(fvk.clone(), note, merkle_path).unwrap();
+            builder
+                .add_output(None, recipient, NoteValue::from_raw(5_000), [0u8; 36])
+                .unwrap();
+            let (unauthorized, _) = builder.build::<i64>(&mut rng).unwrap().unwrap();
+
+            let output_script = create_output_script();
+            let unshielding_amount = 499_995_000u64;
+            let extra_sighash_data = dpp::shielded::shielded_withdrawal_extra_sighash_data_v0(
+                output_script.as_bytes(),
+                unshielding_amount,
+                1,
+                Pooling::Never,
+            );
+            let bundle_commitment: [u8; 32] = unauthorized.commitment().into();
+            let sighash = compute_platform_sighash(&bundle_commitment, &extra_sighash_data);
+            let proven = unauthorized.create_proof(pk, &mut rng).unwrap();
+            let bundle = proven.apply_signatures(rng, sighash, &[ask]).unwrap();
+
+            let (actions, value_balance, anchor_bytes, proof_bytes, binding_sig) =
+                serialize_authorized_bundle_i64(&bundle);
+            assert_eq!(value_balance, 499_995_000);
+
+            // Pool balance passes; the anchor is DELIBERATELY not recorded
+            // (no `insert_anchor_into_state`) — the crux of the reproduction.
+            set_pool_total_balance(&platform, 500_000_000);
+
+            let transition = create_shielded_withdrawal_transition(
+                actions,
+                value_balance as u64,
+                anchor_bytes,
+                proof_bytes,
+                binding_sig,
+                1,
+                Pooling::Never,
+                output_script,
+            );
+
+            let processing_result = process_transition(&platform, transition, platform_version);
+
+            // Real proof passes; anchor validation then rejects the unrecorded
+            // anchor. This is why the withdrawal never lands.
+            assert_matches!(
+                processing_result.execution_results().as_slice(),
+                [StateTransitionExecutionResult::UnpaidConsensusError(
+                    ConsensusError::StateError(StateError::InvalidAnchorError(_))
+                )]
+            );
+        }
+
+        /// Keystone acceptance test for the anchor-selection fix: a **real**
+        /// Orchard proof built against an OLDER recorded anchor — with the
+        /// commitment tree (and the recorded set) advanced past it — must
+        /// validate successfully. This is exactly the spend shape
+        /// `platform-wallet`'s `select_recorded_spends` produces after the
+        /// fix: witnesses taken at a deeper checkpoint whose root Platform
+        /// recorded, while newer commitments and a newer boundary anchor
+        /// already exist. `test_valid_shielded_withdrawal_proof_succeeds`
+        /// covers only the fresh-anchor (depth-0-recorded) case, and
+        /// `test_valid_proof_with_unrecorded_anchor_returns_invalid_anchor_error`
+        /// only the rejection side; this pins the acceptance side the whole
+        /// fix rests on.
+        #[test]
+        fn test_valid_proof_with_older_recorded_anchor_succeeds() {
+            let platform_version = PlatformVersion::latest();
+            let platform = setup_platform();
+            insert_dummy_encrypted_notes(&platform, 250);
+            let mut rng = StdRng::seed_from_u64(0);
+            let pk = get_proving_key();
+
+            let sk = SpendingKey::from_bytes([0u8; 32]).unwrap();
+            let fvk = FullViewingKey::from(&sk);
+            let recipient = fvk.address_at(0u32, Scope::External);
+            let ask = SpendAuthorizingKey::from(&sk);
+
+            let rho_bytes: [u8; 32] = {
+                let mut b = [0u8; 32];
+                b[0] = 1;
+                b
+            };
+            let rho = Rho::from_bytes(&rho_bytes).unwrap();
+            let rseed = RandomSeed::from_bytes([42u8; 32], &rho).unwrap();
+            let note =
+                Note::from_parts(recipient, NoteValue::from_raw(500_000_000), rho, rseed).unwrap();
+
+            // The spent note lands in "block 1", whose boundary root is
+            // recorded (anchor_old). Later commitments then arrive and a
+            // newer boundary is recorded (anchor_new). The spend is built at
+            // checkpoint depth 1 — the wallet fix's exact output when its
+            // depth-0 root is unrecorded.
+            let cmx = ExtractedNoteCommitment::from(note.commitment());
+            let mut tree = ClientMemoryCommitmentTree::new(100);
+            tree.append(cmx.to_bytes(), Retention::Marked).unwrap();
+            tree.checkpoint(0u32).unwrap(); // block-1 boundary
+
+            for later in 2u8..=4 {
+                let mut b = [0u8; 32];
+                b[0] = later;
+                let rho_later = Rho::from_bytes(&b).unwrap();
+                let rseed_later = RandomSeed::from_bytes([42u8; 32], &rho_later).unwrap();
+                let note_later = Note::from_parts(
+                    recipient,
+                    NoteValue::from_raw(1_000),
+                    rho_later,
+                    rseed_later,
+                )
+                .unwrap();
+                let cmx_later = ExtractedNoteCommitment::from(note_later.commitment());
+                tree.append(cmx_later.to_bytes(), Retention::Ephemeral)
+                    .unwrap();
+            }
+            tree.checkpoint(1u32).unwrap(); // block-2 boundary
+
+            let anchor_new = tree.anchor().unwrap();
+            // Witness at checkpoint depth 1 → path rooted at the OLDER
+            // (block-1) recorded root, not the tip.
+            let merkle_path = tree.witness(Position::from(0u64), 1).unwrap().unwrap();
+            let anchor_old = merkle_path.root(cmx);
+            assert_ne!(
+                anchor_old.to_bytes(),
+                anchor_new.to_bytes(),
+                "tree must have advanced past the spend's anchor for this test to be meaningful"
+            );
+
+            // --- Build bundle against the older anchor ---
+            let mut builder = Builder::<DashMemo>::new(BundleType::DEFAULT, anchor_old);
+            builder.add_spend(fvk.clone(), note, merkle_path).unwrap();
+            builder
+                .add_output(None, recipient, NoteValue::from_raw(5_000), [0u8; 36])
+                .unwrap();
+            let (unauthorized, _) = builder.build::<i64>(&mut rng).unwrap().unwrap();
+
+            let output_script = create_output_script();
+            let unshielding_amount = 499_995_000u64;
+            let extra_sighash_data = dpp::shielded::shielded_withdrawal_extra_sighash_data_v0(
+                output_script.as_bytes(),
+                unshielding_amount,
+                1,
+                Pooling::Never,
+            );
+            let bundle_commitment: [u8; 32] = unauthorized.commitment().into();
+            let sighash = compute_platform_sighash(&bundle_commitment, &extra_sighash_data);
+            let proven = unauthorized.create_proof(pk, &mut rng).unwrap();
+            let bundle = proven.apply_signatures(rng, sighash, &[ask]).unwrap();
+
+            let (actions, value_balance, anchor_bytes, proof_bytes, binding_sig) =
+                serialize_authorized_bundle_i64(&bundle);
+            assert_eq!(value_balance, 499_995_000);
+            assert_eq!(
+                anchor_bytes,
+                anchor_old.to_bytes(),
+                "the bundle must carry the older anchor"
+            );
+
+            // The recorded set holds BOTH boundaries — like drive after two
+            // block-ends — and the spend references the older one.
+            insert_anchor_into_state(&platform, &anchor_bytes);
+            insert_anchor_into_state(&platform, &anchor_new.to_bytes());
+            set_pool_total_balance(&platform, 500_000_000);
+
+            let transition = create_shielded_withdrawal_transition(
+                actions,
+                value_balance as u64,
+                anchor_bytes,
+                proof_bytes,
+                binding_sig,
+                1,
+                Pooling::Never,
+                output_script,
+            );
+
+            let processing_result = process_transition(&platform, transition, platform_version);
+
+            assert_matches!(
+                processing_result.execution_results().as_slice(),
+                [StateTransitionExecutionResult::SuccessfulExecution { .. }]
+            );
+        }
+
         #[test]
         fn test_wrong_encrypted_note_size_returns_error() {
             let platform_version = PlatformVersion::latest();

--- a/packages/rs-platform-wallet-ffi/src/error.rs
+++ b/packages/rs-platform-wallet-ffi/src/error.rs
@@ -124,6 +124,16 @@ pub enum PlatformWalletFFIResultCode {
     /// must NOT auto-retry — a retry would select different unreserved notes
     /// and could double-send if the original spend landed.
     ErrorShieldedSpendUnconfirmed = 18,
+    /// Maps `PlatformWalletError::ShieldedNoRecordedAnchor`. The wallet could
+    /// not build the spend against any Platform-recorded anchor yet: its local
+    /// commitment tree is mid-block (an index-chunk sync routinely stops
+    /// between block boundaries) while Platform records an anchor only at each
+    /// block boundary. The transition was NOT broadcast and any note
+    /// reservations were released, so this is RETRYABLE — the host should wait
+    /// for the next shielded sync (which advances the tree onto a recorded
+    /// boundary) and try again. Distinct from `ErrorShieldedSpendUnconfirmed`,
+    /// where a spend WAS broadcast and must NOT be retried.
+    ErrorShieldedNoRecordedAnchor = 19,
 
     NotFound = 98, // Used exclusively for all the Option that are retuned as errors
     ErrorUnknown = 99,
@@ -236,6 +246,9 @@ impl From<PlatformWalletError> for PlatformWalletFFIResult {
             }
             PlatformWalletError::ShieldedSpendUnconfirmed { .. } => {
                 PlatformWalletFFIResultCode::ErrorShieldedSpendUnconfirmed
+            }
+            PlatformWalletError::ShieldedNoRecordedAnchor(..) => {
+                PlatformWalletFFIResultCode::ErrorShieldedNoRecordedAnchor
             }
             _ => PlatformWalletFFIResultCode::ErrorUnknown,
         };

--- a/packages/rs-platform-wallet-ffi/src/identity_registration_with_signer.rs
+++ b/packages/rs-platform-wallet-ffi/src/identity_registration_with_signer.rs
@@ -440,7 +440,7 @@ pub unsafe extern "C" fn platform_wallet_register_identity_with_signer(
     ));
 
     let option = PLATFORM_WALLET_STORAGE.with_item(wallet_handle, |wallet| {
-        let identity_wallet = wallet.identity().clone();
+        let wallet = wallet.clone();
 
         let placeholder = Identity::V0(IdentityV0 {
             id: Identifier::default(),
@@ -455,7 +455,10 @@ pub unsafe extern "C" fn platform_wallet_register_identity_with_signer(
             let address_signer: &VTableSigner =
                 unsafe { &*(signer_address_addr as *const VTableSigner) };
 
-            identity_wallet
+            // The composite registers the identity AND reconciles the
+            // spent funding addresses' platform-address balances from
+            // the proof.
+            wallet
                 .register_from_addresses(
                     &placeholder,
                     input_map,

--- a/packages/rs-platform-wallet-ffi/src/identity_top_up.rs
+++ b/packages/rs-platform-wallet-ffi/src/identity_top_up.rs
@@ -118,11 +118,21 @@ pub unsafe extern "C" fn platform_wallet_top_up_from_addresses_with_signer(
 
     let option = PLATFORM_WALLET_STORAGE.with_item(wallet_handle, |wallet| {
         let identity_wallet = wallet.identity().clone();
+        let platform_wallet = wallet.platform().clone();
         block_on_worker(async move {
             let address_signer: &VTableSigner = unsafe { &*(signer_addr as *const VTableSigner) };
-            identity_wallet
+            let (address_infos, new_balance) = identity_wallet
                 .top_up_from_addresses(&identity_id, input_map, address_signer, None)
-                .await
+                .await?;
+            // Reconcile the spent platform-address balances from the proof so
+            // the wallet's displayed balance and next input selection reflect
+            // the spend. Resolves spent addresses via the address provider, so
+            // it covers addresses restored from disk that are no longer in a
+            // live derived pool.
+            platform_wallet
+                .apply_top_up_reconciliation(&address_infos)
+                .await;
+            Ok::<_, platform_wallet::PlatformWalletError>(new_balance)
         })
     });
     let result = unwrap_option_or_return!(option);

--- a/packages/rs-platform-wallet-ffi/src/identity_top_up.rs
+++ b/packages/rs-platform-wallet-ffi/src/identity_top_up.rs
@@ -3,8 +3,9 @@
 //!
 //! Mirrors [`crate::identity_registration_with_signer`] (registration)
 //! but for an *existing* identity. The single entry point —
-//! [`platform_wallet_top_up_from_addresses_with_signer`] — wraps
-//! [`IdentityWallet::top_up_from_addresses`](platform_wallet::IdentityWallet::top_up_from_addresses)
+//! [`platform_wallet_top_up_from_addresses_with_signer`] — wraps the
+//! composite
+//! [`PlatformWallet::top_up_from_addresses`](platform_wallet::PlatformWallet::top_up_from_addresses)
 //! and reuses the same address-input shape (`IdentityFundingInputFFI`)
 //! the registration FFI exposes.
 //!
@@ -17,10 +18,10 @@
 //!
 //! On success the function writes the post-transition credit balance
 //! back through `out_new_balance`. The local `ManagedIdentity`
-//! manager is updated synchronously inside the library call (see
-//! [`top_up_from_addresses`](platform_wallet::IdentityWallet::top_up_from_addresses)
-//! for the bookkeeping); callers can re-read the balance via
-//! `ManagedIdentity` once this returns.
+//! manager is updated and the spent platform-address balances are
+//! reconciled synchronously inside the composite library call;
+//! callers can re-read the balance via `ManagedIdentity` once this
+//! returns.
 
 use std::collections::BTreeMap;
 use std::slice;
@@ -117,22 +118,17 @@ pub unsafe extern "C" fn platform_wallet_top_up_from_addresses_with_signer(
     let signer_addr = signer_address_handle as usize;
 
     let option = PLATFORM_WALLET_STORAGE.with_item(wallet_handle, |wallet| {
-        let identity_wallet = wallet.identity().clone();
-        let platform_wallet = wallet.platform().clone();
+        let wallet = wallet.clone();
         block_on_worker(async move {
             let address_signer: &VTableSigner = unsafe { &*(signer_addr as *const VTableSigner) };
-            let (address_infos, new_balance) = identity_wallet
+            // The composite tops up the identity AND reconciles the spent
+            // platform-address balances from the proof, so the wallet's
+            // displayed balance and next input selection reflect the spend
+            // (covering addresses restored from disk that are no longer in
+            // a live derived pool).
+            wallet
                 .top_up_from_addresses(&identity_id, input_map, address_signer, None)
-                .await?;
-            // Reconcile the spent platform-address balances from the proof so
-            // the wallet's displayed balance and next input selection reflect
-            // the spend. Resolves spent addresses via the address provider, so
-            // it covers addresses restored from disk that are no longer in a
-            // live derived pool.
-            platform_wallet
-                .apply_top_up_reconciliation(&address_infos)
-                .await;
-            Ok::<_, platform_wallet::PlatformWalletError>(new_balance)
+                .await
         })
     });
     let result = unwrap_option_or_return!(option);

--- a/packages/rs-platform-wallet-ffi/src/identity_transfer.rs
+++ b/packages/rs-platform-wallet-ffi/src/identity_transfer.rs
@@ -97,8 +97,10 @@ pub unsafe extern "C" fn platform_wallet_transfer_credits_with_signer(
 /// [`PlatformAddressCreditOutputFFI`] recipients using the supplied
 /// `signer_handle`.
 ///
-/// Wraps
-/// [`IdentityWallet::transfer_credits_to_addresses_with_external_signer`](platform_wallet::IdentityWallet::transfer_credits_to_addresses_with_external_signer).
+/// Wraps the composite
+/// [`PlatformWallet::transfer_credits_to_addresses_with_external_signer`](platform_wallet::PlatformWallet::transfer_credits_to_addresses_with_external_signer),
+/// which also reconciles wallet-owned recipient addresses' platform
+/// balances from the transfer proof.
 ///
 /// `out_new_balance` (when non-null) receives the sender's remaining
 /// balance after the transfer.
@@ -149,10 +151,13 @@ pub unsafe extern "C" fn platform_wallet_transfer_credits_to_addresses_with_sign
     let signer_addr = signer_handle as usize;
 
     let option = PLATFORM_WALLET_STORAGE.with_item(wallet_handle, |wallet| {
-        let identity_wallet = wallet.identity().clone();
+        let wallet = wallet.clone();
         block_on_worker(async move {
             let signer: &VTableSigner = &*(signer_addr as *const VTableSigner);
-            identity_wallet
+            // The composite transfers the credits AND reconciles any
+            // wallet-owned recipient addresses' platform balances from
+            // the proof (third-party recipients are skipped).
+            wallet
                 .transfer_credits_to_addresses_with_external_signer(
                     &from_id, output_map, signer, None,
                 )

--- a/packages/rs-platform-wallet-ffi/src/platform_address_sync.rs
+++ b/packages/rs-platform-wallet-ffi/src/platform_address_sync.rs
@@ -195,3 +195,29 @@ pub unsafe extern "C" fn platform_wallet_manager_platform_address_sync_sync_now(
     unwrap_option_or_return!(option);
     PlatformWalletFFIResult::ok()
 }
+
+/// Reset the platform-address (BLAST/DIP-17) incremental-sync watermark
+/// and drop every cached balance across all registered wallets, forcing
+/// a full rescan on the next sync. Backs the SwiftExampleApp "Clear"
+/// button.
+///
+/// `reset_platform_address_sync_state` quiesces the background sync loop
+/// before resetting so no in-flight pass can re-write the watermark. The
+/// loop is left stopped (not restarted) — the host re-arms it via
+/// `..._start`, or uses one-shot `..._sync_now`, afterward.
+#[no_mangle]
+pub unsafe extern "C" fn platform_wallet_manager_platform_address_sync_reset(
+    handle: Handle,
+) -> PlatformWalletFFIResult {
+    let option = PLATFORM_WALLET_MANAGER_STORAGE.with_item(handle, |manager| {
+        runtime().block_on(manager.reset_platform_address_sync_state())
+    });
+    let result = unwrap_option_or_return!(option);
+    if let Err(e) = result {
+        return PlatformWalletFFIResult::err(
+            PlatformWalletFFIResultCode::ErrorWalletOperation,
+            format!("reset_platform_address_sync_state failed: {e}"),
+        );
+    }
+    PlatformWalletFFIResult::ok()
+}

--- a/packages/rs-platform-wallet-ffi/src/shielded_send.rs
+++ b/packages/rs-platform-wallet-ffi/src/shielded_send.rs
@@ -448,6 +448,14 @@ fn map_spend_result(
                 e.to_string(),
             )
         }
+        // Retryable: the wallet couldn't build the spend against any
+        // Platform-recorded anchor yet (its commitment tree is mid-block after
+        // an index-chunk sync). Nothing was broadcast and the notes were
+        // released, so the host may retry after the next shielded sync.
+        Err(e @ PlatformWalletError::ShieldedNoRecordedAnchor(_)) => PlatformWalletFFIResult::err(
+            PlatformWalletFFIResultCode::ErrorShieldedNoRecordedAnchor,
+            format!("Wallet is still syncing to a confirmed state — try again shortly. ({e})"),
+        ),
         // Definitive failure: the transition was not executed and the notes
         // were released; the host may retry.
         Err(e @ PlatformWalletError::ShieldedBroadcastFailed(_)) => PlatformWalletFFIResult::err(
@@ -628,6 +636,14 @@ pub unsafe extern "C" fn platform_wallet_manager_shielded_identity_create_from_p
                 ),
             )
         }
+        // Retryable: no Platform-recorded anchor covered the selected notes yet
+        // (the commitment tree is mid-block after an index-chunk sync). Nothing
+        // was broadcast and the notes were released, so the host may retry after
+        // the next shielded sync.
+        Err(e @ PlatformWalletError::ShieldedNoRecordedAnchor(_)) => PlatformWalletFFIResult::err(
+            PlatformWalletFFIResultCode::ErrorShieldedNoRecordedAnchor,
+            format!("Wallet is still syncing to a confirmed state — try again shortly. ({e})"),
+        ),
         // Definitive failure: the transition was not executed and the spent notes were released.
         Err(e @ PlatformWalletError::ShieldedBroadcastFailed(_)) => PlatformWalletFFIResult::err(
             PlatformWalletFFIResultCode::ErrorShieldedBroadcastFailed,
@@ -1330,6 +1346,21 @@ mod tests {
         assert!(
             message_of(&result).contains("relay rejected"),
             "broadcast-failed message must carry the wallet Display payload"
+        );
+
+        // No Platform-recorded anchor yet → its own retryable code, distinct
+        // from the "was broadcast, do NOT retry" unconfirmed code above.
+        let no_anchor: Result<(), PlatformWalletError> = Err(
+            PlatformWalletError::ShieldedNoRecordedAnchor("mid-block".to_string()),
+        );
+        let result = map_spend_result(no_anchor, "shielded withdraw");
+        assert_eq!(
+            result.code,
+            PlatformWalletFFIResultCode::ErrorShieldedNoRecordedAnchor
+        );
+        assert!(
+            message_of(&result).contains("try again shortly"),
+            "no-recorded-anchor message must be the retryable guidance"
         );
 
         let other: Result<(), PlatformWalletError> =

--- a/packages/rs-platform-wallet-ffi/src/shielded_send.rs
+++ b/packages/rs-platform-wallet-ffi/src/shielded_send.rs
@@ -311,9 +311,11 @@ pub unsafe extern "C" fn platform_wallet_manager_shielded_transfer(
     // calling thread.
     let result = block_on_worker(async move {
         let prover = CachedOrchardProver::new();
-        wallet
+        let r = wallet
             .shielded_transfer_to(&coordinator, account, &recipient, amount, memo, &prover)
-            .await
+            .await;
+        poke_sync_on_unconfirmed(&r, handle);
+        r
     });
     map_spend_result(result, "shielded transfer")
 }
@@ -363,9 +365,11 @@ pub unsafe extern "C" fn platform_wallet_manager_shielded_unshield(
 
     let result = block_on_worker(async move {
         let prover = CachedOrchardProver::new();
-        wallet
+        let r = wallet
             .shielded_unshield_to(&coordinator, account, &to_addr_str, amount, &prover)
-            .await
+            .await;
+        poke_sync_on_unconfirmed(&r, handle);
+        r
     });
     map_spend_result(result, "shielded unshield")
 }
@@ -412,7 +416,7 @@ pub unsafe extern "C" fn platform_wallet_manager_shielded_withdraw(
 
     let result = block_on_worker(async move {
         let prover = CachedOrchardProver::new();
-        wallet
+        let r = wallet
             .shielded_withdraw_to(
                 &coordinator,
                 account,
@@ -421,9 +425,59 @@ pub unsafe extern "C" fn platform_wallet_manager_shielded_withdraw(
                 core_fee_per_byte,
                 &prover,
             )
-            .await
+            .await;
+        poke_sync_on_unconfirmed(&r, handle);
+        r
     });
     map_spend_result(result, "shielded withdraw")
+}
+
+/// On the AMBIGUOUS outcome (broadcast accepted, result unconfirmed),
+/// kick an immediate forced shielded sync so the first re-drive check —
+/// nullifier re-check, then re-broadcast of the persisted transition —
+/// happens now instead of at the next background tick.
+///
+/// Routed through the manager's [`ShieldedSyncManager::sync_now`] so the
+/// pass respects the same `is_syncing` CAS + `quiescing` drain barrier as
+/// the periodic loop and the host's Sync Now button — a raw
+/// `coordinator.sync(...)` here would race both. `force = true` bypasses
+/// only the caught-up cooldown, never the serialization gate. If a pass
+/// is already in flight the poke no-ops (empty summary) and the next
+/// tick's pass picks the redrive up — that pass's pre-scan snapshot may
+/// predate this arm, which is fine.
+///
+/// Fire-and-forget: the spend's own result is already decided and the
+/// sync pass owns resolution from here (`redrive_pending_spends` + the
+/// prune backstop); the pass outcome is logged, not surfaced.
+///
+/// [`ShieldedSyncManager::sync_now`]: platform_wallet::manager::shielded_sync::ShieldedSyncManager::sync_now
+fn poke_sync_on_unconfirmed<T>(result: &Result<T, PlatformWalletError>, handle: Handle) {
+    let ambiguous = matches!(
+        result,
+        Err(PlatformWalletError::ShieldedSpendUnconfirmed { .. })
+            | Err(PlatformWalletError::ShieldedBroadcastUnconfirmed { .. })
+    );
+    if !ambiguous {
+        return;
+    }
+    let Some(sync_manager) =
+        PLATFORM_WALLET_MANAGER_STORAGE.with_item(handle, |manager| manager.shielded_sync_arc())
+    else {
+        return;
+    };
+    runtime().spawn(async move {
+        let summary = sync_manager.sync_now(true).await;
+        if summary.sync_unix_seconds == 0 {
+            tracing::debug!(
+                "post-unconfirmed shielded sync poke skipped (a pass was already in flight                  or shielded is unconfigured); the next pass owns the re-drive"
+            );
+        } else {
+            tracing::debug!(
+                wallets = summary.wallet_results.len(),
+                "post-unconfirmed shielded sync pass completed"
+            );
+        }
+    });
 }
 
 /// Map a shielded operation outcome (shield / unshield / transfer /
@@ -600,7 +654,7 @@ pub unsafe extern "C" fn platform_wallet_manager_shielded_identity_create_from_p
         // `Signer<IdentityPublicKey>`.
         let identity_signer: &VTableSigner = &*(signer_identity_addr as *const VTableSigner);
         let prover = CachedOrchardProver::new();
-        wallet
+        let r = wallet
             .shielded_identity_create_from_pool(
                 &coordinator,
                 account,
@@ -611,7 +665,9 @@ pub unsafe extern "C" fn platform_wallet_manager_shielded_identity_create_from_p
                 identity_signer,
                 &prover,
             )
-            .await
+            .await;
+        poke_sync_on_unconfirmed(&r, handle);
+        r
     });
 
     match result {

--- a/packages/rs-platform-wallet/src/error.rs
+++ b/packages/rs-platform-wallet/src/error.rs
@@ -234,6 +234,19 @@ pub enum PlatformWalletError {
     #[error("Shielded Merkle witness unavailable: {0}")]
     ShieldedMerkleWitnessUnavailable(String),
 
+    /// No Platform-recorded anchor covers the notes selected for a shielded
+    /// spend, so the wallet cannot build a proof Platform will accept.
+    ///
+    /// Platform records one commitment-tree anchor per block, but an
+    /// index-chunk sync routinely leaves the wallet's tree mid-block, so the
+    /// current (depth-0) root is frequently a value Platform never recorded.
+    /// This variant is **retryable**: it is returned *before* any broadcast,
+    /// the note reservations are released by the caller's generic error path,
+    /// and the next shielded sync advances the tree onto a recorded boundary.
+    /// `0` carries a human-readable reason.
+    #[error("Shielded spend cannot use a Platform-recorded anchor: {0}")]
+    ShieldedNoRecordedAnchor(String),
+
     #[error("Shielded key derivation failed: {0}")]
     ShieldedKeyDerivation(String),
 

--- a/packages/rs-platform-wallet/src/manager/mod.rs
+++ b/packages/rs-platform-wallet/src/manager/mod.rs
@@ -289,6 +289,42 @@ impl<P: PlatformWalletPersistence + 'static> PlatformWalletManager<P> {
         Ok(())
     }
 
+    /// Reset the platform-address (BLAST/DIP-17) incremental-sync
+    /// watermark and drop every cached balance across **all**
+    /// registered wallets, forcing a full rescan on the next sync.
+    ///
+    /// Backs the SwiftExampleApp "Clear" button. Manager-level (not
+    /// per-wallet) to match [`clear_shielded`](Self::clear_shielded):
+    /// the host's persistence delete is global, so a per-wallet reset
+    /// would leave sibling wallets' in-memory watermarks to
+    /// re-populate the deleted rows on the next sync.
+    ///
+    /// Quiesces the platform-address sync manager first so no in-flight
+    /// pass can call `update_sync_state` and re-write the watermark (or
+    /// re-seed balances) *after* the reset. Does NOT restart the loop —
+    /// manual "Sync Now" works without it, and leaving it stopped is
+    /// the desired UX: data stays cleared until the user explicitly
+    /// resyncs. `quiesce` leaves the manager stopped-but-restartable.
+    pub async fn reset_platform_address_sync_state(
+        &self,
+    ) -> Result<(), crate::error::PlatformWalletError> {
+        self.platform_address_sync_manager.quiesce().await;
+
+        // Snapshot Arc clones under a short read lock; never hold the
+        // `wallets` read guard across the per-wallet `.await`s below —
+        // that would block registration and invite lock-ordering
+        // issues against each wallet's `wallet_manager` lock.
+        let wallets: Vec<Arc<PlatformWallet>> = {
+            let guard = self.wallets.read().await;
+            guard.values().cloned().collect()
+        };
+
+        for wallet in wallets {
+            wallet.platform().reset_sync_state().await;
+        }
+        Ok(())
+    }
+
     /// Stop all background tasks and wait for them to exit.
     ///
     /// **Quiesces** the periodic coordinators

--- a/packages/rs-platform-wallet/src/wallet/identity/network/register_from_addresses.rs
+++ b/packages/rs-platform-wallet/src/wallet/identity/network/register_from_addresses.rs
@@ -37,6 +37,19 @@ impl IdentityWallet {
     /// DIP-9 auth pubkeys) and both signers; the wallet struct
     /// carries no key material.
     ///
+    /// Returns the registered identity alongside the proof-attested
+    /// post-spend `AddressInfos` for the funding addresses. Prefer the
+    /// composite [`PlatformWallet::register_from_addresses`], which feeds
+    /// the returned `AddressInfos` through
+    /// [`PlatformAddressWallet::reconcile_address_infos`] so the spent
+    /// balances and advanced nonces are reflected locally without waiting
+    /// for the next BLAST sync round.
+    ///
+    /// [`PlatformWallet::register_from_addresses`]:
+    /// crate::wallet::PlatformWallet::register_from_addresses
+    /// [`PlatformAddressWallet::reconcile_address_infos`]:
+    /// crate::wallet::PlatformAddressWallet::reconcile_address_infos
+    ///
     /// # Arguments
     ///
     /// * `identity` — fully-constructed placeholder identity (with
@@ -74,7 +87,7 @@ impl IdentityWallet {
         identity_signer: &IS,
         input_address_signer: &AS,
         settings: Option<PutSettings>,
-    ) -> Result<Identity, PlatformWalletError> {
+    ) -> Result<(Identity, dash_sdk::query_types::AddressInfos), PlatformWalletError> {
         if inputs.is_empty() {
             return Err(PlatformWalletError::InvalidIdentityData(
                 "At least one input address is required".to_string(),
@@ -84,7 +97,7 @@ impl IdentityWallet {
         // Route through the auto-fetching SDK variant so the caller
         // doesn't need to maintain its own nonce cache — Platform is
         // always the source of truth at submit time.
-        let (mut registered_identity, _address_infos) = identity
+        let (mut registered_identity, address_infos) = identity
             .put_with_address_funding_fetching_nonces(
                 &self.sdk,
                 inputs,
@@ -136,12 +149,10 @@ impl IdentityWallet {
             )?;
         }
 
-        // TODO(platform-wallet): mirror `transfer()` and push the
-        // returned `address_infos` through the platform-address
-        // balance cache so SwiftData reflects the spent balances +
-        // advanced nonces immediately. For now the next BLAST sync
-        // round refreshes them.
-
-        Ok(identity)
+        // The spent platform-address balances are reconciled by the
+        // composite `PlatformWallet::register_from_addresses`, which routes
+        // the returned `AddressInfos` through the platform-address wallet's
+        // shared reconciliation seam.
+        Ok((identity, address_infos))
     }
 }

--- a/packages/rs-platform-wallet/src/wallet/identity/network/top_up_from_addresses.rs
+++ b/packages/rs-platform-wallet/src/wallet/identity/network/top_up_from_addresses.rs
@@ -28,14 +28,20 @@ impl IdentityWallet {
     /// Uses the `TopUpIdentityFromAddresses` SDK trait. Address nonces are
     /// looked up automatically.
     ///
-    /// Returns the proof-attested post-spend `AddressInfos` alongside the new
-    /// identity balance. The caller MUST reconcile the spent platform-address
-    /// balances from the `AddressInfos` via
-    /// [`PlatformAddressWallet::apply_top_up_reconciliation`] — this method
-    /// only owns the identity-side balance update, because resolving a spent
-    /// address back to its derivation index needs the address provider, which
-    /// lives on the platform-address wallet (and covers addresses restored
-    /// from disk that are no longer in a live derived pool).
+    /// This method owns only the identity-side balance update and returns
+    /// the proof-attested post-spend `AddressInfos` alongside the new
+    /// identity balance. Prefer the composite
+    /// [`PlatformWallet::top_up_from_addresses`], which feeds the returned
+    /// `AddressInfos` through
+    /// [`PlatformAddressWallet::reconcile_address_infos`] — the
+    /// platform-address wallet holds the address provider needed to map a
+    /// spent address back to its derivation index (including addresses
+    /// restored from disk that are no longer in a live derived pool).
+    ///
+    /// [`PlatformWallet::top_up_from_addresses`]:
+    /// crate::wallet::PlatformWallet::top_up_from_addresses
+    /// [`PlatformAddressWallet::reconcile_address_infos`]:
+    /// crate::wallet::PlatformAddressWallet::reconcile_address_infos
     ///
     /// # Arguments
     ///
@@ -100,10 +106,10 @@ impl IdentityWallet {
             }
         }
 
-        // The spent platform-address balances are reconciled by the caller via
-        // `PlatformAddressWallet::apply_top_up_reconciliation`, which has the
-        // address provider needed to map restored addresses back to their
-        // derivation index.
+        // The spent platform-address balances are reconciled by the
+        // composite `PlatformWallet::top_up_from_addresses`, which routes
+        // the returned `AddressInfos` through the platform-address wallet's
+        // shared reconciliation seam.
         Ok((address_infos, new_balance))
     }
 }

--- a/packages/rs-platform-wallet/src/wallet/identity/network/top_up_from_addresses.rs
+++ b/packages/rs-platform-wallet/src/wallet/identity/network/top_up_from_addresses.rs
@@ -12,6 +12,8 @@ use dash_sdk::platform::transition::top_up_identity_from_addresses::TopUpIdentit
 use dpp::address_funds::PlatformAddress;
 use dpp::fee::Credits;
 
+use dash_sdk::query_types::AddressInfos;
+
 use crate::error::PlatformWalletError;
 
 use super::*;
@@ -25,6 +27,15 @@ impl IdentityWallet {
     ///
     /// Uses the `TopUpIdentityFromAddresses` SDK trait. Address nonces are
     /// looked up automatically.
+    ///
+    /// Returns the proof-attested post-spend `AddressInfos` alongside the new
+    /// identity balance. The caller MUST reconcile the spent platform-address
+    /// balances from the `AddressInfos` via
+    /// [`PlatformAddressWallet::apply_top_up_reconciliation`] — this method
+    /// only owns the identity-side balance update, because resolving a spent
+    /// address back to its derivation index needs the address provider, which
+    /// lives on the platform-address wallet (and covers addresses restored
+    /// from disk that are no longer in a live derived pool).
     ///
     /// # Arguments
     ///
@@ -40,7 +51,7 @@ impl IdentityWallet {
         inputs: BTreeMap<PlatformAddress, Credits>,
         address_signer: &S,
         settings: Option<PutSettings>,
-    ) -> Result<Credits, PlatformWalletError> {
+    ) -> Result<(AddressInfos, Credits), PlatformWalletError> {
         let identity = {
             let wm = self.wallet_manager.read().await;
             let info = wm.get_wallet_info(&self.wallet_id).ok_or_else(|| {
@@ -55,7 +66,7 @@ impl IdentityWallet {
                 .ok_or(PlatformWalletError::IdentityNotFound(*identity_id))?
         };
 
-        let (_address_infos, new_balance) = identity
+        let (address_infos, new_balance) = identity
             .top_up_from_addresses(&self.sdk, inputs, address_signer, settings)
             .await
             .map_err(|e| {
@@ -89,6 +100,10 @@ impl IdentityWallet {
             }
         }
 
-        Ok(new_balance)
+        // The spent platform-address balances are reconciled by the caller via
+        // `PlatformAddressWallet::apply_top_up_reconciliation`, which has the
+        // address provider needed to map restored addresses back to their
+        // derivation index.
+        Ok((address_infos, new_balance))
     }
 }

--- a/packages/rs-platform-wallet/src/wallet/identity/network/transfer_to_addresses.rs
+++ b/packages/rs-platform-wallet/src/wallet/identity/network/transfer_to_addresses.rs
@@ -63,13 +63,26 @@ impl IdentityWallet {
     ///
     /// Signing is routed through the supplied `&S: Signer<IdentityPublicKey>`.
     /// Required for external-signable wallets.
+    ///
+    /// Returns the proof-attested post-transfer `AddressInfos` for the
+    /// recipient addresses alongside the sender's new balance. Prefer the
+    /// composite [`PlatformWallet::transfer_credits_to_addresses_with_external_signer`],
+    /// which feeds the returned `AddressInfos` through
+    /// [`PlatformAddressWallet::reconcile_address_infos`] so recipients
+    /// owned by this wallet see their new balance immediately instead of
+    /// waiting for the next BLAST sync round.
+    ///
+    /// [`PlatformWallet::transfer_credits_to_addresses_with_external_signer`]:
+    /// crate::wallet::PlatformWallet::transfer_credits_to_addresses_with_external_signer
+    /// [`PlatformAddressWallet::reconcile_address_infos`]:
+    /// crate::wallet::PlatformAddressWallet::reconcile_address_infos
     pub async fn transfer_credits_to_addresses_with_external_signer<S>(
         &self,
         identity_id: &Identifier,
         recipient_addresses: BTreeMap<PlatformAddress, Credits>,
         signer: &S,
         settings: Option<PutSettings>,
-    ) -> Result<Credits, PlatformWalletError>
+    ) -> Result<(dash_sdk::query_types::AddressInfos, Credits), PlatformWalletError>
     where
         S: Signer<IdentityPublicKey> + Send + Sync,
     {
@@ -87,7 +100,7 @@ impl IdentityWallet {
                 .ok_or(PlatformWalletError::IdentityNotFound(*identity_id))?
         };
 
-        let (_address_infos, new_balance) = identity
+        let (address_infos, new_balance) = identity
             .transfer_credits_to_addresses(
                 &self.sdk,
                 recipient_addresses,
@@ -126,6 +139,10 @@ impl IdentityWallet {
             }
         }
 
-        Ok(new_balance)
+        // Recipient platform-address balances are reconciled by the
+        // composite `PlatformWallet::transfer_credits_to_addresses_with_external_signer`,
+        // which routes the returned `AddressInfos` through the
+        // platform-address wallet's shared reconciliation seam.
+        Ok((address_infos, new_balance))
     }
 }

--- a/packages/rs-platform-wallet/src/wallet/platform_addresses/fund_from_asset_lock.rs
+++ b/packages/rs-platform-wallet/src/wallet/platform_addresses/fund_from_asset_lock.rs
@@ -25,7 +25,6 @@
 //!    tracked outpoint so the row is marked `Consumed` (terminal)
 //!    and dropped from the in-memory tracked-lock map.
 
-use crate::changeset::Merge;
 use crate::wallet::asset_lock::orchestration::{
     out_point_from_proof, submit_with_cl_height_retry, AssetLockFunding, FundingResolution,
     ResolvedFunding, CL_FALLBACK_TIMEOUT,
@@ -273,39 +272,26 @@ impl PlatformAddressWallet {
         // or all recipients.
         validate_address_infos_complete(&addresses, &address_infos)?;
 
-        let cs = self
-            .write_address_balances_changeset(platform_account_index, &address_infos)
-            .await;
-
-        // Mirror `transfer.rs` / `sync.rs`: push the post-submit
-        // balances through the persister so any external store stays
-        // in sync with the in-memory account state we just updated.
-        // Without this, persisted rows for these recipients stay
-        // frozen at pre-top-up values until the next BLAST sync
-        // overwrites them. On the next process start before that
-        // sync, `initialize_from_persisted` would seed
+        // The shared seam applies the proof-attested balances to the
+        // managed accounts, updates the provider's sync seed, and
+        // persists — without the persist, rows for these recipients
+        // stay frozen at pre-top-up values until the next BLAST sync;
+        // on a process restart before that sync,
+        // `initialize_from_persisted` would seed
         // `account.address_credit_balance` from the stale rows while
-        // the asset-lock record is already `Consumed` — leaving
+        // the asset-lock record is already `Consumed`, leaving
         // `auto_select_inputs` to under-budget and produce
         // protocol-level rejections until a sync repairs them.
         //
-        // The persist MUST happen before `consume_asset_lock` so
-        // we never have a Consumed lock paired with a stale balance
-        // row on disk.
-        //
-        // Log-on-error rather than propagate: Platform already
-        // accepted the transition, and a persistence hiccup shouldn't
-        // mask that. A subsequent sync reconciles.
-        if !cs.is_empty() {
-            if let Err(e) = self.persister.store(cs.clone().into()) {
-                tracing::error!(
-                    error = %e,
-                    "Failed to persist fund-from-asset-lock changeset; \
-                     in-memory balances are updated but durable rows are stale \
-                     until the next BLAST sync"
-                );
-            }
-        }
+        // The seam persists before returning, and the persist MUST
+        // happen before `consume_asset_lock` so we never have a
+        // Consumed lock paired with a stale balance row on disk.
+        // Persistence errors are logged inside the seam rather than
+        // propagated: Platform already accepted the transition, and a
+        // persistence hiccup shouldn't mask that.
+        let cs = self
+            .reconcile_address_infos(&address_infos, "fund from asset lock")
+            .await;
 
         if let Some(out_point) = tracked_out_point {
             // Platform DID accept the top-up — propagating an Err
@@ -347,97 +333,6 @@ impl PlatformAddressWallet {
         }
 
         Ok(cs)
-    }
-
-    /// Apply proof-attested credit balances to the
-    /// `ManagedPlatformAccount` for each recipient address, emitting
-    /// a `PlatformAddressChangeSet` describing the new balances.
-    async fn write_address_balances_changeset(
-        &self,
-        platform_account_index: u32,
-        address_infos: &AddressInfos,
-    ) -> PlatformAddressChangeSet {
-        let key_source = {
-            let guard = self.provider.read().await;
-            guard
-                .as_ref()
-                .and_then(|p| p.key_source(&self.wallet_id, platform_account_index))
-        };
-
-        let mut wm = self.wallet_manager.write().await;
-        let mut cs = PlatformAddressChangeSet::default();
-        if let Some(info) = wm.get_wallet_info_mut(&self.wallet_id) {
-            if let Some(account) = info
-                .core_wallet
-                .platform_payment_managed_account_at_index_mut(platform_account_index)
-            {
-                for (addr, maybe_info) in address_infos.iter() {
-                    let PlatformAddress::P2pkh(hash) = *addr else {
-                        continue;
-                    };
-                    let p2pkh = PlatformP2PKHAddress::new(hash);
-                    // Platform's proof must carry an `AddressInfo`
-                    // for every recipient we asked to fund. A `None`
-                    // is a protocol-contract violation, not a
-                    // zero-credit funding — skip and log so a missed
-                    // recipient is visible to operators instead of
-                    // silently writing a "credited 0" row.
-                    let Some(ai) = maybe_info else {
-                        tracing::error!(
-                            address = %p2pkh,
-                            "Platform proof returned None AddressInfo for a recipient that should have been credited; skipping balance write to avoid recording 'credited 0'"
-                        );
-                        continue;
-                    };
-                    let funds = dash_sdk::platform::address_sync::AddressFunds {
-                        balance: ai.balance,
-                        nonce: ai.nonce,
-                    };
-                    // The recipient must exist in the account's
-                    // address pool — `validate_recipient_addresses`
-                    // verified that upstream. A miss here would
-                    // mean the pool was mutated between pre-flight
-                    // and now; skip and log rather than mis-attribute
-                    // credits to whichever address lives at slot 0.
-                    //
-                    // Look this up BEFORE mutating the in-memory
-                    // balance: if we mutated first and then `continue`d
-                    // on a pool miss, the changeset would be missing
-                    // this recipient's entry while the in-memory state
-                    // already carried the new balance — defeating the
-                    // persist-before-consume invariant the caller
-                    // relies on (the persisted row would stay stale
-                    // while the asset lock is consumed regardless).
-                    let Some(address_index) =
-                        account
-                            .addresses
-                            .addresses
-                            .iter()
-                            .find_map(|(&idx, ainfo)| {
-                                PlatformP2PKHAddress::from_address(&ainfo.address)
-                                    .ok()
-                                    .filter(|found| *found == p2pkh)
-                                    .map(|_| idx)
-                            })
-                    else {
-                        tracing::error!(
-                            address = %p2pkh,
-                            "Recipient address not found in account address pool; skipping balance write to avoid mis-attributing credits to slot 0"
-                        );
-                        continue;
-                    };
-                    account.set_address_credit_balance(p2pkh, funds.balance, key_source.as_ref());
-                    cs.addresses.push(crate::PlatformAddressBalanceEntry {
-                        wallet_id: self.wallet_id,
-                        account_index: platform_account_index,
-                        address_index,
-                        address: p2pkh,
-                        funds,
-                    });
-                }
-            }
-        }
-        cs
     }
 }
 

--- a/packages/rs-platform-wallet/src/wallet/platform_addresses/provider.rs
+++ b/packages/rs-platform-wallet/src/wallet/platform_addresses/provider.rs
@@ -32,9 +32,12 @@ use key_wallet_manager::WalletManager;
 
 use crate::error::PlatformWalletError;
 use crate::wallet::platform_wallet::{PlatformWalletInfo, WalletId};
+use crate::PlatformAddressBalanceEntry;
 use dash_sdk::platform::address_sync::{
     AddressFunds, AddressIndex, AddressProvider, AddressSyncResult,
 };
+use dash_sdk::query_types::AddressInfos;
+use dpp::address_funds::PlatformAddress;
 use tokio::sync::RwLock;
 
 /// DIP-17 address coordinates used as both the pending-bimap key and
@@ -202,6 +205,18 @@ pub(crate) struct PlatformPaymentAddressProvider {
 }
 
 impl PlatformPaymentAddressProvider {
+    /// The committed per-account index/balance state for one wallet, or
+    /// `None` if the provider doesn't cover it. Exposes the full persisted
+    /// `index <-> address` bijection — including addresses restored from
+    /// disk that are no longer in a live derived pool — so callers can map a
+    /// spent address back to its derivation index.
+    pub(crate) fn per_wallet_state(
+        &self,
+        wallet_id: &WalletId,
+    ) -> Option<&PerWalletPlatformAddressState> {
+        self.per_wallet.get(wallet_id)
+    }
+
     /// Build a provider covering every platform payment account on
     /// each wallet in `wallet_ids`.
     ///
@@ -811,6 +826,55 @@ impl AddressProvider for PlatformPaymentAddressProvider {
     }
 }
 
+/// Resolve each spent platform address in a top-up's proof-attested
+/// `address_infos` to its `(account_index, address_index)` using the
+/// per-account index bijections, and pair it with the proof's post-spend
+/// balance + nonce. Resolving against the bijections — rather than the live
+/// derived address pool — means addresses restored from disk (present in the
+/// persisted index map but not in `ManagedPlatformAccount::addresses`) are
+/// still reconciled; without this, a top-up that spends a restored cached row
+/// would leave its stale balance behind, preserving the phantom balance.
+///
+/// Addresses the proof returns that the wallet doesn't own (no bijection
+/// entry) are skipped. Pure and lock-free so the reconciliation is
+/// unit-testable.
+pub(crate) fn build_top_up_balance_entries(
+    wallet_id: WalletId,
+    per_account_addresses: &[(u32, &BiBTreeMap<AddressIndex, PlatformP2PKHAddress>)],
+    address_infos: &AddressInfos,
+) -> Vec<PlatformAddressBalanceEntry> {
+    let mut entries = Vec::new();
+    for (addr, maybe_info) in address_infos.iter() {
+        let PlatformAddress::P2pkh(hash) = addr else {
+            continue;
+        };
+        let p2pkh = PlatformP2PKHAddress::new(*hash);
+        let funds = match maybe_info {
+            Some(ai) => AddressFunds {
+                balance: ai.balance,
+                nonce: ai.nonce,
+            },
+            None => AddressFunds {
+                balance: 0,
+                nonce: 0,
+            },
+        };
+        for &(account_index, bimap) in per_account_addresses {
+            if let Some(&address_index) = bimap.get_by_right(&p2pkh) {
+                entries.push(PlatformAddressBalanceEntry {
+                    wallet_id,
+                    account_index,
+                    address_index,
+                    address: p2pkh,
+                    funds,
+                });
+                break;
+            }
+        }
+    }
+    entries
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -835,6 +899,58 @@ mod tests {
 
     fn funds(balance: u64, nonce: u32) -> AddressFunds {
         AddressFunds { balance, nonce }
+    }
+
+    /// Regression for the top-up reconciliation: a spent platform address
+    /// that exists only in the persisted index bijection (restored from
+    /// disk — not in any live derived pool) must still be resolved to its
+    /// derivation index and recorded with the proof's post-spend balance.
+    /// The original fix scanned only the live pool, so it left restored
+    /// rows stale, preserving the phantom Platform Balance the PR targets.
+    #[test]
+    fn build_top_up_entries_resolves_restored_address_outside_live_pool() {
+        use dash_sdk::query_types::AddressInfo;
+
+        // Present in the persisted bijection at index 3, but NOT in a live
+        // derived address pool.
+        let restored = p2pkh(0x11);
+        let mut bimap: BiBTreeMap<AddressIndex, PlatformP2PKHAddress> = BiBTreeMap::new();
+        bimap.insert(3, restored);
+
+        // The top-up spent it; the proof attests post-spend balance 5,
+        // nonce bumped to 4.
+        let restored_addr = PlatformAddress::P2pkh([0x11; 20]);
+        let mut address_infos = AddressInfos::new();
+        address_infos.insert(
+            restored_addr,
+            Some(AddressInfo {
+                address: restored_addr,
+                nonce: 4,
+                balance: 5,
+            }),
+        );
+
+        let per_account: [(u32, &BiBTreeMap<AddressIndex, PlatformP2PKHAddress>); 1] =
+            [(ACCOUNT, &bimap)];
+        let entries = build_top_up_balance_entries(WALLET, &per_account, &address_infos);
+
+        assert_eq!(
+            entries.len(),
+            1,
+            "a restored spent address must still be reconciled"
+        );
+        let e = &entries[0];
+        assert_eq!(e.address, restored);
+        assert_eq!(e.account_index, ACCOUNT);
+        assert_eq!(
+            e.address_index, 3,
+            "index resolved from the persisted bijection, not the live pool"
+        );
+        assert_eq!(
+            e.funds.balance, 5,
+            "records the proof's post-spend balance, not a stale value"
+        );
+        assert_eq!(e.funds.nonce, 4, "records the bumped nonce");
     }
 
     /// Build a provider whose committed `per_wallet` tracks a single
@@ -1134,6 +1250,119 @@ mod tests {
             0,
             "on_address_absent must zero the in-memory managed-account balance"
         );
+    }
+
+    /// Records every changeset handed to `store`, so a test can assert what
+    /// the reconciliation actually persisted.
+    #[derive(Default)]
+    struct CapturingPersister {
+        stored: std::sync::Mutex<Vec<crate::changeset::PlatformWalletChangeSet>>,
+    }
+
+    impl crate::changeset::PlatformWalletPersistence for CapturingPersister {
+        fn store(
+            &self,
+            _wallet_id: WalletId,
+            changeset: crate::changeset::PlatformWalletChangeSet,
+        ) -> Result<(), crate::changeset::PersistenceError> {
+            self.stored.lock().expect("persister mutex").push(changeset);
+            Ok(())
+        }
+
+        fn flush(&self, _wallet_id: WalletId) -> Result<(), crate::changeset::PersistenceError> {
+            Ok(())
+        }
+
+        fn load(
+            &self,
+        ) -> Result<crate::changeset::ClientStartState, crate::changeset::PersistenceError>
+        {
+            Ok(crate::changeset::ClientStartState::default())
+        }
+    }
+
+    /// Integration regression for the top-up reconciliation *contract* — not
+    /// just the pure entry builder. `apply_top_up_reconciliation` must build
+    /// AND **persist** a `PlatformAddressChangeSet` carrying the proof's
+    /// post-spend balance for a spent address resolved via the provider's
+    /// persisted state. The reported bug was the *missing persist* (the SDK's
+    /// `address_infos` were discarded), so this pins that `store` actually
+    /// fires with the decremented entry — a helper-only test would still pass
+    /// if `apply_top_up_reconciliation` stopped persisting.
+    #[tokio::test]
+    async fn apply_top_up_reconciliation_persists_decremented_balance() {
+        use crate::broadcaster::SpvBroadcaster;
+        use crate::events::PlatformEventManager;
+        use crate::spv::SpvRuntime;
+        use crate::wallet::asset_lock::manager::AssetLockManager;
+        use crate::wallet::persister::WalletPersister;
+        use crate::wallet::platform_addresses::PlatformAddressWallet;
+        use dash_sdk::query_types::AddressInfo;
+        use tokio::sync::Notify;
+
+        let recorder = Arc::new(CapturingPersister::default());
+
+        // Wallet wired to the capturing persister. The rest mirrors the
+        // short-circuit fixture — `apply_top_up_reconciliation` only touches
+        // provider / wallet_manager / persister.
+        let sdk = Arc::new(dash_sdk::SdkBuilder::new_mock().build().expect("mock sdk"));
+        let wallet_manager = Arc::new(RwLock::new(WalletManager::new(sdk.network)));
+        let persister = WalletPersister::new(WALLET, recorder.clone());
+        let event_manager = Arc::new(PlatformEventManager::new(Vec::new()));
+        let spv = Arc::new(SpvRuntime::new(Arc::clone(&wallet_manager), event_manager));
+        let broadcaster = Arc::new(SpvBroadcaster::new(spv));
+        let asset_locks = Arc::new(AssetLockManager::new(
+            Arc::clone(&sdk),
+            Arc::clone(&wallet_manager),
+            WALLET,
+            Arc::new(Notify::new()),
+            broadcaster,
+            persister.clone(),
+        ));
+        let wallet = PlatformAddressWallet::new(
+            sdk,
+            Arc::clone(&wallet_manager),
+            WALLET,
+            asset_locks,
+            persister,
+        );
+
+        // The provider knows the spent address via its persisted bijection
+        // (pre-spend balance 100).
+        let addr = p2pkh(0x11);
+        let provider =
+            provider_tracking_address(Arc::clone(&wallet_manager), WALLET, addr, funds(100, 1));
+        *wallet.provider.write().await = Some(provider);
+
+        // The top-up spent it; the proof attests post-spend balance 5, nonce 4.
+        let spent = PlatformAddress::P2pkh([0x11; 20]);
+        let mut address_infos = AddressInfos::new();
+        address_infos.insert(
+            spent,
+            Some(AddressInfo {
+                address: spent,
+                nonce: 4,
+                balance: 5,
+            }),
+        );
+
+        wallet.apply_top_up_reconciliation(&address_infos).await;
+
+        // The reconciliation must have PERSISTED the decremented entry — the
+        // contract the original bug broke by discarding `address_infos`.
+        let stored = recorder.stored.lock().expect("persister mutex");
+        let entry = stored
+            .iter()
+            .filter_map(|cs| cs.platform_addresses.as_ref())
+            .flat_map(|pa| pa.addresses.iter())
+            .find(|e| e.address == addr)
+            .expect("a persisted platform-address entry for the spent address");
+        assert_eq!(entry.account_index, ACCOUNT);
+        assert_eq!(
+            entry.funds.balance, 5,
+            "persists the proof's post-spend balance, not the stale pre-spend value"
+        );
+        assert_eq!(entry.funds.nonce, 4, "persists the bumped nonce");
     }
 
     /// `reset_sync_state` must zero the incremental watermark AND drop

--- a/packages/rs-platform-wallet/src/wallet/platform_addresses/provider.rs
+++ b/packages/rs-platform-wallet/src/wallet/platform_addresses/provider.rs
@@ -826,21 +826,26 @@ impl AddressProvider for PlatformPaymentAddressProvider {
     }
 }
 
-/// Resolve each spent platform address in a top-up's proof-attested
-/// `address_infos` to its `(account_index, address_index)` using the
-/// per-account index bijections, and pair it with the proof's post-spend
-/// balance + nonce. Resolving against the bijections — rather than the live
-/// derived address pool — means addresses restored from disk (present in the
-/// persisted index map but not in `ManagedPlatformAccount::addresses`) are
-/// still reconciled; without this, a top-up that spends a restored cached row
-/// would leave its stale balance behind, preserving the phantom balance.
+/// Translate a state transition's proof-attested `address_infos` into
+/// persistence-changeset entries, resolving each address's
+/// `(account_index, address_index)` through `resolve_index`.
 ///
-/// Addresses the proof returns that the wallet doesn't own (no bijection
-/// entry) are skipped. Pure and lock-free so the reconciliation is
-/// unit-testable.
-pub(crate) fn build_top_up_balance_entries(
+/// Non-P2PKH addresses and addresses the resolver doesn't recognise
+/// (external recipients, or addresses the wallet doesn't own) are skipped.
+/// Missing per-address info (`None`) maps to zero balance / zero nonce —
+/// the on-chain post-transition state for an address removed from state
+/// (e.g. a fully consumed input). Pure and lock-free so every caller's
+/// translation is unit-testable.
+///
+/// Callers supply the resolver so every reconciliation path can resolve
+/// through the provider's persisted `index <-> address` bijection —
+/// covering addresses restored from disk that are no longer in a live
+/// derived pool — with the live pool as fallback for addresses derived
+/// since the last sync (see
+/// [`PlatformPaymentAddressProvider::commit_reconciliation`]).
+pub(crate) fn build_address_balance_entries(
     wallet_id: WalletId,
-    per_account_addresses: &[(u32, &BiBTreeMap<AddressIndex, PlatformP2PKHAddress>)],
+    resolve_index: impl Fn(&PlatformP2PKHAddress) -> Option<(u32, AddressIndex)>,
     address_infos: &AddressInfos,
 ) -> Vec<PlatformAddressBalanceEntry> {
     let mut entries = Vec::new();
@@ -849,6 +854,9 @@ pub(crate) fn build_top_up_balance_entries(
             continue;
         };
         let p2pkh = PlatformP2PKHAddress::new(*hash);
+        let Some((account_index, address_index)) = resolve_index(&p2pkh) else {
+            continue;
+        };
         let funds = match maybe_info {
             Some(ai) => AddressFunds {
                 balance: ai.balance,
@@ -859,20 +867,166 @@ pub(crate) fn build_top_up_balance_entries(
                 nonce: 0,
             },
         };
-        for &(account_index, bimap) in per_account_addresses {
-            if let Some(&address_index) = bimap.get_by_right(&p2pkh) {
-                entries.push(PlatformAddressBalanceEntry {
-                    wallet_id,
-                    account_index,
-                    address_index,
-                    address: p2pkh,
-                    funds,
-                });
-                break;
-            }
-        }
+        entries.push(PlatformAddressBalanceEntry {
+            wallet_id,
+            account_index,
+            address_index,
+            address: p2pkh,
+            funds,
+        });
     }
     entries
+}
+
+/// What [`PlatformPaymentAddressProvider::commit_reconciliation`] did with
+/// a proof-attested `address_infos` map: the entries that survived the
+/// freshness guard (already committed to the provider's `found` seed),
+/// plus counters so the caller can log why entries were dropped.
+#[derive(Default)]
+pub(crate) struct ReconciliationOutcome {
+    /// Entries to apply to the managed accounts and persist. Already
+    /// committed to the provider's `found` map / bijection.
+    pub(crate) entries: Vec<PlatformAddressBalanceEntry>,
+    /// How many proof addresses resolved to a wallet-owned slot at all
+    /// (before the freshness guard). Zero with a non-empty proof means
+    /// either every address belongs to a third party or resolution failed.
+    pub(crate) resolved: usize,
+    /// Resolved entries dropped because the committed `found` seed already
+    /// carries a higher nonce — a background sync (or a later transition)
+    /// committed fresher state after this proof was produced.
+    pub(crate) stale_skipped: usize,
+    /// Resolved entries dropped as no-ops (funds identical to the
+    /// committed seed) to avoid persister churn.
+    pub(crate) unchanged_skipped: usize,
+}
+
+impl PlatformPaymentAddressProvider {
+    /// Resolve a state transition's proof-attested `address_infos` for
+    /// `wallet_id`, apply the freshness guard, and commit the survivors to
+    /// the provider's `found` map (the sync-diff baseline and the seed
+    /// [`current_balances`](AddressProvider::current_balances) hands the
+    /// SDK) so reconciliation and the background sync cannot diverge.
+    ///
+    /// Resolution goes through the persisted `index <-> address` bijection
+    /// first — covering addresses restored from disk that are no longer in
+    /// a live derived pool — then falls back to `pool_indexes` (the live
+    /// pools, covering addresses derived since the last sync, e.g. a fresh
+    /// change address). The fallback is restricted to accounts the
+    /// provider tracks: every emitted entry is committed to the `found`
+    /// seed, so an account without per-account provider state resolves
+    /// to nothing (it reconciles once `initialize` / `add_provider`
+    /// re-snapshots the account set and the next sync runs).
+    /// Pool-resolved addresses are merged into the bijection so
+    /// `current_balances` can yield their committed funds.
+    ///
+    /// Freshness guard, per resolved entry:
+    /// * zero funds (balance 0, nonce 0 — the address was removed from
+    ///   Platform state, e.g. a fully consumed input) is an authoritative
+    ///   removal: always applied, and the address is dropped from `found`
+    ///   (mirroring the sync's absent handling);
+    /// * otherwise, an entry whose nonce is *below* the committed seed's
+    ///   nonce is stale — a concurrent sync pass or later transition
+    ///   already committed fresher state — and is dropped;
+    /// * entries identical to the committed seed are dropped as no-ops.
+    ///
+    /// Callers must hold the provider write lock (i.e. call through
+    /// `&mut self`) across this commit AND the managed-account balance
+    /// write that follows, so a background sync — which holds the same
+    /// lock across its scan — can never interleave between the two.
+    pub(crate) fn commit_reconciliation(
+        &mut self,
+        wallet_id: &WalletId,
+        address_infos: &AddressInfos,
+        pool_indexes: &BTreeMap<PlatformP2PKHAddress, (u32, AddressIndex)>,
+    ) -> ReconciliationOutcome {
+        let mut outcome = ReconciliationOutcome::default();
+        let Some(wallet_state) = self.per_wallet.get_mut(wallet_id) else {
+            return outcome;
+        };
+
+        let resolved_entries = build_address_balance_entries(
+            *wallet_id,
+            |p2pkh| {
+                for (&account_index, account_state) in wallet_state.iter() {
+                    if let Some(&address_index) = account_state.addresses.get_by_right(p2pkh) {
+                        return Some((account_index, address_index));
+                    }
+                }
+                // Pool fallback only for accounts the provider tracks —
+                // an account added to the live wallet after the provider
+                // snapshot has no per-account state to commit into, so
+                // resolving it here would break the contract that every
+                // emitted entry is committed to the `found` seed. Such
+                // addresses stay unresolved until `initialize` /
+                // `add_provider` re-snapshots the account set.
+                pool_indexes
+                    .get(p2pkh)
+                    .copied()
+                    .filter(|(account_index, _)| wallet_state.contains_key(account_index))
+            },
+            address_infos,
+        );
+        outcome.resolved = resolved_entries.len();
+
+        for entry in resolved_entries {
+            // The resolver only yields accounts present in `wallet_state`,
+            // so a miss here is unreachable; skip defensively rather than
+            // emit an entry the seed never committed.
+            let Some(state) = wallet_state.get_mut(&entry.account_index) else {
+                tracing::warn!(
+                    account_index = entry.account_index,
+                    address = %entry.address,
+                    "commit_reconciliation: resolved account has no tracked \
+                     provider state; dropping entry"
+                );
+                continue;
+            };
+            let existing = state.found.get(&entry.address).copied();
+            // Zero funds = the address no longer exists in Platform state.
+            // That removal is attested by the proof, so it bypasses the
+            // nonce guard (the pre-spend seed necessarily has a lower
+            // nonce than "gone").
+            let is_removal = entry.funds.balance == 0 && entry.funds.nonce == 0;
+            if !is_removal {
+                if let Some(existing) = existing {
+                    if existing.nonce > entry.funds.nonce {
+                        outcome.stale_skipped += 1;
+                        continue;
+                    }
+                    if existing == entry.funds {
+                        outcome.unchanged_skipped += 1;
+                        continue;
+                    }
+                }
+            }
+            if is_removal {
+                state.found.remove(&entry.address);
+            } else {
+                state.found.insert(entry.address, entry.funds);
+            }
+            // Merge pool-resolved addresses into the bijection so
+            // `current_balances` can pair the fresh funds with a
+            // derivation index. Never overwrite an existing pairing —
+            // `BiBTreeMap::insert` evicts conflicting pairs, which
+            // would orphan another address's `found` entry.
+            if state.addresses.get_by_right(&entry.address).is_none() {
+                if state.addresses.contains_left(&entry.address_index) {
+                    tracing::error!(
+                        account_index = entry.account_index,
+                        address_index = entry.address_index,
+                        address = %entry.address,
+                        "commit_reconciliation: derivation index already \
+                         maps to a different address — state drift; \
+                         leaving the bijection untouched"
+                    );
+                } else {
+                    state.addresses.insert(entry.address_index, entry.address);
+                }
+            }
+            outcome.entries.push(entry);
+        }
+        outcome
+    }
 }
 
 #[cfg(test)]
@@ -908,7 +1062,7 @@ mod tests {
     /// The original fix scanned only the live pool, so it left restored
     /// rows stale, preserving the phantom Platform Balance the PR targets.
     #[test]
-    fn build_top_up_entries_resolves_restored_address_outside_live_pool() {
+    fn build_entries_resolves_restored_address_outside_live_pool() {
         use dash_sdk::query_types::AddressInfo;
 
         // Present in the persisted bijection at index 3, but NOT in a live
@@ -930,9 +1084,11 @@ mod tests {
             }),
         );
 
-        let per_account: [(u32, &BiBTreeMap<AddressIndex, PlatformP2PKHAddress>); 1] =
-            [(ACCOUNT, &bimap)];
-        let entries = build_top_up_balance_entries(WALLET, &per_account, &address_infos);
+        let entries = build_address_balance_entries(
+            WALLET,
+            |p2pkh| bimap.get_by_right(p2pkh).map(|&idx| (ACCOUNT, idx)),
+            &address_infos,
+        );
 
         assert_eq!(
             entries.len(),
@@ -951,6 +1107,50 @@ mod tests {
             "records the proof's post-spend balance, not a stale value"
         );
         assert_eq!(e.funds.nonce, 4, "records the bumped nonce");
+    }
+
+    /// `transfer_address_funds` returns address info for the full
+    /// `inputs ∪ outputs` set, including external recipients the wallet
+    /// does not own. The builder must keep entries only for addresses the
+    /// resolver recognises — persisting a recipient under a fabricated
+    /// derivation index would poison the account's address map on restore.
+    /// Missing per-address info maps to zero funds (the post-transition
+    /// state for a fully consumed input elided from the proved set).
+    #[test]
+    fn build_entries_drops_unresolved_and_zeroes_missing_info() {
+        use dash_sdk::query_types::AddressInfo;
+
+        let owned = p2pkh(0x01);
+        let mut bimap: BiBTreeMap<AddressIndex, PlatformP2PKHAddress> = BiBTreeMap::new();
+        bimap.insert(7, owned);
+
+        let owned_addr = PlatformAddress::P2pkh([0x01; 20]);
+        let external_addr = PlatformAddress::P2pkh([0xEE; 20]);
+        let mut address_infos = AddressInfos::new();
+        // Fully consumed input: drive elides the info.
+        address_infos.insert(owned_addr, None);
+        // External recipient: resolver won't know it.
+        address_infos.insert(
+            external_addr,
+            Some(AddressInfo {
+                address: external_addr,
+                nonce: 0,
+                balance: 5_000_000,
+            }),
+        );
+
+        let entries = build_address_balance_entries(
+            WALLET,
+            |p2pkh| bimap.get_by_right(p2pkh).map(|&idx| (ACCOUNT, idx)),
+            &address_infos,
+        );
+
+        assert_eq!(entries.len(), 1, "external recipient must be filtered out");
+        let e = &entries[0];
+        assert_eq!(e.address, owned);
+        assert_eq!(e.address_index, 7);
+        assert_eq!(e.funds.balance, 0, "missing info means removed from state");
+        assert_eq!(e.funds.nonce, 0);
     }
 
     /// Build a provider whose committed `per_wallet` tracks a single
@@ -1281,16 +1481,16 @@ mod tests {
         }
     }
 
-    /// Integration regression for the top-up reconciliation *contract* — not
-    /// just the pure entry builder. `apply_top_up_reconciliation` must build
+    /// Integration regression for the reconciliation *contract* — not
+    /// just the pure entry builder. `reconcile_address_infos` must build
     /// AND **persist** a `PlatformAddressChangeSet` carrying the proof's
     /// post-spend balance for a spent address resolved via the provider's
     /// persisted state. The reported bug was the *missing persist* (the SDK's
     /// `address_infos` were discarded), so this pins that `store` actually
     /// fires with the decremented entry — a helper-only test would still pass
-    /// if `apply_top_up_reconciliation` stopped persisting.
+    /// if `reconcile_address_infos` stopped persisting.
     #[tokio::test]
-    async fn apply_top_up_reconciliation_persists_decremented_balance() {
+    async fn reconcile_address_infos_persists_decremented_balance() {
         use crate::broadcaster::SpvBroadcaster;
         use crate::events::PlatformEventManager;
         use crate::spv::SpvRuntime;
@@ -1303,7 +1503,7 @@ mod tests {
         let recorder = Arc::new(CapturingPersister::default());
 
         // Wallet wired to the capturing persister. The rest mirrors the
-        // short-circuit fixture — `apply_top_up_reconciliation` only touches
+        // short-circuit fixture — `reconcile_address_infos` only touches
         // provider / wallet_manager / persister.
         let sdk = Arc::new(dash_sdk::SdkBuilder::new_mock().build().expect("mock sdk"));
         let wallet_manager = Arc::new(RwLock::new(WalletManager::new(sdk.network)));
@@ -1346,23 +1546,247 @@ mod tests {
             }),
         );
 
-        wallet.apply_top_up_reconciliation(&address_infos).await;
+        wallet
+            .reconcile_address_infos(&address_infos, "test top-up")
+            .await;
 
         // The reconciliation must have PERSISTED the decremented entry — the
         // contract the original bug broke by discarding `address_infos`.
-        let stored = recorder.stored.lock().expect("persister mutex");
-        let entry = stored
-            .iter()
-            .filter_map(|cs| cs.platform_addresses.as_ref())
-            .flat_map(|pa| pa.addresses.iter())
-            .find(|e| e.address == addr)
-            .expect("a persisted platform-address entry for the spent address");
-        assert_eq!(entry.account_index, ACCOUNT);
+        // Scope the std mutex guard so it isn't held across the provider
+        // read await below.
+        {
+            let stored = recorder.stored.lock().expect("persister mutex");
+            let entry = stored
+                .iter()
+                .filter_map(|cs| cs.platform_addresses.as_ref())
+                .flat_map(|pa| pa.addresses.iter())
+                .find(|e| e.address == addr)
+                .expect("a persisted platform-address entry for the spent address");
+            assert_eq!(entry.account_index, ACCOUNT);
+            assert_eq!(
+                entry.funds.balance, 5,
+                "persists the proof's post-spend balance, not the stale pre-spend value"
+            );
+            assert_eq!(entry.funds.nonce, 4, "persists the bumped nonce");
+        }
+
+        // ...and the provider's committed `found` seed — the sync-diff
+        // baseline and the seed `current_balances()` hands the SDK — must
+        // agree with what was just applied, so reconciliation and the
+        // background sync stop diverging.
+        let guard = wallet.provider.read().await;
+        let seed: Vec<_> = guard
+            .as_ref()
+            .expect("provider present")
+            .current_balances()
+            .collect();
+        assert_eq!(seed.len(), 1);
         assert_eq!(
-            entry.funds.balance, 5,
-            "persists the proof's post-spend balance, not the stale pre-spend value"
+            seed[0].2,
+            funds(5, 4),
+            "committed found seed must carry the reconciled funds"
         );
-        assert_eq!(entry.funds.nonce, 4, "persists the bumped nonce");
+    }
+
+    /// Freshness guard: an entry whose nonce is below the committed seed's
+    /// (a background sync — or a later transition — already committed
+    /// fresher state) must be dropped, not applied over the fresher value.
+    #[test]
+    fn commit_reconciliation_drops_stale_nonce() {
+        use dash_sdk::query_types::AddressInfo;
+
+        let addr = p2pkh(0x11);
+        // Committed seed already at nonce 5 (e.g. the 15s background sync
+        // landed a fresher state while the proof was in flight).
+        let mut provider = provider_with_one_funded_address(addr, funds(700, 5));
+
+        let spent = PlatformAddress::P2pkh([0x11; 20]);
+        let mut address_infos = AddressInfos::new();
+        address_infos.insert(
+            spent,
+            Some(AddressInfo {
+                address: spent,
+                nonce: 3,
+                balance: 100,
+            }),
+        );
+
+        let outcome = provider.commit_reconciliation(&WALLET, &address_infos, &BTreeMap::new());
+
+        assert_eq!(outcome.resolved, 1);
+        assert_eq!(outcome.stale_skipped, 1);
+        assert!(
+            outcome.entries.is_empty(),
+            "stale entry must not be applied"
+        );
+        // The fresher committed funds survive.
+        let seed: Vec<_> = provider.current_balances().collect();
+        assert_eq!(seed.len(), 1);
+        assert_eq!(seed[0].2, funds(700, 5));
+    }
+
+    /// An entry identical to the committed seed is a no-op and is dropped
+    /// to avoid persister churn.
+    #[test]
+    fn commit_reconciliation_drops_unchanged_entry() {
+        use dash_sdk::query_types::AddressInfo;
+
+        let addr = p2pkh(0x11);
+        let mut provider = provider_with_one_funded_address(addr, funds(700, 5));
+
+        let same = PlatformAddress::P2pkh([0x11; 20]);
+        let mut address_infos = AddressInfos::new();
+        address_infos.insert(
+            same,
+            Some(AddressInfo {
+                address: same,
+                nonce: 5,
+                balance: 700,
+            }),
+        );
+
+        let outcome = provider.commit_reconciliation(&WALLET, &address_infos, &BTreeMap::new());
+
+        assert_eq!(outcome.resolved, 1);
+        assert_eq!(outcome.unchanged_skipped, 1);
+        assert!(outcome.entries.is_empty());
+    }
+
+    /// A fresh entry (nonce at or above the seed's) is applied and
+    /// committed to `found`, replacing the older funds.
+    #[test]
+    fn commit_reconciliation_commits_fresh_entry_to_found() {
+        use dash_sdk::query_types::AddressInfo;
+
+        let addr = p2pkh(0x11);
+        let mut provider = provider_with_one_funded_address(addr, funds(700, 3));
+
+        let spent = PlatformAddress::P2pkh([0x11; 20]);
+        let mut address_infos = AddressInfos::new();
+        address_infos.insert(
+            spent,
+            Some(AddressInfo {
+                address: spent,
+                nonce: 4,
+                balance: 50,
+            }),
+        );
+
+        let outcome = provider.commit_reconciliation(&WALLET, &address_infos, &BTreeMap::new());
+
+        assert_eq!(outcome.entries.len(), 1);
+        assert_eq!(outcome.entries[0].funds, funds(50, 4));
+        assert_eq!(outcome.entries[0].address_index, 0);
+        let seed: Vec<_> = provider.current_balances().collect();
+        assert_eq!(seed.len(), 1);
+        assert_eq!(seed[0].2, funds(50, 4));
+    }
+
+    /// Zero funds (balance 0, nonce 0) means the address was removed from
+    /// Platform state (fully consumed input). That removal is authoritative:
+    /// it bypasses the nonce guard and drops the address from the committed
+    /// `found` seed, mirroring the sync's absent handling.
+    #[test]
+    fn commit_reconciliation_zero_funds_removes_from_found() {
+        let addr = p2pkh(0x11);
+        let mut provider = provider_with_one_funded_address(addr, funds(700, 5));
+
+        let consumed = PlatformAddress::P2pkh([0x11; 20]);
+        let mut address_infos = AddressInfos::new();
+        // Drive elides the info for a fully consumed input.
+        address_infos.insert(consumed, None);
+
+        let outcome = provider.commit_reconciliation(&WALLET, &address_infos, &BTreeMap::new());
+
+        assert_eq!(outcome.entries.len(), 1);
+        assert_eq!(outcome.entries[0].funds, funds(0, 0));
+        assert!(
+            provider.current_balances().next().is_none(),
+            "consumed address must be dropped from the found seed"
+        );
+    }
+
+    /// The live-pool fallback must NOT resolve addresses belonging to an
+    /// account the provider doesn't track: there is no per-account state
+    /// to commit the funds into, so emitting the entry would violate the
+    /// contract that every emitted entry is committed to the `found` seed
+    /// (the applied balance would silently diverge from the sync-diff
+    /// baseline).
+    #[test]
+    fn commit_reconciliation_pool_fallback_skips_untracked_account() {
+        use dash_sdk::query_types::AddressInfo;
+
+        let known = p2pkh(0x11);
+        let mut provider = provider_with_one_funded_address(known, funds(700, 3));
+
+        // Live-pool address on an account (7) the provider has no state for.
+        let untracked = p2pkh(0x33);
+        let mut pool_indexes = BTreeMap::new();
+        pool_indexes.insert(untracked, (7u32, 0u32));
+
+        let untracked_addr = PlatformAddress::P2pkh([0x33; 20]);
+        let mut address_infos = AddressInfos::new();
+        address_infos.insert(
+            untracked_addr,
+            Some(AddressInfo {
+                address: untracked_addr,
+                nonce: 0,
+                balance: 9_999,
+            }),
+        );
+
+        let outcome = provider.commit_reconciliation(&WALLET, &address_infos, &pool_indexes);
+
+        assert_eq!(
+            outcome.resolved, 0,
+            "an untracked account's pool address must stay unresolved"
+        );
+        assert!(outcome.entries.is_empty());
+    }
+
+    /// An address missing from the provider bijection (derived since the
+    /// last sync, e.g. a fresh change address) resolves through the
+    /// live-pool fallback, and the pair is merged into the bijection so
+    /// `current_balances` can yield its committed funds.
+    #[test]
+    fn commit_reconciliation_pool_fallback_extends_bijection() {
+        use dash_sdk::query_types::AddressInfo;
+
+        let known = p2pkh(0x11);
+        let mut provider = provider_with_one_funded_address(known, funds(700, 3));
+
+        // Fresh change address: NOT in the bijection, only in the live pool.
+        let fresh = p2pkh(0x22);
+        let mut pool_indexes = BTreeMap::new();
+        pool_indexes.insert(fresh, (ACCOUNT, 9u32));
+
+        let fresh_addr = PlatformAddress::P2pkh([0x22; 20]);
+        let mut address_infos = AddressInfos::new();
+        address_infos.insert(
+            fresh_addr,
+            Some(AddressInfo {
+                address: fresh_addr,
+                nonce: 0,
+                balance: 1_234,
+            }),
+        );
+
+        let outcome = provider.commit_reconciliation(&WALLET, &address_infos, &pool_indexes);
+
+        assert_eq!(outcome.entries.len(), 1);
+        assert_eq!(
+            outcome.entries[0].address_index, 9,
+            "index resolved from the live-pool fallback"
+        );
+        // The bijection gained the pair, so the committed funds are part
+        // of the next sync's seed.
+        let seed: Vec<_> = provider.current_balances().collect();
+        let fresh_row = seed
+            .iter()
+            .find(|(_, a, _)| *a == fresh)
+            .expect("fresh address must appear in the found seed");
+        assert_eq!(fresh_row.0, (WALLET, ACCOUNT, 9));
+        assert_eq!(fresh_row.2, funds(1_234, 0));
     }
 
     /// `reset_sync_state` must zero the incremental watermark AND drop

--- a/packages/rs-platform-wallet/src/wallet/platform_addresses/provider.rs
+++ b/packages/rs-platform-wallet/src/wallet/platform_addresses/provider.rs
@@ -475,6 +475,36 @@ impl PlatformPaymentAddressProvider {
         self.last_known_recent_block = last_known_recent_block;
     }
 
+    /// Reset the incremental-sync watermark and drop every cached
+    /// balance so the next `sync_balances` performs a full
+    /// trunk/branch/compact rescan from genesis instead of an
+    /// incremental catch-up.
+    ///
+    /// Backs the host's "Clear" flow. Zeroing the three watermark
+    /// scalars alone is not enough: `found` doubles as the
+    /// `current_balances()` seed for the next pass (and the `before`
+    /// snapshot for the persistence diff), so a non-empty `found`
+    /// would re-seed the very balances Clear is meant to wipe.
+    /// `sync_timestamp == 0` is what flips `last_sync_timestamp()`
+    /// back to `None` and the SDK back into full-scan mode.
+    ///
+    /// The `addresses` bijection is intentionally preserved —
+    /// `prepare_for_sync` rebuilds `pending` from it each pass, so
+    /// keeping it avoids needless re-derivation while still forcing a
+    /// full rescan.
+    pub(crate) fn reset_sync_state(&mut self) {
+        self.sync_height = 0;
+        self.sync_timestamp = 0;
+        self.last_known_recent_block = 0;
+        self.per_wallet_in_sync.clear();
+        for state in self.per_wallet.values_mut() {
+            for account_state in state.values_mut() {
+                account_state.found.clear();
+                account_state.absent.clear();
+            }
+        }
+    }
+
     /// Diagnostic snapshot counts used by the read-only memory
     /// explorer surface on
     /// [`crate::manager::PlatformWalletManager::platform_address_provider_state_blocking`].
@@ -1103,6 +1133,40 @@ mod tests {
             account.address_credit_balance(&addr),
             0,
             "on_address_absent must zero the in-memory managed-account balance"
+        );
+    }
+
+    /// `reset_sync_state` must zero the incremental watermark AND drop
+    /// the cached `found` seed, so the next pass is a full rescan rather
+    /// than an incremental catch-up. This is the core of the platform
+    /// "Clear" fix — without the seed drop, a non-empty `found` would
+    /// re-seed the balances the next incremental round, and a non-zero
+    /// `sync_timestamp` would keep the SDK out of full-scan mode.
+    #[tokio::test]
+    async fn reset_sync_state_clears_watermark_and_seed() {
+        let addr = p2pkh(1);
+        let mut provider = provider_with_one_funded_address(addr, funds(294_627_247_940, 5));
+
+        // Simulate a wallet mid-incremental-sync: non-zero watermark and
+        // a populated balance seed.
+        provider.set_stored_sync_state(10, 20, 30);
+        assert_eq!(provider.last_sync_height(), 10);
+        assert_eq!(provider.last_sync_timestamp(), Some(20));
+        assert_eq!(provider.last_known_recent_block(), 30);
+        assert_eq!(provider.current_balances().count(), 1);
+
+        provider.reset_sync_state();
+
+        // Watermark fully zeroed → SDK drops back to full-scan mode
+        // (`last_sync_timestamp() == None` is the full-scan trigger).
+        assert_eq!(provider.last_sync_height(), 0);
+        assert_eq!(provider.last_sync_timestamp(), None);
+        assert_eq!(provider.last_known_recent_block(), 0);
+        // Seed emptied → nothing re-seeds the next incremental pass.
+        assert_eq!(
+            provider.current_balances().count(),
+            0,
+            "reset must drop the cached `found` seed"
         );
     }
 }

--- a/packages/rs-platform-wallet/src/wallet/platform_addresses/sync.rs
+++ b/packages/rs-platform-wallet/src/wallet/platform_addresses/sync.rs
@@ -153,13 +153,19 @@ impl PlatformAddressWallet {
         }
 
         provider.update_sync_state(&result);
-        drop(guard);
 
+        // Persist BEFORE releasing the provider lock. The reconciliation
+        // seam (`reconcile_address_infos`) serializes on this lock and
+        // persists its proof-attested entries while holding it too, so
+        // both writers' stores are totally ordered by the lock: whichever
+        // commits its seed later also lands on disk later, and an older
+        // diff can never overwrite a fresher row.
         if !cs.is_empty() {
             if let Err(e) = self.persister.store(cs.into()) {
                 tracing::error!("Failed to persist address sync changeset: {}", e);
             }
         }
+        drop(guard);
 
         Ok(result)
     }

--- a/packages/rs-platform-wallet/src/wallet/platform_addresses/transfer.rs
+++ b/packages/rs-platform-wallet/src/wallet/platform_addresses/transfer.rs
@@ -8,7 +8,6 @@ use dpp::version::PlatformVersion;
 use dpp::version::LATEST_PLATFORM_VERSION;
 use key_wallet::PlatformP2PKHAddress;
 
-use crate::changeset::Merge;
 use crate::wallet::PlatformAddressWallet;
 use crate::{PlatformAddressChangeSet, PlatformWalletError};
 use dash_sdk::platform::transition::transfer_address_funds::TransferAddressFunds;
@@ -250,73 +249,13 @@ impl PlatformAddressWallet {
             }
         };
 
-        let key_source = {
-            let guard = self.provider.read().await;
-            guard
-                .as_ref()
-                .and_then(|p| p.key_source(&self.wallet_id, account_index))
-        };
-
-        let mut wm = self.wallet_manager.write().await;
-        let mut cs = PlatformAddressChangeSet::default();
-        if let Some(info) = wm.get_wallet_info_mut(&self.wallet_id) {
-            if let Some(account) = info
-                .core_wallet
-                .platform_payment_managed_account_at_index_mut(account_index)
-            {
-                // `transfer_address_funds` returns address info for the full
-                // `inputs ∪ outputs` set, including external recipients the
-                // wallet does not own. Build a lookup of derived addresses
-                // up-front so we can skip non-owned entries — persisting a
-                // recipient under a fake derivation index would poison the
-                // account's address map on restore.
-                let owned: std::collections::BTreeMap<PlatformP2PKHAddress, u32> = account
-                    .addresses
-                    .addresses
-                    .iter()
-                    .filter_map(|(&idx, info)| {
-                        match PlatformP2PKHAddress::from_address(&info.address) {
-                            Ok(p) => Some((p, idx)),
-                            Err(e) => {
-                                tracing::warn!(
-                                    address = %info.address,
-                                    index = idx,
-                                    error = %e,
-                                    "skipping account address that failed P2PKH conversion",
-                                );
-                                None
-                            }
-                        }
-                    })
-                    .collect();
-
-                for entry in build_transfer_persistence_entries(
-                    self.wallet_id,
-                    account_index,
-                    &owned,
-                    address_infos.iter().map(|(a, i)| (a, i.as_ref())),
-                ) {
-                    account.set_address_credit_balance(
-                        entry.address,
-                        entry.funds.balance,
-                        key_source.as_ref(),
-                    );
-                    cs.addresses.push(entry);
-                }
-            }
-        }
-        drop(wm);
-
-        // Mirror `sync.rs`: persist post-broadcast balances so a restart
-        // doesn't reseed `auto_select_inputs` from stale rows. Log-on-error
-        // because the on-chain transition already succeeded.
-        if !cs.is_empty() {
-            if let Err(e) = self.persister.store(cs.clone().into()) {
-                tracing::error!("Failed to persist transfer changeset: {}", e);
-            }
-        }
-
-        Ok(cs)
+        // `transfer_address_funds` returns address info for the full
+        // `inputs ∪ outputs` set, including external recipients the wallet
+        // does not own — the shared seam filters those out, applies the
+        // proof-attested balances, updates the sync seed, and persists.
+        Ok(self
+            .reconcile_address_infos(&address_infos, "address transfer")
+            .await)
     }
 
     /// Transfer credits with an address-keyed fee strategy and an optional
@@ -608,56 +547,6 @@ impl PlatformAddressWallet {
 
         remaining_fee
     }
-}
-
-/// Translate `transfer_address_funds`'s `inputs ∪ outputs` address infos into
-/// the persistence-changeset entries for this wallet. Non-P2PKH addresses and
-/// addresses outside `owned` (i.e. external recipients) are filtered out — the
-/// caller persists only entries that belong to the wallet's derived address
-/// pool. Missing per-address info defaults to zero balance / zero nonce, which
-/// matches the on-chain post-transition state for a fully consumed input.
-fn build_transfer_persistence_entries<'a, I>(
-    wallet_id: [u8; 32],
-    account_index: u32,
-    owned: &BTreeMap<PlatformP2PKHAddress, u32>,
-    address_infos: I,
-) -> Vec<crate::PlatformAddressBalanceEntry>
-where
-    I: IntoIterator<
-        Item = (
-            &'a PlatformAddress,
-            Option<&'a dash_sdk::query_types::AddressInfo>,
-        ),
-    >,
-{
-    let mut entries = Vec::new();
-    for (addr, maybe_info) in address_infos {
-        let PlatformAddress::P2pkh(hash) = addr else {
-            continue;
-        };
-        let p2pkh = PlatformP2PKHAddress::new(*hash);
-        let Some(&address_index) = owned.get(&p2pkh) else {
-            continue;
-        };
-        let funds = match maybe_info {
-            Some(ai) => dash_sdk::platform::address_sync::AddressFunds {
-                balance: ai.balance,
-                nonce: ai.nonce,
-            },
-            None => dash_sdk::platform::address_sync::AddressFunds {
-                balance: 0,
-                nonce: 0,
-            },
-        };
-        entries.push(crate::PlatformAddressBalanceEntry {
-            wallet_id,
-            account_index,
-            address_index,
-            address: p2pkh,
-            funds,
-        });
-    }
-    entries
 }
 
 /// Build the auto-selection candidate list: keep only addresses whose balance
@@ -1991,101 +1880,10 @@ mod auto_select_tests {
         assert!(matches!(err, PlatformWalletError::AddressOperation(_)));
     }
 
-    /// CMT-002: `transfer_address_funds` returns address info for the full
-    /// `inputs ∪ outputs` set, including external recipients. The persistence
-    /// builder must keep entries for wallet-owned addresses only — persisting
-    /// a recipient under a fabricated derivation index would poison the
-    /// account's address map on restore.
-    #[test]
-    fn persistence_filter_drops_external_recipients() {
-        use dash_sdk::query_types::AddressInfo;
-
-        let wallet_id = [0xAAu8; 32];
-        let account_index = 0u32;
-
-        let owned_input = PlatformP2PKHAddress::new([0x01; 20]);
-        // External recipient — not in `owned`.
-        let external_recipient_hash = [0xEE; 20];
-        let external_recipient = PlatformAddress::P2pkh(external_recipient_hash);
-        let owned_input_addr = PlatformAddress::P2pkh([0x01; 20]);
-
-        // Wallet's derived pool: only the input address.
-        let mut owned: BTreeMap<PlatformP2PKHAddress, u32> = BTreeMap::new();
-        owned.insert(owned_input, 7);
-
-        // The proved address-info set drive returns spans inputs ∪ outputs.
-        // We model the input fully consumed (balance = 0, nonce bumped) and
-        // the external recipient receiving credits.
-        let input_info = AddressInfo {
-            address: owned_input_addr,
-            nonce: 1,
-            balance: 0,
-        };
-        let recipient_info = AddressInfo {
-            address: external_recipient,
-            nonce: 0,
-            balance: 5_000_000,
-        };
-        let address_infos: BTreeMap<PlatformAddress, Option<AddressInfo>> = [
-            (owned_input_addr, Some(input_info)),
-            (external_recipient, Some(recipient_info)),
-        ]
-        .into_iter()
-        .collect();
-
-        let entries = build_transfer_persistence_entries(
-            wallet_id,
-            account_index,
-            &owned,
-            address_infos.iter().map(|(a, i)| (a, i.as_ref())),
-        );
-
-        assert_eq!(entries.len(), 1, "external recipient must be filtered out");
-        let entry = &entries[0];
-        assert_eq!(entry.wallet_id, wallet_id);
-        assert_eq!(entry.account_index, account_index);
-        assert_eq!(entry.address, owned_input);
-        assert_eq!(
-            entry.address_index, 7,
-            "owned address must keep its real derivation index"
-        );
-        assert_eq!(entry.funds.balance, 0);
-        assert_eq!(entry.funds.nonce, 1);
-        assert!(
-            !entries
-                .iter()
-                .any(|e| e.address == PlatformP2PKHAddress::new(external_recipient_hash)),
-            "external recipient must not appear in any entry",
-        );
-    }
-
-    /// Missing per-address info defaults to zero balance / zero nonce — this
-    /// is the on-chain post-transition state for a fully consumed input that
-    /// drive elided from the proved set.
-    #[test]
-    fn persistence_filter_treats_missing_info_as_zero() {
-        let wallet_id = [0xBBu8; 32];
-        let account_index = 3u32;
-        let owned_addr = PlatformP2PKHAddress::new([0x42; 20]);
-        let owned_platform = PlatformAddress::P2pkh([0x42; 20]);
-
-        let mut owned: BTreeMap<PlatformP2PKHAddress, u32> = BTreeMap::new();
-        owned.insert(owned_addr, 11);
-
-        let address_infos: BTreeMap<PlatformAddress, Option<dash_sdk::query_types::AddressInfo>> =
-            [(owned_platform, None)].into_iter().collect();
-
-        let entries = build_transfer_persistence_entries(
-            wallet_id,
-            account_index,
-            &owned,
-            address_infos.iter().map(|(a, i)| (a, i.as_ref())),
-        );
-        assert_eq!(entries.len(), 1);
-        assert_eq!(entries[0].funds.balance, 0);
-        assert_eq!(entries[0].funds.nonce, 0);
-        assert_eq!(entries[0].address_index, 11);
-    }
+    // The `inputs ∪ outputs` translation (external-recipient filtering,
+    // missing-info-as-zero) now lives in the shared reconciliation seam —
+    // see `build_entries_drops_unresolved_and_zeroes_missing_info` in
+    // `provider.rs`.
 
     /// Signer used only by tests that exercise paths which short-circuit
     /// before any signing happens. Never produces a signature.

--- a/packages/rs-platform-wallet/src/wallet/platform_addresses/wallet.rs
+++ b/packages/rs-platform-wallet/src/wallet/platform_addresses/wallet.rs
@@ -1,9 +1,11 @@
 //! Platform address wallet for DIP-17 platform payment addresses.
 
+use std::collections::BTreeMap;
 use std::sync::Arc;
 
 use dpp::address_funds::PlatformAddress;
 use dpp::fee::Credits;
+use key_wallet::PlatformP2PKHAddress;
 use tokio::sync::RwLock;
 
 use crate::broadcaster::SpvBroadcaster;
@@ -28,8 +30,11 @@ pub struct PlatformAddressWallet {
     pub(crate) wallet_id: WalletId,
     /// Single provider covering every platform payment account on the
     /// wallet. `None` until [`initialize`] runs so that no-account
-    /// wallets don't allocate empty state. Sync takes a `write` lock;
-    /// transfer/withdraw paths take `read` for key_source lookups.
+    /// wallets don't allocate empty state. Both sync and the
+    /// post-broadcast reconciliation seam
+    /// ([`reconcile_address_infos`](Self::reconcile_address_infos))
+    /// take the `write` lock across their whole apply sequence, which
+    /// is what serializes them against each other.
     pub(crate) provider: Arc<RwLock<Option<PlatformPaymentAddressProvider>>>,
     /// Shared asset-lock manager. Threaded in so the orchestrated
     /// `fund_from_asset_lock` path can drive
@@ -159,72 +164,152 @@ impl PlatformAddressWallet {
         Ok(())
     }
 
-    /// Reconcile platform-address balances after an identity
-    /// top-up-from-addresses, from the proof-attested `address_infos` the SDK
-    /// returns. Each spent address's `(account_index, address_index)` is
-    /// resolved from the persisted provider state — covering addresses
-    /// restored from disk that are no longer in a live derived pool — its
-    /// in-memory balance is set to the proof's post-spend value, and a
-    /// `PlatformAddressChangeSet` is persisted so the displayed balance and
-    /// the next input selection both reflect on-chain reality.
+    /// Reconcile platform-address balances from the proof-attested
+    /// `address_infos` an address-funds state transition returns (transfer,
+    /// withdrawal, asset-lock funding, identity registration / top-up /
+    /// credit transfer). This is the single apply-and-persist seam every
+    /// flow routes through.
     ///
-    /// Without this, the local balances stay frozen at their pre-top-up
-    /// values: the wallet keeps displaying a stale "Platform Balance" and the
-    /// next top-up over-selects the now-drained addresses, which Drive
-    /// rejects with "Insufficient combined address balances".
+    /// Each address's `(account_index, address_index)` is resolved through
+    /// the provider's persisted `index <-> address` bijection — covering
+    /// addresses restored from disk that are no longer in a live derived
+    /// pool — with the live pools as fallback for addresses derived since
+    /// the last sync (e.g. a fresh change address). Non-P2PKH addresses and
+    /// addresses the wallet doesn't own (external recipients) are skipped.
     ///
-    /// Locks are released before persisting (the persistence backend runs its
-    /// callbacks inline), and errors are logged rather than propagated —
-    /// Platform already accepted the top-up, and a later sync reconciles.
-    pub async fn apply_top_up_reconciliation(&self, address_infos: &AddressInfos) {
-        // Resolve spent addresses to balance entries under the provider read
-        // lock, then drop it.
-        let entries = {
-            let guard = self.provider.read().await;
-            match guard
-                .as_ref()
-                .and_then(|p| p.per_wallet_state(&self.wallet_id))
-            {
-                Some(state) => {
-                    let per_account: Vec<_> = state
-                        .iter()
-                        .map(|(idx, acct)| (*idx, acct.addresses()))
-                        .collect();
-                    super::provider::build_top_up_balance_entries(
-                        self.wallet_id,
-                        &per_account,
-                        address_infos,
-                    )
-                }
-                None => {
-                    tracing::warn!(
-                        wallet_id = ?self.wallet_id,
-                        "Top-up reconciliation skipped: no platform-address \
-                         provider state for this wallet; local balances stay \
-                         stale until the next platform-address sync"
-                    );
-                    return;
-                }
-            }
-        };
-        if entries.is_empty() {
-            if !address_infos.is_empty() {
-                tracing::warn!(
-                    wallet_id = ?self.wallet_id,
-                    spent_addresses = address_infos.len(),
-                    "Top-up reconciliation resolved none of the proof's spent \
-                     addresses through the persisted provider state; local \
-                     balances stay stale until the next platform-address sync"
-                );
-            }
-            return;
+    /// For each surviving entry the in-memory account balance is set to the
+    /// proof's attested value, the provider's committed `found` seed is
+    /// updated (so the background sync's diff baseline agrees with what we
+    /// just applied), and a `PlatformAddressChangeSet` is persisted so the
+    /// displayed balance and the next input selection both reflect on-chain
+    /// reality. Without this, local balances stay frozen at their
+    /// pre-transition values: the wallet displays a stale "Platform
+    /// Balance" and the next input selection over-selects drained
+    /// addresses, which Drive rejects with "Insufficient combined address
+    /// balances".
+    ///
+    /// A freshness guard protects against racing the 15s background sync:
+    /// entries whose nonce is below the committed seed's are dropped (a
+    /// fresher state was already committed), see
+    /// [`PlatformPaymentAddressProvider::commit_reconciliation`]. The
+    /// provider write lock is held across the provider commit, the
+    /// account-balance write, AND the persist — mirroring
+    /// [`sync_balances`](Self::sync_balances), so the two writers' stores
+    /// are totally ordered by the lock and a sync pass can never
+    /// interleave between (or persist across) the seam's steps; the lock
+    /// order (provider → wallet manager) matches the sync callbacks.
+    ///
+    /// Persistence errors are logged rather than propagated — Platform
+    /// already accepted the transition, and a later sync reconciles.
+    ///
+    /// [`PlatformPaymentAddressProvider::commit_reconciliation`]:
+    /// super::provider::PlatformPaymentAddressProvider::commit_reconciliation
+    pub async fn reconcile_address_infos(
+        &self,
+        address_infos: &AddressInfos,
+        context: &'static str,
+    ) -> crate::PlatformAddressChangeSet {
+        if address_infos.is_empty() {
+            return crate::PlatformAddressChangeSet::default();
         }
-        // Apply the proof-attested post-spend balances in memory, then drop
-        // the write lock.
+
+        let mut guard = self.provider.write().await;
+        let Some(provider) = guard.as_mut() else {
+            tracing::warn!(
+                wallet_id = ?self.wallet_id,
+                context,
+                "Address reconciliation skipped: no platform-address \
+                 provider for this wallet; local balances stay stale \
+                 until the next platform-address sync"
+            );
+            return crate::PlatformAddressChangeSet::default();
+        };
+        if provider.per_wallet_state(&self.wallet_id).is_none() {
+            tracing::warn!(
+                wallet_id = ?self.wallet_id,
+                context,
+                "Address reconciliation skipped: no platform-address \
+                 provider state for this wallet; local balances stay \
+                 stale until the next platform-address sync"
+            );
+            return crate::PlatformAddressChangeSet::default();
+        }
+
+        // Live-pool fallback indexes for addresses derived since the last
+        // sync (not yet merged into the provider bijection). Taking the
+        // wallet-manager read lock while holding the provider write lock
+        // follows the provider → wallet-manager order the sync callbacks
+        // use.
+        let pool_indexes: BTreeMap<PlatformP2PKHAddress, (u32, u32)> = {
+            let wm = self.wallet_manager.read().await;
+            let mut out = BTreeMap::new();
+            if let Some(info) = wm.get_wallet_info(&self.wallet_id) {
+                for account in info.core_wallet.all_platform_payment_managed_accounts() {
+                    // The provider tracks key-class-0 accounts only; other
+                    // key classes have no per-account provider state to
+                    // reconcile against.
+                    if account.key_class != 0 {
+                        continue;
+                    }
+                    for (&index, addr_info) in &account.addresses.addresses {
+                        if let Ok(p2pkh) = PlatformP2PKHAddress::from_address(&addr_info.address) {
+                            out.entry(p2pkh).or_insert((account.account, index));
+                        }
+                    }
+                }
+            }
+            out
+        };
+
+        let outcome = provider.commit_reconciliation(&self.wallet_id, address_infos, &pool_indexes);
+
+        if outcome.resolved == 0 {
+            tracing::warn!(
+                wallet_id = ?self.wallet_id,
+                context,
+                proof_addresses = address_infos.len(),
+                "Address reconciliation resolved none of the proof's \
+                 addresses to a wallet-owned slot. Expected when every \
+                 address belongs to a third party; otherwise local \
+                 balances stay stale until the next platform-address sync"
+            );
+            return crate::PlatformAddressChangeSet::default();
+        }
+        if outcome.stale_skipped > 0 || outcome.unchanged_skipped > 0 {
+            tracing::debug!(
+                wallet_id = ?self.wallet_id,
+                context,
+                stale_skipped = outcome.stale_skipped,
+                unchanged_skipped = outcome.unchanged_skipped,
+                "Address reconciliation dropped entries superseded by (or \
+                 identical to) the committed sync seed"
+            );
+        }
+        if outcome.entries.is_empty() {
+            return crate::PlatformAddressChangeSet::default();
+        }
+
+        // Apply the proof-attested balances to the managed accounts while
+        // STILL holding the provider write lock, so a background sync can't
+        // interleave between the provider commit above and this write.
+        // The per-account key source drives gap-limit extension when a
+        // previously unfunded address (e.g. a change output) becomes funded.
         {
+            let key_sources: BTreeMap<u32, key_wallet::KeySource> = outcome
+                .entries
+                .iter()
+                .map(|e| e.account_index)
+                .collect::<std::collections::BTreeSet<_>>()
+                .into_iter()
+                .filter_map(|account_index| {
+                    provider
+                        .key_source(&self.wallet_id, account_index)
+                        .map(|ks| (account_index, ks))
+                })
+                .collect();
             let mut wm = self.wallet_manager.write().await;
             if let Some(info) = wm.get_wallet_info_mut(&self.wallet_id) {
-                for entry in &entries {
+                for entry in &outcome.entries {
                     if let Some(account) = info
                         .core_wallet
                         .platform_payment_managed_account_at_index_mut(entry.account_index)
@@ -232,25 +317,36 @@ impl PlatformAddressWallet {
                         account.set_address_credit_balance(
                             entry.address,
                             entry.funds.balance,
-                            None,
+                            key_sources.get(&entry.account_index),
                         );
                     }
                 }
             }
         }
-        // Persist with no locks held.
+        // Persist BEFORE releasing the provider lock, mirroring
+        // `sync_balances`. Both writers persisting inside the same
+        // critical section totally orders the stores with the lock: a
+        // sync pass (or another reconciliation) that commits a fresher
+        // seed after us also persists after us, so an older row can
+        // never overwrite a fresher one on disk. Persistence callbacks
+        // must not re-enter wallet APIs (the pre-existing contract —
+        // stores already run under the wallet-manager write lock
+        // elsewhere).
         let cs = crate::PlatformAddressChangeSet {
-            addresses: entries,
+            addresses: outcome.entries,
             ..Default::default()
         };
-        if let Err(e) = self.persister.store(cs.into()) {
+        if let Err(e) = self.persister.store(cs.clone().into()) {
             tracing::error!(
+                context,
                 error = %e,
-                "Failed to persist top-up platform-address reconciliation; \
+                "Failed to persist platform-address reconciliation; \
                  in-memory balances are updated but durable rows stay stale \
                  until the next platform-address sync"
             );
         }
+        drop(guard);
+        cs
     }
 
     /// Get the network from the SDK.

--- a/packages/rs-platform-wallet/src/wallet/platform_addresses/wallet.rs
+++ b/packages/rs-platform-wallet/src/wallet/platform_addresses/wallet.rs
@@ -16,6 +16,8 @@ use crate::wallet::persister::WalletPersister;
 
 use super::provider::PlatformPaymentAddressProvider;
 
+use dash_sdk::query_types::AddressInfos;
+
 /// Platform address wallet providing DIP-17 platform payment address functionality.
 #[derive(Clone)]
 pub struct PlatformAddressWallet {
@@ -155,6 +157,100 @@ impl PlatformAddressWallet {
         let mut guard = self.provider.write().await;
         *guard = Some(provider);
         Ok(())
+    }
+
+    /// Reconcile platform-address balances after an identity
+    /// top-up-from-addresses, from the proof-attested `address_infos` the SDK
+    /// returns. Each spent address's `(account_index, address_index)` is
+    /// resolved from the persisted provider state — covering addresses
+    /// restored from disk that are no longer in a live derived pool — its
+    /// in-memory balance is set to the proof's post-spend value, and a
+    /// `PlatformAddressChangeSet` is persisted so the displayed balance and
+    /// the next input selection both reflect on-chain reality.
+    ///
+    /// Without this, the local balances stay frozen at their pre-top-up
+    /// values: the wallet keeps displaying a stale "Platform Balance" and the
+    /// next top-up over-selects the now-drained addresses, which Drive
+    /// rejects with "Insufficient combined address balances".
+    ///
+    /// Locks are released before persisting (the persistence backend runs its
+    /// callbacks inline), and errors are logged rather than propagated —
+    /// Platform already accepted the top-up, and a later sync reconciles.
+    pub async fn apply_top_up_reconciliation(&self, address_infos: &AddressInfos) {
+        // Resolve spent addresses to balance entries under the provider read
+        // lock, then drop it.
+        let entries = {
+            let guard = self.provider.read().await;
+            match guard
+                .as_ref()
+                .and_then(|p| p.per_wallet_state(&self.wallet_id))
+            {
+                Some(state) => {
+                    let per_account: Vec<_> = state
+                        .iter()
+                        .map(|(idx, acct)| (*idx, acct.addresses()))
+                        .collect();
+                    super::provider::build_top_up_balance_entries(
+                        self.wallet_id,
+                        &per_account,
+                        address_infos,
+                    )
+                }
+                None => {
+                    tracing::warn!(
+                        wallet_id = ?self.wallet_id,
+                        "Top-up reconciliation skipped: no platform-address \
+                         provider state for this wallet; local balances stay \
+                         stale until the next platform-address sync"
+                    );
+                    return;
+                }
+            }
+        };
+        if entries.is_empty() {
+            if !address_infos.is_empty() {
+                tracing::warn!(
+                    wallet_id = ?self.wallet_id,
+                    spent_addresses = address_infos.len(),
+                    "Top-up reconciliation resolved none of the proof's spent \
+                     addresses through the persisted provider state; local \
+                     balances stay stale until the next platform-address sync"
+                );
+            }
+            return;
+        }
+        // Apply the proof-attested post-spend balances in memory, then drop
+        // the write lock.
+        {
+            let mut wm = self.wallet_manager.write().await;
+            if let Some(info) = wm.get_wallet_info_mut(&self.wallet_id) {
+                for entry in &entries {
+                    if let Some(account) = info
+                        .core_wallet
+                        .platform_payment_managed_account_at_index_mut(entry.account_index)
+                    {
+                        account.set_address_credit_balance(
+                            entry.address,
+                            entry.funds.balance,
+                            None,
+                        );
+                    }
+                }
+            }
+        }
+        // Persist with no locks held.
+        let cs = crate::PlatformAddressChangeSet {
+            addresses: entries,
+            ..Default::default()
+        };
+        if let Err(e) = self.persister.store(cs.into()) {
+            tracing::error!(
+                error = %e,
+                "Failed to persist top-up platform-address reconciliation; \
+                 in-memory balances are updated but durable rows stay stale \
+                 until the next platform-address sync"
+            );
+        }
     }
 
     /// Get the network from the SDK.

--- a/packages/rs-platform-wallet/src/wallet/platform_addresses/wallet.rs
+++ b/packages/rs-platform-wallet/src/wallet/platform_addresses/wallet.rs
@@ -223,6 +223,43 @@ impl PlatformAddressWallet {
         .await;
     }
 
+    /// Reset the platform-address sync watermark and drop every cached
+    /// balance for this wallet, forcing a full trunk/branch/compact
+    /// rescan on the next `sync_balances`.
+    ///
+    /// Backs the host's "Clear" flow. Clears BOTH in-memory balance
+    /// stores a resume would otherwise read from:
+    ///   * the provider's incremental seed (`found`) + watermark — what
+    ///     makes a resync "fast" (see
+    ///     [`PlatformPaymentAddressProvider::reset_sync_state`]);
+    ///   * each `ManagedPlatformAccount`'s `address_balances` map — what
+    ///     [`addresses_with_balances`](Self::addresses_with_balances) /
+    ///     `total_credits` and the transfer/withdraw spend paths read.
+    ///     Without this the UI/spend paths would keep reporting stale
+    ///     balances until the next full sync re-zeroed them via the
+    ///     absent diff.
+    ///
+    /// Does NOT route through [`apply_sync_state`] — that helper's
+    /// all-None early-return guard is meant for persisted-state replay
+    /// and is irrelevant here. The two locks are taken sequentially
+    /// (one released before the next is acquired), so there is no
+    /// nested-lock hazard; this mirrors the ordering rationale in
+    /// [`initialize_from_persisted`].
+    pub async fn reset_sync_state(&self) {
+        {
+            let mut wm = self.wallet_manager.write().await;
+            if let Some(info) = wm.get_wallet_info_mut(&self.wallet_id) {
+                for account in info.core_wallet.all_platform_payment_managed_accounts_mut() {
+                    account.clear_balances();
+                }
+            }
+        }
+        let mut guard = self.provider.write().await;
+        if let Some(provider) = guard.as_mut() {
+            provider.reset_sync_state();
+        }
+    }
+
     /// Internal accessor for the diagnostic snapshot path on
     /// [`crate::manager::PlatformWalletManager`]. The provider lock is
     /// otherwise crate-private — the manager-level snapshot needs to

--- a/packages/rs-platform-wallet/src/wallet/platform_addresses/withdrawal.rs
+++ b/packages/rs-platform-wallet/src/wallet/platform_addresses/withdrawal.rs
@@ -106,62 +106,14 @@ impl PlatformAddressWallet {
             }
         };
 
-        // Get the cached key source from the unified provider for gap
-        // limit maintenance.
-        let key_source = {
-            let guard = self.provider.read().await;
-            guard
-                .as_ref()
-                .and_then(|p| p.key_source(&self.wallet_id, account_index))
-        };
-
-        // Update balances in the ManagedPlatformAccount.
-        let mut wm = self.wallet_manager.write().await;
-        let mut cs = PlatformAddressChangeSet::default();
-        if let Some(info) = wm.get_wallet_info_mut(&self.wallet_id) {
-            if let Some(account) = info
-                .core_wallet
-                .platform_payment_managed_account_at_index_mut(account_index)
-            {
-                for (addr, maybe_info) in address_infos.iter() {
-                    let PlatformAddress::P2pkh(hash) = addr else {
-                        continue;
-                    };
-                    let p2pkh = PlatformP2PKHAddress::new(*hash);
-                    let funds = match maybe_info {
-                        Some(ai) => dash_sdk::platform::address_sync::AddressFunds {
-                            balance: ai.balance,
-                            nonce: ai.nonce,
-                        },
-                        None => dash_sdk::platform::address_sync::AddressFunds {
-                            balance: 0,
-                            nonce: 0,
-                        },
-                    };
-                    account.set_address_credit_balance(p2pkh, funds.balance, key_source.as_ref());
-                    let address_index = account
-                        .addresses
-                        .addresses
-                        .iter()
-                        .find_map(|(&idx, info)| {
-                            PlatformP2PKHAddress::from_address(&info.address)
-                                .ok()
-                                .filter(|found| *found == p2pkh)
-                                .map(|_| idx)
-                        })
-                        .unwrap_or(0);
-                    cs.addresses.push(crate::PlatformAddressBalanceEntry {
-                        wallet_id: self.wallet_id,
-                        account_index,
-                        address_index,
-                        address: p2pkh,
-                        funds,
-                    });
-                }
-            }
-        }
-
-        Ok(cs)
+        // Apply + persist the proof-attested post-withdrawal balances via
+        // the shared seam. Input addresses resolve through the provider's
+        // persisted index bijection (with live-pool fallback), so a
+        // restored address that is no longer in a live derived pool keeps
+        // its real derivation index instead of corrupting index 0.
+        Ok(self
+            .reconcile_address_infos(&address_infos, "address withdrawal")
+            .await)
     }
 
     /// Auto-select all funded addresses for withdrawal. Withdrawals consume

--- a/packages/rs-platform-wallet/src/wallet/platform_wallet.rs
+++ b/packages/rs-platform-wallet/src/wallet/platform_wallet.rs
@@ -24,8 +24,13 @@ use crate::broadcaster::SpvBroadcaster;
 use crate::changeset::{
     ClientStartState, PersistenceError, PlatformWalletChangeSet, PlatformWalletPersistence,
 };
-#[cfg(feature = "shielded")]
 use crate::error::PlatformWalletError;
+use dash_sdk::platform::transition::put_settings::PutSettings;
+use dpp::address_funds::PlatformAddress;
+use dpp::fee::Credits;
+use dpp::identity::signer::Signer;
+use dpp::identity::{Identity, IdentityPublicKey};
+use dpp::prelude::Identifier;
 
 /// Unique identifier for a wallet (32-byte hash).
 pub type WalletId = [u8; 32];
@@ -216,6 +221,128 @@ impl PlatformWallet {
             guard: self.wallet_manager.blocking_write(),
             wallet_id: self.wallet_id,
         }
+    }
+
+    // -----------------------------------------------------------------
+    // Address-funded identity flows
+    //
+    // Composite orchestration: each flow spends or credits platform
+    // addresses through the identity sub-wallet, then routes the
+    // proof-attested `AddressInfos` through the platform-address
+    // sub-wallet's shared reconciliation seam
+    // (`PlatformAddressWallet::reconcile_address_infos`) so displayed
+    // balances and the next input selection reflect on-chain reality
+    // without waiting for the next BLAST sync round. Only this struct
+    // owns both sub-wallets, which is why the composition lives here.
+    // -----------------------------------------------------------------
+
+    /// Top up an existing identity's credit balance by spending platform
+    /// address balances, then reconcile the spent addresses' local
+    /// balances and nonces from the proof-attested post-spend
+    /// `AddressInfos`.
+    ///
+    /// See [`IdentityWallet::top_up_from_addresses`] for the identity-side
+    /// semantics. Reconciliation failures are logged inside the seam
+    /// rather than propagated — Platform already accepted the top-up, and
+    /// a later sync reconciles.
+    ///
+    /// Returns the identity's new credit balance.
+    pub async fn top_up_from_addresses<S: Signer<PlatformAddress> + Send + Sync>(
+        &self,
+        identity_id: &Identifier,
+        inputs: BTreeMap<PlatformAddress, Credits>,
+        address_signer: &S,
+        settings: Option<PutSettings>,
+    ) -> Result<Credits, PlatformWalletError> {
+        let (address_infos, new_balance) = self
+            .identity
+            .top_up_from_addresses(identity_id, inputs, address_signer, settings)
+            .await?;
+        self.platform
+            .reconcile_address_infos(&address_infos, "identity top-up")
+            .await;
+        Ok(new_balance)
+    }
+
+    /// Register a new identity funded by platform-address balances, then
+    /// reconcile the spent funding addresses' local balances and nonces
+    /// from the proof-attested post-spend `AddressInfos`.
+    ///
+    /// See [`IdentityWallet::register_from_addresses`] for the
+    /// identity-side semantics (placeholder construction, signer
+    /// responsibilities, local-manager registration). Reconciliation
+    /// failures are logged inside the seam rather than propagated —
+    /// Platform already accepted the registration, and a later sync
+    /// reconciles.
+    ///
+    /// Returns the registered identity.
+    #[allow(clippy::too_many_arguments)]
+    pub async fn register_from_addresses<IS, AS>(
+        &self,
+        identity: &Identity,
+        inputs: BTreeMap<PlatformAddress, Credits>,
+        output: Option<(PlatformAddress, Credits)>,
+        identity_index: u32,
+        identity_signer: &IS,
+        input_address_signer: &AS,
+        settings: Option<PutSettings>,
+    ) -> Result<Identity, PlatformWalletError>
+    where
+        IS: Signer<IdentityPublicKey>,
+        AS: Signer<PlatformAddress> + Send + Sync,
+    {
+        let (registered_identity, address_infos) = self
+            .identity
+            .register_from_addresses(
+                identity,
+                inputs,
+                output,
+                identity_index,
+                identity_signer,
+                input_address_signer,
+                settings,
+            )
+            .await?;
+        self.platform
+            .reconcile_address_infos(&address_infos, "identity registration")
+            .await;
+        Ok(registered_identity)
+    }
+
+    /// Transfer credits from an identity to platform addresses, then
+    /// reconcile any wallet-owned recipient addresses' local balances
+    /// from the proof-attested `AddressInfos` (recipients belonging to
+    /// third parties are skipped by the seam).
+    ///
+    /// See [`IdentityWallet::transfer_credits_to_addresses_with_external_signer`]
+    /// for the identity-side semantics. Reconciliation failures are
+    /// logged inside the seam rather than propagated — Platform already
+    /// accepted the transfer, and a later sync reconciles.
+    ///
+    /// Returns the sender identity's new credit balance.
+    pub async fn transfer_credits_to_addresses_with_external_signer<S>(
+        &self,
+        identity_id: &Identifier,
+        recipient_addresses: BTreeMap<PlatformAddress, Credits>,
+        signer: &S,
+        settings: Option<PutSettings>,
+    ) -> Result<Credits, PlatformWalletError>
+    where
+        S: Signer<IdentityPublicKey> + Send + Sync,
+    {
+        let (address_infos, new_balance) = self
+            .identity
+            .transfer_credits_to_addresses_with_external_signer(
+                identity_id,
+                recipient_addresses,
+                signer,
+                settings,
+            )
+            .await?;
+        self.platform
+            .reconcile_address_infos(&address_infos, "credit transfer to addresses")
+            .await;
+        Ok(new_balance)
     }
 
     /// Non-blocking read-lock. Returns `None` if the lock is currently

--- a/packages/rs-platform-wallet/src/wallet/shielded/coordinator.rs
+++ b/packages/rs-platform-wallet/src/wallet/shielded/coordinator.rs
@@ -51,7 +51,7 @@
 //!
 //! [`sync_notes_across`]: super::sync::sync_notes_across
 
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, HashSet};
 use std::path::PathBuf;
 use std::sync::Arc;
 
@@ -80,7 +80,7 @@ use tokio::sync::RwLock;
 
 use super::file_store::FileBackedShieldedStore;
 use super::keys::AccountViewingKeys;
-use super::store::{ShieldedStore, SubwalletId};
+use super::store::{ShieldedStore, StalePendingSpend, SubwalletId};
 use super::CAUGHT_UP_COOLDOWN;
 use crate::manager::shielded_sync::{ShieldedSyncPassSummary, WalletShieldedOutcome};
 use crate::wallet::persister::WalletPersister;
@@ -593,6 +593,21 @@ impl NetworkShieldedCoordinator {
             return summary;
         }
 
+        // Snapshot armed reservations and prefetch Platform's recorded
+        // anchor set BEFORE the note scan. The release pass after the scan
+        // may only act on this pre-scan pair: an anchor already absent from
+        // a PRE-scan set was pruned before the scan began, so a spend that
+        // did execute did so at a height the scan covers — the scan's
+        // spent-note reconcile clears its reservation, which the release
+        // pass honors via `clear_pending`'s return value. A set fetched
+        // AFTER the scan would leave a window (spend executes past the
+        // scan's coverage, anchor pruned before the fetch) where a landed
+        // spend could be wrongly released. Reservations armed DURING the
+        // scan are deliberately absent from the snapshot — their anchors
+        // may be newer than this set — and get checked next pass. Skips the
+        // network call entirely when nothing is armed (the common case).
+        let stranded_release = self.prefetch_stranded_release(&subwallets).await;
+
         // ONE SDK call covers every registered IVK on the network.
         // Snapshot the optional progress handler installed by the
         // manager; sync_notes_across feeds it into the SDK's chunk
@@ -622,6 +637,17 @@ impl NetworkShieldedCoordinator {
         // newly-spent counts and the spend records ride the same
         // `notes` result and `notes.changeset` the receipts do.
         let newly_spent_per_sub = notes.per_subwallet_newly_spent.clone();
+
+        // Residual-spend reconcile: `sync_notes_across` above marked every
+        // landed spend (clearing its reservation). Now release any still-
+        // pending pre-scan reservation whose recorded anchor Platform had
+        // already pruned before the scan — a spend broadcast-accepted but
+        // never landed, otherwise stranded for the session. Runs before the
+        // balance read so freed notes are reflected in this pass's balances.
+        if let Some((snapshot, recorded)) = stranded_release {
+            self.release_stranded_spends(snapshot, &recorded).await;
+        }
+
         let balances_per_sub = match super::sync::balances_across(&self.store, &subwallets).await {
             Ok(r) => r,
             Err(e) => return self.fail_all_wallets(&subwallets, &e),
@@ -728,6 +754,193 @@ impl NetworkShieldedCoordinator {
             .duration_since(std::time::UNIX_EPOCH)
             .map(|d| d.as_secs())
             .unwrap_or(0)
+    }
+
+    /// Pre-scan half of the stranded-reservation release: snapshot the
+    /// anchored reservations armed right now and fetch Platform's recorded
+    /// anchor set, or `None` when there is nothing to do.
+    ///
+    /// MUST run before the pass's note scan — the release's fund-safety
+    /// argument ([`Self::release_stranded_spends`]) rests on both the
+    /// snapshot and the set predating the scan's spent-note reconcile.
+    ///
+    /// Skips the network round-trip when no anchored reservation exists (the
+    /// common case), and treats a recorded-anchor fetch failure as
+    /// non-fatal — a sync must not fail because that query hiccupped; the
+    /// release simply waits for the next pass.
+    async fn prefetch_stranded_release(
+        &self,
+        subwallets: &[(SubwalletId, AccountViewingKeys)],
+    ) -> Option<(Vec<(SubwalletId, StalePendingSpend)>, HashSet<[u8; 32]>)> {
+        // Gather anchored reservations across every synced subwallet. The
+        // common case is none — then the network round-trip is skipped.
+        let stale: Vec<(SubwalletId, StalePendingSpend)> = {
+            let store = self.store.read().await;
+            let mut acc = Vec::new();
+            for (id, _) in subwallets {
+                match store.stale_pending_spends(*id) {
+                    Ok(entries) => acc.extend(entries.into_iter().map(|entry| (*id, entry))),
+                    Err(e) => tracing::warn!(
+                        wallet_id = %hex::encode(id.wallet_id),
+                        account = id.account_index,
+                        error = %e,
+                        "shielded reservation release: stale_pending_spends failed; skipping subwallet"
+                    ),
+                }
+            }
+            acc
+        };
+        if stale.is_empty() {
+            return None;
+        }
+
+        use dash_sdk::platform::fetch_current_no_parameters::FetchCurrent;
+        match dash_sdk::query_types::ShieldedAnchors::fetch_current(&self.sdk).await {
+            Ok(dash_sdk::query_types::ShieldedAnchors(anchors)) => {
+                Some((stale, anchors.into_iter().collect()))
+            }
+            Err(e) => {
+                tracing::warn!(
+                    error = %e,
+                    "shielded reservation release: failed to fetch the recorded anchor set; \
+                     skipping this pass"
+                );
+                None
+            }
+        }
+    }
+
+    /// Release any stranded shielded-spend reservation whose recorded
+    /// anchor Platform has pruned.
+    ///
+    /// A spend that returns broadcast-accepted-but-unconfirmed keeps its
+    /// note reservation (so a retry can't double-spend a note that may in
+    /// fact have landed), released only when the tx lands or the app
+    /// restarts. A spend accepted but that never lands would otherwise
+    /// strand its notes for the whole session. Here, after the pass's
+    /// spent-note reconcile, any reservation from the PRE-scan `snapshot`
+    /// whose anchor is absent from the PRE-scan `recorded` set is provably
+    /// dead: `validate_anchor_exists` accepts a spend only while its anchor
+    /// is retained (`shielded_anchor_retention_blocks = 1000`), so once the
+    /// anchor is pruned the transition can never execute. The notes are
+    /// freed and the linked activity row flipped to Failed so the UI shows
+    /// a clear, retryable failure instead of "Pending" forever. The
+    /// on-chain nullifier set stays the authoritative double-spend guard.
+    ///
+    /// Fund-safe by construction, resting on two ordering facts:
+    ///
+    /// 1. Both inputs predate the scan ([`Self::prefetch_stranded_release`]),
+    ///    and the scan's spent-note reconcile ran to completion in between.
+    ///    An anchor absent from the pre-scan set was pruned before the scan
+    ///    began (a pruned root can never re-enter the set — the tree only
+    ///    grows), so if that spend nevertheless executed, it executed at a
+    ///    height the scan covered — the reconcile already cleared its
+    ///    reservation, which fact 2 catches.
+    /// 2. Each release is a check-and-clear under a single store write
+    ///    guard: the reservation is cleared only while the nullifier is
+    ///    still armed with the snapshot's exact anchor + activity. A
+    ///    reservation resolved concurrently (the reconcile above, or the
+    ///    spend's own result-wait confirming mid-pass) — or cleared and
+    ///    re-armed by a retry with a fresh anchor — is skipped, and its
+    ///    activity row is left alone.
+    ///
+    /// A still-recorded (slow-but-landing) spend is never released, and an
+    /// anchor-less reservation (reserved but not yet built) is never in the
+    /// snapshot (`stale_pending_spends` returns only anchored entries).
+    async fn release_stranded_spends(
+        &self,
+        snapshot: Vec<(SubwalletId, StalePendingSpend)>,
+        recorded: &HashSet<[u8; 32]>,
+    ) {
+        // Persister map is only written on wallet register/unregister —
+        // one read acquisition covers the whole loop.
+        let persisters = self.persisters.read().await;
+        // Every note of a multi-note spend carries the same activity id:
+        // flip each linked row once, not once per nullifier.
+        let mut flipped: HashSet<[u8; 32]> = HashSet::new();
+        for (id, (nullifier, anchor, activity_id)) in snapshot {
+            // Fund-safety invariant: release ONLY when the anchor is absent
+            // from the recorded set. A still-recorded anchor may yet land.
+            if recorded.contains(&anchor) {
+                continue;
+            }
+            // Check-and-clear under ONE write acquisition: the snapshot
+            // entry is released only while the nullifier is still armed
+            // with the SAME anchor + activity. A reservation cleared
+            // mid-scan and re-armed by a retry (same note, fresh anchor
+            // and activity) must not be judged against the pre-scan set —
+            // its anchor may postdate the fetch; it gets checked next pass.
+            {
+                let mut store = self.store.write().await;
+                let still_same = match store.stale_pending_spends(id) {
+                    Ok(current) => current
+                        .iter()
+                        .any(|(n, a, act)| *n == nullifier && *a == anchor && *act == activity_id),
+                    Err(e) => {
+                        tracing::warn!(
+                            wallet_id = %hex::encode(id.wallet_id),
+                            account = id.account_index,
+                            error = %e,
+                            "shielded reservation release: stale_pending_spends failed; skipping entry"
+                        );
+                        continue;
+                    }
+                };
+                if !still_same {
+                    // Resolved (landed and reconciled, result-wait
+                    // confirmed) or re-armed by a retry while this pass
+                    // was scanning. Nothing to release — leave the
+                    // activity row alone.
+                    tracing::debug!(
+                        wallet_id = %hex::encode(id.wallet_id),
+                        account = id.account_index,
+                        nullifier = %hex::encode(nullifier),
+                        "shielded reservation release: reservation resolved or re-armed; skipping"
+                    );
+                    continue;
+                }
+                match store.clear_pending(id, &nullifier) {
+                    // `still_same` held under this same guard, so the clear
+                    // removes exactly the snapshot's reservation.
+                    Ok(true) => {}
+                    Ok(false) => continue,
+                    Err(e) => {
+                        tracing::warn!(
+                            wallet_id = %hex::encode(id.wallet_id),
+                            account = id.account_index,
+                            error = %e,
+                            "shielded reservation release: clear_pending failed"
+                        );
+                        continue;
+                    }
+                }
+            }
+            tracing::info!(
+                wallet_id = %hex::encode(id.wallet_id),
+                account = id.account_index,
+                nullifier = %hex::encode(nullifier),
+                anchor = %hex::encode(anchor),
+                "shielded reservation released: its recorded anchor was pruned, so the stranded \
+                 spend can never execute; freeing the notes"
+            );
+            // Flip the linked activity row to Failed. Only queue to the
+            // wallet's own persister (cloned out — `WalletPersister: Clone`).
+            if let Some(entry_id) = activity_id {
+                if !flipped.insert(entry_id) {
+                    continue;
+                }
+                let persister = persisters.get(&id.wallet_id).cloned();
+                super::operations::record_activity_status_by_id(
+                    &self.store,
+                    persister.as_ref(),
+                    id.wallet_id,
+                    id,
+                    &entry_id,
+                    super::activity::ShieldedActivityStatus::Failed,
+                )
+                .await;
+            }
+        }
     }
 
     /// Derive best-effort activity entries from each subwallet's
@@ -1124,5 +1337,92 @@ mod tests {
             !coordinator.persisters.read().await.is_empty(),
             "persisters must survive a failed clear"
         );
+    }
+
+    /// Common case: with no anchored reservation in the store, the pre-scan
+    /// prefetch short-circuits before any network round-trip — it never
+    /// touches the mock SDK (which has no anchor-query expectation), so this
+    /// both pins the fast-path skip and proves the pass is wired without
+    /// panic (sync() skips the release entirely on `None`).
+    #[tokio::test]
+    async fn release_stranded_spends_no_op_without_anchored_reservation() {
+        let dir = temp_dir("release_noop");
+        let coordinator = coordinator_with_one_wallet(&dir).await;
+
+        let subwallets = vec![(
+            SubwalletId::new([0x11; 32], 0),
+            OrchardKeySet::from_seed(&[0x42u8; 64], dashcore::Network::Testnet, 0)
+                .expect("derive viewing keys")
+                .viewing_keys(),
+        )];
+
+        // No reservation was armed, so `stale_pending_spends` is empty and
+        // the prefetch returns None before fetching the recorded anchor set.
+        let prefetched = coordinator.prefetch_stranded_release(&subwallets).await;
+        assert!(
+            prefetched.is_none(),
+            "nothing armed ⇒ no anchor fetch, no release pass"
+        );
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// Full release-path coverage through `release_stranded_spends` itself
+    /// (not just the store predicate): of two armed reservations, the one
+    /// whose anchor is absent from the recorded set is released while the
+    /// one whose anchor is still recorded survives untouched.
+    #[tokio::test]
+    async fn release_stranded_spends_releases_pruned_and_retains_recorded() {
+        let dir = temp_dir("release_paths");
+        let coordinator = coordinator_with_one_wallet(&dir).await;
+        let id = SubwalletId::new([0x11; 32], 0);
+
+        let pruned_nf = [0xAAu8; 32];
+        let pruned_anchor = [0xABu8; 32];
+        let pruned_act = [0xACu8; 32];
+        let live_nf = [0xBAu8; 32];
+        let live_anchor = [0xBBu8; 32];
+        let live_act = [0xBCu8; 32];
+        {
+            let mut store = coordinator.store.write().await;
+            store.mark_pending(id, &pruned_nf).expect("mark pruned");
+            store
+                .set_pending_spend(id, &pruned_nf, pruned_anchor, pruned_act)
+                .expect("arm pruned");
+            store.mark_pending(id, &live_nf).expect("mark live");
+            store
+                .set_pending_spend(id, &live_nf, live_anchor, live_act)
+                .expect("arm live");
+        }
+
+        // Snapshot as the pre-scan prefetch would have produced it; the
+        // recorded set holds only the live anchor (the other was "pruned").
+        let snapshot = vec![
+            (id, (pruned_nf, pruned_anchor, Some(pruned_act))),
+            (id, (live_nf, live_anchor, Some(live_act))),
+        ];
+        let recorded: HashSet<[u8; 32]> = [live_anchor].into_iter().collect();
+
+        coordinator
+            .release_stranded_spends(snapshot, &recorded)
+            .await;
+
+        let remaining = coordinator
+            .store
+            .read()
+            .await
+            .stale_pending_spends(id)
+            .expect("stale_pending_spends");
+        assert_eq!(
+            remaining.len(),
+            1,
+            "pruned-anchor reservation released; recorded-anchor one retained"
+        );
+        assert_eq!(
+            remaining[0].0, live_nf,
+            "the still-recorded reservation must survive"
+        );
+
+        let _ = std::fs::remove_dir_all(&dir);
     }
 }

--- a/packages/rs-platform-wallet/src/wallet/shielded/coordinator.rs
+++ b/packages/rs-platform-wallet/src/wallet/shielded/coordinator.rs
@@ -638,13 +638,46 @@ impl NetworkShieldedCoordinator {
         // `notes` result and `notes.changeset` the receipts do.
         let newly_spent_per_sub = notes.per_subwallet_newly_spent.clone();
 
-        // Residual-spend reconcile: `sync_notes_across` above marked every
-        // landed spend (clearing its reservation). Now release any still-
-        // pending pre-scan reservation whose recorded anchor Platform had
-        // already pruned before the scan — a spend broadcast-accepted but
-        // never landed, otherwise stranded for the session. Runs before the
-        // balance read so freed notes are reflected in this pass's balances.
+        // Residual-spend resolution: `sync_notes_across` above marked every
+        // landed spend (clearing its reservation and dropping its redrive
+        // record via the store hook). Two passes over what's left, both
+        // judged against the PRE-scan recorded-anchor set:
+        //
+        // 1. Re-drive — for each armed unconfirmed spend whose anchor is
+        //    still recorded, re-broadcast the stored byte-identical
+        //    transition (bounded by MAX_REDRIVE_ATTEMPTS) to actively
+        //    resolve the ambiguity instead of waiting out the retention
+        //    window.
+        // 2. Prune backstop — release any still-pending pre-scan
+        //    reservation whose anchor was already pruned (the spend can
+        //    never execute).
+        //
+        // Runs before the balance read so freed notes are reflected in
+        // this pass's balances.
         if let Some((snapshot, recorded)) = stranded_release {
+            // Snapshot the per-wallet persisters BEFORE the loop and drop
+            // the read guard: `redrive_pending_spends` performs network
+            // broadcasts, and holding the persisters lock across those
+            // awaits would block wallet register/unregister for the
+            // duration of the round trips.
+            let subwallet_persisters: Vec<(SubwalletId, Option<WalletPersister>)> = {
+                let persisters = self.persisters.read().await;
+                subwallets
+                    .iter()
+                    .map(|(id, _)| (*id, persisters.get(&id.wallet_id).cloned()))
+                    .collect()
+            };
+            for (id, persister) in &subwallet_persisters {
+                super::operations::redrive_pending_spends(
+                    &self.sdk,
+                    &self.store,
+                    persister.as_ref(),
+                    id.wallet_id,
+                    *id,
+                    &recorded,
+                )
+                .await;
+            }
             self.release_stranded_spends(snapshot, &recorded).await;
         }
 

--- a/packages/rs-platform-wallet/src/wallet/shielded/file_store.rs
+++ b/packages/rs-platform-wallet/src/wallet/shielded/file_store.rs
@@ -283,19 +283,23 @@ impl ShieldedStore for FileBackedShieldedStore {
             .map_err(|e| FileShieldedStoreError(format!("read tree anchor: {e}")))
     }
 
-    fn witness(
+    fn witness_at_depth(
         &self,
         position: u64,
+        depth: usize,
     ) -> Result<Option<grovedb_commitment_tree::MerklePath>, Self::Error> {
         let tree = self
             .tree
             .lock()
             .map_err(|e| FileShieldedStoreError(format!("tree mutex poisoned: {e}")))?;
-        // `checkpoint_depth = 0` = current tree state. The Halo 2
-        // proof we're about to build uses `tree_anchor()` — also
-        // depth 0 — so the witness root must agree.
-        tree.witness(Position::from(position), 0)
-            .map_err(|e| FileShieldedStoreError(format!("witness({position}): {e}")))
+        // `checkpoint_depth = 0` is the current tree state; deeper values
+        // reach older checkpoints so a spend can be built against a root
+        // Platform actually recorded (it records one anchor per block, while
+        // an index-chunk sync routinely leaves the tree mid-block). The proof
+        // uses whichever anchor this witness produces via `MerklePath::root`,
+        // so the anchor and the authentication path always agree.
+        tree.witness(Position::from(position), depth)
+            .map_err(|e| FileShieldedStoreError(format!("witness({position}, depth {depth}): {e}")))
     }
 
     fn tree_size(&self) -> Result<u64, Self::Error> {
@@ -553,6 +557,99 @@ mod tests {
             size, 1,
             "post-reset tree state (1 leaf) must survive persist + reload, \
              confirming reset cleared the SQLite tree tables"
+        );
+    }
+
+    /// Reproduces the shielded **withdrawal-never-lands** root cause (TestFlight
+    /// report B): the wallet builds a spend against its depth-0 (current) tree
+    /// root, but that root is a *Platform-recorded* anchor only when the tree
+    /// sits exactly on a block boundary.
+    ///
+    /// - The spend anchor is `witness(pos, 0).root(cmx)`, which equals
+    ///   `tree_anchor()` (both depth-0; see the comment on `witness`). This test
+    ///   asserts that equality directly.
+    /// - The wallet syncs commitments by index-chunk (`CHUNK_SIZE = 2048` in
+    ///   `sync.rs`), **not** by block, so its tree routinely stops mid-block.
+    /// - drive records **one anchor per block** (`record_anchor_if_changed` at
+    ///   block-processing-end) and `validate_anchor_exists` rejects any anchor
+    ///   it never recorded (`InvalidAnchorError`).
+    ///
+    /// So a mid-block depth-0 anchor is rejected every attempt — repeatable,
+    /// never lands, funds untouched. The team already names this failure at the
+    /// `tree_size` test above ("Anchor not found in the recorded anchors").
+    #[test]
+    fn depth0_spend_anchor_mid_block_is_not_a_recorded_block_boundary_anchor() {
+        use grovedb_commitment_tree::ExtractedNoteCommitment;
+
+        let path = temp_tree_path("anchor_midblock");
+        let mut store = FileBackedShieldedStore::open_path(&path, 100).unwrap();
+
+        let cmx = |b: u8| {
+            let mut c = [0u8; 32];
+            c[0] = b;
+            c
+        };
+
+        // Two blocks of commitments. drive records ONE anchor per block, at
+        // block-processing-end (after ALL of that block's commitments):
+        //   block 1 = commitments 1..=3  -> recorded anchor at tree size 3
+        //   block 2 = commitments 4..=6  -> recorded anchor at tree size 6
+        for b in 1..=3u8 {
+            store.append_commitment(&cmx(b), true).unwrap();
+        }
+        store.checkpoint_tree(3).unwrap();
+        let recorded_after_block1 = store.tree_anchor().unwrap();
+
+        // The index-chunk sync appends block 2's commitments incrementally; a
+        // chunk/stream boundary that lands mid-block (the common case — a
+        // 2048-leaf chunk rarely ends on a block boundary) leaves the wallet at
+        // tree size 4, and it checkpoints there (sync.rs checkpoints at the
+        // post-append leaf count). Its depth-0 anchor is now the root at size 4
+        // — a state drive never recorded.
+        store.append_commitment(&cmx(4), true).unwrap();
+        store.checkpoint_tree(4).unwrap();
+        let wallet_depth0_mid_block = store.tree_anchor().unwrap();
+
+        // The spend path uses exactly this anchor: `extract_spends_and_anchor`
+        // builds it as `witness(pos, 0).root(cmx)`. Pin that it equals the
+        // mid-block `tree_anchor()`.
+        let cmx0 = ExtractedNoteCommitment::from_bytes(&cmx(1))
+            .into_option()
+            .expect("valid cmx");
+        let spend_anchor = store
+            .witness(0)
+            .unwrap()
+            .expect("witness for marked position 0")
+            .root(cmx0)
+            .to_bytes();
+        assert_eq!(
+            spend_anchor, wallet_depth0_mid_block,
+            "the spend anchor (depth-0 witness root) must equal the mid-block tree_anchor"
+        );
+
+        // Finish block 2. drive records the anchor at tree size 6.
+        store.append_commitment(&cmx(5), true).unwrap();
+        store.append_commitment(&cmx(6), true).unwrap();
+        store.checkpoint_tree(6).unwrap();
+        let recorded_after_block2 = store.tree_anchor().unwrap();
+
+        let _ = std::fs::remove_file(&path);
+
+        // drive's recorded anchor set is {block1, block2}. The wallet's mid-block
+        // spend anchor is neither -> `validate_anchor_exists` rejects it with
+        // InvalidAnchorError, and the withdrawal never lands.
+        assert_ne!(
+            wallet_depth0_mid_block, recorded_after_block1,
+            "mid-block spend anchor must differ from block 1's recorded anchor"
+        );
+        assert_ne!(
+            wallet_depth0_mid_block, recorded_after_block2,
+            "mid-block spend anchor must differ from block 2's recorded anchor"
+        );
+        assert_ne!(
+            recorded_after_block1, recorded_after_block2,
+            "the two block-boundary anchors differ (the tree grew), so drive's \
+             recorded set is exactly these two and the mid-block anchor is outside it"
         );
     }
 }

--- a/packages/rs-platform-wallet/src/wallet/shielded/file_store.rs
+++ b/packages/rs-platform-wallet/src/wallet/shielded/file_store.rs
@@ -20,7 +20,8 @@ use std::sync::Mutex;
 use grovedb_commitment_tree::{ClientPersistentCommitmentTree, Position, Retention};
 
 use super::store::{
-    ShieldedNote, ShieldedOutgoingNote, ShieldedStore, SubwalletId, SubwalletState,
+    ShieldedNote, ShieldedOutgoingNote, ShieldedStore, StalePendingSpend, SubwalletId,
+    SubwalletState,
 };
 use crate::wallet::platform_wallet::WalletId;
 
@@ -180,6 +181,27 @@ impl ShieldedStore for FileBackedShieldedStore {
             .get_mut(&id)
             .map(|sw| sw.clear_pending(nullifier))
             .unwrap_or(false))
+    }
+
+    fn set_pending_spend(
+        &mut self,
+        id: SubwalletId,
+        nullifier: &[u8; 32],
+        anchor: [u8; 32],
+        activity_id: [u8; 32],
+    ) -> Result<(), Self::Error> {
+        if let Some(sw) = self.subwallets.get_mut(&id) {
+            sw.set_pending_spend(nullifier, anchor, activity_id);
+        }
+        Ok(())
+    }
+
+    fn stale_pending_spends(&self, id: SubwalletId) -> Result<Vec<StalePendingSpend>, Self::Error> {
+        Ok(self
+            .subwallets
+            .get(&id)
+            .map(SubwalletState::stale_pending_spends)
+            .unwrap_or_default())
     }
 
     fn record_outgoing_note(

--- a/packages/rs-platform-wallet/src/wallet/shielded/file_store.rs
+++ b/packages/rs-platform-wallet/src/wallet/shielded/file_store.rs
@@ -20,8 +20,8 @@ use std::sync::Mutex;
 use grovedb_commitment_tree::{ClientPersistentCommitmentTree, Position, Retention};
 
 use super::store::{
-    ShieldedNote, ShieldedOutgoingNote, ShieldedStore, StalePendingSpend, SubwalletId,
-    SubwalletState,
+    PendingRedrive, ShieldedNote, ShieldedOutgoingNote, ShieldedStore, StalePendingSpend,
+    SubwalletId, SubwalletState,
 };
 use crate::wallet::platform_wallet::WalletId;
 
@@ -66,6 +66,13 @@ pub struct FileBackedShieldedStore {
     /// Per-subwallet notes + sync state, keyed by `(wallet_id,
     /// account_index)`. Lazily populated on first use of an id.
     subwallets: BTreeMap<SubwalletId, SubwalletState>,
+    /// Second connection on the same SQLite file, owning the
+    /// `shielded_pending_spends` table (armed [`PendingRedrive`]
+    /// records). Separate from `tree` because the commitment-tree
+    /// wrapper takes its `Connection` by value; WAL mode makes the
+    /// two-connection setup safe. `Mutex` for the same `Sync`-shim
+    /// reason as `tree`.
+    pending_conn: Mutex<rusqlite::Connection>,
 }
 
 impl FileBackedShieldedStore {
@@ -95,12 +102,94 @@ impl FileBackedShieldedStore {
         let conn = Self::open_tuned_connection(&path)?;
         let tree = ClientPersistentCommitmentTree::open(conn, max_checkpoints)
             .map_err(|e| FileShieldedStoreError(format!("open commitment tree: {e}")))?;
-        Ok(Self {
+        let pending_conn = Self::open_tuned_connection(&path)?;
+        pending_conn
+            .execute(
+                "CREATE TABLE IF NOT EXISTS shielded_pending_spends (
+                    wallet_id     BLOB    NOT NULL,
+                    account_index INTEGER NOT NULL,
+                    activity_id   BLOB    NOT NULL,
+                    anchor        BLOB    NOT NULL,
+                    nullifiers    BLOB    NOT NULL,
+                    st_bytes      BLOB    NOT NULL,
+                    attempts      INTEGER NOT NULL DEFAULT 0,
+                    PRIMARY KEY (wallet_id, account_index, activity_id)
+                )",
+                [],
+            )
+            .map_err(|e| FileShieldedStoreError(format!("create pending_spends table: {e}")))?;
+        let mut store = Self {
             tree: Mutex::new(tree),
             path,
             max_checkpoints,
             subwallets: BTreeMap::new(),
-        })
+            pending_conn: Mutex::new(pending_conn),
+        };
+        store.rehydrate_pending_spends()?;
+        Ok(store)
+    }
+
+    /// Reload every persisted [`PendingRedrive`] into the in-memory
+    /// per-subwallet state, re-arming both the redrive record and the
+    /// note reservations its nullifiers carry — an unconfirmed
+    /// broadcast therefore keeps its notes reserved (and its re-drive
+    /// alive) across restarts. Corrupt rows are dropped with a warning
+    /// rather than failing the open.
+    fn rehydrate_pending_spends(&mut self) -> Result<(), FileShieldedStoreError> {
+        let conn = self.pending_conn.lock().expect("pending_conn mutex");
+        let mut stmt = conn
+            .prepare(
+                "SELECT wallet_id, account_index, activity_id, anchor, nullifiers, st_bytes, \
+                 attempts FROM shielded_pending_spends",
+            )
+            .map_err(|e| FileShieldedStoreError(format!("prepare rehydrate: {e}")))?;
+        let rows = stmt
+            .query_map([], |row| {
+                Ok((
+                    row.get::<_, Vec<u8>>(0)?,
+                    row.get::<_, u32>(1)?,
+                    row.get::<_, Vec<u8>>(2)?,
+                    row.get::<_, Vec<u8>>(3)?,
+                    row.get::<_, Vec<u8>>(4)?,
+                    row.get::<_, Vec<u8>>(5)?,
+                    row.get::<_, u32>(6)?,
+                ))
+            })
+            .map_err(|e| FileShieldedStoreError(format!("query rehydrate: {e}")))?;
+        for row in rows {
+            let (wallet_id, account_index, activity_id, anchor, nullifiers, st_bytes, attempts) =
+                row.map_err(|e| FileShieldedStoreError(format!("read rehydrate row: {e}")))?;
+            let (Ok(wallet_id), Ok(activity_id), Ok(anchor)) = (
+                <[u8; 32]>::try_from(wallet_id.as_slice()),
+                <[u8; 32]>::try_from(activity_id.as_slice()),
+                <[u8; 32]>::try_from(anchor.as_slice()),
+            ) else {
+                tracing::warn!("dropping corrupt shielded_pending_spends row (bad key widths)");
+                continue;
+            };
+            if nullifiers.is_empty() || nullifiers.len() % 32 != 0 {
+                tracing::warn!("dropping corrupt shielded_pending_spends row (bad nullifiers)");
+                continue;
+            }
+            let nullifiers: Vec<[u8; 32]> = nullifiers
+                .chunks_exact(32)
+                .map(|c| <[u8; 32]>::try_from(c).expect("chunks_exact(32)"))
+                .collect();
+            let id = SubwalletId::new(wallet_id, account_index);
+            let sw = self.subwallets.entry(id).or_default();
+            for n in &nullifiers {
+                sw.mark_pending(n);
+                sw.set_pending_spend(n, anchor, activity_id);
+            }
+            sw.arm_redrive(PendingRedrive {
+                activity_id,
+                anchor,
+                nullifiers,
+                st_bytes,
+                attempts,
+            });
+        }
+        Ok(())
     }
 
     /// Open a `rusqlite::Connection` on `path` with the same WAL /
@@ -127,7 +216,54 @@ impl FileBackedShieldedStore {
             conn.pragma_update(None, k, v)
                 .map_err(|e| FileShieldedStoreError(format!("PRAGMA {k}={v}: {e}")))?;
         }
+        // Two writer connections share this file (the commitment tree's and
+        // `pending_conn`). WAL allows one writer at a time; without a busy
+        // timeout a write colliding with the other connection's write txn
+        // fails immediately with SQLITE_BUSY instead of briefly waiting.
+        conn.busy_timeout(std::time::Duration::from_secs(5))
+            .map_err(|e| FileShieldedStoreError(format!("busy_timeout: {e}")))?;
         Ok(conn)
+    }
+
+    /// Mirror to SQLite the redrive deletions [`SubwalletState`] performs
+    /// in memory when a nullifier resolves (`mark_spent` /
+    /// `clear_pending`): delete every persisted row for `id` whose
+    /// nullifier blob contains `nullifier`.
+    fn delete_redrive_rows_containing(
+        &self,
+        id: SubwalletId,
+        nullifier: &[u8; 32],
+    ) -> Result<(), FileShieldedStoreError> {
+        let conn = self.pending_conn.lock().expect("pending_conn mutex");
+        let mut stmt = conn
+            .prepare(
+                "SELECT activity_id, nullifiers FROM shielded_pending_spends \
+                 WHERE wallet_id = ?1 AND account_index = ?2",
+            )
+            .map_err(|e| FileShieldedStoreError(format!("prepare redrive lookup: {e}")))?;
+        let rows: Vec<(Vec<u8>, Vec<u8>)> = stmt
+            .query_map(
+                rusqlite::params![id.wallet_id.as_slice(), id.account_index],
+                |row| Ok((row.get::<_, Vec<u8>>(0)?, row.get::<_, Vec<u8>>(1)?)),
+            )
+            .map_err(|e| FileShieldedStoreError(format!("query redrive lookup: {e}")))?
+            .collect::<Result<_, _>>()
+            .map_err(|e| FileShieldedStoreError(format!("read redrive lookup: {e}")))?;
+        drop(stmt);
+        for (activity_id, nullifiers) in rows {
+            if nullifiers
+                .chunks_exact(32)
+                .any(|c| c == nullifier.as_slice())
+            {
+                conn.execute(
+                    "DELETE FROM shielded_pending_spends \
+                     WHERE wallet_id = ?1 AND account_index = ?2 AND activity_id = ?3",
+                    rusqlite::params![id.wallet_id.as_slice(), id.account_index, activity_id],
+                )
+                .map_err(|e| FileShieldedStoreError(format!("delete redrive row: {e}")))?;
+            }
+        }
+        Ok(())
     }
 }
 
@@ -156,11 +292,27 @@ impl ShieldedStore for FileBackedShieldedStore {
     }
 
     fn mark_spent(&mut self, id: SubwalletId, nullifier: &[u8; 32]) -> Result<bool, Self::Error> {
-        Ok(self
-            .subwallets
-            .get_mut(&id)
-            .map(|sw| sw.mark_spent(nullifier))
-            .unwrap_or(false))
+        let Some(sw) = self.subwallets.get_mut(&id) else {
+            return Ok(false);
+        };
+        let marked = sw.mark_spent(nullifier);
+        if marked {
+            // `SubwalletState::mark_spent` dropped any redrive carrying
+            // this nullifier from memory; mirror the deletions. The
+            // in-memory transition already happened, so a SQLite failure
+            // must not abort the call — log it and keep the trait
+            // behavior consistent. A surviving stale row rehydrates a
+            // reservation on the next open, which the reconcile / prune
+            // passes then clear.
+            if let Err(e) = self.delete_redrive_rows_containing(id, nullifier) {
+                tracing::warn!(
+                    error = %e,
+                    "redrive row deletion failed after mark_spent; a stale row may \
+                     rehydrate on the next open (self-heals via reconcile/prune)"
+                );
+            }
+        }
+        Ok(marked)
     }
 
     fn mark_pending(&mut self, id: SubwalletId, nullifier: &[u8; 32]) -> Result<bool, Self::Error> {
@@ -176,11 +328,21 @@ impl ShieldedStore for FileBackedShieldedStore {
         id: SubwalletId,
         nullifier: &[u8; 32],
     ) -> Result<bool, Self::Error> {
-        Ok(self
-            .subwallets
-            .get_mut(&id)
-            .map(|sw| sw.clear_pending(nullifier))
-            .unwrap_or(false))
+        let Some(sw) = self.subwallets.get_mut(&id) else {
+            return Ok(false);
+        };
+        let removed = sw.clear_pending(nullifier);
+        if removed {
+            // Same log-don't-abort rationale as `mark_spent` above.
+            if let Err(e) = self.delete_redrive_rows_containing(id, nullifier) {
+                tracing::warn!(
+                    error = %e,
+                    "redrive row deletion failed after clear_pending; a stale row may \
+                     rehydrate on the next open (self-heals via reconcile/prune)"
+                );
+            }
+        }
+        Ok(removed)
     }
 
     fn set_pending_spend(
@@ -202,6 +364,98 @@ impl ShieldedStore for FileBackedShieldedStore {
             .get(&id)
             .map(SubwalletState::stale_pending_spends)
             .unwrap_or_default())
+    }
+
+    fn arm_redrive(&mut self, id: SubwalletId, redrive: PendingRedrive) -> Result<(), Self::Error> {
+        {
+            let conn = self.pending_conn.lock().expect("pending_conn mutex");
+            let nullifier_blob: Vec<u8> = redrive.nullifiers.iter().flatten().copied().collect();
+            conn.execute(
+                "INSERT OR REPLACE INTO shielded_pending_spends \
+                 (wallet_id, account_index, activity_id, anchor, nullifiers, st_bytes, attempts) \
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)",
+                rusqlite::params![
+                    id.wallet_id.as_slice(),
+                    id.account_index,
+                    redrive.activity_id.as_slice(),
+                    redrive.anchor.as_slice(),
+                    nullifier_blob,
+                    redrive.st_bytes,
+                    redrive.attempts,
+                ],
+            )
+            .map_err(|e| FileShieldedStoreError(format!("persist redrive: {e}")))?;
+        }
+        self.subwallets.entry(id).or_default().arm_redrive(redrive);
+        Ok(())
+    }
+
+    fn pending_redrives(&self, id: SubwalletId) -> Result<Vec<PendingRedrive>, Self::Error> {
+        Ok(self
+            .subwallets
+            .get(&id)
+            .map(SubwalletState::pending_redrives)
+            .unwrap_or_default())
+    }
+
+    fn bump_redrive_attempts(
+        &mut self,
+        id: SubwalletId,
+        activity_id: &[u8; 32],
+    ) -> Result<u32, Self::Error> {
+        // Persist FIRST, mutate memory only on success: the reverse order
+        // would leave the in-memory counter ahead of the durable row on a
+        // SQLite failure, and a restart would rewind the attempt budget.
+        let Some(next) = self
+            .subwallets
+            .get(&id)
+            .and_then(|sw| sw.redrive_attempts(activity_id))
+            .map(|attempts| attempts + 1)
+        else {
+            return Ok(0);
+        };
+        {
+            let conn = self.pending_conn.lock().expect("pending_conn mutex");
+            conn.execute(
+                "UPDATE shielded_pending_spends SET attempts = ?4 \
+                 WHERE wallet_id = ?1 AND account_index = ?2 AND activity_id = ?3",
+                rusqlite::params![
+                    id.wallet_id.as_slice(),
+                    id.account_index,
+                    activity_id.as_slice(),
+                    next,
+                ],
+            )
+            .map_err(|e| FileShieldedStoreError(format!("bump redrive attempts: {e}")))?;
+        }
+        let attempts = self
+            .subwallets
+            .get_mut(&id)
+            .map(|sw| sw.bump_redrive_attempts(activity_id))
+            .unwrap_or(0);
+        Ok(attempts)
+    }
+
+    fn clear_redrive(
+        &mut self,
+        id: SubwalletId,
+        activity_id: &[u8; 32],
+    ) -> Result<(), Self::Error> {
+        if let Some(sw) = self.subwallets.get_mut(&id) {
+            sw.clear_redrive(activity_id);
+        }
+        let conn = self.pending_conn.lock().expect("pending_conn mutex");
+        conn.execute(
+            "DELETE FROM shielded_pending_spends \
+             WHERE wallet_id = ?1 AND account_index = ?2 AND activity_id = ?3",
+            rusqlite::params![
+                id.wallet_id.as_slice(),
+                id.account_index,
+                activity_id.as_slice(),
+            ],
+        )
+        .map_err(|e| FileShieldedStoreError(format!("clear redrive: {e}")))?;
+        Ok(())
     }
 
     fn record_outgoing_note(
@@ -415,6 +669,63 @@ mod tests {
             .unwrap()
             .as_nanos();
         std::env::temp_dir().join(format!("shielded_tree_test_{tag}_{nanos}.sqlite"))
+    }
+
+    /// A [`PendingRedrive`] survives a store reopen — record, attempt
+    /// counter, AND the note reservations its nullifiers carry — and is
+    /// deleted (durably) when one of its nullifiers resolves.
+    #[test]
+    fn redrive_roundtrip_rehydration_and_resolution() {
+        let path = temp_tree_path("redrive_roundtrip");
+        let id = SubwalletId::new([7u8; 32], 0);
+        let redrive = PendingRedrive {
+            activity_id: [1u8; 32],
+            anchor: [2u8; 32],
+            nullifiers: vec![[3u8; 32], [4u8; 32]],
+            st_bytes: vec![0xAB; 96],
+            attempts: 0,
+        };
+        {
+            let mut store = FileBackedShieldedStore::open_path(&path, 100).expect("open");
+            store.arm_redrive(id, redrive.clone()).expect("arm");
+            assert_eq!(
+                store
+                    .bump_redrive_attempts(id, &redrive.activity_id)
+                    .expect("bump"),
+                1
+            );
+        }
+        {
+            // Reopen: record + attempts + reservations all rehydrated.
+            let store = FileBackedShieldedStore::open_path(&path, 100).expect("reopen");
+            let got = store.pending_redrives(id).expect("pending_redrives");
+            assert_eq!(got.len(), 1, "record survives reopen");
+            assert_eq!(got[0].attempts, 1, "attempt counter persists");
+            assert_eq!(got[0].st_bytes, redrive.st_bytes, "transition bytes intact");
+            assert_eq!(
+                store.stale_pending_spends(id).expect("stale").len(),
+                2,
+                "both nullifier reservations rehydrated from the record"
+            );
+        }
+        {
+            // Resolving one nullifier (release path) durably drops the row.
+            let mut store = FileBackedShieldedStore::open_path(&path, 100).expect("reopen 2");
+            assert!(store.clear_pending(id, &[3u8; 32]).expect("clear"));
+            assert!(store.pending_redrives(id).expect("redrives").is_empty());
+        }
+        {
+            let store = FileBackedShieldedStore::open_path(&path, 100).expect("reopen 3");
+            assert!(
+                store.pending_redrives(id).expect("redrives").is_empty(),
+                "deletion persisted across reopen"
+            );
+            assert!(
+                store.stale_pending_spends(id).expect("stale").is_empty(),
+                "no reservations rehydrate once the record is gone"
+            );
+        }
+        let _ = std::fs::remove_file(&path);
     }
 
     /// Regression test for the "Shielded Merkle witness

--- a/packages/rs-platform-wallet/src/wallet/shielded/operations.rs
+++ b/packages/rs-platform-wallet/src/wallet/shielded/operations.rs
@@ -330,6 +330,33 @@ async fn record_activity_status<S: ShieldedStore>(
     queue_shielded_changeset(persister, wallet_id, changeset_for_entry(id, next));
 }
 
+/// Flip the activity row identified by `entry_id` (if present) to
+/// `status`, reusing [`record_activity_status`]'s semantics — it re-reads
+/// the CURRENT stored row and leaves a scan-`Confirmed`-with-height row
+/// untouched. Used by the sync reconcile, which knows only the reservation's
+/// stored `activity_id`, not the whole entry. No-op if no such row exists.
+pub(super) async fn record_activity_status_by_id<S: ShieldedStore>(
+    store: &Arc<RwLock<S>>,
+    persister: Option<&WalletPersister>,
+    wallet_id: WalletId,
+    id: SubwalletId,
+    entry_id: &[u8; 32],
+    status: ShieldedActivityStatus,
+) {
+    let entry = match store.read().await.get_activity_by_entry_id(id, entry_id) {
+        Ok(entry) => entry,
+        Err(e) => {
+            warn!(
+                entry_id = %hex::encode(entry_id),
+                error = %e,
+                "activity status flip by id: lookup failed; skipping"
+            );
+            return;
+        }
+    };
+    record_activity_status(store, persister, wallet_id, id, &entry, status, None).await;
+}
+
 // -------------------------------------------------------------------------
 // Shield: platform addresses -> shielded pool (Type 15)
 // -------------------------------------------------------------------------
@@ -664,6 +691,10 @@ pub async fn unshield<S: ShieldedStore, P: OrchardProver>(
     let mut pending_entry = None;
     let result = async {
         let (spends, anchor) = extract_spends_and_anchor(sdk, store, &selected_notes).await?;
+        // Capture the recorded anchor before the builder consumes it, so a
+        // broadcast-accepted-but-unconfirmed spend can be auto-released once
+        // this anchor is pruned from Platform's recorded set.
+        let anchor_bytes = anchor.to_bytes();
 
         // The builder computes and returns the fee authoritatively; `exact_fee` (== the
         // minimum) was already used above for note reservation.
@@ -708,6 +739,7 @@ pub async fn unshield<S: ShieldedStore, P: OrchardProver>(
             },
         )
         .await;
+        arm_pending_release(store, id, anchor_bytes, &pending_entry, &selected_notes).await;
 
         trace!("Unshield: state transition built, broadcasting...");
         broadcast_shielded_spend(sdk, &state_transition, "unshield").await
@@ -826,6 +858,10 @@ pub async fn transfer<S: ShieldedStore, P: OrchardProver>(
     let mut pending_entry = None;
     let result = async {
         let (spends, anchor) = extract_spends_and_anchor(sdk, store, &selected_notes).await?;
+        // Capture the recorded anchor before the builder consumes it, so a
+        // broadcast-accepted-but-unconfirmed spend can be auto-released once
+        // this anchor is pruned from Platform's recorded set.
+        let anchor_bytes = anchor.to_bytes();
 
         // The builder computes and returns the fee authoritatively; `exact_fee` (== the
         // minimum) was already used above for note reservation.
@@ -870,6 +906,7 @@ pub async fn transfer<S: ShieldedStore, P: OrchardProver>(
             },
         )
         .await;
+        arm_pending_release(store, id, anchor_bytes, &pending_entry, &selected_notes).await;
 
         trace!("Shielded transfer: state transition built, broadcasting...");
         broadcast_shielded_spend(sdk, &state_transition, "transfer").await
@@ -976,6 +1013,10 @@ pub async fn withdraw<S: ShieldedStore, P: OrchardProver>(
     let mut pending_entry = None;
     let result = async {
         let (spends, anchor) = extract_spends_and_anchor(sdk, store, &selected_notes).await?;
+        // Capture the recorded anchor before the builder consumes it, so a
+        // broadcast-accepted-but-unconfirmed spend can be auto-released once
+        // this anchor is pruned from Platform's recorded set.
+        let anchor_bytes = anchor.to_bytes();
 
         // The builder computes and returns the fee authoritatively; `exact_fee` (== the
         // minimum) was already used above for note reservation.
@@ -1022,6 +1063,7 @@ pub async fn withdraw<S: ShieldedStore, P: OrchardProver>(
             },
         )
         .await;
+        arm_pending_release(store, id, anchor_bytes, &pending_entry, &selected_notes).await;
 
         trace!("Shielded withdrawal: state transition built, broadcasting...");
         broadcast_shielded_spend(sdk, &state_transition, "withdraw").await
@@ -1165,6 +1207,10 @@ where
     let mut pending_entry = None;
     let result = async {
         let (spends, anchor) = extract_spends_and_anchor(sdk, store, &selected_notes).await?;
+        // Capture the recorded anchor before the builder consumes it, so a
+        // broadcast-accepted-but-unconfirmed create can be auto-released once
+        // this anchor is pruned from Platform's recorded set.
+        let anchor_bytes = anchor.to_bytes();
 
         let build = build_identity_create_from_shielded_pool_transition(
             public_keys,
@@ -1211,6 +1257,7 @@ where
             },
         )
         .await;
+        arm_pending_release(store, id, anchor_bytes, &pending_entry, &selected_notes).await;
 
         trace!("IdentityCreateFromShieldedPool: built, broadcasting via SDK...");
         // Stage the broadcast and the result-wait SEPARATELY (instead of one `broadcast_and_wait`)
@@ -1853,6 +1900,42 @@ async fn cancel_pending<S: ShieldedStore>(
     }
 }
 
+/// Record the recorded `anchor` the spend was built against and the
+/// linked activity entry on every selected note's reservation, so a
+/// spend that ends broadcast-accepted-but-unconfirmed can be released
+/// on a later sync once that anchor is pruned from Platform's recorded
+/// set (see `NetworkShieldedCoordinator::release_stranded_spends`).
+///
+/// No-op when no activity entry was recorded (an output-less bundle —
+/// unreachable for our own builders, which always carry a visible
+/// output). Best-effort: a store write failure only means the
+/// reservation won't self-release on a pruned anchor (it still frees
+/// on the next restart), so it must never abort a spend about to
+/// broadcast. A success (`finalize_pending`) or a definite failure
+/// (`cancel_pending`) removes the entry, so only an ambiguous
+/// unconfirmed outcome leaves it carrying the anchor.
+async fn arm_pending_release<S: ShieldedStore>(
+    store: &Arc<RwLock<S>>,
+    id: SubwalletId,
+    anchor: [u8; 32],
+    pending_entry: &Option<super::activity::ShieldedActivityEntry>,
+    notes: &[ShieldedNote],
+) {
+    let Some(entry) = pending_entry else {
+        return;
+    };
+    let mut store = store.write().await;
+    for note in notes {
+        if let Err(e) = store.set_pending_spend(id, &note.nullifier, anchor, entry.id) {
+            warn!(
+                error = %e,
+                "set_pending_spend failed; this reservation won't self-release on a pruned \
+                 anchor (it still frees on the next restart)"
+            );
+        }
+    }
+}
+
 /// Whether an SDK error carries Platform's own consensus verdict on the
 /// transition. Two shapes qualify:
 ///
@@ -2433,6 +2516,58 @@ mod record_activity_status_tests {
             .expect("row must exist");
         assert_eq!(stored.status, ShieldedActivityStatus::Confirmed);
         assert_eq!(stored.block_height, Some(900));
+    }
+
+    /// The by-id flip the sync reconcile uses: it knows only the
+    /// reservation's stored `activity_id`, so it looks the row up and flips
+    /// it — a released stranded spend moves Pending → Failed.
+    #[tokio::test]
+    async fn status_flip_by_id_flips_pending_to_failed() {
+        let store = Arc::new(RwLock::new(InMemoryShieldedStore::new()));
+        let id = sub();
+        let pending = captured_pending();
+        store.write().await.save_activity(id, &pending).unwrap();
+
+        record_activity_status_by_id(
+            &store,
+            None,
+            id.wallet_id,
+            id,
+            &pending.id,
+            ShieldedActivityStatus::Failed,
+        )
+        .await;
+
+        let stored = store
+            .read()
+            .await
+            .get_activity_by_entry_id(id, &pending.id)
+            .unwrap()
+            .expect("row must exist");
+        assert_eq!(stored.status, ShieldedActivityStatus::Failed);
+    }
+
+    /// A by-id flip for an entry that doesn't exist is a silent no-op
+    /// (nothing to flip), never a panic.
+    #[tokio::test]
+    async fn status_flip_by_id_missing_entry_is_noop() {
+        let store = Arc::new(RwLock::new(InMemoryShieldedStore::new()));
+        let id = sub();
+        record_activity_status_by_id(
+            &store,
+            None,
+            id.wallet_id,
+            id,
+            &[0xDE; 32],
+            ShieldedActivityStatus::Failed,
+        )
+        .await;
+        assert!(store
+            .read()
+            .await
+            .get_activity_by_entry_id(id, &[0xDE; 32])
+            .unwrap()
+            .is_none());
     }
 }
 

--- a/packages/rs-platform-wallet/src/wallet/shielded/operations.rs
+++ b/packages/rs-platform-wallet/src/wallet/shielded/operations.rs
@@ -33,9 +33,10 @@ use crate::error::PlatformWalletError;
 use crate::wallet::persister::WalletPersister;
 use crate::wallet::platform_wallet::WalletId;
 
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, HashSet};
 use std::sync::Arc;
 
+use dash_sdk::platform::fetch_current_no_parameters::FetchCurrent;
 use dash_sdk::platform::transition::broadcast::BroadcastStateTransition;
 use dash_sdk::platform::transition::identity_create_from_shielded_pool::IdentityCreateFromShieldedPool;
 use dpp::address_funds::{
@@ -662,7 +663,7 @@ pub async fn unshield<S: ShieldedStore, P: OrchardProver>(
     // it. A build failure leaves it `None` and records nothing.
     let mut pending_entry = None;
     let result = async {
-        let (spends, anchor) = extract_spends_and_anchor(store, &selected_notes).await?;
+        let (spends, anchor) = extract_spends_and_anchor(sdk, store, &selected_notes).await?;
 
         // The builder computes and returns the fee authoritatively; `exact_fee` (== the
         // minimum) was already used above for note reservation.
@@ -824,7 +825,7 @@ pub async fn transfer<S: ShieldedStore, P: OrchardProver>(
 
     let mut pending_entry = None;
     let result = async {
-        let (spends, anchor) = extract_spends_and_anchor(store, &selected_notes).await?;
+        let (spends, anchor) = extract_spends_and_anchor(sdk, store, &selected_notes).await?;
 
         // The builder computes and returns the fee authoritatively; `exact_fee` (== the
         // minimum) was already used above for note reservation.
@@ -974,7 +975,7 @@ pub async fn withdraw<S: ShieldedStore, P: OrchardProver>(
 
     let mut pending_entry = None;
     let result = async {
-        let (spends, anchor) = extract_spends_and_anchor(store, &selected_notes).await?;
+        let (spends, anchor) = extract_spends_and_anchor(sdk, store, &selected_notes).await?;
 
         // The builder computes and returns the fee authoritatively; `exact_fee` (== the
         // minimum) was already used above for note reservation.
@@ -1163,7 +1164,7 @@ where
     // outer match; it lives here so the flip can see it.
     let mut pending_entry = None;
     let result = async {
-        let (spends, anchor) = extract_spends_and_anchor(store, &selected_notes).await?;
+        let (spends, anchor) = extract_spends_and_anchor(sdk, store, &selected_notes).await?;
 
         let build = build_identity_create_from_shielded_pool_transition(
             public_keys,
@@ -1508,88 +1509,213 @@ fn default_orchard_address(keys: &OrchardKeySet) -> Result<OrchardAddress, Platf
     payment_address_to_orchard(&keys.default_address)
 }
 
-/// Extract `SpendableNote` structs with Merkle witnesses and the
-/// tree anchor.
+/// Checkpoint depths probed for a Platform-recorded anchor. Kept equal to the
+/// commitment tree's `max_checkpoints` retention (the store is opened with
+/// `100` — see `PlatformWalletManager`) so the probe reaches every checkpoint
+/// the tree still holds and no further: deeper checkpoints are pruned, so
+/// probing past this bound is wasted work. Coupled by convention — if that
+/// retention changes, update this in lockstep.
+const MAX_ANCHOR_PROBE_DEPTH: usize = 100;
+
+/// Extract `SpendableNote` structs with Merkle witnesses and an anchor
+/// Platform has recorded.
 ///
-/// The anchor is derived from the witness paths themselves (via
-/// `MerklePath::root(cmx)`) rather than from `store.tree_anchor()`.
-/// The store's witness call is `witness_at_checkpoint_depth(0)`
-/// (root of the most recent checkpoint) while `tree_anchor()` is
-/// `root_at_checkpoint_depth(None)` (latest tree state) — any
-/// commitments appended after the last checkpoint move the latter
-/// ahead of the former, and the resulting `AnchorMismatch` from
-/// the Orchard spend builder is what you'd see at proof time.
-/// Using the witness's own computed root keeps the anchor
-/// consistent with the authentication paths the proof actually
-/// verifies.
+/// A shielded spend's proof is accepted only if its anchor is a
+/// commitment-tree root Platform recorded (`validate_anchor_exists`).
+/// Platform records one anchor per block, but an index-chunk sync routinely
+/// leaves the wallet's tree mid-block, so the depth-0 (current) root is
+/// frequently a value Platform never recorded — building against it
+/// unconditionally is what made such spends fail and never land.
+///
+/// This fetches Platform's recorded anchor set (outside the store lock), then
+/// selects the shallowest checkpoint depth whose root is in that set — depth 0
+/// being the fully-synced fast path — witnessing every note at that same depth
+/// so the anchor and the authentication paths agree (the builder derives the
+/// anchor from the witnesses via `MerklePath::root`, so a per-note disagreement
+/// would surface downstream as `AnchorMismatch`). When no probed depth has a
+/// recorded root it returns the retryable
+/// [`PlatformWalletError::ShieldedNoRecordedAnchor`] rather than broadcasting a
+/// spend Platform is guaranteed to reject.
 async fn extract_spends_and_anchor<S: ShieldedStore>(
+    sdk: &Arc<dash_sdk::Sdk>,
     store: &Arc<RwLock<S>>,
     notes: &[ShieldedNote],
 ) -> Result<(Vec<SpendableNote>, Anchor), PlatformWalletError> {
-    use grovedb_commitment_tree::ExtractedNoteCommitment;
-
-    let store = store.read().await;
-
-    let mut spends = Vec::with_capacity(notes.len());
-    let mut anchor: Option<Anchor> = None;
-    for note in notes {
-        let orchard_note = deserialize_note(&note.note_data).ok_or_else(|| {
-            PlatformWalletError::ShieldedBuildError(format!(
-                "Failed to deserialize note at position {}",
-                note.position
-            ))
-        })?;
-
-        let merkle_path = store
-            .witness(note.position)
-            .map_err(|e| PlatformWalletError::ShieldedMerkleWitnessUnavailable(e.to_string()))?
-            .ok_or_else(|| {
-                PlatformWalletError::ShieldedMerkleWitnessUnavailable(format!(
-                    "no witness available for note at position {} (not marked, or pruned past this position)",
-                    note.position
-                ))
-            })?;
-
-        // Compute the anchor this witness was generated against.
-        // All selected notes must share the same anchor — if not,
-        // the store handed us witnesses from different
-        // checkpoints, which the spend builder would reject
-        // downstream with `AnchorMismatch`. Surface the mismatch
-        // here so the host doesn't pay the ~30 s proof cost
-        // first.
-        let cmx = ExtractedNoteCommitment::from_bytes(&note.cmx)
-            .into_option()
-            .ok_or_else(|| {
-                PlatformWalletError::ShieldedBuildError(format!(
-                    "invalid stored cmx for note at position {}",
-                    note.position
-                ))
-            })?;
-        let witness_anchor = merkle_path.root(cmx);
-        match &anchor {
-            None => anchor = Some(witness_anchor),
-            Some(prev) if prev.to_bytes() != witness_anchor.to_bytes() => {
-                return Err(PlatformWalletError::ShieldedBuildError(format!(
-                    "witness anchor mismatch across selected notes (position {})",
-                    note.position
-                )));
-            }
-            _ => {}
-        }
-
-        spends.push(SpendableNote {
-            note: orchard_note,
-            merkle_path,
-        });
+    // Nothing selected — fail before the network round-trip.
+    if notes.is_empty() {
+        return Err(PlatformWalletError::ShieldedBuildError(
+            "no spendable notes selected — anchor undefined".to_string(),
+        ));
     }
 
-    let anchor = anchor.ok_or_else(|| {
-        PlatformWalletError::ShieldedBuildError(
-            "no spendable notes selected — anchor undefined".to_string(),
-        )
-    })?;
+    // Fetch the recorded anchor set OUTSIDE the store lock so the network
+    // round-trip doesn't serialize with other store users, and so the lock is
+    // held only for the mutually-consistent depth/witness probe below.
+    let dash_sdk::query_types::ShieldedAnchors(recorded_anchors) =
+        dash_sdk::query_types::ShieldedAnchors::fetch_current(sdk).await?;
+    let recorded: HashSet<[u8; 32]> = recorded_anchors.into_iter().collect();
 
-    Ok((spends, anchor))
+    // Hold a single read lock across the whole probe so the checkpoint depths
+    // and the per-note witnesses stay mutually consistent: a concurrent sync
+    // checkpointing mid-probe would otherwise shift the depth indices out from
+    // under us.
+    let store = store.read().await;
+    select_recorded_spends(&*store, notes, &recorded)
+}
+
+/// Pick the shallowest checkpoint depth whose tree root is in `recorded`,
+/// witnessing every note at that depth. Pure (no SDK, no async), so the depth
+/// walk can be unit-tested against a real commitment tree.
+///
+/// Depth 0 is the current tree state (the fully-synced fast path). Deeper
+/// checkpoints are older and hold strictly fewer positions, so the probe stops
+/// as soon as a selected note is no longer witnessable at a depth — no deeper
+/// checkpoint could contain it. Returns
+/// [`PlatformWalletError::ShieldedNoRecordedAnchor`] when no probed depth has a
+/// recorded root (a clean, retryable outcome — nothing is broadcast).
+fn select_recorded_spends<S: ShieldedStore>(
+    store: &S,
+    notes: &[ShieldedNote],
+    recorded: &HashSet<[u8; 32]>,
+) -> Result<(Vec<SpendableNote>, Anchor), PlatformWalletError> {
+    use grovedb_commitment_tree::ExtractedNoteCommitment;
+
+    // Deserialize each note and decode its commitment ONCE — both are
+    // independent of the checkpoint depth, so hoisting them out of the probe
+    // keeps the depth walk cheap (each probed depth only re-witnesses).
+    let prepared: Vec<(u64, grovedb_commitment_tree::Note, ExtractedNoteCommitment)> = notes
+        .iter()
+        .map(|note| {
+            let orchard_note = deserialize_note(&note.note_data).ok_or_else(|| {
+                PlatformWalletError::ShieldedBuildError(format!(
+                    "Failed to deserialize note at position {}",
+                    note.position
+                ))
+            })?;
+            let cmx = ExtractedNoteCommitment::from_bytes(&note.cmx)
+                .into_option()
+                .ok_or_else(|| {
+                    PlatformWalletError::ShieldedBuildError(format!(
+                        "invalid stored cmx for note at position {}",
+                        note.position
+                    ))
+                })?;
+            Ok((note.position, orchard_note, cmx))
+        })
+        .collect::<Result<_, PlatformWalletError>>()?;
+
+    // Build every selected note's `SpendableNote` plus the shared anchor at a
+    // single checkpoint `depth`.
+    //
+    // `strict` (depth 0 only): a missing/failed witness is a hard
+    // `ShieldedMerkleWitnessUnavailable` (the note is expected to be witnessable
+    // at the current tip). At depth > 0, `Ok(None)` means the note post-dates
+    // this older checkpoint, so the depth is unusable — return `Ok(None)` and
+    // let the caller stop probing deeper; a genuine store `Err` (poisoned mutex,
+    // IO, tree corruption) is logged — the probe would otherwise discard the
+    // message — and likewise treated as an unusable depth rather than aborting,
+    // so a transient read can't strand a spend a shallower depth already
+    // covered. An anchor disagreement across notes is always a hard error (the
+    // spend builder would reject it downstream).
+    let build_at_depth = |depth: usize,
+                          strict: bool|
+     -> Result<Option<(Vec<SpendableNote>, Anchor)>, PlatformWalletError> {
+        let mut spends = Vec::with_capacity(prepared.len());
+        let mut anchor: Option<Anchor> = None;
+        for (position, note, cmx) in &prepared {
+            let merkle_path = match store.witness_at_depth(*position, depth) {
+                Ok(Some(path)) => path,
+                Ok(None) if strict => {
+                    return Err(PlatformWalletError::ShieldedMerkleWitnessUnavailable(format!(
+                        "no witness available for note at position {position} (not marked, or pruned past this position)"
+                    )));
+                }
+                Err(e) if strict => {
+                    return Err(PlatformWalletError::ShieldedMerkleWitnessUnavailable(
+                        e.to_string(),
+                    ));
+                }
+                // depth > 0: the note isn't witnessable at this older checkpoint
+                // (appended after it, or the depth doesn't exist).
+                Ok(None) => return Ok(None),
+                // depth > 0: a genuine store failure. Log it so the operator sees
+                // it (the anchor probe otherwise swallows the message), then treat
+                // the depth as unusable — never a mid-probe abort.
+                Err(e) => {
+                    tracing::warn!(
+                        position = *position,
+                        depth,
+                        error = %e,
+                        "shielded anchor probe: witness_at_depth failed at depth > 0; skipping depth"
+                    );
+                    return Ok(None);
+                }
+            };
+
+            // The anchor is derived from the witness path itself
+            // (`MerklePath::root(cmx)`); all selected notes must agree on it, or
+            // the store handed back witnesses from different checkpoints and the
+            // spend builder would reject the mismatch downstream.
+            let witness_anchor = merkle_path.root(*cmx);
+            match &anchor {
+                None => anchor = Some(witness_anchor),
+                Some(prev) if prev.to_bytes() != witness_anchor.to_bytes() => {
+                    return Err(PlatformWalletError::ShieldedBuildError(format!(
+                        "witness anchor mismatch across selected notes (position {position})"
+                    )));
+                }
+                _ => {}
+            }
+
+            spends.push(SpendableNote {
+                note: *note,
+                merkle_path,
+            });
+        }
+
+        // `notes` is non-empty (the caller checked), so `anchor` is set.
+        let anchor = anchor.ok_or_else(|| {
+            PlatformWalletError::ShieldedBuildError(
+                "no spendable notes selected — anchor undefined".to_string(),
+            )
+        })?;
+        Ok(Some((spends, anchor)))
+    };
+
+    // Fast path: a fully-synced wallet's depth-0 root is a recorded anchor.
+    let (spends, anchor) = match build_at_depth(0, true)? {
+        Some(pair) => pair,
+        // Unreachable — a strict build returns `Some` or errors — but stay
+        // fund-safe (a clean error, never a panic) if that invariant breaks.
+        None => {
+            return Err(PlatformWalletError::ShieldedMerkleWitnessUnavailable(
+                "depth-0 witness probe returned no witness for a selected note".to_string(),
+            ));
+        }
+    };
+    if recorded.contains(&anchor.to_bytes()) {
+        return Ok((spends, anchor));
+    }
+
+    // Otherwise walk older checkpoints newest→oldest for the shallowest
+    // recorded root.
+    for depth in 1..MAX_ANCHOR_PROBE_DEPTH {
+        match build_at_depth(depth, false)? {
+            Some((spends, anchor)) if recorded.contains(&anchor.to_bytes()) => {
+                return Ok((spends, anchor));
+            }
+            // A root exists at this depth but Platform didn't record it — try an
+            // older checkpoint.
+            Some(_) => continue,
+            // A selected note isn't witnessable this deep; every deeper
+            // checkpoint is older still, so none can cover it either.
+            None => break,
+        }
+    }
+
+    Err(PlatformWalletError::ShieldedNoRecordedAnchor(
+        "no recorded anchor covers the selected notes; wait for the next shielded sync".to_string(),
+    ))
 }
 
 /// Mark the selected notes as spent for `id`. Also queues a
@@ -2307,5 +2433,258 @@ mod record_activity_status_tests {
             .expect("row must exist");
         assert_eq!(stored.status, ShieldedActivityStatus::Confirmed);
         assert_eq!(stored.block_height, Some(900));
+    }
+}
+
+/// Unit tests for the pure anchor-selection probe ([`select_recorded_spends`])
+/// against a real SQLite-backed commitment tree — no SDK, no network.
+///
+/// These pin the fix for the shielded-withdrawal "never lands" root cause:
+/// the wallet must build a spend against a Platform-recorded anchor, not the
+/// bleeding-edge depth-0 root a mid-block index-chunk sync leaves behind. They
+/// reuse the block-boundary tree shape from the `file_store` reproduction test.
+#[cfg(test)]
+mod select_recorded_spends_tests {
+    use super::*;
+    use crate::wallet::shielded::file_store::FileBackedShieldedStore;
+    use dashcore::Network;
+    use grovedb_commitment_tree::{ExtractedNoteCommitment, Note, NoteValue, RandomSeed, Rho};
+
+    /// Unique temp path for a test tree (no `tempfile` dev-dep).
+    fn temp_tree_path(tag: &str) -> std::path::PathBuf {
+        let nanos = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        std::env::temp_dir().join(format!("select_recorded_spends_{tag}_{nanos}.sqlite"))
+    }
+
+    /// A filler leaf commitment for non-owned positions. Any canonical 32-byte
+    /// field element works — the probe only needs the tree to grow between
+    /// blocks so successive checkpoint roots differ.
+    fn filler_cmx(b: u8) -> [u8; 32] {
+        let mut c = [0u8; 32];
+        c[0] = b;
+        c
+    }
+
+    /// Build one real, spendable Orchard note owned by a fixed test seed and
+    /// return the wallet's `ShieldedNote` view of it.
+    ///
+    /// `note_data` is the real serialized note so `deserialize_note` accepts
+    /// it, and `cmx` is the note's real extracted commitment so that appending
+    /// `cmx` as the leaf at `position` makes `witness(position, d).root(cmx)`
+    /// reproduce the tree's anchor at depth `d`.
+    fn real_note(position: u64) -> ShieldedNote {
+        let keys = OrchardKeySet::from_seed(&[0x42; 32], Network::Testnet, 0)
+            .expect("ZIP-32 derivation from a fixed seed");
+        let recipient = keys.default_address;
+
+        // rho and rseed must be canonical Pallas base-field elements; not every
+        // 32-byte pattern is, so scan deterministically for a valid pair drawn
+        // from disjoint byte regions (mirroring the sync tests' note builders).
+        let rho = (1u16..=u16::MAX)
+            .find_map(|n| {
+                let mut b = [0u8; 32];
+                b[0..2].copy_from_slice(&n.to_le_bytes());
+                Rho::from_bytes(&b).into_option()
+            })
+            .expect("a canonical rho exists");
+        let rseed = (1u16..=u16::MAX)
+            .find_map(|m| {
+                let mut b = [0u8; 32];
+                b[2..4].copy_from_slice(&m.to_le_bytes());
+                RandomSeed::from_bytes(b, &rho).into_option()
+            })
+            .expect("a canonical rseed exists");
+
+        let value = NoteValue::from_raw(100_000);
+        let note = Note::from_parts(recipient, value, rho, rseed)
+            .into_option()
+            .expect("valid note parts");
+        let cmx = ExtractedNoteCommitment::from(note.commitment()).to_bytes();
+
+        // `recipient(43) || value(8 LE) || rho(32) || rseed(32)` — the exact
+        // format `deserialize_note` expects.
+        let mut note_data = Vec::with_capacity(115);
+        note_data.extend_from_slice(&note.recipient().to_raw_address_bytes());
+        note_data.extend_from_slice(&note.value().inner().to_le_bytes());
+        note_data.extend_from_slice(&note.rho().to_bytes());
+        note_data.extend_from_slice(note.rseed().as_bytes());
+
+        ShieldedNote {
+            position,
+            cmx,
+            nullifier: [0x07; 32],
+            block_height: 1,
+            is_spent: false,
+            value: 100_000,
+            note_data,
+        }
+    }
+
+    /// Mid-block: the wallet's depth-0 root is not recorded, but a prior
+    /// block-boundary checkpoint is — the probe must select that older recorded
+    /// anchor (the shallowest one), never the mid-block depth-0 root Platform
+    /// never recorded.
+    #[test]
+    fn mid_block_selects_prior_recorded_checkpoint_not_depth0() {
+        let path = temp_tree_path("midblock");
+        let mut store = FileBackedShieldedStore::open_path(&path, 100).unwrap();
+
+        // The owned note lives at position 0, present since block 1.
+        let note = real_note(0);
+
+        // Block 1 = positions 0,1,2 (leaf 0 is the owned note's cmx). drive
+        // records ONE anchor per block, at block-processing-end.
+        store.append_commitment(&note.cmx, true).unwrap();
+        store.append_commitment(&filler_cmx(0xA1), true).unwrap();
+        store.append_commitment(&filler_cmx(0xA2), true).unwrap();
+        store.checkpoint_tree(3).unwrap();
+        let root_block1 = store.tree_anchor().unwrap();
+
+        // Block 2 = positions 3,4,5. Its block-end root is the second recorded
+        // anchor.
+        store.append_commitment(&filler_cmx(0xB1), true).unwrap();
+        store.append_commitment(&filler_cmx(0xB2), true).unwrap();
+        store.append_commitment(&filler_cmx(0xB3), true).unwrap();
+        store.checkpoint_tree(6).unwrap();
+        let root_block2 = store.tree_anchor().unwrap();
+
+        // Mid-block: the index-chunk sync appends one more commitment (position
+        // 6) and checkpoints there. The depth-0 root is now a state drive never
+        // recorded.
+        store.append_commitment(&filler_cmx(0xC1), true).unwrap();
+        store.checkpoint_tree(7).unwrap();
+        let root_depth0 = store.tree_anchor().unwrap();
+
+        // drive's recorded set is exactly the two block-boundary roots.
+        let recorded: HashSet<[u8; 32]> = [root_block1, root_block2].into_iter().collect();
+
+        let (spends, anchor) =
+            select_recorded_spends(&store, std::slice::from_ref(&note), &recorded)
+                .expect("a prior recorded checkpoint covers the owned note");
+
+        let _ = std::fs::remove_file(&path);
+
+        assert_eq!(spends.len(), 1, "the single owned note is spendable");
+        assert!(
+            recorded.contains(&anchor.to_bytes()),
+            "the selected anchor must be a Platform-recorded root"
+        );
+        assert_eq!(
+            anchor.to_bytes(),
+            root_block2,
+            "must pick the shallowest recorded checkpoint (block 2 / depth 1), not a deeper one"
+        );
+        assert_ne!(
+            anchor.to_bytes(),
+            root_depth0,
+            "must NOT use the mid-block depth-0 root drive never recorded"
+        );
+    }
+
+    /// Fully synced: the wallet's depth-0 root IS recorded, so the probe takes
+    /// the fast path and returns the depth-0 anchor without walking deeper.
+    #[test]
+    fn fully_synced_returns_depth0_anchor() {
+        let path = temp_tree_path("fastpath");
+        let mut store = FileBackedShieldedStore::open_path(&path, 100).unwrap();
+
+        let note = real_note(0);
+
+        // One block, checkpointed exactly on its boundary: depth 0 == a recorded
+        // anchor.
+        store.append_commitment(&note.cmx, true).unwrap();
+        store.append_commitment(&filler_cmx(0xA1), true).unwrap();
+        store.append_commitment(&filler_cmx(0xA2), true).unwrap();
+        store.checkpoint_tree(3).unwrap();
+        let root_depth0 = store.tree_anchor().unwrap();
+
+        let recorded: HashSet<[u8; 32]> = [root_depth0].into_iter().collect();
+
+        let (spends, anchor) =
+            select_recorded_spends(&store, std::slice::from_ref(&note), &recorded)
+                .expect("depth-0 root is recorded");
+
+        let _ = std::fs::remove_file(&path);
+
+        assert_eq!(spends.len(), 1);
+        assert_eq!(
+            anchor.to_bytes(),
+            root_depth0,
+            "the fully-synced fast path returns the depth-0 anchor"
+        );
+    }
+
+    /// No checkpoint root is recorded: the probe exhausts every depth and
+    /// returns the retryable `ShieldedNoRecordedAnchor` — nothing is broadcast.
+    #[test]
+    fn no_recorded_checkpoint_returns_retryable_error() {
+        let path = temp_tree_path("none");
+        let mut store = FileBackedShieldedStore::open_path(&path, 100).unwrap();
+
+        let note = real_note(0);
+
+        store.append_commitment(&note.cmx, true).unwrap();
+        store.append_commitment(&filler_cmx(0xA1), true).unwrap();
+        store.append_commitment(&filler_cmx(0xA2), true).unwrap();
+        store.checkpoint_tree(3).unwrap();
+
+        // Platform recorded none of this wallet's checkpoint roots.
+        let recorded: HashSet<[u8; 32]> = HashSet::new();
+
+        // `SpendableNote` isn't `Debug`, so match rather than `expect_err`.
+        let result = select_recorded_spends(&store, std::slice::from_ref(&note), &recorded);
+
+        let _ = std::fs::remove_file(&path);
+
+        match result {
+            Err(PlatformWalletError::ShieldedNoRecordedAnchor(_)) => {}
+            Err(other) => {
+                panic!("expected ShieldedNoRecordedAnchor, got error: {other:?}")
+            }
+            Ok(_) => panic!("expected ShieldedNoRecordedAnchor, got Ok"),
+        }
+    }
+
+    /// A selected note that post-dates the only recorded checkpoint. Depth 0
+    /// (which contains the note) isn't recorded; at depth 1 the note is not yet
+    /// in the tree, so the probe's early-termination fires (a deeper checkpoint
+    /// is older still and can't contain it) and the retryable error is returned
+    /// — even though a recorded anchor exists, it doesn't cover this note. This
+    /// pins the walk's break arm and the value-selection trade-off (a mid-block
+    /// wallet whose selected note is newer than every recorded checkpoint waits
+    /// for the next sync rather than spending).
+    #[test]
+    fn note_newer_than_recorded_checkpoint_breaks_and_returns_retryable_error() {
+        let path = temp_tree_path("toonew");
+        let mut store = FileBackedShieldedStore::open_path(&path, 100).unwrap();
+
+        // Block 1 = positions 0,1,2 (fillers), checkpointed on its boundary —
+        // the only root Platform recorded.
+        store.append_commitment(&filler_cmx(0xA0), true).unwrap();
+        store.append_commitment(&filler_cmx(0xA1), true).unwrap();
+        store.append_commitment(&filler_cmx(0xA2), true).unwrap();
+        store.checkpoint_tree(3).unwrap();
+        let root_block1 = store.tree_anchor().unwrap();
+
+        // The owned note is appended AFTER block 1 (position 3) and checkpointed:
+        // present at depth 0, absent from the block-1 checkpoint (depth 1).
+        let note = real_note(3);
+        store.append_commitment(&note.cmx, true).unwrap();
+        store.checkpoint_tree(4).unwrap();
+
+        let recorded: HashSet<[u8; 32]> = [root_block1].into_iter().collect();
+
+        let result = select_recorded_spends(&store, std::slice::from_ref(&note), &recorded);
+
+        let _ = std::fs::remove_file(&path);
+
+        match result {
+            Err(PlatformWalletError::ShieldedNoRecordedAnchor(_)) => {}
+            Err(other) => panic!("expected ShieldedNoRecordedAnchor, got error: {other:?}"),
+            Ok(_) => panic!("expected ShieldedNoRecordedAnchor, got Ok"),
+        }
     }
 }

--- a/packages/rs-platform-wallet/src/wallet/shielded/operations.rs
+++ b/packages/rs-platform-wallet/src/wallet/shielded/operations.rs
@@ -27,7 +27,7 @@ use super::keys::OrchardKeySet;
 use super::note_selection::{
     select_notes_for_denomination, select_notes_with_fee, ShieldedFeeKind,
 };
-use super::store::{ShieldedNote, ShieldedStore, SubwalletId};
+use super::store::{PendingRedrive, ShieldedNote, ShieldedStore, SubwalletId};
 use crate::changeset::{PlatformWalletChangeSet, ShieldedChangeSet};
 use crate::error::PlatformWalletError;
 use crate::wallet::persister::WalletPersister;
@@ -61,7 +61,7 @@ use dpp::state_transition::StateTransition;
 use dpp::withdrawal::Pooling;
 use grovedb_commitment_tree::{Anchor, PaymentAddress};
 use tokio::sync::RwLock;
-use tracing::{info, trace, warn};
+use tracing::{debug, info, trace, warn};
 
 /// Number of Orchard actions in a `Shield` (Type 15) bundle.
 ///
@@ -742,7 +742,17 @@ pub async fn unshield<S: ShieldedStore, P: OrchardProver>(
         arm_pending_release(store, id, anchor_bytes, &pending_entry, &selected_notes).await;
 
         trace!("Unshield: state transition built, broadcasting...");
-        broadcast_shielded_spend(sdk, &state_transition, "unshield").await
+        broadcast_shielded_spend_with_redrive(
+            sdk,
+            store,
+            id,
+            &pending_entry,
+            anchor_bytes,
+            &selected_notes,
+            &state_transition,
+            "unshield",
+        )
+        .await
     }
     .await;
 
@@ -909,7 +919,17 @@ pub async fn transfer<S: ShieldedStore, P: OrchardProver>(
         arm_pending_release(store, id, anchor_bytes, &pending_entry, &selected_notes).await;
 
         trace!("Shielded transfer: state transition built, broadcasting...");
-        broadcast_shielded_spend(sdk, &state_transition, "transfer").await
+        broadcast_shielded_spend_with_redrive(
+            sdk,
+            store,
+            id,
+            &pending_entry,
+            anchor_bytes,
+            &selected_notes,
+            &state_transition,
+            "transfer",
+        )
+        .await
     }
     .await;
 
@@ -1066,7 +1086,17 @@ pub async fn withdraw<S: ShieldedStore, P: OrchardProver>(
         arm_pending_release(store, id, anchor_bytes, &pending_entry, &selected_notes).await;
 
         trace!("Shielded withdrawal: state transition built, broadcasting...");
-        broadcast_shielded_spend(sdk, &state_transition, "withdraw").await
+        broadcast_shielded_spend_with_redrive(
+            sdk,
+            store,
+            id,
+            &pending_entry,
+            anchor_bytes,
+            &selected_notes,
+            &state_transition,
+            "withdraw",
+        )
+        .await
     }
     .await;
 
@@ -1355,6 +1385,21 @@ where
                         ));
                     }
                     None => {
+                        // Arm the persisted re-drive before surfacing the
+                        // ambiguity: the sync-time pass re-checks the
+                        // nullifiers, then re-broadcasts this
+                        // byte-identical transition up to
+                        // MAX_REDRIVE_ATTEMPTS times.
+                        arm_redrive_record(
+                            store,
+                            id,
+                            &pending_entry,
+                            anchor_bytes,
+                            &selected_notes,
+                            &st,
+                            "identity_create",
+                        )
+                        .await;
                         return Err(PlatformWalletError::ShieldedBroadcastUnconfirmed {
                             identity_id,
                             reason: wait_err.to_string(),
@@ -1936,6 +1981,297 @@ async fn arm_pending_release<S: ShieldedStore>(
     }
 }
 
+/// Maximum sync-time re-broadcast attempts for a
+/// broadcast-accepted-but-unconfirmed spend before the re-drive stops
+/// and the anchor-prune release backstop owns the reservation.
+pub(super) const MAX_REDRIVE_ATTEMPTS: u32 = 3;
+
+/// Broadcast a built shielded spend and, on the AMBIGUOUS outcome only
+/// (`ShieldedSpendUnconfirmed` — accepted broadcast, failed result
+/// wait), persist a [`PendingRedrive`] so the sync-time re-drive can
+/// resolve the ambiguity actively: the next scan detects a landing via
+/// the nullifiers; otherwise the byte-identical transition is
+/// re-broadcast up to [`MAX_REDRIVE_ATTEMPTS`] times (fund-safe —
+/// identical nullifiers cannot double-spend); only if every attempt
+/// stays silent does the anchor-prune release backstop take over.
+#[allow(clippy::too_many_arguments)]
+async fn broadcast_shielded_spend_with_redrive<S: ShieldedStore>(
+    sdk: &Arc<dash_sdk::Sdk>,
+    store: &Arc<RwLock<S>>,
+    id: SubwalletId,
+    pending_entry: &Option<super::activity::ShieldedActivityEntry>,
+    anchor: [u8; 32],
+    notes: &[ShieldedNote],
+    state_transition: &StateTransition,
+    operation: &'static str,
+) -> Result<(), PlatformWalletError> {
+    let result = broadcast_shielded_spend(sdk, state_transition, operation).await;
+    if matches!(
+        &result,
+        Err(PlatformWalletError::ShieldedSpendUnconfirmed { .. })
+    ) {
+        arm_redrive_record(
+            store,
+            id,
+            pending_entry,
+            anchor,
+            notes,
+            state_transition,
+            operation,
+        )
+        .await;
+    }
+    result
+}
+
+/// Persist the re-drivable record for an ambiguous spend. Best-effort:
+/// a failure here only demotes the resolution path to the anchor-prune
+/// backstop (plus restart-loss of the reservation), never fails the
+/// spend call itself — the ambiguity already happened.
+async fn arm_redrive_record<S: ShieldedStore>(
+    store: &Arc<RwLock<S>>,
+    id: SubwalletId,
+    pending_entry: &Option<super::activity::ShieldedActivityEntry>,
+    anchor: [u8; 32],
+    notes: &[ShieldedNote],
+    state_transition: &StateTransition,
+    operation: &'static str,
+) {
+    use dpp::serialization::PlatformSerializable;
+
+    let Some(entry) = pending_entry else {
+        return;
+    };
+    let st_bytes = match state_transition.serialize_to_bytes() {
+        Ok(b) => b,
+        Err(e) => {
+            warn!(
+                operation,
+                error = %e,
+                "failed to serialize the unconfirmed transition; re-drive disabled for this \
+                 spend (prune backstop still applies)"
+            );
+            return;
+        }
+    };
+    let redrive = PendingRedrive {
+        activity_id: entry.id,
+        anchor,
+        nullifiers: notes.iter().map(|n| n.nullifier).collect(),
+        st_bytes,
+        attempts: 0,
+    };
+    if let Err(e) = store.write().await.arm_redrive(id, redrive) {
+        warn!(
+            operation,
+            error = %e,
+            "failed to persist the redrive record; re-drive disabled for this spend (prune \
+             backstop still applies)"
+        );
+    }
+}
+
+/// Whether an SDK error is Platform's `NullifierAlreadySpentError` —
+/// on a RE-broadcast of our own byte-identical transition this means
+/// the ORIGINAL broadcast executed: the nullifiers are consumed by the
+/// very spend being re-driven, so it is a success signal (the next scan
+/// confirms the notes spent), never a failure.
+fn is_nullifier_already_spent(e: &dash_sdk::Error) -> bool {
+    use dpp::consensus::state::state_error::StateError;
+    use dpp::consensus::ConsensusError;
+
+    let consensus: Option<&ConsensusError> = match e {
+        dash_sdk::Error::Protocol(dpp::ProtocolError::ConsensusError(c)) => Some(c),
+        dash_sdk::Error::StateTransitionBroadcastError(b) => b.cause.as_ref(),
+        _ => None,
+    };
+    matches!(
+        consensus,
+        Some(ConsensusError::StateError(
+            StateError::NullifierAlreadySpentError(_)
+        ))
+    )
+}
+
+/// Pure outcome classification for one re-broadcast attempt. Extracted
+/// from the redrive loop so the arm ORDER — `AlreadyExecuted` must win
+/// over the generic consensus-rejection check, since
+/// `NullifierAlreadySpent` is itself a consensus error — is pinned by
+/// unit tests without needing a broadcast-mockable network seam.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum RedriveBroadcastOutcome {
+    /// Relay accepted the re-broadcast; the next scan detects a landing.
+    Accepted,
+    /// `NullifierAlreadySpent`: the ORIGINAL broadcast executed — a
+    /// success signal, never a failure.
+    AlreadyExecuted,
+    /// Any other consensus verdict: the transition can never execute.
+    DefinitiveRejection,
+    /// Transport noise / `AlreadyExists` / anything non-definitive.
+    Inconclusive,
+}
+
+fn classify_redrive_broadcast(result: &Result<(), dash_sdk::Error>) -> RedriveBroadcastOutcome {
+    match result {
+        Ok(()) => RedriveBroadcastOutcome::Accepted,
+        Err(e) if is_nullifier_already_spent(e) => RedriveBroadcastOutcome::AlreadyExecuted,
+        Err(e) if carries_consensus_rejection(e) => RedriveBroadcastOutcome::DefinitiveRejection,
+        Err(_) => RedriveBroadcastOutcome::Inconclusive,
+    }
+}
+
+/// Bump a redrive attempt counter, logging (rather than discarding) a
+/// persistence failure. On `Err` the durable counter did not advance and
+/// the file store's persist-first ordering leaves memory untouched, so
+/// the same attempt slot is retried on the next pass — the log line is
+/// what makes that visible.
+async fn bump_redrive_attempts_logged<S: ShieldedStore>(
+    store: &Arc<RwLock<S>>,
+    id: SubwalletId,
+    activity_id: &[u8; 32],
+) -> u32 {
+    match store.write().await.bump_redrive_attempts(id, activity_id) {
+        Ok(attempts) => attempts,
+        Err(e) => {
+            warn!(
+                error = %e,
+                "redrive: failed to persist the attempt counter; the attempt will be \
+                 retried on the next pass"
+            );
+            0
+        }
+    }
+}
+
+/// Sync-time re-drive for `id`'s armed unconfirmed spends: for each
+/// [`PendingRedrive`] whose anchor is still in Platform's `recorded`
+/// set and whose attempt budget remains, re-broadcast the stored
+/// byte-identical transition (relay-ACK only — the landing itself is
+/// detected by the NEXT scan's nullifier reconcile) and classify:
+///
+/// - accepted / inconclusive → count the attempt; wait for the next scan;
+/// - `NullifierAlreadySpent` → the original executed; the next scan
+///   confirms — touch nothing;
+/// - any other consensus verdict → provably dead NOW: release the
+///   reservation and flip the activity row to Failed, hours before the
+///   prune backstop would;
+/// - pruned anchor / exhausted attempts → leave it to the
+///   prune-backstop release pass.
+///
+/// Runs after the scan's spent-note reconcile (a landed spend's record
+/// was already dropped by the `mark_spent` hook, so anything still
+/// armed here is genuinely unresolved).
+pub(super) async fn redrive_pending_spends<S: ShieldedStore>(
+    sdk: &Arc<dash_sdk::Sdk>,
+    store: &Arc<RwLock<S>>,
+    persister: Option<&WalletPersister>,
+    wallet_id: WalletId,
+    id: SubwalletId,
+    recorded: &std::collections::HashSet<[u8; 32]>,
+) {
+    use dpp::serialization::PlatformDeserializable;
+
+    let redrives = match store.read().await.pending_redrives(id) {
+        Ok(r) => r,
+        Err(e) => {
+            warn!(
+                error = %e,
+                "redrive: pending_redrives failed; skipping subwallet"
+            );
+            return;
+        }
+    };
+    for redrive in redrives {
+        // A pruned anchor is the release pass's call, not ours; an
+        // exhausted budget means we've said our three pieces.
+        if !recorded.contains(&redrive.anchor) || redrive.attempts >= MAX_REDRIVE_ATTEMPTS {
+            continue;
+        }
+        let st = match StateTransition::deserialize_from_bytes(&redrive.st_bytes) {
+            Ok(st) => st,
+            Err(e) => {
+                warn!(
+                    error = %e,
+                    "redrive: stored transition failed to deserialize; dropping the record \
+                     (the prune backstop still frees the notes)"
+                );
+                if let Err(e) = store.write().await.clear_redrive(id, &redrive.activity_id) {
+                    warn!(error = %e, "redrive: clear_redrive failed");
+                }
+                continue;
+            }
+        };
+        let broadcast_result = st.broadcast(sdk, None).await;
+        let err_display = broadcast_result
+            .as_ref()
+            .err()
+            .map(|e| e.to_string())
+            .unwrap_or_default();
+        match classify_redrive_broadcast(&broadcast_result) {
+            RedriveBroadcastOutcome::Accepted => {
+                let attempts = bump_redrive_attempts_logged(store, id, &redrive.activity_id).await;
+                info!(
+                    attempts,
+                    max = MAX_REDRIVE_ATTEMPTS,
+                    "redrive: re-broadcast accepted; the next scan detects the landing"
+                );
+            }
+            RedriveBroadcastOutcome::AlreadyExecuted => {
+                // Success signal — but still consume an attempt: the scan
+                // normally confirms the landing and drops the record, and
+                // if it lags, this arm must not re-broadcast unboundedly
+                // on every pass. The cap parks the record for the scan /
+                // prune passes to settle.
+                let attempts = bump_redrive_attempts_logged(store, id, &redrive.activity_id).await;
+                info!(
+                    attempts,
+                    max = MAX_REDRIVE_ATTEMPTS,
+                    "redrive: transition already executed on-chain; the next scan confirms \
+                     the notes spent"
+                );
+            }
+            RedriveBroadcastOutcome::DefinitiveRejection => {
+                warn!(
+                    error = %err_display,
+                    "redrive: definitive consensus rejection; the spend can never execute — \
+                     releasing the reservation"
+                );
+                {
+                    let mut guard = store.write().await;
+                    for n in &redrive.nullifiers {
+                        // Also drops the redrive record via the
+                        // clear_pending hook.
+                        if let Err(e) = guard.clear_pending(id, n) {
+                            warn!(error = %e, "redrive: clear_pending failed");
+                        }
+                    }
+                }
+                record_activity_status_by_id(
+                    store,
+                    persister,
+                    wallet_id,
+                    id,
+                    &redrive.activity_id,
+                    ShieldedActivityStatus::Failed,
+                )
+                .await;
+            }
+            RedriveBroadcastOutcome::Inconclusive => {
+                // `AlreadyExists` (still in a mempool after a lost-ACK
+                // retry) or transport noise: inconclusive; counts toward
+                // the cap.
+                let attempts = bump_redrive_attempts_logged(store, id, &redrive.activity_id).await;
+                debug!(
+                    attempts,
+                    max = MAX_REDRIVE_ATTEMPTS,
+                    error = %err_display,
+                    "redrive: re-broadcast inconclusive"
+                );
+            }
+        }
+    }
+}
+
 /// Whether an SDK error carries Platform's own consensus verdict on the
 /// transition. Two shapes qualify:
 ///
@@ -2173,6 +2509,146 @@ fn deserialize_note(data: &[u8]) -> Option<grovedb_commitment_tree::Note> {
     let rseed = RandomSeed::from_bytes(rseed_bytes, &rho).into_option()?;
 
     Note::from_parts(recipient, value, rho, rseed).into_option()
+}
+
+#[cfg(test)]
+mod redrive_tests {
+    use super::*;
+    use crate::wallet::shielded::store::InMemoryShieldedStore;
+    use dash_sdk::error::StateTransitionBroadcastError;
+    use dpp::consensus::state::shielded::nullifier_already_spent_error::NullifierAlreadySpentError;
+    use dpp::consensus::state::state_error::StateError;
+    use dpp::consensus::ConsensusError;
+
+    /// On a re-broadcast of our own byte-identical transition,
+    /// `NullifierAlreadySpent` means the ORIGINAL executed — the
+    /// classification must treat it as a success signal, distinct from
+    /// every other consensus verdict.
+    #[test]
+    fn nullifier_already_spent_is_a_success_signal() {
+        let cause = ConsensusError::StateError(StateError::NullifierAlreadySpentError(
+            NullifierAlreadySpentError::new([1u8; 32]),
+        ));
+        let err = dash_sdk::Error::StateTransitionBroadcastError(StateTransitionBroadcastError {
+            code: 1,
+            message: "state error".to_string(),
+            cause: Some(cause),
+        });
+        assert!(is_nullifier_already_spent(&err));
+        // ...and it still counts as a consensus-rejection shape, so arm
+        // ordering matters: the already-spent check must run first.
+        assert!(carries_consensus_rejection(&err));
+
+        let other = dash_sdk::Error::TimeoutReached(
+            std::time::Duration::from_secs(1),
+            "waiting".to_string(),
+        );
+        assert!(!is_nullifier_already_spent(&other));
+    }
+
+    /// The re-broadcast outcome classifier, arm order included:
+    /// `NullifierAlreadySpent` is itself a consensus error, so the
+    /// `AlreadyExecuted` arm must win over `DefinitiveRejection`.
+    #[test]
+    fn redrive_broadcast_classification_matrix() {
+        assert_eq!(
+            classify_redrive_broadcast(&Ok(())),
+            RedriveBroadcastOutcome::Accepted
+        );
+
+        let already_spent = ConsensusError::StateError(StateError::NullifierAlreadySpentError(
+            NullifierAlreadySpentError::new([1u8; 32]),
+        ));
+        let already_spent_err =
+            dash_sdk::Error::StateTransitionBroadcastError(StateTransitionBroadcastError {
+                code: 1,
+                message: "state error".to_string(),
+                cause: Some(already_spent),
+            });
+        assert_eq!(
+            classify_redrive_broadcast(&Err(already_spent_err)),
+            RedriveBroadcastOutcome::AlreadyExecuted,
+            "already-spent must classify as success BEFORE the generic rejection arm"
+        );
+
+        let other_rejection = ConsensusError::BasicError(
+            dpp::consensus::basic::BasicError::ProtocolVersionParsingError(
+                dpp::consensus::basic::decode::ProtocolVersionParsingError::new(
+                    "bad version".to_string(),
+                ),
+            ),
+        );
+        let rejection_err =
+            dash_sdk::Error::StateTransitionBroadcastError(StateTransitionBroadcastError {
+                code: 1,
+                message: "state error".to_string(),
+                cause: Some(other_rejection),
+            });
+        assert_eq!(
+            classify_redrive_broadcast(&Err(rejection_err)),
+            RedriveBroadcastOutcome::DefinitiveRejection
+        );
+
+        let timeout = dash_sdk::Error::TimeoutReached(
+            std::time::Duration::from_secs(1),
+            "waiting".to_string(),
+        );
+        assert_eq!(
+            classify_redrive_broadcast(&Err(timeout)),
+            RedriveBroadcastOutcome::Inconclusive
+        );
+    }
+
+    /// Decision paths that must NOT touch the network (the mock SDK has
+    /// no broadcast expectation, so any attempt would error into the
+    /// inconclusive arm and bump the counter): a pruned anchor belongs
+    /// to the release backstop, an exhausted budget stays parked, and a
+    /// corrupt stored transition is dropped so it can't wedge the pass.
+    #[tokio::test]
+    async fn redrive_skips_pruned_and_exhausted_and_drops_garbage() {
+        let sdk = Arc::new(dash_sdk::SdkBuilder::new_mock().build().expect("mock sdk"));
+        let store = Arc::new(RwLock::new(InMemoryShieldedStore::new()));
+        let wallet_id = [5u8; 32];
+        let id = SubwalletId::new(wallet_id, 0);
+
+        let rec = |activity: u8, anchor: u8, attempts: u32| PendingRedrive {
+            activity_id: [activity; 32],
+            anchor: [anchor; 32],
+            nullifiers: vec![[activity ^ 0xFF; 32]],
+            st_bytes: vec![0xDE, 0xAD], // never deserializes
+            attempts,
+        };
+        {
+            let mut guard = store.write().await;
+            // Pruned anchor (10 not in recorded set) → untouched.
+            guard.arm_redrive(id, rec(1, 10, 0)).unwrap();
+            // Recorded anchor but attempts exhausted → untouched.
+            guard
+                .arm_redrive(id, rec(2, 11, MAX_REDRIVE_ATTEMPTS))
+                .unwrap();
+            // Recorded anchor, budget left, garbage bytes → dropped
+            // before any broadcast.
+            guard.arm_redrive(id, rec(3, 12, 0)).unwrap();
+        }
+        let recorded: std::collections::HashSet<[u8; 32]> =
+            [[11u8; 32], [12u8; 32]].into_iter().collect();
+
+        redrive_pending_spends(&sdk, &store, None, wallet_id, id, &recorded).await;
+
+        let left = store.read().await.pending_redrives(id).unwrap();
+        let ids: Vec<[u8; 32]> = left.iter().map(|r| r.activity_id).collect();
+        assert!(ids.contains(&[1u8; 32]), "pruned-anchor record left alone");
+        assert!(ids.contains(&[2u8; 32]), "exhausted record left alone");
+        assert!(
+            !ids.contains(&[3u8; 32]),
+            "corrupt record dropped without a broadcast attempt"
+        );
+        assert_eq!(
+            left.iter().map(|r| r.attempts).max(),
+            Some(MAX_REDRIVE_ATTEMPTS),
+            "no attempt counters were bumped — nothing touched the network"
+        );
+    }
 }
 
 #[cfg(test)]

--- a/packages/rs-platform-wallet/src/wallet/shielded/store.rs
+++ b/packages/rs-platform-wallet/src/wallet/shielded/store.rs
@@ -252,13 +252,35 @@ pub trait ShieldedStore: Send + Sync {
     /// Return the current tree root (Sinsemilla anchor, 32 bytes).
     fn tree_anchor(&self) -> Result<[u8; 32], Self::Error>;
 
-    /// Generate a Merkle authentication path for `position`
-    /// against the current tree state. Returns `Ok(None)` if no
-    /// witness is available (position not marked, or pruned).
+    /// Generate a Merkle authentication path for `position` as of the
+    /// checkpoint at `depth` (0 = current tree state, 1 = the previous
+    /// checkpoint, and so on). Returns `Ok(None)` when no witness is
+    /// available at that depth — the position is unmarked/pruned, the
+    /// requested checkpoint depth doesn't exist, or the position was
+    /// appended after that checkpoint.
+    ///
+    /// Building a spend against an older-but-recorded checkpoint is how the
+    /// wallet keeps its anchor consistent with a root Platform actually
+    /// recorded: Platform records one anchor per block while an index-chunk
+    /// sync routinely leaves the tree mid-block, so the depth-0 root is often
+    /// one Platform never recorded.
+    fn witness_at_depth(
+        &self,
+        position: u64,
+        depth: usize,
+    ) -> Result<Option<grovedb_commitment_tree::MerklePath>, Self::Error>;
+
+    /// Generate a Merkle authentication path for `position` against the
+    /// current tree state. Returns `Ok(None)` if no witness is available
+    /// (position not marked, or pruned).
+    ///
+    /// Delegates to [`Self::witness_at_depth`] at depth 0.
     fn witness(
         &self,
         position: u64,
-    ) -> Result<Option<grovedb_commitment_tree::MerklePath>, Self::Error>;
+    ) -> Result<Option<grovedb_commitment_tree::MerklePath>, Self::Error> {
+        self.witness_at_depth(position, 0)
+    }
 
     /// Number of leaves currently in the shared commitment tree
     /// (= highest appended position + 1, or 0 when empty).
@@ -633,9 +655,10 @@ impl ShieldedStore for InMemoryShieldedStore {
         Ok(self.anchor)
     }
 
-    fn witness(
+    fn witness_at_depth(
         &self,
         _position: u64,
+        _depth: usize,
     ) -> Result<Option<grovedb_commitment_tree::MerklePath>, Self::Error> {
         Err(InMemoryStoreError(
             "Merkle witness not supported in in-memory store".into(),

--- a/packages/rs-platform-wallet/src/wallet/shielded/store.rs
+++ b/packages/rs-platform-wallet/src/wallet/shielded/store.rs
@@ -116,6 +116,13 @@ pub struct ShieldedOutgoingNote {
     pub block_height: u64,
 }
 
+/// A pending reservation that carries a recorded anchor:
+/// `(nullifier, anchor, activity_id)`. Yielded by
+/// [`ShieldedStore::stale_pending_spends`] for the sync reconcile,
+/// which releases the reservation once `anchor` is no longer in
+/// Platform's recorded set (the spend can then never execute).
+pub type StalePendingSpend = ([u8; 32], [u8; 32], Option<[u8; 32]>);
+
 /// Storage abstraction for shielded wallet state.
 ///
 /// Consumers implement this for their persistence layer. The
@@ -168,6 +175,29 @@ pub trait ShieldedStore: Send + Sync {
     /// `mark_spent`).
     fn clear_pending(&mut self, id: SubwalletId, nullifier: &[u8; 32])
         -> Result<bool, Self::Error>;
+
+    /// Attach the recorded `anchor` the spend was built against, and
+    /// the linked `activity_id`, to `id`'s pending reservation for
+    /// `nullifier` (taken earlier by [`Self::mark_pending`]). No-op
+    /// if the nullifier is no longer pending. The sync reconcile uses
+    /// the stored anchor to detect a stranded spend whose anchor
+    /// Platform has pruned (see [`Self::stale_pending_spends`]).
+    fn set_pending_spend(
+        &mut self,
+        id: SubwalletId,
+        nullifier: &[u8; 32],
+        anchor: [u8; 32],
+        activity_id: [u8; 32],
+    ) -> Result<(), Self::Error>;
+
+    /// Pending reservations for `id` that carry a recorded anchor —
+    /// `(nullifier, anchor, activity_id)` per built-but-unconfirmed
+    /// spend. Empty when `id` has no anchored reservations (the common
+    /// case, which lets the sync reconcile skip its network round-trip).
+    /// The reconcile checks each anchor against Platform's recorded set
+    /// and releases the reservation via [`Self::clear_pending`] when the
+    /// anchor is pruned — the spend can then never execute.
+    fn stale_pending_spends(&self, id: SubwalletId) -> Result<Vec<StalePendingSpend>, Self::Error>;
 
     // ── Outgoing history (per-subwallet) ───────────────────────────────
 
@@ -350,6 +380,28 @@ pub trait ShieldedStore: Send + Sync {
 
 // ── Per-subwallet bookkeeping ──────────────────────────────────────────
 
+/// In-flight-spend bookkeeping for a single reserved nullifier.
+///
+/// A reservation starts life bare (both fields `None`) the moment
+/// [`SubwalletState::mark_pending`] excludes the note from selection.
+/// Once the spend is actually built, [`SubwalletState::set_pending_spend`]
+/// records the Platform-**recorded** anchor it was built against and the
+/// linked activity-log entry, so the sync reconcile can later detect a
+/// stranded (broadcast-accepted-but-never-landed) spend: once that anchor
+/// is pruned from Platform's recorded set the spend can never execute, and
+/// with the nullifier still unspent the reservation is provably dead and
+/// its note can be freed. All in-memory only — a restart drops every
+/// reservation regardless.
+#[derive(Debug, Clone, Default)]
+pub(super) struct PendingSpend {
+    /// The recorded anchor the spend was built against, once known.
+    /// `None` while the note is reserved but the spend isn't built yet.
+    pub anchor: Option<[u8; 32]>,
+    /// The linked activity-log entry id, so a released reservation can
+    /// flip its "Pending" row to "Failed" instead of stranding it.
+    pub activity_id: Option<[u8; 32]>,
+}
+
 /// Per-subwallet note + sync state used by both the in-memory and
 /// file-backed stores. Kept in this module so both share the
 /// exact same shape and the persister callback can serialize it
@@ -364,10 +416,11 @@ pub(super) struct SubwalletState {
     /// global index to scan (exclusive). `0` = nothing scanned yet.
     pub last_synced_index: u64,
     /// Nullifiers of notes currently being spent in an in-flight
-    /// transition. Excluded from `unspent_notes()` so concurrent
-    /// callers can't double-select. In-memory only — never
-    /// persisted; the next sync after a crash reconciles state.
-    pub pending_nullifiers: BTreeSet<[u8; 32]>,
+    /// transition, mapped to the [`PendingSpend`] bookkeeping the
+    /// sync reconcile needs. Excluded from `unspent_notes()` so
+    /// concurrent callers can't double-select. In-memory only —
+    /// never persisted; the next sync after a crash reconciles state.
+    pub pending_nullifiers: BTreeMap<[u8; 32], PendingSpend>,
     /// Notes this subwallet SENT, recovered via OVK during the scan.
     /// Append-only send history in recording order.
     pub outgoing_notes: Vec<ShieldedOutgoingNote>,
@@ -400,7 +453,7 @@ impl SubwalletState {
     pub(super) fn unspent_notes(&self) -> Vec<ShieldedNote> {
         self.notes
             .iter()
-            .filter(|n| !n.is_spent && !self.pending_nullifiers.contains(&n.nullifier))
+            .filter(|n| !n.is_spent && !self.pending_nullifiers.contains_key(&n.nullifier))
             .cloned()
             .collect()
     }
@@ -425,16 +478,60 @@ impl SubwalletState {
     }
 
     /// Reserve `nullifier` against an in-flight spend. Returns
-    /// `true` if newly added.
+    /// `true` if newly added, `false` if it was already reserved.
+    /// Re-reserving is a true no-op: an already-armed entry keeps its
+    /// anchor/activity link (selection excludes pending nullifiers, so
+    /// this shouldn't happen — but a plain `insert` would silently
+    /// wipe the release pass's only handle on a stranded spend if it
+    /// ever did).
     pub(super) fn mark_pending(&mut self, nullifier: &[u8; 32]) -> bool {
-        self.pending_nullifiers.insert(*nullifier)
+        match self.pending_nullifiers.entry(*nullifier) {
+            std::collections::btree_map::Entry::Vacant(e) => {
+                e.insert(PendingSpend::default());
+                true
+            }
+            std::collections::btree_map::Entry::Occupied(_) => false,
+        }
+    }
+
+    /// Attach the built spend's recorded `anchor` and linked
+    /// `activity_id` to an existing reservation for `nullifier`.
+    /// No-op if the nullifier is no longer pending (e.g. the
+    /// reservation was already cleared by a concurrent finalize).
+    pub(super) fn set_pending_spend(
+        &mut self,
+        nullifier: &[u8; 32],
+        anchor: [u8; 32],
+        activity_id: [u8; 32],
+    ) {
+        if let Some(pending) = self.pending_nullifiers.get_mut(nullifier) {
+            pending.anchor = Some(anchor);
+            pending.activity_id = Some(activity_id);
+        }
+    }
+
+    /// Reservations that carry a recorded anchor — i.e. built,
+    /// broadcast-but-unconfirmed spends. Returns `(nullifier,
+    /// anchor, activity_id)` per such entry; reservations still
+    /// awaiting a built spend (`anchor: None`) are skipped. The
+    /// sync reconcile checks each anchor against Platform's recorded
+    /// set and releases the reservation when the anchor is pruned.
+    pub(super) fn stale_pending_spends(&self) -> Vec<StalePendingSpend> {
+        self.pending_nullifiers
+            .iter()
+            .filter_map(|(nullifier, spend)| {
+                spend
+                    .anchor
+                    .map(|anchor| (*nullifier, anchor, spend.activity_id))
+            })
+            .collect()
     }
 
     /// Release a reservation previously taken via `mark_pending`.
     /// Returns `true` if a matching reservation was actually
     /// removed.
     pub(super) fn clear_pending(&mut self, nullifier: &[u8; 32]) -> bool {
-        self.pending_nullifiers.remove(nullifier)
+        self.pending_nullifiers.remove(nullifier).is_some()
     }
 
     /// Record an outgoing (sent) note. Idempotent by `cmx`: returns
@@ -574,6 +671,27 @@ impl ShieldedStore for InMemoryShieldedStore {
             .get_mut(&id)
             .map(|sw| sw.clear_pending(nullifier))
             .unwrap_or(false))
+    }
+
+    fn set_pending_spend(
+        &mut self,
+        id: SubwalletId,
+        nullifier: &[u8; 32],
+        anchor: [u8; 32],
+        activity_id: [u8; 32],
+    ) -> Result<(), Self::Error> {
+        if let Some(sw) = self.subwallets.get_mut(&id) {
+            sw.set_pending_spend(nullifier, anchor, activity_id);
+        }
+        Ok(())
+    }
+
+    fn stale_pending_spends(&self, id: SubwalletId) -> Result<Vec<StalePendingSpend>, Self::Error> {
+        Ok(self
+            .subwallets
+            .get(&id)
+            .map(SubwalletState::stale_pending_spends)
+            .unwrap_or_default())
     }
 
     fn record_outgoing_note(
@@ -887,5 +1005,152 @@ mod tests {
         // Re-append starts from position 0 again.
         store.append_commitment(&[3u8; 32], true).unwrap();
         assert_eq!(store.tree_size().unwrap(), 1);
+    }
+
+    /// Build a minimal unspent note carrying `nullifier`.
+    fn note_with_nullifier(nullifier: [u8; 32]) -> ShieldedNote {
+        ShieldedNote {
+            position: 0,
+            cmx: [1u8; 32],
+            nullifier,
+            block_height: 1,
+            is_spent: false,
+            value: 1_000,
+            note_data: vec![0u8; 115],
+        }
+    }
+
+    /// A reservation carrying a recorded anchor surfaces via
+    /// `stale_pending_spends`, and the sync reconcile's release decision
+    /// (release iff the anchor is absent from the recorded set) must RETAIN
+    /// it while the anchor is still recorded — a slow-but-landing spend is
+    /// never freed, so its note stays out of the unspent set.
+    #[test]
+    fn pending_spend_with_recorded_anchor_is_retained() {
+        use std::collections::HashSet;
+
+        let mut store = InMemoryShieldedStore::new();
+        let id = test_id(0);
+        let nullifier = [0x11; 32];
+        let anchor = [0x22; 32];
+        let activity_id = [0x33; 32];
+
+        store
+            .save_note(id, &note_with_nullifier(nullifier))
+            .unwrap();
+        assert!(
+            store.mark_pending(id, &nullifier).unwrap(),
+            "newly reserved"
+        );
+        store
+            .set_pending_spend(id, &nullifier, anchor, activity_id)
+            .unwrap();
+
+        assert_eq!(
+            store.stale_pending_spends(id).unwrap(),
+            vec![(nullifier, anchor, Some(activity_id))],
+            "an armed reservation surfaces as an anchored (stale-checkable) spend"
+        );
+
+        // Anchor IS still recorded → retain.
+        let recorded: HashSet<[u8; 32]> = [anchor].into_iter().collect();
+        for (n, a, _) in store.stale_pending_spends(id).unwrap() {
+            if !recorded.contains(&a) {
+                store.clear_pending(id, &n).unwrap();
+            }
+        }
+        assert_eq!(
+            store.stale_pending_spends(id).unwrap().len(),
+            1,
+            "a still-recorded anchor must not be released"
+        );
+        assert!(
+            store.get_unspent_notes(id).unwrap().is_empty(),
+            "the retained note stays excluded from selection candidates"
+        );
+    }
+
+    /// The fund-safe release: once the anchor is pruned (absent from the
+    /// recorded set) the spend can never execute, so the reservation is
+    /// released and the freed note becomes spendable again.
+    #[test]
+    fn pending_spend_with_pruned_anchor_is_released() {
+        use std::collections::HashSet;
+
+        let mut store = InMemoryShieldedStore::new();
+        let id = test_id(0);
+        let nullifier = [0x11; 32];
+        let anchor = [0x22; 32];
+        let activity_id = [0x33; 32];
+
+        store
+            .save_note(id, &note_with_nullifier(nullifier))
+            .unwrap();
+        store.mark_pending(id, &nullifier).unwrap();
+        store
+            .set_pending_spend(id, &nullifier, anchor, activity_id)
+            .unwrap();
+        assert!(store.get_unspent_notes(id).unwrap().is_empty());
+
+        // Anchor is ABSENT from the recorded set (pruned) → release.
+        let recorded: HashSet<[u8; 32]> = [[0xEE; 32]].into_iter().collect();
+        for (n, a, _) in store.stale_pending_spends(id).unwrap() {
+            if !recorded.contains(&a) {
+                assert!(store.clear_pending(id, &n).unwrap());
+            }
+        }
+        assert!(
+            store.stale_pending_spends(id).unwrap().is_empty(),
+            "a pruned-anchor reservation must be released"
+        );
+        let unspent = store.get_unspent_notes(id).unwrap();
+        assert_eq!(unspent.len(), 1, "the freed note is spendable again");
+        assert_eq!(unspent[0].nullifier, nullifier);
+    }
+
+    /// A reserved note is excluded from `unspent_notes` (so a concurrent
+    /// spend can't re-select it) and re-included once the reservation is
+    /// cleared.
+    #[test]
+    fn unspent_notes_excludes_pending_and_reincludes_after_clear() {
+        let mut store = InMemoryShieldedStore::new();
+        let id = test_id(0);
+        let nullifier = [0x55; 32];
+        store
+            .save_note(id, &note_with_nullifier(nullifier))
+            .unwrap();
+        assert_eq!(store.get_unspent_notes(id).unwrap().len(), 1);
+
+        store.mark_pending(id, &nullifier).unwrap();
+        assert!(
+            store.get_unspent_notes(id).unwrap().is_empty(),
+            "a reserved note is excluded from selection candidates"
+        );
+
+        assert!(store.clear_pending(id, &nullifier).unwrap());
+        assert_eq!(
+            store.get_unspent_notes(id).unwrap().len(),
+            1,
+            "releasing the reservation re-includes the note"
+        );
+    }
+
+    /// `stale_pending_spends` ignores a reservation that was `mark_pending`ed
+    /// but never armed with an anchor (a just-reserved, not-yet-built spend):
+    /// the reconcile must never release such a transient entry.
+    #[test]
+    fn unarmed_reservation_is_not_stale() {
+        let mut store = InMemoryShieldedStore::new();
+        let id = test_id(0);
+        let nullifier = [0x66; 32];
+        store
+            .save_note(id, &note_with_nullifier(nullifier))
+            .unwrap();
+        store.mark_pending(id, &nullifier).unwrap();
+
+        assert!(
+            store.stale_pending_spends(id).unwrap().is_empty(),
+            "a reservation with no recorded anchor must not surface as stale"
+        );
     }
 }

--- a/packages/rs-platform-wallet/src/wallet/shielded/store.rs
+++ b/packages/rs-platform-wallet/src/wallet/shielded/store.rs
@@ -123,6 +123,35 @@ pub struct ShieldedOutgoingNote {
 /// Platform's recorded set (the spend can then never execute).
 pub type StalePendingSpend = ([u8; 32], [u8; 32], Option<[u8; 32]>);
 
+/// A re-drivable broadcast-accepted-but-unconfirmed spend: the signed
+/// transition bytes plus everything the sync-time re-drive needs to
+/// resolve the ambiguity actively — re-broadcast the transition
+/// ([`nullifiers`](Self::nullifiers) detect a landing, `anchor` feeds
+/// the prune backstop, `activity_id` links the UI row, `attempts`
+/// bounds the retries.
+///
+/// Armed only on the ambiguous outcome (`ShieldedSpendUnconfirmed`):
+/// the broadcast was accepted but the result wait failed, so the spend
+/// may or may not have executed. Re-broadcasting the byte-identical
+/// transition is fund-safe — identical nullifiers cannot double-spend —
+/// and converts silence into either a confirmation (next scan sees the
+/// nullifiers spent) or a definitive consensus verdict.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PendingRedrive {
+    /// Activity-entry id of the spend (sha256 of visible output cmxs);
+    /// the spend-level key — every nullifier of one spend shares it.
+    pub activity_id: [u8; 32],
+    /// Platform-recorded anchor the spend was built against.
+    pub anchor: [u8; 32],
+    /// Nullifiers of every note the spend consumes.
+    pub nullifiers: Vec<[u8; 32]>,
+    /// The signed state transition, platform-serialized byte-exact as
+    /// originally broadcast.
+    pub st_bytes: Vec<u8>,
+    /// Re-broadcast attempts made so far.
+    pub attempts: u32,
+}
+
 /// Storage abstraction for shielded wallet state.
 ///
 /// Consumers implement this for their persistence layer. The
@@ -198,6 +227,39 @@ pub trait ShieldedStore: Send + Sync {
     /// and releases the reservation via [`Self::clear_pending`] when the
     /// anchor is pruned — the spend can then never execute.
     fn stale_pending_spends(&self, id: SubwalletId) -> Result<Vec<StalePendingSpend>, Self::Error>;
+
+    // ── Re-drivable unconfirmed spends (per-subwallet) ─────────────────
+
+    /// Persist a re-drivable record for a broadcast-accepted spend whose
+    /// result wait failed ambiguously. Keyed by `redrive.activity_id`;
+    /// re-arming the same id overwrites. Unlike the bare `mark_pending`
+    /// reservations, redrive records survive a restart where the backend
+    /// persists them (the file store does): on reopen both the record
+    /// and its note reservations are rehydrated, so the re-drive — and
+    /// the linked activity row's eventual Confirmed/Failed flip —
+    /// continue across relaunches.
+    fn arm_redrive(&mut self, id: SubwalletId, redrive: PendingRedrive) -> Result<(), Self::Error>;
+
+    /// Every armed redrive record for `id`.
+    fn pending_redrives(&self, id: SubwalletId) -> Result<Vec<PendingRedrive>, Self::Error>;
+
+    /// Increment the attempt counter on `id`'s redrive keyed by
+    /// `activity_id`, returning the new count (`0` when no such record
+    /// exists).
+    fn bump_redrive_attempts(
+        &mut self,
+        id: SubwalletId,
+        activity_id: &[u8; 32],
+    ) -> Result<u32, Self::Error>;
+
+    /// Drop the redrive record keyed by `activity_id` — the spend
+    /// resolved (landed, definitively rejected, or released by the
+    /// anchor-prune backstop). Implementations also drop the record
+    /// implicitly when [`Self::mark_spent`] or [`Self::clear_pending`]
+    /// resolves one of its nullifiers, since a transition lands or dies
+    /// atomically for all of its nullifiers.
+    fn clear_redrive(&mut self, id: SubwalletId, activity_id: &[u8; 32])
+        -> Result<(), Self::Error>;
 
     // ── Outgoing history (per-subwallet) ───────────────────────────────
 
@@ -418,9 +480,19 @@ pub(super) struct SubwalletState {
     /// Nullifiers of notes currently being spent in an in-flight
     /// transition, mapped to the [`PendingSpend`] bookkeeping the
     /// sync reconcile needs. Excluded from `unspent_notes()` so
-    /// concurrent callers can't double-select. In-memory only —
-    /// never persisted; the next sync after a crash reconciles state.
+    /// concurrent callers can't double-select. Held in memory; a
+    /// pre-broadcast reservation dies with the process, but a
+    /// reservation belonging to an armed [`PendingRedrive`] is
+    /// rehydrated on file-store open (the redrive row carries its
+    /// nullifiers), so an unconfirmed broadcast keeps its notes
+    /// reserved across restarts.
     pub pending_nullifiers: BTreeMap<[u8; 32], PendingSpend>,
+    /// Armed re-drivable unconfirmed spends, keyed by activity id.
+    /// See [`PendingRedrive`]. Kept consistent with
+    /// `pending_nullifiers`: resolving any of a redrive's nullifiers
+    /// (mark_spent / clear_pending) drops the whole record — a
+    /// transition lands or dies atomically for all its nullifiers.
+    pub redrives: BTreeMap<[u8; 32], PendingRedrive>,
     /// Notes this subwallet SENT, recovered via OVK during the scan.
     /// Append-only send history in recording order.
     pub outgoing_notes: Vec<ShieldedOutgoingNote>,
@@ -471,10 +543,30 @@ impl SubwalletState {
                 // common path already cleared pending in the
                 // spend-flow finalizer.
                 self.pending_nullifiers.remove(nullifier);
+                // The spend landed — its redrive record (if armed) is
+                // resolved for every nullifier it carries.
+                self.drop_redrives_containing(nullifier);
                 return true;
             }
         }
         false
+    }
+
+    /// Drop every redrive record that carries `nullifier`, returning
+    /// the dropped activity ids (the file store mirrors the deletions
+    /// to SQLite). A transition lands or dies atomically for all of
+    /// its nullifiers, so resolving one resolves the record.
+    pub(super) fn drop_redrives_containing(&mut self, nullifier: &[u8; 32]) -> Vec<[u8; 32]> {
+        let dropped: Vec<[u8; 32]> = self
+            .redrives
+            .iter()
+            .filter(|(_, r)| r.nullifiers.contains(nullifier))
+            .map(|(id, _)| *id)
+            .collect();
+        for id in &dropped {
+            self.redrives.remove(id);
+        }
+        dropped
     }
 
     /// Reserve `nullifier` against an in-flight spend. Returns
@@ -531,7 +623,43 @@ impl SubwalletState {
     /// Returns `true` if a matching reservation was actually
     /// removed.
     pub(super) fn clear_pending(&mut self, nullifier: &[u8; 32]) -> bool {
-        self.pending_nullifiers.remove(nullifier).is_some()
+        let removed = self.pending_nullifiers.remove(nullifier).is_some();
+        if removed {
+            // Releasing a reservation resolves its spend for good
+            // (definitive rejection or prune backstop) — the redrive
+            // record goes with it.
+            self.drop_redrives_containing(nullifier);
+        }
+        removed
+    }
+
+    /// Arm (or overwrite by activity id) a re-drivable record.
+    pub(super) fn arm_redrive(&mut self, redrive: PendingRedrive) {
+        self.redrives.insert(redrive.activity_id, redrive);
+    }
+
+    pub(super) fn pending_redrives(&self) -> Vec<PendingRedrive> {
+        self.redrives.values().cloned().collect()
+    }
+
+    /// Current attempt count for `activity_id`'s redrive, if armed.
+    pub(super) fn redrive_attempts(&self, activity_id: &[u8; 32]) -> Option<u32> {
+        self.redrives.get(activity_id).map(|r| r.attempts)
+    }
+
+    /// Bump the attempt counter; `0` when no such record exists.
+    pub(super) fn bump_redrive_attempts(&mut self, activity_id: &[u8; 32]) -> u32 {
+        self.redrives
+            .get_mut(activity_id)
+            .map(|r| {
+                r.attempts += 1;
+                r.attempts
+            })
+            .unwrap_or(0)
+    }
+
+    pub(super) fn clear_redrive(&mut self, activity_id: &[u8; 32]) {
+        self.redrives.remove(activity_id);
     }
 
     /// Record an outgoing (sent) note. Idempotent by `cmx`: returns
@@ -692,6 +820,42 @@ impl ShieldedStore for InMemoryShieldedStore {
             .get(&id)
             .map(SubwalletState::stale_pending_spends)
             .unwrap_or_default())
+    }
+
+    fn arm_redrive(&mut self, id: SubwalletId, redrive: PendingRedrive) -> Result<(), Self::Error> {
+        self.subwallets.entry(id).or_default().arm_redrive(redrive);
+        Ok(())
+    }
+
+    fn pending_redrives(&self, id: SubwalletId) -> Result<Vec<PendingRedrive>, Self::Error> {
+        Ok(self
+            .subwallets
+            .get(&id)
+            .map(SubwalletState::pending_redrives)
+            .unwrap_or_default())
+    }
+
+    fn bump_redrive_attempts(
+        &mut self,
+        id: SubwalletId,
+        activity_id: &[u8; 32],
+    ) -> Result<u32, Self::Error> {
+        Ok(self
+            .subwallets
+            .get_mut(&id)
+            .map(|sw| sw.bump_redrive_attempts(activity_id))
+            .unwrap_or(0))
+    }
+
+    fn clear_redrive(
+        &mut self,
+        id: SubwalletId,
+        activity_id: &[u8; 32],
+    ) -> Result<(), Self::Error> {
+        if let Some(sw) = self.subwallets.get_mut(&id) {
+            sw.clear_redrive(activity_id);
+        }
+        Ok(())
     }
 
     fn record_outgoing_note(
@@ -883,6 +1047,53 @@ mod tests {
         assert!(all[0].is_spent);
         // Marking again returns false (already spent).
         assert!(!store.mark_spent(id, &nullifier).unwrap());
+    }
+
+    /// Resolving any of a redrive's nullifiers — landing (`mark_spent`)
+    /// or release (`clear_pending`) — drops the whole record: a
+    /// transition lands or dies atomically for all its nullifiers.
+    #[test]
+    fn resolving_a_nullifier_drops_the_redrive_record() {
+        let mut store = InMemoryShieldedStore::new();
+        let id = test_id(0);
+        let n1 = [3u8; 32];
+        let n2 = [4u8; 32];
+        let note = ShieldedNote {
+            position: 0,
+            cmx: [1u8; 32],
+            nullifier: n1,
+            block_height: 50,
+            is_spent: false,
+            value: 500,
+            note_data: vec![0u8; 115],
+        };
+        store.save_note(id, &note).unwrap();
+        let redrive = PendingRedrive {
+            activity_id: [9u8; 32],
+            anchor: [8u8; 32],
+            nullifiers: vec![n1, n2],
+            st_bytes: vec![1, 2, 3],
+            attempts: 0,
+        };
+
+        // Landing path: mark_spent on one nullifier drops the record.
+        store.mark_pending(id, &n1).unwrap();
+        store.arm_redrive(id, redrive.clone()).unwrap();
+        assert_eq!(store.pending_redrives(id).unwrap().len(), 1);
+        assert!(store.mark_spent(id, &n1).unwrap());
+        assert!(
+            store.pending_redrives(id).unwrap().is_empty(),
+            "landed spend drops its redrive record"
+        );
+
+        // Release path: clear_pending on a nullifier drops the record.
+        store.mark_pending(id, &n2).unwrap();
+        store.arm_redrive(id, redrive).unwrap();
+        assert!(store.clear_pending(id, &n2).unwrap());
+        assert!(
+            store.pending_redrives(id).unwrap().is_empty(),
+            "released reservation drops its redrive record"
+        );
     }
 
     #[test]

--- a/packages/swift-sdk/Sources/SwiftDashSDK/PlatformWallet/PlatformWalletManager.swift
+++ b/packages/swift-sdk/Sources/SwiftDashSDK/PlatformWallet/PlatformWalletManager.swift
@@ -4,12 +4,13 @@ import Combine
 import DashSDKFFI
 
 /// Lock-guarded monotonic generation counter, safe to read and bump from
-/// any thread. Used to drop shielded sync completion events that belong
-/// to a generation already superseded by a `stop`/`clear`, even when a
+/// any thread. Used to drop sync completion events that belong to a
+/// generation already superseded by a `stop`/`clear`/`reset`, even when a
 /// restart happens in the same `@MainActor` turn (a plain boolean gate
 /// can't, because the restart re-opens the gate before the stale,
-/// previously-enqueued completion task runs).
-final class ShieldedSyncGenerationCounter: @unchecked Sendable {
+/// previously-enqueued completion task runs). Shared by the shielded and
+/// platform-address sync paths.
+final class SyncGenerationCounter: @unchecked Sendable {
     private let lock = NSLock()
     private var value: UInt64 = 0
     func current() -> UInt64 { lock.withLock { value } }
@@ -108,7 +109,16 @@ public class PlatformWalletManager: ObservableObject {
     ///
     /// `nonisolated` + lock-guarded so the FFI callback thread can snapshot
     /// it without hopping onto the main actor first.
-    nonisolated let shieldedSyncGeneration = ShieldedSyncGenerationCounter()
+    nonisolated let shieldedSyncGeneration = SyncGenerationCounter()
+
+    /// Generation guard for platform-address (BLAST/DIP-17) sync
+    /// completion events, mirroring [`shieldedSyncGeneration`]. The FFI
+    /// completion callback snapshots this on its own thread before the
+    /// main-actor hop; `stopPlatformAddressSync` / `resetPlatformAddressSyncState`
+    /// bump it so a trailing completion the main actor delivers *after*
+    /// the stop/reset is dropped instead of repainting the just-cleared
+    /// sync-status UI.
+    nonisolated let platformAddressSyncGeneration = SyncGenerationCounter()
 
     /// All wallets currently held by the Rust-side
     /// `PlatformWalletManager`, keyed by the 32-byte wallet id.
@@ -831,5 +841,20 @@ public class PlatformWalletManager: ObservableObject {
                 try? await Task.sleep(for: .seconds(1))
             }
         }
+    }
+
+    /// Drop the platform-address published mirror after a reset/clear so a
+    /// later `configure()` re-subscribe — which Combine replays the current
+    /// `@Published` value to a fresh subscriber — can't repaint stale sync
+    /// state over a just-cleared UI.
+    ///
+    /// Lives here (not in the `…AddressSync` extension) because
+    /// `platformAddressSyncIsSyncing` is `private(set)`; the generation guard
+    /// only blocks *future* stale callbacks and can't un-publish a value
+    /// already held on these `@Published` properties. Called by
+    /// `resetPlatformAddressSyncState` after the Rust drain returns.
+    func resetPlatformAddressPublishedMirror() {
+        lastPlatformAddressSyncEvent = nil
+        platformAddressSyncIsSyncing = false
     }
 }

--- a/packages/swift-sdk/Sources/SwiftDashSDK/PlatformWallet/PlatformWalletManagerAddressSync.swift
+++ b/packages/swift-sdk/Sources/SwiftDashSDK/PlatformWallet/PlatformWalletManagerAddressSync.swift
@@ -80,8 +80,13 @@ private func platformAddressSyncCompletedCallback(
         walletResults: results
     )
 
+    // Snapshot the generation now, on the FFI callback thread, BEFORE the
+    // main-actor hop, so a stop/reset that bumps the counter after this
+    // point invalidates the trailing event (mirrors the shielded path).
+    let generation = handler.manager?.platformAddressSyncGeneration.current() ?? 0
+
     Task { @MainActor [weak manager = handler.manager] in
-        manager?.handlePlatformAddressSyncCompleted(event)
+        manager?.handlePlatformAddressSyncCompleted(event, generation: generation)
     }
 }
 
@@ -100,7 +105,14 @@ private extension AddressSyncMetrics {
 }
 
 extension PlatformWalletManager {
-    func handlePlatformAddressSyncCompleted(_ event: PlatformAddressSyncEvent) {
+    func handlePlatformAddressSyncCompleted(_ event: PlatformAddressSyncEvent, generation: UInt64) {
+        // Drop a trailing event the Rust drain already dispatched but the
+        // main actor only delivers after a stop/reset bumped the counter —
+        // its snapshot predates the bump. Without this, a completion from a
+        // pass drained by `resetPlatformAddressSyncState` (Clear) repaints
+        // chain-tip height, last-sync time, and metrics over the freshly
+        // cleared UI. Mirrors the shielded guard.
+        guard generation == platformAddressSyncGeneration.current() else { return }
         lastPlatformAddressSyncEvent = event
     }
 
@@ -132,6 +144,10 @@ extension PlatformWalletManager {
         }
 
         try platform_wallet_manager_platform_address_sync_stop(handle).check()
+        // The Rust drain returned; bump the generation so any trailing
+        // completion the main actor delivers after this point is dropped
+        // (its snapshot predates this bump). Mirrors the shielded stop.
+        platformAddressSyncGeneration.bump()
     }
 
     public func isPlatformAddressSyncRunning() throws -> Bool {
@@ -218,5 +234,38 @@ extension PlatformWalletManager {
         try await Task.detached(priority: .userInitiated) {
             try platform_wallet_manager_platform_address_sync_sync_now(handle).check()
         }.value
+    }
+
+    /// Reset the platform-address (BLAST/DIP-17) incremental-sync
+    /// watermark and drop every cached balance across all registered
+    /// wallets, forcing a full rescan on the next sync. Backs the
+    /// SwiftExampleApp Platform Sync "Clear" button.
+    ///
+    /// Quiesces the background sync loop before resetting (so no
+    /// in-flight pass re-writes the watermark) and leaves it stopped —
+    /// callers re-arm via `startPlatformAddressSync` or one-shot
+    /// `syncPlatformAddressNow`. Runs off the main actor because the
+    /// quiesce drains any in-flight pass.
+    public func resetPlatformAddressSyncState() async throws {
+        guard isConfigured, handle != NULL_HANDLE else {
+            throw PlatformWalletError.invalidHandle(
+                "PlatformWalletManager not configured"
+            )
+        }
+
+        let handle = self.handle
+        try await Task.detached(priority: .userInitiated) {
+            try platform_wallet_manager_platform_address_sync_reset(handle).check()
+        }.value
+        // The Rust reset quiesced + drained the in-flight pass; bump the
+        // generation so a trailing completion captured before this point
+        // (and delivered onto the main actor after Clear) is dropped
+        // instead of repainting the just-cleared sync-status UI.
+        platformAddressSyncGeneration.bump()
+        // Drop the retained published mirror too: the generation guard only
+        // blocks future stale callbacks, but a later `configure()` would
+        // replay the current `@Published` value to its fresh subscriber and
+        // repaint the cleared UI.
+        resetPlatformAddressPublishedMirror()
     }
 }

--- a/packages/swift-sdk/Sources/SwiftDashSDK/PlatformWallet/PlatformWalletResult.swift
+++ b/packages/swift-sdk/Sources/SwiftDashSDK/PlatformWallet/PlatformWalletResult.swift
@@ -39,6 +39,13 @@ public enum PlatformWalletResultCode: Int32, Sendable {
     /// outcome. Do NOT auto-retry — a retry would rebuild the bundle and
     /// could double-execute if the original landed.
     case errorShieldedSpendUnconfirmed = 18
+    /// A shielded spend could not be built against a Platform-recorded anchor:
+    /// the wallet's commitment tree isn't synced to a checkpoint Platform has
+    /// recorded (an in-progress / interrupted sync leaves it mid-block). Nothing
+    /// was broadcast and the notes were released. This is retryable — let the
+    /// shielded sync reach a confirmed state and try again. Distinct from
+    /// `errorShieldedSpendUnconfirmed`, which must NOT be retried.
+    case errorShieldedNoRecordedAnchor = 19
     case notFound = 98
     case errorUnknown = 99
 
@@ -82,6 +89,8 @@ public enum PlatformWalletResultCode: Int32, Sendable {
             self = .errorShieldedBroadcastUnconfirmed
         case PLATFORM_WALLET_FFI_RESULT_CODE_ERROR_SHIELDED_SPEND_UNCONFIRMED:
             self = .errorShieldedSpendUnconfirmed
+        case PLATFORM_WALLET_FFI_RESULT_CODE_ERROR_SHIELDED_NO_RECORDED_ANCHOR:
+            self = .errorShieldedNoRecordedAnchor
         case PLATFORM_WALLET_FFI_RESULT_CODE_NOT_FOUND:
             self = .notFound
         case PLATFORM_WALLET_FFI_RESULT_CODE_ERROR_UNKNOWN:
@@ -177,6 +186,13 @@ public enum PlatformWalletError: LocalizedError {
     /// notes reserved wallet-side (a shield reserves nothing) until the
     /// next sync reconciles the outcome. Do NOT auto-retry.
     case shieldedSpendUnconfirmed(String)
+    /// A shielded spend could not be built against a Platform-recorded anchor —
+    /// the wallet's commitment tree isn't synced to a checkpoint Platform has
+    /// recorded (an in-progress / interrupted sync leaves it mid-block). Nothing
+    /// was broadcast and the notes were released; retryable once the shielded
+    /// sync reaches a confirmed state. Distinct from `shieldedSpendUnconfirmed`,
+    /// which must NOT be retried.
+    case shieldedNoRecordedAnchor(String)
     case notFound(String)
     case unknown(String)
 
@@ -192,6 +208,7 @@ public enum PlatformWalletError: LocalizedError {
              .arithmeticOverflow(let m), .noSelectableInputs(let m),
              .walletAlreadyExists(let m), .shieldedBroadcastFailed(let m),
              .shieldedBroadcastUnconfirmed(let m), .shieldedSpendUnconfirmed(let m),
+             .shieldedNoRecordedAnchor(let m),
              .notFound(let m), .unknown(let m):
             return m
         }
@@ -222,6 +239,7 @@ public enum PlatformWalletError: LocalizedError {
         case .errorShieldedBroadcastFailed: self = .shieldedBroadcastFailed(detail)
         case .errorShieldedBroadcastUnconfirmed: self = .shieldedBroadcastUnconfirmed(detail)
         case .errorShieldedSpendUnconfirmed: self = .shieldedSpendUnconfirmed(detail)
+        case .errorShieldedNoRecordedAnchor: self = .shieldedNoRecordedAnchor(detail)
         case .notFound:               self = .notFound(detail)
         case .errorUnknown:           self = .unknown(detail)
         }

--- a/packages/swift-sdk/SwiftExampleApp/SwiftExampleApp/Core/Services/PlatformBalanceSyncService.swift
+++ b/packages/swift-sdk/SwiftExampleApp/SwiftExampleApp/Core/Services/PlatformBalanceSyncService.swift
@@ -8,6 +8,7 @@
 import Foundation
 import SwiftUI
 import Combine
+import SwiftData
 import SwiftDashSDK
 
 /// Observable service managing BLAST address balance sync UI state.
@@ -187,6 +188,106 @@ class PlatformBalanceSyncService: ObservableObject {
         walletManager = nil
         syncEventCancellable?.cancel()
         syncStateCancellable?.cancel()
+    }
+
+    /// Clear platform-address sync data for real — what the Platform
+    /// Sync "Clear" button calls.
+    ///
+    /// Plain [`clearDisplay`] only zeroes the in-memory `@Published`
+    /// mirror, so the next sync resumed from the surviving watermark in
+    /// ~2s (the "Clear didn't work" symptom). This clears the stores the
+    /// synced data actually lives in, mirroring
+    /// `ShieldedService.clearLocalState`: Rust-side reset FIRST (so the
+    /// next sync can't re-persist stale rows), then the SwiftData clear,
+    /// then the published-mirror reset.
+    ///
+    /// The `PersistentPlatformAddress` rows are **zeroed in place, not
+    /// deleted** — they carry durable derivation metadata that no sync
+    /// re-emits in-session and that the balance callback only updates
+    /// (never creates), so deleting them would leave the UI empty until
+    /// app restart. Only the volatile balance/sync fields are cleared;
+    /// the network-keyed `PersistentPlatformAddressesSyncState` watermark
+    /// row is deleted to force a full rescan.
+    ///
+    /// Scoped to the **active network**. The SwiftData store holds rows
+    /// for every network at once (the UI filters them by network), so
+    /// clearing must not touch other networks' state. `PersistentPlatformAddress`
+    /// carries no network column, so it's scoped via `walletIdsOnNetwork`
+    /// — the same wallet-id-per-network pivot the view uses;
+    /// `PersistentPlatformAddressesSyncState` is network-keyed and is
+    /// scoped by `networkRaw`. This matches the manager-level Rust reset,
+    /// which only touches the active network's registered wallets.
+    ///
+    /// Fails closed: if the Rust reset OR the SwiftData delete throws, it
+    /// surfaces the error in `lastError` and returns WITHOUT calling
+    /// `clearDisplay()` — the UI never shows a false "cleared" state over
+    /// data that is still on disk / in Rust memory.
+    func clearLocalState(
+        modelContext: ModelContext,
+        network: Network,
+        walletIdsOnNetwork: Set<Data>
+    ) async {
+        // 1) Reset the Rust-owned state BEFORE touching disk. Without
+        //    this the in-memory watermark survives and the next "Sync
+        //    Now" resumes incrementally (fast) instead of doing a full
+        //    rescan; a still-registered background pass could also
+        //    re-persist the rows we're about to delete. Fail closed —
+        //    the reset is load-bearing for the wipe, so abort (surfacing
+        //    the error) rather than leave a half-cleared state.
+        if let walletManager {
+            do {
+                try await walletManager.resetPlatformAddressSyncState()
+            } catch {
+                lastError = "Failed to reset platform-address sync state: \(error.localizedDescription)"
+                SDKLogger.error(lastError ?? "")
+                return
+            }
+        }
+
+        // 2) Zero the volatile balance/sync fields of this network's
+        //    address rows IN PLACE — do NOT delete them. A
+        //    `PersistentPlatformAddress` row is durable derivation state
+        //    (bech32m address, 20-byte hash, 33-byte public key,
+        //    account/address index, derivation path), not just a balance
+        //    cache. The BLAST balance callback `persistAddressBalances`
+        //    only *updates* existing rows (it skips by `addressHash` when
+        //    the row is missing), and no sync re-emits the rows in-session:
+        //    Rust's `reset_sync_state` preserves the address bijection, so
+        //    there is no pool extension to re-fire the address-emit path.
+        //    Deleting would therefore leave the next "Sync Now" with
+        //    nothing to upsert against — balances (and the spend/signing
+        //    derivation lookups) would stay gone until an app restart
+        //    re-seeds the rows. Zeroing clears what the user sees while
+        //    keeping the metadata the rescan needs.
+        do {
+            let addresses = try modelContext.fetch(FetchDescriptor<PersistentPlatformAddress>())
+            for row in addresses where walletIdsOnNetwork.contains(row.walletId) {
+                row.balance = 0
+                row.nonce = 0
+                row.isUsed = false
+                row.firstSeenHeight = 0
+                row.lastSeenHeight = 0
+                row.lastUpdated = Date()
+            }
+
+            // The sync-state watermark is pure volatile sync state (no
+            // durable metadata) and is what actually forces a full rescan,
+            // so delete it outright — the next sync re-creates it.
+            let networkRaw = network.rawValue
+            let syncStates = try modelContext.fetch(FetchDescriptor<PersistentPlatformAddressesSyncState>())
+            for row in syncStates where row.networkRaw == networkRaw {
+                modelContext.delete(row)
+            }
+
+            try modelContext.save()
+        } catch {
+            lastError = "Failed to clear persisted platform-address state: \(error.localizedDescription)"
+            SDKLogger.error(lastError ?? "")
+            return
+        }
+
+        // 3) Zero the published display mirror — only on full success.
+        clearDisplay()
     }
 
     /// Trigger a manual sync. No-op if already syncing.

--- a/packages/swift-sdk/SwiftExampleApp/SwiftExampleApp/Core/Views/CoreContentView.swift
+++ b/packages/swift-sdk/SwiftExampleApp/SwiftExampleApp/Core/Views/CoreContentView.swift
@@ -372,7 +372,13 @@ var body: some View {
                         .disabled(platformBalanceSyncService.isSyncing)
 
                         Button {
-                            platformBalanceSyncService.clearDisplay()
+                            Task {
+                                await platformBalanceSyncService.clearLocalState(
+                                    modelContext: modelContext,
+                                    network: platformState.currentNetwork,
+                                    walletIdsOnNetwork: walletIdsOnNetwork
+                                )
+                            }
                         } label: {
                             Text("Clear")
                                 .font(.caption)

--- a/packages/swift-sdk/SwiftExampleApp/SwiftExampleAppTests/PlatformAddressSyncGenerationTests.swift
+++ b/packages/swift-sdk/SwiftExampleApp/SwiftExampleAppTests/PlatformAddressSyncGenerationTests.swift
@@ -1,0 +1,115 @@
+import XCTest
+@testable import SwiftDashSDK
+
+/// Regression coverage for the platform-address (BLAST/DIP-17) sync
+/// generation guard in
+/// `PlatformWalletManager.handlePlatformAddressSyncCompleted(_:generation:)`.
+///
+/// A completion event is snapshotted with the current generation on the FFI
+/// callback thread, then re-dispatched onto the main actor. `stopPlatformAddressSync`
+/// / `resetPlatformAddressSyncState` (the Clear path) bump the generation
+/// counter, so a trailing event the main actor delivers *after* the stop/reset
+/// must be dropped — otherwise it repaints chain-tip height, last-sync time, and
+/// metrics over the just-cleared sync-status UI (the exact bug a generation-less
+/// platform path had, which Shielded Clear already guards against).
+///
+/// `handlePlatformAddressSyncCompleted` does not touch the FFI handle — it only
+/// reads `platformAddressSyncGeneration` and assigns `lastPlatformAddressSyncEvent`
+/// — so a bare, unconfigured `PlatformWalletManager()` is safe to drive directly.
+@MainActor
+final class PlatformAddressSyncGenerationTests: XCTestCase {
+
+    private func makeEvent(syncUnixSeconds: UInt64) -> PlatformAddressSyncEvent {
+        PlatformAddressSyncEvent(syncUnixSeconds: syncUnixSeconds, walletResults: [])
+    }
+
+    /// The exact race Clear closes: a completion captured under generation N is
+    /// dropped once the counter is bumped to N+1 before delivery —
+    /// `lastPlatformAddressSyncEvent` stays nil.
+    func testStaleCompletionIsDroppedAfterGenerationBump() {
+        let manager = PlatformWalletManager()
+        XCTAssertNil(manager.lastPlatformAddressSyncEvent, "fresh manager has no event")
+
+        // Snapshot at "enqueue" time the way the FFI callback thread does,
+        // then advance it (as stop/reset would) before delivery.
+        let capturedGeneration = manager.platformAddressSyncGeneration.current()
+        manager.platformAddressSyncGeneration.bump()
+
+        manager.handlePlatformAddressSyncCompleted(
+            makeEvent(syncUnixSeconds: 1_000),
+            generation: capturedGeneration
+        )
+
+        XCTAssertNil(
+            manager.lastPlatformAddressSyncEvent,
+            "a completion captured under a superseded generation must be dropped"
+        )
+    }
+
+    /// A completion captured under the CURRENT generation is published, so a
+    /// normal sync (no intervening Clear) still updates the UI.
+    func testCurrentGenerationCompletionIsPublished() {
+        let manager = PlatformWalletManager()
+
+        let currentGeneration = manager.platformAddressSyncGeneration.current()
+        manager.handlePlatformAddressSyncCompleted(
+            makeEvent(syncUnixSeconds: 2_000),
+            generation: currentGeneration
+        )
+
+        XCTAssertEqual(
+            manager.lastPlatformAddressSyncEvent?.syncUnixSeconds,
+            2_000,
+            "a completion captured under the current generation must be published"
+        )
+    }
+
+    /// A previously-published event must not be clobbered by a late straggler
+    /// carrying a superseded (pre-bump) generation — the cleared/updated state
+    /// stays put.
+    func testStaleCompletionDoesNotOverwriteAlreadyPublishedEvent() {
+        let manager = PlatformWalletManager()
+
+        let firstGeneration = manager.platformAddressSyncGeneration.current()
+        manager.handlePlatformAddressSyncCompleted(
+            makeEvent(syncUnixSeconds: 5_000),
+            generation: firstGeneration
+        )
+        XCTAssertEqual(manager.lastPlatformAddressSyncEvent?.syncUnixSeconds, 5_000)
+
+        // Bump (stop/reset), then deliver a straggler carrying the old snapshot.
+        manager.platformAddressSyncGeneration.bump()
+        manager.handlePlatformAddressSyncCompleted(
+            makeEvent(syncUnixSeconds: 6_000),
+            generation: firstGeneration
+        )
+
+        XCTAssertEqual(
+            manager.lastPlatformAddressSyncEvent?.syncUnixSeconds,
+            5_000,
+            "a superseded straggler must not overwrite the last valid event"
+        )
+    }
+
+    /// After a reset the retained published mirror must be dropped. The
+    /// generation guard only blocks *future* stale callbacks; the value
+    /// already held on `lastPlatformAddressSyncEvent` would otherwise replay to
+    /// a fresh `configure()` subscriber (Combine emits the current `@Published`
+    /// value on subscribe) and repaint the cleared sync-status UI.
+    func testResetPublishedMirrorDropsRetainedEvent() {
+        let manager = PlatformWalletManager()
+        manager.lastPlatformAddressSyncEvent = makeEvent(syncUnixSeconds: 7_000)
+        XCTAssertNotNil(manager.lastPlatformAddressSyncEvent)
+
+        manager.resetPlatformAddressPublishedMirror()
+
+        XCTAssertNil(
+            manager.lastPlatformAddressSyncEvent,
+            "reset must drop the retained completion so it can't replay on re-subscribe"
+        )
+        XCTAssertFalse(
+            manager.platformAddressSyncIsSyncing,
+            "reset must clear the syncing mirror so a re-subscribe doesn't replay a stale spinner"
+        )
+    }
+}

--- a/packages/swift-sdk/SwiftExampleApp/SwiftExampleAppTests/PlatformBalanceSyncServiceClearTests.swift
+++ b/packages/swift-sdk/SwiftExampleApp/SwiftExampleAppTests/PlatformBalanceSyncServiceClearTests.swift
@@ -1,0 +1,128 @@
+import SwiftData
+import XCTest
+@testable import SwiftDashSDK
+@testable import SwiftExampleApp
+
+@MainActor
+final class PlatformBalanceSyncServiceClearTests: XCTestCase {
+
+    /// The Platform Sync "Clear" button must delete BOTH platform-address
+    /// SwiftData stores — the cached per-address balances
+    /// (`PersistentPlatformAddress`) and the network-scoped sync-state
+    /// watermark (`PersistentPlatformAddressesSyncState`) — so the UI
+    /// reads zero and the next sync is a full rescan rather than a ~2s
+    /// incremental resume (the reported "Clear didn't work" symptom).
+    ///
+    /// The Rust-side watermark reset is skipped here because no wallet
+    /// manager is configured (the `if let walletManager` guard short-
+    /// circuits); that path is covered by the platform-wallet Rust unit
+    /// test (`reset_sync_state_clears_watermark_and_seed`) and manual
+    /// simulator verification.
+    func testClearLocalStateZerosActiveNetworkBalancesInPlaceAndScopesToNetwork() async throws {
+        let container = try DashModelContainer.createInMemory()
+        let context = ModelContext(container)
+        let testnetWalletId = Data(repeating: 0x44, count: 32)
+        let mainnetWalletId = Data(repeating: 0x55, count: 32)
+
+        // Active-network (testnet) row — must be ZEROED IN PLACE (kept, so
+        // its durable derivation metadata survives for the rescan to
+        // re-persist balances against).
+        context.insert(
+            PersistentPlatformAddress(
+                address: "yTestnetPlatformAddr",
+                addressType: 0,
+                addressHash: Data(repeating: 0x01, count: 20),
+                publicKey: Data(repeating: 0xab, count: 33),
+                accountIndex: 3,
+                addressIndex: 7,
+                derivationPath: "m/9'/1'/17'/3'/0'/7",
+                isUsed: true,
+                balance: 294_627_247_940,
+                nonce: 5,
+                walletId: testnetWalletId
+            )
+        )
+        context.insert(
+            PersistentPlatformAddressesSyncState(
+                walletId: Self.syncStateScopeId(for: .testnet),
+                network: .testnet,
+                syncHeight: 10,
+                syncTimestamp: 20,
+                lastKnownRecentBlock: 30
+            )
+        )
+
+        // Other-network (mainnet) rows — must be untouched, since the
+        // SwiftData store holds every network's rows at once and Clear is
+        // scoped to the active network only.
+        context.insert(
+            PersistentPlatformAddress(
+                address: "XMainnetPlatformAddr",
+                addressType: 0,
+                addressHash: Data(repeating: 0x02, count: 20),
+                accountIndex: 0,
+                addressIndex: 0,
+                derivationPath: "m/9'/5'/17'/0'/0'/0",
+                isUsed: true,
+                balance: 111_111,
+                walletId: mainnetWalletId
+            )
+        )
+        context.insert(
+            PersistentPlatformAddressesSyncState(
+                walletId: Self.syncStateScopeId(for: .mainnet),
+                network: .mainnet,
+                syncHeight: 99,
+                syncTimestamp: 88,
+                lastKnownRecentBlock: 77
+            )
+        )
+        try context.save()
+
+        let service = PlatformBalanceSyncService()
+        await service.clearLocalState(
+            modelContext: context,
+            network: .testnet,
+            walletIdsOnNetwork: [testnetWalletId]
+        )
+
+        // No address rows are deleted — both networks' rows still exist.
+        let addresses = try fetch(PersistentPlatformAddress.self, in: container)
+        XCTAssertEqual(addresses.count, 2, "address rows must be preserved, not deleted")
+
+        // Testnet row: volatile fields zeroed, durable metadata preserved.
+        let testnetAddr = try XCTUnwrap(addresses.first { $0.walletId == testnetWalletId })
+        XCTAssertEqual(testnetAddr.balance, 0, "balance zeroed")
+        XCTAssertEqual(testnetAddr.nonce, 0, "nonce zeroed")
+        XCTAssertFalse(testnetAddr.isUsed, "isUsed zeroed")
+        XCTAssertEqual(testnetAddr.address, "yTestnetPlatformAddr", "durable address preserved")
+        XCTAssertEqual(testnetAddr.publicKey, Data(repeating: 0xab, count: 33), "durable public key preserved")
+        XCTAssertEqual(testnetAddr.derivationPath, "m/9'/1'/17'/3'/0'/7", "durable derivation path preserved")
+        XCTAssertEqual(testnetAddr.accountIndex, 3, "durable account index preserved")
+        XCTAssertEqual(testnetAddr.addressIndex, 7, "durable address index preserved")
+
+        // Mainnet row: fully untouched (other network not in scope).
+        let mainnetAddr = try XCTUnwrap(addresses.first { $0.walletId == mainnetWalletId })
+        XCTAssertEqual(mainnetAddr.balance, 111_111, "other network's balance must be untouched")
+        XCTAssertTrue(mainnetAddr.isUsed)
+
+        // Watermark: testnet deleted (forces full rescan), mainnet preserved.
+        let states = try fetch(PersistentPlatformAddressesSyncState.self, in: container)
+        XCTAssertEqual(
+            states.map(\.networkRaw), [Network.mainnet.rawValue],
+            "only testnet's sync-state watermark is deleted; mainnet survives"
+        )
+    }
+
+    private static func syncStateScopeId(for network: Network) -> Data {
+        var data = Data("platform-sync:\(network.networkName)".utf8.prefix(32))
+        if data.count < 32 {
+            data.append(Data(repeating: 0, count: 32 - data.count))
+        }
+        return data
+    }
+
+    private func fetch<T: PersistentModel>(_ type: T.Type, in container: ModelContainer) throws -> [T] {
+        try ModelContext(container).fetch(FetchDescriptor<T>())
+    }
+}

--- a/packages/wasm-sdk/src/queries/protocol.rs
+++ b/packages/wasm-sdk/src/queries/protocol.rs
@@ -16,55 +16,105 @@ use wasm_dpp2::{ProTxHashLikeNullableJs, ProTxHashWasm};
 pub struct ProtocolVersionUpgradeStateWasm {
     current_protocol_version: u32,
     next_protocol_version: Option<u32>,
-    activation_height: Option<u64>,
-    vote_count: Option<u32>,
-    #[serde(rename = "thresholdReached")]
-    is_threshold_reached: bool,
+    vote_count: Option<u64>,
 }
 
 impl ProtocolVersionUpgradeStateWasm {
     fn new(
         current_protocol_version: u32,
         next_protocol_version: Option<u32>,
-        activation_height: Option<u64>,
-        vote_count: Option<u32>,
-        is_threshold_reached: bool,
+        vote_count: Option<u64>,
     ) -> Self {
         Self {
             current_protocol_version,
             next_protocol_version,
-            activation_height,
             vote_count,
-            is_threshold_reached,
         }
     }
 }
 
 #[wasm_bindgen(js_class = ProtocolVersionUpgradeState)]
 impl ProtocolVersionUpgradeStateWasm {
+    /// Protocol version the chain was running when this response was produced.
     #[wasm_bindgen(getter = "currentProtocolVersion")]
     pub fn current_protocol_version(&self) -> u32 {
         self.current_protocol_version
     }
 
+    /// Candidate upgrade version: the version above the current one with the
+    /// most evonode votes, if any votes exist.
     #[wasm_bindgen(getter = "nextProtocolVersion")]
     pub fn next_protocol_version(&self) -> Option<u32> {
         self.next_protocol_version
     }
 
-    #[wasm_bindgen(getter = "activationHeight")]
-    pub fn activation_height(&self) -> Option<u64> {
-        self.activation_height
-    }
-
+    /// Number of evonode votes cast for `nextProtocolVersion`.
     #[wasm_bindgen(getter = "voteCount")]
-    pub fn vote_count(&self) -> Option<u32> {
+    pub fn vote_count(&self) -> Option<u64> {
         self.vote_count
     }
+}
 
-    #[wasm_bindgen(getter = "isThresholdReached")]
-    pub fn is_threshold_reached(&self) -> bool {
-        self.is_threshold_reached
+/// Pick the candidate upgrade version from the vote counts: among versions
+/// newer than `current_version`, the one with the most votes; equal vote
+/// counts resolve to the highest version.
+fn next_version_upgrade(
+    upgrades: &drive_proof_verifier::types::ProtocolVersionUpgrades,
+    current_version: u32,
+) -> (Option<u32>, Option<u64>) {
+    upgrades
+        .iter()
+        .filter_map(|(version, votes)| votes.map(|votes| (*version, votes)))
+        .filter(|(version, _)| *version > current_version)
+        .max_by_key(|&(version, votes)| (votes, version))
+        .map_or((None, None), |(version, votes)| {
+            (Some(version), Some(votes))
+        })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::next_version_upgrade;
+    use drive_proof_verifier::types::ProtocolVersionUpgrades;
+
+    #[test]
+    fn empty_upgrades_yield_no_candidate() {
+        let upgrades = ProtocolVersionUpgrades::new();
+
+        assert_eq!(next_version_upgrade(&upgrades, 12), (None, None));
+    }
+
+    #[test]
+    fn none_vote_counts_are_skipped() {
+        let upgrades = ProtocolVersionUpgrades::from_iter([(13, None), (14, None)]);
+
+        assert_eq!(next_version_upgrade(&upgrades, 12), (None, None));
+    }
+
+    #[test]
+    fn versions_at_or_below_current_are_excluded() {
+        let upgrades = ProtocolVersionUpgrades::from_iter([(11, Some(50)), (12, Some(80))]);
+
+        assert_eq!(next_version_upgrade(&upgrades, 12), (None, None));
+    }
+
+    #[test]
+    fn picks_future_version_with_most_votes() {
+        let upgrades = ProtocolVersionUpgrades::from_iter([
+            (11, Some(200)),
+            (13, Some(7)),
+            (14, Some(132)),
+            (15, Some(3)),
+        ]);
+
+        assert_eq!(next_version_upgrade(&upgrades, 12), (Some(14), Some(132)));
+    }
+
+    #[test]
+    fn equal_votes_resolve_to_highest_version() {
+        let upgrades = ProtocolVersionUpgrades::from_iter([(13, Some(9)), (14, Some(9))]);
+
+        assert_eq!(next_version_upgrade(&upgrades, 12), (Some(14), Some(9)));
     }
 }
 
@@ -108,36 +158,18 @@ impl WasmSdk {
         use dash_sdk::platform::FetchMany;
         use drive_proof_verifier::types::ProtocolVersionVoteCount;
 
-        let upgrade_result: drive_proof_verifier::types::ProtocolVersionUpgrades =
-            ProtocolVersionVoteCount::fetch_many(self.as_ref(), ()).await?;
+        let (upgrade_result, metadata): (drive_proof_verifier::types::ProtocolVersionUpgrades, _) =
+            ProtocolVersionVoteCount::fetch_many_with_metadata(self.as_ref(), (), None).await?;
 
-        // Get the current protocol version from the SDK
-        let current_version = self.version();
+        // The chain's protocol version at the time of the response
+        let current_version = metadata.protocol_version;
 
-        // Find the next version with votes
-        let mut next_version = None;
-        let mut activation_height = None;
-        let mut vote_count = None;
-        let mut threshold_reached = false;
-
-        // The result is an IndexMap<u32, Option<u64>> where u32 is version and Option<u64> is activation height
-        for (version, height_opt) in upgrade_result.iter() {
-            if *version > current_version {
-                next_version = Some(*version);
-                activation_height = *height_opt;
-                // TODO: Get actual vote count and threshold from platform
-                vote_count = None;
-                threshold_reached = height_opt.is_some();
-                break;
-            }
-        }
+        let (next_version, vote_count) = next_version_upgrade(&upgrade_result, current_version);
 
         Ok(ProtocolVersionUpgradeStateWasm::new(
             current_version,
             next_version,
-            activation_height,
             vote_count,
-            threshold_reached,
         ))
     }
 
@@ -194,32 +226,12 @@ impl WasmSdk {
         ) = ProtocolVersionVoteCount::fetch_many_with_metadata_and_proof(self.as_ref(), (), None)
             .await?;
 
-        // Get the current protocol version from the SDK
-        let current_version = self.version();
+        // The chain's protocol version at the time of the response
+        let current_version = metadata.protocol_version;
 
-        // Find the next version with votes
-        let mut next_version = None;
-        let mut activation_height = None;
-        let mut vote_count = None;
-        let mut threshold_reached = false;
+        let (next_version, vote_count) = next_version_upgrade(&upgrade_result, current_version);
 
-        for (version, height_opt) in upgrade_result.iter() {
-            if *version > current_version {
-                next_version = Some(*version);
-                activation_height = *height_opt;
-                vote_count = None;
-                threshold_reached = height_opt.is_some();
-                break;
-            }
-        }
-
-        let state = ProtocolVersionUpgradeStateWasm::new(
-            current_version,
-            next_version,
-            activation_height,
-            vote_count,
-            threshold_reached,
-        );
+        let state = ProtocolVersionUpgradeStateWasm::new(current_version, next_version, vote_count);
 
         Ok(ProofMetadataResponseWasm::from_sdk_parts(
             state, metadata, proof,

--- a/packages/wasm-sdk/tests/unit/conversion-simple-types.spec.ts
+++ b/packages/wasm-sdk/tests/unit/conversion-simple-types.spec.ts
@@ -52,17 +52,13 @@ describe('Simple Type Conversions', () => {
     const jsonFixture = {
       currentProtocolVersion: 7,
       nextProtocolVersion: 8,
-      activationHeight: 50000,
       voteCount: 100,
-      thresholdReached: false,
     };
 
     const objectFixture = {
       currentProtocolVersion: 7,
       nextProtocolVersion: 8,
-      activationHeight: 50000n,
-      voteCount: 100,
-      thresholdReached: false,
+      voteCount: 100n,
     };
 
     describe('toJSON()', () => {
@@ -84,8 +80,7 @@ describe('Simple Type Conversions', () => {
         const result = sdk.ProtocolVersionUpgradeState.fromJSON(jsonFixture);
         expect(result.currentProtocolVersion).to.equal(7);
         expect(result.nextProtocolVersion).to.equal(8);
-        expect(result.voteCount).to.equal(100);
-        expect(result.isThresholdReached).to.equal(false);
+        expect(result.voteCount).to.equal(100n);
       });
     });
 
@@ -94,17 +89,13 @@ describe('Simple Type Conversions', () => {
         const fixture = {
           currentProtocolVersion: 7,
           nextProtocolVersion: null,
-          activationHeight: null,
           voteCount: null,
-          thresholdReached: true,
         };
 
         const result = sdk.ProtocolVersionUpgradeState.fromJSON(fixture);
         expect(result.currentProtocolVersion).to.equal(7);
         expect(result.nextProtocolVersion).to.be.undefined();
-        expect(result.activationHeight).to.be.undefined();
         expect(result.voteCount).to.be.undefined();
-        expect(result.isThresholdReached).to.equal(true);
       });
     });
   });


### PR DESCRIPTION
## Issue being fixed or feature implemented

Routine sync merge (same pattern as #3978): brings the 4.0.x release line's fixes up to the v4.1 development branch.

## What was done?

Merged `v4.0-dev` into `v4.1-dev` — a clean merge, no conflicts. Carries:

- #3959 — Platform Sync "Clear" actually clears synced data
- #3969 — platform-address balance reconciliation after top-up (phantom-balance fix)
- #3977 — shielded spends build against a Platform-recorded anchor
- #3982 — stranded shielded-spend reservation auto-release
- #3987 — unified platform-address reconciliation seam (`reconcile_address_infos`)
- #3988 — active re-drive of unconfirmed shielded spends (persist + rebroadcast ×3)
- #3979 — wasm-sdk protocol upgrade state fix

## How Has This Been Tested?

`cargo test -p platform-wallet --lib --features shielded` → 326 passed on the merged tree; CI runs the full suite.

## Breaking Changes

None (merge only).

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [ ] I have made corresponding changes to the documentation if needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new local reset action for platform address sync, clearing cached state and forcing a full rescan on next sync.
  * Improved wallet flows so identity top-ups, registrations, transfers, withdrawals, and shielded sends now reconcile balances more consistently after proofs.

* **Bug Fixes**
  * Added a clearer retryable error when a shielded spend lacks a recorded anchor.
  * Improved shielded spend handling so unconfirmed or pruned cases are retried or released more reliably.
  * Fixed stale sync completions so cleared or stopped sync states are no longer repainted in the UI.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->