### PR TITLE
feat(kotlin-sdk): add maven-publish for the release AAR

### DIFF
--- a/packages/kotlin-sdk/PUBLISHING.md
+++ b/packages/kotlin-sdk/PUBLISHING.md
@@ -1,0 +1,84 @@
+# Publishing `org.dashj:dash-sdk-android` to Maven Central
+
+The SDK publishes under the existing **`org.dashj`** namespace (same as
+`dashj-core`), so no new Central namespace verification is needed. This is a
+Maven-coordinates decision only — the Kotlin source packages remain
+`org.dashfoundation.dashsdk`. Deployment uses **JReleaser**, mirroring
+[dashj/core/build.gradle](https://github.com/dashpay/dashj/blob/master/core/build.gradle):
+release versions go to Maven Central via the Central Portal; `-SNAPSHOT`
+versions go to the Sonatype snapshots repository.
+
+## Prerequisites
+
+- **Sonatype Central Portal token** for the `org.dashj` namespace (held by
+  HashEngineering — the same account that publishes `dashj-core`).
+- **GPG signing key** (the dashj release key works), with the public key on the
+  keyservers.
+- **Native toolchain**: Android NDK r28+ (`28.1.13356709`), `cargo-ndk`, rustup
+  targets `aarch64-linux-android` and `x86_64-linux-android`, JDK 17.
+
+## Credentials — environment only, never committed
+
+Gradle signing (signs artifacts during the staging publish; the classic
+`signing.keyId` / `signing.password` / `signing.secretKeyRingFile` entries in
+`~/.gradle/gradle.properties`, as used for dashj-core, also work):
+
+```bash
+export ORG_GRADLE_PROJECT_signingKey="$(cat private-key.asc)"   # ASCII-armored
+export ORG_GRADLE_PROJECT_signingPassword="…"
+```
+
+JReleaser deploy (read only when a `jreleaser*` task runs):
+
+```bash
+export JRELEASER_MAVENCENTRAL_SONATYPE_USERNAME="…"   # Central Portal token name
+export JRELEASER_MAVENCENTRAL_SONATYPE_PASSWORD="…"   # Central Portal token value
+export JRELEASER_NEXUS2_SNAPSHOTS_USERNAME="…"        # same token (snapshots repo)
+export JRELEASER_NEXUS2_SNAPSHOTS_PASSWORD="…"
+export JRELEASER_GPG_PUBLIC_KEY="$(cat public-key.asc)"
+export JRELEASER_GPG_SECRET_KEY="$(cat private-key.asc)"
+export JRELEASER_GPG_PASSPHRASE="…"
+```
+
+## Release steps (from `packages/kotlin-sdk/`)
+
+```bash
+# 1. Build the native JNI library (arm64-v8a + x86_64) and verify its exports.
+./build_android.sh --verify
+
+# 2. Stage the signed release AAR + sources/javadoc jars into sdk/build/staging-deploy.
+./gradlew :sdk:publishReleasePublicationToStagingRepository -PsdkVersion=0.1.0
+
+# 3. Upload the staged artifacts. Release versions -> Maven Central;
+#    -SNAPSHOT versions -> Sonatype snapshots.
+./gradlew :sdk:jreleaserDeploy -PsdkVersion=0.1.0
+```
+
+Then approve/verify the deployment at <https://central.sonatype.com> and
+confirm the artifact appears on search.maven.org (sync takes ~30 min).
+
+**Versioning:** the default is `0.1.0-SNAPSHOT`; pass the same
+`-PsdkVersion=x.y.z` to steps 2 and 3. The first release should be a real
+version (e.g. `0.1.0`) — the Android wallet's CI must depend on a pinned
+release, never a snapshot.
+
+## The JNI guard
+
+`sdk/src/main/jniLibs/` is gitignored, so a clean checkout has no
+`libdash_sdk_jni.so` — and an AAR published without it installs fine but dies
+at runtime with `UnsatisfiedLinkError`. The `verifyJniLibsForRemotePublish`
+task therefore **hard-fails** every staging/remote/jreleaser publish task when
+the `.so` is missing for `arm64-v8a` or `x86_64`. There is no override for
+remote publishes; `-PallowMissingJni` only downgrades the check for
+`publishToMavenLocal` (metadata-only dry runs into `~/.m2`). If the guard
+fires, run step 1.
+
+## Consuming the artifact
+
+```kotlin
+repositories { mavenCentral() }
+dependencies { implementation("org.dashj:dash-sdk-android:0.1.0") }
+```
+
+Requires `minSdk 29`. The AAR bundles the native library for `arm64-v8a` and
+`x86_64`; `armeabi-v7a` is intentionally unsupported.

--- a/packages/kotlin-sdk/PUBLISHING.md
+++ b/packages/kotlin-sdk/PUBLISHING.md
@@ -76,6 +76,19 @@ remote publishes; `-PallowMissingJni` only downgrades the check for
 `publishToMavenLocal` (metadata-only dry runs into `~/.m2`). If the guard
 fires, run step 1.
 
+That check inspects the *source* tree; a second, deploy-time guard —
+`verifyStagedAarForRemotePublish` — inspects what JReleaser will actually
+upload. Immediately before any `jreleaser*` deploy/upload/release task it
+opens the staged AAR in `sdk/build/staging-deploy` and hard-fails unless:
+(a) the staged artifacts live under exactly the intended
+`org/dashj/dash-sdk-android/<version>/` path, with nothing staged outside it;
+(b) exactly one release AAR is staged, named for that coordinate; and
+(c) the AAR contains both `jni/arm64-v8a/libdash_sdk_jni.so` and
+`jni/x86_64/libdash_sdk_jni.so`. A stale or malformed staging dir therefore
+cannot be deployed even when the current source tree is valid. If it fires,
+re-run steps 1–2, then deploy. `publishToMavenLocal` never triggers this
+guard.
+
 ## Consuming the artifact
 
 ```kotlin

--- a/packages/kotlin-sdk/PUBLISHING.md
+++ b/packages/kotlin-sdk/PUBLISHING.md
@@ -48,6 +48,9 @@ export JRELEASER_GPG_PASSPHRASE="…"
 
 # 2. Stage the signed release AAR + sources/javadoc jars into sdk/build/staging-deploy.
 ./gradlew :sdk:publishReleasePublicationToStagingRepository -PsdkVersion=0.1.0
+# (the staging dir sdk/build/staging-deploy is wiped automatically before every
+#  staging publish — cleanStagingDeploy — so stale versions from earlier runs
+#  can never reach JReleaser)
 
 # 3. Upload the staged artifacts. Release versions -> Maven Central;
 #    -SNAPSHOT versions -> Sonatype snapshots.

--- a/packages/kotlin-sdk/gradle/libs.versions.toml
+++ b/packages/kotlin-sdk/gradle/libs.versions.toml
@@ -20,6 +20,7 @@ androidxTestExtJunit = "1.2.1"
 androidxTestRunner = "1.6.2"
 espresso = "3.6.1"
 robolectric = "4.14.1"
+jreleaser = "1.17.0"
 
 [libraries]
 kotlinx-coroutines-core = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-core", version.ref = "coroutines" }
@@ -66,3 +67,4 @@ kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 kotlin-compose = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
 kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
 ksp = { id = "com.google.devtools.ksp", version.ref = "ksp" }
+jreleaser = { id = "org.jreleaser", version.ref = "jreleaser" }

--- a/packages/kotlin-sdk/sdk/build.gradle.kts
+++ b/packages/kotlin-sdk/sdk/build.gradle.kts
@@ -229,13 +229,13 @@ afterEvaluate {
 // (NativeLoader.ensureLoaded → System.loadLibrary("dash_sdk_jni")).
 val requiredJniAbis = listOf("arm64-v8a", "x86_64") // build_android.sh ABI policy
 
-fun missingJniAbis(): List<String> = requiredJniAbis.filterNot { abi ->
-    file("src/main/jniLibs/$abi/libdash_sdk_jni.so").isFile
-}
-
-fun jniMissingMessage(missing: List<String>): String =
-    "Native JNI library libdash_sdk_jni.so is missing for ABI(s) " +
-        "${missing.joinToString()} under src/main/jniLibs/ — run ./build_android.sh " +
+// A 0-byte .so (e.g. from an interrupted build_android.sh) is as broken at
+// runtime as a missing one, so every check below requires real content, and the
+// guard tasks capture plain serializable values (no script-object references)
+// so they stay configuration-cache safe.
+val jniMissingMessageTemplate =
+    "Native JNI library libdash_sdk_jni.so is missing or empty for ABI(s) " +
+        "%s under src/main/jniLibs/ — run ./build_android.sh " +
         "before publishing so the coordinate isn't broken at runtime."
 
 // Remote / staging publish: ALWAYS hard-fail on a missing .so. `-PallowMissingJni`
@@ -244,11 +244,16 @@ fun jniMissingMessage(missing: List<String>): String =
 // uploads to Maven Central). This closes the escape where `-PallowMissingJni`
 // previously downgraded the check to a warning for every publish task.
 val verifyJniLibsForRemotePublish = tasks.register("verifyJniLibsForRemotePublish") {
+    val jniLibsDir = file("src/main/jniLibs")
+    val abis = requiredJniAbis
+    val template = jniMissingMessageTemplate
     doLast {
-        val missing = missingJniAbis()
+        val missing = abis.filterNot { abi ->
+            jniLibsDir.resolve("$abi/libdash_sdk_jni.so").let { so -> so.isFile && so.length() > 0L }
+        }
         if (missing.isNotEmpty()) {
             throw GradleException(
-                jniMissingMessage(missing) +
+                template.format(missing.joinToString()) +
                     " -PallowMissingJni is a local-only escape and is NOT honored for " +
                     "remote/staging deploys."
             )
@@ -259,11 +264,17 @@ val verifyJniLibsForRemotePublish = tasks.register("verifyJniLibsForRemotePublis
 // Local publish (`publishToMavenLocal`): a dev may pass `-PallowMissingJni` for a
 // POM/metadata-only dry run into the local ~/.m2, which never leaves the machine.
 val verifyJniLibsForLocalPublish = tasks.register("verifyJniLibsForLocalPublish") {
+    val jniLibsDir = file("src/main/jniLibs")
+    val abis = requiredJniAbis
+    val template = jniMissingMessageTemplate
+    val allowMissingJni = project.hasProperty("allowMissingJni")
     doLast {
-        val missing = missingJniAbis()
+        val missing = abis.filterNot { abi ->
+            jniLibsDir.resolve("$abi/libdash_sdk_jni.so").let { so -> so.isFile && so.length() > 0L }
+        }
         if (missing.isNotEmpty()) {
-            val message = jniMissingMessage(missing)
-            if (project.hasProperty("allowMissingJni")) {
+            val message = template.format(missing.joinToString())
+            if (allowMissingJni) {
                 logger.warn(
                     "WARNING: $message (continuing: -PallowMissingJni is set — local publish only.)"
                 )
@@ -366,14 +377,19 @@ val verifyStagedAarForRemotePublish = tasks.register("verifyStagedAarForRemotePu
 
         // (3) The staged AAR itself must carry the native library for every ABI.
         ZipFile(aar).use { zip ->
+            // getEntry("x") falls back to a directory entry "x/", and a 0-byte
+            // entry is as fatal at runtime as an absent one — require a real file
+            // with content.
             val missing = requiredAbis.filter { abi ->
-                zip.getEntry("jni/$abi/libdash_sdk_jni.so") == null
+                val entry = zip.getEntry("jni/$abi/libdash_sdk_jni.so")
+                entry == null || entry.isDirectory || entry.size <= 0L
             }
             if (missing.isNotEmpty()) {
                 throw GradleException(
-                    "Staged AAR ${aar.name} is missing jni/<abi>/libdash_sdk_jni.so for " +
-                        "ABI(s) ${missing.joinToString()} — it would die at runtime with " +
-                        "UnsatisfiedLinkError. Run ../build_android.sh, re-stage, then deploy."
+                    "Staged AAR ${aar.name} is missing (or has an empty) " +
+                        "jni/<abi>/libdash_sdk_jni.so for ABI(s) ${missing.joinToString()} — " +
+                        "it would die at runtime with UnsatisfiedLinkError. " +
+                        "Run ../build_android.sh, re-stage, then deploy."
                 )
             }
         }

--- a/packages/kotlin-sdk/sdk/build.gradle.kts
+++ b/packages/kotlin-sdk/sdk/build.gradle.kts
@@ -1,5 +1,7 @@
+import java.util.concurrent.Callable
 import org.gradle.api.publish.maven.tasks.PublishToMavenLocal
 import org.gradle.api.publish.maven.tasks.PublishToMavenRepository
+import org.jreleaser.model.Active
 
 plugins {
     alias(libs.plugins.android.library)
@@ -7,14 +9,20 @@ plugins {
     alias(libs.plugins.kotlin.serialization)
     alias(libs.plugins.ksp)
     `maven-publish`
+    id("signing")
+    alias(libs.plugins.jreleaser)
 }
 
-// NOTE (Maven Central, future): the `org.dashfoundation` groupId can't be
-// published to Maven Central yet — that requires owning the matching domain,
-// and dashfoundation.org is held by a third party (HashEngineering, PR #4045).
-// This coordinate is for `publishToMavenLocal` / an internal repo for now; a
-// Maven Central move is a separate groupId/hosting decision.
-group = "org.dashfoundation"
+// Published Maven coordinate group. Per HashEngineering's call on PR #4045:
+// publish under the existing `org.dashj` group — Dash already owns dashj.org and
+// ships its legacy Core/Platform SDKs there, so this needs no separate domain
+// verification for Maven Central (`org.dashfoundation` would have, since
+// dashfoundation.org is held by a third party). The Kotlin source packages stay
+// `org.dashfoundation.dashsdk`; this is a Maven-coordinates decision only.
+// `maven-publish` handles local / internal-repo publishing; jreleaser (bottom of
+// file) handles Maven Central releases and Sonatype SNAPSHOTs, mirroring
+// dashj/core/build.gradle.
+group = "org.dashj"
 version = project.findProperty("sdkVersion")?.toString() ?: "0.1.0-SNAPSHOT"
 
 android {
@@ -108,14 +116,25 @@ dependencies {
 
 // Publishes the release AAR (incl. libdash_sdk_jni.so if ../build_android.sh ran first) with a
 // POM carrying the Room/DataStore/Biometric api dependencies.
-// Local: ./gradlew :sdk:publishToMavenLocal   Coordinates: org.dashfoundation:dash-sdk-android:<version>
+// Local:  ./gradlew :sdk:publishToMavenLocal   Coordinates: org.dashj:dash-sdk-android:<version>
+// Remote: `:sdk:publishReleasePublicationToStagingRepository` stages the signed
+//         artifacts into build/staging-deploy, then `:sdk:jreleaserDeploy` uploads
+//         them to Maven Central (release) / Sonatype snapshots (see jreleaser block).
 // Override the version with -PsdkVersion=x.y.z (defaults to 0.1.0-SNAPSHOT).
 afterEvaluate {
     publishing {
+        repositories {
+            // Local staging dir that jreleaser reads from and uploads (below); it is
+            // not itself a network repo, so staging never needs credentials.
+            maven {
+                name = "staging"
+                url = uri(layout.buildDirectory.dir("staging-deploy"))
+            }
+        }
         publications {
             create<MavenPublication>("release") {
                 from(components["release"])
-                groupId = "org.dashfoundation"
+                groupId = "org.dashj"
                 artifactId = "dash-sdk-android"
                 pom {
                     name.set("Dash Platform Kotlin SDK")
@@ -131,9 +150,7 @@ afterEvaluate {
                         }
                     }
                     // scm + developers: required by Maven Central (and most
-                    // remote repos) for POM validation. Pointed at the GitHub
-                    // repo rather than a vanity domain (see the group-id note
-                    // above re: dashfoundation.org ownership).
+                    // remote repos) for POM validation. Pointed at the GitHub repo.
                     scm {
                         url.set("https://github.com/dashpay/platform")
                         connection.set("scm:git:git://github.com/dashpay/platform.git")
@@ -151,6 +168,18 @@ afterEvaluate {
                 }
             }
         }
+    }
+
+    // Sign published artifacts, but only for a real remote publish. `publishToMavenLocal`
+    // and a bare `assemble` never put a PublishToMavenRepository task in the graph, so a
+    // local build requires no GPG key. Keys come from the standard signing properties/env
+    // (signing.keyId + signing.password + signing.secretKeyRingFile, or the in-memory
+    // ORG_GRADLE_PROJECT_signingKey / signingPassword pair) when a remote publish runs.
+    signing {
+        setRequired(Callable {
+            gradle.taskGraph.allTasks.any { it is PublishToMavenRepository }
+        })
+        sign(publishing.publications["release"])
     }
 }
 
@@ -183,3 +212,63 @@ val verifyJniLibsPresent = tasks.register("verifyJniLibsPresent") {
 
 tasks.withType<PublishToMavenRepository>().configureEach { dependsOn(verifyJniLibsPresent) }
 tasks.withType<PublishToMavenLocal>().configureEach { dependsOn(verifyJniLibsPresent) }
+
+// Maven Central / Sonatype deployment via jreleaser, mirroring
+// dashj/core/build.gradle (https://github.com/dashpay/dashj/blob/master/core/build.gradle#L139).
+// Flow: `maven-publish` stages the signed artifacts into build/staging-deploy (the
+// `staging` repository configured above), then `./gradlew :sdk:jreleaserDeploy`
+// uploads them — release versions to Maven Central, -SNAPSHOT versions to the
+// Sonatype snapshots repo. jreleaser reads its GPG key and Sonatype credentials
+// from env/props (JRELEASER_GPG_*, JRELEASER_MAVENCENTRAL_*/JRELEASER_NEXUS2_*)
+// at deploy time only, so `publishToMavenLocal` and any build that never invokes a
+// jreleaser task need no signing key or account.
+jreleaser {
+    project {
+        name.set("dash-sdk-android")
+        description.set(
+            "Kotlin SDK for Dash Core (L1 SPV) and Dash Platform " +
+                "(identities, DPNS, DashPay, shielded balances)"
+        )
+        links {
+            homepage.set("https://github.com/dashpay/platform")
+        }
+        authors.set(listOf("Dash Platform Contributors"))
+        license.set("MIT")
+        gitRootSearch.set(true)
+    }
+
+    signing {
+        active.set(Active.ALWAYS)
+        armored.set(true)
+    }
+
+    deploy {
+        maven {
+            // Tagged release versions -> Maven Central via the Sonatype portal.
+            mavenCentral {
+                create("sonatype") {
+                    active.set(Active.RELEASE)
+                    url.set("https://central.sonatype.com/api/v1/publisher")
+                    stagingRepository(
+                        layout.buildDirectory.dir("staging-deploy").get().asFile.path
+                    )
+                }
+            }
+            // -SNAPSHOT versions -> Sonatype snapshots repository.
+            nexus2 {
+                create("snapshots") {
+                    active.set(Active.SNAPSHOT)
+                    url.set("https://central.sonatype.com/repository/maven-snapshots/")
+                    snapshotUrl.set("https://central.sonatype.com/repository/maven-snapshots/")
+                    applyMavenCentralRules.set(true)
+                    snapshotSupported.set(true)
+                    closeRepository.set(true)
+                    releaseRepository.set(true)
+                    stagingRepository(
+                        layout.buildDirectory.dir("staging-deploy").get().asFile.path
+                    )
+                }
+            }
+        }
+    }
+}

--- a/packages/kotlin-sdk/sdk/build.gradle.kts
+++ b/packages/kotlin-sdk/sdk/build.gradle.kts
@@ -1,4 +1,5 @@
 import java.util.concurrent.Callable
+import java.util.zip.ZipFile
 import org.gradle.api.publish.maven.tasks.PublishToMavenLocal
 import org.gradle.api.publish.maven.tasks.PublishToMavenRepository
 import org.jreleaser.model.Active
@@ -24,6 +25,11 @@ plugins {
 // dashj/core/build.gradle.
 group = "org.dashj"
 version = project.findProperty("sdkVersion")?.toString() ?: "0.1.0-SNAPSHOT"
+
+// Single source of truth for the published coordinate — consumed by the
+// `release` publication and by verifyStagedAarForRemotePublish (both below).
+val publishGroupId = "org.dashj"
+val publishArtifactId = "dash-sdk-android"
 
 android {
     namespace = "org.dashfoundation.dashsdk"
@@ -153,8 +159,8 @@ afterEvaluate {
         publications {
             create<MavenPublication>("release") {
                 from(components["release"])
-                groupId = "org.dashj"
-                artifactId = "dash-sdk-android"
+                groupId = publishGroupId
+                artifactId = publishArtifactId
                 pom {
                     name.set("Dash Platform Kotlin SDK")
                     description.set(
@@ -274,13 +280,123 @@ tasks.withType<PublishToMavenRepository>().configureEach {
 tasks.withType<PublishToMavenLocal>().configureEach {
     dependsOn(verifyJniLibsForLocalPublish)
 }
+// Deploy-time guard on the STAGED artifacts. verifyJniLibsForRemotePublish
+// (above) checks the source jniLibs tree, but `jreleaserDeploy` uploads whatever
+// already sits in build/staging-deploy — a valid current source tree could
+// green-light a stale or malformed staged AAR. So, immediately before any
+// jreleaser deploy/upload/release, inspect the staging repository itself:
+//   1. artifacts must exist under exactly the intended
+//      <group>/<artifactId>/<version> path, and nothing may be staged outside it
+//      (jreleaser pushes the whole staging repository, strays included);
+//   2. exactly one release AAR must be staged, named for the intended
+//      artifactId + version (plain, or Maven unique-snapshot timestamped);
+//   3. that AAR, opened as a zip, must contain jni/<abi>/libdash_sdk_jni.so for
+//      every required ABI.
+// Everything is computed in doLast, so configuration stays lazy and
+// mavenLocal/plain builds never touch this. Only jreleaser tasks depend on it.
+val verifyStagedAarForRemotePublish = tasks.register("verifyStagedAarForRemotePublish") {
+    description = "Fails unless build/staging-deploy holds exactly the intended " +
+        "GAV with a release AAR containing all required JNI libraries."
+    // Capture plain values at configuration time; all I/O happens at execution.
+    val stagingDirProvider = layout.buildDirectory.dir("staging-deploy")
+    val expectedGroup = publishGroupId
+    val expectedArtifact = publishArtifactId
+    val expectedVersion = version.toString()
+    val requiredAbis = requiredJniAbis
+    doLast {
+        val stagingRoot = stagingDirProvider.get().asFile
+        val gav = "$expectedGroup:$expectedArtifact:$expectedVersion"
+        val gavDir = stagingRoot
+            .resolve(expectedGroup.replace('.', '/'))
+            .resolve(expectedArtifact)
+            .resolve(expectedVersion)
+        if (!gavDir.isDirectory) {
+            throw GradleException(
+                "Staged repository $stagingRoot has no artifacts for $gav " +
+                    "(expected $gavDir). Run " +
+                    ":sdk:publishReleasePublicationToStagingRepository with this exact " +
+                    "version first — do not deploy a staging dir left over from " +
+                    "another version."
+            )
+        }
+
+        // (1) No artifacts outside the intended GAV directory.
+        val artifactExtensions = setOf("aar", "jar", "pom", "module")
+        val strays = stagingRoot.walkTopDown()
+            .filter { it.isFile && it.extension in artifactExtensions }
+            .filterNot { it.parentFile == gavDir }
+            .toList()
+        if (strays.isNotEmpty()) {
+            throw GradleException(
+                "Staged repository $stagingRoot contains artifacts outside $gav " +
+                    "(jreleaser would upload them too): " +
+                    strays.joinToString { it.relativeTo(stagingRoot).path } +
+                    ". Re-stage from clean (the staging publish runs cleanStagingDeploy)."
+            )
+        }
+
+        // (2) Exactly one release AAR (sources/javadoc are jars, so any .aar is
+        // the main artifact), named for the intended artifactId + version.
+        val aars = gavDir.listFiles { f: java.io.File -> f.isFile && f.extension == "aar" }
+            .orEmpty()
+            .sortedBy { it.name }
+        if (aars.size != 1) {
+            throw GradleException(
+                "Expected exactly one release AAR staged for $gav in $gavDir, found " +
+                    "${aars.size}${if (aars.isEmpty()) "" else ": " + aars.joinToString { it.name }}. " +
+                    "Re-stage from clean."
+            )
+        }
+        val aar = aars.single()
+        val plainName = "$expectedArtifact-$expectedVersion.aar"
+        val timestampedSnapshotName = Regex(
+            Regex.escape("$expectedArtifact-" + expectedVersion.removeSuffix("-SNAPSHOT")) +
+                "-\\d{8}\\.\\d{6}-\\d+\\.aar"
+        )
+        val nameMatchesGav = aar.name == plainName ||
+            (expectedVersion.endsWith("-SNAPSHOT") && timestampedSnapshotName.matches(aar.name))
+        if (!nameMatchesGav) {
+            throw GradleException(
+                "Staged AAR ${aar.name} in $gavDir does not match the intended " +
+                    "coordinate $gav (expected $plainName" +
+                    (if (expectedVersion.endsWith("-SNAPSHOT")) " or a unique-snapshot timestamped variant" else "") +
+                    "). Re-stage from clean."
+            )
+        }
+
+        // (3) The staged AAR itself must carry the native library for every ABI.
+        ZipFile(aar).use { zip ->
+            val missing = requiredAbis.filter { abi ->
+                zip.getEntry("jni/$abi/libdash_sdk_jni.so") == null
+            }
+            if (missing.isNotEmpty()) {
+                throw GradleException(
+                    "Staged AAR ${aar.name} is missing jni/<abi>/libdash_sdk_jni.so for " +
+                        "ABI(s) ${missing.joinToString()} — it would die at runtime with " +
+                        "UnsatisfiedLinkError. Run ../build_android.sh, re-stage, then deploy."
+                )
+            }
+        }
+        logger.lifecycle(
+            "Verified staged AAR ${aar.name} for $gav: all required JNI ABIs present " +
+                "(${requiredAbis.joinToString()})."
+        )
+    }
+    // If a single invocation stages and deploys, verify AFTER staging has run.
+    mustRunAfter(tasks.withType<PublishToMavenRepository>())
+}
+
 // jreleaser's deploy/upload/release tasks push the already-staged artifacts, so
-// gate them on the strict remote check too — a staging dir populated out-of-band
-// (or by a future task rewiring) can't be uploaded without the native library.
+// gate them on both remote checks — the source-tree check (a staging dir
+// populated out-of-band can't be uploaded without the native library) and the
+// staged-AAR inspection above (what is actually uploaded is what is verified).
 tasks.matching { task ->
     task.name.startsWith("jreleaser") &&
         listOf("Deploy", "Upload", "Release").any { task.name.contains(it) }
-}.configureEach { dependsOn(verifyJniLibsForRemotePublish) }
+}.configureEach {
+    dependsOn(verifyJniLibsForRemotePublish)
+    dependsOn(verifyStagedAarForRemotePublish)
+}
 
 // Maven Central / Sonatype deployment via jreleaser, mirroring
 // dashj/core/build.gradle (https://github.com/dashpay/dashj/blob/master/core/build.gradle#L139).

--- a/packages/kotlin-sdk/sdk/build.gradle.kts
+++ b/packages/kotlin-sdk/sdk/build.gradle.kts
@@ -137,6 +137,19 @@ afterEvaluate {
                 url = uri(layout.buildDirectory.dir("staging-deploy"))
             }
         }
+
+        // The staging dir is reused across runs and maven-publish never removes
+        // other versions' directories — a release deploy after an earlier
+        // snapshot/release staging run would hand JReleaser stale coordinates.
+        // Wipe it before every staging publish so each deploy starts clean.
+        val cleanStagingDeploy = tasks.register<Delete>("cleanStagingDeploy") {
+            delete(layout.buildDirectory.dir("staging-deploy"))
+        }
+        tasks.withType<PublishToMavenRepository>().configureEach {
+            if (name.endsWith("ToStagingRepository")) {
+                dependsOn(cleanStagingDeploy)
+            }
+        }
         publications {
             create<MavenPublication>("release") {
                 from(components["release"])

--- a/packages/kotlin-sdk/sdk/build.gradle.kts
+++ b/packages/kotlin-sdk/sdk/build.gradle.kts
@@ -1,3 +1,6 @@
+import org.gradle.api.publish.maven.tasks.PublishToMavenLocal
+import org.gradle.api.publish.maven.tasks.PublishToMavenRepository
+
 plugins {
     alias(libs.plugins.android.library)
     alias(libs.plugins.kotlin.android)
@@ -6,6 +9,11 @@ plugins {
     `maven-publish`
 }
 
+// NOTE (Maven Central, future): the `org.dashfoundation` groupId can't be
+// published to Maven Central yet — that requires owning the matching domain,
+// and dashfoundation.org is held by a third party (HashEngineering, PR #4045).
+// This coordinate is for `publishToMavenLocal` / an internal repo for now; a
+// Maven Central move is a separate groupId/hosting decision.
 group = "org.dashfoundation"
 version = project.findProperty("sdkVersion")?.toString() ?: "0.1.0-SNAPSHOT"
 
@@ -69,7 +77,11 @@ ksp {
 }
 
 dependencies {
-    implementation(libs.kotlinx.coroutines.core)
+    // `api`, not `implementation`: the public SDK surface returns coroutines
+    // types (Room DAO `Flow<…>`, `PlatformWalletManager.pendingIdentityKeys:
+    // StateFlow<…>`, etc.), so a consumer of the published coordinate needs
+    // coroutines-core on its own compile classpath.
+    api(libs.kotlinx.coroutines.core)
     implementation(libs.kotlinx.coroutines.android)
     implementation(libs.kotlinx.serialization.json)
 
@@ -118,8 +130,56 @@ afterEvaluate {
                             url.set("https://github.com/dashpay/platform/blob/master/LICENSE")
                         }
                     }
+                    // scm + developers: required by Maven Central (and most
+                    // remote repos) for POM validation. Pointed at the GitHub
+                    // repo rather than a vanity domain (see the group-id note
+                    // above re: dashfoundation.org ownership).
+                    scm {
+                        url.set("https://github.com/dashpay/platform")
+                        connection.set("scm:git:git://github.com/dashpay/platform.git")
+                        developerConnection.set(
+                            "scm:git:ssh://git@github.com/dashpay/platform.git"
+                        )
+                    }
+                    developers {
+                        developer {
+                            id.set("dashpay")
+                            name.set("Dash Platform Contributors")
+                            url.set("https://github.com/dashpay/platform")
+                        }
+                    }
                 }
             }
         }
     }
 }
+
+// Never publish a coordinate whose AAR lacks the native JNI library
+// (libdash_sdk_jni.so). ../build_android.sh (cargo-ndk) produces it into
+// src/main/jniLibs/<abi>/; that directory is gitignored and absent in a clean
+// checkout, so without this guard a publish from a fresh tree yields an artifact
+// that installs cleanly but dies at runtime with UnsatisfiedLinkError
+// (NativeLoader.ensureLoaded → System.loadLibrary("dash_sdk_jni")). Run
+// ../build_android.sh first, or pass -PallowMissingJni to publish anyway (e.g. a
+// POM/metadata-only dry run).
+val requiredJniAbis = listOf("arm64-v8a", "x86_64") // build_android.sh ABI policy
+val verifyJniLibsPresent = tasks.register("verifyJniLibsPresent") {
+    doLast {
+        val missing = requiredJniAbis.filterNot { abi ->
+            file("src/main/jniLibs/$abi/libdash_sdk_jni.so").isFile
+        }
+        if (missing.isNotEmpty()) {
+            val message = "Native JNI library libdash_sdk_jni.so is missing for ABI(s) " +
+                "${missing.joinToString()} under src/main/jniLibs/ — run ./build_android.sh " +
+                "before publishing so the coordinate isn't broken at runtime."
+            if (project.hasProperty("allowMissingJni")) {
+                logger.warn("WARNING: $message (continuing anyway: -PallowMissingJni is set)")
+            } else {
+                throw GradleException("$message Pass -PallowMissingJni to override.")
+            }
+        }
+    }
+}
+
+tasks.withType<PublishToMavenRepository>().configureEach { dependsOn(verifyJniLibsPresent) }
+tasks.withType<PublishToMavenLocal>().configureEach { dependsOn(verifyJniLibsPresent) }

--- a/packages/kotlin-sdk/sdk/build.gradle.kts
+++ b/packages/kotlin-sdk/sdk/build.gradle.kts
@@ -58,6 +58,12 @@ android {
     publishing {
         singleVariant("release") {
             withSourcesJar()
+            // Maven Central's Publisher Portal rejects any non-POM component that
+            // lacks a javadoc jar, and the snapshot deployer sets
+            // applyMavenCentralRules(true) which enforces it before upload
+            // (dashpay/platform#4045). AGP emits a (Kotlin-appropriate) javadoc jar
+            // here — no Dokka dependency required.
+            withJavadocJar()
         }
     }
 
@@ -176,6 +182,19 @@ afterEvaluate {
     // (signing.keyId + signing.password + signing.secretKeyRingFile, or the in-memory
     // ORG_GRADLE_PROJECT_signingKey / signingPassword pair) when a remote publish runs.
     signing {
+        // Wire the documented in-memory-key path: the ORG_GRADLE_PROJECT_signingKey
+        // / signingPassword env vars land as the Gradle project properties
+        // `signingKey` / `signingPassword`, but the signing plugin does not consume
+        // them automatically — a CI release following that path would otherwise fail
+        // in signReleasePublication before staging anything (dashpay/platform#4045).
+        // Absent (local dev), this is skipped and, with required=false below, no key
+        // is needed. The legacy signing.keyId/password/secretKeyRingFile path is
+        // untouched and still handled by Gradle's standard signing properties.
+        val signingKey = project.findProperty("signingKey") as String?
+        val signingPassword = project.findProperty("signingPassword") as String?
+        if (!signingKey.isNullOrBlank()) {
+            useInMemoryPgpKeys(signingKey, signingPassword)
+        }
         setRequired(Callable {
             gradle.taskGraph.allTasks.any { it is PublishToMavenRepository }
         })
@@ -188,30 +207,68 @@ afterEvaluate {
 // src/main/jniLibs/<abi>/; that directory is gitignored and absent in a clean
 // checkout, so without this guard a publish from a fresh tree yields an artifact
 // that installs cleanly but dies at runtime with UnsatisfiedLinkError
-// (NativeLoader.ensureLoaded → System.loadLibrary("dash_sdk_jni")). Run
-// ../build_android.sh first, or pass -PallowMissingJni to publish anyway (e.g. a
-// POM/metadata-only dry run).
+// (NativeLoader.ensureLoaded → System.loadLibrary("dash_sdk_jni")).
 val requiredJniAbis = listOf("arm64-v8a", "x86_64") // build_android.sh ABI policy
-val verifyJniLibsPresent = tasks.register("verifyJniLibsPresent") {
+
+fun missingJniAbis(): List<String> = requiredJniAbis.filterNot { abi ->
+    file("src/main/jniLibs/$abi/libdash_sdk_jni.so").isFile
+}
+
+fun jniMissingMessage(missing: List<String>): String =
+    "Native JNI library libdash_sdk_jni.so is missing for ABI(s) " +
+        "${missing.joinToString()} under src/main/jniLibs/ — run ./build_android.sh " +
+        "before publishing so the coordinate isn't broken at runtime."
+
+// Remote / staging publish: ALWAYS hard-fail on a missing .so. `-PallowMissingJni`
+// is deliberately NOT honored here — a nativeless AAR must never reach a network
+// repo, nor jreleaser's build/staging-deploy dir (which `jreleaserDeploy` then
+// uploads to Maven Central). This closes the escape where `-PallowMissingJni`
+// previously downgraded the check to a warning for every publish task
+// (dashpay/platform#4045, finding 8b899bc2e5e8).
+val verifyJniLibsForRemotePublish = tasks.register("verifyJniLibsForRemotePublish") {
     doLast {
-        val missing = requiredJniAbis.filterNot { abi ->
-            file("src/main/jniLibs/$abi/libdash_sdk_jni.so").isFile
-        }
+        val missing = missingJniAbis()
         if (missing.isNotEmpty()) {
-            val message = "Native JNI library libdash_sdk_jni.so is missing for ABI(s) " +
-                "${missing.joinToString()} under src/main/jniLibs/ — run ./build_android.sh " +
-                "before publishing so the coordinate isn't broken at runtime."
+            throw GradleException(
+                jniMissingMessage(missing) +
+                    " -PallowMissingJni is a local-only escape and is NOT honored for " +
+                    "remote/staging deploys."
+            )
+        }
+    }
+}
+
+// Local publish (`publishToMavenLocal`): a dev may pass `-PallowMissingJni` for a
+// POM/metadata-only dry run into the local ~/.m2, which never leaves the machine.
+val verifyJniLibsForLocalPublish = tasks.register("verifyJniLibsForLocalPublish") {
+    doLast {
+        val missing = missingJniAbis()
+        if (missing.isNotEmpty()) {
+            val message = jniMissingMessage(missing)
             if (project.hasProperty("allowMissingJni")) {
-                logger.warn("WARNING: $message (continuing anyway: -PallowMissingJni is set)")
+                logger.warn(
+                    "WARNING: $message (continuing: -PallowMissingJni is set — local publish only.)"
+                )
             } else {
-                throw GradleException("$message Pass -PallowMissingJni to override.")
+                throw GradleException("$message Pass -PallowMissingJni for a local-only dry run.")
             }
         }
     }
 }
 
-tasks.withType<PublishToMavenRepository>().configureEach { dependsOn(verifyJniLibsPresent) }
-tasks.withType<PublishToMavenLocal>().configureEach { dependsOn(verifyJniLibsPresent) }
+tasks.withType<PublishToMavenRepository>().configureEach {
+    dependsOn(verifyJniLibsForRemotePublish)
+}
+tasks.withType<PublishToMavenLocal>().configureEach {
+    dependsOn(verifyJniLibsForLocalPublish)
+}
+// jreleaser's deploy/upload/release tasks push the already-staged artifacts, so
+// gate them on the strict remote check too — a staging dir populated out-of-band
+// (or by a future task rewiring) can't be uploaded without the native library.
+tasks.matching { task ->
+    task.name.startsWith("jreleaser") &&
+        listOf("Deploy", "Upload", "Release").any { task.name.contains(it) }
+}.configureEach { dependsOn(verifyJniLibsForRemotePublish) }
 
 // Maven Central / Sonatype deployment via jreleaser, mirroring
 // dashj/core/build.gradle (https://github.com/dashpay/dashj/blob/master/core/build.gradle#L139).

--- a/packages/kotlin-sdk/sdk/build.gradle.kts
+++ b/packages/kotlin-sdk/sdk/build.gradle.kts
@@ -13,7 +13,7 @@ plugins {
     alias(libs.plugins.jreleaser)
 }
 
-// Published Maven coordinate group. Per HashEngineering's call on PR #4045:
+// Published Maven coordinate group. Per HashEngineering's call:
 // publish under the existing `org.dashj` group — Dash already owns dashj.org and
 // ships its legacy Core/Platform SDKs there, so this needs no separate domain
 // verification for Maven Central (`org.dashfoundation` would have, since
@@ -60,9 +60,9 @@ android {
             withSourcesJar()
             // Maven Central's Publisher Portal rejects any non-POM component that
             // lacks a javadoc jar, and the snapshot deployer sets
-            // applyMavenCentralRules(true) which enforces it before upload
-            // (dashpay/platform#4045). AGP emits a (Kotlin-appropriate) javadoc jar
-            // here — no Dokka dependency required.
+            // applyMavenCentralRules(true) which enforces it before upload.
+            // AGP emits a (Kotlin-appropriate) javadoc jar here — no Dokka
+            // dependency required.
             withJavadocJar()
         }
     }
@@ -165,7 +165,7 @@ afterEvaluate {
                     licenses {
                         license {
                             name.set("MIT License")
-                            url.set("https://github.com/dashpay/platform/blob/master/LICENSE")
+                            url.set("https://github.com/dashpay/platform/blob/master/LICENSE.md")
                         }
                     }
                     // scm + developers: required by Maven Central (and most
@@ -199,7 +199,7 @@ afterEvaluate {
         // / signingPassword env vars land as the Gradle project properties
         // `signingKey` / `signingPassword`, but the signing plugin does not consume
         // them automatically — a CI release following that path would otherwise fail
-        // in signReleasePublication before staging anything (dashpay/platform#4045).
+        // in signReleasePublication before staging anything.
         // Absent (local dev), this is skipped and, with required=false below, no key
         // is needed. The legacy signing.keyId/password/secretKeyRingFile path is
         // untouched and still handled by Gradle's standard signing properties.
@@ -236,8 +236,7 @@ fun jniMissingMessage(missing: List<String>): String =
 // is deliberately NOT honored here — a nativeless AAR must never reach a network
 // repo, nor jreleaser's build/staging-deploy dir (which `jreleaserDeploy` then
 // uploads to Maven Central). This closes the escape where `-PallowMissingJni`
-// previously downgraded the check to a warning for every publish task
-// (dashpay/platform#4045, finding 8b899bc2e5e8).
+// previously downgraded the check to a warning for every publish task.
 val verifyJniLibsForRemotePublish = tasks.register("verifyJniLibsForRemotePublish") {
     doLast {
         val missing = missingJniAbis()

--- a/packages/kotlin-sdk/sdk/build.gradle.kts
+++ b/packages/kotlin-sdk/sdk/build.gradle.kts
@@ -3,7 +3,11 @@ plugins {
     alias(libs.plugins.kotlin.android)
     alias(libs.plugins.kotlin.serialization)
     alias(libs.plugins.ksp)
+    `maven-publish`
 }
+
+group = "org.dashfoundation"
+version = project.findProperty("sdkVersion")?.toString() ?: "0.1.0-SNAPSHOT"
 
 android {
     namespace = "org.dashfoundation.dashsdk"
@@ -35,6 +39,12 @@ android {
     // libdash_sdk_jni.so is produced by ../build_android.sh (cargo-ndk) into
     // src/main/jniLibs/<abi>/ — AGP packages it from there. NDK r28 emits
     // 16 KB-aligned ELF segments by default (Android 15+ requirement).
+    publishing {
+        singleVariant("release") {
+            withSourcesJar()
+        }
+    }
+
     packaging {
         jniLibs {
             useLegacyPackaging = false
@@ -82,4 +92,34 @@ dependencies {
     androidTestImplementation(libs.androidx.test.runner)
     androidTestImplementation(libs.espresso.core)
     androidTestImplementation(libs.room.testing)
+}
+
+// Publishes the release AAR (incl. libdash_sdk_jni.so if ../build_android.sh ran first) with a
+// POM carrying the Room/DataStore/Biometric api dependencies.
+// Local: ./gradlew :sdk:publishToMavenLocal   Coordinates: org.dashfoundation:dash-sdk-android:<version>
+// Override the version with -PsdkVersion=x.y.z (defaults to 0.1.0-SNAPSHOT).
+afterEvaluate {
+    publishing {
+        publications {
+            create<MavenPublication>("release") {
+                from(components["release"])
+                groupId = "org.dashfoundation"
+                artifactId = "dash-sdk-android"
+                pom {
+                    name.set("Dash Platform Kotlin SDK")
+                    description.set(
+                        "Kotlin SDK for Dash Core (L1 SPV) and Dash Platform " +
+                            "(identities, DPNS, DashPay, shielded balances)"
+                    )
+                    url.set("https://github.com/dashpay/platform")
+                    licenses {
+                        license {
+                            name.set("MIT License")
+                            url.set("https://github.com/dashpay/platform/blob/master/LICENSE")
+                        }
+                    }
+                }
+            }
+        }
+    }
 }

--- a/packages/kotlin-sdk/sdk/src/main/kotlin/org/dashfoundation/dashsdk/Sdk.kt
+++ b/packages/kotlin-sdk/sdk/src/main/kotlin/org/dashfoundation/dashsdk/Sdk.kt
@@ -174,7 +174,7 @@ class Sdk private constructor(
     // it out of the public ABI means its generated `serializer()` isn't public
     // API, so consumers of the published coordinate don't need
     // kotlinx-serialization on their compile classpath and it can stay
-    // `implementation` (dashpay/platform#4045, finding 96b7b2a236ff).
+    // `implementation`.
     @Serializable
     internal data class MasternodeEntry(
         val address: String,

--- a/packages/kotlin-sdk/sdk/src/main/kotlin/org/dashfoundation/dashsdk/Sdk.kt
+++ b/packages/kotlin-sdk/sdk/src/main/kotlin/org/dashfoundation/dashsdk/Sdk.kt
@@ -167,8 +167,16 @@ class Sdk private constructor(
      * `discoverActiveMasternodes`) — a single strict field would fail the
      * whole devnet discovery.
      */
+    // `internal`, not public: this is a wire-format DTO for the `/masternodes`
+    // response, touched only by the `private` [MasternodesEnvelope] and
+    // `internal` [parseActiveMasternodes] — never returned by a public function
+    // (public discovery returns the non-@Serializable [ActiveMasternode]). Keeping
+    // it out of the public ABI means its generated `serializer()` isn't public
+    // API, so consumers of the published coordinate don't need
+    // kotlinx-serialization on their compile classpath and it can stay
+    // `implementation` (dashpay/platform#4045, finding 96b7b2a236ff).
     @Serializable
-    data class MasternodeEntry(
+    internal data class MasternodeEntry(
         val address: String,
         val status: String = "",
         val platformHTTPPort: Int? = null,


### PR DESCRIPTION
Adds `maven-publish` for the kotlin-sdk release AAR under the `org.dashj` group, with a JReleaser Maven Central/Sonatype deploy pipeline, a javadoc jar for Central, a JNI-presence guard that hard-fails remote publishes (and wipes `staging-deploy` before every staging publish), and a `PUBLISHING.md` runbook.

Re-opens #4045 which was auto-closed when the #3999 base branch was deleted; rebased onto `v4.1-dev`. All six original commits replayed cleanly — no hunks needed to be dropped as already-absorbed.

Verified: `:sdk:assembleRelease` builds the AAR, JReleaser/publish task graph configures, and the 175 sdk unit tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Android SDK can now be published to Maven Central and Sonatype snapshots.
  - Published artifacts now include source and Javadoc documentation.
  - Expanded release workflow support via automated deployment.

- **Bug Fixes**
  - Added checks to block publishing when required native JNI libraries are missing from the staged artifacts.

- **Documentation**
  - Added a publishing guide covering prerequisites, verification, signing, and how to consume the SDK from Maven Central.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

### Provenance notes (moved out of code comments per review)

| Decision in code | Origin |
|---|---|
| Publish under the existing `org.dashj` group (`build.gradle.kts`, coordinate block) | HashEngineering's namespace call on PR #4045 |
| Javadoc jar required — Central Portal rejects non-POM components without one (`applyMavenCentralRules(true)`) | dashpay/platform#4045 |
| In-memory signing-key wiring so CI release via `ORG_GRADLE_PROJECT_signingKey` doesn't fail in `signReleasePublication` | dashpay/platform#4045 |
| `-PallowMissingJni` escape closed for remote/staging publishes | dashpay/platform#4045, finding 8b899bc2e5e8 |
| `MasternodeEntry` kept `internal` so its generated `serializer()` stays out of the public ABI (`Sdk.kt`) | dashpay/platform#4045, finding 96b7b2a236ff |

### Review-response commits
- `d517ba20bc` — POM license URL → `LICENSE.md`; tracking refs moved from comments to this table
- `9190ba3059` — new `verifyStagedAarForRemotePublish`: before any jreleaser deploy, the staged repo must contain exactly the intended GAV, no stray artifacts, exactly one correctly-named release AAR, and that AAR must carry `jni/arm64-v8a/libdash_sdk_jni.so` + `jni/x86_64/libdash_sdk_jni.so`
- `33b2a57188` — round-2 hardening: empty/directory-shaped zip entries rejected (0-byte `.so` from an interrupted build no longer passes), source-tree guard also requires content, guards made configuration-cache safe
