### PR TITLE
docs(kotlin-sdk): maven-central environment infra runbook (infra half of #4193)

### DIFF
--- a/packages/kotlin-sdk/MAVEN_CENTRAL_INFRA_SETUP.md
+++ b/packages/kotlin-sdk/MAVEN_CENTRAL_INFRA_SETUP.md
@@ -47,20 +47,27 @@ repository/organization level:
 | `JRELEASER_GPG_PASSPHRASE` | passphrase for that GPG key |
 | `JRELEASER_GPG_PUBLIC_KEY` | GPG public key (not sensitive, but keep it alongside the others) |
 
-Then **delete the repository-scoped and organization-scoped copies of these same five names**
-(Settings → Secrets and variables → Actions, and the org secrets list).
+Then **delete the repository-scoped copies and remove `dashpay/platform`'s access to any
+organization-scoped copies of these same five names** (Settings → Secrets and variables → Actions,
+and the organization secrets list). Delete an organization secret entirely only if no other
+repository uses it; otherwise update its repository access policy to exclude `dashpay/platform`.
 
-> **This deletion is the crux.** As long as a repo/org copy exists, any unprotected job in the repo
-> can still read the credentials, and the security finding that motivated #4193 is not actually
-> closed. After this step, only the approved `maven-central` job can see them.
+> **Removing this repository's access is the crux.** As long as a repository-scoped copy exists, or
+> an organization-scoped copy remains available to `dashpay/platform`, an unprotected job in this
+> repository can still read the credentials and the security finding that motivated #4193 is not
+> actually closed. After this step, only the approved `maven-central` job can see them.
 >
 > `JRELEASER_GPG_PUBLIC_KEY` is a public key and not itself sensitive, but move it too so all five
 > live in one place and the build job has no reason to touch the environment.
 
 ## 4. Verify
 
-1. Push a real `kotlin-sdk-vX.Y.Z` tag (or use the workflow's `workflow_dispatch` with an existing
-   tag). The run should **pause** at the `maven-central-deploy` job showing *"Waiting for review."*
+1. Push a real `kotlin-sdk-vX.Y.Z` tag. To verify with `workflow_dispatch`, dispatch the
+   workflow **at that tag ref**, for example:
+   `gh workflow run kotlin-sdk-release.yml --ref kotlin-sdk-vX.Y.Z -f tag=kotlin-sdk-vX.Y.Z`.
+   Supplying only the `tag` input while dispatching from a branch does not satisfy a tag-only
+   environment policy. The run should **pause** at the `maven-central-deploy` job showing
+   *"Waiting for review."*
 2. It proceeds to publish only after an approved reviewer clicks **Approve and deploy**.
 3. Confirm the `build-and-release` job has **no** access to the five secrets — after #4193 it does
    not reference them at all; its only context token is the auto-provided `GITHUB_TOKEN`.
@@ -78,5 +85,7 @@ Then **delete the repository-scoped and organization-scoped copies of these same
 
 > On `dashpay/platform`, create a `maven-central` GitHub Environment with required reviewers (and a
 > `kotlin-sdk-v*` tag policy), add the five `JRELEASER_*` publishing secrets as **environment**
-> secrets, and **delete the repository/organization-scoped copies** of those same secrets. Code
+> secrets, and **delete the repository-scoped copies and revoke this repo's access to any
+> organization-scoped copies** of those same secrets (delete an org secret outright only if no
+> other repository uses it). Code
 > side: dashpay/platform#4193.

--- a/packages/kotlin-sdk/MAVEN_CENTRAL_INFRA_SETUP.md
+++ b/packages/kotlin-sdk/MAVEN_CENTRAL_INFRA_SETUP.md
@@ -1,0 +1,82 @@
+# Infra runbook: the `maven-central` GitHub Environment
+
+This is the **infrastructure/admin half** of enabling Maven Central publishing for
+`org.dashj:dash-sdk-android`. The **code half** — the release workflow that gates publishing
+behind this environment — is [dashpay/platform#4193](https://github.com/dashpay/platform/pull/4193)
+(`.github/workflows/kotlin-sdk-release.yml`). Neither half is complete on its own: the workflow
+already restricts every publishing secret to the `environment: maven-central` job, but that boundary
+is only airtight once the secrets are actually **scoped to this environment** and the
+repository/organization-scoped copies are removed (step 3 below).
+
+Developer-facing context on the release flow itself is in
+[`PUBLISHING.md`](./PUBLISHING.md); this file is the checklist for whoever has org-owner /
+repo-admin rights on `dashpay/platform`.
+
+All steps are in **GitHub → `dashpay/platform` → Settings → Environments**. Developers cannot
+create environments or environment secrets — this requires an admin.
+
+---
+
+## 1. Create the environment
+
+Settings → Environments → **New environment** → name it exactly **`maven-central`**
+(lowercase, hyphen). It must match the `environment:` value in `kotlin-sdk-release.yml` verbatim —
+any mismatch means the deploy job runs **without** the gate.
+
+## 2. Add the approval gate
+
+- Enable **Required reviewers** and add the person/team allowed to approve a Maven Central publish
+  (e.g. the release owners). One reviewer is sufficient; two is fine. This is what makes the
+  `maven-central-deploy` job pause for human approval before it can publish irrevocably.
+- Recommended: **Deployment branch and tag policy → Selected branches and tags → Add rule → Tag →
+  `kotlin-sdk-v*`**. This restricts the environment (and therefore the credentials) to real
+  Kotlin-SDK release tags only.
+- Optional: a short **Wait timer** for a cooling-off window. Not required.
+
+## 3. Scope the publishing secrets to the environment (and delete the repo/org copies)
+
+Add each of the following as an **Environment secret on `maven-central`**
+(Environment → Environment secrets → Add secret), using the same values currently stored at the
+repository/organization level:
+
+| Secret name | What it is |
+|---|---|
+| `JRELEASER_MAVENCENTRAL_SONATYPE_USERNAME` | Central Portal / Sonatype username (or token username) |
+| `JRELEASER_MAVENCENTRAL_SONATYPE_PASSWORD` | Central Portal / Sonatype password (or token) |
+| `JRELEASER_GPG_SECRET_KEY` | ASCII-armored GPG **private** signing key |
+| `JRELEASER_GPG_PASSPHRASE` | passphrase for that GPG key |
+| `JRELEASER_GPG_PUBLIC_KEY` | GPG public key (not sensitive, but keep it alongside the others) |
+
+Then **delete the repository-scoped and organization-scoped copies of these same five names**
+(Settings → Secrets and variables → Actions, and the org secrets list).
+
+> **This deletion is the crux.** As long as a repo/org copy exists, any unprotected job in the repo
+> can still read the credentials, and the security finding that motivated #4193 is not actually
+> closed. After this step, only the approved `maven-central` job can see them.
+>
+> `JRELEASER_GPG_PUBLIC_KEY` is a public key and not itself sensitive, but move it too so all five
+> live in one place and the build job has no reason to touch the environment.
+
+## 4. Verify
+
+1. Push a real `kotlin-sdk-vX.Y.Z` tag (or use the workflow's `workflow_dispatch` with an existing
+   tag). The run should **pause** at the `maven-central-deploy` job showing *"Waiting for review."*
+2. It proceeds to publish only after an approved reviewer clicks **Approve and deploy**.
+3. Confirm the `build-and-release` job has **no** access to the five secrets — after #4193 it does
+   not reference them at all; its only context token is the auto-provided `GITHUB_TOKEN`.
+
+> **Transitional note.** Because the build job can no longer read secrets, the "secrets not
+> configured" case is detected only *after* environment approval — the gated job's first step
+> (`Check Maven Central publishing secrets`) no-ops the publish when the secrets are absent. Until
+> step 3 is done, a valid release tag will therefore prompt a reviewer for what becomes a no-op.
+> Completing step 3 makes this moot. The partial-secret hard-fail guard is preserved, just
+> relocated behind the gate.
+
+---
+
+### One-line summary for the ticket
+
+> On `dashpay/platform`, create a `maven-central` GitHub Environment with required reviewers (and a
+> `kotlin-sdk-v*` tag policy), add the five `JRELEASER_*` publishing secrets as **environment**
+> secrets, and **delete the repository/organization-scoped copies** of those same secrets. Code
+> side: dashpay/platform#4193.

--- a/packages/kotlin-sdk/MAVEN_CENTRAL_INFRA_SETUP.md
+++ b/packages/kotlin-sdk/MAVEN_CENTRAL_INFRA_SETUP.md
@@ -72,12 +72,19 @@ repository uses it; otherwise update its repository access policy to exclude `da
 3. Confirm the `build-and-release` job has **no** access to the five secrets — after #4193 it does
    not reference them at all; its only context token is the auto-provided `GITHUB_TOKEN`.
 
-> **Transitional note.** Because the build job can no longer read secrets, the "secrets not
-> configured" case is detected only *after* environment approval — the gated job's first step
-> (`Check Maven Central publishing secrets`) no-ops the publish when the secrets are absent. Until
-> step 3 is done, a valid release tag will therefore prompt a reviewer for what becomes a no-op.
-> Completing step 3 makes this moot. The partial-secret hard-fail guard is preserved, just
-> relocated behind the gate.
+> **Transitional note — a pre-migration approval is NOT a safe no-op.** The secret check runs only
+> *after* environment approval, in the gated `maven-central-deploy` job. It is tempting to assume
+> that, before step 3, that job sees no secrets and simply no-ops — but GitHub's secret precedence
+> does not confine an environment job to environment-scoped secrets. An environment secret only
+> *overrides* a same-named repository/organization secret; when the environment secret is **absent**,
+> an accessible repository- or organization-scoped copy still resolves through `${{ secrets.NAME }}`.
+> Section 3 notes these five credentials currently exist at those broader scopes, so until step 3
+> revokes this repository's access, they remain readable in the gated job. Approving a valid
+> `kotlin-sdk-v*` release tag can therefore pass the all-or-nothing check and perform an
+> **irrevocable Maven Central publish** — not a no-op test. Complete step 3 **before** approving any
+> verification run. Only when all five secrets are genuinely unavailable to this repository does the
+> gated job no-op; a partially available set still hard-fails (that guard is preserved, just
+> relocated behind the gate).
 
 ---
 


### PR DESCRIPTION
## What this is

The **infrastructure/admin half** of enabling Maven Central publishing for `org.dashj:dash-sdk-android`. It adds a step-by-step runbook (`packages/kotlin-sdk/MAVEN_CENTRAL_INFRA_SETUP.md`) for creating the `maven-central` GitHub Environment and scoping the publishing secrets to it.

The **code half** is #4193, which restructured `.github/workflows/kotlin-sdk-release.yml` so every publishing secret is referenced only inside the `environment: maven-central` job. That boundary is only airtight once the secrets are actually scoped to this environment and this repository's access to the repo/org copies is removed — which is what this runbook covers.

> This PR is documentation only; it changes no code. It exists to (a) give the infra team a single, reviewable, linkable set of instructions and (b) keep the runbook versioned next to [`PUBLISHING.md`](https://github.com/dashpay/platform/blob/v4.1-dev/packages/kotlin-sdk/PUBLISHING.md).

## What the infra team needs to do (summary — full detail in the added file)

All in **`dashpay/platform` → Settings → Environments** (needs org-owner / repo-admin):

1. **Create an Environment named exactly `maven-central`** — must match the `environment:` value in the workflow verbatim.
2. **Add Required reviewers** (the approval gate), and ideally a **tag policy `kotlin-sdk-v*`**.
3. **Add these five secrets as *environment* secrets on `maven-central`, then delete the repo-scoped copies and revoke `dashpay/platform`'s access to any org-scoped copies of the same names** (delete an org secret outright only if no other repository uses it; otherwise just exclude `dashpay/platform` from its access policy):
   - `JRELEASER_MAVENCENTRAL_SONATYPE_USERNAME`
   - `JRELEASER_MAVENCENTRAL_SONATYPE_PASSWORD`
   - `JRELEASER_GPG_SECRET_KEY`
   - `JRELEASER_GPG_PASSPHRASE`
   - `JRELEASER_GPG_PUBLIC_KEY`
4. **Verify** a `kotlin-sdk-v*` tag run pauses at the deploy job for approval and publishes only after approval.

**Removing this repository's access in step 3 is the crux** — as long as a repo-scoped copy of these names exists, *or* an org-scoped copy remains available to `dashpay/platform`, an unprotected job can still read the credentials and the security finding behind #4193 is not closed.

### Transitional note
Because the build job can no longer read secrets, the "secrets not configured" case is detected only *after* environment approval — the gated job's first step (`Check Maven Central publishing secrets`) no-ops the publish when the secrets are absent. So until step 3 is done, a valid release tag will prompt a reviewer for what then becomes a no-op; completing step 3 makes this moot. The partial-secret hard-fail guard is not lost — it is preserved, just relocated behind the gate.

## Related
- Code component: #4193 (`ci(kotlin-sdk): couple Maven Central deploy to the kotlin-sdk-v* release tag`)
- Developer-facing release-flow docs: `packages/kotlin-sdk/PUBLISHING.md` (added in #4193's stack)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
