### PR TITLE
fix(platform-wallet): persist address usage discovered during SPV block processing

### DIFF
--- a/packages/rs-platform-wallet-ffi/src/core_wallet_types.rs
+++ b/packages/rs-platform-wallet-ffi/src/core_wallet_types.rs
@@ -305,6 +305,20 @@ impl WalletChangeSetFFI {
             }
         }
 
+        // Watermark-only accounts still need an `AccountChangeSetFFI`
+        // row. A batch can carry a highest-used advance for an account
+        // with no record of its own this round — e.g. upstream's
+        // `confirm_transaction` returning `None` for an idempotent
+        // re-confirmation while `mark_address_used` still ran, or the
+        // bridge's re-check resolving a sibling account of the same
+        // category. Without an empty bucket the watermark would be
+        // silently dropped below.
+        for account_type in cs.account_highest_used.keys() {
+            if !by_account.iter().any(|(at, _)| at == account_type) {
+                by_account.push((*account_type, Vec::new()));
+            }
+        }
+
         let mut ffi_accounts = Vec::with_capacity(by_account.len());
         for (account_type, recs) in by_account {
             let type_name = CString::new(format!("{:?}", account_type))
@@ -1091,4 +1105,55 @@ pub unsafe fn free_wallet_changeset_ffi(cs: &WalletChangeSetFFI) {
         cs.accounts_count,
         cs.accounts_count,
     ));
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use key_wallet::account::{AccountType, StandardAccountType};
+    use platform_wallet::changeset::{CoreChangeSet, HighestUsedIndexes};
+
+    /// A batch can carry a highest-used advance for an account with no
+    /// record of its own in the same `store()` round (idempotent
+    /// re-confirmation, sibling-account resolution). `from_changeset`
+    /// must still surface it as an (otherwise empty) account bucket —
+    /// regression for the shape where the watermark was silently
+    /// dropped because buckets were built from `cs.records` alone.
+    #[test]
+    fn watermark_only_account_survives_from_changeset() {
+        let account = AccountType::Standard {
+            index: 0,
+            standard_account_type: StandardAccountType::BIP44Account,
+        };
+        let mut cs = CoreChangeSet::default();
+        cs.account_highest_used.insert(
+            account,
+            HighestUsedIndexes {
+                external: Some(7),
+                internal: Some(3),
+            },
+        );
+
+        let ffi = WalletChangeSetFFI::from_changeset(&cs);
+        assert_eq!(ffi.accounts_count, 1, "watermark-only account must emit");
+        let bucket = unsafe { &*ffi.accounts };
+        assert!(bucket.has_external_highest_used);
+        assert_eq!(bucket.external_highest_used, 7);
+        assert!(bucket.has_internal_highest_used);
+        assert_eq!(bucket.internal_highest_used, 3);
+        assert_eq!(bucket.transactions_count, 0);
+        assert_eq!(bucket.utxos_added_count, 0);
+        unsafe { free_wallet_changeset_ffi(&ffi) };
+    }
+
+    /// The `has_*` flags stay false (values -1) for accounts with
+    /// records but no watermark update this batch, so the Swift
+    /// persister never regresses a stored value on a no-usage round.
+    #[test]
+    fn accounts_without_watermarks_emit_unset_flags() {
+        let cs = CoreChangeSet::default();
+        let ffi = WalletChangeSetFFI::from_changeset(&cs);
+        assert_eq!(ffi.accounts_count, 0);
+        unsafe { free_wallet_changeset_ffi(&ffi) };
+    }
 }

--- a/packages/rs-platform-wallet-ffi/src/core_wallet_types.rs
+++ b/packages/rs-platform-wallet-ffi/src/core_wallet_types.rs
@@ -338,6 +338,16 @@ impl WalletChangeSetFFI {
             // sync-path emit for the same account collapse onto a
             // single SwiftData row.
             let tags = account_type_to_tags(&account_type);
+            // Post-batch highest-used watermarks, captured by the
+            // event bridge from the authoritative in-memory pools for
+            // every account this batch marked an address used on
+            // (`CoreChangeSet::account_highest_used`). `has_* = false`
+            // means "no update this batch" — the Swift persister only
+            // overwrites its row when the flag is set, so batches
+            // without usage never regress a stored watermark.
+            let highest = cs.account_highest_used.get(&account_type);
+            let external_highest_used = highest.and_then(|h| h.external);
+            let internal_highest_used = highest.and_then(|h| h.internal);
             ffi_accounts.push(AccountChangeSetFFI {
                 account_type_name: type_name.into_raw(),
                 account_index,
@@ -357,15 +367,10 @@ impl WalletChangeSetFFI {
                 utxos_instant_locked_count: 0,
                 transactions: vec_to_ptr(transactions),
                 transactions_count,
-                // Highest-used pool indices were a feature of the
-                // deleted upstream changeset's per-account bucket.
-                // The new event-bus model doesn't surface them; the
-                // persister can derive them from monitored addresses
-                // if needed.
-                external_highest_used: -1,
-                has_external_highest_used: false,
-                internal_highest_used: -1,
-                has_internal_highest_used: false,
+                external_highest_used: external_highest_used.map_or(-1, |v| v as i32),
+                has_external_highest_used: external_highest_used.is_some(),
+                internal_highest_used: internal_highest_used.map_or(-1, |v| v as i32),
+                has_internal_highest_used: internal_highest_used.is_some(),
             });
         }
 

--- a/packages/rs-platform-wallet-ffi/src/persistence.rs
+++ b/packages/rs-platform-wallet-ffi/src/persistence.rs
@@ -835,6 +835,49 @@ impl PlatformWalletPersistence for FFIPersister {
                 }
             }
 
+            // Fan out used-flag flips AFTER the derived-address emit:
+            // a tx can land on a freshly-derived address in the same
+            // round, and the Swift-side `persistAccountAddresses`
+            // overwrites `isUsed` with whatever the latest emit says —
+            // derived-first (`is_used: false`) then marked-used
+            // (`is_used: true`) leaves the row correctly flipped.
+            // These entries carry the authoritative post-mark
+            // `AddressInfo` from the wallet's pools (see
+            // `CoreChangeSet::addresses_marked_used`), so reusing the
+            // whole-pool snapshot encoder is exact, not approximate.
+            if !core_cs.addresses_marked_used.is_empty() {
+                if let Some(cb) = self.callbacks.on_persist_account_address_pools_fn {
+                    let entries =
+                        group_marked_used_into_pool_entries(&core_cs.addresses_marked_used);
+                    match build_address_pools_for_callback(&entries) {
+                        Ok((pools, _address_storage, _string_storage)) => {
+                            let result = unsafe {
+                                cb(
+                                    self.callbacks.context,
+                                    wallet_id.as_ptr(),
+                                    pools.as_ptr(),
+                                    pools.len(),
+                                )
+                            };
+                            drop(pools);
+                            drop(_address_storage);
+                            drop(_string_storage);
+                            if result != 0 {
+                                eprintln!(
+                                    "Marked-used address persistence callback returned error code {}",
+                                    result
+                                );
+                                round_success = false;
+                            }
+                        }
+                        Err(e) => {
+                            eprintln!("Failed to encode marked-used address pool entries: {}", e);
+                            round_success = false;
+                        }
+                    }
+                }
+            }
+
             if let Some(cb) = self.callbacks.on_persist_wallet_changeset_fn {
                 let ffi_cs = WalletChangeSetFFI::from_changeset(core_cs);
                 let result = unsafe { cb(self.callbacks.context, wallet_id.as_ptr(), &ffi_cs) };
@@ -2877,6 +2920,38 @@ fn build_address_pools_from_derived(
     }
 
     Ok((pools, address_storage, owned_strings))
+}
+
+/// Bucket the changeset's marked-used address entries into
+/// [`AccountAddressPoolEntry`] values so the used-flag flip rides the
+/// same `build_address_pools_for_callback` →
+/// `on_persist_account_address_pools_fn` pipeline the registration
+/// snapshot and derived-address emits already use — one Swift code
+/// path (`persistAccountAddresses`) covers all three.
+///
+/// Grouping key is `(account_type, pool_type)`, mirroring
+/// `build_address_pools_from_derived`. Each entry's `AddressInfo` is
+/// the authoritative post-mark pool snapshot the bridge captured
+/// (`used == true`), so no field synthesis happens here.
+fn group_marked_used_into_pool_entries(
+    marked: &[key_wallet::transaction_checking::DerivedAddressInfo],
+) -> Vec<AccountAddressPoolEntry> {
+    let mut entries: Vec<AccountAddressPoolEntry> = Vec::new();
+    for d in marked {
+        if let Some(bucket) = entries
+            .iter_mut()
+            .find(|e| e.account_type == d.account_type && e.pool_type == d.pool_type)
+        {
+            bucket.addresses.push(d.info.clone());
+        } else {
+            entries.push(AccountAddressPoolEntry {
+                account_type: d.account_type,
+                pool_type: d.pool_type,
+                addresses: vec![d.info.clone()],
+            });
+        }
+    }
+    entries
 }
 
 /// RAII drop-guard that invokes the paired free callback on exit, so
@@ -5223,5 +5298,94 @@ mod tests {
         );
 
         unsafe { free_contact_requests_ffi(rows.as_mut_ptr(), rows.len()) };
+    }
+
+    /// Stub one marked-used entry at `(account_type, pool_type, index)`
+    /// for the grouping test. Only the grouping key and the `used`
+    /// flag matter here.
+    fn stub_marked_used(
+        account_type: AccountType,
+        pool_type: AddressPoolType,
+        index: u32,
+    ) -> key_wallet::transaction_checking::DerivedAddressInfo {
+        use key_wallet::bip32::{ChildNumber, DerivationPath};
+        // Compressed secp256k1 generator point — a well-known valid key.
+        const TEST_PUBKEY_G: [u8; 33] = [
+            0x02, 0x79, 0xbe, 0x66, 0x7e, 0xf9, 0xdc, 0xbb, 0xac, 0x55, 0xa0, 0x62, 0x95, 0xce,
+            0x87, 0x0b, 0x07, 0x02, 0x9b, 0xfc, 0xdb, 0x2d, 0xce, 0x28, 0xd9, 0x59, 0xf2, 0x81,
+            0x5b, 0x16, 0xf8, 0x17, 0x98,
+        ];
+        let pubkey =
+            dashcore::PublicKey::from_slice(&TEST_PUBKEY_G).expect("generator point is valid");
+        let address = dashcore::Address::p2pkh(&pubkey, Network::Testnet);
+        let script_pubkey = address.script_pubkey();
+        let path = DerivationPath::from(vec![
+            ChildNumber::from_normal_idx(0).expect("valid child number"),
+            ChildNumber::from_normal_idx(index).expect("valid child number"),
+        ]);
+        key_wallet::transaction_checking::DerivedAddressInfo {
+            account_type,
+            pool_type,
+            info: AddressInfo {
+                address,
+                script_pubkey,
+                public_key: Some(PublicKeyType::ECDSA(TEST_PUBKEY_G.to_vec())),
+                index,
+                path,
+                used: true,
+                generated_at: 0,
+                used_at: None,
+                tx_count: 0,
+                total_received: 0,
+                total_sent: 0,
+                balance: 0,
+                label: None,
+                metadata: BTreeMap::new(),
+            },
+        }
+    }
+
+    /// Marked-used entries bucket into one `AccountAddressPoolEntry`
+    /// per `(account_type, pool_type)` pair — the shape
+    /// `build_address_pools_for_callback` expects — and every emitted
+    /// address keeps `used == true` so the Swift persister flips the
+    /// row instead of resetting it.
+    #[test]
+    fn marked_used_entries_group_per_account_and_pool() {
+        let bip44 = AccountType::Standard {
+            index: 0,
+            standard_account_type: StandardAccountType::BIP44Account,
+        };
+        let owner_keys = AccountType::ProviderOwnerKeys;
+
+        let marked = vec![
+            stub_marked_used(bip44, AddressPoolType::External, 0),
+            stub_marked_used(bip44, AddressPoolType::External, 3),
+            stub_marked_used(bip44, AddressPoolType::Internal, 1),
+            stub_marked_used(owner_keys, AddressPoolType::Absent, 0),
+        ];
+
+        let entries = group_marked_used_into_pool_entries(&marked);
+        assert_eq!(entries.len(), 3, "one bucket per (account, pool) pair");
+
+        let bip44_external = entries
+            .iter()
+            .find(|e| e.account_type == bip44 && e.pool_type == AddressPoolType::External)
+            .expect("bip44 external bucket");
+        assert_eq!(bip44_external.addresses.len(), 2);
+
+        let owner_bucket = entries
+            .iter()
+            .find(|e| e.account_type == owner_keys)
+            .expect("provider owner keys bucket");
+        assert_eq!(owner_bucket.pool_type, AddressPoolType::Absent);
+        assert_eq!(owner_bucket.addresses.len(), 1);
+        assert!(
+            entries
+                .iter()
+                .flat_map(|e| e.addresses.iter())
+                .all(|a| a.used),
+            "every emitted marked-used address must carry used == true"
+        );
     }
 }

--- a/packages/rs-platform-wallet/src/changeset/changeset.rs
+++ b/packages/rs-platform-wallet/src/changeset/changeset.rs
@@ -148,6 +148,43 @@ pub struct CoreChangeSet {
     #[cfg_attr(feature = "serde", serde(skip))]
     pub addresses_derived: Vec<key_wallet_manager::DerivedAddress>,
 
+    /// Addresses the wallet marked **used** while processing the
+    /// records in this batch — the persistence-seam counterpart of
+    /// upstream `wallet_checker`'s in-memory `mark_address_used`
+    /// calls, which the `WalletEvent` bus does not carry. Rebuilt by
+    /// the event bridge from the post-processing pool state (the
+    /// authoritative `AddressInfo`, `used == true`) so persisters can
+    /// flip their mirrored address rows. Without this delta a match
+    /// found during SPV block processing (a TXO landing on a BIP44
+    /// address, or a special-tx payload hitting a provider owner /
+    /// voting key) updates only the in-memory pool and every store
+    /// keeps `is_used = false` forever.
+    ///
+    /// De-duplicated on merge by `(account_type, pool_type, index)`,
+    /// same key discipline as [`Self::addresses_derived`]. Re-emitting
+    /// an already-used address is idempotent on the persister side.
+    ///
+    /// `#[serde(skip)]`: same rationale as `addresses_derived` — the
+    /// breadcrumb targets typed persister tables, not the serialized
+    /// parent changeset.
+    #[cfg_attr(feature = "serde", serde(skip))]
+    pub addresses_marked_used: Vec<key_wallet::transaction_checking::DerivedAddressInfo>,
+
+    /// Post-batch highest-used derivation indexes for every account
+    /// that had an address marked used in this batch, read from the
+    /// authoritative in-memory pools (`AddressPool::highest_used`)
+    /// right after the wallet processed the records. Single-pool
+    /// accounts (provider keys, identity funding — pool type Absent /
+    /// AbsentHardened) surface their pool in the `external` slot,
+    /// matching how the FFI account row exposes exactly two
+    /// highest-used fields. Monotonic-max on merge per account per
+    /// slot; `None` means "no update".
+    ///
+    /// `#[serde(skip)]`: persister breadcrumb, same as the address
+    /// deltas above.
+    #[cfg_attr(feature = "serde", serde(skip))]
+    pub account_highest_used: BTreeMap<AccountType, HighestUsedIndexes>,
+
     /// Highest chainlock the wallet has applied (mirrors
     /// `WalletMetadata::last_applied_chain_lock`). Populated by the
     /// `ChainLockProcessed` bridge arm so the persister can
@@ -160,6 +197,37 @@ pub struct CoreChangeSet {
     /// lower height never overwrites a higher one — chain locks are
     /// strictly forward-advancing per upstream's contract).
     pub last_applied_chain_lock: Option<ChainLock>,
+}
+
+/// Highest-used derivation index per pool slot for one account, as
+/// carried by [`CoreChangeSet::account_highest_used`].
+///
+/// Accounts expose at most two persisted highest-used watermarks
+/// (external / internal). Standard accounts map their External /
+/// Internal pools onto the matching slot; single-pool accounts
+/// (provider keys, identity funding) surface their sole pool in
+/// `external`. `None` means the pool has never had a used address (or
+/// the account has no such pool) — distinct from `Some(0)`, which
+/// means index #0 is used.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct HighestUsedIndexes {
+    /// Highest used index of the external (or sole) pool.
+    pub external: Option<u32>,
+    /// Highest used index of the internal (change) pool.
+    pub internal: Option<u32>,
+}
+
+impl HighestUsedIndexes {
+    /// Fold `other` in with monotonic-max semantics per slot —
+    /// watermarks only advance, `None` never overwrites `Some`.
+    pub fn merge_max(&mut self, other: Self) {
+        if let Some(v) = other.external {
+            self.external = Some(self.external.map_or(v, |e| e.max(v)));
+        }
+        if let Some(v) = other.internal {
+            self.internal = Some(self.internal.map_or(v, |e| e.max(v)));
+        }
+    }
 }
 
 impl Merge for CoreChangeSet {
@@ -233,6 +301,37 @@ impl Merge for CoreChangeSet {
                 }
             }
         }
+
+        // Marked-used dedup: same `(account_type, pool_type, index)`
+        // key as the derived-address dedup above. Re-emitting a used
+        // flip is idempotent at the persister, so first-seen-wins is
+        // purely a payload-size optimization.
+        if !other.addresses_marked_used.is_empty() {
+            let mut seen: std::collections::HashSet<(
+                key_wallet::account::AccountType,
+                key_wallet::managed_account::address_pool::AddressPoolType,
+                u32,
+            )> = self
+                .addresses_marked_used
+                .iter()
+                .map(|d| (d.account_type, d.pool_type, d.info.index))
+                .collect();
+            for d in other.addresses_marked_used {
+                let key = (d.account_type, d.pool_type, d.info.index);
+                if seen.insert(key) {
+                    self.addresses_marked_used.push(d);
+                }
+            }
+        }
+
+        // Highest-used watermarks: monotonic-max per account per pool
+        // slot, same forward-only discipline as the height watermarks.
+        for (account_type, indexes) in other.account_highest_used {
+            self.account_highest_used
+                .entry(account_type)
+                .or_default()
+                .merge_max(indexes);
+        }
     }
 
     fn is_empty(&self) -> bool {
@@ -243,6 +342,8 @@ impl Merge for CoreChangeSet {
             && self.last_processed_height.is_none()
             && self.synced_height.is_none()
             && self.addresses_derived.is_empty()
+            && self.addresses_marked_used.is_empty()
+            && self.account_highest_used.is_empty()
             && self.last_applied_chain_lock.is_none()
     }
 }
@@ -1888,5 +1989,144 @@ mod tests {
         let taken = cs.take();
         assert!(taken.is_some());
         assert!(cs.is_empty());
+    }
+
+    /// Compressed encoding of the secp256k1 generator point — a
+    /// well-known valid public key for stubbing `AddressInfo`s.
+    const TEST_PUBKEY_G: [u8; 33] = [
+        0x02, 0x79, 0xbe, 0x66, 0x7e, 0xf9, 0xdc, 0xbb, 0xac, 0x55, 0xa0, 0x62, 0x95, 0xce, 0x87,
+        0x0b, 0x07, 0x02, 0x9b, 0xfc, 0xdb, 0x2d, 0xce, 0x28, 0xd9, 0x59, 0xf2, 0x81, 0x5b, 0x16,
+        0xf8, 0x17, 0x98,
+    ];
+
+    /// Stub a marked-used entry at `(account_type, pool_type, index)`.
+    /// Tests only exercise the dedup key, not address↔pubkey
+    /// consistency.
+    fn stub_marked_used(
+        account_type: AccountType,
+        pool_type: AddressPoolType,
+        index: u32,
+    ) -> key_wallet::transaction_checking::DerivedAddressInfo {
+        use key_wallet::bip32::{ChildNumber, DerivationPath};
+        use key_wallet::managed_account::address_pool::{AddressInfo, PublicKeyType};
+
+        let pubkey =
+            dashcore::PublicKey::from_slice(&TEST_PUBKEY_G).expect("generator point is valid");
+        let address = dashcore::Address::p2pkh(&pubkey, Network::Testnet);
+        let script_pubkey = address.script_pubkey();
+        let path = DerivationPath::from(vec![
+            ChildNumber::from_normal_idx(0).expect("valid child number"),
+            ChildNumber::from_normal_idx(index).expect("valid child number"),
+        ]);
+        key_wallet::transaction_checking::DerivedAddressInfo {
+            account_type,
+            pool_type,
+            info: AddressInfo {
+                address,
+                script_pubkey,
+                public_key: Some(PublicKeyType::ECDSA(TEST_PUBKEY_G.to_vec())),
+                index,
+                path,
+                used: true,
+                generated_at: 0,
+                used_at: None,
+                tx_count: 0,
+                total_received: 0,
+                total_sent: 0,
+                balance: 0,
+                label: None,
+                metadata: BTreeMap::new(),
+            },
+        }
+    }
+
+    fn bip44_account_0() -> AccountType {
+        AccountType::Standard {
+            index: 0,
+            standard_account_type: key_wallet::account::StandardAccountType::BIP44Account,
+        }
+    }
+
+    /// A marked-used delta (or a highest-used watermark) alone must
+    /// mark the core changeset non-empty, or the event adapter drops
+    /// the persist round and the used flip never reaches any store —
+    /// the exact bug this delta exists to fix.
+    #[test]
+    fn marked_used_and_highest_used_mark_core_changeset_non_empty() {
+        let mut cs = CoreChangeSet::default();
+        assert!(cs.is_empty());
+        cs.addresses_marked_used = vec![stub_marked_used(
+            bip44_account_0(),
+            AddressPoolType::External,
+            0,
+        )];
+        assert!(!cs.is_empty(), "marked-used delta must be persisted");
+
+        let mut cs = CoreChangeSet::default();
+        cs.account_highest_used.insert(
+            bip44_account_0(),
+            HighestUsedIndexes {
+                external: Some(0),
+                internal: None,
+            },
+        );
+        assert!(!cs.is_empty(), "highest-used watermark must be persisted");
+    }
+
+    /// Merge dedups marked-used entries on `(account_type, pool_type,
+    /// index)` — same discipline as `addresses_derived` — and keeps
+    /// distinct indices / pools apart.
+    #[test]
+    fn merge_dedups_marked_used_entries() {
+        let acct = bip44_account_0();
+        let mut cs = CoreChangeSet {
+            addresses_marked_used: vec![stub_marked_used(acct, AddressPoolType::External, 5)],
+            ..CoreChangeSet::default()
+        };
+        cs.merge(CoreChangeSet {
+            addresses_marked_used: vec![
+                // duplicate of the existing entry — dropped
+                stub_marked_used(acct, AddressPoolType::External, 5),
+                // same index, different pool — kept
+                stub_marked_used(acct, AddressPoolType::Internal, 5),
+                // same pool, different index — kept
+                stub_marked_used(acct, AddressPoolType::External, 6),
+            ],
+            ..CoreChangeSet::default()
+        });
+        assert_eq!(cs.addresses_marked_used.len(), 3);
+    }
+
+    /// Highest-used watermarks merge monotonic-max per account per
+    /// pool slot: a later batch can only advance a slot, and `None`
+    /// never erases a prior `Some`.
+    #[test]
+    fn merge_highest_used_is_monotonic_max_per_slot() {
+        let acct = bip44_account_0();
+        let mut cs = CoreChangeSet::default();
+        cs.account_highest_used.insert(
+            acct,
+            HighestUsedIndexes {
+                external: Some(5),
+                internal: None,
+            },
+        );
+        cs.merge(CoreChangeSet {
+            account_highest_used: {
+                let mut m = BTreeMap::new();
+                m.insert(
+                    acct,
+                    HighestUsedIndexes {
+                        external: Some(2), // lower — must not regress
+                        internal: Some(1), // fills the empty slot
+                    },
+                );
+                m
+            },
+            ..CoreChangeSet::default()
+        });
+        let merged = cs.account_highest_used[&acct];
+        assert_eq!(merged.external, Some(5));
+        assert_eq!(merged.internal, Some(1));
     }
 }

--- a/packages/rs-platform-wallet/src/changeset/core_bridge.rs
+++ b/packages/rs-platform-wallet/src/changeset/core_bridge.rs
@@ -30,7 +30,7 @@ use std::sync::Arc;
 use dashcore::blockdata::transaction::{txout::TxOut, OutPoint};
 use dashcore::ScriptBuf;
 use key_wallet::account::AccountType;
-use key_wallet::managed_account::address_pool::AddressPoolType;
+use key_wallet::managed_account::address_pool::{AddressPool, AddressPoolType};
 use key_wallet::managed_account::transaction_record::{OutputRole, TransactionRecord};
 use key_wallet::transaction_checking::transaction_router::AccountTypeToCheck;
 use key_wallet::transaction_checking::{DerivedAddressInfo, TransactionContext};
@@ -263,18 +263,9 @@ async fn build_core_changeset(
 /// reaches the persister and every mirrored store keeps
 /// `is_used = false` / `highest_used = None` forever.
 ///
-/// For each record this re-runs the same **read-only** matcher the
-/// wallet used during processing
-/// ([`ManagedAccountCollection::check_transaction`]), scoped to the
-/// record's own account type, then resolves every involved address
-/// back to its owning pool for the authoritative post-mark
-/// [`AddressInfo`](key_wallet::managed_account::address_pool::AddressInfo)
-/// and the pool's `highest_used` watermark. `used` is forced `true`
-/// on the emitted entry — involvement in a recorded transaction is
-/// the definition of "used", independent of snapshot timing.
-///
 /// Returns empty deltas when the wallet is unknown (raced a removal)
-/// — the next sync round re-emits.
+/// — the next sync round re-emits. See
+/// [`collect_usage_deltas_from_accounts`] for the derivation itself.
 async fn collect_usage_deltas(
     wallet_manager: &Arc<RwLock<WalletManager<PlatformWalletInfo>>>,
     wallet_id: &WalletId,
@@ -283,20 +274,69 @@ async fn collect_usage_deltas(
     Vec<DerivedAddressInfo>,
     BTreeMap<AccountType, HighestUsedIndexes>,
 ) {
-    let mut marked_used: Vec<DerivedAddressInfo> = Vec::new();
-    let mut highest_used: BTreeMap<AccountType, HighestUsedIndexes> = BTreeMap::new();
     if records.is_empty() {
-        return (marked_used, highest_used);
+        return (Vec::new(), BTreeMap::new());
     }
-
     let guard = wallet_manager.read().await;
     let Some(info) = guard.get_wallet_info(wallet_id) else {
-        return (marked_used, highest_used);
+        return (Vec::new(), BTreeMap::new());
     };
-    let accounts = &info.core_wallet.accounts;
-    let account_refs = accounts.all_accounts();
+    collect_usage_deltas_from_accounts(&info.core_wallet.accounts, &records)
+}
 
+/// Synchronous core of [`collect_usage_deltas`], factored over the
+/// account collection so tests can drive it without a `WalletManager`.
+///
+/// Usage-site candidates for each record come from two complementary
+/// sources:
+///
+/// 1. **The record's own `input_details` / `output_details`.**
+///    `input_details` entries are wallet-owned by construction and are
+///    the ONLY reliable source for spent-input addresses: by the time
+///    this bridge runs, `record_transaction`'s UTXO update has already
+///    removed the spent outpoints from the live account, so a replayed
+///    match can no longer see them. Output details are filtered to the
+///    `Received` / `Change` roles (a `Sent` detail carries the
+///    counterparty's address).
+/// 2. **A replayed read-only match**
+///    ([`ManagedAccountCollection::check_transaction`], scoped to the
+///    record's account type), which covers involvement the details
+///    don't carry — most importantly special-tx payload matches: a
+///    ProRegTx hitting a provider owner / voting key produces a record
+///    with no input/output detail for the matched key.
+///
+/// Every candidate is then resolved against the live pools for the
+/// authoritative post-mark
+/// [`AddressInfo`](key_wallet::managed_account::address_pool::AddressInfo)
+/// and its `(account_type, pool_type)`; candidates no pool monitors
+/// (counterparty addresses) simply drop out. `used` is forced `true`
+/// on the emitted entry — involvement in a recorded transaction is the
+/// definition of "used", independent of snapshot timing. Highest-used
+/// watermarks are snapshotted once per touched account at the end.
+fn collect_usage_deltas_from_accounts(
+    accounts: &key_wallet::managed_account::managed_account_collection::ManagedAccountCollection,
+    records: &[&TransactionRecord],
+) -> (
+    Vec<DerivedAddressInfo>,
+    BTreeMap<AccountType, HighestUsedIndexes>,
+) {
+    let account_refs = accounts.all_accounts();
+    // Hoisted `(account_type, pools)` snapshot — `address_pools()`
+    // allocates a fresh Vec per call, so build it once per batch
+    // instead of once per (candidate address × account).
+    let pools_by_account: Vec<(AccountType, Vec<&AddressPool>)> = account_refs
+        .iter()
+        .map(|a| {
+            (
+                a.managed_account_type().to_account_type(),
+                a.managed_account_type().address_pools(),
+            )
+        })
+        .collect();
+
+    let mut marked_used: Vec<DerivedAddressInfo> = Vec::new();
     let mut seen: HashSet<(AccountType, AddressPoolType, u32)> = HashSet::new();
+    let mut touched: HashSet<AccountType> = HashSet::new();
     // A block can carry several records for the same account type
     // (and `check_transaction` is per-tx anyway), so dedup the
     // (txid, type-to-check) pairs to avoid re-matching the same
@@ -306,71 +346,91 @@ async fn collect_usage_deltas(
     let mut checked: Vec<(dashcore::Txid, AccountTypeToCheck)> = Vec::new();
 
     for record in records {
-        // The matcher wants the runtime `AccountTypeToCheck`
-        // discriminant; resolve it through the live managed account so
-        // the conversion stays upstream-owned. A record whose account
-        // vanished from the collection (removed mid-flight) is skipped
-        // — nothing to flip in a pool that no longer exists.
-        let Some(account) = account_refs
+        // Source 1: the record's own details (see doc comment). These
+        // survive the UTXO-set mutation that precedes this bridge.
+        let mut candidates: Vec<dashcore::Address> = record
+            .input_details
             .iter()
-            .find(|a| a.managed_account_type().to_account_type() == record.account_type)
-        else {
-            continue;
-        };
-        let Ok(type_to_check) = AccountTypeToCheck::try_from(account.managed_account_type()) else {
-            continue;
-        };
-        if checked.contains(&(record.txid, type_to_check)) {
-            continue;
-        }
-        checked.push((record.txid, type_to_check));
+            .map(|detail| detail.address.clone())
+            .collect();
+        candidates.extend(record.output_details.iter().filter_map(|detail| {
+            matches!(detail.role, OutputRole::Received | OutputRole::Change)
+                .then(|| detail.address.clone())
+                .flatten()
+        }));
 
-        let result = accounts.check_transaction(&record.transaction, &[type_to_check]);
-        for account_match in result.affected_accounts {
-            for involved in account_match.account_type_match.all_involved_addresses() {
-                // Resolve the involved address back to its owning
-                // account + pool. This recovers the `pool_type` (which
-                // the match doesn't carry) and the authoritative
-                // post-mark `AddressInfo`; any account monitoring the
-                // address is a genuine usage site, matching upstream's
-                // per-matched-account `mark_address_used` sweep.
-                for owner in &account_refs {
-                    let owner_type = owner.managed_account_type().to_account_type();
-                    for pool in owner.managed_account_type().address_pools() {
-                        let Some(pool_info) = pool.address_info(&involved.address) else {
-                            continue;
-                        };
-                        if seen.insert((owner_type, pool.pool_type, pool_info.index)) {
-                            let mut info = pool_info.clone();
-                            info.used = true;
-                            marked_used.push(DerivedAddressInfo {
-                                account_type: owner_type,
-                                pool_type: pool.pool_type,
-                                info,
-                            });
-                        }
-                        // Snapshot the owning account's highest-used
-                        // watermarks. Standard accounts map External /
-                        // Internal onto the two persisted slots;
-                        // single-pool accounts (provider keys, identity
-                        // funding) surface theirs as `external`.
-                        let slot = highest_used.entry(owner_type).or_default();
-                        let mut snapshot = HighestUsedIndexes::default();
-                        for p in owner.managed_account_type().address_pools() {
-                            if p.is_internal() {
-                                snapshot.internal = p.highest_used;
-                            } else {
-                                snapshot.external = match (snapshot.external, p.highest_used) {
-                                    (Some(a), Some(b)) => Some(a.max(b)),
-                                    (a, b) => a.or(b),
-                                };
-                            }
-                        }
-                        slot.merge_max(snapshot);
+        // Source 2: replayed read-only match for involvement the
+        // details don't carry (special-tx payload matches). Account
+        // types with no Core-chain matcher (`PlatformPayment`) skip
+        // the replay and rely on the details alone.
+        if let Ok(type_to_check) = AccountTypeToCheck::try_from(record.account_type) {
+            if !checked.contains(&(record.txid, type_to_check)) {
+                checked.push((record.txid, type_to_check));
+                let result = accounts.check_transaction(&record.transaction, &[type_to_check]);
+                for account_match in result.affected_accounts {
+                    candidates.extend(
+                        account_match
+                            .account_type_match
+                            .all_involved_addresses()
+                            .into_iter()
+                            .map(|involved| involved.address),
+                    );
+                }
+            }
+        }
+
+        // Resolve every candidate back to its owning account + pool.
+        // This recovers the `pool_type` (which neither source carries)
+        // and the authoritative post-mark `AddressInfo`; any account
+        // monitoring the address is a genuine usage site, matching
+        // upstream's per-matched-account `mark_address_used` sweep.
+        for address in candidates {
+            for (owner_type, pools) in &pools_by_account {
+                for pool in pools {
+                    let Some(pool_info) = pool.address_info(&address) else {
+                        continue;
+                    };
+                    touched.insert(*owner_type);
+                    if seen.insert((*owner_type, pool.pool_type, pool_info.index)) {
+                        let mut info = pool_info.clone();
+                        info.used = true;
+                        marked_used.push(DerivedAddressInfo {
+                            account_type: *owner_type,
+                            pool_type: pool.pool_type,
+                            info,
+                        });
                     }
                 }
             }
         }
+    }
+
+    // Snapshot highest-used watermarks once per touched account.
+    // Standard accounts map External / Internal onto the two persisted
+    // slots; single-pool accounts (provider keys, identity funding)
+    // surface theirs as `external`. Folding with max keeps the
+    // invariant if an account ever grows several non-internal pools.
+    let mut highest_used: BTreeMap<AccountType, HighestUsedIndexes> = BTreeMap::new();
+    for (owner_type, pools) in &pools_by_account {
+        if !touched.contains(owner_type) {
+            continue;
+        }
+        let mut snapshot = HighestUsedIndexes::default();
+        for pool in pools {
+            let slot = if pool.is_internal() {
+                &mut snapshot.internal
+            } else {
+                &mut snapshot.external
+            };
+            *slot = match (*slot, pool.highest_used) {
+                (Some(a), Some(b)) => Some(a.max(b)),
+                (a, b) => a.or(b),
+            };
+        }
+        highest_used
+            .entry(*owner_type)
+            .or_default()
+            .merge_max(snapshot);
     }
 
     (marked_used, highest_used)
@@ -505,5 +565,186 @@ impl CoreChangeSet {
             && self.addresses_derived.is_empty()
             && self.addresses_marked_used.is_empty()
             && self.account_highest_used.is_empty()
+    }
+}
+
+#[cfg(test)]
+mod usage_delta_tests {
+    //! Regression coverage for [`collect_usage_deltas_from_accounts`] —
+    //! the matching/resolution seam that rebuilds `mark_address_used`
+    //! results the `WalletEvent` bus doesn't carry. Drives a real
+    //! `ManagedWalletInfo` through `check_core_transaction` (the same
+    //! mutating entry point SPV block processing uses) and then runs
+    //! the bridge's derivation over the post-mutation state, exactly
+    //! as the event adapter does at runtime.
+
+    use super::*;
+    use dashcore::hashes::Hash;
+    use dashcore::{BlockHash, OutPoint, ScriptBuf, Transaction, TxIn, TxOut, Txid, Witness};
+    use key_wallet::account::{AccountType, StandardAccountType};
+    use key_wallet::test_utils::TestWalletContext;
+    use key_wallet::transaction_checking::{BlockInfo, WalletTransactionChecker};
+
+    fn bip44_account_0() -> AccountType {
+        AccountType::Standard {
+            index: 0,
+            standard_account_type: StandardAccountType::BIP44Account,
+        }
+    }
+
+    fn in_block(height: u32) -> TransactionContext {
+        TransactionContext::InBlock(BlockInfo::new(
+            height,
+            BlockHash::from_slice(&[1u8; 32]).expect("valid block hash"),
+            1_234_567_890,
+        ))
+    }
+
+    /// A P2PKH script the wallet does not monitor, for counterparty
+    /// outputs. Built from the secp256k1 generator point.
+    fn foreign_script() -> ScriptBuf {
+        const TEST_PUBKEY_G: [u8; 33] = [
+            0x02, 0x79, 0xbe, 0x66, 0x7e, 0xf9, 0xdc, 0xbb, 0xac, 0x55, 0xa0, 0x62, 0x95, 0xce,
+            0x87, 0x0b, 0x07, 0x02, 0x9b, 0xfc, 0xdb, 0x2d, 0xce, 0x28, 0xd9, 0x59, 0xf2, 0x81,
+            0x5b, 0x16, 0xf8, 0x17, 0x98,
+        ];
+        let pubkey =
+            dashcore::PublicKey::from_slice(&TEST_PUBKEY_G).expect("generator point is valid");
+        dashcore::Address::p2pkh(&pubkey, key_wallet::Network::Testnet).script_pubkey()
+    }
+
+    fn spend_to(previous_output: OutPoint, script_pubkey: ScriptBuf, value: u64) -> Transaction {
+        Transaction {
+            version: 2,
+            lock_time: 0,
+            input: vec![TxIn {
+                previous_output,
+                script_sig: ScriptBuf::new(),
+                sequence: 0xffffffff,
+                witness: Witness::new(),
+            }],
+            output: vec![TxOut {
+                value,
+                script_pubkey,
+            }],
+            special_transaction_payload: None,
+        }
+    }
+
+    /// An output paying a monitored BIP44 receive address must surface
+    /// as a marked-used entry (External pool, index 0, `used == true`)
+    /// and advance the account's external highest-used watermark to 0.
+    #[tokio::test]
+    async fn receive_output_marks_address_used_and_advances_highest_used() {
+        let TestWalletContext {
+            mut managed_wallet,
+            mut wallet,
+            receive_address,
+            ..
+        } = TestWalletContext::new_random();
+
+        let funding_outpoint = OutPoint {
+            txid: Txid::from_slice(&[2u8; 32]).expect("valid txid"),
+            vout: 0,
+        };
+        let tx = spend_to(funding_outpoint, receive_address.script_pubkey(), 75_000);
+        let result = managed_wallet
+            .check_core_transaction(&tx, in_block(100_000), &mut wallet, true, true)
+            .await;
+        assert!(result.is_relevant, "fixture tx must match the wallet");
+
+        let records: Vec<&TransactionRecord> = result.new_records.iter().collect();
+        let (marked, highest) =
+            collect_usage_deltas_from_accounts(&managed_wallet.accounts, &records);
+
+        let entry = marked
+            .iter()
+            .find(|d| d.info.address == receive_address)
+            .expect("receive address must be in the marked-used delta");
+        assert_eq!(entry.account_type, bip44_account_0());
+        assert_eq!(entry.pool_type, AddressPoolType::External);
+        assert_eq!(entry.info.index, 0);
+        assert!(entry.info.used);
+
+        let watermarks = highest
+            .get(&bip44_account_0())
+            .expect("touched account must carry a highest-used snapshot");
+        assert_eq!(watermarks.external, Some(0));
+    }
+
+    /// Spending a wallet-owned UTXO removes it from the live account
+    /// BEFORE the wallet event fires, so the replayed
+    /// `check_transaction` can no longer see the input match. The
+    /// spent address must still be captured — via the record's
+    /// `input_details`, which key-wallet populates pre-removal.
+    #[tokio::test]
+    async fn spent_input_address_is_captured_after_utxo_removal() {
+        let TestWalletContext {
+            mut managed_wallet,
+            mut wallet,
+            receive_address,
+            ..
+        } = TestWalletContext::new_random();
+
+        // Fund the wallet at the receive address...
+        let funding_outpoint = OutPoint {
+            txid: Txid::from_slice(&[2u8; 32]).expect("valid txid"),
+            vout: 0,
+        };
+        let fund_tx = spend_to(funding_outpoint, receive_address.script_pubkey(), 75_000);
+        let fund_result = managed_wallet
+            .check_core_transaction(&fund_tx, in_block(100_000), &mut wallet, true, true)
+            .await;
+        assert!(fund_result.is_relevant);
+
+        // ...then spend that UTXO entirely to a foreign address. After
+        // this call the funded outpoint is gone from the account's
+        // live UTXO set.
+        let spend_tx = spend_to(
+            OutPoint {
+                txid: fund_tx.txid(),
+                vout: 0,
+            },
+            foreign_script(),
+            74_000,
+        );
+        let spend_result = managed_wallet
+            .check_core_transaction(&spend_tx, in_block(100_001), &mut wallet, true, true)
+            .await;
+        assert!(spend_result.is_relevant, "spend of our UTXO must match");
+
+        // Derive usage deltas from the SPEND records only — the
+        // funding record is deliberately excluded, so the only path to
+        // the spent address is the record's own `input_details`.
+        let records: Vec<&TransactionRecord> = spend_result
+            .new_records
+            .iter()
+            .chain(spend_result.updated_records.iter())
+            .collect();
+        assert!(!records.is_empty(), "spend must produce a record");
+        let (marked, highest) =
+            collect_usage_deltas_from_accounts(&managed_wallet.accounts, &records);
+
+        let entry = marked
+            .iter()
+            .find(|d| d.info.address == receive_address)
+            .expect("spent-input address must be in the marked-used delta");
+        assert_eq!(entry.pool_type, AddressPoolType::External);
+        assert!(entry.info.used);
+        // The foreign output must NOT resolve to any pool.
+        assert!(
+            marked.iter().all(|d| d.info.address != {
+                dashcore::Address::from_script(&foreign_script(), key_wallet::Network::Testnet)
+                    .expect("foreign script is a valid P2PKH")
+            }),
+            "counterparty addresses must drop out at pool resolution"
+        );
+        assert_eq!(
+            highest
+                .get(&bip44_account_0())
+                .expect("account touched via input details")
+                .external,
+            Some(0)
+        );
     }
 }

--- a/packages/rs-platform-wallet/src/changeset/core_bridge.rs
+++ b/packages/rs-platform-wallet/src/changeset/core_bridge.rs
@@ -24,12 +24,16 @@
 //! manager's lifetime; on shutdown, fire the [`CancellationToken`] to
 //! make the task exit cleanly.
 
+use std::collections::{BTreeMap, HashSet};
 use std::sync::Arc;
 
 use dashcore::blockdata::transaction::{txout::TxOut, OutPoint};
 use dashcore::ScriptBuf;
+use key_wallet::account::AccountType;
+use key_wallet::managed_account::address_pool::AddressPoolType;
 use key_wallet::managed_account::transaction_record::{OutputRole, TransactionRecord};
-use key_wallet::transaction_checking::TransactionContext;
+use key_wallet::transaction_checking::transaction_router::AccountTypeToCheck;
+use key_wallet::transaction_checking::{DerivedAddressInfo, TransactionContext};
 use key_wallet::Utxo;
 use key_wallet_manager::{WalletEvent, WalletId, WalletManager};
 use tokio::sync::broadcast::error::RecvError;
@@ -37,7 +41,7 @@ use tokio::sync::RwLock;
 use tokio::task::JoinHandle;
 use tokio_util::sync::CancellationToken;
 
-use crate::changeset::changeset::{CoreChangeSet, PlatformWalletChangeSet};
+use crate::changeset::changeset::{CoreChangeSet, HighestUsedIndexes, PlatformWalletChangeSet};
 use crate::changeset::traits::PlatformWalletPersistence;
 use crate::wallet::platform_wallet::PlatformWalletInfo;
 
@@ -125,12 +129,15 @@ async fn build_core_changeset(
 ) -> CoreChangeSet {
     match event {
         WalletEvent::TransactionDetected {
+            wallet_id,
             record,
             addresses_derived,
             ..
         } => {
             // Derive UTXO deltas before moving the record into `records`
             // so the per-record borrows are still live.
+            let (addresses_marked_used, account_highest_used) =
+                collect_usage_deltas(wallet_manager, wallet_id, vec![&**record]).await;
             CoreChangeSet {
                 new_utxos: derive_new_utxos(record),
                 spent_utxos: derive_spent_utxos(record),
@@ -142,6 +149,8 @@ async fn build_core_changeset(
                 // `CoreChangeSet.addresses_derived` for the cascade-
                 // link rationale.
                 addresses_derived: addresses_derived.clone(),
+                addresses_marked_used,
+                account_highest_used,
                 ..CoreChangeSet::default()
             }
         }
@@ -163,6 +172,7 @@ async fn build_core_changeset(
             cs
         }
         WalletEvent::BlockProcessed {
+            wallet_id,
             height,
             inserted,
             updated,
@@ -189,6 +199,20 @@ async fn build_core_changeset(
             // Already deduped upstream by `project_derived_addresses`;
             // `Merge` re-dedupes if multiple events fold together.
             cs.addresses_derived = addresses_derived.clone();
+            // Used-flag flips + highest-used watermarks for every
+            // record in the block. `updated` / `matured` records
+            // re-emit their involved addresses — idempotent at the
+            // persister, and it lets a rescan converge stores that
+            // missed the original insert-time flip.
+            let records: Vec<&TransactionRecord> = inserted
+                .iter()
+                .chain(updated.iter())
+                .chain(matured.iter())
+                .collect();
+            let (addresses_marked_used, account_highest_used) =
+                collect_usage_deltas(wallet_manager, wallet_id, records).await;
+            cs.addresses_marked_used = addresses_marked_used;
+            cs.account_highest_used = account_highest_used;
             cs
         }
         WalletEvent::SyncHeightAdvanced { height, .. } => CoreChangeSet {
@@ -226,6 +250,130 @@ async fn build_core_changeset(
             }
         }
     }
+}
+
+/// Rebuild the "addresses marked used" delta plus the post-batch
+/// highest-used watermarks for the accounts touched by `records`.
+///
+/// Upstream `wallet_checker` marks matched addresses used (and bumps
+/// each pool's `highest_used`) **in memory only** — `WalletEvent`
+/// carries neither. Without re-deriving the flips here, a match found
+/// during SPV block processing (a TXO on a BIP44 address, or a
+/// special-tx payload hitting a provider owner / voting key) never
+/// reaches the persister and every mirrored store keeps
+/// `is_used = false` / `highest_used = None` forever.
+///
+/// For each record this re-runs the same **read-only** matcher the
+/// wallet used during processing
+/// ([`ManagedAccountCollection::check_transaction`]), scoped to the
+/// record's own account type, then resolves every involved address
+/// back to its owning pool for the authoritative post-mark
+/// [`AddressInfo`](key_wallet::managed_account::address_pool::AddressInfo)
+/// and the pool's `highest_used` watermark. `used` is forced `true`
+/// on the emitted entry — involvement in a recorded transaction is
+/// the definition of "used", independent of snapshot timing.
+///
+/// Returns empty deltas when the wallet is unknown (raced a removal)
+/// — the next sync round re-emits.
+async fn collect_usage_deltas(
+    wallet_manager: &Arc<RwLock<WalletManager<PlatformWalletInfo>>>,
+    wallet_id: &WalletId,
+    records: Vec<&TransactionRecord>,
+) -> (
+    Vec<DerivedAddressInfo>,
+    BTreeMap<AccountType, HighestUsedIndexes>,
+) {
+    let mut marked_used: Vec<DerivedAddressInfo> = Vec::new();
+    let mut highest_used: BTreeMap<AccountType, HighestUsedIndexes> = BTreeMap::new();
+    if records.is_empty() {
+        return (marked_used, highest_used);
+    }
+
+    let guard = wallet_manager.read().await;
+    let Some(info) = guard.get_wallet_info(wallet_id) else {
+        return (marked_used, highest_used);
+    };
+    let accounts = &info.core_wallet.accounts;
+    let account_refs = accounts.all_accounts();
+
+    let mut seen: HashSet<(AccountType, AddressPoolType, u32)> = HashSet::new();
+    // A block can carry several records for the same account type
+    // (and `check_transaction` is per-tx anyway), so dedup the
+    // (txid, type-to-check) pairs to avoid re-matching the same
+    // transaction against the same accounts. `AccountTypeToCheck`
+    // isn't `Hash` upstream; a linear scan over this per-batch-sized
+    // vec is cheaper than hashing anyway.
+    let mut checked: Vec<(dashcore::Txid, AccountTypeToCheck)> = Vec::new();
+
+    for record in records {
+        // The matcher wants the runtime `AccountTypeToCheck`
+        // discriminant; resolve it through the live managed account so
+        // the conversion stays upstream-owned. A record whose account
+        // vanished from the collection (removed mid-flight) is skipped
+        // — nothing to flip in a pool that no longer exists.
+        let Some(account) = account_refs
+            .iter()
+            .find(|a| a.managed_account_type().to_account_type() == record.account_type)
+        else {
+            continue;
+        };
+        let Ok(type_to_check) = AccountTypeToCheck::try_from(account.managed_account_type()) else {
+            continue;
+        };
+        if checked.contains(&(record.txid, type_to_check)) {
+            continue;
+        }
+        checked.push((record.txid, type_to_check));
+
+        let result = accounts.check_transaction(&record.transaction, &[type_to_check]);
+        for account_match in result.affected_accounts {
+            for involved in account_match.account_type_match.all_involved_addresses() {
+                // Resolve the involved address back to its owning
+                // account + pool. This recovers the `pool_type` (which
+                // the match doesn't carry) and the authoritative
+                // post-mark `AddressInfo`; any account monitoring the
+                // address is a genuine usage site, matching upstream's
+                // per-matched-account `mark_address_used` sweep.
+                for owner in &account_refs {
+                    let owner_type = owner.managed_account_type().to_account_type();
+                    for pool in owner.managed_account_type().address_pools() {
+                        let Some(pool_info) = pool.address_info(&involved.address) else {
+                            continue;
+                        };
+                        if seen.insert((owner_type, pool.pool_type, pool_info.index)) {
+                            let mut info = pool_info.clone();
+                            info.used = true;
+                            marked_used.push(DerivedAddressInfo {
+                                account_type: owner_type,
+                                pool_type: pool.pool_type,
+                                info,
+                            });
+                        }
+                        // Snapshot the owning account's highest-used
+                        // watermarks. Standard accounts map External /
+                        // Internal onto the two persisted slots;
+                        // single-pool accounts (provider keys, identity
+                        // funding) surface theirs as `external`.
+                        let slot = highest_used.entry(owner_type).or_default();
+                        let mut snapshot = HighestUsedIndexes::default();
+                        for p in owner.managed_account_type().address_pools() {
+                            if p.is_internal() {
+                                snapshot.internal = p.highest_used;
+                            } else {
+                                snapshot.external = match (snapshot.external, p.highest_used) {
+                                    (Some(a), Some(b)) => Some(a.max(b)),
+                                    (a, b) => a.or(b),
+                                };
+                            }
+                        }
+                        slot.merge_max(snapshot);
+                    }
+                }
+            }
+        }
+    }
+
+    (marked_used, highest_used)
 }
 
 /// Returns `true` when the wallet's stored record for `txid` is in a
@@ -355,5 +503,7 @@ impl CoreChangeSet {
             && self.synced_height.is_none()
             && self.last_applied_chain_lock.is_none()
             && self.addresses_derived.is_empty()
+            && self.addresses_marked_used.is_empty()
+            && self.account_highest_used.is_empty()
     }
 }

--- a/packages/rs-platform-wallet/src/changeset/mod.rs
+++ b/packages/rs-platform-wallet/src/changeset/mod.rs
@@ -27,12 +27,13 @@ pub mod traits;
 pub use changeset::{
     upsert_pending_contact_crypto, AccountAddressPoolEntry, AccountRegistrationEntry,
     AssetLockChangeSet, AssetLockEntry, ContactChangeSet, ContactRequestEntry, CoreChangeSet,
-    IdentityChangeSet, IdentityEntry, IdentityKeyDerivationIndices, IdentityKeyEntry,
-    IdentityKeysChangeSet, KeyDerivationBreadcrumb, KeyWithBreadcrumb, PendingContactCrypto,
-    PendingContactCryptoKey, PendingContactCryptoKind, PendingContactCryptoOp,
-    PlatformAddressBalanceEntry, PlatformAddressChangeSet, PlatformWalletChangeSet,
-    ProviderKeyAccountEntry, ProviderKeyExtendedPubKey, ProviderPlatformNodePubKey,
-    ReceivedContactRequestKey, SentContactRequestKey, TokenBalanceChangeSet, WalletMetadataEntry,
+    HighestUsedIndexes, IdentityChangeSet, IdentityEntry, IdentityKeyDerivationIndices,
+    IdentityKeyEntry, IdentityKeysChangeSet, KeyDerivationBreadcrumb, KeyWithBreadcrumb,
+    PendingContactCrypto, PendingContactCryptoKey, PendingContactCryptoKind,
+    PendingContactCryptoOp, PlatformAddressBalanceEntry, PlatformAddressChangeSet,
+    PlatformWalletChangeSet, ProviderKeyAccountEntry, ProviderKeyExtendedPubKey,
+    ProviderPlatformNodePubKey, ReceivedContactRequestKey, SentContactRequestKey,
+    TokenBalanceChangeSet, WalletMetadataEntry,
 };
 pub use client_start_state::ClientStartState;
 pub use client_wallet_start_state::ClientWalletStartState;


### PR DESCRIPTION
## Issue being fixed or feature implemented

On a mainnet wallet whose seed owns masternode provider keys, SPV block processing correctly detects a ProRegTx payload match on the Provider Owner Keys address (verified with txid `5076f9ed731bcb7b5ddf47e21bf1262d22d99665ca89bb6329e6e706d605da85` at height 1030673) and `key-wallet` marks the address used in memory — but nothing ever reaches the persistence layer. The `WalletEvent` bus carries neither the `mark_address_used` results nor the pools' `highest_used` bumps, so:

- every mirrored store keeps `is_used = false` on matched addresses (provider keys and regular BIP44 alike), and
- `WalletChangeSetFFI::from_changeset` hardcoded `has_external_highest_used` / `has_internal_highest_used` to `false`, so `PersistentAccount.externalHighestUsed` stays `-1` on every account in every store.

## What was done?

- **`CoreChangeSet` gains two deltas** (`rs-platform-wallet`): `addresses_marked_used` (the authoritative post-mark `AddressInfo` per involved address, as `DerivedAddressInfo`) and `account_highest_used` (per-account external/internal pool watermarks via a new `HighestUsedIndexes` type). Merge dedups marked-used entries on `(account_type, pool_type, index)` — same discipline as `addresses_derived` — and folds watermarks monotonic-max per slot; both fields gate `is_empty` so a usage-only event still persists.
- **Event-bridge population** (`core_bridge.rs`): `collect_usage_deltas` re-runs the same matcher the wallet used during processing — the read-only `ManagedAccountCollection::check_transaction` — against each record's transaction after processing, then resolves every involved address back to its owning pool. That recovers the pool type (which the match doesn't carry) plus the authoritative `AddressInfo` and `highest_used`, covering both TXO matches (BIP44) and special-tx payload matches (provider owner/voting keys). Single-pool accounts (provider keys, identity funding) surface their watermark in the external slot, matching the account row's two persisted fields.
- **FFI emit** (`rs-platform-wallet-ffi`): marked-used entries are bucketed per `(account_type, pool_type)` and fanned out through the existing `on_persist_account_address_pools_fn` pipeline, deliberately **after** the derived-address emit — the Swift persister overwrites `isUsed` with the latest emit, so derive-then-use within one round lands `true`. `from_changeset` now fills `external/internal_highest_used` + `has_*` flags from the changeset; values are authoritative pool state (not batch maxima) and the flags stay `false` on no-usage batches, so stored watermarks can never regress.

No Swift changes are required — `persistAccountAddresses` and the account-changeset handler already consume both surfaces.

## How Has This Been Tested?

- New unit tests: merge dedup of marked-used entries, monotonic-max watermark merge (lower value / `None` never regresses a slot), usage-only changesets are non-empty (`rs-platform-wallet`), and `(account, pool)` grouping incl. a `ProviderOwnerKeys`/Absent-pool case with `used == true` preserved (`rs-platform-wallet-ffi`).
- `cargo test -p platform-wallet --lib` (415 passed) and `cargo test -p platform-wallet-ffi --lib` (141 passed).
- `cargo clippy -p platform-wallet -p platform-wallet-ffi --all-targets` clean; `cargo check --all-features --tests` clean on both crates; `cargo fmt --all`.
- On-device verification pending: mainnet wallet import + "Rescan Everything" should show Provider Owner Keys address #0 (`XkxD3qhMb7uaQg7rvm9ZNCzyYhZ7tLPQc2`) as used with Highest Used 0.

## Breaking Changes

None. New changeset fields are additive (`serde(skip)` breadcrumbs, `Default`-constructed), and the FFI struct layout is unchanged — only previously-hardcoded fields are now populated.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [ ] I have made corresponding changes to the documentation if needed

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added tracking for addresses marked as used and the highest-used address index for each account.
  * Preserved address usage status and derivation progress when wallet changes are saved.
* **Bug Fixes**
  * Improved wallet synchronization so address pools reflect authoritative usage information.
  * Prevented address usage and highest-used indexes from being lost or regressing when multiple updates are combined.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->