### PR TITLE
fix(swift-example-app): compute direct-purchase price so token Buy can be submitted

### DIFF
--- a/packages/swift-sdk/SwiftExampleApp/SwiftExampleApp/Utils/TokenDirectPurchasePricing.swift
+++ b/packages/swift-sdk/SwiftExampleApp/SwiftExampleApp/Utils/TokenDirectPurchasePricing.swift
@@ -1,0 +1,137 @@
+import Foundation
+
+/// A token's direct-purchase pricing schedule, parsed from the JSON that
+/// `SDK.getTokenDirectPurchasePrices(tokenIds:)` returns (the shape emitted
+/// by the FFI's `dash_sdk_token_get_direct_purchase_prices`):
+///
+/// ```
+/// {"<tokenIdBase58>": {"type":"single_price","price":<u64>}}
+/// {"<tokenIdBase58>": {"type":"set_prices","prices":[{"amount":<u64>,"price":<u64>}, …]}}
+/// {"<tokenIdBase58>": null}
+/// ```
+///
+/// This is the model behind the Direct Purchase form's cost preview. It
+/// resolves the total credits a buyer must pay for a given raw token amount
+/// using the *same* tier rule Drive applies when it validates the purchase
+/// (`token_direct_purchase_transition_action` v0 transformer), so the
+/// `expectedTotalCost` the form submits matches the chain's `required_price`:
+///
+///  - ``singlePrice(_:)``: `price × amount`.
+///  - ``setPrices(_:)``: the highest tier threshold `≤ amount` sets the
+///    per-token price and the total is `tierPrice × amount`. An amount below
+///    the smallest threshold is under the minimum sale amount (not
+///    purchasable); an empty schedule means the token isn't for direct sale.
+///
+/// Prices are `u64` credits on-chain, so multiplication goes through
+/// `multipliedReportingOverflow`; a product that overflows `UInt64` resolves
+/// to `nil` (Buy stays disabled) rather than wrapping. A resolved cost of `0`
+/// (a free tier) is likewise `nil`: the purchase FFI/flow requires a positive
+/// `expectedTotalCost`.
+enum TokenDirectPurchasePricing: Equatable {
+
+    /// One flat per-token price for any amount.
+    case singlePrice(UInt64)
+
+    /// Tiered pricing: an ordered list of `(minimum amount, per-token price)`
+    /// tiers. The highest tier whose `amount ≤` the purchased amount sets the
+    /// per-token price.
+    case setPrices([Tier])
+
+    /// A `(minimum amount, per-token price)` tier in a ``setPrices(_:)``
+    /// schedule.
+    struct Tier: Equatable {
+        let amount: UInt64
+        let price: UInt64
+    }
+
+    /// The required total cost in credits to buy `amount` raw token units, or
+    /// `nil` when the amount isn't purchasable at this schedule (below the
+    /// minimum sale amount, a free tier, or a total that overflows the
+    /// `UInt64` credits the purchase FFI accepts).
+    ///
+    /// This mirrors Drive's `token_direct_purchase_transition_action` v0
+    /// transformer exactly: `required_price = perTokenPrice × token_count`,
+    /// where for a tiered schedule the per-token price is the highest tier
+    /// threshold `≤ amount`.
+    func cost(forAmount amount: UInt64) -> UInt64? {
+        guard amount > 0 else { return nil }
+
+        let perToken: UInt64
+        switch self {
+        case let .singlePrice(price):
+            perToken = price
+        case let .setPrices(tiers):
+            // Highest tier threshold `≤ amount` — the Rust
+            // `set_prices.range(..=token_count).next_back()` lookup. An amount
+            // below every threshold (or an empty schedule) is not purchasable.
+            guard let tierPrice = tiers
+                .filter({ $0.amount <= amount })
+                .max(by: { $0.amount < $1.amount })?
+                .price
+            else { return nil }
+            perToken = tierPrice
+        }
+
+        let (total, overflow) = perToken.multipliedReportingOverflow(by: amount)
+        guard !overflow else { return nil }
+        // A resolved total of 0 (a free tier) is not submittable: the purchase
+        // FFI/flow requires a positive expected total cost.
+        guard total > 0 else { return nil }
+        return total
+    }
+
+    /// The smallest raw amount that can be purchased — `1` for a single price,
+    /// the lowest tier threshold for a tiered schedule. Used for the "minimum
+    /// purchase is N" hint.
+    var minimumPurchaseAmount: UInt64 {
+        switch self {
+        case .singlePrice:
+            return 1
+        case let .setPrices(tiers):
+            return tiers.map { $0.amount }.min() ?? 1
+        }
+    }
+
+    /// Parse the pricing for `canonicalTokenId` out of the dictionary a
+    /// `getTokenDirectPurchasePrices` call produces (a `[String: Any]` from
+    /// `JSONSerialization`), or `nil` when the token has no usable price (a
+    /// `null`/missing entry, an empty tier list) or the entry can't be read.
+    ///
+    /// `price`/`amount` values are `u64` and can exceed `Int64.max`, so they
+    /// are read through `NSNumber.uint64Value` rather than as `Int`.
+    static func parse(
+        _ response: [String: Any],
+        canonicalTokenId: String
+    ) -> TokenDirectPurchasePricing? {
+        // A missing key or an explicit JSON `null` (bridged to `NSNull`) both
+        // mean "no price configured".
+        guard let entry = response[canonicalTokenId] as? [String: Any] else {
+            return nil
+        }
+
+        switch entry["type"] as? String {
+        case "single_price":
+            guard let price = (entry["price"] as? NSNumber)?.uint64Value else {
+                return nil
+            }
+            return .singlePrice(price)
+
+        case "set_prices":
+            guard let rawTiers = entry["prices"] as? [[String: Any]] else {
+                return nil
+            }
+            let tiers: [Tier] = rawTiers.compactMap { tier in
+                guard let amount = (tier["amount"] as? NSNumber)?.uint64Value,
+                      let price = (tier["price"] as? NSNumber)?.uint64Value
+                else { return nil }
+                return Tier(amount: amount, price: price)
+            }
+            // An empty schedule (or one whose every tier failed to parse) means
+            // the token isn't for direct sale.
+            return tiers.isEmpty ? nil : .setPrices(tiers)
+
+        default:
+            return nil
+        }
+    }
+}

--- a/packages/swift-sdk/SwiftExampleApp/SwiftExampleApp/Utils/TokenDirectPurchasePricing.swift
+++ b/packages/swift-sdk/SwiftExampleApp/SwiftExampleApp/Utils/TokenDirectPurchasePricing.swift
@@ -50,9 +50,19 @@ enum TokenDirectPurchasePricing: Equatable {
     /// `UInt64` credits the purchase FFI accepts).
     ///
     /// This mirrors Drive's `token_direct_purchase_transition_action` v0
-    /// transformer exactly: `required_price = perTokenPrice × token_count`,
-    /// where for a tiered schedule the per-token price is the highest tier
-    /// threshold `≤ amount`.
+    /// transformer: `required_price = perTokenPrice × token_count`, where for
+    /// a tiered schedule the per-token price is the highest tier threshold
+    /// `≤ amount`.
+    ///
+    /// One deliberate divergence: Drive's single-price branch uses
+    /// `saturating_mul`, so an overflowing product passes its price check at
+    /// `u64::MAX` — but Drive then debits that `u64::MAX`, which exceeds any
+    /// possible credit balance, so the transition is guaranteed to fail at
+    /// balance deduction (after charging a processing fee). Broadcasting a
+    /// known-doomed purchase is worse than disabling Buy, so this helper
+    /// treats overflow as not-purchasable in both branches (as the Kotlin
+    /// counterpart does — its `Long`-based FFI can't even represent
+    /// `u64::MAX`).
     func cost(forAmount amount: UInt64) -> UInt64? {
         guard amount > 0 else { return nil }
 

--- a/packages/swift-sdk/SwiftExampleApp/SwiftExampleApp/Views/TokenActionPermissionsView.swift
+++ b/packages/swift-sdk/SwiftExampleApp/SwiftExampleApp/Views/TokenActionPermissionsView.swift
@@ -620,18 +620,15 @@ enum TokenActionResolver {
         if token.isPaused {
             return .denied(reason: "Token is paused")
         }
-        // Wave 1: PersistentToken doesn't carry the configured purchase
-        // price. `TokenPurchaseActionView.priceKnown` is hard-coded
-        // `false` until that field lands, so the Buy button is *always*
-        // disabled — routing the user to a permanently-broken screen
-        // is dishonest. Deny here with the same reason the action view
-        // shows. When the price field lands on PersistentToken, this
-        // becomes a real conditional check; until then it short-circuits.
-        // TODO: surface direct-purchase price on PersistentToken and
-        // gate this row on it (and pre-fill the form's total cost).
+        // The token has direct-purchase pricing rules and isn't paused, so
+        // the row is tappable. `TokenPurchaseActionView` fetches the
+        // configured price on appear (`getTokenDirectPurchasePrices`) and
+        // computes the buyer's total cost client-side — including the
+        // "no price configured" case — so the price no longer needs to be
+        // pre-resolved here to keep the user off a broken screen.
         _ = identity
         _ = contract
-        return .denied(reason: "Direct-purchase price not available locally yet")
+        return .allowed
     }
 }
 

--- a/packages/swift-sdk/SwiftExampleApp/SwiftExampleApp/Views/TokenActions/TokenPurchaseActionView.swift
+++ b/packages/swift-sdk/SwiftExampleApp/SwiftExampleApp/Views/TokenActions/TokenPurchaseActionView.swift
@@ -4,19 +4,25 @@ import SwiftDashSDK
 
 /// Form for buying tokens at the configured direct-purchase price.
 ///
-/// Inputs: amount of tokens to buy. The Buy button stays disabled
-/// until `PersistentToken` exposes the configured direct-purchase
-/// price; submitting a known-failing state transition (with a sentinel
-/// total) is worse than telling the user to wait. Direct Purchase is
-/// not group-gated, so there's no group-action banner.
+/// Inputs: amount of tokens to buy. The configured direct-purchase price is
+/// fetched when the view appears via `SDK.getTokenDirectPurchasePrices` (keyed
+/// by the canonical token id derived with `calculateTokenId`, mirroring how
+/// `TokenActionPermissionsView` fetches live token state), then modelled as a
+/// ``TokenDirectPurchasePricing``. The Buy button computes
+/// `expectedTotalCost = pricing.cost(forAmount:)` client-side — the *same*
+/// tier rule Drive uses to validate the purchase — so the submitted total
+/// equals the chain's `required_price`.
 ///
-/// TODO: PersistentToken doesn't yet carry the *current* configured
-/// price. Once it does, surface it as helper text, compute the total
-/// cost client-side, and flip `priceKnown` so Buy enables.
+/// Buy stays disabled while the price loads, when the token has no
+/// direct-purchase price configured, and when the entered amount isn't
+/// purchasable at the configured price (below the minimum, a free tier, or an
+/// overflowing total). Direct Purchase is not group-gated, so there's no
+/// group-action banner.
 struct TokenPurchaseActionView: View {
     let token: PersistentToken
     let identity: PersistentIdentity
 
+    @EnvironmentObject var appState: AppState
     @EnvironmentObject var walletManager: PlatformWalletManager
     @Environment(\.modelContext) private var modelContext
     @Environment(\.dismiss) private var dismiss
@@ -28,6 +34,17 @@ struct TokenPurchaseActionView: View {
     /// `submit()` Task can't write back to a re-entered view instance
     /// after the user pops + repushes mid-broadcast.
     @State private var submitGeneration: Int = 0
+
+    /// Loading / loaded state of the token's configured direct-purchase price.
+    /// Stays `.loading` until the SDK connects and the query resolves; on a
+    /// resolved query with no price set it becomes `.loaded(nil)` and Buy stays
+    /// disabled with a clear reason.
+    private enum PriceState {
+        case loading
+        case loaded(TokenDirectPurchasePricing?)
+    }
+
+    @State private var priceState: PriceState = .loading
 
     private struct AlertMessage: Identifiable {
         let id = UUID()
@@ -56,9 +73,7 @@ struct TokenPurchaseActionView: View {
             }
 
             Section("Total cost") {
-                Text("Price not yet known — waiting for sync.")
-                    .font(.caption)
-                    .foregroundColor(.secondary)
+                priceStatus
             }
 
             Section {
@@ -77,21 +92,68 @@ struct TokenPurchaseActionView: View {
                 }
                 .buttonStyle(.borderedProminent)
                 .disabled(!canSubmit || isSubmitting)
-                if !priceKnown {
-                    Text("Buy is disabled until the configured direct-purchase price is available locally.")
-                        .font(.caption)
-                        .foregroundColor(.secondary)
-                }
             }
         }
         .navigationTitle("Direct Purchase")
         .navigationBarTitleDisplayMode(.inline)
+        // Keyed on SDK connectivity so a form opened before the SDK finishes
+        // connecting re-fetches once it does (an un-keyed `.task` would stick
+        // with the initial run's result forever).
+        .task(id: appState.sdk == nil) { await loadPrice() }
         .alert(item: $submitError) { msg in
             Alert(
                 title: Text("Purchase failed"),
                 message: Text(msg.message),
                 dismissButton: .default(Text("OK"))
             )
+        }
+    }
+
+    // MARK: - Total-cost section
+
+    /// The "Total cost" section body, driven by the price-load state, the
+    /// entered amount, and whether that amount resolves to a submittable cost.
+    @ViewBuilder
+    private var priceStatus: some View {
+        switch priceState {
+        case .loading:
+            Text("Loading the configured direct-purchase price…")
+                .font(.caption)
+                .foregroundColor(.secondary)
+
+        case let .loaded(pricing):
+            if let pricing {
+                loadedPriceStatus(pricing)
+            } else {
+                Text("This token has no direct-purchase price configured, so it can't be bought directly.")
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+            }
+        }
+    }
+
+    /// The "Total cost" body once a pricing schedule is known: prompt for an
+    /// amount, show a resolved cost, or explain why the entered amount can't be
+    /// purchased (under-minimum hint or a generic reason).
+    @ViewBuilder
+    private func loadedPriceStatus(_ pricing: TokenDirectPurchasePricing) -> some View {
+        if let amount = parsedAmount, amount > 0 {
+            if let cost = pricing.cost(forAmount: amount) {
+                Text("\(cost) credits")
+                    .font(.body)
+            } else if amount < pricing.minimumPurchaseAmount {
+                Text("The minimum direct purchase for this token is \(formatTokenAmount(pricing.minimumPurchaseAmount, decimals: token.decimals)).")
+                    .font(.caption)
+                    .foregroundColor(.red)
+            } else {
+                Text("This amount can't be purchased at the configured price.")
+                    .font(.caption)
+                    .foregroundColor(.red)
+            }
+        } else {
+            Text("Enter an amount to see the total cost.")
+                .font(.caption)
+                .foregroundColor(.secondary)
         }
     }
 
@@ -107,18 +169,66 @@ struct TokenPurchaseActionView: View {
         parseTokenAmount(amountText, decimals: token.decimals)
     }
 
-    /// `PersistentToken` doesn't yet carry a direct-purchase price
-    /// field, so we can't compute the buyer's expected total. Until it
-    /// does, Buy stays disabled rather than dispatching a known-failing
-    /// state transition with a sentinel total.
-    /// TODO: surface the configured price on PersistentToken and gate
-    /// Buy on that instead.
-    private var priceKnown: Bool { false }
+    /// The pricing schedule once loaded (`nil` while loading or when the token
+    /// has no configured price).
+    private var pricing: TokenDirectPurchasePricing? {
+        if case let .loaded(pricing) = priceState { return pricing }
+        return nil
+    }
+
+    /// The required total the purchase must pay, computed with the same tier
+    /// rule Drive validates against, or `nil` when the entered amount isn't
+    /// purchasable at the configured price.
+    private var expectedTotalCost: UInt64? {
+        guard let pricing, let amount = parsedAmount else { return nil }
+        return pricing.cost(forAmount: amount)
+    }
 
     private var canSubmit: Bool {
         guard let amount = parsedAmount, amount > 0 else { return false }
-        guard priceKnown else { return false }
+        guard expectedTotalCost != nil else { return false }
         return managedWallet != nil
+    }
+
+    // MARK: - Price fetch
+
+    /// Fetch the token's configured direct-purchase price and model it as a
+    /// ``TokenDirectPurchasePricing``. The canonical token id — which the price
+    /// query is keyed by — is derived the same way `TokenActionPermissionsView`
+    /// derives it (`calculateTokenId(contractId:position:)` on the base58
+    /// contract id), *not* the persisted `(contractId + position)` composite.
+    /// An invalid position or a failed query resolves to `.loaded(nil)` so Buy
+    /// is disabled with a clear reason rather than left spinning; a
+    /// not-yet-connected SDK stays `.loading` — the `.task(id:)` key re-runs
+    /// this once the SDK lands, so "no price configured" is never shown for a
+    /// price that simply hasn't been fetchable yet.
+    private func loadPrice() async {
+        priceState = .loading
+
+        guard let sdk = appState.sdk else { return }
+        guard let position = UInt16(exactly: token.position) else {
+            priceState = .loaded(nil)
+            return
+        }
+
+        let contractIdString = token.contractId.toBase58String()
+        do {
+            let canonicalTokenId = try sdk.calculateTokenId(
+                contractId: contractIdString,
+                position: position
+            )
+            let response = try await sdk.getTokenDirectPurchasePrices(
+                tokenIds: [canonicalTokenId]
+            )
+            let pricing = TokenDirectPurchasePricing.parse(
+                response,
+                canonicalTokenId: canonicalTokenId
+            )
+            priceState = .loaded(pricing)
+        } catch {
+            print("⚠️ TokenPurchaseActionView: failed to load direct-purchase price for \(contractIdString):\(token.position): \(error)")
+            priceState = .loaded(nil)
+        }
     }
 
     // MARK: - Submit
@@ -132,8 +242,8 @@ struct TokenPurchaseActionView: View {
             submitError = .init(message: "Amount must be greater than zero.")
             return
         }
-        guard priceKnown else {
-            submitError = .init(message: "Direct-purchase price isn't known locally yet.")
+        guard let totalCost = expectedTotalCost else {
+            submitError = .init(message: "This amount can't be purchased at the configured price.")
             return
         }
 
@@ -148,10 +258,9 @@ struct TokenPurchaseActionView: View {
         let signer = KeychainSigner(modelContainer: modelContext.container)
         let identityId = identity.identityId
         let contractId = token.contractId
-        // TODO: replace once the price field lands on PersistentToken.
-        // Buy is gated on `priceKnown` above, so this fallback is
-        // unreachable until that gate flips.
-        let expectedTotalCost: UInt64 = 0
+        // `cost(forAmount:)` applies the exact tier rule Drive validates
+        // against, so this equals the chain's `required_price`.
+        let expectedTotalCost = totalCost
 
         Task {
             do {

--- a/packages/swift-sdk/SwiftExampleApp/SwiftExampleApp/Views/TokenActions/TokenPurchaseActionView.swift
+++ b/packages/swift-sdk/SwiftExampleApp/SwiftExampleApp/Views/TokenActions/TokenPurchaseActionView.swift
@@ -35,13 +35,16 @@ struct TokenPurchaseActionView: View {
     /// after the user pops + repushes mid-broadcast.
     @State private var submitGeneration: Int = 0
 
-    /// Loading / loaded state of the token's configured direct-purchase price.
-    /// Stays `.loading` until the SDK connects and the query resolves; on a
-    /// resolved query with no price set it becomes `.loaded(nil)` and Buy stays
-    /// disabled with a clear reason.
+    /// Loading / loaded / failed state of the token's configured
+    /// direct-purchase price. Stays `.loading` until the SDK connects and the
+    /// query resolves; on a resolved query with no price set it becomes
+    /// `.loaded(nil)` and Buy stays disabled with a clear reason. A query
+    /// *failure* is `.failed`, not `.loaded(nil)` — "couldn't fetch the price"
+    /// must not read as "this token isn't for sale", and it offers a retry.
     private enum PriceState {
         case loading
         case loaded(TokenDirectPurchasePricing?)
+        case failed
     }
 
     @State private var priceState: PriceState = .loading
@@ -129,6 +132,15 @@ struct TokenPurchaseActionView: View {
                     .font(.caption)
                     .foregroundColor(.secondary)
             }
+
+        case .failed:
+            Text("Couldn't load the configured direct-purchase price.")
+                .font(.caption)
+                .foregroundColor(.red)
+            Button("Retry") {
+                Task { await loadPrice() }
+            }
+            .font(.caption)
         }
     }
 
@@ -197,11 +209,11 @@ struct TokenPurchaseActionView: View {
     /// query is keyed by — is derived the same way `TokenActionPermissionsView`
     /// derives it (`calculateTokenId(contractId:position:)` on the base58
     /// contract id), *not* the persisted `(contractId + position)` composite.
-    /// An invalid position or a failed query resolves to `.loaded(nil)` so Buy
-    /// is disabled with a clear reason rather than left spinning; a
+    /// An invalid position resolves to `.loaded(nil)` (nothing a retry can
+    /// fix); a failed id-derivation or query resolves to `.failed` so the user
+    /// sees a retryable error instead of a false "no price configured"; a
     /// not-yet-connected SDK stays `.loading` — the `.task(id:)` key re-runs
-    /// this once the SDK lands, so "no price configured" is never shown for a
-    /// price that simply hasn't been fetchable yet.
+    /// this once the SDK lands.
     private func loadPrice() async {
         priceState = .loading
 
@@ -227,7 +239,7 @@ struct TokenPurchaseActionView: View {
             priceState = .loaded(pricing)
         } catch {
             print("⚠️ TokenPurchaseActionView: failed to load direct-purchase price for \(contractIdString):\(token.position): \(error)")
-            priceState = .loaded(nil)
+            priceState = .failed
         }
     }
 

--- a/packages/swift-sdk/SwiftExampleApp/SwiftExampleAppTests/TokenDirectPurchasePricingTests.swift
+++ b/packages/swift-sdk/SwiftExampleApp/SwiftExampleAppTests/TokenDirectPurchasePricingTests.swift
@@ -1,0 +1,120 @@
+import XCTest
+@testable import SwiftExampleApp
+
+/// Parsing + cost-resolution tests for `TokenDirectPurchasePricing` — the
+/// model behind the Direct Purchase form's cost preview. The `cost(forAmount:)`
+/// expectations mirror Drive's `token_direct_purchase_transition_action` v0
+/// transformer (`required_price = perTokenPrice × token_count`, highest tier
+/// `≤ amount`, under-minimum / empty schedule reject).
+final class TokenDirectPurchasePricingTests: XCTestCase {
+
+    private let tokenId = "TokenIdBase58AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+
+    /// Parse the pricing out of a raw JSON body the same way the app does at
+    /// runtime: `getTokenDirectPurchasePrices` returns a `[String: Any]`
+    /// produced by `JSONSerialization`, so route the fixture through it to get
+    /// the exact `NSNumber` bridging the parser sees.
+    private func parse(_ json: String) -> TokenDirectPurchasePricing? {
+        guard let data = json.data(using: .utf8),
+              let object = try? JSONSerialization.jsonObject(with: data),
+              let dictionary = object as? [String: Any]
+        else { return nil }
+        return TokenDirectPurchasePricing.parse(dictionary, canonicalTokenId: tokenId)
+    }
+
+    private func single(_ price: String) -> String {
+        #"{"\#(tokenId)":{"type":"single_price","price":\#(price)}}"#
+    }
+
+    private func setPrices(_ tiers: [(amount: UInt64, price: UInt64)]) -> String {
+        let entries = tiers
+            .map { #"{"amount":\#($0.amount),"price":\#($0.price)}"# }
+            .joined(separator: ",")
+        return #"{"\#(tokenId)":{"type":"set_prices","prices":[\#(entries)]}}"#
+    }
+
+    // MARK: - Parsing
+
+    func test_singlePrice_parses() {
+        XCTAssertEqual(parse(single("100")), .singlePrice(100))
+    }
+
+    func test_setPrices_parsePreservingTiers() {
+        let pricing = parse(setPrices([(1, 100), (10, 80), (100, 50)]))
+        XCTAssertEqual(
+            pricing,
+            .setPrices([
+                .init(amount: 1, price: 100),
+                .init(amount: 10, price: 80),
+                .init(amount: 100, price: 50),
+            ])
+        )
+    }
+
+    func test_nullEntry_meansNoPrice() {
+        XCTAssertNil(parse(#"{"\#(tokenId)":null}"#))
+    }
+
+    func test_missingTokenKey_meansNoPrice() {
+        XCTAssertNil(parse(#"{"other":{"type":"single_price","price":5}}"#))
+    }
+
+    func test_emptySetPricesSchedule_meansNoPrice() {
+        XCTAssertNil(parse(setPrices([])))
+    }
+
+    func test_garbageJson_meansNoPrice() {
+        XCTAssertNil(parse("not json"))
+        XCTAssertNil(parse("[1,2,3]"))
+    }
+
+    func test_u64PriceBeyondInt64Range_parses() {
+        // 2^63 + 1 — outside signed Int64, must survive parsing via uint64Value.
+        let big: UInt64 = (1 << 63) + 1
+        XCTAssertEqual(parse(single("\(big)")), .singlePrice(big))
+    }
+
+    // MARK: - Cost resolution
+
+    func test_singlePrice_costIsPriceTimesAmount() {
+        let pricing = parse(single("250"))!
+        XCTAssertEqual(pricing.cost(forAmount: 4), 1_000)
+    }
+
+    func test_setPrices_picksHighestTierAtOrBelowAmount() {
+        let pricing = parse(setPrices([(1, 100), (10, 80), (100, 50)]))!
+        // Buying 50 matches tier 10 (price 80) => 80 * 50.
+        XCTAssertEqual(pricing.cost(forAmount: 50), 4_000)
+        // Exact boundary hits its own tier.
+        XCTAssertEqual(pricing.cost(forAmount: 10), 800)
+        // Above the top tier uses the top tier.
+        XCTAssertEqual(pricing.cost(forAmount: 1_000), 50_000)
+    }
+
+    func test_amountBelowMinimumTier_isNotPurchasable() {
+        let pricing = parse(setPrices([(5, 200), (10, 150)]))!
+        XCTAssertNil(pricing.cost(forAmount: 2))
+        XCTAssertEqual(pricing.minimumPurchaseAmount, 5)
+    }
+
+    func test_freeTier_isNotPurchasable() {
+        // A resolved cost of 0 is rejected — the purchase FFI needs a positive cost.
+        XCTAssertNil(parse(single("0"))!.cost(forAmount: 10))
+    }
+
+    func test_zeroAmount_isNotPurchasable() {
+        let pricing = parse(single("100"))!
+        XCTAssertNil(pricing.cost(forAmount: 0))
+    }
+
+    func test_totalOverflow_isNotPurchasable() {
+        // price 2^62, amount 4 => 2^64, overflows UInt64.
+        let pricing = parse(single("\(UInt64(1) << 62)"))!
+        XCTAssertNil(pricing.cost(forAmount: 4))
+    }
+
+    func test_singlePrice_minimumIsOne() {
+        let pricing = parse(single("100"))!
+        XCTAssertEqual(pricing.minimumPurchaseAmount, 1)
+    }
+}

--- a/packages/swift-sdk/SwiftExampleApp/TEST_PLAN.md
+++ b/packages/swift-sdk/SwiftExampleApp/TEST_PLAN.md
@@ -234,7 +234,7 @@ All token actions support single-signer **and** group (propose / co-sign) modes 
 |---|---|---|---|---|---|---|
 | TOK-01 | View token balances / details / search | Platform | Common | ✅ | read-only | `TokenDetailsView`, `TokensView`, `TokenSearchView`. |
 | TOK-02 | Transfer token | Platform | Common | ✅ |  | `TokenTransferActionView` → `wallet.tokenTransfer`. |
-| TOK-03 | Direct purchase token | Platform | Common | ✅ |  | `TokenPurchaseActionView` → `wallet.tokenPurchase`. |
+| TOK-03 | Direct purchase token | Platform | Common | ✅ |  | `TokenPurchaseActionView` → `wallet.tokenPurchase`. Fetches the configured price via `getTokenDirectPurchasePrices` (canonical id from `calculateTokenId`), models it as `TokenDirectPurchasePricing`, and computes `expectedTotalCost` client-side with Drive's tier rule so Buy enables only for a purchasable amount. |
 | TOK-04 | Token queries (statuses / prices / contract info / supply / distributions) | Platform | Common | ✅ | read-only | `PlatformQueriesView` token category → `dash_sdk_token_get_*`. |
 | TOK-05 | Mint (issuance) | Platform | Thorough | ✅ |  | `TokenMintActionView` → `wallet.tokenMint`. |
 | TOK-06 | Burn | Platform | Thorough | ✅ |  | `TokenBurnActionView` → `wallet.tokenBurn`. |


### PR DESCRIPTION
## Issue being fixed or feature implemented

The token Direct Purchase form in SwiftExampleApp could never be submitted: `TokenPurchaseActionView` hard-coded `priceKnown = false` (with a TODO), so the Buy button was permanently disabled and `expectedTotalCost` was a dead sentinel `0`. On top of that, `TokenActionResolver.resolveDirectPurchase` unconditionally denied the action row, so the form wasn't even reachable. The app never fetched the token's configured direct-purchase price, even though the SDK surface for it (`getTokenDirectPurchasePrices`, `calculateTokenId`) already existed.

This is the iOS counterpart of the Kotlin fix `f88235fe3c` on `feat/kotlin-sdk-and-example-app`, and unblocks driving TOK-03 (direct purchase) through the UI.

## What was done?

- **New `TokenDirectPurchasePricing` model** (`SwiftExampleApp/Utils/`): parses the pricing schedule from the `getTokenDirectPurchasePrices` response (`single_price` / `set_prices` / `null`) and resolves `cost(forAmount:)` with the exact tier rule Drive's `token_direct_purchase_transition_action` v0 transformer validates against (single: `price × amount`; tiered: highest tier threshold ≤ amount, × amount; under-minimum / empty schedule / free tier / u64 overflow → not purchasable), so the submitted `expectedTotalCost` equals the chain's `required_price`. u64 values are read via `NSNumber.uint64Value` (prices can exceed `Int64.max`).
- **`TokenPurchaseActionView`**: fetches the price on appear in a `.task` keyed on SDK connectivity (canonical token id via `calculateTokenId`, mirroring `TokenActionPermissionsView`'s live-state fetch), shows the resolved total cost, enables Buy only for a purchasable amount, and passes the real `expectedTotalCost` to `wallet.tokenPurchase`. Loading / no-price-configured / under-minimum states each surface a clear message with Buy disabled.
- **`TokenActionResolver.resolveDirectPurchase`**: now returns `.allowed` (when pricing rules exist and the token isn't paused) instead of the unconditional denial that kept the row un-tappable — the form itself now handles the "no price configured" case honestly.
- **`TEST_PLAN.md`**: TOK-03 notes updated to describe the price fetch + client-side cost computation.

## How Has This Been Tested?

- Added `TokenDirectPurchasePricingTests` (14 XCTest cases in `SwiftExampleAppTests`) covering parsing of all response shapes (incl. u64 > `Int64.max` via `JSONSerialization`, null/missing/garbage/empty-schedule) and cost resolution (tier selection incl. exact boundary and above-top-tier, under-minimum, free tier, zero amount, overflow) — mirroring the Kotlin `TokenDirectPurchasePricingTest` suite.
- Built SwiftExampleApp for the iPhone 16 simulator and ran the test target.

## Breaking Changes

None.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [x] I have made corresponding changes to the documentation if needed

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Direct purchase now loads configured token pricing and calculates the total cost client-side before purchase.
  * Supports both flat and tiered pricing, including a minimum purchasable amount.
* **Bug Fixes**
  * Purchase is enabled only when valid pricing is available and the token isn’t paused.
  * Improved validation prevents submitting zero-cost, invalid, or overflowed purchase amounts.
* **Tests**
  * Added unit tests covering pricing parsing, tier selection, boundaries, and invalid inputs (including overflow and null cases).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->