### PR TITLE
fix(platform-wallet): keep prederived typed keys for legacy key-less rows + land the #893 crash-fix pin

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1206,7 +1206,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1637,7 +1637,7 @@ dependencies = [
 [[package]]
 name = "dash-network"
 version = "0.45.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=38c689d97ddce0483d4ca455ade32efb019eb68d#38c689d97ddce0483d4ca455ade32efb019eb68d"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=19690d31b37ba12adc00f6bf2f8413d97e2b669d#19690d31b37ba12adc00f6bf2f8413d97e2b669d"
 dependencies = [
  "bincode",
  "bincode_derive",
@@ -1648,7 +1648,7 @@ dependencies = [
 [[package]]
 name = "dash-network-seeds"
 version = "0.45.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=38c689d97ddce0483d4ca455ade32efb019eb68d#38c689d97ddce0483d4ca455ade32efb019eb68d"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=19690d31b37ba12adc00f6bf2f8413d97e2b669d#19690d31b37ba12adc00f6bf2f8413d97e2b669d"
 dependencies = [
  "dash-network",
 ]
@@ -1725,7 +1725,7 @@ dependencies = [
 [[package]]
 name = "dash-spv"
 version = "0.45.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=38c689d97ddce0483d4ca455ade32efb019eb68d#38c689d97ddce0483d4ca455ade32efb019eb68d"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=19690d31b37ba12adc00f6bf2f8413d97e2b669d#19690d31b37ba12adc00f6bf2f8413d97e2b669d"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1754,7 +1754,7 @@ dependencies = [
 [[package]]
 name = "dashcore"
 version = "0.45.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=38c689d97ddce0483d4ca455ade32efb019eb68d#38c689d97ddce0483d4ca455ade32efb019eb68d"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=19690d31b37ba12adc00f6bf2f8413d97e2b669d#19690d31b37ba12adc00f6bf2f8413d97e2b669d"
 dependencies = [
  "anyhow",
  "base64-compat",
@@ -1780,12 +1780,12 @@ dependencies = [
 [[package]]
 name = "dashcore-private"
 version = "0.45.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=38c689d97ddce0483d4ca455ade32efb019eb68d#38c689d97ddce0483d4ca455ade32efb019eb68d"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=19690d31b37ba12adc00f6bf2f8413d97e2b669d#19690d31b37ba12adc00f6bf2f8413d97e2b669d"
 
 [[package]]
 name = "dashcore-rpc"
 version = "0.45.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=38c689d97ddce0483d4ca455ade32efb019eb68d#38c689d97ddce0483d4ca455ade32efb019eb68d"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=19690d31b37ba12adc00f6bf2f8413d97e2b669d#19690d31b37ba12adc00f6bf2f8413d97e2b669d"
 dependencies = [
  "dashcore-rpc-json",
  "hex",
@@ -1798,7 +1798,7 @@ dependencies = [
 [[package]]
 name = "dashcore-rpc-json"
 version = "0.45.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=38c689d97ddce0483d4ca455ade32efb019eb68d#38c689d97ddce0483d4ca455ade32efb019eb68d"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=19690d31b37ba12adc00f6bf2f8413d97e2b669d#19690d31b37ba12adc00f6bf2f8413d97e2b669d"
 dependencies = [
  "bincode",
  "dashcore",
@@ -1813,7 +1813,7 @@ dependencies = [
 [[package]]
 name = "dashcore_hashes"
 version = "0.45.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=38c689d97ddce0483d4ca455ade32efb019eb68d#38c689d97ddce0483d4ca455ade32efb019eb68d"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=19690d31b37ba12adc00f6bf2f8413d97e2b669d#19690d31b37ba12adc00f6bf2f8413d97e2b669d"
 dependencies = [
  "bincode",
  "dashcore-private",
@@ -2428,7 +2428,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2489,7 +2489,7 @@ checksum = "0ce92ff622d6dadf7349484f42c93271a0d49b7cc4d466a936405bacbe10aa78"
 dependencies = [
  "cfg-if",
  "rustix 1.1.4",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2867,7 +2867,7 @@ dependencies = [
 [[package]]
 name = "git-state"
 version = "0.45.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=38c689d97ddce0483d4ca455ade32efb019eb68d#38c689d97ddce0483d4ca455ade32efb019eb68d"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=19690d31b37ba12adc00f6bf2f8413d97e2b669d#19690d31b37ba12adc00f6bf2f8413d97e2b669d"
 
 [[package]]
 name = "glob"
@@ -3552,7 +3552,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.4",
+ "socket2 0.5.10",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -3803,7 +3803,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4034,7 +4034,7 @@ dependencies = [
 [[package]]
 name = "key-wallet"
 version = "0.45.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=38c689d97ddce0483d4ca455ade32efb019eb68d#38c689d97ddce0483d4ca455ade32efb019eb68d"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=19690d31b37ba12adc00f6bf2f8413d97e2b669d#19690d31b37ba12adc00f6bf2f8413d97e2b669d"
 dependencies = [
  "aes",
  "async-trait",
@@ -4063,7 +4063,7 @@ dependencies = [
 [[package]]
 name = "key-wallet-ffi"
 version = "0.45.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=38c689d97ddce0483d4ca455ade32efb019eb68d#38c689d97ddce0483d4ca455ade32efb019eb68d"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=19690d31b37ba12adc00f6bf2f8413d97e2b669d#19690d31b37ba12adc00f6bf2f8413d97e2b669d"
 dependencies = [
  "cbindgen 0.29.4",
  "dash-network",
@@ -4079,7 +4079,7 @@ dependencies = [
 [[package]]
 name = "key-wallet-manager"
 version = "0.45.0"
-source = "git+https://github.com/dashpay/rust-dashcore?rev=38c689d97ddce0483d4ca455ade32efb019eb68d#38c689d97ddce0483d4ca455ade32efb019eb68d"
+source = "git+https://github.com/dashpay/rust-dashcore?rev=19690d31b37ba12adc00f6bf2f8413d97e2b669d#19690d31b37ba12adc00f6bf2f8413d97e2b669d"
 dependencies = [
  "async-trait",
  "bincode",
@@ -4596,7 +4596,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5658,7 +5658,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash 2.1.2",
  "rustls",
- "socket2 0.6.4",
+ "socket2 0.5.10",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -5696,9 +5696,9 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.4",
+ "socket2 0.5.10",
  "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6489,7 +6489,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6502,7 +6502,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6561,7 +6561,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -7421,7 +7421,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -8870,7 +8870,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,14 +50,14 @@ members = [
 ]
 
 [workspace.dependencies]
-dashcore = { git = "https://github.com/dashpay/rust-dashcore", rev = "38c689d97ddce0483d4ca455ade32efb019eb68d" }
-dash-network-seeds = { git = "https://github.com/dashpay/rust-dashcore", rev = "38c689d97ddce0483d4ca455ade32efb019eb68d" }
-dash-spv = { git = "https://github.com/dashpay/rust-dashcore", rev = "38c689d97ddce0483d4ca455ade32efb019eb68d" }
-key-wallet = { git = "https://github.com/dashpay/rust-dashcore", rev = "38c689d97ddce0483d4ca455ade32efb019eb68d" }
-key-wallet-ffi = { git = "https://github.com/dashpay/rust-dashcore", rev = "38c689d97ddce0483d4ca455ade32efb019eb68d" }
-key-wallet-manager = { git = "https://github.com/dashpay/rust-dashcore", rev = "38c689d97ddce0483d4ca455ade32efb019eb68d" }
-dash-network = { git = "https://github.com/dashpay/rust-dashcore", rev = "38c689d97ddce0483d4ca455ade32efb019eb68d" }
-dashcore-rpc = { git = "https://github.com/dashpay/rust-dashcore", rev = "38c689d97ddce0483d4ca455ade32efb019eb68d" }
+dashcore = { git = "https://github.com/dashpay/rust-dashcore", rev = "19690d31b37ba12adc00f6bf2f8413d97e2b669d" }
+dash-network-seeds = { git = "https://github.com/dashpay/rust-dashcore", rev = "19690d31b37ba12adc00f6bf2f8413d97e2b669d" }
+dash-spv = { git = "https://github.com/dashpay/rust-dashcore", rev = "19690d31b37ba12adc00f6bf2f8413d97e2b669d" }
+key-wallet = { git = "https://github.com/dashpay/rust-dashcore", rev = "19690d31b37ba12adc00f6bf2f8413d97e2b669d" }
+key-wallet-ffi = { git = "https://github.com/dashpay/rust-dashcore", rev = "19690d31b37ba12adc00f6bf2f8413d97e2b669d" }
+key-wallet-manager = { git = "https://github.com/dashpay/rust-dashcore", rev = "19690d31b37ba12adc00f6bf2f8413d97e2b669d" }
+dash-network = { git = "https://github.com/dashpay/rust-dashcore", rev = "19690d31b37ba12adc00f6bf2f8413d97e2b669d" }
+dashcore-rpc = { git = "https://github.com/dashpay/rust-dashcore", rev = "19690d31b37ba12adc00f6bf2f8413d97e2b669d" }
 
 tokio-metrics = "0.5"
 

--- a/packages/rs-platform-wallet-ffi/src/persistence.rs
+++ b/packages/rs-platform-wallet-ffi/src/persistence.rs
@@ -3000,20 +3000,38 @@ unsafe fn address_info_from_ffi(
 }
 
 /// Restore persisted `AddressInfo` rows into a managed account's
-/// `AddressPool`. Plain upsert: a persisted row overwrites the gap-limit
+/// `AddressPool`. Upsert: a persisted row overwrites the gap-limit
 /// default `ManagedWalletInfo::from_wallet` pre-derived at the same
 /// index, and the reverse-lookup maps + `highest_*` watermarks are
 /// extended to cover indices past that default gap window.
 ///
 /// The persisted row is authoritative for its typed public key — the
-/// [`CoreAddressEntryFFI`] row now carries the full typed key (ECDSA-33 /
+/// [`CoreAddressEntryFFI`] row carries the full typed key (ECDSA-33 /
 /// BLS-48 / EdDSA-32) with a [`KeyTypeTagFFI`] discriminator, so BLS
 /// operator and Ed25519 platform-node keys survive the round-trip in the
-/// row itself. No merge against the pre-derived entry is needed or
-/// wanted.
+/// row itself — with ONE legacy exception: rows persisted before the
+/// typed-key column existed carry an empty key (`public_key: None`).
+/// Overwriting a pre-derived typed entry with such a row would strip the
+/// in-memory BLS operator pubkeys that `from_wallet` derived from the
+/// account xpub, silently breaking operator-ownership matching for every
+/// pre-typed-key store. So when the incoming row has no key but the
+/// pre-derived entry at that index does, the existing typed key is kept
+/// (post-migration rows always carry their key, making this a no-op for
+/// them). Legacy Ed25519 platform-node rows cannot be recovered this way
+/// (hardened-only — no public derivation) nor migrated from the removed
+/// account-level batch (its data was dropped by the schema migration);
+/// per the pre-release convention those stores re-derive on
+/// delete+re-import.
 fn restore_address_pool(pool: &mut AddressPool, infos: Vec<AddressInfo>) {
-    for info in infos {
+    for mut info in infos {
         let idx = info.index;
+        if info.public_key.is_none() {
+            if let Some(existing) = pool.addresses.get(&idx) {
+                if existing.public_key.is_some() {
+                    info.public_key = existing.public_key.clone();
+                }
+            }
+        }
         pool.address_index.insert(info.address.clone(), idx);
         pool.script_pubkey_index
             .insert(info.script_pubkey.clone(), idx);
@@ -5918,6 +5936,57 @@ mod tests {
                 other
             ),
         }
+    }
+
+    /// A LEGACY row (persisted before the typed-key column: empty key,
+    /// `public_key: None` after decode) must NOT strip the typed key the
+    /// gap-limit prederivation put at the same index — pre-typed-key
+    /// stores otherwise lose their in-memory BLS operator pubkeys at
+    /// load and masternode operator-ownership matching silently breaks
+    /// (post-migration rows always carry their key, so the preservation
+    /// is a no-op for them). Also pins the inverse: a legacy row at an
+    /// index with no prederived entry restores key-less rather than
+    /// inventing anything.
+    #[test]
+    fn legacy_keyless_row_keeps_prederived_typed_key() {
+        let mut pool = AddressPool::new_without_generation(
+            DerivationPath::from_str("m/9'/1'/3'").expect("static path must parse"),
+            AddressPoolType::AbsentHardened,
+            5,
+            Network::Testnet,
+        );
+
+        // Prederived typed entry, as `ManagedWalletInfo::from_wallet`
+        // seeds BLS operator pools from the account xpub.
+        let bls = vec![0xE7u8; 48];
+        let prederived = typed_key_test_address_info(7, Some(PublicKeyType::BLS(bls.clone())));
+        pool.addresses.insert(7, prederived);
+
+        // Legacy rows: same index key-less, plus one at a fresh index.
+        let legacy_same_idx = typed_key_test_address_info(7, None);
+        let legacy_fresh_idx = typed_key_test_address_info(9, None);
+        restore_address_pool(&mut pool, vec![legacy_same_idx, legacy_fresh_idx]);
+
+        match &pool
+            .addresses
+            .get(&7)
+            .expect("entry 7 must exist")
+            .public_key
+        {
+            Some(PublicKeyType::BLS(bytes)) => assert_eq!(
+                bytes, &bls,
+                "legacy key-less row must keep the prederived BLS key"
+            ),
+            other => panic!("prederived BLS key was stripped, got {:?}", other),
+        }
+        assert!(
+            pool.addresses
+                .get(&9)
+                .expect("entry 9 must exist")
+                .public_key
+                .is_none(),
+            "a legacy row with no prederived counterpart stays key-less"
+        );
     }
 
     /// `account_xpub` must survive the persist→restore byte round-trip — it is

--- a/packages/swift-sdk/Sources/SwiftDashSDK/Persistence/Models/PersistentCoreAddress.swift
+++ b/packages/swift-sdk/Sources/SwiftDashSDK/Persistence/Models/PersistentCoreAddress.swift
@@ -28,9 +28,16 @@ public final class PersistentCoreAddress {
     /// pre-column stores openable: without it, lightweight migration
     /// fails with "missing attribute values on mandatory destination
     /// attribute" and the container refuses to load — a launch crash on
-    /// every device that has existing rows. Defaulted rows read as
-    /// ECDSA until the next Rust address-pool persist pulse re-tags
-    /// typed entries, which it does on every load.
+    /// every device that has existing rows. Defaulted legacy rows read
+    /// as ECDSA with an empty `publicKey` until the next Rust
+    /// address-pool persist pulse (pool extension / address-used /
+    /// registration — NOT plain load, which only reads the snapshot)
+    /// re-emits them with typed keys. On load, Rust's
+    /// `restore_address_pool` keeps the pre-derived typed key when a
+    /// legacy row arrives key-less, so in-memory BLS operator matching
+    /// is unaffected; legacy Ed25519 platform-node keys are hardened-only
+    /// and re-derivable only via delete+re-import (pre-release
+    /// convention).
     public var keyType: UInt8 = 0
     /// `AddressPoolTypeTagFFI` raw value — 0 External, 1 Internal,
     /// 2 Absent, 3 AbsentHardened.


### PR DESCRIPTION
## Issue being fixed or feature implemented

Two follow-ups that missed the #4129 merge window:

1. **thepastaclaw's post-merge blocking finding on #4129** ([review](https://github.com/dashpay/platform/pull/4129#pullrequestreview-4697392092)): the keyType stored default makes legacy stores openable, but legacy rows (persisted before #4127's typed-key column) decode with `public_key: None` and `restore_address_pool`'s plain upsert then STRIPS the typed BLS key the gap-limit prederivation placed at the same index — silently breaking in-memory operator-ownership matching for pre-#4127 stores. The claimed "re-tags on every load" in the #4129 comment was also wrong (load only reads the snapshot; re-tag happens on the next persist pulse).

2. **The rust-dashcore #893 pin never landed on v4.1-dev**: #4129 was merged minutes after opening, and the crash-fix pin commits were pushed to its branch afterwards. v4.1-dev still pins 38c689d9, leaving the dash-spv sparse-filter startup crash-loop (rust-dashcore#892) unfixed on mainline.

## What was done?

- `restore_address_pool`: when an incoming row carries no key but the prederived entry at that index does, keep the existing typed key (no-op for post-#4127 rows, which always carry their key). Doc comment spells out why, and why legacy Ed25519 rows cannot be recovered this way (hardened-only; the old account-level batch's data was already dropped by the schema migration) — per the pre-release convention those stores re-derive on delete+re-import.
- New test `legacy_keyless_row_keeps_prederived_typed_key` pins the preservation and the inverse (a legacy row with no prederived counterpart stays key-less).
- Corrected the `keyType` doc comment to reflect actual re-tag timing.
- Bumped rust-dashcore to 19690d31 (the merged rust-dashcore#893, fixes rust-dashcore#892) — verified live earlier on the previously crash-looping simulator state (one-time discard + re-download, clean restarts since).

## How Has This Been Tested?

`cargo test -p platform-wallet -p platform-wallet-ffi` — 468 + FFI suites, 0 failures, including the new legacy-preservation test. `cargo check --all-targets` clean. The pinned rust-dashcore rev is content-identical to the PR-head pin (828f707d) already exercised on both simulators.

## Breaking Changes

None.

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [ ] I have made corresponding changes to the documentation if needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)