### PR TITLE
ci: accept platform-wallet-storage as a conventional-commit scope

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -52,6 +52,7 @@ jobs:
             release
             wasm-sdk
             platform-wallet
+            platform-wallet-storage
             wallet-storage
             swift-example-app
             kotlin-sdk


### PR DESCRIPTION
## Why this PR exists
- **Problem**: The `platform-wallet-storage` crate (new in #3968) has no matching PR-title scope, so a conventional-commit title like `feat(platform-wallet-storage): …` fails the `pr-title` check.
- **What breaks without it**: Because `pr.yml` runs on `pull_request_target`, the title check executes the **base branch's** config — so the scope must live on `v4.1-dev` for any PR (incl. #3968) to use it. Adding it only on a feature branch does not take effect for that branch's own title check.

## What was done
Add `platform-wallet-storage` to the allowed scopes in `.github/workflows/pr.yml` (one line).

## Testing
Config-only; no code. The scope is a regex auto-wrapped in `^ $` by `amannn/action-semantic-pull-request`.

## Breaking changes
None.

<sub>🤖 Co-authored by [Claudius the Magnificent](https://github.com/lklimek/claudius) AI Agent</sub>