### PR TITLE
fix(drive-abci): enforce historical query bounds

### DIFF
--- a/packages/rs-drive-abci/src/query/system/finalized_epoch_infos/v0/mod.rs
+++ b/packages/rs-drive-abci/src/query/system/finalized_epoch_infos/v0/mod.rs
@@ -10,11 +10,20 @@ use dapi_grpc::platform::v0::get_finalized_epoch_infos_response::{
 };
 use dapi_grpc::platform::v0::get_finalized_epoch_infos_response::get_finalized_epoch_infos_response_v0::{BlockProposer, FinalizedEpochInfo, FinalizedEpochInfos};
 use dpp::block::finalized_epoch_info::v0::getters::FinalizedEpochInfoGettersV0;
+use dpp::block::epoch::MAX_EPOCH;
 use dpp::check_validation_result_with_data;
 use dpp::version::PlatformVersion;
 use dpp::validation::ValidationResult;
 use drive::util::grove_operations::GroveDBToUse;
 use crate::query::response_metadata::CheckpointUsed;
+
+fn epoch_range_cardinality(start: u32, start_included: bool, end: u32, end_included: bool) -> u64 {
+    if start == end {
+        return u64::from(start_included && end_included);
+    }
+
+    u64::from(start.abs_diff(end)) + 1 - u64::from(!start_included) - u64::from(!end_included)
+}
 
 impl<C> Platform<C> {
     pub(super) fn query_finalized_epoch_infos_v0(
@@ -29,23 +38,22 @@ impl<C> Platform<C> {
         platform_state: &PlatformState,
         platform_version: &PlatformVersion,
     ) -> Result<QueryValidationResult<GetFinalizedEpochInfosResponseV0>, Error> {
-        // Validate that epoch indices fit in u16
-        if start_epoch_index > u16::MAX as u32 {
+        // Stored epoch keys reserve a prefix range, so the public index must
+        // fit before the internal offset is added.
+        if start_epoch_index > MAX_EPOCH as u32 {
             return Ok(QueryValidationResult::new_with_error(
                 QueryError::InvalidArgument(format!(
                     "start_epoch_index {} exceeds maximum value of {}",
-                    start_epoch_index,
-                    u16::MAX
+                    start_epoch_index, MAX_EPOCH
                 )),
             ));
         }
 
-        if end_epoch_index > u16::MAX as u32 {
+        if end_epoch_index > MAX_EPOCH as u32 {
             return Ok(QueryValidationResult::new_with_error(
                 QueryError::InvalidArgument(format!(
                     "end_epoch_index {} exceeds maximum value of {}",
-                    end_epoch_index,
-                    u16::MAX
+                    end_epoch_index, MAX_EPOCH
                 )),
             ));
         }
@@ -57,6 +65,22 @@ impl<C> Platform<C> {
                 QueryError::InvalidArgument(
                     format!("when start_epoch_index equals end_epoch_index ({}), both boundaries must be included to return a result", start_epoch_index),
                 ),
+            ));
+        }
+
+        let requested_epochs = epoch_range_cardinality(
+            start_epoch_index,
+            start_epoch_index_included,
+            end_epoch_index,
+            end_epoch_index_included,
+        );
+        let max_epochs = u64::from(platform_version.drive_abci.query.max_returned_elements);
+        if requested_epochs > max_epochs {
+            return Ok(QueryValidationResult::new_with_error(
+                QueryError::InvalidArgument(format!(
+                    "requested epoch range contains {} elements, maximum is {}",
+                    requested_epochs, max_epochs
+                )),
             ));
         }
 
@@ -197,6 +221,69 @@ mod tests {
     }
 
     #[test]
+    fn test_epoch_range_cardinality_respects_direction_and_boundaries() {
+        assert_eq!(epoch_range_cardinality(0, true, 99, true), 100);
+        assert_eq!(epoch_range_cardinality(99, true, 0, true), 100);
+        assert_eq!(epoch_range_cardinality(0, true, 100, true), 101);
+        assert_eq!(epoch_range_cardinality(0, true, 100, false), 100);
+        assert_eq!(epoch_range_cardinality(0, false, 100, true), 100);
+        assert_eq!(epoch_range_cardinality(0, false, 100, false), 99);
+        assert_eq!(epoch_range_cardinality(7, true, 7, true), 1);
+        assert_eq!(epoch_range_cardinality(7, true, 7, false), 0);
+    }
+
+    #[test]
+    fn test_query_finalized_epoch_infos_rejects_ranges_above_response_limit() {
+        let (platform, state, version) = setup_platform(None, Network::Testnet, None);
+        let max_epochs = u32::from(version.drive_abci.query.max_returned_elements);
+
+        for (start_epoch_index, end_epoch_index, prove) in [
+            (0, max_epochs, false),
+            (max_epochs, 0, false),
+            (0, max_epochs, true),
+        ] {
+            let request = GetFinalizedEpochInfosRequestV0 {
+                start_epoch_index,
+                start_epoch_index_included: true,
+                end_epoch_index,
+                end_epoch_index_included: true,
+                prove,
+            };
+
+            let result = platform
+                .query_finalized_epoch_infos_v0(request, &state, version)
+                .expect("expected query validation to succeed");
+
+            assert!(matches!(
+                result.errors.as_slice(),
+                [QueryError::InvalidArgument(msg)] if msg.contains("requested epoch range")
+            ));
+            assert!(result.data.is_none());
+        }
+    }
+
+    #[test]
+    fn test_query_finalized_epoch_infos_accepts_range_at_response_limit() {
+        let (platform, state, version) = setup_platform(None, Network::Testnet, None);
+        let max_epochs = u32::from(version.drive_abci.query.max_returned_elements);
+
+        let request = GetFinalizedEpochInfosRequestV0 {
+            start_epoch_index: 0,
+            start_epoch_index_included: true,
+            end_epoch_index: max_epochs - 1,
+            end_epoch_index_included: true,
+            prove: false,
+        };
+
+        let result = platform
+            .query_finalized_epoch_infos_v0(request, &state, version)
+            .expect("expected bounded query to succeed");
+
+        assert!(result.errors.is_empty());
+        assert!(result.data.is_some());
+    }
+
+    #[test]
     fn test_query_finalized_epoch_infos_equal_indexes_without_both_included() {
         let (platform, state, version) = setup_platform(None, Network::Testnet, None);
 
@@ -298,16 +385,14 @@ mod tests {
 
     #[test]
     fn test_query_finalized_epoch_infos_start_at_max_does_not_trigger_range_guard() {
-        // start_epoch_index exactly at u16::MAX must not trip the
-        // `> u16::MAX` guard. Downstream layers may still reject it, but
-        // not with the InvalidArgument("start_epoch_index ... exceeds
-        // maximum") message this query is responsible for.
+        // MAX_EPOCH is the largest public index that remains representable
+        // after storage adds the reserved epoch-key offset.
         let (platform, state, version) = setup_platform(None, Network::Testnet, None);
 
         let request = GetFinalizedEpochInfosRequestV0 {
-            start_epoch_index: u16::MAX as u32,
+            start_epoch_index: MAX_EPOCH as u32,
             start_epoch_index_included: true,
-            end_epoch_index: u16::MAX as u32,
+            end_epoch_index: MAX_EPOCH as u32,
             end_epoch_index_included: true,
             prove: false,
         };
@@ -316,16 +401,36 @@ mod tests {
             .query_finalized_epoch_infos_v0(request, &state, version)
             .expect("expected query to succeed");
 
-        // No "start_epoch_index ... exceeds maximum" InvalidArgument: any
-        // other error (or success) is acceptable, since the range guard is
-        // what this test covers.
+        // No endpoint-range InvalidArgument should be emitted at MAX_EPOCH.
         for err in &result.errors {
             if let QueryError::InvalidArgument(msg) = err {
                 assert!(
                     !msg.contains("start_epoch_index") || !msg.contains("exceeds maximum"),
-                    "range guard fired at u16::MAX boundary: {msg}"
+                    "range guard fired at MAX_EPOCH boundary: {msg}"
                 );
             }
         }
+    }
+
+    #[test]
+    fn test_query_finalized_epoch_infos_rejects_index_above_max_epoch() {
+        let (platform, state, version) = setup_platform(None, Network::Testnet, None);
+
+        let request = GetFinalizedEpochInfosRequestV0 {
+            start_epoch_index: u32::from(MAX_EPOCH) + 1,
+            start_epoch_index_included: true,
+            end_epoch_index: 0,
+            end_epoch_index_included: true,
+            prove: false,
+        };
+
+        let result = platform
+            .query_finalized_epoch_infos_v0(request, &state, version)
+            .expect("expected query validation to succeed");
+
+        assert!(matches!(
+            result.errors.as_slice(),
+            [QueryError::InvalidArgument(msg)] if msg.contains("start_epoch_index")
+        ));
     }
 }

--- a/packages/rs-drive/src/drive/credit_pools/epochs/get_finalized_epoch_info/v0/mod.rs
+++ b/packages/rs-drive/src/drive/credit_pools/epochs/get_finalized_epoch_info/v0/mod.rs
@@ -77,6 +77,7 @@ impl Drive {
             start_epoch_index_included,
             end_epoch_index,
             end_epoch_index_included,
+            platform_version.drive_abci.query.max_returned_elements,
         )?
         else {
             return Ok(T::from_iter(std::iter::empty()));

--- a/packages/rs-drive/src/drive/credit_pools/epochs/prove_finalized_epoch_infos/v0/mod.rs
+++ b/packages/rs-drive/src/drive/credit_pools/epochs/prove_finalized_epoch_infos/v0/mod.rs
@@ -70,6 +70,7 @@ impl Drive {
             start_epoch_index_included,
             end_epoch_index,
             end_epoch_index_included,
+            platform_version.drive_abci.query.max_returned_elements,
         )?
         else {
             return Err(Error::Query(QuerySyntaxError::NoQueryItems(

--- a/packages/rs-drive/src/drive/credit_pools/epochs/queries.rs
+++ b/packages/rs-drive/src/drive/credit_pools/epochs/queries.rs
@@ -19,6 +19,7 @@ impl Drive {
     /// - `start_epoch_index_included`: If `true`, includes the start epoch in the results.
     /// - `end_epoch_index`: The ending epoch index for the query range.
     /// - `end_epoch_index_included`: If `true`, includes the end epoch in the results.
+    /// - `limit`: The maximum number of epoch records the storage query may return.
     ///
     /// # Returns
     ///
@@ -40,6 +41,7 @@ impl Drive {
         start_epoch_index_included: bool,
         end_epoch_index: u16,
         end_epoch_index_included: bool,
+        limit: u16,
     ) -> Result<Option<PathQuery>, ProtocolError> {
         // Compute the start and end keys with the offset.
         let start_index = start_epoch_index
@@ -94,7 +96,21 @@ impl Drive {
         query.set_subquery_key(KEY_FINISHED_EPOCH_INFO.to_vec());
         Ok(Some(PathQuery::new(
             pools_vec_path(),
-            SizedQuery::new(query, None, None),
+            SizedQuery::new(query, Some(limit), None),
         )))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn finalized_epoch_infos_query_applies_storage_limit() {
+        let path_query = Drive::finalized_epoch_infos_query(1, true, 10, true, 7)
+            .expect("expected query construction to succeed")
+            .expect("expected a non-empty epoch range");
+
+        assert_eq!(path_query.query.limit, Some(7));
     }
 }

--- a/packages/rs-drive/src/verify/system/verify_finalized_epoch_infos/v0/mod.rs
+++ b/packages/rs-drive/src/verify/system/verify_finalized_epoch_infos/v0/mod.rs
@@ -50,6 +50,7 @@ impl Drive {
             start_epoch_index_included,
             end_epoch_index,
             end_epoch_index_included,
+            platform_version.drive_abci.query.max_returned_elements,
         )?
         else {
             return Err(Error::Query(QuerySyntaxError::NoQueryItems(


### PR DESCRIPTION
## Issue being fixed or feature implemented

Keeps historical system queries within the platform-wide response budget. Covers internal review item 302.

## What was done?

- Normalized requested ranges before backend work.
- Applied the same bound to direct reads, proof construction, and proof verification.
- Added boundary and direction regression coverage.

## How Has This Been Tested?

- 11 focused Drive ABCI query tests.
- Focused Drive storage-query test.
- Strict Clippy for drive and drive-abci across all targets.
- Workspace formatting check.

## Breaking Changes

None.

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [x] I have made corresponding changes to the documentation if needed

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone