### PR TITLE
docs(swift-example-app): fix ADDR-05 category reference

### DIFF
--- a/packages/swift-sdk/SwiftExampleApp/TEST_PLAN.md
+++ b/packages/swift-sdk/SwiftExampleApp/TEST_PLAN.md
@@ -347,7 +347,7 @@ Membership of each feature category across **all** sections (primary section mem
 - **Core / Wallet** — `CORE-01..23`
 - **MultiWallet** — `CORE-14..23`, `MW-01..11`
 - **Identity** — `ID-01..13`, `SH-11`, `MW-01`, `MW-08`, `MW-09`, `MW-10`
-- **Address** (DIP-17 platform addresses) — `ADDR-01..06`, `ID-06`, `ID-08`, `ID-11`
+- **Address** (DIP-17 platform addresses) — `ADDR-01..04`, `ADDR-06`, `ID-06`, `ID-08`, `ID-11`
 - **DPNS** — `DPNS-01..07`, `MW-05`
 - **Voting** — `VOTE-01..07`, `DPNS-05`, `MW-05`
 - **Contract** — `DC-01..04`


### PR DESCRIPTION
## Summary
- follow up #3998 by removing the implicit ADDR-05 entry from the Address category index
- keep ADDR-06 stable while making the ADDR list non-contiguous

## Testing
- `rg -n "ADDR-05|ADDR-01\.\.06" packages/swift-sdk/SwiftExampleApp/TEST_PLAN.md` (no matches)
- `git diff --check`
- pre-PR code-review gate: ship

Draft until human-approved.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the Swift example app test plan to adjust the list of items covered under the Address category.
  * Removed one address-related entry from that category’s selection; the remaining address-related entries are unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->