### PR TITLE
feat(swift-sdk): typed DPNS contested-name browsing for voters

### DIFF
--- a/packages/swift-sdk/Sources/SwiftDashSDK/Voting/DPNSContest.swift
+++ b/packages/swift-sdk/Sources/SwiftDashSDK/Voting/DPNSContest.swift
@@ -5,83 +5,84 @@ import Foundation
 /// A contested-resource vote poll is addressed by
 /// `(contract_id, document_type_name, index_name, index_values)`. For DPNS
 /// username contests every component except the label is fixed, so the read
-/// queries and ``SDK/castContestedResourceVote(dataContractId:documentTypeName:indexName:indexValues:choice:proTxHash:votingPrivateKey:)``
-/// can share one definition instead of each caller re-spelling the strings.
+/// queries and
+/// ``SDK/castContestedResourceVote(dataContractId:documentTypeName:indexName:indexValues:choice:proTxHash:votingPrivateKey:)``
+/// share one definition instead of each caller re-spelling the strings.
 public enum DPNSVotePoll {
-    /// Base58 id of the DPNS system data contract (`dpns_contract::ID_BYTES`).
-    public static let contractId = "GWRSAVFMjXx8HpQFaNJMqBV7MBgMK4br5UESsB4S31Ec"
-    /// The contested document type.
-    public static let documentTypeName = "domain"
-    /// The contested index on `domain`
-    /// (`normalizedParentDomainName` + `normalizedLabel`).
-    public static let indexName = "parentNameAndLabel"
-    /// First index value — the parent domain every DPNS username sits under.
-    public static let parentDomain = "dash"
+  /// Base58 id of the DPNS system data contract (`dpns_contract::ID_BYTES`).
+  public static let contractId = "GWRSAVFMjXx8HpQFaNJMqBV7MBgMK4br5UESsB4S31Ec"
+  /// The contested document type.
+  public static let documentTypeName = "domain"
+  /// The contested index on `domain`
+  /// (`normalizedParentDomainName` + `normalizedLabel`).
+  public static let indexName = "parentNameAndLabel"
+  /// First index value — the parent domain every DPNS username sits under.
+  public static let parentDomain = "dash"
 
-    /// Index values addressing one label's poll: `["dash", <normalized label>]`.
-    ///
-    /// - Important: `normalizedLabel` must already be homograph-normalized
-    ///   (`alice` → `a11ce`). Platform indexes polls under the normalized form
-    ///   only, so passing a raw label silently addresses a poll that does not
-    ///   exist. Use ``SDK/dpnsNormalizeLabel(_:)``.
-    public static func indexValues(normalizedLabel: String) -> [String] {
-        [parentDomain, normalizedLabel]
-    }
+  /// Index values addressing one label's poll: `["dash", <normalized label>]`.
+  ///
+  /// - Important: `normalizedLabel` must already be homograph-normalized
+  ///   (`alice` → `a11ce`). Platform indexes polls under the normalized form
+  ///   only, so passing a raw label silently addresses a poll that does not
+  ///   exist. Use ``SDK/dpnsNormalizeLabel(_:)``.
+  public static func indexValues(normalizedLabel: String) -> [String] {
+    [parentDomain, normalizedLabel]
+  }
 }
 
 /// One open DPNS username contest, as returned by
 /// ``SDK/dpnsActiveContests(limit:)``.
 public struct DPNSContest: Sendable, Identifiable, Equatable {
-    /// The contested label in its normalized (homograph-safe) form — this is
-    /// the form Platform indexes, and the form to pass back when voting.
-    public let normalizedLabel: String
-    /// End of the voting period, or `nil` when the FFI reported no end time.
-    /// Modeled as optional rather than defaulted so callers can render
-    /// "unknown" instead of a fabricated deadline.
-    public let endTime: Date?
-    /// Whether Platform has already resolved this contest. Active listings
-    /// normally report `false`; a `true` here means the contest resolved
-    /// between the poll list and the tally read.
-    public let hasWinner: Bool
-    /// Masternode votes cast to abstain.
-    public let abstainVotes: UInt32
-    /// Masternode votes cast to lock the name (nobody wins).
-    public let lockVotes: UInt32
-    /// Contenders and their tallies, in the order the FFI returned them.
-    public let contenders: [DPNSContender]
+  /// The contested label in its normalized (homograph-safe) form — this is
+  /// the form Platform indexes, and the form to pass back when voting.
+  public let normalizedLabel: String
+  /// End of the voting period, or `nil` when the FFI reported no end time.
+  /// Modeled as optional rather than defaulted so callers can render
+  /// "unknown" instead of a fabricated deadline.
+  public let endTime: Date?
+  /// Whether Platform has already resolved this contest. Active listings
+  /// normally report `false`; a `true` here means the contest resolved
+  /// between the poll list and the tally read.
+  public let hasWinner: Bool
+  /// Masternode votes cast to abstain.
+  public let abstainVotes: UInt32
+  /// Masternode votes cast to lock the name (nobody wins).
+  public let lockVotes: UInt32
+  /// Contenders and their tallies, in the order the FFI returned them.
+  public let contenders: [DPNSContender]
 
-    public var id: String { normalizedLabel }
+  public var id: String { normalizedLabel }
 
-    public init(
-        normalizedLabel: String,
-        endTime: Date?,
-        hasWinner: Bool,
-        abstainVotes: UInt32,
-        lockVotes: UInt32,
-        contenders: [DPNSContender]
-    ) {
-        self.normalizedLabel = normalizedLabel
-        self.endTime = endTime
-        self.hasWinner = hasWinner
-        self.abstainVotes = abstainVotes
-        self.lockVotes = lockVotes
-        self.contenders = contenders
-    }
+  public init(
+    normalizedLabel: String,
+    endTime: Date?,
+    hasWinner: Bool,
+    abstainVotes: UInt32,
+    lockVotes: UInt32,
+    contenders: [DPNSContender]
+  ) {
+    self.normalizedLabel = normalizedLabel
+    self.endTime = endTime
+    self.hasWinner = hasWinner
+    self.abstainVotes = abstainVotes
+    self.lockVotes = lockVotes
+    self.contenders = contenders
+  }
 
-    /// Total masternode voting weight recorded so far across contenders,
-    /// abstain and lock. Tallies are weighted by node type on the Platform
-    /// side (regular masternode 1, evonode 4), so this is a weight, not a
-    /// count of nodes.
-    public var totalVotes: UInt32 {
-        contenders.reduce(UInt32(0)) { $0 &+ $1.voteTally } &+ abstainVotes &+ lockVotes
-    }
+  /// Total masternode voting weight recorded so far across contenders,
+  /// abstain and lock. Tallies are weighted by node type on the Platform
+  /// side (regular masternode 1, evonode 4), so this is a weight, not a
+  /// count of nodes.
+  public var totalVotes: UInt32 {
+    contenders.reduce(UInt32(0)) { $0 &+ $1.voteTally } &+ abstainVotes &+ lockVotes
+  }
 
-    /// The contender with the highest tally, or `nil` when there are none.
-    /// Ties resolve to the first in FFI order — callers that care about tie
-    /// display should inspect ``contenders`` directly.
-    public var leadingContender: DPNSContender? {
-        contenders.max { $0.voteTally < $1.voteTally }
-    }
+  /// The contender with the highest tally, or `nil` when there are none.
+  /// Ties resolve to the first in FFI order — callers that care about tie
+  /// display should inspect ``contenders`` directly.
+  public var leadingContender: DPNSContender? {
+    contenders.max { $0.voteTally < $1.voteTally }
+  }
 }
 
 /// One contender for a contested DPNS label.
@@ -93,29 +94,37 @@ public struct DPNSContest: Sendable, Identifiable, Equatable {
 ///   Render ``identityId`` (truncated) alongside the contest's normalized
 ///   label instead.
 public struct DPNSContender: Sendable, Identifiable, Equatable {
-    /// Base58 identity id of the contender.
-    public let identityId: String
-    /// Masternode voting weight cast towards this contender.
-    public let voteTally: UInt32
+  /// Base58 identity id of the contender.
+  public let identityId: String
+  /// Masternode voting weight cast towards this contender.
+  public let voteTally: UInt32
 
-    public var id: String { identityId }
+  public var id: String { identityId }
 
-    public init(identityId: String, voteTally: UInt32) {
-        self.identityId = identityId
-        self.voteTally = voteTally
-    }
+  public init(identityId: String, voteTally: UInt32) {
+    self.identityId = identityId
+    self.voteTally = voteTally
+  }
 }
 
 /// How a contest stands, as reported by the vote-state query.
+///
+/// Platform attaches winner info to a contest **only once the poll has
+/// finished** — `Contenders.winner` is `Option<(winner_info,
+/// finished_at_block_info)>`, and drive-abci wraps every variant, `NoWinner`
+/// included, in a `FinishedVoteInfo`. So the presence of winner info, not its
+/// value, is what separates a live contest from a settled one.
 public enum DPNSContestOutcome: Sendable, Equatable {
-    /// Voting is still open — Platform reported no winner info.
-    case ongoing
-    /// Platform reported winner info but with no winner selected.
-    case noWinner
-    /// The label was awarded to this base58 identity id.
-    case wonBy(String)
-    /// Masternodes locked the label; nobody wins it.
-    case locked
+  /// Voting is still open — Platform reported no winner info at all.
+  case ongoing
+  /// The poll **finished** without awarding the name to anyone and without
+  /// being locked (drive-abci's `FinishedVoteOutcome::NoPreviousWinner`).
+  /// This is a settled contest, not a running one.
+  case noWinner
+  /// The label was awarded to this base58 identity id.
+  case wonBy(String)
+  /// Masternodes locked the label; nobody wins it.
+  case locked
 }
 
 /// Full vote state for a single contest, from
@@ -124,37 +133,42 @@ public enum DPNSContestOutcome: Sendable, Equatable {
 /// Unlike ``DPNSContest`` this carries the resolution outcome, at the cost of
 /// one query per contest.
 public struct DPNSContestVoteState: Sendable, Equatable {
-    /// The normalized label this state describes.
-    public let normalizedLabel: String
-    public let contenders: [DPNSContender]
-    public let abstainVotes: UInt32
-    public let lockVotes: UInt32
-    public let outcome: DPNSContestOutcome
-    /// Block time at which the contest resolved. Present only alongside a
-    /// resolved ``outcome``.
-    public let resolvedAt: Date?
+  /// The normalized label this state describes.
+  public let normalizedLabel: String
+  public let contenders: [DPNSContender]
+  public let abstainVotes: UInt32
+  public let lockVotes: UInt32
+  public let outcome: DPNSContestOutcome
+  /// Block time at which the contest resolved. Present only alongside a
+  /// resolved ``outcome``.
+  public let resolvedAt: Date?
 
-    public init(
-        normalizedLabel: String,
-        contenders: [DPNSContender],
-        abstainVotes: UInt32,
-        lockVotes: UInt32,
-        outcome: DPNSContestOutcome,
-        resolvedAt: Date?
-    ) {
-        self.normalizedLabel = normalizedLabel
-        self.contenders = contenders
-        self.abstainVotes = abstainVotes
-        self.lockVotes = lockVotes
-        self.outcome = outcome
-        self.resolvedAt = resolvedAt
-    }
+  public init(
+    normalizedLabel: String,
+    contenders: [DPNSContender],
+    abstainVotes: UInt32,
+    lockVotes: UInt32,
+    outcome: DPNSContestOutcome,
+    resolvedAt: Date?
+  ) {
+    self.normalizedLabel = normalizedLabel
+    self.contenders = contenders
+    self.abstainVotes = abstainVotes
+    self.lockVotes = lockVotes
+    self.outcome = outcome
+    self.resolvedAt = resolvedAt
+  }
 
-    /// `true` once Platform has picked a winner or locked the label.
-    public var isResolved: Bool {
-        switch outcome {
-        case .ongoing, .noWinner: return false
-        case .wonBy, .locked: return true
-        }
+  /// `true` once the poll has finished, whatever the outcome.
+  ///
+  /// ``DPNSContestOutcome/noWinner`` counts as resolved: Platform only emits
+  /// winner info for a finished poll, so treating it as unresolved would let
+  /// ``SDK/dpnsContestIsOpen(normalizedLabel:)`` report a settled contest as
+  /// still open and send a vote into a poll that can no longer accept it.
+  public var isResolved: Bool {
+    switch outcome {
+    case .ongoing: return false
+    case .noWinner, .wonBy, .locked: return true
     }
+  }
 }

--- a/packages/swift-sdk/Sources/SwiftDashSDK/Voting/DPNSContest.swift
+++ b/packages/swift-sdk/Sources/SwiftDashSDK/Voting/DPNSContest.swift
@@ -1,0 +1,160 @@
+import Foundation
+
+/// Constants identifying the DPNS contested-username vote poll.
+///
+/// A contested-resource vote poll is addressed by
+/// `(contract_id, document_type_name, index_name, index_values)`. For DPNS
+/// username contests every component except the label is fixed, so the read
+/// queries and ``SDK/castContestedResourceVote(dataContractId:documentTypeName:indexName:indexValues:choice:proTxHash:votingPrivateKey:)``
+/// can share one definition instead of each caller re-spelling the strings.
+public enum DPNSVotePoll {
+    /// Base58 id of the DPNS system data contract (`dpns_contract::ID_BYTES`).
+    public static let contractId = "GWRSAVFMjXx8HpQFaNJMqBV7MBgMK4br5UESsB4S31Ec"
+    /// The contested document type.
+    public static let documentTypeName = "domain"
+    /// The contested index on `domain`
+    /// (`normalizedParentDomainName` + `normalizedLabel`).
+    public static let indexName = "parentNameAndLabel"
+    /// First index value — the parent domain every DPNS username sits under.
+    public static let parentDomain = "dash"
+
+    /// Index values addressing one label's poll: `["dash", <normalized label>]`.
+    ///
+    /// - Important: `normalizedLabel` must already be homograph-normalized
+    ///   (`alice` → `a11ce`). Platform indexes polls under the normalized form
+    ///   only, so passing a raw label silently addresses a poll that does not
+    ///   exist. Use ``SDK/dpnsNormalizeLabel(_:)``.
+    public static func indexValues(normalizedLabel: String) -> [String] {
+        [parentDomain, normalizedLabel]
+    }
+}
+
+/// One open DPNS username contest, as returned by
+/// ``SDK/dpnsActiveContests(limit:)``.
+public struct DPNSContest: Sendable, Identifiable, Equatable {
+    /// The contested label in its normalized (homograph-safe) form — this is
+    /// the form Platform indexes, and the form to pass back when voting.
+    public let normalizedLabel: String
+    /// End of the voting period, or `nil` when the FFI reported no end time.
+    /// Modeled as optional rather than defaulted so callers can render
+    /// "unknown" instead of a fabricated deadline.
+    public let endTime: Date?
+    /// Whether Platform has already resolved this contest. Active listings
+    /// normally report `false`; a `true` here means the contest resolved
+    /// between the poll list and the tally read.
+    public let hasWinner: Bool
+    /// Masternode votes cast to abstain.
+    public let abstainVotes: UInt32
+    /// Masternode votes cast to lock the name (nobody wins).
+    public let lockVotes: UInt32
+    /// Contenders and their tallies, in the order the FFI returned them.
+    public let contenders: [DPNSContender]
+
+    public var id: String { normalizedLabel }
+
+    public init(
+        normalizedLabel: String,
+        endTime: Date?,
+        hasWinner: Bool,
+        abstainVotes: UInt32,
+        lockVotes: UInt32,
+        contenders: [DPNSContender]
+    ) {
+        self.normalizedLabel = normalizedLabel
+        self.endTime = endTime
+        self.hasWinner = hasWinner
+        self.abstainVotes = abstainVotes
+        self.lockVotes = lockVotes
+        self.contenders = contenders
+    }
+
+    /// Total masternode voting weight recorded so far across contenders,
+    /// abstain and lock. Tallies are weighted by node type on the Platform
+    /// side (regular masternode 1, evonode 4), so this is a weight, not a
+    /// count of nodes.
+    public var totalVotes: UInt32 {
+        contenders.reduce(UInt32(0)) { $0 &+ $1.voteTally } &+ abstainVotes &+ lockVotes
+    }
+
+    /// The contender with the highest tally, or `nil` when there are none.
+    /// Ties resolve to the first in FFI order — callers that care about tie
+    /// display should inspect ``contenders`` directly.
+    public var leadingContender: DPNSContender? {
+        contenders.max { $0.voteTally < $1.voteTally }
+    }
+}
+
+/// One contender for a contested DPNS label.
+///
+/// - Note: The contender's label exactly as *they* requested it is not
+///   exposed. Platform returns it only inside the serialized `domain`
+///   document, which the FFI hands over as opaque hex; decoding it needs the
+///   contract's document-type schema and is not done on the Swift side.
+///   Render ``identityId`` (truncated) alongside the contest's normalized
+///   label instead.
+public struct DPNSContender: Sendable, Identifiable, Equatable {
+    /// Base58 identity id of the contender.
+    public let identityId: String
+    /// Masternode voting weight cast towards this contender.
+    public let voteTally: UInt32
+
+    public var id: String { identityId }
+
+    public init(identityId: String, voteTally: UInt32) {
+        self.identityId = identityId
+        self.voteTally = voteTally
+    }
+}
+
+/// How a contest stands, as reported by the vote-state query.
+public enum DPNSContestOutcome: Sendable, Equatable {
+    /// Voting is still open — Platform reported no winner info.
+    case ongoing
+    /// Platform reported winner info but with no winner selected.
+    case noWinner
+    /// The label was awarded to this base58 identity id.
+    case wonBy(String)
+    /// Masternodes locked the label; nobody wins it.
+    case locked
+}
+
+/// Full vote state for a single contest, from
+/// ``SDK/dpnsContestVoteState(normalizedLabel:limit:)``.
+///
+/// Unlike ``DPNSContest`` this carries the resolution outcome, at the cost of
+/// one query per contest.
+public struct DPNSContestVoteState: Sendable, Equatable {
+    /// The normalized label this state describes.
+    public let normalizedLabel: String
+    public let contenders: [DPNSContender]
+    public let abstainVotes: UInt32
+    public let lockVotes: UInt32
+    public let outcome: DPNSContestOutcome
+    /// Block time at which the contest resolved. Present only alongside a
+    /// resolved ``outcome``.
+    public let resolvedAt: Date?
+
+    public init(
+        normalizedLabel: String,
+        contenders: [DPNSContender],
+        abstainVotes: UInt32,
+        lockVotes: UInt32,
+        outcome: DPNSContestOutcome,
+        resolvedAt: Date?
+    ) {
+        self.normalizedLabel = normalizedLabel
+        self.contenders = contenders
+        self.abstainVotes = abstainVotes
+        self.lockVotes = lockVotes
+        self.outcome = outcome
+        self.resolvedAt = resolvedAt
+    }
+
+    /// `true` once Platform has picked a winner or locked the label.
+    public var isResolved: Bool {
+        switch outcome {
+        case .ongoing, .noWinner: return false
+        case .wonBy, .locked: return true
+        }
+    }
+}

--- a/packages/swift-sdk/Sources/SwiftDashSDK/Voting/SDK+DPNSContests.swift
+++ b/packages/swift-sdk/Sources/SwiftDashSDK/Voting/SDK+DPNSContests.swift
@@ -22,239 +22,230 @@ import DashSDKFFI
 @MainActor
 extension SDK {
 
-    // MARK: - Label normalization
+  // MARK: - Label normalization
 
-    /// Homograph-normalize a DPNS label the way Platform does before indexing
-    /// it (`o` → `0`, `i`/`l` → `1`, lowercased): `"Alice"` → `"a11ce"`.
-    ///
-    /// Every read and write that addresses a vote poll by label must use the
-    /// normalized form — Platform stores nothing under the raw form. Falls
-    /// back to a local lowercase+substitute mapping only if the FFI call
-    /// fails, so a transient failure cannot silently produce an un-normalized
-    /// label that addresses a non-existent poll.
-    public func dpnsNormalizeLabel(_ label: String) -> String {
-        let result = label.withCString { dash_sdk_dpns_normalize_username($0) }
+  /// Homograph-normalize a DPNS label the way Platform does before indexing
+  /// it (`o` → `0`, `i`/`l` → `1`, lowercased): `"Alice"` → `"a11ce"`.
+  ///
+  /// Every read and write that addresses a vote poll by label must use the
+  /// normalized form — Platform stores nothing under the raw form.
+  ///
+  /// Normalization is protocol behavior and is owned by Rust
+  /// (`dash_sdk::platform::dpns_usernames::convert_to_homograph_safe_chars`,
+  /// reached through `dash_sdk_dpns_normalize_username`). This throws rather
+  /// than falling back to a Swift reimplementation: a second copy of the
+  /// mapping would drift from the canonical one and silently address a poll
+  /// that does not exist.
+  public func dpnsNormalizeLabel(_ label: String) throws -> String {
+    let result = label.withCString { dash_sdk_dpns_normalize_username($0) }
 
-        if let error = result.error {
-            dash_sdk_error_free(error)
-            return Self.locallyNormalizedLabel(label)
-        }
-        guard let dataPtr = result.data else {
-            return Self.locallyNormalizedLabel(label)
-        }
-
-        let normalized = String(cString: dataPtr.assumingMemoryBound(to: CChar.self))
-        dash_sdk_string_free(dataPtr.assumingMemoryBound(to: CChar.self))
-        return normalized
+    if let error = result.error {
+      let sdkError = SDKError.fromDashSDKError(error.pointee)
+      dash_sdk_error_free(error)
+      throw sdkError
+    }
+    guard let dataPtr = result.data else {
+      throw SDKError.internalError("DPNS normalization returned no data")
     }
 
-    /// Mirror of `convert_to_homograph_safe_chars` for callers that have no
-    /// live SDK handle — search filtering, for instance, must normalize the
-    /// user's typing the same way to match normalized labels. Kept in lockstep
-    /// with `dash_sdk::platform::dpns_usernames::convert_to_homograph_safe_chars`.
-    ///
-    /// Prefer ``dpnsNormalizeLabel(_:)`` whenever a handle exists: that asks
-    /// Rust, so it cannot drift.
-    public nonisolated static func locallyNormalizedLabel(_ label: String) -> String {
-        String(label.lowercased().map { character in
-            switch character {
-            case "o": return "0"
-            case "i", "l": return "1"
-            default: return character
-            }
-        })
+    let normalized = String(cString: dataPtr.assumingMemoryBound(to: CChar.self))
+    dash_sdk_string_free(dataPtr.assumingMemoryBound(to: CChar.self))
+    return normalized
+  }
+
+  // MARK: - Active contests
+
+  /// Every DPNS username contest that is still open, with its contenders,
+  /// tallies and end time.
+  ///
+  /// One round trip. Reads the FFI's `DashSDKContestedNamesList` structure
+  /// directly, so contender tallies arrive as integers.
+  ///
+  /// - Parameter limit: Maximum contests to return. The FFI has no
+  ///   start-after cursor on this query, so this is a hard ceiling, not a
+  ///   page size — raise it rather than trying to page.
+  /// - Returns: Contests sorted by normalized label. Empty when nothing is
+  ///   contested.
+  public func dpnsActiveContests(limit: UInt32 = 200) throws -> [DPNSContest] {
+    guard let handle = handle else {
+      throw SDKError.invalidState("SDK not initialized")
     }
 
-    // MARK: - Active contests
+    guard let listPtr = dash_sdk_dpns_get_contested_non_resolved_usernames(handle, limit) else {
+      throw SDKError.internalError("Failed to fetch contested DPNS usernames")
+    }
+    defer { dash_sdk_contested_names_list_free(listPtr) }
 
-    /// Every DPNS username contest that is still open, with its contenders,
-    /// tallies and end time.
-    ///
-    /// One round trip. Reads the FFI's `DashSDKContestedNamesList` structure
-    /// directly, so contender tallies arrive as integers.
-    ///
-    /// - Parameter limit: Maximum contests to return. The FFI has no
-    ///   start-after cursor on this query, so this is a hard ceiling, not a
-    ///   page size — raise it rather than trying to page.
-    /// - Returns: Contests sorted by normalized label. Empty when nothing is
-    ///   contested.
-    public func dpnsActiveContests(limit: UInt32 = 200) throws -> [DPNSContest] {
-        guard let handle = handle else {
-            throw SDKError.invalidState("SDK not initialized")
+    let list = listPtr.pointee
+    guard list.count > 0, let namesPtr = list.names else { return [] }
+
+    var contests: [DPNSContest] = []
+    contests.reserveCapacity(Int(list.count))
+
+    for index in 0..<Int(list.count) {
+      let entry = namesPtr[index]
+      guard let namePtr = entry.name else { continue }
+      let normalizedLabel = String(cString: namePtr)
+
+      let info = entry.contest_info
+      var contenders: [DPNSContender] = []
+      if info.contender_count > 0, let contendersPtr = info.contenders {
+        contenders.reserveCapacity(Int(info.contender_count))
+        for contenderIndex in 0..<Int(info.contender_count) {
+          let contender = contendersPtr[contenderIndex]
+          guard let idPtr = contender.identity_id else { continue }
+          contenders.append(
+            DPNSContender(
+              identityId: String(cString: idPtr),
+              voteTally: contender.vote_count))
         }
+      }
 
-        guard let listPtr = dash_sdk_dpns_get_contested_non_resolved_usernames(handle, limit) else {
-            throw SDKError.internalError("Failed to fetch contested DPNS usernames")
-        }
-        defer { dash_sdk_contested_names_list_free(listPtr) }
-
-        let list = listPtr.pointee
-        guard list.count > 0, let namesPtr = list.names else { return [] }
-
-        var contests: [DPNSContest] = []
-        contests.reserveCapacity(Int(list.count))
-
-        for index in 0..<Int(list.count) {
-            let entry = namesPtr[index]
-            guard let namePtr = entry.name else { continue }
-            let normalizedLabel = String(cString: namePtr)
-
-            let info = entry.contest_info
-            var contenders: [DPNSContender] = []
-            if info.contender_count > 0, let contendersPtr = info.contenders {
-                contenders.reserveCapacity(Int(info.contender_count))
-                for contenderIndex in 0..<Int(info.contender_count) {
-                    let contender = contendersPtr[contenderIndex]
-                    guard let idPtr = contender.identity_id else { continue }
-                    contenders.append(
-                        DPNSContender(
-                            identityId: String(cString: idPtr),
-                            voteTally: contender.vote_count))
-                }
-            }
-
-            contests.append(
-                DPNSContest(
-                    normalizedLabel: normalizedLabel,
-                    // `end_time` is milliseconds since epoch; the FFI reports
-                    // 0 when it has none. Keep that as `nil` rather than
-                    // rendering 1970.
-                    endTime: info.end_time > 0
-                        ? Date(timeIntervalSince1970: Double(info.end_time) / 1000)
-                        : nil,
-                    hasWinner: info.has_winner,
-                    abstainVotes: info.abstain_votes,
-                    lockVotes: info.lock_votes,
-                    contenders: contenders))
-        }
-
-        return contests.sorted { $0.normalizedLabel < $1.normalizedLabel }
+      contests.append(
+        DPNSContest(
+          normalizedLabel: normalizedLabel,
+          // `end_time` is milliseconds since epoch; the FFI reports 0 when it
+          // has none. Keep that as `nil` rather than rendering 1970.
+          endTime: info.end_time > 0
+            ? Date(timeIntervalSince1970: Double(info.end_time) / 1000)
+            : nil,
+          hasWinner: info.has_winner,
+          abstainVotes: info.abstain_votes,
+          lockVotes: info.lock_votes,
+          contenders: contenders))
     }
 
-    // MARK: - One contest's vote state
+    return contests.sorted { $0.normalizedLabel < $1.normalizedLabel }
+  }
 
-    /// Full vote state for a single contest: contenders with tallies, the
-    /// abstain and lock tallies, and the resolution outcome.
-    ///
-    /// - Parameters:
-    ///   - normalizedLabel: Homograph-normalized label — pass the value from
-    ///     ``dpnsNormalizeLabel(_:)`` or a label returned by
-    ///     ``dpnsActiveContests(limit:)`` (already normalized).
-    ///   - limit: Maximum contenders to return.
-    /// - Returns: `nil` when Platform has no contenders on record for this
-    ///   label — either it was never contested or the poll has been pruned.
-    ///   Distinguishing "no contest" from "empty contest" is not possible at
-    ///   this layer, so the absence is surfaced as `nil` rather than as an
-    ///   empty state that reads like a live contest with zero votes.
-    public func dpnsContestVoteState(
-        normalizedLabel: String,
-        limit: UInt32 = 100
-    ) throws -> DPNSContestVoteState? {
-        guard let handle = handle else {
-            throw SDKError.invalidState("SDK not initialized")
-        }
+  // MARK: - One contest's vote state
 
-        let indexValues = DPNSVotePoll.indexValues(normalizedLabel: normalizedLabel)
-        let indexValuesData = try JSONSerialization.data(withJSONObject: indexValues)
-        guard let indexValuesJson = String(data: indexValuesData, encoding: .utf8) else {
-            throw SDKError.serializationError("Failed to encode index values")
-        }
-
-        // result_type 2 = DocumentsAndVoteTally: documents are what carry the
-        // winner info, tallies are what the UI shows.
-        let result = dash_sdk_contested_resource_get_vote_state(
-            handle,
-            DPNSVotePoll.contractId,
-            DPNSVotePoll.documentTypeName,
-            DPNSVotePoll.indexName,
-            indexValuesJson,
-            2,
-            true,
-            limit)
-
-        if let error = result.error {
-            let sdkError = SDKError.fromDashSDKError(error.pointee)
-            dash_sdk_error_free(error)
-            throw sdkError
-        }
-        // The FFI returns NoData (not an error) when there are no contenders.
-        guard let dataPtr = result.data else { return nil }
-
-        let jsonString = String(cString: dataPtr.assumingMemoryBound(to: CChar.self))
-        dash_sdk_string_free(dataPtr)
-
-        guard let data = jsonString.data(using: .utf8),
-              let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
-            throw SDKError.serializationError("Failed to parse contested resource vote state")
-        }
-
-        return Self.decodeVoteState(json: json, normalizedLabel: normalizedLabel)
+  /// Full vote state for a single contest: contenders with tallies, the
+  /// abstain and lock tallies, and the resolution outcome.
+  ///
+  /// - Parameters:
+  ///   - normalizedLabel: Homograph-normalized label — pass the value from
+  ///     ``dpnsNormalizeLabel(_:)`` or a label returned by
+  ///     ``dpnsActiveContests(limit:)`` (already normalized).
+  ///   - limit: Maximum contenders to return.
+  /// - Returns: `nil` when Platform has no contenders on record for this
+  ///   label — either it was never contested or the poll has been pruned.
+  ///   Distinguishing "no contest" from "empty contest" is not possible at
+  ///   this layer, so the absence is surfaced as `nil` rather than as an
+  ///   empty state that reads like a live contest with zero votes.
+  public func dpnsContestVoteState(
+    normalizedLabel: String,
+    limit: UInt32 = 100
+  ) throws -> DPNSContestVoteState? {
+    guard let handle = handle else {
+      throw SDKError.invalidState("SDK not initialized")
     }
 
-    /// Decode the `dash_sdk_contested_resource_get_vote_state` payload:
-    /// `{"abstain_vote_tally":N,"lock_vote_tally":N,
-    ///   "winner_info":"NoWinner"|"Locked"|{"type":"WonByIdentity","identity_id":"…"},
-    ///   "block_info":{"height":…,"core_height":…,"timestamp":…},
-    ///   "contenders":[{"identity_id":"…","vote_count":N,"document":"hex"|null}]}`
-    ///
-    /// `winner_info` and `block_info` are absent while voting is open.
-    nonisolated static func decodeVoteState(
-        json: [String: Any],
-        normalizedLabel: String
-    ) -> DPNSContestVoteState {
-        let contenders: [DPNSContender] = (json["contenders"] as? [[String: Any]] ?? [])
-            .compactMap { entry in
-                guard let identityId = entry["identity_id"] as? String else { return nil }
-                let tally = (entry["vote_count"] as? NSNumber)?.uint32Value ?? 0
-                return DPNSContender(identityId: identityId, voteTally: tally)
-            }
-
-        let outcome: DPNSContestOutcome = {
-            if let winner = json["winner_info"] as? String {
-                switch winner {
-                case "Locked": return .locked
-                case "NoWinner": return .noWinner
-                default: return .ongoing
-                }
-            }
-            if let winner = json["winner_info"] as? [String: Any],
-               winner["type"] as? String == "WonByIdentity",
-               let identityId = winner["identity_id"] as? String {
-                return .wonBy(identityId)
-            }
-            return .ongoing
-        }()
-
-        let resolvedAt: Date? = {
-            guard outcome != .ongoing,
-                  let blockInfo = json["block_info"] as? [String: Any],
-                  let timestamp = (blockInfo["timestamp"] as? NSNumber)?.uint64Value,
-                  timestamp > 0 else { return nil }
-            return Date(timeIntervalSince1970: Double(timestamp) / 1000)
-        }()
-
-        return DPNSContestVoteState(
-            normalizedLabel: normalizedLabel,
-            contenders: contenders,
-            abstainVotes: (json["abstain_vote_tally"] as? NSNumber)?.uint32Value ?? 0,
-            lockVotes: (json["lock_vote_tally"] as? NSNumber)?.uint32Value ?? 0,
-            outcome: outcome,
-            resolvedAt: resolvedAt)
+    let indexValues = DPNSVotePoll.indexValues(normalizedLabel: normalizedLabel)
+    let indexValuesData = try JSONSerialization.data(withJSONObject: indexValues)
+    guard let indexValuesJson = String(data: indexValuesData, encoding: .utf8) else {
+      throw SDKError.serializationError("Failed to encode index values")
     }
 
-    // MARK: - Pre-flight
+    // result_type 2 = DocumentsAndVoteTally: documents are what carry the
+    // winner info, tallies are what the UI shows.
+    let result = dash_sdk_contested_resource_get_vote_state(
+      handle,
+      DPNSVotePoll.contractId,
+      DPNSVotePoll.documentTypeName,
+      DPNSVotePoll.indexName,
+      indexValuesJson,
+      2,
+      true,
+      limit)
 
-    /// Whether Platform has an open, unresolved vote poll for
-    /// `normalizedLabel` — i.e. whether a vote cast now can be accepted.
-    ///
-    /// Broadcasting against a closed poll produces a long, opaque retry before
-    /// failing, so the caster checks this first and reports a precise error
-    /// instead. Implemented over ``dpnsContestVoteState(normalizedLabel:limit:)``
-    /// (one round trip) because that query distinguishes all three states the
-    /// caller cares about: no poll (`nil`), resolved, and open.
-    public func dpnsContestIsOpen(normalizedLabel: String) throws -> Bool {
-        guard let state = try dpnsContestVoteState(normalizedLabel: normalizedLabel, limit: 1)
-        else { return false }
-        return !state.isResolved
+    if let error = result.error {
+      let sdkError = SDKError.fromDashSDKError(error.pointee)
+      dash_sdk_error_free(error)
+      throw sdkError
     }
+    // The FFI returns NoData (not an error) when there are no contenders.
+    guard let dataPtr = result.data else { return nil }
+
+    let jsonString = String(cString: dataPtr.assumingMemoryBound(to: CChar.self))
+    dash_sdk_string_free(dataPtr)
+
+    guard let data = jsonString.data(using: .utf8),
+          let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+      throw SDKError.serializationError("Failed to parse contested resource vote state")
+    }
+
+    return Self.decodeVoteState(json: json, normalizedLabel: normalizedLabel)
+  }
+
+  /// Decode the `dash_sdk_contested_resource_get_vote_state` payload:
+  /// `{"abstain_vote_tally":N,"lock_vote_tally":N,
+  ///   "winner_info":"NoWinner"|"Locked"|{"type":"WonByIdentity","identity_id":"…"},
+  ///   "block_info":{"height":…,"core_height":…,"timestamp":…},
+  ///   "contenders":[{"identity_id":"…","vote_count":N,"document":"hex"|null}]}`
+  ///
+  /// `winner_info` and `block_info` are absent while voting is open; when
+  /// either is present the poll has finished (see ``DPNSContestOutcome``).
+  ///
+  /// `internal` rather than `private` so the hermetic decoder tests can drive
+  /// it without a live SDK handle.
+  nonisolated static func decodeVoteState(
+    json: [String: Any],
+    normalizedLabel: String
+  ) -> DPNSContestVoteState {
+    let contenders: [DPNSContender] = (json["contenders"] as? [[String: Any]] ?? [])
+      .compactMap { entry in
+        guard let identityId = entry["identity_id"] as? String else { return nil }
+        let tally = (entry["vote_count"] as? NSNumber)?.uint32Value ?? 0
+        return DPNSContender(identityId: identityId, voteTally: tally)
+      }
+
+    let outcome: DPNSContestOutcome = {
+      if let winner = json["winner_info"] as? String {
+        switch winner {
+        case "Locked": return .locked
+        case "NoWinner": return .noWinner
+        default: return .ongoing
+        }
+      }
+      if let winner = json["winner_info"] as? [String: Any],
+         winner["type"] as? String == "WonByIdentity",
+         let identityId = winner["identity_id"] as? String {
+        return .wonBy(identityId)
+      }
+      return .ongoing
+    }()
+
+    let resolvedAt: Date? = {
+      guard outcome != .ongoing,
+            let blockInfo = json["block_info"] as? [String: Any],
+            let timestamp = (blockInfo["timestamp"] as? NSNumber)?.uint64Value,
+            timestamp > 0 else { return nil }
+      return Date(timeIntervalSince1970: Double(timestamp) / 1000)
+    }()
+
+    return DPNSContestVoteState(
+      normalizedLabel: normalizedLabel,
+      contenders: contenders,
+      abstainVotes: (json["abstain_vote_tally"] as? NSNumber)?.uint32Value ?? 0,
+      lockVotes: (json["lock_vote_tally"] as? NSNumber)?.uint32Value ?? 0,
+      outcome: outcome,
+      resolvedAt: resolvedAt)
+  }
+
+  // MARK: - Pre-flight
+
+  /// Whether Platform has an open, unresolved vote poll for
+  /// `normalizedLabel` — i.e. whether a vote cast now can be accepted.
+  ///
+  /// Broadcasting against a closed poll produces a long, opaque retry before
+  /// failing, so the caster checks this first and reports a precise error
+  /// instead. Implemented over ``dpnsContestVoteState(normalizedLabel:limit:)``
+  /// (one round trip) because that query distinguishes all three states the
+  /// caller cares about: no poll (`nil`), resolved, and open.
+  public func dpnsContestIsOpen(normalizedLabel: String) throws -> Bool {
+    guard let state = try dpnsContestVoteState(normalizedLabel: normalizedLabel, limit: 1)
+    else { return false }
+    return !state.isResolved
+  }
 }

--- a/packages/swift-sdk/Sources/SwiftDashSDK/Voting/SDK+DPNSContests.swift
+++ b/packages/swift-sdk/Sources/SwiftDashSDK/Voting/SDK+DPNSContests.swift
@@ -1,0 +1,260 @@
+import Foundation
+import DashSDKFFI
+
+// MARK: - DPNS contested-username browsing
+//
+// Typed reads for the *voter's* view of DPNS username contests: every open
+// contest on the network, and the full vote state of one contest.
+//
+// These are deliberately separate from `ManagedPlatformWallet
+// .fetchContestVoteState(identityId:label:)`, which is identity-scoped — it
+// answers "is MY pending name being contested" and returns nothing for a
+// label this identity is not contending in. A masternode operator browsing
+// contests to vote on needs the network-wide view below.
+//
+// They are also separate from the untyped `dpnsGetContestedNonResolvedUsernames`
+// / `dpnsGetContestedVoteState` dictionary wrappers in
+// `FFI/PlatformQueryExtensions.swift`: those stringify each contender's tally
+// into `"ResourceVote { … strength: N }"`, forcing callers to parse a number
+// back out of a debug description. The FFI already provides `vote_count` as a
+// `uint32_t`, so the typed reads here take it straight from the C struct.
+
+@MainActor
+extension SDK {
+
+    // MARK: - Label normalization
+
+    /// Homograph-normalize a DPNS label the way Platform does before indexing
+    /// it (`o` → `0`, `i`/`l` → `1`, lowercased): `"Alice"` → `"a11ce"`.
+    ///
+    /// Every read and write that addresses a vote poll by label must use the
+    /// normalized form — Platform stores nothing under the raw form. Falls
+    /// back to a local lowercase+substitute mapping only if the FFI call
+    /// fails, so a transient failure cannot silently produce an un-normalized
+    /// label that addresses a non-existent poll.
+    public func dpnsNormalizeLabel(_ label: String) -> String {
+        let result = label.withCString { dash_sdk_dpns_normalize_username($0) }
+
+        if let error = result.error {
+            dash_sdk_error_free(error)
+            return Self.locallyNormalizedLabel(label)
+        }
+        guard let dataPtr = result.data else {
+            return Self.locallyNormalizedLabel(label)
+        }
+
+        let normalized = String(cString: dataPtr.assumingMemoryBound(to: CChar.self))
+        dash_sdk_string_free(dataPtr.assumingMemoryBound(to: CChar.self))
+        return normalized
+    }
+
+    /// Mirror of `convert_to_homograph_safe_chars` for callers that have no
+    /// live SDK handle — search filtering, for instance, must normalize the
+    /// user's typing the same way to match normalized labels. Kept in lockstep
+    /// with `dash_sdk::platform::dpns_usernames::convert_to_homograph_safe_chars`.
+    ///
+    /// Prefer ``dpnsNormalizeLabel(_:)`` whenever a handle exists: that asks
+    /// Rust, so it cannot drift.
+    public nonisolated static func locallyNormalizedLabel(_ label: String) -> String {
+        String(label.lowercased().map { character in
+            switch character {
+            case "o": return "0"
+            case "i", "l": return "1"
+            default: return character
+            }
+        })
+    }
+
+    // MARK: - Active contests
+
+    /// Every DPNS username contest that is still open, with its contenders,
+    /// tallies and end time.
+    ///
+    /// One round trip. Reads the FFI's `DashSDKContestedNamesList` structure
+    /// directly, so contender tallies arrive as integers.
+    ///
+    /// - Parameter limit: Maximum contests to return. The FFI has no
+    ///   start-after cursor on this query, so this is a hard ceiling, not a
+    ///   page size — raise it rather than trying to page.
+    /// - Returns: Contests sorted by normalized label. Empty when nothing is
+    ///   contested.
+    public func dpnsActiveContests(limit: UInt32 = 200) throws -> [DPNSContest] {
+        guard let handle = handle else {
+            throw SDKError.invalidState("SDK not initialized")
+        }
+
+        guard let listPtr = dash_sdk_dpns_get_contested_non_resolved_usernames(handle, limit) else {
+            throw SDKError.internalError("Failed to fetch contested DPNS usernames")
+        }
+        defer { dash_sdk_contested_names_list_free(listPtr) }
+
+        let list = listPtr.pointee
+        guard list.count > 0, let namesPtr = list.names else { return [] }
+
+        var contests: [DPNSContest] = []
+        contests.reserveCapacity(Int(list.count))
+
+        for index in 0..<Int(list.count) {
+            let entry = namesPtr[index]
+            guard let namePtr = entry.name else { continue }
+            let normalizedLabel = String(cString: namePtr)
+
+            let info = entry.contest_info
+            var contenders: [DPNSContender] = []
+            if info.contender_count > 0, let contendersPtr = info.contenders {
+                contenders.reserveCapacity(Int(info.contender_count))
+                for contenderIndex in 0..<Int(info.contender_count) {
+                    let contender = contendersPtr[contenderIndex]
+                    guard let idPtr = contender.identity_id else { continue }
+                    contenders.append(
+                        DPNSContender(
+                            identityId: String(cString: idPtr),
+                            voteTally: contender.vote_count))
+                }
+            }
+
+            contests.append(
+                DPNSContest(
+                    normalizedLabel: normalizedLabel,
+                    // `end_time` is milliseconds since epoch; the FFI reports
+                    // 0 when it has none. Keep that as `nil` rather than
+                    // rendering 1970.
+                    endTime: info.end_time > 0
+                        ? Date(timeIntervalSince1970: Double(info.end_time) / 1000)
+                        : nil,
+                    hasWinner: info.has_winner,
+                    abstainVotes: info.abstain_votes,
+                    lockVotes: info.lock_votes,
+                    contenders: contenders))
+        }
+
+        return contests.sorted { $0.normalizedLabel < $1.normalizedLabel }
+    }
+
+    // MARK: - One contest's vote state
+
+    /// Full vote state for a single contest: contenders with tallies, the
+    /// abstain and lock tallies, and the resolution outcome.
+    ///
+    /// - Parameters:
+    ///   - normalizedLabel: Homograph-normalized label — pass the value from
+    ///     ``dpnsNormalizeLabel(_:)`` or a label returned by
+    ///     ``dpnsActiveContests(limit:)`` (already normalized).
+    ///   - limit: Maximum contenders to return.
+    /// - Returns: `nil` when Platform has no contenders on record for this
+    ///   label — either it was never contested or the poll has been pruned.
+    ///   Distinguishing "no contest" from "empty contest" is not possible at
+    ///   this layer, so the absence is surfaced as `nil` rather than as an
+    ///   empty state that reads like a live contest with zero votes.
+    public func dpnsContestVoteState(
+        normalizedLabel: String,
+        limit: UInt32 = 100
+    ) throws -> DPNSContestVoteState? {
+        guard let handle = handle else {
+            throw SDKError.invalidState("SDK not initialized")
+        }
+
+        let indexValues = DPNSVotePoll.indexValues(normalizedLabel: normalizedLabel)
+        let indexValuesData = try JSONSerialization.data(withJSONObject: indexValues)
+        guard let indexValuesJson = String(data: indexValuesData, encoding: .utf8) else {
+            throw SDKError.serializationError("Failed to encode index values")
+        }
+
+        // result_type 2 = DocumentsAndVoteTally: documents are what carry the
+        // winner info, tallies are what the UI shows.
+        let result = dash_sdk_contested_resource_get_vote_state(
+            handle,
+            DPNSVotePoll.contractId,
+            DPNSVotePoll.documentTypeName,
+            DPNSVotePoll.indexName,
+            indexValuesJson,
+            2,
+            true,
+            limit)
+
+        if let error = result.error {
+            let sdkError = SDKError.fromDashSDKError(error.pointee)
+            dash_sdk_error_free(error)
+            throw sdkError
+        }
+        // The FFI returns NoData (not an error) when there are no contenders.
+        guard let dataPtr = result.data else { return nil }
+
+        let jsonString = String(cString: dataPtr.assumingMemoryBound(to: CChar.self))
+        dash_sdk_string_free(dataPtr)
+
+        guard let data = jsonString.data(using: .utf8),
+              let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            throw SDKError.serializationError("Failed to parse contested resource vote state")
+        }
+
+        return Self.decodeVoteState(json: json, normalizedLabel: normalizedLabel)
+    }
+
+    /// Decode the `dash_sdk_contested_resource_get_vote_state` payload:
+    /// `{"abstain_vote_tally":N,"lock_vote_tally":N,
+    ///   "winner_info":"NoWinner"|"Locked"|{"type":"WonByIdentity","identity_id":"…"},
+    ///   "block_info":{"height":…,"core_height":…,"timestamp":…},
+    ///   "contenders":[{"identity_id":"…","vote_count":N,"document":"hex"|null}]}`
+    ///
+    /// `winner_info` and `block_info` are absent while voting is open.
+    nonisolated static func decodeVoteState(
+        json: [String: Any],
+        normalizedLabel: String
+    ) -> DPNSContestVoteState {
+        let contenders: [DPNSContender] = (json["contenders"] as? [[String: Any]] ?? [])
+            .compactMap { entry in
+                guard let identityId = entry["identity_id"] as? String else { return nil }
+                let tally = (entry["vote_count"] as? NSNumber)?.uint32Value ?? 0
+                return DPNSContender(identityId: identityId, voteTally: tally)
+            }
+
+        let outcome: DPNSContestOutcome = {
+            if let winner = json["winner_info"] as? String {
+                switch winner {
+                case "Locked": return .locked
+                case "NoWinner": return .noWinner
+                default: return .ongoing
+                }
+            }
+            if let winner = json["winner_info"] as? [String: Any],
+               winner["type"] as? String == "WonByIdentity",
+               let identityId = winner["identity_id"] as? String {
+                return .wonBy(identityId)
+            }
+            return .ongoing
+        }()
+
+        let resolvedAt: Date? = {
+            guard outcome != .ongoing,
+                  let blockInfo = json["block_info"] as? [String: Any],
+                  let timestamp = (blockInfo["timestamp"] as? NSNumber)?.uint64Value,
+                  timestamp > 0 else { return nil }
+            return Date(timeIntervalSince1970: Double(timestamp) / 1000)
+        }()
+
+        return DPNSContestVoteState(
+            normalizedLabel: normalizedLabel,
+            contenders: contenders,
+            abstainVotes: (json["abstain_vote_tally"] as? NSNumber)?.uint32Value ?? 0,
+            lockVotes: (json["lock_vote_tally"] as? NSNumber)?.uint32Value ?? 0,
+            outcome: outcome,
+            resolvedAt: resolvedAt)
+    }
+
+    // MARK: - Pre-flight
+
+    /// Whether Platform has an open, unresolved vote poll for
+    /// `normalizedLabel` — i.e. whether a vote cast now can be accepted.
+    ///
+    /// Broadcasting against a closed poll produces a long, opaque retry before
+    /// failing, so the caster checks this first and reports a precise error
+    /// instead. Implemented over ``dpnsContestVoteState(normalizedLabel:limit:)``
+    /// (one round trip) because that query distinguishes all three states the
+    /// caller cares about: no poll (`nil`), resolved, and open.
+    public func dpnsContestIsOpen(normalizedLabel: String) throws -> Bool {
+        guard let state = try dpnsContestVoteState(normalizedLabel: normalizedLabel, limit: 1)
+        else { return false }
+        return !state.isResolved
+    }
+}

--- a/packages/swift-sdk/SwiftTests/SwiftDashSDKTests/DPNSContestDecoderTests.swift
+++ b/packages/swift-sdk/SwiftTests/SwiftDashSDKTests/DPNSContestDecoderTests.swift
@@ -1,0 +1,244 @@
+import XCTest
+@testable import SwiftDashSDK
+
+/// Hermetic tests for the `dash_sdk_contested_resource_get_vote_state` →
+/// `DPNSContestVoteState` boundary.
+///
+/// `SDK.decodeVoteState(json:normalizedLabel:)` is pure and `nonisolated`, so
+/// every branch is reachable without an SDK handle or a network. The payload
+/// shapes below mirror what `rs-sdk-ffi`'s
+/// `contested_resource/queries/vote_state.rs` actually emits.
+final class DPNSContestDecoderTests: XCTestCase {
+
+  // MARK: - Helpers
+
+  private func decode(_ json: [String: Any], label: String = "a11ce") -> DPNSContestVoteState {
+    SDK.decodeVoteState(json: json, normalizedLabel: label)
+  }
+
+  private func contender(_ id: String, _ votes: Int) -> [String: Any] {
+    ["identity_id": id, "vote_count": votes, "document": NSNull()]
+  }
+
+  // MARK: - Outcome branches
+
+  func testOngoingWhenWinnerInfoAbsent() {
+    // While voting is open, drive-abci attaches no winner info at all.
+    let state = decode([
+      "abstain_vote_tally": 2,
+      "lock_vote_tally": 1,
+      "contenders": [contender("Ab1", 5), contender("Cd2", 3)],
+    ])
+
+    XCTAssertEqual(state.outcome, .ongoing)
+    XCTAssertFalse(state.isResolved)
+    XCTAssertNil(state.resolvedAt)
+  }
+
+  func testNoWinnerIsResolved() {
+    // `Contenders.winner` is `Some` only for a *finished* poll, so `NoWinner`
+    // means "settled without awarding the name" — not "still running". A
+    // regression here would let `dpnsContestIsOpen` wave a vote into a poll
+    // that can no longer accept it.
+    let state = decode([
+      "abstain_vote_tally": 0,
+      "lock_vote_tally": 0,
+      "winner_info": "NoWinner",
+      "block_info": ["height": 1200, "core_height": 900, "timestamp": 1_700_000_000_000],
+      "contenders": [contender("Ab1", 4)],
+    ])
+
+    XCTAssertEqual(state.outcome, .noWinner)
+    XCTAssertTrue(state.isResolved)
+    XCTAssertEqual(state.resolvedAt, Date(timeIntervalSince1970: 1_700_000_000))
+  }
+
+  func testLockedIsResolved() {
+    let state = decode([
+      "abstain_vote_tally": 1,
+      "lock_vote_tally": 9,
+      "winner_info": "Locked",
+      "block_info": ["height": 10, "core_height": 5, "timestamp": 1_600_000_000_000],
+      "contenders": [contender("Ab1", 2)],
+    ])
+
+    XCTAssertEqual(state.outcome, .locked)
+    XCTAssertTrue(state.isResolved)
+    XCTAssertEqual(state.resolvedAt, Date(timeIntervalSince1970: 1_600_000_000))
+  }
+
+  func testWonByIdentityCarriesTheWinner() {
+    let state = decode([
+      "abstain_vote_tally": 0,
+      "lock_vote_tally": 0,
+      "winner_info": ["type": "WonByIdentity", "identity_id": "WinnerId123"],
+      "block_info": ["height": 42, "core_height": 21, "timestamp": 1_650_000_000_000],
+      "contenders": [contender("WinnerId123", 12), contender("LoserId456", 3)],
+    ])
+
+    XCTAssertEqual(state.outcome, .wonBy("WinnerId123"))
+    XCTAssertTrue(state.isResolved)
+    XCTAssertEqual(state.resolvedAt, Date(timeIntervalSince1970: 1_650_000_000))
+  }
+
+  func testUnknownWinnerStringFallsBackToOngoing() {
+    // An unrecognized discriminant must not be reported as a settled
+    // outcome — treating it as ongoing keeps the pre-flight conservative in
+    // the read direction and lets Platform reject the vote authoritatively.
+    let state = decode([
+      "winner_info": "SomethingNewFromAFutureRelease",
+      "contenders": [contender("Ab1", 1)],
+    ])
+
+    XCTAssertEqual(state.outcome, .ongoing)
+    XCTAssertFalse(state.isResolved)
+  }
+
+  func testMalformedWonByIdentityFallsBackToOngoing() {
+    // `type` present but `identity_id` missing: no winner can be named, so
+    // the decoder must not invent one.
+    let state = decode([
+      "winner_info": ["type": "WonByIdentity"],
+      "contenders": [contender("Ab1", 1)],
+    ])
+
+    XCTAssertEqual(state.outcome, .ongoing)
+  }
+
+  // MARK: - resolvedAt
+
+  func testResolvedAtNilWhenBlockInfoAbsent() {
+    let state = decode([
+      "winner_info": "Locked",
+      "contenders": [contender("Ab1", 1)],
+    ])
+
+    XCTAssertTrue(state.isResolved)
+    XCTAssertNil(state.resolvedAt, "a resolved outcome with no block info has no known time")
+  }
+
+  func testResolvedAtNilWhenTimestampIsZero() {
+    let state = decode([
+      "winner_info": "Locked",
+      "block_info": ["height": 1, "core_height": 1, "timestamp": 0],
+      "contenders": [contender("Ab1", 1)],
+    ])
+
+    XCTAssertNil(state.resolvedAt, "epoch 0 is a missing timestamp, not 1970")
+  }
+
+  func testResolvedAtIgnoredForOngoingContest() {
+    let state = decode([
+      "block_info": ["height": 1, "core_height": 1, "timestamp": 1_700_000_000_000],
+      "contenders": [contender("Ab1", 1)],
+    ])
+
+    XCTAssertEqual(state.outcome, .ongoing)
+    XCTAssertNil(state.resolvedAt)
+  }
+
+  // MARK: - Missing fields and tally conversion
+
+  func testEmptyPayloadDecodesToAnEmptyOngoingContest() {
+    let state = decode([:])
+
+    XCTAssertEqual(state.normalizedLabel, "a11ce")
+    XCTAssertTrue(state.contenders.isEmpty)
+    XCTAssertEqual(state.abstainVotes, 0)
+    XCTAssertEqual(state.lockVotes, 0)
+    XCTAssertEqual(state.outcome, .ongoing)
+  }
+
+  func testMissingTalliesDefaultToZero() {
+    let state = decode(["contenders": [contender("Ab1", 7)]])
+
+    XCTAssertEqual(state.abstainVotes, 0)
+    XCTAssertEqual(state.lockVotes, 0)
+    XCTAssertEqual(state.contenders.first?.voteTally, 7)
+  }
+
+  func testContenderWithoutIdentityIdIsDropped() {
+    // Skipped rather than materialized with a placeholder id — a contender we
+    // cannot identify must not become a votable target.
+    let state = decode([
+      "contenders": [contender("Ab1", 2), ["vote_count": 5]],
+    ])
+
+    XCTAssertEqual(state.contenders.count, 1)
+    XCTAssertEqual(state.contenders.first?.identityId, "Ab1")
+  }
+
+  func testContenderWithoutVoteCountDefaultsToZero() {
+    let state = decode(["contenders": [["identity_id": "Ab1"]]])
+
+    XCTAssertEqual(state.contenders.first?.voteTally, 0)
+  }
+
+  func testLargeTallyConvertsWithoutTruncation() {
+    let state = decode([
+      "abstain_vote_tally": 4_294_967_295,
+      "lock_vote_tally": 4_000_000_000,
+      "contenders": [contender("Ab1", 3_000_000_000)],
+    ])
+
+    XCTAssertEqual(state.abstainVotes, UInt32.max)
+    XCTAssertEqual(state.lockVotes, 4_000_000_000)
+    XCTAssertEqual(state.contenders.first?.voteTally, 3_000_000_000)
+  }
+
+  func testContenderOrderIsPreserved() {
+    let state = decode([
+      "contenders": [contender("Cd2", 1), contender("Ab1", 9), contender("Ef3", 5)],
+    ])
+
+    XCTAssertEqual(state.contenders.map(\.identityId), ["Cd2", "Ab1", "Ef3"])
+  }
+
+  // MARK: - Derived helpers
+
+  func testTotalVotesSumsContendersAbstainAndLock() {
+    let contest = DPNSContest(
+      normalizedLabel: "a11ce",
+      endTime: nil,
+      hasWinner: false,
+      abstainVotes: 2,
+      lockVotes: 3,
+      contenders: [
+        DPNSContender(identityId: "Ab1", voteTally: 5),
+        DPNSContender(identityId: "Cd2", voteTally: 4),
+      ])
+
+    XCTAssertEqual(contest.totalVotes, 14)
+    XCTAssertEqual(contest.leadingContender?.identityId, "Ab1")
+  }
+
+  func testLeadingContenderIsNilWithoutContenders() {
+    let contest = DPNSContest(
+      normalizedLabel: "a11ce",
+      endTime: nil,
+      hasWinner: false,
+      abstainVotes: 0,
+      lockVotes: 0,
+      contenders: [])
+
+    XCTAssertNil(contest.leadingContender)
+    XCTAssertEqual(contest.totalVotes, 0)
+  }
+
+  // MARK: - Vote poll coordinates
+
+  func testIndexValuesPutTheParentDomainFirst() {
+    XCTAssertEqual(
+      DPNSVotePoll.indexValues(normalizedLabel: "a11ce"),
+      ["dash", "a11ce"])
+  }
+
+  func testIndexValuesDoNotNormalizeTheLabel() {
+    // Normalization is the caller's job (and Rust's) — this helper must not
+    // silently re-encode, or read and write paths could address different
+    // polls.
+    XCTAssertEqual(
+      DPNSVotePoll.indexValues(normalizedLabel: "alice"),
+      ["dash", "alice"])
+  }
+}


### PR DESCRIPTION
## Why

The Swift SDK could already **cast** a masternode contested-resource vote (`SDK.castContestedResourceVote`), but it had no usable way to **find** something to vote on. A masternode operator browsing DPNS username contests was stuck between two unsuitable APIs:

- `ManagedPlatformWallet.fetchContestVoteState(identityId:label:)` is identity-scoped — it answers *"is MY pending name being contested"* and returns `nil` for any label the given identity is not contending in.
- `dpnsGetContestedNonResolvedUsernames` / `dpnsGetContestedVoteState` return `[String: Any]` bags, and they **discard the tally the FFI already provides as an integer**, re-emitting it as a debug description:

  ```swift
  // PlatformQueryExtensions.swift:1227
  contenderDict["votes"] = "ResourceVote { vote_choice: TowardsIdentity, strength: \(contender.vote_count) }"
  ```

  The C struct right there carries `uint32_t vote_count`.

The iOS wallet's voting screen needs the network-wide view. This adds it.

## What

New `Sources/SwiftDashSDK/Voting/`:

| API | Purpose |
|---|---|
| `SDK.dpnsActiveContests(limit:)` | Every open contest with contenders, tallies, end time — read directly off `DashSDKContestedNamesList`, so tallies stay integers |
| `SDK.dpnsContestVoteState(normalizedLabel:limit:)` | One contest's full state incl. `DPNSContestOutcome` (`.ongoing` / `.noWinner` / `.wonBy` / `.locked`) |
| `SDK.dpnsContestIsOpen(normalizedLabel:)` | Pre-flight before broadcasting |
| `SDK.dpnsNormalizeLabel(_:)` | `dash_sdk_dpns_normalize_username`, plus a `locallyNormalizedLabel` mirror for callers with no live handle |
| `DPNSVotePoll` | The fixed DPNS poll coordinates, shared by these reads and the existing write path |

Models: `DPNSContest`, `DPNSContender`, `DPNSContestVoteState`, `DPNSContestOutcome`.

## Notes

- **Purely additive.** No Rust or FFI change, so no `build_ios.sh` / xcframework rebuild and no rev bump. Existing untyped wrappers are untouched (they have several `SwiftExampleApp` call sites).
- Label normalization is load-bearing and documented on every entry point: Platform indexes vote polls under the homograph-safe form only, so addressing a poll with a raw label silently misses.
- `DPNSContender` deliberately does **not** expose the contender's own spelling of the label. Platform returns it only inside the serialized `domain` document, which the FFI hands over as opaque hex; decoding needs the contract's document-type schema. Rather than ship an always-`nil` field, the type documents why it is absent.
- `dpnsContestVoteState` returns `nil` rather than an empty state when Platform holds no contenders, so callers can't mistake "no poll" for "a live contest with zero votes".

## Testing

Compiled as part of a clean `dashpay` build of the iOS wallet (`ARCHS=arm64`, iOS Simulator), which consumes this package locally and is the first consumer of all four new APIs. Runtime verification happens in the wallet PR's testnet smoke, where testnet's 90-minute contests make a full contest lifecycle observable in one sitting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Swift SDK support for browsing active DPNS contested-username polls.
  * Added contest models with vote totals, leading contenders, outcomes, and resolution status.
  * Added APIs to normalize labels, retrieve detailed vote states, and check whether contests are open.
  * Added support for identifying contests through normalized labels and poll index values.
  * Improved handling of unavailable or malformed contest data with clear results and errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->