### PR TITLE
fix(platform-wallet): deliver typed AddressNonceMismatch error across wallet, FFI, and Swift host

### DIFF
--- a/packages/rs-platform-wallet-ffi/src/error.rs
+++ b/packages/rs-platform-wallet-ffi/src/error.rs
@@ -145,6 +145,20 @@ pub enum PlatformWalletFFIResultCode {
     /// observing the transaction reconciles the outcome. The host must NOT
     /// auto-retry. Shielded sibling: [`Self::ErrorShieldedSpendUnconfirmed`].
     ErrorTransactionBroadcastUnconfirmed = 20,
+    /// Maps `PlatformWalletError::AddressNonceMismatch`. Platform rejected an
+    /// address-funds transition (shield, or identity top-up-from-addresses)
+    /// because the submitted address nonce raced Platform's expected next
+    /// value (a lagging DAPI replica stale read; consensus code 40603). Same
+    /// definitively-failed / notes-released / safe-to-retry contract as
+    /// [`Self::ErrorShieldedBroadcastFailed`] — the transition did NOT execute
+    /// and any note reservations were released (a shield reserves none) — but
+    /// as its OWN code so hosts can recognize this specific, self-healing
+    /// failure and retry: the retry re-fetches the address nonce, resolving
+    /// the mismatch without host intervention. The submitted and Platform-
+    /// expected nonce values travel in the result `message` (the typed
+    /// `Display`); they are not exposed as structured out-fields (that would
+    /// require an ABI-breaking change to `PlatformWalletFFIResult`).
+    ErrorAddressNonceMismatch = 21,
 
     NotFound = 98, // Used exclusively for all the Option that are retuned as errors
     ErrorUnknown = 99,
@@ -284,6 +298,14 @@ impl From<PlatformWalletError> for PlatformWalletFFIResult {
             // so hosts can distinguish it from a definitive rejection.
             PlatformWalletError::TransactionBroadcastUnconfirmed(..) => {
                 PlatformWalletFFIResultCode::ErrorTransactionBroadcastUnconfirmed
+            }
+            // A definitively-failed address-nonce race (this reaches the blanket
+            // impl via identity `top_up_from_addresses`, which propagates the
+            // error through `?`/`.into()`). Keep the dedicated code so the host
+            // can recognize the self-healing failure and retry; the nonce values
+            // survive in the Display message.
+            PlatformWalletError::AddressNonceMismatch { .. } => {
+                PlatformWalletFFIResultCode::ErrorAddressNonceMismatch
             }
             _ => PlatformWalletFFIResultCode::ErrorUnknown,
         };
@@ -662,6 +684,39 @@ mod tests {
             .to_string_lossy()
             .into_owned();
         assert_eq!(msg, rendered, "Display payload must survive verbatim");
+    }
+
+    /// `AddressNonceMismatch` maps to the dedicated `ErrorAddressNonceMismatch`
+    /// FFI code through the blanket `From` impl (the path identity
+    /// `top_up_from_addresses` takes via `?`/`.into()`) rather than flattening
+    /// to `ErrorUnknown`. The typed Display rendering — carrying the submitted
+    /// and expected nonce values — survives across the boundary as the message.
+    #[test]
+    fn address_nonce_mismatch_maps_to_dedicated_code() {
+        let err = PlatformWalletError::AddressNonceMismatch {
+            address: dpp::address_funds::PlatformAddress::P2pkh([7u8; 20]),
+            provided_nonce: 1,
+            expected_nonce: 2,
+        };
+        let rendered = err.to_string();
+        let result: PlatformWalletFFIResult = err.into();
+        assert_eq!(
+            result.code,
+            PlatformWalletFFIResultCode::ErrorAddressNonceMismatch,
+            "AddressNonceMismatch should map to ErrorAddressNonceMismatch (rendered: {rendered})"
+        );
+        let msg = unsafe { std::ffi::CStr::from_ptr(result.message) }
+            .to_string_lossy()
+            .into_owned();
+        assert_eq!(
+            msg, rendered,
+            "Display payload must survive the FFI boundary verbatim"
+        );
+        // The nonce values the host needs must be present in the message.
+        assert!(
+            msg.contains('1') && msg.contains('2'),
+            "nonce values must survive in the message"
+        );
     }
 
     /// Other wallet-error variants without a dedicated FFI arm still

--- a/packages/rs-platform-wallet-ffi/src/error.rs
+++ b/packages/rs-platform-wallet-ffi/src/error.rs
@@ -299,11 +299,12 @@ impl From<PlatformWalletError> for PlatformWalletFFIResult {
             PlatformWalletError::TransactionBroadcastUnconfirmed(..) => {
                 PlatformWalletFFIResultCode::ErrorTransactionBroadcastUnconfirmed
             }
-            // A definitively-failed address-nonce race (this reaches the blanket
-            // impl via identity `top_up_from_addresses`, which propagates the
-            // error through `?`/`.into()`). Keep the dedicated code so the host
-            // can recognize the self-healing failure and retry; the nonce values
-            // survive in the Display message.
+            // A definitively-failed address-nonce race (reaches the blanket impl
+            // via identity `top_up_from_addresses` → `?`/`.into()`). Exposing
+            // provided/expected nonce as structured out-fields is INTENTIONALLY
+            // out of scope: `PlatformWalletFFIResult` is by-value / ABI-frozen, so
+            // the values travel in the message string and an FFI retry re-fetches
+            // the nonce.
             PlatformWalletError::AddressNonceMismatch { .. } => {
                 PlatformWalletFFIResultCode::ErrorAddressNonceMismatch
             }
@@ -712,10 +713,15 @@ mod tests {
             msg, rendered,
             "Display payload must survive the FFI boundary verbatim"
         );
-        // The nonce values the host needs must be present in the message.
+        // Pin the EXACT rendered substrings, not bare digits, so a
+        // provided/expected transposition would fail the test.
         assert!(
-            msg.contains('1') && msg.contains('2'),
-            "nonce values must survive in the message"
+            msg.contains("submitted nonce 1"),
+            "submitted (provided) nonce must render exactly: {msg}"
+        );
+        assert!(
+            msg.contains("Platform expected 2"),
+            "expected nonce must render exactly: {msg}"
         );
     }
 

--- a/packages/rs-platform-wallet-ffi/src/shielded_send.rs
+++ b/packages/rs-platform-wallet-ffi/src/shielded_send.rs
@@ -1467,9 +1467,15 @@ mod tests {
             "shield nonce rejection must not regress to ErrorWalletOperation"
         );
         let msg = message_of(&result);
+        // Pin the EXACT rendered substrings, not bare digits, so a
+        // provided/expected transposition would fail the test.
         assert!(
-            msg.contains('1') && msg.contains('2'),
-            "nonce values must survive in the message"
+            msg.contains("submitted nonce 1"),
+            "submitted (provided) nonce must render exactly: {msg}"
+        );
+        assert!(
+            msg.contains("Platform expected 2"),
+            "expected nonce must render exactly: {msg}"
         );
     }
 }

--- a/packages/rs-platform-wallet-ffi/src/shielded_send.rs
+++ b/packages/rs-platform-wallet-ffi/src/shielded_send.rs
@@ -516,6 +516,15 @@ fn map_spend_result(
             PlatformWalletFFIResultCode::ErrorShieldedBroadcastFailed,
             format!("{operation} failed: {e}"),
         ),
+        // Definitively failed on an address-nonce race (a shield spends platform
+        // address funds; a shield reserves no notes). Its own code carries the
+        // safe-to-retry contract AND lets the host recognize the self-healing
+        // nonce mismatch — a plain retry re-fetches the nonce. Without this arm
+        // it would regress to the generic `ErrorWalletOperation` below.
+        Err(e @ PlatformWalletError::AddressNonceMismatch { .. }) => PlatformWalletFFIResult::err(
+            PlatformWalletFFIResultCode::ErrorAddressNonceMismatch,
+            format!("{operation} failed: {e}"),
+        ),
         Err(e) => PlatformWalletFFIResult::err(
             PlatformWalletFFIResultCode::ErrorWalletOperation,
             format!("{operation} failed: {e}"),
@@ -1436,6 +1445,31 @@ mod tests {
         assert_eq!(
             map_spend_result(Ok(()), "shielded transfer").code,
             PlatformWalletFFIResultCode::Success
+        );
+    }
+
+    /// A shield (Type 15) definitively rejected on an address-nonce race must
+    /// map to the dedicated `ErrorAddressNonceMismatch` — NOT regress to the
+    /// generic `ErrorWalletOperation` — so hosts keep the safe-to-retry signal.
+    /// The submitted/expected nonce values must survive in the message.
+    #[test]
+    fn map_spend_result_maps_address_nonce_mismatch_to_dedicated_code() {
+        let mismatch: Result<(), PlatformWalletError> =
+            Err(PlatformWalletError::AddressNonceMismatch {
+                address: PlatformAddress::P2pkh([7u8; 20]),
+                provided_nonce: 1,
+                expected_nonce: 2,
+            });
+        let result = map_spend_result(mismatch, "shielded shield");
+        assert_eq!(
+            result.code,
+            PlatformWalletFFIResultCode::ErrorAddressNonceMismatch,
+            "shield nonce rejection must not regress to ErrorWalletOperation"
+        );
+        let msg = message_of(&result);
+        assert!(
+            msg.contains('1') && msg.contains('2'),
+            "nonce values must survive in the message"
         );
     }
 }

--- a/packages/rs-platform-wallet/src/error.rs
+++ b/packages/rs-platform-wallet/src/error.rs
@@ -104,15 +104,11 @@ pub enum PlatformWalletError {
     #[error("SDK error: {0}")]
     Sdk(#[from] dash_sdk::Error),
 
-    /// Platform rejected an address-funds transition because a spent
-    /// address's provided nonce did not equal Platform's expected next value
-    /// (DPP consensus code 40603, `AddressInvalidNonceError`): the optimistic
-    /// `fetched + 1` nonce raced a lagging DAPI replica's stale read.
-    ///
-    /// The rejection is by design — the address-nonce path is optimistic and
-    /// the caller owns the retry. This variant delivers Platform's
-    /// `expected_nonce` verbatim so the caller can rebuild the transition with
-    /// it (no re-fetch needed) instead of parsing a flattened string.
+    /// Platform rejected an address-funds transition because a spent address's
+    /// provided nonce did not equal its expected next value (DPP consensus code
+    /// 40603, `AddressInvalidNonceError`) — an optimistic `fetched + 1` nonce
+    /// racing a lagging replica read. Carries Platform's `expected_nonce`
+    /// verbatim so the caller can rebuild and retry without re-fetching.
     #[error(
         "Address nonce mismatch for {address}: submitted nonce {provided_nonce}, \
          Platform expected {expected_nonce}; retry the operation with the \
@@ -420,24 +416,15 @@ pub fn as_asset_lock_proof_cl_height_too_low(
     }
 }
 
-/// Extract the `AddressInvalidNonceError` (DPP consensus code 40603) from an
-/// SDK error if Platform rejected an address-funds transition because a spent
-/// address's provided nonce did not equal its expected next value.
+/// Extract the `AddressInvalidNonceError` (DPP consensus code 40603) when
+/// Platform rejected an address-funds transition on a stale nonce, exposing
+/// `address()`, `provided_nonce()`, and `expected_nonce()` so the caller can
+/// retry with the expected value; `None` otherwise.
 ///
-/// Returns `Some(&error)` for both `dash_sdk::Error` shapes that carry a
-/// consensus verdict — `StateTransitionBroadcastError` (wait-stream rejection)
-/// and `Protocol(ProtocolError::ConsensusError)` (CheckTx rejection) —
-/// exposing `address()`, `provided_nonce()`, and `expected_nonce()`. Returns
-/// `None` for everything else.
-///
-/// The address-nonce path is optimistic by design: the client submits
-/// `fetched + 1` and Platform rejects a stale/replayed value under a lagging
-/// replica read. This extractor lets a caller recover `expected_nonce` and
-/// retry per that contract. Recurses through
-/// [`dash_sdk::Error::NoAvailableAddressesToRetry`] so it stays in lockstep
-/// with its sibling `broadcast_definitely_failed`; re-audit if a future
-/// `dash_sdk::Error` variant starts carrying consensus errors through yet
-/// another shape.
+/// Matches the three `dash_sdk::Error` shapes that can carry a consensus
+/// verdict — `StateTransitionBroadcastError` (wait-stream), `Protocol(
+/// ConsensusError)` (CheckTx), and a `NoAvailableAddressesToRetry` envelope it
+/// recurses into — staying in lockstep with `broadcast_definitely_failed`.
 pub fn as_address_invalid_nonce(error: &dash_sdk::Error) -> Option<&AddressInvalidNonceError> {
     use dpp::consensus::state::state_error::StateError;
     use dpp::consensus::ConsensusError;
@@ -447,9 +434,7 @@ pub fn as_address_invalid_nonce(error: &dash_sdk::Error) -> Option<&AddressInval
             broadcast_err.cause.as_ref()
         }
         dash_sdk::Error::Protocol(dpp::ProtocolError::ConsensusError(ce)) => Some(ce.as_ref()),
-        // A consensus rejection can arrive wrapped when the dapi-client
-        // exhausted every address mid-retry; recurse so this predicate stays
-        // in lockstep with `broadcast_definitely_failed`.
+        // Unwrap the dapi-client's exhausted-retry envelope.
         dash_sdk::Error::NoAvailableAddressesToRetry(inner) => {
             return as_address_invalid_nonce(inner)
         }
@@ -476,15 +461,11 @@ pub fn promote_address_nonce_error(error: &dash_sdk::Error) -> Option<PlatformWa
     })
 }
 
-/// Map an SDK error from an address-funded transition (transfer / withdrawal) to
-/// a [`PlatformWalletError`], promoting a nonce rejection to the typed
-/// [`PlatformWalletError::AddressNonceMismatch`] and otherwise preserving the
-/// original error under [`PlatformWalletError::Sdk`].
-///
-/// This is the shared owned-error analogue of [`promote_address_nonce_error`]
-/// for the `.map_err(...)?` sites that fall back to `Sdk` — the transfer and
-/// withdrawal call sites — so a nonce mismatch reaches the caller as a typed,
-/// retryable variant instead of a flattened `Sdk` string.
+/// Map an address-funded transition's SDK error to a [`PlatformWalletError`],
+/// promoting a nonce rejection to the typed
+/// [`PlatformWalletError::AddressNonceMismatch`] and otherwise preserving it
+/// under [`PlatformWalletError::Sdk`]. Owned-error `.map_err(...)?` analogue of
+/// [`promote_address_nonce_error`] for the transfer / withdrawal call sites.
 pub fn promote_address_nonce_error_or_sdk(error: dash_sdk::Error) -> PlatformWalletError {
     promote_address_nonce_error(&error).unwrap_or(PlatformWalletError::Sdk(error))
 }

--- a/packages/rs-platform-wallet/src/error.rs
+++ b/packages/rs-platform-wallet/src/error.rs
@@ -1,6 +1,8 @@
 use dpp::address_funds::PlatformAddress;
+use dpp::consensus::state::address_funds::AddressInvalidNonceError;
 use dpp::fee::Credits;
 use dpp::identifier::Identifier;
+use dpp::prelude::AddressNonce;
 use key_wallet::account::StandardAccountType;
 use key_wallet::Network;
 
@@ -101,6 +103,26 @@ pub enum PlatformWalletError {
 
     #[error("SDK error: {0}")]
     Sdk(#[from] dash_sdk::Error),
+
+    /// Platform rejected an address-funds transition because a spent
+    /// address's provided nonce did not equal Platform's expected next value
+    /// (DPP consensus code 40603, `AddressInvalidNonceError`): the optimistic
+    /// `fetched + 1` nonce raced a lagging DAPI replica's stale read.
+    ///
+    /// The rejection is by design — the address-nonce path is optimistic and
+    /// the caller owns the retry. This variant delivers Platform's
+    /// `expected_nonce` verbatim so the caller can rebuild the transition with
+    /// it (no re-fetch needed) instead of parsing a flattened string.
+    #[error(
+        "Address nonce mismatch for {address}: submitted nonce {provided_nonce}, \
+         Platform expected {expected_nonce}; retry the operation with the \
+         expected nonce"
+    )]
+    AddressNonceMismatch {
+        address: PlatformAddress,
+        provided_nonce: AddressNonce,
+        expected_nonce: AddressNonce,
+    },
 
     #[error("Address sync failed: {0}")]
     AddressSync(String),
@@ -395,5 +417,146 @@ pub fn as_asset_lock_proof_cl_height_too_low(
             BasicError::InvalidAssetLockProofCoreChainHeightError(e),
         )) => Some(e),
         _ => None,
+    }
+}
+
+/// Extract the `AddressInvalidNonceError` (DPP consensus code 40603) from an
+/// SDK error if Platform rejected an address-funds transition because a spent
+/// address's provided nonce did not equal its expected next value.
+///
+/// Returns `Some(&error)` for both `dash_sdk::Error` shapes that carry a
+/// consensus verdict — `StateTransitionBroadcastError` (wait-stream rejection)
+/// and `Protocol(ProtocolError::ConsensusError)` (CheckTx rejection) —
+/// exposing `address()`, `provided_nonce()`, and `expected_nonce()`. Returns
+/// `None` for everything else.
+///
+/// The address-nonce path is optimistic by design: the client submits
+/// `fetched + 1` and Platform rejects a stale/replayed value under a lagging
+/// replica read. This extractor lets a caller recover `expected_nonce` and
+/// retry per that contract. Mirrors [`as_asset_lock_proof_cl_height_too_low`];
+/// the same coverage caveat applies — re-audit if a future `dash_sdk::Error`
+/// variant starts carrying consensus errors through a different shape.
+pub fn as_address_invalid_nonce(error: &dash_sdk::Error) -> Option<&AddressInvalidNonceError> {
+    use dpp::consensus::state::state_error::StateError;
+    use dpp::consensus::ConsensusError;
+
+    let consensus_error = match error {
+        dash_sdk::Error::StateTransitionBroadcastError(broadcast_err) => {
+            broadcast_err.cause.as_ref()
+        }
+        dash_sdk::Error::Protocol(dpp::ProtocolError::ConsensusError(ce)) => Some(ce.as_ref()),
+        _ => None,
+    };
+    match consensus_error {
+        Some(ConsensusError::StateError(StateError::AddressInvalidNonceError(e))) => Some(e),
+        _ => None,
+    }
+}
+
+/// Promote a nonce-rejection SDK error to the typed
+/// [`PlatformWalletError::AddressNonceMismatch`] so callers can recover
+/// `expected_nonce` and retry, instead of receiving the rejection flattened
+/// to a string.
+///
+/// Returns `None` for any error [`as_address_invalid_nonce`] does not match,
+/// leaving the caller free to keep its existing fallback mapping.
+pub fn promote_address_nonce_error(error: &dash_sdk::Error) -> Option<PlatformWalletError> {
+    as_address_invalid_nonce(error).map(|e| PlatformWalletError::AddressNonceMismatch {
+        address: *e.address(),
+        provided_nonce: e.provided_nonce(),
+        expected_nonce: e.expected_nonce(),
+    })
+}
+
+#[cfg(test)]
+mod address_nonce_tests {
+    use super::*;
+    use dash_sdk::error::StateTransitionBroadcastError;
+
+    const ADDR_BYTES: [u8; 20] = [7u8; 20];
+
+    /// An `AddressInvalidNonceError` wrapped as a `ConsensusError`, plus the
+    /// address it names, for asserting round-trip field fidelity.
+    fn nonce_consensus_error(
+        provided: AddressNonce,
+        expected: AddressNonce,
+    ) -> (PlatformAddress, dpp::consensus::ConsensusError) {
+        let address = PlatformAddress::P2pkh(ADDR_BYTES);
+        let err = AddressInvalidNonceError::new(address, provided, expected);
+        (address, err.into())
+    }
+
+    /// `Protocol(ConsensusError)` — the CheckTx-rejection shape.
+    fn protocol_shape(provided: AddressNonce, expected: AddressNonce) -> dash_sdk::Error {
+        let (_, cause) = nonce_consensus_error(provided, expected);
+        dash_sdk::Error::Protocol(dpp::ProtocolError::ConsensusError(Box::new(cause)))
+    }
+
+    /// `StateTransitionBroadcastError` — the wait-stream-rejection shape.
+    fn broadcast_shape(provided: AddressNonce, expected: AddressNonce) -> dash_sdk::Error {
+        let (_, cause) = nonce_consensus_error(provided, expected);
+        dash_sdk::Error::StateTransitionBroadcastError(StateTransitionBroadcastError {
+            code: 40603,
+            message: "invalid address nonce".to_string(),
+            cause: Some(cause),
+        })
+    }
+
+    #[test]
+    fn extracts_nonce_error_from_protocol_shape() {
+        let err = protocol_shape(1, 2);
+        let got = as_address_invalid_nonce(&err).expect("protocol shape must match");
+        assert_eq!(*got.address(), PlatformAddress::P2pkh(ADDR_BYTES));
+        assert_eq!(got.provided_nonce(), 1);
+        assert_eq!(got.expected_nonce(), 2);
+    }
+
+    #[test]
+    fn extracts_nonce_error_from_broadcast_shape() {
+        let err = broadcast_shape(5, 6);
+        let got = as_address_invalid_nonce(&err).expect("broadcast shape must match");
+        assert_eq!(*got.address(), PlatformAddress::P2pkh(ADDR_BYTES));
+        assert_eq!(got.provided_nonce(), 5);
+        assert_eq!(got.expected_nonce(), 6);
+    }
+
+    #[test]
+    fn ignores_unrelated_and_causeless_errors() {
+        // A plainly unrelated SDK error.
+        assert!(as_address_invalid_nonce(&dash_sdk::Error::Generic("boom".to_string())).is_none());
+        // The DAPI wait-timeout shape: a broadcast error with no consensus
+        // cause must NOT be misread as a nonce rejection.
+        let causeless =
+            dash_sdk::Error::StateTransitionBroadcastError(StateTransitionBroadcastError {
+                code: 0,
+                message: "timeout".to_string(),
+                cause: None,
+            });
+        assert!(as_address_invalid_nonce(&causeless).is_none());
+    }
+
+    #[test]
+    fn promotes_both_shapes_to_typed_variant() {
+        for err in [protocol_shape(1, 2), broadcast_shape(1, 2)] {
+            match promote_address_nonce_error(&err) {
+                Some(PlatformWalletError::AddressNonceMismatch {
+                    address,
+                    provided_nonce,
+                    expected_nonce,
+                }) => {
+                    assert_eq!(address, PlatformAddress::P2pkh(ADDR_BYTES));
+                    assert_eq!(provided_nonce, 1);
+                    assert_eq!(expected_nonce, 2);
+                }
+                other => panic!("expected AddressNonceMismatch, got {other:?}"),
+            }
+        }
+    }
+
+    #[test]
+    fn promotion_leaves_unrelated_errors_for_the_fallback() {
+        assert!(
+            promote_address_nonce_error(&dash_sdk::Error::Generic("boom".to_string())).is_none()
+        );
     }
 }

--- a/packages/rs-platform-wallet/src/error.rs
+++ b/packages/rs-platform-wallet/src/error.rs
@@ -476,6 +476,19 @@ pub fn promote_address_nonce_error(error: &dash_sdk::Error) -> Option<PlatformWa
     })
 }
 
+/// Map an SDK error from an address-funded transition (transfer / withdrawal) to
+/// a [`PlatformWalletError`], promoting a nonce rejection to the typed
+/// [`PlatformWalletError::AddressNonceMismatch`] and otherwise preserving the
+/// original error under [`PlatformWalletError::Sdk`].
+///
+/// This is the shared owned-error analogue of [`promote_address_nonce_error`]
+/// for the `.map_err(...)?` sites that fall back to `Sdk` — the transfer and
+/// withdrawal call sites — so a nonce mismatch reaches the caller as a typed,
+/// retryable variant instead of a flattened `Sdk` string.
+pub fn promote_address_nonce_error_or_sdk(error: dash_sdk::Error) -> PlatformWalletError {
+    promote_address_nonce_error(&error).unwrap_or(PlatformWalletError::Sdk(error))
+}
+
 #[cfg(test)]
 mod address_nonce_tests {
     use super::*;
@@ -566,6 +579,55 @@ mod address_nonce_tests {
         assert!(
             promote_address_nonce_error(&dash_sdk::Error::Generic("boom".to_string())).is_none()
         );
+    }
+
+    #[test]
+    fn promote_or_sdk_promotes_a_matching_nonce_error() {
+        // The transfer / withdrawal call sites route their SDK error through
+        // this helper; a nonce rejection must surface as the typed variant.
+        for err in [protocol_shape(3, 4), broadcast_shape(3, 4)] {
+            match promote_address_nonce_error_or_sdk(err) {
+                PlatformWalletError::AddressNonceMismatch {
+                    address,
+                    provided_nonce,
+                    expected_nonce,
+                } => {
+                    assert_eq!(address, PlatformAddress::P2pkh(ADDR_BYTES));
+                    assert_eq!(provided_nonce, 3);
+                    assert_eq!(expected_nonce, 4);
+                }
+                other => panic!("expected AddressNonceMismatch, got {other:?}"),
+            }
+        }
+    }
+
+    #[test]
+    fn promote_or_sdk_falls_back_to_sdk_for_unrelated_errors() {
+        // A non-nonce error must be preserved verbatim under `Sdk`, not
+        // flattened — this is the fallback the transfer / withdrawal sites keep.
+        match promote_address_nonce_error_or_sdk(dash_sdk::Error::Generic("boom".to_string())) {
+            PlatformWalletError::Sdk(dash_sdk::Error::Generic(msg)) => assert_eq!(msg, "boom"),
+            other => panic!("expected Sdk(Generic), got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn promote_or_sdk_promotes_through_the_retry_envelope() {
+        // A nonce rejection wrapped in the dapi-client's retry envelope must
+        // still promote (the helper recurses via `as_address_invalid_nonce`).
+        let wrapped =
+            dash_sdk::Error::NoAvailableAddressesToRetry(Box::new(protocol_shape(11, 12)));
+        match promote_address_nonce_error_or_sdk(wrapped) {
+            PlatformWalletError::AddressNonceMismatch {
+                provided_nonce,
+                expected_nonce,
+                ..
+            } => {
+                assert_eq!(provided_nonce, 11);
+                assert_eq!(expected_nonce, 12);
+            }
+            other => panic!("expected AddressNonceMismatch, got {other:?}"),
+        }
     }
 
     #[test]

--- a/packages/rs-platform-wallet/src/error.rs
+++ b/packages/rs-platform-wallet/src/error.rs
@@ -433,9 +433,11 @@ pub fn as_asset_lock_proof_cl_height_too_low(
 /// The address-nonce path is optimistic by design: the client submits
 /// `fetched + 1` and Platform rejects a stale/replayed value under a lagging
 /// replica read. This extractor lets a caller recover `expected_nonce` and
-/// retry per that contract. Mirrors [`as_asset_lock_proof_cl_height_too_low`];
-/// the same coverage caveat applies — re-audit if a future `dash_sdk::Error`
-/// variant starts carrying consensus errors through a different shape.
+/// retry per that contract. Recurses through
+/// [`dash_sdk::Error::NoAvailableAddressesToRetry`] so it stays in lockstep
+/// with its sibling `broadcast_definitely_failed`; re-audit if a future
+/// `dash_sdk::Error` variant starts carrying consensus errors through yet
+/// another shape.
 pub fn as_address_invalid_nonce(error: &dash_sdk::Error) -> Option<&AddressInvalidNonceError> {
     use dpp::consensus::state::state_error::StateError;
     use dpp::consensus::ConsensusError;
@@ -445,6 +447,12 @@ pub fn as_address_invalid_nonce(error: &dash_sdk::Error) -> Option<&AddressInval
             broadcast_err.cause.as_ref()
         }
         dash_sdk::Error::Protocol(dpp::ProtocolError::ConsensusError(ce)) => Some(ce.as_ref()),
+        // A consensus rejection can arrive wrapped when the dapi-client
+        // exhausted every address mid-retry; recurse so this predicate stays
+        // in lockstep with `broadcast_definitely_failed`.
+        dash_sdk::Error::NoAvailableAddressesToRetry(inner) => {
+            return as_address_invalid_nonce(inner)
+        }
         _ => None,
     };
     match consensus_error {
@@ -558,5 +566,17 @@ mod address_nonce_tests {
         assert!(
             promote_address_nonce_error(&dash_sdk::Error::Generic("boom".to_string())).is_none()
         );
+    }
+
+    #[test]
+    fn extracts_nonce_error_wrapped_in_no_available_addresses_to_retry() {
+        // The dapi-client wraps the last rejection in `NoAvailableAddressesToRetry`
+        // when every address is exhausted mid-retry; the extractor must recurse
+        // into it (lockstep with `broadcast_definitely_failed`).
+        let inner = Box::new(protocol_shape(9, 10));
+        let wrapped = dash_sdk::Error::NoAvailableAddressesToRetry(inner);
+        let got = as_address_invalid_nonce(&wrapped).expect("must unwrap the retry envelope");
+        assert_eq!(got.provided_nonce(), 9);
+        assert_eq!(got.expected_nonce(), 10);
     }
 }

--- a/packages/rs-platform-wallet/src/wallet/identity/network/register_from_addresses.rs
+++ b/packages/rs-platform-wallet/src/wallet/identity/network/register_from_addresses.rs
@@ -108,10 +108,12 @@ impl IdentityWallet {
             )
             .await
             .map_err(|e| {
-                PlatformWalletError::InvalidIdentityData(format!(
-                    "Failed to register identity from addresses: {}",
-                    e
-                ))
+                crate::error::promote_address_nonce_error(&e).unwrap_or_else(|| {
+                    PlatformWalletError::InvalidIdentityData(format!(
+                        "Failed to register identity from addresses: {}",
+                        e
+                    ))
+                })
             })?;
 
         // The SDK return path for `put_with_address_funding_fetching_nonces`

--- a/packages/rs-platform-wallet/src/wallet/identity/network/top_up_from_addresses.rs
+++ b/packages/rs-platform-wallet/src/wallet/identity/network/top_up_from_addresses.rs
@@ -76,10 +76,12 @@ impl IdentityWallet {
             .top_up_from_addresses(&self.sdk, inputs, address_signer, settings)
             .await
             .map_err(|e| {
-                PlatformWalletError::InvalidIdentityData(format!(
-                    "Failed to top up identity from addresses: {}",
-                    e
-                ))
+                crate::error::promote_address_nonce_error(&e).unwrap_or_else(|| {
+                    PlatformWalletError::InvalidIdentityData(format!(
+                        "Failed to top up identity from addresses: {}",
+                        e
+                    ))
+                })
             })?;
 
         // Update the identity's balance in the local manager and

--- a/packages/rs-platform-wallet/src/wallet/platform_addresses/transfer.rs
+++ b/packages/rs-platform-wallet/src/wallet/platform_addresses/transfer.rs
@@ -7,6 +7,7 @@ use dpp::state_transition::address_funds_transfer_transition::AddressFundsTransf
 use dpp::version::PlatformVersion;
 use key_wallet::PlatformP2PKHAddress;
 
+use crate::error::promote_address_nonce_error_or_sdk;
 use crate::wallet::PlatformAddressWallet;
 use crate::{PlatformAddressChangeSet, PlatformWalletError};
 use dash_sdk::platform::transition::transfer_address_funds::TransferAddressFunds;
@@ -227,7 +228,8 @@ impl PlatformAddressWallet {
                 }
                 self.sdk
                     .transfer_address_funds(inputs, outputs, fee_strategy, address_signer, None)
-                    .await?
+                    .await
+                    .map_err(promote_address_nonce_error_or_sdk)?
             }
             InputSelection::ExplicitWithNonces(inputs) => {
                 if inputs.is_empty() {
@@ -243,7 +245,8 @@ impl PlatformAddressWallet {
                         address_signer,
                         None,
                     )
-                    .await?
+                    .await
+                    .map_err(promote_address_nonce_error_or_sdk)?
             }
             InputSelection::Auto => {
                 // Auto-select supports `[DeductFromInput(0)]` and `[ReduceOutput(0)]`;
@@ -264,7 +267,8 @@ impl PlatformAddressWallet {
                     .await?;
                 self.sdk
                     .transfer_address_funds(inputs, outputs, fee_strategy, address_signer, None)
-                    .await?
+                    .await
+                    .map_err(promote_address_nonce_error_or_sdk)?
             }
         };
 

--- a/packages/rs-platform-wallet/src/wallet/platform_addresses/withdrawal.rs
+++ b/packages/rs-platform-wallet/src/wallet/platform_addresses/withdrawal.rs
@@ -10,6 +10,7 @@ use dpp::withdrawal::Pooling;
 use key_wallet::PlatformP2PKHAddress;
 
 use super::InputSelection;
+use crate::error::promote_address_nonce_error_or_sdk;
 use crate::wallet::PlatformAddressWallet;
 use crate::{PlatformAddressChangeSet, PlatformWalletError};
 use dash_sdk::platform::transition::address_credit_withdrawal::WithdrawAddressFunds;
@@ -133,7 +134,8 @@ impl PlatformAddressWallet {
                         address_signer,
                         None,
                     )
-                    .await?
+                    .await
+                    .map_err(promote_address_nonce_error_or_sdk)?
             }
             InputSelection::ExplicitWithNonces(inputs) => {
                 if inputs.is_empty() {
@@ -152,7 +154,8 @@ impl PlatformAddressWallet {
                         address_signer,
                         None,
                     )
-                    .await?
+                    .await
+                    .map_err(promote_address_nonce_error_or_sdk)?
             }
             InputSelection::Auto => {
                 // The AUTO path owns its own fee strategy: it picks the
@@ -183,7 +186,8 @@ impl PlatformAddressWallet {
                         address_signer,
                         None,
                     )
-                    .await?
+                    .await
+                    .map_err(promote_address_nonce_error_or_sdk)?
             }
         };
 

--- a/packages/rs-platform-wallet/src/wallet/shielded/operations.rs
+++ b/packages/rs-platform-wallet/src/wallet/shielded/operations.rs
@@ -2287,9 +2287,8 @@ pub(super) async fn redrive_pending_spends<S: ShieldedStore>(
 ///   non-empty consensus `data` — the wait-stream error envelope for a
 ///   transition Platform executed and rejected on its merits.
 ///
-/// Recurses through a `NoAvailableAddressesToRetry` envelope (in lockstep with
-/// [`crate::error::as_address_invalid_nonce`]) so a wrapped nonce rejection is
-/// promoted rather than bucketed as `ShieldedSpendUnconfirmed`.
+/// Recurses through a `NoAvailableAddressesToRetry` envelope, mirroring
+/// [`crate::error::as_address_invalid_nonce`].
 ///
 /// Only these prove the transition was evaluated and REJECTED. Everything
 /// else — transport errors, timeouts, `AlreadyExists` (which proves the

--- a/packages/rs-platform-wallet/src/wallet/shielded/operations.rs
+++ b/packages/rs-platform-wallet/src/wallet/shielded/operations.rs
@@ -556,7 +556,8 @@ pub async fn shield<S: ShieldedStore, Sig: Signer<PlatformAddress>, P: OrchardPr
                 format_addresses_with_info(rich.addresses_with_info(), network),
             ))
         } else {
-            PlatformWalletError::ShieldedBroadcastFailed(e.to_string())
+            crate::error::promote_address_nonce_error(e)
+                .unwrap_or_else(|| PlatformWalletError::ShieldedBroadcastFailed(e.to_string()))
         }
     };
 
@@ -2335,7 +2336,8 @@ async fn broadcast_shielded_spend(
     match state_transition.broadcast(sdk, None).await {
         Ok(()) => {}
         Err(e) if broadcast_definitely_failed(&e) => {
-            return Err(PlatformWalletError::ShieldedBroadcastFailed(e.to_string()));
+            return Err(crate::error::promote_address_nonce_error(&e)
+                .unwrap_or_else(|| PlatformWalletError::ShieldedBroadcastFailed(e.to_string())));
         }
         Err(e) => {
             warn!(
@@ -2443,7 +2445,8 @@ fn classify_spend_wait_failure(
     wait_err: &dash_sdk::Error,
 ) -> PlatformWalletError {
     if carries_consensus_rejection(wait_err) {
-        PlatformWalletError::ShieldedBroadcastFailed(wait_err.to_string())
+        crate::error::promote_address_nonce_error(wait_err)
+            .unwrap_or_else(|| PlatformWalletError::ShieldedBroadcastFailed(wait_err.to_string()))
     } else {
         warn!(
             operation,

--- a/packages/rs-platform-wallet/src/wallet/shielded/operations.rs
+++ b/packages/rs-platform-wallet/src/wallet/shielded/operations.rs
@@ -2287,6 +2287,15 @@ pub(super) async fn redrive_pending_spends<S: ShieldedStore>(
 ///   non-empty consensus `data` — the wait-stream error envelope for a
 ///   transition Platform executed and rejected on its merits.
 ///
+/// A consensus verdict can also arrive wrapped in
+/// [`dash_sdk::Error::NoAvailableAddressesToRetry`] when the dapi-client
+/// exhausted every address mid-retry, so this recurses through it — keeping
+/// the predicate in lockstep with [`crate::error::as_address_invalid_nonce`],
+/// which unwraps the same envelope. Without it a nonce rejection carried in a
+/// retry envelope would fall through to the ambiguous
+/// [`PlatformWalletError::ShieldedSpendUnconfirmed`] bucket instead of being
+/// promoted to [`PlatformWalletError::AddressNonceMismatch`].
+///
 /// Only these prove the transition was evaluated and REJECTED. Everything
 /// else — transport errors, timeouts, `AlreadyExists` (which proves the
 /// opposite: the transition is already in the mempool or on chain),
@@ -2296,6 +2305,7 @@ fn carries_consensus_rejection(err: &dash_sdk::Error) -> bool {
     match err {
         dash_sdk::Error::Protocol(dpp::ProtocolError::ConsensusError(_)) => true,
         dash_sdk::Error::StateTransitionBroadcastError(e) => e.cause.is_some(),
+        dash_sdk::Error::NoAvailableAddressesToRetry(inner) => carries_consensus_rejection(inner),
         _ => false,
     }
 }
@@ -2812,6 +2822,57 @@ mod classify_spend_wait_failure_tests {
         assert!(!broadcast_definitely_failed(
             &dash_sdk::Error::AlreadyExists("state transition already in mempool".to_string())
         ));
+    }
+
+    /// A consensus verdict wrapped in the dapi-client's `NoAvailableAddressesToRetry`
+    /// retry envelope must still count as a rejection — `carries_consensus_rejection`
+    /// recurses through the envelope, in lockstep with `as_address_invalid_nonce`.
+    #[test]
+    fn wrapped_consensus_rejection_is_a_rejection() {
+        let wrapped =
+            dash_sdk::Error::NoAvailableAddressesToRetry(Box::new(consensus_metadata_rejection()));
+        assert!(carries_consensus_rejection(&wrapped));
+    }
+
+    /// A transport error wrapped in the retry envelope carries no consensus
+    /// verdict, so it remains ambiguous — the recursion must not misread it.
+    #[test]
+    fn wrapped_transport_error_is_not_a_rejection() {
+        use dash_sdk::dapi_grpc::tonic::Code;
+        let wrapped = dash_sdk::Error::NoAvailableAddressesToRetry(Box::new(grpc_err(
+            Code::DeadlineExceeded,
+        )));
+        assert!(!carries_consensus_rejection(&wrapped));
+    }
+
+    /// A nonce rejection wrapped in the retry envelope must reach
+    /// `promote_address_nonce_error` and surface as the typed
+    /// `AddressNonceMismatch`, not fall through to `ShieldedSpendUnconfirmed`.
+    #[test]
+    fn wrapped_nonce_rejection_promotes_to_typed_mismatch() {
+        use dpp::address_funds::PlatformAddress;
+        use dpp::consensus::state::address_funds::AddressInvalidNonceError;
+        use dpp::consensus::state::state_error::StateError;
+
+        let address = PlatformAddress::P2pkh([9u8; 20]);
+        let cause = ConsensusError::StateError(StateError::AddressInvalidNonceError(
+            AddressInvalidNonceError::new(address, 7, 8),
+        ));
+        let inner = dash_sdk::Error::Protocol(dpp::ProtocolError::ConsensusError(Box::new(cause)));
+        let wrapped = dash_sdk::Error::NoAvailableAddressesToRetry(Box::new(inner));
+
+        match classify_spend_wait_failure("withdraw", &wrapped) {
+            PlatformWalletError::AddressNonceMismatch {
+                address: got,
+                provided_nonce,
+                expected_nonce,
+            } => {
+                assert_eq!(got, address);
+                assert_eq!(provided_nonce, 7);
+                assert_eq!(expected_nonce, 8);
+            }
+            other => panic!("expected AddressNonceMismatch, got {other:?}"),
+        }
     }
 }
 

--- a/packages/rs-platform-wallet/src/wallet/shielded/operations.rs
+++ b/packages/rs-platform-wallet/src/wallet/shielded/operations.rs
@@ -2287,14 +2287,9 @@ pub(super) async fn redrive_pending_spends<S: ShieldedStore>(
 ///   non-empty consensus `data` — the wait-stream error envelope for a
 ///   transition Platform executed and rejected on its merits.
 ///
-/// A consensus verdict can also arrive wrapped in
-/// [`dash_sdk::Error::NoAvailableAddressesToRetry`] when the dapi-client
-/// exhausted every address mid-retry, so this recurses through it — keeping
-/// the predicate in lockstep with [`crate::error::as_address_invalid_nonce`],
-/// which unwraps the same envelope. Without it a nonce rejection carried in a
-/// retry envelope would fall through to the ambiguous
-/// [`PlatformWalletError::ShieldedSpendUnconfirmed`] bucket instead of being
-/// promoted to [`PlatformWalletError::AddressNonceMismatch`].
+/// Recurses through a `NoAvailableAddressesToRetry` envelope (in lockstep with
+/// [`crate::error::as_address_invalid_nonce`]) so a wrapped nonce rejection is
+/// promoted rather than bucketed as `ShieldedSpendUnconfirmed`.
 ///
 /// Only these prove the transition was evaluated and REJECTED. Everything
 /// else — transport errors, timeouts, `AlreadyExists` (which proves the

--- a/packages/swift-sdk/Sources/SwiftDashSDK/PlatformWallet/PlatformWalletResult.swift
+++ b/packages/swift-sdk/Sources/SwiftDashSDK/PlatformWallet/PlatformWalletResult.swift
@@ -53,6 +53,14 @@ public enum PlatformWalletResultCode: Int32, Sendable {
     /// of double-spending; the reservation TTL or a sync reconciles the
     /// outcome. Do NOT auto-retry.
     case errorTransactionBroadcastUnconfirmed = 20
+    /// Definitively-failed address-nonce race: Platform rejected an
+    /// address-funds transition (shield, or identity top-up-from-addresses)
+    /// because the submitted address nonce raced Platform's expected value
+    /// (a lagging DAPI replica read). The transition did NOT execute and any
+    /// notes were released (a shield reserves none) — safe to retry; the retry
+    /// re-fetches the nonce and self-heals. The submitted/expected nonce values
+    /// travel in the message string, not as structured fields.
+    case errorAddressNonceMismatch = 21
     case notFound = 98
     case errorUnknown = 99
 
@@ -100,6 +108,8 @@ public enum PlatformWalletResultCode: Int32, Sendable {
             self = .errorShieldedNoRecordedAnchor
         case PLATFORM_WALLET_FFI_RESULT_CODE_ERROR_TRANSACTION_BROADCAST_UNCONFIRMED:
             self = .errorTransactionBroadcastUnconfirmed
+        case PLATFORM_WALLET_FFI_RESULT_CODE_ERROR_ADDRESS_NONCE_MISMATCH:
+            self = .errorAddressNonceMismatch
         case PLATFORM_WALLET_FFI_RESULT_CODE_NOT_FOUND:
             self = .notFound
         case PLATFORM_WALLET_FFI_RESULT_CODE_ERROR_UNKNOWN:
@@ -208,6 +218,13 @@ public enum PlatformWalletError: LocalizedError {
     /// reservation TTL or a later sync reconciles the outcome. Do NOT
     /// auto-retry. Core sibling of `shieldedSpendUnconfirmed`.
     case transactionBroadcastUnconfirmed(String)
+    /// Definitively-failed address-nonce race (shield, or identity
+    /// top-up-from-addresses): Platform rejected the transition because the
+    /// submitted address nonce raced its expected value. The transition did
+    /// NOT execute and any notes were released (a shield reserves none) — safe
+    /// to retry, and the retry re-fetches the address nonce so the mismatch
+    /// self-heals. The submitted/expected nonce values are in the message.
+    case addressNonceMismatch(String)
     case notFound(String)
     case unknown(String)
 
@@ -225,6 +242,7 @@ public enum PlatformWalletError: LocalizedError {
              .shieldedBroadcastUnconfirmed(let m), .shieldedSpendUnconfirmed(let m),
              .shieldedNoRecordedAnchor(let m),
              .transactionBroadcastUnconfirmed(let m),
+             .addressNonceMismatch(let m),
              .notFound(let m), .unknown(let m):
             return m
         }
@@ -258,6 +276,8 @@ public enum PlatformWalletError: LocalizedError {
         case .errorShieldedNoRecordedAnchor: self = .shieldedNoRecordedAnchor(detail)
         case .errorTransactionBroadcastUnconfirmed:
             self = .transactionBroadcastUnconfirmed(detail)
+        case .errorAddressNonceMismatch:
+            self = .addressNonceMismatch(detail)
         case .notFound:               self = .notFound(detail)
         case .errorUnknown:           self = .unknown(detail)
         }


### PR DESCRIPTION
## Issue being fixed or feature implemented
Extracted from #3692 (`feat/platform-wallet-rehydration`) at the user's request: these three commits fix address-nonce mismatch error handling and are unrelated to watch-only wallet rehydration, so they belong in their own PR on top of `v4.1-dev`.

The optimistic address-nonce path submits `fetched + 1` by design and relies on the caller retrying when Platform rejects a stale/replayed value under a lagging DAPI replica read (Found-033). The typed `AddressInvalidNonceError` (consensus code 40603) was getting flattened to a string at several mapping seams, so callers (including the FFI boundary and the Swift host binding) lost the ability to recognize this self-healing race and retry correctly.

## What was done?
- `packages/rs-platform-wallet`: added a first-class `PlatformWalletError::AddressNonceMismatch { address, provided_nonce, expected_nonce }` variant, a public `as_address_invalid_nonce` extractor, and a `promote_address_nonce_error` helper. Rewired the lossy string-collapse seams (shield `enrich`, `broadcast_shielded_spend`, `classify_spend_wait_failure`, identity `top_up_from_addresses`) to promote via the helper.
- `packages/rs-platform-wallet-ffi`: added a dedicated `ErrorAddressNonceMismatch = 21` FFI result code (additive), mapped in both `map_spend_result` and the blanket `From<PlatformWalletError>`, preserving the definitively-failed / notes-released / safe-to-retry contract. `as_address_invalid_nonce` now also recurses through `dash_sdk::Error::NoAvailableAddressesToRetry`.
- `packages/swift-sdk`: mirrored the new code 21 in `PlatformWalletResult.swift` (`PlatformWalletResultCode.errorAddressNonceMismatch`, `init(ffi:)`, `PlatformWalletError.addressNonceMismatch(String)`, `init(result:)`), and pinned the FFI nonce tests to exact rendered substrings instead of bare-digit substring checks.

Nonce values are intentionally NOT exposed as structured FFI out-fields (ABI-frozen by-value result struct); they travel in the typed `Display` message, and a retry re-fetches the nonce anyway.

## How Has This Been Tested?
- `cargo check -p platform-wallet -p platform-wallet-ffi`
- `cargo fmt --check -p platform-wallet -p platform-wallet-ffi`
- `cargo clippy -p platform-wallet -p platform-wallet-ffi --all-targets`
- Rust unit tests covering `AddressNonceMismatch` promotion through both the blanket `From` and `map_spend_result`, and extractor recursion through the retry envelope.
- Swift compilation was NOT independently verified in this PR (cbindgen header + DashSDKFFI module require the iOS toolchain, unavailable in this environment); the change is pattern-exact against the existing `errorShieldedBroadcastFailed` arm.

## Breaking Changes
None. The new FFI result code is an additive enum slot; existing codes are unchanged.

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [ ] I have made corresponding changes to the documentation if needed

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new typed error for address nonce mismatches, with clearer messages that include the submitted and expected nonce values.
  * Improved error reporting so retryable nonce-related failures are surfaced consistently across wallet flows.

* **Bug Fixes**
  * Updated top-up, shielded send, and related transaction paths to preserve nonce-mismatch details instead of showing generic wallet errors.
  * Added matching support in the Swift SDK so apps can recognize the new error code and message.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->