### PR TITLE
fix(platform-wallet): re-broadcast a Broadcast-status lock on resume

### DIFF
--- a/packages/rs-platform-wallet/src/wallet/asset_lock/sync/recovery.rs
+++ b/packages/rs-platform-wallet/src/wallet/asset_lock/sync/recovery.rs
@@ -265,7 +265,36 @@ impl<B: TransactionBroadcaster + ?Sized> AssetLockManager<B> {
                     .await?
             }
             AssetLockStatus::Broadcast => {
-                // Already broadcast — just wait for proof.
+                // Defensive re-broadcast, then wait for proof. A lock can
+                // sit at `Broadcast` across app restarts long enough for
+                // its funding tx to be evicted from every mempool (Core's
+                // default `-mempoolexpiry` is two weeks), or the original
+                // broadcast may have reached no peers at all (SPV
+                // connectivity gap). Once no node holds the tx, no IS/CL
+                // proof can ever arrive, and the wait — now unbounded for
+                // the user-facing funding flows — would hang forever. A
+                // re-broadcast revives an evicted/undelivered tx.
+                //
+                // Best-effort: unlike the `Built` arm, this tx was already
+                // broadcast once (that's what `Broadcast` means), so it may
+                // still be in a mempool or already mined — in which case the
+                // network reports "already known" / "already in block
+                // chain". The broadcaster can't distinguish that from a real
+                // rejection (DAPI classifies every failure as `MaybeSent`),
+                // so we log and proceed to `wait_for_proof` regardless
+                // rather than failing the resume on a tx that is actually
+                // fine. If the tx really was mined, `wait_for_proof`
+                // resolves immediately from the SPV/persisted record.
+                if let Err(e) = self.broadcaster.broadcast(&tx).await {
+                    tracing::debug!(
+                        outpoint = %out_point,
+                        error = %e,
+                        "resume_asset_lock: defensive re-broadcast of a \
+                         Broadcast-status lock returned an error (likely \
+                         already in a mempool or mined); proceeding to wait \
+                         for proof"
+                    );
+                }
                 let proof = self.wait_for_proof(out_point, timeout).await?;
                 self.validate_or_upgrade_proof(proof, account_index, out_point)
                     .await?


### PR DESCRIPTION
Follow-up to the ADDR-09 finality work (#4006 / #4007). Surfaced by the review of #4007: resuming an orphaned `Broadcast`-status lock could hang forever.

## Issue being fixed or feature implemented

`resume_asset_lock`'s `Broadcast` arm only waited for a proof — it never re-broadcast the funding tx (only the `Built` arm does). If the tx had been evicted from every mempool (Core's default `-mempoolexpiry` is two weeks) or the original broadcast reached no peers (an SPV connectivity gap — a real condition on the testnet QA setup), no InstantSend/ChainLock proof can ever arrive. And since the user-facing funding flows now wait for the ChainLock **indefinitely** (#4006), the resume hangs forever: the controller stays `.inFlight`, Cancel is disabled, the network toggle is disabled app-wide, and no in-app recovery exists short of relaunch. #4007's new "Resume on a Broadcast orphan" button makes this reachable from the UI.

## What was done?

Add a defensive re-broadcast to the `Broadcast` arm of `resume_asset_lock` before the wait.

Unlike the `Built` arm — whose tx was never broadcast, so a broadcast error is genuine and propagates — a `Broadcast`-status tx may still be in a mempool or already mined, where the network reports "already known" / "already in block chain". The broadcaster can't distinguish that from a real rejection (`DapiBroadcaster` classifies every failure as `MaybeSent`), so the re-broadcast is **best-effort**: log the error and proceed to `wait_for_proof` regardless, rather than failing a resume on a tx that is actually fine. If it was mined, the wait resolves immediately from the persisted record.

This path is shared by the identity, platform-address, and shielded resume flows plus the app-launch catch-up sweep; re-broadcasting an already-known tx is idempotent, so the extra call is harmless where the tx is still live.

## How Has This Been Tested?

- `cargo check -p platform-wallet --features shielded --all-targets` — clean.
- `cargo test -p platform-wallet --features shielded asset_lock` — 19 asset-lock unit tests pass.
- `cargo fmt --all` applied.

Not yet exercised end-to-end (would require an evicted/undelivered asset-lock tx on testnet).

## Breaking Changes

None. No consensus or ABI change.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [ ] I have made corresponding changes to the documentation if needed

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone

🤖 Generated with [Claude Code](https://claude.com/claude-code)