### PR TITLE
ci: cover rs-unified-sdk-jni and missing contract crates in package filters

### DIFF
--- a/.github/package-filters/js-packages-direct.yml
+++ b/.github/package-filters/js-packages-direct.yml
@@ -4,6 +4,12 @@
 '@dashevo/token-history-contract':
   - packages/token-history-contract/**
 
+'@dashevo/document-history-contract':
+  - packages/document-history-contract/**
+
+'@dashevo/keyword-search-contract':
+  - packages/keyword-search-contract/**
+
 '@dashevo/dashpay-contract':
   - packages/dashpay-contract/**
 

--- a/.github/package-filters/js-packages-no-workflows.yml
+++ b/.github/package-filters/js-packages-no-workflows.yml
@@ -4,6 +4,12 @@
 '@dashevo/token-history-contract': &token-history-contract
   - packages/token-history-contract/**
 
+'@dashevo/document-history-contract': &document-history-contract
+  - packages/document-history-contract/**
+
+'@dashevo/keyword-search-contract': &keyword-search-contract
+  - packages/keyword-search-contract/**
+
 '@dashevo/dashpay-contract': &dashpay-contract
   - packages/dashpay-contract/**
 
@@ -27,6 +33,8 @@
   - *withdrawals-contract
   - *wallet-utils-contract
   - *token-history-contract
+  - *document-history-contract
+  - *keyword-search-contract
   - packages/rs-platform-serialization/**
   - packages/rs-platform-serialization-derive/**
   - packages/rs-platform-value/**

--- a/.github/package-filters/js-packages.yml
+++ b/.github/package-filters/js-packages.yml
@@ -6,6 +6,14 @@
   - .github/workflows/tests*
   - packages/token-history-contract/**
 
+'@dashevo/document-history-contract': &document-history-contract
+  - .github/workflows/tests*
+  - packages/document-history-contract/**
+
+'@dashevo/keyword-search-contract': &keyword-search-contract
+  - .github/workflows/tests*
+  - packages/keyword-search-contract/**
+
 '@dashevo/dashpay-contract': &dashpay-contract
   - .github/workflows/tests*
   - packages/dashpay-contract/**
@@ -35,6 +43,8 @@
   - *withdrawals-contract
   - *wallet-utils-contract
   - *token-history-contract
+  - *document-history-contract
+  - *keyword-search-contract
   - packages/rs-platform-serialization/**
   - packages/rs-platform-serialization-derive/**
   - packages/rs-platform-value/**

--- a/.github/package-filters/rs-packages-direct.yml
+++ b/.github/package-filters/rs-packages-direct.yml
@@ -8,6 +8,11 @@ token-history-contract:
   - packages/token-history-contract/schema/**
   - packages/token-history-contract/Cargo.toml
 
+document-history-contract:
+  - packages/document-history-contract/src/**
+  - packages/document-history-contract/schema/**
+  - packages/document-history-contract/Cargo.toml
+
 keyword-search-contract:
   - packages/keyword-search-contract/src/**
   - packages/keyword-search-contract/schema/**
@@ -131,6 +136,9 @@ platform-wallet-ffi:
 
 rs-unified-sdk-ffi:
   - packages/rs-unified-sdk-ffi/**
+
+rs-unified-sdk-jni:
+  - packages/rs-unified-sdk-jni/**
 
 wasm-drive-verify:
   - packages/wasm-drive-verify/**

--- a/.github/package-filters/rs-packages-no-workflows.yml
+++ b/.github/package-filters/rs-packages-no-workflows.yml
@@ -8,6 +8,11 @@ token-history-contract: &token-history-contract
   - packages/token-history-contract/schema/**
   - packages/token-history-contract/Cargo.toml
 
+document-history-contract: &document-history-contract
+  - packages/document-history-contract/src/**
+  - packages/document-history-contract/schema/**
+  - packages/document-history-contract/Cargo.toml
+
 keyword-search-contract: &keyword-search-contract
   - packages/keyword-search-contract/src/**
   - packages/keyword-search-contract/schema/**
@@ -45,6 +50,7 @@ data-contracts: &data-contracts
   - *wallet-utils-contract
   - *token-history-contract
   - *keyword-search-contract
+  - *document-history-contract
 
 dpp: &dpp
   - packages/rs-dpp/**
@@ -158,6 +164,11 @@ platform-wallet-ffi: &platform_wallet_ffi
 
 rs-unified-sdk-ffi:
   - packages/rs-unified-sdk-ffi/**
+  - *platform_wallet_ffi
+  - *sdk_ffi
+
+rs-unified-sdk-jni:
+  - packages/rs-unified-sdk-jni/**
   - *platform_wallet_ffi
   - *sdk_ffi
 

--- a/.github/package-filters/rs-packages.yml
+++ b/.github/package-filters/rs-packages.yml
@@ -10,6 +10,12 @@ token-history-contract: &token-history-contract
   - packages/token-history-contract/schema/**
   - packages/token-history-contract/Cargo.toml
 
+document-history-contract: &document-history-contract
+  - .github/workflows/tests*
+  - packages/document-history-contract/src/**
+  - packages/document-history-contract/schema/**
+  - packages/document-history-contract/Cargo.toml
+
 keyword-search-contract: &keyword-search-contract
   - .github/workflows/tests*
   - packages/keyword-search-contract/src/**
@@ -54,6 +60,7 @@ data-contracts: &data-contracts
   - *wallet-utils-contract
   - *token-history-contract
   - *keyword-search-contract
+  - *document-history-contract
 
 dpp: &dpp
   - .github/workflows/tests*
@@ -188,6 +195,12 @@ platform-wallet-ffi: &platform_wallet_ffi
 rs-unified-sdk-ffi:
   - .github/workflows/tests*
   - packages/rs-unified-sdk-ffi/**
+  - *platform_wallet_ffi
+  - *sdk_ffi
+
+rs-unified-sdk-jni:
+  - .github/workflows/tests*
+  - packages/rs-unified-sdk-jni/**
   - *platform_wallet_ffi
   - *sdk_ffi
 

--- a/.github/package-filters/test-suite-triggers.yml
+++ b/.github/package-filters/test-suite-triggers.yml
@@ -28,6 +28,8 @@ run:
   - packages/dpns-contract/**
   - packages/withdrawals-contract/**
   - packages/token-history-contract/**
+  - packages/document-history-contract/**
+  - packages/keyword-search-contract/**
   - packages/wallet-utils-contract/**
   # Local network scripts and action
   - .github/actions/local-network/**

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -188,6 +188,7 @@ jobs:
               - packages/dapi-grpc/**
               - packages/dashpay-contract/**
               - packages/data-contracts/**
+              - packages/document-history-contract/**
               - packages/dpns-contract/**
               - packages/keyword-search-contract/**
               - packages/masternode-reward-shares-contract/**


### PR DESCRIPTION
## Issue being fixed or feature implemented

Pushes and PRs that touch only `packages/rs-unified-sdk-jni` never trigger the Rust workspace tests job: the crate is absent from `.github/package-filters/rs-packages-no-workflows.yml`, so the `changes` job in `tests.yml` reports no Rust packages changed and `cargo fmt` / `clippy` / `cargo test` are skipped entirely. This is exactly how misformatted code from #4192 landed on `v4.1-dev` and broke the `cargo fmt --check --all` step for every unrelated PR (fixed directly in bcd0ac21a1). The dedicated `kotlin-sdk-build.yml` workflow does trigger on the crate, but it only builds the JNI library and runs emulator tests — it never runs fmt or clippy.

Auditing every file in `.github/package-filters/` against the root `Cargo.toml` workspace members and the yarn workspaces turned up more of the same class of gap:

- `packages/document-history-contract` (Rust crate, added with the document-history work) had no filter entry and was missing from the `data-contracts` alias — contract-only changes skipped Rust CI too.
- `@dashevo/document-history-contract` and `@dashevo/keyword-search-contract` are yarn workspaces with mocha unit suites that were never wired into the JS test matrix.
- `document-history-contract` was also missing from the inline `swift-sdk-changed` filter in `tests.yml`, even though `rs-sdk-ffi` embeds it via `data-contracts`.

## What was done?

- **`rs-packages-no-workflows.yml`** (gates the Rust workspace tests): added `rs-unified-sdk-jni` with its dependency closure (`platform-wallet-ffi` + `rs-sdk-ffi` aliases, mirroring the `rs-unified-sdk-ffi` entry), and `document-history-contract` (own entry + `data-contracts` alias, mirroring its optional dependency in `packages/data-contracts/Cargo.toml`).
- **`js-packages-no-workflows.yml` / `js-packages-direct.yml`** (gate the JS test matrix): added entries for both contract packages and aliased them into `@dashevo/wasm-dpp` like the other embedded system contracts. Neither has JS-side dependents, so no other consumer lists change.
- **`tests.yml`**: added `packages/document-history-contract/**` to the inline `swift-sdk-changed` filter.
- **`rs-packages.yml`, `rs-packages-direct.yml`, `js-packages.yml`, `test-suite-triggers.yml`**: same additions for consistency. Note these four files are not referenced by any workflow anymore (only the `-no-workflows` pair and `js-packages-direct.yml` are used by `tests.yml`), so they are kept in sync here rather than extended in behavior — deleting them could be a follow-up if they are truly dead.

After this change, all 46 Cargo workspace members are matched by at least one pattern in the live Rust filter.

## How Has This Been Tested?

Validated with a script that:
- parses all touched YAML files (anchors/aliases resolve cleanly);
- checks every workspace member in the root `Cargo.toml` against the live Rust filter's patterns — no uncovered members remain;
- simulates the `dorny/paths-filter` matching: a `packages/rs-unified-sdk-jni/src/lib.rs` change now matches the `rs-unified-sdk-jni` key (so `rs-packages != '[]'` and the Rust workspace job runs), and a `document-history-contract` change cascades through `data-contracts` → `dpp` → dependents, matching the behavior of the existing contract crates.

## Breaking Changes

None — CI-only. The new filter keys can only add test jobs for changes that previously ran none.

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [ ] I have made corresponding changes to the documentation if needed

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone

🤖 Generated with [Claude Code](https://claude.com/claude-code)