### PR TITLE
fix(sdk): enforce response freshness anchors

### DIFF
--- a/.github/workflows/swift-sdk-build.yml
+++ b/.github/workflows/swift-sdk-build.yml
@@ -87,5 +87,9 @@ jobs:
           rm -rf packages/swift-sdk/SwiftExampleApp/.build || true
 
       - name: Build and test Swift SDK
+        env:
+          # The self-hosted runner persists Cargo's target cache between jobs.
+          # Keep only one Apple architecture's intermediates at a time.
+          PRUNE_CARGO_TARGETS: "1"
         run: |
           bash packages/swift-sdk/run_tests.sh

--- a/packages/rs-drive-proof-verifier/src/unproved.rs
+++ b/packages/rs-drive-proof-verifier/src/unproved.rs
@@ -13,6 +13,15 @@ use dpp::dashcore::{Network, ProTxHash, PubkeyHash, QuorumHash};
 use dpp::version::PlatformVersion;
 use std::collections::BTreeMap;
 
+fn parse_hash_32(field: &str, bytes: &[u8]) -> Result<[u8; 32], Error> {
+    bytes.try_into().map_err(|_| Error::ProtocolError {
+        error: format!(
+            "Invalid {field} length: expected 32 bytes, received {}",
+            bytes.len()
+        ),
+    })
+}
+
 /// Trait for parsing unproved responses from the Platform.
 ///
 /// This trait defines methods for extracting data from responses received from the Platform
@@ -181,34 +190,15 @@ impl FromUnproved<platform::GetCurrentQuorumsInfoRequest> for CurrentQuorumsInfo
                 let quorum_hashes = v0
                     .quorum_hashes
                     .into_iter()
-                    .map(|q_hash| {
-                        let mut q_hash_array = [0u8; 32];
-                        if q_hash.len() != 32 {
-                            return Err(Error::ProtocolError {
-                                error: "Invalid quorum_hash length".to_string(),
-                            });
-                        }
-                        q_hash_array.copy_from_slice(&q_hash);
-                        Ok(q_hash_array)
-                    })
+                    .map(|q_hash| parse_hash_32("quorum_hash", &q_hash))
                     .collect::<Result<Vec<[u8; 32]>, Error>>()?;
 
                 // Extract current quorum hash
-                let mut current_quorum_hash = [0u8; 32];
-                if v0.current_quorum_hash.len() != 32 {
-                    return Err(Error::ProtocolError {
-                        error: "Invalid current_quorum_hash length".to_string(),
-                    });
-                }
-                current_quorum_hash.copy_from_slice(&v0.current_quorum_hash);
+                let current_quorum_hash =
+                    parse_hash_32("current_quorum_hash", &v0.current_quorum_hash)?;
 
-                let mut last_block_proposer = [0u8; 32];
-                if v0.last_block_proposer.len() != 32 {
-                    return Err(Error::ProtocolError {
-                        error: "Invalid last_block_proposer length".to_string(),
-                    });
-                }
-                last_block_proposer.copy_from_slice(&v0.last_block_proposer);
+                let last_block_proposer =
+                    parse_hash_32("last_block_proposer", &v0.last_block_proposer)?;
 
                 // Extract validator sets
                 let validator_sets =
@@ -216,8 +206,8 @@ impl FromUnproved<platform::GetCurrentQuorumsInfoRequest> for CurrentQuorumsInfo
                         .into_iter()
                         .map(|vs| {
                             // Parse the ValidatorSetV0
-                            let mut quorum_hash = [0u8; 32];
-                            quorum_hash.copy_from_slice(&vs.quorum_hash);
+                            let quorum_hash =
+                                parse_hash_32("validator_set.quorum_hash", &vs.quorum_hash)?;
 
                             // Parse ValidatorV0 members
                             let members = vs
@@ -549,6 +539,31 @@ mod tests {
             err_string.contains("Invalid last_block_proposer length"),
             "unexpected error: {err_string}"
         );
+    }
+
+    #[test]
+    fn test_current_quorums_info_rejects_malformed_nested_quorum_hashes() {
+        for invalid_length in [0, 1, 31, 33, 1024] {
+            let mut response = build_valid_quorums_info_response();
+            if let Some(get_current_quorums_info_response::Version::V0(ref mut v0)) =
+                response.version
+            {
+                v0.validator_sets[0].quorum_hash = vec![0u8; invalid_length];
+            }
+
+            let result = CurrentQuorumsInfo::maybe_from_unproved_with_metadata(
+                platform::GetCurrentQuorumsInfoRequest { version: None },
+                response,
+                Network::Testnet,
+                PlatformVersion::latest(),
+            );
+
+            let error = result.expect_err("malformed nested quorum hash must return an error");
+            assert!(
+                matches!(error, Error::ProtocolError { ref error } if error.contains("validator_set.quorum_hash")),
+                "unexpected error for length {invalid_length}: {error:?}"
+            );
+        }
     }
 
     #[test]

--- a/packages/rs-sdk/src/sdk.rs
+++ b/packages/rs-sdk/src/sdk.rs
@@ -276,7 +276,14 @@ impl Sdk {
     fn freshness_criteria(&self, method_name: &str) -> (Option<u64>, Option<u64>) {
         match method_name {
             "get_addresses_trunk_state" | "get_addresses_branch_state" => (
-                None,
+                // Address synchronization checkpoints can lag the latest
+                // Platform height. Prefer their signed time when available,
+                // but retain the independently trusted height floor for the
+                // explicitly supported height-only configuration.
+                self.metadata_time_tolerance_ms
+                    .is_none()
+                    .then_some(self.metadata_height_tolerance)
+                    .flatten(),
                 self.metadata_time_tolerance_ms
                     .map(|configured| configured.min(DEFAULT_METADATA_TIME_TOLERANCE_MS)),
             ),
@@ -1090,8 +1097,10 @@ impl SdkBuilder {
     /// This method will return an error if the Sdk cannot be created.
     pub fn build(self) -> Result<Sdk, Error> {
         let is_network_sdk = self.addresses.is_some();
-        let has_height_anchor =
-            self.trusted_initial_height.is_some() && self.metadata_height_tolerance.is_some();
+        let has_height_anchor = self
+            .trusted_initial_height
+            .zip(self.metadata_height_tolerance)
+            .is_some_and(|(height, tolerance)| height > tolerance);
         if is_network_sdk
             && self.proofs
             && self.metadata_time_tolerance_ms.is_none()
@@ -1363,6 +1372,54 @@ mod test {
 
         assert!(
             matches!(error, crate::Error::Config(message) if message.contains("trusted initial height"))
+        );
+    }
+
+    #[test_matrix(0, 0; "zero height")]
+    #[test_matrix(1, 1; "height equals tolerance")]
+    #[test_matrix(1, 2; "height below tolerance")]
+    fn proof_enabled_network_builder_rejects_ineffective_height_anchor(
+        trusted_height: u64,
+        tolerance: u64,
+    ) {
+        let error = SdkBuilder::new(super::AddressList::new())
+            .with_time_tolerance(None)
+            .with_height_tolerance(Some(tolerance))
+            .with_trusted_initial_height(trusted_height)
+            .build()
+            .expect_err("trusted height must impose a freshness floor");
+
+        assert!(
+            matches!(error, crate::Error::Config(message) if message.contains("trusted initial height"))
+        );
+    }
+
+    #[test]
+    fn height_only_address_checkpoint_uses_trusted_height_floor() {
+        let sdk = SdkBuilder::new_mock()
+            .with_time_tolerance(None)
+            .with_height_tolerance(Some(2))
+            .with_trusted_initial_height(100)
+            .build()
+            .expect("effective trusted height should permit height-only proof mode");
+
+        assert!(matches!(
+            sdk.verify_response_metadata(
+                "get_addresses_trunk_state",
+                &ResponseMetadata {
+                    height: 97,
+                    ..Default::default()
+                },
+            ),
+            Err(crate::Error::StaleNode(
+                super::StaleNodeError::Height { .. }
+            ))
+        ));
+        assert_eq!(
+            sdk.metadata_last_seen_height
+                .load(std::sync::atomic::Ordering::Acquire),
+            100,
+            "a rejected stale checkpoint must not lower the trusted floor"
         );
     }
 

--- a/packages/rs-sdk/src/sdk.rs
+++ b/packages/rs-sdk/src/sdk.rs
@@ -69,8 +69,8 @@ const fn min_protocol_version(network: Network) -> u32 {
     }
 }
 
-/// The default metadata time tolerance for checkpoint queries in milliseconds
-const ADDRESS_STATE_TIME_TOLERANCE_MS: u64 = 31 * 60 * 1000;
+/// Default signed-metadata freshness window for network SDKs.
+const DEFAULT_METADATA_TIME_TOLERANCE_MS: u64 = 31 * 60 * 1000;
 
 /// The default request settings for the SDK, used when the user does not provide any.
 ///
@@ -278,7 +278,7 @@ impl Sdk {
             "get_addresses_trunk_state" | "get_addresses_branch_state" => (
                 None,
                 self.metadata_time_tolerance_ms
-                    .and(Some(ADDRESS_STATE_TIME_TOLERANCE_MS)),
+                    .map(|configured| configured.min(DEFAULT_METADATA_TIME_TOLERANCE_MS)),
             ),
             _ => (
                 self.metadata_height_tolerance,
@@ -295,16 +295,18 @@ impl Sdk {
     ) -> Result<(), Error> {
         let (metadata_height_tolerance, metadata_time_tolerance_ms) =
             self.freshness_criteria(method_name);
+        // Check the independent local-clock anchor before mutating the
+        // response-derived height high-water mark.
+        if let Some(time_tolerance) = metadata_time_tolerance_ms {
+            let now = chrono::Utc::now().timestamp_millis() as u64;
+            verify_metadata_time(metadata, now, time_tolerance)?;
+        };
         if let Some(height_tolerance) = metadata_height_tolerance {
             verify_metadata_height(
                 metadata,
                 height_tolerance,
                 Arc::clone(&(self.metadata_last_seen_height)),
             )?;
-        };
-        if let Some(time_tolerance) = metadata_time_tolerance_ms {
-            let now = chrono::Utc::now().timestamp_millis() as u64;
-            verify_metadata_time(metadata, now, time_tolerance)?;
         };
 
         self.maybe_update_protocol_version(metadata.protocol_version);
@@ -659,22 +661,14 @@ fn verify_metadata_height(
     tolerance: u64,
     last_seen_height: Arc<atomic::AtomicU64>,
 ) -> Result<(), Error> {
-    let mut expected_height = last_seen_height.load(Ordering::Relaxed);
     let received_height = metadata.height;
+    // Linearize the response at an atomic max update, then reload so a racing
+    // higher response that committed before this validation completes is also
+    // considered. A lower accepted response can never reduce the baseline.
+    let previous_height = last_seen_height.fetch_max(received_height, Ordering::AcqRel);
+    let expected_height = previous_height.max(last_seen_height.load(Ordering::Acquire));
 
-    // Same height, no need to update.
-    if received_height == expected_height {
-        tracing::trace!(
-            expected_height,
-            received_height,
-            tolerance,
-            "received message has the same height as previously seen"
-        );
-        return Ok(());
-    }
-
-    // If expected_height <= tolerance, then Sdk just started, so we just assume what we got is correct.
-    if expected_height > tolerance && received_height < expected_height - tolerance {
+    if expected_height > tolerance && received_height < expected_height.saturating_sub(tolerance) {
         return Err(StaleNodeError::Height {
             expected_height,
             received_height,
@@ -683,25 +677,12 @@ fn verify_metadata_height(
         .into());
     }
 
-    // New height is ahead of the last seen height, so we update the last seen height.
     tracing::trace!(
-        expected_height = expected_height,
-        received_height = received_height,
-        tolerance,
-        "received message with new height"
-    );
-    while let Err(stored_height) = last_seen_height.compare_exchange(
         expected_height,
         received_height,
-        Ordering::SeqCst,
-        Ordering::Relaxed,
-    ) {
-        // The value was changed to a higher value by another thread, so we need to retry.
-        if stored_height >= metadata.height {
-            break;
-        }
-        expected_height = stored_height;
-    }
+        tolerance,
+        "received response within the monotonic height window"
+    );
 
     Ok(())
 }
@@ -788,6 +769,10 @@ pub struct SdkBuilder {
     /// See [SdkBuilder::with_time_tolerance] for more information.
     metadata_time_tolerance_ms: Option<u64>,
 
+    /// Independently trusted initial Platform height used to seed the
+    /// monotonic freshness high-water mark.
+    trusted_initial_height: Option<u64>,
+
     /// directory where dump files will be stored
     #[cfg(feature = "mocks")]
     dump_dir: Option<PathBuf>,
@@ -815,6 +800,7 @@ impl Default for SdkBuilder {
             proofs: true,
             metadata_height_tolerance: Some(1),
             metadata_time_tolerance_ms: None,
+            trusted_initial_height: None,
 
             #[cfg(feature = "mocks")]
             data_contract_cache_size: NonZeroUsize::new(DEFAULT_CONTRACT_CACHE_SIZE)
@@ -859,6 +845,7 @@ impl SdkBuilder {
     pub fn new(addresses: AddressList) -> Self {
         Self {
             addresses: Some(addresses),
+            metadata_time_tolerance_ms: Some(DEFAULT_METADATA_TIME_TOLERANCE_MS),
             ..Default::default()
         }
     }
@@ -1050,7 +1037,9 @@ impl SdkBuilder {
     ///
     /// If None, the time is not checked.
     ///
-    /// This is set to `None` by default.
+    /// Network builders default to 31 minutes. Mock builders default to
+    /// `None`. Disabling this for a proof-enabled network SDK requires a
+    /// trusted initial height with height checking enabled.
     ///
     /// Note that enabling this check can cause issues if the local time is not synchronized with the network time,
     /// when the network is stalled or time between blocks increases significantly.
@@ -1061,6 +1050,16 @@ impl SdkBuilder {
     /// synchronization issues) should be safe.
     pub fn with_time_tolerance(mut self, tolerance_ms: Option<u64>) -> Self {
         self.metadata_time_tolerance_ms = tolerance_ms;
+        self
+    }
+
+    /// Seed proof freshness with an independently trusted Platform height.
+    ///
+    /// This can be used instead of the local-clock policy. The checkpoint must
+    /// come from a trusted source and should be persisted with its network and
+    /// provenance by the caller.
+    pub fn with_trusted_initial_height(mut self, height: u64) -> Self {
+        self.trusted_initial_height = Some(height);
         self
     }
 
@@ -1090,6 +1089,20 @@ impl SdkBuilder {
     ///
     /// This method will return an error if the Sdk cannot be created.
     pub fn build(self) -> Result<Sdk, Error> {
+        let is_network_sdk = self.addresses.is_some();
+        let has_height_anchor =
+            self.trusted_initial_height.is_some() && self.metadata_height_tolerance.is_some();
+        if is_network_sdk
+            && self.proofs
+            && self.metadata_time_tolerance_ms.is_none()
+            && !has_height_anchor
+        {
+            return Err(Error::Config(
+                "proof mode requires a trusted initial height or signed-time freshness policy"
+                    .to_string(),
+            ));
+        }
+
         let dapi_client_settings = match self.settings {
             Some(settings) => DEFAULT_REQUEST_SETTINGS.override_by(settings),
             None => DEFAULT_REQUEST_SETTINGS,
@@ -1126,8 +1139,9 @@ impl SdkBuilder {
                     // pinned is controlled separately by `version_pinned`.
                     protocol_version: Arc::new(atomic::AtomicU32::new(initial_version.protocol_version)),
                     version_pinned: self.version_pinned,
-                    // Note: in the future, we need to securely initialize initial height during Sdk bootstrap or first request.
-                    metadata_last_seen_height: Arc::new(atomic::AtomicU64::new(0)),
+                    metadata_last_seen_height: Arc::new(atomic::AtomicU64::new(
+                        self.trusted_initial_height.unwrap_or(0),
+                    )),
                     metadata_height_tolerance: self.metadata_height_tolerance,
                     metadata_time_tolerance_ms: self.metadata_time_tolerance_ms,
                     #[cfg(feature = "mocks")]
@@ -1196,7 +1210,9 @@ impl SdkBuilder {
                     version_pinned: self.version_pinned,
                     context_provider: ArcSwapOption::new(Some(Arc::new(context_provider))),
                     cancel_token: self.cancel_token,
-                    metadata_last_seen_height: Arc::new(atomic::AtomicU64::new(0)),
+                    metadata_last_seen_height: Arc::new(atomic::AtomicU64::new(
+                        self.trusted_initial_height.unwrap_or(0),
+                    )),
                     metadata_height_tolerance: self.metadata_height_tolerance,
                     metadata_time_tolerance_ms: self.metadata_time_tolerance_ms,
                 };
@@ -1329,6 +1345,41 @@ mod test {
         );
     }
 
+    #[test]
+    fn network_builders_enable_an_independent_time_anchor() {
+        assert_eq!(
+            SdkBuilder::new_testnet().metadata_time_tolerance_ms,
+            Some(super::DEFAULT_METADATA_TIME_TOLERANCE_MS)
+        );
+        assert_eq!(SdkBuilder::new_mock().metadata_time_tolerance_ms, None);
+    }
+
+    #[test]
+    fn proof_enabled_network_builder_rejects_missing_freshness_anchor() {
+        let error = SdkBuilder::new(super::AddressList::new())
+            .with_time_tolerance(None)
+            .build()
+            .expect_err("network proof mode must have an independent freshness anchor");
+
+        assert!(
+            matches!(error, crate::Error::Config(message) if message.contains("trusted initial height"))
+        );
+    }
+
+    #[test]
+    fn trusted_initial_height_seeds_the_high_water_mark() {
+        let sdk = SdkBuilder::new_mock()
+            .with_trusted_initial_height(42)
+            .build()
+            .expect("mock SDK should build");
+
+        assert_eq!(
+            sdk.metadata_last_seen_height
+                .load(std::sync::atomic::Ordering::Acquire),
+            42
+        );
+    }
+
     #[test_matrix(97..102, 100, 2, false; "valid height")]
     #[test_case(103, 100, 2, true; "invalid height")]
     fn test_verify_metadata_height(
@@ -1351,10 +1402,57 @@ mod test {
         if result.is_ok() {
             assert_eq!(
                 last_seen_height.load(std::sync::atomic::Ordering::Relaxed),
-                received_height,
-                "previous height should be updated"
+                expected_height.max(received_height),
+                "height high-water mark must never decrease"
             );
         }
+    }
+
+    #[test]
+    fn accepted_height_tolerance_cannot_walk_the_watermark_backwards() {
+        let last_seen_height = Arc::new(std::sync::atomic::AtomicU64::new(100));
+
+        super::verify_metadata_height(
+            &ResponseMetadata {
+                height: 99,
+                ..Default::default()
+            },
+            1,
+            Arc::clone(&last_seen_height),
+        )
+        .expect("one block behind is within tolerance");
+        assert_eq!(
+            last_seen_height.load(std::sync::atomic::Ordering::Acquire),
+            100
+        );
+
+        super::verify_metadata_height(
+            &ResponseMetadata {
+                height: 98,
+                ..Default::default()
+            },
+            1,
+            Arc::clone(&last_seen_height),
+        )
+        .expect_err("a second rollback step must be compared with the high-water mark");
+        assert_eq!(
+            last_seen_height.load(std::sync::atomic::Ordering::Acquire),
+            100
+        );
+
+        super::verify_metadata_height(
+            &ResponseMetadata {
+                height: 101,
+                ..Default::default()
+            },
+            1,
+            Arc::clone(&last_seen_height),
+        )
+        .expect("a newer height should advance the high-water mark");
+        assert_eq!(
+            last_seen_height.load(std::sync::atomic::Ordering::Acquire),
+            101
+        );
     }
 
     #[test]

--- a/packages/swift-sdk/build_ios.sh
+++ b/packages/swift-sdk/build_ios.sh
@@ -24,6 +24,8 @@ TARGET_DIR="$ROOT_DIR/target"
 PACKAGE="rs-unified-sdk-ffi"
 XCFRAMEWORK="$SCRIPT_DIR/DashSDKFFI.xcframework"
 PROFILE="dev"
+PRUNE_CARGO_TARGETS="${PRUNE_CARGO_TARGETS:-0}"
+STAGING_DIR=""
 
 # Crates whose cbindgen-generated headers ship in the unified framework.
 # Order matters: earlier headers define types referenced by later ones.
@@ -45,6 +47,31 @@ CLEAN=false
 
 log_info() { echo -e "${GREEN}$1${NC}"; }
 log_error() { echo -e "${RED}$1${NC}"; }
+
+cleanup_staging_dir() {
+  if [ -n "$STAGING_DIR" ]; then
+    rm -rf "$STAGING_DIR"
+  fi
+}
+
+stage_target_artifacts() {
+  local target="$1"
+  local library="$2"
+  local headers="$3"
+  local target_staging_dir="$STAGING_DIR/$target"
+
+  mkdir -p "$target_staging_dir"
+  cp "$library" "$target_staging_dir/"
+  cp -R "$headers" "$target_staging_dir/include"
+
+  STAGED_LIB="$target_staging_dir/$(basename "$library")"
+  STAGED_HEADERS="$target_staging_dir/include"
+
+  # The final static library and generated headers are all xcodebuild needs.
+  # Release the much larger per-architecture dependency tree before building
+  # the next target so persistent CI runners cannot exhaust their disk.
+  rm -rf "$TARGET_DIR/$target"
+}
 
 # -------------------------------
 # Help
@@ -125,6 +152,19 @@ OUTPUT_DIR="$PROFILE"
 log_info "Package: $PACKAGE"
 log_info "Profile: $PROFILE"
 
+if [ "$PRUNE_CARGO_TARGETS" = "1" ]; then
+  STAGING_DIR="$(mktemp -d "${TMPDIR:-/tmp}/dash-sdk-ffi.XXXXXX")"
+  trap cleanup_staging_dir EXIT
+
+  # Persistent self-hosted runners may contain incomplete or obsolete builds
+  # from an earlier job. Start the bounded build with only Cargo's shared host
+  # cache, then prune each Apple target after staging its final artifacts.
+  rm -rf \
+    "$TARGET_DIR/aarch64-apple-ios" \
+    "$TARGET_DIR/aarch64-apple-ios-sim" \
+    "$TARGET_DIR/aarch64-apple-darwin"
+fi
+
 # -------------------------------
 # Build commands
 # -------------------------------
@@ -195,6 +235,11 @@ if $BUILD_IOS; then
   IOS_LIB="$TARGET_DIR/$IOS_TARGET/$OUTPUT_DIR/librs_unified_sdk_ffi.a"
   IOS_HEADERS="$TARGET_DIR/$IOS_TARGET/$OUTPUT_DIR/include"
   inject_modulemap "$IOS_HEADERS"
+  if [ "$PRUNE_CARGO_TARGETS" = "1" ]; then
+    stage_target_artifacts "$IOS_TARGET" "$IOS_LIB" "$IOS_HEADERS"
+    IOS_LIB="$STAGED_LIB"
+    IOS_HEADERS="$STAGED_HEADERS"
+  fi
 fi
 
 # iOS simulator
@@ -205,6 +250,11 @@ if $BUILD_SIM; then
   SIM_LIB="$TARGET_DIR/$SIM_TARGET/$OUTPUT_DIR/librs_unified_sdk_ffi.a"
   SIM_HEADERS="$TARGET_DIR/$SIM_TARGET/$OUTPUT_DIR/include"
   inject_modulemap "$SIM_HEADERS"
+  if [ "$PRUNE_CARGO_TARGETS" = "1" ]; then
+    stage_target_artifacts "$SIM_TARGET" "$SIM_LIB" "$SIM_HEADERS"
+    SIM_LIB="$STAGED_LIB"
+    SIM_HEADERS="$STAGED_HEADERS"
+  fi
 fi
 
 # macOS
@@ -215,6 +265,11 @@ if $BUILD_MAC; then
   MAC_LIB="$TARGET_DIR/$MAC_TARGET/$OUTPUT_DIR/librs_unified_sdk_ffi.a"
   MAC_HEADERS="$TARGET_DIR/$MAC_TARGET/$OUTPUT_DIR/include"
   inject_modulemap "$MAC_HEADERS"
+  if [ "$PRUNE_CARGO_TARGETS" = "1" ]; then
+    stage_target_artifacts "$MAC_TARGET" "$MAC_LIB" "$MAC_HEADERS"
+    MAC_LIB="$STAGED_LIB"
+    MAC_HEADERS="$STAGED_HEADERS"
+  fi
 fi
 
 # -------------------------------


### PR DESCRIPTION
## Summary

- enable a signed-metadata time freshness anchor by default for network SDK builders, with an explicit trusted-height alternative
- validate time before advancing a monotonic, concurrency-aware height high-water mark
- reject proof-enabled network configurations that disable every independent freshness anchor
- parse every current-quorum hash through one checked 32-byte conversion, including nested validator sets

This addresses security review findings DS-CAND-232, 249, and 267.

## Compatibility

Network builders now default to a 31-minute signed-time window. Deployments with intentionally unsynchronized clocks or longer network pauses should configure an appropriate time tolerance or seed a trusted initial Platform height. Mock builders retain their previous no-time-check default.

## Validation

- cargo check -p dash-sdk --lib
- cargo check -p drive-proof-verifier --lib
- cargo test -p dash-sdk --lib sdk::test:: (46 passed)
- cargo test -p drive-proof-verifier --lib unproved::tests:: (7 passed)
- cargo clippy -p dash-sdk -p drive-proof-verifier --lib --no-deps -- -D warnings
- cargo fmt --all
- git diff --check