### PR TITLE
fix(platform-wallet): size withdrawal plan from on-chain balances

### DIFF
--- a/packages/rs-platform-wallet-ffi/src/platform_addresses/withdrawal.rs
+++ b/packages/rs-platform-wallet-ffi/src/platform_addresses/withdrawal.rs
@@ -11,7 +11,7 @@ use rs_sdk_ffi::{SignerHandle, VTableSigner};
 use std::os::raw::c_char;
 use std::str::FromStr;
 
-use super::{parse_input_selection, runtime};
+use super::parse_input_selection;
 use crate::runtime::block_on_worker;
 
 /// Withdraw platform credits to a Core L1 address.
@@ -202,12 +202,16 @@ pub unsafe extern "C" fn platform_address_wallet_withdraw_to_address(
 ///
 /// Runs the same Rust planning phase the real withdraw path executes
 /// (`PlatformAddressWallet::preflight_withdrawal` →
-/// `plan_withdrawal`/`reserve_withdrawal_fee_on_largest_input`): it drops
+/// `plan_withdrawal`/`reserve_withdrawal_fee_on_largest_input`): it reads the
+/// account's authoritative on-chain balances (one `AddressInfo::fetch_many`
+/// proof query — the SAME balances the spend re-fetches and hard-checks), drops
 /// sub-`min_input_amount` dust, estimates the transition fee from the selected
 /// input count (NOT from any destination script — no Core address is needed or
 /// touched), reserves that fee on the largest-balance input, and verifies the
-/// net clears `system_limits.min_withdrawal_amount`. Gating a UI submit button
-/// on the result keeps it in lockstep with what the spend path will accept.
+/// net clears `system_limits.min_withdrawal_amount`. Because the plan is sized
+/// from on-chain balances rather than the wallet cache, gating a UI submit
+/// button on the result keeps it in lockstep with what the spend path accepts
+/// even when the cached balance is stale or doubled.
 ///
 /// On success `out` is written with `can_withdraw = true` and the net /
 /// estimated-fee figures, and the call returns [`PlatformWalletFFIResult::ok`].
@@ -239,11 +243,17 @@ pub unsafe extern "C" fn platform_address_wallet_preflight_withdrawal(
 ) -> PlatformWalletFFIResult {
     check_ptr!(out);
 
-    let option = PLATFORM_ADDRESS_WALLET_STORAGE.with_item(handle, |wallet| {
-        runtime().block_on(wallet.preflight_withdrawal(account_index))
-    });
-    // `None` → invalid handle (mapped to NotFound by the blanket Option impl).
-    let result = unwrap_option_or_return!(option);
+    // Clone the wallet out of handle storage so the read lock is released
+    // before the fetch, then poll on a worker thread (8 MB stack). The
+    // preflight now issues an `AddressInfo::fetch_many` proof query to read
+    // authoritative on-chain balances (so the gate can't approve what the
+    // spend rejects), and GroveDB proof verification recurses past the
+    // ~512 KB stacks of iOS dispatch / Swift-concurrency threads (see
+    // runtime.rs) — polling it on the calling thread would crash with
+    // EXC_BAD_ACCESS, the same reason the withdraw path uses the worker.
+    let option = PLATFORM_ADDRESS_WALLET_STORAGE.with_item(handle, |wallet| wallet.clone());
+    let wallet = unwrap_option_or_return!(option);
+    let result = block_on_worker(async move { wallet.preflight_withdrawal(account_index).await });
 
     match result {
         Ok(plan) => {

--- a/packages/rs-platform-wallet/src/wallet/platform_addresses/withdrawal.rs
+++ b/packages/rs-platform-wallet/src/wallet/platform_addresses/withdrawal.rs
@@ -1,4 +1,4 @@
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 
 use dpp::address_funds::{AddressFundsFeeStrategy, AddressFundsFeeStrategyStep, PlatformAddress};
 use dpp::fee::Credits;
@@ -13,6 +13,8 @@ use super::InputSelection;
 use crate::wallet::PlatformAddressWallet;
 use crate::{PlatformAddressChangeSet, PlatformWalletError};
 use dash_sdk::platform::transition::address_credit_withdrawal::WithdrawAddressFunds;
+use dash_sdk::platform::FetchMany;
+use dash_sdk::query_types::AddressInfo;
 
 /// The fully-planned shape of an AUTO withdrawal, computed by
 /// [`PlatformAddressWallet::plan_withdrawal`] without any signing, broadcast,
@@ -27,11 +29,21 @@ use dash_sdk::platform::transition::address_credit_withdrawal::WithdrawAddressFu
 /// path can never drift — there is no second, parallel fee/min computation to
 /// fall out of sync with the protocol version.
 ///
-/// Constructing a plan is a pure, in-memory computation over the account's
-/// cached balances and the active platform version; it does **not** touch the
-/// Core receive pool (the fee estimate depends only on the input/output
-/// *counts*, not on any destination script), so a preflight can be run on
-/// every input change without burning a receive address.
+/// Every per-input amount in [`inputs`](Self::inputs) is sized from the
+/// address's **authoritative on-chain balance** — the value
+/// [`plan_withdrawal`](PlatformAddressWallet::plan_withdrawal) fetches with
+/// `AddressInfo::fetch_many`, which is the SAME balance the spend path
+/// re-fetches and hard-checks in `fetch_inputs_with_nonce` before signing.
+/// The plan is therefore never built from the wallet's cached
+/// `address_credit_balance` (which a stale or racing sync could double or lag
+/// behind chain), so a preflight can never approve — nor the AUTO spend
+/// select — an input amount that exceeds what the address actually holds,
+/// which would otherwise fail with `AddressNotEnoughFundsError`.
+///
+/// Constructing a plan issues one `fetch_many` proof query over the account's
+/// funded addresses; it does **not** touch the Core receive pool (the fee
+/// estimate depends only on the input/output *counts*, not on any destination
+/// script), so a preflight can be run without burning a receive address.
 #[derive(Debug, Clone)]
 pub struct WithdrawalPlan {
     /// The adjusted **withdraw-amount** map: each chosen input address mapped
@@ -187,6 +199,11 @@ impl PlatformAddressWallet {
     /// **current** platform version, without signing, broadcasting, or
     /// touching the Core receive pool.
     ///
+    /// Issues one `AddressInfo::fetch_many` proof query to read the account's
+    /// authoritative on-chain balances (see
+    /// [`plan_withdrawal`](Self::plan_withdrawal)); it does not sign,
+    /// broadcast, or consume a receive address.
+    ///
     /// This is the public preflight entry point: it resolves the version from
     /// the wallet's SDK (the same network-floored, protocol-version-tracking
     /// source the real spend runs under) and delegates to
@@ -215,6 +232,24 @@ impl PlatformAddressWallet {
     /// withdrawal amount — the complete planning phase shared by the UI
     /// preflight and the real `withdraw(...)` spend path. NO signing,
     /// broadcast, or receive-address consumption happens here.
+    ///
+    /// # Balance source: on-chain, not the cache
+    ///
+    /// The account's derived address pool supplies the *set* of candidate
+    /// addresses, but every candidate's **balance** is read from an
+    /// `AddressInfo::fetch_many` proof query — the SAME authoritative value
+    /// the spend path re-fetches in `fetch_inputs_with_nonce` and hard-checks
+    /// with `ensure_address_balance` before signing. The wallet's cached
+    /// `address_credit_balance` is deliberately NOT used to size inputs: a
+    /// stale cache (lagging the chain) or a doubled cache (a sync/reconcile
+    /// race writing a balance larger than reality) would let the planner
+    /// select an input amount the spend path then rejects with
+    /// `AddressNotEnoughFundsError` (the account's balance looked fundable in
+    /// preflight, but the per-input on-chain balance was short). Sizing the
+    /// plan from the same on-chain truth the spend fetches is what makes the
+    /// "single source of truth" guarantee hold even when the cache is wrong.
+    /// Addresses the proof reports as absent or missing (no on-chain balance)
+    /// are treated as zero and filtered out as dust.
     ///
     /// Only addresses whose balance reaches `min_input_amount` are selected:
     /// DPP's `AddressCreditWithdrawalTransition` v0 validator rejects the
@@ -259,41 +294,68 @@ impl PlatformAddressWallet {
         account_index: u32,
         platform_version: &PlatformVersion,
     ) -> Result<WithdrawalPlan, PlatformWalletError> {
-        let wm = self.wallet_manager.read().await;
-        let info = wm.get_wallet_info(&self.wallet_id).ok_or_else(|| {
-            PlatformWalletError::WalletNotFound(format!(
-                "Wallet {:?} not found in wallet manager",
-                hex::encode(self.wallet_id)
-            ))
-        })?;
-
-        let account = info
-            .core_wallet
-            .platform_payment_managed_account_at_index(account_index)
-            .ok_or_else(|| {
-                PlatformWalletError::AddressSync(format!(
-                    "No platform payment account at index {}",
-                    account_index
+        // Enumerate the account's derived addresses to get the candidate SET.
+        // Balances are read from the chain below, NOT from the account cache —
+        // the cache only tells us *which* addresses belong to this account.
+        // Drop the read lock before the network fetch so a concurrent sync /
+        // reconcile can't be blocked behind a proof round-trip.
+        let candidate_addresses: BTreeSet<PlatformAddress> = {
+            let wm = self.wallet_manager.read().await;
+            let info = wm.get_wallet_info(&self.wallet_id).ok_or_else(|| {
+                PlatformWalletError::WalletNotFound(format!(
+                    "Wallet {:?} not found in wallet manager",
+                    hex::encode(self.wallet_id)
                 ))
             })?;
+
+            let account = info
+                .core_wallet
+                .platform_payment_managed_account_at_index(account_index)
+                .ok_or_else(|| {
+                    PlatformWalletError::AddressSync(format!(
+                        "No platform payment account at index {}",
+                        account_index
+                    ))
+                })?;
+
+            account
+                .addresses
+                .addresses
+                .values()
+                .filter_map(|addr_info| {
+                    PlatformP2PKHAddress::from_address(&addr_info.address)
+                        .ok()
+                        .map(|p2pkh| PlatformAddress::P2pkh(p2pkh.to_bytes()))
+                })
+                .collect()
+        };
+
+        if candidate_addresses.is_empty() {
+            return Err(PlatformWalletError::AddressOperation(
+                "No funded addresses available for withdrawal".to_string(),
+            ));
+        }
+
+        // Read the authoritative on-chain balance for each candidate. This is
+        // the exact query the spend path runs in `fetch_inputs_with_nonce`
+        // (`AddressInfo::fetch_many` over a `BTreeSet<PlatformAddress>`), so
+        // the amounts the plan reserves per input match what the spend will
+        // re-fetch and hard-check — a stale or doubled cache can no longer
+        // make the planner over-request. An address the proof reports as
+        // absent / missing (`None`) has no on-chain balance and maps to 0,
+        // which the dust filter then drops.
+        let on_chain: dash_sdk::query_types::AddressInfos =
+            AddressInfo::fetch_many(self.sdk.as_ref(), candidate_addresses).await?;
 
         // Collect every funded address's (PlatformAddress, on-chain balance)
         // pair, then let the helper apply the per-input-minimum filter and
         // classify the dust-only case. Keeping the filter in a free function
         // mirrors the transfer path and makes the dust policy unit-testable
         // without a live wallet.
-        let funded = account
-            .addresses
-            .addresses
-            .values()
-            .filter_map(|addr_info| {
-                PlatformP2PKHAddress::from_address(&addr_info.address)
-                    .ok()
-                    .map(|p2pkh| {
-                        let balance = account.address_credit_balance(&p2pkh);
-                        (PlatformAddress::P2pkh(p2pkh.to_bytes()), balance)
-                    })
-            });
+        let funded = on_chain.into_iter().map(|(address, info)| {
+            let balance = info.map(|i| i.balance).unwrap_or(0);
+            (address, balance)
+        });
 
         let selected = select_withdrawable_inputs(funded, platform_version)?;
 
@@ -985,5 +1047,178 @@ mod tests {
             matches!(err, PlatformWalletError::AddressOperation(_)),
             "no-funds case is the generic error, not OnlyDustInputs"
         );
+    }
+
+    // ---- ADDR-04 spendability regression ------------------------------------
+    //
+    // The withdrawal that fails at spend time does so because an input's
+    // planned withdraw amount exceeds the address's on-chain balance, so the
+    // spend path's `ensure_address_balance(on_chain, requested)` throws
+    // `AddressNotEnoughFundsError`. The planner math itself never over-
+    // requests: a non-fee-source input is planned at exactly its balance and
+    // the fee-source input at `balance − fee`. These tests pin that invariant
+    // — "every per-input requested amount ≤ that input's balance" — so a
+    // future change to `reserve_withdrawal_fee_on_largest_input` can't
+    // reintroduce an over-request. The doubled-balance ADDR-04 repro was a
+    // WRONG INPUT to this function (a stale/doubled cached balance was passed
+    // in); `plan_withdrawal` now sources balances from the same on-chain
+    // `AddressInfo::fetch_many` proof the spend re-checks, so the values fed
+    // here are the authoritative ones.
+
+    /// Assert the plan is spendable: for every input, the planned withdraw
+    /// amount is ≤ the balance that input was selected with. `balances` maps
+    /// each address to the full balance passed into
+    /// `reserve_withdrawal_fee_on_largest_input`.
+    fn assert_plan_spendable(plan: &WithdrawalPlan, balances: &BTreeMap<PlatformAddress, Credits>) {
+        for (addr, &requested) in plan.inputs.iter() {
+            let balance = balances
+                .get(addr)
+                .copied()
+                .expect("every planned input was among the selected balances");
+            assert!(
+                requested <= balance,
+                "planned withdraw amount {requested} for {addr} exceeds its balance \
+                 {balance} — the spend path would reject this with \
+                 AddressNotEnoughFundsError",
+            );
+        }
+    }
+
+    /// Mandated multi-input plan test: one input sits at *exactly*
+    /// `min_input_amount` (the smallest a withdrawable input can be) alongside
+    /// a comfortably larger fee-source input. The plan must:
+    ///   * withdraw the exactly-minimum input at its FULL balance (never
+    ///     doubled, never more than it holds),
+    ///   * reserve the fee on the larger input (`balance − fee`),
+    ///   * be spendable: every per-input requested amount ≤ that input's
+    ///     balance.
+    #[test]
+    fn plan_min_input_amount_input_is_spendable_at_full_balance() {
+        let pv = PlatformVersion::latest();
+        let fee = estimated_fee(2, pv);
+        let min_input = pv.dpp.state_transitions.address_funds.min_input_amount;
+
+        // The exactly-minimum input, and a larger fee-source input that can
+        // absorb the fee while clearing every minimum.
+        let min_amount = min_input;
+        let large = fee + dpp::dash_to_credits!(1.0);
+
+        let mut balances = BTreeMap::new();
+        balances.insert(addr(1), min_amount); // lex-smallest, exactly the minimum
+        balances.insert(addr(9), large); // larger → fee source
+
+        let plan = reserve_withdrawal_fee_on_largest_input(balances.clone(), pv)
+            .expect("an exactly-minimum input beside a fundable fee source must plan");
+
+        // The exactly-minimum input is withdrawn at its FULL balance — not
+        // reduced (it isn't the fee source) and never doubled.
+        assert_eq!(
+            plan.inputs.get(&addr(1)).copied(),
+            Some(min_amount),
+            "the exactly-min_input_amount input is planned at its full balance"
+        );
+        // The fee is reserved on the larger input.
+        assert_eq!(
+            plan.inputs.get(&addr(9)).copied(),
+            Some(large - fee),
+            "the fee is reserved on the larger fee-source input"
+        );
+        assert_eq!(
+            plan.fee_strategy,
+            vec![AddressFundsFeeStrategyStep::DeductFromInput(1)],
+            "the emitted DeductFromInput index points at the larger input (BTreeMap index 1)"
+        );
+        assert_eq!(plan.estimated_fee, fee);
+        assert_eq!(plan.net_withdrawable, min_amount + large - fee);
+
+        // Core spendability invariant: nothing is requested beyond balance.
+        assert_plan_spendable(&plan, &balances);
+    }
+
+    /// ADDR-04 shape regression: the recipient of a prior small transfer holds
+    /// exactly 100_000_000 credits and is a NON-fee-source input beside the
+    /// large origin address that pays the fee. The recipient input must be
+    /// planned at exactly 100_000_000 — the bug reserved a *doubled*
+    /// 200_000_000 (its balance had been cached at 2× reality), which the
+    /// spend path rejected because on-chain it only held 100_000_000. With the
+    /// correct balance fed in, the plan requests exactly the balance and is
+    /// spendable.
+    #[test]
+    fn plan_does_not_over_request_small_recipient_input() {
+        let pv = PlatformVersion::latest();
+        let fee = estimated_fee(2, pv);
+
+        // Addr#1: the ADDR-02 transfer recipient, 0.001 DASH.
+        let recipient_balance: Credits = 100_000_000;
+        // Addr#0: the topped-up origin, comfortably the largest → fee source.
+        let origin_balance = fee + dpp::dash_to_credits!(0.0488);
+
+        let mut balances = BTreeMap::new();
+        balances.insert(addr(1), recipient_balance);
+        balances.insert(addr(9), origin_balance);
+
+        let plan = reserve_withdrawal_fee_on_largest_input(balances.clone(), pv)
+            .expect("both inputs clear the minimums and the origin absorbs the fee");
+
+        assert_eq!(
+            plan.inputs.get(&addr(1)).copied(),
+            Some(recipient_balance),
+            "the recipient input is planned at its true balance, never doubled"
+        );
+        assert_ne!(
+            plan.inputs.get(&addr(1)).copied(),
+            Some(recipient_balance * 2),
+            "the recipient input must NOT be planned at 2x its balance (ADDR-04)"
+        );
+        assert_eq!(
+            plan.inputs.get(&addr(9)).copied(),
+            Some(origin_balance - fee),
+            "the origin (fee source) keeps fee headroom"
+        );
+
+        // Every input is spendable against its balance — the exact property
+        // the spend path's `ensure_address_balance` enforces.
+        assert_plan_spendable(&plan, &balances);
+    }
+
+    /// Generalised spendability: across a mix of input sizes, EVERY planned
+    /// per-input amount stays ≤ that input's balance, and only the fee-source
+    /// input is reduced (by exactly the fee). This is the invariant that keeps
+    /// the preflight/plan from ever approving what the spend rejects, provided
+    /// the balances fed in are the on-chain truth (which `plan_withdrawal` now
+    /// guarantees by fetching them).
+    #[test]
+    fn plan_every_input_is_spendable_and_only_fee_source_is_reduced() {
+        let pv = PlatformVersion::latest();
+        let fee = estimated_fee(4, pv);
+
+        let mut balances = BTreeMap::new();
+        balances.insert(addr(1), dpp::dash_to_credits!(0.01));
+        balances.insert(addr(4), dpp::dash_to_credits!(0.05));
+        balances.insert(addr(7), dpp::dash_to_credits!(5.0)); // largest → fee source
+        balances.insert(addr(9), dpp::dash_to_credits!(0.02));
+
+        let plan = reserve_withdrawal_fee_on_largest_input(balances.clone(), pv)
+            .expect("a spread of fundable inputs must plan");
+
+        assert_plan_spendable(&plan, &balances);
+
+        // The fee source (addr(7), the largest) is the only reduced input.
+        let fee_source = addr(7);
+        for (addr, &requested) in plan.inputs.iter() {
+            let balance = balances[addr];
+            if *addr == fee_source {
+                assert_eq!(
+                    requested,
+                    balance - fee,
+                    "the fee source is reduced by exactly the fee"
+                );
+            } else {
+                assert_eq!(
+                    requested, balance,
+                    "a non-fee-source input is withdrawn at its full balance"
+                );
+            }
+        }
     }
 }


### PR DESCRIPTION
## Issue being fixed or feature implemented

AUTO platform-address withdrawal (ADDR-04) could pass the UI preflight (`can_withdraw = true`, a plausible `net_withdrawable`) and then **fail every time at spend time** with:

```
AddressNotEnoughFundsError: Insufficient address balance for P2PKH(<hash>): has 100000000, requires at least 200000000
```

Repro (testnet): fund platform account #0 via asset-lock top-up (ADDR-03), transfer 0.001 DASH to a second own-wallet address on the same account (ADDR-02), then withdraw the account to Core.

**Root cause:** `PlatformAddressWallet::plan_withdrawal` sized each input's withdraw amount from the wallet's **cached** `address_credit_balance`, whereas the spend path re-fetches the **on-chain** balance in `fetch_inputs_with_nonce` and hard-checks it with `ensure_address_balance`. When an address's cached balance exceeded its on-chain balance (observed: a transfer recipient cached at 2× its real 100,000,000-credit balance), the preflight approved a plan requesting more than the address holds, and the spend rejected it. The planner's fee math (`reserve_withdrawal_fee_on_largest_input`) was correct; only the *balance source* diverged from the spend, so the "single source of truth" guarantee didn't actually hold.

Note: the earlier report's "input at exactly `min_input_amount`" framing was imprecise — `min_input_amount` is 100,000 credits (1 DASH = 1e11 credits), so 100,000,000 is the transfer amount and the `200000000` in the error is exactly **2× the input's on-chain balance**.

## What was done?

- **`plan_withdrawal`** now sizes every per-input amount from **authoritative on-chain balances** via `AddressInfo::fetch_many` — the same query the spend re-runs in `fetch_inputs_with_nonce`. The account's derived-address pool supplies only the candidate address *set*; balances come from the chain. Addresses the proof reports absent/`None` map to 0 and are dropped as dust. Preflight and the AUTO spend can no longer over-request relative to reality even when the cache is stale or doubled. The `reserve_withdrawal_fee_on_largest_input` fee-reservation math is unchanged.
- **`platform_address_wallet_preflight_withdrawal`** (FFI) now clones the wallet out and polls on the 8 MB `block_on_worker` instead of `runtime().block_on`: the preflight now verifies a fetch proof, and GroveDB proof verification recurses past the ~512 KB iOS dispatch/Swift-concurrency thread stacks (would `EXC_BAD_ACCESS`) — the same reason the withdraw path already uses the worker.

## How Has This Been Tested?

- Added 3 unit tests in `platform-wallet` (pure, no network):
  - `plan_min_input_amount_input_is_spendable_at_full_balance` — a multi-input plan with one input at **exactly `min_input_amount`** beside a larger fee source: the min input is withdrawn at full balance, the fee is reserved on the larger input, and every per-input amount ≤ its balance.
  - `plan_does_not_over_request_small_recipient_input` — the ADDR-04 shape: a 100,000,000-credit recipient input is planned at exactly its balance, explicitly **not** 200,000,000.
  - `plan_every_input_is_spendable_and_only_fee_source_is_reduced` — general spendability invariant.
- `cargo test -p platform-wallet` — all pass.
- `cargo check -p platform-wallet-ffi --all-targets` — clean.
- `cargo fmt --all -- --check` — clean.

## Breaking Changes

None. This is a client-side wallet planning change; no consensus rules, serialization, or FFI signatures change. (`plan_withdrawal`/`preflight_withdrawal` now issue one proof query instead of being purely in-memory.)

## Follow-up (out of scope)

The fix corrects the withdrawal regardless of *why* the cache was wrong. The underlying **doubled-cache write** was not pinned down: every balance write in this repo is an idempotent absolute `set_address_credit_balance` (the accumulating `add_` variant is called nowhere), so the double is likely a sync/reconcile race or a SwiftData hydration issue — tracked as a separate task. That doubled cache would also mis-display balances elsewhere and should be fixed at its source.

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [ ] I have made corresponding changes to the documentation if needed

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone

🤖 Generated with [Claude Code](https://claude.com/claude-code)