### PR TITLE
fix(platform-wallet): address sync review feedback for #3990

### DIFF
--- a/packages/rs-platform-wallet-ffi/src/error.rs
+++ b/packages/rs-platform-wallet-ffi/src/error.rs
@@ -134,6 +134,18 @@ pub enum PlatformWalletFFIResultCode {
     /// boundary) and try again. Distinct from `ErrorShieldedSpendUnconfirmed`,
     /// where a spend WAS broadcast and must NOT be retried.
     ErrorShieldedNoRecordedAnchor = 19,
+    /// Maps `PlatformWalletError::ShieldedMerkleWitnessUnavailable`. The wallet
+    /// couldn't build a Merkle witness for a selected note against any probed
+    /// checkpoint (a transient store read failure — poisoned mutex, IO, or
+    /// commitment-tree corruption — skipped every anchor depth). Like
+    /// `ErrorShieldedNoRecordedAnchor` this fires *before* broadcast so
+    /// nothing landed on chain and the note reservations were released — the
+    /// host may retry after the next shielded sync (or an app restart) clears
+    /// the underlying read failure. Distinct from `ErrorShieldedNoRecordedAnchor`
+    /// (Platform simply hasn't recorded a covering anchor yet) and from
+    /// `ErrorShieldedSpendUnconfirmed` (a spend WAS broadcast and must NOT be
+    /// retried).
+    ErrorShieldedMerkleWitnessUnavailable = 20,
 
     NotFound = 98, // Used exclusively for all the Option that are retuned as errors
     ErrorUnknown = 99,
@@ -249,6 +261,9 @@ impl From<PlatformWalletError> for PlatformWalletFFIResult {
             }
             PlatformWalletError::ShieldedNoRecordedAnchor(..) => {
                 PlatformWalletFFIResultCode::ErrorShieldedNoRecordedAnchor
+            }
+            PlatformWalletError::ShieldedMerkleWitnessUnavailable(..) => {
+                PlatformWalletFFIResultCode::ErrorShieldedMerkleWitnessUnavailable
             }
             _ => PlatformWalletFFIResultCode::ErrorUnknown,
         };
@@ -601,6 +616,26 @@ mod tests {
             result.code,
             PlatformWalletFFIResultCode::ErrorShieldedSpendUnconfirmed,
             "ShieldedSpendUnconfirmed should map to ErrorShieldedSpendUnconfirmed (rendered: {rendered})"
+        );
+        let msg = unsafe { std::ffi::CStr::from_ptr(result.message) }
+            .to_string_lossy()
+            .into_owned();
+        assert_eq!(msg, rendered, "Display payload must survive verbatim");
+
+        // The transient witness-build failure gets its own retryable code so
+        // the caller preserves the "nothing broadcast, safe to retry"
+        // semantics instead of flattening to the generic wallet-operation
+        // error.
+        let no_witness = PlatformWalletError::ShieldedMerkleWitnessUnavailable(
+            "store IO failed at every probed depth".to_string(),
+        );
+        let rendered = no_witness.to_string();
+        let result: PlatformWalletFFIResult = no_witness.into();
+        assert_eq!(
+            result.code,
+            PlatformWalletFFIResultCode::ErrorShieldedMerkleWitnessUnavailable,
+            "ShieldedMerkleWitnessUnavailable should map to \
+             ErrorShieldedMerkleWitnessUnavailable (rendered: {rendered})"
         );
         let msg = unsafe { std::ffi::CStr::from_ptr(result.message) }
             .to_string_lossy()

--- a/packages/rs-platform-wallet-ffi/src/shielded_send.rs
+++ b/packages/rs-platform-wallet-ffi/src/shielded_send.rs
@@ -510,6 +510,17 @@ fn map_spend_result(
             PlatformWalletFFIResultCode::ErrorShieldedNoRecordedAnchor,
             format!("Wallet is still syncing to a confirmed state — try again shortly. ({e})"),
         ),
+        // Retryable: a store read (poisoned mutex / IO / tree corruption)
+        // skipped every probed anchor depth so no Merkle witness could be
+        // built for the selected notes. Nothing was broadcast and the notes
+        // were released, so the host may retry after the transient store
+        // failure clears (typically the next shielded sync or an app restart).
+        Err(e @ PlatformWalletError::ShieldedMerkleWitnessUnavailable(_)) => {
+            PlatformWalletFFIResult::err(
+                PlatformWalletFFIResultCode::ErrorShieldedMerkleWitnessUnavailable,
+                format!("Wallet couldn't build a Merkle witness — try again shortly. ({e})"),
+            )
+        }
         // Definitive failure: the transition was not executed and the notes
         // were released; the host may retry.
         Err(e @ PlatformWalletError::ShieldedBroadcastFailed(_)) => PlatformWalletFFIResult::err(
@@ -700,6 +711,15 @@ pub unsafe extern "C" fn platform_wallet_manager_shielded_identity_create_from_p
             PlatformWalletFFIResultCode::ErrorShieldedNoRecordedAnchor,
             format!("Wallet is still syncing to a confirmed state — try again shortly. ({e})"),
         ),
+        // Retryable: a store read (poisoned mutex / IO / tree corruption)
+        // skipped every probed anchor depth so no Merkle witness could be
+        // built. Nothing was broadcast and the notes were released.
+        Err(e @ PlatformWalletError::ShieldedMerkleWitnessUnavailable(_)) => {
+            PlatformWalletFFIResult::err(
+                PlatformWalletFFIResultCode::ErrorShieldedMerkleWitnessUnavailable,
+                format!("Wallet couldn't build a Merkle witness — try again shortly. ({e})"),
+            )
+        }
         // Definitive failure: the transition was not executed and the spent notes were released.
         Err(e @ PlatformWalletError::ShieldedBroadcastFailed(_)) => PlatformWalletFFIResult::err(
             PlatformWalletFFIResultCode::ErrorShieldedBroadcastFailed,
@@ -1417,6 +1437,29 @@ mod tests {
         assert!(
             message_of(&result).contains("try again shortly"),
             "no-recorded-anchor message must be the retryable guidance"
+        );
+
+        // Transient witness build failure (store IO / poisoned mutex /
+        // tree corruption) → its own retryable code, distinct from
+        // ErrorWalletOperation so hosts can preserve the "nothing
+        // broadcast, safe to retry" semantics instead of surfacing a
+        // generic wallet error.
+        let no_witness: Result<(), PlatformWalletError> =
+            Err(PlatformWalletError::ShieldedMerkleWitnessUnavailable(
+                "anchor probe skipped depths on a store failure".to_string(),
+            ));
+        let result = map_spend_result(no_witness, "shielded transfer");
+        assert_eq!(
+            result.code,
+            PlatformWalletFFIResultCode::ErrorShieldedMerkleWitnessUnavailable
+        );
+        assert!(
+            message_of(&result).contains("try again shortly"),
+            "merkle-witness-unavailable message must be the retryable guidance"
+        );
+        assert!(
+            message_of(&result).contains("anchor probe skipped depths"),
+            "merkle-witness-unavailable message must carry the wallet Display payload"
         );
 
         let other: Result<(), PlatformWalletError> =

--- a/packages/rs-platform-wallet/src/wallet/identity/network/register_from_addresses.rs
+++ b/packages/rs-platform-wallet/src/wallet/identity/network/register_from_addresses.rs
@@ -132,21 +132,41 @@ impl IdentityWallet {
         }
         let identity = registered_identity;
 
-        // Step 3: Add the identity to the local manager (with its HD
-        // index) so subsequent operations route through it.
+        // Step 3 (best-effort): add the identity to the local manager
+        // (with its HD index) so subsequent operations route through it.
+        // Platform has already accepted the registration, so a local
+        // persistence failure must not suppress the `(identity,
+        // address_infos)` return — the caller still needs it to
+        // reconcile the spent address balances, and the missed local
+        // add self-heals on the next identity re-sync.
         {
             let mut wm = self.wallet_manager.write().await;
-            let info = wm.get_wallet_info_mut(&self.wallet_id).ok_or_else(|| {
-                crate::error::PlatformWalletError::WalletNotFound(
-                    "Wallet info not found in wallet manager".to_string(),
-                )
-            })?;
-            info.identity_manager.add_identity(
-                identity.clone(),
-                identity_index,
-                self.wallet_id,
-                &self.persister,
-            )?;
+            match wm.get_wallet_info_mut(&self.wallet_id) {
+                Some(info) => {
+                    if let Err(e) = info.identity_manager.add_identity(
+                        identity.clone(),
+                        identity_index,
+                        self.wallet_id,
+                        &self.persister,
+                    ) {
+                        tracing::warn!(
+                            error = %e,
+                            identity_id = %identity.id(),
+                            "register_from_addresses: identity registered on \
+                             Platform but local add_identity failed; returning \
+                             the registered identity anyway"
+                        );
+                    }
+                }
+                None => {
+                    tracing::warn!(
+                        identity_id = %identity.id(),
+                        "register_from_addresses: identity registered on \
+                         Platform but wallet info was not found locally; \
+                         skipping local persistence"
+                    );
+                }
+            }
         }
 
         // The spent platform-address balances are reconciled by the

--- a/packages/rs-platform-wallet/src/wallet/platform_addresses/fund_from_asset_lock.rs
+++ b/packages/rs-platform-wallet/src/wallet/platform_addresses/fund_from_asset_lock.rs
@@ -286,14 +286,33 @@ impl PlatformAddressWallet {
         // The seam persists before returning, and the persist MUST
         // happen before `consume_asset_lock` so we never have a
         // Consumed lock paired with a stale balance row on disk.
-        // Persistence errors are logged inside the seam rather than
-        // propagated: Platform already accepted the transition, and a
-        // persistence hiccup shouldn't mask that.
-        let cs = self
-            .reconcile_address_infos(&address_infos, "fund from asset lock")
+        // Persistence errors don't propagate as `Err` (Platform
+        // already accepted the transition, and a persistence hiccup
+        // shouldn't mask that), but they DO gate the consume below:
+        // marking the lock `Consumed` over stale durable rows would
+        // leave `auto_select_inputs` under-budgeting after a restart
+        // with no Resumable lock left to repair it from.
+        let (cs, persisted) = self
+            .reconcile_address_infos_with_persistence(&address_infos, "fund from asset lock")
             .await;
 
         if let Some(out_point) = tracked_out_point {
+            if !persisted {
+                // Keep the lock row non-Consumed: it stays visible in
+                // the Resumable Funding list, and a user Resume gets
+                // Platform's deterministic 'lock already consumed'
+                // rejection — the same benign recovery path as a
+                // failed consume below — while the next
+                // platform-address sync repairs the stale rows.
+                tracing::error!(
+                    outpoint = %out_point,
+                    "skipping consume_asset_lock: the reconciled balance \
+                     changeset was not durably stored; the lock stays \
+                     non-Consumed (Resumable) rather than pairing a \
+                     Consumed lock with stale balance rows on disk"
+                );
+                return Ok(cs);
+            }
             // Platform DID accept the top-up — propagating an Err
             // here would misreport the protocol outcome, since the
             // caller's recipient(s) already have credits attested

--- a/packages/rs-platform-wallet/src/wallet/platform_addresses/provider.rs
+++ b/packages/rs-platform-wallet/src/wallet/platform_addresses/provider.rs
@@ -999,24 +999,49 @@ impl PlatformPaymentAddressProvider {
                     }
                 }
             }
-            // Drop the entry outright when its derivation index is
-            // already paired with a DIFFERENT address — committing it
-            // would either evict that pairing (`BiBTreeMap::insert`
-            // drops conflicting pairs, orphaning the other address's
-            // `found` entry) or persist an address `current_balances`
-            // can't round-trip back out of the committed seed.
-            if state.addresses.get_by_right(&entry.address).is_none()
-                && state.addresses.contains_left(&entry.address_index)
-            {
+            // The derivation index is already paired with a DIFFERENT
+            // address (`entry.address` isn't in the bijection but its
+            // index is). Bijection insertion here would evict that
+            // pairing (`BiBTreeMap::insert` drops conflicting pairs,
+            // orphaning the other address's `found` entry) or persist an
+            // address `current_balances` can't round-trip back out of
+            // the committed seed. The exact response splits on entry
+            // kind:
+            //
+            // * A credit (non-zero funds) entry is dropped outright —
+            //   committing it either corrupts the bijection or hands
+            //   downstream a `(address_index, address)` pair the seed
+            //   can't reproduce.
+            // * A removal (zero funds/nonce) entry must still zero the
+            //   in-memory `found` row and be emitted downstream so the
+            //   durable persister writes the zero-out — otherwise a
+            //   stale persisted balance for `entry.address` would
+            //   resurrect after restart. We only skip the bijection
+            //   merge; the address is being removed from state anyway,
+            //   so it doesn't need a `(index -> address)` pairing.
+            let index_conflict = state.addresses.get_by_right(&entry.address).is_none()
+                && state.addresses.contains_left(&entry.address_index);
+            if index_conflict && !is_removal {
                 tracing::error!(
                     account_index = entry.account_index,
                     address_index = entry.address_index,
                     address = %entry.address,
                     "commit_reconciliation: derivation index already \
                      maps to a different address — state drift; \
-                     dropping the reconciliation entry"
+                     dropping the credit reconciliation entry"
                 );
                 continue;
+            }
+            if index_conflict {
+                tracing::warn!(
+                    account_index = entry.account_index,
+                    address_index = entry.address_index,
+                    address = %entry.address,
+                    "commit_reconciliation: derivation index already \
+                     maps to a different address — applying the removal \
+                     without touching the bijection so a stale persisted \
+                     balance can't resurrect after restart"
+                );
             }
             if is_removal {
                 state.found.remove(&entry.address);
@@ -1026,8 +1051,9 @@ impl PlatformPaymentAddressProvider {
             // Merge pool-resolved addresses into the bijection so
             // `current_balances` can pair the fresh funds with a
             // derivation index. The conflict guard above already
-            // ensured this never overwrites an existing pairing.
-            if state.addresses.get_by_right(&entry.address).is_none() {
+            // dropped the credit case and gated the removal case, so
+            // this can't overwrite an existing pairing.
+            if !index_conflict && state.addresses.get_by_right(&entry.address).is_none() {
                 state.addresses.insert(entry.address_index, entry.address);
             }
             outcome.entries.push(entry);
@@ -1794,6 +1820,160 @@ mod tests {
             .expect("fresh address must appear in the found seed");
         assert_eq!(fresh_row.0, (WALLET, ACCOUNT, 9));
         assert_eq!(fresh_row.2, funds(1_234, 0));
+    }
+
+    /// A zero-funds removal that pool-resolves to an `address_index` already
+    /// paired to a DIFFERENT address in the bijection must still zero the
+    /// in-memory `found` row AND be emitted downstream — otherwise a durable
+    /// persister row for the removed address would resurrect after restart.
+    /// The bijection stays untouched so the existing `(index -> other addr)`
+    /// pairing isn't orphaned.
+    #[test]
+    fn commit_reconciliation_index_conflict_still_emits_removal() {
+        // Existing pairing: index 0 <-> `owned`, plus a stale persisted row
+        // at index 5 <-> `conflicting_bijection_addr` we want to protect.
+        let owned = p2pkh(0x11);
+        let conflicting_bijection_addr = p2pkh(0x77);
+        let mut provider = provider_with_one_funded_address(owned, funds(700, 3));
+        {
+            let state = provider
+                .per_wallet
+                .get_mut(&WALLET)
+                .and_then(|s| s.get_mut(&ACCOUNT))
+                .expect("account state present");
+            // Pin `conflicting_bijection_addr` at index 5 with a stale credit.
+            state.insert_persisted_entry(5, conflicting_bijection_addr, funds(200, 1));
+        }
+
+        // The removed address is a fresh-pool address at the SAME index 5,
+        // but a DIFFERENT address than what the bijection holds there.
+        let removed = p2pkh(0x22);
+        let removed_addr = PlatformAddress::P2pkh([0x22; 20]);
+        let mut pool_indexes = BTreeMap::new();
+        pool_indexes.insert(removed, (ACCOUNT, 5u32));
+
+        // Seed a stale `found` row for the removed address so we can prove
+        // it's zeroed out in memory.
+        {
+            let state = provider
+                .per_wallet
+                .get_mut(&WALLET)
+                .and_then(|s| s.get_mut(&ACCOUNT))
+                .expect("account state present");
+            state.found.insert(removed, funds(999, 4));
+        }
+
+        let mut address_infos = AddressInfos::new();
+        // Fully-consumed input: drive elides the info → removal entry.
+        address_infos.insert(removed_addr, None);
+
+        let outcome = provider.commit_reconciliation(&WALLET, &address_infos, &pool_indexes);
+
+        // The removal is emitted so the durable persister writes the zero-out.
+        assert_eq!(
+            outcome.entries.len(),
+            1,
+            "removal must survive the index-conflict guard so its zero-out is durably persisted"
+        );
+        assert_eq!(outcome.entries[0].address, removed);
+        assert_eq!(outcome.entries[0].funds, funds(0, 0));
+        assert_eq!(outcome.entries[0].address_index, 5);
+
+        let state = provider
+            .per_wallet
+            .get(&WALLET)
+            .and_then(|s| s.get(&ACCOUNT))
+            .expect("account state present");
+        // In-memory `found` for the removed address is dropped.
+        assert!(
+            !state.found.contains_key(&removed),
+            "removal must clear the in-memory `found` row so a next-pass seed can't resurrect it"
+        );
+        // The bijection is unchanged — the pre-existing pairing survives.
+        assert_eq!(
+            state.addresses.get_by_left(&5u32).copied(),
+            Some(conflicting_bijection_addr),
+            "index conflict must not evict the pre-existing bijection pairing"
+        );
+        assert!(
+            state.addresses.get_by_right(&removed).is_none(),
+            "removal must not be inserted into the bijection"
+        );
+        // The pre-existing address's balance is likewise untouched.
+        assert_eq!(
+            state.found.get(&conflicting_bijection_addr).copied(),
+            Some(funds(200, 1))
+        );
+    }
+
+    /// The credit-side twin of [`commit_reconciliation_index_conflict_still_emits_removal`]:
+    /// a non-zero credit entry whose pool-resolved index conflicts with an
+    /// existing bijection pairing is dropped outright — persisting it would
+    /// either evict the pairing or hand `current_balances` a pair it can't
+    /// round-trip. Nothing is emitted, and neither `found` nor the bijection
+    /// change.
+    #[test]
+    fn commit_reconciliation_index_conflict_drops_credit_entry() {
+        use dash_sdk::query_types::AddressInfo;
+
+        let owned = p2pkh(0x11);
+        let conflicting_bijection_addr = p2pkh(0x77);
+        let mut provider = provider_with_one_funded_address(owned, funds(700, 3));
+        {
+            let state = provider
+                .per_wallet
+                .get_mut(&WALLET)
+                .and_then(|s| s.get_mut(&ACCOUNT))
+                .expect("account state present");
+            state.insert_persisted_entry(5, conflicting_bijection_addr, funds(200, 1));
+        }
+
+        let fresh = p2pkh(0x22);
+        let fresh_addr = PlatformAddress::P2pkh([0x22; 20]);
+        let mut pool_indexes = BTreeMap::new();
+        pool_indexes.insert(fresh, (ACCOUNT, 5u32));
+
+        let mut address_infos = AddressInfos::new();
+        address_infos.insert(
+            fresh_addr,
+            Some(AddressInfo {
+                address: fresh_addr,
+                nonce: 0,
+                balance: 1_234,
+            }),
+        );
+
+        let outcome = provider.commit_reconciliation(&WALLET, &address_infos, &pool_indexes);
+
+        assert!(
+            outcome.entries.is_empty(),
+            "credit entry conflicting on address_index must be dropped, not persisted"
+        );
+
+        let state = provider
+            .per_wallet
+            .get(&WALLET)
+            .and_then(|s| s.get(&ACCOUNT))
+            .expect("account state present");
+        // Bijection untouched: the pre-existing pairing survives.
+        assert_eq!(
+            state.addresses.get_by_left(&5u32).copied(),
+            Some(conflicting_bijection_addr),
+            "index conflict must not evict the pre-existing bijection pairing"
+        );
+        assert!(
+            state.addresses.get_by_right(&fresh).is_none(),
+            "conflicting credit must not enter the bijection"
+        );
+        // `found` is untouched for both addresses.
+        assert!(
+            !state.found.contains_key(&fresh),
+            "conflicting credit must not be inserted into found"
+        );
+        assert_eq!(
+            state.found.get(&conflicting_bijection_addr).copied(),
+            Some(funds(200, 1))
+        );
     }
 
     /// `reset_sync_state` must zero the incremental watermark AND drop

--- a/packages/rs-platform-wallet/src/wallet/platform_addresses/provider.rs
+++ b/packages/rs-platform-wallet/src/wallet/platform_addresses/provider.rs
@@ -999,6 +999,25 @@ impl PlatformPaymentAddressProvider {
                     }
                 }
             }
+            // Drop the entry outright when its derivation index is
+            // already paired with a DIFFERENT address — committing it
+            // would either evict that pairing (`BiBTreeMap::insert`
+            // drops conflicting pairs, orphaning the other address's
+            // `found` entry) or persist an address `current_balances`
+            // can't round-trip back out of the committed seed.
+            if state.addresses.get_by_right(&entry.address).is_none()
+                && state.addresses.contains_left(&entry.address_index)
+            {
+                tracing::error!(
+                    account_index = entry.account_index,
+                    address_index = entry.address_index,
+                    address = %entry.address,
+                    "commit_reconciliation: derivation index already \
+                     maps to a different address — state drift; \
+                     dropping the reconciliation entry"
+                );
+                continue;
+            }
             if is_removal {
                 state.found.remove(&entry.address);
             } else {
@@ -1006,22 +1025,10 @@ impl PlatformPaymentAddressProvider {
             }
             // Merge pool-resolved addresses into the bijection so
             // `current_balances` can pair the fresh funds with a
-            // derivation index. Never overwrite an existing pairing —
-            // `BiBTreeMap::insert` evicts conflicting pairs, which
-            // would orphan another address's `found` entry.
+            // derivation index. The conflict guard above already
+            // ensured this never overwrites an existing pairing.
             if state.addresses.get_by_right(&entry.address).is_none() {
-                if state.addresses.contains_left(&entry.address_index) {
-                    tracing::error!(
-                        account_index = entry.account_index,
-                        address_index = entry.address_index,
-                        address = %entry.address,
-                        "commit_reconciliation: derivation index already \
-                         maps to a different address — state drift; \
-                         leaving the bijection untouched"
-                    );
-                } else {
-                    state.addresses.insert(entry.address_index, entry.address);
-                }
+                state.addresses.insert(entry.address_index, entry.address);
             }
             outcome.entries.push(entry);
         }

--- a/packages/rs-platform-wallet/src/wallet/platform_addresses/wallet.rs
+++ b/packages/rs-platform-wallet/src/wallet/platform_addresses/wallet.rs
@@ -201,16 +201,39 @@ impl PlatformAddressWallet {
     ///
     /// Persistence errors are logged rather than propagated — Platform
     /// already accepted the transition, and a later sync reconciles.
+    /// Callers that must observe persistence (e.g. asset-lock funding,
+    /// which must not consume the lock over stale durable rows) use
+    /// [`reconcile_address_infos_with_persistence`] instead.
     ///
     /// [`PlatformPaymentAddressProvider::commit_reconciliation`]:
     /// super::provider::PlatformPaymentAddressProvider::commit_reconciliation
+    /// [`reconcile_address_infos_with_persistence`]:
+    /// Self::reconcile_address_infos_with_persistence
     pub async fn reconcile_address_infos(
         &self,
         address_infos: &AddressInfos,
         context: &'static str,
     ) -> crate::PlatformAddressChangeSet {
+        self.reconcile_address_infos_with_persistence(address_infos, context)
+            .await
+            .0
+    }
+
+    /// [`reconcile_address_infos`](Self::reconcile_address_infos), but
+    /// also reporting whether the durable rows now reflect the
+    /// transition: `true` when the changeset was stored (or nothing
+    /// new needed storing), `false` when the balances could not be
+    /// applied at all (no provider / no provider state / nothing
+    /// resolved to a wallet-owned slot) or the persist itself failed.
+    /// Callers with a persist-before-cleanup ordering invariant branch
+    /// on the flag; everyone else uses the plain variant.
+    pub(crate) async fn reconcile_address_infos_with_persistence(
+        &self,
+        address_infos: &AddressInfos,
+        context: &'static str,
+    ) -> (crate::PlatformAddressChangeSet, bool) {
         if address_infos.is_empty() {
-            return crate::PlatformAddressChangeSet::default();
+            return (crate::PlatformAddressChangeSet::default(), true);
         }
 
         let mut guard = self.provider.write().await;
@@ -222,7 +245,7 @@ impl PlatformAddressWallet {
                  provider for this wallet; local balances stay stale \
                  until the next platform-address sync"
             );
-            return crate::PlatformAddressChangeSet::default();
+            return (crate::PlatformAddressChangeSet::default(), false);
         };
         if provider.per_wallet_state(&self.wallet_id).is_none() {
             tracing::warn!(
@@ -232,7 +255,7 @@ impl PlatformAddressWallet {
                  provider state for this wallet; local balances stay \
                  stale until the next platform-address sync"
             );
-            return crate::PlatformAddressChangeSet::default();
+            return (crate::PlatformAddressChangeSet::default(), false);
         }
 
         // Live-pool fallback indexes for addresses derived since the last
@@ -273,7 +296,7 @@ impl PlatformAddressWallet {
                  address belongs to a third party; otherwise local \
                  balances stay stale until the next platform-address sync"
             );
-            return crate::PlatformAddressChangeSet::default();
+            return (crate::PlatformAddressChangeSet::default(), false);
         }
         if outcome.stale_skipped > 0 || outcome.unchanged_skipped > 0 {
             tracing::debug!(
@@ -286,7 +309,9 @@ impl PlatformAddressWallet {
             );
         }
         if outcome.entries.is_empty() {
-            return crate::PlatformAddressChangeSet::default();
+            // Everything the proof attested was already committed (or
+            // fresher) in the durable rows — nothing new to store.
+            return (crate::PlatformAddressChangeSet::default(), true);
         }
 
         // Apply the proof-attested balances to the managed accounts while
@@ -336,7 +361,9 @@ impl PlatformAddressWallet {
             addresses: outcome.entries,
             ..Default::default()
         };
+        let mut persisted = true;
         if let Err(e) = self.persister.store(cs.clone().into()) {
+            persisted = false;
             tracing::error!(
                 context,
                 error = %e,
@@ -346,7 +373,7 @@ impl PlatformAddressWallet {
             );
         }
         drop(guard);
-        cs
+        (cs, persisted)
     }
 
     /// Get the network from the SDK.
@@ -433,22 +460,22 @@ impl PlatformAddressWallet {
     ///
     /// Does NOT route through [`apply_sync_state`] — that helper's
     /// all-None early-return guard is meant for persisted-state replay
-    /// and is irrelevant here. The two locks are taken sequentially
-    /// (one released before the next is acquired), so there is no
-    /// nested-lock hazard; this mirrors the ordering rationale in
-    /// [`initialize_from_persisted`].
+    /// and is irrelevant here. Both clears run inside one provider
+    /// write critical section (provider → wallet-manager, the same
+    /// nesting order [`sync_balances`](Self::sync_balances) and the
+    /// reconciliation seam use), so a concurrent sync/reconciliation
+    /// pass can never interleave between the two steps and repopulate
+    /// the managed balances after only one store was cleared.
     pub async fn reset_sync_state(&self) {
-        {
-            let mut wm = self.wallet_manager.write().await;
-            if let Some(info) = wm.get_wallet_info_mut(&self.wallet_id) {
-                for account in info.core_wallet.all_platform_payment_managed_accounts_mut() {
-                    account.clear_balances();
-                }
-            }
-        }
         let mut guard = self.provider.write().await;
         if let Some(provider) = guard.as_mut() {
             provider.reset_sync_state();
+        }
+        let mut wm = self.wallet_manager.write().await;
+        if let Some(info) = wm.get_wallet_info_mut(&self.wallet_id) {
+            for account in info.core_wallet.all_platform_payment_managed_accounts_mut() {
+                account.clear_balances();
+            }
         }
     }
 

--- a/packages/rs-platform-wallet/src/wallet/shielded/file_store.rs
+++ b/packages/rs-platform-wallet/src/wallet/shielded/file_store.rs
@@ -295,11 +295,14 @@ impl ShieldedStore for FileBackedShieldedStore {
         let Some(sw) = self.subwallets.get_mut(&id) else {
             return Ok(false);
         };
+        let known = sw.nullifier_index.contains_key(nullifier);
         let marked = sw.mark_spent(nullifier);
-        if marked {
+        if known {
             // `SubwalletState::mark_spent` dropped any redrive carrying
-            // this nullifier from memory; mirror the deletions. The
-            // in-memory transition already happened, so a SQLite failure
+            // this nullifier from memory — even when the note was
+            // already spent (a redrive row can rehydrate after the
+            // promotion); mirror the deletions. The in-memory
+            // transition already happened, so a SQLite failure
             // must not abort the call — log it and keep the trait
             // behavior consistent. A surviving stale row rehydrates a
             // reservation on the next open, which the reconcile / prune
@@ -611,13 +614,24 @@ impl ShieldedStore for FileBackedShieldedStore {
     fn purge_wallet(&mut self, wallet_id: WalletId) -> Result<(), Self::Error> {
         // Per-subwallet note / watermark / checkpoint state is
         // in-memory only (`subwallets`); the commitment tree in
-        // SQLite is chain-wide and intentionally left intact.
+        // SQLite is chain-wide and intentionally left intact. The
+        // wallet's persisted redrive rows must go too, or they would
+        // rehydrate reservations for a wallet that no longer exists.
         self.subwallets.retain(|id, _| id.wallet_id != wallet_id);
+        let conn = self.pending_conn.lock().expect("pending_conn mutex");
+        conn.execute(
+            "DELETE FROM shielded_pending_spends WHERE wallet_id = ?1",
+            rusqlite::params![wallet_id.as_slice()],
+        )
+        .map_err(|e| FileShieldedStoreError(format!("purge wallet redrive rows: {e}")))?;
         Ok(())
     }
 
     fn purge_all_subwallets(&mut self) -> Result<(), Self::Error> {
         self.subwallets.clear();
+        let conn = self.pending_conn.lock().expect("pending_conn mutex");
+        conn.execute("DELETE FROM shielded_pending_spends", [])
+            .map_err(|e| FileShieldedStoreError(format!("purge redrive rows: {e}")))?;
         Ok(())
     }
 

--- a/packages/rs-platform-wallet/src/wallet/shielded/operations.rs
+++ b/packages/rs-platform-wallet/src/wallet/shielded/operations.rs
@@ -1696,22 +1696,33 @@ fn select_recorded_spends<S: ShieldedStore>(
         })
         .collect::<Result<_, PlatformWalletError>>()?;
 
+    // What probing a single checkpoint depth concluded. `NoteNotCovered` and
+    // `StoreError` are deliberately distinct: the former proves no deeper
+    // (older) checkpoint can cover the note either, while the latter only
+    // invalidates this one depth's probe.
+    enum DepthProbe {
+        Built(Vec<SpendableNote>, Anchor),
+        /// A selected note post-dates this checkpoint (or the depth doesn't
+        /// exist) — stop probing deeper.
+        NoteNotCovered,
+        /// A genuine store failure (poisoned mutex, IO, tree corruption) at
+        /// this depth — skip it, and surface the failure if no depth succeeds.
+        StoreError(String),
+    }
+
     // Build every selected note's `SpendableNote` plus the shared anchor at a
     // single checkpoint `depth`.
     //
     // `strict` (depth 0 only): a missing/failed witness is a hard
     // `ShieldedMerkleWitnessUnavailable` (the note is expected to be witnessable
-    // at the current tip). At depth > 0, `Ok(None)` means the note post-dates
-    // this older checkpoint, so the depth is unusable — return `Ok(None)` and
-    // let the caller stop probing deeper; a genuine store `Err` (poisoned mutex,
-    // IO, tree corruption) is logged — the probe would otherwise discard the
-    // message — and likewise treated as an unusable depth rather than aborting,
-    // so a transient read can't strand a spend a shallower depth already
-    // covered. An anchor disagreement across notes is always a hard error (the
-    // spend builder would reject it downstream).
-    let build_at_depth = |depth: usize,
-                          strict: bool|
-     -> Result<Option<(Vec<SpendableNote>, Anchor)>, PlatformWalletError> {
+    // at the current tip). At depth > 0, a missing witness means the note
+    // post-dates this older checkpoint (`NoteNotCovered`), while a store `Err`
+    // is logged — the probe would otherwise discard the message — and reported
+    // as `StoreError` so the caller can keep probing without mistaking a
+    // transient read failure for an uncoverable note. An anchor disagreement
+    // across notes is always a hard error (the spend builder would reject it
+    // downstream).
+    let build_at_depth = |depth: usize, strict: bool| -> Result<DepthProbe, PlatformWalletError> {
         let mut spends = Vec::with_capacity(prepared.len());
         let mut anchor: Option<Anchor> = None;
         for (position, note, cmx) in &prepared {
@@ -1729,10 +1740,11 @@ fn select_recorded_spends<S: ShieldedStore>(
                 }
                 // depth > 0: the note isn't witnessable at this older checkpoint
                 // (appended after it, or the depth doesn't exist).
-                Ok(None) => return Ok(None),
+                Ok(None) => return Ok(DepthProbe::NoteNotCovered),
                 // depth > 0: a genuine store failure. Log it so the operator sees
-                // it (the anchor probe otherwise swallows the message), then treat
-                // the depth as unusable — never a mid-probe abort.
+                // it (the anchor probe otherwise swallows the message), then let
+                // the caller skip just this depth — never a mid-probe abort, and
+                // never conflated with an uncoverable note.
                 Err(e) => {
                     tracing::warn!(
                         position = *position,
@@ -1740,7 +1752,7 @@ fn select_recorded_spends<S: ShieldedStore>(
                         error = %e,
                         "shielded anchor probe: witness_at_depth failed at depth > 0; skipping depth"
                     );
-                    return Ok(None);
+                    return Ok(DepthProbe::StoreError(e.to_string()));
                 }
             };
 
@@ -1771,19 +1783,16 @@ fn select_recorded_spends<S: ShieldedStore>(
                 "no spendable notes selected — anchor undefined".to_string(),
             )
         })?;
-        Ok(Some((spends, anchor)))
+        Ok(DepthProbe::Built(spends, anchor))
     };
 
     // Fast path: a fully-synced wallet's depth-0 root is a recorded anchor.
-    let (spends, anchor) = match build_at_depth(0, true)? {
-        Some(pair) => pair,
-        // Unreachable — a strict build returns `Some` or errors — but stay
+    let DepthProbe::Built(spends, anchor) = build_at_depth(0, true)? else {
+        // Unreachable — a strict build returns `Built` or errors — but stay
         // fund-safe (a clean error, never a panic) if that invariant breaks.
-        None => {
-            return Err(PlatformWalletError::ShieldedMerkleWitnessUnavailable(
-                "depth-0 witness probe returned no witness for a selected note".to_string(),
-            ));
-        }
+        return Err(PlatformWalletError::ShieldedMerkleWitnessUnavailable(
+            "depth-0 witness probe returned no witness for a selected note".to_string(),
+        ));
     };
     if recorded.contains(&anchor.to_bytes()) {
         return Ok((spends, anchor));
@@ -1791,20 +1800,36 @@ fn select_recorded_spends<S: ShieldedStore>(
 
     // Otherwise walk older checkpoints newest→oldest for the shallowest
     // recorded root.
+    let mut skipped_store_error: Option<String> = None;
     for depth in 1..MAX_ANCHOR_PROBE_DEPTH {
         match build_at_depth(depth, false)? {
-            Some((spends, anchor)) if recorded.contains(&anchor.to_bytes()) => {
+            DepthProbe::Built(spends, anchor) if recorded.contains(&anchor.to_bytes()) => {
                 return Ok((spends, anchor));
             }
             // A root exists at this depth but Platform didn't record it — try an
             // older checkpoint.
-            Some(_) => continue,
+            DepthProbe::Built(..) => continue,
             // A selected note isn't witnessable this deep; every deeper
             // checkpoint is older still, so none can cover it either.
-            None => break,
+            DepthProbe::NoteNotCovered => break,
+            // A store failure only invalidates this one depth's probe — a
+            // deeper checkpoint may still cover the notes, so keep walking,
+            // but remember the failure so an exhausted probe surfaces it
+            // instead of the misleading "no recorded anchor" outcome.
+            DepthProbe::StoreError(e) => {
+                skipped_store_error = Some(e);
+                continue;
+            }
         }
     }
 
+    if let Some(e) = skipped_store_error {
+        return Err(PlatformWalletError::ShieldedMerkleWitnessUnavailable(
+            format!(
+            "anchor probe skipped checkpoint depths on a store failure (last: {e}); retry the spend"
+        ),
+        ));
+    }
     Err(PlatformWalletError::ShieldedNoRecordedAnchor(
         "no recorded anchor covers the selected notes; wait for the next shielded sync".to_string(),
     ))

--- a/packages/rs-platform-wallet/src/wallet/shielded/store.rs
+++ b/packages/rs-platform-wallet/src/wallet/shielded/store.rs
@@ -535,21 +535,23 @@ impl SubwalletState {
     }
 
     pub(super) fn mark_spent(&mut self, nullifier: &[u8; 32]) -> bool {
-        if let Some(&idx) = self.nullifier_index.get(nullifier) {
-            if !self.notes[idx].is_spent {
-                self.notes[idx].is_spent = true;
-                // Promotion implies the spend confirmed; drop any
-                // matching pending reservation. Idempotent — the
-                // common path already cleared pending in the
-                // spend-flow finalizer.
-                self.pending_nullifiers.remove(nullifier);
-                // The spend landed — its redrive record (if armed) is
-                // resolved for every nullifier it carries.
-                self.drop_redrives_containing(nullifier);
-                return true;
-            }
+        let Some(&idx) = self.nullifier_index.get(nullifier) else {
+            return false;
+        };
+        // A confirmed spend resolves any matching reservation and
+        // redrive record even when the note is already marked spent —
+        // a reservation rehydrated after the note was promoted must
+        // not survive this call. Idempotent — the common path already
+        // cleared pending in the spend-flow finalizer.
+        self.pending_nullifiers.remove(nullifier);
+        // The spend landed — its redrive record (if armed) is
+        // resolved for every nullifier it carries.
+        self.drop_redrives_containing(nullifier);
+        if self.notes[idx].is_spent {
+            return false;
         }
-        false
+        self.notes[idx].is_spent = true;
+        true
     }
 
     /// Drop every redrive record that carries `nullifier`, returning

--- a/packages/swift-sdk/Sources/SwiftDashSDK/PlatformWallet/PlatformWalletResult.swift
+++ b/packages/swift-sdk/Sources/SwiftDashSDK/PlatformWallet/PlatformWalletResult.swift
@@ -46,6 +46,16 @@ public enum PlatformWalletResultCode: Int32, Sendable {
     /// shielded sync reach a confirmed state and try again. Distinct from
     /// `errorShieldedSpendUnconfirmed`, which must NOT be retried.
     case errorShieldedNoRecordedAnchor = 19
+    /// The wallet couldn't build a Merkle witness for a selected note against
+    /// any probed checkpoint (a transient store read failure — poisoned mutex,
+    /// IO, or commitment-tree corruption — skipped every anchor depth).
+    /// Nothing was broadcast and the notes were released; retryable once the
+    /// underlying read failure clears (typically the next shielded sync or an
+    /// app restart). Distinct from `errorShieldedNoRecordedAnchor` (Platform
+    /// simply hasn't recorded a covering anchor yet) and from
+    /// `errorShieldedSpendUnconfirmed` (a spend WAS broadcast and must NOT be
+    /// retried).
+    case errorShieldedMerkleWitnessUnavailable = 20
     case notFound = 98
     case errorUnknown = 99
 
@@ -91,6 +101,8 @@ public enum PlatformWalletResultCode: Int32, Sendable {
             self = .errorShieldedSpendUnconfirmed
         case PLATFORM_WALLET_FFI_RESULT_CODE_ERROR_SHIELDED_NO_RECORDED_ANCHOR:
             self = .errorShieldedNoRecordedAnchor
+        case PLATFORM_WALLET_FFI_RESULT_CODE_ERROR_SHIELDED_MERKLE_WITNESS_UNAVAILABLE:
+            self = .errorShieldedMerkleWitnessUnavailable
         case PLATFORM_WALLET_FFI_RESULT_CODE_NOT_FOUND:
             self = .notFound
         case PLATFORM_WALLET_FFI_RESULT_CODE_ERROR_UNKNOWN:
@@ -193,6 +205,11 @@ public enum PlatformWalletError: LocalizedError {
     /// sync reaches a confirmed state. Distinct from `shieldedSpendUnconfirmed`,
     /// which must NOT be retried.
     case shieldedNoRecordedAnchor(String)
+    /// The wallet couldn't build a Merkle witness for a selected note because
+    /// a transient store read failure (poisoned mutex / IO / tree corruption)
+    /// skipped every probed anchor depth. Nothing was broadcast and the notes
+    /// were released; retryable once the underlying read failure clears.
+    case shieldedMerkleWitnessUnavailable(String)
     case notFound(String)
     case unknown(String)
 
@@ -208,7 +225,7 @@ public enum PlatformWalletError: LocalizedError {
              .arithmeticOverflow(let m), .noSelectableInputs(let m),
              .walletAlreadyExists(let m), .shieldedBroadcastFailed(let m),
              .shieldedBroadcastUnconfirmed(let m), .shieldedSpendUnconfirmed(let m),
-             .shieldedNoRecordedAnchor(let m),
+             .shieldedNoRecordedAnchor(let m), .shieldedMerkleWitnessUnavailable(let m),
              .notFound(let m), .unknown(let m):
             return m
         }
@@ -240,6 +257,7 @@ public enum PlatformWalletError: LocalizedError {
         case .errorShieldedBroadcastUnconfirmed: self = .shieldedBroadcastUnconfirmed(detail)
         case .errorShieldedSpendUnconfirmed: self = .shieldedSpendUnconfirmed(detail)
         case .errorShieldedNoRecordedAnchor: self = .shieldedNoRecordedAnchor(detail)
+        case .errorShieldedMerkleWitnessUnavailable: self = .shieldedMerkleWitnessUnavailable(detail)
         case .notFound:               self = .notFound(detail)
         case .errorUnknown:           self = .unknown(detail)
         }

--- a/packages/swift-sdk/SwiftExampleApp/SwiftExampleApp/Core/Services/PlatformBalanceSyncService.swift
+++ b/packages/swift-sdk/SwiftExampleApp/SwiftExampleApp/Core/Services/PlatformBalanceSyncService.swift
@@ -67,6 +67,10 @@ class PlatformBalanceSyncService: ObservableObject {
     /// Last error message, cleared on successful sync.
     @Published var lastError: String?
 
+    /// Whether `clearLocalState` is in flight. Views disable "Sync Now"
+    /// and "Clear" while set so a sync can't race the wipe.
+    @Published var isClearing = false
+
     // MARK: - Internal
 
     /// The platform address wallet handle used to refresh address
@@ -87,6 +91,12 @@ class PlatformBalanceSyncService: ObservableObject {
 
     /// Mirrors the Rust manager's current `is_syncing` flag for the UI.
     private var syncStateCancellable: AnyCancellable?
+
+    /// Invalidation token for in-flight `refreshBalanceSnapshot` calls.
+    /// `clearLocalState` bumps it, so a snapshot that was already off
+    /// the main actor fetching pre-clear balances discards its result
+    /// instead of republishing the cleared data.
+    private var refreshGeneration: UInt64 = 0
 
     // MARK: - Lifecycle
 
@@ -227,6 +237,17 @@ class PlatformBalanceSyncService: ObservableObject {
         network: Network,
         walletIdsOnNetwork: Set<Data>
     ) async {
+        // Invalidate any in-flight balance snapshot refresh FIRST: a
+        // refresh that already read pre-clear balances off the main
+        // actor would otherwise republish them right over the cleared
+        // display. Bumping the generation makes it drop its result.
+        refreshGeneration &+= 1
+        isClearing = true
+        defer {
+            refreshGeneration &+= 1
+            isClearing = false
+        }
+
         // 1) Reset the Rust-owned state BEFORE touching disk. Without
         //    this the in-memory watermark survives and the next "Sync
         //    Now" resumes incrementally (fast) instead of doing a full
@@ -307,7 +328,7 @@ class PlatformBalanceSyncService: ObservableObject {
     /// whole call and the subscription never fires, so we have to
     /// reset locally regardless of outcome.
     func performSync() async {
-        guard !isSyncing else { return }
+        guard !isSyncing, !isClearing else { return }
         guard let walletManager = walletManager else {
             lastError = "Platform address wallet not configured"
             return
@@ -366,7 +387,9 @@ class PlatformBalanceSyncService: ObservableObject {
     }
 
     private func refreshBalanceSnapshot() async {
+        guard !isClearing else { return }
         guard let wallet = platformAddressWallet else { return }
+        let generation = refreshGeneration
 
         do {
             let (balances, credits) = try await Task.detached { [wallet] in
@@ -374,6 +397,17 @@ class PlatformBalanceSyncService: ObservableObject {
                 let credits = try wallet.totalCredits()
                 return (balances, credits)
             }.value
+
+            // A clear ran while we were off the main actor — these
+            // balances predate it; publishing them would resurrect the
+            // just-cleared display.
+            guard generation == refreshGeneration else {
+                SDKLogger.log(
+                    "BLAST snapshot refresh discarded: local state cleared mid-refresh",
+                    minimumLevel: .medium
+                )
+                return
+            }
 
             var newBalances: [String: UInt64] = [:]
             var total: UInt64 = 0
@@ -395,6 +429,9 @@ class PlatformBalanceSyncService: ObservableObject {
                 minimumLevel: .medium
             )
         } catch {
+            // Same staleness rule as the success path: a clear reset
+            // `lastError`, so a pre-clear failure shouldn't repopulate it.
+            guard generation == refreshGeneration else { return }
             lastError = error.localizedDescription
             SDKLogger.log(
                 "BLAST sync snapshot refresh error: \(error.localizedDescription)",

--- a/packages/swift-sdk/SwiftExampleApp/SwiftExampleApp/Core/Views/CoreContentView.swift
+++ b/packages/swift-sdk/SwiftExampleApp/SwiftExampleApp/Core/Views/CoreContentView.swift
@@ -369,10 +369,15 @@ var body: some View {
                         .buttonStyle(.borderedProminent)
                         .tint(.blue)
                         .controlSize(.mini)
-                        .disabled(platformBalanceSyncService.isSyncing)
+                        // Also gated on `isClearing` so a sync kicked
+                        // off mid-clear can't re-persist the rows the
+                        // clear is wiping.
+                        .disabled(platformBalanceSyncService.isSyncing || platformBalanceSyncService.isClearing)
 
                         Button {
                             Task {
+                                // `clearLocalState` drives the service's
+                                // `isClearing` flag; both buttons reflect it.
                                 await platformBalanceSyncService.clearLocalState(
                                     modelContext: modelContext,
                                     network: platformState.currentNetwork,
@@ -387,6 +392,7 @@ var body: some View {
                         .buttonStyle(.borderedProminent)
                         .tint(.red)
                         .controlSize(.mini)
+                        .disabled(platformBalanceSyncService.isSyncing || platformBalanceSyncService.isClearing)
                     }
                 }
                 .padding(.vertical, 4)


### PR DESCRIPTION
Follow-up fixes for CodeRabbit feedback on #3990.\n\nThis branch addresses the platform wallet sync/reconciliation, shielded pending spend cleanup, Swift clear/sync race, and best-effort identity persistence review comments.\n\nValidation:\n- cargo fmt --manifest-path packages/rs-platform-wallet/Cargo.toml --check\n- cargo check -p platform-wallet --features shielded\n\nNote: I could not push directly to dashpay/platform:chore/sync-v4.1-dev-with-v4.0-dev (403/permission denied), so this PR targets that branch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved wallet reconciliation so balance updates are only finalized when local changes are safely saved.
  * Prevented stale or duplicate shielded spend records from reappearing after wallet resets or clears.
  * Made balance syncing more resilient during clear operations, avoiding old data from repopulating the UI.
  * Tightened handling of address and spend reconciliation conflicts to reduce inconsistent wallet states.

* **New Features**
  * Added safer clearing behavior in the example app, with the Clear action disabled while cleanup is in progress.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->