### PR TITLE
fix(dapi): validate bounded request payloads

### DIFF
--- a/packages/rs-dapi/src/services/platform_service/broadcast_state_transition.rs
+++ b/packages/rs-dapi/src/services/platform_service/broadcast_state_transition.rs
@@ -13,6 +13,7 @@ use crate::services::platform_service::error_mapping::decode_consensus_error;
 use crate::services::platform_service::error_mapping::map_tenderdash_message;
 use base64::prelude::*;
 use dapi_grpc::platform::v0::{BroadcastStateTransitionRequest, BroadcastStateTransitionResponse};
+use dpp::version::PlatformVersion;
 use sha2::{Digest, Sha256};
 use tonic::Request;
 use tracing::{Instrument, debug, trace};
@@ -37,15 +38,11 @@ impl PlatformServiceImpl {
         &self,
         request: Request<BroadcastStateTransitionRequest>,
     ) -> Result<BroadcastStateTransitionResponse, DapiError> {
-        let tx = request.get_ref().state_transition.clone();
+        let BroadcastStateTransitionRequest {
+            state_transition: tx,
+        } = request.into_inner();
 
-        // Validate that state transition is provided
-        if tx.is_empty() {
-            debug!("State transition is empty");
-            return Err(DapiError::InvalidArgument(
-                "State Transition is not specified".to_string(),
-            ));
-        }
+        validate_state_transition_bytes(&tx)?;
 
         let txid = Sha256::digest(&tx).to_vec();
         let txid_hex = hex::encode(&txid);
@@ -210,6 +207,27 @@ impl PlatformServiceImpl {
     }
 }
 
+fn validate_state_transition_bytes(tx: &[u8]) -> Result<(), DapiError> {
+    if tx.is_empty() {
+        debug!("State transition is empty");
+        return Err(DapiError::InvalidArgument(
+            "State Transition is not specified".to_string(),
+        ));
+    }
+
+    let max_size = PlatformVersion::latest()
+        .system_limits
+        .max_state_transition_size as usize;
+    if tx.len() > max_size {
+        debug!(actual = tx.len(), max_size, "State transition is too large");
+        return Err(DapiError::InvalidArgument(format!(
+            "State Transition exceeds maximum size of {max_size} bytes"
+        )));
+    }
+
+    Ok(())
+}
+
 /// Convert Tenderdash broadcast error details into a structured `DapiError`.
 fn map_broadcast_error(code: u32, error_message: &str, info: Option<&str>) -> DapiError {
     // TODO: prefer code over message when possible
@@ -234,4 +252,26 @@ fn map_broadcast_error(code: u32, error_message: &str, info: Option<&str>) -> Da
         message,
         consensus_error,
     ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn state_transition_size_is_checked_before_broadcast_work() {
+        let max_size = PlatformVersion::latest()
+            .system_limits
+            .max_state_transition_size as usize;
+
+        assert!(validate_state_transition_bytes(&vec![1; max_size]).is_ok());
+        assert!(matches!(
+            validate_state_transition_bytes(&vec![1; max_size + 1]),
+            Err(DapiError::InvalidArgument(message)) if message.contains("maximum size")
+        ));
+        assert!(matches!(
+            validate_state_transition_bytes(&[]),
+            Err(DapiError::InvalidArgument(message)) if message.contains("not specified")
+        ));
+    }
 }

--- a/packages/rs-dapi/src/services/platform_service/broadcast_state_transition.rs
+++ b/packages/rs-dapi/src/services/platform_service/broadcast_state_transition.rs
@@ -215,6 +215,10 @@ fn validate_state_transition_bytes(tx: &[u8]) -> Result<(), DapiError> {
         ));
     }
 
+    // `latest()` is a static upper bound, not the network's active version:
+    // every released version so far shares the same limit, and if a future
+    // version raises it, latest ≥ active keeps this a pure pre-filter —
+    // Drive still enforces the active version's limit authoritatively.
     let max_size = PlatformVersion::latest()
         .system_limits
         .max_state_transition_size as usize;

--- a/packages/rs-dapi/src/services/platform_service/wait_for_state_transition_result.rs
+++ b/packages/rs-dapi/src/services/platform_service/wait_for_state_transition_result.rs
@@ -14,6 +14,8 @@ use std::time::Duration;
 use tokio::time::timeout;
 use tracing::{Instrument, debug, trace};
 
+const STATE_TRANSITION_HASH_SIZE: usize = 32;
+
 impl PlatformServiceImpl {
     /// Wait for a state transition result by subscribing to platform events and returning proofs when requested.
     pub async fn wait_for_state_transition_result_impl(
@@ -32,14 +34,10 @@ impl PlatformServiceImpl {
 
         // Validate state transition hash
         let state_transition_hash = v0.state_transition_hash;
-        if state_transition_hash.is_empty() {
-            return Err(DapiError::InvalidArgument(
-                "state transition hash is not specified".to_string(),
-            ));
-        }
+        validate_state_transition_hash(&state_transition_hash)?;
 
         // Convert hash to commonly used representations
-        let hash_hex = hex::encode(&state_transition_hash).to_uppercase();
+        let hash_hex = hex::encode_upper(&state_transition_hash);
         let hash_base64 = base64::prelude::BASE64_STANDARD.encode(&state_transition_hash);
 
         let span = tracing::trace_span!("wait_for_state_transition_result", tx = %hash_hex);
@@ -285,6 +283,17 @@ impl PlatformServiceImpl {
     }
 }
 
+fn validate_state_transition_hash(hash: &[u8]) -> Result<(), DapiError> {
+    if hash.len() != STATE_TRANSITION_HASH_SIZE {
+        return Err(DapiError::InvalidArgument(format!(
+            "state transition hash must be {STATE_TRANSITION_HASH_SIZE} bytes, got {}",
+            hash.len()
+        )));
+    }
+
+    Ok(())
+}
+
 /// Convert a `DapiError` into the gRPC error response expected by waitForStateTransitionResult callers.
 pub(super) fn build_wait_for_state_transition_error_response(
     error: &DapiError,
@@ -315,6 +324,18 @@ pub(super) fn build_wait_for_state_transition_error_response(
 mod tests {
     use super::*;
     use dapi_grpc::platform::v0::StateTransitionBroadcastError;
+
+    #[test]
+    fn state_transition_hash_must_be_exact_width() {
+        assert!(validate_state_transition_hash(&[0; STATE_TRANSITION_HASH_SIZE]).is_ok());
+
+        for length in [0, 1, 31, 33, 20 * 1024] {
+            assert!(matches!(
+                validate_state_transition_hash(&vec![0; length]),
+                Err(DapiError::InvalidArgument(message)) if message.contains("must be 32 bytes")
+            ));
+        }
+    }
 
     /// Extract the `StateTransitionBroadcastError` from a
     /// `WaitForStateTransitionResultResponse`, unwrapping the V0 / Error layers.

--- a/packages/rs-dapi/src/services/streaming_service/block_header_stream.rs
+++ b/packages/rs-dapi/src/services/streaming_service/block_header_stream.rs
@@ -16,7 +16,7 @@ use tracing::{debug, trace, warn};
 
 use crate::DapiError;
 use crate::services::streaming_service::{
-    FilterType, StreamingEvent, StreamingServiceImpl, SubscriptionHandle,
+    FilterType, StreamingEvent, StreamingServiceImpl, SubscriptionHandle, validate_core_block_hash,
 };
 
 const BLOCK_HEADER_STREAM_BUFFER: usize = 512;
@@ -51,11 +51,10 @@ impl StreamingServiceImpl {
                 }
                 FromBlock::FromBlockHeight(height)
             }
-            Some(FromBlock::FromBlockHash(ref hash)) if hash.is_empty() => {
-                debug!("block_headers=empty_from_block_hash");
-                return Err(Status::invalid_argument("fromBlockHash cannot be empty"));
+            Some(FromBlock::FromBlockHash(hash)) => {
+                validate_core_block_hash(&hash)?;
+                FromBlock::FromBlockHash(hash)
             }
-            Some(from_block) => from_block,
             None => {
                 debug!("block_headers=missing_from_block");
                 return Err(Status::invalid_argument("from_block is required"));

--- a/packages/rs-dapi/src/services/streaming_service/mod.rs
+++ b/packages/rs-dapi/src/services/streaming_service/mod.rs
@@ -18,6 +18,7 @@ use std::sync::Arc;
 use tokio::sync::broadcast;
 use tokio::sync::broadcast::error::RecvError;
 use tokio::time::{Duration, sleep};
+use tonic::Status;
 use tracing::{debug, trace};
 
 pub(crate) use masternode_list_sync::MasternodeListSync;
@@ -25,6 +26,18 @@ pub(crate) use subscriber_manager::{
     FilterType, StreamingEvent, SubscriberManager, SubscriptionHandle,
 };
 pub(crate) use zmq_listener::{ZmqEvent, ZmqListener};
+
+const CORE_BLOCK_HASH_SIZE: usize = 32;
+
+fn validate_core_block_hash(hash: &[u8]) -> Result<(), Status> {
+    if hash.len() != CORE_BLOCK_HASH_SIZE {
+        return Err(Status::invalid_argument(format!(
+            "fromBlockHash must be exactly {CORE_BLOCK_HASH_SIZE} bytes"
+        )));
+    }
+
+    Ok(())
+}
 
 /// Streaming service implementation with ZMQ integration.
 ///
@@ -484,6 +497,22 @@ pub(crate) fn summarize_zmq_event(event: &ZmqEvent) -> String {
         }
         ZmqEvent::HashBlock { hash } => {
             format!("HashBlock {}", short_hex(hash, 12))
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn core_block_hash_must_be_exact_width() {
+        assert!(validate_core_block_hash(&[0; CORE_BLOCK_HASH_SIZE]).is_ok());
+
+        for length in [0, 1, 31, 33, 64 * 1024] {
+            let status = validate_core_block_hash(&vec![0; length])
+                .expect_err("expected invalid block hash length");
+            assert_eq!(status.code(), tonic::Code::InvalidArgument);
         }
     }
 }

--- a/packages/rs-dapi/src/services/streaming_service/transaction_stream.rs
+++ b/packages/rs-dapi/src/services/streaming_service/transaction_stream.rs
@@ -3,6 +3,7 @@ use std::io::Cursor;
 use std::sync::Arc;
 use std::time::Duration;
 
+use dapi_grpc::core::v0::transactions_with_proofs_request::FromBlock;
 use dapi_grpc::core::v0::transactions_with_proofs_response::Responses;
 use dapi_grpc::core::v0::{
     InstantSendLockMessages, RawTransactions, TransactionsWithProofsRequest,
@@ -22,7 +23,7 @@ use crate::DapiError;
 use crate::clients::{CoreClient, core_client};
 use crate::services::streaming_service::{
     FilterType, StreamingEvent, StreamingServiceImpl, SubscriptionHandle,
-    bloom::bloom_flags_from_int,
+    bloom::bloom_flags_from_int, validate_core_block_hash,
 };
 
 const TRANSACTION_STREAM_BUFFER: usize = 512;
@@ -154,6 +155,14 @@ impl StreamingServiceImpl {
         trace!("transactions_with_proofs=subscribe_begin");
         let req = request.into_inner();
         let count = req.count;
+        let from_block = req
+            .from_block
+            .ok_or_else(|| Status::invalid_argument("Must specify from_block"))?;
+
+        if let FromBlock::FromBlockHash(hash) = &from_block {
+            validate_core_block_hash(hash)?;
+        }
+
         let filter = match req.bloom_filter {
             Some(bloom_filter) => {
                 let (core_filter, flags) = parse_bloom_filter(&bloom_filter)?;
@@ -164,10 +173,6 @@ impl StreamingServiceImpl {
             }
             None => FilterType::CoreAllTxs,
         };
-
-        let from_block = req
-            .from_block
-            .ok_or_else(|| Status::invalid_argument("Must specify from_block"))?;
 
         let (tx, rx) = mpsc::channel(TRANSACTION_STREAM_BUFFER);
         if count > 0 {


### PR DESCRIPTION
## Issue being fixed or feature implemented

Rejects semantically invalid public payloads before representation expansion or backend work. Covers internal review items 003, 004, 170, and 171.

## What was done?

- Applied the active platform state-transition size limit before hashing and encoding.
- Enforced exact-width state-transition and Core block hashes before subscriptions or RPC work.
- Removed an avoidable broadcast payload clone and a temporary hash-string allocation.
- Added boundary regression coverage.

## How Has This Been Tested?

- Full rs-dapi unit and documentation suite: 288 tests.
- Strict Clippy for rs-dapi across all targets.
- Workspace formatting check.

## Breaking Changes

None for valid requests.

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [x] I have made corresponding changes to the documentation if needed

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone