### PR TITLE
feat(platform-wallet): fixed provider key derivation via rust-dashcore bump + legacy BLS display

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1637,7 +1637,7 @@ dependencies = [
 [[package]]
 name = "dash-network"
 version = "0.45.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=337f6ccc7f45a5f7a50abf0d6fecb1ef0b786e7b#337f6ccc7f45a5f7a50abf0d6fecb1ef0b786e7b"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=56a407883fc49a08cdb3b72845fdfc77983af92b#56a407883fc49a08cdb3b72845fdfc77983af92b"
 dependencies = [
  "bincode",
  "bincode_derive",
@@ -1648,7 +1648,7 @@ dependencies = [
 [[package]]
 name = "dash-network-seeds"
 version = "0.45.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=337f6ccc7f45a5f7a50abf0d6fecb1ef0b786e7b#337f6ccc7f45a5f7a50abf0d6fecb1ef0b786e7b"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=56a407883fc49a08cdb3b72845fdfc77983af92b#56a407883fc49a08cdb3b72845fdfc77983af92b"
 dependencies = [
  "dash-network",
 ]
@@ -1725,7 +1725,7 @@ dependencies = [
 [[package]]
 name = "dash-spv"
 version = "0.45.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=337f6ccc7f45a5f7a50abf0d6fecb1ef0b786e7b#337f6ccc7f45a5f7a50abf0d6fecb1ef0b786e7b"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=56a407883fc49a08cdb3b72845fdfc77983af92b#56a407883fc49a08cdb3b72845fdfc77983af92b"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1754,7 +1754,7 @@ dependencies = [
 [[package]]
 name = "dashcore"
 version = "0.45.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=337f6ccc7f45a5f7a50abf0d6fecb1ef0b786e7b#337f6ccc7f45a5f7a50abf0d6fecb1ef0b786e7b"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=56a407883fc49a08cdb3b72845fdfc77983af92b#56a407883fc49a08cdb3b72845fdfc77983af92b"
 dependencies = [
  "anyhow",
  "base64-compat",
@@ -1780,12 +1780,12 @@ dependencies = [
 [[package]]
 name = "dashcore-private"
 version = "0.45.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=337f6ccc7f45a5f7a50abf0d6fecb1ef0b786e7b#337f6ccc7f45a5f7a50abf0d6fecb1ef0b786e7b"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=56a407883fc49a08cdb3b72845fdfc77983af92b#56a407883fc49a08cdb3b72845fdfc77983af92b"
 
 [[package]]
 name = "dashcore-rpc"
 version = "0.45.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=337f6ccc7f45a5f7a50abf0d6fecb1ef0b786e7b#337f6ccc7f45a5f7a50abf0d6fecb1ef0b786e7b"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=56a407883fc49a08cdb3b72845fdfc77983af92b#56a407883fc49a08cdb3b72845fdfc77983af92b"
 dependencies = [
  "dashcore-rpc-json",
  "hex",
@@ -1798,7 +1798,7 @@ dependencies = [
 [[package]]
 name = "dashcore-rpc-json"
 version = "0.45.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=337f6ccc7f45a5f7a50abf0d6fecb1ef0b786e7b#337f6ccc7f45a5f7a50abf0d6fecb1ef0b786e7b"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=56a407883fc49a08cdb3b72845fdfc77983af92b#56a407883fc49a08cdb3b72845fdfc77983af92b"
 dependencies = [
  "bincode",
  "dashcore",
@@ -1813,7 +1813,7 @@ dependencies = [
 [[package]]
 name = "dashcore_hashes"
 version = "0.45.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=337f6ccc7f45a5f7a50abf0d6fecb1ef0b786e7b#337f6ccc7f45a5f7a50abf0d6fecb1ef0b786e7b"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=56a407883fc49a08cdb3b72845fdfc77983af92b#56a407883fc49a08cdb3b72845fdfc77983af92b"
 dependencies = [
  "bincode",
  "dashcore-private",
@@ -2867,7 +2867,7 @@ dependencies = [
 [[package]]
 name = "git-state"
 version = "0.45.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=337f6ccc7f45a5f7a50abf0d6fecb1ef0b786e7b#337f6ccc7f45a5f7a50abf0d6fecb1ef0b786e7b"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=56a407883fc49a08cdb3b72845fdfc77983af92b#56a407883fc49a08cdb3b72845fdfc77983af92b"
 
 [[package]]
 name = "glob"
@@ -4034,7 +4034,7 @@ dependencies = [
 [[package]]
 name = "key-wallet"
 version = "0.45.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=337f6ccc7f45a5f7a50abf0d6fecb1ef0b786e7b#337f6ccc7f45a5f7a50abf0d6fecb1ef0b786e7b"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=56a407883fc49a08cdb3b72845fdfc77983af92b#56a407883fc49a08cdb3b72845fdfc77983af92b"
 dependencies = [
  "aes",
  "async-trait",
@@ -4063,7 +4063,7 @@ dependencies = [
 [[package]]
 name = "key-wallet-ffi"
 version = "0.45.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=337f6ccc7f45a5f7a50abf0d6fecb1ef0b786e7b#337f6ccc7f45a5f7a50abf0d6fecb1ef0b786e7b"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=56a407883fc49a08cdb3b72845fdfc77983af92b#56a407883fc49a08cdb3b72845fdfc77983af92b"
 dependencies = [
  "cbindgen 0.29.4",
  "dash-network",
@@ -4079,7 +4079,7 @@ dependencies = [
 [[package]]
 name = "key-wallet-manager"
 version = "0.45.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=337f6ccc7f45a5f7a50abf0d6fecb1ef0b786e7b#337f6ccc7f45a5f7a50abf0d6fecb1ef0b786e7b"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=56a407883fc49a08cdb3b72845fdfc77983af92b#56a407883fc49a08cdb3b72845fdfc77983af92b"
 dependencies = [
  "async-trait",
  "bincode",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1206,7 +1206,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1637,7 +1637,7 @@ dependencies = [
 [[package]]
 name = "dash-network"
 version = "0.45.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=7221d866954be113888db7fdb36923a8e1d20c04#7221d866954be113888db7fdb36923a8e1d20c04"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=38c689d97ddce0483d4ca455ade32efb019eb68d#38c689d97ddce0483d4ca455ade32efb019eb68d"
 dependencies = [
  "bincode",
  "bincode_derive",
@@ -1648,7 +1648,7 @@ dependencies = [
 [[package]]
 name = "dash-network-seeds"
 version = "0.45.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=7221d866954be113888db7fdb36923a8e1d20c04#7221d866954be113888db7fdb36923a8e1d20c04"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=38c689d97ddce0483d4ca455ade32efb019eb68d#38c689d97ddce0483d4ca455ade32efb019eb68d"
 dependencies = [
  "dash-network",
 ]
@@ -1725,7 +1725,7 @@ dependencies = [
 [[package]]
 name = "dash-spv"
 version = "0.45.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=7221d866954be113888db7fdb36923a8e1d20c04#7221d866954be113888db7fdb36923a8e1d20c04"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=38c689d97ddce0483d4ca455ade32efb019eb68d#38c689d97ddce0483d4ca455ade32efb019eb68d"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1754,7 +1754,7 @@ dependencies = [
 [[package]]
 name = "dashcore"
 version = "0.45.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=7221d866954be113888db7fdb36923a8e1d20c04#7221d866954be113888db7fdb36923a8e1d20c04"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=38c689d97ddce0483d4ca455ade32efb019eb68d#38c689d97ddce0483d4ca455ade32efb019eb68d"
 dependencies = [
  "anyhow",
  "base64-compat",
@@ -1780,12 +1780,12 @@ dependencies = [
 [[package]]
 name = "dashcore-private"
 version = "0.45.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=7221d866954be113888db7fdb36923a8e1d20c04#7221d866954be113888db7fdb36923a8e1d20c04"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=38c689d97ddce0483d4ca455ade32efb019eb68d#38c689d97ddce0483d4ca455ade32efb019eb68d"
 
 [[package]]
 name = "dashcore-rpc"
 version = "0.45.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=7221d866954be113888db7fdb36923a8e1d20c04#7221d866954be113888db7fdb36923a8e1d20c04"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=38c689d97ddce0483d4ca455ade32efb019eb68d#38c689d97ddce0483d4ca455ade32efb019eb68d"
 dependencies = [
  "dashcore-rpc-json",
  "hex",
@@ -1798,7 +1798,7 @@ dependencies = [
 [[package]]
 name = "dashcore-rpc-json"
 version = "0.45.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=7221d866954be113888db7fdb36923a8e1d20c04#7221d866954be113888db7fdb36923a8e1d20c04"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=38c689d97ddce0483d4ca455ade32efb019eb68d#38c689d97ddce0483d4ca455ade32efb019eb68d"
 dependencies = [
  "bincode",
  "dashcore",
@@ -1813,7 +1813,7 @@ dependencies = [
 [[package]]
 name = "dashcore_hashes"
 version = "0.45.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=7221d866954be113888db7fdb36923a8e1d20c04#7221d866954be113888db7fdb36923a8e1d20c04"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=38c689d97ddce0483d4ca455ade32efb019eb68d#38c689d97ddce0483d4ca455ade32efb019eb68d"
 dependencies = [
  "bincode",
  "dashcore-private",
@@ -2428,7 +2428,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2489,7 +2489,7 @@ checksum = "0ce92ff622d6dadf7349484f42c93271a0d49b7cc4d466a936405bacbe10aa78"
 dependencies = [
  "cfg-if",
  "rustix 1.1.4",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2867,7 +2867,7 @@ dependencies = [
 [[package]]
 name = "git-state"
 version = "0.45.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=7221d866954be113888db7fdb36923a8e1d20c04#7221d866954be113888db7fdb36923a8e1d20c04"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=38c689d97ddce0483d4ca455ade32efb019eb68d#38c689d97ddce0483d4ca455ade32efb019eb68d"
 
 [[package]]
 name = "glob"
@@ -3803,7 +3803,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4034,7 +4034,7 @@ dependencies = [
 [[package]]
 name = "key-wallet"
 version = "0.45.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=7221d866954be113888db7fdb36923a8e1d20c04#7221d866954be113888db7fdb36923a8e1d20c04"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=38c689d97ddce0483d4ca455ade32efb019eb68d#38c689d97ddce0483d4ca455ade32efb019eb68d"
 dependencies = [
  "aes",
  "async-trait",
@@ -4063,7 +4063,7 @@ dependencies = [
 [[package]]
 name = "key-wallet-ffi"
 version = "0.45.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=7221d866954be113888db7fdb36923a8e1d20c04#7221d866954be113888db7fdb36923a8e1d20c04"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=38c689d97ddce0483d4ca455ade32efb019eb68d#38c689d97ddce0483d4ca455ade32efb019eb68d"
 dependencies = [
  "cbindgen 0.29.4",
  "dash-network",
@@ -4079,7 +4079,7 @@ dependencies = [
 [[package]]
 name = "key-wallet-manager"
 version = "0.45.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=7221d866954be113888db7fdb36923a8e1d20c04#7221d866954be113888db7fdb36923a8e1d20c04"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=38c689d97ddce0483d4ca455ade32efb019eb68d#38c689d97ddce0483d4ca455ade32efb019eb68d"
 dependencies = [
  "async-trait",
  "bincode",
@@ -4596,7 +4596,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5698,7 +5698,7 @@ dependencies = [
  "once_cell",
  "socket2 0.5.10",
  "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6489,7 +6489,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6502,7 +6502,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6561,7 +6561,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -7421,7 +7421,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -8870,7 +8870,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1637,7 +1637,7 @@ dependencies = [
 [[package]]
 name = "dash-network"
 version = "0.45.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=bc6cbf962333c7bb4ef9029745a98ae1faca1ef6#bc6cbf962333c7bb4ef9029745a98ae1faca1ef6"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=2045cd29efbb323df9ec6c23f542ae5b12389b0e#2045cd29efbb323df9ec6c23f542ae5b12389b0e"
 dependencies = [
  "bincode",
  "bincode_derive",
@@ -1648,7 +1648,7 @@ dependencies = [
 [[package]]
 name = "dash-network-seeds"
 version = "0.45.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=bc6cbf962333c7bb4ef9029745a98ae1faca1ef6#bc6cbf962333c7bb4ef9029745a98ae1faca1ef6"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=2045cd29efbb323df9ec6c23f542ae5b12389b0e#2045cd29efbb323df9ec6c23f542ae5b12389b0e"
 dependencies = [
  "dash-network",
 ]
@@ -1725,7 +1725,7 @@ dependencies = [
 [[package]]
 name = "dash-spv"
 version = "0.45.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=bc6cbf962333c7bb4ef9029745a98ae1faca1ef6#bc6cbf962333c7bb4ef9029745a98ae1faca1ef6"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=2045cd29efbb323df9ec6c23f542ae5b12389b0e#2045cd29efbb323df9ec6c23f542ae5b12389b0e"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1754,7 +1754,7 @@ dependencies = [
 [[package]]
 name = "dashcore"
 version = "0.45.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=bc6cbf962333c7bb4ef9029745a98ae1faca1ef6#bc6cbf962333c7bb4ef9029745a98ae1faca1ef6"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=2045cd29efbb323df9ec6c23f542ae5b12389b0e#2045cd29efbb323df9ec6c23f542ae5b12389b0e"
 dependencies = [
  "anyhow",
  "base64-compat",
@@ -1780,12 +1780,12 @@ dependencies = [
 [[package]]
 name = "dashcore-private"
 version = "0.45.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=bc6cbf962333c7bb4ef9029745a98ae1faca1ef6#bc6cbf962333c7bb4ef9029745a98ae1faca1ef6"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=2045cd29efbb323df9ec6c23f542ae5b12389b0e#2045cd29efbb323df9ec6c23f542ae5b12389b0e"
 
 [[package]]
 name = "dashcore-rpc"
 version = "0.45.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=bc6cbf962333c7bb4ef9029745a98ae1faca1ef6#bc6cbf962333c7bb4ef9029745a98ae1faca1ef6"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=2045cd29efbb323df9ec6c23f542ae5b12389b0e#2045cd29efbb323df9ec6c23f542ae5b12389b0e"
 dependencies = [
  "dashcore-rpc-json",
  "hex",
@@ -1798,7 +1798,7 @@ dependencies = [
 [[package]]
 name = "dashcore-rpc-json"
 version = "0.45.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=bc6cbf962333c7bb4ef9029745a98ae1faca1ef6#bc6cbf962333c7bb4ef9029745a98ae1faca1ef6"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=2045cd29efbb323df9ec6c23f542ae5b12389b0e#2045cd29efbb323df9ec6c23f542ae5b12389b0e"
 dependencies = [
  "bincode",
  "dashcore",
@@ -1813,7 +1813,7 @@ dependencies = [
 [[package]]
 name = "dashcore_hashes"
 version = "0.45.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=bc6cbf962333c7bb4ef9029745a98ae1faca1ef6#bc6cbf962333c7bb4ef9029745a98ae1faca1ef6"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=2045cd29efbb323df9ec6c23f542ae5b12389b0e#2045cd29efbb323df9ec6c23f542ae5b12389b0e"
 dependencies = [
  "bincode",
  "dashcore-private",
@@ -2867,7 +2867,7 @@ dependencies = [
 [[package]]
 name = "git-state"
 version = "0.45.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=bc6cbf962333c7bb4ef9029745a98ae1faca1ef6#bc6cbf962333c7bb4ef9029745a98ae1faca1ef6"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=2045cd29efbb323df9ec6c23f542ae5b12389b0e#2045cd29efbb323df9ec6c23f542ae5b12389b0e"
 
 [[package]]
 name = "glob"
@@ -4034,7 +4034,7 @@ dependencies = [
 [[package]]
 name = "key-wallet"
 version = "0.45.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=bc6cbf962333c7bb4ef9029745a98ae1faca1ef6#bc6cbf962333c7bb4ef9029745a98ae1faca1ef6"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=2045cd29efbb323df9ec6c23f542ae5b12389b0e#2045cd29efbb323df9ec6c23f542ae5b12389b0e"
 dependencies = [
  "aes",
  "async-trait",
@@ -4063,7 +4063,7 @@ dependencies = [
 [[package]]
 name = "key-wallet-ffi"
 version = "0.45.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=bc6cbf962333c7bb4ef9029745a98ae1faca1ef6#bc6cbf962333c7bb4ef9029745a98ae1faca1ef6"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=2045cd29efbb323df9ec6c23f542ae5b12389b0e#2045cd29efbb323df9ec6c23f542ae5b12389b0e"
 dependencies = [
  "cbindgen 0.29.4",
  "dash-network",
@@ -4079,7 +4079,7 @@ dependencies = [
 [[package]]
 name = "key-wallet-manager"
 version = "0.45.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=bc6cbf962333c7bb4ef9029745a98ae1faca1ef6#bc6cbf962333c7bb4ef9029745a98ae1faca1ef6"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=2045cd29efbb323df9ec6c23f542ae5b12389b0e#2045cd29efbb323df9ec6c23f542ae5b12389b0e"
 dependencies = [
  "async-trait",
  "bincode",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1206,7 +1206,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1637,7 +1637,7 @@ dependencies = [
 [[package]]
 name = "dash-network"
 version = "0.45.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=2045cd29efbb323df9ec6c23f542ae5b12389b0e#2045cd29efbb323df9ec6c23f542ae5b12389b0e"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=7221d866954be113888db7fdb36923a8e1d20c04#7221d866954be113888db7fdb36923a8e1d20c04"
 dependencies = [
  "bincode",
  "bincode_derive",
@@ -1648,7 +1648,7 @@ dependencies = [
 [[package]]
 name = "dash-network-seeds"
 version = "0.45.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=2045cd29efbb323df9ec6c23f542ae5b12389b0e#2045cd29efbb323df9ec6c23f542ae5b12389b0e"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=7221d866954be113888db7fdb36923a8e1d20c04#7221d866954be113888db7fdb36923a8e1d20c04"
 dependencies = [
  "dash-network",
 ]
@@ -1725,7 +1725,7 @@ dependencies = [
 [[package]]
 name = "dash-spv"
 version = "0.45.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=2045cd29efbb323df9ec6c23f542ae5b12389b0e#2045cd29efbb323df9ec6c23f542ae5b12389b0e"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=7221d866954be113888db7fdb36923a8e1d20c04#7221d866954be113888db7fdb36923a8e1d20c04"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1754,7 +1754,7 @@ dependencies = [
 [[package]]
 name = "dashcore"
 version = "0.45.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=2045cd29efbb323df9ec6c23f542ae5b12389b0e#2045cd29efbb323df9ec6c23f542ae5b12389b0e"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=7221d866954be113888db7fdb36923a8e1d20c04#7221d866954be113888db7fdb36923a8e1d20c04"
 dependencies = [
  "anyhow",
  "base64-compat",
@@ -1780,12 +1780,12 @@ dependencies = [
 [[package]]
 name = "dashcore-private"
 version = "0.45.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=2045cd29efbb323df9ec6c23f542ae5b12389b0e#2045cd29efbb323df9ec6c23f542ae5b12389b0e"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=7221d866954be113888db7fdb36923a8e1d20c04#7221d866954be113888db7fdb36923a8e1d20c04"
 
 [[package]]
 name = "dashcore-rpc"
 version = "0.45.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=2045cd29efbb323df9ec6c23f542ae5b12389b0e#2045cd29efbb323df9ec6c23f542ae5b12389b0e"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=7221d866954be113888db7fdb36923a8e1d20c04#7221d866954be113888db7fdb36923a8e1d20c04"
 dependencies = [
  "dashcore-rpc-json",
  "hex",
@@ -1798,7 +1798,7 @@ dependencies = [
 [[package]]
 name = "dashcore-rpc-json"
 version = "0.45.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=2045cd29efbb323df9ec6c23f542ae5b12389b0e#2045cd29efbb323df9ec6c23f542ae5b12389b0e"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=7221d866954be113888db7fdb36923a8e1d20c04#7221d866954be113888db7fdb36923a8e1d20c04"
 dependencies = [
  "bincode",
  "dashcore",
@@ -1813,7 +1813,7 @@ dependencies = [
 [[package]]
 name = "dashcore_hashes"
 version = "0.45.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=2045cd29efbb323df9ec6c23f542ae5b12389b0e#2045cd29efbb323df9ec6c23f542ae5b12389b0e"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=7221d866954be113888db7fdb36923a8e1d20c04#7221d866954be113888db7fdb36923a8e1d20c04"
 dependencies = [
  "bincode",
  "dashcore-private",
@@ -2428,7 +2428,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2489,7 +2489,7 @@ checksum = "0ce92ff622d6dadf7349484f42c93271a0d49b7cc4d466a936405bacbe10aa78"
 dependencies = [
  "cfg-if",
  "rustix 1.1.4",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2867,7 +2867,7 @@ dependencies = [
 [[package]]
 name = "git-state"
 version = "0.45.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=2045cd29efbb323df9ec6c23f542ae5b12389b0e#2045cd29efbb323df9ec6c23f542ae5b12389b0e"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=7221d866954be113888db7fdb36923a8e1d20c04#7221d866954be113888db7fdb36923a8e1d20c04"
 
 [[package]]
 name = "glob"
@@ -3803,7 +3803,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4034,7 +4034,7 @@ dependencies = [
 [[package]]
 name = "key-wallet"
 version = "0.45.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=2045cd29efbb323df9ec6c23f542ae5b12389b0e#2045cd29efbb323df9ec6c23f542ae5b12389b0e"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=7221d866954be113888db7fdb36923a8e1d20c04#7221d866954be113888db7fdb36923a8e1d20c04"
 dependencies = [
  "aes",
  "async-trait",
@@ -4063,7 +4063,7 @@ dependencies = [
 [[package]]
 name = "key-wallet-ffi"
 version = "0.45.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=2045cd29efbb323df9ec6c23f542ae5b12389b0e#2045cd29efbb323df9ec6c23f542ae5b12389b0e"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=7221d866954be113888db7fdb36923a8e1d20c04#7221d866954be113888db7fdb36923a8e1d20c04"
 dependencies = [
  "cbindgen 0.29.4",
  "dash-network",
@@ -4079,7 +4079,7 @@ dependencies = [
 [[package]]
 name = "key-wallet-manager"
 version = "0.45.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=2045cd29efbb323df9ec6c23f542ae5b12389b0e#2045cd29efbb323df9ec6c23f542ae5b12389b0e"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=7221d866954be113888db7fdb36923a8e1d20c04#7221d866954be113888db7fdb36923a8e1d20c04"
 dependencies = [
  "async-trait",
  "bincode",
@@ -4596,7 +4596,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5698,7 +5698,7 @@ dependencies = [
  "once_cell",
  "socket2 0.5.10",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6489,7 +6489,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6502,7 +6502,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6561,7 +6561,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -7421,7 +7421,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -8870,7 +8870,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1637,7 +1637,7 @@ dependencies = [
 [[package]]
 name = "dash-network"
 version = "0.45.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=56a407883fc49a08cdb3b72845fdfc77983af92b#56a407883fc49a08cdb3b72845fdfc77983af92b"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=bc6cbf962333c7bb4ef9029745a98ae1faca1ef6#bc6cbf962333c7bb4ef9029745a98ae1faca1ef6"
 dependencies = [
  "bincode",
  "bincode_derive",
@@ -1648,7 +1648,7 @@ dependencies = [
 [[package]]
 name = "dash-network-seeds"
 version = "0.45.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=56a407883fc49a08cdb3b72845fdfc77983af92b#56a407883fc49a08cdb3b72845fdfc77983af92b"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=bc6cbf962333c7bb4ef9029745a98ae1faca1ef6#bc6cbf962333c7bb4ef9029745a98ae1faca1ef6"
 dependencies = [
  "dash-network",
 ]
@@ -1725,7 +1725,7 @@ dependencies = [
 [[package]]
 name = "dash-spv"
 version = "0.45.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=56a407883fc49a08cdb3b72845fdfc77983af92b#56a407883fc49a08cdb3b72845fdfc77983af92b"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=bc6cbf962333c7bb4ef9029745a98ae1faca1ef6#bc6cbf962333c7bb4ef9029745a98ae1faca1ef6"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1754,7 +1754,7 @@ dependencies = [
 [[package]]
 name = "dashcore"
 version = "0.45.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=56a407883fc49a08cdb3b72845fdfc77983af92b#56a407883fc49a08cdb3b72845fdfc77983af92b"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=bc6cbf962333c7bb4ef9029745a98ae1faca1ef6#bc6cbf962333c7bb4ef9029745a98ae1faca1ef6"
 dependencies = [
  "anyhow",
  "base64-compat",
@@ -1780,12 +1780,12 @@ dependencies = [
 [[package]]
 name = "dashcore-private"
 version = "0.45.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=56a407883fc49a08cdb3b72845fdfc77983af92b#56a407883fc49a08cdb3b72845fdfc77983af92b"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=bc6cbf962333c7bb4ef9029745a98ae1faca1ef6#bc6cbf962333c7bb4ef9029745a98ae1faca1ef6"
 
 [[package]]
 name = "dashcore-rpc"
 version = "0.45.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=56a407883fc49a08cdb3b72845fdfc77983af92b#56a407883fc49a08cdb3b72845fdfc77983af92b"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=bc6cbf962333c7bb4ef9029745a98ae1faca1ef6#bc6cbf962333c7bb4ef9029745a98ae1faca1ef6"
 dependencies = [
  "dashcore-rpc-json",
  "hex",
@@ -1798,7 +1798,7 @@ dependencies = [
 [[package]]
 name = "dashcore-rpc-json"
 version = "0.45.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=56a407883fc49a08cdb3b72845fdfc77983af92b#56a407883fc49a08cdb3b72845fdfc77983af92b"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=bc6cbf962333c7bb4ef9029745a98ae1faca1ef6#bc6cbf962333c7bb4ef9029745a98ae1faca1ef6"
 dependencies = [
  "bincode",
  "dashcore",
@@ -1813,7 +1813,7 @@ dependencies = [
 [[package]]
 name = "dashcore_hashes"
 version = "0.45.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=56a407883fc49a08cdb3b72845fdfc77983af92b#56a407883fc49a08cdb3b72845fdfc77983af92b"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=bc6cbf962333c7bb4ef9029745a98ae1faca1ef6#bc6cbf962333c7bb4ef9029745a98ae1faca1ef6"
 dependencies = [
  "bincode",
  "dashcore-private",
@@ -2867,7 +2867,7 @@ dependencies = [
 [[package]]
 name = "git-state"
 version = "0.45.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=56a407883fc49a08cdb3b72845fdfc77983af92b#56a407883fc49a08cdb3b72845fdfc77983af92b"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=bc6cbf962333c7bb4ef9029745a98ae1faca1ef6#bc6cbf962333c7bb4ef9029745a98ae1faca1ef6"
 
 [[package]]
 name = "glob"
@@ -4034,7 +4034,7 @@ dependencies = [
 [[package]]
 name = "key-wallet"
 version = "0.45.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=56a407883fc49a08cdb3b72845fdfc77983af92b#56a407883fc49a08cdb3b72845fdfc77983af92b"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=bc6cbf962333c7bb4ef9029745a98ae1faca1ef6#bc6cbf962333c7bb4ef9029745a98ae1faca1ef6"
 dependencies = [
  "aes",
  "async-trait",
@@ -4063,7 +4063,7 @@ dependencies = [
 [[package]]
 name = "key-wallet-ffi"
 version = "0.45.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=56a407883fc49a08cdb3b72845fdfc77983af92b#56a407883fc49a08cdb3b72845fdfc77983af92b"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=bc6cbf962333c7bb4ef9029745a98ae1faca1ef6#bc6cbf962333c7bb4ef9029745a98ae1faca1ef6"
 dependencies = [
  "cbindgen 0.29.4",
  "dash-network",
@@ -4079,7 +4079,7 @@ dependencies = [
 [[package]]
 name = "key-wallet-manager"
 version = "0.45.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=56a407883fc49a08cdb3b72845fdfc77983af92b#56a407883fc49a08cdb3b72845fdfc77983af92b"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=bc6cbf962333c7bb4ef9029745a98ae1faca1ef6#bc6cbf962333c7bb4ef9029745a98ae1faca1ef6"
 dependencies = [
  "async-trait",
  "bincode",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,14 +50,14 @@ members = [
 ]
 
 [workspace.dependencies]
-dashcore = { git = "https://github.com/dashpay/rust-dashcore", rev = "2045cd29efbb323df9ec6c23f542ae5b12389b0e" }
-dash-network-seeds = { git = "https://github.com/dashpay/rust-dashcore", rev = "2045cd29efbb323df9ec6c23f542ae5b12389b0e" }
-dash-spv = { git = "https://github.com/dashpay/rust-dashcore", rev = "2045cd29efbb323df9ec6c23f542ae5b12389b0e" }
-key-wallet = { git = "https://github.com/dashpay/rust-dashcore", rev = "2045cd29efbb323df9ec6c23f542ae5b12389b0e" }
-key-wallet-ffi = { git = "https://github.com/dashpay/rust-dashcore", rev = "2045cd29efbb323df9ec6c23f542ae5b12389b0e" }
-key-wallet-manager = { git = "https://github.com/dashpay/rust-dashcore", rev = "2045cd29efbb323df9ec6c23f542ae5b12389b0e" }
-dash-network = { git = "https://github.com/dashpay/rust-dashcore", rev = "2045cd29efbb323df9ec6c23f542ae5b12389b0e" }
-dashcore-rpc = { git = "https://github.com/dashpay/rust-dashcore", rev = "2045cd29efbb323df9ec6c23f542ae5b12389b0e" }
+dashcore = { git = "https://github.com/dashpay/rust-dashcore", rev = "7221d866954be113888db7fdb36923a8e1d20c04" }
+dash-network-seeds = { git = "https://github.com/dashpay/rust-dashcore", rev = "7221d866954be113888db7fdb36923a8e1d20c04" }
+dash-spv = { git = "https://github.com/dashpay/rust-dashcore", rev = "7221d866954be113888db7fdb36923a8e1d20c04" }
+key-wallet = { git = "https://github.com/dashpay/rust-dashcore", rev = "7221d866954be113888db7fdb36923a8e1d20c04" }
+key-wallet-ffi = { git = "https://github.com/dashpay/rust-dashcore", rev = "7221d866954be113888db7fdb36923a8e1d20c04" }
+key-wallet-manager = { git = "https://github.com/dashpay/rust-dashcore", rev = "7221d866954be113888db7fdb36923a8e1d20c04" }
+dash-network = { git = "https://github.com/dashpay/rust-dashcore", rev = "7221d866954be113888db7fdb36923a8e1d20c04" }
+dashcore-rpc = { git = "https://github.com/dashpay/rust-dashcore", rev = "7221d866954be113888db7fdb36923a8e1d20c04" }
 
 tokio-metrics = "0.5"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,14 +50,14 @@ members = [
 ]
 
 [workspace.dependencies]
-dashcore = { git = "https://github.com/dashpay/rust-dashcore", rev = "bc6cbf962333c7bb4ef9029745a98ae1faca1ef6" }
-dash-network-seeds = { git = "https://github.com/dashpay/rust-dashcore", rev = "bc6cbf962333c7bb4ef9029745a98ae1faca1ef6" }
-dash-spv = { git = "https://github.com/dashpay/rust-dashcore", rev = "bc6cbf962333c7bb4ef9029745a98ae1faca1ef6" }
-key-wallet = { git = "https://github.com/dashpay/rust-dashcore", rev = "bc6cbf962333c7bb4ef9029745a98ae1faca1ef6" }
-key-wallet-ffi = { git = "https://github.com/dashpay/rust-dashcore", rev = "bc6cbf962333c7bb4ef9029745a98ae1faca1ef6" }
-key-wallet-manager = { git = "https://github.com/dashpay/rust-dashcore", rev = "bc6cbf962333c7bb4ef9029745a98ae1faca1ef6" }
-dash-network = { git = "https://github.com/dashpay/rust-dashcore", rev = "bc6cbf962333c7bb4ef9029745a98ae1faca1ef6" }
-dashcore-rpc = { git = "https://github.com/dashpay/rust-dashcore", rev = "bc6cbf962333c7bb4ef9029745a98ae1faca1ef6" }
+dashcore = { git = "https://github.com/dashpay/rust-dashcore", rev = "2045cd29efbb323df9ec6c23f542ae5b12389b0e" }
+dash-network-seeds = { git = "https://github.com/dashpay/rust-dashcore", rev = "2045cd29efbb323df9ec6c23f542ae5b12389b0e" }
+dash-spv = { git = "https://github.com/dashpay/rust-dashcore", rev = "2045cd29efbb323df9ec6c23f542ae5b12389b0e" }
+key-wallet = { git = "https://github.com/dashpay/rust-dashcore", rev = "2045cd29efbb323df9ec6c23f542ae5b12389b0e" }
+key-wallet-ffi = { git = "https://github.com/dashpay/rust-dashcore", rev = "2045cd29efbb323df9ec6c23f542ae5b12389b0e" }
+key-wallet-manager = { git = "https://github.com/dashpay/rust-dashcore", rev = "2045cd29efbb323df9ec6c23f542ae5b12389b0e" }
+dash-network = { git = "https://github.com/dashpay/rust-dashcore", rev = "2045cd29efbb323df9ec6c23f542ae5b12389b0e" }
+dashcore-rpc = { git = "https://github.com/dashpay/rust-dashcore", rev = "2045cd29efbb323df9ec6c23f542ae5b12389b0e" }
 
 tokio-metrics = "0.5"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,14 +50,14 @@ members = [
 ]
 
 [workspace.dependencies]
-dashcore = { git = "https://github.com/dashpay/rust-dashcore", rev = "56a407883fc49a08cdb3b72845fdfc77983af92b" }
-dash-network-seeds = { git = "https://github.com/dashpay/rust-dashcore", rev = "56a407883fc49a08cdb3b72845fdfc77983af92b" }
-dash-spv = { git = "https://github.com/dashpay/rust-dashcore", rev = "56a407883fc49a08cdb3b72845fdfc77983af92b" }
-key-wallet = { git = "https://github.com/dashpay/rust-dashcore", rev = "56a407883fc49a08cdb3b72845fdfc77983af92b" }
-key-wallet-ffi = { git = "https://github.com/dashpay/rust-dashcore", rev = "56a407883fc49a08cdb3b72845fdfc77983af92b" }
-key-wallet-manager = { git = "https://github.com/dashpay/rust-dashcore", rev = "56a407883fc49a08cdb3b72845fdfc77983af92b" }
-dash-network = { git = "https://github.com/dashpay/rust-dashcore", rev = "56a407883fc49a08cdb3b72845fdfc77983af92b" }
-dashcore-rpc = { git = "https://github.com/dashpay/rust-dashcore", rev = "56a407883fc49a08cdb3b72845fdfc77983af92b" }
+dashcore = { git = "https://github.com/dashpay/rust-dashcore", rev = "bc6cbf962333c7bb4ef9029745a98ae1faca1ef6" }
+dash-network-seeds = { git = "https://github.com/dashpay/rust-dashcore", rev = "bc6cbf962333c7bb4ef9029745a98ae1faca1ef6" }
+dash-spv = { git = "https://github.com/dashpay/rust-dashcore", rev = "bc6cbf962333c7bb4ef9029745a98ae1faca1ef6" }
+key-wallet = { git = "https://github.com/dashpay/rust-dashcore", rev = "bc6cbf962333c7bb4ef9029745a98ae1faca1ef6" }
+key-wallet-ffi = { git = "https://github.com/dashpay/rust-dashcore", rev = "bc6cbf962333c7bb4ef9029745a98ae1faca1ef6" }
+key-wallet-manager = { git = "https://github.com/dashpay/rust-dashcore", rev = "bc6cbf962333c7bb4ef9029745a98ae1faca1ef6" }
+dash-network = { git = "https://github.com/dashpay/rust-dashcore", rev = "bc6cbf962333c7bb4ef9029745a98ae1faca1ef6" }
+dashcore-rpc = { git = "https://github.com/dashpay/rust-dashcore", rev = "bc6cbf962333c7bb4ef9029745a98ae1faca1ef6" }
 
 tokio-metrics = "0.5"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,14 +50,14 @@ members = [
 ]
 
 [workspace.dependencies]
-dashcore = { git = "https://github.com/dashpay/rust-dashcore", rev = "7221d866954be113888db7fdb36923a8e1d20c04" }
-dash-network-seeds = { git = "https://github.com/dashpay/rust-dashcore", rev = "7221d866954be113888db7fdb36923a8e1d20c04" }
-dash-spv = { git = "https://github.com/dashpay/rust-dashcore", rev = "7221d866954be113888db7fdb36923a8e1d20c04" }
-key-wallet = { git = "https://github.com/dashpay/rust-dashcore", rev = "7221d866954be113888db7fdb36923a8e1d20c04" }
-key-wallet-ffi = { git = "https://github.com/dashpay/rust-dashcore", rev = "7221d866954be113888db7fdb36923a8e1d20c04" }
-key-wallet-manager = { git = "https://github.com/dashpay/rust-dashcore", rev = "7221d866954be113888db7fdb36923a8e1d20c04" }
-dash-network = { git = "https://github.com/dashpay/rust-dashcore", rev = "7221d866954be113888db7fdb36923a8e1d20c04" }
-dashcore-rpc = { git = "https://github.com/dashpay/rust-dashcore", rev = "7221d866954be113888db7fdb36923a8e1d20c04" }
+dashcore = { git = "https://github.com/dashpay/rust-dashcore", rev = "38c689d97ddce0483d4ca455ade32efb019eb68d" }
+dash-network-seeds = { git = "https://github.com/dashpay/rust-dashcore", rev = "38c689d97ddce0483d4ca455ade32efb019eb68d" }
+dash-spv = { git = "https://github.com/dashpay/rust-dashcore", rev = "38c689d97ddce0483d4ca455ade32efb019eb68d" }
+key-wallet = { git = "https://github.com/dashpay/rust-dashcore", rev = "38c689d97ddce0483d4ca455ade32efb019eb68d" }
+key-wallet-ffi = { git = "https://github.com/dashpay/rust-dashcore", rev = "38c689d97ddce0483d4ca455ade32efb019eb68d" }
+key-wallet-manager = { git = "https://github.com/dashpay/rust-dashcore", rev = "38c689d97ddce0483d4ca455ade32efb019eb68d" }
+dash-network = { git = "https://github.com/dashpay/rust-dashcore", rev = "38c689d97ddce0483d4ca455ade32efb019eb68d" }
+dashcore-rpc = { git = "https://github.com/dashpay/rust-dashcore", rev = "38c689d97ddce0483d4ca455ade32efb019eb68d" }
 
 tokio-metrics = "0.5"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,14 +50,14 @@ members = [
 ]
 
 [workspace.dependencies]
-dashcore = { git = "https://github.com/dashpay/rust-dashcore", rev = "337f6ccc7f45a5f7a50abf0d6fecb1ef0b786e7b" }
-dash-network-seeds = { git = "https://github.com/dashpay/rust-dashcore", rev = "337f6ccc7f45a5f7a50abf0d6fecb1ef0b786e7b" }
-dash-spv = { git = "https://github.com/dashpay/rust-dashcore", rev = "337f6ccc7f45a5f7a50abf0d6fecb1ef0b786e7b" }
-key-wallet = { git = "https://github.com/dashpay/rust-dashcore", rev = "337f6ccc7f45a5f7a50abf0d6fecb1ef0b786e7b" }
-key-wallet-ffi = { git = "https://github.com/dashpay/rust-dashcore", rev = "337f6ccc7f45a5f7a50abf0d6fecb1ef0b786e7b" }
-key-wallet-manager = { git = "https://github.com/dashpay/rust-dashcore", rev = "337f6ccc7f45a5f7a50abf0d6fecb1ef0b786e7b" }
-dash-network = { git = "https://github.com/dashpay/rust-dashcore", rev = "337f6ccc7f45a5f7a50abf0d6fecb1ef0b786e7b" }
-dashcore-rpc = { git = "https://github.com/dashpay/rust-dashcore", rev = "337f6ccc7f45a5f7a50abf0d6fecb1ef0b786e7b" }
+dashcore = { git = "https://github.com/dashpay/rust-dashcore", rev = "56a407883fc49a08cdb3b72845fdfc77983af92b" }
+dash-network-seeds = { git = "https://github.com/dashpay/rust-dashcore", rev = "56a407883fc49a08cdb3b72845fdfc77983af92b" }
+dash-spv = { git = "https://github.com/dashpay/rust-dashcore", rev = "56a407883fc49a08cdb3b72845fdfc77983af92b" }
+key-wallet = { git = "https://github.com/dashpay/rust-dashcore", rev = "56a407883fc49a08cdb3b72845fdfc77983af92b" }
+key-wallet-ffi = { git = "https://github.com/dashpay/rust-dashcore", rev = "56a407883fc49a08cdb3b72845fdfc77983af92b" }
+key-wallet-manager = { git = "https://github.com/dashpay/rust-dashcore", rev = "56a407883fc49a08cdb3b72845fdfc77983af92b" }
+dash-network = { git = "https://github.com/dashpay/rust-dashcore", rev = "56a407883fc49a08cdb3b72845fdfc77983af92b" }
+dashcore-rpc = { git = "https://github.com/dashpay/rust-dashcore", rev = "56a407883fc49a08cdb3b72845fdfc77983af92b" }
 
 tokio-metrics = "0.5"
 

--- a/packages/rs-platform-wallet-ffi/src/core_wallet_types.rs
+++ b/packages/rs-platform-wallet-ffi/src/core_wallet_types.rs
@@ -1056,7 +1056,7 @@ pub(crate) struct MasternodeAggregate {
     /// ProUpReg.
     pub operator_public_key: Option<[u8; 48]>,
     operator_height: u32,
-    /// Platform node id (hash160, 20 bytes) for evonodes — follows the
+    /// Platform node id (SHA256[..20] Tenderdash, #884, 20 bytes) for evonodes — follows the
     /// latest ProRegTx / ProUpServ.
     pub platform_node_id: Option<[u8; 20]>,
     platform_node_height: u32,
@@ -1172,8 +1172,11 @@ where
                 }
                 if agg.platform_node_id.is_none() || height >= agg.platform_node_height {
                     // Evonode-only; `None` on a regular masternode.
-                    if let Some(node_id) = p.platform_node_id.as_ref() {
-                        agg.platform_node_id = Some(provider_hash_to_20(node_id.as_ref()));
+                    // `platform_node_id` is a `PlatformNodeId` newtype
+                    // (rust-dashcore #885); the 20 raw bytes (SHA256[..20]
+                    // Tenderdash convention) come off `to_byte_array()`.
+                    if let Some(node_id) = p.platform_node_id {
+                        agg.platform_node_id = Some(node_id.to_byte_array());
                         agg.platform_node_height = height;
                     }
                 }
@@ -1187,10 +1190,11 @@ where
                     agg.service_address = Some(provider_ip_port(p.ip_address, p.port));
                     agg.service_height = height;
                 }
-                // ProUpServ's `platform_node_id` is a raw `Option<[u8; 20]>`.
+                // ProUpServ's `platform_node_id` is now `Option<PlatformNodeId>`
+                // (rust-dashcore #885, was `Option<[u8; 20]>`).
                 if let Some(node_id) = p.platform_node_id {
                     if agg.platform_node_id.is_none() || height >= agg.platform_node_height {
-                        agg.platform_node_id = Some(node_id);
+                        agg.platform_node_id = Some(node_id.to_byte_array());
                         agg.platform_node_height = height;
                     }
                 }
@@ -1306,7 +1310,7 @@ pub struct MasternodeEntryFFI {
     /// Operator BLS public key (48 bytes), gated by `has_operator_key`.
     pub operator_public_key: [u8; 48],
     pub has_operator_key: bool,
-    /// Platform node id (hash160, 20 bytes) — evonodes only — gated by
+    /// Platform node id (SHA256[..20] Tenderdash, #884, 20 bytes) — evonodes only — gated by
     /// `has_platform_node_id`.
     pub platform_node_id: [u8; 20],
     pub has_platform_node_id: bool,

--- a/packages/rs-platform-wallet-ffi/src/core_wallet_types.rs
+++ b/packages/rs-platform-wallet-ffi/src/core_wallet_types.rs
@@ -1193,15 +1193,13 @@ where
                 if agg.platform_node_id.is_none() || height >= agg.platform_node_height {
                     // Evonode-only; `None` on a regular masternode.
                     // `platform_node_id` is a `PlatformNodeId` newtype
-                    // (rust-dashcore #885). These stored bytes are currently the
-                    // raw WIRE order (reversed uint160-internal), NOT the
-                    // canonical Tenderdash `SHA256(pubkey)[..20]` form the
-                    // derived ownership index (`accessors.rs`) uses — so display
-                    // and payload-sourced ownership matching of the node id are
-                    // pending rust-dashcore#887, which normalizes the wire bytes
-                    // to canonical inside `PlatformNodeId::consensus_decode`.
-                    // Keep `to_byte_array()` as-is here: reversing platform-side
-                    // would double-reverse once #887 lands via a pin bump.
+                    // (rust-dashcore #885) whose `consensus_decode` normalizes
+                    // the wire's reversed uint160-internal bytes to the
+                    // canonical Tenderdash `SHA256(pubkey)[..20]` order
+                    // (rust-dashcore #887/#889), so `to_byte_array()` here is
+                    // already canonical and matches the derived ownership
+                    // index (`accessors.rs`) and dashmate display directly —
+                    // do NOT reverse platform-side.
                     if let Some(node_id) = p.platform_node_id {
                         agg.platform_node_id = Some(node_id.to_byte_array());
                         agg.platform_node_height = height;
@@ -1218,11 +1216,8 @@ where
                     agg.service_height = height;
                 }
                 // ProUpServ's `platform_node_id` is now `Option<PlatformNodeId>`
-                // (rust-dashcore #885, was `Option<[u8; 20]>`). Stored as raw
-                // WIRE bytes here (see the ProRegTx arm above); canonical
-                // display/ownership matching of the node id is pending
-                // rust-dashcore#887 — don't reverse platform-side or it will
-                // double-reverse once that lands via a pin bump.
+                // (rust-dashcore #885, was `Option<[u8; 20]>`); decoded bytes
+                // are canonical forward order (see the ProRegTx arm above).
                 if let Some(node_id) = p.platform_node_id {
                     if agg.platform_node_id.is_none() || height >= agg.platform_node_height {
                         agg.platform_node_id = Some(node_id.to_byte_array());

--- a/packages/rs-platform-wallet-ffi/src/core_wallet_types.rs
+++ b/packages/rs-platform-wallet-ffi/src/core_wallet_types.rs
@@ -83,6 +83,14 @@ pub struct TransactionRecordFFI {
     pub block_height: u32,
     pub block_hash: [u8; 32],
     pub block_timestamp: u32,
+    /// The transaction's index within its block (`block.vtx` order),
+    /// meaningful only when `has_block_position` (stamped by block
+    /// processing since rust-dashcore#891; absent on records confirmed
+    /// before the field existed and on unconfirmed contexts). Persisted
+    /// so restored provider special transactions keep Core's same-block
+    /// apply order in the masternode aggregation.
+    pub block_position: u32,
+    pub has_block_position: bool,
     /// 0=incoming, 1=outgoing, 2=internal, 3=coinJoin.
     pub direction: u32,
     /// `transaction_type` rendered as a `Debug`-formatted string for
@@ -1123,14 +1131,10 @@ where
     // last and wins under the `>= *_height` guards. Stable so equal keys
     // keep their incoming order.
     //
-    // NOTE: upstream `TransactionRecord`/`TransactionContext`/`BlockInfo`
-    // carry no in-block index (only height/hash/timestamp), so the live
-    // caller currently passes `position = 0` for every tx (see
-    // `provider_masternode_txs_blocking`); until an in-block tx index is
-    // threaded from block processing (rust-dashcore#890), same-block same-field ties still fall
-    // back to feed order. The ordering below is the mechanism that makes it
-    // correct once that field exists, and is exercised by the crafted-position
-    // test.
+    // The position is stamped onto `BlockInfo` during block processing
+    // (rust-dashcore#891) and round-tripped through persistence; legacy
+    // rows confirmed before the field existed come back as 0 and fall
+    // back to feed order among themselves.
     let mut ordered: Vec<(u32, u32, &'a dashcore::Transaction)> = txs.collect();
     ordered.sort_by_key(|(height, position, _)| (*height, *position));
 
@@ -1529,21 +1533,36 @@ fn tx_record_to_ffi(
     let mut txid = [0u8; 32];
     txid.copy_from_slice(tr.txid.as_ref());
 
-    let (ctx_val, blk_height, blk_hash, blk_ts) = match &tr.context {
-        TransactionContext::Mempool => (0u32, 0u32, [0u8; 32], 0u32),
+    let (ctx_val, blk_height, blk_hash, blk_ts, blk_position, has_blk_position) = match &tr.context
+    {
+        TransactionContext::Mempool => (0u32, 0u32, [0u8; 32], 0u32, 0u32, false),
         TransactionContext::InstantSend(_is_lock) => {
             // InstantSend has no block info — treat as mempool-level with flag
-            (1u32, 0u32, [0u8; 32], 0u32)
+            (1u32, 0u32, [0u8; 32], 0u32, 0u32, false)
         }
         TransactionContext::InBlock(bi) => {
             let mut h = [0u8; 32];
             h.copy_from_slice(bi.block_hash().as_ref());
-            (2u32, bi.height(), h, bi.timestamp())
+            (
+                2u32,
+                bi.height(),
+                h,
+                bi.timestamp(),
+                bi.position().unwrap_or(0),
+                bi.position().is_some(),
+            )
         }
         TransactionContext::InChainLockedBlock(bi) => {
             let mut h = [0u8; 32];
             h.copy_from_slice(bi.block_hash().as_ref());
-            (3u32, bi.height(), h, bi.timestamp())
+            (
+                3u32,
+                bi.height(),
+                h,
+                bi.timestamp(),
+                bi.position().unwrap_or(0),
+                bi.position().is_some(),
+            )
         }
     };
 
@@ -1614,6 +1633,8 @@ fn tx_record_to_ffi(
         block_height: blk_height,
         block_hash: blk_hash,
         block_timestamp: blk_ts,
+        block_position: blk_position,
+        has_block_position: has_blk_position,
         direction: dir_val,
         transaction_type: type_str.into_raw(),
         transaction_type_kind: type_kind,

--- a/packages/rs-platform-wallet-ffi/src/core_wallet_types.rs
+++ b/packages/rs-platform-wallet-ffi/src/core_wallet_types.rs
@@ -1105,7 +1105,7 @@ pub(crate) struct MasternodeAggregate {
 /// record source (which txs to feed) is the caller's concern (see the
 /// query fn), which is why this is decoupled and unit-testable.
 pub(crate) fn aggregate_masternodes<'a, F>(
-    txs: impl Iterator<Item = (u32, &'a dashcore::Transaction)>,
+    txs: impl Iterator<Item = (u32, u32, &'a dashcore::Transaction)>,
     list_lookup: F,
 ) -> Vec<MasternodeAggregate>
 where
@@ -1114,11 +1114,31 @@ where
     use dashcore::blockdata::transaction::special_transaction::provider_registration::ProviderMasternodeType;
     use dashcore::transaction::TransactionPayload;
 
+    // Each input item is `(height, in_block_position, tx)`. Core's
+    // `RebuildListFromBlock` applies same-block provider updates in
+    // `block.vtx` order, so the per-field latest-wins below must resolve
+    // ties by `(height, position)`, not by the arbitrary txid order the
+    // caller's `BTreeMap<Txid, _>` dedup produces. Process ascending
+    // `(height, position)` so the block-latest write for each field lands
+    // last and wins under the `>= *_height` guards. Stable so equal keys
+    // keep their incoming order.
+    //
+    // NOTE: upstream `TransactionRecord`/`TransactionContext`/`BlockInfo`
+    // carry no in-block index (only height/hash/timestamp), so the live
+    // caller currently passes `position = 0` for every tx (see
+    // `provider_masternode_txs_blocking`); until an in-block tx index is
+    // threaded from block processing (rust-dashcore#890), same-block same-field ties still fall
+    // back to feed order. The ordering below is the mechanism that makes it
+    // correct once that field exists, and is exercised by the crafted-position
+    // test.
+    let mut ordered: Vec<(u32, u32, &'a dashcore::Transaction)> = txs.collect();
+    ordered.sort_by_key(|(height, position, _)| (*height, *position));
+
     let mut order: Vec<[u8; 32]> = Vec::new();
     let mut by_hash: std::collections::HashMap<[u8; 32], MasternodeAggregate> =
         std::collections::HashMap::new();
 
-    for (height, tx) in txs {
+    for (height, _position, tx) in ordered {
         // proTxHash key: a ProRegTx's own txid, else the update's link.
         let key = match &tx.special_transaction_payload {
             Some(TransactionPayload::ProviderRegistrationPayloadType(_)) => {
@@ -1173,8 +1193,15 @@ where
                 if agg.platform_node_id.is_none() || height >= agg.platform_node_height {
                     // Evonode-only; `None` on a regular masternode.
                     // `platform_node_id` is a `PlatformNodeId` newtype
-                    // (rust-dashcore #885); the 20 raw bytes (SHA256[..20]
-                    // Tenderdash convention) come off `to_byte_array()`.
+                    // (rust-dashcore #885). These stored bytes are currently the
+                    // raw WIRE order (reversed uint160-internal), NOT the
+                    // canonical Tenderdash `SHA256(pubkey)[..20]` form the
+                    // derived ownership index (`accessors.rs`) uses — so display
+                    // and payload-sourced ownership matching of the node id are
+                    // pending rust-dashcore#887, which normalizes the wire bytes
+                    // to canonical inside `PlatformNodeId::consensus_decode`.
+                    // Keep `to_byte_array()` as-is here: reversing platform-side
+                    // would double-reverse once #887 lands via a pin bump.
                     if let Some(node_id) = p.platform_node_id {
                         agg.platform_node_id = Some(node_id.to_byte_array());
                         agg.platform_node_height = height;
@@ -1191,7 +1218,11 @@ where
                     agg.service_height = height;
                 }
                 // ProUpServ's `platform_node_id` is now `Option<PlatformNodeId>`
-                // (rust-dashcore #885, was `Option<[u8; 20]>`).
+                // (rust-dashcore #885, was `Option<[u8; 20]>`). Stored as raw
+                // WIRE bytes here (see the ProRegTx arm above); canonical
+                // display/ownership matching of the node id is pending
+                // rust-dashcore#887 — don't reverse platform-side or it will
+                // double-reverse once that lands via a pin bump.
                 if let Some(node_id) = p.platform_node_id {
                     if agg.platform_node_id.is_none() || height >= agg.platform_node_height {
                         agg.platform_node_id = Some(node_id.to_byte_array());
@@ -1338,6 +1369,15 @@ pub struct MasternodeEntryFFI {
     pub platform_in_wallet: bool,
     pub platform_account_type: u8,
     pub platform_key_index: u32,
+    /// Whether the platform-node ownership check was actually *possible* for
+    /// this query: `true` when the wallet's derived platform-node index had
+    /// entries to compare against, `false` when it was empty/unavailable (no
+    /// platform pool, or a seedless restore before the persisted key batch
+    /// rehydrated it). Lets the persister distinguish a definitive
+    /// `platform_in_wallet == false` (checked, not ours — e.g. an on-chain
+    /// key rotation to an external node) from "couldn't check yet", so it
+    /// never leaves stale ownership set. See `MasternodeSync`.
+    pub platform_ownership_checked: bool,
 }
 
 /// Encode a hash160 as a network-specific base58 P2PKH address string
@@ -1473,6 +1513,11 @@ pub(crate) fn masternode_entry_ffi(
         platform_in_wallet,
         platform_account_type,
         platform_key_index,
+        // The check was possible iff the wallet's derived platform-node index
+        // had entries to compare against. Empty index ⇒ no platform pool / not
+        // yet rehydrated ⇒ ownership is "unchecked", and the persister must
+        // retain any prior value rather than clobber it to false.
+        platform_ownership_checked: !platform_index.is_empty(),
     }
 }
 
@@ -1901,7 +1946,7 @@ mod tests {
         let reg = decode_tx(PROREG_HEX);
         let expected_pro_tx = provider_hash_to_32(reg.txid().as_ref());
 
-        let mns = aggregate_masternodes([(100u32, &reg)].into_iter(), unavailable_dml);
+        let mns = aggregate_masternodes([(100u32, 0u32, &reg)].into_iter(), unavailable_dml);
         assert_eq!(mns.len(), 1);
         let mn = &mns[0];
         assert_eq!(mn.pro_tx_hash, expected_pro_tx);
@@ -1937,7 +1982,7 @@ mod tests {
     #[test]
     fn aggregate_update_only_masternode() {
         let ups = decode_tx(PROUPSERV_HEX);
-        let mns = aggregate_masternodes([(50u32, &ups)].into_iter(), unavailable_dml);
+        let mns = aggregate_masternodes([(50u32, 0u32, &ups)].into_iter(), unavailable_dml);
         assert_eq!(mns.len(), 1);
         let mn = &mns[0];
         assert!(!mn.has_registration);
@@ -1953,7 +1998,7 @@ mod tests {
         let reg = decode_tx(PROREG_HEX);
         let ups = decode_tx(PROUPSERV_HEX);
         let mns = aggregate_masternodes(
-            [(100u32, &reg), (200u32, &ups)].into_iter(),
+            [(100u32, 0u32, &reg), (200u32, 0u32, &ups)].into_iter(),
             unavailable_dml,
         );
         assert_eq!(mns.len(), 2, "distinct proTxHashes ⇒ two masternodes");
@@ -1999,7 +2044,10 @@ mod tests {
         };
 
         // Revocation feed order shouldn't matter (height drives merges).
-        let mns = aggregate_masternodes([(300u32, &rev), (100u32, &reg)].into_iter(), lookup);
+        let mns = aggregate_masternodes(
+            [(300u32, 0u32, &rev), (100u32, 0u32, &reg)].into_iter(),
+            lookup,
+        );
         assert_eq!(mns.len(), 1);
         let mn = &mns[0];
         assert_eq!(mn.pro_tx_hash, revoked_pro_tx);
@@ -2033,7 +2081,7 @@ mod tests {
                 assert_eq!(*pt, pro_tx);
                 membership
             };
-            let mns = aggregate_masternodes([(100u32, &reg)].into_iter(), lookup);
+            let mns = aggregate_masternodes([(100u32, 0u32, &reg)].into_iter(), lookup);
             assert_eq!(mns.len(), 1);
             assert_eq!(mns[0].status, expected);
             assert!(!mns[0].revoked, "no ProUpRevTx ⇒ revoked flag stays false");
@@ -2061,7 +2109,7 @@ mod tests {
         }
 
         let mns = aggregate_masternodes(
-            [(100u32, &regular), (200u32, &evonode)].into_iter(),
+            [(100u32, 0u32, &regular), (200u32, 0u32, &evonode)].into_iter(),
             unavailable_dml,
         );
         assert_eq!(mns.len(), 2, "distinct proTxHashes ⇒ two masternodes");
@@ -2070,5 +2118,73 @@ mod tests {
         let reg = mns.iter().find(|m| !m.is_evonode).expect("regular present");
         assert_eq!(evo.type_index, 1, "first (only) evonode ⇒ Evonode 1");
         assert_eq!(reg.type_index, 1, "first (only) regular ⇒ Masternode 1");
+    }
+
+    /// Two provider updates for one masternode in the SAME block must resolve
+    /// the per-field latest-wins by in-block `position`, matching Core's
+    /// `block.vtx` order — NOT by the arbitrary txid order the caller's
+    /// `BTreeMap<Txid>` dedup would otherwise impose. Feed the same pair in
+    /// both orders; the higher-positioned (block-latest) update wins each time,
+    /// proving position — not feed/txid order — decides the outcome.
+    #[test]
+    fn same_block_updates_resolve_by_position_not_txid() {
+        use dashcore::blockdata::transaction::special_transaction::provider_update_service::ProviderUpdateServicePayload;
+        use dashcore::transaction::TransactionPayload;
+
+        // Shared registration linkage ⇒ both updates land in one bucket.
+        let pro_tx_hash = decode_tx(PROREG_HEX).txid();
+        let group_key = provider_hash_to_32(pro_tx_hash.as_ref());
+
+        // Build a ProUpServTx directly (no raw-hex vector needed); `port`
+        // distinguishes the resulting service address, `inputs` perturbs the
+        // txid so the two txs are genuinely distinct.
+        let make_upserv = |port: u16, inputs: u8| -> dashcore::Transaction {
+            let payload = ProviderUpdateServicePayload {
+                version: 1,
+                mn_type: None,
+                pro_tx_hash,
+                ip_address: 42,
+                port,
+                script_payout: dashcore::ScriptBuf::new(),
+                inputs_hash: [inputs; 32].into(),
+                platform_node_id: None,
+                platform_p2p_port: None,
+                platform_http_port: None,
+                payload_sig: [0u8; 96].into(),
+            };
+            dashcore::Transaction {
+                version: 3,
+                lock_time: 0,
+                input: vec![],
+                output: vec![],
+                special_transaction_payload: Some(
+                    TransactionPayload::ProviderUpdateServicePayloadType(payload),
+                ),
+            }
+        };
+
+        let low = make_upserv(19000, 3); // in-block position 0
+        let high = make_upserv(19999, 4); // in-block position 1 (block-latest)
+
+        for feed in [
+            [(500u32, 0u32, &low), (500u32, 1u32, &high)],
+            // Reversed feed order (block-latest fed first): position, not feed
+            // order, must still pick the winner.
+            [(500u32, 1u32, &high), (500u32, 0u32, &low)],
+        ] {
+            let mns = aggregate_masternodes(feed.into_iter(), unavailable_dml);
+            assert_eq!(mns.len(), 1, "same proTxHash ⇒ one bucket");
+            assert_eq!(mns[0].pro_tx_hash, group_key);
+            assert!(
+                mns[0]
+                    .service_address
+                    .as_deref()
+                    .unwrap_or_default()
+                    .ends_with(":19999"),
+                "higher in-block position (block-latest) must win; got {:?}",
+                mns[0].service_address
+            );
+            assert_eq!(mns[0].tx_count, 2, "both updates counted");
+        }
     }
 }

--- a/packages/rs-platform-wallet-ffi/src/identity_keys_from_mnemonic.rs
+++ b/packages/rs-platform-wallet-ffi/src/identity_keys_from_mnemonic.rs
@@ -104,6 +104,35 @@ pub(crate) unsafe fn resolve_master_from_resolver(
     wallet_id: &[u8; 32],
     network: Network,
 ) -> Result<ExtendedPrivKey, PlatformWalletFFIResult> {
+    let seed = resolve_seed_from_resolver(mnemonic_resolver_handle, wallet_id)?;
+    ExtendedPrivKey::new_master(network, seed.as_ref()).map_err(|e| {
+        PlatformWalletFFIResult::err(
+            PlatformWalletFFIResultCode::ErrorWalletOperation,
+            format!("failed to build master xpriv from resolved mnemonic: {e}"),
+        )
+    })
+}
+
+/// Resolve a wallet's BIP-39 mnemonic via a Swift-owned
+/// [`MnemonicResolverHandle`] and return the **raw 64-byte BIP39 seed**
+/// (empty passphrase).
+///
+/// This is the seed the BLS operator / Ed25519 platform-node HD masters
+/// consume directly (rust-dashcore #879); unlike
+/// [`resolve_master_from_resolver`] it does **not** reduce the seed to a
+/// secp256k1 `ExtendedPrivKey` — doing so would discard the raw seed the
+/// provider-key derivation needs. The mnemonic and the returned seed are
+/// held in [`Zeroizing`] buffers; the seed is scrubbed when the returned
+/// value drops.
+///
+/// # Safety
+/// `mnemonic_resolver_handle` must be non-null, come from
+/// [`rs_sdk_ffi::dash_sdk_mnemonic_resolver_create`], and remain valid
+/// for the duration of the call.
+pub(crate) unsafe fn resolve_seed_from_resolver(
+    mnemonic_resolver_handle: *mut rs_sdk_ffi::MnemonicResolverHandle,
+    wallet_id: &[u8; 32],
+) -> Result<Zeroizing<[u8; 64]>, PlatformWalletFFIResult> {
     use rs_sdk_ffi::{mnemonic_resolver_result, MNEMONIC_RESOLVER_BUFFER_CAPACITY};
     use std::ffi::c_void;
 
@@ -165,13 +194,7 @@ pub(crate) unsafe fn resolve_master_from_resolver(
 
     let seed: Zeroizing<[u8; 64]> = Zeroizing::new(mnemonic.to_seed(""));
     drop(mnemonic);
-
-    ExtendedPrivKey::new_master(network, seed.as_ref()).map_err(|e| {
-        PlatformWalletFFIResult::err(
-            PlatformWalletFFIResultCode::ErrorWalletOperation,
-            format!("failed to build master xpriv from resolved mnemonic: {e}"),
-        )
-    })
+    Ok(seed)
 }
 
 /// Build the DIP-9 identity-authentication derivation path

--- a/packages/rs-platform-wallet-ffi/src/persistence.rs
+++ b/packages/rs-platform-wallet-ffi/src/persistence.rs
@@ -2756,9 +2756,28 @@ unsafe fn address_info_from_ffi(
 /// the same index, and the reverse-lookup maps + `highest_*`
 /// watermarks are extended to cover indices past that default
 /// gap window.
+///
+/// **Typed-key preservation:** a persisted row can lose its typed public
+/// key on the FFI round-trip — the [`CoreAddressEntryFFI`] key field is a
+/// bare 33-byte slot that only fits a compressed ECDSA key and carries no
+/// key-type discriminator, so BLS (48B) operator and Ed25519 (32B)
+/// platform-node entries come back with `public_key: None`. Overwriting a
+/// prederived typed entry (which `from_wallet` filled with
+/// `PublicKeyType::BLS`/`EdDSA`) with such a `None` row would break
+/// key-wallet's provider-key matching. So this MERGES: when the incoming
+/// row has no typed key but the existing entry at that index does, the
+/// existing typed key is kept. (Funds/ECDSA rows always carry their key,
+/// so the merge is a no-op for them.)
 fn restore_address_pool(pool: &mut AddressPool, infos: Vec<AddressInfo>) {
-    for info in infos {
+    for mut info in infos {
         let idx = info.index;
+        if info.public_key.is_none() {
+            if let Some(existing) = pool.addresses.get(&idx) {
+                if existing.public_key.is_some() {
+                    info.public_key = existing.public_key.clone();
+                }
+            }
+        }
         pool.address_index.insert(info.address.clone(), idx);
         pool.script_pubkey_index
             .insert(info.script_pubkey.clone(), idx);
@@ -2980,6 +2999,79 @@ unsafe fn restore_core_address_pools(
         routed: pools_routed,
         dropped: pools_dropped,
     })
+}
+
+/// Rehydrate the persisted platform-node (Ed25519) key `batch` into the
+/// managed `ProviderPlatformKeys` pool.
+///
+/// SLIP-10 Ed25519 is hardened-only, so `ManagedWalletInfo::from_wallet`
+/// can't re-derive these keys from the account xpub on an external-signable
+/// restore — the batch (persisted at registration, supplied by the host on
+/// load) is the only seedless source. Each entry is inserted as a typed
+/// [`PublicKeyType::EdDSA`] pool address, keyed by its hardened index, with
+/// the platform node id recomputed as `SHA256(pubkey)[..20]` (rust-dashcore
+/// #884) — **never** trusting any persisted hash160-era id. This lets the
+/// masternode-ownership scan match a ProRegTx `platform_node_id` to the
+/// wallet's own derivation index on a seedless wallet.
+fn restore_platform_node_pool(
+    wallet_info: &mut ManagedWalletInfo,
+    batch: &[(u32, [u8; 32])],
+    network: Network,
+) -> Result<(), PersistenceError> {
+    use dashcore::hashes::Hash;
+    use key_wallet::managed_account::managed_account_trait::ManagedAccountTrait;
+    if batch.is_empty() {
+        return Ok(());
+    }
+    let Some(account) = wallet_info.accounts.provider_platform_keys.as_mut() else {
+        return Ok(());
+    };
+    let account_path = AccountType::ProviderPlatformKeys
+        .derivation_path(network)
+        .map_err(|e| PersistenceError::backend(format!("platform-node account path: {:?}", e)))?;
+    let base_children: Vec<key_wallet::bip32::ChildNumber> = account_path.as_ref().to_vec();
+
+    let mut infos: Vec<AddressInfo> = Vec::with_capacity(batch.len());
+    for (index, pubkey) in batch {
+        // Recompute the node id from the pubkey (SHA256[..20], #884).
+        let node_id = dashcore::PlatformNodeId::from_ed25519_public_key(pubkey).to_byte_array();
+        let payload =
+            dashcore::address::Payload::PubkeyHash(dashcore::PubkeyHash::from_byte_array(node_id));
+        let address = dashcore::Address::new(network, payload);
+        let script_pubkey = address.script_pubkey();
+        let child = key_wallet::bip32::ChildNumber::from_hardened_idx(*index).map_err(|e| {
+            PersistenceError::backend(format!("platform-node child index {}: {:?}", index, e))
+        })?;
+        let mut children = base_children.clone();
+        children.push(child);
+        let path = DerivationPath::from(children);
+        infos.push(AddressInfo {
+            address,
+            script_pubkey,
+            public_key: Some(PublicKeyType::EdDSA(pubkey.to_vec())),
+            index: *index,
+            path,
+            used: false,
+            generated_at: 0,
+            used_at: None,
+            tx_count: 0,
+            total_received: 0,
+            total_sent: 0,
+            balance: 0,
+            label: None,
+            metadata: std::collections::BTreeMap::new(),
+        });
+    }
+    // The platform-node pool is `AbsentHardened` (SLIP-10 hardened-only).
+    if let Some(pool) = account
+        .managed_account_type_mut()
+        .address_pools_mut()
+        .into_iter()
+        .find(|p| p.pool_type == AddressPoolType::AbsentHardened)
+    {
+        restore_address_pool(pool, infos);
+    }
+    Ok(())
 }
 
 /// Bucket a slice of upstream-emitted `DerivedAddress` entries into the
@@ -3205,6 +3297,13 @@ fn build_wallet_start_state(
 
     // Build the per-account collection from the typed spec array.
     let mut accounts = AccountCollection::new();
+    // The persisted platform-node (Ed25519) key batch, captured from the
+    // `ProviderPlatformKeys` spec so it can be rehydrated into the managed
+    // pool once `ManagedWalletInfo::from_wallet` has created it. SLIP-10 is
+    // hardened-only, so from_wallet can't re-derive these seedlessly on the
+    // external-signable restore — the batch is the only source. Stored as
+    // (index, pubkey); node ids are recomputed SHA256[..20] at insert.
+    let mut platform_node_batch: Vec<(u32, [u8; 32])> = Vec::new();
     let specs: &[AccountSpecFFI] = if entry.accounts.is_null() || entry.accounts_count == 0 {
         &[]
     } else {
@@ -3305,6 +3404,21 @@ fn build_wallet_start_state(
                         e
                     ))
                 })?;
+                // Capture the persisted platform-node key batch (if the host
+                // supplied it on this load) for rehydration into the managed
+                // pool below. Only the pubkeys are trusted; node ids are
+                // recomputed under the #884 convention at insert time.
+                if !spec.derived_platform_node_keys.is_null()
+                    && spec.derived_platform_node_keys_count > 0
+                {
+                    let rows = unsafe {
+                        slice::from_raw_parts(
+                            spec.derived_platform_node_keys,
+                            spec.derived_platform_node_keys_count,
+                        )
+                    };
+                    platform_node_batch = rows.iter().map(|r| (r.index, r.public_key)).collect();
+                }
                 continue;
             }
             _ => {}
@@ -3414,6 +3528,14 @@ fn build_wallet_start_state(
             restore_core_address_pools(&mut wallet_info, pool_entries, network, &entry.wallet_id)?;
         }
     }
+
+    // Rehydrate the platform-node (Ed25519) key batch into its managed pool.
+    // Unlike the ECDSA/BLS pools this can't come from `core_address_pools`
+    // (SLIP-10 is hardened-only and the 33-byte pool ABI can't carry a typed
+    // 32-byte Ed25519 key), so it flows through the dedicated batch captured
+    // from the `ProviderPlatformKeys` spec above. Without it a seedless
+    // restore has no platform-node keys to match masternode ownership.
+    restore_platform_node_pool(&mut wallet_info, &platform_node_batch, network)?;
 
     // Persisted unspent UTXOs → funds-bearing accounts. Keys-only and
     // PlatformPayment variants are skipped: the former never carry
@@ -5239,6 +5361,97 @@ mod tests {
 
         drop(addr_c);
         drop(path_c);
+    }
+
+    /// Build a minimal `AddressInfo` for merge tests. The address/script/
+    /// path content is irrelevant — `restore_address_pool`'s merge only
+    /// inspects `public_key` — so a P2PKH keyed off `index` suffices.
+    fn merge_test_address_info(index: u32, public_key: Option<PublicKeyType>) -> AddressInfo {
+        use dashcore::hashes::Hash;
+        let mut h = [0u8; 20];
+        h[0] = index as u8;
+        let payload =
+            dashcore::address::Payload::PubkeyHash(dashcore::PubkeyHash::from_byte_array(h));
+        let address = dashcore::Address::new(Network::Testnet, payload);
+        let script_pubkey = address.script_pubkey();
+        AddressInfo {
+            address,
+            script_pubkey,
+            public_key,
+            index,
+            path: DerivationPath::from(Vec::<key_wallet::bip32::ChildNumber>::new()),
+            used: false,
+            generated_at: 0,
+            used_at: None,
+            tx_count: 0,
+            total_received: 0,
+            total_sent: 0,
+            balance: 0,
+            label: None,
+            metadata: std::collections::BTreeMap::new(),
+        }
+    }
+
+    /// Blocker #1: a prederived operator entry carrying a typed BLS (48B)
+    /// public key must NOT be clobbered by a persisted row that lost its
+    /// typed key on the 33-byte-slot FFI round-trip (`public_key: None`).
+    /// Pins the merge in `restore_address_pool` so key-wallet's provider-key
+    /// matching keeps a usable typed key after restore.
+    #[test]
+    fn restore_address_pool_merge_preserves_typed_bls_operator_key() {
+        use key_wallet::managed_account::managed_account_trait::ManagedAccountTrait;
+
+        // Any managed keys account gives a real `AddressPool` to exercise
+        // the (pool-type-agnostic) merge against.
+        let mut wallet_info = test_managed_wallet_info_with_provider_owner();
+        let owner = wallet_info
+            .accounts
+            .provider_owner_keys
+            .as_mut()
+            .expect("managed provider-owner account must exist");
+        let pool = owner
+            .managed_account_type_mut()
+            .address_pools_mut()
+            .into_iter()
+            .next()
+            .expect("the account must have at least one pool");
+
+        let bls = vec![0xABu8; 48];
+        // Seed a prederived typed BLS entry at index 0.
+        restore_address_pool(
+            pool,
+            vec![merge_test_address_info(
+                0,
+                Some(PublicKeyType::BLS(bls.clone())),
+            )],
+        );
+        // A persisted row that lost its typed key (None) at the SAME index
+        // must keep the existing BLS key, not overwrite it with None.
+        restore_address_pool(pool, vec![merge_test_address_info(0, None)]);
+        match pool
+            .addresses
+            .get(&0)
+            .expect("entry at index 0")
+            .public_key
+            .as_ref()
+        {
+            Some(PublicKeyType::BLS(bytes)) => {
+                assert_eq!(bytes, &bls, "the prederived BLS key must be preserved")
+            }
+            other => panic!("expected a preserved BLS key at index 0, got {:?}", other),
+        }
+
+        // Control: a `None` row at a fresh index with no existing entry
+        // stays `None` (merge only fills from an existing typed entry).
+        restore_address_pool(pool, vec![merge_test_address_info(7, None)]);
+        assert!(
+            pool.addresses
+                .get(&7)
+                .expect("entry at index 7")
+                .public_key
+                .is_none(),
+            "a None row with no prederived entry must remain None"
+        );
     }
 
     /// `account_xpub` must survive the persist→restore byte round-trip — it is

--- a/packages/rs-platform-wallet-ffi/src/persistence.rs
+++ b/packages/rs-platform-wallet-ffi/src/persistence.rs
@@ -3226,48 +3226,102 @@ fn build_wallet_start_state(
                     continue;
                 }
             };
-            let funds = match account_type {
+            // Resolve the persisted pool's target account to its
+            // `&mut ManagedAccountType` (where the address pools live).
+            // Funds-bearing accounts (`ManagedCoreFundsAccount`) live in the
+            // keyed maps; the four masternode key-material provider accounts
+            // (`ManagedCoreKeysAccount`) live in dedicated `Option` fields.
+            // Both implement `ManagedAccountTrait`, so `managed_account_type_mut()`
+            // unifies them to a single `&mut ManagedAccountType` and the
+            // pool-population below is identical. (A single match — rather
+            // than a funds-match-then-provider-fallback — is required: the
+            // borrow checker won't let a `None` fallback re-borrow
+            // `wallet_info.accounts` after the funds `get_mut`.)
+            let managed_type = match account_type {
                 AccountType::Standard {
                     index,
                     standard_account_type: StandardAccountType::BIP44Account,
-                } => wallet_info.accounts.standard_bip44_accounts.get_mut(&index),
+                } => wallet_info
+                    .accounts
+                    .standard_bip44_accounts
+                    .get_mut(&index)
+                    .map(|a| a.managed_account_type_mut()),
                 AccountType::Standard {
                     index,
                     standard_account_type: StandardAccountType::BIP32Account,
-                } => wallet_info.accounts.standard_bip32_accounts.get_mut(&index),
-                AccountType::CoinJoin { index } => {
-                    wallet_info.accounts.coinjoin_accounts.get_mut(&index)
-                }
+                } => wallet_info
+                    .accounts
+                    .standard_bip32_accounts
+                    .get_mut(&index)
+                    .map(|a| a.managed_account_type_mut()),
+                AccountType::CoinJoin { index } => wallet_info
+                    .accounts
+                    .coinjoin_accounts
+                    .get_mut(&index)
+                    .map(|a| a.managed_account_type_mut()),
                 AccountType::DashpayReceivingFunds {
                     index,
                     user_identity_id,
                     friend_identity_id,
-                } => wallet_info.accounts.dashpay_receival_accounts.get_mut(
-                    &key_wallet::account::account_collection::DashpayAccountKey {
-                        index,
-                        user_identity_id,
-                        friend_identity_id,
-                    },
-                ),
+                } => wallet_info
+                    .accounts
+                    .dashpay_receival_accounts
+                    .get_mut(
+                        &key_wallet::account::account_collection::DashpayAccountKey {
+                            index,
+                            user_identity_id,
+                            friend_identity_id,
+                        },
+                    )
+                    .map(|a| a.managed_account_type_mut()),
                 AccountType::DashpayExternalAccount {
                     index,
                     user_identity_id,
                     friend_identity_id,
-                } => wallet_info.accounts.dashpay_external_accounts.get_mut(
-                    &key_wallet::account::account_collection::DashpayAccountKey {
-                        index,
-                        user_identity_id,
-                        friend_identity_id,
-                    },
-                ),
+                } => wallet_info
+                    .accounts
+                    .dashpay_external_accounts
+                    .get_mut(
+                        &key_wallet::account::account_collection::DashpayAccountKey {
+                            index,
+                            user_identity_id,
+                            friend_identity_id,
+                        },
+                    )
+                    .map(|a| a.managed_account_type_mut()),
+                // Masternode provider key-material accounts — dedicated
+                // `Option<ManagedCoreKeysAccount>` fields. Restoring these
+                // rehydrates the used-flags + beyond-gap indices of the
+                // owner / voting / operator / platform-node pools.
+                AccountType::ProviderOwnerKeys => wallet_info
+                    .accounts
+                    .provider_owner_keys
+                    .as_mut()
+                    .map(|a| a.managed_account_type_mut()),
+                AccountType::ProviderVotingKeys => wallet_info
+                    .accounts
+                    .provider_voting_keys
+                    .as_mut()
+                    .map(|a| a.managed_account_type_mut()),
+                AccountType::ProviderOperatorKeys => wallet_info
+                    .accounts
+                    .provider_operator_keys
+                    .as_mut()
+                    .map(|a| a.managed_account_type_mut()),
+                AccountType::ProviderPlatformKeys => wallet_info
+                    .accounts
+                    .provider_platform_keys
+                    .as_mut()
+                    .map(|a| a.managed_account_type_mut()),
                 _ => None,
             };
-            let Some(funds_account) = funds else {
+            let Some(managed_type) = managed_type else {
                 pools_dropped += 1;
                 tracing::warn!(
                     wallet_id = %hex::encode(entry.wallet_id),
                     ?account_type,
-                    "load: skipping persisted address pool with no matching funds account"
+                    "load: skipping persisted address pool with no matching funds or \
+                     provider account"
                 );
                 continue;
             };
@@ -3292,7 +3346,7 @@ fn build_wallet_start_state(
                     }
                 }
             }
-            let mut managed_pools = funds_account.managed_account_type_mut().address_pools_mut();
+            let mut managed_pools = managed_type.address_pools_mut();
             match managed_pools.iter_mut().find(|p| p.pool_type == pool_type) {
                 Some(pool) => {
                     pools_routed += infos.len();

--- a/packages/rs-platform-wallet-ffi/src/persistence.rs
+++ b/packages/rs-platform-wallet-ffi/src/persistence.rs
@@ -5001,7 +5001,14 @@ fn restore_provider_special_txs(
                         e
                     ))
                 })?;
-                let info = BlockInfo::new(rec.block_height, block_hash, rec.block_timestamp as u32);
+                let mut info =
+                    BlockInfo::new(rec.block_height, block_hash, rec.block_timestamp as u32);
+                // Restore the in-block position (rust-dashcore#891) so the
+                // masternode aggregation keeps Core's same-block apply order
+                // across restarts. Absent on pre-field rows.
+                if rec.has_block_position {
+                    info = info.with_position(rec.block_position);
+                }
                 if ctx == 2 {
                     TransactionContext::InBlock(info)
                 } else {
@@ -5361,6 +5368,79 @@ mod tests {
 
         drop(addr_c);
         drop(path_c);
+    }
+
+    /// A staged provider special tx must round-trip its persisted in-block
+    /// position (rust-dashcore#891) onto the rebuilt record's `BlockInfo`,
+    /// so the masternode aggregation keeps Core's same-block apply order
+    /// across restarts — and a pre-field row (`has_block_position: false`)
+    /// must restore with `position() == None`.
+    #[test]
+    fn provider_special_tx_restore_round_trips_block_position() {
+        use dashcore::blockdata::transaction::special_transaction::provider_update_service::ProviderUpdateServicePayload;
+        use dashcore::hashes::Hash;
+        use dashcore::transaction::TransactionPayload;
+
+        let payload = ProviderUpdateServicePayload {
+            version: 1,
+            mn_type: None,
+            pro_tx_hash: dashcore::Txid::from_byte_array([7u8; 32]),
+            ip_address: 42,
+            port: 19999,
+            script_payout: ScriptBuf::new(),
+            inputs_hash: [3u8; 32].into(),
+            platform_node_id: None,
+            platform_p2p_port: None,
+            platform_http_port: None,
+            payload_sig: [0u8; 96].into(),
+        };
+        let tx = Transaction {
+            version: 3,
+            lock_time: 0,
+            input: vec![],
+            output: vec![],
+            special_transaction_payload: Some(
+                TransactionPayload::ProviderUpdateServicePayloadType(payload),
+            ),
+        };
+        let mut tx_bytes = serialize(&tx);
+
+        for (has_position, expected) in [(true, Some(5u32)), (false, None)] {
+            let entry = ProviderSpecialTxRestoreEntryFFI {
+                tx_bytes: tx_bytes.as_mut_ptr(),
+                tx_bytes_len: tx_bytes.len(),
+                context_raw: 2,
+                block_height: 900,
+                block_hash: [9u8; 32],
+                block_timestamp: 1_700_000_000,
+                block_position: 5,
+                has_block_position: has_position,
+                first_seen: 0,
+            };
+
+            let mut wallet_info = test_managed_wallet_info_with_provider_owner();
+            let stats = restore_provider_special_txs(&mut wallet_info, &[entry])
+                .expect("staged provider tx must restore");
+            assert_eq!(
+                stats.restored, 1,
+                "the record must land on a provider account"
+            );
+
+            let record = wallet_info
+                .accounts
+                .provider_owner_keys
+                .as_ref()
+                .expect("provider-owner account must exist")
+                .transactions()
+                .get(&tx.txid())
+                .expect("restored record must be resident");
+            assert_eq!(
+                record.context.block_info().and_then(|b| b.position()),
+                expected,
+                "restored BlockInfo position must mirror the persisted row \
+                 (has_block_position = {has_position})"
+            );
+        }
     }
 
     /// Build a minimal `AddressInfo` for merge tests. The address/script/

--- a/packages/rs-platform-wallet-ffi/src/persistence.rs
+++ b/packages/rs-platform-wallet-ffi/src/persistence.rs
@@ -2437,35 +2437,6 @@ fn build_account_spec_ffi(account_type: &AccountType, xpub_bytes: &[u8]) -> Acco
     spec
 }
 
-/// Magic prefix stamped onto a persisted **provider key-material**
-/// account's extended-public-key blob (`account_xpub_bytes`) by the
-/// current derivation scheme (rust-dashcore #879: BLS operator /
-/// Ed25519 platform-node keys derived from the raw BIP39 seed).
-///
-/// The restore path requires this prefix on the two provider accounts:
-/// a blob WITHOUT it was written by the pre-#879 secp256k1-hybrid scheme
-/// and is stale. Because an external-signable wallet keeps no seed, the
-/// stale point can't be recomputed at load, so such an account is
-/// skipped (never reinstalled) — the wallet comes back with no provider
-/// key-material accounts instead of ones that display / match the wrong
-/// operator + platform-node keys, and a re-import repopulates them under
-/// the current scheme. The 4th byte is a scheme version, bumpable if the
-/// derivation ever changes again.
-///
-/// This cannot collide with a bare `bincode(ExtendedBLSPubKey)` /
-/// `bincode(ExtendedEd25519PubKey)` payload: those begin with a small
-/// `Network` discriminant byte, never `0x50` (`'P'`). Only the two
-/// provider accounts carry it — ECDSA `account_xpub` blobs stay raw.
-const PROVIDER_KEY_SCHEME_MAGIC: [u8; 4] = *b"PKV\x01";
-
-/// Strip [`PROVIDER_KEY_SCHEME_MAGIC`] from a persisted provider xpub
-/// blob, returning the inner bincode bytes. `None` when the prefix is
-/// absent — i.e. a stale pre-#879 provider account that must be skipped
-/// on restore.
-fn strip_provider_scheme_magic(bytes: &[u8]) -> Option<&[u8]> {
-    bytes.strip_prefix(&PROVIDER_KEY_SCHEME_MAGIC[..])
-}
-
 /// Build the `Vec<AccountSpecFFI>` array for
 /// `on_persist_account_registrations_fn` plus the parallel storage each
 /// spec borrows into:
@@ -2478,16 +2449,6 @@ fn strip_provider_scheme_magic(bytes: &[u8]) -> Option<&[u8]> {
 ///
 /// All three share lifetime — the caller must keep them alive until
 /// after the callback returns.
-///
-/// # Provider-key derivation-scheme versioning
-///
-/// The two provider key-material accounts' extended-public-key blobs are
-/// stamped with [`PROVIDER_KEY_SCHEME_MAGIC`] so the restore path can
-/// tell a current-scheme (rust-dashcore #879, raw-seed) account apart
-/// from a stale pre-#879 (secp256k1-hybrid) one — the point can't be
-/// recomputed at load (external-signable wallets keep no seed), so a
-/// magic-less provider account is skipped rather than reinstalled with a
-/// wrong key. See [`PROVIDER_KEY_SCHEME_MAGIC`] and the load path.
 #[allow(clippy::type_complexity)]
 fn build_account_specs_for_callback(
     entries: &[AccountRegistrationEntry],
@@ -2513,7 +2474,7 @@ fn build_account_specs_for_callback(
         xpub_buffers.push(bytes);
     }
     for entry in provider_entries {
-        let encoded = match &entry.extended_public_key {
+        let bytes = match &entry.extended_public_key {
             ProviderKeyExtendedPubKey::Bls(key) => bincode::encode_to_vec(key, config::standard())
                 .map_err(|e| format!("failed to encode provider BLS xpub: {}", e))?,
             ProviderKeyExtendedPubKey::EdDSA(key) => {
@@ -2521,11 +2482,6 @@ fn build_account_specs_for_callback(
                     .map_err(|e| format!("failed to encode provider EdDSA xpub: {}", e))?
             }
         };
-        // Stamp the current-scheme magic so the restore path can reject a
-        // stale pre-#879 provider account (see `PROVIDER_KEY_SCHEME_MAGIC`).
-        let mut bytes = Vec::with_capacity(PROVIDER_KEY_SCHEME_MAGIC.len() + encoded.len());
-        bytes.extend_from_slice(&PROVIDER_KEY_SCHEME_MAGIC);
-        bytes.extend_from_slice(&encoded);
         xpub_buffers.push(bytes);
     }
 
@@ -3082,25 +3038,17 @@ fn build_wallet_start_state(
         // via the type-specific `new` + insert methods rather than the
         // ECDSA `Account::from_xpub` / `insert` path (which would fail
         // to decode the bytes and reject the provider `AccountType`).
+        // Provider xpubs are stored raw (`bincode(xpub)`), exactly like the
+        // ECDSA accounts. The derivation scheme is NOT versioned here: this
+        // app is pre-release and the pre-#879 (secp256k1-hybrid) derivation
+        // never shipped to production. A wallet whose provider accounts were
+        // persisted by a pre-#879 dev build will restore those (stale) xpubs
+        // and show stale operator / platform-node keys until it's deleted
+        // and re-imported — an accepted, transient dev-only state.
         match account_type {
             AccountType::ProviderOperatorKeys => {
-                // Require the current derivation-scheme magic. A magic-less
-                // blob is a stale pre-#879 (secp256k1-hybrid) operator
-                // account: its point can't be recomputed here (no seed at
-                // load), so skip it rather than reinstall a wrong operator
-                // key — a re-import repopulates it. Skip-and-continue,
-                // mirroring the legacy-tag handling above.
-                let Some(inner) = strip_provider_scheme_magic(xpub_bytes) else {
-                    tracing::warn!(
-                        wallet_id = %hex::encode(entry.wallet_id),
-                        "load: skipping stale pre-#879 provider operator-keys account \
-                         (obsolete derivation scheme); re-import the wallet to repopulate \
-                         operator keys"
-                    );
-                    continue;
-                };
                 let (bls_pubkey, _): (ExtendedBLSPubKey, usize) =
-                    bincode::decode_from_slice(inner, config::standard()).map_err(|e| {
+                    bincode::decode_from_slice(xpub_bytes, config::standard()).map_err(|e| {
                         PersistenceError::backend(format!(
                             "failed to decode provider BLS xpub: {}",
                             e
@@ -3124,18 +3072,8 @@ fn build_wallet_start_state(
                 continue;
             }
             AccountType::ProviderPlatformKeys => {
-                // Same stale-scheme guard as the operator account above.
-                let Some(inner) = strip_provider_scheme_magic(xpub_bytes) else {
-                    tracing::warn!(
-                        wallet_id = %hex::encode(entry.wallet_id),
-                        "load: skipping stale pre-#879 provider platform-keys account \
-                         (obsolete derivation scheme); re-import the wallet to repopulate \
-                         platform-node keys"
-                    );
-                    continue;
-                };
                 let (ed_pubkey, _): (ExtendedEd25519PubKey, usize) =
-                    bincode::decode_from_slice(inner, config::standard()).map_err(|e| {
+                    bincode::decode_from_slice(xpub_bytes, config::standard()).map_err(|e| {
                         PersistenceError::backend(format!(
                             "failed to decode provider EdDSA xpub: {}",
                             e
@@ -5142,39 +5080,6 @@ mod tests {
             restored.account_xpub, expected_xpub,
             "the restored account's xpub must equal the original — the key verify_seed_binds binds against"
         );
-    }
-
-    /// The provider-key derivation-scheme guard (blocker #3): a
-    /// current-scheme provider blob carries [`PROVIDER_KEY_SCHEME_MAGIC`]
-    /// and strips back to its inner bincode bytes, while a bare (pre-#879)
-    /// bincode blob is rejected so the restore path skips a stale provider
-    /// account instead of reinstalling a wrong operator / platform-node key.
-    #[test]
-    fn provider_scheme_magic_strips_and_rejects_stale() {
-        // A stamped blob (as `build_account_specs_for_callback` produces)
-        // strips back to exactly the inner payload.
-        let inner: Vec<u8> = vec![0x01, 0x02, 0x03, 0xaa, 0xbb, 0xcc];
-        let mut stamped = PROVIDER_KEY_SCHEME_MAGIC.to_vec();
-        stamped.extend_from_slice(&inner);
-        assert_eq!(
-            strip_provider_scheme_magic(&stamped),
-            Some(inner.as_slice()),
-            "stamped provider blob must strip to its inner bincode bytes"
-        );
-
-        // A bare bincode payload (pre-#879 stale account) has no magic and
-        // must be rejected. A real `bincode(ExtendedBLSPubKey)` begins with
-        // a small `Network` discriminant byte — modelled here by 0x00.
-        let bare: Vec<u8> = vec![0x00, 0x01, 0x02, 0x03, 0x04];
-        assert!(
-            strip_provider_scheme_magic(&bare).is_none(),
-            "a magic-less (pre-#879) provider blob must be rejected as stale"
-        );
-
-        // The magic's leading byte is 'P' (0x50), which a bincode `Network`
-        // discriminant never is — so the prefix cannot collide with a real
-        // provider xpub payload.
-        assert_eq!(PROVIDER_KEY_SCHEME_MAGIC[0], b'P');
     }
 
     /// Helper: a minimum valid consensus-encodable transaction —

--- a/packages/rs-platform-wallet-ffi/src/persistence.rs
+++ b/packages/rs-platform-wallet-ffi/src/persistence.rs
@@ -2771,6 +2771,217 @@ fn restore_address_pool(pool: &mut AddressPool, infos: Vec<AddressInfo>) {
     }
 }
 
+/// Outcome of [`restore_core_address_pools`]: how many persisted address
+/// rows were routed into a managed pool and how many were skipped
+/// (invalid pool-type tag, no matching account/pool, or un-decodable row).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct PoolRestoreStats {
+    routed: usize,
+    dropped: usize,
+}
+
+/// Restore persisted core address pools onto the matching managed
+/// accounts. Covers the funds-bearing accounts (keyed maps) AND the four
+/// masternode key-material provider accounts (dedicated `Option` fields);
+/// both unify to `&mut ManagedAccountType` via `ManagedAccountTrait`, so
+/// the used-flags + beyond-gap indices in the snapshot rehydrate the
+/// in-memory pools. Extracted from [`build_wallet_start_state`] so the
+/// routing — including the provider arms — is unit-testable.
+///
+/// A single match (rather than a funds-match-then-provider-fallback) is
+/// required: the borrow checker won't let a `None` fallback re-borrow
+/// `wallet_info.accounts` after the funds `get_mut`.
+///
+/// # Safety
+/// Each `AccountAddressPoolFFI`'s `addresses_ptr` must point to
+/// `addresses_count` valid `CoreAddressEntryFFI` rows (Swift-owned, valid
+/// for the call), matching the load-callback contract.
+///
+/// # Errors
+/// Propagates a real (non-legacy-tag) `account_type_from_spec` decode
+/// failure — a corrupt persisted row — so it surfaces rather than
+/// silently under-restoring.
+unsafe fn restore_core_address_pools(
+    wallet_info: &mut ManagedWalletInfo,
+    pool_entries: &[AccountAddressPoolFFI],
+    network: Network,
+    wallet_id: &[u8; 32],
+) -> Result<PoolRestoreStats, PersistenceError> {
+    use key_wallet::managed_account::managed_account_trait::ManagedAccountTrait;
+    let mut pools_routed = 0usize;
+    let mut pools_dropped = 0usize;
+    for pool_ffi in pool_entries {
+        let account_type = match account_type_from_spec(&pool_ffi.account) {
+            Ok(t) => t,
+            Err(e) => {
+                if is_legacy_removed_account_tag(pool_ffi.account.type_tag) {
+                    pools_dropped += 1;
+                    continue;
+                }
+                return Err(e);
+            }
+        };
+        let pool_type = match pool_ffi.pool_type_tag {
+            0 => AddressPoolType::External,
+            1 => AddressPoolType::Internal,
+            2 => AddressPoolType::Absent,
+            3 => AddressPoolType::AbsentHardened,
+            other => {
+                pools_dropped += 1;
+                tracing::warn!(
+                    wallet_id = %hex::encode(wallet_id),
+                    pool_type_tag = other,
+                    "load: skipping persisted address pool with invalid pool_type_tag"
+                );
+                continue;
+            }
+        };
+        // Resolve the persisted pool's target account to its
+        // `&mut ManagedAccountType` (where the address pools live).
+        // Funds-bearing accounts (`ManagedCoreFundsAccount`) live in the
+        // keyed maps; the four masternode key-material provider accounts
+        // (`ManagedCoreKeysAccount`) live in dedicated `Option` fields.
+        // Both implement `ManagedAccountTrait`, so `managed_account_type_mut()`
+        // unifies them to a single `&mut ManagedAccountType` and the
+        // pool-population below is identical.
+        let managed_type = match account_type {
+            AccountType::Standard {
+                index,
+                standard_account_type: StandardAccountType::BIP44Account,
+            } => wallet_info
+                .accounts
+                .standard_bip44_accounts
+                .get_mut(&index)
+                .map(|a| a.managed_account_type_mut()),
+            AccountType::Standard {
+                index,
+                standard_account_type: StandardAccountType::BIP32Account,
+            } => wallet_info
+                .accounts
+                .standard_bip32_accounts
+                .get_mut(&index)
+                .map(|a| a.managed_account_type_mut()),
+            AccountType::CoinJoin { index } => wallet_info
+                .accounts
+                .coinjoin_accounts
+                .get_mut(&index)
+                .map(|a| a.managed_account_type_mut()),
+            AccountType::DashpayReceivingFunds {
+                index,
+                user_identity_id,
+                friend_identity_id,
+            } => wallet_info
+                .accounts
+                .dashpay_receival_accounts
+                .get_mut(
+                    &key_wallet::account::account_collection::DashpayAccountKey {
+                        index,
+                        user_identity_id,
+                        friend_identity_id,
+                    },
+                )
+                .map(|a| a.managed_account_type_mut()),
+            AccountType::DashpayExternalAccount {
+                index,
+                user_identity_id,
+                friend_identity_id,
+            } => wallet_info
+                .accounts
+                .dashpay_external_accounts
+                .get_mut(
+                    &key_wallet::account::account_collection::DashpayAccountKey {
+                        index,
+                        user_identity_id,
+                        friend_identity_id,
+                    },
+                )
+                .map(|a| a.managed_account_type_mut()),
+            // Masternode provider key-material accounts — dedicated
+            // `Option<ManagedCoreKeysAccount>` fields. Restoring these
+            // rehydrates the used-flags + beyond-gap indices of the
+            // owner / voting / operator / platform-node pools.
+            AccountType::ProviderOwnerKeys => wallet_info
+                .accounts
+                .provider_owner_keys
+                .as_mut()
+                .map(|a| a.managed_account_type_mut()),
+            AccountType::ProviderVotingKeys => wallet_info
+                .accounts
+                .provider_voting_keys
+                .as_mut()
+                .map(|a| a.managed_account_type_mut()),
+            AccountType::ProviderOperatorKeys => wallet_info
+                .accounts
+                .provider_operator_keys
+                .as_mut()
+                .map(|a| a.managed_account_type_mut()),
+            AccountType::ProviderPlatformKeys => wallet_info
+                .accounts
+                .provider_platform_keys
+                .as_mut()
+                .map(|a| a.managed_account_type_mut()),
+            _ => None,
+        };
+        let Some(managed_type) = managed_type else {
+            pools_dropped += 1;
+            tracing::warn!(
+                wallet_id = %hex::encode(wallet_id),
+                ?account_type,
+                "load: skipping persisted address pool with no matching funds or \
+                 provider account"
+            );
+            continue;
+        };
+        let rows: &[CoreAddressEntryFFI] =
+            if pool_ffi.addresses_ptr.is_null() || pool_ffi.addresses_count == 0 {
+                &[]
+            } else {
+                unsafe { slice::from_raw_parts(pool_ffi.addresses_ptr, pool_ffi.addresses_count) }
+            };
+        let mut infos: Vec<AddressInfo> = Vec::with_capacity(rows.len());
+        for row in rows {
+            match unsafe { address_info_from_ffi(row, network) } {
+                Ok(info) => infos.push(info),
+                Err(e) => {
+                    pools_dropped += 1;
+                    tracing::warn!(
+                        wallet_id = %hex::encode(wallet_id),
+                        error = %e,
+                        "load: skipping un-decodable persisted address row"
+                    );
+                }
+            }
+        }
+        let mut managed_pools = managed_type.address_pools_mut();
+        match managed_pools.iter_mut().find(|p| p.pool_type == pool_type) {
+            Some(pool) => {
+                pools_routed += infos.len();
+                restore_address_pool(pool, infos);
+            }
+            None => {
+                pools_dropped += 1;
+                tracing::warn!(
+                    wallet_id = %hex::encode(wallet_id),
+                    ?pool_type,
+                    "load: persisted address pool has no matching managed pool"
+                );
+            }
+        }
+    }
+    if pools_dropped > 0 {
+        tracing::warn!(
+            wallet_id = %hex::encode(wallet_id),
+            pools_routed,
+            pools_dropped,
+            "load: persisted address-pool restore completed with skipped rows"
+        );
+    }
+    Ok(PoolRestoreStats {
+        routed: pools_routed,
+        dropped: pools_dropped,
+    })
+}
+
 /// Bucket a slice of upstream-emitted `DerivedAddress` entries into the
 /// same `AccountAddressPoolFFI` shape `build_address_pools_for_callback`
 /// produces, so the event-driven gap-limit-extension flow can fan out
@@ -3189,7 +3400,6 @@ fn build_wallet_start_state(
     // restored wallet can hold a UTXO whose address the signer can't
     // map back to a derivation path, breaking core-to-core spends.
     {
-        use key_wallet::managed_account::managed_account_trait::ManagedAccountTrait;
         let pool_entries: &[AccountAddressPoolFFI] =
             if entry.core_address_pools.is_null() || entry.core_address_pools_count == 0 {
                 &[]
@@ -3198,177 +3408,10 @@ fn build_wallet_start_state(
                     slice::from_raw_parts(entry.core_address_pools, entry.core_address_pools_count)
                 }
             };
-        let mut pools_routed = 0usize;
-        let mut pools_dropped = 0usize;
-        for pool_ffi in pool_entries {
-            let account_type = match account_type_from_spec(&pool_ffi.account) {
-                Ok(t) => t,
-                Err(e) => {
-                    if is_legacy_removed_account_tag(pool_ffi.account.type_tag) {
-                        pools_dropped += 1;
-                        continue;
-                    }
-                    return Err(e);
-                }
-            };
-            let pool_type = match pool_ffi.pool_type_tag {
-                0 => AddressPoolType::External,
-                1 => AddressPoolType::Internal,
-                2 => AddressPoolType::Absent,
-                3 => AddressPoolType::AbsentHardened,
-                other => {
-                    pools_dropped += 1;
-                    tracing::warn!(
-                        wallet_id = %hex::encode(entry.wallet_id),
-                        pool_type_tag = other,
-                        "load: skipping persisted address pool with invalid pool_type_tag"
-                    );
-                    continue;
-                }
-            };
-            // Resolve the persisted pool's target account to its
-            // `&mut ManagedAccountType` (where the address pools live).
-            // Funds-bearing accounts (`ManagedCoreFundsAccount`) live in the
-            // keyed maps; the four masternode key-material provider accounts
-            // (`ManagedCoreKeysAccount`) live in dedicated `Option` fields.
-            // Both implement `ManagedAccountTrait`, so `managed_account_type_mut()`
-            // unifies them to a single `&mut ManagedAccountType` and the
-            // pool-population below is identical. (A single match — rather
-            // than a funds-match-then-provider-fallback — is required: the
-            // borrow checker won't let a `None` fallback re-borrow
-            // `wallet_info.accounts` after the funds `get_mut`.)
-            let managed_type = match account_type {
-                AccountType::Standard {
-                    index,
-                    standard_account_type: StandardAccountType::BIP44Account,
-                } => wallet_info
-                    .accounts
-                    .standard_bip44_accounts
-                    .get_mut(&index)
-                    .map(|a| a.managed_account_type_mut()),
-                AccountType::Standard {
-                    index,
-                    standard_account_type: StandardAccountType::BIP32Account,
-                } => wallet_info
-                    .accounts
-                    .standard_bip32_accounts
-                    .get_mut(&index)
-                    .map(|a| a.managed_account_type_mut()),
-                AccountType::CoinJoin { index } => wallet_info
-                    .accounts
-                    .coinjoin_accounts
-                    .get_mut(&index)
-                    .map(|a| a.managed_account_type_mut()),
-                AccountType::DashpayReceivingFunds {
-                    index,
-                    user_identity_id,
-                    friend_identity_id,
-                } => wallet_info
-                    .accounts
-                    .dashpay_receival_accounts
-                    .get_mut(
-                        &key_wallet::account::account_collection::DashpayAccountKey {
-                            index,
-                            user_identity_id,
-                            friend_identity_id,
-                        },
-                    )
-                    .map(|a| a.managed_account_type_mut()),
-                AccountType::DashpayExternalAccount {
-                    index,
-                    user_identity_id,
-                    friend_identity_id,
-                } => wallet_info
-                    .accounts
-                    .dashpay_external_accounts
-                    .get_mut(
-                        &key_wallet::account::account_collection::DashpayAccountKey {
-                            index,
-                            user_identity_id,
-                            friend_identity_id,
-                        },
-                    )
-                    .map(|a| a.managed_account_type_mut()),
-                // Masternode provider key-material accounts — dedicated
-                // `Option<ManagedCoreKeysAccount>` fields. Restoring these
-                // rehydrates the used-flags + beyond-gap indices of the
-                // owner / voting / operator / platform-node pools.
-                AccountType::ProviderOwnerKeys => wallet_info
-                    .accounts
-                    .provider_owner_keys
-                    .as_mut()
-                    .map(|a| a.managed_account_type_mut()),
-                AccountType::ProviderVotingKeys => wallet_info
-                    .accounts
-                    .provider_voting_keys
-                    .as_mut()
-                    .map(|a| a.managed_account_type_mut()),
-                AccountType::ProviderOperatorKeys => wallet_info
-                    .accounts
-                    .provider_operator_keys
-                    .as_mut()
-                    .map(|a| a.managed_account_type_mut()),
-                AccountType::ProviderPlatformKeys => wallet_info
-                    .accounts
-                    .provider_platform_keys
-                    .as_mut()
-                    .map(|a| a.managed_account_type_mut()),
-                _ => None,
-            };
-            let Some(managed_type) = managed_type else {
-                pools_dropped += 1;
-                tracing::warn!(
-                    wallet_id = %hex::encode(entry.wallet_id),
-                    ?account_type,
-                    "load: skipping persisted address pool with no matching funds or \
-                     provider account"
-                );
-                continue;
-            };
-            let rows: &[CoreAddressEntryFFI] = if pool_ffi.addresses_ptr.is_null()
-                || pool_ffi.addresses_count == 0
-            {
-                &[]
-            } else {
-                unsafe { slice::from_raw_parts(pool_ffi.addresses_ptr, pool_ffi.addresses_count) }
-            };
-            let mut infos: Vec<AddressInfo> = Vec::with_capacity(rows.len());
-            for row in rows {
-                match unsafe { address_info_from_ffi(row, network) } {
-                    Ok(info) => infos.push(info),
-                    Err(e) => {
-                        pools_dropped += 1;
-                        tracing::warn!(
-                            wallet_id = %hex::encode(entry.wallet_id),
-                            error = %e,
-                            "load: skipping un-decodable persisted address row"
-                        );
-                    }
-                }
-            }
-            let mut managed_pools = managed_type.address_pools_mut();
-            match managed_pools.iter_mut().find(|p| p.pool_type == pool_type) {
-                Some(pool) => {
-                    pools_routed += infos.len();
-                    restore_address_pool(pool, infos);
-                }
-                None => {
-                    pools_dropped += 1;
-                    tracing::warn!(
-                        wallet_id = %hex::encode(entry.wallet_id),
-                        ?pool_type,
-                        "load: persisted address pool has no matching managed pool"
-                    );
-                }
-            }
-        }
-        if pools_dropped > 0 {
-            tracing::warn!(
-                wallet_id = %hex::encode(entry.wallet_id),
-                pools_routed,
-                pools_dropped,
-                "load: persisted address-pool restore completed with skipped rows"
-            );
+        // SAFETY: `pool_entries` is a valid slice (checked above) and each
+        // row's `addresses_ptr` follows the load-callback contract.
+        unsafe {
+            restore_core_address_pools(&mut wallet_info, pool_entries, network, &entry.wallet_id)?;
         }
     }
 
@@ -5072,6 +5115,130 @@ mod tests {
             .expect("inserting the single account must succeed");
         let wallet = Wallet::new_external_signable(Network::Testnet, [0u8; 32], accounts);
         ManagedWalletInfo::from_wallet(&wallet, 0)
+    }
+
+    /// Same reproducible testnet xpub as `test_managed_wallet_info_with_bip44`,
+    /// wrapped as a `ProviderOwnerKeys` account so the managed collection
+    /// ends up with a `provider_owner_keys` account carrying its address
+    /// pool — the restore target the provider arms route into.
+    fn test_managed_wallet_info_with_provider_owner() -> ManagedWalletInfo {
+        let mnemonic = Mnemonic::from_phrase(
+            "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about",
+            Language::English,
+        )
+        .expect("static BIP-39 vector must parse");
+        let seed = mnemonic.to_seed("");
+        let master = ExtendedPrivKey::new_master(Network::Testnet, &seed)
+            .expect("master derivation must succeed");
+        let secp = Secp256k1::new();
+        let xpub = ExtendedPubKey::from_priv(&secp, &master);
+        let account =
+            Account::from_xpub(None, AccountType::ProviderOwnerKeys, xpub, Network::Testnet)
+                .expect("Account::from_xpub on a valid xpub must succeed");
+        let mut accounts = key_wallet::AccountCollection::new();
+        accounts
+            .insert(account)
+            .expect("inserting the provider-owner account must succeed");
+        let wallet = Wallet::new_external_signable(Network::Testnet, [0u8; 32], accounts);
+        ManagedWalletInfo::from_wallet(&wallet, 0)
+    }
+
+    /// Restore-arm coverage (PR #4120): a persisted core-address-pool row
+    /// targeting a PROVIDER account (`ProviderOwnerKeys`) must rehydrate
+    /// its used-flag + beyond-gap index into
+    /// `wallet_info.accounts.provider_owner_keys`'s pool. Pins the provider
+    /// arms so a regression back to the funds-only match — which dropped
+    /// these rows with a "no matching funds account" warn — is caught.
+    #[test]
+    fn provider_owner_address_pool_round_trips_used_and_highest_index() {
+        use key_wallet::managed_account::managed_account_trait::ManagedAccountTrait;
+        use std::ffi::CString;
+
+        let mut wallet_info = test_managed_wallet_info_with_provider_owner();
+
+        // Read the managed provider-owner pool's actual type so the staged
+        // FFI pool routes to it regardless of the pool-type convention.
+        let pool_type = {
+            let owner = wallet_info
+                .accounts
+                .provider_owner_keys
+                .as_mut()
+                .expect("managed provider-owner account must exist");
+            owner.managed_account_type_mut().address_pools_mut()[0].pool_type
+        };
+        let pool_type_tag: u8 = match pool_type {
+            AddressPoolType::External => 0,
+            AddressPoolType::Internal => 1,
+            AddressPoolType::Absent => 2,
+            AddressPoolType::AbsentHardened => 3,
+        };
+
+        // A used address at an index beyond the pre-derived gap window.
+        const RESTORED_INDEX: u32 = 50;
+        let addr_c = CString::new("yMqShkrgjTRuReBGFpQr7FozEF1QcNBBYA").unwrap();
+        let path_c = CString::new("m/9'/1'/2'/50").unwrap();
+        let row = CoreAddressEntryFFI {
+            public_key: [0u8; 33],
+            has_public_key: false,
+            pool_type_tag,
+            address_index: RESTORED_INDEX,
+            is_used: true,
+            balance: 0,
+            address_base58: addr_c.as_ptr(),
+            derivation_path: path_c.as_ptr(),
+        };
+        let no_xpub: &[u8] = &[];
+        let pool = AccountAddressPoolFFI {
+            account: build_account_spec_ffi(&AccountType::ProviderOwnerKeys, no_xpub),
+            pool_type_tag,
+            addresses_ptr: &row,
+            addresses_count: 1,
+        };
+        let pools = [pool];
+
+        // SAFETY: `row` / `addr_c` / `path_c` outlive the call below.
+        let stats = unsafe {
+            restore_core_address_pools(&mut wallet_info, &pools, Network::Testnet, &[0u8; 32])
+        }
+        .expect("restore must succeed for a well-formed provider pool");
+        assert_eq!(
+            stats,
+            PoolRestoreStats {
+                routed: 1,
+                dropped: 0
+            },
+            "the single provider-owner row must route into the managed pool, not drop"
+        );
+
+        // The used-flag + beyond-gap index must now live on the managed pool.
+        let owner = wallet_info
+            .accounts
+            .provider_owner_keys
+            .as_mut()
+            .expect("managed provider-owner account must exist");
+        let mut pools_mut = owner.managed_account_type_mut().address_pools_mut();
+        let restored = pools_mut
+            .iter_mut()
+            .find(|p| p.pool_type == pool_type)
+            .expect("the provider-owner pool must exist");
+        assert!(
+            restored.used_indices.contains(&RESTORED_INDEX),
+            "the used index must be restored into the pool"
+        );
+        assert_eq!(
+            restored.highest_used,
+            Some(RESTORED_INDEX),
+            "highest_used must reflect the restored used index"
+        );
+        assert!(
+            restored
+                .highest_generated
+                .map_or(false, |h| h >= RESTORED_INDEX),
+            "highest_generated must advance past the pre-derived gap window"
+        );
+
+        drop(addr_c);
+        drop(path_c);
     }
 
     /// `account_xpub` must survive the persist→restore byte round-trip — it is

--- a/packages/rs-platform-wallet-ffi/src/persistence.rs
+++ b/packages/rs-platform-wallet-ffi/src/persistence.rs
@@ -2437,6 +2437,35 @@ fn build_account_spec_ffi(account_type: &AccountType, xpub_bytes: &[u8]) -> Acco
     spec
 }
 
+/// Magic prefix stamped onto a persisted **provider key-material**
+/// account's extended-public-key blob (`account_xpub_bytes`) by the
+/// current derivation scheme (rust-dashcore #879: BLS operator /
+/// Ed25519 platform-node keys derived from the raw BIP39 seed).
+///
+/// The restore path requires this prefix on the two provider accounts:
+/// a blob WITHOUT it was written by the pre-#879 secp256k1-hybrid scheme
+/// and is stale. Because an external-signable wallet keeps no seed, the
+/// stale point can't be recomputed at load, so such an account is
+/// skipped (never reinstalled) — the wallet comes back with no provider
+/// key-material accounts instead of ones that display / match the wrong
+/// operator + platform-node keys, and a re-import repopulates them under
+/// the current scheme. The 4th byte is a scheme version, bumpable if the
+/// derivation ever changes again.
+///
+/// This cannot collide with a bare `bincode(ExtendedBLSPubKey)` /
+/// `bincode(ExtendedEd25519PubKey)` payload: those begin with a small
+/// `Network` discriminant byte, never `0x50` (`'P'`). Only the two
+/// provider accounts carry it — ECDSA `account_xpub` blobs stay raw.
+const PROVIDER_KEY_SCHEME_MAGIC: [u8; 4] = *b"PKV\x01";
+
+/// Strip [`PROVIDER_KEY_SCHEME_MAGIC`] from a persisted provider xpub
+/// blob, returning the inner bincode bytes. `None` when the prefix is
+/// absent — i.e. a stale pre-#879 provider account that must be skipped
+/// on restore.
+fn strip_provider_scheme_magic(bytes: &[u8]) -> Option<&[u8]> {
+    bytes.strip_prefix(&PROVIDER_KEY_SCHEME_MAGIC[..])
+}
+
 /// Build the `Vec<AccountSpecFFI>` array for
 /// `on_persist_account_registrations_fn` plus the parallel storage each
 /// spec borrows into:
@@ -2449,6 +2478,16 @@ fn build_account_spec_ffi(account_type: &AccountType, xpub_bytes: &[u8]) -> Acco
 ///
 /// All three share lifetime — the caller must keep them alive until
 /// after the callback returns.
+///
+/// # Provider-key derivation-scheme versioning
+///
+/// The two provider key-material accounts' extended-public-key blobs are
+/// stamped with [`PROVIDER_KEY_SCHEME_MAGIC`] so the restore path can
+/// tell a current-scheme (rust-dashcore #879, raw-seed) account apart
+/// from a stale pre-#879 (secp256k1-hybrid) one — the point can't be
+/// recomputed at load (external-signable wallets keep no seed), so a
+/// magic-less provider account is skipped rather than reinstalled with a
+/// wrong key. See [`PROVIDER_KEY_SCHEME_MAGIC`] and the load path.
 #[allow(clippy::type_complexity)]
 fn build_account_specs_for_callback(
     entries: &[AccountRegistrationEntry],
@@ -2474,7 +2513,7 @@ fn build_account_specs_for_callback(
         xpub_buffers.push(bytes);
     }
     for entry in provider_entries {
-        let bytes = match &entry.extended_public_key {
+        let encoded = match &entry.extended_public_key {
             ProviderKeyExtendedPubKey::Bls(key) => bincode::encode_to_vec(key, config::standard())
                 .map_err(|e| format!("failed to encode provider BLS xpub: {}", e))?,
             ProviderKeyExtendedPubKey::EdDSA(key) => {
@@ -2482,6 +2521,11 @@ fn build_account_specs_for_callback(
                     .map_err(|e| format!("failed to encode provider EdDSA xpub: {}", e))?
             }
         };
+        // Stamp the current-scheme magic so the restore path can reject a
+        // stale pre-#879 provider account (see `PROVIDER_KEY_SCHEME_MAGIC`).
+        let mut bytes = Vec::with_capacity(PROVIDER_KEY_SCHEME_MAGIC.len() + encoded.len());
+        bytes.extend_from_slice(&PROVIDER_KEY_SCHEME_MAGIC);
+        bytes.extend_from_slice(&encoded);
         xpub_buffers.push(bytes);
     }
 
@@ -3040,8 +3084,23 @@ fn build_wallet_start_state(
         // to decode the bytes and reject the provider `AccountType`).
         match account_type {
             AccountType::ProviderOperatorKeys => {
+                // Require the current derivation-scheme magic. A magic-less
+                // blob is a stale pre-#879 (secp256k1-hybrid) operator
+                // account: its point can't be recomputed here (no seed at
+                // load), so skip it rather than reinstall a wrong operator
+                // key — a re-import repopulates it. Skip-and-continue,
+                // mirroring the legacy-tag handling above.
+                let Some(inner) = strip_provider_scheme_magic(xpub_bytes) else {
+                    tracing::warn!(
+                        wallet_id = %hex::encode(entry.wallet_id),
+                        "load: skipping stale pre-#879 provider operator-keys account \
+                         (obsolete derivation scheme); re-import the wallet to repopulate \
+                         operator keys"
+                    );
+                    continue;
+                };
                 let (bls_pubkey, _): (ExtendedBLSPubKey, usize) =
-                    bincode::decode_from_slice(xpub_bytes, config::standard()).map_err(|e| {
+                    bincode::decode_from_slice(inner, config::standard()).map_err(|e| {
                         PersistenceError::backend(format!(
                             "failed to decode provider BLS xpub: {}",
                             e
@@ -3065,8 +3124,18 @@ fn build_wallet_start_state(
                 continue;
             }
             AccountType::ProviderPlatformKeys => {
+                // Same stale-scheme guard as the operator account above.
+                let Some(inner) = strip_provider_scheme_magic(xpub_bytes) else {
+                    tracing::warn!(
+                        wallet_id = %hex::encode(entry.wallet_id),
+                        "load: skipping stale pre-#879 provider platform-keys account \
+                         (obsolete derivation scheme); re-import the wallet to repopulate \
+                         platform-node keys"
+                    );
+                    continue;
+                };
                 let (ed_pubkey, _): (ExtendedEd25519PubKey, usize) =
-                    bincode::decode_from_slice(xpub_bytes, config::standard()).map_err(|e| {
+                    bincode::decode_from_slice(inner, config::standard()).map_err(|e| {
                         PersistenceError::backend(format!(
                             "failed to decode provider EdDSA xpub: {}",
                             e
@@ -5073,6 +5142,39 @@ mod tests {
             restored.account_xpub, expected_xpub,
             "the restored account's xpub must equal the original — the key verify_seed_binds binds against"
         );
+    }
+
+    /// The provider-key derivation-scheme guard (blocker #3): a
+    /// current-scheme provider blob carries [`PROVIDER_KEY_SCHEME_MAGIC`]
+    /// and strips back to its inner bincode bytes, while a bare (pre-#879)
+    /// bincode blob is rejected so the restore path skips a stale provider
+    /// account instead of reinstalling a wrong operator / platform-node key.
+    #[test]
+    fn provider_scheme_magic_strips_and_rejects_stale() {
+        // A stamped blob (as `build_account_specs_for_callback` produces)
+        // strips back to exactly the inner payload.
+        let inner: Vec<u8> = vec![0x01, 0x02, 0x03, 0xaa, 0xbb, 0xcc];
+        let mut stamped = PROVIDER_KEY_SCHEME_MAGIC.to_vec();
+        stamped.extend_from_slice(&inner);
+        assert_eq!(
+            strip_provider_scheme_magic(&stamped),
+            Some(inner.as_slice()),
+            "stamped provider blob must strip to its inner bincode bytes"
+        );
+
+        // A bare bincode payload (pre-#879 stale account) has no magic and
+        // must be rejected. A real `bincode(ExtendedBLSPubKey)` begins with
+        // a small `Network` discriminant byte — modelled here by 0x00.
+        let bare: Vec<u8> = vec![0x00, 0x01, 0x02, 0x03, 0x04];
+        assert!(
+            strip_provider_scheme_magic(&bare).is_none(),
+            "a magic-less (pre-#879) provider blob must be rejected as stale"
+        );
+
+        // The magic's leading byte is 'P' (0x50), which a bincode `Network`
+        // discriminant never is — so the prefix cannot collide with a real
+        // provider xpub payload.
+        assert_eq!(PROVIDER_KEY_SCHEME_MAGIC[0], b'P');
     }
 
     /// Helper: a minimum valid consensus-encodable transaction —

--- a/packages/rs-platform-wallet-ffi/src/provider_key_at_index.rs
+++ b/packages/rs-platform-wallet-ffi/src/provider_key_at_index.rs
@@ -34,14 +34,12 @@
 use std::ffi::CString;
 use std::os::raw::c_char;
 
-use key_wallet::bip32::ExtendedPrivKey;
 use platform_wallet::{ProviderDerivedKey, ProviderKeyKind};
 use zeroize::{Zeroize, Zeroizing};
 
 use crate::error::*;
 use crate::handle::*;
-use crate::identity_keys_from_mnemonic::resolve_master_from_resolver;
-use crate::types::Network;
+use crate::identity_keys_from_mnemonic::resolve_seed_from_resolver;
 use crate::{check_ptr, unwrap_option_or_return, unwrap_result_or_return};
 use rs_sdk_ffi::MnemonicResolverHandle;
 
@@ -160,8 +158,6 @@ pub unsafe extern "C" fn platform_wallet_provider_key_at_index(
     let option = PLATFORM_WALLET_STORAGE.with_item(
         wallet_handle,
         |wallet| -> Result<ProviderDerivedKey, PlatformWalletFFIResult> {
-            let network: Network = wallet.network();
-
             // Phase 1 — capability probe under a SHORT read guard,
             // dropped before any resolver interaction. Only relevant when
             // a seed is required at all.
@@ -184,11 +180,13 @@ pub unsafe extern "C" fn platform_wallet_provider_key_at_index(
                 true
             };
 
-            // Phase 2 — resolve the master xpriv for external-signable /
+            // Phase 2 — resolve the raw BIP39 seed for external-signable /
             // watch-only wallets that need a seed. NEVER under the guard
             // above: the resolver synchronously re-enters Swift and reads
-            // the iOS Keychain (which can stall on biometric unlock).
-            let mut master_opt: Option<ExtendedPrivKey> = None;
+            // the iOS Keychain (which can stall on biometric unlock). The
+            // raw seed (not a secp256k1 master) is what the BLS/Ed25519
+            // provider derivation consumes (rust-dashcore #879).
+            let mut seed_opt: Option<Zeroizing<[u8; 64]>> = None;
             if need_seed && !is_resident {
                 if mnemonic_resolver_handle.is_null() {
                     return Err(PlatformWalletFFIResult::err(
@@ -202,27 +200,22 @@ pub unsafe extern "C" fn platform_wallet_provider_key_at_index(
                 // SAFETY: handle is non-null (checked) and the caller's
                 // safety contract guarantees it came from
                 // `dash_sdk_mnemonic_resolver_create`.
-                master_opt = Some(unsafe {
-                    resolve_master_from_resolver(mnemonic_resolver_handle, &wallet_id, network)?
+                seed_opt = Some(unsafe {
+                    resolve_seed_from_resolver(mnemonic_resolver_handle, &wallet_id)?
                 });
             }
 
             // Phase 3 — library derive (re-acquires the guard internally;
-            // the resolver, if any, has already run).
-            let result = wallet.derive_provider_key_at_index(
-                kind,
-                index,
-                master_opt.as_ref(),
-                include_private,
-            );
-
-            // Wipe the resolved master's inner scalar — `ExtendedPrivKey`
-            // has no `Drop` / `Zeroize`. No-op on the seedless path.
-            if let Some(mut master) = master_opt {
-                master.private_key.non_secure_erase();
-            }
-
-            result.map_err(PlatformWalletFFIResult::from)
+            // the resolver, if any, has already run). `seed_opt` (Zeroizing)
+            // scrubs the raw seed on drop — no manual wipe needed.
+            wallet
+                .derive_provider_key_at_index(
+                    kind,
+                    index,
+                    seed_opt.as_deref().map(|s| &s[..]),
+                    include_private,
+                )
+                .map_err(PlatformWalletFFIResult::from)
         },
     );
     let result = unwrap_option_or_return!(option);

--- a/packages/rs-platform-wallet-ffi/src/provider_key_at_index.rs
+++ b/packages/rs-platform-wallet-ffi/src/provider_key_at_index.rs
@@ -63,10 +63,16 @@ pub const PROVIDER_KEY_KIND_PLATFORM_NODE: u8 = 11;
 pub struct ProviderKeyAtIndexFFI {
     /// The key index that was derived (`#0..`).
     pub index: u32,
-    /// Null-terminated lowercase hex of the raw curve public key — 96
-    /// hex chars for a BLS-48 operator key, 64 for an Ed25519-32
-    /// platform-node key. Null on the pre-cleared / freed state.
+    /// Null-terminated lowercase hex of the raw curve public key in the
+    /// MODERN (IETF) serialization — 96 hex chars for a BLS-48 operator
+    /// key, 64 for an Ed25519-32 platform-node key. Null on the
+    /// pre-cleared / freed state.
     pub public_key_hex: *mut c_char,
+    /// Null-terminated lowercase hex of the SAME BLS G1 point in the Dash
+    /// LEGACY serialization (96 chars). Non-null only for operator (BLS)
+    /// keys; null for Ed25519 platform-node keys (no legacy variant) and
+    /// on the empty state.
+    pub legacy_public_key_hex: *mut c_char,
     /// Null-terminated lowercase hex of the 20-byte platform node id
     /// (40 chars) — `hash160` of the Ed25519 public key. Null for
     /// operator keys (no node id) and on the empty state.
@@ -85,6 +91,7 @@ impl ProviderKeyAtIndexFFI {
         Self {
             index: 0,
             public_key_hex: std::ptr::null_mut(),
+            legacy_public_key_hex: std::ptr::null_mut(),
             node_id_hex: std::ptr::null_mut(),
             private_key_hex: std::ptr::null_mut(),
         }
@@ -228,11 +235,18 @@ pub unsafe extern "C" fn platform_wallet_provider_key_at_index(
     let ProviderDerivedKey {
         index,
         public_key_bytes,
+        legacy_public_key_bytes,
         node_id,
         private_key,
     } = derived;
 
     let public_key_hex = unwrap_result_or_return!(CString::new(hex::encode(public_key_bytes)));
+    // Legacy BLS form (operator keys only; `None` for Ed25519). Public
+    // material, so a plain `CString::new` is fine.
+    let legacy_public_key_hex = match legacy_public_key_bytes {
+        Some(bytes) => unwrap_result_or_return!(CString::new(hex::encode(bytes))).into_raw(),
+        None => std::ptr::null_mut(),
+    };
     let node_id_hex = match node_id {
         Some(id) => unwrap_result_or_return!(CString::new(hex::encode(id))).into_raw(),
         None => std::ptr::null_mut(),
@@ -252,6 +266,7 @@ pub unsafe extern "C" fn platform_wallet_provider_key_at_index(
         *out = ProviderKeyAtIndexFFI {
             index,
             public_key_hex: public_key_hex.into_raw(),
+            legacy_public_key_hex,
             node_id_hex,
             private_key_hex,
         };
@@ -280,6 +295,10 @@ pub unsafe extern "C" fn platform_wallet_provider_key_at_index_free(
     if !out.public_key_hex.is_null() {
         let _ = unsafe { CString::from_raw(out.public_key_hex) };
         out.public_key_hex = std::ptr::null_mut();
+    }
+    if !out.legacy_public_key_hex.is_null() {
+        let _ = unsafe { CString::from_raw(out.legacy_public_key_hex) };
+        out.legacy_public_key_hex = std::ptr::null_mut();
     }
     if !out.node_id_hex.is_null() {
         let _ = unsafe { CString::from_raw(out.node_id_hex) };

--- a/packages/rs-platform-wallet-ffi/src/wallet.rs
+++ b/packages/rs-platform-wallet-ffi/src/wallet.rs
@@ -220,6 +220,11 @@ pub unsafe extern "C" fn platform_wallet_manager_list_masternodes(
     check_ptr!(wallet_id);
     check_ptr!(out_entries);
     check_ptr!(out_count);
+    // Initialise outputs immediately so the invalid-handle / unknown-wallet
+    // early returns below leave the caller looking at valid empty state
+    // rather than uninitialised / stale pointers.
+    *out_entries = std::ptr::null();
+    *out_count = 0;
 
     let wid: [u8; 32] = std::ptr::read(wallet_id as *const [u8; 32]);
 

--- a/packages/rs-platform-wallet-ffi/src/wallet.rs
+++ b/packages/rs-platform-wallet-ffi/src/wallet.rs
@@ -250,7 +250,7 @@ pub unsafe extern "C" fn platform_wallet_manager_list_masternodes(
     };
 
     let aggregates = crate::core_wallet_types::aggregate_masternodes(
-        txs.iter().map(|(h, tx)| (*h, tx)),
+        txs.iter().map(|(h, p, tx)| (*h, *p, tx)),
         membership,
     );
 

--- a/packages/rs-platform-wallet-ffi/src/wallet_restore_types.rs
+++ b/packages/rs-platform-wallet-ffi/src/wallet_restore_types.rs
@@ -184,8 +184,13 @@ pub struct AccountSpecFFI {
     /// accounts. For the two provider key-material accounts the bytes
     /// are instead a bincode-encoded extended BLS
     /// (`ProviderOperatorKeys`) or Ed25519 (`ProviderPlatformKeys`)
-    /// public key — the `type_tag` selects the decode. Valid for
-    /// callback duration only; Swift owns the allocation.
+    /// public key, **prefixed with a 4-byte derivation-scheme magic**
+    /// (`crate::persistence::PROVIDER_KEY_SCHEME_MAGIC`) so the restore
+    /// path can reject a stale pre-#879 provider account; the `type_tag`
+    /// selects the decode. Swift treats this whole slot as an opaque blob
+    /// (store on persist, hand back verbatim on restore) — the prefix is
+    /// transparent to the host. Valid for callback duration only; Swift
+    /// owns the allocation.
     pub account_xpub_bytes: *const u8,
     pub account_xpub_bytes_len: usize,
     /// Pre-derived platform-node (Ed25519) public keys — only populated

--- a/packages/rs-platform-wallet-ffi/src/wallet_restore_types.rs
+++ b/packages/rs-platform-wallet-ffi/src/wallet_restore_types.rs
@@ -125,7 +125,7 @@ impl StandardAccountTypeTagFFI {
 /// its platform-node pool without the seed — the batch is pre-derived
 /// at registration (while the seed is in hand) and surfaced here so
 /// the host can persist + display it with no keychain prompt. Plain
-/// POD (no pointers): the `hash160` node id is precomputed on the Rust
+/// POD (no pointers): the Tenderdash node id (SHA256[..20], #884) is precomputed on the Rust
 /// side so the host needs no RIPEMD-160 of its own. The private scalar
 /// is never carried — a per-index reveal still routes through
 /// `platform_wallet_provider_key_at_index` with the resolver.
@@ -136,7 +136,7 @@ pub struct ProviderPlatformNodeKeyFFI {
     pub index: u32,
     /// Raw 32-byte Ed25519 public key at this index.
     pub public_key: [u8; 32],
-    /// 20-byte platform node id — `hash160` of the Ed25519 public key
+    /// 20-byte platform node id — `SHA256(ed25519 pubkey)[..20]` (#884)
     /// (the ProRegTx `platform_node_id`).
     pub node_id: [u8; 20],
 }

--- a/packages/rs-platform-wallet-ffi/src/wallet_restore_types.rs
+++ b/packages/rs-platform-wallet-ffi/src/wallet_restore_types.rs
@@ -583,6 +583,13 @@ pub struct ProviderSpecialTxRestoreEntryFFI {
     pub block_hash: [u8; 32],
     /// Block timestamp (Unix seconds; same meaningfulness rule).
     pub block_timestamp: u64,
+    /// The transaction's index within its block (`block.vtx` order),
+    /// meaningful only when `has_block_position`. Restored onto the
+    /// rebuilt record's `BlockInfo` so the masternode aggregation keeps
+    /// Core's same-block apply order across restarts (rust-dashcore#891).
+    /// `false` for rows persisted before the field existed.
+    pub block_position: u32,
+    pub has_block_position: bool,
     /// Persisted "first seen" Unix-second timestamp (mirrors on-disk).
     pub first_seen: u64,
 }

--- a/packages/rs-platform-wallet-ffi/src/wallet_restore_types.rs
+++ b/packages/rs-platform-wallet-ffi/src/wallet_restore_types.rs
@@ -184,13 +184,8 @@ pub struct AccountSpecFFI {
     /// accounts. For the two provider key-material accounts the bytes
     /// are instead a bincode-encoded extended BLS
     /// (`ProviderOperatorKeys`) or Ed25519 (`ProviderPlatformKeys`)
-    /// public key, **prefixed with a 4-byte derivation-scheme magic**
-    /// (`crate::persistence::PROVIDER_KEY_SCHEME_MAGIC`) so the restore
-    /// path can reject a stale pre-#879 provider account; the `type_tag`
-    /// selects the decode. Swift treats this whole slot as an opaque blob
-    /// (store on persist, hand back verbatim on restore) — the prefix is
-    /// transparent to the host. Valid for callback duration only; Swift
-    /// owns the allocation.
+    /// public key — the `type_tag` selects the decode. Valid for
+    /// callback duration only; Swift owns the allocation.
     pub account_xpub_bytes: *const u8,
     pub account_xpub_bytes_len: usize,
     /// Pre-derived platform-node (Ed25519) public keys — only populated

--- a/packages/rs-platform-wallet/src/changeset/changeset.rs
+++ b/packages/rs-platform-wallet/src/changeset/changeset.rs
@@ -1102,7 +1102,8 @@ pub struct ProviderPlatformNodePubKey {
     pub index: u32,
     /// Raw 32-byte Ed25519 public key at this index.
     pub public_key: [u8; 32],
-    /// The 20-byte platform node id — `hash160` of the Ed25519 public
+    /// The 20-byte platform node id — `SHA256(ed25519 pubkey)[..20]`
+    /// (Tenderdash convention, rust-dashcore #884) of the Ed25519 public
     /// key, exactly what a ProRegTx `platform_node_id` field carries.
     /// Precomputed on the Rust side so the host renders it without a
     /// RIPEMD-160 implementation of its own.

--- a/packages/rs-platform-wallet/src/manager/accessors.rs
+++ b/packages/rs-platform-wallet/src/manager/accessors.rs
@@ -23,7 +23,8 @@ use crate::wallet::PlatformWallet;
 /// Result of [`PlatformWalletManager::provider_masternode_txs_blocking`]:
 /// the wallet's network (for base58 address encoding on the FFI side),
 /// its retained provider special transactions with their confirmation
-/// heights, a DML snapshot (`proTxHash -> is_valid`, `None` when the
+/// height and in-block position (for same-block ordering), a DML snapshot
+/// (`proTxHash -> is_valid`, `None` when the
 /// deterministic masternode list isn't available yet), and two
 /// derive-and-compare ownership maps for the key kinds that live ONLY in
 /// payloads (never as on-chain addresses):
@@ -40,7 +41,12 @@ use crate::wallet::PlatformWallet;
 /// yields an empty map, a documented follow-up).
 pub type ProviderMasternodeTxs = (
     dashcore::Network,
-    Vec<(u32, dashcore::Transaction)>,
+    // Each tuple is `(block_height, in_block_position, tx)`. The position
+    // orders same-block provider updates for the aggregation's latest-wins
+    // (Core applies them in `block.vtx` order). Upstream retained records
+    // carry no in-block index yet (rust-dashcore#890), so `position` is
+    // currently always 0 (see the note where these are built).
+    Vec<(u32, u32, dashcore::Transaction)>,
     Option<std::collections::HashMap<[u8; 32], bool>>,
     std::collections::HashMap<[u8; 48], u32>,
     std::collections::HashMap<[u8; 20], u32>,
@@ -852,7 +858,7 @@ impl<P: PlatformWalletPersistence + 'static> PlatformWalletManager<P> {
 
             let mut by_txid: std::collections::BTreeMap<
                 dashcore::Txid,
-                (u32, dashcore::Transaction),
+                (u32, u32, dashcore::Transaction),
             > = std::collections::BTreeMap::new();
 
             for account in info.core_wallet.accounts.all_accounts().iter() {
@@ -861,9 +867,20 @@ impl<P: PlatformWalletPersistence + 'static> PlatformWalletManager<P> {
                         continue;
                     }
                     let height = record.context.block_info().map(|b| b.height()).unwrap_or(0);
+                    // In-block position for same-height tie-breaking in the
+                    // aggregation (Core resolves same-block provider updates in
+                    // `block.vtx` order). The retained `TransactionContext` /
+                    // `BlockInfo` expose only height/hash/timestamp — NO in-block
+                    // index — and `account.transactions()` is a `BTreeMap<Txid>`
+                    // (txid-ordered, not processing order), so no real position is
+                    // recoverable here. Pass 0 for now; a correct fix needs an
+                    // upstream in-block tx index on `BlockInfo`, set during block
+                    // processing (rust-dashcore#890). Until then two same-block
+                    // updates to one field fall back to feed order.
+                    let position = 0u32;
                     by_txid
                         .entry(record.txid)
-                        .or_insert_with(|| (height, record.transaction.clone()));
+                        .or_insert_with(|| (height, position, record.transaction.clone()));
                 }
             }
 

--- a/packages/rs-platform-wallet/src/manager/accessors.rs
+++ b/packages/rs-platform-wallet/src/manager/accessors.rs
@@ -895,8 +895,24 @@ impl<P: PlatformWalletPersistence + 'static> PlatformWalletManager<P> {
                     false,
                 ) {
                     Ok(key) => {
+                        // Index BOTH serializations under the same index.
+                        // `aggregate_masternodes` preserves the exact
+                        // on-chain payload bytes, and a v1 ProRegTx carries
+                        // the operator key in LEGACY serialization while a
+                        // v2 ProRegTx carries MODERN — so matching only the
+                        // modern form would miss every wallet-owned v1
+                        // masternode. The two forms are distinct byte
+                        // strings for the same G1 point, so inserting both
+                        // can't collide.
                         if let Ok(bytes) = <[u8; 48]>::try_from(key.public_key_bytes.as_slice()) {
                             operator_index.insert(bytes, index);
+                        }
+                        if let Some(legacy) = key
+                            .legacy_public_key_bytes
+                            .as_deref()
+                            .and_then(|b| <[u8; 48]>::try_from(b).ok())
+                        {
+                            operator_index.insert(legacy, index);
                         }
                     }
                     // First failure ⇒ no operator account (or unavailable) ⇒ stop.

--- a/packages/rs-platform-wallet/src/manager/accessors.rs
+++ b/packages/rs-platform-wallet/src/manager/accessors.rs
@@ -29,7 +29,7 @@ use crate::wallet::PlatformWallet;
 /// payloads (never as on-chain addresses):
 ///
 ///   * operator BLS public key (48 bytes) ⇒ derivation index, and
-///   * platform node id (hash160, 20 bytes) ⇒ derivation index.
+///   * platform node id (SHA256[..20] Tenderdash, 20 bytes) ⇒ derivation index.
 ///
 /// Owner / voting keys ARE on-chain addresses, so their ownership is
 /// resolved app-side against the persisted `PersistentCoreAddress` rows;
@@ -836,10 +836,16 @@ impl<P: PlatformWalletPersistence + 'static> PlatformWalletManager<P> {
         &self,
         wallet_id: &WalletId,
     ) -> Option<ProviderMasternodeTxs> {
+        use key_wallet::managed_account::address_pool::PublicKeyType;
+        use key_wallet::managed_account::managed_account_trait::ManagedAccountTrait;
+        // Default provider-key pre-derivation / scan window.
+        const PROVIDER_KEY_WINDOW: u32 = 20;
+
         // Scope the wallet-manager read lock so it's released before we
         // acquire the SPV client / engine locks for the DML snapshot — the
-        // two never nest.
-        let (network, txs) = {
+        // two never nest. Inside this scope we also read the managed
+        // provider pools (`info.core_wallet` is a `ManagedWalletInfo`).
+        let (network, txs, operator_scan_max, platform_index) = {
             let wm = self.wallet_manager.blocking_read();
             let info = wm.get_wallet_info(wallet_id)?;
             let network = info.core_wallet.network();
@@ -861,23 +867,69 @@ impl<P: PlatformWalletPersistence + 'static> PlatformWalletManager<P> {
                 }
             }
 
-            (network, by_txid.into_values().collect::<Vec<_>>())
+            // How far the operator (BLS) pool extends — its
+            // `highest_generated` watermark, which #882 gap-extension and
+            // the pool restore can push past the default window — so the
+            // seedless derive-and-compare scan below covers beyond-window
+            // keys, not a hardcoded 20. Floored at the default window.
+            let operator_scan_max = info
+                .core_wallet
+                .accounts
+                .provider_operator_keys
+                .as_ref()
+                .and_then(|acct| {
+                    acct.managed_account_type()
+                        .address_pools()
+                        .iter()
+                        .filter_map(|p| p.highest_generated)
+                        .max()
+                })
+                .map(|h| h.saturating_add(1))
+                .unwrap_or(PROVIDER_KEY_WINDOW)
+                .max(PROVIDER_KEY_WINDOW);
+
+            // Platform-node ownership: Ed25519/SLIP-10 is hardened-only, so
+            // these keys can't be re-derived seedlessly. Read the wallet's
+            // own platform-node public keys straight from the managed
+            // pool's typed entries (populated at registration and rehydrated
+            // from the persisted batch on restore) and recompute the
+            // Tenderdash node id (SHA256[..20], rust-dashcore #884) — never
+            // trusting a persisted hash160-era id.
+            let mut platform_index: std::collections::HashMap<[u8; 20], u32> =
+                std::collections::HashMap::new();
+            if let Some(acct) = info.core_wallet.accounts.provider_platform_keys.as_ref() {
+                for pool in acct.managed_account_type().address_pools() {
+                    for entry in pool.addresses.values() {
+                        if let Some(PublicKeyType::EdDSA(pk)) = &entry.public_key {
+                            if let Ok(pk32) = <[u8; 32]>::try_from(pk.as_slice()) {
+                                let node_id =
+                                    dashcore::PlatformNodeId::from_ed25519_public_key(&pk32)
+                                        .to_byte_array();
+                                platform_index.insert(node_id, entry.index);
+                            }
+                        }
+                    }
+                }
+            }
+
+            (
+                network,
+                by_txid.into_values().collect::<Vec<_>>(),
+                operator_scan_max,
+                platform_index,
+            )
         };
 
         let dml = self.spv().masternode_validity_snapshot_blocking();
 
-        // Derive-and-compare ownership for the payload-only key kinds
-        // (operator BLS key / platform node id). These never appear as
-        // on-chain addresses, so — unlike owner/voting — they can't be
-        // resolved by the app's persisted-address join; we derive the
-        // wallet's own over the prederive window and let the FFI match each
-        // masternode's payload key. Operator public keys derive from the
-        // account xpub (no seed); platform-node keys use the resident root
-        // (watch-only wallets simply yield no matches — a follow-up that
-        // would thread the mnemonic resolver like the signing paths do).
+        // Operator (BLS) ownership: derive both serializations for every
+        // index the pool covers (`0..operator_scan_max`). Operator public
+        // keys derive from the account xpub with no seed, so this works for
+        // resident and restored external-signable wallets alike. A v1
+        // ProRegTx carries the key in LEGACY serialization and a v2 in
+        // MODERN, so both forms are indexed under the same index (distinct
+        // byte strings for the same G1 point — no collision).
         let mut operator_index: std::collections::HashMap<[u8; 48], u32> =
-            std::collections::HashMap::new();
-        let mut platform_index: std::collections::HashMap<[u8; 20], u32> =
             std::collections::HashMap::new();
         // Clone the `Arc<PlatformWallet>` out and drop the `wallets` read
         // guard before deriving (the derive calls take the wallet's own
@@ -885,9 +937,7 @@ impl<P: PlatformWalletPersistence + 'static> PlatformWalletManager<P> {
         let platform_wallet = self.wallets.blocking_read().get(wallet_id).cloned();
         if let Some(platform_wallet) = platform_wallet {
             use crate::wallet::provider_key_at_index::ProviderKeyKind;
-            // Provider-key pools pre-derive 20 keys; scan that window.
-            const PROVIDER_KEY_WINDOW: u32 = 20;
-            for index in 0..PROVIDER_KEY_WINDOW {
+            for index in 0..operator_scan_max {
                 match platform_wallet.derive_provider_key_at_index(
                     ProviderKeyKind::Operator,
                     index,
@@ -895,15 +945,6 @@ impl<P: PlatformWalletPersistence + 'static> PlatformWalletManager<P> {
                     false,
                 ) {
                     Ok(key) => {
-                        // Index BOTH serializations under the same index.
-                        // `aggregate_masternodes` preserves the exact
-                        // on-chain payload bytes, and a v1 ProRegTx carries
-                        // the operator key in LEGACY serialization while a
-                        // v2 ProRegTx carries MODERN — so matching only the
-                        // modern form would miss every wallet-owned v1
-                        // masternode. The two forms are distinct byte
-                        // strings for the same G1 point, so inserting both
-                        // can't collide.
                         if let Ok(bytes) = <[u8; 48]>::try_from(key.public_key_bytes.as_slice()) {
                             operator_index.insert(bytes, index);
                         }
@@ -916,22 +957,6 @@ impl<P: PlatformWalletPersistence + 'static> PlatformWalletManager<P> {
                         }
                     }
                     // First failure ⇒ no operator account (or unavailable) ⇒ stop.
-                    Err(_) => break,
-                }
-            }
-            for index in 0..PROVIDER_KEY_WINDOW {
-                match platform_wallet.derive_provider_key_at_index(
-                    ProviderKeyKind::PlatformNode,
-                    index,
-                    None,
-                    false,
-                ) {
-                    Ok(key) => {
-                        if let Some(node_id) = key.node_id {
-                            platform_index.insert(node_id, index);
-                        }
-                    }
-                    // No platform account, or watch-only (needs the seed). Stop.
                     Err(_) => break,
                 }
             }

--- a/packages/rs-platform-wallet/src/manager/accessors.rs
+++ b/packages/rs-platform-wallet/src/manager/accessors.rs
@@ -43,9 +43,9 @@ pub type ProviderMasternodeTxs = (
     dashcore::Network,
     // Each tuple is `(block_height, in_block_position, tx)`. The position
     // orders same-block provider updates for the aggregation's latest-wins
-    // (Core applies them in `block.vtx` order). Upstream retained records
-    // carry no in-block index yet (rust-dashcore#890), so `position` is
-    // currently always 0 (see the note where these are built).
+    // (Core applies them in `block.vtx` order). Stamped during block
+    // processing (rust-dashcore#891); 0 for legacy rows persisted before
+    // the field existed.
     Vec<(u32, u32, dashcore::Transaction)>,
     Option<std::collections::HashMap<[u8; 32], bool>>,
     std::collections::HashMap<[u8; 48], u32>,
@@ -869,15 +869,15 @@ impl<P: PlatformWalletPersistence + 'static> PlatformWalletManager<P> {
                     let height = record.context.block_info().map(|b| b.height()).unwrap_or(0);
                     // In-block position for same-height tie-breaking in the
                     // aggregation (Core resolves same-block provider updates in
-                    // `block.vtx` order). The retained `TransactionContext` /
-                    // `BlockInfo` expose only height/hash/timestamp — NO in-block
-                    // index — and `account.transactions()` is a `BTreeMap<Txid>`
-                    // (txid-ordered, not processing order), so no real position is
-                    // recoverable here. Pass 0 for now; a correct fix needs an
-                    // upstream in-block tx index on `BlockInfo`, set during block
-                    // processing (rust-dashcore#890). Until then two same-block
-                    // updates to one field fall back to feed order.
-                    let position = 0u32;
+                    // `block.vtx` order). Stamped by block processing since
+                    // rust-dashcore#891 and round-tripped through persistence;
+                    // `None` only for legacy rows persisted before the field
+                    // existed, which fall back to 0 (feed order).
+                    let position = record
+                        .context
+                        .block_info()
+                        .and_then(|b| b.position())
+                        .unwrap_or(0);
                     by_txid
                         .entry(record.txid)
                         .or_insert_with(|| (height, position, record.transaction.clone()));

--- a/packages/rs-platform-wallet/src/spv/peers.rs
+++ b/packages/rs-platform-wallet/src/spv/peers.rs
@@ -130,7 +130,7 @@ mod tests {
     use dashcore::bls_sig_utils::BLSPublicKey;
     use dashcore::hashes::Hash;
     use dashcore::sml::masternode_list_entry::{MasternodeListEntry, MasternodeNetInfo};
-    use dashcore::{BlockHash, ProTxHash, PubkeyHash};
+    use dashcore::{BlockHash, PlatformNodeId, ProTxHash, PubkeyHash};
 
     use super::*;
 
@@ -187,7 +187,7 @@ mod tests {
                 evo,
                 EntryMasternodeType::HighPerformance {
                     platform_http_port: 443,
-                    platform_node_id: PubkeyHash::from_byte_array([0u8; 20]),
+                    platform_node_id: PlatformNodeId::from_byte_array([0u8; 20]),
                 },
             ),
         ]);

--- a/packages/rs-platform-wallet/src/wallet/provider_key_at_index.rs
+++ b/packages/rs-platform-wallet/src/wallet/provider_key_at_index.rs
@@ -33,38 +33,37 @@
 //!
 //! # Key source
 //!
-//! The BLS operator and Ed25519 platform-node accounts are derived from
-//! the wallet's **raw BIP39 seed** in each curve's own HD scheme — the
-//! exact input [`Wallet::add_bls_account`] / `add_eddsa_account` feed to
-//! `BLSAccount::from_seed` / `EdDSAAccount::from_seed` (rust-dashcore
-//! #879). Concretely:
+//! This module is a thin adapter over key-wallet's **gate-free provider
+//! key-derivation entry points** (rust-dashcore #881, issue #880). Those
+//! functions derive the BLS operator and Ed25519 platform-node keys in
+//! each curve's own HD scheme, are wallet-state-agnostic (no
+//! `is_watch_only` gate), and match dashbls / DashSync:
 //!
-//! - **Operator public** at index `i` = the account xpub's non-hardened
-//!   **legacy** `ckd_pub` child, `ExtendedBLSPubKey::derive_pub_legacy(i)`
-//!   — no seed.
-//! - **Operator private** at `i` = raw seed → `ExtendedBLSPrivKey`
-//!   master → **legacy** DIP-3 account path → non-hardened legacy child
-//!   `i`.
-//! - **Platform node** at `i` = raw seed → `ExtendedEd25519PrivKey`
-//!   master → DIP-3 account path → **hardened** child `i'` (SLIP-10 is
-//!   hardened-only).
+//! - **Operator public** at index `i` = [`BLSAccount::operator_public_key_at`]
+//!   — the account xpub's non-hardened legacy `ckd_pub` child; no seed.
+//! - **Operator private** at `i` = [`BLSAccount::operator_private_key_at`]
+//!   — raw seed → BLS master → legacy DIP-3 account path → non-hardened
+//!   legacy child; no account state.
+//! - **Platform node** at `i` = [`EdDSAAccount::platform_node_key_at`] —
+//!   raw seed → SLIP-10 master → DIP-3 account path → hardened child `i'`;
+//!   no account state.
 //!
-//! This composes the upstream **extended-key primitives directly** rather
-//! than the account's `derive_bls_key_at_index` / `derive_from_seed_*`
-//! convenience wrappers, because those gate on the account's
-//! `is_watch_only` flag *asymmetrically*: the public wrapper requires a
-//! watch-only account, while `derive_from_seed_*` (via
-//! `derive_xpriv_from_master_xpriv`) requires a **non**-watch-only one.
-//! A resident wallet's provider account is non-watch-only and a restored
-//! external-signable wallet's is watch-only, so no single wrapper works
-//! for both. The primitives don't consult `is_watch_only`, so they derive
-//! correctly regardless — and are byte-identical to what
-//! `Wallet::from_mnemonic` account creation produces (pinned to the
-//! dashbls reference vectors in the module tests).
+//! We use these directly rather than the account's older
+//! `derive_bls_key_at_index` / `derive_from_seed_*` convenience wrappers,
+//! which gate on `is_watch_only` *asymmetrically* (the public wrapper
+//! needs a watch-only account; `derive_from_seed_*` needs a
+//! **non**-watch-only one) and so can't both serve a resident and a
+//! restored external-signable wallet. The #880 entry points have no such
+//! gate.
 //!
-//! **Never** derive a secp256k1 child scalar at the DIP-3 path and feed
-//! it to `new_master`: that pre-#879 hybrid yields a different point and
-//! is exactly the bug that made these keys disagree with DashSync/dashbls.
+//! Because the operator public key comes from the stored account xpub
+//! while the operator private key comes from the raw seed, the
+//! private-reveal path runs an **always-on cross-check** that the two
+//! agree on the same G1 point (`operator_private_key_at(..).public_key()`
+//! vs `operator_public_key_at(..)`) — the entry points derive
+//! independently and do not verify against each other, so a stale /
+//! corrupt persisted xpub would otherwise let a mismatched (public,
+//! private) pair escape. On mismatch we return an error rather than a key.
 //!
 //! The raw 64-byte seed is obtained two ways, matching
 //! [`derive_core_address_private_key`](PlatformWallet::derive_core_address_private_key):
@@ -75,10 +74,7 @@
 //! are scrubbed when dropped.
 
 use dashcore::hashes::{hash160, Hash};
-use key_wallet::account::AccountType;
-use key_wallet::bip32::ChildNumber;
-use key_wallet::derivation_bls_bip32::ExtendedBLSPrivKey;
-use key_wallet::derivation_slip10::{ExtendedEd25519PrivKey, ExtendedEd25519PubKey};
+use key_wallet::account::{AccountType, BLSAccount, EdDSAAccount};
 use zeroize::Zeroizing;
 
 use super::platform_wallet::PlatformWallet;
@@ -96,56 +92,6 @@ use crate::error::PlatformWalletError;
 /// screen has a full first page to show from persistence alone.
 pub const PLATFORM_NODE_KEY_PREDERIVE_COUNT: u32 = 20;
 
-/// Derive the platform-node (Ed25519) extended private key at `index`
-/// from the raw BIP39 `seed`: SLIP-10 master → DIP-3
-/// `ProviderPlatformKeys` account path → hardened child `index'`.
-///
-/// The single canonical platform-node private derivation, shared by
-/// [`derive_platform_node_public_keys`] (the registration snapshot) and
-/// [`PlatformWallet::derive_provider_key_at_index`] (the per-index
-/// reveal) so the two can never diverge — the same anti-duplication
-/// rationale as the rest of this module. Composed from the upstream
-/// extended-key primitives directly (gate-free; see the module docs on
-/// why the account's `is_watch_only`-gated `derive_from_seed_*` wrapper
-/// is avoided).
-///
-/// # Errors
-/// [`PlatformWalletError::KeyDerivation`] if the account path can't be
-/// built, the SLIP-10 master / account key can't be derived, or the
-/// per-index child derivation fails.
-fn platform_node_xpriv_at(
-    seed: &[u8],
-    network: key_wallet::Network,
-    index: u32,
-) -> Result<ExtendedEd25519PrivKey, PlatformWalletError> {
-    let account_path = AccountType::ProviderPlatformKeys
-        .derivation_path(network)
-        .map_err(|e| {
-            PlatformWalletError::KeyDerivation(format!(
-                "failed to build provider platform-node account path: {e}"
-            ))
-        })?;
-    let master = ExtendedEd25519PrivKey::new_master(network, seed).map_err(|e| {
-        PlatformWalletError::KeyDerivation(format!(
-            "failed to build Ed25519 master from platform-node seed: {e}"
-        ))
-    })?;
-    let account_xpriv = master.derive_priv(&account_path).map_err(|e| {
-        PlatformWalletError::KeyDerivation(format!(
-            "failed to derive Ed25519 platform-node account key at {account_path}: {e}"
-        ))
-    })?;
-    // SLIP-10 Ed25519 is hardened-only — hardened child `index'`.
-    let child = ChildNumber::from_hardened_idx(index).map_err(|e| {
-        PlatformWalletError::KeyDerivation(format!("invalid platform-node key index {index}: {e}"))
-    })?;
-    account_xpriv.derive_priv(&[child]).map_err(|e| {
-        PlatformWalletError::KeyDerivation(format!(
-            "failed to derive Ed25519 platform-node key at index {index}: {e}"
-        ))
-    })
-}
-
 /// Derive the first `count` platform-node (Ed25519) public keys from a
 /// **seed-bearing** [`Wallet`](key_wallet::wallet::Wallet), returning
 /// the 32-byte public key + 20-byte `hash160` node id per hardened
@@ -154,13 +100,10 @@ fn platform_node_xpriv_at(
 /// Used at registration (`PlatformWalletManager::register_wallet`)
 /// to snapshot the pool while the seed is available, because the
 /// platform-node curve is hardened-only and the pool can never be
-/// extended later from an external-signable / watch-only wallet. The
-/// derivation is the canonical rust-dashcore #879 scheme — the wallet's
-/// **raw BIP39 seed** → [`ExtendedEd25519PrivKey`] master → DIP-3
-/// `ProviderPlatformKeys` account path → hardened child `i` → public key
-/// — composed from the upstream extended-key primitives directly (see the
-/// module docs on why the account's `is_watch_only`-gated
-/// `derive_from_seed_*` wrapper is avoided). It is byte-identical to what
+/// extended later from an external-signable / watch-only wallet. Each key
+/// is the gate-free [`EdDSAAccount::platform_node_key_at`] entry point
+/// (rust-dashcore #881) — raw seed → SLIP-10 master → DIP-3 account path
+/// → hardened child `i'` — so it is byte-identical to what
 /// [`PlatformWallet::derive_provider_key_at_index`] and account creation
 /// produce. Only the public parts leave this function — the raw seed is
 /// wrapped in [`Zeroizing`] and scrubbed on drop.
@@ -178,8 +121,8 @@ pub fn derive_platform_node_public_keys(
     let account_type = AccountType::ProviderPlatformKeys;
 
     // Existence check — a missing platform-node account is a caller error,
-    // not a derivation failure (the account object itself isn't needed for
-    // the gate-free direct derivation below).
+    // not a derivation failure (the seed-based entry point below needs no
+    // account state).
     if wallet
         .accounts
         .eddsa_account_of_type(account_type)
@@ -203,13 +146,13 @@ pub fn derive_platform_node_public_keys(
 
     let mut out = Vec::with_capacity(count as usize);
     for index in 0..count {
-        let xpriv = platform_node_xpriv_at(seed.as_ref(), network, index)?;
-        let verifying = ExtendedEd25519PubKey::from_priv(&xpriv).map_err(|e| {
-            PlatformWalletError::KeyDerivation(format!(
-                "failed to obtain Ed25519 public key at index {index}: {e}"
-            ))
-        })?;
-        let public_key: [u8; 32] = verifying.public_key.to_bytes();
+        let signing_key = EdDSAAccount::platform_node_key_at(seed.as_ref(), network, index)
+            .map_err(|e| {
+                PlatformWalletError::KeyDerivation(format!(
+                    "failed to derive Ed25519 platform-node key at index {index}: {e}"
+                ))
+            })?;
+        let public_key: [u8; 32] = signing_key.verifying_key().to_bytes();
         // The 20-byte platform node id = hash160(ed25519 pubkey), the
         // value a ProRegTx `platform_node_id` matcher compares against.
         let node_id: [u8; 20] = hash160::Hash::hash(&public_key).to_byte_array();
@@ -258,9 +201,8 @@ pub struct ProviderDerivedKey {
     /// dashbls/DashSync use across the BLS HD chain. `Some` only for
     /// operator (BLS) keys; `None` for Ed25519 platform-node keys, which
     /// have no legacy variant. Produced Rust-side via
-    /// `ExtendedBLSPubKey::to_bytes_legacy` / `ExtendedBLSPrivKey::
-    /// public_key_bytes_legacy` (key-wallet #879) — never transformed in
-    /// Swift.
+    /// `ExtendedBLSPubKey::to_bytes_legacy` (key-wallet #879) — never
+    /// transformed in Swift.
     pub legacy_public_key_bytes: Option<Vec<u8>>,
     /// The 20-byte platform node id — `hash160` of the Ed25519 public
     /// key, the value a ProRegTx `platform_node_id` field carries and
@@ -294,11 +236,11 @@ impl PlatformWallet {
     /// [`wallet_seed_bytes`](key_wallet::wallet::Wallet::wallet_seed_bytes).
     /// `include_private` additionally requests the raw private scalar.
     ///
-    /// The derivation delegates to the account's own
-    /// [`AccountDerivation`] routines (rust-dashcore #879) so every
-    /// per-index key is byte-identical to what `Wallet::from_mnemonic`
-    /// account creation produces; it never feeds a secp256k1 child scalar
-    /// into a BLS/Ed25519 master (the pre-#879 hybrid).
+    /// The derivation delegates to key-wallet's gate-free provider-key
+    /// entry points (rust-dashcore #881) so every per-index key is
+    /// byte-identical to what `Wallet::from_mnemonic` account creation
+    /// produces; it never feeds a secp256k1 child scalar into a
+    /// BLS/Ed25519 master (the pre-#879 hybrid).
     ///
     /// # Errors
     /// - [`PlatformWalletError::AddressNotFound`] if this wallet has no
@@ -367,133 +309,69 @@ impl PlatformWallet {
                         )
                     })?;
 
-                // Non-hardened index — the operator pool's single
-                // `AddressPoolType::Absent` chain (`account/i`).
-                let child = ChildNumber::from_normal_idx(index).map_err(|e| {
+                // The operator public key at this index — the account
+                // xpub's non-hardened legacy `ckd_pub` child, via the
+                // gate-free #881 entry point (works for resident and
+                // restored / watch-only accounts). Both serializations of
+                // the same G1 point come off the returned extended key.
+                let xpub = account.operator_public_key_at(index).map_err(|e| {
                     PlatformWalletError::KeyDerivation(format!(
-                        "invalid operator key index {index}: {e}"
+                        "failed to derive BLS operator public key at index {index}: {e}"
                     ))
                 })?;
+                let public_key_bytes = xpub.to_bytes().to_vec();
+                // Same G1 point in Dash legacy serialization (key-wallet
+                // #879) — for the "BLS Public Key (Legacy)" display row.
+                let legacy_public_key_bytes = Some(xpub.to_bytes_legacy().to_vec());
 
-                match &seed {
-                    // Private reveal (or a caller that supplied a seed):
-                    // raw seed → BLS master → **legacy** DIP-3 account path →
-                    // non-hardened legacy child `index`. Composed from the
-                    // upstream primitives directly (the account's
-                    // `derive_from_seed_*` wrapper rejects a watch-only
-                    // account even with a seed in hand — see module docs),
-                    // yet byte-identical to it for a resident account.
+                let private_key = match &seed {
+                    // Private reveal: the operator secret scalar derived
+                    // straight from the raw seed via the #881 entry point
+                    // (no account state, no `is_watch_only` gate).
                     Some(seed) => {
-                        let master = ExtendedBLSPrivKey::new_master(network, seed.as_ref())
-                            .map_err(|e| {
-                                PlatformWalletError::KeyDerivation(format!(
-                                    "failed to build BLS master from operator seed: {e}"
-                                ))
-                            })?;
-                        let account_path = account_type.derivation_path(network).map_err(|e| {
-                            PlatformWalletError::KeyDerivation(format!(
-                                "failed to build BLS operator account path: {e}"
-                            ))
-                        })?;
-                        let account_xpriv =
-                            master.derive_path_legacy(&account_path).map_err(|e| {
-                                PlatformWalletError::KeyDerivation(format!(
-                                    "failed to derive BLS operator account key at \
-                                     {account_path}: {e}"
-                                ))
-                            })?;
-                        let xpriv = account_xpriv.derive_priv_legacy(child).map_err(|e| {
-                            PlatformWalletError::KeyDerivation(format!(
-                                "failed to derive BLS operator key at index {index}: {e}"
-                            ))
-                        })?;
-                        let public_key_bytes = xpriv.public_key_bytes().to_vec();
-                        // Same G1 point, Dash legacy serialization (key-wallet
-                        // #879) — for the "BLS Public Key (Legacy)" display row.
-                        let legacy_public_key_bytes =
-                            Some(xpriv.public_key_bytes_legacy().to_vec());
-
-                        // Always-on guard: the seed-derived public key MUST
-                        // equal the account xpub's non-hardened legacy
-                        // `ckd_pub` child. A mismatch means the wallet seed
-                        // and its stored operator account xpub disagree
-                        // (wrong seed / stale xpub) — exactly the failure
-                        // this PR fixed — so refuse to hand out a mismatched
-                        // key. `derive_pub_legacy` is a gate-free pure public
-                        // operation (works for resident and watch-only
-                        // accounts alike), and the extra derivation on the
-                        // private-reveal path is negligible. If that public
-                        // derivation itself can't be performed we log and
-                        // proceed rather than fail: the private derivation
-                        // already succeeded, so a valid key is in hand and
-                        // failing here would only turn a working path into a
-                        // spurious error.
-                        match account.bls_public_key.derive_pub_legacy(child) {
-                            Ok(xpub) => {
-                                if xpub.to_bytes() != xpriv.public_key_bytes() {
-                                    return Err(PlatformWalletError::KeyDerivation(format!(
-                                        "BLS operator key at index {index}: seed-derived public \
-                                         key does not match the account xpub derivation — the \
-                                         wallet seed and its stored operator account xpub \
-                                         disagree; refusing to return a mismatched key"
-                                    )));
-                                }
-                            }
-                            Err(e) => {
-                                tracing::warn!(
-                                    index,
-                                    error = %e,
-                                    "BLS operator seed/xpub cross-check skipped: account xpub \
-                                     public derivation failed"
-                                );
-                            }
-                        }
-
-                        let private_key = include_private
-                            .then(|| Zeroizing::new(xpriv.private_key.to_be_bytes().to_vec()));
-
-                        Ok(ProviderDerivedKey {
-                            index,
-                            public_key_bytes,
-                            legacy_public_key_bytes,
-                            node_id: None,
-                            private_key,
-                        })
-                    }
-                    // Public-only: the account xpub's non-hardened **legacy**
-                    // `ckd_pub` child — no seed / resolver needed for BLS.
-                    // `derive_pub_legacy` is a pure public-key operation
-                    // (no `is_watch_only` gate), so it works for both
-                    // resident and restored (watch-only) accounts.
-                    None => {
-                        let xpub =
-                            account
-                                .bls_public_key
-                                .derive_pub_legacy(child)
+                        let secret =
+                            BLSAccount::operator_private_key_at(seed.as_ref(), network, index)
                                 .map_err(|e| {
                                     PlatformWalletError::KeyDerivation(format!(
-                                        "failed to derive BLS operator public key at index \
-                                     {index}: {e}"
+                                        "failed to derive BLS operator key at index {index}: {e}"
                                     ))
                                 })?;
-                        // Serialize the same G1 point both ways: modern/IETF
-                        // and Dash legacy (key-wallet #879).
-                        let public_key_bytes = xpub.to_bytes().to_vec();
-                        let legacy_public_key_bytes = Some(xpub.to_bytes_legacy().to_vec());
-                        Ok(ProviderDerivedKey {
-                            index,
-                            public_key_bytes,
-                            legacy_public_key_bytes,
-                            node_id: None,
-                            private_key: None,
-                        })
+
+                        // Always-on guard: the public branch derives from
+                        // the stored account xpub while this derives from
+                        // the raw seed, and the two #881 entry points do
+                        // NOT verify against each other — so a stale /
+                        // corrupt persisted xpub would otherwise let a
+                        // mismatched (public, private) pair escape. Refuse
+                        // to hand one out. The extra public derivation is
+                        // negligible.
+                        if secret.public_key().to_bytes() != xpub.public_key.to_bytes() {
+                            return Err(PlatformWalletError::KeyDerivation(format!(
+                                "BLS operator key at index {index}: seed-derived public key \
+                                 does not match the account xpub derivation — the wallet seed \
+                                 and its stored operator account xpub disagree; refusing to \
+                                 return a mismatched key"
+                            )));
+                        }
+
+                        include_private.then(|| Zeroizing::new(secret.to_be_bytes().to_vec()))
                     }
-                }
+                    // Public-only: no seed, no private scalar.
+                    None => None,
+                };
+
+                Ok(ProviderDerivedKey {
+                    index,
+                    public_key_bytes,
+                    legacy_public_key_bytes,
+                    node_id: None,
+                    private_key,
+                })
             }
             ProviderKeyKind::PlatformNode => {
                 // Existence check — a missing account is a caller error,
-                // not a derivation failure (the account object itself isn't
-                // needed for the gate-free direct derivation below).
+                // not a derivation failure (the seed-based entry point below
+                // needs no account state).
                 if state
                     .wallet()
                     .accounts
@@ -510,19 +388,18 @@ impl PlatformWallet {
                     .as_ref()
                     .expect("platform-node derivation always seeds");
 
-                // Canonical raw-seed derivation via the shared helper (the
-                // exact routine `derive_platform_node_public_keys` uses, so
-                // the per-index reveal can never diverge from the persisted
-                // batch). Composed from the upstream primitives directly —
-                // the account's `derive_from_seed_*` wrapper rejects a
-                // watch-only account even with a seed (see module docs).
-                let xpriv = platform_node_xpriv_at(seed.as_ref(), network, index)?;
-                let verifying = ExtendedEd25519PubKey::from_priv(&xpriv).map_err(|e| {
-                    PlatformWalletError::KeyDerivation(format!(
-                        "failed to obtain Ed25519 public key at index {index}: {e}"
-                    ))
-                })?;
-                let public_key_bytes = verifying.public_key.to_bytes().to_vec();
+                // Gate-free #881 entry point (the exact routine
+                // `derive_platform_node_public_keys` uses, so the per-index
+                // reveal can never diverge from the persisted batch): raw
+                // seed → SLIP-10 master → DIP-3 account path → hardened
+                // child `index'`. No account state involved.
+                let signing_key = EdDSAAccount::platform_node_key_at(seed.as_ref(), network, index)
+                    .map_err(|e| {
+                        PlatformWalletError::KeyDerivation(format!(
+                            "failed to derive Ed25519 platform-node key at index {index}: {e}"
+                        ))
+                    })?;
+                let public_key_bytes = signing_key.verifying_key().to_bytes().to_vec();
 
                 // The 20-byte platform node id = hash160(ed25519 pubkey),
                 // exactly what the ProRegTx `platform_node_id` matcher
@@ -530,7 +407,7 @@ impl PlatformWallet {
                 let node_id: [u8; 20] = hash160::Hash::hash(&public_key_bytes).to_byte_array();
 
                 let private_key =
-                    include_private.then(|| Zeroizing::new(xpriv.private_key.to_vec()));
+                    include_private.then(|| Zeroizing::new(signing_key.to_bytes().to_vec()));
 
                 Ok(ProviderDerivedKey {
                     index,
@@ -548,11 +425,7 @@ impl PlatformWallet {
 #[cfg(test)]
 mod tests {
     use super::*;
-    // The upstream account wrappers (`derive_from_seed_*`) are used ONLY in
-    // tests, as an independent cross-check that the module's gate-free
-    // primitives match upstream for a resident (non-watch-only) account.
     use dashcore::hashes::{hash160, Hash};
-    use key_wallet::account::derivation::AccountDerivation;
     use key_wallet::mnemonic::{Language, Mnemonic};
     use key_wallet::wallet::initialization::WalletAccountCreationOptions;
     use key_wallet::wallet::Wallet;
@@ -571,20 +444,16 @@ mod tests {
     }
 
     /// The load-bearing invariants for platform-node keys, pinned so a
-    /// derivation regression (like the pre-#879 secp256k1 hybrid) can't
-    /// silently hand out wrong key material: `node_id == hash160(pubkey)`
-    /// at every index, all indices distinct, our wrapper's per-index key
-    /// equals the account's own canonical seed derivation, and a golden
-    /// secret scalar pinned to the dashbls/SLIP-10 reference vector from
-    /// key-wallet's `provider_key_derivation_tests.rs`.
+    /// derivation regression can't silently hand out wrong key material:
+    /// `node_id == hash160(pubkey)` at every index, all indices distinct,
+    /// the snapshot's per-index public key corresponds to the #881 seed
+    /// entry point, and a golden secret scalar pinned to the dashbls /
+    /// SLIP-10 reference vector from key-wallet's
+    /// `provider_key_derivation_tests.rs`.
     #[test]
     fn platform_node_keys_are_consistent_and_pinned() {
         let wallet = seed_bearing_wallet(Network::Mainnet);
         let seed = wallet.wallet_seed_bytes().expect("resident seed");
-        let account = wallet
-            .accounts
-            .eddsa_account_of_type(AccountType::ProviderPlatformKeys)
-            .expect("platform-node account");
 
         let keys = derive_platform_node_public_keys(&wallet, Network::Mainnet, 20)
             .expect("platform-node derivation");
@@ -598,20 +467,16 @@ mod tests {
                 "node_id must be hash160(ed25519 pubkey) at index {i}"
             );
 
-            // Cross-path: the registration wrapper's per-index key must be
-            // byte-identical to the account's own canonical raw-seed
-            // derivation — the same routine `derive_provider_key_at_index`
-            // and `Wallet::from_mnemonic` account creation use.
-            let up_xpriv = account
-                .derive_from_seed_extended_xpriv_at(&seed, i as u32)
-                .expect("account seed derivation");
-            let up_pub = ExtendedEd25519PubKey::from_priv(&up_xpriv)
-                .expect("ed25519 pub")
-                .public_key
-                .to_bytes();
+            // The snapshot's per-index public key must be the public key of
+            // the #881 seed entry point at that index — the same routine
+            // `derive_provider_key_at_index` uses for the per-index reveal,
+            // so the persisted batch and the reveal can't diverge.
+            let via_api = EdDSAAccount::platform_node_key_at(&seed, Network::Mainnet, i as u32)
+                .expect("platform_node_key_at");
             assert_eq!(
-                k.public_key, up_pub,
-                "wrapper pubkey must equal the account's canonical derivation at {i}"
+                k.public_key,
+                via_api.verifying_key().to_bytes(),
+                "snapshot pubkey must equal platform_node_key_at at {i}"
             );
         }
 
@@ -624,29 +489,29 @@ mod tests {
         // Golden vector — mainnet platform-node key 0 secret scalar
         // (`m/9'/5'/3'/4'/0'`), pinned to the SLIP-10 reference in
         // key-wallet `provider_key_derivation_tests.rs`. This is the value
-        // DashSync/dashwallet-ios produce; a break means our derivation
-        // diverged from the reference.
-        let sk0 = account
-            .derive_from_seed_private_key_at(&seed, 0)
-            .expect("platform-node sk derivation");
+        // DashSync/dashwallet-ios produce.
+        let sk0 = EdDSAAccount::platform_node_key_at(&seed, Network::Mainnet, 0)
+            .expect("platform_node_key_at");
         assert_eq!(
             hex::encode(sk0.to_bytes()),
             "5fa238b12be77347abf9b5957bd902d16c6aaca28d25c4267ffacbd7458dceb1",
             "mainnet platform-node index-0 secret golden (dashbls/SLIP-10 reference)"
         );
+        // The snapshot's index-0 public key corresponds to that golden secret.
+        assert_eq!(
+            keys[0].public_key,
+            sk0.verifying_key().to_bytes(),
+            "snapshot index-0 pubkey must match the golden secret's public key"
+        );
     }
 
     /// Operator (BLS) keys pinned to the dashbls reference vectors from
     /// key-wallet `provider_key_derivation_tests.rs` — the values
-    /// DashSync/dashwallet-ios produce — on both networks. Exercises BOTH
-    /// derivation paths this module actually uses: the public branch's
-    /// `ExtendedBLSPubKey::derive_pub_legacy` (gate-free) and the private
-    /// branch's gate-free primitive composition, cross-checked against
-    /// each other, the account's own wrapper, and the golden vectors. This
-    /// is the exact key the user reported as mismatched; the pre-#879
-    /// secp256k1 hybrid produced a different point here, and the account's
-    /// `derive_bls_key_at_index` wrapper can't derive it from a resident
-    /// (non-watch-only) account at all.
+    /// DashSync/dashwallet-ios produce — on both networks, via the #881
+    /// gate-free entry points this module now calls. Also exercises the
+    /// always-on seed↔xpub cross-check (`operator_private_key_at(..)`'s
+    /// public key must equal `operator_public_key_at(..)`), the guard that
+    /// refuses to hand out a mismatched (public, private) pair.
     #[test]
     fn operator_keys_match_dashbls_reference_and_cross_check() {
         // --- Mainnet (`m/9'/5'/3'/3'/0`) ---
@@ -657,102 +522,62 @@ mod tests {
             .bls_account_of_type(AccountType::ProviderOperatorKeys)
             .expect("operator account");
 
-        // Public-only path (exactly what `derive_provider_key_at_index`
-        // does for the seedless branch): the account xpub's non-hardened
-        // **legacy** `ckd_pub`. `derive_pub_legacy` is gate-free, so it
-        // works on this resident (non-watch-only) account too.
-        let child0 = ChildNumber::from_normal_idx(0).expect("child 0");
-        let xpub0 = account
-            .bls_public_key
-            .derive_pub_legacy(child0)
-            .expect("operator public derivation");
+        // Public: the gate-free #881 entry point (works on this resident
+        // account and on watch-only accounts alike).
+        let xpub0 = account.operator_public_key_at(0).expect("operator public");
         assert_eq!(
             hex::encode(xpub0.to_bytes_legacy()),
             "078cad04aae29eb76171937eb7101452b401b026efbc27db840f130374e6a9ec8443d917277f8921e0ba6678a7709875",
             "operator key0 legacy pubkey golden (dashbls reference)"
         );
-        // Modern/IETF (basic-scheme) serialization, verbatim from the
-        // upstream reference test.
         assert_eq!(
             hex::encode(xpub0.to_bytes()),
             "878cad04aae29eb76171937eb7101452b401b026efbc27db840f130374e6a9ec8443d917277f8921e0ba6678a7709875",
             "operator key0 modern pubkey golden (dashbls reference)"
         );
 
-        // Private (seed) path composed from the SAME gate-free primitives
-        // `derive_provider_key_at_index` uses: raw seed → BLS master →
-        // legacy account path → non-hardened legacy child.
-        let account_path = AccountType::ProviderOperatorKeys
-            .derivation_path(Network::Mainnet)
-            .expect("account path");
-        let master = ExtendedBLSPrivKey::new_master(Network::Mainnet, &seed).expect("bls master");
-        let xpriv0 = master
-            .derive_path_legacy(&account_path)
-            .expect("account xpriv")
-            .derive_priv_legacy(child0)
-            .expect("child xpriv");
+        // Private: the gate-free #881 seed entry point (no account state).
+        let sk0 = BLSAccount::operator_private_key_at(&seed, Network::Mainnet, 0)
+            .expect("operator private");
         assert_eq!(
-            xpriv0.public_key_bytes(),
-            xpub0.to_bytes(),
-            "gate-free seed-derived operator pubkey must equal the public derivation"
-        );
-        assert_eq!(
-            xpriv0.public_key_bytes_legacy(),
-            xpub0.to_bytes_legacy(),
-            "gate-free seed-derived operator legacy pubkey must equal the public derivation"
-        );
-        assert_eq!(
-            hex::encode(xpriv0.private_key.to_be_bytes()),
+            hex::encode(sk0.to_be_bytes()),
             "11122e1ad656d0610ce0f80d40da874d67ea656a3e66ed371c915ec3a488a43a",
             "operator key0 secret golden (dashbls reference)"
         );
-
-        // The gate-free composition must equal the account's own wrapper
-        // for this resident (non-watch-only) account — proving they agree
-        // where the wrapper is usable.
-        let via_wrapper = account
-            .derive_from_seed_extended_xpriv_at(&seed, 0)
-            .expect("wrapper seed derivation");
+        // The always-on cross-check the adapter runs: the seed-derived
+        // secret's public key must equal the account-xpub-derived public.
         assert_eq!(
-            via_wrapper.public_key_bytes(),
-            xpriv0.public_key_bytes(),
-            "gate-free primitives must match the account's derive_from_seed_* wrapper"
+            sk0.public_key().to_bytes(),
+            xpub0.public_key.to_bytes(),
+            "seed-derived operator pubkey must equal the account-xpub derivation"
         );
 
         // --- Testnet (`m/9'/1'/3'/3'/0`) ---
         let wallet_t = seed_bearing_wallet(Network::Testnet);
+        let seed_t = wallet_t.wallet_seed_bytes().expect("resident seed");
         let account_t = wallet_t
             .accounts
             .bls_account_of_type(AccountType::ProviderOperatorKeys)
             .expect("operator account");
         let xpub0_t = account_t
-            .bls_public_key
-            .derive_pub_legacy(child0)
-            .expect("operator public derivation");
+            .operator_public_key_at(0)
+            .expect("operator public");
         assert_eq!(
             hex::encode(xpub0_t.to_bytes_legacy()),
             "09d8beabae708de1638487f1aff44b38e8c07d9b09f22d76329d6c8ec01e2ad4d030b660bca40ddbd222373a72c5bcef",
             "testnet operator key0 legacy pubkey golden (dashbls reference)"
         );
-        let seed_t = wallet_t.wallet_seed_bytes().expect("resident seed");
-        let account_path_t = AccountType::ProviderOperatorKeys
-            .derivation_path(Network::Testnet)
-            .expect("account path");
-        let xpriv0_t = ExtendedBLSPrivKey::new_master(Network::Testnet, &seed_t)
-            .expect("bls master")
-            .derive_path_legacy(&account_path_t)
-            .expect("account xpriv")
-            .derive_priv_legacy(child0)
-            .expect("child xpriv");
+        let sk0_t = BLSAccount::operator_private_key_at(&seed_t, Network::Testnet, 0)
+            .expect("operator private");
         assert_eq!(
-            xpriv0_t.public_key_bytes_legacy(),
-            xpub0_t.to_bytes_legacy(),
-            "testnet gate-free operator legacy pubkey must equal the public derivation"
-        );
-        assert_eq!(
-            hex::encode(xpriv0_t.private_key.to_be_bytes()),
+            hex::encode(sk0_t.to_be_bytes()),
             "3346dfd71627f9f31cad3ee66fe7b673c32cb077b2eb38c621d7e61c30e46dbd",
             "testnet operator key0 secret golden (dashbls reference)"
+        );
+        assert_eq!(
+            sk0_t.public_key().to_bytes(),
+            xpub0_t.public_key.to_bytes(),
+            "testnet seed-derived operator pubkey must equal the account-xpub derivation"
         );
     }
 

--- a/packages/rs-platform-wallet/src/wallet/provider_key_at_index.rs
+++ b/packages/rs-platform-wallet/src/wallet/provider_key_at_index.rs
@@ -33,21 +33,52 @@
 //!
 //! # Key source
 //!
-//! The account seed (the 32 secret bytes at the account's DIP-3 path,
-//! the exact input [`Wallet::add_bls_account`] / `add_eddsa_account`
-//! feed to `new_master`) is obtained two ways, matching
+//! The BLS operator and Ed25519 platform-node accounts are derived from
+//! the wallet's **raw BIP39 seed** in each curve's own HD scheme — the
+//! exact input [`Wallet::add_bls_account`] / `add_eddsa_account` feed to
+//! `BLSAccount::from_seed` / `EdDSAAccount::from_seed` (rust-dashcore
+//! #879). Concretely:
+//!
+//! - **Operator public** at index `i` = the account xpub's non-hardened
+//!   **legacy** `ckd_pub` child, `ExtendedBLSPubKey::derive_pub_legacy(i)`
+//!   — no seed.
+//! - **Operator private** at `i` = raw seed → `ExtendedBLSPrivKey`
+//!   master → **legacy** DIP-3 account path → non-hardened legacy child
+//!   `i`.
+//! - **Platform node** at `i` = raw seed → `ExtendedEd25519PrivKey`
+//!   master → DIP-3 account path → **hardened** child `i'` (SLIP-10 is
+//!   hardened-only).
+//!
+//! This composes the upstream **extended-key primitives directly** rather
+//! than the account's `derive_bls_key_at_index` / `derive_from_seed_*`
+//! convenience wrappers, because those gate on the account's
+//! `is_watch_only` flag *asymmetrically*: the public wrapper requires a
+//! watch-only account, while `derive_from_seed_*` (via
+//! `derive_xpriv_from_master_xpriv`) requires a **non**-watch-only one.
+//! A resident wallet's provider account is non-watch-only and a restored
+//! external-signable wallet's is watch-only, so no single wrapper works
+//! for both. The primitives don't consult `is_watch_only`, so they derive
+//! correctly regardless — and are byte-identical to what
+//! `Wallet::from_mnemonic` account creation produces (pinned to the
+//! dashbls reference vectors in the module tests).
+//!
+//! **Never** derive a secp256k1 child scalar at the DIP-3 path and feed
+//! it to `new_master`: that pre-#879 hybrid yields a different point and
+//! is exactly the bug that made these keys disagree with DashSync/dashbls.
+//!
+//! The raw 64-byte seed is obtained two ways, matching
 //! [`derive_core_address_private_key`](PlatformWallet::derive_core_address_private_key):
-//! `Some(master)` for external-signable / watch-only wallets whose
-//! mnemonic the caller resolved on demand; `None` to derive from a
-//! resident key-bearing wallet. The seed and any returned scalar are
-//! wrapped in [`Zeroizing`] so they are scrubbed when dropped.
+//! `Some(seed)` for external-signable / watch-only wallets whose mnemonic
+//! the caller resolved on demand; `None` to take a resident key-bearing
+//! wallet's own [`wallet_seed_bytes`](key_wallet::wallet::Wallet::wallet_seed_bytes).
+//! The seed and any returned scalar are wrapped in [`Zeroizing`] so they
+//! are scrubbed when dropped.
 
 use dashcore::hashes::{hash160, Hash};
-use dashcore::secp256k1::Secp256k1;
 use key_wallet::account::AccountType;
-use key_wallet::bip32::{ChildNumber, ExtendedPrivKey};
+use key_wallet::bip32::ChildNumber;
 use key_wallet::derivation_bls_bip32::ExtendedBLSPrivKey;
-use key_wallet::derivation_slip10::ExtendedEd25519PrivKey;
+use key_wallet::derivation_slip10::{ExtendedEd25519PrivKey, ExtendedEd25519PubKey};
 use zeroize::Zeroizing;
 
 use super::platform_wallet::PlatformWallet;
@@ -74,18 +105,21 @@ pub const PLATFORM_NODE_KEY_PREDERIVE_COUNT: u32 = 20;
 /// to snapshot the pool while the seed is available, because the
 /// platform-node curve is hardened-only and the pool can never be
 /// extended later from an external-signable / watch-only wallet. The
-/// derivation mirrors the private path in
-/// [`PlatformWallet::derive_provider_key_at_index`] exactly: account
-/// seed at the DIP-3 `ProviderPlatformKeys` path →
-/// [`ExtendedEd25519PrivKey::new_master`] → hardened child `i` → public
-/// key. Only the public parts leave this function — the account seed
-/// is wrapped in [`Zeroizing`] and scrubbed on drop.
+/// derivation is the canonical rust-dashcore #879 scheme — the wallet's
+/// **raw BIP39 seed** → [`ExtendedEd25519PrivKey`] master → DIP-3
+/// `ProviderPlatformKeys` account path → hardened child `i` → public key
+/// — composed from the upstream extended-key primitives directly (see the
+/// module docs on why the account's `is_watch_only`-gated
+/// `derive_from_seed_*` wrapper is avoided). It is byte-identical to what
+/// [`PlatformWallet::derive_provider_key_at_index`] and account creation
+/// produce. Only the public parts leave this function — the raw seed is
+/// wrapped in [`Zeroizing`] and scrubbed on drop.
 ///
 /// # Errors
-/// [`PlatformWalletError::KeyDerivation`] if the account path can't be
-/// built, the wallet has no resident private key to derive the account
-/// seed (i.e. it's already watch-only), or any per-index derivation
-/// fails.
+/// [`PlatformWalletError::AddressNotFound`] if the wallet has no
+/// platform-node account, or [`PlatformWalletError::KeyDerivation`] if
+/// there's no resident seed to derive from (i.e. it's already
+/// external-signable / watch-only) or any per-index derivation fails.
 pub fn derive_platform_node_public_keys(
     wallet: &key_wallet::wallet::Wallet,
     network: key_wallet::Network,
@@ -93,61 +127,69 @@ pub fn derive_platform_node_public_keys(
 ) -> Result<Vec<ProviderPlatformNodePubKey>, PlatformWalletError> {
     let account_type = AccountType::ProviderPlatformKeys;
 
-    // Account-level seed: the same secp256k1 secret bytes at the DIP-3
-    // `ProviderPlatformKeys` path that `Wallet::add_eddsa_account` feeds
-    // to `new_master`. Errors for a watch-only wallet with no resident
-    // private key — but at registration the wallet is still seed-bearing.
+    // Existence check — a missing platform-node account is a caller error,
+    // not a derivation failure (the account object itself isn't needed for
+    // the gate-free direct derivation below).
+    if wallet
+        .accounts
+        .eddsa_account_of_type(account_type)
+        .is_none()
+    {
+        return Err(PlatformWalletError::AddressNotFound(
+            "wallet has no Ed25519 provider-platform-keys account".to_string(),
+        ));
+    }
+
+    // Raw 64-byte BIP39 seed — the exact input `add_eddsa_account` feeds
+    // to `EdDSAAccount::from_seed`. `None` once the wallet has been
+    // downgraded to external-signable, but registration snapshots this
+    // while the wallet is still seed-bearing.
+    let seed: Zeroizing<[u8; 64]> =
+        Zeroizing::new(wallet.wallet_seed_bytes().ok_or_else(|| {
+            PlatformWalletError::KeyDerivation(
+                "wallet has no resident seed to pre-derive platform-node keys".to_string(),
+            )
+        })?);
+
+    // Raw seed → SLIP-10 master → DIP-3 account path (computed once).
     let account_path = account_type.derivation_path(network).map_err(|e| {
         PlatformWalletError::KeyDerivation(format!(
             "failed to build provider platform-node account path: {e}"
         ))
     })?;
-    let secret = wallet.derive_private_key(&account_path).map_err(|e| {
+    let master = ExtendedEd25519PrivKey::new_master(network, seed.as_ref()).map_err(|e| {
         PlatformWalletError::KeyDerivation(format!(
-            "failed to derive provider platform-node account seed at {account_path}: {e}"
+            "failed to build Ed25519 master from platform-node seed: {e}"
         ))
     })?;
-    let account_seed: Zeroizing<[u8; 32]> = Zeroizing::new(secret.secret_bytes());
-
-    let ed_master =
-        ExtendedEd25519PrivKey::new_master(network, account_seed.as_ref()).map_err(|e| {
-            PlatformWalletError::KeyDerivation(format!(
-                "failed to build Ed25519 master from platform-node seed: {e}"
-            ))
-        })?;
+    let account_xpriv = master.derive_priv(&account_path).map_err(|e| {
+        PlatformWalletError::KeyDerivation(format!(
+            "failed to derive Ed25519 platform-node account key at {account_path}: {e}"
+        ))
+    })?;
 
     let mut out = Vec::with_capacity(count as usize);
     for index in 0..count {
-        // SLIP-10 Ed25519 is hardened-only — the pool derives
-        // platform-node keys at a single hardened index
-        // (`AddressPoolType::AbsentHardened`).
+        // SLIP-10 Ed25519 is hardened-only — hardened child `i'`.
         let child = ChildNumber::from_hardened_idx(index).map_err(|e| {
             PlatformWalletError::KeyDerivation(format!(
                 "invalid platform-node key index {index}: {e}"
             ))
         })?;
-        let derived = ed_master.derive_priv(&[child]).map_err(|e| {
+        let xpriv = account_xpriv.derive_priv(&[child]).map_err(|e| {
             PlatformWalletError::KeyDerivation(format!(
                 "failed to derive Ed25519 platform-node key at index {index}: {e}"
             ))
         })?;
-        let verifying = derived.public_key().map_err(|e| {
+        let verifying = ExtendedEd25519PubKey::from_priv(&xpriv).map_err(|e| {
             PlatformWalletError::KeyDerivation(format!(
                 "failed to obtain Ed25519 public key at index {index}: {e}"
             ))
         })?;
-        // `to_bytes().to_vec()` is exactly how
-        // `derive_provider_key_at_index` materialises the 32-byte Ed25519
-        // public key; normalise into a fixed array for the display struct.
-        let public_key_bytes = verifying.to_bytes().to_vec();
-        let public_key: [u8; 32] = public_key_bytes.as_slice().try_into().map_err(|_| {
-            PlatformWalletError::KeyDerivation(format!(
-                "Ed25519 public key at index {index} was not 32 bytes"
-            ))
-        })?;
+        let public_key: [u8; 32] = verifying.public_key.to_bytes();
         // The 20-byte platform node id = hash160(ed25519 pubkey), the
         // value a ProRegTx `platform_node_id` matcher compares against.
-        let node_id: [u8; 20] = hash160::Hash::hash(&public_key_bytes).to_byte_array();
+        let node_id: [u8; 20] = hash160::Hash::hash(&public_key).to_byte_array();
         out.push(ProviderPlatformNodePubKey {
             index,
             public_key,
@@ -213,90 +255,79 @@ pub struct ProviderDerivedKey {
 impl PlatformWallet {
     /// Derive this wallet's provider key of `kind` at `index`.
     ///
-    /// Public-only when `resolved_master` is `None` and
-    /// `include_private` is `false` — but note the curve asymmetry
-    /// documented at the module level: a [`ProviderKeyKind::Operator`]
-    /// public key derives straight from the account xpub with no seed,
-    /// whereas a [`ProviderKeyKind::PlatformNode`] key (Ed25519, SLIP-10
-    /// hardened-only) always needs the account seed even for its public
-    /// key, so a watch-only wallet must supply `resolved_master` to list
-    /// platform-node keys at all.
+    /// Public-only when `resolved_seed` is `None` and `include_private`
+    /// is `false` — but note the curve asymmetry documented at the module
+    /// level: a [`ProviderKeyKind::Operator`] public key derives straight
+    /// from the account xpub with no seed, whereas a
+    /// [`ProviderKeyKind::PlatformNode`] key (Ed25519, SLIP-10
+    /// hardened-only) always needs the seed even for its public key, so a
+    /// watch-only wallet must supply `resolved_seed` to list platform-node
+    /// keys at all.
     ///
-    /// `resolved_master` selects the key source: `Some(master)` for
-    /// external-signable / watch-only wallets whose mnemonic the caller
-    /// resolved on demand; `None` to derive from a resident key-bearing
-    /// wallet. `include_private` additionally requests the raw private
-    /// scalar.
+    /// `resolved_seed` selects the key source: `Some(seed)` — the wallet's
+    /// **raw BIP39 seed** — for external-signable / watch-only wallets
+    /// whose mnemonic the caller resolved on demand; `None` to take a
+    /// resident key-bearing wallet's own
+    /// [`wallet_seed_bytes`](key_wallet::wallet::Wallet::wallet_seed_bytes).
+    /// `include_private` additionally requests the raw private scalar.
+    ///
+    /// The derivation delegates to the account's own
+    /// [`AccountDerivation`] routines (rust-dashcore #879) so every
+    /// per-index key is byte-identical to what `Wallet::from_mnemonic`
+    /// account creation produces; it never feeds a secp256k1 child scalar
+    /// into a BLS/Ed25519 master (the pre-#879 hybrid).
     ///
     /// # Errors
     /// - [`PlatformWalletError::AddressNotFound`] if this wallet has no
     ///   account of the requested kind.
     /// - [`PlatformWalletError::KeyDerivation`] if key derivation fails —
-    ///   including passing `None` for a watch-only wallet that has no
-    ///   resident private keys when a seed is required.
+    ///   including passing `None` for an external-signable / watch-only
+    ///   wallet that has no resident seed when one is required.
     pub fn derive_provider_key_at_index(
         &self,
         kind: ProviderKeyKind,
         index: u32,
-        resolved_master: Option<&ExtendedPrivKey>,
+        resolved_seed: Option<&[u8]>,
         include_private: bool,
     ) -> Result<ProviderDerivedKey, PlatformWalletError> {
         let network = self.network();
         let account_type = kind.account_type();
 
-        // Single read-lock: the account xpub read and the resident-key
-        // derive both borrow the in-process wallet from the same guard.
-        // No Swift callback runs under this guard — the mnemonic
-        // resolver (if any) already ran on the FFI side and produced
-        // `resolved_master` before we were called.
+        // Single read-lock: the account read and the resident-seed read
+        // both borrow the in-process wallet from the same guard. No Swift
+        // callback runs under this guard — the mnemonic resolver (if any)
+        // already ran on the FFI side and produced `resolved_seed` before
+        // we were called.
         let state = self.state_blocking();
 
-        // The account-level seed (32 secret bytes at the account's DIP-3
-        // path) is the input both curves' `new_master` consumes. Only
-        // compute it when a curve master is actually needed: an operator
-        // public listing derives straight from the account xpub, but an
-        // operator private reveal and *all* platform-node derivations
-        // (Ed25519/SLIP-10 is hardened-only) require it.
+        // Raw 64-byte BIP39 seed — the exact input the account's curve
+        // master consumes (#879). Only obtained when a seed-bearing path
+        // is actually needed: an operator public listing derives straight
+        // from the account xpub, but an operator private reveal and *all*
+        // platform-node derivations (Ed25519/SLIP-10 is hardened-only)
+        // require it.
         let need_seed = include_private || matches!(kind, ProviderKeyKind::PlatformNode);
 
-        let account_seed: Option<Zeroizing<[u8; 32]>> = if need_seed {
-            let account_path = account_type.derivation_path(network).map_err(|e| {
-                PlatformWalletError::KeyDerivation(format!(
-                    "failed to build provider account path for {account_type:?}: {e}"
-                ))
-            })?;
-            let seed = match resolved_master {
-                Some(master) => {
-                    // Same seed `Wallet::add_bls_account` /
-                    // `add_eddsa_account` derive: the account-level
-                    // secp256k1 private-key bytes at the DIP-3 path.
-                    let secp = Secp256k1::new();
-                    let derived = master.derive_priv(&secp, &account_path).map_err(|e| {
-                        PlatformWalletError::KeyDerivation(format!(
-                            "failed to derive provider account xpriv at {account_path}: {e}"
-                        ))
-                    })?;
-                    Zeroizing::new(derived.private_key.secret_bytes())
-                }
+        let seed: Option<Zeroizing<Vec<u8>>> = if need_seed {
+            let raw = match resolved_seed {
+                // Caller-resolved raw seed (external-signable / watch-only).
+                Some(seed) => Zeroizing::new(seed.to_vec()),
                 None => {
-                    // Resident key-bearing wallet — derive the account
-                    // seed from its own root. Errors here for a watch-only
-                    // / external-signable wallet (no resident private
-                    // key), which the caller must instead service with a
-                    // `resolved_master`.
-                    let secret = state
-                        .wallet()
-                        .derive_private_key(&account_path)
-                        .map_err(|e| {
-                            PlatformWalletError::KeyDerivation(format!(
-                                "failed to derive provider account key at {account_path} from \
-                                 resident wallet: {e}"
-                            ))
-                        })?;
-                    Zeroizing::new(secret.secret_bytes())
+                    // Resident key-bearing wallet — take its own raw BIP39
+                    // seed. `None` for a watch-only / external-signable
+                    // wallet (no resident seed), which the caller must
+                    // instead service with a `resolved_seed`.
+                    let raw = state.wallet().wallet_seed_bytes().ok_or_else(|| {
+                        PlatformWalletError::KeyDerivation(
+                            "wallet has no resident seed (external-signable / watch-only); a \
+                             resolved seed is required to derive this provider key"
+                                .to_string(),
+                        )
+                    })?;
+                    Zeroizing::new(raw.to_vec())
                 }
             };
-            Some(seed)
+            Some(raw)
         } else {
             None
         };
@@ -313,51 +344,67 @@ impl PlatformWallet {
                         )
                     })?;
 
-                // Non-hardened index — the pool's `AddressPoolType::Absent`.
+                // Non-hardened index — the operator pool's single
+                // `AddressPoolType::Absent` chain (`account/i`).
                 let child = ChildNumber::from_normal_idx(index).map_err(|e| {
                     PlatformWalletError::KeyDerivation(format!(
                         "invalid operator key index {index}: {e}"
                     ))
                 })?;
 
-                match account_seed {
-                    // Private reveal: rebuild the BLS master from the
-                    // account seed exactly as `Wallet::add_bls_account`
-                    // does, then derive the child.
+                match &seed {
+                    // Private reveal (or a caller that supplied a seed):
+                    // raw seed → BLS master → **legacy** DIP-3 account path →
+                    // non-hardened legacy child `index`. Composed from the
+                    // upstream primitives directly (the account's
+                    // `derive_from_seed_*` wrapper rejects a watch-only
+                    // account even with a seed in hand — see module docs),
+                    // yet byte-identical to it for a resident account.
                     Some(seed) => {
-                        let bls_master = ExtendedBLSPrivKey::new_master(network, seed.as_ref())
+                        let master = ExtendedBLSPrivKey::new_master(network, seed.as_ref())
                             .map_err(|e| {
                                 PlatformWalletError::KeyDerivation(format!(
                                     "failed to build BLS master from operator seed: {e}"
                                 ))
                             })?;
-                        let derived = bls_master.derive_priv(child).map_err(|e| {
+                        let account_path = account_type.derivation_path(network).map_err(|e| {
+                            PlatformWalletError::KeyDerivation(format!(
+                                "failed to build BLS operator account path: {e}"
+                            ))
+                        })?;
+                        let account_xpriv =
+                            master.derive_path_legacy(&account_path).map_err(|e| {
+                                PlatformWalletError::KeyDerivation(format!(
+                                    "failed to derive BLS operator account key at \
+                                     {account_path}: {e}"
+                                ))
+                            })?;
+                        let xpriv = account_xpriv.derive_priv_legacy(child).map_err(|e| {
                             PlatformWalletError::KeyDerivation(format!(
                                 "failed to derive BLS operator key at index {index}: {e}"
                             ))
                         })?;
-                        let public_key_bytes = derived.public_key_bytes().to_vec();
+                        let public_key_bytes = xpriv.public_key_bytes().to_vec();
                         // Same G1 point, Dash legacy serialization (key-wallet
                         // #879) — for the "BLS Public Key (Legacy)" display row.
                         let legacy_public_key_bytes =
-                            Some(derived.public_key_bytes_legacy().to_vec());
+                            Some(xpriv.public_key_bytes_legacy().to_vec());
 
-                        // The private-path public key must equal the
-                        // watch-only `ckd_pub` derivation the pool /
-                        // ProRegTx matcher use — proves the seed and the
-                        // BLS ckd are consistent.
-                        debug_assert_eq!(
-                            account
-                                .bls_public_key
-                                .derive_pub(child)
-                                .map(|p| p.to_bytes())
-                                .ok(),
-                            Some(derived.public_key_bytes()),
-                            "BLS priv-derived operator pubkey diverged from ckd_pub"
-                        );
+                        // The seed-derived public key must equal the public
+                        // (xpub, legacy `ckd_pub`) derivation — proves the
+                        // seed and the stored account xpub agree.
+                        #[cfg(debug_assertions)]
+                        if let Ok(xpub) = account.bls_public_key.derive_pub_legacy(child) {
+                            debug_assert_eq!(
+                                xpub.to_bytes(),
+                                xpriv.public_key_bytes(),
+                                "BLS operator seed-derived pubkey diverged from account-xpub \
+                                 derivation"
+                            );
+                        }
 
                         let private_key = include_private
-                            .then(|| Zeroizing::new(derived.private_key.to_be_bytes().to_vec()));
+                            .then(|| Zeroizing::new(xpriv.private_key.to_be_bytes().to_vec()));
 
                         Ok(ProviderDerivedKey {
                             index,
@@ -367,19 +414,26 @@ impl PlatformWallet {
                             private_key,
                         })
                     }
-                    // Public-only: non-hardened `ckd_pub` off the account
-                    // xpub — no seed / resolver needed for BLS.
+                    // Public-only: the account xpub's non-hardened **legacy**
+                    // `ckd_pub` child — no seed / resolver needed for BLS.
+                    // `derive_pub_legacy` is a pure public-key operation
+                    // (no `is_watch_only` gate), so it works for both
+                    // resident and restored (watch-only) accounts.
                     None => {
-                        let derived_pub =
-                            account.bls_public_key.derive_pub(child).map_err(|e| {
-                                PlatformWalletError::KeyDerivation(format!(
-                                "failed to derive BLS operator public key at index {index}: {e}"
-                            ))
-                            })?;
+                        let xpub =
+                            account
+                                .bls_public_key
+                                .derive_pub_legacy(child)
+                                .map_err(|e| {
+                                    PlatformWalletError::KeyDerivation(format!(
+                                        "failed to derive BLS operator public key at index \
+                                     {index}: {e}"
+                                    ))
+                                })?;
                         // Serialize the same G1 point both ways: modern/IETF
                         // and Dash legacy (key-wallet #879).
-                        let public_key_bytes = derived_pub.to_bytes().to_vec();
-                        let legacy_public_key_bytes = Some(derived_pub.to_bytes_legacy().to_vec());
+                        let public_key_bytes = xpub.to_bytes().to_vec();
+                        let legacy_public_key_bytes = Some(xpub.to_bytes_legacy().to_vec());
                         Ok(ProviderDerivedKey {
                             index,
                             public_key_bytes,
@@ -392,8 +446,8 @@ impl PlatformWallet {
             }
             ProviderKeyKind::PlatformNode => {
                 // Existence check — a missing account is a caller error,
-                // not a derivation failure. (The stored xpub itself is
-                // only needed for the debug cross-check below.)
+                // not a derivation failure (the account object itself isn't
+                // needed for the gate-free direct derivation below).
                 if state
                     .wallet()
                     .accounts
@@ -406,51 +460,49 @@ impl PlatformWallet {
                 }
 
                 // `need_seed` is always true for this kind.
-                let seed = account_seed.expect("platform-node derivation always seeds");
+                let seed = seed
+                    .as_ref()
+                    .expect("platform-node derivation always seeds");
 
-                let ed_master = ExtendedEd25519PrivKey::new_master(network, seed.as_ref())
-                    .map_err(|e| {
+                // Canonical raw-seed derivation via the upstream primitives
+                // directly (the account's `derive_from_seed_*` wrapper
+                // rejects a watch-only account even with a seed — see module
+                // docs): raw seed → SLIP-10 master → DIP-3 account path →
+                // hardened child `index`. Byte-identical to what
+                // `Wallet::from_mnemonic` account creation and
+                // `derive_platform_node_public_keys` produce.
+                let account_path = account_type.derivation_path(network).map_err(|e| {
+                    PlatformWalletError::KeyDerivation(format!(
+                        "failed to build provider platform-node account path: {e}"
+                    ))
+                })?;
+                let master =
+                    ExtendedEd25519PrivKey::new_master(network, seed.as_ref()).map_err(|e| {
                         PlatformWalletError::KeyDerivation(format!(
                             "failed to build Ed25519 master from platform-node seed: {e}"
                         ))
                     })?;
-
-                // In debug, confirm the seed reproduces the stored
-                // account xpub (proves the DIP-3 account path is right).
-                #[cfg(debug_assertions)]
-                {
-                    use key_wallet::derivation_slip10::ExtendedEd25519PubKey;
-                    if let (Ok(acct_pub), Some(account)) = (
-                        ExtendedEd25519PubKey::from_priv(&ed_master),
-                        state.wallet().accounts.eddsa_account_of_type(account_type),
-                    ) {
-                        debug_assert_eq!(
-                            acct_pub.public_key.to_bytes(),
-                            account.ed25519_public_key.public_key.to_bytes(),
-                            "Ed25519 account seed diverged from stored account xpub"
-                        );
-                    }
-                }
-
-                // SLIP-10 Ed25519 is hardened-only; the pool derives
-                // platform-node keys at a single hardened index
-                // (`AddressPoolType::AbsentHardened`).
+                let account_xpriv = master.derive_priv(&account_path).map_err(|e| {
+                    PlatformWalletError::KeyDerivation(format!(
+                        "failed to derive Ed25519 platform-node account key at {account_path}: {e}"
+                    ))
+                })?;
                 let child = ChildNumber::from_hardened_idx(index).map_err(|e| {
                     PlatformWalletError::KeyDerivation(format!(
                         "invalid platform-node key index {index}: {e}"
                     ))
                 })?;
-                let derived = ed_master.derive_priv(&[child]).map_err(|e| {
+                let xpriv = account_xpriv.derive_priv(&[child]).map_err(|e| {
                     PlatformWalletError::KeyDerivation(format!(
                         "failed to derive Ed25519 platform-node key at index {index}: {e}"
                     ))
                 })?;
-                let verifying = derived.public_key().map_err(|e| {
+                let verifying = ExtendedEd25519PubKey::from_priv(&xpriv).map_err(|e| {
                     PlatformWalletError::KeyDerivation(format!(
                         "failed to obtain Ed25519 public key at index {index}: {e}"
                     ))
                 })?;
-                let public_key_bytes = verifying.to_bytes().to_vec();
+                let public_key_bytes = verifying.public_key.to_bytes().to_vec();
 
                 // The 20-byte platform node id = hash160(ed25519 pubkey),
                 // exactly what the ProRegTx `platform_node_id` matcher
@@ -458,7 +510,7 @@ impl PlatformWallet {
                 let node_id: [u8; 20] = hash160::Hash::hash(&public_key_bytes).to_byte_array();
 
                 let private_key =
-                    include_private.then(|| Zeroizing::new(derived.private_key.to_vec()));
+                    include_private.then(|| Zeroizing::new(xpriv.private_key.to_vec()));
 
                 Ok(ProviderDerivedKey {
                     index,
@@ -476,7 +528,11 @@ impl PlatformWallet {
 #[cfg(test)]
 mod tests {
     use super::*;
+    // The upstream account wrappers (`derive_from_seed_*`) are used ONLY in
+    // tests, as an independent cross-check that the module's gate-free
+    // primitives match upstream for a resident (non-watch-only) account.
     use dashcore::hashes::{hash160, Hash};
+    use key_wallet::account::derivation::AccountDerivation;
     use key_wallet::mnemonic::{Language, Mnemonic};
     use key_wallet::wallet::initialization::WalletAccountCreationOptions;
     use key_wallet::wallet::Wallet;
@@ -494,14 +550,23 @@ mod tests {
             .expect("wallet construction")
     }
 
-    /// The two load-bearing invariants for platform-node keys, pinned so an
-    /// upstream SLIP-10 / DIP-9 derivation regression can't silently hand
-    /// out wrong key material: `node_id == hash160(pubkey)` at every index,
-    /// and a stable golden pubkey/node-id for index 0 on testnet.
+    /// The load-bearing invariants for platform-node keys, pinned so a
+    /// derivation regression (like the pre-#879 secp256k1 hybrid) can't
+    /// silently hand out wrong key material: `node_id == hash160(pubkey)`
+    /// at every index, all indices distinct, our wrapper's per-index key
+    /// equals the account's own canonical seed derivation, and a golden
+    /// secret scalar pinned to the dashbls/SLIP-10 reference vector from
+    /// key-wallet's `provider_key_derivation_tests.rs`.
     #[test]
     fn platform_node_keys_are_consistent_and_pinned() {
-        let wallet = seed_bearing_wallet(Network::Testnet);
-        let keys = derive_platform_node_public_keys(&wallet, Network::Testnet, 20)
+        let wallet = seed_bearing_wallet(Network::Mainnet);
+        let seed = wallet.wallet_seed_bytes().expect("resident seed");
+        let account = wallet
+            .accounts
+            .eddsa_account_of_type(AccountType::ProviderPlatformKeys)
+            .expect("platform-node account");
+
+        let keys = derive_platform_node_public_keys(&wallet, Network::Mainnet, 20)
             .expect("platform-node derivation");
 
         assert_eq!(keys.len(), 20, "requested 20 keys");
@@ -512,6 +577,22 @@ mod tests {
                 k.node_id, expected_node_id,
                 "node_id must be hash160(ed25519 pubkey) at index {i}"
             );
+
+            // Cross-path: the registration wrapper's per-index key must be
+            // byte-identical to the account's own canonical raw-seed
+            // derivation — the same routine `derive_provider_key_at_index`
+            // and `Wallet::from_mnemonic` account creation use.
+            let up_xpriv = account
+                .derive_from_seed_extended_xpriv_at(&seed, i as u32)
+                .expect("account seed derivation");
+            let up_pub = ExtendedEd25519PubKey::from_priv(&up_xpriv)
+                .expect("ed25519 pub")
+                .public_key
+                .to_bytes();
+            assert_eq!(
+                k.public_key, up_pub,
+                "wrapper pubkey must equal the account's canonical derivation at {i}"
+            );
         }
 
         // All indices produce distinct keys (hardened SLIP-10 children).
@@ -520,18 +601,138 @@ mod tests {
         pubs.dedup();
         assert_eq!(pubs.len(), 20, "all 20 platform-node keys must be distinct");
 
-        // Golden vector — regenerating the same mnemonic must reproduce
-        // these exact bytes. A break here means the derivation path or an
-        // upstream crate changed.
+        // Golden vector — mainnet platform-node key 0 secret scalar
+        // (`m/9'/5'/3'/4'/0'`), pinned to the SLIP-10 reference in
+        // key-wallet `provider_key_derivation_tests.rs`. This is the value
+        // DashSync/dashwallet-ios produce; a break means our derivation
+        // diverged from the reference.
+        let sk0 = account
+            .derive_from_seed_private_key_at(&seed, 0)
+            .expect("platform-node sk derivation");
         assert_eq!(
-            hex::encode(keys[0].public_key),
-            "fb91ae39aba2a1b8f68016833bfcfcec8516d634237f5842a21b03c225e2b092",
-            "platform-node index-0 pubkey golden vector"
+            hex::encode(sk0.to_bytes()),
+            "5fa238b12be77347abf9b5957bd902d16c6aaca28d25c4267ffacbd7458dceb1",
+            "mainnet platform-node index-0 secret golden (dashbls/SLIP-10 reference)"
+        );
+    }
+
+    /// Operator (BLS) keys pinned to the dashbls reference vectors from
+    /// key-wallet `provider_key_derivation_tests.rs` — the values
+    /// DashSync/dashwallet-ios produce — on both networks. Exercises BOTH
+    /// derivation paths this module actually uses: the public branch's
+    /// `ExtendedBLSPubKey::derive_pub_legacy` (gate-free) and the private
+    /// branch's gate-free primitive composition, cross-checked against
+    /// each other, the account's own wrapper, and the golden vectors. This
+    /// is the exact key the user reported as mismatched; the pre-#879
+    /// secp256k1 hybrid produced a different point here, and the account's
+    /// `derive_bls_key_at_index` wrapper can't derive it from a resident
+    /// (non-watch-only) account at all.
+    #[test]
+    fn operator_keys_match_dashbls_reference_and_cross_check() {
+        // --- Mainnet (`m/9'/5'/3'/3'/0`) ---
+        let wallet = seed_bearing_wallet(Network::Mainnet);
+        let seed = wallet.wallet_seed_bytes().expect("resident seed");
+        let account = wallet
+            .accounts
+            .bls_account_of_type(AccountType::ProviderOperatorKeys)
+            .expect("operator account");
+
+        // Public-only path (exactly what `derive_provider_key_at_index`
+        // does for the seedless branch): the account xpub's non-hardened
+        // **legacy** `ckd_pub`. `derive_pub_legacy` is gate-free, so it
+        // works on this resident (non-watch-only) account too.
+        let child0 = ChildNumber::from_normal_idx(0).expect("child 0");
+        let xpub0 = account
+            .bls_public_key
+            .derive_pub_legacy(child0)
+            .expect("operator public derivation");
+        assert_eq!(
+            hex::encode(xpub0.to_bytes_legacy()),
+            "078cad04aae29eb76171937eb7101452b401b026efbc27db840f130374e6a9ec8443d917277f8921e0ba6678a7709875",
+            "operator key0 legacy pubkey golden (dashbls reference)"
+        );
+        // Modern/IETF (basic-scheme) serialization, verbatim from the
+        // upstream reference test.
+        assert_eq!(
+            hex::encode(xpub0.to_bytes()),
+            "878cad04aae29eb76171937eb7101452b401b026efbc27db840f130374e6a9ec8443d917277f8921e0ba6678a7709875",
+            "operator key0 modern pubkey golden (dashbls reference)"
+        );
+
+        // Private (seed) path composed from the SAME gate-free primitives
+        // `derive_provider_key_at_index` uses: raw seed → BLS master →
+        // legacy account path → non-hardened legacy child.
+        let account_path = AccountType::ProviderOperatorKeys
+            .derivation_path(Network::Mainnet)
+            .expect("account path");
+        let master = ExtendedBLSPrivKey::new_master(Network::Mainnet, &seed).expect("bls master");
+        let xpriv0 = master
+            .derive_path_legacy(&account_path)
+            .expect("account xpriv")
+            .derive_priv_legacy(child0)
+            .expect("child xpriv");
+        assert_eq!(
+            xpriv0.public_key_bytes(),
+            xpub0.to_bytes(),
+            "gate-free seed-derived operator pubkey must equal the public derivation"
         );
         assert_eq!(
-            hex::encode(keys[0].node_id),
-            "bb241cb734e78cfc8c537226322b1492d0458678",
-            "platform-node index-0 node-id golden vector"
+            xpriv0.public_key_bytes_legacy(),
+            xpub0.to_bytes_legacy(),
+            "gate-free seed-derived operator legacy pubkey must equal the public derivation"
+        );
+        assert_eq!(
+            hex::encode(xpriv0.private_key.to_be_bytes()),
+            "11122e1ad656d0610ce0f80d40da874d67ea656a3e66ed371c915ec3a488a43a",
+            "operator key0 secret golden (dashbls reference)"
+        );
+
+        // The gate-free composition must equal the account's own wrapper
+        // for this resident (non-watch-only) account — proving they agree
+        // where the wrapper is usable.
+        let via_wrapper = account
+            .derive_from_seed_extended_xpriv_at(&seed, 0)
+            .expect("wrapper seed derivation");
+        assert_eq!(
+            via_wrapper.public_key_bytes(),
+            xpriv0.public_key_bytes(),
+            "gate-free primitives must match the account's derive_from_seed_* wrapper"
+        );
+
+        // --- Testnet (`m/9'/1'/3'/3'/0`) ---
+        let wallet_t = seed_bearing_wallet(Network::Testnet);
+        let account_t = wallet_t
+            .accounts
+            .bls_account_of_type(AccountType::ProviderOperatorKeys)
+            .expect("operator account");
+        let xpub0_t = account_t
+            .bls_public_key
+            .derive_pub_legacy(child0)
+            .expect("operator public derivation");
+        assert_eq!(
+            hex::encode(xpub0_t.to_bytes_legacy()),
+            "09d8beabae708de1638487f1aff44b38e8c07d9b09f22d76329d6c8ec01e2ad4d030b660bca40ddbd222373a72c5bcef",
+            "testnet operator key0 legacy pubkey golden (dashbls reference)"
+        );
+        let seed_t = wallet_t.wallet_seed_bytes().expect("resident seed");
+        let account_path_t = AccountType::ProviderOperatorKeys
+            .derivation_path(Network::Testnet)
+            .expect("account path");
+        let xpriv0_t = ExtendedBLSPrivKey::new_master(Network::Testnet, &seed_t)
+            .expect("bls master")
+            .derive_path_legacy(&account_path_t)
+            .expect("account xpriv")
+            .derive_priv_legacy(child0)
+            .expect("child xpriv");
+        assert_eq!(
+            xpriv0_t.public_key_bytes_legacy(),
+            xpub0_t.to_bytes_legacy(),
+            "testnet gate-free operator legacy pubkey must equal the public derivation"
+        );
+        assert_eq!(
+            hex::encode(xpriv0_t.private_key.to_be_bytes()),
+            "3346dfd71627f9f31cad3ee66fe7b673c32cb077b2eb38c621d7e61c30e46dbd",
+            "testnet operator key0 secret golden (dashbls reference)"
         );
     }
 

--- a/packages/rs-platform-wallet/src/wallet/provider_key_at_index.rs
+++ b/packages/rs-platform-wallet/src/wallet/provider_key_at_index.rs
@@ -183,10 +183,20 @@ impl ProviderKeyKind {
 pub struct ProviderDerivedKey {
     /// The key index within the provider pool (`#0..`).
     pub index: u32,
-    /// Raw curve public key bytes: 48 for a BLS operator key (this is
-    /// exactly the bytes a ProRegTx `operator_public_key` field
-    /// carries), 32 for an Ed25519 platform-node key.
+    /// Raw curve public key bytes in the MODERN (IETF) serialization: 48
+    /// for a BLS operator key (this is exactly the bytes a ProRegTx
+    /// `operator_public_key` field carries), 32 for an Ed25519
+    /// platform-node key.
     pub public_key_bytes: Vec<u8>,
+    /// The SAME BLS G1 point serialized in the Dash **legacy** scheme (48
+    /// bytes; same point, legacy flag bits in `byte[0]`) — the form
+    /// dashbls/DashSync use across the BLS HD chain. `Some` only for
+    /// operator (BLS) keys; `None` for Ed25519 platform-node keys, which
+    /// have no legacy variant. Produced Rust-side via
+    /// `ExtendedBLSPubKey::to_bytes_legacy` / `ExtendedBLSPrivKey::
+    /// public_key_bytes_legacy` (key-wallet #879) — never transformed in
+    /// Swift.
+    pub legacy_public_key_bytes: Option<Vec<u8>>,
     /// The 20-byte platform node id — `hash160` of the Ed25519 public
     /// key, the value a ProRegTx `platform_node_id` field carries and
     /// the [`Payload::PubkeyHash`](dashcore::address::Payload) the pool
@@ -327,6 +337,10 @@ impl PlatformWallet {
                             ))
                         })?;
                         let public_key_bytes = derived.public_key_bytes().to_vec();
+                        // Same G1 point, Dash legacy serialization (key-wallet
+                        // #879) — for the "BLS Public Key (Legacy)" display row.
+                        let legacy_public_key_bytes =
+                            Some(derived.public_key_bytes_legacy().to_vec());
 
                         // The private-path public key must equal the
                         // watch-only `ckd_pub` derivation the pool /
@@ -348,6 +362,7 @@ impl PlatformWallet {
                         Ok(ProviderDerivedKey {
                             index,
                             public_key_bytes,
+                            legacy_public_key_bytes,
                             node_id: None,
                             private_key,
                         })
@@ -355,20 +370,20 @@ impl PlatformWallet {
                     // Public-only: non-hardened `ckd_pub` off the account
                     // xpub — no seed / resolver needed for BLS.
                     None => {
-                        let public_key_bytes = account
-                            .bls_public_key
-                            .derive_pub(child)
-                            .map_err(|e| {
+                        let derived_pub =
+                            account.bls_public_key.derive_pub(child).map_err(|e| {
                                 PlatformWalletError::KeyDerivation(format!(
-                                    "failed to derive BLS operator public key at index \
-                                     {index}: {e}"
-                                ))
-                            })?
-                            .to_bytes()
-                            .to_vec();
+                                "failed to derive BLS operator public key at index {index}: {e}"
+                            ))
+                            })?;
+                        // Serialize the same G1 point both ways: modern/IETF
+                        // and Dash legacy (key-wallet #879).
+                        let public_key_bytes = derived_pub.to_bytes().to_vec();
+                        let legacy_public_key_bytes = Some(derived_pub.to_bytes_legacy().to_vec());
                         Ok(ProviderDerivedKey {
                             index,
                             public_key_bytes,
+                            legacy_public_key_bytes,
                             node_id: None,
                             private_key: None,
                         })
@@ -448,6 +463,8 @@ impl PlatformWallet {
                 Ok(ProviderDerivedKey {
                     index,
                     public_key_bytes,
+                    // Ed25519 platform-node keys have no BLS legacy variant.
+                    legacy_public_key_bytes: None,
                     node_id: Some(node_id),
                     private_key,
                 })

--- a/packages/rs-platform-wallet/src/wallet/provider_key_at_index.rs
+++ b/packages/rs-platform-wallet/src/wallet/provider_key_at_index.rs
@@ -73,7 +73,6 @@
 //! The seed and any returned scalar are wrapped in [`Zeroizing`] so they
 //! are scrubbed when dropped.
 
-use dashcore::hashes::{hash160, Hash};
 use key_wallet::account::{AccountType, BLSAccount, EdDSAAccount};
 use zeroize::Zeroizing;
 
@@ -94,8 +93,8 @@ pub const PLATFORM_NODE_KEY_PREDERIVE_COUNT: u32 = 20;
 
 /// Derive the first `count` platform-node (Ed25519) public keys from a
 /// **seed-bearing** [`Wallet`](key_wallet::wallet::Wallet), returning
-/// the 32-byte public key + 20-byte `hash160` node id per hardened
-/// index.
+/// the 32-byte public key + 20-byte Tenderdash node id
+/// (`SHA256(pubkey)[..20]`, #884) per hardened index.
 ///
 /// Used at registration (`PlatformWalletManager::register_wallet`)
 /// to snapshot the pool while the seed is available, because the
@@ -153,9 +152,11 @@ pub fn derive_platform_node_public_keys(
                 ))
             })?;
         let public_key: [u8; 32] = signing_key.verifying_key().to_bytes();
-        // The 20-byte platform node id = hash160(ed25519 pubkey), the
-        // value a ProRegTx `platform_node_id` matcher compares against.
-        let node_id: [u8; 20] = hash160::Hash::hash(&public_key).to_byte_array();
+        // The 20-byte platform node id = SHA256(ed25519 pubkey)[..20] — the
+        // Tenderdash/CometBFT convention (rust-dashcore #884) that a ProRegTx
+        // `platform_node_id` field carries, NOT a hash160.
+        let node_id: [u8; 20] =
+            dashcore::PlatformNodeId::from_ed25519_public_key(&public_key).to_byte_array();
         out.push(ProviderPlatformNodePubKey {
             index,
             public_key,
@@ -204,10 +205,10 @@ pub struct ProviderDerivedKey {
     /// `ExtendedBLSPubKey::to_bytes_legacy` (key-wallet #879) — never
     /// transformed in Swift.
     pub legacy_public_key_bytes: Option<Vec<u8>>,
-    /// The 20-byte platform node id — `hash160` of the Ed25519 public
-    /// key, the value a ProRegTx `platform_node_id` field carries and
-    /// the [`Payload::PubkeyHash`](dashcore::address::Payload) the pool
-    /// matcher compares against. `Some` for [`ProviderKeyKind::PlatformNode`];
+    /// The 20-byte platform node id — `SHA256(ed25519 pubkey)[..20]`, the
+    /// Tenderdash/CometBFT convention (rust-dashcore #884), which the
+    /// ProRegTx `platform_node_id` field carries and the pool matcher
+    /// compares against. `Some` for [`ProviderKeyKind::PlatformNode`];
     /// `None` for [`ProviderKeyKind::Operator`] (whose on-chain field is
     /// the raw 48-byte BLS public key, not a hash).
     pub node_id: Option<[u8; 20]>,
@@ -415,12 +416,15 @@ impl PlatformWallet {
                             "failed to derive Ed25519 platform-node key at index {index}: {e}"
                         ))
                     })?;
-                let public_key_bytes = signing_key.verifying_key().to_bytes().to_vec();
+                let verifying_bytes: [u8; 32] = signing_key.verifying_key().to_bytes();
+                let public_key_bytes = verifying_bytes.to_vec();
 
-                // The 20-byte platform node id = hash160(ed25519 pubkey),
-                // exactly what the ProRegTx `platform_node_id` matcher
-                // compares against (`Payload::PubkeyHash`).
-                let node_id: [u8; 20] = hash160::Hash::hash(&public_key_bytes).to_byte_array();
+                // The 20-byte platform node id = SHA256(ed25519 pubkey)[..20]
+                // — the Tenderdash/CometBFT convention (rust-dashcore #884)
+                // the ProRegTx `platform_node_id` field carries, NOT a hash160.
+                let node_id: [u8; 20] =
+                    dashcore::PlatformNodeId::from_ed25519_public_key(&verifying_bytes)
+                        .to_byte_array();
 
                 let private_key =
                     include_private.then(|| Zeroizing::new(signing_key.to_bytes().to_vec()));
@@ -441,7 +445,6 @@ impl PlatformWallet {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use dashcore::hashes::{hash160, Hash};
     use key_wallet::mnemonic::{Language, Mnemonic};
     use key_wallet::wallet::initialization::WalletAccountCreationOptions;
     use key_wallet::wallet::Wallet;
@@ -474,10 +477,10 @@ mod tests {
 
     /// The load-bearing invariants for platform-node keys, pinned so a
     /// derivation regression can't silently hand out wrong key material:
-    /// `node_id == hash160(pubkey)` at every index, all indices distinct,
-    /// the snapshot's per-index public key corresponds to the #881 seed
-    /// entry point, and a golden secret scalar pinned to the dashbls /
-    /// SLIP-10 reference vector from key-wallet's
+    /// `node_id == SHA256(pubkey)[..20]` (the Tenderdash convention,
+    /// rust-dashcore #884) at every index, all indices distinct, the
+    /// snapshot's per-index public key corresponds to the #881 seed entry
+    /// point, and golden secret / node-id vectors pinned to key-wallet's
     /// `provider_key_derivation_tests.rs`.
     #[test]
     fn platform_node_keys_are_consistent_and_pinned() {
@@ -490,10 +493,11 @@ mod tests {
         assert_eq!(keys.len(), 20, "requested 20 keys");
         for (i, k) in keys.iter().enumerate() {
             assert_eq!(k.index, i as u32, "index ordering");
-            let expected_node_id: [u8; 20] = hash160::Hash::hash(&k.public_key).to_byte_array();
+            let expected_node_id: [u8; 20] =
+                dashcore::PlatformNodeId::from_ed25519_public_key(&k.public_key).to_byte_array();
             assert_eq!(
                 k.node_id, expected_node_id,
-                "node_id must be hash160(ed25519 pubkey) at index {i}"
+                "node_id must be SHA256(ed25519 pubkey)[..20] at index {i}"
             );
 
             // The snapshot's per-index public key must be the public key of
@@ -531,6 +535,19 @@ mod tests {
             keys[0].public_key,
             sk0.verifying_key().to_bytes(),
             "snapshot index-0 pubkey must match the golden secret's public key"
+        );
+        // Golden pubkey + Tenderdash node-id (SHA256[..20]) for mainnet
+        // index 0, pinned to key-wallet's post-#884
+        // `provider_key_derivation_tests.rs` reference vectors.
+        assert_eq!(
+            hex::encode(keys[0].public_key),
+            "3130c14339391cf26a68d86879e180ee9a16b660f5aa91f560f67c0abe8cf789",
+            "mainnet platform-node index-0 pubkey golden"
+        );
+        assert_eq!(
+            hex::encode(keys[0].node_id),
+            "302f2615e6955cce8ed3cff81e8011bfd3a2991f",
+            "mainnet platform-node index-0 node-id golden (Tenderdash SHA256[..20], #884)"
         );
     }
 

--- a/packages/rs-platform-wallet/src/wallet/provider_key_at_index.rs
+++ b/packages/rs-platform-wallet/src/wallet/provider_key_at_index.rs
@@ -96,6 +96,56 @@ use crate::error::PlatformWalletError;
 /// screen has a full first page to show from persistence alone.
 pub const PLATFORM_NODE_KEY_PREDERIVE_COUNT: u32 = 20;
 
+/// Derive the platform-node (Ed25519) extended private key at `index`
+/// from the raw BIP39 `seed`: SLIP-10 master → DIP-3
+/// `ProviderPlatformKeys` account path → hardened child `index'`.
+///
+/// The single canonical platform-node private derivation, shared by
+/// [`derive_platform_node_public_keys`] (the registration snapshot) and
+/// [`PlatformWallet::derive_provider_key_at_index`] (the per-index
+/// reveal) so the two can never diverge — the same anti-duplication
+/// rationale as the rest of this module. Composed from the upstream
+/// extended-key primitives directly (gate-free; see the module docs on
+/// why the account's `is_watch_only`-gated `derive_from_seed_*` wrapper
+/// is avoided).
+///
+/// # Errors
+/// [`PlatformWalletError::KeyDerivation`] if the account path can't be
+/// built, the SLIP-10 master / account key can't be derived, or the
+/// per-index child derivation fails.
+fn platform_node_xpriv_at(
+    seed: &[u8],
+    network: key_wallet::Network,
+    index: u32,
+) -> Result<ExtendedEd25519PrivKey, PlatformWalletError> {
+    let account_path = AccountType::ProviderPlatformKeys
+        .derivation_path(network)
+        .map_err(|e| {
+            PlatformWalletError::KeyDerivation(format!(
+                "failed to build provider platform-node account path: {e}"
+            ))
+        })?;
+    let master = ExtendedEd25519PrivKey::new_master(network, seed).map_err(|e| {
+        PlatformWalletError::KeyDerivation(format!(
+            "failed to build Ed25519 master from platform-node seed: {e}"
+        ))
+    })?;
+    let account_xpriv = master.derive_priv(&account_path).map_err(|e| {
+        PlatformWalletError::KeyDerivation(format!(
+            "failed to derive Ed25519 platform-node account key at {account_path}: {e}"
+        ))
+    })?;
+    // SLIP-10 Ed25519 is hardened-only — hardened child `index'`.
+    let child = ChildNumber::from_hardened_idx(index).map_err(|e| {
+        PlatformWalletError::KeyDerivation(format!("invalid platform-node key index {index}: {e}"))
+    })?;
+    account_xpriv.derive_priv(&[child]).map_err(|e| {
+        PlatformWalletError::KeyDerivation(format!(
+            "failed to derive Ed25519 platform-node key at index {index}: {e}"
+        ))
+    })
+}
+
 /// Derive the first `count` platform-node (Ed25519) public keys from a
 /// **seed-bearing** [`Wallet`](key_wallet::wallet::Wallet), returning
 /// the 32-byte public key + 20-byte `hash160` node id per hardened
@@ -151,36 +201,9 @@ pub fn derive_platform_node_public_keys(
             )
         })?);
 
-    // Raw seed → SLIP-10 master → DIP-3 account path (computed once).
-    let account_path = account_type.derivation_path(network).map_err(|e| {
-        PlatformWalletError::KeyDerivation(format!(
-            "failed to build provider platform-node account path: {e}"
-        ))
-    })?;
-    let master = ExtendedEd25519PrivKey::new_master(network, seed.as_ref()).map_err(|e| {
-        PlatformWalletError::KeyDerivation(format!(
-            "failed to build Ed25519 master from platform-node seed: {e}"
-        ))
-    })?;
-    let account_xpriv = master.derive_priv(&account_path).map_err(|e| {
-        PlatformWalletError::KeyDerivation(format!(
-            "failed to derive Ed25519 platform-node account key at {account_path}: {e}"
-        ))
-    })?;
-
     let mut out = Vec::with_capacity(count as usize);
     for index in 0..count {
-        // SLIP-10 Ed25519 is hardened-only — hardened child `i'`.
-        let child = ChildNumber::from_hardened_idx(index).map_err(|e| {
-            PlatformWalletError::KeyDerivation(format!(
-                "invalid platform-node key index {index}: {e}"
-            ))
-        })?;
-        let xpriv = account_xpriv.derive_priv(&[child]).map_err(|e| {
-            PlatformWalletError::KeyDerivation(format!(
-                "failed to derive Ed25519 platform-node key at index {index}: {e}"
-            ))
-        })?;
+        let xpriv = platform_node_xpriv_at(seed.as_ref(), network, index)?;
         let verifying = ExtendedEd25519PubKey::from_priv(&xpriv).map_err(|e| {
             PlatformWalletError::KeyDerivation(format!(
                 "failed to obtain Ed25519 public key at index {index}: {e}"
@@ -390,17 +413,40 @@ impl PlatformWallet {
                         let legacy_public_key_bytes =
                             Some(xpriv.public_key_bytes_legacy().to_vec());
 
-                        // The seed-derived public key must equal the public
-                        // (xpub, legacy `ckd_pub`) derivation — proves the
-                        // seed and the stored account xpub agree.
-                        #[cfg(debug_assertions)]
-                        if let Ok(xpub) = account.bls_public_key.derive_pub_legacy(child) {
-                            debug_assert_eq!(
-                                xpub.to_bytes(),
-                                xpriv.public_key_bytes(),
-                                "BLS operator seed-derived pubkey diverged from account-xpub \
-                                 derivation"
-                            );
+                        // Always-on guard: the seed-derived public key MUST
+                        // equal the account xpub's non-hardened legacy
+                        // `ckd_pub` child. A mismatch means the wallet seed
+                        // and its stored operator account xpub disagree
+                        // (wrong seed / stale xpub) — exactly the failure
+                        // this PR fixed — so refuse to hand out a mismatched
+                        // key. `derive_pub_legacy` is a gate-free pure public
+                        // operation (works for resident and watch-only
+                        // accounts alike), and the extra derivation on the
+                        // private-reveal path is negligible. If that public
+                        // derivation itself can't be performed we log and
+                        // proceed rather than fail: the private derivation
+                        // already succeeded, so a valid key is in hand and
+                        // failing here would only turn a working path into a
+                        // spurious error.
+                        match account.bls_public_key.derive_pub_legacy(child) {
+                            Ok(xpub) => {
+                                if xpub.to_bytes() != xpriv.public_key_bytes() {
+                                    return Err(PlatformWalletError::KeyDerivation(format!(
+                                        "BLS operator key at index {index}: seed-derived public \
+                                         key does not match the account xpub derivation — the \
+                                         wallet seed and its stored operator account xpub \
+                                         disagree; refusing to return a mismatched key"
+                                    )));
+                                }
+                            }
+                            Err(e) => {
+                                tracing::warn!(
+                                    index,
+                                    error = %e,
+                                    "BLS operator seed/xpub cross-check skipped: account xpub \
+                                     public derivation failed"
+                                );
+                            }
                         }
 
                         let private_key = include_private
@@ -464,39 +510,13 @@ impl PlatformWallet {
                     .as_ref()
                     .expect("platform-node derivation always seeds");
 
-                // Canonical raw-seed derivation via the upstream primitives
-                // directly (the account's `derive_from_seed_*` wrapper
-                // rejects a watch-only account even with a seed — see module
-                // docs): raw seed → SLIP-10 master → DIP-3 account path →
-                // hardened child `index`. Byte-identical to what
-                // `Wallet::from_mnemonic` account creation and
-                // `derive_platform_node_public_keys` produce.
-                let account_path = account_type.derivation_path(network).map_err(|e| {
-                    PlatformWalletError::KeyDerivation(format!(
-                        "failed to build provider platform-node account path: {e}"
-                    ))
-                })?;
-                let master =
-                    ExtendedEd25519PrivKey::new_master(network, seed.as_ref()).map_err(|e| {
-                        PlatformWalletError::KeyDerivation(format!(
-                            "failed to build Ed25519 master from platform-node seed: {e}"
-                        ))
-                    })?;
-                let account_xpriv = master.derive_priv(&account_path).map_err(|e| {
-                    PlatformWalletError::KeyDerivation(format!(
-                        "failed to derive Ed25519 platform-node account key at {account_path}: {e}"
-                    ))
-                })?;
-                let child = ChildNumber::from_hardened_idx(index).map_err(|e| {
-                    PlatformWalletError::KeyDerivation(format!(
-                        "invalid platform-node key index {index}: {e}"
-                    ))
-                })?;
-                let xpriv = account_xpriv.derive_priv(&[child]).map_err(|e| {
-                    PlatformWalletError::KeyDerivation(format!(
-                        "failed to derive Ed25519 platform-node key at index {index}: {e}"
-                    ))
-                })?;
+                // Canonical raw-seed derivation via the shared helper (the
+                // exact routine `derive_platform_node_public_keys` uses, so
+                // the per-index reveal can never diverge from the persisted
+                // batch). Composed from the upstream primitives directly —
+                // the account's `derive_from_seed_*` wrapper rejects a
+                // watch-only account even with a seed (see module docs).
+                let xpriv = platform_node_xpriv_at(seed.as_ref(), network, index)?;
                 let verifying = ExtendedEd25519PubKey::from_priv(&xpriv).map_err(|e| {
                     PlatformWalletError::KeyDerivation(format!(
                         "failed to obtain Ed25519 public key at index {index}: {e}"

--- a/packages/rs-platform-wallet/src/wallet/provider_key_at_index.rs
+++ b/packages/rs-platform-wallet/src/wallet/provider_key_at_index.rs
@@ -217,6 +217,43 @@ pub struct ProviderDerivedKey {
     pub private_key: Option<Zeroizing<Vec<u8>>>,
 }
 
+/// The operator seed↔xpub cross-check guard, factored out so it can be
+/// unit-tested without a full [`PlatformWallet`].
+///
+/// Derives the operator secret at `index` from the raw `seed` via the
+/// gate-free #881 entry point, then verifies its public key equals
+/// `xpub_modern` (the modern serialization the account xpub produced).
+/// The two #881 entry points derive independently and do **not** verify
+/// against each other, so this refuses to return a mismatched
+/// `(public, private)` pair — a stale / corrupt persisted xpub would
+/// otherwise let one escape (signing would then produce a signature that
+/// doesn't verify against the displayed public key).
+///
+/// Returns the secret's big-endian scalar bytes when `include_private`,
+/// `None` otherwise; [`PlatformWalletError::KeyDerivation`] on mismatch or
+/// derivation failure.
+fn checked_operator_private_bytes_at(
+    xpub_modern: &[u8],
+    seed: &[u8],
+    network: key_wallet::Network,
+    index: u32,
+    include_private: bool,
+) -> Result<Option<Zeroizing<Vec<u8>>>, PlatformWalletError> {
+    let secret = BLSAccount::operator_private_key_at(seed, network, index).map_err(|e| {
+        PlatformWalletError::KeyDerivation(format!(
+            "failed to derive BLS operator key at index {index}: {e}"
+        ))
+    })?;
+    if secret.public_key().to_bytes().as_slice() != xpub_modern {
+        return Err(PlatformWalletError::KeyDerivation(format!(
+            "BLS operator key at index {index}: seed-derived public key does not match the \
+             account xpub derivation — the wallet seed and its stored operator account xpub \
+             disagree; refusing to return a mismatched key"
+        )));
+    }
+    Ok(include_private.then(|| Zeroizing::new(secret.to_be_bytes().to_vec())))
+}
+
 impl PlatformWallet {
     /// Derive this wallet's provider key of `kind` at `index`.
     ///
@@ -325,37 +362,16 @@ impl PlatformWallet {
                 let legacy_public_key_bytes = Some(xpub.to_bytes_legacy().to_vec());
 
                 let private_key = match &seed {
-                    // Private reveal: the operator secret scalar derived
-                    // straight from the raw seed via the #881 entry point
-                    // (no account state, no `is_watch_only` gate).
-                    Some(seed) => {
-                        let secret =
-                            BLSAccount::operator_private_key_at(seed.as_ref(), network, index)
-                                .map_err(|e| {
-                                    PlatformWalletError::KeyDerivation(format!(
-                                        "failed to derive BLS operator key at index {index}: {e}"
-                                    ))
-                                })?;
-
-                        // Always-on guard: the public branch derives from
-                        // the stored account xpub while this derives from
-                        // the raw seed, and the two #881 entry points do
-                        // NOT verify against each other — so a stale /
-                        // corrupt persisted xpub would otherwise let a
-                        // mismatched (public, private) pair escape. Refuse
-                        // to hand one out. The extra public derivation is
-                        // negligible.
-                        if secret.public_key().to_bytes() != xpub.public_key.to_bytes() {
-                            return Err(PlatformWalletError::KeyDerivation(format!(
-                                "BLS operator key at index {index}: seed-derived public key \
-                                 does not match the account xpub derivation — the wallet seed \
-                                 and its stored operator account xpub disagree; refusing to \
-                                 return a mismatched key"
-                            )));
-                        }
-
-                        include_private.then(|| Zeroizing::new(secret.to_be_bytes().to_vec()))
-                    }
+                    // Private reveal: the operator secret scalar from the
+                    // raw seed (#881 entry point), gated by the always-on
+                    // seed↔xpub cross-check (`checked_operator_private_bytes_at`).
+                    Some(seed) => checked_operator_private_bytes_at(
+                        &public_key_bytes,
+                        seed.as_ref(),
+                        network,
+                        index,
+                        include_private,
+                    )?,
                     // Public-only: no seed, no private scalar.
                     None => None,
                 };
@@ -436,11 +452,24 @@ mod tests {
     const TEST_MNEMONIC: &str = "abandon abandon abandon abandon abandon abandon \
          abandon abandon abandon abandon abandon about";
 
+    // A second, distinct BIP-39 vector (the standard `0x7f7f…` entropy
+    // test mnemonic) whose seed does NOT correspond to `TEST_MNEMONIC`'s
+    // account xpub — used for the operator cross-check negative path.
+    const TEST_MNEMONIC_B: &str =
+        "legal winner thank year wave sausage worth useful legal winner thank yellow";
+
     fn seed_bearing_wallet(network: Network) -> Wallet {
         let mnemonic =
             Mnemonic::from_phrase(TEST_MNEMONIC, Language::English).expect("valid test mnemonic");
         Wallet::from_mnemonic(mnemonic, network, WalletAccountCreationOptions::Default)
             .expect("wallet construction")
+    }
+
+    fn second_seed_bearing_wallet(network: Network) -> Wallet {
+        let mnemonic = Mnemonic::from_phrase(TEST_MNEMONIC_B, Language::English)
+            .expect("valid test mnemonic B");
+        Wallet::from_mnemonic(mnemonic, network, WalletAccountCreationOptions::Default)
+            .expect("wallet B construction")
     }
 
     /// The load-bearing invariants for platform-node keys, pinned so a
@@ -578,6 +607,53 @@ mod tests {
             sk0_t.public_key().to_bytes(),
             xpub0_t.public_key.to_bytes(),
             "testnet seed-derived operator pubkey must equal the account-xpub derivation"
+        );
+    }
+
+    /// Negative path for the operator seed↔xpub cross-check that
+    /// `derive_provider_key_at_index` runs on every private reveal (via
+    /// `checked_operator_private_bytes_at`): an operator private key
+    /// derived from a seed that does NOT correspond to the account xpub
+    /// must be REJECTED with `KeyDerivation`, never returned as a
+    /// mismatched (public, private) pair. Pins the guard so it can't be
+    /// silently weakened.
+    #[test]
+    fn operator_cross_check_rejects_mismatched_seed() {
+        // Account xpub from mnemonic A.
+        let wallet_a = seed_bearing_wallet(Network::Mainnet);
+        let account_a = wallet_a
+            .accounts
+            .bls_account_of_type(AccountType::ProviderOperatorKeys)
+            .expect("operator account");
+        let xpub_a_modern = account_a
+            .operator_public_key_at(0)
+            .expect("operator public")
+            .to_bytes()
+            .to_vec();
+        let seed_a = wallet_a.wallet_seed_bytes().expect("seed A");
+
+        // A distinct wallet whose seed does not match A's xpub.
+        let wallet_b = second_seed_bearing_wallet(Network::Mainnet);
+        let seed_b = wallet_b.wallet_seed_bytes().expect("seed B");
+        assert_ne!(seed_a, seed_b, "the two fixtures must differ");
+
+        // Mismatch: A's xpub, B's seed → the guard must reject.
+        let err =
+            checked_operator_private_bytes_at(&xpub_a_modern, &seed_b, Network::Mainnet, 0, true)
+                .expect_err("a seed not matching the account xpub must be rejected");
+        assert!(
+            matches!(err, PlatformWalletError::KeyDerivation(_)),
+            "cross-check mismatch must surface as KeyDerivation, got {err:?}"
+        );
+
+        // Control: A's own seed passes and yields the golden secret.
+        let ok =
+            checked_operator_private_bytes_at(&xpub_a_modern, &seed_a, Network::Mainnet, 0, true)
+                .expect("the matching seed must pass the cross-check");
+        assert_eq!(
+            hex::encode(&*ok.expect("private scalar returned when include_private")),
+            "11122e1ad656d0610ce0f80d40da874d67ea656a3e66ed371c915ec3a488a43a",
+            "the matching seed returns the golden operator secret"
         );
     }
 

--- a/packages/swift-sdk/Sources/SwiftDashSDK/Persistence/Models/PersistentTransaction.swift
+++ b/packages/swift-sdk/Sources/SwiftDashSDK/Persistence/Models/PersistentTransaction.swift
@@ -54,6 +54,14 @@ public final class PersistentTransaction {
     public var blockHash: Data?
     /// Block timestamp.
     public var blockTimestamp: UInt32
+    /// The transaction's index within its block (`block.vtx` order),
+    /// meaningful only when [`hasBlockPosition`]. Pure storage of the
+    /// Rust-stamped value (rust-dashcore#891): restored provider special
+    /// transactions hand it back so the masternode aggregation keeps
+    /// Core's same-block apply order across restarts. `false` on rows
+    /// persisted before the field existed and on unconfirmed contexts.
+    public var blockPosition: UInt32 = 0
+    public var hasBlockPosition: Bool = false
     /// Direction: 0=incoming, 1=outgoing, 2=internal, 3=coinJoin.
     public var direction: UInt32
     /// Transaction type name (Standard, CoinJoin, etc.). Sourced

--- a/packages/swift-sdk/Sources/SwiftDashSDK/PlatformWallet/ManagedPlatformWallet.swift
+++ b/packages/swift-sdk/Sources/SwiftDashSDK/PlatformWallet/ManagedPlatformWallet.swift
@@ -939,10 +939,16 @@ extension ManagedPlatformWallet {
     public struct ProviderDerivedKey: Sendable {
         /// The key index that was derived (`#0..`).
         public let index: UInt32
-        /// Lowercase hex of the raw curve public key — 96 chars for a
-        /// BLS-48 operator key (the bytes a ProRegTx operator field
-        /// carries), 64 for an Ed25519-32 platform-node key.
+        /// Lowercase hex of the raw curve public key in MODERN (IETF)
+        /// serialization — 96 chars for a BLS-48 operator key (the bytes a
+        /// ProRegTx operator field carries), 64 for an Ed25519-32
+        /// platform-node key.
         public let publicKeyHex: String
+        /// Lowercase hex of the SAME BLS G1 point in the Dash LEGACY
+        /// serialization (96 chars). `nil` for Ed25519 platform-node keys
+        /// (no legacy variant). Serialized on the Rust side — never
+        /// transformed in Swift.
+        public let legacyPublicKeyHex: String?
         /// Lowercase hex of the 20-byte platform node id (`hash160` of
         /// the Ed25519 public key, the ProRegTx `platform_node_id`).
         /// `nil` for operator keys, which have no node id.
@@ -960,11 +966,13 @@ extension ManagedPlatformWallet {
         public init(
             index: UInt32,
             publicKeyHex: String,
+            legacyPublicKeyHex: String?,
             nodeIdHex: String?,
             privateKeyHex: String?
         ) {
             self.index = index
             self.publicKeyHex = publicKeyHex
+            self.legacyPublicKeyHex = legacyPublicKeyHex
             self.nodeIdHex = nodeIdHex
             self.privateKeyHex = privateKeyHex
         }
@@ -1024,11 +1032,13 @@ extension ManagedPlatformWallet {
             try result.check()
 
             let publicKeyHex = out.public_key_hex.map { String(cString: $0) } ?? ""
+            let legacyPublicKeyHex = out.legacy_public_key_hex.map { String(cString: $0) }
             let nodeIdHex = out.node_id_hex.map { String(cString: $0) }
             let privateKeyHex = out.private_key_hex.map { String(cString: $0) }
             return ProviderDerivedKey(
                 index: out.index,
                 publicKeyHex: publicKeyHex,
+                legacyPublicKeyHex: legacyPublicKeyHex,
                 nodeIdHex: nodeIdHex,
                 privateKeyHex: privateKeyHex
             )

--- a/packages/swift-sdk/Sources/SwiftDashSDK/PlatformWallet/PlatformWalletManagerMasternodes.swift
+++ b/packages/swift-sdk/Sources/SwiftDashSDK/PlatformWallet/PlatformWalletManagerMasternodes.swift
@@ -56,6 +56,13 @@ public struct PlatformMasternode: Sendable {
     public let platformInWallet: Bool
     public let platformAccountType: UInt8
     public let platformKeyIndex: UInt32
+    /// Whether Rust could actually check platform-node ownership for this
+    /// query (the wallet's derived platform-node index had entries). When
+    /// false, `platformInWallet` is "unchecked" (empty/not-yet-rehydrated
+    /// pool) and the persister must retain the prior value instead of
+    /// clobbering it. When true, `platformInWallet` is definitive (true OR
+    /// false), so an on-chain rotation to an external key correctly clears it.
+    public let platformOwnershipChecked: Bool
 }
 
 extension PlatformWalletManager {
@@ -141,7 +148,8 @@ extension PlatformWalletManager {
                 operatorKeyIndex: entry.operator_key_index,
                 platformInWallet: entry.platform_in_wallet,
                 platformAccountType: entry.platform_account_type,
-                platformKeyIndex: entry.platform_key_index
+                platformKeyIndex: entry.platform_key_index,
+                platformOwnershipChecked: entry.platform_ownership_checked
             )
         }
     }

--- a/packages/swift-sdk/Sources/SwiftDashSDK/PlatformWallet/PlatformWalletPersistenceHandler.swift
+++ b/packages/swift-sdk/Sources/SwiftDashSDK/PlatformWallet/PlatformWalletPersistenceHandler.swift
@@ -3767,6 +3767,20 @@ public final class PlatformWalletPersistenceHandler: @unchecked Sendable {
                     backgroundContext.delete(row)
                 }
 
+                // Masternode aggregation rows, keyed by raw `walletId` (no
+                // relationship to `PersistentWallet`), so the wallet-row
+                // delete below does not cascade them. `MasternodeSync` never
+                // prunes on an empty aggregation (its no-prune-on-empty
+                // rule), so without an explicit purge a delete-then-reimport
+                // of the same wallet resurrects stale masternode rows
+                // indefinitely.
+                let masternodeDescriptor = FetchDescriptor<PersistentMasternode>(
+                    predicate: #Predicate<PersistentMasternode> { $0.walletId == walletId }
+                )
+                for row in try backgroundContext.fetch(masternodeDescriptor) {
+                    backgroundContext.delete(row)
+                }
+
                 if let walletRow = walletRow {
                     backgroundContext.delete(walletRow)
                 }
@@ -4112,12 +4126,50 @@ public final class PlatformWalletPersistenceHandler: @unchecked Sendable {
                     copyBytes(acc.friendIdentityId, into: &spec.friend_identity_id)
                     spec.account_xpub_bytes = UnsafePointer(xpubBuffer)
                     spec.account_xpub_bytes_len = UInt(xpub.count)
-                    // Display-only data the Rust load path ignores. The
-                    // persisted account row keeps the batch on the Swift
-                    // side (never rewritten after registration), so it is
-                    // not round-tripped back through the restore entry.
-                    spec.derived_platform_node_keys = nil
-                    spec.derived_platform_node_keys_count = 0
+                    // Rehydrate the platform-node (Ed25519) key batch on the
+                    // ProviderPlatformKeys account so the Rust restore can
+                    // repopulate its managed pool. SLIP-10 is hardened-only,
+                    // so these keys can't be re-derived seedlessly, and the
+                    // 33-byte core-address-pool ABI can't carry a typed 32B
+                    // Ed25519 key — the batch is the only path. Only the
+                    // platform account has a non-empty batch, so that alone
+                    // gates this. Pure load-side marshalling of persisted
+                    // rows (the Rust side recomputes node ids under #884).
+                    if !acc.derivedPlatformNodeKeys.isEmpty {
+                        let batch = acc.derivedPlatformNodeKeys
+                        let nkBuf = UnsafeMutablePointer<ProviderPlatformNodeKeyFFI>.allocate(
+                            capacity: batch.count
+                        )
+                        var nkWritten = 0
+                        for dk in batch where dk.publicKey.count == 32 && dk.nodeId.count == 20 {
+                            var row = ProviderPlatformNodeKeyFFI()
+                            row.index = dk.index
+                            dk.publicKey.withUnsafeBytes { src in
+                                withUnsafeMutableBytes(of: &row.public_key) { dst in
+                                    dst.copyMemory(from: src)
+                                }
+                            }
+                            dk.nodeId.withUnsafeBytes { src in
+                                withUnsafeMutableBytes(of: &row.node_id) { dst in
+                                    dst.copyMemory(from: src)
+                                }
+                            }
+                            nkBuf[nkWritten] = row
+                            nkWritten += 1
+                        }
+                        if nkWritten > 0 {
+                            spec.derived_platform_node_keys = UnsafePointer(nkBuf)
+                            spec.derived_platform_node_keys_count = UInt(nkWritten)
+                            allocation.providerPlatformNodeKeyArrays.append((nkBuf, nkWritten))
+                        } else {
+                            nkBuf.deallocate()
+                            spec.derived_platform_node_keys = nil
+                            spec.derived_platform_node_keys_count = 0
+                        }
+                    } else {
+                        spec.derived_platform_node_keys = nil
+                        spec.derived_platform_node_keys_count = 0
+                    }
                     buf[written] = spec
                     written += 1
                 }
@@ -5549,6 +5601,11 @@ private final class LoadAllocation {
     var coreAddressPoolArrays: [(UnsafeMutablePointer<AccountAddressPoolFFI>, Int)] = []
     /// Inner `CoreAddressEntryFFI` arrays, one per pool entry above.
     var coreAddressEntryArrays: [(UnsafeMutablePointer<CoreAddressEntryFFI>, Int)] = []
+    /// Per-`ProviderPlatformKeys`-account `ProviderPlatformNodeKeyFFI`
+    /// arrays — the persisted platform-node key batch marshalled back so
+    /// the Rust restore can repopulate the managed pool. Flat POD (no owned
+    /// pointers), so nothing extra rides `scalarBuffers`.
+    var providerPlatformNodeKeyArrays: [(UnsafeMutablePointer<ProviderPlatformNodeKeyFFI>, Int)] = []
 
     func release() {
         if let entries = entries {
@@ -5628,6 +5685,10 @@ private final class LoadAllocation {
             ptr.deallocate()
         }
         for (ptr, count) in coreAddressPoolArrays {
+            ptr.deinitialize(count: count)
+            ptr.deallocate()
+        }
+        for (ptr, count) in providerPlatformNodeKeyArrays {
             ptr.deinitialize(count: count)
             ptr.deallocate()
         }

--- a/packages/swift-sdk/Sources/SwiftDashSDK/PlatformWallet/PlatformWalletPersistenceHandler.swift
+++ b/packages/swift-sdk/Sources/SwiftDashSDK/PlatformWallet/PlatformWalletPersistenceHandler.swift
@@ -655,6 +655,8 @@ public final class PlatformWalletPersistenceHandler: @unchecked Sendable {
         record.context = tx.context
         record.blockHeight = tx.block_height
         record.blockTimestamp = tx.block_timestamp
+        record.blockPosition = tx.block_position
+        record.hasBlockPosition = tx.has_block_position
         let blockHashBytes = hashData(tx.block_hash)
         record.blockHash = blockHashBytes.allSatisfy { $0 == 0 } ? nil : blockHashBytes
         record.direction = tx.direction
@@ -4910,6 +4912,8 @@ public final class PlatformWalletPersistenceHandler: @unchecked Sendable {
                 }
             }
             entry.block_timestamp = UInt64(txRow.blockTimestamp)
+            entry.block_position = txRow.blockPosition
+            entry.has_block_position = txRow.hasBlockPosition
             entry.first_seen = txRow.firstSeen
             buf[written] = entry
             written += 1

--- a/packages/swift-sdk/SwiftExampleApp/SwiftExampleApp/Core/Services/MasternodeSync.swift
+++ b/packages/swift-sdk/SwiftExampleApp/SwiftExampleApp/Core/Services/MasternodeSync.swift
@@ -82,15 +82,27 @@ enum MasternodeSync {
                 row.votingKeyIndex = voting.index
 
                 // Operator / platform key ownership comes from Rust's
-                // derive-and-compare (these keys have no on-chain address to
-                // join against). Platform is empty for watch-only wallets
-                // (needs the seed) — a documented follow-up.
+                // pool-based match (these keys have no on-chain address to
+                // join against). Operator keys derive from the account xpub
+                // seedlessly, so operator ownership is always computable and
+                // updates unconditionally.
                 row.operatorInWallet = mn.operatorInWallet
                 row.operatorAccountType = mn.operatorAccountType
                 row.operatorKeyIndex = mn.operatorKeyIndex
-                row.platformInWallet = mn.platformInWallet
-                row.platformAccountType = mn.platformAccountType
-                row.platformKeyIndex = mn.platformKeyIndex
+                // Platform-node ownership can be a transient false negative:
+                // on a seedless restore the platform pool is empty until the
+                // persisted key batch has rehydrated it, and the FFI bool
+                // can't distinguish "checked and absent" from "couldn't check
+                // yet". So never DOWNGRADE an already-established platform
+                // ownership to false on an existing row — mirror the
+                // no-prune-on-empty rule. It still upgrades to true and sets
+                // fresh true values (and new rows default to false, so they
+                // take the fresh value regardless).
+                if mn.platformInWallet || !row.platformInWallet {
+                    row.platformInWallet = mn.platformInWallet
+                    row.platformAccountType = mn.platformAccountType
+                    row.platformKeyIndex = mn.platformKeyIndex
+                }
 
                 row.collateralTxid = mn.collateralTxid
                 row.collateralVout = mn.collateralVout

--- a/packages/swift-sdk/SwiftExampleApp/SwiftExampleApp/Core/Services/MasternodeSync.swift
+++ b/packages/swift-sdk/SwiftExampleApp/SwiftExampleApp/Core/Services/MasternodeSync.swift
@@ -61,6 +61,10 @@ enum MasternodeSync {
                 row.ownerAddress = mn.ownerAddress
                 row.votingAddress = mn.votingAddress
                 row.operatorPublicKey = mn.operatorPublicKey
+                // Capture the prior platform node id BEFORE overwriting so a
+                // rotation (id changed on-chain) can drive the ownership guard
+                // below even when Rust couldn't check the pool this round.
+                let priorPlatformNodeId = row.platformNodeId
                 row.platformNodeId = mn.platformNodeId
                 row.payoutAddress = mn.payoutAddress
                 row.operatorPseudoAddress = mn.operatorPseudoAddress
@@ -89,16 +93,22 @@ enum MasternodeSync {
                 row.operatorInWallet = mn.operatorInWallet
                 row.operatorAccountType = mn.operatorAccountType
                 row.operatorKeyIndex = mn.operatorKeyIndex
-                // Platform-node ownership can be a transient false negative:
-                // on a seedless restore the platform pool is empty until the
-                // persisted key batch has rehydrated it, and the FFI bool
-                // can't distinguish "checked and absent" from "couldn't check
-                // yet". So never DOWNGRADE an already-established platform
-                // ownership to false on an existing row — mirror the
-                // no-prune-on-empty rule. It still upgrades to true and sets
-                // fresh true values (and new rows default to false, so they
-                // take the fresh value regardless).
-                if mn.platformInWallet || !row.platformInWallet {
+                // Platform-node ownership is a tri-state driven by Rust's
+                // `platformOwnershipChecked`, which reports whether the derived
+                // platform-node index actually had entries to compare against:
+                //  - checked   ⇒ `platformInWallet` is definitive (true OR
+                //    false); write it verbatim so an on-chain rotation to an
+                //    external key CLEARS stale ownership. (The old height-only
+                //    guard could never clear an established true, leaving a
+                //    wrong "in wallet" claim and wrong Claim gating.)
+                //  - unchecked ⇒ the platform pool was empty / not yet
+                //    rehydrated on a seedless restore, so a false is only
+                //    "couldn't check yet" — retain the prior value.
+                // Belt-and-suspenders: a CHANGED platform node id is definitive
+                // on-chain evidence of a rotation regardless of checked-ness, so
+                // overwrite (clearing stale ownership) in that case too.
+                let platformNodeIdChanged = priorPlatformNodeId != mn.platformNodeId
+                if mn.platformOwnershipChecked || platformNodeIdChanged {
                     row.platformInWallet = mn.platformInWallet
                     row.platformAccountType = mn.platformAccountType
                     row.platformKeyIndex = mn.platformKeyIndex

--- a/packages/swift-sdk/SwiftExampleApp/SwiftExampleApp/Core/Views/AccountDetailView.swift
+++ b/packages/swift-sdk/SwiftExampleApp/SwiftExampleApp/Core/Views/AccountDetailView.swift
@@ -840,36 +840,40 @@ struct AccountDetailView: View {
                 .font(.subheadline)
                 .fontWeight(.semibold)
 
-            derivedValueRow(
+            // Public key in BOTH encodings (hex + base64) so it can be
+            // cross-checked against tools like dashwallet-ios that render
+            // Ed25519 / BLS keys in base64. Base64 is a second rendering of
+            // the same Rust-emitted bytes — never re-derived here.
+            derivedValueRowBothEncodings(
                 label: account.accountType == 10 ? "BLS Public Key" : "Ed25519 Public Key",
-                value: key.publicKeyHex,
+                hex: key.publicKeyHex,
                 copyKey: "\(key.index)-pub"
             )
 
             // The same BLS G1 point in Dash's legacy serialization, shown
             // only for operator (BLS) keys. Ed25519 platform-node keys have
             // no legacy form, so `legacyPublicKeyHex` is `nil` there and the
-            // row is skipped. Rust emits both encodings — never derived here.
+            // rows are skipped. Rust emits both encodings — never derived here.
             if let legacy = key.legacyPublicKeyHex {
-                derivedValueRow(
+                derivedValueRowBothEncodings(
                     label: "BLS Public Key (Legacy)",
-                    value: legacy,
+                    hex: legacy,
                     copyKey: "\(key.index)-pub-legacy"
                 )
             }
 
             if let nodeId = key.nodeIdHex {
-                derivedValueRow(
+                derivedValueRowBothEncodings(
                     label: "Platform Node ID",
-                    value: nodeId,
+                    hex: nodeId,
                     copyKey: "\(key.index)-node"
                 )
             }
 
             if let priv = revealedPrivateKeys[key.index] {
-                derivedValueRow(
+                derivedValueRowBothEncodings(
                     label: "Private Key",
-                    value: priv,
+                    hex: priv,
                     copyKey: "\(key.index)-priv"
                 )
             } else {
@@ -899,8 +903,31 @@ struct AccountDetailView: View {
         }
     }
 
+    /// Render `hex` in BOTH encodings: a "… (Hex)" row and, when the hex
+    /// decodes, a "… (Base64)" sibling — the same bytes rendered a second
+    /// way, so a value can be cross-checked against tools (e.g.
+    /// dashwallet-ios) that display Ed25519 / BLS keys in base64. Both use
+    /// the standard tap-to-copy value-row styling; the base64 row's copy
+    /// key / accessibility id gets a `-b64` suffix.
+    @ViewBuilder
+    private func derivedValueRowBothEncodings(label: String, hex: String, copyKey: String) -> some View {
+        derivedValueRow(label: "\(label) (Hex)", value: hex, copyKey: copyKey)
+        if let b64 = base64(fromHex: hex) {
+            derivedValueRow(label: "\(label) (Base64)", value: b64, copyKey: "\(copyKey)-b64")
+        }
+    }
+
+    /// Re-render a lowercase-hex string as base64 — the same bytes in a
+    /// second display encoding only (no crypto, no byte reinterpretation).
+    /// `nil` only when `hex` isn't valid hex.
+    private func base64(fromHex hex: String) -> String? {
+        Data(hexString: hex)?.base64EncodedString()
+    }
+
     /// One monospaced, middle-truncated value row with tap-to-copy and a
-    /// transient "Copied" confirmation keyed by `copyKey`.
+    /// transient "Copied" confirmation keyed by `copyKey`. The `copyKey`
+    /// doubles as the row's accessibility identifier (unique per row —
+    /// e.g. `"0-pub"`, `"0-pub-b64"`).
     @ViewBuilder
     private func derivedValueRow(label: String, value: String, copyKey: String) -> some View {
         VStack(alignment: .leading, spacing: 2) {
@@ -928,6 +955,7 @@ struct AccountDetailView: View {
         }
         .contentShape(Rectangle())
         .onTapGesture { copyDerived(value, copyKey: copyKey) }
+        .accessibilityIdentifier(copyKey)
     }
 
     private func revealDialogBinding(for index: UInt32) -> Binding<Bool> {

--- a/packages/swift-sdk/SwiftExampleApp/SwiftExampleApp/Core/Views/AccountDetailView.swift
+++ b/packages/swift-sdk/SwiftExampleApp/SwiftExampleApp/Core/Views/AccountDetailView.swift
@@ -863,9 +863,11 @@ struct AccountDetailView: View {
             }
 
             if let nodeId = key.nodeIdHex {
-                derivedValueRowBothEncodings(
+                // Node ids are conventionally rendered in hex — no base64
+                // sibling.
+                derivedValueRow(
                     label: "Platform Node ID",
-                    hex: nodeId,
+                    value: nodeId,
                     copyKey: "\(key.index)-node"
                 )
             }
@@ -876,6 +878,26 @@ struct AccountDetailView: View {
                     hex: priv,
                     copyKey: "\(key.index)-priv"
                 )
+                // Ed25519 platform-node key in dashmate's "Enter Ed25519
+                // node key" format: base64 of the 64-byte `priv(32) ‖
+                // pub(32)` blob its validator accepts (base64-decode →
+                // length 64 → split at 32 → pub matches priv). Built purely
+                // by decoding the two hex strings the FFI already displays
+                // and concatenating the bytes — no crypto, no byte
+                // reinterpretation. Only for the Ed25519 platform-node
+                // account, and only when both halves are present.
+                if account.accountType == 11,
+                    let tenderdash = tenderdashNodeKeyBase64(
+                        privateHex: priv,
+                        publicHex: key.publicKeyHex
+                    )
+                {
+                    derivedValueRow(
+                        label: "Tenderdash Node Key (Base64)",
+                        value: tenderdash,
+                        copyKey: "\(key.index)-tenderdash"
+                    )
+                }
             } else {
                 Button {
                     revealConfirmIndex = key.index
@@ -922,6 +944,20 @@ struct AccountDetailView: View {
     /// `nil` only when `hex` isn't valid hex.
     private func base64(fromHex hex: String) -> String? {
         Data(hexString: hex)?.base64EncodedString()
+    }
+
+    /// The Ed25519 platform-node key in dashmate's "Enter Ed25519 node key"
+    /// format: base64 of the 64-byte `priv(32) ‖ pub(32)` concatenation.
+    /// dashmate's validator base64-decodes, requires length 64, splits at
+    /// 32, and checks the public half matches the private. Built purely by
+    /// decoding the two hex strings the FFI already displays and joining the
+    /// bytes — no crypto, no byte reinterpretation. `nil` unless both halves
+    /// decode to exactly 32 bytes.
+    private func tenderdashNodeKeyBase64(privateHex: String, publicHex: String) -> String? {
+        guard let priv = Data(hexString: privateHex), priv.count == 32,
+            let pub = Data(hexString: publicHex), pub.count == 32
+        else { return nil }
+        return (priv + pub).base64EncodedString()
     }
 
     /// One monospaced, middle-truncated value row with tap-to-copy and a

--- a/packages/swift-sdk/SwiftExampleApp/SwiftExampleApp/Core/Views/AccountDetailView.swift
+++ b/packages/swift-sdk/SwiftExampleApp/SwiftExampleApp/Core/Views/AccountDetailView.swift
@@ -816,6 +816,8 @@ struct AccountDetailView: View {
                 ManagedPlatformWallet.ProviderDerivedKey(
                     index: key.index,
                     publicKeyHex: hexString(key.publicKey),
+                    // Platform-node keys are Ed25519 — no legacy BLS form.
+                    legacyPublicKeyHex: nil,
                     nodeIdHex: hexString(key.nodeId),
                     privateKeyHex: nil
                 )
@@ -843,6 +845,18 @@ struct AccountDetailView: View {
                 value: key.publicKeyHex,
                 copyKey: "\(key.index)-pub"
             )
+
+            // The same BLS G1 point in Dash's legacy serialization, shown
+            // only for operator (BLS) keys. Ed25519 platform-node keys have
+            // no legacy form, so `legacyPublicKeyHex` is `nil` there and the
+            // row is skipped. Rust emits both encodings — never derived here.
+            if let legacy = key.legacyPublicKeyHex {
+                derivedValueRow(
+                    label: "BLS Public Key (Legacy)",
+                    value: legacy,
+                    copyKey: "\(key.index)-pub-legacy"
+                )
+            }
 
             if let nodeId = key.nodeIdHex {
                 derivedValueRow(

--- a/packages/swift-sdk/SwiftExampleApp/SwiftExampleApp/Core/Views/MasternodeDetailView.swift
+++ b/packages/swift-sdk/SwiftExampleApp/SwiftExampleApp/Core/Views/MasternodeDetailView.swift
@@ -221,14 +221,28 @@ struct MasternodeDetailView: View {
 
                     // Claim is only offered when there's a balance AND this
                     // wallet holds the owner key (the owner-key withdrawal
-                    // path signs with it).
+                    // path signs with it). The withdrawal FFI itself is still
+                    // a deliberate stub (see `masternodeWithdrawEnabled`), so
+                    // the action is gated off until the verified-signer pass
+                    // lands — the confirmation sheet + claim plumbing below
+                    // stay in place so re-enabling is a one-line flip.
                     if canClaim {
-                        Button {
-                            prepareClaim()
-                        } label: {
-                            Label("Claim", systemImage: "arrow.down.circle")
+                        if Self.masternodeWithdrawEnabled {
+                            Button {
+                                prepareClaim()
+                            } label: {
+                                Label("Claim", systemImage: "arrow.down.circle")
+                            }
+                            .accessibilityIdentifier("masternode.claimButton")
+                        } else {
+                            Label(
+                                "Claim not yet available (pending verified signer)",
+                                systemImage: "clock.badge.exclamationmark"
+                            )
+                            .font(.caption)
+                            .foregroundColor(.secondary)
+                            .accessibilityIdentifier("masternode.claimUnavailable")
                         }
-                        .accessibilityIdentifier("masternode.claimButton")
                     }
                 }
             }
@@ -244,6 +258,13 @@ struct MasternodeDetailView: View {
             claimConfirmationSheet
         }
     }
+
+    /// Owner-key masternode withdrawal is not yet enabled: the Rust FFI
+    /// `platform_wallet_masternode_withdraw` is a deliberate stub returning
+    /// `ErrorWalletOperation` pending the verified-signer implementation, so
+    /// every confirmed claim would fail. Gate the Claim action off until
+    /// that lands; flip this to re-enable the existing confirmation flow.
+    private static let masternodeWithdrawEnabled = false
 
     /// Claim is enabled only with a positive balance and this wallet's
     /// owner key (the FFI's owner-key path requires it).


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

key-wallet derived wrong masternode operator BLS keys and platform node ids (dashpay/rust-dashcore#878) — they never matched DashSync/on-chain registrations, so #4116's operator/platform ownership matching could never succeed. The fix merged upstream as dashpay/rust-dashcore#879; this picks it up and adds the dual BLS serialization display users expect from dashwallet-ios.

## What was done?
<!--- Describe your changes in detail -->

- **Pin bump** rust-dashcore `337f6ccc` → `56a40788`: #879 (BLS operator / Ed25519 platform-node derivation per DashSync/dashbls — drops the spurious `0x00` in hardened BLS children, uses legacy G1 serialization in the HD chain, feeds the bip39 seed directly instead of the secp256k1 hybrid with double path application), #877 (mainnet sync floors at the HD/BIP39 activation height), #874 (masternode seed refresh).
- **Dual BLS serialization display**: `ProviderDerivedKey` (rs-platform-wallet) now carries `legacy_public_key_bytes` for BLS operator keys (via #879's `to_bytes_legacy()` / `public_key_bytes_legacy()` — Rust-side only, no Swift crypto), threaded through `ProviderKeyAtIndexFFI` and the Swift DTO; the Provider Operator Keys account screen renders both "BLS Public Key" (modern, `82…`) and "BLS Public Key (Legacy)" (`02…`) as copyable rows. Ed25519 platform-node keys are unaffected (no legacy row).

Note: wallets created before this bump persisted provider account roots derived under the broken scheme — a wallet delete + re-import is needed for the corrected keys (the old keys never corresponded to anything on-chain). Follow-up (deliberately excluded): the masternode detail page's raw on-chain operator key row could also show both forms, but that requires a version-aware re-encode (ProRegTx v1 payloads carry legacy encoding, v2+ modern) threaded through the aggregation.

**Follow-up rounds on this PR:**
- Deleted platform-wallet's duplicated derivation and, after dashpay/rust-dashcore#881 landed (from our #880), shrank `provider_key_at_index.rs` to a pure adapter over the gate-free upstream API (`operator_public_key_at` / `operator_private_key_at` / `platform_node_key_at`) — platform holds zero derivation knowledge now. An always-on consistency check guards the private-reveal (the upstream public and private paths derive from independent sources).
- Provider key accounts now route through the address-pool restore, so their persisted address rows rehydrate the in-memory pools at load (previously dropped by the `_ => None` arm).
- Dropped the provider-scheme versioning (pre-release; stale dev wallets delete+re-import).
- User-verified end-to-end: same fresh mnemonic imported in dashwallet-ios (DashSync) and this app on mainnet produces identical operator keypairs (modern + legacy + private).

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

- `cargo check --workspace --all-targets` and `cargo test -p platform-wallet-ffi` (152 tests) green against the new pin; clippy clean.
- `build_ios.sh --target sim` (warnings-as-errors) green, cbindgen headers regenerated with the new FFI field.
- Runtime verification of the corrected derivation requires a wallet re-import (persisted provider account roots predate the fix); the derive-and-compare ownership matching from #4116 is already wired to consume the corrected keys.

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->

None.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [ ] I have made corresponding changes to the documentation if needed

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added legacy BLS operator key support to provider key results, including legacy public-key hex exposure in the Swift SDK and account details UI.
  - Provider key display now supports rendering derived public keys in hex and base64, with an optional “Legacy” row when available.
- **Bug Fixes**
  - Improved restoration and merging of persisted provider key material and core address pools to prevent provider-key matching regressions.
  - Fixed masternode ownership/aggregation consistency during delete/reimport and refresh cycles; ensured clean empty outputs for masternode list calls.
- **Documentation**
  - Updated platform-node id descriptions to use the Tenderdash SHA256[..20] convention, including related persistence notes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

