### PR TITLE
refactor(swift-sdk): promote the testnet faucet client into the SDK package

### DIFF
--- a/packages/swift-sdk/Sources/SwiftDashSDK/Utils/TestnetFaucet.swift
+++ b/packages/swift-sdk/Sources/SwiftDashSDK/Utils/TestnetFaucet.swift
@@ -1,13 +1,15 @@
 import CryptoKit
 import Foundation
 
-/// **Dev/QA tool only.** App-level client for the testnet DASH faucet at
-/// `faucet.thepasta.org`. This is a plain `URLSession` HTTP client plus a
-/// pure-Swift `cap.js` proof-of-work solver — it deliberately does **not**
-/// touch the wallet / Platform FFI, the `platform-wallet` crate, or any
-/// SDK business logic. It exists purely so QA can top up a fresh/drained
-/// testnet wallet with one tap instead of round-tripping through the web
-/// faucet (issue #3897).
+/// **Dev/QA tool only.** Client for the testnet DASH faucet at
+/// `faucet.thepasta.org`, shared by SwiftExampleApp and dashwallet-ios
+/// (promoted here from the example app so the apps don't carry drifting
+/// copies). This is a plain `URLSession` HTTP client plus a pure-Swift
+/// `cap.js` proof-of-work solver — it deliberately does **not** touch the
+/// wallet / Platform FFI, the `platform-wallet` crate, or any SDK business
+/// logic. It exists purely so QA can top up a fresh/drained testnet wallet
+/// with one tap instead of round-tripping through the web faucet
+/// (issue #3897).
 ///
 /// The faucet enforces a server-side captcha (`cap.js`). The "soft"
 /// challenge is a small proof-of-work (≈6.5M SHA-256 ops) that we solve
@@ -125,7 +127,7 @@ enum CapSolver {
 
 /// Result of a faucet funding attempt. The view turns `.failed` /
 /// `.rateLimited` into the clipboard + web-faucet fallback.
-enum TestnetFaucetOutcome: Sendable {
+public enum TestnetFaucetOutcome: Sendable {
     /// Funds were sent. `txid` is the Core transaction id; `amount` is the
     /// tDASH amount reported by `/api/status` (`coreFaucetAmount`).
     case sent(txid: String, amount: Double)
@@ -138,21 +140,21 @@ enum TestnetFaucetOutcome: Sendable {
 // MARK: - HTTP client
 
 /// Thin async client for the testnet faucet. Stateless; create one per use.
-struct TestnetFaucet {
+public struct TestnetFaucet {
     /// Faucet web host. Used both for the JSON API and as the web fallback URL.
-    static let webURL = URL(string: "https://faucet.thepasta.org/")!
+    public static let webURL = URL(string: "https://faucet.thepasta.org/")!
 
     private let host = URL(string: "https://faucet.thepasta.org")!
     private let session: URLSession
 
-    init(session: URLSession = .shared) {
+    public init(session: URLSession = .shared) {
         self.session = session
     }
 
     /// Request 1 tDASH to `address`. Solves the soft captcha on-device and
     /// posts to `/api/core-faucet`. Safe to call from the main actor — the
     /// proof-of-work runs on a detached background-priority task.
-    func requestCoreDash(address: String) async -> TestnetFaucetOutcome {
+    public func requestCoreDash(address: String) async -> TestnetFaucetOutcome {
         let trimmed = address.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty else {
             return .failed(reason: "No address available")


### PR DESCRIPTION
## Issue being fixed or feature implemented

The testnet faucet client (faucet.thepasta.org HTTP client + cap.js proof-of-work solver) lived inside SwiftExampleApp, so other SDK consumers (dashwallet-ios QA builds in particular) couldn't reuse it. dashwallet-ios has been carrying this promotion on its platform pin branch; upstreaming it shrinks the pin.

## What was done?

Moved `SwiftExampleApp/Core/Services/TestnetFaucetService.swift` → `Sources/SwiftDashSDK/Utils/TestnetFaucet.swift` (95% rename), renaming the type to `TestnetFaucet` and adjusting access levels for the package boundary. Pure code motion — no behavior change; testnet-only tooling, never invoked on mainnet paths.

## How Has This Been Tested?

- SwiftExampleApp builds for the iOS simulator on this branch (both the SDK package and the app's existing faucet call sites compile).
- The promoted client is exercised regularly from dashwallet-ios QA builds on the pin branch (funding testnet wallets via the in-app faucet button).

## Breaking Changes

None for the SDK (additive API). Within SwiftExampleApp the type moved/renamed, which is app-internal.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [ ] I have made corresponding changes to the documentation if needed

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone

🤖 Generated with [Claude Code](https://claude.com/claude-code)