### PR TITLE
ci(kotlin-sdk): couple Maven Central deploy to the kotlin-sdk-v* release tag (stacked on #4182)

### DIFF
--- a/.github/workflows/kotlin-sdk-release.yml
+++ b/.github/workflows/kotlin-sdk-release.yml
@@ -32,6 +32,11 @@ jobs:
       version: ${{ steps.sdk-version.outputs.version }}
       tag_name: ${{ steps.sdk-version.outputs.tag_name }}
       deploy: ${{ steps.maven-gate.outputs.deploy }}
+      # The exact commit this job built. The deploy job pins its checkout to
+      # this SHA (not the tag ref), so a tag force-moved during the human
+      # approval pause cannot make Maven Central publish new source against the
+      # native libs built from the original commit.
+      sha: ${{ steps.resolve-sha.outputs.sha }}
 
     steps:
       - name: Checkout repository
@@ -42,6 +47,10 @@ jobs:
           # released AAR could be built from a different commit than the tag.
           # A full `refs/tags/...` value is a valid checkout ref as-is.
           ref: ${{ github.event.inputs.tag || github.ref }}
+
+      - name: Resolve built commit SHA
+        id: resolve-sha
+        run: echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
 
       # The Maven Central version comes from the tag and ONLY from the tag
       # (kotlin-sdk-vX.Y.Z -> X.Y.Z). Because the checkout above is pinned to
@@ -229,9 +238,12 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          # Same tag/commit the build job used, so the staged artifact is the
-          # exact source that produced the attached AAR.
-          ref: ${{ github.event.inputs.tag || github.ref }}
+          # Pin to the exact SHA the build job resolved, NOT the tag ref: the
+          # deploy job runs after an arbitrarily long human-approval pause, and
+          # a tag is mutable. Checking out the SHA guarantees the staged Maven
+          # source is the same commit that produced the attached AAR + the
+          # native libs downloaded below, even if the tag was force-moved.
+          ref: ${{ needs.build-and-release.outputs.sha }}
 
       - name: Set up JDK 17
         uses: actions/setup-java@v4

--- a/.github/workflows/kotlin-sdk-release.yml
+++ b/.github/workflows/kotlin-sdk-release.yml
@@ -14,7 +14,9 @@ on:
       tag:
         description: >-
           Existing kotlin-sdk-* tag to (re-)release (optional; defaults to
-          ref name). The Maven version is derived from this tag.
+          ref name). Accepts either the short tag (kotlin-sdk-vX.Y.Z) or a
+          full ref (refs/tags/kotlin-sdk-vX.Y.Z). The Maven version is derived
+          from this tag.
         required: false
 
 permissions:
@@ -25,6 +27,11 @@ jobs:
     name: Build release AAR (arm64-v8a + x86_64)
     runs-on: ubuntu-latest
     timeout-minutes: 180
+    # Consumed by the gated maven-central-deploy job below.
+    outputs:
+      version: ${{ steps.sdk-version.outputs.version }}
+      tag_name: ${{ steps.sdk-version.outputs.tag_name }}
+      deploy: ${{ steps.maven-gate.outputs.deploy }}
 
     steps:
       - name: Checkout repository
@@ -33,6 +40,7 @@ jobs:
           # A manual dispatch runs on the branch/tag selected in the UI, not
           # on the `tag` input it will publish under — without this ref the
           # released AAR could be built from a different commit than the tag.
+          # A full `refs/tags/...` value is a valid checkout ref as-is.
           ref: ${{ github.event.inputs.tag || github.ref }}
 
       # The Maven Central version comes from the tag and ONLY from the tag
@@ -45,6 +53,13 @@ jobs:
         env:
           TAG: ${{ github.event.inputs.tag || github.ref_name }}
         run: |
+          # A workflow_dispatch `tag` input may be given as a full ref
+          # (refs/tags/kotlin-sdk-vX.Y.Z). Strip that prefix BEFORE the
+          # kotlin-sdk-v* match, otherwise a full ref silently falls through
+          # to the AAR-only branch and no Maven version is derived. (A push's
+          # github.ref_name is already the short tag, so this is a no-op there.)
+          TAG="${TAG#refs/tags/}"
+          echo "tag_name=$TAG" >> "$GITHUB_OUTPUT"
           case "$TAG" in
             kotlin-sdk-v*)
               VERSION="${TAG#kotlin-sdk-v}"
@@ -71,6 +86,44 @@ jobs:
           esac
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
           echo "Derived sdkVersion: ${VERSION:-<none — Maven Central deploy will be skipped>}"
+
+      # Precondition check runs HERE — right after version derivation and
+      # before the ~3-hour native build — so a misconfiguration (partial
+      # secrets) fails fast instead of after the long build. It only decides
+      # WHETHER to deploy; the actual deploy is a separate, environment-gated
+      # job (maven-central-deploy) that consumes this `deploy` output.
+      #
+      # The `secrets` context is mapped into env vars here because emptiness of
+      # the secret is what decides the gate. These names must be resolvable at
+      # repository/organization scope for this fail-fast check to see them; the
+      # human approval gate and (optionally) environment-scoped copies live on
+      # the maven-central environment — see packages/kotlin-sdk/PUBLISHING.md.
+      - name: Check Maven Central deploy preconditions
+        id: maven-gate
+        env:
+          SDK_VERSION: ${{ steps.sdk-version.outputs.version }}
+          PORTAL_USER: ${{ secrets.JRELEASER_MAVENCENTRAL_SONATYPE_USERNAME }}
+          PORTAL_TOKEN: ${{ secrets.JRELEASER_MAVENCENTRAL_SONATYPE_PASSWORD }}
+          GPG_SECRET_KEY: ${{ secrets.JRELEASER_GPG_SECRET_KEY }}
+          GPG_PUBLIC_KEY: ${{ secrets.JRELEASER_GPG_PUBLIC_KEY }}
+          GPG_PASSPHRASE: ${{ secrets.JRELEASER_GPG_PASSPHRASE }}
+        run: |
+          # All five secrets the staging + jreleaser steps actually consume:
+          # Portal user/token, and the GPG secret key, public key and
+          # passphrase (gradle signing needs key+passphrase; jreleaser's
+          # Active.ALWAYS signing needs all three GPG values).
+          if [ -z "$SDK_VERSION" ]; then
+            echo "::notice::Tag is not kotlin-sdk-vX.Y.Z, so no Maven version can be derived — Maven Central deploy skipped."
+            echo "deploy=false" >> "$GITHUB_OUTPUT"
+          elif [ -z "$PORTAL_USER" ] && [ -z "$PORTAL_TOKEN" ] && [ -z "$GPG_SECRET_KEY" ] && [ -z "$GPG_PUBLIC_KEY" ] && [ -z "$GPG_PASSPHRASE" ]; then
+            echo "::notice::Maven Central secrets are not configured on this repository (the Central Portal token is currently personal) — Maven Central deploy skipped. See packages/kotlin-sdk/PUBLISHING.md."
+            echo "deploy=false" >> "$GITHUB_OUTPUT"
+          elif [ -z "$PORTAL_USER" ] || [ -z "$PORTAL_TOKEN" ] || [ -z "$GPG_SECRET_KEY" ] || [ -z "$GPG_PUBLIC_KEY" ] || [ -z "$GPG_PASSPHRASE" ]; then
+            echo "::error::Maven Central secrets are only partially configured — need ALL of JRELEASER_MAVENCENTRAL_SONATYPE_USERNAME, JRELEASER_MAVENCENTRAL_SONATYPE_PASSWORD, JRELEASER_GPG_SECRET_KEY, JRELEASER_GPG_PUBLIC_KEY and JRELEASER_GPG_PASSPHRASE. Refusing to guess."
+            exit 1
+          else
+            echo "deploy=true" >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Free disk space
         run: |
@@ -133,44 +186,78 @@ jobs:
       - name: Attach AAR to release
         uses: softprops/action-gh-release@v2
         with:
-          tag_name: ${{ github.event.inputs.tag || github.ref_name }}
+          tag_name: ${{ steps.sdk-version.outputs.tag_name }}
           files: packages/kotlin-sdk/sdk/build/outputs/aar/sdk-release.aar
           generate_release_notes: true
 
-      # ----- Maven Central deploy: same commit, same tag-derived version -----
-      # Gated on the Sonatype Central Portal credentials being configured as
-      # repository secrets. That token is currently personal (held by
-      # HashEngineering, the org.dashj publisher), so on repos/forks without
-      # the secrets these steps skip with a notice instead of failing and the
-      # release stays GitHub-AAR-only — see packages/kotlin-sdk/PUBLISHING.md.
-      # The `secrets` context is mapped into env vars here because emptiness
-      # of the secret is what decides the gate.
-      - name: Check Maven Central deploy preconditions
-        id: maven-gate
-        env:
-          SDK_VERSION: ${{ steps.sdk-version.outputs.version }}
-          PORTAL_USER: ${{ secrets.JRELEASER_MAVENCENTRAL_SONATYPE_USERNAME }}
-          PORTAL_TOKEN: ${{ secrets.JRELEASER_MAVENCENTRAL_SONATYPE_PASSWORD }}
-          GPG_SECRET_KEY: ${{ secrets.JRELEASER_GPG_SECRET_KEY }}
-          GPG_PUBLIC_KEY: ${{ secrets.JRELEASER_GPG_PUBLIC_KEY }}
-          GPG_PASSPHRASE: ${{ secrets.JRELEASER_GPG_PASSPHRASE }}
-        run: |
-          # All five secrets the staging + jreleaser steps actually consume:
-          # Portal user/token, and the GPG secret key, public key and
-          # passphrase (gradle signing needs key+passphrase; jreleaser's
-          # Active.ALWAYS signing needs all three GPG values).
-          if [ -z "$SDK_VERSION" ]; then
-            echo "::notice::Tag is not kotlin-sdk-vX.Y.Z, so no Maven version can be derived — Maven Central deploy skipped."
-            echo "deploy=false" >> "$GITHUB_OUTPUT"
-          elif [ -z "$PORTAL_USER" ] && [ -z "$PORTAL_TOKEN" ] && [ -z "$GPG_SECRET_KEY" ] && [ -z "$GPG_PUBLIC_KEY" ] && [ -z "$GPG_PASSPHRASE" ]; then
-            echo "::notice::Maven Central secrets are not configured on this repository (the Central Portal token is currently personal) — Maven Central deploy skipped. See packages/kotlin-sdk/PUBLISHING.md."
-            echo "deploy=false" >> "$GITHUB_OUTPUT"
-          elif [ -z "$PORTAL_USER" ] || [ -z "$PORTAL_TOKEN" ] || [ -z "$GPG_SECRET_KEY" ] || [ -z "$GPG_PUBLIC_KEY" ] || [ -z "$GPG_PASSPHRASE" ]; then
-            echo "::error::Maven Central secrets are only partially configured — need ALL of JRELEASER_MAVENCENTRAL_SONATYPE_USERNAME, JRELEASER_MAVENCENTRAL_SONATYPE_PASSWORD, JRELEASER_GPG_SECRET_KEY, JRELEASER_GPG_PUBLIC_KEY and JRELEASER_GPG_PASSPHRASE. Refusing to guess."
-            exit 1
-          else
-            echo "deploy=true" >> "$GITHUB_OUTPUT"
-          fi
+      # Hand the freshly built native libraries to the gated deploy job so it
+      # re-stages the SAME .so (same commit, same tag) without repeating the
+      # multi-hour cargo/NDK build. Only uploaded when a deploy will actually
+      # happen.
+      - name: Upload native libraries for the deploy job
+        if: steps.maven-gate.outputs.deploy == 'true'
+        uses: actions/upload-artifact@v4
+        with:
+          name: kotlin-sdk-jnilibs
+          path: packages/kotlin-sdk/sdk/src/main/jniLibs
+          if-no-files-found: error
+          retention-days: 1
+
+  # -------------------------------------------------------------------------
+  # Maven Central deploy — the human gate.
+  #
+  # This job declares `environment: maven-central`, so GitHub's environment
+  # protection rules apply: with required reviewers configured on that
+  # environment (see packages/kotlin-sdk/PUBLISHING.md) the workflow PAUSES
+  # here and a reviewer must approve before anything is published to Maven
+  # Central — the deploy is irrevocable, so this approval is the human gate.
+  # It runs only when the build job decided a deploy is warranted (valid
+  # tag-derived version AND the secrets are configured); otherwise it is
+  # skipped and no reviewer is prompted. The Central secrets are referenced in
+  # this job's steps so they resolve from the maven-central environment when
+  # scoped there.
+  # -------------------------------------------------------------------------
+  maven-central-deploy:
+    name: Deploy to Maven Central (version from tag)
+    needs: build-and-release
+    if: needs.build-and-release.outputs.deploy == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    environment: maven-central
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          # Same tag/commit the build job used, so the staged artifact is the
+          # exact source that produced the attached AAR.
+          ref: ${{ github.event.inputs.tag || github.ref }}
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '17'
+
+      - name: Set up Android SDK
+        uses: android-actions/setup-android@v3
+        with:
+          # No Rust/cargo here — the native libraries are downloaded below. The
+          # NDK is still needed because AGP strips the packaged .so at assemble
+          # time (ndkVersion is pinned in sdk/build.gradle.kts).
+          packages: >-
+            platforms;android-35
+            build-tools;35.0.0
+            ndk;28.1.13356709
+
+      - name: Restore native libraries from the build job
+        uses: actions/download-artifact@v4
+        with:
+          name: kotlin-sdk-jnilibs
+          path: packages/kotlin-sdk/sdk/src/main/jniLibs
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
 
       # Stages the signed release AAR + sources/javadoc jars into
       # sdk/build/staging-deploy. Task dependencies enforce the publish
@@ -178,10 +265,9 @@ jobs:
       # verifyJniLibsForRemotePublish hard-fails if the source tree lacks
       # libdash_sdk_jni.so for any required ABI.
       - name: Stage signed Maven artifacts (version from tag)
-        if: steps.maven-gate.outputs.deploy == 'true'
         working-directory: packages/kotlin-sdk
         env:
-          SDK_VERSION: ${{ steps.sdk-version.outputs.version }}
+          SDK_VERSION: ${{ needs.build-and-release.outputs.version }}
           # Same ASCII-armored GPG key/passphrase jreleaser uses below; Gradle
           # signing reads them as the in-memory signingKey/signingPassword
           # project properties.
@@ -195,10 +281,9 @@ jobs:
       # verifyJniLibsForRemotePublish and verifyStagedAarForRemotePublish
       # first, so a stale or nativeless staged AAR can never be deployed.
       - name: Deploy to Maven Central (jreleaserDeploy, version from tag)
-        if: steps.maven-gate.outputs.deploy == 'true'
         working-directory: packages/kotlin-sdk
         env:
-          SDK_VERSION: ${{ steps.sdk-version.outputs.version }}
+          SDK_VERSION: ${{ needs.build-and-release.outputs.version }}
           JRELEASER_MAVENCENTRAL_SONATYPE_USERNAME: ${{ secrets.JRELEASER_MAVENCENTRAL_SONATYPE_USERNAME }}
           JRELEASER_MAVENCENTRAL_SONATYPE_PASSWORD: ${{ secrets.JRELEASER_MAVENCENTRAL_SONATYPE_PASSWORD }}
           JRELEASER_GPG_PUBLIC_KEY: ${{ secrets.JRELEASER_GPG_PUBLIC_KEY }}

--- a/.github/workflows/kotlin-sdk-release.yml
+++ b/.github/workflows/kotlin-sdk-release.yml
@@ -51,6 +51,7 @@ jobs:
         env:
           DISPATCH_TAG: ${{ github.event.inputs.tag }}
           PUSH_REF: ${{ github.ref }}
+          EVENT_NAME: ${{ github.event_name }}
           REPO: ${{ github.repository }}
           GH_TOKEN: ${{ github.token }}
         run: |
@@ -72,9 +73,26 @@ jobs:
               exit 1
             fi
             echo "checkout_ref=refs/tags/${TAG}" >> "$GITHUB_OUTPUT"
-          else
+          elif [ "$EVENT_NAME" = "push" ]; then
             # Tag-push trigger: github.ref is already refs/tags/kotlin-sdk-*.
             echo "checkout_ref=${PUSH_REF}" >> "$GITHUB_OUTPUT"
+          else
+            # workflow_dispatch with NO `tag` input. github.ref is whatever ref
+            # the run was started from — typically a BRANCH — so it must not be
+            # trusted as a release source: an omitted input on a branch dispatch
+            # would otherwise fall through to the tag-push handling above and
+            # publish a Maven version derived from a moving branch. Only accept
+            # an empty input when the dispatch itself was started at a tag ref;
+            # otherwise require an explicit existing tag.
+            case "$PUSH_REF" in
+              refs/tags/*)
+                echo "checkout_ref=${PUSH_REF}" >> "$GITHUB_OUTPUT"
+                ;;
+              *)
+                echo "::error::workflow_dispatch requires the 'tag' input (an existing kotlin-sdk-* tag) or must be dispatched at a tag ref — refusing to release from '${PUSH_REF}', which is not a tag."
+                exit 1
+                ;;
+            esac
           fi
 
       - name: Checkout repository
@@ -213,7 +231,50 @@ jobs:
         working-directory: packages/kotlin-sdk
         run: ./gradlew :sdk:assembleRelease --stacktrace
 
+      # The GitHub-release asset has a FIXED name (sdk-release.aar) and
+      # softprops/action-gh-release overwrites a same-named asset by default, so
+      # without this guard a force-moved kotlin-sdk-v* tag could let a later run
+      # (built from commit B) replace the AAR of a version already published
+      # IMMUTABLY to Maven Central from commit A — the two channels would then
+      # disagree and rejecting the later Maven deploy would not restore the
+      # asset. Pinning the deploy checkout to the built SHA only protects a
+      # single run. Two defenses here:
+      #   1. Hard-fail if the tag no longer resolves to the exact commit this
+      #      run built (an in-run / pre-attach force-move).
+      #   2. Never overwrite an sdk-release.aar already attached for this tag:
+      #      once attached (and possibly published to immutable Maven Central)
+      #      the artifact is frozen, so the attach step is skipped rather than
+      #      clobbering it. A deliberate re-release must delete the asset/tag
+      #      first. Skipping (not failing) keeps emergency re-runs able to reach
+      #      the deploy job while leaving the original AAR untouched.
+      - name: Verify tag still resolves to the built commit
+        id: tag-guard
+        env:
+          TAG: ${{ steps.sdk-version.outputs.tag_name }}
+          BUILT_SHA: ${{ steps.resolve-sha.outputs.sha }}
+          REPO: ${{ github.repository }}
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          # Resolve the tag's current commit, dereferencing an annotated tag to
+          # the commit it points at.
+          OBJ_TYPE=$(gh api "repos/${REPO}/git/ref/tags/${TAG}" --jq '.object.type')
+          OBJ_SHA=$(gh api "repos/${REPO}/git/ref/tags/${TAG}" --jq '.object.sha')
+          if [ "$OBJ_TYPE" = "tag" ]; then
+            OBJ_SHA=$(gh api "repos/${REPO}/git/tags/${OBJ_SHA}" --jq '.object.sha')
+          fi
+          if [ "$OBJ_SHA" != "$BUILT_SHA" ]; then
+            echo "::error::Tag ${TAG} now points at ${OBJ_SHA} but this run built ${BUILT_SHA} — the tag was force-moved. Refusing to attach/deploy so the GitHub-release AAR and any already-published Maven Central version for ${TAG} cannot drift."
+            exit 1
+          fi
+          if gh api "repos/${REPO}/releases/tags/${TAG}" --jq '.assets[].name' 2>/dev/null | grep -Fxq 'sdk-release.aar'; then
+            echo "asset_exists=true" >> "$GITHUB_OUTPUT"
+            echo "::notice::Release ${TAG} already has an sdk-release.aar from an earlier run — leaving it untouched. The GitHub-release AAR is never overwritten, so it cannot diverge from an immutable Maven Central version. Delete the asset/tag deliberately to re-release."
+          else
+            echo "asset_exists=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Attach AAR to release
+        if: steps.tag-guard.outputs.asset_exists != 'true'
         uses: softprops/action-gh-release@v2
         with:
           tag_name: ${{ steps.sdk-version.outputs.tag_name }}

--- a/.github/workflows/kotlin-sdk-release.yml
+++ b/.github/workflows/kotlin-sdk-release.yml
@@ -472,16 +472,45 @@ jobs:
       # Uploads the staged artifacts to Maven Central. Task dependencies run
       # verifyJniLibsForRemotePublish and verifyStagedAarForRemotePublish
       # first, so a stale or nativeless staged AAR can never be deployed.
+      #
+      # The post-approval revalidation step above runs BEFORE checkout, setup,
+      # artifact restore and staging — a writer could still force-move the tag
+      # during that window, after the check passed but before this irrevocable
+      # publish. So the tag->built-SHA guard is repeated HERE, inline and in the
+      # SAME step as jreleaserDeploy, immediately before the deploy command:
+      # with no intervening workflow step, a force-move landing before publish
+      # is caught and aborts the run. This cannot make a mutable Git ref and an
+      # external publication atomic (protect the kotlin-sdk-* tags in repo
+      # settings for that — see PUBLISHING.md); it is the defense-in-depth
+      # last check that shrinks the window to this step alone.
       - name: Deploy to Maven Central (jreleaserDeploy, version from tag)
         if: steps.secrets-gate.outputs.proceed == 'true'
         working-directory: packages/kotlin-sdk
         env:
           SDK_VERSION: ${{ needs.build-and-release.outputs.version }}
+          TAG: ${{ needs.build-and-release.outputs.tag_name }}
+          BUILT_SHA: ${{ needs.build-and-release.outputs.sha }}
+          REPO: ${{ github.repository }}
+          GH_TOKEN: ${{ github.token }}
           JRELEASER_MAVENCENTRAL_SONATYPE_USERNAME: ${{ secrets.JRELEASER_MAVENCENTRAL_SONATYPE_USERNAME }}
           JRELEASER_MAVENCENTRAL_SONATYPE_PASSWORD: ${{ secrets.JRELEASER_MAVENCENTRAL_SONATYPE_PASSWORD }}
           JRELEASER_GPG_PUBLIC_KEY: ${{ secrets.JRELEASER_GPG_PUBLIC_KEY }}
           JRELEASER_GPG_SECRET_KEY: ${{ secrets.JRELEASER_GPG_SECRET_KEY }}
           JRELEASER_GPG_PASSPHRASE: ${{ secrets.JRELEASER_GPG_PASSPHRASE }}
-        run: >-
-          ./gradlew :sdk:jreleaserDeploy
-          -PsdkVersion="$SDK_VERSION" --stacktrace
+        run: |
+          # Final tag->built-SHA guard, in the SAME step as the publish so no
+          # workflow step runs between it and jreleaserDeploy. Resolve the tag's
+          # current commit, dereferencing an annotated tag to the commit it
+          # points at, and abort unless it STILL equals the built/approved SHA.
+          OBJ_TYPE=$(gh api "repos/${REPO}/git/ref/tags/${TAG}" --jq '.object.type')
+          OBJ_SHA=$(gh api "repos/${REPO}/git/ref/tags/${TAG}" --jq '.object.sha')
+          if [ "$OBJ_TYPE" = "tag" ]; then
+            OBJ_SHA=$(gh api "repos/${REPO}/git/tags/${OBJ_SHA}" --jq '.object.sha')
+          fi
+          if [ "$OBJ_SHA" != "$BUILT_SHA" ]; then
+            echo "::error::Tag ${TAG} now points at ${OBJ_SHA} but this release was built and approved for ${BUILT_SHA} — the tag was force-moved before deploy. Refusing to publish so the Maven Central version cannot be released under a tag that identifies a different commit."
+            exit 1
+          fi
+          echo "::notice::Tag ${TAG} still resolves to the approved commit ${BUILT_SHA} at deploy time — publishing."
+          ./gradlew :sdk:jreleaserDeploy \
+            -PsdkVersion="$SDK_VERSION" --stacktrace

--- a/.github/workflows/kotlin-sdk-release.yml
+++ b/.github/workflows/kotlin-sdk-release.yml
@@ -42,19 +42,40 @@ jobs:
       # A workflow_dispatch `tag` input is free-form and actions/checkout would
       # happily resolve it to a BRANCH (or any ref), which would let a manual
       # run publish a Maven version derived from a moving branch instead of an
-      # immutable tag. Resolve the ref HERE and hard-fail unless it names an
-      # existing tag, then hand the checkout an explicit refs/tags/<tag> ref so
-      # it can never bind to a branch. The tag-push trigger is already
-      # tag-bound (github.ref is refs/tags/kotlin-sdk-*) and skips the lookup.
+      # immutable tag. Even a valid tag ref is MUTABLE: handing checkout a
+      # refs/tags/<tag> ref lets a writer force-move the tag from commit A to
+      # commit B between the run's trigger and this checkout, so checkout would
+      # build B while the run (and the pending maven-central approval) originated
+      # from A — code would be substituted behind the human gate. So resolve an
+      # IMMUTABLE COMMIT SHA here and hand THAT to checkout:
+      #   * tag push  -> the event SHA (github.sha), the commit the tag pointed
+      #                  at when the run was created;
+      #   * dispatch  -> peel the selected tag to the commit it currently names
+      #                  (dereferencing an annotated tag object).
+      # Checkout then binds to a fixed commit, never a moving ref, and the
+      # later tag-to-SHA guards (attach-time here, and re-validated after
+      # approval in the deploy job) still catch a force-move.
       - name: Resolve and validate release ref
         id: release-ref
         env:
           DISPATCH_TAG: ${{ github.event.inputs.tag }}
           PUSH_REF: ${{ github.ref }}
           EVENT_NAME: ${{ github.event_name }}
+          EVENT_SHA: ${{ github.sha }}
           REPO: ${{ github.repository }}
           GH_TOKEN: ${{ github.token }}
         run: |
+          # Peel a tag to the immutable COMMIT sha it currently points at,
+          # dereferencing an annotated tag object to its target commit.
+          peel_tag_to_commit() {
+            tag="$1"
+            obj_type=$(gh api "repos/${REPO}/git/ref/tags/${tag}" --jq '.object.type') || return 1
+            obj_sha=$(gh api "repos/${REPO}/git/ref/tags/${tag}" --jq '.object.sha') || return 1
+            if [ "$obj_type" = "tag" ]; then
+              obj_sha=$(gh api "repos/${REPO}/git/tags/${obj_sha}" --jq '.object.sha') || return 1
+            fi
+            printf '%s\n' "$obj_sha"
+          }
           if [ -n "$DISPATCH_TAG" ]; then
             # Accept either the short tag or a full refs/tags/ ref; reject
             # anything else (a bare branch name, refs/heads/..., or a slashed
@@ -72,10 +93,13 @@ jobs:
               echo "::error::No existing tag 'refs/tags/${TAG}' in ${REPO}. workflow_dispatch can only (re-)release an existing tag, never a branch or arbitrary ref."
               exit 1
             fi
-            echo "checkout_ref=refs/tags/${TAG}" >> "$GITHUB_OUTPUT"
+            SHA=$(peel_tag_to_commit "$TAG") || { echo "::error::Could not resolve tag '${TAG}' to a commit."; exit 1; }
+            echo "checkout_sha=${SHA}" >> "$GITHUB_OUTPUT"
           elif [ "$EVENT_NAME" = "push" ]; then
-            # Tag-push trigger: github.ref is already refs/tags/kotlin-sdk-*.
-            echo "checkout_ref=${PUSH_REF}" >> "$GITHUB_OUTPUT"
+            # Tag-push trigger: the event SHA is the immutable commit the tag
+            # pointed at when this run was created. Use it directly — a
+            # post-trigger force-move of the tag cannot change it.
+            echo "checkout_sha=${EVENT_SHA}" >> "$GITHUB_OUTPUT"
           else
             # workflow_dispatch with NO `tag` input. github.ref is whatever ref
             # the run was started from — typically a BRANCH — so it must not be
@@ -83,10 +107,13 @@ jobs:
             # would otherwise fall through to the tag-push handling above and
             # publish a Maven version derived from a moving branch. Only accept
             # an empty input when the dispatch itself was started at a tag ref;
-            # otherwise require an explicit existing tag.
+            # otherwise require an explicit existing tag. Peel that tag to its
+            # commit so checkout still binds to an immutable SHA.
             case "$PUSH_REF" in
               refs/tags/*)
-                echo "checkout_ref=${PUSH_REF}" >> "$GITHUB_OUTPUT"
+                TAG="${PUSH_REF#refs/tags/}"
+                SHA=$(peel_tag_to_commit "$TAG") || { echo "::error::Could not resolve tag '${TAG}' to a commit."; exit 1; }
+                echo "checkout_sha=${SHA}" >> "$GITHUB_OUTPUT"
                 ;;
               *)
                 echo "::error::workflow_dispatch requires the 'tag' input (an existing kotlin-sdk-* tag) or must be dispatched at a tag ref — refusing to release from '${PUSH_REF}', which is not a tag."
@@ -98,11 +125,11 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          # Always an explicit refs/tags/<tag> (validated above) or the
-          # tag-push github.ref — never the raw dispatch input — so the
-          # released AAR is built from the tag's commit and a manual run can
-          # never build from a branch.
-          ref: ${{ steps.release-ref.outputs.checkout_ref }}
+          # An immutable COMMIT SHA resolved above — never a mutable tag/branch
+          # ref — so the released AAR is built from a fixed commit that a
+          # force-moved tag cannot substitute behind the environment approval,
+          # and a manual run can never build from a branch.
+          ref: ${{ steps.release-ref.outputs.checkout_sha }}
 
       - name: Resolve built commit SHA
         id: resolve-sha
@@ -349,9 +376,42 @@ jobs:
             echo "proceed=true" >> "$GITHUB_OUTPUT"
           fi
 
+      # The build job's tag-guard verified tag -> built SHA, but that ran BEFORE
+      # this job's (possibly long) human-approval pause. A writer could
+      # force-move the tag DURING that pause: the checkout below is pinned to the
+      # immutable built SHA so this job still stages the approved code, but Maven
+      # Central would then publish the approved version under a tag that now
+      # identifies a DIFFERENT commit, breaking the tag-as-source-of-truth
+      # invariant. So immediately after approval — before checkout or staging —
+      # re-resolve and peel the release tag and abort unless it STILL points at
+      # the exact commit that was built and approved.
+      - name: Revalidate release tag resolves to the built commit (post-approval)
+        if: steps.secrets-gate.outputs.proceed == 'true'
+        env:
+          TAG: ${{ needs.build-and-release.outputs.tag_name }}
+          BUILT_SHA: ${{ needs.build-and-release.outputs.sha }}
+          REPO: ${{ github.repository }}
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          # Resolve the tag's current commit, dereferencing an annotated tag to
+          # the commit it points at.
+          OBJ_TYPE=$(gh api "repos/${REPO}/git/ref/tags/${TAG}" --jq '.object.type')
+          OBJ_SHA=$(gh api "repos/${REPO}/git/ref/tags/${TAG}" --jq '.object.sha')
+          if [ "$OBJ_TYPE" = "tag" ]; then
+            OBJ_SHA=$(gh api "repos/${REPO}/git/tags/${OBJ_SHA}" --jq '.object.sha')
+          fi
+          if [ "$OBJ_SHA" != "$BUILT_SHA" ]; then
+            echo "::error::Tag ${TAG} now points at ${OBJ_SHA} but this release was built and approved for ${BUILT_SHA} — the tag was force-moved during the approval pause. Refusing to publish so the Maven Central version cannot be released under a tag that identifies a different commit."
+            exit 1
+          fi
+          echo "::notice::Tag ${TAG} still resolves to the approved commit ${BUILT_SHA} — proceeding to publish."
+
       - name: Checkout repository
         if: steps.secrets-gate.outputs.proceed == 'true'
-        uses: actions/checkout@v4
+        # Pinned to a reviewed full commit SHA (v4) — a mutable major ref could
+        # be force-moved to substitute this checkout before the credentialed
+        # Gradle/jreleaser steps below receive the Maven Central token + GPG key.
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           # Pin to the exact SHA the build job resolved, NOT the tag ref: the
           # deploy job runs after an arbitrarily long human-approval pause, and
@@ -362,14 +422,14 @@ jobs:
 
       - name: Set up JDK 17
         if: steps.secrets-gate.outputs.proceed == 'true'
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4
         with:
           distribution: temurin
           java-version: '17'
 
       - name: Set up Android SDK
         if: steps.secrets-gate.outputs.proceed == 'true'
-        uses: android-actions/setup-android@v3
+        uses: android-actions/setup-android@9fc6c4e9069bf8d3d10b2204b1fb8f6ef7065407 # v3
         with:
           # No Rust/cargo here — the native libraries are downloaded below. The
           # NDK is still needed because AGP strips the packaged .so at assemble
@@ -381,14 +441,14 @@ jobs:
 
       - name: Restore native libraries from the build job
         if: steps.secrets-gate.outputs.proceed == 'true'
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: kotlin-sdk-jnilibs
           path: packages/kotlin-sdk/sdk/src/main/jniLibs
 
       - name: Setup Gradle
         if: steps.secrets-gate.outputs.proceed == 'true'
-        uses: gradle/actions/setup-gradle@v4
+        uses: gradle/actions/setup-gradle@48b5f213c81028ace310571dc5ec0fbbca0b2947 # v4
 
       # Stages the signed release AAR + sources/javadoc jars into
       # sdk/build/staging-deploy. Task dependencies enforce the publish

--- a/.github/workflows/kotlin-sdk-release.yml
+++ b/.github/workflows/kotlin-sdk-release.yml
@@ -1,4 +1,4 @@
-name: Release Kotlin SDK AAR
+name: Release Kotlin SDK (AAR + Maven Central)
 
 on:
   push:
@@ -6,8 +6,15 @@ on:
       - 'kotlin-sdk-*'
   workflow_dispatch:
     inputs:
+      # Re-run/emergency path only. The tag is still the single source of
+      # truth: the build checks out the tag's commit and the Maven version is
+      # derived from the tag name — there is deliberately no separate version
+      # input, so a dispatch can never publish a version that differs from
+      # what the tag's own push would have published.
       tag:
-        description: 'Tag name to release (optional; defaults to ref name)'
+        description: >-
+          Existing kotlin-sdk-* tag to (re-)release (optional; defaults to
+          ref name). The Maven version is derived from this tag.
         required: false
 
 permissions:
@@ -27,6 +34,40 @@ jobs:
           # on the `tag` input it will publish under — without this ref the
           # released AAR could be built from a different commit than the tag.
           ref: ${{ github.event.inputs.tag || github.ref }}
+
+      # The Maven Central version comes from the tag and ONLY from the tag
+      # (kotlin-sdk-vX.Y.Z -> X.Y.Z). Because the checkout above is pinned to
+      # the same tag, the GitHub-release AAR and the Maven Central artifact
+      # produced by this run are always built from the same commit under the
+      # same version — the two channels cannot drift.
+      - name: Derive SDK version from release tag
+        id: sdk-version
+        env:
+          TAG: ${{ github.event.inputs.tag || github.ref_name }}
+        run: |
+          case "$TAG" in
+            kotlin-sdk-v*)
+              VERSION="${TAG#kotlin-sdk-v}"
+              if ! printf '%s\n' "$VERSION" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+([.-][0-9A-Za-z][0-9A-Za-z.-]*)?$'; then
+                echo "::error::Tag '$TAG' has the kotlin-sdk-v prefix but '$VERSION' is not a valid version (expected kotlin-sdk-vX.Y.Z)."
+                exit 1
+              fi
+              case "$VERSION" in
+                *-SNAPSHOT)
+                  echo "::error::Tag '$TAG' derives the -SNAPSHOT version '$VERSION'; snapshots must never be released from tags."
+                  exit 1
+                  ;;
+              esac
+              ;;
+            *)
+              # A kotlin-sdk-* tag without the vX.Y.Z form still gets its
+              # GitHub-release AAR below, but carries no Maven version, so
+              # the Maven Central steps are skipped.
+              VERSION=""
+              ;;
+          esac
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "Derived sdkVersion: ${VERSION:-<none — Maven Central deploy will be skipped>}"
 
       - name: Free disk space
         run: |
@@ -92,3 +133,68 @@ jobs:
           tag_name: ${{ github.event.inputs.tag || github.ref_name }}
           files: packages/kotlin-sdk/sdk/build/outputs/aar/sdk-release.aar
           generate_release_notes: true
+
+      # ----- Maven Central deploy: same commit, same tag-derived version -----
+      # Gated on the Sonatype Central Portal credentials being configured as
+      # repository secrets. That token is currently personal (held by
+      # HashEngineering, the org.dashj publisher), so on repos/forks without
+      # the secrets these steps skip with a notice instead of failing and the
+      # release stays GitHub-AAR-only — see packages/kotlin-sdk/PUBLISHING.md.
+      # The `secrets` context is mapped into env vars here because emptiness
+      # of the secret is what decides the gate.
+      - name: Check Maven Central deploy preconditions
+        id: maven-gate
+        env:
+          SDK_VERSION: ${{ steps.sdk-version.outputs.version }}
+          PORTAL_USER: ${{ secrets.JRELEASER_MAVENCENTRAL_SONATYPE_USERNAME }}
+          PORTAL_TOKEN: ${{ secrets.JRELEASER_MAVENCENTRAL_SONATYPE_PASSWORD }}
+          GPG_SECRET_KEY: ${{ secrets.JRELEASER_GPG_SECRET_KEY }}
+        run: |
+          if [ -z "$SDK_VERSION" ]; then
+            echo "::notice::Tag is not kotlin-sdk-vX.Y.Z, so no Maven version can be derived — Maven Central deploy skipped."
+            echo "deploy=false" >> "$GITHUB_OUTPUT"
+          elif [ -z "$PORTAL_USER" ] && [ -z "$PORTAL_TOKEN" ] && [ -z "$GPG_SECRET_KEY" ]; then
+            echo "::notice::Maven Central secrets are not configured on this repository (the Central Portal token is currently personal) — Maven Central deploy skipped. See packages/kotlin-sdk/PUBLISHING.md."
+            echo "deploy=false" >> "$GITHUB_OUTPUT"
+          elif [ -z "$PORTAL_USER" ] || [ -z "$PORTAL_TOKEN" ] || [ -z "$GPG_SECRET_KEY" ]; then
+            echo "::error::Maven Central secrets are only partially configured — need JRELEASER_MAVENCENTRAL_SONATYPE_USERNAME, JRELEASER_MAVENCENTRAL_SONATYPE_PASSWORD and JRELEASER_GPG_SECRET_KEY (plus JRELEASER_GPG_PUBLIC_KEY and JRELEASER_GPG_PASSPHRASE). Refusing to guess."
+            exit 1
+          else
+            echo "deploy=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      # Stages the signed release AAR + sources/javadoc jars into
+      # sdk/build/staging-deploy. Task dependencies enforce the publish
+      # guards: cleanStagingDeploy wipes the staging dir first and
+      # verifyJniLibsForRemotePublish hard-fails if the source tree lacks
+      # libdash_sdk_jni.so for any required ABI.
+      - name: Stage signed Maven artifacts (version from tag)
+        if: steps.maven-gate.outputs.deploy == 'true'
+        working-directory: packages/kotlin-sdk
+        env:
+          SDK_VERSION: ${{ steps.sdk-version.outputs.version }}
+          # Same ASCII-armored GPG key/passphrase jreleaser uses below; Gradle
+          # signing reads them as the in-memory signingKey/signingPassword
+          # project properties.
+          ORG_GRADLE_PROJECT_signingKey: ${{ secrets.JRELEASER_GPG_SECRET_KEY }}
+          ORG_GRADLE_PROJECT_signingPassword: ${{ secrets.JRELEASER_GPG_PASSPHRASE }}
+        run: >-
+          ./gradlew :sdk:publishReleasePublicationToStagingRepository
+          -PsdkVersion="$SDK_VERSION" --stacktrace
+
+      # Uploads the staged artifacts to Maven Central. Task dependencies run
+      # verifyJniLibsForRemotePublish and verifyStagedAarForRemotePublish
+      # first, so a stale or nativeless staged AAR can never be deployed.
+      - name: Deploy to Maven Central (jreleaserDeploy, version from tag)
+        if: steps.maven-gate.outputs.deploy == 'true'
+        working-directory: packages/kotlin-sdk
+        env:
+          SDK_VERSION: ${{ steps.sdk-version.outputs.version }}
+          JRELEASER_MAVENCENTRAL_SONATYPE_USERNAME: ${{ secrets.JRELEASER_MAVENCENTRAL_SONATYPE_USERNAME }}
+          JRELEASER_MAVENCENTRAL_SONATYPE_PASSWORD: ${{ secrets.JRELEASER_MAVENCENTRAL_SONATYPE_PASSWORD }}
+          JRELEASER_GPG_PUBLIC_KEY: ${{ secrets.JRELEASER_GPG_PUBLIC_KEY }}
+          JRELEASER_GPG_SECRET_KEY: ${{ secrets.JRELEASER_GPG_SECRET_KEY }}
+          JRELEASER_GPG_PASSPHRASE: ${{ secrets.JRELEASER_GPG_PASSPHRASE }}
+        run: >-
+          ./gradlew :sdk:jreleaserDeploy
+          -PsdkVersion="$SDK_VERSION" --stacktrace

--- a/.github/workflows/kotlin-sdk-release.yml
+++ b/.github/workflows/kotlin-sdk-release.yml
@@ -39,14 +39,52 @@ jobs:
       sha: ${{ steps.resolve-sha.outputs.sha }}
 
     steps:
+      # A workflow_dispatch `tag` input is free-form and actions/checkout would
+      # happily resolve it to a BRANCH (or any ref), which would let a manual
+      # run publish a Maven version derived from a moving branch instead of an
+      # immutable tag. Resolve the ref HERE and hard-fail unless it names an
+      # existing tag, then hand the checkout an explicit refs/tags/<tag> ref so
+      # it can never bind to a branch. The tag-push trigger is already
+      # tag-bound (github.ref is refs/tags/kotlin-sdk-*) and skips the lookup.
+      - name: Resolve and validate release ref
+        id: release-ref
+        env:
+          DISPATCH_TAG: ${{ github.event.inputs.tag }}
+          PUSH_REF: ${{ github.ref }}
+          REPO: ${{ github.repository }}
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          if [ -n "$DISPATCH_TAG" ]; then
+            # Accept either the short tag or a full refs/tags/ ref; reject
+            # anything else (a bare branch name, refs/heads/..., or a slashed
+            # ref) before it can reach checkout.
+            TAG="${DISPATCH_TAG#refs/tags/}"
+            case "$TAG" in
+              refs/*|*/*)
+                echo "::error::Release ref '$DISPATCH_TAG' is not a plain tag name — provide an existing kotlin-sdk-* tag (optionally as refs/tags/kotlin-sdk-vX.Y.Z)."
+                exit 1
+                ;;
+            esac
+            # The tags ref namespace is checked explicitly, so a branch that
+            # happens to share the input's name can never satisfy this guard.
+            if ! gh api "repos/${REPO}/git/ref/tags/${TAG}" >/dev/null 2>&1; then
+              echo "::error::No existing tag 'refs/tags/${TAG}' in ${REPO}. workflow_dispatch can only (re-)release an existing tag, never a branch or arbitrary ref."
+              exit 1
+            fi
+            echo "checkout_ref=refs/tags/${TAG}" >> "$GITHUB_OUTPUT"
+          else
+            # Tag-push trigger: github.ref is already refs/tags/kotlin-sdk-*.
+            echo "checkout_ref=${PUSH_REF}" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          # A manual dispatch runs on the branch/tag selected in the UI, not
-          # on the `tag` input it will publish under — without this ref the
-          # released AAR could be built from a different commit than the tag.
-          # A full `refs/tags/...` value is a valid checkout ref as-is.
-          ref: ${{ github.event.inputs.tag || github.ref }}
+          # Always an explicit refs/tags/<tag> (validated above) or the
+          # tag-push github.ref — never the raw dispatch input — so the
+          # released AAR is built from the tag's commit and a manual run can
+          # never build from a branch.
+          ref: ${{ steps.release-ref.outputs.checkout_ref }}
 
       - name: Resolve built commit SHA
         id: resolve-sha
@@ -96,40 +134,23 @@ jobs:
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
           echo "Derived sdkVersion: ${VERSION:-<none — Maven Central deploy will be skipped>}"
 
-      # Precondition check runs HERE — right after version derivation and
-      # before the ~3-hour native build — so a misconfiguration (partial
-      # secrets) fails fast instead of after the long build. It only decides
-      # WHETHER to deploy; the actual deploy is a separate, environment-gated
-      # job (maven-central-deploy) that consumes this `deploy` output.
-      #
-      # The `secrets` context is mapped into env vars here because emptiness of
-      # the secret is what decides the gate. These names must be resolvable at
-      # repository/organization scope for this fail-fast check to see them; the
-      # human approval gate and (optionally) environment-scoped copies live on
-      # the maven-central environment — see packages/kotlin-sdk/PUBLISHING.md.
-      - name: Check Maven Central deploy preconditions
+      # Decides WHETHER a Maven Central deploy should be attempted, based SOLELY
+      # on the tag-derived version. This job is deliberately UNPROTECTED, so it
+      # must not read any publishing credential — otherwise the maven-central
+      # environment approval gate would not actually protect the secrets. The
+      # all-or-nothing secret precondition therefore lives in the gated
+      # maven-central-deploy job, which is the only place the Maven Central /
+      # GPG secrets are referenced. Deciding the version gate here still lets a
+      # non-releasable tag (kotlin-sdk-* without a vX.Y.Z version) skip the
+      # deploy job entirely so no reviewer is ever prompted for it.
+      - name: Decide whether to deploy to Maven Central
         id: maven-gate
         env:
           SDK_VERSION: ${{ steps.sdk-version.outputs.version }}
-          PORTAL_USER: ${{ secrets.JRELEASER_MAVENCENTRAL_SONATYPE_USERNAME }}
-          PORTAL_TOKEN: ${{ secrets.JRELEASER_MAVENCENTRAL_SONATYPE_PASSWORD }}
-          GPG_SECRET_KEY: ${{ secrets.JRELEASER_GPG_SECRET_KEY }}
-          GPG_PUBLIC_KEY: ${{ secrets.JRELEASER_GPG_PUBLIC_KEY }}
-          GPG_PASSPHRASE: ${{ secrets.JRELEASER_GPG_PASSPHRASE }}
         run: |
-          # All five secrets the staging + jreleaser steps actually consume:
-          # Portal user/token, and the GPG secret key, public key and
-          # passphrase (gradle signing needs key+passphrase; jreleaser's
-          # Active.ALWAYS signing needs all three GPG values).
           if [ -z "$SDK_VERSION" ]; then
             echo "::notice::Tag is not kotlin-sdk-vX.Y.Z, so no Maven version can be derived — Maven Central deploy skipped."
             echo "deploy=false" >> "$GITHUB_OUTPUT"
-          elif [ -z "$PORTAL_USER" ] && [ -z "$PORTAL_TOKEN" ] && [ -z "$GPG_SECRET_KEY" ] && [ -z "$GPG_PUBLIC_KEY" ] && [ -z "$GPG_PASSPHRASE" ]; then
-            echo "::notice::Maven Central secrets are not configured on this repository (the Central Portal token is currently personal) — Maven Central deploy skipped. See packages/kotlin-sdk/PUBLISHING.md."
-            echo "deploy=false" >> "$GITHUB_OUTPUT"
-          elif [ -z "$PORTAL_USER" ] || [ -z "$PORTAL_TOKEN" ] || [ -z "$GPG_SECRET_KEY" ] || [ -z "$GPG_PUBLIC_KEY" ] || [ -z "$GPG_PASSPHRASE" ]; then
-            echo "::error::Maven Central secrets are only partially configured — need ALL of JRELEASER_MAVENCENTRAL_SONATYPE_USERNAME, JRELEASER_MAVENCENTRAL_SONATYPE_PASSWORD, JRELEASER_GPG_SECRET_KEY, JRELEASER_GPG_PUBLIC_KEY and JRELEASER_GPG_PASSPHRASE. Refusing to guess."
-            exit 1
           else
             echo "deploy=true" >> "$GITHUB_OUTPUT"
           fi
@@ -210,7 +231,11 @@ jobs:
           name: kotlin-sdk-jnilibs
           path: packages/kotlin-sdk/sdk/src/main/jniLibs
           if-no-files-found: error
-          retention-days: 1
+          # The deploy job can sit pending human approval on the maven-central
+          # environment for far longer than a day, so this artifact must
+          # outlive any realistic approval pause; download-artifact fails once
+          # it expires.
+          retention-days: 90
 
   # -------------------------------------------------------------------------
   # Maven Central deploy — the human gate.
@@ -220,11 +245,14 @@ jobs:
   # environment (see packages/kotlin-sdk/PUBLISHING.md) the workflow PAUSES
   # here and a reviewer must approve before anything is published to Maven
   # Central — the deploy is irrevocable, so this approval is the human gate.
-  # It runs only when the build job decided a deploy is warranted (valid
-  # tag-derived version AND the secrets are configured); otherwise it is
-  # skipped and no reviewer is prompted. The Central secrets are referenced in
-  # this job's steps so they resolve from the maven-central environment when
-  # scoped there.
+  # It runs only when the build job derived a releasable version (a
+  # kotlin-sdk-vX.Y.Z tag); a non-releasable tag skips it and prompts no
+  # reviewer. The Central / GPG secrets are referenced ONLY in this job's
+  # steps, so they resolve from the maven-central environment when scoped
+  # there and are never exposed to the unprotected build job. The all-or-
+  # nothing secret precondition runs as the first step below (after approval),
+  # so a partial-secret misconfiguration fails loudly instead of half-
+  # publishing, and a repo with no secrets configured yet skips the publish.
   # -------------------------------------------------------------------------
   maven-central-deploy:
     name: Deploy to Maven Central (version from tag)
@@ -235,7 +263,33 @@ jobs:
     environment: maven-central
 
     steps:
+      # All five secrets the staging + jreleaser steps consume: Portal
+      # user/token, and the GPG secret key, public key and passphrase (gradle
+      # signing needs key+passphrase; jreleaser's Active.ALWAYS signing needs
+      # all three GPG values). This is the ONLY place these secrets are
+      # referenced, so the emptiness check now lives behind the environment
+      # gate rather than in the unprotected build job.
+      - name: Check Maven Central publishing secrets
+        id: secrets-gate
+        env:
+          PORTAL_USER: ${{ secrets.JRELEASER_MAVENCENTRAL_SONATYPE_USERNAME }}
+          PORTAL_TOKEN: ${{ secrets.JRELEASER_MAVENCENTRAL_SONATYPE_PASSWORD }}
+          GPG_SECRET_KEY: ${{ secrets.JRELEASER_GPG_SECRET_KEY }}
+          GPG_PUBLIC_KEY: ${{ secrets.JRELEASER_GPG_PUBLIC_KEY }}
+          GPG_PASSPHRASE: ${{ secrets.JRELEASER_GPG_PASSPHRASE }}
+        run: |
+          if [ -z "$PORTAL_USER" ] && [ -z "$PORTAL_TOKEN" ] && [ -z "$GPG_SECRET_KEY" ] && [ -z "$GPG_PUBLIC_KEY" ] && [ -z "$GPG_PASSPHRASE" ]; then
+            echo "::notice::Maven Central secrets are not configured on the maven-central environment (the Central Portal token is currently personal) — Maven Central deploy skipped. See packages/kotlin-sdk/PUBLISHING.md."
+            echo "proceed=false" >> "$GITHUB_OUTPUT"
+          elif [ -z "$PORTAL_USER" ] || [ -z "$PORTAL_TOKEN" ] || [ -z "$GPG_SECRET_KEY" ] || [ -z "$GPG_PUBLIC_KEY" ] || [ -z "$GPG_PASSPHRASE" ]; then
+            echo "::error::Maven Central secrets are only partially configured — need ALL of JRELEASER_MAVENCENTRAL_SONATYPE_USERNAME, JRELEASER_MAVENCENTRAL_SONATYPE_PASSWORD, JRELEASER_GPG_SECRET_KEY, JRELEASER_GPG_PUBLIC_KEY and JRELEASER_GPG_PASSPHRASE. Refusing to guess."
+            exit 1
+          else
+            echo "proceed=true" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Checkout repository
+        if: steps.secrets-gate.outputs.proceed == 'true'
         uses: actions/checkout@v4
         with:
           # Pin to the exact SHA the build job resolved, NOT the tag ref: the
@@ -246,12 +300,14 @@ jobs:
           ref: ${{ needs.build-and-release.outputs.sha }}
 
       - name: Set up JDK 17
+        if: steps.secrets-gate.outputs.proceed == 'true'
         uses: actions/setup-java@v4
         with:
           distribution: temurin
           java-version: '17'
 
       - name: Set up Android SDK
+        if: steps.secrets-gate.outputs.proceed == 'true'
         uses: android-actions/setup-android@v3
         with:
           # No Rust/cargo here — the native libraries are downloaded below. The
@@ -263,12 +319,14 @@ jobs:
             ndk;28.1.13356709
 
       - name: Restore native libraries from the build job
+        if: steps.secrets-gate.outputs.proceed == 'true'
         uses: actions/download-artifact@v4
         with:
           name: kotlin-sdk-jnilibs
           path: packages/kotlin-sdk/sdk/src/main/jniLibs
 
       - name: Setup Gradle
+        if: steps.secrets-gate.outputs.proceed == 'true'
         uses: gradle/actions/setup-gradle@v4
 
       # Stages the signed release AAR + sources/javadoc jars into
@@ -277,6 +335,7 @@ jobs:
       # verifyJniLibsForRemotePublish hard-fails if the source tree lacks
       # libdash_sdk_jni.so for any required ABI.
       - name: Stage signed Maven artifacts (version from tag)
+        if: steps.secrets-gate.outputs.proceed == 'true'
         working-directory: packages/kotlin-sdk
         env:
           SDK_VERSION: ${{ needs.build-and-release.outputs.version }}
@@ -293,6 +352,7 @@ jobs:
       # verifyJniLibsForRemotePublish and verifyStagedAarForRemotePublish
       # first, so a stale or nativeless staged AAR can never be deployed.
       - name: Deploy to Maven Central (jreleaserDeploy, version from tag)
+        if: steps.secrets-gate.outputs.proceed == 'true'
         working-directory: packages/kotlin-sdk
         env:
           SDK_VERSION: ${{ needs.build-and-release.outputs.version }}

--- a/.github/workflows/kotlin-sdk-release.yml
+++ b/.github/workflows/kotlin-sdk-release.yml
@@ -48,7 +48,10 @@ jobs:
           case "$TAG" in
             kotlin-sdk-v*)
               VERSION="${TAG#kotlin-sdk-v}"
-              if ! printf '%s\n' "$VERSION" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+([.-][0-9A-Za-z][0-9A-Za-z.-]*)?$'; then
+              # bash [[ =~ ]] matches the WHOLE string (unlike line-oriented
+              # grep), so a multiline value from a workflow_dispatch input can
+              # never pass validation and inject extra GITHUB_OUTPUT lines.
+              if ! [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+([.-][0-9A-Za-z][0-9A-Za-z.-]*)?$ ]]; then
                 echo "::error::Tag '$TAG' has the kotlin-sdk-v prefix but '$VERSION' is not a valid version (expected kotlin-sdk-vX.Y.Z)."
                 exit 1
               fi
@@ -149,15 +152,21 @@ jobs:
           PORTAL_USER: ${{ secrets.JRELEASER_MAVENCENTRAL_SONATYPE_USERNAME }}
           PORTAL_TOKEN: ${{ secrets.JRELEASER_MAVENCENTRAL_SONATYPE_PASSWORD }}
           GPG_SECRET_KEY: ${{ secrets.JRELEASER_GPG_SECRET_KEY }}
+          GPG_PUBLIC_KEY: ${{ secrets.JRELEASER_GPG_PUBLIC_KEY }}
+          GPG_PASSPHRASE: ${{ secrets.JRELEASER_GPG_PASSPHRASE }}
         run: |
+          # All five secrets the staging + jreleaser steps actually consume:
+          # Portal user/token, and the GPG secret key, public key and
+          # passphrase (gradle signing needs key+passphrase; jreleaser's
+          # Active.ALWAYS signing needs all three GPG values).
           if [ -z "$SDK_VERSION" ]; then
             echo "::notice::Tag is not kotlin-sdk-vX.Y.Z, so no Maven version can be derived — Maven Central deploy skipped."
             echo "deploy=false" >> "$GITHUB_OUTPUT"
-          elif [ -z "$PORTAL_USER" ] && [ -z "$PORTAL_TOKEN" ] && [ -z "$GPG_SECRET_KEY" ]; then
+          elif [ -z "$PORTAL_USER" ] && [ -z "$PORTAL_TOKEN" ] && [ -z "$GPG_SECRET_KEY" ] && [ -z "$GPG_PUBLIC_KEY" ] && [ -z "$GPG_PASSPHRASE" ]; then
             echo "::notice::Maven Central secrets are not configured on this repository (the Central Portal token is currently personal) — Maven Central deploy skipped. See packages/kotlin-sdk/PUBLISHING.md."
             echo "deploy=false" >> "$GITHUB_OUTPUT"
-          elif [ -z "$PORTAL_USER" ] || [ -z "$PORTAL_TOKEN" ] || [ -z "$GPG_SECRET_KEY" ]; then
-            echo "::error::Maven Central secrets are only partially configured — need JRELEASER_MAVENCENTRAL_SONATYPE_USERNAME, JRELEASER_MAVENCENTRAL_SONATYPE_PASSWORD and JRELEASER_GPG_SECRET_KEY (plus JRELEASER_GPG_PUBLIC_KEY and JRELEASER_GPG_PASSPHRASE). Refusing to guess."
+          elif [ -z "$PORTAL_USER" ] || [ -z "$PORTAL_TOKEN" ] || [ -z "$GPG_SECRET_KEY" ] || [ -z "$GPG_PUBLIC_KEY" ] || [ -z "$GPG_PASSPHRASE" ]; then
+            echo "::error::Maven Central secrets are only partially configured — need ALL of JRELEASER_MAVENCENTRAL_SONATYPE_USERNAME, JRELEASER_MAVENCENTRAL_SONATYPE_PASSWORD, JRELEASER_GPG_SECRET_KEY, JRELEASER_GPG_PUBLIC_KEY and JRELEASER_GPG_PASSPHRASE. Refusing to guess."
             exit 1
           else
             echo "deploy=true" >> "$GITHUB_OUTPUT"

--- a/packages/kotlin-sdk/PUBLISHING.md
+++ b/packages/kotlin-sdk/PUBLISHING.md
@@ -49,28 +49,21 @@ secrets are installed**:
    release (e.g. the `org.dashj` publisher). This is the human gate: the
    workflow pauses at the deploy job until a reviewer approves, and the
    approval is the last chance to stop an irrevocable publish.
-3. Only then install the Central secrets (below). Install the five secrets at
-   **repository/organization scope** so the build job's fail-fast precondition
-   check can see them (that check runs before the long native build, so a
-   misconfiguration aborts early — and it reads secrets at repo/org scope, not
-   from the environment). Do **not** scope them environment-only: that would
-   make the presence check compute `deploy=false` and silently disable
-   publishing (green build, only a `::notice`). The `maven-central` environment
-   provides the required-reviewer human gate; if you additionally want the
-   secret *values* withheld from the build job, add environment-scoped copies
-   that override at deploy time — but the repo/org-scoped names must remain for
-   the presence check.
+3. Only then install the five Central/GPG secrets listed below as
+   **environment secrets on `maven-central`**. Do not create repository- or
+   organization-scoped copies: those scopes would make the credentials
+   available to jobs that have not passed this environment's reviewer gate.
 If a `kotlin-sdk-v*` tag is pushed while no reviewer approves, the deploy job
 simply waits and can be rejected — the GitHub-release AAR is already attached
 by job 1 regardless.
 
 **Secrets gate:** the Maven deploy steps only run when the Sonatype Central
-Portal credentials are configured as GitHub repository secrets. That Portal
-token is currently a personal token (held by HashEngineering, the `org.dashj`
-publisher), so until it is installed as repo secrets the deploy steps **skip
-with a notice** instead of failing — the tag still produces the
-GitHub-release AAR, and the Maven release can be done manually with the
-runbook below, **from the tag's commit with the tag's version**. Required
+Portal credentials are configured as secrets on the **`maven-central`
+environment**. That Portal token is currently a personal token (held by
+HashEngineering, the `org.dashj` publisher), so until it is installed there
+the deploy steps **skip with a notice** instead of failing — the tag still
+produces the GitHub-release AAR, and the Maven release can be done manually
+with the runbook below, **from the tag's commit with the tag's version**. Required
 secrets (names match the env vars in the next section):
 `JRELEASER_MAVENCENTRAL_SONATYPE_USERNAME`,
 `JRELEASER_MAVENCENTRAL_SONATYPE_PASSWORD`, `JRELEASER_GPG_PUBLIC_KEY`,

--- a/packages/kotlin-sdk/PUBLISHING.md
+++ b/packages/kotlin-sdk/PUBLISHING.md
@@ -8,7 +8,48 @@ Maven-coordinates decision only — the Kotlin source packages remain
 release versions go to Maven Central via the Central Portal; `-SNAPSHOT`
 versions go to the Sonatype snapshots repository.
 
-## Prerequisites
+## CI release path (preferred): the `kotlin-sdk-vX.Y.Z` tag
+
+Pushing a `kotlin-sdk-vX.Y.Z` tag runs
+`.github/workflows/kotlin-sdk-release.yml`, which from that ONE checkout:
+
+1. builds the native library and the release AAR and attaches the AAR to the
+   GitHub release for the tag (existing behavior), and
+2. stages the signed Maven artifacts and runs `jreleaserDeploy` with
+   `-PsdkVersion` **derived from the tag** (`kotlin-sdk-v0.1.0` → `0.1.0`).
+
+In CI the version is never passed by hand — it comes only from the tag — so
+the Maven Central artifact and the GitHub-release AAR are always the same
+commit under the same version. Tags that would derive a `-SNAPSHOT` version
+are rejected. A `kotlin-sdk-*` tag without the `vX.Y.Z` form still gets its
+GitHub-release AAR but skips the Maven deploy (there is no version to
+derive). The workflow's manual `workflow_dispatch` path is for
+re-runs/emergencies only: it takes an *existing* tag name, checks out that
+tag, and derives the version from it the same way — it has no version input.
+
+**Secrets gate:** the Maven deploy steps only run when the Sonatype Central
+Portal credentials are configured as GitHub repository secrets. That Portal
+token is currently a personal token (held by HashEngineering, the `org.dashj`
+publisher), so until it is installed as repo secrets the deploy steps **skip
+with a notice** instead of failing — the tag still produces the
+GitHub-release AAR, and the Maven release can be done manually with the
+runbook below, **from the tag's commit with the tag's version**. Required
+secrets (names match the env vars in the next section):
+`JRELEASER_MAVENCENTRAL_SONATYPE_USERNAME`,
+`JRELEASER_MAVENCENTRAL_SONATYPE_PASSWORD`, `JRELEASER_GPG_PUBLIC_KEY`,
+`JRELEASER_GPG_SECRET_KEY`, `JRELEASER_GPG_PASSPHRASE`. The GPG secret
+key/passphrase pair is also fed to the Gradle staging signature
+(`ORG_GRADLE_PROJECT_signingKey` / `signingPassword`). A *partially*
+configured secret set fails the run rather than guessing. Both publish guards
+below (`verifyJniLibsForRemotePublish`, `verifyStagedAarForRemotePublish`)
+run in the CI path via the same task dependencies as locally.
+
+## Prerequisites (manual fallback path)
+
+The runbook below is the fallback for while the Portal token is personal (or
+if CI is unavailable). When releasing a tagged version manually, check out
+the `kotlin-sdk-vX.Y.Z` tag and pass exactly its `X.Y.Z` as `-PsdkVersion`,
+so the manual Maven deploy cannot drift from the GitHub-release AAR.
 
 - **Sonatype Central Portal token** for the `org.dashj` namespace (held by
   HashEngineering — the same account that publishes `dashj-core`).

--- a/packages/kotlin-sdk/PUBLISHING.md
+++ b/packages/kotlin-sdk/PUBLISHING.md
@@ -24,15 +24,18 @@ Pushing a `kotlin-sdk-vX.Y.Z` tag runs
 
 In CI the version is never passed by hand — it comes only from the tag — so
 the Maven Central artifact and the GitHub-release AAR are always the same
-commit under the same version (the deploy job checks out the same tag and
-re-stages the native libraries the build job produced, rather than rebuilding
-them). Tags that would derive a `-SNAPSHOT` version are rejected. A
+commit under the same version (the deploy job checks out the exact commit SHA
+the build job built — not the mutable tag ref — and re-stages the native
+libraries that build produced, rather than rebuilding them; the tag is
+re-validated against that SHA after approval, and once more inline immediately
+before the deploy). Tags that would derive a `-SNAPSHOT` version are rejected. A
 `kotlin-sdk-*` tag without the `vX.Y.Z` form still gets its GitHub-release AAR
 but skips the Maven deploy (there is no version to derive). The workflow's
 manual `workflow_dispatch` path is for re-runs/emergencies only: it takes an
 *existing* tag name — either the short `kotlin-sdk-vX.Y.Z` form or a full
-`refs/tags/kotlin-sdk-vX.Y.Z` ref — checks out that tag, and derives the
-version from it the same way; it has no version input.
+`refs/tags/kotlin-sdk-vX.Y.Z` ref — resolves it to the commit it currently
+points at, checks out that commit, and derives the version from the tag the
+same way; it has no version input.
 
 ### The human gate: the `maven-central` environment (required before secrets)
 

--- a/packages/kotlin-sdk/PUBLISHING.md
+++ b/packages/kotlin-sdk/PUBLISHING.md
@@ -11,21 +11,57 @@ versions go to the Sonatype snapshots repository.
 ## CI release path (preferred): the `kotlin-sdk-vX.Y.Z` tag
 
 Pushing a `kotlin-sdk-vX.Y.Z` tag runs
-`.github/workflows/kotlin-sdk-release.yml`, which from that ONE checkout:
+`.github/workflows/kotlin-sdk-release.yml`, which is split into two jobs:
 
-1. builds the native library and the release AAR and attaches the AAR to the
-   GitHub release for the tag (existing behavior), and
-2. stages the signed Maven artifacts and runs `jreleaserDeploy` with
-   `-PsdkVersion` **derived from the tag** (`kotlin-sdk-v0.1.0` → `0.1.0`).
+1. **`build-and-release`** builds the native library and the release AAR and
+   attaches the AAR to the GitHub release for the tag (existing behavior). It
+   derives `-PsdkVersion` **from the tag** (`kotlin-sdk-v0.1.0` → `0.1.0`) and
+   decides whether a Maven Central deploy is warranted.
+2. **`maven-central-deploy`** stages the signed Maven artifacts and runs
+   `jreleaserDeploy` under the tag-derived version. It runs only when job 1
+   decided a deploy is warranted, and it is gated by the **`maven-central`
+   environment** (see the human gate below).
 
 In CI the version is never passed by hand — it comes only from the tag — so
 the Maven Central artifact and the GitHub-release AAR are always the same
-commit under the same version. Tags that would derive a `-SNAPSHOT` version
-are rejected. A `kotlin-sdk-*` tag without the `vX.Y.Z` form still gets its
-GitHub-release AAR but skips the Maven deploy (there is no version to
-derive). The workflow's manual `workflow_dispatch` path is for
-re-runs/emergencies only: it takes an *existing* tag name, checks out that
-tag, and derives the version from it the same way — it has no version input.
+commit under the same version (the deploy job checks out the same tag and
+re-stages the native libraries the build job produced, rather than rebuilding
+them). Tags that would derive a `-SNAPSHOT` version are rejected. A
+`kotlin-sdk-*` tag without the `vX.Y.Z` form still gets its GitHub-release AAR
+but skips the Maven deploy (there is no version to derive). The workflow's
+manual `workflow_dispatch` path is for re-runs/emergencies only: it takes an
+*existing* tag name — either the short `kotlin-sdk-vX.Y.Z` form or a full
+`refs/tags/kotlin-sdk-vX.Y.Z` ref — checks out that tag, and derives the
+version from it the same way; it has no version input.
+
+### The human gate: the `maven-central` environment (required before secrets)
+
+A push of any `kotlin-sdk-v*` tag would otherwise publish **irrevocably** to
+Maven Central with no human review. To gate it, the `maven-central-deploy`
+job declares `environment: maven-central`. That means the deploy is only as
+safe as the environment's protection rules — **the environment must be
+created in repository settings with required reviewers *before* the Central
+secrets are installed**:
+
+1. Repo **Settings → Environments → New environment** named exactly
+   `maven-central`.
+2. Enable **Required reviewers** and add the people allowed to approve a
+   release (e.g. the `org.dashj` publisher). This is the human gate: the
+   workflow pauses at the deploy job until a reviewer approves, and the
+   approval is the last chance to stop an irrevocable publish.
+3. Only then install the Central secrets (below). Scoping them to the
+   `maven-central` environment (rather than repo-wide) keeps them out of every
+   other job — they are exposed only to the reviewer-gated deploy job.
+
+Because the fail-fast precondition check in the **build** job runs before the
+long native build (so a misconfiguration aborts early), it needs to *see* the
+secret names at repository/organization scope. Practical setup: keep the five
+secret **names** resolvable at repo/org scope for that presence check, and use
+the `maven-central` environment for the required-reviewer gate (and, if you
+prefer, environment-scoped copies of the values that override at deploy time).
+If a `kotlin-sdk-v*` tag is pushed while no reviewer approves, the deploy job
+simply waits and can be rejected — the GitHub-release AAR is already attached
+by job 1 regardless.
 
 **Secrets gate:** the Maven deploy steps only run when the Sonatype Central
 Portal credentials are configured as GitHub repository secrets. That Portal

--- a/packages/kotlin-sdk/PUBLISHING.md
+++ b/packages/kotlin-sdk/PUBLISHING.md
@@ -49,16 +49,17 @@ secrets are installed**:
    release (e.g. the `org.dashj` publisher). This is the human gate: the
    workflow pauses at the deploy job until a reviewer approves, and the
    approval is the last chance to stop an irrevocable publish.
-3. Only then install the Central secrets (below). Scoping them to the
-   `maven-central` environment (rather than repo-wide) keeps them out of every
-   other job — they are exposed only to the reviewer-gated deploy job.
-
-Because the fail-fast precondition check in the **build** job runs before the
-long native build (so a misconfiguration aborts early), it needs to *see* the
-secret names at repository/organization scope. Practical setup: keep the five
-secret **names** resolvable at repo/org scope for that presence check, and use
-the `maven-central` environment for the required-reviewer gate (and, if you
-prefer, environment-scoped copies of the values that override at deploy time).
+3. Only then install the Central secrets (below). Install the five secrets at
+   **repository/organization scope** so the build job's fail-fast precondition
+   check can see them (that check runs before the long native build, so a
+   misconfiguration aborts early — and it reads secrets at repo/org scope, not
+   from the environment). Do **not** scope them environment-only: that would
+   make the presence check compute `deploy=false` and silently disable
+   publishing (green build, only a `::notice`). The `maven-central` environment
+   provides the required-reviewer human gate; if you additionally want the
+   secret *values* withheld from the build job, add environment-scoped copies
+   that override at deploy time — but the repo/org-scoped names must remain for
+   the presence check.
 If a `kotlin-sdk-v*` tag is pushed while no reviewer approves, the deploy job
 simply waits and can be rejected — the GitHub-release AAR is already attached
 by job 1 regardless.


### PR DESCRIPTION
**Stacked on #4182 (Maven publishing) — merge after it.** The branch includes #4182's commits until it lands; the last commits are this PR's content.

Follow-up to #4182, addressing @shumkov's review point: nothing tied `-PsdkVersion` on the manual Maven publish to the `kotlin-sdk-*` tag that drives the GitHub-release AAR, so the two channels could ship different commits under one version.

This folds `jreleaserDeploy` into `kotlin-sdk-release.yml`:

- **Version comes only from the tag.** `kotlin-sdk-vX.Y.Z` → `-PsdkVersion=X.Y.Z`; the checkout is already pinned to the same tag, so the Maven Central artifact and the GitHub-release AAR are always the same commit under the same version. There is no version input anywhere in the workflow. Malformed `kotlin-sdk-v*` tags and tag-derived `-SNAPSHOT` versions fail the run (early, before the native build); non-versioned `kotlin-sdk-*` tags keep today's AAR-only behavior.
- **Secrets-gated deploy.** The Central Portal token for `org.dashj` is currently personal, so the deploy steps skip with a notice when the secrets (`JRELEASER_MAVENCENTRAL_SONATYPE_*`, `JRELEASER_GPG_*`) aren't configured — the tag still produces the GitHub-release AAR, and the documented manual runbook (now explicitly "from the tag's commit with the tag's version") remains the fallback. A partially configured secret set fails hard instead of guessing.
- **Existing guards run in CI.** `cleanStagingDeploy`, `verifyJniLibsForRemotePublish` and `verifyStagedAarForRemotePublish` are wired via task dependencies and appear in the `--dry-run` graph for both the staging and deploy invocations used by the workflow.
- **`workflow_dispatch` stays, tag-derived.** It only accepts an existing tag name (re-run/emergency path); the version is derived from that tag exactly as on tag push.

`PUBLISHING.md` documents the CI path as preferred and demotes the manual runbook to a fallback.

Verified: workflow parses (`yaml.safe_load`); tag→version derivation exercised against valid/invalid/snapshot/injection-shaped tags; both Gradle invocations dry-run with the guards in the task graph (JDK 17).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a hardened, tag-driven Kotlin SDK release flow that builds from an immutable tag commit.
  * Introduced approval- and environment-gated Maven Central publishing with safe credential/secret checks.
* **Bug Fixes**
  * Detects force-moved tags and blocks publishing when the tag no longer matches the built commit, preventing drift.
  * Avoids unintended overwrites of the fixed GitHub Release AAR asset.
* **Documentation**
  * Updated Kotlin SDK publishing docs to clarify CI vs manual fallback behavior and how version is derived from `kotlin-sdk-vX.Y.Z` tags.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->