### PR TITLE
fix(swift-sdk): cap the faucet captcha's aggregate proof-of-work

### DIFF
--- a/packages/swift-sdk/Sources/SwiftDashSDK/Utils/TestnetFaucet.swift
+++ b/packages/swift-sdk/Sources/SwiftDashSDK/Utils/TestnetFaucet.swift
@@ -273,7 +273,9 @@ public struct TestnetFaucet {
         // few seconds of parallel hashing.
         let expectedWork = Double(c) * pow(16, Double(d))
         guard expectedWork <= 64_000_000 else {
-            throw FaucetError.message("Captcha challenge too expensive (c=\(c), d=\(d))")
+            throw FaucetError.message(
+                "Captcha challenge too expensive (c=\(c), d=\(d), "
+                    + "expectedWork=\(Int(expectedWork)) > 64000000)")
         }
 
         // Solve all c sub-challenges off the main actor, parallelized, under

--- a/packages/swift-sdk/Sources/SwiftDashSDK/Utils/TestnetFaucet.swift
+++ b/packages/swift-sdk/Sources/SwiftDashSDK/Utils/TestnetFaucet.swift
@@ -265,6 +265,17 @@ public struct TestnetFaucet {
             throw FaucetError.message("Unsupported captcha challenge (c=\(c), s=\(s), d=\(d))")
         }
 
+        // The per-field bounds alone still admit c=256, d=6 ≈ 4.3B expected
+        // attempts — enough to pin the CPU until the 30 s timeout on every
+        // tap. Cap the AGGREGATE expected work (c × 16^d). The live faucet's
+        // soft challenge is c=100, d=4 ≈ 6.6M attempts; 64M gives ~10×
+        // headroom for server-side tuning while keeping the worst case to a
+        // few seconds of parallel hashing.
+        let expectedWork = Double(c) * pow(16, Double(d))
+        guard expectedWork <= 64_000_000 else {
+            throw FaucetError.message("Captcha challenge too expensive (c=\(c), d=\(d))")
+        }
+
         // Solve all c sub-challenges off the main actor, parallelized, under
         // an overall timeout so even an in-bounds-but-slow challenge can't
         // hang the UI indefinitely (the timeout cancels the solve tasks).


### PR DESCRIPTION
Hardening for the `TestnetFaucet` client that merged in #4098: its per-field challenge bounds (`c ≤ 256`, `d ≤ 6`) still admit an aggregate of ~4.3B expected SHA-256 attempts, so a misbehaving or compromised same-domain faucet endpoint can pin the device's cores across 256 parallel solver tasks until the 30-second timeout on every faucet tap. Add an aggregate bound (`c × 16^d ≤ 64M`, ~10× the live faucet's actual soft challenge of c=100, d=4 ≈ 6.6M) so oversized challenges throw and route to the web-faucet fallback instead of burning CPU/battery.

Split out of #4049 when that PR was narrowed to the `send_payment` fee fix — this commit was originally review hardening there (`ad29deae05`) and was deliberately parked for a standalone PR rather than dropped. One hunk, comment-documented; Swift parse-checked.

Note: the faucet client's placement in the SDK package is itself under review (it may move back app-side); if #4098 is reverted, this rides along with the file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)