### PR TITLE
fix(platform-wallet): register data contract for returned-proof verification on writes

### DIFF
--- a/packages/kotlin-sdk/KotlinExampleApp/app/src/main/java/org/dashfoundation/example/di/AppContainer.kt
+++ b/packages/kotlin-sdk/KotlinExampleApp/app/src/main/java/org/dashfoundation/example/di/AppContainer.kt
@@ -10,12 +10,14 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.drop
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
 import org.dashfoundation.dashsdk.Sdk
 import org.dashfoundation.dashsdk.persistence.DashDatabase
 import org.dashfoundation.example.state.AppState
 import org.dashfoundation.example.state.AppUiState
+import org.dashfoundation.example.util.Base58
 
 private val Context.preferencesStore by preferencesDataStore(name = "example_prefs")
 
@@ -243,10 +245,50 @@ class AppContainer(private val context: Context) {
             Sdk.enableLogging(Sdk.LogLevel.DEBUG)
             appState.restorePreferences()
             appState.initializeSdk()
+            loadKnownContractsIntoSdk()
             activateManager()
             _bootstrapState.value = BootstrapState.Ready
         } catch (e: Exception) {
             _bootstrapState.value = BootstrapState.Failed(e)
+        }
+    }
+
+    /**
+     * Pre-load every locally-stored data contract into the SDK's trusted
+     * context provider — port of `AppState.loadKnownContractsIntoSDK`. This
+     * lets proof verification resolve those contracts without a network
+     * fetch. Best-effort and non-fatal: any failure is logged, never thrown,
+     * so it can't stall or fail bootstrap (mirrors iOS, where the load is
+     * "not critical for SDK operation").
+     *
+     * Only contracts with a non-null [DataContractEntity.binarySerialization]
+     * are loaded — that field holds the versioned binary serialization the
+     * trusted provider deserializes; the JSON `serializedContract` is the
+     * wrong shape. Ids are base58-encoded to match what the native
+     * `addKnownContracts` splits from its CSV.
+     */
+    private suspend fun loadKnownContractsIntoSdk() {
+        val sdk = appState.sdk.value ?: return
+        try {
+            val stored = database.dataContractDao().observeAll().first()
+            val contracts = stored.mapNotNull { entity ->
+                entity.binarySerialization?.let { bytes ->
+                    Base58.encode(entity.id) to bytes
+                }
+            }
+            if (contracts.isEmpty()) {
+                android.util.Log.i(TAG, "No stored contracts with binary serialization to load")
+                return
+            }
+            sdk.contracts.loadKnownContracts(contracts)
+            android.util.Log.i(
+                TAG,
+                "Loaded ${contracts.size} known contracts into SDK's trusted provider",
+            )
+        } catch (e: Exception) {
+            // Non-fatal, exactly like iOS — a preload failure must not block
+            // the SDK from operating (it falls back to network fetches).
+            android.util.Log.w(TAG, "Failed to load known contracts into SDK", e)
         }
     }
 

--- a/packages/kotlin-sdk/KotlinExampleApp/app/src/main/java/org/dashfoundation/example/ui/contracts/ContractDownloader.kt
+++ b/packages/kotlin-sdk/KotlinExampleApp/app/src/main/java/org/dashfoundation/example/ui/contracts/ContractDownloader.kt
@@ -60,8 +60,13 @@ object ContractDownloader {
         val trimmedId = contractIdBase58.trim()
         require(trimmedId.isNotEmpty()) { "Please enter a contract ID" }
 
-        val json = try {
-            sdk.contracts.fetchJson(trimmedId)
+        // Fetch JSON + the versioned binary serialization in one round trip
+        // (← Swift's `dataContractGetWithSerialization`). The binary blob is
+        // what the trusted context provider deserializes, so persisting it
+        // lets `AppContainer.loadKnownContractsIntoSdk` preload this contract
+        // for proof verification without a network fetch.
+        val fetched = try {
+            sdk.contracts.fetchWithSerialization(trimmedId)
         } catch (e: Exception) {
             val message = e.message ?: "Unknown error"
             if (message.contains("not found", ignoreCase = true)) {
@@ -69,6 +74,8 @@ object ContractDownloader {
             }
             throw Exception("Failed to fetch data contract: $message", e)
         } ?: throw ContractNotFoundException("Data contract not found")
+        val json = fetched.json
+        val binarySerialization = fetched.binarySerialization
 
         val root = LenientJson.parseToJsonElement(json).jsonObject
 
@@ -82,7 +89,15 @@ object ContractDownloader {
         val dao = database.dataContractDao()
         val preExisting = dao.getById(contractIdBytes)
         if (preExisting != null) {
-            dao.upsert(preExisting.copy(lastAccessedAt = Date()))
+            // Backfill the binary serialization for rows persisted before the
+            // with-serialization fetch, so the startup preload can pick them
+            // up. Keep any existing value when the node didn't return one.
+            dao.upsert(
+                preExisting.copy(
+                    lastAccessedAt = Date(),
+                    binarySerialization = binarySerialization ?: preExisting.binarySerialization,
+                ),
+            )
             // Re-runs are how rows stored before the token materializer
             // landed pick up their token children.
             org.dashfoundation.example.services.tokens.TokenMaterializer
@@ -99,6 +114,7 @@ object ContractDownloader {
             id = contractIdBytes,
             name = resolveName(suggestedName, trimmedId, documents, tokens),
             serializedContract = json.toByteArray(Charsets.UTF_8),
+            binarySerialization = binarySerialization,
             version = (root["version"] as? JsonPrimitive)?.content?.toIntOrNull() ?: 1,
             ownerId = (root["ownerId"] as? JsonPrimitive)?.content
                 ?.let { Base58.decodeIdentifier(it) },

--- a/packages/kotlin-sdk/sdk/src/main/kotlin/org/dashfoundation/dashsdk/ffi/QueriesNative.kt
+++ b/packages/kotlin-sdk/sdk/src/main/kotlin/org/dashfoundation/dashsdk/ffi/QueriesNative.kt
@@ -44,6 +44,20 @@ internal object QueriesNative {
     /** Release a handle from [dataContractFetch]. Safe on 0. */
     external fun dataContractDestroy(handle: Long)
 
+    /**
+     * Pre-load data contracts into the SDK's trusted context provider so
+     * proof verification resolves them without a network fetch. [contractIds]
+     * is a comma-separated list of base58 contract ids; [serializedContracts]
+     * holds each contract's versioned binary serialization in the SAME order.
+     * Empty input is a no-op. Throws on error (missing trusted provider,
+     * malformed contract, or id/contract count mismatch).
+     */
+    external fun addKnownContracts(
+        sdk: Long,
+        contractIds: String,
+        serializedContracts: Array<ByteArray>,
+    )
+
     /** JSON array of documents. whereJson/orderByJson may be null. */
     external fun documentSearch(
         sdk: Long,

--- a/packages/kotlin-sdk/sdk/src/main/kotlin/org/dashfoundation/dashsdk/queries/PlatformQueries.kt
+++ b/packages/kotlin-sdk/sdk/src/main/kotlin/org/dashfoundation/dashsdk/queries/PlatformQueries.kt
@@ -586,6 +586,29 @@ class Contracts internal constructor(private val sdk: Sdk) {
         val handle = mapNativeErrors { QueriesNative.dataContractFetch(sdk.handle, contractId) }
         DataContractRef(handle)
     }
+
+    /**
+     * Pre-load known contracts into the SDK's trusted context provider so
+     * proof verification resolves them without a network fetch — mirrors
+     * Swift's `SDK.loadKnownContracts`. Each pair is
+     * `(base58ContractId, versionedBinarySerialization)`; the second element
+     * must be the contract's versioned binary serialization (what
+     * `DataContract.versionedDeserialize` expects), NOT its JSON. Entries with
+     * an empty id or empty bytes are skipped; empty input short-circuits.
+     * Throws on error (missing trusted provider or a malformed contract).
+     */
+    suspend fun loadKnownContracts(contracts: List<Pair<String, ByteArray>>) =
+        withContext(Dispatchers.IO) {
+            val filtered = contracts.filter { it.first.isNotEmpty() && it.second.isNotEmpty() }
+            if (filtered.isEmpty()) return@withContext
+            mapNativeErrors {
+                QueriesNative.addKnownContracts(
+                    sdk.handle,
+                    filtered.joinToString(",") { it.first },
+                    filtered.map { it.second }.toTypedArray(),
+                )
+            }
+        }
 }
 
 /**

--- a/packages/rs-context-provider/src/provider.rs
+++ b/packages/rs-context-provider/src/provider.rs
@@ -43,6 +43,16 @@ pub trait ContextProvider: Send + Sync {
         platform_version: &PlatformVersion,
     ) -> Result<Option<Arc<DataContract>>, ContextProviderError>;
 
+    /// Register a data contract into the provider's cache so that a
+    /// subsequent proof verification (e.g. the returned-proof check after a
+    /// document or token state-transition broadcast) can resolve it without
+    /// a network fetch.
+    ///
+    /// Providers that maintain a writable known-contracts cache (e.g. the
+    /// mobile `TrustedHttpContextProvider`) override this; the default is a
+    /// no-op for providers that fetch on demand or don't cache.
+    fn register_data_contract(&self, _contract: Arc<DataContract>) {}
+
     /// Fetches the token configuration for a specified token ID.
     /// This method is used by [FromProof](crate::FromProof) implementations to fetch token configurations
     /// referenced in proofs.
@@ -99,6 +109,10 @@ impl<C: AsRef<dyn ContextProvider> + Send + Sync> ContextProvider for C {
         self.as_ref().get_data_contract(id, platform_version)
     }
 
+    fn register_data_contract(&self, contract: Arc<DataContract>) {
+        self.as_ref().register_data_contract(contract)
+    }
+
     fn get_token_configuration(
         &self,
         token_id: &Identifier,
@@ -132,6 +146,11 @@ where
     ) -> Result<Option<Arc<DataContract>>, ContextProviderError> {
         let lock = self.lock().expect("lock poisoned");
         lock.get_data_contract(id, platform_version)
+    }
+
+    fn register_data_contract(&self, contract: Arc<DataContract>) {
+        let lock = self.lock().expect("lock poisoned");
+        lock.register_data_contract(contract)
     }
 
     fn get_token_configuration(

--- a/packages/rs-platform-wallet/src/wallet/identity/network/document.rs
+++ b/packages/rs-platform-wallet/src/wallet/identity/network/document.rs
@@ -54,7 +54,7 @@ use dash_sdk::platform::documents::transitions::{
     DocumentTransferTransitionBuilder,
 };
 use dash_sdk::platform::transition::put_document::PutDocument;
-use dash_sdk::platform::{DocumentQuery, Fetch};
+use dash_sdk::platform::{ContextProvider, DocumentQuery, Fetch};
 
 use crate::error::PlatformWalletError;
 
@@ -130,6 +130,19 @@ fn allowed_signing_security_levels(requirement: SecurityLevel) -> Vec<SecurityLe
 }
 
 impl IdentityWallet {
+    /// Register a freshly-fetched data contract into the SDK's shared
+    /// context provider so the returned-proof verification after a document
+    /// state-transition broadcast can resolve it. Without this, the mobile
+    /// `TrustedHttpContextProvider` — which never fetches contracts itself —
+    /// returns `None` for the contract and proof verification fails with
+    /// "unknown contract ... in document verification", even though the
+    /// write landed on-chain.
+    fn register_contract_for_proof_verification(&self, contract: &DataContract) {
+        if let Some(provider) = self.sdk.context_provider() {
+            provider.register_data_contract(Arc::new(contract.clone()));
+        }
+    }
+
     /// Create a new revision-1 document on `contract_id`'s
     /// `document_type_name` owned by `owner_identity_id`, and broadcast
     /// it to Platform.
@@ -191,6 +204,9 @@ impl IdentityWallet {
                     "Data contract {contract_id} not found on Platform; cannot create document"
                 ))
             })?;
+
+        // Make the contract resolvable for the post-broadcast proof check.
+        self.register_contract_for_proof_verification(&data_contract);
 
         // Owned `DocumentType` — `put_to_platform_and_wait_for_response`
         // takes the document type by value.
@@ -334,6 +350,9 @@ impl IdentityWallet {
                     "Document type {document_type_name:?} not found on contract {contract_id}: {e}"
                 ))
             })?;
+        // Make the contract resolvable for the post-broadcast proof check
+        // (covers replace/delete/transfer/set-price/purchase).
+        self.register_contract_for_proof_verification(&data_contract);
         Ok(Arc::new(data_contract))
     }
 

--- a/packages/rs-sdk-trusted-context-provider/src/provider.rs
+++ b/packages/rs-sdk-trusted-context-provider/src/provider.rs
@@ -777,6 +777,12 @@ impl ContextProvider for TrustedHttpContextProvider {
         }
     }
 
+    fn register_data_contract(&self, contract: Arc<DataContract>) {
+        let id = contract.id();
+        let mut known = self.known_contracts.lock().unwrap();
+        known.insert(id, contract);
+    }
+
     fn get_token_configuration(
         &self,
         token_id: &Identifier,

--- a/packages/rs-sdk/src/mock/provider.rs
+++ b/packages/rs-sdk/src/mock/provider.rs
@@ -224,6 +224,12 @@ impl ContextProvider for GrpcContextProvider {
         Ok(data_contract.map(Arc::new))
     }
 
+    fn register_data_contract(&self, contract: Arc<DataContract>) {
+        use dpp::data_contract::accessors::v0::DataContractV0Getters;
+        self.data_contracts_cache
+            .put(contract.id(), (*contract).clone());
+    }
+
     fn get_token_configuration(
         &self,
         token_id: &Identifier,

--- a/packages/rs-unified-sdk-jni/src/queries.rs
+++ b/packages/rs-unified-sdk-jni/src/queries.rs
@@ -9,13 +9,13 @@ use crate::results::{
     unwrap_string,
 };
 use crate::support::{guard, throw_sdk_exception};
-use jni::objects::{JByteArray, JClass, JObject, JString};
+use jni::objects::{JByteArray, JClass, JObject, JObjectArray, JString};
 use jni::sys::{jboolean, jint, jlong, jobject, jstring};
 use jni::JNIEnv;
 use rs_sdk_ffi::{
-    dash_sdk_address_fetch_info, dash_sdk_addresses_fetch_infos, dash_sdk_calculate_token_id,
-    dash_sdk_contested_resource_get_identity_votes, dash_sdk_contested_resource_get_resources,
-    dash_sdk_contested_resource_get_vote_state,
+    dash_sdk_add_known_contracts, dash_sdk_address_fetch_info, dash_sdk_addresses_fetch_infos,
+    dash_sdk_calculate_token_id, dash_sdk_contested_resource_get_identity_votes,
+    dash_sdk_contested_resource_get_resources, dash_sdk_contested_resource_get_vote_state,
     dash_sdk_contested_resource_get_voters_for_identity, dash_sdk_data_contract_destroy,
     dash_sdk_data_contract_fetch, dash_sdk_data_contract_fetch_json,
     dash_sdk_data_contract_fetch_result_free, dash_sdk_data_contract_fetch_with_serialization,
@@ -1460,5 +1460,115 @@ pub extern "system" fn Java_org_dashfoundation_dashsdk_ffi_QueriesNative_dataCon
             return ptr::null_mut();
         }
         array.into_raw()
+    })
+}
+
+/// Pre-load locally-stored data contracts into the SDK's trusted context
+/// provider so proof verification resolves them without a network fetch —
+/// the JNI bridge over `dash_sdk_add_known_contracts` (Swift
+/// `SDK.loadKnownContracts`, called at SDK init from
+/// `AppState.loadKnownContractsIntoSDK`).
+///
+/// * `contract_ids` — a comma-separated list of base58 contract ids.
+/// * `serialized_contracts` — a `byte[][]` of each contract's **versioned
+///   binary serialization** (the bytes `DataContract::versioned_deserialize`
+///   expects — i.e. `DataContractEntity.binarySerialization`, NOT the JSON),
+///   in the SAME order as `contract_ids`.
+///
+/// Trusted-provider config keyed off the SDK handle (like
+/// `dataContractFetchWithSerialization`), not a per-query fetch. The FFI
+/// splits the ids CSV itself and rejects an id/contract count mismatch, so
+/// this must pass exactly one `byte[]` per id. Returns nothing on success
+/// (throws on error): a missing trusted provider, a malformed contract, or a
+/// count mismatch all surface as a thrown `DashSDKException`.
+#[no_mangle]
+pub extern "system" fn Java_org_dashfoundation_dashsdk_ffi_QueriesNative_addKnownContracts(
+    mut env: JNIEnv,
+    _class: JClass,
+    sdk: jlong,
+    contract_ids: JString,
+    serialized_contracts: JObjectArray,
+) {
+    guard(&mut env, (), |env| {
+        let ids = match opt_c_string(env, &contract_ids) {
+            Some(s) => s,
+            None => {
+                throw_sdk_exception(env, 1, "contractIds was null");
+                return;
+            }
+        };
+
+        if serialized_contracts.is_null() {
+            throw_sdk_exception(env, 1, "serializedContracts was null");
+            return;
+        }
+
+        let count = match env.get_array_length(&serialized_contracts) {
+            Ok(len) if len >= 0 => len as usize,
+            _ => {
+                let _ = env.exception_clear();
+                throw_sdk_exception(env, 1, "serializedContracts length was invalid");
+                return;
+            }
+        };
+
+        // Empty input is a legitimate no-op (nothing stored to preload).
+        if count == 0 {
+            return;
+        }
+
+        // Copy every contract's bytes into owned buffers that outlive the FFI
+        // call (the FFI borrows each pointer for the call duration).
+        let mut buffers: Vec<Vec<u8>> = Vec::with_capacity(count);
+        for i in 0..count {
+            let bytes = match env.get_object_array_element(&serialized_contracts, i as i32) {
+                Ok(obj) => {
+                    let arr: JByteArray = obj.into();
+                    if arr.is_null() {
+                        throw_sdk_exception(env, 1, &format!("serializedContracts[{i}] was null"));
+                        return;
+                    }
+                    match env.convert_byte_array(&arr) {
+                        Ok(b) => b,
+                        Err(_) => {
+                            let _ = env.exception_clear();
+                            throw_sdk_exception(
+                                env,
+                                1,
+                                &format!("serializedContracts[{i}] byte[] was invalid"),
+                            );
+                            return;
+                        }
+                    }
+                }
+                Err(_) => {
+                    let _ = env.exception_clear();
+                    throw_sdk_exception(
+                        env,
+                        1,
+                        &format!("serializedContracts[{i}] could not be read"),
+                    );
+                    return;
+                }
+            };
+            buffers.push(bytes);
+        }
+
+        // Build the pointer + length arrays the FFI expects. Both `buffers`
+        // and these two Vecs outlive the synchronous FFI call.
+        let ptrs: Vec<*const u8> = buffers.iter().map(|b| b.as_ptr()).collect();
+        let lengths: Vec<usize> = buffers.iter().map(|b| b.len()).collect();
+
+        let result = unsafe {
+            dash_sdk_add_known_contracts(
+                sdk as *const SDKHandle,
+                ids.as_ptr(),
+                ptrs.as_ptr(),
+                lengths.as_ptr(),
+                count,
+            )
+        };
+        // Success carries no payload; take_error throws + frees on error.
+        unsafe { crate::results::take_error(env, &result) };
     })
 }


### PR DESCRIPTION
This PR has two parts: (1) the core fix — the shared Rust write path now registers the contract so returned-proof verification resolves it; and (2) an Android parity follow-up — the Kotlin app now preloads stored contracts into the trusted provider at SDK init, the way iOS already does.

## Issue being fixed or feature implemented

On mobile (KotlinExampleApp / rs-unified-sdk-jni, and the same shared code on Swift), a document write broadcasts successfully and the document lands on-chain, but the app reports failure with:

> Proof verification error: dash drive: proof: unknown contract in documents batch transition error: unknown contract with id `HLY575cN…` in document verification

The token write path hits the identical "unknown contract … in token verification".

**Root cause:** the returned-proof verifier resolves the target data contract **only** through the SDK's `ContextProvider` (`Drive::verify_state_transition_was_executed_with_proof` → `known_contracts_provider_fn` → `ContextProvider::get_data_contract`). The mobile FFI SDK uses `TrustedHttpContextProvider`, whose `get_data_contract` serves contracts **only** from its `known_contracts` map + built-in system contracts + optional fallback — no network fetch. The platform-wallet write path fetches the contract to build the document but never registers it there, so post-broadcast verification returns `None` → `ProofError::UnknownContract`. Reads are unaffected (`DocumentQuery`/`Fetch` embed the `Arc<DataContract>` and verify against that); `DataContractCreate` is unaffected (verifies straight from the proof).

iOS didn't surface this only because the SwiftExampleApp bulk-preloads all stored contracts into the trusted provider at SDK init (`AppState.loadKnownContractsIntoSDK` → `dash_sdk_add_known_contracts`); the Kotlin app had no equivalent. So the bug was latent on both platforms — Android just wasn't papering over it.

## What was done?

**Part 1 — the fix (register at write time, all platforms):**
- Added a provided `ContextProvider::register_data_contract(&self, Arc<DataContract>)` (default no-op) in `rs-context-provider`, **forwarded in both blanket impls** (`AsRef<dyn ContextProvider>` and `Mutex<T>`) — load-bearing, since `Sdk::context_provider()` returns an `Arc<dyn ContextProvider>`.
- Overrode it in `TrustedHttpContextProvider` (into `known_contracts`) and `GrpcContextProvider` (into its cache).
- `rs-platform-wallet` `network/document.rs`: `create_document_with_signer` and the shared `fetch_contract_arc_for_document_op` (replace/delete/transfer/set-price/purchase) register the fetched contract before broadcast.

**Part 2 — Android parity (preload at init, matches iOS):**
- JNI `Java_…_QueriesNative_addKnownContracts` bridges `dash_sdk_add_known_contracts` (marshals a `byte[][]` of versioned serializations + a comma-joined base58 id list; throws on FFI error).
- Kotlin SDK: `QueriesNative.addKnownContracts` + `Contracts.loadKnownContracts(List<Pair<String, ByteArray>>)` (mirrors `SDK.loadKnownContracts`).
- App: `AppContainer.bootstrap` preloads every `DataContractEntity` with a non-null `binarySerialization` after SDK init — best-effort, non-fatal.
- `ContractDownloader` now fetches JSON + binary serialization in one round trip and persists `binarySerialization` (new rows + backfill), so the preload has bytes to load (it was always null before).

Token write paths hit the identical error and can reuse `register_data_contract` — left as a follow-up to keep this scoped to documents.

## How Has This Been Tested?

- `cargo check` on `dash-context-provider`, `rs-sdk-trusted-context-provider`, `dash-sdk`, `platform-wallet`, and `rs-unified-sdk-jni` — all clean; `rustfmt --check` clean; Kotlin `:sdk:` + `:app:compileDebugKotlin` BUILD SUCCESSFUL.
- **Part 1 device-verified** (KotlinExampleApp, testnet, arm64 JNI rebuilt): re-drove DOC-02 — the app now shows **"Document Created / Broadcast confirmed on-chain."** instead of the error dialog; the confirmed doc (`8f28eqGDPm4Fa6CHzXbtp7x1wovdYnVYag6n1BDzzqLA`) is queryable via Browse Documents.
- **Part 2 device-verified**: the new JNI symbol is exported in the rebuilt `.so` (`llvm-nm`); after downloading a contract, the app logs `AppContainer: Loaded 1 known contracts into SDK's trusted provider` at startup — no `UnsatisfiedLinkError`, no deserialize error (proves the `byte[][]` marshaling → `versioned_deserialize` → register path works end to end).

## Breaking Changes

None. `register_data_contract` is a provided trait method with a default no-op (additive, backward-compatible for all existing `ContextProvider` implementors). Not consensus-breaking.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [ ] I have made corresponding changes to the documentation if needed

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone

🤖 Generated with [Claude Code](https://claude.com/claude-code)