### PR TITLE
feat(dashmate)!: bump gateway Envoy to 1.39.0

### DIFF
--- a/packages/dashmate/configs/defaults/getBaseConfigFactory.js
+++ b/packages/dashmate/configs/defaults/getBaseConfigFactory.js
@@ -179,7 +179,7 @@ export default function getBaseConfigFactory() {
         },
         gateway: {
           docker: {
-            image: 'dashpay/envoy:1.35.11-impr.1',
+            image: 'dashpay/envoy:1.39.0-impr.1',
           },
           maxConnections: 1000,
           maxHeapSizeInBytes: 125000000, // 1 Gb

--- a/packages/dashmate/configs/getConfigFileMigrationsFactory.js
+++ b/packages/dashmate/configs/getConfigFileMigrationsFactory.js
@@ -1561,6 +1561,25 @@ export default function getConfigFileMigrationsFactory(homeDir, defaultConfigs) 
 
         return configFile;
       },
+      '4.1.0-rc.2': (configFile) => {
+        // Move the Platform Gateway onto the Envoy 1.39 line. Only configs still
+        // carrying the previously shipped 1.35.x image are re-pinned; an image
+        // the operator chose themselves (private fork, vendor-patched build,
+        // floating tag) is left alone. Pulled from the base config so it tracks
+        // whatever is pinned there.
+        // Keyed at the next release, not the released 4.1.0-rc.1: the runner
+        // skips fromVersion===toVersion, so a key equal to an operator's current
+        // version never fires.
+        Object.entries(configFile.configs)
+          .forEach(([, options]) => {
+            const docker = options.platform?.gateway?.docker;
+            if (docker && /^dashpay\/envoy:1\.35\./.test(docker.image)) {
+              docker.image = base.get('platform.gateway.docker.image');
+            }
+          });
+
+        return configFile;
+      },
     };
   }
 

--- a/packages/dashmate/docs/config/gateway.md
+++ b/packages/dashmate/docs/config/gateway.md
@@ -6,7 +6,7 @@ The `platform.gateway` section configures the Dash Platform Gateway, which serve
 
 | Option | Description | Default | Example |
 |--------|-------------|---------|---------|
-| `platform.gateway.docker.image` | Docker image for Gateway | `dashpay/envoy:1.35.11-impr.1` | `dashpay/envoy:latest` |
+| `platform.gateway.docker.image` | Docker image for Gateway | `dashpay/envoy:1.39.0-impr.1` | `dashpay/envoy:latest` |
 
 ## Listeners
 

--- a/packages/dashmate/docs/services/gateway-envoy-upgrade.md
+++ b/packages/dashmate/docs/services/gateway-envoy-upgrade.md
@@ -1,0 +1,130 @@
+# Validating an Envoy version bump for the Gateway
+
+The gateway runs Envoy with a config rendered from
+[`templates/platform/gateway/envoy.yaml.dot`](../../templates/platform/gateway/envoy.yaml.dot),
+and the image is pinned in [`configs/defaults/getBaseConfigFactory.js`](../../configs/defaults/getBaseConfigFactory.js)
+(`platform.gateway.docker.image`). `dashpay/envoy:<version>-impr.N` is a stock
+`envoyproxy/envoy:v<version>` plus Envoy's hot-restart supervisor, so a stock release can be
+validated before the custom image exists.
+
+Bumping that pin means the rendered config has to keep loading, and the parts of the gateway that
+only exist at runtime — the rate limit service wire protocol and the grpc-web over-limit reply —
+have to keep working. `scripts/validate-envoy-config.js` checks both.
+
+## Running the harness
+
+```bash
+cd packages/dashmate
+
+# validate against the currently pinned version
+yarn node scripts/validate-envoy-config.js
+
+# validate against a candidate, side by side with the pin
+yarn node scripts/validate-envoy-config.js v1.35.11 v1.39.0
+
+# add the runtime checks (starts Envoy + the rate limiter + redis on a throwaway network)
+yarn node scripts/validate-envoy-config.js --smoke v1.39.0
+
+# the custom image, once docker-envoy has built it
+yarn node scripts/validate-envoy-config.js --smoke dashpay/envoy:1.39.0-impr.1
+
+yarn node scripts/validate-envoy-config.js --list        # the variant matrix
+yarn node scripts/validate-envoy-config.js --out=/tmp/x  # keep renderings and logs
+```
+
+Requires `docker`, `curl` and `openssl`. Bare tags resolve against `envoyproxy/envoy`; anything
+containing `:` is used as a full image reference. With no argument the baseline is derived from the
+pinned image, so the default run always targets what dashmate currently ships.
+
+### Config validation
+
+The template branches on the TLS provider, the rate limiter, metrics/admin and the access-log
+settings, so the harness renders one config per branch (`--list` prints them) and runs Envoy's own
+validator on each:
+
+```
+docker run --rm --entrypoint envoy -v <rendered>:/etc/envoy/envoy.yaml:ro <image> \
+  --mode validate -c /etc/envoy/envoy.yaml
+```
+
+`--mode validate` builds the entire config graph — listeners, filter chains, TLS contexts,
+clusters, the overload manager — and exits. Unknown or removed fields fail hard; fields that are
+merely deprecated log `Deprecated field: … Using deprecated option '<field>'`, which the harness
+reports per variant. Both paths are worth trusting only because they were confirmed to fire: an
+injected bogus field fails validation, and a config using a known-deprecated field
+(`UpstreamTlsContext.enforce_rsa_key_usage`) produces the warning the harness greps for.
+
+### Runtime checks (`--smoke`)
+
+Boots redis, `platform.gateway.rateLimiter.docker.image` and the Envoy image under test on a
+throwaway Docker network with the rendered default config, then asserts:
+
+1. Envoy reaches `starting workers` and logs no warnings — this also covers `STRICT_DNS`
+   resolution of the upstream service names.
+2. Exactly `platform.gateway.rateLimiter.requestsPerUnit` requests pass, and the next one is
+   rejected — i.e. Envoy's RLS v3 calls to the pinned rate limiter build are understood.
+3. The grpc-web over-limit reply is `HTTP 200` + `grpc-status: 8` + `ratelimit-reset`, which is what
+   browser clients need for node backoff.
+4. The native gRPC over-limit reply is `HTTP 200` + `grpc-status: 8`.
+
+The upstreams are stand-ins, so pre-limit requests answer `503`. The rate limit decision happens
+before routing, which is what these checks are about.
+
+### What it does not cover
+
+Behavior changes that a valid config cannot reveal (see the release-note review below), throughput
+and memory under real load, the hot-restart supervisor in the custom image, and anything requiring
+real upstreams — run `yarn test:suite` against a node for that.
+
+## Assessment: v1.35.11 → v1.39.0 (July 2026)
+
+Verdict: **go**, no config edits required. 8/8 variants validate clean and all runtime checks pass
+on `envoyproxy/envoy:v1.39.0`, with results identical to the `v1.35.11` baseline (which was also run
+through the custom `dashpay/envoy:1.35.11-impr.1` image). No field in the rendered config is
+deprecated or removed at v1.39.0, and nothing in the `1.36.0`–`1.39.0` release notes removes config
+we use. `envoyproxy/ratelimit:3fcc3609` (April 2024) still interoperates: the filter's
+`transport_api_version: V3` remains current, and the over-limit path was exercised end to end.
+
+Two behavior changes will alter how the gateway behaves once bumped, without changing the config:
+
+- **The overload actions keyed on `global_downstream_max_connections` start working.** v1.37.0 fixed
+  that monitor to actually trigger actions ("previously, actions never triggered"). So
+  `disable_http_keepalive` at 95% and `stop_accepting_connections` at 100% of
+  `platform.gateway.maxConnections` become live: at ~950 of 1000 connections Envoy will start
+  draining HTTP/2 connections with GOAWAY, which clients see as connection churn. The
+  `overload.envoy.resource_monitors.global_downstream_max_connections.pressure` gauge is new and
+  confirms it (absent on v1.35.11, present on v1.39.0). Consider whether the shipped default is the
+  right threshold now that it is enforced.
+- **HTTP/2 flood protection now scales with active streams.** v1.39.0 closed a bypass where
+  PRIORITY/WINDOW_UPDATE flood protection could be evaded by rapid stream churn; frame budget is now
+  tied to active streams. The gateway sets small windows (64 KiB per stream) and
+  `max_concurrent_streams` of 10, so long-lived streaming endpoints emit many WINDOW_UPDATE frames.
+  Watch `http.ingress_http.http2.inbound_window_update_frames_flood` after the bump; the change can
+  be reverted with the `envoy.reloadable_features.http2_flood_protection_active_streams` runtime
+  guard.
+
+Lower-risk notes, all reversible via runtime guards, none needing config changes: upstream
+`max_concurrent_streams` now defaults to 1024 instead of 2^31-1 (v1.36.0) — far above the
+`max_requests: 100` circuit breakers; the TLS inspector used by the self-signed provider now
+enforces client TLS 1.0–1.3 (v1.39.0); upstream transport failure reasons no longer reach response
+bodies (v1.39.0); `HeaderMatcher` matches multi-value headers individually (v1.39.0) — the only
+header matcher in the config is a `present_match` on `x-grpc-web`, which is unaffected; and a
+`timeout: 0s` on the rate limit filter now means "no timeout" (v1.38.0) — the config sets `5s`.
+
+v1.39.0 also adds `Http2ProtocolOptions.stream_reset_burst`/`stream_reset_rate`, worth considering
+separately as rapid-reset hardening.
+
+### Notes for the bump
+
+- `dashpay/envoy` has no 1.39 build yet; docker-envoy has to publish `dashpay/envoy:1.39.0-impr.N`
+  first, then re-run the harness against it (the supervisor entrypoint is handled). That wrapper only
+  needs its `FROM` bumped: v1.39.0 still ships Ubuntu 22.04 without python3, so the `apt install`
+  step is still required, and `envoy --restart-epoch`/`--log-level` — all `start_envoy.sh` uses —
+  still exist.
+- v1.39.0 is the only 1.39 release; the HTTP/2 flood-protection fix was not backported to the
+  1.35–1.38 patch lines. The pin is also two patches behind on its own line — v1.35.13 carries the
+  June 2026 CVE batch, none of which touch the extensions this gateway loads.
+- Unrelated pre-existing finding, identical on both versions: the route returning `grpc-status: 12`
+  for unsupported API versions never matches. `RouteMatch.safe_regex` must match the whole path, and
+  the pattern `\/org\.dash\.platform\.dapi\.v[1-9]+\.` only covers a prefix, so
+  `/org.dash.platform.dapi.v1.Platform/getIdentity` gets a plain `404`.

--- a/packages/dashmate/docs/services/gateway-envoy-upgrade.md
+++ b/packages/dashmate/docs/services/gateway-envoy-upgrade.md
@@ -25,7 +25,7 @@ yarn node scripts/validate-envoy-config.js v1.35.11 v1.39.0
 # add the runtime checks (starts Envoy + the rate limiter + redis on a throwaway network)
 yarn node scripts/validate-envoy-config.js --smoke v1.39.0
 
-# the custom image, once docker-envoy has built it
+# the custom image docker-envoy publishes, which is what dashmate actually runs
 yarn node scripts/validate-envoy-config.js --smoke dashpay/envoy:1.39.0-impr.1
 
 yarn node scripts/validate-envoy-config.js --list        # the variant matrix
@@ -78,14 +78,17 @@ real upstreams — run `yarn test:suite` against a node for that.
 
 ## Assessment: v1.35.11 → v1.39.0 (July 2026)
 
+This is the bump the pin now carries — `dashpay/envoy:1.39.0-impr.1`.
+
 Verdict: **go**, no config edits required. 8/8 variants validate clean and all runtime checks pass
-on `envoyproxy/envoy:v1.39.0`, with results identical to the `v1.35.11` baseline (which was also run
-through the custom `dashpay/envoy:1.35.11-impr.1` image). No field in the rendered config is
+on `envoyproxy/envoy:v1.39.0` and on the custom `dashpay/envoy:1.39.0-impr.1` (both its amd64 and
+arm64 manifests), with results identical to the `v1.35.11` baseline (which was also run
+through `dashpay/envoy:1.35.11-impr.1`). No field in the rendered config is
 deprecated or removed at v1.39.0, and nothing in the `1.36.0`–`1.39.0` release notes removes config
 we use. `envoyproxy/ratelimit:3fcc3609` (April 2024) still interoperates: the filter's
 `transport_api_version: V3` remains current, and the over-limit path was exercised end to end.
 
-Two behavior changes will alter how the gateway behaves once bumped, without changing the config:
+Two behavior changes do alter how the gateway behaves on this version, without changing the config:
 
 - **The overload actions keyed on `global_downstream_max_connections` start working.** v1.37.0 fixed
   that monitor to actually trigger actions ("previously, actions never triggered"). So
@@ -116,11 +119,11 @@ separately as rapid-reset hardening.
 
 ### Notes for the bump
 
-- `dashpay/envoy` has no 1.39 build yet; docker-envoy has to publish `dashpay/envoy:1.39.0-impr.N`
-  first, then re-run the harness against it (the supervisor entrypoint is handled). That wrapper only
-  needs its `FROM` bumped: v1.39.0 still ships Ubuntu 22.04 without python3, so the `apt install`
-  step is still required, and `envoy --restart-epoch`/`--log-level` — all `start_envoy.sh` uses —
-  still exist.
+- The hot-restart supervisor in the custom image is outside what the harness covers, because it
+  overrides the entrypoint to reach Envoy's flags. It was checked by hand on
+  `dashpay/envoy:1.39.0-impr.1`: the container boots through `hot-restarter.py` at epoch 0, `SIGHUP`
+  forks a child at epoch 1 and the parent exits cleanly, which is the zero-downtime path dashmate
+  uses after certificate renewal. Worth repeating on future bumps.
 - v1.39.0 is the only 1.39 release; the HTTP/2 flood-protection fix was not backported to the
   1.35–1.38 patch lines. The pin is also two patches behind on its own line — v1.35.13 carries the
   June 2026 CVE batch, none of which touch the extensions this gateway loads.

--- a/packages/dashmate/docs/services/gateway.md
+++ b/packages/dashmate/docs/services/gateway.md
@@ -321,6 +321,12 @@ The admin interface is a powerful tool but presents security risks:
 | **Rate Limiter Redis**    | Redis                | 6379          | (fixed internal)                                 | (internal)            | -               |
 
 
+## Upgrading Envoy
+
+The Envoy image is pinned in `configs/defaults/getBaseConfigFactory.js`. Before changing that pin,
+validate the rendered configuration against the candidate release — see
+[Validating an Envoy version bump](./gateway-envoy-upgrade.md).
+
 ## Best Practices
 
 1. **Security**: Restrict admin and metrics access to trusted networks

--- a/packages/dashmate/docs/services/index.md
+++ b/packages/dashmate/docs/services/index.md
@@ -64,6 +64,7 @@ Dashmate runs and orchestrate Dash Platform components:
 - [Core](./core.md): Dash Core service
 - [Platform](./platform.md): Platform services (Drive, Tenderdash, DAPI)
 - [Gateway](./gateway.md): API Gateway service
+  - [Validating an Envoy version bump](./gateway-envoy-upgrade.md): pre-bump checks for the gateway image
 - [Quorum List](./quorum_list.md): Optional quorum list sidecar (local preset)
 - [Dashmate Helper](./dashmate_helper.md): Helper service for Dashmate CLI
 

--- a/packages/dashmate/docs/update.md
+++ b/packages/dashmate/docs/update.md
@@ -78,7 +78,7 @@ $  dashmate update --format=json --config local_1 | jq
     "name": "gateway",
     "title": "Gateway",
     "updated": "up to date",
-    "image": "dashpay/envoy:1.35.11-impr.1"
+    "image": "dashpay/envoy:1.39.0-impr.1"
   }
 ]
 ```

--- a/packages/dashmate/scripts/validate-envoy-config.js
+++ b/packages/dashmate/scripts/validate-envoy-config.js
@@ -19,7 +19,7 @@
  *   yarn node scripts/validate-envoy-config.js                      # pinned version
  *   yarn node scripts/validate-envoy-config.js v1.39.0              # candidate
  *   yarn node scripts/validate-envoy-config.js v1.35.11 v1.39.0     # side by side
- *   yarn node scripts/validate-envoy-config.js dashpay/envoy:1.35.11-impr.1
+ *   yarn node scripts/validate-envoy-config.js dashpay/envoy:1.39.0-impr.1
  *
  * Options:
  *   --image=<repo>     image repository for bare tags (default: envoyproxy/envoy)
@@ -186,7 +186,7 @@ function parseArgs(argv) {
 
 /**
  * The pinned gateway image is a custom build of a stock Envoy release
- * (`dashpay/envoy:1.35.11-impr.1` wraps `envoyproxy/envoy:v1.35.11`), so the
+ * (`dashpay/envoy:1.39.0-impr.1` wraps `envoyproxy/envoy:v1.39.0`), so the
  * baseline tag is the pinned version without the build suffix.
  *
  * @param {Config} config

--- a/packages/dashmate/scripts/validate-envoy-config.js
+++ b/packages/dashmate/scripts/validate-envoy-config.js
@@ -1,0 +1,676 @@
+#!/usr/bin/env node
+
+/**
+ * Validate the gateway's Envoy configuration against one or more Envoy images.
+ *
+ * The gateway config is rendered from `templates/platform/gateway/envoy.yaml.dot`,
+ * which branches on the TLS provider, the rate limiter, metrics/admin and the
+ * access-log settings. This script renders the template for a matrix of config
+ * variants covering every branch and feeds each rendering to Envoy's built-in
+ * config validator (`envoy --mode validate`) inside the requested image.
+ *
+ * The validator builds the whole config graph — listeners, filter chains,
+ * clusters, TLS contexts, the overload manager — and then exits, so it reports
+ * both hard errors (unknown/removed fields, type mismatches) and warnings about
+ * fields that are deprecated in that Envoy version. That makes it the cheapest
+ * gate to run before bumping the pinned gateway image.
+ *
+ * Usage:
+ *   yarn node scripts/validate-envoy-config.js                      # pinned version
+ *   yarn node scripts/validate-envoy-config.js v1.39.0              # candidate
+ *   yarn node scripts/validate-envoy-config.js v1.35.11 v1.39.0     # side by side
+ *   yarn node scripts/validate-envoy-config.js dashpay/envoy:1.35.11-impr.1
+ *
+ * Options:
+ *   --image=<repo>     image repository for bare tags (default: envoyproxy/envoy)
+ *   --variant=<name>   only run the named variant (repeatable)
+ *   --out=<dir>        keep renderings, logs and results.json in <dir>
+ *   --smoke            additionally boot the gateway against the pinned rate
+ *                      limiter and assert the over-limit replies (see below)
+ *   --list             print the variant matrix and exit
+ *
+ * With no image reference the baseline is taken from the image pinned in
+ * `configs/defaults/getBaseConfigFactory.js`, so it tracks the pin.
+ *
+ * `--mode validate` proves the config loads, but two things about this gateway
+ * only show up at runtime: the rate limit service wire protocol (Envoy speaks
+ * RLS v3 to the pinned `envoyproxy/ratelimit` build) and the `local_reply_config`
+ * mapper that turns the grpc-web over-limit reply into `grpc-status: 8`, which
+ * depends on how Envoy orders local replies through encoder filters. `--smoke`
+ * covers both by running the real thing on a throwaway Docker network.
+ *
+ * Exits non-zero when any validation or smoke check fails.
+ */
+
+import { spawnSync } from 'child_process';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
+import getBaseConfigFactory from '../configs/defaults/getBaseConfigFactory.js';
+import HomeDir from '../src/config/HomeDir.js';
+import renderServiceTemplatesFactory from '../src/templates/renderServiceTemplatesFactory.js';
+import renderTemplateFactory from '../src/templates/renderTemplateFactory.js';
+
+const DEFAULT_IMAGE_REPO = 'envoyproxy/envoy';
+const ENVOY_CONFIG_TEMPLATE = 'platform/gateway/envoy.yaml';
+const RATE_LIMITER_CONFIG_TEMPLATE = 'platform/gateway/rate_limiter/rate_limiter.yaml';
+const DOCKER_TIMEOUT_MS = 180000;
+
+// Same storage image docker-compose.rate_limiter.yml uses for the rate limiter.
+const REDIS_IMAGE = 'redis:alpine';
+// The smoke checks exercise the shipped defaults, where the rate limiter is on.
+const SMOKE_VARIANT = 'default';
+const SMOKE_NETWORK = 'dashmate-envoy-validate';
+const SMOKE_CONTAINERS = {
+  redis: 'dashmate-envoy-validate-redis',
+  rateLimiter: 'dashmate-envoy-validate-rate-limiter',
+  gateway: 'dashmate-envoy-validate-gateway',
+};
+
+/**
+ * Config variants covering every branch of envoy.yaml.dot.
+ *
+ * Each variant mutates a fresh copy of the default config, so the renderings
+ * differ only in the settings named by the variant.
+ */
+const VARIANTS = [
+  {
+    name: 'default',
+    description: 'dashmate defaults: rate limiter on, stdout text access log, no metrics/admin',
+    apply: () => {},
+  },
+  {
+    name: 'ssl-self-signed',
+    description: 'self-signed TLS: tls_inspector listener filter + raw_buffer/tls filter chains',
+    apply: (config) => {
+      config.set('platform.gateway.ssl.enabled', true);
+      config.set('platform.gateway.ssl.provider', 'self-signed');
+    },
+  },
+  {
+    name: 'metrics-and-admin',
+    description: 'Prometheus listener + admin cluster, admin bound to 0.0.0.0',
+    apply: (config) => {
+      config.set('platform.gateway.metrics.enabled', true);
+      config.set('platform.gateway.admin.enabled', true);
+    },
+  },
+  {
+    name: 'metrics-only',
+    description: 'Prometheus listener with the admin interface kept on loopback',
+    apply: (config) => {
+      config.set('platform.gateway.metrics.enabled', true);
+      config.set('platform.gateway.admin.enabled', false);
+    },
+  },
+  {
+    name: 'no-rate-limiter',
+    description: 'rate limiter off: no ratelimit filter, cluster, rate_limits or local_reply_config',
+    apply: (config) => {
+      config.set('platform.gateway.rateLimiter.enabled', false);
+    },
+  },
+  {
+    name: 'access-log-json',
+    description: 'JSON access logs, default and custom field dictionaries',
+    apply: (config) => {
+      config.set('platform.gateway.log.accessLogs', [
+        { type: 'stdout', format: 'json', template: null },
+        { type: 'stderr', format: 'json', template: { start: '%START_TIME%', code: '%RESPONSE_CODE%' } },
+      ]);
+    },
+  },
+  {
+    name: 'access-log-file',
+    description: 'file access logs, text and JSON, alongside a custom text template',
+    apply: (config) => {
+      config.set('platform.gateway.log.accessLogs', [
+        { type: 'file', format: 'text', path: '/var/log/dashmate/gateway/access.log', template: null },
+        {
+          type: 'file',
+          format: 'json',
+          path: '/var/log/dashmate/gateway/access_json.log',
+          template: { start: '%START_TIME%', flags: '%RESPONSE_FLAGS%' },
+        },
+        { type: 'stdout', format: 'text', template: '[%START_TIME%] %RESPONSE_CODE%' },
+      ]);
+    },
+  },
+  {
+    name: 'all-features',
+    description: 'every optional feature at once: self-signed TLS, metrics, admin, rate limiter, JSON logs',
+    apply: (config) => {
+      config.set('platform.gateway.ssl.enabled', true);
+      config.set('platform.gateway.ssl.provider', 'self-signed');
+      config.set('platform.gateway.metrics.enabled', true);
+      config.set('platform.gateway.admin.enabled', true);
+      config.set('platform.gateway.rateLimiter.enabled', true);
+      config.set('platform.gateway.log.accessLogs', [
+        { type: 'stdout', format: 'json', template: null },
+      ]);
+    },
+  },
+];
+
+/**
+ * @param {string[]} argv
+ * @return {{imageRepo: string, refs: string[], variants: string[], out: string|null,
+ *   list: boolean, smoke: boolean}}
+ */
+function parseArgs(argv) {
+  const options = {
+    imageRepo: DEFAULT_IMAGE_REPO, refs: [], variants: [], out: null, list: false, smoke: false,
+  };
+
+  for (const arg of argv) {
+    if (arg === '--list') {
+      options.list = true;
+    } else if (arg === '--smoke') {
+      options.smoke = true;
+    } else if (arg.startsWith('--image=')) {
+      options.imageRepo = arg.slice('--image='.length);
+    } else if (arg.startsWith('--variant=')) {
+      options.variants.push(arg.slice('--variant='.length));
+    } else if (arg.startsWith('--out=')) {
+      options.out = path.resolve(arg.slice('--out='.length));
+    } else if (arg.startsWith('-')) {
+      throw new Error(`Unknown option ${arg}`);
+    } else {
+      options.refs.push(arg);
+    }
+  }
+
+  return options;
+}
+
+/**
+ * The pinned gateway image is a custom build of a stock Envoy release
+ * (`dashpay/envoy:1.35.11-impr.1` wraps `envoyproxy/envoy:v1.35.11`), so the
+ * baseline tag is the pinned version without the build suffix.
+ *
+ * @param {Config} config
+ * @return {string} full image reference
+ */
+function resolveBaselineRef(config) {
+  const pinnedImage = config.get('platform.gateway.docker.image');
+  const pinnedTag = pinnedImage.slice(pinnedImage.lastIndexOf(':') + 1);
+  const version = pinnedTag.replace(/-.*$/, '');
+
+  return `${DEFAULT_IMAGE_REPO}:v${version}`;
+}
+
+/**
+ * @param {string} ref - either `tag` or `repo/name:tag`
+ * @param {string} imageRepo
+ * @return {string}
+ */
+function resolveRef(ref, imageRepo) {
+  return ref.includes(':') ? ref : `${imageRepo}:${ref}`;
+}
+
+/**
+ * Certificate material for the TLS transport socket. The validator loads the
+ * files named by the config, so they have to exist and hold a usable keypair.
+ *
+ * @param {string} dir
+ */
+function generateTlsMaterial(dir) {
+  fs.mkdirSync(dir, { recursive: true });
+
+  const result = spawnSync('openssl', [
+    'req', '-x509', '-newkey', 'rsa:2048', '-nodes', '-days', '1',
+    '-subj', '/CN=dashmate-envoy-validate',
+    '-keyout', path.join(dir, 'private.key'),
+    '-out', path.join(dir, 'bundle.crt'),
+  ], { encoding: 'utf8' });
+
+  if (result.status !== 0) {
+    throw new Error(`openssl failed to generate TLS material: ${result.stderr || result.error}`);
+  }
+}
+
+/**
+ * @param {{name: string, apply: Function}} variant
+ * @return {{config: Config, renderedConfigs: Object<string,string>}}
+ */
+function renderVariant(variant) {
+  const getBaseConfig = getBaseConfigFactory(HomeDir.createTemp());
+  const config = getBaseConfig();
+
+  variant.apply(config);
+
+  const renderServiceTemplates = renderServiceTemplatesFactory(renderTemplateFactory());
+
+  return { config, renderedConfigs: renderServiceTemplates(config) };
+}
+
+/**
+ * Pull the image up front so its progress output stays out of the validator log.
+ *
+ * @param {string} imageRef
+ */
+function ensureImage(imageRef) {
+  const inspect = spawnSync('docker', ['image', 'inspect', imageRef], { encoding: 'utf8' });
+
+  if (inspect.status === 0) {
+    return;
+  }
+
+  const pull = spawnSync('docker', ['pull', '--quiet', imageRef], {
+    encoding: 'utf8',
+    stdio: ['ignore', 'inherit', 'inherit'],
+    timeout: DOCKER_TIMEOUT_MS,
+  });
+
+  if (pull.status !== 0) {
+    throw new Error(`Failed to pull ${imageRef}`);
+  }
+}
+
+/**
+ * The config file is mounted as a single file, exactly as docker-compose.yml
+ * mounts it, so that the rest of /etc/envoy in the image stays visible — the
+ * custom `dashpay/envoy` image keeps its hot-restart supervisor there.
+ *
+ * The entrypoint is overridden for the same reason: the custom image's
+ * entrypoint is the supervisor, which does not forward Envoy's own flags.
+ *
+ * @param {string} imageRef
+ * @param {string} configPath - rendered envoy.yaml on the host
+ * @param {string} tlsDir
+ * @param {string} logDir - mounted at /var/log for file access logs
+ * @return {{status: number, output: string}}
+ */
+function runValidator(imageRef, configPath, tlsDir, logDir) {
+  const result = spawnSync('docker', [
+    'run', '--rm',
+    '--entrypoint', 'envoy',
+    '-v', `${configPath}:/etc/envoy/envoy.yaml:ro`,
+    '-v', `${path.join(tlsDir, 'bundle.crt')}:/etc/ssl/bundle.crt:ro`,
+    '-v', `${path.join(tlsDir, 'private.key')}:/etc/ssl/private.key:ro`,
+    '-v', `${logDir}:/var/log`,
+    imageRef,
+    '--mode', 'validate',
+    '-c', '/etc/envoy/envoy.yaml',
+  ], { encoding: 'utf8', timeout: DOCKER_TIMEOUT_MS });
+
+  if (result.error) {
+    return { status: -1, output: `docker run failed: ${result.error.message}` };
+  }
+
+  return {
+    status: result.status,
+    output: `${result.stdout || ''}${result.stderr || ''}`,
+  };
+}
+
+/**
+ * @param {string} output
+ * @return {{deprecations: string[], warnings: string[], errors: string[]}}
+ */
+function classifyOutput(output) {
+  const lines = output.split('\n').map((line) => line.trim()).filter(Boolean);
+
+  return {
+    deprecations: lines.filter((line) => /deprecat/i.test(line)),
+    warnings: lines.filter((line) => /\[warning]/.test(line) && !/deprecat/i.test(line)),
+    errors: lines.filter((line) => /\[(error|critical)]/.test(line)),
+  };
+}
+
+/**
+ * @param {string[]} args
+ * @param {boolean} [check=true] - throw when docker exits non-zero
+ * @return {string} trimmed stdout
+ */
+function docker(args, check = true) {
+  const result = spawnSync('docker', args, { encoding: 'utf8', timeout: DOCKER_TIMEOUT_MS });
+
+  if (check && result.status !== 0) {
+    throw new Error(`docker ${args.join(' ')} failed: ${result.stderr || result.stdout}`);
+  }
+
+  return (result.stdout || '').trim();
+}
+
+/**
+ * Envoy writes its log to both stdout and stderr, so both streams are collected.
+ *
+ * @param {string} name - container name
+ * @return {string}
+ */
+function containerLogs(name) {
+  const result = spawnSync('docker', ['logs', name], { encoding: 'utf8' });
+
+  return `${result.stdout || ''}${result.stderr || ''}`;
+}
+
+/**
+ * Block the calling thread — this script drives docker synchronously throughout.
+ *
+ * @param {number} ms
+ */
+function sleepSync(ms) {
+  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms);
+}
+
+/**
+ * @param {string} url
+ * @param {number} times
+ * @param {string[]} [headers=[]]
+ * @return {string[]} HTTP status code per request
+ */
+function httpStatuses(url, times, headers = []) {
+  const headerArgs = headers.flatMap((header) => ['-H', header]);
+  const result = spawnSync('curl', [
+    // The listener terminates TLS with the throwaway certificate generated above.
+    '--insecure', '--silent', '--output', '/dev/null',
+    '--write-out', '%{http_code}\n',
+    ...headerArgs,
+    ...Array(times).fill(url),
+  ], { encoding: 'utf8', timeout: DOCKER_TIMEOUT_MS });
+
+  return (result.stdout || '').split('\n').filter(Boolean);
+}
+
+/**
+ * @param {string} url
+ * @param {string[]} [headers=[]]
+ * @return {string} response status line and headers
+ */
+function httpResponseHeaders(url, headers = []) {
+  const headerArgs = headers.flatMap((header) => ['-H', header]);
+  const result = spawnSync('curl', [
+    '--insecure', '--silent', '--output', '/dev/null', '--dump-header', '-',
+    ...headerArgs, url,
+  ], { encoding: 'utf8', timeout: DOCKER_TIMEOUT_MS });
+
+  return result.stdout || '';
+}
+
+function removeSmokeContainers() {
+  docker(['rm', '--force', ...Object.values(SMOKE_CONTAINERS)], false);
+  docker(['network', 'rm', SMOKE_NETWORK], false);
+}
+
+/**
+ * Boot the gateway with the rate limiter behind it and assert the over-limit
+ * behaviour browser and native gRPC clients depend on.
+ *
+ * The rate limiter environment mirrors docker-compose.rate_limiter.yml; keep the
+ * two in sync when that file changes.
+ *
+ * @param {string} imageRef - Envoy image to boot
+ * @param {Config} config - the config the passed renderings came from
+ * @param {string} envoyConfigPath
+ * @param {string} rateLimiterConfigPath
+ * @param {string} tlsDir
+ * @return {{name: string, ok: boolean, detail: string}[]}
+ */
+function runSmokeChecks(imageRef, config, envoyConfigPath, rateLimiterConfigPath, tlsDir) {
+  const checks = [];
+  const record = (name, ok, detail = '') => checks.push({ name, ok, detail });
+
+  removeSmokeContainers();
+  docker(['network', 'create', SMOKE_NETWORK]);
+
+  try {
+    // The upstream aliases only make the STRICT_DNS clusters resolvable, so that
+    // an unexpected warning in the gateway log is a real finding.
+    docker(['run', '--detach', '--name', SMOKE_CONTAINERS.redis,
+      '--network', SMOKE_NETWORK,
+      '--network-alias', 'gateway_rate_limiter_redis',
+      '--network-alias', 'rs_dapi',
+      '--network-alias', 'drive_abci',
+      REDIS_IMAGE]);
+
+    docker(['run', '--detach', '--name', SMOKE_CONTAINERS.rateLimiter,
+      '--network', SMOKE_NETWORK,
+      '--network-alias', 'gateway_rate_limiter',
+      '-v', `${rateLimiterConfigPath}:/data/ratelimit/config/config.yaml:ro`,
+      '-e', 'LOG_LEVEL=info', '-e', 'LOG_FORMAT=text',
+      '-e', 'BACKEND_TYPE=redis', '-e', 'REDIS_SOCKET_TYPE=tcp',
+      '-e', 'REDIS_URL=gateway_rate_limiter_redis:6379',
+      '-e', 'RUNTIME_ROOT=/data', '-e', 'RUNTIME_SUBDIRECTORY=ratelimit',
+      '-e', 'RUNTIME_WATCH_ROOT=false', '-e', 'DISABLE_STATS=true',
+      '-e', 'CONFIG_TYPE=FILE', '-e', 'GRPC_PORT=8081',
+      '-e', 'GRPC_MAX_CONNECTION_AGE=1h', '-e', 'GRPC_MAX_CONNECTION_AGE_GRACE=10m',
+      '-e', 'LIMIT_RESPONSE_HEADERS_ENABLED=true',
+      config.get('platform.gateway.rateLimiter.docker.image'),
+      '/bin/ratelimit']);
+
+    docker(['run', '--detach', '--name', SMOKE_CONTAINERS.gateway,
+      '--network', SMOKE_NETWORK,
+      '--publish', '0:10000',
+      '-v', `${envoyConfigPath}:/etc/envoy/envoy.yaml:ro`,
+      '-v', `${path.join(tlsDir, 'bundle.crt')}:/etc/ssl/bundle.crt:ro`,
+      '-v', `${path.join(tlsDir, 'private.key')}:/etc/ssl/private.key:ro`,
+      imageRef, '-c', '/etc/envoy/envoy.yaml']);
+
+    const deadline = Date.now() + 60000;
+    let gatewayLog = containerLogs(SMOKE_CONTAINERS.gateway);
+
+    while (!gatewayLog.includes('starting workers') && Date.now() < deadline) {
+      sleepSync(500);
+      gatewayLog = containerLogs(SMOKE_CONTAINERS.gateway);
+    }
+
+    if (!gatewayLog.includes('starting workers')) {
+      record('gateway starts', false, gatewayLog.split('\n').slice(-5).join(' | '));
+
+      return checks;
+    }
+
+    record('gateway starts', true);
+
+    const noisyLines = gatewayLog.split('\n')
+      .filter((line) => /\[(warning|error|critical)]/.test(line));
+
+    record('gateway log is free of warnings', noisyLines.length === 0, noisyLines.join(' | '));
+
+    const port = docker(['port', SMOKE_CONTAINERS.gateway, '10000/tcp'])
+      .split('\n')[0].split(':').pop();
+    const url = `https://127.0.0.1:${port}/`;
+    const grpcUrl = `https://127.0.0.1:${port}/org.dash.platform.dapi.v0.Platform/getIdentity`;
+
+    // The limiter allows exactly requestsPerUnit requests per remote address,
+    // and the request after that must be rejected.
+    const requestsPerUnit = config.get('platform.gateway.rateLimiter.requestsPerUnit');
+    const statuses = httpStatuses(url, requestsPerUnit);
+    const allowed = statuses.filter((status) => status !== '429').length;
+
+    record(
+      `first ${requestsPerUnit} requests pass the limiter`,
+      allowed === requestsPerUnit,
+      `allowed ${allowed}/${requestsPerUnit}`,
+    );
+
+    const overLimit = httpStatuses(url, 1)[0];
+    record(`request ${requestsPerUnit + 1} is rate limited`, overLimit === '429', `got ${overLimit}`);
+
+    // grpc-web over-limit reply: HTTP 200 carrying grpc-status 8 and the reset
+    // hint in the same header map, which is what browser clients read.
+    const grpcWebReply = httpResponseHeaders(grpcUrl, [
+      'x-grpc-web: 1', 'content-type: application/grpc-web+proto',
+    ]);
+
+    record(
+      'grpc-web over-limit reply is 200 + grpc-status 8 + ratelimit-reset',
+      /HTTP\/2 200/.test(grpcWebReply)
+        && /^grpc-status: 8/im.test(grpcWebReply)
+        && /^ratelimit-reset:/im.test(grpcWebReply),
+      grpcWebReply.split('\n').map((line) => line.trim()).filter(Boolean).join(' | '),
+    );
+
+    const grpcReply = httpResponseHeaders(grpcUrl, ['content-type: application/grpc']);
+
+    record(
+      'native gRPC over-limit reply is 200 + grpc-status 8',
+      /HTTP\/2 200/.test(grpcReply) && /^grpc-status: 8/im.test(grpcReply),
+      grpcReply.split('\n').map((line) => line.trim()).filter(Boolean).join(' | '),
+    );
+
+    return checks;
+  } finally {
+    removeSmokeContainers();
+  }
+}
+
+function main() {
+  const options = parseArgs(process.argv.slice(2));
+
+  const variants = options.variants.length > 0
+    ? VARIANTS.filter(({ name }) => options.variants.includes(name))
+    : VARIANTS;
+
+  if (variants.length === 0) {
+    throw new Error(`No variant matched ${options.variants.join(', ')}`);
+  }
+
+  if (options.list) {
+    for (const variant of VARIANTS) {
+      process.stdout.write(`${variant.name.padEnd(20)} ${variant.description}\n`);
+    }
+
+    return 0;
+  }
+
+  const outDir = options.out ?? fs.mkdtempSync(path.join(os.tmpdir(), 'dashmate-envoy-validate-'));
+  const renderedDir = path.join(outDir, 'rendered');
+  const logsDir = path.join(outDir, 'logs');
+  const tlsDir = path.join(outDir, 'tls');
+  // Envoy runs as an unprivileged user inside the image; the file access-log
+  // variant needs to create log files under the mounted /var/log.
+  const logDir = path.join(outDir, 'var-log');
+
+  for (const dir of [renderedDir, logsDir, logDir]) {
+    fs.mkdirSync(dir, { recursive: true });
+  }
+  fs.chmodSync(logDir, 0o777);
+
+  generateTlsMaterial(tlsDir);
+
+  // Render first so a template error is reported before any image is pulled.
+  const renderings = variants.map((variant) => {
+    const { config, renderedConfigs } = renderVariant(variant);
+    const configPath = path.join(renderedDir, `envoy.${variant.name}.yaml`);
+
+    fs.writeFileSync(configPath, renderedConfigs[ENVOY_CONFIG_TEMPLATE]);
+
+    if (config.get('platform.gateway.rateLimiter.enabled')) {
+      fs.writeFileSync(
+        path.join(renderedDir, `rate_limiter.${variant.name}.yaml`),
+        renderedConfigs[RATE_LIMITER_CONFIG_TEMPLATE],
+      );
+    }
+
+    return { variant, configPath };
+  });
+
+  const refs = (options.refs.length > 0 ? options.refs : [null])
+    .map((ref) => (ref === null
+      ? resolveBaselineRef(getBaseConfigFactory(HomeDir.createTemp())())
+      : resolveRef(ref, options.imageRepo)));
+
+  process.stdout.write(`Work directory: ${outDir}\n`);
+  process.stdout.write(`Images: ${refs.join(', ')}\n\n`);
+
+  const results = [];
+  let failed = 0;
+
+  for (const ref of refs) {
+    ensureImage(ref);
+
+    process.stdout.write(`=== ${ref} ===\n`);
+
+    for (const { variant, configPath } of renderings) {
+      const { status, output } = runValidator(ref, configPath, tlsDir, logDir);
+      const classified = classifyOutput(output);
+      const ok = status === 0 && /configuration '.*' OK/.test(output);
+
+      const logName = `${ref.replace(/[^\w.-]/g, '_')}__${variant.name}.log`;
+      fs.writeFileSync(path.join(logsDir, logName), output);
+
+      results.push({
+        image: ref,
+        variant: variant.name,
+        ok,
+        exitCode: status,
+        ...classified,
+        log: path.join(logsDir, logName),
+      });
+
+      if (!ok) {
+        failed += 1;
+      }
+
+      const notes = [
+        classified.deprecations.length > 0 ? `${classified.deprecations.length} deprecation` : null,
+        classified.warnings.length > 0 ? `${classified.warnings.length} warning` : null,
+        classified.errors.length > 0 ? `${classified.errors.length} error` : null,
+      ].filter(Boolean).join(', ');
+
+      process.stdout.write(`${ok ? 'OK    ' : 'FAILED'}  ${variant.name.padEnd(20)}${notes}\n`);
+
+      for (const line of [...classified.errors, ...classified.deprecations]) {
+        process.stdout.write(`          ${line}\n`);
+      }
+    }
+
+    process.stdout.write('\n');
+  }
+
+  const smokeResults = [];
+
+  if (options.smoke) {
+    const smokeVariant = VARIANTS.find(({ name }) => name === SMOKE_VARIANT);
+    const { config, renderedConfigs } = renderVariant(smokeVariant);
+    const envoyConfigPath = path.join(renderedDir, `envoy.${SMOKE_VARIANT}.yaml`);
+    const rateLimiterConfigPath = path.join(renderedDir, `rate_limiter.${SMOKE_VARIANT}.yaml`);
+
+    fs.writeFileSync(envoyConfigPath, renderedConfigs[ENVOY_CONFIG_TEMPLATE]);
+    fs.writeFileSync(rateLimiterConfigPath, renderedConfigs[RATE_LIMITER_CONFIG_TEMPLATE]);
+
+    ensureImage(config.get('platform.gateway.rateLimiter.docker.image'));
+    ensureImage(REDIS_IMAGE);
+
+    for (const ref of refs) {
+      process.stdout.write(`=== ${ref} — smoke (${SMOKE_VARIANT} variant) ===\n`);
+
+      const checks = runSmokeChecks(
+        ref,
+        config,
+        envoyConfigPath,
+        rateLimiterConfigPath,
+        tlsDir,
+      );
+
+      for (const check of checks) {
+        process.stdout.write(`${check.ok ? 'OK    ' : 'FAILED'}  ${check.name}\n`);
+
+        if (!check.ok && check.detail) {
+          process.stdout.write(`          ${check.detail}\n`);
+        }
+      }
+
+      failed += checks.filter(({ ok }) => !ok).length;
+      smokeResults.push({ image: ref, checks });
+      process.stdout.write('\n');
+    }
+  }
+
+  fs.writeFileSync(
+    path.join(outDir, 'results.json'),
+    `${JSON.stringify({ images: refs, results, smokeResults }, null, 2)}\n`,
+  );
+
+  const total = results.length + smokeResults.reduce((sum, { checks }) => sum + checks.length, 0);
+
+  process.stdout.write(`${total - failed}/${total} checks passed\n`);
+  process.stdout.write(`Logs and renderings: ${outDir}\n`);
+
+  return failed === 0 ? 0 : 1;
+}
+
+process.exit(main());

--- a/packages/dashmate/test/unit/config/configFile/migrateConfigFileFactory.spec.js
+++ b/packages/dashmate/test/unit/config/configFile/migrateConfigFileFactory.spec.js
@@ -85,49 +85,4 @@ describe('migrateConfigFileFactory', () => {
       );
     }
   });
-
-  it('should move the gateway off the previous Envoy image but keep a customised one', async () => {
-    // Bumping the pinned gateway image in the base config only affects configs
-    // created afterwards, so existing operators stay on the previous Envoy
-    // release until a migration re-pins them. An image the operator chose
-    // themselves — private fork, vendor-patched build, a floating tag — must
-    // survive untouched, which is why the migration matches the image dashmate
-    // used to ship rather than any dashpay/envoy image.
-    const { version } = JSON.parse(fs.readFileSync(path.join(PACKAGE_ROOT_DIR, 'package.json'), 'utf8'));
-
-    const defaultConfigFileData = createConfigFile().toObject();
-    const [firstConfigName] = Object.keys(defaultConfigFileData.configs);
-    const expectedGatewayImage = defaultConfigFileData
-      .configs[firstConfigName].platform.gateway.docker.image;
-
-    const staleConfigFileData = createConfigFile().toObject();
-    staleConfigFileData.configFormatVersion = '4.0.0';
-    for (const options of Object.values(staleConfigFileData.configs)) {
-      options.platform.gateway.docker.image = 'dashpay/envoy:1.35.11-impr.1';
-    }
-
-    const customisedConfigName = Object.keys(staleConfigFileData.configs).pop();
-    staleConfigFileData.configs[customisedConfigName]
-      .platform.gateway.docker.image = 'dashpay/envoy:latest';
-
-    const migratedConfigFileData = migrateConfigFile(
-      staleConfigFileData,
-      staleConfigFileData.configFormatVersion,
-      version,
-    );
-
-    for (const [name, options] of Object.entries(migratedConfigFileData.configs)) {
-      if (name === customisedConfigName) {
-        expect(options.platform.gateway.docker.image).to.equal(
-          'dashpay/envoy:latest',
-          `customised gateway image overwritten for ${name}`,
-        );
-      } else {
-        expect(options.platform.gateway.docker.image).to.equal(
-          expectedGatewayImage,
-          `gateway image not re-pinned for ${name}`,
-        );
-      }
-    }
-  });
 });

--- a/packages/dashmate/test/unit/config/configFile/migrateConfigFileFactory.spec.js
+++ b/packages/dashmate/test/unit/config/configFile/migrateConfigFileFactory.spec.js
@@ -85,4 +85,49 @@ describe('migrateConfigFileFactory', () => {
       );
     }
   });
+
+  it('should move the gateway off the previous Envoy image but keep a customised one', async () => {
+    // Bumping the pinned gateway image in the base config only affects configs
+    // created afterwards, so existing operators stay on the previous Envoy
+    // release until a migration re-pins them. An image the operator chose
+    // themselves — private fork, vendor-patched build, a floating tag — must
+    // survive untouched, which is why the migration matches the image dashmate
+    // used to ship rather than any dashpay/envoy image.
+    const { version } = JSON.parse(fs.readFileSync(path.join(PACKAGE_ROOT_DIR, 'package.json'), 'utf8'));
+
+    const defaultConfigFileData = createConfigFile().toObject();
+    const [firstConfigName] = Object.keys(defaultConfigFileData.configs);
+    const expectedGatewayImage = defaultConfigFileData
+      .configs[firstConfigName].platform.gateway.docker.image;
+
+    const staleConfigFileData = createConfigFile().toObject();
+    staleConfigFileData.configFormatVersion = '4.0.0';
+    for (const options of Object.values(staleConfigFileData.configs)) {
+      options.platform.gateway.docker.image = 'dashpay/envoy:1.35.11-impr.1';
+    }
+
+    const customisedConfigName = Object.keys(staleConfigFileData.configs).pop();
+    staleConfigFileData.configs[customisedConfigName]
+      .platform.gateway.docker.image = 'dashpay/envoy:latest';
+
+    const migratedConfigFileData = migrateConfigFile(
+      staleConfigFileData,
+      staleConfigFileData.configFormatVersion,
+      version,
+    );
+
+    for (const [name, options] of Object.entries(migratedConfigFileData.configs)) {
+      if (name === customisedConfigName) {
+        expect(options.platform.gateway.docker.image).to.equal(
+          'dashpay/envoy:latest',
+          `customised gateway image overwritten for ${name}`,
+        );
+      } else {
+        expect(options.platform.gateway.docker.image).to.equal(
+          expectedGatewayImage,
+          `gateway image not re-pinned for ${name}`,
+        );
+      }
+    }
+  });
 });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

The gateway was pinned to `dashpay/envoy:1.35.11-impr.1`. Envoy v1.39.0 fixes an HTTP/2
PRIORITY/WINDOW_UPDATE flood-protection bypass (protection could be evaded by rapidly opening and
closing streams) that was **not** backported to the 1.35–1.38 patch lines, so the fix is only
reachable by moving to the 1.39 line.

Bumping that pin also had no repeatable pre-check: nothing verified that the config rendered from
`envoy.yaml.dot` still loads on a candidate release, or that the pieces of this gateway that only
exist at runtime — the rate limit service wire protocol and the grpc-web over-limit reply — still
work. This PR adds that gate and then performs the bump with it.

## What was done?
<!--- Describe your changes in detail -->

### Validation harness — `packages/dashmate/scripts/validate-envoy-config.js`

- Renders `templates/platform/gateway/envoy.yaml.dot` through dashmate's own renderer for 8 config
  variants covering every branch of the template (TLS provider, rate limiter on/off, metrics/admin,
  stdout/stderr/file × text/JSON access logs, all features at once), then runs Envoy's built-in
  validator — `envoy --mode validate` — on each rendering inside a given image. Hard errors and
  deprecated-field warnings are reported per variant.
- `--smoke` additionally boots redis, the pinned `envoyproxy/ratelimit` and the Envoy image under
  test on a throwaway Docker network and asserts: Envoy reaches `starting workers` with no warnings,
  exactly `requestsPerUnit` requests pass the limiter and the next is rejected, the grpc-web
  over-limit reply is `HTTP 200` + `grpc-status: 8` + `ratelimit-reset`, and the native gRPC
  over-limit reply is `HTTP 200` + `grpc-status: 8`.
- With no image argument the baseline is derived from the pinned image, so the default run always
  targets what dashmate currently ships. Bare tags resolve against `envoyproxy/envoy`; full refs
  (including the custom `dashpay/envoy` image, whose entrypoint is the hot-restart supervisor) work too.
- Procedure, the caveats it does not cover, and the v1.35.11 → v1.39.0 assessment are documented in
  `packages/dashmate/docs/services/gateway-envoy-upgrade.md`, linked from `docs/services/gateway.md`.

### The bump

- `configs/defaults/getBaseConfigFactory.js`: `platform.gateway.docker.image` →
  `dashpay/envoy:1.39.0-impr.1`.
- New config-file migration in `configs/getConfigFileMigrationsFactory.js` keyed `4.1.0-rc.2`.
  Existing configs store resolved values, so the base-config change alone leaves operators on 1.35.11.
  Following the `3.0.2` precedent, it re-pins only images matching `^dashpay/envoy:1\.35\.` and pulls
  the new value from the base config, leaving a deliberately customised image (private fork,
  vendor-patched build, floating tag) untouched.
- Docs: `docs/config/gateway.md`, `docs/update.md`.

### Behaviour changes that come with 1.39.0 (no config change needed)

- **Overload actions keyed on `global_downstream_max_connections` start firing.** v1.37.0 fixed that
  monitor — previously its actions never triggered — so `disable_http_keepalive` at 95% and
  `stop_accepting_connections` at 100% of `platform.gateway.maxConnections` become live. At ~950 of
  1000 connections Envoy will GOAWAY-drain HTTP/2 connections. Confirmed by the new
  `overload.envoy.resource_monitors.global_downstream_max_connections.pressure` gauge, absent on
  v1.35.11 and present on v1.39.0.
- **HTTP/2 flood protection scales with active streams.** Worth watching
  `http.ingress_http.http2.inbound_window_update_frames_flood`; revert guard is
  `envoy.reloadable_features.http2_flood_protection_active_streams`.

Both are documented with their revert guards in the new doc, along with lower-risk notes (upstream
`max_concurrent_streams` default, tls_inspector client TLS version enforcement, transport failure
reasons dropped from response bodies, `HeaderMatcher` multi-value matching, ratelimit `timeout: 0s`
semantics) — none of which require config edits.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

- **Harness, v1.39.0**: 8/8 variants validate clean and 6/6 smoke checks pass on
  `envoyproxy/envoy:v1.39.0` and on `dashpay/envoy:1.39.0-impr.1` (both its amd64 and arm64
  manifests), identical to the `v1.35.11` baseline, which was also run through
  `dashpay/envoy:1.35.11-impr.1`. No field in the rendered config is deprecated or removed at 1.39.0.
- **Harness can fail** — verified before trusting it: a bogus field injected into the template makes
  the run report `FAILED` and exit 1 (exit 0 once reverted), and a config using a known-deprecated
  field (`UpstreamTlsContext.enforce_rsa_key_usage`) produces the `Deprecated field:` warning the
  harness greps for.
- **Migration** — no automated test: a unit test pinning it was written and verified red→green
  (✖ `-dashpay/envoy:1.35.11-impr.1 / +dashpay/envoy:1.39.0-impr.1` before the migration, ✔ after),
  then dropped at review request. The remaining `migrate v0.25.0 config file to the latest one` test
  does not exercise the 1.35.x match or the customised-image carve-out for the 3.0.0+ cohort, so that
  behaviour is currently unguarded.
- **Hot-restart supervisor** (outside what the harness covers, since it overrides the entrypoint to
  reach Envoy's flags) checked by hand on `dashpay/envoy:1.39.0-impr.1`: boots through
  `hot-restarter.py` at epoch 0, `SIGHUP` forks a child at epoch 1 and the parent exits cleanly —
  the zero-downtime path dashmate uses after certificate renewal.
- **dashmate unit suite**: 157 passing. ESLint clean on all changed files.
- **e2e: incomplete — no full-suite verdict.** The platform test suite was run against a local 3-node
  network with all three gateways recreated on `dashpay/envoy:1.39.0-impr.1`. Everything not dependent
  on block production passed (`getBlockchainStatus`, `getStatus`, `getEpochsInfo`,
  `subscribeToBlockHeadersWithChainLocks` historical streaming), and Envoy access logs show correct
  unary and streaming proxying, including the 300s `stream_idle_timeout` firing with response flag
  `SI`. Five specs failed on `before all` timeouts, but that was an environment fault of my own making
  (the local miner — a detached `docker exec` loop in the seed's core container, recreated only by
  `dashmate group start` — was killed by a `group restart` attempt, so the chain stopped producing
  blocks and no wallet funding could confirm). The miner was restored and the suite restarted, but the
  environment was torn down before it finished. **A clean full-suite run on 1.39.0 is still
  outstanding and should gate the merge.**

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->

No API or config-schema breaks. Marked `!` because upgrading operators get a new gateway binary whose
load-shedding behaviour differs: the overload actions bound to `global_downstream_max_connections`
begin taking effect, so a node at ~95% of `platform.gateway.maxConnections` starts draining HTTP/2
connections instead of silently ignoring the thresholds. Operators who relied on the previous
(non-functioning) behaviour should review `platform.gateway.maxConnections`.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [x] I have made corresponding changes to the documentation if needed

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone


