### PR TITLE
chore(platform-wallet): merge platform-wallet-rehydration (PR #3692) into dash-evo-tool

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1637,7 +1637,7 @@ dependencies = [
 [[package]]
 name = "dash-network"
 version = "0.45.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=647fa9820f3614090e4e5f5f2b709961d68e538b#647fa9820f3614090e4e5f5f2b709961d68e538b"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=d42081e7bc916fb5c4f994cdfa1c01cf5ede9e0f#d42081e7bc916fb5c4f994cdfa1c01cf5ede9e0f"
 dependencies = [
  "bincode",
  "bincode_derive",
@@ -1648,7 +1648,7 @@ dependencies = [
 [[package]]
 name = "dash-network-seeds"
 version = "0.45.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=647fa9820f3614090e4e5f5f2b709961d68e538b#647fa9820f3614090e4e5f5f2b709961d68e538b"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=d42081e7bc916fb5c4f994cdfa1c01cf5ede9e0f#d42081e7bc916fb5c4f994cdfa1c01cf5ede9e0f"
 dependencies = [
  "dash-network",
 ]
@@ -1725,7 +1725,7 @@ dependencies = [
 [[package]]
 name = "dash-spv"
 version = "0.45.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=647fa9820f3614090e4e5f5f2b709961d68e538b#647fa9820f3614090e4e5f5f2b709961d68e538b"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=d42081e7bc916fb5c4f994cdfa1c01cf5ede9e0f#d42081e7bc916fb5c4f994cdfa1c01cf5ede9e0f"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1754,7 +1754,7 @@ dependencies = [
 [[package]]
 name = "dashcore"
 version = "0.45.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=647fa9820f3614090e4e5f5f2b709961d68e538b#647fa9820f3614090e4e5f5f2b709961d68e538b"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=d42081e7bc916fb5c4f994cdfa1c01cf5ede9e0f#d42081e7bc916fb5c4f994cdfa1c01cf5ede9e0f"
 dependencies = [
  "anyhow",
  "base64-compat",
@@ -1780,12 +1780,12 @@ dependencies = [
 [[package]]
 name = "dashcore-private"
 version = "0.45.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=647fa9820f3614090e4e5f5f2b709961d68e538b#647fa9820f3614090e4e5f5f2b709961d68e538b"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=d42081e7bc916fb5c4f994cdfa1c01cf5ede9e0f#d42081e7bc916fb5c4f994cdfa1c01cf5ede9e0f"
 
 [[package]]
 name = "dashcore-rpc"
 version = "0.45.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=647fa9820f3614090e4e5f5f2b709961d68e538b#647fa9820f3614090e4e5f5f2b709961d68e538b"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=d42081e7bc916fb5c4f994cdfa1c01cf5ede9e0f#d42081e7bc916fb5c4f994cdfa1c01cf5ede9e0f"
 dependencies = [
  "dashcore-rpc-json",
  "hex",
@@ -1798,7 +1798,7 @@ dependencies = [
 [[package]]
 name = "dashcore-rpc-json"
 version = "0.45.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=647fa9820f3614090e4e5f5f2b709961d68e538b#647fa9820f3614090e4e5f5f2b709961d68e538b"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=d42081e7bc916fb5c4f994cdfa1c01cf5ede9e0f#d42081e7bc916fb5c4f994cdfa1c01cf5ede9e0f"
 dependencies = [
  "bincode",
  "dashcore",
@@ -1813,7 +1813,7 @@ dependencies = [
 [[package]]
 name = "dashcore_hashes"
 version = "0.45.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=647fa9820f3614090e4e5f5f2b709961d68e538b#647fa9820f3614090e4e5f5f2b709961d68e538b"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=d42081e7bc916fb5c4f994cdfa1c01cf5ede9e0f#d42081e7bc916fb5c4f994cdfa1c01cf5ede9e0f"
 dependencies = [
  "bincode",
  "dashcore-private",
@@ -2867,7 +2867,7 @@ dependencies = [
 [[package]]
 name = "git-state"
 version = "0.45.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=647fa9820f3614090e4e5f5f2b709961d68e538b#647fa9820f3614090e4e5f5f2b709961d68e538b"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=d42081e7bc916fb5c4f994cdfa1c01cf5ede9e0f#d42081e7bc916fb5c4f994cdfa1c01cf5ede9e0f"
 
 [[package]]
 name = "glob"
@@ -4034,7 +4034,7 @@ dependencies = [
 [[package]]
 name = "key-wallet"
 version = "0.45.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=647fa9820f3614090e4e5f5f2b709961d68e538b#647fa9820f3614090e4e5f5f2b709961d68e538b"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=d42081e7bc916fb5c4f994cdfa1c01cf5ede9e0f#d42081e7bc916fb5c4f994cdfa1c01cf5ede9e0f"
 dependencies = [
  "aes",
  "async-trait",
@@ -4063,7 +4063,7 @@ dependencies = [
 [[package]]
 name = "key-wallet-ffi"
 version = "0.45.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=647fa9820f3614090e4e5f5f2b709961d68e538b#647fa9820f3614090e4e5f5f2b709961d68e538b"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=d42081e7bc916fb5c4f994cdfa1c01cf5ede9e0f#d42081e7bc916fb5c4f994cdfa1c01cf5ede9e0f"
 dependencies = [
  "cbindgen 0.29.4",
  "dash-network",
@@ -4079,7 +4079,7 @@ dependencies = [
 [[package]]
 name = "key-wallet-manager"
 version = "0.45.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=647fa9820f3614090e4e5f5f2b709961d68e538b#647fa9820f3614090e4e5f5f2b709961d68e538b"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=d42081e7bc916fb5c4f994cdfa1c01cf5ede9e0f#d42081e7bc916fb5c4f994cdfa1c01cf5ede9e0f"
 dependencies = [
  "async-trait",
  "bincode",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1206,7 +1206,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1637,7 +1637,7 @@ dependencies = [
 [[package]]
 name = "dash-network"
 version = "0.45.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=d42081e7bc916fb5c4f994cdfa1c01cf5ede9e0f#d42081e7bc916fb5c4f994cdfa1c01cf5ede9e0f"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=48a07d3fcd2f8d37e109f969eb5da0a8bbbb9aff#48a07d3fcd2f8d37e109f969eb5da0a8bbbb9aff"
 dependencies = [
  "bincode",
  "bincode_derive",
@@ -1648,7 +1648,7 @@ dependencies = [
 [[package]]
 name = "dash-network-seeds"
 version = "0.45.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=d42081e7bc916fb5c4f994cdfa1c01cf5ede9e0f#d42081e7bc916fb5c4f994cdfa1c01cf5ede9e0f"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=48a07d3fcd2f8d37e109f969eb5da0a8bbbb9aff#48a07d3fcd2f8d37e109f969eb5da0a8bbbb9aff"
 dependencies = [
  "dash-network",
 ]
@@ -1725,7 +1725,7 @@ dependencies = [
 [[package]]
 name = "dash-spv"
 version = "0.45.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=d42081e7bc916fb5c4f994cdfa1c01cf5ede9e0f#d42081e7bc916fb5c4f994cdfa1c01cf5ede9e0f"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=48a07d3fcd2f8d37e109f969eb5da0a8bbbb9aff#48a07d3fcd2f8d37e109f969eb5da0a8bbbb9aff"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1754,7 +1754,7 @@ dependencies = [
 [[package]]
 name = "dashcore"
 version = "0.45.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=d42081e7bc916fb5c4f994cdfa1c01cf5ede9e0f#d42081e7bc916fb5c4f994cdfa1c01cf5ede9e0f"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=48a07d3fcd2f8d37e109f969eb5da0a8bbbb9aff#48a07d3fcd2f8d37e109f969eb5da0a8bbbb9aff"
 dependencies = [
  "anyhow",
  "base64-compat",
@@ -1780,12 +1780,12 @@ dependencies = [
 [[package]]
 name = "dashcore-private"
 version = "0.45.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=d42081e7bc916fb5c4f994cdfa1c01cf5ede9e0f#d42081e7bc916fb5c4f994cdfa1c01cf5ede9e0f"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=48a07d3fcd2f8d37e109f969eb5da0a8bbbb9aff#48a07d3fcd2f8d37e109f969eb5da0a8bbbb9aff"
 
 [[package]]
 name = "dashcore-rpc"
 version = "0.45.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=d42081e7bc916fb5c4f994cdfa1c01cf5ede9e0f#d42081e7bc916fb5c4f994cdfa1c01cf5ede9e0f"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=48a07d3fcd2f8d37e109f969eb5da0a8bbbb9aff#48a07d3fcd2f8d37e109f969eb5da0a8bbbb9aff"
 dependencies = [
  "dashcore-rpc-json",
  "hex",
@@ -1798,7 +1798,7 @@ dependencies = [
 [[package]]
 name = "dashcore-rpc-json"
 version = "0.45.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=d42081e7bc916fb5c4f994cdfa1c01cf5ede9e0f#d42081e7bc916fb5c4f994cdfa1c01cf5ede9e0f"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=48a07d3fcd2f8d37e109f969eb5da0a8bbbb9aff#48a07d3fcd2f8d37e109f969eb5da0a8bbbb9aff"
 dependencies = [
  "bincode",
  "dashcore",
@@ -1813,7 +1813,7 @@ dependencies = [
 [[package]]
 name = "dashcore_hashes"
 version = "0.45.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=d42081e7bc916fb5c4f994cdfa1c01cf5ede9e0f#d42081e7bc916fb5c4f994cdfa1c01cf5ede9e0f"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=48a07d3fcd2f8d37e109f969eb5da0a8bbbb9aff#48a07d3fcd2f8d37e109f969eb5da0a8bbbb9aff"
 dependencies = [
  "bincode",
  "dashcore-private",
@@ -2428,7 +2428,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2489,7 +2489,7 @@ checksum = "0ce92ff622d6dadf7349484f42c93271a0d49b7cc4d466a936405bacbe10aa78"
 dependencies = [
  "cfg-if",
  "rustix 1.1.4",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2867,7 +2867,7 @@ dependencies = [
 [[package]]
 name = "git-state"
 version = "0.45.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=d42081e7bc916fb5c4f994cdfa1c01cf5ede9e0f#d42081e7bc916fb5c4f994cdfa1c01cf5ede9e0f"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=48a07d3fcd2f8d37e109f969eb5da0a8bbbb9aff#48a07d3fcd2f8d37e109f969eb5da0a8bbbb9aff"
 
 [[package]]
 name = "glob"
@@ -3803,7 +3803,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4034,7 +4034,7 @@ dependencies = [
 [[package]]
 name = "key-wallet"
 version = "0.45.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=d42081e7bc916fb5c4f994cdfa1c01cf5ede9e0f#d42081e7bc916fb5c4f994cdfa1c01cf5ede9e0f"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=48a07d3fcd2f8d37e109f969eb5da0a8bbbb9aff#48a07d3fcd2f8d37e109f969eb5da0a8bbbb9aff"
 dependencies = [
  "aes",
  "async-trait",
@@ -4063,7 +4063,7 @@ dependencies = [
 [[package]]
 name = "key-wallet-ffi"
 version = "0.45.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=d42081e7bc916fb5c4f994cdfa1c01cf5ede9e0f#d42081e7bc916fb5c4f994cdfa1c01cf5ede9e0f"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=48a07d3fcd2f8d37e109f969eb5da0a8bbbb9aff#48a07d3fcd2f8d37e109f969eb5da0a8bbbb9aff"
 dependencies = [
  "cbindgen 0.29.4",
  "dash-network",
@@ -4079,7 +4079,7 @@ dependencies = [
 [[package]]
 name = "key-wallet-manager"
 version = "0.45.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=d42081e7bc916fb5c4f994cdfa1c01cf5ede9e0f#d42081e7bc916fb5c4f994cdfa1c01cf5ede9e0f"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=48a07d3fcd2f8d37e109f969eb5da0a8bbbb9aff#48a07d3fcd2f8d37e109f969eb5da0a8bbbb9aff"
 dependencies = [
  "async-trait",
  "bincode",
@@ -4596,7 +4596,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5698,7 +5698,7 @@ dependencies = [
  "once_cell",
  "socket2 0.5.10",
  "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6489,7 +6489,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6502,7 +6502,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6561,7 +6561,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -7421,7 +7421,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -8870,7 +8870,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,14 +50,16 @@ members = [
 ]
 
 [workspace.dependencies]
-dashcore = { git = "https://github.com/dashpay/rust-dashcore", rev = "647fa9820f3614090e4e5f5f2b709961d68e538b" }
-dash-network-seeds = { git = "https://github.com/dashpay/rust-dashcore", rev = "647fa9820f3614090e4e5f5f2b709961d68e538b" }
-dash-spv = { git = "https://github.com/dashpay/rust-dashcore", rev = "647fa9820f3614090e4e5f5f2b709961d68e538b" }
-key-wallet = { git = "https://github.com/dashpay/rust-dashcore", rev = "647fa9820f3614090e4e5f5f2b709961d68e538b" }
-key-wallet-ffi = { git = "https://github.com/dashpay/rust-dashcore", rev = "647fa9820f3614090e4e5f5f2b709961d68e538b" }
-key-wallet-manager = { git = "https://github.com/dashpay/rust-dashcore", rev = "647fa9820f3614090e4e5f5f2b709961d68e538b" }
-dash-network = { git = "https://github.com/dashpay/rust-dashcore", rev = "647fa9820f3614090e4e5f5f2b709961d68e538b" }
-dashcore-rpc = { git = "https://github.com/dashpay/rust-dashcore", rev = "647fa9820f3614090e4e5f5f2b709961d68e538b" }
+# TODO(pin): tracks dashpay/rust-dashcore#850 (draft) — asset-lock explicit
+# UTXO override. Bump to the merged `dev` SHA once that PR lands.
+dashcore = { git = "https://github.com/dashpay/rust-dashcore", rev = "d42081e7bc916fb5c4f994cdfa1c01cf5ede9e0f" }
+dash-network-seeds = { git = "https://github.com/dashpay/rust-dashcore", rev = "d42081e7bc916fb5c4f994cdfa1c01cf5ede9e0f" }
+dash-spv = { git = "https://github.com/dashpay/rust-dashcore", rev = "d42081e7bc916fb5c4f994cdfa1c01cf5ede9e0f" }
+key-wallet = { git = "https://github.com/dashpay/rust-dashcore", rev = "d42081e7bc916fb5c4f994cdfa1c01cf5ede9e0f" }
+key-wallet-ffi = { git = "https://github.com/dashpay/rust-dashcore", rev = "d42081e7bc916fb5c4f994cdfa1c01cf5ede9e0f" }
+key-wallet-manager = { git = "https://github.com/dashpay/rust-dashcore", rev = "d42081e7bc916fb5c4f994cdfa1c01cf5ede9e0f" }
+dash-network = { git = "https://github.com/dashpay/rust-dashcore", rev = "d42081e7bc916fb5c4f994cdfa1c01cf5ede9e0f" }
+dashcore-rpc = { git = "https://github.com/dashpay/rust-dashcore", rev = "d42081e7bc916fb5c4f994cdfa1c01cf5ede9e0f" }
 
 tokio-metrics = "0.5"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,16 +50,17 @@ members = [
 ]
 
 [workspace.dependencies]
-# TODO(pin): tracks dashpay/rust-dashcore#850 (draft) — asset-lock explicit
-# UTXO override. Bump to the merged `dev` SHA once that PR lands.
-dashcore = { git = "https://github.com/dashpay/rust-dashcore", rev = "d42081e7bc916fb5c4f994cdfa1c01cf5ede9e0f" }
-dash-network-seeds = { git = "https://github.com/dashpay/rust-dashcore", rev = "d42081e7bc916fb5c4f994cdfa1c01cf5ede9e0f" }
-dash-spv = { git = "https://github.com/dashpay/rust-dashcore", rev = "d42081e7bc916fb5c4f994cdfa1c01cf5ede9e0f" }
-key-wallet = { git = "https://github.com/dashpay/rust-dashcore", rev = "d42081e7bc916fb5c4f994cdfa1c01cf5ede9e0f" }
-key-wallet-ffi = { git = "https://github.com/dashpay/rust-dashcore", rev = "d42081e7bc916fb5c4f994cdfa1c01cf5ede9e0f" }
-key-wallet-manager = { git = "https://github.com/dashpay/rust-dashcore", rev = "d42081e7bc916fb5c4f994cdfa1c01cf5ede9e0f" }
-dash-network = { git = "https://github.com/dashpay/rust-dashcore", rev = "d42081e7bc916fb5c4f994cdfa1c01cf5ede9e0f" }
-dashcore-rpc = { git = "https://github.com/dashpay/rust-dashcore", rev = "d42081e7bc916fb5c4f994cdfa1c01cf5ede9e0f" }
+# TODO(pin): tracks dashpay/rust-dashcore#851 (draft) — key-wallet
+# out-of-order UTXO spend fix (#649). Bump to the merged `dev` SHA once
+# that PR lands.
+dashcore = { git = "https://github.com/dashpay/rust-dashcore", rev = "48a07d3fcd2f8d37e109f969eb5da0a8bbbb9aff" }
+dash-network-seeds = { git = "https://github.com/dashpay/rust-dashcore", rev = "48a07d3fcd2f8d37e109f969eb5da0a8bbbb9aff" }
+dash-spv = { git = "https://github.com/dashpay/rust-dashcore", rev = "48a07d3fcd2f8d37e109f969eb5da0a8bbbb9aff" }
+key-wallet = { git = "https://github.com/dashpay/rust-dashcore", rev = "48a07d3fcd2f8d37e109f969eb5da0a8bbbb9aff" }
+key-wallet-ffi = { git = "https://github.com/dashpay/rust-dashcore", rev = "48a07d3fcd2f8d37e109f969eb5da0a8bbbb9aff" }
+key-wallet-manager = { git = "https://github.com/dashpay/rust-dashcore", rev = "48a07d3fcd2f8d37e109f969eb5da0a8bbbb9aff" }
+dash-network = { git = "https://github.com/dashpay/rust-dashcore", rev = "48a07d3fcd2f8d37e109f969eb5da0a8bbbb9aff" }
+dashcore-rpc = { git = "https://github.com/dashpay/rust-dashcore", rev = "48a07d3fcd2f8d37e109f969eb5da0a8bbbb9aff" }
 
 tokio-metrics = "0.5"
 

--- a/packages/rs-platform-wallet/src/wallet/asset_lock/build.rs
+++ b/packages/rs-platform-wallet/src/wallet/asset_lock/build.rs
@@ -98,7 +98,6 @@ impl<B: TransactionBroadcaster + ?Sized> AssetLockManager<B> {
                 vec![funding],
                 DEFAULT_FEE_PER_KB,
                 signer,
-                None,
             )
             .await
             .map_err(|e| {

--- a/packages/rs-platform-wallet/src/wallet/asset_lock/build.rs
+++ b/packages/rs-platform-wallet/src/wallet/asset_lock/build.rs
@@ -98,6 +98,7 @@ impl<B: TransactionBroadcaster + ?Sized> AssetLockManager<B> {
                 vec![funding],
                 DEFAULT_FEE_PER_KB,
                 signer,
+                None,
             )
             .await
             .map_err(|e| {


### PR DESCRIPTION
## Why this PR exists
- **Problem**: `dash-evo-tool` app depends on this repo's `dash-evo-tool` integration branch, which was pinned to an older rust-dashcore rev (`647fa982`) than PR #3692's branch (`feat/platform-wallet-rehydration`).
- **What breaks without it**: `dash-evo-tool` app doesn't get the rust-dashcore #851 fix (key-wallet out-of-order UTXO spend / #649) that #3692 now depends on, nor #3692's own watch-only rehydration work.
- **Blocking relationship**: brings `dash-evo-tool` branch up to date with PR #3692 (dashpay/platform#3692).

## What was done
Merge commit bringing `feat/platform-wallet-rehydration` (PR #3692) into `dash-evo-tool`. Only diff beyond history reconciliation: the rust-dashcore workspace pin bump (`647fa982` → `48a07d3f`, tracking rust-dashcore#851) already present on #3692's branch. No conflicts — `dash-evo-tool` had never diverged on those Cargo.toml lines.

## Testing
- `cargo check -p platform-wallet -p platform-wallet-storage -p platform-wallet-ffi` — clean compile against the merged tree.
- Cargo.lock conflict auto-resolved cleanly by git's `ort` merge strategy; no manual resolution needed.

## Breaking changes
None.

## Checklist
- [x] Compiles clean
- [ ] CI green (pending)

## Attribution

<sub>🤖 Co-authored by [Claudius the Magnificent](https://github.com/lklimek/claudius) AI Agent</sub>