### PR TITLE
fix(drive-abci): bound CheckTx verification work

### DIFF
--- a/packages/rs-drive-abci/src/abci/app/check_tx.rs
+++ b/packages/rs-drive-abci/src/abci/app/check_tx.rs
@@ -95,7 +95,14 @@ where
 }
 
 pub fn error_into_status(error: Error) -> tonic::Status {
-    tonic::Status::internal(error.to_string())
+    match error {
+        Error::Execution(crate::error::execution::ExecutionError::CheckTxProofVerificationBusy) => {
+            tonic::Status::resource_exhausted(
+                "check tx verification capacity is temporarily unavailable",
+            )
+        }
+        error => tonic::Status::internal(error.to_string()),
+    }
 }
 
 #[cfg(test)]
@@ -119,6 +126,16 @@ mod tests {
         let status = error_into_status(error);
 
         assert!(status.message().contains("no active transaction"));
+    }
+
+    #[test]
+    fn error_into_status_marks_proof_capacity_as_retryable() {
+        let status = error_into_status(Error::Execution(
+            ExecutionError::CheckTxProofVerificationBusy,
+        ));
+
+        assert_eq!(status.code(), tonic::Code::ResourceExhausted);
+        assert!(!status.message().contains("proof"));
     }
 
     #[test]

--- a/packages/rs-drive-abci/src/abci/app/mod.rs
+++ b/packages/rs-drive-abci/src/abci/app/mod.rs
@@ -11,6 +11,8 @@ mod full;
 
 use crate::execution::types::block_execution_context::BlockExecutionContext;
 use crate::rpc::core::DefaultCoreRPC;
+#[cfg(test)]
+pub(crate) use check_tx::error_into_status;
 pub use check_tx::CheckTxAbciApplication;
 pub use consensus::ConsensusAbciApplication;
 use dpp::version::PlatformVersion;

--- a/packages/rs-drive-abci/src/abci/handler/check_tx.rs
+++ b/packages/rs-drive-abci/src/abci/handler/check_tx.rs
@@ -186,8 +186,19 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::abci::app::error_into_status;
+    use crate::execution::validation::state_transition::test_helpers::{
+        create_dummy_serialized_action, insert_anchor_into_state, set_pool_total_balance,
+        setup_platform,
+    };
     use crate::rpc::core::MockCoreRPCLike;
     use crate::test::helpers::setup::TestPlatformBuilder;
+    use dpp::serialization::PlatformSerializable;
+    use dpp::state_transition::shielded_transfer_transition::v0::ShieldedTransferTransitionV0;
+    use dpp::state_transition::shielded_transfer_transition::ShieldedTransferTransition;
+    use dpp::state_transition::StateTransition;
+    use dpp::version::PlatformVersion;
+    use tenderdash_abci::proto::tonic;
 
     /// Exercises the early-return path in `check_tx` where `r#type.try_into()?`
     /// propagates a `BadRequest` error before the validation result pipeline is
@@ -291,5 +302,43 @@ mod tests {
             .expect("empty tx should not propagate an Err");
 
         assert_ne!(response.code, 0);
+    }
+
+    #[test]
+    fn occupied_proof_capacity_reaches_resource_exhausted_status() {
+        let platform_version = PlatformVersion::latest();
+        let platform = setup_platform();
+        set_pool_total_balance(&platform, 1_000_000_000);
+        let anchor = [42; 32];
+        insert_anchor_into_state(&platform, &anchor);
+
+        let fee = dpp::shielded::compute_minimum_shielded_fee(1, platform_version)
+            .expect("minimum shielded fee");
+        let transition = StateTransition::ShieldedTransfer(ShieldedTransferTransition::V0(
+            ShieldedTransferTransitionV0 {
+                actions: vec![create_dummy_serialized_action()],
+                value_balance: fee,
+                anchor,
+                proof: vec![0; 100],
+                binding_signature: [0; 64],
+            },
+        ));
+        let tx = transition
+            .serialize_to_bytes()
+            .expect("serialize transition");
+
+        let _held_permit = platform
+            .check_tx_proof_verifier
+            .try_acquire(usize::MAX)
+            .expect("occupy proof capacity");
+        let error = check_tx(
+            &platform.platform,
+            &MockCoreRPCLike::new(),
+            proto::RequestCheckTx { tx, r#type: 0 },
+        )
+        .expect_err("handler must propagate retryable proof backpressure");
+        let status = error_into_status(error);
+
+        assert_eq!(status.code(), tonic::Code::ResourceExhausted);
     }
 }

--- a/packages/rs-drive-abci/src/abci/handler/check_tx.rs
+++ b/packages/rs-drive-abci/src/abci/handler/check_tx.rs
@@ -148,6 +148,13 @@ where
             })
         })
         .or_else(|error| {
+            if matches!(
+                error,
+                Error::Execution(ExecutionError::CheckTxProofVerificationBusy)
+            ) {
+                return Err(error);
+            }
+
             let handler_error = HandlerError::Internal(error.to_string());
 
             if tracing::enabled!(tracing::Level::ERROR) {

--- a/packages/rs-drive-abci/src/error/execution.rs
+++ b/packages/rs-drive-abci/src/error/execution.rs
@@ -139,4 +139,8 @@ pub enum ExecutionError {
     /// General IO Error
     #[error("io error: {0}")]
     IOError(#[from] std::io::Error),
+
+    /// CheckTx proof-verification capacity is currently unavailable.
+    #[error("check tx proof verification capacity is temporarily unavailable")]
+    CheckTxProofVerificationBusy,
 }

--- a/packages/rs-drive-abci/src/execution/check_tx/v0/mod.rs
+++ b/packages/rs-drive-abci/src/execution/check_tx/v0/mod.rs
@@ -158,6 +158,7 @@ where
             platform_ref,
             state_transition,
             check_tx_level,
+            &self.check_tx_proof_verifier,
             platform_version,
         )?;
 

--- a/packages/rs-drive-abci/src/execution/validation/state_transition/check_tx_verification/mod.rs
+++ b/packages/rs-drive-abci/src/execution/validation/state_transition/check_tx_verification/mod.rs
@@ -3,6 +3,7 @@ pub(crate) mod v0;
 use crate::error::execution::ExecutionError;
 use crate::error::Error;
 use crate::execution::types::execution_event::ExecutionEvent;
+use crate::platform_types::check_tx_proof_verifier::CheckTxProofVerifier;
 use crate::platform_types::platform::PlatformRef;
 use crate::rpc::core::CoreRPCLike;
 use dpp::prelude::ConsensusValidationResult;
@@ -26,6 +27,7 @@ pub(in crate::execution) fn state_transition_to_execution_event_for_check_tx<'a,
     platform: &'a PlatformRef<C>,
     state_transition: StateTransition,
     check_tx_level: CheckTxLevel,
+    proof_verifier: &CheckTxProofVerifier,
     platform_version: &PlatformVersion,
 ) -> Result<ConsensusValidationResult<Option<ExecutionEvent<'a>>>, Error> {
     match platform_version
@@ -37,6 +39,7 @@ pub(in crate::execution) fn state_transition_to_execution_event_for_check_tx<'a,
             platform,
             state_transition,
             check_tx_level,
+            proof_verifier,
             platform_version,
         ),
         version => Err(Error::Execution(ExecutionError::UnknownVersionMismatch {

--- a/packages/rs-drive-abci/src/execution/validation/state_transition/check_tx_verification/v0/mod.rs
+++ b/packages/rs-drive-abci/src/execution/validation/state_transition/check_tx_verification/v0/mod.rs
@@ -1,6 +1,7 @@
 use crate::error::Error;
 use crate::execution::types::execution_event::ExecutionEvent;
 use crate::execution::validation::state_transition::transformer::StateTransitionActionTransformer;
+use crate::execution::validation::state_transition::shield_from_asset_lock::StateTransitionShieldFromAssetLockTransitionActionTransformer;
 use crate::platform_types::platform::PlatformRef;
 use crate::platform_types::check_tx_proof_verifier::CheckTxProofVerifier;
 use crate::platform_types::platform_state::PlatformStateV0Methods;
@@ -28,6 +29,41 @@ use crate::execution::validation::state_transition::processor::is_allowed::State
 use crate::execution::validation::state_transition::processor::state::StateTransitionStateValidation;
 use crate::execution::validation::state_transition::ValidationMode;
 use crate::execution::validation::state_transition::processor::traits::address_balances_and_nonces::StateTransitionAddressBalancesAndNoncesValidation;
+use drive::state_transition_action::StateTransitionAction;
+use std::collections::BTreeMap;
+use dpp::address_funds::PlatformAddress;
+use dpp::fee::Credits;
+use dpp::prelude::AddressNonce;
+
+fn transform_into_action_for_check_tx<C: CoreRPCLike>(
+    state_transition: &StateTransition,
+    platform: &PlatformRef<C>,
+    remaining_address_balances: &Option<BTreeMap<PlatformAddress, (AddressNonce, Credits)>>,
+    validation_mode: ValidationMode,
+    execution_context: &mut StateTransitionExecutionContext,
+    proof_verifier: &CheckTxProofVerifier,
+) -> Result<ConsensusValidationResult<StateTransitionAction>, Error> {
+    match state_transition {
+        StateTransition::ShieldFromAssetLock(transition) => transition
+            .transform_into_action_for_shield_from_asset_lock_transition(
+                platform,
+                state_transition.signable_bytes()?,
+                validation_mode,
+                platform.state.last_block_info(),
+                execution_context,
+                Some(proof_verifier),
+                None,
+            ),
+        _ => state_transition.transform_into_action(
+            platform,
+            platform.state.last_block_info(),
+            remaining_address_balances,
+            validation_mode,
+            execution_context,
+            None,
+        ),
+    }
+}
 
 /// Changes the state transition to the execution event.
 /// As this is for check tx it normally does not need to be versioned.
@@ -242,13 +278,13 @@ pub(super) fn state_transition_to_execution_event_for_check_tx_v0<'a, C: CoreRPC
             let action = if state_transition
                 .requires_advanced_structure_validation_with_state_on_check_tx()
             {
-                let state_transition_action_result = state_transition.transform_into_action(
+                let state_transition_action_result = transform_into_action_for_check_tx(
+                    &state_transition,
                     platform,
-                    platform.state.last_block_info(),
                     &remaining_address_balances,
                     ValidationMode::CheckTx,
                     &mut state_transition_execution_context,
-                    None,
+                    proof_verifier,
                 )?;
                 if !state_transition_action_result.is_valid_with_data() {
                     return Ok(
@@ -307,13 +343,13 @@ pub(super) fn state_transition_to_execution_event_for_check_tx_v0<'a, C: CoreRPC
             let action = if let Some(action) = action {
                 action
             } else {
-                let state_transition_action_result = state_transition.transform_into_action(
+                let state_transition_action_result = transform_into_action_for_check_tx(
+                    &state_transition,
                     platform,
-                    platform.state.last_block_info(),
                     &remaining_address_balances,
                     ValidationMode::CheckTx,
                     &mut state_transition_execution_context,
-                    None,
+                    proof_verifier,
                 )?;
                 if !state_transition_action_result.is_valid_with_data() {
                     return Ok(
@@ -426,13 +462,13 @@ pub(super) fn state_transition_to_execution_event_for_check_tx_v0<'a, C: CoreRPC
                     }
                 }
 
-                let state_transition_action_result = state_transition.transform_into_action(
+                let state_transition_action_result = transform_into_action_for_check_tx(
+                    &state_transition,
                     platform,
-                    platform.state.last_block_info(),
                     &remaining_address_balances,
                     ValidationMode::RecheckTx,
                     &mut state_transition_execution_context,
-                    None,
+                    proof_verifier,
                 )?;
 
                 if !state_transition_action_result.is_valid_with_data() {

--- a/packages/rs-drive-abci/src/execution/validation/state_transition/check_tx_verification/v0/mod.rs
+++ b/packages/rs-drive-abci/src/execution/validation/state_transition/check_tx_verification/v0/mod.rs
@@ -2,6 +2,7 @@ use crate::error::Error;
 use crate::execution::types::execution_event::ExecutionEvent;
 use crate::execution::validation::state_transition::transformer::StateTransitionActionTransformer;
 use crate::platform_types::platform::PlatformRef;
+use crate::platform_types::check_tx_proof_verifier::CheckTxProofVerifier;
 use crate::platform_types::platform_state::PlatformStateV0Methods;
 use crate::rpc::core::CoreRPCLike;
 use dpp::identity::state_transition::OptionallyAssetLockProved;
@@ -35,6 +36,7 @@ pub(super) fn state_transition_to_execution_event_for_check_tx_v0<'a, C: CoreRPC
     platform: &'a PlatformRef<C>,
     state_transition: StateTransition,
     check_tx_level: CheckTxLevel,
+    proof_verifier: &CheckTxProofVerifier,
     platform_version: &PlatformVersion,
 ) -> Result<ConsensusValidationResult<Option<ExecutionEvent<'a>>>, Error> {
     // we need to validate the structure, the fees, and the signature
@@ -139,19 +141,6 @@ pub(super) fn state_transition_to_execution_event_for_check_tx_v0<'a, C: CoreRPC
             // address inputs and ShieldFromAssetLock pays from the asset lock.
             if state_transition.has_shielded_minimum_fee_validation() {
                 let result = state_transition.validate_minimum_shielded_fee(platform_version)?;
-                if !result.is_valid() {
-                    return Ok(
-                        ConsensusValidationResult::<Option<ExecutionEvent>>::new_with_errors(
-                            result.errors,
-                        ),
-                    );
-                }
-            }
-
-            // Verify ZK proof for shielded transitions (stateless, like signature verification).
-            // This happens before any state reads to reject invalid proofs cheaply.
-            if state_transition.has_shielded_proof_validation() {
-                let result = state_transition.validate_shielded_proof(platform_version)?;
                 if !result.is_valid() {
                     return Ok(
                         ConsensusValidationResult::<Option<ExecutionEvent>>::new_with_errors(
@@ -336,6 +325,25 @@ pub(super) fn state_transition_to_execution_event_for_check_tx_v0<'a, C: CoreRPC
                 state_transition_action_result.into_data()?
             };
 
+            // Run proof verification only after cheap current-state admission has
+            // accepted the transition. CheckTx uses a node-local, fail-fast budget;
+            // proposal and block execution do not share it and retain capacity.
+            if state_transition.has_shielded_proof_validation() {
+                let _permit = proof_verifier
+                    .try_acquire(state_transition.shielded_proof_action_count())
+                    .ok_or(Error::Execution(
+                        ExecutionError::CheckTxProofVerificationBusy,
+                    ))?;
+                let result = state_transition.validate_shielded_proof(platform_version)?;
+                if !result.is_valid() {
+                    return Ok(
+                        ConsensusValidationResult::<Option<ExecutionEvent>>::new_with_errors(
+                            result.errors,
+                        ),
+                    );
+                }
+            }
+
             let execution_event = ExecutionEvent::create_from_state_transition_action(
                 action,
                 maybe_identity,
@@ -475,6 +483,10 @@ pub(super) fn state_transition_to_execution_event_for_check_tx_v0<'a, C: CoreRPC
 mod tests {
     use super::*;
     use crate::execution::check_tx::CheckTxLevel;
+    use crate::execution::validation::state_transition::state_transitions::test_helpers::{
+        create_dummy_serialized_action, insert_anchor_into_state, set_pool_total_balance,
+        setup_platform,
+    };
     use crate::execution::validation::state_transition::state_transitions::tests::setup_identity;
     use crate::platform_types::platform::PlatformRef;
     use crate::platform_types::platform_state::PlatformStateV0Methods;
@@ -491,6 +503,8 @@ mod tests {
     use dpp::serialization::PlatformSerializable;
     use dpp::state_transition::data_contract_create_transition::methods::DataContractCreateTransitionMethodsV0;
     use dpp::state_transition::data_contract_create_transition::DataContractCreateTransition;
+    use dpp::state_transition::shielded_transfer_transition::v0::ShieldedTransferTransitionV0;
+    use dpp::state_transition::shielded_transfer_transition::ShieldedTransferTransition;
     use dpp::tests::json_document::json_document_to_contract_with_ids;
     use dpp::version::DefaultForPlatformVersion;
     use platform_version::version::PlatformVersion;
@@ -543,6 +557,71 @@ mod tests {
     mod first_time_check {
         use super::*;
 
+        fn shielded_transfer_with_dummy_proof(anchor: [u8; 32]) -> StateTransition {
+            let fee = dpp::shielded::compute_minimum_shielded_fee(1, PlatformVersion::latest())
+                .expect("minimum shielded fee");
+
+            StateTransition::ShieldedTransfer(ShieldedTransferTransition::V0(
+                ShieldedTransferTransitionV0 {
+                    actions: vec![create_dummy_serialized_action()],
+                    value_balance: fee,
+                    anchor,
+                    proof: vec![0; 100],
+                    binding_signature: [0; 64],
+                },
+            ))
+        }
+
+        #[test]
+        fn shielded_state_admission_precedes_proof_capacity() {
+            let platform_version = PlatformVersion::latest();
+            let platform = setup_platform();
+            set_pool_total_balance(&platform, 1_000_000_000);
+
+            let verifier = CheckTxProofVerifier::new(1);
+            let _held_permit = verifier.try_acquire(1).expect("held test permit");
+
+            let platform_state = platform.state.load();
+            let platform_ref = PlatformRef {
+                drive: &platform.drive,
+                state: &platform_state,
+                config: &platform.config,
+                core_rpc: &platform.core_rpc,
+            };
+
+            let missing_anchor = [42; 32];
+            let result = state_transition_to_execution_event_for_check_tx_v0(
+                &platform_ref,
+                shielded_transfer_with_dummy_proof(missing_anchor),
+                CheckTxLevel::FirstTimeCheck,
+                &verifier,
+                platform_version,
+            )
+            .expect("state rejection must occur before proof admission");
+
+            assert!(result.errors.iter().any(|error| matches!(
+                error,
+                ConsensusError::StateError(StateError::InvalidAnchorError(_))
+            )));
+
+            insert_anchor_into_state(&platform, &missing_anchor);
+            let error = match state_transition_to_execution_event_for_check_tx_v0(
+                &platform_ref,
+                shielded_transfer_with_dummy_proof(missing_anchor),
+                CheckTxLevel::FirstTimeCheck,
+                &verifier,
+                platform_version,
+            ) {
+                Err(error) => error,
+                Ok(_) => panic!("admissible proof work must fail fast when capacity is occupied"),
+            };
+
+            assert!(matches!(
+                error,
+                Error::Execution(ExecutionError::CheckTxProofVerificationBusy)
+            ));
+        }
+
         #[tokio::test]
         async fn should_return_valid_result_for_data_contract_create() {
             let platform_version = PlatformVersion::latest();
@@ -561,6 +640,7 @@ mod tests {
                 &platform_ref,
                 state_transition,
                 CheckTxLevel::FirstTimeCheck,
+                &platform.check_tx_proof_verifier,
                 platform_version,
             );
 
@@ -595,6 +675,7 @@ mod tests {
                 &platform_ref,
                 state_transition,
                 CheckTxLevel::FirstTimeCheck,
+                &platform.check_tx_proof_verifier,
                 platform_version,
             );
 
@@ -661,6 +742,7 @@ mod tests {
                 &platform_ref,
                 state_transition,
                 CheckTxLevel::FirstTimeCheck,
+                &platform.check_tx_proof_verifier,
                 platform_version,
             );
 
@@ -728,6 +810,7 @@ mod tests {
                 &platform_ref,
                 state_transition,
                 CheckTxLevel::FirstTimeCheck,
+                &platform.check_tx_proof_verifier,
                 platform_version,
             );
 
@@ -796,6 +879,7 @@ mod tests {
                 &platform_ref,
                 state_transition,
                 CheckTxLevel::FirstTimeCheck,
+                &platform.check_tx_proof_verifier,
                 platform_version,
             );
 
@@ -839,6 +923,7 @@ mod tests {
                 &platform_ref,
                 state_transition,
                 CheckTxLevel::Recheck,
+                &platform.check_tx_proof_verifier,
                 platform_version,
             );
 
@@ -901,6 +986,7 @@ mod tests {
                 &platform_ref,
                 state_transition,
                 CheckTxLevel::Recheck,
+                &platform.check_tx_proof_verifier,
                 platform_version,
             );
 

--- a/packages/rs-drive-abci/src/execution/validation/state_transition/processor/traits/shielded_proof.rs
+++ b/packages/rs-drive-abci/src/execution/validation/state_transition/processor/traits/shielded_proof.rs
@@ -88,6 +88,11 @@ impl StateTransitionHasShieldedProofValidationV0 for StateTransition {
             StateTransition::IdentityCreateFromShieldedPool(st) => match st {
                 IdentityCreateFromShieldedPoolTransition::V0(v0) => v0.actions.len(),
             },
+            StateTransition::ShieldFromAssetLock(st) => match st {
+                dpp::state_transition::shield_from_asset_lock_transition::ShieldFromAssetLockTransition::V0(v0) => {
+                    v0.actions.len()
+                }
+            },
             _ => 0,
         }
     }

--- a/packages/rs-drive-abci/src/execution/validation/state_transition/processor/traits/shielded_proof.rs
+++ b/packages/rs-drive-abci/src/execution/validation/state_transition/processor/traits/shielded_proof.rs
@@ -21,8 +21,11 @@ use dpp::version::PlatformVersion;
 /// A trait for checking whether a state transition requires shielded ZK proof validation.
 pub(crate) trait StateTransitionHasShieldedProofValidationV0 {
     /// Returns true if this state transition has a ZK proof that must be verified
-    /// before any state reads.
+    /// during validation.
     fn has_shielded_proof_validation(&self) -> bool;
+
+    /// Returns the number of Orchard actions whose proof work must be admitted.
+    fn shielded_proof_action_count(&self) -> usize;
 
     /// Returns true if this state transition pays fees from the shielded pool's
     /// value_balance and requires minimum fee validation.
@@ -58,6 +61,35 @@ impl StateTransitionHasShieldedProofValidationV0 for StateTransition {
                 | StateTransition::ShieldedWithdrawal(_)
                 | StateTransition::IdentityCreateFromShieldedPool(_)
         )
+    }
+
+    fn shielded_proof_action_count(&self) -> usize {
+        match self {
+            StateTransition::Shield(st) => match st {
+                dpp::state_transition::shield_transition::ShieldTransition::V0(v0) => {
+                    v0.actions.len()
+                }
+            },
+            StateTransition::ShieldedTransfer(st) => match st {
+                dpp::state_transition::shielded_transfer_transition::ShieldedTransferTransition::V0(v0) => {
+                    v0.actions.len()
+                }
+            },
+            StateTransition::Unshield(st) => match st {
+                dpp::state_transition::unshield_transition::UnshieldTransition::V0(v0) => {
+                    v0.actions.len()
+                }
+            },
+            StateTransition::ShieldedWithdrawal(st) => match st {
+                dpp::state_transition::shielded_withdrawal_transition::ShieldedWithdrawalTransition::V0(v0) => {
+                    v0.actions.len()
+                }
+            },
+            StateTransition::IdentityCreateFromShieldedPool(st) => match st {
+                IdentityCreateFromShieldedPoolTransition::V0(v0) => v0.actions.len(),
+            },
+            _ => 0,
+        }
     }
 
     fn has_shielded_minimum_fee_validation(&self) -> bool {

--- a/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/batch/tests/document/replacement.rs
+++ b/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/batch/tests/document/replacement.rs
@@ -923,6 +923,7 @@ mod replacement_tests {
             &platform_ref,
             replayed_state_transition,
             CheckTxLevel::FirstTimeCheck,
+            &platform.check_tx_proof_verifier,
             platform_version,
         )
         .expect("expected check_tx to not return an Err");

--- a/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/mod.rs
+++ b/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/mod.rs
@@ -82,7 +82,7 @@ impl ValidationMode {
 }
 
 #[cfg(test)]
-pub(in crate::execution) mod test_helpers;
+pub(crate) mod test_helpers;
 
 #[cfg(test)]
 pub(in crate::execution) mod tests {

--- a/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/shield_from_asset_lock/mod.rs
+++ b/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/shield_from_asset_lock/mod.rs
@@ -12,6 +12,7 @@ use crate::execution::types::state_transition_execution_context::StateTransition
 use crate::execution::validation::state_transition::shield_from_asset_lock::transform_into_action::v0::ShieldFromAssetLockStateTransitionTransformIntoActionValidationV0;
 use crate::execution::validation::state_transition::ValidationMode;
 use crate::platform_types::platform::PlatformRef;
+use crate::platform_types::check_tx_proof_verifier::CheckTxProofVerifier;
 use crate::platform_types::platform_state::PlatformStateV0Methods;
 use crate::rpc::core::CoreRPCLike;
 use dpp::validation::ConsensusValidationResult;
@@ -21,6 +22,7 @@ use drive::state_transition_action::StateTransitionAction;
 /// A trait to transform into an action for shield from asset lock transition
 pub(in crate::execution) trait StateTransitionShieldFromAssetLockTransitionActionTransformer {
     /// Transform into an action for shield from asset lock transition
+    #[allow(clippy::too_many_arguments)]
     fn transform_into_action_for_shield_from_asset_lock_transition<C: CoreRPCLike>(
         &self,
         platform: &PlatformRef<C>,
@@ -28,6 +30,7 @@ pub(in crate::execution) trait StateTransitionShieldFromAssetLockTransitionActio
         validation_mode: ValidationMode,
         block_info: &BlockInfo,
         execution_context: &mut StateTransitionExecutionContext,
+        check_tx_proof_verifier: Option<&CheckTxProofVerifier>,
         tx: TransactionArg,
     ) -> Result<ConsensusValidationResult<StateTransitionAction>, Error>;
 }
@@ -35,6 +38,7 @@ pub(in crate::execution) trait StateTransitionShieldFromAssetLockTransitionActio
 impl StateTransitionShieldFromAssetLockTransitionActionTransformer
     for ShieldFromAssetLockTransition
 {
+    #[allow(clippy::too_many_arguments)]
     fn transform_into_action_for_shield_from_asset_lock_transition<C: CoreRPCLike>(
         &self,
         platform: &PlatformRef<C>,
@@ -42,6 +46,7 @@ impl StateTransitionShieldFromAssetLockTransitionActionTransformer
         validation_mode: ValidationMode,
         _block_info: &BlockInfo,
         execution_context: &mut StateTransitionExecutionContext,
+        check_tx_proof_verifier: Option<&CheckTxProofVerifier>,
         tx: TransactionArg,
     ) -> Result<ConsensusValidationResult<StateTransitionAction>, Error> {
         let platform_version = platform.state.current_platform_version()?;
@@ -58,6 +63,7 @@ impl StateTransitionShieldFromAssetLockTransitionActionTransformer
                 signable_bytes,
                 validation_mode,
                 execution_context,
+                check_tx_proof_verifier,
                 tx,
             ),
             version => Err(Error::Execution(ExecutionError::UnknownVersionMismatch {

--- a/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/shield_from_asset_lock/tests.rs
+++ b/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/shield_from_asset_lock/tests.rs
@@ -1,11 +1,15 @@
 #[cfg(test)]
 #[allow(clippy::module_inception)]
 mod tests {
+    use crate::error::execution::ExecutionError;
+    use crate::error::Error;
+    use crate::execution::check_tx::CheckTxLevel;
     use crate::execution::validation::state_transition::state_transitions::shielded_common::compute_platform_sighash;
     use crate::execution::validation::state_transition::state_transitions::test_helpers::{
         create_dummy_serialized_action, get_proving_key, process_transition,
         serialize_authorized_bundle_with_flags, setup_platform,
     };
+    use crate::platform_types::platform::PlatformRef;
     use crate::platform_types::state_transitions_processing_result::StateTransitionExecutionResult;
     use assert_matches::assert_matches;
     use dpp::consensus::basic::BasicError;
@@ -395,6 +399,53 @@ mod tests {
                     error: ConsensusError::StateError(StateError::InvalidShieldedProofError(_)),
                     ..
                 }]
+            );
+        }
+
+        #[test]
+        fn check_tx_rejects_when_proof_verification_capacity_is_exhausted() {
+            let platform_version = PlatformVersion::latest();
+            let platform = setup_platform();
+
+            let mut rng = StdRng::seed_from_u64(567);
+            let (asset_lock_proof, asset_lock_pk) = create_asset_lock_proof_with_key(&mut rng);
+            let transition = create_signed_shield_from_asset_lock_transition(
+                asset_lock_proof,
+                &asset_lock_pk,
+                vec![create_dummy_serialized_action()],
+                5000,
+                [42u8; 32],
+                vec![0u8; 100],
+                [0u8; 64],
+            );
+            let raw_transition = transition
+                .serialize_to_bytes()
+                .expect("transition should serialize");
+
+            let platform_state = platform.state.load();
+            let platform_ref = PlatformRef {
+                drive: &platform.drive,
+                state: &platform_state,
+                config: &platform.config,
+                core_rpc: &platform.core_rpc,
+            };
+            let _occupied_capacity = platform
+                .check_tx_proof_verifier
+                .try_acquire(usize::MAX)
+                .expect("test should occupy all proof-verification capacity");
+
+            let result = platform.check_tx(
+                &raw_transition,
+                CheckTxLevel::FirstTimeCheck,
+                &platform_ref,
+                platform_version,
+            );
+
+            assert_matches!(
+                result,
+                Err(Error::Execution(
+                    ExecutionError::CheckTxProofVerificationBusy
+                ))
             );
         }
     }

--- a/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/shield_from_asset_lock/transform_into_action/v0/mod.rs
+++ b/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/shield_from_asset_lock/transform_into_action/v0/mod.rs
@@ -12,6 +12,7 @@ use crate::execution::validation::state_transition::state_transitions::shielded_
 };
 use crate::execution::validation::state_transition::ValidationMode;
 use crate::platform_types::platform::PlatformRef;
+use crate::platform_types::check_tx_proof_verifier::CheckTxProofVerifier;
 use crate::platform_types::platform_state::PlatformStateV0Methods;
 use crate::rpc::core::CoreRPCLike;
 use dpp::asset_lock::reduced_asset_lock_value::{AssetLockValue, AssetLockValueGettersV0};
@@ -45,6 +46,7 @@ pub(in crate::execution::validation::state_transition::state_transitions::shield
         signable_bytes: Vec<u8>,
         validation_mode: ValidationMode,
         execution_context: &mut StateTransitionExecutionContext,
+        check_tx_proof_verifier: Option<&CheckTxProofVerifier>,
         tx: TransactionArg,
     ) -> Result<ConsensusValidationResult<StateTransitionAction>, Error>;
 }
@@ -58,6 +60,7 @@ impl ShieldFromAssetLockStateTransitionTransformIntoActionValidationV0
         signable_bytes: Vec<u8>,
         validation_mode: ValidationMode,
         execution_context: &mut StateTransitionExecutionContext,
+        check_tx_proof_verifier: Option<&CheckTxProofVerifier>,
         tx: TransactionArg,
     ) -> Result<ConsensusValidationResult<StateTransitionAction>, Error> {
         let platform_version = platform.state.current_platform_version()?;
@@ -282,6 +285,17 @@ impl ShieldFromAssetLockStateTransitionTransformIntoActionValidationV0
         let mut drive_operations = vec![];
         let current_total_balance =
             read_pool_total_balance(platform.drive, tx, &mut drive_operations, platform_version)?;
+
+        // CheckTx admits the expensive proof only after the asset lock, its
+        // signature, funding, fee cap, and current pool state have all passed.
+        // Proposal and block processing pass `None` and retain the existing
+        // penalty action when proof verification fails.
+        let _check_tx_permit = match check_tx_proof_verifier {
+            Some(verifier) => Some(verifier.try_acquire(num_actions).ok_or(Error::Execution(
+                ExecutionError::CheckTxProofVerificationBusy,
+            ))?),
+            None => None,
+        };
 
         // Step 9: Verify Orchard ZK proof via reconstruct_and_verify_bundle()
         // Use EMPTY extra_sighash_data -- no transparent binding needed since

--- a/packages/rs-drive-abci/src/execution/validation/state_transition/transformer/mod.rs
+++ b/packages/rs-drive-abci/src/execution/validation/state_transition/transformer/mod.rs
@@ -264,6 +264,7 @@ impl StateTransitionActionTransformer for StateTransition {
                     validation_mode,
                     block_info,
                     execution_context,
+                    None,
                     tx,
                 )
             }

--- a/packages/rs-drive-abci/src/platform_types/check_tx_proof_verifier.rs
+++ b/packages/rs-drive-abci/src/platform_types/check_tx_proof_verifier.rs
@@ -1,0 +1,100 @@
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+/// Node-local admission control for expensive proof verification in CheckTx.
+///
+/// Consensus block processing deliberately does not use this limiter, so
+/// public mempool work cannot reserve all proof-verification capacity needed
+/// by proposal validation and finalization.
+pub struct CheckTxProofVerifier {
+    in_flight_weight: AtomicUsize,
+    limit: usize,
+}
+
+impl Default for CheckTxProofVerifier {
+    fn default() -> Self {
+        let available_cores = std::thread::available_parallelism()
+            .map(|parallelism| parallelism.get())
+            .unwrap_or(1);
+        let limit = (available_cores / 4).clamp(1, 4);
+
+        Self::new(limit)
+    }
+}
+
+impl CheckTxProofVerifier {
+    pub(crate) fn new(limit: usize) -> Self {
+        Self {
+            in_flight_weight: AtomicUsize::new(0),
+            limit: limit.max(1),
+        }
+    }
+
+    pub(crate) fn try_acquire(
+        &self,
+        action_count: usize,
+    ) -> Option<CheckTxProofVerifierPermit<'_>> {
+        // Verification cost grows with the bundle. Charge one local capacity
+        // unit per two actions, while allowing a single proof to fit on nodes
+        // whose conservative default budget is one unit.
+        let weight = action_count.max(1).div_ceil(2).min(self.limit);
+        let mut current = self.in_flight_weight.load(Ordering::Acquire);
+
+        loop {
+            if current.saturating_add(weight) > self.limit {
+                return None;
+            }
+
+            match self.in_flight_weight.compare_exchange_weak(
+                current,
+                current + weight,
+                Ordering::AcqRel,
+                Ordering::Acquire,
+            ) {
+                Ok(_) => {
+                    return Some(CheckTxProofVerifierPermit {
+                        verifier: self,
+                        weight,
+                    })
+                }
+                Err(observed) => current = observed,
+            }
+        }
+    }
+}
+
+pub(crate) struct CheckTxProofVerifierPermit<'a> {
+    verifier: &'a CheckTxProofVerifier,
+    weight: usize,
+}
+
+impl Drop for CheckTxProofVerifierPermit<'_> {
+    fn drop(&mut self) {
+        let previous = self
+            .verifier
+            .in_flight_weight
+            .fetch_sub(self.weight, Ordering::AcqRel);
+        debug_assert!(
+            previous >= self.weight,
+            "proof verifier permit counter underflow"
+        );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn bounds_and_releases_admitted_work() {
+        let verifier = CheckTxProofVerifier::new(3);
+        let first = verifier.try_acquire(1).expect("first permit");
+        let second = verifier.try_acquire(4).expect("weighted second permit");
+
+        assert!(verifier.try_acquire(1).is_none());
+
+        drop(first);
+        assert!(verifier.try_acquire(1).is_some());
+
+        drop(second);
+    }
+}

--- a/packages/rs-drive-abci/src/platform_types/check_tx_proof_verifier.rs
+++ b/packages/rs-drive-abci/src/platform_types/check_tx_proof_verifier.rs
@@ -83,6 +83,9 @@ impl Drop for CheckTxProofVerifierPermit<'_> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::{Arc, Barrier};
+    use std::thread;
+    use std::time::Duration;
 
     #[test]
     fn bounds_and_releases_admitted_work() {
@@ -96,5 +99,45 @@ mod tests {
         assert!(verifier.try_acquire(1).is_some());
 
         drop(second);
+    }
+
+    #[test]
+    fn bounds_concurrent_admission_and_releases_all_capacity() {
+        const LIMIT: usize = 3;
+        const CALLERS: usize = 24;
+
+        let verifier = Arc::new(CheckTxProofVerifier::new(LIMIT));
+        let start = Arc::new(Barrier::new(CALLERS));
+        let active = Arc::new(AtomicUsize::new(0));
+        let maximum = Arc::new(AtomicUsize::new(0));
+
+        thread::scope(|scope| {
+            for _ in 0..CALLERS {
+                let verifier = Arc::clone(&verifier);
+                let start = Arc::clone(&start);
+                let active = Arc::clone(&active);
+                let maximum = Arc::clone(&maximum);
+                scope.spawn(move || {
+                    start.wait();
+                    if let Some(permit) = verifier.try_acquire(1) {
+                        let simultaneous = active.fetch_add(1, Ordering::AcqRel) + 1;
+                        maximum.fetch_max(simultaneous, Ordering::AcqRel);
+                        thread::sleep(Duration::from_millis(10));
+                        active.fetch_sub(1, Ordering::AcqRel);
+                        drop(permit);
+                    }
+                });
+            }
+        });
+
+        assert!(maximum.load(Ordering::Acquire) <= LIMIT);
+        assert_eq!(active.load(Ordering::Acquire), 0);
+
+        let permits: Vec<_> = (0..LIMIT)
+            .map(|_| verifier.try_acquire(1).expect("released capacity"))
+            .collect();
+        assert!(verifier.try_acquire(1).is_none());
+        drop(permits);
+        assert!(verifier.try_acquire(LIMIT * 2).is_some());
     }
 }

--- a/packages/rs-drive-abci/src/platform_types/mod.rs
+++ b/packages/rs-drive-abci/src/platform_types/mod.rs
@@ -2,6 +2,8 @@
 pub mod block_execution_outcome;
 /// The block proposal
 pub mod block_proposal;
+/// CheckTx proof-verification admission control
+pub(crate) mod check_tx_proof_verifier;
 /// A clean version of the request to finalize a block
 pub mod cleaned_abci_messages;
 /// The commit

--- a/packages/rs-drive-abci/src/platform_types/platform/mod.rs
+++ b/packages/rs-drive-abci/src/platform_types/platform/mod.rs
@@ -8,6 +8,7 @@ use crate::rpc::core::{CoreRPCLike, DefaultCoreRPC};
 use drive::drive::Drive;
 use std::fmt::{Debug, Formatter};
 
+use crate::platform_types::check_tx_proof_verifier::CheckTxProofVerifier;
 use crate::platform_types::platform_state::{PlatformState, PlatformStateV0Methods};
 use arc_swap::ArcSwap;
 use dpp::prelude::BlockHeight;
@@ -41,6 +42,8 @@ pub struct Platform<C> {
     pub config: PlatformConfig,
     /// Core RPC Client
     pub core_rpc: C,
+    /// CheckTx-only proof-verification admission control
+    pub(crate) check_tx_proof_verifier: CheckTxProofVerifier,
 }
 
 // @append_only
@@ -252,6 +255,7 @@ impl<C> Platform<C> {
             committed_block_height_guard: AtomicU64::from(height),
             config,
             core_rpc,
+            check_tx_proof_verifier: CheckTxProofVerifier::default(),
         };
 
         Ok(platform)
@@ -285,6 +289,7 @@ impl<C> Platform<C> {
             committed_block_height_guard: AtomicU64::from(height),
             config,
             core_rpc,
+            check_tx_proof_verifier: CheckTxProofVerifier::default(),
         })
     }
 }


### PR DESCRIPTION
## Summary

- perform current-state admission before shielded cryptographic validation in CheckTx
- add a small action-weighted CheckTx verification budget isolated from proposal and block processing
- return transient backpressure when local verification capacity is occupied

Addresses security review findings DS-CAND-207 through DS-CAND-211.

## Verification

- `cargo test -p drive-abci --lib check_tx_verification -- --nocapture`
- focused proof-budget and transport-status regression tests
- `cargo clippy -p drive-abci --lib --no-deps -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`