### PR TITLE
docs(agents): never commit working specs; enforce by discipline, not git plumbing

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -93,6 +93,12 @@ Platform uses data contracts to define application data schemas:
 - Keep PRs focused, link issues, include tests, and fill the PR template (`.github/PULL_REQUEST_TEMPLATE.md`).
 - Branching: bugfixes and new features to the current `vX-dev` branch.
 
+## Specs are working artifacts — never commit them
+A design doc / spec / plan written to drive a change (the problem, chosen approach, alternatives rejected, failure modes, test plan) exists to guide the work, not to ship. It goes stale the moment the code lands.
+- Keep it in the working tree but **never stage or commit it**. Enforce this by discipline, not git plumbing: stage with explicit paths (`git add <file> …`), never a blind `git add -A`/`git add .`. Do NOT edit `.git/info/exclude`, add a `.gitignore` entry, or use any other git trick to hide it — just don't add it.
+- Delete it once the task ships. If a branch already committed one, `git rm --cached <path>` before merge; the file stays on disk for the life of the task.
+- Only commit documentation the project keeps long-term: user/developer guides, architecture references, runbooks, API docs. A fact worth keeping after merge goes in a code comment, a test name, the commit message, or the PR description — not a design doc.
+
 ## Agent-Specific Instructions
 
 **Always use the `swift-rust-ffi-engineer` agent for:**


### PR DESCRIPTION
## What

Adds a convention to the canonical agent-instructions file (`AGENTS.md`, symlinked as `CLAUDE.md`): design docs / specs / plans written to drive a change are **working artifacts** — kept in the working tree to guide the work, but never staged or committed, and deleted once the task ships.

Placed right after **Commit & Pull Request Guidelines**.

## Why

The research→spec→review pipeline produces specs that go stale the moment the code lands; a reader who wasn't there gets nothing from a design doc re-litigating rejected alternatives. So they shouldn't ship in the repo.

Crucially, the rule says to enforce this **by discipline, not git plumbing** — explicit `git add <file>`, never a blind `git add -A` — and **explicitly forbids** hiding specs via `.git/info/exclude` or `.gitignore`. Those tricks leave orphaned entries behind after the spec is deleted (observed in practice: an exclude line outliving the file it referenced).

## Scope

Docs-only, one file. No code or behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance to keep temporary design and specification documents out of commits.
  * Clarified that only long-term project documentation, such as guides, runbooks, and API documentation, should be committed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->