### PR TITLE
feat(platform): introduce protocol version 13

### DIFF
--- a/packages/rs-platform-version/src/version/mod.rs
+++ b/packages/rs-platform-version/src/version/mod.rs
@@ -1,6 +1,6 @@
 mod protocol_version;
 
-use crate::version::v12::PROTOCOL_VERSION_12;
+use crate::version::v13::PROTOCOL_VERSION_13;
 pub use protocol_version::*;
 use std::ops::RangeInclusive;
 
@@ -18,6 +18,7 @@ pub mod v1;
 pub mod v10;
 pub mod v11;
 pub mod v12;
+pub mod v13;
 pub mod v2;
 pub mod v3;
 pub mod v4;
@@ -31,5 +32,5 @@ pub type ProtocolVersion = u32;
 
 pub const ALL_VERSIONS: RangeInclusive<ProtocolVersion> = 1..=LATEST_VERSION;
 
-pub const LATEST_VERSION: ProtocolVersion = PROTOCOL_VERSION_12;
+pub const LATEST_VERSION: ProtocolVersion = PROTOCOL_VERSION_13;
 pub const INITIAL_PROTOCOL_VERSION: ProtocolVersion = 1;

--- a/packages/rs-platform-version/src/version/protocol_version.rs
+++ b/packages/rs-platform-version/src/version/protocol_version.rs
@@ -20,6 +20,7 @@ use crate::version::v1::PLATFORM_V1;
 use crate::version::v10::PLATFORM_V10;
 use crate::version::v11::PLATFORM_V11;
 use crate::version::v12::PLATFORM_V12;
+use crate::version::v13::PLATFORM_V13;
 use crate::version::v2::PLATFORM_V2;
 use crate::version::v3::PLATFORM_V3;
 use crate::version::v4::PLATFORM_V4;
@@ -57,6 +58,7 @@ pub const PLATFORM_VERSIONS: &[PlatformVersion] = &[
     PLATFORM_V10,
     PLATFORM_V11,
     PLATFORM_V12,
+    PLATFORM_V13,
 ];
 
 #[cfg(feature = "mock-versions")]
@@ -65,7 +67,7 @@ pub static PLATFORM_TEST_VERSIONS: OnceLock<Vec<PlatformVersion>> = OnceLock::ne
 #[cfg(feature = "mock-versions")]
 const DEFAULT_PLATFORM_TEST_VERSIONS: &[PlatformVersion] = &[TEST_PLATFORM_V2, TEST_PLATFORM_V3];
 
-pub const LATEST_PLATFORM_VERSION: &PlatformVersion = &PLATFORM_V12;
+pub const LATEST_PLATFORM_VERSION: &PlatformVersion = &PLATFORM_V13;
 
 pub const DESIRED_PLATFORM_VERSION: &PlatformVersion = LATEST_PLATFORM_VERSION;
 

--- a/packages/rs-platform-version/src/version/v13.rs
+++ b/packages/rs-platform-version/src/version/v13.rs
@@ -1,0 +1,73 @@
+use crate::version::consensus_versions::ConsensusVersions;
+use crate::version::dpp_versions::dpp_asset_lock_versions::v1::DPP_ASSET_LOCK_VERSIONS_V1;
+use crate::version::dpp_versions::dpp_contract_versions::v4::CONTRACT_VERSIONS_V4;
+use crate::version::dpp_versions::dpp_costs_versions::v1::DPP_COSTS_VERSIONS_V1;
+use crate::version::dpp_versions::dpp_document_versions::v3::DOCUMENT_VERSIONS_V3;
+use crate::version::dpp_versions::dpp_factory_versions::v1::DPP_FACTORY_VERSIONS_V1;
+use crate::version::dpp_versions::dpp_identity_versions::v1::IDENTITY_VERSIONS_V1;
+use crate::version::dpp_versions::dpp_method_versions::v2::DPP_METHOD_VERSIONS_V2;
+use crate::version::dpp_versions::dpp_state_transition_conversion_versions::v2::STATE_TRANSITION_CONVERSION_VERSIONS_V2;
+use crate::version::dpp_versions::dpp_state_transition_method_versions::v1::STATE_TRANSITION_METHOD_VERSIONS_V1;
+use crate::version::dpp_versions::dpp_state_transition_serialization_versions::v2::STATE_TRANSITION_SERIALIZATION_VERSIONS_V2;
+use crate::version::dpp_versions::dpp_state_transition_versions::v3::STATE_TRANSITION_VERSIONS_V3;
+use crate::version::dpp_versions::dpp_token_versions::v2::TOKEN_VERSIONS_V2;
+use crate::version::dpp_versions::dpp_validation_versions::v3::DPP_VALIDATION_VERSIONS_V3;
+use crate::version::dpp_versions::dpp_voting_versions::v2::VOTING_VERSION_V2;
+use crate::version::dpp_versions::DPPVersion;
+use crate::version::drive_abci_versions::drive_abci_checkpoint_parameters::v1::DRIVE_ABCI_CHECKPOINT_PARAMETERS_V1;
+use crate::version::drive_abci_versions::drive_abci_method_versions::v8::DRIVE_ABCI_METHOD_VERSIONS_V8;
+use crate::version::drive_abci_versions::drive_abci_query_versions::v1::DRIVE_ABCI_QUERY_VERSIONS_V1;
+use crate::version::drive_abci_versions::drive_abci_structure_versions::v1::DRIVE_ABCI_STRUCTURE_VERSIONS_V1;
+use crate::version::drive_abci_versions::drive_abci_validation_versions::v8::DRIVE_ABCI_VALIDATION_VERSIONS_V8;
+use crate::version::drive_abci_versions::drive_abci_withdrawal_constants::v2::DRIVE_ABCI_WITHDRAWAL_CONSTANTS_V2;
+use crate::version::drive_abci_versions::DriveAbciVersion;
+use crate::version::drive_versions::v7::DRIVE_VERSION_V7;
+use crate::version::fee::v2::FEE_VERSION2;
+use crate::version::protocol_version::PlatformVersion;
+use crate::version::system_data_contract_versions::v1::SYSTEM_DATA_CONTRACT_VERSIONS_V1;
+use crate::version::system_limits::v2::SYSTEM_LIMITS_V2;
+use crate::version::ProtocolVersion;
+
+pub const PROTOCOL_VERSION_13: ProtocolVersion = 13;
+
+/// Introduced as the activation gate for recording shielded-spend transparent
+/// credits (Unshield / shield surplus / identity-create fallback) into the
+/// recent-address-balance-changes tree. Functionally identical to v12 at
+/// introduction — the same component version structs, no behavior change. The
+/// consensus change that consumes this gate (a bumped drive-abci methods
+/// struct) lands in a follow-up; keeping v13 == v12 here lets mixed-version
+/// validators agree until that change activates.
+pub const PLATFORM_V13: PlatformVersion = PlatformVersion {
+    protocol_version: PROTOCOL_VERSION_13,
+    drive: DRIVE_VERSION_V7,
+    drive_abci: DriveAbciVersion {
+        structs: DRIVE_ABCI_STRUCTURE_VERSIONS_V1,
+        methods: DRIVE_ABCI_METHOD_VERSIONS_V8,
+        validation_and_processing: DRIVE_ABCI_VALIDATION_VERSIONS_V8,
+        withdrawal_constants: DRIVE_ABCI_WITHDRAWAL_CONSTANTS_V2,
+        query: DRIVE_ABCI_QUERY_VERSIONS_V1,
+        checkpoints: DRIVE_ABCI_CHECKPOINT_PARAMETERS_V1,
+    },
+    dpp: DPPVersion {
+        costs: DPP_COSTS_VERSIONS_V1,
+        validation: DPP_VALIDATION_VERSIONS_V3,
+        state_transition_serialization_versions: STATE_TRANSITION_SERIALIZATION_VERSIONS_V2,
+        state_transition_conversion_versions: STATE_TRANSITION_CONVERSION_VERSIONS_V2,
+        state_transition_method_versions: STATE_TRANSITION_METHOD_VERSIONS_V1,
+        state_transitions: STATE_TRANSITION_VERSIONS_V3,
+        contract_versions: CONTRACT_VERSIONS_V4,
+        document_versions: DOCUMENT_VERSIONS_V3,
+        identity_versions: IDENTITY_VERSIONS_V1,
+        voting_versions: VOTING_VERSION_V2,
+        token_versions: TOKEN_VERSIONS_V2,
+        asset_lock_versions: DPP_ASSET_LOCK_VERSIONS_V1,
+        methods: DPP_METHOD_VERSIONS_V2,
+        factory_versions: DPP_FACTORY_VERSIONS_V1,
+    },
+    system_data_contracts: SYSTEM_DATA_CONTRACT_VERSIONS_V1,
+    fee_version: FEE_VERSION2,
+    system_limits: SYSTEM_LIMITS_V2,
+    consensus: ConsensusVersions {
+        tenderdash_consensus_version: 1,
+    },
+};


### PR DESCRIPTION
## What

Introduces **protocol version 13**, functionally identical to v12 — same component version structs throughout, no behavior change at introduction.

## Why

Foundation for rolling-upgrade safety on #4142: recording shielded-spend transparent credits (Unshield / shield surplus / identity-create fallback) into the recent-address-balance-changes tree changes the committed state root, so it must not activate until validators agree — #4142 will be reworked to gate the new recording on v13, activated by the normal masternode version voting instead of requiring a lockstep deploy.

## Changes

- `v13.rs`: exact clone of v12 (verified by diff: only the constant, the struct name, and the doc comment differ). Per repo convention, v12's inline "changed:" delta comments are dropped — they document deltas introduced at v12.
- Registration: `mod.rs`, `protocol_version.rs` imports, `PLATFORM_VERSIONS` array, `LATEST_PLATFORM_VERSION → &PLATFORM_V13` (`DESIRED_PLATFORM_VERSION` follows by alias — drive-abci now advertises 13 to Tenderdash).

## Deliberately unchanged (each checked individually)

- **SDK per-network minimum floors** (`min_protocol_version`: testnet/devnet/regtest = 12, mainnet = 11) — these are the *currently running* floors, not "latest"; they ratchet automatically when a network actually reports 13.
- **`feature_initial_protocol_versions`** — activation markers name the version where a feature turned on; v13 activates nothing at introduction (the #4142 follow-up adds its marker).
- **Migration dispatch** (`perform_events_on_first_block_of_protocol_change`) — v13 shares `DRIVE_VERSION_V7`, no new GroveDB structures, so a v12→v13 upgrade is correctly a no-op fallthrough.
- All `PlatformVersion::get(12)` / `PROTOCOL_VERSION_12` test and doc references to v12-activation-specific behavior.

## Verification

- `cargo fmt --check` clean; `cargo check` on platform-version, dpp, drive-abci, dash-sdk clean
- `cargo test -p platform-version` → 7 passed (incl. the shielded-pool v12 gating tests)
- `cargo test -p drive-abci --lib protocol_upgrade` → 42 passed (transition chains, same-version no-op, v12 tree creation)
- `cargo test -p dpp` state-transition range assertions (92) + validation-result (61) green — the `..=LATEST_VERSION` ranges follow to 13
- `cargo test -p dash-sdk` version floor/ratchet/pin tests → 55 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)