### PR TITLE
fix(platform-wallet): persist the DashPay send used-flip after releasing the wallet-manager lock

### DIFF
--- a/packages/rs-platform-wallet-ffi/src/persistence.rs
+++ b/packages/rs-platform-wallet-ffi/src/persistence.rs
@@ -113,6 +113,22 @@ pub const PLATFORM_WALLET_PERSISTENCE_CAPABILITY_WALLET_RESTORE: u64 = 1 << 7;
 /// General-purpose notifications (`on_store_fn`, `on_flush_fn`) plus
 /// typed callbacks that send incremental data across FFI for the caller
 /// to persist in their preferred storage backend.
+///
+/// # Reentrancy contract (required of every callback)
+///
+/// A persistence callback runs **synchronously on the calling native thread**,
+/// which is frequently a wallet-manager task **holding the manager's write
+/// lock**. That lock is non-reentrant. Therefore a callback MUST NOT call back
+/// into any wallet-manager / platform-wallet FFI (`dash_sdk_*` /
+/// `platform_wallet_*` and friends), directly or indirectly — doing so
+/// deadlocks. Write the changeset to your storage backend and return; do not
+/// query live wallet state to enrich a row, and do not synchronously drive an
+/// observer/UI reaction that re-enters native on the same thread. (A UI layer
+/// reacting to the committed rows on a *later* turn — SwiftUI `@Query`, a Room
+/// `Flow` collector on an async dispatcher — is fine: it runs after the
+/// callback returns and the lock is released.) Keep the work bounded; the call
+/// blocks every other wallet accessor while it runs. Mirrors the Rust-side
+/// `PlatformWalletPersistence::store` reentrancy contract.
 #[repr(C)]
 #[allow(clippy::type_complexity)]
 pub struct PersistenceCallbacks {

--- a/packages/rs-platform-wallet/src/changeset/traits.rs
+++ b/packages/rs-platform-wallet/src/changeset/traits.rs
@@ -220,6 +220,25 @@ pub trait PlatformWalletPersistence: Send + Sync {
     /// Returns an error if the internal accumulator cannot be accessed
     /// (e.g. mutex poisoning). Callers that use fire-and-forget
     /// semantics should log the error rather than propagating.
+    ///
+    /// ## Reentrancy contract (required)
+    ///
+    /// **A `store` implementation MUST NOT call back into any wallet-manager /
+    /// platform-wallet API.** The wallet manager is guarded by a single,
+    /// **non-reentrant** async `RwLock`, and many callers invoke `store`
+    /// **while holding that lock's write guard** (the balance/registration/
+    /// contact/payment mutation paths persist inside their critical section).
+    /// A callback that re-acquired the manager lock — directly, or indirectly
+    /// via a wallet-manager FFI call, an event/observer that synchronously
+    /// drives one, or a read-back that queries live wallet state — would
+    /// **deadlock on first execution**. Persist only the changeset you were
+    /// handed; do not consult the wallet manager to enrich it.
+    ///
+    /// Because `store` may run under that write guard, it is also
+    /// **latency-sensitive**: a slow synchronous write blocks every other
+    /// wallet accessor (readers and writers) for its duration. Keep the
+    /// per-call work bounded; if the backend does inline I/O (see the type
+    /// doc), size it accordingly.
     fn store(
         &self,
         wallet_id: WalletId,

--- a/packages/rs-platform-wallet/src/wallet/identity/network/payments.rs
+++ b/packages/rs-platform-wallet/src/wallet/identity/network/payments.rs
@@ -578,7 +578,7 @@ impl<B: TransactionBroadcaster + ?Sized> DashPayView<'_, B> {
         // re-acquires that (non-reentrant) lock internally.
         self.drain_pending_contact_crypto(provider).await;
 
-        let (payment_address, tx, fee) = {
+        let (payment_address, used_flip_changeset, tx, fee) = {
             let mut wm = self.wallet_manager.write().await;
 
             // Resolve the external account's xpub so we can derive addresses.
@@ -652,36 +652,30 @@ impl<B: TransactionBroadcaster + ?Sized> DashPayView<'_, B> {
                 )));
             }
 
-            // Persist the used-flag flip (and any gap-window extension)
+            // Snapshot the used-flag flip (and any gap-window extension)
             // `next_address` + `mark_address_used` just applied to the
-            // external account's pool.
-            // This must be durable BEFORE the broadcast below: once the
-            // transaction is on the network the address is publicly
-            // spent-to, and a relaunch that rehydrates the pool from a
-            // stale snapshot would hand the SAME address to the next
-            // payment — breaking DIP-15 per-payment rotation and linking
-            // the payments on-chain. A store failure aborts the send
-            // pre-broadcast (nothing has hit the network); the consumed
-            // in-memory address only leaves a one-address gap that the
-            // pool's gap window absorbs on retry.
+            // external account's pool, as an owned changeset. The snapshot is
+            // captured here — while the pool is still borrowed under the
+            // guard — so the persisted state is exactly the flip just made,
+            // but the `persister.store` call itself is deferred until after
+            // this write guard is released (see below, before the broadcast).
+            // The host persistence callback must not run while the
+            // wallet-manager write lock is held: a slow host write would stall
+            // every other wallet accessor for its duration, and a host store
+            // that re-entered any manager API would deadlock the non-reentrant
+            // lock.
             let external_account_type = key_wallet::account::AccountType::DashpayExternalAccount {
                 index: account_index,
                 user_identity_id: from_identity_id.to_buffer(),
                 friend_identity_id: to_contact_id.to_buffer(),
             };
-            self.persister
-                .store(crate::changeset::PlatformWalletChangeSet {
-                    account_address_pools: crate::changeset::account_address_pool_entries(
-                        external_account_type,
-                        external_account.managed_account_type().address_pools(),
-                    ),
-                    ..Default::default()
-                })
-                .map_err(|e| {
-                    PlatformWalletError::Persistence(format!(
-                        "failed to persist payment-address used flip: {e}"
-                    ))
-                })?;
+            let used_flip_changeset = crate::changeset::PlatformWalletChangeSet {
+                account_address_pools: crate::changeset::account_address_pool_entries(
+                    external_account_type,
+                    external_account.managed_account_type().address_pools(),
+                ),
+                ..Default::default()
+            };
 
             let current_height = info.core_wallet.synced_height();
 
@@ -727,8 +721,27 @@ impl<B: TransactionBroadcaster + ?Sized> DashPayView<'_, B> {
                 .await
                 .map_err(|e| PlatformWalletError::TransactionBuild(e.to_string()))?;
 
-            (payment_address, tx, fee)
+            (payment_address, used_flip_changeset, tx, fee)
         };
+
+        // Persist the payment-address used flip now that the wallet-manager
+        // write guard is released, but BEFORE the broadcast below. Durability
+        // must precede broadcast: once the transaction is on the network the
+        // address is publicly spent-to, and a relaunch that rehydrated the
+        // pool from a stale snapshot would re-hand the SAME address to the
+        // next payment — breaking DIP-15 per-payment rotation and linking the
+        // payments on-chain. A store failure aborts the send pre-broadcast
+        // (nothing has hit the network); the consumed in-memory address only
+        // leaves a one-address gap that the pool's gap window absorbs on
+        // retry. A funding-build failure above returns before this point, so
+        // an address consumed for a send that never broadcasts is likewise
+        // left only in memory — safe to re-hand, since it was never exposed
+        // on-chain.
+        self.persister.store(used_flip_changeset).map_err(|e| {
+            PlatformWalletError::Persistence(format!(
+                "failed to persist payment-address used flip: {e}"
+            ))
+        })?;
 
         // --- 3. Broadcast the transaction, releasing the build's UTXO
         // reservation if the broadcast is definitively rejected pre-send. ---
@@ -3465,25 +3478,79 @@ mod tests {
         }
     }
 
-    /// `send_payment` must persist the used-flag flip `next_address`
-    /// applies to the contact's external-account pool. The flip is
-    /// otherwise in-memory only: after a relaunch the pool rehydrates
-    /// from the last persisted snapshot with the address unused, and the
-    /// next payment to the same contact reuses the SAME address —
-    /// breaking DIP-15 per-payment rotation and linking the payments
-    /// on-chain. Pins the `AccountAddressPoolEntry` contract (snapshots
-    /// at register / pool-extend / used-flip): a whole-pool snapshot
-    /// carrying the used flag is emitted once the payment address is
-    /// consumed, before anything reaches the network.
+    /// The `send_payment` used-flag flip persist must run only AFTER the
+    /// wallet-manager write guard is released (and before the broadcast).
+    ///
+    /// The host persistence callback is synchronous, so holding the manager's
+    /// write lock across it would stall every other wallet accessor for the
+    /// host write's duration, and a host store that re-entered a manager API
+    /// would deadlock the non-reentrant lock. This pins that the used-flip
+    /// changeset is persisted AND that the write lock was already released
+    /// when it was — a `try_read` on the shared manager succeeds iff no writer
+    /// holds it. Against the pre-fix ordering (store inside the write-guarded
+    /// block) the lock-released assertion fails; with the persist deferred
+    /// until after the guard drops it holds.
     #[tokio::test]
-    async fn send_payment_persists_external_pool_used_flip() {
+    async fn send_payment_persists_external_pool_used_flip_after_releasing_lock() {
         use crate::wallet::identity::network::contact_requests::SeedCryptoProvider;
         use key_wallet::account::AccountType;
-        use key_wallet::managed_account::managed_account_trait::ManagedAccountTrait;
 
-        let (manager, persister, wallet_id) = make_wallet().await;
+        // Probe persister: on the used-flip store (the changeset carrying an
+        // external account's address pools), records whether the shared
+        // wallet-manager write lock was already released — a `try_read`
+        // succeeds iff no writer holds it. A `Weak` back-reference avoids a
+        // persister <-> manager cycle.
+        type ManagerLock = tokio::sync::RwLock<
+            key_wallet_manager::WalletManager<crate::wallet::platform_wallet::PlatformWalletInfo>,
+        >;
+        struct LockProbePersister {
+            manager: Mutex<Option<std::sync::Weak<ManagerLock>>>,
+            /// `Some(true)`: an external-pool store was seen with the write
+            /// lock released; `Some(false)`: seen but the lock was still held;
+            /// `None`: never seen.
+            external_pool_store_unlocked: Mutex<Option<bool>>,
+        }
+
+        impl PlatformWalletPersistence for LockProbePersister {
+            fn store(
+                &self,
+                _wallet_id: WalletId,
+                changeset: PlatformWalletChangeSet,
+            ) -> Result<(), PersistenceError> {
+                let carries_external_pool = changeset
+                    .account_address_pools
+                    .iter()
+                    .any(|e| matches!(e.account_type, AccountType::DashpayExternalAccount { .. }));
+                if carries_external_pool {
+                    let unlocked = self
+                        .manager
+                        .lock()
+                        .unwrap()
+                        .as_ref()
+                        .and_then(|w| w.upgrade())
+                        .map(|m| m.try_read().is_ok())
+                        .unwrap_or(false);
+                    *self.external_pool_store_unlocked.lock().unwrap() = Some(unlocked);
+                }
+                Ok(())
+            }
+            fn flush(&self, _wallet_id: WalletId) -> Result<(), PersistenceError> {
+                Ok(())
+            }
+            fn load(&self) -> Result<ClientStartState, PersistenceError> {
+                Ok(ClientStartState::default())
+            }
+        }
+
+        let probe = Arc::new(LockProbePersister {
+            manager: Mutex::new(None),
+            external_pool_store_unlocked: Mutex::new(None),
+        });
+        let (manager, wallet_id) = make_wallet_with(Arc::clone(&probe)).await;
         let wallet_arc = manager.get_wallet(&wallet_id).await.expect("wallet");
         let iw = wallet_arc.identity();
+        // Point the probe at the shared manager lock the send will contend on.
+        *probe.manager.lock().unwrap() = Some(Arc::downgrade(&iw.wallet_manager));
 
         let owner_id = Identifier::from([0x11; 32]);
         let contact_id = Identifier::from([0x22; 32]);
@@ -3495,7 +3562,7 @@ mod tests {
                     bare_identity([0x11; 32]),
                     0,
                     wallet_id,
-                    &WalletPersister::new(wallet_id, Arc::clone(&persister) as _),
+                    &WalletPersister::new(wallet_id, Arc::clone(&probe) as _),
                 )
                 .expect("add owner");
         }
@@ -3538,9 +3605,15 @@ mod tests {
             .await
             .expect("register external account");
 
-        // Drop the registration round's (all-unused) snapshot so the
-        // assertions below only see what the send path emits.
-        persister.stores.lock().unwrap().clear();
+        // Isolate the assertion to the send path: forget any external-pool
+        // store the registration round may have made (that one runs under the
+        // registration write guard).
+        *probe.external_pool_store_unlocked.lock().unwrap() = None;
+
+        // Fund BIP-44 account 0 so the send builds, signs, and broadcasts —
+        // reaching the used-flip persist, which now fires only on the path to
+        // broadcast (a funding-build failure returns before it).
+        fund_bip44_account_0(&manager, wallet_id, 0xA1, 60_000).await;
 
         let seed = Mnemonic::from_phrase(TEST_MNEMONIC, Language::English)
             .expect("valid mnemonic")
@@ -3548,67 +3621,23 @@ mod tests {
         let provider = SeedCryptoProvider::from_seed(seed, Network::Testnet);
         let signer = SeedSigner::new(seed, Network::Testnet);
 
-        // The seedless test wallet has no UTXOs, so the send fails at
-        // funding — AFTER the payment address was consumed and its
-        // used-flip persisted, which is exactly the window under test.
-        let _err = iw
+        let iw_send = with_accepting_broadcaster(iw);
+        iw_send
             .dashpay()
-            .send_payment(&owner_id, &contact_id, 10_000, None, &signer, &provider)
+            .send_payment(&owner_id, &contact_id, 50_000, None, &signer, &provider)
             .await
-            .expect_err("no spendable UTXOs — the funding build must fail");
+            .expect("funded + signable send must succeed through the accepting broadcaster");
 
-        // In-memory: the pool consumed exactly one payment address.
-        let key = DashpayAccountKey {
-            index: 0,
-            user_identity_id: owner_id.to_buffer(),
-            friend_identity_id: contact_id.to_buffer(),
-        };
-        let used_address = {
-            let wm = iw.wallet_manager.read().await;
-            let info = wm.get_wallet_info(&wallet_id).expect("info");
-            let account = info
-                .core_wallet
-                .accounts
-                .dashpay_external_accounts
-                .get(&key)
-                .expect("external account resident");
-            let used: Vec<dashcore::Address> = account
-                .managed_account_type()
-                .address_pools()
-                .iter()
-                .flat_map(|p| p.addresses.values())
-                .filter(|a| a.used)
-                .map(|a| a.address.clone())
-                .collect();
-            assert_eq!(
-                used.len(),
-                1,
-                "exactly one payment address must be marked used in memory"
-            );
-            used.into_iter().next().expect("one used address")
-        };
-
-        // Persisted: a whole-pool snapshot for THIS contact's external
-        // account was emitted with the consumed address flagged used.
-        let expected_account_type = AccountType::DashpayExternalAccount {
-            index: 0,
-            user_identity_id: owner_id.to_buffer(),
-            friend_identity_id: contact_id.to_buffer(),
-        };
-        let stores = persister.stores.lock().unwrap();
-        let flip_persisted = stores.iter().any(|(_, cs)| {
-            cs.account_address_pools.iter().any(|entry| {
-                entry.account_type == expected_account_type
-                    && entry
-                        .addresses
-                        .iter()
-                        .any(|a| a.used && a.address == used_address)
-            })
-        });
-        assert!(
-            flip_persisted,
-            "send_payment must persist the external-account pool snapshot \
-             with the consumed address marked used"
+        // The used-flip changeset was persisted (Some(_)) AND the store ran
+        // after the write guard was released (Some(true)). Some(false) means
+        // it still ran under the held write guard (the pre-fix ordering);
+        // None means the flip was never persisted.
+        let observed = *probe.external_pool_store_unlocked.lock().unwrap();
+        assert_eq!(
+            observed,
+            Some(true),
+            "send_payment must persist the external-account used flip AFTER \
+             releasing the wallet-manager write lock (observed: {observed:?})"
         );
     }
 
@@ -3653,8 +3682,8 @@ mod tests {
     /// Plant a single spendable UTXO of `value_duffs` on BIP-44 account 0's
     /// first pool address (a real derived address, so its derivation path is
     /// resolvable and [`SeedSigner`] can sign the funding input).
-    async fn fund_bip44_account_0(
-        manager: &Arc<PlatformWalletManager<RecordingPersister>>,
+    async fn fund_bip44_account_0<P: PlatformWalletPersistence + 'static>(
+        manager: &Arc<PlatformWalletManager<P>>,
         wallet_id: WalletId,
         txid_byte: u8,
         value_duffs: u64,


### PR DESCRIPTION
## Issue being fixed or feature implemented

An external review of the Kotlin-SDK PR's `rs-platform-wallet` / FFI changes flagged that `send_payment`'s used-flip store invokes the host persistence callback (Room/SwiftData FFI) **while holding the `wallet_manager` write lock**. I verified the finding by tracing it from source:

- `WalletPersister::store` → `FFIPersister::store` is **synchronous** and fires the host C-ABI callback inline; the trait doc notes `SqliteWalletPersister` even flushes on every `store`.
- The wallet is guarded by a single `tokio::sync::RwLock` (~100 read + ~104 write consumers). While the write guard is held across a slow host write, **every** accessor — balance queries, signing, other sends, background sync — is blocked, and the tokio worker thread is blocked too (the call is not `.await`ed).
- The lock is **non-reentrant**: a host store that called back into any manager API deadlocks. Both shipping hosts are safe today (Swift: synchronous SwiftData write, no manager reference; Kotlin: synchronous Room write, and its one native call — identity-key derive — is deliberately lock-free *because* a handle-keyed derive would re-`blocking_read` this same lock and deadlock). But the contract was **undocumented on the trait/vtable** — it existed only as an incidental inline comment — so a future change could reintroduce the deadlock with no signal.

## What was done?

**Persist-after-drop for the used-flip (the one clean site).** `send_payment` now captures the pool snapshot as an owned changeset under the guard, **drops the guard, then stores before the broadcast**. The durability-before-broadcast invariant is fully preserved (a relaunch must never re-hand a broadcast-to address). A funding-build failure now returns *before* the persist, leaving the consumed address only in memory — safe to re-hand, since it was never broadcast on-chain (and strictly less address-waste than before).

**Documented no-reentrancy contract.** Hoisted the previously-informal rule onto `PlatformWalletPersistence::store` and the FFI `PersistenceCallbacks` vtable: a `store` callback MUST NOT call back into any wallet-manager API (deadlocks the non-reentrant lock), and is latency-sensitive because it may run under the write guard.

**Left as-is (deliberately):** `ensure_identity_topup_account`'s registration persist and `record_dashpay_payment`'s Sent-entry persist both couple their rollback to the write-guarded `&mut` borrow, so moving them out of the lock cleanly would need a re-acquire + a TOCTOU window — more risk than benefit. `ensure_identity_topup_account` also already does a larger under-lock host round-trip (the Keychain xpub derivation), so isolating only its persister buys little.

## How Has This Been Tested?

- New regression test `send_payment_persists_external_pool_used_flip_after_releasing_lock` uses a probe persister that, from inside `store`, checks the shared wallet-manager lock state (`try_read` succeeds iff no writer holds it). Demonstrated red → green:
  - **✖ before fix** (store under the write guard): `observed: Some(false)` — assertion fails.
  - **✔ after fix** (store after the guard is released): `observed: Some(true)` — passes.
- `cargo test -p platform-wallet --lib`: **490 passed, 0 failed**.
- `cargo clippy -p platform-wallet -p platform-wallet-ffi --all-targets`: clean on the changed code (the 2 remaining warnings are pre-existing, in untouched test code).
- `cargo fmt --check` on both crates: clean.

## Breaking Changes

None. Public API unchanged; the persist-ordering change is internal and preserves the durability-before-broadcast guarantee.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [x] I have made corresponding changes to the documentation if needed

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone

🤖 Generated with [Claude Code](https://claude.com/claude-code)
