### PR TITLE
fix(dashmate): extend Core shutdown grace period

### DIFF
--- a/packages/dashmate/docker-compose.yml
+++ b/packages/dashmate/docker-compose.yml
@@ -41,7 +41,7 @@ services:
       - ${DASHMATE_HOME_DIR:?err}/${CONFIG_NAME:?err}/core/dash.conf:/home/dash/.dashcore/dash.conf:ro
     command:
       - dashd
-    stop_grace_period: 30s
+    stop_grace_period: 120s
     environment:
       # Solving issue under WSL when after restart container volume is not being mounted properly
       # https://github.com/docker/for-win/issues/4812


### PR DESCRIPTION
## Issue being fixed or feature implemented

Dashmate currently gives Dash Core 30 seconds to stop before Docker sends SIGKILL. Core shutdown can exceed that deadline while flushing a large UTXO cache, reindexing, repairing EvoDB, or waiting for background load/repair work, risking an unclean shutdown.

The original grace-period implementation deliberately used fixed per-service Compose values instead of adding user-facing configuration. This keeps that design and increases only Core's deadline.

## What was done?

Increased the Core service's `stop_grace_period` from 30 seconds to 120 seconds. Other service shutdown deadlines are unchanged.

## How Has This Been Tested?

- Parsed `packages/dashmate/docker-compose.yml` as YAML and verified `services.core.stop_grace_period` is `120s`
- Validated that Docker Compose v5.1.2 accepts `stop_grace_period: 120s`
- Ran `git diff --check upstream/v4.2-dev`
- Ran the exact-head pre-PR review gate (`ship`, 0 findings)

A live Core shutdown under reindex/repair load was not reproduced locally; CI will exercise the normal Dashmate test suites.

## Breaking Changes

None.

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [ ] I have made corresponding changes to the documentation if needed

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved service shutdown reliability by allowing more time for graceful stopping.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->