### PR TITLE
chore: fix rustfmt drift on v4.2-dev

### DIFF
--- a/packages/rs-platform-wallet-ffi/src/dashpay.rs
+++ b/packages/rs-platform-wallet-ffi/src/dashpay.rs
@@ -1334,9 +1334,7 @@ mod tests {
     fn get_managed_identity_unknown_wallet_is_invalid_handle() {
         let id = [0u8; 32];
         let mut out: Handle = 0;
-        let r = unsafe {
-            platform_wallet_get_managed_identity(0xDEAD_BEEF, id.as_ptr(), &mut out)
-        };
+        let r = unsafe { platform_wallet_get_managed_identity(0xDEAD_BEEF, id.as_ptr(), &mut out) };
         assert_eq!(r.code, PlatformWalletFFIResultCode::ErrorInvalidHandle);
         assert_eq!(out, 0, "out handle is untouched on an invalid-handle miss");
     }

--- a/packages/rs-sdk-ffi/src/signer.rs
+++ b/packages/rs-sdk-ffi/src/signer.rs
@@ -746,7 +746,9 @@ pub unsafe extern "C" fn dash_sdk_sign_async_completion(
             // to begin with the marker would otherwise impersonate a typed
             // completion, so disambiguate it by pushing the marker off
             // position 0 (dashpay/platform#4183 review).
-            Err(ProtocolError::Generic(format!("generic_signer_error: {msg}")))
+            Err(ProtocolError::Generic(format!(
+                "generic_signer_error: {msg}"
+            )))
         } else {
             Err(ProtocolError::Generic(msg))
         }
@@ -1348,7 +1350,13 @@ mod tests {
         completion(completion_ctx, std::ptr::null(), 0, 0, err_msg.as_ptr());
         // Duplicate success payload — still a no-op.
         let sig2 = [0x99u8; 64];
-        completion(completion_ctx, sig2.as_ptr(), sig2.len(), 0, std::ptr::null());
+        completion(
+            completion_ctx,
+            sig2.as_ptr(),
+            sig2.len(),
+            0,
+            std::ptr::null(),
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Issue being fixed or feature implemented

`cargo fmt --check --all` fails on the current `v4.2-dev` head (verified on a clean checkout of `7afc8a8ff3`) with three diffs in `packages/rs-platform-wallet-ffi/src/dashpay.rs` and `packages/rs-sdk-ffi/src/signer.rs`, introduced by recently merged kotlin-sdk FFI PRs. Since CI builds each PR's merge ref against the branch head, the `Rust workspace tests / Tests (macOS)` formatting step currently fails for **every** open PR targeting `v4.2-dev` (e.g. it just failed on #4276, which touches neither file).

## What was done?

`cargo fmt -p rs-sdk-ffi -p platform-wallet-ffi` — the tool's own output, nothing else. `cargo fmt --all --check` is clean afterwards.

## How Has This Been Tested?

Formatting-only change; `cargo fmt --all --check` passes on the branch.

## Breaking Changes

None.

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
- [x] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone

🤖 Generated with [Claude Code](https://claude.com/claude-code)