### PR TITLE
feat(platform-wallet): return the exact network fee from send_payment

### DIFF
--- a/packages/rs-platform-wallet-ffi/src/dashpay.rs
+++ b/packages/rs-platform-wallet-ffi/src/dashpay.rs
@@ -543,6 +543,7 @@ pub unsafe extern "C" fn platform_wallet_send_dashpay_payment(
     memo: *const c_char,
     core_signer_handle: *mut MnemonicResolverHandle,
     out_txid: *mut [u8; 32],
+    out_fee_duffs: *mut u64,
 ) -> PlatformWalletFFIResult {
     check_ptr!(core_signer_handle);
     check_ptr!(out_txid);
@@ -592,7 +593,13 @@ pub unsafe extern "C" fn platform_wallet_send_dashpay_payment(
         })
     });
     let result = unwrap_option_or_return!(option);
-    let (txid, _entry) = unwrap_result_or_return!(result);
+    let (txid, _entry, fee_duffs) = unwrap_result_or_return!(result);
+    // Exact network fee of the broadcast transaction (inputs − outputs),
+    // straight from the builder — nullable so callers that don't care
+    // can pass NULL.
+    if !out_fee_duffs.is_null() {
+        unsafe { *out_fee_duffs = fee_duffs };
+    }
     use dashcore::hashes::Hash;
     let bytes = txid.to_raw_hash().to_byte_array();
     unsafe {

--- a/packages/rs-platform-wallet/src/wallet/identity/network/payments.rs
+++ b/packages/rs-platform-wallet/src/wallet/identity/network/payments.rs
@@ -552,6 +552,7 @@ impl<B: TransactionBroadcaster + ?Sized> DashPayView<'_, B> {
         (
             dashcore::Txid,
             crate::wallet::identity::types::dashpay::payment::PaymentEntry,
+            u64, // network fee in duffs, from the broadcast transaction
         ),
         PlatformWalletError,
     >
@@ -575,7 +576,7 @@ impl<B: TransactionBroadcaster + ?Sized> DashPayView<'_, B> {
         // re-acquires that (non-reentrant) lock internally.
         self.drain_pending_contact_crypto(provider).await;
 
-        let (payment_address, tx) = {
+        let (payment_address, tx, fee) = {
             let mut wm = self.wallet_manager.write().await;
 
             // Resolve the external account's xpub so we can derive addresses.
@@ -664,14 +665,14 @@ impl<B: TransactionBroadcaster + ?Sized> DashPayView<'_, B> {
             // `impl<S: Signer> TransactionSigner for S`) rather than the
             // resident `wallet`, so funding-input signatures are produced
             // from Keychain-derived keys without a resident seed.
-            let (tx, _fee) = builder
+            let (tx, fee) = builder
                 .build_signed(signer, |addr| {
                     managed_account.address_derivation_path(&addr)
                 })
                 .await
                 .map_err(|e| PlatformWalletError::TransactionBuild(e.to_string()))?;
 
-            (payment_address, tx)
+            (payment_address, tx, fee)
         };
 
         // --- 3. Broadcast the transaction, releasing the build's UTXO
@@ -726,7 +727,7 @@ impl<B: TransactionBroadcaster + ?Sized> DashPayView<'_, B> {
                 })?;
         }
 
-        Ok((txid, entry))
+        Ok((txid, entry, fee))
     }
 }
 

--- a/packages/swift-sdk/Sources/SwiftDashSDK/PlatformWallet/ManagedPlatformWallet.swift
+++ b/packages/swift-sdk/Sources/SwiftDashSDK/PlatformWallet/ManagedPlatformWallet.swift
@@ -2101,7 +2101,8 @@ extension ManagedPlatformWallet {
 
     /// Send a Dash payment to an established DashPay contact.
     /// `amountDuffs` is in duffs (1 DASH = 100_000_000 duffs).
-    /// Returns the 32-byte transaction id.
+    /// Returns the 32-byte transaction id plus the exact network fee
+    /// (duffs) of the broadcast transaction, straight from the builder.
     ///
     /// Prerequisite: `register_external_contact_account` must have
     /// run for the `(fromIdentityId, toContactIdentityId)` pair on
@@ -2113,7 +2114,7 @@ extension ManagedPlatformWallet {
         toContactIdentityId: Identifier,
         amountDuffs: UInt64,
         memo: String? = nil
-    ) async throws -> Data {
+    ) async throws -> (txid: Data, feeDuffs: UInt64) {
         let handle = self.handle
         let fromBytes: [UInt8] = fromIdentityId.withFFIBytes { ptr in
             Array(UnsafeBufferPointer(start: ptr, count: 32))
@@ -2128,7 +2129,8 @@ extension ManagedPlatformWallet {
         // derived, digest signed, buffers zeroed) — the seed never becomes
         // resident and no private key leaves Swift.
         let coreSigner = MnemonicResolver()
-        return try await Task.detached(priority: .userInitiated) { () -> Data in
+        return try await Task.detached(priority: .userInitiated) { () -> (txid: Data, feeDuffs: UInt64) in
+            var feeDuffs: UInt64 = 0
             var txidTuple: (
                 UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8,
                 UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8,
@@ -2153,7 +2155,8 @@ extension ManagedPlatformWallet {
                                 amountDuffs,
                                 memoPtr,
                                 coreSigner.handle,
-                                &txidTuple
+                                &txidTuple,
+                                &feeDuffs
                             )
                         }
                         if let memoCopy {
@@ -2165,7 +2168,8 @@ extension ManagedPlatformWallet {
                 }
             }
             try result.check()
-            return Swift.withUnsafeBytes(of: &txidTuple) { Data($0) }
+            let txid = Swift.withUnsafeBytes(of: &txidTuple) { Data($0) }
+            return (txid: txid, feeDuffs: feeDuffs)
         }.value
     }
 }

--- a/packages/swift-sdk/SwiftExampleApp/SwiftExampleApp/Views/DashPay/SendDashPayPaymentSheet.swift
+++ b/packages/swift-sdk/SwiftExampleApp/SwiftExampleApp/Views/DashPay/SendDashPayPaymentSheet.swift
@@ -364,7 +364,7 @@ struct SendDashPayPaymentSheet: View {
                 // useful to pass. The Rust-side
                 // `PaymentEntry.memo` slot stays available for
                 // future local-note wiring.
-                let txid = try await wallet.sendDashPayPayment(
+                let (txid, _) = try await wallet.sendDashPayPayment(
                     fromIdentityId: senderIdentity.identityId,
                     toContactIdentityId: contact.identityId,
                     amountDuffs: duffs,


### PR DESCRIPTION
## Issue being fixed or feature implemented

DashPay payment callers (dashwallet-ios in particular) need to show the exact network fee of the broadcast transaction. The transaction builder already computes this fee for every DashPay payment, but `send_payment` discarded it, so wallets could only re-estimate it after the fact.

This has been carried as a local patch on the dashwallet-ios platform pin branch and is flagged in that repo's DASHSYNC_MIGRATION.md as needing upstreaming — landing it here shrinks the next pin bump.

## What was done?

Thread the fee the builder already computes through the full stack:

- `PlatformWallet::send_payment` (rust): returns `(txid, entry, fee)` instead of dropping the fee.
- `platform_wallet_send_dashpay_payment` (FFI): gains a nullable `out_fee_duffs` out-param.
- `ManagedPlatformWallet.sendDashPayPayment` (Swift): returns `(txid: Data, feeDuffs: UInt64)`.
- `SendDashPayPaymentSheet` (SwiftExampleApp): adjusted to the tuple return.

## How Has This Been Tested?

- `cargo check -p platform-wallet -p platform-wallet-ffi --all-targets` passes.
- `cargo fmt --all --check` clean.
- SwiftExampleApp builds for the iOS simulator against a freshly rebuilt `DashSDKFFI.xcframework` containing the updated header.
- The same change has been exercised end-to-end on the dashwallet-ios pin branch, where the returned fee is displayed after a DashPay payment broadcast.

## Breaking Changes

None for consensus or the platform protocol. API-wise, `send_payment`'s return type and the FFI/Swift signatures change; the FFI out-param is nullable so existing C callers can pass NULL.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [ ] I have made corresponding changes to the documentation if needed

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - DashPay payment results now include the exact network fee in duffs, along with the transaction ID.
  - Swift SDK integrations can access the fee returned for each completed DashPay payment.
- **Updates**
  - Existing payment flows continue to display success and handle errors as before.
  - Applications using the updated payment API should accommodate the additional fee value in the result.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->