### PR TITLE
feat(platform-wallet): anchor fresh wallets at a checkpoint, set birth height on import

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1206,7 +1206,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1637,7 +1637,7 @@ dependencies = [
 [[package]]
 name = "dash-network"
 version = "0.45.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=116421f116cae5bd73a0557f87c97e391bf0198e#116421f116cae5bd73a0557f87c97e391bf0198e"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=1860089eddea27f66e5b3e637d18a73ae138478c#1860089eddea27f66e5b3e637d18a73ae138478c"
 dependencies = [
  "bincode",
  "bincode_derive",
@@ -1648,7 +1648,7 @@ dependencies = [
 [[package]]
 name = "dash-network-seeds"
 version = "0.45.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=116421f116cae5bd73a0557f87c97e391bf0198e#116421f116cae5bd73a0557f87c97e391bf0198e"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=1860089eddea27f66e5b3e637d18a73ae138478c#1860089eddea27f66e5b3e637d18a73ae138478c"
 dependencies = [
  "dash-network",
 ]
@@ -1725,7 +1725,7 @@ dependencies = [
 [[package]]
 name = "dash-spv"
 version = "0.45.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=116421f116cae5bd73a0557f87c97e391bf0198e#116421f116cae5bd73a0557f87c97e391bf0198e"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=1860089eddea27f66e5b3e637d18a73ae138478c#1860089eddea27f66e5b3e637d18a73ae138478c"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1754,7 +1754,7 @@ dependencies = [
 [[package]]
 name = "dashcore"
 version = "0.45.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=116421f116cae5bd73a0557f87c97e391bf0198e#116421f116cae5bd73a0557f87c97e391bf0198e"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=1860089eddea27f66e5b3e637d18a73ae138478c#1860089eddea27f66e5b3e637d18a73ae138478c"
 dependencies = [
  "anyhow",
  "base64-compat",
@@ -1780,12 +1780,12 @@ dependencies = [
 [[package]]
 name = "dashcore-private"
 version = "0.45.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=116421f116cae5bd73a0557f87c97e391bf0198e#116421f116cae5bd73a0557f87c97e391bf0198e"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=1860089eddea27f66e5b3e637d18a73ae138478c#1860089eddea27f66e5b3e637d18a73ae138478c"
 
 [[package]]
 name = "dashcore-rpc"
 version = "0.45.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=116421f116cae5bd73a0557f87c97e391bf0198e#116421f116cae5bd73a0557f87c97e391bf0198e"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=1860089eddea27f66e5b3e637d18a73ae138478c#1860089eddea27f66e5b3e637d18a73ae138478c"
 dependencies = [
  "dashcore-rpc-json",
  "hex",
@@ -1798,7 +1798,7 @@ dependencies = [
 [[package]]
 name = "dashcore-rpc-json"
 version = "0.45.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=116421f116cae5bd73a0557f87c97e391bf0198e#116421f116cae5bd73a0557f87c97e391bf0198e"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=1860089eddea27f66e5b3e637d18a73ae138478c#1860089eddea27f66e5b3e637d18a73ae138478c"
 dependencies = [
  "bincode",
  "dashcore",
@@ -1813,7 +1813,7 @@ dependencies = [
 [[package]]
 name = "dashcore_hashes"
 version = "0.45.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=116421f116cae5bd73a0557f87c97e391bf0198e#116421f116cae5bd73a0557f87c97e391bf0198e"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=1860089eddea27f66e5b3e637d18a73ae138478c#1860089eddea27f66e5b3e637d18a73ae138478c"
 dependencies = [
  "bincode",
  "dashcore-private",
@@ -2428,7 +2428,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2489,7 +2489,7 @@ checksum = "0ce92ff622d6dadf7349484f42c93271a0d49b7cc4d466a936405bacbe10aa78"
 dependencies = [
  "cfg-if",
  "rustix 1.1.4",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2867,7 +2867,7 @@ dependencies = [
 [[package]]
 name = "git-state"
 version = "0.45.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=116421f116cae5bd73a0557f87c97e391bf0198e#116421f116cae5bd73a0557f87c97e391bf0198e"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=1860089eddea27f66e5b3e637d18a73ae138478c#1860089eddea27f66e5b3e637d18a73ae138478c"
 
 [[package]]
 name = "glob"
@@ -3803,7 +3803,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4034,7 +4034,7 @@ dependencies = [
 [[package]]
 name = "key-wallet"
 version = "0.45.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=116421f116cae5bd73a0557f87c97e391bf0198e#116421f116cae5bd73a0557f87c97e391bf0198e"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=1860089eddea27f66e5b3e637d18a73ae138478c#1860089eddea27f66e5b3e637d18a73ae138478c"
 dependencies = [
  "aes",
  "async-trait",
@@ -4063,7 +4063,7 @@ dependencies = [
 [[package]]
 name = "key-wallet-ffi"
 version = "0.45.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=116421f116cae5bd73a0557f87c97e391bf0198e#116421f116cae5bd73a0557f87c97e391bf0198e"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=1860089eddea27f66e5b3e637d18a73ae138478c#1860089eddea27f66e5b3e637d18a73ae138478c"
 dependencies = [
  "cbindgen 0.29.4",
  "dash-network",
@@ -4079,7 +4079,7 @@ dependencies = [
 [[package]]
 name = "key-wallet-manager"
 version = "0.45.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=116421f116cae5bd73a0557f87c97e391bf0198e#116421f116cae5bd73a0557f87c97e391bf0198e"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=1860089eddea27f66e5b3e637d18a73ae138478c#1860089eddea27f66e5b3e637d18a73ae138478c"
 dependencies = [
  "async-trait",
  "bincode",
@@ -4596,7 +4596,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5698,7 +5698,7 @@ dependencies = [
  "once_cell",
  "socket2 0.5.10",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6489,7 +6489,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6502,7 +6502,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6561,7 +6561,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -7421,7 +7421,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -8870,7 +8870,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1206,7 +1206,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1637,7 +1637,7 @@ dependencies = [
 [[package]]
 name = "dash-network"
 version = "0.45.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=647fa9820f3614090e4e5f5f2b709961d68e538b#647fa9820f3614090e4e5f5f2b709961d68e538b"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=116421f116cae5bd73a0557f87c97e391bf0198e#116421f116cae5bd73a0557f87c97e391bf0198e"
 dependencies = [
  "bincode",
  "bincode_derive",
@@ -1648,7 +1648,7 @@ dependencies = [
 [[package]]
 name = "dash-network-seeds"
 version = "0.45.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=647fa9820f3614090e4e5f5f2b709961d68e538b#647fa9820f3614090e4e5f5f2b709961d68e538b"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=116421f116cae5bd73a0557f87c97e391bf0198e#116421f116cae5bd73a0557f87c97e391bf0198e"
 dependencies = [
  "dash-network",
 ]
@@ -1725,7 +1725,7 @@ dependencies = [
 [[package]]
 name = "dash-spv"
 version = "0.45.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=647fa9820f3614090e4e5f5f2b709961d68e538b#647fa9820f3614090e4e5f5f2b709961d68e538b"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=116421f116cae5bd73a0557f87c97e391bf0198e#116421f116cae5bd73a0557f87c97e391bf0198e"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1754,7 +1754,7 @@ dependencies = [
 [[package]]
 name = "dashcore"
 version = "0.45.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=647fa9820f3614090e4e5f5f2b709961d68e538b#647fa9820f3614090e4e5f5f2b709961d68e538b"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=116421f116cae5bd73a0557f87c97e391bf0198e#116421f116cae5bd73a0557f87c97e391bf0198e"
 dependencies = [
  "anyhow",
  "base64-compat",
@@ -1780,12 +1780,12 @@ dependencies = [
 [[package]]
 name = "dashcore-private"
 version = "0.45.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=647fa9820f3614090e4e5f5f2b709961d68e538b#647fa9820f3614090e4e5f5f2b709961d68e538b"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=116421f116cae5bd73a0557f87c97e391bf0198e#116421f116cae5bd73a0557f87c97e391bf0198e"
 
 [[package]]
 name = "dashcore-rpc"
 version = "0.45.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=647fa9820f3614090e4e5f5f2b709961d68e538b#647fa9820f3614090e4e5f5f2b709961d68e538b"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=116421f116cae5bd73a0557f87c97e391bf0198e#116421f116cae5bd73a0557f87c97e391bf0198e"
 dependencies = [
  "dashcore-rpc-json",
  "hex",
@@ -1798,7 +1798,7 @@ dependencies = [
 [[package]]
 name = "dashcore-rpc-json"
 version = "0.45.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=647fa9820f3614090e4e5f5f2b709961d68e538b#647fa9820f3614090e4e5f5f2b709961d68e538b"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=116421f116cae5bd73a0557f87c97e391bf0198e#116421f116cae5bd73a0557f87c97e391bf0198e"
 dependencies = [
  "bincode",
  "dashcore",
@@ -1813,7 +1813,7 @@ dependencies = [
 [[package]]
 name = "dashcore_hashes"
 version = "0.45.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=647fa9820f3614090e4e5f5f2b709961d68e538b#647fa9820f3614090e4e5f5f2b709961d68e538b"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=116421f116cae5bd73a0557f87c97e391bf0198e#116421f116cae5bd73a0557f87c97e391bf0198e"
 dependencies = [
  "bincode",
  "dashcore-private",
@@ -2428,7 +2428,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2489,7 +2489,7 @@ checksum = "0ce92ff622d6dadf7349484f42c93271a0d49b7cc4d466a936405bacbe10aa78"
 dependencies = [
  "cfg-if",
  "rustix 1.1.4",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2867,7 +2867,7 @@ dependencies = [
 [[package]]
 name = "git-state"
 version = "0.45.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=647fa9820f3614090e4e5f5f2b709961d68e538b#647fa9820f3614090e4e5f5f2b709961d68e538b"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=116421f116cae5bd73a0557f87c97e391bf0198e#116421f116cae5bd73a0557f87c97e391bf0198e"
 
 [[package]]
 name = "glob"
@@ -3803,7 +3803,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4034,7 +4034,7 @@ dependencies = [
 [[package]]
 name = "key-wallet"
 version = "0.45.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=647fa9820f3614090e4e5f5f2b709961d68e538b#647fa9820f3614090e4e5f5f2b709961d68e538b"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=116421f116cae5bd73a0557f87c97e391bf0198e#116421f116cae5bd73a0557f87c97e391bf0198e"
 dependencies = [
  "aes",
  "async-trait",
@@ -4063,7 +4063,7 @@ dependencies = [
 [[package]]
 name = "key-wallet-ffi"
 version = "0.45.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=647fa9820f3614090e4e5f5f2b709961d68e538b#647fa9820f3614090e4e5f5f2b709961d68e538b"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=116421f116cae5bd73a0557f87c97e391bf0198e#116421f116cae5bd73a0557f87c97e391bf0198e"
 dependencies = [
  "cbindgen 0.29.4",
  "dash-network",
@@ -4079,7 +4079,7 @@ dependencies = [
 [[package]]
 name = "key-wallet-manager"
 version = "0.45.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=647fa9820f3614090e4e5f5f2b709961d68e538b#647fa9820f3614090e4e5f5f2b709961d68e538b"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=116421f116cae5bd73a0557f87c97e391bf0198e#116421f116cae5bd73a0557f87c97e391bf0198e"
 dependencies = [
  "async-trait",
  "bincode",
@@ -4596,7 +4596,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5698,7 +5698,7 @@ dependencies = [
  "once_cell",
  "socket2 0.5.10",
  "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6489,7 +6489,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6502,7 +6502,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6561,7 +6561,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -7421,7 +7421,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -8870,7 +8870,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,14 +50,14 @@ members = [
 ]
 
 [workspace.dependencies]
-dashcore = { git = "https://github.com/dashpay/rust-dashcore", rev = "647fa9820f3614090e4e5f5f2b709961d68e538b" }
-dash-network-seeds = { git = "https://github.com/dashpay/rust-dashcore", rev = "647fa9820f3614090e4e5f5f2b709961d68e538b" }
-dash-spv = { git = "https://github.com/dashpay/rust-dashcore", rev = "647fa9820f3614090e4e5f5f2b709961d68e538b" }
-key-wallet = { git = "https://github.com/dashpay/rust-dashcore", rev = "647fa9820f3614090e4e5f5f2b709961d68e538b" }
-key-wallet-ffi = { git = "https://github.com/dashpay/rust-dashcore", rev = "647fa9820f3614090e4e5f5f2b709961d68e538b" }
-key-wallet-manager = { git = "https://github.com/dashpay/rust-dashcore", rev = "647fa9820f3614090e4e5f5f2b709961d68e538b" }
-dash-network = { git = "https://github.com/dashpay/rust-dashcore", rev = "647fa9820f3614090e4e5f5f2b709961d68e538b" }
-dashcore-rpc = { git = "https://github.com/dashpay/rust-dashcore", rev = "647fa9820f3614090e4e5f5f2b709961d68e538b" }
+dashcore = { git = "https://github.com/dashpay/rust-dashcore", rev = "116421f116cae5bd73a0557f87c97e391bf0198e" }
+dash-network-seeds = { git = "https://github.com/dashpay/rust-dashcore", rev = "116421f116cae5bd73a0557f87c97e391bf0198e" }
+dash-spv = { git = "https://github.com/dashpay/rust-dashcore", rev = "116421f116cae5bd73a0557f87c97e391bf0198e" }
+key-wallet = { git = "https://github.com/dashpay/rust-dashcore", rev = "116421f116cae5bd73a0557f87c97e391bf0198e" }
+key-wallet-ffi = { git = "https://github.com/dashpay/rust-dashcore", rev = "116421f116cae5bd73a0557f87c97e391bf0198e" }
+key-wallet-manager = { git = "https://github.com/dashpay/rust-dashcore", rev = "116421f116cae5bd73a0557f87c97e391bf0198e" }
+dash-network = { git = "https://github.com/dashpay/rust-dashcore", rev = "116421f116cae5bd73a0557f87c97e391bf0198e" }
+dashcore-rpc = { git = "https://github.com/dashpay/rust-dashcore", rev = "116421f116cae5bd73a0557f87c97e391bf0198e" }
 
 tokio-metrics = "0.5"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,14 +50,14 @@ members = [
 ]
 
 [workspace.dependencies]
-dashcore = { git = "https://github.com/dashpay/rust-dashcore", rev = "116421f116cae5bd73a0557f87c97e391bf0198e" }
-dash-network-seeds = { git = "https://github.com/dashpay/rust-dashcore", rev = "116421f116cae5bd73a0557f87c97e391bf0198e" }
-dash-spv = { git = "https://github.com/dashpay/rust-dashcore", rev = "116421f116cae5bd73a0557f87c97e391bf0198e" }
-key-wallet = { git = "https://github.com/dashpay/rust-dashcore", rev = "116421f116cae5bd73a0557f87c97e391bf0198e" }
-key-wallet-ffi = { git = "https://github.com/dashpay/rust-dashcore", rev = "116421f116cae5bd73a0557f87c97e391bf0198e" }
-key-wallet-manager = { git = "https://github.com/dashpay/rust-dashcore", rev = "116421f116cae5bd73a0557f87c97e391bf0198e" }
-dash-network = { git = "https://github.com/dashpay/rust-dashcore", rev = "116421f116cae5bd73a0557f87c97e391bf0198e" }
-dashcore-rpc = { git = "https://github.com/dashpay/rust-dashcore", rev = "116421f116cae5bd73a0557f87c97e391bf0198e" }
+dashcore = { git = "https://github.com/dashpay/rust-dashcore", rev = "1860089eddea27f66e5b3e637d18a73ae138478c" }
+dash-network-seeds = { git = "https://github.com/dashpay/rust-dashcore", rev = "1860089eddea27f66e5b3e637d18a73ae138478c" }
+dash-spv = { git = "https://github.com/dashpay/rust-dashcore", rev = "1860089eddea27f66e5b3e637d18a73ae138478c" }
+key-wallet = { git = "https://github.com/dashpay/rust-dashcore", rev = "1860089eddea27f66e5b3e637d18a73ae138478c" }
+key-wallet-ffi = { git = "https://github.com/dashpay/rust-dashcore", rev = "1860089eddea27f66e5b3e637d18a73ae138478c" }
+key-wallet-manager = { git = "https://github.com/dashpay/rust-dashcore", rev = "1860089eddea27f66e5b3e637d18a73ae138478c" }
+dash-network = { git = "https://github.com/dashpay/rust-dashcore", rev = "1860089eddea27f66e5b3e637d18a73ae138478c" }
+dashcore-rpc = { git = "https://github.com/dashpay/rust-dashcore", rev = "1860089eddea27f66e5b3e637d18a73ae138478c" }
 
 tokio-metrics = "0.5"
 

--- a/packages/rs-platform-wallet/src/manager/wallet_lifecycle.rs
+++ b/packages/rs-platform-wallet/src/manager/wallet_lifecycle.rs
@@ -65,7 +65,8 @@ impl<P: PlatformWalletPersistence + 'static> PlatformWalletManager<P> {
     /// anything funded before init is invisible — **but** when SPV is
     /// not running yet or header state is unavailable (e.g. wallet
     /// created before the SPV client is started), it falls back to
-    /// `0`, i.e. a full historical scan from genesis. `Some(0)`
+    /// the latest network checkpoint height, keeping the scan near
+    /// the chain head instead of rescanning from genesis. `Some(0)`
     /// always requests a full historical scan from genesis (use
     /// sparingly — expensive on long-lived chains, but required when
     /// an address may have received funds before the wallet was first
@@ -95,7 +96,7 @@ impl<P: PlatformWalletPersistence + 'static> PlatformWalletManager<P> {
     /// See [`Self::create_wallet_from_mnemonic`] for the
     /// `birth_height_override` semantics. `None` scans from the
     /// current SPV tip forward when SPV is running, otherwise from
-    /// genesis; `Some(h)` is for callers that need to see funding
+    /// the latest network checkpoint; `Some(h)` is for callers that need to see funding
     /// deposited before the wallet was registered (e.g. a long-lived
     /// bank address pre-funded with testnet duffs).
     pub async fn create_wallet_from_seed_bytes(

--- a/packages/rs-platform-wallet/src/manager/wallet_lifecycle.rs
+++ b/packages/rs-platform-wallet/src/manager/wallet_lifecycle.rs
@@ -2,6 +2,7 @@
 
 use std::sync::Arc;
 
+use dash_spv::chain::CheckpointManager;
 use key_wallet::mnemonic::{Language, Mnemonic};
 use key_wallet::wallet::initialization::WalletAccountCreationOptions;
 use key_wallet::wallet::managed_wallet_info::ManagedWalletInfo;
@@ -149,18 +150,30 @@ impl<P: PlatformWalletPersistence + 'static> PlatformWalletManager<P> {
         // persisted id verbatim, so it stays self-consistent across
         // launches.
 
-        // Birth height resolution: explicit override wins; otherwise
-        // fall back to SPV's confirmed header tip (default for fresh
-        // wallets — they only need to see funding from now on); 0 if
-        // SPV isn't running yet.
+        // Birth height resolution: explicit override wins; otherwise fall back
+        // to SPV's confirmed header tip (default for fresh wallets — they only
+        // need to see funding from now on). Before SPV has synced any headers
+        // the tip is 0, so a brand-new wallet created at startup would otherwise
+        // anchor at genesis and rescan the whole chain. Fall back to the latest
+        // hardcoded checkpoint instead, keeping the scan near the chain head.
         let birth_height: u32 = match birth_height_override {
             Some(h) => h,
-            None => self
-                .spv_manager
-                .sync_progress()
-                .await
-                .and_then(|p| p.headers().ok().map(|h| h.tip_height()))
-                .unwrap_or(0),
+            None => {
+                let tip = self
+                    .spv_manager
+                    .sync_progress()
+                    .await
+                    .and_then(|p| p.headers().ok().map(|h| h.tip_height()))
+                    .unwrap_or(0);
+                if tip > 0 {
+                    tip
+                } else {
+                    CheckpointManager::for_network(self.sdk.network)
+                        .last_checkpoint()
+                        .map(|checkpoint| checkpoint.height)
+                        .unwrap_or(0)
+                }
+            }
         };
 
         let wallet_info = ManagedWalletInfo::from_wallet(&wallet, birth_height);

--- a/packages/swift-sdk/Sources/SwiftDashSDK/KeyWallet/WalletManager.swift
+++ b/packages/swift-sdk/Sources/SwiftDashSDK/KeyWallet/WalletManager.swift
@@ -652,7 +652,7 @@ public class WalletManager {
     /// - Parameters:
     ///   - walletBytes: The serialized wallet data
     /// - Returns: The wallet ID of the imported wallet
-    public func importWallet(from walletBytes: Data) throws -> Data {
+    public func importWallet(from walletBytes: Data, birthHeight: UInt32 = 0) throws -> Data {
         guard !walletBytes.isEmpty else {
             throw KeyWalletError.invalidInput("Wallet bytes cannot be empty")
         }
@@ -665,6 +665,7 @@ public class WalletManager {
                 handle,
                 bytes.bindMemory(to: UInt8.self).baseAddress,
                 size_t(walletBytes.count),
+                birthHeight,
                 &walletId,
                 &error
             )

--- a/packages/swift-sdk/SwiftExampleApp/SwiftExampleApp/Core/Views/CreateWalletView.swift
+++ b/packages/swift-sdk/SwiftExampleApp/SwiftExampleApp/Core/Views/CreateWalletView.swift
@@ -12,6 +12,7 @@ struct CreateWalletView: View {
     @State private var walletLabel: String = ""
     @State private var showImportOption: Bool = false
     @State private var importMnemonic: String = ""
+    @State private var importBirthHeight: String = ""
     @State private var walletPin: String = ""
     @State private var confirmPin: String = ""
     @State private var isCreating: Bool = false
@@ -195,6 +196,15 @@ struct CreateWalletView: View {
                 } footer: {
                     Text("Enter your 12-word recovery phrase separated by spaces")
                 }
+
+                Section {
+                    TextField("Birth height (optional)", text: $importBirthHeight)
+                        .keyboardType(.numberPad)
+                } header: {
+                    Text("Birth Height")
+                } footer: {
+                    Text("Block height the wallet first received funds. Sync anchors at the nearest checkpoint at or before it, avoiding a full-chain scan. Leave empty to scan from genesis.")
+                }
             }
         }
         .navigationTitle("Create Wallet")
@@ -352,19 +362,20 @@ struct CreateWalletView: View {
                     // the user so a partial create isn't reported as
                     // success.
                     var failures: [(network: Network, message: String)] = []
+                    // For an imported wallet, honour a user-entered birth height:
+                    // sync anchors at the nearest checkpoint at or before it,
+                    // avoiding a full-chain scan. Left empty it falls back to
+                    // genesis (0) so a wallet of unknown age still sees all its
+                    // history. A freshly generated wallet passes nil (tip).
+                    let importBirth = UInt32(importBirthHeight.trimmingCharacters(in: .whitespaces)) ?? 0
                     for net in selectedNetworks {
                         do {
                             let mgr = try walletManagerStore.backgroundManager(for: net)
-                            // An imported mnemonic may already have on-chain
-                            // history (incl. DashPay payments) from before this
-                            // device — scan from genesis (birthHeight 0) so it
-                            // is seen. A freshly generated mnemonic has nothing
-                            // before now, so scan from the tip (nil).
                             let managed = try mgr.createWallet(
                                 mnemonic: mnemonicPhrase,
                                 network: net,
                                 name: walletLabel,
-                                birthHeight: showImportOption ? 0 : nil
+                                birthHeight: showImportOption ? importBirth : nil
                             )
                             createdWallets.append((net, managed.walletId))
                         } catch {

--- a/packages/swift-sdk/SwiftExampleApp/SwiftExampleApp/Core/Views/CreateWalletView.swift
+++ b/packages/swift-sdk/SwiftExampleApp/SwiftExampleApp/Core/Views/CreateWalletView.swift
@@ -367,7 +367,20 @@ struct CreateWalletView: View {
                     // avoiding a full-chain scan. Left empty it falls back to
                     // genesis (0) so a wallet of unknown age still sees all its
                     // history. A freshly generated wallet passes nil (tip).
-                    let importBirth = UInt32(importBirthHeight.trimmingCharacters(in: .whitespaces)) ?? 0
+                    let trimmedImportBirthHeight = importBirthHeight.trimmingCharacters(in: .whitespaces)
+                    let importBirth = UInt32(trimmedImportBirthHeight) ?? 0
+                    // Birth height is chain-local: a single value can't be
+                    // correct for more than one network, so reject a non-empty
+                    // height when importing to multiple networks. Left blank the
+                    // safe genesis (0) fallback still applies to each network.
+                    if showImportOption, !trimmedImportBirthHeight.isEmpty, selectedNetworks.count > 1 {
+                        struct MultiNetworkBirthHeightUnsupported: LocalizedError {
+                            var errorDescription: String? {
+                                "Birth height is network-specific. Select one network or leave birth height empty when importing to multiple networks."
+                            }
+                        }
+                        throw MultiNetworkBirthHeightUnsupported()
+                    }
                     for net in selectedNetworks {
                         do {
                             let mgr = try walletManagerStore.backgroundManager(for: net)


### PR DESCRIPTION
- **Fresh wallet:** a wallet created at app startup registers before SPV has synced any headers, so the tip read as 0 and it anchored at genesis and rescanned the whole chain. It now falls back to the network's latest checkpoint, so a new wallet syncs from near the chain head.
- **Imported wallet:** thread a `birth_height` through the swift-sdk import FFI and the example app, so a recovered wallet scans from its birth height instead of from scratch.
- **Dependency:** bump rust-dashcore to the branch carrying the wallet birth-height checkpoint anchoring engine (`dash-spv`).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional **Birth height** field when importing an existing wallet, allowing users to choose the sync start point.
  * Wallet import now carries the selected birth height through to the underlying SDK.

* **Bug Fixes**
  * Fresh wallet syncing now prefers the latest available checkpoint when the SPV tip height isn’t usable, reducing unnecessary catch-up from genesis.
  * Import now safely defaults when the height field is empty, and importing a provided birth height across multiple networks is now blocked with a clear error.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->