### PR TITLE
fix(swift-sdk): label provider special txs instead of Self-Transfer

### DIFF
--- a/packages/swift-sdk/Sources/SwiftDashSDK/Persistence/Models/PersistentTransaction.swift
+++ b/packages/swift-sdk/Sources/SwiftDashSDK/Persistence/Models/PersistentTransaction.swift
@@ -195,10 +195,33 @@ public final class PersistentTransaction {
         typedKind == .assetUnlock
     }
 
+    /// `true` for masternode provider special transactions (ProRegTx
+    /// and the three ProUp*Tx kinds). Like asset locks, these get
+    /// classified `Internal` by the wallet's direction logic (the
+    /// wallet only sees its own owner/voting/payout keys referenced
+    /// in the payload), so direction-derived labels like
+    /// "Self-Transfer" are misleading for them.
+    public var isProviderSpecial: Bool {
+        providerSpecialName != nil
+    }
+
+    /// Human-readable name for provider special transactions, `nil`
+    /// for every other kind.
+    public var providerSpecialName: String? {
+        switch typedKind {
+        case .providerRegistration: return "Provider Registration"
+        case .providerUpdateRegistrar: return "Provider Update Registrar"
+        case .providerUpdateService: return "Provider Update Service"
+        case .providerUpdateRevocation: return "Provider Update Revocation"
+        default: return nil
+        }
+    }
+
     /// Direction text for UI surfaces, overridden for asset-lock /
-    /// asset-unlock txs where the raw `Internal` direction is
-    /// misleading (the L1 DASH isn't going "to myself" — it's being
-    /// converted to / from L2 platform credits).
+    /// asset-unlock txs (the L1 DASH isn't going "to myself" — it's
+    /// being converted to / from L2 platform credits) and for
+    /// provider special txs (the payload references our keys but no
+    /// value moves "to myself").
     ///
     /// Use this anywhere a human-readable "what happened" label is
     /// needed; fall back to [`directionName`] only when the consumer
@@ -206,6 +229,7 @@ public final class PersistentTransaction {
     public var displayDirection: String {
         if isAssetLock { return "Asset Lock" }
         if isAssetUnlock { return "Asset Unlock" }
+        if let name = providerSpecialName { return name }
         return directionName
     }
 

--- a/packages/swift-sdk/SwiftExampleApp/SwiftExampleApp/Core/Views/TransactionDetailView.swift
+++ b/packages/swift-sdk/SwiftExampleApp/SwiftExampleApp/Core/Views/TransactionDetailView.swift
@@ -18,7 +18,10 @@ struct TransactionDetailView: View {
     /// have them, else an explicit "amount unknown" label for the
     /// historical-asset-lock case (rather than the misleading
     /// `+0.00000000 DASH` from `transaction.formattedAmount`).
-    private var displayAmount: String {
+    /// `nil` for a payload-only provider special tx — a ProRegTx
+    /// observed via the owner/voting keys moves no wallet balance,
+    /// and `+0.00000000 DASH` reads as a broken zero-value receive.
+    private var displayAmount: String? {
         if transaction.isAssetLock {
             if let duffs = assetLockAmountDuffs {
                 let dash = Double(duffs) / 100_000_000.0
@@ -26,12 +29,16 @@ struct TransactionDetailView: View {
             }
             return "Asset Lock (amount unknown)"
         }
+        if transaction.isProviderSpecial && transaction.netAmount == 0 {
+            return nil
+        }
         return transaction.formattedAmount
     }
 
     private var typeDescription: String {
         if transaction.isAssetLock { return "Asset Lock" }
         if transaction.isAssetUnlock { return "Asset Unlock" }
+        if let name = transaction.providerSpecialName { return name }
         switch transaction.netAmount {
         case let amount where amount > 0:
             return "Received"
@@ -45,6 +52,7 @@ struct TransactionDetailView: View {
     private var typeIcon: String {
         if transaction.isAssetLock { return "lock.fill" }
         if transaction.isAssetUnlock { return "lock.open.fill" }
+        if transaction.isProviderSpecial { return "server.rack" }
         switch transaction.netAmount {
         case let amount where amount > 0:
             return "arrow.down.circle.fill"
@@ -58,6 +66,9 @@ struct TransactionDetailView: View {
     private var typeColor: Color {
         if transaction.isAssetLock || transaction.isAssetUnlock {
             return .purple
+        }
+        if transaction.isProviderSpecial {
+            return .orange
         }
         switch transaction.netAmount {
         case let amount where amount > 0:
@@ -102,9 +113,11 @@ struct TransactionDetailView: View {
                             .font(.headline)
                             .foregroundColor(.secondary)
 
-                        Text(displayAmount)
-                            .font(.system(size: 32, weight: .bold, design: .rounded))
-                            .foregroundColor(typeColor)
+                        if let displayAmount {
+                            Text(displayAmount)
+                                .font(.system(size: 32, weight: .bold, design: .rounded))
+                                .foregroundColor(typeColor)
+                        }
                     }
                     .padding(.top, 20)
 

--- a/packages/swift-sdk/SwiftExampleApp/SwiftExampleApp/Core/Views/TransactionDetailView.swift
+++ b/packages/swift-sdk/SwiftExampleApp/SwiftExampleApp/Core/Views/TransactionDetailView.swift
@@ -36,9 +36,12 @@ struct TransactionDetailView: View {
     }
 
     private var typeDescription: String {
-        if transaction.isAssetLock { return "Asset Lock" }
-        if transaction.isAssetUnlock { return "Asset Unlock" }
-        if let name = transaction.providerSpecialName { return name }
+        // Special kinds (asset lock/unlock, provider txs) take their
+        // label from the model so it can't drift from the list rows.
+        if transaction.isAssetLock || transaction.isAssetUnlock
+            || transaction.isProviderSpecial {
+            return transaction.displayDirection
+        }
         switch transaction.netAmount {
         case let amount where amount > 0:
             return "Received"

--- a/packages/swift-sdk/SwiftExampleApp/SwiftExampleApp/Core/Views/TransactionListView.swift
+++ b/packages/swift-sdk/SwiftExampleApp/SwiftExampleApp/Core/Views/TransactionListView.swift
@@ -229,6 +229,10 @@ struct TransactionRowView: View {
         // "receive" applies cleanly.
         if transaction.isAssetLock { return "lock.fill" }
         if transaction.isAssetUnlock { return "lock.open.fill" }
+        // Provider special txs (ProRegTx / ProUp*Tx) also classify as
+        // `Internal` — the wallet just sees its own owner/voting/payout
+        // keys in the payload — so the self-transfer arrows would lie.
+        if transaction.isProviderSpecial { return "server.rack" }
         // direction: 0=incoming, 1=outgoing, 2=internal, 3=coinJoin
         switch transaction.direction {
         case 0: return "arrow.down.circle.fill"
@@ -248,6 +252,11 @@ struct TransactionRowView: View {
         // list and immediately spot identity-funding rows.
         if transaction.isAssetLock || transaction.isAssetUnlock {
             return .purple
+        }
+        // Provider special txs get their own axis too — orange, so a
+        // masternode registration doesn't scan as a red "sent" row.
+        if transaction.isProviderSpecial {
+            return .orange
         }
         switch transaction.direction {
         case 0: return .green
@@ -408,6 +417,14 @@ struct TransactionRowView: View {
                 return String(format: "-%.8f DASH", dash)
             }
             return "Asset Lock (amount unknown)"
+        }
+        // A payload-only provider special tx moves no wallet balance;
+        // `+0.00000000 DASH` reads as a broken zero-value receive, so
+        // put the tx kind in the amount slot instead. A provider tx
+        // that DOES move value (e.g. this wallet funded the collateral)
+        // falls through and shows the real signed amount.
+        if transaction.isProviderSpecial && transaction.netAmount == 0 {
+            return transaction.providerSpecialName ?? transaction.transactionType
         }
         return transaction.formattedAmount
     }

--- a/packages/swift-sdk/SwiftTests/SwiftDashSDKTests/PersistentTransactionDisplayTests.swift
+++ b/packages/swift-sdk/SwiftTests/SwiftDashSDKTests/PersistentTransactionDisplayTests.swift
@@ -1,0 +1,59 @@
+import XCTest
+@testable import SwiftDashSDK
+
+/// Pins the `transactionTypeKind` discriminant → display mapping on
+/// `PersistentTransaction`. The raw bytes mirror Rust's
+/// `transaction_type_to_u8` (rs-platform-wallet-ffi
+/// `core_wallet_types.rs`); a drift there, a `TransactionTypeKind`
+/// case renumbering, or a label typo shows up here without UI
+/// automation.
+final class PersistentTransactionDisplayTests: XCTestCase {
+
+    /// Direction 2 = internal — the raw classification every special
+    /// tx gets (asset locks, provider txs), which the display helpers
+    /// exist to override.
+    private func makeTransaction(kind: UInt8, direction: UInt32 = 2) -> PersistentTransaction {
+        let tx = PersistentTransaction(
+            txid: Data(repeating: 0xAB, count: 32),
+            transactionData: Data(),
+            direction: direction
+        )
+        tx.transactionTypeKind = kind
+        return tx
+    }
+
+    func testProviderSpecialNameForProviderKinds() {
+        let expected: [UInt8: String] = [
+            2: "Provider Registration",
+            3: "Provider Update Registrar",
+            4: "Provider Update Service",
+            5: "Provider Update Revocation",
+        ]
+        for (kind, name) in expected {
+            let tx = makeTransaction(kind: kind)
+            XCTAssertEqual(tx.providerSpecialName, name, "kind \(kind)")
+            XCTAssertTrue(tx.isProviderSpecial, "kind \(kind)")
+            XCTAssertEqual(tx.displayDirection, name, "kind \(kind)")
+        }
+    }
+
+    func testNonProviderKindsAreNotProviderSpecial() {
+        // Every other discriminant, plus the 0xFF "not populated"
+        // sentinel and an out-of-range future byte.
+        for kind: UInt8 in [0, 1, 6, 7, 8, 9, 0xFF, 42] {
+            let tx = makeTransaction(kind: kind)
+            XCTAssertNil(tx.providerSpecialName, "kind \(kind)")
+            XCTAssertFalse(tx.isProviderSpecial, "kind \(kind)")
+        }
+    }
+
+    func testDisplayDirectionPrecedenceUnchangedForOtherKinds() {
+        // Asset lock/unlock keep their existing overrides…
+        XCTAssertEqual(makeTransaction(kind: 6).displayDirection, "Asset Lock")
+        XCTAssertEqual(makeTransaction(kind: 7).displayDirection, "Asset Unlock")
+        // …and non-special kinds fall through to the raw direction.
+        XCTAssertEqual(makeTransaction(kind: 0).displayDirection, "Internal")
+        XCTAssertEqual(makeTransaction(kind: 0, direction: 0).displayDirection, "Incoming")
+        XCTAssertEqual(makeTransaction(kind: 0xFF).displayDirection, "Internal")
+    }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Provider special transactions (ProRegTx / ProUpRegTx / ProUpServTx / ProUpRevTx) classify as `direction=internal` — the wallet only sees its own owner/voting/payout keys referenced in the payload — so SwiftExampleApp rendered them as "Self-Transfer" with a misleading "+0.00000000 DASH" amount.

Verified repro: mainnet wallet, Provider Owner Keys account, ProRegTx `5076f9ed731bcb7b5ddf47e21bf1262d22d99665ca89bb6329e6e706d605da85` (height 1030673).

## What was done?
<!--- Describe your changes in detail -->

Extends the existing asset-lock/unlock display override pattern to provider special kinds (2–5):

- `PersistentTransaction` (SwiftDashSDK): added `isProviderSpecial` and `providerSpecialName` helpers and wired them into `displayDirection` — Storage Explorer list/detail views pick up the correct label with no view changes.
- `TransactionDetailView`: header shows the provider tx name instead of "Self-Transfer", uses a `server.rack` icon in orange, and hides the amount line entirely for payload-only provider txs (`netAmount == 0`).
- `TransactionRowView` (`TransactionListView.swift`): same icon/color treatment; the amount slot shows the tx kind (e.g. "Provider Registration") instead of "+0.00000000 DASH" when no wallet value moved. A provider tx that does move value (e.g. wallet-funded collateral) still shows its real signed amount.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

- Built SwiftExampleApp for the iPhone 16 simulator (`xcodebuild -sdk iphonesimulator`) with no errors.
- Display-only change over an already-persisted `transactionTypeKind` discriminant; the mainnet repro row (kind 2) renders "Provider Registration" on relaunch without a rescan.

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->

None.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [ ] I have made corresponding changes to the documentation if needed

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added clearer labels and dedicated icons/colors for provider-special transactions.
  * Provider-special transactions with no amount now display their transaction type instead of a zero-value amount.
  * Transaction details now show provider-special names and hide empty amount fields.

* **Bug Fixes**
  * Preserved existing display behavior for asset lock and unlock transactions.
  * Added coverage to verify transaction classification and display labels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->