### PR TITLE
fix(platform-wallet): make shielded re-bind non-destructive so it cannot wipe an in-flight sync pass

### DIFF
--- a/packages/rs-platform-wallet/src/manager/wallet_lifecycle.rs
+++ b/packages/rs-platform-wallet/src/manager/wallet_lifecycle.rs
@@ -615,6 +615,20 @@ impl<P: PlatformWalletPersistence + 'static> PlatformWalletManager<P> {
         // resurrecting private shielded history on disk after the
         // host believed the wallet was gone. Drops the registry +
         // persister entries and the per-subwallet store state.
+        //
+        // The handle is marked detached first: a caller that resolved
+        // this wallet before the removal can still be inside a bind
+        // (the seed-backed path resolves a mnemonic through the host,
+        // so it may take arbitrarily long), and its registration would
+        // otherwise land after the unregister below and resurrect
+        // exactly the state this call exists to drop. The flag is read
+        // inside the coordinator's install transaction, which the
+        // unregister also takes, so the two cannot interleave.
+        // Unconditional: a removal with no coordinator yet has nothing
+        // to unregister, but the handle must still be barred from
+        // binding onto one a later `configure_shielded` installs.
+        #[cfg(feature = "shielded")]
+        removed.mark_shielded_detached();
         #[cfg(feature = "shielded")]
         if let Some(coordinator) = self.shielded_coordinator().await {
             coordinator.unregister_wallet(*wallet_id).await;

--- a/packages/rs-platform-wallet/src/wallet/platform_wallet.rs
+++ b/packages/rs-platform-wallet/src/wallet/platform_wallet.rs
@@ -114,6 +114,18 @@ pub struct PlatformWallet {
     /// cloned wallet handles share the one lock.
     #[cfg(feature = "shielded")]
     pub(crate) shield_guard: Arc<tokio::sync::Mutex<()>>,
+    /// Set once this wallet has been removed from the manager, to stop
+    /// a handle that outlives the removal from binding shielded state
+    /// back onto the coordinator. Callers resolve an
+    /// `Arc<PlatformWallet>` and then hold it across a bind that can
+    /// take arbitrarily long (it may resolve a mnemonic through the
+    /// host), so a removal can complete in the middle; without this
+    /// flag the bind would re-register the wallet the removal just
+    /// detached, and the next sync pass would re-fetch and re-persist
+    /// shielded history the host believes it deleted. `Arc` so cloned
+    /// wallet handles observe the one flag.
+    #[cfg(feature = "shielded")]
+    pub(crate) shielded_detached: Arc<std::sync::atomic::AtomicBool>,
 }
 
 impl PlatformWallet {
@@ -468,6 +480,8 @@ impl PlatformWallet {
             shielded_keys: Arc::new(RwLock::new(None)),
             #[cfg(feature = "shielded")]
             shield_guard: Arc::new(tokio::sync::Mutex::new(())),
+            #[cfg(feature = "shielded")]
+            shielded_detached: Arc::new(std::sync::atomic::AtomicBool::new(false)),
         }
     }
 
@@ -533,6 +547,36 @@ impl PlatformWallet {
             account_views.insert(account, ks.viewing_keys());
         }
 
+        // Refuse to overwrite a persisted viewing key with a different
+        // one. The durable notes, activity and sync watermark this
+        // wallet already has are keyed by `(wallet_id, account_index)`
+        // alone — nothing records which key produced them — so a row
+        // written under the old key is indistinguishable from one
+        // written under the new. Upserting the new key would leave the
+        // old key's notes attributed to it (unspendable, yet counted)
+        // and its watermark in force (hiding the new key's own
+        // history). No legitimate flow re-keys an account in place, so
+        // treat it like the malformed-row case below: surface it rather
+        // than silently mixing two keys' state. The recovery is a
+        // shielded Clear, which drops both sides at once.
+        let start = self.persister.load().map_err(|e| {
+            PlatformWalletError::ShieldedBuildError(format!(
+                "persister load failed while binding shielded viewing keys: {e}"
+            ))
+        })?;
+        for (account, views) in &account_views {
+            let id = SubwalletId::new(self.wallet_id, *account);
+            if let Some(persisted) = start.shielded.viewing_keys.get(&id) {
+                if persisted.as_slice() != views.to_fvk_bytes().as_slice() {
+                    return Err(PlatformWalletError::ShieldedKeyDerivation(format!(
+                        "persisted shielded viewing key for account {account} differs from the \
+                         one derived from this seed; clear shielded state before binding a \
+                         re-keyed account"
+                    )));
+                }
+            }
+        }
+
         // Persist the viewing keys while the seed is legitimately present, so
         // every later launch can rebind seedlessly. Do not install the in-memory
         // keys when persistence rejects the write: that would advertise a
@@ -555,7 +599,10 @@ impl PlatformWallet {
                 ))
             })?;
 
-        self.install_shielded_views(account_views, coordinator, None)
+        // Hand the snapshot loaded above to the install step: it is the
+        // same start state the restore needs, minus the viewing-key
+        // rows just written (which the restore doesn't consume).
+        self.install_shielded_views(account_views, coordinator, start)
             .await
     }
 
@@ -617,32 +664,78 @@ impl PlatformWallet {
         }
         // Hand the already-loaded snapshot to the install step so the
         // restore doesn't pay a second full persister load.
-        self.install_shielded_views(account_views, coordinator, Some(start))
+        self.install_shielded_views(account_views, coordinator, start)
             .await?;
         Ok(true)
     }
 
     /// Shared tail of the two bind paths: store the viewing-grade
     /// map on this handle, replace this wallet's registration on
-    /// the coordinator, and rehydrate persisted notes / watermarks.
-    /// `preloaded` reuses a start-state snapshot the caller already
-    /// fetched (the persisted-keys path); `None` loads one here.
+    /// the coordinator, and rehydrate persisted notes / watermarks
+    /// from `start` — the snapshot both callers have already loaded
+    /// (one to reconstruct the viewing keys, the other to check them
+    /// against the seed), so the restore never pays a second load.
+    ///
+    /// Runs as one coordinator install transaction, so a concurrent
+    /// bind, wallet removal or Clear either happens entirely before or
+    /// entirely after it — never between the key-slot write and the
+    /// registration (which would leave sync decrypting under one key
+    /// while addresses and spends use another), nor between the
+    /// restore's registration check and its store write.
     #[cfg(feature = "shielded")]
     async fn install_shielded_views(
         &self,
         account_views: std::collections::BTreeMap<u32, super::shielded::AccountViewingKeys>,
         coordinator: &Arc<crate::wallet::shielded::NetworkShieldedCoordinator>,
-        preloaded: Option<crate::changeset::ClientStartState>,
+        start: crate::changeset::ClientStartState,
     ) -> Result<(), PlatformWalletError> {
+        let install = coordinator.begin_install(self.wallet_id).await;
+
+        // A wallet the manager has already removed must not be able to
+        // re-register itself. Callers reach a bind through an
+        // `Arc<PlatformWallet>` they resolved earlier and keep across
+        // the (possibly seed-resolving, so arbitrarily long) bind, so
+        // the removal can land in between; re-registering here would
+        // resurrect the wallet on the coordinator, and the next sync
+        // pass would re-fetch and re-persist shielded history the host
+        // believes it deleted. Checked inside the transaction, which
+        // `remove_wallet`'s unregister also has to take, so the two
+        // cannot interleave.
+        if self
+            .shielded_detached
+            .load(std::sync::atomic::Ordering::Acquire)
+        {
+            return Err(PlatformWalletError::WalletNotFound(format!(
+                "{} was removed from the manager; shielded bind refused",
+                hex::encode(self.wallet_id)
+            )));
+        }
+
+        // Refuse to re-key a bound account. Durable per-subwallet state
+        // (notes, activity, watermark) is keyed by
+        // `(wallet_id, account_index)` alone, so it cannot be attributed
+        // to the key that produced it: installing a different key for an
+        // account that already has state would leave notes the new
+        // spend key cannot spend, and a watermark that makes the scan
+        // skip the range where the new key's own notes live. There is no
+        // legitimate flow that changes an account's key in place — see
+        // `ShieldedChangeSet::viewing_keys` — so this is corruption or a
+        // derivation change, and the host has to Clear (which wipes both
+        // sides) before binding the new key.
+        if let Some(account) = install.conflicting_account(&account_views).await {
+            return Err(PlatformWalletError::ShieldedKeyDerivation(format!(
+                "account {account} is already bound to a different shielded viewing key; \
+                 clear shielded state before binding a re-keyed account"
+            )));
+        }
+
         let mut slot = self.shielded_keys.write().await;
         *slot = Some(account_views.clone());
         drop(slot);
 
         // Compute idempotence BEFORE registering — after
         // register_wallet the registration always matches.
-        let identical = coordinator
-            .wallet_registration_matches(self.wallet_id, &account_views)
-            .await;
+        let identical = install.registration_matches(&account_views).await;
 
         // (Re-)register on the coordinator. This is non-destructive
         // by construction: the persister handle is replaced, never
@@ -659,8 +752,8 @@ impl PlatformWallet {
         // 0" failure). Registration also runs BEFORE the restore so
         // the restore path's "is this account registered?" gate sees
         // this wallet's subwallets.
-        coordinator
-            .register_wallet(self.wallet_id, account_views, self.persister.clone())
+        install
+            .register(account_views, self.persister.clone())
             .await;
 
         // Idempotent re-bind fast path: hosts re-run bind liberally
@@ -676,7 +769,7 @@ impl PlatformWallet {
         // may have failed transiently and is only logged), and
         // skipping on registration match alone would leave notes and
         // the watermark absent until a full rescan or restart.
-        if identical && coordinator.is_hydrated(self.wallet_id).await {
+        if identical && install.is_hydrated().await {
             return Ok(());
         }
 
@@ -689,28 +782,17 @@ impl PlatformWallet {
         // not fatal — first-launch wallets simply see no persisted
         // state; the hydration flag stays unset on failure so the
         // next re-bind retries the restore instead of fast-pathing
-        // over an unhydrated store.
-        match preloaded.map(Ok).unwrap_or_else(|| self.persister.load()) {
-            Ok(start) => match coordinator
-                .restore_for_wallet(self.wallet_id, &start.shielded)
-                .await
-            {
-                Ok(()) => coordinator.mark_hydrated(self.wallet_id, true).await,
-                Err(e) => {
-                    coordinator.mark_hydrated(self.wallet_id, false).await;
-                    tracing::warn!(
-                        wallet_id = %hex::encode(self.wallet_id),
-                        error = %e,
-                        "Failed to restore shielded snapshot at bind time"
-                    );
-                }
-            },
+        // over an unhydrated store. (A snapshot that cannot be READ
+        // is fatal, but earlier: both bind paths need it before they
+        // can decide what to install.)
+        match install.restore(&start.shielded).await {
+            Ok(()) => install.mark_hydrated(true).await,
             Err(e) => {
-                coordinator.mark_hydrated(self.wallet_id, false).await;
+                install.mark_hydrated(false).await;
                 tracing::warn!(
                     wallet_id = %hex::encode(self.wallet_id),
                     error = %e,
-                    "persister.load() failed at shielded bind time"
+                    "Failed to restore shielded snapshot at bind time"
                 );
             }
         }
@@ -783,6 +865,22 @@ impl PlatformWallet {
     #[cfg(feature = "shielded")]
     pub async fn is_shielded_bound(&self) -> bool {
         self.shielded_keys.read().await.is_some()
+    }
+
+    /// Mark this wallet as removed from the manager, so any handle that
+    /// outlives the removal can no longer bind shielded state onto the
+    /// coordinator.
+    ///
+    /// Must be called **before** the coordinator's
+    /// `unregister_wallet`: that call takes the same install
+    /// transaction a bind holds, so setting the flag first makes every
+    /// bind either commit fully before the unregister purges it, or see
+    /// the flag and refuse. Setting it afterwards would leave the
+    /// window this closes.
+    #[cfg(feature = "shielded")]
+    pub(crate) fn mark_shielded_detached(&self) {
+        self.shielded_detached
+            .store(true, std::sync::atomic::Ordering::Release);
     }
 
     /// Bound ZIP-32 account indices on the shielded sub-wallet,
@@ -1409,6 +1507,8 @@ impl Clone for PlatformWallet {
             shielded_keys: self.shielded_keys.clone(),
             #[cfg(feature = "shielded")]
             shield_guard: self.shield_guard.clone(),
+            #[cfg(feature = "shielded")]
+            shielded_detached: self.shielded_detached.clone(),
         }
     }
 }

--- a/packages/rs-platform-wallet/src/wallet/platform_wallet.rs
+++ b/packages/rs-platform-wallet/src/wallet/platform_wallet.rs
@@ -638,6 +638,33 @@ impl PlatformWallet {
         *slot = Some(account_views.clone());
         drop(slot);
 
+        // Idempotent re-bind fast path: hosts re-run bind liberally
+        // (launch fires it twice — a direct call plus the wallet-set
+        // observer — and again on Sync Now / wallet navigation).
+        // When this wallet is already registered with the exact same
+        // account → FVK map, the coordinator's in-memory state is
+        // strictly fresher than any persister snapshot (the
+        // snapshot's rows were produced FROM it), so the
+        // unregister → purge → restore cycle below can only destroy
+        // information. Worse, against an in-flight sync pass those
+        // store-lock acquisitions queue behind the pass's write
+        // guard and then wipe the pass's freshly-discovered notes
+        // and watermark, restoring a snapshot loaded before the
+        // pass ran — the "note discovered by sync is unspendable
+        // until app restart" / "every pass rescans from 0" failure.
+        // Re-register (cheap, non-destructive — it never touches
+        // per-subwallet store state) to refresh the persister
+        // handle, and skip the purge + restore entirely.
+        if coordinator
+            .wallet_registration_matches(self.wallet_id, &account_views)
+            .await
+        {
+            coordinator
+                .register_wallet(self.wallet_id, account_views, self.persister.clone())
+                .await;
+            return Ok(());
+        }
+
         // Rebind is replace-not-merge (the doc contract above).
         // `register_wallet` replaces the coordinator's `accounts`
         // entries for this wallet, but it does NOT touch the

--- a/packages/rs-platform-wallet/src/wallet/platform_wallet.rs
+++ b/packages/rs-platform-wallet/src/wallet/platform_wallet.rs
@@ -851,10 +851,21 @@ impl PlatformWallet {
             )));
         }
         self.ensure_shielded_attached()?;
-        let mut slot = self.shielded_keys.write().await;
-        let keys = slot.as_mut().ok_or(PlatformWalletError::ShieldedNotBound)?;
-        if keys.contains_key(&account) {
-            return Ok(());
+        // Everything that calls into the host — the snapshot read below
+        // and the viewing-key write further down — stays OUTSIDE the key
+        // slot's lock. A host callback invoked while this write guard is
+        // held would deadlock against a concurrent bind, which takes the
+        // coordinator's lifecycle mutex and then this same slot: the
+        // callback re-enters the FFI, waits on the lifecycle mutex, and
+        // the bind holding it waits on the slot the callback's caller
+        // never released. It also keeps the slot free for the address /
+        // balance reads that run constantly while this does host I/O.
+        {
+            let slot = self.shielded_keys.read().await;
+            let keys = slot.as_ref().ok_or(PlatformWalletError::ShieldedNotBound)?;
+            if keys.contains_key(&account) {
+                return Ok(());
+            }
         }
         let views = OrchardKeySet::from_seed(seed, self.sdk.network, account)?.viewing_keys();
         // This is the other writer of a subwallet's viewing-key row, so
@@ -897,6 +908,15 @@ impl PlatformWallet {
                     "failed to persist shielded viewing key for account {account}: {e}"
                 ))
             })?;
+        // Re-check detachment before mutating the handle: the host I/O
+        // above can take arbitrarily long, and a removal completing in
+        // that window means this account must not be installed.
+        self.ensure_shielded_attached()?;
+        let mut slot = self.shielded_keys.write().await;
+        let keys = slot.as_mut().ok_or(PlatformWalletError::ShieldedNotBound)?;
+        // Idempotent against a bind that added this account while the
+        // host I/O above was in flight: same seed and index derive the
+        // same key, so re-inserting is a no-op either way.
         keys.insert(account, views);
         // NOTE: this only updates the per-wallet keys slot — the
         // coordinator's `accounts` registry isn't refreshed here.

--- a/packages/rs-platform-wallet/src/wallet/platform_wallet.rs
+++ b/packages/rs-platform-wallet/src/wallet/platform_wallet.rs
@@ -638,71 +638,75 @@ impl PlatformWallet {
         *slot = Some(account_views.clone());
         drop(slot);
 
-        // Idempotent re-bind fast path: hosts re-run bind liberally
-        // (launch fires it twice — a direct call plus the wallet-set
-        // observer — and again on Sync Now / wallet navigation).
-        // When this wallet is already registered with the exact same
-        // account → FVK map, the coordinator's in-memory state is
-        // strictly fresher than any persister snapshot (the
-        // snapshot's rows were produced FROM it), so the
-        // unregister → purge → restore cycle below can only destroy
-        // information. Worse, against an in-flight sync pass those
-        // store-lock acquisitions queue behind the pass's write
-        // guard and then wipe the pass's freshly-discovered notes
-        // and watermark, restoring a snapshot loaded before the
-        // pass ran — the "note discovered by sync is unspendable
-        // until app restart" / "every pass rescans from 0" failure.
-        // Re-register (cheap, non-destructive — it never touches
-        // per-subwallet store state) to refresh the persister
-        // handle, and skip the purge + restore entirely.
-        if coordinator
+        // Compute idempotence BEFORE registering — after
+        // register_wallet the registration always matches.
+        let identical = coordinator
             .wallet_registration_matches(self.wallet_id, &account_views)
-            .await
-        {
-            coordinator
-                .register_wallet(self.wallet_id, account_views, self.persister.clone())
-                .await;
-            return Ok(());
-        }
+            .await;
 
-        // Rebind is replace-not-merge (the doc contract above).
-        // `register_wallet` replaces the coordinator's `accounts`
-        // entries for this wallet, but it does NOT touch the
-        // store's per-`SubwalletId` state — so a same-process
-        // rebind would otherwise leave stale watermarks, orphaned
-        // accounts dropped from the new bind set, and abandoned
-        // `pending_nullifiers` reservations behind (the latter can
-        // make note selection skip spendable notes). Unregister
-        // first to purge that state; it's a no-op on first bind.
-        coordinator.unregister_wallet(self.wallet_id).await;
-
-        // Register on the coordinator BEFORE restoring so the
-        // restore path's "is this account registered?" gate
-        // sees this wallet's subwallets.
+        // (Re-)register on the coordinator. This is non-destructive
+        // by construction: the persister handle is replaced, never
+        // removed (a sync pass finishing mid-bind always finds one),
+        // and per-subwallet store state is purged only for accounts
+        // this registration DROPS or re-keys — accounts that remain
+        // bound with the same viewing key keep their in-memory notes
+        // and watermark. A re-bind racing an in-flight sync pass can
+        // therefore no longer wipe the pass's results (the former
+        // unregister-then-register cycle here purged the whole
+        // wallet behind the pass's store lock and then restored a
+        // pre-pass snapshot — the "note discovered by sync is
+        // unspendable until app restart" / "every pass rescans from
+        // 0" failure). Registration also runs BEFORE the restore so
+        // the restore path's "is this account registered?" gate sees
+        // this wallet's subwallets.
         coordinator
             .register_wallet(self.wallet_id, account_views, self.persister.clone())
             .await;
 
+        // Idempotent re-bind fast path: hosts re-run bind liberally
+        // (launch fires it twice — a direct call plus the wallet-set
+        // observer — and again on Sync Now / wallet navigation). When
+        // the registration is unchanged AND a prior hydration
+        // succeeded, the coordinator's in-memory state is strictly
+        // fresher than any persister snapshot (the snapshot's rows
+        // were produced FROM it), so re-running the restore could
+        // only re-apply older data — skip it. The hydration flag is
+        // load-bearing: a matching registration alone doesn't prove
+        // the store was ever hydrated (the first bind's load/restore
+        // may have failed transiently and is only logged), and
+        // skipping on registration match alone would leave notes and
+        // the watermark absent until a full rescan or restart.
+        if identical && coordinator.is_hydrated(self.wallet_id).await {
+            return Ok(());
+        }
+
         // Rehydrate per-subwallet notes / sync watermarks from
         // the persister's start state if any are present for
-        // this wallet. The lookup is cheap: load() is the
-        // boot-time snapshot, indexed by SubwalletId. Errors are
-        // logged but not fatal — first-launch wallets simply
-        // see no persisted state.
+        // this wallet. The restore is additive and monotonic
+        // (`restore_for_wallet` never rewinds a watermark or
+        // overwrites a known note), so applying a snapshot on top
+        // of retained live state is safe. Errors are logged but
+        // not fatal — first-launch wallets simply see no persisted
+        // state; the hydration flag stays unset on failure so the
+        // next re-bind retries the restore instead of fast-pathing
+        // over an unhydrated store.
         match preloaded.map(Ok).unwrap_or_else(|| self.persister.load()) {
-            Ok(start) => {
-                if let Err(e) = coordinator
-                    .restore_for_wallet(self.wallet_id, &start.shielded)
-                    .await
-                {
+            Ok(start) => match coordinator
+                .restore_for_wallet(self.wallet_id, &start.shielded)
+                .await
+            {
+                Ok(()) => coordinator.mark_hydrated(self.wallet_id, true).await,
+                Err(e) => {
+                    coordinator.mark_hydrated(self.wallet_id, false).await;
                     tracing::warn!(
                         wallet_id = %hex::encode(self.wallet_id),
                         error = %e,
                         "Failed to restore shielded snapshot at bind time"
                     );
                 }
-            }
+            },
             Err(e) => {
+                coordinator.mark_hydrated(self.wallet_id, false).await;
                 tracing::warn!(
                     wallet_id = %hex::encode(self.wallet_id),
                     error = %e,

--- a/packages/rs-platform-wallet/src/wallet/platform_wallet.rs
+++ b/packages/rs-platform-wallet/src/wallet/platform_wallet.rs
@@ -535,6 +535,13 @@ impl PlatformWallet {
                 "shielded wallet requires at least one account".to_string(),
             ));
         }
+        // Before anything is read or written: a wallet the manager has
+        // dropped must not persist viewing keys the host can no longer
+        // delete (see `ensure_shielded_attached`).
+        self.ensure_shielded_attached()?;
+        // Sampled before the load below so the install can tell that the
+        // snapshot predates a Clear.
+        let snapshot_generation = coordinator.clear_generation();
         let network = self.sdk.network;
         let mut account_views: std::collections::BTreeMap<u32, AccountViewingKeys> =
             std::collections::BTreeMap::new();
@@ -599,10 +606,12 @@ impl PlatformWallet {
                 ))
             })?;
 
-        // Hand the snapshot loaded above to the install step: it is the
-        // same start state the restore needs, minus the viewing-key
-        // rows just written (which the restore doesn't consume).
-        self.install_shielded_views(account_views, coordinator, start)
+        // Hand the snapshot loaded above to the install step. It predates
+        // the viewing-key upsert just made, which is safe precisely
+        // because the loop above proved the derived keys equal the
+        // persisted ones: the rows the restore filters on are unchanged
+        // by that write.
+        self.install_shielded_views(account_views, coordinator, start, snapshot_generation)
             .await
     }
 
@@ -642,6 +651,10 @@ impl PlatformWallet {
                 "shielded wallet requires at least one account".to_string(),
             ));
         }
+        self.ensure_shielded_attached()?;
+        // Sampled before the load so the install can tell that the
+        // snapshot predates a Clear.
+        let snapshot_generation = coordinator.clear_generation();
         let start = self.persister.load().map_err(|e| {
             PlatformWalletError::ShieldedBuildError(format!(
                 "persister load failed while rebinding shielded viewing keys: {e}"
@@ -664,7 +677,7 @@ impl PlatformWallet {
         }
         // Hand the already-loaded snapshot to the install step so the
         // restore doesn't pay a second full persister load.
-        self.install_shielded_views(account_views, coordinator, start)
+        self.install_shielded_views(account_views, coordinator, start, snapshot_generation)
             .await?;
         Ok(true)
     }
@@ -688,6 +701,7 @@ impl PlatformWallet {
         account_views: std::collections::BTreeMap<u32, super::shielded::AccountViewingKeys>,
         coordinator: &Arc<crate::wallet::shielded::NetworkShieldedCoordinator>,
         start: crate::changeset::ClientStartState,
+        snapshot_generation: u64,
     ) -> Result<(), PlatformWalletError> {
         let install = coordinator.begin_install(self.wallet_id).await;
 
@@ -701,15 +715,7 @@ impl PlatformWallet {
         // believes it deleted. Checked inside the transaction, which
         // `remove_wallet`'s unregister also has to take, so the two
         // cannot interleave.
-        if self
-            .shielded_detached
-            .load(std::sync::atomic::Ordering::Acquire)
-        {
-            return Err(PlatformWalletError::WalletNotFound(format!(
-                "{} was removed from the manager; shielded bind refused",
-                hex::encode(self.wallet_id)
-            )));
-        }
+        self.ensure_shielded_attached()?;
 
         // Refuse to re-key a bound account. Durable per-subwallet state
         // (notes, activity, watermark) is keyed by
@@ -785,6 +791,23 @@ impl PlatformWallet {
         // over an unhydrated store. (A snapshot that cannot be READ
         // is fatal, but earlier: both bind paths need it before they
         // can decide what to install.)
+        // A Clear that completed after `start` was read wiped both the
+        // store and (once it returned) the host's own rows, so this
+        // snapshot describes state the user asked to be deleted.
+        // Restoring it would put the notes back and re-arm the pre-Clear
+        // watermark, which reports caught-up and suppresses the cold
+        // rebuild Clear promises. Register (done above) but restore
+        // nothing, and leave hydration unset so the next bind hydrates
+        // from the host's post-Clear rows.
+        if install.snapshot_predates_clear(snapshot_generation) {
+            install.mark_hydrated(false).await;
+            tracing::info!(
+                wallet_id = %hex::encode(self.wallet_id),
+                "Skipped shielded snapshot restore: shielded state was cleared while binding"
+            );
+            return Ok(());
+        }
+
         match install.restore(&start.shielded).await {
             Ok(()) => install.mark_hydrated(true).await,
             Err(e) => {
@@ -827,12 +850,35 @@ impl PlatformWallet {
                 missing.bits(),
             )));
         }
+        self.ensure_shielded_attached()?;
         let mut slot = self.shielded_keys.write().await;
         let keys = slot.as_mut().ok_or(PlatformWalletError::ShieldedNotBound)?;
         if keys.contains_key(&account) {
             return Ok(());
         }
         let views = OrchardKeySet::from_seed(seed, self.sdk.network, account)?.viewing_keys();
+        // This is the other writer of a subwallet's viewing-key row, so
+        // it owes the same refusal `bind_shielded` makes: an account
+        // absent from the in-memory map can still have durable rows from
+        // an earlier session, and overwriting its key would leave those
+        // notes and their watermark attributed to a key that did not
+        // produce them, undetectably (a later seedless bind derives its
+        // keys FROM this row, so nothing downstream can see the swap).
+        let start = self.persister.load().map_err(|e| {
+            PlatformWalletError::ShieldedBuildError(format!(
+                "persister load failed while adding shielded account {account}: {e}"
+            ))
+        })?;
+        let id = SubwalletId::new(self.wallet_id, account);
+        if let Some(persisted) = start.shielded.viewing_keys.get(&id) {
+            if persisted.as_slice() != views.to_fvk_bytes().as_slice() {
+                return Err(PlatformWalletError::ShieldedKeyDerivation(format!(
+                    "persisted shielded viewing key for account {account} differs from the one \
+                     derived from this seed; clear shielded state before binding a re-keyed \
+                     account"
+                )));
+            }
+        }
         // Persist the new account's viewing key alongside the
         // in-memory insert, mirroring `bind_shielded`, so the
         // seedless rebind path covers it on the next launch.
@@ -865,6 +911,30 @@ impl PlatformWallet {
     #[cfg(feature = "shielded")]
     pub async fn is_shielded_bound(&self) -> bool {
         self.shielded_keys.read().await.is_some()
+    }
+
+    /// `Err` once this wallet has been removed from the manager.
+    ///
+    /// The install transaction performs the authoritative check, but the
+    /// bind paths also write to the HOST persister (viewing-key rows)
+    /// before they get there, and hosts delete their own wallet data
+    /// after `remove_wallet` returns — so a bind that only failed at the
+    /// end would still leave a full viewing key on disk for a wallet the
+    /// user deleted, with the mnemonic already gone. An FVK discloses
+    /// every incoming and outgoing note of its account, so the bind
+    /// paths check here first, before writing anything.
+    #[cfg(feature = "shielded")]
+    fn ensure_shielded_attached(&self) -> Result<(), PlatformWalletError> {
+        if self
+            .shielded_detached
+            .load(std::sync::atomic::Ordering::Acquire)
+        {
+            return Err(PlatformWalletError::WalletNotFound(format!(
+                "{} was removed from the manager; shielded bind refused",
+                hex::encode(self.wallet_id)
+            )));
+        }
+        Ok(())
     }
 
     /// Mark this wallet as removed from the manager, so any handle that
@@ -1357,21 +1427,33 @@ impl PlatformWallet {
             select_shield_inputs(candidates, amount, FEE_RESERVE_CREDITS)?
         };
 
-        let guard = self.shielded_keys.read().await;
-        let keys = guard
-            .as_ref()
-            .ok_or(PlatformWalletError::ShieldedNotBound)?;
-        let keyset = keys.get(&shielded_account).ok_or_else(|| {
-            PlatformWalletError::ShieldedKeyDerivation(format!(
-                "shielded account {shielded_account} not bound"
-            ))
-        })?;
+        // Clone the account's viewing keys and release the slot before
+        // the proof: `shield` runs a Halo 2 proof plus a broadcast, and
+        // holding the read guard across it would block the bind path's
+        // slot write for that whole window — which, because a bind holds
+        // the coordinator's lifecycle mutex while waiting for it, would
+        // stall wallet removal and Clear for every wallet on the network
+        // (tokio's RwLock is write-preferring, so queued readers pile up
+        // behind that write too).
+        let keyset = {
+            let guard = self.shielded_keys.read().await;
+            let keys = guard
+                .as_ref()
+                .ok_or(PlatformWalletError::ShieldedNotBound)?;
+            keys.get(&shielded_account)
+                .ok_or_else(|| {
+                    PlatformWalletError::ShieldedKeyDerivation(format!(
+                        "shielded account {shielded_account} not bound"
+                    ))
+                })?
+                .clone()
+        };
         super::shielded::operations::shield(
             &self.sdk,
             coordinator.store(),
             Some(&self.persister),
             self.wallet_id,
-            keyset,
+            &keyset,
             shielded_account,
             inputs,
             amount,

--- a/packages/rs-platform-wallet/src/wallet/shielded/coordinator.rs
+++ b/packages/rs-platform-wallet/src/wallet/shielded/coordinator.rs
@@ -295,6 +295,17 @@ impl NetworkShieldedCoordinator {
         account_views: BTreeMap<u32, AccountViewingKeys>,
         persister: WalletPersister,
     ) {
+        // Persister FIRST, accounts second. `sync()` snapshots
+        // `accounts` at pass start and looks the persister up only
+        // when it queues the pass's changeset — with the reverse
+        // order a pass starting between the two inserts would see
+        // the subwallets but find no persister and silently drop
+        // the whole changeset ("no persister registered", observed
+        // on device as a scan pass whose discovered notes never
+        // reached the host). Registering the persister before the
+        // accounts makes "accounts visible ⇒ persister visible"
+        // hold at every interleaving.
+        self.persisters.write().await.insert(wallet_id, persister);
         let mut accounts = self.accounts.write().await;
         // Drop any prior subwallets for this wallet_id before
         // installing the new set so a re-bind with a different
@@ -303,8 +314,40 @@ impl NetworkShieldedCoordinator {
         for (account_index, views) in account_views {
             accounts.insert(SubwalletId::new(wallet_id, account_index), views);
         }
-        drop(accounts);
-        self.persisters.write().await.insert(wallet_id, persister);
+    }
+
+    /// Whether `wallet_id` is currently registered with exactly
+    /// `account_views` — the same account indices, each bound to the
+    /// same full viewing key (compared by the canonical 96-byte FVK
+    /// encoding; IVK / OVK / default address are pure functions of
+    /// the FVK, so FVK equality covers the whole viewing set).
+    ///
+    /// Used by `PlatformWallet::install_shielded_views` to detect an
+    /// idempotent re-bind (same wallet, same accounts, same keys) and
+    /// skip the destructive unregister → purge → restore cycle. That
+    /// cycle is only safe when the registration actually changed:
+    /// against an in-flight sync pass its `purge_wallet` /
+    /// `restore_for_wallet` lock acquisitions queue BEHIND the pass's
+    /// store write guard and then wipe the pass's freshly-saved notes
+    /// and watermark, replacing them with a persister snapshot loaded
+    /// before the pass ran (observed on iOS as "note discovered by
+    /// sync is not spendable until app restart" plus a full rescan
+    /// on every subsequent pass).
+    pub async fn wallet_registration_matches(
+        &self,
+        wallet_id: WalletId,
+        account_views: &BTreeMap<u32, AccountViewingKeys>,
+    ) -> bool {
+        let accounts = self.accounts.read().await;
+        let registered: BTreeMap<u32, [u8; 96]> = accounts
+            .iter()
+            .filter(|(id, _)| id.wallet_id == wallet_id)
+            .map(|(id, views)| (id.account_index, views.to_fvk_bytes()))
+            .collect();
+        registered.len() == account_views.len()
+            && account_views
+                .iter()
+                .all(|(account, views)| registered.get(account) == Some(&views.to_fvk_bytes()))
     }
 
     /// Remove every account belonging to `wallet_id` from the
@@ -395,7 +438,27 @@ impl NetworkShieldedCoordinator {
             if id.wallet_id != wallet_id || !registered.contains(id) {
                 continue;
             }
+            // Nullifiers the store already tracks for this subwallet.
+            // The in-memory state is always at least as fresh as the
+            // host snapshot (the snapshot's rows were produced from
+            // it via the persister changesets), so a note the store
+            // already knows must NOT be overwritten from the
+            // snapshot: `save_note` is overwrite-by-nullifier, and a
+            // stale snapshot copy could flip a spent note back to
+            // unspent (re-offering it to selection = double-spend
+            // attempt) or roll back a fresher block height. Restore
+            // is additive-only: it fills in notes the store has never
+            // seen (the cold-start case, where this set is empty).
+            let known_nullifiers: std::collections::BTreeSet<[u8; 32]> = store
+                .get_all_notes(*id)
+                .map_err(|e| crate::error::PlatformWalletError::ShieldedStoreError(e.to_string()))?
+                .into_iter()
+                .map(|n| n.nullifier)
+                .collect();
             for note in &sub.notes {
+                if known_nullifiers.contains(&note.nullifier) {
+                    continue;
+                }
                 store.save_note(*id, note).map_err(|e| {
                     crate::error::PlatformWalletError::ShieldedStoreError(e.to_string())
                 })?;
@@ -423,11 +486,26 @@ impl NetworkShieldedCoordinator {
                     crate::error::PlatformWalletError::ShieldedStoreError(e.to_string())
                 })?;
             }
-            store
-                .set_last_synced_note_index(*id, sub.last_synced_index)
-                .map_err(|e| {
-                    crate::error::PlatformWalletError::ShieldedStoreError(e.to_string())
-                })?;
+            // Watermark restore is advance-only. A snapshot loaded
+            // before an in-flight sync pass (a mid-session re-bind
+            // queues behind the pass's store write lock) carries the
+            // PRE-pass watermark; applying it unconditionally rewinds
+            // the store below what the pass just scanned and forces a
+            // full rescan on every subsequent pass until restart.
+            // The store's own value only ever comes from a completed
+            // scan or a prior restore, so taking the max is always
+            // safe; genuine rewinds (chain rollback handling, Clear)
+            // write the store directly rather than through restore.
+            let current = store.last_synced_note_index(*id).map_err(|e| {
+                crate::error::PlatformWalletError::ShieldedStoreError(e.to_string())
+            })?;
+            if sub.last_synced_index > current {
+                store
+                    .set_last_synced_note_index(*id, sub.last_synced_index)
+                    .map_err(|e| {
+                        crate::error::PlatformWalletError::ShieldedStoreError(e.to_string())
+                    })?;
+            }
         }
         Ok(())
     }
@@ -1485,6 +1563,191 @@ mod tests {
         assert!(
             prefetched.is_none(),
             "nothing armed ⇒ no anchor fetch, no release pass"
+        );
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// Build a minimal unspent [`super::super::store::ShieldedNote`]
+    /// carrying `nullifier` at `position`.
+    fn test_note(
+        nullifier: [u8; 32],
+        position: u64,
+        is_spent: bool,
+    ) -> crate::wallet::shielded::ShieldedNote {
+        crate::wallet::shielded::ShieldedNote {
+            position,
+            cmx: [0x2A; 32],
+            nullifier,
+            block_height: 100,
+            is_spent,
+            value: 1_000,
+            note_data: vec![0u8; 115],
+        }
+    }
+
+    /// Regression guard for the mid-session re-bind stomp: a
+    /// `restore_for_wallet` call whose snapshot predates a completed
+    /// sync pass (the exact state a re-bind queued behind the pass's
+    /// store write lock applies) must not rewind the watermark and
+    /// must not overwrite notes the store already tracks.
+    ///
+    /// Observed on iOS (rc.2, testnet): pass discovers a note and
+    /// advances the watermark 0 → 2248; a second launch-time bind then
+    /// applies its pre-pass snapshot, wiping the note from selection
+    /// ("No unspent shielded notes available" until app restart) and
+    /// rewinding the watermark so every subsequent pass rescanned the
+    /// full tree.
+    #[tokio::test]
+    async fn restore_with_stale_snapshot_does_not_rewind_watermark_or_clobber_notes() {
+        use crate::changeset::{ShieldedSubwalletStartState, ShieldedSyncStartState};
+
+        let dir = temp_dir("stale_restore");
+        let coordinator = coordinator_with_one_wallet(&dir).await;
+        let wallet_id: WalletId = [0x11; 32];
+        let id = SubwalletId::new(wallet_id, 0);
+
+        // State a completed sync pass left behind: one fresh unspent
+        // note, watermark advanced to 2248.
+        let fresh_nf = [0xF1; 32];
+        {
+            let mut store = coordinator.store().write().await;
+            store
+                .save_note(id, &test_note(fresh_nf, 2246, false))
+                .unwrap();
+            store.set_last_synced_note_index(id, 2248).unwrap();
+        }
+
+        // A stale snapshot loaded BEFORE that pass: no notes yet,
+        // watermark still at the pre-pass value.
+        let mut snapshot = ShieldedSyncStartState::default();
+        snapshot.per_subwallet.insert(
+            id,
+            ShieldedSubwalletStartState {
+                last_synced_index: 2046,
+                ..Default::default()
+            },
+        );
+
+        coordinator
+            .restore_for_wallet(wallet_id, &snapshot)
+            .await
+            .expect("restore should succeed");
+
+        let store = coordinator.store().read().await;
+        assert_eq!(
+            store.last_synced_note_index(id).unwrap(),
+            2248,
+            "a stale snapshot must not rewind the watermark below a completed pass"
+        );
+        let unspent = store.get_unspent_notes(id).unwrap();
+        assert_eq!(unspent.len(), 1, "the pass's note must survive the restore");
+        assert_eq!(unspent[0].nullifier, fresh_nf);
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// A snapshot may never resurrect a note the store already marked
+    /// spent: `save_note` is overwrite-by-nullifier, so an
+    /// unconditional restore of a stale `is_spent = false` row would
+    /// re-offer a spent note to selection (a double-spend attempt at
+    /// broadcast). Restore must be additive-only over nullifiers.
+    #[tokio::test]
+    async fn restore_does_not_resurrect_a_spent_note() {
+        use crate::changeset::{ShieldedSubwalletStartState, ShieldedSyncStartState};
+
+        let dir = temp_dir("no_resurrect");
+        let coordinator = coordinator_with_one_wallet(&dir).await;
+        let wallet_id: WalletId = [0x11; 32];
+        let id = SubwalletId::new(wallet_id, 0);
+
+        let nf = [0xD0; 32];
+        {
+            let mut store = coordinator.store().write().await;
+            store.save_note(id, &test_note(nf, 5, false)).unwrap();
+            assert!(store.mark_spent(id, &nf).unwrap());
+        }
+
+        // Stale snapshot still carries the note as unspent, plus one
+        // genuinely new note the store has never seen.
+        let new_nf = [0xD1; 32];
+        let mut snapshot = ShieldedSyncStartState::default();
+        snapshot.per_subwallet.insert(
+            id,
+            ShieldedSubwalletStartState {
+                notes: vec![test_note(nf, 5, false), test_note(new_nf, 6, false)],
+                ..Default::default()
+            },
+        );
+
+        coordinator
+            .restore_for_wallet(wallet_id, &snapshot)
+            .await
+            .expect("restore should succeed");
+
+        let store = coordinator.store().read().await;
+        let unspent = store.get_unspent_notes(id).unwrap();
+        assert_eq!(
+            unspent.len(),
+            1,
+            "only the genuinely new note is restored; the spent one stays spent"
+        );
+        assert_eq!(unspent[0].nullifier, new_nf);
+        assert_eq!(store.get_all_notes(id).unwrap().len(), 2);
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// `wallet_registration_matches` — the idempotent-re-bind gate:
+    /// true only for the exact same wallet + account → FVK map; false
+    /// for an unknown wallet, a different account set, or a different
+    /// key on the same account index.
+    #[tokio::test]
+    async fn wallet_registration_matches_detects_identical_rebind() {
+        let dir = temp_dir("reg_match");
+        let coordinator = coordinator_with_one_wallet(&dir).await;
+        let wallet_id: WalletId = [0x11; 32];
+
+        let same_views = OrchardKeySet::from_seed(&[0x42u8; 64], dashcore::Network::Testnet, 0)
+            .expect("derive viewing keys")
+            .viewing_keys();
+        let mut same = BTreeMap::new();
+        same.insert(0u32, same_views.clone());
+        assert!(
+            coordinator
+                .wallet_registration_matches(wallet_id, &same)
+                .await,
+            "identical wallet + account + FVK must match"
+        );
+
+        // Unknown wallet id.
+        assert!(
+            !coordinator
+                .wallet_registration_matches([0x99; 32], &same)
+                .await
+        );
+
+        // Extra account on the request side.
+        let extra_views = OrchardKeySet::from_seed(&[0x42u8; 64], dashcore::Network::Testnet, 1)
+            .expect("derive viewing keys")
+            .viewing_keys();
+        let mut extra = same.clone();
+        extra.insert(1u32, extra_views.clone());
+        assert!(
+            !coordinator
+                .wallet_registration_matches(wallet_id, &extra)
+                .await,
+            "a changed account set must not match"
+        );
+
+        // Same account index, different key material.
+        let mut different_key = BTreeMap::new();
+        different_key.insert(0u32, extra_views);
+        assert!(
+            !coordinator
+                .wallet_registration_matches(wallet_id, &different_key)
+                .await,
+            "a different FVK on the same account must not match"
         );
 
         let _ = std::fs::remove_dir_all(&dir);

--- a/packages/rs-platform-wallet/src/wallet/shielded/coordinator.rs
+++ b/packages/rs-platform-wallet/src/wallet/shielded/coordinator.rs
@@ -1047,6 +1047,20 @@ impl NetworkShieldedCoordinator {
                 }
             }
         }
+        // Hydration and snapshot validity go regardless of the outcome
+        // above, because the subwallet purge runs FIRST: a failure in a
+        // later step still leaves the per-subwallet notes and watermarks
+        // destroyed. Leaving the hydrated flag set there would let the
+        // next identical re-bind take the idempotent fast path over a
+        // store whose contents this call just deleted — the host keeps
+        // its rows on a failed Clear, and they would never be restored
+        // until a restart. Leaving the generation unbumped would
+        // likewise let an in-flight bind restore a pre-Clear snapshot
+        // into the half-emptied store.
+        self.hydrated.write().await.clear();
+        self.clear_generation
+            .fetch_add(1, std::sync::atomic::Ordering::AcqRel);
+
         if let Some(e) = first_err {
             return Err(e);
         }
@@ -1054,17 +1068,12 @@ impl NetworkShieldedCoordinator {
         // Store reset succeeded — now it is safe to drop the in-memory
         // registries and reset the cooldown so the first post-clear
         // background pass runs immediately rather than honoring a stale
-        // "caught up" stamp. On the failure path above none of this runs,
-        // so a failed clear leaves coordinator state untouched.
+        // "caught up" stamp. The registries deliberately survive a failed
+        // clear: dropping them would make the coordinator forget every
+        // bound wallet (no syncs until the host rebinds) while the host,
+        // told the clear failed, keeps its own state.
         self.accounts.write().await.clear();
         self.persisters.write().await.clear();
-        self.hydrated.write().await.clear();
-        // Invalidate every host snapshot loaded before this point. Bumped
-        // under the lifecycle mutex and after the purge, so any install
-        // that observes the old value is still queued behind this Clear
-        // and will re-read the new one once it holds the mutex.
-        self.clear_generation
-            .fetch_add(1, std::sync::atomic::Ordering::AcqRel);
         if let Ok(mut g) = self.last_caught_up_at.lock() {
             *g = None;
         }
@@ -1969,6 +1978,44 @@ mod tests {
         assert!(
             !coordinator.persisters.read().await.is_empty(),
             "persisters must survive a failed clear"
+        );
+    }
+
+    /// A Clear that fails partway has still destroyed restorable state:
+    /// the subwallet purge runs before the tree reset, so the notes and
+    /// watermarks are gone even when a later step errors. Hydration must
+    /// therefore be invalidated on that path too — otherwise the next
+    /// identical re-bind takes the idempotent fast path over a store this
+    /// call emptied, and the host rows it deliberately kept (it was told
+    /// the Clear failed) are never restored until a restart.
+    ///
+    /// Unix-only for the same reason as `clear_failure_preserves_registries`:
+    /// the failure injection relies on POSIX unlink-while-open.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn clear_failure_still_invalidates_hydration_and_snapshots() {
+        let dir = temp_dir("clear_err_hydration");
+        let coordinator = coordinator_with_one_wallet(&dir).await;
+        let wallet_id: WalletId = [0x11; 32];
+
+        coordinator.mark_hydrated(wallet_id, true).await;
+        let generation_before = coordinator.clear_generation();
+
+        // Break the tree reset's reopen, leaving the subwallet purge —
+        // which runs first — to succeed.
+        std::fs::remove_dir_all(&dir).expect("remove temp dir to break reopen");
+
+        let result = coordinator.clear().await;
+        assert!(result.is_err(), "the store-reset failure must surface");
+        assert!(
+            !coordinator.is_hydrated(wallet_id).await,
+            "a failed clear still purged the subwallet state, so hydration must not survive — \
+             the next re-bind would otherwise fast-path over an emptied store"
+        );
+        assert_ne!(
+            coordinator.clear_generation(),
+            generation_before,
+            "snapshots loaded before a partial clear must be invalidated too"
         );
     }
 

--- a/packages/rs-platform-wallet/src/wallet/shielded/coordinator.rs
+++ b/packages/rs-platform-wallet/src/wallet/shielded/coordinator.rs
@@ -181,6 +181,37 @@ pub struct NetworkShieldedCoordinator {
     ///
     /// Same `std::sync::Mutex` rationale as `progress_handler`.
     tree_progress_handler: std::sync::Mutex<Option<ShieldedTreeProgressCallback>>,
+
+    /// Serializes every registry LIFECYCLE mutation —
+    /// [`register_wallet`](Self::register_wallet),
+    /// [`unregister_wallet`](Self::unregister_wallet), and the
+    /// registry phase of [`clear`](Self::clear) — so the `accounts` /
+    /// `persisters` pair always mutates as one atomic step. The two
+    /// maps sit behind separate `RwLock`s (readers like `sync()` take
+    /// them independently), so without this outer mutex a concurrent
+    /// register + unregister could interleave as *insert persister →
+    /// remove accounts → insert accounts → remove persister*, leaving
+    /// visible accounts with no persister — a state in which `sync()`
+    /// silently drops that wallet's changeset. With the mutex, the
+    /// only accounts-without-persister window a `sync()` pass can
+    /// observe is a wallet being genuinely removed mid-pass, where
+    /// dropping its changeset is the intended outcome.
+    lifecycle: tokio::sync::Mutex<()>,
+
+    /// Wallets whose per-subwallet store state has been successfully
+    /// hydrated from the host's persisted snapshot this session
+    /// (`restore_for_wallet` completed without error after the
+    /// wallet's current registration was installed). A matching
+    /// registration alone does NOT imply hydration: the first bind
+    /// registers before restoring, and a transient persister
+    /// load/restore failure is logged rather than surfaced — without
+    /// this flag a later re-bind would see matching keys, take the
+    /// idempotent fast path, and silently skip the restore that could
+    /// now succeed, leaving notes and the watermark absent until a
+    /// full rescan or restart. Cleared on unregister / clear, and
+    /// whenever a re-bind replaces the registration with a different
+    /// account set.
+    hydrated: RwLock<std::collections::BTreeSet<WalletId>>,
 }
 
 impl NetworkShieldedCoordinator {
@@ -207,6 +238,8 @@ impl NetworkShieldedCoordinator {
             last_caught_up_at: std::sync::Mutex::new(None),
             progress_handler: std::sync::Mutex::new(None),
             tree_progress_handler: std::sync::Mutex::new(None),
+            lifecycle: tokio::sync::Mutex::new(()),
+            hydrated: RwLock::new(std::collections::BTreeSet::new()),
         }
     }
 
@@ -285,7 +318,17 @@ impl NetworkShieldedCoordinator {
     /// Idempotent: a second call with the same `wallet_id`
     /// replaces every previously-registered account and the
     /// persister handle for that wallet (so a re-bind after a
-    /// clear is consistent).
+    /// clear is consistent). A re-bind never removes the persister
+    /// (it only ever replaces it), so a sync pass finishing during a
+    /// re-bind always finds a persister for its changeset. Store
+    /// state is purged ONLY for subwallets the new registration
+    /// drops or re-keys: an account that was registered before but
+    /// is absent from `account_views`, or whose full viewing key
+    /// changed (its stored notes were decrypted under — and belong
+    /// to — the old key). Accounts that remain bound with the same
+    /// key keep their in-memory notes and watermark across the
+    /// re-bind, so a registration replacement racing an in-flight
+    /// sync pass can no longer wipe the pass's results.
     ///
     /// [`ShieldedWallet`]: super::ShieldedWallet
     /// [`PlatformWallet::bind_shielded`]: crate::wallet::PlatformWallet::bind_shielded
@@ -295,6 +338,46 @@ impl NetworkShieldedCoordinator {
         account_views: BTreeMap<u32, AccountViewingKeys>,
         persister: WalletPersister,
     ) {
+        // Serialize against unregister_wallet / clear so the
+        // accounts + persisters pair mutates atomically (see the
+        // `lifecycle` field doc for the interleaving this forbids).
+        let _lifecycle = self.lifecycle.lock().await;
+
+        // Subwallets the new registration drops or re-keys. Their
+        // store state must go: a dropped account would otherwise
+        // keep unspendable notes and a stale watermark alive, and a
+        // re-keyed account's stored notes belong to the OLD viewing
+        // key. Computed before the maps mutate.
+        let stale: Vec<SubwalletId> = {
+            let accounts = self.accounts.read().await;
+            accounts
+                .iter()
+                .filter(|(id, _)| id.wallet_id == wallet_id)
+                .filter(|(id, views)| {
+                    account_views
+                        .get(&id.account_index)
+                        .map(|new_views| new_views.to_fvk_bytes() != views.to_fvk_bytes())
+                        .unwrap_or(true)
+                })
+                .map(|(id, _)| *id)
+                .collect()
+        };
+        // Whether the registration shape changed AT ALL — a dropped or
+        // re-keyed subwallet (`stale`), or an ADDED account (present in
+        // `account_views` but not registered before). An added account
+        // needs its own hydration (the host may hold persisted notes /
+        // a watermark for it from an earlier session), so any shape
+        // change invalidates the wallet's hydrated flag even when
+        // nothing is purged.
+        let shape_changed = !stale.is_empty() || {
+            let accounts = self.accounts.read().await;
+            let registered_count = accounts
+                .keys()
+                .filter(|id| id.wallet_id == wallet_id)
+                .count();
+            registered_count != account_views.len()
+        };
+
         // Persister FIRST, accounts second. `sync()` snapshots
         // `accounts` at pass start and looks the persister up only
         // when it queues the pass's changeset — with the reverse
@@ -306,13 +389,67 @@ impl NetworkShieldedCoordinator {
         // accounts makes "accounts visible ⇒ persister visible"
         // hold at every interleaving.
         self.persisters.write().await.insert(wallet_id, persister);
-        let mut accounts = self.accounts.write().await;
-        // Drop any prior subwallets for this wallet_id before
-        // installing the new set so a re-bind with a different
-        // account list doesn't leave orphan entries.
-        accounts.retain(|id, _| id.wallet_id != wallet_id);
-        for (account_index, views) in account_views {
-            accounts.insert(SubwalletId::new(wallet_id, account_index), views);
+        {
+            let mut accounts = self.accounts.write().await;
+            // Drop any prior subwallets for this wallet_id before
+            // installing the new set so a re-bind with a different
+            // account list doesn't leave orphan entries.
+            accounts.retain(|id, _| id.wallet_id != wallet_id);
+            for (account_index, views) in account_views {
+                accounts.insert(SubwalletId::new(wallet_id, account_index), views);
+            }
+        }
+
+        // Any shape change invalidates prior hydration — the restore
+        // that ran for the old shape doesn't cover the new one (an
+        // added account may have host-persisted state waiting).
+        if shape_changed {
+            self.hydrated.write().await.remove(&wallet_id);
+        }
+
+        // Purge ONLY the dropped / re-keyed subwallets' store state.
+        // Skipped entirely on the identical-registration path (empty
+        // `stale`), which keeps that path free of the store lock — it
+        // must never queue behind an in-flight sync pass (that
+        // blocking, followed by a purge, was the original
+        // wipe-the-pass bug). A changed-set re-bind may block here,
+        // but it only ever touches subwallets the caller explicitly
+        // dropped; retained accounts are left untouched.
+        if !stale.is_empty() {
+            let mut store = self.store.write().await;
+            for id in stale {
+                if let Err(e) = store.purge_subwallet(id) {
+                    tracing::warn!(
+                        wallet_id = %hex::encode(id.wallet_id),
+                        account = id.account_index,
+                        error = %e,
+                        "Failed to purge dropped subwallet store state on re-register"
+                    );
+                }
+            }
+        }
+    }
+
+    /// Whether `wallet_id`'s per-subwallet store state has been
+    /// successfully hydrated from the host snapshot this session
+    /// (see [`mark_hydrated`](Self::mark_hydrated)).
+    pub async fn is_hydrated(&self, wallet_id: WalletId) -> bool {
+        self.hydrated.read().await.contains(&wallet_id)
+    }
+
+    /// Record whether `wallet_id`'s hydration
+    /// ([`restore_for_wallet`](Self::restore_for_wallet) after the
+    /// current registration was installed) succeeded. The bind path
+    /// sets `true` only after a successful load + restore; a
+    /// transient persistence failure leaves it `false` so the next
+    /// re-bind retries the restore instead of taking the idempotent
+    /// fast path on top of an unhydrated store.
+    pub async fn mark_hydrated(&self, wallet_id: WalletId, hydrated: bool) {
+        let mut set = self.hydrated.write().await;
+        if hydrated {
+            set.insert(wallet_id);
+        } else {
+            set.remove(&wallet_id);
         }
     }
 
@@ -323,16 +460,17 @@ impl NetworkShieldedCoordinator {
     /// the FVK, so FVK equality covers the whole viewing set).
     ///
     /// Used by `PlatformWallet::install_shielded_views` to detect an
-    /// idempotent re-bind (same wallet, same accounts, same keys) and
-    /// skip the destructive unregister → purge → restore cycle. That
-    /// cycle is only safe when the registration actually changed:
-    /// against an in-flight sync pass its `purge_wallet` /
-    /// `restore_for_wallet` lock acquisitions queue BEHIND the pass's
-    /// store write guard and then wipe the pass's freshly-saved notes
-    /// and watermark, replacing them with a persister snapshot loaded
-    /// before the pass ran (observed on iOS as "note discovered by
-    /// sync is not spendable until app restart" plus a full rescan
-    /// on every subsequent pass).
+    /// idempotent re-bind (same wallet, same accounts, same keys):
+    /// together with [`is_hydrated`](Self::is_hydrated) it gates the
+    /// fast path that skips reloading and re-applying the persister
+    /// snapshot. On a matching-and-hydrated re-bind the in-memory
+    /// store is strictly fresher than any snapshot, and skipping the
+    /// restore keeps the bind free of the store lock — it must never
+    /// queue behind an in-flight sync pass (the pre-fix full-purge
+    /// re-bind did exactly that and then wiped the pass's
+    /// freshly-saved notes and watermark; observed on iOS as "note
+    /// discovered by sync is not spendable until app restart" plus a
+    /// full rescan on every subsequent pass).
     pub async fn wallet_registration_matches(
         &self,
         wallet_id: WalletId,
@@ -364,11 +502,17 @@ impl NetworkShieldedCoordinator {
     /// `last_synced_note_index` and silently skip re-emitting its
     /// notes to the host.
     pub async fn unregister_wallet(&self, wallet_id: WalletId) {
+        // Same lifecycle serialization as register_wallet — without
+        // it a concurrent register could interleave between the two
+        // map mutations and end up with visible accounts whose
+        // persister this removal just deleted.
+        let _lifecycle = self.lifecycle.lock().await;
         self.accounts
             .write()
             .await
             .retain(|id, _| id.wallet_id != wallet_id);
         self.persisters.write().await.remove(&wallet_id);
+        self.hydrated.write().await.remove(&wallet_id);
         if let Err(e) = self.store.write().await.purge_wallet(wallet_id) {
             tracing::warn!(
                 wallet_id = %hex::encode(wallet_id),
@@ -630,9 +774,15 @@ impl NetworkShieldedCoordinator {
         // registries and reset the cooldown so the first post-clear
         // background pass runs immediately rather than honoring a stale
         // "caught up" stamp. On the failure path above none of this runs,
-        // so a failed clear leaves coordinator state untouched.
-        self.accounts.write().await.clear();
-        self.persisters.write().await.clear();
+        // so a failed clear leaves coordinator state untouched. The
+        // registry drop takes the lifecycle mutex so it is atomic
+        // against a concurrent register/unregister (see the field doc).
+        {
+            let _lifecycle = self.lifecycle.lock().await;
+            self.accounts.write().await.clear();
+            self.persisters.write().await.clear();
+            self.hydrated.write().await.clear();
+        }
         if let Ok(mut g) = self.last_caught_up_at.lock() {
             *g = None;
         }
@@ -1694,6 +1844,175 @@ mod tests {
         );
         assert_eq!(unspent[0].nullifier, new_nf);
         assert_eq!(store.get_all_notes(id).unwrap().len(), 2);
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// A changed-set re-register purges ONLY the dropped subwallet's
+    /// store state: accounts that remain bound with the same viewing
+    /// key keep their in-memory notes and watermark across the
+    /// re-bind, and the persister handle survives throughout. This is
+    /// the account-set-change analog of the identical-re-bind fast
+    /// path — a registration replacement racing an in-flight sync
+    /// pass can no longer wipe results for accounts the caller kept.
+    #[tokio::test]
+    async fn changed_set_reregister_keeps_retained_account_state_and_purges_dropped() {
+        let dir = temp_dir("reg_partial_purge");
+        let coordinator = coordinator_with_one_wallet(&dir).await;
+        let wallet_id: WalletId = [0x11; 32];
+        let keep = SubwalletId::new(wallet_id, 0);
+        let drop_id = SubwalletId::new(wallet_id, 1);
+
+        // Register accounts {0, 1} and give both live store state.
+        let views0 = OrchardKeySet::from_seed(&[0x42u8; 64], dashcore::Network::Testnet, 0)
+            .expect("derive viewing keys")
+            .viewing_keys();
+        let views1 = OrchardKeySet::from_seed(&[0x42u8; 64], dashcore::Network::Testnet, 1)
+            .expect("derive viewing keys")
+            .viewing_keys();
+        let persister = WalletPersister::new(wallet_id, Arc::new(NoPlatformPersistence));
+        let mut both = BTreeMap::new();
+        both.insert(0u32, views0.clone());
+        both.insert(1u32, views1);
+        coordinator
+            .register_wallet(wallet_id, both, persister.clone())
+            .await;
+        {
+            let mut store = coordinator.store().write().await;
+            store
+                .save_note(keep, &test_note([0xA0; 32], 10, false))
+                .unwrap();
+            store.set_last_synced_note_index(keep, 500).unwrap();
+            store
+                .save_note(drop_id, &test_note([0xB0; 32], 11, false))
+                .unwrap();
+            store.set_last_synced_note_index(drop_id, 500).unwrap();
+        }
+
+        // Re-register with only account 0.
+        let mut only0 = BTreeMap::new();
+        only0.insert(0u32, views0);
+        coordinator
+            .register_wallet(wallet_id, only0, persister)
+            .await;
+
+        let store = coordinator.store().read().await;
+        assert_eq!(
+            store.get_unspent_notes(keep).unwrap().len(),
+            1,
+            "retained account keeps its notes across a changed-set re-bind"
+        );
+        assert_eq!(
+            store.last_synced_note_index(keep).unwrap(),
+            500,
+            "retained account keeps its watermark across a changed-set re-bind"
+        );
+        assert!(
+            store.get_all_notes(drop_id).unwrap().is_empty(),
+            "dropped account's notes are purged"
+        );
+        assert_eq!(
+            store.last_synced_note_index(drop_id).unwrap(),
+            0,
+            "dropped account's watermark is purged"
+        );
+        drop(store);
+        assert!(
+            coordinator.persisters.read().await.contains_key(&wallet_id),
+            "the persister handle survives the whole re-bind"
+        );
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// Re-registering the same account index under a DIFFERENT viewing
+    /// key purges its store state: the stored notes were decrypted
+    /// under — and belong to — the old key, and must not survive into
+    /// the new registration.
+    #[tokio::test]
+    async fn rekeyed_account_state_is_purged_on_reregister() {
+        let dir = temp_dir("reg_rekey_purge");
+        let coordinator = coordinator_with_one_wallet(&dir).await;
+        let wallet_id: WalletId = [0x11; 32];
+        let id = SubwalletId::new(wallet_id, 0);
+
+        {
+            let mut store = coordinator.store().write().await;
+            store
+                .save_note(id, &test_note([0xC0; 32], 3, false))
+                .unwrap();
+            store.set_last_synced_note_index(id, 42).unwrap();
+        }
+
+        // Same account index, different seed ⇒ different FVK.
+        let rekeyed = OrchardKeySet::from_seed(&[0x99u8; 64], dashcore::Network::Testnet, 0)
+            .expect("derive viewing keys")
+            .viewing_keys();
+        let mut views = BTreeMap::new();
+        views.insert(0u32, rekeyed);
+        let persister = WalletPersister::new(wallet_id, Arc::new(NoPlatformPersistence));
+        coordinator
+            .register_wallet(wallet_id, views, persister)
+            .await;
+
+        let store = coordinator.store().read().await;
+        assert!(
+            store.get_all_notes(id).unwrap().is_empty(),
+            "a re-keyed account's old-key notes must not survive"
+        );
+        assert_eq!(store.last_synced_note_index(id).unwrap(), 0);
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// Hydration-flag mechanics: unset by default, set/cleared via
+    /// `mark_hydrated`, cleared by a changed-set re-register (the new
+    /// shape hasn't been hydrated) but preserved by an identical
+    /// re-register (the fast path's precondition), and cleared by
+    /// unregister.
+    #[tokio::test]
+    async fn hydration_flag_follows_registration_lifecycle() {
+        let dir = temp_dir("hydration_flag");
+        let coordinator = coordinator_with_one_wallet(&dir).await;
+        let wallet_id: WalletId = [0x11; 32];
+
+        assert!(!coordinator.is_hydrated(wallet_id).await, "unset initially");
+        coordinator.mark_hydrated(wallet_id, true).await;
+        assert!(coordinator.is_hydrated(wallet_id).await);
+
+        // Identical re-register preserves the flag.
+        let views0 = OrchardKeySet::from_seed(&[0x42u8; 64], dashcore::Network::Testnet, 0)
+            .expect("derive viewing keys")
+            .viewing_keys();
+        let persister = WalletPersister::new(wallet_id, Arc::new(NoPlatformPersistence));
+        let mut same = BTreeMap::new();
+        same.insert(0u32, views0.clone());
+        coordinator
+            .register_wallet(wallet_id, same.clone(), persister.clone())
+            .await;
+        assert!(
+            coordinator.is_hydrated(wallet_id).await,
+            "identical re-register must not clear hydration"
+        );
+
+        // Changed-set re-register clears it.
+        let views1 = OrchardKeySet::from_seed(&[0x42u8; 64], dashcore::Network::Testnet, 1)
+            .expect("derive viewing keys")
+            .viewing_keys();
+        let mut expanded = same.clone();
+        expanded.insert(1u32, views1);
+        coordinator
+            .register_wallet(wallet_id, expanded, persister.clone())
+            .await;
+        assert!(
+            !coordinator.is_hydrated(wallet_id).await,
+            "a changed account set invalidates prior hydration"
+        );
+
+        // And unregister clears it too.
+        coordinator.mark_hydrated(wallet_id, true).await;
+        coordinator.unregister_wallet(wallet_id).await;
+        assert!(!coordinator.is_hydrated(wallet_id).await);
 
         let _ = std::fs::remove_dir_all(&dir);
     }

--- a/packages/rs-platform-wallet/src/wallet/shielded/coordinator.rs
+++ b/packages/rs-platform-wallet/src/wallet/shielded/coordinator.rs
@@ -233,6 +233,24 @@ pub struct NetworkShieldedCoordinator {
     /// whenever a re-bind replaces the registration with a different
     /// account set.
     hydrated: RwLock<std::collections::BTreeSet<WalletId>>,
+
+    /// Counts completed [`clear`](Self::clear) calls, so a bind can tell
+    /// that the host snapshot it loaded predates a wipe.
+    ///
+    /// A bind reads the host's persisted snapshot BEFORE it opens its
+    /// install transaction — it has to, because the seedless path
+    /// reconstructs the viewing keys from that snapshot and the
+    /// seed-backed path checks its derived keys against it, and neither
+    /// may run a host callback under the lifecycle mutex. So the mutex
+    /// alone cannot stop a Clear from landing in between: the bind would
+    /// then restore pre-Clear notes and the pre-Clear watermark into the
+    /// store the Clear just purged, and the host — which wipes its own
+    /// rows only after `clear()` returns — would see its shielded
+    /// history come back, with a watermark that reports caught-up so the
+    /// promised cold rebuild from index 0 never runs. Sampling this
+    /// counter before the load and re-reading it inside the transaction
+    /// makes that snapshot detectably stale.
+    clear_generation: std::sync::atomic::AtomicU64,
 }
 
 /// Exclusive handle on one wallet's shielded install transaction,
@@ -249,7 +267,16 @@ pub struct NetworkShieldedCoordinator {
 ///
 /// Drop it as soon as the install commits: it blocks wallet removal and
 /// Clear for the whole scope.
-pub struct ShieldedInstall<'a> {
+///
+/// Crate-internal: holding one across a call to any other lifecycle
+/// entry point self-deadlocks on the non-reentrant mutex, and Rust's
+/// temporary scopes make that easy to write by accident (both operands
+/// of an `&&` share one scope, so a guard built in the left operand is
+/// still alive while the right one runs). Keeping the type and
+/// [`begin_install`](NetworkShieldedCoordinator::begin_install) inside
+/// the crate confines that hazard to code reviewed alongside the
+/// coordinator.
+pub(crate) struct ShieldedInstall<'a> {
     coordinator: &'a NetworkShieldedCoordinator,
     wallet_id: WalletId,
     _lifecycle: tokio::sync::MutexGuard<'a, ()>,
@@ -288,6 +315,17 @@ impl ShieldedInstall<'_> {
                 .filter(|registered| registered.to_fvk_bytes() != views.to_fvk_bytes())
                 .map(|_| *account)
         })
+    }
+
+    /// Whether a host snapshot taken at `generation` (from
+    /// [`clear_generation`](NetworkShieldedCoordinator::clear_generation),
+    /// sampled before the load) predates a completed Clear.
+    ///
+    /// Such a snapshot describes state the user asked to be wiped —
+    /// restoring it would put the notes and the watermark back while the
+    /// host's own rows are gone. See the `clear_generation` field doc.
+    pub fn snapshot_predates_clear(&self, generation: u64) -> bool {
+        self.coordinator.clear_generation() != generation
     }
 
     /// See [`register_wallet`](NetworkShieldedCoordinator::register_wallet).
@@ -350,7 +388,17 @@ impl NetworkShieldedCoordinator {
             tree_progress_handler: std::sync::Mutex::new(None),
             lifecycle: tokio::sync::Mutex::new(()),
             hydrated: RwLock::new(std::collections::BTreeSet::new()),
+            clear_generation: std::sync::atomic::AtomicU64::new(0),
         }
+    }
+
+    /// Snapshot of the clear counter, to be taken **before** reading the
+    /// host's persisted state and handed to
+    /// [`ShieldedInstall::snapshot_predates_clear`] inside the install
+    /// transaction. See the `clear_generation` field doc.
+    pub fn clear_generation(&self) -> u64 {
+        self.clear_generation
+            .load(std::sync::atomic::Ordering::Acquire)
     }
 
     /// Network this coordinator is pinned to. Used by hosts that
@@ -440,6 +488,12 @@ impl NetworkShieldedCoordinator {
     /// re-bind, so a registration replacement racing an in-flight
     /// sync pass can no longer wipe the pass's results.
     ///
+    /// The re-key half of that purge is a floor, not a supported
+    /// operation: the bind paths refuse a viewing-key change for a bound
+    /// account outright, because the durable rows behind it carry no
+    /// record of which key produced them. It covers state left by builds
+    /// that predated the refusal.
+    ///
     /// [`ShieldedWallet`]: super::ShieldedWallet
     /// [`PlatformWallet::bind_shielded`]: crate::wallet::PlatformWallet::bind_shielded
     pub async fn register_wallet(
@@ -461,12 +515,23 @@ impl NetworkShieldedCoordinator {
     /// restore the host snapshot, commit hydration — only compose into
     /// the intended "replace this wallet's shielded state" operation if
     /// nothing else mutates the registries in between; see the
-    /// `lifecycle` field doc for the interleavings this forbids. Every
-    /// single-step public method below opens (and immediately closes)
-    /// one of these transactions, so a caller holding a guard must go
-    /// through the guard rather than calling them — they would deadlock
-    /// on the same non-reentrant mutex.
-    pub async fn begin_install(&self, wallet_id: WalletId) -> ShieldedInstall<'_> {
+    /// `lifecycle` field doc for the interleavings this forbids.
+    ///
+    /// Every other lifecycle entry point — the single-step methods
+    /// ([`register_wallet`](Self::register_wallet),
+    /// [`is_hydrated`](Self::is_hydrated),
+    /// [`mark_hydrated`](Self::mark_hydrated),
+    /// [`wallet_registration_matches`](Self::wallet_registration_matches),
+    /// [`restore_for_wallet`](Self::restore_for_wallet)),
+    /// [`unregister_wallet`](Self::unregister_wallet) and
+    /// [`clear`](Self::clear) — takes this same non-reentrant mutex, so
+    /// a caller holding a guard must go through the guard instead of
+    /// calling any of them.
+    ///
+    /// Note that the single-step methods therefore cost a mutex
+    /// acquisition, not just the registry read they appear to be: an
+    /// install holds the mutex across a whole snapshot restore.
+    pub(crate) async fn begin_install(&self, wallet_id: WalletId) -> ShieldedInstall<'_> {
         ShieldedInstall {
             coordinator: self,
             wallet_id,
@@ -699,7 +764,7 @@ impl NetworkShieldedCoordinator {
     /// matches what the host already has on disk (notes, spent
     /// marks, sync watermarks, nullifier checkpoints).
     ///
-    /// Filters the supplied [`ShieldedSyncStartState`] in two
+    /// Filters the supplied [`ShieldedSyncStartState`] in three
     /// ways:
     /// - **By `wallet_id`**: only entries whose `SubwalletId`
     ///   belongs to `wallet_id` are restored. The startup
@@ -722,7 +787,10 @@ impl NetworkShieldedCoordinator {
     ///   watermark would make the pass that should find the current
     ///   key's history skip straight past it. Snapshots with no viewing
     ///   key for a subwallet (persistence predating those rows) are
-    ///   restored as before.
+    ///   restored as before. This guards state written by builds that
+    ///   predated the bind-time refusal of a key change — the bind paths
+    ///   themselves can no longer present a mismatched pair — so it is
+    ///   a floor, not the primary defense.
     ///
     /// No-op on empty snapshots.
     pub async fn restore_for_wallet(
@@ -909,9 +977,12 @@ impl NetworkShieldedCoordinator {
         // Held across the whole Clear, store reset included, so no bind
         // install can be halfway through its transaction here: one that
         // already registered would otherwise restore its pre-Clear
-        // snapshot into the store this just purged, which is the
-        // "Clear did nothing" symptom seen from the other side. Taken
-        // before the store lock to keep the `lifecycle` → `store` order.
+        // snapshot into the store this just purged. A bind that has not
+        // yet opened its transaction is a separate problem — it may
+        // already hold a snapshot loaded before this Clear — and is
+        // handled by the generation bumped at the end of this function.
+        // Taken before the store lock to keep the `lifecycle` → `store`
+        // order.
         let _lifecycle = self.lifecycle.lock().await;
 
         // Reset the persistent store FIRST and bail before mutating any
@@ -988,6 +1059,12 @@ impl NetworkShieldedCoordinator {
         self.accounts.write().await.clear();
         self.persisters.write().await.clear();
         self.hydrated.write().await.clear();
+        // Invalidate every host snapshot loaded before this point. Bumped
+        // under the lifecycle mutex and after the purge, so any install
+        // that observes the old value is still queued behind this Clear
+        // and will re-read the new one once it holds the mutex.
+        self.clear_generation
+            .fetch_add(1, std::sync::atomic::Ordering::AcqRel);
         if let Ok(mut g) = self.last_caught_up_at.lock() {
             *g = None;
         }

--- a/packages/rs-platform-wallet/src/wallet/shielded/coordinator.rs
+++ b/packages/rs-platform-wallet/src/wallet/shielded/coordinator.rs
@@ -182,13 +182,17 @@ pub struct NetworkShieldedCoordinator {
     /// Same `std::sync::Mutex` rationale as `progress_handler`.
     tree_progress_handler: std::sync::Mutex<Option<ShieldedTreeProgressCallback>>,
 
-    /// Serializes every registry LIFECYCLE mutation —
-    /// [`register_wallet`](Self::register_wallet),
-    /// [`unregister_wallet`](Self::unregister_wallet), and the
-    /// registry phase of [`clear`](Self::clear) — so the `accounts` /
-    /// `persisters` pair always mutates as one atomic step. The two
-    /// maps sit behind separate `RwLock`s (readers like `sync()` take
-    /// them independently), so without this outer mutex a concurrent
+    /// Serializes every shielded lifecycle TRANSACTION on this
+    /// coordinator: a wallet's whole bind install (see
+    /// [`begin_install`](Self::begin_install)),
+    /// [`unregister_wallet`](Self::unregister_wallet), and
+    /// [`clear`](Self::clear).
+    ///
+    /// Two properties depend on it.
+    ///
+    /// *Registry atomicity.* `accounts` / `persisters` sit behind
+    /// separate `RwLock`s (readers like `sync()` take them
+    /// independently), so without this outer mutex a concurrent
     /// register + unregister could interleave as *insert persister →
     /// remove accounts → insert accounts → remove persister*, leaving
     /// visible accounts with no persister — a state in which `sync()`
@@ -196,6 +200,23 @@ pub struct NetworkShieldedCoordinator {
     /// only accounts-without-persister window a `sync()` pass can
     /// observe is a wallet being genuinely removed mid-pass, where
     /// dropping its changeset is the intended outcome.
+    ///
+    /// *Install atomicity.* A bind is not one map write but a
+    /// sequence — compare the incoming registration, replace it,
+    /// restore the host snapshot, commit the hydration flag — and each
+    /// step reads state the previous one established. Serializing only
+    /// the individual steps would let two binds of the same wallet
+    /// commit their registrations in the opposite order to their
+    /// key-slot writes (leaving the coordinator decrypting under one
+    /// key while addresses and spends use another), and would let an
+    /// `unregister_wallet` / `clear` purge state between a restore's
+    /// registration check and its store write (repopulating a purged
+    /// wallet and re-arming its hydration flag). Holding the mutex
+    /// across the whole transaction is what makes "the registration a
+    /// restore commits against is the one it checked" hold.
+    ///
+    /// Lock order is `lifecycle` → `store`; nothing takes them the
+    /// other way round.
     lifecycle: tokio::sync::Mutex<()>,
 
     /// Wallets whose per-subwallet store state has been successfully
@@ -212,6 +233,95 @@ pub struct NetworkShieldedCoordinator {
     /// whenever a re-bind replaces the registration with a different
     /// account set.
     hydrated: RwLock<std::collections::BTreeSet<WalletId>>,
+}
+
+/// Exclusive handle on one wallet's shielded install transaction,
+/// returned by
+/// [`begin_install`](NetworkShieldedCoordinator::begin_install).
+///
+/// Holds the coordinator's lifecycle mutex for as long as it lives, so
+/// every step taken through it — registration comparison, registration
+/// replacement, snapshot restore, hydration commit — observes the same
+/// registration, and no `register` / `unregister_wallet` / `clear` from
+/// another task can slip between two of them. Callers that need only a
+/// single step can use the equivalent method on the coordinator, which
+/// wraps it in a one-step transaction.
+///
+/// Drop it as soon as the install commits: it blocks wallet removal and
+/// Clear for the whole scope.
+pub struct ShieldedInstall<'a> {
+    coordinator: &'a NetworkShieldedCoordinator,
+    wallet_id: WalletId,
+    _lifecycle: tokio::sync::MutexGuard<'a, ()>,
+}
+
+impl ShieldedInstall<'_> {
+    /// See
+    /// [`wallet_registration_matches`](NetworkShieldedCoordinator::wallet_registration_matches).
+    pub async fn registration_matches(
+        &self,
+        account_views: &BTreeMap<u32, AccountViewingKeys>,
+    ) -> bool {
+        self.coordinator
+            .registration_matches_locked(self.wallet_id, account_views)
+            .await
+    }
+
+    /// The first account of `account_views` that is already registered
+    /// on this wallet under a DIFFERENT full viewing key, if any.
+    ///
+    /// Per-subwallet durable state (notes, activity, watermark) is keyed
+    /// by `(wallet_id, account_index)` alone — nothing records which key
+    /// decrypted it — so a re-key of a bound account cannot be applied
+    /// coherently: the surviving durable rows belong to the old key
+    /// while the registration claims the new one. Bind paths use this to
+    /// refuse the change instead of silently mixing the two.
+    pub async fn conflicting_account(
+        &self,
+        account_views: &BTreeMap<u32, AccountViewingKeys>,
+    ) -> Option<u32> {
+        let accounts = self.coordinator.accounts.read().await;
+        account_views.iter().find_map(|(account, views)| {
+            let id = SubwalletId::new(self.wallet_id, *account);
+            accounts
+                .get(&id)
+                .filter(|registered| registered.to_fvk_bytes() != views.to_fvk_bytes())
+                .map(|_| *account)
+        })
+    }
+
+    /// See [`register_wallet`](NetworkShieldedCoordinator::register_wallet).
+    pub async fn register(
+        &self,
+        account_views: BTreeMap<u32, AccountViewingKeys>,
+        persister: WalletPersister,
+    ) {
+        self.coordinator
+            .register_locked(self.wallet_id, account_views, persister)
+            .await
+    }
+
+    /// See [`restore_for_wallet`](NetworkShieldedCoordinator::restore_for_wallet).
+    pub async fn restore(
+        &self,
+        snapshot: &crate::changeset::ShieldedSyncStartState,
+    ) -> Result<(), crate::error::PlatformWalletError> {
+        self.coordinator
+            .restore_locked(self.wallet_id, snapshot)
+            .await
+    }
+
+    /// See [`is_hydrated`](NetworkShieldedCoordinator::is_hydrated).
+    pub async fn is_hydrated(&self) -> bool {
+        self.coordinator.is_hydrated_locked(self.wallet_id).await
+    }
+
+    /// See [`mark_hydrated`](NetworkShieldedCoordinator::mark_hydrated).
+    pub async fn mark_hydrated(&self, hydrated: bool) {
+        self.coordinator
+            .mark_hydrated_locked(self.wallet_id, hydrated)
+            .await
+    }
 }
 
 impl NetworkShieldedCoordinator {
@@ -338,11 +448,40 @@ impl NetworkShieldedCoordinator {
         account_views: BTreeMap<u32, AccountViewingKeys>,
         persister: WalletPersister,
     ) {
-        // Serialize against unregister_wallet / clear so the
-        // accounts + persisters pair mutates atomically (see the
-        // `lifecycle` field doc for the interleaving this forbids).
-        let _lifecycle = self.lifecycle.lock().await;
+        self.begin_install(wallet_id)
+            .await
+            .register(account_views, persister)
+            .await
+    }
 
+    /// Open an install transaction for `wallet_id`, taking the
+    /// coordinator's lifecycle mutex for the returned guard's lifetime.
+    ///
+    /// A bind's steps — compare the incoming registration, replace it,
+    /// restore the host snapshot, commit hydration — only compose into
+    /// the intended "replace this wallet's shielded state" operation if
+    /// nothing else mutates the registries in between; see the
+    /// `lifecycle` field doc for the interleavings this forbids. Every
+    /// single-step public method below opens (and immediately closes)
+    /// one of these transactions, so a caller holding a guard must go
+    /// through the guard rather than calling them — they would deadlock
+    /// on the same non-reentrant mutex.
+    pub async fn begin_install(&self, wallet_id: WalletId) -> ShieldedInstall<'_> {
+        ShieldedInstall {
+            coordinator: self,
+            wallet_id,
+            _lifecycle: self.lifecycle.lock().await,
+        }
+    }
+
+    /// [`register_wallet`](Self::register_wallet)'s body, with the
+    /// lifecycle mutex already held by the caller's transaction.
+    async fn register_locked(
+        &self,
+        wallet_id: WalletId,
+        account_views: BTreeMap<u32, AccountViewingKeys>,
+        persister: WalletPersister,
+    ) {
         // Subwallets the new registration drops or re-keys. Their
         // store state must go: a dropped account would otherwise
         // keep unspendable notes and a stale watermark alive, and a
@@ -434,6 +573,10 @@ impl NetworkShieldedCoordinator {
     /// successfully hydrated from the host snapshot this session
     /// (see [`mark_hydrated`](Self::mark_hydrated)).
     pub async fn is_hydrated(&self, wallet_id: WalletId) -> bool {
+        self.begin_install(wallet_id).await.is_hydrated().await
+    }
+
+    async fn is_hydrated_locked(&self, wallet_id: WalletId) -> bool {
         self.hydrated.read().await.contains(&wallet_id)
     }
 
@@ -445,6 +588,13 @@ impl NetworkShieldedCoordinator {
     /// re-bind retries the restore instead of taking the idempotent
     /// fast path on top of an unhydrated store.
     pub async fn mark_hydrated(&self, wallet_id: WalletId, hydrated: bool) {
+        self.begin_install(wallet_id)
+            .await
+            .mark_hydrated(hydrated)
+            .await
+    }
+
+    async fn mark_hydrated_locked(&self, wallet_id: WalletId, hydrated: bool) {
         let mut set = self.hydrated.write().await;
         if hydrated {
             set.insert(wallet_id);
@@ -476,6 +626,17 @@ impl NetworkShieldedCoordinator {
         wallet_id: WalletId,
         account_views: &BTreeMap<u32, AccountViewingKeys>,
     ) -> bool {
+        self.begin_install(wallet_id)
+            .await
+            .registration_matches(account_views)
+            .await
+    }
+
+    async fn registration_matches_locked(
+        &self,
+        wallet_id: WalletId,
+        account_views: &BTreeMap<u32, AccountViewingKeys>,
+    ) -> bool {
         let accounts = self.accounts.read().await;
         let registered: BTreeMap<u32, [u8; 96]> = accounts
             .iter()
@@ -502,10 +663,12 @@ impl NetworkShieldedCoordinator {
     /// `last_synced_note_index` and silently skip re-emitting its
     /// notes to the host.
     pub async fn unregister_wallet(&self, wallet_id: WalletId) {
-        // Same lifecycle serialization as register_wallet — without
-        // it a concurrent register could interleave between the two
-        // map mutations and end up with visible accounts whose
-        // persister this removal just deleted.
+        // Same lifecycle serialization as an install transaction —
+        // without it a concurrent register could interleave between the
+        // two map mutations and end up with visible accounts whose
+        // persister this removal just deleted, and an in-flight bind's
+        // restore could repopulate (and re-mark hydrated) the state
+        // purged below after the purge ran.
         let _lifecycle = self.lifecycle.lock().await;
         self.accounts
             .write()
@@ -550,6 +713,16 @@ impl NetworkShieldedCoordinator {
     ///   coordinator are skipped — they'd accumulate state we
     ///   can never spend (no `OrchardKeySet` for them on the
     ///   per-wallet side).
+    /// - **By viewing key**: a subwallet whose snapshot carries a
+    ///   viewing key that differs from the registered one is skipped.
+    ///   Durable notes, activity and watermarks are keyed by
+    ///   `(wallet_id, account_index)` only, so nothing else
+    ///   distinguishes rows produced under a since-replaced key; they
+    ///   describe funds the current key cannot spend, and their
+    ///   watermark would make the pass that should find the current
+    ///   key's history skip straight past it. Snapshots with no viewing
+    ///   key for a subwallet (persistence predating those rows) are
+    ///   restored as before.
     ///
     /// No-op on empty snapshots.
     pub async fn restore_for_wallet(
@@ -557,18 +730,30 @@ impl NetworkShieldedCoordinator {
         wallet_id: WalletId,
         snapshot: &crate::changeset::ShieldedSyncStartState,
     ) -> Result<(), crate::error::PlatformWalletError> {
+        self.begin_install(wallet_id).await.restore(snapshot).await
+    }
+
+    /// [`restore_for_wallet`](Self::restore_for_wallet)'s body, with the
+    /// lifecycle mutex already held by the caller's transaction — which
+    /// is what makes the registration this reads still be the one in
+    /// force when the store write below lands.
+    async fn restore_locked(
+        &self,
+        wallet_id: WalletId,
+        snapshot: &crate::changeset::ShieldedSyncStartState,
+    ) -> Result<(), crate::error::PlatformWalletError> {
         if snapshot.is_empty() {
             return Ok(());
         }
-        // Snapshot of registered subwallets for the membership
-        // check. Cheaper than holding the accounts read lock
+        // Snapshot of this wallet's registered subwallets and their
+        // viewing keys. Cheaper than holding the accounts read lock
         // across the store write below.
-        let registered: std::collections::BTreeSet<SubwalletId> = {
+        let registered: BTreeMap<SubwalletId, [u8; 96]> = {
             let accounts = self.accounts.read().await;
             accounts
-                .keys()
-                .copied()
-                .filter(|id| id.wallet_id == wallet_id)
+                .iter()
+                .filter(|(id, _)| id.wallet_id == wallet_id)
+                .map(|(id, views)| (*id, views.to_fvk_bytes()))
                 .collect()
         };
         if registered.is_empty() {
@@ -577,10 +762,27 @@ impl NetworkShieldedCoordinator {
 
         let mut store = self.store.write().await;
         for (id, sub) in &snapshot.per_subwallet {
-            // Only restore subwallets that belong to `wallet_id`
-            // and are registered on this coordinator.
-            if id.wallet_id != wallet_id || !registered.contains(id) {
+            // Only restore subwallets that are registered on this
+            // coordinator — `registered` holds `wallet_id`'s alone, so
+            // this covers the by-wallet filter too.
+            let Some(registered_fvk) = registered.get(id) else {
                 continue;
+            };
+            // ...and whose snapshot was produced under the key that is
+            // registered now. A mismatch means these rows belong to a
+            // key this account no longer holds: restoring them would
+            // surface unspendable notes and carry over a watermark that
+            // hides the current key's own history.
+            if let Some(snapshot_fvk) = snapshot.viewing_keys.get(id) {
+                if snapshot_fvk.as_slice() != registered_fvk.as_slice() {
+                    tracing::warn!(
+                        wallet_id = %hex::encode(id.wallet_id),
+                        account = id.account_index,
+                        "Skipping shielded snapshot restore: it was produced under a \
+                         different viewing key than the one registered"
+                    );
+                    continue;
+                }
             }
             // Nullifiers the store already tracks for this subwallet.
             // The in-memory state is always at least as fresh as the
@@ -704,6 +906,14 @@ impl NetworkShieldedCoordinator {
     /// stays populated, and the next cold resync would gate-skip every
     /// re-downloaded position against the stale `tree_size`.
     pub async fn clear(&self) -> Result<(), crate::error::PlatformWalletError> {
+        // Held across the whole Clear, store reset included, so no bind
+        // install can be halfway through its transaction here: one that
+        // already registered would otherwise restore its pre-Clear
+        // snapshot into the store this just purged, which is the
+        // "Clear did nothing" symptom seen from the other side. Taken
+        // before the store lock to keep the `lifecycle` → `store` order.
+        let _lifecycle = self.lifecycle.lock().await;
+
         // Reset the persistent store FIRST and bail before mutating any
         // in-memory state if it fails. Clearing `accounts` / `persisters`
         // makes the coordinator forget every bound wallet (no syncs until
@@ -774,15 +984,10 @@ impl NetworkShieldedCoordinator {
         // registries and reset the cooldown so the first post-clear
         // background pass runs immediately rather than honoring a stale
         // "caught up" stamp. On the failure path above none of this runs,
-        // so a failed clear leaves coordinator state untouched. The
-        // registry drop takes the lifecycle mutex so it is atomic
-        // against a concurrent register/unregister (see the field doc).
-        {
-            let _lifecycle = self.lifecycle.lock().await;
-            self.accounts.write().await.clear();
-            self.persisters.write().await.clear();
-            self.hydrated.write().await.clear();
-        }
+        // so a failed clear leaves coordinator state untouched.
+        self.accounts.write().await.clear();
+        self.persisters.write().await.clear();
+        self.hydrated.write().await.clear();
         if let Ok(mut g) = self.last_caught_up_at.lock() {
             *g = None;
         }
@@ -2013,6 +2218,120 @@ mod tests {
         coordinator.mark_hydrated(wallet_id, true).await;
         coordinator.unregister_wallet(wallet_id).await;
         assert!(!coordinator.is_hydrated(wallet_id).await);
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// A snapshot produced under a viewing key the account no longer
+    /// holds must not be restored: its notes are unspendable under the
+    /// registered key and its watermark would hide that key's own
+    /// history from the scan. Durable rows are keyed by
+    /// `(wallet_id, account_index)` only, so the snapshot's own viewing
+    /// key is the only thing that distinguishes them.
+    ///
+    /// The second half pins that the filter is key-based, not a blanket
+    /// skip: the same snapshot restores once its key matches.
+    #[tokio::test]
+    async fn restore_skips_a_snapshot_produced_under_a_different_viewing_key() {
+        use crate::changeset::{ShieldedSubwalletStartState, ShieldedSyncStartState};
+
+        let dir = temp_dir("restore_rekeyed");
+        let coordinator = coordinator_with_one_wallet(&dir).await;
+        let wallet_id: WalletId = [0x11; 32];
+        let id = SubwalletId::new(wallet_id, 0);
+
+        // `coordinator_with_one_wallet` registers account 0 under the
+        // 0x42 seed's key; stage a snapshot from a different one.
+        let old_key = OrchardKeySet::from_seed(&[0x99u8; 64], dashcore::Network::Testnet, 0)
+            .expect("derive viewing keys")
+            .viewing_keys();
+        let mut snapshot = ShieldedSyncStartState::default();
+        snapshot.per_subwallet.insert(
+            id,
+            ShieldedSubwalletStartState {
+                notes: vec![test_note([0xD0; 32], 7, false)],
+                last_synced_index: 5_000,
+                ..Default::default()
+            },
+        );
+        snapshot
+            .viewing_keys
+            .insert(id, old_key.to_fvk_bytes().to_vec());
+
+        coordinator
+            .restore_for_wallet(wallet_id, &snapshot)
+            .await
+            .expect("restore reports success, having skipped the stale subwallet");
+
+        {
+            let store = coordinator.store().read().await;
+            assert!(
+                store.get_all_notes(id).unwrap().is_empty(),
+                "notes decrypted under a replaced viewing key must not be restored"
+            );
+            assert_eq!(
+                store.last_synced_note_index(id).unwrap(),
+                0,
+                "the replaced key's watermark must not carry over — it would make the \
+                 scan skip the range holding the registered key's own notes"
+            );
+        }
+
+        // Same snapshot, now carrying the registered key: restored.
+        let current_key = OrchardKeySet::from_seed(&[0x42u8; 64], dashcore::Network::Testnet, 0)
+            .expect("derive viewing keys")
+            .viewing_keys();
+        snapshot
+            .viewing_keys
+            .insert(id, current_key.to_fvk_bytes().to_vec());
+        coordinator
+            .restore_for_wallet(wallet_id, &snapshot)
+            .await
+            .expect("restore");
+
+        let store = coordinator.store().read().await;
+        assert_eq!(
+            store.get_all_notes(id).unwrap().len(),
+            1,
+            "a snapshot matching the registered key restores as before"
+        );
+        assert_eq!(store.last_synced_note_index(id).unwrap(), 5_000);
+        drop(store);
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// An install transaction excludes wallet removal for its whole
+    /// scope. Without that, an `unregister_wallet` could purge between a
+    /// bind's registration check and its restore, and the restore would
+    /// repopulate the state the removal just dropped — then mark the
+    /// removed wallet hydrated.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn install_transaction_blocks_unregister_until_it_commits() {
+        let dir = temp_dir("install_excludes_unregister");
+        let coordinator = Arc::new(coordinator_with_one_wallet(&dir).await);
+        let wallet_id: WalletId = [0x11; 32];
+
+        let install = coordinator.begin_install(wallet_id).await;
+        let remover = {
+            let coordinator = Arc::clone(&coordinator);
+            tokio::spawn(async move { coordinator.unregister_wallet(wallet_id).await })
+        };
+
+        // Long enough that an unserialized unregister (a couple of
+        // in-memory map writes) would certainly have landed.
+        tokio::time::sleep(Duration::from_millis(200)).await;
+        assert!(
+            !coordinator.registered_subwallets().await.is_empty(),
+            "unregister must wait for the in-flight install transaction to commit"
+        );
+
+        drop(install);
+        remover.await.expect("unregister task");
+        assert!(
+            coordinator.registered_subwallets().await.is_empty(),
+            "the queued unregister runs as soon as the transaction commits"
+        );
 
         let _ = std::fs::remove_dir_all(&dir);
     }

--- a/packages/rs-platform-wallet/src/wallet/shielded/coordinator.rs
+++ b/packages/rs-platform-wallet/src/wallet/shielded/coordinator.rs
@@ -2383,7 +2383,11 @@ mod tests {
     /// bind's registration check and its restore, and the restore would
     /// repopulate the state the removal just dropped — then mark the
     /// removed wallet hydrated.
-    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    ///
+    /// Paused clock: `sleep` fires only once nothing is runnable, so the
+    /// assertion means "the runtime had no work left and the unregister
+    /// still had not landed" rather than "200 ms passed".
+    #[tokio::test(flavor = "current_thread", start_paused = true)]
     async fn install_transaction_blocks_unregister_until_it_commits() {
         let dir = temp_dir("install_excludes_unregister");
         let coordinator = Arc::new(coordinator_with_one_wallet(&dir).await);
@@ -2408,6 +2412,71 @@ mod tests {
         assert!(
             coordinator.registered_subwallets().await.is_empty(),
             "the queued unregister runs as soon as the transaction commits"
+        );
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// Clear must wait for an in-flight install transaction, purge
+    /// included. The mutex is taken before the store reset precisely so
+    /// the purge cannot land between a bind's registration and its
+    /// restore — the bind would then put its snapshot back into the
+    /// store Clear had just emptied, which the host reads as "Clear did
+    /// nothing".
+    ///
+    /// Paused clock, same reasoning as the unregister test above.
+    #[tokio::test(flavor = "current_thread", start_paused = true)]
+    async fn clear_waits_for_an_in_flight_install_transaction() {
+        let dir = temp_dir("clear_vs_install");
+        let coordinator = Arc::new(coordinator_with_one_wallet(&dir).await);
+        let wallet_id: WalletId = [0x11; 32];
+        let id = SubwalletId::new(wallet_id, 0);
+        {
+            let mut store = coordinator.store().write().await;
+            store
+                .save_note(id, &test_note([0xF0; 32], 3, false))
+                .unwrap();
+        }
+
+        let install = coordinator.begin_install(wallet_id).await;
+        let clearer = {
+            let coordinator = Arc::clone(&coordinator);
+            tokio::spawn(async move { coordinator.clear().await })
+        };
+
+        tokio::time::sleep(Duration::from_millis(200)).await;
+        assert!(
+            !coordinator.registered_subwallets().await.is_empty(),
+            "clear must wait for the in-flight install transaction"
+        );
+        assert_eq!(
+            coordinator
+                .store()
+                .read()
+                .await
+                .get_all_notes(id)
+                .unwrap()
+                .len(),
+            1,
+            "the store purge must be inside the mutex too — a purge landing mid-install \
+             is what lets the bind restore its snapshot back over a completed Clear"
+        );
+
+        drop(install);
+        clearer.await.expect("clear task").expect("clear succeeds");
+        assert!(
+            coordinator.registered_subwallets().await.is_empty(),
+            "the queued clear runs as soon as the transaction commits"
+        );
+        assert!(
+            coordinator
+                .store()
+                .read()
+                .await
+                .get_all_notes(id)
+                .unwrap()
+                .is_empty(),
+            "and it purges the store once it does"
         );
 
         let _ = std::fs::remove_dir_all(&dir);

--- a/packages/rs-platform-wallet/src/wallet/shielded/file_store.rs
+++ b/packages/rs-platform-wallet/src/wallet/shielded/file_store.rs
@@ -647,6 +647,25 @@ impl ShieldedStore for FileBackedShieldedStore {
         Ok(())
     }
 
+    fn purge_subwallet(&mut self, id: SubwalletId) -> Result<(), Self::Error> {
+        // Durable redrive rows are scoped by (wallet_id, account_index);
+        // delete this subwallet's before the in-memory drop, same
+        // SQL-before-memory fail-atomic ordering as `purge_wallet`.
+        {
+            let conn = self.pending_conn.lock().expect("pending_conn mutex");
+            conn.execute(
+                "DELETE FROM shielded_pending_spends \
+                 WHERE wallet_id = ?1 AND account_index = ?2",
+                rusqlite::params![id.wallet_id.as_slice(), id.account_index],
+            )
+            .map_err(|e| {
+                FileShieldedStoreError(format!("purge pending spends for subwallet: {e}"))
+            })?;
+        }
+        self.subwallets.remove(&id);
+        Ok(())
+    }
+
     fn purge_all_subwallets(&mut self) -> Result<(), Self::Error> {
         // Durable redrive rows for every wallet go with the in-memory
         // purge; SQL first for the same fail-atomic reason as

--- a/packages/rs-platform-wallet/src/wallet/shielded/mod.rs
+++ b/packages/rs-platform-wallet/src/wallet/shielded/mod.rs
@@ -51,7 +51,7 @@ pub use activity::{
     ScanDeriveInput, ShieldedActivityEntry, ShieldedActivityKind, ShieldedActivityStatus,
     ShieldedDirection,
 };
-pub use coordinator::{NetworkShieldedCoordinator, ShieldedInstall};
+pub use coordinator::NetworkShieldedCoordinator;
 pub use file_store::{FileBackedShieldedStore, FileShieldedStoreError};
 pub use keys::{AccountViewingKeys, OrchardKeySet};
 pub use prover::CachedOrchardProver;

--- a/packages/rs-platform-wallet/src/wallet/shielded/mod.rs
+++ b/packages/rs-platform-wallet/src/wallet/shielded/mod.rs
@@ -51,7 +51,7 @@ pub use activity::{
     ScanDeriveInput, ShieldedActivityEntry, ShieldedActivityKind, ShieldedActivityStatus,
     ShieldedDirection,
 };
-pub use coordinator::NetworkShieldedCoordinator;
+pub use coordinator::{NetworkShieldedCoordinator, ShieldedInstall};
 pub use file_store::{FileBackedShieldedStore, FileShieldedStoreError};
 pub use keys::{AccountViewingKeys, OrchardKeySet};
 pub use prover::CachedOrchardProver;

--- a/packages/rs-platform-wallet/src/wallet/shielded/store.rs
+++ b/packages/rs-platform-wallet/src/wallet/shielded/store.rs
@@ -430,6 +430,18 @@ pub trait ShieldedStore: Send + Sync {
     /// rather than resuming behind the stale watermark.
     fn purge_wallet(&mut self, wallet_id: WalletId) -> Result<(), Self::Error>;
 
+    /// Drop the per-subwallet state (and any durable redrive rows)
+    /// for exactly ONE subwallet, leaving every other subwallet of
+    /// the same wallet — and the shared commitment tree — intact.
+    ///
+    /// The account-scoped sibling of [`Self::purge_wallet`]. Used by
+    /// the coordinator when a re-bind changes a wallet's account set:
+    /// only the accounts that were dropped (or whose viewing key
+    /// changed — their stored notes belong to the old key) are
+    /// purged, so the accounts that remain bound keep their fresh
+    /// in-memory notes and watermarks across the re-bind.
+    fn purge_subwallet(&mut self, id: SubwalletId) -> Result<(), Self::Error>;
+
     /// Drop ALL in-memory per-subwallet state for every subwallet
     /// of every wallet. The shared commitment tree is left
     /// untouched. Used by `NetworkShieldedCoordinator::clear()`.
@@ -994,6 +1006,11 @@ impl ShieldedStore for InMemoryShieldedStore {
 
     fn purge_wallet(&mut self, wallet_id: WalletId) -> Result<(), Self::Error> {
         self.subwallets.retain(|id, _| id.wallet_id != wallet_id);
+        Ok(())
+    }
+
+    fn purge_subwallet(&mut self, id: SubwalletId) -> Result<(), Self::Error> {
+        self.subwallets.remove(&id);
         Ok(())
     }
 

--- a/packages/rs-platform-wallet/src/wallet/shielded/sync.rs
+++ b/packages/rs-platform-wallet/src/wallet/shielded/sync.rs
@@ -35,7 +35,7 @@ use dash_sdk::platform::shielded::{
 use futures::StreamExt;
 use grovedb_commitment_tree::{ExtractedNoteCommitment, Note as OrchardNote, PaymentAddress};
 use tokio::sync::RwLock;
-use tracing::{debug, info, warn};
+use tracing::{debug, info};
 
 use super::keys::AccountViewingKeys;
 use super::store::{ShieldedStore, SubwalletId};
@@ -369,9 +369,14 @@ pub(super) async fn sync_notes_across<S: ShieldedStore>(
     // — drives the watermark advance and the host-visible scan volume,
     // exactly as `result.total_notes_scanned` did in the one-shot path.
     let mut total_notes_scanned: u64 = 0;
-    // Mirrors the one-shot rewind rule: track the last non-empty
-    // batch's `(start_index, is_partial)` so we can warn on a
-    // rewind-to-zero just like before.
+    // Track the last non-empty batch's `(start_index, is_partial)` —
+    // diagnostic only. The one-shot path used this to rewind its resume
+    // point to the mutable buffer chunk's start; the streaming path's
+    // watermark is `aligned_start + total_notes_scanned` (the partial
+    // chunk is re-fetched via the chunk-boundary realignment at the
+    // next pass's start instead), so this value never feeds the
+    // watermark — it is surfaced in the completion log for parity with
+    // the SDK's `next_start_index` semantics.
     let mut last_nonempty: Option<(u64, bool)> = None;
 
     // Scan-based spend detection (replaces the dedicated
@@ -511,9 +516,16 @@ pub(super) async fn sync_notes_across<S: ShieldedStore>(
         }
     }
 
-    // Preserve the one-shot `next_start_index` warning: if the resume
-    // point would rewind to 0 after scanning notes, the next sync
-    // rescans from the beginning.
+    // Diagnostic mirror of the SDK's one-shot `next_start_index`
+    // (rewinds to the last partial chunk's start). NOT the watermark:
+    // the streaming path persists `aligned_start + total_notes_scanned`
+    // below, and re-covers the partial buffer chunk through the
+    // chunk-boundary realignment at the next pass's start. The old
+    // "next_start_index is 0 — next sync will rescan from the
+    // beginning" warning keyed off this value was therefore wrong for
+    // any single-partial-batch cold scan (a from-scratch rescan always
+    // tripped it while the watermark advanced correctly), and sent a
+    // real field investigation chasing the wrong mechanism — dropped.
     let next_start_index = match last_nonempty {
         Some((s, true)) => s,
         _ => aligned_start + total_notes_scanned,
@@ -527,13 +539,6 @@ pub(super) async fn sync_notes_across<S: ShieldedStore>(
         next_start_index,
         "SDK stream consumed"
     );
-    if next_start_index == 0 && total_notes_scanned > 0 {
-        warn!(
-            "Shielded sync: next_start_index is 0 after scanning {} notes — \
-             next sync will rescan from the beginning",
-            total_notes_scanned,
-        );
-    }
 
     if appended > 0 {
         // Checkpoint at the tree's true post-append leaf count. The

--- a/packages/rs-platform-wallet/src/wallet/shielded/viewing_key_bind_tests.rs
+++ b/packages/rs-platform-wallet/src/wallet/shielded/viewing_key_bind_tests.rs
@@ -18,7 +18,7 @@ use key_wallet::account::StandardAccountType;
 
 use crate::changeset::PersistenceError;
 use crate::changeset::PlatformWalletPersistence;
-use crate::changeset::{ClientStartState, PlatformWalletChangeSet};
+use crate::changeset::{ClientStartState, PlatformWalletChangeSet, ShieldedSubwalletStartState};
 use crate::test_support::funded_wallet_manager;
 use crate::wallet::platform_wallet::{PlatformWallet, WalletId};
 use crate::wallet::shielded::{FileBackedShieldedStore, NetworkShieldedCoordinator, SubwalletId};
@@ -33,6 +33,7 @@ use crate::wallet::shielded::{FileBackedShieldedStore, NetworkShieldedCoordinato
 struct CapturingPersistence {
     stored: Mutex<Vec<PlatformWalletChangeSet>>,
     serve: Mutex<BTreeMap<SubwalletId, Vec<u8>>>,
+    serve_subwallets: Mutex<BTreeMap<SubwalletId, ShieldedSubwalletStartState>>,
     load_calls: Mutex<usize>,
 }
 
@@ -54,6 +55,12 @@ impl CapturingPersistence {
     /// restarted session finds.
     fn serve_viewing_keys(&self, rows: BTreeMap<SubwalletId, Vec<u8>>) {
         *self.serve.lock().expect("serve lock") = rows;
+    }
+
+    /// Stage the per-subwallet snapshot `load()` hands back, so a bind's
+    /// restore has something to apply (and therefore reaches the store).
+    fn serve_subwallets(&self, rows: BTreeMap<SubwalletId, ShieldedSubwalletStartState>) {
+        *self.serve_subwallets.lock().expect("serve_subwallets lock") = rows;
     }
 
     fn load_calls(&self) -> usize {
@@ -83,6 +90,11 @@ impl PlatformWalletPersistence for CapturingPersistence {
         *self.load_calls.lock().expect("load_calls lock") += 1;
         let mut start = ClientStartState::default();
         start.shielded.viewing_keys = self.serve.lock().expect("serve lock").clone();
+        start.shielded.per_subwallet = self
+            .serve_subwallets
+            .lock()
+            .expect("serve_subwallets lock")
+            .clone();
         Ok(start)
     }
 }
@@ -251,6 +263,175 @@ async fn bind_persists_viewing_keys_and_restart_rebinds_seedlessly() {
         persister2.captured_viewing_keys().is_empty(),
         "seedless rebind must not re-emit viewing keys"
     );
+}
+
+/// A seed whose derived key disagrees with the persisted one must not
+/// bind. The wallet's durable notes, activity and watermark are keyed by
+/// `(wallet_id, account_index)` alone, so nothing marks which key
+/// produced them: upserting the new key would leave the old key's notes
+/// counted but unspendable, and its watermark in force — hiding the new
+/// key's own history from every subsequent scan. Fail closed instead,
+/// changing neither the persisted rows nor the coordinator.
+#[tokio::test]
+async fn bind_rejects_a_viewing_key_change_for_an_already_persisted_account() {
+    let persister = Arc::new(CapturingPersistence::default());
+    let wallet = platform_wallet_with(Arc::clone(&persister)).await;
+    let coordinator = coordinator_at(&temp_dir("rekey_refused"));
+
+    // Durable row from an earlier bind, under a different seed.
+    let persisted =
+        crate::wallet::shielded::OrchardKeySet::from_seed(&[0x99u8; 64], Network::Testnet, 0)
+            .expect("derive")
+            .viewing_keys();
+    let mut rows = BTreeMap::new();
+    rows.insert(
+        SubwalletId::new(wallet.wallet_id(), 0),
+        persisted.to_fvk_bytes().to_vec(),
+    );
+    persister.serve_viewing_keys(rows);
+
+    let err = wallet
+        .bind_shielded(&[0x42u8; 64], &[0], &coordinator)
+        .await
+        .expect_err("a re-keyed account must not bind over the old key's state");
+    assert!(
+        format!("{err}").contains("differs"),
+        "error must name the key conflict: {err}"
+    );
+
+    assert!(!wallet.is_shielded_bound().await, "nothing was installed");
+    assert!(
+        persister.captured_viewing_keys().is_empty(),
+        "the conflicting key must not be upserted over the persisted row"
+    );
+    assert!(
+        coordinator.registered_subwallets().await.is_empty(),
+        "the coordinator must not be registered with the rejected key"
+    );
+}
+
+/// A wallet the manager has removed cannot bind shielded state back onto
+/// the coordinator. Callers resolve an `Arc<PlatformWallet>` and keep it
+/// across the bind (which may resolve a mnemonic through the host, so it
+/// is not short), so a removal can land in between; re-registering would
+/// resurrect shielded history the host believes it deleted, on the very
+/// next sync pass.
+#[tokio::test]
+async fn bind_after_wallet_removal_is_refused() {
+    let persister = Arc::new(CapturingPersistence::default());
+    let wallet = platform_wallet_with(Arc::clone(&persister)).await;
+    let coordinator = coordinator_at(&temp_dir("detached_bind"));
+
+    wallet
+        .bind_shielded(&[0x42u8; 64], &[0], &coordinator)
+        .await
+        .expect("first bind succeeds");
+    assert_eq!(coordinator.registered_subwallets().await.len(), 1);
+
+    // What `PlatformWalletManager::remove_wallet` does to this handle.
+    wallet.mark_shielded_detached();
+    coordinator.unregister_wallet(wallet.wallet_id()).await;
+
+    let err = wallet
+        .bind_shielded(&[0x42u8; 64], &[0], &coordinator)
+        .await
+        .expect_err("a removed wallet must not re-register itself");
+    assert!(
+        format!("{err}").contains("removed from the manager"),
+        "error must name the removal: {err}"
+    );
+    assert!(
+        coordinator.registered_subwallets().await.is_empty(),
+        "the removed wallet must stay unregistered"
+    );
+}
+
+/// Two binds of one wallet must not interleave. Each publishes the
+/// viewing-grade map on the handle and then replaces the coordinator's
+/// registration; interleaved, the two commits can land in opposite
+/// orders, leaving sync trial-decrypting under one bind's keys while
+/// addresses, balances and spends use the other's.
+///
+/// The first bind is parked mid-transaction by holding the store lock its
+/// restore needs, then a second bind is started: it must not be able to
+/// publish its registration until the first one commits.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn a_second_bind_cannot_commit_inside_another_binds_transaction() {
+    let persister = Arc::new(CapturingPersistence::default());
+    let wallet = platform_wallet_with(Arc::clone(&persister)).await;
+    let coordinator = coordinator_at(&temp_dir("bind_interleave"));
+    let wallet_id = wallet.wallet_id();
+
+    // Give the restore something to apply so it reaches the store lock.
+    let mut snapshot = BTreeMap::new();
+    snapshot.insert(
+        SubwalletId::new(wallet_id, 0),
+        ShieldedSubwalletStartState {
+            last_synced_index: 1,
+            ..Default::default()
+        },
+    );
+    persister.serve_subwallets(snapshot);
+
+    // Park bind A inside its transaction: it registers, then blocks in
+    // the restore on the store write lock this test holds.
+    let store_guard = coordinator.store().write().await;
+    let bind_a = {
+        let wallet = wallet.clone();
+        let coordinator = Arc::clone(&coordinator);
+        tokio::spawn(async move {
+            wallet
+                .bind_shielded(&[0x42u8; 64], &[0], &coordinator)
+                .await
+        })
+    };
+    for _ in 0..200 {
+        if !coordinator.registered_subwallets().await.is_empty() {
+            break;
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(5)).await;
+    }
+    assert_eq!(
+        coordinator.registered_subwallets().await.len(),
+        1,
+        "bind A must have registered and parked in its restore"
+    );
+
+    // Bind B adds an account, so its registration would not need the
+    // store lock: only the transaction can hold it back.
+    let bind_b = {
+        let wallet = wallet.clone();
+        let coordinator = Arc::clone(&coordinator);
+        tokio::spawn(async move {
+            wallet
+                .bind_shielded(&[0x42u8; 64], &[0, 1], &coordinator)
+                .await
+        })
+    };
+    tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+    assert_eq!(
+        coordinator.registered_subwallets().await.len(),
+        1,
+        "bind B must not publish its registration while bind A's transaction is open"
+    );
+
+    drop(store_guard);
+    bind_a.await.expect("bind A task").expect("bind A");
+    bind_b.await.expect("bind B task").expect("bind B");
+
+    let registered: Vec<u32> = coordinator
+        .registered_subwallets()
+        .await
+        .into_iter()
+        .map(|id| id.account_index)
+        .collect();
+    assert_eq!(
+        registered,
+        wallet.shielded_account_indices().await,
+        "the coordinator's registration and the wallet's own keys must agree once \
+         both binds have run"
+    );
+    assert_eq!(registered, vec![0, 1], "the last bind to run wins");
 }
 
 /// First-launch shape: no persisted rows → `Ok(false)`, no state

--- a/packages/rs-platform-wallet/src/wallet/shielded/viewing_key_bind_tests.rs
+++ b/packages/rs-platform-wallet/src/wallet/shielded/viewing_key_bind_tests.rs
@@ -542,16 +542,26 @@ async fn bind_does_not_restore_a_snapshot_that_predates_a_clear() {
     );
 }
 
-/// Two binds of one wallet must not interleave. Each publishes the
-/// viewing-grade map on the handle and then replaces the coordinator's
-/// registration; interleaved, the two commits can land in opposite
-/// orders, leaving sync trial-decrypting under one bind's keys while
-/// addresses, balances and spends use the other's.
+/// Two binds of one wallet must not interleave: neither may publish its
+/// registration while the other's transaction is open. That is what
+/// keeps the handle's key slot and the coordinator's registration from
+/// committing in opposite orders — which would leave sync
+/// trial-decrypting under one bind's keys while addresses, balances and
+/// spends use the other's. (This test drives both binds from one seed,
+/// so it pins the account-set half of that agreement; the key bytes are
+/// identical by construction.)
 ///
 /// The first bind is parked mid-transaction by holding the store lock its
-/// restore needs, then a second bind is started: it must not be able to
-/// publish its registration until the first one commits.
-#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+/// restore needs, then a second bind is started.
+///
+/// The paused clock is load-bearing. `sleep` on a paused runtime only
+/// fires once nothing else is runnable, so the assertion below reads
+/// "the runtime had no work left and bind B still had not registered".
+/// With a real 200 ms sleep the same assertion passes whenever bind B is
+/// merely slow to be scheduled — it derives two Orchard keysets and
+/// round-trips the persister before it ever reaches the lock — which on
+/// a loaded CI box makes it silently green even with the lock removed.
+#[tokio::test(flavor = "current_thread", start_paused = true)]
 async fn a_second_bind_cannot_commit_inside_another_binds_transaction() {
     let persister = Arc::new(CapturingPersistence::default());
     let wallet = platform_wallet_with(Arc::clone(&persister)).await;

--- a/packages/rs-platform-wallet/src/wallet/shielded/viewing_key_bind_tests.rs
+++ b/packages/rs-platform-wallet/src/wallet/shielded/viewing_key_bind_tests.rs
@@ -640,6 +640,66 @@ async fn a_second_bind_cannot_commit_inside_another_binds_transaction() {
     assert_eq!(registered, vec![0, 1], "the last bind to run wins");
 }
 
+/// `shielded_add_account` must not hold the key slot across its host
+/// persistence calls.
+///
+/// A host callback invoked under that write guard deadlocks against a
+/// concurrent bind: the bind holds the coordinator's lifecycle mutex and
+/// waits for this slot, while the callback re-enters the FFI and waits
+/// for that mutex. It also freezes every address and balance read for
+/// the duration of host I/O, which is unbounded.
+///
+/// Parks `add_account` inside the persister load and asserts a slot
+/// reader still completes.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn add_account_does_not_hold_the_key_slot_across_host_persistence() {
+    let persister = Arc::new(CapturingPersistence::default());
+    let wallet = platform_wallet_with(Arc::clone(&persister)).await;
+    let coordinator = coordinator_at(&temp_dir("add_account_slot"));
+    let seed = [0x42u8; 64];
+
+    wallet
+        .bind_shielded(&seed, &[0], &coordinator)
+        .await
+        .expect("bind succeeds");
+
+    let release = persister.gate_next_load();
+    let entries_before = persister.load_entries();
+    let adder = {
+        let wallet = wallet.clone();
+        tokio::spawn(async move { wallet.shielded_add_account(&seed, 1).await })
+    };
+    for _ in 0..400 {
+        if persister.load_entries() > entries_before {
+            break;
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(5)).await;
+    }
+    assert!(
+        persister.load_entries() > entries_before,
+        "add_account never reached the persister load"
+    );
+
+    // The slot must still be readable while the host call is parked.
+    let read = tokio::time::timeout(
+        std::time::Duration::from_millis(500),
+        wallet.shielded_account_indices(),
+    )
+    .await;
+    assert_eq!(
+        read.expect("reading the key slot must not block on host persistence"),
+        vec![0],
+        "the account is not installed until its key is persisted"
+    );
+
+    release.send(()).expect("release the parked load");
+    adder
+        .await
+        .expect("add task")
+        .expect("add_account succeeds");
+    assert_eq!(wallet.shielded_account_indices().await, vec![0, 1]);
+}
+
 /// First-launch shape: no persisted rows → `Ok(false)`, no state
 /// change, so the caller knows to fall back to the seed path. Partial
 /// coverage (a requested account missing) behaves the same.

--- a/packages/rs-platform-wallet/src/wallet/shielded/viewing_key_bind_tests.rs
+++ b/packages/rs-platform-wallet/src/wallet/shielded/viewing_key_bind_tests.rs
@@ -21,6 +21,7 @@ use crate::changeset::PlatformWalletPersistence;
 use crate::changeset::{ClientStartState, PlatformWalletChangeSet, ShieldedSubwalletStartState};
 use crate::test_support::funded_wallet_manager;
 use crate::wallet::platform_wallet::{PlatformWallet, WalletId};
+use crate::wallet::shielded::store::ShieldedStore;
 use crate::wallet::shielded::{FileBackedShieldedStore, NetworkShieldedCoordinator, SubwalletId};
 
 /// Persister double for both halves of the round trip:
@@ -35,6 +36,15 @@ struct CapturingPersistence {
     serve: Mutex<BTreeMap<SubwalletId, Vec<u8>>>,
     serve_subwallets: Mutex<BTreeMap<SubwalletId, ShieldedSubwalletStartState>>,
     load_calls: Mutex<usize>,
+    /// Blocks the next `load()` until the test releases it, so a test can
+    /// hold a bind at the point where it has read the host snapshot but
+    /// has not yet opened its install transaction. A real host callback
+    /// blocks its calling thread the same way.
+    load_gate: Mutex<Option<std::sync::mpsc::Receiver<()>>>,
+    /// Incremented on ENTRY to `load()`, before the gate blocks — the
+    /// handshake a test waits on to know a bind has actually reached the
+    /// gate rather than merely having been spawned.
+    load_entries: Mutex<usize>,
 }
 
 impl CapturingPersistence {
@@ -66,6 +76,24 @@ impl CapturingPersistence {
     fn load_calls(&self) -> usize {
         *self.load_calls.lock().expect("load_calls lock")
     }
+
+    /// Number of changesets queued so far — lets a test assert that a
+    /// refused bind wrote nothing to durable storage.
+    fn stored_count(&self) -> usize {
+        self.stored.lock().expect("stored lock").len()
+    }
+
+    /// Make the next `load()` block until the returned sender fires.
+    fn gate_next_load(&self) -> std::sync::mpsc::Sender<()> {
+        let (tx, rx) = std::sync::mpsc::channel();
+        *self.load_gate.lock().expect("load_gate lock") = Some(rx);
+        tx
+    }
+
+    /// How many `load()` calls have STARTED (gated ones included).
+    fn load_entries(&self) -> usize {
+        *self.load_entries.lock().expect("load_entries lock")
+    }
 }
 
 impl PlatformWalletPersistence for CapturingPersistence {
@@ -87,6 +115,13 @@ impl PlatformWalletPersistence for CapturingPersistence {
     }
 
     fn load(&self) -> Result<ClientStartState, PersistenceError> {
+        *self.load_entries.lock().expect("load_entries lock") += 1;
+        // Take the gate before blocking on it, so a second load() isn't
+        // stuck behind the mutex of the one being held.
+        let gate = self.load_gate.lock().expect("load_gate lock").take();
+        if let Some(rx) = gate {
+            let _ = rx.recv();
+        }
         *self.load_calls.lock().expect("load_calls lock") += 1;
         let mut start = ClientStartState::default();
         start.shielded.viewing_keys = self.serve.lock().expect("serve lock").clone();
@@ -278,9 +313,11 @@ async fn bind_rejects_a_viewing_key_change_for_an_already_persisted_account() {
     let wallet = platform_wallet_with(Arc::clone(&persister)).await;
     let coordinator = coordinator_at(&temp_dir("rekey_refused"));
 
-    // Durable row from an earlier bind, under a different seed.
+    // Durable row from an earlier bind, under a different seed. Derived
+    // on the wallet's own network so the SEED is the only difference —
+    // otherwise the refusal could be a network mismatch instead.
     let persisted =
-        crate::wallet::shielded::OrchardKeySet::from_seed(&[0x99u8; 64], Network::Testnet, 0)
+        crate::wallet::shielded::OrchardKeySet::from_seed(&[0x99u8; 64], wallet.sdk().network, 0)
             .expect("derive")
             .viewing_keys();
     let mut rows = BTreeMap::new();
@@ -331,6 +368,7 @@ async fn bind_after_wallet_removal_is_refused() {
     // What `PlatformWalletManager::remove_wallet` does to this handle.
     wallet.mark_shielded_detached();
     coordinator.unregister_wallet(wallet.wallet_id()).await;
+    let persisted_before = persister.stored_count();
 
     let err = wallet
         .bind_shielded(&[0x42u8; 64], &[0], &coordinator)
@@ -343,6 +381,164 @@ async fn bind_after_wallet_removal_is_refused() {
     assert!(
         coordinator.registered_subwallets().await.is_empty(),
         "the removed wallet must stay unregistered"
+    );
+    // The refusal must land BEFORE the viewing-key write, not after it.
+    // Hosts delete their own wallet data once removal returns, so a row
+    // written here survives with no wallet and no mnemonic to match it —
+    // and an FVK discloses every note of its account.
+    assert_eq!(
+        persister.stored_count(),
+        persisted_before,
+        "a refused bind must not persist anything for a removed wallet"
+    );
+}
+
+/// `shielded_add_account` is the other writer of a subwallet's
+/// viewing-key row, so it owes the same refusal as the bind paths. An
+/// account missing from the in-memory map can still have durable rows
+/// from an earlier session; overwriting its key would leave those notes
+/// and their watermark attributed to a key that did not produce them,
+/// and nothing downstream could detect it — the next seedless bind
+/// derives its keys FROM the row that was overwritten.
+#[tokio::test]
+async fn add_account_rejects_a_viewing_key_change_for_a_persisted_account() {
+    let persister = Arc::new(CapturingPersistence::default());
+    let wallet = platform_wallet_with(Arc::clone(&persister)).await;
+    let coordinator = coordinator_at(&temp_dir("add_account_rekey"));
+    let seed = [0x42u8; 64];
+
+    // Durable rows: account 0 under this seed (so the bind agrees),
+    // account 1 under a different one. Derived on the wallet's own
+    // network — the bind derives with `sdk.network`, and a mismatch there
+    // would make this test pass for the wrong reason.
+    let network = wallet.sdk().network;
+    let views0 = crate::wallet::shielded::OrchardKeySet::from_seed(&seed, network, 0)
+        .expect("derive")
+        .viewing_keys();
+    let foreign1 = crate::wallet::shielded::OrchardKeySet::from_seed(&[0x99u8; 64], network, 1)
+        .expect("derive")
+        .viewing_keys();
+    let mut rows = BTreeMap::new();
+    rows.insert(
+        SubwalletId::new(wallet.wallet_id(), 0),
+        views0.to_fvk_bytes().to_vec(),
+    );
+    rows.insert(
+        SubwalletId::new(wallet.wallet_id(), 1),
+        foreign1.to_fvk_bytes().to_vec(),
+    );
+    persister.serve_viewing_keys(rows);
+
+    wallet
+        .bind_shielded(&seed, &[0], &coordinator)
+        .await
+        .expect("bind of the matching account succeeds");
+    let persisted_before = persister.stored_count();
+
+    let err = wallet
+        .shielded_add_account(&seed, 1)
+        .await
+        .expect_err("adding an account whose persisted key differs must fail closed");
+    assert!(
+        format!("{err}").contains("differs"),
+        "error must name the key conflict: {err}"
+    );
+    assert_eq!(
+        wallet.shielded_account_indices().await,
+        vec![0],
+        "the conflicting account must not be installed on the handle"
+    );
+    assert_eq!(
+        persister.stored_count(),
+        persisted_before,
+        "the conflicting key must not be upserted over the persisted row"
+    );
+}
+
+/// A bind that read the host snapshot before a Clear must not put that
+/// snapshot back afterwards.
+///
+/// The snapshot has to be read before the install transaction opens (the
+/// seedless path reconstructs its keys from it, and a host callback must
+/// not run under the coordinator's lifecycle mutex), so serializing the
+/// transaction alone cannot cover this: Clear takes the mutex, finishes,
+/// and the host then wipes its own rows — while a bind still holds the
+/// pre-Clear notes and watermark in hand. Restoring them resurrects
+/// history the user deleted and re-arms a watermark that reports
+/// caught-up, so the cold rebuild from index 0 that Clear promises never
+/// runs.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn bind_does_not_restore_a_snapshot_that_predates_a_clear() {
+    let persister = Arc::new(CapturingPersistence::default());
+    let wallet = platform_wallet_with(Arc::clone(&persister)).await;
+    let coordinator = coordinator_at(&temp_dir("clear_during_bind"));
+    let id = SubwalletId::new(wallet.wallet_id(), 0);
+
+    // Pre-Clear host state: one note and a high watermark.
+    let mut snapshot = BTreeMap::new();
+    snapshot.insert(
+        id,
+        ShieldedSubwalletStartState {
+            notes: vec![crate::wallet::shielded::ShieldedNote {
+                position: 7,
+                cmx: [0x2A; 32],
+                nullifier: [0xE0; 32],
+                block_height: 100,
+                is_spent: false,
+                value: 1_000,
+                note_data: vec![0u8; 115],
+            }],
+            last_synced_index: 900_000,
+            ..Default::default()
+        },
+    );
+    persister.serve_subwallets(snapshot);
+
+    // Park the bind inside load(): it has sampled the clear generation
+    // and is about to read the pre-Clear snapshot.
+    let release = persister.gate_next_load();
+    let bind = {
+        let wallet = wallet.clone();
+        let coordinator = Arc::clone(&coordinator);
+        tokio::spawn(async move {
+            wallet
+                .bind_shielded(&[0x42u8; 64], &[0], &coordinator)
+                .await
+        })
+    };
+    // Wait for the bind to actually REACH the gate. Without this
+    // handshake the Clear below could land before the bind samples the
+    // generation — a different ordering, which the fix is not about and
+    // which would make this test pass either way.
+    for _ in 0..400 {
+        if persister.load_entries() > 0 {
+            break;
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(5)).await;
+    }
+    assert!(
+        persister.load_entries() > 0,
+        "bind never reached the persister load"
+    );
+
+    // The user taps Clear and it completes — store purged, registries
+    // dropped — then the host wipes its own rows.
+    coordinator.clear().await.expect("clear succeeds");
+
+    release.send(()).expect("release the parked load");
+    bind.await.expect("bind task").expect("bind succeeds");
+
+    let store = coordinator.store().read().await;
+    assert!(
+        store.get_all_notes(id).unwrap().is_empty(),
+        "a snapshot read before the Clear must not be restored after it — those notes \
+         are exactly what the user asked to delete"
+    );
+    assert_eq!(
+        store.last_synced_note_index(id).unwrap(),
+        0,
+        "the pre-Clear watermark must not come back; it would report caught-up and \
+         suppress the cold rebuild from index 0"
     );
 }
 


### PR DESCRIPTION
## Issue being fixed or feature implemented

On iOS (rc.2, testnet), a shielded note discovered by a sync pass was not spendable until the app restarted — `IdentityCreateFromShieldedPool` / unshield immediately after a shield failed with `ShieldedNoUnspentNotes` even though the host's persisted note row existed and was unspent. A second defect in the same area: after a from-scratch rescan, the sync watermark never advanced in-session, so every subsequent pass rescanned the entire tree until restart.

Both have one root cause. Hosts re-run `bind_shielded` liberally (the example app fires it twice at launch — a direct `rebindWalletScopedServices()` call plus the wallet-set `onChange` observer — and again on Sync Now and wallet navigation). `PlatformWallet::install_shielded_views` ran unregister → purge → restore on **every** bind. Against an in-flight `sync_notes_across` pass (which holds the store write lock for the whole streamed pass, 45–90 s on testnet), the purge/restore lock acquisitions queue behind the pass and land the moment it finishes — wiping the pass's freshly discovered notes and watermark from the coordinator's in-memory store and restoring a persister snapshot loaded *before* the pass ran. The host's SwiftData rows survive (the pass's changeset persists synchronously first), which is why an app restart always healed it.

Log fingerprint from the failing sessions: Core SPV auto-start (main-actor-queued behind the second bind) begins <0.5 s after pass 1 ends; the next pass reads the pre-pass watermark and re-discovers the same note (`new_notes_total=1` twice for one on-chain note). A related interleaving also produced `WARN Shielded sync changeset dropped: no persister registered` — `register_wallet` inserted `accounts` and `persisters` under two separate lock acquisitions, so a pass starting between them dropped its whole changeset.

## What was done?

- **Re-binds are non-destructive by construction.** `install_shielded_views` no longer calls `unregister_wallet` at all. `register_wallet` now purges only the subwallets the new registration *drops or re-keys* (via the new `ShieldedStore::purge_subwallet`; an account whose FVK changed is treated as dropped — its stored notes belong to the old key) and it replaces, never removes, the persister handle. Retained accounts keep their in-memory notes and watermark across **any** re-bind — identical or account-set-changing — so a registration replacement racing an in-flight sync pass cannot wipe the pass's results, and a pass finishing mid-bind always finds a persister for its changeset.
- **Idempotent re-bind fast path**: when the wallet is already registered with the exact same account → FVK map (new `NetworkShieldedCoordinator::wallet_registration_matches`, compared by the canonical 96-byte FVK encoding) *and* its hydration previously succeeded, the bind skips reloading/re-applying the persister snapshot entirely and never touches the store lock. Side effect: the second launch-time bind no longer blocks the main actor behind the in-flight pass (~50 s launch freeze gone).
- **Hydration is tracked separately from registration** (review finding): the coordinator records per-wallet hydration success (set only after a successful load + restore for the current registration shape; cleared on shape change, unregister, and clear). A matching registration alone no longer short-circuits the restore, so a transient persistence failure on the first bind is retried by the next re-bind instead of leaving notes and the watermark absent until a rescan or restart.
- **`restore_for_wallet` is monotonic**: the watermark only advances (`max`), and a snapshot note whose nullifier the store already tracks is skipped — `save_note` is overwrite-by-nullifier, so a stale `is_spent = false` copy would otherwise re-offer a spent note to selection (a double-spend attempt at broadcast).
- **Registry lifecycle mutations are atomic** (review finding): a coordinator-level lifecycle mutex serializes `register_wallet` / `unregister_wallet` / `clear`'s registry phase, and `register_wallet` inserts the persister before the accounts. Together these make "accounts visible ⇒ persister visible" hold at every interleaving — including concurrent register + unregister — so a pass can no longer silently drop its changeset (the only remaining accounts-without-persister window is a wallet genuinely being removed mid-pass, where dropping its changeset is intended).
- **Removed the stale warning** `next_start_index is 0 after scanning N notes — next sync will rescan from the beginning`: since the streaming refactor that value is diagnostic-only (the watermark is `aligned_start + total_notes_scanned`; the partial buffer chunk is re-covered by chunk-boundary realignment on the next pass), and it fired spuriously on every single-partial-batch cold scan — it pointed the field investigation of this bug at the wrong mechanism.

## How Has This Been Tested?

- Six new regression tests in the coordinator test module: a stale pre-pass snapshot can neither rewind the watermark nor clobber a fresh note; a spent note can never be resurrected by restore (only genuinely new nullifiers are added); `wallet_registration_matches` accepts only the identical wallet + account set + FVK and rejects unknown wallets, changed account sets, and changed keys; a changed-set re-register keeps retained-account state (notes + watermark + persister) while purging only the dropped subwallet; a re-keyed account's old-key notes are purged; and the hydration flag follows the registration lifecycle (preserved on identical re-register, cleared on shape change / unregister).
- `cargo test -p platform-wallet --features shielded --lib`: 629 passed, 0 failed.
- `cargo check -p platform-wallet --all-targets --features shielded` and `cargo check -p platform-wallet-ffi --features shielded` clean; `cargo fmt` applied.
- Root cause was verified against device logs from four app sessions (two failing, two healthy restarts): the stomped watermark values and the SPV-start timing match the mechanism exactly in every session.

### End-to-end verification on the iOS simulator (this build)

Rebuilt the sim xcframework + SwiftExampleApp from this branch (`build_info.txt` in the session log confirms commit `da4e45a3`, clean tree) and re-ran the originally failing shield-then-spend flow on testnet, all in **one app session with no restart**:

| Time (UTC) | Event |
|---|---|
| 07:39:24 | Launch; pass 1 starts with restored watermark 2268 |
| 07:42:51 | Shield 0.05 tDASH (Type 18 asset lock) submitted from the UI |
| 07:43:27 | Shield executed on-chain — 4,787,148,800 credits into the pool |
| 07:45:02 | Sync pass discovers the note (`new_notes_total=1`, watermark → 2274) |
| 07:48:47 | `IdentityCreateFromShieldedPool` (denomination 3B credits): **selection succeeds instantly** — `inputs=1 total_input=4787148800`, i.e. exactly the note discovered 3½ min earlier |
| 07:48:54 | Broadcast succeeded → new identity `HVvuKeae6bpLsBNUZK9gN8rYEK7vWxa4Vr7r4pVWD6f1` |
| 07:49:37 | Next pass discovers the change note → watermark 2276 |

The 3B-credit denomination could only be covered by the fresh note (the only other unspent note was 1.787B), so the spend provably selected the note discovered mid-session — the exact case that returned `ShieldedNoUnspentNotes` before this fix.

Both defects confirmed fixed in the session logs:
- **Watermark monotonic across every pass** (2268 → 2272 → 2274 → 2276). The launch even reproduced the original stomp setup — the second bind racing pass 1 with a stale snapshot (2268) — and the following pass read pass 1's advanced 2272, not the snapshot's value.
- **Fast path observable**: Core SPV auto-start began 0.7 s into pass 1 instead of ~50 s after it (pre-fix the second bind blocked the main actor on the store lock for the whole pass).
- Zero WARN/ERROR lines for the entire session (no dropped-changeset warning, no spurious rescan warning), and SwiftData ground truth is coherent afterwards: the fresh note is marked spent, its change note unspent, and the new identity row is present at slot #7.

## Breaking Changes

None. `wallet_registration_matches` is a new public method; existing APIs and persisted formats are unchanged.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [ ] I have made corresponding changes to the documentation if needed

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone

🤖 Generated with [Claude Code](https://claude.com/claude-code)
