### PR TITLE
fix(swift-example-app): let pre-programmed distribution recipients open token Claim

### DIFF
--- a/packages/swift-sdk/Sources/SwiftDashSDK/Core/Utils/DataContractParser.swift
+++ b/packages/swift-sdk/Sources/SwiftDashSDK/Core/Utils/DataContractParser.swift
@@ -407,6 +407,39 @@ public struct DataContractParser {
         return "0"
     }
 
+    /// Render a pre-programmed distribution amount to a canonical
+    /// decimal string. JSONSerialization decodes numeric JSON values as
+    /// `NSNumber` and string values as `String`; token amounts can
+    /// exceed `Int.max`, so read through `UInt64`/`NSNumber` rather than
+    /// `Int` to avoid truncating large balances. Returns `nil` for
+    /// unparseable values so the caller can skip the malformed entry.
+    private static func stringifyDistributionAmount(_ value: Any) -> String? {
+        if let string = value as? String {
+            return string
+        }
+        // `NSNumber` covers Int/UInt/Double bridged from JSON. Prefer a
+        // lossless UInt64 read; fall back to the number's own string.
+        if let number = value as? NSNumber {
+            if let unsigned = UInt64(exactly: number) {
+                return String(unsigned)
+            }
+            if let signed = Int64(exactly: number) {
+                return String(signed)
+            }
+            return number.stringValue
+        }
+        if let unsigned = value as? UInt64 {
+            return String(unsigned)
+        }
+        if let signed = value as? Int64 {
+            return String(signed)
+        }
+        if let intValue = value as? Int {
+            return String(intValue)
+        }
+        return nil
+    }
+
     private static func parseTokenConfiguration(token: PersistentToken, from tokenDict: [String: Any]) {
         // Basic properties
         let maxSupplyStr = extractTokenSupply(from: tokenDict, key: "maxSupply")
@@ -511,7 +544,41 @@ public struct DataContractParser {
             // Pre-programmed distribution
             if let preProgrammed = distributionRules["preProgrammedDistribution"] as? [String: Any] {
                 var dist = TokenPreProgrammedDistribution()
-                if let schedule = preProgrammed["distributionSchedule"] as? [[String: Any]] {
+
+                // Real contract JSON shape (rs-dpp): a `distributions`
+                // map keyed by timestamp-in-milliseconds, each value a
+                // map of recipient-base58 -> amount. Flatten it into the
+                // existing `DistributionEvent` list so downstream
+                // eligibility checks (see `resolveClaim`) can find the
+                // recipient. Amounts may be encoded as JSON numbers or
+                // strings — including large UInt64 values — so render
+                // whatever we get back to a canonical decimal string.
+                if let distributions = preProgrammed["distributions"] as? [String: Any] {
+                    var events: [DistributionEvent] = []
+                    for (timestampKey, recipientsAny) in distributions {
+                        guard let recipients = recipientsAny as? [String: Any] else { continue }
+                        let triggerTime: Date? = UInt64(timestampKey).map {
+                            Date(timeIntervalSince1970: Double($0) / 1000.0)
+                        }
+                        for (recipient, amountAny) in recipients {
+                            guard let amountString = Self.stringifyDistributionAmount(amountAny) else {
+                                continue
+                            }
+                            var event = DistributionEvent(
+                                triggerTime: triggerTime ?? Date(),
+                                amount: amountString,
+                                recipient: recipient
+                            )
+                            if triggerTime == nil {
+                                event.triggerTime = nil
+                            }
+                            events.append(event)
+                        }
+                    }
+                    dist.distributionSchedule = events
+                } else if let schedule = preProgrammed["distributionSchedule"] as? [[String: Any]] {
+                    // Backward-compat: older/synthetic shape carrying an
+                    // explicit array of pre-built event dictionaries.
                     dist.distributionSchedule = schedule.compactMap { eventDict in
                         guard let amount = eventDict["amount"] as? String else { return nil }
                         var event = DistributionEvent(

--- a/packages/swift-sdk/SwiftExampleApp/SwiftExampleApp/Views/TokenActionPermissionsView.swift
+++ b/packages/swift-sdk/SwiftExampleApp/SwiftExampleApp/Views/TokenActionPermissionsView.swift
@@ -589,6 +589,24 @@ enum TokenActionResolver {
             return .denied(reason: "Token has no distribution schedule")
         }
 
+        // Pre-programmed distributions pin their payouts to explicit
+        // recipient identities at each scheduled timestamp rather than
+        // to `newTokensDestinationIdentity` / `mintingAllowChoosingDestination`
+        // (both of which are minting-side concepts). Check recipient
+        // membership BEFORE the designated-recipient guards below, so a
+        // listed pre-programmed recipient isn't denied for not being the
+        // pinned mint destination. If this identity appears as a
+        // recipient in any scheduled event, let the Claim row open.
+        // We deliberately do NOT evaluate maturity or already-claimed
+        // status here — those are enforced on-chain by Drive when the
+        // claim state transition is submitted. Mirrors the Android fix
+        // in `TokenActionResolver.resolveClaim`.
+        let identityBase58 = identity.identityIdBase58
+        if let schedule = token.preProgrammedDistribution?.distributionSchedule,
+           schedule.contains(where: { $0.recipient == identityBase58 }) {
+            return .allowed
+        }
+
         // The contract doesn't let identities choose where new
         // mints go AND this identity isn't the pinned recipient,
         // so they'd never receive anything to claim.
@@ -601,8 +619,9 @@ enum TokenActionResolver {
         }
 
         // Allowed-to-choose-destination but not yet computed who's
-        // next-in-line for a perpetual slot. Surface the limitation
-        // rather than blocking outright.
+        // next-in-line for a perpetual slot, and not a listed
+        // pre-programmed recipient. Surface the limitation rather than
+        // blocking outright.
         // TODO: query the next-in-line distribution slot for this identity.
         return .denied(reason: "Distribution eligibility not yet evaluated")
     }

--- a/packages/swift-sdk/SwiftTests/SwiftDashSDKTests/DataContractParserPreProgrammedTests.swift
+++ b/packages/swift-sdk/SwiftTests/SwiftDashSDKTests/DataContractParserPreProgrammedTests.swift
@@ -1,0 +1,266 @@
+import XCTest
+import SwiftData
+@testable import SwiftDashSDK
+
+/// Coverage for `DataContractParser`'s pre-programmed-distribution
+/// parsing — the parse half of the iOS "pre-programmed recipient can
+/// never open the Claim row" fix.
+///
+/// The real rs-dpp contract JSON encodes a pre-programmed distribution
+/// as a `distributions` map keyed by trigger-timestamp-in-milliseconds,
+/// each value a map of recipient-base58 -> amount:
+///
+/// ```json
+/// "preProgrammedDistribution": {
+///   "$formatVersion": "0",
+///   "distributions": { "<timestampMs>": { "<recipientBase58>": <amount> } }
+/// }
+/// ```
+///
+/// The parser previously only understood a synthetic
+/// `distributionSchedule` array shape, so on real contracts the schedule
+/// came back empty and the recipient information was lost — leaving the
+/// Claim-action resolver unable to match a listed recipient. These tests
+/// drive the public `parseDataContract` entry point against an in-memory
+/// `ModelContainer` (no network, no FFI handle) and assert the recipient,
+/// amount, and trigger-time land on the persisted `PersistentToken`.
+///
+/// Mirrors the live testnet contract
+/// `CNpuW3ZjmTrfxKm2VyEJYSBm2jFn7Va2YCmRyVP1ZPvC` / token `androidqadist`.
+@MainActor
+final class DataContractParserPreProgrammedTests: XCTestCase {
+
+    private let contractId = Data(repeating: 0xCD, count: 32)
+
+    /// A canonical base58 identity id (the recipient key shape used in
+    /// the real contract's `distributions` map).
+    private let recipientBase58 = "29n6ZVEWvTVM7BaQCs7Ubsi4KdnqkPBTQ8QxEyyXciAc"
+
+    private func makeContext() throws -> ModelContext {
+        let container = try DashModelContainer.createInMemory()
+        return ModelContext(container)
+    }
+
+    /// The parser's `parseTokens` bails out early unless a
+    /// `PersistentDataContract` row already exists for `contractId`
+    /// (tokens hang off the contract relationship). Seed that row, then
+    /// run the parser and hand back the single parsed token.
+    private func parseSingleToken(
+        tokenDict: [String: Any],
+        in context: ModelContext
+    ) throws -> PersistentToken {
+        let contract = PersistentDataContract(
+            id: contractId,
+            name: "Fixture",
+            serializedContract: Data(),
+            network: .testnet
+        )
+        context.insert(contract)
+        try context.save()
+
+        let contractData: [String: Any] = [
+            "tokens": ["0": tokenDict]
+        ]
+
+        try DataContractParser.parseDataContract(
+            contractData: contractData,
+            contractId: contractId,
+            modelContext: context
+        )
+
+        let id = contractId
+        let descriptor = FetchDescriptor<PersistentToken>(
+            predicate: #Predicate { $0.contractId == id }
+        )
+        let tokens = try context.fetch(descriptor)
+        return try XCTUnwrap(tokens.first, "parser should have persisted one token")
+    }
+
+    /// Wrap a `preProgrammedDistribution` payload in the minimal token
+    /// dict shape the parser expects (`distributionRules` wrapper).
+    private func tokenDict(preProgrammed: [String: Any]) -> [String: Any] {
+        return [
+            "baseSupply": 0,
+            "distributionRules": [
+                "preProgrammedDistribution": preProgrammed
+            ]
+        ]
+    }
+
+    // MARK: - 1. Real rs-dpp shape
+
+    /// The live-contract shape: one timestamp key, one recipient, a
+    /// numeric amount. Assert the flattened event carries the recipient,
+    /// amount, and a trigger-time derived from the ms timestamp.
+    func testRealDistributionsShapeParsesRecipientAmountAndTime() throws {
+        let context = try makeContext()
+
+        let preProgrammed: [String: Any] = [
+            "$formatVersion": "0",
+            "distributions": [
+                "1719000000000": [
+                    recipientBase58: 5000
+                ]
+            ]
+        ]
+
+        let token = try parseSingleToken(
+            tokenDict: tokenDict(preProgrammed: preProgrammed),
+            in: context
+        )
+
+        let schedule = try XCTUnwrap(token.preProgrammedDistribution?.distributionSchedule)
+        XCTAssertEqual(schedule.count, 1)
+
+        let event = try XCTUnwrap(schedule.first)
+        XCTAssertEqual(event.recipient, recipientBase58)
+        XCTAssertEqual(event.amount, "5000")
+        // 1719000000000 ms -> 1719000000 s since epoch.
+        XCTAssertEqual(event.triggerTime, Date(timeIntervalSince1970: 1719000000))
+    }
+
+    // MARK: - 2. String + large (> Int64.max) amounts
+
+    /// Amounts encoded as JSON strings — including a value larger than
+    /// `Int64.max` — must survive verbatim (no truncation / overflow).
+    func testAmountAsStringAndBeyondInt64MaxPreservedVerbatim() throws {
+        let context = try makeContext()
+
+        // 18446744073709551615 == UInt64.max, which exceeds Int64.max.
+        let hugeAmount = "18446744073709551615"
+        let smallStringAmount = "12345"
+
+        let recipientB = "Gsj5AqEnKzGZAdA4kZUZRWkQRxqXV7UwSFDdKQPGoXA6"
+
+        let preProgrammed: [String: Any] = [
+            "$formatVersion": "0",
+            "distributions": [
+                "1719000000000": [
+                    recipientBase58: hugeAmount,
+                    recipientB: smallStringAmount
+                ]
+            ]
+        ]
+
+        let token = try parseSingleToken(
+            tokenDict: tokenDict(preProgrammed: preProgrammed),
+            in: context
+        )
+
+        let schedule = try XCTUnwrap(token.preProgrammedDistribution?.distributionSchedule)
+        XCTAssertEqual(schedule.count, 2)
+
+        let hugeEvent = try XCTUnwrap(schedule.first { $0.recipient == recipientBase58 })
+        XCTAssertEqual(hugeEvent.amount, hugeAmount)
+
+        let smallEvent = try XCTUnwrap(schedule.first { $0.recipient == recipientB })
+        XCTAssertEqual(smallEvent.amount, smallStringAmount)
+    }
+
+    // MARK: - 3. Multiple timestamps × multiple recipients
+
+    /// Two timestamps, each with two recipients, flatten to four events —
+    /// one per (timestamp, recipient) pair — with correct per-pair data.
+    func testMultipleTimestampsAndRecipientsProduceOneEventPerPair() throws {
+        let context = try makeContext()
+
+        let recipientB = "Gsj5AqEnKzGZAdA4kZUZRWkQRxqXV7UwSFDdKQPGoXA6"
+
+        let preProgrammed: [String: Any] = [
+            "$formatVersion": "0",
+            "distributions": [
+                "1719000000000": [
+                    recipientBase58: 100,
+                    recipientB: 200
+                ],
+                "1720000000000": [
+                    recipientBase58: 300,
+                    recipientB: 400
+                ]
+            ]
+        ]
+
+        let token = try parseSingleToken(
+            tokenDict: tokenDict(preProgrammed: preProgrammed),
+            in: context
+        )
+
+        let schedule = try XCTUnwrap(token.preProgrammedDistribution?.distributionSchedule)
+        XCTAssertEqual(schedule.count, 4, "2 timestamps × 2 recipients = 4 events")
+
+        // Spot-check one specific (timestamp, recipient) pairing.
+        let earlyTime = Date(timeIntervalSince1970: 1719000000)
+        let lateTime = Date(timeIntervalSince1970: 1720000000)
+
+        let earlyForA = schedule.first {
+            $0.recipient == recipientBase58 && $0.triggerTime == earlyTime
+        }
+        XCTAssertEqual(earlyForA?.amount, "100")
+
+        let lateForB = schedule.first {
+            $0.recipient == recipientB && $0.triggerTime == lateTime
+        }
+        XCTAssertEqual(lateForB?.amount, "400")
+
+        // Every recipient string is one of the two we supplied.
+        let recipients = Set(schedule.map { $0.recipient })
+        XCTAssertEqual(recipients, [recipientBase58, recipientB])
+    }
+
+    // MARK: - 4. Backward-compat: legacy `distributionSchedule` array
+
+    /// The older/synthetic `distributionSchedule` array shape must still
+    /// parse when no real `distributions` map is present.
+    func testLegacyDistributionScheduleArrayStillParses() throws {
+        let context = try makeContext()
+
+        let preProgrammed: [String: Any] = [
+            "distributionSchedule": [
+                [
+                    "amount": "7500",
+                    "recipient": recipientBase58,
+                    "triggerType": "Time"
+                ]
+            ]
+        ]
+
+        let token = try parseSingleToken(
+            tokenDict: tokenDict(preProgrammed: preProgrammed),
+            in: context
+        )
+
+        let schedule = try XCTUnwrap(token.preProgrammedDistribution?.distributionSchedule)
+        XCTAssertEqual(schedule.count, 1)
+
+        let event = try XCTUnwrap(schedule.first)
+        XCTAssertEqual(event.recipient, recipientBase58)
+        XCTAssertEqual(event.amount, "7500")
+        XCTAssertEqual(event.triggerType, "Time")
+    }
+
+    // MARK: - 5. No preProgrammedDistribution key
+
+    /// A token whose `distributionRules` carry no
+    /// `preProgrammedDistribution` leaves the model's optional nil.
+    func testNoPreProgrammedDistributionLeavesPropertyNil() throws {
+        let context = try makeContext()
+
+        let dict: [String: Any] = [
+            "baseSupply": 0,
+            "distributionRules": [
+                // Only a perpetual block — no preProgrammedDistribution.
+                "perpetualDistribution": [
+                    "distributionType": ["Fixed": ["amount": 1]],
+                    "distributionRecipient": "ContractOwner"
+                ]
+            ]
+        ]
+
+        let token = try parseSingleToken(tokenDict: dict, in: context)
+
+        XCTAssertNil(
+            token.preProgrammedDistribution,
+            "no preProgrammedDistribution key -> property stays nil"
+        )
+    }
+}

--- a/packages/swift-sdk/SwiftTests/SwiftDashSDKTests/SDKMethodTests.swift
+++ b/packages/swift-sdk/SwiftTests/SwiftDashSDKTests/SDKMethodTests.swift
@@ -27,6 +27,7 @@ final class SDKMethodTests: XCTestCase {
     print("✅ SDK methods inspection complete")
   }
 
+  @MainActor
   func testDirectMethodCall() async throws {
     print("=== Testing Direct Method Call ===")
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

A pre-programmed-distribution recipient could never open the token Claim action row in SwiftExampleApp. Two compounding bugs (iOS mirror of the KotlinExampleApp `TokenActionResolver.resolveClaim` fix):

1. `DataContractParser` parsed `preProgrammedDistribution` expecting a `distributionSchedule` array, but real contract JSON is `{"$formatVersion":"0","distributions":{"<timestampMs>":{"<recipientBase58>":amount}}}` — so the schedule was always empty and recipient info was lost.
2. `resolveClaim` only allowed the designated `newTokensDestinationIdentity`; pre-programmed recipients fell through to a denial.

## What was done?
<!--- Describe your changes in detail -->

- `Sources/SwiftDashSDK/Core/Utils/DataContractParser.swift`: parse the real rs-dpp `distributions` map into `DistributionEvent` entries (`triggerTime` from the ms timestamp key, `recipient` from the base58 key, `amount` stringified losslessly through `UInt64` so values above `Int64.max` aren't truncated). The legacy `distributionSchedule` array shape is kept as a fallback.
- `SwiftExampleApp/Views/TokenActionPermissionsView.swift` (`resolveClaim`): return `.allowed` when the identity appears as a recipient in any pre-programmed distribution event. The check runs before the minting-side `mintingAllowChoosingDestination`/designated-recipient guards, which would otherwise deny legitimate recipients. Maturity and already-claimed checks are left to on-chain enforcement, matching Android.
- `SwiftTests/SwiftDashSDKTests/SDKMethodTests.swift`: marked `testDirectMethodCall` `@MainActor` to fix a pre-existing Swift 6 `sending-risks-data-race` compile error that blocked building the hermetic test target.
- `TokenClaimActionView` needed no change: it auto-selects `.preProgrammed` when it's the only schedule and already passes the correct FFI discriminant (0) to `platform_wallet_token_claim`.

Note: tokens persisted before this fix keep an empty schedule; re-fetching the contract re-materializes the recipient list.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

- New hermetic unit tests in `SwiftTests/SwiftDashSDKTests/DataContractParserPreProgrammedTests.swift` (5 tests, in-memory SwiftData container): real `distributions` shape mirroring live testnet contract `CNpuW3ZjmTrfxKm2VyEJYSBm2jFn7Va2YCmRyVP1ZPvC` (token `androidqadist`, recipient `29n6ZVEWvTVM7BaQCs7Ubsi4KdnqkPBTQ8QxEyyXciAc`), string and >`Int64.max` amounts, multi-timestamp × multi-recipient flattening, legacy array fallback, and absent pre-programmed config.
- `swift test --filter DataContractParserPreProgrammedTests` — all 5 pass.
- Full `./build_ios.sh` (xcframework + SwiftExampleApp simulator build) succeeds.

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->

None.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [ ] I have made corresponding changes to the documentation if needed

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved claim eligibility handling so accounts listed as recipients in pre-programmed distribution schedules are recognized correctly.
  - Fixed parsing of pre-programmed distribution data from newer contract formats, while keeping support for the older format.
  - Preserved exact distribution amounts, including very large values, and handled timestamp-based schedules more reliably.

- **Tests**
  - Added coverage for new and legacy pre-programmed distribution shapes, amount formatting, and empty/missing distribution cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->