### PR TITLE
chore(kotlin-sdk): tx-decode follow-up — blob hardening, net_from_ord hoist, prevVout docs (#4187 review)

### DIFF
--- a/packages/kotlin-sdk/sdk/src/main/kotlin/org/dashfoundation/dashsdk/keywallet/TransactionDecoder.kt
+++ b/packages/kotlin-sdk/sdk/src/main/kotlin/org/dashfoundation/dashsdk/keywallet/TransactionDecoder.kt
@@ -33,7 +33,16 @@ class DecodedTransaction(
          * reverse for explorer-style display (see [prevTxidDisplayHex]).
          */
         val prevTxid: ByteArray,
-        /** Previous output's index. */
+        /**
+         * Previous output's index — the raw u32 bits carried in a signed
+         * [Int]. Kotlin has no unsigned field type in this API surface, so
+         * the wire value is preserved bit-for-bit rather than range-checked:
+         * indices above `Int.MAX_VALUE` appear negative, and in particular
+         * the coinbase sentinel `0xFFFFFFFF` appears as `-1` (the Swift
+         * wrapper's `UInt32` shows the same value as `4294967295`). Compare
+         * against literal bit patterns, or use [prevVoutUnsigned] for the
+         * numeric u32 value.
+         */
         val prevVout: Int,
         /**
          * Sender address recovered from a P2PKH-shaped scriptSig; null for
@@ -46,6 +55,13 @@ class DecodedTransaction(
          */
         val address: String?,
     ) {
+        /**
+         * [prevVout] widened to its unsigned u32 numeric value
+         * (0..4294967295) — the coinbase sentinel reads as `4294967295L`
+         * here, matching the Swift wrapper's `UInt32` rendering.
+         */
+        val prevVoutUnsigned: Long get() = prevVout.toLong() and 0xFFFFFFFFL
+
         /** Explorer-style (reversed, hex) rendering of [prevTxid]. */
         val prevTxidDisplayHex: String get() = displayHex(prevTxid)
     }

--- a/packages/kotlin-sdk/sdk/src/test/kotlin/org/dashfoundation/dashsdk/keywallet/TransactionDecoderTest.kt
+++ b/packages/kotlin-sdk/sdk/src/test/kotlin/org/dashfoundation/dashsdk/keywallet/TransactionDecoderTest.kt
@@ -37,6 +37,7 @@ class TransactionDecoderTest {
         val input = decoded.inputs[0]
         assertArrayEquals(ByteArray(32) { 0x11 }, input.prevTxid)
         assertEquals(3, input.prevVout)
+        assertEquals(3L, input.prevVoutUnsigned)
         assertEquals("yNDj28QBMm5sY6bLjFcNdWRNef24KLQNuQ", input.address)
         assertEquals("11".repeat(32), input.prevTxidDisplayHex)
 
@@ -77,6 +78,8 @@ class TransactionDecoderTest {
         assertEquals(1, decoded.inputs.size)
         assertNull(decoded.inputs[0].address)
         assertEquals(-1, decoded.inputs[0].prevVout) // u32 max crosses as -1 bits
+        // Convenience view recovers the numeric u32 (Swift UInt32 parity).
+        assertEquals(0xFFFFFFFFL, decoded.inputs[0].prevVoutUnsigned)
         assertEquals(1, decoded.outputs.size)
         assertNull(decoded.outputs[0].address)
         assertEquals(5_000_000_000L, decoded.outputs[0].valueDuffs)

--- a/packages/rs-unified-sdk-jni/src/identity.rs
+++ b/packages/rs-unified-sdk-jni/src/identity.rs
@@ -33,7 +33,8 @@
 
 use crate::pubkey_rows::decode_registration_pubkeys_blob;
 use crate::support::{
-    generic_asset_lock_recovery_allowed, guard, take_pwffi_error, throw_sdk_exception,
+    generic_asset_lock_recovery_allowed, guard, net_from_ord, take_pwffi_error,
+    throw_sdk_exception,
 };
 use jni::objects::{JByteArray, JClass, JString, JValue};
 use jni::sys::{jboolean, jbyteArray, jint, jlong, jobject};
@@ -45,7 +46,6 @@ use platform_wallet_ffi::identity_discovery::DiscoveredIdentityIdsFFI;
 use platform_wallet_ffi::identity_key_preview::{IdentityKeyPreviewFFI, IdentityKeyPreviewsFFI};
 use platform_wallet_ffi::identity_registration::IdentityFundingInputFFI;
 use platform_wallet_ffi::identity_registration_with_signer::IdentityPubkeyFFI;
-use platform_wallet_ffi::types::FFINetwork;
 use rs_sdk_ffi::{MnemonicResolverHandle, SignerHandle};
 use std::ffi::{CStr, CString};
 use std::os::raw::c_char;
@@ -309,18 +309,6 @@ unsafe fn encode_preview_rows(previews: &IdentityKeyPreviewsFFI) -> Vec<u8> {
         out.extend_from_slice(&row.private_key_bytes);
     }
     out
-}
-
-/// FFINetwork ordinal → the crate's `FFINetwork` enum
-/// (0=Mainnet, 2=Devnet, 3=Regtest, else Testnet). Kept in step with
-/// `persistence::net_from_ord`.
-fn net_from_ord(ord: i32) -> FFINetwork {
-    match ord {
-        0 => FFINetwork::Mainnet,
-        2 => FFINetwork::Devnet,
-        3 => FFINetwork::Regtest,
-        _ => FFINetwork::Testnet,
-    }
 }
 
 /// Resolver-keyed single-slot identity private-key derive for the

--- a/packages/rs-unified-sdk-jni/src/persistence.rs
+++ b/packages/rs-unified-sdk-jni/src/persistence.rs
@@ -47,7 +47,7 @@
 
 #![allow(clippy::missing_safety_doc)]
 
-use crate::support::JVM;
+use crate::support::{net_from_ord, JVM};
 use jni::objects::{GlobalRef, JByteArray, JObject, JString, JValue};
 use jni::JNIEnv;
 use platform_wallet_ffi::{
@@ -3759,18 +3759,6 @@ unsafe extern "C" fn tramp_get_core_tx_record_free(
 }
 
 // ── Shared low-level helpers ──────────────────────────────────────────
-
-/// FFINetwork ordinal → the crate's `FFINetwork` enum. Out-of-range
-/// ordinals fall back to Testnet (matches sdk.rs's default arm).
-fn net_from_ord(ord: i32) -> platform_wallet_ffi::FFINetwork {
-    use platform_wallet_ffi::FFINetwork;
-    match ord {
-        0 => FFINetwork::Mainnet,
-        2 => FFINetwork::Devnet,
-        3 => FFINetwork::Regtest,
-        _ => FFINetwork::Testnet,
-    }
-}
 
 /// Build a `&[T]` from a raw `(ptr, count)` pair, treating null as empty.
 ///

--- a/packages/rs-unified-sdk-jni/src/support.rs
+++ b/packages/rs-unified-sdk-jni/src/support.rs
@@ -1,5 +1,6 @@
 //! Shared JNI plumbing: JVM caching, panic guards, exception throwing.
 
+use dash_network::ffi::FFINetwork;
 use jni::objects::JThrowable;
 use jni::{JNIEnv, JavaVM};
 use platform_wallet_ffi::error::{
@@ -26,6 +27,22 @@ use std::sync::OnceLock;
 /// stay in 1–10. Must stay in lockstep with
 /// `DashSdkError.PLATFORM_WALLET_CODE_OFFSET` on the Kotlin side.
 pub const PWFFI_CODE_OFFSET: i32 = 1000;
+
+/// FFINetwork ordinal → enum (0=Mainnet, 2=Devnet, 3=Regtest, else
+/// Testnet). Must stay in lockstep with Kotlin's `Network.ffiValue`.
+///
+/// This is the single shared mapping for every JNI module:
+/// `rs_sdk_ffi::FFINetwork` and `platform_wallet_ffi::FFINetwork` are both
+/// re-exports of this same `dash_network::ffi::FFINetwork`, so the one
+/// helper serves callers regardless of which FFI crate they talk to.
+pub fn net_from_ord(ord: i32) -> FFINetwork {
+    match ord {
+        0 => FFINetwork::Mainnet,
+        2 => FFINetwork::Devnet,
+        3 => FFINetwork::Regtest,
+        _ => FFINetwork::Testnet,
+    }
+}
 
 /// Android's generic crash-recovery APIs must never authorize consumption of
 /// a bearer invitation voucher. That authority belongs exclusively to the
@@ -117,11 +134,21 @@ pub fn guard<T>(env: &mut JNIEnv, default: T, f: impl FnOnce(&mut JNIEnv) -> T) 
 
 #[cfg(test)]
 mod tests {
-    use super::generic_asset_lock_recovery_allowed;
+    use super::{generic_asset_lock_recovery_allowed, net_from_ord};
+    use dash_network::ffi::FFINetwork;
 
     #[test]
     fn generic_asset_lock_recovery_rejects_invitation_authority() {
         assert!(generic_asset_lock_recovery_allowed(false));
         assert!(!generic_asset_lock_recovery_allowed(true));
+    }
+
+    #[test]
+    fn net_from_ord_matches_kotlin_ffi_values() {
+        assert_eq!(net_from_ord(0), FFINetwork::Mainnet);
+        assert_eq!(net_from_ord(1), FFINetwork::Testnet);
+        assert_eq!(net_from_ord(2), FFINetwork::Devnet);
+        assert_eq!(net_from_ord(3), FFINetwork::Regtest);
+        assert_eq!(net_from_ord(-1), FFINetwork::Testnet, "unknown → Testnet");
     }
 }

--- a/packages/rs-unified-sdk-jni/src/transactions.rs
+++ b/packages/rs-unified-sdk-jni/src/transactions.rs
@@ -39,13 +39,13 @@
 #![allow(clippy::missing_safety_doc)]
 
 use crate::pubkey_rows::decode_update_pubkeys_blob;
-use crate::support::{guard, take_pwffi_error, throw_sdk_exception};
+use crate::support::{guard, net_from_ord, take_pwffi_error, throw_sdk_exception};
 use jni::objects::{JByteArray, JClass, JString};
 use jni::sys::{jint, jlong, jstring};
 use jni::JNIEnv;
 use platform_wallet_ffi::handle::Handle;
 use platform_wallet_ffi::identity_registration_with_signer::IdentityPubkeyFFI;
-use rs_sdk_ffi::{FFINetwork, SignerHandle};
+use rs_sdk_ffi::SignerHandle;
 use std::ffi::{CStr, CString};
 use std::os::raw::c_char;
 use std::ptr;
@@ -127,18 +127,6 @@ fn read_cstring(env: &mut JNIEnv, s: &JString, field: &str) -> Option<CString> {
             throw_sdk_exception(env, 1, &format!("{field} contained an interior NUL"));
             None
         }
-    }
-}
-
-/// FFINetwork ordinal → the crate's `FFINetwork` enum
-/// (0=Mainnet, 2=Devnet, 3=Regtest, else Testnet). Matches
-/// `identity::net_from_ord` and Kotlin's `Network.ffiValue`.
-fn net_from_ord(ord: i32) -> FFINetwork {
-    match ord {
-        0 => FFINetwork::Mainnet,
-        2 => FFINetwork::Devnet,
-        3 => FFINetwork::Regtest,
-        _ => FFINetwork::Testnet,
     }
 }
 

--- a/packages/rs-unified-sdk-jni/src/tx_decode.rs
+++ b/packages/rs-unified-sdk-jni/src/tx_decode.rs
@@ -80,9 +80,13 @@ unsafe fn encode_decoded_transaction(decoded: &DecodedTransactionFFI) -> Vec<u8>
     let mut blob = Vec::with_capacity(256);
     blob.extend_from_slice(&decoded.txid);
 
-    blob.extend_from_slice(&(decoded.inputs_count as u32).to_be_bytes());
-    if !decoded.inputs.is_null() {
-        let inputs = std::slice::from_raw_parts(decoded.inputs, decoded.inputs_count);
+    // Same count-and-records-together rule as the script encoding below: a
+    // null array pointer encodes as count 0, never as a lying nonzero count
+    // with no records — that would desync every field parseBlob reads after.
+    let inputs_count = if decoded.inputs.is_null() { 0 } else { decoded.inputs_count };
+    blob.extend_from_slice(&(inputs_count as u32).to_be_bytes());
+    if inputs_count > 0 {
+        let inputs = std::slice::from_raw_parts(decoded.inputs, inputs_count);
         for input in inputs {
             blob.extend_from_slice(&input.prev_txid);
             blob.extend_from_slice(&input.prev_vout.to_be_bytes());
@@ -90,9 +94,10 @@ unsafe fn encode_decoded_transaction(decoded: &DecodedTransactionFFI) -> Vec<u8>
         }
     }
 
-    blob.extend_from_slice(&(decoded.outputs_count as u32).to_be_bytes());
-    if !decoded.outputs.is_null() {
-        let outputs = std::slice::from_raw_parts(decoded.outputs, decoded.outputs_count);
+    let outputs_count = if decoded.outputs.is_null() { 0 } else { decoded.outputs_count };
+    blob.extend_from_slice(&(outputs_count as u32).to_be_bytes());
+    if outputs_count > 0 {
+        let outputs = std::slice::from_raw_parts(decoded.outputs, outputs_count);
         for output in outputs {
             blob.extend_from_slice(&output.value_duffs.to_be_bytes());
             push_cstr_opt(&mut blob, output.address);
@@ -379,6 +384,30 @@ mod tests {
         assert_eq!(r.u64(), 42);
         assert_eq!(r.str_opt(), None, "no address");
         assert_eq!(r.u32(), 0, "null script pointer must encode length 0");
+        assert_eq!(r.pos, blob.len(), "no trailing bytes");
+    }
+
+    #[test]
+    fn null_array_pointers_encode_as_count_zero() {
+        // Same hazard one level up: null inputs/outputs arrays whose count
+        // fields LIE (nonzero). The encoder must write count 0 — a nonzero
+        // count with no records would desync everything parseBlob reads
+        // after it.
+        let decoded = DecodedTransactionFFI {
+            txid: [0xCDu8; 32],
+            inputs: std::ptr::null_mut(),
+            inputs_count: 3,
+            outputs: std::ptr::null_mut(),
+            outputs_count: 2,
+        };
+        // SAFETY: stack-built graph; the null arrays are the case under test
+        // and never dereferenced. Not passed to decoded_transaction_free.
+        let blob = unsafe { encode_decoded_transaction(&decoded) };
+
+        let mut r = Reader { blob: &blob, pos: 0 };
+        assert_eq!(r.take(32), [0xCDu8; 32]);
+        assert_eq!(r.u32(), 0, "null inputs array must encode count 0");
+        assert_eq!(r.u32(), 0, "null outputs array must encode count 0");
         assert_eq!(r.pos, blob.len(), "no trailing bytes");
     }
 }

--- a/packages/rs-unified-sdk-jni/src/tx_decode.rs
+++ b/packages/rs-unified-sdk-jni/src/tx_decode.rs
@@ -35,7 +35,8 @@
 //!   u64    value_duffs
 //!   u16    address_len           (0 = non-standard script, no address)
 //!   u8[address_len] address      (UTF-8 base58)
-//!   u32    script_len
+//!   u32    script_len          (0 = null or empty script; a nonzero
+//!                               length is always followed by its bytes)
 //!   u8[script_len] script_pubkey
 //! ```
 
@@ -95,8 +96,14 @@ unsafe fn encode_decoded_transaction(decoded: &DecodedTransactionFFI) -> Vec<u8>
         for output in outputs {
             blob.extend_from_slice(&output.value_duffs.to_be_bytes());
             push_cstr_opt(&mut blob, output.address);
-            blob.extend_from_slice(&(output.script_pubkey_len as u32).to_be_bytes());
-            if !output.script_pubkey.is_null() && output.script_pubkey_len > 0 {
+            // Length and bytes must be written (or omitted) together: a
+            // null script pointer encodes as length 0, never as a nonzero
+            // length with no bytes, so a defensive-null upstream can't
+            // shift every field that follows in the blob.
+            if output.script_pubkey.is_null() || output.script_pubkey_len == 0 {
+                blob.extend_from_slice(&0u32.to_be_bytes());
+            } else {
+                blob.extend_from_slice(&(output.script_pubkey_len as u32).to_be_bytes());
                 blob.extend_from_slice(std::slice::from_raw_parts(
                     output.script_pubkey,
                     output.script_pubkey_len,
@@ -340,4 +347,38 @@ mod tests {
         assert_eq!(err.0, key_wallet_ffi::FFIErrorCode::InvalidInput as i32);
     }
 
+    #[test]
+    fn null_script_pointer_encodes_as_length_zero() {
+        use key_wallet_ffi::tx_decode::DecodedTxOutputFFI;
+
+        // Hand-built pointer graph: one output whose script pointer is
+        // null but whose length field LIES (nonzero). The encoder must
+        // write length 0 — never a nonzero length without bytes — so the
+        // fields after the script can't shift.
+        let mut output = DecodedTxOutputFFI {
+            address: std::ptr::null_mut(),
+            value_duffs: 42,
+            script_pubkey: std::ptr::null_mut(),
+            script_pubkey_len: 7,
+        };
+        let decoded = DecodedTransactionFFI {
+            txid: [0xABu8; 32],
+            inputs: std::ptr::null_mut(),
+            inputs_count: 0,
+            outputs: &mut output,
+            outputs_count: 1,
+        };
+        // SAFETY: stack-built graph; null pointers are the case under test
+        // and never dereferenced. Not passed to decoded_transaction_free.
+        let blob = unsafe { encode_decoded_transaction(&decoded) };
+
+        let mut r = Reader { blob: &blob, pos: 0 };
+        assert_eq!(r.take(32), [0xABu8; 32]);
+        assert_eq!(r.u32(), 0, "no inputs");
+        assert_eq!(r.u32(), 1, "one output");
+        assert_eq!(r.u64(), 42);
+        assert_eq!(r.str_opt(), None, "no address");
+        assert_eq!(r.u32(), 0, "null script pointer must encode length 0");
+        assert_eq!(r.pos, blob.len(), "no trailing bytes");
+    }
 }

--- a/packages/rs-unified-sdk-jni/src/tx_decode.rs
+++ b/packages/rs-unified-sdk-jni/src/tx_decode.rs
@@ -39,7 +39,7 @@
 //!   u8[script_len] script_pubkey
 //! ```
 
-use crate::support::{guard, throw_sdk_exception};
+use crate::support::{guard, net_from_ord, throw_sdk_exception};
 use dash_network::ffi::FFINetwork;
 use jni::objects::{JByteArray, JClass};
 use jni::sys::{jbyteArray, jint};
@@ -48,18 +48,6 @@ use key_wallet_ffi::tx_decode::{
     decoded_transaction_free, transaction_decode, DecodedTransactionFFI,
 };
 use std::ffi::CStr;
-
-/// FFINetwork ordinal → enum (0=Mainnet, 2=Devnet, 3=Regtest, else
-/// Testnet). Matches `transactions::net_from_ord` and Kotlin's
-/// `Network.ffiValue`.
-fn net_from_ord(ord: i32) -> FFINetwork {
-    match ord {
-        0 => FFINetwork::Mainnet,
-        2 => FFINetwork::Devnet,
-        3 => FFINetwork::Regtest,
-        _ => FFINetwork::Testnet,
-    }
-}
 
 /// Append `u16 len + bytes` for an optional C string (null → len 0).
 /// An `Address` rendering is never empty, so 0 unambiguously means "none".
@@ -352,12 +340,4 @@ mod tests {
         assert_eq!(err.0, key_wallet_ffi::FFIErrorCode::InvalidInput as i32);
     }
 
-    #[test]
-    fn net_from_ord_matches_kotlin_ffi_values() {
-        assert_eq!(net_from_ord(0), FFINetwork::Mainnet);
-        assert_eq!(net_from_ord(1), FFINetwork::Testnet);
-        assert_eq!(net_from_ord(2), FFINetwork::Devnet);
-        assert_eq!(net_from_ord(3), FFINetwork::Regtest);
-        assert_eq!(net_from_ord(-1), FFINetwork::Testnet, "unknown → Testnet");
-    }
 }


### PR DESCRIPTION
Small follow-up promised on #4187, addressing @shumkov's three post-approval review notes on the Kotlin tx-decode JNI binding:

1. **Blob hardening** (`rs-unified-sdk-jni/src/tx_decode.rs`) — the output encoder wrote `script_pubkey_len` unconditionally but the script bytes only when the pointer was non-null, so a defensively-null pointer with a nonzero length field could shift every subsequent field in the blob. Length and bytes are now written together: a null (or empty) script encodes as length 0, never a nonzero length without its bytes. Pinned by a new unit test with a hand-built null-script fixture whose length field deliberately lies. The cross-pinned Kotlin/Rust fixture blob is unchanged.
2. **`net_from_ord` deduplication** — tx_decode.rs had added the third private copy (after transactions.rs and identity.rs). There is now a single shared `support::net_from_ord`; `rs_sdk_ffi::FFINetwork` and `platform_wallet_ffi::FFINetwork` are both re-exports of `dash_network::ffi::FFINetwork`, so the one helper serves every module. A fourth identical copy in persistence.rs was consolidated too. The exhaustive ordinal test moved to support.rs.
3. **`prevVout` signedness** — documented rather than retyped: `DecodedTransaction.Input.prevVout` stays a signed `Int` carrying the raw u32 bits (the coinbase sentinel `0xFFFFFFFF` reads as `-1`; Swift's `UInt32` shows `4294967295`), with KDoc spelling that out and a new `prevVoutUnsigned: Long` convenience view for the numeric u32 / Swift-parity rendering. The existing pinned `-1` test is untouched; assertions for the unsigned view were added alongside it.

Verified: `cargo test -p rs-unified-sdk-jni` (37 pass), `cargo clippy -p rs-unified-sdk-jni --all-targets` clean, and kotlin-sdk `:sdk:compileDebugKotlin` + `:sdk:testDebugUnitTest` green (`TransactionDecoderTest` 4/4). Each commit builds and tests green standalone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an unsigned view of transaction input output indexes, supporting the full 32-bit range and clearly representing coinbase inputs.

* **Bug Fixes**
  * Improved transaction encoding when input or output data is unavailable or contains inconsistent lengths, preventing malformed data from causing decoding issues.
  * Standardized network handling across SDK operations, including safe fallback behavior for unknown network values.

* **Documentation**
  * Clarified how signed and unsigned transaction output indexes are represented.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->