### PR TITLE
fix(platform-value): reject lossy CBOR integer conversions

### DIFF
--- a/packages/rs-platform-value/src/converter/ciborium.rs
+++ b/packages/rs-platform-value/src/converter/ciborium.rs
@@ -155,6 +155,8 @@ mod tests {
     use ciborium::value::Integer;
     use ciborium::Value as CborValue;
 
+    const MIN_NATIVE_CBOR_INTEGER: i128 = -(u64::MAX as i128) - 1;
+
     // -----------------------------------------------------------------------
     // Round-trip: Value -> CborValue -> Value for basic types
     // -----------------------------------------------------------------------
@@ -397,8 +399,6 @@ mod tests {
 
     #[test]
     fn i128_preserves_the_full_native_cbor_integer_range() {
-        const MIN_NATIVE_CBOR_INTEGER: i128 = -(u64::MAX as i128) - 1;
-
         for value in [
             MIN_NATIVE_CBOR_INTEGER,
             i64::MIN as i128,
@@ -415,8 +415,6 @@ mod tests {
 
     #[test]
     fn i128_rejects_values_outside_the_native_cbor_integer_range() {
-        const MIN_NATIVE_CBOR_INTEGER: i128 = -(u64::MAX as i128) - 1;
-
         for value in [
             MIN_NATIVE_CBOR_INTEGER - 1,
             u64::MAX as i128 + 1,
@@ -595,8 +593,6 @@ mod tests {
 
     #[test]
     fn to_cbor_buffer_roundtrips_native_cbor_integer_boundaries() {
-        const MIN_NATIVE_CBOR_INTEGER: i128 = -(u64::MAX as i128) - 1;
-
         for value in [
             MIN_NATIVE_CBOR_INTEGER,
             i64::MIN as i128 - 1,

--- a/packages/rs-platform-value/src/converter/ciborium.rs
+++ b/packages/rs-platform-value/src/converter/ciborium.rs
@@ -374,6 +374,10 @@ mod tests {
         let val = Value::U128(42);
         let cbor: CborValue = val.try_into().unwrap();
         assert_eq!(cbor, CborValue::Integer(42u64.into()));
+
+        let max_native = Value::U128(u64::MAX as u128);
+        let cbor: CborValue = max_native.try_into().unwrap();
+        assert_eq!(cbor, CborValue::Integer(u64::MAX.into()));
     }
 
     #[test]
@@ -385,10 +389,6 @@ mod tests {
 
     #[test]
     fn u128_rejects_values_outside_the_native_cbor_integer_range() {
-        let max_native = Value::U128(u64::MAX as u128);
-        let cbor: CborValue = max_native.try_into().unwrap();
-        assert_eq!(cbor, CborValue::Integer(u64::MAX.into()));
-
         for value in [u64::MAX as u128 + 1, u128::MAX] {
             let result: Result<CborValue, Error> = Value::U128(value).try_into();
             assert_eq!(result.unwrap_err(), Error::IntegerSizeError);
@@ -591,6 +591,23 @@ mod tests {
         let val = Value::Text("cbor buffer test".into());
         let buf = val.to_cbor_buffer().unwrap();
         assert!(!buf.is_empty());
+    }
+
+    #[test]
+    fn to_cbor_buffer_roundtrips_native_cbor_integer_boundaries() {
+        const MIN_NATIVE_CBOR_INTEGER: i128 = -(u64::MAX as i128) - 1;
+
+        for value in [
+            MIN_NATIVE_CBOR_INTEGER,
+            i64::MIN as i128 - 1,
+            i64::MAX as i128 + 1,
+            u64::MAX as i128,
+        ] {
+            let buf = Value::I128(value).to_cbor_buffer().unwrap();
+            let cbor: CborValue = ciborium::de::from_reader(buf.as_slice()).unwrap();
+            let decoded: Value = cbor.try_into().unwrap();
+            assert_eq!(decoded, Value::I128(value));
+        }
     }
 
     // -----------------------------------------------------------------------

--- a/packages/rs-platform-value/src/converter/ciborium.rs
+++ b/packages/rs-platform-value/src/converter/ciborium.rs
@@ -90,8 +90,12 @@ impl TryInto<CborValue> for Value {
 
     fn try_into(self) -> Result<CborValue, Self::Error> {
         Ok(match self {
-            Value::U128(i) => CborValue::Integer((i as u64).into()),
-            Value::I128(i) => CborValue::Integer((i as i64).into()),
+            Value::U128(i) => {
+                CborValue::Integer(Integer::try_from(i).map_err(|_| Error::IntegerSizeError)?)
+            }
+            Value::I128(i) => {
+                CborValue::Integer(Integer::try_from(i).map_err(|_| Error::IntegerSizeError)?)
+            }
             Value::U64(i) => CborValue::Integer(i.into()),
             Value::I64(i) => CborValue::Integer(i.into()),
             Value::U32(i) => CborValue::Integer(i.into()),
@@ -362,23 +366,77 @@ mod tests {
     }
 
     // -----------------------------------------------------------------------
-    // U128 / I128 narrowing in TryInto<CborValue>
+    // U128 / I128 conversion in TryInto<CborValue>
     // -----------------------------------------------------------------------
 
     #[test]
-    fn u128_narrowed_to_u64_in_cbor() {
-        // U128 is cast to u64 when converting to CborValue::Integer
+    fn u128_in_native_range_converts_to_cbor() {
         let val = Value::U128(42);
         let cbor: CborValue = val.try_into().unwrap();
         assert_eq!(cbor, CborValue::Integer(42u64.into()));
     }
 
     #[test]
-    fn i128_narrowed_to_i64_in_cbor() {
-        // I128 is cast to i64 when converting to CborValue::Integer
+    fn i128_in_native_range_converts_to_cbor() {
         let val = Value::I128(-99);
         let cbor: CborValue = val.try_into().unwrap();
         assert_eq!(cbor, CborValue::Integer((-99i64).into()));
+    }
+
+    #[test]
+    fn u128_rejects_values_outside_the_native_cbor_integer_range() {
+        let max_native = Value::U128(u64::MAX as u128);
+        let cbor: CborValue = max_native.try_into().unwrap();
+        assert_eq!(cbor, CborValue::Integer(u64::MAX.into()));
+
+        for value in [u64::MAX as u128 + 1, u128::MAX] {
+            let result: Result<CborValue, Error> = Value::U128(value).try_into();
+            assert_eq!(result.unwrap_err(), Error::IntegerSizeError);
+        }
+    }
+
+    #[test]
+    fn i128_preserves_the_full_native_cbor_integer_range() {
+        const MIN_NATIVE_CBOR_INTEGER: i128 = -(u64::MAX as i128) - 1;
+
+        for value in [
+            MIN_NATIVE_CBOR_INTEGER,
+            i64::MIN as i128,
+            i64::MAX as i128,
+            u64::MAX as i128,
+        ] {
+            let cbor: CborValue = Value::I128(value).try_into().unwrap();
+            let CborValue::Integer(integer) = cbor else {
+                panic!("expected CBOR integer");
+            };
+            assert_eq!(i128::from(integer), value);
+        }
+    }
+
+    #[test]
+    fn i128_rejects_values_outside_the_native_cbor_integer_range() {
+        const MIN_NATIVE_CBOR_INTEGER: i128 = -(u64::MAX as i128) - 1;
+
+        for value in [
+            MIN_NATIVE_CBOR_INTEGER - 1,
+            u64::MAX as i128 + 1,
+            i128::MIN,
+            i128::MAX,
+        ] {
+            let result: Result<CborValue, Error> = Value::I128(value).try_into();
+            assert_eq!(result.unwrap_err(), Error::IntegerSizeError);
+        }
+    }
+
+    #[test]
+    fn nested_out_of_range_integer_fails_the_entire_conversion() {
+        let value = Value::Array(vec![Value::Map(vec![(
+            Value::Text("amount".to_string()),
+            Value::U128(u64::MAX as u128 + 1),
+        )])]);
+
+        let result: Result<CborValue, Error> = value.try_into();
+        assert_eq!(result.unwrap_err(), Error::IntegerSizeError);
     }
 
     // -----------------------------------------------------------------------


### PR DESCRIPTION
## What

- replace unchecked 128-bit CBOR integer narrowing with checked native-range conversion
- preserve the full native CBOR signed and unsigned integer range
- reject out-of-range values before nested maps or arrays can emit altered data
- add boundary, round-trip, collision-prevention, and nested-container regressions

## Why

Distinct Platform Value integers could previously serialize to the same CBOR integer, and some native CBOR values could change sign during a decode/re-encode cycle. The conversion now fails closed with the existing IntegerSizeError.

This covers PLATFORM-DS-CAND-366 and PLATFORM-DS-CAND-367.

## Checks

- cargo fmt --all -- --check
- cargo test -p platform-value --features cbor --lib --tests (1,316 passed)
- cargo clippy -p platform-value --features cbor --all-targets -- -D warnings

The complete package command also ran all unit and integration tests successfully; its unrelated pre-existing doctest example fails because serde_json is not available to that doctest target.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CBOR conversion for 128-bit signed and unsigned values by using safe integer conversion instead of narrowing.
  * Out-of-range 128-bit values now reliably fail with a dedicated integer size error.
  * Nested composite values containing out-of-range 128-bit integers correctly cause the overall conversion to fail.
* **Tests**
  * Expanded test coverage for boundary behavior and verified CBOR serialization/deserialization round-trips for signed 128-bit values within the native range.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->