### PR TITLE
fix(kotlin-sdk): accept Base58 identity ids on the Load Identity screen

### DIFF
--- a/packages/kotlin-sdk/KotlinExampleApp/app/src/main/java/org/dashfoundation/example/ui/identity/LoadIdentityScreen.kt
+++ b/packages/kotlin-sdk/KotlinExampleApp/app/src/main/java/org/dashfoundation/example/ui/identity/LoadIdentityScreen.kt
@@ -45,7 +45,7 @@ import org.dashfoundation.example.navigation.QrScanner
 import org.dashfoundation.example.ui.components.ErrorAlertDialog
 import org.dashfoundation.example.ui.components.FormSection
 import org.dashfoundation.example.ui.components.SubmitButton
-import org.dashfoundation.example.util.hexToBytes
+import org.dashfoundation.example.util.Base58
 
 /**
  * Load an existing identity by id — port of `LoadIdentityView.swift`. Paste
@@ -148,16 +148,13 @@ fun LoadIdentityScreen(navController: NavHostController) {
                                 ?.jsonPrimitive?.longOrNull ?: 0L
                         }.getOrDefault(0L)
 
-                        // Decode the id to raw 32 bytes for the primary key. Hex
-                        // ids are 64 chars; Base58 falls back to the SDK id in
-                        // the fetched JSON if present.
-                        val idBytes = if (id.length == 64 && id.all { it.isHexDigit() }) {
-                            id.hexToBytes()
-                        } else {
-                            decodeIdFromJson(json) ?: throw IllegalStateException(
-                                "Could not decode identity id — paste the 64-char hex form.",
+                        // Decode the input id (64-char hex or Base58) to raw 32
+                        // bytes for the primary key. `Base58.decodeIdentifier`
+                        // accepts either encoding and enforces the 32-byte width.
+                        val idBytes = Base58.decodeIdentifier(id)
+                            ?: throw IllegalStateException(
+                                "Could not decode identity id — enter a 64-char hex or Base58 identity id.",
                             )
-                        }
 
                         container.database.identityDao().upsert(
                             IdentityEntity(
@@ -190,19 +187,6 @@ fun LoadIdentityScreen(navController: NavHostController) {
 
     ErrorAlertDialog(message = error, onDismiss = { error = null })
 }
-
-private fun Char.isHexDigit(): Boolean = this in '0'..'9' || this in 'a'..'f' || this in 'A'..'F'
-
-/** Pull a hex/id field out of the fetched identity JSON as a fallback. */
-private fun decodeIdFromJson(json: String): ByteArray? = runCatching {
-    val obj = Json.parseToJsonElement(json).jsonObject
-    val idStr = obj["id"]?.jsonPrimitive?.content ?: return null
-    if (idStr.length == 64 && idStr.all { it in "0123456789abcdefABCDEF" }) {
-        idStr.hexToBytes()
-    } else {
-        null
-    }
-}.getOrNull()
 
 @OptIn(ExperimentalStdlibApi::class)
 private fun ByteArray.toHexString(): String = toHexString(HexFormat.Default)


### PR DESCRIPTION
## Issue being fixed or feature implemented

The KotlinExampleApp **Load Identity** screen advertises `Identity ID (hex or Base58)` but rejected Base58 input. Pasting a Base58 identity id (e.g. `5DbLwAxGBzUzo81VewMUwn4b5P4bpv9FNFybi25XB5Bk`) and tapping **Load Identity** surfaced the misleading error *"Could not decode identity id — paste the 64-char hex form."* The hex form of the same id loaded fine.

Root cause: any non-hex input fell back to `decodeIdFromJson(json)`, which read the fetched identity's `"id"` field and only accepted it if it was a 64-char hex string. But `identities.fetch(id)` returns the identity's `"id"` in Base58 (~44 chars), so the `length == 64` check always failed → `null` → the error — even though `fetch` itself succeeded.

## What was done?

Decode the **input string** directly via the app's existing `Base58.decodeIdentifier` helper, which accepts either 64-char hex or Base58 and enforces the 32-byte identifier width. This replaces the fragile round-trip through the fetched JSON.

- Removed the now-dead `decodeIdFromJson` and `isHexDigit` helpers and the unused `hexToBytes` import.
- Reworded the failure message to *"Could not decode identity id — enter a 64-char hex or Base58 identity id."*
- The `fetch(id)` call and balance parse are unchanged (`fetch` already accepts Base58).

UI/example-app only — no SDK/FFI changes.

## How Has This Been Tested?

- Reproduced `Base58.decode`'s algorithm and confirmed `5DbLwAxGBzUzo81VewMUwn4b5P4bpv9FNFybi25XB5Bk` decodes to exactly **32 bytes** = `3ea88cc9622ec22d94db9e2e7a823be13c263d0328146ba80afec33b34ba81af`, identical to the hex path. Both encodings therefore persist the same `identityId`, and `decodeIdentifier`'s 32-byte guard still fails a mistyped id fast.
- Verified the change is self-consistent: no dangling references to the removed helpers, and the retained `kotlinx.serialization` imports are still used by the balance parse.

_Not yet run on an emulator against Testnet — the Android build environment (native `.so` / APFS build volume / emulator) was not provisioned in this session._

## Breaking Changes

None.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [ ] I have made corresponding changes to the documentation if needed

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone

🤖 Generated with [Claude Code](https://claude.com/claude-code)
