### PR TITLE
test(swift-sdk): update address vectors to DIP-0018 after #4021

### DIFF
--- a/packages/swift-sdk/SwiftTests/SwiftDashSDKTests/DataTransformersTests.swift
+++ b/packages/swift-sdk/SwiftTests/SwiftDashSDKTests/DataTransformersTests.swift
@@ -85,11 +85,12 @@ final class DataTransformersTests: XCTestCase {
     }
 
     func testParseAddressBech32m() {
-        // Valid testnet bech32m address
-        let address = "tdashevo1qz4242424242424242424242424242424g4dj6u7"
+        // A real DIP-0018 testnet platform address (tdash1...).
+        let address = "tdash1kzdl4c3apkekqevkqrzctgagv2v2ng5hysegt5x4"
         let data = AddressTransformer.parseAddress(address)
-        // Should return data if Bech32m decoder works, nil otherwise
-        XCTAssertTrue(data == nil || data?.count == 21)
+        XCTAssertEqual(data?.count, 21, "a valid tdash1 address must decode to the 21-byte payload")
+        // The pre-DIP-0018 HRP is rejected.
+        XCTAssertNil(AddressTransformer.parseAddress("tdashevo1qz4242424242424242424242424242424g4dj6u7"))
     }
 
     func testParseAddressInvalid() {

--- a/packages/swift-sdk/SwiftTests/SwiftDashSDKTests/ValidationTests.swift
+++ b/packages/swift-sdk/SwiftTests/SwiftDashSDKTests/ValidationTests.swift
@@ -76,15 +76,19 @@ final class ValidationTests: XCTestCase {
     }
 
     func testValidateBech32mAddress_valid() {
-        // Valid testnet address (tdashevo1...)
-        // Using a well-formed bech32m address
-        let validTestnetAddress = "tdashevo1qz4242424242424242424242424242424g4dj6u7"
+        // A real DIP-0018 testnet platform address (tdash1..., 21-byte
+        // payload, valid bech32m checksum) — proof-verified on testnet.
+        let validTestnetAddress = "tdash1kzdl4c3apkekqevkqrzctgagv2v2ng5hysegt5x4"
         XCTAssertTrue(AddressValidator.validateBech32mAddress(validTestnetAddress))
     }
 
     func testValidateBech32mAddress_invalid() {
         // Wrong HRP
         XCTAssertFalse(AddressValidator.validateBech32mAddress("bitcoin1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq"))
+        // Pre-DIP-0018 HRP ("tdashevo") — rejected since the DIP-0018
+        // decode fix; the canonical testnet HRP is "tdash".
+        XCTAssertFalse(
+            AddressValidator.validateBech32mAddress("tdashevo1qz4242424242424242424242424242424g4dj6u7"))
         // No separator
         XCTAssertFalse(AddressValidator.validateBech32mAddress("tdashevoqqqqqqqqqqq"))
         // Empty
@@ -98,8 +102,8 @@ final class ValidationTests: XCTestCase {
         let hexAddr = "00aaff11223344556677889900aabbccddeeff0011"
         XCTAssertTrue(AddressValidator.validateAddress(hexAddr))
 
-        // Bech32m address (if valid)
-        let bech32mAddr = "tdashevo1qz4242424242424242424242424242424g4dj6u7"
+        // DIP-0018 bech32m address
+        let bech32mAddr = "tdash1kzdl4c3apkekqevkqrzctgagv2v2ng5hysegt5x4"
         XCTAssertTrue(AddressValidator.validateAddress(bech32mAddr))
 
         // Invalid


### PR DESCRIPTION
## Issue being fixed or feature implemented
#4021 moved `AddressValidator` / `AddressTransformer` to the DIP-0018 HRPs (`tdash`/`dash`) but did not update `SwiftTests/`, so the legacy `tdashevo1…` vectors now (correctly) fail validation and the Swift package test suite is red on `v4.1-dev` — `ValidationTests.testValidateBech32mAddress_valid` and `testValidateAddress_autoDetect` fail on CI. (This fix rode on the #4019 branch but landed just after that PR was squash-merged, so it needs its own PR.)

## What was done?
- `testValidateBech32mAddress_valid` / `testValidateAddress_autoDetect`: vectors replaced with a real proof-verified testnet platform address (`tdash1kzdl4c…`).
- `testValidateBech32mAddress_invalid`: the pre-DIP-0018 `tdashevo1…` vector added as an explicitly **rejected** case — a regression pin on #4021's behavior change.
- `DataTransformersTests.testParseAddressBech32m`: was silently vacuous (`nil || count == 21` with a vector that now always decodes to nil) — now asserts the real address yields the 21-byte payload and the legacy HRP yields nil.

## How was it tested?
Full Swift package suite via `run_tests.sh` (the CI job's runner script): **TEST SUCCEEDED**, with `ValidationTests`, `DataTransformersTests`, and `AddressBalancePersistTests` all passing.

## Breaking changes
None (test-only).

## Checklist
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [x] I have made corresponding changes to the documentation if needed

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone

🤖 Generated with [Claude Code](https://claude.com/claude-code)