### PR TITLE
ci: lint test targets with clippy --all-targets

### DIFF
--- a/.github/workflows/tests-rs-wallet.yml
+++ b/.github/workflows/tests-rs-wallet.yml
@@ -196,6 +196,7 @@ jobs:
             --package platform-wallet-ffi \
             --package rs-unified-sdk-ffi \
             --package rs-unified-sdk-jni \
+            --all-targets \
             --all-features \
             --locked \
             -- --no-deps -D warnings

--- a/.github/workflows/tests-rs-workspace.yml
+++ b/.github/workflows/tests-rs-workspace.yml
@@ -176,10 +176,14 @@ jobs:
       - name: Verify wallet reverse-dependency closure
         run: python3 .github/scripts/check-wallet-closure.py
 
+      # `--all-targets` keeps test/bench/example code in scope. Without it
+      # clippy only sees the lib/bin targets, so lints in `#[cfg(test)]` code
+      # merge unnoticed and only surface for whoever runs clippy locally.
       - name: Clippy lints
         run: |
           cargo clippy \
             --workspace \
+            --all-targets \
             --all-features \
             --locked \
             -- --no-deps -D warnings

--- a/packages/rs-platform-wallet-ffi/src/core_wallet_types.rs
+++ b/packages/rs-platform-wallet-ffi/src/core_wallet_types.rs
@@ -1982,7 +1982,7 @@ mod tests {
             "ProRegTx carries a 48-byte operator BLS key"
         );
         assert!(
-            mn.payout_script.as_ref().map_or(false, |s| !s.is_empty()),
+            mn.payout_script.as_ref().is_some_and(|s| !s.is_empty()),
             "ProRegTx carries a payout script"
         );
         assert!(

--- a/packages/rs-platform-wallet-ffi/src/persistence.rs
+++ b/packages/rs-platform-wallet-ffi/src/persistence.rs
@@ -5936,33 +5936,41 @@ mod tests {
     /// callback without its registration callback must not attest pools.
     #[test]
     fn partially_wired_persister_attests_only_complete_pairs() {
-        let mut cb = PersistenceCallbacks::default();
-        cb.on_changeset_begin_fn = Some(noop_begin);
+        let cb = PersistenceCallbacks {
+            on_changeset_begin_fn: Some(noop_begin),
+            ..Default::default()
+        };
         assert_eq!(
             declared_persister(cb, PersistenceCapabilities::ATOMIC_CHANGESETS)
                 .persistence_capabilities(),
             PersistenceCapabilities::NONE
         );
 
-        let mut cb = PersistenceCallbacks::default();
-        cb.on_changeset_begin_fn = Some(noop_begin);
-        cb.on_changeset_end_fn = Some(noop_end);
+        let cb = PersistenceCallbacks {
+            on_changeset_begin_fn: Some(noop_begin),
+            on_changeset_end_fn: Some(noop_end),
+            ..Default::default()
+        };
         let capabilities = declared_persister(cb, PersistenceCapabilities::ATOMIC_CHANGESETS)
             .persistence_capabilities();
         assert_eq!(capabilities, PersistenceCapabilities::ATOMIC_CHANGESETS);
         assert!(!capabilities.contains(PersistenceCapabilities::INVITATION_CREATION));
 
-        let mut cb = PersistenceCallbacks::default();
         let declaration = PersistenceCapabilities::INVITATIONS
             .union(PersistenceCapabilities::ASSET_LOCK_FUNDING_INDICES);
-        cb.on_persist_invitations_fn = Some(noop_invitations);
-        cb.on_persist_account_address_pools_fn = Some(noop_pools);
+        let cb = PersistenceCallbacks {
+            on_persist_invitations_fn: Some(noop_invitations),
+            on_persist_account_address_pools_fn: Some(noop_pools),
+            ..Default::default()
+        };
         let capabilities = declared_persister(cb, declaration).persistence_capabilities();
         assert_eq!(capabilities, PersistenceCapabilities::INVITATIONS);
 
-        let mut cb = PersistenceCallbacks::default();
-        cb.on_persist_account_registrations_fn = Some(noop_registrations);
-        cb.on_persist_account_address_pools_fn = Some(noop_pools);
+        let cb = PersistenceCallbacks {
+            on_persist_account_registrations_fn: Some(noop_registrations),
+            on_persist_account_address_pools_fn: Some(noop_pools),
+            ..Default::default()
+        };
         let capabilities =
             declared_persister(cb, PersistenceCapabilities::ASSET_LOCK_FUNDING_INDICES)
                 .persistence_capabilities();
@@ -6003,14 +6011,16 @@ mod tests {
 
     #[test]
     fn complete_callbacks_without_declaration_attest_nothing() {
-        let mut cb = PersistenceCallbacks::default();
-        cb.on_changeset_begin_fn = Some(noop_begin);
-        cb.on_changeset_end_fn = Some(noop_end);
-        cb.on_persist_invitations_fn = Some(noop_invitations);
-        cb.on_persist_account_registrations_fn = Some(noop_registrations);
-        cb.on_persist_account_address_pools_fn = Some(noop_pools);
-        cb.on_load_wallet_list_fn = Some(noop_load_wallets);
-        cb.on_load_wallet_list_free_fn = Some(noop_free_wallets);
+        let cb = PersistenceCallbacks {
+            on_changeset_begin_fn: Some(noop_begin),
+            on_changeset_end_fn: Some(noop_end),
+            on_persist_invitations_fn: Some(noop_invitations),
+            on_persist_account_registrations_fn: Some(noop_registrations),
+            on_persist_account_address_pools_fn: Some(noop_pools),
+            on_load_wallet_list_fn: Some(noop_load_wallets),
+            on_load_wallet_list_free_fn: Some(noop_free_wallets),
+            ..Default::default()
+        };
         assert_eq!(
             FFIPersister::new(cb).persistence_capabilities(),
             PersistenceCapabilities::NONE
@@ -6019,9 +6029,11 @@ mod tests {
 
     #[test]
     fn declaration_is_intersected_with_callback_structure() {
-        let mut cb = PersistenceCallbacks::default();
-        cb.on_changeset_begin_fn = Some(noop_begin);
-        cb.on_changeset_end_fn = Some(noop_end);
+        let cb = PersistenceCallbacks {
+            on_changeset_begin_fn: Some(noop_begin),
+            on_changeset_end_fn: Some(noop_end),
+            ..Default::default()
+        };
         assert_eq!(
             declared_persister(cb, PersistenceCapabilities::INVITATION_CREATION)
                 .persistence_capabilities(),
@@ -6274,19 +6286,23 @@ mod tests {
     #[cfg(feature = "shielded")]
     #[test]
     fn shielded_viewing_key_capability_requires_complete_callback_triplet() {
-        let mut cb = PersistenceCallbacks::default();
-        cb.on_persist_shielded_viewing_keys_fn = Some(noop_persist_viewing_keys);
-        cb.on_load_shielded_viewing_keys_fn = Some(noop_load_viewing_keys);
+        let cb = PersistenceCallbacks {
+            on_persist_shielded_viewing_keys_fn: Some(noop_persist_viewing_keys),
+            on_load_shielded_viewing_keys_fn: Some(noop_load_viewing_keys),
+            ..Default::default()
+        };
         assert!(
             !declared_persister(cb, PersistenceCapabilities::SHIELDED_VIEWING_KEYS)
                 .persistence_capabilities()
                 .contains(PersistenceCapabilities::SHIELDED_VIEWING_KEYS)
         );
 
-        let mut cb = PersistenceCallbacks::default();
-        cb.on_persist_shielded_viewing_keys_fn = Some(noop_persist_viewing_keys);
-        cb.on_load_shielded_viewing_keys_fn = Some(noop_load_viewing_keys);
-        cb.on_load_shielded_viewing_keys_free_fn = Some(noop_free_viewing_keys);
+        let cb = PersistenceCallbacks {
+            on_persist_shielded_viewing_keys_fn: Some(noop_persist_viewing_keys),
+            on_load_shielded_viewing_keys_fn: Some(noop_load_viewing_keys),
+            on_load_shielded_viewing_keys_free_fn: Some(noop_free_viewing_keys),
+            ..Default::default()
+        };
         assert!(
             declared_persister(cb, PersistenceCapabilities::SHIELDED_VIEWING_KEYS)
                 .persistence_capabilities()
@@ -6595,7 +6611,7 @@ mod tests {
         assert!(
             restored
                 .highest_generated
-                .map_or(false, |h| h >= RESTORED_INDEX),
+                .is_some_and(|h| h >= RESTORED_INDEX),
             "highest_generated must advance past the pre-derived gap window"
         );
 
@@ -6772,7 +6788,7 @@ mod tests {
         const ECDSA_IDX: u32 = 502;
         for idx in [BLS_IDX, EDDSA_IDX, ECDSA_IDX] {
             assert!(
-                pool.addresses.get(&idx).is_none(),
+                !pool.addresses.contains_key(&idx),
                 "index {idx} must start with no pre-seeded entry"
             );
         }

--- a/packages/rs-platform-wallet/src/wallet/asset_lock/sync/recovery.rs
+++ b/packages/rs-platform-wallet/src/wallet/asset_lock/sync/recovery.rs
@@ -582,13 +582,14 @@ mod tests {
             timed_out,
             PlatformWalletError::FinalityTimeout(actual) if actual == out_point
         ));
-        let broadcast = broadcaster
-            .transactions
-            .lock()
-            .expect("recording broadcaster mutex");
-        assert_eq!(broadcast.as_slice(), std::slice::from_ref(&transaction));
-        assert_eq!(broadcast[0].txid(), out_point.txid);
-        drop(broadcast);
+        {
+            let broadcast = broadcaster
+                .transactions
+                .lock()
+                .expect("recording broadcaster mutex");
+            assert_eq!(broadcast.as_slice(), std::slice::from_ref(&transaction));
+            assert_eq!(broadcast[0].txid(), out_point.txid);
+        }
 
         // The real consume path leaves a terminal tombstone. That gives a
         // same-process retry a truthful typed error, while a foreign outpoint

--- a/packages/rs-platform-wallet/src/wallet/identity/network/withdrawal.rs
+++ b/packages/rs-platform-wallet/src/wallet/identity/network/withdrawal.rs
@@ -232,7 +232,7 @@ mod masternode_withdrawal_tests {
     fn selects_the_matching_owner_hash160_key_over_decoys() {
         let owner_hash = [0x11u8; 20];
         let other_hash = [0x22u8; 20];
-        let keys = vec![
+        let keys = [
             // Right hash, wrong purpose.
             make_key(
                 0,
@@ -271,7 +271,7 @@ mod masternode_withdrawal_tests {
     #[test]
     fn returns_none_when_no_owner_key_matches() {
         let owner_hash = [0x11u8; 20];
-        let keys = vec![
+        let keys = [
             make_key(
                 0,
                 Purpose::TRANSFER,

--- a/packages/wasm-drive-verify/src/state_transition/verify_state_transition_was_executed_with_proof.rs
+++ b/packages/wasm-drive-verify/src/state_transition/verify_state_transition_was_executed_with_proof.rs
@@ -165,25 +165,6 @@ fn bind_known_contract(
     Ok((embedded_id, Arc::new(contract)))
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use dpp::tests::fixtures::get_data_contract_fixture;
-
-    #[test]
-    fn rejects_known_contract_under_an_alias_identifier() {
-        let platform_version = PlatformVersion::latest();
-        let contract = get_data_contract_fixture(None, 0, platform_version.protocol_version)
-            .data_contract_owned();
-        let alias = Identifier::new([0x5a; 32]);
-        assert_ne!(alias, contract.id());
-
-        let error = bind_known_contract(alias, contract).expect_err("alias must be rejected");
-
-        assert!(error.contains("does not match embedded contract ID"));
-    }
-}
-
 fn convert_proof_result_to_js(
     proof_result: &StateTransitionProofResult,
 ) -> Result<JsValue, JsValue> {
@@ -268,4 +249,23 @@ fn convert_proof_result_to_js(
     }
 
     Ok(obj.into())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use dpp::tests::fixtures::get_data_contract_fixture;
+
+    #[test]
+    fn rejects_known_contract_under_an_alias_identifier() {
+        let platform_version = PlatformVersion::latest();
+        let contract = get_data_contract_fixture(None, 0, platform_version.protocol_version)
+            .data_contract_owned();
+        let alias = Identifier::new([0x5a; 32]);
+        assert_ne!(alias, contract.id());
+
+        let error = bind_known_contract(alias, contract).expect_err("alias must be rejected");
+
+        assert!(error.contains("does not match embedded contract ID"));
+    }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Clippy never linted test code in CI. Both gates ran without `--all-targets`:

- `tests-rs-workspace.yml` — `cargo clippy --workspace --all-features --locked -- --no-deps -D warnings`
- `tests-rs-wallet.yml` — the same, scoped to the wallet crates + dependents

Without `--all-targets` clippy only sees the lib/bin targets, so lints inside `#[cfg(test)]` code merge unnoticed and only surface for whoever runs clippy locally. `cargo clippy -p platform-wallet --all-targets --all-features -- -D warnings` currently fails on `v4.2-dev` with 3 errors, none of which CI can see.

## What was done?
<!--- Describe your changes in detail -->

### CI

Added `--all-targets` to both clippy steps. The wallet fast path needed it too — it lints `platform-wallet-ffi`, so it carried the same blind spot.

### Lints cleared

A full `--workspace --all-targets --all-features` sweep over all 46 members turned up 11 findings in 2 crates beyond the 3 that prompted this. All are in `#[cfg(test)]` code:

- `rs-platform-wallet` — `await_holding_lock` in `recovery.rs`; two `useless_vec` in `withdrawal.rs` (`vec![…]` → `[…]`)
- `rs-platform-wallet-ffi` — seven `field_reassign_with_default` in `persistence.rs` (`PersistenceCallbacks::default()` + field assignment → struct literal with `..Default::default()`); two `unnecessary_map_or` (`map_or(false, …)` → `is_some_and`); one `unnecessary_get_then_check` (`get(&k).is_none()` → `!contains_key(&k)`)
- `wasm-drive-verify` — `items_after_test_module`; `mod tests` moved below `convert_proof_result_to_js`

### Note on the `await_holding_lock` fix

`built_resume_rebroadcasts_original_and_typed_failures_do_not_broadcast` already released its guard with an explicit `drop(broadcast)` before the awaits, so the guard was never live across them at runtime. The lint fires regardless because it reasons about the binding's **scope**, not its liveness — a `let` binding's scope runs to the end of its enclosing block whatever `drop()` does. Scoping the guard to a nested block ends it for real. No `#[allow]`, no behavior change.

Everything outside the two workflow lines is test-only.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

No new tests — this fixes lints in existing ones. All commands below exited 0:

- `cargo clippy --workspace --all-targets --all-features --locked -- --no-deps -D warnings` (the exact new CI command)
- The new wallet fast-path command, with `--all-targets`
- `cargo clippy -p platform-wallet --all-targets --all-features -- -D warnings`
- `cargo test -p platform-wallet --lib` — 574 passed
- `cargo test -p platform-wallet-ffi --lib --all-features` — 246 passed (`--all-features` so the `shielded`-gated test is included)
- `cargo test -p wasm-drive-verify --lib` — 15 passed
- `cargo fmt --check --all`

Each edited test was confirmed present in the runner output rather than filtered out.

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->

None.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have added "!" to the title and described breaking changes in the corresponding section if my code contains any
- [x] I have made corresponding changes to the documentation if needed

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Expanded automated linting to cover all package targets, including tests, benchmarks, and examples.
  - Updated test implementations and organization without changing expected behavior or assertions.

- **Refactor**
  - Simplified test setup and modernized collection and option checks for clearer, more maintainable test code.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->