### PR TITLE
test(swift-sdk): assert transaction decoder error cases

### DIFF
--- a/packages/swift-sdk/SwiftTests/SwiftDashSDKTests/TransactionDecoderTests.swift
+++ b/packages/swift-sdk/SwiftTests/SwiftDashSDKTests/TransactionDecoderTests.swift
@@ -58,7 +58,6 @@ final class TransactionDecoderTests: XCTestCase {
     func testTxidDisplayHexMatchesExplorerOrder() throws {
         let decoded = try TransactionDecoder.decode(fixtureData, network: .testnet)
         XCTAssertEqual(decoded.txidDisplayHex, Self.fixtureTxidDisplay)
-        XCTAssertEqual(decoded.txid, Data(decoded.txid.reversed().reversed()))
     }
 
     func testNetworkChangesRenderedAddresses() throws {
@@ -70,11 +69,29 @@ final class TransactionDecoderTests: XCTestCase {
     func testMalformedBytesThrowDeserialization() {
         var bytes = fixtureData
         bytes.append(contentsOf: [0xDE, 0xAD]) // trailing garbage
-        XCTAssertThrowsError(try TransactionDecoder.decode(bytes, network: .testnet))
-        XCTAssertThrowsError(try TransactionDecoder.decode(Data([0xFF, 0xFF, 0xFF]), network: .testnet))
+        XCTAssertThrowsError(try TransactionDecoder.decode(bytes, network: .testnet)) { error in
+            if case PlatformWalletError.deserialization = error {
+                // Expected
+            } else {
+                XCTFail("Expected deserialization error, got \(error)")
+            }
+        }
+        XCTAssertThrowsError(try TransactionDecoder.decode(Data([0xFF, 0xFF, 0xFF]), network: .testnet)) { error in
+            if case PlatformWalletError.deserialization = error {
+                // Expected
+            } else {
+                XCTFail("Expected deserialization error, got \(error)")
+            }
+        }
     }
 
     func testEmptyInputThrowsInvalidParameter() {
-        XCTAssertThrowsError(try TransactionDecoder.decode(Data(), network: .testnet))
+        XCTAssertThrowsError(try TransactionDecoder.decode(Data(), network: .testnet)) { error in
+            if case PlatformWalletError.invalidParameter = error {
+                // Expected
+            } else {
+                XCTFail("Expected invalidParameter error, got \(error)")
+            }
+        }
     }
 }


### PR DESCRIPTION
## Summary
- removes a tautological double-reversal assertion from `testTxidDisplayHexMatchesExplorerOrder`
- asserts specific `PlatformWalletError` cases for malformed/trailing transaction bytes and empty input

## Validation
- `git diff --check`
- `bash build_ios.sh --target mac --profile dev` built `DashSDKFFI.xcframework` for macOS, then failed the script follow-up iOS Simulator app build because this invocation only produced a macOS library
- `swift test --filter TransactionDecoderTests/testMalformedBytesThrowDeserialization` passed
- `swift test --filter TransactionDecoderTests/testEmptyInputThrowsInvalidParameter` passed
- `swift test --filter TransactionDecoderTests` still fails 4 decode happy-path tests with `deserialization("IO error")` using the freshly built FFI slice; the two changed error-path tests pass

Addresses CodeRabbit feedback on dashpay/platform#3981.