### PR TITLE
fix(swift-example-app): persist proven token balance after mint

### DIFF
--- a/packages/rs-platform-wallet-ffi/src/tokens/mint.rs
+++ b/packages/rs-platform-wallet-ffi/src/tokens/mint.rs
@@ -3,8 +3,10 @@
 use std::ffi::CStr;
 use std::os::raw::c_char;
 
+use dash_sdk::platform::tokens::transitions::MintResult;
 use rs_sdk_ffi::{SignerHandle, VTableSigner};
 
+use super::balances_json::{single_token_balance_to_json_cstring, write_empty_balances_json};
 use super::group_info::decode_group_info;
 use crate::check_ptr;
 use crate::error::*;
@@ -14,6 +16,17 @@ use crate::types::read_identifier;
 use crate::{unwrap_option_or_return, unwrap_result_or_return};
 
 /// Mint `amount` of token at `token_position` on `token_contract_id`.
+///
+/// On success, `out_balances_json` is written with a heap-allocated C
+/// string holding a JSON object mapping the recipient identity's base58
+/// id to its proof-verified post-mint balance, encoded as a decimal
+/// **string** (u64 exceeds JSON's safe-integer range), e.g.
+/// `{"<recipientBase58>": "<newBalance>"}`. History-tracking / group
+/// tokens carry no per-identity balance in the proof result, so an empty
+/// object `{}` is written. The caller owns the string and must free it
+/// via [`platform_wallet_string_free`](crate::types::platform_wallet_string_free).
+/// On error nothing is written through `out_balances_json` (it is set to
+/// null first) and the failure surfaces via the returned result.
 #[no_mangle]
 #[allow(clippy::too_many_arguments)]
 pub unsafe extern "C" fn platform_wallet_token_mint(
@@ -30,8 +43,11 @@ pub unsafe extern "C" fn platform_wallet_token_mint(
     group_info_action_is_proposer: bool,
     _signing_key_id: u32,
     signer_handle: *mut SignerHandle,
+    out_balances_json: *mut *mut c_char,
 ) -> PlatformWalletFFIResult {
     check_ptr!(signer_handle);
+    check_ptr!(out_balances_json);
+    *out_balances_json = std::ptr::null_mut();
 
     let id = unwrap_result_or_return!(read_identifier(identity_id));
     let contract_id = unwrap_result_or_return!(read_identifier(token_contract_id));
@@ -85,6 +101,37 @@ pub unsafe extern "C" fn platform_wallet_token_mint(
         })
     });
     let result = unwrap_option_or_return!(option);
-    unwrap_result_or_return!(result);
+    let mint_result = unwrap_result_or_return!(result);
+
+    // Map the proof-verified outcome to the balances JSON, mirroring the
+    // burn path. A standard mint carries the recipient's new balance
+    // (`recipient` from the proof); a group-authorized mint carries the
+    // recipient's balance once the action CLOSES. The recipient defaults
+    // to the minting identity `id` when no explicit destination was given.
+    // The document variants, and a group action still awaiting
+    // co-signatures (`balance == None`), have nothing to persist.
+    match mint_result {
+        MintResult::TokenBalance(recipient_id, new_balance) => {
+            let c_str = unwrap_result_or_return!(single_token_balance_to_json_cstring(
+                &recipient_id,
+                new_balance
+            ));
+            *out_balances_json = c_str;
+        }
+        MintResult::GroupActionWithBalance(_, _, Some(new_balance)) => {
+            let target = recipient.unwrap_or(id);
+            let c_str = unwrap_result_or_return!(single_token_balance_to_json_cstring(
+                &target,
+                new_balance
+            ));
+            *out_balances_json = c_str;
+        }
+        MintResult::HistoricalDocument(_)
+        | MintResult::GroupActionWithDocument(_, _)
+        | MintResult::GroupActionWithBalance(_, _, None) => {
+            *out_balances_json = unwrap_result_or_return!(write_empty_balances_json());
+        }
+    }
+
     PlatformWalletFFIResult::ok()
 }

--- a/packages/rs-platform-wallet-ffi/src/tokens/mint.rs
+++ b/packages/rs-platform-wallet-ffi/src/tokens/mint.rs
@@ -105,11 +105,16 @@ pub unsafe extern "C" fn platform_wallet_token_mint(
 
     // Map the proof-verified outcome to the balances JSON, mirroring the
     // burn path. A standard mint carries the recipient's new balance
-    // (`recipient` from the proof); a group-authorized mint carries the
-    // recipient's balance once the action CLOSES. The recipient defaults
-    // to the minting identity `id` when no explicit destination was given.
-    // The document variants, and a group action still awaiting
-    // co-signatures (`balance == None`), have nothing to persist.
+    // straight from the proof (`TokenBalance`), so it is always keyed
+    // correctly. A group-authorized mint, once the action CLOSES, carries
+    // only the raw balance — not the identity it belongs to — so we can
+    // only key it when the caller passed an explicit `recipient`. A
+    // `recipient == None` group mint resolves to the token's configured
+    // `newTokensDestinationIdentity` on the Rust/DPP side, an identity we
+    // do not have here; keying it under the signer would upsert the wrong
+    // local row, so we emit an empty object and let the periodic sync
+    // reconcile that holder. The document variants and an action still
+    // awaiting co-signatures (`balance == None`) likewise persist nothing.
     match mint_result {
         MintResult::TokenBalance(recipient_id, new_balance) => {
             let c_str = unwrap_result_or_return!(single_token_balance_to_json_cstring(
@@ -119,12 +124,15 @@ pub unsafe extern "C" fn platform_wallet_token_mint(
             *out_balances_json = c_str;
         }
         MintResult::GroupActionWithBalance(_, _, Some(new_balance)) => {
-            let target = recipient.unwrap_or(id);
-            let c_str = unwrap_result_or_return!(single_token_balance_to_json_cstring(
-                &target,
-                new_balance
-            ));
-            *out_balances_json = c_str;
+            if let Some(target) = recipient {
+                let c_str = unwrap_result_or_return!(single_token_balance_to_json_cstring(
+                    &target,
+                    new_balance
+                ));
+                *out_balances_json = c_str;
+            } else {
+                *out_balances_json = unwrap_result_or_return!(write_empty_balances_json());
+            }
         }
         MintResult::HistoricalDocument(_)
         | MintResult::GroupActionWithDocument(_, _)

--- a/packages/swift-sdk/Sources/SwiftDashSDK/PlatformWallet/Tokens/TokenActions.swift
+++ b/packages/swift-sdk/Sources/SwiftDashSDK/PlatformWallet/Tokens/TokenActions.swift
@@ -203,6 +203,15 @@ extension ManagedPlatformWallet {
     ///
     /// Same signing-key resolution and lifetime contract as
     /// `tokenTransfer` / `tokenBurn`.
+    ///
+    /// - Returns: The proof-verified post-mint balance the broadcast
+    ///   already carried, keyed by raw 32-byte identity id — for a
+    ///   standard mint this is the single `{ recipient: newBalance }`
+    ///   pair. A group-action proposal (or a history-tracking token)
+    ///   carries no balance in the proof result (nothing is minted until
+    ///   the group signs), so an empty map is returned. The caller
+    ///   persists these directly — no follow-up balance query is needed.
+    @discardableResult
     public func tokenMint(
         identityId: Identifier,
         contractId: Identifier,
@@ -213,7 +222,7 @@ extension ManagedPlatformWallet {
         groupAction: GroupActionMode = .none,
         signingKeyId: UInt32 = 0,
         signer: KeychainSigner
-    ) async throws {
+    ) async throws -> [Data: UInt64] {
         let handle = self.handle
         let signerHandle = signer.handle
         let identityBytes = identityId.toFFIByteArray()
@@ -221,28 +230,31 @@ extension ManagedPlatformWallet {
         let recipientBytes: [UInt8]? = recipient.map { $0.toFFIByteArray() }
         let groupTuple = groupAction.toFFITuple()
 
-        try await Task.detached(priority: .userInitiated) {
+        return try await Task.detached(priority: .userInitiated) {
             _ = signer
-            try identityBytes.withUnsafeBufferPointer { idBp in
+            return try identityBytes.withUnsafeBufferPointer { idBp in
                 try contractBytes.withUnsafeBufferPointer { contractBp in
                     try ManagedPlatformWallet.tokenWithOptionalRecipient(recipientBytes) { recipientPtr in
                         try ManagedPlatformWallet.tokenWithOptionalCString(publicNote) { notePtr in
                             try ManagedPlatformWallet.tokenWithOptionalActionId(groupTuple.actionId) { actionIdPtr in
-                                try platform_wallet_token_mint(
-                                    handle,
-                                    idBp.baseAddress!,
-                                    contractBp.baseAddress!,
-                                    tokenPosition,
-                                    recipientPtr,
-                                    amount,
-                                    notePtr,
-                                    groupTuple.kind,
-                                    groupTuple.position,
-                                    actionIdPtr,
-                                    groupTuple.actionIsProposer,
-                                    signingKeyId,
-                                    signerHandle
-                                ).check()
+                                try ManagedPlatformWallet.tokenReadingBalancesJSON { outJSON in
+                                    platform_wallet_token_mint(
+                                        handle,
+                                        idBp.baseAddress!,
+                                        contractBp.baseAddress!,
+                                        tokenPosition,
+                                        recipientPtr,
+                                        amount,
+                                        notePtr,
+                                        groupTuple.kind,
+                                        groupTuple.position,
+                                        actionIdPtr,
+                                        groupTuple.actionIsProposer,
+                                        signingKeyId,
+                                        signerHandle,
+                                        outJSON
+                                    )
+                                }
                             }
                         }
                     }

--- a/packages/swift-sdk/SwiftExampleApp/SwiftExampleApp/Views/TokenActions/CoSignProposalView.swift
+++ b/packages/swift-sdk/SwiftExampleApp/SwiftExampleApp/Views/TokenActions/CoSignProposalView.swift
@@ -396,7 +396,12 @@ struct CoSignProposalView: View {
     ) async throws {
         switch proposal.params {
         case .mint(let amount, let recipient, let note):
-            try await wallet.tokenMint(
+            // A co-signature that CLOSES the group mint returns the
+            // recipient's proof-verified post-mint balance (empty while the
+            // action is still awaiting signatures). Persist it so the
+            // closing co-signer's local row updates immediately instead of
+            // waiting for the next periodic sync.
+            let balances = try await wallet.tokenMint(
                 identityId: identityId,
                 contractId: contractId,
                 tokenPosition: tokenPosition,
@@ -405,6 +410,11 @@ struct CoSignProposalView: View {
                 publicNote: note,
                 groupAction: mode,
                 signer: signer
+            )
+            await persistCoSignedBalances(
+                balances: balances,
+                contractId: contractId,
+                tokenPosition: tokenPosition
             )
         case .burn(let amount, _, let note):
             // The burn proposal carries `burnFrom` (the account being
@@ -428,7 +438,7 @@ struct CoSignProposalView: View {
                 groupAction: mode,
                 signer: signer
             )
-            await persistCoSignedBurnBalances(
+            await persistCoSignedBalances(
                 balances: balances,
                 contractId: contractId,
                 tokenPosition: tokenPosition
@@ -500,14 +510,14 @@ struct CoSignProposalView: View {
         }
     }
 
-    /// Persist the proof-verified post-burn balance a co-signed group
-    /// burn returned into the local `PersistentTokenBalance` row (keyed by
-    /// this view's `token`). Empty when the action is still awaiting
-    /// signatures → no-op. Best-effort: a persist failure is logged and
-    /// swallowed; the periodic sync is the backstop. Mirrors
+    /// Persist the proof-verified post-action balance a co-signed group
+    /// mint / burn returned into the local `PersistentTokenBalance` row
+    /// (keyed by this view's `token`). Empty when the action is still
+    /// awaiting signatures → no-op. Best-effort: a persist failure is
+    /// logged and swallowed; the periodic sync is the backstop. Mirrors
     /// `TokenBurnActionView.persistBalanceAfterBurn`.
     @MainActor
-    private func persistCoSignedBurnBalances(
+    private func persistCoSignedBalances(
         balances: [Data: UInt64],
         contractId: Data,
         tokenPosition: UInt16
@@ -522,7 +532,7 @@ struct CoSignProposalView: View {
                 in: modelContext
             )
         } catch {
-            print("⚠️ Co-signed burn balance persist failed: \(error)")
+            print("⚠️ Co-signed balance persist failed: \(error)")
         }
     }
 

--- a/packages/swift-sdk/SwiftExampleApp/SwiftExampleApp/Views/TokenActions/TokenMintActionView.swift
+++ b/packages/swift-sdk/SwiftExampleApp/SwiftExampleApp/Views/TokenActions/TokenMintActionView.swift
@@ -16,6 +16,7 @@ struct TokenMintActionView: View {
     let identity: PersistentIdentity
 
     @EnvironmentObject var walletManager: PlatformWalletManager
+    @EnvironmentObject var appState: AppState
     @Environment(\.modelContext) private var modelContext
     @Environment(\.dismiss) private var dismiss
 
@@ -266,10 +267,20 @@ struct TokenMintActionView: View {
         let contractId = token.contractId
         let note = publicNote.trimmingCharacters(in: .whitespacesAndNewlines)
         let publicNoteOrNil: String? = note.isEmpty ? nil : note
+        // Grab the token relationship key while still on the main actor so
+        // the post-mint persist doesn't read a SwiftData model from inside
+        // the Task. (`contractId` above is already `token.contractId`.)
+        let tokenRelationshipKey = token.id
 
         Task {
             do {
-                try await wallet.tokenMint(
+                // The mint's broadcast result already carries the
+                // proof-verified post-mint balance of the recipient —
+                // persist it straight into the local row the UI observes so
+                // a mint-to-self shows up (and Transfer / Burn unlock)
+                // immediately, without waiting for the next periodic sync
+                // and with no extra round-trip.
+                let balances = try await wallet.tokenMint(
                     identityId: identityId,
                     contractId: contractId,
                     tokenPosition: position,
@@ -278,6 +289,12 @@ struct TokenMintActionView: View {
                     publicNote: publicNoteOrNil,
                     groupAction: groupAction,
                     signer: signer
+                )
+                await self.persistBalancesAfterMint(
+                    balances: balances,
+                    contractId: contractId,
+                    tokenPosition: position,
+                    tokenRelationshipKey: tokenRelationshipKey
                 )
                 await MainActor.run {
                     guard self.submitGeneration == gen else { return }
@@ -291,6 +308,37 @@ struct TokenMintActionView: View {
                     self.isSubmitting = false
                 }
             }
+        }
+    }
+
+    /// Persist the proof-verified post-mint balance the mint returned into
+    /// the local `PersistentTokenBalance` row. Keyed by the recipient the
+    /// FFI reports, so a mint-to-self updates the holder's row (and the
+    /// Transfer / Burn forms, which gate on the local balance, immediately
+    /// see it). A group-action proposal / history-tracking token returns an
+    /// empty map and nothing is written. Best-effort — any failure is
+    /// logged and swallowed; the periodic sync is the backstop.
+    ///
+    /// `@MainActor`-isolated: writes the main-context `modelContext` via the
+    /// SDK's `@MainActor` persist helper. No network round-trip.
+    @MainActor
+    private func persistBalancesAfterMint(
+        balances: [Data: UInt64],
+        contractId: Data,
+        tokenPosition: UInt16,
+        tokenRelationshipKey: Data
+    ) async {
+        guard let sdk = appState.sdk else { return }
+        do {
+            try sdk.persistProvenTokenBalances(
+                contractId: contractId,
+                tokenPosition: tokenPosition,
+                tokenRelationshipKey: tokenRelationshipKey,
+                balances: balances,
+                in: modelContext
+            )
+        } catch {
+            print("⚠️ Post-mint balance persist failed: \(error)")
         }
     }
 }

--- a/packages/swift-sdk/SwiftTests/SwiftDashSDKTests/SDKMethodTests.swift
+++ b/packages/swift-sdk/SwiftTests/SwiftDashSDKTests/SDKMethodTests.swift
@@ -41,7 +41,6 @@ final class SDKMethodTests: XCTestCase {
     // Test if we can call identityTransferCredits without crashing
     do {
       print("Attempting to call identityTransferCredits...")
-      let fromId = "test1"
       let toId = "test2"
       let amount: UInt64 = 1
       let key = Data(repeating: 0, count: 32)
@@ -74,7 +73,7 @@ final class SDKMethodTests: XCTestCase {
         dash_sdk_signer_destroy(OpaquePointer(signer))
       }
 
-      nonisolated(unsafe) let signerPtr = OpaquePointer(signer)
+      let signerPtr = OpaquePointer(signer)
       _ = try await sdk.transferCredits(
         from: identity,
         toIdentityId: toId,

--- a/packages/swift-sdk/run_tests.sh
+++ b/packages/swift-sdk/run_tests.sh
@@ -8,6 +8,36 @@ set -euo pipefail
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 cd "$SCRIPT_DIR" || exit 1
 
+# Provision an unlocked keychain for CI.
+#
+# The `WalletStorage` tests write to the login keychain via `SecItemAdd`.
+# On a headless self-hosted runner (agent connected over SSH, no Aqua GUI
+# session) that call can fail with `errAuthorizationInternal` (-60008)
+# because the Security authorization subsystem has no session to service
+# the request, which surfaces as `keychainError(-60008)` and fails the
+# suite intermittently (it only passes when the runner happens to have a
+# live GUI session).
+#
+# Create a dedicated, explicitly-unlocked, no-auto-lock keychain and make
+# it the default for the duration of the run so `SecItemAdd` targets a
+# keychain that needs no interactive authorization. Gated to CI so it
+# never touches a developer's login keychain, and the previous default is
+# restored on exit so the persistent runner is left unchanged.
+if [ -n "${CI:-}${GITHUB_ACTIONS:-}" ]; then
+  CI_KEYCHAIN="$HOME/Library/Keychains/dash-ci-tests.keychain-db"
+  PREV_DEFAULT_KEYCHAIN="$(security default-keychain -d user | sed -E 's/^[[:space:]]*"?//;s/"?[[:space:]]*$//')"
+  restore_default_keychain() {
+    if [ -n "${PREV_DEFAULT_KEYCHAIN:-}" ] && [ -e "$PREV_DEFAULT_KEYCHAIN" ]; then
+      security default-keychain -s "$PREV_DEFAULT_KEYCHAIN" || true
+    fi
+  }
+  trap restore_default_keychain EXIT
+  security create-keychain -p "" "$CI_KEYCHAIN" 2>/dev/null || true
+  security set-keychain-settings "$CI_KEYCHAIN"   # no auto-lock timeout
+  security unlock-keychain -p "" "$CI_KEYCHAIN"
+  security default-keychain -s "$CI_KEYCHAIN"
+fi
+
 # Pick a concrete iOS Simulator for the `xcodebuild test` run. A name
 # can be pinned via `SIM_NAME`; otherwise grab the first available
 SIM_NAME="${SIM_NAME:-}"


### PR DESCRIPTION
## Issue being fixed or feature implemented

Minting a token never surfaced the newly minted balance to the app, so it was never written to `PersistentTokenBalance`. Because the Transfer and Burn forms gate on the local balance, a mint-to-self left the holder unable to transfer or burn until the next periodic balance sync caught up — a chicken-and-egg lock (you can't transfer/burn to trigger the first persist).

This is the iOS counterpart of the Android fix already landed on the `feat/kotlin-sdk-and-example-app` branch (PR #3999).

## What was done?

Mirrored the burn / transfer path end-to-end. The mint proof result already carries the recipient's new balance (`MintResult::TokenBalance`), identical in shape to `BurnResult`, so the balance is marshalled straight out of the broadcast result — no separate racy balance query:

- **FFI** `platform_wallet_token_mint` gains an `out_balances_json` out-param and maps `MintResult` → balances JSON (`{"<recipientBase58>": "<newBalance>"}`), exactly as `platform_wallet_token_burn` does. History-tracking / group-proposal variants write `{}`.
- **Swift wrapper** `ManagedPlatformWallet.tokenMint` threads the out-param and returns `[Data: UInt64]` (`@discardableResult`), matching `tokenBurn` / `tokenTransfer`.
- **`TokenMintActionView`** persists via `persistProvenTokenBalances(...)` after a successful mint, keyed by the recipient the proof reports, so a mint-to-self updates the holder's row and unlocks Transfer / Burn immediately.
- **`CoSignProposalView`** generalizes `persistCoSignedBurnBalances` → `persistCoSignedBalances` and persists on a co-signed group-mint close too (it had the same latent gap).

## How Has This Been Tested?

- `cargo check -p platform-wallet-ffi` — green.
- `cargo fmt` applied.
- iOS simulator xcframework rebuilt (regenerates the cbindgen header with the new out-param) and the `SwiftExampleApp` compiled for the simulator — green.

## Breaking Changes

None. The FFI signature change is internal to this repo's own bindings (the Swift wrapper is updated in the same change); it is not a consensus-level change.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [ ] I have made corresponding changes to the documentation if needed

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Token mint operations now return proof-verified post-mint balances to the SDK caller, enabling immediate balance updates.
  * The example app now persists those returned balances right after mint completion and after group co-sign actions.

* **Bug Fixes**
  * Improved balance handling for group and history-related mint variants to prevent writing balances under an unknown destination.
  * Co-sign mint and burn now use a unified balance persistence flow for more consistent updates.

* **Tests**
  * Updated SDK method tests to match the new calling behavior and remove unused setup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->