### PR TITLE
feat(kotlin-sdk): expose core_wallet_next_receive_address / next_change_address (Swift parity)

### DIFF
--- a/packages/kotlin-sdk/sdk/src/main/kotlin/org/dashfoundation/dashsdk/ffi/WalletManagerNative.kt
+++ b/packages/kotlin-sdk/sdk/src/main/kotlin/org/dashfoundation/dashsdk/ffi/WalletManagerNative.kt
@@ -224,6 +224,22 @@ internal object WalletManagerNative {
         accountIndex: Int,
     ): String
 
+    /**
+     * `core_wallet_next_receive_address` — the engine's next unused BIP-44
+     * EXTERNAL (receive) address for [accountIndex], base58-encoded.
+     * Answered from the engine's in-memory used-set (authoritative over
+     * the Room `core_addresses` mirror). Kotlin parity for the Swift
+     * binding (`coreWallet().nextReceiveAddress(accountIndex:)`).
+     */
+    external fun coreWalletNextReceiveAddress(coreHandle: Long, accountIndex: Int): String
+
+    /**
+     * `core_wallet_next_change_address` — the engine's next unused BIP-44
+     * INTERNAL (change) address for [accountIndex], base58-encoded. The
+     * change-side twin of [coreWalletNextReceiveAddress].
+     */
+    external fun coreWalletNextChangeAddress(coreHandle: Long, accountIndex: Int): String
+
     /** Consume and broadcast an atomically finalized V2 transaction. */
     external fun coreWalletBroadcastSignedTransactionV2(coreHandle: Long, transaction: Long): String
 

--- a/packages/kotlin-sdk/sdk/src/main/kotlin/org/dashfoundation/dashsdk/wallet/ManagedCoreWallet.kt
+++ b/packages/kotlin-sdk/sdk/src/main/kotlin/org/dashfoundation/dashsdk/wallet/ManagedCoreWallet.kt
@@ -1,5 +1,6 @@
 package org.dashfoundation.dashsdk.wallet
 
+import org.dashfoundation.dashsdk.errors.mapNativeErrors
 import org.dashfoundation.dashsdk.ffi.NativeCleaner
 import org.dashfoundation.dashsdk.ffi.WalletManagerNative
 import java.util.concurrent.atomic.AtomicLong
@@ -11,9 +12,10 @@ import java.util.concurrent.atomic.AtomicLong
  *
  * Obtained via [ManagedPlatformWallet.coreWallet]. Owns the transient
  * core-wallet handle and destroys it (`core_wallet_destroy`) on [close] or a
- * [NativeCleaner] backstop, exactly like the Swift type's `deinit`. Balance /
- * address reads live on other Kotlin paths; this port carries only the
- * broadcast entry point the Core→Core send needs.
+ * [NativeCleaner] backstop, exactly like the Swift type's `deinit`.
+ * Balance reads live on other Kotlin paths; this port carries the
+ * broadcast entry points the Core→Core send needs plus the engine's
+ * next-unused address accessors ([nextReceiveAddress] / [nextChangeAddress]).
  */
 class ManagedCoreWallet internal constructor(handle: Long) : AutoCloseable {
 
@@ -72,7 +74,11 @@ class ManagedCoreWallet internal constructor(handle: Long) : AutoCloseable {
      */
     fun nextReceiveAddress(accountIndex: Int = 0): String {
         require(accountIndex >= 0) { "accountIndex must be non-negative, got $accountIndex" }
-        return WalletManagerNative.coreWalletNextReceiveAddress(handle, accountIndex)
+        // Public boundary: map the JNI layer's DashSDKException into the
+        // typed DashSdkError hierarchy (the DashSdkError.kt contract).
+        return mapNativeErrors {
+            WalletManagerNative.coreWalletNextReceiveAddress(handle, accountIndex)
+        }
     }
 
     /**
@@ -85,7 +91,9 @@ class ManagedCoreWallet internal constructor(handle: Long) : AutoCloseable {
      */
     fun nextChangeAddress(accountIndex: Int = 0): String {
         require(accountIndex >= 0) { "accountIndex must be non-negative, got $accountIndex" }
-        return WalletManagerNative.coreWalletNextChangeAddress(handle, accountIndex)
+        return mapNativeErrors {
+            WalletManagerNative.coreWalletNextChangeAddress(handle, accountIndex)
+        }
     }
 
     override fun close() {

--- a/packages/kotlin-sdk/sdk/src/main/kotlin/org/dashfoundation/dashsdk/wallet/ManagedCoreWallet.kt
+++ b/packages/kotlin-sdk/sdk/src/main/kotlin/org/dashfoundation/dashsdk/wallet/ManagedCoreWallet.kt
@@ -55,6 +55,39 @@ class ManagedCoreWallet internal constructor(handle: Long) : AutoCloseable {
         )
     }
 
+    /**
+     * The engine's next unused BIP-44 EXTERNAL (receive) address for
+     * [accountIndex], base58-encoded — Android port of Swift's
+     * `ManagedCoreWallet.nextReceiveAddress(accountIndex:)`
+     * (`SwiftDashSDKReceiveAddressReader`'s source on iOS).
+     *
+     * Answered from the engine's in-memory used-set, so it is
+     * authoritative over the Room `core_addresses` mirror and needs no
+     * persistence read. "Unused" means never seen on-chain: the engine
+     * keeps no issued-marker, so repeated calls return the SAME address
+     * until it receives funds (current-address semantics, not
+     * per-invoice handout). Cold-start caveat (same as iOS documents):
+     * on a fresh install/post-wipe the used-set starts empty, so this
+     * answers index 0 until SPV replay catches the used-set up.
+     */
+    fun nextReceiveAddress(accountIndex: Int = 0): String {
+        require(accountIndex >= 0) { "accountIndex must be non-negative, got $accountIndex" }
+        return WalletManagerNative.coreWalletNextReceiveAddress(handle, accountIndex)
+    }
+
+    /**
+     * The engine's next unused BIP-44 INTERNAL (change) address for
+     * [accountIndex], base58-encoded — the change-side twin of
+     * [nextReceiveAddress]; same used-set semantics and cold-start
+     * caveat. Builds pick change themselves (`setFunding`); this
+     * accessor exists for callers that must NAME a change address
+     * up front (e.g. `CoreTransactionBuilder.setChangeAddress`).
+     */
+    fun nextChangeAddress(accountIndex: Int = 0): String {
+        require(accountIndex >= 0) { "accountIndex must be non-negative, got $accountIndex" }
+        return WalletManagerNative.coreWalletNextChangeAddress(handle, accountIndex)
+    }
+
     override fun close() {
         cleanable.clean()
     }

--- a/packages/kotlin-sdk/sdk/src/test/kotlin/org/dashfoundation/dashsdk/wallet/ManagedCoreWalletAddressTest.kt
+++ b/packages/kotlin-sdk/sdk/src/test/kotlin/org/dashfoundation/dashsdk/wallet/ManagedCoreWalletAddressTest.kt
@@ -1,0 +1,135 @@
+package org.dashfoundation.dashsdk.wallet
+
+import java.io.File
+import org.dashfoundation.dashsdk.errors.DashSdkError
+import org.dashfoundation.dashsdk.errors.mapNativeErrors
+import org.dashfoundation.dashsdk.ffi.DashSDKException
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Assert.fail
+import org.junit.Test
+
+/**
+ * Host-JVM coverage for [ManagedCoreWallet.nextReceiveAddress] /
+ * [ManagedCoreWallet.nextChangeAddress] — everything on the Kotlin side of
+ * the JNI boundary. The native library cannot load on the host, so these
+ * tests exercise exactly the paths that never reach an `external fun`:
+ * argument validation, the closed-handle guard, the
+ * [mapNativeErrors] error contract, and (as a source-scanning guard in the
+ * [GateCoverageLintTest] tradition) the requirement that both public
+ * methods actually WRAP their native call in [mapNativeErrors]. Real JNI
+ * linkage, derivation, and used-set semantics belong to the instrumented
+ * follow-up (`connectedDebugAndroidTest`).
+ */
+class ManagedCoreWalletAddressTest {
+
+    // ── Argument validation: rejected BEFORE any native call ─────────
+
+    @Test
+    fun negativeAccountIndexIsRejectedBeforeAnyNativeCall() {
+        // A live (non-zero) handle: if validation did NOT fire first, the
+        // call would hit the unloadable native lib and throw
+        // UnsatisfiedLinkError instead of IllegalArgumentException.
+        val wallet = ManagedCoreWallet(handle = 1L)
+        for (call in listOf<(Int) -> String>(
+            { wallet.nextReceiveAddress(it) },
+            { wallet.nextChangeAddress(it) },
+        )) {
+            try {
+                call(-1)
+                fail("expected IllegalArgumentException for accountIndex -1")
+            } catch (e: IllegalArgumentException) {
+                assertTrue(
+                    "message should name the bad index: ${e.message}",
+                    e.message!!.contains("-1")
+                )
+            }
+        }
+    }
+
+    // ── Lifecycle: the closed-handle guard fires before any native call ──
+
+    @Test
+    fun closedWalletThrowsIllegalStateBeforeAnyNativeCall() {
+        // A zero handle is the closed state; close() on it never reaches
+        // the native destroy (HandleCleanup skips handle 0), so the whole
+        // test stays on the host side of the boundary.
+        val wallet = ManagedCoreWallet(handle = 0L)
+        wallet.close()
+        for (call in listOf(
+            { wallet.nextReceiveAddress() },
+            { wallet.nextChangeAddress() },
+        )) {
+            try {
+                call()
+                fail("expected IllegalStateException on a closed wallet")
+            } catch (e: IllegalStateException) {
+                assertTrue(
+                    "message should say the wallet is closed: ${e.message}",
+                    e.message!!.contains("closed")
+                )
+            }
+        }
+    }
+
+    // ── Error contract: the exact mapping the address accessors rely on ──
+
+    @Test
+    fun nativeNotFoundMapsToTypedDashSdkError() {
+        // Code 7 (NotFound) is what a nonexistent account surfaces as —
+        // the failure mode the accessors' public contract cares about.
+        try {
+            mapNativeErrors { throw DashSDKException(7, "BIP-44 account 9 not found") }
+            fail("expected DashSdkError.NotFound")
+        } catch (e: DashSdkError.NotFound) {
+            assertEquals("BIP-44 account 9 not found", e.message)
+            assertTrue(e.cause is DashSDKException)
+        }
+    }
+
+    // ── Structural guard (the review blocker, made permanent) ─────────
+
+    /**
+     * Both public address accessors MUST wrap their native call in
+     * [mapNativeErrors] — the `DashSdkError.kt` contract for public SDK
+     * entry points. This was a review blocker on the PR that introduced
+     * them; enforce it structurally so it cannot regress silently.
+     */
+    @Test
+    fun addressAccessorsWrapTheirNativeCallInMapNativeErrors() {
+        val src = File(findSdkMainSources(), "wallet/ManagedCoreWallet.kt").readText()
+        for (method in listOf("nextReceiveAddress", "nextChangeAddress")) {
+            val header = "fun $method("
+            val start = src.indexOf(header)
+            assertTrue("ManagedCoreWallet.$method not found", start >= 0)
+            // The method body runs to the next fun declaration (or EOF).
+            val end = src.indexOf("fun ", start + header.length)
+                .let { if (it < 0) src.length else it }
+            val body = src.substring(start, end)
+            val native = body.indexOf("WalletManagerNative.")
+            val wrapper = body.indexOf("mapNativeErrors")
+            assertTrue("$method makes no native call?", native >= 0)
+            assertTrue(
+                "$method must wrap its WalletManagerNative call in " +
+                    "mapNativeErrors (public-boundary error contract)",
+                wrapper in 0 until native
+            )
+        }
+    }
+
+    /** Same walk-up lookup as [GateCoverageLintTest]. */
+    private fun findSdkMainSources(): File {
+        var dir: File? = File(System.getProperty("user.dir") ?: ".")
+        while (dir != null) {
+            for (candidate in listOf(
+                File(dir, "src/main/kotlin/org/dashfoundation/dashsdk"),
+                File(dir, "sdk/src/main/kotlin/org/dashfoundation/dashsdk"),
+                File(dir, "packages/kotlin-sdk/sdk/src/main/kotlin/org/dashfoundation/dashsdk"),
+            )) {
+                if (candidate.isDirectory) return candidate
+            }
+            dir = dir.parentFile
+        }
+        error("could not locate the SDK main source set from ${System.getProperty("user.dir")}")
+    }
+}

--- a/packages/rs-unified-sdk-jni/src/wallet_manager.rs
+++ b/packages/rs-unified-sdk-jni/src/wallet_manager.rs
@@ -1094,6 +1094,106 @@ pub extern "system" fn Java_org_dashfoundation_dashsdk_ffi_WalletManagerNative_c
     })
 }
 
+/// `core_wallet_next_receive_address` — the engine's next unused BIP-44
+/// EXTERNAL (receive) address for `account_index`, base58-encoded.
+///
+/// Kotlin parity for the Swift binding (`SwiftDashSDKReceiveAddressReader`
+/// → `coreWallet().nextReceiveAddress(accountIndex:)`): the engine answers
+/// from its in-memory used-set, so this is authoritative over the Room
+/// `core_addresses` mirror and needs no persistence read. Same cold-start
+/// caveat as iOS documents: until SPV replay populates the used-set a
+/// fresh install answers index 0.
+#[no_mangle]
+pub extern "system" fn Java_org_dashfoundation_dashsdk_ffi_WalletManagerNative_coreWalletNextReceiveAddress(
+    mut env: JNIEnv,
+    _class: JClass,
+    core_handle: jlong,
+    account_index: jni::sys::jint,
+) -> jstring {
+    guard(&mut env, ptr::null_mut(), |env| {
+        if core_handle == 0 {
+            throw_sdk_exception(env, 1, "core wallet handle is 0");
+            return ptr::null_mut();
+        }
+        if account_index < 0 {
+            throw_sdk_exception(env, 1, "accountIndex must be non-negative");
+            return ptr::null_mut();
+        }
+
+        let mut out_address: *mut c_char = ptr::null_mut();
+        let result = unsafe {
+            platform_wallet_ffi::core_wallet_next_receive_address(
+                core_handle as Handle,
+                account_index as u32,
+                &mut out_address as *mut *mut c_char,
+            )
+        };
+        if take_pwffi_error(env, result) {
+            return ptr::null_mut();
+        }
+
+        if out_address.is_null() {
+            throw_sdk_exception(env, 1, "next receive address returned NULL");
+            return ptr::null_mut();
+        }
+        // Copy the address out, then free the Rust-owned C string with the
+        // module's own free (`core_wallet_free_address`).
+        let address = unsafe { CStr::from_ptr(out_address) }
+            .to_string_lossy()
+            .into_owned();
+        unsafe { platform_wallet_ffi::core_wallet_free_address(out_address) };
+        env.new_string(address)
+            .map(|s| s.into_raw())
+            .unwrap_or(ptr::null_mut())
+    })
+}
+
+/// `core_wallet_next_change_address` — the engine's next unused BIP-44
+/// INTERNAL (change) address for `account_index`, base58-encoded. The
+/// change-side twin of [coreWalletNextReceiveAddress]; same contract.
+#[no_mangle]
+pub extern "system" fn Java_org_dashfoundation_dashsdk_ffi_WalletManagerNative_coreWalletNextChangeAddress(
+    mut env: JNIEnv,
+    _class: JClass,
+    core_handle: jlong,
+    account_index: jni::sys::jint,
+) -> jstring {
+    guard(&mut env, ptr::null_mut(), |env| {
+        if core_handle == 0 {
+            throw_sdk_exception(env, 1, "core wallet handle is 0");
+            return ptr::null_mut();
+        }
+        if account_index < 0 {
+            throw_sdk_exception(env, 1, "accountIndex must be non-negative");
+            return ptr::null_mut();
+        }
+
+        let mut out_address: *mut c_char = ptr::null_mut();
+        let result = unsafe {
+            platform_wallet_ffi::core_wallet_next_change_address(
+                core_handle as Handle,
+                account_index as u32,
+                &mut out_address as *mut *mut c_char,
+            )
+        };
+        if take_pwffi_error(env, result) {
+            return ptr::null_mut();
+        }
+
+        if out_address.is_null() {
+            throw_sdk_exception(env, 1, "next change address returned NULL");
+            return ptr::null_mut();
+        }
+        let address = unsafe { CStr::from_ptr(out_address) }
+            .to_string_lossy()
+            .into_owned();
+        unsafe { platform_wallet_ffi::core_wallet_free_address(out_address) };
+        env.new_string(address)
+            .map(|s| s.into_raw())
+            .unwrap_or(ptr::null_mut())
+    })
+}
+
 /// Consume and broadcast an atomically finalized V2 transaction handle.
 #[no_mangle]
 pub extern "system" fn Java_org_dashfoundation_dashsdk_ffi_WalletManagerNative_coreWalletBroadcastSignedTransactionV2(


### PR DESCRIPTION
## What

Kotlin parity for the **existing** address-derivation FFI. `rs-platform-wallet-ffi` has shipped `core_wallet_next_receive_address` / `core_wallet_next_change_address` for some time, and iOS binds the C ABI directly (`SwiftDashSDKReceiveAddressReader` → `coreWallet().nextReceiveAddress(accountIndex:)` — the DashWallet-iOS Receive screen's source). No rs-unified-sdk-jni/Kotlin plumbing existed, so Android callers (including the SDK's own KotlinExampleApp `ReceiveAddressSheet`) have been reading the Room `core_addresses` mirror instead of asking the engine.

- `rs-unified-sdk-jni/src/wallet_manager.rs`: `coreWalletNextReceiveAddress` / `coreWalletNextChangeAddress` — same `guard` / `take_pwffi_error` / `core_wallet_free_address` pattern as the neighboring core-wallet JNI calls.
- `WalletManagerNative.kt`: the two `external fun` declarations.
- `ManagedCoreWallet.kt`: public `nextReceiveAddress(accountIndex: Int = 0)` / `nextChangeAddress(accountIndex: Int = 0)`, named to mirror the Swift surface.

## Semantics (documented on the Kotlin surface)

Engine-authoritative over the in-memory used-set — "unused" means never seen on-chain. There is no issued-marker, so repeated calls return the **same** address until it receives funds (current-address semantics, matching iOS exactly, including the documented cold-start caveat: index 0 until SPV replay populates the used-set). A per-invoice `fresh_address` with an engine-side issued-marker is a separate, future ask — deliberately out of scope here.

## Why now

dash-wallet's BIP70 cutover work (dashpay/dash-wallet#1531) sources `Payment.refund_to` from the Room pool as a stopgap; once this lands in a published AAR, that Room read swaps for `coreWallet().nextReceiveAddress()` (one function body, no callers change), and the same call becomes the Receive screen's post-dashj source in Phase 2 — identical to how iOS already works.

## Verified

`cargo check -p rs-unified-sdk-jni` clean; `:sdk` Kotlin compile clean. Purely additive — no existing surface touched. Not yet exercised on-device (needs an AAR rebuild via `build_android.sh`); the FFI itself is already proven in production by iOS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for retrieving the next unused receive address for a wallet account.
  * Added support for retrieving the next unused change address for a wallet account.
  * Account selection is supported, defaulting to the first account.
  * Invalid account indices and address retrieval errors are reported clearly through the SDK.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->