### PR TITLE
feat(platform-wallet): persist Orchard viewing keys for seedless shielded bind

### DIFF
--- a/packages/rs-platform-wallet-ffi/src/persistence.rs
+++ b/packages/rs-platform-wallet-ffi/src/persistence.rs
@@ -384,6 +384,20 @@ pub struct PersistenceCallbacks {
             count: usize,
         ) -> i32,
     >,
+    /// Per-subwallet Orchard viewing-key upserts (raw 96-byte FVK
+    /// encoding). Emitted once per seed-backed `bind_shielded` /
+    /// `shielded_add_account`; the host upserts by
+    /// `(wallet_id, account_index)` so later launches can rebind
+    /// the shielded sub-wallet without a mnemonic resolve.
+    #[cfg(feature = "shielded")]
+    pub on_persist_shielded_viewing_keys_fn: Option<
+        unsafe extern "C" fn(
+            context: *mut c_void,
+            wallet_id: *const u8,
+            entries: *const crate::shielded_persistence::ShieldedViewingKeyFFI,
+            count: usize,
+        ) -> i32,
+    >,
     /// Restore-on-load: every persisted shielded note. Host
     /// allocates the array; Rust calls the matching free
     /// callback after copying. Same lifetime contract as
@@ -461,6 +475,26 @@ pub struct PersistenceCallbacks {
         unsafe extern "C" fn(
             context: *mut c_void,
             entries: *const crate::shielded_persistence::ShieldedActivityRestoreFFI,
+            count: usize,
+        ),
+    >,
+    /// Restore-on-load: every persisted Orchard viewing key. Same
+    /// host-allocates / Rust-frees lifetime contract as
+    /// `on_load_shielded_notes_fn`. Inlined so cbindgen emits the
+    /// referenced struct in the header.
+    #[cfg(feature = "shielded")]
+    pub on_load_shielded_viewing_keys_fn: Option<
+        unsafe extern "C" fn(
+            context: *mut c_void,
+            out_entries: *mut *const crate::shielded_persistence::ShieldedViewingKeyRestoreFFI,
+            out_count: *mut usize,
+        ) -> i32,
+    >,
+    #[cfg(feature = "shielded")]
+    pub on_load_shielded_viewing_keys_free_fn: Option<
+        unsafe extern "C" fn(
+            context: *mut c_void,
+            entries: *const crate::shielded_persistence::ShieldedViewingKeyRestoreFFI,
             count: usize,
         ),
     >,
@@ -594,6 +628,8 @@ impl Default for PersistenceCallbacks {
             #[cfg(feature = "shielded")]
             on_persist_shielded_activity_fn: None,
             #[cfg(feature = "shielded")]
+            on_persist_shielded_viewing_keys_fn: None,
+            #[cfg(feature = "shielded")]
             on_load_shielded_notes_fn: None,
             #[cfg(feature = "shielded")]
             on_load_shielded_notes_free_fn: None,
@@ -609,6 +645,10 @@ impl Default for PersistenceCallbacks {
             on_load_shielded_activity_fn: None,
             #[cfg(feature = "shielded")]
             on_load_shielded_activity_free_fn: None,
+            #[cfg(feature = "shielded")]
+            on_load_shielded_viewing_keys_fn: None,
+            #[cfg(feature = "shielded")]
+            on_load_shielded_viewing_keys_free_fn: None,
         }
     }
 }
@@ -1433,7 +1473,53 @@ impl PlatformWalletPersistence for FFIPersister {
                 }
             }
 
-            // 5) activity entries (derived activity log). The variable-
+            // 5) viewing keys (raw 96-byte FVK encodings). Fixed-size
+            //    rows, no borrowed pointers. A malformed length can
+            //    only come from a corrupted changeset; skip + warn so
+            //    one bad row doesn't sink the flush.
+            if !shielded_cs.viewing_keys.is_empty() {
+                if let Some(cb) = self.callbacks.on_persist_shielded_viewing_keys_fn {
+                    let entries: Vec<ShieldedViewingKeyFFI> = shielded_cs
+                        .viewing_keys
+                        .iter()
+                        .filter_map(|(id, fvk)| {
+                            let fvk_bytes: [u8; 96] = match fvk.as_slice().try_into() {
+                                Ok(b) => b,
+                                Err(_) => {
+                                    tracing::warn!(
+                                        fvk_len = fvk.len(),
+                                        "skipping viewing-key persist row: \
+                                             FVK is not the expected 96 bytes"
+                                    );
+                                    return None;
+                                }
+                            };
+                            Some(ShieldedViewingKeyFFI {
+                                wallet_id: id.wallet_id,
+                                account_index: id.account_index,
+                                fvk_bytes,
+                            })
+                        })
+                        .collect();
+                    let result = unsafe {
+                        cb(
+                            self.callbacks.context,
+                            wallet_id.as_ptr(),
+                            entries.as_ptr(),
+                            entries.len(),
+                        )
+                    };
+                    if result != 0 {
+                        eprintln!(
+                            "Shielded viewing-key persistence callback returned error code {}",
+                            result
+                        );
+                        round_success = false;
+                    }
+                }
+            }
+
+            // 6) activity entries (derived activity log). The variable-
             //    length fields (counterparty / memo / cmx + nullifier
             //    arrays) borrow into `backing`, a Vec of owned byte
             //    buffers that outlives the callback — same pointer-validity
@@ -2049,6 +2135,69 @@ impl PlatformWalletPersistence for FFIPersister {
                             note_cmxs,
                             spent_nullifiers,
                         });
+                    }
+                }
+            }
+
+            // 5) persisted Orchard viewing keys (raw 96-byte FVK
+            //    encodings), consumed by
+            //    `PlatformWallet::bind_shielded_from_persisted` so a
+            //    launch-time rebind needs no mnemonic resolve.
+            if self.callbacks.on_load_shielded_viewing_keys_fn.is_some()
+                != self
+                    .callbacks
+                    .on_load_shielded_viewing_keys_free_fn
+                    .is_some()
+            {
+                return Err(PersistenceError::backend(
+                    "on_load_shielded_viewing_keys_fn and \
+                     on_load_shielded_viewing_keys_free_fn must be provided together",
+                ));
+            }
+            if let Some(load_viewing_keys) = self.callbacks.on_load_shielded_viewing_keys_fn {
+                let mut vk_ptr: *const ShieldedViewingKeyRestoreFFI = std::ptr::null();
+                let mut vk_count: usize = 0;
+                let rc = unsafe {
+                    load_viewing_keys(self.callbacks.context, &mut vk_ptr, &mut vk_count)
+                };
+                if rc != 0 {
+                    return Err(PersistenceError::backend(format!(
+                        "on_load_shielded_viewing_keys_fn returned error code {}",
+                        rc
+                    )));
+                }
+                struct ViewingKeysGuard {
+                    context: *mut c_void,
+                    free_fn: Option<
+                        unsafe extern "C" fn(
+                            context: *mut c_void,
+                            entries: *const ShieldedViewingKeyRestoreFFI,
+                            count: usize,
+                        ),
+                    >,
+                    entries: *const ShieldedViewingKeyRestoreFFI,
+                    count: usize,
+                }
+                impl Drop for ViewingKeysGuard {
+                    fn drop(&mut self) {
+                        if let Some(free_fn) = self.free_fn {
+                            unsafe { free_fn(self.context, self.entries, self.count) };
+                        }
+                    }
+                }
+                let _viewing_keys_guard = ViewingKeysGuard {
+                    context: self.callbacks.context,
+                    free_fn: self.callbacks.on_load_shielded_viewing_keys_free_fn,
+                    entries: vk_ptr,
+                    count: vk_count,
+                };
+                if !vk_ptr.is_null() && vk_count > 0 {
+                    let slice = unsafe { slice::from_raw_parts(vk_ptr, vk_count) };
+                    for ffi in slice {
+                        let id = SubwalletId::new(ffi.wallet_id, ffi.account_index);
+                        shielded_state
+                            .viewing_keys
+                            .insert(id, ffi.fvk_bytes.to_vec());
                     }
                 }
             }

--- a/packages/rs-platform-wallet-ffi/src/shielded_persistence.rs
+++ b/packages/rs-platform-wallet-ffi/src/shielded_persistence.rs
@@ -172,6 +172,26 @@ pub struct ShieldedActivityFFI {
     pub spent_nullifiers_count: usize,
 }
 
+/// One per-subwallet Orchard viewing key for the host to persist.
+///
+/// The 96 bytes are the raw `FullViewingKey` encoding (`ak ‖ nk ‖
+/// rivk`); IVK / OVK / default address are all pure functions of it,
+/// so this row alone lets a later launch rebind the shielded
+/// sub-wallet without resolving the mnemonic. Viewing-grade only —
+/// it can decrypt and recognize notes but cannot authorize a spend.
+/// The host upserts one row keyed by `(wallet_id, account_index)`;
+/// the FVK for a subwallet never legitimately changes on a network,
+/// so a re-emit is byte-identical.
+#[repr(C)]
+pub struct ShieldedViewingKeyFFI {
+    /// 32-byte wallet identifier.
+    pub wallet_id: [u8; 32],
+    /// ZIP-32 account index.
+    pub account_index: u32,
+    /// Raw 96-byte Orchard `FullViewingKey` encoding.
+    pub fvk_bytes: [u8; 96],
+}
+
 // ── Restore (load) ──────────────────────────────────────────────────────
 
 /// One persisted note as the host hands it back at boot. Mirrors
@@ -216,6 +236,17 @@ pub struct ShieldedSubwalletSyncStateFFI {
     pub wallet_id: [u8; 32],
     pub account_index: u32,
     pub last_synced_index: u64,
+}
+
+/// One persisted Orchard viewing key as the host hands it back at
+/// boot. Mirrors [`ShieldedViewingKeyFFI`] but lives in a
+/// Swift-allocated array, so the buffer ownership / free contract
+/// differs (see the matching `on_load_shielded_viewing_keys_free_fn`).
+#[repr(C)]
+pub struct ShieldedViewingKeyRestoreFFI {
+    pub wallet_id: [u8; 32],
+    pub account_index: u32,
+    pub fvk_bytes: [u8; 96],
 }
 
 /// One persisted activity entry as the host hands it back at boot.

--- a/packages/rs-platform-wallet-ffi/src/shielded_send.rs
+++ b/packages/rs-platform-wallet-ffi/src/shielded_send.rs
@@ -248,6 +248,13 @@ fn encode_memo_text(memo_text: Option<&str>) -> Result<[u8; 36], PlatformWalletF
 /// shielded sub-wallet, no spendable notes, or insufficient
 /// shielded balance to cover `amount + estimated_fee`.
 ///
+/// `mnemonic_resolver_handle` supplies the Orchard spend authority:
+/// the resolver fires exactly once, the seed is derived in a
+/// `Zeroizing` buffer, the account's `SpendAuthorizingKey` is
+/// re-derived for this call only, and everything is dropped before
+/// this function returns. No spend key is resident between spends
+/// (mirror of the transparent `MnemonicResolverCoreSigner` flow).
+///
 /// `memo_text` is an optional NUL-terminated UTF-8 string attached
 /// to the recipient's note. `null` or an empty string means no memo
 /// (the all-zero 36-byte memo). A non-empty memo's UTF-8 byte length
@@ -257,6 +264,9 @@ fn encode_memo_text(memo_text: Option<&str>) -> Result<[u8; 36], PlatformWalletF
 ///
 /// # Safety
 /// - `wallet_id_bytes` must point to 32 readable bytes.
+/// - `mnemonic_resolver_handle` must come from
+///   `dash_sdk_mnemonic_resolver_create` and outlive this call; the
+///   caller retains ownership.
 /// - `recipient_raw_43` must point to 43 readable bytes (the
 ///   recipient's raw Orchard payment address — same shape
 ///   `platform_wallet_manager_shielded_default_address` returns).
@@ -266,12 +276,14 @@ fn encode_memo_text(memo_text: Option<&str>) -> Result<[u8; 36], PlatformWalletF
 pub unsafe extern "C" fn platform_wallet_manager_shielded_transfer(
     handle: Handle,
     wallet_id_bytes: *const u8,
+    mnemonic_resolver_handle: *mut MnemonicResolverHandle,
     account: u32,
     recipient_raw_43: *const u8,
     amount: u64,
     memo_text: *const c_char,
 ) -> PlatformWalletFFIResult {
     check_ptr!(wallet_id_bytes);
+    check_ptr!(mnemonic_resolver_handle);
     check_ptr!(recipient_raw_43);
 
     let mut wallet_id = [0u8; 32];
@@ -304,6 +316,16 @@ pub unsafe extern "C" fn platform_wallet_manager_shielded_transfer(
         Err(result) => return result,
     };
 
+    // Resolve the spend authority per-operation: mnemonic → seed in
+    // `Zeroizing` buffers, scrubbed when the worker task drops them.
+    let seed = match crate::identity_keys_from_mnemonic::resolve_seed_from_resolver(
+        mnemonic_resolver_handle,
+        &wallet_id,
+    ) {
+        Ok(seed) => seed,
+        Err(result) => return result,
+    };
+
     // Run the proof on a worker thread (8 MB stack). Halo 2 circuit
     // synthesis recurses past the ~512 KB iOS dispatch-thread stack
     // and crashes with EXC_BAD_ACCESS at the first
@@ -312,7 +334,15 @@ pub unsafe extern "C" fn platform_wallet_manager_shielded_transfer(
     let result = block_on_worker(async move {
         let prover = CachedOrchardProver::new();
         let r = wallet
-            .shielded_transfer_to(&coordinator, account, &recipient, amount, memo, &prover)
+            .shielded_transfer_to(
+                &coordinator,
+                seed.as_ref(),
+                account,
+                &recipient,
+                amount,
+                memo,
+                &prover,
+            )
             .await;
         poke_sync_on_unconfirmed(&r, handle);
         r
@@ -331,19 +361,27 @@ pub unsafe extern "C" fn platform_wallet_manager_shielded_transfer(
 /// which differs from the bech32m payload's type byte
 /// (`0xb0`/`0x80`).
 ///
+/// `mnemonic_resolver_handle` supplies the per-operation Orchard
+/// spend authority (see `platform_wallet_manager_shielded_transfer`).
+///
 /// # Safety
 /// - `wallet_id_bytes` must point to 32 readable bytes.
+/// - `mnemonic_resolver_handle` must come from
+///   `dash_sdk_mnemonic_resolver_create` and outlive this call; the
+///   caller retains ownership.
 /// - `to_platform_addr_cstr` must be a valid NUL-terminated UTF-8
 ///   C string for the duration of the call.
 #[no_mangle]
 pub unsafe extern "C" fn platform_wallet_manager_shielded_unshield(
     handle: Handle,
     wallet_id_bytes: *const u8,
+    mnemonic_resolver_handle: *mut MnemonicResolverHandle,
     account: u32,
     to_platform_addr_cstr: *const c_char,
     amount: u64,
 ) -> PlatformWalletFFIResult {
     check_ptr!(wallet_id_bytes);
+    check_ptr!(mnemonic_resolver_handle);
     check_ptr!(to_platform_addr_cstr);
 
     let mut wallet_id = [0u8; 32];
@@ -363,10 +401,25 @@ pub unsafe extern "C" fn platform_wallet_manager_shielded_unshield(
         Err(result) => return result,
     };
 
+    let seed = match crate::identity_keys_from_mnemonic::resolve_seed_from_resolver(
+        mnemonic_resolver_handle,
+        &wallet_id,
+    ) {
+        Ok(seed) => seed,
+        Err(result) => return result,
+    };
+
     let result = block_on_worker(async move {
         let prover = CachedOrchardProver::new();
         let r = wallet
-            .shielded_unshield_to(&coordinator, account, &to_addr_str, amount, &prover)
+            .shielded_unshield_to(
+                &coordinator,
+                seed.as_ref(),
+                account,
+                &to_addr_str,
+                amount,
+                &prover,
+            )
             .await;
         poke_sync_on_unconfirmed(&r, handle);
         r
@@ -381,20 +434,28 @@ pub unsafe extern "C" fn platform_wallet_manager_shielded_unshield(
 /// the network matches the wallet's. `core_fee_per_byte` is the
 /// L1 fee rate in duffs/byte (`1` is the dashmate default).
 ///
+/// `mnemonic_resolver_handle` supplies the per-operation Orchard
+/// spend authority (see `platform_wallet_manager_shielded_transfer`).
+///
 /// # Safety
 /// - `wallet_id_bytes` must point to 32 readable bytes.
+/// - `mnemonic_resolver_handle` must come from
+///   `dash_sdk_mnemonic_resolver_create` and outlive this call; the
+///   caller retains ownership.
 /// - `to_core_address_cstr` must be a valid NUL-terminated UTF-8
 ///   C string for the duration of the call.
 #[no_mangle]
 pub unsafe extern "C" fn platform_wallet_manager_shielded_withdraw(
     handle: Handle,
     wallet_id_bytes: *const u8,
+    mnemonic_resolver_handle: *mut MnemonicResolverHandle,
     account: u32,
     to_core_address_cstr: *const c_char,
     amount: u64,
     core_fee_per_byte: u32,
 ) -> PlatformWalletFFIResult {
     check_ptr!(wallet_id_bytes);
+    check_ptr!(mnemonic_resolver_handle);
     check_ptr!(to_core_address_cstr);
 
     let mut wallet_id = [0u8; 32];
@@ -414,11 +475,20 @@ pub unsafe extern "C" fn platform_wallet_manager_shielded_withdraw(
         Err(result) => return result,
     };
 
+    let seed = match crate::identity_keys_from_mnemonic::resolve_seed_from_resolver(
+        mnemonic_resolver_handle,
+        &wallet_id,
+    ) {
+        Ok(seed) => seed,
+        Err(result) => return result,
+    };
+
     let result = block_on_worker(async move {
         let prover = CachedOrchardProver::new();
         let r = wallet
             .shielded_withdraw_to(
                 &coordinator,
+                seed.as_ref(),
                 account,
                 &to_core,
                 amount,
@@ -571,8 +641,13 @@ fn map_spend_result(
 /// penalty, exactly like the asset-lock / address-funded identity-create penalties. It is bound into
 /// the transition sighash, so it cannot be redirected after signing.
 ///
+/// `mnemonic_resolver_handle` supplies the per-operation Orchard spend authority (see
+/// `platform_wallet_manager_shielded_transfer`).
+///
 /// # Safety
 /// - `wallet_id_bytes` must point to 32 readable bytes.
+/// - `mnemonic_resolver_handle` must come from `dash_sdk_mnemonic_resolver_create` and outlive
+///   this call; the caller retains ownership.
 /// - `identity_pubkeys` must point to `identity_pubkeys_count` contiguous [`IdentityPubkeyFFI`]
 ///   rows that outlive this call (each row's pointers per the [`IdentityPubkeyFFI`] contract).
 /// - `send_to_address_on_creation_failure_bytes` must point to exactly 21 readable bytes for the
@@ -588,6 +663,7 @@ fn map_spend_result(
 pub unsafe extern "C" fn platform_wallet_manager_shielded_identity_create_from_pool(
     handle: Handle,
     wallet_id_bytes: *const u8,
+    mnemonic_resolver_handle: *mut MnemonicResolverHandle,
     account: u32,
     identity_index: u32,
     identity_pubkeys: *const IdentityPubkeyFFI,
@@ -598,6 +674,7 @@ pub unsafe extern "C" fn platform_wallet_manager_shielded_identity_create_from_p
     out_identity_id: *mut [u8; 32],
 ) -> PlatformWalletFFIResult {
     check_ptr!(wallet_id_bytes);
+    check_ptr!(mnemonic_resolver_handle);
     check_ptr!(identity_pubkeys);
     check_ptr!(send_to_address_on_creation_failure_bytes);
     check_ptr!(signer_identity_handle);
@@ -647,6 +724,16 @@ pub unsafe extern "C" fn platform_wallet_manager_shielded_identity_create_from_p
         Err(result) => return result,
     };
 
+    // Resolve the per-operation Orchard spend authority before entering the worker; the seed
+    // rides into the task in its `Zeroizing` buffer and is scrubbed when the task drops it.
+    let seed = match crate::identity_keys_from_mnemonic::resolve_seed_from_resolver(
+        mnemonic_resolver_handle,
+        &wallet_id,
+    ) {
+        Ok(seed) => seed,
+        Err(result) => return result,
+    };
+
     // Round-trip the signer pointer through `usize` so the worker future captures only plain
     // `Send + 'static` data and re-materializes the borrow INSIDE the task — never a fabricated
     // `&'static` borrow of a host-owned vtable across the FFI boundary. The caller's contract is
@@ -666,6 +753,7 @@ pub unsafe extern "C" fn platform_wallet_manager_shielded_identity_create_from_p
         let r = wallet
             .shielded_identity_create_from_pool(
                 &coordinator,
+                seed.as_ref(),
                 account,
                 identity_index,
                 public_keys,

--- a/packages/rs-platform-wallet-ffi/src/shielded_sync.rs
+++ b/packages/rs-platform-wallet-ffi/src/shielded_sync.rs
@@ -15,17 +15,12 @@ use std::time::Duration;
 
 use platform_wallet::wallet::shielded::ShieldedSyncSummary;
 
-use zeroize::Zeroizing;
-
 use crate::error::*;
 use crate::handle::*;
-use crate::identity_keys_from_mnemonic::parse_mnemonic_any_language;
 use crate::runtime::{block_on_worker, runtime};
 use crate::shielded_types::ShieldedSyncWalletResultFFI;
 use crate::{check_ptr, unwrap_option_or_return};
-use rs_sdk_ffi::{
-    mnemonic_resolver_result, MnemonicResolverHandle, MNEMONIC_RESOLVER_BUFFER_CAPACITY,
-};
+use rs_sdk_ffi::MnemonicResolverHandle;
 
 impl ShieldedSyncWalletResultFFI {
     pub(crate) fn ok(wallet_id: [u8; 32], summary: &ShieldedSyncSummary) -> Self {
@@ -188,22 +183,31 @@ pub unsafe extern "C" fn platform_wallet_manager_shielded_sync_sync_now(
 // Bind shielded
 // ---------------------------------------------------------------------------
 
-/// Derive Orchard keys for the given wallet from the host-supplied
-/// mnemonic resolver and register the resulting accounts on the
-/// network-scoped shielded coordinator.
+/// Bind the given wallet's Orchard accounts on the network-scoped
+/// shielded coordinator — from persisted viewing keys when the host
+/// persister has them, falling back to a mnemonic-resolver seed
+/// derivation only when it doesn't.
 ///
 /// `accounts_ptr` / `accounts_len` describe the ZIP-32 account
-/// indices to derive. The slice must be non-empty and at most
+/// indices to bind. The slice must be non-empty and at most
 /// `64` entries; pass a one-element `[0]` array for the
 /// single-account default. Each entry produces an independent
-/// [`OrchardKeySet`] and bookkeeping `SubwalletId` inside the
-/// store; the same commitment tree backs every account on the
+/// viewing-key registration and bookkeeping `SubwalletId` inside
+/// the store; the same commitment tree backs every account on the
 /// network.
 ///
-/// The resolver fires exactly once per call. The mnemonic and the
-/// derived seed live in `Zeroizing` buffers and are scrubbed
-/// before this function returns; only the per-account FVK / IVK /
-/// OVK / default payment addresses survive on the wallet.
+/// **The resolver does NOT fire on the common path.** When every
+/// requested account has a persisted viewing key (written by the
+/// first seed-backed bind via
+/// `on_persist_shielded_viewing_keys_fn`), the bind completes from
+/// those rows and the mnemonic is never touched. The resolver fires
+/// exactly once only on the fallback (first bind after create /
+/// import, or persistence predating viewing-key rows); the mnemonic
+/// and the derived seed then live in `Zeroizing` buffers and are
+/// scrubbed before this function returns. In every case only the
+/// per-account FVK / IVK / OVK / default payment addresses survive
+/// on the wallet — no `SpendAuthorizingKey` stays resident; spends
+/// re-derive it per operation.
 ///
 /// **Prerequisite**: the host must have already called
 /// [`platform_wallet_manager_configure_shielded`] with the
@@ -220,8 +224,6 @@ pub unsafe extern "C" fn platform_wallet_manager_shielded_sync_sync_now(
 /// - `accounts_ptr` must point at `accounts_len` readable `u32`s.
 /// - `mnemonic_resolver_handle` must come from
 ///   [`crate::dash_sdk_mnemonic_resolver_create`].
-///
-/// [`OrchardKeySet`]: platform_wallet::wallet::shielded::OrchardKeySet
 #[no_mangle]
 pub unsafe extern "C" fn platform_wallet_manager_bind_shielded(
     handle: Handle,
@@ -244,76 +246,10 @@ pub unsafe extern "C" fn platform_wallet_manager_bind_shielded(
     let mut wallet_id = [0u8; 32];
     std::ptr::copy_nonoverlapping(wallet_id_bytes, wallet_id.as_mut_ptr(), 32);
 
-    // Resolve mnemonic via the host callback.
-    let mut mnemonic_buf: Zeroizing<[u8; MNEMONIC_RESOLVER_BUFFER_CAPACITY]> =
-        Zeroizing::new([0u8; MNEMONIC_RESOLVER_BUFFER_CAPACITY]);
-    let mut mnemonic_len: usize = 0;
-
-    let resolver = &*mnemonic_resolver_handle;
-    let resolver_vtable = &*resolver.vtable;
-    let rc = (resolver_vtable.resolve)(
-        resolver.ctx as *const std::os::raw::c_void,
-        wallet_id_bytes,
-        mnemonic_buf.as_mut_ptr() as *mut c_char,
-        MNEMONIC_RESOLVER_BUFFER_CAPACITY,
-        &mut mnemonic_len,
-    );
-
-    match rc {
-        x if x == mnemonic_resolver_result::SUCCESS => {}
-        x if x == mnemonic_resolver_result::NOT_FOUND => {
-            return PlatformWalletFFIResult::err(
-                PlatformWalletFFIResultCode::ErrorWalletOperation,
-                "mnemonic missing for wallet",
-            );
-        }
-        x if x == mnemonic_resolver_result::BUFFER_TOO_SMALL => {
-            return PlatformWalletFFIResult::err(
-                PlatformWalletFFIResultCode::ErrorWalletOperation,
-                "mnemonic resolver buffer too small",
-            );
-        }
-        _ => {
-            return PlatformWalletFFIResult::err(
-                PlatformWalletFFIResultCode::ErrorWalletOperation,
-                "mnemonic resolver failed",
-            );
-        }
-    }
-    if mnemonic_len == 0 || mnemonic_len > MNEMONIC_RESOLVER_BUFFER_CAPACITY {
-        return PlatformWalletFFIResult::err(
-            PlatformWalletFFIResultCode::ErrorWalletOperation,
-            "mnemonic resolver returned empty buffer",
-        );
-    }
-
-    // Parse and derive seed. Both intermediate forms live in
-    // `Zeroizing` so they're scrubbed when this function exits.
-    let mnemonic_str = match std::str::from_utf8(&mnemonic_buf[..mnemonic_len]) {
-        Ok(s) => s,
-        Err(e) => {
-            return PlatformWalletFFIResult::err(
-                PlatformWalletFFIResultCode::ErrorUtf8Conversion,
-                format!("mnemonic is not valid UTF-8: {e}"),
-            );
-        }
-    };
-    let mnemonic = match parse_mnemonic_any_language(mnemonic_str) {
-        Ok(m) => m,
-        Err(e) => {
-            return PlatformWalletFFIResult::err(
-                PlatformWalletFFIResultCode::ErrorWalletOperation,
-                format!("invalid mnemonic: {e}"),
-            );
-        }
-    };
-    let seed: Zeroizing<[u8; 64]> = Zeroizing::new(mnemonic.to_seed(""));
-    drop(mnemonic);
-
     // Look up the wallet + the network-scoped shielded coordinator
     // on the manager. The coordinator owns the single SQLite handle
     // *and* the per-network sync-coordination registry; we hand it
-    // to `bind_shielded` so the wallet reuses the shared store and
+    // to the bind so the wallet reuses the shared store and
     // self-registers its viewing keys for the coordinator-driven
     // sync loop.
     let lookup = PLATFORM_WALLET_MANAGER_STORAGE.with_item(handle, |manager| {
@@ -341,6 +277,34 @@ pub unsafe extern "C" fn platform_wallet_manager_bind_shielded(
                 "shielded support not configured — call platform_wallet_manager_configure_shielded first",
             );
         }
+    };
+
+    // Seedless path first: rebind from viewing keys persisted by a
+    // prior seed-backed bind. `Ok(false)` means at least one
+    // requested account has no persisted row — only then is the
+    // mnemonic resolved.
+    match runtime()
+        .block_on(wallet_arc.bind_shielded_from_persisted(accounts.as_slice(), &coordinator))
+    {
+        Ok(true) => return PlatformWalletFFIResult::ok(),
+        Ok(false) => {}
+        Err(e) => {
+            return PlatformWalletFFIResult::err(
+                PlatformWalletFFIResultCode::ErrorWalletOperation,
+                format!("bind_shielded_from_persisted failed: {e}"),
+            );
+        }
+    }
+
+    // Fallback: resolve the mnemonic via the host callback and
+    // derive from seed (which also persists the viewing keys so the
+    // next launch takes the seedless path above).
+    let seed = match crate::identity_keys_from_mnemonic::resolve_seed_from_resolver(
+        mnemonic_resolver_handle,
+        &wallet_id,
+    ) {
+        Ok(seed) => seed,
+        Err(result) => return result,
     };
 
     if let Err(e) = runtime().block_on(wallet_arc.bind_shielded(

--- a/packages/rs-platform-wallet/src/changeset/shielded_changeset.rs
+++ b/packages/rs-platform-wallet/src/changeset/shielded_changeset.rs
@@ -51,6 +51,14 @@ pub struct ShieldedChangeSet {
     /// Defaults empty so every pre-activity flow rides the existing
     /// changeset path unchanged.
     pub activity_entries: BTreeMap<SubwalletId, Vec<ShieldedActivityEntry>>,
+    /// Per-subwallet Orchard viewing keys to persist, as the raw
+    /// 96-byte FVK encoding (stored as `Vec<u8>` — serde-derive only
+    /// covers arrays ≤ 32). Emitted once per seed-backed
+    /// `bind_shielded` so later launches can rebind viewing-grade
+    /// state without resolving the mnemonic. Last write wins on
+    /// merge (the FVK for a `(wallet, account, network)` never
+    /// legitimately changes).
+    pub viewing_keys: BTreeMap<SubwalletId, Vec<u8>>,
 }
 
 impl ShieldedChangeSet {
@@ -61,6 +69,7 @@ impl ShieldedChangeSet {
             && self.outgoing_notes.is_empty()
             && self.synced_indices.is_empty()
             && self.activity_entries.is_empty()
+            && self.viewing_keys.is_empty()
     }
 
     /// Accumulator helper: record a saved note for `id`.
@@ -93,6 +102,12 @@ impl ShieldedChangeSet {
         }
     }
 
+    /// Accumulator helper: record a subwallet's Orchard viewing key
+    /// (raw 96-byte FVK encoding). Last write wins.
+    pub fn record_viewing_key(&mut self, id: SubwalletId, fvk_bytes: [u8; 96]) {
+        self.viewing_keys.insert(id, fvk_bytes.to_vec());
+    }
+
     /// Split a consolidated shielded changeset into one
     /// `ShieldedChangeSet` per `WalletId`. Used by the
     /// network-scoped coordinator's sync path: the free
@@ -111,6 +126,7 @@ impl ShieldedChangeSet {
             outgoing_notes,
             synced_indices,
             activity_entries,
+            viewing_keys,
         } = self;
         let mut out: BTreeMap<crate::wallet::platform_wallet::WalletId, ShieldedChangeSet> =
             BTreeMap::new();
@@ -143,6 +159,12 @@ impl ShieldedChangeSet {
                 .or_default()
                 .activity_entries
                 .insert(id, entries);
+        }
+        for (id, fvk) in viewing_keys {
+            out.entry(id.wallet_id)
+                .or_default()
+                .viewing_keys
+                .insert(id, fvk);
         }
         // Defensive: drop empty entries so the persister doesn't
         // see noise. `split_by_wallet_id` is called on the result
@@ -177,6 +199,11 @@ impl Merge for ShieldedChangeSet {
         // original) wins at persist time without needing to dedupe here.
         for (id, entries) in other.activity_entries {
             self.activity_entries.entry(id).or_default().extend(entries);
+        }
+        // Viewing keys: last write wins (the FVK for a subwallet is
+        // stable on a given network, so any re-emit is identical).
+        for (id, fvk) in other.viewing_keys {
+            self.viewing_keys.insert(id, fvk);
         }
     }
 

--- a/packages/rs-platform-wallet/src/changeset/shielded_sync_start_state.rs
+++ b/packages/rs-platform-wallet/src/changeset/shielded_sync_start_state.rs
@@ -53,11 +53,21 @@ pub struct ShieldedSubwalletStartState {
 #[derive(Debug, Default)]
 pub struct ShieldedSyncStartState {
     pub per_subwallet: BTreeMap<SubwalletId, ShieldedSubwalletStartState>,
+    /// Persisted per-subwallet Orchard viewing keys, as the raw
+    /// 96-byte FVK encoding (`Vec<u8>` for symmetry with the
+    /// changeset field). Written once at the first seed-backed
+    /// `bind_shielded`; consumed by
+    /// `PlatformWallet::bind_shielded_from_persisted` so a launch
+    /// can rebind viewing-grade state without resolving the
+    /// mnemonic. Kept separate from `per_subwallet` — a subwallet
+    /// can have a viewing key but no notes yet, and vice versa
+    /// (legacy rows persisted before this field existed).
+    pub viewing_keys: BTreeMap<SubwalletId, Vec<u8>>,
 }
 
 impl ShieldedSyncStartState {
     /// `true` iff no subwallet snapshot is restored.
     pub fn is_empty(&self) -> bool {
-        self.per_subwallet.is_empty()
+        self.per_subwallet.is_empty() && self.viewing_keys.is_empty()
     }
 }

--- a/packages/rs-platform-wallet/src/wallet/platform_wallet.rs
+++ b/packages/rs-platform-wallet/src/wallet/platform_wallet.rs
@@ -92,16 +92,19 @@ pub struct PlatformWallet {
     /// Sync / spend operations source the shared
     /// commitment-tree store from
     /// [`NetworkShieldedCoordinator`] (one SQLite handle per
-    /// network) rather than per-wallet, so all this slot needs
-    /// to hold is the spend-authority keysets — the
-    /// `SpendAuthorizingKey` lives here, the viewing-key half
-    /// is mirrored on the coordinator's account registry.
+    /// network) rather than per-wallet, so all this slot holds
+    /// is the per-account viewing-grade material (FVK / IVK /
+    /// OVK / default address), mirrored on the coordinator's
+    /// account registry. No `SpendAuthorizingKey` is resident:
+    /// spend operations re-derive the full `OrchardKeySet` from
+    /// the caller-supplied wallet seed for the duration of the
+    /// spend call only, then drop it.
     ///
     /// [`bind_shielded`]: Self::bind_shielded
     /// [`NetworkShieldedCoordinator`]: crate::wallet::shielded::NetworkShieldedCoordinator
     #[cfg(feature = "shielded")]
     pub(crate) shielded_keys:
-        Arc<RwLock<Option<std::collections::BTreeMap<u32, super::shielded::OrchardKeySet>>>>,
+        Arc<RwLock<Option<std::collections::BTreeMap<u32, super::shielded::AccountViewingKeys>>>>,
     /// Per-wallet single-flight guard for shield-class operations
     /// (Type 15). Two concurrent `shield` calls on one wallet would
     /// each fetch the same address nonce and build with `nonce + 1`, so
@@ -472,14 +475,19 @@ impl PlatformWallet {
     ///
     /// Derives ZIP-32 Orchard keys for every entry of `accounts`
     /// from `seed` (a 32-252 byte BIP-39 seed; see
-    /// [`SpendingKey::from_zip32_seed`]), opens or creates the
-    /// per-network commitment tree at `db_path`, and stores the
-    /// resulting multi-account [`ShieldedWallet`] on this handle.
-    /// The caller is responsible for sourcing the seed (e.g. via
-    /// the host `MnemonicResolverHandle`) and for zeroizing it
-    /// once this call returns. The seed is not retained — only
-    /// the per-account FVK / IVK / OVK / default address derived
-    /// from it survive on the wallet.
+    /// [`SpendingKey::from_zip32_seed`]) and installs the
+    /// viewing-grade half (FVK / IVK / OVK / default address) on
+    /// this handle and the coordinator's registry. The caller is
+    /// responsible for sourcing the seed (e.g. via the host
+    /// `MnemonicResolverHandle`) and for zeroizing it once this
+    /// call returns. The seed is not retained, and neither is any
+    /// `SpendAuthorizingKey` — spend operations re-derive it from
+    /// a caller-supplied seed per call.
+    ///
+    /// The derived per-account viewing keys are queued to the host
+    /// persister (as raw 96-byte FVK encodings) so later launches
+    /// can rebind via [`bind_shielded_from_persisted`] without
+    /// resolving the mnemonic at all.
     ///
     /// Idempotent: a second call replaces the previously-bound
     /// shielded wallet (e.g. after a network switch).
@@ -487,6 +495,7 @@ impl PlatformWallet {
     /// `accounts` must be non-empty; pass `&[0]` for the
     /// single-account default.
     ///
+    /// [`bind_shielded_from_persisted`]: Self::bind_shielded_from_persisted
     /// [`SpendingKey::from_zip32_seed`]: grovedb_commitment_tree::SpendingKey::from_zip32_seed
     #[cfg(feature = "shielded")]
     pub async fn bind_shielded(
@@ -495,41 +504,121 @@ impl PlatformWallet {
         accounts: &[u32],
         coordinator: &Arc<crate::wallet::shielded::NetworkShieldedCoordinator>,
     ) -> Result<(), PlatformWalletError> {
-        // Phase 4d.3: derive the per-account `OrchardKeySet` map
-        // directly — no more `ShieldedWallet` wrapper. The shared
-        // commitment-tree store lives on the coordinator (one
-        // SQLite handle per network); the spend methods source it
-        // there at call time. The per-wallet side just needs the
-        // keysets (with the `SpendAuthorizingKey`) for spend
-        // authorization.
-        use super::shielded::{AccountViewingKeys, OrchardKeySet};
+        use super::shielded::{AccountViewingKeys, OrchardKeySet, SubwalletId};
         if accounts.is_empty() {
             return Err(PlatformWalletError::ShieldedKeyDerivation(
                 "shielded wallet requires at least one account".to_string(),
             ));
         }
         let network = self.sdk.network;
-        let mut keys: std::collections::BTreeMap<u32, OrchardKeySet> =
+        let mut account_views: std::collections::BTreeMap<u32, AccountViewingKeys> =
             std::collections::BTreeMap::new();
         for &account in accounts {
             // `accounts` may contain duplicates; the BTreeMap
-            // dedups by definition.
+            // dedups by definition. The full keyset (with its
+            // `SpendAuthorizingKey`) is dropped at the end of
+            // this iteration — only the viewing half survives.
             let ks = OrchardKeySet::from_seed(seed, network, account)?;
-            keys.insert(account, ks);
+            account_views.insert(account, ks.viewing_keys());
         }
 
-        // Snapshot the viewing-key subset for coordinator
-        // registration. Privilege separation: only FVK / IVK /
-        // OVK / default address cross to the coordinator; the
-        // `SpendAuthorizingKey` stays here on the per-wallet
-        // side inside `OrchardKeySet`.
-        let account_views: std::collections::BTreeMap<u32, AccountViewingKeys> = keys
-            .iter()
-            .map(|(account, ks)| (*account, ks.viewing_keys()))
-            .collect();
+        // Persist the viewing keys while the seed is legitimately
+        // present, so every later launch can rebind seedlessly. A
+        // queue failure is logged inside the persister wrapper and
+        // does not fail the bind — the next seed-backed bind
+        // re-emits the same bytes.
+        let mut cs = crate::changeset::ShieldedChangeSet::default();
+        for (account, views) in &account_views {
+            cs.record_viewing_key(
+                SubwalletId::new(self.wallet_id, *account),
+                views.to_fvk_bytes(),
+            );
+        }
+        if let Err(e) = self
+            .persister
+            .store(crate::changeset::PlatformWalletChangeSet {
+                shielded: Some(cs),
+                ..Default::default()
+            })
+        {
+            tracing::warn!(
+                wallet_id = %hex::encode(self.wallet_id),
+                error = %e,
+                "Failed to queue shielded viewing keys for persistence; \
+                 the next seed-backed bind will retry"
+            );
+        }
 
+        self.install_shielded_views(account_views, coordinator, None)
+            .await
+    }
+
+    /// Bind the shielded sub-wallet from viewing keys persisted by a
+    /// prior seed-backed [`bind_shielded`](Self::bind_shielded),
+    /// without touching the wallet seed.
+    ///
+    /// Reads the persister's start-state snapshot for this wallet's
+    /// per-account FVK rows and installs the reconstructed
+    /// viewing-grade material exactly like a seed bind. Returns
+    /// `Ok(false)` — with no state change — when the persister has no
+    /// viewing key for at least one entry of `accounts` (first bind
+    /// after create/import, or legacy persistence predating viewing-key
+    /// rows); the caller then falls back to the seed path. A persisted
+    /// row that fails to decode is an error, not a fallback — silent
+    /// re-resolution would mask persistence corruption.
+    #[cfg(feature = "shielded")]
+    pub async fn bind_shielded_from_persisted(
+        &self,
+        accounts: &[u32],
+        coordinator: &Arc<crate::wallet::shielded::NetworkShieldedCoordinator>,
+    ) -> Result<bool, PlatformWalletError> {
+        use super::shielded::{AccountViewingKeys, SubwalletId};
+        if accounts.is_empty() {
+            return Err(PlatformWalletError::ShieldedKeyDerivation(
+                "shielded wallet requires at least one account".to_string(),
+            ));
+        }
+        let start = self.persister.load().map_err(|e| {
+            PlatformWalletError::ShieldedBuildError(format!(
+                "persister load failed while rebinding shielded viewing keys: {e}"
+            ))
+        })?;
+        let mut account_views: std::collections::BTreeMap<u32, AccountViewingKeys> =
+            std::collections::BTreeMap::new();
+        for &account in accounts {
+            let id = SubwalletId::new(self.wallet_id, account);
+            let Some(fvk_bytes) = start.shielded.viewing_keys.get(&id) else {
+                return Ok(false);
+            };
+            let fvk_bytes: &[u8; 96] = fvk_bytes.as_slice().try_into().map_err(|_| {
+                PlatformWalletError::ShieldedKeyDerivation(format!(
+                    "persisted viewing key for account {account} is {} bytes, expected 96",
+                    fvk_bytes.len()
+                ))
+            })?;
+            account_views.insert(account, AccountViewingKeys::from_fvk_bytes(fvk_bytes)?);
+        }
+        // Hand the already-loaded snapshot to the install step so the
+        // restore doesn't pay a second full persister load.
+        self.install_shielded_views(account_views, coordinator, Some(start))
+            .await?;
+        Ok(true)
+    }
+
+    /// Shared tail of the two bind paths: store the viewing-grade
+    /// map on this handle, replace this wallet's registration on
+    /// the coordinator, and rehydrate persisted notes / watermarks.
+    /// `preloaded` reuses a start-state snapshot the caller already
+    /// fetched (the persisted-keys path); `None` loads one here.
+    #[cfg(feature = "shielded")]
+    async fn install_shielded_views(
+        &self,
+        account_views: std::collections::BTreeMap<u32, super::shielded::AccountViewingKeys>,
+        coordinator: &Arc<crate::wallet::shielded::NetworkShieldedCoordinator>,
+        preloaded: Option<crate::changeset::ClientStartState>,
+    ) -> Result<(), PlatformWalletError> {
         let mut slot = self.shielded_keys.write().await;
-        *slot = Some(keys);
+        *slot = Some(account_views.clone());
         drop(slot);
 
         // Rebind is replace-not-merge (the doc contract above).
@@ -556,7 +645,7 @@ impl PlatformWallet {
         // boot-time snapshot, indexed by SubwalletId. Errors are
         // logged but not fatal — first-launch wallets simply
         // see no persisted state.
-        match self.persister.load() {
+        match preloaded.map(Ok).unwrap_or_else(|| self.persister.load()) {
             Ok(start) => {
                 if let Err(e) = coordinator
                     .restore_for_wallet(self.wallet_id, &start.shielded)
@@ -596,14 +685,36 @@ impl PlatformWallet {
         seed: &[u8],
         account: u32,
     ) -> Result<(), PlatformWalletError> {
-        use super::shielded::OrchardKeySet;
+        use super::shielded::{OrchardKeySet, SubwalletId};
         let mut slot = self.shielded_keys.write().await;
         let keys = slot.as_mut().ok_or(PlatformWalletError::ShieldedNotBound)?;
         if keys.contains_key(&account) {
             return Ok(());
         }
-        let ks = OrchardKeySet::from_seed(seed, self.sdk.network, account)?;
-        keys.insert(account, ks);
+        let views = OrchardKeySet::from_seed(seed, self.sdk.network, account)?.viewing_keys();
+        // Persist the new account's viewing key alongside the
+        // in-memory insert, mirroring `bind_shielded`, so the
+        // seedless rebind path covers it on the next launch.
+        let mut cs = crate::changeset::ShieldedChangeSet::default();
+        cs.record_viewing_key(
+            SubwalletId::new(self.wallet_id, account),
+            views.to_fvk_bytes(),
+        );
+        if let Err(e) = self
+            .persister
+            .store(crate::changeset::PlatformWalletChangeSet {
+                shielded: Some(cs),
+                ..Default::default()
+            })
+        {
+            tracing::warn!(
+                wallet_id = %hex::encode(self.wallet_id),
+                account,
+                error = %e,
+                "Failed to queue shielded viewing key for persistence"
+            );
+        }
+        keys.insert(account, views);
         // NOTE: this only updates the per-wallet keys slot — the
         // coordinator's `accounts` registry isn't refreshed here.
         // Hosts that add accounts after bind should re-call
@@ -677,12 +788,7 @@ impl PlatformWallet {
         };
         let subwallets: Vec<(SubwalletId, AccountViewingKeys)> = keys
             .iter()
-            .map(|(account, ks)| {
-                (
-                    SubwalletId::new(self.wallet_id, *account),
-                    ks.viewing_keys(),
-                )
-            })
+            .map(|(account, views)| (SubwalletId::new(self.wallet_id, *account), views.clone()))
             .collect();
         let per_sub =
             super::shielded::sync::balances_across(coordinator.store(), &subwallets).await?;
@@ -693,16 +799,59 @@ impl PlatformWallet {
             .collect())
     }
 
+    /// Transiently re-derive `account`'s full `OrchardKeySet` (ASK
+    /// included) from the caller-supplied wallet seed, for the
+    /// duration of one spend operation. The derived spend authority
+    /// is dropped when the returned value goes out of scope — no
+    /// `SpendAuthorizingKey` is ever resident on the wallet.
+    ///
+    /// Guards two invariants before handing the keyset back:
+    /// - `account` must be bound (viewing keys installed), so spend
+    ///   errors match the pre-split `ShieldedNotBound` /
+    ///   "account not bound" contract.
+    /// - the seed-derived FVK must equal the bound viewing key —
+    ///   a wrong seed (or a persisted-key / seed mismatch) fails
+    ///   loudly here instead of burning a ~30 s Halo 2 proof on a
+    ///   spend the chain would reject.
+    #[cfg(feature = "shielded")]
+    async fn derive_spend_keyset(
+        &self,
+        seed: &[u8],
+        account: u32,
+    ) -> Result<super::shielded::OrchardKeySet, PlatformWalletError> {
+        use super::shielded::OrchardKeySet;
+        let bound_fvk = {
+            let guard = self.shielded_keys.read().await;
+            let keys = guard
+                .as_ref()
+                .ok_or(PlatformWalletError::ShieldedNotBound)?;
+            let views = keys.get(&account).ok_or_else(|| {
+                PlatformWalletError::ShieldedKeyDerivation(format!(
+                    "shielded account {account} not bound"
+                ))
+            })?;
+            views.full_viewing_key.to_bytes()
+        };
+        let keyset = OrchardKeySet::from_seed(seed, self.sdk.network, account)?;
+        if keyset.full_viewing_key.to_bytes() != bound_fvk {
+            return Err(PlatformWalletError::ShieldedKeyDerivation(format!(
+                "seed does not derive the bound viewing key for shielded account {account}"
+            )));
+        }
+        Ok(keyset)
+    }
+
     /// Send a private shielded → shielded transfer from `account`'s
     /// notes to `recipient_raw_43` (the recipient's Orchard payment
     /// address as the 43 raw bytes).
     ///
     /// `coordinator` supplies the shared, network-scoped
-    /// commitment-tree store; the wallet supplies the
-    /// `OrchardKeySet` (with the `SpendAuthorizingKey`) by
-    /// account. Privilege separation: the ASK never crosses to
-    /// the coordinator — the spend free function takes the
-    /// keyset by reference at call time.
+    /// commitment-tree store; `seed` supplies the spend authority —
+    /// the full `OrchardKeySet` (with the `SpendAuthorizingKey`) is
+    /// re-derived from it for this call only and dropped on return.
+    /// Privilege separation: the ASK never crosses to the
+    /// coordinator — the spend free function takes the keyset by
+    /// reference at call time.
     ///
     /// The prover is consumed by value rather than borrowed
     /// because `OrchardProver` is impl'd on
@@ -711,24 +860,18 @@ impl PlatformWallet {
     /// and we forward it down to the spend free function's
     /// `&P` parameter.
     #[cfg(feature = "shielded")]
+    #[allow(clippy::too_many_arguments)]
     pub async fn shielded_transfer_to<P: dpp::shielded::builder::OrchardProver>(
         &self,
         coordinator: &Arc<crate::wallet::shielded::NetworkShieldedCoordinator>,
+        seed: &[u8],
         account: u32,
         recipient_raw_43: &[u8; 43],
         amount: u64,
         memo: [u8; 36],
         prover: P,
     ) -> Result<(), PlatformWalletError> {
-        let guard = self.shielded_keys.read().await;
-        let keys = guard
-            .as_ref()
-            .ok_or(PlatformWalletError::ShieldedNotBound)?;
-        let keyset = keys.get(&account).ok_or_else(|| {
-            PlatformWalletError::ShieldedKeyDerivation(format!(
-                "shielded account {account} not bound"
-            ))
-        })?;
+        let keyset = self.derive_spend_keyset(seed, account).await?;
         let recipient = Option::<grovedb_commitment_tree::PaymentAddress>::from(
             grovedb_commitment_tree::PaymentAddress::from_raw_address_bytes(recipient_raw_43),
         )
@@ -742,7 +885,7 @@ impl PlatformWallet {
             coordinator.store(),
             Some(&self.persister),
             self.wallet_id,
-            keyset,
+            &keyset,
             account,
             &recipient,
             amount,
@@ -756,25 +899,20 @@ impl PlatformWallet {
     /// address (`"dash1…"` / `"tdash1…"`). Parsed via
     /// `PlatformAddress::from_bech32m_string`; the recipient's HRP is
     /// verified against the wallet's network HRP class here, since the
-    /// network-agnostic decoder no longer enforces it.
+    /// network-agnostic decoder no longer enforces it. `seed` supplies
+    /// the transient spend authority (see
+    /// [`shielded_transfer_to`](Self::shielded_transfer_to)).
     #[cfg(feature = "shielded")]
     pub async fn shielded_unshield_to<P: dpp::shielded::builder::OrchardProver>(
         &self,
         coordinator: &Arc<crate::wallet::shielded::NetworkShieldedCoordinator>,
+        seed: &[u8],
         account: u32,
         to_platform_addr_bech32m: &str,
         amount: u64,
         prover: P,
     ) -> Result<(), PlatformWalletError> {
-        let guard = self.shielded_keys.read().await;
-        let keys = guard
-            .as_ref()
-            .ok_or(PlatformWalletError::ShieldedNotBound)?;
-        let keyset = keys.get(&account).ok_or_else(|| {
-            PlatformWalletError::ShieldedKeyDerivation(format!(
-                "shielded account {account} not bound"
-            ))
-        })?;
+        let keyset = self.derive_spend_keyset(seed, account).await?;
         // The decoder is network-agnostic, so guard the recipient's HRP class
         // against the wallet's network before decoding.
         check_recipient_hrp(to_platform_addr_bech32m, self.sdk.network)?;
@@ -787,7 +925,7 @@ impl PlatformWallet {
             coordinator.store(),
             Some(&self.persister),
             self.wallet_id,
-            keyset,
+            &keyset,
             account,
             &to,
             amount,
@@ -798,26 +936,22 @@ impl PlatformWallet {
 
     /// Withdraw from `account`'s notes to a Core L1 address
     /// (Base58Check string). `core_fee_per_byte` is the L1 fee
-    /// rate (duffs/byte).
+    /// rate (duffs/byte). `seed` supplies the transient spend
+    /// authority (see
+    /// [`shielded_transfer_to`](Self::shielded_transfer_to)).
     #[cfg(feature = "shielded")]
+    #[allow(clippy::too_many_arguments)]
     pub async fn shielded_withdraw_to<P: dpp::shielded::builder::OrchardProver>(
         &self,
         coordinator: &Arc<crate::wallet::shielded::NetworkShieldedCoordinator>,
+        seed: &[u8],
         account: u32,
         to_core_address: &str,
         amount: u64,
         core_fee_per_byte: u32,
         prover: P,
     ) -> Result<(), PlatformWalletError> {
-        let guard = self.shielded_keys.read().await;
-        let keys = guard
-            .as_ref()
-            .ok_or(PlatformWalletError::ShieldedNotBound)?;
-        let keyset = keys.get(&account).ok_or_else(|| {
-            PlatformWalletError::ShieldedKeyDerivation(format!(
-                "shielded account {account} not bound"
-            ))
-        })?;
+        let keyset = self.derive_spend_keyset(seed, account).await?;
         let network = self.sdk.network;
         let parsed = to_core_address
             .parse::<dashcore::Address<dashcore::address::NetworkUnchecked>>()
@@ -835,7 +969,7 @@ impl PlatformWallet {
             coordinator.store(),
             Some(&self.persister),
             self.wallet_id,
-            keyset,
+            &keyset,
             account,
             &parsed,
             amount,
@@ -854,8 +988,8 @@ impl PlatformWallet {
     ///
     /// `public_keys` is the new identity's key set (each entry pairs the `IdentityPublicKey` with
     /// its `IdentityPublicKeyInCreation` form); `identity_signer` produces each key's
-    /// proof-of-possession signature. The Orchard spend authority comes from the wallet's own
-    /// `OrchardKeySet` (the ASK never crosses to the coordinator).
+    /// proof-of-possession signature. The Orchard spend authority is re-derived from `seed` for
+    /// this call only (the ASK never crosses to the coordinator and is not retained).
     ///
     /// `identity_index` is the DIP-9 identity-registration slot the new identity occupies in the
     /// local `IdentityManager`; on a successful broadcast the proof-verified identity is registered
@@ -868,6 +1002,7 @@ impl PlatformWallet {
     pub async fn shielded_identity_create_from_pool<P, IS>(
         &self,
         coordinator: &Arc<crate::wallet::shielded::NetworkShieldedCoordinator>,
+        seed: &[u8],
         account: u32,
         identity_index: u32,
         public_keys: Vec<(
@@ -884,23 +1019,16 @@ impl PlatformWallet {
         IS: dpp::identity::signer::Signer<dpp::identity::IdentityPublicKey> + Send + Sync,
     {
         let (identity_id, identity) = {
-            // Scope the read guard so it's released before we take the wallet-manager write lock
-            // below — the keyset is only needed for the spend, not for the registration step.
-            let guard = self.shielded_keys.read().await;
-            let keys = guard
-                .as_ref()
-                .ok_or(PlatformWalletError::ShieldedNotBound)?;
-            let keyset = keys.get(&account).ok_or_else(|| {
-                PlatformWalletError::ShieldedKeyDerivation(format!(
-                    "shielded account {account} not bound"
-                ))
-            })?;
+            // Scope the transient keyset so its spend authority is dropped before we take the
+            // wallet-manager write lock below — it's only needed for the spend, not for the
+            // registration step.
+            let keyset = self.derive_spend_keyset(seed, account).await?;
             super::shielded::operations::identity_create_from_shielded_pool(
                 &self.sdk,
                 coordinator.store(),
                 Some(&self.persister),
                 self.wallet_id,
-                keyset,
+                &keyset,
                 account,
                 public_keys,
                 denomination,

--- a/packages/rs-platform-wallet/src/wallet/shielded/activity_recorder.rs
+++ b/packages/rs-platform-wallet/src/wallet/shielded/activity_recorder.rs
@@ -32,7 +32,7 @@ use super::activity::{
     compute_activity_id, ShieldedActivityEntry, ShieldedActivityKind, ShieldedActivityStatus,
     ShieldedDirection,
 };
-use super::keys::OrchardKeySet;
+use super::keys::AccountViewingKeys;
 use super::store::{ShieldedNote, SubwalletId};
 use crate::changeset::ShieldedChangeSet;
 
@@ -52,8 +52,10 @@ use dpp::shielded::SerializedAction;
 /// recoverable output plaintext for this wallet) contribute nothing —
 /// exactly the outputs the scan can't see either. Order-independent: the
 /// caller hashes via [`compute_activity_id`], which sorts + dedups.
-pub fn visible_output_cmxs(actions: &[SerializedAction], keys: &OrchardKeySet) -> Vec<[u8; 32]> {
-    let prepared_ivk = keys.prepared_ivk();
+pub fn visible_output_cmxs(
+    actions: &[SerializedAction],
+    keys: &AccountViewingKeys,
+) -> Vec<[u8; 32]> {
     let mut cmxs: Vec<[u8; 32]> = Vec::new();
     for a in actions {
         let wire = ShieldedEncryptedNote {
@@ -63,7 +65,7 @@ pub fn visible_output_cmxs(actions: &[SerializedAction], keys: &OrchardKeySet) -
             encrypted_note: a.encrypted_note.clone(),
         };
         // Own output (change / self-send) via IVK.
-        if let Some((note, _addr)) = try_decrypt_note(&prepared_ivk, &wire) {
+        if let Some((note, _addr)) = try_decrypt_note(&keys.prepared_ivk, &wire) {
             cmxs.push(ExtractedNoteCommitment::from(note.commitment()).to_bytes());
             continue;
         }
@@ -108,7 +110,7 @@ pub struct LiveEntryParams<'a> {
 /// wallet-visible output cmx (a degenerate all-dummy bundle), so the
 /// caller skips recording rather than persisting a degenerate id.
 pub fn build_pending_entry(
-    keys: &OrchardKeySet,
+    keys: &AccountViewingKeys,
     params: LiveEntryParams<'_>,
 ) -> Option<ShieldedActivityEntry> {
     let note_cmxs = visible_output_cmxs(params.actions, keys);

--- a/packages/rs-platform-wallet/src/wallet/shielded/keys.rs
+++ b/packages/rs-platform-wallet/src/wallet/shielded/keys.rs
@@ -152,10 +152,14 @@ impl OrchardKeySet {
 ///
 /// The network-scoped shielded coordinator holds these for every
 /// bound `(walletId, accountIndex)`; it never sees a
-/// `SpendAuthorizingKey`. Spend operations are driven from the
-/// per-wallet side, which holds the full [`OrchardKeySet`] (ASK
-/// included) and passes it into the coordinator's spend methods
-/// only for the duration of that call.
+/// `SpendAuthorizingKey`. Spend operations re-derive the full
+/// [`OrchardKeySet`] (ASK included) from the wallet seed for the
+/// duration of that call only.
+///
+/// The whole struct is a pure function of the 96-byte raw FVK
+/// encoding ([`Self::to_fvk_bytes`] / [`Self::from_fvk_bytes`]),
+/// which is what hosts persist so a later launch can rebind the
+/// shielded sub-wallet without touching the wallet seed.
 #[derive(Clone)]
 pub struct AccountViewingKeys {
     pub full_viewing_key: FullViewingKey,
@@ -166,6 +170,48 @@ pub struct AccountViewingKeys {
     pub prepared_ivk: PreparedIncomingViewingKey,
     pub outgoing_viewing_key: OutgoingViewingKey,
     pub default_address: PaymentAddress,
+}
+
+impl AccountViewingKeys {
+    /// Derive the full viewing-grade set from an Orchard
+    /// `FullViewingKey`. IVK / OVK / default address are all pure
+    /// functions of the FVK (external scope, diversifier index 0 —
+    /// the same choices [`OrchardKeySet::from_seed`] makes), so a
+    /// persisted FVK alone reconstructs everything sync needs.
+    pub fn from_full_viewing_key(fvk: FullViewingKey) -> Self {
+        let ivk = fvk.to_ivk(Scope::External);
+        let ovk = fvk.to_ovk(Scope::External);
+        let default_address = fvk.address_at(0u32, Scope::External);
+        let prepared_ivk = PreparedIncomingViewingKey::new(&ivk);
+        Self {
+            full_viewing_key: fvk,
+            incoming_viewing_key: ivk,
+            prepared_ivk,
+            outgoing_viewing_key: ovk,
+            default_address,
+        }
+    }
+
+    /// The raw 96-byte FVK encoding (`ak ‖ nk ‖ rivk`) — the only
+    /// bytes a host has to persist to reconstruct this struct.
+    pub fn to_fvk_bytes(&self) -> [u8; 96] {
+        self.full_viewing_key.to_bytes()
+    }
+
+    /// Reconstruct from a persisted raw 96-byte FVK encoding.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when the bytes are not a canonical FVK
+    /// encoding (any component fails its curve / field check).
+    pub fn from_fvk_bytes(bytes: &[u8; 96]) -> Result<Self, PlatformWalletError> {
+        let fvk = FullViewingKey::from_bytes(bytes).ok_or_else(|| {
+            PlatformWalletError::ShieldedKeyDerivation(
+                "persisted Orchard full viewing key bytes are not a canonical encoding".to_string(),
+            )
+        })?;
+        Ok(Self::from_full_viewing_key(fvk))
+    }
 }
 
 #[cfg(test)]
@@ -315,5 +361,49 @@ mod tests {
             "default address drifted"
         );
         assert_eq!(hex::encode(ivk), EXPECTED_IVK, "raw IVK encoding drifted");
+    }
+
+    /// The persisted-FVK round trip must reconstruct the exact
+    /// viewing-grade set the seed derived: a launch that rebinds
+    /// from the 96 persisted bytes has to trial-decrypt the same
+    /// notes, recover the same send history (OVK), and show the
+    /// same default address as the original seed bind — with no
+    /// seed in reach.
+    #[test]
+    fn viewing_keys_round_trip_through_fvk_bytes() {
+        let seed = [0x42u8; 64];
+        let ks = OrchardKeySet::from_seed(&seed, Network::Testnet, 0).expect("derivation succeeds");
+        let original = ks.viewing_keys();
+
+        let fvk_bytes = original.to_fvk_bytes();
+        let restored =
+            AccountViewingKeys::from_fvk_bytes(&fvk_bytes).expect("persisted FVK decodes");
+
+        assert_eq!(
+            restored.full_viewing_key.to_bytes(),
+            original.full_viewing_key.to_bytes(),
+            "FVK drifted through the byte round trip"
+        );
+        assert_eq!(
+            restored.incoming_viewing_key.to_bytes(),
+            original.incoming_viewing_key.to_bytes(),
+            "IVK must re-derive identically from the persisted FVK"
+        );
+        assert_eq!(
+            restored.outgoing_viewing_key.as_ref(),
+            original.outgoing_viewing_key.as_ref(),
+            "OVK must re-derive identically from the persisted FVK"
+        );
+        assert_eq!(
+            restored.default_address.to_raw_address_bytes(),
+            original.default_address.to_raw_address_bytes(),
+            "default address must re-derive identically from the persisted FVK"
+        );
+
+        // Corrupt encodings are rejected, not silently accepted.
+        assert!(
+            AccountViewingKeys::from_fvk_bytes(&[0xFFu8; 96]).is_err(),
+            "non-canonical FVK bytes must be rejected"
+        );
     }
 }

--- a/packages/rs-platform-wallet/src/wallet/shielded/mod.rs
+++ b/packages/rs-platform-wallet/src/wallet/shielded/mod.rs
@@ -43,6 +43,8 @@ pub mod prover;
 pub mod seed_pool;
 pub mod store;
 pub mod sync;
+#[cfg(test)]
+mod viewing_key_bind_tests;
 
 pub use activity::{
     compute_activity_id, derive_activity_from_scan_data, sort_activity_for_display,

--- a/packages/rs-platform-wallet/src/wallet/shielded/operations.rs
+++ b/packages/rs-platform-wallet/src/wallet/shielded/operations.rs
@@ -23,7 +23,7 @@ use super::activity::{ShieldedActivityKind, ShieldedActivityStatus, ShieldedDire
 use super::activity_recorder::{
     build_pending_entry, changeset_for_entry, non_zero_memo, with_status, LiveEntryParams,
 };
-use super::keys::OrchardKeySet;
+use super::keys::{AccountViewingKeys, OrchardKeySet};
 use super::note_selection::{
     select_notes_for_denomination, select_notes_with_fee, ShieldedFeeKind,
 };
@@ -242,7 +242,7 @@ async fn record_pending_activity<S: ShieldedStore>(
     persister: Option<&WalletPersister>,
     wallet_id: WalletId,
     id: SubwalletId,
-    keys: &OrchardKeySet,
+    keys: &AccountViewingKeys,
     params: LiveEntryParams<'_>,
 ) -> Option<super::activity::ShieldedActivityEntry> {
     let kind = params.kind.clone();
@@ -401,7 +401,7 @@ pub async fn shield<S: ShieldedStore, Sig: Signer<PlatformAddress>, P: OrchardPr
     store: &Arc<RwLock<S>>,
     persister: Option<&WalletPersister>,
     wallet_id: WalletId,
-    keys: &OrchardKeySet,
+    keys: &AccountViewingKeys,
     account: u32,
     inputs: BTreeMap<PlatformAddress, Credits>,
     amount: u64,
@@ -657,7 +657,8 @@ pub async fn unshield<S: ShieldedStore, P: OrchardProver>(
     amount: u64,
     prover: &P,
 ) -> Result<(), PlatformWalletError> {
-    let change_addr = default_orchard_address(keys)?;
+    let views = keys.viewing_keys();
+    let change_addr = default_orchard_address(&views)?;
     let id = SubwalletId::new(wallet_id, account);
 
     // Reserve against the 2-action floor: Orchard's BundleType::DEFAULT pads single-spend
@@ -727,7 +728,7 @@ pub async fn unshield<S: ShieldedStore, P: OrchardProver>(
             persister,
             wallet_id,
             id,
-            keys,
+            &views,
             LiveEntryParams {
                 kind: ShieldedActivityKind::Unshield,
                 direction: ShieldedDirection::Out,
@@ -849,7 +850,8 @@ pub async fn transfer<S: ShieldedStore, P: OrchardProver>(
     prover: &P,
 ) -> Result<(), PlatformWalletError> {
     let recipient_addr = payment_address_to_orchard(to_address)?;
-    let change_addr = default_orchard_address(keys)?;
+    let views = keys.viewing_keys();
+    let change_addr = default_orchard_address(&views)?;
     let id = SubwalletId::new(wallet_id, account);
 
     // ShieldedTransfer is carved with the base `compute_minimum_shielded_fee`, so reserve
@@ -904,7 +906,7 @@ pub async fn transfer<S: ShieldedStore, P: OrchardProver>(
             persister,
             wallet_id,
             id,
-            keys,
+            &views,
             LiveEntryParams {
                 kind: ShieldedActivityKind::Sent,
                 direction: ShieldedDirection::Out,
@@ -1002,7 +1004,8 @@ pub async fn withdraw<S: ShieldedStore, P: OrchardProver>(
     core_fee_per_byte: u32,
     prover: &P,
 ) -> Result<(), PlatformWalletError> {
-    let change_addr = default_orchard_address(keys)?;
+    let views = keys.viewing_keys();
+    let change_addr = default_orchard_address(&views)?;
     let id = SubwalletId::new(wallet_id, account);
     let output_script = CoreScript::from_bytes(to_address.script_pubkey().to_bytes());
 
@@ -1071,7 +1074,7 @@ pub async fn withdraw<S: ShieldedStore, P: OrchardProver>(
             persister,
             wallet_id,
             id,
-            keys,
+            &views,
             LiveEntryParams {
                 kind: ShieldedActivityKind::Withdrawal,
                 direction: ShieldedDirection::Out,
@@ -1197,7 +1200,8 @@ where
             "identity-create-from-shielded-pool requires at least one public key".to_string(),
         ));
     }
-    let change_addr = default_orchard_address(keys)?;
+    let views = keys.viewing_keys();
+    let change_addr = default_orchard_address(&views)?;
     let id = SubwalletId::new(wallet_id, account);
     let num_keys = public_keys.len();
 
@@ -1273,7 +1277,7 @@ where
             persister,
             wallet_id,
             id,
-            keys,
+            &views,
             LiveEntryParams {
                 kind: ShieldedActivityKind::IdentityCreate {
                     identity_id: identity_id.to_buffer(),
@@ -1598,7 +1602,9 @@ async fn fetch_identity_with_retries(
 // -------------------------------------------------------------------------
 
 /// Convert `keys`'s default `PaymentAddress` to an `OrchardAddress`.
-fn default_orchard_address(keys: &OrchardKeySet) -> Result<OrchardAddress, PlatformWalletError> {
+fn default_orchard_address(
+    keys: &AccountViewingKeys,
+) -> Result<OrchardAddress, PlatformWalletError> {
     payment_address_to_orchard(&keys.default_address)
 }
 

--- a/packages/rs-platform-wallet/src/wallet/shielded/sync/ovk_builder_roundtrip_tests.rs
+++ b/packages/rs-platform-wallet/src/wallet/shielded/sync/ovk_builder_roundtrip_tests.rs
@@ -237,14 +237,15 @@ async fn live_recorder_builds_entry_from_real_shield_bundle() {
         panic!("expected a Shield state transition");
     };
 
-    let cmxs = visible_output_cmxs(&v0.actions, &keys);
+    let views = keys.viewing_keys();
+    let cmxs = visible_output_cmxs(&v0.actions, &views);
     assert!(
         !cmxs.is_empty(),
         "recorder must recover the wallet-visible output cmx from a real bundle"
     );
 
     let entry = build_pending_entry(
-        &keys,
+        &views,
         LiveEntryParams {
             kind: ShieldedActivityKind::Shield,
             direction: ShieldedDirection::In,

--- a/packages/rs-platform-wallet/src/wallet/shielded/viewing_key_bind_tests.rs
+++ b/packages/rs-platform-wallet/src/wallet/shielded/viewing_key_bind_tests.rs
@@ -1,0 +1,278 @@
+//! Round-trip: bind → persist → simulated restart → seedless rebind.
+//!
+//! Pins the launch-path contract behind the viewing-key persistence
+//! seam: the first (seed-backed) `bind_shielded` queues each account's
+//! raw 96-byte FVK through the persister, and a later launch rebinds
+//! via `bind_shielded_from_persisted` from those rows alone — no seed
+//! parameter exists on that path, so a mnemonic resolve is impossible
+//! by construction. The rebind must reproduce the exact same
+//! viewing-grade material (FVK / IVK / OVK / default address) or the
+//! restarted wallet would trial-decrypt someone else's notes.
+
+use std::collections::BTreeMap;
+use std::path::PathBuf;
+use std::sync::{Arc, Mutex};
+
+use dashcore::Network;
+use key_wallet::account::StandardAccountType;
+
+use crate::changeset::PersistenceError;
+use crate::changeset::PlatformWalletPersistence;
+use crate::changeset::{ClientStartState, PlatformWalletChangeSet};
+use crate::test_support::funded_wallet_manager;
+use crate::wallet::platform_wallet::{PlatformWallet, WalletId};
+use crate::wallet::shielded::{FileBackedShieldedStore, NetworkShieldedCoordinator, SubwalletId};
+
+/// Persister double for both halves of the round trip:
+/// - `store` captures every queued changeset (the persist half);
+/// - `load` serves whatever viewing-key rows the test staged via
+///   [`Self::serve_viewing_keys`] (the restart half). Load calls are
+///   counted so the test can assert the seedless path actually read
+///   persistence rather than short-circuiting.
+#[derive(Default)]
+struct CapturingPersistence {
+    stored: Mutex<Vec<PlatformWalletChangeSet>>,
+    serve: Mutex<BTreeMap<SubwalletId, Vec<u8>>>,
+    load_calls: Mutex<usize>,
+}
+
+impl CapturingPersistence {
+    /// Every viewing-key row captured across all stored changesets.
+    fn captured_viewing_keys(&self) -> BTreeMap<SubwalletId, Vec<u8>> {
+        let mut out = BTreeMap::new();
+        for cs in self.stored.lock().expect("stored lock").iter() {
+            if let Some(shielded) = &cs.shielded {
+                for (id, fvk) in &shielded.viewing_keys {
+                    out.insert(*id, fvk.clone());
+                }
+            }
+        }
+        out
+    }
+
+    /// Stage the rows `load()` hands back — the "durable storage" the
+    /// restarted session finds.
+    fn serve_viewing_keys(&self, rows: BTreeMap<SubwalletId, Vec<u8>>) {
+        *self.serve.lock().expect("serve lock") = rows;
+    }
+
+    fn load_calls(&self) -> usize {
+        *self.load_calls.lock().expect("load_calls lock")
+    }
+}
+
+impl PlatformWalletPersistence for CapturingPersistence {
+    fn store(
+        &self,
+        _wallet_id: WalletId,
+        changeset: PlatformWalletChangeSet,
+    ) -> Result<(), PersistenceError> {
+        self.stored.lock().expect("stored lock").push(changeset);
+        Ok(())
+    }
+
+    fn flush(&self, _wallet_id: WalletId) -> Result<(), PersistenceError> {
+        Ok(())
+    }
+
+    fn load(&self) -> Result<ClientStartState, PersistenceError> {
+        *self.load_calls.lock().expect("load_calls lock") += 1;
+        let mut start = ClientStartState::default();
+        start.shielded.viewing_keys = self.serve.lock().expect("serve lock").clone();
+        Ok(start)
+    }
+}
+
+/// Unique temp directory for a test's SQLite tree (no `tempfile` dev-dep).
+fn temp_dir(tag: &str) -> PathBuf {
+    let nanos = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_nanos();
+    std::env::temp_dir().join(format!("viewing_key_bind_test_{tag}_{nanos}"))
+}
+
+fn coordinator_at(dir: &std::path::Path) -> Arc<NetworkShieldedCoordinator> {
+    std::fs::create_dir_all(dir).expect("create temp dir");
+    let db_path = dir.join("tree.sqlite");
+    let store = FileBackedShieldedStore::open_path(&db_path, 100).expect("open file store");
+    Arc::new(NetworkShieldedCoordinator::new(
+        Arc::new(dash_sdk::Sdk::new_mock()),
+        Network::Testnet,
+        db_path,
+        store,
+    ))
+}
+
+/// Build a `PlatformWallet` over a fresh test wallet manager with the
+/// given persister. Each call mimics one app process: a fresh handle
+/// whose shielded slot starts unbound.
+async fn platform_wallet_with(persister: Arc<CapturingPersistence>) -> PlatformWallet {
+    let (wallet_manager, wallet_id, balance, _signer) =
+        funded_wallet_manager(StandardAccountType::BIP44Account).await;
+    let sdk = Arc::new(dash_sdk::Sdk::new_mock());
+    let spv = Arc::new(crate::spv::SpvRuntime::new(
+        Arc::clone(&wallet_manager),
+        Arc::new(crate::events::PlatformEventManager::new(Vec::new())),
+    ));
+    PlatformWallet::new(
+        sdk,
+        wallet_id,
+        wallet_manager,
+        balance,
+        Arc::new(tokio::sync::Notify::new()),
+        persister as Arc<dyn PlatformWalletPersistence>,
+        Arc::new(crate::broadcaster::SpvBroadcaster::new(spv)),
+    )
+}
+
+/// The full launch contract in one pass:
+/// 1. the seed bind persists one 96-byte FVK row per account;
+/// 2. a "restarted" wallet (fresh handle + fresh coordinator, no seed
+///    anywhere — the API takes none) rebinds from those rows and
+///    reports `true`;
+/// 3. the rebound viewing state is identical per account (default
+///    address ⇐ FVK ⇐ IVK/OVK, all pure functions of the persisted
+///    bytes) and sync-capable (a coordinator-backed balance read
+///    succeeds for every account).
+#[tokio::test]
+async fn bind_persists_viewing_keys_and_restart_rebinds_seedlessly() {
+    let seed = [0x42u8; 64];
+    let accounts = [0u32, 1u32];
+
+    // Session 1: seed-backed bind.
+    let persister1 = Arc::new(CapturingPersistence::default());
+    let wallet1 = platform_wallet_with(Arc::clone(&persister1)).await;
+    let coordinator1 = coordinator_at(&temp_dir("session1"));
+    wallet1
+        .bind_shielded(&seed, &accounts, &coordinator1)
+        .await
+        .expect("seed bind succeeds");
+
+    let original_addresses = wallet1.shielded_default_addresses().await;
+    assert_eq!(original_addresses.len(), 2, "both accounts bound");
+
+    // The bind queued exactly one FVK row per account, 96 bytes each.
+    let captured = persister1.captured_viewing_keys();
+    assert_eq!(
+        captured.len(),
+        2,
+        "one persisted viewing key per bound account"
+    );
+    for &account in &accounts {
+        let row = captured
+            .get(&SubwalletId::new(wallet1.wallet_id(), account))
+            .expect("viewing key persisted for account");
+        assert_eq!(row.len(), 96, "raw FVK encoding is 96 bytes");
+    }
+
+    // Session 2 ("restart"): fresh handle, fresh coordinator. The test
+    // manager mints a new random wallet per call, so re-key session 1's
+    // rows to the new wallet id — the exact bytes a real restart hands
+    // back for its own (stable) id.
+    let persister2 = Arc::new(CapturingPersistence::default());
+    let wallet2 = platform_wallet_with(Arc::clone(&persister2)).await;
+    let restored_rows: BTreeMap<SubwalletId, Vec<u8>> = accounts
+        .iter()
+        .map(|&account| {
+            (
+                SubwalletId::new(wallet2.wallet_id(), account),
+                captured[&SubwalletId::new(wallet1.wallet_id(), account)].clone(),
+            )
+        })
+        .collect();
+    persister2.serve_viewing_keys(restored_rows);
+    let coordinator2 = coordinator_at(&temp_dir("session2"));
+
+    let rebound = wallet2
+        .bind_shielded_from_persisted(&accounts, &coordinator2)
+        .await
+        .expect("seedless rebind succeeds");
+    assert!(rebound, "persisted rows cover all accounts → rebound");
+    assert!(
+        persister2.load_calls() >= 1,
+        "the seedless rebind actually read persistence"
+    );
+    assert!(wallet2.is_shielded_bound().await);
+
+    // Identical viewing state per account. The default address is a
+    // pure function of the FVK (as are IVK / OVK), so address equality
+    // pins the whole viewing-grade set.
+    let restored_addresses = wallet2.shielded_default_addresses().await;
+    assert_eq!(restored_addresses.len(), 2);
+    for &account in &accounts {
+        assert_eq!(
+            restored_addresses.get(&account),
+            original_addresses.get(&account),
+            "account {account} default address must survive the restart"
+        );
+    }
+
+    // Sync capability: the coordinator-backed balance read works for
+    // every rebound account (empty store → zero balances, not errors).
+    let balances = wallet2
+        .shielded_balances(&coordinator2)
+        .await
+        .expect("balance read over rebound viewing keys");
+    for &account in &accounts {
+        assert_eq!(balances.get(&account), Some(&0));
+    }
+
+    // No seed-backed bind ran in session 2, so nothing re-persisted:
+    // the persister captured no viewing-key rows of its own.
+    assert!(
+        persister2.captured_viewing_keys().is_empty(),
+        "seedless rebind must not re-emit viewing keys"
+    );
+}
+
+/// First-launch shape: no persisted rows → `Ok(false)`, no state
+/// change, so the caller knows to fall back to the seed path. Partial
+/// coverage (a requested account missing) behaves the same.
+#[tokio::test]
+async fn rebind_without_persisted_rows_reports_false_and_binds_nothing() {
+    let persister = Arc::new(CapturingPersistence::default());
+    let wallet = platform_wallet_with(Arc::clone(&persister)).await;
+    let coordinator = coordinator_at(&temp_dir("no_rows"));
+
+    let rebound = wallet
+        .bind_shielded_from_persisted(&[0], &coordinator)
+        .await
+        .expect("load succeeds with no rows");
+    assert!(!rebound, "no persisted rows → caller falls back to seed");
+    assert!(!wallet.is_shielded_bound().await);
+
+    // Partial coverage: stage account 0 only, request 0 and 1.
+    let seed = [0x42u8; 64];
+    let views0 = crate::wallet::shielded::OrchardKeySet::from_seed(&seed, Network::Testnet, 0)
+        .expect("derive")
+        .viewing_keys();
+    let mut rows = BTreeMap::new();
+    rows.insert(
+        SubwalletId::new(wallet.wallet_id(), 0),
+        views0.to_fvk_bytes().to_vec(),
+    );
+    persister.serve_viewing_keys(rows);
+
+    let rebound = wallet
+        .bind_shielded_from_persisted(&[0, 1], &coordinator)
+        .await
+        .expect("load succeeds");
+    assert!(
+        !rebound,
+        "any requested account without a persisted row → fall back to seed"
+    );
+    assert!(!wallet.is_shielded_bound().await);
+
+    // A corrupt row is an error, not a silent fallback.
+    let mut rows = BTreeMap::new();
+    rows.insert(SubwalletId::new(wallet.wallet_id(), 0), vec![0u8; 5]);
+    persister.serve_viewing_keys(rows);
+    assert!(
+        wallet
+            .bind_shielded_from_persisted(&[0], &coordinator)
+            .await
+            .is_err(),
+        "malformed persisted viewing key must surface as an error"
+    );
+}

--- a/packages/swift-sdk/Sources/SwiftDashSDK/FFI/MnemonicResolverAndPersister.swift
+++ b/packages/swift-sdk/Sources/SwiftDashSDK/FFI/MnemonicResolverAndPersister.swift
@@ -142,6 +142,17 @@ public final class MnemonicResolver: @unchecked Sendable {
         outCapacity: UInt,
         outLen: UnsafeMutablePointer<UInt>
     ) -> MnemonicResolverResult {
+        // Secret-free audit line: every mnemonic pull through a resolver
+        // handle is observable, so "the launch path never touches the
+        // mnemonic" is checkable from the unified log alone (shielded
+        // binds rehydrate persisted viewing keys and must NOT appear
+        // here; spends and first binds legitimately do). NSLog rather
+        // than SDKLogger.log so the audit trail is emitted regardless
+        // of the user's logging preset.
+        NSLog(
+            "MnemonicResolver.resolve fired for wallet %@…",
+            walletId.prefix(4).map { String(format: "%02x", $0) }.joined()
+        )
         let mnemonicUTF8Bytes: Data
         do {
             mnemonicUTF8Bytes = try storage.retrieveMnemonicUTF8Bytes(for: walletId)

--- a/packages/swift-sdk/Sources/SwiftDashSDK/Persistence/DashModelContainer.swift
+++ b/packages/swift-sdk/Sources/SwiftDashSDK/Persistence/DashModelContainer.swift
@@ -36,6 +36,7 @@ public enum DashModelContainer {
             PersistentShieldedOutgoingNote.self,
             PersistentShieldedSyncState.self,
             PersistentShieldedActivity.self,
+            PersistentShieldedViewingKey.self,
             PersistentAssetLock.self,
             PersistentMasternode.self
         ]

--- a/packages/swift-sdk/Sources/SwiftDashSDK/Persistence/Models/PersistentShieldedViewingKey.swift
+++ b/packages/swift-sdk/Sources/SwiftDashSDK/Persistence/Models/PersistentShieldedViewingKey.swift
@@ -1,0 +1,46 @@
+import Foundation
+import SwiftData
+
+/// SwiftData row for a per-subwallet Orchard viewing key.
+///
+/// Mirrors `platform_wallet::changeset::ShieldedChangeSet::viewing_keys`
+/// from the Rust side. `fvkBytes` is the raw 96-byte Orchard
+/// `FullViewingKey` encoding; IVK / OVK / the default payment address
+/// are all pure functions of it, so this row alone lets Rust rebind
+/// the shielded sub-wallet at launch without reading the mnemonic
+/// from the Keychain. Viewing-grade only — the bytes can decrypt and
+/// recognize notes but cannot authorize a spend, so they live in
+/// SwiftData alongside the other derived-key batches (the same
+/// placement as `PersistentAccount.derivedPlatformNodeKeys`), not in
+/// the Keychain.
+///
+/// Written via the `on_persist_shielded_viewing_keys_fn` FFI callback
+/// (fired once per seed-backed bind); streamed back to Rust on cold
+/// start via `on_load_shielded_viewing_keys_fn`.
+@Model
+public final class PersistentShieldedViewingKey {
+    /// Composite uniqueness on `(walletId, accountIndex)` — at most
+    /// one viewing key per subwallet. The FVK for a subwallet never
+    /// legitimately changes on a network, so re-persists are
+    /// byte-identical upserts.
+    #Unique<PersistentShieldedViewingKey>([\.walletId, \.accountIndex])
+    #Index<PersistentShieldedViewingKey>([\.walletId])
+
+    public var walletId: Data
+    public var accountIndex: UInt32
+    /// Raw 96-byte Orchard `FullViewingKey` encoding (`ak ‖ nk ‖ rivk`).
+    public var fvkBytes: Data
+
+    public var lastUpdated: Date
+
+    public init(
+        walletId: Data,
+        accountIndex: UInt32,
+        fvkBytes: Data
+    ) {
+        self.walletId = walletId
+        self.accountIndex = accountIndex
+        self.fvkBytes = fvkBytes
+        self.lastUpdated = Date()
+    }
+}

--- a/packages/swift-sdk/Sources/SwiftDashSDK/PlatformWallet/PlatformWalletManagerShieldedSync.swift
+++ b/packages/swift-sdk/Sources/SwiftDashSDK/PlatformWallet/PlatformWalletManagerShieldedSync.swift
@@ -154,21 +154,26 @@ extension PlatformWalletManager {
         currentShieldedTreeTotal = total
     }
 
-    /// Derive Orchard keys for `walletId` from the host-side mnemonic
-    /// resolver, open or create the per-network commitment tree at
-    /// `dbPath`, and bind the resulting multi-account shielded
-    /// sub-wallet to the `PlatformWallet`.
+    /// Bind `walletId`'s multi-account shielded sub-wallet to the
+    /// `PlatformWallet` — from viewing keys the persister already
+    /// holds when possible, deriving from the mnemonic only when it
+    /// doesn't.
     ///
-    /// `accounts` is the list of ZIP-32 account indices to derive.
+    /// `accounts` is the list of ZIP-32 account indices to bind.
     /// Pass `[0]` for the single-account default; pass
     /// `[0, 1, …]` to bind multiple accounts up front. Each entry
     /// produces an independent FVK / IVK / OVK / default address;
     /// notes are scoped per-`(walletId, accountIndex)` inside the
     /// store. Must be non-empty and at most 64 entries.
     ///
-    /// The resolver is fired exactly once. The mnemonic and the
-    /// derived seed live in zeroized buffers on the Rust side and
-    /// are scrubbed before this call returns.
+    /// The resolver does NOT fire on the common path: when every
+    /// requested account has a persisted viewing key (written by the
+    /// first seed-backed bind into `PersistentShieldedViewingKey`
+    /// rows), Rust rebinds from those rows and the mnemonic is never
+    /// read. Only when a row is missing (first bind after create /
+    /// import) does the resolver fire — exactly once, with the
+    /// mnemonic and derived seed in zeroized Rust-side buffers,
+    /// scrubbed before this call returns.
     ///
     /// Idempotent: calling again replaces the previously-bound
     /// shielded wallet.
@@ -492,6 +497,12 @@ extension PlatformWalletManager {
     /// Rust rejects it. The 36-byte on-chain encoding is done on the
     /// Rust side.
     ///
+    /// `resolver` supplies the Orchard spend authority for this one
+    /// operation: Rust resolves the mnemonic, derives the spend key,
+    /// signs, and scrubs everything before returning — no spend key
+    /// stays resident between spends (the launch-time bind is
+    /// viewing-grade only).
+    ///
     /// Throws `PlatformWalletError.shieldedSpendUnconfirmed` when the
     /// broadcast was accepted but its execution result couldn't be
     /// confirmed — the spend may already be on chain, so the caller
@@ -499,6 +510,7 @@ extension PlatformWalletManager {
     /// next shielded sync reconciles them).
     public func shieldedTransfer(
         walletId: Data,
+        resolver: MnemonicResolver,
         account: UInt32 = 0,
         recipientRaw43: Data,
         amount: UInt64,
@@ -519,9 +531,19 @@ extension PlatformWalletManager {
                 "recipient must be exactly 43 raw Orchard bytes"
             )
         }
+        guard let resolverHandle = resolver.handle else {
+            throw PlatformWalletError.invalidParameter(
+                "MnemonicResolver has no handle"
+            )
+        }
 
         let handle = self.handle
         try await Task.detached(priority: .userInitiated) {
+            // Keepalive — the trampoline ctx pointer inside the
+            // resolver dangles unless the Swift owner outlives this
+            // detached work.
+            _ = resolver
+
             try walletId.withUnsafeBytes { widRaw in
                 guard let widPtr = widRaw.baseAddress?.assumingMemoryBound(to: UInt8.self)
                 else {
@@ -540,7 +562,8 @@ extension PlatformWalletManager {
                     // 32-byte limit and does the 36-byte encoding.
                     let send: (UnsafePointer<CChar>?) throws -> Void = { memoCStr in
                         try platform_wallet_manager_shielded_transfer(
-                            handle, widPtr, account, recipientPtr, amount, memoCStr
+                            handle, widPtr, resolverHandle, account, recipientPtr, amount,
+                            memoCStr
                         ).check()
                     }
                     if let memo, !memo.isEmpty {
@@ -621,6 +644,9 @@ extension PlatformWalletManager {
     /// parses and network-checks the address; hosts don't have to
     /// hand-roll the bincode storage variant tag.
     ///
+    /// `resolver` supplies the per-operation Orchard spend authority
+    /// (see [`shieldedTransfer`]).
+    ///
     /// Throws `PlatformWalletError.shieldedSpendUnconfirmed` when the
     /// broadcast was accepted but its execution result couldn't be
     /// confirmed — the spend may already be on chain, so the caller
@@ -628,6 +654,7 @@ extension PlatformWalletManager {
     /// next shielded sync reconciles them).
     public func shieldedUnshield(
         walletId: Data,
+        resolver: MnemonicResolver,
         account: UInt32 = 0,
         toPlatformAddress: String,
         amount: UInt64
@@ -647,9 +674,17 @@ extension PlatformWalletManager {
                 "toPlatformAddress is empty"
             )
         }
+        guard let resolverHandle = resolver.handle else {
+            throw PlatformWalletError.invalidParameter(
+                "MnemonicResolver has no handle"
+            )
+        }
 
         let handle = self.handle
         try await Task.detached(priority: .userInitiated) {
+            // Keepalive — same rationale as `shieldedTransfer`.
+            _ = resolver
+
             try walletId.withUnsafeBytes { widRaw in
                 guard let widPtr = widRaw.baseAddress?.assumingMemoryBound(to: UInt8.self)
                 else {
@@ -657,7 +692,7 @@ extension PlatformWalletManager {
                 }
                 try toPlatformAddress.withCString { addrCStr in
                     try platform_wallet_manager_shielded_unshield(
-                        handle, widPtr, account, addrCStr, amount
+                        handle, widPtr, resolverHandle, account, addrCStr, amount
                     ).check()
                 }
             }
@@ -669,6 +704,9 @@ extension PlatformWalletManager {
     /// `toCoreAddress` (Base58Check string). `coreFeePerByte` is
     /// the L1 fee rate in duffs/byte (`1` is the dashmate default).
     ///
+    /// `resolver` supplies the per-operation Orchard spend authority
+    /// (see [`shieldedTransfer`]).
+    ///
     /// Throws `PlatformWalletError.shieldedSpendUnconfirmed` when the
     /// broadcast was accepted but its execution result couldn't be
     /// confirmed — the spend may already be on chain, so the caller
@@ -676,6 +714,7 @@ extension PlatformWalletManager {
     /// next shielded sync reconciles them).
     public func shieldedWithdraw(
         walletId: Data,
+        resolver: MnemonicResolver,
         account: UInt32 = 0,
         toCoreAddress: String,
         amount: UInt64,
@@ -691,9 +730,17 @@ extension PlatformWalletManager {
                 "walletId must be exactly 32 bytes"
             )
         }
+        guard let resolverHandle = resolver.handle else {
+            throw PlatformWalletError.invalidParameter(
+                "MnemonicResolver has no handle"
+            )
+        }
 
         let handle = self.handle
         try await Task.detached(priority: .userInitiated) {
+            // Keepalive — same rationale as `shieldedTransfer`.
+            _ = resolver
+
             try walletId.withUnsafeBytes { widRaw in
                 guard let widPtr = widRaw.baseAddress?.assumingMemoryBound(to: UInt8.self)
                 else {
@@ -701,7 +748,8 @@ extension PlatformWalletManager {
                 }
                 try toCoreAddress.withCString { addrCStr in
                     try platform_wallet_manager_shielded_withdraw(
-                        handle, widPtr, account, addrCStr, amount, coreFeePerByte
+                        handle, widPtr, resolverHandle, account, addrCStr, amount,
+                        coreFeePerByte
                     ).check()
                 }
             }
@@ -720,7 +768,8 @@ extension PlatformWalletManager {
     /// should be the MASTER key). `identitySigner` is the host-side
     /// `KeychainSigner` whose `.handle` produces each key's
     /// proof-of-possession signature; the Orchard spend authority is
-    /// the bound wallet's own key. Returns the 32-byte new identity id
+    /// re-derived per operation via `resolver` (see
+    /// [`shieldedTransfer`]). Returns the 32-byte new identity id
     /// (`double_sha256(sorted nullifiers)`).
     ///
     /// `identityIndex` is the DIP-9 identity-registration slot the new
@@ -743,6 +792,7 @@ extension PlatformWalletManager {
     /// detached task so the caller's actor isn't blocked.
     public func shieldedIdentityCreateFromPool(
         walletId: Data,
+        resolver: MnemonicResolver,
         account: UInt32 = 0,
         identityIndex: UInt32,
         identityPubkeys: [ManagedPlatformWallet.IdentityPubkey],
@@ -770,6 +820,11 @@ extension PlatformWalletManager {
                 "sendToAddressOnCreationFailure must be exactly 21 PlatformAddress bytes"
             )
         }
+        guard let resolverHandle = resolver.handle else {
+            throw PlatformWalletError.invalidParameter(
+                "MnemonicResolver has no handle"
+            )
+        }
 
         let handle = self.handle
         let identitySignerHandle = identitySigner.handle
@@ -794,11 +849,12 @@ extension PlatformWalletManager {
             // Reuses the same marshalling helper the address-funded
             // registration path uses so the two can't drift.
             let pubkeyBuffers: [Data] = identityPubkeys.map { $0.pubkeyBytes }
-            // KeychainSigner is passed to Rust via `passUnretained`, so the Rust ctx pointer dangles
-            // unless the Swift owner is kept alive across the FFI call. `_ = identitySigner` is
-            // folklore that the optimizer may elide in -O builds; `withExtendedLifetime` is the
-            // guaranteed keepalive (matches this module's signer-lifetime guidance).
-            let result = try withExtendedLifetime(identitySigner) {
+            // KeychainSigner and MnemonicResolver are passed to Rust via `passUnretained`, so the
+            // Rust ctx pointers dangle unless the Swift owners are kept alive across the FFI call.
+            // `_ = identitySigner` is folklore that the optimizer may elide in -O builds;
+            // `withExtendedLifetime` is the guaranteed keepalive (matches this module's
+            // signer-lifetime guidance).
+            let result = try withExtendedLifetime((identitySigner, resolver)) {
                 try walletId.withUnsafeBytes { widRaw -> PlatformWalletFFIResult in
                     guard let widPtr = widRaw.baseAddress?.assumingMemoryBound(to: UInt8.self)
                     else {
@@ -822,6 +878,7 @@ extension PlatformWalletManager {
                             platform_wallet_manager_shielded_identity_create_from_pool(
                                 handle,
                                 widPtr,
+                                resolverHandle,
                                 account,
                                 identityIndex,
                                 ffiRowsPtr,

--- a/packages/swift-sdk/Sources/SwiftDashSDK/PlatformWallet/PlatformWalletManagerShieldedSync.swift
+++ b/packages/swift-sdk/Sources/SwiftDashSDK/PlatformWallet/PlatformWalletManagerShieldedSync.swift
@@ -539,37 +539,40 @@ extension PlatformWalletManager {
 
         let handle = self.handle
         try await Task.detached(priority: .userInitiated) {
-            // Keepalive — the trampoline ctx pointer inside the
-            // resolver dangles unless the Swift owner outlives this
-            // detached work.
-            _ = resolver
-
-            try walletId.withUnsafeBytes { widRaw in
-                guard let widPtr = widRaw.baseAddress?.assumingMemoryBound(to: UInt8.self)
-                else {
-                    throw PlatformWalletError.invalidParameter("walletId baseAddress is nil")
-                }
-                try recipientRaw43.withUnsafeBytes { recipientRaw in
-                    guard let recipientPtr = recipientRaw.baseAddress?
-                        .assumingMemoryBound(to: UInt8.self)
+            // MnemonicResolver is passed to Rust via `passUnretained`,
+            // so the Rust ctx pointer dangles unless the Swift owner
+            // stays alive across the whole FFI call. A bare
+            // `_ = resolver` is folklore the optimizer may elide in -O
+            // builds; `withExtendedLifetime` is the guaranteed
+            // keepalive (same as the identity-create sibling).
+            try withExtendedLifetime(resolver) {
+                try walletId.withUnsafeBytes { widRaw in
+                    guard let widPtr = widRaw.baseAddress?.assumingMemoryBound(to: UInt8.self)
                     else {
-                        throw PlatformWalletError.invalidParameter(
-                            "recipient baseAddress is nil"
-                        )
+                        throw PlatformWalletError.invalidParameter("walletId baseAddress is nil")
                     }
-                    // `nil` / empty → null pointer (no memo); otherwise
-                    // pass the text as a C string. Rust validates the
-                    // 32-byte limit and does the 36-byte encoding.
-                    let send: (UnsafePointer<CChar>?) throws -> Void = { memoCStr in
-                        try platform_wallet_manager_shielded_transfer(
-                            handle, widPtr, resolverHandle, account, recipientPtr, amount,
-                            memoCStr
-                        ).check()
-                    }
-                    if let memo, !memo.isEmpty {
-                        try memo.withCString { try send($0) }
-                    } else {
-                        try send(nil)
+                    try recipientRaw43.withUnsafeBytes { recipientRaw in
+                        guard let recipientPtr = recipientRaw.baseAddress?
+                            .assumingMemoryBound(to: UInt8.self)
+                        else {
+                            throw PlatformWalletError.invalidParameter(
+                                "recipient baseAddress is nil"
+                            )
+                        }
+                        // `nil` / empty → null pointer (no memo); otherwise
+                        // pass the text as a C string. Rust validates the
+                        // 32-byte limit and does the 36-byte encoding.
+                        let send: (UnsafePointer<CChar>?) throws -> Void = { memoCStr in
+                            try platform_wallet_manager_shielded_transfer(
+                                handle, widPtr, resolverHandle, account, recipientPtr, amount,
+                                memoCStr
+                            ).check()
+                        }
+                        if let memo, !memo.isEmpty {
+                            try memo.withCString { try send($0) }
+                        } else {
+                            try send(nil)
+                        }
                     }
                 }
             }
@@ -682,18 +685,19 @@ extension PlatformWalletManager {
 
         let handle = self.handle
         try await Task.detached(priority: .userInitiated) {
-            // Keepalive — same rationale as `shieldedTransfer`.
-            _ = resolver
-
-            try walletId.withUnsafeBytes { widRaw in
-                guard let widPtr = widRaw.baseAddress?.assumingMemoryBound(to: UInt8.self)
-                else {
-                    throw PlatformWalletError.invalidParameter("walletId baseAddress is nil")
-                }
-                try toPlatformAddress.withCString { addrCStr in
-                    try platform_wallet_manager_shielded_unshield(
-                        handle, widPtr, resolverHandle, account, addrCStr, amount
-                    ).check()
+            // Guaranteed resolver keepalive across the FFI call —
+            // same rationale as `shieldedTransfer`.
+            try withExtendedLifetime(resolver) {
+                try walletId.withUnsafeBytes { widRaw in
+                    guard let widPtr = widRaw.baseAddress?.assumingMemoryBound(to: UInt8.self)
+                    else {
+                        throw PlatformWalletError.invalidParameter("walletId baseAddress is nil")
+                    }
+                    try toPlatformAddress.withCString { addrCStr in
+                        try platform_wallet_manager_shielded_unshield(
+                            handle, widPtr, resolverHandle, account, addrCStr, amount
+                        ).check()
+                    }
                 }
             }
         }.value
@@ -738,19 +742,20 @@ extension PlatformWalletManager {
 
         let handle = self.handle
         try await Task.detached(priority: .userInitiated) {
-            // Keepalive — same rationale as `shieldedTransfer`.
-            _ = resolver
-
-            try walletId.withUnsafeBytes { widRaw in
-                guard let widPtr = widRaw.baseAddress?.assumingMemoryBound(to: UInt8.self)
-                else {
-                    throw PlatformWalletError.invalidParameter("walletId baseAddress is nil")
-                }
-                try toCoreAddress.withCString { addrCStr in
-                    try platform_wallet_manager_shielded_withdraw(
-                        handle, widPtr, resolverHandle, account, addrCStr, amount,
-                        coreFeePerByte
-                    ).check()
+            // Guaranteed resolver keepalive across the FFI call —
+            // same rationale as `shieldedTransfer`.
+            try withExtendedLifetime(resolver) {
+                try walletId.withUnsafeBytes { widRaw in
+                    guard let widPtr = widRaw.baseAddress?.assumingMemoryBound(to: UInt8.self)
+                    else {
+                        throw PlatformWalletError.invalidParameter("walletId baseAddress is nil")
+                    }
+                    try toCoreAddress.withCString { addrCStr in
+                        try platform_wallet_manager_shielded_withdraw(
+                            handle, widPtr, resolverHandle, account, addrCStr, amount,
+                            coreFeePerByte
+                        ).check()
+                    }
                 }
             }
         }.value

--- a/packages/swift-sdk/Sources/SwiftDashSDK/PlatformWallet/PlatformWalletPersistenceHandler.swift
+++ b/packages/swift-sdk/Sources/SwiftDashSDK/PlatformWallet/PlatformWalletPersistenceHandler.swift
@@ -1108,6 +1108,9 @@ public final class PlatformWalletPersistenceHandler: @unchecked Sendable {
         cb.on_load_shielded_sync_states_free_fn = loadShieldedSyncStatesFreeCallback
         cb.on_load_shielded_activity_fn = loadShieldedActivityCallback
         cb.on_load_shielded_activity_free_fn = loadShieldedActivityFreeCallback
+        cb.on_persist_shielded_viewing_keys_fn = persistShieldedViewingKeysCallback
+        cb.on_load_shielded_viewing_keys_fn = loadShieldedViewingKeysCallback
+        cb.on_load_shielded_viewing_keys_free_fn = loadShieldedViewingKeysFreeCallback
         cb.on_persist_asset_locks_fn = persistAssetLocksCallback
         cb.on_get_core_tx_record_fn = getCoreTxRecordCallback
         cb.on_get_core_tx_record_free_fn = getCoreTxRecordFreeCallback
@@ -3044,6 +3047,45 @@ public final class PlatformWalletPersistenceHandler: @unchecked Sendable {
         }
     }
 
+    /// Upsert per-subwallet Orchard viewing keys (raw 96-byte FVK
+    /// encodings). Fired once per seed-backed bind; the FVK for a
+    /// subwallet never changes on a network, so re-persists are
+    /// byte-identical upserts.
+    func persistShieldedViewingKeys(
+        walletId: Data,
+        entries: [(walletId: Data, accountIndex: UInt32, fvkBytes: Data)]
+    ) {
+        onQueue {
+            for entry in entries {
+                guard entry.fvkBytes.count == 96 else { continue }
+                let rowWalletId = entry.walletId
+                let rowAccountIndex = entry.accountIndex
+                let predicate = #Predicate<PersistentShieldedViewingKey> { row in
+                    row.walletId == rowWalletId && row.accountIndex == rowAccountIndex
+                }
+                var descriptor = FetchDescriptor<PersistentShieldedViewingKey>(
+                    predicate: predicate
+                )
+                descriptor.fetchLimit = 1
+                if let row = try? backgroundContext.fetch(descriptor).first {
+                    if row.fvkBytes != entry.fvkBytes {
+                        row.fvkBytes = entry.fvkBytes
+                        row.lastUpdated = Date()
+                    }
+                } else {
+                    backgroundContext.insert(
+                        PersistentShieldedViewingKey(
+                            walletId: rowWalletId,
+                            accountIndex: rowAccountIndex,
+                            fvkBytes: entry.fvkBytes
+                        )
+                    )
+                }
+            }
+            if !self.inChangeset { try? backgroundContext.save() }
+        }
+    }
+
     /// Fetch-or-create a `PersistentShieldedSyncState` row for
     /// `(walletId, accountIndex)`. Caller must be on `onQueue`.
     private func ensureShieldedSyncStateRow(
@@ -3494,6 +3536,80 @@ public final class PlatformWalletPersistenceHandler: @unchecked Sendable {
         }
     }
 
+    /// Build the host-allocated `ShieldedViewingKeyRestoreFFI` array
+    /// Rust reads at boot so `bind_shielded_from_persisted` can rebind
+    /// without a mnemonic resolve. Same allocation pattern (and
+    /// network scoping) as `loadShieldedSyncStates`.
+    func loadShieldedViewingKeys() -> (
+        entries: UnsafePointer<ShieldedViewingKeyRestoreFFI>?,
+        count: Int,
+        errored: Bool
+    ) {
+        var resultEntries: UnsafePointer<ShieldedViewingKeyRestoreFFI>?
+        var resultCount: Int = 0
+        var resultErrored = false
+        onQueue {
+            let descriptor = FetchDescriptor<PersistentShieldedViewingKey>()
+            var rows: [PersistentShieldedViewingKey]
+            do {
+                rows = try backgroundContext.fetch(descriptor)
+            } catch {
+                resultErrored = true
+                return
+            }
+            // Same network scoping as the other shielded loaders — the
+            // FVK embeds the coin type, so serving another network's
+            // rows would fail the Rust-side bind, not corrupt it, but
+            // the loaders stay consistent regardless.
+            if let inNetworkIds = self.inNetworkWalletIds() {
+                rows = rows.filter { inNetworkIds.contains($0.walletId) }
+            }
+            if rows.isEmpty {
+                return
+            }
+            let allocation = ShieldedViewingKeyLoadAllocation()
+            let buf = UnsafeMutablePointer<ShieldedViewingKeyRestoreFFI>.allocate(
+                capacity: rows.count
+            )
+            allocation.entries = buf
+            allocation.entriesCount = rows.count
+            // Same `written`-counter pattern as `loadShieldedSyncStates`:
+            // skip malformed rows without leaving holes in the
+            // contiguous prefix Rust will read.
+            var written = 0
+            for row in rows {
+                guard row.walletId.count == 32, row.fvkBytes.count == 96 else { continue }
+                var entry = ShieldedViewingKeyRestoreFFI()
+                Swift.withUnsafeMutableBytes(of: &entry.wallet_id) { dst in
+                    row.walletId.withUnsafeBytes { dst.copyMemory(from: $0) }
+                }
+                entry.account_index = row.accountIndex
+                Swift.withUnsafeMutableBytes(of: &entry.fvk_bytes) { dst in
+                    row.fvkBytes.withUnsafeBytes { dst.copyMemory(from: $0) }
+                }
+                buf[written] = entry
+                written += 1
+                allocation.entriesInitialized = written
+            }
+            let entriesPtr = UnsafePointer(buf)
+            shieldedViewingKeyLoadAllocations[UnsafeRawPointer(entriesPtr)] = allocation
+            resultEntries = entriesPtr
+            resultCount = written
+        }
+        return (resultEntries, resultCount, resultErrored)
+    }
+
+    func loadShieldedViewingKeysFree(entries: UnsafeRawPointer?) {
+        onQueue {
+            guard let entries = entries,
+                  let allocation = shieldedViewingKeyLoadAllocations.removeValue(forKey: entries)
+            else {
+                return
+            }
+            allocation.release()
+        }
+    }
+
     /// Outstanding shielded-load allocations keyed by the entries
     /// pointer we handed Rust. Drained by `loadShieldedNotesFree`.
     private var shieldedLoadAllocations: [UnsafeRawPointer: ShieldedLoadAllocation] = [:]
@@ -3503,6 +3619,8 @@ public final class PlatformWalletPersistenceHandler: @unchecked Sendable {
         [UnsafeRawPointer: ShieldedSyncStateLoadAllocation] = [:]
     private var shieldedActivityLoadAllocations:
         [UnsafeRawPointer: ShieldedActivityLoadAllocation] = [:]
+    private var shieldedViewingKeyLoadAllocations:
+        [UnsafeRawPointer: ShieldedViewingKeyLoadAllocation] = [:]
 
     /// Set network, group id + birth height on the `PersistentWallet`
     /// row. Fires once at wallet registration with values the Rust side
@@ -3766,6 +3884,13 @@ public final class PlatformWalletPersistenceHandler: @unchecked Sendable {
                     predicate: #Predicate<PersistentShieldedActivity> { $0.walletId == walletId }
                 )
                 for row in try backgroundContext.fetch(shieldedActivityDescriptor) {
+                    backgroundContext.delete(row)
+                }
+
+                let shieldedViewingKeyDescriptor = FetchDescriptor<PersistentShieldedViewingKey>(
+                    predicate: #Predicate<PersistentShieldedViewingKey> { $0.walletId == walletId }
+                )
+                for row in try backgroundContext.fetch(shieldedViewingKeyDescriptor) {
                     backgroundContext.delete(row)
                 }
 
@@ -5765,6 +5890,25 @@ private final class ShieldedSyncStateLoadAllocation {
     }
 }
 
+/// Allocation tracker for `loadShieldedViewingKeys` — a flat entries
+/// buffer with no per-row pointer fields (the FVK is a fixed 96-byte
+/// inline array), so the same shape as
+/// `ShieldedSyncStateLoadAllocation`.
+private final class ShieldedViewingKeyLoadAllocation {
+    var entries: UnsafeMutablePointer<ShieldedViewingKeyRestoreFFI>?
+    var entriesCount: Int = 0
+    var entriesInitialized: Int = 0
+
+    func release() {
+        if let entries = entries {
+            if entriesInitialized > 0 {
+                entries.deinitialize(count: entriesInitialized)
+            }
+            entries.deallocate()
+        }
+    }
+}
+
 /// Allocation tracker for `loadShieldedActivity` — the entries buffer
 /// plus per-row byte buffers for the four pointer-backed fields
 /// (counterparty / memo / note-cmx array / spent-nullifier array). Each
@@ -6966,6 +7110,64 @@ private func loadShieldedSyncStatesFreeCallback(
         .fromOpaque(context)
         .takeUnretainedValue()
     handler.loadShieldedSyncStatesFree(entries: entries.map(UnsafeRawPointer.init))
+}
+
+private func persistShieldedViewingKeysCallback(
+    context: UnsafeMutableRawPointer?,
+    walletIdPtr: UnsafePointer<UInt8>?,
+    entriesPtr: UnsafePointer<ShieldedViewingKeyFFI>?,
+    count: UInt
+) -> Int32 {
+    guard let context = context, let walletIdPtr = walletIdPtr else { return 0 }
+    let handler = Unmanaged<PlatformWalletPersistenceHandler>
+        .fromOpaque(context)
+        .takeUnretainedValue()
+    let walletId = Data(bytes: walletIdPtr, count: 32)
+
+    var entries: [(walletId: Data, accountIndex: UInt32, fvkBytes: Data)] = []
+    if count > 0, let entriesPtr = entriesPtr {
+        entries.reserveCapacity(Int(count))
+        for i in 0..<Int(count) {
+            let e = entriesPtr[i]
+            let fvkBytes = Swift.withUnsafeBytes(of: e.fvk_bytes) { Data($0) }
+            entries.append((
+                walletId: dataFromTuple32(e.wallet_id),
+                accountIndex: e.account_index,
+                fvkBytes: fvkBytes
+            ))
+        }
+    }
+    handler.persistShieldedViewingKeys(walletId: walletId, entries: entries)
+    return 0
+}
+
+private func loadShieldedViewingKeysCallback(
+    context: UnsafeMutableRawPointer?,
+    outEntries: UnsafeMutablePointer<UnsafePointer<ShieldedViewingKeyRestoreFFI>?>?,
+    outCount: UnsafeMutablePointer<UInt>?
+) -> Int32 {
+    guard let context = context, let outEntries = outEntries, let outCount = outCount else {
+        return 1
+    }
+    let handler = Unmanaged<PlatformWalletPersistenceHandler>
+        .fromOpaque(context)
+        .takeUnretainedValue()
+    let (entries, count, errored) = handler.loadShieldedViewingKeys()
+    outEntries.pointee = entries
+    outCount.pointee = UInt(count)
+    return errored ? 1 : 0
+}
+
+private func loadShieldedViewingKeysFreeCallback(
+    context: UnsafeMutableRawPointer?,
+    entries: UnsafePointer<ShieldedViewingKeyRestoreFFI>?,
+    _ count: UInt
+) {
+    guard let context = context else { return }
+    let handler = Unmanaged<PlatformWalletPersistenceHandler>
+        .fromOpaque(context)
+        .takeUnretainedValue()
+    handler.loadShieldedViewingKeysFree(entries: entries.map(UnsafeRawPointer.init))
 }
 
 // MARK: - Core tx-record persister fallback

--- a/packages/swift-sdk/Sources/SwiftDashSDK/PlatformWallet/PlatformWalletPersistenceHandler.swift
+++ b/packages/swift-sdk/Sources/SwiftDashSDK/PlatformWallet/PlatformWalletPersistenceHandler.swift
@@ -3567,18 +3567,32 @@ public final class PlatformWalletPersistenceHandler: @unchecked Sendable {
             if rows.isEmpty {
                 return
             }
+            // Fail closed on a present-but-malformed row, BEFORE any
+            // allocation: silently skipping it (the sync-state
+            // loader's pattern) would make Rust see the account as
+            // "no persisted key" and fall back to a mnemonic resolve,
+            // masking persistence corruption — the exact opposite of
+            // `bind_shielded_from_persisted`'s documented contract,
+            // which surfaces a malformed row as an error.
+            if let bad = rows.first(where: {
+                $0.walletId.count != 32 || $0.fvkBytes.count != 96
+            }) {
+                SDKLogger.error(
+                    "loadShieldedViewingKeys: corrupt row "
+                        + "(walletId \(bad.walletId.count)B, fvk \(bad.fvkBytes.count)B) — "
+                        + "failing the load rather than masking it as a missing key"
+                )
+                resultErrored = true
+                return
+            }
             let allocation = ShieldedViewingKeyLoadAllocation()
             let buf = UnsafeMutablePointer<ShieldedViewingKeyRestoreFFI>.allocate(
                 capacity: rows.count
             )
             allocation.entries = buf
             allocation.entriesCount = rows.count
-            // Same `written`-counter pattern as `loadShieldedSyncStates`:
-            // skip malformed rows without leaving holes in the
-            // contiguous prefix Rust will read.
             var written = 0
             for row in rows {
-                guard row.walletId.count == 32, row.fvkBytes.count == 96 else { continue }
                 var entry = ShieldedViewingKeyRestoreFFI()
                 Swift.withUnsafeMutableBytes(of: &entry.wallet_id) { dst in
                     row.walletId.withUnsafeBytes { dst.copyMemory(from: $0) }

--- a/packages/swift-sdk/SwiftExampleApp/SwiftExampleApp/Core/Services/ShieldedService.swift
+++ b/packages/swift-sdk/SwiftExampleApp/SwiftExampleApp/Core/Services/ShieldedService.swift
@@ -763,6 +763,10 @@ class ShieldedService: ObservableObject {
             try modelContext.delete(model: PersistentShieldedOutgoingNote.self)
             try modelContext.delete(model: PersistentShieldedSyncState.self)
             try modelContext.delete(model: PersistentShieldedActivity.self)
+            // Viewing keys are included in the wipe so a corrupted
+            // row can't outlive Clear; the next bind falls back to
+            // the mnemonic resolver once and re-persists them.
+            try modelContext.delete(model: PersistentShieldedViewingKey.self)
             try modelContext.save()
         } catch {
             lastError = "Failed to wipe persisted shielded state: \(error.localizedDescription)"

--- a/packages/swift-sdk/SwiftExampleApp/SwiftExampleApp/Core/ViewModels/SendViewModel.swift
+++ b/packages/swift-sdk/SwiftExampleApp/SwiftExampleApp/Core/ViewModels/SendViewModel.swift
@@ -660,8 +660,12 @@ class SendViewModel: ObservableObject {
                     return
                 }
                 let trimmedMemo = memoText.trimmingCharacters(in: .whitespacesAndNewlines)
+                // Per-operation spend authority: the resolver fires
+                // exactly for this spend (launch binds are
+                // viewing-key only and never read the mnemonic).
                 try await walletManager.shieldedTransfer(
                     walletId: wallet.walletId,
+                    resolver: MnemonicResolver(),
                     account: 0,
                     recipientRaw43: recipientRaw,
                     amount: amountCredits,
@@ -682,6 +686,7 @@ class SendViewModel: ObservableObject {
                 let trimmed = recipientAddress.trimmingCharacters(in: .whitespacesAndNewlines)
                 try await walletManager.shieldedUnshield(
                     walletId: wallet.walletId,
+                    resolver: MnemonicResolver(),
                     account: 0,
                     toPlatformAddress: trimmed,
                     amount: amountCredits
@@ -700,6 +705,7 @@ class SendViewModel: ObservableObject {
                 let trimmed = recipientAddress.trimmingCharacters(in: .whitespacesAndNewlines)
                 try await walletManager.shieldedWithdraw(
                     walletId: wallet.walletId,
+                    resolver: MnemonicResolver(),
                     account: 0,
                     toCoreAddress: trimmed,
                     amount: amountCredits,

--- a/packages/swift-sdk/SwiftExampleApp/SwiftExampleApp/Views/CreateIdentityView.swift
+++ b/packages/swift-sdk/SwiftExampleApp/SwiftExampleApp/Views/CreateIdentityView.swift
@@ -1278,6 +1278,7 @@ struct CreateIdentityView: View {
                 // app's shielded default.
                 let identityId = try await manager.shieldedIdentityCreateFromPool(
                     walletId: walletId,
+                    resolver: MnemonicResolver(),
                     account: 0,
                     identityIndex: identityIndex,
                     identityPubkeys: identityPubkeys,

--- a/packages/swift-sdk/SwiftExampleApp/SwiftExampleApp/Views/StorageExplorerView.swift
+++ b/packages/swift-sdk/SwiftExampleApp/SwiftExampleApp/Views/StorageExplorerView.swift
@@ -164,6 +164,13 @@ struct StorageExplorerView: View {
             ) {
                 ShieldedActivityStorageListView(network: network)
             }
+            modelRow(
+                "Shielded Viewing Keys",
+                icon: "eye",
+                type: PersistentShieldedViewingKey.self
+            ) {
+                ShieldedViewingKeyStorageListView(network: network)
+            }
         }
         .navigationTitle("Storage Explorer")
         .toolbar {
@@ -313,6 +320,9 @@ struct StorageExplorerView: View {
             walletsOnNetwork.contains($0.walletId)
         }
         filteredCount(PersistentShieldedActivity.self) {
+            walletsOnNetwork.contains($0.walletId)
+        }
+        filteredCount(PersistentShieldedViewingKey.self) {
             walletsOnNetwork.contains($0.walletId)
         }
         filteredCount(PersistentAssetLock.self) {

--- a/packages/swift-sdk/SwiftExampleApp/SwiftExampleApp/Views/StorageModelListViews.swift
+++ b/packages/swift-sdk/SwiftExampleApp/SwiftExampleApp/Views/StorageModelListViews.swift
@@ -2208,3 +2208,59 @@ struct ShieldedSyncStateStorageListView: View {
         }
     }
 }
+
+// MARK: - PersistentShieldedViewingKey
+
+struct ShieldedViewingKeyStorageListView: View {
+    let network: Network
+
+    // Same Data-isn't-Comparable constraint as the sync-state list:
+    // sort by `accountIndex` only, wallet grouping falls out of
+    // insertion order (one row per subwallet).
+    @Query(sort: [SortDescriptor(\PersistentShieldedViewingKey.accountIndex)])
+    private var records: [PersistentShieldedViewingKey]
+
+    @Query private var allWallets: [PersistentWallet]
+
+    private var walletIdsOnNetwork: Set<Data> {
+        Set(allWallets.lazy
+            .filter { $0.networkRaw == network.rawValue }
+            .map(\.walletId))
+    }
+
+    private var scopedRecords: [PersistentShieldedViewingKey] {
+        let ids = walletIdsOnNetwork
+        return records.filter { ids.contains($0.walletId) }
+    }
+
+    var body: some View {
+        let visible = scopedRecords
+        List {
+            ForEach(visible) { record in
+                NavigationLink(destination: ShieldedViewingKeyStorageDetailView(record: record)) {
+                    VStack(alignment: .leading, spacing: 4) {
+                        HStack {
+                            Text(
+                                record.walletId.prefix(4)
+                                    .map { String(format: "%02x", $0) }.joined()
+                            )
+                            .font(.system(.caption2, design: .monospaced))
+                            Text("acct \(record.accountIndex)")
+                                .font(.caption2)
+                                .foregroundColor(.secondary)
+                            Spacer()
+                        }
+                        Text("FVK: \(record.fvkBytes.count) bytes")
+                            .font(.caption)
+                    }
+                }
+            }
+        }
+        .navigationTitle("Shielded Viewing Keys (\(visible.count))")
+        .overlay {
+            if visible.isEmpty {
+                ContentUnavailableView("No Viewing Keys", systemImage: "eye")
+            }
+        }
+    }
+}

--- a/packages/swift-sdk/SwiftExampleApp/SwiftExampleApp/Views/StorageRecordDetailViews.swift
+++ b/packages/swift-sdk/SwiftExampleApp/SwiftExampleApp/Views/StorageRecordDetailViews.swift
@@ -2666,3 +2666,31 @@ private extension AssetLockStorageDetailView {
         }
     }
 }
+
+// MARK: - PersistentShieldedViewingKey
+
+struct ShieldedViewingKeyStorageDetailView: View {
+    let record: PersistentShieldedViewingKey
+
+    var body: some View {
+        Form {
+            Section("Identity") {
+                FieldRow(label: "Wallet ID", value: hexString(record.walletId))
+                FieldRow(label: "Account Index", value: "\(record.accountIndex)")
+            }
+            Section("Viewing Key") {
+                // Viewing-grade only (cannot spend), but still key
+                // material — the full 96-byte FVK is intentionally
+                // rendered for QA inspection, matching how the
+                // explorer shows other derived public-key batches.
+                FieldRow(label: "FVK Length", value: "\(record.fvkBytes.count) bytes")
+                FieldRow(label: "FVK (hex)", value: hexString(record.fvkBytes))
+            }
+            Section("Timestamps") {
+                FieldRow(label: "Updated", value: dateString(record.lastUpdated))
+            }
+        }
+        .navigationTitle("Shielded Viewing Key")
+        .navigationBarTitleDisplayMode(.inline)
+    }
+}


### PR DESCRIPTION
## Issue being fixed or feature implemented

At every app launch, `rebindWalletScopedServices` shielded-bound every loaded wallet through the mnemonic resolver: the mnemonic was pulled from the Keychain, the seed derived, and a resident Orchard `SpendAuthorizingKey` stayed in memory for the whole session — re-firing on network switch and Sync Now. The mnemonic should not be touched at launch for shielded sync, and no spend authority should be resident between spends.

## What was done?

**rs-platform-wallet**
- Split the bind into a viewing bind vs on-demand spend authorization. `PlatformWallet.shielded_keys` now holds `AccountViewingKeys` (FVK / IVK / OVK / default address) — everything trial-decryption and sync need, nothing that can spend.
- The first seed-backed `bind_shielded` persists each account's raw 96-byte FVK through the persister (`ShieldedChangeSet.viewing_keys`). `AccountViewingKeys::from_fvk_bytes` reconstructs the whole viewing set from those bytes (IVK / OVK / default address are pure functions of the FVK).
- New `bind_shielded_from_persisted` rebinds from those rows with no seed parameter at all; a corrupt row is an error, a missing row means "fall back to the seed path".
- The four spend entry points (`transfer` / `unshield` / `withdraw` / `identity_create_from_pool`) take a `seed` and re-derive the full `OrchardKeySet` per operation via `derive_spend_keyset`, which also guards derived-FVK == bound-FVK so a wrong seed fails before the ~30 s Halo 2 proof. The keyset is dropped (evicted) when the call returns. `shield` and fund-from-asset-lock need only viewing-grade material and take none.

**rs-platform-wallet-ffi**
- `platform_wallet_manager_bind_shielded` keeps its ABI but tries the persisted-keys path first — the resolver fires only when a requested account has no persisted row (first bind after create/import). Launch, network switch, and Sync Now all ride this and never resolve the mnemonic once rows exist.
- New `ShieldedViewingKeyFFI` / `ShieldedViewingKeyRestoreFFI` + `on_persist_shielded_viewing_keys_fn` / `on_load_shielded_viewing_keys_fn`(+free) callback pair, modeled on the platform-node pubkey batch pattern.
- The four spend FFIs gained a `MnemonicResolverHandle` parameter (reusing `resolve_seed_from_resolver`; seed lives in `Zeroizing` buffers), mirroring the transparent `MnemonicResolverCoreSigner` flow.

**swift-sdk / SwiftExampleApp**
- `PersistentShieldedViewingKey` SwiftData model (viewing-grade key material stored like the other derived-key batches, not Keychain) + persistence-handler arms; wallet deletion and shielded Clear purge the rows (Clear so a corrupt row can't outlive it — the next bind re-resolves once and re-persists).
- Spend wrappers/call sites pass a per-operation `MnemonicResolver`; a secret-free `NSLog` audit line fires on every resolver invocation so the no-mnemonic-at-launch property is checkable from the unified log.

## How Has This Been Tested?

- `cargo test -p platform-wallet -p platform-wallet-ffi --all-features` — 753 tests pass, including new ones: FVK byte round-trip reproduces identical FVK/IVK/OVK/default address; bind→persist→simulated-restart→`bind_shielded_from_persisted` yields identical addresses and a working coordinator balance read with no seed anywhere (the API takes none); missing rows report `false` with no state change; corrupt rows error.
- On the iPhone 16 Pro simulator (testnet, 5 wallets): first launch after the change fired the resolver once per wallet (legacy-bind fallback) and persisted one 96-byte FVK row per account; after restart the shielded rebind fired **zero** resolver calls (per-wallet firings went 2 → 1, the remaining one being the separate seed-verify startup path) while the shielded balance (0.09987149 DASH), 1,315 synced notes, and activity all displayed and background/manual syncs completed; Sync Now fired zero resolver calls; a 0.001 DASH unshield fired the resolver exactly once and executed on-chain (platform balance +0.001, pool −0.001 − 0.00168934 fee). A full store-wipe recovery also exercised the first-bind fallback end-to-end (rows re-persisted).

## Breaking Changes

None on-chain / consensus. The four shielded spend FFI signatures gained a resolver parameter (pre-release SDK surface, Swift call sites updated in this PR).

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [ ] I have made corresponding changes to the documentation if needed

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone

🤖 Generated with [Claude Code](https://claude.com/claude-code)