### PR TITLE
fix: prevent secret tracing in dependency build stages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -464,7 +464,7 @@ RUN --mount=type=cache,sharing=shared,id=cargo_registry_index,target=${CARGO_HOM
     --mount=type=secret,id=GITHUB_TOKEN \
     trap 'rm -f "${HOME}/.gitconfig"' EXIT; \
     if [ -s /run/secrets/GITHUB_TOKEN ]; then \
-    git config --global url."https://$(cat /run/secrets/GITHUB_TOKEN)@github.com/".insteadOf "https://github.com/"; \
+    git config --global url."https://x-access-token:$(cat /run/secrets/GITHUB_TOKEN)@github.com/".insteadOf "https://github.com/"; \
     fi && \
     source /root/env && \
     export FEATURES_FLAG=""; \
@@ -641,8 +641,9 @@ RUN --mount=type=cache,sharing=shared,id=cargo_registry_index,target=${CARGO_HOM
     --mount=type=cache,sharing=locked,id=cargo_git,target=${CARGO_HOME}/git/db \
     --mount=type=secret,id=AWS \
     --mount=type=secret,id=GITHUB_TOKEN \
-    if [ -f /run/secrets/GITHUB_TOKEN ]; then \
-    git config --global url."https://$(cat /run/secrets/GITHUB_TOKEN)@github.com/".insteadOf "https://github.com/"; \
+    trap 'rm -f "${HOME}/.gitconfig"' EXIT; \
+    if [ -s /run/secrets/GITHUB_TOKEN ]; then \
+    git config --global url."https://x-access-token:$(cat /run/secrets/GITHUB_TOKEN)@github.com/".insteadOf "https://github.com/"; \
     fi && \
     source /root/env && \
     unset CFLAGS CXXFLAGS && \
@@ -652,8 +653,7 @@ RUN --mount=type=cache,sharing=shared,id=cargo_registry_index,target=${CARGO_HOM
     --package wasm-dpp \
     --target wasm32-unknown-unknown \
     --locked && \
-    if [[ -x /usr/bin/sccache ]]; then sccache --show-stats; fi && \
-    rm -f ~/.gitconfig || true
+    if [[ -x /usr/bin/sccache ]]; then sccache --show-stats; fi
 
 
 # Rust deps
@@ -886,7 +886,7 @@ RUN --mount=type=cache,sharing=shared,id=cargo_registry_index,target=${CARGO_HOM
     --mount=type=secret,id=GITHUB_TOKEN \
     trap 'rm -f "${HOME}/.gitconfig"' EXIT; \
     if [ -s /run/secrets/GITHUB_TOKEN ]; then \
-    git config --global url."https://$(cat /run/secrets/GITHUB_TOKEN)@github.com/".insteadOf "https://github.com/"; \
+    git config --global url."https://x-access-token:$(cat /run/secrets/GITHUB_TOKEN)@github.com/".insteadOf "https://github.com/"; \
     fi && \
     source /root/env && \
     if  [[ "${CARGO_BUILD_PROFILE}" == "release" ]] ; then \

--- a/Dockerfile
+++ b/Dockerfile
@@ -450,7 +450,7 @@ ARG SDK_TEST_DATA
 ARG SHIELDED_TEST_DATA
 ARG ADDITIONAL_FEATURES=""
 
-SHELL ["/bin/bash", "-o", "pipefail","-e", "-x", "-c"]
+SHELL ["/bin/bash", "-o", "pipefail", "-e", "-c"]
 
 WORKDIR /platform
 
@@ -462,8 +462,8 @@ RUN --mount=type=cache,sharing=shared,id=cargo_registry_index,target=${CARGO_HOM
     --mount=type=cache,sharing=locked,id=cargo_git,target=${CARGO_HOME}/git/db \
     --mount=type=secret,id=AWS \
     --mount=type=secret,id=GITHUB_TOKEN \
-    set -ex; \
-    if [ -f /run/secrets/GITHUB_TOKEN ]; then \
+    trap 'rm -f "${HOME}/.gitconfig"' EXIT; \
+    if [ -s /run/secrets/GITHUB_TOKEN ]; then \
     git config --global url."https://$(cat /run/secrets/GITHUB_TOKEN)@github.com/".insteadOf "https://github.com/"; \
     fi && \
     source /root/env && \
@@ -491,8 +491,7 @@ RUN --mount=type=cache,sharing=shared,id=cargo_registry_index,target=${CARGO_HOM
     --package drive-abci \
     ${FEATURES_FLAG} \
     --locked && \
-    if [[ -x /usr/bin/sccache ]]; then sccache --show-stats; fi && \
-    rm -f ~/.gitconfig || true
+    if [[ -x /usr/bin/sccache ]]; then sccache --show-stats; fi
 
 COPY --parents \
     Cargo.lock \
@@ -873,7 +872,7 @@ USER node
 #
 FROM deps AS build-rs-dapi
 
-SHELL ["/bin/bash", "-o", "pipefail","-e", "-x", "-c"]
+SHELL ["/bin/bash", "-o", "pipefail", "-e", "-c"]
 
 WORKDIR /platform
 
@@ -885,8 +884,8 @@ RUN --mount=type=cache,sharing=shared,id=cargo_registry_index,target=${CARGO_HOM
     --mount=type=cache,sharing=locked,id=cargo_git,target=${CARGO_HOME}/git/db \
     --mount=type=secret,id=AWS \
     --mount=type=secret,id=GITHUB_TOKEN \
-    set -ex; \
-    if [ -f /run/secrets/GITHUB_TOKEN ]; then \
+    trap 'rm -f "${HOME}/.gitconfig"' EXIT; \
+    if [ -s /run/secrets/GITHUB_TOKEN ]; then \
     git config --global url."https://$(cat /run/secrets/GITHUB_TOKEN)@github.com/".insteadOf "https://github.com/"; \
     fi && \
     source /root/env && \
@@ -898,8 +897,7 @@ RUN --mount=type=cache,sharing=shared,id=cargo_registry_index,target=${CARGO_HOM
     --profile "$CARGO_BUILD_PROFILE" \
     --package rs-dapi \
     --locked && \
-    if [[ -x /usr/bin/sccache ]]; then sccache --show-stats; fi && \
-    rm -f ~/.gitconfig || true
+    if [[ -x /usr/bin/sccache ]]; then sccache --show-stats; fi
 
 COPY --parents \
     Cargo.lock \


### PR DESCRIPTION
## What

- disable shell command tracing in the Drive and rs-dapi dependency stages that consume an optional GitHub credential
- require a non-empty mounted credential before configuring Git authentication
- remove the temporary Git configuration through an exit trap on both successful and failed builds

## Why

The affected stages expanded a mounted credential while command tracing was enabled. Raw build output could therefore include credential material even though BuildKit kept the mounted file out of image layers.

This covers PLATFORM-DS-CAND-376.

## Checks

- Dockerfile diff and whitespace validation
- synthetic credential output test: marker absent from stdout and stderr
- failure-path cleanup test: temporary Git configuration removed

A Docker build parser check was attempted, but the local Docker daemon is not running.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Docker build reliability by enforcing stricter shell error handling.
  * Updated credential cleanup to run automatically when build steps exit.
  * Prevented empty secret files from triggering Git URL rewriting.
  * Simplified build-cache statistics handling while maintaining cleanup safeguards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->