### PR TITLE
ci: install Rust lint components for workspace tests

### DIFF
--- a/.github/workflows/tests-rs-workspace.yml
+++ b/.github/workflows/tests-rs-workspace.yml
@@ -113,7 +113,7 @@ jobs:
         uses: ./.github/actions/rust
         with:
           cache: false
-          components: llvm-tools
+          components: llvm-tools, rustfmt, clippy
 
       - name: Install cargo-llvm-cov
         run: cargo install cargo-llvm-cov 2>/dev/null || true


### PR DESCRIPTION
## Summary
- install `rustfmt` and `clippy` with the workspace test toolchain
- retain the existing `llvm-tools` component
- make clean and newly provisioned self-hosted runners independent of preinstalled lint components

## Verification
- `cargo fmt --check --all` resolves with Rust 1.92 on `ubuntu-runner-1`
- `cargo clippy --version` resolves with Rust 1.92 on `ubuntu-runner-1`
- a post-install Rust workspace rerun passed formatting and Clippy and progressed into nextest

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced automated checks to include Rust formatting and lint validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->