### PR TITLE
feat(dashmate): expose Tenderdash consensus DoS rate-limit knobs

### DIFF
--- a/packages/dashmate/configs/defaults/getBaseConfigFactory.js
+++ b/packages/dashmate/configs/defaults/getBaseConfigFactory.js
@@ -407,6 +407,9 @@ export default function getBaseConfigFactory() {
                 gossipSleepDuration: '100ms',
                 queryMaj23SleepDuration: '2s',
               },
+              verificationRateLimit: 300,
+              peerVoteRateLimit: 600,
+              peerDataRateLimit: 500,
               unsafeOverride: {
                 propose: {
                   timeout: null,

--- a/packages/dashmate/configs/getConfigFileMigrationsFactory.js
+++ b/packages/dashmate/configs/getConfigFileMigrationsFactory.js
@@ -1701,6 +1701,36 @@ export default function getConfigFileMigrationsFactory(homeDir, defaultConfigs) 
 
         return configFile;
       },
+      '4.2.0': (configFile) => {
+        // Backfill the Tenderdash consensus rate-limit defaults so a regenerated
+        // config.toml carries the new [consensus] keys. The schema now requires
+        // them, so an existing config that predates them would fail validation
+        // until it gains the values.
+        //
+        // Keyed at the release that ships these keys: the runner skips a
+        // migration whose version equals the operator's current version, so a
+        // key equal to the version an operator already runs never fires and only
+        // configs written before this release are backfilled.
+        Object.entries(configFile.configs)
+          .forEach(([name, options]) => {
+            const defaultConfig = getDefaultConfigByNameOrGroup(name, options.group);
+            const consensus = options.platform?.drive?.tenderdash?.consensus;
+            if (!consensus) {
+              return;
+            }
+            if (typeof consensus.verificationRateLimit === 'undefined') {
+              consensus.verificationRateLimit = defaultConfig.getStored('platform.drive.tenderdash.consensus.verificationRateLimit');
+            }
+            if (typeof consensus.peerVoteRateLimit === 'undefined') {
+              consensus.peerVoteRateLimit = defaultConfig.getStored('platform.drive.tenderdash.consensus.peerVoteRateLimit');
+            }
+            if (typeof consensus.peerDataRateLimit === 'undefined') {
+              consensus.peerDataRateLimit = defaultConfig.getStored('platform.drive.tenderdash.consensus.peerDataRateLimit');
+            }
+          });
+
+        return configFile;
+      },
     };
   }
 

--- a/packages/dashmate/src/config/configJsonSchema.js
+++ b/packages/dashmate/src/config/configJsonSchema.js
@@ -1211,6 +1211,18 @@ export default {
                       additionalProperties: false,
                       required: ['gossipSleepDuration', 'queryMaj23SleepDuration'],
                     },
+                    verificationRateLimit: {
+                      type: 'number',
+                      minimum: 0,
+                    },
+                    peerVoteRateLimit: {
+                      type: 'number',
+                      minimum: 0,
+                    },
+                    peerDataRateLimit: {
+                      type: 'number',
+                      minimum: 0,
+                    },
                     unsafeOverride: {
                       type: 'object',
                       properties: {
@@ -1259,7 +1271,7 @@ export default {
                     },
                   },
                   additionalProperties: false,
-                  required: ['createEmptyBlocks', 'createEmptyBlocksInterval', 'peer', 'unsafeOverride'],
+                  required: ['createEmptyBlocks', 'createEmptyBlocksInterval', 'peer', 'unsafeOverride', 'verificationRateLimit', 'peerVoteRateLimit', 'peerDataRateLimit'],
                 },
                 log: {
                   type: 'object',

--- a/packages/dashmate/templates/platform/drive/tenderdash/config.toml.dot
+++ b/packages/dashmate/templates/platform/drive/tenderdash/config.toml.dot
@@ -478,6 +478,13 @@ create-empty-blocks-interval = "{{= it.platform.drive.tenderdash.consensus.creat
 peer-gossip-sleep-duration = "{{= it.platform.drive.tenderdash.consensus.peer.gossipSleepDuration }}"
 peer-query-maj23-sleep-duration = "{{= it.platform.drive.tenderdash.consensus.peer.queryMaj23SleepDuration }}"
 
+# Per-peer vote-channel budget (verification-work/sec). 0 disables.
+peer-vote-rate-limit = {{= it.platform.drive.tenderdash.consensus.peerVoteRateLimit }}
+# Node-wide BLS verification budget (ops/sec). Must be 0 or >= 33.
+verification-rate-limit = {{= it.platform.drive.tenderdash.consensus.verificationRateLimit }}
+# Per-peer data-channel budget (verification-work/sec). 0 disables.
+peer-data-rate-limit = {{= it.platform.drive.tenderdash.consensus.peerDataRateLimit }}
+
 ### Unsafe Timeout Overrides ###
 
 # These fields provide temporary overrides for the Timeout consensus parameters.


### PR DESCRIPTION
## What

Exposes three Tenderdash `[consensus]` rate-limit knobs through dashmate so operators can override them from dashmate config. The keys map:

| TOML (`config.toml`) | dashmate (camelCase) | default |
|---|---|---|
| `verification-rate-limit` | `verificationRateLimit` | `300` |
| `peer-vote-rate-limit` | `peerVoteRateLimit` | `600` |
| `peer-data-rate-limit` | `peerDataRateLimit` | `500` |

These are node-wide / per-peer verification-work budgets used by Tenderdash's consensus DoS-hardening. They did not exist in dashmate before this PR (0 hits for all spellings).

## Why (this is prep, not urgent)

A Tenderdash node with these keys **omitted** falls back to its compiled-in defaults (`300 / 600 / 500`), because the generated `config.toml` is unmarshalled on top of the default config struct. So dashmate-managed nodes already run the correct defaults today, and **nothing here is required for a node or a devnet to run**. This PR is preparation so the limits can be *tuned* (e.g. limit sweeps) later without hand-editing `config.toml`.

## Changes (4 files, all in `packages/dashmate`)

1. **`templates/platform/drive/tenderdash/config.toml.dot`** — emit the three keys as bare numbers (they are floats) in the `[consensus]` block.
2. **`configs/defaults/getBaseConfigFactory.js`** — add the three defaults (`300 / 600 / 500`) to the `consensus` object.
3. **`src/config/configJsonSchema.js`** — add three `number` properties (`minimum: 0`) and extend the consensus `required` array. The consensus object is `additionalProperties: false`, so both the properties and the `required` edit are mandatory or a config carrying the keys fails validation.
4. **`configs/getConfigFileMigrationsFactory.js`** — a backfill migration so an existing (pre-this-release) config gains the now-required keys and keeps validating after upgrade.

Schema enforces only `minimum: 0`. The stricter "`0` or `>= 33`" rule for `verificationRateLimit` is left to Tenderdash's own `ValidateBasic` at node start, consistent with how dashmate treats other Tenderdash-validated numbers.

## ⚠️ Migration version placeholder — must fix before release

The migration is keyed at **`4.2.0`** as a **placeholder** for the release that will actually ship this change. `getConfigFormatVersion` makes the newest migration key the effective config-format version, so this key both drives the backfill and stamps the format. **Set this key to the real shipping dashmate version before merge/release.** Current `packages/dashmate` version is `4.1.0`.

## Verification

Full monorepo `yarn install` (Rust/wasm native builds) was not run in this environment. Instead the JS was checked directly:

- `node --check` on all three edited `.js` files — pass.
- Built the base config via `getBaseConfigFactory()` → `new Config('base', options)` **validates the defaults against the schema (Ajv)** on construction — pass (proves the defaults ⇄ schema `required`/`additionalProperties:false` edits are consistent).
- Simulated the backfill migration on a config with the keys removed, then re-applied via `Config.set` (re-validates) — result matches defaults `300 / 600 / 500` — pass.
- Negative control: a config missing `verificationRateLimit` is **rejected** by the schema with a `required` error — pass (confirms the `required` edit actually bites; the positive check is not tautological).

Recommend running `packages/dashmate` `yarn test:unit` in CI — in particular `test/unit/config/configFile/migrateConfigFileFactory.spec.js`, which migrates an old config fixture to the latest and asserts deep-equality with the freshly built default config (exercises the migration + defaults together).

## Dependency order

This is the top of a three-repo chain (prep only):

**platform (this PR) → a dashmate release carrying these keys → `dash-network-deploy` ansible plumbing → per-network `dash-network-configs` override.**

The downstream `dash-network-deploy` change is BLOCKED-ON a dashmate release that contains this PR (its `dashmate_version` must be bumped to that release). None of this blocks a first devnet, which runs the built-in defaults.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
