### PR TITLE
fix(swift-example-app): resume orphaned Broadcast identity-registration locks

### DIFF
--- a/packages/swift-sdk/SwiftExampleApp/SwiftExampleApp/Core/Views/IdentitiesContentView.swift
+++ b/packages/swift-sdk/SwiftExampleApp/SwiftExampleApp/Core/Views/IdentitiesContentView.swift
@@ -570,32 +570,37 @@ private struct ResumableRegistrationRow: View {
         .padding(.vertical, 2)
     }
 
-    /// Trailing view that depends on the lock's stage. At Broadcast
-    /// (`!canFundIdentity`) the lock isn't usable yet — SPV is waiting
-    /// on the masternodes to sign an InstantSendLock — so we show
-    /// a spinner instead of a button. SwiftData `@Query` is
-    /// reactive, so when the persister flips the row to
-    /// `InstantSendLocked` this view re-renders into the Resume
-    /// button without any extra plumbing.
-    @ViewBuilder
+    /// Trailing Resume button. Every lock reaching this row is
+    /// `statusRaw` 1...3 (per `crossWalletResumableLocks`) AND — by the
+    /// list's `(walletId, identityIndex)` slot anti-join, which unions
+    /// active-controller slots — is NOT owned by an in-flight
+    /// registration. So every row is a genuinely-orphaned lock with no
+    /// driver, and offering Resume is always safe:
+    /// - InstantSendLocked / ChainLocked (`canFundIdentity`) submits the
+    ///   IdentityCreate as soon as it's tapped.
+    /// - Broadcast (statusRaw 1) has no proof yet; resuming re-enters the
+    ///   finality wait via `resume_asset_lock` (which re-broadcasts the
+    ///   tx, then waits for the ChainLock — guaranteed finality, however
+    ///   long it takes). This previously rendered a permanent spinner,
+    ///   stranding a broadcast-but-interrupted registration lock (app
+    ///   killed mid-wait, or an aged lock whose IS quorum rotated) with
+    ///   no in-app recovery path.
+    ///
+    /// Unlike the address-funding sibling, no `hasActiveFunding` gate is
+    /// needed here: identity locks carry their `identityIndex`, so the
+    /// anti-join excludes the in-flight lock precisely, where the
+    /// address flow (whose lock doesn't know its recipient) cannot.
+    ///
+    /// SwiftData `@Query` re-renders this row as the persister advances
+    /// the lock's status.
     private var trailingAffordance: some View {
-        if lock.canFundIdentity {
-            Button(action: onResume) {
-                Label("Resume", systemImage: "arrow.clockwise")
-                    .labelStyle(.titleAndIcon)
-                    .font(.callout)
-            }
-            .buttonStyle(.borderedProminent)
-            .controlSize(.small)
-        } else {
-            HStack(spacing: 6) {
-                ProgressView()
-                    .controlSize(.small)
-                Text("Waiting for InstantSendLock or ChainLock…")
-                    .font(.caption)
-                    .foregroundColor(.secondary)
-            }
+        Button(action: onResume) {
+            Label("Resume", systemImage: "arrow.clockwise")
+                .labelStyle(.titleAndIcon)
+                .font(.callout)
         }
+        .buttonStyle(.borderedProminent)
+        .controlSize(.small)
     }
 
     private func formatDuffs(_ amountDuffs: Int64) -> String {


### PR DESCRIPTION
Sibling of #4007. The review of that PR flagged that the identity-registration resume list has the identical Broadcast dead-end, unfixed.

## Issue being fixed or feature implemented

`ResumableRegistrationRow` gated its Resume button on `canFundIdentity` (statusRaw 2/3) and rendered a permanent "Waiting for InstantSendLock or ChainLock…" spinner for a Broadcast (statusRaw 1) lock. An identity registration interrupted at Broadcast — app killed mid-wait, or an aged lock whose InstantSend quorum rotated — left committed on-chain funds behind that spinner with no in-app recovery (the launch catch-up sweep caps each pass at 300s, so an SPV that isn't caught up in time leaves the lock stuck until the next relaunch).

## What was done?

Offer Resume for every row in the "Resumable Registrations" list.

Safe without any extra gate: the list already filters to statusRaw 1...3 (`crossWalletResumableLocks`) and anti-joins on `(walletId, identityIndex)` unioned with active-controller slots, so any lock reaching a row is a genuinely-orphaned one with no active driver. Resuming a Broadcast lock re-enters the finality wait via `resume_asset_lock`.

Unlike the address-funding sibling (#4007) — whose lock doesn't know its recipient, forcing a coarser `hasActiveFunding` gate — identity locks carry their `identityIndex`, so the anti-join excludes the in-flight lock precisely and no gate is needed here. The row already shows `lock.statusLabel`, so a Broadcast lock reads clearly next to the button.

## How Has This Been Tested?

Not yet built/run — validation is pending the xcframework rebuild that also picks up the related finality changes (#4006). Code-level self-review only; the safety argument rests on the existing precise anti-join (`crossWalletResumableLocks` + `identitySlots ∪ activeSlots`).

## Breaking Changes

None.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [ ] I have made corresponding changes to the documentation if needed

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone

🤖 Generated with [Claude Code](https://claude.com/claude-code)