### PR TITLE
fix(platform-wallet): freeze sync watermark on persistence fault — TXO loss/duplication (#4069)

### DIFF
--- a/packages/kotlin-sdk/sdk/src/test/kotlin/org/dashfoundation/dashsdk/persistence/PlatformWalletPersistenceHandlerTest.kt
+++ b/packages/kotlin-sdk/sdk/src/test/kotlin/org/dashfoundation/dashsdk/persistence/PlatformWalletPersistenceHandlerTest.kt
@@ -150,6 +150,57 @@ class PlatformWalletPersistenceHandlerTest {
         assertEquals(123_456, db.walletDao().getByWalletId(walletId)!!.syncedHeight)
     }
 
+    /**
+     * dashpay/platform#4069 (Kotlin half of signature C): the
+     * `syncedHeight` watermark is written by [onWalletChangesetHeader]
+     * into the SAME buffered transaction as the TXO/tx rows of its
+     * changeset. A round that rolls back (`success = false`) must
+     * therefore NOT advance the persisted watermark — otherwise the
+     * durable watermark could outrun the rows it implies, exactly the
+     * "empty-and-scanned after restart" corruption in #4069. Pins the
+     * rollback path for the core header specifically (the sibling
+     * `changesetRollbackDiscardsBufferedWrites` only covers the
+     * platform sync-state write).
+     */
+    @Test
+    fun walletChangesetHeaderDoesNotAdvanceSyncedHeightOnRollback() = runTest {
+        handler.onPersistWalletMetadata(walletId, testnet, groupId, 0)
+        // Establish a committed baseline watermark.
+        handler.onChangesetBegin(walletId)
+        handler.onWalletChangesetHeader(
+            walletId = walletId,
+            hasSyncedHeight = true,
+            syncedHeight = 1_000,
+            hasBalance = false,
+            confirmedDelta = 0,
+            unconfirmedDelta = 0,
+            immatureDelta = 0,
+            lockedDelta = 0,
+            lastAppliedChainLockBytes = ByteArray(0),
+        )
+        handler.onChangesetEnd(walletId, success = true)
+        assertEquals(1_000, db.walletDao().getByWalletId(walletId)!!.syncedHeight)
+
+        // A later round tries to advance the watermark but rolls back.
+        handler.onChangesetBegin(walletId)
+        handler.onWalletChangesetHeader(
+            walletId = walletId,
+            hasSyncedHeight = true,
+            syncedHeight = 2_000,
+            hasBalance = false,
+            confirmedDelta = 0,
+            unconfirmedDelta = 0,
+            immatureDelta = 0,
+            lockedDelta = 0,
+            lastAppliedChainLockBytes = ByteArray(0),
+        )
+        handler.onChangesetEnd(walletId, success = false)
+
+        // Watermark stays at the last committed value — never the
+        // rolled-back 2_000.
+        assertEquals(1_000, db.walletDao().getByWalletId(walletId)!!.syncedHeight)
+    }
+
     @Test
     fun walletChangesetAddsAccountUtxoAndTransaction() = runTest {
         handler.onPersistWalletMetadata(walletId, testnet, groupId, 0)

--- a/packages/rs-platform-wallet-ffi/src/persistence.rs
+++ b/packages/rs-platform-wallet-ffi/src/persistence.rs
@@ -15,7 +15,7 @@ use key_wallet::wallet::managed_wallet_info::wallet_info_interface::WalletInfoIn
 use key_wallet::wallet::managed_wallet_info::ManagedWalletInfo;
 use key_wallet::wallet::Wallet;
 use key_wallet::AddressInfo;
-use parking_lot::RwLock;
+use parking_lot::{Mutex, RwLock};
 use std::str::FromStr;
 
 use crate::types::{FFINetwork, Network};
@@ -610,10 +610,62 @@ impl Default for PersistenceCallbacks {
     }
 }
 
+/// Defensive state machine for the begin→end FFI callback round, guarded
+/// by [`FFIPersister::round_lock`]. `in_round` is set when a round opens
+/// and cleared once it closes, so a nested begin (or an `end` with no
+/// matching `begin`) is detectable and rejected — as an error, never a
+/// panic — instead of silently corrupting the client's single in-flight
+/// transaction state.
+#[derive(Default)]
+struct RoundGuardState {
+    in_round: bool,
+}
+
+impl RoundGuardState {
+    /// Open a round. Rejects (does not panic) if one is already open —
+    /// a nested begin, or an unclean round left open by a prior call
+    /// that unwound between its begin and end.
+    fn begin_round(&mut self) -> Result<(), PersistenceError> {
+        if self.in_round {
+            return Err(PersistenceError::backend(
+                "FFIPersister: changeset round already open (nested begin); \
+                 refusing to start a new round",
+            ));
+        }
+        self.in_round = true;
+        Ok(())
+    }
+
+    /// Close the current round. Rejects (does not panic) if no round is
+    /// open — an unmatched end.
+    fn end_round(&mut self) -> Result<(), PersistenceError> {
+        if !self.in_round {
+            return Err(PersistenceError::backend(
+                "FFIPersister: changeset round is not open (unmatched end)",
+            ));
+        }
+        self.in_round = false;
+        Ok(())
+    }
+}
+
 /// In-memory persister that accumulates changesets and notifies via callbacks.
 pub struct FFIPersister {
     callbacks: PersistenceCallbacks,
     pending: RwLock<BTreeMap<WalletId, PlatformWalletChangeSet>>,
+    /// Serializes the ENTIRE begin→per-kind→end callback round of
+    /// [`Self::store`]. Every round producer (the core-changeset bridge,
+    /// platform-address sync, shielded sync, spawned DashPay tasks) shares
+    /// one `Arc<FFIPersister>` and calls `store()` concurrently; the host
+    /// client keeps a single in-flight-round transaction state (Kotlin: one
+    /// per-wallet buffer; Swift: one global `inChangeset` flag), so two
+    /// overlapping rounds would let one round's writes land in — or roll
+    /// back with — the other round's transaction. That drops core TXO /
+    /// spent-marker rows while both `store()` calls still return `Ok`,
+    /// bypassing the durable-watermark fault latch and recreating
+    /// dashpay/platform#4069. Holding this lock for the whole round makes
+    /// each round atomic with respect to every other round.
+    round_lock: Mutex<RoundGuardState>,
 }
 
 impl FFIPersister {
@@ -621,6 +673,7 @@ impl FFIPersister {
         Self {
             callbacks,
             pending: RwLock::new(BTreeMap::new()),
+            round_lock: Mutex::new(RoundGuardState::default()),
         }
     }
 }
@@ -637,6 +690,23 @@ impl PlatformWalletPersistence for FFIPersister {
         wallet_id: WalletId,
         changeset: PlatformWalletChangeSet,
     ) -> Result<(), PersistenceError> {
+        // Serialize the ENTIRE begin→per-kind→end round against every
+        // other round producer (see `round_lock`'s field doc and
+        // dashpay/platform#4069). The lock is a synchronous
+        // `parking_lot::Mutex`, NOT a `tokio::sync::Mutex`: `store()`
+        // is a synchronous trait method invoked directly (blocking) from
+        // both async tasks and blocking FFI entry points, so an async
+        // mutex cannot be `.await`ed here and `blocking_lock()` panics
+        // inside a runtime. Serialization — not async yielding — is the
+        // requirement; callers already block for the round's duration, so
+        // the sync mutex only adds waiting under genuine round contention.
+        let mut round = self.round_lock.lock();
+
+        // Open the round on the Rust side (rejects a nested begin / an
+        // unclean round left open by a prior unwind — error, never
+        // panic). Matched 1:1 with the `round.end_round()` below.
+        round.begin_round()?;
+
         // Bracket the whole per-kind callback sequence with a
         // begin/end pair so clients (Swift, etc.) can treat the
         // round as a single atomic transaction: begin opens a
@@ -648,7 +718,19 @@ impl PlatformWalletPersistence for FFIPersister {
         if let Some(cb) = self.callbacks.on_changeset_begin_fn {
             let result = unsafe { cb(self.callbacks.context, wallet_id.as_ptr()) };
             if result != 0 {
-                eprintln!("Changeset-begin callback returned error code {}", result);
+                // A nonzero begin means the client could NOT open its
+                // transaction. Proceeding would run every per-kind
+                // callback against no batch and then fire an unmatched
+                // `end`. Treat it as fatal: close the Rust-side round
+                // (so `in_round` doesn't wedge) and fail now, before any
+                // per-kind write. (Unlike the previous advisory-log
+                // behavior, the round is aborted so no state advances
+                // against an unopened batch.)
+                let _ = round.end_round();
+                return Err(PersistenceError::backend(format!(
+                    "changeset-begin callback returned error code {result}; \
+                     round aborted before any write"
+                )));
             }
         }
         let mut round_success = true;
@@ -1525,6 +1607,15 @@ impl PlatformWalletPersistence for FFIPersister {
                 round_success = false;
             }
         }
+
+        // Close the round: its `end` callback has fired (committing or
+        // rolling back the client transaction), or there was no end
+        // callback wired. Clear the state-machine flag now — BEFORE any
+        // early return below — so a rejected round doesn't wedge the
+        // persister into permanent "round already open" rejection on the
+        // next `store()`. (`end_round` only errors on an unmatched end,
+        // which cannot happen here since `begin_round` succeeded above.)
+        round.end_round()?;
 
         if !round_success {
             return Err(PersistenceError::backend(
@@ -5086,5 +5177,191 @@ mod tests {
         );
 
         unsafe { free_contact_requests_ffi(rows.as_mut_ptr(), rows.len()) };
+    }
+
+    // ── Round serialization + defensive state machine (dashpay/platform#4069) ──
+
+    use std::os::raw::c_void as TestCVoid;
+    use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+    use std::sync::Arc;
+
+    /// Shared context for the begin/end probe callbacks. Records the
+    /// chronological boundary log and flags any interleave (a begin while
+    /// another round is already open, or an end that doesn't close the
+    /// round it should).
+    struct RoundProbe {
+        /// `true` = begin fired, `false` = end fired, in call order.
+        events: parking_lot::Mutex<Vec<bool>>,
+        /// Live round depth: must only ever toggle 0↔1. Anything else
+        /// means two rounds overlapped.
+        depth: AtomicUsize,
+        /// Latched if `depth` ever leaves the {0,1} set.
+        interleaved: AtomicBool,
+    }
+
+    impl RoundProbe {
+        fn new() -> Arc<Self> {
+            Arc::new(Self {
+                events: parking_lot::Mutex::new(Vec::new()),
+                depth: AtomicUsize::new(0),
+                interleaved: AtomicBool::new(false),
+            })
+        }
+    }
+
+    extern "C" fn probe_begin(ctx: *mut TestCVoid, _wallet_id: *const u8) -> i32 {
+        let probe = unsafe { &*(ctx as *const RoundProbe) };
+        // Entering a round: depth must transition 0 -> 1.
+        if probe.depth.fetch_add(1, Ordering::SeqCst) != 0 {
+            probe.interleaved.store(true, Ordering::SeqCst);
+        }
+        probe.events.lock().push(true);
+        // Widen the interleave window so an UNSERIALIZED persister is
+        // caught deterministically: without the round lock, the sibling
+        // thread's begin lands inside this sleep.
+        std::thread::sleep(std::time::Duration::from_millis(15));
+        0
+    }
+
+    extern "C" fn probe_end(ctx: *mut TestCVoid, _wallet_id: *const u8, _success: bool) -> i32 {
+        let probe = unsafe { &*(ctx as *const RoundProbe) };
+        probe.events.lock().push(false);
+        // Leaving a round: depth must transition 1 -> 0.
+        if probe.depth.fetch_sub(1, Ordering::SeqCst) != 1 {
+            probe.interleaved.store(true, Ordering::SeqCst);
+        }
+        0
+    }
+
+    /// dashpay/platform#4069 (P1 from QuantumExplorer's review): two
+    /// concurrent `store()` rounds through the SAME `FFIPersister` must be
+    /// fully serialized — no begin fires while another round's begin→end
+    /// bracket is still open. Without the global round lock the probe's
+    /// `begin` sleep lets the sibling thread's begin interleave, tripping
+    /// `interleaved`.
+    #[test]
+    fn concurrent_store_rounds_are_serialized() {
+        let probe = RoundProbe::new();
+        let callbacks = PersistenceCallbacks {
+            context: Arc::as_ptr(&probe) as *mut TestCVoid,
+            on_changeset_begin_fn: Some(probe_begin),
+            on_changeset_end_fn: Some(probe_end),
+            ..PersistenceCallbacks::default()
+        };
+        let persister = Arc::new(FFIPersister::new(callbacks));
+
+        const THREADS: u8 = 2;
+        const ROUNDS_PER_THREAD: usize = 10;
+        let mut handles = Vec::new();
+        for t in 0..THREADS {
+            let p = Arc::clone(&persister);
+            handles.push(std::thread::spawn(move || {
+                for _ in 0..ROUNDS_PER_THREAD {
+                    // An empty changeset still fires begin + end (they
+                    // bracket every round unconditionally).
+                    p.store([t; 32], PlatformWalletChangeSet::default())
+                        .expect("empty changeset round must succeed");
+                }
+            }));
+        }
+        for h in handles {
+            h.join().expect("store thread panicked");
+        }
+
+        assert!(
+            !probe.interleaved.load(Ordering::SeqCst),
+            "begin/end rounds interleaved — the global round lock did not \
+             serialize concurrent store() calls"
+        );
+
+        let events = probe.events.lock();
+        let expected = THREADS as usize * ROUNDS_PER_THREAD * 2;
+        assert_eq!(
+            events.len(),
+            expected,
+            "each round must fire exactly one begin + one end"
+        );
+        // Every begin must be immediately followed by its own end.
+        let mut i = 0;
+        while i < events.len() {
+            assert!(events[i], "expected a begin at position {i}");
+            assert!(!events[i + 1], "expected an end at position {}", i + 1);
+            i += 2;
+        }
+        drop(events);
+
+        // Keep the probe alive until no thread can touch the context
+        // pointer any more.
+        drop(persister);
+        drop(probe);
+    }
+
+    /// A nonzero `begin` return is fatal: the client failed to open its
+    /// transaction, so `store()` must abort before any per-kind write and
+    /// leave the round CLOSED (so the next `store()` isn't wedged).
+    #[test]
+    fn nonzero_begin_aborts_the_round() {
+        extern "C" fn failing_begin(_ctx: *mut TestCVoid, _wallet_id: *const u8) -> i32 {
+            7
+        }
+        let callbacks = PersistenceCallbacks {
+            on_changeset_begin_fn: Some(failing_begin),
+            ..PersistenceCallbacks::default()
+        };
+        let persister = FFIPersister::new(callbacks);
+        let err = persister
+            .store([1u8; 32], PlatformWalletChangeSet::default())
+            .expect_err("a nonzero begin must fail the round");
+        assert!(
+            err.to_string().contains("changeset-begin callback returned error code 7"),
+            "unexpected error: {err}"
+        );
+        // The round must be closed again: a follow-up store() with a
+        // healthy (absent) begin succeeds — proving `in_round` was reset.
+        let healthy = PersistenceCallbacks::default();
+        let persister2 = FFIPersister::new(healthy);
+        persister2
+            .store([1u8; 32], PlatformWalletChangeSet::default())
+            .expect("a healthy round must succeed");
+        // And the failing persister itself is not wedged: repeated calls
+        // keep returning the same begin error, never a "round already
+        // open" rejection.
+        let err2 = persister
+            .store([1u8; 32], PlatformWalletChangeSet::default())
+            .expect_err("second call must also fail on begin, not on a stuck round");
+        assert!(
+            err2.to_string().contains("changeset-begin"),
+            "expected a fresh begin error, got a wedged-round error: {err2}"
+        );
+    }
+
+    /// The round state machine rejects a nested begin and an unmatched end
+    /// as errors (never panics), and a normal begin→end pair round-trips.
+    #[test]
+    fn round_guard_state_machine_rejects_nesting_and_unmatched_end() {
+        let mut state = RoundGuardState::default();
+        // Fresh: begin opens the round.
+        state.begin_round().expect("first begin must open the round");
+        // Nested begin is rejected (error, not panic).
+        let nested = state
+            .begin_round()
+            .expect_err("a nested begin must be rejected");
+        assert!(
+            nested.to_string().contains("nested begin"),
+            "unexpected nested-begin error: {nested}"
+        );
+        // End closes it.
+        state.end_round().expect("end must close the open round");
+        // A second end is unmatched → rejected.
+        let unmatched = state
+            .end_round()
+            .expect_err("an unmatched end must be rejected");
+        assert!(
+            unmatched.to_string().contains("unmatched end"),
+            "unexpected unmatched-end error: {unmatched}"
+        );
+        // Fully cycled back to a usable state.
+        state.begin_round().expect("state must be reusable after a clean cycle");
+        state.end_round().expect("end must close the reopened round");
     }
 }

--- a/packages/rs-platform-wallet/src/changeset/core_bridge.rs
+++ b/packages/rs-platform-wallet/src/changeset/core_bridge.rs
@@ -24,6 +24,8 @@
 //! manager's lifetime; on shutdown, fire the [`CancellationToken`] to
 //! make the task exit cleanly.
 
+use std::collections::HashMap;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 
 use dashcore::blockdata::transaction::{txout::TxOut, OutPoint};
@@ -32,6 +34,7 @@ use key_wallet::managed_account::transaction_record::{OutputRole, TransactionRec
 use key_wallet::transaction_checking::TransactionContext;
 use key_wallet::Utxo;
 use key_wallet_manager::{WalletEvent, WalletId, WalletManager};
+use tokio::sync::broadcast;
 use tokio::sync::broadcast::error::RecvError;
 use tokio::sync::RwLock;
 use tokio::task::JoinHandle;
@@ -41,13 +44,62 @@ use crate::changeset::changeset::{CoreChangeSet, PlatformWalletChangeSet};
 use crate::changeset::traits::PlatformWalletPersistence;
 use crate::wallet::platform_wallet::PlatformWalletInfo;
 
+/// Session fault state for the durable-watermark guard
+/// (dashpay/platform#4069).
+///
+/// Faults are scoped as narrowly as the triggering signal allows:
+///
+/// - A **`store()` rejection** carries a `wallet_id`, so only THAT
+///   wallet's watermark freezes. A sibling wallet whose rows are still
+///   landing atomically keeps advancing — freezing it too would force a
+///   redundant rescan of a wallet that never lost a row (the CodeRabbit /
+///   reviewer suggestion made concrete).
+/// - A broadcast **`Lagged`** has no `wallet_id` — the dropped events
+///   could have belonged to any wallet — so it freezes EVERY wallet,
+///   including wallets first seen in a later event. That is modelled as a
+///   single `global` latch rather than a per-wallet entry so future
+///   wallet ids are covered without the adapter having to enumerate them.
+#[derive(Default)]
+struct AdapterFaultState {
+    /// Set by a broadcast `Lagged`: freezes every wallet's watermark.
+    global: bool,
+    /// Set by a `store()` rejection: freezes only the named wallet.
+    per_wallet: HashMap<WalletId, bool>,
+}
+
+impl AdapterFaultState {
+    /// Whether `wallet_id`'s durable watermark must be held frozen.
+    fn is_faulted(&self, wallet_id: &WalletId) -> bool {
+        self.global || self.per_wallet.get(wallet_id).copied().unwrap_or(false)
+    }
+
+    /// Fault a single wallet after its `store()` was rejected, and raise
+    /// the host-visible hard-fault signal.
+    fn fault_wallet(&mut self, wallet_id: WalletId, hard_signal: &AtomicBool) {
+        self.per_wallet.insert(wallet_id, true);
+        hard_signal.store(true, Ordering::Relaxed);
+    }
+
+    /// Fault every wallet after a dropped-event broadcast lag, and raise
+    /// the host-visible hard-fault signal.
+    fn fault_all(&mut self, hard_signal: &AtomicBool) {
+        self.global = true;
+        hard_signal.store(true, Ordering::Relaxed);
+    }
+}
+
 /// Spawn the wallet-event subscriber task.
 ///
-/// Subscribes to `wallet_manager.subscribe_events()` from inside the
-/// spawned task (so the call-site doesn't need to be on a tokio
-/// runtime), then loops dispatching events to the persister via
-/// [`PlatformWalletPersistence::store`]. Exits when `cancel` fires
-/// or the upstream broadcast channel closes.
+/// The `receiver` MUST be subscribed by the caller *before the manager is
+/// published to producers* (see [`run_wallet_event_adapter`] for why) and
+/// then handed to this function. This function only moves it into the
+/// spawned task; it does not subscribe. Exits when `cancel` fires or the
+/// upstream broadcast channel closes.
+///
+/// `sync_fault` is the host-visible hard-fault latch: the task sets it
+/// (and never clears it) the first time it freezes a durable watermark, so
+/// an integrator can surface "verification failed / rescan pending" rather
+/// than silently re-freezing on the next launch.
 ///
 /// Generic over `P` so the spawned task gets static-dispatch on
 /// every `persister.store(...)` call. Pass the manager's own
@@ -56,134 +108,175 @@ use crate::wallet::platform_wallet::PlatformWalletInfo;
 pub fn spawn_wallet_event_adapter<P>(
     wallet_manager: Arc<RwLock<WalletManager<PlatformWalletInfo>>>,
     persister: Arc<P>,
+    receiver: broadcast::Receiver<WalletEvent>,
+    sync_fault: Arc<AtomicBool>,
     cancel: CancellationToken,
 ) -> JoinHandle<()>
 where
     P: PlatformWalletPersistence + 'static,
 {
-    tokio::spawn(async move {
-        let mut receiver = {
-            let guard = wallet_manager.read().await;
-            guard.subscribe_events()
-        };
-        tracing::debug!("wallet-event adapter task started");
+    tokio::spawn(run_wallet_event_adapter(
+        wallet_manager,
+        persister,
+        receiver,
+        sync_fault,
+        cancel,
+    ))
+}
 
-        // Durable-watermark guard (dashpay/platform#4069).
-        //
-        // The upstream `WalletManager` publishes `WalletEvent`s onto a
-        // *bounded* `tokio::broadcast` ring (capacity
-        // `DEFAULT_WALLET_EVENT_CAPACITY`, 1000) via fire-and-forget
-        // `let _ = event_sender.send(..)`. During a historical SPV
-        // catch-up the manager processes blocks far faster than this
-        // single-threaded adapter can drain them through the (slow,
-        // JNI + Room) persister, so the ring overflows and `recv()`
-        // returns `RecvError::Lagged(n)` — the `n` dropped events are
-        // gone for good. Those dropped events are exactly the
-        // `TransactionDetected` / `BlockProcessed` records that carry
-        // the new UTXOs and the spent-outpoint markers. Meanwhile the
-        // separate `SyncHeightAdvanced` event (a bare height watermark,
-        // the ONLY event whose height reaches the host persister's
-        // `syncedHeight` — see `WalletChangeSetFFI::from_changeset`)
-        // keeps flowing and eventually lands, advancing the persisted
-        // watermark past blocks whose rows never made it to disk.
-        //
-        // Symptoms (all one root cause): rows dropped entirely while the
-        // watermark advances (fresh scan persists nothing yet reports
-        // "scanned"); spent-markers lost so consumed outputs rehydrate
-        // as spendable (inflated balance); and — because the wallet's
-        // own `synced_height` is what gates a rescan — the wallet
-        // believes it is fully scanned and never re-matches, so the
-        // corruption is unrecoverable without deleting + recreating the
-        // wallet.
-        //
-        // Fix: once persistence has faulted this session (a broadcast
-        // lag OR a `store()` rejection), never advance the persisted
-        // sync watermark again. We strip `synced_height` from every
-        // subsequent changeset, freezing the durable watermark at the
-        // last height whose rows were fully committed. On the next
-        // process launch the wallet restores that (lower) watermark and
-        // the SPV scan resumes from it, re-emitting the dropped
-        // `BlockProcessed` records; the persister's upserts are
-        // idempotent on the outpoint key, so re-applying them restores
-        // the missing rows AND re-marks the lost spends — turning the
-        // integrator's current manual "clear + recreate the wallet"
-        // recovery into automatic self-healing across a restart. This is
-        // deliberately conservative (freeze for the rest of the session
-        // after the first fault); the worst case is one extra rescan on
-        // the next launch, never lost or inflated funds.
-        let mut persistence_faulted = false;
+/// Drain `receiver`, project each [`WalletEvent`] into a
+/// [`CoreChangeSet`], and forward to the persister. Split out of
+/// [`spawn_wallet_event_adapter`] so the loop — not just the
+/// [`freeze_synced_height_if_faulted`] helper — is directly testable
+/// (drive a real `broadcast::Sender`, inject a probe persister).
+///
+/// # Subscribe-before-publish
+///
+/// The caller subscribes and passes the `receiver` in, rather than the
+/// task subscribing itself. A `tokio::broadcast::Receiver` only sees
+/// messages sent *after* its `subscribe()` returns; a message sent before
+/// the receiver exists is simply invisible to it — NOT reported as
+/// `Lagged`. If subscription happened inside the spawned task (as it used
+/// to), every event emitted between the manager being handed to producers
+/// and the task's first poll would be silently lost with no fault signal.
+/// Subscribing synchronously before the manager is published closes that
+/// window.
+///
+/// # Durable-watermark guard (dashpay/platform#4069)
+///
+/// The upstream `WalletManager` publishes `WalletEvent`s onto a *bounded*
+/// `tokio::broadcast` ring (capacity `DEFAULT_WALLET_EVENT_CAPACITY`,
+/// 1000) via fire-and-forget `let _ = event_sender.send(..)`. During a
+/// historical SPV catch-up the manager processes blocks far faster than
+/// this single-threaded adapter can drain them through the (slow, JNI +
+/// Room) persister, so the ring overflows and `recv()` returns
+/// `RecvError::Lagged(n)` — the `n` dropped events are gone for good.
+/// Those dropped events are exactly the `TransactionDetected` /
+/// `BlockProcessed` records that carry the new UTXOs and the
+/// spent-outpoint markers. Meanwhile the separate `SyncHeightAdvanced`
+/// event (a bare height watermark, the ONLY event whose height reaches the
+/// host persister's `syncedHeight` — see
+/// `WalletChangeSetFFI::from_changeset`) keeps flowing and eventually
+/// lands, advancing the persisted watermark past blocks whose rows never
+/// made it to disk.
+///
+/// Symptoms (all one root cause): rows dropped entirely while the
+/// watermark advances (fresh scan persists nothing yet reports "scanned");
+/// spent-markers lost so consumed outputs rehydrate as spendable (inflated
+/// balance); and — because the wallet's own `synced_height` is what gates
+/// a rescan — the wallet believes it is fully scanned and never
+/// re-matches, so the corruption is unrecoverable without deleting +
+/// recreating the wallet.
+///
+/// Fix: once a wallet has faulted this session (a broadcast lag OR a
+/// `store()` rejection), never advance ITS persisted sync watermark again
+/// (see [`AdapterFaultState`] for the per-wallet vs. global scoping). We
+/// strip `synced_height` from every subsequent changeset, freezing the
+/// durable watermark at the last height whose rows were fully committed.
+///
+/// This is a **fail-closed mitigation, not lossless recovery.** On the
+/// next process launch the wallet restores that (lower) watermark and the
+/// SPV scan resumes from it, re-emitting the dropped `BlockProcessed`
+/// records; the persister's upserts are idempotent on the outpoint key, so
+/// re-applying them restores the missing rows and re-marks the lost
+/// spends. But the capacity-1000 producer is still fire-and-forget: if the
+/// replayed catch-up again outruns this consumer, the ring lags again and
+/// the watermark re-freezes. A single restart therefore resumes from the
+/// last durable watermark — it does NOT *guarantee* a one-restart
+/// self-heal under repeated overload; repeated overload keeps freezing
+/// until the throughput mismatch is resolved (or the host acts on the
+/// hard-fault signal below). The guarantee it DOES make is the safety one:
+/// the durable watermark never outruns the rows it implies, so funds are
+/// never silently lost or inflated — the worst case is a repeated rescan.
+///
+/// When any wallet faults, the task also raises `sync_fault` (an
+/// `AtomicBool` the host can poll via
+/// `PlatformWalletManager::sync_fault_detected`) and logs at error level,
+/// so integrators can show a hard "verification failed / rescan pending"
+/// state instead of the failure being visible only in logs.
+async fn run_wallet_event_adapter<P>(
+    wallet_manager: Arc<RwLock<WalletManager<PlatformWalletInfo>>>,
+    persister: Arc<P>,
+    mut receiver: broadcast::Receiver<WalletEvent>,
+    sync_fault: Arc<AtomicBool>,
+    cancel: CancellationToken,
+) where
+    P: PlatformWalletPersistence + 'static,
+{
+    tracing::debug!("wallet-event adapter task started");
+    let mut fault = AdapterFaultState::default();
 
-        loop {
-            tokio::select! {
-                recv = receiver.recv() => {
-                    match recv {
-                        Ok(event) => {
-                            let wallet_id = event.wallet_id();
-                            // For events that need to consult per-wallet
-                            // state (today only `TransactionInstantLocked`,
-                            // which checks finality before recording the IS
-                            // lock), grab a brief read lock on the manager.
-                            let mut core = build_core_changeset(&wallet_manager, &event).await;
-                            // Hold the durable watermark at the last
-                            // fully-persisted height once persistence has
-                            // faulted (see the guard doc above). Records/UTXOs
-                            // in this changeset are still persisted — only the
-                            // height advance is suppressed.
-                            freeze_synced_height_if_faulted(&mut core, persistence_faulted);
-                            if core.is_empty_no_records() {
-                                // SyncHeightAdvanced for an unknown wallet,
-                                // empty BlockProcessed, a watermark-only event
-                                // stripped by the fault guard above, etc. —
-                                // nothing to persist. Skip the round-trip.
-                                continue;
-                            }
-                            let cs = PlatformWalletChangeSet {
-                                core: Some(core),
-                                ..PlatformWalletChangeSet::default()
-                            };
-                            if let Err(e) = persister.store(wallet_id, cs) {
-                                // A rejected changeset means these rows are not
-                                // on disk. Fault the watermark so it can't
-                                // outrun them; the next scan re-emits and the
-                                // idempotent upserts recover the state.
-                                persistence_faulted = true;
-                                tracing::error!(
-                                    wallet_id = %hex::encode(wallet_id),
-                                    error = %e,
-                                    "Persister rejected core changeset; freezing sync watermark so the next scan re-persists the missing rows (dashpay/platform#4069)"
-                                );
-                            }
+    loop {
+        tokio::select! {
+            recv = receiver.recv() => {
+                match recv {
+                    Ok(event) => {
+                        let wallet_id = event.wallet_id();
+                        // For events that need to consult per-wallet
+                        // state (today only `TransactionInstantLocked`,
+                        // which checks finality before recording the IS
+                        // lock), grab a brief read lock on the manager.
+                        let mut core = build_core_changeset(&wallet_manager, &event).await;
+                        // Hold this wallet's durable watermark at the last
+                        // fully-persisted height once it has faulted (see
+                        // the guard doc above). Records/UTXOs in this
+                        // changeset are still persisted — only the height
+                        // advance is suppressed.
+                        freeze_synced_height_if_faulted(&mut core, fault.is_faulted(&wallet_id));
+                        if core.is_empty_no_records() {
+                            // SyncHeightAdvanced for an unknown wallet,
+                            // empty BlockProcessed, a watermark-only event
+                            // stripped by the fault guard above, etc. —
+                            // nothing to persist. Skip the round-trip.
+                            continue;
                         }
-                        Err(RecvError::Closed) if cancel.is_cancelled() => break,
-                        Err(RecvError::Closed) => {
-                            tracing::error!("WalletEvent broadcast closed unexpectedly");
-                            break;
-                        }
-                        Err(RecvError::Lagged(n)) => {
-                            // The `n` dropped events carried record/UTXO/spend
-                            // rows we will never see again this session. Fault
-                            // the watermark so it stays at the last
-                            // fully-persisted height and the next scan
-                            // re-emits the lost blocks (dashpay/platform#4069).
-                            persistence_faulted = true;
+                        let cs = PlatformWalletChangeSet {
+                            core: Some(core),
+                            ..PlatformWalletChangeSet::default()
+                        };
+                        if let Err(e) = persister.store(wallet_id, cs) {
+                            // A rejected changeset means these rows are not
+                            // on disk. Fault THIS wallet's watermark so it
+                            // can't outrun them; the next scan re-emits and
+                            // the idempotent upserts recover the state.
+                            fault.fault_wallet(wallet_id, &sync_fault);
                             tracing::error!(
-                                missed = n,
-                                "wallet-event adapter lagged on broadcast channel; {n} persistence events dropped — freezing sync watermark so the next scan re-persists them (dashpay/platform#4069)"
+                                wallet_id = %hex::encode(wallet_id),
+                                error = %e,
+                                "Persister rejected core changeset; freezing this wallet's sync watermark so the next scan re-persists the missing rows (dashpay/platform#4069)"
                             );
                         }
                     }
+                    Err(RecvError::Closed) if cancel.is_cancelled() => break,
+                    Err(RecvError::Closed) => {
+                        tracing::error!("WalletEvent broadcast closed unexpectedly");
+                        break;
+                    }
+                    Err(RecvError::Lagged(n)) => {
+                        // The `n` dropped events carried record/UTXO/spend
+                        // rows we will never see again this session, and we
+                        // don't know which wallet(s) they belonged to.
+                        // Fault EVERY wallet so no watermark outruns its
+                        // rows; the next scan re-emits the lost blocks
+                        // (dashpay/platform#4069).
+                        fault.fault_all(&sync_fault);
+                        tracing::error!(
+                            missed = n,
+                            "wallet-event adapter lagged on broadcast channel; {n} persistence events dropped — freezing every wallet's sync watermark so the next scan re-persists them (dashpay/platform#4069)"
+                        );
+                    }
                 }
-                _ = cancel.cancelled() => break,
             }
+            _ = cancel.cancelled() => break,
         }
-        tracing::debug!("wallet-event adapter task exiting");
-    })
+    }
+    tracing::debug!("wallet-event adapter task exiting");
 }
 
 /// Durable-watermark guard for dashpay/platform#4069.
 ///
-/// When the persister has faulted this session (a broadcast lag dropped
-/// record-bearing events, or a `store()` was rejected), the persisted
+/// When a wallet has faulted this session (a broadcast lag dropped
+/// record-bearing events, or a `store()` was rejected), its persisted
 /// `synced_height` watermark must not advance past the last height whose
 /// rows were fully committed — otherwise the wallet believes it is
 /// scanned and never re-matches the blocks whose rows were lost. This
@@ -479,5 +572,333 @@ mod tests {
             Some(300),
             "non-watermark fields must still persist while faulted"
         );
+    }
+
+    /// dashpay/platform#4069 (per-wallet fault scoping): a `store()`
+    /// rejection freezes ONLY the named wallet; a broadcast `Lagged`
+    /// (no wallet id) freezes every wallet, including one first seen later.
+    #[test]
+    fn fault_state_scopes_store_rejection_per_wallet_and_lag_globally() {
+        let a = [0xAAu8; 32];
+        let b = [0xBBu8; 32];
+        let signal = std::sync::atomic::AtomicBool::new(false);
+
+        let mut fault = AdapterFaultState::default();
+        assert!(!fault.is_faulted(&a) && !fault.is_faulted(&b));
+
+        // store() rejection for A: A frozen, B untouched.
+        fault.fault_wallet(a, &signal);
+        assert!(fault.is_faulted(&a), "rejected wallet must freeze");
+        assert!(!fault.is_faulted(&b), "sibling wallet must keep advancing");
+        assert!(
+            signal.load(std::sync::atomic::Ordering::Relaxed),
+            "hard-fault signal must be raised on a store rejection"
+        );
+
+        // A broadcast lag freezes everything, including a never-before-seen
+        // wallet id.
+        let mut fault2 = AdapterFaultState::default();
+        let c = [0xCCu8; 32];
+        fault2.fault_all(&signal);
+        assert!(fault2.is_faulted(&c), "lag must freeze every wallet, even future ids");
+    }
+
+    // ── Adapter-loop integration tests (dashpay/platform#4069) ──
+    //
+    // These drive `run_wallet_event_adapter` with a real `broadcast`
+    // channel and a probe persister so the LOOP — not just the
+    // `freeze_synced_height_if_faulted` helper — is exercised: actual
+    // `RecvError::Lagged`, a rejected `store()`, the per-wallet freeze,
+    // and subscribe-before-publish timing.
+
+    use super::{run_wallet_event_adapter, AdapterFaultState};
+    use crate::changeset::changeset::PlatformWalletChangeSet;
+    use crate::changeset::client_start_state::ClientStartState;
+    use crate::changeset::traits::{PersistenceError, PlatformWalletPersistence};
+    use crate::wallet::platform_wallet::{PlatformWalletInfo, WalletId};
+    use key_wallet::WalletCoreBalance;
+    use key_wallet_manager::{WalletEvent, WalletManager};
+    use std::collections::{BTreeMap, HashSet};
+    use std::sync::atomic::{AtomicBool, Ordering};
+    use std::sync::{Arc, Mutex};
+    use tokio::sync::broadcast;
+    use tokio::sync::mpsc::{unbounded_channel, UnboundedSender};
+    use tokio::sync::RwLock;
+    use tokio_util::sync::CancellationToken;
+
+    /// One observed `store()` call, projected to just the fields the
+    /// watermark-freeze invariant cares about.
+    #[derive(Debug)]
+    struct StoreObserved {
+        wallet_id: WalletId,
+        synced_height: Option<u32>,
+        last_processed_height: Option<u32>,
+        n_records: usize,
+        rejected: bool,
+    }
+
+    /// Test persister: records every `store()` (over an unbounded tokio
+    /// channel so the async test can await progress without blocking the
+    /// current-thread runtime) and can be told to reject the NEXT store for
+    /// a given wallet exactly once.
+    struct ProbePersister {
+        obs: UnboundedSender<StoreObserved>,
+        fail_once: Mutex<HashSet<WalletId>>,
+    }
+
+    impl ProbePersister {
+        fn new(obs: UnboundedSender<StoreObserved>) -> Self {
+            Self {
+                obs,
+                fail_once: Mutex::new(HashSet::new()),
+            }
+        }
+        fn fail_next(&self, wallet_id: WalletId) {
+            self.fail_once.lock().unwrap().insert(wallet_id);
+        }
+    }
+
+    impl PlatformWalletPersistence for ProbePersister {
+        fn store(
+            &self,
+            wallet_id: WalletId,
+            changeset: PlatformWalletChangeSet,
+        ) -> Result<(), PersistenceError> {
+            let core = changeset.core.as_ref();
+            let rejected = self.fail_once.lock().unwrap().remove(&wallet_id);
+            let _ = self.obs.send(StoreObserved {
+                wallet_id,
+                synced_height: core.and_then(|c| c.synced_height),
+                last_processed_height: core.and_then(|c| c.last_processed_height),
+                n_records: core.map(|c| c.records.len()).unwrap_or(0),
+                rejected,
+            });
+            if rejected {
+                Err(PersistenceError::backend("probe: forced store rejection"))
+            } else {
+                Ok(())
+            }
+        }
+
+        fn flush(&self, _wallet_id: WalletId) -> Result<(), PersistenceError> {
+            Ok(())
+        }
+
+        fn load(&self) -> Result<ClientStartState, PersistenceError> {
+            Ok(ClientStartState::default())
+        }
+    }
+
+    fn test_manager() -> Arc<RwLock<WalletManager<PlatformWalletInfo>>> {
+        Arc::new(RwLock::new(WalletManager::<PlatformWalletInfo>::new(
+            dashcore::Network::Testnet,
+        )))
+    }
+
+    /// A bare watermark event — the ONLY event whose height reaches the
+    /// persisted `syncedHeight`, and therefore the one the guard strips.
+    fn sync_height_event(wallet_id: WalletId, height: u32) -> WalletEvent {
+        WalletEvent::SyncHeightAdvanced { wallet_id, height }
+    }
+
+    /// A record-bearing (non-watermark) event: carries
+    /// `last_processed_height` but no `synced_height`, so it survives the
+    /// freeze untouched. Used both as a sentinel to prove loop progress and
+    /// to prove records still persist after the guard activates.
+    fn block_processed_event(wallet_id: WalletId, height: u32) -> WalletEvent {
+        WalletEvent::BlockProcessed {
+            wallet_id,
+            height,
+            chain_lock: None,
+            inserted: vec![],
+            updated: vec![],
+            matured: vec![],
+            balance: WalletCoreBalance::default(),
+            account_balances: BTreeMap::new(),
+            addresses_derived: vec![],
+        }
+    }
+
+    /// (b) A real `RecvError::Lagged` flips the fault latch, and a
+    /// subsequent watermark-only event is stripped (never delivered as a
+    /// store), while a record-bearing event still persists.
+    #[tokio::test]
+    async fn lagged_broadcast_freezes_and_strips_subsequent_watermark() {
+        let wallet_id = [7u8; 32];
+        // Capacity 2, send 4 before the adapter drains → the receiver's
+        // first recv() observes Lagged(2). Ring retains heights 3,4.
+        let (tx, rx) = broadcast::channel::<WalletEvent>(2);
+        for h in 1..=4u32 {
+            tx.send(sync_height_event(wallet_id, h)).unwrap();
+        }
+
+        let (obs_tx, mut obs_rx) = unbounded_channel();
+        let persister = Arc::new(ProbePersister::new(obs_tx));
+        let sync_fault = Arc::new(AtomicBool::new(false));
+        let cancel = CancellationToken::new();
+        let handle = tokio::spawn(run_wallet_event_adapter(
+            test_manager(),
+            Arc::clone(&persister),
+            rx,
+            Arc::clone(&sync_fault),
+            cancel.clone(),
+        ));
+
+        // Post-lag watermark: must be stripped (never stored).
+        tx.send(sync_height_event(wallet_id, 100)).unwrap();
+        // Record-bearing sentinel: proves the loop advanced past every
+        // watermark AND that records still persist after the freeze.
+        tx.send(block_processed_event(wallet_id, 50)).unwrap();
+
+        let observed = obs_rx.recv().await.expect("sentinel store must arrive");
+        assert_eq!(observed.wallet_id, wallet_id);
+        assert_eq!(
+            observed.synced_height, None,
+            "watermark must be stripped after a broadcast lag"
+        );
+        assert_eq!(
+            observed.last_processed_height,
+            Some(50),
+            "record-bearing field must persist after the freeze"
+        );
+        assert!(
+            obs_rx.try_recv().is_err(),
+            "no watermark-only store should have been delivered after the lag"
+        );
+        assert!(
+            sync_fault.load(Ordering::Relaxed),
+            "hard sync-fault signal must be raised on a lag"
+        );
+
+        cancel.cancel();
+        drop(tx);
+        handle.await.unwrap();
+    }
+
+    /// (c) A rejected `store()` faults the wallet, and the very next
+    /// watermark-only event is stripped and dropped (not delivered).
+    #[tokio::test]
+    async fn rejected_store_freezes_wallet_and_strips_watermark() {
+        let wallet_id = [9u8; 32];
+        let (tx, rx) = broadcast::channel::<WalletEvent>(16);
+        let (obs_tx, mut obs_rx) = unbounded_channel();
+        let persister = Arc::new(ProbePersister::new(obs_tx));
+        persister.fail_next(wallet_id); // first store() for this wallet is rejected
+        let sync_fault = Arc::new(AtomicBool::new(false));
+        let cancel = CancellationToken::new();
+        let handle = tokio::spawn(run_wallet_event_adapter(
+            test_manager(),
+            Arc::clone(&persister),
+            rx,
+            Arc::clone(&sync_fault),
+            cancel.clone(),
+        ));
+
+        // 1) Record-bearing event whose store() is rejected → faults wallet.
+        tx.send(block_processed_event(wallet_id, 10)).unwrap();
+        let first = obs_rx.recv().await.expect("rejected store still calls store()");
+        assert!(first.rejected, "first store must be the forced rejection");
+        assert_eq!(first.last_processed_height, Some(10));
+
+        // 2) Watermark-only event → stripped, never delivered.
+        tx.send(sync_height_event(wallet_id, 200)).unwrap();
+        // 3) Sentinel proving the loop moved past the watermark.
+        tx.send(block_processed_event(wallet_id, 20)).unwrap();
+
+        let sentinel = obs_rx.recv().await.expect("sentinel store must arrive");
+        assert_eq!(
+            sentinel.last_processed_height,
+            Some(20),
+            "the sentinel (not the stripped watermark) is the next delivered store"
+        );
+        assert_eq!(sentinel.synced_height, None);
+        assert!(
+            obs_rx.try_recv().is_err(),
+            "the watermark-only changeset must not have been delivered after the fault"
+        );
+        assert!(sync_fault.load(Ordering::Relaxed));
+
+        cancel.cancel();
+        drop(tx);
+        handle.await.unwrap();
+    }
+
+    /// (d) Record-bearing changesets keep persisting after the guard is
+    /// active — only the watermark is held back.
+    #[tokio::test]
+    async fn record_bearing_changesets_persist_after_guard_activates() {
+        let wallet_id = [4u8; 32];
+        let (tx, rx) = broadcast::channel::<WalletEvent>(16);
+        let (obs_tx, mut obs_rx) = unbounded_channel();
+        let persister = Arc::new(ProbePersister::new(obs_tx));
+        persister.fail_next(wallet_id); // activate the guard via a rejection
+        let sync_fault = Arc::new(AtomicBool::new(false));
+        let cancel = CancellationToken::new();
+        let handle = tokio::spawn(run_wallet_event_adapter(
+            test_manager(),
+            Arc::clone(&persister),
+            rx,
+            Arc::clone(&sync_fault),
+            cancel.clone(),
+        ));
+
+        // Trip the guard.
+        tx.send(block_processed_event(wallet_id, 10)).unwrap();
+        let _ = obs_rx.recv().await.expect("first (rejected) store");
+
+        // A later record-bearing event must STILL be persisted.
+        tx.send(block_processed_event(wallet_id, 30)).unwrap();
+        let later = obs_rx.recv().await.expect("post-guard record-bearing store must arrive");
+        assert_eq!(
+            later.last_processed_height,
+            Some(30),
+            "record-bearing changesets must still persist while the watermark is frozen"
+        );
+        assert_eq!(later.synced_height, None, "watermark stays frozen");
+        assert!(!later.rejected, "second store must succeed");
+
+        cancel.cancel();
+        drop(tx);
+        handle.await.unwrap();
+    }
+
+    /// (e) Subscribe-before-publish: an event emitted BEFORE the adapter
+    /// task is spawned (i.e. before it polls) is still delivered, because
+    /// the receiver was subscribed up-front and handed to the task. This is
+    /// the exact invariant the manager now relies on.
+    #[tokio::test]
+    async fn events_emitted_before_task_poll_are_received() {
+        let wallet_id = [3u8; 32];
+        let (tx, rx) = broadcast::channel::<WalletEvent>(16);
+        // Emit BEFORE the task is spawned / polls.
+        tx.send(block_processed_event(wallet_id, 77)).unwrap();
+
+        let (obs_tx, mut obs_rx) = unbounded_channel();
+        let persister = Arc::new(ProbePersister::new(obs_tx));
+        let sync_fault = Arc::new(AtomicBool::new(false));
+        let cancel = CancellationToken::new();
+        let handle = tokio::spawn(run_wallet_event_adapter(
+            test_manager(),
+            Arc::clone(&persister),
+            rx,
+            Arc::clone(&sync_fault),
+            cancel.clone(),
+        ));
+
+        let observed = obs_rx
+            .recv()
+            .await
+            .expect("a pre-spawn event must still be delivered");
+        assert_eq!(observed.wallet_id, wallet_id);
+        assert_eq!(observed.last_processed_height, Some(77));
+        assert_eq!(observed.n_records, 0);
+        assert!(
+            !sync_fault.load(Ordering::Relaxed),
+            "no fault expected on the happy path"
+        );
+
+        cancel.cancel();
+        drop(tx);
+        handle.await.unwrap();
     }
 }

--- a/packages/rs-platform-wallet/src/changeset/core_bridge.rs
+++ b/packages/rs-platform-wallet/src/changeset/core_bridge.rs
@@ -68,6 +68,51 @@ where
         };
         tracing::debug!("wallet-event adapter task started");
 
+        // Durable-watermark guard (dashpay/platform#4069).
+        //
+        // The upstream `WalletManager` publishes `WalletEvent`s onto a
+        // *bounded* `tokio::broadcast` ring (capacity
+        // `DEFAULT_WALLET_EVENT_CAPACITY`, 1000) via fire-and-forget
+        // `let _ = event_sender.send(..)`. During a historical SPV
+        // catch-up the manager processes blocks far faster than this
+        // single-threaded adapter can drain them through the (slow,
+        // JNI + Room) persister, so the ring overflows and `recv()`
+        // returns `RecvError::Lagged(n)` — the `n` dropped events are
+        // gone for good. Those dropped events are exactly the
+        // `TransactionDetected` / `BlockProcessed` records that carry
+        // the new UTXOs and the spent-outpoint markers. Meanwhile the
+        // separate `SyncHeightAdvanced` event (a bare height watermark,
+        // the ONLY event whose height reaches the host persister's
+        // `syncedHeight` — see `WalletChangeSetFFI::from_changeset`)
+        // keeps flowing and eventually lands, advancing the persisted
+        // watermark past blocks whose rows never made it to disk.
+        //
+        // Symptoms (all one root cause): rows dropped entirely while the
+        // watermark advances (fresh scan persists nothing yet reports
+        // "scanned"); spent-markers lost so consumed outputs rehydrate
+        // as spendable (inflated balance); and — because the wallet's
+        // own `synced_height` is what gates a rescan — the wallet
+        // believes it is fully scanned and never re-matches, so the
+        // corruption is unrecoverable without deleting + recreating the
+        // wallet.
+        //
+        // Fix: once persistence has faulted this session (a broadcast
+        // lag OR a `store()` rejection), never advance the persisted
+        // sync watermark again. We strip `synced_height` from every
+        // subsequent changeset, freezing the durable watermark at the
+        // last height whose rows were fully committed. On the next
+        // process launch the wallet restores that (lower) watermark and
+        // the SPV scan resumes from it, re-emitting the dropped
+        // `BlockProcessed` records; the persister's upserts are
+        // idempotent on the outpoint key, so re-applying them restores
+        // the missing rows AND re-marks the lost spends — turning the
+        // integrator's current manual "clear + recreate the wallet"
+        // recovery into automatic self-healing across a restart. This is
+        // deliberately conservative (freeze for the rest of the session
+        // after the first fault); the worst case is one extra rescan on
+        // the next launch, never lost or inflated funds.
+        let mut persistence_faulted = false;
+
         loop {
             tokio::select! {
                 recv = receiver.recv() => {
@@ -78,11 +123,18 @@ where
                             // state (today only `TransactionInstantLocked`,
                             // which checks finality before recording the IS
                             // lock), grab a brief read lock on the manager.
-                            let core = build_core_changeset(&wallet_manager, &event).await;
+                            let mut core = build_core_changeset(&wallet_manager, &event).await;
+                            // Hold the durable watermark at the last
+                            // fully-persisted height once persistence has
+                            // faulted (see the guard doc above). Records/UTXOs
+                            // in this changeset are still persisted — only the
+                            // height advance is suppressed.
+                            freeze_synced_height_if_faulted(&mut core, persistence_faulted);
                             if core.is_empty_no_records() {
                                 // SyncHeightAdvanced for an unknown wallet,
-                                // empty BlockProcessed, etc. — nothing to
-                                // persist. Skip the round-trip.
+                                // empty BlockProcessed, a watermark-only event
+                                // stripped by the fault guard above, etc. —
+                                // nothing to persist. Skip the round-trip.
                                 continue;
                             }
                             let cs = PlatformWalletChangeSet {
@@ -90,10 +142,15 @@ where
                                 ..PlatformWalletChangeSet::default()
                             };
                             if let Err(e) = persister.store(wallet_id, cs) {
-                                tracing::warn!(
+                                // A rejected changeset means these rows are not
+                                // on disk. Fault the watermark so it can't
+                                // outrun them; the next scan re-emits and the
+                                // idempotent upserts recover the state.
+                                persistence_faulted = true;
+                                tracing::error!(
                                     wallet_id = %hex::encode(wallet_id),
                                     error = %e,
-                                    "Persister rejected core changeset; state will be re-emitted on next sync round"
+                                    "Persister rejected core changeset; freezing sync watermark so the next scan re-persists the missing rows (dashpay/platform#4069)"
                                 );
                             }
                         }
@@ -103,9 +160,15 @@ where
                             break;
                         }
                         Err(RecvError::Lagged(n)) => {
-                            tracing::warn!(
+                            // The `n` dropped events carried record/UTXO/spend
+                            // rows we will never see again this session. Fault
+                            // the watermark so it stays at the last
+                            // fully-persisted height and the next scan
+                            // re-emits the lost blocks (dashpay/platform#4069).
+                            persistence_faulted = true;
+                            tracing::error!(
                                 missed = n,
-                                "wallet-event adapter lagged on broadcast channel; some events were dropped"
+                                "wallet-event adapter lagged on broadcast channel; {n} persistence events dropped — freezing sync watermark so the next scan re-persists them (dashpay/platform#4069)"
                             );
                         }
                     }
@@ -115,6 +178,23 @@ where
         }
         tracing::debug!("wallet-event adapter task exiting");
     })
+}
+
+/// Durable-watermark guard for dashpay/platform#4069.
+///
+/// When the persister has faulted this session (a broadcast lag dropped
+/// record-bearing events, or a `store()` was rejected), the persisted
+/// `synced_height` watermark must not advance past the last height whose
+/// rows were fully committed — otherwise the wallet believes it is
+/// scanned and never re-matches the blocks whose rows were lost. This
+/// strips ONLY `synced_height`; every other field (records, UTXO
+/// deltas, `last_processed_height`, chain-lock) is left intact so
+/// in-flight rows still persist. Factored out as a pure function so the
+/// invariant is unit-testable without the async broadcast plumbing.
+fn freeze_synced_height_if_faulted(core: &mut CoreChangeSet, persistence_faulted: bool) {
+    if persistence_faulted {
+        core.synced_height = None;
+    }
 }
 
 /// Project an upstream [`WalletEvent`] into a [`CoreChangeSet`] suitable
@@ -355,5 +435,49 @@ impl CoreChangeSet {
             && self.synced_height.is_none()
             && self.last_applied_chain_lock.is_none()
             && self.addresses_derived.is_empty()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::freeze_synced_height_if_faulted;
+    use crate::changeset::changeset::CoreChangeSet;
+
+    /// dashpay/platform#4069: while persistence is healthy the sync
+    /// watermark flows through untouched.
+    #[test]
+    fn healthy_persistence_keeps_synced_height() {
+        let mut core = CoreChangeSet {
+            synced_height: Some(100),
+            last_processed_height: Some(300),
+            ..CoreChangeSet::default()
+        };
+        freeze_synced_height_if_faulted(&mut core, false);
+        assert_eq!(core.synced_height, Some(100));
+        assert_eq!(core.last_processed_height, Some(300));
+    }
+
+    /// dashpay/platform#4069: once persistence has faulted, the durable
+    /// watermark is frozen (`synced_height` stripped) so it can't outrun
+    /// the rows — but ONLY `synced_height` is dropped; every other field
+    /// (here `last_processed_height`, standing in for records/UTXO
+    /// deltas) still persists.
+    #[test]
+    fn faulted_persistence_freezes_only_synced_height() {
+        let mut core = CoreChangeSet {
+            synced_height: Some(200),
+            last_processed_height: Some(300),
+            ..CoreChangeSet::default()
+        };
+        freeze_synced_height_if_faulted(&mut core, true);
+        assert_eq!(
+            core.synced_height, None,
+            "watermark must be frozen after a persistence fault"
+        );
+        assert_eq!(
+            core.last_processed_height,
+            Some(300),
+            "non-watermark fields must still persist while faulted"
+        );
     }
 }

--- a/packages/rs-platform-wallet/src/manager/mod.rs
+++ b/packages/rs-platform-wallet/src/manager/mod.rs
@@ -99,6 +99,14 @@ pub struct PlatformWalletManager<P: PlatformWalletPersistence + 'static> {
     /// is torn down.
     pub(super) event_adapter_cancel: CancellationToken,
     pub(super) event_adapter_join: tokio::sync::Mutex<Option<JoinHandle<()>>>,
+    /// Host-visible hard sync-fault latch (dashpay/platform#4069). Set
+    /// (and never cleared) by the wallet-event adapter the first time it
+    /// freezes a durable watermark after a persistence `store()` rejection
+    /// or a dropped-event broadcast lag. Poll via
+    /// [`Self::sync_fault_detected`] to surface a "verification failed /
+    /// rescan pending" state rather than re-freezing silently on the next
+    /// launch.
+    pub(super) sync_fault: Arc<std::sync::atomic::AtomicBool>,
 }
 
 impl<P: PlatformWalletPersistence + 'static> PlatformWalletManager<P> {
@@ -112,9 +120,22 @@ impl<P: PlatformWalletPersistence + 'static> PlatformWalletManager<P> {
         persister: Arc<P>,
         app_handler: Arc<dyn PlatformEventHandler>,
     ) -> Self {
-        let wallet_manager = Arc::new(RwLock::new(WalletManager::new(sdk.network)));
+        // Subscribe to the wallet-event broadcast BEFORE the manager is
+        // wrapped in the shared `Arc<RwLock>` and handed to any producer,
+        // so no event emitted during startup is lost without a `Lagged`
+        // marker (a `broadcast::Receiver` only sees messages sent after its
+        // `subscribe()` — see `run_wallet_event_adapter`'s
+        // subscribe-before-publish note). The receiver is created here,
+        // synchronously, and moved into the adapter task below.
+        let wallet_manager_inner = WalletManager::new(sdk.network);
+        let event_receiver = wallet_manager_inner.subscribe_events();
+        let wallet_manager = Arc::new(RwLock::new(wallet_manager_inner));
         let wallets = Arc::new(RwLock::new(std::collections::BTreeMap::new()));
         let lock_notify = Arc::new(Notify::new());
+
+        // Host-visible hard sync-fault latch (dashpay/platform#4069). The
+        // adapter raises it the first time it freezes a durable watermark.
+        let sync_fault = Arc::new(std::sync::atomic::AtomicBool::new(false));
 
         // Spawn the wallet-event adapter that translates upstream
         // `WalletEvent`s into `CoreChangeSet`s and forwards them to
@@ -123,6 +144,8 @@ impl<P: PlatformWalletPersistence + 'static> PlatformWalletManager<P> {
         let event_adapter_join = spawn_wallet_event_adapter(
             Arc::clone(&wallet_manager),
             Arc::clone(&persister),
+            event_receiver,
+            Arc::clone(&sync_fault),
             event_adapter_cancel.clone(),
         );
 
@@ -192,7 +215,26 @@ impl<P: PlatformWalletPersistence + 'static> PlatformWalletManager<P> {
             persister,
             event_adapter_cancel,
             event_adapter_join: tokio::sync::Mutex::new(Some(event_adapter_join)),
+            sync_fault,
         }
+    }
+
+    /// Whether the wallet-event adapter has frozen a durable sync
+    /// watermark this session (dashpay/platform#4069).
+    ///
+    /// Returns `true` once — and stays `true` for the manager's lifetime
+    /// — after the adapter drops record-bearing events (a broadcast lag)
+    /// or a persistence `store()` is rejected, meaning the persisted
+    /// `syncedHeight` is deliberately held behind the chain tip and a
+    /// rescan is pending on the next launch. Integrators poll this to
+    /// surface a hard "verification failed / rescan pending" state instead
+    /// of the fault being visible only in error logs. It is intentionally
+    /// a coarse, latch-once, all-or-nothing signal (the per-wallet vs.
+    /// global scoping lives inside the adapter); a host that needs
+    /// per-wallet granularity should re-derive it from the persisted
+    /// watermark vs. chain tip.
+    pub fn sync_fault_detected(&self) -> bool {
+        self.sync_fault.load(std::sync::atomic::Ordering::Relaxed)
     }
 
     /// Configure network-scoped shielded support. Opens the


### PR DESCRIPTION
Fixes the root cause behind #4069 (all three reported signatures).

## Root cause
`key-wallet-manager` publishes wallet persistence events on a **bounded tokio broadcast ring (capacity 1000) with fire-and-forget sends**. During historical SPV catch-up the producer outruns the JNI→Room consumer, `recv()` returns `Lagged(n)`, and the dropped events — exactly the TXO/record/spent-marker payloads — are silently lost. `SyncHeightAdvanced` is the only event whose height reaches the persisted watermark (`WalletEntity.syncedHeight`), so the watermark advances past blocks whose rows never hit storage:

- **store-nothing**: fresh scan floods the ring → all record events dropped → zero rows persisted, watermark = tip → wallet rehydrates empty-and-"fully scanned" (funds invisible, unrecoverable without wallet re-creation)
- **inflated balance**: dropped spend events → consumed TXOs rehydrate as spendable
- **watermark vs rows**: nothing gates the watermark on record persistence across changesets (within one changeset the Kotlin handler is already atomic — verified)

Also verified NOT the cause: outpoint encoding is consistently wire-order end-to-end, and Room uses a true `@Upsert` on the outpoint PK.

## Fix (workspace-local, `rs-platform-wallet/src/changeset/core_bridge.rs`)
Once a persistence fault occurs in a session — broadcast `Lagged` **or** a rejected `store()` — `freeze_synced_height_if_faulted` strips `synced_height` from every subsequent changeset (record/UTXO deltas still persist), pinning the durable watermark at the last fully-committed height. On next launch the wallet restores the lower watermark, the SPV scan resumes over the gap, and the idempotent outpoint-keyed upserts restore missing rows / re-mark lost spends — self-healing instead of silent corruption. Fault logs raised to `error!`.

The bounded capacity itself lives in the pinned `key-wallet-manager` crate; bumping it and/or moving persistence to a backpressured channel is the recommended upstream follow-up (noted in code comments).

## Tests
- Rust: 2 new unit tests over the freeze helper; `platform-wallet` suite 400 passed / 0 failed.
- Kotlin: new regression test pinning that a rolled-back changeset does not advance `WalletEntity.syncedHeight`; `:sdk:testDebugUnitTest` green.
- On-device validation on the Android wallet's parity harness (dashpay/dash-wallet#1507, Galaxy S22/testnet) to follow — the harness that produced the three reproductions in #4069.

cc @quantumexplorer

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented synchronization progress from advancing when wallet persistence encounters an error or misses events.
  * Ensured failed or rolled-back changesets do not permanently update the stored synchronization height.
  * Preserved other wallet progress information so affected data can be reprocessed safely on the next scan.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->