### PR TITLE
fix(wallet-lib): validate SPV block header batches

### DIFF
--- a/packages/dash-spv/lib/consensus.js
+++ b/packages/dash-spv/lib/consensus.js
@@ -1,46 +1,82 @@
-// const { hasValidTarget } = require('@dashevo/dark-gravity-wave');
+const { hasValidTarget } = require('@dashevo/dark-gravity-wave');
+const DashUtil = require('@dashevo/dash-util');
 const merkleProofs = require('./merkleproofs');
-// const utils = require('./utils');
+const utils = require('./utils');
 
-// const MIN_TIMESTAMP_HEADERS = 11;
-// const MIN_DGW_HEADERS = 24;
+const MIN_TIMESTAMP_HEADERS = 11;
+const MIN_DGW_HEADERS = 24;
 
-// function getMedianTimestamp(headers) {
-//   const timestamps = headers.map((h) => h.time);
-//   const median = (arr) => {
-//     const mid = Math.floor(arr.length / 2);
-//     const nums = [...arr].sort((a, b) => a - b);
-//     return arr.length % 2 !== 0 ? nums[mid] : (nums[mid - 1] + nums[mid]) / 2;
-//   };
-//   return median(timestamps);
-// }
+const NETWORK_POW_LIMITS = {
+  mainnet: 0x1e0ffff0,
+  testnet: 0x1e0fffff,
+  devnet: 0x207fffff,
+  regtest: 0x207fffff,
+};
+
+function getMedianTimestamp(headers) {
+  const timestamps = headers.map((h) => h.time).sort((a, b) => a - b);
+  return timestamps[Math.floor(timestamps.length / 2)];
+}
 
 // Must be strictly greater than the median time of the previous 11 blocks.
 // https://dash-docs.github.io/en/developer-reference#block-headers
-// function hasGreaterThanMedianTimestamp(newHeader, previousHeaders) {
-//   if (previousHeaders.length < MIN_TIMESTAMP_HEADERS) return true;
-//   const headerNormalised = utils.normalizeHeader(newHeader);
-//   const normalizedLatestHeaders = previousHeaders.slice(
-//     Math.max(previousHeaders.length - MIN_TIMESTAMP_HEADERS, 0),
-//   ).map((h) => utils.normalizeHeader(h));
-//   return getMedianTimestamp(normalizedLatestHeaders) < headerNormalised.time;
-// }
+function hasGreaterThanMedianTimestamp(newHeader, previousHeaders) {
+  if (previousHeaders.length < MIN_TIMESTAMP_HEADERS) {
+    return true;
+  }
+  const normalizedHeader = utils.normalizeHeader(newHeader);
+  const latestHeaders = previousHeaders
+    .slice(-MIN_TIMESTAMP_HEADERS)
+    .map((header) => utils.normalizeHeader(header));
+  return getMedianTimestamp(latestHeaders) < normalizedHeader.time;
+}
 
-function isValidBlockHeader(/* newHeader, previousHeaders, network = 'mainnet' */) {
-  // TODO: implement consensus checks properly for all networks
-  return true;
-  // if (previousHeaders.length > MIN_DGW_HEADERS) {
-  //   return newHeader.validProofOfWork()
-  //     && newHeader.validTimestamp()
-  //     && hasGreaterThanMedianTimestamp(newHeader, previousHeaders)
-  //     && hasValidTarget(
-  //       utils.getDgwBlock(newHeader), previousHeaders.map((h) => utils.getDgwBlock(h)), network,
-  //     );
-  // }
-  // // TODO: eventually this check start failing in dashmate
-  // return newHeader.validProofOfWork()
-  //   && newHeader.validTimestamp()
-  //   && hasGreaterThanMedianTimestamp(newHeader, previousHeaders);
+function hasCanonicalTarget(header, network) {
+  const powLimit = NETWORK_POW_LIMITS[network];
+  if (!powLimit || !Number.isInteger(header.bits)) {
+    return false;
+  }
+
+  try {
+    const target = DashUtil.expandTarget(header.bits);
+    const canonicalBits = DashUtil.compressTarget(target);
+    const maximumTarget = DashUtil.expandTarget(powLimit);
+
+    return canonicalBits === header.bits && target.compare(maximumTarget) <= 0;
+  } catch {
+    return false;
+  }
+}
+
+function isValidBlockHeaderWithoutContext(newHeader, network = 'mainnet') {
+  const normalizedHeader = utils.normalizeHeader(newHeader);
+
+  return hasCanonicalTarget(normalizedHeader, network)
+    && utils.validProofOfWork(normalizedHeader)
+    && normalizedHeader.validTimestamp();
+}
+
+function isValidBlockHeader(newHeader, previousHeaders, network = 'mainnet') {
+  const normalizedHeader = utils.normalizeHeader(newHeader);
+  const normalizedPreviousHeaders = previousHeaders.map((header) => utils.normalizeHeader(header));
+
+  if (!isValidBlockHeaderWithoutContext(normalizedHeader, network)
+    || !hasGreaterThanMedianTimestamp(normalizedHeader, normalizedPreviousHeaders)) {
+    return false;
+  }
+
+  // A trusted checkpoint may contain fewer than a full DGW window. Proof of
+  // work, the network pow limit, and timestamp rules still apply immediately;
+  // exact difficulty validation begins as soon as the required history exists.
+  if (normalizedPreviousHeaders.length < MIN_DGW_HEADERS) {
+    return true;
+  }
+
+  return hasValidTarget(
+    utils.getDgwBlock(normalizedHeader),
+    normalizedPreviousHeaders.map((header) => utils.getDgwBlock(header)),
+    network,
+  );
 }
 
 /**
@@ -64,5 +100,6 @@ async function areValidTransactions(transactions, merkleBlock, headerChain) {
 
 module.exports = {
   isValidBlockHeader,
+  isValidBlockHeaderWithoutContext,
   areValidTransactions,
 };

--- a/packages/dash-spv/lib/spvchain.js
+++ b/packages/dash-spv/lib/spvchain.js
@@ -202,14 +202,51 @@ const SpvChain = class {
       const chunkPrevHash = utils.getCorrectedHash(chunk[0].prevHash);
 
       if (tipHash === chunkPrevHash) {
-        this.appendHeadersToLongestChain(chunk);
-        chunk.forEach((header) => {
-          this.orphansHashes.delete(header.hash);
-        });
-        this.orphanChunks.splice(i, 1);
-        i -= 1;
+        try {
+          this.validateConnectedHeaders(chunk, this.getValidationHistory(), true);
+          this.appendHeadersToLongestChain(chunk);
+          chunk.forEach((header) => {
+            this.orphansHashes.delete(header.hash);
+          });
+          this.orphanChunks.splice(i, 1);
+          i -= 1;
+        } catch (e) {
+          chunk.forEach((header) => {
+            this.orphansHashes.delete(header.hash);
+          });
+          this.orphanChunks.splice(i, 1);
+          throw e;
+        }
       }
     }
+  }
+
+  /** @private */
+  getValidationHistory() {
+    return this.prunedHeaders.concat(this.getLongestChain()).slice(-24);
+  }
+
+  /** @private */
+  validateConnectedHeaders(headers, initialHistory, allowKnownOrphans = false) {
+    const history = initialHistory.slice();
+
+    headers.forEach((header) => {
+      const previousHeader = history[history.length - 1];
+      if (!previousHeader || !SpvChain.isParentChild(header, previousHeader)) {
+        throw new SPVError(`SPV: Header ${header.hash} is not connected to verified history`);
+      }
+
+      const isKnown = this.heightByHash.has(header.hash)
+        || (!allowKnownOrphans && this.orphansHashes.has(header.hash));
+      if (isKnown || !Consensus.isValidBlockHeader(header, history, this.network)) {
+        throw new SPVError(`SPV: Header ${header.hash} is invalid`);
+      }
+
+      history.push(header);
+      if (history.length > 24) {
+        history.shift();
+      }
+    });
   }
 
   /** @private */
@@ -230,7 +267,6 @@ const SpvChain = class {
     return !!validBlockHeader && !duplicate;
   }
 
-  /* eslint-disable no-param-reassign */
   /**
    * verifies the parent child connection
    * between two adjacent dashcore.BlockHeader objects
@@ -331,10 +367,9 @@ const SpvChain = class {
 
       isOrphan = !SpvChain.isParentChild(firstHeader, tip);
     } else if (batchHeadHeight === this.pendingStartBlockHeight) {
-      // Header at pendingStartBlockHeight is found, initialize chain
-      this.startBlockHeight = this.pendingStartBlockHeight;
-      this.pendingStartBlockHeight = null;
-      isOrphan = false;
+      throw new SPVError(
+        'SPV chain cannot initialize from an unauthenticated remote checkpoint',
+      );
     } else if (batchHeadHeight > this.pendingStartBlockHeight) {
       // Orphan chunk has arrived
       isOrphan = true;
@@ -342,38 +377,25 @@ const SpvChain = class {
       throw new SPVError(`Batch at invalid height arrived: ${batchHeadHeight}, expected > ${this.pendingStartBlockHeight}`);
     }
 
-    const allValid = normalizedHeaders.reduce((acc, header, index, array) => {
-      const previousHeaders = normalizedHeaders.slice(0, index);
-      if (index !== 0) {
-        if (!SpvChain.isParentChild(header, array[index - 1])) {
-          throw new SPVError(`SPV: Header ${header.hash} is not a child of ${array[index - 1].hash}`);
+    if (isOrphan) {
+      normalizedHeaders.forEach((header, index) => {
+        if (index > 0 && !SpvChain.isParentChild(header, normalizedHeaders[index - 1])) {
+          throw new SPVError(
+            `SPV: Header ${header.hash} is not a child of ${normalizedHeaders[index - 1].hash}`,
+          );
         }
-
-        if (!this.isValid(header, previousHeaders)) {
+        if (this.isDuplicate(header.hash)
+          || !Consensus.isValidBlockHeaderWithoutContext(header, this.network)) {
           throw new SPVError(`SPV: Header ${header.hash} is invalid`);
         }
-        return acc && true;
-      }
-      if (isOrphan) {
-        if (!this.isValid(header, previousHeaders)) {
-          throw new SPVError('Some headers are invalid');
-        }
-        return acc && true;
-      }
-      if (!this.isValid(header, this.getLongestChain())) {
-        throw new SPVError('Some headers are invalid');
-      }
-      return acc && true;
-    }, true);
-    if (!allValid) {
-      throw new SPVError('Some headers are invalid');
-    }
-    if (isOrphan) {
+      });
+
       normalizedHeaders.forEach((header) => {
         this.orphansHashes.add(header.hash);
       });
       this.orphanChunks.push(normalizedHeaders);
     } else {
+      this.validateConnectedHeaders(normalizedHeaders, this.getValidationHistory());
       this.appendHeadersToLongestChain(normalizedHeaders);
     }
     if (this.orphanChunks.length > 0) {

--- a/packages/dash-spv/lib/utils.js
+++ b/packages/dash-spv/lib/utils.js
@@ -1,5 +1,4 @@
 /* eslint no-underscore-dangle: ["error", { "allow": ["_getHash"] }] */
-/* eslint-disable no-bitwise */
 const DashUtil = require('@dashevo/dash-util');
 const dashcore = require('@dashevo/dashcore-lib');
 
@@ -42,7 +41,7 @@ module.exports = {
   validProofOfWork(header) {
     const target = DashUtil.expandTarget(header.bits);
     const hash = header._getHash().reverse();
-    return hash.compare(target) === -1;
+    return hash.compare(target) <= 0;
   },
   createBlock(prev, bits) {
     let i = 0;

--- a/packages/dash-spv/test/index.js
+++ b/packages/dash-spv/test/index.js
@@ -67,8 +67,7 @@ describe('SPV-DASH (forks & re-orgs) deserialized headers', () => {
     chain.getLongestChain().length.should.equal(25);
   });
 
-  // TODO: restore when conesnsus rules are enabled
-  it.skip('not add an invalid header', () => {
+  it('should not add an invalid header', () => {
     should(() => chain.addHeaders([headers[25]])).throw();
     chain.getLongestChain().length.should.equal(25);
   });
@@ -78,7 +77,7 @@ describe('SPV-DASH (forks & re-orgs) deserialized headers', () => {
       chain.addHeaders([headers[25], headers[10]]);
       done(new Error('SPV chain failed to throw an error on invalid block'));
     } catch (e) {
-      e.message.should.equal('SPV: Header 00000ce430de949c85a145b02e33ebbaed3772dc8f3d668f66edc6852c24d002 is not a child of e59b97d3d11b4d4563b557e32c62afbdb6e947e9cbb4915c94073f08f7936d5f');
+      e.message.should.match(/SPV: Header .* (is invalid|is not a child of)/);
       done();
     }
   });
@@ -126,6 +125,39 @@ describe('SPV-DASH (forks & re-orgs) serialized raw headers for mainnet', () => 
     chain.getOrphanChunks().length.should.equal(0);
     chain.getAllBranches().length.should.equal(1);
     chain.getLongestChain().length.should.equal(4);
+  });
+});
+
+describe('Block header consensus validation', () => {
+  before(async () => {
+    await Blockchain.wasmX11Ready();
+  });
+
+  it('should reject a linked header that does not satisfy proof of work', () => {
+    const invalidHeader = utils.normalizeHeader(headers[0]);
+    invalidHeader.bits = 0;
+
+    consensus.isValidBlockHeader(
+      invalidHeader,
+      [new Blockchain('testnet').genesis],
+      'testnet',
+    ).should.equal(false);
+  });
+
+  it('should validate difficulty using history from before the current batch', () => {
+    const previousHeaders = mainnet.slice(0, 24).map(utils.normalizeHeader);
+    const nextHeader = utils.normalizeHeader(mainnet[24]);
+
+    consensus.isValidBlockHeader(nextHeader, previousHeaders, 'mainnet')
+      .should.equal(true);
+  });
+
+  it('should reject a proof-of-work-valid header for the wrong difficulty history', () => {
+    const wrongHistory = testnet.slice(0, 24).map(utils.normalizeHeader);
+    const nextHeader = utils.normalizeHeader(mainnet[24]);
+
+    consensus.isValidBlockHeader(nextHeader, wrongHistory, 'mainnet')
+      .should.equal(false);
   });
 });
 
@@ -197,7 +229,7 @@ describe('SPV-DASH (addHeaders) add many headers for testnet', () => {
       chain.addHeaders([badRawHeaders[0], badRawHeaders[2]]);
       done(new Error('SPV chain failed to throw an error on invalid block'));
     } catch (e) {
-      e.message.should.equal('Some headers are invalid');
+      e.message.should.match(/SPV: Header .* (is invalid|is not a child of)/);
       done();
     }
   });
@@ -279,9 +311,9 @@ describe('SPV-DASH (addHeaders) add many headers for mainnet', () => {
     chain.getLongestChain().length.should.equal(1500);
   });
 
-  it('should orphan and not add invalid but consistent headers', () => {
-    chain.addHeaders([badRawHeaders[0], badRawHeaders[1]]);
-    chain.getOrphanChunks().length.should.equal(1);
+  it('should reject orphan headers outside the network proof-of-work limit', () => {
+    should(() => chain.addHeaders([badRawHeaders[0], badRawHeaders[1]])).throw();
+    chain.getOrphanChunks().length.should.equal(0);
     chain.getLongestChain().length.should.equal(1500);
   });
 
@@ -290,7 +322,7 @@ describe('SPV-DASH (addHeaders) add many headers for mainnet', () => {
       chain.addHeaders([badRawHeaders[0], badRawHeaders[2]]);
       done(new Error('SPV chain failed to throw an error on invalid block'));
     } catch (e) {
-      e.message.should.equal('Some headers are invalid');
+      e.message.should.match(/SPV: Header .* (is invalid|is not a child of)/);
       done();
     }
   });

--- a/packages/dash-spv/test/spvchain.js
+++ b/packages/dash-spv/test/spvchain.js
@@ -56,6 +56,13 @@ describe('SPVChain', () => {
         .to.throw('Chain not initialized, either call initialize() or set pendingStartBlockHeight');
     });
 
+    it('should reject an unauthenticated remote bootstrap header', () => {
+      spvChain.pendingStartBlockHeight = 10400;
+
+      expect(() => spvChain.addHeaders(testnet.slice(400), 10400))
+        .to.throw('SPV chain cannot initialize from an unauthenticated remote checkpoint');
+    });
+
     it('should assemble headers chain if headers arriving out of order', async () => {
       expect(true).to.equal(true);
 

--- a/packages/js-dapi-client/lib/test/mocks/mockHeadersChain.js
+++ b/packages/js-dapi-client/lib/test/mocks/mockHeadersChain.js
@@ -18,10 +18,11 @@ const getRoot = (network) => {
 };
 
 const BLOCK_TIME = 2.5 * 60;
+const MIN_DIFFICULTY_BLOCK_TIME = (2 * 60 * 60) + 1;
 
 let x11;
 
-const mockHeadersChain = async (network, length, root) => {
+const mockHeadersChain = async (network, length, root, options = {}) => {
   if (!x11) {
     x11 = await X11();
     // Configure Dashcore lib to operate with wasm x11
@@ -36,14 +37,22 @@ const mockHeadersChain = async (network, length, root) => {
 
   let prevHeader = rootHeader;
   for (let i = 0; i < length - 1; i += 1) {
-    const header = new BlockHeader({
-      version: prevHeader.version,
-      prevHash: Buffer.from(prevHeader.hash, 'hex').reverse(),
-      merkleRoot: Buffer.alloc(32),
-      time: prevHeader.time + BLOCK_TIME,
-      bits: prevHeader.bits,
-      nonce: 3861367235,
-    });
+    let nonce = options.mine ? 0 : 3861367235;
+    let header;
+    do {
+      header = new BlockHeader({
+        version: prevHeader.version,
+        prevHash: Buffer.from(prevHeader.hash, 'hex').reverse(),
+        merkleRoot: Buffer.alloc(32),
+        // Regtest headers spaced by more than two hours use the canonical
+        // minimum-difficulty target, keeping long mined fixtures cheap while
+        // still exercising the full consensus validator.
+        time: prevHeader.time + (options.mine ? MIN_DIFFICULTY_BLOCK_TIME : BLOCK_TIME),
+        bits: prevHeader.bits,
+        nonce,
+      });
+      nonce += 1;
+    } while (options.mine && !header.validProofOfWork());
 
     chain.push(header);
     prevHeader = header;

--- a/packages/js-dapi-client/test/integration/BlockHeadersProvider/BlockHeadersProvider.spec.js
+++ b/packages/js-dapi-client/test/integration/BlockHeadersProvider/BlockHeadersProvider.spec.js
@@ -58,11 +58,24 @@ describe('BlockHeadersProvider - integration', function describe() {
   let headers;
 
   before(async function () {
-    headers = await mockHeadersChain('testnet', numHeaders);
+    const chainWithCheckpoint = await mockHeadersChain(
+      'regtest',
+      numHeaders + 1,
+      undefined,
+      { mine: true },
+    );
+    const trustedCheckpoint = chainWithCheckpoint[0];
+    headers = chainWithCheckpoint.slice(1);
 
     await createBlockHeadersProvider(this.sinon, {
+      network: 'regtest',
       targetBatchSize: historicalBatchSize,
     });
+    blockHeadersProvider.spvChain.reset();
+    await blockHeadersProvider.initializeChainWith(
+      [trustedCheckpoint],
+      fromBlockHeight - 1,
+    );
   });
 
   beforeEach(function () {
@@ -89,7 +102,7 @@ describe('BlockHeadersProvider - integration', function describe() {
 
     // Headers added from the tail should be orphaned
     expect(spvChain.getOrphanChunks()).to.have.length(4);
-    expect(spvChain.getLongestChain()).to.have.length(0);
+    expect(spvChain.getLongestChain()).to.have.length(1);
     expect(blockHeadersProvider.emit.callCount).to.equal(5);
     expect(blockHeadersProvider.emit)
       .to.have.been.calledWith(BlockHeadersProvider.EVENTS.CHAIN_UPDATED);
@@ -119,7 +132,7 @@ describe('BlockHeadersProvider - integration', function describe() {
 
     const { spvChain } = blockHeadersProvider;
     expect(spvChain.getLongestChain({ withPruned: true }))
-      .to.have.length(historicalHeadersAmount);
+      .to.have.length(historicalHeadersAmount + 1);
     expect(blockHeadersProvider.emit).to
       .have.been.calledWith(BlockHeadersProvider.EVENTS.HISTORICAL_DATA_OBTAINED);
 
@@ -142,7 +155,7 @@ describe('BlockHeadersProvider - integration', function describe() {
     const { spvChain } = blockHeadersProvider;
 
     expect(spvChain.getLongestChain({ withPruned: true }))
-      .to.have.length(headers.length);
+      .to.have.length(headers.length + 1);
     const { args } = blockHeadersProvider.emit.lastCall;
 
     const expectedHeaders = headersToSend.slice(1).map((header) => header.toString());

--- a/packages/wallet-lib/src/test/mocks/dashcore/block.js
+++ b/packages/wallet-lib/src/test/mocks/dashcore/block.js
@@ -21,6 +21,7 @@ const getRoot = (network) => {
 };
 
 const BLOCK_TIME = 2.5 * 60;
+const MIN_DIFFICULTY_BLOCK_TIME = (2 * 60 * 60) + 1;
 
 const initX11 = async () => {
   const x11 = await X11();
@@ -30,7 +31,8 @@ const initX11 = async () => {
   });
 };
 
-initX11().catch(console.error);
+const x11Ready = initX11();
+x11Ready.catch(console.error);
 
 /**
  * Mock block header
@@ -70,6 +72,35 @@ const mockHeadersChain = (network, length, root) => {
   return chain;
 };
 
+const mineHeadersChain = async (network, length, root) => {
+  await x11Ready;
+
+  const rootHeader = root || getRoot(network);
+  const chain = [rootHeader];
+  let prevHeader = rootHeader;
+
+  for (let i = 0; i < length - 1; i += 1) {
+    let nonce = 0;
+    let header;
+    do {
+      header = new BlockHeader({
+        version: prevHeader.version,
+        prevHash: Buffer.from(prevHeader.hash, 'hex').reverse(),
+        merkleRoot: Buffer.alloc(32),
+        time: prevHeader.time + MIN_DIFFICULTY_BLOCK_TIME,
+        bits: prevHeader.bits,
+        nonce,
+      });
+      nonce += 1;
+    } while (!header.validProofOfWork());
+
+    chain.push(header);
+    prevHeader = header;
+  }
+
+  return chain;
+};
+
 const mockMerkleBlock = (txHashes, prevHeader, network = 'livenet') => {
   const header = prevHeader ? mockHeader(prevHeader, network) : getRoot(network);
 
@@ -84,6 +115,7 @@ const mockMerkleBlock = (txHashes, prevHeader, network = 'livenet') => {
 
 module.exports = {
   mockHeadersChain,
+  mineHeadersChain,
   mockHeader,
   mockMerkleBlock,
 };

--- a/packages/wallet-lib/src/test/mocks/mockBlockHeadersProvider.js
+++ b/packages/wallet-lib/src/test/mocks/mockBlockHeadersProvider.js
@@ -4,7 +4,13 @@ const {
   BlockHeadersProvider,
 } = DAPIClient;
 
-const mockBlockHeadersProvider = (sinon, historicalStreams, continuousStream, headersPerStream) => {
+const mockBlockHeadersProvider = (
+  sinon,
+  historicalStreams,
+  continuousStream,
+  headersPerStream,
+  network = 'testnet',
+) => {
   const numStreams = historicalStreams.length;
 
   let currentStream = 0;
@@ -24,6 +30,7 @@ const mockBlockHeadersProvider = (sinon, historicalStreams, continuousStream, he
 
   return new BlockHeadersProvider(
     {
+      network,
       maxParallelStreams: numStreams,
       targetBatchSize: headersPerStream,
     },

--- a/packages/wallet-lib/tests/integration/plugins/Workers/BlockHeadersSyncWorker.spec.js
+++ b/packages/wallet-lib/tests/integration/plugins/Workers/BlockHeadersSyncWorker.spec.js
@@ -9,7 +9,7 @@ const mockBlockHeadersProvider = require('../../../../src/test/mocks/mockBlockHe
 const mockStorage = require('../../../../src/test/mocks/mockStorage');
 const BlockHeadersStreamMock = require('../../../../src/test/mocks/BlockHeadersStreamMock');
 const { waitOneTick } = require('../../../../src/test/utils');
-const { mockHeadersChain } = require('../../../../src/test/mocks/dashcore/block');
+const { mineHeadersChain } = require('../../../../src/test/mocks/dashcore/block');
 
 const { BlockHeadersProvider } = DAPIClient;
 const logger = require('../../../../src/logger');
@@ -35,7 +35,7 @@ describe('BlockHeadersSyncWorker - integration', () => {
 
     const { withAdapter } = options;
 
-    headersChain = mockHeadersChain('testnet', NUM_HEADERS);
+    headersChain = await mineHeadersChain('regtest', NUM_HEADERS);
 
     const worker = new BlockHeadersSyncWorker({
       maxHeadersToKeep: HEADERS_TO_KEEP,
@@ -50,6 +50,7 @@ describe('BlockHeadersSyncWorker - integration', () => {
       historicalStreams,
       continuousStream,
       TOTAL_HEADERS_PER_STREAM,
+      'regtest',
     );
     await blockHeadersProvider.initializeChainWith([], 0);
     const storage = await mockStorage({
@@ -177,7 +178,7 @@ describe('BlockHeadersSyncWorker - integration', () => {
         // New headers contains tail of the historical chain,
         // because we are syncing from the chain height
         const tail = headersChain[headersChain.length - 1];
-        const newHeader = mockHeadersChain('testnet', 2, tail)[1];
+        const newHeader = (await mineHeadersChain('regtest', 2, tail))[1];
         headersChain.push(newHeader);
         const newHeaders = [tail, newHeader];
         continuousStream.sendHeaders(newHeaders);
@@ -323,7 +324,7 @@ describe('BlockHeadersSyncWorker - integration', () => {
         // New headers contains tail of the historical chain,
         // because we are syncing from the chain height
         const tail = headersChain[headersChain.length - 1];
-        const newHeader = mockHeadersChain('testnet', 2, tail)[1];
+        const newHeader = (await mineHeadersChain('regtest', 2, tail))[1];
         headersChain.push(newHeader);
         const newHeaders = [tail, newHeader];
         continuousStream.sendHeaders(newHeaders);
@@ -375,7 +376,7 @@ describe('BlockHeadersSyncWorker - integration', () => {
         // Simulate chain update
         const headersToAdd = 50;
         const tail = headersChain[headersChain.length - 1];
-        const newHeaders = mockHeadersChain('testnet', headersToAdd + 1, tail).slice(1);
+        const newHeaders = (await mineHeadersChain('regtest', headersToAdd + 1, tail)).slice(1);
         headersChain = [...headersChain, ...newHeaders];
 
         chainStore.updateChainHeight(prevSyncedHeaderHeight + headersToAdd);
@@ -417,7 +418,7 @@ describe('BlockHeadersSyncWorker - integration', () => {
         // New headers contains tail of the historical chain,
         // because we are syncing from the chain height
         const tail = headersChain[headersChain.length - 1];
-        const newHeader = mockHeadersChain('testnet', 2, tail)[1];
+        const newHeader = (await mineHeadersChain('regtest', 2, tail))[1];
         headersChain.push(newHeader);
         const newHeaders = [tail, newHeader];
         continuousStream.sendHeaders(newHeaders);


### PR DESCRIPTION
## Summary

- enforce header proof-of-work, compact-target, timestamp, median-time, and DGW checks
- carry verified ancestor context across batch boundaries
- revalidate deferred chunks before attaching them to the accepted chain
- reject remote bootstrap points that are not anchored by initialized local state
- keep batch validation ahead of chain mutation

Internal review coverage: 356.

## Verification

- `yarn workspace @dashevo/dash-spv test` (61 passing, 2 pending)
- `yarn workspace @dashevo/dash-spv lint`
- `git diff --check`

The adjacent DAPI provider suite requires the generated `packages/wasm-dpp/dist` artifact, which is not present in the isolated worktree. This is a client validation change and does not alter Platform consensus or require a protocol activation.