### PR TITLE
fix(release): base changelog on the immediately-preceding release

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -117,6 +117,12 @@ curl -s https://registry.npmjs.org/@dashevo/<pkg>/<version> | python3 -c "import
 
 **Permanent fix (a human with owner rights on the package, via the npm web UI):** configure the trusted publisher, then re-run the failed job.
 
+**Bootstrap first if the package was _never published_.** Trusted-publisher configuration needs an existing package page — a `404` package has no **Access** settings to configure. So you must create the package before you can wire up OIDC:
+
+0. Publish one version with a token (`npm publish --access public` from the package dir, or the Stopgap command below). This creates the package on npm.
+
+Then, for **both** cases (never-published-now-bootstrapped, and exists-without-a-publisher):
+
 1. npmjs.com → the package → **Access** → **Trusted Publisher** → **GitHub Actions**: organization/user `dashpay`, repository `platform`, workflow filename `release.yml`, environment **blank** (the `release-npm` job uses no environment). Save.
 2. Re-run the failed job — OIDC now publishes the missing version and `--tolerate-republish` skips the rest → green:
 
@@ -126,7 +132,7 @@ gh run rerun <release-run-id> --repo dashpay/platform --failed
 
 **Stopgap only (does not stop the recurrence):** publish the exact release version once with a token, then re-run the failed job (`--tolerate-republish` skips it). The dist-tag matches CI's — prerelease `<major>.<minor>-<suffix>` (e.g. `4.1-rc`), stable `latest` (`npm view @dashevo/dpns-contract dist-tags`). This unblocks the current release but the next one fails the same way until the trusted publisher is configured.
 
-**Prevention:** whenever you add a new publishable npm package, configure its npm trusted publisher (org `dashpay`, repo `platform`, workflow `release.yml`) **before** cutting the release that ships it. `release.sh` prints this reminder after opening the release PR.
+**Prevention:** whenever you add a new publishable npm package, bootstrap it **before** cutting the release that ships it — publish one version with a token so the package exists, then configure its npm trusted publisher (org `dashpay`, repo `platform`, workflow `release.yml`) on the freshly created package. The publisher cannot be configured until the package exists, so the token publish is the required first step, not an optional stopgap. `release.sh` prints this reminder after opening the release PR.
 
 ## Post-stable-release: graduate the dev branch
 

--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -127,3 +127,34 @@ gh run rerun <release-run-id> --repo dashpay/platform --failed
 **Stopgap only (does not stop the recurrence):** publish the exact release version once with a token, then re-run the failed job (`--tolerate-republish` skips it). The dist-tag matches CI's — prerelease `<major>.<minor>-<suffix>` (e.g. `4.1-rc`), stable `latest` (`npm view @dashevo/dpns-contract dist-tags`). This unblocks the current release but the next one fails the same way until the trusted publisher is configured.
 
 **Prevention:** whenever you add a new publishable npm package, configure its npm trusted publisher (org `dashpay`, repo `platform`, workflow `release.yml`) **before** cutting the release that ships it. `release.sh` prints this reminder after opening the release PR.
+
+## Post-stable-release: graduate the dev branch
+
+After a **stable** `vX.Y.0` release PR merges into `vX.Y-dev`, promote the branches so `vX.Y-dev` becomes the `X.Y.x` patch line and the next dev line takes over. Only do this for a **stable** release, not prereleases. (Example below is the 4.1.0 run: current dev `v4.1-dev`, next dev `v4.2-dev`. If the next release is a **major** bump, the user says so — e.g. `v5.0-dev`.)
+
+**Read first — the ruleset, not classic protection, is what blocks direct pushes.** `master`, `main`, `develop`, and every `v*` branch are covered by a repo **ruleset** (`Block deletions, require PR`, `id 501248`) that requires a PR and is **separate** from classic branch protection — a repo admin does **not** automatically bypass it, and `gh api repos/.../branches/<b>/protection` does **not** show it. Only users in the ruleset's `bypass_actors` can push directly (currently shumkov `24296` and QuantumExplorer `11468583`, both `always`). To grant a user standing bypass, fetch the ruleset, append them, and PUT it back:
+
+```sh
+gh api repos/dashpay/platform/rulesets/501248 > r.json
+jq '{name,target,enforcement,bypass_actors:(.bypass_actors+[{actor_id:<userId>,actor_type:"User",bypass_mode:"always"}]),conditions,rules}' r.json > put.json
+gh api --method PUT repos/dashpay/platform/rulesets/501248 --input put.json   # find <userId>: gh api users/<login> --jq .id
+```
+
+Steps (skip whatever is already done — e.g. the next dev branch and default may have been set early):
+
+1. **Ensure the next dev branch exists** — `v(X.Y+1)-dev`. If it exists but is behind current dev, it just needs the sync in step 3.
+2. **Merge current dev → `master`** (master tracks the latest stable). master is usually far behind and its only unique commits are **auto-generated** (e.g. `.github/grpc-queries-cache.json`, committed by `tests-rs-sdk-grpc-coverage.yml` as `chore: update gRPC queries cache [skip ci]`) — disposable. **Merge, don't force-reset** (master sets `allow_force_pushes:false`, and `required_linear_history:false` so a merge commit is allowed); resolve the generated cache toward the dev branch:
+   ```sh
+   git checkout master && git reset --hard origin/master
+   git merge origin/vX.Y-dev                                    # conflicts only on generated caches
+   git checkout --theirs .github/grpc-queries-cache.json && git add -A
+   git commit --no-edit && git push origin master
+   ```
+3. **Fast-forward next dev to current dev** (carry the release commits into the next line). It is typically strictly behind → a clean fast-forward:
+   ```sh
+   git push origin origin/vX.Y-dev:v(X.Y+1)-dev
+   ```
+   The next dev branch **stays at version `X.Y.0`** until its first `v(X.Y+1).0-dev.1` release is cut — do **not** bump it now.
+4. **Make next dev the default branch** if it isn't already (repo Settings → Branches, or `gh api`).
+5. **Milestones** — ensure `vX.Y.x` (patches for the just-released line) and `v(X.Y+1).0` (next dev prereleases) exist. Create with `gh api repos/dashpay/platform/milestones -f title="vX.Y.x" -f state=open`. (Stable-release milestone convention is `vX.Y.x`; prerelease is `vX.Y.0`.)
+6. **Re-target open PRs** from current dev → next dev: `gh pr edit <n> --base v(X.Y+1)-dev`. Leave genuine `vX.Y.x` patch PRs on `vX.Y-dev`. Note the `milestone.yml` workflow auto-assigns a PR's milestone by its base branch.

--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -56,6 +56,8 @@ Given current root version and its type:
 3. Run `yarn release -v=<target-version>` (this pushes a branch and opens a PR — an outward-facing action; confirm before running unless already told to proceed).
 4. Report back: new version, the `release_<version>` branch, the changelog-from tag used, and the PR URL. Verify the bump landed in `package.json` + `Cargo.toml` and that the versions match.
 
+**Changelog base tag.** `find_latest_tag.js` resolves the tag the changelog is generated from and `release.sh` prints it (`Changelog base tag : <tag>`) for verification before generating — an interactive run also pauses for confirmation. The base must be the **immediately-preceding release** (by creation date); a too-far-back base regenerates already-present `CHANGELOG.md` sections and duplicates them. The resolver bases a first prerelease of a new id (e.g. the first `rc` after betas) off the newest prerelease on that `X.Y.0` line, and warns if existing tags would be duplicated. If the base is ever wrong, abort and re-run with `-c=<correct-tag>`.
+
 ## First 4.1 beta example
 
 Current version `4.0.0` on branch `v4.1-dev`, cutting the first 4.1 beta:
@@ -96,29 +98,32 @@ Changelog link for the notes: `https://github.com/dashpay/platform/blob/v<versio
 
 4. Publishing fires `release.yml` — verify the release build succeeds and the dashmate / Docker assets attach to the release. The Kotlin and Swift SDK jobs run in the same workflow but take longer (the Kotlin native build can run ~3 h) — the release page fills in as they finish. The Maven Central deploy runs automatically after the Kotlin build (no approval gate); note that PR CI does **not** exercise the release-profile arm64 SDK builds, so an SDK build break surfaces here first — for a stable release, confirm the SDK jobs were green on the preceding rc. To re-run just one SDK release: `gh workflow run release-kotlin-sdk.yml --ref v<version> -f tag=v<version>` (same for `release-swift-sdk.yml`) — must be dispatched **at the tag ref**, with the **plain tag name** as input (no `refs/tags/` prefix). **Confirm with the release owner immediately before dispatching**: the re-run attaches public release assets and the Kotlin one can publish an irrevocable Maven Central version (no approval gate). Works only for tags that already contain these workflow files (post-consolidation); for older tags, dispatch at the dev branch — assets attach, Maven deploy skips — and use the manual runbook in `packages/kotlin-sdk/PUBLISHING.md` for Maven.
 
-## Known gotcha: a brand-new npm package breaks the publish
+## Known gotcha: a new npm package without a trusted publisher breaks the publish
 
-`release.yml`'s **Release NPM packages** job publishes with `yarn workspaces foreach --all --no-private --parallel npm publish --tolerate-republish --access public` over **npm trusted-publishers OIDC**. OIDC trusted publishing can **only publish to a package that already exists** on npm with a trusted publisher configured — it **cannot create (bootstrap) a brand-new package**. So the first release after someone adds a new `@dashevo/*` package fails: the job publishes every existing package fine, then exits 1 on the new one (which is `404 Not Found` on the registry). `--access public` and `--tolerate-republish` are already set — they are **not** the fix.
+`release.yml`'s **Release NPM packages** job publishes with `yarn workspaces foreach --all --no-private --parallel npm publish --tolerate-republish --access public` over **npm trusted-publishers OIDC**. OIDC can only publish to a package that has a **trusted publisher configured** on npm for it. Two ways a new `@dashevo/*` package trips this:
 
-**Symptom:** the release run's "Release NPM packages" job fails; `yarn` reports `The command failed in workspace @dashevo/<new-pkg> ... exit code 1`; `npm view @dashevo/<new-pkg>` → `E404`, while the other contracts show the release version.
+- **Never published** — the package does not exist on npm; OIDC cannot bootstrap it (`404`).
+- **Exists but has no trusted publisher** — e.g. it was first-published manually with a token. The package exists, but OIDC has nothing to authenticate against, so publishing a *new version* fails. This is the subtle one: a one-off manual publish is **not** a permanent fix — the publish job keeps failing on that package **every** release until the trusted publisher is configured.
 
-**Fix (needs `@dashevo` publish rights + a 2FA OTP — a human with npm access must do it):**
+`--access public` and `--tolerate-republish` are already set — they are **not** the fix.
 
-1. Check out the package at the released version and publish it once with a token (not OIDC). The npm dist-tag matches CI's: for a prerelease it is `<major>.<minor>-<suffix>` (e.g. `4.1-beta`); for a stable release it is `latest`. Read it from an already-published package: `npm view @dashevo/dpns-contract dist-tags`.
+**Symptom:** the run's "Release NPM packages" job fails; `yarn` reports `The command failed in workspace @dashevo/<pkg> ... exit code 1`. The per-package error is `YN0033: No authentication configured for request` (no trusted publisher) or a `404`/`E404` (never published). Confirm which package and how it was last published:
 
 ```sh
-git checkout origin/<dev-branch> -- packages/<new-pkg>          # get the released version
-cd packages/<new-pkg>
-npm publish --access public --tag <major.minor-suffix> --otp=<code>
-git checkout HEAD -- packages/<new-pkg>                          # restore working tree
+# what published the latest version — GitHub Actions (OIDC) has a trustedPublisher field; a
+# human username means it was a manual token publish and OIDC is NOT wired up:
+curl -s https://registry.npmjs.org/@dashevo/<pkg>/<version> | python3 -c "import sys,json;print(json.load(sys.stdin).get('_npmUser'))"
 ```
 
-2. Re-run the failed job — `--tolerate-republish` now skips every package (all already at the release version) → green:
+**Permanent fix (a human with owner rights on the package, via the npm web UI):** configure the trusted publisher, then re-run the failed job.
+
+1. npmjs.com → the package → **Access** → **Trusted Publisher** → **GitHub Actions**: organization/user `dashpay`, repository `platform`, workflow filename `release.yml`, environment **blank** (the `release-npm` job uses no environment). Save.
+2. Re-run the failed job — OIDC now publishes the missing version and `--tolerate-republish` skips the rest → green:
 
 ```sh
 gh run rerun <release-run-id> --repo dashpay/platform --failed
 ```
 
-After this first publish the package exists on npm, so **every later release publishes it automatically**. Note: right after publishing, `npm view` may still `404` for a few minutes (npm CDN negative-cache); the `http fetch PUT 200` line in `~/.npm/_logs/…` confirms the publish landed.
+**Stopgap only (does not stop the recurrence):** publish the exact release version once with a token, then re-run the failed job (`--tolerate-republish` skips it). The dist-tag matches CI's — prerelease `<major>.<minor>-<suffix>` (e.g. `4.1-rc`), stable `latest` (`npm view @dashevo/dpns-contract dist-tags`). This unblocks the current release but the next one fails the same way until the trusted publisher is configured.
 
-**Prevention:** whenever you add a new publishable npm package to the monorepo, first-publish it manually (or set up its trusted publisher on npm) **before** cutting the release that would ship it.
+**Prevention:** whenever you add a new publishable npm package, configure its npm trusted publisher (org `dashpay`, repo `platform`, workflow `release.yml`) **before** cutting the release that ships it. `release.sh` prints this reminder after opening the release PR.

--- a/scripts/release/find_latest_tag.js
+++ b/scripts/release/find_latest_tag.js
@@ -105,7 +105,10 @@ if (require.main === module) {
   }
 
   (async () => {
-    const rawTags = await execute('git tag -l --sort=-creatordate');
+    // --merged HEAD restricts candidates to tags reachable from the release branch,
+    // excluding prereleases created on divergent PR branches (e.g. vX.Y.0-pr.NNNN.M)
+    // that would otherwise be picked as a bogus base by the creation-ordered fallback.
+    const rawTags = await execute('git tag -l --merged HEAD --sort=-creatordate');
     const tags = rawTags.split('\n').map((tag) => tag.trim()).filter(Boolean);
 
     const result = findLatestTag(version, tags);

--- a/scripts/release/find_latest_tag.js
+++ b/scripts/release/find_latest_tag.js
@@ -1,47 +1,127 @@
 const semver = require('semver');
 const execute = require('../utils/execute');
 
-const [ version ] = process.argv.slice(2);
+/**
+ * Choose the tag the changelog should be generated from for a given target version.
+ *
+ * The base must be the immediately-preceding release so conventional-changelog only
+ * emits the delta for the new version. Picking a base that is too far back makes it
+ * regenerate the intervening version sections and prepend them on top of the copies
+ * already in CHANGELOG.md, duplicating them.
+ *
+ * `tags` must be ordered newest-created-first (git tag --sort=-creatordate). Release
+ * chronology is used rather than semver precedence on purpose: prerelease ids do not
+ * sort by release order (semver compares them alphabetically, so e.g. "beta" < "dev"),
+ * so the last prerelease actually released before a new one is only knowable from
+ * creation order.
+ *
+ * Resolution order:
+ *   prerelease vX.Y.0-<id>.N
+ *     1. newest prerelease on the same X.Y.0 line sharing the same <id>
+ *     2. newest prerelease of any id on the same X.Y.0 line
+ *        (so the first rc after betas bases off the last beta, not the previous stable)
+ *     3. latest stable release of the previous minor
+ *   stable vX.Y.Z
+ *     1. latest stable release of the same minor
+ *     2. newest prerelease on the same X.Y.0 line (a stable cut from a prerelease line)
+ *     3. latest stable release of the previous minor
+ *
+ * @param {string} version - target version, with or without a leading "v"
+ * @param {string[]} tags - existing git tags, ordered newest-created-first
+ * @returns {string|null} the chosen tag, or null if none matches
+ */
+function findLatestTag(version, tags) {
+  const parsed = semver.parse(version);
 
-if (!version) {
-  console.error('usage example: yarn node find_latest_tag.js v0.21.0');
-  process.exit(1);
-}
-
-(async () => {
-  const tags = await execute('git tag -l --sort=-v:refname');
-
-  const isPrerelease = semver.prerelease(version) !== null;
-  const parsedVersion = semver.parse(version);
-
-  let result;
-
-  if (!isPrerelease) {
-    // stable
-
-    // try to find the latest stable version with same minor part
-    result = tags.match(new RegExp(`^v${parsedVersion.major}\.${parsedVersion.minor}\.([0-9]+)$`, 'mgi'));
-
-    // try to find the latest stable version with previous minor part
-    if (!result) {
-      result = tags.match(new RegExp(`^v${parsedVersion.major}\.${parsedVersion.minor - 1}\.([0-9]+)$`, 'mgi'));
-    }
-  } else {
-    // prerelease
-
-    // try to find previous prerelease
-    result = tags.match(new RegExp(`^v${parsedVersion.major}\.${parsedVersion.minor}\.0-${parsedVersion.prerelease[0]}.([0-9]+)$`, 'mgi'));
-
-    if (!result) {
-      // try to find the latest stable version with previous minor part
-      result = tags.match(new RegExp(`^v${parsedVersion.major}\.${parsedVersion.minor - 1}\.([0-9]+)$`, 'mgi'));
-    }
+  if (!parsed) {
+    throw new Error(`Invalid version: ${version}`);
   }
 
-  if (!result) {
-    console.error(`Can't find latest tag for the version ${version}`);
+  const { major, minor } = parsed;
+  const isPrerelease = parsed.prerelease.length > 0;
+
+  // Preserve the given (newest-first) order; drop unparseable tags and the target itself.
+  const candidates = tags
+    .map((tag) => ({ tag, semver: semver.parse(tag) }))
+    .filter(({ semver: v }) => v && v.version !== parsed.version);
+
+  const first = (predicate) => {
+    const match = candidates.find(({ semver: v }) => predicate(v));
+    return match ? match.tag : null;
+  };
+
+  const sameLinePrerelease = (v) => v.prerelease.length > 0 && v.major === major && v.minor === minor;
+  const stableOfMinor = (targetMinor) => (v) => v.prerelease.length === 0
+    && v.major === major
+    && v.minor === targetMinor;
+
+  if (isPrerelease) {
+    const [preId] = parsed.prerelease;
+
+    return first((v) => sameLinePrerelease(v) && v.prerelease[0] === preId)
+      || first(sameLinePrerelease)
+      || first(stableOfMinor(minor - 1));
+  }
+
+  return first(stableOfMinor(minor))
+    || first(sameLinePrerelease)
+    || first(stableOfMinor(minor - 1));
+}
+
+/**
+ * Existing tags created after the chosen base (i.e. newer than it) other than the
+ * target. Each already has its own CHANGELOG.md section, so regenerating from `base`
+ * would duplicate them — a signal that `base` is wrong.
+ *
+ * @param {string} version - target version
+ * @param {string} base - chosen base tag
+ * @param {string[]} tags - existing git tags, ordered newest-created-first
+ * @returns {string[]} intervening tags, newest first
+ */
+function interveningTags(version, base, tags) {
+  const parsedTarget = semver.parse(version);
+  const baseIndex = tags.indexOf(base);
+
+  if (baseIndex === -1) {
+    return [];
+  }
+
+  return tags
+    .slice(0, baseIndex)
+    .filter((tag) => {
+      const v = semver.parse(tag);
+      return v && (!parsedTarget || v.version !== parsedTarget.version);
+    });
+}
+
+module.exports = { findLatestTag, interveningTags };
+
+if (require.main === module) {
+  const [version] = process.argv.slice(2);
+
+  if (!version) {
+    console.error('usage example: yarn node find_latest_tag.js v0.21.0');
     process.exit(1);
   }
 
-  console.log(result[0]);
-})();
+  (async () => {
+    const rawTags = await execute('git tag -l --sort=-creatordate');
+    const tags = rawTags.split('\n').map((tag) => tag.trim()).filter(Boolean);
+
+    const result = findLatestTag(version, tags);
+
+    if (!result) {
+      console.error(`Can't find latest tag for the version ${version}`);
+      process.exit(1);
+    }
+
+    const intervening = interveningTags(version, result, tags);
+    if (intervening.length > 0) {
+      console.error(`WARNING: existing tags newer than the changelog base (${result}) already have `
+        + `CHANGELOG.md sections and will be duplicated: ${intervening.join(', ')}. `
+        + `Pass an explicit -c=<tag> if this base is wrong.`);
+    }
+
+    console.log(result);
+  })();
+}

--- a/scripts/release/find_latest_tag.test.js
+++ b/scripts/release/find_latest_tag.test.js
@@ -1,0 +1,88 @@
+const assert = require('assert');
+const { findLatestTag, interveningTags } = require('./find_latest_tag');
+
+// Tag lists are ordered newest-created-first, matching `git tag --sort=-creatordate`.
+
+let failures = 0;
+
+function check(name, actual, expected) {
+  try {
+    assert.deepStrictEqual(actual, expected);
+    console.log(`  ok - ${name}`);
+  } catch (e) {
+    failures += 1;
+    console.error(`  FAIL - ${name}\n    expected: ${JSON.stringify(expected)}\n    actual:   ${JSON.stringify(actual)}`);
+  }
+}
+
+// The regression: first rc of a new minor line. The base must be the last beta on the
+// same line, NOT the previous stable minor. Basing off v4.0.0 regenerates the beta
+// sections and duplicates them in CHANGELOG.md (the 4.1.0-rc.1 release bug).
+check(
+  'first rc bases off the newest beta, not the previous stable',
+  findLatestTag('4.1.0-rc.1', ['v4.1.0-beta.2', 'v4.1.0-beta.1', 'v4.0.0']),
+  'v4.1.0-beta.2',
+);
+
+// First beta of a line that had dev prereleases: base is the newest dev. semver would
+// order "dev" after "beta" alphabetically, so this only works off release chronology.
+check(
+  'first beta bases off the newest dev on the line',
+  findLatestTag('4.1.0-beta.1', ['v4.1.0-dev.2', 'v4.1.0-dev.1', 'v4.0.0']),
+  'v4.1.0-dev.2',
+);
+
+// Truly first prerelease of a line (no prior prereleases): fall back to previous stable minor.
+check(
+  'first dev of a line bases off the previous stable minor',
+  findLatestTag('4.1.0-dev.1', ['v4.0.1', 'v4.0.0']),
+  'v4.0.1',
+);
+
+// Subsequent prerelease with the same id: base is the previous same-id prerelease.
+check(
+  'second rc bases off the first rc',
+  findLatestTag('4.1.0-rc.2', ['v4.1.0-rc.1', 'v4.1.0-beta.2', 'v4.0.0']),
+  'v4.1.0-rc.1',
+);
+
+// Stable cut from a prerelease line: base is the newest prerelease on that line.
+check(
+  'stable bases off the newest prerelease on its line',
+  findLatestTag('4.1.0', ['v4.1.0-rc.1', 'v4.1.0-beta.2', 'v4.0.0']),
+  'v4.1.0-rc.1',
+);
+
+// Patch stable: base is the previous stable of the same minor.
+check(
+  'patch release bases off the previous same-minor stable',
+  findLatestTag('4.0.1', ['v4.0.0', 'v3.0.2']),
+  'v4.0.0',
+);
+
+// The target tag already existing (e.g. a re-run) must not pick itself.
+check(
+  'does not pick the target tag itself',
+  findLatestTag('4.1.0-rc.1', ['v4.1.0-rc.1', 'v4.1.0-beta.2', 'v4.0.0']),
+  'v4.1.0-beta.2',
+);
+
+// Intervening-tag detection: a too-far-back base surfaces the tags that would duplicate.
+check(
+  'intervening tags flags the sections that would be regenerated',
+  interveningTags('4.1.0-rc.1', 'v4.0.0', ['v4.1.0-beta.2', 'v4.1.0-beta.1', 'v4.0.0']),
+  ['v4.1.0-beta.2', 'v4.1.0-beta.1'],
+);
+
+// A correct base has no intervening tags.
+check(
+  'correct base has no intervening tags',
+  interveningTags('4.1.0-rc.1', 'v4.1.0-beta.2', ['v4.1.0-beta.2', 'v4.1.0-beta.1', 'v4.0.0']),
+  [],
+);
+
+if (failures > 0) {
+  console.error(`\n${failures} test(s) failed`);
+  process.exit(1);
+}
+console.log('\nAll find_latest_tag tests passed');

--- a/scripts/release/release.sh
+++ b/scripts/release/release.sh
@@ -91,6 +91,21 @@ then
   LATEST_TAG=$(yarn node $DIR/find_latest_tag.js $NEW_PACKAGE_VERSION)
 fi
 
+# Surface the changelog base tag for a human to verify: a wrong base makes
+# conventional-changelog regenerate and duplicate existing CHANGELOG.md sections.
+# Any WARNING printed above (from find_latest_tag) lists tags that would be duplicated.
+echo ""
+echo "----------------------------------------------------------------"
+echo "Changelog base tag : $LATEST_TAG"
+echo "New version        : $NEW_PACKAGE_VERSION"
+echo "Verify the base tag is the immediately-preceding release."
+echo "If it is wrong, abort and re-run with:"
+echo "  yarn release -v=$NEW_PACKAGE_VERSION -c=<correct-tag>"
+echo "----------------------------------------------------------------"
+if [ -t 0 ]; then
+  read -r -p "Press Enter to generate the changelog and open the release PR, or Ctrl-C to abort... "
+fi
+
 # generate changelog
 yarn node $DIR/generate_changelog.js $LATEST_TAG
 
@@ -121,6 +136,16 @@ gh pr create --base $CURRENT_BRANCH \
              --title "chore(release): update changelog and bump version to $NEW_PACKAGE_VERSION" \
              --body-file $DIR/pr_description.md \
              --milestone $MILESTONE
+
+echo ""
+echo "----------------------------------------------------------------"
+echo "Before publishing the GitHub release for $NEW_PACKAGE_VERSION:"
+echo "If this release adds a NEW publishable @dashevo/* package, configure its"
+echo "npm trusted publisher first (npmjs.com -> the package -> Access ->"
+echo "Trusted Publisher: GitHub Actions, dashpay/platform, workflow release.yml)."
+echo "OIDC cannot publish a package that has no trusted publisher, so the publish"
+echo "job fails on it otherwise -- a one-off manual publish does NOT fix this."
+echo "----------------------------------------------------------------"
 
 # switch back to base branch
 git checkout -


### PR DESCRIPTION
## Issue being fixed or feature implemented

Cutting `4.1.0-rc.1` produced a `CHANGELOG.md` with the `4.1.0-beta.1` and `4.1.0-beta.2` sections **duplicated**.

Root cause: `scripts/release/find_latest_tag.js` chooses the tag the changelog is generated from. For a **first prerelease of a new id** (the first `rc` after the betas) it looked only for a prior tag with the *same* id (`v4.1.0-rc.*`); finding none, it fell straight back to the previous stable minor (`v4.0.0`), skipping the `4.1.0-beta.*` tags. `conventional-changelog` then regenerated every version block from `v4.0.0`→HEAD and prepended them on top of the copies already in the file, duplicating the beta sections.

This class of bug recurs for the first `alpha`/`beta`/`rc`/`dev` of any line, and for a stable release cut from a prerelease line.

## What was done?

- **`find_latest_tag.js`** — resolve the base to the **newest prerelease on the same `X.Y.0` line** before dropping to the previous stable minor (and likewise for a stable cut from a prerelease line). Ordering is by **tag creation date**, not semver precedence: semver compares prerelease ids alphabetically (`beta` < `dev` < `rc`), which does not match release chronology, so the last prerelease actually released before a new one is only knowable from creation order. Refactored into pure `findLatestTag()` / `interveningTags()` functions.
- **Surface to a human** — `find_latest_tag.js` prints a `WARNING` (stderr) when existing tags would be duplicated; `release.sh` prints the chosen `Changelog base tag` and, on an interactive run, pauses for confirmation before generating the changelog (TTY-guarded, so it never blocks CI/automation).
- **New-package reminder** — after opening the release PR, `release.sh` reminds the operator to configure a new `@dashevo/*` package's npm **trusted publisher** before publishing, since OIDC cannot publish a package that has none.
- **Skill docs** — document the base-tag behavior and correct the trusted-publisher gotcha (a one-off manual publish bootstraps the package's existence but not its OIDC trusted publisher, so the publish job keeps failing every release until the trusted publisher is configured).

## How Has This Been Tested?

Added `scripts/release/find_latest_tag.test.js` (9 assertions incl. the exact rc.1 regression). Demonstrated red→green: against the old fallback the regression case returns `v4.0.0` (RED); with the fix it returns `v4.1.0-beta.2` (GREEN).

```
yarn node scripts/release/find_latest_tag.test.js
```

Also smoke-tested the CLI against the live repo tags: `4.1.0-rc.2` → `v4.1.0-rc.1`, stable `4.1.0` → `v4.1.0-rc.1`, and no spurious warnings. `bash -n scripts/release/release.sh` passes.

Note: `scripts/` has no test runner in CI, so the test is run manually (by design for this change).

## Breaking Changes

None. Behavior is unchanged for cases that already worked (subsequent same-id prerelease, patch releases). Major-bump stable (`X.0.0`) still requires an explicit `-c=<tag>`, as before.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [x] I have made corresponding changes to the documentation if needed

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Clarified changelog base-tag verification, correction, and rerun procedures.
  - Expanded npm Trusted Publishers troubleshooting for OIDC publishing.
  - Added post-stable-release workflow guidance for branch promotion and synchronization.

- **Release Improvements**
  - Added interactive confirmation of the selected base tag and computed version.
  - Improved tag selection across stable and prerelease releases.
  - Warns about intervening changelog tags to help prevent duplicate entries.

- **Tests**
  - Added coverage for tag selection, prerelease handling, patch releases, and intervening-tag detection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->