### PR TITLE
fix(drive): preserve typed proof query fields

### DIFF
--- a/packages/rs-drive-proof-verifier/src/from_request.rs
+++ b/packages/rs-drive-proof-verifier/src/from_request.rs
@@ -188,6 +188,22 @@ impl TryFromRequest<GetContestedResourceIdentityVotesRequest>
                     .map(|id| (id, v.start_poll_identifier_included))
             })
             .transpose()?;
+        let offset =
+            value
+                .offset
+                .map(u16::try_from)
+                .transpose()
+                .map_err(|_| Error::RequestError {
+                    error: "offset out of bounds".to_string(),
+                })?;
+        let limit =
+            value
+                .limit
+                .map(u16::try_from)
+                .transpose()
+                .map_err(|_| Error::RequestError {
+                    error: "limit out of bounds".to_string(),
+                })?;
 
         Ok(Self {
             identity_id: Identifier::from_vec(value.identity_id.to_vec()).map_err(|e| {
@@ -195,8 +211,8 @@ impl TryFromRequest<GetContestedResourceIdentityVotesRequest>
                     error: e.to_string(),
                 }
             })?,
-            offset: None,
-            limit: value.limit.map(|x| x as u16),
+            offset,
+            limit,
             start_at,
             order_ascending: value.order_ascending,
         })
@@ -204,9 +220,6 @@ impl TryFromRequest<GetContestedResourceIdentityVotesRequest>
 
     fn try_to_request(&self) -> Result<GetContestedResourceIdentityVotesRequest, Error> {
         use proto::get_contested_resource_identity_votes_request::get_contested_resource_identity_votes_request_v0 as request_v0;
-        if self.offset.is_some() {
-            return Err(Error::RequestError{error:"ContestedResourceVotesGivenByIdentityQuery.offset field is internal and must be set to None".into()});
-        }
 
         Ok(proto::get_contested_resource_identity_votes_request::GetContestedResourceIdentityVotesRequestV0 {
                     prove: true,
@@ -701,23 +714,77 @@ mod tests {
     }
 
     // ---------------------------------------------------------------
-    // Error path: ContestedResourceVotesGivenByIdentityQuery try_to_request
-    // rejects offset != None
+    // ContestedResourceVotesGivenByIdentityQuery preserves proof-critical
+    // pagination fields in both conversion directions.
     // ---------------------------------------------------------------
 
     #[test]
-    fn test_contested_resource_votes_given_by_identity_rejects_offset() {
+    fn test_contested_resource_votes_given_by_identity_preserves_offset() {
         let id = Identifier::from_bytes(&[3u8; 32]).unwrap();
         let query = ContestedResourceVotesGivenByIdentityQuery {
             identity_id: id,
-            offset: Some(10), // should trigger rejection
-            limit: None,
+            offset: Some(10),
+            limit: Some(20),
             start_at: None,
             order_ascending: true,
         };
-        let err = query.try_to_request().unwrap_err();
-        let msg = format!("{}", err);
-        assert!(msg.contains("offset"), "error should mention offset: {msg}");
+        let request = query.try_to_request().expect("request conversion");
+        let converted = ContestedResourceVotesGivenByIdentityQuery::try_from_request(request)
+            .expect("query conversion");
+        assert_eq!(converted, query);
+    }
+
+    #[test]
+    fn test_contested_resource_votes_given_by_identity_rejects_wide_pagination_values() {
+        use dapi_grpc::platform::v0::get_contested_resource_identity_votes_request::{
+            GetContestedResourceIdentityVotesRequestV0, Version as ReqVersion,
+        };
+
+        for (limit, offset, expected_field) in [
+            (Some(u16::MAX as u32 + 1), None, "limit"),
+            (None, Some(u16::MAX as u32 + 1), "offset"),
+        ] {
+            let request = GetContestedResourceIdentityVotesRequest {
+                version: Some(ReqVersion::V0(GetContestedResourceIdentityVotesRequestV0 {
+                    identity_id: vec![0u8; 32],
+                    start_at_vote_poll_id_info: None,
+                    limit,
+                    offset,
+                    order_ascending: true,
+                    prove: true,
+                })),
+            };
+            let err =
+                ContestedResourceVotesGivenByIdentityQuery::try_from_request(request).unwrap_err();
+            assert!(
+                format!("{err}").contains(expected_field),
+                "unexpected error: {err}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_contested_resource_votes_given_by_identity_accepts_u16_pagination_boundaries() {
+        use dapi_grpc::platform::v0::get_contested_resource_identity_votes_request::{
+            GetContestedResourceIdentityVotesRequestV0, Version as ReqVersion,
+        };
+
+        for value in [0, 1, u16::MAX as u32] {
+            let request = GetContestedResourceIdentityVotesRequest {
+                version: Some(ReqVersion::V0(GetContestedResourceIdentityVotesRequestV0 {
+                    identity_id: vec![0u8; 32],
+                    start_at_vote_poll_id_info: None,
+                    limit: Some(value),
+                    offset: Some(value),
+                    order_ascending: true,
+                    prove: true,
+                })),
+            };
+            let query = ContestedResourceVotesGivenByIdentityQuery::try_from_request(request)
+                .expect("pagination value should fit");
+            assert_eq!(query.limit, Some(value as u16));
+            assert_eq!(query.offset, Some(value as u16));
+        }
     }
 
     #[test]

--- a/packages/wasm-drive-verify/src/identity/verify_identities_contract_keys.rs
+++ b/packages/wasm-drive-verify/src/identity/verify_identities_contract_keys.rs
@@ -6,6 +6,14 @@ use js_sys::{Array, Uint8Array};
 use serde_wasm_bindgen::to_value;
 use wasm_bindgen::prelude::*;
 
+fn purpose_from_js_number(value: f64) -> Result<Purpose, ()> {
+    if !value.is_finite() || value.fract() != 0.0 || !(0.0..=u8::MAX as f64).contains(&value) {
+        return Err(());
+    }
+
+    Purpose::try_from(value as u8).map_err(|_| ())
+}
+
 #[wasm_bindgen]
 pub struct VerifyIdentitiesContractKeysResult {
     root_hash: Vec<u8>,
@@ -63,16 +71,8 @@ pub fn verify_identities_contract_keys(
             .get(i)
             .as_f64()
             .ok_or_else(|| JsValue::from_str("Invalid purpose value"))?;
-        let purpose = match purpose_num as u8 {
-            0 => Purpose::AUTHENTICATION,
-            1 => Purpose::ENCRYPTION,
-            2 => Purpose::DECRYPTION,
-            3 => Purpose::TRANSFER,
-            4 => Purpose::SYSTEM,
-            5 => Purpose::VOTING,
-            6 => Purpose::OWNER,
-            _ => return Err(JsValue::from_str("Invalid purpose value")),
-        };
+        let purpose = purpose_from_js_number(purpose_num)
+            .map_err(|_| JsValue::from_str("Invalid purpose value"))?;
         purposes_vec.push(purpose);
     }
 
@@ -98,4 +98,49 @@ pub fn verify_identities_contract_keys(
         root_hash: root_hash.to_vec(),
         keys: keys_js,
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn purpose_parser_accepts_only_exact_discriminants() {
+        for (value, expected) in [
+            (0.0, Purpose::AUTHENTICATION),
+            (1.0, Purpose::ENCRYPTION),
+            (2.0, Purpose::DECRYPTION),
+            (3.0, Purpose::TRANSFER),
+            (4.0, Purpose::SYSTEM),
+            (5.0, Purpose::VOTING),
+            (6.0, Purpose::OWNER),
+        ] {
+            assert_eq!(purpose_from_js_number(value), Ok(expected));
+        }
+    }
+
+    #[test]
+    fn purpose_parser_rejects_lossy_or_unknown_values() {
+        for value in [
+            -1.0,
+            -0.5,
+            0.9,
+            1.9,
+            3.9,
+            5.9,
+            6.9,
+            7.0,
+            255.0,
+            256.0,
+            f64::NAN,
+            f64::NEG_INFINITY,
+            f64::INFINITY,
+        ] {
+            assert_eq!(
+                purpose_from_js_number(value),
+                Err(()),
+                "{value:?} should be rejected"
+            );
+        }
+    }
 }

--- a/packages/wasm-drive-verify/src/voting/verify_identity_votes_given_proof.rs
+++ b/packages/wasm-drive-verify/src/voting/verify_identity_votes_given_proof.rs
@@ -9,75 +9,51 @@ use drive::query::contested_resource_votes_given_by_identity_query::ContestedRes
 use drive::query::ContractLookupFn;
 use drive::verify::RootHash;
 use js_sys::{Array, Object, Reflect, Uint8Array};
+use serde::Deserialize;
 use std::collections::BTreeMap;
 use std::sync::Arc;
 use wasm_bindgen::prelude::*;
 
-fn deserialize_contested_resource_votes_query(
-    query_cbor: &Uint8Array,
-) -> Result<ContestedResourceVotesGivenByIdentityQuery, JsValue> {
-    // Deserialize the query components from CBOR
-    let query_value: serde_json::Value = ciborium::de::from_reader(&query_cbor.to_vec()[..])
-        .map_err(|e| JsValue::from_str(&format!("Failed to deserialize query: {:?}", e)))?;
+#[derive(Deserialize)]
+struct ContestedResourceVotesGivenByIdentityWireQuery {
+    identity_id: Vec<u8>,
+    #[serde(default)]
+    offset: Option<u16>,
+    #[serde(default)]
+    limit: Option<u16>,
+    #[serde(default)]
+    start_at: Option<([u8; 32], bool)>,
+    #[serde(default = "default_order_ascending")]
+    order_ascending: bool,
+}
 
-    // Extract fields from the deserialized value
-    let query_obj = query_value
-        .as_object()
-        .ok_or_else(|| JsValue::from_str("Query must be an object"))?;
+fn default_order_ascending() -> bool {
+    true
+}
 
-    let identity_id_bytes: Vec<u8> = query_obj
-        .get("identity_id")
-        .and_then(|v| v.as_array())
-        .and_then(|arr| {
-            arr.iter()
-                .map(|v| v.as_u64().map(|n| n as u8))
-                .collect::<Option<Vec<_>>>()
-        })
-        .ok_or_else(|| JsValue::from_str("Invalid identity_id in query"))?;
-
-    let identity_id = Identifier::from_bytes(&identity_id_bytes)
-        .map_err(|e| JsValue::from_str(&format!("Invalid identity_id: {:?}", e)))?;
-
-    let offset = query_obj
-        .get("offset")
-        .and_then(|v| v.as_u64())
-        .map(|n| n as u16);
-
-    let limit = query_obj
-        .get("limit")
-        .and_then(|v| v.as_u64())
-        .map(|n| n as u16);
-
-    let start_at = query_obj
-        .get("start_at")
-        .and_then(|v| v.as_array())
-        .and_then(|arr| {
-            if arr.len() == 2 {
-                let bytes_arr = arr[0].as_array()?;
-                let bytes: Vec<u8> = bytes_arr
-                    .iter()
-                    .map(|v| v.as_u64().map(|n| n as u8))
-                    .collect::<Option<Vec<_>>>()?;
-                let bytes_32: [u8; 32] = bytes.try_into().ok()?;
-                let included = arr[1].as_bool()?;
-                Some((bytes_32, included))
-            } else {
-                None
-            }
-        });
-
-    let order_ascending = query_obj
-        .get("order_ascending")
-        .and_then(|v| v.as_bool())
-        .unwrap_or(true);
+fn deserialize_contested_resource_votes_query_bytes(
+    query_cbor: &[u8],
+) -> Result<ContestedResourceVotesGivenByIdentityQuery, String> {
+    let query: ContestedResourceVotesGivenByIdentityWireQuery =
+        ciborium::de::from_reader(query_cbor)
+            .map_err(|e| format!("Failed to deserialize query: {e:?}"))?;
+    let identity_id = Identifier::from_bytes(&query.identity_id)
+        .map_err(|e| format!("Invalid identity_id: {e:?}"))?;
 
     Ok(ContestedResourceVotesGivenByIdentityQuery {
         identity_id,
-        offset,
-        limit,
-        start_at,
-        order_ascending,
+        offset: query.offset,
+        limit: query.limit,
+        start_at: query.start_at,
+        order_ascending: query.order_ascending,
     })
+}
+
+fn deserialize_contested_resource_votes_query(
+    query_cbor: &Uint8Array,
+) -> Result<ContestedResourceVotesGivenByIdentityQuery, JsValue> {
+    deserialize_contested_resource_votes_query_bytes(&query_cbor.to_vec())
+        .map_err(|e| JsValue::from_str(&e))
 }
 
 #[wasm_bindgen]
@@ -234,4 +210,110 @@ fn create_contract_lookup_fn<'a>(
         Box::new(move |id: &Identifier| Ok(contracts_map.get(id).cloned()));
 
     Ok(lookup_fn)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::{json, Value};
+
+    fn encode_query(value: &Value) -> Vec<u8> {
+        let mut bytes = Vec::new();
+        ciborium::into_writer(value, &mut bytes).expect("encode query");
+        bytes
+    }
+
+    fn valid_query() -> Value {
+        json!({
+            "identity_id": vec![1u8; 32],
+            "offset": 7,
+            "limit": 11,
+            "start_at": [vec![2u8; 32], true],
+            "order_ascending": false
+        })
+    }
+
+    #[test]
+    fn query_decoder_preserves_all_proof_critical_fields() {
+        let query = deserialize_contested_resource_votes_query_bytes(&encode_query(&valid_query()))
+            .expect("valid query");
+
+        assert_eq!(query.identity_id, Identifier::from([1u8; 32]));
+        assert_eq!(query.offset, Some(7));
+        assert_eq!(query.limit, Some(11));
+        assert_eq!(query.start_at, Some(([2u8; 32], true)));
+        assert!(!query.order_ascending);
+    }
+
+    #[test]
+    fn query_decoder_rejects_out_of_range_identity_bytes() {
+        let mut query = valid_query();
+        query["identity_id"][0] = json!(256);
+
+        assert!(deserialize_contested_resource_votes_query_bytes(&encode_query(&query)).is_err());
+    }
+
+    #[test]
+    fn query_decoder_rejects_out_of_range_pagination_values() {
+        for field in ["offset", "limit"] {
+            let mut query = valid_query();
+            query[field] = json!(u16::MAX as u32 + 1);
+
+            assert!(
+                deserialize_contested_resource_votes_query_bytes(&encode_query(&query)).is_err(),
+                "{field} should be rejected"
+            );
+        }
+    }
+
+    #[test]
+    fn query_decoder_accepts_pagination_boundaries() {
+        for value in [0, 1, u16::MAX] {
+            let mut query = valid_query();
+            query["offset"] = json!(value);
+            query["limit"] = json!(value);
+
+            let decoded = deserialize_contested_resource_votes_query_bytes(&encode_query(&query))
+                .expect("pagination value should fit");
+            assert_eq!(decoded.offset, Some(value));
+            assert_eq!(decoded.limit, Some(value));
+        }
+    }
+
+    #[test]
+    fn query_decoder_rejects_out_of_range_start_at_bytes() {
+        let mut query = valid_query();
+        query["start_at"][0][31] = json!(256);
+
+        assert!(deserialize_contested_resource_votes_query_bytes(&encode_query(&query)).is_err());
+    }
+
+    #[test]
+    fn query_decoder_rejects_malformed_present_optional_fields() {
+        for (field, malformed) in [
+            ("offset", json!("1")),
+            ("limit", json!(-1)),
+            ("start_at", json!([vec![0u8; 31], true])),
+        ] {
+            let mut query = valid_query();
+            query[field] = malformed;
+
+            assert!(
+                deserialize_contested_resource_votes_query_bytes(&encode_query(&query)).is_err(),
+                "{field} should be rejected"
+            );
+        }
+    }
+
+    #[test]
+    fn query_decoder_defaults_only_absent_optional_fields() {
+        let query = json!({ "identity_id": vec![1u8; 32] });
+        let decoded = deserialize_contested_resource_votes_query_bytes(&encode_query(&query))
+            .expect("minimal query");
+
+        assert_eq!(decoded.offset, None);
+        assert_eq!(decoded.limit, None);
+        assert_eq!(decoded.start_at, None);
+        assert!(decoded.order_ascending);
+    }
 }


### PR DESCRIPTION
## Summary

- preserve checked pagination fields when converting identity-vote proof requests
- decode WASM identity-vote queries into bounded Rust types instead of narrowing generic numeric values
- validate JavaScript key-purpose values before converting them into proof-query discriminants

## Compatibility

This changes only client-side request/proof-query reconstruction. It does not change consensus or require a protocol activation. Malformed or out-of-range request fields now fail before proof verification.

## Validation

- `cargo test -p drive-proof-verifier --lib` (242 passed)
- `cargo test -p wasm-drive-verify --lib` (11 passed)
- strict Clippy for both crates
- native and `wasm32-unknown-unknown` builds
- formatting and diff checks

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Pagination offsets and limits are now preserved when converting vote queries.
  * Invalid or out-of-range pagination values are rejected instead of being truncated.
  * Identity key purposes now reject fractional, negative, non-finite, and out-of-range values.
  * Vote query decoding now correctly validates malformed optional fields and invalid identifiers.
  * Missing optional query fields now receive the appropriate defaults.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->