### PR TITLE
fix(drive-abci): refresh the contract cache when the v13 migration rewrites DPNS

### DIFF
--- a/packages/rs-drive-abci/src/execution/platform_events/protocol_upgrade/perform_events_on_first_block_of_protocol_change/v0/mod.rs
+++ b/packages/rs-drive-abci/src/execution/platform_events/protocol_upgrade/perform_events_on_first_block_of_protocol_change/v0/mod.rs
@@ -691,26 +691,25 @@ impl<C> Platform<C> {
 
         // CONSENSUS-CRITICAL. Both writes above go straight to state and bypass the drive
         // operation batch, whose finalization task is what normally evicts a superseded
-        // contract from the data contract cache. Every contract a migration writes must
-        // therefore be refreshed here explicitly.
+        // contract from the data contract cache. A migration that rewrites a contract
+        // that may already be cached must therefore refresh the cache explicitly.
         //
-        // DPNS is the one that can actually be stale, and the consequences are severe:
-        // the pre-v13 DPNS was stored with a v0 `DataContractConfig`, the v2 contract
-        // written above carries a v1 config, and `DocumentV0::serialize` selects
-        // `serialize_v0` for the former and `serialize_v2` for the latter. A node holding
-        // the pre-migration DPNS in cache would keep writing DPNS documents with a `00`
-        // version prefix while a node with a cold cache writes `02` — the same block,
-        // two different app hashes.
-        for contract_id in [
-            document_history_contract.id().to_buffer(),
+        // Here that is DPNS, and the consequences of skipping it are severe: the pre-v13
+        // DPNS was stored with a v0 `DataContractConfig`, the v2 contract written above
+        // carries a v1 config, and `DocumentV0::serialize` selects `serialize_v0` for
+        // the former and `serialize_v2` for the latter. A node holding the pre-migration
+        // DPNS in cache would keep writing DPNS documents with a `00` version prefix
+        // while a node with a cold cache writes `02` — the same block, two different app
+        // hashes.
+        //
+        // The document history contract needs no refresh: it first comes into existence
+        // in this transition, and the data contract cache holds no negative entries, so
+        // no node can have a stale copy.
+        self.drive.refresh_data_contract_cache_from_state(
             dpns_contract.id().to_buffer(),
-        ] {
-            self.drive.refresh_data_contract_cache_from_state(
-                contract_id,
-                Some(transaction),
-                platform_version,
-            )?;
-        }
+            Some(transaction),
+            platform_version,
+        )?;
 
         Ok(())
     }

--- a/packages/rs-drive-abci/src/execution/platform_events/protocol_upgrade/perform_events_on_first_block_of_protocol_change/v0/mod.rs
+++ b/packages/rs-drive-abci/src/execution/platform_events/protocol_upgrade/perform_events_on_first_block_of_protocol_change/v0/mod.rs
@@ -5,6 +5,7 @@ use crate::platform_types::platform_state::PlatformState;
 use crate::platform_types::platform_state::PlatformStateV0Methods;
 use dpp::block::block_info::BlockInfo;
 use dpp::dashcore::hashes::Hash;
+use dpp::data_contract::accessors::v0::DataContractV0Getters;
 use dpp::data_contracts::SystemDataContract;
 use dpp::fee::Credits;
 use dpp::platform_value::Identifier;
@@ -688,6 +689,29 @@ impl<C> Platform<C> {
             platform_version,
         )?;
 
+        // CONSENSUS-CRITICAL. Both writes above go straight to state and bypass the drive
+        // operation batch, whose finalization task is what normally evicts a superseded
+        // contract from the data contract cache. Every contract a migration writes must
+        // therefore be refreshed here explicitly.
+        //
+        // DPNS is the one that can actually be stale, and the consequences are severe:
+        // the pre-v13 DPNS was stored with a v0 `DataContractConfig`, the v2 contract
+        // written above carries a v1 config, and `DocumentV0::serialize` selects
+        // `serialize_v0` for the former and `serialize_v2` for the latter. A node holding
+        // the pre-migration DPNS in cache would keep writing DPNS documents with a `00`
+        // version prefix while a node with a cold cache writes `02` — the same block,
+        // two different app hashes.
+        for contract_id in [
+            document_history_contract.id().to_buffer(),
+            dpns_contract.id().to_buffer(),
+        ] {
+            self.drive.refresh_data_contract_cache_from_state(
+                contract_id,
+                Some(transaction),
+                platform_version,
+            )?;
+        }
+
         Ok(())
     }
 }
@@ -1012,6 +1036,134 @@ mod tests {
         assert!(domain.documents_keep_transfer_history());
         assert!(domain.documents_keep_purchase_history());
         assert!(domain.documents_keep_pricing_history());
+    }
+
+    /// CONSENSUS REGRESSION, reproducing the testnet divergence at block 467,976.
+    ///
+    /// DPNS has been stored with a **v0** `DataContractConfig` ever since it was
+    /// registered at genesis under protocol version 1. The v13 transition rewrites it
+    /// with the v2 schema, which carries a **v1** config. That rewrite goes straight to
+    /// state and bypasses the drive operation batch, whose finalization task is what
+    /// normally evicts a superseded contract from the data contract cache — so a node
+    /// that had been up long enough to have read DPNS once kept serving the v0-config
+    /// copy for the rest of its process lifetime, while a node whose cache was cold read
+    /// the migrated one.
+    ///
+    /// That difference reaches state. `DocumentV0::serialize` selects `serialize_v0` for
+    /// a contract whose config is v0 and `serialize_v2` otherwise, so the warm node wrote
+    /// DPNS documents with a leading `00` and the cold node wrote the identical document
+    /// with a leading `02`. One byte, a different Merk node hash, a different app hash.
+    #[test]
+    fn test_transition_to_version_13_refreshes_warm_dpns_contract_cache() {
+        use dpp::data_contract::accessors::v0::DataContractV0Getters;
+        use dpp::data_contract::document_type::accessors::DocumentTypeV0Getters;
+        use dpp::data_contract::document_type::random_document::CreateRandomDocument;
+        use dpp::document::serialization_traits::DocumentPlatformConversionMethodsV0;
+        use dpp::system_data_contracts::{load_system_data_contract, SystemDataContract};
+
+        let platform = TestPlatformBuilder::new()
+            .with_initial_protocol_version(12)
+            .build_with_mock_rpc()
+            .set_genesis_state();
+
+        let platform_version_12 = PlatformVersion::get(12).expect("expected platform version 12");
+        let platform_version = PlatformVersion::get(13).expect("expected platform version 13");
+
+        let dpns_id = *SystemDataContract::DPNS.id().as_bytes();
+
+        // Put state where testnet actually was: DPNS as it was written at genesis under
+        // protocol version 1, carrying a v0 config. Nothing had rewritten it since.
+        let genesis_dpns =
+            load_system_data_contract(SystemDataContract::DPNS, PlatformVersion::first())
+                .expect("expected to load the genesis-era DPNS contract");
+
+        platform
+            .drive
+            .apply_contract(
+                &genesis_dpns,
+                BlockInfo::default(),
+                true,
+                None,
+                None,
+                platform_version_12,
+            )
+            .expect("expected to store the genesis-era DPNS contract");
+
+        // Warm the global cache the way a long-lived node does: a read with no
+        // transaction, which is also the path every read-only DAPI query takes.
+        let warm = platform
+            .drive
+            .get_contract_with_fetch_info(dpns_id, true, None, platform_version_12)
+            .expect("expected to fetch DPNS")
+            .expect("expected DPNS to exist")
+            .contract
+            .clone();
+
+        let warm_preorder = warm
+            .document_type_for_name("preorder")
+            .expect("expected the preorder document type");
+        let document = warm_preorder
+            .random_document(Some(42), platform_version_12)
+            .expect("expected to build a preorder document");
+
+        assert_eq!(
+            document
+                .serialize(warm_preorder, &warm, platform_version_12)
+                .expect("expected to serialize")
+                .first()
+                .copied(),
+            Some(0),
+            "precondition: the pre-migration contract serializes preorders with the v0 prefix"
+        );
+
+        let transaction = platform.drive.grove.start_transaction();
+
+        let block_info = BlockInfo {
+            time_ms: 1_000_000,
+            height: 100,
+            core_height: 100,
+            epoch: Epoch::new(1).expect("expected epoch"),
+        };
+
+        platform
+            .transition_to_version_13(&block_info, &transaction, platform_version)
+            .expect("expected the transition to succeed");
+
+        // The block execution read path: a transactional fetch, which consults the block
+        // cache first and then falls back to the global cache. Before the fix this fell
+        // through to the stale global entry and returned the v0-config contract.
+        let migrated = platform
+            .drive
+            .get_contract_with_fetch_info(dpns_id, false, Some(&transaction), platform_version)
+            .expect("expected to fetch DPNS")
+            .expect("expected DPNS to exist after the transition")
+            .contract
+            .clone();
+
+        assert!(
+            migrated
+                .document_type_for_name("domain")
+                .expect("expected the domain document type")
+                .documents_keep_transfer_history(),
+            "a warm node must see the migrated DPNS v2 contract, not its cached copy"
+        );
+
+        // The consensus-visible consequence, asserted directly: the very same preorder
+        // document must now serialize with the v2 prefix, matching what a node with a
+        // cold cache writes into the block.
+        let migrated_preorder = migrated
+            .document_type_for_name("preorder")
+            .expect("expected the preorder document type");
+
+        assert_eq!(
+            document
+                .serialize(migrated_preorder, &migrated, platform_version)
+                .expect("expected to serialize")
+                .first()
+                .copied(),
+            Some(2),
+            "a warm node must serialize preorders identically to a cold node after the migration"
+        );
     }
 
     // test_transition_to_version_9 removed: requires prior state from versions 4-8

--- a/packages/rs-drive/src/cache/data_contract.rs
+++ b/packages/rs-drive/src/cache/data_contract.rs
@@ -1,5 +1,6 @@
 use crate::drive::contract::DataContractFetchInfo;
 use dpp::data_contract::accessors::v0::DataContractV0Getters;
+use moka::ops::compute::Op;
 use moka::sync::Cache;
 use std::sync::Arc;
 
@@ -20,14 +21,41 @@ impl DataContractCache {
 
     /// Inserts DataContract to block cache
     /// otherwise to goes to global cache
+    ///
+    /// The insert is skipped if the cache already holds the same contract at a
+    /// **higher** version. Contract versions increase strictly monotonically —
+    /// the data contract update transition enforces `new == old + 1`, and system
+    /// contract migrations bump the version — so an insert carrying a lower
+    /// version is always a delayed writer racing a newer copy in, never fresh
+    /// information. CONSENSUS-CRITICAL: a read-only query thread fetches from
+    /// committed state without a transaction and populates the global cache from
+    /// what it read. If such a thread reads a contract, gets descheduled while
+    /// block execution rewrites that contract, and performs its insert after the
+    /// block cache is promoted, an unconditional insert would clobber the newer
+    /// contract with the stale one — and block execution would then serialize
+    /// documents against a different contract than a node whose cache was cold,
+    /// producing a different app hash from the same block. The check-and-insert
+    /// is atomic per key via moka's compute API, so there is no window between
+    /// the version comparison and the write. Same-version inserts still
+    /// overwrite: re-inserting an identical contract with a freshly calculated
+    /// fee is the normal cache-hit fee path.
     pub fn insert(&self, fetch_info: Arc<DataContractFetchInfo>, is_block_cache: bool) {
         let data_contract_id_bytes = fetch_info.contract.id().to_buffer();
 
-        if is_block_cache {
-            self.block_cache.insert(data_contract_id_bytes, fetch_info);
+        let cache = if is_block_cache {
+            &self.block_cache
         } else {
-            self.global_cache.insert(data_contract_id_bytes, fetch_info);
-        }
+            &self.global_cache
+        };
+
+        cache
+            .entry(data_contract_id_bytes)
+            .and_compute_with(|existing| match existing {
+                Some(entry) if entry.value().contract.version() > fetch_info.contract.version() => {
+                    Op::Nop
+                }
+                _ => Op::Put(Arc::clone(&fetch_info)),
+            });
     }
 
     /// Tries to get a data contract from block cache if present
@@ -163,6 +191,104 @@ mod tests {
                 .expect("should be present");
 
             assert_eq!(fetch_info_from_cache, fetch_info_block)
+        }
+    }
+
+    mod insert {
+        use super::*;
+        use dpp::data_contract::accessors::v0::{DataContractV0Getters, DataContractV0Setters};
+
+        /// Two copies of the SAME contract (same id) at the given versions. The
+        /// fixture generates a fresh contract id per call, so both copies must
+        /// derive from a single fixture.
+        fn same_contract_at_versions(
+            first: u32,
+            second: u32,
+        ) -> (Arc<DataContractFetchInfo>, Arc<DataContractFetchInfo>) {
+            let fetch_info = DataContractFetchInfo::dpns_contract_fixture(
+                PlatformVersion::latest().protocol_version,
+            );
+            let mut first_info = fetch_info.clone();
+            first_info.contract.set_version(first);
+            let mut second_info = fetch_info;
+            second_info.contract.set_version(second);
+            (Arc::new(first_info), Arc::new(second_info))
+        }
+
+        /// A delayed insert carrying an older contract version must not clobber a newer
+        /// entry. This is the query-thread race: a read-only query reads a contract from
+        /// committed state, is descheduled while block execution rewrites the contract,
+        /// and performs its cache insert only after the migrated contract was promoted
+        /// to the global cache.
+        #[test]
+        fn test_insert_does_not_overwrite_newer_version_with_older() {
+            let data_contract_cache = DataContractCache::new(10, 10);
+
+            let (stale, newer) = same_contract_at_versions(1, 2);
+            let contract_id = newer.contract.id().to_buffer();
+            data_contract_cache.insert(newer, false);
+
+            // The delayed stale insert
+            data_contract_cache.insert(stale, false);
+
+            let cached = data_contract_cache
+                .get(contract_id, false)
+                .expect("should be present");
+            assert_eq!(cached.contract.version(), 2);
+        }
+
+        /// Same-version inserts must overwrite: re-inserting the same contract with a
+        /// freshly calculated fee is the normal cache-hit fee path.
+        #[test]
+        fn test_insert_overwrites_same_version() {
+            let data_contract_cache = DataContractCache::new(10, 10);
+
+            let (mut original, mut with_fee) = same_contract_at_versions(1, 1);
+            let contract_id = original.contract.id().to_buffer();
+            Arc::make_mut(&mut original).fee = None;
+            data_contract_cache.insert(original, false);
+
+            Arc::make_mut(&mut with_fee).fee =
+                Some(dpp::fee::fee_result::FeeResult::new_from_processing_fee(1));
+            data_contract_cache.insert(with_fee, false);
+
+            let cached = data_contract_cache
+                .get(contract_id, false)
+                .expect("should be present");
+            assert!(cached.fee.is_some(), "same-version insert must overwrite");
+        }
+
+        /// The full race, end to end: block execution seeds the migrated (newer)
+        /// contract into the block cache, the block finalizes and promotes it to the
+        /// global cache, and only then does the delayed query thread insert the
+        /// pre-migration contract it read before the rewrite. The promoted contract
+        /// must survive.
+        #[test]
+        fn test_delayed_stale_insert_after_promotion_does_not_stick() {
+            let data_contract_cache = DataContractCache::new(10, 10);
+
+            // The pre-migration contract, as read from committed state by a query
+            // thread that will be descheduled before its insert.
+            let (stale, migrated) = same_contract_at_versions(1, 2);
+            let contract_id = stale.contract.id().to_buffer();
+
+            // Block execution writes the migrated contract and seeds the block cache.
+            data_contract_cache.insert(migrated, true);
+
+            // The block finalizes: block cache promotes to global.
+            data_contract_cache.merge_and_clear_block_cache();
+
+            // The query thread wakes up and performs its stale insert.
+            data_contract_cache.insert(stale, false);
+
+            let cached = data_contract_cache
+                .get(contract_id, false)
+                .expect("should be present");
+            assert_eq!(
+                cached.contract.version(),
+                2,
+                "the promoted migrated contract must survive a delayed stale insert"
+            );
         }
     }
 

--- a/packages/rs-drive/src/drive/contract/migration/mod.rs
+++ b/packages/rs-drive/src/drive/contract/migration/mod.rs
@@ -1,1 +1,2 @@
+mod refresh_contract_cache;
 mod strip_unknown_document_schema_properties;

--- a/packages/rs-drive/src/drive/contract/migration/refresh_contract_cache.rs
+++ b/packages/rs-drive/src/drive/contract/migration/refresh_contract_cache.rs
@@ -5,8 +5,11 @@ use grovedb::TransactionArg;
 
 impl Drive {
     /// Re-reads a data contract from state and re-seeds the in-memory data contract cache
-    /// with it. Call this from a protocol-upgrade migration for **every** contract the
-    /// migration writes.
+    /// with it. Call this from a protocol-upgrade migration for every contract the
+    /// migration **rewrites** — i.e. any contract that existed before the migration and
+    /// so may already sit in a node's cache. A contract the migration introduces for the
+    /// first time needs no refresh: the cache holds no negative entries, so no node can
+    /// have a stale copy of a contract that never existed.
     ///
     /// CONSENSUS-CRITICAL. Contracts written by a state transition go through the drive
     /// operation batch, whose `RemoveDataContractFromCache` finalization task evicts the

--- a/packages/rs-drive/src/drive/contract/migration/refresh_contract_cache.rs
+++ b/packages/rs-drive/src/drive/contract/migration/refresh_contract_cache.rs
@@ -1,0 +1,174 @@
+use crate::drive::Drive;
+use crate::error::Error;
+use dpp::version::PlatformVersion;
+use grovedb::TransactionArg;
+
+impl Drive {
+    /// Re-reads a data contract from state and re-seeds the in-memory data contract cache
+    /// with it. Call this from a protocol-upgrade migration for **every** contract the
+    /// migration writes.
+    ///
+    /// CONSENSUS-CRITICAL. Contracts written by a state transition go through the drive
+    /// operation batch, whose `RemoveDataContractFromCache` finalization task evicts the
+    /// superseded copy from the cache. Migrations write contracts directly
+    /// (`insert_contract` / `apply_contract`) and bypass that machinery entirely, so
+    /// without this call a node that already holds the pre-migration contract in its
+    /// global cache keeps serving that copy for the rest of the process lifetime, while a
+    /// node whose cache is cold (freshly restarted, or the entry was evicted under
+    /// capacity pressure) reads the migrated one. The two nodes then serialize documents
+    /// of that contract against different `DataContract`s — a difference that reaches
+    /// state, because `DocumentV0::serialize` picks its serialization version from the
+    /// contract's config version — and produce different app hashes from the same block.
+    ///
+    /// The refreshed contract is placed in the **block** cache, not the global cache: at
+    /// this point the migration's write is still uncommitted, and the block cache is the
+    /// only cache that transactional reads consult first. It is promoted to the global
+    /// cache once the block commits (`merge_and_clear_block_cache`), and dropped at the
+    /// start of the next block if the block never commits (`clear_block_cache`).
+    ///
+    /// The read deliberately bypasses both caches rather than going through
+    /// `get_contract_with_fetch_info`: a concurrent read-only query thread (which reads
+    /// committed state, with no transaction, and does populate the global cache) could
+    /// otherwise race a pre-migration copy back into the global cache between the
+    /// eviction and the re-seed.
+    ///
+    /// Billing is unaffected. `fetch_contract_v0` computes the cached `OperationCost`
+    /// with grovedb value caching disabled precisely so the cost of a contract fetch is
+    /// deterministic, and derives `fee` from that cost only when an epoch is supplied —
+    /// so a cache hit seeded here bills identically to the cold fetch it replaces.
+    pub fn refresh_data_contract_cache_from_state(
+        &self,
+        contract_id: [u8; 32],
+        transaction: TransactionArg,
+        platform_version: &PlatformVersion,
+    ) -> Result<(), Error> {
+        // Cache-bypassing read: the contract exactly as state now holds it.
+        let maybe_fetch_info = self.fetch_contract_and_add_operations(
+            contract_id,
+            None,
+            transaction,
+            &mut vec![],
+            platform_version,
+        )?;
+
+        // Drop the pre-migration copy from both the block and the global cache.
+        self.cache.data_contracts.remove(contract_id);
+
+        // Re-seed with what state now holds. A migration always writes the contract it
+        // asks us to refresh, so `None` here means the contract genuinely is not in
+        // state; leaving the caches empty is then the correct outcome.
+        if let Some(fetch_info) = maybe_fetch_info {
+            self.cache
+                .data_contracts
+                .insert(fetch_info, transaction.is_some());
+        }
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::drive::contract::DataContractFetchInfo;
+    use crate::util::test_helpers::setup::setup_drive_with_initial_state_structure;
+    use dpp::block::block_info::BlockInfo;
+    use dpp::data_contract::accessors::v0::{DataContractV0Getters, DataContractV0Setters};
+    use dpp::system_data_contracts::{load_system_data_contract, SystemDataContract};
+    use dpp::version::PlatformVersion;
+    use std::sync::Arc;
+
+    /// A contract written directly to state must replace a stale cached copy, so that a
+    /// warm node and a cold node read the same contract afterwards.
+    #[test]
+    fn test_refresh_replaces_stale_cached_contract() {
+        let drive = setup_drive_with_initial_state_structure(None);
+        let platform_version = PlatformVersion::latest();
+        let transaction = drive.grove.start_transaction();
+
+        let dpns = load_system_data_contract(SystemDataContract::DPNS, platform_version)
+            .expect("expected to load DPNS");
+        let contract_id = dpns.id().to_buffer();
+
+        // Warm the global cache with a contract that does NOT match state: a distinct
+        // version stands in for the pre-migration copy a long-lived node would hold.
+        let mut stale = dpns.clone();
+        stale.set_version(u32::MAX);
+        drive.cache.data_contracts.insert(
+            Arc::new(DataContractFetchInfo {
+                contract: stale,
+                storage_flags: None,
+                cost: Default::default(),
+                fee: None,
+            }),
+            false,
+        );
+
+        drive
+            .apply_contract(
+                &dpns,
+                BlockInfo::default(),
+                true,
+                None,
+                Some(&transaction),
+                platform_version,
+            )
+            .expect("expected to apply contract");
+
+        // Without the refresh this still reads the stale copy out of the global cache.
+        drive
+            .refresh_data_contract_cache_from_state(
+                contract_id,
+                Some(&transaction),
+                platform_version,
+            )
+            .expect("expected to refresh cache");
+
+        let refreshed = drive
+            .get_contract_with_fetch_info(contract_id, false, Some(&transaction), platform_version)
+            .expect("expected to fetch contract")
+            .expect("expected the contract to be present");
+
+        assert_eq!(refreshed.contract.version(), dpns.version());
+    }
+
+    /// The refresh must seed the block cache, not the global cache: the migration's write
+    /// is still uncommitted, so a non-transactional reader must not see it yet.
+    #[test]
+    fn test_refresh_seeds_block_cache_not_global_cache() {
+        let drive = setup_drive_with_initial_state_structure(None);
+        let platform_version = PlatformVersion::latest();
+        let transaction = drive.grove.start_transaction();
+
+        let dpns = load_system_data_contract(SystemDataContract::DPNS, platform_version)
+            .expect("expected to load DPNS");
+        let contract_id = dpns.id().to_buffer();
+
+        drive
+            .apply_contract(
+                &dpns,
+                BlockInfo::default(),
+                true,
+                None,
+                Some(&transaction),
+                platform_version,
+            )
+            .expect("expected to apply contract");
+
+        drive
+            .refresh_data_contract_cache_from_state(
+                contract_id,
+                Some(&transaction),
+                platform_version,
+            )
+            .expect("expected to refresh cache");
+
+        assert!(
+            drive.cache.data_contracts.get(contract_id, true).is_some(),
+            "transactional reads must see the refreshed contract"
+        );
+        assert!(
+            drive.cache.data_contracts.get(contract_id, false).is_none(),
+            "the uncommitted contract must not be visible in the global cache"
+        );
+    }
+}

--- a/packages/rs-drive/src/drive/contract/migration/refresh_contract_cache.rs
+++ b/packages/rs-drive/src/drive/contract/migration/refresh_contract_cache.rs
@@ -33,7 +33,14 @@ impl Drive {
     /// `get_contract_with_fetch_info`: a concurrent read-only query thread (which reads
     /// committed state, with no transaction, and does populate the global cache) could
     /// otherwise race a pre-migration copy back into the global cache between the
-    /// eviction and the re-seed.
+    /// eviction and the re-seed. The other half of that race — a query thread that read
+    /// the pre-migration contract, was descheduled, and performs its cache insert only
+    /// after the migrated contract was promoted to the global cache — is closed by the
+    /// monotonic version guard in [`DataContractCache::insert`], which requires every
+    /// migration rewrite to bump the contract's version (the v13 DPNS rewrite goes
+    /// 1 → 2).
+    ///
+    /// [`DataContractCache::insert`]: crate::cache::DataContractCache::insert
     ///
     /// Billing is unaffected. `fetch_contract_v0` computes the cached `OperationCost`
     /// with grovedb value caching disabled precisely so the cost of a contract fetch is


### PR DESCRIPTION
## Issue being fixed or feature implemented

A consensus divergence at the protocol version 13 activation block. Nodes split into two groups producing different app hashes from the same block, and the split did **not** follow node role — it followed cache history.

The v13 transition rewrites the DPNS contract in state:

```rust
self.drive.apply_contract(&dpns_contract, *block_info, true, None, Some(transaction), platform_version)?;
```

`apply_contract` writes straight to state. It does not go through the drive operation batch, and the batch is the only path that carries the `RemoveDataContractFromCache` finalization task. Nothing evicted the pre-migration DPNS from `drive.cache.data_contracts`.

So a node that had been up long enough to have read DPNS once kept serving its cached copy for the rest of the process lifetime, while a node whose cache was cold — freshly restarted, or the entry evicted under capacity pressure — read the migrated contract.

The two copies differ in a way that reaches state. DPNS has been stored with a **v0** `DataContractConfig` ever since it was registered at genesis under protocol version 1; the v13 contract carries a **v1** config. `DocumentV0::serialize` branches on exactly that:

```rust
if matches!(contract, DataContract::V0(_)) || matches!(contract.config(), DataContractConfig::V0(_)) {
    self.serialize_v0(document_type)   // leading varint 00
} else {
    ... 2 => self.serialize_v2(document_type),   // leading varint 02
}
```

A warm node wrote DPNS documents with a leading `00`; a cold node wrote the identical document with a leading `02`. One byte, a different Merk node hash, a different app hash. Everything else — paths, keys, flags, fees, the preceding app hash — matched.

Note that `perform_events_on_first_block_of_protocol_change_v0` already reloads the *separate* `system_data_contracts` cache. It is the ordinary `data_contracts` cache, the one document state transitions actually read through, that was missed.

## What was done?

Added `Drive::refresh_data_contract_cache_from_state`, and called it from `transition_to_version_13` for DPNS. The document history contract needs no refresh: it first comes into existence in this transition, and the cache holds no negative entries, so no node can hold a stale copy of it.

The helper re-reads the contract from state and re-seeds the cache with it. Two details are deliberate:

- **The read bypasses both caches** rather than going through `get_contract_with_fetch_info`. Read-only DAPI queries fetch with no transaction and `add_to_cache_if_pulled = true`, so a concurrent query thread could otherwise race a pre-migration copy back into the global cache between the eviction and the re-seed.
- **The result goes into the block cache, not the global cache.** The migration's write is still uncommitted at that point. The block cache is the first cache transactional reads consult, it is promoted to global when the block commits (`merge_and_clear_block_cache`), and dropped at the start of the next block if the block never commits (`clear_block_cache`).

Billing is unaffected: `fetch_contract_v0` computes the cached `OperationCost` with grovedb value caching disabled precisely so a contract fetch costs the same every time, and derives `fee` from that cost only when an epoch is supplied — so a cache hit seeded here bills identically to the cold fetch it replaces.

### Delayed-query race (review finding)

Review surfaced a residual race: a read-only query thread reads the pre-migration contract from committed state, is descheduled, and performs its `add_to_cache_if_pulled` insert only **after** the migrated contract is promoted to the global cache at finalize — clobbering it with the stale copy, and re-opening the divergence in a later block. The window is millisecond-scale, but the activation height is predictable and query flooding on public DAPI endpoints could widen it. The same window exists on the ordinary contract-update path, where the batch finalization task evicts during block execution.

Closed with a monotonic version guard in `DataContractCache::insert`: an insert carrying a **lower** `version()` than the cached entry is skipped, atomically per key via moka's compute API. Contract versions increase strictly monotonically — the update transition enforces `new == old + 1`, and the v13 DPNS rewrite goes 1 → 2 — so a lower-version insert is always a delayed writer, never fresh information. Same-version inserts still overwrite (the cache-hit fee-recalculation path relies on that). This closes the race for user contract updates as well, not just the migration.

The fix is scoped to the v13 transition rather than pushed down into `apply_contract` / `insert_contract`, so that replay of the v4 through v12 upgrade blocks stays bit-identical. The helper's doc comment states the rule for future migrations: every contract a migration **rewrites** (i.e. that existed before, and so may already be cached) must be refreshed.

## Consensus impact

**This changes the outcome of the v13 upgrade block relative to rc.1.** It is not a breaking change against any well-defined prior behaviour — the rc.1 behaviour is nondeterministic — but it does mean the fixed binary converges every node on the migrated contract, i.e. on `02` serialization. Replaying the preserved testnet state under rc.1 reproduces the bad app hash, confirming there is no intentional beta.2 → rc.1 change involved.

Mainnet has never activated PV13, so mainnet is unaffected. Testnet needs a coordinated rollback to before the activation height and a re-activation on fixed binaries; clearing caches on the current binary would make things worse, not better, because it flips an individual node onto the other side of the fork.

## How Has This Been Tested?

`test_transition_to_version_13_refreshes_warm_dpns_contract_cache` reproduces the testnet divergence: it puts state where testnet actually was (DPNS as written at genesis under protocol version 1, carrying a v0 config), warms the global cache the way a long-lived node does, asserts the pre-migration contract serializes preorders with the `00` prefix, runs the transition, and then asserts the transactional read returns the migrated contract and serializes the identical document with `02`.

Verified the test fails without the fix and passes with it. The pre-existing `test_transition_to_version_13_inserts_document_history_contract_and_updates_dpns` passes either way — it fetches against a cold cache, which is why the bug got through.

Two unit tests on the helper itself cover replacing a stale cached copy and seeding the block cache rather than the global cache. Three cache-level tests cover the version guard, including an end-to-end reproduction of the delayed-query race: stale contract read → migrated contract seeded into the block cache → promotion → delayed stale insert → the promoted contract survives.

- `cargo test -p drive-abci --lib protocol_upgrade` — 44 passed
- `cargo test -p drive --lib contract::` — 227 passed
- `cargo test -p drive --lib refresh_contract_cache` — 2 passed
- `cargo clippy -p drive -p drive-abci --all-targets` — clean
- `cargo check -p drive --no-default-features --features verify` — clean

## Breaking Changes

None for mainnet: PV13 has not activated there. Testnet requires a coordinated reset — see Consensus impact.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**

- [x] I have assigned this pull request to a milestone
