### PR TITLE
fix(kotlin-sdk): unmanaged-identity reads return absence + typed SigningKeyUnavailable (split from #4183)

### DIFF
--- a/packages/kotlin-sdk/sdk/src/main/kotlin/org/dashfoundation/dashsdk/errors/DashSdkError.kt
+++ b/packages/kotlin-sdk/sdk/src/main/kotlin/org/dashfoundation/dashsdk/errors/DashSdkError.kt
@@ -177,6 +177,35 @@ sealed class DashSdkError(
             )
 
         /**
+         * A state transition could not be signed because the signer has no
+         * usable private key for the requested public key — the stored blob
+         * is missing (never derived, wiped, or written under a different
+         * Keystore alias/policy) rather than the operation itself failing.
+         *
+         * Signing failures originate as free text in
+         * `KeystoreSigner.completeSign` (the "[MESSAGE_MARKER] <pubkeyHex>"
+         * string), travel through Rust, and come back under the catch-all
+         * platform-wallet codes; [fromPlatformWalletNative] recognizes the
+         * marker on the Kotlin boundary and surfaces this typed error so
+         * hosts can route users to key repair (e.g.
+         * `PlatformWalletManager.repairIdentityKey`) instead of treating it
+         * as an opaque [Generic] failure. Not retryable as-is — the key must
+         * be (re-)derived first.
+         */
+        class SigningKeyUnavailable(message: String, cause: Throwable? = null) :
+            PlatformWallet(message, cause) {
+            companion object {
+                /**
+                 * Stable prefix of the `KeystoreSigner` "missing key"
+                 * completion error. `KeystoreSigner` builds its message from
+                 * this constant, so the emitter and the matcher cannot
+                 * drift.
+                 */
+                const val MESSAGE_MARKER = "no private key stored for"
+            }
+        }
+
+        /**
          * Any other `PlatformWalletFFIResultCode` without a dedicated type.
          * Carries the platform-wallet [nativeCode] (already de-offset) and
          * the Rust-supplied message.
@@ -234,7 +263,11 @@ sealed class DashSdkError(
          * [PlatformWallet] subtree — mirror of Swift's
          * `PlatformWalletError(result:)` construction. Retry-semantics-bearing
          * codes get dedicated types; the rest fall through to
-         * [PlatformWallet.Generic].
+         * [PlatformWallet.Generic] — except the `KeystoreSigner` "missing
+         * key" completion error, which travels as free text through Rust and
+         * is recognized by its [PlatformWallet.SigningKeyUnavailable]
+         * message marker here (only on the catch-all codes, so the dedicated
+         * retry-semantics types are never overridden).
          */
         private fun fromPlatformWalletNative(
             code: Int,
@@ -243,7 +276,12 @@ sealed class DashSdkError(
         ): DashSdkError = when (code) {
             // PlatformWalletFFIResultCode variants (platform-wallet-ffi/src/error.rs)
             1 -> PlatformWallet.InvalidHandle(message, cause) // ErrorInvalidHandle
-            6 -> PlatformWallet.WalletOperation(message, cause) // ErrorWalletOperation
+            6 -> // ErrorWalletOperation
+                if (isSigningKeyUnavailable(message)) {
+                    PlatformWallet.SigningKeyUnavailable(message, cause)
+                } else {
+                    PlatformWallet.WalletOperation(message, cause)
+                }
             7, // ErrorIdentityNotFound
             8, // ErrorContactNotFound
             PLATFORM_WALLET_NOT_FOUND_CODE, // NotFound (Option returned as an error)
@@ -256,8 +294,16 @@ sealed class DashSdkError(
             23 -> PlatformWallet.AssetLockNotTracked(message, cause) // ErrorAssetLockNotTracked
             24 -> PlatformWallet.AssetLockAlreadyConsumed(message, cause) // ErrorAssetLockAlreadyConsumed
             25 -> PlatformWallet.AssetLockFundingMismatch(message, cause) // ErrorAssetLockFundingMismatch
-            else -> PlatformWallet.Generic(code, message, cause)
+            else ->
+                if (isSigningKeyUnavailable(message)) {
+                    PlatformWallet.SigningKeyUnavailable(message, cause)
+                } else {
+                    PlatformWallet.Generic(code, message, cause)
+                }
         }
+
+        private fun isSigningKeyUnavailable(message: String): Boolean =
+            message.contains(PlatformWallet.SigningKeyUnavailable.MESSAGE_MARKER)
     }
 }
 

--- a/packages/kotlin-sdk/sdk/src/main/kotlin/org/dashfoundation/dashsdk/errors/DashSdkError.kt
+++ b/packages/kotlin-sdk/sdk/src/main/kotlin/org/dashfoundation/dashsdk/errors/DashSdkError.kt
@@ -197,6 +197,17 @@ sealed class DashSdkError(
          */
         const val PLATFORM_WALLET_CODE_OFFSET = 1000
 
+        /**
+         * `PlatformWalletFFIResultCode::NotFound` (98) — the code the FFI's
+         * blanket `Option → result` conversion emits for every "requested
+         * <thing> not found" miss (e.g. an identity id that is not managed
+         * by the wallet). Mapped to [NotFound]; Dashpay's managed-identity
+         * local reads intercept the RAW code (offset + 98) via
+         * `translateManagedIdentityNotFoundToZero` before [fromNative] runs
+         * and turn the miss into an absence (zero handle → null / empty).
+         */
+        const val PLATFORM_WALLET_NOT_FOUND_CODE = 98
+
         /** Map a native error code + message into the public hierarchy. */
         fun fromNative(e: DashSDKException): DashSdkError {
             val message = e.message ?: "Unknown SDK error"
@@ -235,7 +246,7 @@ sealed class DashSdkError(
             6 -> PlatformWallet.WalletOperation(message, cause) // ErrorWalletOperation
             7, // ErrorIdentityNotFound
             8, // ErrorContactNotFound
-            98, // NotFound (Option returned as an error)
+            PLATFORM_WALLET_NOT_FOUND_CODE, // NotFound (Option returned as an error)
             -> NotFound(message, cause)
             16 -> PlatformWallet.ShieldedBroadcastFailed(message, cause) // ErrorShieldedBroadcastFailed
             18 -> PlatformWallet.ShieldedSpendUnconfirmed(message, cause) // ErrorShieldedSpendUnconfirmed

--- a/packages/kotlin-sdk/sdk/src/main/kotlin/org/dashfoundation/dashsdk/identity/IdentityRegistration.kt
+++ b/packages/kotlin-sdk/sdk/src/main/kotlin/org/dashfoundation/dashsdk/identity/IdentityRegistration.kt
@@ -12,6 +12,7 @@ import org.dashfoundation.dashsdk.ffi.ContestedDpnsNamesNativeResult
 import org.dashfoundation.dashsdk.ffi.IdentityNative
 import org.dashfoundation.dashsdk.ffi.IdentityRegistrationNativeResult
 import org.dashfoundation.dashsdk.ffi.TokensNative
+import org.dashfoundation.dashsdk.tokens.translateManagedIdentityNotFoundToZero
 import org.dashfoundation.dashsdk.wallet.TrackedAssetLock
 
 internal fun interface ResumeIdentityNativeCall {
@@ -90,8 +91,14 @@ class IdentityRegistration internal constructor(
         val refreshedCount = mapNativeErrors {
             syncContestedDpnsNative.call(walletHandle, identityId)
         }
+        // The native side reports an unmanaged identity as a platform-wallet
+        // NotFound error, not a zero handle; translate the raw code back to
+        // the zero-handle signal so the intended, caller-facing message below
+        // is what actually surfaces (dashpay/platform#4060).
         val identityHandle = mapNativeErrors {
-            managedIdentityLookupNative.call(walletHandle, identityId)
+            translateManagedIdentityNotFoundToZero {
+                managedIdentityLookupNative.call(walletHandle, identityId)
+            }
         }
         if (identityHandle == 0L) {
             throw DashSdkError.NotFound("identity is not managed by this wallet")

--- a/packages/kotlin-sdk/sdk/src/main/kotlin/org/dashfoundation/dashsdk/security/KeystoreSigner.kt
+++ b/packages/kotlin-sdk/sdk/src/main/kotlin/org/dashfoundation/dashsdk/security/KeystoreSigner.kt
@@ -8,6 +8,7 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import java.util.concurrent.ConcurrentHashMap
 import org.dashfoundation.dashsdk.Network
+import org.dashfoundation.dashsdk.errors.DashSdkError
 import org.dashfoundation.dashsdk.ffi.NativeSignerBridge
 import org.dashfoundation.dashsdk.ffi.SignerNative
 import org.dashfoundation.dashsdk.persistence.dao.PlatformAddressDao
@@ -100,10 +101,15 @@ class KeystoreSigner(
             val storageKey = storageKeyFor(pubkeyBytes)
             key = retrieveKeyWithAuth(storageKey)
             if (key == null) {
+                // Built from the shared marker so the error survives the
+                // Rust round-trip and comes back typed as
+                // DashSdkError.PlatformWallet.SigningKeyUnavailable (the
+                // fromPlatformWalletNative message match) instead of Generic.
                 SignerNative.completeSign(
                     completionToken,
                     null,
-                    "no private key stored for ${storageKey.take(16)}…",
+                    "${DashSdkError.PlatformWallet.SigningKeyUnavailable.MESSAGE_MARKER} " +
+                        "${storageKey.take(16)}…",
                 )
                 return
             }

--- a/packages/kotlin-sdk/sdk/src/main/kotlin/org/dashfoundation/dashsdk/tokens/Dashpay.kt
+++ b/packages/kotlin-sdk/sdk/src/main/kotlin/org/dashfoundation/dashsdk/tokens/Dashpay.kt
@@ -5,7 +5,9 @@ import org.dashfoundation.dashsdk.wallet.op
 import java.util.concurrent.atomic.AtomicLong
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
+import org.dashfoundation.dashsdk.errors.DashSdkError
 import org.dashfoundation.dashsdk.errors.mapNativeErrors
+import org.dashfoundation.dashsdk.ffi.DashSDKException
 import org.dashfoundation.dashsdk.ffi.DashpayNative
 import org.dashfoundation.dashsdk.ffi.NativeCleaner
 import org.dashfoundation.dashsdk.ffi.TokensNative
@@ -215,7 +217,7 @@ class Dashpay internal constructor(private val walletHandle: Long,
      */
     suspend fun contacts(identityId: ByteArray): Contacts = withContext(Dispatchers.IO) {
         mapNativeErrors {
-            val identityHandle = TokensNative.getManagedIdentity(walletHandle, identityId)
+            val identityHandle = managedIdentityHandleOrZero(identityId)
             if (identityHandle == 0L) {
                 return@mapNativeErrors Contacts(emptyList(), emptyList(), emptyList())
             }
@@ -253,7 +255,7 @@ class Dashpay internal constructor(private val walletHandle: Long,
         coreSignerHandle: Long,
     ): Boolean = gate.op {
         mapNativeErrors {
-            val identityHandle = TokensNative.getManagedIdentity(walletHandle, ourIdentityId)
+            val identityHandle = managedIdentityHandleOrZero(ourIdentityId)
             if (identityHandle == 0L) return@mapNativeErrors false
             try {
                 val requestHandle =
@@ -441,6 +443,21 @@ class Dashpay internal constructor(private val walletHandle: Long,
     }
 
     /**
+     * Snapshot the managed identity for [identityId], or 0 when the wallet
+     * does not manage it. The native side reports an unmanaged identity as
+     * a platform-wallet NotFound error rather than a zero handle, so the
+     * "not managed" outcome is translated here — every local-read caller
+     * treats it as an absence (null / empty / false), never an exception.
+     * An invalid/stale wallet handle is a distinct native error
+     * (ErrorInvalidHandle) that is NOT translated, so it propagates instead
+     * of masquerading as an unmanaged identity (dashpay/platform#4060).
+     */
+    private fun managedIdentityHandleOrZero(identityId: ByteArray): Long =
+        translateManagedIdentityNotFoundToZero {
+            TokensNative.getManagedIdentity(walletHandle, identityId)
+        }
+
+    /**
      * Open the managed-identity handle for [identityId], run [block],
      * and destroy the handle before returning (the [contacts] /
      * [acceptIncomingRequest] discipline). Returns null when the
@@ -450,7 +467,7 @@ class Dashpay internal constructor(private val walletHandle: Long,
         identityId: ByteArray,
         block: (Long) -> T,
     ): T? {
-        val handle = TokensNative.getManagedIdentity(walletHandle, identityId)
+        val handle = managedIdentityHandleOrZero(identityId)
         if (handle == 0L) return null
         return try {
             block(handle)
@@ -547,3 +564,28 @@ class EstablishedContactRef internal constructor(handle: Long) : AutoCloseable {
         }
     }
 }
+
+// ── Free functions (unit-testable, no `this`) ─────────────────────────
+
+/**
+ * Run [getHandle] (a `TokensNative.getManagedIdentity` call), translating
+ * the platform-wallet NotFound error the native layer raises for an
+ * identity the wallet does not manage into a zero handle — the same "not
+ * managed" signal the callers already handle by returning null / empty.
+ *
+ * The FFI's blanket `Option → result` conversion reports the miss as
+ * `PlatformWalletFFIResultCode::NotFound` (98, offset into the
+ * `DashSDKException` code by [DashSdkError.PLATFORM_WALLET_CODE_OFFSET]),
+ * so without this every local read over an unmanaged identity — e.g.
+ * [Dashpay.syncState] on a contact's identity — would throw
+ * a typed `DashSdkError.NotFound("…ManagedIdentity not found")`
+ * instead of returning null. Any other error is rethrown untouched.
+ */
+internal inline fun translateManagedIdentityNotFoundToZero(getHandle: () -> Long): Long =
+    try {
+        getHandle()
+    } catch (e: DashSDKException) {
+        val notFound = DashSdkError.PLATFORM_WALLET_CODE_OFFSET +
+            DashSdkError.PLATFORM_WALLET_NOT_FOUND_CODE
+        if (e.code == notFound) 0L else throw e
+    }

--- a/packages/kotlin-sdk/sdk/src/main/kotlin/org/dashfoundation/dashsdk/wallet/ManagedPlatformWallet.kt
+++ b/packages/kotlin-sdk/sdk/src/main/kotlin/org/dashfoundation/dashsdk/wallet/ManagedPlatformWallet.kt
@@ -6,6 +6,7 @@ import org.dashfoundation.dashsdk.errors.mapNativeErrors
 import org.dashfoundation.dashsdk.ffi.NativeCleaner
 import org.dashfoundation.dashsdk.ffi.TokensNative
 import org.dashfoundation.dashsdk.ffi.WalletManagerNative
+import org.dashfoundation.dashsdk.tokens.translateManagedIdentityNotFoundToZero
 import java.util.concurrent.atomic.AtomicLong
 
 /**
@@ -546,7 +547,14 @@ class ManagedPlatformWallet internal constructor(
         val watched = inMemoryWatchedIdentityIds().map { it to true }
         (managed + watched).mapNotNull { (id, isWatched) ->
             mapNativeErrors {
-                val identityHandle = TokensNative.getManagedIdentity(handle, id)
+                // The native side reports an unmanaged / just-removed identity
+                // as a platform-wallet NotFound error, not a zero handle, so
+                // the raw code is translated back to the zero-handle "skip"
+                // signal here — otherwise one removed id would throw through
+                // the whole listing (dashpay/platform#4060).
+                val identityHandle = translateManagedIdentityNotFoundToZero {
+                    TokensNative.getManagedIdentity(handle, id)
+                }
                 if (identityHandle == 0L) return@mapNativeErrors null
                 try {
                     val index = WalletManagerNative.managedIdentityGetIdentityIndex(identityHandle)

--- a/packages/kotlin-sdk/sdk/src/test/kotlin/org/dashfoundation/dashsdk/errors/DashSdkErrorTest.kt
+++ b/packages/kotlin-sdk/sdk/src/test/kotlin/org/dashfoundation/dashsdk/errors/DashSdkErrorTest.kt
@@ -117,6 +117,43 @@ class DashSdkErrorTest {
     }
 
     @Test
+    fun signingKeyUnavailableIsRecognizedByItsMessageMarker() {
+        val offset = DashSdkError.PLATFORM_WALLET_CODE_OFFSET
+        val marker = DashSdkError.PlatformWallet.SigningKeyUnavailable.MESSAGE_MARKER
+        // The KeystoreSigner completion error travels as free text through
+        // Rust and returns under the catch-all codes (ErrorUnknown = 99 via
+        // the blanket PlatformWalletError conversion, sometimes wrapped as
+        // ErrorWalletOperation = 6) — both must surface typed (#4052).
+        for (code in intArrayOf(6, 99)) {
+            val mapped = DashSdkError.fromNative(
+                DashSDKException(offset + code, "Signing failed: $marker deadbeef00112233…"),
+            )
+            assertTrue(
+                "code $code with marker → SigningKeyUnavailable",
+                mapped is DashSdkError.PlatformWallet.SigningKeyUnavailable,
+            )
+            assertFalse(mapped.isRetryable)
+        }
+        // Without the marker the catch-all mappings are untouched.
+        val walletOp = DashSdkError.fromNative(DashSDKException(offset + 6, "op failed"))
+        assertTrue(walletOp is DashSdkError.PlatformWallet.WalletOperation)
+        val generic = DashSdkError.fromNative(DashSDKException(offset + 99, "boom"))
+        assertTrue(generic is DashSdkError.PlatformWallet.Generic)
+    }
+
+    @Test
+    fun signingKeyMarkerNeverOverridesRetrySemanticsCodes() {
+        val offset = DashSdkError.PLATFORM_WALLET_CODE_OFFSET
+        val marker = DashSdkError.PlatformWallet.SigningKeyUnavailable.MESSAGE_MARKER
+        // A dedicated retry-semantics code keeps its type even if the Rust
+        // message happens to embed the marker text.
+        val mapped = DashSdkError.fromNative(
+            DashSDKException(offset + 19, "anchor missing; $marker something"),
+        )
+        assertTrue(mapped is DashSdkError.PlatformWallet.ShieldedNoRecordedAnchor)
+    }
+
+    @Test
     fun mapNativeErrorsConvertsAtTheBoundary() {
         try {
             mapNativeErrors { throw DashSDKException(7, "identity not found") }

--- a/packages/kotlin-sdk/sdk/src/test/kotlin/org/dashfoundation/dashsdk/tokens/ManagedIdentityNotFoundTranslationTest.kt
+++ b/packages/kotlin-sdk/sdk/src/test/kotlin/org/dashfoundation/dashsdk/tokens/ManagedIdentityNotFoundTranslationTest.kt
@@ -1,0 +1,53 @@
+package org.dashfoundation.dashsdk.tokens
+
+import org.dashfoundation.dashsdk.errors.DashSdkError
+import org.dashfoundation.dashsdk.ffi.DashSDKException
+import org.junit.Assert.assertEquals
+import org.junit.Assert.fail
+import org.junit.Test
+
+/**
+ * Pins the dashpay/platform#4051 fix: `TokensNative.getManagedIdentity`
+ * reports an identity the wallet does not manage as a platform-wallet
+ * NotFound error (code 98, via the FFI's blanket `Option → result`
+ * conversion), which [translateManagedIdentityNotFoundToZero] turns into a
+ * zero handle so [Dashpay.syncState] / [Dashpay.payments] /
+ * [Dashpay.contacts] return null / empty instead of throwing a typed
+ * `DashSdkError.NotFound("…ManagedIdentity not found")`.
+ */
+class ManagedIdentityNotFoundTranslationTest {
+
+    private val notFoundCode =
+        DashSdkError.PLATFORM_WALLET_CODE_OFFSET + DashSdkError.PLATFORM_WALLET_NOT_FOUND_CODE
+
+    @Test
+    fun notFoundBecomesAZeroHandle() {
+        val handle = translateManagedIdentityNotFoundToZero {
+            throw DashSDKException(
+                notFoundCode,
+                "requested platform_wallet::identity::ManagedIdentity not found",
+            )
+        }
+        assertEquals(0L, handle)
+    }
+
+    @Test
+    fun aRealHandlePassesThrough() {
+        assertEquals(42L, translateManagedIdentityNotFoundToZero { 42L })
+    }
+
+    @Test
+    fun otherNativeErrorsAreRethrownUntouched() {
+        val other = DashSDKException(
+            DashSdkError.PLATFORM_WALLET_CODE_OFFSET + 1, // ErrorInvalidHandle
+            "stale wallet handle",
+        )
+        try {
+            translateManagedIdentityNotFoundToZero { throw other }
+            fail("expected the non-NotFound error to be rethrown")
+        } catch (e: DashSDKException) {
+            assertEquals(other.code, e.code)
+            assertEquals(other.message, e.message)
+        }
+    }
+}

--- a/packages/rs-platform-wallet-ffi/src/dashpay.rs
+++ b/packages/rs-platform-wallet-ffi/src/dashpay.rs
@@ -50,6 +50,46 @@ use crate::{check_ptr, unwrap_option_or_return, unwrap_result_or_return};
 // Managed identity lookup
 // ---------------------------------------------------------------------------
 
+/// Outcome of the layered [`platform_wallet_get_managed_identity`] lookup,
+/// split out so the dual-error decision (dashpay/platform#4060, findings
+/// `03ff842bd7d7` / `d7c06333de19`) is unit-testable without a fully-seeded
+/// `PlatformWallet` fixture.
+enum ManagedIdentityOutcome<T> {
+    /// A present, live wallet manages the identity.
+    Found(T),
+    /// The `wallet_handle` no longer resolves to a live, managed wallet:
+    /// either absent from `PLATFORM_WALLET_STORAGE` (the outer lookup miss) OR
+    /// present as a handle but already removed from the shared `WalletManager`
+    /// map (a `get_wallet_info` miss — a stale handle racing `removeWallet`,
+    /// which clears the manager entry *before* destroying the handle). Both are
+    /// real wallet failures and must surface as `ErrorInvalidHandle`, never be
+    /// swallowed as "identity not managed".
+    InvalidHandle,
+    /// A valid, live wallet that simply does not manage the identity — the only
+    /// outcome Kotlin's `translateManagedIdentityNotFoundToZero` turns into a
+    /// zero handle.
+    NotManaged,
+}
+
+/// Classify the nested lookup `Option` layers into the FFI result contract:
+///  - outer  = `wallet_handle` presence in `PLATFORM_WALLET_STORAGE`,
+///  - middle = `get_wallet_info` presence in the shared `WalletManager` map,
+///  - inner  = `managed_identity` presence on that wallet.
+///
+/// The two distinct `None`-producing failures (handle absent, and wallet
+/// removed from the manager map) must NOT collapse into `NotManaged` — see
+/// [`ManagedIdentityOutcome`]. Pure and generic so both error arms are directly
+/// unit-testable.
+fn classify_managed_identity_outcome<T>(
+    outcome: Option<Option<Option<T>>>,
+) -> ManagedIdentityOutcome<T> {
+    match outcome {
+        None | Some(None) => ManagedIdentityOutcome::InvalidHandle,
+        Some(Some(None)) => ManagedIdentityOutcome::NotManaged,
+        Some(Some(Some(managed))) => ManagedIdentityOutcome::Found(managed),
+    }
+}
+
 /// Look up the live [`ManagedIdentity`](platform_wallet::ManagedIdentity)
 /// for `identity_id` under `wallet_handle` and return a fresh handle
 /// into the shared `MANAGED_IDENTITY_STORAGE`.
@@ -74,13 +114,42 @@ pub unsafe extern "C" fn platform_wallet_get_managed_identity(
     check_ptr!(out_managed_identity_handle);
     let id = unwrap_result_or_return!(unsafe { read_identifier(identity_id) });
 
-    let option = PLATFORM_WALLET_STORAGE.with_item(wallet_handle, |wallet| {
+    // THREE distinct outcomes must stay distinct — they must NOT collapse into
+    // one `NotFound` (dashpay/platform#4060, finding 03ff842bd7d7). Using `?`
+    // inside the closure previously folded the `get_wallet_info` miss into the
+    // same closure-`None` as the `managed_identity` miss, so a wallet removed
+    // from the manager map (but not yet handle-destroyed) reported as "identity
+    // not managed". `.map()` keeps the `get_wallet_info` presence in its own
+    // layer instead:
+    //   outer `None`           -> handle absent from PLATFORM_WALLET_STORAGE
+    //   `Some(None)`           -> handle live, wallet REMOVED from the manager map
+    //                             (a stale handle racing `removeWallet`)
+    //   `Some(Some(None))`     -> valid live wallet, identity not managed
+    //   `Some(Some(Some(mi)))` -> found
+    // Kotlin's `translateManagedIdentityNotFoundToZero` (Dashpay.kt) turns ONLY
+    // `NotFound` into a zero handle, so the two handle-invalid cases must surface
+    // as `ErrorInvalidHandle` and never masquerade as an empty (zero-balance)
+    // unmanaged identity. See [`classify_managed_identity_outcome`].
+    let outcome = PLATFORM_WALLET_STORAGE.with_item(wallet_handle, |wallet| {
         let wm = wallet.wallet_manager().blocking_read();
-        let info = wm.get_wallet_info(&wallet.wallet_id())?;
-        info.identity_manager.managed_identity(&id).cloned()
+        wm.get_wallet_info(&wallet.wallet_id())
+            .map(|info| info.identity_manager.managed_identity(&id).cloned())
     });
-    let inner = unwrap_option_or_return!(option);
-    let managed = unwrap_option_or_return!(inner);
+    let managed = match classify_managed_identity_outcome(outcome) {
+        ManagedIdentityOutcome::Found(managed) => managed,
+        ManagedIdentityOutcome::InvalidHandle => {
+            return PlatformWalletFFIResult::err(
+                PlatformWalletFFIResultCode::ErrorInvalidHandle,
+                format!("platform wallet handle {wallet_handle} is not backed by a live wallet"),
+            );
+        }
+        ManagedIdentityOutcome::NotManaged => {
+            return PlatformWalletFFIResult::err(
+                PlatformWalletFFIResultCode::NotFound,
+                format!("wallet {wallet_handle} does not manage the requested identity"),
+            );
+        }
+    };
     unsafe { *out_managed_identity_handle = MANAGED_IDENTITY_STORAGE.insert(managed) };
     PlatformWalletFFIResult::ok()
 }
@@ -1244,5 +1313,75 @@ mod tests {
         let r = unsafe { platform_wallet_pending_contact_crypto_count(0xDEAD_BEEF, &mut count) };
         assert_eq!(r.code, PlatformWalletFFIResultCode::NotFound);
         assert_eq!(count, 7, "out_count is untouched on a lookup miss");
+    }
+
+    /// An unknown `wallet_handle` surfaces `ErrorInvalidHandle` — the OUTER
+    /// `with_item` miss — NOT `NotFound` (dashpay/platform#4060). This is the
+    /// load-bearing half of the dual-error contract: the Kotlin `Dashpay` layer
+    /// translates only `NotFound` (a valid wallet that does not manage the id)
+    /// into a zero handle, so a stale/closed wallet MUST arrive as
+    /// `ErrorInvalidHandle` to avoid masquerading as an unmanaged identity. The
+    /// 32-byte `identity_id` is read before the wallet lookup (`read_identifier`),
+    /// so a real buffer is supplied; `out_managed_identity_handle` must be left
+    /// untouched on the miss.
+    ///
+    /// The complementary inner outcome (a valid wallet lacking the managed
+    /// identity → `NotFound`) needs a fully seeded wallet in
+    /// `PLATFORM_WALLET_STORAGE`, which this unit-test module has no fixture for;
+    /// that path is covered at the translation layer by the Kotlin
+    /// `ManagedIdentityNotFoundTranslationTest`.
+    #[test]
+    fn get_managed_identity_unknown_wallet_is_invalid_handle() {
+        let id = [0u8; 32];
+        let mut out: Handle = 0;
+        let r = unsafe {
+            platform_wallet_get_managed_identity(0xDEAD_BEEF, id.as_ptr(), &mut out)
+        };
+        assert_eq!(r.code, PlatformWalletFFIResultCode::ErrorInvalidHandle);
+        assert_eq!(out, 0, "out handle is untouched on an invalid-handle miss");
+    }
+
+    /// The dual-error decision (dashpay/platform#4060, findings 03ff842bd7d7 &
+    /// d7c06333de19), exercised at the `classify_managed_identity_outcome` seam
+    /// so BOTH error codes are covered without a fully-seeded `PlatformWallet`
+    /// fixture (which this unit-test module cannot build). This is exactly the
+    /// layer where the two `None` outcomes previously collapsed:
+    ///
+    /// - Outer `None` (handle absent from `PLATFORM_WALLET_STORAGE`) AND
+    ///   `Some(None)` (handle live but the wallet was REMOVED from the shared
+    ///   `WalletManager` map — the removed-but-not-destroyed race the finding
+    ///   describes) both classify as `InvalidHandle` → `ErrorInvalidHandle`, so
+    ///   Kotlin's `translateManagedIdentityNotFoundToZero` never swallows a real
+    ///   wallet failure as a zero-balance unmanaged identity.
+    /// - `Some(Some(None))` (valid live wallet that does not manage the id)
+    ///   classifies as `NotManaged` → `NotFound`, the only outcome Kotlin
+    ///   translates to a zero handle.
+    /// - `Some(Some(Some(_)))` classifies as `Found`.
+    ///
+    /// The full FFI path for the outer-`None` arm is additionally covered by
+    /// `get_managed_identity_unknown_wallet_is_invalid_handle` above.
+    #[test]
+    fn classify_managed_identity_outcome_distinguishes_removed_wallet_from_unmanaged() {
+        // Handle absent from storage → invalid handle.
+        assert!(matches!(
+            classify_managed_identity_outcome::<u32>(None),
+            ManagedIdentityOutcome::InvalidHandle
+        ));
+        // Removed-but-not-destroyed: handle live, wallet gone from the manager
+        // map (get_wallet_info miss). Must NOT be "not managed".
+        assert!(matches!(
+            classify_managed_identity_outcome::<u32>(Some(None)),
+            ManagedIdentityOutcome::InvalidHandle
+        ));
+        // Valid live wallet that simply does not manage the identity.
+        assert!(matches!(
+            classify_managed_identity_outcome::<u32>(Some(Some(None))),
+            ManagedIdentityOutcome::NotManaged
+        ));
+        // Found.
+        assert!(matches!(
+            classify_managed_identity_outcome(Some(Some(Some(7u32)))),
+            ManagedIdentityOutcome::Found(7)
+        ));
     }
 }

--- a/packages/rs-platform-wallet-ffi/src/dashpay.rs
+++ b/packages/rs-platform-wallet-ffi/src/dashpay.rs
@@ -1334,9 +1334,7 @@ mod tests {
     fn get_managed_identity_unknown_wallet_is_invalid_handle() {
         let id = [0u8; 32];
         let mut out: Handle = 0;
-        let r = unsafe {
-            platform_wallet_get_managed_identity(0xDEAD_BEEF, id.as_ptr(), &mut out)
-        };
+        let r = unsafe { platform_wallet_get_managed_identity(0xDEAD_BEEF, id.as_ptr(), &mut out) };
         assert_eq!(r.code, PlatformWalletFFIResultCode::ErrorInvalidHandle);
         assert_eq!(out, 0, "out handle is untouched on an invalid-handle miss");
     }


### PR DESCRIPTION

Splits the two conflict-free, review-approved slices out of #4183 so they aren't blocked on the
Keystore rework, as suggested by @shumkov in review.

### What's included

**Unmanaged-identity local reads return absence, not an exception.** The FFI's blanket
`Option → result` conversion reports an identity the wallet does not manage as
`PlatformWalletFFIResultCode::NotFound` (98), so the Kotlin callers' zero-handle checks were dead and
any local read over an unmanaged identity (e.g. `Dashpay.syncState` on a contact's identity) threw
instead of returning null/empty.

- `Dashpay` routes `getManagedIdentity` through a `translateManagedIdentityNotFoundToZero` helper:
  `contacts()` / `syncState()` / `payments()` / `sendContactRequest()` treat "not managed" as
  null / empty / false. `ErrorInvalidHandle` still propagates — a stale wallet handle never
  masquerades as an unmanaged identity.
- Sweep of the remaining dead `== 0L` sites flagged in review:
  `ManagedPlatformWallet.inMemoryIdentityStates()` (one unmanaged id no longer throws through the
  whole listing) and `IdentityRegistration.contestedDpnsNames()` (the intended "identity is not
  managed by this wallet" error now actually surfaces).
- `platform-wallet-ffi`: `platform_wallet_get_managed_identity` keeps the three lookup outcomes
  distinct (handle absent / wallet removed from the manager map → `ErrorInvalidHandle`; valid wallet
  not managing the id → `NotFound`), with unit tests pinning both error arms.

**Typed `SigningKeyUnavailable`.** The `KeystoreSigner` "missing key" completion error travels as
free text through Rust and came back as an opaque `Generic`/`WalletOperation` failure. It is now
built from a shared `MESSAGE_MARKER` constant and recognized at the Kotlin boundary as
`DashSdkError.PlatformWallet.SigningKeyUnavailable`, so hosts can route users to key repair. The
marker is only consulted on the catch-all codes, so dedicated retry-semantics types are never
overridden.

Known limitation, kept deliberately: the discriminator is still message-text-based
(`message.contains`); moving to a structured code across the FFI boundary is follow-up work in the
parent PR line.

### What's NOT included (stays in #4183)

- The Keystore rework: `KeySecurityPolicy` (AUTH_GATED/DEVICE_BOUND), the keys-alias split and
  legacy-blob migration matrix, decrypt-probing, pending-identity-key state, and their tests.
- The host-visible retarget of native code 98 to a typed `PlatformWallet.NotFound` (this PR keeps the
  existing 98 → `DashSdkError.NotFound` mapping, only naming the code via
  `PLATFORM_WALLET_NOT_FOUND_CODE`).

### Testing

- `:sdk:compileDebugKotlin` and `:sdk:testDebugUnitTest` (new: `ManagedIdentityNotFoundTranslationTest`,
  two `SigningKeyUnavailable` mapping tests; existing 98-mapping tests unchanged and passing).
- `cargo test -p platform-wallet-ffi` dashpay unit tests, including the two new outcome-classification
  tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved error reporting when a required signing key is unavailable, with clearer non-retryable guidance.
  - Managed identities that are missing or removed are now handled consistently instead of exposing raw native errors.
  - Wallet handles that are invalid or stale are now distinguished from identities that simply aren’t managed.
  - Identity-related operations and listings continue gracefully when managed identities are no longer available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->