### PR TITLE
fix(drive): accept MMR-aligned shielded note proof ranges

### DIFF
--- a/packages/rs-drive/src/verify/shielded/verify_shielded_encrypted_notes/v0/mod.rs
+++ b/packages/rs-drive/src/verify/shielded/verify_shielded_encrypted_notes/v0/mod.rs
@@ -1,5 +1,7 @@
 use super::VerifiedShieldedEncryptedNote;
-use crate::drive::shielded::paths::{shielded_credit_pool_path_vec, SHIELDED_NOTES_KEY};
+use crate::drive::shielded::paths::{
+    shielded_credit_pool_path_vec, SHIELDED_NOTES_CHUNK_POWER, SHIELDED_NOTES_KEY,
+};
 use crate::drive::Drive;
 use crate::error::drive::DriveError;
 use crate::error::proof::ProofError;
@@ -42,11 +44,14 @@ impl Drive {
             )));
         }
 
-        // start_index must be chunk-aligned (multiple of max_elements)
-        let chunk_size = max_elements as u64;
-        if !start_index.is_multiple_of(chunk_size) {
+        // The query limit may span multiple MMR chunks, but the start only
+        // needs to align to one on-chain chunk. Treating `max_elements` as
+        // the alignment unit rejects valid resume points such as 2048 when
+        // a request is allowed to fetch 4 × 2048 notes.
+        let mmr_chunk_size = 1u64 << SHIELDED_NOTES_CHUNK_POWER;
+        if !start_index.is_multiple_of(mmr_chunk_size) {
             return Err(Error::Drive(DriveError::CorruptedElementType(
-                "start_index is not chunk-aligned; must be a multiple of max_elements",
+                "start_index is not chunk-aligned; must be a multiple of the shielded-notes MMR chunk size",
             )));
         }
 
@@ -387,5 +392,40 @@ mod tests {
 
         assert_eq!(tc_full, N);
         assert_eq!(tc_subset, N);
+    }
+
+    /// A multi-chunk request may resume at any MMR chunk boundary, not only
+    /// at a boundary of the full request size. This is the production shape
+    /// when a wallet watermark in the first chunk advances to 2100: the
+    /// wallet rewinds to 2048, while the query cap remains 4 × 2048.
+    #[test]
+    fn accepts_mmr_aligned_start_inside_multi_chunk_query_boundary() {
+        let drive = setup_drive_with_initial_state_structure(None);
+        let platform_version = PlatformVersion::latest();
+
+        const N: u64 = 5;
+        insert_notes(&drive, N, platform_version);
+
+        let mmr_chunk_size: u64 = 1u64 << SHIELDED_NOTES_CHUNK_POWER;
+        let max_elements = (4 * mmr_chunk_size) as u32;
+        let start_index = mmr_chunk_size;
+        let limit = max_elements.min(u16::MAX as u32) as u16;
+        let path_query = notes_fetch_path_query(start_index, limit);
+        let proof = drive
+            .grove_get_proved_path_query_v1(&path_query, &mut vec![], &platform_version.drive)
+            .expect("should produce note-fetch proof from the second MMR chunk");
+
+        let (_, notes, total_count) = Drive::verify_shielded_encrypted_notes_v0(
+            proof.as_slice(),
+            start_index,
+            0,
+            max_elements,
+            false,
+            platform_version,
+        )
+        .expect("MMR-aligned resume point should verify for a multi-chunk request");
+
+        assert!(notes.is_empty());
+        assert_eq!(total_count, N);
     }
 }

--- a/packages/rs-drive/src/verify/shielded/verify_shielded_encrypted_notes/v0/mod.rs
+++ b/packages/rs-drive/src/verify/shielded/verify_shielded_encrypted_notes/v0/mod.rs
@@ -65,7 +65,13 @@ impl Drive {
         // PathQuery must match the server-side proof generation exactly:
         // path = [ShieldedBalances, "M"], key = [SHIELDED_NOTES_KEY],
         // subquery = range_inclusive(start..=end)
-        let end_index = start_index + limit as u64 - 1;
+        // `limit >= 1` here (max_elements > 0 was checked above), so
+        // `limit - 1` cannot underflow; only the addition can overflow.
+        let end_index = start_index.checked_add(limit as u64 - 1).ok_or_else(|| {
+            Error::Drive(DriveError::CorruptedElementType(
+                "shielded notes query range exceeds u64::MAX",
+            ))
+        })?;
         let mut inner_query = Query::new();
         inner_query.insert_range_inclusive(
             start_index.to_be_bytes().to_vec()..=end_index.to_be_bytes().to_vec(),
@@ -427,5 +433,38 @@ mod tests {
 
         assert!(notes.is_empty());
         assert_eq!(total_count, N);
+    }
+
+    /// A chunk-aligned `start_index` near `u64::MAX` must be rejected with a
+    /// clean error before the inclusive end index is computed — not wrap or
+    /// panic on `start_index + limit - 1`.
+    #[test]
+    fn rejects_range_end_overflow_past_u64_max() {
+        let platform_version = PlatformVersion::latest();
+
+        let mmr_chunk_size: u64 = 1u64 << SHIELDED_NOTES_CHUNK_POWER;
+        let max_elements = (4 * mmr_chunk_size) as u32;
+        // Largest chunk-aligned start: u64::MAX + 1 is a power of two, so
+        // u64::MAX - (mmr_chunk_size - 1) is a multiple of mmr_chunk_size.
+        // The alignment check passes, then end = start + limit - 1 overflows.
+        let start_index = u64::MAX - (mmr_chunk_size - 1);
+
+        let result = Drive::verify_shielded_encrypted_notes_v0(
+            &[],
+            start_index,
+            0,
+            max_elements,
+            false,
+            platform_version,
+        );
+
+        assert!(
+            matches!(
+                result,
+                Err(Error::Drive(DriveError::CorruptedElementType(msg)))
+                    if msg.contains("exceeds u64::MAX")
+            ),
+            "overflowing range must fail closed with a corruption error"
+        );
     }
 }


### PR DESCRIPTION
## Summary
- validate shielded encrypted-note proof resume offsets against the on-chain MMR chunk size instead of the multi-chunk request limit
- add a proof-based regression test for start index 2048 with an 8192-element request cap

## Context
Wallet sync rewinds its encrypted-note watermark to a 2048-note MMR chunk boundary, while one request may fetch four chunks. The verifier previously treated the 8192-element request limit as the alignment unit and rejected the valid 2048 resume point, leaving shielded sync and balance recovery stuck.

## Validation
- cargo fmt --package drive -- --check
- cargo test -p drive accepts_mmr_aligned_start_inside_multi_chunk_query_boundary --lib
- ./packages/swift-sdk/build_ios.sh --target ios --target sim
- xcodebuild dashwallet-dashpay Debug for arm64 iOS Simulator

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved shielded notes verification when resuming from multi-chunk queries.
  * Resume points are now validated against the correct MMR chunk boundaries (not element-count alignment).
  * Added safety to prevent index overflow during range calculations, returning a clear corruption error when invalid.
* **Tests**
  * Added coverage for aligned resume points inside multi-chunk requests.
  * Added coverage for rejecting chunk-aligned start points near the maximum index with the expected error.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->