### PR TITLE
ci: don't block PRs when CodeRabbit is rate limited

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://storage.googleapis.com/coderabbit_public_assets/schema.v2.json
+
+reviews:
+  # Don't fail the "CodeRabbit" commit status when a review can't be performed
+  # (e.g. "Review rate limited"). The "AI Review" workflow enforces that either
+  # CodeRabbit or thepastaclaw has reviewed the PR instead.
+  fail_commit_status: false

--- a/.github/workflows/pr-ai-review.yml
+++ b/.github/workflows/pr-ai-review.yml
@@ -1,0 +1,55 @@
+name: "AI Review"
+
+on:
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - ready_for_review
+      - synchronize
+  pull_request_review:
+    types:
+      - submitted
+
+permissions:
+  pull-requests: read
+
+concurrency:
+  group: ai-review-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  ai-review:
+    name: CodeRabbit or PastaClaw review
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Check for a review from CodeRabbit or thepastaclaw
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const reviewers = new Set(['coderabbitai[bot]', 'coderabbitai', 'thepastaclaw']);
+
+            const reviews = await github.paginate(github.rest.pulls.listReviews, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.payload.pull_request.number,
+            });
+
+            const found = reviews.filter(
+              (review) =>
+                review.state !== 'PENDING' &&
+                reviewers.has(review.user?.login?.toLowerCase())
+            );
+
+            if (found.length > 0) {
+              const authors = [...new Set(found.map((review) => review.user.login))];
+              core.info(`Found ${found.length} review(s) from: ${authors.join(', ')}`);
+              return;
+            }
+
+            core.setFailed(
+              'No review from CodeRabbit or thepastaclaw yet. This check passes ' +
+                'once either of them submits a review, so a rate-limited ' +
+                'CodeRabbit does not block the PR when thepastaclaw has reviewed ' +
+                '(or vice versa). It re-runs automatically when a review is submitted.'
+            );


### PR DESCRIPTION
## Issue being fixed or feature implemented

When CodeRabbit is rate limited it posts a failing `CodeRabbit` commit status ("Review rate limited"), which turns the PR checks rollup red (e.g. #4171) even when thepastaclaw has already reviewed the PR. The desired policy is: **either** a CodeRabbit **or** a thepastaclaw review must happen — a rate-limited CodeRabbit should not block a PR on its own.

## What was done?

- Added `.coderabbit.yaml` with `reviews.fail_commit_status: false` so CodeRabbit no longer fails its commit status when a review can't be performed (this checked-in config overrides the org/UI setting where the failing status is currently enabled).
- Added an **AI Review** workflow check (`.github/workflows/pr-ai-review.yml`) that passes once **either** `coderabbitai` **or** `thepastaclaw` has submitted a review on the PR. It re-runs automatically on `pull_request_review` events, so it flips green as soon as the first review lands. Because either reviewer satisfies it, a rate-limited CodeRabbit never blocks a PR that thepastaclaw reviewed (and vice versa).

Note: the `CodeRabbit` status was never a *required* check in branch protection — the failing status was cosmetic but made PRs look blocked. If we want the new gate to be enforced, the context `AI Review / CodeRabbit or PastaClaw review` can be added to the required status checks on the dev branches **after** this merges.

## How Has This Been Tested?

- Validated both YAML files parse.
- Verified `reviews.fail_commit_status` exists (default `false`) in the CodeRabbit v2 config schema.
- Confirmed via the GitHub API that the failing `CodeRabbit` status on #4171 is not a required check, and that this workflow's review query matches the reviews present there (thepastaclaw has reviewed → gate would pass).

## Breaking Changes

None.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [ ] I have made corresponding changes to the documentation if needed

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an automated pull request review check that passes when an approved automated or designated reviewer submits a review.
  * The check reruns automatically when pull requests are updated or new reviews are submitted.

* **Chores**
  * Updated review status handling so temporary review failures, such as rate limiting, do not incorrectly fail the commit status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->