### PR TITLE
feat(platform-wallet): expose SPV filter rescan via wallet synced-height rewind

### DIFF
--- a/packages/rs-platform-wallet-ffi/src/spv.rs
+++ b/packages/rs-platform-wallet-ffi/src/spv.rs
@@ -484,6 +484,58 @@ pub unsafe extern "C" fn platform_wallet_manager_spv_stop(
     PlatformWalletFFIResult::ok()
 }
 
+/// Arm an organic compact-filter rescan for one wallet by rewinding its
+/// SPV filter-scan checkpoint (`synced_height`) to `from_height`.
+///
+/// This does not itself scan; it rewinds the checkpoint on the *shared*
+/// wallet state the running `DashSpvClient` reads. On the filter-sync
+/// loop's next tick, `dash-spv`'s `FiltersManager` observes this wallet
+/// in `wallets_behind(committed_height)`, calls `reset_for_rescan()`,
+/// rewinds its committed height to this wallet's `synced_height`, and
+/// re-downloads / re-matches compact filters from there — matching any
+/// scripts (e.g. newly watched addresses) that weren't in the watch set
+/// when those blocks were first scanned.
+///
+/// `from_height` at or above the wallet's current checkpoint is written
+/// verbatim but arms no rescan (the loop only rescans wallets strictly
+/// behind the committed height), so a forward/equal set is a harmless
+/// no-op for rescan purposes.
+///
+/// Requires SPV running for an immediate effect; otherwise the rewound
+/// checkpoint takes effect when SPV next starts and its filter loop
+/// first ticks. The rewound checkpoint is in-memory only (not persisted
+/// by this call); if the process dies mid-rescan the wallet is simply
+/// still behind and the next start re-arms the backfill.
+///
+/// # Safety
+/// - `wallet_id` must point to 32 readable bytes.
+#[no_mangle]
+pub unsafe extern "C" fn platform_wallet_manager_spv_rescan_filters(
+    handle: Handle,
+    wallet_id: *const u8,
+    from_height: u32,
+) -> PlatformWalletFFIResult {
+    check_ptr!(wallet_id);
+    let wid: [u8; 32] = std::ptr::read(wallet_id as *const [u8; 32]);
+
+    let option = PLATFORM_WALLET_MANAGER_STORAGE.with_item(handle, |manager| {
+        manager.spv_rescan_filters_blocking(&wid, from_height)
+    });
+    let found = unwrap_option_or_return!(option);
+    if !found {
+        return PlatformWalletFFIResult::err(
+            PlatformWalletFFIResultCode::NotFound,
+            "Wallet not found".to_string(),
+        );
+    }
+    tracing::info!(
+        wallet_id = %hex::encode(wid),
+        from_height,
+        "platform_wallet_manager_spv_rescan_filters: armed filter rescan"
+    );
+    PlatformWalletFFIResult::ok()
+}
+
 /// Clear all persisted SPV storage (headers, filters, state).
 #[no_mangle]
 pub unsafe extern "C" fn platform_wallet_manager_spv_clear_storage(

--- a/packages/rs-platform-wallet/src/manager/accessors.rs
+++ b/packages/rs-platform-wallet/src/manager/accessors.rs
@@ -458,6 +458,58 @@ impl<P: PlatformWalletPersistence + 'static> PlatformWalletManager<P> {
         })
     }
 
+    /// Rewind a single wallet's SPV filter-scan checkpoint
+    /// (`synced_height`) to `from_height`, arming an organic filter
+    /// rescan.
+    ///
+    /// This is the write half of the same mechanism `reconcile_dashpay_rescan`
+    /// uses for historical-contact backfill. It mutates the *shared*
+    /// `wallet_manager` (`Arc<RwLock<..>>`) that the running `DashSpvClient`
+    /// holds a clone of — so the change is observed by the live filter-sync
+    /// loop: on its next tick `FiltersManager` sees this wallet in
+    /// `wallets_behind(committed_height)`, calls `reset_for_rescan()`, rewinds
+    /// its committed height to this wallet's `synced_height`, and re-downloads /
+    /// re-matches compact filters from there.
+    ///
+    /// Unlike the `WalletInterface::update_wallet_synced_height` trait method
+    /// (which is forward-only and silently ignores a lower value), this writes
+    /// `core_wallet.update_synced_height` directly, which is an unconditional
+    /// set — so a **rewind** actually takes effect. A `from_height` at or above
+    /// the current checkpoint is written verbatim but arms no rescan: the
+    /// filter loop only rescans wallets strictly *behind* the committed height,
+    /// so a forward/equal set is a harmless no-op for the rescan purpose.
+    ///
+    /// `synced_height` may regress here: that is safe because it is the
+    /// filter-scan checkpoint, decoupled from the monotonic
+    /// `last_processed_height`, and every persisted sync cursor is
+    /// monotonic-max guarded (see `reconcile_dashpay_rescan`'s note), so a
+    /// transient rewind cannot corrupt state or persist a lower cursor.
+    ///
+    /// The rewound checkpoint lives in the in-memory `WalletManager`; it is not
+    /// itself persisted by this call, and that is fine for the feature: a
+    /// rescan completes in-session, and if the process dies mid-rescan the
+    /// wallet is simply still behind, so the next `start` re-arms the same
+    /// backfill from the persisted high-water. Requires SPV running for an
+    /// immediate effect; otherwise it takes effect when SPV next starts and its
+    /// filter loop first ticks.
+    ///
+    /// Returns `false` when no wallet matches `wallet_id`.
+    pub fn spv_rescan_filters_blocking(&self, wallet_id: &WalletId, from_height: u32) -> bool {
+        use key_wallet::wallet::managed_wallet_info::wallet_info_interface::WalletInfoInterface;
+
+        let mut wm = self.wallet_manager.blocking_write();
+        let Some(info) = wm.get_wallet_info_mut(wallet_id) else {
+            return false;
+        };
+        info.core_wallet.update_synced_height(from_height);
+        tracing::info!(
+            wallet_id = %hex::encode(wallet_id),
+            from_height,
+            "SPV rescan: rewound wallet synced_height to arm a filter rescan"
+        );
+        true
+    }
+
     /// Snapshot of identity-wallet scan state for a single wallet.
     /// See [`IdentityWalletStateSnapshot`] for the field doc and the
     /// upstream renaming history (the legacy `last_scanned_index`

--- a/packages/swift-sdk/Sources/SwiftDashSDK/PlatformWallet/PlatformWalletManagerSPV.swift
+++ b/packages/swift-sdk/Sources/SwiftDashSDK/PlatformWallet/PlatformWalletManagerSPV.swift
@@ -288,4 +288,40 @@ extension PlatformWalletManager {
     public func clearSpvStorage() throws {
         try platform_wallet_manager_spv_clear_storage(handle).check()
     }
+
+    /// Arm an organic compact-filter rescan for one wallet by rewinding
+    /// its SPV filter-scan checkpoint (`synced_height`) to `fromHeight`.
+    ///
+    /// This does not scan directly. It lowers the wallet's synced height
+    /// on the shared wallet state the running filter sync reads; on that
+    /// sync's next tick the filter manager detects the wallet is behind,
+    /// resets its committed height to the rewound value, and re-downloads
+    /// and re-matches compact filters from there — picking up scripts
+    /// (e.g. addresses added after those blocks were first scanned) that
+    /// were not in the watch set the first time.
+    ///
+    /// Requires SPV running for an immediate effect; otherwise the
+    /// rewound checkpoint takes effect when SPV next starts and its
+    /// filter loop first ticks. A `fromHeight` at or above the wallet's
+    /// current checkpoint is stored but arms no rescan (the sync only
+    /// rescans wallets that are strictly behind). Throws `.notFound`
+    /// (via `.check()`) when no loaded wallet matches `walletId`.
+    ///
+    /// - Parameters:
+    ///   - walletId: the 32-byte wallet identifier.
+    ///   - fromHeight: the core block height to rewind the filter scan to.
+    public func spvRescanFilters(walletId: Data, fromHeight: UInt32) throws {
+        guard walletId.count == 32 else {
+            throw PlatformWalletError.invalidParameter(
+                "walletId must be exactly 32 bytes"
+            )
+        }
+        try walletId.withUnsafeBytes { widRaw in
+            guard let widPtr = widRaw.baseAddress?.assumingMemoryBound(to: UInt8.self)
+            else {
+                throw PlatformWalletError.invalidParameter("walletId baseAddress is nil")
+            }
+            try platform_wallet_manager_spv_rescan_filters(handle, widPtr, fromHeight).check()
+        }
+    }
 }


### PR DESCRIPTION
## Issue being fixed or feature implemented

There was no way for an SDK consumer to force the SPV engine to re-scan compact filters from an earlier height — needed when a wallet's filter matching may have missed transactions (e.g. after address-set changes) and the client wants a targeted re-check without a full resync. dashwallet-ios has been carrying this on its platform pin branch; upstreaming it shrinks the pin.

## What was done?

- `platform-wallet` (`manager/accessors.rs`): rescan entry point that rewinds the wallet's synced height so the filter loop re-fetches and re-matches filters from the requested height.
- `platform-wallet-ffi` (`spv.rs`): `platform_wallet_manager_spv_rescan_filters` wrapping it.
- Swift (`PlatformWalletManagerSPV.swift`): `spvRescanFilters(fromHeight:)` thin wrapper.

Decision logic lives in Rust; the Swift layer only marshals, per the SDK's architectural rules.

## How Has This Been Tested?

- `cargo check -p platform-wallet -p platform-wallet-ffi --all-targets` passes; `cargo fmt --all --check` clean.
- Full `build_ios.sh` run on this branch: Rust slice + regenerated headers + SwiftExampleApp simulator build all succeed.
- Exercised on-device from dashwallet-ios (pin branch): rescan from a pre-transaction height re-detects wallet transactions.

## Breaking Changes

None — additive API at all three layers.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [ ] I have made corresponding changes to the documentation if needed

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone

🤖 Generated with [Claude Code](https://claude.com/claude-code)