### PR TITLE
fix(drive-abci): bound contested value nesting depth

### DIFF
--- a/packages/rs-drive-abci/src/query/voting/contested_resources/v0/mod.rs
+++ b/packages/rs-drive-abci/src/query/voting/contested_resources/v0/mod.rs
@@ -483,4 +483,34 @@ mod tests {
                 if msg == "serialized index values exceed the contested index query limits"
         ));
     }
+
+    #[test]
+    fn test_query_contested_resources_accepts_cursor_count_at_index_arity() {
+        use dapi_grpc::platform::v0::get_contested_resources_request::get_contested_resources_request_v0::StartAtValueInfo;
+
+        let (platform, state, version) = setup_platform(Some((1, 1)), Network::Testnet, None);
+        let config = bincode::config::standard().with_big_endian();
+        let end_value =
+            bincode::encode_to_vec(Value::Text("label".to_string()), config).expect("encode");
+        let start_at_value =
+            bincode::encode_to_vec(Value::Text("$root".to_string()), config).expect("encode");
+
+        // DPNS parentNameAndLabel has two properties. One end-range value plus
+        // start-at occupies exactly the two slots allowed by the aggregate
+        // arity guard and must remain a valid query shape.
+        let request = GetContestedResourcesRequestV0 {
+            end_index_values: vec![end_value],
+            start_at_value_info: Some(StartAtValueInfo {
+                start_value: start_at_value,
+                start_value_included: true,
+            }),
+            ..dpns_contested_request()
+        };
+
+        let result = platform
+            .query_contested_resources_v0(request, &state, version)
+            .expect("expected query to succeed");
+
+        assert!(result.errors.is_empty());
+    }
 }

--- a/packages/rs-drive-abci/src/query/voting/decode_index_value.rs
+++ b/packages/rs-drive-abci/src/query/voting/decode_index_value.rs
@@ -1,4 +1,6 @@
 use crate::error::query::QueryError;
+use bincode::de::{Decode, Decoder};
+use bincode::error::DecodeError;
 use dpp::platform_value::Value;
 
 /// Maximum number of encoded bytes accepted for a single caller-supplied,
@@ -19,10 +21,102 @@ use dpp::platform_value::Value;
 /// overhead.
 pub(crate) const MAX_ENCODED_INDEX_VALUE_BYTES: usize = 4 * 1024;
 
+/// Maximum total encoded index/cursor bytes accepted across one query.
+///
+/// Keep this separate from the per-value ceiling so either boundary can be
+/// tightened without silently changing the other.
+const MAX_AGGREGATE_ENCODED_INDEX_VALUES_BYTES: usize = 4 * 1024;
+
 /// Maximum decoded-memory budget for one value. This remains deliberately
 /// larger than the encoded budget to accommodate valid nested Values while
 /// preventing declared container lengths from causing unreasonable allocation.
 const MAX_DECODED_INDEX_VALUE_BYTES: usize = 64 * 1024;
+
+/// Maximum nesting depth for caller-supplied Array and Map values.
+///
+/// Bincode's allocation limit does not bound recursive decoder frames. A
+/// canonical 4 KiB payload can otherwise contain more than 2,000 nested
+/// single-element arrays and overflow Drive's 8 MiB dev-profile worker stack.
+const MAX_INDEX_VALUE_NESTING_DEPTH: usize = 64;
+
+struct DepthLimitedValue(Value);
+
+impl Decode<()> for DepthLimitedValue {
+    fn decode<D: Decoder<Context = ()>>(decoder: &mut D) -> Result<Self, DecodeError> {
+        decode_value_at_depth(decoder, 0).map(Self)
+    }
+}
+
+fn decode_value_at_depth<D: Decoder<Context = ()>>(
+    decoder: &mut D,
+    depth: usize,
+) -> Result<Value, DecodeError> {
+    if depth > MAX_INDEX_VALUE_NESTING_DEPTH {
+        return Err(DecodeError::Other(
+            "maximum platform Value nesting depth exceeded",
+        ));
+    }
+
+    Ok(match u32::decode(decoder)? {
+        0 => Value::U128(u128::decode(decoder)?),
+        1 => Value::I128(i128::decode(decoder)?),
+        2 => Value::U64(u64::decode(decoder)?),
+        3 => Value::I64(i64::decode(decoder)?),
+        4 => Value::U32(u32::decode(decoder)?),
+        5 => Value::I32(i32::decode(decoder)?),
+        6 => Value::U16(u16::decode(decoder)?),
+        7 => Value::I16(i16::decode(decoder)?),
+        8 => Value::U8(u8::decode(decoder)?),
+        9 => Value::I8(i8::decode(decoder)?),
+        10 => Value::Bytes(Vec::<u8>::decode(decoder)?),
+        11 => Value::Bytes20(<[u8; 20]>::decode(decoder)?),
+        12 => Value::Bytes32(<[u8; 32]>::decode(decoder)?),
+        13 => Value::Bytes36(<[u8; 36]>::decode(decoder)?),
+        14 => Value::EnumU8(Vec::<u8>::decode(decoder)?),
+        15 => Value::EnumString(Vec::<String>::decode(decoder)?),
+        16 => Value::Identifier(<[u8; 32]>::decode(decoder)?),
+        17 => Value::Float(f64::decode(decoder)?),
+        18 => Value::Text(String::decode(decoder)?),
+        19 => Value::Bool(bool::decode(decoder)?),
+        20 => Value::Null,
+        21 => Value::Array(decode_array_at_depth(decoder, depth)?),
+        22 => Value::Map(decode_map_at_depth(decoder, depth)?),
+        _ => return Err(DecodeError::Other("unexpected platform Value variant")),
+    })
+}
+
+fn decode_array_at_depth<D: Decoder<Context = ()>>(
+    decoder: &mut D,
+    depth: usize,
+) -> Result<Vec<Value>, DecodeError> {
+    let len = usize::decode(decoder)?;
+    decoder.claim_container_read::<Value>(len)?;
+
+    let mut values = Vec::with_capacity(len);
+    for _ in 0..len {
+        decoder.unclaim_bytes_read(std::mem::size_of::<Value>());
+        values.push(decode_value_at_depth(decoder, depth + 1)?);
+    }
+    Ok(values)
+}
+
+fn decode_map_at_depth<D: Decoder<Context = ()>>(
+    decoder: &mut D,
+    depth: usize,
+) -> Result<Vec<(Value, Value)>, DecodeError> {
+    let len = usize::decode(decoder)?;
+    decoder.claim_container_read::<(Value, Value)>(len)?;
+
+    let mut values = Vec::with_capacity(len);
+    for _ in 0..len {
+        decoder.unclaim_bytes_read(std::mem::size_of::<(Value, Value)>());
+        values.push((
+            decode_value_at_depth(decoder, depth + 1)?,
+            decode_value_at_depth(decoder, depth + 1)?,
+        ));
+    }
+    Ok(values)
+}
 
 /// Validate the aggregate cursor budget before decoding any individual value.
 ///
@@ -46,7 +140,7 @@ where
         count = count.saturating_add(1);
         total_bytes = total_bytes.saturating_add(serialized_value.len());
 
-        if count > max_values || total_bytes > MAX_ENCODED_INDEX_VALUE_BYTES {
+        if count > max_values || total_bytes > MAX_AGGREGATE_ENCODED_INDEX_VALUES_BYTES {
             return Err(QueryError::InvalidArgument(invalid_argument()));
         }
     }
@@ -81,8 +175,8 @@ where
             .with_big_endian()
             .with_limit::<MAX_DECODED_INDEX_VALUE_BYTES>();
 
-        let (value, consumed) =
-            bincode::decode_from_slice::<Value, _>(serialized_value, config).ok()?;
+        let (DepthLimitedValue(value), consumed) =
+            bincode::decode_from_slice::<DepthLimitedValue, _>(serialized_value, config).ok()?;
 
         // Reject trailing bytes so each encoded cursor value is canonical.
         if consumed != serialized_value.len() {
@@ -104,6 +198,15 @@ mod tests {
     /// `u64::MAX` declared length with no body.
     const CAPACITY_OVERFLOW_PAYLOAD: [u8; 10] =
         [0x0a, 0xfd, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff];
+
+    fn nested_array_payload(levels: usize) -> Vec<u8> {
+        let mut encoded = Vec::with_capacity(levels * 2 + 1);
+        for _ in 0..levels {
+            encoded.extend_from_slice(&[0x15, 0x01]);
+        }
+        encoded.push(0x14);
+        encoded
+    }
 
     #[test]
     fn rejects_unbounded_length_payload_without_panicking() {
@@ -131,8 +234,8 @@ mod tests {
     #[test]
     fn rejects_aggregate_input_over_the_byte_ceiling() {
         let values = [
-            vec![0u8; MAX_ENCODED_INDEX_VALUE_BYTES / 2 + 1],
-            vec![0u8; MAX_ENCODED_INDEX_VALUE_BYTES / 2],
+            vec![0u8; MAX_AGGREGATE_ENCODED_INDEX_VALUES_BYTES / 2 + 1],
+            vec![0u8; MAX_AGGREGATE_ENCODED_INDEX_VALUES_BYTES / 2],
         ];
         let result = validate_serialized_index_values(
             values.iter().map(Vec::as_slice),
@@ -185,5 +288,80 @@ mod tests {
         let decoded =
             decode_serialized_index_value(&encoded, || "invalid".to_string()).expect("decode");
         assert_eq!(decoded, value);
+    }
+
+    #[test]
+    fn round_trips_every_value_variant() {
+        let values = vec![
+            Value::U128(u128::MAX),
+            Value::I128(i128::MIN),
+            Value::U64(u64::MAX),
+            Value::I64(i64::MIN),
+            Value::U32(u32::MAX),
+            Value::I32(i32::MIN),
+            Value::U16(u16::MAX),
+            Value::I16(i16::MIN),
+            Value::U8(u8::MAX),
+            Value::I8(i8::MIN),
+            Value::Bytes(vec![1, 2, 3]),
+            Value::Bytes20([1; 20]),
+            Value::Bytes32([2; 32]),
+            Value::Bytes36([3; 36]),
+            Value::EnumU8(vec![1, 2]),
+            Value::EnumString(vec!["one".to_string(), "two".to_string()]),
+            Value::Identifier([4; 32]),
+            Value::Float(1.5),
+            Value::Text("text".to_string()),
+            Value::Bool(true),
+            Value::Null,
+            Value::Array(vec![Value::U8(1)]),
+            Value::Map(vec![(Value::Text("key".to_string()), Value::U8(1))]),
+        ];
+
+        for value in values {
+            let encoded = bincode::encode_to_vec(
+                value.clone(),
+                bincode::config::standard().with_big_endian(),
+            )
+            .expect("encode");
+            let decoded =
+                decode_serialized_index_value(&encoded, || "invalid".to_string()).expect("decode");
+            assert_eq!(decoded, value);
+        }
+    }
+
+    #[test]
+    fn accepts_the_maximum_nesting_depth() {
+        let encoded = nested_array_payload(MAX_INDEX_VALUE_NESTING_DEPTH);
+        decode_serialized_index_value(&encoded, || "invalid".to_string())
+            .expect("depth at the limit should decode");
+    }
+
+    #[test]
+    fn rejects_excessively_nested_maps() {
+        let levels = MAX_INDEX_VALUE_NESTING_DEPTH + 1;
+        let mut encoded = Vec::with_capacity(levels * 3 + 1);
+        for _ in 0..levels {
+            encoded.extend_from_slice(&[0x16, 0x01, 0x14]);
+        }
+        encoded.push(0x14);
+
+        let result = decode_serialized_index_value(&encoded, || "invalid".to_string());
+        assert!(matches!(result, Err(QueryError::InvalidArgument(_))));
+    }
+
+    #[test]
+    fn rejects_excessive_nesting_without_overflowing_the_drive_stack() {
+        const NESTING_LEVELS: usize = 2047;
+        let encoded = nested_array_payload(NESTING_LEVELS);
+        assert_eq!(encoded.len(), MAX_ENCODED_INDEX_VALUE_BYTES - 1);
+
+        let result = std::thread::Builder::new()
+            .stack_size(8 * 1024 * 1024)
+            .spawn(move || decode_serialized_index_value(&encoded, || "invalid".to_string()))
+            .expect("spawn")
+            .join();
+
+        assert!(matches!(result, Ok(Err(QueryError::InvalidArgument(_)))));
     }
 }


### PR DESCRIPTION
## Issue being fixed or feature implemented

Follow-up to #4101 and the review by @thepastaclaw. The existing byte and allocation ceilings still allow a canonical 4,095-byte `Value` containing 2,047 nested arrays to overflow the 8 MiB Drive dev-profile worker stack.

## What was done?

- Decode caller-controlled index values with an explicit maximum Array/Map nesting depth of 64.
- Preserve the existing encoded-size, decoded-allocation, aggregate-size, and canonical trailing-byte checks.
- Separate the per-value and aggregate encoded-byte constants.
- Add regression coverage for every current `Value` variant, the accepted depth boundary, hostile nested arrays and maps, the exact 4,095-byte stack-overflow payload, and the contested-index arity boundary.

## How Has This Been Tested?

- `cargo test -p drive-abci decode_index_value::tests --locked` (12 passed)
- `cargo test -p drive-abci test_query_contested_resources_accepts_cursor_count_at_index_arity --locked` (passed)
- `cargo test -p drive-abci query::voting --locked` (56 passed)
- `cargo clippy -p drive-abci --all-targets --locked -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`

The exact hostile payload was also confirmed to abort an 8 MiB test thread before this patch and return `InvalidArgument` after it.

## Breaking Changes

None. Valid values nested up to 64 levels continue to decode.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [x] I have made corresponding changes to the documentation if needed

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation of query cursor and index values to prevent excessively large or deeply nested inputs from causing errors.
  * Queries now reject malformed or overly complex encoded values more reliably.
  * Preserved validation for canonical encoding and trailing data.

* **Tests**
  * Added coverage for maximum supported nesting depth.
  * Added coverage confirming valid contested-resource queries are accepted when cursor ranges exactly fit the allowed index capacity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->