### PR TITLE
fix(drive-abci): record unshield and shield-surplus credits in recent address balance changes

### DIFF
--- a/packages/rs-drive-abci/src/abci/app/execution_result.rs
+++ b/packages/rs-drive-abci/src/abci/app/execution_result.rs
@@ -29,14 +29,14 @@ impl TryIntoPlatformVersioned<Option<ExecTxResult>> for StateTransitionExecution
                 gas_used: 0,
                 ..Default::default()
             }),
-            StateTransitionExecutionResult::PaidConsensusError { error, actual_fees } => {
-                Some(ExecTxResult {
-                    code: HandlerError::from(&error).code(),
-                    info: error.response_info_for_version(platform_version)?,
-                    gas_used: actual_fees.total_base_fee() as SignedCredits,
-                    ..Default::default()
-                })
-            }
+            StateTransitionExecutionResult::PaidConsensusError {
+                error, actual_fees, ..
+            } => Some(ExecTxResult {
+                code: HandlerError::from(&error).code(),
+                info: error.response_info_for_version(platform_version)?,
+                gas_used: actual_fees.total_base_fee() as SignedCredits,
+                ..Default::default()
+            }),
             StateTransitionExecutionResult::InternalError(message) => Some(ExecTxResult {
                 code: HandlerError::Internal(message).code(),
                 // TODO: That would be nice to provide more information about the error for debugging
@@ -118,6 +118,7 @@ mod tests {
         let execution_result = StateTransitionExecutionResult::PaidConsensusError {
             error: consensus_error,
             actual_fees: fee_result.clone(),
+            address_balance_changes: BTreeMap::new(),
         };
 
         let result: Option<ExecTxResult> = execution_result

--- a/packages/rs-drive-abci/src/execution/platform_events/state_transition_processing/execute_event/v0/mod.rs
+++ b/packages/rs-drive-abci/src/execution/platform_events/state_transition_processing/execute_event/v0/mod.rs
@@ -434,32 +434,7 @@ where
                 )?;
 
                 // Track address outputs if provided (e.g., for IdentityCreditTransferToAddresses)
-                if let Some(outputs) = added_to_balance_outputs {
-                    if let Some(balance_updates) = address_balances_in_update {
-                        for (address, credits) in outputs {
-                            let new_op = CreditOperation::AddToCredits(credits);
-                            balance_updates
-                                .entry(address)
-                                .and_modify(|existing| {
-                                    *existing = match existing {
-                                        // Set + Add = Set to combined value
-                                        CreditOperation::SetCredits(set_val) => {
-                                            CreditOperation::SetCredits(
-                                                set_val.saturating_add(credits),
-                                            )
-                                        }
-                                        // Add + Add = saturating add
-                                        CreditOperation::AddToCredits(add_val) => {
-                                            CreditOperation::AddToCredits(
-                                                add_val.saturating_add(credits),
-                                            )
-                                        }
-                                    };
-                                })
-                                .or_insert(new_op);
-                        }
-                    }
-                }
+                record_added_balance_outputs(address_balances_in_update, added_to_balance_outputs);
 
                 Ok(result)
             }
@@ -591,34 +566,9 @@ where
                 // The ops just applied credited any transparent output address (an Unshield's
                 // recipient, including the chargeable-failure fallback address). Record that credit
                 // into the recent-address-balance-changes tree so incremental client sync sees it —
-                // same entry/merge idiom as the `Paid` arm's `added_to_balance_outputs`. Reached only
-                // on the applied path (the early return above skips this), mirroring the `Paid` arm.
-                if let Some(outputs) = added_to_balance_outputs {
-                    if let Some(balance_updates) = address_balances_in_update {
-                        for (address, credits) in outputs {
-                            let new_op = CreditOperation::AddToCredits(credits);
-                            balance_updates
-                                .entry(address)
-                                .and_modify(|existing| {
-                                    *existing = match existing {
-                                        // Set + Add = Set to combined value
-                                        CreditOperation::SetCredits(set_val) => {
-                                            CreditOperation::SetCredits(
-                                                set_val.saturating_add(credits),
-                                            )
-                                        }
-                                        // Add + Add = saturating add
-                                        CreditOperation::AddToCredits(add_val) => {
-                                            CreditOperation::AddToCredits(
-                                                add_val.saturating_add(credits),
-                                            )
-                                        }
-                                    };
-                                })
-                                .or_insert(new_op);
-                        }
-                    }
-                }
+                // same merge as the `Paid` arm's `added_to_balance_outputs`. Reached only on the
+                // applied path (the early return above skips this), mirroring the `Paid` arm.
+                record_added_balance_outputs(address_balances_in_update, added_to_balance_outputs);
 
                 // Split the carved fee like every other transition: the real storage
                 // cost of the (permanent) shielded writes goes to the storage pool, so it
@@ -669,34 +619,12 @@ where
 
                     // The ops just applied credited the shield's transparent surplus-output address
                     // (when set). Record that credit into the recent-address-balance-changes tree so
-                    // incremental client sync sees it — same entry/merge idiom as the `Paid` arm's
+                    // incremental client sync sees it — same merge as the `Paid` arm's
                     // `added_to_balance_outputs`. Reached only on the applied (no-errors) path.
-                    if let Some(outputs) = added_to_balance_outputs {
-                        if let Some(balance_updates) = address_balances_in_update {
-                            for (address, credits) in outputs {
-                                let new_op = CreditOperation::AddToCredits(credits);
-                                balance_updates
-                                    .entry(address)
-                                    .and_modify(|existing| {
-                                        *existing = match existing {
-                                            // Set + Add = Set to combined value
-                                            CreditOperation::SetCredits(set_val) => {
-                                                CreditOperation::SetCredits(
-                                                    set_val.saturating_add(credits),
-                                                )
-                                            }
-                                            // Add + Add = saturating add
-                                            CreditOperation::AddToCredits(add_val) => {
-                                                CreditOperation::AddToCredits(
-                                                    add_val.saturating_add(credits),
-                                                )
-                                            }
-                                        };
-                                    })
-                                    .or_insert(new_op);
-                            }
-                        }
-                    }
+                    record_added_balance_outputs(
+                        address_balances_in_update,
+                        added_to_balance_outputs,
+                    );
 
                     // Route the real storage cost of the shielded writes to the storage pool
                     // (amortised over time, epoch fee multiplier applied at payout); the
@@ -764,6 +692,40 @@ where
                 Ok(SuccessfulFreeExecution)
             }
         }
+    }
+}
+
+/// Fold transparent-address credit outputs into the per-block address-balance
+/// map — the sole feed for `store_address_balances_for_block`, i.e. the
+/// recent-address-balance-changes tree incremental client sync reads. One
+/// definition so every event path (`Paid`, `PaidFromShieldedPool`,
+/// `PaidFromAssetLockToPool`) shares identical merge semantics:
+/// Set + Add = Set(sum), Add + Add = Add(sum), both saturating.
+fn record_added_balance_outputs(
+    address_balances_in_update: Option<&mut BTreeMap<PlatformAddress, CreditOperation>>,
+    added_to_balance_outputs: Option<BTreeMap<PlatformAddress, Credits>>,
+) {
+    let (Some(balance_updates), Some(outputs)) =
+        (address_balances_in_update, added_to_balance_outputs)
+    else {
+        return;
+    };
+    for (address, credits) in outputs {
+        balance_updates
+            .entry(address)
+            .and_modify(|existing| {
+                *existing = match existing {
+                    // Set + Add = Set to combined value
+                    CreditOperation::SetCredits(set_val) => {
+                        CreditOperation::SetCredits(set_val.saturating_add(credits))
+                    }
+                    // Add + Add = saturating add
+                    CreditOperation::AddToCredits(add_val) => {
+                        CreditOperation::AddToCredits(add_val.saturating_add(credits))
+                    }
+                };
+            })
+            .or_insert(CreditOperation::AddToCredits(credits));
     }
 }
 

--- a/packages/rs-drive-abci/src/execution/platform_events/state_transition_processing/execute_event/v0/mod.rs
+++ b/packages/rs-drive-abci/src/execution/platform_events/state_transition_processing/execute_event/v0/mod.rs
@@ -548,6 +548,7 @@ where
             ExecutionEvent::PaidFromShieldedPool {
                 operations,
                 fees_to_add_to_pool,
+                added_to_balance_outputs,
                 chargeable_failure,
             } => {
                 // An error-bearing `PaidFromShieldedPool` is legitimate ONLY for the
@@ -587,6 +588,38 @@ where
                     )
                     .map_err(Error::Drive)?;
 
+                // The ops just applied credited any transparent output address (an Unshield's
+                // recipient, including the chargeable-failure fallback address). Record that credit
+                // into the recent-address-balance-changes tree so incremental client sync sees it —
+                // same entry/merge idiom as the `Paid` arm's `added_to_balance_outputs`. Reached only
+                // on the applied path (the early return above skips this), mirroring the `Paid` arm.
+                if let Some(outputs) = added_to_balance_outputs {
+                    if let Some(balance_updates) = address_balances_in_update {
+                        for (address, credits) in outputs {
+                            let new_op = CreditOperation::AddToCredits(credits);
+                            balance_updates
+                                .entry(address)
+                                .and_modify(|existing| {
+                                    *existing = match existing {
+                                        // Set + Add = Set to combined value
+                                        CreditOperation::SetCredits(set_val) => {
+                                            CreditOperation::SetCredits(
+                                                set_val.saturating_add(credits),
+                                            )
+                                        }
+                                        // Add + Add = saturating add
+                                        CreditOperation::AddToCredits(add_val) => {
+                                            CreditOperation::AddToCredits(
+                                                add_val.saturating_add(credits),
+                                            )
+                                        }
+                                    };
+                                })
+                                .or_insert(new_op);
+                        }
+                    }
+                }
+
                 // Split the carved fee like every other transition: the real storage
                 // cost of the (permanent) shielded writes goes to the storage pool, so it
                 // is amortised to the validators that store it over time and picks up the
@@ -612,6 +645,7 @@ where
             }
             ExecutionEvent::PaidFromAssetLockToPool {
                 fees_to_add_to_pool,
+                added_to_balance_outputs,
                 operations,
                 ..
             } => {
@@ -632,6 +666,37 @@ where
                             Some(previous_fee_versions),
                         )
                         .map_err(Error::Drive)?;
+
+                    // The ops just applied credited the shield's transparent surplus-output address
+                    // (when set). Record that credit into the recent-address-balance-changes tree so
+                    // incremental client sync sees it — same entry/merge idiom as the `Paid` arm's
+                    // `added_to_balance_outputs`. Reached only on the applied (no-errors) path.
+                    if let Some(outputs) = added_to_balance_outputs {
+                        if let Some(balance_updates) = address_balances_in_update {
+                            for (address, credits) in outputs {
+                                let new_op = CreditOperation::AddToCredits(credits);
+                                balance_updates
+                                    .entry(address)
+                                    .and_modify(|existing| {
+                                        *existing = match existing {
+                                            // Set + Add = Set to combined value
+                                            CreditOperation::SetCredits(set_val) => {
+                                                CreditOperation::SetCredits(
+                                                    set_val.saturating_add(credits),
+                                                )
+                                            }
+                                            // Add + Add = saturating add
+                                            CreditOperation::AddToCredits(add_val) => {
+                                                CreditOperation::AddToCredits(
+                                                    add_val.saturating_add(credits),
+                                                )
+                                            }
+                                        };
+                                    })
+                                    .or_insert(new_op);
+                            }
+                        }
+                    }
 
                     // Route the real storage cost of the shielded writes to the storage pool
                     // (amortised over time, epoch fee multiplier applied at payout); the
@@ -699,5 +764,143 @@ where
                 Ok(SuccessfulFreeExecution)
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::platform_types::event_execution_result::EventExecutionResult;
+    use crate::test::helpers::setup::TestPlatformBuilder;
+    use dpp::fee::default_costs::CachedEpochIndexFeeVersions;
+
+    /// Regression for the recent-address-balance-changes gap: a `PaidFromShieldedPool` carrying an
+    /// Unshield's output credit must fold that credit into the `address_balances_in_update` map (the
+    /// sole feed for `store_address_balances_for_block`), so incremental client sync can see the
+    /// unshield. Before the fix the arm applied the drive ops but never touched the map, leaving the
+    /// credit invisible to incremental sync.
+    #[test]
+    fn paid_from_shielded_pool_folds_output_credit_into_address_balances() {
+        let platform_version = PlatformVersion::latest();
+        let platform = TestPlatformBuilder::new()
+            .build_with_mock_rpc()
+            .set_genesis_state();
+        let transaction = platform.drive.grove.start_transaction();
+        let fee_versions = CachedEpochIndexFeeVersions::new();
+
+        let output_address = PlatformAddress::P2pkh([0xBB; 20]);
+        let event = ExecutionEvent::PaidFromShieldedPool {
+            operations: vec![],
+            fees_to_add_to_pool: 0,
+            added_to_balance_outputs: Some(BTreeMap::from([(output_address, 2500)])),
+            chargeable_failure: false,
+        };
+
+        let mut address_balances: BTreeMap<PlatformAddress, CreditOperation> = BTreeMap::new();
+        let result = platform
+            .platform
+            .execute_event_v0(
+                event,
+                vec![],
+                &BlockInfo::default(),
+                &transaction,
+                Some(&mut address_balances),
+                platform_version,
+                &fee_versions,
+            )
+            .expect("execute_event_v0 should not error");
+
+        assert!(
+            matches!(result, EventExecutionResult::SuccessfulPaidExecution(..)),
+            "an ordinary unshield must execute successfully"
+        );
+        assert_eq!(
+            address_balances.get(&output_address),
+            Some(&CreditOperation::AddToCredits(2500)),
+            "the unshield output credit must be recorded for incremental sync"
+        );
+    }
+
+    /// A `PaidFromShieldedPool` with no output (ShieldedTransfer / ShieldedWithdrawal, or a net-zero
+    /// unshield) must leave the address-balances map untouched.
+    #[test]
+    fn paid_from_shielded_pool_without_output_records_nothing() {
+        let platform_version = PlatformVersion::latest();
+        let platform = TestPlatformBuilder::new()
+            .build_with_mock_rpc()
+            .set_genesis_state();
+        let transaction = platform.drive.grove.start_transaction();
+        let fee_versions = CachedEpochIndexFeeVersions::new();
+
+        let event = ExecutionEvent::PaidFromShieldedPool {
+            operations: vec![],
+            fees_to_add_to_pool: 0,
+            added_to_balance_outputs: None,
+            chargeable_failure: false,
+        };
+
+        let mut address_balances: BTreeMap<PlatformAddress, CreditOperation> = BTreeMap::new();
+        platform
+            .platform
+            .execute_event_v0(
+                event,
+                vec![],
+                &BlockInfo::default(),
+                &transaction,
+                Some(&mut address_balances),
+                platform_version,
+                &fee_versions,
+            )
+            .expect("execute_event_v0 should not error");
+
+        assert!(
+            address_balances.is_empty(),
+            "a shielded spend crediting no transparent address must record nothing"
+        );
+    }
+
+    /// The `PaidFromAssetLockToPool` counterpart: a `ShieldFromAssetLock` surplus credit must be
+    /// folded into the address-balances map on the applied (no-errors) path.
+    #[test]
+    fn paid_from_asset_lock_to_pool_folds_surplus_credit_into_address_balances() {
+        let platform_version = PlatformVersion::latest();
+        let platform = TestPlatformBuilder::new()
+            .with_latest_protocol_version()
+            .build_with_mock_rpc()
+            .set_initial_state_structure();
+        let transaction = platform.drive.grove.start_transaction();
+        let fee_versions = CachedEpochIndexFeeVersions::new();
+
+        let surplus_address = PlatformAddress::P2pkh([0x42; 20]);
+        let event = ExecutionEvent::PaidFromAssetLockToPool {
+            fees_to_add_to_pool: 1_000_000,
+            added_to_balance_outputs: Some(BTreeMap::from([(surplus_address, 2000)])),
+            operations: vec![],
+            execution_operations: vec![],
+        };
+
+        let mut address_balances: BTreeMap<PlatformAddress, CreditOperation> = BTreeMap::new();
+        let result = platform
+            .platform
+            .execute_event_v0(
+                event,
+                vec![],
+                &BlockInfo::default(),
+                &transaction,
+                Some(&mut address_balances),
+                platform_version,
+                &fee_versions,
+            )
+            .expect("execute_event_v0 should not error");
+
+        assert!(
+            matches!(result, EventExecutionResult::SuccessfulPaidExecution(..)),
+            "a sufficiently-funded shield-from-asset-lock must execute successfully"
+        );
+        assert_eq!(
+            address_balances.get(&surplus_address),
+            Some(&CreditOperation::AddToCredits(2000)),
+            "the shield surplus credit must be recorded for incremental sync"
+        );
     }
 }

--- a/packages/rs-drive-abci/src/execution/platform_events/state_transition_processing/execute_event/v0/mod.rs
+++ b/packages/rs-drive-abci/src/execution/platform_events/state_transition_processing/execute_event/v0/mod.rs
@@ -1,5 +1,6 @@
 use crate::error::execution::ExecutionError;
 use crate::error::Error;
+use crate::execution::platform_events::state_transition_processing::record_added_balance_outputs::AddedBalanceOutputsOrigin;
 use crate::execution::types::execution_event::ExecutionEvent;
 use crate::execution::types::execution_operation::ValidationOperation;
 use crate::platform_types::event_execution_result::EventExecutionResult;
@@ -433,8 +434,15 @@ where
                     previous_fee_versions,
                 )?;
 
-                // Track address outputs if provided (e.g., for IdentityCreditTransferToAddresses)
-                record_added_balance_outputs(address_balances_in_update, added_to_balance_outputs);
+                // Track address outputs if provided (e.g., for IdentityCreditTransferToAddresses).
+                // Transparent origin: this long-standing recording is preserved by every version
+                // (v0 and v1 both fold Transparent-origin outputs).
+                self.record_added_balance_outputs(
+                    address_balances_in_update,
+                    added_to_balance_outputs,
+                    AddedBalanceOutputsOrigin::Transparent,
+                    platform_version,
+                )?;
 
                 Ok(result)
             }
@@ -565,10 +573,15 @@ where
 
                 // The ops just applied credited any transparent output address (an Unshield's
                 // recipient, including the chargeable-failure fallback address). Record that credit
-                // into the recent-address-balance-changes tree so incremental client sync sees it —
-                // same merge as the `Paid` arm's `added_to_balance_outputs`. Reached only on the
-                // applied path (the early return above skips this), mirroring the `Paid` arm.
-                record_added_balance_outputs(address_balances_in_update, added_to_balance_outputs);
+                // so incremental client sync sees it. ShieldedSpend origin: recorded only from v1
+                // (protocol v13); v0 drops it so pre-v13 blocks byte-match. Reached only on the
+                // applied path (the early return above skips this).
+                self.record_added_balance_outputs(
+                    address_balances_in_update,
+                    added_to_balance_outputs,
+                    AddedBalanceOutputsOrigin::ShieldedSpend,
+                    platform_version,
+                )?;
 
                 // Split the carved fee like every other transition: the real storage
                 // cost of the (permanent) shielded writes goes to the storage pool, so it
@@ -618,13 +631,15 @@ where
                         .map_err(Error::Drive)?;
 
                     // The ops just applied credited the shield's transparent surplus-output address
-                    // (when set). Record that credit into the recent-address-balance-changes tree so
-                    // incremental client sync sees it — same merge as the `Paid` arm's
-                    // `added_to_balance_outputs`. Reached only on the applied (no-errors) path.
-                    record_added_balance_outputs(
+                    // (when set). Record that credit so incremental client sync sees it. ShieldedSpend
+                    // origin: recorded only from v1 (protocol v13); v0 drops it so pre-v13 blocks
+                    // byte-match. Reached only on the applied (no-errors) path.
+                    self.record_added_balance_outputs(
                         address_balances_in_update,
                         added_to_balance_outputs,
-                    );
+                        AddedBalanceOutputsOrigin::ShieldedSpend,
+                        platform_version,
+                    )?;
 
                     // Route the real storage cost of the shielded writes to the storage pool
                     // (amortised over time, epoch fee multiplier applied at payout); the
@@ -695,40 +710,6 @@ where
     }
 }
 
-/// Fold transparent-address credit outputs into the per-block address-balance
-/// map — the sole feed for `store_address_balances_for_block`, i.e. the
-/// recent-address-balance-changes tree incremental client sync reads. One
-/// definition so every event path (`Paid`, `PaidFromShieldedPool`,
-/// `PaidFromAssetLockToPool`) shares identical merge semantics:
-/// Set + Add = Set(sum), Add + Add = Add(sum), both saturating.
-fn record_added_balance_outputs(
-    address_balances_in_update: Option<&mut BTreeMap<PlatformAddress, CreditOperation>>,
-    added_to_balance_outputs: Option<BTreeMap<PlatformAddress, Credits>>,
-) {
-    let (Some(balance_updates), Some(outputs)) =
-        (address_balances_in_update, added_to_balance_outputs)
-    else {
-        return;
-    };
-    for (address, credits) in outputs {
-        balance_updates
-            .entry(address)
-            .and_modify(|existing| {
-                *existing = match existing {
-                    // Set + Add = Set to combined value
-                    CreditOperation::SetCredits(set_val) => {
-                        CreditOperation::SetCredits(set_val.saturating_add(credits))
-                    }
-                    // Add + Add = saturating add
-                    CreditOperation::AddToCredits(add_val) => {
-                        CreditOperation::AddToCredits(add_val.saturating_add(credits))
-                    }
-                };
-            })
-            .or_insert(CreditOperation::AddToCredits(credits));
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -743,7 +724,9 @@ mod tests {
     /// credit invisible to incremental sync.
     #[test]
     fn paid_from_shielded_pool_folds_output_credit_into_address_balances() {
-        let platform_version = PlatformVersion::latest();
+        // Pin v13: the executor's record_added_balance_outputs is v1 here, which folds
+        // shielded-spend-origin outputs (v0 would drop them).
+        let platform_version = PlatformVersion::get(13).expect("v13 must exist");
         let platform = TestPlatformBuilder::new()
             .build_with_mock_rpc()
             .set_genesis_state();
@@ -787,7 +770,9 @@ mod tests {
     /// unshield) must leave the address-balances map untouched.
     #[test]
     fn paid_from_shielded_pool_without_output_records_nothing() {
-        let platform_version = PlatformVersion::latest();
+        // Pin v13: the executor's record_added_balance_outputs is v1 here, which folds
+        // shielded-spend-origin outputs (v0 would drop them).
+        let platform_version = PlatformVersion::get(13).expect("v13 must exist");
         let platform = TestPlatformBuilder::new()
             .build_with_mock_rpc()
             .set_genesis_state();
@@ -825,7 +810,9 @@ mod tests {
     /// folded into the address-balances map on the applied (no-errors) path.
     #[test]
     fn paid_from_asset_lock_to_pool_folds_surplus_credit_into_address_balances() {
-        let platform_version = PlatformVersion::latest();
+        // Pin v13: the executor's record_added_balance_outputs is v1 here, which folds
+        // shielded-spend-origin outputs (v0 would drop them).
+        let platform_version = PlatformVersion::get(13).expect("v13 must exist");
         let platform = TestPlatformBuilder::new()
             .with_latest_protocol_version()
             .build_with_mock_rpc()

--- a/packages/rs-drive-abci/src/execution/platform_events/state_transition_processing/mod.rs
+++ b/packages/rs-drive-abci/src/execution/platform_events/state_transition_processing/mod.rs
@@ -2,5 +2,22 @@ mod cleanup_recent_block_storage_address_balances;
 mod decode_raw_state_transitions;
 mod execute_event;
 mod process_raw_state_transitions;
+mod process_validation_result;
+mod record_added_balance_outputs;
 mod store_address_balances_to_recent_block_storage;
 mod validate_fees_of_event;
+
+use crate::error::Error;
+
+/// Pairs an [`Error`] with the raw state transition (and its name) that produced it, so failures can
+/// be logged with context and mapped to an `InternalError` execution result.
+///
+/// Shared by the `process_raw_state_transitions` outer loop and the `process_validation_result`
+/// versioned helper it dispatches to (both are descendants of this module, so the private fields are
+/// visible to them).
+#[derive(Debug)]
+pub(in crate::execution) struct StateTransitionAwareError<'t> {
+    error: Error,
+    raw_state_transition: &'t [u8],
+    state_transition_name: Option<String>,
+}

--- a/packages/rs-drive-abci/src/execution/platform_events/state_transition_processing/process_raw_state_transitions/v0/mod.rs
+++ b/packages/rs-drive-abci/src/execution/platform_events/state_transition_processing/process_raw_state_transitions/v0/mod.rs
@@ -275,13 +275,20 @@ where
             // In this case the execution event will be to pay for the state transition processing
             // This ONLY pays for what is needed to prevent attacks on the system
 
+            // A paid-INVALID transition can still be APPLIED and credit a transparent address: the
+            // IdentityCreateFromShieldedPool duplicate-key fallback finalizes as a chargeable-failure
+            // UnshieldAction that credits the fallback address the net unshielded amount. Track those
+            // credits so they reach `address_balances_updated` for incremental sync. The executor
+            // only records into the map on the applied path, so ordinary (bump-only) paid-invalid
+            // transitions leave it empty.
+            let mut address_balances = BTreeMap::new();
             let event_execution_result = self
                 .execute_event(
                     execution_event,
                     errors,
                     block_info,
                     transaction,
-                    None, // No address balance tracking for invalid state transitions
+                    Some(&mut address_balances),
                     platform_version,
                     previous_fee_versions,
                 )
@@ -313,6 +320,7 @@ where
                     StateTransitionExecutionResult::PaidConsensusError {
                         error: first_consensus_error,
                         actual_fees,
+                        address_balance_changes: address_balances,
                     }
                 }
                 EventExecutionResult::SuccessfulFreeExecution => {
@@ -429,9 +437,13 @@ where
                     );
                 }
 
+                // Carry any address credits the applied ops recorded. For a chargeable-failure
+                // shielded spend that reaches this valid-branch UnsuccessfulPaidExecution arm, the
+                // executor already folded the credited address into `address_balances`.
                 StateTransitionExecutionResult::PaidConsensusError {
                     error: payment_consensus_error,
                     actual_fees,
+                    address_balance_changes: address_balances,
                 }
             }
             EventExecutionResult::SuccessfulFreeExecution => {
@@ -500,4 +512,118 @@ fn error_to_internal_error_execution_result(
     }
 
     StateTransitionExecutionResult::InternalError(error_with_st.error.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test::helpers::setup::TestPlatformBuilder;
+    use dpp::address_funds::PlatformAddress;
+    use dpp::balances::credits::CreditOperation;
+    use dpp::consensus::ConsensusError;
+
+    // A `PaidFromShieldedPool` with `chargeable_failure = true` carrying an output credit is the shape
+    // the IdentityCreateFromShieldedPool duplicate-key fallback produces at this seam: an APPLIED,
+    // paid-invalid transition that still credits the fallback address (the net unshielded amount).
+    // The real fallback's event shape is covered by the `unshield_populates_net_output_credit`
+    // construction test in `execution_event`; here we drive the invalid branch of
+    // `process_validation_result_v0` and assert it carries that credit out.
+    fn fallback_event<'a>(
+        output: Option<(PlatformAddress, dpp::fee::Credits)>,
+    ) -> ExecutionEvent<'a> {
+        ExecutionEvent::PaidFromShieldedPool {
+            operations: vec![],
+            fees_to_add_to_pool: 0,
+            added_to_balance_outputs: output.map(|(addr, net)| BTreeMap::from([(addr, net)])),
+            chargeable_failure: true,
+        }
+    }
+
+    /// Regression for the paid-INVALID address-credit gap: the applied chargeable-failure fallback
+    /// flows through the invalid branch of `process_validation_result_v0`, which used to pass `None`
+    /// for address tracking and silently drop the credit the block actually applied. Assert the
+    /// returned `PaidConsensusError` now carries the fallback-address credit so
+    /// `StateTransitionsProcessingResult::add` can merge it into `address_balances_updated`.
+    #[test]
+    fn invalid_branch_chargeable_failure_carries_address_credit() {
+        let platform_version = PlatformVersion::latest();
+        let platform = TestPlatformBuilder::new()
+            .build_with_mock_rpc()
+            .set_genesis_state();
+        let transaction = platform.drive.grove.start_transaction();
+        let fee_versions = CachedEpochIndexFeeVersions::new();
+
+        let fallback_address = PlatformAddress::P2pkh([0xCD; 20]);
+        let validation_result = ConsensusValidationResult::new_with_data_and_errors(
+            fallback_event(Some((fallback_address, 2500))),
+            vec![ConsensusError::DefaultError],
+        );
+
+        let result = platform
+            .platform
+            .process_validation_result_v0(
+                b"raw-st",
+                "Unshield",
+                validation_result,
+                &BlockInfo::default(),
+                &transaction,
+                platform_version,
+                &fee_versions,
+            )
+            .expect("process_validation_result_v0 should not error");
+
+        match result {
+            StateTransitionExecutionResult::PaidConsensusError {
+                address_balance_changes,
+                ..
+            } => assert_eq!(
+                address_balance_changes.get(&fallback_address),
+                Some(&CreditOperation::AddToCredits(2500)),
+                "the applied fallback credit must be carried in PaidConsensusError"
+            ),
+            other => panic!("expected PaidConsensusError, got {other:?}"),
+        }
+    }
+
+    /// An ordinary paid-invalid transition (a bump-only penalty crediting no address) must produce a
+    /// `PaidConsensusError` with an EMPTY balance-change map — the tracking added for the fallback
+    /// must not fabricate credits for the common case.
+    #[test]
+    fn invalid_branch_without_address_credit_carries_empty_map() {
+        let platform_version = PlatformVersion::latest();
+        let platform = TestPlatformBuilder::new()
+            .build_with_mock_rpc()
+            .set_genesis_state();
+        let transaction = platform.drive.grove.start_transaction();
+        let fee_versions = CachedEpochIndexFeeVersions::new();
+
+        let validation_result = ConsensusValidationResult::new_with_data_and_errors(
+            fallback_event(None),
+            vec![ConsensusError::DefaultError],
+        );
+
+        let result = platform
+            .platform
+            .process_validation_result_v0(
+                b"raw-st",
+                "Unshield",
+                validation_result,
+                &BlockInfo::default(),
+                &transaction,
+                platform_version,
+                &fee_versions,
+            )
+            .expect("process_validation_result_v0 should not error");
+
+        match result {
+            StateTransitionExecutionResult::PaidConsensusError {
+                address_balance_changes,
+                ..
+            } => assert!(
+                address_balance_changes.is_empty(),
+                "a bump-only paid-invalid transition must carry no address credit"
+            ),
+            other => panic!("expected PaidConsensusError, got {other:?}"),
+        }
+    }
 }

--- a/packages/rs-drive-abci/src/execution/platform_events/state_transition_processing/process_raw_state_transitions/v0/mod.rs
+++ b/packages/rs-drive-abci/src/execution/platform_events/state_transition_processing/process_raw_state_transitions/v0/mod.rs
@@ -4,33 +4,22 @@ use crate::platform_types::platform_state::{PlatformState, PlatformStateV0Method
 use crate::rpc::core::CoreRPCLike;
 use dpp::block::block_info::BlockInfo;
 use dpp::consensus::codes::ErrorWithCode;
-use dpp::fee::fee_result::FeeResult;
-use std::collections::BTreeMap;
 
-use crate::execution::types::execution_event::ExecutionEvent;
 use crate::execution::types::state_transition_container::v0::{
     DecodedStateTransition, InvalidStateTransition, InvalidWithProtocolErrorStateTransition,
     SuccessfullyDecodedStateTransition,
 };
 use crate::execution::validation::state_transition::processor::process_state_transition;
 use crate::metrics::{state_transition_execution_histogram, HistogramTiming};
-use crate::platform_types::event_execution_result::EventExecutionResult;
 use crate::platform_types::state_transitions_processing_result::{
     NotExecutedReason, StateTransitionExecutionResult, StateTransitionsProcessingResult,
 };
-use dpp::fee::default_costs::CachedEpochIndexFeeVersions;
 use dpp::util::hash::hash_single;
-use dpp::validation::ConsensusValidationResult;
 use dpp::version::PlatformVersion;
 use drive::grovedb::Transaction;
 use std::time::Instant;
 
-#[derive(Debug)]
-struct StateTransitionAwareError<'t> {
-    error: Error,
-    raw_state_transition: &'t [u8],
-    state_transition_name: Option<String>,
-}
+use super::super::StateTransitionAwareError;
 
 impl<C> Platform<C>
 where
@@ -127,7 +116,10 @@ where
                             Some(transaction),
                         )
                         .map(|validation_result| {
-                            self.process_validation_result_v0(
+                            // Dispatch to the versioned helper (v0 = pre-v13, v1 = records
+                            // paid-invalid balance effects). Only this helper changed at v13; the outer
+                            // loop is version-agnostic, so it must NOT be versioned.
+                            self.process_validation_result(
                                 raw_state_transition,
                                 &state_transition_name,
                                 validation_result,
@@ -218,280 +210,6 @@ where
 
         Ok(processing_result)
     }
-
-    #[allow(clippy::too_many_arguments)]
-    fn process_validation_result_v0<'a>(
-        &self,
-        raw_state_transition: &'a [u8], //used for errors
-        state_transition_name: &str,
-        mut validation_result: ConsensusValidationResult<ExecutionEvent>,
-        block_info: &BlockInfo,
-        transaction: &Transaction,
-        platform_version: &PlatformVersion,
-        previous_fee_versions: &CachedEpochIndexFeeVersions,
-    ) -> Result<StateTransitionExecutionResult, StateTransitionAwareError<'a>> {
-        // State Transition is invalid
-        if !validation_result.is_valid() {
-            // To prevent spam we should deduct fees for invalid state transitions as well.
-            // There are three cases when the user can't pay fees:
-            // 1. The state transition is funded by an asset lock transactions. This transactions are
-            //    placed on the payment blockchain and they can't be partially spent.
-            // 2. We can't prove that the state transition is associated with the identity
-            // 3. The revision given by the state transition isn't allowed based on the state
-            if validation_result.data.is_none() {
-                let first_consensus_error = validation_result
-                    .errors
-                    // the first error must be present for an invalid result
-                    .remove(0);
-
-                if tracing::enabled!(tracing::Level::DEBUG) {
-                    let st_hash = hex::encode(hash_single(raw_state_transition));
-
-                    tracing::debug!(
-                        error = ?first_consensus_error,
-                        st_hash,
-                        "Invalid {} state transition without identity ({}): {}",
-                        state_transition_name,
-                        st_hash,
-                        &first_consensus_error
-                    );
-                }
-
-                // We don't have execution event, so we can't pay for processing
-                return Ok(StateTransitionExecutionResult::UnpaidConsensusError(
-                    first_consensus_error,
-                ));
-            };
-
-            let (execution_event, errors) = validation_result
-                .into_data_and_errors()
-                .expect("data must be present since we check it few lines above");
-
-            let first_consensus_error = errors
-                .first()
-                .expect("error must be present since we check it few lines above")
-                .clone();
-
-            // In this case the execution event will be to pay for the state transition processing
-            // This ONLY pays for what is needed to prevent attacks on the system
-
-            // A paid-INVALID transition can still be APPLIED and credit a transparent address: the
-            // IdentityCreateFromShieldedPool duplicate-key fallback finalizes as a chargeable-failure
-            // UnshieldAction that credits the fallback address the net unshielded amount. Track those
-            // credits so they reach `address_balances_updated` for incremental sync. The executor
-            // only records into the map on the applied path, so ordinary (bump-only) paid-invalid
-            // transitions leave it empty.
-            let mut address_balances = BTreeMap::new();
-            let event_execution_result = self
-                .execute_event(
-                    execution_event,
-                    errors,
-                    block_info,
-                    transaction,
-                    Some(&mut address_balances),
-                    platform_version,
-                    previous_fee_versions,
-                )
-                .map_err(|error| StateTransitionAwareError {
-                    error,
-                    raw_state_transition,
-                    state_transition_name: Some(state_transition_name.to_string()),
-                })?;
-
-            let state_transition_execution_result = match event_execution_result {
-                EventExecutionResult::SuccessfulPaidExecution(estimated_fees, actual_fees)
-                | EventExecutionResult::UnsuccessfulPaidExecution(estimated_fees, actual_fees, _) =>
-                {
-                    if tracing::enabled!(tracing::Level::DEBUG) {
-                        let st_hash = hex::encode(hash_single(raw_state_transition));
-
-                        tracing::debug!(
-                            error = ?first_consensus_error,
-                            st_hash,
-                            ?estimated_fees,
-                            ?actual_fees,
-                            "Invalid {} state transition ({}): {}",
-                            state_transition_name,
-                            st_hash,
-                            &first_consensus_error
-                        );
-                    }
-
-                    StateTransitionExecutionResult::PaidConsensusError {
-                        error: first_consensus_error,
-                        actual_fees,
-                        address_balance_changes: address_balances,
-                    }
-                }
-                EventExecutionResult::SuccessfulFreeExecution => {
-                    if tracing::enabled!(tracing::Level::DEBUG) {
-                        let st_hash = hex::encode(hash_single(raw_state_transition));
-
-                        tracing::debug!(
-                            error = ?first_consensus_error,
-                            st_hash,
-                            "Free invalid {} state transition ({}): {}",
-                            state_transition_name,
-                            st_hash,
-                            &first_consensus_error
-                        );
-                    }
-
-                    StateTransitionExecutionResult::UnpaidConsensusError(first_consensus_error)
-                }
-                EventExecutionResult::UnpaidConsensusExecutionError(mut payment_errors) => {
-                    let payment_consensus_error = payment_errors
-                        // the first error must be present for an invalid result
-                        .remove(0);
-
-                    if tracing::enabled!(tracing::Level::ERROR) {
-                        let st_hash = hex::encode(hash_single(raw_state_transition));
-
-                        tracing::error!(
-                            main_error = ?first_consensus_error,
-                            payment_error = ?payment_consensus_error,
-                            st_hash,
-                            "Not able to reduce balance for identity {} state transition ({}): {}",
-                            state_transition_name,
-                            st_hash,
-                            payment_consensus_error
-                        );
-                    }
-
-                    StateTransitionExecutionResult::InternalError(format!(
-                        "{first_consensus_error} {payment_consensus_error}",
-                    ))
-                }
-            };
-
-            return Ok(state_transition_execution_result);
-        }
-
-        let (execution_event, errors) =
-            validation_result.into_data_and_errors().map_err(|error| {
-                StateTransitionAwareError {
-                    error: error.into(),
-                    raw_state_transition,
-                    state_transition_name: Some(state_transition_name.to_string()),
-                }
-            })?;
-
-        let mut address_balances = BTreeMap::new();
-        let event_execution_result = self
-            .execute_event(
-                execution_event,
-                errors,
-                block_info,
-                transaction,
-                Some(&mut address_balances),
-                platform_version,
-                previous_fee_versions,
-            )
-            .map_err(|error| StateTransitionAwareError {
-                error,
-                raw_state_transition,
-                state_transition_name: Some(state_transition_name.to_string()),
-            })?;
-
-        let state_transition_execution_result = match event_execution_result {
-            EventExecutionResult::SuccessfulPaidExecution(estimated_fees, actual_fees) => {
-                if tracing::enabled!(tracing::Level::DEBUG) {
-                    let st_hash = hex::encode(hash_single(raw_state_transition));
-
-                    tracing::debug!(
-                        ?actual_fees,
-                        ?estimated_fees,
-                        st_hash,
-                        "{} state transition ({}) successfully processed",
-                        state_transition_name,
-                        st_hash,
-                    );
-                }
-
-                StateTransitionExecutionResult::SuccessfulExecution {
-                    estimated_fees,
-                    fee_result: actual_fees,
-                    address_balance_changes: address_balances,
-                }
-            }
-            EventExecutionResult::UnsuccessfulPaidExecution(
-                estimated_fees,
-                actual_fees,
-                mut errors,
-            ) => {
-                let payment_consensus_error = errors
-                    // the first error must be present for an invalid result
-                    .remove(0);
-
-                if tracing::enabled!(tracing::Level::DEBUG) {
-                    let st_hash = hex::encode(hash_single(raw_state_transition));
-
-                    tracing::debug!(
-                        ?actual_fees,
-                        ?estimated_fees,
-                        st_hash,
-                        "{} state transition ({}) processed and mark as invalid: {}",
-                        state_transition_name,
-                        st_hash,
-                        payment_consensus_error
-                    );
-                }
-
-                // Carry any address credits the applied ops recorded. For a chargeable-failure
-                // shielded spend that reaches this valid-branch UnsuccessfulPaidExecution arm, the
-                // executor already folded the credited address into `address_balances`.
-                StateTransitionExecutionResult::PaidConsensusError {
-                    error: payment_consensus_error,
-                    actual_fees,
-                    address_balance_changes: address_balances,
-                }
-            }
-            EventExecutionResult::SuccessfulFreeExecution => {
-                if tracing::enabled!(tracing::Level::DEBUG) {
-                    let st_hash = hex::encode(hash_single(raw_state_transition));
-
-                    tracing::debug!(
-                        st_hash,
-                        "Free {} state transition ({}) successfully processed",
-                        state_transition_name,
-                        st_hash,
-                    );
-                }
-
-                StateTransitionExecutionResult::SuccessfulExecution {
-                    estimated_fees: None,
-                    fee_result: FeeResult::default(),
-                    address_balance_changes: BTreeMap::new(),
-                }
-            }
-            EventExecutionResult::UnpaidConsensusExecutionError(mut errors) => {
-                // TODO: In case of balance is not enough, we need to reduce balance only for processing fees
-                //  and return paid consensus error.
-                //  Unpaid consensus error should be only if balance not enough even
-                //  to cover processing fees
-                let first_consensus_error = errors
-                    // the first error must be present for an invalid result
-                    .remove(0);
-
-                if tracing::enabled!(tracing::Level::DEBUG) {
-                    let st_hash = hex::encode(hash_single(raw_state_transition));
-
-                    tracing::debug!(
-                        error = ?first_consensus_error,
-                        st_hash,
-                        "Insufficient identity balance to process {} state transition ({}): {}",
-                        state_transition_name,
-                        st_hash,
-                        first_consensus_error
-                    );
-                }
-
-                StateTransitionExecutionResult::UnpaidConsensusError(first_consensus_error)
-            }
-        };
-
-        Ok(state_transition_execution_result)
-    }
 }
 
 fn error_to_internal_error_execution_result(
@@ -512,118 +230,4 @@ fn error_to_internal_error_execution_result(
     }
 
     StateTransitionExecutionResult::InternalError(error_with_st.error.to_string())
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use crate::test::helpers::setup::TestPlatformBuilder;
-    use dpp::address_funds::PlatformAddress;
-    use dpp::balances::credits::CreditOperation;
-    use dpp::consensus::ConsensusError;
-
-    // A `PaidFromShieldedPool` with `chargeable_failure = true` carrying an output credit is the shape
-    // the IdentityCreateFromShieldedPool duplicate-key fallback produces at this seam: an APPLIED,
-    // paid-invalid transition that still credits the fallback address (the net unshielded amount).
-    // The real fallback's event shape is covered by the `unshield_populates_net_output_credit`
-    // construction test in `execution_event`; here we drive the invalid branch of
-    // `process_validation_result_v0` and assert it carries that credit out.
-    fn fallback_event<'a>(
-        output: Option<(PlatformAddress, dpp::fee::Credits)>,
-    ) -> ExecutionEvent<'a> {
-        ExecutionEvent::PaidFromShieldedPool {
-            operations: vec![],
-            fees_to_add_to_pool: 0,
-            added_to_balance_outputs: output.map(|(addr, net)| BTreeMap::from([(addr, net)])),
-            chargeable_failure: true,
-        }
-    }
-
-    /// Regression for the paid-INVALID address-credit gap: the applied chargeable-failure fallback
-    /// flows through the invalid branch of `process_validation_result_v0`, which used to pass `None`
-    /// for address tracking and silently drop the credit the block actually applied. Assert the
-    /// returned `PaidConsensusError` now carries the fallback-address credit so
-    /// `StateTransitionsProcessingResult::add` can merge it into `address_balances_updated`.
-    #[test]
-    fn invalid_branch_chargeable_failure_carries_address_credit() {
-        let platform_version = PlatformVersion::latest();
-        let platform = TestPlatformBuilder::new()
-            .build_with_mock_rpc()
-            .set_genesis_state();
-        let transaction = platform.drive.grove.start_transaction();
-        let fee_versions = CachedEpochIndexFeeVersions::new();
-
-        let fallback_address = PlatformAddress::P2pkh([0xCD; 20]);
-        let validation_result = ConsensusValidationResult::new_with_data_and_errors(
-            fallback_event(Some((fallback_address, 2500))),
-            vec![ConsensusError::DefaultError],
-        );
-
-        let result = platform
-            .platform
-            .process_validation_result_v0(
-                b"raw-st",
-                "Unshield",
-                validation_result,
-                &BlockInfo::default(),
-                &transaction,
-                platform_version,
-                &fee_versions,
-            )
-            .expect("process_validation_result_v0 should not error");
-
-        match result {
-            StateTransitionExecutionResult::PaidConsensusError {
-                address_balance_changes,
-                ..
-            } => assert_eq!(
-                address_balance_changes.get(&fallback_address),
-                Some(&CreditOperation::AddToCredits(2500)),
-                "the applied fallback credit must be carried in PaidConsensusError"
-            ),
-            other => panic!("expected PaidConsensusError, got {other:?}"),
-        }
-    }
-
-    /// An ordinary paid-invalid transition (a bump-only penalty crediting no address) must produce a
-    /// `PaidConsensusError` with an EMPTY balance-change map — the tracking added for the fallback
-    /// must not fabricate credits for the common case.
-    #[test]
-    fn invalid_branch_without_address_credit_carries_empty_map() {
-        let platform_version = PlatformVersion::latest();
-        let platform = TestPlatformBuilder::new()
-            .build_with_mock_rpc()
-            .set_genesis_state();
-        let transaction = platform.drive.grove.start_transaction();
-        let fee_versions = CachedEpochIndexFeeVersions::new();
-
-        let validation_result = ConsensusValidationResult::new_with_data_and_errors(
-            fallback_event(None),
-            vec![ConsensusError::DefaultError],
-        );
-
-        let result = platform
-            .platform
-            .process_validation_result_v0(
-                b"raw-st",
-                "Unshield",
-                validation_result,
-                &BlockInfo::default(),
-                &transaction,
-                platform_version,
-                &fee_versions,
-            )
-            .expect("process_validation_result_v0 should not error");
-
-        match result {
-            StateTransitionExecutionResult::PaidConsensusError {
-                address_balance_changes,
-                ..
-            } => assert!(
-                address_balance_changes.is_empty(),
-                "a bump-only paid-invalid transition must carry no address credit"
-            ),
-            other => panic!("expected PaidConsensusError, got {other:?}"),
-        }
-    }
 }

--- a/packages/rs-drive-abci/src/execution/platform_events/state_transition_processing/process_validation_result/mod.rs
+++ b/packages/rs-drive-abci/src/execution/platform_events/state_transition_processing/process_validation_result/mod.rs
@@ -1,0 +1,217 @@
+mod v0;
+mod v1;
+
+use super::StateTransitionAwareError;
+use crate::error::execution::ExecutionError;
+use crate::error::Error;
+use crate::execution::types::execution_event::ExecutionEvent;
+use crate::platform_types::platform::Platform;
+use crate::platform_types::state_transitions_processing_result::StateTransitionExecutionResult;
+use crate::rpc::core::CoreRPCLike;
+use dpp::block::block_info::BlockInfo;
+use dpp::fee::default_costs::CachedEpochIndexFeeVersions;
+use dpp::validation::ConsensusValidationResult;
+use dpp::version::PlatformVersion;
+use drive::grovedb::Transaction;
+
+impl<C> Platform<C>
+where
+    C: CoreRPCLike,
+{
+    /// Turn a validated execution event into a [`StateTransitionExecutionResult`], applying the paid
+    /// event and mapping its outcome.
+    ///
+    /// Versioned because the recent-address-balance recorded SET expanded at protocol v13: v0 records
+    /// NOTHING for paid-invalid / unsuccessful-paid transitions (byte parity with pre-v13 nodes), v1
+    /// records their balance effects. The outer `process_raw_state_transitions` loop is UNCHANGED
+    /// across the bump — only this helper's behavior is — so only this helper is versioned; the loop
+    /// calls this dispatcher exactly like `execute_event_v0` calls the dispatching
+    /// `record_added_balance_outputs`.
+    #[allow(clippy::too_many_arguments)]
+    pub(in crate::execution) fn process_validation_result<'a>(
+        &self,
+        raw_state_transition: &'a [u8],
+        state_transition_name: &str,
+        validation_result: ConsensusValidationResult<ExecutionEvent>,
+        block_info: &BlockInfo,
+        transaction: &Transaction,
+        platform_version: &PlatformVersion,
+        previous_fee_versions: &CachedEpochIndexFeeVersions,
+    ) -> Result<StateTransitionExecutionResult, StateTransitionAwareError<'a>> {
+        match platform_version
+            .drive_abci
+            .methods
+            .state_transition_processing
+            .process_validation_result
+        {
+            0 => self.process_validation_result_v0(
+                raw_state_transition,
+                state_transition_name,
+                validation_result,
+                block_info,
+                transaction,
+                platform_version,
+                previous_fee_versions,
+            ),
+            1 => self.process_validation_result_v1(
+                raw_state_transition,
+                state_transition_name,
+                validation_result,
+                block_info,
+                transaction,
+                platform_version,
+                previous_fee_versions,
+            ),
+            version => Err(StateTransitionAwareError {
+                error: Error::Execution(ExecutionError::UnknownVersionMismatch {
+                    method: "process_validation_result".to_string(),
+                    known_versions: vec![0, 1],
+                    received: version,
+                }),
+                raw_state_transition,
+                state_transition_name: Some(state_transition_name.to_string()),
+            }),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test::helpers::setup::TestPlatformBuilder;
+    use dpp::address_funds::PlatformAddress;
+    use dpp::balances::credits::CreditOperation;
+    use dpp::consensus::ConsensusError;
+    use std::collections::BTreeMap;
+
+    // A `PaidFromShieldedPool` with `chargeable_failure = true` carrying an output credit is the shape
+    // the IdentityCreateFromShieldedPool duplicate-key fallback produces at this seam: an APPLIED,
+    // paid-invalid transition that still credits the fallback address (the net unshielded amount).
+    fn fallback_event<'a>(
+        output: Option<(PlatformAddress, dpp::fee::Credits)>,
+    ) -> ExecutionEvent<'a> {
+        ExecutionEvent::PaidFromShieldedPool {
+            operations: vec![],
+            fees_to_add_to_pool: 0,
+            added_to_balance_outputs: output.map(|(addr, net)| BTreeMap::from([(addr, net)])),
+            chargeable_failure: true,
+        }
+    }
+
+    /// Drive the paid-invalid branch of the requested version (`process_validation_result_v0` when
+    /// `via_v1` is false, `_v1` otherwise) and return the `PaidConsensusError`'s recorded balance
+    /// changes. `platform_version` is threaded only for the executor's own versioned calls — neither
+    /// helper branches on it, so this exercises each version's behavior directly.
+    fn recorded_changes(
+        via_v1: bool,
+        event: ExecutionEvent<'_>,
+        platform_version: &PlatformVersion,
+    ) -> BTreeMap<PlatformAddress, CreditOperation> {
+        let platform = TestPlatformBuilder::new()
+            .build_with_mock_rpc()
+            .set_genesis_state();
+        let transaction = platform.drive.grove.start_transaction();
+        let fee_versions = CachedEpochIndexFeeVersions::new();
+
+        let validation_result = ConsensusValidationResult::new_with_data_and_errors(
+            event,
+            vec![ConsensusError::DefaultError],
+        );
+
+        let result = if via_v1 {
+            platform.platform.process_validation_result_v1(
+                b"raw-st",
+                "Unshield",
+                validation_result,
+                &BlockInfo::default(),
+                &transaction,
+                platform_version,
+                &fee_versions,
+            )
+        } else {
+            platform.platform.process_validation_result_v0(
+                b"raw-st",
+                "Unshield",
+                validation_result,
+                &BlockInfo::default(),
+                &transaction,
+                platform_version,
+                &fee_versions,
+            )
+        }
+        .expect("process_validation_result should not error");
+
+        match result {
+            StateTransitionExecutionResult::PaidConsensusError {
+                address_balance_changes,
+                ..
+            } => address_balance_changes,
+            other => panic!("expected PaidConsensusError, got {other:?}"),
+        }
+    }
+
+    /// v0 = pre-v13 behavior (state-root parity with old nodes): an applied chargeable-failure credit
+    /// is DROPPED, because v0 hands the executor no tracking map. This holds regardless of the
+    /// `platform_version` passed in — v0 has no version conditional; the gating is the
+    /// `process_validation_result` dispatch that routes v13 to v1 (see the v1 tests and the
+    /// platform-version routing test).
+    #[test]
+    fn v0_records_nothing_even_with_credit() {
+        let fallback_address = PlatformAddress::P2pkh([0xCD; 20]);
+
+        for platform_version in [
+            PlatformVersion::get(12).expect("v12 must exist"),
+            PlatformVersion::get(13).expect("v13 must exist"),
+        ] {
+            let with_credit = recorded_changes(
+                false,
+                fallback_event(Some((fallback_address, 2500))),
+                platform_version,
+            );
+            assert!(
+                with_credit.is_empty(),
+                "v0 must NOT record paid-invalid balance effects (byte parity with pre-v13 nodes)"
+            );
+
+            let without_credit = recorded_changes(false, fallback_event(None), platform_version);
+            assert!(
+                without_credit.is_empty(),
+                "a bump-only paid-invalid transition records nothing"
+            );
+        }
+    }
+
+    /// v1 carries an applied paid-invalid credit into `PaidConsensusError` so
+    /// `StateTransitionsProcessingResult::add` can merge it into `address_balances_updated` — the v13
+    /// recorded-set expansion. The version boundary (v12 -> v0 drops, v13 -> v1 records) is covered by
+    /// the platform-version routing test plus `v0_records_nothing_even_with_credit`.
+    #[test]
+    fn v1_records_paid_invalid_credit() {
+        let fallback_address = PlatformAddress::P2pkh([0xCD; 20]);
+        let changes = recorded_changes(
+            true,
+            fallback_event(Some((fallback_address, 2500))),
+            PlatformVersion::get(13).expect("v13 must exist"),
+        );
+        assert_eq!(
+            changes.get(&fallback_address),
+            Some(&CreditOperation::AddToCredits(2500)),
+            "v1 must carry the applied fallback credit into PaidConsensusError"
+        );
+    }
+
+    /// A paid-invalid transition that credits no address records nothing even in v1 — the expansion
+    /// must not fabricate credits for the common bump-only case.
+    #[test]
+    fn v1_without_address_credit_carries_empty_map() {
+        let changes = recorded_changes(
+            true,
+            fallback_event(None),
+            PlatformVersion::get(13).expect("v13 must exist"),
+        );
+        assert!(
+            changes.is_empty(),
+            "a bump-only paid-invalid transition must carry no address credit"
+        );
+    }
+}

--- a/packages/rs-drive-abci/src/execution/platform_events/state_transition_processing/process_validation_result/v0/mod.rs
+++ b/packages/rs-drive-abci/src/execution/platform_events/state_transition_processing/process_validation_result/v0/mod.rs
@@ -1,0 +1,302 @@
+use super::super::StateTransitionAwareError;
+use crate::execution::types::execution_event::ExecutionEvent;
+use crate::platform_types::event_execution_result::EventExecutionResult;
+use crate::platform_types::platform::Platform;
+use crate::platform_types::state_transitions_processing_result::StateTransitionExecutionResult;
+use crate::rpc::core::CoreRPCLike;
+use dpp::block::block_info::BlockInfo;
+use dpp::fee::default_costs::CachedEpochIndexFeeVersions;
+use dpp::fee::fee_result::FeeResult;
+use dpp::util::hash::hash_single;
+use dpp::validation::ConsensusValidationResult;
+use dpp::version::PlatformVersion;
+use drive::grovedb::Transaction;
+use std::collections::BTreeMap;
+
+impl<C> Platform<C>
+where
+    C: CoreRPCLike,
+{
+    /// v0 = pre-v13 behavior for turning a validated execution event into a
+    /// [`StateTransitionExecutionResult`]. Paid-INVALID and unsuccessful-paid transitions contribute
+    /// NOTHING to the recent-address-balance tree: the invalid branch passes `None` for tracking, and
+    /// both `PaidConsensusError` constructions carry an empty map. This byte-matches old nodes (whose
+    /// `PaidConsensusError` had no balance-changes field at all). There is no version conditional
+    /// here; the v13 recorded-set expansion lives in `process_validation_result_v1`, selected by the
+    /// `process_validation_result` method version.
+    #[allow(clippy::too_many_arguments)]
+    pub(super) fn process_validation_result_v0<'a>(
+        &self,
+        raw_state_transition: &'a [u8], //used for errors
+        state_transition_name: &str,
+        mut validation_result: ConsensusValidationResult<ExecutionEvent>,
+        block_info: &BlockInfo,
+        transaction: &Transaction,
+        platform_version: &PlatformVersion,
+        previous_fee_versions: &CachedEpochIndexFeeVersions,
+    ) -> Result<StateTransitionExecutionResult, StateTransitionAwareError<'a>> {
+        // State Transition is invalid
+        if !validation_result.is_valid() {
+            // To prevent spam we should deduct fees for invalid state transitions as well.
+            // There are three cases when the user can't pay fees:
+            // 1. The state transition is funded by an asset lock transactions. This transactions are
+            //    placed on the payment blockchain and they can't be partially spent.
+            // 2. We can't prove that the state transition is associated with the identity
+            // 3. The revision given by the state transition isn't allowed based on the state
+            if validation_result.data.is_none() {
+                let first_consensus_error = validation_result
+                    .errors
+                    // the first error must be present for an invalid result
+                    .remove(0);
+
+                if tracing::enabled!(tracing::Level::DEBUG) {
+                    let st_hash = hex::encode(hash_single(raw_state_transition));
+
+                    tracing::debug!(
+                        error = ?first_consensus_error,
+                        st_hash,
+                        "Invalid {} state transition without identity ({}): {}",
+                        state_transition_name,
+                        st_hash,
+                        &first_consensus_error
+                    );
+                }
+
+                // We don't have execution event, so we can't pay for processing
+                return Ok(StateTransitionExecutionResult::UnpaidConsensusError(
+                    first_consensus_error,
+                ));
+            };
+
+            let (execution_event, errors) = validation_result
+                .into_data_and_errors()
+                .expect("data must be present since we check it few lines above");
+
+            let first_consensus_error = errors
+                .first()
+                .expect("error must be present since we check it few lines above")
+                .clone();
+
+            // In this case the execution event will be to pay for the state transition processing
+            // This ONLY pays for what is needed to prevent attacks on the system
+
+            // v0 = pre-v13 behavior: paid-INVALID transitions are NOT tracked. Old nodes passed
+            // `None` here, so no paid-invalid balance effect ever reached `address_balances_updated`.
+            // The v13 recorded-set expansion (which DOES track them) lives in this method's v1,
+            // selected by the `process_validation_result` method version — keeping v0 byte-identical
+            // to the old build with no version conditional of its own.
+            let event_execution_result = self
+                .execute_event(
+                    execution_event,
+                    errors,
+                    block_info,
+                    transaction,
+                    None, // No address balance tracking for invalid state transitions
+                    platform_version,
+                    previous_fee_versions,
+                )
+                .map_err(|error| StateTransitionAwareError {
+                    error,
+                    raw_state_transition,
+                    state_transition_name: Some(state_transition_name.to_string()),
+                })?;
+
+            let state_transition_execution_result = match event_execution_result {
+                EventExecutionResult::SuccessfulPaidExecution(estimated_fees, actual_fees)
+                | EventExecutionResult::UnsuccessfulPaidExecution(estimated_fees, actual_fees, _) =>
+                {
+                    if tracing::enabled!(tracing::Level::DEBUG) {
+                        let st_hash = hex::encode(hash_single(raw_state_transition));
+
+                        tracing::debug!(
+                            error = ?first_consensus_error,
+                            st_hash,
+                            ?estimated_fees,
+                            ?actual_fees,
+                            "Invalid {} state transition ({}): {}",
+                            state_transition_name,
+                            st_hash,
+                            &first_consensus_error
+                        );
+                    }
+
+                    StateTransitionExecutionResult::PaidConsensusError {
+                        error: first_consensus_error,
+                        actual_fees,
+                        // v0 carries an empty map: paid-invalid effects are unrecorded pre-v13 (the
+                        // struct field is new, but old code had none). v1 records them.
+                        address_balance_changes: BTreeMap::new(),
+                    }
+                }
+                EventExecutionResult::SuccessfulFreeExecution => {
+                    if tracing::enabled!(tracing::Level::DEBUG) {
+                        let st_hash = hex::encode(hash_single(raw_state_transition));
+
+                        tracing::debug!(
+                            error = ?first_consensus_error,
+                            st_hash,
+                            "Free invalid {} state transition ({}): {}",
+                            state_transition_name,
+                            st_hash,
+                            &first_consensus_error
+                        );
+                    }
+
+                    StateTransitionExecutionResult::UnpaidConsensusError(first_consensus_error)
+                }
+                EventExecutionResult::UnpaidConsensusExecutionError(mut payment_errors) => {
+                    let payment_consensus_error = payment_errors
+                        // the first error must be present for an invalid result
+                        .remove(0);
+
+                    if tracing::enabled!(tracing::Level::ERROR) {
+                        let st_hash = hex::encode(hash_single(raw_state_transition));
+
+                        tracing::error!(
+                            main_error = ?first_consensus_error,
+                            payment_error = ?payment_consensus_error,
+                            st_hash,
+                            "Not able to reduce balance for identity {} state transition ({}): {}",
+                            state_transition_name,
+                            st_hash,
+                            payment_consensus_error
+                        );
+                    }
+
+                    StateTransitionExecutionResult::InternalError(format!(
+                        "{first_consensus_error} {payment_consensus_error}",
+                    ))
+                }
+            };
+
+            return Ok(state_transition_execution_result);
+        }
+
+        let (execution_event, errors) =
+            validation_result.into_data_and_errors().map_err(|error| {
+                StateTransitionAwareError {
+                    error: error.into(),
+                    raw_state_transition,
+                    state_transition_name: Some(state_transition_name.to_string()),
+                }
+            })?;
+
+        let mut address_balances = BTreeMap::new();
+        let event_execution_result = self
+            .execute_event(
+                execution_event,
+                errors,
+                block_info,
+                transaction,
+                Some(&mut address_balances),
+                platform_version,
+                previous_fee_versions,
+            )
+            .map_err(|error| StateTransitionAwareError {
+                error,
+                raw_state_transition,
+                state_transition_name: Some(state_transition_name.to_string()),
+            })?;
+
+        let state_transition_execution_result = match event_execution_result {
+            EventExecutionResult::SuccessfulPaidExecution(estimated_fees, actual_fees) => {
+                if tracing::enabled!(tracing::Level::DEBUG) {
+                    let st_hash = hex::encode(hash_single(raw_state_transition));
+
+                    tracing::debug!(
+                        ?actual_fees,
+                        ?estimated_fees,
+                        st_hash,
+                        "{} state transition ({}) successfully processed",
+                        state_transition_name,
+                        st_hash,
+                    );
+                }
+
+                StateTransitionExecutionResult::SuccessfulExecution {
+                    estimated_fees,
+                    fee_result: actual_fees,
+                    address_balance_changes: address_balances,
+                }
+            }
+            EventExecutionResult::UnsuccessfulPaidExecution(
+                estimated_fees,
+                actual_fees,
+                mut errors,
+            ) => {
+                let payment_consensus_error = errors
+                    // the first error must be present for an invalid result
+                    .remove(0);
+
+                if tracing::enabled!(tracing::Level::DEBUG) {
+                    let st_hash = hex::encode(hash_single(raw_state_transition));
+
+                    tracing::debug!(
+                        ?actual_fees,
+                        ?estimated_fees,
+                        st_hash,
+                        "{} state transition ({}) processed and mark as invalid: {}",
+                        state_transition_name,
+                        st_hash,
+                        payment_consensus_error
+                    );
+                }
+
+                // v0 = pre-v13 behavior: the tracked map is DROPPED here (old `PaidConsensusError`
+                // had no such field), so an unsuccessful-paid transition contributes nothing to the
+                // recent-address-balance tree. v1 carries it. The success arm's `SuccessfulExecution`
+                // recording is the pre-existing behavior gated by
+                // `store_address_balances_to_recent_block_storage`, so it is left untouched.
+                StateTransitionExecutionResult::PaidConsensusError {
+                    error: payment_consensus_error,
+                    actual_fees,
+                    address_balance_changes: BTreeMap::new(),
+                }
+            }
+            EventExecutionResult::SuccessfulFreeExecution => {
+                if tracing::enabled!(tracing::Level::DEBUG) {
+                    let st_hash = hex::encode(hash_single(raw_state_transition));
+
+                    tracing::debug!(
+                        st_hash,
+                        "Free {} state transition ({}) successfully processed",
+                        state_transition_name,
+                        st_hash,
+                    );
+                }
+
+                StateTransitionExecutionResult::SuccessfulExecution {
+                    estimated_fees: None,
+                    fee_result: FeeResult::default(),
+                    address_balance_changes: BTreeMap::new(),
+                }
+            }
+            EventExecutionResult::UnpaidConsensusExecutionError(mut errors) => {
+                // TODO: In case of balance is not enough, we need to reduce balance only for processing fees
+                //  and return paid consensus error.
+                //  Unpaid consensus error should be only if balance not enough even
+                //  to cover processing fees
+                let first_consensus_error = errors
+                    // the first error must be present for an invalid result
+                    .remove(0);
+
+                if tracing::enabled!(tracing::Level::DEBUG) {
+                    let st_hash = hex::encode(hash_single(raw_state_transition));
+
+                    tracing::debug!(
+                        error = ?first_consensus_error,
+                        st_hash,
+                        "Insufficient identity balance to process {} state transition ({}): {}",
+                        state_transition_name,
+                        st_hash,
+                        first_consensus_error
+                    );
+                }
+
+                StateTransitionExecutionResult::UnpaidConsensusError(first_consensus_error)
+            }
+        };
+
+        Ok(state_transition_execution_result)
+    }
+}

--- a/packages/rs-drive-abci/src/execution/platform_events/state_transition_processing/process_validation_result/v1/mod.rs
+++ b/packages/rs-drive-abci/src/execution/platform_events/state_transition_processing/process_validation_result/v1/mod.rs
@@ -1,0 +1,301 @@
+use super::super::StateTransitionAwareError;
+use crate::execution::types::execution_event::ExecutionEvent;
+use crate::platform_types::event_execution_result::EventExecutionResult;
+use crate::platform_types::platform::Platform;
+use crate::platform_types::state_transitions_processing_result::StateTransitionExecutionResult;
+use crate::rpc::core::CoreRPCLike;
+use dpp::block::block_info::BlockInfo;
+use dpp::fee::default_costs::CachedEpochIndexFeeVersions;
+use dpp::fee::fee_result::FeeResult;
+use dpp::util::hash::hash_single;
+use dpp::validation::ConsensusValidationResult;
+use dpp::version::PlatformVersion;
+use drive::grovedb::Transaction;
+use std::collections::BTreeMap;
+
+impl<C> Platform<C>
+where
+    C: CoreRPCLike,
+{
+    /// v1 (protocol v13+) = the recorded-set expansion for turning a validated execution event into a
+    /// [`StateTransitionExecutionResult`]. It additionally records the balance effects of paid-INVALID
+    /// and unsuccessful-paid transitions that v0 drops: the invalid branch hands the executor a
+    /// tracking map, and both `PaidConsensusError` constructions carry it. Identical to
+    /// `process_validation_result_v0` apart from this tracking/carry; the `process_validation_result`
+    /// method version selects which runs, so there is no version conditional inside either.
+    #[allow(clippy::too_many_arguments)]
+    pub(super) fn process_validation_result_v1<'a>(
+        &self,
+        raw_state_transition: &'a [u8], //used for errors
+        state_transition_name: &str,
+        mut validation_result: ConsensusValidationResult<ExecutionEvent>,
+        block_info: &BlockInfo,
+        transaction: &Transaction,
+        platform_version: &PlatformVersion,
+        previous_fee_versions: &CachedEpochIndexFeeVersions,
+    ) -> Result<StateTransitionExecutionResult, StateTransitionAwareError<'a>> {
+        // State Transition is invalid
+        if !validation_result.is_valid() {
+            // To prevent spam we should deduct fees for invalid state transitions as well.
+            // There are three cases when the user can't pay fees:
+            // 1. The state transition is funded by an asset lock transactions. This transactions are
+            //    placed on the payment blockchain and they can't be partially spent.
+            // 2. We can't prove that the state transition is associated with the identity
+            // 3. The revision given by the state transition isn't allowed based on the state
+            if validation_result.data.is_none() {
+                let first_consensus_error = validation_result
+                    .errors
+                    // the first error must be present for an invalid result
+                    .remove(0);
+
+                if tracing::enabled!(tracing::Level::DEBUG) {
+                    let st_hash = hex::encode(hash_single(raw_state_transition));
+
+                    tracing::debug!(
+                        error = ?first_consensus_error,
+                        st_hash,
+                        "Invalid {} state transition without identity ({}): {}",
+                        state_transition_name,
+                        st_hash,
+                        &first_consensus_error
+                    );
+                }
+
+                // We don't have execution event, so we can't pay for processing
+                return Ok(StateTransitionExecutionResult::UnpaidConsensusError(
+                    first_consensus_error,
+                ));
+            };
+
+            let (execution_event, errors) = validation_result
+                .into_data_and_errors()
+                .expect("data must be present since we check it few lines above");
+
+            let first_consensus_error = errors
+                .first()
+                .expect("error must be present since we check it few lines above")
+                .clone();
+
+            // In this case the execution event will be to pay for the state transition processing
+            // This ONLY pays for what is needed to prevent attacks on the system
+
+            // v1 = the v13 recorded-set expansion: an applied paid-INVALID transition's transparent
+            // balance effects (a chargeable-failure fallback credit, or a PaidFromAddressInputs inline
+            // adjustment) ARE tracked and reach `address_balances_updated` for incremental sync. v0
+            // passes `None` here and drops them (pre-v13 state parity); the `process_validation_result`
+            // method version selects which runs.
+            let mut address_balances = BTreeMap::new();
+            let event_execution_result = self
+                .execute_event(
+                    execution_event,
+                    errors,
+                    block_info,
+                    transaction,
+                    Some(&mut address_balances),
+                    platform_version,
+                    previous_fee_versions,
+                )
+                .map_err(|error| StateTransitionAwareError {
+                    error,
+                    raw_state_transition,
+                    state_transition_name: Some(state_transition_name.to_string()),
+                })?;
+
+            let state_transition_execution_result = match event_execution_result {
+                EventExecutionResult::SuccessfulPaidExecution(estimated_fees, actual_fees)
+                | EventExecutionResult::UnsuccessfulPaidExecution(estimated_fees, actual_fees, _) =>
+                {
+                    if tracing::enabled!(tracing::Level::DEBUG) {
+                        let st_hash = hex::encode(hash_single(raw_state_transition));
+
+                        tracing::debug!(
+                            error = ?first_consensus_error,
+                            st_hash,
+                            ?estimated_fees,
+                            ?actual_fees,
+                            "Invalid {} state transition ({}): {}",
+                            state_transition_name,
+                            st_hash,
+                            &first_consensus_error
+                        );
+                    }
+
+                    StateTransitionExecutionResult::PaidConsensusError {
+                        error: first_consensus_error,
+                        actual_fees,
+                        // v1 carries the tracked map: applied paid-invalid credits reach the recent
+                        // tree from v13 (v0 carries an empty map).
+                        address_balance_changes: address_balances,
+                    }
+                }
+                EventExecutionResult::SuccessfulFreeExecution => {
+                    if tracing::enabled!(tracing::Level::DEBUG) {
+                        let st_hash = hex::encode(hash_single(raw_state_transition));
+
+                        tracing::debug!(
+                            error = ?first_consensus_error,
+                            st_hash,
+                            "Free invalid {} state transition ({}): {}",
+                            state_transition_name,
+                            st_hash,
+                            &first_consensus_error
+                        );
+                    }
+
+                    StateTransitionExecutionResult::UnpaidConsensusError(first_consensus_error)
+                }
+                EventExecutionResult::UnpaidConsensusExecutionError(mut payment_errors) => {
+                    let payment_consensus_error = payment_errors
+                        // the first error must be present for an invalid result
+                        .remove(0);
+
+                    if tracing::enabled!(tracing::Level::ERROR) {
+                        let st_hash = hex::encode(hash_single(raw_state_transition));
+
+                        tracing::error!(
+                            main_error = ?first_consensus_error,
+                            payment_error = ?payment_consensus_error,
+                            st_hash,
+                            "Not able to reduce balance for identity {} state transition ({}): {}",
+                            state_transition_name,
+                            st_hash,
+                            payment_consensus_error
+                        );
+                    }
+
+                    StateTransitionExecutionResult::InternalError(format!(
+                        "{first_consensus_error} {payment_consensus_error}",
+                    ))
+                }
+            };
+
+            return Ok(state_transition_execution_result);
+        }
+
+        let (execution_event, errors) =
+            validation_result.into_data_and_errors().map_err(|error| {
+                StateTransitionAwareError {
+                    error: error.into(),
+                    raw_state_transition,
+                    state_transition_name: Some(state_transition_name.to_string()),
+                }
+            })?;
+
+        let mut address_balances = BTreeMap::new();
+        let event_execution_result = self
+            .execute_event(
+                execution_event,
+                errors,
+                block_info,
+                transaction,
+                Some(&mut address_balances),
+                platform_version,
+                previous_fee_versions,
+            )
+            .map_err(|error| StateTransitionAwareError {
+                error,
+                raw_state_transition,
+                state_transition_name: Some(state_transition_name.to_string()),
+            })?;
+
+        let state_transition_execution_result = match event_execution_result {
+            EventExecutionResult::SuccessfulPaidExecution(estimated_fees, actual_fees) => {
+                if tracing::enabled!(tracing::Level::DEBUG) {
+                    let st_hash = hex::encode(hash_single(raw_state_transition));
+
+                    tracing::debug!(
+                        ?actual_fees,
+                        ?estimated_fees,
+                        st_hash,
+                        "{} state transition ({}) successfully processed",
+                        state_transition_name,
+                        st_hash,
+                    );
+                }
+
+                StateTransitionExecutionResult::SuccessfulExecution {
+                    estimated_fees,
+                    fee_result: actual_fees,
+                    address_balance_changes: address_balances,
+                }
+            }
+            EventExecutionResult::UnsuccessfulPaidExecution(
+                estimated_fees,
+                actual_fees,
+                mut errors,
+            ) => {
+                let payment_consensus_error = errors
+                    // the first error must be present for an invalid result
+                    .remove(0);
+
+                if tracing::enabled!(tracing::Level::DEBUG) {
+                    let st_hash = hex::encode(hash_single(raw_state_transition));
+
+                    tracing::debug!(
+                        ?actual_fees,
+                        ?estimated_fees,
+                        st_hash,
+                        "{} state transition ({}) processed and mark as invalid: {}",
+                        state_transition_name,
+                        st_hash,
+                        payment_consensus_error
+                    );
+                }
+
+                // v1 carries the tracked balance effects (charged fees, adjusted outputs) into the
+                // result — the v13 recorded-set expansion. v0 discards them (pre-v13 parity). The
+                // success arm's `SuccessfulExecution` recording is the pre-existing behavior gated by
+                // `store_address_balances_to_recent_block_storage`, so it is left untouched.
+                StateTransitionExecutionResult::PaidConsensusError {
+                    error: payment_consensus_error,
+                    actual_fees,
+                    address_balance_changes: address_balances,
+                }
+            }
+            EventExecutionResult::SuccessfulFreeExecution => {
+                if tracing::enabled!(tracing::Level::DEBUG) {
+                    let st_hash = hex::encode(hash_single(raw_state_transition));
+
+                    tracing::debug!(
+                        st_hash,
+                        "Free {} state transition ({}) successfully processed",
+                        state_transition_name,
+                        st_hash,
+                    );
+                }
+
+                StateTransitionExecutionResult::SuccessfulExecution {
+                    estimated_fees: None,
+                    fee_result: FeeResult::default(),
+                    address_balance_changes: BTreeMap::new(),
+                }
+            }
+            EventExecutionResult::UnpaidConsensusExecutionError(mut errors) => {
+                // TODO: In case of balance is not enough, we need to reduce balance only for processing fees
+                //  and return paid consensus error.
+                //  Unpaid consensus error should be only if balance not enough even
+                //  to cover processing fees
+                let first_consensus_error = errors
+                    // the first error must be present for an invalid result
+                    .remove(0);
+
+                if tracing::enabled!(tracing::Level::DEBUG) {
+                    let st_hash = hex::encode(hash_single(raw_state_transition));
+
+                    tracing::debug!(
+                        error = ?first_consensus_error,
+                        st_hash,
+                        "Insufficient identity balance to process {} state transition ({}): {}",
+                        state_transition_name,
+                        st_hash,
+                        first_consensus_error
+                    );
+                }
+
+                StateTransitionExecutionResult::UnpaidConsensusError(first_consensus_error)
+            }
+        };
+
+        Ok(state_transition_execution_result)
+    }
+}

--- a/packages/rs-drive-abci/src/execution/platform_events/state_transition_processing/record_added_balance_outputs/mod.rs
+++ b/packages/rs-drive-abci/src/execution/platform_events/state_transition_processing/record_added_balance_outputs/mod.rs
@@ -1,0 +1,196 @@
+mod v0;
+mod v1;
+
+use crate::error::execution::ExecutionError;
+use crate::error::Error;
+use crate::platform_types::platform::Platform;
+use crate::rpc::core::CoreRPCLike;
+use dpp::address_funds::PlatformAddress;
+use dpp::balances::credits::CreditOperation;
+use dpp::fee::Credits;
+use dpp::version::PlatformVersion;
+use std::collections::BTreeMap;
+
+/// Which event family produced the `added_to_balance_outputs` being recorded. The recorded SET of
+/// transparent-address credits changed at protocol v13, and this discriminator is what the versioned
+/// `record_added_balance_outputs` method filters on.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(in crate::execution) enum AddedBalanceOutputsOrigin {
+    /// Long-standing transparent credits (e.g. `IdentityCreditTransferToAddresses`). Recorded in
+    /// every version.
+    Transparent,
+    /// Shielded-spend transparent credits: the `Unshield` net output, the `ShieldFromAssetLock`
+    /// surplus, and the `IdentityCreateFromShieldedPool` duplicate-key fallback. Recorded only from
+    /// v1 (protocol v13); dropped by v0 so pre-v13 blocks byte-match.
+    ShieldedSpend,
+}
+
+impl<C> Platform<C>
+where
+    C: CoreRPCLike,
+{
+    /// Fold the transparent-address credits an applied event produced into the per-block
+    /// address-balance update map that feeds the recent-address-balance-changes tree.
+    ///
+    /// Versioned because the recorded SET changed at protocol v13: v0 records only
+    /// `Transparent`-origin credits (the historical behavior), v1 additionally records
+    /// `ShieldedSpend`-origin credits. Events always carry their outputs regardless of version — the
+    /// version decides only whether shielded-origin outputs are folded — and construction and the
+    /// downstream storage stay unconditional.
+    ///
+    /// This fold is NOT the only part of the v13 recorded-set expansion: `process_raw_state_transitions`
+    /// has its own v0/v1 (a SIBLING versioned method) where v1 additionally records the balance
+    /// effects of paid-invalid / unsuccessful-paid transitions that v0 drops. That method reads its
+    /// OWN version field (`process_raw_state_transitions`), not this one — but both bump to v1
+    /// together in the v13 method set, so the expansion activates atomically. Neither site carries a
+    /// version conditional inside a _v0 function; the version is chosen by dispatch.
+    pub(in crate::execution) fn record_added_balance_outputs(
+        &self,
+        address_balances_in_update: Option<&mut BTreeMap<PlatformAddress, CreditOperation>>,
+        added_to_balance_outputs: Option<BTreeMap<PlatformAddress, Credits>>,
+        origin: AddedBalanceOutputsOrigin,
+        platform_version: &PlatformVersion,
+    ) -> Result<(), Error> {
+        match platform_version
+            .drive_abci
+            .methods
+            .state_transition_processing
+            .record_added_balance_outputs
+        {
+            0 => self.record_added_balance_outputs_v0(
+                address_balances_in_update,
+                added_to_balance_outputs,
+                origin,
+            ),
+            1 => self.record_added_balance_outputs_v1(
+                address_balances_in_update,
+                added_to_balance_outputs,
+                origin,
+            ),
+            version => Err(Error::Execution(ExecutionError::UnknownVersionMismatch {
+                method: "record_added_balance_outputs".to_string(),
+                known_versions: vec![0, 1],
+                received: version,
+            })),
+        }
+    }
+}
+
+/// Merge `added_to_balance_outputs` into `address_balances_in_update` (when both are present) with
+/// the standard Set+Add merge semantics: Set + Add = Set(sum), Add + Add = Add(sum), both saturating.
+/// Shared by v0 and v1 — the only difference between the two versions is the origin filter in the
+/// caller, never the merge itself.
+fn fold_added_balance_outputs(
+    address_balances_in_update: Option<&mut BTreeMap<PlatformAddress, CreditOperation>>,
+    added_to_balance_outputs: Option<BTreeMap<PlatformAddress, Credits>>,
+) {
+    let (Some(balance_updates), Some(outputs)) =
+        (address_balances_in_update, added_to_balance_outputs)
+    else {
+        return;
+    };
+    for (address, credits) in outputs {
+        balance_updates
+            .entry(address)
+            .and_modify(|existing| {
+                *existing = match existing {
+                    // Set + Add = Set to combined value
+                    CreditOperation::SetCredits(set_val) => {
+                        CreditOperation::SetCredits(set_val.saturating_add(credits))
+                    }
+                    // Add + Add = saturating add
+                    CreditOperation::AddToCredits(add_val) => {
+                        CreditOperation::AddToCredits(add_val.saturating_add(credits))
+                    }
+                };
+            })
+            .or_insert(CreditOperation::AddToCredits(credits));
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test::helpers::setup::TestPlatformBuilder;
+
+    /// v0 (protocol < v13): `Transparent`-origin credits are folded (historical behavior);
+    /// `ShieldedSpend`-origin credits are dropped even though the event carried them.
+    #[test]
+    fn v0_folds_transparent_and_drops_shielded_spend() {
+        let platform = TestPlatformBuilder::new().build_with_mock_rpc();
+        let v12 = PlatformVersion::get(12).expect("v12 must exist");
+
+        let transparent = PlatformAddress::P2pkh([0xA1; 20]);
+        let shielded = PlatformAddress::P2pkh([0xB2; 20]);
+
+        // Transparent-origin: recorded by v0.
+        let mut map: BTreeMap<PlatformAddress, CreditOperation> = BTreeMap::new();
+        platform
+            .record_added_balance_outputs(
+                Some(&mut map),
+                Some(BTreeMap::from([(transparent, 100)])),
+                AddedBalanceOutputsOrigin::Transparent,
+                v12,
+            )
+            .expect("record must not error");
+        assert_eq!(
+            map.get(&transparent),
+            Some(&CreditOperation::AddToCredits(100)),
+            "v0 must record transparent-origin credits"
+        );
+
+        // ShieldedSpend-origin: dropped by v0.
+        let mut map2: BTreeMap<PlatformAddress, CreditOperation> = BTreeMap::new();
+        platform
+            .record_added_balance_outputs(
+                Some(&mut map2),
+                Some(BTreeMap::from([(shielded, 200)])),
+                AddedBalanceOutputsOrigin::ShieldedSpend,
+                v12,
+            )
+            .expect("record must not error");
+        assert!(
+            map2.is_empty(),
+            "v0 must DROP shielded-spend-origin credits (pre-v13 byte-match)"
+        );
+    }
+
+    /// v1 (protocol v13+): both origins are folded.
+    #[test]
+    fn v1_records_both_origins() {
+        let platform = TestPlatformBuilder::new().build_with_mock_rpc();
+        let v13 = PlatformVersion::get(13).expect("v13 must exist");
+
+        let transparent = PlatformAddress::P2pkh([0xA1; 20]);
+        let shielded = PlatformAddress::P2pkh([0xB2; 20]);
+
+        let mut map: BTreeMap<PlatformAddress, CreditOperation> = BTreeMap::new();
+        platform
+            .record_added_balance_outputs(
+                Some(&mut map),
+                Some(BTreeMap::from([(transparent, 100)])),
+                AddedBalanceOutputsOrigin::Transparent,
+                v13,
+            )
+            .expect("record must not error");
+        platform
+            .record_added_balance_outputs(
+                Some(&mut map),
+                Some(BTreeMap::from([(shielded, 200)])),
+                AddedBalanceOutputsOrigin::ShieldedSpend,
+                v13,
+            )
+            .expect("record must not error");
+
+        assert_eq!(
+            map.get(&transparent),
+            Some(&CreditOperation::AddToCredits(100)),
+            "v1 must record transparent-origin credits"
+        );
+        assert_eq!(
+            map.get(&shielded),
+            Some(&CreditOperation::AddToCredits(200)),
+            "v1 must record shielded-spend-origin credits"
+        );
+    }
+}

--- a/packages/rs-drive-abci/src/execution/platform_events/state_transition_processing/record_added_balance_outputs/v0/mod.rs
+++ b/packages/rs-drive-abci/src/execution/platform_events/state_transition_processing/record_added_balance_outputs/v0/mod.rs
@@ -1,0 +1,33 @@
+use super::{fold_added_balance_outputs, AddedBalanceOutputsOrigin};
+use crate::error::Error;
+use crate::platform_types::platform::Platform;
+use crate::rpc::core::CoreRPCLike;
+use dpp::address_funds::PlatformAddress;
+use dpp::balances::credits::CreditOperation;
+use dpp::fee::Credits;
+use std::collections::BTreeMap;
+
+impl<C> Platform<C>
+where
+    C: CoreRPCLike,
+{
+    /// v0: the HISTORICAL recorded set. Only `Transparent`-origin credits are folded (the `Paid`
+    /// arm's long-standing `IdentityCreditTransferToAddresses` recording). `ShieldedSpend`-origin
+    /// credits are DROPPED — the events carry them unconditionally now, but recording them would
+    /// change the committed state root, so pre-v13 blocks byte-match by discarding them here.
+    pub(super) fn record_added_balance_outputs_v0(
+        &self,
+        address_balances_in_update: Option<&mut BTreeMap<PlatformAddress, CreditOperation>>,
+        added_to_balance_outputs: Option<BTreeMap<PlatformAddress, Credits>>,
+        origin: AddedBalanceOutputsOrigin,
+    ) -> Result<(), Error> {
+        match origin {
+            AddedBalanceOutputsOrigin::Transparent => {
+                fold_added_balance_outputs(address_balances_in_update, added_to_balance_outputs);
+            }
+            // Dropped in v0: shielded-spend credits are not recorded before protocol v13.
+            AddedBalanceOutputsOrigin::ShieldedSpend => {}
+        }
+        Ok(())
+    }
+}

--- a/packages/rs-drive-abci/src/execution/platform_events/state_transition_processing/record_added_balance_outputs/v1/mod.rs
+++ b/packages/rs-drive-abci/src/execution/platform_events/state_transition_processing/record_added_balance_outputs/v1/mod.rs
@@ -1,0 +1,28 @@
+use super::{fold_added_balance_outputs, AddedBalanceOutputsOrigin};
+use crate::error::Error;
+use crate::platform_types::platform::Platform;
+use crate::rpc::core::CoreRPCLike;
+use dpp::address_funds::PlatformAddress;
+use dpp::balances::credits::CreditOperation;
+use dpp::fee::Credits;
+use std::collections::BTreeMap;
+
+impl<C> Platform<C>
+where
+    C: CoreRPCLike,
+{
+    /// v1 (protocol v13+): records BOTH origins. In addition to the historical `Transparent`-origin
+    /// credits, this folds `ShieldedSpend`-origin credits (the `Unshield` net output, the
+    /// `ShieldFromAssetLock` surplus, and the `IdentityCreateFromShieldedPool` fallback) so
+    /// incremental client sync observes shielded-spend payouts. The merge semantics are identical to
+    /// v0; only the origin filter differs (there is none here), so `origin` is unused.
+    pub(super) fn record_added_balance_outputs_v1(
+        &self,
+        address_balances_in_update: Option<&mut BTreeMap<PlatformAddress, CreditOperation>>,
+        added_to_balance_outputs: Option<BTreeMap<PlatformAddress, Credits>>,
+        _origin: AddedBalanceOutputsOrigin,
+    ) -> Result<(), Error> {
+        fold_added_balance_outputs(address_balances_in_update, added_to_balance_outputs);
+        Ok(())
+    }
+}

--- a/packages/rs-drive-abci/src/execution/platform_events/state_transition_processing/validate_fees_of_event/v0/mod.rs
+++ b/packages/rs-drive-abci/src/execution/platform_events/state_transition_processing/validate_fees_of_event/v0/mod.rs
@@ -235,6 +235,7 @@ where
                 fees_to_add_to_pool,
                 operations,
                 execution_operations,
+                ..
             } => {
                 let mut estimated_fee_result = self
                     .drive
@@ -474,6 +475,7 @@ mod tests {
             ExecutionEvent::PaidFromShieldedPool {
                 operations: vec![],
                 fees_to_add_to_pool: 0,
+                added_to_balance_outputs: None,
                 chargeable_failure: false,
             },
             ExecutionEvent::Free { operations: vec![] },
@@ -530,6 +532,7 @@ mod tests {
         let fees_to_add_to_pool = 1_000_000u64;
         let event = ExecutionEvent::PaidFromAssetLockToPool {
             fees_to_add_to_pool,
+            added_to_balance_outputs: None,
             operations: vec![],
             execution_operations: vec![],
         };

--- a/packages/rs-drive-abci/src/execution/types/execution_event/mod.rs
+++ b/packages/rs-drive-abci/src/execution/types/execution_event/mod.rs
@@ -94,11 +94,12 @@ pub(in crate::execution) enum ExecutionEvent<'a> {
         fees_to_add_to_pool: Credits,
         /// Transparent platform-address credits produced by this shielded spend, to be folded into
         /// the recent-address-balance-changes tree (`store_address_balances_for_block`) so
-        /// incremental client sync sees them. `Some` only for `Unshield`, which credits its output
-        /// address the NET amount (`amount - fee`) and only when that net is positive — mirroring the
-        /// `AddBalanceToAddress` op the converter emits. `None` for every other shielded spend
-        /// (ShieldedTransfer / ShieldedWithdrawal / IdentityCreateFromShieldedPool): they credit no
-        /// transparent address, so there is nothing for incremental sync to observe.
+        /// incremental client sync sees them. `Some` only for an `UnshieldAction` whose NET amount
+        /// (`amount - fee`) is positive — mirroring the `AddBalanceToAddress` op the converter
+        /// emits — which includes the `IdentityCreateFromShieldedPool` duplicate-key fallback,
+        /// since that fallback surfaces as an `UnshieldAction` crediting the fallback address.
+        /// `None` for ShieldedTransfer and ShieldedWithdrawal: they credit no transparent
+        /// address, so there is nothing for incremental sync to observe.
         added_to_balance_outputs: Option<BTreeMap<PlatformAddress, Credits>>,
         /// `true` ONLY for the `IdentityCreateFromShieldedPool` chargeable-failure fallback. It
         /// authorizes the executor to apply `operations` even when consensus errors are attached
@@ -614,10 +615,9 @@ impl ExecutionEvent<'_> {
                 // here so it is recorded in the recent-address-balance-changes tree for incremental
                 // sync. When there is no surplus output the surplus folds into the fee pools instead,
                 // crediting no address, so this stays `None`.
-                let added_to_balance_outputs = match shield_from_asset_lock_action.surplus_output() {
-                    Some(surplus_address)
-                        if shield_from_asset_lock_action.surplus_amount() > 0 =>
-                    {
+                let added_to_balance_outputs = match shield_from_asset_lock_action.surplus_output()
+                {
+                    Some(surplus_address) if shield_from_asset_lock_action.surplus_amount() > 0 => {
                         Some(BTreeMap::from([(
                             *surplus_address,
                             shield_from_asset_lock_action.surplus_amount(),

--- a/packages/rs-drive-abci/src/execution/types/execution_event/mod.rs
+++ b/packages/rs-drive-abci/src/execution/types/execution_event/mod.rs
@@ -805,6 +805,50 @@ mod tests {
         }
     }
 
+    /// The IdentityCreateFromShieldedPool duplicate-key fallback surfaces as a `chargeable_failure`
+    /// `UnshieldAction` that still credits the fallback address the net amount. The event must carry
+    /// that credit AND set `chargeable_failure`, so the executor records it on the applied path even
+    /// though the transition is paid-invalid. (The `chargeable_failure` flag is independent of the
+    /// output-credit computation — this pins the exact shape the paid-invalid seam relies on.)
+    #[test]
+    fn unshield_chargeable_failure_still_populates_net_output_credit() {
+        let output_address = PlatformAddress::P2pkh([0xCD; 20]);
+        let action = StateTransitionAction::UnshieldAction(UnshieldTransitionAction::V0(
+            UnshieldTransitionActionV0 {
+                output_address,
+                amount: 3000,
+                notes: vec![note()],
+                anchor: [0xAA; 32],
+                fee_amount: 500,
+                current_total_balance: 10_000,
+                chargeable_failure: true,
+            },
+        ));
+
+        let event = ExecutionEvent::create_from_state_transition_action(
+            action,
+            None,
+            &Epoch::new(0).unwrap(),
+            ctx(),
+            PlatformVersion::latest(),
+        )
+        .expect("create event");
+
+        match event {
+            ExecutionEvent::PaidFromShieldedPool {
+                added_to_balance_outputs,
+                chargeable_failure,
+                ..
+            } => {
+                assert!(chargeable_failure, "the fallback must be chargeable");
+                let outputs = added_to_balance_outputs
+                    .expect("fallback must carry the fallback-address credit");
+                assert_eq!(outputs.get(&output_address).copied(), Some(2500));
+            }
+            _ => panic!("expected PaidFromShieldedPool"),
+        }
+    }
+
     /// A `ShieldFromAssetLock` routing a surplus to a `surplus_output` address must carry that credit
     /// in `PaidFromAssetLockToPool::added_to_balance_outputs`.
     #[test]

--- a/packages/rs-drive-abci/src/execution/types/execution_event/mod.rs
+++ b/packages/rs-drive-abci/src/execution/types/execution_event/mod.rs
@@ -92,6 +92,14 @@ pub(in crate::execution) enum ExecutionEvent<'a> {
         operations: Vec<DriveOperation<'a>>,
         /// fees derived from value_balance to add to the fee pool
         fees_to_add_to_pool: Credits,
+        /// Transparent platform-address credits produced by this shielded spend, to be folded into
+        /// the recent-address-balance-changes tree (`store_address_balances_for_block`) so
+        /// incremental client sync sees them. `Some` only for `Unshield`, which credits its output
+        /// address the NET amount (`amount - fee`) and only when that net is positive — mirroring the
+        /// `AddBalanceToAddress` op the converter emits. `None` for every other shielded spend
+        /// (ShieldedTransfer / ShieldedWithdrawal / IdentityCreateFromShieldedPool): they credit no
+        /// transparent address, so there is nothing for incremental sync to observe.
+        added_to_balance_outputs: Option<BTreeMap<PlatformAddress, Credits>>,
         /// `true` ONLY for the `IdentityCreateFromShieldedPool` chargeable-failure fallback. It
         /// authorizes the executor to apply `operations` even when consensus errors are attached
         /// (the spend is finalized to the fallback address minus the penalty). For every ordinary
@@ -124,6 +132,12 @@ pub(in crate::execution) enum ExecutionEvent<'a> {
     PaidFromAssetLockToPool {
         /// Fee (asset_lock_value - shield_amount) to add to the fee pool
         fees_to_add_to_pool: Credits,
+        /// Transparent platform-address credit produced by this shield, to be folded into the
+        /// recent-address-balance-changes tree (`store_address_balances_for_block`) so incremental
+        /// client sync sees it. `Some` only when `ShieldFromAssetLock` routes an asset-lock surplus
+        /// to a `surplus_output` address (mirroring the converter's `AddBalanceToAddress` op); `None`
+        /// when there is no surplus output (the surplus folds into the fee pools instead).
+        added_to_balance_outputs: Option<BTreeMap<PlatformAddress, Credits>>,
         /// the operations that should be performed
         operations: Vec<DriveOperation<'a>>,
         /// the execution operations that we must also pay for
@@ -544,6 +558,8 @@ impl ExecutionEvent<'_> {
                 Ok(ExecutionEvent::PaidFromShieldedPool {
                     operations,
                     fees_to_add_to_pool: fee_amount,
+                    // A shielded-to-shielded transfer credits no transparent address.
+                    added_to_balance_outputs: None,
                     chargeable_failure: false,
                 })
             }
@@ -552,11 +568,25 @@ impl ExecutionEvent<'_> {
                 // An ordinary Unshield is always `false`; only the IdentityCreateFromShieldedPool
                 // duplicate-key fallback (which also surfaces as an UnshieldAction) sets it `true`.
                 let chargeable_failure = unshield_action.chargeable_failure();
+                // The converter credits the output address the NET amount (`amount - fee`) via an
+                // `AddBalanceToAddress` op, and only when that net is positive (see
+                // `unshield_transition.rs`). Thread the identical value here so the credit is also
+                // recorded in the recent-address-balance-changes tree for incremental sync.
+                // `checked_sub` returning `None` on underflow yields no output here — the converter
+                // call below then errors on the same underflow, so no event is constructed.
+                let added_to_balance_outputs = unshield_action
+                    .amount()
+                    .checked_sub(fee_amount)
+                    .filter(|net_recipient_amount| *net_recipient_amount > 0)
+                    .map(|net_recipient_amount| {
+                        BTreeMap::from([(*unshield_action.output_address(), net_recipient_amount)])
+                    });
                 let operations =
                     action.into_high_level_drive_operations(epoch, platform_version)?;
                 Ok(ExecutionEvent::PaidFromShieldedPool {
                     operations,
                     fees_to_add_to_pool: fee_amount,
+                    added_to_balance_outputs,
                     chargeable_failure,
                 })
             }
@@ -578,10 +608,28 @@ impl ExecutionEvent<'_> {
                             "shield amount + surplus exceeds asset lock value to be consumed in ShieldFromAssetLock fee computation",
                         ),
                     ))?;
+                // The converter routes `surplus_amount` to the `surplus_output` platform address via
+                // an `AddBalanceToAddress` op, but only when the output is set AND the surplus is
+                // positive (see `shield_from_asset_lock_transition.rs`). Thread the identical credit
+                // here so it is recorded in the recent-address-balance-changes tree for incremental
+                // sync. When there is no surplus output the surplus folds into the fee pools instead,
+                // crediting no address, so this stays `None`.
+                let added_to_balance_outputs = match shield_from_asset_lock_action.surplus_output() {
+                    Some(surplus_address)
+                        if shield_from_asset_lock_action.surplus_amount() > 0 =>
+                    {
+                        Some(BTreeMap::from([(
+                            *surplus_address,
+                            shield_from_asset_lock_action.surplus_amount(),
+                        )]))
+                    }
+                    _ => None,
+                };
                 let operations =
                     action.into_high_level_drive_operations(epoch, platform_version)?;
                 Ok(ExecutionEvent::PaidFromAssetLockToPool {
                     fees_to_add_to_pool: fee_amount,
+                    added_to_balance_outputs,
                     operations,
                     execution_operations: execution_context.operations_consume(),
                 })
@@ -593,6 +641,9 @@ impl ExecutionEvent<'_> {
                 Ok(ExecutionEvent::PaidFromShieldedPool {
                     operations,
                     fees_to_add_to_pool: fee_amount,
+                    // A shielded withdrawal leaves Platform for a Core-chain output; it credits no
+                    // transparent platform address, so there is nothing to record here.
+                    added_to_balance_outputs: None,
                     chargeable_failure: false,
                 })
             }
@@ -647,6 +698,188 @@ impl ExecutionEvent<'_> {
                     )))
                 }
             }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use dpp::version::DefaultForPlatformVersion;
+    use drive::state_transition_action::shielded::shield_from_asset_lock::v0::ShieldFromAssetLockTransitionActionV0;
+    use drive::state_transition_action::shielded::shield_from_asset_lock::ShieldFromAssetLockTransitionAction;
+    use drive::state_transition_action::shielded::unshield::v0::UnshieldTransitionActionV0;
+    use drive::state_transition_action::shielded::unshield::UnshieldTransitionAction;
+    use drive::state_transition_action::shielded::ShieldedActionNote;
+
+    fn note() -> ShieldedActionNote {
+        ShieldedActionNote {
+            nullifier: [0x11; 32],
+            cmx: [0x22; 32],
+            cv_net: [0x33; 32],
+            encrypted_note: vec![1, 2, 3],
+        }
+    }
+
+    fn ctx() -> StateTransitionExecutionContext {
+        StateTransitionExecutionContext::default_for_platform_version(PlatformVersion::latest())
+            .expect("execution context")
+    }
+
+    /// An `Unshield` crediting its output address a positive NET (`amount - fee`) must carry that
+    /// credit in `PaidFromShieldedPool::added_to_balance_outputs`, so the executor can record it in
+    /// the recent-address-balance-changes tree that incremental client sync reads.
+    #[test]
+    fn unshield_populates_net_output_credit() {
+        let output_address = PlatformAddress::P2pkh([0xBB; 20]);
+        let action = StateTransitionAction::UnshieldAction(UnshieldTransitionAction::V0(
+            UnshieldTransitionActionV0 {
+                output_address,
+                amount: 3000,
+                notes: vec![note()],
+                anchor: [0xAA; 32],
+                fee_amount: 500,
+                current_total_balance: 10_000,
+                chargeable_failure: false,
+            },
+        ));
+
+        let event = ExecutionEvent::create_from_state_transition_action(
+            action,
+            None,
+            &Epoch::new(0).unwrap(),
+            ctx(),
+            PlatformVersion::latest(),
+        )
+        .expect("create event");
+
+        match event {
+            ExecutionEvent::PaidFromShieldedPool {
+                added_to_balance_outputs,
+                ..
+            } => {
+                let outputs =
+                    added_to_balance_outputs.expect("net > 0 must carry an output credit");
+                assert_eq!(outputs.len(), 1);
+                // 3000 amount - 500 fee = 2500 net to the output address.
+                assert_eq!(outputs.get(&output_address).copied(), Some(2500));
+            }
+            _ => panic!("expected PaidFromShieldedPool"),
+        }
+    }
+
+    /// A net-zero `Unshield` (the whole unshielding amount consumed by the fee) credits no address —
+    /// the converter emits no `AddBalanceToAddress`, so the event must carry no output either.
+    #[test]
+    fn unshield_net_zero_records_no_output_credit() {
+        let action = StateTransitionAction::UnshieldAction(UnshieldTransitionAction::V0(
+            UnshieldTransitionActionV0 {
+                output_address: PlatformAddress::P2pkh([0xBB; 20]),
+                amount: 500,
+                notes: vec![note()],
+                anchor: [0xAA; 32],
+                fee_amount: 500, // net = 0
+                current_total_balance: 10_000,
+                chargeable_failure: false,
+            },
+        ));
+
+        let event = ExecutionEvent::create_from_state_transition_action(
+            action,
+            None,
+            &Epoch::new(0).unwrap(),
+            ctx(),
+            PlatformVersion::latest(),
+        )
+        .expect("create event");
+
+        match event {
+            ExecutionEvent::PaidFromShieldedPool {
+                added_to_balance_outputs,
+                ..
+            } => assert!(
+                added_to_balance_outputs.is_none(),
+                "net-zero unshield must credit no address"
+            ),
+            _ => panic!("expected PaidFromShieldedPool"),
+        }
+    }
+
+    /// A `ShieldFromAssetLock` routing a surplus to a `surplus_output` address must carry that credit
+    /// in `PaidFromAssetLockToPool::added_to_balance_outputs`.
+    #[test]
+    fn shield_from_asset_lock_populates_surplus_credit() {
+        let surplus_address = PlatformAddress::P2pkh([0x42; 20]);
+        let action = StateTransitionAction::ShieldFromAssetLockAction(
+            ShieldFromAssetLockTransitionAction::V0(ShieldFromAssetLockTransitionActionV0 {
+                asset_lock_outpoint: [0xDD; 36],
+                asset_lock_value_to_be_consumed: 10_000,
+                signable_bytes_hasher: [0xEE; 32],
+                shield_amount: 5_000,
+                notes: vec![note()],
+                current_total_balance: 10_000,
+                surplus_output: Some(surplus_address),
+                surplus_amount: 2_000,
+            }),
+        );
+
+        let event = ExecutionEvent::create_from_state_transition_action(
+            action,
+            None,
+            &Epoch::new(0).unwrap(),
+            ctx(),
+            PlatformVersion::latest(),
+        )
+        .expect("create event");
+
+        match event {
+            ExecutionEvent::PaidFromAssetLockToPool {
+                added_to_balance_outputs,
+                fees_to_add_to_pool,
+                ..
+            } => {
+                let outputs =
+                    added_to_balance_outputs.expect("surplus must carry an output credit");
+                assert_eq!(outputs.get(&surplus_address).copied(), Some(2_000));
+                // fee = consumed - shield - surplus = 10000 - 5000 - 2000.
+                assert_eq!(fees_to_add_to_pool, 3_000);
+            }
+            _ => panic!("expected PaidFromAssetLockToPool"),
+        }
+    }
+
+    /// A `ShieldFromAssetLock` with no `surplus_output` credits no address (the surplus folds into
+    /// the fee pools), so the event must carry no output.
+    #[test]
+    fn shield_from_asset_lock_without_surplus_output_records_nothing() {
+        let action = StateTransitionAction::ShieldFromAssetLockAction(
+            ShieldFromAssetLockTransitionAction::V0(ShieldFromAssetLockTransitionActionV0 {
+                asset_lock_outpoint: [0xDD; 36],
+                asset_lock_value_to_be_consumed: 10_000,
+                signable_bytes_hasher: [0xEE; 32],
+                shield_amount: 5_000,
+                notes: vec![note()],
+                current_total_balance: 10_000,
+                surplus_output: None,
+                surplus_amount: 0,
+            }),
+        );
+
+        let event = ExecutionEvent::create_from_state_transition_action(
+            action,
+            None,
+            &Epoch::new(0).unwrap(),
+            ctx(),
+            PlatformVersion::latest(),
+        )
+        .expect("create event");
+
+        match event {
+            ExecutionEvent::PaidFromAssetLockToPool {
+                added_to_balance_outputs,
+                ..
+            } => assert!(added_to_balance_outputs.is_none()),
+            _ => panic!("expected PaidFromAssetLockToPool"),
         }
     }
 }

--- a/packages/rs-drive-abci/src/execution/types/execution_event/mod.rs
+++ b/packages/rs-drive-abci/src/execution/types/execution_event/mod.rs
@@ -571,10 +571,16 @@ impl ExecutionEvent<'_> {
                 let chargeable_failure = unshield_action.chargeable_failure();
                 // The converter credits the output address the NET amount (`amount - fee`) via an
                 // `AddBalanceToAddress` op, and only when that net is positive (see
-                // `unshield_transition.rs`). Thread the identical value here so the credit is also
+                // `unshield_transition.rs`). Thread the identical value here so the credit can be
                 // recorded in the recent-address-balance-changes tree for incremental sync.
                 // `checked_sub` returning `None` on underflow yields no output here — the converter
                 // call below then errors on the same underflow, so no event is constructed.
+                //
+                // This is populated UNCONDITIONALLY (the event is in-memory only). The rolling-upgrade
+                // versioning lives entirely in the executor's `record_added_balance_outputs` method:
+                // its v0 (protocol < v13) DROPS these shielded-spend-origin outputs, so pre-v13 blocks
+                // byte-match the earlier behavior; its v1 (v13+) records them. Keeping construction
+                // version-independent means there is exactly one versioned site.
                 let added_to_balance_outputs = unshield_action
                     .amount()
                     .checked_sub(fee_amount)
@@ -612,9 +618,14 @@ impl ExecutionEvent<'_> {
                 // The converter routes `surplus_amount` to the `surplus_output` platform address via
                 // an `AddBalanceToAddress` op, but only when the output is set AND the surplus is
                 // positive (see `shield_from_asset_lock_transition.rs`). Thread the identical credit
-                // here so it is recorded in the recent-address-balance-changes tree for incremental
-                // sync. When there is no surplus output the surplus folds into the fee pools instead,
-                // crediting no address, so this stays `None`.
+                // here so it can be recorded in the recent-address-balance-changes tree for
+                // incremental sync. When there is no surplus output the surplus folds into the fee
+                // pools instead, crediting no address, so this stays `None`.
+                //
+                // Populated UNCONDITIONALLY, like the `UnshieldAction` arm above: the rolling-upgrade
+                // versioning lives in the executor's `record_added_balance_outputs` method (v0 drops
+                // these shielded-spend-origin outputs, v1 records them), so construction stays
+                // version-independent and there is exactly one versioned site.
                 let added_to_balance_outputs = match shield_from_asset_lock_action.surplus_output()
                 {
                     Some(surplus_address) if shield_from_asset_lock_action.surplus_amount() > 0 => {
@@ -924,6 +935,99 @@ mod tests {
                 ..
             } => assert!(added_to_balance_outputs.is_none()),
             _ => panic!("expected PaidFromAssetLockToPool"),
+        }
+    }
+
+    /// Construction is now VERSION-INDEPENDENT: an `Unshield` with a positive net always carries the
+    /// output credit in the event, at BOTH v12 and v13. The rolling-upgrade gate moved to the
+    /// executor's `record_added_balance_outputs` (v0 drops shielded-spend outputs, v1 records them),
+    /// so the event carries the credit either way — only whether it is recorded differs.
+    #[test]
+    fn unshield_credit_populated_at_construction_regardless_of_version() {
+        let output_address = PlatformAddress::P2pkh([0xBB; 20]);
+        let make_action = || {
+            StateTransitionAction::UnshieldAction(UnshieldTransitionAction::V0(
+                UnshieldTransitionActionV0 {
+                    output_address,
+                    amount: 3000,
+                    notes: vec![note()],
+                    anchor: [0xAA; 32],
+                    fee_amount: 500,
+                    current_total_balance: 10_000,
+                    chargeable_failure: false,
+                },
+            ))
+        };
+
+        for platform_version in [
+            PlatformVersion::get(12).expect("v12 must exist"),
+            PlatformVersion::get(13).expect("v13 must exist"),
+        ] {
+            let event = ExecutionEvent::create_from_state_transition_action(
+                make_action(),
+                None,
+                &Epoch::new(0).unwrap(),
+                ctx(),
+                platform_version,
+            )
+            .expect("create event");
+            match event {
+                ExecutionEvent::PaidFromShieldedPool {
+                    added_to_balance_outputs,
+                    ..
+                } => {
+                    let outputs = added_to_balance_outputs
+                        .expect("construction always carries the unshield credit (net > 0)");
+                    assert_eq!(outputs.get(&output_address).copied(), Some(2500));
+                }
+                _ => panic!("expected PaidFromShieldedPool"),
+            }
+        }
+    }
+
+    /// Construction is version-independent for the `ShieldFromAssetLock` surplus too: the surplus
+    /// credit is carried in the event at BOTH v12 and v13 (the recording gate lives in the executor).
+    #[test]
+    fn shield_surplus_populated_at_construction_regardless_of_version() {
+        let surplus_address = PlatformAddress::P2pkh([0x42; 20]);
+        let make_action = || {
+            StateTransitionAction::ShieldFromAssetLockAction(
+                ShieldFromAssetLockTransitionAction::V0(ShieldFromAssetLockTransitionActionV0 {
+                    asset_lock_outpoint: [0xDD; 36],
+                    asset_lock_value_to_be_consumed: 10_000,
+                    signable_bytes_hasher: [0xEE; 32],
+                    shield_amount: 5_000,
+                    notes: vec![note()],
+                    current_total_balance: 10_000,
+                    surplus_output: Some(surplus_address),
+                    surplus_amount: 2_000,
+                }),
+            )
+        };
+
+        for platform_version in [
+            PlatformVersion::get(12).expect("v12 must exist"),
+            PlatformVersion::get(13).expect("v13 must exist"),
+        ] {
+            let event = ExecutionEvent::create_from_state_transition_action(
+                make_action(),
+                None,
+                &Epoch::new(0).unwrap(),
+                ctx(),
+                platform_version,
+            )
+            .expect("create event");
+            match event {
+                ExecutionEvent::PaidFromAssetLockToPool {
+                    added_to_balance_outputs,
+                    ..
+                } => {
+                    let outputs = added_to_balance_outputs
+                        .expect("construction always carries the shield surplus credit");
+                    assert_eq!(outputs.get(&surplus_address).copied(), Some(2_000));
+                }
+                _ => panic!("expected PaidFromAssetLockToPool"),
+            }
         }
     }
 }

--- a/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/batch/tests/document/creation.rs
+++ b/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/batch/tests/document/creation.rs
@@ -492,7 +492,8 @@ mod creation_tests {
                     processing_fee: 526140,
                     fee_refunds: FeeRefunds::default(),
                     removed_bytes_from_system: 0
-                }
+                },
+                address_balance_changes: std::collections::BTreeMap::new()
             }
         );
 

--- a/packages/rs-drive-abci/src/platform_types/state_transitions_processing_result/mod.rs
+++ b/packages/rs-drive-abci/src/platform_types/state_transitions_processing_result/mod.rs
@@ -25,6 +25,14 @@ pub enum StateTransitionExecutionResult {
         error: ConsensusError,
         /// Actual fees charged
         actual_fees: FeeResult,
+        /// Address balance changes applied by this paid-INVALID transition. Non-empty only for an
+        /// APPLIED chargeable-failure transition that still credits a transparent address — e.g. the
+        /// `IdentityCreateFromShieldedPool` duplicate-key fallback, which finalizes as an
+        /// `UnshieldAction` (paid-invalid) yet credits the fallback address the net unshielded
+        /// amount. These must reach `address_balances_updated` so incremental sync sees the GroveDB
+        /// credit the block actually applied. Empty for ordinary paid-invalid transitions (bump-only
+        /// penalties that credit no address).
+        address_balance_changes: BTreeMap<PlatformAddress, CreditOperation>,
     },
     /// State Transition is invalid, and is not paid for because we either :
     ///     * don't have a proved identity associated with it so we can't deduct balance.
@@ -107,9 +115,19 @@ impl StateTransitionsProcessingResult {
             StateTransitionExecutionResult::InternalError(_) => {
                 self.failed_count += 1;
             }
-            StateTransitionExecutionResult::PaidConsensusError { actual_fees, .. } => {
+            StateTransitionExecutionResult::PaidConsensusError {
+                actual_fees,
+                address_balance_changes,
+                ..
+            } => {
                 self.invalid_paid_count += 1;
                 self.fees.checked_add_assign(actual_fees.clone())?;
+
+                // An applied chargeable-failure transition (e.g. the identity-create-from-shielded-
+                // pool fallback) can credit a transparent address even though it is paid-invalid;
+                // merge those credits so incremental sync sees them. Ordinary paid-invalid
+                // transitions carry an empty map, so this is a no-op for them.
+                self.add_address_balances_in_update(address_balance_changes.clone());
             }
             StateTransitionExecutionResult::UnpaidConsensusError(_) => {
                 self.invalid_unpaid_count += 1;
@@ -169,5 +187,56 @@ impl StateTransitionsProcessingResult {
     /// State Transition execution results
     pub fn execution_results(&self) -> &Vec<StateTransitionExecutionResult> {
         &self.execution_results
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A `PaidConsensusError` carrying address credits (the applied chargeable-failure fallback,
+    /// e.g. IdentityCreateFromShieldedPool's duplicate-key path) must merge those credits into
+    /// `address_balances_updated`, exactly like `SuccessfulExecution` — otherwise a credit the block
+    /// applied never reaches the recent-address-balance-changes tree that incremental sync reads.
+    #[test]
+    fn add_merges_paid_consensus_error_address_changes() {
+        let mut result = StateTransitionsProcessingResult::default();
+        let address = PlatformAddress::P2pkh([0xCD; 20]);
+
+        result
+            .add(StateTransitionExecutionResult::PaidConsensusError {
+                error: ConsensusError::DefaultError,
+                actual_fees: FeeResult::default(),
+                address_balance_changes: BTreeMap::from([(
+                    address,
+                    CreditOperation::AddToCredits(2500),
+                )]),
+            })
+            .expect("add should succeed");
+
+        assert_eq!(result.invalid_paid_count(), 1);
+        assert_eq!(
+            result.address_balances_updated.get(&address),
+            Some(&CreditOperation::AddToCredits(2500)),
+            "PaidConsensusError credits must reach address_balances_updated"
+        );
+    }
+
+    /// An ordinary `PaidConsensusError` (bump-only penalty, no credit) must leave
+    /// `address_balances_updated` empty.
+    #[test]
+    fn add_paid_consensus_error_without_changes_leaves_balances_empty() {
+        let mut result = StateTransitionsProcessingResult::default();
+
+        result
+            .add(StateTransitionExecutionResult::PaidConsensusError {
+                error: ConsensusError::DefaultError,
+                actual_fees: FeeResult::default(),
+                address_balance_changes: BTreeMap::new(),
+            })
+            .expect("add should succeed");
+
+        assert_eq!(result.invalid_paid_count(), 1);
+        assert!(result.address_balances_updated.is_empty());
     }
 }

--- a/packages/rs-platform-version/src/version/drive_abci_versions/drive_abci_method_versions/mod.rs
+++ b/packages/rs-platform-version/src/version/drive_abci_versions/drive_abci_method_versions/mod.rs
@@ -8,6 +8,7 @@ pub mod v5;
 pub mod v6;
 pub mod v7;
 pub mod v8;
+pub mod v9;
 
 #[derive(Clone, Debug, Default)]
 pub struct DriveAbciMethodVersions {
@@ -176,8 +177,23 @@ pub struct DriveAbciProtocolUpgradeMethodVersions {
 pub struct DriveAbciStateTransitionProcessingMethodVersions {
     pub execute_event: FeatureVersion,
     pub process_raw_state_transitions: FeatureVersion,
+    /// Version of `process_validation_result`, the helper that turns a validated execution event into
+    /// a `StateTransitionExecutionResult`. v0 records nothing for paid-invalid / unsuccessful-paid
+    /// transitions (pre-v13 parity); v1 records their balance effects (charged fees, adjusted outputs,
+    /// applied chargeable-failure credits) into the per-block address-balance updates. The outer
+    /// `process_raw_state_transitions` loop is unchanged across the bump, so only this helper is
+    /// versioned.
+    pub process_validation_result: FeatureVersion,
     pub decode_raw_state_transitions: FeatureVersion,
     pub validate_fees_of_event: FeatureVersion,
     pub store_address_balances_to_recent_block_storage: OptionalFeatureVersion,
     pub cleanup_recent_block_storage_address_balances: OptionalFeatureVersion,
+    /// Version of `record_added_balance_outputs`, the method that folds an applied event's
+    /// transparent-address credits into the per-block address-balance updates. v0 records only the
+    /// long-standing transparent credits (e.g. `IdentityCreditTransferToAddresses`); v1 additionally
+    /// records shielded-spend transparent credits (Unshield net output, ShieldFromAssetLock surplus,
+    /// IdentityCreateFromShieldedPool fallback). The storage method
+    /// (`store_address_balances_to_recent_block_storage`) is unchanged across the bump — only the
+    /// recorded set differs.
+    pub record_added_balance_outputs: FeatureVersion,
 }

--- a/packages/rs-platform-version/src/version/drive_abci_versions/drive_abci_method_versions/v1.rs
+++ b/packages/rs-platform-version/src/version/drive_abci_versions/drive_abci_method_versions/v1.rs
@@ -103,10 +103,12 @@ pub const DRIVE_ABCI_METHOD_VERSIONS_V1: DriveAbciMethodVersions = DriveAbciMeth
     state_transition_processing: DriveAbciStateTransitionProcessingMethodVersions {
         execute_event: 0,
         process_raw_state_transitions: 0,
+        process_validation_result: 0,
         decode_raw_state_transitions: 0,
         validate_fees_of_event: 0,
         store_address_balances_to_recent_block_storage: None,
         cleanup_recent_block_storage_address_balances: None,
+        record_added_balance_outputs: 0,
     },
     epoch: DriveAbciEpochMethodVersions {
         gather_epoch_info: 0,

--- a/packages/rs-platform-version/src/version/drive_abci_versions/drive_abci_method_versions/v2.rs
+++ b/packages/rs-platform-version/src/version/drive_abci_versions/drive_abci_method_versions/v2.rs
@@ -104,10 +104,12 @@ pub const DRIVE_ABCI_METHOD_VERSIONS_V2: DriveAbciMethodVersions = DriveAbciMeth
     state_transition_processing: DriveAbciStateTransitionProcessingMethodVersions {
         execute_event: 0,
         process_raw_state_transitions: 0,
+        process_validation_result: 0,
         decode_raw_state_transitions: 0,
         validate_fees_of_event: 0,
         store_address_balances_to_recent_block_storage: None,
         cleanup_recent_block_storage_address_balances: None,
+        record_added_balance_outputs: 0,
     },
     epoch: DriveAbciEpochMethodVersions {
         gather_epoch_info: 0,

--- a/packages/rs-platform-version/src/version/drive_abci_versions/drive_abci_method_versions/v3.rs
+++ b/packages/rs-platform-version/src/version/drive_abci_versions/drive_abci_method_versions/v3.rs
@@ -103,10 +103,12 @@ pub const DRIVE_ABCI_METHOD_VERSIONS_V3: DriveAbciMethodVersions = DriveAbciMeth
     state_transition_processing: DriveAbciStateTransitionProcessingMethodVersions {
         execute_event: 0,
         process_raw_state_transitions: 0,
+        process_validation_result: 0,
         decode_raw_state_transitions: 0,
         validate_fees_of_event: 0,
         store_address_balances_to_recent_block_storage: None,
         cleanup_recent_block_storage_address_balances: None,
+        record_added_balance_outputs: 0,
     },
     epoch: DriveAbciEpochMethodVersions {
         gather_epoch_info: 0,

--- a/packages/rs-platform-version/src/version/drive_abci_versions/drive_abci_method_versions/v4.rs
+++ b/packages/rs-platform-version/src/version/drive_abci_versions/drive_abci_method_versions/v4.rs
@@ -103,10 +103,12 @@ pub const DRIVE_ABCI_METHOD_VERSIONS_V4: DriveAbciMethodVersions = DriveAbciMeth
     state_transition_processing: DriveAbciStateTransitionProcessingMethodVersions {
         execute_event: 0,
         process_raw_state_transitions: 0,
+        process_validation_result: 0,
         decode_raw_state_transitions: 0,
         validate_fees_of_event: 0,
         store_address_balances_to_recent_block_storage: None,
         cleanup_recent_block_storage_address_balances: None,
+        record_added_balance_outputs: 0,
     },
     epoch: DriveAbciEpochMethodVersions {
         gather_epoch_info: 0,

--- a/packages/rs-platform-version/src/version/drive_abci_versions/drive_abci_method_versions/v5.rs
+++ b/packages/rs-platform-version/src/version/drive_abci_versions/drive_abci_method_versions/v5.rs
@@ -107,10 +107,12 @@ pub const DRIVE_ABCI_METHOD_VERSIONS_V5: DriveAbciMethodVersions = DriveAbciMeth
     state_transition_processing: DriveAbciStateTransitionProcessingMethodVersions {
         execute_event: 0,
         process_raw_state_transitions: 0,
+        process_validation_result: 0,
         decode_raw_state_transitions: 0,
         validate_fees_of_event: 0,
         store_address_balances_to_recent_block_storage: None,
         cleanup_recent_block_storage_address_balances: None,
+        record_added_balance_outputs: 0,
     },
     epoch: DriveAbciEpochMethodVersions {
         gather_epoch_info: 0,

--- a/packages/rs-platform-version/src/version/drive_abci_versions/drive_abci_method_versions/v6.rs
+++ b/packages/rs-platform-version/src/version/drive_abci_versions/drive_abci_method_versions/v6.rs
@@ -105,10 +105,12 @@ pub const DRIVE_ABCI_METHOD_VERSIONS_V6: DriveAbciMethodVersions = DriveAbciMeth
     state_transition_processing: DriveAbciStateTransitionProcessingMethodVersions {
         execute_event: 0,
         process_raw_state_transitions: 0,
+        process_validation_result: 0,
         decode_raw_state_transitions: 0,
         validate_fees_of_event: 0,
         store_address_balances_to_recent_block_storage: None,
         cleanup_recent_block_storage_address_balances: None,
+        record_added_balance_outputs: 0,
     },
     epoch: DriveAbciEpochMethodVersions {
         gather_epoch_info: 0,

--- a/packages/rs-platform-version/src/version/drive_abci_versions/drive_abci_method_versions/v7.rs
+++ b/packages/rs-platform-version/src/version/drive_abci_versions/drive_abci_method_versions/v7.rs
@@ -112,10 +112,12 @@ pub const DRIVE_ABCI_METHOD_VERSIONS_V7: DriveAbciMethodVersions = DriveAbciMeth
     state_transition_processing: DriveAbciStateTransitionProcessingMethodVersions {
         execute_event: 0,
         process_raw_state_transitions: 0,
+        process_validation_result: 0,
         decode_raw_state_transitions: 0,
         validate_fees_of_event: 0,
         store_address_balances_to_recent_block_storage: Some(0), // changed
         cleanup_recent_block_storage_address_balances: Some(0), // cleanup enabled when store is enabled
+        record_added_balance_outputs: 0,
     },
     epoch: DriveAbciEpochMethodVersions {
         gather_epoch_info: 0,

--- a/packages/rs-platform-version/src/version/drive_abci_versions/drive_abci_method_versions/v9.rs
+++ b/packages/rs-platform-version/src/version/drive_abci_versions/drive_abci_method_versions/v9.rs
@@ -12,18 +12,27 @@ use crate::version::drive_abci_versions::drive_abci_method_versions::{
     DriveAbciVotingMethodVersions,
 };
 
-// Introduced in Protocol version 12 for the shielded credit pool.
+// Introduced in Protocol version 13.
 //
-// Identical to DRIVE_ABCI_METHOD_VERSIONS_V7 (the protocol-v11 method set)
-// except the four shielded-pool block-processing methods are active here.
-// These read/write the shielded credit pool subtree
-// `[RootTree::ShieldedBalances (52), MAIN_SHIELDED_CREDIT_POOL_KEY ("M")]`,
-// which only exists from protocol v12 onward (created by the v12 upgrade
-// migration `transition_to_version_12` or a v12 genesis). They MUST stay
-// inactive on v11 (see DRIVE_ABCI_METHOD_VERSIONS_V7), so the shielded
-// activation lives in this dedicated v12 struct rather than being shared
-// with v11 via V7.
-pub const DRIVE_ABCI_METHOD_VERSIONS_V8: DriveAbciMethodVersions = DriveAbciMethodVersions {
+// Identical to DRIVE_ABCI_METHOD_VERSIONS_V8 (the protocol-v12 method set)
+// except TWO fields are bumped from 0 to 1, both serving the same v13 recorded-set
+// expansion — enlarging the per-block address-balance set that v0 dropped:
+//   (1) `record_added_balance_outputs` 0 -> 1: folds shielded-spend transparent
+//       credits (the Unshield net output, the ShieldFromAssetLock surplus, and the
+//       IdentityCreateFromShieldedPool duplicate-key fallback); and
+//   (2) `process_validation_result` 0 -> 1: records the balance effects of
+//       paid-INVALID and unsuccessful-paid transitions (charged fees, adjusted
+//       input/output balances, applied chargeable-failure credits) that pre-v13
+//       nodes never tracked (they passed no map, and PaidConsensusError had no
+//       balance-changes field). Only this helper changed — `process_raw_state_transitions`
+//       (the outer loop) stays at v0 — and it lives in a real _v1, so the _v0
+//       stays byte-identical to old nodes with no version conditional.
+// The storage method `store_address_balances_to_recent_block_storage` is
+// deliberately UNCHANGED (stays Some(0)) — its _v0 implementation did not change;
+// only which changes feed its map did. The expanded recorded set changes the
+// committed state root, so both bumps MUST stay inactive on v12 (see
+// DRIVE_ABCI_METHOD_VERSIONS_V8, which keeps both fields at 0).
+pub const DRIVE_ABCI_METHOD_VERSIONS_V9: DriveAbciMethodVersions = DriveAbciMethodVersions {
     engine: DriveAbciEngineMethodVersions {
         init_chain: 0,
         check_tx: 0,
@@ -113,13 +122,22 @@ pub const DRIVE_ABCI_METHOD_VERSIONS_V8: DriveAbciMethodVersions = DriveAbciMeth
     },
     state_transition_processing: DriveAbciStateTransitionProcessingMethodVersions {
         execute_event: 0,
+        // Unchanged: the outer processing loop did not change at v13, so it stays at v0. Only the
+        // `process_validation_result` helper it dispatches to changed (below).
         process_raw_state_transitions: 0,
-        process_validation_result: 0,
+        // changed: v1 records the balance effects of paid-INVALID / unsuccessful-paid transitions
+        // (charged fees, adjusted outputs, applied chargeable-failure credits) that v0 dropped. Same
+        // v13 recorded-set expansion as `record_added_balance_outputs` below; kept in a real _v1 so
+        // no version conditional lives inside the _v0 helper.
+        process_validation_result: 1,
         decode_raw_state_transitions: 0,
         validate_fees_of_event: 0,
         store_address_balances_to_recent_block_storage: Some(0),
         cleanup_recent_block_storage_address_balances: Some(0),
-        record_added_balance_outputs: 0,
+        // changed: v1 records shielded-spend transparent credits (Unshield net output,
+        // ShieldFromAssetLock surplus, identity-create fallback) folded at the executor. The storage
+        // method above is unchanged — only which credits feed its map did.
+        record_added_balance_outputs: 1,
     },
     epoch: DriveAbciEpochMethodVersions {
         gather_epoch_info: 0,

--- a/packages/rs-platform-version/src/version/mocks/v3_test.rs
+++ b/packages/rs-platform-version/src/version/mocks/v3_test.rs
@@ -138,10 +138,12 @@ pub const TEST_PLATFORM_V3: PlatformVersion = PlatformVersion {
             state_transition_processing: DriveAbciStateTransitionProcessingMethodVersions {
                 execute_event: 0,
                 process_raw_state_transitions: 0,
+                process_validation_result: 0,
                 decode_raw_state_transitions: 0,
                 validate_fees_of_event: 0,
                 store_address_balances_to_recent_block_storage: None,
                 cleanup_recent_block_storage_address_balances: None,
+                record_added_balance_outputs: 0,
             },
             epoch: DriveAbciEpochMethodVersions {
                 gather_epoch_info: 0,

--- a/packages/rs-platform-version/src/version/protocol_version.rs
+++ b/packages/rs-platform-version/src/version/protocol_version.rs
@@ -228,4 +228,68 @@ mod shielded_pool_gating_tests {
         assert_eq!(block_end.record_shielded_pool_anchor, Some(0));
         assert_eq!(block_end.prune_shielded_pool_anchors, Some(0));
     }
+
+    // The v13 recorded-set expansion of the recent per-block address-balance set changes the
+    // committed state root, so it is gated to v13 via TWO method versions that both stay 0 before
+    // v13 and become 1 at v13:
+    //   - `record_added_balance_outputs`: v1 folds shielded-spend transparent credits (Unshield net
+    //     output, ShieldFromAssetLock surplus, identity-create fallback);
+    //   - `process_validation_result`: v1 records paid-invalid / unsuccessful-paid balance effects
+    //     that _v0 drops.
+    // Crucially the OUTER loop (`process_raw_state_transitions`) and the storage method
+    // (`store_address_balances_to_recent_block_storage`) are NOT bumped — their _v0 implementations
+    // did not change — so they stay 0 / Some(0) at BOTH versions.
+    #[test]
+    fn shielded_transparent_credit_recording_gated_to_v13() {
+        let v12 = PlatformVersion::get(12).expect("protocol version 12 must exist");
+        let v13 = PlatformVersion::get(13).expect("protocol version 13 must exist");
+        let stp12 = &v12.drive_abci.methods.state_transition_processing;
+        let stp13 = &v13.drive_abci.methods.state_transition_processing;
+
+        // The recording method version: v0 before v13 (drops shielded-spend), v1 from v13 (records).
+        assert_eq!(
+            stp12.record_added_balance_outputs, 0,
+            "v12 must use record_added_balance_outputs v0 (drops shielded-spend credits)"
+        );
+        assert_eq!(
+            stp13.record_added_balance_outputs, 1,
+            "v13 must use record_added_balance_outputs v1 (records shielded-spend credits)"
+        );
+
+        // The paid-invalid / unsuccessful-paid tracking version: v0 before v13 (drops those balance
+        // effects), v1 from v13 (records them).
+        assert_eq!(
+            stp12.process_validation_result, 0,
+            "v12 must use process_validation_result v0 (drops paid-invalid balance effects)"
+        );
+        assert_eq!(
+            stp13.process_validation_result, 1,
+            "v13 must use process_validation_result v1 (records paid-invalid balance effects)"
+        );
+
+        // The outer loop is UNCHANGED across the gate — its _v0 did not change, so it stays 0.
+        assert_eq!(
+            stp12.process_raw_state_transitions, 0,
+            "v12 outer loop stays process_raw_state_transitions v0"
+        );
+        assert_eq!(
+            stp13.process_raw_state_transitions, 0,
+            "v13 must NOT bump the unchanged outer loop"
+        );
+
+        // The storage method is UNCHANGED across the gate — we must not bump a method whose _v0
+        // implementation did not change. It stays Some(0) at both v12 and v13.
+        assert_eq!(
+            stp12.store_address_balances_to_recent_block_storage,
+            Some(0),
+            "v12 store method is Some(0)"
+        );
+        assert_eq!(
+            stp13.store_address_balances_to_recent_block_storage,
+            Some(0),
+            "v13 must NOT bump the unchanged store method"
+        );
+        // Cleanup mechanics likewise unchanged.
+        assert_eq!(stp13.cleanup_recent_block_storage_address_balances, Some(0));
+    }
 }

--- a/packages/rs-platform-version/src/version/v13.rs
+++ b/packages/rs-platform-version/src/version/v13.rs
@@ -15,7 +15,7 @@ use crate::version::dpp_versions::dpp_validation_versions::v3::DPP_VALIDATION_VE
 use crate::version::dpp_versions::dpp_voting_versions::v2::VOTING_VERSION_V2;
 use crate::version::dpp_versions::DPPVersion;
 use crate::version::drive_abci_versions::drive_abci_checkpoint_parameters::v1::DRIVE_ABCI_CHECKPOINT_PARAMETERS_V1;
-use crate::version::drive_abci_versions::drive_abci_method_versions::v8::DRIVE_ABCI_METHOD_VERSIONS_V8;
+use crate::version::drive_abci_versions::drive_abci_method_versions::v9::DRIVE_ABCI_METHOD_VERSIONS_V9;
 use crate::version::drive_abci_versions::drive_abci_query_versions::v1::DRIVE_ABCI_QUERY_VERSIONS_V1;
 use crate::version::drive_abci_versions::drive_abci_structure_versions::v1::DRIVE_ABCI_STRUCTURE_VERSIONS_V1;
 use crate::version::drive_abci_versions::drive_abci_validation_versions::v9::DRIVE_ABCI_VALIDATION_VERSIONS_V9;
@@ -30,10 +30,18 @@ use crate::version::ProtocolVersion;
 
 pub const PROTOCOL_VERSION_13: ProtocolVersion = 13;
 
-/// Introduced as the activation gate for recording shielded-spend transparent
-/// credits (Unshield / shield surplus / identity-create fallback) into the
-/// recent-address-balance-changes tree. The consensus change that consumes
-/// that gate (a bumped drive-abci methods struct) lands in a follow-up.
+/// v13 expands the recent per-block address-balance set that incremental client
+/// sync reads: `DRIVE_ABCI_METHOD_VERSIONS_V9` bumps two fields from 0 to 1, both
+/// recording what v0 dropped — (1) `record_added_balance_outputs` folds
+/// shielded-spend transparent credits (Unshield net output, ShieldFromAssetLock
+/// surplus, identity-create fallback), and (2) `process_validation_result`
+/// records the balance effects of paid-invalid / unsuccessful-paid transitions
+/// (charged fees, adjusted outputs), in a real _v1 of the helper so its _v0 stays
+/// byte-identical to old nodes (the outer `process_raw_state_transitions` loop is
+/// unchanged and stays at v0). The storage method
+/// (`store_address_balances_to_recent_block_storage`) is unchanged — only the
+/// recorded set differs. Because that set changes the committed state root, both
+/// bumps activate only once the network votes in v13.
 ///
 /// v13 also enables DPNS username transfers and sales:
 /// * `DRIVE_ABCI_VALIDATION_VERSIONS_V9` bumps data trigger bindings to v1,
@@ -48,7 +56,7 @@ pub const PLATFORM_V13: PlatformVersion = PlatformVersion {
     drive: DRIVE_VERSION_V8, // changed: DPNS domain records.identity rewrite on transfer/purchase
     drive_abci: DriveAbciVersion {
         structs: DRIVE_ABCI_STRUCTURE_VERSIONS_V1,
-        methods: DRIVE_ABCI_METHOD_VERSIONS_V8,
+        methods: DRIVE_ABCI_METHOD_VERSIONS_V9, // changed: records shielded-spend transparent credits (Unshield net output, ShieldFromAssetLock surplus, identity-create fallback) into the recent per-block address-balance set
         validation_and_processing: DRIVE_ABCI_VALIDATION_VERSIONS_V9, // changed: allow DPNS domain transfer/purchase/update-price
         withdrawal_constants: DRIVE_ABCI_WITHDRAWAL_CONSTANTS_V2,
         query: DRIVE_ABCI_QUERY_VERSIONS_V1,


### PR DESCRIPTION
## Symptom (dashwallet-ios QA)

Platform payments received via **Unshield (Type 17)** never appear through incremental address sync — the wallet's `GetRecentAddressBalanceChanges` passes returned **0 entries across 18 consecutive queries** with `last_known_recent_block` stuck at 0, while the same payments showed up immediately after a full trunk/branch rescan (app relaunch / sync-state clear). Receivers see the money "sometimes" — i.e. only after the next full scan.

## Root cause

`UnshieldAction` credits the transparent platform output address by pushing a raw `AddressFundsOperationType::AddBalanceToAddress` drive op (`action_convert_to_operations/shielded/unshield_transition.rs`), which mutates the **absolute** address-funds tree — what full scans read. But its execution event `PaidFromShieldedPool` carried no output data, and the executor arm never wrote the credit into `address_balances_in_update` — the **sole feed** for `store_address_balances_for_block`, i.e. the recent-address-balance-changes tree (`SavedBlockTransactions/'m'`) that incremental sync queries. The recent tree was genuinely empty for unshield-credited blocks.

`PaidFromAssetLockToPool` had the identical omission for a **Type 18 ShieldFromAssetLock `surplus_output`** credit.

All transparent-side transitions (`AddressFundsTransfer`, `IdentityCreditTransferToAddresses`, fundings, withdrawals, identity ops) already record correctly via `PaidFromAddressInputs` / `Paid { added_to_balance_outputs }`. The client-side apply in rs-sdk was verified correct — it would have applied entries had any existed.

## Fix

- Extend `ExecutionEvent::PaidFromShieldedPool` and `::PaidFromAssetLockToPool` with `added_to_balance_outputs: Option<BTreeMap<PlatformAddress, Credits>>` (same shape as `Paid`'s field).
  - Unshield populates `output_address → amount − fee` (only when net > 0, mirroring the converter's guard).
  - ShieldFromAssetLock populates the surplus output when set and positive.
  - Type 16 ShieldedTransfer / Type 19 ShieldedWithdrawal pass `None` — neither credits a transparent platform address (Type 19's output is a Core-chain address).
- Both executor arms fold the outputs into `address_balances_in_update` as `CreditOperation::AddToCredits` on the applied path, using the identical entry/merge idiom as the `Paid` arm (including the chargeable-failure fallback, whose address is genuinely credited by the applied ops).

## Rolling-upgrade safety (protocol v13)

The recording changes the committed state root, so each changed behavior — and ONLY the changed behavior — is a versioned method with a real v0/v1:

- **`record_added_balance_outputs/{mod.rs, v0/, v1/}`** (new method, field 0 in V1..V8 → 1 in V9): **v0** folds `Transparent`-origin outputs, drops `ShieldedSpend`-origin; **v1** folds both. Events carry credits unconditionally (in-memory only).
- **`process_validation_result/{mod.rs, v0/, v1/}`** (the per-ST result helper, hoisted into its own method with a new field, 0 in V1..V8 → 1 in V9): **v0** = base behavior (paid-invalid passes `None`, `PaidConsensusError` carries empty); **v1** = unconditional paid-invalid tracking + carry into `address_balances_updated`. The outer `process_raw_state_transitions` loop did not change and **stays at v0** — it just calls the dispatching helper, same as `execute_event_v0` calls the dispatching `record_added_balance_outputs`.
- `DRIVE_ABCI_METHOD_VERSIONS_V9` therefore carries exactly two field deltas — together they define the v13 **recorded-set expansion**: shielded-spend transparent credits (Unshield net output, shield surplus, identity-create fallback) plus the previously-dropped balance effects of paid-invalid / unsuccessful-paid transitions (charged fees, adjusted outputs).
- `store_address_balances_to_recent_block_storage` untouched at `Some(0)`; the `process_raw_state_transitions` dispatch, store dispatch, and `feature_initial_protocol_versions` are byte-identical to base.
- Pre-v13 parity is proven compositionally: v0 helpers record nothing (asserted even when handed credit-bearing events, at v12 and v13 inputs), v1 records, and the platform-version gating test pins both fields 0@v12 / 1@v13 (and the store method + outer loop unchanged at both).

## Tests

- 4 construction tests (net output populated, net-zero → none, surplus populated, no-surplus → none)
- 3 executor tests proving `address_balances_in_update` receives `AddToCredits` for both variants and stays empty without outputs
- `cargo check -p drive-abci` / `-p drive` clean; touched-module suites green (17 passed drive-abci filter, 43 passed drive saved_block_transactions/converters)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Transparent credits resulting from unshielding and asset-lock surplus outputs are now included in address balance updates.
  * Paid consensus errors on paid-invalid chargeable-failure paths can now carry eligible address balance changes for incremental sync.
  * Protocol version 13 expands shielded-spend transparent credit recording while keeping prior behavior for older versions.

* **Bug Fixes**
  * Fixed credit aggregation for paid-invalid and chargeable-failure flows, including correct zero/none handling.
  * Ensured paid-consensus error results include accurate balance-change data when applicable.

* **Tests**
  * Added regression tests for protocol gating and paid failure scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->





