### PR TITLE
build(docker): build evo-sdk + wasm-sdk in the test-suite image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -357,7 +357,7 @@ RUN --mount=type=secret,id=AWS \
 
 RUN --mount=type=secret,id=AWS \
     source /root/env; \
-    cargo binstall wasm-bindgen-cli@0.2.108 cargo-chef@0.1.72 \
+    cargo binstall wasm-bindgen-cli@0.2.108 cargo-chef@0.1.72 wasm-pack \
     --locked \
     --no-discover-github-token \
     --disable-telemetry \
@@ -655,6 +655,7 @@ RUN --mount=type=cache,sharing=shared,id=cargo_registry_index,target=${CARGO_HOM
     --recipe-path recipe.json \
     --profile "$CARGO_BUILD_PROFILE" \
     --package wasm-dpp \
+    --package wasm-sdk \
     --target wasm32-unknown-unknown \
     --locked && \
     if [[ -x /usr/bin/sccache ]]; then sccache --show-stats; fi
@@ -666,6 +667,7 @@ COPY --parents \
     Cargo.toml \
     rust-toolchain.toml \
     .cargo \
+    packages/scripts \
     packages/rs-dapi \
     packages/rs-dash-async \
     packages/rs-dash-event-bus \
@@ -682,9 +684,18 @@ COPY --parents \
     packages/rs-unified-sdk-ffi \
     packages/rs-unified-sdk-jni \
     packages/rs-json-schema-compatibility-validator \
+    # rs-sdk stack (needed to build wasm-sdk / evo-sdk for the test suite)
+    packages/rs-context-provider \
+    packages/rs-dapi-client \
+    packages/rs-dash-platform-macros \
+    packages/rs-drive \
+    packages/rs-drive-proof-verifier \
+    packages/rs-sdk \
+    packages/rs-sdk-trusted-context-provider \
     # Common
     packages/wasm-dpp \
     packages/wasm-dpp2 \
+    packages/wasm-sdk \
     packages/dashpay-contract \
     packages/withdrawals-contract \
     packages/wallet-utils-contract \
@@ -706,6 +717,7 @@ COPY --parents \
     packages/wallet-lib \
     packages/js-dash-sdk \
     packages/dash-spv \
+    packages/js-evo-sdk \
     /platform/
 
 # We unset CFLAGS CXXFLAGS because they hold `march` flags which break wasm32 build
@@ -722,6 +734,8 @@ RUN --mount=type=cache,sharing=shared,id=cargo_registry_index,target=${CARGO_HOM
     export SKIP_GRPC_PROTO_BUILD=1 && \
     # Build JS Dash SDK and dependencies
     yarn run ultra -r --filter '+dash' --build && \
+    # Build Evo SDK (and wasm-sdk) — the platform test suite's proof verifier
+    yarn run ultra -r --filter '+@dashevo/evo-sdk' --build && \
     if [[ -x /usr/bin/sccache ]]; then sccache --show-stats; fi && \
     # Remove target directory and rust packages to save space
     rm -rf target packages/rs-*


### PR DESCRIPTION
## Issue
The `v4.1.0-beta.1` release build failed on the **Test Suite image** ([run](https://github.com/dashpay/platform/actions/runs/30009762463/job/89214532383)):
```
yarn workspaces focus --production @dashevo/platform-test-suite
→ YN0001: @dashevo/evo-sdk@workspace:*: Workspace not found
```

## Root cause
`packages/platform-test-suite` gained a **production** dependency on `@dashevo/evo-sdk` — the EvoSDK-backed platform proof verifier wired into every client factory (`lib/test/createPlatformProofVerifier.js`), which quorum-verifies platform responses. `evo-sdk` needs the compiled `@dashevo/wasm-sdk`. Neither was present in the Dockerfile's `build-js` stage. The Test Suite image only builds **on release**, so PR CI (which builds the suite via a full `yarn build`) never caught it. It built fine at v4.0.0, before evo-sdk was added.

## What was done (all in the `build-js` stage)
- **Cook** wasm-sdk's wasm32 deps: `cargo chef cook … --package wasm-sdk`.
- **COPY** wasm-sdk's transitive Rust closure (`rs-sdk`, `rs-drive`, `rs-drive-proof-verifier`, `rs-dapi-client`, `rs-context-provider`, `rs-sdk-trusted-context-provider`, `rs-dash-platform-macros`) + `wasm-sdk` + `js-evo-sdk`.
- **COPY** `packages/scripts` — the shared `build-wasm.sh` that wasm-sdk's build invokes (wasm-dpp uses its own local copy, so the image never needed it before).
- **Install** `wasm-pack` in the `deps` stage — wasm-sdk builds via wasm-pack (wasm-dpp uses plain cargo + wasm-bindgen); it was only ever on CI runners, never in the image.
- **Build** evo-sdk (and wasm-sdk) via a second `ultra --filter '+@dashevo/evo-sdk' --build`.

## Verification
- Rust closure recomputed from `cargo metadata` → 0 missing; JS closure of platform-test-suite → 0 missing.
- `ultra --filter '+@dashevo/evo-sdk' --build --dryRun` confirms topological order wasm-sdk → evo-sdk.
- Both build profiles (dev/release) converge on `packages/scripts/build-wasm.sh`; required tooling covered (wasm-pack added, wasm-bindgen present, wasm-opt/wasm-snip gracefully skipped).
- Independent review pass caught the `packages/scripts` + `wasm-pack` gaps (folded in).
- **Not** locally Docker-built (heavy Rust+WASM compile); end-to-end gate is the next release (`v4.1.0-beta.2`) build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)