### PR TITLE
feat(swift-sdk): compact-filter rescan button in Core Sync Status

### DIFF
--- a/packages/swift-sdk/SwiftExampleApp/SwiftExampleApp/Core/Views/CoreContentView.swift
+++ b/packages/swift-sdk/SwiftExampleApp/SwiftExampleApp/Core/Views/CoreContentView.swift
@@ -21,6 +21,15 @@ struct CoreContentView: View {
     @State private var dashPayLastSync: Date?
     // Progress values come from PlatformWalletManager (polled from FFI each second)
 
+    /// Rescan controls: the height-choice dialog, the follow-up
+    /// custom-height alert + its numeric field, and a transient
+    /// caption summarizing the last arm attempt (the Core section
+    /// has no other feedback surface — Start/Clear only `print`).
+    @State private var showRescanDialog = false
+    @State private var showCustomHeightAlert = false
+    @State private var customHeightText = ""
+    @State private var rescanStatus: String?
+
     /// All persisted platform addresses across every wallet. Summed
     /// directly here so the global Sync Status view survives app
     /// restarts / wallet reconfigures without depending on the
@@ -172,6 +181,17 @@ var body: some View {
                         .tint(isSpvRunning ? .orange : .blue)
                         .controlSize(.mini)
 
+                        Button(action: { showRescanDialog = true }) {
+                            Text("Rescan")
+                                .font(.caption)
+                                .fontWeight(.medium)
+                        }
+                        .buttonStyle(.borderedProminent)
+                        .tint(.indigo)
+                        .controlSize(.mini)
+                        .disabled(walletIdsOnNetwork.isEmpty)
+                        .accessibilityIdentifier("coreSync.rescanFiltersButton")
+
                         Button(action: clearSyncData) {
                             Text("Clear")
                                 .font(.caption)
@@ -183,8 +203,47 @@ var body: some View {
                         .disabled(isSpvRunning)
                         .opacity(isSpvRunning ? 0.5 : 1.0)
                     }
+
+                    // Last rescan-arm outcome (success summary or the
+                    // per-wallet failures). Cleared on the next arm.
+                    if let rescanStatus {
+                        Text(rescanStatus)
+                            .font(.caption)
+                            .foregroundColor(.secondary)
+                            .lineLimit(3)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                    }
                 }
                 .padding(.vertical, 4)
+                .confirmationDialog(
+                    "Rescan Compact Filters",
+                    isPresented: $showRescanDialog,
+                    titleVisibility: .visible
+                ) {
+                    Button("Last 1,000 blocks") { armRescan(lastBlocks: 1_000) }
+                    Button("Last 10,000 blocks") { armRescan(lastBlocks: 10_000) }
+                    Button("Everything (from height 0)") { armRescan(fromHeight: 0) }
+                    Button("Custom height…") { showCustomHeightAlert = true }
+                    Button("Cancel", role: .cancel) {}
+                } message: {
+                    Text("Rewind the filter scan to re-download and re-match "
+                        + "compact filters for every wallet on this network.")
+                }
+                .alert("Rescan From Height", isPresented: $showCustomHeightAlert) {
+                    TextField("Block height", text: $customHeightText)
+                        .keyboardType(.numberPad)
+                    Button("Rescan") {
+                        if let height = UInt32(
+                            customHeightText.trimmingCharacters(in: .whitespaces)
+                        ) {
+                            armRescan(fromHeight: height)
+                        }
+                        customHeightText = ""
+                    }
+                    Button("Cancel", role: .cancel) { customHeightText = "" }
+                } message: {
+                    Text("Enter the core block height to rescan compact filters from.")
+                }
             } header: {
                 Text("Core Sync Status")
             }
@@ -852,6 +911,58 @@ var body: some View {
         } catch {
             print("❌ Failed to clear SPV storage: \(error)")
         }
+    }
+
+    // MARK: - Rescan
+
+    /// Height the "last N blocks" rescan choices count back from:
+    /// filter-scan tip, falling back to filter-headers then headers
+    /// when the earlier stages haven't produced a height yet.
+    private var rescanReferenceTip: UInt32 {
+        let filters = walletManager.spvProgress.filters?.currentHeight ?? 0
+        if filters > 0 { return filters }
+        let filterHeaders = walletManager.spvProgress.filterHeaders?.currentHeight ?? 0
+        if filterHeaders > 0 { return filterHeaders }
+        return walletManager.spvProgress.headers?.currentHeight ?? 0
+    }
+
+    private func armRescan(lastBlocks: UInt32) {
+        let tip = rescanReferenceTip
+        armRescan(fromHeight: tip > lastBlocks ? tip - lastBlocks : 0)
+    }
+
+    /// Rewind the filter-scan checkpoint to `fromHeight` for every
+    /// wallet on the active network. Collects per-wallet failures
+    /// instead of aborting on the first, then reports the outcome in
+    /// `rescanStatus`.
+    private func armRescan(fromHeight: UInt32) {
+        let ids = walletIdsOnNetwork
+        guard !ids.isEmpty else { return }
+
+        var failures: [String] = []
+        for walletId in ids {
+            do {
+                try walletManager.spvRescanFilters(walletId: walletId, fromHeight: fromHeight)
+            } catch {
+                failures.append("\(rescanShortId(walletId)): \(error.localizedDescription)")
+            }
+        }
+
+        let armed = ids.count - failures.count
+        var msg = "Rescan armed from height \(fromHeight.formatted()) "
+            + "for \(armed) wallet\(armed == 1 ? "" : "s")"
+        if !isSpvRunning {
+            msg += " — applies on next SPV start"
+        }
+        if !failures.isEmpty {
+            msg += ". Failed: " + failures.joined(separator: ", ")
+        }
+        rescanStatus = msg
+    }
+
+    /// First 4 bytes of a wallet id as hex, for compact failure lines.
+    private func rescanShortId(_ walletId: Data) -> String {
+        walletId.prefix(4).map { String(format: "%02x", $0) }.joined()
     }
 
     @MainActor

--- a/packages/swift-sdk/SwiftExampleApp/SwiftExampleApp/Core/Views/CoreContentView.swift
+++ b/packages/swift-sdk/SwiftExampleApp/SwiftExampleApp/Core/Views/CoreContentView.swift
@@ -221,13 +221,12 @@ var body: some View {
                     TextField("Block height", text: $customHeightText)
                         .keyboardType(.numberPad)
                     Button("Rescan") {
-                        if let height = UInt32(
-                            customHeightText.trimmingCharacters(in: .whitespaces)
-                        ) {
+                        if let height = customHeightValue {
                             armRescan(fromHeight: height)
                         }
                         customHeightText = ""
                     }
+                    .disabled(customHeightValue == nil)
                     Button("Cancel", role: .cancel) { customHeightText = "" }
                 } message: {
                     Text("Enter the core block height to rescan compact filters from.")
@@ -917,6 +916,13 @@ var body: some View {
     private func armRescan(lastBlocks: UInt32) {
         let tip = rescanReferenceTip
         armRescan(fromHeight: tip > lastBlocks ? tip - lastBlocks : 0)
+    }
+
+    /// The custom-height field parsed as a block height, or `nil` when
+    /// blank / non-numeric. Shared by the alert's disabled check and
+    /// its action so the two can't drift out of sync.
+    private var customHeightValue: UInt32? {
+        UInt32(customHeightText.trimmingCharacters(in: .whitespaces))
     }
 
     /// Rewind the filter-scan checkpoint to `fromHeight` for every

--- a/packages/swift-sdk/SwiftExampleApp/SwiftExampleApp/Core/Views/CoreContentView.swift
+++ b/packages/swift-sdk/SwiftExampleApp/SwiftExampleApp/Core/Views/CoreContentView.swift
@@ -21,14 +21,12 @@ struct CoreContentView: View {
     @State private var dashPayLastSync: Date?
     // Progress values come from PlatformWalletManager (polled from FFI each second)
 
-    /// Rescan controls: the height-choice dialog, the follow-up
-    /// custom-height alert + its numeric field, and a transient
-    /// caption summarizing the last arm attempt (the Core section
-    /// has no other feedback surface — Start/Clear only `print`).
+    /// Rescan controls: the height-choice dialog and the follow-up
+    /// custom-height alert + its numeric field. The arm outcome is
+    /// logged to the console, matching Start/Clear — no UI surface.
     @State private var showRescanDialog = false
     @State private var showCustomHeightAlert = false
     @State private var customHeightText = ""
-    @State private var rescanStatus: String?
 
     /// All persisted platform addresses across every wallet. Summed
     /// directly here so the global Sync Status view survives app
@@ -202,16 +200,6 @@ var body: some View {
                         .controlSize(.mini)
                         .disabled(isSpvRunning)
                         .opacity(isSpvRunning ? 0.5 : 1.0)
-                    }
-
-                    // Last rescan-arm outcome (success summary or the
-                    // per-wallet failures). Cleared on the next arm.
-                    if let rescanStatus {
-                        Text(rescanStatus)
-                            .font(.caption)
-                            .foregroundColor(.secondary)
-                            .lineLimit(3)
-                            .frame(maxWidth: .infinity, alignment: .leading)
                     }
                 }
                 .padding(.vertical, 4)
@@ -933,8 +921,8 @@ var body: some View {
 
     /// Rewind the filter-scan checkpoint to `fromHeight` for every
     /// wallet on the active network. Collects per-wallet failures
-    /// instead of aborting on the first, then reports the outcome in
-    /// `rescanStatus`.
+    /// instead of aborting on the first, then logs the outcome to the
+    /// console (matching Start/Clear — no UI surface).
     private func armRescan(fromHeight: UInt32) {
         let ids = walletIdsOnNetwork
         guard !ids.isEmpty else { return }
@@ -949,15 +937,12 @@ var body: some View {
         }
 
         let armed = ids.count - failures.count
-        var msg = "Rescan armed from height \(fromHeight.formatted()) "
-            + "for \(armed) wallet\(armed == 1 ? "" : "s")"
-        if !isSpvRunning {
-            msg += " — applies on next SPV start"
-        }
+        let applied = isSpvRunning ? "" : " (applies on next SPV start)"
+        print("🔁 Rescan armed from height \(fromHeight.formatted()) "
+            + "for \(armed) wallet\(armed == 1 ? "" : "s")\(applied)")
         if !failures.isEmpty {
-            msg += ". Failed: " + failures.joined(separator: ", ")
+            print("❌ Rescan failed for: \(failures.joined(separator: ", "))")
         }
-        rescanStatus = msg
     }
 
     /// First 4 bytes of a wallet id as hex, for compact failure lines.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

#4099 exposed SPV compact-filter rescan (`spvRescanFilters(walletId:fromHeight:)`, a wallet synced-height rewind), but SwiftExampleApp had no way to trigger it. The only way to recheck filters was the Core sync Clear button, which throws away headers and all sync state. This adds the cheap middle option: recheck filters without nuking anything.

## What was done?
<!--- Describe your changes in detail -->

All in `SwiftExampleApp/Core/Views/CoreContentView.swift` (app-layer orchestration only; no SDK/FFI changes):

- Added an indigo **Rescan** button to the Core Sync Status controls row between Start/Pause and Clear (`coreSync.rescanFiltersButton`), disabled when the active network has no wallets.
- Tapping it presents a `confirmationDialog` with height choices — last 1,000 blocks, last 10,000 blocks, everything (height 0), or a custom height via a numeric-input alert. "Last N" counts back from the filter-scan tip, falling back to filter-headers then headers height.
- On selection, `armRescan(fromHeight:)` calls `walletManager.spvRescanFilters` for every wallet on the active network, collecting per-wallet failures instead of aborting on the first.
- The outcome (armed height/wallet count, plus any per-wallet failures) is logged to the console, matching how the Start/Clear actions report.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

- `build_ios.sh --target sim` (warnings-as-errors) passes.
- Driven live on an iOS 26.3 simulator: the preset path ("Last 1,000 blocks" with Core sync unstarted correctly clamps to height 0) and the custom path (typed 5000 into the height alert) both arm the rescan for the network's wallet.
- The underlying checkpoint-rewind behavior is covered by #4099's tests; this PR only adds the UI trigger.

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->

None.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [ ] I have made corresponding changes to the documentation if needed

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a **Rescan** control for SPV compact filters in the Core Sync Status section.
  * Users can rescan preset recent block ranges or enter a custom starting height.
  * Added confirmation dialogs and status messages showing successful rescans or wallet-specific failures.
  * Rescan is unavailable when no wallets exist on the active network.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
