### PR TITLE
fix(swift-sdk): remove the tmp todo in build_ios.sh

### DIFF
--- a/packages/swift-sdk/build_ios.sh
+++ b/packages/swift-sdk/build_ios.sh
@@ -126,29 +126,6 @@ log_info "Package: $PACKAGE"
 log_info "Profile: $PROFILE"
 
 # -------------------------------
-# Force header regeneration
-# -------------------------------
-# TODO: this is a temporal fix. Because this script
-# was modifying the headers in place, this PR, that removes
-# that weird behaviour, hits an issue, cargo doesnt re-run
-# the build.rs scripts, leaving the old modified headers,
-# so I have to force the headers generation for this PR
-#
-# Once this change is in the dev branch a new PR will be open
-# removing this step
-log_info "Forcing cbindgen header regeneration: ${INCLUDED_CRATES[*]}"
-TRIPLES=()
-if $BUILD_IOS; then TRIPLES+=("aarch64-apple-ios"); fi
-if $BUILD_SIM; then TRIPLES+=("aarch64-apple-ios-sim"); fi
-if $BUILD_MAC; then TRIPLES+=("aarch64-apple-darwin"); fi
-for triple in "${TRIPLES[@]}"; do
-  for c in "${INCLUDED_CRATES[@]}"; do
-    cargo clean -p "$c" --profile "$PROFILE" --target "$triple"
-  done
-  rm -rf "$TARGET_DIR/$triple/$OUTPUT_DIR/include"
-done
-
-# -------------------------------
 # Build commands
 # -------------------------------
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->


## What was done?
<!--- Describe your changes in detail -->


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [ ] I have made corresponding changes to the documentation if needed

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Streamlined the iOS build process by removing an automatic header-regeneration step.
  * Builds now proceed more directly, which may reduce build time and avoid unnecessary cleanup during packaging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->