### PR TITLE
fix(dashmate): restrict helper API capabilities

### DIFF
--- a/packages/dashmate/src/helper/api/createHttpApiServerFactory.js
+++ b/packages/dashmate/src/helper/api/createHttpApiServerFactory.js
@@ -61,7 +61,10 @@ export default function createHttpApiServerFactory() {
           try {
             const { execute } = await import('@oclif/core');
             return await execute({ dir: import.meta.url, args: argv });
-          } catch {
+          } catch (error) {
+            // Log the real failure for the operator; the client still only
+            // sees the generic error so no internals leak over the API.
+            console.error('Helper API status request failed:', error);
             throw server.error(-32603, 'Status request failed');
           }
         });

--- a/packages/dashmate/src/helper/api/createHttpApiServerFactory.js
+++ b/packages/dashmate/src/helper/api/createHttpApiServerFactory.js
@@ -1,5 +1,41 @@
 import jayson from 'jayson/promise/index.js';
 
+const STATUS_METHOD = 'status';
+const ALLOWED_STATUS_PARAMETERS = new Set(['config', 'format']);
+const SAFE_CONFIG_NAME_PATTERN = /^[a-zA-Z0-9][a-zA-Z0-9_-]{0,63}$/;
+
+/**
+ * Convert the deliberately narrow helper API request into CLI arguments.
+ *
+ * @param {string} method
+ * @param {Object} params
+ * @returns {string[]|null}
+ */
+export function createHelperCommandArgs(method, params) {
+  if (method !== STATUS_METHOD) {
+    return null;
+  }
+
+  if (params === null || Array.isArray(params) || typeof params !== 'object') {
+    throw new TypeError('Status parameters must be an object');
+  }
+
+  const parameterNames = Object.keys(params);
+  if (parameterNames.some((name) => !ALLOWED_STATUS_PARAMETERS.has(name))) {
+    throw new TypeError('Unsupported status parameter');
+  }
+
+  if (params.format !== 'json') {
+    throw new TypeError('Status format must be json');
+  }
+
+  if (typeof params.config !== 'string' || !SAFE_CONFIG_NAME_PATTERN.test(params.config)) {
+    throw new TypeError('Invalid config name');
+  }
+
+  return [STATUS_METHOD, `--format=${params.format}`, `--config=${params.config}`];
+}
+
 export default function createHttpApiServerFactory() {
   /**
    * @return {HttpServer}
@@ -7,23 +43,26 @@ export default function createHttpApiServerFactory() {
   function createHttpApiServer() {
     const server = new jayson.Server({}, {
       router(method, params) {
-        const argv = method.split(' ');
+        let argv;
 
-        // map arguments to argv
-        if (Array.isArray(params)) {
-          argv.push(...params);
-        } else {
-          for (const [name, value] of Object.entries(params)) {
-            argv.push(`--${name}=${value}`);
-          }
+        try {
+          argv = createHelperCommandArgs(method, params);
+        } catch (error) {
+          return new jayson.Method(async () => {
+            throw server.error(-32602, error.message);
+          });
+        }
+
+        if (argv === null) {
+          return undefined;
         }
 
         return new jayson.Method(async () => {
           try {
             const { execute } = await import('@oclif/core');
             return await execute({ dir: import.meta.url, args: argv });
-          } catch (e) {
-            throw server.error(501, e.message);
+          } catch {
+            throw server.error(-32603, 'Status request failed');
           }
         });
       },

--- a/packages/dashmate/templates/dynamic-compose.yml.dot
+++ b/packages/dashmate/templates/dynamic-compose.yml.dot
@@ -5,7 +5,7 @@ services:
     command:
       - dashd
       {{~ it.core.docker.commandArgs :arg }}
-      - {{=arg}}
+      - {{=JSON.stringify(arg)}}
       {{~}}
     {{? it.core.log.filePath !== null }}
     volumes:

--- a/packages/dashmate/test/unit/helper/api/createHttpApiServerFactory.spec.js
+++ b/packages/dashmate/test/unit/helper/api/createHttpApiServerFactory.spec.js
@@ -1,0 +1,48 @@
+import { expect } from 'chai';
+import { createHelperCommandArgs } from '../../../../src/helper/api/createHttpApiServerFactory.js';
+
+describe('createHttpApiServerFactory', () => {
+  describe('createHelperCommandArgs', () => {
+    it('creates arguments for a JSON status request', () => {
+      expect(createHelperCommandArgs('status', {
+        format: 'json',
+        config: 'testnet-1',
+      })).to.deep.equal([
+        'status',
+        '--format=json',
+        '--config=testnet-1',
+      ]);
+    });
+
+    it('does not route commands other than status', () => {
+      expect(createHelperCommandArgs('config get', {})).to.equal(null);
+      expect(createHelperCommandArgs('reset', {})).to.equal(null);
+    });
+
+    it('rejects positional and extra parameters', () => {
+      expect(() => createHelperCommandArgs('status', ['--format=json']))
+        .to.throw('Status parameters must be an object');
+      expect(() => createHelperCommandArgs('status', {
+        format: 'json',
+        config: 'testnet',
+        verbose: true,
+      })).to.throw('Unsupported status parameter');
+    });
+
+    it('requires the JSON output format', () => {
+      expect(() => createHelperCommandArgs('status', {
+        format: 'plain',
+        config: 'testnet',
+      })).to.throw('Status format must be json');
+    });
+
+    it('rejects unsafe config names', () => {
+      for (const config of ['', '../mainnet', 'name/child', 'name\nnext']) {
+        expect(() => createHelperCommandArgs('status', {
+          format: 'json',
+          config,
+        })).to.throw('Invalid config name');
+      }
+    });
+  });
+});

--- a/packages/dashmate/test/unit/templates/dynamicComposeBuildArgs.spec.js
+++ b/packages/dashmate/test/unit/templates/dynamicComposeBuildArgs.spec.js
@@ -11,12 +11,12 @@ const TEMPLATE_PATH = path.resolve(
   '../../../templates/dynamic-compose.yml.dot',
 );
 
-function render(buildArgsByService) {
+function render(buildArgsByService, coreCommandArgs = []) {
   dot.templateSettings.strip = false;
   const tpl = fs.readFileSync(TEMPLATE_PATH, 'utf8');
   const fn = dot.template(tpl);
   return fn({
-    core: { docker: { commandArgs: [] }, log: { filePath: null } },
+    core: { docker: { commandArgs: coreCommandArgs }, log: { filePath: null } },
     platform: {
       drive: {
         abci: {
@@ -61,6 +61,14 @@ describe('dynamic-compose buildArgs rendering', () => {
 
     const parsed = yaml.load(out);
     expect(parsed.services.drive_abci.build.args.TRICKY).to.equal(tricky);
+  });
+
+  it('escapes core command arguments as YAML strings', () => {
+    const commandArgs = ['--safe=value', '--multiline=a\nb', '--quoted="value"'];
+    const out = render({}, commandArgs);
+
+    const parsed = yaml.load(out);
+    expect(parsed.services.core.command).to.deep.equal(['dashd', ...commandArgs]);
   });
 
   it('omits the build block entirely when buildArgs is empty', () => {


### PR DESCRIPTION
## Summary

- replace the opt-in helper's generic CLI dispatcher with an exact read-only `status` method allowlist
- require typed `config` and `format=json` parameters and reject unsafe configuration names
- serialize Core command arguments as quoted YAML scalars before generating dynamic Compose configuration
- avoid returning internal command errors across the HTTP boundary

## Security review coverage

Addresses DS-CAND-015, DS-CAND-016, DS-CAND-021, DS-CAND-053, DS-CAND-054, and DS-CAND-272.

## Validation

- `yarn workspace dashmate exec mocha test/unit/helper/api/createHttpApiServerFactory.spec.js test/unit/templates/dynamicComposeBuildArgs.spec.js` (10 passing)
- `yarn workspace dashmate lint` (0 errors; pre-existing warnings only)
- `git diff --check`

The recursive unit command remains blocked in this isolated worktree because the generated `packages/wasm-dpp/dist` artifact is not present; the directly affected tests pass.
