### PR TITLE
fix(swift-sdk): updated the swift integration tests to use the new tx broadcast flow

### DIFF
--- a/packages/swift-sdk/SwiftTests/SwiftDashSDKIntegrationTests/Core/CoreSendIntegrationTests.swift
+++ b/packages/swift-sdk/SwiftTests/SwiftDashSDKIntegrationTests/Core/CoreSendIntegrationTests.swift
@@ -32,9 +32,7 @@ final class CoreSendIntegrationTests: IntegrationTestCase {
             let recipientAddress = try receiver.getCoreWallet().nextReceiveAddress()
 
             let beforeTxids = try await readTxids()
-            _ = try sender.getCoreWallet().sendToAddresses(
-                recipients: [(address: recipientAddress, amountDuffs: amount)]
-            )
+            _ = try sender.send(to: recipientAddress, amountDuffs: amount)
             guard let sendTxid = try await waitForNewTxid(notIn: beforeTxids) else {
                 XCTFail("send PersistentTransaction row never appeared on iteration \(i)")
                 return

--- a/packages/swift-sdk/SwiftTests/SwiftDashSDKIntegrationTests/Core/PersisterRestartClassificationIntegrationTests.swift
+++ b/packages/swift-sdk/SwiftTests/SwiftDashSDKIntegrationTests/Core/PersisterRestartClassificationIntegrationTests.swift
@@ -19,10 +19,8 @@ final class PersisterRestartClassificationIntegrationTests: IntegrationTestCase 
         try await alice.waitForSpendable(exactly: fundingDuffs, timeout: 90)
 
         let aliceSecondAddr = try alice.getCoreWallet().nextReceiveAddress()
-        let sendTxData = try alice.getCoreWallet().sendToAddresses(
-            recipients: [(address: aliceSecondAddr, amountDuffs: sendAmount)]
-        )
-        let sendTxid = Self.txid(ofRawTx: sendTxData)
+        let sendTx = try alice.send(to: aliceSecondAddr, amountDuffs: sendAmount)
+        let sendTxid = Self.txid(ofRawTx: sendTx.data)
         try await waitForTxRow(sendTxid)
 
         // First sighting must already classify as Internal / -fee.

--- a/packages/swift-sdk/SwiftTests/SwiftDashSDKIntegrationTests/Core/SpvRestartIntegrationTests.swift
+++ b/packages/swift-sdk/SwiftTests/SwiftDashSDKIntegrationTests/Core/SpvRestartIntegrationTests.swift
@@ -64,9 +64,7 @@ final class SpvRestartIntegrationTests: IntegrationTestCase {
         let recipientAddress = try receiver.getCoreWallet().nextReceiveAddress()
 
         let beforeTxids = try await readTxids()
-        _ = try sender.getCoreWallet().sendToAddresses(
-            recipients: [(address: recipientAddress, amountDuffs: amount)]
-        )
+        _ = try sender.send(to: recipientAddress, amountDuffs: amount)
         guard let sendTxid = try await waitForNewTxid(notIn: beforeTxids) else {
             XCTFail("send PersistentTransaction row never appeared")
             return

--- a/packages/swift-sdk/SwiftTests/SwiftDashSDKIntegrationTests/Support/TestWallet.swift
+++ b/packages/swift-sdk/SwiftTests/SwiftDashSDKIntegrationTests/Support/TestWallet.swift
@@ -19,6 +19,20 @@ final class TestWalletWrapper {
         wallet
     }
 
+    /// Build + sign + broadcast a single-output payment from this wallet's
+    /// BIP-44 account 0 — the integration-test replacement for the removed
+    /// one-shot `ManagedCoreWallet.sendToAddresses`. Returns the built
+    /// `CoreTransaction` (its `.data` is the raw signed bytes).
+    @discardableResult
+    func send(to address: String, amountDuffs: UInt64) throws -> CoreTransaction {
+        let builder = try CoreTransactionBuilder(network: core.network())
+        _ = try builder.addOutput(address: address, amountDuffs: amountDuffs)
+        try builder.setFunding(wallet: wallet, accountType: .bip44, accountIndex: 0)
+        let tx = try builder.buildSigned(wallet: wallet, accountType: .bip44, accountIndex: 0)
+        _ = try core.broadcastTransaction(tx)
+        return tx
+    }
+
     func waitForSpendable(exactly duffs: UInt64, timeout: TimeInterval = 60) async throws {
         try await Wait.until(
             "wallet spendable == \(duffs) duffs",


### PR DESCRIPTION

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [ ] I have made corresponding changes to the documentation if needed

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved coverage for wallet-to-wallet sends, self-sends, and restart scenarios to better verify transaction handling and balance updates.

* **Tests**
  * Updated integration tests to use a simpler send flow for single-recipient transfers.
  * Added support for building and broadcasting a single-output transaction in test wallet utilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->