### PR TITLE
docs: add missing group-read rows (TOK-18/19/20) to Android test plan

### DIFF
--- a/packages/kotlin-sdk/KotlinExampleApp/TEST_PLAN.md
+++ b/packages/kotlin-sdk/KotlinExampleApp/TEST_PLAN.md
@@ -227,6 +227,9 @@ All token actions support single-signer **and** group (propose / co-sign) modes 
 | TOK-15 | Group action — propose | Platform | Uncommon | ✅ | group | Token action in `.propose` mode (`CoSignProposalScreen`). |
 | TOK-16 | Group action — co-sign existing | Platform | Uncommon | ✅ | group | `PendingGroupActionsScreen` / `CoSignProposalScreen`. Action executes when accumulated signer power ≥ required. |
 | TOK-17 | Token transfer between two on-device identities | Platform | Thorough | ✅ | multiwallet, regression | `TOK-02`, recipient = wallet B's identity. Switch to B; verify the token balance arrived. |
+| TOK-18 | View group info / members | Platform | Thorough | ✅ | group, read-only | `GroupDetailScreen` — from `DataContractDetailsScreen` Groups section, tap a group to see required power + members (drills into member identities). |
+| TOK-19 | Group queries (info / actions / signers) | Platform | Thorough | ✅ | group, read-only | `QueryRegistry` Group category (`Get Group Info` / `Get Group Actions` / `Get Group Action Signers`) → `sdk.groups.*`. |
+| TOK-20 | Standalone group lifecycle management | Platform | — | ➖ | group | Retired — no group-create/membership transition exists; groups are only a token access-control construct (read queries `TOK-18`/`TOK-19`; actions fold into `TOK-15`/`TOK-16`). Documents the absence; not seeded. |
 
 ### 4.9 Shielded Pool (Orchard) — `Domain=Shielded`
 
@@ -319,7 +322,7 @@ Membership of each feature category across **all** sections (primary section mem
 - **Voting** — `VOTE-01..07`, `DPNS-05`, `DPNS-08`
 - **Contract** — `DC-01..04`
 - **Document** — `DOC-01..15`
-- **Token** — `TOK-01..17`
+- **Token** — `TOK-01..20`
 - **Shielded** — `SH-01..17`
 - **DashPay** — `DP-01..11`
 - **System / Diagnostics** — `SYS-01..08`
@@ -329,9 +332,9 @@ Membership of each feature category across **all** sections (primary section mem
 Tags are cross-cutting modalities. A test may appear under multiple tags.
 
 - **multiwallet** — `CORE-14..23`, `ID-14`, `ID-15`, `TOK-17`, `DPNS-08`, `DP-11`, `DOC-15`, `SH-14`, `SH-15`, `SH-16`, `SYS-08`
-- **group** — `TOK-15`, `TOK-16`
+- **group** — `TOK-15`, `TOK-16`, `TOK-18`, `TOK-19`
 - **contested** — `DPNS-05`, `DPNS-08`, `VOTE-01..06`
 - **withdrawal** — `ID-10`, `ADDR-04`, `SH-08`, `SH-16`
 - **regression** — `TOK-17`, `DP-10`
-- **read-only** — `SH-13`, `SYS-05`, `SYS-06`, `VOTE-02..06`
+- **read-only** — `SH-13`, `SYS-05`, `SYS-06`, `VOTE-02..06`, `TOK-18`, `TOK-19`
 - **masternode** — `VOTE-01`


### PR DESCRIPTION
## Issue being fixed or feature implemented
Diffing the two TEST_PLANs, the iOS plan had `TOK-18`/`TOK-19`/`TOK-20` with no Android counterpart — but the Android app implements the underlying features. It was a plan gap, not a feature gap.

## What was done?
Added the rows to the Android plan and squared the tag/category indexes:
- **TOK-18** View group info / members — `GroupDetailScreen` (from `DataContractDetailsScreen` Groups section).
- **TOK-19** Group queries (info / actions / signers) — `QueryRegistry` Group category → `sdk.groups.*`.
- **TOK-20** Standalone group lifecycle — retired `➖` tombstone (no group-create transition exists; matches iOS).

Seeded TOK-18/19 to the Kotlin QA catalog (TOK-20 `➖` not seeded). Both are read-only and drivable now that a group-member token exists on testnet (`AfroGYG9…`).

## How Has This Been Tested?
Docs-only; verified against the app source (`GroupDetailScreen.kt`, `QueryRegistry.kt` Group category) and the `GRP-01→TOK-18` / `GRP-02→TOK-19` remap in `qa-contract/src/codes.mjs`.

## Breaking Changes
None.

## Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [x] I have made corresponding changes to the documentation if needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)