### PR TITLE
test(dapi): make transactionsFilter bloom-filter test deterministic

### DIFF
--- a/packages/dapi/test/unit/transactionsFilter/testTransactionAgainstFilter.spec.js
+++ b/packages/dapi/test/unit/transactionsFilter/testTransactionAgainstFilter.spec.js
@@ -15,10 +15,32 @@ chai.use(dirtyChai);
 
 const testTransactionAgainstFilter = require('../../../lib/transactionsFilter/testTransactionAgainstFilter');
 
+// Deterministic test-vector private keys.
+//
+// These tests build a fresh, single-element BloomFilter and then assert that
+// unrelated data (an outpoint, a different address, a transaction hash) does
+// NOT match. A bloom filter has a non-zero false-positive rate, so with
+// randomly generated keys those negative assertions occasionally match by
+// chance and the test flakes (observed rate ~0.3% for the BLOOM_UPDATE_NONE
+// case). Fixed keys make every assertion reproducible. Do not replace these
+// with `new PrivateKey()`.
+const testPrivateKeys = [
+  '0000000000000000000000000000000000000000000000000000000000000001',
+  '0000000000000000000000000000000000000000000000000000000000000002',
+  '0000000000000000000000000000000000000000000000000000000000000003',
+  '0000000000000000000000000000000000000000000000000000000000000004',
+  '0000000000000000000000000000000000000000000000000000000000000005',
+  '0000000000000000000000000000000000000000000000000000000000000006',
+  '0000000000000000000000000000000000000000000000000000000000000007',
+  '0000000000000000000000000000000000000000000000000000000000000008',
+  '0000000000000000000000000000000000000000000000000000000000000009',
+  '000000000000000000000000000000000000000000000000000000000000000a',
+].map((privateKeyHex) => new PrivateKey(privateKeyHex));
+
 describe('testTransactionAgainstFilter', () => {
   it('should match on address in output', () => {
     const filter = BloomFilter.create(1, 0.0001);
-    const address = new PrivateKey().toAddress();
+    const address = testPrivateKeys[0].toAddress();
     const tx = new Transaction().to(address, 10);
     filter.insert(address.hashBuffer);
 
@@ -28,8 +50,8 @@ describe('testTransactionAgainstFilter', () => {
 
   it('should not match on address if there is no such output in transaction', () => {
     const filter = BloomFilter.create(1, 0.0001);
-    const addressInFilter = new PrivateKey().toAddress();
-    const addressInTransaction = new PrivateKey().toAddress();
+    const addressInFilter = testPrivateKeys[1].toAddress();
+    const addressInTransaction = testPrivateKeys[2].toAddress();
     const tx = new Transaction().to(addressInTransaction, 10);
     filter.insert(addressInFilter.hashBuffer);
 
@@ -39,7 +61,7 @@ describe('testTransactionAgainstFilter', () => {
 
   it('should match when input script contains desired data', () => {
     const filter = BloomFilter.create(1, 0.0001);
-    const address = new PrivateKey().toAddress();
+    const address = testPrivateKeys[3].toAddress();
     const tx = new Transaction().to(address, 10);
 
     filter.insert(address.hashBuffer);
@@ -60,8 +82,8 @@ describe('testTransactionAgainstFilter', () => {
 
   it("should not match when input script doesn't contain desired data", () => {
     const filter = BloomFilter.create(1, 0.0001);
-    const addressInFilter = new PrivateKey().toAddress();
-    const addressInTransaction = new PrivateKey().toAddress();
+    const addressInFilter = testPrivateKeys[4].toAddress();
+    const addressInTransaction = testPrivateKeys[5].toAddress();
     const tx = new Transaction().to(addressInTransaction, 10);
 
     filter.insert(addressInFilter.hashBuffer);
@@ -83,7 +105,7 @@ describe('testTransactionAgainstFilter', () => {
   it('should add outpoint to the filter if BLOOM_UPDATE_ALL flag is set in the filter'
     + ' and match transaction with that outpoint in input', () => {
     const filter = BloomFilter.create(1, 0.0001);
-    const address = new PrivateKey().toAddress();
+    const address = testPrivateKeys[6].toAddress();
     const tx = new Transaction().to(address, 10);
 
     filter.nFlags = BloomFilter.BLOOM_UPDATE_ALL;
@@ -107,7 +129,7 @@ describe('testTransactionAgainstFilter', () => {
   it('should not add outpoint to the filter if BLOOM_UPDATE_NONE flag is'
     + ' set in the filter', () => {
     const filter = BloomFilter.create(1, 0.0001);
-    const address = new PrivateKey().toAddress();
+    const address = testPrivateKeys[7].toAddress();
     const tx = new Transaction().to(address, 10);
 
     filter.nFlags = BloomFilter.BLOOM_UPDATE_NONE;
@@ -131,7 +153,7 @@ describe('testTransactionAgainstFilter', () => {
   it('should add outpoint to the filter if BLOOM_UPDATE_P2PUBKEY_ONLY,'
     + ' and output is pub key out', () => {
     const filter = BloomFilter.create(1, 0.0001);
-    const pubKey = new PrivateKey().toPublicKey();
+    const pubKey = testPrivateKeys[8].toPublicKey();
     const output = new Output({
       satoshis: 10,
       script: Script.buildPublicKeyOut(pubKey),
@@ -159,7 +181,7 @@ describe('testTransactionAgainstFilter', () => {
   it('should not add outpoint to the filter if BLOOM_UPDATE_P2PUBKEY_ONLY,'
     + ' and output is to pub key hash', () => {
     const filter = BloomFilter.create(1, 0.0001);
-    const address = new PrivateKey().toAddress();
+    const address = testPrivateKeys[9].toAddress();
     const tx = new Transaction().to(address, 10);
 
     filter.nFlags = BloomFilter.BLOOM_UPDATE_P2PUBKEY_ONLY;
@@ -184,9 +206,9 @@ describe('testTransactionAgainstFilter', () => {
     + ' is set and matched output is multisig', () => {
     const filter = BloomFilter.create(3, 0.0001);
     const pubKeys = [
-      new PrivateKey().toPublicKey(),
-      new PrivateKey().toPublicKey(),
-      new PrivateKey().toPublicKey(),
+      testPrivateKeys[0].toPublicKey(),
+      testPrivateKeys[1].toPublicKey(),
+      testPrivateKeys[2].toPublicKey(),
     ];
     const output = new Output({
       satoshis: 10,
@@ -216,9 +238,9 @@ describe('testTransactionAgainstFilter', () => {
     + 'BLOOM_UPDATE_P2PUBKEY_ONLY flag is not set', () => {
     const filter = BloomFilter.create(3, 0.0001);
     const pubKeys = [
-      new PrivateKey().toPublicKey(),
-      new PrivateKey().toPublicKey(),
-      new PrivateKey().toPublicKey(),
+      testPrivateKeys[3].toPublicKey(),
+      testPrivateKeys[4].toPublicKey(),
+      testPrivateKeys[5].toPublicKey(),
     ];
     const output = new Output({
       satoshis: 10,


### PR DESCRIPTION
## Issue being fixed or feature implemented

The `testTransactionAgainstFilter` unit test **"should not add outpoint to the filter if BLOOM_UPDATE_NONE flag is set in the filter"** is flaky. It intermittently fails with:

```
AssertionError: expected true to be false
```

This flaked on CI run [28774171971](https://github.com/dashpay/platform/actions/runs/28774171971) (job 85315592482) for an unrelated PR (#3841) that touches no dapi code.

**Root cause:** the affected tests build a fresh `BloomFilter.create(1, 0.0001)`, insert a **randomly generated** address/pubkey (`new PrivateKey().toAddress()`), and then assert that unrelated data does **not** match. But `testTransactionAgainstFilter` also runs the transaction hash (`checkHash`) and the input outpoint `txid:vout` (`checkInputs`) through `filter.contains()` — neither of which was inserted. A bloom filter has a non-zero false-positive rate, so with random inputs those negative checks occasionally match by chance and the expected `false` flips to `true`.

The same latent flakiness affects every test in the file that generates random keys and asserts `.to.be.false()` (the "no such output", "input doesn't contain desired data", `BLOOM_UPDATE_P2PUBKEY_ONLY` pub-key-hash, and multisig `BLOOM_UPDATE_NONE` cases).

## What was done?

Replaced the random `new PrivateKey()` inputs with a fixed pool of deterministic test-vector private keys (`0x01…0x0a`), mirroring the idiom already used by the neighboring *"should pass the same test vector as dashcore implementation does"* test. Every address, transaction hash, and outpoint is now fixed, so each assertion is fully reproducible. A comment documents why the keys must stay fixed.

No production code changed — this is a test-only fix.

## How Has This Been Tested?

Because the repo's `node_modules` weren't installed locally, I ran the **actual post-edit spec file** through the same tool versions the package pins (mocha 11, chai 4, dirty-chai 2, `@dashevo/dashcore-lib` 0.22.0) in an isolated sandbox against an exact copy of the lib under test:

| Version | Runs | Failures |
| --- | --- | --- |
| Original (random keys) | 200 | **2** (~1%) — flake reproduced |
| Fixed (this PR) | **400** | **0** |

All 12 tests in the file pass. Reviewers can confirm in an installed tree with:

```bash
yarn workspace @dashevo/dapi test:unit
```

## Breaking Changes

None.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [ ] I have made corresponding changes to the documentation if needed

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated transaction filter tests to use fixed, reproducible key vectors instead of randomly generated keys.
  * Reduced occasional flaky failures by making address and public-key test inputs deterministic.
  * Kept all changes confined to test coverage; no production behavior was changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->