### PR TITLE
fix: shield asset-lock funding from all funds accounts incl. CoinJoin (#4073)

### DIFF
--- a/packages/kotlin-sdk/sdk/src/main/kotlin/org/dashfoundation/dashsdk/errors/DashSdkError.kt
+++ b/packages/kotlin-sdk/sdk/src/main/kotlin/org/dashfoundation/dashsdk/errors/DashSdkError.kt
@@ -114,20 +114,6 @@ sealed class DashSdkError(
             PlatformWallet(message, cause)
 
         /**
-         * `ErrorAssetLockCrossDomainConsentRequired` (native code 30). The default
-         * single-privacy-domain funding rule (dashpay/platform#4184) refused to
-         * co-spend across privacy domains: the transparent domain (BIP44 + BIP32)
-         * alone cannot cover the asset lock, but the wallet-wide union — adding
-         * CoinJoin and/or DashPay-receiving funds — can. Combining them in one L1
-         * transaction would irreversibly link those domains on-chain, so it is
-         * gated behind explicit user consent. Prompt the user, then re-issue the
-         * funding request with cross-domain consent enabled. The transparent /
-         * union / required duff amounts travel in [message].
-         */
-        class AssetLockCrossDomainConsentRequired(message: String, cause: Throwable? = null) :
-            PlatformWallet(message, cause)
-
-        /**
          * `ErrorShieldedNoRecordedAnchor` (native code 19). A shielded spend
          * could not be built against a Platform-recorded anchor because the
          * local commitment tree is mid-block. Nothing was broadcast and the
@@ -375,7 +361,6 @@ sealed class DashSdkError(
             24 -> PlatformWallet.AssetLockAlreadyConsumed(message, cause) // ErrorAssetLockAlreadyConsumed
             25 -> PlatformWallet.AssetLockFundingMismatch(message, cause) // ErrorAssetLockFundingMismatch
             29 -> PlatformWallet.AssetLockInsufficientFunds(message, cause) // ErrorAssetLockInsufficientFunds
-            30 -> PlatformWallet.AssetLockCrossDomainConsentRequired(message, cause) // ErrorAssetLockCrossDomainConsentRequired
             // ErrorSigningKeyUnavailable — the STRUCTURED signer
             // discriminator (dashpay/platform#4060 finding 7): the typed
             // completion code rides the whole Rust round-trip, no message

--- a/packages/kotlin-sdk/sdk/src/main/kotlin/org/dashfoundation/dashsdk/errors/DashSdkError.kt
+++ b/packages/kotlin-sdk/sdk/src/main/kotlin/org/dashfoundation/dashsdk/errors/DashSdkError.kt
@@ -99,7 +99,7 @@ sealed class DashSdkError(
             PlatformWallet(message, cause)
 
         /**
-         * `ErrorAssetLockInsufficientFunds` (native code 26). Asset-lock coin
+         * `ErrorAssetLockInsufficientFunds` (native code 29). Asset-lock coin
          * selection came up short over the *permitted* funding set — the requested
          * amount plus the L1 fee exceeds the spendable funds the selector was
          * allowed to draw on. Raised strictly pre-broadcast (while BUILDING the
@@ -114,7 +114,7 @@ sealed class DashSdkError(
             PlatformWallet(message, cause)
 
         /**
-         * `ErrorAssetLockCrossDomainConsentRequired` (native code 27). The default
+         * `ErrorAssetLockCrossDomainConsentRequired` (native code 30). The default
          * single-privacy-domain funding rule (dashpay/platform#4184) refused to
          * co-spend across privacy domains: the transparent domain (BIP44 + BIP32)
          * alone cannot cover the asset lock, but the wallet-wide union — adding
@@ -374,8 +374,8 @@ sealed class DashSdkError(
             23 -> PlatformWallet.AssetLockNotTracked(message, cause) // ErrorAssetLockNotTracked
             24 -> PlatformWallet.AssetLockAlreadyConsumed(message, cause) // ErrorAssetLockAlreadyConsumed
             25 -> PlatformWallet.AssetLockFundingMismatch(message, cause) // ErrorAssetLockFundingMismatch
-            26 -> PlatformWallet.AssetLockInsufficientFunds(message, cause) // ErrorAssetLockInsufficientFunds
-            27 -> PlatformWallet.AssetLockCrossDomainConsentRequired(message, cause) // ErrorAssetLockCrossDomainConsentRequired
+            29 -> PlatformWallet.AssetLockInsufficientFunds(message, cause) // ErrorAssetLockInsufficientFunds
+            30 -> PlatformWallet.AssetLockCrossDomainConsentRequired(message, cause) // ErrorAssetLockCrossDomainConsentRequired
             // ErrorSigningKeyUnavailable — the STRUCTURED signer
             // discriminator (dashpay/platform#4060 finding 7): the typed
             // completion code rides the whole Rust round-trip, no message

--- a/packages/kotlin-sdk/sdk/src/main/kotlin/org/dashfoundation/dashsdk/errors/DashSdkError.kt
+++ b/packages/kotlin-sdk/sdk/src/main/kotlin/org/dashfoundation/dashsdk/errors/DashSdkError.kt
@@ -99,6 +99,35 @@ sealed class DashSdkError(
             PlatformWallet(message, cause)
 
         /**
+         * `ErrorAssetLockInsufficientFunds` (native code 26). Asset-lock coin
+         * selection came up short over the *permitted* funding set — the requested
+         * amount plus the L1 fee exceeds the spendable funds the selector was
+         * allowed to draw on. Raised strictly pre-broadcast (while BUILDING the
+         * asset-lock transaction), so nothing reached the wire. The structured
+         * `available`/`required` duff amounts travel in [message]
+         * (`"asset lock coin selection is short: available N duffs, required M
+         * duffs"`); the typed code lets callers branch without substring-matching.
+         * Distinct from [CoreInsufficientFunds] (code 22), which is the atomic
+         * Core-send selector rather than the asset-lock builder.
+         */
+        class AssetLockInsufficientFunds(message: String, cause: Throwable? = null) :
+            PlatformWallet(message, cause)
+
+        /**
+         * `ErrorAssetLockCrossDomainConsentRequired` (native code 27). The default
+         * single-privacy-domain funding rule (dashpay/platform#4184) refused to
+         * co-spend across privacy domains: the transparent domain (BIP44 + BIP32)
+         * alone cannot cover the asset lock, but the wallet-wide union — adding
+         * CoinJoin and/or DashPay-receiving funds — can. Combining them in one L1
+         * transaction would irreversibly link those domains on-chain, so it is
+         * gated behind explicit user consent. Prompt the user, then re-issue the
+         * funding request with cross-domain consent enabled. The transparent /
+         * union / required duff amounts travel in [message].
+         */
+        class AssetLockCrossDomainConsentRequired(message: String, cause: Throwable? = null) :
+            PlatformWallet(message, cause)
+
+        /**
          * `ErrorShieldedNoRecordedAnchor` (native code 19). A shielded spend
          * could not be built against a Platform-recorded anchor because the
          * local commitment tree is mid-block. Nothing was broadcast and the
@@ -345,11 +374,12 @@ sealed class DashSdkError(
             23 -> PlatformWallet.AssetLockNotTracked(message, cause) // ErrorAssetLockNotTracked
             24 -> PlatformWallet.AssetLockAlreadyConsumed(message, cause) // ErrorAssetLockAlreadyConsumed
             25 -> PlatformWallet.AssetLockFundingMismatch(message, cause) // ErrorAssetLockFundingMismatch
+            26 -> PlatformWallet.AssetLockInsufficientFunds(message, cause) // ErrorAssetLockInsufficientFunds
+            27 -> PlatformWallet.AssetLockCrossDomainConsentRequired(message, cause) // ErrorAssetLockCrossDomainConsentRequired
             // ErrorSigningKeyUnavailable — the STRUCTURED signer
             // discriminator (dashpay/platform#4060 finding 7): the typed
             // completion code rides the whole Rust round-trip, no message
-            // sniffing involved. (Codes 26-30 are reserved by sibling PRs
-            // #4185 / #4184 — see PlatformWalletFFIResultCode.)
+            // sniffing involved.
             31 -> PlatformWallet.SigningKeyUnavailable(message, cause)
             else ->
                 // @Deprecated fallback — see the code-6 arm; code 31 is the

--- a/packages/kotlin-sdk/sdk/src/main/kotlin/org/dashfoundation/dashsdk/ffi/FundingNative.kt
+++ b/packages/kotlin-sdk/sdk/src/main/kotlin/org/dashfoundation/dashsdk/ffi/FundingNative.kt
@@ -49,8 +49,13 @@ internal object FundingNative {
      * `platform_wallet_manager_shielded_fund_from_asset_lock`).
      * [recipientRaw43] is the 43-byte raw Orchard address; [surplusOutput]
      * is the optional 21-byte remainder platform address (null = none);
-     * [coreSignerHandle] is the manager's `MnemonicResolverHandle`. Blocks
-     * for the ~30s Halo 2 proof; the note arrives on the next shielded sync.
+     * [coreSignerHandle] is the manager's `MnemonicResolverHandle`.
+     * [allowCrossDomain] is the cross-privacy-domain co-spend consent
+     * (dashpay/platform#4184): `false` (default) confines the L1 asset-lock
+     * funding to the transparent BIP44/BIP32 domain; pass `true` only after the
+     * user consents to also drawing CoinJoin / DashPay-receiving funds. A refusal
+     * throws with [org.dashfoundation.dashsdk.errors.DashSdkError.PlatformWallet.AssetLockCrossDomainConsentRequired].
+     * Blocks for the ~30s Halo 2 proof; the note arrives on the next shielded sync.
      */
     external fun shieldedFundFromAssetLock(
         managerHandle: Long,
@@ -60,6 +65,7 @@ internal object FundingNative {
         recipientRaw43: ByteArray,
         surplusOutput: ByteArray?,
         coreSignerHandle: Long,
+        allowCrossDomain: Boolean,
     )
 
     /**

--- a/packages/kotlin-sdk/sdk/src/main/kotlin/org/dashfoundation/dashsdk/ffi/FundingNative.kt
+++ b/packages/kotlin-sdk/sdk/src/main/kotlin/org/dashfoundation/dashsdk/ffi/FundingNative.kt
@@ -50,11 +50,13 @@ internal object FundingNative {
      * [recipientRaw43] is the 43-byte raw Orchard address; [surplusOutput]
      * is the optional 21-byte remainder platform address (null = none);
      * [coreSignerHandle] is the manager's `MnemonicResolverHandle`.
-     * [allowCrossDomain] is the cross-privacy-domain co-spend consent
-     * (dashpay/platform#4184): `false` (default) confines the L1 asset-lock
-     * funding to the transparent BIP44/BIP32 domain; pass `true` only after the
-     * user consents to also drawing CoinJoin / DashPay-receiving funds. A refusal
-     * throws with [org.dashfoundation.dashsdk.errors.DashSdkError.PlatformWallet.AssetLockCrossDomainConsentRequired].
+     * [fundingPath] is an optional UTF-8 BIP32 derivation-path string
+     * (dashpay/platform#4184) naming the single funds account whose UTXOs fund
+     * the lock: null (the default) funds from the unmixed BIP44 account at
+     * [fundingAccountIndex]; an explicit account-level path (e.g. the DIP-9
+     * CoinJoin account path) funds strictly from that one account, with no union
+     * across accounts and no consent gate. A shortfall throws
+     * [org.dashfoundation.dashsdk.errors.DashSdkError.PlatformWallet.AssetLockInsufficientFunds].
      * Blocks for the ~30s Halo 2 proof; the note arrives on the next shielded sync.
      */
     external fun shieldedFundFromAssetLock(
@@ -65,7 +67,7 @@ internal object FundingNative {
         recipientRaw43: ByteArray,
         surplusOutput: ByteArray?,
         coreSignerHandle: Long,
-        allowCrossDomain: Boolean,
+        fundingPath: String?,
     )
 
     /**

--- a/packages/kotlin-sdk/sdk/src/main/kotlin/org/dashfoundation/dashsdk/wallet/PlatformWalletManager.kt
+++ b/packages/kotlin-sdk/sdk/src/main/kotlin/org/dashfoundation/dashsdk/wallet/PlatformWalletManager.kt
@@ -1400,6 +1400,14 @@ class PlatformWalletManager(
      * @param fundingAccountIndex the Core BIP44 account funding the lock.
      * @param amountDuffs the L1 lock amount in duffs.
      * @param surplusOutput optional 21-byte remainder platform address.
+     * @param allowCrossDomain cross-privacy-domain co-spend consent
+     *   (dashpay/platform#4184). Defaults to `false`, which confines the L1
+     *   asset-lock funding to the transparent BIP44/BIP32 domain. Pass `true`
+     *   ONLY after the user has explicitly consented to also drawing CoinJoin /
+     *   DashPay-receiving funds into the lock (an irreversible on-chain linkage).
+     *   When `false` and only the wider union could cover the amount, this throws
+     *   [org.dashfoundation.dashsdk.errors.DashSdkError.PlatformWallet.AssetLockCrossDomainConsentRequired];
+     *   the caller should prompt for consent and retry with `true`.
      */
     suspend fun shieldedFundFromAssetLock(
         walletId: ByteArray,
@@ -1407,6 +1415,7 @@ class PlatformWalletManager(
         amountDuffs: Long,
         fundingAccountIndex: Int = 0,
         surplusOutput: ByteArray? = null,
+        allowCrossDomain: Boolean = false,
     ): Unit = teardownGate.op {
         require(amountDuffs > 0) { "amountDuffs must be positive, got $amountDuffs" }
         require(fundingAccountIndex >= 0) {
@@ -1421,6 +1430,7 @@ class PlatformWalletManager(
                 recipientRaw43,
                 surplusOutput,
                 mnemonicResolverHandle,
+                allowCrossDomain,
             )
         }
     }

--- a/packages/kotlin-sdk/sdk/src/main/kotlin/org/dashfoundation/dashsdk/wallet/PlatformWalletManager.kt
+++ b/packages/kotlin-sdk/sdk/src/main/kotlin/org/dashfoundation/dashsdk/wallet/PlatformWalletManager.kt
@@ -1397,7 +1397,11 @@ class PlatformWalletManager(
      * @param walletId the 32-byte wallet id.
      * @param recipientRaw43 the 43-byte raw Orchard payment address
      *   (11-byte diversifier + 32-byte pk_d).
-     * @param fundingAccountIndex the Core BIP44 account funding the lock.
+     * @param fundingAccountIndex the Core BIP44 account that always sinks the
+     *   asset lock's transparent CHANGE, and — when [fundingPath] is `null` —
+     *   is also the account whose UTXOs fund the lock. With an explicit
+     *   [fundingPath] the inputs come exclusively from the account that path
+     *   names and this index remains only the (still required) change sink.
      * @param amountDuffs the L1 lock amount in duffs.
      * @param surplusOutput optional 21-byte remainder platform address.
      * @param fundingPath optional UTF-8 BIP32 derivation-path string

--- a/packages/kotlin-sdk/sdk/src/main/kotlin/org/dashfoundation/dashsdk/wallet/PlatformWalletManager.kt
+++ b/packages/kotlin-sdk/sdk/src/main/kotlin/org/dashfoundation/dashsdk/wallet/PlatformWalletManager.kt
@@ -1400,14 +1400,15 @@ class PlatformWalletManager(
      * @param fundingAccountIndex the Core BIP44 account funding the lock.
      * @param amountDuffs the L1 lock amount in duffs.
      * @param surplusOutput optional 21-byte remainder platform address.
-     * @param allowCrossDomain cross-privacy-domain co-spend consent
-     *   (dashpay/platform#4184). Defaults to `false`, which confines the L1
-     *   asset-lock funding to the transparent BIP44/BIP32 domain. Pass `true`
-     *   ONLY after the user has explicitly consented to also drawing CoinJoin /
-     *   DashPay-receiving funds into the lock (an irreversible on-chain linkage).
-     *   When `false` and only the wider union could cover the amount, this throws
-     *   [org.dashfoundation.dashsdk.errors.DashSdkError.PlatformWallet.AssetLockCrossDomainConsentRequired];
-     *   the caller should prompt for consent and retry with `true`.
+     * @param fundingPath optional UTF-8 BIP32 derivation-path string
+     *   (dashpay/platform#4184) naming the single funds account whose UTXOs fund
+     *   the lock. Defaults to `null`, which funds from the unmixed BIP44 account
+     *   at [fundingAccountIndex]. Pass an explicit account-level path (e.g. the
+     *   DIP-9 CoinJoin account path) to fund strictly from that one account — to
+     *   shield previously-mixed CoinJoin coins, for instance. There is no union
+     *   across accounts and no consent gate: exactly one funding source
+     *   participates, and if it cannot cover the lock this throws
+     *   [org.dashfoundation.dashsdk.errors.DashSdkError.PlatformWallet.AssetLockInsufficientFunds].
      */
     suspend fun shieldedFundFromAssetLock(
         walletId: ByteArray,
@@ -1415,7 +1416,7 @@ class PlatformWalletManager(
         amountDuffs: Long,
         fundingAccountIndex: Int = 0,
         surplusOutput: ByteArray? = null,
-        allowCrossDomain: Boolean = false,
+        fundingPath: String? = null,
     ): Unit = teardownGate.op {
         require(amountDuffs > 0) { "amountDuffs must be positive, got $amountDuffs" }
         require(fundingAccountIndex >= 0) {
@@ -1430,7 +1431,7 @@ class PlatformWalletManager(
                 recipientRaw43,
                 surplusOutput,
                 mnemonicResolverHandle,
-                allowCrossDomain,
+                fundingPath,
             )
         }
     }

--- a/packages/kotlin-sdk/sdk/src/test/kotlin/org/dashfoundation/dashsdk/errors/DashSdkErrorTest.kt
+++ b/packages/kotlin-sdk/sdk/src/test/kotlin/org/dashfoundation/dashsdk/errors/DashSdkErrorTest.kt
@@ -104,10 +104,9 @@ class DashSdkErrorTest {
             23 to DashSdkError.PlatformWallet.AssetLockNotTracked::class,
             24 to DashSdkError.PlatformWallet.AssetLockAlreadyConsumed::class,
             25 to DashSdkError.PlatformWallet.AssetLockFundingMismatch::class,
-            // dashpay/platform#4073 request 3 + #4184: the asset-lock shortfall and
-            // the cross-domain-consent refusal get dedicated types, not Generic.
+            // dashpay/platform#4073 request 3 + #4184: the asset-lock shortfall
+            // gets a dedicated type, not Generic.
             29 to DashSdkError.PlatformWallet.AssetLockInsufficientFunds::class,
-            30 to DashSdkError.PlatformWallet.AssetLockCrossDomainConsentRequired::class,
         )
         recoveryCodes.forEach { (code, expected) ->
             val mapped = DashSdkError.fromNative(DashSDKException(offset + code, "recovery"))

--- a/packages/kotlin-sdk/sdk/src/test/kotlin/org/dashfoundation/dashsdk/errors/DashSdkErrorTest.kt
+++ b/packages/kotlin-sdk/sdk/src/test/kotlin/org/dashfoundation/dashsdk/errors/DashSdkErrorTest.kt
@@ -106,8 +106,8 @@ class DashSdkErrorTest {
             25 to DashSdkError.PlatformWallet.AssetLockFundingMismatch::class,
             // dashpay/platform#4073 request 3 + #4184: the asset-lock shortfall and
             // the cross-domain-consent refusal get dedicated types, not Generic.
-            26 to DashSdkError.PlatformWallet.AssetLockInsufficientFunds::class,
-            27 to DashSdkError.PlatformWallet.AssetLockCrossDomainConsentRequired::class,
+            29 to DashSdkError.PlatformWallet.AssetLockInsufficientFunds::class,
+            30 to DashSdkError.PlatformWallet.AssetLockCrossDomainConsentRequired::class,
         )
         recoveryCodes.forEach { (code, expected) ->
             val mapped = DashSdkError.fromNative(DashSDKException(offset + code, "recovery"))

--- a/packages/kotlin-sdk/sdk/src/test/kotlin/org/dashfoundation/dashsdk/errors/DashSdkErrorTest.kt
+++ b/packages/kotlin-sdk/sdk/src/test/kotlin/org/dashfoundation/dashsdk/errors/DashSdkErrorTest.kt
@@ -104,6 +104,10 @@ class DashSdkErrorTest {
             23 to DashSdkError.PlatformWallet.AssetLockNotTracked::class,
             24 to DashSdkError.PlatformWallet.AssetLockAlreadyConsumed::class,
             25 to DashSdkError.PlatformWallet.AssetLockFundingMismatch::class,
+            // dashpay/platform#4073 request 3 + #4184: the asset-lock shortfall and
+            // the cross-domain-consent refusal get dedicated types, not Generic.
+            26 to DashSdkError.PlatformWallet.AssetLockInsufficientFunds::class,
+            27 to DashSdkError.PlatformWallet.AssetLockCrossDomainConsentRequired::class,
         )
         recoveryCodes.forEach { (code, expected) ->
             val mapped = DashSdkError.fromNative(DashSDKException(offset + code, "recovery"))

--- a/packages/rs-platform-wallet-ffi/README.md
+++ b/packages/rs-platform-wallet-ffi/README.md
@@ -209,12 +209,12 @@ signature or the numeric value of a result code are **breaking** for C/Swift/JNI
 consumers and must be called out here.
 
 - **C-ABI break:** `platform_wallet_manager_shielded_fund_from_asset_lock`
-  gained a trailing `bool allow_cross_domain` parameter (cross-privacy-domain
-  co-spend consent). Callers linking the old symbol must be recompiled against
-  the regenerated header; passing `false` reproduces the previous
-  single-privacy-domain behaviour. Adds result codes
-  `ERROR_ASSET_LOCK_INSUFFICIENT_FUNDS = 29` and
-  `ERROR_ASSET_LOCK_CROSS_DOMAIN_CONSENT_REQUIRED = 30`.
+  gained a trailing `funding_path_ptr: *const u8, funding_path_len: usize`
+  parameter — a UTF-8 BIP32 derivation path selecting the single source
+  account (a null pointer / zero length = the unmixed BIP44 account). Callers
+  linking the old symbol must be recompiled against the regenerated header;
+  a null path reproduces the previous single-account behaviour. Adds result
+  code `ERROR_ASSET_LOCK_INSUFFICIENT_FUNDS = 29`.
 
 ## License
 

--- a/packages/rs-platform-wallet-ffi/README.md
+++ b/packages/rs-platform-wallet-ffi/README.md
@@ -202,6 +202,20 @@ Strings and arrays returned by the library must be freed using the provided free
 - `platform_wallet_bytes_free()`
 - `platform_wallet_identifier_array_free()`
 
+## ABI stability / Release notes
+
+This crate exposes a C ABI. Changes that alter an exported function's
+signature or the numeric value of a result code are **breaking** for C/Swift/JNI
+consumers and must be called out here.
+
+- **C-ABI break:** `platform_wallet_manager_shielded_fund_from_asset_lock`
+  gained a trailing `bool allow_cross_domain` parameter (cross-privacy-domain
+  co-spend consent). Callers linking the old symbol must be recompiled against
+  the regenerated header; passing `false` reproduces the previous
+  single-privacy-domain behaviour. Adds result codes
+  `ERROR_ASSET_LOCK_INSUFFICIENT_FUNDS = 29` and
+  `ERROR_ASSET_LOCK_CROSS_DOMAIN_CONSENT_REQUIRED = 30`.
+
 ## License
 
 MIT

--- a/packages/rs-platform-wallet-ffi/README.md
+++ b/packages/rs-platform-wallet-ffi/README.md
@@ -213,7 +213,7 @@ consumers and must be called out here.
   parameter — a UTF-8 BIP32 derivation path selecting the single source
   account (a null pointer / zero length = the unmixed BIP44 account). Callers
   linking the old symbol must be recompiled against the regenerated header;
-  a null path reproduces the previous single-account behaviour. Adds result
+  a null path reproduces the previous single-account behavior. Adds result
   code `ERROR_ASSET_LOCK_INSUFFICIENT_FUNDS = 29`.
 
 ## License

--- a/packages/rs-platform-wallet-ffi/src/asset_lock/build.rs
+++ b/packages/rs-platform-wallet-ffi/src/asset_lock/build.rs
@@ -76,6 +76,8 @@ pub unsafe extern "C" fn asset_lock_manager_build_transaction(
             funding,
             identity_index,
             &signer,
+            // Non-shielded funding always uses the single BIP44 account.
+            None,
         ))
     });
     let result = unwrap_option_or_return!(option);
@@ -149,6 +151,8 @@ pub unsafe extern "C" fn asset_lock_manager_create_funded_proof(
             funding,
             identity_index,
             &signer,
+            // Non-shielded funding always uses the single BIP44 account.
+            None,
         ))
     });
     let result = unwrap_option_or_return!(option);

--- a/packages/rs-platform-wallet-ffi/src/error.rs
+++ b/packages/rs-platform-wallet-ffi/src/error.rs
@@ -812,7 +812,7 @@ mod tests {
     }
 
     /// The asset-lock coin-selection shortfall must cross the FFI boundary as the
-    /// dedicated `ErrorAssetLockInsufficientFunds` (26) code — NOT `ErrorUnknown`
+    /// dedicated `ErrorAssetLockInsufficientFunds` (29) code — NOT `ErrorUnknown`
     /// (99) as it did before this arm existed (dashpay/platform#4073 request 3) —
     /// and its structured `available`/`required` duffs must survive verbatim in
     /// the message so hosts can still parse the amounts.
@@ -850,7 +850,7 @@ mod tests {
     }
 
     /// The default single-privacy-domain refusal (dashpay/platform#4184) must
-    /// cross as the dedicated `ErrorAssetLockCrossDomainConsentRequired` (27) code
+    /// cross as the dedicated `ErrorAssetLockCrossDomainConsentRequired` (30) code
     /// so hosts can prompt for consent and re-issue, instead of seeing an opaque
     /// insufficient-funds/unknown error even though the union covers the amount.
     #[test]

--- a/packages/rs-platform-wallet-ffi/src/error.rs
+++ b/packages/rs-platform-wallet-ffi/src/error.rs
@@ -227,12 +227,6 @@ pub enum PlatformWalletFFIResultCode {
     /// [`Self::ErrorCoreInsufficientFunds`] (22), which is the atomic Core-send
     /// selector, not the asset-lock builder.
     ErrorAssetLockInsufficientFunds = 29,
-    /// The default single-privacy-domain funding rule refused a cross-domain
-    /// co-spend (dashpay/platform#4184): the transparent domain alone is short
-    /// but the wallet-wide union would cover it. The host must obtain explicit
-    /// user consent and re-issue the funding request with cross-domain consent.
-    /// The transparent/union/required duff amounts travel in the message string.
-    ErrorAssetLockCrossDomainConsentRequired = 30,
     /// A state transition could not be signed because the signer has no
     /// usable private key for the requested public key — the stored blob is
     /// missing, stranded, or written under a different Keystore/Keychain
@@ -431,13 +425,6 @@ impl PlatformWalletFFIResultCode {
             // now lets a host branch on the shortfall without parsing text.
             PlatformWalletError::AssetLockInsufficientFunds { .. } => {
                 PlatformWalletFFIResultCode::ErrorAssetLockInsufficientFunds
-            }
-            // The default single-privacy-domain refusal (dashpay/platform#4184):
-            // a typed, actionable signal so the host can prompt for cross-domain
-            // consent and re-issue, rather than seeing an opaque insufficient-funds
-            // error even though the wallet-wide union covers the amount.
-            PlatformWalletError::AssetLockCrossDomainConsentRequired { .. } => {
-                PlatformWalletFFIResultCode::ErrorAssetLockCrossDomainConsentRequired
             }
             // A signer failure can also reach this blanket impl wrapped as
             // `PlatformWalletError::Sdk(dash_sdk::Error::Protocol(..))` (any
@@ -847,30 +834,6 @@ mod tests {
             msg, rendered,
             "structured available/required duffs must survive the FFI boundary verbatim"
         );
-    }
-
-    /// The default single-privacy-domain refusal (dashpay/platform#4184) must
-    /// cross as the dedicated `ErrorAssetLockCrossDomainConsentRequired` (30) code
-    /// so hosts can prompt for consent and re-issue, instead of seeing an opaque
-    /// insufficient-funds/unknown error even though the union covers the amount.
-    #[test]
-    fn asset_lock_cross_domain_consent_required_maps_to_dedicated_code() {
-        let err = PlatformWalletError::AssetLockCrossDomainConsentRequired {
-            transparent_available: 9_000_000,
-            cross_domain_available: 18_000_000,
-            required: 15_000_000,
-        };
-        let rendered = err.to_string();
-        let result: PlatformWalletFFIResult = err.into();
-        assert_eq!(
-            result.code,
-            PlatformWalletFFIResultCode::ErrorAssetLockCrossDomainConsentRequired,
-        );
-        assert!(!result.message.is_null());
-        let msg = unsafe { std::ffi::CStr::from_ptr(result.message) }
-            .to_string_lossy()
-            .into_owned();
-        assert_eq!(msg, rendered);
     }
 
     /// `WalletAlreadyExists` maps to the dedicated

--- a/packages/rs-platform-wallet-ffi/src/error.rs
+++ b/packages/rs-platform-wallet-ffi/src/error.rs
@@ -215,13 +215,24 @@ pub enum PlatformWalletFFIResultCode {
     /// join instead of erroring. Swift mirror:
     /// `PlatformWalletResultCode.errorShutdownIncomplete`.
     ErrorShutdownIncomplete = 27,
-    // Codes 28-30 are NOT claimed here. 28 and 30 are reserved (vacated by the
-    // deferred-payment reservation-token trio on dashpay/platform#4185/#4256
-    // when it moved to 34-36) and 29 belongs to ErrorAssetLockInsufficientFunds
-    // on the asset-lock funding branch (dashpay/platform#4184). Allocating any
-    // of them here too would merge without a textual conflict and silently
-    // misclassify across hosts. See
-    // packages/rs-platform-wallet-ffi/ERROR_CODE_REGISTRY.md.
+    // 28 is deliberately skipped: the deferred-payment reservation-token trio
+    // (ErrorStaleReservationToken / ErrorReservationTokenConsumed /
+    // ErrorReservationWalletMismatch) held 27/28/30 on the split-build-broadcast
+    // branch (dashpay/platform#4185) while this branch was numbered. Allocating
+    // into that range here would merge without a textual conflict and silently
+    // misclassify across hosts. See packages/rs-platform-wallet-ffi/ERROR_CODE_REGISTRY.md.
+    /// Asset-lock coin selection came up short over the *permitted* funding set
+    /// (dashpay/platform#4073 request 3). Carries the structured
+    /// `available`/`required` duff amounts in the message string. Distinct from
+    /// [`Self::ErrorCoreInsufficientFunds`] (22), which is the atomic Core-send
+    /// selector, not the asset-lock builder.
+    ErrorAssetLockInsufficientFunds = 29,
+    /// The default single-privacy-domain funding rule refused a cross-domain
+    /// co-spend (dashpay/platform#4184): the transparent domain alone is short
+    /// but the wallet-wide union would cover it. The host must obtain explicit
+    /// user consent and re-issue the funding request with cross-domain consent.
+    /// The transparent/union/required duff amounts travel in the message string.
+    ErrorAssetLockCrossDomainConsentRequired = 30,
     /// A state transition could not be signed because the signer has no
     /// usable private key for the requested public key — the stored blob is
     /// missing, stranded, or written under a different Keystore/Keychain
@@ -331,14 +342,20 @@ impl<T> From<Option<T>> for PlatformWalletFFIResult {
     }
 }
 
-impl From<PlatformWalletError> for PlatformWalletFFIResult {
-    fn from(error: PlatformWalletError) -> Self {
+impl PlatformWalletFFIResultCode {
+    /// Map a [`PlatformWalletError`] to its dedicated FFI code without consuming
+    /// the error or allocating a message. Kept separate from the `From` impl so
+    /// FFI entry points that want to keep a *prefixed* message (for host log
+    /// matchers) can still surface the typed code instead of flattening to
+    /// `ErrorWalletOperation`/`ErrorUnknown`. The two must stay in lockstep — the
+    /// `From` impl delegates here.
+    pub fn for_platform_wallet_error(error: &PlatformWalletError) -> Self {
         // Map the typed wallet error variants explicitly so they
         // don't flatten to ErrorUnknown at the FFI boundary. The
         // catch-all ErrorUnknown remains for variants the FFI hasn't
         // assigned a dedicated code yet — those still carry the
         // typed Display rendering as the message.
-        let code = match &error {
+        match error {
             PlatformWalletError::NoSpendableInputs { .. }
             | PlatformWalletError::OnlyOutputAddressesFunded { .. }
             | PlatformWalletError::OnlyDustInputs { .. } => {
@@ -405,6 +422,23 @@ impl From<PlatformWalletError> for PlatformWalletFFIResult {
             PlatformWalletError::ShutdownIncomplete(..) => {
                 PlatformWalletFFIResultCode::ErrorShutdownIncomplete
             }
+            // The asset-lock coin-selection shortfall (dashpay/platform#4073
+            // request 3). Without this arm it flattened to `ErrorUnknown(99)`,
+            // hiding a typed shortfall behind the catch-all and forcing hosts to
+            // string-match the Display text. The structured `available`/`required`
+            // duff amounts still travel in the message (the by-value
+            // `PlatformWalletFFIResult` has no out-params for them), but the code
+            // now lets a host branch on the shortfall without parsing text.
+            PlatformWalletError::AssetLockInsufficientFunds { .. } => {
+                PlatformWalletFFIResultCode::ErrorAssetLockInsufficientFunds
+            }
+            // The default single-privacy-domain refusal (dashpay/platform#4184):
+            // a typed, actionable signal so the host can prompt for cross-domain
+            // consent and re-issue, rather than seeing an opaque insufficient-funds
+            // error even though the wallet-wide union covers the amount.
+            PlatformWalletError::AssetLockCrossDomainConsentRequired { .. } => {
+                PlatformWalletFFIResultCode::ErrorAssetLockCrossDomainConsentRequired
+            }
             // A signer failure can also reach this blanket impl wrapped as
             // `PlatformWalletError::Sdk(dash_sdk::Error::Protocol(..))` (any
             // wallet operation that propagates the SDK error via `?`). The
@@ -424,7 +458,13 @@ impl From<PlatformWalletError> for PlatformWalletFFIResult {
                 PlatformWalletFFIResultCode::ErrorSigningKeyUnavailable
             }
             _ => PlatformWalletFFIResultCode::ErrorUnknown,
-        };
+        }
+    }
+}
+
+impl From<PlatformWalletError> for PlatformWalletFFIResult {
+    fn from(error: PlatformWalletError) -> Self {
+        let code = PlatformWalletFFIResultCode::for_platform_wallet_error(&error);
         PlatformWalletFFIResult::err(code, error.to_string())
     }
 }
@@ -769,6 +809,68 @@ mod tests {
             let result: PlatformWalletFFIResult = error.into();
             assert_eq!(result.code, expected);
         }
+    }
+
+    /// The asset-lock coin-selection shortfall must cross the FFI boundary as the
+    /// dedicated `ErrorAssetLockInsufficientFunds` (26) code — NOT `ErrorUnknown`
+    /// (99) as it did before this arm existed (dashpay/platform#4073 request 3) —
+    /// and its structured `available`/`required` duffs must survive verbatim in
+    /// the message so hosts can still parse the amounts.
+    #[test]
+    fn asset_lock_insufficient_funds_maps_to_dedicated_code() {
+        let err = PlatformWalletError::AssetLockInsufficientFunds {
+            available: 18_000_000,
+            required: 100_000_000,
+        };
+        let rendered = err.to_string();
+        // Guard the exact text hosts (dash-wallet) substring-match on.
+        assert!(
+            rendered.contains("asset lock coin selection is short"),
+            "shortfall Display text changed — coordinate dash-wallet's matcher \
+             (rendered: {rendered})"
+        );
+        let result: PlatformWalletFFIResult = err.into();
+        assert_eq!(
+            result.code,
+            PlatformWalletFFIResultCode::ErrorAssetLockInsufficientFunds,
+            "must not flatten to ErrorUnknown(99) (rendered: {rendered})"
+        );
+        assert_ne!(
+            result.code as i32,
+            PlatformWalletFFIResultCode::ErrorUnknown as i32
+        );
+        assert!(!result.message.is_null());
+        let msg = unsafe { std::ffi::CStr::from_ptr(result.message) }
+            .to_string_lossy()
+            .into_owned();
+        assert_eq!(
+            msg, rendered,
+            "structured available/required duffs must survive the FFI boundary verbatim"
+        );
+    }
+
+    /// The default single-privacy-domain refusal (dashpay/platform#4184) must
+    /// cross as the dedicated `ErrorAssetLockCrossDomainConsentRequired` (27) code
+    /// so hosts can prompt for consent and re-issue, instead of seeing an opaque
+    /// insufficient-funds/unknown error even though the union covers the amount.
+    #[test]
+    fn asset_lock_cross_domain_consent_required_maps_to_dedicated_code() {
+        let err = PlatformWalletError::AssetLockCrossDomainConsentRequired {
+            transparent_available: 9_000_000,
+            cross_domain_available: 18_000_000,
+            required: 15_000_000,
+        };
+        let rendered = err.to_string();
+        let result: PlatformWalletFFIResult = err.into();
+        assert_eq!(
+            result.code,
+            PlatformWalletFFIResultCode::ErrorAssetLockCrossDomainConsentRequired,
+        );
+        assert!(!result.message.is_null());
+        let msg = unsafe { std::ffi::CStr::from_ptr(result.message) }
+            .to_string_lossy()
+            .into_owned();
+        assert_eq!(msg, rendered);
     }
 
     /// `WalletAlreadyExists` maps to the dedicated

--- a/packages/rs-platform-wallet-ffi/src/shielded_send.rs
+++ b/packages/rs-platform-wallet-ffi/src/shielded_send.rs
@@ -51,7 +51,6 @@ use dpp::shielded::{
 use dpp::state_transition::public_key_in_creation::IdentityPublicKeyInCreation;
 use platform_wallet::wallet::asset_lock::AssetLockFunding;
 use platform_wallet::wallet::shielded::CachedOrchardProver;
-use platform_wallet::CrossDomainConsent;
 use platform_wallet::PlatformWalletError;
 use rs_sdk_ffi::{MnemonicResolverCoreSigner, MnemonicResolverHandle, SignerHandle, VTableSigner};
 
@@ -127,6 +126,40 @@ unsafe fn parse_required_platform_address(
             format!("{field_name} is required ({PLATFORM_ADDRESS_LEN} PlatformAddress bytes)"),
         )),
     }
+}
+
+/// Decode an OPTIONAL BIP32 derivation-path string from a raw `(ptr, len)` pair
+/// over the C ABI. A null pointer or zero length is `None` (the default: fund
+/// from the unmixed BIP44 account). Otherwise the bytes are parsed as a UTF-8
+/// BIP32 path (e.g. `"m/44'/5'/0'"`); invalid UTF-8 or a malformed path is a
+/// hard `ErrorInvalidParameter`.
+///
+/// # Safety
+/// `ptr`, when non-null, must point to `len` readable bytes for the duration of
+/// the call.
+unsafe fn parse_optional_derivation_path(
+    ptr: *const u8,
+    len: usize,
+) -> Result<Option<key_wallet::bip32::DerivationPath>, PlatformWalletFFIResult> {
+    use std::str::FromStr;
+    if ptr.is_null() || len == 0 {
+        return Ok(None);
+    }
+    let bytes = std::slice::from_raw_parts(ptr, len);
+    let text = std::str::from_utf8(bytes).map_err(|e| {
+        PlatformWalletFFIResult::err(
+            PlatformWalletFFIResultCode::ErrorInvalidParameter,
+            format!("funding_path is not valid UTF-8: {e}"),
+        )
+    })?;
+    key_wallet::bip32::DerivationPath::from_str(text)
+        .map(Some)
+        .map_err(|e| {
+            PlatformWalletFFIResult::err(
+                PlatformWalletFFIResultCode::ErrorInvalidParameter,
+                format!("invalid funding_path derivation path {text:?}: {e}"),
+            )
+        })
 }
 
 /// Kick off the Halo 2 proving-key build on a background tokio
@@ -922,14 +955,14 @@ pub unsafe extern "C" fn platform_wallet_manager_shielded_shield(
 /// for a future DPP-side Orchard multi-output bundle change; today
 /// the orchestration rejects anything but a single recipient.
 ///
-/// `allow_cross_domain` is the cross-privacy-domain co-spend consent
-/// (dashpay/platform#4184). Pass `false` by default: the L1 asset-lock funding
-/// is confined to the transparent BIP44/BIP32 privacy domain. Pass `true` ONLY
-/// after the user has consented to also drawing CoinJoin / DashPay-receiving
-/// funds into the lock (an irreversible on-chain linkage between those domains).
-/// When `false` and only the wallet-wide union could cover the amount, the call
-/// fails with the typed `ErrorAssetLockCrossDomainConsentRequired` code so the
-/// host can prompt for consent and re-issue.
+/// `funding_path_ptr` / `funding_path_len` optionally supply a UTF-8 BIP32
+/// derivation-path string (e.g. `"m/44'/5'/0'"`) naming the SINGLE funds account
+/// whose UTXOs fund the L1 asset lock (dashpay/platform#4184). Pass `null` / `0`
+/// for the default — the unmixed BIP44 account at `account_index`. Pass an
+/// explicit account-level path (e.g. the DIP-9 CoinJoin account path) to shield
+/// previously-mixed coins from that one account. There is no union across
+/// accounts and no consent gate: exactly one funding source participates, and if
+/// it cannot cover the lock the call fails with `ErrorAssetLockInsufficientFunds`.
 ///
 /// # Safety
 /// - `wallet_id_bytes` must point to 32 readable bytes.
@@ -937,6 +970,8 @@ pub unsafe extern "C" fn platform_wallet_manager_shielded_shield(
 ///   Orchard payment address: 11-byte diversifier + 32-byte pk_d).
 /// - `surplus_output_ptr`, when non-null, must point to
 ///   `surplus_output_len` readable bytes for the duration of the call.
+/// - `funding_path_ptr`, when non-null, must point to `funding_path_len`
+///   readable bytes (UTF-8) for the duration of the call.
 /// - `core_signer_handle` must be a valid, non-destroyed
 ///   `*mut MnemonicResolverHandle` produced by
 ///   `dash_sdk_mnemonic_resolver_create`. The caller retains
@@ -952,7 +987,8 @@ pub unsafe extern "C" fn platform_wallet_manager_shielded_fund_from_asset_lock(
     surplus_output_ptr: *const u8,
     surplus_output_len: usize,
     core_signer_handle: *mut MnemonicResolverHandle,
-    allow_cross_domain: bool,
+    funding_path_ptr: *const u8,
+    funding_path_len: usize,
 ) -> PlatformWalletFFIResult {
     check_ptr!(wallet_id_bytes);
     check_ptr!(recipient_raw_43);
@@ -979,6 +1015,11 @@ pub unsafe extern "C" fn platform_wallet_manager_shielded_fund_from_asset_lock(
         "surplus_output",
     ) {
         Ok(s) => s,
+        Err(result) => return result,
+    };
+
+    let funding_path = match parse_optional_derivation_path(funding_path_ptr, funding_path_len) {
+        Ok(p) => p,
         Err(result) => return result,
     };
 
@@ -1029,10 +1070,9 @@ pub unsafe extern "C" fn platform_wallet_manager_shielded_fund_from_asset_lock(
                 // User-facing funding: wait for the ChainLock indefinitely —
                 // a broadcast asset lock is pending finality, never failed.
                 None,
-                // Cross-privacy-domain co-spend consent (dashpay/platform#4184):
-                // the host sets this only after the user opts into drawing the
-                // L1 lock from CoinJoin / DashPay-receiving funds.
-                CrossDomainConsent::from_allow_flag(allow_cross_domain),
+                // Single funds account named by the caller's derivation path
+                // (dashpay/platform#4184); `None` = the unmixed BIP44 account.
+                funding_path,
             )
             .await
     });
@@ -1188,9 +1228,8 @@ pub unsafe extern "C" fn platform_wallet_manager_shielded_resume_fund_from_asset
                 // a broadcast asset lock is pending finality, never failed.
                 None,
                 // Resume replays an already-broadcast lock (no fresh coin
-                // selection), so the cross-domain consent is inert here — the
-                // default single-domain rule is correct.
-                CrossDomainConsent::Denied,
+                // selection), so the funding-source path is inert here.
+                None,
             )
             .await
     });

--- a/packages/rs-platform-wallet-ffi/src/shielded_send.rs
+++ b/packages/rs-platform-wallet-ffi/src/shielded_send.rs
@@ -51,6 +51,7 @@ use dpp::shielded::{
 use dpp::state_transition::public_key_in_creation::IdentityPublicKeyInCreation;
 use platform_wallet::wallet::asset_lock::AssetLockFunding;
 use platform_wallet::wallet::shielded::CachedOrchardProver;
+use platform_wallet::CrossDomainConsent;
 use platform_wallet::PlatformWalletError;
 use rs_sdk_ffi::{MnemonicResolverCoreSigner, MnemonicResolverHandle, SignerHandle, VTableSigner};
 
@@ -921,6 +922,15 @@ pub unsafe extern "C" fn platform_wallet_manager_shielded_shield(
 /// for a future DPP-side Orchard multi-output bundle change; today
 /// the orchestration rejects anything but a single recipient.
 ///
+/// `allow_cross_domain` is the cross-privacy-domain co-spend consent
+/// (dashpay/platform#4184). Pass `false` by default: the L1 asset-lock funding
+/// is confined to the transparent BIP44/BIP32 privacy domain. Pass `true` ONLY
+/// after the user has consented to also drawing CoinJoin / DashPay-receiving
+/// funds into the lock (an irreversible on-chain linkage between those domains).
+/// When `false` and only the wallet-wide union could cover the amount, the call
+/// fails with the typed `ErrorAssetLockCrossDomainConsentRequired` code so the
+/// host can prompt for consent and re-issue.
+///
 /// # Safety
 /// - `wallet_id_bytes` must point to 32 readable bytes.
 /// - `recipient_raw_43` must point to 43 readable bytes (raw
@@ -942,6 +952,7 @@ pub unsafe extern "C" fn platform_wallet_manager_shielded_fund_from_asset_lock(
     surplus_output_ptr: *const u8,
     surplus_output_len: usize,
     core_signer_handle: *mut MnemonicResolverHandle,
+    allow_cross_domain: bool,
 ) -> PlatformWalletFFIResult {
     check_ptr!(wallet_id_bytes);
     check_ptr!(recipient_raw_43);
@@ -1018,12 +1029,23 @@ pub unsafe extern "C" fn platform_wallet_manager_shielded_fund_from_asset_lock(
                 // User-facing funding: wait for the ChainLock indefinitely —
                 // a broadcast asset lock is pending finality, never failed.
                 None,
+                // Cross-privacy-domain co-spend consent (dashpay/platform#4184):
+                // the host sets this only after the user opts into drawing the
+                // L1 lock from CoinJoin / DashPay-receiving funds.
+                CrossDomainConsent::from_allow_flag(allow_cross_domain),
             )
             .await
     });
     if let Err(e) = result {
+        // Preserve the typed FFI code so a cross-domain refusal
+        // (`AssetLockCrossDomainConsentRequired`) or the asset-lock shortfall
+        // (`AssetLockInsufficientFunds`) reaches the host as its dedicated code
+        // instead of the generic `ErrorWalletOperation` — the host prompts for
+        // consent / surfaces the shortfall accordingly. The message stays
+        // prefixed for continuity with the existing dash-wallet log matcher.
+        let code = PlatformWalletFFIResultCode::for_platform_wallet_error(&e);
         return PlatformWalletFFIResult::err(
-            PlatformWalletFFIResultCode::ErrorWalletOperation,
+            code,
             format!("shielded fund-from-asset-lock failed: {e}"),
         );
     }
@@ -1165,12 +1187,18 @@ pub unsafe extern "C" fn platform_wallet_manager_shielded_resume_fund_from_asset
                 // User-facing funding: wait for the ChainLock indefinitely —
                 // a broadcast asset lock is pending finality, never failed.
                 None,
+                // Resume replays an already-broadcast lock (no fresh coin
+                // selection), so the cross-domain consent is inert here — the
+                // default single-domain rule is correct.
+                CrossDomainConsent::Denied,
             )
             .await
     });
     if let Err(e) = result {
+        // Keep the typed code (a resume can still surface asset-lock shortfalls).
+        let code = PlatformWalletFFIResultCode::for_platform_wallet_error(&e);
         return PlatformWalletFFIResult::err(
-            PlatformWalletFFIResultCode::ErrorWalletOperation,
+            code,
             format!("shielded resume fund-from-asset-lock failed: {e}"),
         );
     }

--- a/packages/rs-platform-wallet-ffi/src/shielded_send.rs
+++ b/packages/rs-platform-wallet-ffi/src/shielded_send.rs
@@ -1081,14 +1081,37 @@ pub unsafe extern "C" fn platform_wallet_manager_shielded_fund_from_asset_lock(
         // (`AssetLockInsufficientFunds`) reaches the host as its dedicated code
         // instead of the generic `ErrorWalletOperation` — the host surfaces the
         // shortfall accordingly. The message stays prefixed for continuity with
-        // the existing dash-wallet log matcher.
-        let code = PlatformWalletFFIResultCode::for_platform_wallet_error(&e);
+        // the existing dash-wallet log matcher. A genuinely-generic failure maps
+        // to `ErrorWalletOperation` (this entry point's historical generic code),
+        // NOT the catch-all `ErrorUnknown` that
+        // `for_platform_wallet_error` returns for unmapped variants.
+        let code = platform_wallet_error_code_or_wallet_operation(&e);
         return PlatformWalletFFIResult::err(
             code,
             format!("shielded fund-from-asset-lock failed: {e}"),
         );
     }
     PlatformWalletFFIResult::ok()
+}
+
+/// Map a [`PlatformWalletError`] to its dedicated FFI code, falling back to
+/// `ErrorWalletOperation` (this module's historical generic funding-failure
+/// code) instead of the catch-all `ErrorUnknown` that
+/// [`PlatformWalletFFIResultCode::for_platform_wallet_error`] returns for
+/// variants without a dedicated code. Typed variants (e.g.
+/// `AssetLockInsufficientFunds`) keep their dedicated code; only the generic
+/// arm changes, restoring the pre-re-scope contract where a generic
+/// fund-from-asset-lock failure surfaced as `ErrorWalletOperation(6)` rather
+/// than `ErrorUnknown(99)`.
+fn platform_wallet_error_code_or_wallet_operation(
+    error: &PlatformWalletError,
+) -> PlatformWalletFFIResultCode {
+    match PlatformWalletFFIResultCode::for_platform_wallet_error(error) {
+        PlatformWalletFFIResultCode::ErrorUnknown => {
+            PlatformWalletFFIResultCode::ErrorWalletOperation
+        }
+        typed => typed,
+    }
 }
 
 /// Resume a shielded fund-from-asset-lock by outpoint.
@@ -1233,8 +1256,11 @@ pub unsafe extern "C" fn platform_wallet_manager_shielded_resume_fund_from_asset
             .await
     });
     if let Err(e) = result {
-        // Keep the typed code (a resume can still surface asset-lock shortfalls).
-        let code = PlatformWalletFFIResultCode::for_platform_wallet_error(&e);
+        // Keep the typed code (a resume can still surface asset-lock shortfalls),
+        // but map a genuinely-generic failure to `ErrorWalletOperation` rather
+        // than the catch-all `ErrorUnknown` — same generic-arm contract as the
+        // build entry point above.
+        let code = platform_wallet_error_code_or_wallet_operation(&e);
         return PlatformWalletFFIResult::err(
             code,
             format!("shielded resume fund-from-asset-lock failed: {e}"),

--- a/packages/rs-platform-wallet-ffi/src/shielded_send.rs
+++ b/packages/rs-platform-wallet-ffi/src/shielded_send.rs
@@ -1077,12 +1077,11 @@ pub unsafe extern "C" fn platform_wallet_manager_shielded_fund_from_asset_lock(
             .await
     });
     if let Err(e) = result {
-        // Preserve the typed FFI code so a cross-domain refusal
-        // (`AssetLockCrossDomainConsentRequired`) or the asset-lock shortfall
+        // Preserve the typed FFI code so the asset-lock shortfall
         // (`AssetLockInsufficientFunds`) reaches the host as its dedicated code
-        // instead of the generic `ErrorWalletOperation` — the host prompts for
-        // consent / surfaces the shortfall accordingly. The message stays
-        // prefixed for continuity with the existing dash-wallet log matcher.
+        // instead of the generic `ErrorWalletOperation` — the host surfaces the
+        // shortfall accordingly. The message stays prefixed for continuity with
+        // the existing dash-wallet log matcher.
         let code = PlatformWalletFFIResultCode::for_platform_wallet_error(&e);
         return PlatformWalletFFIResult::err(
             code,

--- a/packages/rs-platform-wallet-ffi/src/shielded_send.rs
+++ b/packages/rs-platform-wallet-ffi/src/shielded_send.rs
@@ -930,8 +930,12 @@ pub unsafe extern "C" fn platform_wallet_manager_shielded_shield(
 /// by a `MnemonicResolverHandle` — the raw key never crosses the
 /// FFI boundary.
 ///
-/// `account_index` selects the BIP44 Core account whose UTXOs
-/// fund the asset lock. `amount_duffs` is the L1 amount to lock.
+/// `account_index` names the BIP44 Core account that always sinks the
+/// asset lock's transparent CHANGE, and is ALSO the input source when
+/// `funding_path` is null. With an explicit `funding_path` the inputs
+/// come exclusively from the account that path names and
+/// `account_index` remains only the (still required) change sink —
+/// see `funding_path` below. `amount_duffs` is the L1 amount to lock.
 /// The wallet derives the shielded credit amount internally
 /// (`lock_value − pool_fee`, where `pool_fee = shielded fee +
 /// asset_lock_base_cost`) — callers don't need to know about

--- a/packages/rs-platform-wallet-ffi/src/shielded_send.rs
+++ b/packages/rs-platform-wallet-ffi/src/shielded_send.rs
@@ -1507,6 +1507,74 @@ mod tests {
         );
     }
 
+    /// dashpay/platform#4184 review: `funding_path` selects WHICH account
+    /// supplies the money, so the absent-vs-invalid distinction at the C
+    /// boundary is load-bearing. Absent (null pointer or zero length)
+    /// deliberately means "default BIP44 source"; malformed input must fail
+    /// CLOSED with `ErrorInvalidParameter` rather than degrading to that
+    /// default and silently spending a different account's coins.
+    #[test]
+    fn parse_optional_derivation_path_treats_absent_as_default_source() {
+        let null = unsafe { parse_optional_derivation_path(std::ptr::null(), 0) }
+            .expect("a null pointer is absence, not an error");
+        assert!(
+            null.is_none(),
+            "a null funding_path must select the default BIP44 source"
+        );
+
+        // Non-null pointer, zero length: the length must win, so hosts that
+        // pass an empty string get the default rather than a parse error.
+        let buf = b"m/44'/5'/0'";
+        let empty = unsafe { parse_optional_derivation_path(buf.as_ptr(), 0) }
+            .expect("zero length is absence, not an error");
+        assert!(
+            empty.is_none(),
+            "a zero-length funding_path must select the default BIP44 source \
+             even when the pointer is non-null"
+        );
+    }
+
+    #[test]
+    fn parse_optional_derivation_path_accepts_account_level_path() {
+        use std::str::FromStr;
+
+        let text = "m/44'/5'/0'";
+        let parsed = unsafe { parse_optional_derivation_path(text.as_ptr(), text.len()) }
+            .expect("a well-formed account-level path must parse")
+            .expect("a well-formed path must be present");
+        assert_eq!(
+            parsed,
+            key_wallet::bip32::DerivationPath::from_str(text).expect("reference path"),
+            "the parsed path must be exactly the caller's account-level path"
+        );
+    }
+
+    #[test]
+    fn parse_optional_derivation_path_rejects_invalid_utf8() {
+        // 0xFF is never a valid UTF-8 leading byte.
+        let bytes = [0xffu8, 0xfe, 0x2f];
+        let err = unsafe { parse_optional_derivation_path(bytes.as_ptr(), bytes.len()) }
+            .expect_err("invalid UTF-8 must be rejected");
+        assert_eq!(
+            err.code,
+            PlatformWalletFFIResultCode::ErrorInvalidParameter,
+            "invalid UTF-8 must fail closed, not fall back to the default account"
+        );
+    }
+
+    #[test]
+    fn parse_optional_derivation_path_rejects_malformed_syntax() {
+        let text = "m/44'/not-an-index'/0'";
+        let err = unsafe { parse_optional_derivation_path(text.as_ptr(), text.len()) }
+            .expect_err("a malformed derivation path must be rejected");
+        assert_eq!(
+            err.code,
+            PlatformWalletFFIResultCode::ErrorInvalidParameter,
+            "a malformed funding_path must fail closed, not fall back to the \
+             default account"
+        );
+    }
+
     /// Pin the fee estimator to the on-chain ground-truth values observed at the current platform
     /// version with 2 actions (single-note spend + change). These are the exact credits the
     /// builder carves and the consensus gate validates, so the host's "Estimated Fee" must match.

--- a/packages/rs-platform-wallet/src/error.rs
+++ b/packages/rs-platform-wallet/src/error.rs
@@ -71,6 +71,23 @@ pub enum PlatformWalletError {
     #[error("Asset lock transaction failed: {0}")]
     AssetLockTransaction(String),
 
+    /// Asset-lock coin selection could not raise the requested amount from
+    /// the wallet's spendable Core funds. Carries the exact `available` and
+    /// `required` duff amounts the coin selector reported so callers (and the
+    /// UI) can render a precise shortfall instead of a stringly-typed
+    /// "Insufficient funds" message.
+    ///
+    /// After dashpay/platform#4073 the `available` figure reflects the UNION
+    /// of every spendable funds account (BIP44 + BIP32 + CoinJoin + DashPay)
+    /// for shielded funding, not just the primary BIP44 slice — so a genuine
+    /// shortfall here means the whole wallet is short, not that funds are
+    /// stranded on an unreachable derivation account.
+    #[error(
+        "asset lock coin selection is short: available {available} duffs, \
+         required {required} duffs"
+    )]
+    AssetLockInsufficientFunds { available: u64, required: u64 },
+
     #[error("Transaction broadcast failed: {0}")]
     TransactionBroadcast(String),
 

--- a/packages/rs-platform-wallet/src/error.rs
+++ b/packages/rs-platform-wallet/src/error.rs
@@ -77,42 +77,17 @@ pub enum PlatformWalletError {
     /// UI) can render a precise shortfall instead of a stringly-typed
     /// "Insufficient funds" message.
     ///
-    /// After dashpay/platform#4073 the `available` figure reflects the spendable
-    /// funds the coin selector was actually allowed to draw on for shielded
-    /// funding. Under the default single-privacy-domain rule (dashpay/platform#4184)
-    /// that is the transparent domain (BIP44 + BIP32); with explicit cross-domain
-    /// consent it is the wallet-wide union (BIP44 + BIP32 + CoinJoin + DashPay).
-    /// Either way a shortfall here means the *permitted* funding set is short —
-    /// not that funds are stranded on an unreachable derivation account. When the
-    /// wider union WOULD cover the amount but the default domain does not, the
-    /// selector returns [`Self::AssetLockCrossDomainConsentRequired`] instead of
-    /// this variant.
+    /// For shielded fund-from-asset-lock the `available` figure reflects the
+    /// single funds account the caller selected by derivation path (the unmixed
+    /// BIP44 account by default, or an explicit account such as CoinJoin). A
+    /// shortfall here means that one account is short — funding never unions
+    /// across accounts, so a different source must be named explicitly rather
+    /// than combined automatically.
     #[error(
         "asset lock coin selection is short: available {available} duffs, \
          required {required} duffs"
     )]
     AssetLockInsufficientFunds { available: u64, required: u64 },
-
-    /// The default single-privacy-domain funding rule (dashpay/platform#4184)
-    /// refused to co-spend across privacy domains. The transparent domain
-    /// (BIP44 + BIP32) alone cannot cover the asset lock, but the wallet-wide
-    /// union — adding CoinJoin and/or DashPay-receiving funds — can. Combining
-    /// them in one L1 transaction would irreversibly link those domains on-chain
-    /// (and, because the key-wallet builder derives change only on transparent
-    /// accounts, emit BIP44 change from non-transparent inputs), so it is gated
-    /// behind explicit caller/user consent. Re-issue the funding request with
-    /// cross-domain consent to proceed.
-    #[error(
-        "asset lock funding needs cross-privacy-domain co-spend: transparent \
-         domain has {transparent_available} duffs, wallet-wide union has \
-         {cross_domain_available} duffs, required {required} duffs; re-issue with \
-         cross-domain consent to combine privacy domains"
-    )]
-    AssetLockCrossDomainConsentRequired {
-        transparent_available: u64,
-        cross_domain_available: u64,
-        required: u64,
-    },
 
     #[error("Transaction broadcast failed: {0}")]
     TransactionBroadcast(String),

--- a/packages/rs-platform-wallet/src/error.rs
+++ b/packages/rs-platform-wallet/src/error.rs
@@ -77,16 +77,42 @@ pub enum PlatformWalletError {
     /// UI) can render a precise shortfall instead of a stringly-typed
     /// "Insufficient funds" message.
     ///
-    /// After dashpay/platform#4073 the `available` figure reflects the UNION
-    /// of every spendable funds account (BIP44 + BIP32 + CoinJoin + DashPay)
-    /// for shielded funding, not just the primary BIP44 slice — so a genuine
-    /// shortfall here means the whole wallet is short, not that funds are
-    /// stranded on an unreachable derivation account.
+    /// After dashpay/platform#4073 the `available` figure reflects the spendable
+    /// funds the coin selector was actually allowed to draw on for shielded
+    /// funding. Under the default single-privacy-domain rule (dashpay/platform#4184)
+    /// that is the transparent domain (BIP44 + BIP32); with explicit cross-domain
+    /// consent it is the wallet-wide union (BIP44 + BIP32 + CoinJoin + DashPay).
+    /// Either way a shortfall here means the *permitted* funding set is short —
+    /// not that funds are stranded on an unreachable derivation account. When the
+    /// wider union WOULD cover the amount but the default domain does not, the
+    /// selector returns [`Self::AssetLockCrossDomainConsentRequired`] instead of
+    /// this variant.
     #[error(
         "asset lock coin selection is short: available {available} duffs, \
          required {required} duffs"
     )]
     AssetLockInsufficientFunds { available: u64, required: u64 },
+
+    /// The default single-privacy-domain funding rule (dashpay/platform#4184)
+    /// refused to co-spend across privacy domains. The transparent domain
+    /// (BIP44 + BIP32) alone cannot cover the asset lock, but the wallet-wide
+    /// union — adding CoinJoin and/or DashPay-receiving funds — can. Combining
+    /// them in one L1 transaction would irreversibly link those domains on-chain
+    /// (and, because the key-wallet builder derives change only on transparent
+    /// accounts, emit BIP44 change from non-transparent inputs), so it is gated
+    /// behind explicit caller/user consent. Re-issue the funding request with
+    /// cross-domain consent to proceed.
+    #[error(
+        "asset lock funding needs cross-privacy-domain co-spend: transparent \
+         domain has {transparent_available} duffs, wallet-wide union has \
+         {cross_domain_available} duffs, required {required} duffs; re-issue with \
+         cross-domain consent to combine privacy domains"
+    )]
+    AssetLockCrossDomainConsentRequired {
+        transparent_available: u64,
+        cross_domain_available: u64,
+        required: u64,
+    },
 
     #[error("Transaction broadcast failed: {0}")]
     TransactionBroadcast(String),

--- a/packages/rs-platform-wallet/src/lib.rs
+++ b/packages/rs-platform-wallet/src/lib.rs
@@ -54,6 +54,7 @@ pub use manager::platform_address_sync::{
 pub use manager::PlatformWalletManager;
 pub use spv::SpvRuntime;
 pub use wallet::asset_lock::manager::AssetLockManager;
+pub use wallet::asset_lock::CrossDomainConsent;
 pub use wallet::asset_lock::tracked::{AssetLockStatus, TrackedAssetLock};
 pub use wallet::asset_lock::AssetLockFunding;
 pub use wallet::core::WalletBalance;

--- a/packages/rs-platform-wallet/src/lib.rs
+++ b/packages/rs-platform-wallet/src/lib.rs
@@ -54,7 +54,6 @@ pub use manager::platform_address_sync::{
 pub use manager::PlatformWalletManager;
 pub use spv::SpvRuntime;
 pub use wallet::asset_lock::manager::AssetLockManager;
-pub use wallet::asset_lock::CrossDomainConsent;
 pub use wallet::asset_lock::tracked::{AssetLockStatus, TrackedAssetLock};
 pub use wallet::asset_lock::AssetLockFunding;
 pub use wallet::core::WalletBalance;

--- a/packages/rs-platform-wallet/src/test_support.rs
+++ b/packages/rs-platform-wallet/src/test_support.rs
@@ -13,13 +13,18 @@ use async_trait::async_trait;
 use dashcore::hashes::Hash;
 use dashcore::secp256k1::{ecdsa, Message, PublicKey, Secp256k1};
 use dashcore::BlockHash;
-use dashcore::{Network, OutPoint, Transaction, TxOut, Txid};
+use dashcore::{Network, Transaction};
+// Consumed only by the `cfg(test)`-gated split fixtures below.
+#[cfg(test)]
+use dashcore::{OutPoint, TxOut, Txid};
 use key_wallet::account::account_type::StandardAccountType;
 use key_wallet::bip32::ExtendedPubKey;
 use key_wallet::signer::{ExtendedPubKeySigner, Signer, SignerMethod};
 use key_wallet::test_utils::TestWalletContext;
 use key_wallet::transaction_checking::{BlockInfo, TransactionContext};
-use key_wallet::{DerivationPath, Utxo, Wallet};
+#[cfg(test)]
+use key_wallet::Utxo;
+use key_wallet::{DerivationPath, Wallet};
 use key_wallet_manager::WalletManager;
 use tokio::sync::RwLock;
 
@@ -287,6 +292,13 @@ pub async fn funded_spv_core_wallet(
 /// Returns the manager, the wallet id, and a soft signer over the wallet's
 /// seed (which can derive keys for BOTH accounts, so per-account signing of a
 /// mixed-input asset lock can be exercised end-to-end).
+///
+/// Like the broadcasters above, this and the other split fixtures are consumed
+/// only by this crate's own `#[cfg(test)]` unit tests (never via the
+/// `test-utils` feature alone), so they're gated on `cfg(test)` directly —
+/// otherwise `--all-features` builds without `--tests` compile them with no
+/// consumer and clippy flags them as dead code.
+#[cfg(test)]
 pub(crate) async fn split_funded_wallet_manager(
     bip44_duffs: u64,
     coinjoin_duffs: u64,
@@ -371,6 +383,7 @@ pub(crate) async fn split_funded_wallet_manager(
 /// are fund-bearing and both are covered by the vendored asset-lock router fix
 /// (`get_relevant_account_types(AssetLock)` lists `DashpayReceivingFunds` AND
 /// `DashpayExternalAccount` alongside `CoinJoin`).
+#[cfg(test)]
 #[derive(Clone, Copy, Debug)]
 pub(crate) enum DashpayLeg {
     /// Incoming DashPay funds account (`user_id/friend_id`).
@@ -388,6 +401,7 @@ pub(crate) enum DashpayLeg {
 /// account unsignable by the local seed exactly as it is in production, so an
 /// asset-lock builder that (wrongly) selected its UTXOs would sign them with
 /// the local mnemonic's key and produce an invalid input signature.
+#[cfg(test)]
 fn foreign_contact_account_xpub() -> ExtendedPubKey {
     let foreign = TestWalletContext::new_random();
     foreign
@@ -422,6 +436,7 @@ fn foreign_contact_account_xpub() -> ExtendedPubKey {
 /// seed and is signable end-to-end; the `ExternalAccount` account is watch-only
 /// (its xpub is a contact's, from a foreign seed), so the local signer CANNOT
 /// sign its UTXOs — the asset-lock builder must exclude them.
+#[cfg(test)]
 pub(crate) async fn split_funded_wallet_manager_dashpay(
     bip44_duffs: u64,
     dashpay_duffs: u64,
@@ -582,6 +597,7 @@ pub(crate) async fn split_funded_wallet_manager_dashpay(
 /// real DIP-9 CoinJoin account carries (0.001 / 0.01 / 0.1 DASH mixing
 /// outputs) — the shape that made the asset-lock coin selector blow up
 /// on-device when it defaulted to the exponential BranchAndBound subset-sum.
+#[cfg(test)]
 pub(crate) async fn split_funded_wallet_manager_many_coinjoin(
     bip44_duffs: u64,
     coinjoin_values: &[u64],

--- a/packages/rs-platform-wallet/src/test_support.rs
+++ b/packages/rs-platform-wallet/src/test_support.rs
@@ -13,15 +13,13 @@ use async_trait::async_trait;
 use dashcore::hashes::Hash;
 use dashcore::secp256k1::{ecdsa, Message, PublicKey, Secp256k1};
 use dashcore::BlockHash;
-#[cfg(test)]
-use dashcore::Txid;
-use dashcore::{Network, Transaction};
+use dashcore::{Network, OutPoint, Transaction, TxOut, Txid};
 use key_wallet::account::account_type::StandardAccountType;
 use key_wallet::bip32::ExtendedPubKey;
 use key_wallet::signer::{ExtendedPubKeySigner, Signer, SignerMethod};
 use key_wallet::test_utils::TestWalletContext;
 use key_wallet::transaction_checking::{BlockInfo, TransactionContext};
-use key_wallet::{DerivationPath, Wallet};
+use key_wallet::{DerivationPath, Utxo, Wallet};
 use key_wallet_manager::WalletManager;
 use tokio::sync::RwLock;
 
@@ -276,4 +274,401 @@ pub async fn funded_spv_core_wallet(
         crate::CoreWallet::new(sdk, manager, wallet_id, broadcaster, balance),
         signer,
     )
+}
+
+/// Builds a testnet wallet manager whose balance is SPLIT across two
+/// derivation accounts: BIP44 standard account 0 holds a single spendable
+/// UTXO of `bip44_duffs`, and the DIP-9 CoinJoin account 0 holds a single
+/// spendable UTXO of `coinjoin_duffs`. Mirrors the live S22/testnet wallet in
+/// dashpay/platform#4073 whose ~1.44 DASH of previously-mixed coins sit on the
+/// CoinJoin path while only ~0.09 DASH rides on BIP44 — the asset-lock coin
+/// selector must span BOTH to shield the union.
+///
+/// Returns the manager, the wallet id, and a soft signer over the wallet's
+/// seed (which can derive keys for BOTH accounts, so per-account signing of a
+/// mixed-input asset lock can be exercised end-to-end).
+pub(crate) async fn split_funded_wallet_manager(
+    bip44_duffs: u64,
+    coinjoin_duffs: u64,
+) -> (
+    Arc<RwLock<WalletManager<PlatformWalletInfo>>>,
+    WalletId,
+    WalletSigner,
+) {
+    use key_wallet::managed_account::managed_account_trait::ManagedAccountTrait;
+
+    let mut ctx = TestWalletContext::new_random();
+
+    // Fund BIP44 account 0 (the primary) at its pre-derived receive address.
+    let bip44_tx = Transaction::dummy(&ctx.receive_address, 0..1, &[bip44_duffs]);
+    let bip44_result = ctx
+        .check_transaction(
+            &bip44_tx,
+            TransactionContext::InChainLockedBlock(BlockInfo::new(
+                1,
+                BlockHash::all_zeros(),
+                1_700_000_000,
+            )),
+        )
+        .await;
+    assert!(
+        bip44_result.is_relevant && bip44_result.is_new_transaction,
+        "BIP44 funding tx should be recognized"
+    );
+
+    // Derive a fresh CoinJoin receive address (registering it in the CoinJoin
+    // pool so the checker recognizes the funding), then fund CoinJoin account 0.
+    let coinjoin_xpub = ctx
+        .wallet
+        .get_coinjoin_account(0)
+        .expect("default wallet has CoinJoin account 0")
+        .account_xpub;
+    // CoinJoin is a single-pool (non-standard) account, so it derives via
+    // `next_address` rather than `next_receive_address`.
+    let coinjoin_address = ctx
+        .managed_wallet
+        .first_coinjoin_managed_account_mut()
+        .expect("default wallet has a managed CoinJoin account 0")
+        .next_address(Some(&coinjoin_xpub), true)
+        .expect("CoinJoin receive address");
+    let coinjoin_tx = Transaction::dummy(&coinjoin_address, 0..1, &[coinjoin_duffs]);
+    let coinjoin_result = ctx
+        .check_transaction(
+            &coinjoin_tx,
+            TransactionContext::InChainLockedBlock(BlockInfo::new(
+                2,
+                BlockHash::all_zeros(),
+                1_700_000_100,
+            )),
+        )
+        .await;
+    assert!(
+        coinjoin_result.is_relevant && coinjoin_result.is_new_transaction,
+        "CoinJoin funding tx should be recognized"
+    );
+
+    let signer = WalletSigner {
+        wallet: ctx.wallet.clone(),
+    };
+
+    let balance = Arc::new(WalletBalance::new());
+    let info = PlatformWalletInfo {
+        core_wallet: ctx.managed_wallet,
+        balance,
+        identity_manager: IdentityManager::new(),
+        tracked_asset_locks: BTreeMap::new(),
+    };
+
+    let mut wm = WalletManager::<PlatformWalletInfo>::new(Network::Testnet);
+    let wallet_id = wm.insert_wallet(ctx.wallet, info).expect("insert wallet");
+
+    (Arc::new(RwLock::new(wm)), wallet_id, signer)
+}
+
+/// Which DashPay funds account arm a [`split_funded_wallet_manager_dashpay`]
+/// fixture provisions. The two arms differ only in which collection they land
+/// in and the DIP-15 derivation order (user/friend vs friend/user), but both
+/// are fund-bearing and both are covered by the vendored asset-lock router fix
+/// (`get_relevant_account_types(AssetLock)` lists `DashpayReceivingFunds` AND
+/// `DashpayExternalAccount` alongside `CoinJoin`).
+#[derive(Clone, Copy, Debug)]
+pub(crate) enum DashpayLeg {
+    /// Incoming DashPay funds account (`user_id/friend_id`).
+    ReceivingFunds,
+    /// DashPay external (watch-only-style) account (`friend_id/user_id`).
+    ExternalAccount,
+}
+
+/// Builds a testnet wallet manager whose balance is SPLIT across BIP44 account
+/// 0 (`bip44_duffs`) and a DashPay funds account (`dashpay_duffs`) — the
+/// DashPay analogue of [`split_funded_wallet_manager`]'s BIP44 + CoinJoin split.
+/// `leg` selects which DashPay account type carries the mixed slice.
+///
+/// This exercises the DashPay legs of the vendored asset-lock router fix that
+/// the CoinJoin fixture does not reach: `get_relevant_account_types(AssetLock)`
+/// covers `CoinJoin`, `DashpayReceivingFunds`, AND `DashpayExternalAccount`, so
+/// an asset lock funded from a DashPay UTXO must have that input debited by the
+/// `check_core_transaction` scan (dashpay/platform#4073, dashpay/dash-wallet#1507).
+///
+/// `WalletAccountCreationOptions::Default` does not create DashPay accounts, so
+/// this provisions one — identity ids are arbitrary-but-distinct test vectors —
+/// on BOTH the signing `Wallet` and the `ManagedWalletInfo`, derives a fresh
+/// receive address from its single pool (registering it so the checker
+/// recognizes the funding), and funds it, mirroring how
+/// [`split_funded_wallet_manager`] funds the CoinJoin account.
+///
+/// Signability of the DashPay input matches production per arm (see the inline
+/// note in the body): the `ReceivingFunds` account is derived from our own
+/// seed and is signable end-to-end; the `ExternalAccount` account is watch-only
+/// (its xpub is a contact's, from a foreign seed), so the local signer CANNOT
+/// sign its UTXOs — the asset-lock builder must exclude them.
+/// An account-level xpub whose private keys the wallet under test does NOT
+/// hold — derived from a SEPARATE random wallet. Models a DashPay contact's
+/// decrypted xpub, from which production builds the watch-only
+/// `DashpayExternalAccount` (`is_watch_only: true`,
+/// `wallet/identity/network/contacts.rs`). Any well-formed testnet account
+/// xpub serves as a single-pool account key; using a FOREIGN one makes the
+/// account unsignable by the local seed exactly as it is in production, so an
+/// asset-lock builder that (wrongly) selected its UTXOs would sign them with
+/// the local mnemonic's key and produce an invalid input signature.
+fn foreign_contact_account_xpub() -> ExtendedPubKey {
+    let foreign = TestWalletContext::new_random();
+    foreign
+        .wallet
+        .accounts
+        .standard_bip44_accounts
+        .get(&0)
+        .expect("foreign wallet has BIP44 account 0")
+        .account_xpub
+}
+
+pub(crate) async fn split_funded_wallet_manager_dashpay(
+    bip44_duffs: u64,
+    dashpay_duffs: u64,
+    leg: DashpayLeg,
+) -> (
+    Arc<RwLock<WalletManager<PlatformWalletInfo>>>,
+    WalletId,
+    WalletSigner,
+) {
+    use key_wallet::account::account_collection::DashpayAccountKey;
+    use key_wallet::managed_account::managed_account_trait::ManagedAccountTrait;
+    use key_wallet::wallet::managed_wallet_info::managed_account_operations::ManagedAccountOperations;
+    use key_wallet::AccountType;
+
+    let mut ctx = TestWalletContext::new_random();
+
+    // Fund BIP44 account 0 (the primary) at its pre-derived receive address.
+    let bip44_tx = Transaction::dummy(&ctx.receive_address, 0..1, &[bip44_duffs]);
+    let bip44_result = ctx
+        .check_transaction(
+            &bip44_tx,
+            TransactionContext::InChainLockedBlock(BlockInfo::new(
+                1,
+                BlockHash::all_zeros(),
+                1_700_000_000,
+            )),
+        )
+        .await;
+    assert!(
+        bip44_result.is_relevant && bip44_result.is_new_transaction,
+        "BIP44 funding tx should be recognized"
+    );
+
+    // Provision a DashPay funds account of the requested arm on the wallet and
+    // mirror it into the managed side. The identity ids are arbitrary distinct
+    // test vectors; distinct ids keep the receiving (user/friend) and external
+    // (friend/user) derivations on different keys/paths.
+    let user_identity_id = [0x11u8; 32];
+    let friend_identity_id = [0x22u8; 32];
+    let account_type = match leg {
+        DashpayLeg::ReceivingFunds => AccountType::DashpayReceivingFunds {
+            index: 0,
+            user_identity_id,
+            friend_identity_id,
+        },
+        DashpayLeg::ExternalAccount => AccountType::DashpayExternalAccount {
+            index: 0,
+            user_identity_id,
+            friend_identity_id,
+        },
+    };
+    // Provision the DashPay funds account of the requested arm, matching how
+    // production derives each so the local signer's capability is faithful:
+    //
+    //  * `ReceivingFunds` is OURS. Production derives it from our own
+    //    friendship xpub (`register_contact_account`, `is_watch_only: false`),
+    //    so the local seed CAN sign it. `add_account(_, None)` models that by
+    //    deriving the account from this wallet's own root xpriv.
+    //
+    //  * `ExternalAccount` is the CONTACT's, WATCH-ONLY. Production builds it
+    //    from the contact's decrypted xpub (`register_dashpay_external_account`,
+    //    `is_watch_only: true`), whose private keys live under a DIFFERENT seed
+    //    the wallet does not hold. Model that faithfully: derive the account
+    //    xpub from a SEPARATE random wallet and insert it via
+    //    `add_account(_, Some(xpub))`, which stores the account
+    //    `is_watch_only: true`. The old shortcut — `add_account(_, None)` for
+    //    BOTH arms — derived the external account from our OWN seed, making it
+    //    locally signable and MASKING the union-funding bug (an asset lock
+    //    would silently spend the contact's coins with a wrong-key, invalid
+    //    signature). This arm now proves the builder excludes it.
+    match leg {
+        DashpayLeg::ReceivingFunds => {
+            ctx.wallet
+                .add_account(account_type, None)
+                .expect("add DashPay receiving account to wallet");
+        }
+        DashpayLeg::ExternalAccount => {
+            let foreign_xpub = foreign_contact_account_xpub();
+            ctx.wallet
+                .add_account(account_type, Some(foreign_xpub))
+                .expect("add watch-only DashPay external account to wallet");
+        }
+    }
+    ctx.managed_wallet
+        .add_managed_account(&ctx.wallet, account_type)
+        .expect("mirror DashPay account into managed wallet");
+
+    // Derive a fresh DashPay receive address from the single-pool managed
+    // account, then fund it. DashPay accounts are single-pool (like CoinJoin),
+    // so they derive via `next_address` rather than `next_receive_address`.
+    let key = DashpayAccountKey {
+        index: 0,
+        user_identity_id,
+        friend_identity_id,
+    };
+    let dashpay_xpub = match leg {
+        DashpayLeg::ReceivingFunds => ctx.wallet.accounts.dashpay_receival_accounts.get(&key),
+        DashpayLeg::ExternalAccount => ctx.wallet.accounts.dashpay_external_accounts.get(&key),
+    }
+    .expect("DashPay account present in wallet")
+    .account_xpub;
+    let dashpay_address = {
+        let managed = match leg {
+            DashpayLeg::ReceivingFunds => ctx
+                .managed_wallet
+                .accounts
+                .dashpay_receival_accounts
+                .get_mut(&key),
+            DashpayLeg::ExternalAccount => ctx
+                .managed_wallet
+                .accounts
+                .dashpay_external_accounts
+                .get_mut(&key),
+        }
+        .expect("managed DashPay account present");
+        managed
+            .next_address(Some(&dashpay_xpub), true)
+            .expect("DashPay receive address")
+    };
+    let dashpay_tx = Transaction::dummy(&dashpay_address, 0..1, &[dashpay_duffs]);
+    let dashpay_result = ctx
+        .check_transaction(
+            &dashpay_tx,
+            TransactionContext::InChainLockedBlock(BlockInfo::new(
+                2,
+                BlockHash::all_zeros(),
+                1_700_000_100,
+            )),
+        )
+        .await;
+    assert!(
+        dashpay_result.is_relevant && dashpay_result.is_new_transaction,
+        "DashPay funding tx should be recognized"
+    );
+
+    let signer = WalletSigner {
+        wallet: ctx.wallet.clone(),
+    };
+
+    let balance = Arc::new(WalletBalance::new());
+    let info = PlatformWalletInfo {
+        core_wallet: ctx.managed_wallet,
+        balance,
+        identity_manager: IdentityManager::new(),
+        tracked_asset_locks: BTreeMap::new(),
+    };
+
+    let mut wm = WalletManager::<PlatformWalletInfo>::new(Network::Testnet);
+    let wallet_id = wm.insert_wallet(ctx.wallet, info).expect("insert wallet");
+
+    (Arc::new(RwLock::new(wm)), wallet_id, signer)
+}
+
+/// Like [`split_funded_wallet_manager`] but seeds CoinJoin account 0 with
+/// `coinjoin_values.len()` separate spendable UTXOs, each at its own derived
+/// CoinJoin address (so the cross-account signer resolver can find a
+/// derivation path for every one). Models the many-small-denomination shape a
+/// real DIP-9 CoinJoin account carries (0.001 / 0.01 / 0.1 DASH mixing
+/// outputs) — the shape that made the asset-lock coin selector blow up
+/// on-device when it defaulted to the exponential BranchAndBound subset-sum.
+pub(crate) async fn split_funded_wallet_manager_many_coinjoin(
+    bip44_duffs: u64,
+    coinjoin_values: &[u64],
+) -> (
+    Arc<RwLock<WalletManager<PlatformWalletInfo>>>,
+    WalletId,
+    WalletSigner,
+) {
+    use key_wallet::managed_account::managed_account_trait::ManagedAccountTrait;
+    use key_wallet::wallet::managed_wallet_info::wallet_info_interface::WalletInfoInterface;
+
+    let mut ctx = TestWalletContext::new_random();
+
+    // Fund BIP44 account 0 (the primary) at its pre-derived receive address.
+    let bip44_tx = Transaction::dummy(&ctx.receive_address, 0..1, &[bip44_duffs]);
+    let bip44_result = ctx
+        .check_transaction(
+            &bip44_tx,
+            TransactionContext::InChainLockedBlock(BlockInfo::new(
+                1,
+                BlockHash::all_zeros(),
+                1_700_000_000,
+            )),
+        )
+        .await;
+    assert!(
+        bip44_result.is_relevant && bip44_result.is_new_transaction,
+        "BIP44 funding tx should be recognized"
+    );
+
+    // Seed CoinJoin account 0 with one UTXO per requested value, each at a
+    // freshly-derived (and thus pool-registered) CoinJoin address so the
+    // cross-account resolver can derive its signing key.
+    let coinjoin_xpub = ctx
+        .wallet
+        .get_coinjoin_account(0)
+        .expect("default wallet has CoinJoin account 0")
+        .account_xpub;
+    for (i, &value) in coinjoin_values.iter().enumerate() {
+        let address = ctx
+            .managed_wallet
+            .first_coinjoin_managed_account_mut()
+            .expect("default wallet has a managed CoinJoin account 0")
+            .next_address(Some(&coinjoin_xpub), true)
+            .expect("CoinJoin address");
+        let outpoint = OutPoint {
+            txid: Txid::from_byte_array([(i as u8).wrapping_add(1); 32]),
+            vout: 0,
+        };
+        let utxo = Utxo {
+            outpoint,
+            txout: TxOut {
+                value,
+                script_pubkey: address.script_pubkey(),
+            },
+            address,
+            height: 1,
+            is_coinbase: false,
+            is_confirmed: true,
+            is_instantlocked: false,
+            is_locked: false,
+            is_trusted: false,
+        };
+        ctx.managed_wallet
+            .accounts
+            .coinjoin_accounts
+            .get_mut(&0)
+            .expect("managed CoinJoin account 0")
+            .utxos
+            .insert(outpoint, utxo);
+    }
+    ctx.managed_wallet.update_last_processed_height(1000);
+
+    let signer = WalletSigner {
+        wallet: ctx.wallet.clone(),
+    };
+
+    let balance = Arc::new(WalletBalance::new());
+    let info = PlatformWalletInfo {
+        core_wallet: ctx.managed_wallet,
+        balance,
+        identity_manager: IdentityManager::new(),
+        tracked_asset_locks: BTreeMap::new(),
+    };
+
+    let mut wm = WalletManager::<PlatformWalletInfo>::new(Network::Testnet);
+    let wallet_id = wm.insert_wallet(ctx.wallet, info).expect("insert wallet");
+
+    (Arc::new(RwLock::new(wm)), wallet_id, signer)
 }

--- a/packages/rs-platform-wallet/src/test_support.rs
+++ b/packages/rs-platform-wallet/src/test_support.rs
@@ -379,6 +379,26 @@ pub(crate) enum DashpayLeg {
     ExternalAccount,
 }
 
+/// An account-level xpub whose private keys the wallet under test does NOT
+/// hold — derived from a SEPARATE random wallet. Models a DashPay contact's
+/// decrypted xpub, from which production builds the watch-only
+/// `DashpayExternalAccount` (`is_watch_only: true`,
+/// `wallet/identity/network/contacts.rs`). Any well-formed testnet account
+/// xpub serves as a single-pool account key; using a FOREIGN one makes the
+/// account unsignable by the local seed exactly as it is in production, so an
+/// asset-lock builder that (wrongly) selected its UTXOs would sign them with
+/// the local mnemonic's key and produce an invalid input signature.
+fn foreign_contact_account_xpub() -> ExtendedPubKey {
+    let foreign = TestWalletContext::new_random();
+    foreign
+        .wallet
+        .accounts
+        .standard_bip44_accounts
+        .get(&0)
+        .expect("foreign wallet has BIP44 account 0")
+        .account_xpub
+}
+
 /// Builds a testnet wallet manager whose balance is SPLIT across BIP44 account
 /// 0 (`bip44_duffs`) and a DashPay funds account (`dashpay_duffs`) — the
 /// DashPay analogue of [`split_funded_wallet_manager`]'s BIP44 + CoinJoin split.
@@ -402,26 +422,6 @@ pub(crate) enum DashpayLeg {
 /// seed and is signable end-to-end; the `ExternalAccount` account is watch-only
 /// (its xpub is a contact's, from a foreign seed), so the local signer CANNOT
 /// sign its UTXOs — the asset-lock builder must exclude them.
-/// An account-level xpub whose private keys the wallet under test does NOT
-/// hold — derived from a SEPARATE random wallet. Models a DashPay contact's
-/// decrypted xpub, from which production builds the watch-only
-/// `DashpayExternalAccount` (`is_watch_only: true`,
-/// `wallet/identity/network/contacts.rs`). Any well-formed testnet account
-/// xpub serves as a single-pool account key; using a FOREIGN one makes the
-/// account unsignable by the local seed exactly as it is in production, so an
-/// asset-lock builder that (wrongly) selected its UTXOs would sign them with
-/// the local mnemonic's key and produce an invalid input signature.
-fn foreign_contact_account_xpub() -> ExtendedPubKey {
-    let foreign = TestWalletContext::new_random();
-    foreign
-        .wallet
-        .accounts
-        .standard_bip44_accounts
-        .get(&0)
-        .expect("foreign wallet has BIP44 account 0")
-        .account_xpub
-}
-
 pub(crate) async fn split_funded_wallet_manager_dashpay(
     bip44_duffs: u64,
     dashpay_duffs: u64,

--- a/packages/rs-platform-wallet/src/wallet/asset_lock/build.rs
+++ b/packages/rs-platform-wallet/src/wallet/asset_lock/build.rs
@@ -6,6 +6,8 @@
 use crate::broadcaster::TransactionBroadcaster;
 use std::time::Duration;
 
+use dashcore::blockdata::transaction::special_transaction::asset_lock::AssetLockPayload;
+use dashcore::blockdata::transaction::special_transaction::TransactionPayload;
 use dashcore::Address as DashAddress;
 use dashcore::{OutPoint, Transaction, TxOut};
 use key_wallet::account::AccountType;
@@ -15,9 +17,17 @@ use key_wallet::signer::ExtendedPubKeySigner;
 use key_wallet::wallet::managed_wallet_info::asset_lock_builder::{
     AssetLockFundingType, CreditOutputFunding,
 };
+use key_wallet::wallet::managed_wallet_info::coin_selection::{SelectionError, SelectionStrategy};
+use key_wallet::wallet::managed_wallet_info::fee::FeeRate;
 use key_wallet::wallet::managed_wallet_info::managed_account_operations::ManagedAccountOperations;
+use key_wallet::wallet::managed_wallet_info::transaction_builder::{
+    BuilderError, TransactionBuilder,
+};
+use key_wallet::wallet::managed_wallet_info::wallet_info_interface::WalletInfoInterface;
 use key_wallet::wallet::managed_wallet_info::ManagedWalletInfo;
 use key_wallet::wallet::Wallet;
+use key_wallet::ManagedAccountType;
+use key_wallet::Utxo;
 
 use crate::changeset::{AccountRegistrationEntry, PlatformWalletChangeSet};
 use crate::error::PlatformWalletError;
@@ -106,7 +116,32 @@ impl<B: TransactionBroadcaster + ?Sized> AssetLockManager<B> {
             identity_index,
         };
 
-        // 3. Delegate to the key-wallet signer-driven builder.
+        // 3. Fund the asset lock.
+        //
+        // Shielded funding (`AssetLockShieldedAddressTopUp`) must be able to
+        // draw on previously-mixed CoinJoin coins, which live on the DIP-9
+        // CoinJoin derivation account — the pinned key-wallet
+        // `build_asset_lock_with_signer` funds from a SINGLE BIP44 account
+        // only, so those coins counted in the balance but could not be
+        // shielded (dashpay/platform#4073). Route shielded funding through the
+        // union-of-accounts builder; every other funding type keeps the
+        // single-BIP44-account path (spending mixed CoinJoin coins into an
+        // identity registration would de-anonymize them — a deliberate
+        // privacy choice left out of scope here).
+        if funding_type == AssetLockFundingType::AssetLockShieldedAddressTopUp {
+            return self
+                .build_asset_lock_tx_from_all_funding_accounts(
+                    wallet,
+                    info,
+                    account_index,
+                    vec![funding],
+                    DEFAULT_FEE_PER_KB,
+                    signer,
+                )
+                .await;
+        }
+
+        // Delegate to the key-wallet signer-driven builder (single BIP44 account).
         let result = info
             .core_wallet
             .build_asset_lock_with_signer(
@@ -148,6 +183,257 @@ impl<B: TransactionBroadcaster + ?Sized> AssetLockManager<B> {
         };
 
         Ok((result.transaction, path))
+    }
+
+    /// Build + sign an asset-lock transaction whose funding inputs are drawn
+    /// from the UNION of every spendable Core funds account (BIP44 + BIP32 +
+    /// CoinJoin + DashPay), not just the single BIP44 account at
+    /// `account_index`.
+    ///
+    /// ## Why this exists (dashpay/platform#4073)
+    ///
+    /// The pinned key-wallet `ManagedWalletInfo::build_asset_lock_with_signer`
+    /// funds an asset lock from exactly ONE BIP44 standard account: it calls
+    /// `TransactionBuilder::set_funding` on
+    /// `standard_bip44_accounts[account_index]` and signs with a
+    /// single-account path resolver (`funds_acc.address_derivation_path`).
+    /// Previously-mixed CoinJoin coins live on the DIP-9 CoinJoin derivation
+    /// account (`coinjoin_accounts`), so they are counted in the wallet
+    /// balance (which sums `all_funding_accounts`) yet were invisible to the
+    /// asset-lock coin selector — shielding failed with a coin-selection
+    /// "Insufficient funds" even though the wallet-wide balance covered the
+    /// amount.
+    ///
+    /// This method keeps `account_index` as the PRIMARY account (its
+    /// reservation ledger gates concurrent primary-account builds, and change
+    /// flows back to it via `set_funding`'s change address) but ADDS the
+    /// spendable UTXOs of every other funds account as explicit builder
+    /// inputs (`add_inputs`), and signs with a resolver that spans all funds
+    /// accounts. The credit-output key is still derived from the
+    /// shielded-topup account exactly as the single-account builder does
+    /// (peek path → signer pubkey → mark used), so the returned
+    /// `DerivationPath` lines up with the credit-output script the caller
+    /// already peeked.
+    ///
+    /// ## Interim caveat (superseded by the upstream fix)
+    ///
+    /// The clean long-term fix belongs upstream in key-wallet
+    /// (`build_asset_lock_with_signer` gathering inputs + reservations across
+    /// accounts). Until that pin bump lands, this workspace composition makes
+    /// CoinJoin funds shieldable today. `TransactionBuilder::set_funding`
+    /// captures only the PRIMARY account's `ReservationSet` (the type is
+    /// `pub(crate)` in key-wallet, so this crate cannot reserve per-account),
+    /// so inputs selected from non-primary accounts are recorded in the
+    /// primary account's reservation ledger rather than their own. They are
+    /// therefore not protected against a concurrent build on their own
+    /// account for the brief window before the broadcast tx is processed back
+    /// into the wallet (which releases the outpoints from every account's
+    /// ledger). Shielded funding is single-flighted under `shield_guard` and
+    /// the whole build runs under the wallet write lock, and the app issues no
+    /// concurrent non-shielded spend on the CoinJoin/BIP32 accounts, so the
+    /// race window is not reachable in practice.
+    async fn build_asset_lock_tx_from_all_funding_accounts<S: ExtendedPubKeySigner>(
+        &self,
+        wallet: &Wallet,
+        info: &mut PlatformWalletInfo,
+        account_index: u32,
+        credit_output_fundings: Vec<CreditOutputFunding>,
+        fee_per_kb: u64,
+        signer: &S,
+    ) -> Result<(Transaction, DerivationPath), PlatformWalletError> {
+        use std::collections::{HashMap, HashSet};
+
+        let target_duffs: u64 = credit_output_fundings.iter().map(|f| f.output.value).sum();
+        let height = info.core_wallet.last_processed_height();
+        tracing::debug!(
+            target_duffs,
+            height,
+            primary_account_index = account_index,
+            funding_accounts = info.core_wallet.accounts.all_funding_accounts().len(),
+            "multi-account asset-lock funding: enumerating spendable funds accounts"
+        );
+
+        // Snapshot the primary account's spendable outpoints so the union
+        // sweep below does not add them twice: `set_funding` already seeds
+        // them, and `add_inputs` must contribute only the OTHER accounts.
+        let primary_outpoints: HashSet<OutPoint> = info
+            .core_wallet
+            .accounts
+            .standard_bip44_accounts
+            .get(&account_index)
+            .map(|a| {
+                a.spendable_utxos(height)
+                    .into_iter()
+                    .map(|u| u.outpoint)
+                    .collect()
+            })
+            .unwrap_or_default();
+
+        // Build, from an immutable borrow of every funds account:
+        //   (a) an owned `Address -> DerivationPath` resolver covering every
+        //       spendable input across ALL accounts, so signing can resolve a
+        //       key for an input selected from any account; and
+        //   (b) the explicit extra inputs (all non-primary accounts).
+        let mut path_map: HashMap<DashAddress, DerivationPath> = HashMap::new();
+        let mut extra_inputs: Vec<Utxo> = Vec::new();
+        let mut union_value: u64 = 0;
+        let mut union_count: usize = 0;
+        for acc in info.core_wallet.accounts.all_funding_accounts() {
+            // Never fund an asset lock from coins the local wallet holds no
+            // signing key for. `all_funding_accounts()` (in the pinned
+            // key-wallet fork) includes `dashpay_external_accounts`, and
+            // `spendable_utxos()` filters on maturity but not ownership. The
+            // managed layer stores every account's PUBLIC key only (its
+            // `KeySource` is always `Public`), so a managed-level watch-only
+            // flag cannot discriminate here — the ownership signal is the
+            // account-type variant. `DashpayExternalAccount` is the sole
+            // watch-only funds account type: production builds it from a
+            // CONTACT's decrypted xpub with `is_watch_only: true` (see
+            // `wallet/identity/network/contacts.rs`), so its UTXOs are the
+            // contact's coins. `MnemonicResolverCoreSigner` would blindly
+            // derive `acc.address_derivation_path(&utxo.address)` from the
+            // LOCAL mnemonic, yielding a different key and therefore an invalid
+            // input signature. Skip such accounts entirely — both from the
+            // path resolver and from the explicit extra inputs.
+            if matches!(
+                acc.managed_account_type(),
+                ManagedAccountType::DashpayExternalAccount { .. }
+            ) {
+                continue;
+            }
+            for utxo in acc.spendable_utxos(height) {
+                union_value = union_value.saturating_add(utxo.value());
+                union_count += 1;
+                if let Some(path) = acc.address_derivation_path(&utxo.address) {
+                    path_map.insert(utxo.address.clone(), path);
+                }
+                if !primary_outpoints.contains(&utxo.outpoint) {
+                    extra_inputs.push(utxo.clone());
+                }
+            }
+        }
+        tracing::debug!(
+            union_count,
+            union_value,
+            primary_count = primary_outpoints.len(),
+            extra_count = extra_inputs.len(),
+            resolver_entries = path_map.len(),
+            "multi-account asset-lock funding: union UTXO set assembled"
+        );
+
+        let acc = wallet
+            .get_bip44_account(account_index)
+            .ok_or_else(|| {
+                PlatformWalletError::AssetLockTransaction(format!(
+                    "BIP44 account {account_index} not found for asset-lock funding"
+                ))
+            })?
+            .clone();
+        let credit_outputs: Vec<TxOut> = credit_output_fundings
+            .iter()
+            .map(|f| f.output.clone())
+            .collect();
+
+        // Seed the primary account (inputs + change address + reservations),
+        // then append the union of the other accounts' spendable inputs. The
+        // `&mut` borrow of the primary account is scoped to this block; the
+        // returned builder owns cloned inputs / reservations / change address,
+        // so no account borrow is held across the signer await below.
+        let builder = {
+            let primary_funds = info
+                .core_wallet
+                .accounts
+                .standard_bip44_accounts
+                .get_mut(&account_index)
+                .ok_or_else(|| {
+                    PlatformWalletError::AssetLockTransaction(format!(
+                        "managed BIP44 account {account_index} not found for asset-lock funding"
+                    ))
+                })?;
+            TransactionBuilder::new()
+                .set_fee_rate(FeeRate::new(fee_per_kb))
+                .set_current_height(height)
+                // LargestFirst, NOT the `TransactionBuilder::new()` default
+                // `BranchAndBound`. This is load-bearing, not an optimization:
+                // BranchAndBound routes to a recursive exact-match subset-sum
+                // (`CoinSelector::find_exact_match`) whose search space is
+                // EXPONENTIAL in the number of sub-target UTXOs. The
+                // single-BIP44-account path tolerates it (a handful of UTXOs),
+                // but a CoinJoin account holds many small mixed denominations
+                // (0.001 / 0.01 / 0.1 DASH ...); feeding that whole set to
+                // BranchAndBound hangs the FFI call for minutes with no logs and
+                // no broadcast (observed on-device, dashpay/platform#4073
+                // follow-up). LargestFirst uses the linear greedy accumulator
+                // (`accumulate_coins_with_size`), which also minimizes the input
+                // count — fewer signer round-trips (each input is one resolver
+                // upcall) and a smaller tx/fee.
+                .set_selection_strategy(SelectionStrategy::LargestFirst)
+                .set_special_payload(TransactionPayload::AssetLockPayloadType(
+                    AssetLockPayload::new(credit_outputs),
+                ))
+                .set_funding(primary_funds, &acc)
+                .add_inputs(extra_inputs)
+                .require_final_inputs()
+        };
+
+        tracing::debug!(
+            target_duffs,
+            "multi-account asset-lock funding: selecting + signing (LargestFirst)"
+        );
+        let (transaction, fee) = builder
+            .build_signed(signer, move |addr| path_map.get(&addr).cloned())
+            .await
+            .map_err(|e| map_builder_error(e, target_duffs))?;
+        tracing::debug!(
+            selected_inputs = transaction.input.len(),
+            fee,
+            txid = %transaction.txid(),
+            "multi-account asset-lock funding: transaction built + signed"
+        );
+
+        // Derive the single credit-output key from the shielded-topup account,
+        // mirroring the pinned single-account builder's phase-1/2/3 sequence
+        // (peek without marking → signer round-trip → commit the index) so a
+        // signer failure never irreversibly consumes a pool index.
+        let (path, index) = {
+            let credit_account = info
+                .core_wallet
+                .accounts
+                .asset_lock_shielded_address_topup
+                .as_mut()
+                .ok_or_else(|| {
+                    PlatformWalletError::AssetLockTransaction(
+                        "Asset lock shielded address top-up account not found".to_string(),
+                    )
+                })?;
+            credit_account
+                .peek_next_path()
+                .map_err(|e| PlatformWalletError::AssetLockTransaction(e.to_string()))?
+        };
+        signer.public_key(&path).await.map_err(|e| {
+            PlatformWalletError::AssetLockTransaction(format!("signer public_key failed: {e}"))
+        })?;
+        {
+            let credit_account = info
+                .core_wallet
+                .accounts
+                .asset_lock_shielded_address_topup
+                .as_mut()
+                .ok_or_else(|| {
+                    PlatformWalletError::AssetLockTransaction(
+                        "Asset lock shielded address top-up account not found".to_string(),
+                    )
+                })?;
+            credit_account
+                .mark_first_pool_index_used(index)
+                .map_err(|e| PlatformWalletError::AssetLockTransaction(e.to_string()))?;
+        }
+
+        tracing::debug!(
+            selected_inputs = transaction.input.len(),
+            "multi-account asset-lock funding: credit-output key derived; returning built tx"
+        );
+        Ok((transaction, path))
     }
 
     /// Peek at the next unused address from a funding account without
@@ -788,6 +1074,45 @@ impl<B: TransactionBroadcaster + ?Sized> AssetLockManager<B> {
     }
 }
 
+/// Map a key-wallet [`BuilderError`] to a [`PlatformWalletError`], promoting
+/// every shortfall shape to the typed
+/// [`PlatformWalletError::AssetLockInsufficientFunds`] so callers get one
+/// structured shortfall contract (dashpay/platform#4073's typed-error ask)
+/// instead of a string they must pattern-match:
+///   - `BuilderError::InsufficientFunds` / `SelectionError::InsufficientFunds`
+///     carry their own exact `available`/`required` duff amounts — preserved.
+///   - `SelectionError::NoUtxosAvailable` — the zero-spendable-candidate case,
+///     the MOST extreme shortfall — carries no amounts, so it previously fell
+///     through to the generic string form while partial shortfalls stayed typed
+///     (dashpay/platform#4074 prior-no-utxos-846). It now maps to `available: 0`
+///     with the caller's `requested` target as `required`, keeping the empty
+///     candidate set on the same structured path.
+/// Every other builder error keeps the generic `AssetLockTransaction` string.
+fn map_builder_error(e: BuilderError, requested: u64) -> PlatformWalletError {
+    match e {
+        BuilderError::InsufficientFunds {
+            available,
+            required,
+        }
+        | BuilderError::CoinSelection(SelectionError::InsufficientFunds {
+            available,
+            required,
+        }) => PlatformWalletError::AssetLockInsufficientFunds {
+            available,
+            required,
+        },
+        BuilderError::CoinSelection(SelectionError::NoUtxosAvailable) => {
+            PlatformWalletError::AssetLockInsufficientFunds {
+                available: 0,
+                required: requested,
+            }
+        }
+        other => {
+            PlatformWalletError::AssetLockTransaction(format!("Asset lock builder failed: {other}"))
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use std::sync::{Arc, Mutex};
@@ -807,7 +1132,7 @@ mod tests {
     };
     use crate::test_support::{
         funded_wallet_manager, AlwaysMaybeSentBroadcaster, AlwaysOkBroadcaster,
-        AlwaysRejectedBroadcaster, WalletSigner,
+        AlwaysRejectedBroadcaster, DashpayLeg, WalletSigner,
     };
     use crate::wallet::asset_lock::manager::AssetLockManager;
     use crate::wallet::asset_lock::tracked::AssetLockStatus;
@@ -815,6 +1140,52 @@ mod tests {
     use crate::wallet::platform_wallet::PlatformWalletInfo;
     use crate::wallet::platform_wallet::WalletId;
     use crate::{AssetLockFundingType, PlatformWalletError};
+
+    /// prior-no-utxos-846 (dashpay/platform#4074): the zero-spendable-candidate
+    /// selection error must surface the SAME typed shortfall as a partial
+    /// shortfall (not the generic string), so hosts stay on one structured path;
+    /// and a partial shortfall must still carry its own exact amounts.
+    #[test]
+    fn no_utxos_available_maps_to_typed_insufficient_funds() {
+        use super::{map_builder_error, BuilderError, SelectionError};
+
+        // Zero spendable candidates -> typed, available: 0, required = requested.
+        match map_builder_error(
+            BuilderError::CoinSelection(SelectionError::NoUtxosAvailable),
+            12_345,
+        ) {
+            PlatformWalletError::AssetLockInsufficientFunds {
+                available,
+                required,
+            } => {
+                assert_eq!(available, 0, "empty candidate set means nothing available");
+                assert_eq!(
+                    required, 12_345,
+                    "requested target threaded through as required"
+                );
+            }
+            other => panic!("expected typed AssetLockInsufficientFunds, got {other:?}"),
+        }
+
+        // A partial shortfall keeps its own exact amounts; the requested arg is
+        // NOT substituted for the builder's carried values.
+        match map_builder_error(
+            BuilderError::CoinSelection(SelectionError::InsufficientFunds {
+                available: 100,
+                required: 500,
+            }),
+            999,
+        ) {
+            PlatformWalletError::AssetLockInsufficientFunds {
+                available,
+                required,
+            } => {
+                assert_eq!(available, 100);
+                assert_eq!(required, 500, "carried amounts win over the requested arg");
+            }
+            other => panic!("expected typed AssetLockInsufficientFunds, got {other:?}"),
+        }
+    }
 
     /// Persistence stub that records every stored changeset so tests can
     /// assert what the asset-lock flow queued. `fail_flush` simulates a
@@ -1566,5 +1937,997 @@ mod tests {
                 }
             }
         }
+    }
+
+    // -- Multi-account asset-lock funding (dashpay/platform#4073) --
+
+    /// Wraps the split BIP44 + CoinJoin fixture in an `AssetLockManager`.
+    /// `build_asset_lock_transaction` never broadcasts, so the broadcaster is
+    /// irrelevant here.
+    async fn split_asset_lock_manager(
+        bip44_duffs: u64,
+        coinjoin_duffs: u64,
+    ) -> (
+        Arc<AssetLockManager<AlwaysRejectedBroadcaster>>,
+        WalletSigner,
+    ) {
+        let (wallet_manager, wallet_id, signer) =
+            crate::test_support::split_funded_wallet_manager(bip44_duffs, coinjoin_duffs).await;
+        let persistence = Arc::new(CapturingPersistence::default());
+        let sdk = Arc::new(dash_sdk::SdkBuilder::new_mock().build().expect("mock sdk"));
+        let manager = Arc::new(AssetLockManager::new(
+            sdk,
+            wallet_manager,
+            wallet_id,
+            Arc::new(Notify::new()),
+            Arc::new(AlwaysRejectedBroadcaster),
+            WalletPersister::new(
+                wallet_id,
+                Arc::clone(&persistence) as Arc<dyn PlatformWalletPersistence>,
+            ),
+        ));
+        (manager, signer)
+    }
+
+    /// Wraps the many-CoinJoin-UTXO fixture in an `AssetLockManager`.
+    async fn split_asset_lock_manager_many_coinjoin(
+        bip44_duffs: u64,
+        coinjoin_values: &[u64],
+    ) -> (
+        Arc<AssetLockManager<AlwaysRejectedBroadcaster>>,
+        WalletSigner,
+    ) {
+        let (wallet_manager, wallet_id, signer) =
+            crate::test_support::split_funded_wallet_manager_many_coinjoin(
+                bip44_duffs,
+                coinjoin_values,
+            )
+            .await;
+        let persistence = Arc::new(CapturingPersistence::default());
+        let sdk = Arc::new(dash_sdk::SdkBuilder::new_mock().build().expect("mock sdk"));
+        let manager = Arc::new(AssetLockManager::new(
+            sdk,
+            wallet_manager,
+            wallet_id,
+            Arc::new(Notify::new()),
+            Arc::new(AlwaysRejectedBroadcaster),
+            WalletPersister::new(
+                wallet_id,
+                Arc::clone(&persistence) as Arc<dyn PlatformWalletPersistence>,
+            ),
+        ));
+        (manager, signer)
+    }
+
+    /// The `(BIP44 account 0, CoinJoin account 0)` UTXO outpoint sets, so a
+    /// test can prove a built transaction drew inputs from both accounts.
+    async fn account_outpoints(
+        manager: &AssetLockManager<AlwaysRejectedBroadcaster>,
+    ) -> (
+        std::collections::HashSet<OutPoint>,
+        std::collections::HashSet<OutPoint>,
+    ) {
+        let wm = manager.wallet_manager.read().await;
+        let (_, info) = wm
+            .get_wallet_and_info(&manager.wallet_id)
+            .expect("wallet present");
+        let bip44 = info
+            .core_wallet
+            .accounts
+            .standard_bip44_accounts
+            .get(&0)
+            .map(|a| a.utxos.keys().copied().collect())
+            .unwrap_or_default();
+        let coinjoin = info
+            .core_wallet
+            .accounts
+            .coinjoin_accounts
+            .get(&0)
+            .map(|a| a.utxos.keys().copied().collect())
+            .unwrap_or_default();
+        (bip44, coinjoin)
+    }
+
+    /// The bug: shielded asset-lock funding must be able to spend
+    /// previously-mixed CoinJoin coins, not just the BIP44 slice. Split the
+    /// balance so NEITHER account alone can fund the lock (0.09 DASH each) and
+    /// require 0.15 DASH — coin selection must reach across both the BIP44 and
+    /// the DIP-9 CoinJoin account, and the mixed inputs must each be signed
+    /// under their own account's derivation path.
+    #[tokio::test]
+    async fn shielded_asset_lock_funds_from_bip44_and_coinjoin_union() {
+        // 0.09 DASH on BIP44, 0.09 DASH on CoinJoin; require 0.15 DASH.
+        let (manager, signer) = split_asset_lock_manager(9_000_000, 9_000_000).await;
+        let (bip44_outpoints, coinjoin_outpoints) = account_outpoints(&manager).await;
+
+        let (tx, _path) = manager
+            .build_asset_lock_transaction(
+                15_000_000,
+                0,
+                AssetLockFundingType::AssetLockShieldedAddressTopUp,
+                0,
+                &signer,
+            )
+            .await
+            .expect("shielded asset lock must fund from the BIP44 + CoinJoin union");
+
+        // Neither account alone covers 0.15 DASH, so both must be selected.
+        let spent: std::collections::HashSet<OutPoint> =
+            tx.input.iter().map(|i| i.previous_output).collect();
+        assert!(
+            spent.iter().any(|o| bip44_outpoints.contains(o)),
+            "expected at least one BIP44 input, tx spent {spent:?}"
+        );
+        assert!(
+            spent.iter().any(|o| coinjoin_outpoints.contains(o)),
+            "expected at least one CoinJoin input (the #4073 fix), tx spent {spent:?}"
+        );
+
+        // Per-account signing: every selected input, regardless of which
+        // account's derivation path it needed, must carry a signature.
+        assert!(!tx.input.is_empty(), "asset lock must have selected inputs");
+        for (i, txin) in tx.input.iter().enumerate() {
+            assert!(
+                !txin.script_sig.is_empty(),
+                "input {i} ({}) has an empty script_sig — the cross-account \
+                 resolver failed to derive/sign its key",
+                txin.previous_output
+            );
+        }
+    }
+
+    /// The widening is deliberately scoped to shielded funding: spending mixed
+    /// CoinJoin coins into an identity registration would de-anonymize them.
+    /// With the balance split 0.09/0.09, an identity-registration lock for
+    /// 0.15 DASH must still fail (BIP44 alone is short) while the shielded lock
+    /// for the same amount succeeds from the union.
+    #[tokio::test]
+    async fn non_shielded_asset_lock_stays_single_bip44_account() {
+        let (manager, signer) = split_asset_lock_manager(9_000_000, 9_000_000).await;
+
+        let identity = manager
+            .build_asset_lock_transaction(
+                15_000_000,
+                0,
+                AssetLockFundingType::IdentityRegistration,
+                0,
+                &signer,
+            )
+            .await;
+        assert!(
+            identity.is_err(),
+            "identity registration must NOT reach CoinJoin coins — BIP44 alone \
+             is short of 0.15 DASH, got {identity:?}"
+        );
+
+        let shielded = manager
+            .build_asset_lock_transaction(
+                15_000_000,
+                0,
+                AssetLockFundingType::AssetLockShieldedAddressTopUp,
+                0,
+                &signer,
+            )
+            .await;
+        assert!(
+            shielded.is_ok(),
+            "shielded funding must reach the union, got {shielded:?}"
+        );
+    }
+
+    /// A shielded lock exceeding even the UNION balance surfaces the typed
+    /// [`PlatformWalletError::AssetLockInsufficientFunds`], and its `available`
+    /// reflects the whole spendable balance (both accounts), not the BIP44
+    /// slice — the pre-#4073 symptom was `available` reporting only the BIP44
+    /// portion.
+    #[tokio::test]
+    async fn shielded_asset_lock_union_shortfall_is_typed() {
+        // Union spendable is 0.18 DASH; ask for 1.0 DASH.
+        let (manager, signer) = split_asset_lock_manager(9_000_000, 9_000_000).await;
+
+        let result = manager
+            .build_asset_lock_transaction(
+                100_000_000,
+                0,
+                AssetLockFundingType::AssetLockShieldedAddressTopUp,
+                0,
+                &signer,
+            )
+            .await;
+
+        match result {
+            Err(PlatformWalletError::AssetLockInsufficientFunds {
+                available,
+                required,
+            }) => {
+                // `available` must reflect the union (both 0.09 UTXOs), i.e.
+                // strictly more than the BIP44-only slice the old path saw.
+                assert!(
+                    available > 9_000_000,
+                    "available ({available}) should reflect the BIP44 + CoinJoin \
+                     union (> the 9_000_000 BIP44 slice)"
+                );
+                assert!(
+                    available <= 18_000_000,
+                    "available ({available}) cannot exceed the 18_000_000 union"
+                );
+                assert!(
+                    required >= 100_000_000,
+                    "required ({required}) should be at least the requested amount"
+                );
+            }
+            other => panic!(
+                "expected typed AssetLockInsufficientFunds carrying the union \
+                 available/required, got {other:?}"
+            ),
+        }
+    }
+
+    /// On-device regression: a real CoinJoin account holds many small mixed
+    /// denominations. The first version of the multi-account builder inherited
+    /// `TransactionBuilder`'s default `BranchAndBound`, whose recursive
+    /// exact-match subset-sum (`CoinSelector::find_exact_match`) is EXPONENTIAL
+    /// in the count of sub-target UTXOs — feeding it a large CoinJoin set hung
+    /// the whole FFI call for minutes with no logs and no broadcast. The builder
+    /// now pins `LargestFirst` (linear greedy).
+    ///
+    /// The blowup is SYNCHRONOUS CPU work with no `.await` points, so it cannot
+    /// be interrupted by `tokio::time::timeout` (that is exactly why on-device
+    /// it hangs RUNNABLE-in-native and the enclosing coroutine never yields).
+    /// The build therefore runs on a **detached OS thread**, and the test body
+    /// waits on a channel with a wall-clock deadline: a regression to an
+    /// exponential strategy makes `recv_timeout` fire and the test FAIL (rather
+    /// than hang the whole suite). The detached thread is reclaimed at process
+    /// exit; on the happy path (LargestFirst) it finishes in well under a
+    /// millisecond and the channel delivers immediately.
+    #[test]
+    fn shielded_asset_lock_over_many_coinjoin_utxos_does_not_hang() {
+        use std::sync::mpsc;
+        use std::time::Duration;
+
+        // 40 x 0.02 DASH CoinJoin UTXOs (0.8 DASH), 0.09 DASH on BIP44; shield
+        // 0.2 DASH. BranchAndBound would explore ~sum_k C(40, k<=10) subsets —
+        // empirically minutes+; LargestFirst returns instantly.
+        let coinjoin: Vec<u64> = vec![2_000_000; 40];
+
+        // Fixture build is async; drive it on a throwaway current-thread runtime.
+        let setup_rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("setup runtime");
+        let (manager, signer) =
+            setup_rt.block_on(split_asset_lock_manager_many_coinjoin(9_000_000, &coinjoin));
+
+        let (result_tx, result_rx) = mpsc::channel();
+        // Detached: NOT joined anywhere, so a hung build can't wedge runtime
+        // teardown; libtest reclaims it at process exit.
+        std::thread::spawn(move || {
+            let rt = tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+                .expect("worker runtime");
+            let outcome = rt
+                .block_on(manager.build_asset_lock_transaction(
+                    20_000_000,
+                    0,
+                    AssetLockFundingType::AssetLockShieldedAddressTopUp,
+                    0,
+                    &signer,
+                ))
+                .map(|(tx, _path)| tx);
+            let _ = result_tx.send(outcome);
+        });
+
+        // LargestFirst completes in ~25ms; a 30s deadline is a ~1000x margin
+        // against CI contention while still bounding a regression to an
+        // exponential strategy (which never returns) to a prompt failure.
+        match result_rx.recv_timeout(Duration::from_secs(30)) {
+            Ok(Ok(tx)) => {
+                // LargestFirst minimizes the input count; every selected input
+                // must be signed under its own account's derivation path.
+                assert!(!tx.input.is_empty(), "must select inputs");
+                for txin in &tx.input {
+                    assert!(
+                        !txin.script_sig.is_empty(),
+                        "input {} is unsigned",
+                        txin.previous_output
+                    );
+                }
+            }
+            Ok(Err(e)) => panic!("funding must succeed from the CoinJoin union, got {e:?}"),
+            Err(_) => panic!(
+                "multi-account asset-lock funding did not return within 30s — \
+                 regression to an exponential coin-selection strategy over the \
+                 CoinJoin UTXO set (dashpay/platform#4073 on-device hang)"
+            ),
+        }
+    }
+
+    /// Aggregate wallet balance across all funds accounts (recomputes from the
+    /// current UTXO maps).
+    async fn aggregate_total(manager: &AssetLockManager<AlwaysRejectedBroadcaster>) -> u64 {
+        use key_wallet::wallet::managed_wallet_info::wallet_info_interface::WalletInfoInterface;
+        let mut wm = manager.wallet_manager.write().await;
+        let info = wm
+            .get_wallet_info_mut(&manager.wallet_id)
+            .expect("wallet present");
+        info.core_wallet.update_balance();
+        WalletInfoInterface::balance(&info.core_wallet).total()
+    }
+
+    /// `true` iff CoinJoin account 0 still holds `outpoint` as an unspent UTXO.
+    async fn coinjoin_has_utxo(
+        manager: &AssetLockManager<AlwaysRejectedBroadcaster>,
+        outpoint: &OutPoint,
+    ) -> bool {
+        let wm = manager.wallet_manager.read().await;
+        let (_, info) = wm
+            .get_wallet_and_info(&manager.wallet_id)
+            .expect("wallet present");
+        info.core_wallet
+            .accounts
+            .coinjoin_accounts
+            .get(&0)
+            .is_some_and(|a| a.utxos.contains_key(outpoint))
+    }
+
+    /// Build a CoinJoin-funded shield over the split fixture and return the
+    /// manager, the pre-spend aggregate, the spent-input total, the wallet
+    /// change total, and the built tx. 0.09 DASH BIP44 + one 2.0 DASH CoinJoin
+    /// UTXO, shield 0.2 DASH — LargestFirst funds it entirely from the CoinJoin
+    /// UTXO, so the tx spends only a CoinJoin input and the change lands on BIP44.
+    async fn build_coinjoin_shield() -> (
+        Arc<AssetLockManager<AlwaysRejectedBroadcaster>>,
+        u64,
+        u64,
+        u64,
+        Transaction,
+    ) {
+        use key_wallet::wallet::managed_wallet_info::wallet_info_interface::WalletInfoInterface;
+
+        let (manager, signer) = split_asset_lock_manager(9_000_000, 200_000_000).await;
+
+        let (before_total, utxo_values) = {
+            let mut wm = manager.wallet_manager.write().await;
+            let info = wm
+                .get_wallet_info_mut(&manager.wallet_id)
+                .expect("wallet present");
+            info.core_wallet.update_balance();
+            let before = WalletInfoInterface::balance(&info.core_wallet).total();
+            let mut values = std::collections::HashMap::new();
+            for acc in info.core_wallet.accounts.all_funding_accounts() {
+                for (op, utxo) in &acc.utxos {
+                    values.insert(*op, utxo.txout.value);
+                }
+            }
+            (before, values)
+        };
+
+        let (tx, _path) = manager
+            .build_asset_lock_transaction(
+                20_000_000,
+                0,
+                AssetLockFundingType::AssetLockShieldedAddressTopUp,
+                0,
+                &signer,
+            )
+            .await
+            .expect("build multi-account asset lock");
+
+        let sum_spent: u64 = tx
+            .input
+            .iter()
+            .map(|i| utxo_values.get(&i.previous_output).copied().unwrap_or(0))
+            .sum();
+        // Wallet-owned outputs = the change (the AssetLock burn is an OP_RETURN).
+        let sum_change: u64 = tx
+            .output
+            .iter()
+            .filter(|o| !o.script_pubkey.is_op_return())
+            .map(|o| o.value)
+            .sum();
+        assert!(sum_spent > 0, "tx must spend a wallet (CoinJoin) UTXO");
+        assert!(sum_change > 0, "tx must return change to the wallet");
+
+        (manager, before_total, sum_spent, sum_change, tx)
+    }
+
+    /// THE CASE THE DEVICE IS STUCK ON: after a hard reset the wallet is rebuilt
+    /// from scratch and the asset-lock tx is re-seen by a block/rescan. The
+    /// `check_core_transaction` scan — with NO broadcast-time mitigation in
+    /// play (a rescan never runs the broadcast path) — must debit the spent
+    /// CoinJoin input, so the balance settles to `previous − inputs + change`
+    /// rather than re-inflating by the spent amount and re-triggering the
+    /// reset→rescan→inflate loop. This passes ONLY because the vendored
+    /// rust-dashcore carries the router fix (CoinJoin in the AssetLock relevant
+    /// types); on the un-patched pin the CoinJoin input stays counted.
+    #[tokio::test]
+    async fn router_fix_debits_coinjoin_asset_lock_spend_on_rescan() {
+        use key_wallet::transaction_checking::{TransactionContext, WalletTransactionChecker};
+
+        let (manager, before_total, sum_spent, sum_change, tx) = build_coinjoin_shield().await;
+        let spent_outpoint = tx.input[0].previous_output;
+        assert!(
+            coinjoin_has_utxo(&manager, &spent_outpoint).await,
+            "the CoinJoin UTXO must be present before the scan (rescan re-added it)"
+        );
+
+        // Confirmation/rescan processing ONLY — no broadcast-time mitigation.
+        {
+            let mut wm = manager.wallet_manager.write().await;
+            let (wallet, info) = wm
+                .get_wallet_mut_and_info_mut(&manager.wallet_id)
+                .expect("wallet present");
+            info.core_wallet
+                .check_core_transaction(
+                    &tx,
+                    TransactionContext::InChainLockedBlock(
+                        key_wallet::transaction_checking::BlockInfo::new(
+                            10,
+                            dashcore::BlockHash::from_raw_hash(dashcore::hashes::Hash::all_zeros()),
+                            1_700_001_000,
+                        ),
+                    ),
+                    wallet,
+                    true,
+                    true,
+                )
+                .await;
+        }
+
+        assert!(
+            !coinjoin_has_utxo(&manager, &spent_outpoint).await,
+            "router fix must mark the spent CoinJoin UTXO spent on the scan"
+        );
+        assert_eq!(
+            aggregate_total(&manager).await,
+            before_total - sum_spent + sum_change,
+            "post-rescan balance must be previous − inputs + change (no re-inflation)"
+        );
+    }
+
+    /// The persistence half of dashpay/dash-wallet#1507: proving the router-
+    /// fixed scan not only debits the CoinJoin input in memory but produces a
+    /// [`TransactionRecord`] whose `input_details` reference the spent CoinJoin
+    /// outpoint — the exact data `core_bridge::derive_spent_utxos` walks to tell
+    /// the persister to DELETE that UTXO row. This is what makes the debit
+    /// survive restart. The removed broadcast-time mitigation defeated this:
+    /// by `.remove()`ing the UTXO in-memory first, it made the later scan's
+    /// `ManagedCoreFundsAccount::check_transaction_for_match` find no UTXO, emit
+    /// no CoinJoin record, and thus leave `input_details` empty — so nothing was
+    /// ever persisted and the stale row reloaded on restart. With the mitigation
+    /// gone, the scan owns the debit and the record carries the deletion through.
+    #[tokio::test]
+    async fn router_fix_records_spent_coinjoin_input_for_persistence() {
+        use key_wallet::transaction_checking::{TransactionContext, WalletTransactionChecker};
+
+        let (manager, _before_total, _sum_spent, _sum_change, tx) = build_coinjoin_shield().await;
+        let spent_outpoint = tx.input[0].previous_output;
+        assert!(
+            coinjoin_has_utxo(&manager, &spent_outpoint).await,
+            "the CoinJoin UTXO must be present before the scan"
+        );
+
+        // Normal-pipeline scan (no mitigation), capturing the emitted records.
+        let result = {
+            let mut wm = manager.wallet_manager.write().await;
+            let (wallet, info) = wm
+                .get_wallet_mut_and_info_mut(&manager.wallet_id)
+                .expect("wallet present");
+            info.core_wallet
+                .check_core_transaction(&tx, TransactionContext::Mempool, wallet, true, true)
+                .await
+        };
+
+        // A record must exist whose `input_details` resolve — through the same
+        // `record.transaction.input[detail.index].previous_output` lookup
+        // `derive_spent_utxos` uses — to the spent CoinJoin outpoint. Without
+        // that entry the persister is never told to delete the row (the #1507
+        // gap). It must belong to the CoinJoin account, the account the pinned
+        // router omitted and the mitigation used to suppress.
+        let persisted_spend = result
+            .new_records
+            .iter()
+            .chain(result.updated_records.iter())
+            .filter(|r| matches!(r.account_type, key_wallet::AccountType::CoinJoin { .. }))
+            .flat_map(|r| {
+                r.input_details.iter().filter_map(move |d| {
+                    r.transaction
+                        .input
+                        .get(d.index as usize)
+                        .map(|i| i.previous_output)
+                })
+            })
+            .any(|op| op == spent_outpoint);
+
+        assert!(
+            persisted_spend,
+            "the router-fixed scan must emit a CoinJoin TransactionRecord whose \
+             input_details cover the spent outpoint {spent_outpoint}, so \
+             derive_spent_utxos persists the deletion (dashpay/dash-wallet#1507)"
+        );
+
+        // And the in-memory debit itself must have happened.
+        assert!(
+            !coinjoin_has_utxo(&manager, &spent_outpoint).await,
+            "the scan must mark the spent CoinJoin UTXO spent"
+        );
+    }
+
+    // -- DashPay-leg asset-lock persistence (dashpay/dash-wallet#1507) --
+    //
+    // The vendored router fix and the removed broadcast-time mitigation's own
+    // doc comment (see the `no broadcast-time balance mitigation` note above)
+    // cover THREE previously-omitted fund-bearing account types for asset-lock
+    // spend detection: `CoinJoin`, `DashpayReceivingFunds`, and
+    // `DashpayExternalAccount`. The `build_coinjoin_shield` tests above exercise
+    // only the CoinJoin leg; the following mirror them for BOTH DashPay legs, so
+    // a latent gap in either DashPay arm of `get_relevant_account_types(AssetLock)`
+    // (e.g. a `DashpayReceivingFunds`-vs-`DashpayExternalAccount` routing edge
+    // case) cannot silently recur the exact persistence regression this PR closes.
+
+    /// Wraps the split BIP44 + DashPay fixture (`leg` selects which DashPay
+    /// account type carries the mixed slice) in an `AssetLockManager`.
+    async fn split_asset_lock_manager_dashpay(
+        bip44_duffs: u64,
+        dashpay_duffs: u64,
+        leg: DashpayLeg,
+    ) -> (
+        Arc<AssetLockManager<AlwaysRejectedBroadcaster>>,
+        WalletSigner,
+    ) {
+        let (wallet_manager, wallet_id, signer) =
+            crate::test_support::split_funded_wallet_manager_dashpay(
+                bip44_duffs,
+                dashpay_duffs,
+                leg,
+            )
+            .await;
+        let persistence = Arc::new(CapturingPersistence::default());
+        let sdk = Arc::new(dash_sdk::SdkBuilder::new_mock().build().expect("mock sdk"));
+        let manager = Arc::new(AssetLockManager::new(
+            sdk,
+            wallet_manager,
+            wallet_id,
+            Arc::new(Notify::new()),
+            Arc::new(AlwaysRejectedBroadcaster),
+            WalletPersister::new(
+                wallet_id,
+                Arc::clone(&persistence) as Arc<dyn PlatformWalletPersistence>,
+            ),
+        ));
+        (manager, signer)
+    }
+
+    /// The set of outpoints held by the DashPay funds account of the given
+    /// `leg` on account key index 0.
+    async fn dashpay_account_outpoints(
+        manager: &AssetLockManager<AlwaysRejectedBroadcaster>,
+        leg: DashpayLeg,
+    ) -> std::collections::HashSet<OutPoint> {
+        let wm = manager.wallet_manager.read().await;
+        let (_, info) = wm
+            .get_wallet_and_info(&manager.wallet_id)
+            .expect("wallet present");
+        let map = match leg {
+            DashpayLeg::ReceivingFunds => &info.core_wallet.accounts.dashpay_receival_accounts,
+            DashpayLeg::ExternalAccount => &info.core_wallet.accounts.dashpay_external_accounts,
+        };
+        map.values().flat_map(|a| a.utxos.keys().copied()).collect()
+    }
+
+    /// `true` iff the DashPay funds account of the given `leg` still holds
+    /// `outpoint` as an unspent UTXO.
+    async fn dashpay_has_utxo(
+        manager: &AssetLockManager<AlwaysRejectedBroadcaster>,
+        leg: DashpayLeg,
+        outpoint: &OutPoint,
+    ) -> bool {
+        let wm = manager.wallet_manager.read().await;
+        let (_, info) = wm
+            .get_wallet_and_info(&manager.wallet_id)
+            .expect("wallet present");
+        let map = match leg {
+            DashpayLeg::ReceivingFunds => &info.core_wallet.accounts.dashpay_receival_accounts,
+            DashpayLeg::ExternalAccount => &info.core_wallet.accounts.dashpay_external_accounts,
+        };
+        map.values().any(|a| a.utxos.contains_key(outpoint))
+    }
+
+    /// `true` iff `account_type` is the DashPay funds variant matching `leg`.
+    fn record_matches_dashpay_leg(account_type: &key_wallet::AccountType, leg: DashpayLeg) -> bool {
+        match leg {
+            DashpayLeg::ReceivingFunds => matches!(
+                account_type,
+                key_wallet::AccountType::DashpayReceivingFunds { .. }
+            ),
+            DashpayLeg::ExternalAccount => matches!(
+                account_type,
+                key_wallet::AccountType::DashpayExternalAccount { .. }
+            ),
+        }
+    }
+
+    /// DashPay analogue of [`build_coinjoin_shield`]: fund a shield entirely
+    /// from a single 2.0-DASH DashPay UTXO (the DashPay account of `leg`) over a
+    /// BIP44 slice too small to cover it, so the tx spends exactly the DashPay
+    /// input and change lands on BIP44. Returns the manager, the pre-spend
+    /// aggregate, the spent-input total, the change total, the built tx, and the
+    /// spent DashPay outpoint (resolved against the DashPay account's own UTXO
+    /// set rather than assumed positionally).
+    async fn build_dashpay_shield(
+        leg: DashpayLeg,
+    ) -> (
+        Arc<AssetLockManager<AlwaysRejectedBroadcaster>>,
+        u64,
+        u64,
+        u64,
+        Transaction,
+        OutPoint,
+    ) {
+        use key_wallet::wallet::managed_wallet_info::wallet_info_interface::WalletInfoInterface;
+
+        let (manager, signer) = split_asset_lock_manager_dashpay(9_000_000, 200_000_000, leg).await;
+        let dashpay_outpoints = dashpay_account_outpoints(&manager, leg).await;
+
+        let (before_total, utxo_values) = {
+            let mut wm = manager.wallet_manager.write().await;
+            let info = wm
+                .get_wallet_info_mut(&manager.wallet_id)
+                .expect("wallet present");
+            info.core_wallet.update_balance();
+            let before = WalletInfoInterface::balance(&info.core_wallet).total();
+            let mut values = std::collections::HashMap::new();
+            for acc in info.core_wallet.accounts.all_funding_accounts() {
+                for (op, utxo) in &acc.utxos {
+                    values.insert(*op, utxo.txout.value);
+                }
+            }
+            (before, values)
+        };
+
+        let (tx, _path) = manager
+            .build_asset_lock_transaction(
+                20_000_000,
+                0,
+                AssetLockFundingType::AssetLockShieldedAddressTopUp,
+                0,
+                &signer,
+            )
+            .await
+            .expect("build DashPay-funded asset lock");
+
+        let sum_spent: u64 = tx
+            .input
+            .iter()
+            .map(|i| utxo_values.get(&i.previous_output).copied().unwrap_or(0))
+            .sum();
+        let sum_change: u64 = tx
+            .output
+            .iter()
+            .filter(|o| !o.script_pubkey.is_op_return())
+            .map(|o| o.value)
+            .sum();
+        assert!(sum_spent > 0, "tx must spend a wallet (DashPay) UTXO");
+        assert!(sum_change > 0, "tx must return change to the wallet");
+
+        // The spent DashPay outpoint, resolved against the DashPay account's own
+        // UTXO set (not `input[0]`), so a future change in selection ordering
+        // can't quietly make this assert about the wrong input.
+        let dashpay_spent = tx
+            .input
+            .iter()
+            .map(|i| i.previous_output)
+            .find(|op| dashpay_outpoints.contains(op))
+            .expect("shield must spend a DashPay UTXO (the multi-account #4073 fix)");
+
+        (
+            manager,
+            before_total,
+            sum_spent,
+            sum_change,
+            tx,
+            dashpay_spent,
+        )
+    }
+
+    /// Rescan-debit body shared by both DashPay legs: mirrors
+    /// [`router_fix_debits_coinjoin_asset_lock_spend_on_rescan`] but over a
+    /// DashPay-funded shield. A confirmation/rescan `check_core_transaction`
+    /// (no broadcast-time mitigation) must debit the spent DashPay input so the
+    /// balance settles to `previous − inputs + change` rather than re-inflating.
+    async fn assert_router_fix_debits_dashpay_on_rescan(leg: DashpayLeg) {
+        use key_wallet::transaction_checking::{TransactionContext, WalletTransactionChecker};
+
+        let (manager, before_total, sum_spent, sum_change, tx, spent_outpoint) =
+            build_dashpay_shield(leg).await;
+        assert!(
+            dashpay_has_utxo(&manager, leg, &spent_outpoint).await,
+            "the DashPay UTXO must be present before the scan (rescan re-added it)"
+        );
+
+        {
+            let mut wm = manager.wallet_manager.write().await;
+            let (wallet, info) = wm
+                .get_wallet_mut_and_info_mut(&manager.wallet_id)
+                .expect("wallet present");
+            info.core_wallet
+                .check_core_transaction(
+                    &tx,
+                    TransactionContext::InChainLockedBlock(
+                        key_wallet::transaction_checking::BlockInfo::new(
+                            10,
+                            dashcore::BlockHash::from_raw_hash(dashcore::hashes::Hash::all_zeros()),
+                            1_700_001_000,
+                        ),
+                    ),
+                    wallet,
+                    true,
+                    true,
+                )
+                .await;
+        }
+
+        assert!(
+            !dashpay_has_utxo(&manager, leg, &spent_outpoint).await,
+            "router fix must mark the spent DashPay UTXO spent on the scan ({leg:?})"
+        );
+        assert_eq!(
+            aggregate_total(&manager).await,
+            before_total - sum_spent + sum_change,
+            "post-rescan balance must be previous − inputs + change (no re-inflation, {leg:?})"
+        );
+    }
+
+    /// Persistence-record body shared by both DashPay legs: mirrors
+    /// [`router_fix_records_spent_coinjoin_input_for_persistence`]. The scan must
+    /// emit a `TransactionRecord` belonging to the DashPay account whose
+    /// `input_details` resolve — through the same
+    /// `record.transaction.input[detail.index].previous_output` lookup
+    /// `derive_spent_utxos` uses — to the spent DashPay outpoint, so the
+    /// persister is told to delete that UTXO row and the debit survives restart.
+    async fn assert_router_fix_records_spent_dashpay_input(leg: DashpayLeg) {
+        use key_wallet::transaction_checking::{TransactionContext, WalletTransactionChecker};
+
+        let (manager, _before_total, _sum_spent, _sum_change, tx, spent_outpoint) =
+            build_dashpay_shield(leg).await;
+        assert!(
+            dashpay_has_utxo(&manager, leg, &spent_outpoint).await,
+            "the DashPay UTXO must be present before the scan"
+        );
+
+        let result = {
+            let mut wm = manager.wallet_manager.write().await;
+            let (wallet, info) = wm
+                .get_wallet_mut_and_info_mut(&manager.wallet_id)
+                .expect("wallet present");
+            info.core_wallet
+                .check_core_transaction(&tx, TransactionContext::Mempool, wallet, true, true)
+                .await
+        };
+
+        let persisted_spend = result
+            .new_records
+            .iter()
+            .chain(result.updated_records.iter())
+            .filter(|r| record_matches_dashpay_leg(&r.account_type, leg))
+            .flat_map(|r| {
+                r.input_details.iter().filter_map(move |d| {
+                    r.transaction
+                        .input
+                        .get(d.index as usize)
+                        .map(|i| i.previous_output)
+                })
+            })
+            .any(|op| op == spent_outpoint);
+
+        assert!(
+            persisted_spend,
+            "the router-fixed scan must emit a {leg:?} TransactionRecord whose \
+             input_details cover the spent outpoint {spent_outpoint}, so \
+             derive_spent_utxos persists the deletion (dashpay/dash-wallet#1507)"
+        );
+
+        assert!(
+            !dashpay_has_utxo(&manager, leg, &spent_outpoint).await,
+            "the scan must mark the spent DashPay UTXO spent ({leg:?})"
+        );
+    }
+
+    /// DashpayReceivingFunds analogue of
+    /// `router_fix_debits_coinjoin_asset_lock_spend_on_rescan`.
+    #[tokio::test]
+    async fn router_fix_debits_dashpay_receiving_asset_lock_spend_on_rescan() {
+        assert_router_fix_debits_dashpay_on_rescan(DashpayLeg::ReceivingFunds).await;
+    }
+
+    /// DashpayReceivingFunds analogue of
+    /// `router_fix_records_spent_coinjoin_input_for_persistence`.
+    #[tokio::test]
+    async fn router_fix_records_spent_dashpay_receiving_input_for_persistence() {
+        assert_router_fix_records_spent_dashpay_input(DashpayLeg::ReceivingFunds).await;
+    }
+
+    // -- Watch-only DashpayExternalAccount exclusion (finding 5b52d9844055) --
+    //
+    // A `DashpayExternalAccount` is created in production from a CONTACT's
+    // decrypted xpub with `is_watch_only: true` (wallet/identity/network/
+    // contacts.rs): its UTXOs are the contact's coins, and the local mnemonic
+    // holds no key for them. `all_funding_accounts()` in the pinned key-wallet
+    // fork nonetheless includes it, so the multi-account asset-lock builder must
+    // filter it out — otherwise it would select those UTXOs, sign them with the
+    // wrong local key, and produce an invalid input signature.
+    //
+    // Unlike the DashPay RECEIVING-funds leg (which IS ours and signable, and is
+    // correctly INCLUDED — see the receiving tests above), these two tests assert
+    // the EXCLUSION. The fixture builds the external account watch-only from a
+    // FOREIGN seed's xpub, mirroring production; the earlier `add_account(_, None)`
+    // fixture derived it from the test wallet's own seed, making it locally
+    // signable and MASKING this defect.
+
+    /// The union-of-accounts asset-lock builder must NOT select watch-only
+    /// `DashpayExternalAccount` UTXOs. The external account here holds the
+    /// LARGEST UTXO (0.5 DASH) while signable BIP44 (0.15 DASH) alone covers the
+    /// 0.1-DASH shield, so a naive `LargestFirst` over the union would grab the
+    /// external UTXO FIRST (the pre-fix bug). The build must instead succeed from
+    /// BIP44 alone and leave every external UTXO unspent.
+    #[tokio::test]
+    async fn asset_lock_funding_excludes_watch_only_dashpay_external_utxos() {
+        let (manager, signer) =
+            split_asset_lock_manager_dashpay(15_000_000, 50_000_000, DashpayLeg::ExternalAccount)
+                .await;
+        let external_outpoints =
+            dashpay_account_outpoints(&manager, DashpayLeg::ExternalAccount).await;
+        assert!(
+            !external_outpoints.is_empty(),
+            "fixture must seed at least one watch-only external UTXO"
+        );
+
+        let (tx, _path) = manager
+            .build_asset_lock_transaction(
+                10_000_000,
+                0,
+                AssetLockFundingType::AssetLockShieldedAddressTopUp,
+                0,
+                &signer,
+            )
+            .await
+            .expect("asset lock must build from signable BIP44 funds alone");
+
+        for op in &external_outpoints {
+            assert!(
+                !tx.input.iter().any(|i| i.previous_output == *op),
+                "watch-only external UTXO {op} must be excluded from asset-lock funding \
+                 (no invalid-signature input reachable)"
+            );
+            assert!(
+                dashpay_has_utxo(&manager, DashpayLeg::ExternalAccount, op).await,
+                "excluded external UTXO {op} must remain unspent"
+            );
+        }
+    }
+
+    /// Watch-only external coins must not be *borrowed* to cover a shortfall.
+    /// Signable BIP44 (0.05 DASH) alone is too small for the 0.1-DASH shield;
+    /// the only way to cover it would be to (wrongly) spend the 0.5-DASH
+    /// watch-only external UTXO. The build must FAIL with the typed
+    /// insufficient-funds error rather than emit an invalid-signature input.
+    #[tokio::test]
+    async fn asset_lock_funding_cannot_borrow_watch_only_dashpay_external_utxos() {
+        let (manager, signer) =
+            split_asset_lock_manager_dashpay(5_000_000, 50_000_000, DashpayLeg::ExternalAccount)
+                .await;
+
+        let result = manager
+            .build_asset_lock_transaction(
+                10_000_000,
+                0,
+                AssetLockFundingType::AssetLockShieldedAddressTopUp,
+                0,
+                &signer,
+            )
+            .await;
+
+        assert!(
+            matches!(
+                result,
+                Err(PlatformWalletError::AssetLockInsufficientFunds { .. })
+            ),
+            "must not fund an asset lock from watch-only external coins; got {result:?}"
+        );
+    }
+
+    /// Heavy-mixer CoinJoin discovery (dashpay/dash-wallet#1507): the CoinJoin
+    /// account's default gap limit must watch a discovery window wide enough to
+    /// bridge the address gaps a heavy mixer leaves — matched to dashj's
+    /// ~100-key lookahead. Index 50 is beyond the OLD 30-address window; a fresh
+    /// account must pre-generate it (so the BIP158 filter watches it) and
+    /// recognize a tx paying it. On the old gap of 30 the address was never
+    /// watched, so txs at far CoinJoin indices were skipped entirely — the
+    /// starvation that survived a clean re-creation + full rescan, missing both
+    /// the txs that created far-index UTXOs and the txs that spent nearer ones.
+    #[tokio::test]
+    async fn coinjoin_gap_limit_discovers_addresses_beyond_the_old_window() {
+        use key_wallet::managed_account::address_pool::AddressPoolType;
+        use key_wallet::managed_account::managed_account_trait::ManagedAccountTrait;
+        use key_wallet::transaction_checking::{
+            BlockInfo, TransactionContext, WalletTransactionChecker,
+        };
+
+        // Fresh wallet (BIP44 funded, CoinJoin account provisioned but empty).
+        let (wallet_manager, wallet_id, _signer) =
+            crate::test_support::split_funded_wallet_manager_many_coinjoin(9_000_000, &[]).await;
+
+        // `far_index` sits past the old 30-address gap but within dashj's window.
+        let far_index: u32 = 50;
+        let far_address = {
+            let wm = wallet_manager.read().await;
+            let (_, info) = wm.get_wallet_and_info(&wallet_id).expect("wallet present");
+            let cj = info
+                .core_wallet
+                .accounts
+                .coinjoin_accounts
+                .get(&0)
+                .expect("coinjoin account 0");
+            assert_eq!(
+                cj.gap_limit(),
+                Some(100),
+                "CoinJoin gap limit must match dashj's lookahead (100)"
+            );
+            let external = cj
+                .managed_account_type()
+                .address_pools()
+                .into_iter()
+                .find(|p| p.pool_type == AddressPoolType::External)
+                .expect("external CoinJoin pool");
+            // The load-bearing assertion: index 50 is pre-generated (and thus
+            // filter-watched) ONLY because the gap was widened. On the old gap
+            // of 30 this is `None` and the address below can't be fetched.
+            external
+                .address_at_index(far_index)
+                .expect("index 50 must be pre-generated with the widened CoinJoin gap")
+        };
+
+        // A tx paying the far-index CoinJoin address must be discovered and its
+        // UTXO tracked — proving the filter watched an address the old window
+        // would have missed.
+        let tx = Transaction::dummy(&far_address, 0..1, &[12_345_678]);
+        let result = {
+            let mut wm = wallet_manager.write().await;
+            let (wallet, info) = wm
+                .get_wallet_mut_and_info_mut(&wallet_id)
+                .expect("wallet present");
+            info.core_wallet
+                .check_core_transaction(
+                    &tx,
+                    TransactionContext::InChainLockedBlock(BlockInfo::new(
+                        5,
+                        dashcore::BlockHash::from_raw_hash(dashcore::hashes::Hash::all_zeros()),
+                        1_700_002_000,
+                    )),
+                    wallet,
+                    true,
+                    true,
+                )
+                .await
+        };
+        assert!(
+            result.is_relevant,
+            "a payment to the far-index CoinJoin address must be discovered"
+        );
+        assert!(result.is_new_transaction);
+
+        let wm = wallet_manager.read().await;
+        let (_, info) = wm.get_wallet_and_info(&wallet_id).expect("wallet present");
+        let cj = info
+            .core_wallet
+            .accounts
+            .coinjoin_accounts
+            .get(&0)
+            .expect("coinjoin account 0");
+        assert!(
+            cj.utxos.values().any(|u| u.txout.value == 12_345_678),
+            "the far-index CoinJoin UTXO must be tracked after discovery"
+        );
     }
 }

--- a/packages/rs-platform-wallet/src/wallet/asset_lock/build.rs
+++ b/packages/rs-platform-wallet/src/wallet/asset_lock/build.rs
@@ -392,6 +392,32 @@ impl<B: TransactionBroadcaster + ?Sized> AssetLockManager<B> {
             "single-account asset-lock funding: selecting + signing (LargestFirst)"
         );
 
+        // Resolve the wallet-level `Account` whose account-level derivation path
+        // equals `funding_path` — the SELECTED account's own signing-side account.
+        // `set_funding` calls `funds_acc.next_change_address(Some(&acc.account_xpub))`
+        // BEFORE the `set_change_address` override below, so `acc` MUST be the
+        // selected account, not the BIP44 change account. Passing the BIP44 xpub
+        // for an explicitly-selected Standard BIP32 account with no pre-generated
+        // unused internal address makes key-wallet derive `[1, index]` from the
+        // wrong xpub and record it under the BIP32 account's path — poisoning that
+        // pool so a later normal BIP32 send can use a change entry whose signer key
+        // does not match the address (dashpay/platform#4184 review). The change
+        // OUTPUT of this transaction is still routed to the transparent BIP44 sink
+        // by `set_change_address` regardless. For the default BIP44 account this
+        // resolves to `bip44_acc` itself (unchanged behavior); for a non-Standard
+        // (CoinJoin / DashPay) account `next_change_address` fails and is swallowed
+        // to `None` so the xpub is immaterial, and the `bip44_acc` fallback (no
+        // matching wallet account found) preserves the prior behavior.
+        let funding_wallet_acc = wallet
+            .all_accounts()
+            .into_iter()
+            .find(|a| {
+                a.derivation_path()
+                    .map(|p| p == funding_path)
+                    .unwrap_or(false)
+            })
+            .unwrap_or(&bip44_acc);
+
         let builder = TransactionBuilder::new()
             .set_fee_rate(FeeRate::new(fee_per_kb))
             .set_current_height(height)
@@ -419,8 +445,11 @@ impl<B: TransactionBroadcaster + ?Sized> AssetLockManager<B> {
             // them across build → broadcast. `set_funding` also seeds a change
             // address, but for a non-Standard (CoinJoin / DashPay) account that
             // derivation fails and is swallowed to `None`; we override it next
-            // with the transparent BIP44 change sink regardless.
-            .set_funding(selected, &bip44_acc)
+            // with the transparent BIP44 change sink regardless. `funding_wallet_acc`
+            // is the SELECTED account's own wallet-level `Account` (see above), so
+            // its xpub — not the BIP44 change account's — governs any pool mutation
+            // `set_funding` performs on `selected`.
+            .set_funding(selected, funding_wallet_acc)
             .set_change_address(change_addr)
             .require_final_inputs();
 

--- a/packages/rs-platform-wallet/src/wallet/asset_lock/build.rs
+++ b/packages/rs-platform-wallet/src/wallet/asset_lock/build.rs
@@ -2935,6 +2935,115 @@ mod tests {
         );
     }
 
+    /// A [`WalletSigner`] that records every `public_key` request and answers
+    /// only the FIRST one — every later request is a hard error. A delegated
+    /// build can therefore only succeed if the credit key it needs is served
+    /// from the prefetch cache rather than re-requested downstream.
+    struct RecordingCreditKeySigner {
+        inner: WalletSigner,
+        public_key_requests: Arc<Mutex<Vec<DerivationPath>>>,
+    }
+
+    #[async_trait::async_trait]
+    impl Signer for RecordingCreditKeySigner {
+        type Error = String;
+
+        fn supported_methods(&self) -> &[key_wallet::signer::SignerMethod] {
+            self.inner.supported_methods()
+        }
+
+        async fn sign_ecdsa(
+            &self,
+            path: &DerivationPath,
+            sighash: [u8; 32],
+        ) -> Result<
+            (
+                dashcore::secp256k1::ecdsa::Signature,
+                dashcore::secp256k1::PublicKey,
+            ),
+            Self::Error,
+        > {
+            self.inner.sign_ecdsa(path, sighash).await
+        }
+
+        async fn public_key(
+            &self,
+            path: &DerivationPath,
+        ) -> Result<dashcore::secp256k1::PublicKey, Self::Error> {
+            let is_first = {
+                let mut seen = self.public_key_requests.lock().expect("requests lock");
+                seen.push(path.clone());
+                seen.len() == 1
+            };
+            if !is_first {
+                return Err(format!(
+                    "underlying signer re-queried for {path} after the prefetch"
+                ));
+            }
+            self.inner.public_key(path).await
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl ExtendedPubKeySigner for RecordingCreditKeySigner {
+        async fn extended_public_key(
+            &self,
+            path: &DerivationPath,
+        ) -> Result<key_wallet::bip32::ExtendedPubKey, Self::Error> {
+            self.inner.extended_public_key(path).await
+        }
+    }
+
+    /// dashpay/platform#4184 review: the delegated builder must be served the
+    /// credit key from [`PrefetchedCreditKeySigner`]'s cache.
+    ///
+    /// The sibling failure test above only proves that a *prefetch* failure is
+    /// reservation-free — its signer rejects every `public_key` call, so that
+    /// build dies during the up-front prefetch and the wrapper is never
+    /// exercised. This pins the load-bearing other half: the prefetch asks the
+    /// underlying signer for exactly ONE key, that key's path is exactly the
+    /// credit path the builder returns, and the builder's own later request is
+    /// answered from cache without touching the underlying signer again.
+    ///
+    /// This fails if the prefetch and delegated paths ever diverge (the
+    /// wrapper's `*path == self.path` guard misses, so the request delegates
+    /// and hits the poisoned second call) or if the wrapper stops caching.
+    #[tokio::test]
+    async fn delegated_builder_serves_credit_key_from_prefetch_cache() {
+        let (manager, signer, _persistence) =
+            funded_asset_lock_manager(Arc::new(AlwaysOkBroadcaster)).await;
+
+        let requests = Arc::new(Mutex::new(Vec::new()));
+        let recording = RecordingCreditKeySigner {
+            inner: signer.clone(),
+            public_key_requests: Arc::clone(&requests),
+        };
+
+        let (_tx, credit_path) = manager
+            .build_asset_lock_transaction(
+                5_000_000,
+                0,
+                AssetLockFundingType::IdentityRegistration,
+                0,
+                &recording,
+                None,
+            )
+            .await
+            .expect("the delegated build must succeed when the credit key is cached");
+
+        let seen = requests.lock().expect("requests lock").clone();
+        assert_eq!(
+            seen.len(),
+            1,
+            "the underlying signer must be asked for a public key exactly once (the \
+             prefetch) — the builder's own credit-key request must hit the cache, saw {seen:?}"
+        );
+        assert_eq!(
+            seen[0], credit_path,
+            "the prefetched path must be exactly the credit path the builder returns"
+        );
+    }
+
     /// dashpay/platform#4184 review: an explicitly-selected **Standard BIP32**
     /// funding account must have its own xpub passed to `set_funding`.
     ///

--- a/packages/rs-platform-wallet/src/wallet/asset_lock/build.rs
+++ b/packages/rs-platform-wallet/src/wallet/asset_lock/build.rs
@@ -36,81 +36,13 @@ use crate::wallet::platform_wallet::PlatformWalletInfo;
 use super::manager::{AssetLockManager, DEFAULT_FEE_PER_KB};
 use super::tracked::{AssetLockStatus, TrackedAssetLock};
 
-/// Caller consent for co-spending Core funds across privacy domains in a single
-/// asset-lock funding transaction (dashpay/platform#4184).
-///
-/// The multi-account shielded-funding builder unions spendable UTXOs across the
-/// wallet's funds accounts. Those accounts fall into distinct **privacy domains**
-/// (see [`PrivacyDomain`]); combining inputs from more than one domain into one
-/// L1 transaction irreversibly links those domains on-chain — and, because the
-/// key-wallet builder derives change only on transparent (BIP44/BIP32) accounts,
-/// a spend of non-transparent funds also emits transparent change. Shielding the
-/// resulting credit output afterward cannot undo that linkage.
-///
-/// The builder therefore defaults to [`CrossDomainConsent::Denied`] and confines
-/// selection to a single domain. [`CrossDomainConsent::Allowed`] is the explicit,
-/// per-request opt-in a host threads through only after obtaining user consent.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum CrossDomainConsent {
-    /// Default. Confine funding selection to a single privacy domain (the
-    /// transparent BIP44/BIP32 domain, which uniquely owns the change path). If
-    /// the transparent domain alone cannot cover the amount but the wallet-wide
-    /// union could, the builder returns
-    /// [`crate::error::PlatformWalletError::AssetLockCrossDomainConsentRequired`]
-    /// rather than silently linking domains.
-    Denied,
-    /// Explicit opt-in: allow the wallet-wide union of every spendable funding
-    /// domain (BIP44 + BIP32 + CoinJoin + DashPay-receiving) in one L1
-    /// transaction. Only pass this after the caller/user has consented to the
-    /// cross-domain linkage.
-    Allowed,
-}
-
-impl CrossDomainConsent {
-    /// Map a C-ABI `bool` opt-in flag (from the FFI boundary) to the typed
-    /// consent. `true` == the host obtained user consent to cross privacy
-    /// domains; `false` (the default) confines selection to one domain.
-    pub fn from_allow_flag(allow_cross_domain: bool) -> Self {
-        if allow_cross_domain {
-            Self::Allowed
-        } else {
-            Self::Denied
-        }
-    }
-}
-
-/// The privacy domain a funds account belongs to, for cross-domain co-spend
-/// gating (dashpay/platform#4184). Ordinary BIP44 and BIP32 funds share the one
-/// transparent domain (the reviewer's "ordinary BIP44/BIP32 funds"): it holds
-/// the primary funding account and is the sole source of change, so it is the
-/// only domain that can fund a lock without creating a cross-domain change
-/// output. CoinJoin (mixed) and DashPay-receiving (contact-scoped) funds are each
-/// their own domain.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-enum PrivacyDomain {
-    /// Ordinary BIP44 + BIP32 funds. Owns the change path.
-    Transparent,
-    /// DIP-9 CoinJoin mixed outputs.
-    CoinJoin,
-    /// DashPay receiving-funds account (ours; signable).
-    DashpayReceiving,
-}
-
-/// Classify a funds account into its [`PrivacyDomain`], or `None` for accounts
-/// that must never fund an asset lock (watch-only `DashpayExternalAccount` — a
-/// contact's coins the local mnemonic can't sign). Returning `None` here is what
-/// preserves the watch-only exclusion across every
-/// consent mode, replacing the old ad-hoc skip. Non-funds account types cannot
-/// appear in `all_funding_accounts()` and also map to `None` defensively.
-fn account_privacy_domain(managed_type: &ManagedAccountType) -> Option<PrivacyDomain> {
-    match managed_type {
-        ManagedAccountType::Standard { .. } => Some(PrivacyDomain::Transparent),
-        ManagedAccountType::CoinJoin { .. } => Some(PrivacyDomain::CoinJoin),
-        ManagedAccountType::DashpayReceivingFunds { .. } => Some(PrivacyDomain::DashpayReceiving),
-        // Watch-only contact coins — never signable locally, always excluded.
-        ManagedAccountType::DashpayExternalAccount { .. } => None,
-        _ => None,
-    }
+/// Whether a funds account can *sign* an asset-lock funding spend. Watch-only
+/// `DashpayExternalAccount`s hold a contact's coins the local mnemonic cannot
+/// sign, so they must never fund an asset lock — even when a caller names their
+/// derivation path explicitly. Every other funds-account type is locally
+/// signable.
+fn is_signable_funding_account(managed_type: &ManagedAccountType) -> bool {
+    !matches!(managed_type, ManagedAccountType::DashpayExternalAccount { .. })
 }
 
 // ---------------------------------------------------------------------------
@@ -141,10 +73,19 @@ impl<B: TransactionBroadcaster + ?Sized> AssetLockManager<B> {
     ///   Keychain-resolver vtable so private keys never cross the FFI
     ///   boundary.
     ///
-    /// Uses the default [`CrossDomainConsent::Denied`] privacy-domain rule: for
-    /// shielded funding, selection is confined to the transparent (BIP44/BIP32)
-    /// domain. Call [`Self::build_asset_lock_transaction_with_consent`] to opt
-    /// into a cross-domain union after obtaining user consent.
+    /// * `funding_path` — **Shielded funding only.** The account-level
+    ///   derivation path of the SINGLE funds account whose UTXOs fund the lock.
+    ///   `None` (the default) funds from the unmixed BIP44 account at
+    ///   `account_index`. `Some(path)` funds strictly from the one funds account
+    ///   whose account-level path equals `path` (e.g. the DIP-9 CoinJoin
+    ///   account), with change routed to the BIP44 account at `account_index`
+    ///   (non-Standard accounts such as CoinJoin cannot derive their own change
+    ///   — see [`Self::build_asset_lock_tx_from_selected_account`]). Both cases
+    ///   go through the single-account selector, so there is no union across
+    ///   accounts and no privacy-domain consent gate: the caller names exactly
+    ///   one funding source. Ignored for every non-shielded funding type, which
+    ///   always uses the single BIP44 account at `account_index` via the pinned
+    ///   key-wallet builder.
     pub async fn build_asset_lock_transaction<S: ExtendedPubKeySigner>(
         &self,
         amount_duffs: u64,
@@ -152,31 +93,7 @@ impl<B: TransactionBroadcaster + ?Sized> AssetLockManager<B> {
         funding_type: AssetLockFundingType,
         identity_index: u32,
         signer: &S,
-    ) -> Result<(Transaction, DerivationPath), PlatformWalletError> {
-        self.build_asset_lock_transaction_with_consent(
-            amount_duffs,
-            account_index,
-            funding_type,
-            identity_index,
-            signer,
-            CrossDomainConsent::Denied,
-        )
-        .await
-    }
-
-    /// Cross-domain-aware form of [`Self::build_asset_lock_transaction`]. The
-    /// extra `cross_domain` argument controls, for shielded funding only, whether
-    /// coin selection may co-spend across privacy domains (see
-    /// [`CrossDomainConsent`]). Every non-shielded funding type keeps the
-    /// single-BIP44-account path regardless of `cross_domain`.
-    pub async fn build_asset_lock_transaction_with_consent<S: ExtendedPubKeySigner>(
-        &self,
-        amount_duffs: u64,
-        account_index: u32,
-        funding_type: AssetLockFundingType,
-        identity_index: u32,
-        signer: &S,
-        cross_domain: CrossDomainConsent,
+        funding_path: Option<DerivationPath>,
     ) -> Result<(Transaction, DerivationPath), PlatformWalletError> {
         if amount_duffs == 0 {
             return Err(PlatformWalletError::AssetLockTransaction(
@@ -225,28 +142,26 @@ impl<B: TransactionBroadcaster + ?Sized> AssetLockManager<B> {
 
         // 3. Fund the asset lock.
         //
-        // Shielded funding (`AssetLockShieldedAddressTopUp`) must be able to
-        // draw on previously-mixed CoinJoin coins, which live on the DIP-9
-        // CoinJoin derivation account — the pinned key-wallet
-        // `build_asset_lock_with_signer` funds from a SINGLE BIP44 account
-        // only, so those coins counted in the balance but could not be
-        // shielded (dashpay/platform#4073). Route shielded funding through the
-        // union-of-accounts builder; every other funding type keeps the
-        // single-BIP44-account path (spending mixed CoinJoin coins into an
-        // identity registration would de-anonymize them — a deliberate
-        // privacy choice left out of scope here). The union builder itself
-        // applies the single-privacy-domain rule per `cross_domain`
-        // (dashpay/platform#4184).
+        // Shielded funding (`AssetLockShieldedAddressTopUp`) goes through the
+        // single-account selector: `Some(path)` funds strictly from the named
+        // account (e.g. the DIP-9 CoinJoin account, whose previously-mixed coins
+        // the pinned BIP44-only `build_asset_lock_with_signer` cannot reach —
+        // dashpay/platform#4073), and `None` funds from the unmixed BIP44
+        // account. No union across accounts, no consent gate. Every non-shielded
+        // funding type instead uses the single BIP44 account at `account_index`
+        // via the pinned builder and ignores `funding_path` (spending mixed
+        // CoinJoin coins into an identity registration would de-anonymize them,
+        // so non-shielded funding never leaves the BIP44 account).
         if funding_type == AssetLockFundingType::AssetLockShieldedAddressTopUp {
             return self
-                .build_asset_lock_tx_from_all_funding_accounts(
+                .build_asset_lock_tx_from_selected_account(
                     wallet,
                     info,
                     account_index,
                     vec![funding],
                     DEFAULT_FEE_PER_KB,
                     signer,
-                    cross_domain,
+                    funding_path,
                 )
                 .await;
         }
@@ -296,69 +211,50 @@ impl<B: TransactionBroadcaster + ?Sized> AssetLockManager<B> {
     }
 
     /// Build + sign an asset-lock transaction whose funding inputs are drawn
-    /// from the eligible spendable Core funds accounts (BIP44 + BIP32, plus
-    /// CoinJoin + DashPay-receiving when the caller consents), not just the
-    /// single BIP44 account at `account_index`.
+    /// **strictly from a single funds account** named by its account-level
+    /// derivation `funding_path` — e.g. the DIP-9 CoinJoin account — instead of
+    /// the BIP44 account at `account_index`.
     ///
-    /// ## Privacy-domain gate (dashpay/platform#4184)
+    /// This is the shielded-funding path for an *explicit* non-default funding
+    /// source (the dashpay/platform#4184 re-scope). There is no union across
+    /// accounts and no privacy-domain consent gate: the caller selects exactly
+    /// one account by path, and only that account's UTXOs fund the lock. If the
+    /// selected account cannot cover the lock (+ fee), the build fails with
+    /// [`PlatformWalletError::AssetLockInsufficientFunds`] rather than silently
+    /// topping up from another account.
     ///
-    /// The eligible set is governed by `cross_domain`. Funds accounts fall into
-    /// distinct **privacy domains** (see [`PrivacyDomain`]): the transparent
-    /// BIP44/BIP32 domain, the CoinJoin (mixed) domain, and the DashPay-receiving
-    /// domain. By default ([`CrossDomainConsent::Denied`]) selection is confined
-    /// to the transparent domain — it holds the primary account and is the only
-    /// domain that can supply change without linking domains (key-wallet derives
-    /// change only on transparent accounts). If the transparent domain alone
-    /// cannot cover the amount but the wallet-wide union could, the method returns
-    /// [`PlatformWalletError::AssetLockCrossDomainConsentRequired`]. With
-    /// [`CrossDomainConsent::Allowed`] the full signable union participates — the
-    /// original dashpay/platform#4073 behaviour — so a host can shield
-    /// previously-mixed CoinJoin coins after obtaining explicit user consent.
+    /// ## Why the pinned single-account builder can't do this (dashpay/platform#4073)
     ///
-    /// ## Why the union path exists (dashpay/platform#4073)
+    /// `ManagedWalletInfo::build_asset_lock_with_signer` funds from exactly ONE
+    /// BIP44 *standard* account (`standard_bip44_accounts[account_index]`), so
+    /// previously-mixed CoinJoin coins — which live on the DIP-9 CoinJoin
+    /// account — are unreachable through it. This method composes the key-wallet
+    /// `TransactionBuilder` directly: it seeds the selected account's spendable
+    /// UTXOs as explicit inputs (`add_inputs`) and signs with a resolver over
+    /// that account's addresses. The credit-output key is still derived from the
+    /// shielded-topup account exactly as the single-account builder does (peek
+    /// path → signer pubkey → mark used), so the returned `DerivationPath` lines
+    /// up with the credit-output script the caller already peeked.
     ///
-    /// The pinned key-wallet `ManagedWalletInfo::build_asset_lock_with_signer`
-    /// funds an asset lock from exactly ONE BIP44 standard account: it calls
-    /// `TransactionBuilder::set_funding` on
-    /// `standard_bip44_accounts[account_index]` and signs with a
-    /// single-account path resolver (`funds_acc.address_derivation_path`).
-    /// Previously-mixed CoinJoin coins live on the DIP-9 CoinJoin derivation
-    /// account (`coinjoin_accounts`), so they are counted in the wallet
-    /// balance (which sums `all_funding_accounts`) yet were invisible to the
-    /// asset-lock coin selector — shielding failed with a coin-selection
-    /// "Insufficient funds" even though the wallet-wide balance covered the
-    /// amount.
+    /// ## Change routing (structural BIP44 dependency)
     ///
-    /// This method keeps `account_index` as the PRIMARY account (its
-    /// reservation ledger gates concurrent primary-account builds, and change
-    /// flows back to it via `set_funding`'s change address) but ADDS the
-    /// spendable UTXOs of every other funds account as explicit builder
-    /// inputs (`add_inputs`), and signs with a resolver that spans all funds
-    /// accounts. The credit-output key is still derived from the
-    /// shielded-topup account exactly as the single-account builder does
-    /// (peek path → signer pubkey → mark used), so the returned
-    /// `DerivationPath` lines up with the credit-output script the caller
-    /// already peeked.
+    /// The pinned key-wallet derives change addresses only for *Standard*
+    /// (BIP44/BIP32) accounts — `ManagedCoreFundsAccount::next_change_address`
+    /// hard-errors ("Cannot generate change address for non-standard account
+    /// type") for CoinJoin / DashPay-receiving accounts. A lock funded from a
+    /// non-Standard account therefore MUST route its change to a Standard
+    /// account; this method uses the BIP44 account at `account_index` as that
+    /// change sink (the same change model the previous multi-account builder
+    /// used). When the selected account is itself the BIP44 `account_index`
+    /// account, this reduces to funding and change on that one account.
     ///
-    /// ## Interim caveat (superseded by the upstream fix)
+    /// ## Reservations
     ///
-    /// The clean long-term fix belongs upstream in key-wallet
-    /// (`build_asset_lock_with_signer` gathering inputs + reservations across
-    /// accounts). Until that pin bump lands, this workspace composition makes
-    /// CoinJoin funds shieldable today. `TransactionBuilder::set_funding`
-    /// captures only the PRIMARY account's `ReservationSet` (the type is
-    /// `pub(crate)` in key-wallet, so this crate cannot reserve per-account),
-    /// so inputs selected from non-primary accounts are recorded in the
-    /// primary account's reservation ledger rather than their own. They are
-    /// therefore not protected against a concurrent build on their own
-    /// account for the brief window before the broadcast tx is processed back
-    /// into the wallet (which releases the outpoints from every account's
-    /// ledger). Shielded funding is single-flighted under `shield_guard` and
-    /// the whole build runs under the wallet write lock, and the app issues no
-    /// concurrent non-shielded spend on the CoinJoin/BIP32 accounts, so the
-    /// race window is not reachable in practice.
+    /// The whole build runs under the wallet write lock and shielded funding is
+    /// single-flighted under `shield_guard`, so no concurrent build can race the
+    /// selected account's UTXOs; the builder runs without a reservation set.
     #[allow(clippy::too_many_arguments)]
-    async fn build_asset_lock_tx_from_all_funding_accounts<S: ExtendedPubKeySigner>(
+    async fn build_asset_lock_tx_from_selected_account<S: ExtendedPubKeySigner>(
         &self,
         wallet: &Wallet,
         info: &mut PlatformWalletInfo,
@@ -366,140 +262,102 @@ impl<B: TransactionBroadcaster + ?Sized> AssetLockManager<B> {
         credit_output_fundings: Vec<CreditOutputFunding>,
         fee_per_kb: u64,
         signer: &S,
-        cross_domain: CrossDomainConsent,
+        funding_path: Option<DerivationPath>,
     ) -> Result<(Transaction, DerivationPath), PlatformWalletError> {
-        use std::collections::{HashMap, HashSet};
+        use std::collections::HashMap;
 
         let target_duffs: u64 = credit_output_fundings.iter().map(|f| f.output.value).sum();
         let height = info.core_wallet.last_processed_height();
-        let allow_cross_domain = matches!(cross_domain, CrossDomainConsent::Allowed);
-        tracing::debug!(
-            target_duffs,
-            height,
-            primary_account_index = account_index,
-            allow_cross_domain,
-            funding_accounts = info.core_wallet.accounts.all_funding_accounts().len(),
-            "multi-account asset-lock funding: enumerating spendable funds accounts"
-        );
+        let network = info.core_wallet.network();
 
-        // Single-privacy-domain gate (dashpay/platform#4184). Total the spendable
-        // value per privacy domain: `transparent_total` is the BIP44/BIP32 domain
-        // (which holds the primary account and is the ONLY domain that can supply
-        // change without linking domains), and `union_total` sums every SIGNABLE
-        // domain (transparent + CoinJoin + DashPay-receiving). Watch-only
-        // `DashpayExternalAccount` UTXOs are excluded here by
-        // `account_privacy_domain` returning `None` — the same ownership carve-out
-        // as before, now expressed through the domain map.
-        let mut transparent_total: u64 = 0;
-        let mut union_total: u64 = 0;
-        for acc in info.core_wallet.accounts.all_funding_accounts() {
-            let Some(domain) = account_privacy_domain(acc.managed_account_type()) else {
-                continue;
-            };
-            let acc_spendable: u64 = acc
-                .spendable_utxos(height)
-                .into_iter()
-                .fold(0u64, |sum, u| sum.saturating_add(u.value()));
-            union_total = union_total.saturating_add(acc_spendable);
-            if domain == PrivacyDomain::Transparent {
-                transparent_total = transparent_total.saturating_add(acc_spendable);
-            }
-        }
+        // Resolve the target account-level path: an explicit `funding_path`, or
+        // (the default) the unmixed BIP44 account at `account_index`. Routing the
+        // default through this same builder keeps error typing uniform — a
+        // shortfall always surfaces as the typed `AssetLockInsufficientFunds`
+        // (via `map_builder_error`), the pre-existing shielded-funding contract.
+        let funding_path = match funding_path {
+            Some(p) => p,
+            None => info
+                .core_wallet
+                .accounts
+                .standard_bip44_accounts
+                .get(&account_index)
+                .ok_or_else(|| {
+                    PlatformWalletError::AssetLockTransaction(format!(
+                        "BIP44 account {account_index} not found for default asset-lock funding"
+                    ))
+                })?
+                .managed_account_type()
+                .to_account_type()
+                .derivation_path(network)
+                .map_err(|e| {
+                    PlatformWalletError::AssetLockTransaction(format!(
+                        "failed to derive the unmixed BIP44 account-level path: {e}"
+                    ))
+                })?,
+        };
 
-        // Default rule: confine selection to the transparent domain. If a single
-        // transparent-domain spend cannot cover the lock but adding
-        // CoinJoin/DashPay-receiving funds would, refuse with a typed, actionable
-        // error rather than silently crossing domains (which would irreversibly
-        // link them and emit BIP44 change from non-transparent inputs). The host
-        // obtains user consent and re-issues with `CrossDomainConsent::Allowed`.
-        // Note: coin selection accounts for the L1 fee, so `transparent_total`
-        // being >= `target_duffs` here is necessary but not sufficient; a
-        // fee-driven shortfall surfaces from the builder below and is
-        // reclassified to consent-required at that site when the union covers
-        // the fee-inclusive amount. This gate handles the plain-amount case
-        // early, before any selection work.
-        if !allow_cross_domain && transparent_total < target_duffs && union_total >= target_duffs {
-            tracing::debug!(
-                transparent_total,
-                union_total,
-                target_duffs,
-                "multi-account asset-lock funding: refusing cross-domain co-spend without consent"
-            );
-            return Err(PlatformWalletError::AssetLockCrossDomainConsentRequired {
-                transparent_available: transparent_total,
-                cross_domain_available: union_total,
-                required: target_duffs,
-            });
-        }
-
-        // Snapshot the primary account's spendable outpoints so the union
-        // sweep below does not add them twice: `set_funding` already seeds
-        // them, and `add_inputs` must contribute only the OTHER accounts.
-        let primary_outpoints: HashSet<OutPoint> = info
-            .core_wallet
-            .accounts
-            .standard_bip44_accounts
-            .get(&account_index)
-            .map(|a| {
-                a.spendable_utxos(height)
-                    .into_iter()
-                    .map(|u| u.outpoint)
-                    .collect()
-            })
-            .unwrap_or_default();
-
-        // Build, from an immutable borrow of the ELIGIBLE funds accounts:
-        //   (a) an owned `Address -> DerivationPath` resolver covering every
-        //       spendable input across the eligible accounts, so signing can
-        //       resolve a key for an input selected from any of them; and
-        //   (b) the explicit extra inputs (eligible non-primary accounts).
-        //
-        // Eligibility follows the privacy-domain gate: with consent, every
-        // signable domain participates (the full union — the dashpay/platform#4073
-        // behaviour); by default only the transparent (BIP44/BIP32) domain does.
-        // Watch-only `DashpayExternalAccount` UTXOs are never eligible in either
-        // mode (`account_privacy_domain` returns `None`), so a naive `LargestFirst`
-        // can no longer grab a contact's coins and sign them with the wrong local
-        // key.
+        // Immutable pass over the funds accounts: find the ONE account whose
+        // account-level derivation path equals `funding_path`, and collect its
+        // spendable UTXOs plus an `Address -> DerivationPath` resolver so signing
+        // can resolve a key for any input selected from it. Watch-only
+        // `DashpayExternalAccount`s are never fundable (the local mnemonic can't
+        // sign them) — refuse even when their path is named explicitly.
         let mut path_map: HashMap<DashAddress, DerivationPath> = HashMap::new();
-        let mut extra_inputs: Vec<Utxo> = Vec::new();
+        let mut selected_inputs: Vec<Utxo> = Vec::new();
         let mut selected_value: u64 = 0;
-        let mut selected_count: usize = 0;
+        let mut matched = false;
         for acc in info.core_wallet.accounts.all_funding_accounts() {
-            let Some(domain) = account_privacy_domain(acc.managed_account_type()) else {
-                continue;
-            };
-            if !allow_cross_domain && domain != PrivacyDomain::Transparent {
+            let acc_path = acc
+                .managed_account_type()
+                .to_account_type()
+                .derivation_path(network)
+                .map_err(|e| {
+                    PlatformWalletError::AssetLockTransaction(format!(
+                        "failed to derive account-level path for a funds account: {e}"
+                    ))
+                })?;
+            if acc_path != funding_path {
                 continue;
             }
+            if !is_signable_funding_account(acc.managed_account_type()) {
+                return Err(PlatformWalletError::AssetLockTransaction(format!(
+                    "funding derivation path {funding_path} names a watch-only account whose \
+                     coins the local wallet cannot sign; choose a signable funds account"
+                )));
+            }
+            matched = true;
             for utxo in acc.spendable_utxos(height) {
                 selected_value = selected_value.saturating_add(utxo.value());
-                selected_count += 1;
                 if let Some(path) = acc.address_derivation_path(&utxo.address) {
                     path_map.insert(utxo.address.clone(), path);
                 }
-                if !primary_outpoints.contains(&utxo.outpoint) {
-                    extra_inputs.push(utxo.clone());
-                }
+                selected_inputs.push(utxo.clone());
             }
         }
+        if !matched {
+            return Err(PlatformWalletError::AssetLockTransaction(format!(
+                "no spendable funds account matches funding derivation path {funding_path}"
+            )));
+        }
         tracing::debug!(
-            selected_count,
+            target_duffs,
+            height,
+            %funding_path,
             selected_value,
-            transparent_total,
-            union_total,
-            allow_cross_domain,
-            primary_count = primary_outpoints.len(),
-            extra_count = extra_inputs.len(),
+            selected_inputs = selected_inputs.len(),
             resolver_entries = path_map.len(),
-            "multi-account asset-lock funding: eligible UTXO set assembled"
+            "single-account asset-lock funding: selected account UTXO set assembled"
         );
 
+        // Change must land on a Standard (BIP44) account: non-Standard accounts
+        // (CoinJoin / DashPay-receiving) cannot derive change. Route it to the
+        // BIP44 account at `account_index`.
         let acc = wallet
             .get_bip44_account(account_index)
             .ok_or_else(|| {
                 PlatformWalletError::AssetLockTransaction(format!(
-                    "BIP44 account {account_index} not found for asset-lock funding"
+                    "BIP44 account {account_index} not found for asset-lock change routing"
                 ))
             })?
             .clone();
@@ -508,85 +366,65 @@ impl<B: TransactionBroadcaster + ?Sized> AssetLockManager<B> {
             .map(|f| f.output.clone())
             .collect();
 
-        // Seed the primary account (inputs + change address + reservations),
-        // then append the union of the other accounts' spendable inputs. The
-        // `&mut` borrow of the primary account is scoped to this block; the
-        // returned builder owns cloned inputs / reservations / change address,
-        // so no account borrow is held across the signer await below.
-        let builder = {
-            let primary_funds = info
+        // Derive the change address from the BIP44 account (scoped `&mut`
+        // borrow; the builder below owns the cloned change address, so no
+        // account borrow is held across the signer await).
+        let change_addr = {
+            let change_acc = info
                 .core_wallet
                 .accounts
                 .standard_bip44_accounts
                 .get_mut(&account_index)
                 .ok_or_else(|| {
                     PlatformWalletError::AssetLockTransaction(format!(
-                        "managed BIP44 account {account_index} not found for asset-lock funding"
+                        "managed BIP44 account {account_index} not found for asset-lock change routing"
                     ))
                 })?;
-            TransactionBuilder::new()
-                .set_fee_rate(FeeRate::new(fee_per_kb))
-                .set_current_height(height)
-                // LargestFirst, NOT the `TransactionBuilder::new()` default
-                // `BranchAndBound`. This is load-bearing, not an optimization:
-                // BranchAndBound routes to a recursive exact-match subset-sum
-                // (`CoinSelector::find_exact_match`) whose search space is
-                // EXPONENTIAL in the number of sub-target UTXOs. The
-                // single-BIP44-account path tolerates it (a handful of UTXOs),
-                // but a CoinJoin account holds many small mixed denominations
-                // (0.001 / 0.01 / 0.1 DASH ...); feeding that whole set to
-                // BranchAndBound hangs the FFI call for minutes with no logs and
-                // no broadcast (observed on-device, dashpay/platform#4073
-                // follow-up). LargestFirst uses the linear greedy accumulator
-                // (`accumulate_coins_with_size`), which also minimizes the input
-                // count — fewer signer round-trips (each input is one resolver
-                // upcall) and a smaller tx/fee.
-                .set_selection_strategy(SelectionStrategy::LargestFirst)
-                .set_special_payload(TransactionPayload::AssetLockPayloadType(
-                    AssetLockPayload::new(credit_outputs),
-                ))
-                .set_funding(primary_funds, &acc)
-                .add_inputs(extra_inputs)
-                .require_final_inputs()
+            change_acc
+                .next_change_address(Some(&acc.account_xpub), true)
+                .map_err(|e| {
+                    PlatformWalletError::AssetLockTransaction(format!(
+                        "failed to derive change address on BIP44 account {account_index}: {e}"
+                    ))
+                })?
         };
+
+        let builder = TransactionBuilder::new()
+            .set_fee_rate(FeeRate::new(fee_per_kb))
+            .set_current_height(height)
+            // LargestFirst, NOT the `TransactionBuilder::new()` default
+            // `BranchAndBound`. This is load-bearing, not an optimization:
+            // BranchAndBound routes to a recursive exact-match subset-sum
+            // (`CoinSelector::find_exact_match`) whose search space is
+            // EXPONENTIAL in the number of sub-target UTXOs. A CoinJoin account
+            // holds many small mixed denominations (0.001 / 0.01 / 0.1 DASH ...);
+            // feeding that whole set to BranchAndBound hangs the FFI call for
+            // minutes with no logs and no broadcast (observed on-device,
+            // dashpay/platform#4073 follow-up). LargestFirst uses the linear
+            // greedy accumulator (`accumulate_coins_with_size`), which also
+            // minimizes the input count — fewer signer round-trips (each input is
+            // one resolver upcall) and a smaller tx/fee.
+            .set_selection_strategy(SelectionStrategy::LargestFirst)
+            .set_special_payload(TransactionPayload::AssetLockPayloadType(
+                AssetLockPayload::new(credit_outputs),
+            ))
+            .set_change_address(change_addr)
+            .add_inputs(selected_inputs)
+            .require_final_inputs();
 
         tracing::debug!(
             target_duffs,
-            "multi-account asset-lock funding: selecting + signing (LargestFirst)"
+            "single-account asset-lock funding: selecting + signing (LargestFirst)"
         );
         let (transaction, fee) = builder
             .build_signed(signer, move |addr| path_map.get(&addr).cloned())
             .await
-            .map_err(|e| {
-                let mapped = map_builder_error(e, target_duffs);
-                // Fee-band consent reclassification: the pre-selection gate
-                // compares domain totals against the fee-EXCLUSIVE target, so a
-                // transparent total in [target, target+fee) slips past it and
-                // then fails selection on the fee. When the union would cover
-                // the fee-inclusive `required` that selection reported, the
-                // actionable answer is still consent — reclassify to the
-                // consent-required error so hosts prompt instead of
-                // dead-ending on "insufficient funds".
-                match mapped {
-                    PlatformWalletError::AssetLockInsufficientFunds { available, required }
-                        if !allow_cross_domain
-                            && union_total > available
-                            && union_total >= required =>
-                    {
-                        PlatformWalletError::AssetLockCrossDomainConsentRequired {
-                            transparent_available: available,
-                            cross_domain_available: union_total,
-                            required,
-                        }
-                    }
-                    other => other,
-                }
-            })?;
+            .map_err(|e| map_builder_error(e, target_duffs))?;
         tracing::debug!(
             selected_inputs = transaction.input.len(),
             fee,
             txid = %transaction.txid(),
-            "multi-account asset-lock funding: transaction built + signed"
+            "single-account asset-lock funding: transaction built + signed"
         );
 
         // Derive the single credit-output key from the shielded-topup account,
@@ -629,7 +467,7 @@ impl<B: TransactionBroadcaster + ?Sized> AssetLockManager<B> {
 
         tracing::debug!(
             selected_inputs = transaction.input.len(),
-            "multi-account asset-lock funding: credit-output key derived; returning built tx"
+            "single-account asset-lock funding: credit-output key derived; returning built tx"
         );
         Ok((transaction, path))
     }
@@ -1051,6 +889,11 @@ impl<B: TransactionBroadcaster + ?Sized> AssetLockManager<B> {
     ///   the registration index identifying which identity is being topped up).
     /// * `signer` — External ECDSA signer (Swift Keychain-backed in
     ///   production via `MnemonicResolverCoreSigner`).
+    /// * `funding_path` — Shielded funding only: the account-level derivation
+    ///   path of the single funds account to draw from (`None` = the unmixed
+    ///   BIP44 account at `account_index`). See
+    ///   [`Self::build_asset_lock_transaction`]. Ignored by non-shielded
+    ///   funding types.
     pub async fn create_funded_asset_lock_proof<S: ExtendedPubKeySigner>(
         &self,
         amount_duffs: u64,
@@ -1058,39 +901,16 @@ impl<B: TransactionBroadcaster + ?Sized> AssetLockManager<B> {
         funding_type: AssetLockFundingType,
         identity_index: u32,
         signer: &S,
-    ) -> Result<(dpp::prelude::AssetLockProof, DerivationPath, OutPoint), PlatformWalletError> {
-        self.create_funded_asset_lock_proof_with_consent(
-            amount_duffs,
-            account_index,
-            funding_type,
-            identity_index,
-            signer,
-            CrossDomainConsent::Denied,
-        )
-        .await
-    }
-
-    /// Cross-domain-aware form of [`Self::create_funded_asset_lock_proof`]. The
-    /// `cross_domain` consent is threaded down to the shielded union builder;
-    /// non-shielded funding types ignore it (they never leave the single BIP44
-    /// account). See [`CrossDomainConsent`].
-    pub async fn create_funded_asset_lock_proof_with_consent<S: ExtendedPubKeySigner>(
-        &self,
-        amount_duffs: u64,
-        account_index: u32,
-        funding_type: AssetLockFundingType,
-        identity_index: u32,
-        signer: &S,
-        cross_domain: CrossDomainConsent,
+        funding_path: Option<DerivationPath>,
     ) -> Result<(dpp::prelude::AssetLockProof, DerivationPath, OutPoint), PlatformWalletError> {
         let (path, out_point) = self
-            .broadcast_funded_asset_lock_with_consent(
+            .broadcast_funded_asset_lock(
                 amount_duffs,
                 account_index,
                 funding_type,
                 identity_index,
                 signer,
-                cross_domain,
+                funding_path,
             )
             .await?;
         let proof = self
@@ -1107,6 +927,10 @@ impl<B: TransactionBroadcaster + ?Sized> AssetLockManager<B> {
     /// lock (e.g. the inviter-side invitation row) between the broadcast and
     /// the potentially long proof wait in
     /// [`Self::wait_for_funded_asset_lock_proof`].
+    ///
+    /// `funding_path` (shielded funding only) selects the single funds account
+    /// to draw from; `None` = the unmixed BIP44 account at `account_index`. See
+    /// [`Self::build_asset_lock_transaction`].
     pub(crate) async fn broadcast_funded_asset_lock<S: ExtendedPubKeySigner>(
         &self,
         amount_duffs: u64,
@@ -1114,28 +938,7 @@ impl<B: TransactionBroadcaster + ?Sized> AssetLockManager<B> {
         funding_type: AssetLockFundingType,
         identity_index: u32,
         signer: &S,
-    ) -> Result<(DerivationPath, OutPoint), PlatformWalletError> {
-        self.broadcast_funded_asset_lock_with_consent(
-            amount_duffs,
-            account_index,
-            funding_type,
-            identity_index,
-            signer,
-            CrossDomainConsent::Denied,
-        )
-        .await
-    }
-
-    /// Cross-domain-aware form of [`Self::broadcast_funded_asset_lock`]. Threads
-    /// `cross_domain` to the shielded union builder (see [`CrossDomainConsent`]).
-    pub(crate) async fn broadcast_funded_asset_lock_with_consent<S: ExtendedPubKeySigner>(
-        &self,
-        amount_duffs: u64,
-        account_index: u32,
-        funding_type: AssetLockFundingType,
-        identity_index: u32,
-        signer: &S,
-        cross_domain: CrossDomainConsent,
+        funding_path: Option<DerivationPath>,
     ) -> Result<(DerivationPath, OutPoint), PlatformWalletError> {
         // Serialize build→persist so a concurrent build cannot interleave its
         // pool snapshot with ours. The snapshot is collected from live wallet
@@ -1168,13 +971,13 @@ impl<B: TransactionBroadcaster + ?Sized> AssetLockManager<B> {
 
         // 1. Build the asset lock transaction.
         let (tx, path) = self
-            .build_asset_lock_transaction_with_consent(
+            .build_asset_lock_transaction(
                 amount_duffs,
                 account_index,
                 funding_type,
                 identity_index,
                 signer,
-                cross_domain,
+                funding_path,
             )
             .await?;
 
@@ -1385,7 +1188,7 @@ mod tests {
     use crate::wallet::persister::WalletPersister;
     use crate::wallet::platform_wallet::PlatformWalletInfo;
     use crate::wallet::platform_wallet::WalletId;
-    use super::CrossDomainConsent;
+    use key_wallet::bip32::DerivationPath;
     use crate::{AssetLockFundingType, PlatformWalletError};
 
     /// prior-no-utxos-846 (dashpay/platform#4074): the zero-spendable-candidate
@@ -1545,6 +1348,7 @@ mod tests {
                 AssetLockFundingType::IdentityInvitation,
                 0,
                 &signer,
+                None,
             )
             .await;
 
@@ -1582,6 +1386,7 @@ mod tests {
                 AssetLockFundingType::IdentityRegistration,
                 0,
                 &signer,
+                None,
             )
             .await;
         assert!(
@@ -1617,6 +1422,7 @@ mod tests {
                 AssetLockFundingType::IdentityRegistration,
                 0,
                 &signer,
+                None,
             )
             .await;
         assert!(
@@ -1642,6 +1448,7 @@ mod tests {
                 AssetLockFundingType::IdentityRegistration,
                 0,
                 &signer,
+                None,
             )
             .await;
         assert!(
@@ -1677,6 +1484,7 @@ mod tests {
                 AssetLockFundingType::IdentityRegistration,
                 0,
                 &signer,
+                None,
             )
             .await;
         assert!(
@@ -1751,6 +1559,7 @@ mod tests {
                 AssetLockFundingType::IdentityRegistration,
                 0,
                 &signer,
+                None,
             )
             .await;
         assert!(
@@ -1783,6 +1592,7 @@ mod tests {
                 AssetLockFundingType::IdentityRegistration,
                 0,
                 &signer,
+                None,
             )
             .await;
         assert!(
@@ -1895,6 +1705,7 @@ mod tests {
                     AssetLockFundingType::IdentityInvitation,
                     0,
                     &signer_a,
+                    None,
                 )
                 .await
         });
@@ -1918,6 +1729,7 @@ mod tests {
                     AssetLockFundingType::IdentityInvitation,
                     0,
                     &signer,
+                    None,
                 )
                 .await
         });
@@ -2002,6 +1814,7 @@ mod tests {
                 AssetLockFundingType::IdentityInvitation,
                 0,
                 &signer,
+                None,
             )
             .await;
         match result {
@@ -2042,6 +1855,7 @@ mod tests {
                 AssetLockFundingType::IdentityRegistration,
                 0,
                 &signer,
+                None,
             )
             .await;
         assert!(
@@ -2073,6 +1887,7 @@ mod tests {
                 AssetLockFundingType::IdentityInvitation,
                 0,
                 &signer,
+                None,
             )
             .await
             .expect("broadcast half should succeed");
@@ -2127,6 +1942,7 @@ mod tests {
                 AssetLockFundingType::IdentityInvitation,
                 0,
                 &signer,
+                None,
             )
             .await
             .expect("invitation broadcast half succeeds");
@@ -2141,6 +1957,7 @@ mod tests {
                 AssetLockFundingType::IdentityRegistration,
                 0,
                 &signer,
+                None,
             )
             .await;
         match refused {
@@ -2170,6 +1987,7 @@ mod tests {
                     reclaim_target,
                     0,
                     &signer,
+                    None,
                 ),
             )
             .await;
@@ -2275,68 +2093,95 @@ mod tests {
         (bip44, coinjoin)
     }
 
-    /// The bug: shielded asset-lock funding must be able to spend
-    /// previously-mixed CoinJoin coins, not just the BIP44 slice. Split the
-    /// balance so NEITHER account alone can fund the lock (0.09 DASH each) and
-    /// require 0.15 DASH — coin selection must reach across both the BIP44 and
-    /// the DIP-9 CoinJoin account, and the mixed inputs must each be signed
-    /// under their own account's derivation path.
-    ///
-    /// Because BIP44 and CoinJoin are DIFFERENT privacy domains, this union is a
-    /// cross-domain co-spend and requires explicit consent (dashpay/platform#4184);
-    /// the test therefore drives the `CrossDomainConsent::Allowed` path.
+    /// The account-level derivation path of CoinJoin account 0 in the split
+    /// fixture — the `funding_path` a caller passes to fund a shielded lock
+    /// strictly from previously-mixed CoinJoin coins (dashpay/platform#4184).
+    async fn coinjoin_account_path(
+        manager: &AssetLockManager<AlwaysRejectedBroadcaster>,
+    ) -> DerivationPath {
+        use key_wallet::managed_account::managed_account_trait::ManagedAccountTrait;
+        let wm = manager.wallet_manager.read().await;
+        let (_, info) = wm
+            .get_wallet_and_info(&manager.wallet_id)
+            .expect("wallet present");
+        let network = info.core_wallet.network();
+        info.core_wallet
+            .accounts
+            .coinjoin_accounts
+            .get(&0)
+            .expect("coinjoin account 0 present")
+            .managed_account_type()
+            .to_account_type()
+            .derivation_path(network)
+            .expect("coinjoin account-level path")
+    }
+
+    /// dashpay/platform#4073, re-scoped by #4184: shielded asset-lock funding
+    /// must be able to spend previously-mixed CoinJoin coins — but now the caller
+    /// names that one account EXPLICITLY by its account-level derivation path,
+    /// with no union and no consent gate. Fund 0.15 DASH from a CoinJoin account
+    /// that holds 0.2 DASH: the inputs must come solely from CoinJoin (each signed
+    /// under its own path), the BIP44 slice must be untouched, and the change must
+    /// land on the transparent BIP44 account (CoinJoin cannot sink change).
     #[tokio::test]
-    async fn shielded_asset_lock_funds_from_bip44_and_coinjoin_union() {
-        // 0.09 DASH on BIP44, 0.09 DASH on CoinJoin; require 0.15 DASH.
-        let (manager, signer) = split_asset_lock_manager(9_000_000, 9_000_000).await;
+    async fn shielded_asset_lock_funds_from_explicit_coinjoin_path() {
+        // 0.09 DASH on BIP44, 0.2 DASH on CoinJoin; require 0.15 DASH from CoinJoin.
+        let (manager, signer) = split_asset_lock_manager(9_000_000, 20_000_000).await;
         let (bip44_outpoints, coinjoin_outpoints) = account_outpoints(&manager).await;
+        let coinjoin_path = coinjoin_account_path(&manager).await;
 
         let (tx, _path) = manager
-            .build_asset_lock_transaction_with_consent(
+            .build_asset_lock_transaction(
                 15_000_000,
                 0,
                 AssetLockFundingType::AssetLockShieldedAddressTopUp,
                 0,
                 &signer,
-                CrossDomainConsent::Allowed,
+                Some(coinjoin_path),
             )
             .await
-            .expect("shielded asset lock must fund from the BIP44 + CoinJoin union");
+            .expect("shielded asset lock must fund from the named CoinJoin account");
 
-        // Neither account alone covers 0.15 DASH, so both must be selected.
         let spent: std::collections::HashSet<OutPoint> =
             tx.input.iter().map(|i| i.previous_output).collect();
-        assert!(
-            spent.iter().any(|o| bip44_outpoints.contains(o)),
-            "expected at least one BIP44 input, tx spent {spent:?}"
-        );
         assert!(
             spent.iter().any(|o| coinjoin_outpoints.contains(o)),
             "expected at least one CoinJoin input (the #4073 fix), tx spent {spent:?}"
         );
+        assert!(
+            !spent.iter().any(|o| bip44_outpoints.contains(o)),
+            "explicit CoinJoin funding must NOT reach BIP44 inputs, tx spent {spent:?}"
+        );
 
-        // Per-account signing: every selected input, regardless of which
-        // account's derivation path it needed, must carry a signature.
+        // Change must land on the transparent BIP44 account (the OP_RETURN burn
+        // is the AssetLock output; any non-OP_RETURN output is wallet change).
+        let has_change = tx.output.iter().any(|o| !o.script_pubkey.is_op_return());
+        assert!(has_change, "a CoinJoin-funded lock must return change to BIP44");
+
+        // Per-account signing: every selected input must carry a signature.
         assert!(!tx.input.is_empty(), "asset lock must have selected inputs");
         for (i, txin) in tx.input.iter().enumerate() {
             assert!(
                 !txin.script_sig.is_empty(),
-                "input {i} ({}) has an empty script_sig — the cross-account \
-                 resolver failed to derive/sign its key",
+                "input {i} ({}) has an empty script_sig — the resolver failed to \
+                 derive/sign its key",
                 txin.previous_output
             );
         }
     }
 
-    /// The widening is deliberately scoped to shielded funding: spending mixed
-    /// CoinJoin coins into an identity registration would de-anonymize them.
-    /// With the balance split 0.09/0.09, an identity-registration lock for
-    /// 0.15 DASH must still fail (BIP44 alone is short and non-shielded funding
-    /// never reaches the union), regardless of consent.
+    /// The explicit-account funding is deliberately scoped to shielded funding:
+    /// spending mixed CoinJoin coins into an identity registration would
+    /// de-anonymize them. With 0.09 DASH on BIP44 and 0.2 DASH on CoinJoin, an
+    /// identity-registration lock for 0.15 DASH must still fail — BIP44 alone is
+    /// short, and a non-shielded funding type IGNORES `funding_path`, so naming
+    /// the CoinJoin account cannot pull those coins.
     #[tokio::test]
-    async fn non_shielded_asset_lock_stays_single_bip44_account() {
-        let (manager, signer) = split_asset_lock_manager(9_000_000, 9_000_000).await;
+    async fn non_shielded_asset_lock_ignores_funding_path() {
+        let (manager, signer) = split_asset_lock_manager(9_000_000, 20_000_000).await;
+        let coinjoin_path = coinjoin_account_path(&manager).await;
 
+        // Default (None): BIP44 alone is short, so it fails.
         let identity = manager
             .build_asset_lock_transaction(
                 15_000_000,
@@ -2344,6 +2189,7 @@ mod tests {
                 AssetLockFundingType::IdentityRegistration,
                 0,
                 &signer,
+                None,
             )
             .await;
         assert!(
@@ -2352,86 +2198,82 @@ mod tests {
              is short of 0.15 DASH, got {identity:?}"
         );
 
-        // Even with cross-domain consent, non-shielded funding stays single-BIP44.
-        let identity_consented = manager
-            .build_asset_lock_transaction_with_consent(
+        // Even when the CoinJoin account is named explicitly, non-shielded
+        // funding ignores `funding_path` and stays on the single BIP44 account.
+        let identity_pathed = manager
+            .build_asset_lock_transaction(
                 15_000_000,
                 0,
                 AssetLockFundingType::IdentityRegistration,
                 0,
                 &signer,
-                CrossDomainConsent::Allowed,
+                Some(coinjoin_path),
             )
             .await;
         assert!(
-            identity_consented.is_err(),
-            "identity registration must ignore cross-domain consent, got {identity_consented:?}"
+            identity_pathed.is_err(),
+            "identity registration must ignore an explicit funding_path, got {identity_pathed:?}"
         );
     }
 
-    /// Privacy-domain gate (dashpay/platform#4184): shielded funding whose
-    /// transparent (BIP44) slice alone cannot cover the amount, but whose
-    /// BIP44 + CoinJoin union can, must be REFUSED by default with the typed
-    /// [`PlatformWalletError::AssetLockCrossDomainConsentRequired`] — and must
-    /// SUCCEED once the caller passes `CrossDomainConsent::Allowed`.
+    /// No auto-union (dashpay/platform#4184 re-scope): funding never combines
+    /// accounts. With 0.09 DASH on BIP44 and 0.09 DASH on CoinJoin and a 0.15
+    /// DASH lock, NEITHER the default (BIP44) nor an explicit CoinJoin path can
+    /// cover it — each account alone is short, and there is no union to fall back
+    /// on. Both must fail with the typed `AssetLockInsufficientFunds`.
     #[tokio::test]
-    async fn shielded_asset_lock_cross_domain_refused_without_consent() {
-        // 0.09 DASH BIP44 (transparent) + 0.09 DASH CoinJoin; require 0.15 DASH.
-        // Transparent alone (0.09) is short; the union (0.18) covers it.
+    async fn shielded_asset_lock_never_unions_accounts() {
+        // 0.09 DASH BIP44 + 0.09 DASH CoinJoin; require 0.15 DASH.
         let (manager, signer) = split_asset_lock_manager(9_000_000, 9_000_000).await;
+        let coinjoin_path = coinjoin_account_path(&manager).await;
 
-        // Default (Denied): refused with the typed cross-domain error carrying
-        // the transparent-vs-union availability.
-        let refused = manager
+        // Default (None => BIP44): BIP44 alone is short, and CoinJoin is NOT
+        // auto-added.
+        let default_funded = manager
             .build_asset_lock_transaction(
                 15_000_000,
                 0,
                 AssetLockFundingType::AssetLockShieldedAddressTopUp,
                 0,
                 &signer,
+                None,
             )
             .await;
-        match refused {
-            Err(PlatformWalletError::AssetLockCrossDomainConsentRequired {
-                transparent_available,
-                cross_domain_available,
-                required,
-            }) => {
-                assert_eq!(transparent_available, 9_000_000, "transparent = BIP44 slice");
-                assert_eq!(cross_domain_available, 18_000_000, "union = BIP44 + CoinJoin");
-                assert_eq!(required, 15_000_000);
-            }
-            other => panic!(
-                "default funding must refuse the cross-domain co-spend with a typed \
-                 AssetLockCrossDomainConsentRequired, got {other:?}"
+        assert!(
+            matches!(
+                default_funded,
+                Err(PlatformWalletError::AssetLockInsufficientFunds { .. })
             ),
-        }
+            "default BIP44 funding must not silently union in CoinJoin, got {default_funded:?}"
+        );
 
-        // With consent: the union funds it.
-        let consented = manager
-            .build_asset_lock_transaction_with_consent(
+        // Explicit CoinJoin path: CoinJoin alone is short, and BIP44 is NOT
+        // auto-added either.
+        let coinjoin_funded = manager
+            .build_asset_lock_transaction(
                 15_000_000,
                 0,
                 AssetLockFundingType::AssetLockShieldedAddressTopUp,
                 0,
                 &signer,
-                CrossDomainConsent::Allowed,
+                Some(coinjoin_path),
             )
             .await;
         assert!(
-            consented.is_ok(),
-            "shielded funding must succeed once cross-domain consent is granted, got {consented:?}"
+            matches!(
+                coinjoin_funded,
+                Err(PlatformWalletError::AssetLockInsufficientFunds { .. })
+            ),
+            "explicit CoinJoin funding must not silently union in BIP44, got {coinjoin_funded:?}"
         );
     }
 
-    /// Privacy-domain gate happy path: when the transparent (BIP44) domain ALONE
-    /// covers the shielded lock, funding succeeds under the DEFAULT
-    /// (`CrossDomainConsent::Denied`) rule with no consent needed — and spends
-    /// only transparent inputs, never the CoinJoin coins.
+    /// Default happy path: with `funding_path = None`, a shielded lock funds from
+    /// the unmixed BIP44 account (the tested single-account builder) and never
+    /// touches the CoinJoin coins.
     #[tokio::test]
-    async fn shielded_asset_lock_single_transparent_domain_needs_no_consent() {
-        // 0.2 DASH BIP44 (transparent) + 0.09 DASH CoinJoin; require 0.15 DASH.
-        // Transparent alone covers it, so no cross-domain co-spend is needed.
+    async fn shielded_asset_lock_default_funds_from_bip44() {
+        // 0.2 DASH BIP44 + 0.09 DASH CoinJoin; require 0.15 DASH from BIP44.
         let (manager, signer) = split_asset_lock_manager(20_000_000, 9_000_000).await;
         let (bip44_outpoints, coinjoin_outpoints) = account_outpoints(&manager).await;
 
@@ -2442,19 +2284,20 @@ mod tests {
                 AssetLockFundingType::AssetLockShieldedAddressTopUp,
                 0,
                 &signer,
+                None,
             )
             .await
-            .expect("transparent-domain-only shielded funding needs no consent");
+            .expect("default (unmixed BIP44) shielded funding must succeed");
 
         let spent: std::collections::HashSet<OutPoint> =
             tx.input.iter().map(|i| i.previous_output).collect();
         assert!(
             spent.iter().any(|o| bip44_outpoints.contains(o)),
-            "must spend transparent BIP44 inputs, tx spent {spent:?}"
+            "must spend unmixed BIP44 inputs, tx spent {spent:?}"
         );
         assert!(
             !spent.iter().any(|o| coinjoin_outpoints.contains(o)),
-            "default single-domain rule must NOT reach CoinJoin coins, tx spent {spent:?}"
+            "the default (unmixed BIP44) path must NOT reach CoinJoin coins, tx spent {spent:?}"
         );
         for (i, txin) in tx.input.iter().enumerate() {
             assert!(
@@ -2465,26 +2308,25 @@ mod tests {
         }
     }
 
-    /// A shielded lock exceeding even the UNION balance surfaces the typed
-    /// [`PlatformWalletError::AssetLockInsufficientFunds`], and its `available`
-    /// reflects the whole spendable balance (both accounts), not the BIP44
-    /// slice — the pre-#4073 symptom was `available` reporting only the BIP44
-    /// portion. Driven with `CrossDomainConsent::Allowed` so the shortfall is
-    /// measured over the full union (not the transparent slice) and the
-    /// cross-domain gate does not pre-empt it.
+    /// A shielded lock that exceeds the SELECTED account's balance surfaces the
+    /// typed [`PlatformWalletError::AssetLockInsufficientFunds`], and its
+    /// `available` reflects only that one account (there is no union). Here the
+    /// CoinJoin account holds 0.09 DASH and the caller names it explicitly while
+    /// asking for 1.0 DASH.
     #[tokio::test]
-    async fn shielded_asset_lock_union_shortfall_is_typed() {
-        // Union spendable is 0.18 DASH; ask for 1.0 DASH.
+    async fn shielded_asset_lock_selected_account_shortfall_is_typed() {
+        // 0.09 DASH BIP44 + 0.09 DASH CoinJoin; ask for 1.0 DASH from CoinJoin.
         let (manager, signer) = split_asset_lock_manager(9_000_000, 9_000_000).await;
+        let coinjoin_path = coinjoin_account_path(&manager).await;
 
         let result = manager
-            .build_asset_lock_transaction_with_consent(
+            .build_asset_lock_transaction(
                 100_000_000,
                 0,
                 AssetLockFundingType::AssetLockShieldedAddressTopUp,
                 0,
                 &signer,
-                CrossDomainConsent::Allowed,
+                Some(coinjoin_path),
             )
             .await;
 
@@ -2493,124 +2335,12 @@ mod tests {
                 available,
                 required,
             }) => {
-                // `available` must reflect the union (both 0.09 UTXOs), i.e.
-                // strictly more than the BIP44-only slice the old path saw.
-                assert!(
-                    available > 9_000_000,
-                    "available ({available}) should reflect the BIP44 + CoinJoin \
-                     union (> the 9_000_000 BIP44 slice)"
-                );
-                assert!(
-                    available <= 18_000_000,
-                    "available ({available}) cannot exceed the 18_000_000 union"
-                );
-                assert!(
-                    required >= 100_000_000,
-                    "required ({required}) should be at least the requested amount"
-                );
-            }
-            other => panic!(
-                "expected typed AssetLockInsufficientFunds carrying the union \
-                 available/required, got {other:?}"
-            ),
-        }
-    }
-
-    /// Fee-band reclassification: the transparent domain covers the requested
-    /// amount but not amount + fee, while the union does. The pre-selection
-    /// gate (fee-exclusive) does not fire, transparent-only selection then
-    /// fails on the fee — and that shortfall must surface as the typed
-    /// consent-required error (the union unlocks it), NOT as a dead-end
-    /// insufficient-funds.
-    #[tokio::test]
-    async fn shielded_asset_lock_fee_band_reclassifies_to_consent_required() {
-        // Transparent = 0.09 DASH, CoinJoin = 0.09 DASH; ask for exactly the
-        // transparent balance so only the fee is short.
-        let (manager, signer) = split_asset_lock_manager(9_000_000, 9_000_000).await;
-
-        let result = manager
-            .build_asset_lock_transaction_with_consent(
-                9_000_000,
-                0,
-                AssetLockFundingType::AssetLockShieldedAddressTopUp,
-                0,
-                &signer,
-                CrossDomainConsent::Denied,
-            )
-            .await;
-
-        match result {
-            Err(PlatformWalletError::AssetLockCrossDomainConsentRequired {
-                transparent_available,
-                cross_domain_available,
-                required,
-            }) => {
-                assert_eq!(
-                    transparent_available, 9_000_000,
-                    "transparent_available should be the transparent slice"
-                );
-                assert_eq!(
-                    cross_domain_available, 18_000_000,
-                    "cross_domain_available should be the full union"
-                );
-                // key-wallet reports `required` as the plain target here (the
-                // fee shortfall is why selection failed, but the error carries
-                // the requested amount) — the reclassification must not depend
-                // on a fee-inclusive `required`.
-                assert!(
-                    required >= 9_000_000,
-                    "required ({required}) must be at least the 9_000_000 target"
-                );
-            }
-            other => panic!(
-                "fee-band shortfall the union can cover must ask for consent, got {other:?}"
-            ),
-        }
-
-        // And consent does unlock exactly this request.
-        manager
-            .build_asset_lock_transaction_with_consent(
-                9_000_000,
-                0,
-                AssetLockFundingType::AssetLockShieldedAddressTopUp,
-                0,
-                &signer,
-                CrossDomainConsent::Allowed,
-            )
-            .await
-            .expect("the fee-band request must succeed once consent is granted");
-    }
-
-    /// Denied + both domains short: when even the union cannot cover the
-    /// request, consent would not help, so the error stays the typed
-    /// insufficient-funds (code path distinct from consent-required) with the
-    /// transparent slice as `available` — the permitted funding set under the
-    /// default rule.
-    #[tokio::test]
-    async fn shielded_asset_lock_denied_union_shortfall_stays_insufficient() {
-        // Union spendable is 0.18 DASH; ask for 1.0 DASH with consent Denied.
-        let (manager, signer) = split_asset_lock_manager(9_000_000, 9_000_000).await;
-
-        let result = manager
-            .build_asset_lock_transaction_with_consent(
-                100_000_000,
-                0,
-                AssetLockFundingType::AssetLockShieldedAddressTopUp,
-                0,
-                &signer,
-                CrossDomainConsent::Denied,
-            )
-            .await;
-
-        match result {
-            Err(PlatformWalletError::AssetLockInsufficientFunds {
-                available,
-                required,
-            }) => {
+                // `available` must reflect ONLY the named CoinJoin account
+                // (0.09 DASH) — never the wallet-wide union.
                 assert!(
                     available <= 9_000_000,
-                    "available ({available}) must reflect the permitted \
-                     transparent slice under Denied, not the union"
+                    "available ({available}) must reflect only the named CoinJoin \
+                     account, not a union"
                 );
                 assert!(
                     required >= 100_000_000,
@@ -2618,8 +2348,7 @@ mod tests {
                 );
             }
             other => panic!(
-                "a shortfall consent cannot fix must stay AssetLockInsufficientFunds, \
-                 got {other:?}"
+                "expected typed AssetLockInsufficientFunds for the named account, got {other:?}"
             ),
         }
     }
@@ -2658,6 +2387,10 @@ mod tests {
             .expect("setup runtime");
         let (manager, signer) =
             setup_rt.block_on(split_asset_lock_manager_many_coinjoin(9_000_000, &coinjoin));
+        // The many-UTXO selection lives on the CoinJoin account; name it
+        // explicitly so the build funds the 0.2 DASH lock from those 40 mixed
+        // denominations (0.09 BIP44 alone is short).
+        let coinjoin_path = setup_rt.block_on(coinjoin_account_path(&manager));
 
         let (result_tx, result_rx) = mpsc::channel();
         // Detached: NOT joined anywhere, so a hung build can't wedge runtime
@@ -2668,16 +2401,13 @@ mod tests {
                 .build()
                 .expect("worker runtime");
             let outcome = rt
-                .block_on(manager.build_asset_lock_transaction_with_consent(
+                .block_on(manager.build_asset_lock_transaction(
                     20_000_000,
                     0,
                     AssetLockFundingType::AssetLockShieldedAddressTopUp,
                     0,
                     &signer,
-                    // 0.09 BIP44 (transparent) is short of 0.2; the CoinJoin coins
-                    // that trigger the many-UTXO selection are a cross-domain
-                    // co-spend, so drive the consented path.
-                    CrossDomainConsent::Allowed,
+                    Some(coinjoin_path),
                 ))
                 .map(|(tx, _path)| tx);
             let _ = result_tx.send(outcome);
@@ -2768,19 +2498,20 @@ mod tests {
             (before, values)
         };
 
+        // 0.09 BIP44 is short of 0.2; name the CoinJoin account (2.0 DASH UTXO)
+        // so the lock funds from mixed coins, with change routed to BIP44.
+        let coinjoin_path = coinjoin_account_path(&manager).await;
         let (tx, _path) = manager
-            .build_asset_lock_transaction_with_consent(
+            .build_asset_lock_transaction(
                 20_000_000,
                 0,
                 AssetLockFundingType::AssetLockShieldedAddressTopUp,
                 0,
                 &signer,
-                // 0.09 BIP44 (transparent) is short of 0.2; funding from the
-                // 2.0 CoinJoin UTXO is a cross-domain co-spend.
-                CrossDomainConsent::Allowed,
+                Some(coinjoin_path),
             )
             .await
-            .expect("build multi-account asset lock");
+            .expect("build CoinJoin-funded asset lock");
 
         let sum_spent: u64 = tx
             .input
@@ -3002,6 +2733,32 @@ mod tests {
         map.values().any(|a| a.utxos.contains_key(outpoint))
     }
 
+    /// The account-level derivation path of the DashPay funds account of `leg`
+    /// (the first account in the leg's map), for use as an explicit
+    /// `funding_path`.
+    async fn dashpay_account_path(
+        manager: &AssetLockManager<AlwaysRejectedBroadcaster>,
+        leg: DashpayLeg,
+    ) -> DerivationPath {
+        use key_wallet::managed_account::managed_account_trait::ManagedAccountTrait;
+        let wm = manager.wallet_manager.read().await;
+        let (_, info) = wm
+            .get_wallet_and_info(&manager.wallet_id)
+            .expect("wallet present");
+        let network = info.core_wallet.network();
+        let map = match leg {
+            DashpayLeg::ReceivingFunds => &info.core_wallet.accounts.dashpay_receival_accounts,
+            DashpayLeg::ExternalAccount => &info.core_wallet.accounts.dashpay_external_accounts,
+        };
+        map.values()
+            .next()
+            .expect("dashpay account present")
+            .managed_account_type()
+            .to_account_type()
+            .derivation_path(network)
+            .expect("dashpay account-level path")
+    }
+
     /// `true` iff `account_type` is the DashPay funds variant matching `leg`.
     fn record_matches_dashpay_leg(account_type: &key_wallet::AccountType, leg: DashpayLeg) -> bool {
         match leg {
@@ -3054,16 +2811,17 @@ mod tests {
             (before, values)
         };
 
+        // 0.09 BIP44 is short of 0.2; name the DashPay-receiving account (2.0
+        // DASH UTXO) so the lock funds from it, with change routed to BIP44.
+        let dashpay_path = dashpay_account_path(&manager, leg).await;
         let (tx, _path) = manager
-            .build_asset_lock_transaction_with_consent(
+            .build_asset_lock_transaction(
                 20_000_000,
                 0,
                 AssetLockFundingType::AssetLockShieldedAddressTopUp,
                 0,
                 &signer,
-                // 0.09 BIP44 (transparent) is short of 0.2; funding from the
-                // 2.0 DashPay-receiving UTXO is a cross-domain co-spend.
-                CrossDomainConsent::Allowed,
+                Some(dashpay_path),
             )
             .await
             .expect("build DashPay-funded asset lock");
@@ -3236,12 +2994,11 @@ mod tests {
     // fixture derived it from the test wallet's own seed, making it locally
     // signable and MASKING this defect.
 
-    /// The union-of-accounts asset-lock builder must NOT select watch-only
+    /// Default (unmixed BIP44) shielded funding must never select watch-only
     /// `DashpayExternalAccount` UTXOs. The external account here holds the
     /// LARGEST UTXO (0.5 DASH) while signable BIP44 (0.15 DASH) alone covers the
-    /// 0.1-DASH shield, so a naive `LargestFirst` over the union would grab the
-    /// external UTXO FIRST (the pre-fix bug). The build must instead succeed from
-    /// BIP44 alone and leave every external UTXO unspent.
+    /// 0.1-DASH shield; the build must succeed from BIP44 alone and leave every
+    /// external UTXO unspent (default funding never leaves the BIP44 account).
     #[tokio::test]
     async fn asset_lock_funding_excludes_watch_only_dashpay_external_utxos() {
         let (manager, signer) =
@@ -3261,6 +3018,7 @@ mod tests {
                 AssetLockFundingType::AssetLockShieldedAddressTopUp,
                 0,
                 &signer,
+                None,
             )
             .await
             .expect("asset lock must build from signable BIP44 funds alone");
@@ -3281,8 +3039,8 @@ mod tests {
     /// Watch-only external coins must not be *borrowed* to cover a shortfall.
     /// Signable BIP44 (0.05 DASH) alone is too small for the 0.1-DASH shield;
     /// the only way to cover it would be to (wrongly) spend the 0.5-DASH
-    /// watch-only external UTXO. The build must FAIL with the typed
-    /// insufficient-funds error rather than emit an invalid-signature input.
+    /// watch-only external UTXO. Default funding must FAIL with the typed
+    /// insufficient-funds error rather than reach the external coins.
     #[tokio::test]
     async fn asset_lock_funding_cannot_borrow_watch_only_dashpay_external_utxos() {
         let (manager, signer) =
@@ -3296,6 +3054,7 @@ mod tests {
                 AssetLockFundingType::AssetLockShieldedAddressTopUp,
                 0,
                 &signer,
+                None,
             )
             .await;
 
@@ -3306,6 +3065,32 @@ mod tests {
             ),
             "must not fund an asset lock from watch-only external coins; got {result:?}"
         );
+
+        // Naming the watch-only external account EXPLICITLY by path must also be
+        // refused — the local mnemonic cannot sign its coins — with the typed
+        // account-operation error, not insufficient-funds.
+        let external_path = dashpay_account_path(&manager, DashpayLeg::ExternalAccount).await;
+        let pathed = manager
+            .build_asset_lock_transaction(
+                10_000_000,
+                0,
+                AssetLockFundingType::AssetLockShieldedAddressTopUp,
+                0,
+                &signer,
+                Some(external_path),
+            )
+            .await;
+        match pathed {
+            Err(PlatformWalletError::AssetLockTransaction(msg)) => {
+                assert!(
+                    msg.contains("watch-only"),
+                    "explicit watch-only funding path must be refused as watch-only, got: {msg}"
+                );
+            }
+            other => panic!(
+                "naming a watch-only external account by path must be refused, got {other:?}"
+            ),
+        }
     }
 
     /// Heavy-mixer CoinJoin discovery (dashpay/dash-wallet#1507): the CoinJoin

--- a/packages/rs-platform-wallet/src/wallet/asset_lock/build.rs
+++ b/packages/rs-platform-wallet/src/wallet/asset_lock/build.rs
@@ -663,6 +663,15 @@ impl<B: TransactionBroadcaster + ?Sized> AssetLockManager<B> {
                 // on the selected funds account so its inputs are immediately
                 // reselectable, rather than stranded until the reservation-TTL
                 // backstop.
+                //
+                // PRIVACY-DOMAIN-OK: selects no coins. The iteration LOOKS UP
+                // the single account whose derivation path equals the
+                // already-chosen `funding_path`, releases that one account's
+                // reservation, and `break`s — the inverse of a funding union,
+                // undoing a reservation the single-account build already placed.
+                // key-wallet exposes no by-path accessor, so walking the funds
+                // accounts is the only way to reach the owning account's
+                // `release_reservation`. See `wallet::funding_privacy`.
                 let mut released = false;
                 for acc in info.core_wallet.accounts.all_funding_accounts() {
                     if acc

--- a/packages/rs-platform-wallet/src/wallet/asset_lock/build.rs
+++ b/packages/rs-platform-wallet/src/wallet/asset_lock/build.rs
@@ -414,9 +414,10 @@ impl<B: TransactionBroadcaster + ?Sized> AssetLockManager<B> {
         // obtains user consent and re-issues with `CrossDomainConsent::Allowed`.
         // Note: coin selection accounts for the L1 fee, so `transparent_total`
         // being >= `target_duffs` here is necessary but not sufficient; a
-        // fee-driven shortfall still surfaces as `AssetLockInsufficientFunds` from
-        // the builder below. The consent gate only fires when the WIDER union is
-        // what unlocks the amount.
+        // fee-driven shortfall surfaces from the builder below and is
+        // reclassified to consent-required at that site when the union covers
+        // the fee-inclusive amount. This gate handles the plain-amount case
+        // early, before any selection work.
         if !allow_cross_domain && transparent_total < target_duffs && union_total >= target_duffs {
             tracing::debug!(
                 transparent_total,
@@ -556,7 +557,31 @@ impl<B: TransactionBroadcaster + ?Sized> AssetLockManager<B> {
         let (transaction, fee) = builder
             .build_signed(signer, move |addr| path_map.get(&addr).cloned())
             .await
-            .map_err(|e| map_builder_error(e, target_duffs))?;
+            .map_err(|e| {
+                let mapped = map_builder_error(e, target_duffs);
+                // Fee-band consent reclassification: the pre-selection gate
+                // compares domain totals against the fee-EXCLUSIVE target, so a
+                // transparent total in [target, target+fee) slips past it and
+                // then fails selection on the fee. When the union would cover
+                // the fee-inclusive `required` that selection reported, the
+                // actionable answer is still consent — reclassify to the
+                // consent-required error so hosts prompt instead of
+                // dead-ending on "insufficient funds".
+                match mapped {
+                    PlatformWalletError::AssetLockInsufficientFunds { available, required }
+                        if !allow_cross_domain
+                            && union_total > available
+                            && union_total >= required =>
+                    {
+                        PlatformWalletError::AssetLockCrossDomainConsentRequired {
+                            transparent_available: available,
+                            cross_domain_available: union_total,
+                            required,
+                        }
+                    }
+                    other => other,
+                }
+            })?;
         tracing::debug!(
             selected_inputs = transaction.input.len(),
             fee,
@@ -2487,6 +2512,114 @@ mod tests {
             other => panic!(
                 "expected typed AssetLockInsufficientFunds carrying the union \
                  available/required, got {other:?}"
+            ),
+        }
+    }
+
+    /// Fee-band reclassification: the transparent domain covers the requested
+    /// amount but not amount + fee, while the union does. The pre-selection
+    /// gate (fee-exclusive) does not fire, transparent-only selection then
+    /// fails on the fee — and that shortfall must surface as the typed
+    /// consent-required error (the union unlocks it), NOT as a dead-end
+    /// insufficient-funds.
+    #[tokio::test]
+    async fn shielded_asset_lock_fee_band_reclassifies_to_consent_required() {
+        // Transparent = 0.09 DASH, CoinJoin = 0.09 DASH; ask for exactly the
+        // transparent balance so only the fee is short.
+        let (manager, signer) = split_asset_lock_manager(9_000_000, 9_000_000).await;
+
+        let result = manager
+            .build_asset_lock_transaction_with_consent(
+                9_000_000,
+                0,
+                AssetLockFundingType::AssetLockShieldedAddressTopUp,
+                0,
+                &signer,
+                CrossDomainConsent::Denied,
+            )
+            .await;
+
+        match result {
+            Err(PlatformWalletError::AssetLockCrossDomainConsentRequired {
+                transparent_available,
+                cross_domain_available,
+                required,
+            }) => {
+                assert_eq!(
+                    transparent_available, 9_000_000,
+                    "transparent_available should be the transparent slice"
+                );
+                assert_eq!(
+                    cross_domain_available, 18_000_000,
+                    "cross_domain_available should be the full union"
+                );
+                // key-wallet reports `required` as the plain target here (the
+                // fee shortfall is why selection failed, but the error carries
+                // the requested amount) — the reclassification must not depend
+                // on a fee-inclusive `required`.
+                assert!(
+                    required >= 9_000_000,
+                    "required ({required}) must be at least the 9_000_000 target"
+                );
+            }
+            other => panic!(
+                "fee-band shortfall the union can cover must ask for consent, got {other:?}"
+            ),
+        }
+
+        // And consent does unlock exactly this request.
+        manager
+            .build_asset_lock_transaction_with_consent(
+                9_000_000,
+                0,
+                AssetLockFundingType::AssetLockShieldedAddressTopUp,
+                0,
+                &signer,
+                CrossDomainConsent::Allowed,
+            )
+            .await
+            .expect("the fee-band request must succeed once consent is granted");
+    }
+
+    /// Denied + both domains short: when even the union cannot cover the
+    /// request, consent would not help, so the error stays the typed
+    /// insufficient-funds (code path distinct from consent-required) with the
+    /// transparent slice as `available` — the permitted funding set under the
+    /// default rule.
+    #[tokio::test]
+    async fn shielded_asset_lock_denied_union_shortfall_stays_insufficient() {
+        // Union spendable is 0.18 DASH; ask for 1.0 DASH with consent Denied.
+        let (manager, signer) = split_asset_lock_manager(9_000_000, 9_000_000).await;
+
+        let result = manager
+            .build_asset_lock_transaction_with_consent(
+                100_000_000,
+                0,
+                AssetLockFundingType::AssetLockShieldedAddressTopUp,
+                0,
+                &signer,
+                CrossDomainConsent::Denied,
+            )
+            .await;
+
+        match result {
+            Err(PlatformWalletError::AssetLockInsufficientFunds {
+                available,
+                required,
+            }) => {
+                assert!(
+                    available <= 9_000_000,
+                    "available ({available}) must reflect the permitted \
+                     transparent slice under Denied, not the union"
+                );
+                assert!(
+                    required >= 100_000_000,
+                    "required ({required}) should be at least the requested amount"
+                );
+            }
+            other => panic!(
+                "a shortfall consent cannot fix must stay AssetLockInsufficientFunds, \
+                 got {other:?}"
             ),
         }
     }

--- a/packages/rs-platform-wallet/src/wallet/asset_lock/build.rs
+++ b/packages/rs-platform-wallet/src/wallet/asset_lock/build.rs
@@ -99,7 +99,7 @@ enum PrivacyDomain {
 /// Classify a funds account into its [`PrivacyDomain`], or `None` for accounts
 /// that must never fund an asset lock (watch-only `DashpayExternalAccount` — a
 /// contact's coins the local mnemonic can't sign). Returning `None` here is what
-/// preserves the watch-only exclusion (finding 5b52d9844055) across every
+/// preserves the watch-only exclusion across every
 /// consent mode, replacing the old ad-hoc skip. Non-funds account types cannot
 /// appear in `all_funding_accounts()` and also map to `None` defensively.
 fn account_privacy_domain(managed_type: &ManagedAccountType) -> Option<PrivacyDomain> {
@@ -389,7 +389,7 @@ impl<B: TransactionBroadcaster + ?Sized> AssetLockManager<B> {
         // domain (transparent + CoinJoin + DashPay-receiving). Watch-only
         // `DashpayExternalAccount` UTXOs are excluded here by
         // `account_privacy_domain` returning `None` — the same ownership carve-out
-        // as before (finding 5b52d9844055), now expressed through the domain map.
+        // as before, now expressed through the domain map.
         let mut transparent_total: u64 = 0;
         let mut union_total: u64 = 0;
         for acc in info.core_wallet.accounts.all_funding_accounts() {
@@ -460,7 +460,7 @@ impl<B: TransactionBroadcaster + ?Sized> AssetLockManager<B> {
         // Watch-only `DashpayExternalAccount` UTXOs are never eligible in either
         // mode (`account_privacy_domain` returns `None`), so a naive `LargestFirst`
         // can no longer grab a contact's coins and sign them with the wrong local
-        // key (finding 5b52d9844055).
+        // key.
         let mut path_map: HashMap<DashAddress, DerivationPath> = HashMap::new();
         let mut extra_inputs: Vec<Utxo> = Vec::new();
         let mut selected_value: u64 = 0;
@@ -3219,7 +3219,7 @@ mod tests {
         assert_router_fix_records_spent_dashpay_input(DashpayLeg::ReceivingFunds).await;
     }
 
-    // -- Watch-only DashpayExternalAccount exclusion (finding 5b52d9844055) --
+    // -- Watch-only DashpayExternalAccount exclusion --
     //
     // A `DashpayExternalAccount` is created in production from a CONTACT's
     // decrypted xpub with `is_watch_only: true` (wallet/identity/network/

--- a/packages/rs-platform-wallet/src/wallet/asset_lock/build.rs
+++ b/packages/rs-platform-wallet/src/wallet/asset_lock/build.rs
@@ -13,7 +13,7 @@ use dashcore::{OutPoint, Transaction, TxOut};
 use key_wallet::account::AccountType;
 use key_wallet::bip32::DerivationPath;
 use key_wallet::managed_account::managed_account_trait::ManagedAccountTrait;
-use key_wallet::signer::ExtendedPubKeySigner;
+use key_wallet::signer::{ExtendedPubKeySigner, Signer};
 use key_wallet::wallet::managed_wallet_info::asset_lock_builder::{
     AssetLockFundingType, CreditOutputFunding,
 };
@@ -41,7 +41,87 @@ use super::tracked::{AssetLockStatus, TrackedAssetLock};
 /// derivation path explicitly. Every other funds-account type is locally
 /// signable.
 fn is_signable_funding_account(managed_type: &ManagedAccountType) -> bool {
-    !matches!(managed_type, ManagedAccountType::DashpayExternalAccount { .. })
+    !matches!(
+        managed_type,
+        ManagedAccountType::DashpayExternalAccount { .. }
+    )
+}
+
+/// A [`Signer`] that answers ONE pre-fetched credit-output `public_key` request
+/// from cache and delegates everything else to the real signer.
+///
+/// ## Why this exists (dashpay/platform#4184 review)
+///
+/// The pinned `ManagedWalletInfo::build_asset_lock_with_signer` — the delegated
+/// builder every NON-shielded funding type uses — runs its credit-output
+/// bookkeeping *after* `build_signed` has already RESERVED the transaction's
+/// inputs on the BIP44 account: peek the next unused path, ask the signer for
+/// the matching public key, then mark the index used. `build_signed` itself
+/// rolls its reservation back when input signing fails, but a failure in that
+/// post-signing loop abandons a fully signed transaction with its inputs still
+/// reserved, and the error carries no transaction — so the caller has nothing to
+/// hand `ManagedCoreFundsAccount::release_reservation`, and the account's
+/// `ReservationSet` is `pub(crate)` to key-wallet. At this pin the stranded
+/// inputs are therefore *unreleasable* from platform-wallet and stay withheld
+/// from every other send until the reservation-TTL backstop.
+///
+/// Since the abandon path cannot be rolled back, it is instead **removed**: of
+/// the loop's fallible steps only the external `signer.public_key` round-trip is
+/// genuinely reachable (a transient Keychain/resolver failure). The other steps
+/// — resolving the credit account, `peek_next_path`, and
+/// `mark_first_pool_index_used` — cannot fail once
+/// [`AssetLockManager::peek_next_funding_address`] has resolved and peeked that
+/// same account earlier in the same call, under the same held wallet write lock,
+/// with nothing in between able to mutate it (`mark_first_pool_index_used` only
+/// rejects Standard accounts and empty pools, both already excluded by the
+/// successful peek). So the caller performs the signer round-trip ONCE, up
+/// front, *before* anything is reserved, and hands the builder this wrapper: the
+/// loop's `public_key` call hits the cache and is infallible, leaving no
+/// reachable post-reservation failure.
+///
+/// The cache is keyed by the exact path and holds a single entry captured
+/// microseconds earlier; any other path — including every `sign_ecdsa` input
+/// signature — goes straight to the real signer, so this narrows nothing about
+/// what the device is asked to authorize.
+struct PrefetchedCreditKeySigner<'a, S: Signer> {
+    inner: &'a S,
+    /// The credit-output path whose public key was pre-fetched.
+    path: DerivationPath,
+    /// The pre-fetched public key at [`Self::path`].
+    public_key: dashcore::secp256k1::PublicKey,
+}
+
+#[async_trait::async_trait]
+impl<S: Signer> key_wallet::signer::Signer for PrefetchedCreditKeySigner<'_, S> {
+    type Error = S::Error;
+
+    fn supported_methods(&self) -> &[key_wallet::signer::SignerMethod] {
+        self.inner.supported_methods()
+    }
+
+    async fn sign_ecdsa(
+        &self,
+        path: &DerivationPath,
+        sighash: [u8; 32],
+    ) -> Result<
+        (
+            dashcore::secp256k1::ecdsa::Signature,
+            dashcore::secp256k1::PublicKey,
+        ),
+        Self::Error,
+    > {
+        self.inner.sign_ecdsa(path, sighash).await
+    }
+
+    async fn public_key(
+        &self,
+        path: &DerivationPath,
+    ) -> Result<dashcore::secp256k1::PublicKey, Self::Error> {
+        if *path == self.path {
+            return Ok(self.public_key);
+        }
+        self.inner.public_key(path).await
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -119,8 +199,9 @@ impl<B: TransactionBroadcaster + ?Sized> AssetLockManager<B> {
         }
 
         // 1. Peek at the next unused address from the funding account to
-        //    build the credit output P2PKH script.
-        let funding_address = Self::peek_next_funding_address(
+        //    build the credit output P2PKH script, plus that entry's
+        //    derivation path (the delegated builder re-peeks the same one).
+        let (funding_address, credit_path) = Self::peek_next_funding_address(
             &mut info.core_wallet,
             wallet,
             funding_type,
@@ -165,6 +246,35 @@ impl<B: TransactionBroadcaster + ?Sized> AssetLockManager<B> {
                 .await;
         }
 
+        // Pre-fetch the credit-output public key BEFORE delegating, so the
+        // builder's post-signing credit-key loop cannot fail on a signer
+        // round-trip once it has reserved the BIP44 inputs.
+        //
+        // The delegated builder reserves the transaction's inputs inside
+        // `build_signed` and only rolls that back when *input* signing fails.
+        // Its credit-key loop runs afterwards, and an error there abandons a
+        // fully-signed transaction whose inputs stay reserved — with no
+        // transaction in the `Err` to hand `release_reservation`, and no way to
+        // reach the account's `pub(crate)` `ReservationSet` from here, those
+        // inputs are unreleasable at this pin and stay withheld from every other
+        // send until the reservation-TTL backstop (dashpay/platform#4184
+        // review). The abandon path is therefore removed rather than rolled
+        // back: the only genuinely reachable failure in that loop is this
+        // external signer round-trip, so it happens HERE, before anything is
+        // reserved, and the builder gets a wrapper that answers the repeat
+        // request from cache. See [`PrefetchedCreditKeySigner`] for why the
+        // loop's remaining steps cannot fail after the peek above.
+        let credit_public_key = signer.public_key(&credit_path).await.map_err(|e| {
+            PlatformWalletError::AssetLockTransaction(format!(
+                "signer public_key failed for credit output at {credit_path}: {e}"
+            ))
+        })?;
+        let prefetched_signer = PrefetchedCreditKeySigner {
+            inner: signer,
+            path: credit_path,
+            public_key: credit_public_key,
+        };
+
         // Delegate to the key-wallet signer-driven builder (single BIP44 account).
         let result = info
             .core_wallet
@@ -173,7 +283,7 @@ impl<B: TransactionBroadcaster + ?Sized> AssetLockManager<B> {
                 account_index,
                 vec![funding],
                 DEFAULT_FEE_PER_KB,
-                signer,
+                &prefetched_signer,
             )
             .await
             .map_err(|e| {
@@ -653,16 +763,25 @@ impl<B: TransactionBroadcaster + ?Sized> AssetLockManager<B> {
     }
 
     /// Peek at the next unused address from a funding account without
-    /// consuming it (i.e. without marking it as used).
+    /// consuming it (i.e. without marking it as used), together with that
+    /// entry's derivation path.
     ///
     /// The key-wallet builder's `next_private_key` will later find the same
     /// address, derive the private key, and mark it as used.
+    ///
+    /// The returned path is the *same* pool entry the delegated builder's
+    /// credit-output loop re-peeks: both resolve this account's first address
+    /// pool through `next_unused*`, and nothing between the two peeks mutates it
+    /// (the wallet write lock is held across the whole build, and the builder
+    /// itself only touches funds accounts). Returning it here lets the caller
+    /// pre-fetch the credit public key BEFORE any input is reserved — see
+    /// [`PrefetchedCreditKeySigner`].
     fn peek_next_funding_address(
         wallet_info: &mut ManagedWalletInfo,
         wallet: &Wallet,
         funding_type: AssetLockFundingType,
         identity_index: u32,
-    ) -> Result<DashAddress, PlatformWalletError> {
+    ) -> Result<(DashAddress, DerivationPath), PlatformWalletError> {
         let (managed_account, account_xpub) = match funding_type {
             AssetLockFundingType::IdentityRegistration => {
                 let xpub = wallet
@@ -774,14 +893,25 @@ impl<B: TransactionBroadcaster + ?Sized> AssetLockManager<B> {
         // state so the builder's `next_private_key` can find it. The
         // address is NOT marked as used yet — that happens inside the
         // builder after a successful transaction build.
-        managed_account
+        let address = managed_account
             .next_address(account_xpub.as_ref(), false)
             .map_err(|e| {
                 PlatformWalletError::AssetLockTransaction(format!(
                     "Failed to get next funding address: {}",
                     e
                 ))
-            })
+            })?;
+
+        // Same pool entry, read back as a path. `peek_next_path` does not mark
+        // the index used, so this stays a pure peek.
+        let (path, _index) = managed_account.peek_next_path().map_err(|e| {
+            PlatformWalletError::AssetLockTransaction(format!(
+                "Failed to peek next funding derivation path: {}",
+                e
+            ))
+        })?;
+
+        Ok((address, path))
     }
 
     /// Idempotently derive + insert the per-index `IdentityTopUp`
@@ -1387,8 +1517,11 @@ mod tests {
     use crate::wallet::persister::WalletPersister;
     use crate::wallet::platform_wallet::PlatformWalletInfo;
     use crate::wallet::platform_wallet::WalletId;
-    use key_wallet::bip32::DerivationPath;
     use crate::{AssetLockFundingType, PlatformWalletError};
+    use dashcore::Address as DashAddress;
+    use key_wallet::bip32::DerivationPath;
+    use key_wallet::signer::{ExtendedPubKeySigner, Signer};
+    use key_wallet::ManagedAccountType;
 
     /// prior-no-utxos-846 (dashpay/platform#4074): the zero-spendable-candidate
     /// selection error must surface the SAME typed shortfall as a partial
@@ -2355,7 +2488,10 @@ mod tests {
         // Change must land on the transparent BIP44 account (the OP_RETURN burn
         // is the AssetLock output; any non-OP_RETURN output is wallet change).
         let has_change = tx.output.iter().any(|o| !o.script_pubkey.is_op_return());
-        assert!(has_change, "a CoinJoin-funded lock must return change to BIP44");
+        assert!(
+            has_change,
+            "a CoinJoin-funded lock must return change to BIP44"
+        );
 
         // Per-account signing: every selected input must carry a signature.
         assert!(!tx.input.is_empty(), "asset lock must have selected inputs");
@@ -2693,6 +2829,256 @@ mod tests {
             "a rejected selected-account broadcast must release the CoinJoin \
              reservation so the coin is reselectable, got {rebuild:?}"
         );
+    }
+
+    /// A [`WalletSigner`] that signs transaction inputs normally but fails
+    /// every `public_key` request — a transient Keychain/resolver outage that
+    /// hits the credit-output round-trip only.
+    struct CreditKeyFailingSigner {
+        inner: WalletSigner,
+    }
+
+    #[async_trait::async_trait]
+    impl Signer for CreditKeyFailingSigner {
+        type Error = String;
+
+        fn supported_methods(&self) -> &[key_wallet::signer::SignerMethod] {
+            self.inner.supported_methods()
+        }
+
+        async fn sign_ecdsa(
+            &self,
+            path: &DerivationPath,
+            sighash: [u8; 32],
+        ) -> Result<
+            (
+                dashcore::secp256k1::ecdsa::Signature,
+                dashcore::secp256k1::PublicKey,
+            ),
+            Self::Error,
+        > {
+            self.inner.sign_ecdsa(path, sighash).await
+        }
+
+        async fn public_key(
+            &self,
+            _path: &DerivationPath,
+        ) -> Result<dashcore::secp256k1::PublicKey, Self::Error> {
+            Err("simulated transient Keychain failure".to_string())
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl ExtendedPubKeySigner for CreditKeyFailingSigner {
+        async fn extended_public_key(
+            &self,
+            path: &DerivationPath,
+        ) -> Result<key_wallet::bip32::ExtendedPubKey, Self::Error> {
+            self.inner.extended_public_key(path).await
+        }
+    }
+
+    /// dashpay/platform#4184 reservation regression, DELEGATED (non-shielded)
+    /// path: a credit-output signer failure must not strand the BIP44 inputs.
+    ///
+    /// The pinned `build_asset_lock_with_signer` reserves the transaction's
+    /// inputs inside `build_signed` and rolls that back only when *input*
+    /// signing fails. Its credit-output loop runs afterwards and asks the signer
+    /// for the credit public key; before the fix, a transient failure there
+    /// returned `Err` with the inputs still reserved — and the error carries no
+    /// transaction, so nothing downstream could release them. The single funded
+    /// UTXO was therefore withheld from every later send until the
+    /// reservation-TTL backstop.
+    ///
+    /// Proven via the observable proxy the other reservation tests use: a fresh
+    /// build over the same single-UTXO account must succeed. Reverting the
+    /// pre-fetch makes the rebuild fail at input selection.
+    #[tokio::test]
+    async fn delegated_builder_credit_key_failure_does_not_strand_bip44_inputs() {
+        let (manager, signer, _persistence) =
+            funded_asset_lock_manager(Arc::new(AlwaysOkBroadcaster)).await;
+
+        // The whole 0.1 DASH balance rides on one UTXO, so a leaked reservation
+        // is immediately visible as a shortfall on the next build.
+        let failing = CreditKeyFailingSigner {
+            inner: signer.clone(),
+        };
+        let abandoned = manager
+            .build_asset_lock_transaction(
+                5_000_000,
+                0,
+                AssetLockFundingType::IdentityRegistration,
+                0,
+                &failing,
+                None,
+            )
+            .await;
+        assert!(
+            abandoned.is_err(),
+            "a failing credit-output signer must abandon the build, got {abandoned:?}"
+        );
+
+        let rebuild = manager
+            .build_asset_lock_transaction(
+                5_000_000,
+                0,
+                AssetLockFundingType::IdentityRegistration,
+                0,
+                &signer,
+                None,
+            )
+            .await;
+        assert!(
+            rebuild.is_ok(),
+            "the abandoned delegated build must leave its BIP44 input reselectable, \
+             got {rebuild:?}"
+        );
+    }
+
+    /// dashpay/platform#4184 review: an explicitly-selected **Standard BIP32**
+    /// funding account must have its own xpub passed to `set_funding`.
+    ///
+    /// `TransactionBuilder::set_funding(funds_acc, acc)` calls
+    /// `funds_acc.next_change_address(Some(&acc.account_xpub), true)` before the
+    /// `set_change_address` override. When the selected BIP32 account has no
+    /// pre-generated unused internal address, that call *derives* one — so
+    /// passing the BIP44 change account as `acc` (the pre-fix behaviour) derives
+    /// `[1, index]` from the BIP44 xpub while recording it under the BIP32
+    /// account's own path. Overriding this transaction's change output does not
+    /// undo the pool mutation: a later normal BIP32 send can pick that entry as
+    /// change and record a derivation path whose signer key does not match the
+    /// address.
+    ///
+    /// The existing 25-test suite covers default BIP44 and explicit
+    /// CoinJoin/DashPay funding only — for those the xpub is either already
+    /// correct or immaterial (non-Standard change derivation fails and is
+    /// swallowed), so reverting the lookup leaves them all green. This test
+    /// exhausts the BIP32 internal pool first to force the derivation, then
+    /// asserts every pool entry is still signable at its recorded path.
+    #[tokio::test]
+    async fn shielded_selected_bip32_account_change_pool_derives_from_its_own_xpub() {
+        use key_wallet::managed_account::managed_account_trait::ManagedAccountTrait;
+
+        let (wallet_manager, wallet_id, _balance, signer) =
+            crate::test_support::funded_wallet_manager_with_outputs(
+                StandardAccountType::BIP32Account,
+                &[20_000_000],
+            )
+            .await;
+        let sdk = Arc::new(dash_sdk::SdkBuilder::new_mock().build().expect("mock sdk"));
+        let manager = Arc::new(AssetLockManager::new(
+            sdk,
+            Arc::clone(&wallet_manager),
+            wallet_id,
+            Arc::new(Notify::new()),
+            Arc::new(AlwaysOkBroadcaster),
+            WalletPersister::new(
+                wallet_id,
+                Arc::new(CapturingPersistence::default()) as Arc<dyn PlatformWalletPersistence>,
+            ),
+        ));
+
+        // The account-level path naming BIP32 account 0 as the single funding
+        // source, and the BIP44 xpub whose derivations must NOT appear in the
+        // BIP32 pool.
+        let bip32_path = {
+            let wm = wallet_manager.read().await;
+            let (_, info) = wm.get_wallet_and_info(&wallet_id).expect("wallet present");
+            let network = info.core_wallet.network();
+            info.core_wallet
+                .accounts
+                .standard_bip32_accounts
+                .get(&0)
+                .expect("fixture has BIP32 account 0")
+                .managed_account_type()
+                .to_account_type()
+                .derivation_path(network)
+                .expect("BIP32 account-level path")
+        };
+
+        // Exhaust the BIP32 account's pre-generated unused internal entries, so
+        // `set_funding`'s `next_change_address` has to derive a fresh one from
+        // whichever xpub it was handed — the branch this fix governs.
+        {
+            let mut wm = wallet_manager.write().await;
+            let (_, info) = wm
+                .get_wallet_mut_and_info_mut(&wallet_id)
+                .expect("wallet present");
+            let account = info
+                .core_wallet
+                .first_bip32_managed_account_mut()
+                .expect("fixture has a managed BIP32 account 0");
+            if let ManagedAccountType::Standard {
+                internal_addresses, ..
+            } = account.managed_account_type_mut()
+            {
+                let generated: Vec<u32> = internal_addresses.addresses.keys().copied().collect();
+                assert!(
+                    !generated.is_empty(),
+                    "fixture should pre-generate some internal addresses to exhaust"
+                );
+                for index in generated {
+                    internal_addresses.mark_index_used(index);
+                }
+            } else {
+                panic!("BIP32 account 0 should be a Standard managed account");
+            }
+        }
+
+        manager
+            .build_asset_lock_transaction(
+                15_000_000,
+                0,
+                AssetLockFundingType::AssetLockShieldedAddressTopUp,
+                0,
+                &signer,
+                Some(bip32_path),
+            )
+            .await
+            .expect("explicit BIP32-account shielded build should succeed");
+
+        // Every internal-pool entry must be spendable with the key at its own
+        // recorded path. An entry derived from the BIP44 xpub but filed under the
+        // BIP32 account's path fails exactly here — the address and the signer
+        // key disagree.
+        let entries: Vec<(DerivationPath, DashAddress)> = {
+            let mut wm = wallet_manager.write().await;
+            let (_, info) = wm
+                .get_wallet_mut_and_info_mut(&wallet_id)
+                .expect("wallet present");
+            let account = info
+                .core_wallet
+                .first_bip32_managed_account_mut()
+                .expect("managed BIP32 account 0");
+            match account.managed_account_type_mut() {
+                ManagedAccountType::Standard {
+                    internal_addresses, ..
+                } => internal_addresses
+                    .addresses
+                    .values()
+                    .map(|info| (info.path.clone(), info.address.clone()))
+                    .collect(),
+                _ => panic!("BIP32 account 0 should be a Standard managed account"),
+            }
+        };
+        assert!(
+            entries.len() > 1,
+            "the build should have appended a freshly-derived internal address"
+        );
+        for (path, address) in entries {
+            let public_key = signer
+                .public_key(&path)
+                .await
+                .expect("test wallet can derive any of its own paths");
+            let expected = DashAddress::p2pkh(
+                &dashcore::PublicKey::new(public_key),
+                dashcore::Network::Testnet,
+            );
+            assert_eq!(
+                expected, address,
+                "BIP32 internal-pool entry at {path} was derived from the wrong xpub"
+            );
+        }
     }
 
     /// On-device regression: a real CoinJoin account holds many small mixed

--- a/packages/rs-platform-wallet/src/wallet/asset_lock/build.rs
+++ b/packages/rs-platform-wallet/src/wallet/asset_lock/build.rs
@@ -36,6 +36,83 @@ use crate::wallet::platform_wallet::PlatformWalletInfo;
 use super::manager::{AssetLockManager, DEFAULT_FEE_PER_KB};
 use super::tracked::{AssetLockStatus, TrackedAssetLock};
 
+/// Caller consent for co-spending Core funds across privacy domains in a single
+/// asset-lock funding transaction (dashpay/platform#4184).
+///
+/// The multi-account shielded-funding builder unions spendable UTXOs across the
+/// wallet's funds accounts. Those accounts fall into distinct **privacy domains**
+/// (see [`PrivacyDomain`]); combining inputs from more than one domain into one
+/// L1 transaction irreversibly links those domains on-chain — and, because the
+/// key-wallet builder derives change only on transparent (BIP44/BIP32) accounts,
+/// a spend of non-transparent funds also emits transparent change. Shielding the
+/// resulting credit output afterward cannot undo that linkage.
+///
+/// The builder therefore defaults to [`CrossDomainConsent::Denied`] and confines
+/// selection to a single domain. [`CrossDomainConsent::Allowed`] is the explicit,
+/// per-request opt-in a host threads through only after obtaining user consent.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CrossDomainConsent {
+    /// Default. Confine funding selection to a single privacy domain (the
+    /// transparent BIP44/BIP32 domain, which uniquely owns the change path). If
+    /// the transparent domain alone cannot cover the amount but the wallet-wide
+    /// union could, the builder returns
+    /// [`crate::error::PlatformWalletError::AssetLockCrossDomainConsentRequired`]
+    /// rather than silently linking domains.
+    Denied,
+    /// Explicit opt-in: allow the wallet-wide union of every spendable funding
+    /// domain (BIP44 + BIP32 + CoinJoin + DashPay-receiving) in one L1
+    /// transaction. Only pass this after the caller/user has consented to the
+    /// cross-domain linkage.
+    Allowed,
+}
+
+impl CrossDomainConsent {
+    /// Map a C-ABI `bool` opt-in flag (from the FFI boundary) to the typed
+    /// consent. `true` == the host obtained user consent to cross privacy
+    /// domains; `false` (the default) confines selection to one domain.
+    pub fn from_allow_flag(allow_cross_domain: bool) -> Self {
+        if allow_cross_domain {
+            Self::Allowed
+        } else {
+            Self::Denied
+        }
+    }
+}
+
+/// The privacy domain a funds account belongs to, for cross-domain co-spend
+/// gating (dashpay/platform#4184). Ordinary BIP44 and BIP32 funds share the one
+/// transparent domain (the reviewer's "ordinary BIP44/BIP32 funds"): it holds
+/// the primary funding account and is the sole source of change, so it is the
+/// only domain that can fund a lock without creating a cross-domain change
+/// output. CoinJoin (mixed) and DashPay-receiving (contact-scoped) funds are each
+/// their own domain.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+enum PrivacyDomain {
+    /// Ordinary BIP44 + BIP32 funds. Owns the change path.
+    Transparent,
+    /// DIP-9 CoinJoin mixed outputs.
+    CoinJoin,
+    /// DashPay receiving-funds account (ours; signable).
+    DashpayReceiving,
+}
+
+/// Classify a funds account into its [`PrivacyDomain`], or `None` for accounts
+/// that must never fund an asset lock (watch-only `DashpayExternalAccount` — a
+/// contact's coins the local mnemonic can't sign). Returning `None` here is what
+/// preserves the watch-only exclusion (finding 5b52d9844055) across every
+/// consent mode, replacing the old ad-hoc skip. Non-funds account types cannot
+/// appear in `all_funding_accounts()` and also map to `None` defensively.
+fn account_privacy_domain(managed_type: &ManagedAccountType) -> Option<PrivacyDomain> {
+    match managed_type {
+        ManagedAccountType::Standard { .. } => Some(PrivacyDomain::Transparent),
+        ManagedAccountType::CoinJoin { .. } => Some(PrivacyDomain::CoinJoin),
+        ManagedAccountType::DashpayReceivingFunds { .. } => Some(PrivacyDomain::DashpayReceiving),
+        // Watch-only contact coins — never signable locally, always excluded.
+        ManagedAccountType::DashpayExternalAccount { .. } => None,
+        _ => None,
+    }
+}
+
 // ---------------------------------------------------------------------------
 // Asset lock transaction building
 // ---------------------------------------------------------------------------
@@ -63,6 +140,11 @@ impl<B: TransactionBroadcaster + ?Sized> AssetLockManager<B> {
     ///   from `platform-wallet-ffi` — built on top of the
     ///   Keychain-resolver vtable so private keys never cross the FFI
     ///   boundary.
+    ///
+    /// Uses the default [`CrossDomainConsent::Denied`] privacy-domain rule: for
+    /// shielded funding, selection is confined to the transparent (BIP44/BIP32)
+    /// domain. Call [`Self::build_asset_lock_transaction_with_consent`] to opt
+    /// into a cross-domain union after obtaining user consent.
     pub async fn build_asset_lock_transaction<S: ExtendedPubKeySigner>(
         &self,
         amount_duffs: u64,
@@ -70,6 +152,31 @@ impl<B: TransactionBroadcaster + ?Sized> AssetLockManager<B> {
         funding_type: AssetLockFundingType,
         identity_index: u32,
         signer: &S,
+    ) -> Result<(Transaction, DerivationPath), PlatformWalletError> {
+        self.build_asset_lock_transaction_with_consent(
+            amount_duffs,
+            account_index,
+            funding_type,
+            identity_index,
+            signer,
+            CrossDomainConsent::Denied,
+        )
+        .await
+    }
+
+    /// Cross-domain-aware form of [`Self::build_asset_lock_transaction`]. The
+    /// extra `cross_domain` argument controls, for shielded funding only, whether
+    /// coin selection may co-spend across privacy domains (see
+    /// [`CrossDomainConsent`]). Every non-shielded funding type keeps the
+    /// single-BIP44-account path regardless of `cross_domain`.
+    pub async fn build_asset_lock_transaction_with_consent<S: ExtendedPubKeySigner>(
+        &self,
+        amount_duffs: u64,
+        account_index: u32,
+        funding_type: AssetLockFundingType,
+        identity_index: u32,
+        signer: &S,
+        cross_domain: CrossDomainConsent,
     ) -> Result<(Transaction, DerivationPath), PlatformWalletError> {
         if amount_duffs == 0 {
             return Err(PlatformWalletError::AssetLockTransaction(
@@ -127,7 +234,9 @@ impl<B: TransactionBroadcaster + ?Sized> AssetLockManager<B> {
         // union-of-accounts builder; every other funding type keeps the
         // single-BIP44-account path (spending mixed CoinJoin coins into an
         // identity registration would de-anonymize them — a deliberate
-        // privacy choice left out of scope here).
+        // privacy choice left out of scope here). The union builder itself
+        // applies the single-privacy-domain rule per `cross_domain`
+        // (dashpay/platform#4184).
         if funding_type == AssetLockFundingType::AssetLockShieldedAddressTopUp {
             return self
                 .build_asset_lock_tx_from_all_funding_accounts(
@@ -137,6 +246,7 @@ impl<B: TransactionBroadcaster + ?Sized> AssetLockManager<B> {
                     vec![funding],
                     DEFAULT_FEE_PER_KB,
                     signer,
+                    cross_domain,
                 )
                 .await;
         }
@@ -186,11 +296,26 @@ impl<B: TransactionBroadcaster + ?Sized> AssetLockManager<B> {
     }
 
     /// Build + sign an asset-lock transaction whose funding inputs are drawn
-    /// from the UNION of every spendable Core funds account (BIP44 + BIP32 +
-    /// CoinJoin + DashPay), not just the single BIP44 account at
-    /// `account_index`.
+    /// from the eligible spendable Core funds accounts (BIP44 + BIP32, plus
+    /// CoinJoin + DashPay-receiving when the caller consents), not just the
+    /// single BIP44 account at `account_index`.
     ///
-    /// ## Why this exists (dashpay/platform#4073)
+    /// ## Privacy-domain gate (dashpay/platform#4184)
+    ///
+    /// The eligible set is governed by `cross_domain`. Funds accounts fall into
+    /// distinct **privacy domains** (see [`PrivacyDomain`]): the transparent
+    /// BIP44/BIP32 domain, the CoinJoin (mixed) domain, and the DashPay-receiving
+    /// domain. By default ([`CrossDomainConsent::Denied`]) selection is confined
+    /// to the transparent domain — it holds the primary account and is the only
+    /// domain that can supply change without linking domains (key-wallet derives
+    /// change only on transparent accounts). If the transparent domain alone
+    /// cannot cover the amount but the wallet-wide union could, the method returns
+    /// [`PlatformWalletError::AssetLockCrossDomainConsentRequired`]. With
+    /// [`CrossDomainConsent::Allowed`] the full signable union participates — the
+    /// original dashpay/platform#4073 behaviour — so a host can shield
+    /// previously-mixed CoinJoin coins after obtaining explicit user consent.
+    ///
+    /// ## Why the union path exists (dashpay/platform#4073)
     ///
     /// The pinned key-wallet `ManagedWalletInfo::build_asset_lock_with_signer`
     /// funds an asset lock from exactly ONE BIP44 standard account: it calls
@@ -232,6 +357,7 @@ impl<B: TransactionBroadcaster + ?Sized> AssetLockManager<B> {
     /// the whole build runs under the wallet write lock, and the app issues no
     /// concurrent non-shielded spend on the CoinJoin/BIP32 accounts, so the
     /// race window is not reachable in practice.
+    #[allow(clippy::too_many_arguments)]
     async fn build_asset_lock_tx_from_all_funding_accounts<S: ExtendedPubKeySigner>(
         &self,
         wallet: &Wallet,
@@ -240,18 +366,70 @@ impl<B: TransactionBroadcaster + ?Sized> AssetLockManager<B> {
         credit_output_fundings: Vec<CreditOutputFunding>,
         fee_per_kb: u64,
         signer: &S,
+        cross_domain: CrossDomainConsent,
     ) -> Result<(Transaction, DerivationPath), PlatformWalletError> {
         use std::collections::{HashMap, HashSet};
 
         let target_duffs: u64 = credit_output_fundings.iter().map(|f| f.output.value).sum();
         let height = info.core_wallet.last_processed_height();
+        let allow_cross_domain = matches!(cross_domain, CrossDomainConsent::Allowed);
         tracing::debug!(
             target_duffs,
             height,
             primary_account_index = account_index,
+            allow_cross_domain,
             funding_accounts = info.core_wallet.accounts.all_funding_accounts().len(),
             "multi-account asset-lock funding: enumerating spendable funds accounts"
         );
+
+        // Single-privacy-domain gate (dashpay/platform#4184). Total the spendable
+        // value per privacy domain: `transparent_total` is the BIP44/BIP32 domain
+        // (which holds the primary account and is the ONLY domain that can supply
+        // change without linking domains), and `union_total` sums every SIGNABLE
+        // domain (transparent + CoinJoin + DashPay-receiving). Watch-only
+        // `DashpayExternalAccount` UTXOs are excluded here by
+        // `account_privacy_domain` returning `None` — the same ownership carve-out
+        // as before (finding 5b52d9844055), now expressed through the domain map.
+        let mut transparent_total: u64 = 0;
+        let mut union_total: u64 = 0;
+        for acc in info.core_wallet.accounts.all_funding_accounts() {
+            let Some(domain) = account_privacy_domain(acc.managed_account_type()) else {
+                continue;
+            };
+            let acc_spendable: u64 = acc
+                .spendable_utxos(height)
+                .into_iter()
+                .fold(0u64, |sum, u| sum.saturating_add(u.value()));
+            union_total = union_total.saturating_add(acc_spendable);
+            if domain == PrivacyDomain::Transparent {
+                transparent_total = transparent_total.saturating_add(acc_spendable);
+            }
+        }
+
+        // Default rule: confine selection to the transparent domain. If a single
+        // transparent-domain spend cannot cover the lock but adding
+        // CoinJoin/DashPay-receiving funds would, refuse with a typed, actionable
+        // error rather than silently crossing domains (which would irreversibly
+        // link them and emit BIP44 change from non-transparent inputs). The host
+        // obtains user consent and re-issues with `CrossDomainConsent::Allowed`.
+        // Note: coin selection accounts for the L1 fee, so `transparent_total`
+        // being >= `target_duffs` here is necessary but not sufficient; a
+        // fee-driven shortfall still surfaces as `AssetLockInsufficientFunds` from
+        // the builder below. The consent gate only fires when the WIDER union is
+        // what unlocks the amount.
+        if !allow_cross_domain && transparent_total < target_duffs && union_total >= target_duffs {
+            tracing::debug!(
+                transparent_total,
+                union_total,
+                target_duffs,
+                "multi-account asset-lock funding: refusing cross-domain co-spend without consent"
+            );
+            return Err(PlatformWalletError::AssetLockCrossDomainConsentRequired {
+                transparent_available: transparent_total,
+                cross_domain_available: union_total,
+                required: target_duffs,
+            });
+        }
 
         // Snapshot the primary account's spendable outpoints so the union
         // sweep below does not add them twice: `set_funding` already seeds
@@ -269,41 +447,33 @@ impl<B: TransactionBroadcaster + ?Sized> AssetLockManager<B> {
             })
             .unwrap_or_default();
 
-        // Build, from an immutable borrow of every funds account:
+        // Build, from an immutable borrow of the ELIGIBLE funds accounts:
         //   (a) an owned `Address -> DerivationPath` resolver covering every
-        //       spendable input across ALL accounts, so signing can resolve a
-        //       key for an input selected from any account; and
-        //   (b) the explicit extra inputs (all non-primary accounts).
+        //       spendable input across the eligible accounts, so signing can
+        //       resolve a key for an input selected from any of them; and
+        //   (b) the explicit extra inputs (eligible non-primary accounts).
+        //
+        // Eligibility follows the privacy-domain gate: with consent, every
+        // signable domain participates (the full union — the dashpay/platform#4073
+        // behaviour); by default only the transparent (BIP44/BIP32) domain does.
+        // Watch-only `DashpayExternalAccount` UTXOs are never eligible in either
+        // mode (`account_privacy_domain` returns `None`), so a naive `LargestFirst`
+        // can no longer grab a contact's coins and sign them with the wrong local
+        // key (finding 5b52d9844055).
         let mut path_map: HashMap<DashAddress, DerivationPath> = HashMap::new();
         let mut extra_inputs: Vec<Utxo> = Vec::new();
-        let mut union_value: u64 = 0;
-        let mut union_count: usize = 0;
+        let mut selected_value: u64 = 0;
+        let mut selected_count: usize = 0;
         for acc in info.core_wallet.accounts.all_funding_accounts() {
-            // Never fund an asset lock from coins the local wallet holds no
-            // signing key for. `all_funding_accounts()` (in the pinned
-            // key-wallet fork) includes `dashpay_external_accounts`, and
-            // `spendable_utxos()` filters on maturity but not ownership. The
-            // managed layer stores every account's PUBLIC key only (its
-            // `KeySource` is always `Public`), so a managed-level watch-only
-            // flag cannot discriminate here — the ownership signal is the
-            // account-type variant. `DashpayExternalAccount` is the sole
-            // watch-only funds account type: production builds it from a
-            // CONTACT's decrypted xpub with `is_watch_only: true` (see
-            // `wallet/identity/network/contacts.rs`), so its UTXOs are the
-            // contact's coins. `MnemonicResolverCoreSigner` would blindly
-            // derive `acc.address_derivation_path(&utxo.address)` from the
-            // LOCAL mnemonic, yielding a different key and therefore an invalid
-            // input signature. Skip such accounts entirely — both from the
-            // path resolver and from the explicit extra inputs.
-            if matches!(
-                acc.managed_account_type(),
-                ManagedAccountType::DashpayExternalAccount { .. }
-            ) {
+            let Some(domain) = account_privacy_domain(acc.managed_account_type()) else {
+                continue;
+            };
+            if !allow_cross_domain && domain != PrivacyDomain::Transparent {
                 continue;
             }
             for utxo in acc.spendable_utxos(height) {
-                union_value = union_value.saturating_add(utxo.value());
-                union_count += 1;
+                selected_value = selected_value.saturating_add(utxo.value());
+                selected_count += 1;
                 if let Some(path) = acc.address_derivation_path(&utxo.address) {
                     path_map.insert(utxo.address.clone(), path);
                 }
@@ -313,12 +483,15 @@ impl<B: TransactionBroadcaster + ?Sized> AssetLockManager<B> {
             }
         }
         tracing::debug!(
-            union_count,
-            union_value,
+            selected_count,
+            selected_value,
+            transparent_total,
+            union_total,
+            allow_cross_domain,
             primary_count = primary_outpoints.len(),
             extra_count = extra_inputs.len(),
             resolver_entries = path_map.len(),
-            "multi-account asset-lock funding: union UTXO set assembled"
+            "multi-account asset-lock funding: eligible UTXO set assembled"
         );
 
         let acc = wallet
@@ -861,13 +1034,38 @@ impl<B: TransactionBroadcaster + ?Sized> AssetLockManager<B> {
         identity_index: u32,
         signer: &S,
     ) -> Result<(dpp::prelude::AssetLockProof, DerivationPath, OutPoint), PlatformWalletError> {
+        self.create_funded_asset_lock_proof_with_consent(
+            amount_duffs,
+            account_index,
+            funding_type,
+            identity_index,
+            signer,
+            CrossDomainConsent::Denied,
+        )
+        .await
+    }
+
+    /// Cross-domain-aware form of [`Self::create_funded_asset_lock_proof`]. The
+    /// `cross_domain` consent is threaded down to the shielded union builder;
+    /// non-shielded funding types ignore it (they never leave the single BIP44
+    /// account). See [`CrossDomainConsent`].
+    pub async fn create_funded_asset_lock_proof_with_consent<S: ExtendedPubKeySigner>(
+        &self,
+        amount_duffs: u64,
+        account_index: u32,
+        funding_type: AssetLockFundingType,
+        identity_index: u32,
+        signer: &S,
+        cross_domain: CrossDomainConsent,
+    ) -> Result<(dpp::prelude::AssetLockProof, DerivationPath, OutPoint), PlatformWalletError> {
         let (path, out_point) = self
-            .broadcast_funded_asset_lock(
+            .broadcast_funded_asset_lock_with_consent(
                 amount_duffs,
                 account_index,
                 funding_type,
                 identity_index,
                 signer,
+                cross_domain,
             )
             .await?;
         let proof = self
@@ -891,6 +1089,28 @@ impl<B: TransactionBroadcaster + ?Sized> AssetLockManager<B> {
         funding_type: AssetLockFundingType,
         identity_index: u32,
         signer: &S,
+    ) -> Result<(DerivationPath, OutPoint), PlatformWalletError> {
+        self.broadcast_funded_asset_lock_with_consent(
+            amount_duffs,
+            account_index,
+            funding_type,
+            identity_index,
+            signer,
+            CrossDomainConsent::Denied,
+        )
+        .await
+    }
+
+    /// Cross-domain-aware form of [`Self::broadcast_funded_asset_lock`]. Threads
+    /// `cross_domain` to the shielded union builder (see [`CrossDomainConsent`]).
+    pub(crate) async fn broadcast_funded_asset_lock_with_consent<S: ExtendedPubKeySigner>(
+        &self,
+        amount_duffs: u64,
+        account_index: u32,
+        funding_type: AssetLockFundingType,
+        identity_index: u32,
+        signer: &S,
+        cross_domain: CrossDomainConsent,
     ) -> Result<(DerivationPath, OutPoint), PlatformWalletError> {
         // Serialize build→persist so a concurrent build cannot interleave its
         // pool snapshot with ours. The snapshot is collected from live wallet
@@ -923,12 +1143,13 @@ impl<B: TransactionBroadcaster + ?Sized> AssetLockManager<B> {
 
         // 1. Build the asset lock transaction.
         let (tx, path) = self
-            .build_asset_lock_transaction(
+            .build_asset_lock_transaction_with_consent(
                 amount_duffs,
                 account_index,
                 funding_type,
                 identity_index,
                 signer,
+                cross_domain,
             )
             .await?;
 
@@ -1139,6 +1360,7 @@ mod tests {
     use crate::wallet::persister::WalletPersister;
     use crate::wallet::platform_wallet::PlatformWalletInfo;
     use crate::wallet::platform_wallet::WalletId;
+    use super::CrossDomainConsent;
     use crate::{AssetLockFundingType, PlatformWalletError};
 
     /// prior-no-utxos-846 (dashpay/platform#4074): the zero-spendable-candidate
@@ -2034,6 +2256,10 @@ mod tests {
     /// require 0.15 DASH — coin selection must reach across both the BIP44 and
     /// the DIP-9 CoinJoin account, and the mixed inputs must each be signed
     /// under their own account's derivation path.
+    ///
+    /// Because BIP44 and CoinJoin are DIFFERENT privacy domains, this union is a
+    /// cross-domain co-spend and requires explicit consent (dashpay/platform#4184);
+    /// the test therefore drives the `CrossDomainConsent::Allowed` path.
     #[tokio::test]
     async fn shielded_asset_lock_funds_from_bip44_and_coinjoin_union() {
         // 0.09 DASH on BIP44, 0.09 DASH on CoinJoin; require 0.15 DASH.
@@ -2041,12 +2267,13 @@ mod tests {
         let (bip44_outpoints, coinjoin_outpoints) = account_outpoints(&manager).await;
 
         let (tx, _path) = manager
-            .build_asset_lock_transaction(
+            .build_asset_lock_transaction_with_consent(
                 15_000_000,
                 0,
                 AssetLockFundingType::AssetLockShieldedAddressTopUp,
                 0,
                 &signer,
+                CrossDomainConsent::Allowed,
             )
             .await
             .expect("shielded asset lock must fund from the BIP44 + CoinJoin union");
@@ -2079,8 +2306,8 @@ mod tests {
     /// The widening is deliberately scoped to shielded funding: spending mixed
     /// CoinJoin coins into an identity registration would de-anonymize them.
     /// With the balance split 0.09/0.09, an identity-registration lock for
-    /// 0.15 DASH must still fail (BIP44 alone is short) while the shielded lock
-    /// for the same amount succeeds from the union.
+    /// 0.15 DASH must still fail (BIP44 alone is short and non-shielded funding
+    /// never reaches the union), regardless of consent.
     #[tokio::test]
     async fn non_shielded_asset_lock_stays_single_bip44_account() {
         let (manager, signer) = split_asset_lock_manager(9_000_000, 9_000_000).await;
@@ -2100,7 +2327,37 @@ mod tests {
              is short of 0.15 DASH, got {identity:?}"
         );
 
-        let shielded = manager
+        // Even with cross-domain consent, non-shielded funding stays single-BIP44.
+        let identity_consented = manager
+            .build_asset_lock_transaction_with_consent(
+                15_000_000,
+                0,
+                AssetLockFundingType::IdentityRegistration,
+                0,
+                &signer,
+                CrossDomainConsent::Allowed,
+            )
+            .await;
+        assert!(
+            identity_consented.is_err(),
+            "identity registration must ignore cross-domain consent, got {identity_consented:?}"
+        );
+    }
+
+    /// Privacy-domain gate (dashpay/platform#4184): shielded funding whose
+    /// transparent (BIP44) slice alone cannot cover the amount, but whose
+    /// BIP44 + CoinJoin union can, must be REFUSED by default with the typed
+    /// [`PlatformWalletError::AssetLockCrossDomainConsentRequired`] — and must
+    /// SUCCEED once the caller passes `CrossDomainConsent::Allowed`.
+    #[tokio::test]
+    async fn shielded_asset_lock_cross_domain_refused_without_consent() {
+        // 0.09 DASH BIP44 (transparent) + 0.09 DASH CoinJoin; require 0.15 DASH.
+        // Transparent alone (0.09) is short; the union (0.18) covers it.
+        let (manager, signer) = split_asset_lock_manager(9_000_000, 9_000_000).await;
+
+        // Default (Denied): refused with the typed cross-domain error carrying
+        // the transparent-vs-union availability.
+        let refused = manager
             .build_asset_lock_transaction(
                 15_000_000,
                 0,
@@ -2109,29 +2366,100 @@ mod tests {
                 &signer,
             )
             .await;
+        match refused {
+            Err(PlatformWalletError::AssetLockCrossDomainConsentRequired {
+                transparent_available,
+                cross_domain_available,
+                required,
+            }) => {
+                assert_eq!(transparent_available, 9_000_000, "transparent = BIP44 slice");
+                assert_eq!(cross_domain_available, 18_000_000, "union = BIP44 + CoinJoin");
+                assert_eq!(required, 15_000_000);
+            }
+            other => panic!(
+                "default funding must refuse the cross-domain co-spend with a typed \
+                 AssetLockCrossDomainConsentRequired, got {other:?}"
+            ),
+        }
+
+        // With consent: the union funds it.
+        let consented = manager
+            .build_asset_lock_transaction_with_consent(
+                15_000_000,
+                0,
+                AssetLockFundingType::AssetLockShieldedAddressTopUp,
+                0,
+                &signer,
+                CrossDomainConsent::Allowed,
+            )
+            .await;
         assert!(
-            shielded.is_ok(),
-            "shielded funding must reach the union, got {shielded:?}"
+            consented.is_ok(),
+            "shielded funding must succeed once cross-domain consent is granted, got {consented:?}"
         );
+    }
+
+    /// Privacy-domain gate happy path: when the transparent (BIP44) domain ALONE
+    /// covers the shielded lock, funding succeeds under the DEFAULT
+    /// (`CrossDomainConsent::Denied`) rule with no consent needed — and spends
+    /// only transparent inputs, never the CoinJoin coins.
+    #[tokio::test]
+    async fn shielded_asset_lock_single_transparent_domain_needs_no_consent() {
+        // 0.2 DASH BIP44 (transparent) + 0.09 DASH CoinJoin; require 0.15 DASH.
+        // Transparent alone covers it, so no cross-domain co-spend is needed.
+        let (manager, signer) = split_asset_lock_manager(20_000_000, 9_000_000).await;
+        let (bip44_outpoints, coinjoin_outpoints) = account_outpoints(&manager).await;
+
+        let (tx, _path) = manager
+            .build_asset_lock_transaction(
+                15_000_000,
+                0,
+                AssetLockFundingType::AssetLockShieldedAddressTopUp,
+                0,
+                &signer,
+            )
+            .await
+            .expect("transparent-domain-only shielded funding needs no consent");
+
+        let spent: std::collections::HashSet<OutPoint> =
+            tx.input.iter().map(|i| i.previous_output).collect();
+        assert!(
+            spent.iter().any(|o| bip44_outpoints.contains(o)),
+            "must spend transparent BIP44 inputs, tx spent {spent:?}"
+        );
+        assert!(
+            !spent.iter().any(|o| coinjoin_outpoints.contains(o)),
+            "default single-domain rule must NOT reach CoinJoin coins, tx spent {spent:?}"
+        );
+        for (i, txin) in tx.input.iter().enumerate() {
+            assert!(
+                !txin.script_sig.is_empty(),
+                "input {i} ({}) is unsigned",
+                txin.previous_output
+            );
+        }
     }
 
     /// A shielded lock exceeding even the UNION balance surfaces the typed
     /// [`PlatformWalletError::AssetLockInsufficientFunds`], and its `available`
     /// reflects the whole spendable balance (both accounts), not the BIP44
     /// slice — the pre-#4073 symptom was `available` reporting only the BIP44
-    /// portion.
+    /// portion. Driven with `CrossDomainConsent::Allowed` so the shortfall is
+    /// measured over the full union (not the transparent slice) and the
+    /// cross-domain gate does not pre-empt it.
     #[tokio::test]
     async fn shielded_asset_lock_union_shortfall_is_typed() {
         // Union spendable is 0.18 DASH; ask for 1.0 DASH.
         let (manager, signer) = split_asset_lock_manager(9_000_000, 9_000_000).await;
 
         let result = manager
-            .build_asset_lock_transaction(
+            .build_asset_lock_transaction_with_consent(
                 100_000_000,
                 0,
                 AssetLockFundingType::AssetLockShieldedAddressTopUp,
                 0,
                 &signer,
+                CrossDomainConsent::Allowed,
             )
             .await;
 
@@ -2207,12 +2535,16 @@ mod tests {
                 .build()
                 .expect("worker runtime");
             let outcome = rt
-                .block_on(manager.build_asset_lock_transaction(
+                .block_on(manager.build_asset_lock_transaction_with_consent(
                     20_000_000,
                     0,
                     AssetLockFundingType::AssetLockShieldedAddressTopUp,
                     0,
                     &signer,
+                    // 0.09 BIP44 (transparent) is short of 0.2; the CoinJoin coins
+                    // that trigger the many-UTXO selection are a cross-domain
+                    // co-spend, so drive the consented path.
+                    CrossDomainConsent::Allowed,
                 ))
                 .map(|(tx, _path)| tx);
             let _ = result_tx.send(outcome);
@@ -2304,12 +2636,15 @@ mod tests {
         };
 
         let (tx, _path) = manager
-            .build_asset_lock_transaction(
+            .build_asset_lock_transaction_with_consent(
                 20_000_000,
                 0,
                 AssetLockFundingType::AssetLockShieldedAddressTopUp,
                 0,
                 &signer,
+                // 0.09 BIP44 (transparent) is short of 0.2; funding from the
+                // 2.0 CoinJoin UTXO is a cross-domain co-spend.
+                CrossDomainConsent::Allowed,
             )
             .await
             .expect("build multi-account asset lock");
@@ -2587,12 +2922,15 @@ mod tests {
         };
 
         let (tx, _path) = manager
-            .build_asset_lock_transaction(
+            .build_asset_lock_transaction_with_consent(
                 20_000_000,
                 0,
                 AssetLockFundingType::AssetLockShieldedAddressTopUp,
                 0,
                 &signer,
+                // 0.09 BIP44 (transparent) is short of 0.2; funding from the
+                // 2.0 DashPay-receiving UTXO is a cross-domain co-spend.
+                CrossDomainConsent::Allowed,
             )
             .await
             .expect("build DashPay-funded asset lock");

--- a/packages/rs-platform-wallet/src/wallet/asset_lock/build.rs
+++ b/packages/rs-platform-wallet/src/wallet/asset_lock/build.rs
@@ -2944,6 +2944,142 @@ mod tests {
         );
     }
 
+    /// Like [`CreditKeyFailingSigner`] but counts the transaction inputs it
+    /// signs, so a selected-account test can prove the credit-key failure lands
+    /// AFTER `build_signed` has selected, signed, and therefore reserved the
+    /// account's inputs — i.e. that it genuinely reaches the post-reservation
+    /// rollback in `build_asset_lock_tx_from_selected_account`, not a shortfall
+    /// or a prefetch failure that would die before any reservation is placed.
+    struct ReservingCreditKeyFailingSigner {
+        inner: WalletSigner,
+        inputs_signed: Arc<std::sync::atomic::AtomicUsize>,
+    }
+
+    #[async_trait::async_trait]
+    impl Signer for ReservingCreditKeyFailingSigner {
+        type Error = String;
+
+        fn supported_methods(&self) -> &[key_wallet::signer::SignerMethod] {
+            self.inner.supported_methods()
+        }
+
+        async fn sign_ecdsa(
+            &self,
+            path: &DerivationPath,
+            sighash: [u8; 32],
+        ) -> Result<
+            (
+                dashcore::secp256k1::ecdsa::Signature,
+                dashcore::secp256k1::PublicKey,
+            ),
+            Self::Error,
+        > {
+            // A completed input signature means `build_signed` has already
+            // selected and reserved this input, before the credit-key round-trip.
+            self.inputs_signed
+                .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+            self.inner.sign_ecdsa(path, sighash).await
+        }
+
+        async fn public_key(
+            &self,
+            _path: &DerivationPath,
+        ) -> Result<dashcore::secp256k1::PublicKey, Self::Error> {
+            Err("simulated transient Keychain failure".to_string())
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl ExtendedPubKeySigner for ReservingCreditKeyFailingSigner {
+        async fn extended_public_key(
+            &self,
+            path: &DerivationPath,
+        ) -> Result<key_wallet::bip32::ExtendedPubKey, Self::Error> {
+            self.inner.extended_public_key(path).await
+        }
+    }
+
+    /// dashpay/platform#4184 review (thepastaclaw): the SELECTED-account builder
+    /// must release its reservation when the credit-key round-trip fails AFTER
+    /// `build_signed` has already reserved the account's inputs.
+    ///
+    /// `build_asset_lock_tx_from_selected_account` reserves the selected
+    /// account's inputs inside `build_signed`, then performs the external
+    /// `signer.public_key(&path)` credit-key request; a failure there reaches the
+    /// path-matched rollback loop that releases the reservation on the funds
+    /// account whose derivation path equals `funding_path`. The sibling test
+    /// [`delegated_builder_credit_key_failure_does_not_strand_bip44_inputs`]
+    /// exercises the pinned BIP44 (`IdentityRegistration`) path instead, where
+    /// the credit signer is wrapped by `PrefetchedCreditKeySigner` and fails
+    /// up-front during the prefetch — before any reservation is placed — so it
+    /// never covers this selected-account rollback. Only
+    /// `AssetLockShieldedAddressTopUp` with an explicit funding path reaches it,
+    /// and this PR's account-by-`funding_path` rollback is what keeps a failed
+    /// CoinJoin / DashPay-receiving / explicit-BIP32 build from stranding its
+    /// inputs until the reservation-TTL backstop.
+    ///
+    /// The account holds a single CoinJoin UTXO, so a leaked reservation is
+    /// immediately visible as a shortfall on the next build. The signer counts
+    /// signed inputs, pinning that the failure is genuinely post-reservation
+    /// (not a shortfall or prefetch failure that would strand nothing). Reverting
+    /// the rollback loop's `release_reservation` makes the rebuild fail at input
+    /// selection.
+    #[tokio::test]
+    async fn shielded_selected_account_credit_key_failure_releases_reservation() {
+        // 0.09 DASH BIP44 (change sink) + a single 0.2 DASH CoinJoin UTXO.
+        let (manager, signer) = split_asset_lock_manager_ok(9_000_000, 20_000_000).await;
+        let coinjoin_path = coinjoin_account_path_for(&*manager).await;
+
+        let inputs_signed = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let failing = ReservingCreditKeyFailingSigner {
+            inner: signer.clone(),
+            inputs_signed: Arc::clone(&inputs_signed),
+        };
+
+        // `build_signed` selects, signs, and reserves the CoinJoin UTXO; the
+        // subsequent credit-key `public_key` request then fails, driving the
+        // selected-account rollback.
+        let abandoned = manager
+            .build_asset_lock_transaction(
+                15_000_000,
+                0,
+                AssetLockFundingType::AssetLockShieldedAddressTopUp,
+                0,
+                &failing,
+                Some(coinjoin_path.clone()),
+            )
+            .await;
+        assert!(
+            abandoned.is_err(),
+            "a failing credit-output signer must abandon the selected-account build, \
+             got {abandoned:?}"
+        );
+        assert!(
+            inputs_signed.load(std::sync::atomic::Ordering::SeqCst) > 0,
+            "build_signed must have signed (and therefore reserved) the CoinJoin input \
+             before the credit-key failure, so the rollback under test is genuinely \
+             post-reservation"
+        );
+
+        // The rollback released the CoinJoin reservation: a fresh build over the
+        // same single-UTXO account reselects the freed coin and succeeds.
+        let rebuild = manager
+            .build_asset_lock_transaction(
+                15_000_000,
+                0,
+                AssetLockFundingType::AssetLockShieldedAddressTopUp,
+                0,
+                &signer,
+                Some(coinjoin_path),
+            )
+            .await;
+        assert!(
+            rebuild.is_ok(),
+            "the selected-account rollback must release the CoinJoin reservation after a \
+             post-reservation credit-key failure so the coin is reselectable, got {rebuild:?}"
+        );
+    }
+
     /// A [`WalletSigner`] that records every `public_key` request and answers
     /// only the FIRST one — every later request is a hard error. A delegated
     /// build can therefore only succeed if the credit key it needs is served

--- a/packages/rs-platform-wallet/src/wallet/asset_lock/build.rs
+++ b/packages/rs-platform-wallet/src/wallet/asset_lock/build.rs
@@ -27,7 +27,6 @@ use key_wallet::wallet::managed_wallet_info::wallet_info_interface::WalletInfoIn
 use key_wallet::wallet::managed_wallet_info::ManagedWalletInfo;
 use key_wallet::wallet::Wallet;
 use key_wallet::ManagedAccountType;
-use key_wallet::Utxo;
 
 use crate::changeset::{AccountRegistrationEntry, PlatformWalletChangeSet};
 use crate::error::PlatformWalletError;
@@ -229,12 +228,15 @@ impl<B: TransactionBroadcaster + ?Sized> AssetLockManager<B> {
     /// BIP44 *standard* account (`standard_bip44_accounts[account_index]`), so
     /// previously-mixed CoinJoin coins — which live on the DIP-9 CoinJoin
     /// account — are unreachable through it. This method composes the key-wallet
-    /// `TransactionBuilder` directly: it seeds the selected account's spendable
-    /// UTXOs as explicit inputs (`add_inputs`) and signs with a resolver over
-    /// that account's addresses. The credit-output key is still derived from the
-    /// shielded-topup account exactly as the single-account builder does (peek
-    /// path → signer pubkey → mark used), so the returned `DerivationPath` lines
-    /// up with the credit-output script the caller already peeked.
+    /// `TransactionBuilder` directly: it points the builder's `set_funding` at
+    /// the *selected* funds account (rather than the BIP44 account the pinned
+    /// builder hard-codes), so the builder seeds that account's spendable UTXOs
+    /// and reserves the chosen inputs in that same account's reservation ledger,
+    /// and signs with a resolver over that account's addresses. The
+    /// credit-output key is still derived from the shielded-topup account exactly
+    /// as the single-account builder does (peek path → signer pubkey → mark
+    /// used), so the returned `DerivationPath` lines up with the credit-output
+    /// script the caller already peeked.
     ///
     /// ## Change routing (structural BIP44 dependency)
     ///
@@ -250,9 +252,21 @@ impl<B: TransactionBroadcaster + ?Sized> AssetLockManager<B> {
     ///
     /// ## Reservations
     ///
-    /// The whole build runs under the wallet write lock and shielded funding is
-    /// single-flighted under `shield_guard`, so no concurrent build can race the
-    /// selected account's UTXOs; the builder runs without a reservation set.
+    /// Pointing `set_funding` at the selected account reserves the chosen inputs
+    /// in **that account's own `ReservationSet`** — the same single-account
+    /// reservation machinery the pinned BIP44 builder
+    /// (`build_asset_lock_with_signer`) uses, just aimed at the selected account
+    /// instead of the BIP44 one. The reservation is held across
+    /// build → broadcast and is released only when the broadcast transaction is
+    /// processed back into the wallet (its input leaves the UTXO set), when a
+    /// rejected broadcast releases it via
+    /// [`release_asset_lock_funding_reservation`](Self::release_asset_lock_funding_reservation),
+    /// or by the reservation-TTL backstop. This is load-bearing, not defensive:
+    /// the wallet write lock and `shield_guard` only serialize *shielded* builds,
+    /// so without a reservation a concurrent normal Core send (the BIP44
+    /// `build_asset_lock_with_signer` path, taken by every non-shielded funding
+    /// type) or a CoinJoin mix could reselect the selected account's UTXOs in the
+    /// build → broadcast → reconcile window and double-spend them.
     #[allow(clippy::too_many_arguments)]
     async fn build_asset_lock_tx_from_selected_account<S: ExtendedPubKeySigner>(
         &self,
@@ -264,7 +278,7 @@ impl<B: TransactionBroadcaster + ?Sized> AssetLockManager<B> {
         signer: &S,
         funding_path: Option<DerivationPath>,
     ) -> Result<(Transaction, DerivationPath), PlatformWalletError> {
-        use std::collections::HashMap;
+        use key_wallet::managed_account::ManagedCoreFundsAccount;
 
         let target_duffs: u64 = credit_output_fundings.iter().map(|f| f.output.value).sum();
         let height = info.core_wallet.last_processed_height();
@@ -297,17 +311,52 @@ impl<B: TransactionBroadcaster + ?Sized> AssetLockManager<B> {
                 })?,
         };
 
-        // Immutable pass over the funds accounts: find the ONE account whose
-        // account-level derivation path equals `funding_path`, and collect its
-        // spendable UTXOs plus an `Address -> DerivationPath` resolver so signing
-        // can resolve a key for any input selected from it. Watch-only
+        // Change must land on a Standard (BIP44) account: non-Standard accounts
+        // (CoinJoin / DashPay-receiving) cannot derive change. Route it to the
+        // BIP44 account at `account_index`. Clone the xpub-bearing account and
+        // derive the change address up front into an OWNED value, so the BIP44
+        // `&mut` borrow is dropped before we take the selected account's `&mut`
+        // for `set_funding` below (they may be different accounts of the same
+        // collection, which cannot both be borrowed mutably at once).
+        let bip44_acc = wallet
+            .get_bip44_account(account_index)
+            .ok_or_else(|| {
+                PlatformWalletError::AssetLockTransaction(format!(
+                    "BIP44 account {account_index} not found for asset-lock change routing"
+                ))
+            })?
+            .clone();
+        let credit_outputs: Vec<TxOut> = credit_output_fundings
+            .iter()
+            .map(|f| f.output.clone())
+            .collect();
+        let change_addr = {
+            let change_acc = info
+                .core_wallet
+                .accounts
+                .standard_bip44_accounts
+                .get_mut(&account_index)
+                .ok_or_else(|| {
+                    PlatformWalletError::AssetLockTransaction(format!(
+                        "managed BIP44 account {account_index} not found for asset-lock change routing"
+                    ))
+                })?;
+            change_acc
+                .next_change_address(Some(&bip44_acc.account_xpub), true)
+                .map_err(|e| {
+                    PlatformWalletError::AssetLockTransaction(format!(
+                        "failed to derive change address on BIP44 account {account_index}: {e}"
+                    ))
+                })?
+        };
+
+        // Locate the ONE funds account whose account-level derivation path
+        // equals `funding_path`, MUTABLY, so `set_funding` below reserves the
+        // selected inputs in that account's OWN reservation ledger. Watch-only
         // `DashpayExternalAccount`s are never fundable (the local mnemonic can't
         // sign them) — refuse even when their path is named explicitly.
-        let mut path_map: HashMap<DashAddress, DerivationPath> = HashMap::new();
-        let mut selected_inputs: Vec<Utxo> = Vec::new();
-        let mut selected_value: u64 = 0;
-        let mut matched = false;
-        for acc in info.core_wallet.accounts.all_funding_accounts() {
+        let mut selected: Option<&mut ManagedCoreFundsAccount> = None;
+        for acc in info.core_wallet.accounts.all_funding_accounts_mut() {
             let acc_path = acc
                 .managed_account_type()
                 .to_account_type()
@@ -326,68 +375,22 @@ impl<B: TransactionBroadcaster + ?Sized> AssetLockManager<B> {
                      coins the local wallet cannot sign; choose a signable funds account"
                 )));
             }
-            matched = true;
-            for utxo in acc.spendable_utxos(height) {
-                selected_value = selected_value.saturating_add(utxo.value());
-                if let Some(path) = acc.address_derivation_path(&utxo.address) {
-                    path_map.insert(utxo.address.clone(), path);
-                }
-                selected_inputs.push(utxo.clone());
-            }
+            selected = Some(acc);
+            break;
         }
-        if !matched {
-            return Err(PlatformWalletError::AssetLockTransaction(format!(
+        let selected = selected.ok_or_else(|| {
+            PlatformWalletError::AssetLockTransaction(format!(
                 "no spendable funds account matches funding derivation path {funding_path}"
-            )));
-        }
+            ))
+        })?;
+
         tracing::debug!(
             target_duffs,
             height,
             %funding_path,
-            selected_value,
-            selected_inputs = selected_inputs.len(),
-            resolver_entries = path_map.len(),
-            "single-account asset-lock funding: selected account UTXO set assembled"
+            candidate_utxos = selected.utxos.len(),
+            "single-account asset-lock funding: selecting + signing (LargestFirst)"
         );
-
-        // Change must land on a Standard (BIP44) account: non-Standard accounts
-        // (CoinJoin / DashPay-receiving) cannot derive change. Route it to the
-        // BIP44 account at `account_index`.
-        let acc = wallet
-            .get_bip44_account(account_index)
-            .ok_or_else(|| {
-                PlatformWalletError::AssetLockTransaction(format!(
-                    "BIP44 account {account_index} not found for asset-lock change routing"
-                ))
-            })?
-            .clone();
-        let credit_outputs: Vec<TxOut> = credit_output_fundings
-            .iter()
-            .map(|f| f.output.clone())
-            .collect();
-
-        // Derive the change address from the BIP44 account (scoped `&mut`
-        // borrow; the builder below owns the cloned change address, so no
-        // account borrow is held across the signer await).
-        let change_addr = {
-            let change_acc = info
-                .core_wallet
-                .accounts
-                .standard_bip44_accounts
-                .get_mut(&account_index)
-                .ok_or_else(|| {
-                    PlatformWalletError::AssetLockTransaction(format!(
-                        "managed BIP44 account {account_index} not found for asset-lock change routing"
-                    ))
-                })?;
-            change_acc
-                .next_change_address(Some(&acc.account_xpub), true)
-                .map_err(|e| {
-                    PlatformWalletError::AssetLockTransaction(format!(
-                        "failed to derive change address on BIP44 account {account_index}: {e}"
-                    ))
-                })?
-        };
 
         let builder = TransactionBuilder::new()
             .set_fee_rate(FeeRate::new(fee_per_kb))
@@ -408,16 +411,21 @@ impl<B: TransactionBroadcaster + ?Sized> AssetLockManager<B> {
             .set_special_payload(TransactionPayload::AssetLockPayloadType(
                 AssetLockPayload::new(credit_outputs),
             ))
+            // Seed the selected account's spendable UTXOs AND capture its
+            // reservation ledger (`set_funding` clones the account's
+            // `ReservationSet` into the builder and filters out any UTXO already
+            // reserved by another in-flight build). `build_signed`'s internal
+            // `assemble_unsigned` then reserves the chosen inputs there, holding
+            // them across build → broadcast. `set_funding` also seeds a change
+            // address, but for a non-Standard (CoinJoin / DashPay) account that
+            // derivation fails and is swallowed to `None`; we override it next
+            // with the transparent BIP44 change sink regardless.
+            .set_funding(selected, &bip44_acc)
             .set_change_address(change_addr)
-            .add_inputs(selected_inputs)
             .require_final_inputs();
 
-        tracing::debug!(
-            target_duffs,
-            "single-account asset-lock funding: selecting + signing (LargestFirst)"
-        );
         let (transaction, fee) = builder
-            .build_signed(signer, move |addr| path_map.get(&addr).cloned())
+            .build_signed(signer, |addr| selected.address_derivation_path(&addr))
             .await
             .map_err(|e| map_builder_error(e, target_duffs))?;
         tracing::debug!(
@@ -470,6 +478,73 @@ impl<B: TransactionBroadcaster + ?Sized> AssetLockManager<B> {
             "single-account asset-lock funding: credit-output key derived; returning built tx"
         );
         Ok((transaction, path))
+    }
+
+    /// Release the UTXO reservation held for `tx` after its broadcast came back
+    /// [`BroadcastError::Rejected`](crate::broadcaster::BroadcastError::Rejected),
+    /// targeting the account that actually holds it.
+    ///
+    /// Shielded funding with an explicit `funding_path` reserves on the single
+    /// funds account named by that path — which may be a non-BIP44
+    /// CoinJoin/DashPay account (dashpay/platform#4184) — so a rejected shielded
+    /// broadcast must release there. Every other funding type, and shielded
+    /// funding with the default (`None`) path (which funds from the BIP44
+    /// account at `account_index`), reserves on that BIP44 account and reuses
+    /// the shared
+    /// [`release_reservation_after_rejected_broadcast`](crate::wallet::reservations::release_reservation_after_rejected_broadcast)
+    /// helper. Releasing the wrong account would be a silent no-op (the
+    /// outpoints wouldn't be in its set), stranding the inputs until the
+    /// reservation-TTL backstop — hence the explicit routing here.
+    async fn release_asset_lock_funding_reservation(
+        &self,
+        tx: &Transaction,
+        account_index: u32,
+        funding_type: AssetLockFundingType,
+        funding_path: &Option<DerivationPath>,
+    ) {
+        if funding_type == AssetLockFundingType::AssetLockShieldedAddressTopUp {
+            if let Some(path) = funding_path {
+                let wm = self.wallet_manager.read().await;
+                let Some((_, info)) = wm.get_wallet_and_info(&self.wallet_id) else {
+                    tracing::warn!(
+                        wallet_id = %hex::encode(self.wallet_id),
+                        "could not release shielded asset-lock reservation: wallet not found"
+                    );
+                    return;
+                };
+                let network = info.core_wallet.network();
+                for acc in info.core_wallet.accounts.all_funding_accounts() {
+                    if acc
+                        .managed_account_type()
+                        .to_account_type()
+                        .derivation_path(network)
+                        .map(|p| p == *path)
+                        .unwrap_or(false)
+                    {
+                        acc.release_reservation(tx);
+                        return;
+                    }
+                }
+                tracing::warn!(
+                    wallet_id = %hex::encode(self.wallet_id),
+                    %path,
+                    "could not release shielded asset-lock reservation: no funds account \
+                     matches the funding path"
+                );
+                return;
+            }
+        }
+
+        // Non-shielded funding, or shielded funding with the default (`None`)
+        // path: the reservation lives on the BIP44 account at `account_index`.
+        crate::wallet::reservations::release_reservation_after_rejected_broadcast(
+            &self.wallet_manager,
+            &self.wallet_id,
+            key_wallet::account::account_type::StandardAccountType::BIP44Account,
+            account_index,
+            tx,
+        )
+        .await;
     }
 
     /// Peek at the next unused address from a funding account without
@@ -969,7 +1044,9 @@ impl<B: TransactionBroadcaster + ?Sized> AssetLockManager<B> {
         };
         let build_persist_guard = self.build_persist_serial.lock().await;
 
-        // 1. Build the asset lock transaction.
+        // 1. Build the asset lock transaction. Clone `funding_path` so it
+        //    survives for the reservation-release path below (a rejected
+        //    broadcast releases from the account this path named).
         let (tx, path) = self
             .build_asset_lock_transaction(
                 amount_duffs,
@@ -977,7 +1054,7 @@ impl<B: TransactionBroadcaster + ?Sized> AssetLockManager<B> {
                 funding_type,
                 identity_index,
                 signer,
-                funding_path,
+                funding_path.clone(),
             )
             .await?;
 
@@ -1040,14 +1117,12 @@ impl<B: TransactionBroadcaster + ?Sized> AssetLockManager<B> {
         );
 
         // 3. Broadcast. On a definitive pre-send rejection, untrack the
-        //    `Built` row BEFORE releasing the funding reservation (the
-        //    asset-lock builder funds from the BIP44 account at
-        //    `account_index`): while the reservation is held the inputs
-        //    cannot be re-selected by a new build, and once the row is gone
-        //    `resume_asset_lock` can no longer re-drive the rejected
-        //    transaction — so at no point is the row resumable while its
-        //    inputs are re-spendable. A `MaybeSent` failure keeps both the
-        //    reservation and the resumable row.
+        //    `Built` row BEFORE releasing the funding reservation: while the
+        //    reservation is held the inputs cannot be re-selected by a new
+        //    build, and once the row is gone `resume_asset_lock` can no longer
+        //    re-drive the rejected transaction — so at no point is the row
+        //    resumable while its inputs are re-spendable. A `MaybeSent` failure
+        //    keeps both the reservation and the resumable row.
         if let Err(e) = self.broadcaster.broadcast(&tx).await {
             if matches!(e, crate::broadcaster::BroadcastError::Rejected { .. }) {
                 let cs_untrack = self.untrack_asset_lock(&out_point).await;
@@ -1061,12 +1136,16 @@ impl<B: TransactionBroadcaster + ?Sized> AssetLockManager<B> {
                 let removed_built_row = cs_untrack.removed.contains(&out_point);
                 self.queue_asset_lock_changeset(cs_untrack);
                 if removed_built_row {
-                    crate::wallet::reservations::release_reservation_after_rejected_broadcast(
-                        &self.wallet_manager,
-                        &self.wallet_id,
-                        key_wallet::account::account_type::StandardAccountType::BIP44Account,
-                        account_index,
+                    // Release from whichever account actually holds the
+                    // reservation: the selected funds account for shielded
+                    // funding (possibly the CoinJoin/DashPay account named by
+                    // `funding_path`), or the BIP44 account at `account_index`
+                    // for every non-shielded funding type.
+                    self.release_asset_lock_funding_reservation(
                         &tx,
+                        account_index,
+                        funding_type,
+                        &funding_path,
                     )
                     .await;
                 }
@@ -2351,6 +2430,149 @@ mod tests {
                 "expected typed AssetLockInsufficientFunds for the named account, got {other:?}"
             ),
         }
+    }
+
+    /// Like [`split_asset_lock_manager`] but over an `AlwaysOkBroadcaster`, so a
+    /// build+broadcast leaves the funding reservation HELD (a successful
+    /// broadcast keeps the reservation until the tx is processed back in).
+    async fn split_asset_lock_manager_ok(
+        bip44_duffs: u64,
+        coinjoin_duffs: u64,
+    ) -> (Arc<AssetLockManager<AlwaysOkBroadcaster>>, WalletSigner) {
+        let (wallet_manager, wallet_id, signer) =
+            crate::test_support::split_funded_wallet_manager(bip44_duffs, coinjoin_duffs).await;
+        let persistence = Arc::new(CapturingPersistence::default());
+        let sdk = Arc::new(dash_sdk::SdkBuilder::new_mock().build().expect("mock sdk"));
+        let manager = Arc::new(AssetLockManager::new(
+            sdk,
+            wallet_manager,
+            wallet_id,
+            Arc::new(Notify::new()),
+            Arc::new(AlwaysOkBroadcaster),
+            WalletPersister::new(
+                wallet_id,
+                Arc::clone(&persistence) as Arc<dyn PlatformWalletPersistence>,
+            ),
+        ));
+        (manager, signer)
+    }
+
+    /// The account-level derivation path of CoinJoin account 0 — generic sibling
+    /// of [`coinjoin_account_path`] usable with any broadcaster.
+    async fn coinjoin_account_path_for<B: TransactionBroadcaster>(
+        manager: &AssetLockManager<B>,
+    ) -> DerivationPath {
+        use key_wallet::managed_account::managed_account_trait::ManagedAccountTrait;
+        let wm = manager.wallet_manager.read().await;
+        let (_, info) = wm
+            .get_wallet_and_info(&manager.wallet_id)
+            .expect("wallet present");
+        let network = info.core_wallet.network();
+        info.core_wallet
+            .accounts
+            .coinjoin_accounts
+            .get(&0)
+            .expect("coinjoin account 0 present")
+            .managed_account_type()
+            .to_account_type()
+            .derivation_path(network)
+            .expect("coinjoin account-level path")
+    }
+
+    /// dashpay/platform#4184 reservation regression: a selected-account
+    /// (CoinJoin) shielded build must reserve its inputs in the CoinJoin
+    /// account's OWN ledger and HOLD them across broadcast. Otherwise a
+    /// concurrent normal Core send (the BIP44 `build_asset_lock_with_signer`
+    /// path) or a CoinJoin mix could reselect the same UTXOs in the
+    /// build→broadcast window and double-spend — the wallet write lock and
+    /// `shield_guard` only serialize *shielded* builds. Proven via the observable
+    /// proxy the other reservation tests use: while the single CoinJoin UTXO is
+    /// reserved, a fresh build over that account fails at input selection.
+    #[tokio::test]
+    async fn shielded_selected_account_build_reserves_its_inputs() {
+        // 0.09 DASH BIP44 (change sink) + a single 0.2 DASH CoinJoin UTXO.
+        let (manager, signer) = split_asset_lock_manager_ok(9_000_000, 20_000_000).await;
+        let coinjoin_path = coinjoin_account_path_for(&*manager).await;
+
+        // Build + broadcast a lock funded strictly from the CoinJoin account. A
+        // successful broadcast keeps the reservation held.
+        manager
+            .broadcast_funded_asset_lock(
+                15_000_000,
+                0,
+                AssetLockFundingType::AssetLockShieldedAddressTopUp,
+                0,
+                &signer,
+                Some(coinjoin_path.clone()),
+            )
+            .await
+            .expect("first shielded build+broadcast must succeed");
+
+        // The single CoinJoin UTXO is now reserved, so a second build over the
+        // same account cannot reselect it and fails at input selection.
+        let rebuild = manager
+            .build_asset_lock_transaction(
+                15_000_000,
+                0,
+                AssetLockFundingType::AssetLockShieldedAddressTopUp,
+                0,
+                &signer,
+                Some(coinjoin_path),
+            )
+            .await;
+        assert!(
+            matches!(
+                rebuild,
+                Err(PlatformWalletError::AssetLockInsufficientFunds { .. })
+            ),
+            "the selected CoinJoin UTXO must stay reserved across broadcast so a \
+             concurrent build cannot reselect it, got {rebuild:?}"
+        );
+    }
+
+    /// A rejected shielded broadcast must release the reservation held on the
+    /// SELECTED (CoinJoin) account — not the BIP44 change-sink account — so a
+    /// fresh build immediately reselects the freed coin. Guards the path-aware
+    /// [`AssetLockManager::release_asset_lock_funding_reservation`]: a naive
+    /// release against BIP44 would silently no-op and strand the CoinJoin coin
+    /// until the TTL backstop.
+    #[tokio::test]
+    async fn rejected_shielded_selected_account_broadcast_releases_reservation() {
+        let (manager, signer) = split_asset_lock_manager(9_000_000, 20_000_000).await;
+        let coinjoin_path = coinjoin_account_path(&manager).await;
+
+        let result = manager
+            .create_funded_asset_lock_proof(
+                15_000_000,
+                0,
+                AssetLockFundingType::AssetLockShieldedAddressTopUp,
+                0,
+                &signer,
+                Some(coinjoin_path.clone()),
+            )
+            .await;
+        assert!(
+            matches!(result, Err(PlatformWalletError::TransactionBroadcast(_))),
+            "rejected broadcast should surface as TransactionBroadcast, got {result:?}"
+        );
+
+        // The CoinJoin reservation was released on rejection: a fresh build over
+        // the same single-UTXO account reselects the freed coin and succeeds.
+        let rebuild = manager
+            .build_asset_lock_transaction(
+                15_000_000,
+                0,
+                AssetLockFundingType::AssetLockShieldedAddressTopUp,
+                0,
+                &signer,
+                Some(coinjoin_path),
+            )
+            .await;
+        assert!(
+            rebuild.is_ok(),
+            "a rejected selected-account broadcast must release the CoinJoin \
+             reservation so the coin is reselectable, got {rebuild:?}"
+        );
     }
 
     /// On-device regression: a real CoinJoin account holds many small mixed

--- a/packages/rs-platform-wallet/src/wallet/asset_lock/build.rs
+++ b/packages/rs-platform-wallet/src/wallet/asset_lock/build.rs
@@ -189,17 +189,41 @@ impl<B: TransactionBroadcaster + ?Sized> AssetLockManager<B> {
         // variant. The `Private` arm would only come from the soft-
         // wallet `build_asset_lock` path which we no longer call from
         // platform-wallet — defensively bail if it appears.
+        // `build_asset_lock_with_signer` has already RESERVED the transaction's
+        // inputs on the BIP44 account at `account_index`. The two error arms
+        // below abandon that signed-but-un-broadcast transaction, so — like the
+        // shielded path above — each must roll the reservation back or the
+        // inputs stay stranded until the reservation-TTL backstop
+        // (dashpay/platform#4184 review). These arms are defensive (the
+        // signer-driven builder always returns a non-empty `Public`), but the
+        // rollback keeps the invariant total: no abandon path strands inputs.
         use key_wallet::wallet::managed_wallet_info::asset_lock_builder::AssetLockCreditKeys;
         let path = match result.keys {
-            AssetLockCreditKeys::Public(mut keys) => {
-                let (_pubkey, path) = keys.drain(..).next().ok_or_else(|| {
-                    PlatformWalletError::AssetLockTransaction(
+            AssetLockCreditKeys::Public(mut keys) => match keys.drain(..).next() {
+                Some((_pubkey, path)) => path,
+                None => {
+                    if let Some(acc) = info
+                        .core_wallet
+                        .accounts
+                        .standard_bip44_accounts
+                        .get(&account_index)
+                    {
+                        acc.release_reservation(&result.transaction);
+                    }
+                    return Err(PlatformWalletError::AssetLockTransaction(
                         "Builder returned no credit-output keys".to_string(),
-                    )
-                })?;
-                path
-            }
+                    ));
+                }
+            },
             AssetLockCreditKeys::Private(_) => {
+                if let Some(acc) = info
+                    .core_wallet
+                    .accounts
+                    .standard_bip44_accounts
+                    .get(&account_index)
+                {
+                    acc.release_reservation(&result.transaction);
+                }
                 return Err(PlatformWalletError::AssetLockTransaction(
                     "Builder returned Private keys; signer-driven path expected Public".to_string(),
                 ));
@@ -468,39 +492,91 @@ impl<B: TransactionBroadcaster + ?Sized> AssetLockManager<B> {
         // mirroring the pinned single-account builder's phase-1/2/3 sequence
         // (peek without marking → signer round-trip → commit the index) so a
         // signer failure never irreversibly consumes a pool index.
-        let (path, index) = {
-            let credit_account = info
-                .core_wallet
-                .accounts
-                .asset_lock_shielded_address_topup
-                .as_mut()
-                .ok_or_else(|| {
-                    PlatformWalletError::AssetLockTransaction(
-                        "Asset lock shielded address top-up account not found".to_string(),
-                    )
-                })?;
-            credit_account
-                .peek_next_path()
-                .map_err(|e| PlatformWalletError::AssetLockTransaction(e.to_string()))?
-        };
-        signer.public_key(&path).await.map_err(|e| {
-            PlatformWalletError::AssetLockTransaction(format!("signer public_key failed: {e}"))
-        })?;
-        {
-            let credit_account = info
-                .core_wallet
-                .accounts
-                .asset_lock_shielded_address_topup
-                .as_mut()
-                .ok_or_else(|| {
-                    PlatformWalletError::AssetLockTransaction(
-                        "Asset lock shielded address top-up account not found".to_string(),
-                    )
-                })?;
-            credit_account
-                .mark_first_pool_index_used(index)
-                .map_err(|e| PlatformWalletError::AssetLockTransaction(e.to_string()))?;
+        //
+        // `build_signed` above already RESERVED this transaction's inputs in the
+        // selected account's `ReservationSet`, and the reservation is normally
+        // held all the way to broadcast. But every step below can still fail
+        // (missing shielded-topup account, `peek_next_path`, the signer
+        // round-trip, `mark_first_pool_index_used`), and each such failure
+        // abandons a signed transaction that never reaches the wire. Without a
+        // rollback those reserved inputs would stay stranded until the
+        // reservation-TTL backstop (~24 blocks), silently withholding the coins
+        // from any other send in the meantime (dashpay/platform#4184 review,
+        // thepastaclaw). So derive the key inside an inner future whose `Result`
+        // we inspect, and on ANY error release the reservation before
+        // propagating. The lookup mirrors `release_asset_lock_funding_reservation`
+        // (match the selected funds account by `funding_path`); it must run on a
+        // fresh shared borrow of `info` because the `&mut selected` used for
+        // `set_funding` cannot be revived across the credit-account borrows above.
+        let derive_credit_key = async {
+            let (path, index) = {
+                let credit_account = info
+                    .core_wallet
+                    .accounts
+                    .asset_lock_shielded_address_topup
+                    .as_mut()
+                    .ok_or_else(|| {
+                        PlatformWalletError::AssetLockTransaction(
+                            "Asset lock shielded address top-up account not found".to_string(),
+                        )
+                    })?;
+                credit_account
+                    .peek_next_path()
+                    .map_err(|e| PlatformWalletError::AssetLockTransaction(e.to_string()))?
+            };
+            signer.public_key(&path).await.map_err(|e| {
+                PlatformWalletError::AssetLockTransaction(format!("signer public_key failed: {e}"))
+            })?;
+            {
+                let credit_account = info
+                    .core_wallet
+                    .accounts
+                    .asset_lock_shielded_address_topup
+                    .as_mut()
+                    .ok_or_else(|| {
+                        PlatformWalletError::AssetLockTransaction(
+                            "Asset lock shielded address top-up account not found".to_string(),
+                        )
+                    })?;
+                credit_account
+                    .mark_first_pool_index_used(index)
+                    .map_err(|e| PlatformWalletError::AssetLockTransaction(e.to_string()))?;
+            }
+            Ok::<DerivationPath, PlatformWalletError>(path)
         }
+        .await;
+
+        let path = match derive_credit_key {
+            Ok(path) => path,
+            Err(e) => {
+                // Abandon path: roll back the reservation `build_signed` placed
+                // on the selected funds account so its inputs are immediately
+                // reselectable, rather than stranded until the reservation-TTL
+                // backstop.
+                let mut released = false;
+                for acc in info.core_wallet.accounts.all_funding_accounts() {
+                    if acc
+                        .managed_account_type()
+                        .to_account_type()
+                        .derivation_path(network)
+                        .map(|p| p == funding_path)
+                        .unwrap_or(false)
+                    {
+                        acc.release_reservation(&transaction);
+                        released = true;
+                        break;
+                    }
+                }
+                if !released {
+                    tracing::warn!(
+                        %funding_path,
+                        "abandoned signed asset-lock tx but could not release its reservation: \
+                         no funds account matches the funding path (inputs will free on TTL)"
+                    );
+                }
+                return Err(e);
+            }
+        };
 
         tracing::debug!(
             selected_inputs = transaction.input.len(),
@@ -1112,6 +1188,21 @@ impl<B: TransactionBroadcaster + ?Sized> AssetLockManager<B> {
         if let Err(e) = pool_durability {
             tracing::error!(error = %e, "failed to persist asset-lock funding index");
             if funding_type == AssetLockFundingType::IdentityInvitation {
+                // Aborting a SIGNED but un-broadcast transaction: `build`'s inputs
+                // are still reserved (the reservation is held from build through
+                // broadcast). Roll it back before bailing, or the funding inputs
+                // stay stranded until the reservation-TTL backstop
+                // (dashpay/platform#4184 review — abandon before broadcast). Safe
+                // to route through `release_asset_lock_funding_reservation` here:
+                // `build_asset_lock_transaction` already dropped the wallet write
+                // lock on return, so re-acquiring the read lock does not deadlock.
+                self.release_asset_lock_funding_reservation(
+                    &tx,
+                    account_index,
+                    funding_type,
+                    &funding_path,
+                )
+                .await;
                 return Err(PlatformWalletError::AssetLockTransaction(format!(
                     "aborted before broadcast: could not durably record the invitation \
                      funding index (broadcasting anyway would risk voucher-key reuse on \

--- a/packages/rs-platform-wallet/src/wallet/asset_lock/mod.rs
+++ b/packages/rs-platform-wallet/src/wallet/asset_lock/mod.rs
@@ -10,5 +10,6 @@ pub mod orchestration;
 mod sync;
 pub mod tracked;
 
+pub use build::CrossDomainConsent;
 pub use lock_notify_handler::LockNotifyHandler;
 pub use orchestration::AssetLockFunding;

--- a/packages/rs-platform-wallet/src/wallet/asset_lock/mod.rs
+++ b/packages/rs-platform-wallet/src/wallet/asset_lock/mod.rs
@@ -10,6 +10,5 @@ pub mod orchestration;
 mod sync;
 pub mod tracked;
 
-pub use build::CrossDomainConsent;
 pub use lock_notify_handler::LockNotifyHandler;
 pub use orchestration::AssetLockFunding;

--- a/packages/rs-platform-wallet/src/wallet/asset_lock/orchestration.rs
+++ b/packages/rs-platform-wallet/src/wallet/asset_lock/orchestration.rs
@@ -403,18 +403,49 @@ impl<B: TransactionBroadcaster + ?Sized> AssetLockManager<B> {
     where
         AS: ::key_wallet::signer::ExtendedPubKeySigner + Send + Sync,
     {
+        // Non-shielded funding never leaves the single BIP44 account, so the
+        // default single-privacy-domain rule applies. Shielded fund-from-asset-lock
+        // routes through the consent-bearing variant instead.
+        self.resolve_funding_with_is_timeout_fallback_with_consent(
+            funding,
+            funding_type,
+            destination_index,
+            asset_lock_signer,
+            crate::CrossDomainConsent::Denied,
+        )
+        .await
+    }
+
+    /// Cross-domain-aware form of
+    /// [`Self::resolve_funding_with_is_timeout_fallback`]. `cross_domain` is
+    /// threaded to the shielded union builder for the `FromWalletBalance` path;
+    /// the `FromExistingAssetLock` resume path ignores it (the lock is already
+    /// on-chain, so no fresh coin selection occurs). See
+    /// [`crate::CrossDomainConsent`].
+    pub(crate) async fn resolve_funding_with_is_timeout_fallback_with_consent<AS>(
+        &self,
+        funding: AssetLockFunding,
+        funding_type: AssetLockFundingType,
+        destination_index: u32,
+        asset_lock_signer: &AS,
+        cross_domain: crate::CrossDomainConsent,
+    ) -> Result<FundingResolution, PlatformWalletError>
+    where
+        AS: ::key_wallet::signer::ExtendedPubKeySigner + Send + Sync,
+    {
         match funding {
             AssetLockFunding::FromWalletBalance {
                 amount_duffs,
                 account_index,
             } => {
                 match self
-                    .create_funded_asset_lock_proof(
+                    .create_funded_asset_lock_proof_with_consent(
                         amount_duffs,
                         account_index,
                         funding_type,
                         destination_index,
                         asset_lock_signer,
+                        cross_domain,
                     )
                     .await
                 {

--- a/packages/rs-platform-wallet/src/wallet/asset_lock/orchestration.rs
+++ b/packages/rs-platform-wallet/src/wallet/asset_lock/orchestration.rs
@@ -121,27 +121,36 @@ pub enum AssetLockFunding {
     /// - `AssetLockAddressTopUp` — for platform-address funding flows
     /// - others — see [`AssetLockFundingType`]
     ///
-    /// `account_index` selects the PRIMARY BIP44 *standard* account (by
-    /// BIP44 account index) — it supplies the change address and its
-    /// reservation ledger gates concurrent primary-account builds.
+    /// `account_index` selects the BIP44 *standard* account that supplies the
+    /// transparent CHANGE address (key-wallet derives change only on Standard
+    /// accounts, so a non-Standard funding source must still sink change here).
+    /// For non-shielded funding it is also the sole INPUT source.
     ///
     /// Input SELECTION scope depends on the funding type:
     ///
-    /// - `AssetLockShieldedAddressTopUp` — funds from the UNION of every
-    ///   spendable funds account (BIP44 + BIP32 + CoinJoin + DashPay), so
-    ///   previously-mixed CoinJoin coins can be shielded
-    ///   (dashpay/platform#4073). See
-    ///   [`AssetLockManager::build_asset_lock_tx_from_all_funding_accounts`].
+    /// - `AssetLockShieldedAddressTopUp` — funds strictly from the SINGLE funds
+    ///   account named by the caller's `funding_path` argument
+    ///   (dashpay/platform#4184): `None` funds from the unmixed BIP44 account at
+    ///   `account_index`, while an explicit account-level path (e.g. the DIP-9
+    ///   CoinJoin account) funds from that one account so previously-mixed
+    ///   CoinJoin coins can be shielded (dashpay/platform#4073), with change
+    ///   routed to the BIP44 account. There is no union across accounts and no
+    ///   privacy-domain consent gate — the caller names exactly one funding
+    ///   source, and that account's OWN reservation ledger gates concurrent
+    ///   builds against its UTXOs. See
+    ///   [`AssetLockManager::build_asset_lock_tx_from_selected_account`].
     /// - every other funding type — funds from the single BIP44 account at
     ///   `account_index` only (spending mixed CoinJoin coins into an
     ///   identity registration would de-anonymize them). This is the pinned
-    ///   key-wallet `build_asset_lock_with_signer` behavior.
+    ///   key-wallet `build_asset_lock_with_signer` behavior, whose reservation
+    ///   ledger gates concurrent builds on that BIP44 account.
     FromWalletBalance {
         /// Amount to lock (in duffs).
         amount_duffs: u64,
-        /// Primary BIP44 standard-account index. Supplies the change
-        /// address and reservation ledger; for shielded funding the input
-        /// set is widened to every spendable funds account (see above).
+        /// BIP44 standard-account index. Supplies the transparent change
+        /// address, and for non-shielded funding is also the input source. For
+        /// shielded funding the inputs come from the single account named by the
+        /// caller's `funding_path` (`None` = this BIP44 account); see above.
         account_index: u32,
     },
 

--- a/packages/rs-platform-wallet/src/wallet/asset_lock/orchestration.rs
+++ b/packages/rs-platform-wallet/src/wallet/asset_lock/orchestration.rs
@@ -393,42 +393,21 @@ impl<B: TransactionBroadcaster + ?Sized> AssetLockManager<B> {
     /// carries the *exact* outpoint that timed out (no
     /// `find_tracked_unproven_lock` BTreeMap walk needed), so the
     /// `IsTimeout` outcome is built directly from the error payload.
+    ///
+    /// `funding_path` selects the single funds account for shielded
+    /// fund-from-asset-lock's fresh `FromWalletBalance` build (`None` = the
+    /// unmixed BIP44 account at the funding `account_index`; `Some(path)` = the
+    /// one funds account whose account-level path equals `path`, e.g. CoinJoin).
+    /// Non-shielded funding ignores it, and the `FromExistingAssetLock` resume
+    /// path ignores it too (the lock is already on-chain, so no fresh coin
+    /// selection occurs). See [`Self::build_asset_lock_transaction`].
     pub(crate) async fn resolve_funding_with_is_timeout_fallback<AS>(
         &self,
         funding: AssetLockFunding,
         funding_type: AssetLockFundingType,
         destination_index: u32,
         asset_lock_signer: &AS,
-    ) -> Result<FundingResolution, PlatformWalletError>
-    where
-        AS: ::key_wallet::signer::ExtendedPubKeySigner + Send + Sync,
-    {
-        // Non-shielded funding never leaves the single BIP44 account, so the
-        // default single-privacy-domain rule applies. Shielded fund-from-asset-lock
-        // routes through the consent-bearing variant instead.
-        self.resolve_funding_with_is_timeout_fallback_with_consent(
-            funding,
-            funding_type,
-            destination_index,
-            asset_lock_signer,
-            crate::CrossDomainConsent::Denied,
-        )
-        .await
-    }
-
-    /// Cross-domain-aware form of
-    /// [`Self::resolve_funding_with_is_timeout_fallback`]. `cross_domain` is
-    /// threaded to the shielded union builder for the `FromWalletBalance` path;
-    /// the `FromExistingAssetLock` resume path ignores it (the lock is already
-    /// on-chain, so no fresh coin selection occurs). See
-    /// [`crate::CrossDomainConsent`].
-    pub(crate) async fn resolve_funding_with_is_timeout_fallback_with_consent<AS>(
-        &self,
-        funding: AssetLockFunding,
-        funding_type: AssetLockFundingType,
-        destination_index: u32,
-        asset_lock_signer: &AS,
-        cross_domain: crate::CrossDomainConsent,
+        funding_path: Option<::key_wallet::bip32::DerivationPath>,
     ) -> Result<FundingResolution, PlatformWalletError>
     where
         AS: ::key_wallet::signer::ExtendedPubKeySigner + Send + Sync,
@@ -439,13 +418,13 @@ impl<B: TransactionBroadcaster + ?Sized> AssetLockManager<B> {
                 account_index,
             } => {
                 match self
-                    .create_funded_asset_lock_proof_with_consent(
+                    .create_funded_asset_lock_proof(
                         amount_duffs,
                         account_index,
                         funding_type,
                         destination_index,
                         asset_lock_signer,
-                        cross_domain,
+                        funding_path,
                     )
                     .await
                 {

--- a/packages/rs-platform-wallet/src/wallet/asset_lock/orchestration.rs
+++ b/packages/rs-platform-wallet/src/wallet/asset_lock/orchestration.rs
@@ -121,20 +121,27 @@ pub enum AssetLockFunding {
     /// - `AssetLockAddressTopUp` — for platform-address funding flows
     /// - others — see [`AssetLockFundingType`]
     ///
-    /// `account_index` selects which BIP44 *standard* account (by
-    /// BIP44 account index) supplies the UTXOs. Only BIP44 standard
-    /// accounts are supported today — CoinJoin / BIP32 funding for
-    /// any asset-lock-funded operation is out of scope and would
-    /// require additional plumbing in
-    /// [`AssetLockManager::create_funded_asset_lock_proof`].
+    /// `account_index` selects the PRIMARY BIP44 *standard* account (by
+    /// BIP44 account index) — it supplies the change address and its
+    /// reservation ledger gates concurrent primary-account builds.
+    ///
+    /// Input SELECTION scope depends on the funding type:
+    ///
+    /// - `AssetLockShieldedAddressTopUp` — funds from the UNION of every
+    ///   spendable funds account (BIP44 + BIP32 + CoinJoin + DashPay), so
+    ///   previously-mixed CoinJoin coins can be shielded
+    ///   (dashpay/platform#4073). See
+    ///   [`AssetLockManager::build_asset_lock_tx_from_all_funding_accounts`].
+    /// - every other funding type — funds from the single BIP44 account at
+    ///   `account_index` only (spending mixed CoinJoin coins into an
+    ///   identity registration would de-anonymize them). This is the pinned
+    ///   key-wallet `build_asset_lock_with_signer` behavior.
     FromWalletBalance {
         /// Amount to lock (in duffs).
         amount_duffs: u64,
-        /// BIP44 standard-account index to draw the funding UTXOs from.
-        ///
-        /// Only BIP44 standard accounts (`AccountType::Standard` with
-        /// `StandardAccountTypeTag::Bip44`) are supported today;
-        /// CoinJoin / BIP32 are not.
+        /// Primary BIP44 standard-account index. Supplies the change
+        /// address and reservation ledger; for shielded funding the input
+        /// set is widened to every spendable funds account (see above).
         account_index: u32,
     },
 

--- a/packages/rs-platform-wallet/src/wallet/asset_lock/sync/recovery.rs
+++ b/packages/rs-platform-wallet/src/wallet/asset_lock/sync/recovery.rs
@@ -550,6 +550,7 @@ mod tests {
                 AssetLockFundingType::IdentityRegistration,
                 4,
                 &signer,
+                None,
             )
             .await
             .expect("build asset lock");
@@ -691,6 +692,7 @@ mod tests {
                 AssetLockFundingType::IdentityTopUp,
                 TOPUP_INDEX,
                 &signer,
+                None,
             )
             .await
             .expect("build top-up asset lock");

--- a/packages/rs-platform-wallet/src/wallet/identity/network/invitation.rs
+++ b/packages/rs-platform-wallet/src/wallet/identity/network/invitation.rs
@@ -278,6 +278,8 @@ impl IdentityWallet {
                 AssetLockFundingType::IdentityInvitation,
                 0,
                 asset_lock_signer,
+                // Non-shielded funding always uses the single BIP44 account.
+                None,
             )
             .await?;
 

--- a/packages/rs-platform-wallet/src/wallet/identity/network/registration.rs
+++ b/packages/rs-platform-wallet/src/wallet/identity/network/registration.rs
@@ -173,6 +173,8 @@ impl IdentityWallet {
                 AssetLockFundingType::IdentityRegistration,
                 identity_index,
                 asset_lock_signer,
+                // Non-shielded funding always uses the single BIP44 account.
+                None,
             )
             .await?
         {
@@ -428,6 +430,8 @@ impl IdentityWallet {
                 AssetLockFundingType::IdentityTopUp,
                 identity_index,
                 asset_lock_signer,
+                // Non-shielded funding always uses the single BIP44 account.
+                None,
             )
             .await?
         {

--- a/packages/rs-platform-wallet/src/wallet/platform_addresses/fund_from_asset_lock.rs
+++ b/packages/rs-platform-wallet/src/wallet/platform_addresses/fund_from_asset_lock.rs
@@ -169,6 +169,8 @@ impl PlatformAddressWallet {
                 AssetLockFundingType::AssetLockAddressTopUp,
                 /* destination_index */ 0,
                 asset_lock_signer,
+                // Non-shielded funding always uses the single BIP44 account.
+                None,
             )
             .await?
         {

--- a/packages/rs-platform-wallet/src/wallet/shielded/fund_from_asset_lock.rs
+++ b/packages/rs-platform-wallet/src/wallet/shielded/fund_from_asset_lock.rs
@@ -127,13 +127,16 @@ impl PlatformWallet {
     ///   shielded seed pool passes `Some(CL_FALLBACK_TIMEOUT)` so a
     ///   `FinalityTimeout` surfaces as its unconfirmed-ancestor pacing
     ///   signal (see `seed_pool.rs`).
-    /// * `cross_domain` — Cross-privacy-domain co-spend consent for the
-    ///   asset-lock funding coin selection (dashpay/platform#4184). Defaults
-    ///   should be [`crate::CrossDomainConsent::Denied`]; pass
-    ///   [`crate::CrossDomainConsent::Allowed`] only after the user has
-    ///   consented to draw the L1 lock from CoinJoin / DashPay-receiving funds
-    ///   in addition to transparent BIP44/BIP32 funds. Ignored for the
-    ///   `FromExistingAssetLock` resume path (no fresh coin selection occurs).
+    /// * `funding_path` — The account-level derivation path of the SINGLE funds
+    ///   account whose UTXOs fund the L1 asset lock, for the fresh
+    ///   `FromWalletBalance` build. `None` funds from the unmixed BIP44 account
+    ///   (the default); `Some(path)` funds strictly from the one funds account
+    ///   whose account-level path equals `path` — e.g. the DIP-9 CoinJoin
+    ///   account, to shield previously-mixed coins (dashpay/platform#4073). There
+    ///   is no union across accounts and no privacy-domain consent gate: the
+    ///   caller names exactly one funding source (dashpay/platform#4184).
+    ///   Ignored for the `FromExistingAssetLock` resume path (no fresh coin
+    ///   selection occurs).
     #[cfg(feature = "shielded")]
     #[allow(clippy::too_many_arguments)]
     pub async fn shielded_fund_from_asset_lock<AS, P>(
@@ -147,7 +150,7 @@ impl PlatformWallet {
         dummy_outputs: usize,
         settings: Option<PutSettings>,
         cl_wait: Option<Duration>,
-        cross_domain: crate::CrossDomainConsent,
+        funding_path: Option<::key_wallet::bip32::DerivationPath>,
     ) -> Result<(), PlatformWalletError>
     where
         AS: ::key_wallet::signer::ExtendedPubKeySigner + Send + Sync,
@@ -216,12 +219,12 @@ impl PlatformWallet {
             tracked_out_point,
         } = match self
             .asset_locks
-            .resolve_funding_with_is_timeout_fallback_with_consent(
+            .resolve_funding_with_is_timeout_fallback(
                 funding,
                 AssetLockFundingType::AssetLockShieldedAddressTopUp,
                 /* destination_index */ 0,
                 asset_lock_signer,
-                cross_domain,
+                funding_path,
             )
             .await?
         {

--- a/packages/rs-platform-wallet/src/wallet/shielded/fund_from_asset_lock.rs
+++ b/packages/rs-platform-wallet/src/wallet/shielded/fund_from_asset_lock.rs
@@ -127,6 +127,13 @@ impl PlatformWallet {
     ///   shielded seed pool passes `Some(CL_FALLBACK_TIMEOUT)` so a
     ///   `FinalityTimeout` surfaces as its unconfirmed-ancestor pacing
     ///   signal (see `seed_pool.rs`).
+    /// * `cross_domain` — Cross-privacy-domain co-spend consent for the
+    ///   asset-lock funding coin selection (dashpay/platform#4184). Defaults
+    ///   should be [`crate::CrossDomainConsent::Denied`]; pass
+    ///   [`crate::CrossDomainConsent::Allowed`] only after the user has
+    ///   consented to draw the L1 lock from CoinJoin / DashPay-receiving funds
+    ///   in addition to transparent BIP44/BIP32 funds. Ignored for the
+    ///   `FromExistingAssetLock` resume path (no fresh coin selection occurs).
     #[cfg(feature = "shielded")]
     #[allow(clippy::too_many_arguments)]
     pub async fn shielded_fund_from_asset_lock<AS, P>(
@@ -140,6 +147,7 @@ impl PlatformWallet {
         dummy_outputs: usize,
         settings: Option<PutSettings>,
         cl_wait: Option<Duration>,
+        cross_domain: crate::CrossDomainConsent,
     ) -> Result<(), PlatformWalletError>
     where
         AS: ::key_wallet::signer::ExtendedPubKeySigner + Send + Sync,
@@ -208,11 +216,12 @@ impl PlatformWallet {
             tracked_out_point,
         } = match self
             .asset_locks
-            .resolve_funding_with_is_timeout_fallback(
+            .resolve_funding_with_is_timeout_fallback_with_consent(
                 funding,
                 AssetLockFundingType::AssetLockShieldedAddressTopUp,
                 /* destination_index */ 0,
                 asset_lock_signer,
+                cross_domain,
             )
             .await?
         {

--- a/packages/rs-platform-wallet/src/wallet/shielded/seed_pool.rs
+++ b/packages/rs-platform-wallet/src/wallet/shielded/seed_pool.rs
@@ -288,9 +288,9 @@ impl PlatformWallet {
                         // Bounded: a ChainLock timeout here is the deliberate
                         // unconfirmed-ancestor pacing signal this loop retries on.
                         Some(CL_FALLBACK_TIMEOUT),
-                        // Pool seeding stays within the single privacy domain by
-                        // default (dashpay/platform#4184); no cross-domain consent.
-                        crate::CrossDomainConsent::Denied,
+                        // Pool seeding funds from the unmixed BIP44 account
+                        // (dashpay/platform#4184); no explicit funding path.
+                        None,
                     )
                     .await
                 {

--- a/packages/rs-platform-wallet/src/wallet/shielded/seed_pool.rs
+++ b/packages/rs-platform-wallet/src/wallet/shielded/seed_pool.rs
@@ -288,6 +288,9 @@ impl PlatformWallet {
                         // Bounded: a ChainLock timeout here is the deliberate
                         // unconfirmed-ancestor pacing signal this loop retries on.
                         Some(CL_FALLBACK_TIMEOUT),
+                        // Pool seeding stays within the single privacy domain by
+                        // default (dashpay/platform#4184); no cross-domain consent.
+                        crate::CrossDomainConsent::Denied,
                     )
                     .await
                 {

--- a/packages/rs-unified-sdk-jni/src/funding.rs
+++ b/packages/rs-unified-sdk-jni/src/funding.rs
@@ -316,12 +316,14 @@ pub extern "system" fn Java_org_dashfoundation_dashsdk_ffi_FundingNative_shielde
 /// (43-byte raw Orchard address). `coreSignerHandle` is the manager's
 /// `MnemonicResolverHandle` (asset-lock outer ST signature); `surplusOutput`
 /// is the optional 21-byte remainder platform address (null = none).
-/// `allowCrossDomain` is the cross-privacy-domain co-spend consent
-/// (dashpay/platform#4184): `false` (default) confines the L1 asset-lock funding
-/// to the transparent BIP44/BIP32 domain; `true` — set only after the user
-/// consents — lets it also draw CoinJoin / DashPay-receiving funds. A refusal
-/// surfaces as the typed `ErrorAssetLockCrossDomainConsentRequired` code. The
-/// ~30s Halo 2 proof runs inside the call; nothing is returned on success.
+/// `fundingPath` is an optional UTF-8 BIP32 derivation-path string
+/// (dashpay/platform#4184) naming the SINGLE funds account whose UTXOs fund the
+/// lock: null (the default) funds from the unmixed BIP44 account at
+/// `fundingAccountIndex`; an explicit account-level path (e.g. the DIP-9 CoinJoin
+/// account path) funds strictly from that one account, with no union across
+/// accounts and no consent gate. A shortfall surfaces as the typed
+/// `ErrorAssetLockInsufficientFunds` code. The ~30s Halo 2 proof runs inside the
+/// call; nothing is returned on success.
 #[no_mangle]
 #[allow(clippy::too_many_arguments)]
 pub extern "system" fn Java_org_dashfoundation_dashsdk_ffi_FundingNative_shieldedFundFromAssetLock(
@@ -334,7 +336,7 @@ pub extern "system" fn Java_org_dashfoundation_dashsdk_ffi_FundingNative_shielde
     recipient_raw43: JByteArray,
     surplus_output: JByteArray,
     core_signer_handle: jlong,
-    allow_cross_domain: jboolean,
+    funding_path: JString,
 ) {
     guard(&mut env, (), |env| {
         // Reject sign errors at the boundary — negatives would otherwise
@@ -361,6 +363,19 @@ pub extern "system" fn Java_org_dashfoundation_dashsdk_ffi_FundingNative_shielde
         let (surplus_ptr, surplus_len) = surplus
             .as_ref()
             .map_or((ptr::null(), 0usize), |v| (v.as_ptr(), v.len()));
+        // Optional BIP32 derivation-path string naming the single funds account
+        // (null = the unmixed BIP44 account). Passed to the FFI as UTF-8 bytes
+        // (without the trailing NUL) + length.
+        let funding_path = match read_cstring_opt(env, &funding_path, "fundingPath") {
+            Ok(v) => v,
+            Err(()) => return,
+        };
+        let (funding_path_ptr, funding_path_len) = funding_path
+            .as_ref()
+            .map_or((ptr::null(), 0usize), |c| {
+                let b = c.as_bytes();
+                (b.as_ptr(), b.len())
+            });
         let result = unsafe {
             platform_wallet_ffi::platform_wallet_manager_shielded_fund_from_asset_lock(
                 manager_handle as Handle,
@@ -371,7 +386,8 @@ pub extern "system" fn Java_org_dashfoundation_dashsdk_ffi_FundingNative_shielde
                 surplus_ptr,
                 surplus_len,
                 core_signer_handle as *mut MnemonicResolverHandle,
-                allow_cross_domain != 0,
+                funding_path_ptr,
+                funding_path_len,
             )
         };
         let _ = take_pwffi_error(env, result);

--- a/packages/rs-unified-sdk-jni/src/funding.rs
+++ b/packages/rs-unified-sdk-jni/src/funding.rs
@@ -258,6 +258,46 @@ fn read_cstring_opt(
     }
 }
 
+/// Read an OPTIONAL Java `String` into `Option<CString>`, like
+/// [`read_cstring_opt`] but treating a genuine JNI read error as a hard failure
+/// (throws + `Err(())`) rather than silently normalizing it to `None`.
+///
+/// Use this for a money-source parameter such as `fundingPath`, where the two
+/// outcomes MUST NOT be conflated: JVM null means "absent" (fund from the
+/// default BIP44 account — `Ok(None)`), but a failed `get_string` means the
+/// caller *did* pass a path we couldn't read, and silently degrading that to
+/// the default account would fund the lock from the wrong coins. The memo path
+/// keeps the lenient [`read_cstring_opt`], where a read error harmlessly
+/// degrades to "no memo". Empty and interior-NUL handling match the lenient
+/// helper (empty → `Ok(None)`; interior NUL → throws + `Err(())`).
+fn read_cstring_opt_strict(
+    env: &mut JNIEnv,
+    s: &JString,
+    field: &str,
+) -> Result<Option<std::ffi::CString>, ()> {
+    if s.is_null() {
+        return Ok(None);
+    }
+    let owned: String = match env.get_string(s) {
+        Ok(v) => v.into(),
+        Err(_) => {
+            let _ = env.exception_clear();
+            throw_sdk_exception(env, 1, &format!("{field} string was invalid"));
+            return Err(());
+        }
+    };
+    if owned.is_empty() {
+        return Ok(None);
+    }
+    match std::ffi::CString::new(owned) {
+        Ok(c) => Ok(Some(c)),
+        Err(_) => {
+            throw_sdk_exception(env, 1, &format!("{field} contained an interior NUL"));
+            Err(())
+        }
+    }
+}
+
 /// The default Orchard payment address for `account` on the wallet's bound
 /// shielded sub-wallet — bridges `platform_wallet_manager_shielded_default_address`.
 /// Returns the 43 raw bytes (11-byte diversifier + 32-byte pk_d) as a
@@ -365,8 +405,10 @@ pub extern "system" fn Java_org_dashfoundation_dashsdk_ffi_FundingNative_shielde
             .map_or((ptr::null(), 0usize), |v| (v.as_ptr(), v.len()));
         // Optional BIP32 derivation-path string naming the single funds account
         // (null = the unmixed BIP44 account). Passed to the FFI as UTF-8 bytes
-        // (without the trailing NUL) + length.
-        let funding_path = match read_cstring_opt(env, &funding_path, "fundingPath") {
+        // (without the trailing NUL) + length. Uses the STRICT reader: a genuine
+        // read error must throw, not silently degrade this money-source param to
+        // the default BIP44 account (which would fund from the wrong coins).
+        let funding_path = match read_cstring_opt_strict(env, &funding_path, "fundingPath") {
             Ok(v) => v,
             Err(()) => return,
         };

--- a/packages/rs-unified-sdk-jni/src/funding.rs
+++ b/packages/rs-unified-sdk-jni/src/funding.rs
@@ -412,9 +412,8 @@ pub extern "system" fn Java_org_dashfoundation_dashsdk_ffi_FundingNative_shielde
             Ok(v) => v,
             Err(()) => return,
         };
-        let (funding_path_ptr, funding_path_len) = funding_path
-            .as_ref()
-            .map_or((ptr::null(), 0usize), |c| {
+        let (funding_path_ptr, funding_path_len) =
+            funding_path.as_ref().map_or((ptr::null(), 0usize), |c| {
                 let b = c.as_bytes();
                 (b.as_ptr(), b.len())
             });

--- a/packages/rs-unified-sdk-jni/src/funding.rs
+++ b/packages/rs-unified-sdk-jni/src/funding.rs
@@ -315,7 +315,12 @@ pub extern "system" fn Java_org_dashfoundation_dashsdk_ffi_FundingNative_shielde
 /// `fundingAccountIndex`, and shields a single real note to `recipientRaw43`
 /// (43-byte raw Orchard address). `coreSignerHandle` is the manager's
 /// `MnemonicResolverHandle` (asset-lock outer ST signature); `surplusOutput`
-/// is the optional 21-byte remainder platform address (null = none). The
+/// is the optional 21-byte remainder platform address (null = none).
+/// `allowCrossDomain` is the cross-privacy-domain co-spend consent
+/// (dashpay/platform#4184): `false` (default) confines the L1 asset-lock funding
+/// to the transparent BIP44/BIP32 domain; `true` — set only after the user
+/// consents — lets it also draw CoinJoin / DashPay-receiving funds. A refusal
+/// surfaces as the typed `ErrorAssetLockCrossDomainConsentRequired` code. The
 /// ~30s Halo 2 proof runs inside the call; nothing is returned on success.
 #[no_mangle]
 #[allow(clippy::too_many_arguments)]
@@ -329,6 +334,7 @@ pub extern "system" fn Java_org_dashfoundation_dashsdk_ffi_FundingNative_shielde
     recipient_raw43: JByteArray,
     surplus_output: JByteArray,
     core_signer_handle: jlong,
+    allow_cross_domain: jboolean,
 ) {
     guard(&mut env, (), |env| {
         // Reject sign errors at the boundary — negatives would otherwise
@@ -365,6 +371,7 @@ pub extern "system" fn Java_org_dashfoundation_dashsdk_ffi_FundingNative_shielde
                 surplus_ptr,
                 surplus_len,
                 core_signer_handle as *mut MnemonicResolverHandle,
+                allow_cross_domain != 0,
             )
         };
         let _ = take_pwffi_error(env, result);

--- a/packages/swift-sdk/Sources/SwiftDashSDK/PlatformWallet/PlatformWalletManagerShieldedFunding.swift
+++ b/packages/swift-sdk/Sources/SwiftDashSDK/PlatformWallet/PlatformWalletManagerShieldedFunding.swift
@@ -126,18 +126,23 @@ extension PlatformWalletManager {
     ///     `lock_value − pool_fee`), so `nil` is always valid; the
     ///     parameter is exposed for parity with the Rust builder and
     ///     forward-compatibility with multi-output bundles.
-    /// - Parameter allowCrossDomain: cross-privacy-domain co-spend consent
-    ///   (dashpay/platform#4184). `false` (default) confines the L1 asset-lock
-    ///   funding to the transparent BIP44/BIP32 domain; pass `true` only after
-    ///   the user consents to also drawing CoinJoin / DashPay-receiving funds. A
-    ///   refusal surfaces as `.errorAssetLockCrossDomainConsentRequired`.
+    /// - Parameter fundingPath: optional UTF-8 BIP32 derivation-path string
+    ///   (dashpay/platform#4184) naming the single funds account whose UTXOs
+    ///   fund the lock. `nil` (default) funds from the unmixed BIP44 account at
+    ///   `fundingAccountIndex`. Pass an explicit account-level path (e.g. the
+    ///   DIP-9 CoinJoin account path, `"m/44'/5'/…"`) to fund strictly from that
+    ///   one account — to shield previously-mixed CoinJoin coins, for instance.
+    ///   There is no union across accounts and no consent gate: exactly one
+    ///   funding source participates, and if it cannot cover the lock the call
+    ///   fails with `.assetLockInsufficientFunds`. A malformed path or one that
+    ///   is not valid UTF-8 surfaces as `.invalidParameter`.
     public func shieldedFundFromAssetLock(
         walletId: Data,
         fundingAccountIndex: UInt32,
         amountDuffs: UInt64,
         recipients: [ShieldedFundFromAssetLockRecipient],
         surplusOutput: Data? = nil,
-        allowCrossDomain: Bool = false
+        fundingPath: String? = nil
     ) async throws {
         try shieldedFundFromAssetLockPreflight(
             walletId: walletId,
@@ -174,20 +179,23 @@ extension PlatformWalletManager {
                         )
                     }
                     try Self.withOptionalSurplusOutput(surplusOutput) { surplusPtr, surplusLen in
-                        let result = withExtendedLifetime(coreSigner) {
-                            platform_wallet_manager_shielded_fund_from_asset_lock(
-                                handle,
-                                widPtr,
-                                fundingAccountIndex,
-                                amountDuffs,
-                                recipientPtr,
-                                surplusPtr,
-                                surplusLen,
-                                coreSigner.handle,
-                                allowCrossDomain
-                            )
+                        try Self.withOptionalFundingPath(fundingPath) { fundingPathPtr, fundingPathLen in
+                            let result = withExtendedLifetime(coreSigner) {
+                                platform_wallet_manager_shielded_fund_from_asset_lock(
+                                    handle,
+                                    widPtr,
+                                    fundingAccountIndex,
+                                    amountDuffs,
+                                    recipientPtr,
+                                    surplusPtr,
+                                    surplusLen,
+                                    coreSigner.handle,
+                                    fundingPathPtr,
+                                    fundingPathLen
+                                )
+                            }
+                            try result.check()
                         }
-                        try result.check()
                     }
                 }
             }
@@ -467,6 +475,40 @@ extension PlatformWalletManager {
             guard let ptr = raw.baseAddress?.assumingMemoryBound(to: UInt8.self) else {
                 throw PlatformWalletError.invalidParameter(
                     "surplusOutput baseAddress is nil"
+                )
+            }
+            return try body(ptr, UInt(raw.count))
+        }
+    }
+
+    /// Run `body` with a `(pointer, length)` view of the optional funding
+    /// derivation-path string, marshalled as raw UTF-8 bytes (no NUL
+    /// terminator — the FFI reads exactly `funding_path_len` bytes).
+    ///
+    /// `nil` yields `(nil, 0)`, which the FFI reads as "no explicit funding
+    /// path" (fund from the unmixed BIP44 account at `fundingAccountIndex`). A
+    /// non-nil value is encoded to its UTF-8 byte view and pinned for the call
+    /// via `withUnsafeBytes` so the pointer stays valid for the duration of
+    /// `body`. The FFI parses the bytes as a BIP32 path and returns an error
+    /// for invalid UTF-8 or a malformed path, so no validation is duplicated
+    /// here. An empty (but non-nil) string yields `(nil, 0)` — the same "no
+    /// path" semantics the FFI applies to a zero length.
+    ///
+    /// `nonisolated` for the same reason as `withOptionalSurplusOutput`: it is
+    /// pure byte marshalling invoked from the off-main-actor `Task.detached`
+    /// body and touches no `PlatformWalletManager` state.
+    nonisolated private static func withOptionalFundingPath<R>(
+        _ fundingPath: String?,
+        _ body: (UnsafePointer<UInt8>?, UInt) throws -> R
+    ) throws -> R {
+        guard let fundingPath, !fundingPath.isEmpty else {
+            return try body(nil, 0)
+        }
+        let utf8 = Array(fundingPath.utf8)
+        return try utf8.withUnsafeBufferPointer { raw in
+            guard let ptr = raw.baseAddress else {
+                throw PlatformWalletError.invalidParameter(
+                    "fundingPath baseAddress is nil"
                 )
             }
             return try body(ptr, UInt(raw.count))

--- a/packages/swift-sdk/Sources/SwiftDashSDK/PlatformWallet/PlatformWalletManagerShieldedFunding.swift
+++ b/packages/swift-sdk/Sources/SwiftDashSDK/PlatformWallet/PlatformWalletManagerShieldedFunding.swift
@@ -107,8 +107,12 @@ extension PlatformWalletManager {
     /// - Parameters:
     ///   - walletId: 32-byte wallet identifier (the same key
     ///     `bindShielded` uses to look up the bound subwallet).
-    ///   - fundingAccountIndex: BIP44 Core account whose UTXOs fund
-    ///     the asset lock.
+    ///   - fundingAccountIndex: BIP44 Core account that always sinks
+    ///     the asset lock's transparent CHANGE, and — when
+    ///     `fundingPath` is `nil` — is also the account whose UTXOs
+    ///     fund the lock. With an explicit `fundingPath` the inputs
+    ///     come exclusively from the account that path names and this
+    ///     index remains only the (still required) change sink.
     ///   - amountDuffs: L1 amount to lock in Core duffs. Must be
     ///     large enough to cover `recipients.credits + Platform fee`;
     ///     undersized locks fail at Platform submission.

--- a/packages/swift-sdk/Sources/SwiftDashSDK/PlatformWallet/PlatformWalletManagerShieldedFunding.swift
+++ b/packages/swift-sdk/Sources/SwiftDashSDK/PlatformWallet/PlatformWalletManagerShieldedFunding.swift
@@ -126,12 +126,18 @@ extension PlatformWalletManager {
     ///     `lock_value − pool_fee`), so `nil` is always valid; the
     ///     parameter is exposed for parity with the Rust builder and
     ///     forward-compatibility with multi-output bundles.
+    /// - Parameter allowCrossDomain: cross-privacy-domain co-spend consent
+    ///   (dashpay/platform#4184). `false` (default) confines the L1 asset-lock
+    ///   funding to the transparent BIP44/BIP32 domain; pass `true` only after
+    ///   the user consents to also drawing CoinJoin / DashPay-receiving funds. A
+    ///   refusal surfaces as `.errorAssetLockCrossDomainConsentRequired`.
     public func shieldedFundFromAssetLock(
         walletId: Data,
         fundingAccountIndex: UInt32,
         amountDuffs: UInt64,
         recipients: [ShieldedFundFromAssetLockRecipient],
-        surplusOutput: Data? = nil
+        surplusOutput: Data? = nil,
+        allowCrossDomain: Bool = false
     ) async throws {
         try shieldedFundFromAssetLockPreflight(
             walletId: walletId,
@@ -177,7 +183,8 @@ extension PlatformWalletManager {
                                 recipientPtr,
                                 surplusPtr,
                                 surplusLen,
-                                coreSigner.handle
+                                coreSigner.handle,
+                                allowCrossDomain
                             )
                         }
                         try result.check()

--- a/packages/swift-sdk/Sources/SwiftDashSDK/PlatformWallet/PlatformWalletResult.swift
+++ b/packages/swift-sdk/Sources/SwiftDashSDK/PlatformWallet/PlatformWalletResult.swift
@@ -76,10 +76,18 @@ public enum PlatformWalletResultCode: Int32, Sendable {
     /// (Not returned by `destroy`: Rust owns the callback contexts, so a
     /// straggling worker is memory-safe and merely logged there.)
     case errorShutdownIncomplete = 27
-    // Raw values 28-30 are NOT claimed here: 28 and 30 are reserved (vacated by
-    // the deferred-payment reservation-token trio on dashpay/platform#4185 /
-    // #4256 when it moved to 34-36) and 29 belongs to the asset-lock funding
-    // shortfall on dashpay/platform#4184.
+    // Raw value 28 is NOT claimed here: it is held by the deferred-payment
+    // reservation-token trio on dashpay/platform#4185.
+    /// Asset-lock coin selection came up short over the permitted funding set
+    /// (dashpay/platform#4073 request 3). The structured available/required
+    /// duffs travel in the message string. Distinct from
+    /// `errorCoreInsufficientFunds` (22), which is the atomic Core-send selector.
+    case errorAssetLockInsufficientFunds = 29
+    /// The default single-privacy-domain funding rule refused a cross-domain
+    /// co-spend (dashpay/platform#4184): the transparent domain alone is short
+    /// but the wallet-wide union would cover it. Obtain explicit user consent
+    /// and re-issue the funding request with cross-domain consent.
+    case errorAssetLockCrossDomainConsentRequired = 30
     /// A state transition could not be signed because the signer has no
     /// usable private key for the requested public key — restored from the
     /// structured signer completion code (dashpay/platform#4060 finding 7).
@@ -146,6 +154,10 @@ public enum PlatformWalletResultCode: Int32, Sendable {
             self = .errorTransactionBroadcastRejected
         case PLATFORM_WALLET_FFI_RESULT_CODE_ERROR_SHUTDOWN_INCOMPLETE:
             self = .errorShutdownIncomplete
+        case PLATFORM_WALLET_FFI_RESULT_CODE_ERROR_ASSET_LOCK_INSUFFICIENT_FUNDS:
+            self = .errorAssetLockInsufficientFunds
+        case PLATFORM_WALLET_FFI_RESULT_CODE_ERROR_ASSET_LOCK_CROSS_DOMAIN_CONSENT_REQUIRED:
+            self = .errorAssetLockCrossDomainConsentRequired
         case PLATFORM_WALLET_FFI_RESULT_CODE_ERROR_SIGNING_KEY_UNAVAILABLE:
             self = .errorSigningKeyUnavailable
         case PLATFORM_WALLET_FFI_RESULT_CODE_NOT_FOUND:

--- a/packages/swift-sdk/Sources/SwiftDashSDK/PlatformWallet/PlatformWalletResult.swift
+++ b/packages/swift-sdk/Sources/SwiftDashSDK/PlatformWallet/PlatformWalletResult.swift
@@ -83,11 +83,6 @@ public enum PlatformWalletResultCode: Int32, Sendable {
     /// duffs travel in the message string. Distinct from
     /// `errorCoreInsufficientFunds` (22), which is the atomic Core-send selector.
     case errorAssetLockInsufficientFunds = 29
-    /// The default single-privacy-domain funding rule refused a cross-domain
-    /// co-spend (dashpay/platform#4184): the transparent domain alone is short
-    /// but the wallet-wide union would cover it. Obtain explicit user consent
-    /// and re-issue the funding request with cross-domain consent.
-    case errorAssetLockCrossDomainConsentRequired = 30
     /// A state transition could not be signed because the signer has no
     /// usable private key for the requested public key — restored from the
     /// structured signer completion code (dashpay/platform#4060 finding 7).
@@ -156,8 +151,6 @@ public enum PlatformWalletResultCode: Int32, Sendable {
             self = .errorShutdownIncomplete
         case PLATFORM_WALLET_FFI_RESULT_CODE_ERROR_ASSET_LOCK_INSUFFICIENT_FUNDS:
             self = .errorAssetLockInsufficientFunds
-        case PLATFORM_WALLET_FFI_RESULT_CODE_ERROR_ASSET_LOCK_CROSS_DOMAIN_CONSENT_REQUIRED:
-            self = .errorAssetLockCrossDomainConsentRequired
         case PLATFORM_WALLET_FFI_RESULT_CODE_ERROR_SIGNING_KEY_UNAVAILABLE:
             self = .errorSigningKeyUnavailable
         case PLATFORM_WALLET_FFI_RESULT_CODE_NOT_FOUND:
@@ -251,15 +244,6 @@ public enum PlatformWalletError: LocalizedError {
     /// duffs"`). Distinct from `coreInsufficientFunds`, which is the atomic
     /// Core-send selector rather than the asset-lock builder.
     case assetLockInsufficientFunds(String)
-    /// The default single-privacy-domain funding rule (dashpay/platform#4184)
-    /// refused a cross-domain co-spend: the transparent domain (BIP44 + BIP32)
-    /// alone cannot cover the asset lock, but the wallet-wide union — adding
-    /// CoinJoin and/or DashPay-receiving funds — can. Combining them in one L1
-    /// transaction would irreversibly link those domains on-chain, so it is
-    /// gated behind explicit user consent. Prompt the user, then re-issue the
-    /// funding request with `allowCrossDomain: true`. The transparent / union /
-    /// required duff amounts travel in the message.
-    case assetLockCrossDomainConsentRequired(String)
     case walletAlreadyExists(String)
     /// Definitive shielded-broadcast failure: the shielded transition
     /// (identity-create or a spend — unshield / transfer / withdrawal) was
@@ -328,7 +312,6 @@ public enum PlatformWalletError: LocalizedError {
              .assetLockNotTracked(let m), .assetLockAlreadyConsumed(let m),
              .assetLockFundingMismatch(let m),
              .assetLockInsufficientFunds(let m),
-             .assetLockCrossDomainConsentRequired(let m),
              .walletAlreadyExists(let m), .shieldedBroadcastFailed(let m),
              .shieldedBroadcastUnconfirmed(let m), .shieldedSpendUnconfirmed(let m),
              .shieldedNoRecordedAnchor(let m),
@@ -368,8 +351,6 @@ public enum PlatformWalletError: LocalizedError {
         case .errorAssetLockAlreadyConsumed: self = .assetLockAlreadyConsumed(detail)
         case .errorAssetLockFundingMismatch: self = .assetLockFundingMismatch(detail)
         case .errorAssetLockInsufficientFunds: self = .assetLockInsufficientFunds(detail)
-        case .errorAssetLockCrossDomainConsentRequired:
-            self = .assetLockCrossDomainConsentRequired(detail)
         case .errorWalletAlreadyExists: self = .walletAlreadyExists(detail)
         case .errorShieldedBroadcastFailed: self = .shieldedBroadcastFailed(detail)
         case .errorShieldedBroadcastUnconfirmed: self = .shieldedBroadcastUnconfirmed(detail)

--- a/packages/swift-sdk/Sources/SwiftDashSDK/PlatformWallet/PlatformWalletResult.swift
+++ b/packages/swift-sdk/Sources/SwiftDashSDK/PlatformWallet/PlatformWalletResult.swift
@@ -241,6 +241,25 @@ public enum PlatformWalletError: LocalizedError {
     case assetLockNotTracked(String)
     case assetLockAlreadyConsumed(String)
     case assetLockFundingMismatch(String)
+    /// Asset-lock coin selection came up short over the *permitted* funding
+    /// set (dashpay/platform#4073 request 3): the requested amount plus the L1
+    /// fee exceeds the spendable funds the selector was allowed to draw on.
+    /// Raised strictly pre-broadcast (while building the asset-lock
+    /// transaction), so nothing reached the wire. The structured
+    /// `available`/`required` duff amounts travel in the message
+    /// (`"asset lock coin selection is short: available N duffs, required M
+    /// duffs"`). Distinct from `coreInsufficientFunds`, which is the atomic
+    /// Core-send selector rather than the asset-lock builder.
+    case assetLockInsufficientFunds(String)
+    /// The default single-privacy-domain funding rule (dashpay/platform#4184)
+    /// refused a cross-domain co-spend: the transparent domain (BIP44 + BIP32)
+    /// alone cannot cover the asset lock, but the wallet-wide union — adding
+    /// CoinJoin and/or DashPay-receiving funds — can. Combining them in one L1
+    /// transaction would irreversibly link those domains on-chain, so it is
+    /// gated behind explicit user consent. Prompt the user, then re-issue the
+    /// funding request with `allowCrossDomain: true`. The transparent / union /
+    /// required duff amounts travel in the message.
+    case assetLockCrossDomainConsentRequired(String)
     case walletAlreadyExists(String)
     /// Definitive shielded-broadcast failure: the shielded transition
     /// (identity-create or a spend — unshield / transfer / withdrawal) was
@@ -308,6 +327,8 @@ public enum PlatformWalletError: LocalizedError {
              .coreInsufficientFunds(let m),
              .assetLockNotTracked(let m), .assetLockAlreadyConsumed(let m),
              .assetLockFundingMismatch(let m),
+             .assetLockInsufficientFunds(let m),
+             .assetLockCrossDomainConsentRequired(let m),
              .walletAlreadyExists(let m), .shieldedBroadcastFailed(let m),
              .shieldedBroadcastUnconfirmed(let m), .shieldedSpendUnconfirmed(let m),
              .shieldedNoRecordedAnchor(let m),
@@ -346,6 +367,9 @@ public enum PlatformWalletError: LocalizedError {
         case .errorAssetLockNotTracked: self = .assetLockNotTracked(detail)
         case .errorAssetLockAlreadyConsumed: self = .assetLockAlreadyConsumed(detail)
         case .errorAssetLockFundingMismatch: self = .assetLockFundingMismatch(detail)
+        case .errorAssetLockInsufficientFunds: self = .assetLockInsufficientFunds(detail)
+        case .errorAssetLockCrossDomainConsentRequired:
+            self = .assetLockCrossDomainConsentRequired(detail)
         case .errorWalletAlreadyExists: self = .walletAlreadyExists(detail)
         case .errorShieldedBroadcastFailed: self = .shieldedBroadcastFailed(detail)
         case .errorShieldedBroadcastUnconfirmed: self = .shieldedBroadcastUnconfirmed(detail)

--- a/packages/swift-sdk/SwiftExampleApp/SwiftExampleApp/Views/ShieldedFundFromAssetLockView.swift
+++ b/packages/swift-sdk/SwiftExampleApp/SwiftExampleApp/Views/ShieldedFundFromAssetLockView.swift
@@ -110,15 +110,14 @@ struct ShieldedFundFromAssetLockView: View {
     /// fight the formatter on partial input.
     @State private var recipientHex: String = ""
     @State private var amountDash: String = "0.001"
-    /// Cross-privacy-domain co-spend consent (dashpay/platform#4184). Off by
-    /// default: the L1 asset-lock funding is confined to the transparent
-    /// BIP44/BIP32 domain. When the transparent slice alone can't cover the
-    /// lock, the funding call fails with `.errorAssetLockCrossDomainConsentRequired`;
-    /// flipping this on and resubmitting re-issues with `allowCrossDomain: true`,
-    /// widening funding to the wallet-wide signable union (CoinJoin +
-    /// DashPay-receiving). See the TODO on `crossDomainConsentSection` for the
-    /// fuller catch-30-and-retry UX this stand-in stands in for.
-    @State private var allowCrossDomain: Bool = false
+    /// Optional BIP32 derivation-path override selecting the single funds
+    /// account whose UTXOs fund the asset lock (dashpay/platform#4184). Empty
+    /// (the default) funds from the unmixed BIP44 account at the selected Core
+    /// account index; an explicit account-level path (e.g. the DIP-9 CoinJoin
+    /// account path) funds strictly from that one account, with no union across
+    /// accounts and no consent gate. Threaded to
+    /// `shieldedFundFromAssetLock(fundingPath:)` as `nil` when blank.
+    @State private var fundingPath: String = ""
     /// Platform-branch amount in DASH (parsed to credits, 1e11/DASH).
     /// Kept separate from `amountDash` so the Core (duffs) and
     /// Platform (credits) unit systems never share a text buffer.
@@ -183,7 +182,7 @@ struct ShieldedFundFromAssetLockView: View {
                         coreFundingSection
                         recipientSection
                         amountSection
-                        crossDomainConsentSection
+                        fundingPathSection
                     case .platformBalance:
                         platformAccountSection
                         platformAmountSection
@@ -272,31 +271,28 @@ struct ShieldedFundFromAssetLockView: View {
         }
     }
 
-    /// Cross-privacy-domain co-spend consent (dashpay/platform#4184).
+    /// Optional funding-account derivation path (dashpay/platform#4184).
     ///
-    /// TODO(dashpay/platform#4184 follow-up): this is a minimal stand-in, not
-    /// the intended UX. The proper flow submits with `allowCrossDomain: false`,
-    /// catches `.errorAssetLockCrossDomainConsentRequired` (result code 30),
-    /// shows the transparent/union/required duff breakdown parsed from the
-    /// error message, and only then offers a consent prompt that retries with
-    /// `allowCrossDomain: true` — rather than asking the user to pre-consent
-    /// blind. A fuller version would also let the funding picker surface
-    /// CoinJoin / DashPay-receiving balances so the user can see what the
-    /// union adds. Tracked as a follow-up to file (see the PR description); the
-    /// PR is held for rust-dashcore#912 (atomic multi-account reservation)
-    /// before this UX lands.
-    private var crossDomainConsentSection: some View {
+    /// A minimal stand-in for a richer picker: a fuller version would let the
+    /// user choose the funding account from a list that surfaces each
+    /// account's balance and label (unmixed BIP44, DIP-9 CoinJoin, etc.)
+    /// rather than typing a raw BIP32 path. Left blank funds from the default
+    /// unmixed BIP44 account.
+    private var fundingPathSection: some View {
         Section {
-            Toggle("Allow cross-domain funds", isOn: $allowCrossDomain)
+            TextField("m/44'/5'/0' (blank = default account)", text: $fundingPath)
+                .autocorrectionDisabled()
+                .textInputAutocapitalization(.never)
         } header: {
-            Text("Privacy")
+            Text("Funding Account (optional)")
         } footer: {
             Text(
-                "Off: fund the asset lock only from your transparent "
-                    + "(BIP44/BIP32) balance. On: if that alone can't cover the "
-                    + "lock, also draw CoinJoin and DashPay-receiving funds — this "
-                    + "combines those funds in one on-chain transaction and links "
-                    + "them together. Only enable after you understand that trade-off."
+                "Blank: fund the asset lock from your default unmixed BIP44 "
+                    + "account. Or enter one account-level BIP32 path (e.g. the "
+                    + "DIP-9 CoinJoin account) to fund strictly from that single "
+                    + "account — no union across accounts. If that one account "
+                    + "cannot cover the lock, the funding call fails with "
+                    + "insufficient funds."
             )
         }
     }
@@ -728,7 +724,9 @@ struct ShieldedFundFromAssetLockView: View {
                     recipients: [
                         ShieldedFundFromAssetLockRecipient(recipientRaw43: recipient)
                     ],
-                    allowCrossDomain: allowCrossDomain
+                    fundingPath: fundingPath.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+                        ? nil
+                        : fundingPath.trimmingCharacters(in: .whitespacesAndNewlines)
                 )
             }
         }

--- a/packages/swift-sdk/SwiftExampleApp/SwiftExampleApp/Views/ShieldedFundFromAssetLockView.swift
+++ b/packages/swift-sdk/SwiftExampleApp/SwiftExampleApp/Views/ShieldedFundFromAssetLockView.swift
@@ -248,14 +248,14 @@ struct ShieldedFundFromAssetLockView: View {
         let options = coreAccountOptions
         Section {
             if options.isEmpty {
-                Text("No spendable Core (BIP44 standard) accounts on this wallet.")
+                Text("No spendable Core funds accounts on this wallet.")
                     .font(.caption)
                     .foregroundColor(.secondary)
             } else {
                 Picker("Core Account", selection: $fundingCoreAccountIndex) {
                     Text("Select…").tag(Optional<UInt32>.none)
-                    ForEach(options, id: \.accountIndex) { opt in
-                        Text("Account #\(opt.accountIndex) — \(formatDuffs(opt.balanceDuffs))")
+                    ForEach(options) { opt in
+                        Text("\(opt.typeLabel) #\(opt.accountIndex) — \(formatDuffs(opt.balanceDuffs))")
                             .tag(Optional(opt.accountIndex))
                     }
                 }
@@ -264,9 +264,11 @@ struct ShieldedFundFromAssetLockView: View {
             Text("Core Source")
         } footer: {
             Text(
-                "The selected Core account's UTXOs are locked into an asset lock; "
-                    + "the locked DASH becomes shielded credits on the destination "
-                    + "Orchard address."
+                "Supplies the transparent CHANGE address, and is the default "
+                    + "funding source when the Funding Account path below is blank. "
+                    + "Non-Standard accounts (CoinJoin, DashPay) are listed so their "
+                    + "balances are visible — to actually draw the lock from one, "
+                    + "enter its account-level path in the Funding Account field."
             )
         }
     }
@@ -782,9 +784,30 @@ struct ShieldedFundFromAssetLockView: View {
 
     // MARK: - Derived
 
-    private struct CoreAccountOption {
+    private struct CoreAccountOption: Identifiable {
         let accountIndex: UInt32
         let balanceDuffs: UInt64
+        /// Core account discriminant (`0` Standard, `1` CoinJoin, `12` DashPay
+        /// receiving) and, for Standard, the BIP44(`0`)/BIP32(`1`) split. Kept so
+        /// non-Standard funds accounts can be surfaced in the picker with a label
+        /// (dashpay/platform#4184).
+        let typeTag: UInt8
+        let standardTag: UInt8
+
+        /// Stable identity for `ForEach`: a CoinJoin account can share its
+        /// `accountIndex` with a Standard account (both are account 0), so the
+        /// index alone is not unique.
+        var id: String { "\(typeTag)-\(standardTag)-\(accountIndex)" }
+
+        /// Short label distinguishing the funds-account kind in the picker row.
+        var typeLabel: String {
+            switch typeTag {
+            case 0: return standardTag == 0 ? "BIP44" : "BIP32"
+            case 1: return "CoinJoin"
+            case 12: return "DashPay"
+            default: return "Account"
+            }
+        }
     }
 
     private struct PlatformAccountOption {
@@ -830,14 +853,24 @@ struct ShieldedFundFromAssetLockView: View {
         return UInt64(creditsDouble.rounded(.toNearestOrAwayFromZero))
     }
 
+    /// Spendable Core FUNDS accounts eligible to fund an asset lock. Standard
+    /// (`typeTag == 0`, BIP44/BIP32), CoinJoin (`1`), and DashPay-receiving
+    /// (`12`) all hold L1 UTXOs; keys-only accounts (identity/asset-lock/
+    /// provider) and watch-only DashPay-external (`13`, unsignable) are excluded.
+    /// Non-Standard accounts are surfaced too (dashpay/platform#4184) so their
+    /// balances are visible — the actual funding source is the `fundingPath`
+    /// field; the account selected here supplies the transparent change sink and
+    /// is the default source when `fundingPath` is blank.
     private var coreAccountOptions: [CoreAccountOption] {
         walletManager.accountBalances(for: wallet.walletId)
-            .filter { $0.typeTag == 0 && $0.standardTag == 0 && $0.confirmed > 0 }
-            .sorted { $0.index < $1.index }
+            .filter { ($0.typeTag == 0 || $0.typeTag == 1 || $0.typeTag == 12) && $0.confirmed > 0 }
+            .sorted { ($0.typeTag, $0.standardTag, $0.index) < ($1.typeTag, $1.standardTag, $1.index) }
             .map {
                 CoreAccountOption(
                     accountIndex: $0.index,
-                    balanceDuffs: $0.confirmed
+                    balanceDuffs: $0.confirmed,
+                    typeTag: $0.typeTag,
+                    standardTag: $0.standardTag
                 )
             }
     }
@@ -845,6 +878,15 @@ struct ShieldedFundFromAssetLockView: View {
     private var selectedCoreAccountBalanceDuffs: UInt64 {
         guard let idx = fundingCoreAccountIndex else { return 0 }
         return coreAccountOptions.first(where: { $0.accountIndex == idx })?.balanceDuffs ?? 0
+    }
+
+    /// True when the user named an explicit funding source via a non-blank
+    /// `fundingPath` (dashpay/platform#4184). The lock then draws from THAT
+    /// account (e.g. the DIP-9 CoinJoin account), and the selected Core account
+    /// only supplies change — so `canSubmit` must not gate on the Core account's
+    /// balance covering the full amount.
+    private var hasExplicitFundingPath: Bool {
+        !fundingPath.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
     }
 
     /// Fresh-build path: L1 duffs the user typed in the Amount field.
@@ -875,10 +917,16 @@ struct ShieldedFundFromAssetLockView: View {
                 && credits <= selectedPlatformAccountCredits
         }
         let amount = parsedDuffs ?? 0
+        // With an explicit funding path the lock draws from that named account,
+        // not the selected Core account (which only sinks change) — so don't gate
+        // on the selected account's balance covering the full amount. The Rust
+        // side still fails with a typed insufficient-funds error if the named
+        // account can't cover the lock.
+        let selectedCoversAmount = hasExplicitFundingPath || selectedCoreAccountBalanceDuffs >= amount
         return fundingCoreAccountIndex != nil
             && recipientRaw43 != nil
             && amount >= Self.minDuffs
-            && selectedCoreAccountBalanceDuffs >= amount
+            && selectedCoversAmount
             && activeController == nil
     }
 

--- a/packages/swift-sdk/SwiftExampleApp/SwiftExampleApp/Views/ShieldedFundFromAssetLockView.swift
+++ b/packages/swift-sdk/SwiftExampleApp/SwiftExampleApp/Views/ShieldedFundFromAssetLockView.swift
@@ -110,6 +110,15 @@ struct ShieldedFundFromAssetLockView: View {
     /// fight the formatter on partial input.
     @State private var recipientHex: String = ""
     @State private var amountDash: String = "0.001"
+    /// Cross-privacy-domain co-spend consent (dashpay/platform#4184). Off by
+    /// default: the L1 asset-lock funding is confined to the transparent
+    /// BIP44/BIP32 domain. When the transparent slice alone can't cover the
+    /// lock, the funding call fails with `.errorAssetLockCrossDomainConsentRequired`;
+    /// flipping this on and resubmitting re-issues with `allowCrossDomain: true`,
+    /// widening funding to the wallet-wide signable union (CoinJoin +
+    /// DashPay-receiving). See the TODO on `crossDomainConsentSection` for the
+    /// fuller catch-30-and-retry UX this stand-in stands in for.
+    @State private var allowCrossDomain: Bool = false
     /// Platform-branch amount in DASH (parsed to credits, 1e11/DASH).
     /// Kept separate from `amountDash` so the Core (duffs) and
     /// Platform (credits) unit systems never share a text buffer.
@@ -174,6 +183,7 @@ struct ShieldedFundFromAssetLockView: View {
                         coreFundingSection
                         recipientSection
                         amountSection
+                        crossDomainConsentSection
                     case .platformBalance:
                         platformAccountSection
                         platformAmountSection
@@ -258,6 +268,35 @@ struct ShieldedFundFromAssetLockView: View {
                 "The selected Core account's UTXOs are locked into an asset lock; "
                     + "the locked DASH becomes shielded credits on the destination "
                     + "Orchard address."
+            )
+        }
+    }
+
+    /// Cross-privacy-domain co-spend consent (dashpay/platform#4184).
+    ///
+    /// TODO(dashpay/platform#4184 follow-up): this is a minimal stand-in, not
+    /// the intended UX. The proper flow submits with `allowCrossDomain: false`,
+    /// catches `.errorAssetLockCrossDomainConsentRequired` (result code 30),
+    /// shows the transparent/union/required duff breakdown parsed from the
+    /// error message, and only then offers a consent prompt that retries with
+    /// `allowCrossDomain: true` — rather than asking the user to pre-consent
+    /// blind. A fuller version would also let the funding picker surface
+    /// CoinJoin / DashPay-receiving balances so the user can see what the
+    /// union adds. Tracked as a follow-up to file (see the PR description); the
+    /// PR is held for rust-dashcore#912 (atomic multi-account reservation)
+    /// before this UX lands.
+    private var crossDomainConsentSection: some View {
+        Section {
+            Toggle("Allow cross-domain funds", isOn: $allowCrossDomain)
+        } header: {
+            Text("Privacy")
+        } footer: {
+            Text(
+                "Off: fund the asset lock only from your transparent "
+                    + "(BIP44/BIP32) balance. On: if that alone can't cover the "
+                    + "lock, also draw CoinJoin and DashPay-receiving funds — this "
+                    + "combines those funds in one on-chain transaction and links "
+                    + "them together. Only enable after you understand that trade-off."
             )
         }
     }
@@ -688,7 +727,8 @@ struct ShieldedFundFromAssetLockView: View {
                     amountDuffs: duffs,
                     recipients: [
                         ShieldedFundFromAssetLockRecipient(recipientRaw43: recipient)
-                    ]
+                    ],
+                    allowCrossDomain: allowCrossDomain
                 )
             }
         }

--- a/packages/swift-sdk/SwiftExampleApp/SwiftExampleApp/Views/ShieldedFundFromAssetLockView.swift
+++ b/packages/swift-sdk/SwiftExampleApp/SwiftExampleApp/Views/ShieldedFundFromAssetLockView.swift
@@ -245,30 +245,50 @@ struct ShieldedFundFromAssetLockView: View {
 
     @ViewBuilder
     private var coreFundingSection: some View {
-        let options = coreAccountOptions
+        let changeOptions = changeAccountOptions
+        let otherOptions = otherFundsAccountOptions
         Section {
-            if options.isEmpty {
-                Text("No spendable Core funds accounts on this wallet.")
+            if changeOptions.isEmpty {
+                Text("No spendable BIP44 Core accounts on this wallet.")
                     .font(.caption)
                     .foregroundColor(.secondary)
             } else {
                 Picker("Core Account", selection: $fundingCoreAccountIndex) {
                     Text("Select…").tag(Optional<UInt32>.none)
-                    ForEach(options) { opt in
+                    ForEach(changeOptions) { opt in
                         Text("\(opt.typeLabel) #\(opt.accountIndex) — \(formatDuffs(opt.balanceDuffs))")
                             .tag(Optional(opt.accountIndex))
                     }
                 }
             }
+            // Non-BIP44 funds accounts are shown READ-ONLY, never as picker
+            // rows: account families reuse indices (BIP44 #0, BIP32 #0 and
+            // CoinJoin #0 all exist), so tagging every row with its bare
+            // `accountIndex` made the selection ambiguous — SwiftUI could not
+            // tell which row was chosen, and picking a non-BIP44 row whose
+            // index has no BIP44 counterpart fed an invalid change account to
+            // Rust (dashpay/platform#4184 review). Their balances stay visible
+            // here; to actually draw the lock from one, enter its account-level
+            // path in the Funding Account field below.
+            ForEach(otherOptions) { opt in
+                HStack {
+                    Text("\(opt.typeLabel) #\(opt.accountIndex)")
+                    Spacer()
+                    Text(formatDuffs(opt.balanceDuffs))
+                        .foregroundColor(.secondary)
+                }
+                .font(.caption)
+            }
         } header: {
             Text("Core Source")
         } footer: {
             Text(
-                "Supplies the transparent CHANGE address, and is the default "
-                    + "funding source when the Funding Account path below is blank. "
-                    + "Non-Standard accounts (CoinJoin, DashPay) are listed so their "
-                    + "balances are visible — to actually draw the lock from one, "
-                    + "enter its account-level path in the Funding Account field."
+                "The picker chooses a BIP44 account: it supplies the transparent "
+                    + "CHANGE address, and is the default funding source when the "
+                    + "Funding Account path below is blank. Other funds accounts "
+                    + "(BIP32, CoinJoin, DashPay) are listed read-only so their "
+                    + "balances are visible — to draw the lock from one, enter its "
+                    + "account-level path in the Funding Account field."
             )
         }
     }
@@ -859,11 +879,17 @@ struct ShieldedFundFromAssetLockView: View {
     /// provider) and watch-only DashPay-external (`13`, unsignable) are excluded.
     /// Non-Standard accounts are surfaced too (dashpay/platform#4184) so their
     /// balances are visible — the actual funding source is the `fundingPath`
-    /// field; the account selected here supplies the transparent change sink and
-    /// is the default source when `fundingPath` is blank.
+    /// field; the BIP44 account selected in the picker supplies the transparent
+    /// change sink and is the default source when `fundingPath` is blank.
+    ///
+    /// BIP44 accounts are listed even at zero balance: they are needed as the
+    /// change sink whether or not they hold coins, which is exactly the #4073
+    /// case (all the DASH sits on the CoinJoin path). Every other family is
+    /// listed only when it has something to show.
     private var coreAccountOptions: [CoreAccountOption] {
         walletManager.accountBalances(for: wallet.walletId)
-            .filter { ($0.typeTag == 0 || $0.typeTag == 1 || $0.typeTag == 12) && $0.confirmed > 0 }
+            .filter { $0.typeTag == 0 || $0.typeTag == 1 || $0.typeTag == 12 }
+            .filter { ($0.typeTag == 0 && $0.standardTag == 0) || $0.confirmed > 0 }
             .sorted { ($0.typeTag, $0.standardTag, $0.index) < ($1.typeTag, $1.standardTag, $1.index) }
             .map {
                 CoreAccountOption(
@@ -875,9 +901,24 @@ struct ShieldedFundFromAssetLockView: View {
             }
     }
 
+    /// BIP44 accounts only — the ones the picker binds to. `fundingAccountIndex`
+    /// is the mandatory BIP44 change sink on the Rust side, so only a BIP44
+    /// index is a valid selection, and restricting the list keeps each
+    /// `accountIndex` tag unambiguous (dashpay/platform#4184 review).
+    private var changeAccountOptions: [CoreAccountOption] {
+        coreAccountOptions.filter { $0.typeTag == 0 && $0.standardTag == 0 }
+    }
+
+    /// The remaining spendable funds accounts (BIP32, CoinJoin, DashPay). Shown
+    /// read-only so their balances are visible; they are reached as a funding
+    /// source through the `fundingPath` field, not through the picker.
+    private var otherFundsAccountOptions: [CoreAccountOption] {
+        coreAccountOptions.filter { !($0.typeTag == 0 && $0.standardTag == 0) }
+    }
+
     private var selectedCoreAccountBalanceDuffs: UInt64 {
         guard let idx = fundingCoreAccountIndex else { return 0 }
-        return coreAccountOptions.first(where: { $0.accountIndex == idx })?.balanceDuffs ?? 0
+        return changeAccountOptions.first(where: { $0.accountIndex == idx })?.balanceDuffs ?? 0
     }
 
     /// True when the user named an explicit funding source via a non-blank
@@ -934,9 +975,9 @@ struct ShieldedFundFromAssetLockView: View {
 
     private func autoSelectDefaults() {
         if fundingCoreAccountIndex == nil {
-            fundingCoreAccountIndex = coreAccountOptions
+            fundingCoreAccountIndex = changeAccountOptions
                 .first { $0.balanceDuffs > 0 }?.accountIndex
-                ?? coreAccountOptions.first?.accountIndex
+                ?? changeAccountOptions.first?.accountIndex
         }
         // Platform branch: default to the first Platform Payment
         // account (prefer one with a credit balance), mirroring the


### PR DESCRIPTION
Shields asset-lock funding from all funds accounts: a multi-account funding builder (`build_asset_lock_tx_from_all_funding_accounts`) that unions spendable UTXOs across BIP44 + CoinJoin + DashPay funds accounts with LargestFirst coin selection, excludes watch-only `DashpayExternalAccount` UTXOs (a contact's coins the local mnemonic cannot sign), and maps `NoUtxosAvailable` to the typed asset-lock insufficient-funds error, with regression tests for the router-fix persistence path and the watch-only exclusion.

Re-opens #4074 which was auto-closed when the #3999 base branch was deleted; rebased onto `v4.1-dev`. The PR's own rust-dashcore router customization stays dropped — `v4.1-dev`'s rust-dashcore pin already carries that fix upstream (rust-dashcore#867), which the ported regression tests confirm against the pin. The platform-side changes in `rs-platform-wallet` are NOT in `v4.1-dev` and are all retained; the only conflict was a trivial import union in `test_support.rs`.

Verified: `cargo test -p platform-wallet` — 502 tests pass (38 asset-lock).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

### Review-response summary (2026-07-21)

- **FFI error arm**: `AssetLockInsufficientFunds` now crosses as dedicated code **29** (`ErrorAssetLockInsufficientFunds`), mapped in Kotlin and Swift, with an FFI-level test pinning the numeric code and verbatim message. The Display text is unchanged from what dash-wallet already matches, so no host breakage; hosts should migrate from substring-matching to the typed code at their convenience. Codes **26–28 are deliberately skipped** — they're allocated by the reservation-token errors on the split-build-broadcast branch (#4185); a comment in the enum documents the reservation so the two PRs can't collide.
- **Privacy-domain gate**: selection now defaults to a single privacy domain (transparent BIP44/BIP32 — the only domain that can supply change without linking, since key-wallet derives change on Standard accounts only). Cross-domain union requires an explicit consent parameter threaded from the builder through the FFI (`allow_cross_domain`, default false everywhere, including the resume path); refusal is typed code **30** (`ErrorAssetLockCrossDomainConsentRequired`) carrying transparent/union/required amounts. The identity-funding carve-out is unchanged — consent is ignored there, pinned by test. Round-2 addition: a fee-band shortfall (transparent covers the amount but not amount+fee, union covers it) is reclassified to consent-required at the selection-failure site, so hosts prompt instead of dead-ending; both the fee-band and denied-both-short paths are now tested.
- **Reservation-ledger blocker**: agreed this belongs upstream in key-wallet — a concrete design for atomic per-owning-account reservation commits (API shape, rollback semantics, platform adoption path) is drafted and will be proposed against rust-dashcore; the platform-side race window remains documented in code until that lands.
- **CI**: fork PRs skip the Rust suite and we can't push same-repo refs. Local evidence a maintainer can compare: `cargo test -p platform-wallet --lib` → 506 passed; `--features shielded --lib` → 636 passed; `-p platform-wallet-ffi --lib` → 198 passed; clippy clean on all three crates.
- **Host coordination note**: shielding CoinJoin/DashPay funds now requires `allowCrossDomain = true` after explicit user opt-in; dash-wallet will need a consent touchpoint before adopting the next AAR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional funding-path support for shielded asset-lock funding in the Kotlin and Swift SDKs.
  * Users can select a specific account’s UTXOs; blank paths preserve default funding behavior.
  * Added an optional funding-account field to the Swift example app.

* **Bug Fixes**
  * Asset-lock insufficient-funds failures now return dedicated errors across supported SDKs.
  * Invalid or malformed funding paths are rejected with parameter errors.
  * Existing asset-lock resume flows continue using their original funding selection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---
### Provenance (tracker refs moved from code comments per review)
The `build.rs` funding-eligibility comments previously carried an internal review-tracking token `finding 5b52d9844055` (4 sites). Removed from the comments (rationale text kept); it tracked the watch-only `DashpayExternalAccount` ownership carve-out now expressed through the privacy-domain map.

### C-ABI note
`platform_wallet_manager_shielded_fund_from_asset_lock` gained a trailing `allow_cross_domain: bool` parameter — a C-ABI break — and result codes 29/30 (`ErrorAssetLockInsufficientFunds` / `ErrorAssetLockCrossDomainConsentRequired`) are added. See `packages/rs-platform-wallet-ffi/README.md`.
