### PR TITLE
fix(drive-abci): report configured main control group authority when unauthorized

### DIFF
--- a/packages/rs-dpp/src/data_contract/associated_token/token_configuration/methods/authorized_action_takers_for_configuration_item/v0/mod.rs
+++ b/packages/rs-dpp/src/data_contract/associated_token/token_configuration/methods/authorized_action_takers_for_configuration_item/v0/mod.rs
@@ -308,6 +308,24 @@ mod tests {
     }
 
     #[test]
+    fn controlling_main_group_change_reports_configured_rule_verbatim() {
+        for takers in [
+            AuthorizedActionTakers::NoOne,
+            AuthorizedActionTakers::ContractOwner,
+            AuthorizedActionTakers::MainGroup,
+            AuthorizedActionTakers::Group(0),
+            AuthorizedActionTakers::Identity(Identifier::from([7u8; 32])),
+        ] {
+            let mut c = TokenConfigurationV0::default_most_restrictive();
+            c.set_main_control_group_can_be_modified(takers);
+            let result = c.controlling_action_takers_for_configuration_item(
+                &TokenConfigurationChangeItem::MainControlGroup(Some(3)),
+            );
+            assert_eq!(result, takers);
+        }
+    }
+
+    #[test]
     fn marketplace_trade_mode_returns_authorized_to_make_change() {
         let c = TokenConfigurationV0::default_most_restrictive();
         let result = c.authorized_action_takers_for_configuration_item(

--- a/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/batch/action_validation/token/token_config_update_transition_action/state_v0/mod.rs
+++ b/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/batch/action_validation/token/token_config_update_transition_action/state_v0/mod.rs
@@ -43,6 +43,7 @@ pub(in crate::execution::validation::state_transition::state_transitions::batch:
     /// `main_control_group_can_be_modified`. The v0 report must stay unchanged for
     /// protocol versions where it is already live; newer validation versions pass the
     /// controlling rule here.
+    #[allow(clippy::too_many_arguments)]
     fn validate_state_v0_with_reported_action_takers(
         &self,
         platform: &PlatformStateRef,
@@ -75,6 +76,7 @@ impl TokenConfigUpdateTransitionActionStateValidationV0 for TokenConfigUpdateTra
         )
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn validate_state_v0_with_reported_action_takers(
         &self,
         platform: &PlatformStateRef,

--- a/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/batch/action_validation/token/token_config_update_transition_action/state_v0/mod.rs
+++ b/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/batch/action_validation/token/token_config_update_transition_action/state_v0/mod.rs
@@ -35,6 +35,24 @@ pub(in crate::execution::validation::state_transition::state_transitions::batch:
         transaction: TransactionArg,
         platform_version: &PlatformVersion,
     ) -> Result<SimpleConsensusValidationResult, Error>;
+
+    /// Same as `validate_state_v0`, but reports `reported_action_takers_on_unauthorized`
+    /// in the `UnauthorizedTokenActionError` instead of
+    /// `authorized_action_takers_for_configuration_item`, which reports `NoOne` for
+    /// `MainControlGroup` change items regardless of
+    /// `main_control_group_can_be_modified`. The v0 report must stay unchanged for
+    /// protocol versions where it is already live; newer validation versions pass the
+    /// controlling rule here.
+    fn validate_state_v0_with_reported_action_takers(
+        &self,
+        platform: &PlatformStateRef,
+        owner_id: Identifier,
+        block_info: &BlockInfo,
+        execution_context: &mut StateTransitionExecutionContext,
+        transaction: TransactionArg,
+        platform_version: &PlatformVersion,
+        reported_action_takers_on_unauthorized: Option<AuthorizedActionTakers>,
+    ) -> Result<SimpleConsensusValidationResult, Error>;
 }
 impl TokenConfigUpdateTransitionActionStateValidationV0 for TokenConfigUpdateTransitionAction {
     fn validate_state_v0(
@@ -45,6 +63,27 @@ impl TokenConfigUpdateTransitionActionStateValidationV0 for TokenConfigUpdateTra
         execution_context: &mut StateTransitionExecutionContext,
         transaction: TransactionArg,
         platform_version: &PlatformVersion,
+    ) -> Result<SimpleConsensusValidationResult, Error> {
+        self.validate_state_v0_with_reported_action_takers(
+            platform,
+            owner_id,
+            block_info,
+            execution_context,
+            transaction,
+            platform_version,
+            None,
+        )
+    }
+
+    fn validate_state_v0_with_reported_action_takers(
+        &self,
+        platform: &PlatformStateRef,
+        owner_id: Identifier,
+        block_info: &BlockInfo,
+        execution_context: &mut StateTransitionExecutionContext,
+        transaction: TransactionArg,
+        platform_version: &PlatformVersion,
+        reported_action_takers_on_unauthorized: Option<AuthorizedActionTakers>,
     ) -> Result<SimpleConsensusValidationResult, Error> {
         let validation_result = self.base().validate_state(
             platform,
@@ -119,15 +158,19 @@ impl TokenConfigUpdateTransitionActionStateValidationV0 for TokenConfigUpdateTra
             &ActionTaker::SingleIdentity(owner_id),
             goal,
         ) {
+            let reported_action_takers =
+                reported_action_takers_on_unauthorized.unwrap_or_else(|| {
+                    token_configuration.authorized_action_takers_for_configuration_item(
+                        self.update_token_configuration_item(),
+                    )
+                });
             return Ok(SimpleConsensusValidationResult::new_with_error(
                 ConsensusError::StateError(StateError::UnauthorizedTokenActionError(
                     UnauthorizedTokenActionError::new(
                         self.token_id(),
                         owner_id,
                         "config_update".to_string(),
-                        token_configuration.authorized_action_takers_for_configuration_item(
-                            self.update_token_configuration_item(),
-                        ),
+                        reported_action_takers,
                     ),
                 )),
             ));

--- a/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/batch/action_validation/token/token_config_update_transition_action/state_v1/mod.rs
+++ b/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/batch/action_validation/token/token_config_update_transition_action/state_v1/mod.rs
@@ -81,13 +81,17 @@ impl TokenConfigUpdateTransitionActionStateValidationV1 for TokenConfigUpdateTra
             }
         }
 
-        let validation_result = self.validate_state_v0(
+        // Pass the controlling rule so an unauthorized `MainControlGroup` change item
+        // is reported with `main_control_group_can_be_modified` instead of the
+        // hardcoded `NoOne` that v0 reports.
+        let validation_result = self.validate_state_v0_with_reported_action_takers(
             platform,
             owner_id,
             block_info,
             execution_context,
             transaction,
             platform_version,
+            Some(authorized_action_takers),
         )?;
         if !validation_result.is_valid() {
             return Ok(validation_result);

--- a/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/batch/tests/token/config_update/mod.rs
+++ b/packages/rs-drive-abci/src/execution/validation/state_transition/state_transitions/batch/tests/token/config_update/mod.rs
@@ -1708,6 +1708,317 @@ mod token_config_update_tests {
         }
 
         #[tokio::test]
+        async fn test_token_config_update_by_group_member_changing_main_control_group() {
+            let platform_version = PlatformVersion::latest();
+            let mut platform = TestPlatformBuilder::new()
+                .with_latest_protocol_version()
+                .build_with_mock_rpc()
+                .set_genesis_state();
+
+            let mut rng = StdRng::seed_from_u64(49853);
+
+            let platform_state = platform.state.load();
+
+            let (identity, signer, key) =
+                setup_identity(&mut platform, rng.gen(), dash_to_credits!(0.5));
+
+            let (identity_2, signer_2, key_2) =
+                setup_identity(&mut platform, rng.gen(), dash_to_credits!(0.5));
+
+            let (contract, token_id) = create_token_contract_with_owner_identity(
+                &mut platform,
+                identity.id(),
+                Some(|token_configuration: &mut TokenConfiguration| {
+                    token_configuration
+                        .set_main_control_group_can_be_modified(AuthorizedActionTakers::Group(0));
+                }),
+                None,
+                Some(
+                    [(
+                        0,
+                        Group::V0(GroupV0 {
+                            members: [(identity.id(), 1), (identity_2.id(), 1)].into(),
+                            required_power: 2,
+                        }),
+                    )]
+                    .into(),
+                ),
+                None,
+                platform_version,
+            );
+
+            let action_id = TokenConfigUpdateTransition::calculate_action_id_with_fields(
+                token_id.as_bytes(),
+                identity.id().as_bytes(),
+                2,
+                &TokenConfigurationChangeItem::MainControlGroup(Some(0)),
+                platform_version,
+            )
+            .expect("expected to calculate action id");
+
+            let config_update_transition = BatchTransition::new_token_config_update_transition(
+                token_id,
+                identity.id(),
+                contract.id(),
+                0,
+                TokenConfigurationChangeItem::MainControlGroup(Some(0)),
+                None,
+                Some(GroupStateTransitionInfoStatus::GroupStateTransitionInfoProposer(0)),
+                &key,
+                2,
+                0,
+                &signer,
+                platform_version,
+                None,
+            )
+            .await
+            .expect("expect to create documents batch transition");
+
+            let config_update_transition_serialized_transition = config_update_transition
+                .serialize_to_bytes()
+                .expect("expected documents batch serialized state transition");
+
+            let transaction = platform.drive.grove.start_transaction();
+
+            let processing_result = platform
+                .platform
+                .process_raw_state_transitions(
+                    &[config_update_transition_serialized_transition.clone()],
+                    &platform_state,
+                    &BlockInfo::default(),
+                    &transaction,
+                    platform_version,
+                    false,
+                    None,
+                )
+                .expect("expected to process state transition");
+
+            assert_matches!(
+                processing_result.execution_results().as_slice(),
+                [StateTransitionExecutionResult::SuccessfulExecution { .. }]
+            );
+
+            platform
+                .drive
+                .grove
+                .commit_transaction(transaction)
+                .unwrap()
+                .expect("expected to commit transaction");
+
+            let new_contract = platform
+                .drive
+                .fetch_contract(
+                    contract.id().to_buffer(),
+                    None,
+                    None,
+                    None,
+                    platform_version,
+                )
+                .unwrap()
+                .expect("expected to fetch contract")
+                .expect("expected contract");
+            let updated_token_config = new_contract
+                .contract
+                .expected_token_configuration(0)
+                .expect("expected token configuration");
+            // only proposed so far, group power 1 of required 2
+            assert_eq!(updated_token_config.main_control_group(), None);
+
+            let config_update_transition = BatchTransition::new_token_config_update_transition(
+                token_id,
+                identity_2.id(),
+                contract.id(),
+                0,
+                TokenConfigurationChangeItem::MainControlGroup(Some(0)),
+                None,
+                Some(
+                    GroupStateTransitionInfoStatus::GroupStateTransitionInfoOtherSigner(
+                        GroupStateTransitionInfo {
+                            group_contract_position: 0,
+                            action_id,
+                            action_is_proposer: false,
+                        },
+                    ),
+                ),
+                &key_2,
+                2,
+                0,
+                &signer_2,
+                platform_version,
+                None,
+            )
+            .await
+            .expect("expect to create documents batch transition");
+
+            let config_update_transition_serialized_transition = config_update_transition
+                .serialize_to_bytes()
+                .expect("expected documents batch serialized state transition");
+
+            let transaction = platform.drive.grove.start_transaction();
+
+            let processing_result = platform
+                .platform
+                .process_raw_state_transitions(
+                    &[config_update_transition_serialized_transition.clone()],
+                    &platform_state,
+                    &BlockInfo::default(),
+                    &transaction,
+                    platform_version,
+                    false,
+                    None,
+                )
+                .expect("expected to process state transition");
+
+            assert_matches!(
+                processing_result.execution_results().as_slice(),
+                [StateTransitionExecutionResult::SuccessfulExecution { .. }]
+            );
+
+            platform
+                .drive
+                .grove
+                .commit_transaction(transaction)
+                .unwrap()
+                .expect("expected to commit transaction");
+
+            let new_contract = platform
+                .drive
+                .fetch_contract(
+                    contract.id().to_buffer(),
+                    None,
+                    None,
+                    None,
+                    platform_version,
+                )
+                .unwrap()
+                .expect("expected to fetch contract")
+                .expect("expected contract");
+            let updated_token_config = new_contract
+                .contract
+                .expected_token_configuration(0)
+                .expect("expected token configuration");
+            assert_eq!(updated_token_config.main_control_group(), Some(0));
+        }
+
+        #[tokio::test]
+        async fn test_token_config_update_main_control_group_unauthorized_reports_configured_rule()
+        {
+            let platform_version = PlatformVersion::latest();
+            let mut platform = TestPlatformBuilder::new()
+                .with_latest_protocol_version()
+                .build_with_mock_rpc()
+                .set_genesis_state();
+
+            let mut rng = StdRng::seed_from_u64(49853);
+
+            let platform_state = platform.state.load();
+
+            let (identity, _, _) = setup_identity(&mut platform, rng.gen(), dash_to_credits!(0.5));
+
+            let (identity_2, _, _) =
+                setup_identity(&mut platform, rng.gen(), dash_to_credits!(0.5));
+
+            let (identity_3, signer_3, key_3) =
+                setup_identity(&mut platform, rng.gen(), dash_to_credits!(0.5));
+
+            let (contract, token_id) = create_token_contract_with_owner_identity(
+                &mut platform,
+                identity.id(),
+                Some(|token_configuration: &mut TokenConfiguration| {
+                    token_configuration
+                        .set_main_control_group_can_be_modified(AuthorizedActionTakers::Group(0));
+                }),
+                None,
+                Some(
+                    [(
+                        0,
+                        Group::V0(GroupV0 {
+                            members: [(identity.id(), 1), (identity_2.id(), 1)].into(),
+                            required_power: 2,
+                        }),
+                    )]
+                    .into(),
+                ),
+                None,
+                platform_version,
+            );
+
+            // identity_3 is neither the owner nor a member of group 0
+            let config_update_transition = BatchTransition::new_token_config_update_transition(
+                token_id,
+                identity_3.id(),
+                contract.id(),
+                0,
+                TokenConfigurationChangeItem::MainControlGroup(Some(0)),
+                None,
+                None,
+                &key_3,
+                2,
+                0,
+                &signer_3,
+                platform_version,
+                None,
+            )
+            .await
+            .expect("expect to create documents batch transition");
+
+            let config_update_transition_serialized_transition = config_update_transition
+                .serialize_to_bytes()
+                .expect("expected documents batch serialized state transition");
+
+            let transaction = platform.drive.grove.start_transaction();
+
+            let processing_result = platform
+                .platform
+                .process_raw_state_transitions(
+                    &[config_update_transition_serialized_transition.clone()],
+                    &platform_state,
+                    &BlockInfo::default(),
+                    &transaction,
+                    platform_version,
+                    false,
+                    None,
+                )
+                .expect("expected to process state transition");
+
+            // The error must report the configured rule (Group(0)), not NoOne
+            assert_matches!(
+                processing_result.execution_results().as_slice(),
+                [PaidConsensusError {
+                    error: ConsensusError::StateError(StateError::UnauthorizedTokenActionError(
+                        error
+                    )),
+                    ..
+                }] if *error.authorized_action_takers() == AuthorizedActionTakers::Group(0)
+            );
+
+            platform
+                .drive
+                .grove
+                .commit_transaction(transaction)
+                .unwrap()
+                .expect("expected to commit transaction");
+
+            let new_contract = platform
+                .drive
+                .fetch_contract(
+                    contract.id().to_buffer(),
+                    None,
+                    None,
+                    None,
+                    platform_version,
+                )
+                .unwrap()
+                .expect("expected to fetch contract")
+                .expect("expected contract");
+            let updated_token_config = new_contract
+                .contract
+                .expected_token_configuration(0)
+                .expect("expected token configuration");
+            assert_eq!(updated_token_config.main_control_group(), None);
+        }
+
+        #[tokio::test]
         async fn test_token_config_update_by_group_member_changing_minting_destination_group() {
             let platform_version = PlatformVersion::latest();
             let mut platform = TestPlatformBuilder::new()


### PR DESCRIPTION
## Issue being fixed or feature implemented

Replaces #4000, reworked on top of the design introduced in #4154.

`TokenConfigurationChangeItem::MainControlGroup` is authorized by the token field `main_control_group_can_be_modified`. The validation gate already used that field correctly, but the `UnauthorizedTokenActionError` produced when the check fails reported the takers from `authorized_action_takers_for_configuration_item`, which hardcodes `NoOne` for `MainControlGroup`. That made failures look like the action was impossible for everyone, when the configured rule could be `ContractOwner`, `MainGroup`, `Group(0)`, or a specific identity:

```text
Access denied. Required actor: NoOne      # reported
Access denied. Required actor: Group(0)   # actual configured rule
```

Since #4000 was opened, #4154 added `controlling_action_takers_for_configuration_item` (which returns `main_control_group_can_be_modified`) and a version-gated `state_v1` validation that uses it for the group-binding check. That superseded the original approach here of changing `authorized_action_takers_for_configuration_item` directly — the legacy helper's report must stay unchanged for protocol versions where it is already live.

However, the misleading report was still reachable at the new validation version: `validate_state_v1` delegates the main authorization check to `validate_state_v0`, which still built the error from the legacy helper. This PR fixes that remaining path.

## What was done?

- Added `validate_state_v0_with_reported_action_takers`, which takes an optional override for the action takers reported in `UnauthorizedTokenActionError`. `validate_state_v0` passes `None`, so behavior at validation version 0 is byte-for-byte unchanged.
- `validate_state_v1` now passes the already-computed controlling rule, so unauthorized `MainControlGroup` updates report `main_control_group_can_be_modified` instead of `NoOne`. For every other change item the controlling rule equals the legacy report, so nothing else changes.
- Added a dpp unit test that `controlling_action_takers_for_configuration_item` reports each configured `main_control_group_can_be_modified` value verbatim.
- Added Drive ABCI coverage:
  - `test_token_config_update_main_control_group_unauthorized_reports_configured_rule` — a non-member submitting a `MainControlGroup` change gets `UnauthorizedTokenActionError` reporting `Group(0)` (the configured rule), not `NoOne`.
  - `test_token_config_update_by_group_member_changing_main_control_group` — the existing valid path where a configured group updates the main control group once enough group power has signed.

## How Has This Been Tested?

```bash
cargo test -p dpp authorized_action_takers_for_configuration_item
cargo test -p drive-abci token_config_update
```

## Breaking Changes

None. Validation version 0 output is unchanged; the corrected report only applies at validation version 1 (protocol v13, not yet released).

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [ ] I have made corresponding changes to the documentation if needed

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved authorization handling for token configuration changes involving the main control group.
  * Unauthorized changes now report the correctly configured authorized action takers.
  * Valid group members can complete main control group updates once the required quorum is reached.

* **Tests**
  * Added coverage for supported authorization rules, successful group-controlled changes, and unauthorized attempts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->