### PR TITLE
fix(drive): derive wasm-drive-verify platform version cap from rs-platform-version

### DIFF
--- a/packages/wasm-drive-verify/src/utils/platform_version.rs
+++ b/packages/wasm-drive-verify/src/utils/platform_version.rs
@@ -1,75 +1,59 @@
 //! Platform version validation utilities
 
 use crate::utils::error::{format_error, ErrorCategory};
-use dpp::version::PlatformVersion;
+use dpp::version::{PlatformVersion, INITIAL_PROTOCOL_VERSION, LATEST_VERSION};
 use wasm_bindgen::JsValue;
 
 /// Minimum supported platform version
-pub const MIN_PLATFORM_VERSION: u32 = 1;
+pub const MIN_PLATFORM_VERSION: u32 = INITIAL_PROTOCOL_VERSION;
 
 /// Maximum supported platform version
-/// This should be updated when new versions are released
-pub const MAX_PLATFORM_VERSION: u32 = 9;
+pub const MAX_PLATFORM_VERSION: u32 = LATEST_VERSION;
 
 /// Validate and get a platform version with range checks
 pub fn get_platform_version_with_validation(
     version_number: u32,
 ) -> Result<&'static PlatformVersion, JsValue> {
-    // Range check
+    validate_platform_version(version_number)
+        .map_err(|details| format_error(ErrorCategory::PlatformVersionError, &details))
+}
+
+// JsValue-free so the range checks stay testable on non-wasm targets
+fn validate_platform_version(version_number: u32) -> Result<&'static PlatformVersion, String> {
     if version_number < MIN_PLATFORM_VERSION {
-        return Err(format_error(
-            ErrorCategory::PlatformVersionError,
-            &format!(
-                "platform version {} is below minimum supported version {}",
-                version_number, MIN_PLATFORM_VERSION
-            ),
+        return Err(format!(
+            "platform version {} is below minimum supported version {}",
+            version_number, MIN_PLATFORM_VERSION
         ));
     }
 
     if version_number > MAX_PLATFORM_VERSION {
-        return Err(format_error(
-            ErrorCategory::PlatformVersionError,
-            &format!(
-                "platform version {} exceeds maximum supported version {}",
-                version_number, MAX_PLATFORM_VERSION
-            ),
+        return Err(format!(
+            "platform version {} exceeds maximum supported version {}",
+            version_number, MAX_PLATFORM_VERSION
         ));
     }
 
-    // Get the version - this should not fail for valid range
-    PlatformVersion::get(version_number).map_err(|e| {
-        format_error(
-            ErrorCategory::PlatformVersionError,
-            &format!("failed to get platform version {}: {:?}", version_number, e),
-        )
-    })
+    PlatformVersion::get(version_number)
+        .map_err(|e| format!("failed to get platform version {}: {:?}", version_number, e))
 }
 
-#[cfg(all(test, target_arch = "wasm32"))]
+#[cfg(test)]
 mod tests {
     use super::*;
 
     #[test]
-    fn test_valid_platform_versions() {
-        // Test all valid versions
+    fn should_resolve_every_supported_platform_version() {
         for version in MIN_PLATFORM_VERSION..=MAX_PLATFORM_VERSION {
-            let result = get_platform_version_with_validation(version);
+            let result = validate_platform_version(version);
             assert!(result.is_ok(), "Version {} should be valid", version);
         }
     }
 
     #[test]
-    fn test_invalid_platform_versions() {
-        // Test below minimum
-        let result = get_platform_version_with_validation(0);
-        assert!(result.is_err());
-
-        // Test above maximum
-        let result = get_platform_version_with_validation(MAX_PLATFORM_VERSION + 1);
-        assert!(result.is_err());
-
-        // Test very large number
-        let result = get_platform_version_with_validation(u32::MAX);
-        assert!(result.is_err());
+    fn should_reject_platform_versions_outside_supported_range() {
+        assert!(validate_platform_version(MIN_PLATFORM_VERSION - 1).is_err());
+        assert!(validate_platform_version(MAX_PLATFORM_VERSION + 1).is_err());
+        assert!(validate_platform_version(u32::MAX).is_err());
     }
 }


### PR DESCRIPTION
## Issue being fixed or feature implemented

`packages/wasm-drive-verify` hardcoded `MAX_PLATFORM_VERSION = 9` while the workspace's latest protocol version is 13 (`rs-platform-version` `LATEST_VERSION`). `get_platform_version_with_validation` gates the wasm verify entry points (document and identity proof verification), so any caller passing platform versions 10–13 was rejected with "exceeds maximum supported version". Nothing in the crate is version-specific — 9 was simply the latest version when the file was written, and the constant went stale.

The associated unit tests couldn't catch the drift: besides looping up to the constant itself, they were gated `#[cfg(all(test, target_arch = "wasm32"))]` with plain `#[test]` — a combination neither the native test harness nor the wasm-bindgen test runner ever executes.

## What was done?

- Derive `MIN_PLATFORM_VERSION`/`MAX_PLATFORM_VERSION` from `rs-platform-version`'s `INITIAL_PROTOCOL_VERSION`/`LATEST_VERSION` (via `dpp::version` re-exports), so the cap moves with the workspace and can no longer drift. `PLATFORM_VERSIONS` is contiguous and `PlatformVersion::get` indexes `version - 1`, so the range check and the getter stay in agreement by construction.
- Split the range checks and version resolution into a private `JsValue`-free `validate_platform_version` helper; the public function is now a thin wrapper that maps error details through `format_error`. Error messages are unchanged. This is what makes the error path testable natively, since `JsValue` construction aborts on non-wasm targets.
- Un-gated the tests to plain `#[cfg(test)]` so they run in the native workspace test job (which strips `cdylib` and runs this crate under nextest). The valid-range test now genuinely resolves every version from 1 through `LATEST_VERSION`, so it fails loudly if `LATEST_VERSION` ever advances past the `PLATFORM_VERSIONS` list.

## How Has This Been Tested?

- `cargo test -p wasm-drive-verify --lib` — both new tests execute natively and pass (previously this module contributed zero running tests).
- `cargo check -p wasm-drive-verify --target wasm32-unknown-unknown` — the crate's real target still compiles.
- `cargo fmt --all --check` and `cargo clippy -p wasm-drive-verify` are clean.

## Breaking Changes

None. The public API is unchanged; versions 1–9 validate exactly as before, and 10–13 now validate instead of being rejected.

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [ ] I have made corresponding changes to the documentation if needed

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone

🤖 Generated with [Claude Code](https://claude.com/claude-code)