### PR TITLE
feat(platform)!: enable DPNS username transfers and sales in protocol version 13

### DIFF
--- a/packages/dpns-contract/src/v1/mod.rs
+++ b/packages/dpns-contract/src/v1/mod.rs
@@ -13,6 +13,7 @@ pub mod document_types {
             pub const PREORDER_SALT: &str = "preorderSalt";
             pub const ALLOW_SUBDOMAINS: &str = "subdomainRules.allowSubdomains";
             pub const RECORDS: &str = "records";
+            pub const IDENTITY: &str = "identity";
             pub const DASH_UNIQUE_IDENTITY_ID: &str = "dashUniqueIdentityId";
             pub const DASH_ALIAS_IDENTITY_ID: &str = "dashAliasIdentityId";
         }

--- a/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/batch/data_triggers/bindings/list/mod.rs
+++ b/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/batch/data_triggers/bindings/list/mod.rs
@@ -3,6 +3,7 @@ use dpp::version::PlatformVersion;
 use crate::execution::validation::state_transition::batch::data_triggers::bindings::data_trigger_binding::DataTriggerBinding;
 
 mod v0;
+mod v1;
 
 pub fn data_trigger_bindings_list(
     platform_version: &PlatformVersion,
@@ -19,9 +20,13 @@ pub fn data_trigger_bindings_list(
             .into_iter()
             .map(|binding| binding.into())
             .collect()),
+        1 => Ok(v1::data_trigger_bindings_list_v1()?
+            .into_iter()
+            .map(|binding| binding.into())
+            .collect()),
         version => Err(ProtocolError::UnknownVersionMismatch {
             method: "data_trigger_bindings".to_string(),
-            known_versions: vec![0],
+            known_versions: vec![0, 1],
             received: version,
         }),
     }

--- a/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/batch/data_triggers/bindings/list/v1/mod.rs
+++ b/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/batch/data_triggers/bindings/list/v1/mod.rs
@@ -1,0 +1,101 @@
+use crate::execution::validation::state_transition::batch::data_triggers::bindings::data_trigger_binding::DataTriggerBindingV0;
+use crate::execution::validation::state_transition::batch::data_triggers::triggers::dashpay::create_contact_request_data_trigger;
+use crate::execution::validation::state_transition::batch::data_triggers::triggers::dpns::create_domain_data_trigger;
+use crate::execution::validation::state_transition::batch::data_triggers::triggers::reject::reject_data_trigger;
+use crate::execution::validation::state_transition::batch::data_triggers::triggers::withdrawals::delete_withdrawal_data_trigger;
+
+use dpp::errors::ProtocolError;
+use dpp::system_data_contracts::withdrawals_contract::v1::document_types::withdrawal;
+use dpp::system_data_contracts::{dashpay_contract, dpns_contract, SystemDataContract};
+use drive::state_transition_action::batch::batched_transition::document_transition::DocumentTransitionActionType;
+
+/// Retrieves a list of data triggers binding with matching params.
+///
+/// This function gets all known data triggers which are then returned
+/// as a vector of `DataTrigger` structs.
+///
+/// v1 (PROTOCOL_VERSION_13): DPNS `domain` documents no longer reject
+/// `Transfer`, `Purchase` and `UpdatePrice`, enabling username transfers
+/// and sales. The DPNS contract has declared `transferable: 1` and
+/// `tradeMode: 1` (direct purchase) since genesis, so the generic document
+/// validation paths accept these transitions once the reject bindings are
+/// gone. `Replace` and `Delete` stay rejected: name records remain
+/// immutable and permanent. On transfer and purchase, drive rewrites the
+/// domain's `records.identity` to the new owner so the name resolves to
+/// the buyer (see the v1 document transfer/purchase high-level operation
+/// conversions in rs-drive).
+///
+/// # Returns
+///
+/// A `Vec<DataTriggerBinding>` containing all known data triggers.
+///
+/// # Errors
+///
+/// Returns a `ProtocolError` if there was an error.
+#[inline(always)]
+pub(super) fn data_trigger_bindings_list_v1() -> Result<Vec<DataTriggerBindingV0>, ProtocolError> {
+    let data_triggers = vec![
+        DataTriggerBindingV0 {
+            data_contract_id: dpns_contract::ID,
+            document_type: "domain".to_string(),
+            transition_action_type: DocumentTransitionActionType::Create,
+            data_trigger: create_domain_data_trigger,
+        },
+        // Domain documents can never be modified or deleted, but since
+        // protocol version 13 they can be transferred and sold
+        DataTriggerBindingV0 {
+            data_contract_id: dpns_contract::ID,
+            document_type: "domain".to_string(),
+            transition_action_type: DocumentTransitionActionType::Replace,
+            data_trigger: reject_data_trigger,
+        },
+        DataTriggerBindingV0 {
+            data_contract_id: dpns_contract::ID,
+            document_type: "domain".to_string(),
+            transition_action_type: DocumentTransitionActionType::Delete,
+            data_trigger: reject_data_trigger,
+        },
+        DataTriggerBindingV0 {
+            data_contract_id: dashpay_contract::ID,
+            document_type: "contactRequest".to_string(),
+            transition_action_type: DocumentTransitionActionType::Create,
+            data_trigger: create_contact_request_data_trigger,
+        },
+        // Only masternodes will be able to update it
+        DataTriggerBindingV0 {
+            data_contract_id: SystemDataContract::MasternodeRewards.id(),
+            document_type: "rewardShare".to_string(),
+            transition_action_type: DocumentTransitionActionType::Create,
+            data_trigger: reject_data_trigger,
+        },
+        // Only masternodes will be able to update it
+        DataTriggerBindingV0 {
+            data_contract_id: SystemDataContract::MasternodeRewards.id(),
+            document_type: "rewardShare".to_string(),
+            transition_action_type: DocumentTransitionActionType::Replace,
+            data_trigger: reject_data_trigger,
+        },
+        // Only masternodes will be able to update it
+        DataTriggerBindingV0 {
+            data_contract_id: SystemDataContract::MasternodeRewards.id(),
+            document_type: "rewardShare".to_string(),
+            transition_action_type: DocumentTransitionActionType::Delete,
+            data_trigger: reject_data_trigger,
+        },
+        // We can't use mutability flag otherwise documents won't have revision
+        DataTriggerBindingV0 {
+            data_contract_id: SystemDataContract::Withdrawals.id(),
+            document_type: withdrawal::NAME.to_string(),
+            transition_action_type: DocumentTransitionActionType::Replace,
+            data_trigger: reject_data_trigger,
+        },
+        DataTriggerBindingV0 {
+            data_contract_id: SystemDataContract::Withdrawals.id(),
+            document_type: withdrawal::NAME.to_string(),
+            transition_action_type: DocumentTransitionActionType::Delete,
+            data_trigger: delete_withdrawal_data_trigger,
+        },
+    ];
+
+    Ok(data_triggers)
+}

--- a/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/batch/tests/document/dpns.rs
+++ b/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/batch/tests/document/dpns.rs
@@ -959,6 +959,7 @@ mod dpns_tests {
 
 mod dpns_username_transfer_tests {
     use super::*;
+    use dpp::consensus::basic::BasicError;
     use dpp::consensus::state::data_trigger::DataTriggerError;
     use dpp::data_contract::DataContract;
     use dpp::document::Document;
@@ -1463,6 +1464,21 @@ mod dpns_username_transfer_tests {
                 }]
             );
 
+            // The domain must still belong to Alice, keep its records.identity
+            // pointing at her, and have no $price set
+            let alice_documents =
+                query_domain_documents_by_record_identity(&platform, &dpns_contract, alice.id());
+
+            assert_eq!(alice_documents.len(), 1);
+
+            let kept_document = alice_documents.first().expect("expected a document");
+
+            assert_eq!(kept_document.owner_id(), alice.id());
+
+            assert_identity_record(kept_document, alice.id());
+
+            assert!(kept_document.properties().get("$price").is_none());
+
             return;
         }
 
@@ -1486,6 +1502,18 @@ mod dpns_username_transfer_tests {
             .expect("expected to get back the price");
 
         assert_eq!(price, dash_to_credits!(0.1));
+
+        let alice_balance_before_sale = platform
+            .drive
+            .fetch_identity_balance(alice.id().to_buffer(), None, platform_version)
+            .expect("expected to get alice's balance")
+            .expect("expected alice's identity to exist");
+
+        let bob_balance_before_purchase = platform
+            .drive
+            .fetch_identity_balance(bob.id().to_buffer(), None, platform_version)
+            .expect("expected to get bob's balance")
+            .expect("expected bob's identity to exist");
 
         document.set_revision(Some(3));
 
@@ -1561,6 +1589,192 @@ mod dpns_username_transfer_tests {
             query_domain_documents_by_record_identity(&platform, &dpns_contract, alice.id());
 
         assert_eq!(alice_documents.len(), 0);
+
+        // Alice pays no fees on Bob's purchase transition, so her balance must
+        // grow by exactly the sale price plus the refund of the document
+        // storage she originally paid for: the purchased revision is stored
+        // under Bob's storage flags, releasing the bytes Alice had prepaid
+        let alice_storage_refund: Credits = 7711268;
+
+        let alice_balance_after_sale = platform
+            .drive
+            .fetch_identity_balance(alice.id().to_buffer(), None, platform_version)
+            .expect("expected to get alice's balance")
+            .expect("expected alice's identity to exist");
+
+        assert_eq!(
+            alice_balance_after_sale,
+            alice_balance_before_sale + dash_to_credits!(0.1) + alice_storage_refund
+        );
+
+        // Bob pays the sale price plus processing and storage fees
+        let bob_balance_after_purchase = platform
+            .drive
+            .fetch_identity_balance(bob.id().to_buffer(), None, platform_version)
+            .expect("expected to get bob's balance")
+            .expect("expected bob's identity to exist");
+
+        assert!(bob_balance_after_purchase < bob_balance_before_purchase - dash_to_credits!(0.1));
+
+        let issues = platform
+            .drive
+            .grove
+            .visualize_verify_grovedb(None, true, false, &platform_version.drive.grove_version)
+            .expect("expected to have no issues");
+
+        assert_eq!(
+            issues.len(),
+            0,
+            "issues are {}",
+            issues
+                .iter()
+                .map(|(hash, (a, b, c))| format!("{}: {} {} {}", hash, a, b, c))
+                .collect::<Vec<_>>()
+                .join(" | ")
+        );
+    }
+
+    /// The v1 data-trigger bindings list drops the rejects for `Transfer`,
+    /// `Purchase` and `UpdatePrice`, but `Replace` and `Delete` must stay
+    /// rejected: name records are immutable and permanent even though they can
+    /// now change hands.
+    ///
+    /// `Replace` is stopped before data triggers run because the domain
+    /// document type is not mutable, but `Delete` is stopped only by the
+    /// reject data trigger (the domain document type sets `canBeDeleted:
+    /// true`), so this pins the single guard protecting names from deletion.
+    #[tokio::test]
+    async fn test_dpns_username_replace_and_delete_still_rejected() {
+        let mut platform = TestPlatformBuilder::new()
+            .with_initial_protocol_version(PlatformVersion::latest().protocol_version)
+            .build_with_mock_rpc()
+            .set_genesis_state();
+
+        let platform_state = platform.state.load();
+        let platform_version = platform_state
+            .current_platform_version()
+            .expect("expected to get current platform version");
+
+        let mut rng = StdRng::seed_from_u64(439);
+
+        let alice = setup_identity(&mut platform, 960, dash_to_credits!(0.5));
+
+        let (mut document, dpns_contract) = register_dpns_username(
+            &mut platform,
+            &alice,
+            &mut rng,
+            "quantum8",
+            platform_version,
+        )
+        .await;
+
+        let (alice, signer, key) = &alice;
+
+        let domain = dpns_contract
+            .document_type_for_name("domain")
+            .expect("expected the domain document type");
+
+        document.set_revision(Some(2));
+
+        let documents_batch_replace_transition =
+            BatchTransition::new_document_replacement_transition_from_document(
+                document.clone(),
+                domain,
+                key,
+                4,
+                0,
+                None,
+                signer,
+                platform_version,
+                None,
+            )
+            .await
+            .expect("expect to create documents batch transition for the replacement");
+
+        let documents_batch_delete_transition =
+            BatchTransition::new_document_deletion_transition_from_document(
+                document,
+                domain,
+                key,
+                5,
+                0,
+                None,
+                signer,
+                platform_version,
+                None,
+            )
+            .await
+            .expect("expect to create documents batch transition for the deletion");
+
+        for (transition, expect_data_trigger_reject) in [
+            (documents_batch_replace_transition, false),
+            (documents_batch_delete_transition, true),
+        ] {
+            let serialized_transition = transition
+                .serialize_to_bytes()
+                .expect("expected documents batch serialized state transition");
+
+            let transaction = platform.drive.grove.start_transaction();
+
+            let processing_result = platform
+                .platform
+                .process_raw_state_transitions(
+                    &[serialized_transition],
+                    &platform_state,
+                    &BlockInfo::default_with_time(
+                        platform_state
+                            .last_committed_block_time_ms()
+                            .unwrap_or_default()
+                            + 3000,
+                    ),
+                    &transaction,
+                    platform_version,
+                    false,
+                    None,
+                )
+                .expect("expected to process state transition");
+
+            platform
+                .drive
+                .grove
+                .commit_transaction(transaction)
+                .unwrap()
+                .expect("expected to commit transaction");
+
+            if expect_data_trigger_reject {
+                assert_matches!(
+                    processing_result.execution_results().as_slice(),
+                    [StateTransitionExecutionResult::PaidConsensusError {
+                        error: ConsensusError::StateError(StateError::DataTriggerError(
+                            DataTriggerError::DataTriggerConditionError(_)
+                        )),
+                        ..
+                    }]
+                );
+            } else {
+                assert_matches!(
+                    processing_result.execution_results().as_slice(),
+                    [StateTransitionExecutionResult::PaidConsensusError {
+                        error: ConsensusError::BasicError(
+                            BasicError::InvalidDocumentTransitionActionError(_)
+                        ),
+                        ..
+                    }]
+                );
+            }
+
+            // The username must still belong to and resolve to Alice
+            let alice_documents =
+                query_domain_documents_by_record_identity(&platform, &dpns_contract, alice.id());
+
+            assert_eq!(alice_documents.len(), 1);
+
+            let kept_document = alice_documents.first().expect("expected a document");
+
+            assert_eq!(kept_document.owner_id(), alice.id());
+
+            assert_identity_record(kept_document, alice.id());
+        }
 
         let issues = platform
             .drive

--- a/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/batch/tests/document/dpns.rs
+++ b/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/batch/tests/document/dpns.rs
@@ -956,3 +956,627 @@ mod dpns_tests {
         assert_eq!(documents.len(), 2);
     }
 }
+
+mod dpns_username_transfer_tests {
+    use super::*;
+    use dpp::consensus::state::data_trigger::DataTriggerError;
+    use dpp::data_contract::DataContract;
+    use dpp::document::Document;
+    use dpp::identity::{Identity, IdentityPublicKey};
+    use dpp::util::hash::hash_double;
+    use dpp::util::strings::convert_to_homograph_safe_chars;
+    use drive::query::{InternalClauses, WhereClause, WhereOperator};
+    use simple_signer::signer::SimpleSigner;
+    use std::collections::BTreeMap;
+    use std::sync::Arc;
+
+    use crate::rpc::core::MockCoreRPCLike;
+    use crate::test::helpers::setup::TempPlatform;
+    use dpp::prelude::Identifier;
+    use dpp::version::ProtocolVersion;
+
+    /// Registers `<label>.dash` (preorder + domain) for the given identity and
+    /// returns the domain document as submitted along with the DPNS contract.
+    ///
+    /// The label must not match the contested-name regex (it should contain at
+    /// least one digit in 2-9) so the domain document is inserted immediately
+    /// instead of starting a masternode vote contest.
+    async fn register_dpns_username(
+        platform: &mut TempPlatform<MockCoreRPCLike>,
+        identity: &(Identity, SimpleSigner, IdentityPublicKey),
+        rng: &mut StdRng,
+        label: &str,
+        platform_version: &PlatformVersion,
+    ) -> (Document, Arc<DataContract>) {
+        let (identity, signer, key) = identity;
+
+        let platform_state = platform.state.load();
+
+        let dpns = platform.drive.cache.system_data_contracts.load_dpns();
+        let dpns_contract = dpns.clone();
+
+        let preorder = dpns_contract
+            .document_type_for_name("preorder")
+            .expect("expected the preorder document type");
+
+        let domain = dpns_contract
+            .document_type_for_name("domain")
+            .expect("expected the domain document type");
+
+        let entropy = Bytes32::random_with_rng(rng);
+
+        let mut preorder_document = preorder
+            .random_document_with_identifier_and_entropy(
+                rng,
+                identity.id(),
+                entropy,
+                DocumentFieldFillType::FillIfNotRequired,
+                DocumentFieldFillSize::AnyDocumentFillSize,
+                platform_version,
+            )
+            .expect("expected a random preorder document");
+
+        let mut document = domain
+            .random_document_with_identifier_and_entropy(
+                rng,
+                identity.id(),
+                entropy,
+                DocumentFieldFillType::FillIfNotRequired,
+                DocumentFieldFillSize::AnyDocumentFillSize,
+                platform_version,
+            )
+            .expect("expected a random domain document");
+
+        let normalized_label = convert_to_homograph_safe_chars(label);
+
+        document.set("parentDomainName", "dash".into());
+        document.set("normalizedParentDomainName", "dash".into());
+        document.set("label", label.into());
+        document.set("normalizedLabel", normalized_label.clone().into());
+        document.set("records.identity", document.owner_id().into());
+        document.set("subdomainRules.allowSubdomains", false.into());
+
+        let salt: [u8; 32] = rng.gen();
+
+        let mut salted_domain_buffer: Vec<u8> = vec![];
+        salted_domain_buffer.extend(salt);
+        salted_domain_buffer.extend((normalized_label + ".dash").as_bytes());
+
+        let salted_domain_hash = hash_double(salted_domain_buffer);
+
+        preorder_document.set("saltedDomainHash", salted_domain_hash.into());
+        document.set("preorderSalt", salt.into());
+
+        let documents_batch_create_preorder_transition =
+            BatchTransition::new_document_creation_transition_from_document(
+                preorder_document,
+                preorder,
+                entropy.0,
+                key,
+                2,
+                0,
+                None,
+                signer,
+                platform_version,
+                None,
+            )
+            .await
+            .expect("expect to create preorder batch transition");
+
+        let documents_batch_create_serialized_preorder_transition =
+            documents_batch_create_preorder_transition
+                .serialize_to_bytes()
+                .expect("expected preorder batch serialized state transition");
+
+        let documents_batch_create_transition =
+            BatchTransition::new_document_creation_transition_from_document(
+                document.clone(),
+                domain,
+                entropy.0,
+                key,
+                3,
+                0,
+                None,
+                signer,
+                platform_version,
+                None,
+            )
+            .await
+            .expect("expect to create domain batch transition");
+
+        let documents_batch_create_serialized_transition = documents_batch_create_transition
+            .serialize_to_bytes()
+            .expect("expected domain batch serialized state transition");
+
+        for serialized_transition in [
+            documents_batch_create_serialized_preorder_transition,
+            documents_batch_create_serialized_transition,
+        ] {
+            let transaction = platform.drive.grove.start_transaction();
+
+            let processing_result = platform
+                .platform
+                .process_raw_state_transitions(
+                    &[serialized_transition],
+                    &platform_state,
+                    &BlockInfo::default_with_time(
+                        platform_state
+                            .last_committed_block_time_ms()
+                            .unwrap_or_default()
+                            + 3000,
+                    ),
+                    &transaction,
+                    platform_version,
+                    false,
+                    None,
+                )
+                .expect("expected to process state transition");
+
+            assert_matches!(
+                processing_result.execution_results().as_slice(),
+                [StateTransitionExecutionResult::SuccessfulExecution { .. }]
+            );
+
+            platform
+                .drive
+                .grove
+                .commit_transaction(transaction)
+                .unwrap()
+                .expect("expected to commit transaction");
+        }
+
+        (document, dpns_contract)
+    }
+
+    /// Queries domain documents whose `records.identity` name record points to
+    /// the given identity.
+    fn query_domain_documents_by_record_identity(
+        platform: &TempPlatform<MockCoreRPCLike>,
+        dpns_contract: &DataContract,
+        identity_id: Identifier,
+    ) -> Vec<Document> {
+        let domain = dpns_contract
+            .document_type_for_name("domain")
+            .expect("expected the domain document type");
+
+        let drive_query = DriveDocumentQuery {
+            contract: dpns_contract,
+            document_type: domain,
+            internal_clauses: InternalClauses {
+                primary_key_in_clause: None,
+                primary_key_equal_clause: None,
+                in_clause: None,
+                range_clause: None,
+                equal_clauses: BTreeMap::from([(
+                    "records.identity".to_string(),
+                    WhereClause {
+                        field: "records.identity".to_string(),
+                        operator: WhereOperator::Equal,
+                        value: Value::Identifier(identity_id.to_buffer()),
+                    },
+                )]),
+            },
+            offset: None,
+            limit: None,
+            order_by: Default::default(),
+            start_at: None,
+            start_at_included: false,
+            block_time_ms: None,
+        };
+
+        platform
+            .drive
+            .query_documents(drive_query, None, false, None, None)
+            .expect("expected to query domain documents")
+            .documents_owned()
+    }
+
+    fn assert_identity_record(document: &Document, expected_identity_id: Identifier) {
+        let records = document
+            .properties()
+            .get("records")
+            .expect("expected the domain document to have records");
+
+        let record_identity = records
+            .get_optional_identifier("identity")
+            .expect("expected a valid identity record")
+            .expect("expected an identity record to be set");
+
+        assert_eq!(record_identity, expected_identity_id);
+    }
+
+    #[tokio::test]
+    async fn test_dpns_username_transfer() {
+        run_dpns_username_transfer_at_protocol_version(
+            PlatformVersion::latest().protocol_version,
+            true,
+        )
+        .await;
+    }
+
+    /// PROTOCOL_VERSION_12: domain transfers are still rejected by the
+    /// `reject_data_trigger` binding. Pinned so v12 chain history stays
+    /// bit-for-bit reproducible.
+    #[tokio::test]
+    async fn test_dpns_username_transfer_protocol_version_12_rejected() {
+        run_dpns_username_transfer_at_protocol_version(12, false).await;
+    }
+
+    async fn run_dpns_username_transfer_at_protocol_version(
+        protocol_version: ProtocolVersion,
+        expect_allowed: bool,
+    ) {
+        let mut platform = TestPlatformBuilder::new()
+            .with_initial_protocol_version(protocol_version)
+            .build_with_mock_rpc()
+            .set_genesis_state();
+
+        let platform_state = platform.state.load();
+        let platform_version = platform_state
+            .current_platform_version()
+            .expect("expected to get current platform version");
+
+        let mut rng = StdRng::seed_from_u64(437);
+
+        let alice = setup_identity(&mut platform, 958, dash_to_credits!(0.5));
+
+        let (bob, _, _) = setup_identity(&mut platform, 450, dash_to_credits!(0.5));
+
+        // "quantum7" contains a digit outside 0/1 so the name is not contested
+        let (mut document, dpns_contract) = register_dpns_username(
+            &mut platform,
+            &alice,
+            &mut rng,
+            "quantum7",
+            platform_version,
+        )
+        .await;
+
+        let (alice, signer, key) = &alice;
+
+        let domain = dpns_contract
+            .document_type_for_name("domain")
+            .expect("expected the domain document type");
+
+        document.set_revision(Some(2));
+
+        let documents_batch_transfer_transition =
+            BatchTransition::new_document_transfer_transition_from_document(
+                document,
+                domain,
+                bob.id(),
+                key,
+                4,
+                0,
+                None,
+                signer,
+                platform_version,
+                None,
+            )
+            .await
+            .expect("expect to create documents batch transition for transfer");
+
+        let documents_batch_transfer_serialized_transition = documents_batch_transfer_transition
+            .serialize_to_bytes()
+            .expect("expected documents batch serialized state transition");
+
+        let transaction = platform.drive.grove.start_transaction();
+
+        let processing_result = platform
+            .platform
+            .process_raw_state_transitions(
+                &[documents_batch_transfer_serialized_transition],
+                &platform_state,
+                &BlockInfo::default_with_time(
+                    platform_state
+                        .last_committed_block_time_ms()
+                        .unwrap_or_default()
+                        + 3000,
+                ),
+                &transaction,
+                platform_version,
+                false,
+                None,
+            )
+            .expect("expected to process state transition");
+
+        platform
+            .drive
+            .grove
+            .commit_transaction(transaction)
+            .unwrap()
+            .expect("expected to commit transaction");
+
+        if expect_allowed {
+            assert_matches!(
+                processing_result.execution_results().as_slice(),
+                [StateTransitionExecutionResult::SuccessfulExecution { .. }]
+            );
+
+            // The username must now belong to and resolve to Bob
+            let bob_documents =
+                query_domain_documents_by_record_identity(&platform, &dpns_contract, bob.id());
+
+            assert_eq!(bob_documents.len(), 1);
+
+            let transferred_document = bob_documents.first().expect("expected a document");
+
+            assert_eq!(transferred_document.owner_id(), bob.id());
+
+            assert_identity_record(transferred_document, bob.id());
+
+            // Alice must no longer have a name record pointing to her
+            let alice_documents =
+                query_domain_documents_by_record_identity(&platform, &dpns_contract, alice.id());
+
+            assert_eq!(alice_documents.len(), 0);
+        } else {
+            assert_matches!(
+                processing_result.execution_results().as_slice(),
+                [StateTransitionExecutionResult::PaidConsensusError {
+                    error: ConsensusError::StateError(StateError::DataTriggerError(
+                        DataTriggerError::DataTriggerConditionError(_)
+                    )),
+                    ..
+                }]
+            );
+
+            // The username must still belong to and resolve to Alice
+            let alice_documents =
+                query_domain_documents_by_record_identity(&platform, &dpns_contract, alice.id());
+
+            assert_eq!(alice_documents.len(), 1);
+
+            let kept_document = alice_documents.first().expect("expected a document");
+
+            assert_eq!(kept_document.owner_id(), alice.id());
+        }
+
+        let issues = platform
+            .drive
+            .grove
+            .visualize_verify_grovedb(None, true, false, &platform_version.drive.grove_version)
+            .expect("expected to have no issues");
+
+        assert_eq!(
+            issues.len(),
+            0,
+            "issues are {}",
+            issues
+                .iter()
+                .map(|(hash, (a, b, c))| format!("{}: {} {} {}", hash, a, b, c))
+                .collect::<Vec<_>>()
+                .join(" | ")
+        );
+    }
+
+    #[tokio::test]
+    async fn test_dpns_username_sale() {
+        run_dpns_username_sale_at_protocol_version(
+            PlatformVersion::latest().protocol_version,
+            true,
+        )
+        .await;
+    }
+
+    /// PROTOCOL_VERSION_12: setting a price on a domain document is still
+    /// rejected by the `reject_data_trigger` binding, so a sale can not even
+    /// be started. Pinned so v12 chain history stays bit-for-bit reproducible.
+    #[tokio::test]
+    async fn test_dpns_username_sale_protocol_version_12_rejected() {
+        run_dpns_username_sale_at_protocol_version(12, false).await;
+    }
+
+    async fn run_dpns_username_sale_at_protocol_version(
+        protocol_version: ProtocolVersion,
+        expect_allowed: bool,
+    ) {
+        let mut platform = TestPlatformBuilder::new()
+            .with_initial_protocol_version(protocol_version)
+            .build_with_mock_rpc()
+            .set_genesis_state();
+
+        let platform_state = platform.state.load();
+        let platform_version = platform_state
+            .current_platform_version()
+            .expect("expected to get current platform version");
+
+        let mut rng = StdRng::seed_from_u64(438);
+
+        let alice = setup_identity(&mut platform, 959, dash_to_credits!(0.5));
+
+        let (bob, bob_signer, bob_key) = setup_identity(&mut platform, 451, dash_to_credits!(0.5));
+
+        let (mut document, dpns_contract) = register_dpns_username(
+            &mut platform,
+            &alice,
+            &mut rng,
+            "quantum9",
+            platform_version,
+        )
+        .await;
+
+        let (alice, signer, key) = &alice;
+
+        let domain = dpns_contract
+            .document_type_for_name("domain")
+            .expect("expected the domain document type");
+
+        document.set_revision(Some(2));
+
+        let documents_batch_update_price_transition =
+            BatchTransition::new_document_update_price_transition_from_document(
+                document,
+                domain,
+                dash_to_credits!(0.1),
+                key,
+                4,
+                0,
+                None,
+                signer,
+                platform_version,
+                None,
+            )
+            .await
+            .expect("expect to create documents batch transition for the price update");
+
+        let documents_batch_update_price_serialized_transition =
+            documents_batch_update_price_transition
+                .serialize_to_bytes()
+                .expect("expected documents batch serialized state transition");
+
+        let transaction = platform.drive.grove.start_transaction();
+
+        let processing_result = platform
+            .platform
+            .process_raw_state_transitions(
+                &[documents_batch_update_price_serialized_transition],
+                &platform_state,
+                &BlockInfo::default_with_time(
+                    platform_state
+                        .last_committed_block_time_ms()
+                        .unwrap_or_default()
+                        + 3000,
+                ),
+                &transaction,
+                platform_version,
+                false,
+                None,
+            )
+            .expect("expected to process state transition");
+
+        platform
+            .drive
+            .grove
+            .commit_transaction(transaction)
+            .unwrap()
+            .expect("expected to commit transaction");
+
+        if !expect_allowed {
+            assert_matches!(
+                processing_result.execution_results().as_slice(),
+                [StateTransitionExecutionResult::PaidConsensusError {
+                    error: ConsensusError::StateError(StateError::DataTriggerError(
+                        DataTriggerError::DataTriggerConditionError(_)
+                    )),
+                    ..
+                }]
+            );
+
+            return;
+        }
+
+        assert_matches!(
+            processing_result.execution_results().as_slice(),
+            [StateTransitionExecutionResult::SuccessfulExecution { .. }]
+        );
+
+        // Read the listed document back so the purchase is built on the
+        // priced revision
+        let mut listed_documents =
+            query_domain_documents_by_record_identity(&platform, &dpns_contract, alice.id());
+
+        assert_eq!(listed_documents.len(), 1);
+
+        let mut document = listed_documents.remove(0);
+
+        let price: Credits = document
+            .properties()
+            .get_integer("$price")
+            .expect("expected to get back the price");
+
+        assert_eq!(price, dash_to_credits!(0.1));
+
+        document.set_revision(Some(3));
+
+        let documents_batch_purchase_transition =
+            BatchTransition::new_document_purchase_transition_from_document(
+                document,
+                domain,
+                bob.id(),
+                dash_to_credits!(0.1),
+                &bob_key,
+                1,
+                0,
+                None,
+                &bob_signer,
+                platform_version,
+                None,
+            )
+            .await
+            .expect("expect to create documents batch transition for the purchase");
+
+        let documents_batch_purchase_serialized_transition = documents_batch_purchase_transition
+            .serialize_to_bytes()
+            .expect("expected documents batch serialized state transition");
+
+        let transaction = platform.drive.grove.start_transaction();
+
+        let processing_result = platform
+            .platform
+            .process_raw_state_transitions(
+                &[documents_batch_purchase_serialized_transition],
+                &platform_state,
+                &BlockInfo::default_with_time(
+                    platform_state
+                        .last_committed_block_time_ms()
+                        .unwrap_or_default()
+                        + 3000,
+                ),
+                &transaction,
+                platform_version,
+                false,
+                None,
+            )
+            .expect("expected to process state transition");
+
+        platform
+            .drive
+            .grove
+            .commit_transaction(transaction)
+            .unwrap()
+            .expect("expected to commit transaction");
+
+        assert_matches!(
+            processing_result.execution_results().as_slice(),
+            [StateTransitionExecutionResult::SuccessfulExecution { .. }]
+        );
+
+        // The username must now belong to and resolve to Bob, and it must no
+        // longer be for sale
+        let bob_documents =
+            query_domain_documents_by_record_identity(&platform, &dpns_contract, bob.id());
+
+        assert_eq!(bob_documents.len(), 1);
+
+        let purchased_document = bob_documents.first().expect("expected a document");
+
+        assert_eq!(purchased_document.owner_id(), bob.id());
+
+        assert_identity_record(purchased_document, bob.id());
+
+        assert!(purchased_document.properties().get("$price").is_none());
+
+        let alice_documents =
+            query_domain_documents_by_record_identity(&platform, &dpns_contract, alice.id());
+
+        assert_eq!(alice_documents.len(), 0);
+
+        let issues = platform
+            .drive
+            .grove
+            .visualize_verify_grovedb(None, true, false, &platform_version.drive.grove_version)
+            .expect("expected to have no issues");
+
+        assert_eq!(
+            issues.len(),
+            0,
+            "issues are {}",
+            issues
+                .iter()
+                .map(|(hash, (a, b, c))| format!("{}: {} {} {}", hash, a, b, c))
+                .collect::<Vec<_>>()
+                .join(" | ")
+        );
+    }
+}

--- a/packages/rs-drive/src/state_transition_action/action_convert_to_operations/batch/document/document_purchase_transition.rs
+++ b/packages/rs-drive/src/state_transition_action/action_convert_to_operations/batch/document/document_purchase_transition.rs
@@ -106,11 +106,96 @@ impl DriveHighLevelBatchOperationConverter for DocumentPurchaseTransitionAction 
 
                 Ok(ops)
             }
+            1 => {
+                // PROTOCOL_VERSION_13: identical to v0 except a purchased
+                // DPNS domain document has its `records.identity` rewritten to
+                // the buyer so the username resolves to its new owner.
+                let data_contract_id = self.base().data_contract_id();
+                let document_type_name = self.base().document_type_name().clone();
+                let identity_contract_nonce = self.base().identity_contract_nonce();
+                let original_owner_id = self.original_owner_id();
+                let purchase_amount = self.price();
+                let contract_fetch_info = self.base().data_contract_fetch_info();
+
+                let contract_owner_id = contract_fetch_info.contract.owner_id();
+
+                let document_purchase_token_cost = self.base().token_cost();
+
+                let mut document = self.document_owned();
+
+                // we are purchasing the document so the new storage flags should be on the new owner
+
+                let new_document_owner_id = owner_id;
+
+                super::rewrite_dpns_domain_identity_record_to_new_owner(
+                    &mut document,
+                    data_contract_id,
+                    document_type_name.as_str(),
+                    new_document_owner_id,
+                )?;
+
+                let storage_flags = StorageFlags::new_single_epoch(
+                    epoch.index,
+                    Some(new_document_owner_id.to_buffer()),
+                );
+
+                let mut ops = vec![
+                    IdentityOperation(IdentityOperationType::UpdateIdentityContractNonce {
+                        identity_id: owner_id.into_buffer(),
+                        contract_id: data_contract_id.into_buffer(),
+                        nonce: identity_contract_nonce,
+                    }),
+                    DocumentOperation(DocumentOperationType::UpdateDocument {
+                        owned_document_info: OwnedDocumentInfo {
+                            document_info: DocumentOwnedInfo((
+                                document,
+                                Some(Cow::Owned(storage_flags)),
+                            )),
+                            owner_id: Some(new_document_owner_id.into_buffer()),
+                        },
+                        contract_info: DataContractInfo::DataContractFetchInfo(contract_fetch_info),
+                        document_type_info: DocumentTypeInfo::DocumentTypeName(document_type_name),
+                    }),
+                    IdentityOperation(IdentityOperationType::RemoveFromIdentityBalance {
+                        identity_id: owner_id.to_buffer(),
+                        balance_to_remove: purchase_amount,
+                    }),
+                    IdentityOperation(IdentityOperationType::AddToIdentityBalance {
+                        identity_id: original_owner_id.to_buffer(),
+                        added_balance: purchase_amount,
+                    }),
+                ];
+
+                if let Some((token_id, effect, cost)) = document_purchase_token_cost {
+                    match effect {
+                        DocumentActionTokenEffect::TransferTokenToContractOwner => {
+                            // If we are the owner, no need to send anything
+                            if owner_id != contract_owner_id {
+                                ops.push(TokenOperation(TokenOperationType::TokenTransfer {
+                                    token_id,
+                                    sender_id: owner_id,
+                                    recipient_id: contract_owner_id,
+                                    amount: cost,
+                                }));
+                            }
+                        }
+                        DocumentActionTokenEffect::BurnToken => {
+                            ops.push(TokenOperation(TokenOperationType::TokenBurn {
+                                token_id,
+                                identity_balance_holder_id: owner_id,
+                                burn_amount: cost,
+                            }));
+                        }
+                    }
+                }
+
+                Ok(ops)
+            }
             version => Err(Error::Drive(DriveError::UnknownVersionMismatch {
                 method:
                     "DocumentPurchaseTransitionAction::into_high_level_document_drive_operations"
                         .to_string(),
-                known_versions: vec![0],
+                known_versions: vec![0, 1],
                 received: version,
             })),
         }

--- a/packages/rs-drive/src/state_transition_action/action_convert_to_operations/batch/document/document_transfer_transition.rs
+++ b/packages/rs-drive/src/state_transition_action/action_convert_to_operations/batch/document/document_transfer_transition.rs
@@ -95,11 +95,84 @@ impl DriveHighLevelBatchOperationConverter for DocumentTransferTransitionAction 
 
                 Ok(ops)
             }
+            1 => {
+                // PROTOCOL_VERSION_13: identical to v0 except a transferred
+                // DPNS domain document has its `records.identity` rewritten to
+                // the new owner so the username resolves to its new owner.
+                let data_contract_id = self.base().data_contract_id();
+                let document_type_name = self.base().document_type_name().clone();
+                let identity_contract_nonce = self.base().identity_contract_nonce();
+                let contract_fetch_info = self.base().data_contract_fetch_info();
+                let contract_owner_id = contract_fetch_info.contract.owner_id();
+
+                let document_transfer_token_cost = self.base().token_cost();
+                let mut document = self.document_owned();
+
+                // we are transferring the document so the new storage flags should be on the new owner
+
+                let new_document_owner_id = document.owner_id();
+
+                super::rewrite_dpns_domain_identity_record_to_new_owner(
+                    &mut document,
+                    data_contract_id,
+                    document_type_name.as_str(),
+                    new_document_owner_id,
+                )?;
+
+                let storage_flags = StorageFlags::new_single_epoch(
+                    epoch.index,
+                    Some(new_document_owner_id.to_buffer()),
+                );
+
+                let mut ops = vec![
+                    IdentityOperation(IdentityOperationType::UpdateIdentityContractNonce {
+                        identity_id: owner_id.into_buffer(),
+                        contract_id: data_contract_id.into_buffer(),
+                        nonce: identity_contract_nonce,
+                    }),
+                    DocumentOperation(DocumentOperationType::UpdateDocument {
+                        owned_document_info: OwnedDocumentInfo {
+                            document_info: DocumentOwnedInfo((
+                                document,
+                                Some(Cow::Owned(storage_flags)),
+                            )),
+                            owner_id: Some(new_document_owner_id.into_buffer()),
+                        },
+                        contract_info: DataContractInfo::DataContractFetchInfo(contract_fetch_info),
+                        document_type_info: DocumentTypeInfo::DocumentTypeName(document_type_name),
+                    }),
+                ];
+
+                if let Some((token_id, effect, cost)) = document_transfer_token_cost {
+                    match effect {
+                        DocumentActionTokenEffect::TransferTokenToContractOwner => {
+                            // If we are the owner, no need to send anything
+                            if owner_id != contract_owner_id {
+                                ops.push(TokenOperation(TokenOperationType::TokenTransfer {
+                                    token_id,
+                                    sender_id: owner_id,
+                                    recipient_id: contract_owner_id,
+                                    amount: cost,
+                                }));
+                            }
+                        }
+                        DocumentActionTokenEffect::BurnToken => {
+                            ops.push(TokenOperation(TokenOperationType::TokenBurn {
+                                token_id,
+                                identity_balance_holder_id: owner_id,
+                                burn_amount: cost,
+                            }));
+                        }
+                    }
+                }
+
+                Ok(ops)
+            }
             version => Err(Error::Drive(DriveError::UnknownVersionMismatch {
                 method:
                     "DocumentTransferTransitionAction::into_high_level_document_drive_operations"
                         .to_string(),
-                known_versions: vec![0],
+                known_versions: vec![0, 1],
                 received: version,
             })),
         }

--- a/packages/rs-drive/src/state_transition_action/action_convert_to_operations/batch/document/mod.rs
+++ b/packages/rs-drive/src/state_transition_action/action_convert_to_operations/batch/document/mod.rs
@@ -6,3 +6,39 @@ mod document_transfer_transition;
 mod document_transition;
 mod document_update_price_transition;
 mod documents_batch_transition;
+
+use crate::error::Error;
+use dpp::document::{Document, DocumentV0Getters};
+use dpp::platform_value::Value;
+use dpp::prelude::Identifier;
+use dpp::system_data_contracts::dpns_contract;
+use dpp::system_data_contracts::dpns_contract::v1::document_types::domain;
+
+/// Rewrites the `records.identity` name record of a DPNS `domain` document to
+/// the document's new owner. Does nothing for any other document type.
+///
+/// A username resolves through `records.identity`, not through the document's
+/// `$ownerId`, and domain documents are immutable (`Replace` is rejected by a
+/// data trigger). Without this rewrite a transferred or purchased username
+/// would keep resolving to the previous owner's identity with no way for the
+/// new owner to repoint it.
+fn rewrite_dpns_domain_identity_record_to_new_owner(
+    document: &mut Document,
+    data_contract_id: Identifier,
+    document_type_name: &str,
+    new_owner_id: Identifier,
+) -> Result<(), Error> {
+    if data_contract_id != dpns_contract::ID || document_type_name != domain::NAME {
+        return Ok(());
+    }
+
+    document
+        .properties_mut()
+        .entry(domain::properties::RECORDS.to_string())
+        .or_insert_with(|| Value::Map(Vec::new()))
+        .set_value(
+            domain::properties::IDENTITY,
+            Value::Identifier(new_owner_id.into_buffer()),
+        )
+        .map_err(Error::Value)
+}

--- a/packages/rs-platform-version/src/version/drive_abci_versions/drive_abci_validation_versions/mod.rs
+++ b/packages/rs-platform-version/src/version/drive_abci_versions/drive_abci_validation_versions/mod.rs
@@ -6,6 +6,7 @@ pub mod v5;
 pub mod v6;
 pub mod v7;
 pub mod v8;
+pub mod v9;
 
 use versioned_feature_core::{FeatureVersion, OptionalFeatureVersion};
 

--- a/packages/rs-platform-version/src/version/drive_abci_versions/drive_abci_validation_versions/v9.rs
+++ b/packages/rs-platform-version/src/version/drive_abci_versions/drive_abci_validation_versions/v9.rs
@@ -1,0 +1,340 @@
+use crate::version::drive_abci_versions::drive_abci_validation_versions::{
+    DriveAbciAssetLockValidationVersions, DriveAbciDocumentsStateTransitionValidationVersions,
+    DriveAbciStateTransitionCommonValidationVersions, DriveAbciStateTransitionValidationVersion,
+    DriveAbciStateTransitionValidationVersions, DriveAbciValidationConstants,
+    DriveAbciValidationDataTriggerAndBindingVersions, DriveAbciValidationDataTriggerVersions,
+    DriveAbciValidationVersions, PenaltyAmounts,
+};
+
+// PROTOCOL_VERSION_13: bump data_triggers.bindings to v1, which drops the
+// reject bindings for Transfer, Purchase and UpdatePrice on DPNS `domain`
+// documents — enabling username transfers and sales. Replace and Delete stay
+// rejected. v8 (bindings: 0) remains for PROTOCOL_VERSION_12 chain replay.
+pub const DRIVE_ABCI_VALIDATION_VERSIONS_V9: DriveAbciValidationVersions =
+    DriveAbciValidationVersions {
+        state_transitions: DriveAbciStateTransitionValidationVersions {
+            common_validation_methods: DriveAbciStateTransitionCommonValidationVersions {
+                asset_locks: DriveAbciAssetLockValidationVersions {
+                    fetch_asset_lock_transaction_output_sync: 0,
+                    verify_asset_lock_is_not_spent_and_has_enough_balance: 0,
+                },
+                validate_identity_public_key_contract_bounds: 1,
+                validate_identity_public_key_ids_dont_exist_in_state: 0,
+                validate_identity_public_key_ids_exist_in_state: 0,
+                validate_state_transition_identity_signed: 0,
+                validate_unique_identity_public_key_hashes_in_state: 1,
+                validate_master_key_uniqueness: 0,
+                validate_non_masternode_identity_exists: 0,
+                validate_identity_exists: 0,
+            },
+            max_asset_lock_usage_attempts: 16,
+            identity_create_state_transition: DriveAbciStateTransitionValidationVersion {
+                basic_structure: Some(0),
+                advanced_structure: Some(0),
+                identity_signatures: Some(0),
+                nonce: None,
+                state: 0,
+                transform_into_action: 0,
+            },
+            identity_update_state_transition: DriveAbciStateTransitionValidationVersion {
+                basic_structure: Some(0),
+                advanced_structure: Some(0),
+                identity_signatures: Some(0),
+                nonce: Some(0),
+                state: 0,
+                transform_into_action: 0,
+            },
+            identity_top_up_state_transition: DriveAbciStateTransitionValidationVersion {
+                basic_structure: Some(0),
+                advanced_structure: None,
+                identity_signatures: None,
+                nonce: None,
+                state: 0,
+                transform_into_action: 0,
+            },
+            identity_credit_withdrawal_state_transition:
+                DriveAbciStateTransitionValidationVersion {
+                    // v1 adds config min_version enforcement: since protocol version 12, V0 config is no longer
+                    // accepted because it lacks sized_integer_types support.
+                    basic_structure: Some(1),
+                    advanced_structure: None,
+                    identity_signatures: None,
+                    nonce: Some(0),
+                    state: 0,
+                    transform_into_action: 0,
+                },
+            identity_credit_withdrawal_state_transition_purpose_matches_requirements: 0,
+            identity_credit_transfer_state_transition: DriveAbciStateTransitionValidationVersion {
+                basic_structure: Some(0),
+                advanced_structure: None,
+                identity_signatures: None,
+                nonce: Some(0),
+                state: 0,
+                transform_into_action: 0,
+            },
+            identity_credit_transfer_to_addresses_state_transition:
+                DriveAbciStateTransitionValidationVersion {
+                    basic_structure: Some(0),
+                    advanced_structure: None,
+                    identity_signatures: None,
+                    nonce: Some(0),
+                    state: 0,
+                    transform_into_action: 0,
+                },
+            masternode_vote_state_transition: DriveAbciStateTransitionValidationVersion {
+                basic_structure: None,
+                advanced_structure: Some(0),
+                identity_signatures: None,
+                nonce: Some(1),
+                state: 0,
+                transform_into_action: 0,
+            },
+            masternode_vote_state_transition_balance_pre_check: 0,
+            contract_create_state_transition: DriveAbciStateTransitionValidationVersion {
+                basic_structure: Some(1),
+                advanced_structure: Some(1),
+                identity_signatures: None,
+                nonce: Some(0),
+                state: 0,
+                transform_into_action: 0,
+            },
+            contract_update_state_transition: DriveAbciStateTransitionValidationVersion {
+                basic_structure: Some(1),
+                advanced_structure: None,
+                identity_signatures: None,
+                nonce: Some(0),
+                state: 0,
+                transform_into_action: 0,
+            },
+            batch_state_transition: DriveAbciDocumentsStateTransitionValidationVersions {
+                basic_structure: 0,
+                advanced_structure: 0,
+                state: 0,
+                revision: 0,
+                // PROTOCOL_VERSION_12 (v3.1 hard fork): batch state transition
+                // fee accounting fixes. This single field gates multiple
+                // related billing changes so they all activate together at
+                // the same hard fork. On v0 every behavior below is the
+                // legacy under-billing, preserved verbatim for
+                // PROTOCOL_VERSION_11 chain replay.
+                //
+                // Gated by `transform_into_action: 1`:
+                //   * B7 — outer `execution_context` is threaded through the
+                //     batch transformer (was a dropped local) so per-
+                //     transition fee_results in `try_into_action_v0` are
+                //     billed.
+                //   * B4 — `query_documents` cost in
+                //     `fetch_documents_for_transitions_knowing_contract_and_document_type`
+                //     is added to `execution_context`.
+                //   * B5 — `query_documents` cost in `fetch_document_with_id`
+                //     is added to `execution_context`.
+                //   * T1 — DPNS data trigger parent-domain
+                //     `query_documents` cost.
+                //   * T2 — DPNS data trigger preorder `query_documents` cost.
+                //   * T3 — DashPay data trigger recipient identity-balance
+                //     fetch cost (switched to `fetch_identity_balance_with_costs`).
+                //   * T4 — withdrawals data trigger `query_documents` cost.
+                transform_into_action: 1,
+                // PROTOCOL_VERSION_12 (v3.1 hard fork): per-transition
+                // failure paths in `transform_document_transition` now emit
+                // a `BumpIdentityDataContractNonce` action so the user pays
+                // for the validation work that already ran (fetch +
+                // ownership/revision check). v0 stays for chain
+                // reproducibility on PROTOCOL_VERSION_11 and below.
+                failed_per_transition_action: 1,
+                // PROTOCOL_VERSION_12 (v3.1 hard fork): fetch_documents
+                // helpers bumped to v1 which bill the grovedb cost of
+                // their query_documents calls. v0 stays for PV11 chain
+                // replay (the v0 helpers pass epoch=None and never call
+                // add_operation — byte-identical to pre-PR behavior).
+                fetch_documents_for_transitions_knowing_contract_and_document_type: 1,
+                fetch_document_with_id: 1,
+                data_triggers: DriveAbciValidationDataTriggerAndBindingVersions {
+                    // PROTOCOL_VERSION_13: v1 drops the reject bindings for
+                    // Transfer, Purchase and UpdatePrice on DPNS `domain`
+                    // documents, enabling username transfers and sales.
+                    bindings: 1,
+                    triggers: DriveAbciValidationDataTriggerVersions {
+                        // PROTOCOL_VERSION_12 (v3.1 hard fork): triggers
+                        // that perform drive reads now have `_v1` versions
+                        // that bill the cost via add_operation on the
+                        // outer execution_context. v0 versions remain
+                        // byte-identical to PV11 (don't bill).
+                        create_contact_request_data_trigger: 1,
+                        create_domain_data_trigger: 1,
+                        create_identity_data_trigger: 0,
+                        create_feature_flag_data_trigger: 0,
+                        create_masternode_reward_shares_data_trigger: 0,
+                        delete_withdrawal_data_trigger: 1,
+                        // Reject does no drive reads — stays at v0.
+                        reject_data_trigger: 0,
+                    },
+                },
+                is_allowed: 0,
+                document_create_transition_structure_validation: 0,
+                document_delete_transition_structure_validation: 0,
+                document_replace_transition_structure_validation: 0,
+                document_transfer_transition_structure_validation: 0,
+                document_purchase_transition_structure_validation: 0,
+                document_update_price_transition_structure_validation: 0,
+                document_base_transition_state_validation: 0,
+                document_create_transition_state_validation: 1,
+                document_delete_transition_state_validation: 0,
+                document_replace_transition_state_validation: 0,
+                document_transfer_transition_state_validation: 0,
+                document_purchase_transition_state_validation: 0,
+                document_update_price_transition_state_validation: 0,
+                token_mint_transition_structure_validation: 0,
+                token_burn_transition_structure_validation: 0,
+                token_transfer_transition_structure_validation: 0,
+                token_mint_transition_state_validation: 0,
+                token_burn_transition_state_validation: 0,
+                token_transfer_transition_state_validation: 0,
+                token_base_transition_structure_validation: 0,
+                token_base_transition_state_validation: 0,
+                token_freeze_transition_structure_validation: 0,
+                token_unfreeze_transition_structure_validation: 0,
+                token_freeze_transition_state_validation: 0,
+                token_unfreeze_transition_state_validation: 0,
+                token_destroy_frozen_funds_transition_structure_validation: 0,
+                token_destroy_frozen_funds_transition_state_validation: 0,
+                token_emergency_action_transition_structure_validation: 0,
+                token_emergency_action_transition_state_validation: 0,
+                token_config_update_transition_structure_validation: 0,
+                token_config_update_transition_state_validation: 0,
+                token_base_transition_group_action_validation: 0,
+                token_claim_transition_structure_validation: 0,
+                token_claim_transition_state_validation: 0,
+                token_direct_purchase_transition_structure_validation: 0,
+                token_direct_purchase_transition_state_validation: 0,
+                token_set_price_for_direct_purchase_transition_structure_validation: 0,
+                token_set_price_for_direct_purchase_transition_state_validation: 0,
+            },
+            identity_create_from_addresses_state_transition:
+                DriveAbciStateTransitionValidationVersion {
+                    basic_structure: Some(0),
+                    advanced_structure: Some(0),
+                    identity_signatures: Some(0),
+                    nonce: Some(0),
+                    state: 0,
+                    transform_into_action: 0,
+                },
+            identity_top_up_from_addresses_state_transition:
+                DriveAbciStateTransitionValidationVersion {
+                    basic_structure: Some(0),
+                    advanced_structure: None,
+                    identity_signatures: None,
+                    nonce: Some(0),
+                    state: 0,
+                    transform_into_action: 0,
+                },
+            address_credit_withdrawal: DriveAbciStateTransitionValidationVersion {
+                basic_structure: Some(0),
+                advanced_structure: None,
+                identity_signatures: None,
+                nonce: Some(0),
+                state: 0,
+                transform_into_action: 0,
+            },
+            address_funds_from_asset_lock: DriveAbciStateTransitionValidationVersion {
+                basic_structure: Some(0),
+                advanced_structure: Some(0),
+                identity_signatures: None,
+                nonce: Some(0),
+                state: 0,
+                transform_into_action: 0,
+            },
+            address_funds_transfer: DriveAbciStateTransitionValidationVersion {
+                basic_structure: Some(0),
+                advanced_structure: None,
+                identity_signatures: None,
+                nonce: Some(0),
+                state: 0,
+                transform_into_action: 0,
+            },
+            shield_state_transition: DriveAbciStateTransitionValidationVersion {
+                basic_structure: Some(0),
+                advanced_structure: None,
+                identity_signatures: None,
+                nonce: None,
+                state: 0,
+                transform_into_action: 0,
+            },
+            shielded_transfer_state_transition: DriveAbciStateTransitionValidationVersion {
+                basic_structure: Some(0),
+                advanced_structure: None,
+                identity_signatures: None,
+                nonce: None,
+                state: 0,
+                transform_into_action: 0,
+            },
+            unshield_state_transition: DriveAbciStateTransitionValidationVersion {
+                basic_structure: Some(0),
+                advanced_structure: None,
+                identity_signatures: None,
+                nonce: None,
+                state: 0,
+                transform_into_action: 0,
+            },
+            shield_from_asset_lock_state_transition: DriveAbciStateTransitionValidationVersion {
+                basic_structure: Some(0),
+                advanced_structure: None,
+                identity_signatures: None,
+                nonce: None,
+                state: 0,
+                transform_into_action: 0,
+            },
+            shielded_withdrawal_state_transition: DriveAbciStateTransitionValidationVersion {
+                basic_structure: Some(0),
+                advanced_structure: None,
+                identity_signatures: None,
+                nonce: None,
+                state: 0,
+                transform_into_action: 0,
+            },
+            identity_create_from_shielded_pool_state_transition:
+                DriveAbciStateTransitionValidationVersion {
+                    basic_structure: Some(0),
+                    advanced_structure: None,
+                    identity_signatures: None,
+                    nonce: None,
+                    state: 0,
+                    transform_into_action: 0,
+                },
+        },
+        has_nonce_validation: 1,
+        has_address_witness_validation: 0,
+        validate_address_witnesses: 0,
+        validate_shielded_proof: 0,
+        validate_minimum_shielded_fee: 0,
+        process_state_transition: 0,
+        state_transition_to_execution_event_for_check_tx: 0,
+        penalties: PenaltyAmounts {
+            identity_id_not_correct: 50000000,
+            unique_key_already_present: 10000000,
+            validation_of_added_keys_structure_failure: 10000000,
+            validation_of_added_keys_proof_of_possession_failure: 50000000,
+            address_funds_insufficient_balance: 10000000,
+            shielded_proof_verification_failure: 50000000,
+        },
+        event_constants: DriveAbciValidationConstants {
+            maximum_vote_polls_to_process: 2,
+            maximum_contenders_to_consider: 100,
+            minimum_pool_notes_for_outgoing: 250,
+            shielded_anchor_retention_blocks: 1000,
+            shielded_anchor_pruning_interval: 100,
+            shielded_proof_verification_fee: 100_000_000,
+            // Per-action processing prices the ~1.1 ms/action Halo 2 verification CPU at the
+            // same rate the flat fee prices the ~5 ms base (100M ≈ 4.5× this), so the fee
+            // tracks the per-action cost and the margin stays uniform as actions grow.
+            shielded_per_action_processing_fee: 22_000_000,
+            shielded_implicit_fee_cap: 20_000_000_000,
+            // 0.1, 0.3, 0.5, 1.0 DASH in credits (1 DASH = 10^8 duffs, CREDITS_PER_DUFF = 1000).
+            shielded_identity_create_denominations: &[
+                10_000_000_000,
+                30_000_000_000,
+                50_000_000_000,
+                100_000_000_000,
+            ],
+        },
+    };

--- a/packages/rs-platform-version/src/version/drive_versions/drive_state_transition_method_versions/mod.rs
+++ b/packages/rs-platform-version/src/version/drive_versions/drive_state_transition_method_versions/mod.rs
@@ -1,5 +1,6 @@
 pub mod v1;
 pub mod v2;
+pub mod v3;
 
 use crate::version::drive_versions::DriveDataContractOperationMethodVersions;
 use versioned_feature_core::FeatureVersion;

--- a/packages/rs-platform-version/src/version/drive_versions/drive_state_transition_method_versions/v3.rs
+++ b/packages/rs-platform-version/src/version/drive_versions/drive_state_transition_method_versions/v3.rs
@@ -1,0 +1,64 @@
+use crate::version::drive_versions::drive_state_transition_method_versions::{
+    DriveStateTransitionActionConvertToHighLevelOperationsMethodVersions,
+    DriveStateTransitionMethodVersions, DriveStateTransitionOperationMethodVersions,
+};
+use crate::version::drive_versions::DriveDataContractOperationMethodVersions;
+
+// This started at protocol 13
+pub const DRIVE_STATE_TRANSITION_METHOD_VERSIONS_V3: DriveStateTransitionMethodVersions =
+    DriveStateTransitionMethodVersions {
+        operations: DriveStateTransitionOperationMethodVersions {
+            finalization_tasks: 0,
+            contracts: DriveDataContractOperationMethodVersions {
+                finalization_tasks: 0,
+            },
+        },
+        convert_to_high_level_operations:
+            DriveStateTransitionActionConvertToHighLevelOperationsMethodVersions {
+                data_contract_create_transition: 0,
+                data_contract_update_transition: 0,
+                document_create_transition: 0,
+                document_delete_transition: 0,
+                // PROTOCOL_VERSION_13: v1 rewrites a transferred or purchased
+                // DPNS domain document's `records.identity` to the new owner
+                // so the username resolves to the buyer. v0 stays for
+                // PROTOCOL_VERSION_12 chain replay.
+                document_purchase_transition: 1, // changed
+                document_replace_transition: 0,
+                document_transfer_transition: 1, // changed
+                document_update_price_transition: 0,
+                token_burn_transition: 0,
+                token_mint_transition: 0,
+                token_transfer_transition: 0,
+                documents_batch_transition: 0,
+                identity_create_transition: 0,
+                identity_create_from_addresses_transition: 0,
+                identity_credit_transfer_transition: 0,
+                identity_credit_withdrawal_transition: 0,
+                identity_top_up_transition: 0,
+                identity_top_up_from_addresses_transition: 0,
+                identity_update_transition: 1, //changed
+                masternode_vote_transition: 0,
+                bump_identity_data_contract_nonce: 0,
+                bump_identity_nonce: 0,
+                partially_use_asset_lock: 0,
+                token_freeze_transition: 0,
+                token_unfreeze_transition: 0,
+                token_emergency_action_transition: 0,
+                token_destroy_frozen_funds_transition: 0,
+                token_config_update_transition: 0,
+                token_claim_transition: 0,
+                token_direct_purchase_transition: 0,
+                token_set_price_for_direct_purchase_transition: 0,
+                identity_credit_transfer_to_addresses_transition: 0,
+                address_funds_transfer_transition: 0,
+                address_credit_withdrawal_transition: 0,
+                address_funding_from_asset_lock_transition: 0,
+                shield_transition: 0,
+                shield_from_asset_lock_transition: 0,
+                shielded_transfer_transition: 0,
+                unshield_transition: 0,
+                shielded_withdrawal_transition: 0,
+                identity_create_from_shielded_pool_transition: 0,
+            },
+    };

--- a/packages/rs-platform-version/src/version/drive_versions/drive_state_transition_method_versions/v3.rs
+++ b/packages/rs-platform-version/src/version/drive_versions/drive_state_transition_method_versions/v3.rs
@@ -37,7 +37,7 @@ pub const DRIVE_STATE_TRANSITION_METHOD_VERSIONS_V3: DriveStateTransitionMethodV
                 identity_credit_withdrawal_transition: 0,
                 identity_top_up_transition: 0,
                 identity_top_up_from_addresses_transition: 0,
-                identity_update_transition: 1, //changed
+                identity_update_transition: 1,
                 masternode_vote_transition: 0,
                 bump_identity_data_contract_nonce: 0,
                 bump_identity_nonce: 0,

--- a/packages/rs-platform-version/src/version/drive_versions/mod.rs
+++ b/packages/rs-platform-version/src/version/drive_versions/mod.rs
@@ -34,6 +34,7 @@ pub mod v4;
 pub mod v5;
 pub mod v6;
 pub mod v7;
+pub mod v8;
 
 #[derive(Clone, Debug, Default)]
 pub struct DriveVersion {

--- a/packages/rs-platform-version/src/version/drive_versions/v8.rs
+++ b/packages/rs-platform-version/src/version/drive_versions/v8.rs
@@ -1,0 +1,131 @@
+use crate::version::drive_versions::drive_address_funds_method_versions::v2::DRIVE_ADDRESS_FUNDS_METHOD_VERSIONS_V2;
+use crate::version::drive_versions::drive_contract_method_versions::v3::DRIVE_CONTRACT_METHOD_VERSIONS_V3;
+use crate::version::drive_versions::drive_credit_pool_method_versions::v1::CREDIT_POOL_METHOD_VERSIONS_V1;
+use crate::version::drive_versions::drive_document_method_versions::v3::DRIVE_DOCUMENT_METHOD_VERSIONS_V3;
+use crate::version::drive_versions::drive_group_method_versions::v1::DRIVE_GROUP_METHOD_VERSIONS_V1;
+use crate::version::drive_versions::drive_group_method_versions::DriveShieldedMethodVersions;
+use crate::version::drive_versions::drive_grove_method_versions::v1::DRIVE_GROVE_METHOD_VERSIONS_V1;
+use crate::version::drive_versions::drive_identity_method_versions::v1::DRIVE_IDENTITY_METHOD_VERSIONS_V1;
+use crate::version::drive_versions::drive_state_transition_method_versions::v3::DRIVE_STATE_TRANSITION_METHOD_VERSIONS_V3;
+use crate::version::drive_versions::drive_structure_version::v1::DRIVE_STRUCTURE_V1;
+use crate::version::drive_versions::drive_token_method_versions::v1::DRIVE_TOKEN_METHOD_VERSIONS_V1;
+use crate::version::drive_versions::drive_verify_method_versions::v1::DRIVE_VERIFY_METHOD_VERSIONS_V1;
+use crate::version::drive_versions::drive_vote_method_versions::v2::DRIVE_VOTE_METHOD_VERSIONS_V2;
+use crate::version::drive_versions::{
+    DriveAssetLockMethodVersions, DriveBalancesMethodVersions, DriveBatchOperationsMethodVersion,
+    DriveEstimatedCostsMethodVersions, DriveFeesMethodVersions, DriveFetchMethodVersions,
+    DriveInitializationMethodVersions, DriveMethodVersions, DriveOperationsMethodVersion,
+    DrivePlatformStateMethodVersions, DrivePlatformSystemMethodVersions,
+    DrivePrefundedSpecializedMethodVersions, DriveProtocolUpgradeVersions,
+    DriveProveMethodVersions, DriveSavedBlockTransactionsMethodVersions,
+    DriveSystemEstimationCostsMethodVersions, DriveVersion,
+};
+use grovedb_version::version::v3::GROVE_V3;
+
+/// Drive version 8.
+/// This was introduced in protocol v13 for DPNS username transfers and sales.
+pub const DRIVE_VERSION_V8: DriveVersion = DriveVersion {
+    structure: DRIVE_STRUCTURE_V1,
+    methods: DriveMethodVersions {
+        initialization: DriveInitializationMethodVersions {
+            create_initial_state_structure: 3, // changed: adds shielded pool trees (commitment tree, nullifiers, anchors)
+        },
+        credit_pools: CREDIT_POOL_METHOD_VERSIONS_V1,
+        protocol_upgrade: DriveProtocolUpgradeVersions {
+            clear_version_information: 0,
+            fetch_versions_with_counter: 0,
+            fetch_proved_versions_with_counter: 0,
+            fetch_validator_version_votes: 0,
+            fetch_proved_validator_version_votes: 0,
+            remove_validators_proposed_app_versions: 0,
+            update_validator_proposed_app_version: 0,
+        },
+        prove: DriveProveMethodVersions {
+            prove_elements: 0,
+            prove_multiple_state_transition_results: 0,
+            prove_state_transition: 0,
+        },
+        balances: DriveBalancesMethodVersions {
+            add_to_system_credits: 0,
+            add_to_system_credits_operations: 0,
+            remove_from_system_credits: 0,
+            remove_from_system_credits_operations: 0,
+            calculate_total_credits_balance: 2, // ShieldedBalances root tree adds a fifth term to the equation
+        },
+        document: DRIVE_DOCUMENT_METHOD_VERSIONS_V3,
+        vote: DRIVE_VOTE_METHOD_VERSIONS_V2,
+        contract: DRIVE_CONTRACT_METHOD_VERSIONS_V3, // changed: count-tree-aware contract-insertion cost estimation (v12+ countable/range_countable doctypes)
+        fees: DriveFeesMethodVersions { calculate_fee: 0 },
+        estimated_costs: DriveEstimatedCostsMethodVersions {
+            add_estimation_costs_for_levels_up_to_contract: 0,
+            add_estimation_costs_for_levels_up_to_contract_document_type_excluded: 0,
+            add_estimation_costs_for_contested_document_tree_levels_up_to_contract: 0,
+            add_estimation_costs_for_contested_document_tree_levels_up_to_contract_document_type_excluded: 0,
+        },
+        asset_lock: DriveAssetLockMethodVersions {
+            add_asset_lock_outpoint: 0,
+            add_estimation_costs_for_adding_asset_lock: 0,
+            fetch_asset_lock_outpoint_info: 0,
+        },
+        verify: DRIVE_VERIFY_METHOD_VERSIONS_V1,
+        identity: DRIVE_IDENTITY_METHOD_VERSIONS_V1,
+        token: DRIVE_TOKEN_METHOD_VERSIONS_V1,
+        platform_system: DrivePlatformSystemMethodVersions {
+            estimation_costs: DriveSystemEstimationCostsMethodVersions {
+                for_total_system_credits_update: 0,
+            },
+        },
+        operations: DriveOperationsMethodVersion {
+            rollback_transaction: 0,
+            drop_cache: 0,
+            commit_transaction: 0,
+            apply_partial_batch_low_level_drive_operations: 0,
+            apply_partial_batch_grovedb_operations: 0,
+            apply_batch_low_level_drive_operations: 0,
+            apply_batch_grovedb_operations: 0,
+        },
+        state_transitions: DRIVE_STATE_TRANSITION_METHOD_VERSIONS_V3, // changed: DPNS domain records.identity rewrite on transfer/purchase
+        batch_operations: DriveBatchOperationsMethodVersion {
+            convert_drive_operations_to_grove_operations: 0,
+            apply_drive_operations: 0,
+        },
+        platform_state: DrivePlatformStateMethodVersions {
+            fetch_platform_state_bytes: 0,
+            store_platform_state_bytes: 0,
+        },
+        fetch: DriveFetchMethodVersions { fetch_elements: 0 },
+        prefunded_specialized_balances: DrivePrefundedSpecializedMethodVersions {
+            fetch_single: 0,
+            prove_single: 0,
+            add_prefunded_specialized_balance: 0,
+            add_prefunded_specialized_balance_operations: 1,
+            deduct_from_prefunded_specialized_balance: 1,
+            deduct_from_prefunded_specialized_balance_operations: 0,
+            estimated_cost_for_prefunded_specialized_balance_update: 0,
+            empty_prefunded_specialized_balance: 0,
+        },
+        group: DRIVE_GROUP_METHOD_VERSIONS_V1,
+        address_funds: DRIVE_ADDRESS_FUNDS_METHOD_VERSIONS_V2,
+        shielded: DriveShieldedMethodVersions {
+            insert_note: 0,
+            insert_nullifiers: 0,
+            update_total_balance: 0,
+            record_anchor_if_changed: 0,
+            prune_anchors: 0,
+            has_anchor: 0,
+            has_nullifier: 0,
+            read_total_balance: 0,
+            notes_count: 0,
+        },
+        saved_block_transactions: DriveSavedBlockTransactionsMethodVersions {
+            store_address_balances: 0,
+            fetch_address_balances: 0,
+            compact_address_balances: 0,
+            cleanup_expired_address_balances: 0,
+            max_blocks_before_compaction: 64,
+            max_addresses_before_compaction: 2048,
+        },
+    },
+    grove_methods: DRIVE_GROVE_METHOD_VERSIONS_V1,
+    grove_version: GROVE_V3, // changed in v7: upgraded for shielded transaction support
+};

--- a/packages/rs-platform-version/src/version/v13.rs
+++ b/packages/rs-platform-version/src/version/v13.rs
@@ -18,10 +18,10 @@ use crate::version::drive_abci_versions::drive_abci_checkpoint_parameters::v1::D
 use crate::version::drive_abci_versions::drive_abci_method_versions::v8::DRIVE_ABCI_METHOD_VERSIONS_V8;
 use crate::version::drive_abci_versions::drive_abci_query_versions::v1::DRIVE_ABCI_QUERY_VERSIONS_V1;
 use crate::version::drive_abci_versions::drive_abci_structure_versions::v1::DRIVE_ABCI_STRUCTURE_VERSIONS_V1;
-use crate::version::drive_abci_versions::drive_abci_validation_versions::v8::DRIVE_ABCI_VALIDATION_VERSIONS_V8;
+use crate::version::drive_abci_versions::drive_abci_validation_versions::v9::DRIVE_ABCI_VALIDATION_VERSIONS_V9;
 use crate::version::drive_abci_versions::drive_abci_withdrawal_constants::v2::DRIVE_ABCI_WITHDRAWAL_CONSTANTS_V2;
 use crate::version::drive_abci_versions::DriveAbciVersion;
-use crate::version::drive_versions::v7::DRIVE_VERSION_V7;
+use crate::version::drive_versions::v8::DRIVE_VERSION_V8;
 use crate::version::fee::v2::FEE_VERSION2;
 use crate::version::protocol_version::PlatformVersion;
 use crate::version::system_data_contract_versions::v1::SYSTEM_DATA_CONTRACT_VERSIONS_V1;
@@ -32,18 +32,24 @@ pub const PROTOCOL_VERSION_13: ProtocolVersion = 13;
 
 /// Introduced as the activation gate for recording shielded-spend transparent
 /// credits (Unshield / shield surplus / identity-create fallback) into the
-/// recent-address-balance-changes tree. Functionally identical to v12 at
-/// introduction — the same component version structs, no behavior change. The
-/// consensus change that consumes this gate (a bumped drive-abci methods
-/// struct) lands in a follow-up; keeping v13 == v12 here lets mixed-version
-/// validators agree until that change activates.
+/// recent-address-balance-changes tree. The consensus change that consumes
+/// that gate (a bumped drive-abci methods struct) lands in a follow-up.
+///
+/// v13 also enables DPNS username transfers and sales:
+/// * `DRIVE_ABCI_VALIDATION_VERSIONS_V9` bumps data trigger bindings to v1,
+///   dropping the reject bindings for Transfer, Purchase and UpdatePrice on
+///   DPNS `domain` documents.
+/// * `DRIVE_VERSION_V8` bumps the document transfer/purchase high-level
+///   operation conversions to v1, which rewrite a transferred or purchased
+///   domain's `records.identity` to the new owner so the username resolves
+///   to the buyer.
 pub const PLATFORM_V13: PlatformVersion = PlatformVersion {
     protocol_version: PROTOCOL_VERSION_13,
-    drive: DRIVE_VERSION_V7,
+    drive: DRIVE_VERSION_V8, // changed: DPNS domain records.identity rewrite on transfer/purchase
     drive_abci: DriveAbciVersion {
         structs: DRIVE_ABCI_STRUCTURE_VERSIONS_V1,
         methods: DRIVE_ABCI_METHOD_VERSIONS_V8,
-        validation_and_processing: DRIVE_ABCI_VALIDATION_VERSIONS_V8,
+        validation_and_processing: DRIVE_ABCI_VALIDATION_VERSIONS_V9, // changed: allow DPNS domain transfer/purchase/update-price
         withdrawal_constants: DRIVE_ABCI_WITHDRAWAL_CONSTANTS_V2,
         query: DRIVE_ABCI_QUERY_VERSIONS_V1,
         checkpoints: DRIVE_ABCI_CHECKPOINT_PARAMETERS_V1,


### PR DESCRIPTION
## Issue being fixed or feature implemented

DPNS usernames could not change hands: even though the DPNS `domain` document type has declared `transferable: 1` and `tradeMode: 1` (direct purchase) since genesis, data triggers unconditionally rejected `Transfer`, `Purchase` and `UpdatePrice` on domain documents. On top of that, a username resolves through `records.identity` — not through the document's `$ownerId` — and domain documents are immutable, so even if a transfer had been allowed, the name would have kept resolving to the previous owner with no way for the new owner to repoint it.

This PR enables username transfers and sales as of protocol version 13.

## What was done?

- **Data trigger bindings list v1** (`rs-drive-abci`): drops the reject bindings for `Transfer`, `Purchase` and `UpdatePrice` on DPNS `domain` documents, letting the generic document validation paths (which already honor `transferable`/`tradeMode`) accept these transitions. `Replace` and `Delete` stay rejected — name records remain immutable and permanent.
- **`records.identity` rewrite** (`rs-drive`): v1 of the document transfer and purchase high-level operation conversions rewrites a transferred or purchased domain document's `records.identity` to the new owner as part of the same batch operation, so the username resolves to the buyer atomically. All other document types are unaffected.
- **Platform version wiring** (`rs-platform-version`): new `DRIVE_ABCI_VALIDATION_VERSIONS_V9` (bindings: 1), `DRIVE_STATE_TRANSITION_METHOD_VERSIONS_V3` (transfer/purchase conversion: 1) and `DRIVE_VERSION_V8`, consumed by `PLATFORM_V13`. Protocol versions ≤ 12 keep the old structs for chain replay.
- **DPNS contract**: added the `identity` property-name constant used by the rewrite.

## How Has This Been Tested?

New drive-abci execution tests in `batch/tests/document/dpns.rs` (`dpns_username_transfer_tests`):

- `test_dpns_username_transfer` — registers a name, transfers the domain document to a second identity under PV13, and asserts the processed document's owner **and** `records.identity` both point to the recipient.
- `test_dpns_username_sale` — sets a price with `UpdatePrice`, purchases with a second identity, and asserts ownership, `records.identity` rewrite, and the seller's balance credit.
- `test_dpns_username_transfer_protocol_version_12_rejected` / `test_dpns_username_sale_protocol_version_12_rejected` — the same flows under PV12 still hit the reject data trigger, proving activation is gated on PV13.

All 9 DPNS-related drive-abci tests pass; `cargo clippy` on the touched crates and `cargo fmt --all` are clean.

## Breaking Changes

Consensus-breaking at protocol version 13 activation: nodes without this change would reject DPNS domain transfer/purchase/update-price transitions (and would not perform the `records.identity` rewrite) that nodes with this change accept once PV13 activates. No behavior change for protocol versions ≤ 12.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [ ] I have made corresponding changes to the documentation if needed

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added protocol support for DPNS domain transfers, purchases, and versioned data-trigger bindings.
  - Domain identity records now automatically rewrite to the new owner as part of supported actions.
  - Updated platform configuration for protocol 13, including Drive version and validation gating updates.

- **Bug Fixes**
  - Improved DPNS ownership and identity consistency after domain transfer and sale.

- **Tests**
  - Added protocol-aware DPNS username transfer/sale coverage, including explicit checks for rejected Replace/Delete scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->