### PR TITLE
fix(swift-sdk): stored default on keyType so pre-column stores can migrate

### DIFF
--- a/packages/swift-sdk/Sources/SwiftDashSDK/Persistence/Models/PersistentCoreAddress.swift
+++ b/packages/swift-sdk/Sources/SwiftDashSDK/Persistence/Models/PersistentCoreAddress.swift
@@ -23,8 +23,15 @@ public final class PersistentCoreAddress {
     public var publicKey: Data
     /// `KeyTypeTagFFI` raw value identifying the curve of `publicKey`:
     /// 0 ECDSA / 1 BLS / 2 EdDSA. Meaningful only when `publicKey` is
-    /// non-empty.
-    public var keyType: UInt8
+    /// non-empty. The stored default (NOT just the init-parameter
+    /// default, which SwiftData migration never consults) keeps
+    /// pre-column stores openable: without it, lightweight migration
+    /// fails with "missing attribute values on mandatory destination
+    /// attribute" and the container refuses to load — a launch crash on
+    /// every device that has existing rows. Defaulted rows read as
+    /// ECDSA until the next Rust address-pool persist pulse re-tags
+    /// typed entries, which it does on every load.
+    public var keyType: UInt8 = 0
     /// `AddressPoolTypeTagFFI` raw value — 0 External, 1 Internal,
     /// 2 Absent, 3 AbsentHardened.
     public var poolTypeTag: UInt8


### PR DESCRIPTION
## Issue being fixed or feature implemented

#4127 added `PersistentCoreAddress.keyType: UInt8` with only an init-parameter default, which SwiftData lightweight migration never consults. Opening any pre-#4127 store fails migration ("Validation error missing attribute values on mandatory destination attribute: PersistentCoreAddress.keyType"), `DashModelContainer.create()` throws, and `SwiftExampleAppApp` hits `fatalError` — the app crash-loops on every device that has existing data.

## What was done?

Stored default `= 0` (ECDSA) on the property, matching the established convention for post-hoc columns (`isImported`, `statusRaw`, `blockPosition`). Defaulted rows read as ECDSA until the next Rust address-pool persist pulse re-tags typed entries, which happens on every load — so provider BLS/EdDSA rows self-heal immediately.

## How Has This Been Tested?

Reproduced the crash on the booted simulator: pre-#4127 store + v4.1-dev tip → container load error + crash to home screen. With this fix the same store migrates, the container loads, and the app launches.

## Breaking Changes

None.

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [ ] I have made corresponding changes to the documentation if needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility when opening existing local data stores after an update.
  * Prevented launch crashes by providing a default address key type for legacy records.
  * Existing records are interpreted consistently until their key type is refreshed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->