### PR TITLE
feat(platform): introduce protocol version 14

### DIFF
--- a/packages/rs-platform-version/src/version/mod.rs
+++ b/packages/rs-platform-version/src/version/mod.rs
@@ -1,6 +1,6 @@
 mod protocol_version;
 
-use crate::version::v13::PROTOCOL_VERSION_13;
+use crate::version::v14::PROTOCOL_VERSION_14;
 pub use protocol_version::*;
 use std::ops::RangeInclusive;
 
@@ -19,6 +19,7 @@ pub mod v10;
 pub mod v11;
 pub mod v12;
 pub mod v13;
+pub mod v14;
 pub mod v2;
 pub mod v3;
 pub mod v4;
@@ -32,5 +33,5 @@ pub type ProtocolVersion = u32;
 
 pub const ALL_VERSIONS: RangeInclusive<ProtocolVersion> = 1..=LATEST_VERSION;
 
-pub const LATEST_VERSION: ProtocolVersion = PROTOCOL_VERSION_13;
+pub const LATEST_VERSION: ProtocolVersion = PROTOCOL_VERSION_14;
 pub const INITIAL_PROTOCOL_VERSION: ProtocolVersion = 1;

--- a/packages/rs-platform-version/src/version/protocol_version.rs
+++ b/packages/rs-platform-version/src/version/protocol_version.rs
@@ -21,6 +21,7 @@ use crate::version::v10::PLATFORM_V10;
 use crate::version::v11::PLATFORM_V11;
 use crate::version::v12::PLATFORM_V12;
 use crate::version::v13::PLATFORM_V13;
+use crate::version::v14::PLATFORM_V14;
 use crate::version::v2::PLATFORM_V2;
 use crate::version::v3::PLATFORM_V3;
 use crate::version::v4::PLATFORM_V4;
@@ -59,6 +60,7 @@ pub const PLATFORM_VERSIONS: &[PlatformVersion] = &[
     PLATFORM_V11,
     PLATFORM_V12,
     PLATFORM_V13,
+    PLATFORM_V14,
 ];
 
 #[cfg(feature = "mock-versions")]
@@ -67,7 +69,7 @@ pub static PLATFORM_TEST_VERSIONS: OnceLock<Vec<PlatformVersion>> = OnceLock::ne
 #[cfg(feature = "mock-versions")]
 const DEFAULT_PLATFORM_TEST_VERSIONS: &[PlatformVersion] = &[TEST_PLATFORM_V2, TEST_PLATFORM_V3];
 
-pub const LATEST_PLATFORM_VERSION: &PlatformVersion = &PLATFORM_V13;
+pub const LATEST_PLATFORM_VERSION: &PlatformVersion = &PLATFORM_V14;
 
 pub const DESIRED_PLATFORM_VERSION: &PlatformVersion = LATEST_PLATFORM_VERSION;
 

--- a/packages/rs-platform-version/src/version/v14.rs
+++ b/packages/rs-platform-version/src/version/v14.rs
@@ -1,0 +1,74 @@
+use crate::version::consensus_versions::ConsensusVersions;
+use crate::version::dpp_versions::dpp_asset_lock_versions::v1::DPP_ASSET_LOCK_VERSIONS_V1;
+use crate::version::dpp_versions::dpp_contract_versions::v5::CONTRACT_VERSIONS_V5;
+use crate::version::dpp_versions::dpp_costs_versions::v1::DPP_COSTS_VERSIONS_V1;
+use crate::version::dpp_versions::dpp_document_versions::v3::DOCUMENT_VERSIONS_V3;
+use crate::version::dpp_versions::dpp_factory_versions::v1::DPP_FACTORY_VERSIONS_V1;
+use crate::version::dpp_versions::dpp_identity_versions::v1::IDENTITY_VERSIONS_V1;
+use crate::version::dpp_versions::dpp_method_versions::v2::DPP_METHOD_VERSIONS_V2;
+use crate::version::dpp_versions::dpp_state_transition_conversion_versions::v2::STATE_TRANSITION_CONVERSION_VERSIONS_V2;
+use crate::version::dpp_versions::dpp_state_transition_method_versions::v1::STATE_TRANSITION_METHOD_VERSIONS_V1;
+use crate::version::dpp_versions::dpp_state_transition_serialization_versions::v2::STATE_TRANSITION_SERIALIZATION_VERSIONS_V2;
+use crate::version::dpp_versions::dpp_state_transition_versions::v3::STATE_TRANSITION_VERSIONS_V3;
+use crate::version::dpp_versions::dpp_token_versions::v2::TOKEN_VERSIONS_V2;
+use crate::version::dpp_versions::dpp_validation_versions::v4::DPP_VALIDATION_VERSIONS_V4;
+use crate::version::dpp_versions::dpp_voting_versions::v2::VOTING_VERSION_V2;
+use crate::version::dpp_versions::DPPVersion;
+use crate::version::drive_abci_versions::drive_abci_checkpoint_parameters::v1::DRIVE_ABCI_CHECKPOINT_PARAMETERS_V1;
+use crate::version::drive_abci_versions::drive_abci_method_versions::v9::DRIVE_ABCI_METHOD_VERSIONS_V9;
+use crate::version::drive_abci_versions::drive_abci_query_versions::v1::DRIVE_ABCI_QUERY_VERSIONS_V1;
+use crate::version::drive_abci_versions::drive_abci_structure_versions::v1::DRIVE_ABCI_STRUCTURE_VERSIONS_V1;
+use crate::version::drive_abci_versions::drive_abci_validation_versions::v9::DRIVE_ABCI_VALIDATION_VERSIONS_V9;
+use crate::version::drive_abci_versions::drive_abci_withdrawal_constants::v2::DRIVE_ABCI_WITHDRAWAL_CONSTANTS_V2;
+use crate::version::drive_abci_versions::DriveAbciVersion;
+use crate::version::drive_versions::v8::DRIVE_VERSION_V8;
+use crate::version::fee::v2::FEE_VERSION2;
+use crate::version::protocol_version::PlatformVersion;
+use crate::version::system_data_contract_versions::v2::SYSTEM_DATA_CONTRACT_VERSIONS_V2;
+use crate::version::system_limits::v3::SYSTEM_LIMITS_V3;
+use crate::version::ProtocolVersion;
+
+pub const PROTOCOL_VERSION_14: ProtocolVersion = 14;
+
+/// Introduced as the activation gate for the shared-prefix aggregate index
+/// fix (v2 document index walkers: an aggregating countable / summable index
+/// whose terminal property also prefixes a compound index registers today
+/// but rejects document inserts). Functionally identical to v13 at
+/// introduction — the same component version structs, no behavior change.
+/// The consensus change that consumes this gate (a bumped drive document
+/// methods struct) lands in a follow-up; keeping v14 == v13 here lets
+/// mixed-version validators agree until that change activates.
+pub const PLATFORM_V14: PlatformVersion = PlatformVersion {
+    protocol_version: PROTOCOL_VERSION_14,
+    drive: DRIVE_VERSION_V8,
+    drive_abci: DriveAbciVersion {
+        structs: DRIVE_ABCI_STRUCTURE_VERSIONS_V1,
+        methods: DRIVE_ABCI_METHOD_VERSIONS_V9,
+        validation_and_processing: DRIVE_ABCI_VALIDATION_VERSIONS_V9,
+        withdrawal_constants: DRIVE_ABCI_WITHDRAWAL_CONSTANTS_V2,
+        query: DRIVE_ABCI_QUERY_VERSIONS_V1,
+        checkpoints: DRIVE_ABCI_CHECKPOINT_PARAMETERS_V1,
+    },
+    dpp: DPPVersion {
+        costs: DPP_COSTS_VERSIONS_V1,
+        validation: DPP_VALIDATION_VERSIONS_V4,
+        state_transition_serialization_versions: STATE_TRANSITION_SERIALIZATION_VERSIONS_V2,
+        state_transition_conversion_versions: STATE_TRANSITION_CONVERSION_VERSIONS_V2,
+        state_transition_method_versions: STATE_TRANSITION_METHOD_VERSIONS_V1,
+        state_transitions: STATE_TRANSITION_VERSIONS_V3,
+        contract_versions: CONTRACT_VERSIONS_V5,
+        document_versions: DOCUMENT_VERSIONS_V3,
+        identity_versions: IDENTITY_VERSIONS_V1,
+        voting_versions: VOTING_VERSION_V2,
+        token_versions: TOKEN_VERSIONS_V2,
+        asset_lock_versions: DPP_ASSET_LOCK_VERSIONS_V1,
+        methods: DPP_METHOD_VERSIONS_V2,
+        factory_versions: DPP_FACTORY_VERSIONS_V1,
+    },
+    system_data_contracts: SYSTEM_DATA_CONTRACT_VERSIONS_V2,
+    fee_version: FEE_VERSION2,
+    system_limits: SYSTEM_LIMITS_V3,
+    consensus: ConsensusVersions {
+        tenderdash_consensus_version: 1,
+    },
+};


### PR DESCRIPTION
## Issue being fixed or feature implemented

Creates protocol version 14 as a standalone, behavior-free gate — the same pattern as #4143 (protocol version 13). The consensus change that consumes this gate is the shared-prefix aggregate index fix (#3960, currently #4265): an aggregating `countable` / `summable` index whose terminal property also prefixes a compound index registers today but rejects document inserts. That fix lands in a follow-up PR that bumps the drive document methods struct at v14.

## What was done?

Three files, mirroring the v13 introduction:

- `v14.rs`: `PLATFORM_V14` with the exact same component version structs as `PLATFORM_V13` — no behavior change at introduction, so mixed-version validators agree until a follow-up activates real changes.
- `protocol_version.rs`: registers `PLATFORM_V14` and moves `LATEST_PLATFORM_VERSION` to it.
- `version/mod.rs`: bumps `LATEST_VERSION` to `PROTOCOL_VERSION_14`, which also extends every bounded state-transition activation range (contract-create V1 `9..=LATEST`, address transitions `11..=LATEST`, shielded transitions `12..=LATEST`) to cover v14 — exactly as the v13 introduction did. This is consensus-safe: the ranges are checked against the runtime protocol version, so nothing changes for nodes running at v13 and below.

## How Has This Been Tested?

With v14 == v13, everything that passes at latest simply runs at 14: dpp (3806), rs-drive lib (3251) and drive-abci lib (2629) suites green on this branch.

## Breaking Changes

Adds a protocol version; nodes on binaries without v14 cannot participate once the network votes it in. Behavior at v14 is identical to v13 until a follow-up consumes the gate.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [ ] I have made corresponding changes to the documentation if needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
