### PR TITLE
docs(platform-wallet): clarify broadcast retry contract

### DIFF
--- a/packages/rs-platform-wallet/src/broadcaster.rs
+++ b/packages/rs-platform-wallet/src/broadcaster.rs
@@ -20,8 +20,13 @@ use crate::spv::SpvRuntime;
 /// Implementations may use DAPI (gRPC), SPV (P2P peers), or Core RPC.
 #[async_trait]
 pub trait TransactionBroadcaster: Send + Sync {
-    /// Contract: `Err` must mean the transaction was **not** accepted by the
-    /// network, so callers may safely release its reserved inputs and retry.
+    /// Error contract:
+    /// [`TransactionBroadcast`](PlatformWalletError::TransactionBroadcast) and
+    /// [`SpvError`](PlatformWalletError::SpvError) mean the submission was
+    /// rejected pre-send — the network never accepted the transaction — so
+    /// callers may release its reserved inputs and retry. Any other `Err` is
+    /// ambiguous: the transaction may already have been accepted, so callers
+    /// must keep the reservation rather than risk a double-spend on retry.
     async fn broadcast(&self, transaction: &Transaction) -> Result<Txid, PlatformWalletError>;
 }
 

--- a/packages/rs-platform-wallet/src/broadcaster.rs
+++ b/packages/rs-platform-wallet/src/broadcaster.rs
@@ -22,11 +22,12 @@ use crate::spv::SpvRuntime;
 pub trait TransactionBroadcaster: Send + Sync {
     /// Error contract:
     /// [`TransactionBroadcast`](PlatformWalletError::TransactionBroadcast) and
-    /// [`SpvError`](PlatformWalletError::SpvError) mean the submission was
-    /// rejected pre-send — the network never accepted the transaction — so
-    /// callers may release its reserved inputs and retry. Any other `Err` is
-    /// ambiguous: the transaction may already have been accepted, so callers
-    /// must keep the reservation rather than risk a double-spend on retry.
+    /// [`SpvError`](PlatformWalletError::SpvError) are treated as observed
+    /// pre-send rejections: callers may release reserved inputs and retry.
+    /// Implementations must not use these variants for ambiguous transport
+    /// failures where the transaction may already have reached the network.
+    /// Any other `Err` is ambiguous, so callers must keep the reservation
+    /// rather than risk a double-spend on retry.
     async fn broadcast(&self, transaction: &Transaction) -> Result<Txid, PlatformWalletError>;
 }
 

--- a/packages/rs-platform-wallet/src/wallet/core/broadcast.rs
+++ b/packages/rs-platform-wallet/src/wallet/core/broadcast.rs
@@ -238,19 +238,16 @@ mod tests {
     use crate::wallet::platform_wallet::PlatformWalletInfo;
     use crate::PlatformWalletError;
 
-    /// Broadcaster that fails its first call with the given pre-send error and
-    /// succeeds afterwards, to model a transient broadcast error followed by a
-    /// user retry.
+    /// Broadcaster that fails its first call and succeeds afterwards, to model
+    /// a transient broadcast error followed by a user retry.
     struct FailFirstBroadcaster {
         failed_once: AtomicBool,
-        make_error: fn() -> PlatformWalletError,
     }
 
     impl FailFirstBroadcaster {
-        fn new(make_error: fn() -> PlatformWalletError) -> Self {
+        fn new() -> Self {
             Self {
                 failed_once: AtomicBool::new(false),
-                make_error,
             }
         }
     }
@@ -261,7 +258,9 @@ mod tests {
             if self.failed_once.swap(true, Ordering::SeqCst) {
                 Ok(transaction.txid())
             } else {
-                Err((self.make_error)())
+                Err(PlatformWalletError::TransactionBroadcast(
+                    "simulated broadcast failure".to_string(),
+                ))
             }
         }
     }
@@ -410,44 +409,36 @@ mod tests {
     /// A pre-send broadcast failure must release the UTXO reservation taken while
     /// building the transaction, so an immediate retry can reselect those inputs
     /// instead of failing with spurious insufficient funds until the TTL backstop.
-    /// Covers both funds-account arms of the release path and both pre-send error
-    /// variants allowlisted by `broadcast_failure_is_pre_send`.
+    /// Covers both funds-account arms of the release path.
     #[tokio::test]
     async fn send_to_addresses_releases_reservation_on_broadcast_failure() {
-        let pre_send_errors: [fn() -> PlatformWalletError; 2] = [
-            || PlatformWalletError::TransactionBroadcast("simulated broadcast failure".to_string()),
-            || PlatformWalletError::SpvError("simulated SPV failure".to_string()),
-        ];
         for account_type in [
             StandardAccountType::BIP44Account,
             StandardAccountType::BIP32Account,
         ] {
-            for make_error in pre_send_errors {
-                let broadcaster = Arc::new(FailFirstBroadcaster::new(make_error));
-                let (core, signer, outputs) = funded_core_wallet(account_type, broadcaster).await;
+            let broadcaster = Arc::new(FailFirstBroadcaster::new());
+            let (core, signer, outputs) = funded_core_wallet(account_type, broadcaster).await;
 
-                // First attempt: build + sign succeed, broadcast fails.
-                let first = core
-                    .send_to_addresses(account_type, 0, outputs.clone(), &signer)
-                    .await;
-                assert!(
-                    matches!(&first, Err(e) if super::broadcast_failure_is_pre_send(e)),
-                    "first send should surface the pre-send broadcast failure for \
-                     {account_type:?}, got {first:?}"
-                );
+            // First attempt: build + sign succeed, broadcast fails.
+            let first = core
+                .send_to_addresses(account_type, 0, outputs.clone(), &signer)
+                .await;
+            assert!(
+                matches!(first, Err(PlatformWalletError::TransactionBroadcast(_))),
+                "first send should surface the broadcast failure for {account_type:?}, got {first:?}"
+            );
 
-                // Immediate retry: only succeeds if the failed broadcast released the
-                // reservation. With the leak, coin selection sees no spendable UTXO and
-                // this fails with a build error instead.
-                let second = core
-                    .send_to_addresses(account_type, 0, outputs, &signer)
-                    .await;
-                assert!(
-                    second.is_ok(),
-                    "retry after a failed broadcast should succeed once the reservation \
-                     is released for {account_type:?}, got {second:?}"
-                );
-            }
+            // Immediate retry: only succeeds if the failed broadcast released the
+            // reservation. With the leak, coin selection sees no spendable UTXO and
+            // this fails with a build error instead.
+            let second = core
+                .send_to_addresses(account_type, 0, outputs, &signer)
+                .await;
+            assert!(
+                second.is_ok(),
+                "retry after a failed broadcast should succeed once the reservation \
+                 is released for {account_type:?}, got {second:?}"
+            );
         }
     }
 

--- a/packages/rs-platform-wallet/src/wallet/core/broadcast.rs
+++ b/packages/rs-platform-wallet/src/wallet/core/broadcast.rs
@@ -238,16 +238,19 @@ mod tests {
     use crate::wallet::platform_wallet::PlatformWalletInfo;
     use crate::PlatformWalletError;
 
-    /// Broadcaster that fails its first call and succeeds afterwards, to model
-    /// a transient broadcast error followed by a user retry.
+    /// Broadcaster that fails its first call with the given pre-send error and
+    /// succeeds afterwards, to model a transient broadcast error followed by a
+    /// user retry.
     struct FailFirstBroadcaster {
         failed_once: AtomicBool,
+        make_error: fn() -> PlatformWalletError,
     }
 
     impl FailFirstBroadcaster {
-        fn new() -> Self {
+        fn new(make_error: fn() -> PlatformWalletError) -> Self {
             Self {
                 failed_once: AtomicBool::new(false),
+                make_error,
             }
         }
     }
@@ -258,9 +261,7 @@ mod tests {
             if self.failed_once.swap(true, Ordering::SeqCst) {
                 Ok(transaction.txid())
             } else {
-                Err(PlatformWalletError::TransactionBroadcast(
-                    "simulated broadcast failure".to_string(),
-                ))
+                Err((self.make_error)())
             }
         }
     }
@@ -409,36 +410,44 @@ mod tests {
     /// A pre-send broadcast failure must release the UTXO reservation taken while
     /// building the transaction, so an immediate retry can reselect those inputs
     /// instead of failing with spurious insufficient funds until the TTL backstop.
-    /// Covers both funds-account arms of the release path.
+    /// Covers both funds-account arms of the release path and both pre-send error
+    /// variants allowlisted by `broadcast_failure_is_pre_send`.
     #[tokio::test]
     async fn send_to_addresses_releases_reservation_on_broadcast_failure() {
+        let pre_send_errors: [fn() -> PlatformWalletError; 2] = [
+            || PlatformWalletError::TransactionBroadcast("simulated broadcast failure".to_string()),
+            || PlatformWalletError::SpvError("simulated SPV failure".to_string()),
+        ];
         for account_type in [
             StandardAccountType::BIP44Account,
             StandardAccountType::BIP32Account,
         ] {
-            let broadcaster = Arc::new(FailFirstBroadcaster::new());
-            let (core, signer, outputs) = funded_core_wallet(account_type, broadcaster).await;
+            for make_error in pre_send_errors {
+                let broadcaster = Arc::new(FailFirstBroadcaster::new(make_error));
+                let (core, signer, outputs) = funded_core_wallet(account_type, broadcaster).await;
 
-            // First attempt: build + sign succeed, broadcast fails.
-            let first = core
-                .send_to_addresses(account_type, 0, outputs.clone(), &signer)
-                .await;
-            assert!(
-                matches!(first, Err(PlatformWalletError::TransactionBroadcast(_))),
-                "first send should surface the broadcast failure for {account_type:?}, got {first:?}"
-            );
+                // First attempt: build + sign succeed, broadcast fails.
+                let first = core
+                    .send_to_addresses(account_type, 0, outputs.clone(), &signer)
+                    .await;
+                assert!(
+                    matches!(&first, Err(e) if super::broadcast_failure_is_pre_send(e)),
+                    "first send should surface the pre-send broadcast failure for \
+                     {account_type:?}, got {first:?}"
+                );
 
-            // Immediate retry: only succeeds if the failed broadcast released the
-            // reservation. With the leak, coin selection sees no spendable UTXO and
-            // this fails with a build error instead.
-            let second = core
-                .send_to_addresses(account_type, 0, outputs, &signer)
-                .await;
-            assert!(
-                second.is_ok(),
-                "retry after a failed broadcast should succeed once the reservation \
-                 is released for {account_type:?}, got {second:?}"
-            );
+                // Immediate retry: only succeeds if the failed broadcast released the
+                // reservation. With the leak, coin selection sees no spendable UTXO and
+                // this fails with a build error instead.
+                let second = core
+                    .send_to_addresses(account_type, 0, outputs, &signer)
+                    .await;
+                assert!(
+                    second.is_ok(),
+                    "retry after a failed broadcast should succeed once the reservation \
+                     is released for {account_type:?}, got {second:?}"
+                );
+            }
         }
     }
 


### PR DESCRIPTION
Follow-up for CodeRabbit comments on #3985.

Changes:
- Clarifies the `TransactionBroadcaster::broadcast` error contract so only pre-send/not-accepted errors are retry-safe and ambiguous errors keep reservations.
- Extends the `send_to_addresses_releases_reservation_on_broadcast_failure` test to cover both pre-send variants allowlisted by `broadcast_failure_is_pre_send`: `TransactionBroadcast` and `SpvError`, across BIP44 and BIP32 accounts.

Validation:
- `cargo test -p platform-wallet --lib wallet::core::broadcast`
- `cargo fmt --check`
- `git diff --check HEAD~1..HEAD`

Closes CodeRabbit follow-up comments on dashpay/platform#3985.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified the broadcast error behavior so callers know when a failed send is safe to retry versus when they should keep reservations to avoid double-spend risks.

* **Tests**
  * Expanded broadcast retry coverage to validate both supported pre-send failure cases.
  * Verified that a failed first attempt can be retried successfully across account types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->