### PR TITLE
feat(kotlin-sdk): transaction decoder JNI binding over key-wallet-ffi transaction_decode

### DIFF
--- a/packages/kotlin-sdk/sdk/src/main/kotlin/org/dashfoundation/dashsdk/ffi/TxDecodeNative.kt
+++ b/packages/kotlin-sdk/sdk/src/main/kotlin/org/dashfoundation/dashsdk/ffi/TxDecodeNative.kt
@@ -1,0 +1,20 @@
+package org.dashfoundation.dashsdk.ffi
+
+/**
+ * Raw JNI surface for consensus transaction decoding — mirrors
+ * `rs-unified-sdk-jni/src/tx_decode.rs`.
+ */
+internal object TxDecodeNative {
+
+    /**
+     * Consensus-decode raw transaction bytes (key-wallet-ffi
+     * `transaction_decode`) into the packed big-endian BLOB documented in
+     * `tx_decode.rs` / parsed by
+     * [org.dashfoundation.dashsdk.keywallet.TransactionDecoder.parseBlob].
+     * [networkOrd] is [org.dashfoundation.dashsdk.Network.ffiValue].
+     *
+     * @throws DashSDKException on malformed bytes (including trailing
+     *   garbage after a valid transaction)
+     */
+    external fun decodeTransaction(txBytes: ByteArray, networkOrd: Int): ByteArray
+}

--- a/packages/kotlin-sdk/sdk/src/main/kotlin/org/dashfoundation/dashsdk/keywallet/TransactionDecoder.kt
+++ b/packages/kotlin-sdk/sdk/src/main/kotlin/org/dashfoundation/dashsdk/keywallet/TransactionDecoder.kt
@@ -1,0 +1,139 @@
+package org.dashfoundation.dashsdk.keywallet
+
+import java.nio.ByteBuffer
+import org.dashfoundation.dashsdk.Network
+import org.dashfoundation.dashsdk.Sdk
+import org.dashfoundation.dashsdk.errors.mapNativeErrors
+import org.dashfoundation.dashsdk.ffi.TxDecodeNative
+
+/**
+ * A consensus-decoded Dash transaction: per-output `(address, value,
+ * script)` plus per-input previous outpoints with a best-effort P2PKH
+ * sender address — port of `SwiftDashSDK/KeyWallet/TransactionDecoder.swift`
+ * (platform PR #3981) over key-wallet-ffi's `transaction_decode`.
+ *
+ * Wallet persistence stores every transaction's raw bytes
+ * (`TransactionEntity.transactionData`) but only materializes TXO rows for
+ * the wallet's own outputs, so rendering or matching a transaction's FULL
+ * input/output detail requires decoding the stored bytes.
+ * [TransactionDecoder.decode] is that opener.
+ */
+class DecodedTransaction(
+    /**
+     * Transaction id in consensus (internal) byte order — reverse for
+     * explorer-style display (see [txidDisplayHex]).
+     */
+    val txid: ByteArray,
+    val inputs: List<Input>,
+    val outputs: List<Output>,
+) {
+    class Input(
+        /**
+         * Previous output's txid in consensus (internal) byte order —
+         * reverse for explorer-style display (see [prevTxidDisplayHex]).
+         */
+        val prevTxid: ByteArray,
+        /** Previous output's index. */
+        val prevVout: Int,
+        /**
+         * Sender address recovered from a P2PKH-shaped scriptSig; null for
+         * coinbase / non-P2PKH / unparseable script sigs. Unauthenticated —
+         * derived from a script push the spender fully controls, with no
+         * signature verification against the spent UTXO. Use it for display
+         * or as a matching hint only, never for authentication or
+         * authorization; the attacker-resistant matching primitive is the
+         * per-output `(address, valueDuffs)` pair.
+         */
+        val address: String?,
+    ) {
+        /** Explorer-style (reversed, hex) rendering of [prevTxid]. */
+        val prevTxidDisplayHex: String get() = displayHex(prevTxid)
+    }
+
+    class Output(
+        /**
+         * Destination address for standard scripts (P2PKH / P2SH); null
+         * for non-standard scripts (OP_RETURN, bare multisig, …).
+         */
+        val address: String?,
+        /** Output value in duffs (unsigned semantics). */
+        val valueDuffs: Long,
+        /** Raw scriptPubKey bytes. */
+        val scriptPubkey: ByteArray,
+    )
+
+    /** Explorer-style (reversed, hex) rendering of [txid]. */
+    val txidDisplayHex: String get() = displayHex(txid)
+
+    private companion object {
+        fun displayHex(wire: ByteArray): String =
+            wire.reversedArray().joinToString("") { "%02x".format(it) }
+    }
+}
+
+/**
+ * Pure utility — decodes raw transaction bytes via key-wallet-ffi's
+ * `transaction_decode`. No wallet handle or state involved.
+ */
+object TransactionDecoder {
+
+    /**
+     * Consensus-decode raw transaction bytes.
+     *
+     * @param txData serialized transaction bytes (e.g. a persisted
+     *   `TransactionEntity.transactionData`).
+     * @param network network used to render addresses (base58 version bytes).
+     * @throws org.dashfoundation.dashsdk.errors.DashSdkError.InvalidParameter
+     *   for malformed or empty bytes (including trailing garbage).
+     */
+    fun decode(txData: ByteArray, network: Network): DecodedTransaction {
+        Sdk.initialize()
+        val blob = mapNativeErrors { TxDecodeNative.decodeTransaction(txData, network.ffiValue) }
+        return parseBlob(blob)
+    }
+
+    /**
+     * Parse the packed big-endian BLOB produced by
+     * `rs-unified-sdk-jni/src/tx_decode.rs` (layout documented there; the
+     * Rust test `fixture_blob_hex_is_pinned_for_kotlin` and
+     * `TransactionDecoderTest` pin the same fixture bytes from both sides).
+     * Internal + pure so it is host-JVM unit-testable without the native
+     * library.
+     */
+    internal fun parseBlob(blob: ByteArray): DecodedTransaction {
+        val buf = ByteBuffer.wrap(blob) // big-endian by default
+        val txid = ByteArray(32).also { buf.get(it) }
+
+        val inputCount = buf.int
+        require(inputCount >= 0) { "malformed decode blob: negative input count" }
+        val inputs = ArrayList<DecodedTransaction.Input>(inputCount)
+        repeat(inputCount) {
+            val prevTxid = ByteArray(32).also { buf.get(it) }
+            val prevVout = buf.int
+            inputs += DecodedTransaction.Input(prevTxid, prevVout, readStringOpt(buf))
+        }
+
+        val outputCount = buf.int
+        require(outputCount >= 0) { "malformed decode blob: negative output count" }
+        val outputs = ArrayList<DecodedTransaction.Output>(outputCount)
+        repeat(outputCount) {
+            val valueDuffs = buf.long
+            val address = readStringOpt(buf)
+            val scriptLen = buf.int
+            require(scriptLen >= 0) { "malformed decode blob: negative script length" }
+            val script = ByteArray(scriptLen).also { buf.get(it) }
+            outputs += DecodedTransaction.Output(address, valueDuffs, script)
+        }
+
+        require(!buf.hasRemaining()) { "malformed decode blob: trailing bytes" }
+        return DecodedTransaction(txid, inputs, outputs)
+    }
+
+    /** `u16 len + UTF-8 bytes`; len 0 = null (addresses are never empty). */
+    private fun readStringOpt(buf: ByteBuffer): String? {
+        val len = buf.short.toInt() and 0xFFFF
+        if (len == 0) return null
+        val bytes = ByteArray(len).also { buf.get(it) }
+        return String(bytes, Charsets.UTF_8)
+    }
+}

--- a/packages/kotlin-sdk/sdk/src/test/kotlin/org/dashfoundation/dashsdk/keywallet/TransactionDecoderTest.kt
+++ b/packages/kotlin-sdk/sdk/src/test/kotlin/org/dashfoundation/dashsdk/keywallet/TransactionDecoderTest.kt
@@ -1,0 +1,117 @@
+package org.dashfoundation.dashsdk.keywallet
+
+import java.nio.ByteBuffer
+import org.junit.Assert.assertArrayEquals
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertThrows
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Host-JVM tests of [TransactionDecoder.parseBlob] — the Kotlin half of the
+ * JNI decode contract. The fixture blob is the EXACT byte string the Rust
+ * side pins in `rs-unified-sdk-jni/src/tx_decode.rs`
+ * (`fixture_blob_hex_is_pinned_for_kotlin`): decoded from a deterministic
+ * one-input / two-output P2PKH spend on testnet, so the layout is verified
+ * from both ends without loading the native library. Regenerate BOTH
+ * constants together if the layout ever changes.
+ */
+class TransactionDecoderTest {
+
+    @Test
+    fun `parses the Rust-pinned fixture blob`() {
+        val decoded = TransactionDecoder.parseBlob(FIXTURE_BLOB_HEX.hexToBytes())
+
+        // txid is consensus (internal) order; display rendering reverses it.
+        assertEquals(
+            "d5b51c39a335f82c33beee64bbcdf9c62418884c6511bf606fa75b6e217974bf",
+            decoded.txid.joinToString("") { "%02x".format(it) }
+        )
+        assertEquals(
+            "bf7479216e5ba76f60bf11654c881824c6f9cdbb64eebe332cf835a3391cb5d5",
+            decoded.txidDisplayHex
+        )
+
+        assertEquals(1, decoded.inputs.size)
+        val input = decoded.inputs[0]
+        assertArrayEquals(ByteArray(32) { 0x11 }, input.prevTxid)
+        assertEquals(3, input.prevVout)
+        assertEquals("yNDj28QBMm5sY6bLjFcNdWRNef24KLQNuQ", input.address)
+        assertEquals("11".repeat(32), input.prevTxidDisplayHex)
+
+        assertEquals(2, decoded.outputs.size)
+        val paid = decoded.outputs[0]
+        assertEquals("yNDj28QBMm5sY6bLjFcNdWRNef24KLQNuQ", paid.address)
+        assertEquals(151_072L, paid.valueDuffs)
+        assertEquals(
+            "76a91414db4138d56a2ecfb10881a9be394d9f321985b288ac",
+            paid.scriptPubkey.joinToString("") { "%02x".format(it) }
+        )
+
+        val opReturn = decoded.outputs[1]
+        assertNull("OP_RETURN output has no address", opReturn.address)
+        assertEquals(0L, opReturn.valueDuffs)
+        assertEquals(
+            "6a04aaaaaaaa",
+            opReturn.scriptPubkey.joinToString("") { "%02x".format(it) }
+        )
+    }
+
+    @Test
+    fun `null address markers and empty lists round-trip`() {
+        // Hand-built blob: coinbase-like tx — one input without an address,
+        // one output without an address (non-standard script), empty script.
+        val blob = ByteBuffer.allocate(32 + 4 + (32 + 4 + 2) + 4 + (8 + 2 + 4))
+        blob.put(ByteArray(32) { 0xAB.toByte() })
+        blob.putInt(1)
+        blob.put(ByteArray(32)) // null prev txid (coinbase)
+        blob.putInt(-1) // coinbase vout 0xFFFFFFFF
+        blob.putShort(0) // no address
+        blob.putInt(1)
+        blob.putLong(5_000_000_000L)
+        blob.putShort(0) // no address
+        blob.putInt(0) // empty script
+
+        val decoded = TransactionDecoder.parseBlob(blob.array())
+        assertEquals(1, decoded.inputs.size)
+        assertNull(decoded.inputs[0].address)
+        assertEquals(-1, decoded.inputs[0].prevVout) // u32 max crosses as -1 bits
+        assertEquals(1, decoded.outputs.size)
+        assertNull(decoded.outputs[0].address)
+        assertEquals(5_000_000_000L, decoded.outputs[0].valueDuffs)
+        assertEquals(0, decoded.outputs[0].scriptPubkey.size)
+    }
+
+    @Test
+    fun `truncated blob throws`() {
+        val fixture = FIXTURE_BLOB_HEX.hexToBytes()
+        assertThrows(Exception::class.java) {
+            TransactionDecoder.parseBlob(fixture.copyOfRange(0, fixture.size - 3))
+        }
+    }
+
+    @Test
+    fun `trailing bytes throw`() {
+        val fixture = FIXTURE_BLOB_HEX.hexToBytes()
+        val padded = fixture + byteArrayOf(0x00)
+        val error = assertThrows(IllegalArgumentException::class.java) {
+            TransactionDecoder.parseBlob(padded)
+        }
+        assertTrue(error.message!!.contains("trailing"))
+    }
+
+    private fun String.hexToBytes(): ByteArray =
+        chunked(2).map { it.toInt(16).toByte() }.toByteArray()
+
+    companion object {
+        /** Pinned in `tx_decode.rs::fixture_blob_hex_is_pinned_for_kotlin`. */
+        private const val FIXTURE_BLOB_HEX =
+            "d5b51c39a335f82c33beee64bbcdf9c62418884c6511bf606fa75b6e217974bf" +
+                "000000011111111111111111111111111111111111111111111111111111111111111111" +
+                "000000030022794e446a323851424d6d35735936624c6a46634e6457524e656632344b4c514e7551" +
+                "000000020000000000024e200022794e446a323851424d6d35735936624c6a46634e6457524e656632344b4c514e7551" +
+                "0000001976a91414db4138d56a2ecfb10881a9be394d9f321985b288ac" +
+                "00000000000000000000000000066a04aaaaaaaa"
+    }
+}

--- a/packages/rs-unified-sdk-jni/src/lib.rs
+++ b/packages/rs-unified-sdk-jni/src/lib.rs
@@ -28,6 +28,7 @@ mod signer;
 mod support;
 mod tokens;
 mod transactions;
+mod tx_decode;
 mod wallet_manager;
 
 use jni::sys::{jint, JNI_VERSION_1_6};

--- a/packages/rs-unified-sdk-jni/src/tx_decode.rs
+++ b/packages/rs-unified-sdk-jni/src/tx_decode.rs
@@ -1,0 +1,363 @@
+//! JNI bridge for consensus transaction decoding — a thin marshaler over
+//! key-wallet-ffi's `transaction_decode` (single Rust FFI entry point, per
+//! the `packages/kotlin-sdk/CLAUDE.md` boundary rule).
+//!
+//! Kotlin counterpart: `org.dashfoundation.dashsdk.ffi.TxDecodeNative`,
+//! driven by `org.dashfoundation.dashsdk.keywallet.TransactionDecoder` —
+//! the Android analog of `SwiftDashSDK/KeyWallet/TransactionDecoder.swift`
+//! (platform PR #3981).
+//!
+//! ## Result convention
+//!
+//! `DecodedTransactionFFI` is a pointer graph (per-input/per-output C
+//! strings and script buffers); rather than exposing a native handle plus
+//! N accessors across JNI, the whole decode result is copied ONCE into a
+//! packed byte blob (the same big-endian BLOB convention as
+//! `wallet_manager::walletAddressesWithBalances`) and every Rust
+//! allocation is freed via `decoded_transaction_free` before the export
+//! returns. Errors throw `DashSDKException` carrying the raw
+//! key-wallet-ffi `FFIErrorCode` (same namespace `MnemonicNative
+//! .generateMnemonic` already throws — `InvalidInput = 1` for malformed /
+//! empty / trailing-garbage bytes).
+//!
+//! ## BLOB layout (big-endian; keep in sync with `TransactionDecoder.parseBlob`)
+//!
+//! ```text
+//! u8[32] txid                    (consensus/internal byte order)
+//! u32    input_count
+//! repeat input_count times:
+//!   u8[32] prev_txid             (consensus/internal byte order)
+//!   u32    prev_vout
+//!   u16    address_len           (0 = no recovered sender address)
+//!   u8[address_len] address      (UTF-8 base58; unauthenticated P2PKH hint)
+//! u32    output_count
+//! repeat output_count times:
+//!   u64    value_duffs
+//!   u16    address_len           (0 = non-standard script, no address)
+//!   u8[address_len] address      (UTF-8 base58)
+//!   u32    script_len
+//!   u8[script_len] script_pubkey
+//! ```
+
+use crate::support::{guard, throw_sdk_exception};
+use dash_network::ffi::FFINetwork;
+use jni::objects::{JByteArray, JClass};
+use jni::sys::{jbyteArray, jint};
+use jni::JNIEnv;
+use key_wallet_ffi::tx_decode::{
+    decoded_transaction_free, transaction_decode, DecodedTransactionFFI,
+};
+use std::ffi::CStr;
+
+/// FFINetwork ordinal → enum (0=Mainnet, 2=Devnet, 3=Regtest, else
+/// Testnet). Matches `transactions::net_from_ord` and Kotlin's
+/// `Network.ffiValue`.
+fn net_from_ord(ord: i32) -> FFINetwork {
+    match ord {
+        0 => FFINetwork::Mainnet,
+        2 => FFINetwork::Devnet,
+        3 => FFINetwork::Regtest,
+        _ => FFINetwork::Testnet,
+    }
+}
+
+/// Append `u16 len + bytes` for an optional C string (null → len 0).
+/// An `Address` rendering is never empty, so 0 unambiguously means "none".
+///
+/// # Safety
+/// `ptr` must be null or a valid NUL-terminated C string.
+unsafe fn push_cstr_opt(blob: &mut Vec<u8>, ptr: *const std::os::raw::c_char) {
+    if ptr.is_null() {
+        blob.extend_from_slice(&0u16.to_be_bytes());
+        return;
+    }
+    let bytes = CStr::from_ptr(ptr).to_bytes();
+    // Addresses are ~34 chars; anything that would overflow u16 is not an
+    // address — encode as absent rather than corrupting the layout.
+    let Ok(len) = u16::try_from(bytes.len()) else {
+        blob.extend_from_slice(&0u16.to_be_bytes());
+        return;
+    };
+    blob.extend_from_slice(&len.to_be_bytes());
+    blob.extend_from_slice(bytes);
+}
+
+/// Copy a `DecodedTransactionFFI` pointer graph into the packed blob.
+///
+/// # Safety
+/// `decoded` must be a valid result of `transaction_decode` that has not
+/// been freed.
+unsafe fn encode_decoded_transaction(decoded: &DecodedTransactionFFI) -> Vec<u8> {
+    let mut blob = Vec::with_capacity(256);
+    blob.extend_from_slice(&decoded.txid);
+
+    blob.extend_from_slice(&(decoded.inputs_count as u32).to_be_bytes());
+    if !decoded.inputs.is_null() {
+        let inputs = std::slice::from_raw_parts(decoded.inputs, decoded.inputs_count);
+        for input in inputs {
+            blob.extend_from_slice(&input.prev_txid);
+            blob.extend_from_slice(&input.prev_vout.to_be_bytes());
+            push_cstr_opt(&mut blob, input.address);
+        }
+    }
+
+    blob.extend_from_slice(&(decoded.outputs_count as u32).to_be_bytes());
+    if !decoded.outputs.is_null() {
+        let outputs = std::slice::from_raw_parts(decoded.outputs, decoded.outputs_count);
+        for output in outputs {
+            blob.extend_from_slice(&output.value_duffs.to_be_bytes());
+            push_cstr_opt(&mut blob, output.address);
+            blob.extend_from_slice(&(output.script_pubkey_len as u32).to_be_bytes());
+            if !output.script_pubkey.is_null() && output.script_pubkey_len > 0 {
+                blob.extend_from_slice(std::slice::from_raw_parts(
+                    output.script_pubkey,
+                    output.script_pubkey_len,
+                ));
+            }
+        }
+    }
+    blob
+}
+
+/// JNI-free core: consensus-decode `tx_bytes` and marshal the result into
+/// the packed blob, freeing every Rust-side allocation before returning.
+/// `Err((code, message))` carries the key-wallet-ffi `FFIErrorCode`.
+fn decode_to_blob(tx_bytes: &[u8], network: FFINetwork) -> Result<Vec<u8>, (i32, String)> {
+    // Out-param error slot; the FFI writes code+message into it.
+    let mut error = key_wallet_ffi::FFIError {
+        code: key_wallet_ffi::FFIErrorCode::Success,
+        message: std::ptr::null_mut(),
+    };
+    let mut out: *mut DecodedTransactionFFI = std::ptr::null_mut();
+    let ok = unsafe {
+        transaction_decode(tx_bytes.as_ptr(), tx_bytes.len(), network, &mut out, &mut error)
+    };
+    if !ok || out.is_null() {
+        let message = if error.message.is_null() {
+            String::from("transaction decode failed")
+        } else {
+            unsafe { CStr::from_ptr(error.message) }
+                .to_string_lossy()
+                .into_owned()
+        };
+        // Capture the code BEFORE clean() — clean() resets it to Success
+        // while freeing the message (same hazard as MnemonicNative).
+        let code = error.code as i32;
+        unsafe { error.clean() };
+        return Err((code, message));
+    }
+    let blob = unsafe { encode_decoded_transaction(&*out) };
+    unsafe { decoded_transaction_free(out) };
+    Ok(blob)
+}
+
+/// Consensus-decode raw transaction bytes into the packed BLOB documented
+/// in the module header. `networkOrd` is `Network.ffiValue`. Throws
+/// `DashSDKException` (key-wallet-ffi code namespace; `InvalidInput = 1`)
+/// on malformed bytes — including a valid transaction followed by trailing
+/// garbage.
+#[no_mangle]
+pub extern "system" fn Java_org_dashfoundation_dashsdk_ffi_TxDecodeNative_decodeTransaction(
+    mut env: JNIEnv,
+    _class: JClass,
+    tx_bytes: JByteArray,
+    network_ord: jint,
+) -> jbyteArray {
+    guard(&mut env, std::ptr::null_mut(), |env| {
+        let bytes = match env.convert_byte_array(&tx_bytes) {
+            Ok(b) => b,
+            Err(_) => {
+                let _ = env.exception_clear();
+                throw_sdk_exception(env, 1, "txBytes byte[] was null/invalid");
+                return std::ptr::null_mut();
+            }
+        };
+        match decode_to_blob(&bytes, net_from_ord(network_ord)) {
+            Ok(blob) => env
+                .byte_array_from_slice(&blob)
+                .map(|a| a.into_raw())
+                .unwrap_or(std::ptr::null_mut()),
+            Err((code, message)) => {
+                throw_sdk_exception(env, code, &message);
+                std::ptr::null_mut()
+            }
+        }
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    //! Everything funnels through [`decode_to_blob`] — the exact code the
+    //! JNI export runs minus the `JNIEnv` marshaling — so the blob bytes
+    //! these tests pin are the bytes Kotlin's `TransactionDecoder
+    //! .parseBlob` receives. `TransactionDecoderTest.kt` asserts the SAME
+    //! fixture blob hex, cross-pinning the layout from both sides.
+
+    use super::*;
+    use dashcore::consensus::serialize;
+    use dashcore::hashes::Hash;
+    use dashcore::secp256k1::{Secp256k1, SecretKey};
+    use dashcore::{
+        Address, Network, OutPoint, PublicKey, ScriptBuf, Transaction, TxIn, TxOut, Txid, Witness,
+    };
+
+    /// Minimal big-endian blob reader mirroring the Kotlin parser.
+    struct Reader<'a> {
+        blob: &'a [u8],
+        pos: usize,
+    }
+
+    impl<'a> Reader<'a> {
+        fn take(&mut self, n: usize) -> &'a [u8] {
+            let s = &self.blob[self.pos..self.pos + n];
+            self.pos += n;
+            s
+        }
+        fn u16(&mut self) -> u16 {
+            u16::from_be_bytes(self.take(2).try_into().unwrap())
+        }
+        fn u32(&mut self) -> u32 {
+            u32::from_be_bytes(self.take(4).try_into().unwrap())
+        }
+        fn u64(&mut self) -> u64 {
+            u64::from_be_bytes(self.take(8).try_into().unwrap())
+        }
+        fn str_opt(&mut self) -> Option<String> {
+            let len = self.u16() as usize;
+            if len == 0 {
+                None
+            } else {
+                Some(String::from_utf8(self.take(len).to_vec()).unwrap())
+            }
+        }
+    }
+
+    fn test_pubkey() -> PublicKey {
+        let secp = Secp256k1::new();
+        let sk = SecretKey::from_slice(&[0x42u8; 32]).expect("valid secret key");
+        PublicKey::new(sk.public_key(&secp))
+    }
+
+    /// The same deterministic fixture as key-wallet-ffi's
+    /// `p2pkh_spend_tx`: one P2PKH-shaped input spending 11..11:3, one
+    /// P2PKH output of 151_072 duffs, one OP_RETURN output.
+    fn p2pkh_spend_tx(network: Network) -> (Transaction, Address) {
+        let pubkey = test_pubkey();
+        let addr = Address::p2pkh(&pubkey, network);
+        let script_sig = dashcore::blockdata::script::Builder::new()
+            .push_slice([0x30u8; 71])
+            .push_key(&pubkey)
+            .into_script();
+        let tx = Transaction {
+            version: 1,
+            lock_time: 0,
+            input: vec![TxIn {
+                previous_output: OutPoint {
+                    txid: Txid::from_byte_array([0x11u8; 32]),
+                    vout: 3,
+                },
+                script_sig,
+                sequence: 0xffffffff,
+                witness: Witness::default(),
+            }],
+            output: vec![
+                TxOut {
+                    value: 151_072,
+                    script_pubkey: addr.script_pubkey(),
+                },
+                TxOut {
+                    value: 0,
+                    script_pubkey: ScriptBuf::new_op_return(&[0xAAu8; 4]),
+                },
+            ],
+            special_transaction_payload: None,
+        };
+        (tx, addr)
+    }
+
+    #[test]
+    fn blob_roundtrips_the_fixture_transaction() {
+        let (tx, addr) = p2pkh_spend_tx(Network::Testnet);
+        let bytes = serialize(&tx);
+        let blob = decode_to_blob(&bytes, FFINetwork::Testnet).expect("decode ok");
+
+        let mut r = Reader { blob: &blob, pos: 0 };
+        assert_eq!(r.take(32), tx.txid().to_byte_array());
+
+        assert_eq!(r.u32(), 1, "one input");
+        assert_eq!(r.take(32), [0x11u8; 32]);
+        assert_eq!(r.u32(), 3, "prev vout");
+        assert_eq!(r.str_opt().as_deref(), Some(addr.to_string().as_str()));
+
+        assert_eq!(r.u32(), 2, "two outputs");
+        assert_eq!(r.u64(), 151_072);
+        assert_eq!(r.str_opt().as_deref(), Some(addr.to_string().as_str()));
+        let script_len = r.u32() as usize;
+        assert_eq!(r.take(script_len), addr.script_pubkey().as_bytes());
+
+        assert_eq!(r.u64(), 0, "OP_RETURN value");
+        assert_eq!(r.str_opt(), None, "OP_RETURN has no address");
+        let op_return_len = r.u32() as usize;
+        assert!(op_return_len > 0, "script bytes still present");
+        r.take(op_return_len);
+
+        assert_eq!(r.pos, blob.len(), "no trailing bytes");
+    }
+
+    #[test]
+    fn fixture_blob_hex_is_pinned_for_kotlin() {
+        // The exact bytes `TransactionDecoderTest.kt` parses — regenerate
+        // BOTH sides together if the layout ever changes.
+        let (tx, _) = p2pkh_spend_tx(Network::Testnet);
+        let blob = decode_to_blob(&serialize(&tx), FFINetwork::Testnet).expect("decode ok");
+        let hex: String = blob.iter().map(|b| format!("{b:02x}")).collect();
+        assert_eq!(hex, FIXTURE_BLOB_HEX);
+    }
+
+    /// Shared fixture blob (see [`fixture_blob_hex_is_pinned_for_kotlin`]).
+    const FIXTURE_BLOB_HEX: &str = "d5b51c39a335f82c33beee64bbcdf9c62418884c6511bf606fa75b6e217974bf000000011111111111111111111111111111111111111111111111111111111111111111000000030022794e446a323851424d6d35735936624c6a46634e6457524e656632344b4c514e7551000000020000000000024e200022794e446a323851424d6d35735936624c6a46634e6457524e656632344b4c514e75510000001976a91414db4138d56a2ecfb10881a9be394d9f321985b288ac00000000000000000000000000066a04aaaaaaaa";
+
+    #[test]
+    fn network_changes_rendered_addresses() {
+        let (tx, addr) = p2pkh_spend_tx(Network::Testnet);
+        let blob = decode_to_blob(&serialize(&tx), FFINetwork::Mainnet).expect("decode ok");
+        let mut r = Reader { blob: &blob, pos: 0 };
+        r.take(32);
+        r.u32();
+        r.take(36);
+        let input_addr = r.str_opt().unwrap();
+        assert_ne!(input_addr, addr.to_string());
+        assert!(input_addr.starts_with('X'), "mainnet P2PKH starts with 'X'");
+    }
+
+    #[test]
+    fn garbage_bytes_error_with_invalid_input() {
+        let err = decode_to_blob(&[0xFFu8; 16], FFINetwork::Testnet).unwrap_err();
+        assert_eq!(err.0, key_wallet_ffi::FFIErrorCode::InvalidInput as i32);
+        assert!(!err.1.is_empty());
+    }
+
+    #[test]
+    fn trailing_garbage_is_an_error() {
+        let (tx, _) = p2pkh_spend_tx(Network::Testnet);
+        let mut bytes = serialize(&tx);
+        bytes.extend_from_slice(&[0xDE, 0xAD]);
+        let err = decode_to_blob(&bytes, FFINetwork::Testnet).unwrap_err();
+        assert_eq!(err.0, key_wallet_ffi::FFIErrorCode::InvalidInput as i32);
+    }
+
+    #[test]
+    fn empty_bytes_error_with_invalid_input() {
+        let err = decode_to_blob(&[], FFINetwork::Testnet).unwrap_err();
+        assert_eq!(err.0, key_wallet_ffi::FFIErrorCode::InvalidInput as i32);
+    }
+
+    #[test]
+    fn net_from_ord_matches_kotlin_ffi_values() {
+        assert_eq!(net_from_ord(0), FFINetwork::Mainnet);
+        assert_eq!(net_from_ord(1), FFINetwork::Testnet);
+        assert_eq!(net_from_ord(2), FFINetwork::Devnet);
+        assert_eq!(net_from_ord(3), FFINetwork::Regtest);
+        assert_eq!(net_from_ord(-1), FFINetwork::Testnet, "unknown → Testnet");
+    }
+}


### PR DESCRIPTION
Adds the Android/Kotlin counterpart of the Swift `TransactionDecoder` (#3981): a single JNI export (`TxDecodeNative.decodeTransaction`) over key-wallet-ffi's `transaction_decode` — already present in `v4.1-dev`'s rust-dashcore pin via upstream rust-dashcore#870, so no vendored Rust changes are needed. The JNI layer marshals the decode result into a packed big-endian BLOB parsed by the new `org.dashfoundation.dashsdk.keywallet.TransactionDecoder` into `DecodedTransaction` (txid + per-input prev outpoints / unauthenticated P2PKH sender hints + per-output address/value/script).

The JNI-free `decode_to_blob` core is host-tested (7 Rust tests), including a fixture blob pinned byte-for-byte against Kotlin's `TransactionDecoderTest` (4 tests) as a cross-language layout pin.

Verified: `cargo test -p rs-unified-sdk-jni` (17 tests) and `:sdk:assembleRelease` + sdk unit tests all pass against the pin's `transaction_decode` signature (no API drift).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
