### PR TITLE
fix(sdk): point parity manifest at the renamed identity-resume test

### DIFF
--- a/docs/sdk/sdk-parity-manifest.json
+++ b/docs/sdk/sdk-parity-manifest.json
@@ -630,7 +630,7 @@
           "host": "swift",
           "kind": "unit",
           "file": "packages/swift-sdk/SwiftExampleApp/SwiftExampleAppTests/CreateIdentityResumableTests.swift",
-          "id": "testInvitationVouchersAreExcludedFromResumableList",
+          "id": "testFundingTypeGateAcceptsOnlyGenericIdentityResumeTypes",
           "command": "xcodebuild test -project packages/swift-sdk/SwiftExampleApp/SwiftExampleApp.xcodeproj -scheme SwiftExampleApp",
           "covers_restart": false
         },


### PR DESCRIPTION
## Issue being fixed or feature implemented
#4015 renamed `testInvitationVouchersAreExcludedFromResumableList` to `testFundingTypeGateAcceptsOnlyGenericIdentityResumeTypes` in `CreateIdentityResumableTests.swift` but left the old id in `docs/sdk/sdk-parity-manifest.json`, so `check_sdk_parity_manifest.py` fails the "Kotlin SDK build + tests" job on every PR targeting v4.2-dev (first seen on #4300's run).

## What was done?
Updated the `identity.asset_lock_resume` capability's Swift unit verification id to the renamed test.

## How Has This Been Tested?
`python3 scripts/check_sdk_parity_manifest.py` (now reports "SDK parity manifest OK: 22 capabilities; summary current") and `python3 -m unittest discover -s scripts/tests -p 'test_*.py'` (11 tests OK).

## Breaking Changes
None.

## Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [x] I have made corresponding changes to the documentation if needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)