### PR TITLE
fix(drive): reject zero effective distinct count limit

### DIFF
--- a/packages/rs-drive/src/query/drive_document_count_query/drive_dispatcher.rs
+++ b/packages/rs-drive/src/query/drive_document_count_query/drive_dispatcher.rs
@@ -496,10 +496,21 @@ impl Drive {
                 let effective_limit = if request.mode.is_aggregate() {
                     super::MAX_LIMIT_AS_FAILSAFE
                 } else {
-                    request
+                    let effective_limit = request
                         .limit
                         .unwrap_or(request.drive_config.default_query_limit as u32)
-                        .min(request.drive_config.max_query_limit as u32)
+                        .min(request.drive_config.max_query_limit as u32);
+                    // Fail closed instead of walking storage with a
+                    // zero bound (grovedb treats `limit: 0` as "return
+                    // nothing", which would masquerade as an empty
+                    // result set). Mirrors the sum-side
+                    // `effective_no_proof_distinct_limit` policy.
+                    if effective_limit == 0 {
+                        return Err(Error::Query(QuerySyntaxError::InvalidLimit(
+                            "effective distinct COUNT limit must be greater than zero".to_string(),
+                        )));
+                    }
+                    effective_limit
                 };
                 let options = RangeCountOptions {
                     distinct: request.mode.requires_distinct_walk(),

--- a/packages/rs-drive/src/query/drive_document_count_query/tests.rs
+++ b/packages/rs-drive/src/query/drive_document_count_query/tests.rs
@@ -1652,6 +1652,89 @@ fn test_range_distinct_proof_uses_compile_time_default_query_limit_not_operator_
     );
 }
 
+/// A `max_query_limit: 0` config (or an explicit `limit: 0`) must fail
+/// closed on the no-proof distinct walk instead of reaching storage
+/// with a zero bound, which grovedb treats as "return nothing" and
+/// which would masquerade as an empty result set. Mirrors the sum-side
+/// `effective_no_proof_distinct_limit` policy.
+#[test]
+fn test_range_distinct_no_proof_rejects_zero_effective_limit() {
+    use crate::config::DriveConfig;
+    use crate::error::query::QuerySyntaxError;
+    use crate::error::Error;
+    use crate::query::drive_document_count_query::drive_dispatcher::DocumentCountRequest;
+    use dpp::data_contract::DataContractFactory;
+    use dpp::platform_value::platform_value;
+
+    const PROTOCOL_VERSION_V12: u32 = 12;
+
+    let drive = setup_drive_with_initial_state_structure(None);
+    let platform_version = PlatformVersion::latest();
+
+    let factory =
+        DataContractFactory::new(PROTOCOL_VERSION_V12).expect("expected to create factory");
+    let document_schema = platform_value!({
+        "type": "object",
+        "properties": {
+            "color": {"type": "string", "position": 0, "maxLength": 32},
+        },
+        "indices": [{
+            "name": "byColor",
+            "properties": [{"color": "asc"}],
+            "countable": "countable",
+            "rangeCountable": true,
+        }],
+        "additionalProperties": false,
+    });
+    let schemas = platform_value!({ "widget": document_schema });
+    let data_contract = factory
+        .create_with_value_config(
+            dpp::tests::utils::generate_random_identifier_struct(),
+            0,
+            schemas,
+            None,
+            None,
+        )
+        .expect("expected to create data contract")
+        .data_contract_owned();
+    let document_type = data_contract
+        .document_type_for_name("widget")
+        .expect("widget doc type exists");
+
+    // The rejection fires in the dispatcher before any storage walk,
+    // so the contract does not need to be applied nor documents
+    // inserted for this check to be load-bearing.
+    let drive_config = DriveConfig {
+        max_query_limit: 0,
+        ..Default::default()
+    };
+    let request = DocumentCountRequest {
+        contract: &data_contract,
+        document_type,
+        where_clauses: vec![WhereClause {
+            field: "color".to_string(),
+            operator: WhereOperator::GreaterThan,
+            value: Value::Text("blue".to_string()),
+        }],
+        order_clauses: Vec::new(),
+        mode: CountMode::GroupByRange,
+        limit: None,
+        prove: false,
+        drive_config: &drive_config,
+    };
+
+    let result = drive.execute_document_count_request(request, None, platform_version);
+    match result {
+        Err(Error::Query(QuerySyntaxError::InvalidLimit(msg))) => {
+            assert!(
+                msg.contains("greater than zero"),
+                "error must state the zero-limit rejection; got: {msg}"
+            );
+        }
+        other => panic!("expected InvalidLimit error, got {other:?}"),
+    }
+}
+
 /// `execute_document_count_per_in_value_no_proof` runs one GroveDB walk
 /// per `In` value, so its iteration cost is proportional to the array's
 /// length rather than the configured `max_query_limit`. That makes the

--- a/packages/rs-drive/src/query/drive_document_sum_query/execute_range_sum.rs
+++ b/packages/rs-drive/src/query/drive_document_sum_query/execute_range_sum.rs
@@ -14,6 +14,7 @@
 
 use super::{DriveDocumentSumQuery, RangeSumOptions, RangeSumWalkMode, SumEntry};
 use crate::drive::Drive;
+use crate::error::drive::DriveError;
 use crate::error::query::QuerySyntaxError;
 use crate::error::Error;
 use crate::query::{WhereClause, WhereOperator};
@@ -149,7 +150,9 @@ impl DriveDocumentSumQuery<'_> {
         }
 
         let RangeSumWalkMode::Distinct(distinct_limit) = options.walk_mode else {
-            unreachable!("aggregate range sums return before the distinct storage walk")
+            return Err(Error::Drive(DriveError::CorruptedCodeExecution(
+                "aggregate range sums must return before the distinct storage walk",
+            )));
         };
         let path_query = self.distinct_sum_path_query(
             Some(distinct_limit),

--- a/packages/rs-drive/src/query/drive_document_sum_query/tests.rs
+++ b/packages/rs-drive/src/query/drive_document_sum_query/tests.rs
@@ -574,9 +574,18 @@ mod limit_policy_regression {
             )
             .expect("apply contract");
 
-        for (i, (color, amount)) in [("blue", 2u64), ("green", 3), ("red", 5), ("yellow", 7)]
-            .iter()
-            .enumerate()
+        // Five colors so the range predicate below matches FOUR distinct
+        // values — one more than `max_query_limit` — otherwise the clamp
+        // case would pass even against an unbounded walk.
+        for (i, (color, amount)) in [
+            ("blue", 2u64),
+            ("green", 3),
+            ("red", 5),
+            ("white", 11),
+            ("yellow", 7),
+        ]
+        .iter()
+        .enumerate()
         {
             insert_widget(&drive, &data_contract, i, color, *amount);
         }


### PR DESCRIPTION
## What

- reject a zero effective limit on the no-proof distinct COUNT walk before it reaches storage, mirroring the sum-side `effective_no_proof_distinct_limit` policy (with a regression test)
- return `CorruptedCodeExecution` instead of `unreachable!` ahead of the distinct SUM storage walk
- strengthen the distinct-SUM limit regression so the max-clamp case actually truncates at storage (four matching values against `max_query_limit: 3`)

## Why

Review follow-ups to #4149, which merged while they were being prepared:

- A `max_query_limit: 0` config (or explicit zero limit) previously reached grovedb with a zero bound on the count path, which returns nothing and masquerades as an empty result set. The sum side already failed closed; the count side now matches.
- The `unreachable!` was provably dead, but a future early-exit in the aggregate branch would have turned it into a query-path panic rather than an error.
- The prior clamp test case matched only three distinct values, so it passed identically with or without the storage bound.

## Checks

- cargo test -p drive --features server drive_document_sum_query (30 passed)
- cargo test -p drive --features server drive_document_count_query (49 passed)
- cargo clippy -p drive --features server --all-targets
- cargo check -p drive --no-default-features --features verify
- cargo fmt --all -- --check

🤖 Generated with [Claude Code](https://claude.com/claude-code)