### PR TITLE
fix(drive): version the compacted address-balance proof wire format

### DIFF
--- a/packages/rs-drive/src/drive/saved_block_transactions/fetch_compacted_address_balances/mod.rs
+++ b/packages/rs-drive/src/drive/saved_block_transactions/fetch_compacted_address_balances/mod.rs
@@ -1,4 +1,5 @@
 mod v0;
+mod v1;
 
 use crate::drive::Drive;
 use crate::error::drive::DriveError;
@@ -55,7 +56,12 @@ impl Drive {
     /// * `platform_version` - The platform version
     ///
     /// # Returns
-    /// A grovedb proof
+    /// A proof whose wire format depends on the protocol version: feature
+    /// version 0 returns a single GroveDB proof, feature version 1 returns
+    /// the two-proof `CompactedAddressBalanceProof` bincode envelope. The
+    /// client's `verify_compacted_address_balance_changes` dispatches its
+    /// decoder on the same protocol version, so both sides switch formats
+    /// together at the version boundary.
     pub fn prove_compacted_address_balance_changes(
         &self,
         start_block_height: u64,
@@ -67,7 +73,7 @@ impl Drive {
             .drive
             .methods
             .saved_block_transactions
-            .fetch_address_balances
+            .prove_compacted_address_balance_changes
         {
             0 => self.prove_compacted_address_balance_changes_v0(
                 start_block_height,
@@ -75,9 +81,15 @@ impl Drive {
                 transaction,
                 platform_version,
             ),
+            1 => self.prove_compacted_address_balance_changes_v1(
+                start_block_height,
+                limit,
+                transaction,
+                platform_version,
+            ),
             version => Err(Error::Drive(DriveError::UnknownVersionMismatch {
                 method: "prove_compacted_address_balance_changes".to_string(),
-                known_versions: vec![0],
+                known_versions: vec![0, 1],
                 received: version,
             })),
         }

--- a/packages/rs-drive/src/drive/saved_block_transactions/fetch_compacted_address_balances/v0/mod.rs
+++ b/packages/rs-drive/src/drive/saved_block_transactions/fetch_compacted_address_balances/v0/mod.rs
@@ -8,8 +8,6 @@ use grovedb::{Element, PathQuery, Query, SizedQuery, TransactionArg};
 use platform_version::version::PlatformVersion;
 use std::collections::BTreeMap;
 
-use crate::verify::address_funds::verify_compacted_address_balance_changes::CompactedAddressBalanceProof;
-
 /// Result type for fetched compacted address balance changes
 /// Each entry is (start_block, end_block, address_balance_map)
 pub type CompactedAddressBalanceChanges = Vec<(
@@ -189,15 +187,17 @@ impl Drive {
         Ok(compacted_changes)
     }
 
-    /// Version 0 implementation for proving compacted address balance changes.
+    /// Version 0 implementation for proving compacted address balance changes
+    /// — legacy single-proof wire format used by protocol versions whose
+    /// `prove_compacted_address_balance_changes` feature version is 0.
     ///
-    /// Uses two independently verifiable proofs:
-    /// 1. A descending predecessor proof authenticates which range, if any,
-    ///    contains `start_block_height`.
-    /// 2. A forward proof starts at that authenticated range (or at the
-    ///    request-derived fallback key when no range contains the height).
+    /// Uses a two-step approach:
+    /// 1. First query (non-proving): descending to find any range containing start_block_height
+    /// 2. Second query (proving): ascending from the found start_block or start_block_height
     ///
-    /// This ensures the proof covers all relevant ranges efficiently.
+    /// Kept byte-for-byte wire-compatible with the legacy
+    /// `verify_compacted_address_balance_changes_v0` decoder. The two-proof
+    /// envelope (predecessor authentication) lives in v1.
     pub(super) fn prove_compacted_address_balance_changes_v0(
         &self,
         start_block_height: u64,
@@ -207,7 +207,7 @@ impl Drive {
     ) -> Result<Vec<u8>, Error> {
         let path = Self::saved_compacted_block_transactions_address_balances_path_vec();
 
-        // Step 1: Authenticate the predecessor used to select the forward query.
+        // Step 1: Non-proving descending query to find any range containing start_block_height
         let mut desc_end_key = Vec::with_capacity(16);
         desc_end_key.extend_from_slice(&start_block_height.to_be_bytes());
         desc_end_key.extend_from_slice(&u64::MAX.to_be_bytes());
@@ -222,13 +222,6 @@ impl Drive {
             &desc_path_query,
             transaction,
             QueryResultType::QueryKeyElementPairResultType,
-            &mut vec![],
-            &platform_version.drive,
-        )?;
-
-        let predecessor_proof = self.grove_get_proved_path_query(
-            &desc_path_query,
-            transaction,
             &mut vec![],
             &platform_version.drive,
         )?;
@@ -269,27 +262,12 @@ impl Drive {
 
         let path_query = PathQuery::new(path, SizedQuery::new(query, limit, None));
 
-        let forward_proof = self.grove_get_proved_path_query(
+        self.grove_get_proved_path_query(
             &path_query,
             transaction,
             &mut vec![],
             &platform_version.drive,
-        )?;
-
-        bincode::encode_to_vec(
-            CompactedAddressBalanceProof {
-                predecessor_proof,
-                forward_proof,
-            },
-            bincode::config::standard()
-                .with_big_endian()
-                .with_no_limit(),
         )
-        .map_err(|e| {
-            Error::Protocol(Box::new(ProtocolError::CorruptedSerialization(format!(
-                "cannot encode compacted address balance proof: {e}"
-            ))))
-        })
     }
 }
 

--- a/packages/rs-drive/src/drive/saved_block_transactions/fetch_compacted_address_balances/v1/mod.rs
+++ b/packages/rs-drive/src/drive/saved_block_transactions/fetch_compacted_address_balances/v1/mod.rs
@@ -1,0 +1,118 @@
+use crate::drive::Drive;
+use crate::error::Error;
+use dpp::ProtocolError;
+use grovedb::query_result_type::QueryResultType;
+use grovedb::{PathQuery, Query, SizedQuery, TransactionArg};
+use platform_version::version::PlatformVersion;
+
+use crate::verify::address_funds::verify_compacted_address_balance_changes::CompactedAddressBalanceProof;
+
+impl Drive {
+    /// Version 1 implementation for proving compacted address balance changes
+    /// — the two-proof [`CompactedAddressBalanceProof`] bincode envelope used
+    /// by protocol versions whose `prove_compacted_address_balance_changes`
+    /// feature version is 1.
+    ///
+    /// Uses two independently verifiable proofs:
+    /// 1. A descending predecessor proof authenticates which range, if any,
+    ///    contains `start_block_height`.
+    /// 2. A forward proof starts at that authenticated range (or at the
+    ///    request-derived fallback key when no range contains the height).
+    ///
+    /// This ensures the proof covers all relevant ranges efficiently, and the
+    /// matching `verify_compacted_address_balance_changes_v1` decoder can
+    /// bind the forward-query start key to independently verified state.
+    pub(super) fn prove_compacted_address_balance_changes_v1(
+        &self,
+        start_block_height: u64,
+        limit: Option<u16>,
+        transaction: TransactionArg,
+        platform_version: &PlatformVersion,
+    ) -> Result<Vec<u8>, Error> {
+        let path = Self::saved_compacted_block_transactions_address_balances_path_vec();
+
+        // Step 1: Authenticate the predecessor used to select the forward query.
+        let mut desc_end_key = Vec::with_capacity(16);
+        desc_end_key.extend_from_slice(&start_block_height.to_be_bytes());
+        desc_end_key.extend_from_slice(&u64::MAX.to_be_bytes());
+
+        let mut desc_query = Query::new_with_direction(false); // descending
+        desc_query.insert_range_to_inclusive(..=desc_end_key);
+
+        let desc_path_query =
+            PathQuery::new(path.clone(), SizedQuery::new(desc_query, Some(1), None));
+
+        let (desc_results, _) = self.grove_get_path_query(
+            &desc_path_query,
+            transaction,
+            QueryResultType::QueryKeyElementPairResultType,
+            &mut vec![],
+            &platform_version.drive,
+        )?;
+
+        let predecessor_proof = self.grove_get_proved_path_query(
+            &desc_path_query,
+            transaction,
+            &mut vec![],
+            &platform_version.drive,
+        )?;
+
+        // Determine the actual start key for the proved query
+        // If we found a containing range, use its exact key
+        // Otherwise use (start_block_height, start_block_height) since end_block >= start_block always
+        let start_key = if let Some((key, _)) = desc_results.to_key_elements().into_iter().next() {
+            if key.len() == 16 {
+                let end_block = u64::from_be_bytes(key[8..16].try_into().unwrap());
+                // If this range contains start_block_height, use its exact key
+                if end_block >= start_block_height {
+                    key
+                } else {
+                    // No containing range, use (start_block_height, start_block_height)
+                    let mut key = Vec::with_capacity(16);
+                    key.extend_from_slice(&start_block_height.to_be_bytes());
+                    key.extend_from_slice(&start_block_height.to_be_bytes());
+                    key
+                }
+            } else {
+                let mut key = Vec::with_capacity(16);
+                key.extend_from_slice(&start_block_height.to_be_bytes());
+                key.extend_from_slice(&start_block_height.to_be_bytes());
+                key
+            }
+        } else {
+            let mut key = Vec::with_capacity(16);
+            key.extend_from_slice(&start_block_height.to_be_bytes());
+            key.extend_from_slice(&start_block_height.to_be_bytes());
+            key
+        };
+
+        // Step 2: Proved ascending query from start_key
+
+        let mut query = Query::new();
+        query.insert_range_from(start_key..);
+
+        let path_query = PathQuery::new(path, SizedQuery::new(query, limit, None));
+
+        let forward_proof = self.grove_get_proved_path_query(
+            &path_query,
+            transaction,
+            &mut vec![],
+            &platform_version.drive,
+        )?;
+
+        bincode::encode_to_vec(
+            CompactedAddressBalanceProof {
+                predecessor_proof,
+                forward_proof,
+            },
+            bincode::config::standard()
+                .with_big_endian()
+                .with_no_limit(),
+        )
+        .map_err(|e| {
+            Error::Protocol(Box::new(ProtocolError::CorruptedSerialization(format!(
+                "cannot encode compacted address balance proof: {e}"
+            ))))
+        })
+    }
+}

--- a/packages/rs-drive/src/verify/address_funds/verify_compacted_address_balance_changes/mod.rs
+++ b/packages/rs-drive/src/verify/address_funds/verify_compacted_address_balance_changes/mod.rs
@@ -1,4 +1,5 @@
 mod v0;
+mod v1;
 
 use crate::drive::Drive;
 use crate::error::drive::DriveError;
@@ -45,6 +46,14 @@ impl Drive {
     ///   - `RootHash`: The root hash of the Merkle tree.
     ///   - `VerifiedCompactedAddressBalanceChanges`: Vector of (start_block, end_block, address_balance_changes) tuples.
     /// - `Err(Error)`: If verification fails.
+    ///
+    /// # Wire format versioning
+    /// Feature version 0 decodes the legacy single GroveDB proof; feature
+    /// version 1 decodes the two-proof [`CompactedAddressBalanceProof`]
+    /// envelope. The server's
+    /// `prove_compacted_address_balance_changes` dispatches its encoder on
+    /// the same protocol version, so both sides switch formats together at
+    /// the version boundary.
     pub fn verify_compacted_address_balance_changes(
         proof: &[u8],
         start_block_height: u64,
@@ -64,9 +73,15 @@ impl Drive {
                 limit,
                 platform_version,
             ),
+            1 => Self::verify_compacted_address_balance_changes_v1(
+                proof,
+                start_block_height,
+                limit,
+                platform_version,
+            ),
             version => Err(Error::Drive(DriveError::UnknownVersionMismatch {
                 method: "verify_compacted_address_balance_changes".to_string(),
-                known_versions: vec![0],
+                known_versions: vec![0, 1],
                 received: version,
             })),
         }

--- a/packages/rs-drive/src/verify/address_funds/verify_compacted_address_balance_changes/v0/mod.rs
+++ b/packages/rs-drive/src/verify/address_funds/verify_compacted_address_balance_changes/v0/mod.rs
@@ -212,7 +212,7 @@ impl Drive {
             let row_decode_config = bincode::config::standard()
                 .with_big_endian()
                 .with_limit::<MAX_COMPACTED_BALANCE_ROW_DECODE_BYTES>();
-            let (address_balances, _): (
+            let (address_balances, consumed): (
                 BTreeMap<PlatformAddress, BlockAwareCreditOperation>,
                 usize,
             ) = bincode::decode_from_slice(&serialized_data, row_decode_config).map_err(|e| {
@@ -221,6 +221,14 @@ impl Drive {
                     e
                 )))
             })?;
+            // Wire-safe tightening (parity with v1): honest encoders emit
+            // rows with no trailing bytes, so rejecting them cannot break
+            // legacy peers.
+            if consumed != serialized_data.len() {
+                return Err(Error::Proof(ProofError::CorruptedProof(
+                    "compacted address balance row contains trailing bytes".to_string(),
+                )));
+            }
 
             compacted_changes.push((range_start, range_end, address_balances));
         }

--- a/packages/rs-drive/src/verify/address_funds/verify_compacted_address_balance_changes/v0/mod.rs
+++ b/packages/rs-drive/src/verify/address_funds/verify_compacted_address_balance_changes/v0/mod.rs
@@ -7,28 +7,69 @@ use dpp::address_funds::PlatformAddress;
 
 /// The subtree key for compacted address balances storage as u8
 const COMPACTED_ADDRESS_BALANCES_KEY_U8: u8 = b'c';
-/// Standalone decode budget for the two-proof envelope. Not derived from any
-/// transport limit (tonic clients default to a 4 MiB response cap and the
-/// DAPI server encodes at most 32 MiB): it only needs to sit far above any
-/// realistic proof while bounding hostile allocations before GroveDB
-/// verification runs.
+/// Decode budget for the legacy single GroveDB proof. Mirrors the v1
+/// envelope budget: far above any realistic proof while bounding hostile
+/// allocations before GroveDB verification runs.
 const MAX_COMPACTED_PROOF_DECODE_BYTES: usize = 16 * 1024 * 1024;
 /// A compacted row contains at most one configured address chunk. Keep a
-/// separate semantic-object budget after the GroveDB envelope is decoded.
+/// separate semantic-object budget after the GroveDB proof is decoded.
 const MAX_COMPACTED_BALANCE_ROW_DECODE_BYTES: usize = 1024 * 1024;
 use dpp::balances::credits::BlockAwareCreditOperation;
-use grovedb::{GroveDb, PathQuery, Query, SizedQuery};
+use grovedb::operations::proof::{GroveDBProof, ProofBytes};
+use grovedb::{
+    GroveDb, MerkProofDecoder, MerkProofNode, MerkProofOp, PathQuery, Query, SizedQuery,
+};
 use platform_version::version::PlatformVersion;
 use std::collections::BTreeMap;
 
-use super::{CompactedAddressBalanceProof, VerifiedCompactedAddressBalanceChanges};
+use super::VerifiedCompactedAddressBalanceChanges;
+
+/// Extract KV entries from merk proof bytes using the proper decoder.
+#[allow(clippy::type_complexity)]
+fn extract_kv_entries_from_merk_proof(merk_proof: &[u8]) -> Result<Vec<(Vec<u8>, Vec<u8>)>, Error> {
+    let mut entries = Vec::new();
+
+    let decoder = MerkProofDecoder::new(merk_proof);
+
+    for op in decoder {
+        match op {
+            Ok(MerkProofOp::Push(MerkProofNode::KV(key, value)))
+            | Ok(MerkProofOp::PushInverted(MerkProofNode::KV(key, value))) => {
+                entries.push((key, value));
+            }
+            Err(e) => {
+                tracing::error!(%e, "merk proof decode error");
+                return Err(Error::Proof(ProofError::CorruptedProof(format!(
+                    "failed to decode merk proof op: {}",
+                    e
+                ))));
+            }
+            _ => {}
+        }
+    }
+
+    Ok(entries)
+}
 
 impl Drive {
-    /// Verifies compacted address balance changes proof.
+    /// Verifies compacted address balance changes proof — legacy single-proof
+    /// wire format used by protocol versions whose
+    /// `verify_compacted_address_balance_changes` feature version is 0.
     ///
-    /// The request-derived predecessor query is verified first. Its
-    /// authenticated result selects the start key for a separately verified
-    /// forward query, and both proofs must commit to the same root.
+    /// This verification works by:
+    /// 1. Decoding the GroveDBProof structure
+    /// 2. Navigating to the compacted address balances layer ('c')
+    /// 3. Extracting KV entries from the merk proof
+    /// 4. Filtering entries where the key range contains start_block_height
+    /// 5. Verifying the root hash using a subset query
+    ///
+    /// Kept byte-for-byte wire-compatible with the proofs emitted by
+    /// `prove_compacted_address_balance_changes_v0`, so nodes and clients on
+    /// pre-envelope protocol versions keep interoperating. Its start key is
+    /// derived from proof-carried (not independently verified) KV entries —
+    /// the binding soundness fix requires the two-proof envelope and
+    /// therefore lives in v1; only decode-allocation bounds are applied
+    /// here, as they do not change the accepted format.
     pub(super) fn verify_compacted_address_balance_changes_v0(
         proof: &[u8],
         start_block_height: u64,
@@ -41,96 +82,102 @@ impl Drive {
             )));
         }
 
-        let proof_decode_config = bincode::config::standard()
+        let bincode_config = bincode::config::standard()
             .with_big_endian()
             .with_limit::<MAX_COMPACTED_PROOF_DECODE_BYTES>();
 
-        let (proof_envelope, consumed): (CompactedAddressBalanceProof, usize) =
-            bincode::decode_from_slice(proof, proof_decode_config).map_err(|e| {
+        // Decode the GroveDBProof to navigate its structure
+        let grovedb_proof: GroveDBProof = bincode::decode_from_slice(proof, bincode_config)
+            .map(|(p, _)| p)
+            .map_err(|e| {
                 Error::Proof(ProofError::CorruptedProof(format!(
-                    "cannot decode compacted address balance proof: {}",
+                    "cannot decode GroveDBProof: {}",
                     e
                 )))
             })?;
-        if consumed != proof.len() {
-            return Err(Error::Proof(ProofError::CorruptedProof(
-                "compacted address balance proof contains trailing bytes".to_string(),
-            )));
-        }
 
-        let path = vec![
-            vec![RootTree::SavedBlockTransactions as u8],
-            vec![COMPACTED_ADDRESS_BALANCES_KEY_U8],
-        ];
+        // Navigate to the compacted address balances layer
+        // Path: SavedBlockTransactions ('$' = 0x24) -> CompactedAddressBalances ('c' = 0x63)
+        let saved_block_key = vec![RootTree::SavedBlockTransactions as u8];
+        let compacted_key = vec![COMPACTED_ADDRESS_BALANCES_KEY_U8];
 
-        let mut predecessor_end_key = Vec::with_capacity(16);
-        predecessor_end_key.extend_from_slice(&start_block_height.to_be_bytes());
-        predecessor_end_key.extend_from_slice(&u64::MAX.to_be_bytes());
-        let mut predecessor_query = Query::new_with_direction(false);
-        predecessor_query.insert_range_to_inclusive(..=predecessor_end_key);
-        let predecessor_path_query = PathQuery::new(
-            path.clone(),
-            SizedQuery::new(predecessor_query, Some(1), None),
-        );
-        let (predecessor_root_hash, predecessor_results) = GroveDb::verify_query(
-            &proof_envelope.predecessor_proof,
-            &predecessor_path_query,
-            &platform_version.drive.grove_version,
-        )?;
-
-        let mut authenticated_predecessors = predecessor_results
-            .into_iter()
-            .filter_map(|(_path, key, element)| element.map(|element| (key, element)));
-        let authenticated_predecessor = authenticated_predecessors.next();
-        if authenticated_predecessors.next().is_some() {
-            return Err(Error::Proof(ProofError::CorruptedProof(
-                "predecessor proof returned more than one compacted range".to_string(),
-            )));
-        }
-
-        let start_key = if let Some((key, _element)) = authenticated_predecessor {
-            let key_bytes: [u8; 16] = key.as_slice().try_into().map_err(|_| {
-                Error::Proof(ProofError::CorruptedProof(
-                    "invalid compacted predecessor key length".to_string(),
-                ))
-            })?;
-            let range_start = u64::from_be_bytes(key_bytes[..8].try_into().expect("key length"));
-            let range_end = u64::from_be_bytes(key_bytes[8..].try_into().expect("key length"));
-            if range_start > range_end {
-                return Err(Error::Proof(ProofError::CorruptedProof(
-                    "compacted predecessor has an invalid block range".to_string(),
-                )));
+        // Extract KV entries from the compacted layer's merk proof to find
+        // if there's a containing range for start_block_height.
+        // V0 and V1 proofs have different layer types (MerkOnlyLayerProof vs LayerProof),
+        // so we handle them separately.
+        let kv_entries = match &grovedb_proof {
+            GroveDBProof::V0(v0) => {
+                let compacted_layer = v0
+                    .root_layer
+                    .lower_layers
+                    .get(&saved_block_key)
+                    .and_then(|layer| layer.lower_layers.get(&compacted_key));
+                compacted_layer
+                    .map(|layer| extract_kv_entries_from_merk_proof(&layer.merk_proof))
+                    .transpose()?
+                    .unwrap_or_default()
             }
-            if range_end >= start_block_height {
-                key
+            GroveDBProof::V1(v1) => {
+                let compacted_layer = v1
+                    .root_layer
+                    .lower_layers
+                    .get(&saved_block_key)
+                    .and_then(|layer| layer.lower_layers.get(&compacted_key));
+                compacted_layer
+                    .map(|layer| match &layer.merk_proof {
+                        ProofBytes::Merk(bytes) => extract_kv_entries_from_merk_proof(bytes),
+                        other => Err(Error::Proof(ProofError::CorruptedProof(format!(
+                            "unsupported V1 proof bytes variant for compacted address balances: {:?}",
+                            std::mem::discriminant(other)
+                        )))),
+                    })
+                    .transpose()?
+                    .unwrap_or_default()
+            }
+        };
+
+        // Look for a KV entry where the range contains start_block_height
+        // Keys are 16 bytes: (start_block, end_block), both big-endian
+        let containing_key = kv_entries.iter().find_map(|(key, _)| {
+            if key.len() != 16 {
+                return None;
+            }
+            let range_start = u64::from_be_bytes(key[0..8].try_into().unwrap());
+            let range_end = u64::from_be_bytes(key[8..16].try_into().unwrap());
+
+            // Check if this range contains start_block_height
+            if range_start <= start_block_height && start_block_height <= range_end {
+                Some(key.clone())
             } else {
-                let mut fallback = Vec::with_capacity(16);
-                fallback.extend_from_slice(&start_block_height.to_be_bytes());
-                fallback.extend_from_slice(&start_block_height.to_be_bytes());
-                fallback
+                None
             }
-        } else {
+        });
+
+        // Determine the start_key for the query
+        // Use the containing range's key if found, otherwise (start_block_height, start_block_height)
+        let start_key = containing_key.unwrap_or_else(|| {
             let mut key = Vec::with_capacity(16);
             key.extend_from_slice(&start_block_height.to_be_bytes());
             key.extend_from_slice(&start_block_height.to_be_bytes());
             key
-        };
+        });
+
+        // Verify the proof and get results using subset query
+        let path = vec![
+            vec![RootTree::SavedBlockTransactions as u8],
+            vec![COMPACTED_ADDRESS_BALANCES_KEY_U8],
+        ];
 
         let mut query = Query::new();
         query.insert_range_from(start_key..);
 
         let path_query = PathQuery::new(path, SizedQuery::new(query, limit, None));
 
-        let (root_hash, proved_key_values) = GroveDb::verify_query(
-            &proof_envelope.forward_proof,
+        let (root_hash, proved_key_values) = GroveDb::verify_subset_query(
+            proof,
             &path_query,
             &platform_version.drive.grove_version,
         )?;
-        if root_hash != predecessor_root_hash {
-            return Err(Error::Proof(ProofError::CorruptedProof(
-                "compacted address balance proofs commit to different roots".to_string(),
-            )));
-        }
 
         // Process the verified results
         let mut compacted_changes = Vec::new();
@@ -156,7 +203,7 @@ impl Drive {
                 )));
             };
 
-            // Deserialize the address balance map
+            // Deserialize the address balance map within its bounded budget
             if serialized_data.len() > MAX_COMPACTED_BALANCE_ROW_DECODE_BYTES {
                 return Err(Error::Proof(ProofError::CorruptedProof(
                     "compacted address balance row exceeds the decoding limit".to_string(),
@@ -165,7 +212,7 @@ impl Drive {
             let row_decode_config = bincode::config::standard()
                 .with_big_endian()
                 .with_limit::<MAX_COMPACTED_BALANCE_ROW_DECODE_BYTES>();
-            let (address_balances, consumed): (
+            let (address_balances, _): (
                 BTreeMap<PlatformAddress, BlockAwareCreditOperation>,
                 usize,
             ) = bincode::decode_from_slice(&serialized_data, row_decode_config).map_err(|e| {
@@ -174,11 +221,6 @@ impl Drive {
                     e
                 )))
             })?;
-            if consumed != serialized_data.len() {
-                return Err(Error::Proof(ProofError::CorruptedProof(
-                    "compacted address balance row contains trailing bytes".to_string(),
-                )));
-            }
 
             compacted_changes.push((range_start, range_end, address_balances));
         }
@@ -196,17 +238,32 @@ mod tests {
     use platform_version::version::PlatformVersion;
     use std::collections::BTreeMap;
 
+    /// Latest protocol version still on the legacy (v0) single-proof wire
+    /// format for compacted address balance proofs.
+    fn legacy_platform_version() -> &'static PlatformVersion {
+        let version = PlatformVersion::get(12).expect("protocol version 12 must exist");
+        assert_eq!(
+            version
+                .drive
+                .methods
+                .verify
+                .address_funds
+                .verify_compacted_address_balance_changes,
+            0,
+            "protocol version 12 must still use the legacy proof format"
+        );
+        version
+    }
+
     #[test]
-    fn should_prove_and_verify_compacted_address_balance_changes_roundtrip() {
+    fn should_prove_and_verify_legacy_compacted_address_balance_changes_roundtrip() {
         let drive = setup_drive_with_initial_state_structure(None);
-        let platform_version = PlatformVersion::latest();
+        let platform_version = legacy_platform_version();
 
         let address_1 = PlatformAddress::P2pkh([10; 20]);
         let address_2 = PlatformAddress::P2sh([11; 20]);
 
         // Store enough blocks of changes to trigger compaction
-        // The compaction threshold is controlled by platform_version
-        // We insert many blocks to ensure compaction happens
         let max_blocks = platform_version
             .drive
             .methods
@@ -233,12 +290,13 @@ mod tests {
                 .expect("should store balances");
         }
 
-        // Prove compacted changes from block 1
+        // Prove compacted changes from block 1 — dispatches to the legacy
+        // single-proof prover on this protocol version.
         let proof = drive
             .prove_compacted_address_balance_changes(1, None, None, platform_version)
             .expect("should prove compacted address balance changes");
 
-        // Verify the proof
+        // Verify the proof — dispatches to the legacy verifier.
         let (root_hash, compacted_changes) = Drive::verify_compacted_address_balance_changes(
             proof.as_slice(),
             1,
@@ -248,50 +306,26 @@ mod tests {
         .expect("should verify proof");
 
         assert!(!root_hash.is_empty(), "root hash should not be empty");
-        // We should have at least one compacted entry
         assert!(
             !compacted_changes.is_empty(),
             "should have at least one compacted entry"
         );
 
-        // All entries should have valid block ranges
         for (start, end, changes) in &compacted_changes {
             assert!(*start <= *end, "start should be <= end");
             assert!(!changes.is_empty(), "each entry should have changes");
         }
-
-        // A query beginning inside a compacted range must include that range.
-        // This exercises the independently authenticated predecessor witness.
-        let interior_height = max_blocks / 2;
-        let interior_proof = drive
-            .prove_compacted_address_balance_changes(interior_height, None, None, platform_version)
-            .expect("should prove changes from inside a compacted range");
-        let (_, interior_changes) = Drive::verify_compacted_address_balance_changes(
-            &interior_proof,
-            interior_height,
-            None,
-            platform_version,
-        )
-        .expect("should verify the authenticated predecessor proof");
-        assert!(
-            interior_changes
-                .iter()
-                .any(|(start, end, _)| *start <= interior_height && interior_height <= *end),
-            "the compacted range containing the requested height must be returned"
-        );
     }
 
     #[test]
-    fn should_prove_and_verify_empty_compacted_address_balance_changes() {
+    fn should_prove_and_verify_empty_legacy_compacted_address_balance_changes() {
         let drive = setup_drive_with_initial_state_structure(None);
-        let platform_version = PlatformVersion::latest();
+        let platform_version = legacy_platform_version();
 
-        // Prove compacted changes from block 100 with no data stored
         let proof = drive
             .prove_compacted_address_balance_changes(100, None, None, platform_version)
             .expect("should prove empty compacted changes");
 
-        // Verify the proof
         let (root_hash, compacted_changes) = Drive::verify_compacted_address_balance_changes(
             proof.as_slice(),
             100,
@@ -307,384 +341,38 @@ mod tests {
         );
     }
 
-    /// Stores enough per-block changes to trigger compaction, leaving at
-    /// least one compacted range and one uncompacted recent block.
-    fn setup_drive_with_compacted_ranges() -> (Drive, u64) {
-        let drive = setup_drive_with_initial_state_structure(None);
-        let platform_version = PlatformVersion::latest();
-        let address = PlatformAddress::P2pkh([10; 20]);
-        let max_blocks = platform_version
-            .drive
-            .methods
-            .saved_block_transactions
-            .max_blocks_before_compaction as u64;
-
-        for block_height in 1u64..=(max_blocks + 1) {
-            let mut changes = BTreeMap::new();
-            changes.insert(address, CreditOperation::AddToCredits(block_height * 1000));
-            drive
-                .store_address_balances_for_block(
-                    &changes,
-                    block_height,
-                    block_height * 1000,
-                    None,
-                    platform_version,
-                )
-                .expect("should store balances");
-        }
-
-        (drive, max_blocks)
-    }
-
+    /// Cross-format guard: an envelope proof produced under a protocol
+    /// version using the v1 two-proof format must fail closed when verified
+    /// under a legacy protocol version, rather than being misinterpreted.
     #[test]
-    fn beyond_last_compacted_range_uses_fallback_and_returns_empty() {
-        // Exercises the predecessor-exists-but-does-not-contain branch: a
-        // compacted range sits below the requested height, so the verifier
-        // must fall back to the request-derived start key instead of the
-        // authenticated predecessor key.
-        let (drive, max_blocks) = setup_drive_with_compacted_ranges();
-        let platform_version = PlatformVersion::latest();
-
-        // Precondition: compaction produced at least one range below.
-        let proof = drive
-            .prove_compacted_address_balance_changes(1, None, None, platform_version)
-            .expect("should prove from genesis");
-        let (_, changes) =
-            Drive::verify_compacted_address_balance_changes(&proof, 1, None, platform_version)
-                .expect("should verify from genesis");
-        assert!(!changes.is_empty(), "compaction must have produced ranges");
-
-        let beyond_height = max_blocks * 10;
-        let beyond_proof = drive
-            .prove_compacted_address_balance_changes(beyond_height, None, None, platform_version)
-            .expect("should prove beyond the last compacted range");
-        let (_, beyond_changes) = Drive::verify_compacted_address_balance_changes(
-            &beyond_proof,
-            beyond_height,
-            None,
-            platform_version,
-        )
-        .expect("a non-containing predecessor must verify via the fallback key");
-        assert!(
-            beyond_changes.is_empty(),
-            "no compacted range lies at or beyond the requested height"
-        );
-    }
-
-    /// Stores a single compacted address-balance entry directly under the
-    /// compacted address balances path with the given `(start_block,
-    /// end_block)` key. Bypasses normal compaction so tests can build exact
-    /// tree shapes (e.g. several ranges at/below the queried height).
-    fn store_compacted_entry(
-        drive: &Drive,
-        start_block: u64,
-        end_block: u64,
-        changes: BTreeMap<PlatformAddress, BlockAwareCreditOperation>,
-        platform_version: &PlatformVersion,
-    ) {
-        use grovedb::Element;
-        use grovedb_costs::CostContext;
-        use grovedb_path::SubtreePath;
-
-        let config = bincode::config::standard()
-            .with_big_endian()
-            .with_no_limit();
-
-        let mut key = Vec::with_capacity(16);
-        key.extend_from_slice(&start_block.to_be_bytes());
-        key.extend_from_slice(&end_block.to_be_bytes());
-        let value = bincode::encode_to_vec(&changes, config).expect("encode changes");
-
-        let path = Drive::saved_compacted_block_transactions_address_balances_path();
-
-        let CostContext { value: result, .. } = drive.grove.insert(
-            SubtreePath::from(path.as_ref()),
-            key.as_slice(),
-            Element::new_item(value),
-            None,
-            None,
-            &platform_version.drive.grove_version,
-        );
-        result.expect("insert compacted entry");
-    }
-
-    fn single_change_for(
-        end_block: u64,
-        credits: u64,
-    ) -> BTreeMap<PlatformAddress, BlockAwareCreditOperation> {
-        let mut changes = BTreeMap::new();
-        changes.insert(
-            PlatformAddress::P2pkh([7; 20]),
-            BlockAwareCreditOperation::from_operation(
-                end_block,
-                &CreditOperation::AddToCredits(credits),
-            ),
-        );
-        changes
-    }
-
-    /// Regression for the chained-proof liveness bug that blocked the
-    /// original soundness fix: with two or more compacted ranges sorting
-    /// at/below the queried height — the normal paginated-sync shape — a
-    /// single one-directional proof could not satisfy both the descending
-    /// predecessor query and the ascending forward query. The two-proof
-    /// envelope must verify the honest roundtrip.
-    #[test]
-    fn multiple_ranges_below_query_height_verify() {
+    fn envelope_proof_is_rejected_by_legacy_verifier() {
         let drive = setup_drive_with_initial_state_structure(None);
-        let platform_version = PlatformVersion::latest();
-
-        let containing_changes = single_change_for(192, 192_000);
-        for (start, end) in [(1u64, 64u64), (65, 128), (129, 192)] {
-            let changes = if end == 192 {
-                containing_changes.clone()
-            } else {
-                single_change_for(end, end * 1000)
-            };
-            store_compacted_entry(&drive, start, end, changes, platform_version);
-        }
-
-        // All three ranges sort at/below (150, u64::MAX).
-        let proof = drive
-            .prove_compacted_address_balance_changes(150, None, None, platform_version)
-            .expect("should prove with multiple ranges below the query height");
-        let (_, changes) = Drive::verify_compacted_address_balance_changes(
-            proof.as_slice(),
-            150,
-            None,
-            platform_version,
-        )
-        .expect("verification must not fail with multiple ranges at/below the bound");
-
+        let envelope_version = PlatformVersion::latest();
         assert_eq!(
-            changes
-                .iter()
-                .map(|(start, end, _)| (*start, *end))
-                .collect::<Vec<_>>(),
-            vec![(129, 192)],
-            "only the range containing the requested height must be returned"
+            envelope_version
+                .drive
+                .methods
+                .verify
+                .address_funds
+                .verify_compacted_address_balance_changes,
+            1,
+            "latest protocol version must use the envelope proof format"
         );
-        assert_eq!(
-            changes[0].2, containing_changes,
-            "the containing range must carry its stored changes"
-        );
-    }
-
-    /// The forward scan starts at the authenticated containing range and
-    /// continues through later ranges; ranges wholly below the queried
-    /// height stay excluded even though they sort below the predecessor
-    /// bound.
-    #[test]
-    fn containing_range_with_lower_and_higher_ranges() {
-        let drive = setup_drive_with_initial_state_structure(None);
-        let platform_version = PlatformVersion::latest();
-
-        for (start, end) in [(1u64, 64u64), (65, 128), (129, 192), (193, 256)] {
-            store_compacted_entry(
-                &drive,
-                start,
-                end,
-                single_change_for(end, end * 1000),
-                platform_version,
-            );
-        }
 
         let proof = drive
-            .prove_compacted_address_balance_changes(150, None, None, platform_version)
-            .expect("should prove with ranges on both sides of the query height");
-        let (_, changes) = Drive::verify_compacted_address_balance_changes(
-            proof.as_slice(),
-            150,
-            None,
-            platform_version,
-        )
-        .expect("should verify");
-
-        assert_eq!(
-            changes
-                .iter()
-                .map(|(start, end, _)| (*start, *end))
-                .collect::<Vec<_>>(),
-            vec![(129, 192), (193, 256)],
-            "the containing range and every later range must be returned in order"
-        );
-    }
-
-    /// Mirrors the paginated sync the gRPC handler performs (it passes an
-    /// explicit limit): the caller limit truncates the forward scan, and the
-    /// next page resumes past the last returned range — including a final
-    /// page that exercises the non-containing-predecessor fallback under a
-    /// limit.
-    #[test]
-    fn caller_limit_paginates_across_ranges() {
-        let drive = setup_drive_with_initial_state_structure(None);
-        let platform_version = PlatformVersion::latest();
-
-        for (start, end) in [(1u64, 64u64), (65, 128), (129, 192), (193, 256)] {
-            store_compacted_entry(
-                &drive,
-                start,
-                end,
-                single_change_for(end, end * 1000),
-                platform_version,
-            );
-        }
-
-        let page = |start_height: u64| -> Vec<(u64, u64)> {
-            let proof = drive
-                .prove_compacted_address_balance_changes(
-                    start_height,
-                    Some(1),
-                    None,
-                    platform_version,
-                )
-                .expect("should prove a limited page");
-            let (_, changes) = Drive::verify_compacted_address_balance_changes(
-                proof.as_slice(),
-                start_height,
-                Some(1),
-                platform_version,
-            )
-            .expect("a limited page must verify");
-            changes
-                .iter()
-                .map(|(start, end, _)| (*start, *end))
-                .collect()
-        };
-
-        assert_eq!(
-            page(150),
-            vec![(129, 192)],
-            "first page returns only the containing range"
-        );
-        assert_eq!(
-            page(193),
-            vec![(193, 256)],
-            "second page resumes at the next range"
-        );
-        assert_eq!(
-            page(257),
-            Vec::<(u64, u64)>::new(),
-            "past the last range the fallback start key yields an empty page"
-        );
-    }
-
-    #[test]
-    fn rejects_envelope_halves_committing_to_different_roots() {
-        // Splice a predecessor proof from one state with a forward proof from
-        // a later state. Each half verifies on its own, so only the explicit
-        // cross-proof root binding can reject the mixed envelope.
-        let (drive, max_blocks) = setup_drive_with_compacted_ranges();
-        let platform_version = PlatformVersion::latest();
-        let interior_height = max_blocks / 2;
-
-        let proof_before = drive
-            .prove_compacted_address_balance_changes(interior_height, None, None, platform_version)
-            .expect("should prove at the earlier state");
-
-        // Mutate uncompacted recent state only: the root changes while the
-        // compacted ranges (and therefore the derived start key) do not.
-        let address = PlatformAddress::P2pkh([10; 20]);
-        let mut changes = BTreeMap::new();
-        changes.insert(address, CreditOperation::AddToCredits(1));
-        drive
-            .store_address_balances_for_block(
-                &changes,
-                max_blocks + 2,
-                (max_blocks + 2) * 1000,
-                None,
-                platform_version,
-            )
-            .expect("should store an additional recent block");
-
-        let proof_after = drive
-            .prove_compacted_address_balance_changes(interior_height, None, None, platform_version)
-            .expect("should prove at the later state");
-
-        let envelope_config = bincode::config::standard().with_big_endian();
-        let (before_envelope, _): (CompactedAddressBalanceProof, usize) =
-            bincode::decode_from_slice(&proof_before, envelope_config)
-                .expect("decode earlier envelope");
-        let (after_envelope, _): (CompactedAddressBalanceProof, usize) =
-            bincode::decode_from_slice(&proof_after, envelope_config)
-                .expect("decode later envelope");
-
-        let spliced = bincode::encode_to_vec(
-            CompactedAddressBalanceProof {
-                predecessor_proof: before_envelope.predecessor_proof,
-                forward_proof: after_envelope.forward_proof,
-            },
-            envelope_config,
-        )
-        .expect("encode spliced envelope");
-
-        let error = Drive::verify_compacted_address_balance_changes(
-            &spliced,
-            interior_height,
-            None,
-            platform_version,
-        )
-        .expect_err("mixed-root envelope halves must be rejected");
-        assert!(
-            error.to_string().contains("different roots"),
-            "expected the cross-proof root binding to reject the envelope, got: {error}"
-        );
-    }
-
-    #[test]
-    fn rejects_legacy_single_compacted_address_balance_proof() {
-        // This proof was generated with start_block_height = 329
-        // Path: [[36], [99]] = [['$'], ['c']] = SavedBlockTransactions -> CompactedAddressBalances
-        // Query: RangeTo(..[0, 0, 0, 0, 0, 0, 1, 73, 0, 0, 0, 0, 0, 0, 1, 73]) = RangeTo(..(329, 329))
-        let proof: Vec<u8> = vec![
-            0, 251, 1, 24, 1, 24, 215, 122, 183, 233, 12, 7, 14, 37, 119, 175, 74, 229, 6, 76, 88,
-            209, 79, 175, 135, 230, 45, 89, 116, 17, 76, 49, 87, 242, 4, 40, 35, 2, 33, 229, 84,
-            218, 198, 132, 136, 197, 212, 253, 180, 247, 125, 228, 176, 179, 248, 100, 19, 202,
-            143, 20, 196, 132, 112, 114, 44, 43, 11, 174, 49, 96, 16, 4, 1, 36, 0, 5, 2, 1, 1, 101,
-            0, 126, 152, 206, 30, 157, 147, 101, 232, 212, 68, 50, 242, 52, 170, 136, 72, 39, 136,
-            235, 41, 105, 28, 199, 93, 222, 168, 227, 241, 80, 234, 2, 185, 2, 120, 2, 233, 247,
-            175, 89, 203, 114, 37, 58, 187, 95, 169, 151, 247, 245, 82, 228, 73, 77, 131, 5, 100,
-            241, 7, 152, 139, 156, 94, 138, 33, 173, 16, 2, 124, 156, 122, 25, 79, 47, 39, 233, 96,
-            90, 9, 165, 232, 130, 103, 245, 113, 145, 31, 183, 102, 94, 40, 86, 140, 146, 128, 172,
-            85, 184, 13, 220, 16, 1, 48, 30, 57, 216, 246, 121, 172, 45, 163, 129, 189, 9, 238,
-            108, 64, 21, 231, 140, 164, 160, 37, 184, 182, 34, 151, 148, 194, 74, 83, 124, 199, 87,
-            17, 17, 2, 199, 32, 12, 6, 52, 58, 219, 92, 42, 60, 69, 132, 209, 186, 193, 248, 18,
-            33, 26, 78, 216, 110, 114, 103, 202, 56, 45, 175, 163, 68, 139, 6, 16, 1, 62, 159, 56,
-            33, 169, 193, 143, 7, 131, 179, 169, 31, 163, 163, 50, 117, 235, 211, 94, 247, 244, 60,
-            246, 149, 186, 142, 105, 187, 230, 247, 212, 141, 17, 1, 1, 36, 125, 4, 1, 99, 0, 20,
-            2, 1, 16, 0, 0, 0, 0, 0, 0, 1, 4, 0, 0, 0, 0, 0, 0, 1, 8, 0, 97, 206, 71, 247, 121, 93,
-            103, 7, 209, 119, 82, 59, 209, 145, 171, 254, 112, 14, 204, 81, 30, 98, 213, 203, 146,
-            141, 32, 167, 232, 34, 0, 37, 2, 170, 200, 228, 36, 229, 197, 116, 242, 100, 137, 25,
-            37, 45, 57, 56, 2, 38, 8, 75, 144, 250, 71, 108, 90, 106, 133, 2, 231, 236, 42, 149,
-            206, 16, 1, 77, 52, 100, 69, 203, 109, 100, 190, 84, 2, 6, 238, 168, 74, 208, 99, 16,
-            56, 200, 98, 181, 205, 24, 79, 120, 235, 223, 144, 61, 197, 8, 215, 17, 1, 1, 99, 220,
-            1, 28, 113, 173, 87, 207, 150, 171, 166, 221, 201, 207, 122, 14, 62, 119, 8, 5, 100,
-            182, 50, 112, 191, 244, 5, 125, 9, 161, 17, 66, 201, 126, 148, 2, 170, 62, 172, 42,
-            117, 12, 62, 165, 78, 141, 84, 194, 75, 135, 140, 198, 85, 219, 214, 218, 149, 56, 32,
-            251, 16, 134, 21, 44, 31, 22, 80, 69, 16, 1, 191, 139, 156, 120, 188, 0, 187, 111, 169,
-            41, 135, 146, 156, 103, 102, 125, 235, 0, 70, 180, 94, 103, 134, 250, 135, 56, 55, 144,
-            156, 185, 212, 67, 2, 223, 93, 226, 244, 94, 203, 160, 13, 145, 161, 22, 104, 133, 135,
-            132, 239, 27, 61, 12, 167, 134, 237, 120, 58, 229, 208, 50, 55, 70, 139, 211, 234, 16,
-            2, 58, 253, 249, 36, 12, 24, 122, 198, 7, 161, 13, 237, 229, 3, 224, 98, 176, 51, 237,
-            101, 105, 33, 10, 45, 111, 96, 89, 201, 212, 82, 1, 141, 5, 16, 0, 0, 0, 0, 0, 0, 1,
-            32, 0, 0, 0, 0, 0, 0, 1, 36, 77, 228, 149, 252, 55, 96, 22, 145, 235, 199, 188, 83, 13,
-            88, 13, 241, 48, 191, 78, 152, 20, 50, 252, 186, 199, 105, 134, 73, 62, 136, 228, 196,
-            17, 17, 17, 0, 1,
-        ];
-
-        let start_block_height = 329u64;
-        let platform_version = PlatformVersion::latest();
+            .prove_compacted_address_balance_changes(100, None, None, envelope_version)
+            .expect("should prove with the envelope format");
 
         let result = Drive::verify_compacted_address_balance_changes(
-            &proof,
-            start_block_height,
+            proof.as_slice(),
+            100,
             None,
-            platform_version,
+            legacy_platform_version(),
         );
 
         assert!(
             result.is_err(),
-            "a single adaptive proof must fail closed without an authenticated predecessor"
+            "an envelope proof must not verify under the legacy format"
         );
     }
 }

--- a/packages/rs-drive/src/verify/address_funds/verify_compacted_address_balance_changes/v1/mod.rs
+++ b/packages/rs-drive/src/verify/address_funds/verify_compacted_address_balance_changes/v1/mod.rs
@@ -1,0 +1,690 @@
+use crate::drive::Drive;
+use crate::drive::RootTree;
+use crate::error::proof::ProofError;
+use crate::error::Error;
+use crate::verify::RootHash;
+use dpp::address_funds::PlatformAddress;
+
+/// The subtree key for compacted address balances storage as u8
+const COMPACTED_ADDRESS_BALANCES_KEY_U8: u8 = b'c';
+/// Standalone decode budget for the two-proof envelope. Not derived from any
+/// transport limit (tonic clients default to a 4 MiB response cap and the
+/// DAPI server encodes at most 32 MiB): it only needs to sit far above any
+/// realistic proof while bounding hostile allocations before GroveDB
+/// verification runs.
+const MAX_COMPACTED_PROOF_DECODE_BYTES: usize = 16 * 1024 * 1024;
+/// A compacted row contains at most one configured address chunk. Keep a
+/// separate semantic-object budget after the GroveDB envelope is decoded.
+const MAX_COMPACTED_BALANCE_ROW_DECODE_BYTES: usize = 1024 * 1024;
+use dpp::balances::credits::BlockAwareCreditOperation;
+use grovedb::{GroveDb, PathQuery, Query, SizedQuery};
+use platform_version::version::PlatformVersion;
+use std::collections::BTreeMap;
+
+use super::{CompactedAddressBalanceProof, VerifiedCompactedAddressBalanceChanges};
+
+impl Drive {
+    /// Verifies compacted address balance changes proof.
+    ///
+    /// The request-derived predecessor query is verified first. Its
+    /// authenticated result selects the start key for a separately verified
+    /// forward query, and both proofs must commit to the same root.
+    pub(super) fn verify_compacted_address_balance_changes_v1(
+        proof: &[u8],
+        start_block_height: u64,
+        limit: Option<u16>,
+        platform_version: &PlatformVersion,
+    ) -> Result<(RootHash, VerifiedCompactedAddressBalanceChanges), Error> {
+        if proof.len() > MAX_COMPACTED_PROOF_DECODE_BYTES {
+            return Err(Error::Proof(ProofError::CorruptedProof(
+                "compacted address balance proof exceeds the decoding limit".to_string(),
+            )));
+        }
+
+        let proof_decode_config = bincode::config::standard()
+            .with_big_endian()
+            .with_limit::<MAX_COMPACTED_PROOF_DECODE_BYTES>();
+
+        let (proof_envelope, consumed): (CompactedAddressBalanceProof, usize) =
+            bincode::decode_from_slice(proof, proof_decode_config).map_err(|e| {
+                Error::Proof(ProofError::CorruptedProof(format!(
+                    "cannot decode compacted address balance proof: {}",
+                    e
+                )))
+            })?;
+        if consumed != proof.len() {
+            return Err(Error::Proof(ProofError::CorruptedProof(
+                "compacted address balance proof contains trailing bytes".to_string(),
+            )));
+        }
+
+        let path = vec![
+            vec![RootTree::SavedBlockTransactions as u8],
+            vec![COMPACTED_ADDRESS_BALANCES_KEY_U8],
+        ];
+
+        let mut predecessor_end_key = Vec::with_capacity(16);
+        predecessor_end_key.extend_from_slice(&start_block_height.to_be_bytes());
+        predecessor_end_key.extend_from_slice(&u64::MAX.to_be_bytes());
+        let mut predecessor_query = Query::new_with_direction(false);
+        predecessor_query.insert_range_to_inclusive(..=predecessor_end_key);
+        let predecessor_path_query = PathQuery::new(
+            path.clone(),
+            SizedQuery::new(predecessor_query, Some(1), None),
+        );
+        let (predecessor_root_hash, predecessor_results) = GroveDb::verify_query(
+            &proof_envelope.predecessor_proof,
+            &predecessor_path_query,
+            &platform_version.drive.grove_version,
+        )?;
+
+        let mut authenticated_predecessors = predecessor_results
+            .into_iter()
+            .filter_map(|(_path, key, element)| element.map(|element| (key, element)));
+        let authenticated_predecessor = authenticated_predecessors.next();
+        if authenticated_predecessors.next().is_some() {
+            return Err(Error::Proof(ProofError::CorruptedProof(
+                "predecessor proof returned more than one compacted range".to_string(),
+            )));
+        }
+
+        let start_key = if let Some((key, _element)) = authenticated_predecessor {
+            let key_bytes: [u8; 16] = key.as_slice().try_into().map_err(|_| {
+                Error::Proof(ProofError::CorruptedProof(
+                    "invalid compacted predecessor key length".to_string(),
+                ))
+            })?;
+            let range_start = u64::from_be_bytes(key_bytes[..8].try_into().expect("key length"));
+            let range_end = u64::from_be_bytes(key_bytes[8..].try_into().expect("key length"));
+            if range_start > range_end {
+                return Err(Error::Proof(ProofError::CorruptedProof(
+                    "compacted predecessor has an invalid block range".to_string(),
+                )));
+            }
+            if range_end >= start_block_height {
+                key
+            } else {
+                let mut fallback = Vec::with_capacity(16);
+                fallback.extend_from_slice(&start_block_height.to_be_bytes());
+                fallback.extend_from_slice(&start_block_height.to_be_bytes());
+                fallback
+            }
+        } else {
+            let mut key = Vec::with_capacity(16);
+            key.extend_from_slice(&start_block_height.to_be_bytes());
+            key.extend_from_slice(&start_block_height.to_be_bytes());
+            key
+        };
+
+        let mut query = Query::new();
+        query.insert_range_from(start_key..);
+
+        let path_query = PathQuery::new(path, SizedQuery::new(query, limit, None));
+
+        let (root_hash, proved_key_values) = GroveDb::verify_query(
+            &proof_envelope.forward_proof,
+            &path_query,
+            &platform_version.drive.grove_version,
+        )?;
+        if root_hash != predecessor_root_hash {
+            return Err(Error::Proof(ProofError::CorruptedProof(
+                "compacted address balance proofs commit to different roots".to_string(),
+            )));
+        }
+
+        // Process the verified results
+        let mut compacted_changes = Vec::new();
+
+        for (_path, key, maybe_element) in proved_key_values {
+            let Some(element) = maybe_element else {
+                continue;
+            };
+
+            if key.len() != 16 {
+                return Err(Error::Proof(ProofError::CorruptedProof(
+                    "invalid compacted block key length, expected 16 bytes".to_string(),
+                )));
+            }
+
+            let range_start = u64::from_be_bytes(key[0..8].try_into().unwrap());
+            let range_end = u64::from_be_bytes(key[8..16].try_into().unwrap());
+
+            // Get the serialized data from the Item element
+            let grovedb::Element::Item(serialized_data, _) = element else {
+                return Err(Error::Proof(ProofError::CorruptedProof(
+                    "expected item element for compacted address balances".to_string(),
+                )));
+            };
+
+            // Deserialize the address balance map
+            if serialized_data.len() > MAX_COMPACTED_BALANCE_ROW_DECODE_BYTES {
+                return Err(Error::Proof(ProofError::CorruptedProof(
+                    "compacted address balance row exceeds the decoding limit".to_string(),
+                )));
+            }
+            let row_decode_config = bincode::config::standard()
+                .with_big_endian()
+                .with_limit::<MAX_COMPACTED_BALANCE_ROW_DECODE_BYTES>();
+            let (address_balances, consumed): (
+                BTreeMap<PlatformAddress, BlockAwareCreditOperation>,
+                usize,
+            ) = bincode::decode_from_slice(&serialized_data, row_decode_config).map_err(|e| {
+                Error::Proof(ProofError::CorruptedProof(format!(
+                    "cannot decode compacted address balances: {}",
+                    e
+                )))
+            })?;
+            if consumed != serialized_data.len() {
+                return Err(Error::Proof(ProofError::CorruptedProof(
+                    "compacted address balance row contains trailing bytes".to_string(),
+                )));
+            }
+
+            compacted_changes.push((range_start, range_end, address_balances));
+        }
+
+        Ok((root_hash, compacted_changes))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::util::test_helpers::setup::setup_drive_with_initial_state_structure;
+    use dpp::address_funds::PlatformAddress;
+    use dpp::balances::credits::CreditOperation;
+    use platform_version::version::PlatformVersion;
+    use std::collections::BTreeMap;
+
+    #[test]
+    fn should_prove_and_verify_compacted_address_balance_changes_roundtrip() {
+        let drive = setup_drive_with_initial_state_structure(None);
+        let platform_version = PlatformVersion::latest();
+
+        let address_1 = PlatformAddress::P2pkh([10; 20]);
+        let address_2 = PlatformAddress::P2sh([11; 20]);
+
+        // Store enough blocks of changes to trigger compaction
+        // The compaction threshold is controlled by platform_version
+        // We insert many blocks to ensure compaction happens
+        let max_blocks = platform_version
+            .drive
+            .methods
+            .saved_block_transactions
+            .max_blocks_before_compaction as u64;
+
+        for block_height in 1u64..=(max_blocks + 1) {
+            let mut changes = BTreeMap::new();
+            changes.insert(
+                address_1,
+                CreditOperation::AddToCredits(block_height * 1000),
+            );
+            if block_height % 2 == 0 {
+                changes.insert(address_2, CreditOperation::AddToCredits(block_height * 500));
+            }
+            drive
+                .store_address_balances_for_block(
+                    &changes,
+                    block_height,
+                    block_height * 1000,
+                    None,
+                    platform_version,
+                )
+                .expect("should store balances");
+        }
+
+        // Prove compacted changes from block 1
+        let proof = drive
+            .prove_compacted_address_balance_changes(1, None, None, platform_version)
+            .expect("should prove compacted address balance changes");
+
+        // Verify the proof
+        let (root_hash, compacted_changes) = Drive::verify_compacted_address_balance_changes(
+            proof.as_slice(),
+            1,
+            None,
+            platform_version,
+        )
+        .expect("should verify proof");
+
+        assert!(!root_hash.is_empty(), "root hash should not be empty");
+        // We should have at least one compacted entry
+        assert!(
+            !compacted_changes.is_empty(),
+            "should have at least one compacted entry"
+        );
+
+        // All entries should have valid block ranges
+        for (start, end, changes) in &compacted_changes {
+            assert!(*start <= *end, "start should be <= end");
+            assert!(!changes.is_empty(), "each entry should have changes");
+        }
+
+        // A query beginning inside a compacted range must include that range.
+        // This exercises the independently authenticated predecessor witness.
+        let interior_height = max_blocks / 2;
+        let interior_proof = drive
+            .prove_compacted_address_balance_changes(interior_height, None, None, platform_version)
+            .expect("should prove changes from inside a compacted range");
+        let (_, interior_changes) = Drive::verify_compacted_address_balance_changes(
+            &interior_proof,
+            interior_height,
+            None,
+            platform_version,
+        )
+        .expect("should verify the authenticated predecessor proof");
+        assert!(
+            interior_changes
+                .iter()
+                .any(|(start, end, _)| *start <= interior_height && interior_height <= *end),
+            "the compacted range containing the requested height must be returned"
+        );
+    }
+
+    #[test]
+    fn should_prove_and_verify_empty_compacted_address_balance_changes() {
+        let drive = setup_drive_with_initial_state_structure(None);
+        let platform_version = PlatformVersion::latest();
+
+        // Prove compacted changes from block 100 with no data stored
+        let proof = drive
+            .prove_compacted_address_balance_changes(100, None, None, platform_version)
+            .expect("should prove empty compacted changes");
+
+        // Verify the proof
+        let (root_hash, compacted_changes) = Drive::verify_compacted_address_balance_changes(
+            proof.as_slice(),
+            100,
+            None,
+            platform_version,
+        )
+        .expect("should verify proof");
+
+        assert!(!root_hash.is_empty(), "root hash should not be empty");
+        assert!(
+            compacted_changes.is_empty(),
+            "should have no compacted entries when no data stored"
+        );
+    }
+
+    /// Stores enough per-block changes to trigger compaction, leaving at
+    /// least one compacted range and one uncompacted recent block.
+    fn setup_drive_with_compacted_ranges() -> (Drive, u64) {
+        let drive = setup_drive_with_initial_state_structure(None);
+        let platform_version = PlatformVersion::latest();
+        let address = PlatformAddress::P2pkh([10; 20]);
+        let max_blocks = platform_version
+            .drive
+            .methods
+            .saved_block_transactions
+            .max_blocks_before_compaction as u64;
+
+        for block_height in 1u64..=(max_blocks + 1) {
+            let mut changes = BTreeMap::new();
+            changes.insert(address, CreditOperation::AddToCredits(block_height * 1000));
+            drive
+                .store_address_balances_for_block(
+                    &changes,
+                    block_height,
+                    block_height * 1000,
+                    None,
+                    platform_version,
+                )
+                .expect("should store balances");
+        }
+
+        (drive, max_blocks)
+    }
+
+    #[test]
+    fn beyond_last_compacted_range_uses_fallback_and_returns_empty() {
+        // Exercises the predecessor-exists-but-does-not-contain branch: a
+        // compacted range sits below the requested height, so the verifier
+        // must fall back to the request-derived start key instead of the
+        // authenticated predecessor key.
+        let (drive, max_blocks) = setup_drive_with_compacted_ranges();
+        let platform_version = PlatformVersion::latest();
+
+        // Precondition: compaction produced at least one range below.
+        let proof = drive
+            .prove_compacted_address_balance_changes(1, None, None, platform_version)
+            .expect("should prove from genesis");
+        let (_, changes) =
+            Drive::verify_compacted_address_balance_changes(&proof, 1, None, platform_version)
+                .expect("should verify from genesis");
+        assert!(!changes.is_empty(), "compaction must have produced ranges");
+
+        let beyond_height = max_blocks * 10;
+        let beyond_proof = drive
+            .prove_compacted_address_balance_changes(beyond_height, None, None, platform_version)
+            .expect("should prove beyond the last compacted range");
+        let (_, beyond_changes) = Drive::verify_compacted_address_balance_changes(
+            &beyond_proof,
+            beyond_height,
+            None,
+            platform_version,
+        )
+        .expect("a non-containing predecessor must verify via the fallback key");
+        assert!(
+            beyond_changes.is_empty(),
+            "no compacted range lies at or beyond the requested height"
+        );
+    }
+
+    /// Stores a single compacted address-balance entry directly under the
+    /// compacted address balances path with the given `(start_block,
+    /// end_block)` key. Bypasses normal compaction so tests can build exact
+    /// tree shapes (e.g. several ranges at/below the queried height).
+    fn store_compacted_entry(
+        drive: &Drive,
+        start_block: u64,
+        end_block: u64,
+        changes: BTreeMap<PlatformAddress, BlockAwareCreditOperation>,
+        platform_version: &PlatformVersion,
+    ) {
+        use grovedb::Element;
+        use grovedb_costs::CostContext;
+        use grovedb_path::SubtreePath;
+
+        let config = bincode::config::standard()
+            .with_big_endian()
+            .with_no_limit();
+
+        let mut key = Vec::with_capacity(16);
+        key.extend_from_slice(&start_block.to_be_bytes());
+        key.extend_from_slice(&end_block.to_be_bytes());
+        let value = bincode::encode_to_vec(&changes, config).expect("encode changes");
+
+        let path = Drive::saved_compacted_block_transactions_address_balances_path();
+
+        let CostContext { value: result, .. } = drive.grove.insert(
+            SubtreePath::from(path.as_ref()),
+            key.as_slice(),
+            Element::new_item(value),
+            None,
+            None,
+            &platform_version.drive.grove_version,
+        );
+        result.expect("insert compacted entry");
+    }
+
+    fn single_change_for(
+        end_block: u64,
+        credits: u64,
+    ) -> BTreeMap<PlatformAddress, BlockAwareCreditOperation> {
+        let mut changes = BTreeMap::new();
+        changes.insert(
+            PlatformAddress::P2pkh([7; 20]),
+            BlockAwareCreditOperation::from_operation(
+                end_block,
+                &CreditOperation::AddToCredits(credits),
+            ),
+        );
+        changes
+    }
+
+    /// Regression for the chained-proof liveness bug that blocked the
+    /// original soundness fix: with two or more compacted ranges sorting
+    /// at/below the queried height — the normal paginated-sync shape — a
+    /// single one-directional proof could not satisfy both the descending
+    /// predecessor query and the ascending forward query. The two-proof
+    /// envelope must verify the honest roundtrip.
+    #[test]
+    fn multiple_ranges_below_query_height_verify() {
+        let drive = setup_drive_with_initial_state_structure(None);
+        let platform_version = PlatformVersion::latest();
+
+        let containing_changes = single_change_for(192, 192_000);
+        for (start, end) in [(1u64, 64u64), (65, 128), (129, 192)] {
+            let changes = if end == 192 {
+                containing_changes.clone()
+            } else {
+                single_change_for(end, end * 1000)
+            };
+            store_compacted_entry(&drive, start, end, changes, platform_version);
+        }
+
+        // All three ranges sort at/below (150, u64::MAX).
+        let proof = drive
+            .prove_compacted_address_balance_changes(150, None, None, platform_version)
+            .expect("should prove with multiple ranges below the query height");
+        let (_, changes) = Drive::verify_compacted_address_balance_changes(
+            proof.as_slice(),
+            150,
+            None,
+            platform_version,
+        )
+        .expect("verification must not fail with multiple ranges at/below the bound");
+
+        assert_eq!(
+            changes
+                .iter()
+                .map(|(start, end, _)| (*start, *end))
+                .collect::<Vec<_>>(),
+            vec![(129, 192)],
+            "only the range containing the requested height must be returned"
+        );
+        assert_eq!(
+            changes[0].2, containing_changes,
+            "the containing range must carry its stored changes"
+        );
+    }
+
+    /// The forward scan starts at the authenticated containing range and
+    /// continues through later ranges; ranges wholly below the queried
+    /// height stay excluded even though they sort below the predecessor
+    /// bound.
+    #[test]
+    fn containing_range_with_lower_and_higher_ranges() {
+        let drive = setup_drive_with_initial_state_structure(None);
+        let platform_version = PlatformVersion::latest();
+
+        for (start, end) in [(1u64, 64u64), (65, 128), (129, 192), (193, 256)] {
+            store_compacted_entry(
+                &drive,
+                start,
+                end,
+                single_change_for(end, end * 1000),
+                platform_version,
+            );
+        }
+
+        let proof = drive
+            .prove_compacted_address_balance_changes(150, None, None, platform_version)
+            .expect("should prove with ranges on both sides of the query height");
+        let (_, changes) = Drive::verify_compacted_address_balance_changes(
+            proof.as_slice(),
+            150,
+            None,
+            platform_version,
+        )
+        .expect("should verify");
+
+        assert_eq!(
+            changes
+                .iter()
+                .map(|(start, end, _)| (*start, *end))
+                .collect::<Vec<_>>(),
+            vec![(129, 192), (193, 256)],
+            "the containing range and every later range must be returned in order"
+        );
+    }
+
+    /// Mirrors the paginated sync the gRPC handler performs (it passes an
+    /// explicit limit): the caller limit truncates the forward scan, and the
+    /// next page resumes past the last returned range — including a final
+    /// page that exercises the non-containing-predecessor fallback under a
+    /// limit.
+    #[test]
+    fn caller_limit_paginates_across_ranges() {
+        let drive = setup_drive_with_initial_state_structure(None);
+        let platform_version = PlatformVersion::latest();
+
+        for (start, end) in [(1u64, 64u64), (65, 128), (129, 192), (193, 256)] {
+            store_compacted_entry(
+                &drive,
+                start,
+                end,
+                single_change_for(end, end * 1000),
+                platform_version,
+            );
+        }
+
+        let page = |start_height: u64| -> Vec<(u64, u64)> {
+            let proof = drive
+                .prove_compacted_address_balance_changes(
+                    start_height,
+                    Some(1),
+                    None,
+                    platform_version,
+                )
+                .expect("should prove a limited page");
+            let (_, changes) = Drive::verify_compacted_address_balance_changes(
+                proof.as_slice(),
+                start_height,
+                Some(1),
+                platform_version,
+            )
+            .expect("a limited page must verify");
+            changes
+                .iter()
+                .map(|(start, end, _)| (*start, *end))
+                .collect()
+        };
+
+        assert_eq!(
+            page(150),
+            vec![(129, 192)],
+            "first page returns only the containing range"
+        );
+        assert_eq!(
+            page(193),
+            vec![(193, 256)],
+            "second page resumes at the next range"
+        );
+        assert_eq!(
+            page(257),
+            Vec::<(u64, u64)>::new(),
+            "past the last range the fallback start key yields an empty page"
+        );
+    }
+
+    #[test]
+    fn rejects_envelope_halves_committing_to_different_roots() {
+        // Splice a predecessor proof from one state with a forward proof from
+        // a later state. Each half verifies on its own, so only the explicit
+        // cross-proof root binding can reject the mixed envelope.
+        let (drive, max_blocks) = setup_drive_with_compacted_ranges();
+        let platform_version = PlatformVersion::latest();
+        let interior_height = max_blocks / 2;
+
+        let proof_before = drive
+            .prove_compacted_address_balance_changes(interior_height, None, None, platform_version)
+            .expect("should prove at the earlier state");
+
+        // Mutate uncompacted recent state only: the root changes while the
+        // compacted ranges (and therefore the derived start key) do not.
+        let address = PlatformAddress::P2pkh([10; 20]);
+        let mut changes = BTreeMap::new();
+        changes.insert(address, CreditOperation::AddToCredits(1));
+        drive
+            .store_address_balances_for_block(
+                &changes,
+                max_blocks + 2,
+                (max_blocks + 2) * 1000,
+                None,
+                platform_version,
+            )
+            .expect("should store an additional recent block");
+
+        let proof_after = drive
+            .prove_compacted_address_balance_changes(interior_height, None, None, platform_version)
+            .expect("should prove at the later state");
+
+        let envelope_config = bincode::config::standard().with_big_endian();
+        let (before_envelope, _): (CompactedAddressBalanceProof, usize) =
+            bincode::decode_from_slice(&proof_before, envelope_config)
+                .expect("decode earlier envelope");
+        let (after_envelope, _): (CompactedAddressBalanceProof, usize) =
+            bincode::decode_from_slice(&proof_after, envelope_config)
+                .expect("decode later envelope");
+
+        let spliced = bincode::encode_to_vec(
+            CompactedAddressBalanceProof {
+                predecessor_proof: before_envelope.predecessor_proof,
+                forward_proof: after_envelope.forward_proof,
+            },
+            envelope_config,
+        )
+        .expect("encode spliced envelope");
+
+        let error = Drive::verify_compacted_address_balance_changes(
+            &spliced,
+            interior_height,
+            None,
+            platform_version,
+        )
+        .expect_err("mixed-root envelope halves must be rejected");
+        assert!(
+            error.to_string().contains("different roots"),
+            "expected the cross-proof root binding to reject the envelope, got: {error}"
+        );
+    }
+
+    #[test]
+    fn rejects_legacy_single_compacted_address_balance_proof() {
+        // This proof was generated with start_block_height = 329
+        // Path: [[36], [99]] = [['$'], ['c']] = SavedBlockTransactions -> CompactedAddressBalances
+        // Query: RangeTo(..[0, 0, 0, 0, 0, 0, 1, 73, 0, 0, 0, 0, 0, 0, 1, 73]) = RangeTo(..(329, 329))
+        let proof: Vec<u8> = vec![
+            0, 251, 1, 24, 1, 24, 215, 122, 183, 233, 12, 7, 14, 37, 119, 175, 74, 229, 6, 76, 88,
+            209, 79, 175, 135, 230, 45, 89, 116, 17, 76, 49, 87, 242, 4, 40, 35, 2, 33, 229, 84,
+            218, 198, 132, 136, 197, 212, 253, 180, 247, 125, 228, 176, 179, 248, 100, 19, 202,
+            143, 20, 196, 132, 112, 114, 44, 43, 11, 174, 49, 96, 16, 4, 1, 36, 0, 5, 2, 1, 1, 101,
+            0, 126, 152, 206, 30, 157, 147, 101, 232, 212, 68, 50, 242, 52, 170, 136, 72, 39, 136,
+            235, 41, 105, 28, 199, 93, 222, 168, 227, 241, 80, 234, 2, 185, 2, 120, 2, 233, 247,
+            175, 89, 203, 114, 37, 58, 187, 95, 169, 151, 247, 245, 82, 228, 73, 77, 131, 5, 100,
+            241, 7, 152, 139, 156, 94, 138, 33, 173, 16, 2, 124, 156, 122, 25, 79, 47, 39, 233, 96,
+            90, 9, 165, 232, 130, 103, 245, 113, 145, 31, 183, 102, 94, 40, 86, 140, 146, 128, 172,
+            85, 184, 13, 220, 16, 1, 48, 30, 57, 216, 246, 121, 172, 45, 163, 129, 189, 9, 238,
+            108, 64, 21, 231, 140, 164, 160, 37, 184, 182, 34, 151, 148, 194, 74, 83, 124, 199, 87,
+            17, 17, 2, 199, 32, 12, 6, 52, 58, 219, 92, 42, 60, 69, 132, 209, 186, 193, 248, 18,
+            33, 26, 78, 216, 110, 114, 103, 202, 56, 45, 175, 163, 68, 139, 6, 16, 1, 62, 159, 56,
+            33, 169, 193, 143, 7, 131, 179, 169, 31, 163, 163, 50, 117, 235, 211, 94, 247, 244, 60,
+            246, 149, 186, 142, 105, 187, 230, 247, 212, 141, 17, 1, 1, 36, 125, 4, 1, 99, 0, 20,
+            2, 1, 16, 0, 0, 0, 0, 0, 0, 1, 4, 0, 0, 0, 0, 0, 0, 1, 8, 0, 97, 206, 71, 247, 121, 93,
+            103, 7, 209, 119, 82, 59, 209, 145, 171, 254, 112, 14, 204, 81, 30, 98, 213, 203, 146,
+            141, 32, 167, 232, 34, 0, 37, 2, 170, 200, 228, 36, 229, 197, 116, 242, 100, 137, 25,
+            37, 45, 57, 56, 2, 38, 8, 75, 144, 250, 71, 108, 90, 106, 133, 2, 231, 236, 42, 149,
+            206, 16, 1, 77, 52, 100, 69, 203, 109, 100, 190, 84, 2, 6, 238, 168, 74, 208, 99, 16,
+            56, 200, 98, 181, 205, 24, 79, 120, 235, 223, 144, 61, 197, 8, 215, 17, 1, 1, 99, 220,
+            1, 28, 113, 173, 87, 207, 150, 171, 166, 221, 201, 207, 122, 14, 62, 119, 8, 5, 100,
+            182, 50, 112, 191, 244, 5, 125, 9, 161, 17, 66, 201, 126, 148, 2, 170, 62, 172, 42,
+            117, 12, 62, 165, 78, 141, 84, 194, 75, 135, 140, 198, 85, 219, 214, 218, 149, 56, 32,
+            251, 16, 134, 21, 44, 31, 22, 80, 69, 16, 1, 191, 139, 156, 120, 188, 0, 187, 111, 169,
+            41, 135, 146, 156, 103, 102, 125, 235, 0, 70, 180, 94, 103, 134, 250, 135, 56, 55, 144,
+            156, 185, 212, 67, 2, 223, 93, 226, 244, 94, 203, 160, 13, 145, 161, 22, 104, 133, 135,
+            132, 239, 27, 61, 12, 167, 134, 237, 120, 58, 229, 208, 50, 55, 70, 139, 211, 234, 16,
+            2, 58, 253, 249, 36, 12, 24, 122, 198, 7, 161, 13, 237, 229, 3, 224, 98, 176, 51, 237,
+            101, 105, 33, 10, 45, 111, 96, 89, 201, 212, 82, 1, 141, 5, 16, 0, 0, 0, 0, 0, 0, 1,
+            32, 0, 0, 0, 0, 0, 0, 1, 36, 77, 228, 149, 252, 55, 96, 22, 145, 235, 199, 188, 83, 13,
+            88, 13, 241, 48, 191, 78, 152, 20, 50, 252, 186, 199, 105, 134, 73, 62, 136, 228, 196,
+            17, 17, 17, 0, 1,
+        ];
+
+        let start_block_height = 329u64;
+        let platform_version = PlatformVersion::latest();
+
+        let result = Drive::verify_compacted_address_balance_changes(
+            &proof,
+            start_block_height,
+            None,
+            platform_version,
+        );
+
+        assert!(
+            result.is_err(),
+            "a single adaptive proof must fail closed without an authenticated predecessor"
+        );
+    }
+}

--- a/packages/rs-platform-version/src/version/drive_versions/drive_verify_method_versions/mod.rs
+++ b/packages/rs-platform-version/src/version/drive_versions/drive_verify_method_versions/mod.rs
@@ -1,6 +1,7 @@
 use versioned_feature_core::FeatureVersion;
 
 pub mod v1;
+pub mod v2;
 
 #[derive(Clone, Debug, Default)]
 pub struct DriveVerifyMethodVersions {

--- a/packages/rs-platform-version/src/version/drive_versions/drive_verify_method_versions/v2.rs
+++ b/packages/rs-platform-version/src/version/drive_versions/drive_verify_method_versions/v2.rs
@@ -1,0 +1,26 @@
+use crate::version::drive_versions::drive_verify_method_versions::v1::DRIVE_VERIFY_METHOD_VERSIONS_V1;
+use crate::version::drive_versions::drive_verify_method_versions::{
+    DriveVerifyAddressFundsMethodVersions, DriveVerifyMethodVersions,
+};
+
+/// Version 2 of the Drive verify method versions.
+///
+/// Changed from v1: `verify_compacted_address_balance_changes` 0 → 1. Version
+/// 1 decodes the legacy single GroveDB proof; version 2 decodes the two-proof
+/// `CompactedAddressBalanceProof` bincode envelope whose independently
+/// verified predecessor proof binds the forward-query start key (the
+/// soundness fix from the bind-and-bound proof decoding change). Must move in
+/// lockstep with
+/// `DriveSavedBlockTransactionsMethodVersions::prove_compacted_address_balance_changes`,
+/// which selects the matching encoder on the server side.
+pub const DRIVE_VERIFY_METHOD_VERSIONS_V2: DriveVerifyMethodVersions = DriveVerifyMethodVersions {
+    address_funds: DriveVerifyAddressFundsMethodVersions {
+        verify_address_info: 0,
+        verify_addresses_infos: 0,
+        verify_address_funds_trunk_query: 0,
+        verify_address_funds_branch_query: 0,
+        verify_recent_address_balance_changes: 0,
+        verify_compacted_address_balance_changes: 1,
+    },
+    ..DRIVE_VERIFY_METHOD_VERSIONS_V1
+};

--- a/packages/rs-platform-version/src/version/drive_versions/drive_verify_method_versions/v2.rs
+++ b/packages/rs-platform-version/src/version/drive_versions/drive_verify_method_versions/v2.rs
@@ -5,12 +5,12 @@ use crate::version::drive_versions::drive_verify_method_versions::{
 
 /// Version 2 of the Drive verify method versions.
 ///
-/// Changed from v1: `verify_compacted_address_balance_changes` 0 → 1. Version
-/// 1 decodes the legacy single GroveDB proof; version 2 decodes the two-proof
-/// `CompactedAddressBalanceProof` bincode envelope whose independently
-/// verified predecessor proof binds the forward-query start key (the
-/// soundness fix from the bind-and-bound proof decoding change). Must move in
-/// lockstep with
+/// Changed from v1: `verify_compacted_address_balance_changes` 0 → 1. Feature
+/// version 0 decodes the legacy single GroveDB proof; feature version 1
+/// decodes the two-proof `CompactedAddressBalanceProof` bincode envelope
+/// whose independently verified predecessor proof binds the forward-query
+/// start key (the soundness fix from the bind-and-bound proof decoding
+/// change). Must move in lockstep with
 /// `DriveSavedBlockTransactionsMethodVersions::prove_compacted_address_balance_changes`,
 /// which selects the matching encoder on the server side.
 pub const DRIVE_VERIFY_METHOD_VERSIONS_V2: DriveVerifyMethodVersions = DriveVerifyMethodVersions {

--- a/packages/rs-platform-version/src/version/drive_versions/mod.rs
+++ b/packages/rs-platform-version/src/version/drive_versions/mod.rs
@@ -83,6 +83,13 @@ pub struct DrivePlatformStateMethodVersions {
 pub struct DriveSavedBlockTransactionsMethodVersions {
     pub store_address_balances: FeatureVersion,
     pub fetch_address_balances: FeatureVersion,
+    /// Wire format of the compacted address-balance-changes proof. 0 emits a
+    /// single GroveDB proof; 1 emits the two-proof
+    /// `CompactedAddressBalanceProof` bincode envelope (predecessor +
+    /// forward). Must move in lockstep with
+    /// `DriveVerifyAddressFundsMethodVersions::verify_compacted_address_balance_changes`,
+    /// which selects the matching decoder on the client side.
+    pub prove_compacted_address_balance_changes: FeatureVersion,
     pub compact_address_balances: FeatureVersion,
     pub cleanup_expired_address_balances: FeatureVersion,
     /// Maximum number of blocks to store before compaction is triggered

--- a/packages/rs-platform-version/src/version/drive_versions/v1.rs
+++ b/packages/rs-platform-version/src/version/drive_versions/v1.rs
@@ -118,6 +118,7 @@ pub const DRIVE_VERSION_V1: DriveVersion = DriveVersion {
         saved_block_transactions: DriveSavedBlockTransactionsMethodVersions {
             store_address_balances: 0,
             fetch_address_balances: 0,
+            prove_compacted_address_balance_changes: 0,
             compact_address_balances: 0,
             cleanup_expired_address_balances: 0,
             max_blocks_before_compaction: 64,

--- a/packages/rs-platform-version/src/version/drive_versions/v2.rs
+++ b/packages/rs-platform-version/src/version/drive_versions/v2.rs
@@ -118,6 +118,7 @@ pub const DRIVE_VERSION_V2: DriveVersion = DriveVersion {
         saved_block_transactions: DriveSavedBlockTransactionsMethodVersions {
             store_address_balances: 0,
             fetch_address_balances: 0,
+            prove_compacted_address_balance_changes: 0,
             compact_address_balances: 0,
             cleanup_expired_address_balances: 0,
             max_blocks_before_compaction: 64,

--- a/packages/rs-platform-version/src/version/drive_versions/v3.rs
+++ b/packages/rs-platform-version/src/version/drive_versions/v3.rs
@@ -118,6 +118,7 @@ pub const DRIVE_VERSION_V3: DriveVersion = DriveVersion {
         saved_block_transactions: DriveSavedBlockTransactionsMethodVersions {
             store_address_balances: 0,
             fetch_address_balances: 0,
+            prove_compacted_address_balance_changes: 0,
             compact_address_balances: 0,
             cleanup_expired_address_balances: 0,
             max_blocks_before_compaction: 64,

--- a/packages/rs-platform-version/src/version/drive_versions/v4.rs
+++ b/packages/rs-platform-version/src/version/drive_versions/v4.rs
@@ -118,6 +118,7 @@ pub const DRIVE_VERSION_V4: DriveVersion = DriveVersion {
         saved_block_transactions: DriveSavedBlockTransactionsMethodVersions {
             store_address_balances: 0,
             fetch_address_balances: 0,
+            prove_compacted_address_balance_changes: 0,
             compact_address_balances: 0,
             cleanup_expired_address_balances: 0,
             max_blocks_before_compaction: 64,

--- a/packages/rs-platform-version/src/version/drive_versions/v5.rs
+++ b/packages/rs-platform-version/src/version/drive_versions/v5.rs
@@ -120,6 +120,7 @@ pub const DRIVE_VERSION_V5: DriveVersion = DriveVersion {
         saved_block_transactions: DriveSavedBlockTransactionsMethodVersions {
             store_address_balances: 0,
             fetch_address_balances: 0,
+            prove_compacted_address_balance_changes: 0,
             compact_address_balances: 0,
             cleanup_expired_address_balances: 0,
             max_blocks_before_compaction: 64,

--- a/packages/rs-platform-version/src/version/drive_versions/v6.rs
+++ b/packages/rs-platform-version/src/version/drive_versions/v6.rs
@@ -122,6 +122,7 @@ pub const DRIVE_VERSION_V6: DriveVersion = DriveVersion {
         saved_block_transactions: DriveSavedBlockTransactionsMethodVersions {
             store_address_balances: 0,
             fetch_address_balances: 0,
+            prove_compacted_address_balance_changes: 0,
             compact_address_balances: 0,
             cleanup_expired_address_balances: 0,
             max_blocks_before_compaction: 64,

--- a/packages/rs-platform-version/src/version/drive_versions/v7.rs
+++ b/packages/rs-platform-version/src/version/drive_versions/v7.rs
@@ -120,6 +120,7 @@ pub const DRIVE_VERSION_V7: DriveVersion = DriveVersion {
         saved_block_transactions: DriveSavedBlockTransactionsMethodVersions {
             store_address_balances: 0,
             fetch_address_balances: 0,
+            prove_compacted_address_balance_changes: 0,
             compact_address_balances: 0,
             cleanup_expired_address_balances: 0,
             max_blocks_before_compaction: 64,

--- a/packages/rs-platform-version/src/version/drive_versions/v8.rs
+++ b/packages/rs-platform-version/src/version/drive_versions/v8.rs
@@ -9,7 +9,7 @@ use crate::version::drive_versions::drive_identity_method_versions::v1::DRIVE_ID
 use crate::version::drive_versions::drive_state_transition_method_versions::v3::DRIVE_STATE_TRANSITION_METHOD_VERSIONS_V3;
 use crate::version::drive_versions::drive_structure_version::v1::DRIVE_STRUCTURE_V1;
 use crate::version::drive_versions::drive_token_method_versions::v1::DRIVE_TOKEN_METHOD_VERSIONS_V1;
-use crate::version::drive_versions::drive_verify_method_versions::v1::DRIVE_VERIFY_METHOD_VERSIONS_V1;
+use crate::version::drive_versions::drive_verify_method_versions::v2::DRIVE_VERIFY_METHOD_VERSIONS_V2;
 use crate::version::drive_versions::drive_vote_method_versions::v2::DRIVE_VOTE_METHOD_VERSIONS_V2;
 use crate::version::drive_versions::{
     DriveAssetLockMethodVersions, DriveBalancesMethodVersions, DriveBatchOperationsMethodVersion,
@@ -67,7 +67,7 @@ pub const DRIVE_VERSION_V8: DriveVersion = DriveVersion {
             add_estimation_costs_for_adding_asset_lock: 0,
             fetch_asset_lock_outpoint_info: 0,
         },
-        verify: DRIVE_VERIFY_METHOD_VERSIONS_V1,
+        verify: DRIVE_VERIFY_METHOD_VERSIONS_V2, // changed in v8: compacted address-balance proof envelope (verify v1)
         identity: DRIVE_IDENTITY_METHOD_VERSIONS_V1,
         token: DRIVE_TOKEN_METHOD_VERSIONS_V1,
         platform_system: DrivePlatformSystemMethodVersions {
@@ -120,6 +120,7 @@ pub const DRIVE_VERSION_V8: DriveVersion = DriveVersion {
         saved_block_transactions: DriveSavedBlockTransactionsMethodVersions {
             store_address_balances: 0,
             fetch_address_balances: 0,
+            prove_compacted_address_balance_changes: 1,
             compact_address_balances: 0,
             cleanup_expired_address_balances: 0,
             max_blocks_before_compaction: 64,

--- a/packages/rs-platform-version/src/version/mocks/v2_test.rs
+++ b/packages/rs-platform-version/src/version/mocks/v2_test.rs
@@ -153,7 +153,7 @@ pub const TEST_PLATFORM_V2: PlatformVersion = PlatformVersion {
                 read_total_balance: 0,
                 notes_count: 0,
             },
-            saved_block_transactions: DriveSavedBlockTransactionsMethodVersions { store_address_balances: 0, fetch_address_balances: 0, compact_address_balances: 0, cleanup_expired_address_balances: 0, max_blocks_before_compaction: 64, max_addresses_before_compaction: 2048 },
+            saved_block_transactions: DriveSavedBlockTransactionsMethodVersions { store_address_balances: 0, fetch_address_balances: 0, prove_compacted_address_balance_changes: 0, compact_address_balances: 0, cleanup_expired_address_balances: 0, max_blocks_before_compaction: 64, max_addresses_before_compaction: 2048 },
         },
         grove_methods: DRIVE_GROVE_METHOD_VERSIONS_V1,
         grove_version: GROVE_V1,

--- a/packages/rs-platform-version/src/version/v13.rs
+++ b/packages/rs-platform-version/src/version/v13.rs
@@ -53,6 +53,13 @@ pub const PROTOCOL_VERSION_13: ProtocolVersion = 13;
 ///   operation conversions to v1, which rewrite a transferred or purchased
 ///   domain's `records.identity` to the new owner so the username resolves
 ///   to the buyer.
+/// * `DRIVE_VERSION_V8` also switches the compacted address-balance-changes
+///   proof to the two-proof `CompactedAddressBalanceProof` bincode envelope
+///   (`prove_compacted_address_balance_changes` 1 via
+///   `DRIVE_VERIFY_METHOD_VERSIONS_V2`'s matching decoder bump): the
+///   independently verified predecessor proof binds the forward-query start
+///   key. Nodes and clients on v12 and below keep the legacy single GroveDB
+///   proof, so mixed-version networks interoperate until v13 activates.
 pub const PLATFORM_V13: PlatformVersion = PlatformVersion {
     protocol_version: PROTOCOL_VERSION_13,
     drive: DRIVE_VERSION_V8,


### PR DESCRIPTION
## Issue being fixed or feature implemented

#4165 rewrote the compacted address-balance-changes proof wire format in place: the legacy single GroveDB proof became the two-proof `CompactedAddressBalanceProof` bincode envelope, while the method-version registry stayed at 0 on both the prove and verify sides (`drive_verify_method_versions/v1.rs` still said `verify_compacted_address_balance_changes: 0`, and the dispatcher only knew v0). With the format mutated under an unchanged version number there was no way to distinguish old-format from new-format peers at runtime — any client/server pair not built from the same commit failed this query by construction (a 4.1 client against today's 4.0-rc testnet nodes fails on every peer, and vice versa). This is the versioning-discipline hole raised in review of #4221: peer preference can only mitigate it probabilistically; the format itself has to be protocol-version negotiated.

## What was done?

- **Verify side (`rs-drive/src/verify/.../verify_compacted_address_balance_changes`)**: the legacy single-proof decoder is restored as `v0`, byte-for-byte wire-compatible with proofs emitted by 4.0-era nodes (the decode-allocation bounds from #4165 are kept, since they bound hostile allocations without changing the accepted format). The envelope decoder — including the predecessor-binding soundness fix, which inherently requires the two-proof format — moves to `v1`. The dispatcher now knows versions 0 and 1.
- **Prove side (`rs-drive/src/drive/saved_block_transactions/fetch_compacted_address_balances`)**: `v0` emits the legacy single proof again; the envelope encoder moves to `v1`. Proving now dispatches on a new dedicated `prove_compacted_address_balance_changes` feature version instead of overloading `fetch_address_balances`, so the proof wire format is versioned independently of the data-fetch path.
- **Registry (`rs-platform-version`)**: new `DRIVE_VERIFY_METHOD_VERSIONS_V2` bumps the verify method to 1 and is wired only into `DRIVE_VERSION_V8` (protocol version 13); drive bundles v1–v7 (protocol ≤ 12) stay on 0 for both sides. The two fields are documented as lockstep pairs.

Because drive-abci serves queries with the network's **active epoch** platform version (`platform_state.current_platform_version()`), and SDK clients track that same version through the proven metadata ratchet, both sides now flip formats together when PV13 activates. Mixed 4.0/4.1 networks interoperate on the legacy format until then — old peers are never broken by new software, and the hardened envelope (predecessor-bound start key) becomes the enforced format from PV13 onward.

## How Has This Been Tested?

- New tests pin the legacy roundtrip under protocol version 12 (prove v0 → verify v0 through the public dispatchers) and cross-format rejection in **both** directions: an envelope proof must fail closed under the legacy verifier, and a legacy proof must fail closed under the envelope verifier (existing #4208 test, now in `v1`).
- All #4208 envelope tests (multi-range, pagination, spliced-root rejection) moved to `v1` and pass under PV13/latest.
- `cargo test -p drive --lib` — 3242 passed; `cargo test -p drive-abci compacted` (handler + strategy address tests) green; `cargo test -p platform-version` green; `cargo check -p drive --no-default-features --features verify`, `drive-proof-verifier`, `dash-sdk`, `rs-sdk-ffi`, and the full workspace all compile; clippy clean; `cargo fmt` applied.

## Breaking Changes

None released: protocol version 13 is not yet active on any network, so this only re-gates the (unreleased) envelope format behind PV13 activation while restoring compatibility with deployed 4.0-era peers on PV12 and below. Not consensus-breaking — proofs are client-server wire, not app-hash state.

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [x] I have made corresponding changes to the documentation if needed

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for a versioned compacted address-balance proof format.
  * Newer protocol versions use an authenticated two-part proof, while earlier versions continue using the legacy format.
  * Added protocol-version negotiation and configuration for producing and verifying both formats.

* **Bug Fixes**
  * Improved proof validation, including root consistency checks, malformed-data rejection, pagination, and range selection.

* **Documentation**
  * Documented proof-format differences and compatibility behavior across protocol versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->