### PR TITLE
test(platform-wallet): fund wallet fixture with a chain-locked tx

### DIFF
--- a/packages/rs-platform-wallet/src/test_support.rs
+++ b/packages/rs-platform-wallet/src/test_support.rs
@@ -9,12 +9,14 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 
 use async_trait::async_trait;
+use dashcore::hashes::Hash;
 use dashcore::secp256k1::{ecdsa, Message, PublicKey, Secp256k1};
+use dashcore::BlockHash;
 use dashcore::{Network, Transaction, Txid};
 use key_wallet::account::account_type::StandardAccountType;
 use key_wallet::signer::{Signer, SignerMethod};
 use key_wallet::test_utils::TestWalletContext;
-use key_wallet::transaction_checking::TransactionContext;
+use key_wallet::transaction_checking::{BlockInfo, TransactionContext};
 use key_wallet::{DerivationPath, Wallet};
 use key_wallet_manager::WalletManager;
 use tokio::sync::RwLock;
@@ -155,8 +157,19 @@ pub(crate) async fn funded_wallet_manager(
     };
 
     let funding_tx = Transaction::dummy(&receive_address, 0..1, &[10_000_000]);
+    // Chain-locked funding, not `Mempool`: asset-lock builders only
+    // select final (confirmed / InstantSend-locked) inputs since
+    // rust-dashcore#836, so a mempool-funded fixture leaves the
+    // asset-lock tests with no eligible UTXO.
     let result = ctx
-        .check_transaction(&funding_tx, TransactionContext::Mempool)
+        .check_transaction(
+            &funding_tx,
+            TransactionContext::InChainLockedBlock(BlockInfo::new(
+                1,
+                BlockHash::all_zeros(),
+                1_700_000_000,
+            )),
+        )
         .await;
     assert!(
         result.is_relevant,


### PR DESCRIPTION
## Issue being fixed or feature implemented

The "Rust wallet tests / Wallet tests (macOS)" check is red on every PR targeting v4.1-dev: three `wallet::asset_lock::build::tests` tests fail with `Coin selection error: No UTXOs available for selection`. Verified they fail on the base branch itself (at e9aae0d9b4) — bisected to the rust-dashcore bump #4022.

Root cause: rust-dashcore#836 ("don't build asset locks on unconfirmed funds", in the 647fa98 bump) intentionally restricts asset-lock coin selection to final inputs (`is_confirmed || is_instantlocked`). The shared `funded_wallet_manager` fixture funds its single UTXO with a `TransactionContext::Mempool` transaction, which is now correctly ineligible for asset-lock funding — so the three asset-lock broadcast tests can no longer build their transaction. The production behavior is right; the fixture is stale.

## What was done?

Fund the fixture UTXO via `TransactionContext::InChainLockedBlock(BlockInfo::new(1, BlockHash::all_zeros(), ...))` instead of `Mempool`, so the input is final and selectable by the asset-lock builder, matching what production requires since #836.

## How Has This Been Tested?

`cargo test -p platform-wallet --lib` — all 394 tests pass, including the three previously failing:
- `ambiguous_asset_lock_broadcast_keeps_reservation_and_built_row`
- `rejected_asset_lock_broadcast_untracks_row_and_releases_reservation`
- `rejected_broadcast_racing_concurrent_resume_keeps_row_and_reservation`

## Breaking Changes

None (test-only).

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [ ] I have made corresponding changes to the documentation if needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)