### PR TITLE
fix(swift-sdk): remove EstablishedContact's clone-mutating setters

### DIFF
--- a/packages/rs-platform-wallet-ffi/src/established_contact.rs
+++ b/packages/rs-platform-wallet-ffi/src/established_contact.rs
@@ -117,49 +117,6 @@ pub unsafe extern "C" fn established_contact_get_alias(
     PlatformWalletFFIResult::ok()
 }
 
-/// Set the alias for an established contact
-/// **Handle-local only**: mutates the clone held by this handle, NOT the
-/// wallet manager's contact state — the change is never persisted and is
-/// lost when the handle is freed. Real writes go through
-/// `platform_wallet_set_dashpay_contact_info_with_signer`.
-#[no_mangle]
-pub unsafe extern "C" fn established_contact_set_alias(
-    contact_handle: Handle,
-    alias: *const std::os::raw::c_char,
-) -> PlatformWalletFFIResult {
-    let alias_str = if alias.is_null() {
-        None
-    } else {
-        unsafe {
-            Some(unwrap_result_or_return!(std::ffi::CStr::from_ptr(alias).to_str()).to_string())
-        }
-    };
-
-    let option = ESTABLISHED_CONTACT_STORAGE.with_item_mut(contact_handle, |contact| {
-        if let Some(a) = alias_str {
-            contact.set_alias(a);
-        }
-    });
-    unwrap_option_or_return!(option);
-    PlatformWalletFFIResult::ok()
-}
-
-/// Clear the alias for an established contact
-/// **Handle-local only**: mutates the clone held by this handle, NOT the
-/// wallet manager's contact state — the change is never persisted and is
-/// lost when the handle is freed. Real writes go through
-/// `platform_wallet_set_dashpay_contact_info_with_signer`.
-#[no_mangle]
-pub unsafe extern "C" fn established_contact_clear_alias(
-    contact_handle: Handle,
-) -> PlatformWalletFFIResult {
-    let option = ESTABLISHED_CONTACT_STORAGE.with_item_mut(contact_handle, |contact| {
-        contact.clear_alias();
-    });
-    unwrap_option_or_return!(option);
-    PlatformWalletFFIResult::ok()
-}
-
 /// Get the note for an established contact
 #[no_mangle]
 pub unsafe extern "C" fn established_contact_get_note(
@@ -179,49 +136,6 @@ pub unsafe extern "C" fn established_contact_get_note(
     let note = unwrap_option_or_return!(option);
     let c_str = unwrap_result_or_return!(std::ffi::CString::new(note));
     unsafe { *out_note = c_str.into_raw() };
-    PlatformWalletFFIResult::ok()
-}
-
-/// Set the note for an established contact
-/// **Handle-local only**: mutates the clone held by this handle, NOT the
-/// wallet manager's contact state — the change is never persisted and is
-/// lost when the handle is freed. Real writes go through
-/// `platform_wallet_set_dashpay_contact_info_with_signer`.
-#[no_mangle]
-pub unsafe extern "C" fn established_contact_set_note(
-    contact_handle: Handle,
-    note: *const std::os::raw::c_char,
-) -> PlatformWalletFFIResult {
-    let note_str = if note.is_null() {
-        None
-    } else {
-        unsafe {
-            Some(unwrap_result_or_return!(std::ffi::CStr::from_ptr(note).to_str()).to_string())
-        }
-    };
-
-    let option = ESTABLISHED_CONTACT_STORAGE.with_item_mut(contact_handle, |contact| {
-        if let Some(n) = note_str {
-            contact.set_note(n);
-        }
-    });
-    unwrap_option_or_return!(option);
-    PlatformWalletFFIResult::ok()
-}
-
-/// Clear the note for an established contact
-/// **Handle-local only**: mutates the clone held by this handle, NOT the
-/// wallet manager's contact state — the change is never persisted and is
-/// lost when the handle is freed. Real writes go through
-/// `platform_wallet_set_dashpay_contact_info_with_signer`.
-#[no_mangle]
-pub unsafe extern "C" fn established_contact_clear_note(
-    contact_handle: Handle,
-) -> PlatformWalletFFIResult {
-    let option = ESTABLISHED_CONTACT_STORAGE.with_item_mut(contact_handle, |contact| {
-        contact.clear_note();
-    });
-    unwrap_option_or_return!(option);
     PlatformWalletFFIResult::ok()
 }
 
@@ -257,38 +171,6 @@ pub unsafe extern "C" fn established_contact_is_payment_channel_broken(
     let option = ESTABLISHED_CONTACT_STORAGE
         .with_item(contact_handle, |contact| contact.payment_channel_broken);
     *out_is_broken = unwrap_option_or_return!(option);
-    PlatformWalletFFIResult::ok()
-}
-
-/// Hide an established contact from the contact list
-/// **Handle-local only**: mutates the clone held by this handle, NOT the
-/// wallet manager's contact state — the change is never persisted and is
-/// lost when the handle is freed. Real writes go through
-/// `platform_wallet_set_dashpay_contact_info_with_signer`.
-#[no_mangle]
-pub unsafe extern "C" fn established_contact_hide(
-    contact_handle: Handle,
-) -> PlatformWalletFFIResult {
-    let option = ESTABLISHED_CONTACT_STORAGE.with_item_mut(contact_handle, |contact| {
-        contact.hide();
-    });
-    unwrap_option_or_return!(option);
-    PlatformWalletFFIResult::ok()
-}
-
-/// Unhide an established contact
-/// **Handle-local only**: mutates the clone held by this handle, NOT the
-/// wallet manager's contact state — the change is never persisted and is
-/// lost when the handle is freed. Real writes go through
-/// `platform_wallet_set_dashpay_contact_info_with_signer`.
-#[no_mangle]
-pub unsafe extern "C" fn established_contact_unhide(
-    contact_handle: Handle,
-) -> PlatformWalletFFIResult {
-    let option = ESTABLISHED_CONTACT_STORAGE.with_item_mut(contact_handle, |contact| {
-        contact.unhide();
-    });
-    unwrap_option_or_return!(option);
     PlatformWalletFFIResult::ok()
 }
 

--- a/packages/rs-platform-wallet-ffi/src/established_contact.rs
+++ b/packages/rs-platform-wallet-ffi/src/established_contact.rs
@@ -118,6 +118,10 @@ pub unsafe extern "C" fn established_contact_get_alias(
 }
 
 /// Set the alias for an established contact
+/// **Handle-local only**: mutates the clone held by this handle, NOT the
+/// wallet manager's contact state — the change is never persisted and is
+/// lost when the handle is freed. Real writes go through
+/// `platform_wallet_set_dashpay_contact_info_with_signer`.
 #[no_mangle]
 pub unsafe extern "C" fn established_contact_set_alias(
     contact_handle: Handle,
@@ -141,6 +145,10 @@ pub unsafe extern "C" fn established_contact_set_alias(
 }
 
 /// Clear the alias for an established contact
+/// **Handle-local only**: mutates the clone held by this handle, NOT the
+/// wallet manager's contact state — the change is never persisted and is
+/// lost when the handle is freed. Real writes go through
+/// `platform_wallet_set_dashpay_contact_info_with_signer`.
 #[no_mangle]
 pub unsafe extern "C" fn established_contact_clear_alias(
     contact_handle: Handle,
@@ -175,6 +183,10 @@ pub unsafe extern "C" fn established_contact_get_note(
 }
 
 /// Set the note for an established contact
+/// **Handle-local only**: mutates the clone held by this handle, NOT the
+/// wallet manager's contact state — the change is never persisted and is
+/// lost when the handle is freed. Real writes go through
+/// `platform_wallet_set_dashpay_contact_info_with_signer`.
 #[no_mangle]
 pub unsafe extern "C" fn established_contact_set_note(
     contact_handle: Handle,
@@ -198,6 +210,10 @@ pub unsafe extern "C" fn established_contact_set_note(
 }
 
 /// Clear the note for an established contact
+/// **Handle-local only**: mutates the clone held by this handle, NOT the
+/// wallet manager's contact state — the change is never persisted and is
+/// lost when the handle is freed. Real writes go through
+/// `platform_wallet_set_dashpay_contact_info_with_signer`.
 #[no_mangle]
 pub unsafe extern "C" fn established_contact_clear_note(
     contact_handle: Handle,
@@ -245,6 +261,10 @@ pub unsafe extern "C" fn established_contact_is_payment_channel_broken(
 }
 
 /// Hide an established contact from the contact list
+/// **Handle-local only**: mutates the clone held by this handle, NOT the
+/// wallet manager's contact state — the change is never persisted and is
+/// lost when the handle is freed. Real writes go through
+/// `platform_wallet_set_dashpay_contact_info_with_signer`.
 #[no_mangle]
 pub unsafe extern "C" fn established_contact_hide(
     contact_handle: Handle,
@@ -257,6 +277,14 @@ pub unsafe extern "C" fn established_contact_hide(
 }
 
 /// Unhide an established contact
+/// **Handle-local only**: mutates the clone held by this handle, NOT the
+/// wallet manager's contact state — the change is never persisted and is
+/// lost when the handle is freed. Real writes go through
+/// `platform_wallet_set_dashpay_contact_info_with_signer`.
+/// **Handle-local only**: mutates the clone held by this handle, NOT the
+/// wallet manager's contact state — the change is never persisted and is
+/// lost when the handle is freed. Real writes go through
+/// `platform_wallet_set_dashpay_contact_info_with_signer`.
 #[no_mangle]
 pub unsafe extern "C" fn established_contact_unhide(
     contact_handle: Handle,

--- a/packages/rs-platform-wallet-ffi/src/established_contact.rs
+++ b/packages/rs-platform-wallet-ffi/src/established_contact.rs
@@ -281,10 +281,6 @@ pub unsafe extern "C" fn established_contact_hide(
 /// wallet manager's contact state — the change is never persisted and is
 /// lost when the handle is freed. Real writes go through
 /// `platform_wallet_set_dashpay_contact_info_with_signer`.
-/// **Handle-local only**: mutates the clone held by this handle, NOT the
-/// wallet manager's contact state — the change is never persisted and is
-/// lost when the handle is freed. Real writes go through
-/// `platform_wallet_set_dashpay_contact_info_with_signer`.
 #[no_mangle]
 pub unsafe extern "C" fn established_contact_unhide(
     contact_handle: Handle,

--- a/packages/swift-sdk/Sources/SwiftDashSDK/PlatformWallet/EstablishedContact.swift
+++ b/packages/swift-sdk/Sources/SwiftDashSDK/PlatformWallet/EstablishedContact.swift
@@ -54,19 +54,6 @@ public final class EstablishedContact: @unchecked Sendable {
         return String(cString: ptr)
     }
 
-    /// Set the contact's alias
-    @available(*, deprecated, message: "Mutates a detached FFI clone — the change never reaches wallet state, is never persisted, and is silently lost when the handle is freed. Use ManagedPlatformWallet.setDashPayContactInfo(identityId:contactId:alias:note:hidden:signer:), which writes real state and publishes the encrypted contactInfo document.")
-    public func setAlias(_ alias: String) throws {
-        let aliasCStr = (alias as NSString).utf8String
-        try established_contact_set_alias(handle, aliasCStr).check()
-    }
-
-    /// Clear the contact's alias
-    @available(*, deprecated, message: "Mutates a detached FFI clone — the change never reaches wallet state, is never persisted, and is silently lost when the handle is freed. Use ManagedPlatformWallet.setDashPayContactInfo(identityId:contactId:alias:note:hidden:signer:), which writes real state and publishes the encrypted contactInfo document.")
-    public func clearAlias() throws {
-        try established_contact_clear_alias(handle).check()
-    }
-
     /// Get the contact's note. Returns `nil` when no note is set —
     /// see `getAlias()` for the `NotFound` rationale.
     public func getNote() throws -> String? {
@@ -93,35 +80,10 @@ public final class EstablishedContact: @unchecked Sendable {
         return String(cString: ptr)
     }
 
-    /// Set the contact's note
-    @available(*, deprecated, message: "Mutates a detached FFI clone — the change never reaches wallet state, is never persisted, and is silently lost when the handle is freed. Use ManagedPlatformWallet.setDashPayContactInfo(identityId:contactId:alias:note:hidden:signer:), which writes real state and publishes the encrypted contactInfo document.")
-    public func setNote(_ note: String) throws {
-        let noteCStr = (note as NSString).utf8String
-        try established_contact_set_note(handle, noteCStr).check()
-    }
-
-    /// Clear the contact's note
-    @available(*, deprecated, message: "Mutates a detached FFI clone — the change never reaches wallet state, is never persisted, and is silently lost when the handle is freed. Use ManagedPlatformWallet.setDashPayContactInfo(identityId:contactId:alias:note:hidden:signer:), which writes real state and publishes the encrypted contactInfo document.")
-    public func clearNote() throws {
-        try established_contact_clear_note(handle).check()
-    }
-
     /// Check if the contact is hidden
     public func isHidden() throws -> Bool {
         var hidden: Bool = false
         try established_contact_is_hidden(handle, &hidden).check()
         return hidden
-    }
-
-    /// Hide the contact
-    @available(*, deprecated, message: "Mutates a detached FFI clone — the change never reaches wallet state, is never persisted, and is silently lost when the handle is freed. Use ManagedPlatformWallet.setDashPayContactInfo(identityId:contactId:alias:note:hidden:signer:), which writes real state and publishes the encrypted contactInfo document.")
-    public func hide() throws {
-        try established_contact_hide(handle).check()
-    }
-
-    /// Unhide the contact
-    @available(*, deprecated, message: "Mutates a detached FFI clone — the change never reaches wallet state, is never persisted, and is silently lost when the handle is freed. Use ManagedPlatformWallet.setDashPayContactInfo(identityId:contactId:alias:note:hidden:signer:), which writes real state and publishes the encrypted contactInfo document.")
-    public func unhide() throws {
-        try established_contact_unhide(handle).check()
     }
 }

--- a/packages/swift-sdk/Sources/SwiftDashSDK/PlatformWallet/EstablishedContact.swift
+++ b/packages/swift-sdk/Sources/SwiftDashSDK/PlatformWallet/EstablishedContact.swift
@@ -55,12 +55,14 @@ public final class EstablishedContact: @unchecked Sendable {
     }
 
     /// Set the contact's alias
+    @available(*, deprecated, message: "Mutates a detached FFI clone — the change never reaches wallet state, is never persisted, and is silently lost when the handle is freed. Use ManagedPlatformWallet.setDashPayContactInfo(identityId:contactId:alias:note:hidden:signer:), which writes real state and publishes the encrypted contactInfo document.")
     public func setAlias(_ alias: String) throws {
         let aliasCStr = (alias as NSString).utf8String
         try established_contact_set_alias(handle, aliasCStr).check()
     }
 
     /// Clear the contact's alias
+    @available(*, deprecated, message: "Mutates a detached FFI clone — the change never reaches wallet state, is never persisted, and is silently lost when the handle is freed. Use ManagedPlatformWallet.setDashPayContactInfo(identityId:contactId:alias:note:hidden:signer:), which writes real state and publishes the encrypted contactInfo document.")
     public func clearAlias() throws {
         try established_contact_clear_alias(handle).check()
     }
@@ -92,12 +94,14 @@ public final class EstablishedContact: @unchecked Sendable {
     }
 
     /// Set the contact's note
+    @available(*, deprecated, message: "Mutates a detached FFI clone — the change never reaches wallet state, is never persisted, and is silently lost when the handle is freed. Use ManagedPlatformWallet.setDashPayContactInfo(identityId:contactId:alias:note:hidden:signer:), which writes real state and publishes the encrypted contactInfo document.")
     public func setNote(_ note: String) throws {
         let noteCStr = (note as NSString).utf8String
         try established_contact_set_note(handle, noteCStr).check()
     }
 
     /// Clear the contact's note
+    @available(*, deprecated, message: "Mutates a detached FFI clone — the change never reaches wallet state, is never persisted, and is silently lost when the handle is freed. Use ManagedPlatformWallet.setDashPayContactInfo(identityId:contactId:alias:note:hidden:signer:), which writes real state and publishes the encrypted contactInfo document.")
     public func clearNote() throws {
         try established_contact_clear_note(handle).check()
     }
@@ -110,11 +114,13 @@ public final class EstablishedContact: @unchecked Sendable {
     }
 
     /// Hide the contact
+    @available(*, deprecated, message: "Mutates a detached FFI clone — the change never reaches wallet state, is never persisted, and is silently lost when the handle is freed. Use ManagedPlatformWallet.setDashPayContactInfo(identityId:contactId:alias:note:hidden:signer:), which writes real state and publishes the encrypted contactInfo document.")
     public func hide() throws {
         try established_contact_hide(handle).check()
     }
 
     /// Unhide the contact
+    @available(*, deprecated, message: "Mutates a detached FFI clone — the change never reaches wallet state, is never persisted, and is silently lost when the handle is freed. Use ManagedPlatformWallet.setDashPayContactInfo(identityId:contactId:alias:note:hidden:signer:), which writes real state and publishes the encrypted contactInfo document.")
     public func unhide() throws {
         try established_contact_unhide(handle).check()
     }


### PR DESCRIPTION
## Summary

`managed_identity_get_established_contact` inserts a **`.cloned()`** copy of the contact into the FFI handle table, so `EstablishedContact.setAlias / clearAlias / setNote / clearNote / hide / unhide` mutated a detached clone: the change never reached the wallet manager's contact state, was never persisted, and was silently lost when the handle was freed.

Found via dashwallet QA: the contact-settings sheet was wired to these setters and showed a "Saved" toast over a complete no-op (empty `contactAlias`/`contactNote` mirror columns, nothing published).

Since **nothing has shipped**, the setters are **removed outright** (Swift wrappers + the six FFI functions) rather than deprecated — no consumer exists: dashwallet is rewired to the correct API in [dashwallet-ios#834](https://github.com/dashpay/dashwallet-ios/pull/834) and SwiftExampleApp always used it.

The correct write path is untouched and already complete: `ManagedPlatformWallet.setDashPayContactInfo` → `platform_wallet_set_dashpay_contact_info_with_signer` → `set_contact_info_with_external_signer` (local state first + persist + encrypted DIP-15 `contactInfo` document publish, with published / deferred / skipped outcome).

Getters (`getAlias`, `getNote`, `isHidden`, …) stay — reading the clone snapshot is fine.

## Test plan
- [x] `cargo check -p platform-wallet-ffi` clean
- [x] dashwallet `dashpay` scheme builds against this branch (compiles swift-sdk from source; no remaining references)

🤖 Generated with [Claude Code](https://claude.com/claude-code)